### PR TITLE
fix(release): make fleet deployment opt-in

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -9,7 +9,7 @@
 #   1. ci-gate — wait for same-SHA CI and verify all CI jobs succeeded
 #   2. build — compile gateway, shell, kernel into host bundle tarball
 #   3. publish — upload immutable R2 artifacts and register metadata in platform DB
-#   4. deploy — main/dev publishes trigger exact-version VPS deployment by default
+#   4. (optional) deploy — explicit dispatches may trigger exact-version VPS deployment
 
 name: Host Bundle Release
 
@@ -51,7 +51,7 @@ on:
       deploy_after_publish:
         description: "Deploy the published exact version to existing VPSes after registration"
         required: false
-        default: true
+        default: false
         type: boolean
 
 permissions:
@@ -412,7 +412,7 @@ jobs:
   deploy:
     name: Deploy published host bundle
     needs: [dev-bundle-gate, build, publish]
-    if: ${{ needs.dev-bundle-gate.outputs.should_build == 'true' && ((github.event_name == 'push' && github.ref_type == 'branch' && github.ref_name == 'main') || inputs.deploy_after_publish) }}
+    if: ${{ needs.dev-bundle-gate.outputs.should_build == 'true' && github.event_name == 'workflow_dispatch' && inputs.deploy_after_publish && ((github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:

--- a/docs/dev/releases.md
+++ b/docs/dev/releases.md
@@ -28,12 +28,12 @@ that image.
 - `main` is the source of truth. A push to `main` runs `.github/workflows/host-bundle-release.yml`.
 - The workflow builds `dist/host-bundle/matrix-host-bundle.tar.gz`, uploads it to R2, registers it in platform Postgres through `POST /system-bundles/releases`, and promotes the `dev` channel.
 - R2 JSON manifests are not authoritative. The platform DB release row and channel row are authoritative; R2 only holds the tarball and `.sha256` bytes.
-- Existing VPSes are updated by platform deploy fan-out: `POST /vps/deploy {"version":"<version>"}` or `{"channel":"dev"}`.
+- Existing VPS deployments are explicit and opt-in. Normal `main` pushes publish and promote `dev` without deploying any VPS.
 - A customer VPS sync agent fetches DB-backed release metadata, verifies SHA-256, extracts to staging, moves the old app to `/opt/matrix/app.rollback`, moves the new app into `/opt/matrix/app`, writes `/opt/matrix/release.json`, and restarts Matrix services.
 - Host-bundle updates must never overwrite owner data. Do not delete or replace `/home/matrix/home`, `/opt/matrix/env`, or the local Postgres data directory during deploys or rollbacks.
 - `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` and CI/release paths use `pnpm install --frozen-lockfile`; do not bypass either during releases.
 - Host bundle release validation is blocking. If typecheck, tests, public build-env validation, build, publish, or registration fails, do not publish or deploy the bundle.
-- Eligible main/tag releases request a golden snapshot build after publication. This request is an optional acceleration path: enqueue/build failure does not block publication or the unchanged existing-fleet deploy job. See [Golden VPS Snapshots](golden-vps-snapshots.md).
+- Eligible main/tag releases request a golden snapshot build after publication. This request is an optional acceleration path: enqueue/build failure does not block publication or a separately authorized deployment. See [Golden VPS Snapshots](golden-vps-snapshots.md).
 - CLI releases are manual through `.github/workflows/release.yml`; bump `packages/sync-client/package.json`, run the sync-client checks, and dispatch the workflow with the same semver.
 - Fleet upgrade operations, blocked-machine handling, and the durable control-plane setup are documented in [Fleet Upgrade Operations](fleet-upgrade-operations.md).
 - Staging platform containers and disposable feature VPSes are temporary test
@@ -93,19 +93,19 @@ Release metadata also records:
    | `PLATFORM_PUBLIC_URL` | var | publish/deploy; defaults to `https://app.matrix-os.com` |
    | `PLATFORM_SECRET` | secret | release registration and deploy fan-out |
 
-3. Deploy to existing VPSes.
+3. Deploy to existing VPSes only when explicitly authorized.
 
-   Normal `main` pushes publish `dev` but do not automatically fan out to the fleet. Trigger deploy after the workflow is green:
+   Normal `main` pushes publish `dev` but do not automatically fan out to the fleet. The workflow-dispatch input `deploy_after_publish` defaults to `false`. Setting `deploy_after_publish=true` intentionally deploys the newly published exact version to the full running fleet, so use it only for a reviewed fleet-wide rollout. Security severity does not override this opt-in deployment gate.
+
+   For a scoped rollout, target each reviewed handle explicitly after the workflow is green:
 
    ```bash
    curl --fail --silent --show-error \
      -X POST https://app.matrix-os.com/vps/deploy \
      -H "Authorization: Bearer $PLATFORM_SECRET" \
      -H "Content-Type: application/json" \
-     -d '{"version":"v2026.05.12-43"}'
+     -d '{"handle":"<reviewed-handle>","version":"v2026.05.12-43"}'
    ```
-
-   Security releases can use the workflow `severity=security` path, which auto-deploys the built version after publish.
 
 4. Verify every VPS.
 

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -460,14 +460,18 @@ describe('CI workflows', () => {
     expect(workflow).toContain('${cache_image}');
   });
 
-  it('deploys published dev host bundles by exact version on main by default', () => {
+  it('publishes main dev host bundles without deploying the fleet', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
+    const releaseDocs = readFileSync(join(root, 'docs/dev/releases.md'), 'utf8');
+    const deployJob = workflow.slice(workflow.indexOf('\n  deploy:'));
 
     expect(workflow).toContain('deploy_after_publish:');
+    expect(workflow).toMatch(/deploy_after_publish:[\s\S]*?default: false/);
     expect(workflow).toContain('Deploy published host bundle');
-    expect(workflow).toContain("github.event_name == 'push' && github.ref_type == 'branch' && github.ref_name == 'main'");
-    expect(workflow).toContain('|| inputs.deploy_after_publish');
+    expect(deployJob).toContain("github.event_name == 'workflow_dispatch' && inputs.deploy_after_publish");
+    expect(deployJob).toContain("(github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag'");
+    expect(deployJob).not.toContain("github.event_name == 'push'");
     expect(workflow).not.toContain("|| inputs.severity == 'security'");
     expect(workflow).toContain('PUBLISH_VERSION: ${{ needs.build.outputs.version }}');
     expect(workflow).toContain('VERSION="$PUBLISH_VERSION"');
@@ -478,5 +482,8 @@ describe('CI workflows', () => {
     expect(workflow).toContain('if [ "$failed" -gt 0 ] || [ "$triggered" -eq 0 ]; then');
     expect(workflow).toContain('-d "{\\"version\\":\\"$VERSION\\"}"');
     expect(workflow).not.toContain('Auto-deploy on security severity');
+    expect(releaseDocs).toContain('`deploy_after_publish=true`');
+    expect(releaseDocs).toContain('Security severity does not override this opt-in deployment gate.');
+    expect(releaseDocs).not.toContain('which auto-deploys the built version after publish');
   });
 });


### PR DESCRIPTION
## Summary

- stop normal `main` host-bundle releases from deploying an exact dev version to the fleet
- make fleet deployment available only through an explicit workflow dispatch with `deploy_after_publish=true`, defaulting to false
- align the release runbook and its CI contract with the opt-in behavior

## Tests

- `pnpm exec vitest run tests/platform/ci-workflows.test.ts` (red before implementation, green after)
- 104 focused release/deployment tests
- `bun run typecheck`
- `bun run check:patterns` (0 violations)
- `bun run test`
- `git diff --check`

## Review and monitoring

- require Greptile 5/5 on the live head before adding `ready-for-ci`
- require all GitHub checks green before merge
- after merge, verify the Host Bundle Release publishes/promotes dev and skips the deploy job

## Invariants

- source of truth: platform release rows and channel pointers remain authoritative
- normal main pushes build/register/promote dev only
- fleet deployment remains possible only through explicit operator intent
- no database, locking, authentication, or customer data path changes
- publishing a dev bundle without deploying it is an acceptable and intended state

## Deferred

- effective-channel UI and downgrade suppression are handled in the follow-up PR
- persistent platform channel assignment and channel-aware deployment filtering remain separate follow-up architecture work
