### PR TITLE
fix(release): make fleet deployment opt-in

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -1,8 +1,7 @@
 # Host Bundle Release
 #
 # Builds, publishes, and registers the Matrix OS host bundle.
-# TEMPORARY REVERT INTERLOCK: push releases are disabled until the deployment
-# containment change is reapplied in the next stacked PR.
+# Main publishes the dev channel. Tags publish immutable release versions.
 #
 # Version format: v{YYYY.MM.DD}-{run_number} (date-based, monotonically increasing)
 #
@@ -10,12 +9,13 @@
 #   1. ci-gate — wait for same-SHA CI and verify all CI jobs succeeded
 #   2. build — compile gateway, shell, kernel into host bundle tarball
 #   3. publish — upload immutable R2 artifacts and register metadata in platform DB
-#   4. deploy — hard-disabled during the temporary revert window
+#   4. (optional) deploy — explicit dispatches may trigger exact-version VPS deployment
 
 name: Host Bundle Release
 
 on:
   push:
+    branches: [main]
     tags:
       - "v*"
   workflow_dispatch:
@@ -412,7 +412,7 @@ jobs:
   deploy:
     name: Deploy published host bundle
     needs: [dev-bundle-gate, build, publish]
-    if: ${{ false }} # TEMPORARY REVERT INTERLOCK
+    if: ${{ needs.dev-bundle-gate.outputs.should_build == 'true' && github.event_name == 'workflow_dispatch' && inputs.deploy_after_publish && ((github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:

--- a/docs/dev/releases.md
+++ b/docs/dev/releases.md
@@ -28,12 +28,12 @@ that image.
 - `main` is the source of truth. A push to `main` runs `.github/workflows/host-bundle-release.yml`.
 - The workflow builds `dist/host-bundle/matrix-host-bundle.tar.gz`, uploads it to R2, registers it in platform Postgres through `POST /system-bundles/releases`, and promotes the `dev` channel.
 - R2 JSON manifests are not authoritative. The platform DB release row and channel row are authoritative; R2 only holds the tarball and `.sha256` bytes.
-- Existing VPSes are updated by platform deploy fan-out: `POST /vps/deploy {"version":"<version>"}` or `{"channel":"dev"}`.
+- Existing VPS deployments are explicit and opt-in. Normal `main` pushes publish and promote `dev` without deploying any VPS.
 - A customer VPS sync agent fetches DB-backed release metadata, verifies SHA-256, extracts to staging, moves the old app to `/opt/matrix/app.rollback`, moves the new app into `/opt/matrix/app`, writes `/opt/matrix/release.json`, and restarts Matrix services.
 - Host-bundle updates must never overwrite owner data. Do not delete or replace `/home/matrix/home`, `/opt/matrix/env`, or the local Postgres data directory during deploys or rollbacks.
 - `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` and CI/release paths use `pnpm install --frozen-lockfile`; do not bypass either during releases.
 - Host bundle release validation is blocking. If typecheck, tests, public build-env validation, build, publish, or registration fails, do not publish or deploy the bundle.
-- Eligible main/tag releases request a golden snapshot build after publication. This request is an optional acceleration path: enqueue/build failure does not block publication or the unchanged existing-fleet deploy job. See [Golden VPS Snapshots](golden-vps-snapshots.md).
+- Eligible main/tag releases request a golden snapshot build after publication. This request is an optional acceleration path: enqueue/build failure does not block publication or a separately authorized deployment. See [Golden VPS Snapshots](golden-vps-snapshots.md).
 - CLI releases are manual through `.github/workflows/release.yml`; bump `packages/sync-client/package.json`, run the sync-client checks, and dispatch the workflow with the same semver.
 - Fleet upgrade operations, blocked-machine handling, and the durable control-plane setup are documented in [Fleet Upgrade Operations](fleet-upgrade-operations.md).
 - Staging platform containers and disposable feature VPSes are temporary test
@@ -93,23 +93,19 @@ Release metadata also records:
    | `PLATFORM_PUBLIC_URL` | var | publish/deploy; defaults to `https://app.matrix-os.com` |
    | `PLATFORM_SECRET` | secret | release registration and deploy fan-out |
 
-3. Deploy to existing VPSes.
+3. Deploy to existing VPSes only when explicitly authorized.
 
-   During the temporary revert window, `host-bundle-release.yml` has no push
-   trigger and its deploy job is hard-disabled. Do not remove this interlock
-   until the deployment opt-in change is reapplied by the next stacked PR.
+   Normal `main` pushes publish `dev` but do not automatically fan out to the fleet. The workflow-dispatch input `deploy_after_publish` defaults to `false`. Setting `deploy_after_publish=true` intentionally deploys the newly published exact version to the full running fleet, so use it only for a reviewed fleet-wide rollout. Security severity does not override this opt-in deployment gate.
 
-   Normal `main` pushes publish `dev` but do not automatically fan out to the fleet. Trigger deploy after the workflow is green:
+   For a scoped rollout, target each reviewed handle explicitly after the workflow is green:
 
    ```bash
    curl --fail --silent --show-error \
      -X POST https://app.matrix-os.com/vps/deploy \
      -H "Authorization: Bearer $PLATFORM_SECRET" \
      -H "Content-Type: application/json" \
-     -d '{"version":"v2026.05.12-43"}'
+     -d '{"handle":"<reviewed-handle>","version":"v2026.05.12-43"}'
    ```
-
-   Security releases can use the workflow `severity=security` path, which auto-deploys the built version after publish.
 
 4. Verify every VPS.
 

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -460,18 +460,30 @@ describe('CI workflows', () => {
     expect(workflow).toContain('${cache_image}');
   });
 
-  it('temporarily disables host-bundle push releases while the containment fix is reverted', () => {
+  it('publishes main dev host bundles without deploying the fleet', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
+    const releaseDocs = readFileSync(join(root, 'docs/dev/releases.md'), 'utf8');
+    const deployJob = workflow.slice(workflow.indexOf('\n  deploy:'));
 
-    expect(workflow).toContain('TEMPORARY REVERT INTERLOCK');
-    expect(workflow).not.toContain('branches: [main]');
-    expect(workflow).toContain('tags:');
-    expect(workflow).toContain('- "v*"');
+    expect(workflow).toContain('deploy_after_publish:');
     expect(workflow).toMatch(/deploy_after_publish:[\s\S]*?default: false/);
-    expect(workflow).toContain('if: ${{ false }} # TEMPORARY REVERT INTERLOCK');
     expect(workflow).toContain('Deploy published host bundle');
+    expect(deployJob).toContain("github.event_name == 'workflow_dispatch' && inputs.deploy_after_publish");
+    expect(deployJob).toContain("(github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag'");
+    expect(deployJob).not.toContain("github.event_name == 'push'");
+    expect(workflow).not.toContain("|| inputs.severity == 'security'");
     expect(workflow).toContain('PUBLISH_VERSION: ${{ needs.build.outputs.version }}');
     expect(workflow).toContain('VERSION="$PUBLISH_VERSION"');
+    expect(workflow).not.toContain('VERSION="${{ needs.build.outputs.version }}"');
+    expect(workflow).toContain('DEPLOY_RESPONSE="$(curl --fail --silent --show-error --max-time 30 \\');
+    expect(workflow).toContain('failed="$(printf \'%s\' "$DEPLOY_RESPONSE" | jq -r \'.failed // 0\')"');
+    expect(workflow).toContain('triggered="$(printf \'%s\' "$DEPLOY_RESPONSE" | jq -r \'.triggered // 0\')"');
+    expect(workflow).toContain('if [ "$failed" -gt 0 ] || [ "$triggered" -eq 0 ]; then');
+    expect(workflow).toContain('-d "{\\"version\\":\\"$VERSION\\"}"');
+    expect(workflow).not.toContain('Auto-deploy on security severity');
+    expect(releaseDocs).toContain('`deploy_after_publish=true`');
+    expect(releaseDocs).toContain('Security severity does not override this opt-in deployment gate.');
+    expect(releaseDocs).not.toContain('which auto-deploys the built version after publish');
   });
 });


### PR DESCRIPTION
## Summary

- reapply PR #1160 under the intended GitHub account
- restore normal main pushes that publish and promote dev
- keep deployment explicitly opt-in through trusted manual dispatch only
- remove the temporary revert interlock

## Tests

- red contract test against the temporary interlock
- workflow and host-bundle tests: 78 passed
- replacement tree matches the original #1160 final tree exactly

## Review/Monitoring

- second PR in the stack, based on the combined revert PR
- merge only after the combined revert
- verify the post-merge host-bundle workflow skips fleet deployment

## Invariants

- source of truth: platform Postgres remains authoritative for release and channel pointers
- lock/transaction scope: no database writes are introduced by this change
- acceptable orphan states: publication may succeed while the optional golden-snapshot enqueue fails; fleet deployment remains separately authorized
- auth source of truth: PLATFORM_SECRET remains the deploy API credential and is never exposed
- deferred scope: persistent channel reporting and passive downgrade protection return in the next stacked PR
