### PR TITLE
revert(release): roll back channel fixes for reattribution

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -1,7 +1,8 @@
 # Host Bundle Release
 #
 # Builds, publishes, and registers the Matrix OS host bundle.
-# Main publishes the dev channel. Tags publish immutable release versions.
+# TEMPORARY REVERT INTERLOCK: push releases are disabled until the deployment
+# containment change is reapplied in the next stacked PR.
 #
 # Version format: v{YYYY.MM.DD}-{run_number} (date-based, monotonically increasing)
 #
@@ -9,13 +10,12 @@
 #   1. ci-gate — wait for same-SHA CI and verify all CI jobs succeeded
 #   2. build — compile gateway, shell, kernel into host bundle tarball
 #   3. publish — upload immutable R2 artifacts and register metadata in platform DB
-#   4. (optional) deploy — explicit dispatches may trigger exact-version VPS deployment
+#   4. deploy — hard-disabled during the temporary revert window
 
 name: Host Bundle Release
 
 on:
   push:
-    branches: [main]
     tags:
       - "v*"
   workflow_dispatch:
@@ -412,7 +412,7 @@ jobs:
   deploy:
     name: Deploy published host bundle
     needs: [dev-bundle-gate, build, publish]
-    if: ${{ needs.dev-bundle-gate.outputs.should_build == 'true' && github.event_name == 'workflow_dispatch' && inputs.deploy_after_publish && ((github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag') }}
+    if: ${{ false }} # TEMPORARY REVERT INTERLOCK
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -106,31 +106,6 @@ release_url_for_channel() { echo "$(platform_url)/system-bundles/channels/$1.jso
 
 json_field() { python3 -c "import json,sys; print(json.load(sys.stdin).get(sys.argv[1],''))" "$2" <<< "$1"; }
 
-compare_host_bundle_versions() {
-  local candidate="$1" current="$2"
-  python3 - "$candidate" "$current" <<'PY'
-import re
-import sys
-
-def parse(value):
-    match = re.fullmatch(r"v?(\d{4})\.(\d{2})\.(\d{2})[-.](\d+)", value)
-    if not match:
-        return None
-    return tuple(int(part) for part in match.groups())
-
-candidate = parse(sys.argv[1])
-current = parse(sys.argv[2])
-if candidate is None or current is None:
-    print("unknown")
-elif candidate > current:
-    print("newer")
-elif candidate < current:
-    print("older")
-else:
-    print("equal")
-PY
-}
-
 write_update_error() {
   local code="$1" message="$2" version="${3:-}" available_kb="${4:-}" required_kb="${5:-}"
   python3 - "$UPDATE_ERROR_MARKER" "$code" "$message" "$version" "$available_kb" "$required_kb" <<'PY'
@@ -218,18 +193,7 @@ check_for_update() {
     log "WARN: manifest missing 'version' field"; return 1
   fi
   cur="$(current_version)"
-  if [ "$remote_version" = "$cur" ]; then
-    rm -f "$UPDATE_MARKER"
-    return 0
-  fi
-
-  local version_comparison
-  version_comparison="$(compare_host_bundle_versions "$remote_version" "$cur")"
-  if [ "$version_comparison" = "older" ]; then
-    log "Ignoring older channel release: $remote_version (current: $cur)"
-    rm -f "$UPDATE_MARKER" "$UPDATE_ERROR_MARKER"
-    return 0
-  fi
+  if [ "$remote_version" = "$cur" ]; then return 0; fi
 
   local severity update_type
   severity="$(json_field "$manifest" severity)"

--- a/docs/dev/releases.md
+++ b/docs/dev/releases.md
@@ -28,12 +28,12 @@ that image.
 - `main` is the source of truth. A push to `main` runs `.github/workflows/host-bundle-release.yml`.
 - The workflow builds `dist/host-bundle/matrix-host-bundle.tar.gz`, uploads it to R2, registers it in platform Postgres through `POST /system-bundles/releases`, and promotes the `dev` channel.
 - R2 JSON manifests are not authoritative. The platform DB release row and channel row are authoritative; R2 only holds the tarball and `.sha256` bytes.
-- Existing VPS deployments are explicit and opt-in. Normal `main` pushes publish and promote `dev` without deploying any VPS.
+- Existing VPSes are updated by platform deploy fan-out: `POST /vps/deploy {"version":"<version>"}` or `{"channel":"dev"}`.
 - A customer VPS sync agent fetches DB-backed release metadata, verifies SHA-256, extracts to staging, moves the old app to `/opt/matrix/app.rollback`, moves the new app into `/opt/matrix/app`, writes `/opt/matrix/release.json`, and restarts Matrix services.
 - Host-bundle updates must never overwrite owner data. Do not delete or replace `/home/matrix/home`, `/opt/matrix/env`, or the local Postgres data directory during deploys or rollbacks.
 - `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` and CI/release paths use `pnpm install --frozen-lockfile`; do not bypass either during releases.
 - Host bundle release validation is blocking. If typecheck, tests, public build-env validation, build, publish, or registration fails, do not publish or deploy the bundle.
-- Eligible main/tag releases request a golden snapshot build after publication. This request is an optional acceleration path: enqueue/build failure does not block publication or a separately authorized deployment. See [Golden VPS Snapshots](golden-vps-snapshots.md).
+- Eligible main/tag releases request a golden snapshot build after publication. This request is an optional acceleration path: enqueue/build failure does not block publication or the unchanged existing-fleet deploy job. See [Golden VPS Snapshots](golden-vps-snapshots.md).
 - CLI releases are manual through `.github/workflows/release.yml`; bump `packages/sync-client/package.json`, run the sync-client checks, and dispatch the workflow with the same semver.
 - Fleet upgrade operations, blocked-machine handling, and the durable control-plane setup are documented in [Fleet Upgrade Operations](fleet-upgrade-operations.md).
 - Staging platform containers and disposable feature VPSes are temporary test
@@ -93,19 +93,23 @@ Release metadata also records:
    | `PLATFORM_PUBLIC_URL` | var | publish/deploy; defaults to `https://app.matrix-os.com` |
    | `PLATFORM_SECRET` | secret | release registration and deploy fan-out |
 
-3. Deploy to existing VPSes only when explicitly authorized.
+3. Deploy to existing VPSes.
 
-   Normal `main` pushes publish `dev` but do not automatically fan out to the fleet. The workflow-dispatch input `deploy_after_publish` defaults to `false`. Setting `deploy_after_publish=true` intentionally deploys the newly published exact version to the full running fleet, so use it only for a reviewed fleet-wide rollout. Security severity does not override this opt-in deployment gate.
+   During the temporary revert window, `host-bundle-release.yml` has no push
+   trigger and its deploy job is hard-disabled. Do not remove this interlock
+   until the deployment opt-in change is reapplied by the next stacked PR.
 
-   For a scoped rollout, target each reviewed handle explicitly after the workflow is green:
+   Normal `main` pushes publish `dev` but do not automatically fan out to the fleet. Trigger deploy after the workflow is green:
 
    ```bash
    curl --fail --silent --show-error \
      -X POST https://app.matrix-os.com/vps/deploy \
      -H "Authorization: Bearer $PLATFORM_SECRET" \
      -H "Content-Type: application/json" \
-     -d '{"handle":"<reviewed-handle>","version":"v2026.05.12-43"}'
+     -d '{"version":"v2026.05.12-43"}'
    ```
+
+   Security releases can use the workflow `severity=security` path, which auto-deploys the built version after publish.
 
 4. Verify every VPS.
 

--- a/docs/dev/vps-deployment.md
+++ b/docs/dev/vps-deployment.md
@@ -619,29 +619,20 @@ sha256sum dist/host-bundle/matrix-host-bundle.tar.gz
 
 Publish with `./scripts/publish-release.sh <version> --channel <channel>` or let `.github/workflows/host-bundle-release.yml` do it on `main`. The publish step uploads immutable R2 objects and registers the release in platform Postgres; platform Postgres is the source of truth for release metadata and channel pointers.
 
-Existing VPS deployments are explicit. Normal `main` pushes publish and promote
-`dev` without updating any VPS. Target each reviewed customer handle rather than
-using an unqualified fleet deploy:
+Existing VPSes update through platform fan-out:
 
 ```bash
 curl --fail --silent --show-error \
   -X POST https://app.matrix-os.com/vps/deploy \
   -H "Authorization: Bearer $PLATFORM_SECRET" \
   -H "Content-Type: application/json" \
-  -d '{"handle":"<reviewed-handle>","version":"v2026.05.12-43"}'
+  -d '{"version":"v2026.05.12-43"}'
 ```
 
 Do not SSH-copy bundles except for break-glass recovery. The sync agent downloads the registered bundle through platform, verifies the SHA-256, stages extraction, keeps `/opt/matrix/app.rollback`, swaps `/opt/matrix/app`, writes `/opt/matrix/release.json`, and restarts services.
 
 Operational rules:
 
-- Keep release provenance and update subscription separate. `/opt/matrix/release.json`
-  describes the installed immutable artifact and may retain its build channel.
-  `/opt/matrix/env/host.env` `MATRIX_UPDATE_CHANNEL` is the persistent channel
-  followed by the sync agent and exposed as `updateChannel` by `/api/system/info`.
-- Passive sync polling must not treat an older channel pointer as an available
-  update. Explicit `matrix-update <channel-or-version>` remains the operator/user
-  path for an intentional downgrade.
 - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is build-time, not runtime. If the browser tries to load `https://clerk.example.com/...`, the served shell bundle was built with the placeholder Clerk key and must be rebuilt with the real key.
 - `DATABASE_URL` must exist in `/opt/matrix/env/host.env` or be assembled by `/opt/matrix/bin/matrix-gateway` from `/opt/matrix/env/postgres.env`. Without it, gateway state can drift away from owner-controlled Postgres.
 - Do not use `owner: root:matrix` in cloud-init `write_files` before the `matrix` group exists. Prefer `root:root` for env files unless the file must be group-readable.

--- a/packages/gateway/src/system-info.ts
+++ b/packages/gateway/src/system-info.ts
@@ -136,7 +136,6 @@ export function getVersion(release?: HostBundleRelease): string {
 export interface SystemInfo {
   version: string;
   channel?: string;
-  updateChannel: string;
   model: string;
   effort: string;
   image: string;
@@ -191,25 +190,6 @@ function readReleaseInfo(): HostBundleRelease | undefined {
     }
   }
   return undefined;
-}
-
-function readPersistentUpdateChannel(): string | undefined {
-  const hostEnvFile = process.env.MATRIX_HOST_ENV_FILE ?? "/opt/matrix/env/host.env";
-  try {
-    return readCachedSystemInfoFile(`host-env:${hostEnvFile}`, () => {
-      const raw = readBoundedTextFile(hostEnvFile);
-      for (const line of raw.split(/\r?\n/)) {
-        const match = line.match(/^MATRIX_UPDATE_CHANNEL=(stable|canary|beta|dev)$/);
-        if (match) return match[1];
-      }
-      return undefined;
-    });
-  } catch (err) {
-    if (!isMissingFileError(err)) {
-      logSystemInfoReadFailure("Failed to read persistent update channel", err);
-    }
-    return undefined;
-  }
 }
 
 function readDiskUsage(path: string): { totalBytes: number; freeBytes: number } | null {
@@ -290,15 +270,10 @@ export function getSystemInfo(
   const [load1 = 0, load5 = 0, load15 = 0] = loadavg();
   const release = readReleaseInfo();
   const channel = parseReleaseChannel(release?.channel);
-  const updateChannel = readPersistentUpdateChannel()
-    ?? parseReleaseChannel(process.env.MATRIX_UPDATE_CHANNEL)
-    ?? channel
-    ?? "stable";
 
   return {
     version: getVersion(release),
     ...(channel ? { channel } : {}),
-    updateChannel,
     model: kernelOverrides.model ?? kernel.model,
     effort: kernel.effort,
     image: process.env.MATRIX_IMAGE ?? "unknown",

--- a/shell/src/components/RuntimeIdentityBanner.tsx
+++ b/shell/src/components/RuntimeIdentityBanner.tsx
@@ -8,7 +8,6 @@ import { ShellNotificationCard } from "./ShellNotificationCard";
 const ATTENTION_RELEASE_CHANNELS = new Set(["dev", "canary", "beta"]);
 
 interface RuntimeInfo {
-  updateChannel?: string | null;
   runtime?: {
     handle?: string | null;
     machineId?: string | null;
@@ -93,9 +92,7 @@ export function RuntimeIdentityBanner() {
     const slot = runtime?.runtime?.runtimeSlot ?? "primary";
     const machineId = runtime?.runtime?.machineId ?? null;
     const isStaging = slot !== "primary";
-    const channel = runtime?.updateChannel?.toLowerCase()
-      ?? runtime?.release?.channel?.toLowerCase()
-      ?? null;
+    const channel = runtime?.release?.channel?.toLowerCase() ?? null;
     const shouldShow = isStaging || (channel ? ATTENTION_RELEASE_CHANNELS.has(channel) : false);
     return {
       handle,

--- a/shell/src/components/settings/sections/SystemSection.tsx
+++ b/shell/src/components/settings/sections/SystemSection.tsx
@@ -15,7 +15,6 @@ const UPDATE_INSTALL_TIMEOUT_MS = 5 * 60_000;
 interface SystemInfo {
   version?: string;
   image?: string;
-  updateChannel?: string;
   release?: {
     version?: string;
     channel?: string;
@@ -185,7 +184,7 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
       .then((r) => r.ok ? r.json() : {})
       .then((data: SystemInfo) => {
         setInfo(data);
-        const channel = coerceReleaseChannel(data.updateChannel ?? data.release?.channel);
+        const channel = coerceReleaseChannel(data.release?.channel);
         setSelectedChannel(channel);
         void refreshReleaseData(channel);
       })
@@ -214,7 +213,7 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
   const currentVersion = resolvedUpdate.currentVersion;
   const latestVersion = resolvedUpdate.latestVersion;
   const updateAvailable = resolvedUpdate.updateAvailable;
-  const installedChannel = coerceReleaseChannel(info.updateChannel ?? info.release?.channel);
+  const installedChannel = coerceReleaseChannel(info.release?.channel);
   const releaseRows = releaseList?.releases ?? [];
   const canInstallSelectedChannel = Boolean(latestVersion && (updateAvailable || selectedChannel !== installedChannel));
   const systemUpdatesLocked = !billingActive;

--- a/tests/gateway/system-info.test.ts
+++ b/tests/gateway/system-info.test.ts
@@ -109,36 +109,6 @@ describe("T135: System info", () => {
     }
   });
 
-  it("reports the persistent update channel separately from bundle provenance", () => {
-    const homePath = tmpHome();
-    const releasePath = join(homePath, "release.json");
-    const hostEnvPath = join(homePath, "host.env");
-    const previousReleasePath = process.env.MATRIX_RELEASE_FILE;
-    const previousHostEnvPath = process.env.MATRIX_HOST_ENV_FILE;
-    const previousUpdateChannel = process.env.MATRIX_UPDATE_CHANNEL;
-    process.env.MATRIX_RELEASE_FILE = releasePath;
-    process.env.MATRIX_HOST_ENV_FILE = hostEnvPath;
-    process.env.MATRIX_UPDATE_CHANNEL = "dev";
-    writeFileSync(releasePath, JSON.stringify({ version: "v2026.08.05-912", channel: "dev" }));
-    writeFileSync(hostEnvPath, "MATRIX_UPDATE_CHANNEL=stable\n");
-
-    try {
-      const info = getSystemInfo(homePath);
-
-      expect(info.release?.channel).toBe("dev");
-      expect(info.channel).toBe("dev");
-      expect(info.updateChannel).toBe("stable");
-    } finally {
-      if (previousReleasePath === undefined) delete process.env.MATRIX_RELEASE_FILE;
-      else process.env.MATRIX_RELEASE_FILE = previousReleasePath;
-      if (previousHostEnvPath === undefined) delete process.env.MATRIX_HOST_ENV_FILE;
-      else process.env.MATRIX_HOST_ENV_FILE = previousHostEnvPath;
-      if (previousUpdateChannel === undefined) delete process.env.MATRIX_UPDATE_CHANNEL;
-      else process.env.MATRIX_UPDATE_CHANNEL = previousUpdateChannel;
-      rmSync(homePath, { recursive: true, force: true });
-    }
-  });
-
   it("falls back to the installed bundle version when release metadata has no version", () => {
     const homePath = tmpHome();
     const releasePath = join(homePath, "release.json");

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -460,30 +460,18 @@ describe('CI workflows', () => {
     expect(workflow).toContain('${cache_image}');
   });
 
-  it('publishes main dev host bundles without deploying the fleet', () => {
+  it('temporarily disables host-bundle push releases while the containment fix is reverted', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
-    const releaseDocs = readFileSync(join(root, 'docs/dev/releases.md'), 'utf8');
-    const deployJob = workflow.slice(workflow.indexOf('\n  deploy:'));
 
-    expect(workflow).toContain('deploy_after_publish:');
+    expect(workflow).toContain('TEMPORARY REVERT INTERLOCK');
+    expect(workflow).not.toContain('branches: [main]');
+    expect(workflow).toContain('tags:');
+    expect(workflow).toContain('- "v*"');
     expect(workflow).toMatch(/deploy_after_publish:[\s\S]*?default: false/);
+    expect(workflow).toContain('if: ${{ false }} # TEMPORARY REVERT INTERLOCK');
     expect(workflow).toContain('Deploy published host bundle');
-    expect(deployJob).toContain("github.event_name == 'workflow_dispatch' && inputs.deploy_after_publish");
-    expect(deployJob).toContain("(github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag'");
-    expect(deployJob).not.toContain("github.event_name == 'push'");
-    expect(workflow).not.toContain("|| inputs.severity == 'security'");
     expect(workflow).toContain('PUBLISH_VERSION: ${{ needs.build.outputs.version }}');
     expect(workflow).toContain('VERSION="$PUBLISH_VERSION"');
-    expect(workflow).not.toContain('VERSION="${{ needs.build.outputs.version }}"');
-    expect(workflow).toContain('DEPLOY_RESPONSE="$(curl --fail --silent --show-error --max-time 30 \\');
-    expect(workflow).toContain('failed="$(printf \'%s\' "$DEPLOY_RESPONSE" | jq -r \'.failed // 0\')"');
-    expect(workflow).toContain('triggered="$(printf \'%s\' "$DEPLOY_RESPONSE" | jq -r \'.triggered // 0\')"');
-    expect(workflow).toContain('if [ "$failed" -gt 0 ] || [ "$triggered" -eq 0 ]; then');
-    expect(workflow).toContain('-d "{\\"version\\":\\"$VERSION\\"}"');
-    expect(workflow).not.toContain('Auto-deploy on security severity');
-    expect(releaseDocs).toContain('`deploy_after_publish=true`');
-    expect(releaseDocs).toContain('Security severity does not override this opt-in deployment gate.');
-    expect(releaseDocs).not.toContain('which auto-deploys the built version after publish');
   });
 });

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -51,19 +51,6 @@ function runHostBundlePreflight(env: Record<string, string>) {
   });
 }
 
-function compareSyncAgentVersions(candidate: string, current: string): string {
-  const root = process.cwd();
-  const syncAgent = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-sync-agent'), 'utf8');
-  const functionSource = syncAgent.match(/compare_host_bundle_versions\(\) \{[\s\S]*?\n\}/)?.[0];
-  expect(functionSource).toBeDefined();
-  const result = spawnSync('bash', ['-c', `${functionSource}\ncompare_host_bundle_versions "$1" "$2"`, 'version-test', candidate, current], {
-    cwd: root,
-    encoding: 'utf8',
-  });
-  expect(result.status, result.stderr || result.stdout).toBe(0);
-  return result.stdout.trim();
-}
-
 describe('customer VPS host bundle', () => {
   it('build script packages the systemd entrypoint binaries', () => {
     const root = process.cwd();
@@ -1078,25 +1065,6 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(updater).toContain('stable|canary|beta|dev|v[0-9]*|main-[A-Za-z0-9]*');
     expect(updater).toContain('journalctl -u matrix-sync-agent -f --no-pager -n 20');
     expect(updater).toContain('Usage: matrix-update [--no-tail] [apply|rollback|repair|stable|canary|beta|dev|v<version>|main-<build>]');
-  });
-
-  it('sync agent distinguishes newer and older date-based host bundles', () => {
-    const syncAgent = readFileSync(join(process.cwd(), 'distro/customer-vps/host-bin/matrix-sync-agent'), 'utf8');
-
-    expect(compareSyncAgentVersions('v2026.08.06-1', 'v2026.08.05-912')).toBe('newer');
-    expect(compareSyncAgentVersions('v2026.08.05-912', 'v2026.08.05-912')).toBe('equal');
-    expect(compareSyncAgentVersions('v2026.08.04-898', 'v2026.08.05-912')).toBe('older');
-    expect(compareSyncAgentVersions('v0.0.0-preview', 'v2026.08.05-912')).toBe('unknown');
-    expect(syncAgent).toContain('version_comparison="$(compare_host_bundle_versions "$remote_version" "$cur")"');
-    expect(syncAgent).toContain('if [ "$version_comparison" = "older" ]; then');
-    expect(syncAgent).toContain('Ignoring older channel release: $remote_version (current: $cur)');
-    expect(syncAgent).toContain([
-      'if [ "$version_comparison" = "older" ]; then',
-      '    log "Ignoring older channel release: $remote_version (current: $cur)"',
-      '    rm -f "$UPDATE_MARKER" "$UPDATE_ERROR_MARKER"',
-      '    return 0',
-      '  fi',
-    ].join('\n'));
   });
 
   it('sync agent installs bundled messaging systemd units during updates', () => {

--- a/tests/shell/runtime-identity-banner.test.tsx
+++ b/tests/shell/runtime-identity-banner.test.tsx
@@ -59,7 +59,7 @@ describe("RuntimeIdentityBanner", () => {
     });
   });
 
-  it("hides the primary VM banner for stable subscribers with a dev-built bundle", async () => {
+  it("hides the primary VM banner for stable releases", async () => {
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.endsWith("/api/system/info")) {
@@ -69,8 +69,7 @@ describe("RuntimeIdentityBanner", () => {
             machineId: "11111111-2222-3333-4444-555555555556",
             runtimeSlot: "primary",
           },
-          updateChannel: "stable",
-          release: { version: "v082-test", channel: "dev" },
+          release: { version: "v082-test", channel: "stable" },
         }));
       }
       if (url.endsWith("/api/identity")) {
@@ -96,8 +95,7 @@ describe("RuntimeIdentityBanner", () => {
             machineId: "11111111-2222-3333-4444-555555555557",
             runtimeSlot: "primary",
           },
-          updateChannel: "dev",
-          release: { version: "v2026.05.28-151", channel: "stable" },
+          release: { version: "v2026.05.28-151", channel: "dev" },
         }));
       }
       if (url.endsWith("/api/identity")) {

--- a/tests/shell/system-section-refresh.test.tsx
+++ b/tests/shell/system-section-refresh.test.tsx
@@ -34,51 +34,6 @@ describe("SystemSection release refresh", () => {
     vi.restoreAllMocks();
   });
 
-  it("uses the persistent update channel instead of the bundle provenance channel", async () => {
-    const fetchMock = vi.fn((input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url.endsWith("/api/system/info")) {
-        return Promise.resolve(jsonResponse({
-          version: "v2026.08.05-912",
-          updateChannel: "stable",
-          release: {
-            version: "v2026.08.05-912",
-            channel: "dev",
-          },
-        }));
-      }
-      if (url.endsWith("/health")) {
-        return Promise.resolve(jsonResponse({ status: "ok", cronJobs: 0, channels: {} }));
-      }
-      if (url.endsWith("/api/system/update?channel=stable")) {
-        return Promise.resolve(jsonResponse({
-          channel: "stable",
-          latest: { version: "v2026.08.05-912" },
-          updateAvailable: false,
-        }));
-      }
-      if (url.endsWith("/api/system/releases?channel=stable")) {
-        return Promise.resolve(jsonResponse({ channel: "stable", releases: [] }));
-      }
-      return Promise.reject(new Error(`unexpected fetch ${url}`));
-    });
-    vi.stubGlobal("fetch", fetchMock);
-
-    render(<SystemSection />);
-
-    await waitFor(() => {
-      expect((screen.getByLabelText("Release channel") as HTMLSelectElement).value).toBe("stable");
-      expect(fetchMock).toHaveBeenCalledWith(
-        "http://gateway.test/api/system/update?channel=stable",
-        expect.any(Object),
-      );
-    });
-    expect(fetchMock).not.toHaveBeenCalledWith(
-      "http://gateway.test/api/system/update?channel=dev",
-      expect.anything(),
-    );
-  });
-
   it("ignores stale release metadata when the selected channel changes", async () => {
     const stableUpdate = deferred<Response>();
     const stableReleases = deferred<Response>();


### PR DESCRIPTION
## Summary

- revert merged PRs #1160 and #1162 in one commit so their changes can be resubmitted under the intended GitHub account
- temporarily remove the main-branch host-bundle push trigger during the revert window
- hard-disable the fleet deploy job until the next stacked PR restores deployment containment

## Tests

- focused workflow, gateway, shell, and host-bundle tests: 112 passed
- exact temporary-interlock contract test passed
- git diff check passed

## Review/Monitoring

- first PR in a three-PR stack
- do not retarget or merge the replacement PRs out of order
- after this PR merges, merge the deployment-containment replacement before restoring normal main host-bundle publishing

## Invariants

- source of truth: platform channel pointers and per-host MATRIX_UPDATE_CHANNEL remain unchanged
- lock/transaction scope: no database or filesystem transaction changes
- acceptable orphan states: the temporary branch state permits manual/tag release preparation but no main-triggered release and no fleet deployment
- auth source of truth: existing GitHub environment secrets and platform bearer authentication remain unchanged
- deferred scope: the next two stacked PRs reapply #1160 and #1162 respectively
