### PR TITLE
fix(desktop): reconcile project creation and folder reuse

### DIFF
--- a/desktop/src/renderer/src/features/board/AddProjectStepFields.tsx
+++ b/desktop/src/renderer/src/features/board/AddProjectStepFields.tsx
@@ -2,7 +2,8 @@
 // orchestration live in CreateProjectDialog; these components only render
 // fields and forward edits.
 import { Button } from "../../design/primitives";
-import ComputerFileBrowser from "../files/ComputerFileBrowser";
+import type { Project } from "../../stores/board";
+import ComputerFileBrowser, { type FolderPickerChoice } from "../files/ComputerFileBrowser";
 
 export const FIELD_STYLE: React.CSSProperties = {
   background: "var(--bg-raised)",
@@ -103,15 +104,45 @@ export function ExistingFolderStepFields({
   name,
   onNameChange,
   folderPath,
+  projects,
   onChooseFolder,
+  onOpenProject,
   submitting,
 }: {
   name: string;
   onNameChange: (value: string) => void;
   folderPath: string;
+  projects: Project[];
   onChooseFolder: (path: string) => void;
+  onOpenProject: (slug: string) => void;
   submitting: boolean;
 }) {
+  const projectForRegistryPath = (path: string): Project | undefined => {
+    const segments = path.replace(/^\.\/+/, "").replace(/\/+$/, "").split("/");
+    if (segments.length !== 2 || segments[0] !== "projects") return undefined;
+    return projects.find((project) => project.slug === segments[1]);
+  };
+  const resolveFolderChoice = (path: string): FolderPickerChoice => {
+    const normalized = path.replace(/^\.\/+/, "").replace(/\/+$/, "");
+    const segments = normalized.split("/");
+    if (segments[0] !== "projects") return { kind: "choose" };
+    // projects/<slug> is Matrix-owned registry state. Only the repo checkout
+    // beneath it (and its descendants) is a user workspace.
+    if (segments.length >= 3 && segments[2] === "repo") return { kind: "choose" };
+    const project = projectForRegistryPath(normalized);
+    if (project) {
+      return {
+        kind: "alternate",
+        label: `Open ${project.name}`,
+        message: "This folder contains Matrix project data, not a workspace.",
+      };
+    }
+    return {
+      kind: "blocked",
+      message: "This folder is managed by Matrix and can't be used as a workspace.",
+    };
+  };
+
   return (
     <>
       <label className="flex flex-col gap-1">
@@ -127,7 +158,16 @@ export function ExistingFolderStepFields({
       </label>
       <div className="flex flex-col gap-1.5">
         <span className="text-xs font-medium" style={{ color: "var(--text-secondary)" }}>Choose a folder on this computer</span>
-        <ComputerFileBrowser compact mode="folder-picker" onChooseFolder={onChooseFolder} />
+        <ComputerFileBrowser
+          compact
+          mode="folder-picker"
+          onChooseFolder={onChooseFolder}
+          resolveFolderChoice={resolveFolderChoice}
+          onAlternateFolderAction={(path) => {
+            const project = projectForRegistryPath(path);
+            if (project) onOpenProject(project.slug);
+          }}
+        />
         <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
           {folderPath ? `Selected: ${folderPath}` : "Select a folder. It stays in place and remains yours."}
         </span>

--- a/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
+++ b/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
@@ -87,6 +87,7 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
   } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [cloneRequestId] = useState(() => `req_${crypto.randomUUID()}`);
+  const folderRequestRef = useRef<{ payload: string; id: string } | null>(null);
   const dialogClosedRef = useRef(false);
   const dialogGenerationRef = useRef(0);
   // Latest runtime identity. A submission captures the identity it was sent to
@@ -217,7 +218,18 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
           clientRequestId: cloneRequestId,
         });
       } else {
-        await submitNewFolder(ctx, { name: name.trim(), parentPath });
+        const folderPayload = JSON.stringify({ name: name.trim(), parentPath });
+        if (folderRequestRef.current?.payload !== folderPayload) {
+          folderRequestRef.current = {
+            payload: folderPayload,
+            id: `req_desktop_folder_${crypto.randomUUID()}`,
+          };
+        }
+        await submitNewFolder(ctx, {
+          name: name.trim(),
+          parentPath,
+          clientRequestId: folderRequestRef.current.id,
+        });
       }
     } catch (err: unknown) {
       if (isCurrent()) setError(toUserMessage(err));

--- a/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
+++ b/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
@@ -6,7 +6,13 @@ import { useBoard } from "../../stores/board";
 import { useConnection } from "../../stores/connection";
 import { useTabs } from "../../stores/tabs";
 import { CloneStepFields, ExistingFolderStepFields, NewFolderStepFields } from "./AddProjectStepFields";
-import { submitClone, submitExistingFolder, submitNewFolder } from "./add-project-submit";
+import {
+  openExistingProject,
+  submitClone,
+  submitExistingFolder,
+  submitNewFolder,
+  type AddProjectSubmitContext,
+} from "./add-project-submit";
 import {
   isValidBranchName,
   isValidProjectSlug,
@@ -65,6 +71,7 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
   const createProject = useBoard((s) => s.createProject);
   const selectProject = useBoard((s) => s.selectProject);
   const loadProjects = useBoard((s) => s.loadProjects);
+  const projects = useBoard((s) => s.projects);
   const openTab = useTabs((s) => s.openTab);
   const runtimeSlot = useConnection((s) => s.runtimeSlot);
   const authGeneration = useConnection((s) => s.authGeneration);
@@ -175,17 +182,8 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
     return false;
   })();
 
-  const submit = async () => {
-    if (!api || step === "pick" || !canSubmit || submitting) return;
-    if (step === "github") {
-      setUrlAttempted(true);
-      setBranchAttempted(true);
-      if (!parsedUrl || branchInvalid || !isValidProjectSlug(effectiveFolderName)) return;
-    }
-    if (step === "scratch" && slugifyProjectName(name.trim()).length === 0) {
-      setError("Use at least one letter or number in the name.");
-      return;
-    }
+  const beginSubmission = (): { ctx: AddProjectSubmitContext; isCurrent: () => boolean } | null => {
+    if (!api || submitting) return null;
     const submitGeneration = dialogGenerationRef.current;
     const submitRuntimeSlot = runtimeSlot;
     const submitAuthGeneration = authGeneration;
@@ -196,18 +194,47 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
       && dialogGenerationRef.current === submitGeneration
       && runtimeIdentityRef.current.runtimeSlot === submitRuntimeSlot
       && runtimeIdentityRef.current.authGeneration === submitAuthGeneration;
-    const ctx = {
-      api,
-      runtimeSlot,
-      createProject,
-      selectProject,
-      loadProjects,
-      openTab,
+    return {
       isCurrent,
-      setError,
-      close: closeFromUser,
+      ctx: {
+        api,
+        runtimeSlot,
+        getProjects: () => useBoard.getState().projects,
+        createProject,
+        selectProject,
+        loadProjects,
+        openTab,
+        isCurrent,
+        setError,
+        close: closeFromUser,
+      },
     };
+  };
+
+  const runSubmission = async (action: (ctx: AddProjectSubmitContext) => Promise<void>) => {
+    const submission = beginSubmission();
+    if (!submission) return;
     try {
+      await action(submission.ctx);
+    } catch (err: unknown) {
+      if (submission.isCurrent()) setError(toUserMessage(err));
+    } finally {
+      if (submission.isCurrent()) setActiveSubmission(null);
+    }
+  };
+
+  const submit = async () => {
+    if (step === "pick" || !canSubmit || submitting) return;
+    if (step === "github") {
+      setUrlAttempted(true);
+      setBranchAttempted(true);
+      if (!parsedUrl || branchInvalid || !isValidProjectSlug(effectiveFolderName)) return;
+    }
+    if (step === "scratch" && slugifyProjectName(name.trim()).length === 0) {
+      setError("Use at least one letter or number in the name.");
+      return;
+    }
+    await runSubmission(async (ctx) => {
       if (step === "folder") {
         await submitExistingFolder(ctx, { name: name.trim(), path: folderPath });
       } else if (step === "github") {
@@ -231,11 +258,7 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
           clientRequestId: folderRequestRef.current.id,
         });
       }
-    } catch (err: unknown) {
-      if (isCurrent()) setError(toUserMessage(err));
-    } finally {
-      if (isCurrent()) setActiveSubmission(null);
-    }
+    });
   };
 
   const submitLabel = step === "github" ? (submitting ? "Cloning…" : "Clone") : submitting ? "Creating…" : "Create";
@@ -325,7 +348,9 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
             setNameTouched(true);
           }}
           folderPath={folderPath}
+          projects={projects}
           onChooseFolder={chooseFolder}
+          onOpenProject={(slug) => void runSubmission((ctx) => openExistingProject(ctx, slug))}
           submitting={submitting}
         />
       ) : null}

--- a/desktop/src/renderer/src/features/board/add-project-submit.ts
+++ b/desktop/src/renderer/src/features/board/add-project-submit.ts
@@ -1,7 +1,7 @@
 // Submit orchestration for the add-project dialog: one function per mode.
 // Every helper re-checks the dialog generation (isCurrent) after each await
-// so a closed dialog or a superseded submit never mutates state, and all
-// client-visible errors are generic copy.
+// so a closed dialog or a superseded submit never mutates state. User-facing
+// errors use bounded app-owned copy rather than raw upstream messages.
 import type { ApiClient } from "../../lib/api";
 import { AppError, toUserMessage } from "../../lib/errors";
 import type { Project } from "../../stores/board";
@@ -11,6 +11,7 @@ import { slugifyProjectName } from "./add-project-model";
 export interface AddProjectSubmitContext {
   api: ApiClient;
   runtimeSlot: string;
+  getProjects: () => Project[];
   createProject: (
     api: ApiClient,
     input: { name: string; mode: "scratch" | "github" | "folder"; url?: string; path?: string },
@@ -24,6 +25,39 @@ export interface AddProjectSubmitContext {
   close: () => void;
 }
 
+function projectPathMatches(localPath: string | undefined, selectedPath: string): boolean {
+  if (!localPath) return false;
+  const normalizedLocalPath = localPath.replaceAll("\\", "/").replace(/\/+$/, "");
+  const normalizedSelectedPath = selectedPath
+    .replaceAll("\\", "/")
+    .replace(/^\.\/+/, "")
+    .replace(/\/+$/, "");
+  return normalizedSelectedPath.length > 0
+    && (normalizedLocalPath === normalizedSelectedPath
+      || normalizedLocalPath.endsWith(`/${normalizedSelectedPath}`));
+}
+
+async function handleExistingFolderProject(
+  ctx: AddProjectSubmitContext,
+  input: { name: string; path: string },
+): Promise<boolean> {
+  const projects = ctx.getProjects();
+  // Folder identity is stronger than the editable display name. In particular,
+  // managed checkouts end in /repo, so deriving the form name from the final
+  // path segment cannot recover the owning project slug.
+  const projectAtPath = projects.find((project) => projectPathMatches(project.localPath, input.path));
+  if (projectAtPath) {
+    await finish(ctx, projectAtPath);
+    return true;
+  }
+  const existingProject = projects.find(
+    (project) => project.slug === slugifyProjectName(input.name),
+  );
+  if (!existingProject) return false;
+  ctx.setError(`A project named “${existingProject.name}” already exists. Choose another name.`);
+  return true;
+}
+
 // Shared success path for every mode: make the new project active and open
 // its project tab.
 async function finish(ctx: AddProjectSubmitContext, project: { slug: string; name: string }): Promise<void> {
@@ -33,13 +67,26 @@ async function finish(ctx: AddProjectSubmitContext, project: { slug: string; nam
   ctx.openTab({ kind: "project", projectSlug: project.slug, title: project.name || project.slug });
 }
 
+export async function openExistingProject(ctx: AddProjectSubmitContext, slug: string): Promise<void> {
+  const project = ctx.getProjects().find((candidate) => candidate.slug === slug);
+  if (!project) {
+    ctx.setError("That project is no longer available. Refresh and try again.");
+    return;
+  }
+  await finish(ctx, project);
+}
+
 export async function submitExistingFolder(
   ctx: AddProjectSubmitContext,
   input: { name: string; path: string },
 ): Promise<void> {
+  if (await handleExistingFolderProject(ctx, input)) return;
   const project = await ctx.createProject(ctx.api, { name: input.name, mode: "folder", path: input.path });
   if (!ctx.isCurrent()) return;
   if (!project) {
+    await ctx.loadProjects(ctx.api);
+    if (!ctx.isCurrent()) return;
+    if (await handleExistingFolderProject(ctx, input)) return;
     ctx.setError("Couldn't connect that folder. Check that it exists on this computer.");
     return;
   }

--- a/desktop/src/renderer/src/features/board/add-project-submit.ts
+++ b/desktop/src/renderer/src/features/board/add-project-submit.ts
@@ -75,7 +75,7 @@ export async function submitClone(
 
 export async function submitNewFolder(
   ctx: AddProjectSubmitContext,
-  input: { name: string; parentPath: string },
+  input: { name: string; parentPath: string; clientRequestId: string },
 ): Promise<void> {
   const parentPath = input.parentPath.trim().replace(/^\.\/+/, "").replace(/\/+$/, "");
   // Selecting the visible Projects directory is semantically identical to the
@@ -96,10 +96,26 @@ export async function submitNewFolder(
   // behind; the user can connect it with "Existing folder".
   let createdPath: string;
   try {
-    const created = await ctx.api.post<{ path?: unknown }>("/api/projects/mkdir", {
+    const body = {
       name: slugifyProjectName(input.name),
       parent: parentPath,
-    });
+      clientRequestId: input.clientRequestId,
+    };
+    let created: { path?: unknown };
+    try {
+      created = await ctx.api.post<{ path?: unknown }>(
+        "/api/projects/mkdir",
+        body,
+        { timeoutMs: 30_000 },
+      );
+    } catch (err: unknown) {
+      if (!(err instanceof AppError) || err.category !== "timeout") throw err;
+      created = await ctx.api.post<{ path?: unknown }>(
+        "/api/projects/mkdir",
+        body,
+        { timeoutMs: 310_000 },
+      );
+    }
     if (typeof created.path !== "string" || created.path.length === 0) {
       if (ctx.isCurrent()) ctx.setError("Couldn't create the folder. Try again.");
       return;

--- a/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
+++ b/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
@@ -28,6 +28,11 @@ import {
 
 type BrowserStatus = "loading" | "ready" | "error";
 
+export type FolderPickerChoice =
+  | { kind: "choose" }
+  | { kind: "blocked"; message: string }
+  | { kind: "alternate"; label: string; message: string };
+
 const NO_ENTRIES: BrowserEntry[] = [];
 
 function joinPath(parent: string, name: string): string {
@@ -44,6 +49,8 @@ export default function ComputerFileBrowser({
   mode = "browse",
   onOpenFile,
   onChooseFolder,
+  resolveFolderChoice,
+  onAlternateFolderAction,
 }: {
   compact?: boolean;
   // framed renders the browser as its own bordered card (dialogs, pickers).
@@ -55,6 +62,8 @@ export default function ComputerFileBrowser({
   mode?: "browse" | "folder-picker";
   onOpenFile?: (path: string) => void;
   onChooseFolder?: (path: string) => void;
+  resolveFolderChoice?: (path: string) => FolderPickerChoice;
+  onAlternateFolderAction?: (path: string) => void;
 }) {
   const api = useConnection((state) => state.api);
   const runtimeSlot = useConnection((state) => state.runtimeSlot);
@@ -232,6 +241,9 @@ export default function ComputerFileBrowser({
   }, [viewCurrentPath]);
 
   const chosenName = (viewCandidatePath.split("/").pop() || "Matrix home");
+  const folderChoice = viewCandidatePath
+    ? resolveFolderChoice?.(viewCandidatePath) ?? { kind: "choose" as const }
+    : null;
   // Name flexes (minmax(0,1fr) + truncate); Size/Modified are fixed-width
   // right-aligned columns sized to the format.ts outputs, so long names only
   // truncate once the pane is genuinely out of room.
@@ -346,12 +358,29 @@ export default function ComputerFileBrowser({
 
       {onChooseFolder ? (
         <div className="flex shrink-0 items-center justify-between gap-3 border-t px-3 py-2" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }}>
-          <span className="min-w-0 truncate text-xs" style={{ color: "var(--text-secondary)" }} title={viewCandidatePath || "Matrix home"}>
-            {viewCandidatePath || "Matrix home"}
-          </span>
-          <Button variant="primary" disabled={!viewCandidatePath} onClick={() => onChooseFolder(viewCandidatePath)}>
-            Choose {chosenName}
-          </Button>
+          <div className="min-w-0">
+            <div className="truncate text-xs" style={{ color: "var(--text-secondary)" }} title={viewCandidatePath || "Matrix home"}>
+              {viewCandidatePath || "Matrix home"}
+            </div>
+            {folderChoice && folderChoice.kind !== "choose" ? (
+              <div className="mt-0.5 text-[11px]" style={{ color: "var(--text-tertiary)" }}>
+                {folderChoice.message}
+              </div>
+            ) : null}
+          </div>
+          {folderChoice?.kind === "alternate" ? (
+            <Button variant="primary" onClick={() => onAlternateFolderAction?.(viewCandidatePath)}>
+              {folderChoice.label}
+            </Button>
+          ) : (
+            <Button
+              variant="primary"
+              disabled={!viewCandidatePath || folderChoice?.kind === "blocked"}
+              onClick={() => onChooseFolder(viewCandidatePath)}
+            >
+              Choose {chosenName}
+            </Button>
+          )}
         </div>
       ) : null}
     </div>

--- a/desktop/src/renderer/src/stores/board.ts
+++ b/desktop/src/renderer/src/stores/board.ts
@@ -48,6 +48,7 @@ export const BOARD_COLUMNS: readonly CardStatus[] = [
 ];
 
 const CardStatusSchema = z.enum(["todo", "running", "waiting", "blocked", "complete", "archived"]);
+const PROJECT_CREATE_TIMEOUT_MS = 30_000;
 
 const WireTaskSchema = z.object({
   id: z.string().min(1),
@@ -334,12 +335,24 @@ export const useBoard = create<BoardState>()((set, get) => {
       // new computer's board with the previous runtime's projects.
       const runtimeGeneration = captureRuntimeGeneration();
       try {
+        const clientRequestId = `req_desktop_project_${crypto.randomUUID()}`;
         const body = input.mode === "github"
-          ? { name: input.name, mode: "github" as const, url: input.url }
+          ? { name: input.name, mode: "github" as const, url: input.url, clientRequestId }
           : input.mode === "folder"
-            ? { name: input.name, mode: "folder" as const, path: input.path }
-            : { name: input.name, mode: "scratch" as const };
-        const res = await api.post<{ project: unknown }>("/api/projects", body);
+            ? { name: input.name, mode: "folder" as const, path: input.path, clientRequestId }
+            : { name: input.name, mode: "scratch" as const, clientRequestId };
+        const sendCreate = () => api.post<{ project: unknown }>(
+          "/api/projects",
+          body,
+          { timeoutMs: PROJECT_CREATE_TIMEOUT_MS },
+        );
+        let res: { project: unknown };
+        try {
+          res = await sendCreate();
+        } catch (err: unknown) {
+          if (!(err instanceof AppError) || err.category !== "timeout") throw err;
+          res = await sendCreate();
+        }
         if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
         const project = toProject(res.project);
         if (!project) {

--- a/desktop/src/renderer/src/stores/board.ts
+++ b/desktop/src/renderer/src/stores/board.ts
@@ -49,6 +49,7 @@ export const BOARD_COLUMNS: readonly CardStatus[] = [
 
 const CardStatusSchema = z.enum(["todo", "running", "waiting", "blocked", "complete", "archived"]);
 const PROJECT_CREATE_TIMEOUT_MS = 30_000;
+const PROJECT_CREATE_RETRY_TIMEOUT_MS = 310_000;
 
 const WireTaskSchema = z.object({
   id: z.string().min(1),
@@ -341,17 +342,20 @@ export const useBoard = create<BoardState>()((set, get) => {
           : input.mode === "folder"
             ? { name: input.name, mode: "folder" as const, path: input.path, clientRequestId }
             : { name: input.name, mode: "scratch" as const, clientRequestId };
-        const sendCreate = () => api.post<{ project: unknown }>(
+        const sendCreate = (timeoutMs: number) => api.post<{ project: unknown }>(
           "/api/projects",
           body,
-          { timeoutMs: PROJECT_CREATE_TIMEOUT_MS },
+          { timeoutMs },
         );
         let res: { project: unknown };
         try {
-          res = await sendCreate();
+          res = await sendCreate(PROJECT_CREATE_TIMEOUT_MS);
         } catch (err: unknown) {
           if (!(err instanceof AppError) || err.category !== "timeout") throw err;
-          res = await sendCreate();
+          // The gateway bounds Git cloning at five minutes. Waiting slightly
+          // longer on the replay lets the original request finish and return
+          // its persisted idempotent result instead of surfacing ambiguity.
+          res = await sendCreate(PROJECT_CREATE_RETRY_TIMEOUT_MS);
         }
         if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
         const project = toProject(res.project);

--- a/packages/gateway/src/project-folders.ts
+++ b/packages/gateway/src/project-folders.ts
@@ -96,13 +96,19 @@ export function createProjectFolders(options: { homePath: string }) {
   async function readReceipt(clientRequestId: string): Promise<FolderRequestReceipt | null> {
     try {
       const receipt = await readJsonFile<FolderRequestReceipt>(receiptPath(clientRequestId));
-      return typeof receipt.fingerprint === "string"
+      const valid = typeof receipt.fingerprint === "string"
         && typeof receipt.path === "string"
         && typeof receipt.createdAt === "string"
         && (receipt.ownerScope?.type === "user" || receipt.ownerScope?.type === "org")
-        && typeof receipt.ownerScope.id === "string"
-        ? receipt
-        : null;
+        && typeof receipt.ownerScope.id === "string";
+      if (!valid) return null;
+
+      const createdAtMs = Date.parse(receipt.createdAt);
+      if (!Number.isFinite(createdAtMs) || createdAtMs <= Date.now() - FOLDER_REQUEST_RECEIPT_TTL_MS) {
+        await rm(receiptPath(clientRequestId), { force: true });
+        return null;
+      }
+      return receipt;
     } catch (err: unknown) {
       if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") return null;
       if (err instanceof SyntaxError) return null;

--- a/packages/gateway/src/project-folders.ts
+++ b/packages/gateway/src/project-folders.ts
@@ -9,7 +9,8 @@
 //   - custom parent: <parent>/<name> anywhere else non-protected in the
 //     home. The projects registry itself is manager-owned metadata and is
 //     rejected as a custom parent.
-import { lstat, mkdir, realpath, rm } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { lstat, mkdir, readdir, realpath, rm } from "node:fs/promises";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { z } from "zod/v4";
 import { PROJECT_SLUG_REGEX } from "./project-manager.js";
@@ -19,12 +20,24 @@ import {
   isProtectedHomeSubpath,
   resolveWithinHome,
 } from "./path-security.js";
+import { atomicCreateJson, readJsonFile, type OwnerScope } from "./state-ops.js";
 
 type Result<T> = { ok: true; status?: number } & T;
 type Failure = { ok: false; status: number; error: { code: string; message: string } };
 
 const FolderNameSchema = z.string().trim().regex(PROJECT_SLUG_REGEX);
 const ParentSchema = z.string().trim().min(1).max(1024);
+const ClientRequestIdSchema = z.string().min(5).max(132).regex(/^req_[A-Za-z0-9_-]+$/);
+
+interface FolderRequestReceipt {
+  fingerprint: string;
+  path: string;
+  ownerScope: OwnerScope;
+  createdAt: string;
+}
+
+const MAX_FOLDER_REQUEST_RECEIPTS = 256;
+const FOLDER_REQUEST_RECEIPT_TTL_MS = 24 * 60 * 60 * 1000;
 
 function failure(status: number, code: string, message: string): Failure {
   return { ok: false, status, error: { code, message } };
@@ -44,6 +57,83 @@ function overlapsRoot(root: string, path: string): boolean {
 
 export function createProjectFolders(options: { homePath: string }) {
   const homePath = resolve(options.homePath);
+
+  function receiptPath(clientRequestId: string): string {
+    return join(homePath, "system", "project-folder-requests", `${clientRequestId}.json`);
+  }
+
+  async function pruneReceipts(): Promise<void> {
+    const root = join(homePath, "system", "project-folder-requests");
+    let entries;
+    try {
+      entries = await readdir(root, { withFileTypes: true });
+    } catch (err: unknown) {
+      if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw err;
+    }
+    const files: Array<{ path: string; mtimeMs: number }> = [];
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+      const path = join(root, entry.name);
+      let stats;
+      try {
+        stats = await lstat(path);
+      } catch (err: unknown) {
+        if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw err;
+      }
+      if (stats.isSymbolicLink() || !stats.isFile()) continue;
+      files.push({ path, mtimeMs: stats.mtimeMs });
+    }
+    files.sort((a, b) => a.mtimeMs - b.mtimeMs);
+    const expiredBefore = Date.now() - FOLDER_REQUEST_RECEIPT_TTL_MS;
+    const overflow = Math.max(0, files.length - MAX_FOLDER_REQUEST_RECEIPTS + 1);
+    await Promise.all(files.map(async (file, index) => {
+      if (file.mtimeMs < expiredBefore || index < overflow) await rm(file.path, { force: true });
+    }));
+  }
+
+  async function readReceipt(clientRequestId: string): Promise<FolderRequestReceipt | null> {
+    try {
+      const receipt = await readJsonFile<FolderRequestReceipt>(receiptPath(clientRequestId));
+      return typeof receipt.fingerprint === "string"
+        && typeof receipt.path === "string"
+        && typeof receipt.createdAt === "string"
+        && (receipt.ownerScope?.type === "user" || receipt.ownerScope?.type === "org")
+        && typeof receipt.ownerScope.id === "string"
+        ? receipt
+        : null;
+    } catch (err: unknown) {
+      if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      if (err instanceof SyntaxError) return null;
+      throw err;
+    }
+  }
+
+  async function receiptTargetExists(path: string): Promise<boolean> {
+    const target = resolveWithinHome(homePath, path);
+    if (!target) return false;
+    try {
+      return (await lstat(target)).isDirectory();
+    } catch (err: unknown) {
+      if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") return false;
+      throw err;
+    }
+  }
+
+  async function reconcileReceipt(
+    clientRequestId: string,
+    fingerprint: string,
+  ): Promise<Result<{ path: string }> | null> {
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      const receipt = await readReceipt(clientRequestId);
+      if (receipt?.fingerprint === fingerprint && await receiptTargetExists(receipt.path)) {
+        return { ok: true, status: 200, path: receipt.path };
+      }
+      await new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 25));
+    }
+    return null;
+  }
 
   // Creates projects/<name>/repo atomically: mkdir without recursive fails
   // with EEXIST when the slug slot is taken, so a conflict can never
@@ -131,15 +221,65 @@ export function createProjectFolders(options: { homePath: string }) {
   }
 
   return {
-    async createFolder(input: { name: string; parent?: string }): Promise<Result<{ path: string }> | Failure> {
+    async createFolder(input: {
+      name: string;
+      parent?: string;
+      clientRequestId?: string;
+      ownerScope?: OwnerScope;
+    }): Promise<Result<{ path: string }> | Failure> {
       if (!FolderNameSchema.safeParse(input.name).success) {
         return failure(400, "invalid_folder_name", "Folder name is invalid");
       }
       const parent = input.parent?.trim().replace(/\/+$/, "");
-      if (!parent || parent === "projects") {
-        return createRegistryFolder(input.name);
+      if (input.clientRequestId && !ClientRequestIdSchema.safeParse(input.clientRequestId).success) {
+        return failure(400, "invalid_request", "Folder request is invalid");
       }
-      return createNestedFolder(input.name, parent);
+      const ownerScope = input.ownerScope ?? { type: "user" as const, id: "local" };
+      const fingerprint = createHash("sha256")
+        .update(JSON.stringify({ name: input.name, parent: parent || "projects", ownerScope }))
+        .digest("hex");
+      if (input.clientRequestId) {
+        const receipt = await readReceipt(input.clientRequestId);
+        if (receipt) {
+          if (receipt.fingerprint !== fingerprint) {
+            return failure(409, "request_conflict", "Folder request conflicts with an earlier request");
+          }
+          if (await receiptTargetExists(receipt.path)) {
+            return { ok: true, status: 200, path: receipt.path };
+          }
+          await rm(receiptPath(input.clientRequestId), { force: true });
+        }
+        // Preserve an existing replay receipt even when the store is at its
+        // cap; reserve room only for a genuinely new receipt.
+        await pruneReceipts();
+      }
+
+      const result = !parent || parent === "projects"
+        ? await createRegistryFolder(input.name)
+        : await createNestedFolder(input.name, parent);
+      if (!result.ok) {
+        if (input.clientRequestId && result.error.code === "folder_conflict") {
+          const reconciled = await reconcileReceipt(input.clientRequestId, fingerprint);
+          if (reconciled) return reconciled;
+        }
+        return result;
+      }
+      if (!input.clientRequestId) return result;
+
+      const published = await atomicCreateJson(receiptPath(input.clientRequestId), {
+        fingerprint,
+        path: result.path,
+        ownerScope,
+        createdAt: new Date().toISOString(),
+      } satisfies FolderRequestReceipt);
+      if (published) return result;
+      const receipt = await readReceipt(input.clientRequestId);
+      if (receipt?.fingerprint === fingerprint && receipt.path === result.path) {
+        return { ok: true, status: 200, path: receipt.path };
+      }
+      const createdTarget = resolveWithinHome(homePath, result.path);
+      if (createdTarget) await rm(createdTarget, { recursive: true, force: true });
+      return failure(409, "request_conflict", "Folder request conflicts with an earlier request");
     },
   };
 }

--- a/packages/gateway/src/project-folders.ts
+++ b/packages/gateway/src/project-folders.ts
@@ -20,7 +20,7 @@ import {
   isProtectedHomeSubpath,
   resolveWithinHome,
 } from "./path-security.js";
-import { atomicCreateJson, readJsonFile, type OwnerScope } from "./state-ops.js";
+import { atomicCreateJson, readJsonFile, withProjectLock, type OwnerScope } from "./state-ops.js";
 
 type Result<T> = { ok: true; status?: number } & T;
 type Failure = { ok: false; status: number; error: { code: string; message: string } };
@@ -34,6 +34,13 @@ interface FolderRequestReceipt {
   path: string;
   ownerScope: OwnerScope;
   createdAt: string;
+}
+
+interface CreateFolderInput {
+  name: string;
+  parent?: string;
+  clientRequestId?: string;
+  ownerScope?: OwnerScope;
 }
 
 const MAX_FOLDER_REQUEST_RECEIPTS = 256;
@@ -226,66 +233,74 @@ export function createProjectFolders(options: { homePath: string }) {
     return { ok: true, status: 201, path: toHomeRelative(realHome, target) };
   }
 
-  return {
-    async createFolder(input: {
-      name: string;
-      parent?: string;
-      clientRequestId?: string;
-      ownerScope?: OwnerScope;
-    }): Promise<Result<{ path: string }> | Failure> {
-      if (!FolderNameSchema.safeParse(input.name).success) {
-        return failure(400, "invalid_folder_name", "Folder name is invalid");
-      }
-      const parent = input.parent?.trim().replace(/\/+$/, "");
-      if (input.clientRequestId && !ClientRequestIdSchema.safeParse(input.clientRequestId).success) {
-        return failure(400, "invalid_request", "Folder request is invalid");
-      }
-      const ownerScope = input.ownerScope ?? { type: "user" as const, id: "local" };
-      const fingerprint = createHash("sha256")
-        .update(JSON.stringify({ name: input.name, parent: parent || "projects", ownerScope }))
-        .digest("hex");
-      if (input.clientRequestId) {
-        const receipt = await readReceipt(input.clientRequestId);
-        if (receipt) {
-          if (receipt.fingerprint !== fingerprint) {
-            return failure(409, "request_conflict", "Folder request conflicts with an earlier request");
-          }
-          if (await receiptTargetExists(receipt.path)) {
-            return { ok: true, status: 200, path: receipt.path };
-          }
-          await rm(receiptPath(input.clientRequestId), { force: true });
-        }
-        // Preserve an existing replay receipt even when the store is at its
-        // cap; reserve room only for a genuinely new receipt.
-        await pruneReceipts();
-      }
-
-      const result = !parent || parent === "projects"
-        ? await createRegistryFolder(input.name)
-        : await createNestedFolder(input.name, parent);
-      if (!result.ok) {
-        if (input.clientRequestId && result.error.code === "folder_conflict") {
-          const reconciled = await reconcileReceipt(input.clientRequestId, fingerprint);
-          if (reconciled) return reconciled;
-        }
-        return result;
-      }
-      if (!input.clientRequestId) return result;
-
-      const published = await atomicCreateJson(receiptPath(input.clientRequestId), {
-        fingerprint,
-        path: result.path,
-        ownerScope,
-        createdAt: new Date().toISOString(),
-      } satisfies FolderRequestReceipt);
-      if (published) return result;
+  async function createFolderUnlocked(input: CreateFolderInput): Promise<Result<{ path: string }> | Failure> {
+    if (!FolderNameSchema.safeParse(input.name).success) {
+      return failure(400, "invalid_folder_name", "Folder name is invalid");
+    }
+    const parent = input.parent?.trim().replace(/\/+$/, "");
+    if (input.clientRequestId && !ClientRequestIdSchema.safeParse(input.clientRequestId).success) {
+      return failure(400, "invalid_request", "Folder request is invalid");
+    }
+    const ownerScope = input.ownerScope ?? { type: "user" as const, id: "local" };
+    const fingerprint = createHash("sha256")
+      .update(JSON.stringify({ name: input.name, parent: parent || "projects", ownerScope }))
+      .digest("hex");
+    if (input.clientRequestId) {
       const receipt = await readReceipt(input.clientRequestId);
-      if (receipt?.fingerprint === fingerprint && receipt.path === result.path) {
-        return { ok: true, status: 200, path: receipt.path };
+      if (receipt) {
+        if (receipt.fingerprint !== fingerprint) {
+          return failure(409, "request_conflict", "Folder request conflicts with an earlier request");
+        }
+        if (await receiptTargetExists(receipt.path)) {
+          return { ok: true, status: 200, path: receipt.path };
+        }
+        await rm(receiptPath(input.clientRequestId), { force: true });
       }
-      const createdTarget = resolveWithinHome(homePath, result.path);
-      if (createdTarget) await rm(createdTarget, { recursive: true, force: true });
-      return failure(409, "request_conflict", "Folder request conflicts with an earlier request");
+      // Preserve an existing replay receipt even when the store is at its
+      // cap; reserve room only for a genuinely new receipt.
+      await pruneReceipts();
+    }
+
+    const result = !parent || parent === "projects"
+      ? await createRegistryFolder(input.name)
+      : await createNestedFolder(input.name, parent);
+    if (!result.ok) {
+      if (input.clientRequestId && result.error.code === "folder_conflict") {
+        const reconciled = await reconcileReceipt(input.clientRequestId, fingerprint);
+        if (reconciled) return reconciled;
+      }
+      return result;
+    }
+    if (!input.clientRequestId) return result;
+
+    const published = await atomicCreateJson(receiptPath(input.clientRequestId), {
+      fingerprint,
+      path: result.path,
+      ownerScope,
+      createdAt: new Date().toISOString(),
+    } satisfies FolderRequestReceipt);
+    if (published) return result;
+    const receipt = await readReceipt(input.clientRequestId);
+    if (receipt?.fingerprint === fingerprint && receipt.path === result.path) {
+      return { ok: true, status: 200, path: receipt.path };
+    }
+    const createdTarget = resolveWithinHome(homePath, result.path);
+    if (createdTarget) await rm(createdTarget, { recursive: true, force: true });
+    return failure(409, "request_conflict", "Folder request conflicts with an earlier request");
+  }
+
+  return {
+    async createFolder(input: CreateFolderInput): Promise<Result<{ path: string }> | Failure> {
+      if (!input.clientRequestId || !ClientRequestIdSchema.safeParse(input.clientRequestId).success) {
+        return createFolderUnlocked(input);
+      }
+      // Receipt expiry is a read/remove/replace sequence. Serialize it by
+      // request ID so a delayed cleanup cannot unlink a newer receipt written
+      // by an overlapping retry in this gateway process.
+      return withProjectLock(
+        `folder-request:${homePath}:${input.clientRequestId}`,
+        () => createFolderUnlocked(input),
+      );
     },
   };
 }

--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -5,7 +5,7 @@ import { access, lstat, mkdir, readdir, realpath, rename, rm } from "node:fs/pro
 import { join, relative, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import { z } from "zod/v4";
-import { atomicWriteJson, readJsonFile, withProjectLock, type OwnerScope } from "./state-ops.js";
+import { atomicCreateJson, atomicWriteJson, readJsonFile, withProjectLock, type OwnerScope } from "./state-ops.js";
 import { containsDeniedFileApiPath, resolveExistingFileApiPath } from "./path-security.js";
 
 export const PROJECT_SLUG_REGEX = /^[a-z0-9][a-z0-9-]{0,62}$/;
@@ -340,18 +340,6 @@ export function createProjectManager(options: {
         const ownerScope = input.ownerScope ?? { type: "user" as const, id: "local" };
         const fingerprint = createRequestFingerprint({ mode, slug, name, localPath: realLocalPath, ownerScope });
         return withProjectLock(slug, async () => {
-          if (await pathExists(metadataPath)) {
-            const existing = await readProjectConfig(homePath, slug);
-            const idempotentProject = isIdempotentProjectRetry({
-              existing,
-              clientRequestId: input.clientRequestId,
-              fingerprint,
-            });
-            if (idempotentProject) {
-              return { ok: true, status: 200, project: idempotentProject };
-            }
-            return genericError(409, "slug_conflict", "Project slug already exists");
-          }
           await mkdir(metadataPath, { recursive: true });
           const timestamp = nowIso(options.now);
           const project: ProjectConfig = {
@@ -369,7 +357,19 @@ export function createProjectManager(options: {
             createRequestId: input.clientRequestId,
             createRequestFingerprint: input.clientRequestId ? fingerprint : undefined,
           };
-          await atomicWriteJson(join(metadataPath, "config.json"), project);
+          const created = await atomicCreateJson(join(metadataPath, "config.json"), project);
+          if (!created) {
+            const existing = await readProjectConfig(homePath, slug);
+            const idempotentProject = isIdempotentProjectRetry({
+              existing,
+              clientRequestId: input.clientRequestId,
+              fingerprint,
+            });
+            if (idempotentProject) {
+              return { ok: true, status: 200, project: idempotentProject };
+            }
+            return genericError(409, "slug_conflict", "Project slug already exists");
+          }
           return { ok: true, status: 201, project };
         });
       }

--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -102,6 +102,7 @@ function createRequestFingerprint(input: {
   mode: CreateProjectMode;
   slug: string;
   name?: string;
+  localPath?: string;
   repositoryUrl?: string;
   branch?: string;
   ownerScope: OwnerScope;
@@ -336,8 +337,19 @@ export function createProjectManager(options: {
           }
         }
         const metadataPath = projectPath(homePath, slug);
+        const ownerScope = input.ownerScope ?? { type: "user" as const, id: "local" };
+        const fingerprint = createRequestFingerprint({ mode, slug, name, localPath: realLocalPath, ownerScope });
         return withProjectLock(slug, async () => {
           if (await pathExists(metadataPath)) {
+            const existing = await readProjectConfig(homePath, slug);
+            const idempotentProject = isIdempotentProjectRetry({
+              existing,
+              clientRequestId: input.clientRequestId,
+              fingerprint,
+            });
+            if (idempotentProject) {
+              return { ok: true, status: 200, project: idempotentProject };
+            }
             return genericError(409, "slug_conflict", "Project slug already exists");
           }
           await mkdir(metadataPath, { recursive: true });
@@ -353,7 +365,9 @@ export function createProjectManager(options: {
             localPath: realLocalPath,
             addedAt: timestamp,
             updatedAt: timestamp,
-            ownerScope: input.ownerScope ?? { type: "user", id: "local" },
+            ownerScope,
+            createRequestId: input.clientRequestId,
+            createRequestFingerprint: input.clientRequestId ? fingerprint : undefined,
           };
           await atomicWriteJson(join(metadataPath, "config.json"), project);
           return { ok: true, status: 201, project };

--- a/packages/gateway/src/state-ops.ts
+++ b/packages/gateway/src/state-ops.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
-import { access, mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { access, link, mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { resolveWithinHome } from "./path-security.js";
 
@@ -68,6 +68,26 @@ export async function atomicWriteJson(path: string, value: unknown): Promise<voi
   const tmpPath = join(dirname(path), `.${randomUUID()}.tmp`);
   await writeFile(tmpPath, `${JSON.stringify(value, null, 2)}\n`, { flag: "wx" });
   await rename(tmpPath, path);
+}
+
+// Publish a fully written JSON file without replacing an existing file. The
+// hard-link is atomic on the same filesystem, so concurrent writers either
+// publish one complete value or observe EEXIST and reconcile with the winner.
+export async function atomicCreateJson(path: string, value: unknown): Promise<boolean> {
+  await mkdir(dirname(path), { recursive: true });
+  const tmpPath = join(dirname(path), `.${randomUUID()}.tmp`);
+  await writeFile(tmpPath, `${JSON.stringify(value, null, 2)}\n`, { flag: "wx" });
+  try {
+    await link(tmpPath, path);
+    return true;
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "EEXIST") {
+      return false;
+    }
+    throw err;
+  } finally {
+    await rm(tmpPath, { force: true });
+  }
 }
 
 export async function readJsonFile<T = unknown>(path: string): Promise<T> {

--- a/packages/gateway/src/workspace-routes.ts
+++ b/packages/gateway/src/workspace-routes.ts
@@ -47,6 +47,7 @@ const CreateProjectSchema = z.object({
   name: z.string().trim().min(1).max(128).optional(),
   path: z.string().min(1).max(4096).optional(),
   branch: GitBranchSchema.optional(),
+  clientRequestId: z.string().min(5).max(132).regex(/^req_[A-Za-z0-9_-]+$/).optional(),
   mode: z.enum(["scratch", "github", "folder"]).optional(),
   ownerScope: z.object({
     type: z.enum(["user", "org"]),
@@ -332,6 +333,7 @@ export function createWorkspaceRoutes(options: {
       name: body.value.name,
       path: body.value.path,
       branch: body.value.branch,
+      clientRequestId: body.value.clientRequestId,
       mode: body.value.mode ?? (body.value.url ? "github" : "scratch"),
       ownerScope,
     });

--- a/packages/gateway/src/workspace-routes.ts
+++ b/packages/gateway/src/workspace-routes.ts
@@ -94,6 +94,7 @@ const CloneProjectSchema = z.object({
 const MkdirFolderSchema = z.object({
   name: z.string().trim().regex(PROJECT_SLUG_REGEX),
   parent: z.string().trim().min(1).max(1024).optional(),
+  clientRequestId: z.string().min(5).max(132).regex(/^req_[A-Za-z0-9_-]+$/).optional(),
 });
 
 const CreateWorktreeSchema = z.object({
@@ -338,7 +339,7 @@ export function createWorkspaceRoutes(options: {
       ownerScope,
     });
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
-    return c.json({ project: result.project }, 201);
+    return c.json({ project: result.project }, status(result.status ?? 201));
   });
 
   // Purpose-specific add-project endpoints used by the desktop dialog. Both
@@ -368,17 +369,20 @@ export function createWorkspaceRoutes(options: {
   app.post("/api/projects/mkdir", limited, async (c) => {
     const body = await parseJson(c, MkdirFolderSchema);
     if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
+    let ownerScope: OwnerScope;
     try {
-      getOwnerScope(c);
+      ownerScope = getOwnerScope(c);
     } catch (err: unknown) {
       return principalError(c, err);
     }
     const result = await projectFolders.createFolder({
       name: body.value.name,
       parent: body.value.parent,
+      clientRequestId: body.value.clientRequestId,
+      ownerScope,
     });
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
-    return c.json({ path: result.path }, 201);
+    return c.json({ path: result.path }, status(result.status ?? 201));
   });
 
   app.get("/api/workspace/projects", async (c) => {

--- a/tests/desktop/add-project-dialog.test.tsx
+++ b/tests/desktop/add-project-dialog.test.tsx
@@ -364,9 +364,16 @@ describe("CreateProjectDialog add-project flows", () => {
         }
         return { entries: [] };
       });
-      const post = vi.fn(async (requestPath: string, body: unknown) => {
+      let mkdirAttempts = 0;
+      const post = vi.fn(async (requestPath: string, body: unknown, _options?: unknown) => {
         if (requestPath === "/api/projects/mkdir") {
-          expect(body).toEqual({ name: "side-project", parent: "code" });
+          expect(body).toEqual({
+            name: "side-project",
+            parent: "code",
+            clientRequestId: expect.stringMatching(/^req_[A-Za-z0-9_-]+$/),
+          });
+          mkdirAttempts += 1;
+          if (mkdirAttempts === 1) throw new AppError("timeout");
           return { path: "code/side-project" };
         }
         throw new Error(`unexpected POST ${requestPath}`);
@@ -390,7 +397,15 @@ describe("CreateProjectDialog add-project flows", () => {
 
       fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
-      await waitFor(() => expect(post).toHaveBeenCalledWith("/api/projects/mkdir", { name: "side-project", parent: "code" }));
+      await waitFor(() => expect(post).toHaveBeenCalledWith(
+        "/api/projects/mkdir",
+        expect.objectContaining({ name: "side-project", parent: "code" }),
+        { timeoutMs: 30_000 },
+      ));
+      const mkdirCalls = post.mock.calls.filter(([path]) => path === "/api/projects/mkdir");
+      expect(mkdirCalls).toHaveLength(2);
+      expect(mkdirCalls[1]?.[1]).toEqual(mkdirCalls[0]?.[1]);
+      expect(mkdirCalls[1]?.[2]).toEqual({ timeoutMs: 310_000 });
       await waitFor(() => expect(createProject).toHaveBeenCalledWith(expect.anything(), {
         name: "Side Project",
         mode: "folder",

--- a/tests/desktop/board-store.test.ts
+++ b/tests/desktop/board-store.test.ts
@@ -118,16 +118,48 @@ describe("createProject", () => {
     const api = makeApi({ post, get });
 
     const project = await useBoard.getState().createProject(api, { name: "My App", mode: "scratch" });
-    expect(post).toHaveBeenCalledWith("/api/projects", { name: "My App", mode: "scratch" });
+    expect(post).toHaveBeenCalledWith("/api/projects", {
+      name: "My App",
+      mode: "scratch",
+      clientRequestId: expect.stringMatching(/^req_[A-Za-z0-9_-]+$/),
+    }, { timeoutMs: 30_000 });
     expect(project).toEqual({ slug: "my-app", name: "My App" });
     expect(useBoard.getState().projects).toEqual([{ slug: "my-app", name: "My App" }]);
+  });
+
+  it("recovers a timed-out project create with one idempotent retry", async () => {
+    const createdResponse = { project: { slug: "my-app", name: "My App" } };
+    const post = vi.fn()
+      .mockRejectedValueOnce(new AppError("timeout"))
+      .mockResolvedValueOnce(createdResponse);
+    const get = vi.fn().mockResolvedValue({ projects: [createdResponse.project] });
+    const api = makeApi({ post, get });
+
+    const project = await useBoard.getState().createProject(api, { name: "My App", mode: "scratch" });
+
+    expect(project).toEqual({ slug: "my-app", name: "My App" });
+    expect(post).toHaveBeenCalledTimes(2);
+    const firstBody = post.mock.calls[0]?.[1];
+    const retryBody = post.mock.calls[1]?.[1];
+    expect(firstBody).toMatchObject({
+      name: "My App",
+      mode: "scratch",
+      clientRequestId: expect.stringMatching(/^req_[A-Za-z0-9_-]+$/),
+    });
+    expect(retryBody).toEqual(firstBody);
+    expect(useBoard.getState().error).toBeNull();
   });
 
   it("sends the url for a github project", async () => {
     const post = vi.fn().mockResolvedValue({ project: { slug: "repo", name: "repo" } });
     const api = makeApi({ post, get: vi.fn().mockResolvedValue({ projects: [] }) });
     await useBoard.getState().createProject(api, { name: "repo", mode: "github", url: "https://github.com/o/repo" });
-    expect(post).toHaveBeenCalledWith("/api/projects", { name: "repo", mode: "github", url: "https://github.com/o/repo" });
+    expect(post).toHaveBeenCalledWith("/api/projects", {
+      name: "repo",
+      mode: "github",
+      url: "https://github.com/o/repo",
+      clientRequestId: expect.stringMatching(/^req_[A-Za-z0-9_-]+$/),
+    }, { timeoutMs: 30_000 });
   });
 
   it("connects a project to an existing computer folder", async () => {
@@ -146,7 +178,8 @@ describe("createProject", () => {
       name: "App",
       mode: "folder",
       path: "workspaces/app",
-    });
+      clientRequestId: expect.stringMatching(/^req_[A-Za-z0-9_-]+$/),
+    }, { timeoutMs: 30_000 });
   });
 
   it("preserves the refresh error when creation succeeds but the project list reload fails", async () => {

--- a/tests/desktop/board-store.test.ts
+++ b/tests/desktop/board-store.test.ts
@@ -147,6 +147,8 @@ describe("createProject", () => {
       clientRequestId: expect.stringMatching(/^req_[A-Za-z0-9_-]+$/),
     });
     expect(retryBody).toEqual(firstBody);
+    expect(post.mock.calls[0]?.[2]).toEqual({ timeoutMs: 30_000 });
+    expect(post.mock.calls[1]?.[2]).toEqual({ timeoutMs: 310_000 });
     expect(useBoard.getState().error).toBeNull();
   });
 

--- a/tests/desktop/create-project-dialog.test.tsx
+++ b/tests/desktop/create-project-dialog.test.tsx
@@ -5,6 +5,7 @@ import * as Tooltip from "@radix-ui/react-tooltip";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import CreateProjectDialog from "../../desktop/src/renderer/src/features/board/CreateProjectDialog";
+import { AppError } from "../../desktop/src/renderer/src/lib/errors";
 import type { Project } from "../../desktop/src/renderer/src/stores/board";
 import { useBoard } from "../../desktop/src/renderer/src/stores/board";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
@@ -110,6 +111,277 @@ describe("CreateProjectDialog", () => {
       mode: "folder",
       path: "workspaces/customer-app",
     }));
+  });
+
+  it("opens a project when the selected folder is already connected", async () => {
+    const existingProject = {
+      slug: "matrix-os",
+      name: "Matrix OS",
+      localPath: "/home/matrix/home/apps/matrix-os",
+      githubBacked: false,
+    };
+    const get = vi.fn(async (requestPath: string) => {
+      if (requestPath === "/api/files/list?path=") {
+        return { entries: [{ name: "apps", type: "directory" }] };
+      }
+      if (requestPath === "/api/files/list?path=apps") {
+        return { entries: [{ name: "matrix-os", type: "directory" }] };
+      }
+      return { entries: [] };
+    });
+    const createProject = vi.fn(async () => null);
+    const selectProject = vi.fn(async () => undefined);
+    const openTab = vi.fn();
+    const onClose = vi.fn();
+    useConnection.setState({ api: { post: vi.fn(), get, baseUrl: "https://gateway.test" } as never });
+    useBoard.setState({ projects: [existingProject], createProject, selectProject });
+    useTabs.setState({ openTab });
+
+    render(<Tooltip.Provider><CreateProjectDialog open onClose={onClose} /></Tooltip.Provider>);
+    fireEvent.click(screen.getByRole("button", { name: /Existing folder/ }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open apps" })).not.toBeNull());
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Open apps" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open matrix-os" })).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Open matrix-os" }));
+    fireEvent.click(screen.getByRole("button", { name: "Choose matrix-os" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(selectProject).toHaveBeenCalledWith(expect.anything(), "matrix-os"));
+    expect(createProject).not.toHaveBeenCalled();
+    expect(openTab).toHaveBeenCalledWith({
+      kind: "project",
+      projectSlug: "matrix-os",
+      title: "Matrix OS",
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("opens the existing project instead of connecting its Matrix-managed registry folder", async () => {
+    const existingProject = {
+      slug: "matrix-os",
+      name: "Matrix OS",
+      localPath: "/home/matrix/home/apps/matrix-os",
+      githubBacked: false,
+    };
+    const get = vi.fn(async (requestPath: string) => {
+      if (requestPath === "/api/files/list?path=") {
+        return { entries: [{ name: "projects", type: "directory" }] };
+      }
+      if (requestPath === "/api/files/list?path=projects") {
+        return { entries: [{ name: "matrix-os", type: "directory" }] };
+      }
+      return { entries: [] };
+    });
+    const createProject = vi.fn(async () => null);
+    const selectProject = vi.fn(async () => undefined);
+    const openTab = vi.fn();
+    const onClose = vi.fn();
+    useConnection.setState({ api: { post: vi.fn(), get, baseUrl: "https://gateway.test" } as never });
+    useBoard.setState({ projects: [existingProject], createProject, selectProject });
+    useTabs.setState({ openTab });
+
+    render(<Tooltip.Provider><CreateProjectDialog open onClose={onClose} /></Tooltip.Provider>);
+    fireEvent.click(screen.getByRole("button", { name: /Existing folder/ }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open projects" })).not.toBeNull());
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Open projects" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open matrix-os" })).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Open matrix-os" }));
+
+    expect(screen.getByText("This folder contains Matrix project data, not a workspace.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Open Matrix OS" }));
+
+    await waitFor(() => expect(selectProject).toHaveBeenCalledWith(expect.anything(), "matrix-os"));
+    expect(createProject).not.toHaveBeenCalled();
+    expect(openTab).toHaveBeenCalledWith({
+      kind: "project",
+      projectSlug: "matrix-os",
+      title: "Matrix OS",
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("blocks Matrix registry metadata folders while keeping repo workspaces selectable", async () => {
+    const get = vi.fn(async (requestPath: string) => {
+      if (requestPath === "/api/files/list?path=") {
+        return { entries: [{ name: "projects", type: "directory" }] };
+      }
+      if (requestPath === "/api/files/list?path=projects") {
+        return { entries: [{ name: "unregistered", type: "directory" }] };
+      }
+      if (requestPath === "/api/files/list?path=projects%2Funregistered") {
+        return {
+          entries: [
+            { name: "repo", type: "directory" },
+            { name: "worktrees", type: "directory" },
+          ],
+        };
+      }
+      return { entries: [] };
+    });
+    useConnection.setState({ api: { post: vi.fn(), get, baseUrl: "https://gateway.test" } as never });
+    useBoard.setState({ projects: [] });
+
+    render(<Tooltip.Provider><CreateProjectDialog open onClose={vi.fn()} /></Tooltip.Provider>);
+    fireEvent.click(screen.getByRole("button", { name: /Existing folder/ }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open projects" })).not.toBeNull());
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Open projects" }));
+    const registryFolder = await screen.findByRole("button", { name: "Open unregistered" });
+    fireEvent.click(registryFolder);
+
+    expect(screen.getByText("This folder is managed by Matrix and can't be used as a workspace.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Choose unregistered" }).hasAttribute("disabled")).toBe(true);
+
+    fireEvent.doubleClick(registryFolder);
+    const worktrees = await screen.findByRole("button", { name: "Open worktrees" });
+    fireEvent.click(worktrees);
+    expect(screen.getByRole("button", { name: "Choose worktrees" }).hasAttribute("disabled")).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open repo" }));
+    expect(screen.queryByText("This folder is managed by Matrix and can't be used as a workspace.")).toBeNull();
+    expect(screen.getByRole("button", { name: "Choose repo" }).hasAttribute("disabled")).toBe(false);
+  });
+
+  it("opens an existing project when its selected repo workspace has a different folder name", async () => {
+    const existingProject = {
+      slug: "scratch-project",
+      name: "Scratch Project",
+      localPath: "/home/matrix/home/projects/scratch-project/repo",
+      githubBacked: true,
+    };
+    const get = vi.fn(async (requestPath: string) => {
+      if (requestPath === "/api/files/list?path=") {
+        return { entries: [{ name: "projects", type: "directory" }] };
+      }
+      if (requestPath === "/api/files/list?path=projects") {
+        return { entries: [{ name: "scratch-project", type: "directory" }] };
+      }
+      if (requestPath === "/api/files/list?path=projects%2Fscratch-project") {
+        return { entries: [{ name: "repo", type: "directory" }] };
+      }
+      return { entries: [] };
+    });
+    const createProject = vi.fn(async () => null);
+    const selectProject = vi.fn(async () => undefined);
+    const openTab = vi.fn();
+    const onClose = vi.fn();
+    useConnection.setState({ api: { post: vi.fn(), get, baseUrl: "https://gateway.test" } as never });
+    useBoard.setState({ projects: [existingProject], createProject, selectProject });
+    useTabs.setState({ openTab });
+
+    render(<Tooltip.Provider><CreateProjectDialog open onClose={onClose} /></Tooltip.Provider>);
+    fireEvent.click(screen.getByRole("button", { name: /Existing folder/ }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open projects" })).not.toBeNull());
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Open projects" }));
+    const registryFolder = await screen.findByRole("button", { name: "Open scratch-project" });
+    fireEvent.doubleClick(registryFolder);
+    const repo = await screen.findByRole("button", { name: "Open repo" });
+    fireEvent.click(repo);
+    fireEvent.click(screen.getByRole("button", { name: "Choose repo" }));
+    expect(screen.getByPlaceholderText("Project name")).toHaveProperty("value", "repo");
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(selectProject).toHaveBeenCalledWith(expect.anything(), "scratch-project"));
+    expect(createProject).not.toHaveBeenCalled();
+    expect(openTab).toHaveBeenCalledWith({
+      kind: "project",
+      projectSlug: "scratch-project",
+      title: "Scratch Project",
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("recovers an already-connected folder after a create conflict", async () => {
+    const existingProject = {
+      slug: "matrix-os",
+      name: "Matrix OS",
+      localPath: "/home/matrix/home/apps/matrix-os",
+    };
+    const post = vi.fn(async (requestPath: string) => {
+      if (requestPath === "/api/projects") {
+        throw new AppError("server", { detail: "slug_conflict" });
+      }
+      throw new Error(`unexpected POST ${requestPath}`);
+    });
+    const get = vi.fn(async (requestPath: string) => {
+      if (requestPath === "/api/files/list?path=") {
+        return { entries: [{ name: "apps", type: "directory" }] };
+      }
+      if (requestPath === "/api/files/list?path=apps") {
+        return { entries: [{ name: "matrix-os", type: "directory" }] };
+      }
+      if (requestPath === "/api/workspace/projects") {
+        return { projects: [existingProject] };
+      }
+      return { entries: [] };
+    });
+    const selectProject = vi.fn(async () => undefined);
+    const openTab = vi.fn();
+    const onClose = vi.fn();
+    useBoard.setState(useBoard.getInitialState(), true);
+    useBoard.setState({ selectProject });
+    useConnection.setState({ api: { post, get, baseUrl: "https://gateway.test" } as never });
+    useTabs.setState({ openTab });
+
+    render(<Tooltip.Provider><CreateProjectDialog open onClose={onClose} /></Tooltip.Provider>);
+    fireEvent.click(screen.getByRole("button", { name: /Existing folder/ }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open apps" })).not.toBeNull());
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Open apps" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open matrix-os" })).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Open matrix-os" }));
+    fireEvent.click(screen.getByRole("button", { name: "Choose matrix-os" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(selectProject).toHaveBeenCalledWith(expect.anything(), "matrix-os"));
+    expect(post).toHaveBeenCalledWith(
+      "/api/projects",
+      expect.objectContaining({ name: "matrix-os", mode: "folder", path: "apps/matrix-os" }),
+      { timeoutMs: 30_000 },
+    );
+    expect(openTab).toHaveBeenCalledWith({
+      kind: "project",
+      projectSlug: "matrix-os",
+      title: "Matrix OS",
+    });
+    expect(onClose).toHaveBeenCalled();
+    expect(screen.queryByText(/Check that it exists on this computer/)).toBeNull();
+  });
+
+  it("asks for another name when the project slug belongs to a different folder", async () => {
+    const existingProject = {
+      slug: "matrix-os",
+      name: "Matrix OS",
+      localPath: "/home/matrix/home/apps/matrix-os",
+      githubBacked: false,
+    };
+    const get = vi.fn(async (requestPath: string) => {
+      if (requestPath === "/api/files/list?path=") {
+        return { entries: [{ name: "apps", type: "directory" }] };
+      }
+      if (requestPath === "/api/files/list?path=apps") {
+        return { entries: [{ name: "other-app", type: "directory" }] };
+      }
+      return { entries: [] };
+    });
+    const createProject = vi.fn(async () => null);
+    const selectProject = vi.fn(async () => undefined);
+    useConnection.setState({ api: { post: vi.fn(), get, baseUrl: "https://gateway.test" } as never });
+    useBoard.setState({ projects: [existingProject], createProject, selectProject });
+
+    render(<Tooltip.Provider><CreateProjectDialog open onClose={vi.fn()} /></Tooltip.Provider>);
+    fireEvent.click(screen.getByRole("button", { name: /Existing folder/ }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open apps" })).not.toBeNull());
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Open apps" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open other-app" })).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Open other-app" }));
+    fireEvent.click(screen.getByRole("button", { name: "Choose other-app" }));
+    fireEvent.change(screen.getByPlaceholderText("Project name"), { target: { value: "Matrix OS" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(screen.getByText(
+      "A project named “Matrix OS” already exists. Choose another name.",
+    )).toBeTruthy());
+    expect(createProject).not.toHaveBeenCalled();
+    expect(selectProject).not.toHaveBeenCalled();
   });
 
   it("opens the created project in a project tab", async () => {

--- a/tests/desktop/project-task-chat-flow.test.ts
+++ b/tests/desktop/project-task-chat-flow.test.ts
@@ -72,7 +72,15 @@ describe("project to task to chat flow", () => {
 
     const project = await useBoard.getState().createProject(api, { name: "Desktop", mode: "scratch" });
     const task = await useBoard.getState().createTask(api, project!.slug, { title: "Build chat" });
-    expect(api.post).toHaveBeenCalledWith("/api/projects", { name: "Desktop", mode: "scratch" });
+    expect(api.post).toHaveBeenCalledWith(
+      "/api/projects",
+      {
+        name: "Desktop",
+        mode: "scratch",
+        clientRequestId: expect.stringMatching(/^req_desktop_project_[A-Za-z0-9-]+$/),
+      },
+      { timeoutMs: 30_000 },
+    );
     expect(api.post).toHaveBeenCalledWith("/api/projects/desktop/tasks", { title: "Build chat" });
 
     const runtimeSummary = summary();

--- a/tests/gateway/project-clone-mkdir.test.ts
+++ b/tests/gateway/project-clone-mkdir.test.ts
@@ -249,6 +249,25 @@ describe("project clone and mkdir routes", () => {
       }));
     });
 
+    it("preserves the manager status for an idempotent replay", async () => {
+      const projectManager = makeProjectManager({
+        createProject: vi.fn(async () => ({
+          ok: true as const,
+          status: 200,
+          project: { id: "proj_1", name: "My App", slug: "my-app", localPath: "/x", addedAt: "", updatedAt: "" },
+        })),
+      });
+      const app = createWorkspaceRoutes({ homePath, projectManager });
+
+      const res = await app.request(jsonRequest("/api/projects", {
+        mode: "scratch",
+        name: "My App",
+        clientRequestId: "req_desktop_project_123",
+      }));
+
+      expect(res.status).toBe(200);
+    });
+
     it("passes an optional branch to the project manager", async () => {
       const projectManager = makeProjectManager();
       const app = createWorkspaceRoutes({ homePath, projectManager });
@@ -403,6 +422,46 @@ describe("project clone and mkdir routes", () => {
       await expect(res.json()).resolves.toEqual({ path: "code/side-project" });
       const created = await stat(join(homePath, "code", "side-project"));
       expect(created.isDirectory()).toBe(true);
+    });
+
+    it("returns the same custom folder for an idempotent mkdir retry", async () => {
+      await mkdir(join(homePath, "code"), { recursive: true });
+      const app = createWorkspaceRoutes({ homePath });
+      const request = {
+        name: "side-project",
+        parent: "code",
+        clientRequestId: "req_desktop_folder_123",
+      };
+
+      const first = await app.request(jsonRequest("/api/projects/mkdir", request));
+      const retry = await app.request(jsonRequest("/api/projects/mkdir", request));
+
+      expect(first.status).toBe(201);
+      expect(retry.status).toBe(200);
+      await expect(retry.json()).resolves.toEqual({ path: "code/side-project" });
+    });
+
+    it("reconciles overlapping idempotent mkdir requests", async () => {
+      await mkdir(join(homePath, "code"), { recursive: true });
+      const firstManager = createProjectFolders({ homePath });
+      const secondManager = createProjectFolders({ homePath });
+      const request = {
+        name: "side-project",
+        parent: "code",
+        clientRequestId: "req_desktop_folder_overlap",
+        ownerScope: { type: "user" as const, id: "user_123" },
+      };
+
+      const [first, second] = await Promise.all([
+        firstManager.createFolder(request),
+        secondManager.createFolder(request),
+      ]);
+
+      expect(first.ok).toBe(true);
+      expect(second.ok).toBe(true);
+      if (!first.ok || !second.ok) throw new Error("expected idempotent folder creation");
+      expect(first.path).toBe("code/side-project");
+      expect(second.path).toBe(first.path);
     });
 
     it("allows a safe child beside a denied subtree", async () => {

--- a/tests/gateway/project-clone-mkdir.test.ts
+++ b/tests/gateway/project-clone-mkdir.test.ts
@@ -233,6 +233,22 @@ describe("project clone and mkdir routes", () => {
   });
 
   describe("POST /api/projects branch passthrough", () => {
+    it("passes the idempotency key to the project manager", async () => {
+      const projectManager = makeProjectManager();
+      const app = createWorkspaceRoutes({ homePath, projectManager });
+
+      const res = await app.request(jsonRequest("/api/projects", {
+        mode: "scratch",
+        name: "My App",
+        clientRequestId: "req_desktop_project_123",
+      }));
+
+      expect(res.status).toBe(201);
+      expect(projectManager.createProject).toHaveBeenCalledWith(expect.objectContaining({
+        clientRequestId: "req_desktop_project_123",
+      }));
+    });
+
     it("passes an optional branch to the project manager", async () => {
       const projectManager = makeProjectManager();
       const app = createWorkspaceRoutes({ homePath, projectManager });
@@ -324,6 +340,30 @@ describe("project clone and mkdir routes", () => {
         error: { code: "invalid_branch", message: "Branch name is invalid" },
       });
       expect(runCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("folder project idempotency", () => {
+    it("returns the original project when the same create request is retried", async () => {
+      await mkdir(join(homePath, "workspaces", "my-app"), { recursive: true });
+      const manager = createProjectManager({ homePath });
+      const input = {
+        mode: "folder" as const,
+        name: "My App",
+        path: "workspaces/my-app",
+        clientRequestId: "req_desktop_project_123",
+      };
+
+      const first = await manager.createProject(input);
+      const retry = await manager.createProject(input);
+
+      expect(first.ok).toBe(true);
+      expect(retry.ok).toBe(true);
+      if (!first.ok || !retry.ok) throw new Error("expected idempotent project creation");
+      expect(first.status).toBe(201);
+      expect(retry.status).toBe(200);
+      expect(retry.project.id).toBe(first.project.id);
+      expect(retry.project.slug).toBe("my-app");
     });
   });
 

--- a/tests/gateway/project-clone-mkdir.test.ts
+++ b/tests/gateway/project-clone-mkdir.test.ts
@@ -447,6 +447,39 @@ describe("project clone and mkdir routes", () => {
       expect(created.isDirectory()).toBe(true);
     });
 
+    it("connects a custom-parent folder returned by mkdir as a project", async () => {
+      await mkdir(join(homePath, "apps"), { recursive: true });
+      // A legacy/unmanaged directory may already occupy the registry slug.
+      // Folder binding should publish config.json into that slot instead of
+      // reporting a false slug conflict after mkdir has already succeeded.
+      await mkdir(join(homePath, "projects", "matrix-os", "symphony-workspaces"), { recursive: true });
+      const app = createWorkspaceRoutes({ homePath });
+
+      const mkdirResponse = await app.request(jsonRequest("/api/projects/mkdir", {
+        name: "matrix-os",
+        parent: "apps",
+        clientRequestId: "req_desktop_folder_connect",
+      }));
+      expect(mkdirResponse.status).toBe(201);
+      const folder = await mkdirResponse.json() as { path: string };
+
+      const connectResponse = await app.request(jsonRequest("/api/projects", {
+        name: "matrix-os",
+        mode: "folder",
+        path: folder.path,
+        clientRequestId: "req_desktop_project_connect",
+      }));
+
+      expect(connectResponse.status).toBe(201);
+      await expect(connectResponse.json()).resolves.toMatchObject({
+        project: {
+          name: "matrix-os",
+          localPath: expect.stringMatching(/[/\\]apps[/\\]matrix-os$/),
+        },
+      });
+      await expect(stat(join(homePath, "projects", "matrix-os", "config.json"))).resolves.toBeTruthy();
+    });
+
     it("returns the same custom folder for an idempotent mkdir retry", async () => {
       await mkdir(join(homePath, "code"), { recursive: true });
       const app = createWorkspaceRoutes({ homePath });

--- a/tests/gateway/project-clone-mkdir.test.ts
+++ b/tests/gateway/project-clone-mkdir.test.ts
@@ -441,6 +441,36 @@ describe("project clone and mkdir routes", () => {
       await expect(retry.json()).resolves.toEqual({ path: "code/side-project" });
     });
 
+    it("does not let an expired mkdir receipt conflict with a new payload", async () => {
+      await mkdir(join(homePath, "code"), { recursive: true });
+      const manager = createProjectFolders({ homePath });
+      const clientRequestId = "req_desktop_folder_expired";
+      const ownerScope = { type: "user" as const, id: "user_123" };
+
+      const first = await manager.createFolder({
+        name: "old-project",
+        parent: "code",
+        clientRequestId,
+        ownerScope,
+      });
+      expect(first.ok).toBe(true);
+
+      const receiptPath = join(homePath, "system", "project-folder-requests", `${clientRequestId}.json`);
+      const receipt = JSON.parse(await readFile(receiptPath, "utf8")) as Record<string, unknown>;
+      await writeFile(receiptPath, JSON.stringify({ ...receipt, createdAt: "2020-01-01T00:00:00.000Z" }));
+
+      const next = await manager.createFolder({
+        name: "new-project",
+        parent: "code",
+        clientRequestId,
+        ownerScope,
+      });
+
+      expect(next).toMatchObject({ ok: true, status: 201, path: "code/new-project" });
+      const created = await stat(join(homePath, "code", "new-project"));
+      expect(created.isDirectory()).toBe(true);
+    });
+
     it("reconciles overlapping idempotent mkdir requests", async () => {
       await mkdir(join(homePath, "code"), { recursive: true });
       const firstManager = createProjectFolders({ homePath });

--- a/tests/gateway/project-clone-mkdir.test.ts
+++ b/tests/gateway/project-clone-mkdir.test.ts
@@ -7,6 +7,29 @@ import { createWorkspaceRoutes } from "../../packages/gateway/src/workspace-rout
 import { createProjectManager } from "../../packages/gateway/src/project-manager.js";
 import { createProjectFolders } from "../../packages/gateway/src/project-folders.js";
 
+const receiptRemovalRace = vi.hoisted(() => ({
+  enabled: false,
+  active: 0,
+  maxActive: 0,
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    rm: async (...args: unknown[]) => {
+      const path = String(args[0]);
+      if (receiptRemovalRace.enabled && path.endsWith("req_desktop_folder_expired_overlap.json")) {
+        receiptRemovalRace.active += 1;
+        receiptRemovalRace.maxActive = Math.max(receiptRemovalRace.maxActive, receiptRemovalRace.active);
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        receiptRemovalRace.active -= 1;
+      }
+      return (actual.rm as (...rmArgs: unknown[]) => Promise<void>)(...args);
+    },
+  };
+});
+
 function jsonRequest(path: string, body: unknown): Request {
   const requestBody = path === "/api/projects/clone"
     && typeof body === "object"
@@ -469,6 +492,43 @@ describe("project clone and mkdir routes", () => {
       expect(next).toMatchObject({ ok: true, status: 201, path: "code/new-project" });
       const created = await stat(join(homePath, "code", "new-project"));
       expect(created.isDirectory()).toBe(true);
+    });
+
+    it("preserves the replacement receipt when expired mkdir retries overlap", async () => {
+      await mkdir(join(homePath, "code"), { recursive: true });
+      const clientRequestId = "req_desktop_folder_expired_overlap";
+      const ownerScope = { type: "user" as const, id: "user_123" };
+      const seedManager = createProjectFolders({ homePath });
+      await seedManager.createFolder({
+        name: "old-project",
+        parent: "code",
+        clientRequestId,
+        ownerScope,
+      });
+
+      const receiptPath = join(homePath, "system", "project-folder-requests", `${clientRequestId}.json`);
+      const receipt = JSON.parse(await readFile(receiptPath, "utf8")) as Record<string, unknown>;
+      await writeFile(receiptPath, JSON.stringify({ ...receipt, createdAt: "2020-01-01T00:00:00.000Z" }));
+      const request = {
+        name: "new-project",
+        parent: "code",
+        clientRequestId,
+        ownerScope,
+      };
+
+      receiptRemovalRace.enabled = true;
+      receiptRemovalRace.active = 0;
+      receiptRemovalRace.maxActive = 0;
+      const overlapping = await Promise.all([
+        createProjectFolders({ homePath }).createFolder(request),
+        createProjectFolders({ homePath }).createFolder(request),
+      ]);
+      receiptRemovalRace.enabled = false;
+      expect(receiptRemovalRace.maxActive).toBe(1);
+      expect(overlapping.every((result) => result.ok)).toBe(true);
+
+      const retry = await createProjectFolders({ homePath }).createFolder(request);
+      expect(retry).toMatchObject({ ok: true, status: 200, path: "code/new-project" });
     });
 
     it("reconciles overlapping idempotent mkdir requests", async () => {

--- a/tests/gateway/project-manager.test.ts
+++ b/tests/gateway/project-manager.test.ts
@@ -117,6 +117,29 @@ describe("project-manager", () => {
     expect(changedPayload).toMatchObject({ ok: false, status: 409 });
   });
 
+  it("publishes folder project config exclusively across manager instances", async () => {
+    await mkdir(join(homePath, "workspaces", "shared"), { recursive: true });
+    const firstManager = createProjectManager({ homePath, runCommand: vi.fn() });
+    const secondManager = createProjectManager({ homePath, runCommand: vi.fn() });
+    const input = {
+      mode: "folder" as const,
+      name: "Shared",
+      path: "workspaces/shared",
+      ownerScope: { type: "user" as const, id: "user_123" },
+      clientRequestId: "req_folder_shared_1",
+    };
+
+    const [first, second] = await Promise.all([
+      firstManager.createProject(input),
+      secondManager.createProject(input),
+    ]);
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    if (!first.ok || !second.ok) throw new Error("expected idempotent project creation");
+    expect(second.project.id).toBe(first.project.id);
+  });
+
   it("treats Git and GitHub as optional capabilities for folder projects", async () => {
     const runCommand = vi.fn(async (command: string, args: string[]) => {
       if (command === "git" && args[0] === "rev-parse") {


### PR DESCRIPTION
## Summary

- attach a stable, payload-scoped idempotency key to Desktop project and custom-folder creation
- replay timed-out creates beyond the gateway's bounded five-minute clone window
- reconcile overlapping folder requests through owner-scoped, bounded receipts
- publish folder project configs atomically without overwriting a concurrent winner
- open already-connected workspaces instead of showing a false create error
- distinguish Matrix-managed project registry directories from selectable repo workspaces
- recover stale slug conflicts after refreshing the authoritative project list

Closes MAT-263.

## UX behavior

- Selecting an already-connected workspace such as `apps/matrix-os` opens its existing project.
- Selecting `projects/<slug>` explains that it contains Matrix project data and offers to open the owning project.
- Matrix-managed registry metadata and worktree folders cannot be connected as user workspaces.
- A managed `projects/<slug>/repo` checkout remains selectable and resolves to its owning project by path.
- Reusing a slug for a genuinely different folder still asks the user to choose another name.

## Tests

- `bunx vitest run tests/desktop/create-project-dialog.test.tsx tests/desktop/files-browser-views.test.tsx tests/desktop/add-project-dialog.test.tsx` (57 passed)
- `bun run typecheck`
- `bun run build:desktop`
- `bun run check:patterns` (0 violations)
- live Electron validation against `pr-1163` for both `apps/matrix-os` and `projects/matrix-os`

Local full-suite note: `bun run test` completed with 10,354 passed and 24 failures in unchanged suites. The failures are outside this diff and include missing Vitest resolution in UI test setup, Codex control-socket and interactive-shell timeouts, a date-sensitive Todo fixture, and environment-specific host-tool tests. The changed Desktop suites passed in the same run; CI on the new PR head is authoritative.

## Invariants

### Source of truth

- `projects/<slug>/config.json` remains the canonical project record.
- Folder request receipts are bounded idempotency metadata only; a replay is accepted only when the receipt fingerprint, owner scope, and on-disk target all agree.
- The refreshed Desktop project list is authoritative when reconciling an existing workspace path.

### Lock/transaction scope

- The existing per-slug process lock still serializes local creates.
- Folder config publication additionally uses an atomic exclusive hard-link, so separate gateway processes cannot overwrite the winning config.
- Custom-folder creation uses exclusive `mkdir`; only an `EEXIST` from the same request fingerprint enters bounded receipt reconciliation. No network call is held inside these critical sections.

### Acceptable orphan states

- If custom-folder creation succeeds and later binding fails, the empty user folder may remain and can be connected through Existing folder.
- If project metadata directory creation succeeds but exclusive config publication fails, an empty metadata directory may remain; no existing config is overwritten.
- Receipts expire after 24 hours and are capped at 256 entries with symlink-safe cleanup.

### Auth source of truth

- The workspace route's request principal remains authoritative.
- The principal-derived owner scope is included in the folder request fingerprint and receipt; invalid or mismatched requests fail closed.

### Deferred scope

- This PR does not redesign project creation as an asynchronous job API.
- It does not migrate or delete previously duplicated user folders automatically.
- No public documentation change is proposed; this aligns Desktop recovery with the existing project registry contract.
