### PR TITLE
fix(observability): reduce PostHog log and Cloudflare 4xx noise

### DIFF
--- a/distro/customer-vps/host-bin/matrix-install-logship
+++ b/distro/customer-vps/host-bin/matrix-install-logship
@@ -168,7 +168,9 @@ loki.source.journal "matrix_symphony" {
   matches       = "_SYSTEMD_UNIT=matrix-symphony.service"
   relabel_rules = loki.relabel.journal.rules
   labels        = { source = "journal", handle = "${HANDLE}", env = "${MATRIX_ENV}" }
-  forward_to    = [loki.write.central.receiver, otelcol.receiver.loki.posthog.receiver]
+  // Symphony renders an ANSI status dashboard to stdout. Keep that raw stream
+  // in Loki for host troubleshooting, but do not bill it as PostHog product logs.
+  forward_to    = [loki.write.central.receiver]
 }
 
 local.file_match "kernel_jsonl" {

--- a/packages/symphony-elixir/lib/symphony_elixir/orchestrator.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir/orchestrator.ex
@@ -12,7 +12,6 @@ defmodule SymphonyElixir.Orchestrator do
 
   @continuation_retry_delay_ms 1_000
   @failure_retry_base_ms 10_000
-  @setup_required_poll_interval_ms 300_000
   # Slightly above the dashboard render interval so "checking now…" can render.
   @poll_transition_render_delay_ms 20
   @empty_codex_totals %{
@@ -118,7 +117,14 @@ defmodule SymphonyElixir.Orchestrator do
   def handle_info(:run_poll_cycle, state) do
     state = refresh_runtime_config(state)
     state = maybe_dispatch(state)
-    state = schedule_tick(state, next_poll_delay_ms(state))
+    state =
+      schedule_tick(
+        state,
+        SymphonyElixir.PollingPolicy.next_delay_ms(
+          state.last_tracker_status,
+          state.poll_interval_ms
+        )
+      )
     state = %{state | poll_check_in_progress: false}
 
     notify_dashboard()
@@ -1242,15 +1248,6 @@ defmodule SymphonyElixir.Orchestrator do
     :timer.send_after(@poll_transition_render_delay_ms, self(), :run_poll_cycle)
     :ok
   end
-
-  defp next_poll_delay_ms(%State{
-         last_tracker_status: :setup_required,
-         poll_interval_ms: poll_interval_ms
-       }) do
-    max(poll_interval_ms, @setup_required_poll_interval_ms)
-  end
-
-  defp next_poll_delay_ms(%State{poll_interval_ms: poll_interval_ms}), do: poll_interval_ms
 
   defp next_poll_in_ms(nil, _now_ms), do: nil
 

--- a/packages/symphony-elixir/lib/symphony_elixir/orchestrator.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir/orchestrator.ex
@@ -12,6 +12,7 @@ defmodule SymphonyElixir.Orchestrator do
 
   @continuation_retry_delay_ms 1_000
   @failure_retry_base_ms 10_000
+  @setup_required_poll_interval_ms 300_000
   # Slightly above the dashboard render interval so "checking now…" can render.
   @poll_transition_render_delay_ms 20
   @empty_codex_totals %{
@@ -117,7 +118,7 @@ defmodule SymphonyElixir.Orchestrator do
   def handle_info(:run_poll_cycle, state) do
     state = refresh_runtime_config(state)
     state = maybe_dispatch(state)
-    state = schedule_tick(state, state.poll_interval_ms)
+    state = schedule_tick(state, next_poll_delay_ms(state))
     state = %{state | poll_check_in_progress: false}
 
     notify_dashboard()
@@ -1241,6 +1242,15 @@ defmodule SymphonyElixir.Orchestrator do
     :timer.send_after(@poll_transition_render_delay_ms, self(), :run_poll_cycle)
     :ok
   end
+
+  defp next_poll_delay_ms(%State{
+         last_tracker_status: :setup_required,
+         poll_interval_ms: poll_interval_ms
+       }) do
+    max(poll_interval_ms, @setup_required_poll_interval_ms)
+  end
+
+  defp next_poll_delay_ms(%State{poll_interval_ms: poll_interval_ms}), do: poll_interval_ms
 
   defp next_poll_in_ms(nil, _now_ms), do: nil
 

--- a/packages/symphony-elixir/lib/symphony_elixir/polling_policy.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir/polling_policy.ex
@@ -1,0 +1,11 @@
+defmodule SymphonyElixir.PollingPolicy do
+  @moduledoc false
+
+  @setup_required_poll_interval_ms 300_000
+
+  def next_delay_ms(:setup_required, poll_interval_ms) do
+    max(poll_interval_ms, @setup_required_poll_interval_ms)
+  end
+
+  def next_delay_ms(_tracker_status, poll_interval_ms), do: poll_interval_ms
+end

--- a/packages/symphony-elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir/status_dashboard.ex
@@ -1945,6 +1945,10 @@ defmodule SymphonyElixir.StatusDashboard do
   defp truncate(value, _max), do: value
 
   defp dashboard_enabled? do
+    non_test_environment?() and terminal_output_available?()
+  end
+
+  defp non_test_environment? do
     if Code.ensure_loaded?(Mix) and function_exported?(Mix, :env, 0) do
       try do
         Mix.env() != :test
@@ -1953,6 +1957,13 @@ defmodule SymphonyElixir.StatusDashboard do
       end
     else
       true
+    end
+  end
+
+  defp terminal_output_available? do
+    case :io.columns() do
+      {:ok, columns} when is_integer(columns) and columns > 0 -> true
+      _ -> false
     end
   end
 

--- a/packages/symphony-elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir/status_dashboard.ex
@@ -1945,7 +1945,7 @@ defmodule SymphonyElixir.StatusDashboard do
   defp truncate(value, _max), do: value
 
   defp dashboard_enabled? do
-    non_test_environment?() and terminal_output_available?()
+    non_test_environment?() and SymphonyElixir.TerminalCapabilities.output_available?()
   end
 
   defp non_test_environment? do
@@ -1957,13 +1957,6 @@ defmodule SymphonyElixir.StatusDashboard do
       end
     else
       true
-    end
-  end
-
-  defp terminal_output_available? do
-    case :io.columns() do
-      {:ok, columns} when is_integer(columns) and columns > 0 -> true
-      _ -> false
     end
   end
 

--- a/packages/symphony-elixir/lib/symphony_elixir/terminal_capabilities.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir/terminal_capabilities.ex
@@ -1,0 +1,10 @@
+defmodule SymphonyElixir.TerminalCapabilities do
+  @moduledoc false
+
+  def output_available? do
+    case :io.columns() do
+      {:ok, columns} when is_integer(columns) and columns > 0 -> true
+      _ -> false
+    end
+  end
+end

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -194,6 +194,8 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(statusDashboard).not.toContain('Enum.map_join(", ", &format_retry_summary/1)');
     expect(statusDashboard).not.toContain("when byte_size(value) > max");
     expect(statusDashboard).toContain("String.trim_trailing");
+    expect(statusDashboard).toContain("terminal_output_available?()");
+    expect(statusDashboard).toContain(":io.columns()");
   });
 
   it("keeps Codex dynamic tools inside the workspace and bounded on Linear calls", async () => {
@@ -227,6 +229,17 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(orchestrator).toContain("cleanup_issue_workspace(Map.get(metadata, :identifier))");
     expect(orchestrator).toContain("state = %{state | claimed: MapSet.put(state.claimed, issue.id)}");
     expect(orchestrator).toContain("defp retry_delay(_attempt, _metadata), do: @failure_retry_base_ms");
+  });
+
+  it("backs off platform polling while Linear setup is required", async () => {
+    const orchestrator = await readFile("packages/symphony-elixir/lib/symphony_elixir/orchestrator.ex", "utf8");
+    const workflow = await readFile("packages/symphony-elixir/WORKFLOW.md", "utf8");
+
+    expect(workflow).toContain("interval_ms: 5000");
+    expect(orchestrator).toContain("@setup_required_poll_interval_ms 300_000");
+    expect(orchestrator).toContain("state = schedule_tick(state, next_poll_delay_ms(state))");
+    expect(orchestrator).toMatch(/defp next_poll_delay_ms\(%State\{\s*last_tracker_status: :setup_required,/);
+    expect(orchestrator).toContain("max(poll_interval_ms, @setup_required_poll_interval_ms)");
   });
 
   it("uses Matrix-owned repository and runtime endpoint secrets", async () => {

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -181,6 +181,10 @@ describe("customer VPS Symphony systemd unit", () => {
 
   it("keeps terminal status dashboard rendering stable", async () => {
     const statusDashboard = await readFile("packages/symphony-elixir/lib/symphony_elixir/status_dashboard.ex", "utf8");
+    const terminalCapabilities = await readFile(
+      "packages/symphony-elixir/lib/symphony_elixir/terminal_capabilities.ex",
+      "utf8",
+    );
 
     expect(statusDashboard).toContain("def handle_info(:tick, state)");
     expect(statusDashboard).toContain("schedule_tick(state.refresh_ms)");
@@ -194,8 +198,9 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(statusDashboard).not.toContain('Enum.map_join(", ", &format_retry_summary/1)');
     expect(statusDashboard).not.toContain("when byte_size(value) > max");
     expect(statusDashboard).toContain("String.trim_trailing");
-    expect(statusDashboard).toContain("terminal_output_available?()");
-    expect(statusDashboard).toContain(":io.columns()");
+    expect(statusDashboard).toContain("SymphonyElixir.TerminalCapabilities.output_available?()");
+    expect(terminalCapabilities).toContain("def output_available?");
+    expect(terminalCapabilities).toContain(":io.columns()");
   });
 
   it("keeps Codex dynamic tools inside the workspace and bounded on Linear calls", async () => {
@@ -233,13 +238,19 @@ describe("customer VPS Symphony systemd unit", () => {
 
   it("backs off platform polling while Linear setup is required", async () => {
     const orchestrator = await readFile("packages/symphony-elixir/lib/symphony_elixir/orchestrator.ex", "utf8");
+    const pollingPolicy = await readFile(
+      "packages/symphony-elixir/lib/symphony_elixir/polling_policy.ex",
+      "utf8",
+    );
     const workflow = await readFile("packages/symphony-elixir/WORKFLOW.md", "utf8");
 
     expect(workflow).toContain("interval_ms: 5000");
-    expect(orchestrator).toContain("@setup_required_poll_interval_ms 300_000");
-    expect(orchestrator).toContain("state = schedule_tick(state, next_poll_delay_ms(state))");
-    expect(orchestrator).toMatch(/defp next_poll_delay_ms\(%State\{\s*last_tracker_status: :setup_required,/);
-    expect(orchestrator).toContain("max(poll_interval_ms, @setup_required_poll_interval_ms)");
+    expect(orchestrator).toMatch(
+      /SymphonyElixir\.PollingPolicy\.next_delay_ms\(\s*state\.last_tracker_status,\s*state\.poll_interval_ms\s*\)/,
+    );
+    expect(pollingPolicy).toContain("@setup_required_poll_interval_ms 300_000");
+    expect(pollingPolicy).toContain("def next_delay_ms(:setup_required, poll_interval_ms)");
+    expect(pollingPolicy).toContain("max(poll_interval_ms, @setup_required_poll_interval_ms)");
   });
 
   it("uses Matrix-owned repository and runtime endpoint secrets", async () => {

--- a/tests/observability/posthog-logship.test.ts
+++ b/tests/observability/posthog-logship.test.ts
@@ -24,6 +24,15 @@ describe("PostHog fleet log shipping", () => {
     expect(installer).toContain('forward_to = [loki.write.central.receiver, otelcol.receiver.loki.posthog.receiver]');
   });
 
+  it("keeps the Symphony terminal dashboard out of PostHog while retaining it in Loki", () => {
+    const installer = readRepoFile("distro/customer-vps/host-bin/matrix-install-logship");
+    const symphonySource = installer.match(/loki\.source\.journal "matrix_symphony" \{[\s\S]*?\n\}/)?.[0];
+
+    expect(symphonySource).toBeDefined();
+    expect(symphonySource).toContain("forward_to    = [loki.write.central.receiver]");
+    expect(symphonySource).not.toContain("otelcol.receiver.loki.posthog.receiver");
+  });
+
   it("threads the PostHog project token through logship enrollment without argv exposure", () => {
     const helper = readRepoFile("scripts/enable-vps-logship.sh");
 


### PR DESCRIPTION
## Root cause

- `matrix-symphony.service` renders an ANSI terminal dashboard every refresh. Alloy forwarded every redraw to both Loki and PostHog, producing roughly 21k low-value log records/minute during the observed burst.
- Disconnected Linear trackers poll `/internal/containers/<handle>/integrations/call` every 5 seconds. The expected setup-required 404 therefore creates about 17,280 Cloudflare 4xx requests per host/day, matching the dashboard's ~17.1k per-path counts.

## Fix

- Disable the Symphony status dashboard when no real terminal is attached (systemd/journald).
- Keep the Symphony journal source in Loki but exclude it from PostHog OTLP log shipping.
- Back off setup-required tracker polling to 5 minutes while preserving the configured interval for connected trackers.

This cuts disconnected polling by 60x (17,280 to 288 requests/host/day) and removes the dominant terminal-redraw stream from PostHog.

## Verification

- `pnpm exec vitest run tests/observability/posthog-logship.test.ts tests/deploy/customer-vps/symphony-systemd.test.ts`
- 2 files passed, 16 tests passed
- `git diff --check`