### PR TITLE
docs(agents): recover durable skill and AGENTS updates

### DIFF
--- a/.agents/skills/clerk-custom-ui/SKILL.md
+++ b/.agents/skills/clerk-custom-ui/SKILL.md
@@ -1,29 +1,61 @@
 ---
 name: clerk-custom-ui
-description: Customize Clerk component appearance - themes, layout, colors, fonts, CSS. Use for appearance styling, visual customization, branding.
+description: Custom authentication flows and component appearance - hooks (useSignIn,
+  useSignUp), themes, colors, fonts, CSS. Use for custom sign-in/sign-up flows, appearance
+  styling, visual customization, branding.
 allowed-tools: WebFetch
 license: MIT
 metadata:
   author: clerk
-  version: "1.0.0"
+  version: 2.3.0
 ---
 
-# Component Customization
+# Custom UI
 
-> **Prerequisite**: Ensure `ClerkProvider` wraps your app. See `setup/`.
+> **Prerequisite**: Ensure `ClerkProvider` wraps your app. See `clerk-setup` skill.
+>
+> **Version**: Check `package.json` for the SDK version — see `clerk` skill for the version table. This determines which custom flow references to use below.
 
-## Component Customization Options
+This skill covers two areas:
+1. **Custom authentication flows** — build your own sign-in/sign-up UI with hooks
+2. **Appearance customization** — theme, style, and brand Clerk's pre-built components
+
+## What Do You Need?
+
+| Task | Reference |
+|------|-----------|
+| Custom sign-in (Core 2 / LTS) | core-2/custom-sign-in.md |
+| Custom sign-up (Core 2 / LTS) | core-2/custom-sign-up.md |
+| Custom sign-in (Current SDK v7+) | core-3/custom-sign-in.md |
+| Custom sign-up (Current SDK v7+) | core-3/custom-sign-up.md |
+| Show component pattern (Current SDK) | core-3/show-component.md |
+
+## Custom Flow References
+
+| Task | Core 2 | Current |
+|------|--------|---------|
+| Custom sign-in (useSignIn) | `core-2/custom-sign-in.md` | `core-3/custom-sign-in.md` |
+| Custom sign-up (useSignUp) | `core-2/custom-sign-up.md` | `core-3/custom-sign-up.md` |
+| `<Show>` component | *(use `<SignedIn>`, `<SignedOut>`, `<Protect>`)* | `core-3/show-component.md` |
+
+---
+
+## Appearance Customization
+
+Appearance customization applies to both Core 2 and the current SDK.
+
+### Component Customization Options
 
 | Task | Documentation |
 |------|---------------|
 | Appearance prop overview | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/overview |
-| Layout (structure, logo, buttons) | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/layout |
+| Options (structure, logo, buttons) | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/layout |
 | Themes (pre-built dark/light) | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/themes |
 | Variables (colors, fonts, spacing) | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/variables |
 | CAPTCHA configuration | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/captcha |
 | Bring your own CSS | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/bring-your-own-css |
 
-## Appearance Pattern
+### Appearance Pattern
 
 ```typescript
 <SignIn
@@ -32,13 +64,15 @@ metadata:
       colorPrimary: '#0000ff',
       borderRadius: '0.5rem',
     },
-    layout: {
+    options: {
       logoImageUrl: '/logo.png',
       socialButtonsVariant: 'iconButton',
     },
   }}
 />
 ```
+
+> **Core 2 ONLY (skip if current SDK):** The `options` property was named `layout`. Use `layout: { logoImageUrl: '...', socialButtonsVariant: '...' }` instead of `options`.
 
 ### variables (colors, typography, borders)
 
@@ -48,45 +82,94 @@ metadata:
 | `colorBackground` | Background color |
 | `borderRadius` | Border radius (default: `0.375rem`) |
 
-### layout (structure, logo, social buttons)
+**Opacity change:** `colorRing` and `colorModalBackdrop` now render at full opacity. Use explicit `rgba()` values if you need transparency.
+
+> **Core 2 ONLY (skip if current SDK):** `colorRing` and `colorModalBackdrop` rendered at 15% opacity by default.
+
+### options (structure, logo, social buttons)
 
 | Property | Description |
 |----------|-------------|
 | `logoImageUrl` | URL to custom logo |
 | `socialButtonsVariant` | `'blockButton'` \| `'iconButton'` \| `'auto'` |
 | `socialButtonsPlacement` | `'top'` \| `'bottom'` |
+| `showOptionalFields` | Show optional fields (default: `false`) |
 
-## shadcn Theme
+> **Core 2 ONLY (skip if current SDK):** This property is called `layout`, not `options`. Also, `showOptionalFields` defaulted to `true`.
 
-**If the project has `components.json`** (shadcn/ui installed), use the shadcn theme:
+### Themes
+
+Install themes from `@clerk/ui`:
+
+```bash
+npm install @clerk/ui
+```
 
 ```typescript
-import { shadcn } from '@clerk/themes'
+import { dark } from '@clerk/ui/themes'
 
-<ClerkProvider
-  appearance={{
-    theme: shadcn,
-  }}
-/>
+<ClerkProvider appearance={{ theme: dark }} />
 ```
 
-Also import shadcn CSS in your global.css:
+> **Core 2 ONLY (skip if current SDK):** Themes are imported from `@clerk/themes` (install `@clerk/themes` instead of `@clerk/ui`). Example: `import { dark } from '@clerk/themes'`.
+
+**Theme stacking** — pass an array where the last theme takes precedence:
+
+```typescript
+import { dark, neobrutalism } from '@clerk/ui/themes'
+
+<ClerkProvider appearance={{ theme: [dark, neobrutalism] }} />
+```
+
+**CSS `color-scheme` support** — the default theme respects the CSS `color-scheme` property for automatic light/dark mode toggling.
+
+**Available themes:** `dark`, `neobrutalism`, `shadcn`, `simple`
+
+#### shadcn Theme
+
+> **IMPORTANT:** If the project has `components.json` (shadcn/ui installed), ALWAYS apply the shadcn theme as the FIRST customization step. This ensures Clerk components visually match the existing shadcn design system. Skip this only if the user explicitly requests a different theme.
+
+**If the project uses shadcn/ui** (check for `components.json` in the project root), **always use the shadcn theme**:
+
+```typescript
+import { shadcn } from '@clerk/ui/themes'
+
+<ClerkProvider appearance={{ theme: shadcn }} />
+```
+
+Also import shadcn CSS in your global styles:
 ```css
 @import 'tailwindcss';
-@import '@clerk/themes/shadcn.css';
+@import '@clerk/ui/themes/shadcn.css';
 ```
+
+> **Core 2 ONLY (skip if current SDK):** Import from `@clerk/themes` and `@clerk/themes/shadcn.css`:
+> ```typescript
+> import { shadcn } from '@clerk/themes'
+> ```
+> ```css
+> @import '@clerk/themes/shadcn.css';
+> ```
+
 ## Workflow
 
-1. Identify customization needs (colors, layout, theme, CSS)
-2. WebFetch the appropriate documentation from table above
-3. Follow official code examples from the docs
-4. Apply appearance prop to your Clerk components
+1. Identify customization needs (custom flow or appearance)
+2. For custom flows: check SDK version → read appropriate `core-2/` or `core-3/` reference
+3. For appearance: WebFetch the appropriate documentation from table above
+4. Apply appearance prop to your Clerk components or build custom flow with hooks
 
 ## Common Pitfalls
 
 | Issue | Solution |
 |-------|----------|
 | Colors not applying | Use `colorPrimary` not `primaryColor` |
-| Logo not showing | Put `logoImageUrl` inside `layout: {}` |
-| Social buttons wrong | Add `socialButtonsVariant: 'iconButton'` in `layout` |
+| Logo not showing | Put `logoImageUrl` inside `options: {}` (or `layout: {}` in Core 2) |
+| Social buttons wrong | Add `socialButtonsVariant: 'iconButton'` in `options` (or `layout` in Core 2) |
 | Styling not working | Use appearance prop, not direct CSS (unless with bring-your-own-css) |
+| Hook returns different shape | Check SDK version — Core 2 and current have completely different `useSignIn`/`useSignUp` APIs |
+
+## See Also
+
+- `clerk-setup` - Initial Clerk install
+- `clerk-nextjs-patterns` - Next.js patterns
+- `clerk-orgs` - B2B organizations

--- a/.agents/skills/clerk-orgs/SKILL.md
+++ b/.agents/skills/clerk-orgs/SKILL.md
@@ -1,87 +1,187 @@
 ---
 name: clerk-orgs
-description: Clerk Organizations for B2B SaaS - create multi-tenant apps with org switching, role-based access, verified domains, and enterprise SSO. Use for team workspaces, RBAC, org-based routing, member management.
+description: Clerk Organizations for B2B SaaS - create multi-tenant apps with org
+  switching, role-based access, verified domains, and enterprise SSO. Use for team
+  workspaces, RBAC, org-based routing, member management.
 allowed-tools: WebFetch
 license: MIT
+compatibility: Requires NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY and CLERK_SECRET_KEY. Organizations must be enabled in Clerk Dashboard → Organizations. Membership mode (required vs optional) must match the B2B vs B2C + B2B coexistence story of your app.
 metadata:
   author: clerk
-  version: "1.0.0"
+  version: 3.0.0
 ---
 
 # Organizations (B2B SaaS)
 
-> **Prerequisite**: Enable Organizations in Clerk Dashboard first.
+> **STOP — prerequisite.** Organizations must be enabled before any org-related API, hook, or component works. Two paths: (1) [Dashboard → Organizations settings](https://dashboard.clerk.com/last-active?path=organizations-settings), or (2) `clerk enable orgs` (see "Agent-first: Programmatic org management" below). Pick the Membership mode deliberately: `Membership required` (default since 2025-08-22) routes signed-in users through the `choose-organization` task and disables personal accounts, while `Membership optional` keeps personal accounts available for B2C + B2B coexistence. Pick `optional` if you need personal subscriptions alongside org subscriptions.
+>
+> **Version**: This skill targets current SDKs (`@clerk/nextjs` v7+, `@clerk/react` v6+ — Core 3). Core 2 differences are noted inline with `> **Core 2 ONLY (skip if current SDK):**` callouts — see `clerk` skill for the full version table.
 
 ## Quick Start
 
-1. **Create an organization via dashboard** or through Clerk API
-2. **Use OrganizationSwitcher** to let users switch between orgs
-3. **Protect routes** using orgSlug from URL and role checks
+1. **Enable Organizations** — via [Dashboard → Organizations settings](https://dashboard.clerk.com/last-active?path=organizations-settings) or `clerk enable orgs` (see Agent-first section). Pick `Membership required` (B2B-only) or `Membership optional` (B2C + B2B).
+2. **Create an org** — via `<OrganizationSwitcher />`, `<CreateOrganization />`, or programmatically with `clerkClient().organizations.createOrganization()`.
+3. **Protect routes** — read `orgId` / `orgSlug` from `auth()` and gate with `has({ role })` or `has({ permission })`.
+4. **Manage members** — send invitations via Backend API or the built-in `<OrganizationProfile />` tab.
+5. **Cap membership** — set `maxAllowedMemberships` at org creation or pick a seat-limited Billing Plan (see `clerk-billing` skill).
 
-## Documentation Reference
+## What Do You Need?
 
-| Task | Link |
-|------|------|
-| Overview | https://clerk.com/docs/guides/organizations/overview |
-| Org slugs in URLs | https://clerk.com/docs/guides/organizations/org-slugs-in-urls |
-| Roles & permissions | https://clerk.com/docs/guides/organizations/control-access/roles-and-permissions |
-| Check access | https://clerk.com/docs/guides/organizations/control-access/check-access |
-| Invitations | https://clerk.com/docs/guides/organizations/add-members/invitations |
-| OrganizationSwitcher | https://clerk.com/docs/reference/components/organization/organization-switcher |
-| Verified domains | https://clerk.com/docs/guides/organizations/verified-domains |
-| Enterprise SSO | https://clerk.com/docs/guides/organizations/add-members/sso |
+| Task | Reference |
+|------|-----------|
+| System permissions catalog, custom roles, role sets | references/roles-permissions.md |
+| Invitation lifecycle (create, list, revoke, built-in UI) | references/invitations.md |
+| Enterprise SSO setup, provider field access, domain verification | references/enterprise-sso.md |
+| Next.js adaptations for orgs (role/permission middleware, slug invariants, orgId-scoped writes) | references/nextjs-patterns.md |
+
+## References
+
+| Reference | Description |
+|-----------|-------------|
+| `references/roles-permissions.md` | Default + custom roles, System Permissions catalog, permission naming |
+| `references/invitations.md` | Backend API for invitations + built-in UI |
+| `references/enterprise-sso.md` | SAML/OIDC per-org, domain verification, correct field access |
+| `references/nextjs-patterns.md` | Next.js adaptations specific to orgs. For generic Next.js patterns see `clerk-nextjs-patterns` skill. |
+
+## Dashboard shortcuts
+
+| Action | URL |
+|---|---|
+| Enable Organizations + Membership mode | `https://dashboard.clerk.com/last-active?path=organizations-settings` |
+| Manage roles + permissions | `https://dashboard.clerk.com/last-active?path=organizations-settings/roles` |
+| Create/edit an organization | `https://dashboard.clerk.com/last-active?path=organizations` |
+| Webhooks for org events | `https://dashboard.clerk.com/last-active?path=webhooks` |
+
+## Agent-first: Programmatic org management
+
+Org settings (enable toggle, membership cap, admin delete, domains) are patchable via PLAPI Instance Config. Org CRUD + memberships + invitations live in BAPI. Useful for agents seeding orgs, replicating settings across instances, or version-controlling org structure.
+
+Pre-req: project linked (`clerk auth login` + `clerk link`, see `clerk-setup`).
+
+### Enable Organizations + settings via CLI
+
+```bash
+clerk enable orgs
+```
+
+For additional settings (membership cap, verified domains, admin delete), patch the instance config:
+
+```bash
+clerk api --platform PATCH /v1/platform/applications/<app_id>/instances/<ins_id>/config \
+  -d '{"organization_settings":{"max_allowed_memberships":50,"domains_enabled":true,"admin_delete_enabled":true}}'
+```
+
+### Create / list / delete orgs (BAPI)
+
+```bash
+# Create:
+clerk api -X POST /v1/organizations \
+  -d '{"name":"Acme","slug":"acme","created_by":"user_xxx","max_allowed_memberships":10}'
+
+# List:
+clerk api /v1/organizations --query 'limit=20'
+
+# Get one:
+clerk api /v1/organizations/<org_id>
+
+# Update:
+clerk api -X PATCH /v1/organizations/<org_id> -d '{"name":"Acme Inc."}'
+
+# Delete:
+clerk api -X DELETE /v1/organizations/<org_id>
+```
+
+### Memberships
+
+```bash
+# Add a user to an org:
+clerk api -X POST /v1/organizations/<org_id>/memberships \
+  -d '{"user_id":"user_xxx","role":"org:admin"}'
+
+# List members:
+clerk api /v1/organizations/<org_id>/memberships --query 'limit=50'
+
+# Update role:
+clerk api -X PATCH /v1/organizations/<org_id>/memberships/<user_id> \
+  -d '{"role":"org:member"}'
+
+# Remove:
+clerk api -X DELETE /v1/organizations/<org_id>/memberships/<user_id>
+```
+
+### Invitations
+
+```bash
+# Send:
+clerk api -X POST /v1/organizations/<org_id>/invitations \
+  -d '{"email_address":"alice@example.com","role":"org:member","redirect_url":"https://app.com/accept"}'
+
+# List pending:
+clerk api /v1/organizations/<org_id>/invitations --query 'status=pending'
+
+# Revoke:
+clerk api -X POST /v1/organizations/<org_id>/invitations/<inv_id>/revoke \
+  -d '{"requesting_user_id":"user_xxx"}'
+```
+
+### Notes
+
+- This handles **org config + CRUD**. Subscription / billing for orgs (org plans, seat-limit pricing) flows through `clerk-billing` skill.
+- Roles + permissions catalog is editable in `references/roles-permissions.md`. Custom role creation goes through `clerk config patch` (instance-level role definitions) — see Dashboard's role editor for the UX equivalent.
+- For SSO / verified domain provisioning, see `references/enterprise-sso.md`.
+
+## Documentation
+
+- [Overview](https://clerk.com/docs/guides/organizations/overview)
+- [Configure + enable](https://clerk.com/docs/guides/organizations/configure)
+- [Roles and permissions](https://clerk.com/docs/guides/organizations/control-access/roles-and-permissions)
+- [Check access](https://clerk.com/docs/guides/organizations/control-access/check-access)
+- [Invitations](https://clerk.com/docs/guides/organizations/add-members/invitations)
+- [OrganizationSwitcher](https://clerk.com/docs/reference/components/organization/organization-switcher)
+- [Verified domains](https://clerk.com/docs/guides/organizations/add-members/verified-domains)
+- [Enterprise SSO](https://clerk.com/docs/guides/organizations/add-members/sso)
 
 ## Key Patterns
 
-### 1. Get Organization from Auth
+Examples use `@clerk/nextjs` by default. For other frameworks swap the import to `@clerk/react` (Vite/CRA), `@clerk/astro/components`, `@clerk/vue`, `@clerk/expo`, `@clerk/react-router`, or `@clerk/tanstack-react-start` — the feature-level APIs (`has()`, `orgId`, `<OrganizationSwitcher />`, `<Show>`) are identical across SDKs. Framework-specific patterns (middleware, redirects) live in `references/nextjs-patterns.md`.
 
-Server-side access to organization:
+### 1. Read Organization from Auth
+
+Server-side access to active organization:
 
 ```typescript
 import { auth } from '@clerk/nextjs/server'
 
-const { orgId, orgSlug } = await auth()
-console.log(`Current org: ${orgSlug}`)
+const { orgId, orgSlug, orgRole } = await auth()
+if (!orgId) {
+  // user has no active org — either not in any, or viewing Personal Account
+}
 ```
+
+`auth()` is Next.js-specific. Equivalent server-side accessors per SDK: `auth(event)` (Nuxt via `event.context.auth()`), `context.locals.auth()` (Astro), `getAuth(req)` (Express, after `clerkMiddleware()`). Client-side: `useAuth()` (React-based SDKs) or composables (Vue/Nuxt). All return the same `orgId` / `orgSlug` / `orgRole` shape.
 
 ### 2. Dynamic Routes with Org Slug
 
-Create routes that accept org slug:
+Route-per-org pattern works in any framework supporting file-based dynamic routes. Next.js example:
 
 ```
 app/orgs/[slug]/page.tsx
 app/orgs/[slug]/settings/page.tsx
 ```
 
-Access the slug:
+Always verify the URL slug matches the active org slug — otherwise users can hit `/orgs/other-org/...` with a stale `orgSlug` in their session:
 
 ```typescript
-export default function DashboardPage({ params }: { params: { slug: string } }) {
-  return <div>Organization: {params.slug}</div>
-}
-```
-
-### 3. Check Organization Membership
-
-Verify user has access to specific org:
-
-```typescript
-import { auth } from '@clerk/nextjs/server'
-
-export default async function ProtectedPage() {
-  const { orgId, orgSlug } = await auth()
-
-  if (!orgId) {
-    return <div>Not in an organization</div>
+export default async function OrgPage({ params }: { params: { slug: string } }) {
+  const { orgSlug } = await auth()
+  if (orgSlug !== params.slug) {
+    redirect('/dashboard')  // or whatever your "no-access" flow is
   }
-
   return <div>Welcome to {orgSlug}</div>
 }
 ```
 
-### 4. Role-Based Access Control
-
-Check if user has specific role:
+### 3. Role-Based Access Control
 
 ```typescript
 const { has } = await auth()
@@ -91,46 +191,180 @@ if (!has({ role: 'org:admin' })) {
 }
 ```
 
-### 5. OrganizationSwitcher Component
-
-Let users switch between organizations:
+Permission checks use the same `has()` surface:
 
 ```typescript
-import { OrganizationSwitcher } from '@clerk/nextjs'
-
-export default function Nav() {
-  return (
-    <header>
-      <h1>Dashboard</h1>
-      <OrganizationSwitcher />
-    </header>
-  )
+if (!has({ permission: 'org:sys_memberships:manage' })) {
+  redirect('/unauthorized')
 }
 ```
 
-## Default Roles
+**Permission naming convention.** System Permissions prefix with `org:sys_`; custom Permissions use `org:<resource>:<action>`. The full System Permissions catalog lives in `references/roles-permissions.md` — the short list is:
 
-All new members get assigned a role:
+- `org:sys_memberships:{read, manage}`
+- `org:sys_profile:{manage, delete}`
+- `org:sys_domains:{read, manage}`
+- `org:sys_billing:{read, manage}`
 
-| Role | Permissions |
+Do NOT invent names like `org:create`, `org:manage_members`, `org:update_metadata` — those are not real permission slugs. See `references/roles-permissions.md` for custom roles and the permission table.
+
+### 4. Conditional Rendering with `<Show>`
+
+```tsx
+import { Show } from '@clerk/nextjs'
+
+<Show when={{ role: 'org:admin' }}>
+  <AdminPanel />
+</Show>
+
+<Show when={{ permission: 'org:sys_memberships:manage' }}>
+  <MembersTab />
+</Show>
+```
+
+> **Core 2 ONLY (skip if current SDK):** Use `<Protect role="org:admin">` / `<Protect permission="...">` instead of `<Show>`. `<Show>` replaced both `<Protect>` and `<SignedIn>`/`<SignedOut>` in Core 3.
+
+Astro template syntax for the same component (imported from `@clerk/astro/components`):
+
+```astro
+<Show when={{ role: 'org:admin' }}>
+  <AdminPanel />
+</Show>
+```
+
+### 5. OrganizationSwitcher
+
+```tsx
+import { OrganizationSwitcher } from '@clerk/nextjs'
+
+<OrganizationSwitcher
+  hidePersonal
+  afterCreateOrganizationUrl="/orgs/:slug/dashboard"
+  afterSelectOrganizationUrl="/orgs/:slug/dashboard"
+/>
+```
+
+Key props:
+- `hidePersonal: boolean` — hide the Personal Account option. Defaults to `false`. Pass `true` for B2B-only apps.
+- `afterCreateOrganizationUrl`, `afterSelectOrganizationUrl`, `afterLeaveOrganizationUrl`, `afterSelectPersonalUrl` — navigation hooks. `:slug` is substituted at runtime.
+- `createOrganizationMode`, `organizationProfileMode` — `'modal' | 'navigation'` (default `'modal'`).
+
+The full prop list lives in the [component reference](https://clerk.com/docs/reference/components/organization/organization-switcher).
+
+### 6. Session Task — Choose Organization
+
+When `Membership required` is enabled (the default), users without an org are routed through a `choose-organization` session task after sign-in. Clerk handles this automatically inside `<SignIn />`, but you can host the UI yourself:
+
+```tsx
+import { ClerkProvider } from '@clerk/nextjs'
+
+<ClerkProvider taskUrls={{ 'choose-organization': '/session-tasks/choose-organization' }}>
+  {children}
+</ClerkProvider>
+```
+
+```tsx
+// app/session-tasks/choose-organization/page.tsx
+import { TaskChooseOrganization } from '@clerk/nextjs'
+
+export default function Page() {
+  return <TaskChooseOrganization redirectUrlComplete="/dashboard" />
+}
+```
+
+`TaskChooseOrganization` ships as an imported component in the React-based SDKs (`@clerk/nextjs`, `@clerk/react`, `@clerk/react-router`, `@clerk/tanstack-react-start`). For the JS Frontend SDK (`@clerk/clerk-js`) the equivalent is `clerk.mountTaskChooseOrganization(node)` / `clerk.unmountTaskChooseOrganization(node)`.
+
+> **Core 2 ONLY (skip if current SDK):** Session tasks aren't available. Force an org selection at sign-in by redirecting to a page that renders `<OrganizationSwitcher hidePersonal />`.
+
+## Default Roles + System Permissions
+
+| Role | Default meaning |
 |------|-------------|
-| `org:admin` | Full access, manage members, settings |
-| `org:member` | Limited access, read-only |
+| `org:admin` | Full access — all System Permissions, can manage org + memberships |
+| `org:member` | Read members + Read billing Permissions only |
 
-Custom roles can be created in the dashboard.
+You can create up to 10 custom roles per instance in Dashboard → Organizations → Roles & Permissions. Role-per-org is controlled via **Role Sets** — see `references/roles-permissions.md` for the full model (custom roles, Creator/Default role settings, role sets, and the System Permissions catalog).
 
-## Default Permissions
+## Billing Checks
 
-| Permission | Role |
-|-----------|------|
-| `org:create` | Can create new organizations |
-| `org:manage_members` | Can invite/remove members (default: admin) |
-| `org:manage_roles` | Can change member roles (default: admin) |
-| `org:update_metadata` | Can update org metadata (default: admin) |
+`has()` also supports plan and feature checks when Clerk Billing is enabled:
 
-## Authorization Pattern
+```typescript
+const { has } = await auth()
 
-Complete example protecting a route:
+has({ plan: 'gold' })        // subscription plan
+has({ feature: 'widgets' })  // feature entitlement
+```
+
+> **Core 2 ONLY (skip if current SDK):** `has()` only supports `role` and `permission`. Billing checks aren't available.
+
+See `clerk-billing` for the full Billing surface and seat-limit plan model.
+
+## Enterprise SSO
+
+Per-org SAML/OIDC. Configured in Dashboard → Configure → Enterprise Connections (or per-org: Organizations → select org → SSO Connections). The SSO connection owns its domain directly; no separate Verified Domain is required (and the two features are mutually exclusive on the same domain). Auto-join on first SSO sign-in uses JIT Provisioning, not Verified Domains. Key fact: the `provider` field lives on `enterpriseConnection`, not on `enterpriseAccounts[0]` directly. See `references/enterprise-sso.md` for the full flow and correct field access.
+
+```typescript
+// Strategy name for Enterprise SSO (Core 3)
+strategy: 'enterprise_sso'
+```
+
+> **Core 2 ONLY (skip if current SDK):** Uses `strategy: 'saml'` and `user.samlAccounts` instead of `user.enterpriseAccounts`.
+
+## Gotchas
+
+### `maxAllowedMemberships` caps seats
+
+```typescript
+const clerk = await clerkClient()
+await clerk.organizations.createOrganization({
+  name: 'Acme Corp',
+  createdBy: userId,
+  maxAllowedMemberships: 10,
+})
+
+// Update later:
+await clerk.organizations.updateOrganization(orgId, {
+  maxAllowedMemberships: 25,
+})
+```
+
+For tier-based seat limits tied to a subscription, use a seat-limited Billing Plan (see `clerk-billing`).
+
+### Billing gates Permissions at the Feature level
+
+When Clerk Billing is enabled, `has({ permission: 'org:posts:edit' })` returns `false` if the Feature associated with that permission is not included in the organization's active Plan — even if the user has the Permission assigned via their role. Ensure the Feature is attached to the active Plan in Dashboard → Billing → Plans → Features.
+
+### Metadata updates REPLACE, not merge
+
+`updateOrganization({ publicMetadata })` overwrites all public metadata. Read first, spread, then write:
+
+```typescript
+const org = await clerk.organizations.getOrganization({ organizationId: orgId })
+await clerk.organizations.updateOrganization(orgId, {
+  publicMetadata: { ...org.publicMetadata, newField: 'value' },
+})
+```
+
+Applies identically to `privateMetadata` and to user metadata via `clerkClient.users.updateUser`.
+
+## Error Signatures (diagnose fast)
+
+Most "org-related" failures are configuration, not code. Do not edit components before checking these:
+
+| Error / symptom | Root cause | Fix |
+|---|---|---|
+| `orgId` / `orgSlug` is `undefined` for a signed-in user | Organizations not enabled for this instance, OR user has no active org (personal account) | Enable in Dashboard → Organizations; check Membership mode; surface `<OrganizationSwitcher />` |
+| `has({ permission: 'org:manage_members' })` always `false` | Using an invented permission slug | Use `org:sys_memberships:manage` (see roles-permissions.md catalog) |
+| `has({ role })` returns `false` but user looks like an admin | Session token stale after role change | Re-sign-in, or refresh the session: `await clerk.session?.reload()` |
+| `has({ permission })` `false` even with the role assigned | Feature not attached to active Plan (Billing gates permissions) | Dashboard → Billing → Plans → attach Feature |
+| `<OrganizationSwitcher />` doesn't show "Personal Account" | `Membership required` mode is on (the default since Aug 22, 2025) | Dashboard → Organizations settings → `Membership optional` |
+| `TaskChooseOrganization` throws "cannot render when a user doesn't have current session tasks" | Rendered outside a `choose-organization` task context | Wrap in a `choose-organization` session-task route only; don't render unconditionally |
+| `enterpriseAccounts[0].provider` is `undefined` | Accessing `provider` at the wrong nesting level | Use `user.enterpriseAccounts[0].enterpriseConnection?.provider` |
+
+## Authorization Pattern (Complete Example)
+
+Server component protecting a slug-scoped admin page:
 
 ```typescript
 import { auth } from '@clerk/nextjs/server'
@@ -139,35 +373,56 @@ import { redirect } from 'next/navigation'
 export default async function AdminPage({ params }: { params: { slug: string } }) {
   const { orgSlug, has } = await auth()
 
-  // Verify user is in the org
-  if (orgSlug !== params.slug) {
-    redirect('/dashboard')
-  }
-
-  // Check if admin
-  if (!has({ role: 'org:admin' })) {
-    redirect(`/orgs/${orgSlug}`)
-  }
+  if (orgSlug !== params.slug) redirect('/dashboard')
+  if (!has({ role: 'org:admin' })) redirect(`/orgs/${orgSlug}`)
 
   return <div>Admin settings for {orgSlug}</div>
 }
 ```
 
-## Common Pitfalls
+For middleware-level protection (Next.js) see `references/nextjs-patterns.md`.
 
-| Symptom | Cause | Solution |
-|---------|-------|----------|
-| `orgSlug` is undefined | Not calling `await auth()` | Use `const { orgSlug } = await auth()` |
-| Role check always fails | Not awaiting `auth()` | Add `await` before `auth()` |
-| Users can access other orgs | Not checking orgSlug matches URL | Verify `orgSlug === params.slug` |
-| Org not appearing in switcher | Organizations not enabled | Enable in Clerk Dashboard → Organizations |
-| Invitations not working | Wrong role configuration | Ensure members have invite role permissions |
+## Invitations (short form)
+
+Send from a server action or route handler:
+
+```typescript
+import { clerkClient, auth } from '@clerk/nextjs/server'
+
+export async function inviteMember(organizationId: string, emailAddress: string, role: string) {
+  const { userId, has } = await auth()
+
+  if (!userId) throw new Error('Not signed in')
+  if (!has({ permission: 'org:sys_memberships:manage' })) {
+    throw new Error('Not authorized to invite members')
+  }
+
+  const clerk = await clerkClient()
+  return clerk.organizations.createOrganizationInvitation({
+    organizationId,
+    inviterUserId: userId,       // required per Backend API
+    emailAddress,
+    role,                        // e.g. 'org:admin' or 'org:member'
+    redirectUrl: 'https://yourapp.com/accept-invite',
+  })
+}
+```
+
+The full lifecycle (list, revoke, bulk create, built-in `<OrganizationProfile />` UI) lives in `references/invitations.md`.
 
 ## Workflow
 
-1. **Setup** - Enable Organizations in Clerk Dashboard
-2. **Create org** - Users create org or admin creates via API
-3. **Add members** - Send invitations or add directly
-4. **Assign roles** - Default member role, promote to admin as needed
-5. **Build protected routes** - Use auth() to check orgSlug and roles
-6. **Use OrganizationSwitcher** - Let users switch between orgs
+1. **Enable** — Organizations + Membership mode in Dashboard
+2. **Create org** — via UI component or Backend API
+3. **Invite members** — Backend API or built-in UI, with `inviterUserId`
+4. **Gate access** — `has({ role })` / `has({ permission })` with canonical `org:sys_*` names
+5. **Scope routes** — `orgSlug === params.slug` on every protected page
+6. **Switch orgs** — `<OrganizationSwitcher />` handles the whole flow
+
+## See Also
+
+- `clerk-setup` — Initial Clerk install
+- `clerk-billing` — Seat-limit plans, per-plan billing, `has({ plan })` / `has({ feature })`
+- `clerk-webhooks` — Sync org events to your database (`organization.created`, `organizationMembership.*`)
+- `clerk-backend-api` — Full Backend API reference
+- `clerk-nextjs-patterns` — Framework-specific middleware, server actions, caching

--- a/.agents/skills/clerk-setup/SKILL.md
+++ b/.agents/skills/clerk-setup/SKILL.md
@@ -1,25 +1,88 @@
 ---
 name: clerk-setup
-description: Add Clerk authentication to any project by following the official quickstart guides.
+description: Add Clerk authentication to any project by following the official quickstart
+  guides.
 license: MIT
 allowed-tools: WebFetch
+compatibility: Requires NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY and CLERK_SECRET_KEY (or framework-specific equivalents like VITE_CLERK_PUBLISHABLE_KEY for Vite-based apps). Keys can be auto-generated via Keyless on first SDK initialization, or pulled from the Clerk Dashboard. Requires Node.js 20.9.0 or higher.
 metadata:
   author: clerk
-  version: "1.0.0"
+  version: 2.3.0
 ---
 
 # Adding Clerk
 
-This skill sets up Clerk for authentication by following the official quickstart documentation.
+> **Version**: Check `package.json` for the SDK version — see `clerk` skill for the version table. Core 2 differences are noted inline with `> **Core 2 ONLY (skip if current SDK):**` callouts.
 
-## Quick Reference
+This skill sets up Clerk for authentication by following the official quickstart documentation. For agents, the `clerk` CLI handles most of this end to end — see the next section.
+
+## Agent-first: Provision via CLI
+
+The `clerk` CLI replaces most Dashboard clicks. Three scenarios cover almost everything:
+
+### Scenario A — New project, new Clerk app
+
+```bash
+clerk init --framework <next|react|vue|nuxt|astro|react-router|tanstack-react-start|expressjs|fastify|expo> -y
+```
+
+`clerk init` creates the Clerk app via PLAPI, links the project, writes the framework-specific publishable + secret keys to the right env file (e.g. `.env.local` for Next.js, `.env` for Vite-based projects), and installs the SDK package.
+
+### Scenario B — Existing project, existing Clerk app
+
+```bash
+clerk auth login                      # one-time OAuth (skip if already logged in)
+clerk link                            # autolinks if a CLERK_PUBLISHABLE_KEY is in your .env
+clerk link --app app_xxx              # explicit form, required in agent mode
+clerk env pull                        # writes the framework-detected env vars
+```
+
+### Scenario C — Existing project, new Clerk app
+
+```bash
+clerk auth login
+clerk apps create "My App" --json     # returns the new app_id
+clerk link --app app_xxx
+clerk env pull
+```
+
+### Daily ops
+
+```bash
+clerk env pull                        # refresh keys (uses linked profile)
+clerk env pull --instance prod        # production keys
+clerk doctor --json                   # framework integration health check
+```
+
+### Rotate the secret key (replaces Dashboard rotation)
+
+PLAPI exposes secret-key rotation directly. Use raw `clerk api` until the friendly wrapper ships:
+
+```bash
+clerk api --platform POST /v1/platform/applications/<app_id>/rotate_secret_keys \
+  -d '{"delay_old_secrets_expiration_hours": 24, "reason": "scheduled rotation"}'
+```
+
+`delay_old_secrets_expiration_hours` keeps the old key valid for the grace period so deploys can roll forward without downtime.
+
+### Notes for agents
+
+- `clerk link` (no flags) only autolinks when a `CLERK_PUBLISHABLE_KEY` is already in `.env` / `.env.local`. Without it, agent mode errors out: "Cannot select an application in agent mode." When that happens, run `clerk apps list --json`, and ask the user which `app_id` to link rather than guessing.
+- Pass `--json` on `apps list/create`, `users create`, and `doctor` for parseable output.
+- The CLI auto-detects framework env var names (`VITE_CLERK_PUBLISHABLE_KEY` for Vite, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` for Next.js, etc.) and target file (`.env.development.local` > `.env.local` > `.env`).
+
+## Quick Reference (Dashboard fallback)
+
+If the CLI isn't an option (sandboxed environments, docs walkthroughs), here's the manual Dashboard path:
 
 | Step | Action |
 |------|--------|
 | 1. Detect framework | Check `package.json` dependencies |
 | 2. Fetch quickstart | Use WebFetch on the appropriate docs URL |
-| 3. Follow instructions | Execute the steps from the official guide |
-| 4. Get API keys | From [dashboard.clerk.com](https://dashboard.clerk.com/last-active?path=api-keys) |
+| 3. Follow instructions | Execute steps; create `proxy.ts` (Next.js <=15: `middleware.ts`) |
+| 4. Get API keys | From [dashboard.clerk.com](https://dashboard.clerk.com/~/api-keys) |
+
+> If the project has `components.json` (shadcn/ui), apply the shadcn theme after setup. See `clerk-custom-ui` skill → shadcn Theme.
 
 ## Framework Detection
 
@@ -28,10 +91,10 @@ Check `package.json` to identify the framework:
 | Dependency | Framework | Quickstart URL |
 |------------|-----------|----------------|
 | `next` | Next.js | `https://clerk.com/docs/nextjs/getting-started/quickstart` |
-| `@remix-run/react` | Remix | `https://clerk.com/docs/remix/getting-started/quickstart` |
+| `@remix-run/react` | Remix (deprecated) | Migrate to React Router v7 — use the React Router quickstart below |
+| `react-router` | React Router (v7+) | `https://clerk.com/docs/react-router/getting-started/quickstart` |
 | `astro` | Astro | `https://clerk.com/docs/astro/getting-started/quickstart` |
 | `nuxt` | Nuxt | `https://clerk.com/docs/nuxt/getting-started/quickstart` |
-| `react-router` | React Router | `https://clerk.com/docs/react-router/getting-started/quickstart` |
 | `@tanstack/react-start` | TanStack Start | `https://clerk.com/docs/tanstack-react-start/getting-started/quickstart` |
 | `react` (no framework) | React SPA | `https://clerk.com/docs/react/getting-started/quickstart` |
 | `vue` | Vue | `https://clerk.com/docs/vue/getting-started/quickstart` |
@@ -53,17 +116,13 @@ User Request: "Add Clerk" / "Add authentication"
     ├─ Read package.json
     │
     ├─ Existing auth detected?
-    │   │
-    │   ├─ YES → Audit current auth → Create migration plan
-    │   │        → See "Migrating from Another Auth Provider"
-    │   │
+    │   ├─ YES → Audit → Migration plan
     │   └─ NO → Fresh install
     │
-    ├─ Identify framework from dependencies
+    ├─ Identify framework → WebFetch quickstart → Follow instructions
+    │   └─ Next.js? → Create proxy.ts (Next.js <=15: middleware.ts)
     │
-    ├─ WebFetch the appropriate quickstart URL
-    │
-    └─ Follow the official instructions step-by-step
+    └─ components.json exists? → YES → Apply shadcn theme (see clerk-custom-ui)
 ```
 
 ## Setup Process
@@ -86,21 +145,26 @@ Prompt: "Extract the complete setup instructions including all code snippets, fi
 Execute each step from the quickstart guide:
 - Install the required packages
 - Set up environment variables
-- Add the provider/middleware
+- Add the provider and proxy/middleware
 - Create sign-in/sign-up routes if needed
 - Test the integration
+
+> **Next.js:** Create `proxy.ts` (Next.js <=15: `middleware.ts`). See the `clerk-nextjs-patterns` skill for middleware strategies.
+
+> **shadcn/ui detected** (`components.json` exists): ALWAYS apply the shadcn theme. See `clerk-custom-ui` skill → shadcn Theme section.
 
 ### 4. Get API Keys
 
 Two paths for development API keys:
 
 **Keyless (Automatic)**
-- On first SDK initialization, Clerk auto-generates dev keys and shows "Claim your application" popover
-- No manual key setup required—keys are created and injected automatically
+- On first SDK initialization, Clerk auto-generates dev keys and shows a "Configure your application" button in the bottom right of the running app
+- No manual key setup required, keys are created and injected automatically
+- Selecting "Configure your application" associates the auto-generated app with your Clerk account so you can edit it from the Dashboard
 - Simplest path for new projects
 
 **Manual (Dashboard)**
-- Get keys from [dashboard.clerk.com](https://dashboard.clerk.com/last-active?path=api-keys) if Keyless doesn't trigger
+- Get keys from [dashboard.clerk.com](https://dashboard.clerk.com/~/api-keys) if Keyless doesn't trigger
 - **Publishable Key**: Starts with `pk_test_` or `pk_live_`
 - **Secret Key**: Starts with `sk_test_` or `sk_live_`
 - Set as environment variables: `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY`
@@ -143,25 +207,118 @@ Check `package.json` for existing auth libraries:
 
 - **Migration Overview**: https://clerk.com/docs/guides/development/migrating/overview
 
+## SDK Notes
+
+### Package Names
+
+| Package | Install |
+|---------|---------|
+| Next.js | `@clerk/nextjs` |
+| React | `@clerk/react` |
+| Expo | `@clerk/expo` |
+| React Router | `@clerk/react-router` |
+| TanStack Start | `@clerk/tanstack-react-start` |
+
+> **Core 2 ONLY (skip if current SDK):** React and Expo packages have different names: `@clerk/clerk-react` and `@clerk/clerk-expo` (with `clerk-` prefix).
+
+### ClerkProvider Placement (Next.js)
+
+`ClerkProvider` must be placed **inside `<body>`**, not wrapping `<html>`:
+
+```tsx
+// root layout.tsx
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        <ClerkProvider>{children}</ClerkProvider>
+      </body>
+    </html>
+  )
+}
+```
+
+> **Core 2 ONLY (skip if current SDK):** `ClerkProvider` can wrap `<html>` directly.
+
+### Dynamic Rendering (Next.js)
+
+For dynamic rendering with auth data, use the `dynamic` prop:
+
+```tsx
+<ClerkProvider dynamic>{children}</ClerkProvider>
+```
+
+### Node.js Requirement
+
+Requires **Node.js 20.9.0** or higher.
+
+> **Core 2 ONLY (skip if current SDK):** Minimum Node.js 18.17.0.
+
+### Themes Package
+
+Themes are installed from `@clerk/ui`:
+
+```bash
+npm install @clerk/ui
+```
+
+> **Core 2 ONLY (skip if current SDK):** Themes are from `@clerk/themes` instead of `@clerk/ui`.
+
+### shadcn Theme
+
+If the project uses shadcn/ui (check for `components.json` in the project root), apply the shadcn theme so Clerk components match the app's design system:
+
+```bash
+npm install @clerk/ui
+```
+
+```tsx
+import { shadcn } from '@clerk/ui/themes'
+
+<ClerkProvider appearance={{ theme: shadcn }}>{children}</ClerkProvider>
+```
+
+Also import the shadcn CSS in your global styles:
+```css
+@import 'tailwindcss';
+@import '@clerk/ui/themes/shadcn.css';
+```
+
+> **Core 2 ONLY (skip if current SDK):** Import from `@clerk/themes` and `@clerk/themes/shadcn.css` instead.
+
 ## Common Pitfalls
 
-| Level | Issue | Solution |
-|-------|-------|----------|
-| CRITICAL | Missing `await` on `auth()` | In Next.js 15+, `auth()` is async: `const { userId } = await auth()` |
-| CRITICAL | Exposing `CLERK_SECRET_KEY` | Never use secret key in client code; only `NEXT_PUBLIC_*` keys are safe |
-| HIGH | Missing middleware matcher | Include API routes: `matcher: ['/((?!.*\\..*|_next).*)', '/']` |
-| HIGH | ClerkProvider not at root | Must wrap entire app in root layout/App component |
-| HIGH | Auth routes not public | Allow `/sign-in`, `/sign-up` in middleware config |
-| HIGH | Landing page requires auth | To keep "/" public, exclude it: `matcher: ['/((?!.*\\..*|_next|^/$).*)', '/api/(.*)']` |
-| MEDIUM | Wrong import path | Server code uses `@clerk/nextjs/server`, client uses `@clerk/nextjs` |
+> **Run `clerk doctor` first.** It checks framework integration, env vars, middleware presence, and SDK install status. Fixes a lot of these in one shot.
+
+| Issue | Solution |
+|-------|----------|
+| Missing `await` on `auth()` | In Next.js 15+, `auth()` is async: `const { userId } = await auth()` |
+| Exposing `CLERK_SECRET_KEY` | Never use the secret key in client code; only `NEXT_PUBLIC_*` keys are safe |
+| Missing middleware matcher | Include API routes: `matcher: ['/((?!.*\\..*|_next).*)', '/']` |
+| ClerkProvider placement | Must be inside `<body>` in root layout (Core 2: could wrap `<html>`) |
+| Auth routes not public | Allow `/sign-in`, `/sign-up` in middleware config |
+| Landing page requires auth | To keep "/" public, exclude it: `matcher: ['/((?!.*\\..*|_next|^/$).*)', '/api/(.*)']` |
+| Wrong import path | Server code uses `@clerk/nextjs/server`, client uses `@clerk/nextjs` |
+| Wrong package name | Use `@clerk/react` not `@clerk/clerk-react` (Core 2 naming) |
 
 ## See Also
 
-- `custom-flows/` - Custom sign-in/up components
-- `syncing-users/` - Webhook → database sync
-- `managing-orgs/` - B2B multi-tenant organizations
-- `testing/` - E2E testing setup
-- `nextjs-patterns/` - Advanced Next.js patterns
+- `clerk-custom-ui` - Custom sign-in/up components
+- `clerk-nextjs-patterns` - Advanced Next.js patterns
+- `clerk-react-patterns` - React SPA patterns
+- `clerk-react-router-patterns` - React Router patterns
+- `clerk-vue-patterns` - Vue patterns
+- `clerk-nuxt-patterns` - Nuxt patterns
+- `clerk-astro-patterns` - Astro patterns
+- `clerk-tanstack-patterns` - TanStack Start patterns
+- `clerk-chrome-extension-patterns` - Chrome Extension patterns
+- `clerk-orgs` - B2B multi-tenant organizations
+- `clerk-webhooks` - Webhook → database sync
+- `clerk-testing` - E2E testing setup
+- `clerk-swift` - Native iOS auth
+- `clerk-android` - Native Android auth
+- `clerk-expo` - Expo / React Native auth
+- `clerk-backend-api` - Backend REST API explorer
 
 ## Documentation
 

--- a/.agents/skills/clerk-testing/SKILL.md
+++ b/.agents/skills/clerk-testing/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: clerk-testing
-description: E2E testing for Clerk apps. Use with Playwright or Cypress for auth flow tests.
+description: E2E testing for Clerk apps. Use with Playwright or Cypress for auth flow
+  tests.
 allowed-tools: WebFetch
 license: MIT
 metadata:
   author: clerk
-  version: "1.0.0"
+  version: 1.2.0
+compatibility: Requires CLERK_TESTING_TOKEN from Clerk dashboard
 ---
 
 # Testing
@@ -54,4 +56,6 @@ Test auth = isolated session state. Each test needs fresh auth context.
 
 ## See Also
 
-- [Demo Repo](https://github.com/clerk/clerk-playwright-nextjs/tree/95c7189a48c24d7e9e9744897040aa9418f68ac2/e2e)
+- `clerk-setup` - Install Clerk before adding tests
+- `clerk-nextjs-patterns` - Next.js patterns being tested
+- [Demo Repo](https://github.com/clerk/clerk-playwright-nextjs/tree/main/e2e)

--- a/.agents/skills/clerk-webhooks/SKILL.md
+++ b/.agents/skills/clerk-webhooks/SKILL.md
@@ -1,115 +1,315 @@
 ---
 name: clerk-webhooks
-description: Clerk webhooks for real-time events and data syncing. Listen for user creation, updates, deletion, and organization events. Build event-driven features like database sync, notifications, integrations.
+description: Clerk webhooks for real-time events and data syncing. Verify with verifyWebhook
+  from the framework-specific package. Handle user, session, organization, billing, and
+  payment events. Build event-driven features like database sync, notifications, and
+  integrations.
 allowed-tools: WebFetch
 license: MIT
 metadata:
   author: clerk
-  version: "1.0.0"
+  version: 1.2.0
+compatibility: Requires CLERK_WEBHOOK_SIGNING_SECRET (svix signing secret from Clerk dashboard)
 ---
 
 # Webhooks
 
-> **Prerequisite**: Webhooks are asynchronous. Use for background tasks (sync, notifications), not synchronous flows.
+Output complete, working webhook handlers with `verifyWebhook(req)` verification in every handler.
 
-## Documentation Reference
+## When to Use Webhooks
 
-| Task | Link |
-|------|------|
-| Overview | https://clerk.com/docs/guides/development/webhooks/overview |
-| Sync to database | https://clerk.com/docs/guides/development/webhooks/syncing |
-| Debugging | https://clerk.com/docs/guides/development/webhooks/debugging |
-| Event catalog | https://dashboard.clerk.com/~/webhooks (Event Catalog tab) |
+Webhooks are **asynchronous and eventually consistent**. Delivery is fast but not guaranteed to be immediate, and may occasionally fail (Svix retries on a fixed schedule). Use them for:
 
-## Quick Start
+- Database sync (a separate users / orgs table that follows Clerk)
+- Notifications (welcome emails, Slack pings, internal alerts)
+- Integrations triggered by lifecycle events
 
-1. Create endpoint at `app/api/webhooks/route.ts`
-2. Use `verifyWebhook(req)` from `@clerk/nextjs/webhooks`
-3. Dashboard → Webhooks → Add Endpoint
-4. Set `CLERK_WEBHOOK_SIGNING_SECRET` in env
-5. Make route public (not protected by middleware)
+Do NOT rely on webhook delivery as part of a synchronous flow such as onboarding ("user signs up, then we read X from our DB"). For data the user just created, read it from the [Clerk session token](https://clerk.com/docs/guides/sessions/session-tokens) or call the Backend API directly. Webhooks fill the gap when you need data about *other* users or events the session token doesn't carry.
 
-## Supported Events
+## Verify Every Webhook
 
-**User**: `user.created` `user.updated` `user.deleted`
+Use `verifyWebhook(req)` from the framework-specific package (`@clerk/nextjs/webhooks`, `@clerk/express/webhooks`, etc.). It reads `CLERK_WEBHOOK_SIGNING_SECRET` automatically and throws on bad signatures. Skipping verification, even for notification-only handlers, exposes the endpoint to spoofed events.
 
-**Organization**: `organization.created` `organization.updated` `organization.deleted`
+## Make the Webhook Route Public
 
-**Organization Domain**: `organizationDomain.created` `organizationDomain.updated` `organizationDomain.deleted`
-
-**Organization Invitation**: `organizationInvitation.created` `organizationInvitation.accepted` `organizationInvitation.revoked`
-
-**Organization Membership**: `organizationMembership.created` `organizationMembership.updated` `organizationMembership.deleted`
-
-**Roles**: `role.created` `role.updated` `role.deleted`
-
-**Permissions**: `permission.created` `permission.updated` `permission.deleted`
-
-**Session**: `session.created` `session.updated` `session.ended` `session.removed` `session.revoked` `session.pending`
-
-**Communication**: `email.created` `sms.created`
-
-**Invitations**: `invitation.created` `invitation.accepted` `invitation.revoked`
-
-**Waitlist**: `waitlistEntry.created` `waitlistEntry.updated`
-
-Full catalog: Dashboard → Webhooks → Event Catalog
-
-## When to Sync
-
-**Do sync when:**
-- Need other users' data (social features, profiles)
-- Storing extra custom fields (birthday, country, bio)
-- Building notifications or integrations
-
-**Don't sync when:**
-- Only need current user data (use session token)
-- No custom fields (Clerk has everything)
-- Need immediate access (webhooks are eventual consistency)
-
-## Key Patterns
-
-### Make Route Public
-
-Webhooks come unsigned. Route must be public:
-
-Ensure `clerkMiddleware()` doesn't protect `/api/webhooks(.*)` path.
-
-### Verify Webhook
-
-Use correct import and single parameter:
+Webhook routes must be excluded from Clerk middleware protection. Without this, Clerk returns 401.
 
 ```typescript
-import { verifyWebhook } from '@clerk/nextjs/webhooks'
-const evt = await verifyWebhook(req)  // Pass request directly
+// proxy.ts (Next.js <=15: middleware.ts)
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+
+const isPublicRoute = createRouteMatcher(['/api/webhooks(.*)'])
+
+export default clerkMiddleware(async (auth, req) => {
+  if (!isPublicRoute(req)) await auth.protect()
+})
 ```
 
-### Type-Safe Events
-
-Narrow to specific event:
+## Complete Webhook Handler (Next.js App Router)
 
 ```typescript
-if (evt.type === 'user.created') {
-  // TypeScript knows evt.data structure
+// app/api/webhooks/route.ts
+import { verifyWebhook } from '@clerk/nextjs/webhooks'
+import { NextRequest } from 'next/server'
+import { db } from '@/lib/db'
+
+export async function POST(req: NextRequest) {
+  // ALWAYS verify - never skip, even for notification-only handlers
+  let evt
+  try {
+    evt = await verifyWebhook(req) // uses CLERK_WEBHOOK_SIGNING_SECRET automatically
+  } catch (err) {
+    console.error('Webhook verification failed:', err)
+    return new Response('Verification failed', { status: 400 })
+  }
+
+  if (evt.type === 'user.created') {
+    const { id, email_addresses, first_name, last_name } = evt.data
+    const email = email_addresses[0]?.email_address
+    const name = `${first_name ?? ''} ${last_name ?? ''}`.trim()
+    await db.users.create({ data: { clerkId: id, email, name } })
+  }
+
+  if (evt.type === 'user.updated') {
+    const { id, email_addresses, first_name, last_name } = evt.data
+    const email = email_addresses[0]?.email_address
+    await db.users.update({ where: { clerkId: id }, data: { email, first_name, last_name } })
+  }
+
+  if (evt.type === 'user.deleted') {
+    const { id } = evt.data
+    await db.users.delete({ where: { clerkId: id } })
+  }
+
+  if (evt.type === 'organizationMembership.created') {
+    const { organization, public_user_data, role } = evt.data
+    const orgId = organization.id
+    const userId = public_user_data.user_id
+    await db.teamMembers.create({ data: { orgId, userId, role } })
+  }
+
+  if (evt.type === 'organizationMembership.deleted') {
+    const { organization, public_user_data } = evt.data
+    const orgId = organization.id
+    const userId = public_user_data.user_id
+    await db.teamMembers.delete({ where: { orgId_userId: { orgId, userId } } })
+  }
+
+  return new Response('OK', { status: 200 })
 }
 ```
 
-### Handle All Three Events
+## Full Example: Welcome Email (Resend) + Slack Notification on user.created
 
-Don't only listen to `user.created`. Also handle `user.updated` and `user.deleted`.
-
-### Queue Async Work
-
-Return 200 immediately, queue long operations:
+Notification-only handlers still verify the signature. Same pattern as the database-sync handler:
 
 ```typescript
-await queue.enqueue('process-webhook', evt)
-return new Response('Received', { status: 200 })
+// app/api/webhooks/route.ts
+import { verifyWebhook } from '@clerk/nextjs/webhooks'
+import { NextRequest } from 'next/server'
+import { Resend } from 'resend'
+
+const resend = new Resend(process.env.RESEND_API_KEY)
+
+export async function POST(req: NextRequest) {
+  // Step 1: ALWAYS verify the webhook signature - NEVER skip this
+  let evt
+  try {
+    evt = await verifyWebhook(req) // uses CLERK_WEBHOOK_SIGNING_SECRET env var
+  } catch (err) {
+    console.error('Webhook verification failed:', err)
+    return new Response('Verification failed', { status: 400 })
+  }
+
+  // Step 2: Listen for user.created event
+  if (evt.type === 'user.created') {
+    // Step 3: Extract user email and name from webhook payload
+    const { id, email_addresses, first_name, last_name } = evt.data
+    const email = email_addresses[0]?.email_address
+    const name = `${first_name ?? ''} ${last_name ?? ''}`.trim()
+
+    // Step 4: Call Resend API to send welcome email
+    await resend.emails.send({
+      from: 'noreply@yourdomain.com',
+      to: email,
+      subject: 'Welcome!',
+      html: `<p>Hi ${name}, welcome to our app!</p>`,
+    })
+
+    // Step 5: Post notification to Slack channel
+    await fetch(process.env.SLACK_WEBHOOK_URL!, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        text: `New user signed up: ${name} (${email})`,
+      }),
+    })
+  }
+
+  // Always return 200 to acknowledge receipt
+  return new Response('OK', { status: 200 })
+}
 ```
+
+**Also include proxy.ts (Next.js <=15: middleware.ts) to make the route public:**
+```typescript
+// proxy.ts (Next.js <=15: middleware.ts)
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+const isPublicRoute = createRouteMatcher(['/api/webhooks(.*)'])
+export default clerkMiddleware(async (auth, req) => {
+  if (!isPublicRoute(req)) await auth.protect()
+})
+```
+
+## Full Example: Organization Membership Sync to Database
+
+```typescript
+// app/api/webhooks/route.ts
+import { verifyWebhook } from '@clerk/nextjs/webhooks'
+import { NextRequest } from 'next/server'
+import { db } from '@/lib/db' // your database client
+
+export async function POST(req: NextRequest) {
+  // ALWAYS verify signature - never skip, even for simple handlers
+  let evt
+  try {
+    evt = await verifyWebhook(req) // uses CLERK_WEBHOOK_SIGNING_SECRET env var
+  } catch (err) {
+    console.error('Webhook verification failed:', err)
+    return new Response('Verification failed', { status: 400 })
+  }
+
+  if (evt.type === 'organization.created') {
+    const { id, name } = evt.data
+    await db.workspaces.create({
+      data: { orgId: id, name, createdAt: new Date() },
+    })
+  }
+
+  if (evt.type === 'organizationMembership.created') {
+    // Extract organization ID, user ID, and role from payload
+    const { organization, public_user_data, role } = evt.data
+    const orgId = organization.id
+    const userId = public_user_data.user_id
+
+    // Add to team_members table
+    await db.team_members.create({
+      data: { orgId, userId, role },
+    })
+
+    // Create workspace record for new member
+    await db.workspaces.create({
+      data: { orgId, userId, createdAt: new Date() },
+    })
+  }
+
+  if (evt.type === 'organizationMembership.deleted') {
+    // Extract organization ID and user ID from payload
+    const { organization, public_user_data } = evt.data
+    const orgId = organization.id
+    const userId = public_user_data.user_id
+
+    // Remove from team_members table
+    await db.team_members.delete({
+      where: { orgId, userId },
+    })
+
+    // Remove workspace record
+    await db.workspaces.deleteMany({
+      where: { orgId, userId },
+    })
+  }
+
+  // Return 200 status on success
+  return new Response('OK', { status: 200 })
+}
+```
+
+## Other Frameworks
+
+For Express, Astro, Fastify, Nuxt, React Router, and TanStack Start, use the framework-specific `verifyWebhook` adapter. Each Clerk SDK package ships its own (`@clerk/express/webhooks`, `@clerk/astro/webhooks`, `@clerk/fastify/webhooks`, etc.).
+
+See `references/frameworks.md` for full handler examples per framework.
+
+## Type Narrowing for `evt.data`
+
+`verifyWebhook` returns `WebhookEvent`, a discriminated union of all event types. Narrow with `evt.type` to get type-safe access to `evt.data`:
+
+```typescript
+const evt = await verifyWebhook(req)
+
+if (evt.type === 'user.created') {
+  // evt.data is now UserJSON, autocompletes id, email_addresses, etc.
+  console.log(evt.data.id)
+}
+```
+
+For manual typing of nested payloads, import the JSON types from your framework's webhook subpath: `DeletedObjectJSON`, `EmailJSON`, `OrganizationInvitationJSON`, `OrganizationJSON`, `OrganizationMembershipJSON`, `SessionJSON`, `SMSMessageJSON`, `UserJSON`.
+
+## Payload Field Reference
+
+### User events (`user.created`, `user.updated`, `user.deleted`)
+```typescript
+const {
+  id,                  // Clerk user ID
+  email_addresses,     // array; [0].email_address is primary email
+  first_name,
+  last_name,
+  image_url,
+  public_metadata,
+} = evt.data
+```
+
+### Organization events (`organization.created`, `organization.updated`, `organization.deleted`)
+```typescript
+const {
+  id,    // org ID
+  name,  // org name
+  slug,
+} = evt.data
+```
+
+### Organization Membership events (`organizationMembership.created`, `organizationMembership.updated`, `organizationMembership.deleted`)
+```typescript
+const {
+  organization,        // { id, name, ... }
+  public_user_data,    // { user_id, first_name, last_name, ... }
+  role,                // e.g. 'org:admin', 'org:member'
+} = evt.data
+// Access: organization.id, public_user_data.user_id, role
+```
+
+## Supported Events (Full Catalog)
+
+**User**: `user.created` `user.updated` `user.deleted`
+
+**Session**: `session.created` `session.ended` `session.removed` `session.revoked`
+
+**Organization**: `organization.created` `organization.updated` `organization.deleted`
+
+**Organization Membership**: `organizationMembership.created` `organizationMembership.updated` `organizationMembership.deleted`
+
+**Organization Domain**: `organizationDomain.created` `organizationDomain.updated` `organizationDomain.deleted`
+
+**Organization Invitation**: `organizationInvitation.accepted` `organizationInvitation.created` `organizationInvitation.revoked`
+
+**Communication**: `email.created` `sms.created`
+
+**Waitlist**: `waitlistEntry.created` `waitlistEntry.updated`
+
+**Permission**: `permission.created` `permission.updated` `permission.deleted`
+
+**Role**: `role.created` `role.updated` `role.deleted`
+
+**Subscription**: `subscription.created` `subscription.updated` `subscription.active` `subscription.pastDue`
+
+**Subscription Item**: `subscriptionItem.created` `subscriptionItem.active` `subscriptionItem.updated` `subscriptionItem.canceled` `subscriptionItem.upcoming` `subscriptionItem.ended` `subscriptionItem.abandoned` `subscriptionItem.incomplete` `subscriptionItem.pastDue` `subscriptionItem.freeTrialEnding`
+
+**Payment**: `paymentAttempt.created` `paymentAttempt.updated`
 
 ## Webhook Reliability
 
-**Retries**: Svix retries failed webhooks for up to 3 days. Return 2xx to succeed, 4xx/5xx to retry.
+**Retries**: Svix retries failed webhooks on a set schedule (see [Svix Retry Schedule](https://docs.svix.com/retries)). Return 2xx to succeed, 4xx/5xx to retry. Use the `svix-id` header as an idempotency key to deduplicate retried events.
 
 **Replay**: Failed webhooks can be replayed from Dashboard.
 
@@ -117,15 +317,36 @@ return new Response('Received', { status: 200 })
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| Verification fails | Wrong import or usage | Use `@clerk/nextjs/webhooks`, pass `req` directly |
-| Route not found (404) | Wrong path | Use `/api/webhooks` |
-| Not authorized (401) | Route is protected | Make route public |
+| Verification fails (Next.js) | Wrong import or usage | Use `@clerk/nextjs/webhooks`, pass `req` directly |
+| Verification fails (Express) | Using `express.json()` | Use `express.raw({ type: 'application/json' })` for webhook route |
+| Route not found (404) | Wrong path | Use `/api/webhooks` or preserve existing path |
+| Not authorized (401) | Route is protected by middleware | Make route public in `clerkMiddleware()` |
 | No data in DB | Async job pending | Wait/check logs |
 | Duplicate entries | Only handling `user.created` | Also handle `user.updated` |
-| Timeouts | Handler too slow | Queue async work |
+| Timeouts | Handler too slow | Queue async work, return 200 first |
 
 ## Testing & Deployment
 
-**Local**: Use ngrok to tunnel `localhost:3000` to internet. Add ngrok URL to Dashboard endpoint.
+**Local**: Use the Clerk CLI's first-party tunnel — no auth or linked project needed:
 
-**Production**: Update webhook endpoint URL to production domain. Copy signing secret to production env vars.
+```sh
+clerk webhooks listen --token "$(clerk webhooks token)" --forward-to http://localhost:3000/api/webhooks
+```
+
+Add the printed relay URL (`https://webhooks.clerk.com/in/c_.../`) as a webhook endpoint in the Dashboard — events don't flow until you do. `svix-*` headers are preserved, so `verifyWebhook()` works against that endpoint's signing secret as usual. Flags, offline signature checks (`clerk webhooks verify`), and agent-mode behavior are in the `clerk-cli` skill. Without the CLI, tunnel `localhost:3000` yourself (`ngrok`, `localtunnel`, `Cloudflare Tunnel`) and add the public URL to the Dashboard endpoint.
+
+**Production**: Update webhook endpoint URL to production domain. Copy `CLERK_WEBHOOK_SIGNING_SECRET` to production env vars.
+
+## References
+
+| Reference | Description |
+|-----------|-------------|
+| `references/frameworks.md` | Webhook handler examples for Express, Astro, Fastify, Nuxt, React Router, TanStack Start |
+
+## See Also
+
+- `clerk-cli` - `clerk webhooks listen`/`verify` for local webhook testing
+- `clerk-setup` - Initial Clerk install
+- `clerk-orgs` - Org membership events
+- `clerk-billing` - Subscription, subscription item, and payment attempt events
+- `clerk-backend-api` - Sync via direct API calls

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,34 +153,13 @@ Without Flox: install Node 24+, pnpm 10, bun manually, then `pnpm install`. Full
 
 ## Running
 
-```bash
-bun run test              # unit tests
-bun run test:watch        # Vitest watch mode
-bun run test:integration  # integration tests (needs ANTHROPIC_API_KEY, uses haiku)
-bun run test:coverage     # coverage report
-bun run test:e2e          # end-to-end tests
-bun run build:shell:production  # canonical production shell build (release-parity auth/shell build)
-bun run build:desktop     # Electron desktop production build
+Run scripts with `bun run <script>`; see `package.json` for the full list (`test*`, `dev*`, `docker*`, `build:*`, `typecheck`, `check:patterns`). Non-obvious ones:
 
-bun run dev               # local dev: gateway + proxy + shell
-bun run dev:gateway       # gateway only
-bun run dev:shell         # shell only
-bun run dev:mobile-shell  # browser shell forced into the mobile launcher/runtime
-bun run dev:proxy         # proxy only
-bun run dev:platform      # platform only
-bun run dev:kernel        # kernel package only
-bun run dev:desktop       # Electron desktop shell
-
-bun run docker            # Legacy/local Docker dev only; not production customer runtime
-bun run docker:full       # + proxy, platform, conduit
-bun run docker:all        # + observability stack
-bun run docker:multi      # + alice & bob multi-user
-bun run docker:stop       # stop containers, preserve volumes
-bun run docker:restart    # restart dev container
-bun run docker:logs       # tail dev container logs
-bun run docker:shell      # shell into container as matrixos user
-bun run docker:build      # full rebuild (no cache)
-```
+- `test:integration` needs `ANTHROPIC_API_KEY` and runs on haiku (<$0.10/run).
+- `test:golden-snapshots` is the preferred low-CPU single-worker gate for golden snapshot, host-bundle snapshot workflow, and related customer-VPS provisioning changes.
+- `build:shell:production` is the canonical production shell build (release-parity auth/shell build).
+- `dev:mobile-shell` forces the browser shell into the mobile launcher/runtime.
+- `docker*` is legacy/local dev only -- never the production customer runtime.
 
 **IMPORTANT**: Production Matrix OS is VPS-native per user. Do not use Docker Compose, image rebuilds, or rolling container restarts as the customer runtime deployment path.
 **IMPORTANT**: Always run `pnpm install` from the repo root after adding/removing dependencies to update `pnpm-lock.yaml`. Vercel deployments fail on stale lockfiles.
@@ -192,22 +171,15 @@ bun run docker:build      # full rebuild (no cache)
 
 Production customer runtime ships as VPS-native host bundles. R2 stores immutable tarball bytes, platform Postgres stores release metadata and channel pointers, and each VPS keeps the installed release at `/opt/matrix/release.json`.
 
+Full runbook (channels, build/publish/deploy, verification, R2 cleanup, PostHog bootstrap): use the **release-procedure** skill. Desktop app packaging: use the **desktop-release** skill.
+
+These invariants stay here because they bind every release:
+
 - **Package safety**: pnpm is pinned to 10.33.4 and `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` (7 days). Keep `pnpm install --frozen-lockfile` in CI/release paths; do not bypass the lockfile or downgrade pnpm below 10.16.
-- **Bundle object store split**: host-bundle publish/download flows now prefer dedicated `R2_BUNDLES_*` / `S3_BUNDLES_*` settings when present and fall back to the existing `R2_*` / `S3_*` sync store otherwise. Keep sync/user objects on the primary store; use `R2_BUNDLES_ENDPOINT` or `R2_ENDPOINT` for jurisdictional bundle buckets instead of repointing the sync bucket.
-- **Main channel**: pushes to `main` run `.github/workflows/host-bundle-release.yml`, build a host bundle, register it in platform DB, and promote `dev` by default.
-- **Tags**: `v*` tags build immutable release versions and promote `canary` by default. Promote `stable` only after live verification.
-- **Manual release**: workflow dispatch can choose `dev`, `canary`, `beta`, or `stable`, plus severity/changelog. Security severity may auto-deploy.
-- **Build-time env**: `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN`/`NEXT_PUBLIC_POSTHOG_KEY`, `NEXT_PUBLIC_POSTHOG_HOST`, and `NEXT_PUBLIC_POSTHOG_API_HOST` are baked into the shell bundle. `NEXT_PUBLIC_POSTHOG_API_HOST` should stay the relative `/relay` same-origin proxy for client traffic; use `POSTHOG_HOST=https://eu.posthog.com` as the private API host for source-map uploads or PostHog API scripts.
-- **PostHog alerts bootstrap**: `bun run observability:posthog-alerts` idempotently provisions the "Matrix OS Errors" dashboard plus the baseline exception/provisioning/billing/onboarding insights. Requires `POSTHOG_PERSONAL_API_KEY` and `POSTHOG_PROJECT_ID`; optional `POSTHOG_API_HOST` defaults to `https://eu.posthog.com`. Issue/spike alerts are still configured manually in the PostHog UI because there is no stable public API for them.
-- **Incremental bundle metadata ships with every host bundle**: `./scripts/build-host-bundle.sh` now emits `dist/host-bundle/incremental-manifest.json` plus `dist/host-bundle/objects/sha256/*`, and `./scripts/publish-release.sh` / platform release registration must publish them alongside the full tarball. Platform serves `/system-bundles/<version>/incremental-manifest.json` and `/system-bundles/objects/sha256/<sha256>`, but `requiresFullBundle` remains `true` until the VPS-side delta installer is explicitly enabled.
+- **Desktop canary is a recreated mutable release, not an append-only asset bucket**: each successful canary run must preserve the rolling `desktop-canary` tag, delete only the previous GitHub release object after artifacts/manifest/release notes are ready, then publish a fresh prerelease. Do not let timestamped canary assets accumulate across runs.
+- **Golden snapshots are a separate fail-closed acceleration path**: eligible `main`, `v*` tag, and manual customer-channel publications enqueue an idempotent build after publish via `bun run release:enqueue-golden-snapshot -- --version <version>` / `scripts/enqueue-golden-snapshot.mjs`, but enqueue/build failure must not block host-bundle publication or the unchanged existing-fleet deploy job.
+- **Snapshot auth and rollout stay split**: release automation uses `PLATFORM_SECRET` only for immutable build enqueue. Status, retry, revoke, inventory, and cleanup controls require `GOLDEN_SNAPSHOT_OPERATOR_SECRET`, and `GOLDEN_SNAPSHOT_BUILDS_ENABLED` must stay separate from `GOLDEN_SNAPSHOTS_ENABLED` so selection stays off until the disposable-spike and rollout gates pass.
 - **User data invariant**: updates may replace `/opt/matrix/app` only. Never overwrite owner data under `$MATRIX_HOME` (`/home/matrix/home`), especially `system/desktop.json`, `system/theme.json`, `system/wallpapers/`, `system/icons/`, identity/profile/session/state files, logs, memory, or conversations. Template sync may add/upgrade OS-owned files, but protected user paths must be skipped. Exception: the four OS-bundled wallpapers (`xp-bliss.jpg`, `win11-bloom.jpg`, `macos-light.svg`, `moraine-lake.jpg`) under `system/wallpapers/` are template-managed so OS designs reach existing VPS homes; every other file there (user uploads, and the superseded `xp-bliss.svg`/`win11-bloom.svg` files older homes received) stays protected.
-- **Local emergency build**: `set -a; source .env; set +a; HOST_BUNDLE_VERSION=<version> HOST_BUNDLE_CHANNEL=<channel> MATRIX_BUILD_SHA=$(git rev-parse HEAD) MATRIX_BUILD_REF=main ./scripts/build-host-bundle.sh`.
-- **Publish**: `./scripts/publish-release.sh <version> --channel <channel>` uploads `system-bundles/<version>/matrix-host-bundle.tar.gz` and `.sha256`, then registers release metadata through `/system-bundles/releases`.
-- **Deploy**: trigger existing VPSes through platform with `POST /vps/deploy {"channel":"dev"}` or `{"version":"<version>"}`. Do not SSH-copy bundles except for break-glass recovery.
-- **Verify**: for every VPS, check `/opt/matrix/app/BUNDLE_VERSION`, `/opt/matrix/release.json`, `matrix-gateway`, `matrix-shell`, `matrix-sync-agent`, and local health.
-- **Feature test VMs**: for risky shell/onboarding/platform changes, prefer a disposable test VPS over the user's primary computer. Use the same Clerk login, switch via `https://app.matrix-os.com/runtime` or explicit `https://app.matrix-os.com/vm/<handle>`, deploy exact bundle versions, and ask the user whether to delete the test VM after validation to avoid extra Hetzner charges.
-- **R2 cleanup**: old `system-bundles/*` versions may be deleted after the new version is published, deployed, and verified. Keep the currently promoted/live version and its `.sha256`; do not delete objects still referenced by active channel pointers or rollback plans.
-- **Optional developer tools provision out of band**: the post-payment Default installs step stores selected `codex`, `claude-code`, `opencode`, and `pi` tool IDs for provisioning, then first boot runs `matrix-developer-tools.service` to install them asynchronously. Failures should show up under `/var/lib/matrix-developer-tools/` (`*.log`, `failed-tools`, `installed-tools`) and retry via systemd; they must not block core Matrix readiness.
 
 ## Customer Support Notes
 
@@ -215,16 +187,6 @@ Production customer runtime ships as VPS-native host bundles. R2 stores immutabl
 - **Machine resizing exists as a platform-internal support primitive**: `POST /vps/:machineId/resize` is protected by platform auth and is intended for support or platform automation, not direct customer UI use. It performs an in-place Hetzner `change_type` flow with graceful shutdown first, `upgrade_disk: false`, guarded `running -> resizing -> running` state, and stale resize reconciliation.
 - **Resize compatibility is constrained by Hetzner disk rules**: local root disks cannot shrink. Treat same-or-larger local disk x86 moves as eligible; reject smaller-disk downgrades before shutting down the customer VPS. For current plan shapes, `cpx22 -> cpx32/cpx52` and `cpx32 -> cpx52` are valid, while `cpx32 -> cpx22` and `cpx52 -> cpx32/cpx22` are not safe unless a separate migration/storage architecture proves the root data fits.
 - **Customer-facing plan changes are separate**: billing/Stripe may change a user's plan entitlement, but existing VPS resizing should remain support/platform-controlled until preflight compatibility checks and UX copy explicitly handle unsupported downgrades.
-
-## Desktop Release Workflow
-
-- **Desktop OTA channels include `dev`**: treat `dev`, `canary`, `beta`, and `stable` as first-class update channels. Unsigned prerelease packaging must omit empty mac signing env vars rather than exporting blank values.
-- **mac artifact verification must be exact-name, not glob-based**: compute the version/artifact base once, then verify `Matrix-OS-${version}-mac-${arch}.{dmg,zip}` plus both `.blockmap` files and fail on unexpected extra mac artifacts.
-- **mac CI must smoke-test the produced DMG**: mount the generated DMG with `hdiutil`, copy `Matrix OS.app` out with `ditto`, and verify the executable before upload/publish.
-- **Prerelease mac manifests may be arch-only**: when a channel build does not emit `<channel>-mac.yml`, merge `arm64-mac.yml` + `x64-mac.yml` as the fallback manifest pair instead of failing the publish.
-- **`desktop/electron-builder.yml` should not hardcode mac `arch:` arrays**: the workflow matrix `--arch` flag is the source of truth for which architecture each mac job builds.
-- **Packaged desktop CSP must be main-process injected and gateway-scoped**: do not reintroduce a static renderer HTML CSP meta tag or broad `connect-src https: wss:` allowances. The packaged renderer policy must be injected from Electron with the resolved Matrix gateway origin.
-- **Desktop auth callback is `matrixos://auth?status=approved`**: keep `matrix-os://device-auth` only as a legacy compatibility path, register both URL schemes, keep deep-link handling in the main process, and preserve cold-start deep-link handoff until a window exists. Only trusted native desktop clients (`matrix-os-desktop`, `matrix-os-macos`) may receive signed native redirects, and the legacy scheme must stay narrowed to `matrix-os://device-auth` with no query params. The deep link is only a focus signal; auth still completes via polling.
 
 ## Shell Gotchas
 
@@ -255,6 +217,7 @@ Production customer runtime ships as VPS-native host bundles. R2 stores immutabl
 - **Customer VPS shell/gateway changes need host-bundle rebuild + publish**: per-user VPSes do not use the Docker user image. Run `set -a; source .env; set +a; ./scripts/build-host-bundle.sh`, publish `dist/host-bundle/matrix-host-bundle.tar.gz` and `.sha256` to `system-bundles/$CUSTOMER_VPS_IMAGE_VERSION/`, then refresh existing VPSes in place and restart `matrix-gateway.service`, `matrix-shell.service`, and `matrix-code.service`.
 - **Hermes state is owner-local under `MATRIX_HOME`**: customer VPSes now canonicalize Hermes data at `/home/matrix/home/.hermes` via `HERMES_HOME`; legacy `/home/matrix/.hermes` is only a compatibility symlink. When changing `distro/customer-vps/host-bin/matrix-owner-env` or service launchers, preserve `matrix_reconcile_owner_home`, pass the reconcile owner/group through migrations, and guard new owner-env helpers with `declare -F` so older bundles degrade gracefully instead of crashing.
 - **Pipedream stays platform-owned**: never put `PIPEDREAM_*` secrets on customer VPSes. VPS gateways need `PLATFORM_INTERNAL_URL` plus their existing `UPGRADE_TOKEN`/`MATRIX_HANDLE` so `/api/integrations*` proxies to platform-owned routes.
+- **Customer-VPS service homes may be read-only by design**: host units can run with `ProtectHome=read-only`. Do not assume `~/.npm` or other owner-home cache paths are writable during service startup or self-repair; redirect reproducible scratch/cache data to the unit's private temp/runtime directory instead of weakening home protections.
 - **Never publish a shell bundle with the example Clerk key**: `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is baked at host-bundle build time. If production logs show `clerk.example.com`, the served shell bundle was built with the placeholder key and must be rebuilt and redeployed.
 - **Canvas panning must be target-gated**: wheel/pointer pan handlers should only accept events from the canvas surface/zoom overlay, not bubbled events from selected app windows. Add regression tests for scrolling inside an active app window.
 
@@ -295,6 +258,8 @@ react-doctor scans a **project directory that has a React `package.json`** (e.g.
 minimal React `package.json` and running react-doctor there. See
 https://github.com/millionco/react-doctor. CI runs this on the project dirs of changed React files.
 
+**Local review before Greptile (mandatory)**: after local validation gates and before any paid Greptile request, the agent doing the work must review the diff itself (Claude `/code-review`, the Codex equivalent, or the three repository review passes applied directly). Greptile is a current-head confirmation gate, not the first reviewer. Verify reviewer findings against the actual code and tool behavior before acting on them.
+
 **Production shell build gate**: when a PR changes `shell/`, shell-facing `packages/platform/`, or CI wiring for the auth shell, run `bun run build:shell:production`. This is the canonical production build command, matches release tooling, and `CI Results` now blocks on the `Shell Production Build` job.
 
 **Focused test reruns**: if `bun run test -- <path>` or `pnpm run test -- <path>` ignores the file filter and fans out into a broad repo run, fall back to `pnpm exec vitest run <path>` (or `pnpm exec vitest <path>` for watch mode) after the usual prerequisite builds are up to date.
@@ -313,6 +278,10 @@ evidence still blocks review-readiness. Do not rely on verbal descriptions for v
 a screenshot is practical.
 
 **Mobile shell gates**: if a PR touches `apps/mobile/` or shared terminal/mobile shell behavior, follow `docs/dev/mobile-shell.md`. Minimum local gates: `pnpm --dir apps/mobile exec jest --runInBand`, `pnpm --dir apps/mobile exec tsc --noEmit`, the relevant `bun run test` shell/gateway suites listed in that doc, and real-device validation before treating the change as review-ready.
+
+**Dormant terminal-runtime gate**: `MATRIX_TERMINAL_RUNTIME_DORMANT=1` is preview-only and must stay off by default. If a PR touches the dormant terminal-runtime generation or activation path, require exact-head S1/S2 proof plus `.github/workflows/terminal-runtime-production-acceptance.yml` (label `terminal-production-acceptance`) or `scripts/spikes/terminal-runtime/production-acceptance.sh` against the matching `pr-<number>` disposable preview before treating activation or rollout as review-ready.
+
+**Preview feature-proof gate**: for runtime/provider activation, systemd hardening, or other deploy-only host changes, a green preview deploy, inventory check, or generic health check is not enough. Keep the PR draft until the exact `pr-<number>` preview passes the feature-specific live acceptance path; when host evidence is needed, use `./scripts/preview-logs.sh --handle pr-<number>` and enroll log shipping first with `./scripts/enable-vps-logship.sh pr-<number> preview` if required. If the disposable preview is stale, still carries a previous head, or updater convergence stalls, recycle only that preview through the supported close/reopen PR path before collecting fresh proof.
 
 ### Three Review Passes
 
@@ -385,8 +354,8 @@ blocker, not a green light):
 ### Hard Rules (never violate)
 
 - **All changes ship via PR from a manual `git worktree`** -- no direct commits to `main`, no exceptions. Create the worktree with `git worktree add -b <kebab-branch> ../<dir-name> origin/main` and do all work there. Applies to code AND docs.
-- **No PR merge until Greptile reports 5/5** -- every finding must be fixed in the diff or explicitly deferred in the PR body with a linked follow-up issue.
-- **Do not spam Greptile re-review comments** -- Greptile is configured to review every new commit. If the score/footer is stale after a push, it means the review is still running; wait and poll instead of repeatedly mentioning it.
+- **No PR merge until Greptile reports 5/5 on the current head** -- every finding must be fixed in the diff or explicitly deferred in the PR body with a linked follow-up issue.
+- **Do not assume Greptile reruns on every push** -- non-draft PR open may get one automatic review of the initial head, but later commits require an explicit `@greptileai` request. Treat each run as paid, review locally first, and request at most once per head SHA.
 - No bare `catch {}` or `.catch(() => {})` -- every catch must check error type and log
 - No `fetch()` without `signal: AbortSignal.timeout()` -- 10s APIs, 30s downloads
 - No `writeFileSync`/`appendFileSync` in request handlers -- use `fs/promises`
@@ -419,6 +388,7 @@ Read these on demand, not every session:
 - `docs/dev/mobile-shell.md` -- when working on the Expo/native mobile shell, physical-device testing, or terminal resume controls
 - `docs/dev/pr-review-analysis.md` -- when triaging review comments or understanding recurring defect patterns
 - `docs/dev/docker-development.md` -- when working on Docker setup or debugging container issues
+- `docs/dev/golden-vps-snapshots.md` -- when working on golden snapshot build/selection, release enqueue, sanitation, or recovery fallback behavior
 - `docs/dev/vps-deployment.md` -- when deploying to production or managing the VPS
 - `docs/dev/preview-environments.md` -- when a change needs to be seen running: per-PR preview VPSes (`preview-vps` label), platform preview revisions, HMR staging slots, and centralized log queries via `scripts/preview-logs.sh`
 - `docs/dev/releases.md` -- when tagging a release or managing versions
@@ -433,33 +403,6 @@ Read these on demand, not every session:
 - **NEVER call TeamDelete** -- team files are cheap, lost work is expensive
 - Sub-agents spawned for parallel exploration share the parent's worktree; they must commit before exiting.
 
-## Active Technologies
-- TypeScript 5.5+ strict, ES modules, Node.js 24+, React 19, Next.js 16 + Hono, Zod 4 via `zod/v4`, Kysely/Postgres for user app/workspace data, existing terminal stack (`node-pty`, `@xterm/xterm`), `@tldraw/tldraw` for the shell canvas renderer (071-tldraw-workspace-canvas)
-- User-owned Postgres workspace tables for canonical canvas documents and references; filesystem export/backup integration under `~/system/` or project export bundles where required by recovery flows (071-tldraw-workspace-canvas)
-- TypeScript 5.5+ strict, ES modules, Node.js 24+ + Hono gateway, Hono WebSocket support, node-pty, zod/v4, citty, ws, Node child_process/fs/promises/path/crypto APIs, zellij 0.44.1 pinned in Docker images (068-zellij-cli)
-- Files under the owner-controlled Matrix home (`~/system/shell-sessions.json`, `~/system/layouts/*.kdl`) plus local CLI files under `~/.matrixos/profiles.json` and `~/.matrixos/profiles/<name>/` (068-zellij-cli)
-- TypeScript 5.5+ strict, ES modules, Node.js 24+ + Hono gateway, Hono WebSocket support, Zod 4 via `zod/v4`, existing `jose` JWT validation, Vitest (072-request-principal)
-- No new persistence; request principal is request-scoped. Existing consumers continue to use owner-controlled PostgreSQL/Kysely and sync R2/object storage through existing repositories. (072-request-principal)
-- TypeScript strict, ES modules, Node.js 24+ for gateway; React 19, React Native 0.83, Expo Router 55 for mobile shell + Hono gateway, Zod 4 via `zod/v4`, existing terminal stack (`node-pty`, `@xterm/xterm` on web), Expo Router, React Native WebView, Clerk Expo, AsyncStorage/SecureStore (075-mobile-shell)
-- Owner-controlled Matrix home files for shell/terminal session metadata (`~/system/terminal-sessions.json`, terminal layout files) plus existing owner Postgres where current workspace/app data already lives. No new embedded database or ORM. (075-mobile-shell)
-- TypeScript 5.5+ strict, ES modules, Node.js 24+, React 19, Next.js 16 + Hono gateway routes, Zod 4 via `zod/v4`, Kysely/Postgres, Matrix homeserver appservice support, self-hosted Telegram and WhatsApp bridge runtimes, existing Matrix OS shell/app bridge, Hermes/Claude Agent SDK V1 `query()` path (077-matrix-messaging-bridge)
-- Owner-local Postgres on the customer VPS for Matrix OS permission/audit data; separate homeserver database; separate Telegram bridge database; separate WhatsApp bridge database; owner-local media/cache paths covered by backup/restore policy (077-matrix-messaging-bridge)
-- TypeScript 5.5+ strict, ES modules, Node.js 24+, React 19, Next.js 16 shell/platform, Hono gateway + Hono, Zod 4 via `zod/v4`, Kysely/Postgres, existing onboarding WebSocket, existing Symphony routes, existing integrations registry/Pipedream proxy, existing terminal stack, lucide-react, Playwright/Vitest, always-on Hermes with Claude/Codex augmentation, Finna-inspired admin/control surface patterns (082-paid-beta-readiness)
-- Owner-controlled Postgres/Kysely for readiness, integration capability, agent action, admin/control activity, company context, and audit data; owner home files for inspectable onboarding completion/profile/config exports under `~/system/`; no new embedded database or ORM (082-paid-beta-readiness)
-- TypeScript 5.9+, strict mode, ES modules; runtime target Node.js 24+ + Existing sync-client CLI, gateway shell routes, Hono, Zod 4, native Fetch/FormData/Blob, existing `ws` attach transport (106-terminal-rich-paste)
-- Owner-controlled filesystem under Matrix home for paste assets; no new database persistence (106-terminal-rich-paste)
-- TypeScript 5.5+ strict ES modules on Node.js 24+; POSIX shell/cloud-init for host sanitation and activation; GitHub Actions YAML + Hono, Kysely, PostgreSQL, Zod 4 via `zod/v4`, native `fetch`, Vitest, existing host-bundle and customer-VPS services, Hetzner Cloud API v1 (109-golden-vps-snapshots)
-- Platform PostgreSQL via Kysely for authoritative lifecycle, jobs, leases, evidence, and exact-resource cleanup; Hetzner snapshot storage for disk images; R2 remains the immutable host-bundle object store (109-golden-vps-snapshots)
-
-- TypeScript 5.5+ strict, ES modules + node-pty (backend), @xterm/xterm + addon-webgl + addon-search + addon-serialize + addon-fit (frontend), Hono WebSocket (gateway), Zod 4 (validation) (056-terminal-upgrade)
-- Files — `~/system/terminal-sessions.json` (session metadata), `~/system/terminal-layout.json` (layout with sessionId) (056-terminal-upgrade)
-
-## Recent Changes
-
-- 106-terminal-rich-paste: Planned attached CLI rich paste for local image paths and observable clipboard image pastes, with owner-scoped gateway paste assets and safe prompt rewriting.
-- 077-matrix-messaging-bridge: Planned owner-controlled Matrix messaging bridge for Telegram and WhatsApp first, with homeserver/appservice spike gates, per-room Hermes permissions, and separate owner-local bridge/homeserver/permission storage.
-- 056-terminal-upgrade: Added TypeScript 5.5+ strict, ES modules + node-pty (backend), @xterm/xterm + addon-webgl + addon-search + addon-serialize + addon-fit (frontend), Hono WebSocket (gateway), Zod 4 (validation)
-
 ## Agent skills
 
 ### Canonical Matrix skill pack
@@ -471,21 +414,15 @@ Read these on demand, not every session:
 
 ### Matrix CLI agent bootstrap
 
-- Preferred developer bootstrap commands are:
+Commands, readiness gates, and session conventions live in the **matrix-cloud-run** skill. Two rules stay here because they are security boundaries, not procedure:
 
-```bash
-matrix login
-matrix run -it -- claude
-matrix run -it -- codex
-matrix run -it --session setup -- gh auth login
-matrix shell connect -c setup
-```
-
-- `matrix run -it` starts a zellij-backed Matrix shell session and attaches the local terminal over `/ws/terminal`; use named sessions such as `setup` when multiple humans/agents may need to reattach the same VPS context.
-- `matrix login` may stay open while the browser completes signup, trial checkout, and provisioning; approve the CLI in that same browser tab once the instance is ready. For local dev, `matrix login --profile local` or `matrix login --dev` skips the device flow and writes the local dev stub token.
 - Keep auth flows separate: use browser/device approval for `matrix login`, then run `gh auth login` inside the Matrix terminal session for GitHub browser auth. Do not ask users to upload local private SSH keys into Matrix; Matrix-managed SSH keys live on the VPS.
-- Prefer `matrix shell connect` over `matrix shell attach`. `matrix shell connect -c <session>` is the create-if-missing path.
-- If `matrix run -it`, `matrix shell new`, or `matrix shell attach` fails with `zellij_failed`, run `matrix shell ls` and connect to an existing session instead of retrying the same create path.
+- Every remote command gets its own unique purpose-specific named session. Never share one generic setup session across unrelated work.
+
+### Matrix handoff
+
+- Use the repo `matrix-handoff` workflow (`.agents/skills/matrix-handoff/` and Claude `/matrix-handoff`) when moving an active local task onto Matrix. Always preview first, then rerun the identical command with the exact printed `--approve TOKEN`; any scope change requires a new preview.
+- Handoffs must stay secret-free: exclude `.env`, auth stores, private keys, `.git`, dependencies, and generated output; use `--no-history` when transcript discovery is ambiguous or the conversation may contain sensitive content. The workflow always creates a new unique destination instead of overwriting an existing Matrix project.
 
 ### Stack review monitor
 
@@ -506,5 +443,5 @@ Five canonical roles using default label names. See `docs/agents/triage-labels.m
 Single-context: `CONTEXT.md` + `docs/adr/` at repo root. See `docs/agents/domain.md`.
 
 <!-- SPECKIT START -->
-Current Spec Kit plan: `specs/109-golden-vps-snapshots/plan.md`.
+Current Spec Kit plan: `specs/106-terminal-rich-paste/plan.md`.
 <!-- SPECKIT END -->


### PR DESCRIPTION
## Summary
- recover durable AGENTS.md guidance edits from the detached-head stash
- recover substantive Clerk skill markdown updates for custom UI, orgs, setup, testing, and webhooks
- intentionally leave plugin metadata deletions and local generated/untracked directories in the stash for separate review

## Validation
- docs-only recovery; no tests run

## Notes
- main was restored clean and fast-forwarded before creating this branch
- stash `detached-head-doc-skill-recovery-2026-08-07` remains available for anything intentionally excluded here