### PR TITLE
fix(updates): honor persistent release channel

### DIFF
--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -106,6 +106,31 @@ release_url_for_channel() { echo "$(platform_url)/system-bundles/channels/$1.jso
 
 json_field() { python3 -c "import json,sys; print(json.load(sys.stdin).get(sys.argv[1],''))" "$2" <<< "$1"; }
 
+compare_host_bundle_versions() {
+  local candidate="$1" current="$2"
+  python3 - "$candidate" "$current" <<'PY'
+import re
+import sys
+
+def parse(value):
+    match = re.fullmatch(r"v?(\d{4})\.(\d{2})\.(\d{2})[-.](\d+)", value)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+candidate = parse(sys.argv[1])
+current = parse(sys.argv[2])
+if candidate is None or current is None:
+    print("unknown")
+elif candidate > current:
+    print("newer")
+elif candidate < current:
+    print("older")
+else:
+    print("equal")
+PY
+}
+
 write_update_error() {
   local code="$1" message="$2" version="${3:-}" available_kb="${4:-}" required_kb="${5:-}"
   python3 - "$UPDATE_ERROR_MARKER" "$code" "$message" "$version" "$available_kb" "$required_kb" <<'PY'
@@ -193,7 +218,18 @@ check_for_update() {
     log "WARN: manifest missing 'version' field"; return 1
   fi
   cur="$(current_version)"
-  if [ "$remote_version" = "$cur" ]; then return 0; fi
+  if [ "$remote_version" = "$cur" ]; then
+    rm -f "$UPDATE_MARKER"
+    return 0
+  fi
+
+  local version_comparison
+  version_comparison="$(compare_host_bundle_versions "$remote_version" "$cur")"
+  if [ "$version_comparison" = "older" ]; then
+    log "Ignoring older channel release: $remote_version (current: $cur)"
+    rm -f "$UPDATE_MARKER" "$UPDATE_ERROR_MARKER"
+    return 0
+  fi
 
   local severity update_type
   severity="$(json_field "$manifest" severity)"

--- a/docs/dev/vps-deployment.md
+++ b/docs/dev/vps-deployment.md
@@ -619,20 +619,29 @@ sha256sum dist/host-bundle/matrix-host-bundle.tar.gz
 
 Publish with `./scripts/publish-release.sh <version> --channel <channel>` or let `.github/workflows/host-bundle-release.yml` do it on `main`. The publish step uploads immutable R2 objects and registers the release in platform Postgres; platform Postgres is the source of truth for release metadata and channel pointers.
 
-Existing VPSes update through platform fan-out:
+Existing VPS deployments are explicit. Normal `main` pushes publish and promote
+`dev` without updating any VPS. Target each reviewed customer handle rather than
+using an unqualified fleet deploy:
 
 ```bash
 curl --fail --silent --show-error \
   -X POST https://app.matrix-os.com/vps/deploy \
   -H "Authorization: Bearer $PLATFORM_SECRET" \
   -H "Content-Type: application/json" \
-  -d '{"version":"v2026.05.12-43"}'
+  -d '{"handle":"<reviewed-handle>","version":"v2026.05.12-43"}'
 ```
 
 Do not SSH-copy bundles except for break-glass recovery. The sync agent downloads the registered bundle through platform, verifies the SHA-256, stages extraction, keeps `/opt/matrix/app.rollback`, swaps `/opt/matrix/app`, writes `/opt/matrix/release.json`, and restarts services.
 
 Operational rules:
 
+- Keep release provenance and update subscription separate. `/opt/matrix/release.json`
+  describes the installed immutable artifact and may retain its build channel.
+  `/opt/matrix/env/host.env` `MATRIX_UPDATE_CHANNEL` is the persistent channel
+  followed by the sync agent and exposed as `updateChannel` by `/api/system/info`.
+- Passive sync polling must not treat an older channel pointer as an available
+  update. Explicit `matrix-update <channel-or-version>` remains the operator/user
+  path for an intentional downgrade.
 - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is build-time, not runtime. If the browser tries to load `https://clerk.example.com/...`, the served shell bundle was built with the placeholder Clerk key and must be rebuilt with the real key.
 - `DATABASE_URL` must exist in `/opt/matrix/env/host.env` or be assembled by `/opt/matrix/bin/matrix-gateway` from `/opt/matrix/env/postgres.env`. Without it, gateway state can drift away from owner-controlled Postgres.
 - Do not use `owner: root:matrix` in cloud-init `write_files` before the `matrix` group exists. Prefer `root:root` for env files unless the file must be group-readable.

--- a/packages/gateway/src/system-info.ts
+++ b/packages/gateway/src/system-info.ts
@@ -136,6 +136,7 @@ export function getVersion(release?: HostBundleRelease): string {
 export interface SystemInfo {
   version: string;
   channel?: string;
+  updateChannel: string;
   model: string;
   effort: string;
   image: string;
@@ -190,6 +191,25 @@ function readReleaseInfo(): HostBundleRelease | undefined {
     }
   }
   return undefined;
+}
+
+function readPersistentUpdateChannel(): string | undefined {
+  const hostEnvFile = process.env.MATRIX_HOST_ENV_FILE ?? "/opt/matrix/env/host.env";
+  try {
+    return readCachedSystemInfoFile(`host-env:${hostEnvFile}`, () => {
+      const raw = readBoundedTextFile(hostEnvFile);
+      for (const line of raw.split(/\r?\n/)) {
+        const match = line.match(/^MATRIX_UPDATE_CHANNEL=(stable|canary|beta|dev)$/);
+        if (match) return match[1];
+      }
+      return undefined;
+    });
+  } catch (err) {
+    if (!isMissingFileError(err)) {
+      logSystemInfoReadFailure("Failed to read persistent update channel", err);
+    }
+    return undefined;
+  }
 }
 
 function readDiskUsage(path: string): { totalBytes: number; freeBytes: number } | null {
@@ -270,10 +290,15 @@ export function getSystemInfo(
   const [load1 = 0, load5 = 0, load15 = 0] = loadavg();
   const release = readReleaseInfo();
   const channel = parseReleaseChannel(release?.channel);
+  const updateChannel = readPersistentUpdateChannel()
+    ?? parseReleaseChannel(process.env.MATRIX_UPDATE_CHANNEL)
+    ?? channel
+    ?? "stable";
 
   return {
     version: getVersion(release),
     ...(channel ? { channel } : {}),
+    updateChannel,
     model: kernelOverrides.model ?? kernel.model,
     effort: kernel.effort,
     image: process.env.MATRIX_IMAGE ?? "unknown",

--- a/shell/src/components/RuntimeIdentityBanner.tsx
+++ b/shell/src/components/RuntimeIdentityBanner.tsx
@@ -8,6 +8,7 @@ import { ShellNotificationCard } from "./ShellNotificationCard";
 const ATTENTION_RELEASE_CHANNELS = new Set(["dev", "canary", "beta"]);
 
 interface RuntimeInfo {
+  updateChannel?: string | null;
   runtime?: {
     handle?: string | null;
     machineId?: string | null;
@@ -92,7 +93,9 @@ export function RuntimeIdentityBanner() {
     const slot = runtime?.runtime?.runtimeSlot ?? "primary";
     const machineId = runtime?.runtime?.machineId ?? null;
     const isStaging = slot !== "primary";
-    const channel = runtime?.release?.channel?.toLowerCase() ?? null;
+    const channel = runtime?.updateChannel?.toLowerCase()
+      ?? runtime?.release?.channel?.toLowerCase()
+      ?? null;
     const shouldShow = isStaging || (channel ? ATTENTION_RELEASE_CHANNELS.has(channel) : false);
     return {
       handle,

--- a/shell/src/components/settings/sections/SystemSection.tsx
+++ b/shell/src/components/settings/sections/SystemSection.tsx
@@ -15,6 +15,7 @@ const UPDATE_INSTALL_TIMEOUT_MS = 5 * 60_000;
 interface SystemInfo {
   version?: string;
   image?: string;
+  updateChannel?: string;
   release?: {
     version?: string;
     channel?: string;
@@ -184,7 +185,7 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
       .then((r) => r.ok ? r.json() : {})
       .then((data: SystemInfo) => {
         setInfo(data);
-        const channel = coerceReleaseChannel(data.release?.channel);
+        const channel = coerceReleaseChannel(data.updateChannel ?? data.release?.channel);
         setSelectedChannel(channel);
         void refreshReleaseData(channel);
       })
@@ -213,7 +214,7 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
   const currentVersion = resolvedUpdate.currentVersion;
   const latestVersion = resolvedUpdate.latestVersion;
   const updateAvailable = resolvedUpdate.updateAvailable;
-  const installedChannel = coerceReleaseChannel(info.release?.channel);
+  const installedChannel = coerceReleaseChannel(info.updateChannel ?? info.release?.channel);
   const releaseRows = releaseList?.releases ?? [];
   const canInstallSelectedChannel = Boolean(latestVersion && (updateAvailable || selectedChannel !== installedChannel));
   const systemUpdatesLocked = !billingActive;

--- a/tests/gateway/system-info.test.ts
+++ b/tests/gateway/system-info.test.ts
@@ -109,6 +109,36 @@ describe("T135: System info", () => {
     }
   });
 
+  it("reports the persistent update channel separately from bundle provenance", () => {
+    const homePath = tmpHome();
+    const releasePath = join(homePath, "release.json");
+    const hostEnvPath = join(homePath, "host.env");
+    const previousReleasePath = process.env.MATRIX_RELEASE_FILE;
+    const previousHostEnvPath = process.env.MATRIX_HOST_ENV_FILE;
+    const previousUpdateChannel = process.env.MATRIX_UPDATE_CHANNEL;
+    process.env.MATRIX_RELEASE_FILE = releasePath;
+    process.env.MATRIX_HOST_ENV_FILE = hostEnvPath;
+    process.env.MATRIX_UPDATE_CHANNEL = "dev";
+    writeFileSync(releasePath, JSON.stringify({ version: "v2026.08.05-912", channel: "dev" }));
+    writeFileSync(hostEnvPath, "MATRIX_UPDATE_CHANNEL=stable\n");
+
+    try {
+      const info = getSystemInfo(homePath);
+
+      expect(info.release?.channel).toBe("dev");
+      expect(info.channel).toBe("dev");
+      expect(info.updateChannel).toBe("stable");
+    } finally {
+      if (previousReleasePath === undefined) delete process.env.MATRIX_RELEASE_FILE;
+      else process.env.MATRIX_RELEASE_FILE = previousReleasePath;
+      if (previousHostEnvPath === undefined) delete process.env.MATRIX_HOST_ENV_FILE;
+      else process.env.MATRIX_HOST_ENV_FILE = previousHostEnvPath;
+      if (previousUpdateChannel === undefined) delete process.env.MATRIX_UPDATE_CHANNEL;
+      else process.env.MATRIX_UPDATE_CHANNEL = previousUpdateChannel;
+      rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
   it("falls back to the installed bundle version when release metadata has no version", () => {
     const homePath = tmpHome();
     const releasePath = join(homePath, "release.json");

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -51,6 +51,19 @@ function runHostBundlePreflight(env: Record<string, string>) {
   });
 }
 
+function compareSyncAgentVersions(candidate: string, current: string): string {
+  const root = process.cwd();
+  const syncAgent = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-sync-agent'), 'utf8');
+  const functionSource = syncAgent.match(/compare_host_bundle_versions\(\) \{[\s\S]*?\n\}/)?.[0];
+  expect(functionSource).toBeDefined();
+  const result = spawnSync('bash', ['-c', `${functionSource}\ncompare_host_bundle_versions "$1" "$2"`, 'version-test', candidate, current], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  expect(result.status, result.stderr || result.stdout).toBe(0);
+  return result.stdout.trim();
+}
+
 describe('customer VPS host bundle', () => {
   it('build script packages the systemd entrypoint binaries', () => {
     const root = process.cwd();
@@ -1065,6 +1078,25 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(updater).toContain('stable|canary|beta|dev|v[0-9]*|main-[A-Za-z0-9]*');
     expect(updater).toContain('journalctl -u matrix-sync-agent -f --no-pager -n 20');
     expect(updater).toContain('Usage: matrix-update [--no-tail] [apply|rollback|repair|stable|canary|beta|dev|v<version>|main-<build>]');
+  });
+
+  it('sync agent distinguishes newer and older date-based host bundles', () => {
+    const syncAgent = readFileSync(join(process.cwd(), 'distro/customer-vps/host-bin/matrix-sync-agent'), 'utf8');
+
+    expect(compareSyncAgentVersions('v2026.08.06-1', 'v2026.08.05-912')).toBe('newer');
+    expect(compareSyncAgentVersions('v2026.08.05-912', 'v2026.08.05-912')).toBe('equal');
+    expect(compareSyncAgentVersions('v2026.08.04-898', 'v2026.08.05-912')).toBe('older');
+    expect(compareSyncAgentVersions('v0.0.0-preview', 'v2026.08.05-912')).toBe('unknown');
+    expect(syncAgent).toContain('version_comparison="$(compare_host_bundle_versions "$remote_version" "$cur")"');
+    expect(syncAgent).toContain('if [ "$version_comparison" = "older" ]; then');
+    expect(syncAgent).toContain('Ignoring older channel release: $remote_version (current: $cur)');
+    expect(syncAgent).toContain([
+      'if [ "$version_comparison" = "older" ]; then',
+      '    log "Ignoring older channel release: $remote_version (current: $cur)"',
+      '    rm -f "$UPDATE_MARKER" "$UPDATE_ERROR_MARKER"',
+      '    return 0',
+      '  fi',
+    ].join('\n'));
   });
 
   it('sync agent installs bundled messaging systemd units during updates', () => {

--- a/tests/shell/runtime-identity-banner.test.tsx
+++ b/tests/shell/runtime-identity-banner.test.tsx
@@ -59,7 +59,7 @@ describe("RuntimeIdentityBanner", () => {
     });
   });
 
-  it("hides the primary VM banner for stable releases", async () => {
+  it("hides the primary VM banner for stable subscribers with a dev-built bundle", async () => {
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.endsWith("/api/system/info")) {
@@ -69,7 +69,8 @@ describe("RuntimeIdentityBanner", () => {
             machineId: "11111111-2222-3333-4444-555555555556",
             runtimeSlot: "primary",
           },
-          release: { version: "v082-test", channel: "stable" },
+          updateChannel: "stable",
+          release: { version: "v082-test", channel: "dev" },
         }));
       }
       if (url.endsWith("/api/identity")) {
@@ -95,7 +96,8 @@ describe("RuntimeIdentityBanner", () => {
             machineId: "11111111-2222-3333-4444-555555555557",
             runtimeSlot: "primary",
           },
-          release: { version: "v2026.05.28-151", channel: "dev" },
+          updateChannel: "dev",
+          release: { version: "v2026.05.28-151", channel: "stable" },
         }));
       }
       if (url.endsWith("/api/identity")) {

--- a/tests/shell/system-section-refresh.test.tsx
+++ b/tests/shell/system-section-refresh.test.tsx
@@ -34,6 +34,51 @@ describe("SystemSection release refresh", () => {
     vi.restoreAllMocks();
   });
 
+  it("uses the persistent update channel instead of the bundle provenance channel", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/system/info")) {
+        return Promise.resolve(jsonResponse({
+          version: "v2026.08.05-912",
+          updateChannel: "stable",
+          release: {
+            version: "v2026.08.05-912",
+            channel: "dev",
+          },
+        }));
+      }
+      if (url.endsWith("/health")) {
+        return Promise.resolve(jsonResponse({ status: "ok", cronJobs: 0, channels: {} }));
+      }
+      if (url.endsWith("/api/system/update?channel=stable")) {
+        return Promise.resolve(jsonResponse({
+          channel: "stable",
+          latest: { version: "v2026.08.05-912" },
+          updateAvailable: false,
+        }));
+      }
+      if (url.endsWith("/api/system/releases?channel=stable")) {
+        return Promise.resolve(jsonResponse({ channel: "stable", releases: [] }));
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SystemSection />);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText("Release channel") as HTMLSelectElement).value).toBe("stable");
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://gateway.test/api/system/update?channel=stable",
+        expect.any(Object),
+      );
+    });
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "http://gateway.test/api/system/update?channel=dev",
+      expect.anything(),
+    );
+  });
+
   it("ignores stale release metadata when the selected channel changes", async () => {
     const stableUpdate = deferred<Response>();
     const stableReleases = deferred<Response>();


### PR DESCRIPTION
## Summary

- expose the persistent VPS subscription as `updateChannel`, reading `/opt/matrix/env/host.env` before process or installed-release fallbacks
- make the runtime banner and System Settings use that effective channel while preserving `release.channel` as immutable artifact provenance
- prevent passive sync polling from advertising or auto-applying an older date-based channel pointer; explicit downgrade commands remain supported
- document the channel/provenance distinction and scoped deployment policy

## Tests

- red/green coverage for a stable subscriber running a dev-built artifact
- red/green coverage for Settings selecting stable from `updateChannel`
- red/green coverage for newer/equal/older/unrecognized sync-agent versions
- 125 focused gateway, shell, update, and host-bundle tests
- `bun run typecheck`
- `bun run check:patterns` (0 violations)
- `bun run test`
- `git diff --check`

## Invariants

- `/opt/matrix/env/host.env` `MATRIX_UPDATE_CHANNEL` is the persistent subscription source of truth
- `/opt/matrix/release.json` remains installed immutable-artifact provenance and is not rewritten
- explicit `matrix-update <channel-or-version>` can still perform an intentional downgrade
- passive polling only suppresses older versions when both versions use the recognized date-based host-bundle scheme; unknown schemes preserve prior behavior
- no database, auth, customer data, owner home, Postgres, or session paths change

## Rollout

- normal main publication must not deploy this bundle automatically
- verify the post-merge host-bundle workflow publishes/promotes dev and skips fleet deployment
- stable remains pinned unless an operator explicitly promotes a validated immutable bundle

## Deferred

- persistent platform database channel assignment, authenticated assignment APIs, per-user provisioning overrides, and channel-aware deploy filtering remain separate architecture work
