### PR TITLE
feat(desktop): align Hermes configuration flow

### DIFF
--- a/desktop/src/main/hermes/configuration-client.ts
+++ b/desktop/src/main/hermes/configuration-client.ts
@@ -1,0 +1,166 @@
+import {
+  HermesConfigurationChangeRequestSchema,
+  HermesConfigurationSchema,
+  HermesCredentialRemoveRequestSchema,
+  HermesCredentialSetRequestSchema,
+  HermesEnvironmentSchema,
+  HermesMutationResponseSchema,
+  type HermesConfiguration,
+  type HermesConfigurationChangeRequest,
+  type HermesCredentialRemoveRequest,
+  type HermesCredentialSetRequest,
+  type HermesEnvironment,
+} from "@matrix-os/contracts";
+import type { AuthService } from "../auth/auth-service";
+
+const RESPONSE_LIMIT_BYTES = 1024 * 1024;
+const READ_TIMEOUT_MS = 10_000;
+const WRITE_TIMEOUT_MS = 15_000;
+const READ_ERROR = "Hermes configuration is unavailable.";
+const WRITE_ERROR = "Hermes configuration could not be saved.";
+
+export type HermesFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+function runtimeUrl(auth: AuthService, path: string): string {
+  const url = new URL(path, auth.getGatewayOrigin());
+  const runtimeSlot = auth.getStatus().runtimeSlot;
+  if (runtimeSlot !== "primary") url.searchParams.set("runtime", runtimeSlot);
+  return url.toString();
+}
+
+async function boundedJson(response: Response, errorMessage: string): Promise<unknown> {
+  const text = await response.text();
+  if (new TextEncoder().encode(text).byteLength > RESPONSE_LIMIT_BYTES) {
+    throw new Error(errorMessage);
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (error) {
+    console.warn(
+      "Hermes Desktop response parsing failed",
+      error instanceof Error ? error.name : "UnknownError",
+    );
+    throw new Error(errorMessage);
+  }
+}
+
+async function request(
+  auth: AuthService,
+  path: string,
+  init: RequestInit,
+  timeoutMs: number,
+  errorMessage: string,
+  fetchFn: HermesFetch,
+): Promise<unknown> {
+  const token = auth.getToken();
+  if (!token) throw new Error(errorMessage);
+  let response: Response;
+  try {
+    response = await fetchFn(runtimeUrl(auth, path), {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        ...init.headers,
+      },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    console.warn(
+      "Hermes Desktop request failed",
+      error instanceof Error ? error.name : "UnknownError",
+    );
+    throw new Error(errorMessage);
+  }
+  if (!response.ok) throw new Error(errorMessage);
+  return boundedJson(response, errorMessage);
+}
+
+export async function fetchHermesConfiguration(
+  auth: AuthService,
+  fetchFn: HermesFetch = fetch,
+): Promise<HermesConfiguration> {
+  const parsed = HermesConfigurationSchema.safeParse(await request(
+    auth,
+    "/api/hermes/configuration",
+    { method: "GET" },
+    READ_TIMEOUT_MS,
+    READ_ERROR,
+    fetchFn,
+  ));
+  if (!parsed.success) throw new Error(READ_ERROR);
+  return parsed.data;
+}
+
+export async function fetchHermesEnvironment(
+  auth: AuthService,
+  fetchFn: HermesFetch = fetch,
+): Promise<HermesEnvironment> {
+  const parsed = HermesEnvironmentSchema.safeParse(await request(
+    auth,
+    "/api/hermes/env",
+    { method: "GET" },
+    READ_TIMEOUT_MS,
+    READ_ERROR,
+    fetchFn,
+  ));
+  if (!parsed.success) throw new Error(READ_ERROR);
+  return parsed.data;
+}
+
+async function mutate<T>(
+  auth: AuthService,
+  path: string,
+  method: "PUT" | "DELETE",
+  rawRequest: T,
+  requestSchema: { safeParse: (value: unknown) => { success: boolean; data?: T } },
+  fetchFn: HermesFetch,
+): Promise<{ ok: true }> {
+  const parsedRequest = requestSchema.safeParse(rawRequest);
+  if (!parsedRequest.success) throw new Error(WRITE_ERROR);
+  const parsedResponse = HermesMutationResponseSchema.safeParse(await request(
+    auth,
+    path,
+    {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(parsedRequest.data),
+    },
+    WRITE_TIMEOUT_MS,
+    WRITE_ERROR,
+    fetchFn,
+  ));
+  if (!parsedResponse.success) throw new Error(WRITE_ERROR);
+  return { ok: true };
+}
+
+export function updateHermesConfiguration(
+  auth: AuthService,
+  requestValue: HermesConfigurationChangeRequest,
+  fetchFn: HermesFetch = fetch,
+): Promise<{ ok: true }> {
+  return mutate(
+    auth,
+    "/api/hermes/configuration",
+    "PUT",
+    requestValue,
+    HermesConfigurationChangeRequestSchema,
+    fetchFn,
+  );
+}
+
+export function setHermesCredential(
+  auth: AuthService,
+  requestValue: HermesCredentialSetRequest,
+  fetchFn: HermesFetch = fetch,
+): Promise<{ ok: true }> {
+  return mutate(auth, "/api/hermes/env", "PUT", requestValue, HermesCredentialSetRequestSchema, fetchFn);
+}
+
+export function removeHermesCredential(
+  auth: AuthService,
+  requestValue: HermesCredentialRemoveRequest,
+  fetchFn: HermesFetch = fetch,
+): Promise<{ ok: true }> {
+  return mutate(auth, "/api/hermes/env", "DELETE", requestValue, HermesCredentialRemoveRequestSchema, fetchFn);
+}

--- a/desktop/src/main/hermes/configuration-client.ts
+++ b/desktop/src/main/hermes/configuration-client.ts
@@ -58,6 +58,7 @@ async function request(
   try {
     response = await fetchFn(runtimeUrl(auth, path), {
       ...init,
+      redirect: "error",
       headers: {
         Authorization: `Bearer ${token}`,
         Accept: "application/json",

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -25,6 +25,13 @@ import {
   updateCodingAgentNotificationPreferences,
 } from "./coding-agents/runtime-summary-client";
 import { createCodingAgentThreadEventStreamer } from "./coding-agents/thread-event-stream";
+import {
+  fetchHermesConfiguration,
+  fetchHermesEnvironment,
+  removeHermesCredential,
+  setHermesCredential,
+  updateHermesConfiguration,
+} from "./hermes/configuration-client";
 import { registerIpcHandlers } from "./ipc/handlers";
 import { createLocalStore } from "./persistence/local-store";
 import { installAppMenu } from "./platform/menu";
@@ -261,6 +268,11 @@ if (!gotLock) {
         fetchProjectWorkspace: (request) => fetchCodingAgentProjectWorkspace(auth, request),
         fetchNotificationPreferences: () => fetchCodingAgentNotificationPreferences(auth),
         updateNotificationPreferences: (request) => updateCodingAgentNotificationPreferences(auth, request),
+        fetchHermesConfiguration: () => fetchHermesConfiguration(auth),
+        fetchHermesEnvironment: () => fetchHermesEnvironment(auth),
+        updateHermesConfiguration: (request) => updateHermesConfiguration(auth, request),
+        setHermesCredential: (request) => setHermesCredential(auth, request),
+        removeHermesCredential: (request) => removeHermesCredential(auth, request),
         fetchReviewSummaries: (options) => fetchCodingAgentReviewSummaries(auth, options),
         fetchReviewSnapshot: (options) => fetchCodingAgentReviewSnapshot(auth, options),
         fetchFileBrowse: (request) => fetchCodingAgentFileBrowse(auth, request),

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -36,6 +36,17 @@ export interface HandlerContext {
   updateNotificationPreferences: (
     request: CodingAgentNotificationPreferencesUpdate,
   ) => Promise<CodingAgentNotificationPreferences>;
+  fetchHermesConfiguration: () => Promise<InvokeResponse<"runtime:get-hermes-configuration">>;
+  fetchHermesEnvironment: () => Promise<InvokeResponse<"runtime:get-hermes-environment">>;
+  updateHermesConfiguration: (
+    request: InvokeRequest<"runtime:update-hermes-configuration">,
+  ) => Promise<InvokeResponse<"runtime:update-hermes-configuration">>;
+  setHermesCredential: (
+    request: InvokeRequest<"runtime:set-hermes-credential">,
+  ) => Promise<InvokeResponse<"runtime:set-hermes-credential">>;
+  removeHermesCredential: (
+    request: InvokeRequest<"runtime:remove-hermes-credential">,
+  ) => Promise<InvokeResponse<"runtime:remove-hermes-credential">>;
   fetchReviewSummaries: (
     options: { cursor?: string },
   ) => Promise<{ items: ReviewSummary[]; hasMore: boolean; limit: number; nextCursor?: string }>;
@@ -154,6 +165,11 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
   handle("runtime:get-project-workspace", (request) => ctx.fetchProjectWorkspace(request));
   handle("runtime:get-notification-preferences", () => ctx.fetchNotificationPreferences());
   handle("runtime:update-notification-preferences", (request) => ctx.updateNotificationPreferences(request));
+  handle("runtime:get-hermes-configuration", () => ctx.fetchHermesConfiguration());
+  handle("runtime:get-hermes-environment", () => ctx.fetchHermesEnvironment());
+  handle("runtime:update-hermes-configuration", (request) => ctx.updateHermesConfiguration(request));
+  handle("runtime:set-hermes-credential", (request) => ctx.setHermesCredential(request));
+  handle("runtime:remove-hermes-credential", (request) => ctx.removeHermesCredential(request));
   handle("runtime:get-reviews", (request) => ctx.fetchReviewSummaries(request));
   handle("runtime:get-review-snapshot", (request) => ctx.fetchReviewSnapshot(request));
   handle("runtime:browse-files", (request) => ctx.fetchFileBrowse(request));

--- a/desktop/src/renderer/src/design/primitives.tsx
+++ b/desktop/src/renderer/src/design/primitives.tsx
@@ -77,6 +77,7 @@ export function Dialog({
   width = 480,
   title = "Dialog",
   role = "dialog",
+  placement = "top",
 }: {
   open: boolean;
   onClose: () => void;
@@ -84,6 +85,7 @@ export function Dialog({
   width?: number;
   title?: string;
   role?: "dialog" | "alertdialog";
+  placement?: "top" | "center";
 }) {
   return (
     <RadixDialog.Root open={open} onOpenChange={(next) => { if (!next) onClose(); }}>
@@ -92,8 +94,20 @@ export function Dialog({
         <RadixDialog.Content
           role={role}
           aria-describedby={undefined}
-          className="fade-in fixed top-[18vh] left-1/2 z-50 -translate-x-1/2 rounded-xl border focus:outline-none"
-          style={{ width, background: "var(--bg-overlay)", borderColor: "var(--border-default)", boxShadow: "var(--shadow-3)" }}
+          className={`fade-in fixed left-1/2 z-50 rounded-xl border focus:outline-none ${
+            placement === "center" ? "" : "top-[18vh] -translate-x-1/2"
+          }`}
+          style={{
+            width,
+            background: "var(--bg-overlay)",
+            borderColor: "var(--border-default)",
+            boxShadow: "var(--shadow-3)",
+            ...(placement === "center" ? {
+              top: "50%",
+              transform: "translate(-50%, -50%)",
+              maxHeight: "calc(100vh - 32px)",
+            } : {}),
+          }}
         >
           <RadixDialog.Title className="sr-only">{title}</RadixDialog.Title>
           {children}

--- a/desktop/src/renderer/src/design/primitives.tsx
+++ b/desktop/src/renderer/src/design/primitives.tsx
@@ -75,22 +75,27 @@ export function Dialog({
   onClose,
   children,
   width = 480,
+  title = "Dialog",
+  role = "dialog",
 }: {
   open: boolean;
   onClose: () => void;
   children: ReactNode;
   width?: number;
+  title?: string;
+  role?: "dialog" | "alertdialog";
 }) {
   return (
     <RadixDialog.Root open={open} onOpenChange={(next) => { if (!next) onClose(); }}>
       <RadixDialog.Portal>
         <RadixDialog.Overlay className="fixed inset-0 z-50" style={{ background: "var(--overlay-dim)" }} />
         <RadixDialog.Content
+          role={role}
           aria-describedby={undefined}
           className="fade-in fixed top-[18vh] left-1/2 z-50 -translate-x-1/2 rounded-xl border focus:outline-none"
           style={{ width, background: "var(--bg-overlay)", borderColor: "var(--border-default)", boxShadow: "var(--shadow-3)" }}
         >
-          <RadixDialog.Title className="sr-only">Dialog</RadixDialog.Title>
+          <RadixDialog.Title className="sr-only">{title}</RadixDialog.Title>
           {children}
         </RadixDialog.Content>
       </RadixDialog.Portal>

--- a/desktop/src/renderer/src/features/settings/hermes/HermesConfigurationDialog.tsx
+++ b/desktop/src/renderer/src/features/settings/hermes/HermesConfigurationDialog.tsx
@@ -30,6 +30,9 @@ interface HermesConfigurationDialogProps {
 const LOAD_ERROR = "Hermes configuration is unavailable.";
 const SAVE_ERROR = "Hermes configuration could not be saved.";
 const CREDENTIAL_ERROR = "Hermes credential could not be updated.";
+// Matches the shared HermesConfigurationSchema field limit. Invalid paths can
+// only originate from rendered, schema-validated fields.
+const MAX_INVALID_PATHS = 1_024;
 
 export function HermesConfigurationDialog({
   open,
@@ -45,7 +48,7 @@ export function HermesConfigurationDialog({
   const [category, setCategory] = useState("");
   const [settingsSearch, setSettingsSearch] = useState("");
   const [credentialSearch, setCredentialSearch] = useState("");
-  const [invalidPaths, setInvalidPaths] = useState<Set<string>>(() => new Set());
+  const [invalidPaths, setInvalidPaths] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -68,7 +71,7 @@ export function HermesConfigurationDialog({
       setConfiguration(nextConfiguration);
       setEnvironment(nextEnvironment);
       setDraft(structuredClone(nextConfiguration.config));
-      setInvalidPaths(new Set());
+      setInvalidPaths([]);
       setCategory(configurationCategories(nextConfiguration)[0]?.id ?? "");
     } catch (loadError) {
       if (isCurrentRequestRevision(requestRevision.current, revision)) {
@@ -116,19 +119,24 @@ export function HermesConfigurationDialog({
       return parsed.success ? [{ path, value: parsed.data }] : [];
     });
   }, [configuration, draft]);
+  const dirtyPathCount = changes.reduce(
+    (count, change) => count + (invalidPaths.includes(change.path) ? 0 : 1),
+    invalidPaths.length,
+  );
+  const isDirty = dirtyPathCount > 0;
 
   const requestRefresh = () => {
-    if (changes.length > 0) setConfirmation("refresh");
+    if (isDirty) setConfirmation("refresh");
     else void load(true);
   };
 
   const requestClose = () => {
-    if (changes.length > 0) setConfirmation("close");
+    if (isDirty) setConfirmation("close");
     else onClose();
   };
 
   const save = async () => {
-    if (!configuration || changes.length === 0 || invalidPaths.size > 0) return;
+    if (!configuration || changes.length === 0 || invalidPaths.length > 0) return;
     setSaving(true);
     setError(null);
     try {
@@ -294,10 +302,10 @@ export function HermesConfigurationDialog({
                         defaultValue={configValueAt(configuration.defaults, path)}
                         onChange={(value) => setDraft((current) => setConfigValue(current, path, value))}
                         onValidityChange={(valid) => setInvalidPaths((current) => {
-                          const next = new Set(current);
-                          if (valid) next.delete(path);
-                          else next.add(path);
-                          return next;
+                          if (valid) return current.filter((item) => item !== path);
+                          if (current.includes(path)) return current;
+                          if (current.length >= MAX_INVALID_PATHS) return current;
+                          return [...current, path];
                         })}
                       />
                     ))}
@@ -323,7 +331,7 @@ export function HermesConfigurationDialog({
               <div>
                 {error ? <span role="alert" className="text-xs" style={{ color: "var(--danger)" }}>{error}</span> : (
                   <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
-                    {changes.length} unsaved {changes.length === 1 ? "change" : "changes"}
+                    {dirtyPathCount} unsaved {dirtyPathCount === 1 ? "change" : "changes"}
                   </span>
                 )}
               </div>
@@ -331,10 +339,10 @@ export function HermesConfigurationDialog({
                 <Button
                   variant="ghost"
                   aria-label="Discard Hermes changes"
-                  disabled={changes.length === 0 || saving}
+                  disabled={!isDirty || saving}
                   onClick={() => {
                     setDraft(structuredClone(configuration.config));
-                    setInvalidPaths(new Set());
+                    setInvalidPaths([]);
                   }}
                 >
                   Discard
@@ -342,7 +350,7 @@ export function HermesConfigurationDialog({
                 <Button
                   variant="primary"
                   aria-label="Save Hermes settings"
-                  disabled={changes.length === 0 || invalidPaths.size > 0 || saving}
+                  disabled={changes.length === 0 || invalidPaths.length > 0 || saving}
                   onClick={() => void save()}
                 >
                   {saving ? "Saving…" : "Save changes"}

--- a/desktop/src/renderer/src/features/settings/hermes/HermesConfigurationDialog.tsx
+++ b/desktop/src/renderer/src/features/settings/hermes/HermesConfigurationDialog.tsx
@@ -1,0 +1,346 @@
+import {
+  HermesConfigValueSchema,
+  type HermesConfiguration,
+  type HermesEnvironment,
+} from "@matrix-os/contracts";
+import { RefreshCw, Search, Sparkles, SquareTerminal, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Button, Dialog } from "../../../design/primitives";
+import { invoke } from "../../../lib/operator";
+import { HermesCredentialRow } from "./HermesCredentialRow";
+import { HermesSettingEditor } from "./HermesSettingEditor";
+import {
+  configValueAt,
+  configurationCategories,
+  isCurrentRequestRevision,
+  matchingConfigurationFields,
+  matchingCredentials,
+  setConfigValue,
+  valuesEqual,
+} from "./hermes-form-model";
+
+interface HermesConfigurationDialogProps {
+  open: boolean;
+  version?: string;
+  onClose: () => void;
+  onOpenSetupTerminal: () => Promise<void> | void;
+  onConfigurationChanged: () => void;
+}
+
+const LOAD_ERROR = "Hermes configuration is unavailable.";
+const SAVE_ERROR = "Hermes configuration could not be saved.";
+const CREDENTIAL_ERROR = "Hermes credential could not be updated.";
+
+export function HermesConfigurationDialog({
+  open,
+  version,
+  onClose,
+  onOpenSetupTerminal,
+  onConfigurationChanged,
+}: HermesConfigurationDialogProps) {
+  const [configuration, setConfiguration] = useState<HermesConfiguration | null>(null);
+  const [environment, setEnvironment] = useState<HermesEnvironment>({});
+  const [draft, setDraft] = useState<Record<string, unknown>>({});
+  const [tab, setTab] = useState<"settings" | "credentials">("settings");
+  const [category, setCategory] = useState("");
+  const [settingsSearch, setSettingsSearch] = useState("");
+  const [credentialSearch, setCredentialSearch] = useState("");
+  const [invalidPaths, setInvalidPaths] = useState<Set<string>>(() => new Set());
+  const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [credentialBusy, setCredentialBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestRevision = useRef(0);
+
+  const load = useCallback(async (refresh: boolean) => {
+    const revision = ++requestRevision.current;
+    if (refresh) setRefreshing(true);
+    else setLoading(true);
+    setError(null);
+    try {
+      const [nextConfiguration, nextEnvironment] = await Promise.all([
+        invoke("runtime:get-hermes-configuration", {}),
+        invoke("runtime:get-hermes-environment", {}),
+      ]);
+      if (!isCurrentRequestRevision(requestRevision.current, revision)) return;
+      setConfiguration(nextConfiguration);
+      setEnvironment(nextEnvironment);
+      setDraft(structuredClone(nextConfiguration.config));
+      setInvalidPaths(new Set());
+      setCategory(configurationCategories(nextConfiguration)[0]?.id ?? "");
+    } catch (loadError) {
+      if (isCurrentRequestRevision(requestRevision.current, revision)) {
+        console.warn("Hermes Desktop configuration load failed", loadError instanceof Error ? loadError.name : "UnknownError");
+        setError(LOAD_ERROR);
+      }
+    } finally {
+      if (isCurrentRequestRevision(requestRevision.current, revision)) {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      ++requestRevision.current;
+      setConfiguration(null);
+      setEnvironment({});
+      setDraft({});
+      return;
+    }
+    void load(false);
+  }, [open, load]);
+
+  const categories = useMemo(
+    () => configuration ? configurationCategories(configuration) : [],
+    [configuration],
+  );
+  const visibleFields = useMemo(
+    () => configuration ? matchingConfigurationFields(configuration, settingsSearch, category) : [],
+    [configuration, settingsSearch, category],
+  );
+  const visibleCredentials = useMemo(
+    () => matchingCredentials(environment, credentialSearch),
+    [environment, credentialSearch],
+  );
+  const changes = useMemo(() => {
+    if (!configuration) return [];
+    return Object.keys(configuration.fields).flatMap((path) => {
+      const current = configValueAt(configuration.config, path);
+      const next = configValueAt(draft, path);
+      if (valuesEqual(current, next)) return [];
+      const parsed = HermesConfigValueSchema.safeParse(next);
+      return parsed.success ? [{ path, value: parsed.data }] : [];
+    });
+  }, [configuration, draft]);
+
+  const save = async () => {
+    if (!configuration || changes.length === 0 || invalidPaths.size > 0) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await invoke("runtime:update-hermes-configuration", { changes });
+      setConfiguration({ ...configuration, config: structuredClone(draft) });
+      onConfigurationChanged();
+    } catch (saveError) {
+      console.warn("Hermes Desktop configuration save failed", saveError instanceof Error ? saveError.name : "UnknownError");
+      setError(SAVE_ERROR);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const saveCredential = async (key: string, value: string): Promise<boolean> => {
+    setCredentialBusy(true);
+    setError(null);
+    try {
+      await invoke("runtime:set-hermes-credential", { key, value });
+      setEnvironment((current) => ({
+        ...current,
+        [key]: { ...current[key]!, is_set: true, redacted_value: "Configured" },
+      }));
+      onConfigurationChanged();
+      return true;
+    } catch (credentialError) {
+      console.warn("Hermes Desktop credential save failed", credentialError instanceof Error ? credentialError.name : "UnknownError");
+      setError(CREDENTIAL_ERROR);
+      return false;
+    } finally {
+      setCredentialBusy(false);
+    }
+  };
+
+  const removeCredential = async (key: string): Promise<boolean> => {
+    setCredentialBusy(true);
+    setError(null);
+    try {
+      await invoke("runtime:remove-hermes-credential", { key });
+      setEnvironment((current) => ({
+        ...current,
+        [key]: { ...current[key]!, is_set: false, redacted_value: undefined },
+      }));
+      onConfigurationChanged();
+      return true;
+    } catch (credentialError) {
+      console.warn("Hermes Desktop credential removal failed", credentialError instanceof Error ? credentialError.name : "UnknownError");
+      setError(CREDENTIAL_ERROR);
+      return false;
+    } finally {
+      setCredentialBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} width={980}>
+      <div className="flex h-[min(720px,82vh)] flex-col overflow-hidden">
+        <header className="flex items-start justify-between border-b px-5 py-4" style={{ borderColor: "var(--border-subtle)" }}>
+          <div className="flex items-start gap-3">
+            <div className="rounded-lg p-2" style={{ background: "var(--accent-muted)", color: "var(--accent)" }}>
+              <Sparkles size={19} />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold" style={{ color: "var(--text-primary)" }}>Configure Hermes</h2>
+              <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
+                Settings and credentials for this Matrix computer
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            {version ? <span className="rounded-full border px-2 py-1 text-xs" style={{ borderColor: "var(--border-default)", color: "var(--text-secondary)" }}>Version {version}</span> : null}
+            <Button variant="ghost" disabled={loading || refreshing} onClick={() => void load(true)}>
+              <RefreshCw size={13} className={refreshing ? "animate-spin" : ""} />
+              {refreshing ? "Refreshing…" : "Refresh"}
+            </Button>
+            <Button
+              variant="ghost"
+              className="h-7 w-7 px-0"
+              aria-label="Close Hermes configuration"
+              onClick={onClose}
+            >
+              <X size={16} />
+            </Button>
+          </div>
+        </header>
+
+        {loading ? (
+          <div className="flex flex-1 items-center justify-center text-sm" style={{ color: "var(--text-secondary)" }}>
+            Loading Hermes configuration…
+          </div>
+        ) : !configuration ? (
+          <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
+            <p role="alert" className="text-sm" style={{ color: "var(--danger)" }}>{error ?? LOAD_ERROR}</p>
+            <div className="flex gap-2">
+              <Button onClick={() => void load(false)}>Try again</Button>
+              <Button variant="primary" aria-label="Open setup terminal" onClick={() => void onOpenSetupTerminal()}>
+                <SquareTerminal size={14} />Open setup terminal
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center justify-between border-b px-5" style={{ borderColor: "var(--border-subtle)" }}>
+              <div role="tablist" className="flex gap-1">
+                {(["settings", "credentials"] as const).map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    role="tab"
+                    aria-selected={tab === value}
+                    className="border-b-2 px-3 py-3 text-sm font-medium capitalize"
+                    style={{
+                      borderColor: tab === value ? "var(--accent)" : "transparent",
+                      color: tab === value ? "var(--text-primary)" : "var(--text-tertiary)",
+                    }}
+                    onClick={() => setTab(value)}
+                  >
+                    {value === "settings" ? "Settings" : "Credentials"}
+                  </button>
+                ))}
+              </div>
+              <label className="relative w-80">
+                <Search size={14} className="absolute top-1/2 left-2.5 -translate-y-1/2" style={{ color: "var(--text-tertiary)" }} />
+                <span className="sr-only">Search {tab}</span>
+                <input
+                  aria-label={`Search Hermes ${tab}`}
+                  className="h-8 w-full rounded-md border bg-transparent pr-2 pl-8 text-sm outline-none"
+                  style={{ borderColor: "var(--border-default)", color: "var(--text-primary)" }}
+                  placeholder={`Search ${tab}…`}
+                  value={tab === "settings" ? settingsSearch : credentialSearch}
+                  onChange={(event) => tab === "settings" ? setSettingsSearch(event.target.value) : setCredentialSearch(event.target.value)}
+                />
+              </label>
+            </div>
+
+            <div className="flex min-h-0 flex-1">
+              {tab === "settings" ? (
+                <>
+                  <aside className="w-52 shrink-0 overflow-y-auto border-r p-3" style={{ borderColor: "var(--border-subtle)" }}>
+                    {categories.map((item) => (
+                      <button
+                        key={item.id}
+                        type="button"
+                        aria-label={item.label}
+                        className="mb-1 flex w-full items-center justify-between rounded-md px-2.5 py-2 text-left text-sm"
+                        style={{
+                          background: category === item.id ? "var(--accent-muted)" : "transparent",
+                          color: category === item.id ? "var(--text-primary)" : "var(--text-secondary)",
+                        }}
+                        onClick={() => setCategory(item.id)}
+                      >
+                        {item.label}<span className="text-xs" style={{ color: "var(--text-tertiary)" }}>{item.count}</span>
+                      </button>
+                    ))}
+                  </aside>
+                  <main className="min-w-0 flex-1 space-y-3 overflow-y-auto p-4">
+                    {visibleFields.map(([path, field]) => (
+                      <HermesSettingEditor
+                        key={path}
+                        path={path}
+                        field={field}
+                        value={configValueAt(draft, path) ?? configValueAt(configuration.defaults, path)}
+                        defaultValue={configValueAt(configuration.defaults, path)}
+                        onChange={(value) => setDraft((current) => setConfigValue(current, path, value))}
+                        onValidityChange={(valid) => setInvalidPaths((current) => {
+                          const next = new Set(current);
+                          if (valid) next.delete(path);
+                          else next.add(path);
+                          return next;
+                        })}
+                      />
+                    ))}
+                  </main>
+                </>
+              ) : (
+                <main className="min-w-0 flex-1 space-y-3 overflow-y-auto p-4">
+                  {visibleCredentials.map(([key, entry]) => (
+                    <HermesCredentialRow
+                      key={key}
+                      credentialKey={key}
+                      entry={entry}
+                      busy={credentialBusy}
+                      onSave={saveCredential}
+                      onRemove={removeCredential}
+                    />
+                  ))}
+                </main>
+              )}
+            </div>
+
+            <footer className="flex items-center justify-between border-t px-5 py-3" style={{ borderColor: "var(--border-subtle)" }}>
+              <div>
+                {error ? <span role="alert" className="text-xs" style={{ color: "var(--danger)" }}>{error}</span> : (
+                  <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+                    {changes.length} unsaved {changes.length === 1 ? "change" : "changes"}
+                  </span>
+                )}
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  variant="ghost"
+                  aria-label="Discard Hermes changes"
+                  disabled={changes.length === 0 || saving}
+                  onClick={() => {
+                    setDraft(structuredClone(configuration.config));
+                    setInvalidPaths(new Set());
+                  }}
+                >
+                  Discard
+                </Button>
+                <Button
+                  variant="primary"
+                  aria-label="Save Hermes settings"
+                  disabled={changes.length === 0 || invalidPaths.size > 0 || saving}
+                  onClick={() => void save()}
+                >
+                  {saving ? "Saving…" : "Save changes"}
+                </Button>
+              </div>
+            </footer>
+          </>
+        )}
+      </div>
+    </Dialog>
+  );
+}

--- a/desktop/src/renderer/src/features/settings/hermes/HermesConfigurationDialog.tsx
+++ b/desktop/src/renderer/src/features/settings/hermes/HermesConfigurationDialog.tsx
@@ -192,7 +192,7 @@ export function HermesConfigurationDialog({
   };
 
   return (
-    <Dialog open={open} onClose={requestClose} width={980}>
+    <Dialog open={open} onClose={requestClose} width={980} placement="center">
       <div className="relative flex h-[min(720px,82vh)] flex-col overflow-hidden">
         <header className="flex items-start justify-between border-b px-5 py-4" style={{ borderColor: "var(--border-subtle)" }}>
           <div className="flex items-start gap-3">

--- a/desktop/src/renderer/src/features/settings/hermes/HermesConfigurationDialog.tsx
+++ b/desktop/src/renderer/src/features/settings/hermes/HermesConfigurationDialog.tsx
@@ -50,6 +50,7 @@ export function HermesConfigurationDialog({
   const [refreshing, setRefreshing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [credentialBusy, setCredentialBusy] = useState(false);
+  const [confirmation, setConfirmation] = useState<"refresh" | "close" | null>(null);
   const [error, setError] = useState<string | null>(null);
   const requestRevision = useRef(0);
 
@@ -116,6 +117,16 @@ export function HermesConfigurationDialog({
     });
   }, [configuration, draft]);
 
+  const requestRefresh = () => {
+    if (changes.length > 0) setConfirmation("refresh");
+    else void load(true);
+  };
+
+  const requestClose = () => {
+    if (changes.length > 0) setConfirmation("close");
+    else onClose();
+  };
+
   const save = async () => {
     if (!configuration || changes.length === 0 || invalidPaths.size > 0) return;
     setSaving(true);
@@ -173,8 +184,8 @@ export function HermesConfigurationDialog({
   };
 
   return (
-    <Dialog open={open} onClose={onClose} width={980}>
-      <div className="flex h-[min(720px,82vh)] flex-col overflow-hidden">
+    <Dialog open={open} onClose={requestClose} width={980}>
+      <div className="relative flex h-[min(720px,82vh)] flex-col overflow-hidden">
         <header className="flex items-start justify-between border-b px-5 py-4" style={{ borderColor: "var(--border-subtle)" }}>
           <div className="flex items-start gap-3">
             <div className="rounded-lg p-2" style={{ background: "var(--accent-muted)", color: "var(--accent)" }}>
@@ -189,7 +200,7 @@ export function HermesConfigurationDialog({
           </div>
           <div className="flex items-center gap-2">
             {version ? <span className="rounded-full border px-2 py-1 text-xs" style={{ borderColor: "var(--border-default)", color: "var(--text-secondary)" }}>Version {version}</span> : null}
-            <Button variant="ghost" disabled={loading || refreshing} onClick={() => void load(true)}>
+            <Button variant="ghost" disabled={loading || refreshing} onClick={requestRefresh}>
               <RefreshCw size={13} className={refreshing ? "animate-spin" : ""} />
               {refreshing ? "Refreshing…" : "Refresh"}
             </Button>
@@ -197,7 +208,7 @@ export function HermesConfigurationDialog({
               variant="ghost"
               className="h-7 w-7 px-0"
               aria-label="Close Hermes configuration"
-              onClick={onClose}
+              onClick={requestClose}
             >
               <X size={16} />
             </Button>
@@ -340,6 +351,41 @@ export function HermesConfigurationDialog({
             </footer>
           </>
         )}
+        {confirmation ? (
+          <div className="absolute inset-0 z-10 flex items-center justify-center p-6" style={{ background: "var(--overlay-dim)" }}>
+            <div
+              role="alertdialog"
+              aria-modal="true"
+              aria-label={confirmation === "refresh" ? "Confirm refresh" : "Confirm close"}
+              className="w-full max-w-sm rounded-xl border p-5"
+              style={{ background: "var(--bg-overlay)", borderColor: "var(--border-default)", boxShadow: "var(--shadow-3)" }}
+            >
+              <h3 className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+                {confirmation === "refresh"
+                  ? "Discard unsaved changes and refresh?"
+                  : "Discard unsaved changes and close?"}
+              </h3>
+              <p className="mt-2 text-xs" style={{ color: "var(--text-secondary)" }}>
+                Your unsaved Hermes setting changes will be lost.
+              </p>
+              <div className="mt-4 flex justify-end gap-2">
+                <Button variant="ghost" onClick={() => setConfirmation(null)}>Cancel</Button>
+                <Button
+                  variant="danger"
+                  aria-label={confirmation === "refresh" ? "Discard and refresh" : "Discard and close"}
+                  onClick={() => {
+                    const action = confirmation;
+                    setConfirmation(null);
+                    if (action === "refresh") void load(true);
+                    else onClose();
+                  }}
+                >
+                  {confirmation === "refresh" ? "Discard and refresh" : "Discard and close"}
+                </Button>
+              </div>
+            </div>
+          </div>
+        ) : null}
       </div>
     </Dialog>
   );

--- a/desktop/src/renderer/src/features/settings/hermes/HermesConfigurationDialog.tsx
+++ b/desktop/src/renderer/src/features/settings/hermes/HermesConfigurationDialog.tsx
@@ -351,15 +351,15 @@ export function HermesConfigurationDialog({
             </footer>
           </>
         )}
-        {confirmation ? (
-          <div className="absolute inset-0 z-10 flex items-center justify-center p-6" style={{ background: "var(--overlay-dim)" }}>
-            <div
-              role="alertdialog"
-              aria-modal="true"
-              aria-label={confirmation === "refresh" ? "Confirm refresh" : "Confirm close"}
-              className="w-full max-w-sm rounded-xl border p-5"
-              style={{ background: "var(--bg-overlay)", borderColor: "var(--border-default)", boxShadow: "var(--shadow-3)" }}
-            >
+        <Dialog
+          open={confirmation !== null}
+          onClose={() => setConfirmation(null)}
+          width={400}
+          role="alertdialog"
+          title={confirmation === "refresh" ? "Confirm refresh" : "Confirm close"}
+        >
+          {confirmation ? (
+            <div className="p-5">
               <h3 className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
                 {confirmation === "refresh"
                   ? "Discard unsaved changes and refresh?"
@@ -384,8 +384,8 @@ export function HermesConfigurationDialog({
                 </Button>
               </div>
             </div>
-          </div>
-        ) : null}
+          ) : null}
+        </Dialog>
       </div>
     </Dialog>
   );

--- a/desktop/src/renderer/src/features/settings/hermes/HermesCredentialRow.tsx
+++ b/desktop/src/renderer/src/features/settings/hermes/HermesCredentialRow.tsx
@@ -1,0 +1,90 @@
+import type { HermesEnvironmentEntry } from "@matrix-os/contracts";
+import { Check, KeyRound, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { Button } from "../../../design/primitives";
+
+interface HermesCredentialRowProps {
+  credentialKey: string;
+  entry: HermesEnvironmentEntry;
+  busy: boolean;
+  onSave: (key: string, value: string) => Promise<boolean>;
+  onRemove: (key: string) => Promise<boolean>;
+}
+
+export function HermesCredentialRow({ credentialKey, entry, busy, onSave, onRemove }: HermesCredentialRowProps) {
+  const [value, setValue] = useState("");
+  const [confirmRemove, setConfirmRemove] = useState(false);
+  const managed = entry.channel_managed;
+
+  return (
+    <article className="rounded-lg border p-4" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-sunken)" }}>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <KeyRound size={14} style={{ color: "var(--accent)" }} />
+            <span className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>{credentialKey}</span>
+            {entry.is_set ? (
+              <span className="flex items-center gap-1 text-xs" style={{ color: "var(--success)" }}>
+                <Check size={12} />Configured
+              </span>
+            ) : null}
+          </div>
+          <p className="mt-1 text-xs" style={{ color: "var(--text-secondary)" }}>
+            {entry.provider_label || entry.description}
+            {entry.is_set && entry.redacted_value ? ` · ${entry.redacted_value}` : ""}
+          </p>
+        </div>
+        {entry.is_set && !managed ? (
+          confirmRemove ? (
+            <div className="flex gap-1">
+              <Button variant="ghost" disabled={busy} onClick={() => setConfirmRemove(false)}>Cancel</Button>
+              <Button
+                variant="danger"
+                aria-label={`Confirm remove ${credentialKey}`}
+                disabled={busy}
+                onClick={() => void onRemove(credentialKey).then((removed) => { if (removed) setConfirmRemove(false); })}
+              >
+                Remove
+              </Button>
+            </div>
+          ) : (
+            <Button
+              variant="ghost"
+              aria-label={`Remove ${credentialKey}`}
+              disabled={busy}
+              onClick={() => setConfirmRemove(true)}
+            >
+              <Trash2 size={13} />Remove
+            </Button>
+          )
+        ) : null}
+      </div>
+      {managed ? (
+        <p className="mt-3 text-xs" style={{ color: "var(--text-tertiary)" }}>Managed by a connected channel.</p>
+      ) : (
+        <div className="mt-3 flex items-end gap-2">
+          <label className="min-w-0 flex-1 text-xs" style={{ color: "var(--text-secondary)" }}>
+            {entry.is_set ? "Replace value" : "New value"}
+            <input
+              aria-label={`${credentialKey} value`}
+              type={entry.is_password ? "password" : "text"}
+              autoComplete="off"
+              className="mt-1 h-9 w-full rounded-md border bg-transparent px-2.5 text-sm outline-none"
+              style={{ borderColor: "var(--border-default)", color: "var(--text-primary)" }}
+              value={value}
+              onChange={(event) => setValue(event.target.value)}
+            />
+          </label>
+          <Button
+            variant="primary"
+            aria-label={`Save ${credentialKey}`}
+            disabled={busy || value.length === 0}
+            onClick={() => void onSave(credentialKey, value).then((saved) => { if (saved) setValue(""); })}
+          >
+            Save
+          </Button>
+        </div>
+      )}
+    </article>
+  );
+}

--- a/desktop/src/renderer/src/features/settings/hermes/HermesSettingEditor.tsx
+++ b/desktop/src/renderer/src/features/settings/hermes/HermesSettingEditor.tsx
@@ -1,0 +1,155 @@
+import type { HermesConfigField } from "@matrix-os/contracts";
+import { RotateCcw } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "../../../design/primitives";
+import { parseHermesList, titleCase, valuesEqual } from "./hermes-form-model";
+
+interface HermesSettingEditorProps {
+  path: string;
+  field: HermesConfigField;
+  value: unknown;
+  defaultValue: unknown;
+  onChange: (value: string | number | boolean | Array<string | number | boolean>) => void;
+  onValidityChange: (valid: boolean) => void;
+}
+
+const INPUT_CLASS = "mt-2 min-h-9 w-full rounded-md border bg-transparent px-2.5 text-sm outline-none focus:border-[var(--accent)]";
+
+export function HermesSettingEditor({
+  path,
+  field,
+  value,
+  defaultValue,
+  onChange,
+  onValidityChange,
+}: HermesSettingEditorProps) {
+  const label = field.description || titleCase(path.split(".").at(-1) ?? path);
+  const [listText, setListText] = useState(() => JSON.stringify(value ?? [], null, 2));
+  const [listValid, setListValid] = useState(true);
+
+  useEffect(() => {
+    if (field.type === "list") {
+      setListText(JSON.stringify(value ?? [], null, 2));
+      setListValid(true);
+      onValidityChange(true);
+    }
+  // Reset the textual list draft when its authoritative value changes. The
+  // callback is intentionally excluded: parents provide a render-local setter
+  // and including it would turn a reset into a render loop.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [field.type, path, value]);
+
+  const restore = () => {
+    if (field.type === "list") {
+      const next = Array.isArray(defaultValue) ? defaultValue as Array<string | number | boolean> : [];
+      setListText(JSON.stringify(next, null, 2));
+      setListValid(true);
+      onValidityChange(true);
+      onChange(next);
+      return;
+    }
+    if (typeof defaultValue === "string" || typeof defaultValue === "number" || typeof defaultValue === "boolean") {
+      onValidityChange(true);
+      onChange(defaultValue);
+    }
+  };
+
+  let control;
+  if (field.type === "boolean") {
+    control = (
+      <label className="mt-2 flex items-center gap-2 text-sm" style={{ color: "var(--text-secondary)" }}>
+        <input
+          aria-label={label}
+          type="checkbox"
+          checked={Boolean(value)}
+          onChange={(event) => onChange(event.target.checked)}
+        />
+        {Boolean(value) ? "Enabled" : "Disabled"}
+      </label>
+    );
+  } else if (field.type === "select") {
+    control = (
+      <select
+        aria-label={label}
+        className={INPUT_CLASS}
+        style={{ borderColor: "var(--border-default)", color: "var(--text-primary)" }}
+        value={typeof value === "string" ? value : ""}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        {field.options?.map((option) => <option key={option} value={option}>{option}</option>)}
+      </select>
+    );
+  } else if (field.type === "number") {
+    control = (
+      <input
+        aria-label={label}
+        type="number"
+        className={INPUT_CLASS}
+        style={{ borderColor: "var(--border-default)", color: "var(--text-primary)" }}
+        value={typeof value === "number" ? value : ""}
+        onChange={(event) => {
+          const next = event.target.valueAsNumber;
+          const valid = Number.isFinite(next);
+          onValidityChange(valid);
+          if (valid) onChange(next);
+        }}
+      />
+    );
+  } else if (field.type === "list") {
+    control = (
+      <>
+        <textarea
+          aria-label={label}
+          className={`${INPUT_CLASS} min-h-24 py-2 font-mono text-xs`}
+          style={{ borderColor: listValid ? "var(--border-default)" : "var(--danger)", color: "var(--text-primary)" }}
+          value={listText}
+          onChange={(event) => {
+            const text = event.target.value;
+            const parsed = parseHermesList(text);
+            setListText(text);
+            setListValid(parsed !== null);
+            onValidityChange(parsed !== null);
+            if (parsed) onChange(parsed);
+          }}
+        />
+        {!listValid ? (
+          <p role="alert" className="mt-1 text-xs" style={{ color: "var(--danger)" }}>
+            Enter a JSON list of strings, numbers, or booleans.
+          </p>
+        ) : null}
+      </>
+    );
+  } else {
+    control = (
+      <input
+        aria-label={label}
+        type="text"
+        className={INPUT_CLASS}
+        style={{ borderColor: "var(--border-default)", color: "var(--text-primary)" }}
+        value={typeof value === "string" ? value : ""}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    );
+  }
+
+  return (
+    <article className="rounded-lg border p-4" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-sunken)" }}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <label className="block text-sm font-medium" style={{ color: "var(--text-primary)" }}>{label}</label>
+          <code className="text-xs" style={{ color: "var(--text-tertiary)" }}>{path}</code>
+        </div>
+        <Button
+          variant="ghost"
+          className="h-7 w-7 px-0"
+          aria-label={`Restore ${label} to default`}
+          disabled={valuesEqual(value, defaultValue)}
+          onClick={restore}
+        >
+          <RotateCcw size={14} />
+        </Button>
+      </div>
+      {control}
+    </article>
+  );
+}

--- a/desktop/src/renderer/src/features/settings/hermes/HermesSettingEditor.tsx
+++ b/desktop/src/renderer/src/features/settings/hermes/HermesSettingEditor.tsx
@@ -136,7 +136,7 @@ export function HermesSettingEditor({
     <article className="rounded-lg border p-4" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-sunken)" }}>
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <label className="block text-sm font-medium" style={{ color: "var(--text-primary)" }}>{label}</label>
+          <span className="block text-sm font-medium" style={{ color: "var(--text-primary)" }}>{label}</span>
           <code className="text-xs" style={{ color: "var(--text-tertiary)" }}>{path}</code>
         </div>
         <Button

--- a/desktop/src/renderer/src/features/settings/hermes/hermes-form-model.ts
+++ b/desktop/src/renderer/src/features/settings/hermes/hermes-form-model.ts
@@ -42,16 +42,15 @@ export function setConfigValue(
 }
 
 export function configurationCategories(configuration: HermesConfiguration) {
-  const counts = new Map<string, number>();
+  const counts: Record<string, number> = Object.create(null) as Record<string, number>;
   for (const field of Object.values(configuration.fields)) {
-    counts.set(field.category, (counts.get(field.category) ?? 0) + 1);
+    counts[field.category] = (counts[field.category] ?? 0) + 1;
   }
-  const orderedCategories = new Set(configuration.categoryOrder);
   const ordered = [
-    ...configuration.categoryOrder.filter((category) => counts.has(category)),
-    ...[...counts.keys()].filter((category) => !orderedCategories.has(category)).sort(),
+    ...configuration.categoryOrder.filter((category) => counts[category] !== undefined),
+    ...Object.keys(counts).filter((category) => !configuration.categoryOrder.includes(category)).sort(),
   ];
-  return ordered.map((id) => ({ id, label: titleCase(id), count: counts.get(id) ?? 0 }));
+  return ordered.map((id) => ({ id, label: titleCase(id), count: counts[id] ?? 0 }));
 }
 
 export function matchingConfigurationFields(

--- a/desktop/src/renderer/src/features/settings/hermes/hermes-form-model.ts
+++ b/desktop/src/renderer/src/features/settings/hermes/hermes-form-model.ts
@@ -46,9 +46,10 @@ export function configurationCategories(configuration: HermesConfiguration) {
   for (const field of Object.values(configuration.fields)) {
     counts.set(field.category, (counts.get(field.category) ?? 0) + 1);
   }
+  const orderedCategories = new Set(configuration.categoryOrder);
   const ordered = [
     ...configuration.categoryOrder.filter((category) => counts.has(category)),
-    ...[...counts.keys()].filter((category) => !configuration.categoryOrder.includes(category)).sort(),
+    ...[...counts.keys()].filter((category) => !orderedCategories.has(category)).sort(),
   ];
   return ordered.map((id) => ({ id, label: titleCase(id), count: counts.get(id) ?? 0 }));
 }

--- a/desktop/src/renderer/src/features/settings/hermes/hermes-form-model.ts
+++ b/desktop/src/renderer/src/features/settings/hermes/hermes-form-model.ts
@@ -1,0 +1,98 @@
+import {
+  HermesConfigValueSchema,
+  type HermesConfiguration,
+  type HermesEnvironment,
+} from "@matrix-os/contracts";
+
+export function titleCase(value: string): string {
+  return value
+    .replace(/[_-]+/g, " ")
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
+    .join(" ");
+}
+
+export function configValueAt(config: Record<string, unknown>, path: string): unknown {
+  let value: unknown = config;
+  for (const segment of path.split(".")) {
+    if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+    value = (value as Record<string, unknown>)[segment];
+  }
+  return value;
+}
+
+export function setConfigValue(
+  config: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): Record<string, unknown> {
+  const next = structuredClone(config);
+  const segments = path.split(".");
+  let target = next;
+  for (const segment of segments.slice(0, -1)) {
+    const child = target[segment];
+    if (child === null || typeof child !== "object" || Array.isArray(child)) {
+      target[segment] = {};
+    }
+    target = target[segment] as Record<string, unknown>;
+  }
+  target[segments.at(-1)!] = value;
+  return next;
+}
+
+export function configurationCategories(configuration: HermesConfiguration) {
+  const counts = new Map<string, number>();
+  for (const field of Object.values(configuration.fields)) {
+    counts.set(field.category, (counts.get(field.category) ?? 0) + 1);
+  }
+  const ordered = [
+    ...configuration.categoryOrder.filter((category) => counts.has(category)),
+    ...[...counts.keys()].filter((category) => !configuration.categoryOrder.includes(category)).sort(),
+  ];
+  return ordered.map((id) => ({ id, label: titleCase(id), count: counts.get(id) ?? 0 }));
+}
+
+export function matchingConfigurationFields(
+  configuration: HermesConfiguration,
+  search: string,
+  category: string,
+) {
+  const query = search.trim().toLowerCase();
+  return Object.entries(configuration.fields).filter(([path, field]) => {
+    if (!query) return field.category === category;
+    return `${path} ${field.description} ${field.category}`.toLowerCase().includes(query);
+  });
+}
+
+export function matchingCredentials(environment: HermesEnvironment, search: string) {
+  const query = search.trim().toLowerCase();
+  return Object.entries(environment)
+    .filter(([key, entry]) => `${key} ${entry.provider_label} ${entry.description}`.toLowerCase().includes(query))
+    .sort(([leftKey, left], [rightKey, right]) => {
+      if (left.is_set !== right.is_set) return left.is_set ? -1 : 1;
+      return leftKey.localeCompare(rightKey);
+    });
+}
+
+export function parseHermesList(value: string): Array<string | number | boolean> | null {
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(value) as unknown;
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) {
+      console.warn("Unexpected Hermes list parsing failure", error instanceof Error ? error.name : "UnknownError");
+    }
+    return null;
+  }
+  const parsed = HermesConfigValueSchema.safeParse(decoded);
+  return parsed.success && Array.isArray(parsed.data) ? parsed.data : null;
+}
+
+export function valuesEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function isCurrentRequestRevision(activeRevision: number, responseRevision: number): boolean {
+  return activeRevision === responseRevision;
+}

--- a/desktop/src/renderer/src/features/settings/sections/AgentRuntimeSettingsCard.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/AgentRuntimeSettingsCard.tsx
@@ -15,6 +15,7 @@ import {
   type ProviderSetupCommand,
 } from "../../coding-agents/provider-setup-terminal";
 import { Card, Empty } from "./section-kit";
+import { HermesConfigurationDialog } from "../hermes/HermesConfigurationDialog";
 
 const AGENT_PATH = "/api/settings/agent";
 const API_KEY_PATH = "/api/settings/api-key";
@@ -229,12 +230,12 @@ function MessagingProvider({
   view,
   busy,
   onSave,
-  onOpenSetup,
+  onConfigure,
 }: {
   view: AgentSettingsView;
   busy: boolean;
   onSave: (provider: string, model: string) => void;
-  onOpenSetup: (setup: ProviderSetupCommand) => Promise<void>;
+  onConfigure: (runtime: AgentRuntimeId) => void;
 }) {
   const providers = useMemo(() => view.providers.filter((candidate) =>
     candidate.runtime === view.runtime.selected && candidate.scopes.includes("messaging")), [view]);
@@ -296,7 +297,7 @@ function MessagingProvider({
         <Button
           variant="subtle"
           aria-label={`Configure ${statusLabel(view.runtime.selected)} provider`}
-          onClick={() => void onOpenSetup(RUNTIME_SETUP[view.runtime.selected])}
+          onClick={() => onConfigure(view.runtime.selected)}
         >
           <SquareTerminal size={13} />Configure
         </Button>
@@ -314,12 +315,19 @@ function MessagingProvider({
 
 export default function AgentRuntimeSettingsCard() {
   const api = useConnection((state) => state.api);
+  const handle = useConnection((state) => state.handle);
+  const runtimeSlot = useConnection((state) => state.runtimeSlot);
   const openTab = useTabs((state) => state.openTab);
   const [view, setView] = useState<AgentSettingsView | null>(null);
   const [legacy, setLegacy] = useState(false);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [hermesOpen, setHermesOpen] = useState(false);
+
+  useEffect(() => {
+    setHermesOpen(false);
+  }, [handle, runtimeSlot]);
 
   const load = async () => {
     if (!api) return;
@@ -430,6 +438,7 @@ export default function AgentRuntimeSettingsCard() {
   if (!view) return <Card><Empty text={error ?? LOAD_ERROR} /></Card>;
 
   return (
+    <>
     <Card>
       <div className="flex items-start gap-2">
         <Radio size={15} style={{ color: "var(--accent)" }} />
@@ -457,7 +466,10 @@ export default function AgentRuntimeSettingsCard() {
           key={`${view.revision}:${view.runtime.selected}`}
           view={view}
           busy={busy}
-          onOpenSetup={openSetup}
+          onConfigure={(runtime) => {
+            if (runtime === "hermes") setHermesOpen(true);
+            else void openSetup(RUNTIME_SETUP[runtime]);
+          }}
           onSave={(provider, messagingModel) => void mutate({
             provider,
             messagingModel,
@@ -466,5 +478,22 @@ export default function AgentRuntimeSettingsCard() {
         />
       </div>
     </Card>
+    <HermesConfigurationDialog
+      key={`${handle ?? "signed-out"}:${runtimeSlot}`}
+      open={hermesOpen}
+      version={view.runtime.options.find((runtime) => runtime.id === "hermes")?.version}
+      onClose={() => setHermesOpen(false)}
+      onOpenSetupTerminal={() => {
+        setHermesOpen(false);
+        return openSetup(RUNTIME_SETUP.hermes);
+      }}
+      onConfigurationChanged={() => {
+        void load().catch((loadError: unknown) => {
+          console.warn("Hermes provider status refresh failed", loadError instanceof Error ? loadError.name : "UnknownError");
+          setError(LOAD_ERROR);
+        });
+      }}
+    />
+    </>
   );
 }

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -1,7 +1,8 @@
 // Single source of truth for the renderer ↔ trusted-core IPC contract
 // (specs/094-electron-macos-shell/contracts/ipc-contract.md). Both main and
 // preload import this module; every channel is validated on both sides
-// (FR-081). The credential never appears in any schema.
+// (FR-081). The bearer credential never appears in any schema; Hermes provider
+// credentials are accepted only by the bounded write-only setter request.
 import { z } from "zod/v4";
 import {
   ApprovalDecisionRequestSchema,
@@ -23,6 +24,11 @@ import {
   FileSearchResponseSchema,
   FileWriteRequestSchema,
   FileWriteResponseSchema,
+  HermesConfigurationChangeRequestSchema,
+  HermesConfigurationSchema,
+  HermesCredentialRemoveRequestSchema,
+  HermesCredentialSetRequestSchema,
+  HermesEnvironmentSchema,
   ProjectAgentWorkspaceSchema,
   ReviewSnapshotSchema,
   ReviewSummarySchema,
@@ -44,6 +50,7 @@ import { CodingAgentProjectWorkspaceRequestSchema } from "./coding-agent-project
 const Empty = z.object({}).strict();
 
 const Ok = z.object({ ok: z.boolean() }).strict();
+const HermesOk = z.object({ ok: z.literal(true) }).strict();
 const CodingAgentCreateTurnRequestSchema = CreateAgentTurnRequestSchema.extend({
   threadId: ThreadIdSchema,
 }).strict();
@@ -166,6 +173,26 @@ export const INVOKE_CHANNELS = {
   "runtime:update-notification-preferences": {
     request: CodingAgentNotificationPreferencesUpdateSchema,
     response: CodingAgentNotificationPreferencesSchema,
+  },
+  "runtime:get-hermes-configuration": {
+    request: Empty,
+    response: HermesConfigurationSchema,
+  },
+  "runtime:get-hermes-environment": {
+    request: Empty,
+    response: HermesEnvironmentSchema,
+  },
+  "runtime:update-hermes-configuration": {
+    request: HermesConfigurationChangeRequestSchema,
+    response: HermesOk,
+  },
+  "runtime:set-hermes-credential": {
+    request: HermesCredentialSetRequestSchema,
+    response: HermesOk,
+  },
+  "runtime:remove-hermes-credential": {
+    request: HermesCredentialRemoveRequestSchema,
+    response: HermesOk,
   },
   "runtime:get-reviews": {
     request: z.object({ cursor: CursorSchema.optional() }).strict(),

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -8,7 +8,8 @@
   },
   "imports": {
     "#agent-runtime-config": "./src/agent-runtime-config.ts",
-    "#contract-primitives": "./src/primitives.ts"
+    "#contract-primitives": "./src/primitives.ts",
+    "#hermes-configuration": "./src/hermes-configuration.ts"
   },
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/contracts/src/hermes-configuration.ts
+++ b/packages/contracts/src/hermes-configuration.ts
@@ -1,0 +1,90 @@
+import { z } from "zod/v4";
+
+const HermesEnvironmentKeySchema = z.string().regex(/^[A-Z][A-Z0-9_]{0,127}$/);
+export const HermesConfigPathSchema = z.string()
+  .min(1)
+  .max(160)
+  .regex(/^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*){0,7}$/);
+
+export const HermesConfigFieldSchema = z.object({
+  type: z.enum(["boolean", "number", "string", "select", "list"]),
+  description: z.string().max(512),
+  category: z.string().max(64),
+  options: z.array(z.string().max(256)).max(128).optional(),
+}).strict();
+
+export const HermesConfigurationSchema = z.object({
+  config: z.record(z.string(), z.unknown()),
+  defaults: z.record(z.string(), z.unknown()),
+  fields: z.record(HermesConfigPathSchema, HermesConfigFieldSchema)
+    .refine((fields) => Object.keys(fields).length <= 1_024, {
+      message: "Hermes configuration exceeds the field limit",
+    }),
+  categoryOrder: z.array(z.string().max(64)).max(64),
+}).strict();
+
+export const HermesConfigValueSchema = z.union([
+  z.string().max(8_192),
+  z.number().finite(),
+  z.boolean(),
+  z.array(z.union([
+    z.string().max(4_096),
+    z.number().finite(),
+    z.boolean(),
+  ])).max(128),
+]);
+
+export const HermesConfigurationChangeSchema = z.object({
+  path: HermesConfigPathSchema,
+  value: HermesConfigValueSchema,
+}).strict();
+
+export const HermesConfigurationChangeRequestSchema = z.object({
+  changes: z.array(HermesConfigurationChangeSchema).min(1).max(64),
+}).strict();
+
+export const HermesCredentialSetRequestSchema = z.object({
+  key: HermesEnvironmentKeySchema,
+  value: z.string().max(4_096),
+}).strict();
+
+export const HermesCredentialRemoveRequestSchema = z.object({
+  key: HermesEnvironmentKeySchema,
+}).strict();
+
+// Older host bundles may include an already-sanitized config snapshot in a
+// successful response. Consumers use only `ok`; current Gateway routes return
+// the normalized shape.
+export const HermesMutationResponseSchema = z.object({ ok: z.literal(true) }).passthrough();
+
+export const HermesEnvironmentEntrySchema = z.object({
+  is_set: z.boolean(),
+  redacted_value: z.string().max(512).nullable().optional(),
+  description: z.string().max(512).default(""),
+  url: z.string().url().max(2_048).nullable().optional(),
+  category: z.string().max(64).default(""),
+  is_password: z.boolean().default(true),
+  tools: z.array(z.string().max(128)).max(128).default([]),
+  advanced: z.boolean().default(false),
+  channel_managed: z.boolean().default(false),
+  provider: z.string().max(128).default(""),
+  provider_label: z.string().max(128).default(""),
+}).strict();
+
+export const HermesEnvironmentSchema = z
+  .record(HermesEnvironmentKeySchema, HermesEnvironmentEntrySchema)
+  .refine((environment) => Object.keys(environment).length <= 1_024, {
+    message: "Hermes environment metadata exceeds the entry limit",
+  });
+
+export type HermesEnvironmentEntry = z.infer<typeof HermesEnvironmentEntrySchema>;
+export type HermesEnvironment = z.infer<typeof HermesEnvironmentSchema>;
+export type HermesConfigField = z.infer<typeof HermesConfigFieldSchema>;
+export type HermesConfiguration = z.infer<typeof HermesConfigurationSchema>;
+export type HermesConfigValue = z.infer<typeof HermesConfigValueSchema>;
+export type HermesConfigurationChange = z.infer<typeof HermesConfigurationChangeSchema>;
+export type HermesConfigChange = HermesConfigurationChange;
+export type HermesConfigurationChangeRequest = z.infer<typeof HermesConfigurationChangeRequestSchema>;
+export type HermesCredentialSetRequest = z.infer<typeof HermesCredentialSetRequestSchema>;
+export type HermesCredentialRemoveRequest = z.infer<typeof HermesCredentialRemoveRequestSchema>;
+export type HermesMutationResponse = z.infer<typeof HermesMutationResponseSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -4,6 +4,7 @@ import { IsoTimestampSchema, SAFE_SLUG } from "#contract-primitives";
 export const CODEX_VERIFIED_VERSION = "0.146.0";
 export const CODEX_VERIFIED_NPM_PACKAGE = `@openai/codex@${CODEX_VERIFIED_VERSION}`;
 export * from "#agent-runtime-config";
+export * from "#hermes-configuration";
 export { IsoTimestampSchema } from "#contract-primitives";
 
 const SAFE_ID_BODY = /^[A-Za-z0-9_-]+$/;

--- a/packages/gateway/src/routes/hermes.ts
+++ b/packages/gateway/src/routes/hermes.ts
@@ -16,6 +16,15 @@
 
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
+import {
+  HermesConfigurationChangeRequestSchema,
+  HermesCredentialRemoveRequestSchema,
+  HermesCredentialSetRequestSchema,
+  HermesEnvironmentEntrySchema,
+  HermesEnvironmentSchema,
+  type HermesConfigField,
+  type HermesEnvironment,
+} from "@matrix-os/contracts";
 import { z } from "zod/v4";
 import {
   requireRequestPrincipal,
@@ -97,41 +106,11 @@ const ModelSetSchema = z.object({
   base_url: z.string().url().optional(),
 });
 
-const EnvSetSchema = z.object({
-  key: z.string().regex(ENV_KEY),
-  value: z.string().max(4096),
-}).strict();
-
-const EnvDeleteSchema = z.object({
-  key: z.string().regex(ENV_KEY),
-}).strict();
-
 const ConfigListItemSchema = z.union([
   z.string().max(4096),
   z.number().finite(),
   z.boolean(),
 ]);
-
-const ConfigChangeSchema = z.object({
-  path: z.string().min(1).max(160).regex(CONFIG_PATH),
-  value: z.union([
-    z.string().max(8192),
-    z.number().finite(),
-    z.boolean(),
-    z.array(ConfigListItemSchema).max(128),
-  ]),
-}).strict();
-
-const ConfigChangesSchema = z.object({
-  changes: z.array(ConfigChangeSchema).min(1).max(64),
-}).strict();
-
-type ConfigField = {
-  type: "boolean" | "number" | "string" | "select" | "list";
-  description: string;
-  category: string;
-  options?: string[];
-};
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -153,11 +132,11 @@ function sanitizeConfig(value: unknown, path = ""): unknown {
   return sanitized;
 }
 
-function parseConfigSchema(value: unknown): { fields: Record<string, ConfigField>; categoryOrder: string[] } | null {
+function parseConfigSchema(value: unknown): { fields: Record<string, HermesConfigField>; categoryOrder: string[] } | null {
   if (!isPlainRecord(value) || !isPlainRecord(value.fields) || !Array.isArray(value.category_order)) return null;
   const entries = Object.entries(value.fields);
   if (entries.length > MAX_CONFIG_FIELDS) return null;
-  const fields: Record<string, ConfigField> = {};
+  const fields: Record<string, HermesConfigField> = {};
   for (const [path, rawField] of entries) {
     if (!CONFIG_PATH.test(path) || isSensitiveConfigPath(path) || !isPlainRecord(rawField)) continue;
     const type = rawField.type;
@@ -177,7 +156,7 @@ function parseConfigSchema(value: unknown): { fields: Record<string, ConfigField
       }
       options = rawField.options as string[];
     }
-    fields[path] = { type: type as ConfigField["type"], description, category, ...(options ? { options } : {}) };
+    fields[path] = { type: type as HermesConfigField["type"], description, category, ...(options ? { options } : {}) };
   }
   const categoryOrder = value.category_order.filter(
     (category): category is string => typeof category === "string" && category.length <= 64,
@@ -185,7 +164,7 @@ function parseConfigSchema(value: unknown): { fields: Record<string, ConfigField
   return { fields, categoryOrder };
 }
 
-function fieldAcceptsValue(field: ConfigField, value: unknown): boolean {
+function fieldAcceptsValue(field: HermesConfigField, value: unknown): boolean {
   switch (field.type) {
     case "boolean": return typeof value === "boolean";
     case "number": return typeof value === "number" && Number.isFinite(value);
@@ -193,6 +172,32 @@ function fieldAcceptsValue(field: ConfigField, value: unknown): boolean {
     case "select": return typeof value === "string" && Boolean(field.options?.includes(value));
     case "list": return ConfigListItemSchema.array().max(128).safeParse(value).success;
   }
+}
+
+function sanitizeEnvironment(value: unknown): HermesEnvironment | null {
+  if (!isPlainRecord(value) || Object.keys(value).length > 1_024) return null;
+  const environment: Record<string, unknown> = {};
+  for (const [key, rawEntry] of Object.entries(value)) {
+    if (!ENV_KEY.test(key) || !isPlainRecord(rawEntry)) return null;
+    const projected = {
+      is_set: rawEntry.is_set,
+      redacted_value: rawEntry.redacted_value,
+      description: rawEntry.description,
+      url: rawEntry.url,
+      category: rawEntry.category,
+      is_password: rawEntry.is_password,
+      tools: rawEntry.tools,
+      advanced: rawEntry.advanced,
+      channel_managed: rawEntry.channel_managed,
+      provider: rawEntry.provider,
+      provider_label: rawEntry.provider_label,
+    };
+    const parsedEntry = HermesEnvironmentEntrySchema.safeParse(projected);
+    if (!parsedEntry.success) return null;
+    environment[key] = parsedEntry.data;
+  }
+  const parsed = HermesEnvironmentSchema.safeParse(environment);
+  return parsed.success ? parsed.data : null;
 }
 
 function setConfigPath(config: Record<string, unknown>, path: string, value: unknown): void {
@@ -373,7 +378,7 @@ export function createHermesRoutes(_deps: HermesRouteDeps = {}): Hono {
       logIgnoredHermesError("PUT /configuration invalid JSON", err);
       return c.json({ error: "Invalid JSON" }, 400);
     }
-    const parsed = ConfigChangesSchema.safeParse(raw);
+    const parsed = HermesConfigurationChangeRequestSchema.safeParse(raw);
     if (!parsed.success) return c.json({ error: "Invalid request body" }, 400);
 
     try {
@@ -402,7 +407,7 @@ export function createHermesRoutes(_deps: HermesRouteDeps = {}): Hono {
           body: JSON.stringify({ config: updated }),
         });
         if (!saveRes.ok) return upstreamError(c);
-        return c.json({ ok: true, config: sanitizeConfig(updated) });
+        return c.json({ ok: true });
       });
     } catch (err) {
       if (err instanceof HermesUnavailableError) return unavailable(c);
@@ -492,7 +497,8 @@ export function createHermesRoutes(_deps: HermesRouteDeps = {}): Hono {
     try {
       const res = await hermesFetch("/api/env");
       if (!res.ok) return upstreamError(c);
-      return c.json(await res.json());
+      const environment = sanitizeEnvironment(await res.json());
+      return environment ? c.json(environment) : upstreamError(c);
     } catch (err) {
       if (err instanceof HermesUnavailableError) return unavailable(c);
       console.error("[hermes-proxy] GET /env error:", err);
@@ -515,7 +521,7 @@ export function createHermesRoutes(_deps: HermesRouteDeps = {}): Hono {
       return c.json({ error: "Invalid JSON" }, 400);
     }
 
-    const parsed = EnvSetSchema.safeParse(raw);
+    const parsed = HermesCredentialSetRequestSchema.safeParse(raw);
     if (!parsed.success) {
       return c.json({ error: "Invalid request body" }, 400);
     }
@@ -527,7 +533,7 @@ export function createHermesRoutes(_deps: HermesRouteDeps = {}): Hono {
         body: JSON.stringify(parsed.data),
       });
       if (!res.ok) return upstreamError(c);
-      return c.json(await res.json());
+      return c.json({ ok: true });
     } catch (err) {
       if (err instanceof HermesUnavailableError) return unavailable(c);
       console.error("[hermes-proxy] PUT /env error:", err);
@@ -549,7 +555,7 @@ export function createHermesRoutes(_deps: HermesRouteDeps = {}): Hono {
       logIgnoredHermesError("DELETE /env invalid JSON", err);
       return c.json({ error: "Invalid JSON" }, 400);
     }
-    const parsed = EnvDeleteSchema.safeParse(raw);
+    const parsed = HermesCredentialRemoveRequestSchema.safeParse(raw);
     if (!parsed.success) return c.json({ error: "Invalid request body" }, 400);
 
     try {
@@ -559,7 +565,7 @@ export function createHermesRoutes(_deps: HermesRouteDeps = {}): Hono {
         body: JSON.stringify(parsed.data),
       });
       if (!res.ok) return upstreamError(c);
-      return c.json(await res.json());
+      return c.json({ ok: true });
     } catch (err) {
       if (err instanceof HermesUnavailableError) return unavailable(c);
       console.error("[hermes-proxy] DELETE /env error:", err);

--- a/packages/gateway/src/routes/hermes.ts
+++ b/packages/gateway/src/routes/hermes.ts
@@ -183,7 +183,7 @@ function sanitizeEnvironment(value: unknown): HermesEnvironment | null {
       is_set: rawEntry.is_set,
       redacted_value: rawEntry.redacted_value,
       description: rawEntry.description,
-      url: rawEntry.url,
+      url: rawEntry.url === "" ? null : rawEntry.url,
       category: rawEntry.category,
       is_password: rawEntry.is_password,
       tools: rawEntry.tools,

--- a/shell/src/components/settings/sections/HermesConfigurationDialog.tsx
+++ b/shell/src/components/settings/sections/HermesConfigurationDialog.tsx
@@ -129,14 +129,13 @@ async function readHermesConfigurationData() {
 function configurationCategories(configuration: HermesConfiguration | null) {
   if (!configuration) return [];
   // Bounded by the gateway's 1,024-field schema cap.
-  const counts = new Map<string, number>();
+  const counts: Record<string, number> = Object.create(null) as Record<string, number>;
   for (const field of Object.values(configuration.fields)) {
-    counts.set(field.category, (counts.get(field.category) ?? 0) + 1);
+    counts[field.category] = (counts[field.category] ?? 0) + 1;
   }
-  const ordered = configuration.categoryOrder.filter((entry) => counts.has(entry));
-  const orderedSet = new Set(ordered);
-  const remaining = [...counts.keys()].filter((entry) => !orderedSet.has(entry)).sort();
-  return [...ordered, ...remaining].map((id) => ({ id, count: counts.get(id) ?? 0 }));
+  const ordered = configuration.categoryOrder.filter((entry) => counts[entry] !== undefined);
+  const remaining = Object.keys(counts).filter((entry) => !ordered.includes(entry)).sort();
+  return [...ordered, ...remaining].map((id) => ({ id, count: counts[id] ?? 0 }));
 }
 
 function matchingConfigurationFields(configuration: HermesConfiguration | null, search: string, category: string) {

--- a/shell/src/components/settings/sections/HermesConfigurationDialog.tsx
+++ b/shell/src/components/settings/sections/HermesConfigurationDialog.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircle2Icon,
   KeyRoundIcon,
   LoaderCircleIcon,
+  RefreshCwIcon,
   RotateCcwIcon,
   SearchIcon,
   Settings2Icon,
@@ -423,11 +424,14 @@ export function HermesConfigurationDialog({ open, onOpenChange, version }: Herme
   const [tab, setTab] = useState("settings");
   const [loading, setLoading] = useState(open);
   const [saving, setSaving] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [confirmation, setConfirmation] = useState<"refresh" | "close" | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [previousOpen, setPreviousOpen] = useState(open);
   const hasLoadedConfiguration = useRef(false);
   const environmentRevision = useRef(0);
+  const configurationRevision = useRef(0);
   const pendingConfigValues = useRef<Record<string, HermesConfigValue>>({});
   const latestConfiguration = useRef(configuration);
   latestConfiguration.current = configuration;
@@ -468,35 +472,57 @@ export function HermesConfigurationDialog({ open, onOpenChange, version }: Herme
     }
   };
 
-  useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
+  const loadData = async (discardDrafts: boolean, mode: "initial" | "refresh") => {
+    const revision = configurationRevision.current + 1;
+    configurationRevision.current = revision;
+    if (mode === "initial") setLoading(true);
+    else setRefreshing(true);
+    setError(null);
     const environmentReadRevision = environmentRevision.current;
-    void Promise.all([loadHermesConfiguration(), loadHermesEnvironment()]).then(([nextConfig, nextEnv]) => {
-      if (cancelled) return;
+    try {
+      const [nextConfig, nextEnv] = await Promise.all([loadHermesConfiguration(), loadHermesEnvironment()]);
+      if (revision !== configurationRevision.current) return;
       setConfiguration(nextConfig);
       if (environmentReadRevision === environmentRevision.current) setEnvironment(nextEnv);
-      setDrafts((current) => Object.fromEntries(
+      setDrafts((current) => discardDrafts ? {} : Object.fromEntries(
         Object.entries(current).filter(([path]) => Object.hasOwn(nextConfig.fields, path)),
       ));
-      setInvalidFields((current) => Object.fromEntries(
+      setInvalidFields((current) => discardDrafts ? {} : Object.fromEntries(
         Object.entries(current).filter(([path]) => Object.hasOwn(nextConfig.fields, path)),
       ));
-      setFieldTexts((current) => Object.fromEntries(
+      setFieldTexts((current) => discardDrafts ? {} : Object.fromEntries(
         Object.entries(current).filter(([path]) => Object.hasOwn(nextConfig.fields, path)),
       ));
+      setNotice(null);
       if (!hasLoadedConfiguration.current) {
         hasLoadedConfiguration.current = true;
         setCategory(nextConfig.categoryOrder[0] ?? Object.values(nextConfig.fields)[0]?.category ?? "general");
       }
-    }).catch((loadError: unknown) => {
-      if (!cancelled) setError(loadError instanceof HermesConfigurationError ? loadError.message : "Hermes configuration is unavailable.");
-    }).finally(() => {
-      if (!cancelled) setLoading(false);
-    });
+    } catch (loadError) {
+      if (revision === configurationRevision.current) {
+        console.warn("Hermes configuration refresh failed", loadError instanceof Error ? loadError.name : "UnknownError");
+        setError(loadError instanceof HermesConfigurationError ? loadError.message : "Hermes configuration is unavailable.");
+      }
+    } finally {
+      if (revision === configurationRevision.current) {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (!open) {
+      configurationRevision.current += 1;
+      return;
+    }
+    void loadData(false, "initial");
     return () => {
-      cancelled = true;
+      configurationRevision.current += 1;
     };
+    // Opening is the only automatic load. Explicit refreshes call loadData
+    // directly and use the request revision to reject stale responses.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   const categories = configurationCategories(configuration);
@@ -504,6 +530,23 @@ export function HermesConfigurationDialog({ open, onOpenChange, version }: Herme
   const visibleCredentials = matchingCredentials(environment, credentialSearch);
   const invalidFieldCount = Object.keys(invalidFields).length;
   const draftCount = Object.keys(drafts).length;
+
+  const requestRefresh = () => {
+    if (draftCount > 0 || invalidFieldCount > 0) setConfirmation("refresh");
+    else void loadData(true, "refresh");
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) {
+      onOpenChange(true);
+      return;
+    }
+    if (draftCount > 0 || invalidFieldCount > 0) {
+      setConfirmation("close");
+      return;
+    }
+    onOpenChange(false);
+  };
 
   const save = async () => {
     if (!configuration || invalidFieldCount > 0) return;
@@ -564,7 +607,7 @@ export function HermesConfigurationDialog({ open, onOpenChange, version }: Herme
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         className="flex h-[min(86vh,820px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-5xl"
         style={{ zIndex: SHELL_Z_INDEX.popover }}
@@ -580,7 +623,19 @@ export function HermesConfigurationDialog({ open, onOpenChange, version }: Herme
                 A friendly control center generated from the exact Hermes version installed on this computer.
               </DialogDescription>
             </div>
-            {version && <Badge variant="outline">Version {version}</Badge>}
+            <div className="flex items-center gap-2">
+              {version && <Badge variant="outline">Version {version}</Badge>}
+              <Button
+                size="sm"
+                variant="outline"
+                aria-label="Refresh Hermes configuration"
+                disabled={loading || refreshing}
+                onClick={requestRefresh}
+              >
+                <RefreshCwIcon className={`size-3.5 ${refreshing ? "animate-spin" : ""}`} />
+                {refreshing ? "Refreshing…" : "Refresh"}
+              </Button>
+            </div>
           </div>
         </DialogHeader>
 
@@ -775,6 +830,44 @@ export function HermesConfigurationDialog({ open, onOpenChange, version }: Herme
             </TabsContent>
           </Tabs>
         ) : null}
+        {confirmation && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/50 p-6">
+            <div
+              role="alertdialog"
+              aria-modal="true"
+              aria-label={confirmation === "refresh" ? "Confirm refresh" : "Confirm close"}
+              className="w-full max-w-sm rounded-xl border bg-background p-5 shadow-xl"
+            >
+              <h3 className="text-sm font-semibold">
+                {confirmation === "refresh"
+                  ? "Discard unsaved changes and refresh?"
+                  : "Discard unsaved changes and close?"}
+              </h3>
+              <p className="mt-2 text-xs text-muted-foreground">Your unsaved Hermes setting changes will be lost.</p>
+              <div className="mt-4 flex justify-end gap-2">
+                <Button size="sm" variant="outline" onClick={() => setConfirmation(null)}>Cancel</Button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => {
+                    const action = confirmation;
+                    setConfirmation(null);
+                    if (action === "refresh") {
+                      void loadData(true, "refresh");
+                    } else {
+                      setDrafts({});
+                      setInvalidFields({});
+                      setFieldTexts({});
+                      onOpenChange(false);
+                    }
+                  }}
+                >
+                  {confirmation === "refresh" ? "Discard and refresh" : "Discard and close"}
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/shell/src/components/settings/sections/HermesConfigurationDialog.tsx
+++ b/shell/src/components/settings/sections/HermesConfigurationDialog.tsx
@@ -114,6 +114,18 @@ async function attemptCredentialMutation(operation: () => Promise<void>, action:
   }
 }
 
+async function readHermesConfigurationData() {
+  try {
+    const [configuration, environment] = await Promise.all([
+      loadHermesConfiguration(),
+      loadHermesEnvironment(),
+    ]);
+    return { ok: true as const, configuration, environment };
+  } catch (error) {
+    return { ok: false as const, error };
+  }
+}
+
 function configurationCategories(configuration: HermesConfiguration | null) {
   if (!configuration) return [];
   // Bounded by the gateway's 1,024-field schema cap.
@@ -479,36 +491,33 @@ export function HermesConfigurationDialog({ open, onOpenChange, version }: Herme
     else setRefreshing(true);
     setError(null);
     const environmentReadRevision = environmentRevision.current;
-    try {
-      const [nextConfig, nextEnv] = await Promise.all([loadHermesConfiguration(), loadHermesEnvironment()]);
-      if (revision !== configurationRevision.current) return;
-      setConfiguration(nextConfig);
-      if (environmentReadRevision === environmentRevision.current) setEnvironment(nextEnv);
+    const result = await readHermesConfigurationData();
+    if (revision !== configurationRevision.current) return;
+    if (result.ok) {
+      setConfiguration(result.configuration);
+      if (environmentReadRevision === environmentRevision.current) setEnvironment(result.environment);
       setDrafts((current) => discardDrafts ? {} : Object.fromEntries(
-        Object.entries(current).filter(([path]) => Object.hasOwn(nextConfig.fields, path)),
+        Object.entries(current).filter(([path]) => Object.hasOwn(result.configuration.fields, path)),
       ));
       setInvalidFields((current) => discardDrafts ? {} : Object.fromEntries(
-        Object.entries(current).filter(([path]) => Object.hasOwn(nextConfig.fields, path)),
+        Object.entries(current).filter(([path]) => Object.hasOwn(result.configuration.fields, path)),
       ));
       setFieldTexts((current) => discardDrafts ? {} : Object.fromEntries(
-        Object.entries(current).filter(([path]) => Object.hasOwn(nextConfig.fields, path)),
+        Object.entries(current).filter(([path]) => Object.hasOwn(result.configuration.fields, path)),
       ));
       setNotice(null);
       if (!hasLoadedConfiguration.current) {
         hasLoadedConfiguration.current = true;
-        setCategory(nextConfig.categoryOrder[0] ?? Object.values(nextConfig.fields)[0]?.category ?? "general");
+        setCategory(result.configuration.categoryOrder[0]
+          ?? Object.values(result.configuration.fields)[0]?.category
+          ?? "general");
       }
-    } catch (loadError) {
-      if (revision === configurationRevision.current) {
-        console.warn("Hermes configuration refresh failed", loadError instanceof Error ? loadError.name : "UnknownError");
-        setError(loadError instanceof HermesConfigurationError ? loadError.message : "Hermes configuration is unavailable.");
-      }
-    } finally {
-      if (revision === configurationRevision.current) {
-        setLoading(false);
-        setRefreshing(false);
-      }
+    } else {
+      console.warn("Hermes configuration refresh failed", result.error instanceof Error ? result.error.name : "UnknownError");
+      setError(result.error instanceof HermesConfigurationError ? result.error.message : "Hermes configuration is unavailable.");
     }
+    setLoading(false);
+    setRefreshing(false);
   };
 
   useEffect(() => {
@@ -830,20 +839,25 @@ export function HermesConfigurationDialog({ open, onOpenChange, version }: Herme
             </TabsContent>
           </Tabs>
         ) : null}
-        {confirmation && (
-          <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/50 p-6">
-            <div
+        <Dialog open={confirmation !== null} onOpenChange={(nextOpen) => {
+          if (!nextOpen) setConfirmation(null);
+        }}>
+          {confirmation && (
+            <DialogContent
               role="alertdialog"
-              aria-modal="true"
-              aria-label={confirmation === "refresh" ? "Confirm refresh" : "Confirm close"}
-              className="w-full max-w-sm rounded-xl border bg-background p-5 shadow-xl"
+              showCloseButton={false}
+              className="max-w-sm gap-0 p-5"
+              style={{ zIndex: SHELL_Z_INDEX.popover }}
+              overlayStyle={{ zIndex: SHELL_Z_INDEX.popover }}
             >
-              <h3 className="text-sm font-semibold">
+              <DialogTitle className="text-sm">
                 {confirmation === "refresh"
                   ? "Discard unsaved changes and refresh?"
                   : "Discard unsaved changes and close?"}
-              </h3>
-              <p className="mt-2 text-xs text-muted-foreground">Your unsaved Hermes setting changes will be lost.</p>
+              </DialogTitle>
+              <DialogDescription className="mt-2 text-xs">
+                Your unsaved Hermes setting changes will be lost.
+              </DialogDescription>
               <div className="mt-4 flex justify-end gap-2">
                 <Button size="sm" variant="outline" onClick={() => setConfirmation(null)}>Cancel</Button>
                 <Button
@@ -865,9 +879,9 @@ export function HermesConfigurationDialog({ open, onOpenChange, version }: Herme
                   {confirmation === "refresh" ? "Discard and refresh" : "Discard and close"}
                 </Button>
               </div>
-            </div>
-          </div>
-        )}
+            </DialogContent>
+          )}
+        </Dialog>
       </DialogContent>
     </Dialog>
   );

--- a/shell/src/lib/hermes-configuration.ts
+++ b/shell/src/lib/hermes-configuration.ts
@@ -1,49 +1,26 @@
-import { z } from "zod/v4";
+import {
+  HermesConfigurationSchema,
+  HermesEnvironmentSchema,
+  HermesMutationResponseSchema,
+  type HermesConfigChange,
+  type HermesConfigField,
+  type HermesConfigValue,
+  type HermesConfiguration,
+  type HermesEnvironment,
+} from "@matrix-os/contracts";
 import { getGatewayUrl } from "./gateway";
 
 const RESPONSE_LIMIT_BYTES = 1024 * 1024;
 const READ_TIMEOUT_MS = 10_000;
 const WRITE_TIMEOUT_MS = 15_000;
 
-const ConfigFieldSchema = z.object({
-  type: z.enum(["boolean", "number", "string", "select", "list"]),
-  description: z.string().max(512),
-  category: z.string().max(64),
-  options: z.array(z.string().max(256)).max(128).optional(),
-}).strict();
-
-const ConfigurationSchema = z.object({
-  config: z.record(z.string(), z.unknown()),
-  defaults: z.record(z.string(), z.unknown()),
-  fields: z.record(z.string(), ConfigFieldSchema),
-  categoryOrder: z.array(z.string().max(64)).max(64),
-}).strict();
-
-const EnvironmentEntrySchema = z.object({
-  is_set: z.boolean(),
-  redacted_value: z.string().nullable().optional(),
-  description: z.string().max(512).default(""),
-  url: z.string().nullable().optional(),
-  category: z.string().max(64).default(""),
-  is_password: z.boolean().default(true),
-  tools: z.array(z.string()).max(128).default([]),
-  advanced: z.boolean().default(false),
-  channel_managed: z.boolean().default(false),
-  provider: z.string().max(128).default(""),
-  provider_label: z.string().max(128).default(""),
-});
-
-const EnvironmentSchema = z.record(z.string(), EnvironmentEntrySchema);
-const SaveResponseSchema = z.object({ ok: z.literal(true) }).passthrough();
-
-export type HermesConfiguration = z.infer<typeof ConfigurationSchema>;
-export type HermesConfigField = z.infer<typeof ConfigFieldSchema>;
-export type HermesEnvironment = z.infer<typeof EnvironmentSchema>;
-export type HermesConfigValue = string | number | boolean | Array<string | number | boolean>;
-export interface HermesConfigChange {
-  path: string;
-  value: HermesConfigValue;
-}
+export type {
+  HermesConfigChange,
+  HermesConfigField,
+  HermesConfigValue,
+  HermesConfiguration,
+  HermesEnvironment,
+};
 
 export class HermesConfigurationError extends Error {
   constructor(message = "Hermes configuration is unavailable.") {
@@ -91,19 +68,19 @@ async function request(path: string, init: RequestInit = {}, timeoutMs = READ_TI
 }
 
 export async function loadHermesConfiguration(): Promise<HermesConfiguration> {
-  const parsed = ConfigurationSchema.safeParse(await request("/api/hermes/configuration"));
+  const parsed = HermesConfigurationSchema.safeParse(await request("/api/hermes/configuration"));
   if (!parsed.success) throw new HermesConfigurationError();
   return parsed.data;
 }
 
 export async function loadHermesEnvironment(): Promise<HermesEnvironment> {
-  const parsed = EnvironmentSchema.safeParse(await request("/api/hermes/env"));
+  const parsed = HermesEnvironmentSchema.safeParse(await request("/api/hermes/env"));
   if (!parsed.success) throw new HermesConfigurationError();
   return parsed.data;
 }
 
 export async function saveHermesConfiguration(changes: HermesConfigChange[]): Promise<void> {
-  const parsed = SaveResponseSchema.safeParse(await request("/api/hermes/configuration", {
+  const parsed = HermesMutationResponseSchema.safeParse(await request("/api/hermes/configuration", {
     method: "PUT",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ changes }),
@@ -112,7 +89,7 @@ export async function saveHermesConfiguration(changes: HermesConfigChange[]): Pr
 }
 
 export async function saveHermesCredential(key: string, value: string): Promise<void> {
-  const parsed = SaveResponseSchema.safeParse(await request("/api/hermes/env", {
+  const parsed = HermesMutationResponseSchema.safeParse(await request("/api/hermes/env", {
     method: "PUT",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ key, value }),
@@ -121,7 +98,7 @@ export async function saveHermesCredential(key: string, value: string): Promise<
 }
 
 export async function removeHermesCredential(key: string): Promise<void> {
-  const parsed = SaveResponseSchema.safeParse(await request("/api/hermes/env", {
+  const parsed = HermesMutationResponseSchema.safeParse(await request("/api/hermes/env", {
     method: "DELETE",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ key }),

--- a/specs/105-coding-agent-shells/desktop-hermes-configuration-plan.md
+++ b/specs/105-coding-agent-shells/desktop-hermes-configuration-plan.md
@@ -327,7 +327,7 @@ git commit -m "feat(desktop): add Hermes configuration modal"
 - Consumes: Task 3 dialog and the existing `openProviderSetupTerminal()` helper.
 - Produces: matching explicit Refresh semantics in Shell and Desktop, plus the graphical Desktop Configure entry.
 
-- [ ] **Step 1: Add failing Desktop refresh and integration tests**
+- [x] **Step 1: Add failing Desktop refresh and integration tests**
 
 Cover immediate clean refresh, confirmation before dirty refresh, failed refresh preserving last-good data and draft, duplicate-refresh suppression, close confirmation, runtime-scope unmount clearing state, `Configure Hermes` opening the modal, and fallback opening the canonical setup terminal.
 
@@ -339,31 +339,31 @@ fireEvent.click(screen.getByRole("button", { name: "Discard and refresh" }));
 await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("runtime:get-hermes-configuration", {}));
 ```
 
-- [ ] **Step 2: Run Desktop refresh tests and verify red**
+- [x] **Step 2: Run Desktop refresh tests and verify red**
 
 Run: `flox activate -- bun run test -- tests/desktop/hermes-configuration-dialog.test.tsx tests/desktop/agent-section.test.tsx`
 
 Expected: FAIL because refresh confirmation and the graphical entry are not wired.
 
-- [ ] **Step 3: Implement Desktop refresh and integration**
+- [x] **Step 3: Implement Desktop refresh and integration**
 
 Use a bounded monotonically increasing request revision so older refreshes cannot overwrite newer state. On refresh failure, keep current configuration, credentials, and drafts. In `AgentRuntimeSettingsCard`, open the graphical modal only for Hermes; retain OpenClaw and graphical-fallback terminal actions. Call the existing `load()` after successful settings or credential mutations.
 
-- [ ] **Step 4: Add failing Shell refresh tests**
+- [x] **Step 4: Add failing Shell refresh tests**
 
 Assert Shell exposes `Refresh Hermes configuration`, asks before discarding dirty settings, preserves last-good state and drafts when refresh fails, and ignores stale older responses.
 
-- [ ] **Step 5: Implement the matching Shell refresh flow**
+- [x] **Step 5: Implement the matching Shell refresh flow**
 
 Extract the existing load effect body into a stable `loadConfiguration({ discardDrafts: boolean })` operation. Add a Refresh button beside the version, an accessible discard confirmation, request revision protection, and non-destructive failure handling. Do not change Shell styling or share Desktop state.
 
-- [ ] **Step 6: Run integration regression tests and verify green**
+- [x] **Step 6: Run integration regression tests and verify green**
 
 Run: `flox activate -- bun run test -- tests/desktop/hermes-configuration-dialog.test.tsx tests/desktop/agent-section.test.tsx tests/desktop/providers-section.test.tsx tests/shell/hermes-configuration.test.tsx tests/shell/agent-settings.test.tsx`
 
 Expected: all selected tests PASS.
 
-- [ ] **Step 7: Commit refresh and integration**
+- [x] **Step 7: Commit refresh and integration**
 
 ```bash
 git add desktop/src/renderer/src/features/settings/hermes/HermesConfigurationDialog.tsx desktop/src/renderer/src/features/settings/sections/AgentRuntimeSettingsCard.tsx shell/src/components/settings/sections/HermesConfigurationDialog.tsx tests/desktop/hermes-configuration-dialog.test.tsx tests/desktop/agent-section.test.tsx tests/shell/hermes-configuration.test.tsx

--- a/specs/105-coding-agent-shells/desktop-hermes-configuration-plan.md
+++ b/specs/105-coding-agent-shells/desktop-hermes-configuration-plan.md
@@ -383,7 +383,7 @@ git commit -m "feat(desktop): align Hermes setup flow"
 - Consumes: all previous tasks.
 - Produces: release-ready validation evidence and one focused Matrix OS PR.
 
-- [ ] **Step 1: Run focused tests**
+- [x] **Step 1: Run focused tests**
 
 Run:
 
@@ -404,7 +404,7 @@ flox activate -- bun run test -- \
 
 Expected: all selected tests PASS.
 
-- [ ] **Step 2: Run repository quality gates**
+- [x] **Step 2: Run repository quality gates**
 
 Run:
 

--- a/specs/105-coding-agent-shells/desktop-hermes-configuration-plan.md
+++ b/specs/105-coding-agent-shells/desktop-hermes-configuration-plan.md
@@ -1,0 +1,440 @@
+# Desktop Hermes Configuration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Desktop-native graphical Hermes configuration modal whose user flow matches the browser Shell, including explicit refresh and foreground-terminal fallback.
+
+**Architecture:** The Gateway remains the configuration authority. Bounded Hermes schemas live in `@matrix-os/contracts`; Electron main performs authenticated Gateway calls behind typed IPC; Desktop renders its own modal and form components. Shell keeps its existing UI and gains the same explicit refresh semantics without sharing React state or styling.
+
+**Tech Stack:** TypeScript 5.9 strict ESM, Zod 4, React 19, Electron 41, Radix Dialog, Vitest, Testing Library, pnpm 10.33.4, Bun.
+
+## Global Constraints
+
+- Work only in the manual `codex/mat-262-hermes-desktop-setup` worktree based on `origin/main`.
+- Follow TDD for every behavior: failing test, minimal implementation, passing focused test, refactor.
+- Use pnpm for dependency operations and Bun for repository scripts; never npm.
+- Do not add persistence. Gateway and Hermes remain authoritative.
+- Do not return stored credential values to Desktop or Shell; reads contain metadata only and writes are bounded.
+- Every request and response boundary uses strict Zod validation, bounded collections, and fixed safe client errors.
+- Read requests use a 10 second timeout; writes use a 15 second timeout.
+- Do not log request bodies, credential values, raw provider errors, private hosts, or filesystem paths.
+- Keep the existing foreground-terminal setup path as an explicit compatibility fallback.
+- Desktop uses its own design tokens and primitives; do not share Shell JSX or visual tokens.
+- Keep composition files under 500 lines where practical; extract focused field and credential components.
+- Update public user documentation through a separate `FinnaAI/matrix-os-site` PR after behavior is finalized.
+
+---
+
+### Task 1: Shared Hermes configuration contracts
+
+**Files:**
+- Create: `packages/contracts/src/hermes-configuration.ts`
+- Modify: `packages/contracts/package.json`
+- Modify: `packages/contracts/src/index.ts`
+- Modify: `packages/gateway/src/routes/hermes.ts`
+- Modify: `shell/src/lib/hermes-configuration.ts`
+- Test: `tests/contracts/hermes-configuration.test.ts`
+- Test: `tests/gateway/hermes-proxy.test.ts`
+- Test: `tests/shell/hermes-configuration.test.tsx`
+
+**Interfaces:**
+- Produces: `HermesConfigurationSchema`, `HermesEnvironmentSchema`, `HermesConfigurationChangeRequestSchema`, `HermesCredentialSetRequestSchema`, `HermesCredentialRemoveRequestSchema`, `HermesMutationResponseSchema` and their inferred types.
+- Consumes: Zod 4 only.
+
+- [ ] **Step 1: Write failing contract tests**
+
+Add tests that prove valid dynamic configuration parses, more than 1,024 fields is rejected, more than 64 changes is rejected, unsupported nested values are rejected, environment entries expose metadata only, and a response containing a `value` secret is rejected.
+
+```ts
+import {
+  HermesConfigurationChangeRequestSchema,
+  HermesConfigurationSchema,
+  HermesEnvironmentSchema,
+} from "@matrix-os/contracts";
+
+it("rejects stored credential values in environment reads", () => {
+  expect(HermesEnvironmentSchema.safeParse({
+    ANTHROPIC_API_KEY: {
+      is_set: true,
+      value: "secret",
+      description: "Anthropic",
+      category: "model",
+      is_password: true,
+      tools: [],
+      advanced: false,
+      channel_managed: false,
+      provider: "anthropic",
+      provider_label: "Anthropic",
+    },
+  }).success).toBe(false);
+});
+
+it("caps a configuration mutation at 64 changes", () => {
+  const changes = Array.from({ length: 65 }, (_, index) => ({
+    path: `general.field_${index}`,
+    value: true,
+  }));
+  expect(HermesConfigurationChangeRequestSchema.safeParse({ changes }).success).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run the new contract tests and verify red**
+
+Run: `flox activate -- bun run test -- tests/contracts/hermes-configuration.test.ts`
+
+Expected: FAIL because the Hermes schemas are not exported.
+
+- [ ] **Step 3: Implement the bounded shared schemas**
+
+Create a focused contract module with strict objects and these types:
+
+```ts
+export type HermesConfigValue =
+  | string
+  | number
+  | boolean
+  | Array<string | number | boolean>;
+
+export const HermesConfigurationSchema = z.object({
+  config: z.record(z.string(), z.unknown()),
+  defaults: z.record(z.string(), z.unknown()),
+  fields: z.record(HermesConfigPathSchema, HermesConfigFieldSchema)
+    .refine((fields) => Object.keys(fields).length <= 1_024),
+  categoryOrder: z.array(z.string().max(64)).max(64),
+}).strict();
+```
+
+Use a package-local import alias in `packages/contracts/package.json`, export the module from `index.ts`, replace the duplicate Shell response schemas, and reuse the shared request schemas at Gateway route boundaries. Keep Gateway-sensitive-path filtering and schema-aware value checks in the Gateway.
+
+- [ ] **Step 4: Run contract, Gateway, and Shell tests and verify green**
+
+Run: `flox activate -- bun run test -- tests/contracts/hermes-configuration.test.ts tests/gateway/hermes-proxy.test.ts tests/shell/hermes-configuration.test.tsx`
+
+Expected: all selected tests PASS.
+
+- [ ] **Step 5: Commit the contract slice**
+
+```bash
+git add packages/contracts packages/gateway/src/routes/hermes.ts shell/src/lib/hermes-configuration.ts tests/contracts/hermes-configuration.test.ts tests/gateway/hermes-proxy.test.ts tests/shell/hermes-configuration.test.tsx
+git commit -m "feat(contracts): share Hermes configuration schemas"
+```
+
+---
+
+### Task 2: Trusted Desktop Hermes client and typed IPC
+
+**Files:**
+- Create: `desktop/src/main/hermes/configuration-client.ts`
+- Modify: `desktop/src/shared/ipc-contract.ts`
+- Modify: `desktop/src/main/ipc/handlers.ts`
+- Modify: `desktop/src/main/index.ts`
+- Test: `tests/desktop/hermes-configuration-client.test.ts`
+- Test: `tests/desktop/ipc-contract.test.ts`
+- Test: `tests/desktop/ipc-handlers.test.ts`
+
+**Interfaces:**
+- Consumes: shared Hermes schemas from Task 1 and `AuthService`.
+- Produces: five typed IPC channels named in the approved design and main-client functions with matching request/response types.
+
+- [ ] **Step 1: Write failing main-client tests**
+
+Cover bearer authentication, selected runtime query routing, 10/15 second abort signals, strict response validation, generic errors, bounded request validation, and DELETE bodies.
+
+```ts
+it("routes configuration reads through the selected runtime", async () => {
+  fetchMock.mockResolvedValue(response(configuration));
+  await fetchHermesConfiguration(authWithRuntime("preview"), fetchMock);
+  expect(fetchMock).toHaveBeenCalledWith(
+    "https://app.matrix-os.com/api/hermes/configuration?runtime=preview",
+    expect.objectContaining({
+      method: "GET",
+      headers: expect.objectContaining({ Authorization: "Bearer device-token" }),
+    }),
+  );
+});
+
+it("never exposes an upstream body when a write fails", async () => {
+  fetchMock.mockResolvedValue(new Response("provider failed at /home/matrix", { status: 502 }));
+  await expect(updateHermesConfiguration(auth, { changes: [{ path: "general.model", value: "x" }] }, fetchMock))
+    .rejects.toThrow("Hermes configuration could not be saved.");
+});
+```
+
+- [ ] **Step 2: Run the client test and verify red**
+
+Run: `flox activate -- bun run test -- tests/desktop/hermes-configuration-client.test.ts`
+
+Expected: FAIL because `desktop/src/main/hermes/configuration-client.ts` does not exist.
+
+- [ ] **Step 3: Implement the trusted main client**
+
+Export these functions:
+
+```ts
+export function fetchHermesConfiguration(auth: AuthService, fetchFn?: FetchFn): Promise<HermesConfiguration>;
+export function fetchHermesEnvironment(auth: AuthService, fetchFn?: FetchFn): Promise<HermesEnvironment>;
+export function updateHermesConfiguration(auth: AuthService, request: HermesConfigurationChangeRequest, fetchFn?: FetchFn): Promise<{ ok: true }>;
+export function setHermesCredential(auth: AuthService, request: HermesCredentialSetRequest, fetchFn?: FetchFn): Promise<{ ok: true }>;
+export function removeHermesCredential(auth: AuthService, request: HermesCredentialRemoveRequest, fetchFn?: FetchFn): Promise<{ ok: true }>;
+```
+
+Build URLs from `auth.getGatewayOrigin()` and `auth.getStatus().runtimeSlot`, require `auth.getToken()`, parse all bodies with shared schemas, and throw only `Hermes configuration is unavailable.` or `Hermes configuration could not be saved.`.
+
+- [ ] **Step 4: Write failing IPC contract and handler tests**
+
+Assert malformed paths, keys, and oversized credential values are rejected in preload/main contracts; valid calls reach the injected handler dependency; returned secrets or malformed responses are rejected.
+
+```ts
+expect(INVOKE_CHANNELS["runtime:set-hermes-credential"].request.safeParse({
+  key: "ANTHROPIC_API_KEY",
+  value: "x".repeat(4_097),
+}).success).toBe(false);
+```
+
+- [ ] **Step 5: Add the typed IPC channels and registration-time dependencies**
+
+Extend `INVOKE_CHANNELS` with:
+
+```ts
+"runtime:get-hermes-configuration": { request: Empty, response: HermesConfigurationSchema },
+"runtime:get-hermes-environment": { request: Empty, response: HermesEnvironmentSchema },
+"runtime:update-hermes-configuration": { request: HermesConfigurationChangeRequestSchema, response: HermesMutationResponseSchema },
+"runtime:set-hermes-credential": { request: HermesCredentialSetRequestSchema, response: HermesMutationResponseSchema },
+"runtime:remove-hermes-credential": { request: HermesCredentialRemoveRequestSchema, response: HermesMutationResponseSchema },
+```
+
+Add five required functions to `HandlerContext`, register them directly, and inject the Task 2 main-client functions from `desktop/src/main/index.ts`.
+
+- [ ] **Step 6: Run Desktop client and IPC tests and verify green**
+
+Run: `flox activate -- bun run test -- tests/desktop/hermes-configuration-client.test.ts tests/desktop/ipc-contract.test.ts tests/desktop/ipc-handlers.test.ts`
+
+Expected: all selected tests PASS.
+
+- [ ] **Step 7: Commit the trusted transport slice**
+
+```bash
+git add desktop/src/main/hermes/configuration-client.ts desktop/src/shared/ipc-contract.ts desktop/src/main/ipc/handlers.ts desktop/src/main/index.ts tests/desktop/hermes-configuration-client.test.ts tests/desktop/ipc-contract.test.ts tests/desktop/ipc-handlers.test.ts
+git commit -m "feat(desktop): add Hermes configuration IPC"
+```
+
+---
+
+### Task 3: Desktop form model and native modal
+
+**Files:**
+- Create: `desktop/src/renderer/src/features/settings/hermes/hermes-form-model.ts`
+- Create: `desktop/src/renderer/src/features/settings/hermes/HermesSettingEditor.tsx`
+- Create: `desktop/src/renderer/src/features/settings/hermes/HermesCredentialRow.tsx`
+- Create: `desktop/src/renderer/src/features/settings/hermes/HermesConfigurationDialog.tsx`
+- Test: `tests/desktop/hermes-form-model.test.ts`
+- Test: `tests/desktop/hermes-configuration-dialog.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 1 contract types and Task 2 IPC channels through `invoke()`.
+- Produces: `HermesConfigurationDialog({ open, version, onClose, onOpenSetupTerminal, onConfigurationChanged })`.
+
+- [ ] **Step 1: Write failing pure-model tests**
+
+Test category ordering/counts, settings and credential search, nested value access, typed list parsing, draft comparison, and stale revision rejection.
+
+```ts
+it("searches all categories without changing the selected category", () => {
+  expect(matchingConfigurationFields(configuration, "context", "general").map(([path]) => path))
+    .toEqual(["agent.model_context_length"]);
+});
+
+it("accepts only bounded scalar JSON lists", () => {
+  expect(parseHermesList('["codex", 2, true]')).toEqual(["codex", 2, true]);
+  expect(parseHermesList('[{"secret":"x"}]')).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run the model tests and verify red**
+
+Run: `flox activate -- bun run test -- tests/desktop/hermes-form-model.test.ts`
+
+Expected: FAIL because the form-model module does not exist.
+
+- [ ] **Step 3: Implement the focused pure model**
+
+Export `titleCase`, `configValueAt`, `setConfigValue`, `configurationCategories`, `matchingConfigurationFields`, `matchingCredentials`, `parseHermesList`, and `valuesEqual`. Keep all functions pure and bounded by the shared contract.
+
+- [ ] **Step 4: Write failing modal interaction tests**
+
+Mock `invoke()` and cover initial parallel load, Desktop-token modal rendering, tabs, category navigation, search, field controls, invalid values, discard, save, write-only credential set/remove, loading states, fixed safe errors, and terminal fallback.
+
+```tsx
+render(<HermesConfigurationDialog
+  open
+  version="0.20.0"
+  onClose={onClose}
+  onOpenSetupTerminal={onOpenSetupTerminal}
+  onConfigurationChanged={onConfigurationChanged}
+/>);
+
+expect(await screen.findByRole("heading", { name: "Configure Hermes" })).toBeVisible();
+fireEvent.change(screen.getByLabelText("Default model"), { target: { value: "anthropic/claude-opus-4.6" } });
+fireEvent.click(screen.getByRole("button", { name: "Save Hermes settings" }));
+await waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+  "runtime:update-hermes-configuration",
+  { changes: [{ path: "general.model", value: "anthropic/claude-opus-4.6" }] },
+));
+```
+
+- [ ] **Step 5: Implement the Desktop-native modal**
+
+Use Radix Dialog for focus containment and Desktop `Button`/token variables for appearance. Keep the composition component below 500 lines by extracting field and credential rows. Configuration values live only in component state. Credential input clears immediately after accepted mutation and is never echoed into status copy.
+
+The public props are:
+
+```ts
+interface HermesConfigurationDialogProps {
+  open: boolean;
+  version?: string;
+  onClose: () => void;
+  onOpenSetupTerminal: () => Promise<void>;
+  onConfigurationChanged: () => Promise<void>;
+}
+```
+
+- [ ] **Step 6: Run model and modal tests and verify green**
+
+Run: `flox activate -- bun run test -- tests/desktop/hermes-form-model.test.ts tests/desktop/hermes-configuration-dialog.test.tsx`
+
+Expected: all selected tests PASS.
+
+- [ ] **Step 7: Commit the native modal slice**
+
+```bash
+git add desktop/src/renderer/src/features/settings/hermes tests/desktop/hermes-form-model.test.ts tests/desktop/hermes-configuration-dialog.test.tsx
+git commit -m "feat(desktop): add Hermes configuration modal"
+```
+
+---
+
+### Task 4: Refresh, discard confirmation, and settings integration
+
+**Files:**
+- Modify: `desktop/src/renderer/src/features/settings/hermes/HermesConfigurationDialog.tsx`
+- Modify: `desktop/src/renderer/src/features/settings/sections/AgentRuntimeSettingsCard.tsx`
+- Modify: `shell/src/components/settings/sections/HermesConfigurationDialog.tsx`
+- Test: `tests/desktop/hermes-configuration-dialog.test.tsx`
+- Test: `tests/desktop/agent-section.test.tsx`
+- Test: `tests/shell/hermes-configuration.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 3 dialog and the existing `openProviderSetupTerminal()` helper.
+- Produces: matching explicit Refresh semantics in Shell and Desktop, plus the graphical Desktop Configure entry.
+
+- [ ] **Step 1: Add failing Desktop refresh and integration tests**
+
+Cover immediate clean refresh, confirmation before dirty refresh, failed refresh preserving last-good data and draft, duplicate-refresh suppression, close confirmation, runtime-scope unmount clearing state, `Configure Hermes` opening the modal, and fallback opening the canonical setup terminal.
+
+```tsx
+fireEvent.change(screen.getByLabelText("Default model"), { target: { value: "local-change" } });
+fireEvent.click(screen.getByRole("button", { name: "Refresh Hermes configuration" }));
+expect(screen.getByRole("dialog", { name: "Discard unsaved changes?" })).toBeVisible();
+fireEvent.click(screen.getByRole("button", { name: "Discard and refresh" }));
+await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("runtime:get-hermes-configuration", {}));
+```
+
+- [ ] **Step 2: Run Desktop refresh tests and verify red**
+
+Run: `flox activate -- bun run test -- tests/desktop/hermes-configuration-dialog.test.tsx tests/desktop/agent-section.test.tsx`
+
+Expected: FAIL because refresh confirmation and the graphical entry are not wired.
+
+- [ ] **Step 3: Implement Desktop refresh and integration**
+
+Use a bounded monotonically increasing request revision so older refreshes cannot overwrite newer state. On refresh failure, keep current configuration, credentials, and drafts. In `AgentRuntimeSettingsCard`, open the graphical modal only for Hermes; retain OpenClaw and graphical-fallback terminal actions. Call the existing `load()` after successful settings or credential mutations.
+
+- [ ] **Step 4: Add failing Shell refresh tests**
+
+Assert Shell exposes `Refresh Hermes configuration`, asks before discarding dirty settings, preserves last-good state and drafts when refresh fails, and ignores stale older responses.
+
+- [ ] **Step 5: Implement the matching Shell refresh flow**
+
+Extract the existing load effect body into a stable `loadConfiguration({ discardDrafts: boolean })` operation. Add a Refresh button beside the version, an accessible discard confirmation, request revision protection, and non-destructive failure handling. Do not change Shell styling or share Desktop state.
+
+- [ ] **Step 6: Run integration regression tests and verify green**
+
+Run: `flox activate -- bun run test -- tests/desktop/hermes-configuration-dialog.test.tsx tests/desktop/agent-section.test.tsx tests/desktop/providers-section.test.tsx tests/shell/hermes-configuration.test.tsx tests/shell/agent-settings.test.tsx`
+
+Expected: all selected tests PASS.
+
+- [ ] **Step 7: Commit refresh and integration**
+
+```bash
+git add desktop/src/renderer/src/features/settings/hermes/HermesConfigurationDialog.tsx desktop/src/renderer/src/features/settings/sections/AgentRuntimeSettingsCard.tsx shell/src/components/settings/sections/HermesConfigurationDialog.tsx tests/desktop/hermes-configuration-dialog.test.tsx tests/desktop/agent-section.test.tsx tests/shell/hermes-configuration.test.tsx
+git commit -m "feat(desktop): align Hermes setup flow"
+```
+
+---
+
+### Task 5: Full verification, live Desktop evidence, and handoff
+
+**Files:**
+- Modify: `specs/105-coding-agent-shells/desktop-hermes-configuration.md` only if implementation reveals a reviewed design correction
+- Modify: `workpad.md` locally; do not commit it
+- External follow-up: `FinnaAI/matrix-os-site` public documentation PR
+
+**Interfaces:**
+- Consumes: all previous tasks.
+- Produces: release-ready validation evidence and one focused Matrix OS PR.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+flox activate -- bun run test -- \
+  tests/contracts/hermes-configuration.test.ts \
+  tests/gateway/hermes-proxy.test.ts \
+  tests/shell/hermes-configuration.test.tsx \
+  tests/shell/agent-settings.test.tsx \
+  tests/desktop/hermes-configuration-client.test.ts \
+  tests/desktop/hermes-form-model.test.ts \
+  tests/desktop/hermes-configuration-dialog.test.tsx \
+  tests/desktop/agent-section.test.tsx \
+  tests/desktop/providers-section.test.tsx \
+  tests/desktop/ipc-contract.test.ts \
+  tests/desktop/ipc-handlers.test.ts
+```
+
+Expected: all selected tests PASS.
+
+- [ ] **Step 2: Run repository quality gates**
+
+Run:
+
+```bash
+flox activate -- bun run typecheck
+flox activate -- bun run check:patterns:diff
+flox activate -- pnpm exec react-doctor@latest desktop/src/renderer/src shell/src
+flox activate -- bun run build:desktop
+git diff --check origin/main...HEAD
+```
+
+Expected: commands PASS, or pre-existing non-blocking baseline findings are recorded exactly and separated from MAT-262 changes.
+
+- [ ] **Step 3: Run live Electron verification**
+
+Launch `flox activate -- bun run dev:desktop`, sign in to the selected Matrix computer, and verify:
+
+1. `Settings -> Agent -> Configure Hermes` opens the Desktop-native modal.
+2. Settings and Credentials match the Shell operation order.
+3. Clean Refresh reloads immediately.
+4. Dirty Refresh and dirty Close require confirmation.
+5. Save, discard, credential set/remove, failure preservation, runtime switch, and terminal fallback behave as specified.
+6. Keyboard navigation, Escape handling, focus containment, and Desktop zoom remain usable.
+
+Capture English-labeled Desktop and Shell screenshots for the PR.
+
+- [ ] **Step 4: Sync the existing Linear workpad comment**
+
+Update comment `3c74d75b-3c9e-46e7-b84e-a3171316a949` with implementation status, exact validation, screenshot/PR links, remaining risks, and the separate docs follow-up. Do not create duplicate milestone comments.
+
+- [ ] **Step 5: Prepare the focused PR**
+
+Use a Conventional Commit PR title such as `feat(desktop): align Hermes configuration flow`. Include Summary, Tests, Screenshots, and the mandatory Invariants section covering source of truth, write serialization scope, acceptable orphan states, auth source of truth, and deferred scope. Attach the PR to MAT-262 and request Greptile review; do not merge before 5/5.

--- a/specs/105-coding-agent-shells/desktop-hermes-configuration-plan.md
+++ b/specs/105-coding-agent-shells/desktop-hermes-configuration-plan.md
@@ -136,7 +136,7 @@ git commit -m "feat(contracts): share Hermes configuration schemas"
 - Consumes: shared Hermes schemas from Task 1 and `AuthService`.
 - Produces: five typed IPC channels named in the approved design and main-client functions with matching request/response types.
 
-- [ ] **Step 1: Write failing main-client tests**
+- [x] **Step 1: Write failing main-client tests**
 
 Cover bearer authentication, selected runtime query routing, 10/15 second abort signals, strict response validation, generic errors, bounded request validation, and DELETE bodies.
 
@@ -160,13 +160,13 @@ it("never exposes an upstream body when a write fails", async () => {
 });
 ```
 
-- [ ] **Step 2: Run the client test and verify red**
+- [x] **Step 2: Run the client test and verify red**
 
 Run: `flox activate -- bun run test -- tests/desktop/hermes-configuration-client.test.ts`
 
 Expected: FAIL because `desktop/src/main/hermes/configuration-client.ts` does not exist.
 
-- [ ] **Step 3: Implement the trusted main client**
+- [x] **Step 3: Implement the trusted main client**
 
 Export these functions:
 
@@ -180,7 +180,7 @@ export function removeHermesCredential(auth: AuthService, request: HermesCredent
 
 Build URLs from `auth.getGatewayOrigin()` and `auth.getStatus().runtimeSlot`, require `auth.getToken()`, parse all bodies with shared schemas, and throw only `Hermes configuration is unavailable.` or `Hermes configuration could not be saved.`.
 
-- [ ] **Step 4: Write failing IPC contract and handler tests**
+- [x] **Step 4: Write failing IPC contract and handler tests**
 
 Assert malformed paths, keys, and oversized credential values are rejected in preload/main contracts; valid calls reach the injected handler dependency; returned secrets or malformed responses are rejected.
 
@@ -191,7 +191,7 @@ expect(INVOKE_CHANNELS["runtime:set-hermes-credential"].request.safeParse({
 }).success).toBe(false);
 ```
 
-- [ ] **Step 5: Add the typed IPC channels and registration-time dependencies**
+- [x] **Step 5: Add the typed IPC channels and registration-time dependencies**
 
 Extend `INVOKE_CHANNELS` with:
 
@@ -205,13 +205,13 @@ Extend `INVOKE_CHANNELS` with:
 
 Add five required functions to `HandlerContext`, register them directly, and inject the Task 2 main-client functions from `desktop/src/main/index.ts`.
 
-- [ ] **Step 6: Run Desktop client and IPC tests and verify green**
+- [x] **Step 6: Run Desktop client and IPC tests and verify green**
 
 Run: `flox activate -- bun run test -- tests/desktop/hermes-configuration-client.test.ts tests/desktop/ipc-contract.test.ts tests/desktop/ipc-handlers.test.ts`
 
 Expected: all selected tests PASS.
 
-- [ ] **Step 7: Commit the trusted transport slice**
+- [x] **Step 7: Commit the trusted transport slice**
 
 ```bash
 git add desktop/src/main/hermes/configuration-client.ts desktop/src/shared/ipc-contract.ts desktop/src/main/ipc/handlers.ts desktop/src/main/index.ts tests/desktop/hermes-configuration-client.test.ts tests/desktop/ipc-contract.test.ts tests/desktop/ipc-handlers.test.ts

--- a/specs/105-coding-agent-shells/desktop-hermes-configuration-plan.md
+++ b/specs/105-coding-agent-shells/desktop-hermes-configuration-plan.md
@@ -234,7 +234,7 @@ git commit -m "feat(desktop): add Hermes configuration IPC"
 - Consumes: Task 1 contract types and Task 2 IPC channels through `invoke()`.
 - Produces: `HermesConfigurationDialog({ open, version, onClose, onOpenSetupTerminal, onConfigurationChanged })`.
 
-- [ ] **Step 1: Write failing pure-model tests**
+- [x] **Step 1: Write failing pure-model tests**
 
 Test category ordering/counts, settings and credential search, nested value access, typed list parsing, draft comparison, and stale revision rejection.
 
@@ -250,17 +250,17 @@ it("accepts only bounded scalar JSON lists", () => {
 });
 ```
 
-- [ ] **Step 2: Run the model tests and verify red**
+- [x] **Step 2: Run the model tests and verify red**
 
 Run: `flox activate -- bun run test -- tests/desktop/hermes-form-model.test.ts`
 
 Expected: FAIL because the form-model module does not exist.
 
-- [ ] **Step 3: Implement the focused pure model**
+- [x] **Step 3: Implement the focused pure model**
 
 Export `titleCase`, `configValueAt`, `setConfigValue`, `configurationCategories`, `matchingConfigurationFields`, `matchingCredentials`, `parseHermesList`, and `valuesEqual`. Keep all functions pure and bounded by the shared contract.
 
-- [ ] **Step 4: Write failing modal interaction tests**
+- [x] **Step 4: Write failing modal interaction tests**
 
 Mock `invoke()` and cover initial parallel load, Desktop-token modal rendering, tabs, category navigation, search, field controls, invalid values, discard, save, write-only credential set/remove, loading states, fixed safe errors, and terminal fallback.
 
@@ -282,7 +282,7 @@ await waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
 ));
 ```
 
-- [ ] **Step 5: Implement the Desktop-native modal**
+- [x] **Step 5: Implement the Desktop-native modal**
 
 Use Radix Dialog for focus containment and Desktop `Button`/token variables for appearance. Keep the composition component below 500 lines by extracting field and credential rows. Configuration values live only in component state. Credential input clears immediately after accepted mutation and is never echoed into status copy.
 
@@ -298,13 +298,13 @@ interface HermesConfigurationDialogProps {
 }
 ```
 
-- [ ] **Step 6: Run model and modal tests and verify green**
+- [x] **Step 6: Run model and modal tests and verify green**
 
 Run: `flox activate -- bun run test -- tests/desktop/hermes-form-model.test.ts tests/desktop/hermes-configuration-dialog.test.tsx`
 
 Expected: all selected tests PASS.
 
-- [ ] **Step 7: Commit the native modal slice**
+- [x] **Step 7: Commit the native modal slice**
 
 ```bash
 git add desktop/src/renderer/src/features/settings/hermes tests/desktop/hermes-form-model.test.ts tests/desktop/hermes-configuration-dialog.test.tsx

--- a/specs/105-coding-agent-shells/desktop-hermes-configuration-plan.md
+++ b/specs/105-coding-agent-shells/desktop-hermes-configuration-plan.md
@@ -41,7 +41,7 @@
 - Produces: `HermesConfigurationSchema`, `HermesEnvironmentSchema`, `HermesConfigurationChangeRequestSchema`, `HermesCredentialSetRequestSchema`, `HermesCredentialRemoveRequestSchema`, `HermesMutationResponseSchema` and their inferred types.
 - Consumes: Zod 4 only.
 
-- [ ] **Step 1: Write failing contract tests**
+- [x] **Step 1: Write failing contract tests**
 
 Add tests that prove valid dynamic configuration parses, more than 1,024 fields is rejected, more than 64 changes is rejected, unsupported nested values are rejected, environment entries expose metadata only, and a response containing a `value` secret is rejected.
 
@@ -78,13 +78,13 @@ it("caps a configuration mutation at 64 changes", () => {
 });
 ```
 
-- [ ] **Step 2: Run the new contract tests and verify red**
+- [x] **Step 2: Run the new contract tests and verify red**
 
 Run: `flox activate -- bun run test -- tests/contracts/hermes-configuration.test.ts`
 
 Expected: FAIL because the Hermes schemas are not exported.
 
-- [ ] **Step 3: Implement the bounded shared schemas**
+- [x] **Step 3: Implement the bounded shared schemas**
 
 Create a focused contract module with strict objects and these types:
 
@@ -106,13 +106,13 @@ export const HermesConfigurationSchema = z.object({
 
 Use a package-local import alias in `packages/contracts/package.json`, export the module from `index.ts`, replace the duplicate Shell response schemas, and reuse the shared request schemas at Gateway route boundaries. Keep Gateway-sensitive-path filtering and schema-aware value checks in the Gateway.
 
-- [ ] **Step 4: Run contract, Gateway, and Shell tests and verify green**
+- [x] **Step 4: Run contract, Gateway, and Shell tests and verify green**
 
 Run: `flox activate -- bun run test -- tests/contracts/hermes-configuration.test.ts tests/gateway/hermes-proxy.test.ts tests/shell/hermes-configuration.test.tsx`
 
 Expected: all selected tests PASS.
 
-- [ ] **Step 5: Commit the contract slice**
+- [x] **Step 5: Commit the contract slice**
 
 ```bash
 git add packages/contracts packages/gateway/src/routes/hermes.ts shell/src/lib/hermes-configuration.ts tests/contracts/hermes-configuration.test.ts tests/gateway/hermes-proxy.test.ts tests/shell/hermes-configuration.test.tsx

--- a/specs/105-coding-agent-shells/desktop-hermes-configuration.md
+++ b/specs/105-coding-agent-shells/desktop-hermes-configuration.md
@@ -1,0 +1,213 @@
+# Desktop Hermes Configuration
+
+**Linear:** MAT-262
+
+**Status:** Approved design
+
+**Scope:** Electron Desktop provider setup
+
+## Problem
+
+The browser Shell exposes a structured Hermes control center with searchable
+settings and write-only credential management. Electron Desktop currently
+opens the interactive Hermes provider wizard in a foreground terminal. The
+terminal remains a necessary compatibility and recovery path, but it should
+not be the primary setup experience when the installed Hermes version exposes
+the structured dashboard API.
+
+## Goals
+
+- Make the Desktop Hermes setup flow match the current browser Shell flow.
+- Render the experience with Desktop design primitives and theme tokens.
+- Support dynamic settings, write-only credentials, refresh, discard, save,
+  and safe terminal fallback.
+- Keep the Gateway authoritative for Hermes configuration and credential
+  mutations.
+- Preserve the existing foreground-terminal setup action for unsupported or
+  unavailable structured setup.
+
+## Non-goals
+
+- Sharing React components, styling, or view state between Shell and Desktop.
+- Requiring both surfaces to ship future UI changes in lockstep.
+- Redesigning Hermes installation, runtime switching, coding-agent provider
+  cards, or the terminal runtime.
+- Returning stored credential values to the renderer.
+- Replacing the Hermes dashboard API or persisting configuration in Desktop.
+
+## User Flow
+
+The primary flow is:
+
+1. Open `Settings`.
+2. Open the agent/runtime settings section.
+3. Select `Configure Hermes`.
+4. Load structured Settings and Credentials metadata for the selected Matrix
+   computer.
+5. Search, inspect, and edit settings or manage a credential.
+6. Save or discard changes.
+7. Refresh live configuration and provider/runtime state.
+
+When structured setup is unavailable, the modal explains that configuration
+cannot be loaded and offers `Open setup terminal`. Desktop must not silently
+replace the graphical flow with a terminal tab.
+
+## Desktop UI
+
+The feature is a large native Desktop modal. It follows Desktop typography,
+spacing, color, focus, button, dialog, and status primitives rather than
+copying Shell JSX or Shell visual tokens.
+
+### Header
+
+- Hermes identity and `Configure Hermes` title
+- Installed Hermes version when available
+- `Refresh` action with an in-progress state
+- Close action
+
+### Settings tab
+
+- Search across field path, description, and category
+- Category navigation with bounded field counts
+- Dynamic controls for boolean, number, string, select, and bounded list fields
+- Per-field restore-to-default action
+- Invalid input remains visible and blocks save
+
+### Credentials tab
+
+- Search across key, provider label, and description
+- Configured credentials sort before unconfigured credentials
+- Add and replace write-only values
+- Two-step confirmation before removal
+- Channel-managed credentials remain hidden or non-editable according to the
+  Gateway contract
+
+### Footer
+
+- Unsaved-change count for settings
+- `Discard`
+- `Save changes`
+
+Credential mutations commit per row. The settings footer does not retain or
+submit credential values.
+
+## Refresh and Close Behavior
+
+- Refresh reloads configuration schema, current configuration, credential
+  metadata, and current provider/runtime status.
+- If settings contain unsaved changes, Refresh asks for confirmation before
+  discarding them.
+- A failed refresh keeps the last successfully loaded content and any unsaved
+  draft visible.
+- Refresh is disabled while a refresh is already in progress.
+- Closing with unsaved settings requires confirmation. Closing without changes
+  is immediate.
+- Runtime switch, sign-out, or authenticated identity change clears modal data
+  before another runtime can be displayed.
+
+## Architecture
+
+```text
+Desktop Hermes modal
+  -> typed preload IPC
+  -> validated main-process handler
+  -> authenticated Gateway Hermes routes
+  -> fixed-loopback Hermes dashboard API
+```
+
+Shell continues to call the authenticated Gateway routes through its browser
+client. Shell and Desktop share API contracts where useful, but do not share UI
+components or view state.
+
+### Contracts
+
+`@matrix-os/contracts` should own bounded schemas for:
+
+- configuration fields and category order
+- sanitized configuration and defaults
+- environment metadata without stored secret values
+- bounded configuration change requests
+- credential set and removal requests
+- successful mutation responses
+
+The Gateway remains responsible for route-boundary validation, sensitive
+configuration filtering, serialized configuration writes, body limits, and
+safe upstream error mapping.
+
+### Desktop main process
+
+The main process owns all authenticated requests. It:
+
+- adds the device bearer token and selected runtime routing
+- uses bounded 10 second reads and 15 second writes
+- rejects redirects and validates every response
+- returns fixed public errors to IPC callers
+- never logs response bodies, credential values, raw provider errors, private
+  hosts, or filesystem paths
+
+The Desktop renderer must not call these Gateway routes directly.
+
+### IPC
+
+Each operation has a dedicated request and response schema in the existing IPC
+contract. Requests and responses are validated in preload and main. Required
+client dependencies are resolved when handlers are registered.
+
+Suggested operations:
+
+- `runtime:get-hermes-configuration`
+- `runtime:get-hermes-environment`
+- `runtime:update-hermes-configuration`
+- `runtime:set-hermes-credential`
+- `runtime:remove-hermes-credential`
+
+## Consistency Boundary
+
+Flow consistency means the two surfaces use the same concepts and operation
+order: open, load, search, edit, save or discard, refresh, and recover through
+the terminal. It does not require identical layouts, visual styling, shared
+React code, or automatic lockstep UI releases.
+
+## Failure Handling
+
+- Initial load failure shows bounded generic copy and a retry action.
+- Unsupported or persistently unavailable structured setup also exposes
+  `Open setup terminal`.
+- Save failure retains the submitted settings as a retryable draft.
+- Refresh failure retains the last good data instead of clearing the modal.
+- Credential mutation failure clears no unrelated state and never echoes the
+  submitted value.
+- A stale response from an earlier refresh or credential mutation cannot
+  overwrite newer state.
+- Provider/runtime status refresh failure is non-destructive and reported with
+  generic copy.
+
+## Test-Driven Implementation
+
+Implementation follows red-green-refactor in this order:
+
+1. Shared contract tests for bounds, field types, patches, environment metadata,
+   and exclusion of stored secrets.
+2. Main-client tests for auth, runtime routing, timeouts, status mapping, and
+   response validation.
+3. IPC contract and handler tests for request/response validation and
+   registration-time dependency wiring.
+4. Desktop component tests for loading, search, categories, field validation,
+   discard, save, credential mutations, refresh confirmation, close
+   confirmation, stale-response protection, and terminal fallback.
+5. Regression tests for existing provider setup terminals, runtime switching,
+   and Shell Hermes configuration.
+6. Manual Electron verification against a real Matrix computer, including
+   screenshots of the matching browser and Desktop flows.
+
+## Delivery
+
+The implementation should remain one focused PR if it stays within the normal
+review target. If the shared contracts and trusted main-process client make the
+diff too large, split them as the base of a short Graphite stack and place the
+Desktop UI above them.
+
+The implementation PR must include the required invariants section, validation
+evidence, Desktop screenshots, and Greptile 5/5 before merge. Because this is a
+user-facing workflow, update the canonical public documentation in a separate
+`FinnaAI/matrix-os-site` PR after the behavior is finalized.

--- a/tests/contracts/hermes-configuration.test.ts
+++ b/tests/contracts/hermes-configuration.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  HermesConfigurationChangeRequestSchema,
+  HermesConfigurationSchema,
+  HermesCredentialRemoveRequestSchema,
+  HermesCredentialSetRequestSchema,
+  HermesEnvironmentSchema,
+} from "@matrix-os/contracts";
+
+const anthropicCredential = {
+  is_set: true,
+  redacted_value: "sk-ant-...last4",
+  description: "Anthropic API key",
+  url: "https://console.anthropic.com/",
+  category: "model",
+  is_password: true,
+  tools: ["hermes"],
+  advanced: false,
+  channel_managed: false,
+  provider: "anthropic",
+  provider_label: "Anthropic",
+};
+
+describe("Hermes configuration contracts", () => {
+  it("accepts credential metadata and rejects stored credential values", () => {
+    expect(HermesEnvironmentSchema.safeParse({
+      ANTHROPIC_API_KEY: anthropicCredential,
+    }).success).toBe(true);
+
+    expect(HermesEnvironmentSchema.safeParse({
+      ANTHROPIC_API_KEY: {
+        ...anthropicCredential,
+        value: "secret",
+      },
+    }).success).toBe(false);
+  });
+
+  it("parses bounded dynamic settings and rejects oversized field catalogs", () => {
+    const configuration = {
+      config: { general: { model: "anthropic/claude-opus-4.6" } },
+      defaults: { general: { model: "" } },
+      fields: {
+        "general.model": {
+          type: "string",
+          description: "Default model",
+          category: "general",
+        },
+      },
+      categoryOrder: ["general"],
+    };
+
+    expect(HermesConfigurationSchema.safeParse(configuration).success).toBe(true);
+    expect(HermesConfigurationSchema.safeParse({
+      ...configuration,
+      fields: Object.fromEntries(Array.from({ length: 1_025 }, (_, index) => [
+        `general.field_${index}`,
+        configuration.fields["general.model"],
+      ])),
+    }).success).toBe(false);
+  });
+
+  it("accepts only bounded typed configuration patches", () => {
+    expect(HermesConfigurationChangeRequestSchema.safeParse({
+      changes: [
+        { path: "general.model", value: "anthropic/claude-opus-4.6" },
+        { path: "display.compact", value: true },
+        { path: "agent.max_steps", value: 40 },
+        { path: "agent.fallbacks", value: ["openrouter", 2, false] },
+      ],
+    }).success).toBe(true);
+
+    expect(HermesConfigurationChangeRequestSchema.safeParse({
+      changes: [{ path: "general.model", value: { secret: "nested" } }],
+    }).success).toBe(false);
+    expect(HermesConfigurationChangeRequestSchema.safeParse({
+      changes: Array.from({ length: 65 }, (_, index) => ({
+        path: `general.field_${index}`,
+        value: true,
+      })),
+    }).success).toBe(false);
+  });
+
+  it("bounds write-only credential mutations", () => {
+    expect(HermesCredentialSetRequestSchema.safeParse({
+      key: "ANTHROPIC_API_KEY",
+      value: "secret",
+    }).success).toBe(true);
+    expect(HermesCredentialSetRequestSchema.safeParse({
+      key: "anthropic-api-key",
+      value: "secret",
+    }).success).toBe(false);
+    expect(HermesCredentialSetRequestSchema.safeParse({
+      key: "ANTHROPIC_API_KEY",
+      value: "x".repeat(4_097),
+    }).success).toBe(false);
+    expect(HermesCredentialRemoveRequestSchema.safeParse({
+      key: "OPENROUTER_API_KEY",
+    }).success).toBe(true);
+  });
+});

--- a/tests/desktop/agent-section.test.tsx
+++ b/tests/desktop/agent-section.test.tsx
@@ -145,6 +145,9 @@ describe("AgentSection", () => {
     });
     window.operator = {
       invoke: vi.fn((channel: string) => {
+        if (channel === "runtime:get-hermes-configuration" || channel === "runtime:get-hermes-environment") {
+          return Promise.reject(new Error("structured setup unavailable"));
+        }
         if (channel === "runtime:get-summary") {
           return Promise.resolve({
             runtime: { id: "rt_primary", label: "Primary", status: "available" },
@@ -332,6 +335,13 @@ describe("AgentSection", () => {
     ));
 
     fireEvent.click(screen.getByRole("button", { name: "Configure Hermes provider" }));
+    expect(await screen.findByRole("heading", { name: "Configure Hermes" })).toBeTruthy();
+    expect(api.post).not.toHaveBeenCalledWith(
+      "/api/terminal/sessions",
+      expect.objectContaining({ cmd: "hermes model", cwd: "projects" }),
+    );
+    expect(await screen.findByRole("button", { name: "Open setup terminal" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Open setup terminal" }));
     await waitFor(() => expect(api.post).toHaveBeenCalledWith(
       "/api/terminal/sessions",
       expect.objectContaining({ cmd: "hermes model", cwd: "projects" }),

--- a/tests/desktop/hermes-configuration-client.test.ts
+++ b/tests/desktop/hermes-configuration-client.test.ts
@@ -49,6 +49,7 @@ describe("Desktop Hermes configuration client", () => {
       "https://runtime.test/api/hermes/configuration?runtime=preview",
       expect.objectContaining({
         method: "GET",
+        redirect: "error",
         headers: {
           Authorization: "Bearer desktop-token",
           Accept: "application/json",
@@ -127,6 +128,7 @@ describe("Desktop Hermes configuration client", () => {
       `https://runtime.test${path}`,
       expect.objectContaining({
         method,
+        redirect: "error",
         headers: {
           Authorization: "Bearer desktop-token",
           Accept: "application/json",

--- a/tests/desktop/hermes-configuration-client.test.ts
+++ b/tests/desktop/hermes-configuration-client.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  fetchHermesConfiguration,
+  fetchHermesEnvironment,
+  removeHermesCredential,
+  setHermesCredential,
+  updateHermesConfiguration,
+} from "../../desktop/src/main/hermes/configuration-client";
+import type { AuthService } from "../../desktop/src/main/auth/auth-service";
+
+function auth(runtimeSlot = "primary", token: string | null = "desktop-token"): AuthService {
+  return {
+    getToken: () => token,
+    getGatewayOrigin: () => "https://runtime.test",
+    getStatus: () => ({
+      signedIn: token !== null,
+      handle: "operator",
+      runtimeSlot,
+      platformHost: "https://runtime.test",
+    }),
+  } as unknown as AuthService;
+}
+
+function configurationBody() {
+  return {
+    config: { general: { model: "anthropic/claude-opus-4.6" } },
+    defaults: { general: { model: "" } },
+    fields: {
+      "general.model": {
+        type: "string",
+        description: "Default model",
+        category: "general",
+      },
+    },
+    categoryOrder: ["general"],
+  };
+}
+
+describe("Desktop Hermes configuration client", () => {
+  it("fetches configuration with bearer auth for the selected runtime", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify(configurationBody()),
+      { status: 200, headers: { "content-type": "application/json" } },
+    ));
+
+    await expect(fetchHermesConfiguration(auth("preview"), fetchFn)).resolves.toEqual(configurationBody());
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://runtime.test/api/hermes/configuration?runtime=preview",
+      expect.objectContaining({
+        method: "GET",
+        headers: {
+          Authorization: "Bearer desktop-token",
+          Accept: "application/json",
+        },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("fetches strict credential metadata without accepting secret values", async () => {
+    const environment = {
+      ANTHROPIC_API_KEY: {
+        is_set: true,
+        redacted_value: "sk-ant-...1234",
+        description: "Anthropic API key",
+        category: "Providers",
+        is_password: true,
+        tools: ["hermes"],
+        advanced: false,
+        channel_managed: false,
+        provider: "anthropic",
+        provider_label: "Anthropic",
+      },
+    };
+    const fetchFn = vi.fn().mockResolvedValue(Response.json(environment));
+
+    await expect(fetchHermesEnvironment(auth(), fetchFn)).resolves.toEqual(environment);
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://runtime.test/api/hermes/env",
+      expect.objectContaining({ method: "GET" }),
+    );
+
+    fetchFn.mockResolvedValueOnce(Response.json({
+      ...environment,
+      ANTHROPIC_API_KEY: { ...environment.ANTHROPIC_API_KEY, value: "secret" },
+    }));
+    await expect(fetchHermesEnvironment(auth(), fetchFn)).rejects.toThrow(
+      "Hermes configuration is unavailable.",
+    );
+  });
+
+  it.each([
+    {
+      name: "configuration changes",
+      call: (fetchFn: typeof fetch) => updateHermesConfiguration(auth(), {
+        changes: [{ path: "general.model", value: "openai/gpt-5" }],
+      }, fetchFn),
+      path: "/api/hermes/configuration",
+      method: "PUT",
+      body: { changes: [{ path: "general.model", value: "openai/gpt-5" }] },
+    },
+    {
+      name: "credential values",
+      call: (fetchFn: typeof fetch) => setHermesCredential(auth(), {
+        key: "OPENAI_API_KEY",
+        value: "write-only-secret",
+      }, fetchFn),
+      path: "/api/hermes/env",
+      method: "PUT",
+      body: { key: "OPENAI_API_KEY", value: "write-only-secret" },
+    },
+    {
+      name: "credential removal",
+      call: (fetchFn: typeof fetch) => removeHermesCredential(auth(), {
+        key: "OPENAI_API_KEY",
+      }, fetchFn),
+      path: "/api/hermes/env",
+      method: "DELETE",
+      body: { key: "OPENAI_API_KEY" },
+    },
+  ])("validates and sends $name with a bounded authenticated write", async ({ call, path, method, body }) => {
+    const fetchFn = vi.fn().mockResolvedValue(Response.json({ ok: true, ignored: "legacy" }));
+
+    await expect(call(fetchFn)).resolves.toEqual({ ok: true });
+    expect(fetchFn).toHaveBeenCalledWith(
+      `https://runtime.test${path}`,
+      expect.objectContaining({
+        method,
+        headers: {
+          Authorization: "Bearer desktop-token",
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("rejects invalid writes before a network request", async () => {
+    const fetchFn = vi.fn();
+
+    await expect(setHermesCredential(auth(), {
+      key: "invalid-key",
+      value: "secret",
+    }, fetchFn)).rejects.toThrow("Hermes configuration could not be saved.");
+    await expect(updateHermesConfiguration(auth(), {
+      changes: [],
+    }, fetchFn)).rejects.toThrow("Hermes configuration could not be saved.");
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("uses 10 second reads and 15 second writes", async () => {
+    const timeout = vi.spyOn(AbortSignal, "timeout");
+    const readFetch = vi.fn().mockResolvedValue(Response.json(configurationBody()));
+    const writeFetch = vi.fn().mockResolvedValue(Response.json({ ok: true }));
+
+    await fetchHermesConfiguration(auth(), readFetch);
+    await setHermesCredential(auth(), { key: "OPENAI_API_KEY", value: "secret" }, writeFetch);
+
+    expect(timeout).toHaveBeenCalledWith(10_000);
+    expect(timeout).toHaveBeenCalledWith(15_000);
+    timeout.mockRestore();
+  });
+
+  it("never exposes an upstream response body or missing auth detail", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ error: "provider failed at /home/matrix with sk-secret" }),
+      { status: 502 },
+    ));
+
+    await expect(fetchHermesConfiguration(auth(), fetchFn)).rejects.toThrow(
+      "Hermes configuration is unavailable.",
+    );
+    await expect(setHermesCredential(auth(), {
+      key: "OPENAI_API_KEY",
+      value: "secret",
+    }, fetchFn)).rejects.toThrow("Hermes configuration could not be saved.");
+    await expect(fetchHermesConfiguration(auth("primary", null), fetchFn)).rejects.toThrow(
+      "Hermes configuration is unavailable.",
+    );
+  });
+});

--- a/tests/desktop/hermes-configuration-dialog.test.tsx
+++ b/tests/desktop/hermes-configuration-dialog.test.tsx
@@ -85,6 +85,11 @@ describe("Desktop Hermes configuration dialog", () => {
 
     expect(screen.getByText("Loading Hermes configuration…")).toBeTruthy();
     expect(await screen.findByRole("heading", { name: "Configure Hermes" })).toBeTruthy();
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.style.top).toBe("50%");
+    expect(dialog.style.transform).toBe("translate(-50%, -50%)");
+    expect(dialog.style.maxHeight).toBe("calc(100vh - 32px)");
+    expect(dialog.className).not.toContain("-translate-x-1/2");
     expect(screen.getByText("Version 0.20.0")).toBeTruthy();
     expect(screen.getByRole("tab", { name: "Settings" })).toBeTruthy();
     expect(screen.getByRole("tab", { name: "Credentials" })).toBeTruthy();

--- a/tests/desktop/hermes-configuration-dialog.test.tsx
+++ b/tests/desktop/hermes-configuration-dialog.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HermesConfigurationDialog } from "../../desktop/src/renderer/src/features/settings/hermes/HermesConfigurationDialog";
+
+const configuration = {
+  config: {
+    general: { model: "anthropic/claude-sonnet-4.6", quiet: false },
+    delegation: { tools: ["codex"] },
+  },
+  defaults: {
+    general: { model: "", quiet: true },
+    delegation: { tools: [] },
+  },
+  fields: {
+    "general.model": { type: "string", description: "Default model", category: "general" },
+    "general.quiet": { type: "boolean", description: "Quiet mode", category: "general" },
+    "delegation.tools": { type: "list", description: "Delegation tools", category: "delegation" },
+  },
+  categoryOrder: ["general", "delegation"],
+};
+
+const environment = {
+  OPENAI_API_KEY: {
+    is_set: false,
+    description: "OpenAI API key",
+    category: "Providers",
+    is_password: true,
+    tools: ["hermes"],
+    advanced: false,
+    channel_managed: false,
+    provider: "openai",
+    provider_label: "OpenAI",
+  },
+  ANTHROPIC_API_KEY: {
+    is_set: true,
+    redacted_value: "sk-ant-...1234",
+    description: "Anthropic API key",
+    category: "Providers",
+    is_password: true,
+    tools: ["hermes"],
+    advanced: false,
+    channel_managed: false,
+    provider: "anthropic",
+    provider_label: "Anthropic",
+  },
+};
+
+function renderDialog(props: Partial<React.ComponentProps<typeof HermesConfigurationDialog>> = {}) {
+  const onClose = vi.fn();
+  const onOpenSetupTerminal = vi.fn().mockResolvedValue(undefined);
+  const onConfigurationChanged = vi.fn();
+  render(<HermesConfigurationDialog
+    open
+    version="0.20.0"
+    onClose={onClose}
+    onOpenSetupTerminal={onOpenSetupTerminal}
+    onConfigurationChanged={onConfigurationChanged}
+    {...props}
+  />);
+  return { onClose, onOpenSetupTerminal, onConfigurationChanged };
+}
+
+describe("Desktop Hermes configuration dialog", () => {
+  beforeEach(() => {
+    window.operator = {
+      invoke: vi.fn((channel: string) => {
+        if (channel === "runtime:get-hermes-configuration") return Promise.resolve(configuration);
+        if (channel === "runtime:get-hermes-environment") return Promise.resolve(environment);
+        return Promise.resolve({ ok: true });
+      }),
+      on: vi.fn(() => () => undefined),
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("loads settings and credential metadata in parallel into a Desktop-themed modal", async () => {
+    renderDialog();
+
+    expect(screen.getByText("Loading Hermes configuration…")).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Configure Hermes" })).toBeTruthy();
+    expect(screen.getByText("Version 0.20.0")).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Settings" })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Credentials" })).toBeTruthy();
+    expect(window.operator.invoke).toHaveBeenCalledWith("runtime:get-hermes-configuration", {});
+    expect(window.operator.invoke).toHaveBeenCalledWith("runtime:get-hermes-environment", {});
+  });
+
+  it("edits, discards, validates, and saves dynamic settings", async () => {
+    const { onConfigurationChanged } = renderDialog();
+    const model = await screen.findByLabelText("Default model") as HTMLInputElement;
+
+    fireEvent.change(model, { target: { value: "openai/gpt-5" } });
+    expect(screen.getByText("1 unsaved change")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Discard Hermes changes" }));
+    expect(model.value).toBe("anthropic/claude-sonnet-4.6");
+
+    fireEvent.click(screen.getByRole("button", { name: "Delegation" }));
+    const list = screen.getByLabelText("Delegation tools") as HTMLTextAreaElement;
+    fireEvent.change(list, { target: { value: '[{"not":"allowed"}]' } });
+    expect(screen.getByRole("alert").textContent).toContain("Enter a JSON list of strings, numbers, or booleans.");
+    expect((screen.getByRole("button", { name: "Save Hermes settings" }) as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.change(list, { target: { value: '["codex", "claude"]' } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Hermes settings" }));
+    await waitFor(() => expect(window.operator.invoke).toHaveBeenCalledWith(
+      "runtime:update-hermes-configuration",
+      { changes: [{ path: "delegation.tools", value: ["codex", "claude"] }] },
+    ));
+    expect(onConfigurationChanged).toHaveBeenCalled();
+  });
+
+  it("sets and removes write-only credentials without rendering their values", async () => {
+    renderDialog();
+    await screen.findByRole("heading", { name: "Configure Hermes" });
+    fireEvent.click(screen.getByRole("tab", { name: "Credentials" }));
+
+    const key = screen.getByLabelText("OPENAI_API_KEY value") as HTMLInputElement;
+    fireEvent.change(key, { target: { value: "sk-write-only" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save OPENAI_API_KEY" }));
+    await waitFor(() => expect(window.operator.invoke).toHaveBeenCalledWith(
+      "runtime:set-hermes-credential",
+      { key: "OPENAI_API_KEY", value: "sk-write-only" },
+    ));
+    expect(key.value).toBe("");
+    expect(screen.queryByDisplayValue("sk-write-only")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove ANTHROPIC_API_KEY" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm remove ANTHROPIC_API_KEY" }));
+    await waitFor(() => expect(window.operator.invoke).toHaveBeenCalledWith(
+      "runtime:remove-hermes-credential",
+      { key: "ANTHROPIC_API_KEY" },
+    ));
+  });
+
+  it("keeps failures generic and exposes the explicit terminal fallback", async () => {
+    vi.mocked(window.operator.invoke).mockRejectedValueOnce(
+      new Error("connect ECONNREFUSED /home/matrix secret-token"),
+    );
+    const { onOpenSetupTerminal } = renderDialog();
+
+    expect((await screen.findByRole("alert")).textContent).toContain("Hermes configuration is unavailable.");
+    expect(screen.queryByText(/ECONNREFUSED|\/home\/matrix|secret-token/)).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Open setup terminal" }));
+    expect(onOpenSetupTerminal).toHaveBeenCalled();
+  });
+});

--- a/tests/desktop/hermes-configuration-dialog.test.tsx
+++ b/tests/desktop/hermes-configuration-dialog.test.tsx
@@ -171,6 +171,26 @@ describe("Desktop Hermes configuration dialog", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("confirms before discarding visible invalid input", async () => {
+    const { onClose } = renderDialog();
+    await screen.findByLabelText("Default model");
+    fireEvent.click(screen.getByRole("button", { name: "Delegation" }));
+    fireEvent.change(screen.getByLabelText("Delegation tools"), {
+      target: { value: '[{"not":"allowed"}]' },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(screen.getByRole("alertdialog").textContent)
+      .toContain("Discard unsaved changes and refresh?");
+    expect(window.operator.invoke).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    fireEvent.click(screen.getByRole("button", { name: "Close Hermes configuration" }));
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole("alertdialog").textContent)
+      .toContain("Discard unsaved changes and close?");
+  });
+
   it("preserves the last good draft when refresh fails", async () => {
     renderDialog();
     const model = await screen.findByLabelText("Default model") as HTMLInputElement;

--- a/tests/desktop/hermes-configuration-dialog.test.tsx
+++ b/tests/desktop/hermes-configuration-dialog.test.tsx
@@ -150,4 +150,37 @@ describe("Desktop Hermes configuration dialog", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open setup terminal" }));
     expect(onOpenSetupTerminal).toHaveBeenCalled();
   });
+
+  it("confirms before refresh or close would discard unsaved settings", async () => {
+    const { onClose } = renderDialog();
+    const model = await screen.findByLabelText("Default model") as HTMLInputElement;
+    fireEvent.change(model, { target: { value: "openai/gpt-5" } });
+    await screen.findByText("1 unsaved change");
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(screen.getByRole("alertdialog").textContent).toContain("Discard unsaved changes and refresh?");
+    expect(window.operator.invoke).toHaveBeenCalledTimes(2);
+    fireEvent.click(screen.getByRole("button", { name: "Discard and refresh" }));
+    await waitFor(() => expect(window.operator.invoke).toHaveBeenCalledTimes(4));
+
+    fireEvent.change(screen.getByLabelText("Default model"), { target: { value: "openai/gpt-5" } });
+    fireEvent.click(screen.getByRole("button", { name: "Close Hermes configuration" }));
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole("alertdialog").textContent).toContain("Discard unsaved changes and close?");
+    fireEvent.click(screen.getByRole("button", { name: "Discard and close" }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("preserves the last good draft when refresh fails", async () => {
+    renderDialog();
+    const model = await screen.findByLabelText("Default model") as HTMLInputElement;
+    vi.mocked(window.operator.invoke).mockRejectedValueOnce(new Error("private upstream detail"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    expect(await screen.findByRole("alert")).toHaveProperty("textContent", "Hermes configuration is unavailable.");
+    expect((screen.getByLabelText("Default model") as HTMLInputElement).value)
+      .toBe("anthropic/claude-sonnet-4.6");
+    expect(screen.queryByText(/private upstream detail/)).toBeNull();
+  });
 });

--- a/tests/desktop/hermes-form-model.test.ts
+++ b/tests/desktop/hermes-form-model.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { HermesConfiguration, HermesEnvironment } from "@matrix-os/contracts";
+import {
+  configValueAt,
+  configurationCategories,
+  isCurrentRequestRevision,
+  matchingConfigurationFields,
+  matchingCredentials,
+  parseHermesList,
+  setConfigValue,
+  titleCase,
+  valuesEqual,
+} from "../../desktop/src/renderer/src/features/settings/hermes/hermes-form-model";
+
+const configuration: HermesConfiguration = {
+  config: {
+    general: { model: "anthropic/claude-opus-4.6", quiet: false },
+    agent: { model_context_length: 0 },
+  },
+  defaults: {
+    general: { model: "", quiet: true },
+    agent: { model_context_length: 200_000 },
+  },
+  fields: {
+    "general.model": { type: "string", description: "Default model", category: "general" },
+    "general.quiet": { type: "boolean", description: "Quiet mode", category: "general" },
+    "agent.model_context_length": {
+      type: "number",
+      description: "Context window override",
+      category: "agent",
+    },
+  },
+  categoryOrder: ["general", "agent"],
+};
+
+const environment: HermesEnvironment = {
+  OPENAI_API_KEY: {
+    is_set: false,
+    description: "OpenAI API key",
+    category: "Providers",
+    is_password: true,
+    tools: ["hermes"],
+    advanced: false,
+    channel_managed: false,
+    provider: "openai",
+    provider_label: "OpenAI",
+  },
+  ANTHROPIC_API_KEY: {
+    is_set: true,
+    redacted_value: "sk-ant-...1234",
+    description: "Claude models",
+    category: "Providers",
+    is_password: true,
+    tools: ["hermes"],
+    advanced: false,
+    channel_managed: false,
+    provider: "anthropic",
+    provider_label: "Anthropic",
+  },
+};
+
+describe("Desktop Hermes form model", () => {
+  it("orders categories from the schema and reports bounded field counts", () => {
+    expect(configurationCategories(configuration)).toEqual([
+      { id: "general", label: "General", count: 2 },
+      { id: "agent", label: "Agent", count: 1 },
+    ]);
+    expect(titleCase("browser_tools")).toBe("Browser Tools");
+  });
+
+  it("searches all categories without changing the selected category", () => {
+    expect(matchingConfigurationFields(configuration, "context", "general").map(([path]) => path))
+      .toEqual(["agent.model_context_length"]);
+    expect(matchingConfigurationFields(configuration, "", "general").map(([path]) => path))
+      .toEqual(["general.model", "general.quiet"]);
+  });
+
+  it("reads and immutably updates nested draft values", () => {
+    const next = setConfigValue(configuration.config, "general.model", "openai/gpt-5");
+
+    expect(configValueAt(next, "general.model")).toBe("openai/gpt-5");
+    expect(configValueAt(configuration.config, "general.model")).toBe("anthropic/claude-opus-4.6");
+    expect(configValueAt(next, "missing.path")).toBeUndefined();
+    expect(valuesEqual(["codex", 2], ["codex", 2])).toBe(true);
+    expect(valuesEqual(["codex", 2], ["codex", 3])).toBe(false);
+  });
+
+  it("accepts only bounded scalar JSON lists", () => {
+    expect(parseHermesList('["codex", 2, true]')).toEqual(["codex", 2, true]);
+    expect(parseHermesList('[{"secret":"x"}]')).toBeNull();
+    expect(parseHermesList("not-json")).toBeNull();
+    expect(parseHermesList(JSON.stringify(Array.from({ length: 129 }, () => "x")))).toBeNull();
+  });
+
+  it("sorts configured credentials first and searches metadata only", () => {
+    expect(matchingCredentials(environment, "").map(([key]) => key)).toEqual([
+      "ANTHROPIC_API_KEY",
+      "OPENAI_API_KEY",
+    ]);
+    expect(matchingCredentials(environment, "openai").map(([key]) => key)).toEqual([
+      "OPENAI_API_KEY",
+    ]);
+  });
+
+  it("rejects stale async revisions", () => {
+    expect(isCurrentRequestRevision(4, 4)).toBe(true);
+    expect(isCurrentRequestRevision(5, 4)).toBe(false);
+  });
+});

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -19,6 +19,11 @@ describe("IPC contract", () => {
       "runtime:unsubscribe-thread-events",
       "runtime:get-notification-preferences",
       "runtime:update-notification-preferences",
+      "runtime:get-hermes-configuration",
+      "runtime:get-hermes-environment",
+      "runtime:update-hermes-configuration",
+      "runtime:set-hermes-credential",
+      "runtime:remove-hermes-credential",
       "runtime:submit-approval-decision",
       "runtime:submit-input-answer",
       "runtime:get-thread-snapshot",
@@ -49,6 +54,58 @@ describe("IPC contract", () => {
     for (const ch of expected) {
       expect(INVOKE_CHANNELS[ch], ch).toBeDefined();
     }
+  });
+
+  it("keeps Hermes setup IPC typed and credentials write-only", () => {
+    const getConfiguration = INVOKE_CHANNELS["runtime:get-hermes-configuration"];
+    const getEnvironment = INVOKE_CHANNELS["runtime:get-hermes-environment"];
+    const updateConfiguration = INVOKE_CHANNELS["runtime:update-hermes-configuration"];
+    const setCredential = INVOKE_CHANNELS["runtime:set-hermes-credential"];
+    const removeCredential = INVOKE_CHANNELS["runtime:remove-hermes-credential"];
+    const configuration = {
+      config: { general: { model: "anthropic/claude-opus-4.6" } },
+      defaults: {},
+      fields: {
+        "general.model": {
+          type: "string",
+          description: "Default model",
+          category: "general",
+        },
+      },
+      categoryOrder: ["general"],
+    };
+    const environment = {
+      ANTHROPIC_API_KEY: {
+        is_set: true,
+        redacted_value: "sk-ant-...1234",
+        description: "Anthropic API key",
+        category: "Providers",
+        is_password: true,
+        tools: ["hermes"],
+        advanced: false,
+        channel_managed: false,
+        provider: "anthropic",
+        provider_label: "Anthropic",
+      },
+    };
+
+    expect(getConfiguration.request.safeParse({}).success).toBe(true);
+    expect(getConfiguration.response.safeParse(configuration).success).toBe(true);
+    expect(getEnvironment.response.safeParse(environment).success).toBe(true);
+    expect(getEnvironment.response.safeParse({
+      ANTHROPIC_API_KEY: { ...environment.ANTHROPIC_API_KEY, value: "secret" },
+    }).success).toBe(false);
+    expect(updateConfiguration.request.safeParse({
+      changes: [{ path: "general.model", value: "openai/gpt-5" }],
+    }).success).toBe(true);
+    expect(setCredential.request.safeParse({ key: "OPENAI_API_KEY", value: "secret" }).success).toBe(true);
+    expect(setCredential.request.safeParse({
+      key: "OPENAI_API_KEY",
+      value: "secret",
+      bearerToken: "leak",
+    }).success).toBe(false);
+    expect(removeCredential.request.safeParse({ key: "OPENAI_API_KEY" }).success).toBe(true);
+    expect(updateConfiguration.response.safeParse({ ok: true }).success).toBe(true);
   });
 
   it("validates trusted desktop thread stream IPC without credential fields", () => {

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -37,6 +37,11 @@ function makeHarness(overrides: Partial<HandlerContext> = {}) {
     onRuntimeChanged: vi.fn(),
     getUpdateStatus: vi.fn(() => "disabled"),
     fetchRuntimeSummary: vi.fn(),
+    fetchHermesConfiguration: vi.fn(),
+    fetchHermesEnvironment: vi.fn(),
+    updateHermesConfiguration: vi.fn(),
+    setHermesCredential: vi.fn(),
+    removeHermesCredential: vi.fn(),
     fetchProjectWorkspace: vi.fn(),
     fetchReviewSummaries: vi.fn(),
     fetchReviewSnapshot: vi.fn(),
@@ -186,6 +191,58 @@ describe("registerIpcHandlers", () => {
 
     await expect(harness.invoke("runtime:get-summary")).rejects.toThrow("internal error");
     await expect(harness.invoke("runtime:get-summary")).rejects.not.toThrow("10.0.0.5");
+  });
+
+  it("routes Hermes setup through strict trusted-core IPC handlers", async () => {
+    const configuration = {
+      config: {},
+      defaults: {},
+      fields: {},
+      categoryOrder: [],
+    };
+    const environment = {
+      OPENAI_API_KEY: {
+        is_set: false,
+        description: "OpenAI API key",
+        category: "Providers",
+        is_password: true,
+        tools: ["hermes"],
+        advanced: false,
+        channel_managed: false,
+        provider: "openai",
+        provider_label: "OpenAI",
+      },
+    };
+    const handlers = {
+      fetchHermesConfiguration: vi.fn().mockResolvedValue(configuration),
+      fetchHermesEnvironment: vi.fn().mockResolvedValue(environment),
+      updateHermesConfiguration: vi.fn().mockResolvedValue({ ok: true }),
+      setHermesCredential: vi.fn().mockResolvedValue({ ok: true }),
+      removeHermesCredential: vi.fn().mockResolvedValue({ ok: true }),
+    };
+    const harness = makeHarness(handlers as Partial<HandlerContext>);
+
+    await expect(harness.invoke("runtime:get-hermes-configuration")).resolves.toEqual(configuration);
+    await expect(harness.invoke("runtime:get-hermes-environment")).resolves.toEqual(environment);
+    await expect(harness.invoke("runtime:update-hermes-configuration", {
+      changes: [{ path: "general.model", value: "openai/gpt-5" }],
+    })).resolves.toEqual({ ok: true });
+    await expect(harness.invoke("runtime:set-hermes-credential", {
+      key: "OPENAI_API_KEY",
+      value: "secret",
+    })).resolves.toEqual({ ok: true });
+    await expect(harness.invoke("runtime:remove-hermes-credential", {
+      key: "OPENAI_API_KEY",
+    })).resolves.toEqual({ ok: true });
+    expect(handlers.setHermesCredential).toHaveBeenCalledWith({
+      key: "OPENAI_API_KEY",
+      value: "secret",
+    });
+    await expect(harness.invoke("runtime:set-hermes-credential", {
+      key: "OPENAI_API_KEY",
+      value: "secret",
+      bearerToken: "leak",
+    })).rejects.toThrow("invalid request");
   });
 
   it("DT-001 returns a project workspace through strict trusted-core IPC", async () => {

--- a/tests/gateway/hermes-proxy.test.ts
+++ b/tests/gateway/hermes-proxy.test.ts
@@ -630,6 +630,48 @@ describe("Upstream error mapping", () => {
     const text = await res.text();
     expect(text).not.toContain("sk-ant-api-key");
   });
+
+  it("projects environment reads to credential metadata without stored values", async () => {
+    const app = authenticatedApp({
+      client: {
+        fetch: async () => upstreamJson({
+          ANTHROPIC_API_KEY: {
+            is_set: true,
+            redacted_value: "sk-ant-...last4",
+            description: "Anthropic API key",
+            category: "model",
+            is_password: true,
+            tools: ["hermes"],
+            advanced: false,
+            channel_managed: false,
+            provider: "anthropic",
+            provider_label: "Anthropic",
+            value: "secret-from-upstream",
+          },
+        }),
+        readJson: vi.fn(),
+        requestJson: vi.fn(),
+      },
+    });
+
+    const res = await app.request("/api/hermes/env");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ANTHROPIC_API_KEY: {
+        is_set: true,
+        redacted_value: "sk-ant-...last4",
+        description: "Anthropic API key",
+        category: "model",
+        is_password: true,
+        tools: ["hermes"],
+        advanced: false,
+        channel_managed: false,
+        provider: "anthropic",
+        provider_label: "Anthropic",
+      },
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/gateway/hermes-proxy.test.ts
+++ b/tests/gateway/hermes-proxy.test.ts
@@ -672,6 +672,37 @@ describe("Upstream error mapping", () => {
       },
     });
   });
+
+  it("normalizes the empty metadata URLs emitted by Hermes 0.20", async () => {
+    const app = authenticatedApp({
+      client: {
+        fetch: async () => upstreamJson({
+          DEEPSEEK_BASE_URL: {
+            is_set: false,
+            redacted_value: null,
+            description: "Custom DeepSeek API base URL (advanced)",
+            url: "",
+            category: "provider",
+            is_password: false,
+            tools: [],
+            advanced: false,
+            channel_managed: false,
+            provider: "",
+            provider_label: "",
+          },
+        }),
+        readJson: vi.fn(),
+        requestJson: vi.fn(),
+      },
+    });
+
+    const res = await app.request("/api/hermes/env");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      DEEPSEEK_BASE_URL: expect.objectContaining({ url: null }),
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/shell/hermes-configuration.test.tsx
+++ b/tests/shell/hermes-configuration.test.tsx
@@ -259,6 +259,7 @@ describe("Hermes configuration dialog", () => {
     await waitFor(() => expect(resolveSave).toBeDefined());
 
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    fireEvent.click(screen.getByRole("button", { name: "Discard and close" }));
     await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
     fireEvent.click(screen.getByRole("button", { name: "Open Hermes configuration" }));
     expect(await screen.findByRole("button", { name: "Fresh, 1 setting" })).toBeVisible();
@@ -411,7 +412,7 @@ describe("Hermes configuration dialog", () => {
     expect(screen.queryByText("Credential could not be saved.")).not.toBeInTheDocument();
   });
 
-  it("preserves unsaved invalid text when the dialog closes and reopens", async () => {
+  it("confirms before closing with invalid text and preserves it when close is cancelled", async () => {
     const listConfiguration = {
       ...configuration,
       config: { ...configuration.config, tools: { allowed: ["bash"] } },
@@ -441,12 +442,54 @@ describe("Hermes configuration dialog", () => {
     fireEvent.change(search, { target: { value: "allowed tools" } });
     fireEvent.change(screen.getByRole("textbox", { name: "Allowed tools" }), { target: { value: '["bash"' } });
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(screen.getByRole("alertdialog")).toHaveTextContent("Discard unsaved changes and close?");
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.getByRole("textbox", { name: "Allowed tools" })).toHaveValue('["bash"');
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    fireEvent.click(screen.getByRole("button", { name: "Discard and close" }));
     await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
     fireEvent.click(screen.getByRole("button", { name: "Open Hermes configuration" }));
 
-    expect(await screen.findByRole("textbox", { name: "Allowed tools" })).toHaveValue('["bash"');
-    expect(screen.getByText("Enter a valid JSON list before saving.")).toBeVisible();
+    expect(JSON.parse((await screen.findByRole("textbox", { name: "Allowed tools" }) as HTMLTextAreaElement).value))
+      .toEqual(["bash"]);
+    expect(screen.queryByText("Enter a valid JSON list before saving.")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save Hermes settings" })).toBeDisabled();
+  });
+
+  it("confirms dirty refresh and reloads settings plus credential metadata", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL) => (
+      String(input).endsWith("/api/hermes/env") ? response(environment) : response(configuration)
+    ));
+    vi.stubGlobal("fetch", fetcher);
+    render(<HermesConfigurationDialog open onOpenChange={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Agent, 1 setting" }));
+    fireEvent.change(screen.getByRole("spinbutton", { name: "Maximum turns" }), { target: { value: "120" } });
+    expect(screen.getByText("1 unsaved change")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Refresh Hermes configuration" }));
+
+    expect(screen.getByRole("alertdialog")).toHaveTextContent("Discard unsaved changes and refresh?");
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    fireEvent.click(screen.getByRole("button", { name: "Discard and refresh" }));
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(4));
+    expect(screen.getByRole("spinbutton", { name: "Maximum turns" })).toHaveValue(90);
+  });
+
+  it("keeps the last good content when an explicit refresh fails", async () => {
+    let failRefresh = false;
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      if (failRefresh) throw new Error("private upstream detail");
+      return String(input).endsWith("/api/hermes/env") ? response(environment) : response(configuration);
+    }));
+    render(<HermesConfigurationDialog open onOpenChange={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Agent, 1 setting" }));
+    failRefresh = true;
+    fireEvent.click(screen.getByRole("button", { name: "Refresh Hermes configuration" }));
+
+    expect(await screen.findByText("Hermes configuration is unavailable.")).toBeVisible();
+    expect(screen.getByRole("spinbutton", { name: "Maximum turns" })).toHaveValue(90);
+    expect(screen.queryByText("private upstream detail")).not.toBeInTheDocument();
   });
 
   it("ignores an older credential refresh that resolves after a newer mutation", async () => {


### PR DESCRIPTION
## Summary

- add strict shared Hermes configuration contracts and authenticated Desktop IPC
- add a Desktop-native Hermes Settings/Credentials dialog with write-only credential handling
- align Desktop and browser Shell refresh, dirty-confirmation, error-preservation, and terminal fallback flows
- keep the Hermes configuration dialog centered inside the visible viewport with a 16px safety margin while preserving the shared dialog's existing default placement
- preserve visible invalid setting drafts across close/refresh confirmation and keep category/validation collections explicitly bounded
- normalize the empty `url` metadata emitted by Hermes 0.20 before validating `/api/hermes/env`, preventing the Gateway from returning a false 502 to Desktop

## Tests

- `flox activate -- bun run test tests/gateway/hermes-proxy.test.ts` — 34 passed
- Desktop IPC and shared contract regression suite — 52 passed
- MAT-262 changed-scope suite — 176 passed before the compatibility follow-up
- `flox activate -- bun run typecheck` — passed
- `flox activate -- bun run check:patterns` — 0 violations (5 heuristic warning groups)
- `flox activate -- bun run check:patterns:diff` — passed
- `flox activate -- bun run build:desktop` — passed
- full `flox activate -- bun run test` exposes unrelated existing failures in customer VPS cloud-init, Zellij/Codex path resolution, and the cancelled Codex connect timeout; each failure reproduces in isolation and none of those files are changed by this PR

## Live validation

- verified the Desktop entry point, viewport-centered modal, explicit Refresh action, safe compatibility fallback, and foreground terminal fallback against Preview Computer `pr-1164`
- cold-start validation confirmed the 980px dialog is horizontally and vertically centered, remains within a 1200x768 viewport, and keeps fallback actions centered in the visible content area
- traced the live configuration failure to Gateway response sanitization: Hermes 0.20 returns empty metadata URLs for `DEEPSEEK_BASE_URL` and `DASHSCOPE_BASE_URL`, which previously invalidated the complete response
- added a red-to-green regression test for the exact Hermes 0.20 payload shape
- Preview VPS workflow 31290091894 deployed exact-head bundle `v2026.08.09-pr1164-c681323`
- post-deploy Desktop validation received HTTP 200 from `/api/hermes/env` and rendered Settings, Credentials, category counts, typed fields, and save/discard controls instead of the compatibility fallback

## Invariants

### Source of truth
- Hermes and the Gateway remain authoritative; Desktop stores no duplicate configuration
- the Gateway normalizes only Hermes metadata representation (`url: ""` to `url: null`) before enforcing the existing client contract

### Lock/transaction scope
- the existing Gateway Hermes configuration write tail serializes mutations; Desktop rejects stale reads and preserves newer drafts
- this compatibility fix changes only a read projection and introduces no database, file, or network transaction

### Acceptable orphan states
- a failed post-write refresh may leave the last known UI snapshot visible; explicit Refresh reconciles it
- credentials remain write-only and are never returned to the renderer

### Auth source of truth
- Electron main obtains the native bearer token and selected runtime; the renderer never receives credentials or constructs authenticated requests
- the Gateway's existing Hermes route authentication remains unchanged

### Deferred scope
- no Hermes upstream behavior is changed; malformed non-empty URLs still fail the strict client contract
- public documentation in `FinnaAI/matrix-os-site` remains out of scope
- merge remains gated on review and CI; this PR is not being merged as part of preview validation

Linear: MAT-262
