### PR TITLE
fix(platform): restore jurisdictional R2 provisioning

### DIFF
--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -305,6 +305,38 @@ jobs:
             fi
           done
 
+      - name: Verify primary R2 endpoint secret
+        run: |
+          set -euo pipefail
+          secret_name=r2-endpoint
+          gcloud secrets describe "$secret_name" \
+            --project "$GCP_PROJECT_ID" >/dev/null
+          endpoint_tmpfile="$(mktemp)"
+          trap 'rm -f "$endpoint_tmpfile"' EXIT
+          chmod 600 "$endpoint_tmpfile"
+          if ! gcloud secrets versions access latest \
+            --secret "$secret_name" \
+            --project "$GCP_PROJECT_ID" >"$endpoint_tmpfile"; then
+            echo "$secret_name must have an accessible latest version." >&2
+            exit 1
+          fi
+          if [ ! -s "$endpoint_tmpfile" ]; then
+            echo "$secret_name must have a non-empty latest version." >&2
+            exit 1
+          fi
+          accessor_member="$(
+            gcloud secrets get-iam-policy "$secret_name" \
+              --project "$GCP_PROJECT_ID" \
+              --flatten='bindings[].members' \
+              --filter="bindings.role:roles/secretmanager.secretAccessor AND bindings.members:serviceAccount:${CLOUD_RUN_SERVICE_ACCOUNT}" \
+              --format='value(bindings.members)' \
+              | head -1
+          )"
+          if [ "$accessor_member" != "serviceAccount:${CLOUD_RUN_SERVICE_ACCOUNT}" ]; then
+            echo "$secret_name must grant roles/secretmanager.secretAccessor to the Cloud Run runtime identity." >&2
+            exit 1
+          fi
+
       - name: Build platform image
         run: |
           set -euo pipefail
@@ -357,7 +389,7 @@ jobs:
               --format 'value(status)')
             case "$status" in
               SUCCESS)
-                exit 0
+                break
                 ;;
               FAILURE|INTERNAL_ERROR|TIMEOUT|CANCELLED|EXPIRED)
                 echo "Cloud Build $build_id ended with status $status" >&2
@@ -366,9 +398,18 @@ jobs:
             esac
             sleep 5
           done
-
-          echo "Timed out waiting for Cloud Build $build_id" >&2
-          exit 1
+          if [ "$status" != "SUCCESS" ]; then
+            echo "Timed out waiting for Cloud Build $build_id" >&2
+            exit 1
+          fi
+          digest="$(gcloud artifacts docker images describe "$image" \
+            --project "$GCP_PROJECT_ID" \
+            --format='value(image_summary.digest)')"
+          if [ -z "$digest" ]; then
+            echo "Could not resolve the immutable platform image digest." >&2
+            exit 1
+          fi
+          echo "IMAGE_DIGEST=${image%:*}@${digest}" >> "$GITHUB_ENV"
 
       - name: Deploy tagged revision
         run: |
@@ -389,16 +430,11 @@ jobs:
             traffic_flags+=(--no-traffic)
           fi
 
-          min_instances=0
-          if [ "$DEPLOY_ENVIRONMENT" = "production" ]; then
-            min_instances=1
-          fi
-
           # TODO(#410): flip CUSTOMER_VPS_TLS_VERIFY back to true once customer VPS origins present trusted certs.
           if ! deploy_json=$(gcloud run deploy "$CLOUD_RUN_SERVICE" \
             --project "$GCP_PROJECT_ID" \
             --region "$GCP_REGION" \
-            --image "$IMAGE" \
+            --image "$IMAGE_DIGEST" \
             --service-account "$CLOUD_RUN_SERVICE_ACCOUNT" \
             --platform managed \
             --port 8080 \
@@ -406,13 +442,13 @@ jobs:
             --memory 1Gi \
             --concurrency 30 \
             --timeout 300 \
-            --min-instances "$min_instances" \
+            --min-instances 0 \
             --max-instances 10 \
             --ingress all \
             --allow-unauthenticated \
             "${traffic_flags[@]}" \
-            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL},MATRIX_API_ORIGIN=${MATRIX_API_ORIGIN},CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_TLS_VERIFY=false,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_APP_DOMAIN_HOSTS=${MATRIX_APP_DOMAIN_HOSTS},MATRIX_CODE_DOMAIN_HOSTS=${MATRIX_CODE_DOMAIN_HOSTS},NEXT_PUBLIC_MATRIX_APP_URL=${MATRIX_APP_URL},MATRIX_BILLING_PROVIDER=stripe,POSTHOG_HOST=https://eu.i.posthog.com,POSTHOG_API_HOST=https://eu.i.posthog.com,NEXT_PUBLIC_POSTHOG_HOST=${POSTHOG_PUBLIC_HOST},NEXT_PUBLIC_POSTHOG_API_HOST=${POSTHOG_PUBLIC_API_HOST},R2_PREFIX_ROOT=matrixos-sync" \
-            --set-secrets "PLATFORM_DATABASE_URL=platform-database-url:latest,PLATFORM_SECRET=platform-secret:latest,GOLDEN_SNAPSHOT_OPERATOR_SECRET=golden-snapshot-operator-secret:latest,PLATFORM_JWT_SECRET=platform-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,STRIPE_SECRET_KEY=stripe-secret-key:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual:latest,PIPEDREAM_CLIENT_ID=pipedream-client-id:latest,PIPEDREAM_CLIENT_SECRET=pipedream-client-secret:latest,PIPEDREAM_PROJECT_ID=pipedream-project-id:latest,PIPEDREAM_ENVIRONMENT=pipedream-environment:latest,R2_ACCOUNT_ID=r2-account-id:latest,R2_BUCKET=r2-bucket:latest,R2_ACCESS_KEY_ID=r2-access-key-id:latest,R2_SECRET_ACCESS_KEY=r2-secret-access-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,HETZNER_API_TOKEN=hetzner-api-token:latest,POSTHOG_TOKEN=posthog-token:latest,POSTHOG_PROJECT_TOKEN=posthog-project-token:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,NEXT_PUBLIC_POSTHOG_KEY=next-public-posthog-key:latest,NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=next-public-posthog-project-token:latest" \
+            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_BACKGROUND_WORKERS_ENABLED=false,PLATFORM_PORT=8080,PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL},MATRIX_API_ORIGIN=${MATRIX_API_ORIGIN},CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_TLS_VERIFY=false,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_APP_DOMAIN_HOSTS=${MATRIX_APP_DOMAIN_HOSTS},MATRIX_CODE_DOMAIN_HOSTS=${MATRIX_CODE_DOMAIN_HOSTS},NEXT_PUBLIC_MATRIX_APP_URL=${MATRIX_APP_URL},MATRIX_BILLING_PROVIDER=stripe,POSTHOG_HOST=https://eu.i.posthog.com,POSTHOG_API_HOST=https://eu.i.posthog.com,NEXT_PUBLIC_POSTHOG_HOST=${POSTHOG_PUBLIC_HOST},NEXT_PUBLIC_POSTHOG_API_HOST=${POSTHOG_PUBLIC_API_HOST},R2_PREFIX_ROOT=matrixos-sync" \
+            --set-secrets "PLATFORM_DATABASE_URL=platform-database-url:latest,PLATFORM_SECRET=platform-secret:latest,GOLDEN_SNAPSHOT_OPERATOR_SECRET=golden-snapshot-operator-secret:latest,PLATFORM_JWT_SECRET=platform-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,STRIPE_SECRET_KEY=stripe-secret-key:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual:latest,PIPEDREAM_CLIENT_ID=pipedream-client-id:latest,PIPEDREAM_CLIENT_SECRET=pipedream-client-secret:latest,PIPEDREAM_PROJECT_ID=pipedream-project-id:latest,PIPEDREAM_ENVIRONMENT=pipedream-environment:latest,R2_ACCOUNT_ID=r2-account-id:latest,R2_BUCKET=r2-bucket:latest,R2_ENDPOINT=r2-endpoint:latest,R2_ACCESS_KEY_ID=r2-access-key-id:latest,R2_SECRET_ACCESS_KEY=r2-secret-access-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,HETZNER_API_TOKEN=hetzner-api-token:latest,POSTHOG_TOKEN=posthog-token:latest,POSTHOG_PROJECT_TOKEN=posthog-project-token:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,NEXT_PUBLIC_POSTHOG_KEY=next-public-posthog-key:latest,NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=next-public-posthog-project-token:latest" \
             --format=json); then
             exit 1
           fi
@@ -512,19 +548,55 @@ jobs:
             exit 1
           fi
           curl --fail --silent --show-error --max-time 20 --range 0-0 "$bundle_url" >/dev/null
+          platform_secret="$(gcloud secrets versions access latest \
+            --secret platform-secret \
+            --project "$GCP_PROJECT_ID" | tr -d '\r\n')"
+          if [ -z "$platform_secret" ]; then
+            echo "Could not read the platform smoke-test credential." >&2
+            exit 1
+          fi
+          echo "::add-mask::$platform_secret"
+          curl --fail --silent --show-error --max-time 45 \
+            --request POST \
+            --header "Authorization: Bearer ${platform_secret}" \
+            "$CANDIDATE_URL/vps/storage-check" >/dev/null
+
+      - name: Deploy production-role revision
+        if: ${{ github.event_name == 'push' || inputs.promote }}
+        run: |
+          set -euo pipefail
+          min_instances=0
+          if [ "$DEPLOY_ENVIRONMENT" = "production" ]; then
+            min_instances=1
+          fi
+          deploy_json="$(gcloud run deploy "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_REGION" \
+            --image "$IMAGE_DIGEST" \
+            --tag production-candidate \
+            --no-traffic \
+            --min-instances "$min_instances" \
+            --update-env-vars "PLATFORM_BACKGROUND_WORKERS_ENABLED=true" \
+            --format=json)"
+          production_revision="$(printf '%s\n' "$deploy_json" | jq -r '.status.traffic[]? | select(.tag == "production-candidate") | .revisionName // empty' | head -1)"
+          if [ -z "$production_revision" ]; then
+            echo "Could not resolve the production-role revision." >&2
+            exit 1
+          fi
+          echo "PRODUCTION_REVISION=$production_revision" >> "$GITHUB_ENV"
 
       - name: Promote revision
         if: ${{ github.event_name == 'push' || inputs.promote }}
         run: |
           set -euo pipefail
-          if [ -z "${CANDIDATE_REVISION:-}" ]; then
-            echo "No candidate revision found" >&2
+          if [ -z "${PRODUCTION_REVISION:-}" ]; then
+            echo "No production-role revision found" >&2
             exit 1
           fi
           gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
             --project "$GCP_PROJECT_ID" \
             --region "$GCP_REGION" \
-            --to-revisions "$CANDIDATE_REVISION=100"
+            --to-revisions "$PRODUCTION_REVISION=100"
 
       - name: Verify promoted revision traffic
         if: ${{ github.event_name == 'push' || inputs.promote }}
@@ -534,12 +606,12 @@ jobs:
             --project "$GCP_PROJECT_ID" \
             --region "$GCP_REGION" \
             --format=json)"
-          candidate_percent="$(printf '%s\n' "$service_json" | jq -r '(.status.traffic[]? | select(.revisionName == env.CANDIDATE_REVISION) | .percent) // empty' | head -1)"
-          if [ "$candidate_percent" != "100" ]; then
-            echo "Candidate revision ${CANDIDATE_REVISION} does not have 100% traffic." >&2
+          production_percent="$(printf '%s\n' "$service_json" | jq -r '(.status.traffic[]? | select(.revisionName == env.PRODUCTION_REVISION) | .percent) // empty' | head -1)"
+          if [ "$production_percent" != "100" ]; then
+            echo "Production revision ${PRODUCTION_REVISION} does not have 100% traffic." >&2
             exit 1
           fi
-          stale_revision="$(printf '%s\n' "$service_json" | jq -r '(.status.traffic[]? | select(.revisionName != env.CANDIDATE_REVISION and (.percent // 0) > 0) | "\(.revisionName)=\(.percent)") // empty' | head -1)"
+          stale_revision="$(printf '%s\n' "$service_json" | jq -r '(.status.traffic[]? | select(.revisionName != env.PRODUCTION_REVISION and (.percent // 0) > 0) | "\(.revisionName)=\(.percent)") // empty' | head -1)"
           if [ -n "$stale_revision" ]; then
             echo "Stale Cloud Run revision is still receiving traffic: $stale_revision" >&2
             exit 1

--- a/distro/customer-vps/host-bin/matrix-restore.sh
+++ b/distro/customer-vps/host-bin/matrix-restore.sh
@@ -46,12 +46,15 @@ check_r2_exists system/vps-meta.json "VPS metadata" || vps_meta_status="$?"
 check_r2_exists "$latest_pointer_key" "latest snapshot pointer" || latest_pointer_status="$?"
 
 if [ "$vps_meta_status" -eq 44 ] && [ "$latest_pointer_status" -eq 44 ]; then
+  # First installation: neither registration metadata nor a backup exists.
   touch "$restore_flag"
   exit 0
 fi
-if [ "$vps_meta_status" -eq 44 ] || [ "$latest_pointer_status" -eq 44 ]; then
-  echo "matrix-restore: owner restore state is incomplete" >&2
-  exit 1
+if [ "$vps_meta_status" -eq 0 ] && [ "$latest_pointer_status" -eq 44 ]; then
+  # A registered host may reboot before its first scheduled backup. Its local
+  # Postgres volume remains authoritative until the first pointer is written.
+  touch "$restore_flag"
+  exit 0
 fi
 
 if ! /opt/matrix/bin/matrixctl r2 get "$latest_pointer_key" "$latest_file"; then

--- a/distro/customer-vps/host-bin/matrix-restore.sh
+++ b/distro/customer-vps/host-bin/matrix-restore.sh
@@ -24,7 +24,7 @@ fi
 mkdir -p /home/matrix/home /home/matrix/projects /var/lib/matrix/db
 rm -f "$restore_flag"
 
-check_r2_exists_or_skip_restore() {
+check_r2_exists() {
   local key="$1"
   local label="$2"
   local status
@@ -33,16 +33,26 @@ check_r2_exists_or_skip_restore() {
   else
     status="$?"
   fi
-  if [ "$status" -eq 1 ]; then
-    touch "$restore_flag"
-    exit 0
+  if [ "$status" -eq 44 ]; then
+    return 44
   fi
   echo "matrix-restore: failed to check ${label}" >&2
   exit 1
 }
 
-check_r2_exists_or_skip_restore system/vps-meta.json "VPS metadata"
-check_r2_exists_or_skip_restore "$latest_pointer_key" "latest snapshot pointer"
+vps_meta_status=0
+latest_pointer_status=0
+check_r2_exists system/vps-meta.json "VPS metadata" || vps_meta_status="$?"
+check_r2_exists "$latest_pointer_key" "latest snapshot pointer" || latest_pointer_status="$?"
+
+if [ "$vps_meta_status" -eq 44 ] && [ "$latest_pointer_status" -eq 44 ]; then
+  touch "$restore_flag"
+  exit 0
+fi
+if [ "$vps_meta_status" -eq 44 ] || [ "$latest_pointer_status" -eq 44 ]; then
+  echo "matrix-restore: owner restore state is incomplete" >&2
+  exit 1
+fi
 
 if ! /opt/matrix/bin/matrixctl r2 get "$latest_pointer_key" "$latest_file"; then
   echo "matrix-restore: failed to fetch latest pointer" >&2

--- a/distro/customer-vps/host-bin/matrixctl
+++ b/distro/customer-vps/host-bin/matrixctl
@@ -1,16 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ -f /opt/matrix/env/r2.env ]; then
+R2_ENV_FILE="${MATRIX_R2_ENV_FILE:-/opt/matrix/env/r2.env}"
+HOST_ENV_FILE="${MATRIX_HOST_ENV_FILE:-/opt/matrix/env/host.env}"
+R2_ENV_LOADED=false
+if [ -e "$R2_ENV_FILE" ]; then
+  if [ ! -f "$R2_ENV_FILE" ] || [ ! -r "$R2_ENV_FILE" ]; then
+    echo "matrixctl: r2 configuration unreadable" >&2
+    exit 2
+  fi
   # shellcheck disable=SC1091
   set +u
-  source /opt/matrix/env/r2.env
+  if ! source "$R2_ENV_FILE"; then
+    set -u
+    echo "matrixctl: r2 configuration invalid" >&2
+    exit 2
+  fi
   set -u
+  R2_ENV_LOADED=true
 fi
-if [ -f /opt/matrix/env/host.env ]; then
+if [ -f "$HOST_ENV_FILE" ]; then
   # shellcheck disable=SC1091
   set +u
-  source /opt/matrix/env/host.env
+  source "$HOST_ENV_FILE"
   set -u
 fi
 export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}"
@@ -42,6 +54,14 @@ fail() {
 require_r2() {
   [ -n "$R2_BUCKET" ] || fail "r2 bucket not configured"
   [ -n "$R2_PREFIX" ] || fail "r2 prefix not configured"
+  [ -n "$AWS_ACCESS_KEY_ID" ] || fail "r2 access key not configured"
+  [ -n "$AWS_SECRET_ACCESS_KEY" ] || fail "r2 secret key not configured"
+  if [ -n "${MATRIX_MACHINE_ID:-}" ]; then
+    [ "$R2_ENV_LOADED" = true ] || fail "r2 configuration file missing"
+    [ -n "$R2_ACCOUNT_ID" ] || fail "r2 account not configured"
+    [ "$R2_ENDPOINT" = "https://${R2_ACCOUNT_ID}.eu.r2.cloudflarestorage.com" ] \
+      || fail "r2 endpoint invalid"
+  fi
 }
 
 r2_endpoint_arg() {
@@ -114,7 +134,7 @@ r2_exists() {
   esac
   case "$output" in
     *"(404)"*|*"Not Found"*|*"NotFound"*|*"NoSuchKey"*)
-      return 1
+      return 44
       ;;
   esac
   echo "matrixctl: r2 exists failed" >&2

--- a/distro/customer-vps/host-bin/matrixctl
+++ b/distro/customer-vps/host-bin/matrixctl
@@ -133,7 +133,7 @@ r2_exists() {
       ;;
   esac
   case "$output" in
-    *"(404)"*|*"Not Found"*|*"NotFound"*|*"NoSuchKey"*)
+    *"An error occurred (404) when calling the HeadObject operation:"*|*"An error occurred (NoSuchKey) when calling the HeadObject operation:"*|*"An error occurred (NotFound) when calling the HeadObject operation:"*)
       return 44
       ;;
   esac

--- a/distro/customer-vps/matrix-restore.sh
+++ b/distro/customer-vps/matrix-restore.sh
@@ -46,12 +46,15 @@ check_r2_exists system/vps-meta.json "VPS metadata" || vps_meta_status="$?"
 check_r2_exists "$latest_pointer_key" "latest snapshot pointer" || latest_pointer_status="$?"
 
 if [ "$vps_meta_status" -eq 44 ] && [ "$latest_pointer_status" -eq 44 ]; then
+  # First installation: neither registration metadata nor a backup exists.
   touch "$restore_flag"
   exit 0
 fi
-if [ "$vps_meta_status" -eq 44 ] || [ "$latest_pointer_status" -eq 44 ]; then
-  echo "matrix-restore: owner restore state is incomplete" >&2
-  exit 1
+if [ "$vps_meta_status" -eq 0 ] && [ "$latest_pointer_status" -eq 44 ]; then
+  # A registered host may reboot before its first scheduled backup. Its local
+  # Postgres volume remains authoritative until the first pointer is written.
+  touch "$restore_flag"
+  exit 0
 fi
 
 if ! /opt/matrix/bin/matrixctl r2 get "$latest_pointer_key" "$latest_file"; then

--- a/distro/customer-vps/matrix-restore.sh
+++ b/distro/customer-vps/matrix-restore.sh
@@ -24,7 +24,7 @@ fi
 mkdir -p /home/matrix/home /home/matrix/projects /var/lib/matrix/db
 rm -f "$restore_flag"
 
-check_r2_exists_or_skip_restore() {
+check_r2_exists() {
   local key="$1"
   local label="$2"
   local status
@@ -33,16 +33,26 @@ check_r2_exists_or_skip_restore() {
   else
     status="$?"
   fi
-  if [ "$status" -eq 1 ]; then
-    touch "$restore_flag"
-    exit 0
+  if [ "$status" -eq 44 ]; then
+    return 44
   fi
   echo "matrix-restore: failed to check ${label}" >&2
   exit 1
 }
 
-check_r2_exists_or_skip_restore system/vps-meta.json "VPS metadata"
-check_r2_exists_or_skip_restore "$latest_pointer_key" "latest snapshot pointer"
+vps_meta_status=0
+latest_pointer_status=0
+check_r2_exists system/vps-meta.json "VPS metadata" || vps_meta_status="$?"
+check_r2_exists "$latest_pointer_key" "latest snapshot pointer" || latest_pointer_status="$?"
+
+if [ "$vps_meta_status" -eq 44 ] && [ "$latest_pointer_status" -eq 44 ]; then
+  touch "$restore_flag"
+  exit 0
+fi
+if [ "$vps_meta_status" -eq 44 ] || [ "$latest_pointer_status" -eq 44 ]; then
+  echo "matrix-restore: owner restore state is incomplete" >&2
+  exit 1
+fi
 
 if ! /opt/matrix/bin/matrixctl r2 get "$latest_pointer_key" "$latest_file"; then
   echo "matrix-restore: failed to fetch latest pointer" >&2

--- a/distro/customer-vps/matrixctl
+++ b/distro/customer-vps/matrixctl
@@ -1,16 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ -f /opt/matrix/env/r2.env ]; then
+R2_ENV_FILE="${MATRIX_R2_ENV_FILE:-/opt/matrix/env/r2.env}"
+HOST_ENV_FILE="${MATRIX_HOST_ENV_FILE:-/opt/matrix/env/host.env}"
+R2_ENV_LOADED=false
+if [ -e "$R2_ENV_FILE" ]; then
+  if [ ! -f "$R2_ENV_FILE" ] || [ ! -r "$R2_ENV_FILE" ]; then
+    echo "matrixctl: r2 configuration unreadable" >&2
+    exit 2
+  fi
   # shellcheck disable=SC1091
   set +u
-  source /opt/matrix/env/r2.env
+  if ! source "$R2_ENV_FILE"; then
+    set -u
+    echo "matrixctl: r2 configuration invalid" >&2
+    exit 2
+  fi
   set -u
+  R2_ENV_LOADED=true
 fi
-if [ -f /opt/matrix/env/host.env ]; then
+if [ -f "$HOST_ENV_FILE" ]; then
   # shellcheck disable=SC1091
   set +u
-  source /opt/matrix/env/host.env
+  source "$HOST_ENV_FILE"
   set -u
 fi
 export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}"
@@ -42,6 +54,14 @@ fail() {
 require_r2() {
   [ -n "$R2_BUCKET" ] || fail "r2 bucket not configured"
   [ -n "$R2_PREFIX" ] || fail "r2 prefix not configured"
+  [ -n "$AWS_ACCESS_KEY_ID" ] || fail "r2 access key not configured"
+  [ -n "$AWS_SECRET_ACCESS_KEY" ] || fail "r2 secret key not configured"
+  if [ -n "${MATRIX_MACHINE_ID:-}" ]; then
+    [ "$R2_ENV_LOADED" = true ] || fail "r2 configuration file missing"
+    [ -n "$R2_ACCOUNT_ID" ] || fail "r2 account not configured"
+    [ "$R2_ENDPOINT" = "https://${R2_ACCOUNT_ID}.eu.r2.cloudflarestorage.com" ] \
+      || fail "r2 endpoint invalid"
+  fi
 }
 
 r2_endpoint_arg() {
@@ -114,7 +134,7 @@ r2_exists() {
   esac
   case "$output" in
     *"(404)"*|*"Not Found"*|*"NotFound"*|*"NoSuchKey"*)
-      return 1
+      return 44
       ;;
   esac
   echo "matrixctl: r2 exists failed" >&2

--- a/distro/customer-vps/matrixctl
+++ b/distro/customer-vps/matrixctl
@@ -133,7 +133,7 @@ r2_exists() {
       ;;
   esac
   case "$output" in
-    *"(404)"*|*"Not Found"*|*"NotFound"*|*"NoSuchKey"*)
+    *"An error occurred (404) when calling the HeadObject operation:"*|*"An error occurred (NoSuchKey) when calling the HeadObject operation:"*|*"An error occurred (NotFound) when calling the HeadObject operation:"*)
       return 44
       ;;
   esac

--- a/packages/platform/src/customer-vps-routes.ts
+++ b/packages/platform/src/customer-vps-routes.ts
@@ -43,6 +43,7 @@ export function meetsMessagingResourceFloor(
 export interface CustomerVpsRoutesDeps {
   service: CustomerVpsService;
   platformSecret: string;
+  assertPrimaryStorageReady?: (options?: { force?: boolean }) => Promise<void>;
   probeMachineHealth?: (machine: { machineId: string; handle: string; publicIPv4: string | null }) => Promise<boolean>;
   probeMachineRuntime?: (machine: { machineId: string; handle: string; publicIPv4: string | null }) => Promise<{
     healthy: boolean;
@@ -127,6 +128,21 @@ export function createCustomerVpsRoutes(deps: CustomerVpsRoutesDeps): Hono {
     }
     return null;
   }
+
+  app.post('/storage-check', bodyLimit({ maxSize: VPS_BODY_LIMIT }), async (c) => {
+    const authError = requirePlatformAuth(c);
+    if (authError) return authError;
+    if (!deps.assertPrimaryStorageReady) {
+      return c.json({ error: 'Storage unavailable' }, 503);
+    }
+    try {
+      await deps.assertPrimaryStorageReady({ force: true });
+      return c.json({ status: 'ok' });
+    } catch (err: unknown) {
+      logCustomerVpsError('primary storage capability check failed', err);
+      return c.json({ error: 'Storage unavailable' }, 503);
+    }
+  });
 
   app.post('/provision', bodyLimit({ maxSize: VPS_BODY_LIMIT }), async (c) => {
     const authError = requirePlatformAuth(c);

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -120,6 +120,7 @@ import {
 } from './container-endpoint.js';
 import { startPlatformServer } from './platform-startup.js';
 import {
+  checkCustomerVpsPrimaryStorageEnv,
   checkHomeMirrorS3Env,
   checkHostBundleStorageEnv,
   checkUnsafeDefaultSecrets,
@@ -130,6 +131,7 @@ export { escapeInlineScriptJson } from './auth-pages.js';
 export { buildPostAuthRedirectPath } from './request-routing.js';
 export type { PlatformApp } from './platform-app-types.js';
 export {
+  checkCustomerVpsPrimaryStorageEnv,
   checkHomeMirrorS3Env,
   checkHostBundleStorageEnv,
   checkUnsafeDefaultSecrets,
@@ -323,6 +325,7 @@ export function createApp(deps: {
   goldenSnapshotConfig?: GoldenSnapshotRuntimeConfig;
   customerVpsObjectStore?: CustomerVpsObjectStore;
   hostBundleObjectStore?: CustomerVpsObjectStore;
+  assertPrimaryStorageReady?: (options?: { force?: boolean }) => Promise<void>;
   env?: NodeJS.ProcessEnv;
 }) {
   const { db, docker, orchestrator, clerkAuth, matrixProvisioner } = deps;
@@ -745,6 +748,7 @@ export function createApp(deps: {
       probeMachineRuntime,
       recordRuntimeMetrics: platformMetricsRoutes.recordRuntimeMetrics,
       captureEvent: captureFunnelEvent,
+      assertPrimaryStorageReady: deps.assertPrimaryStorageReady,
     }));
   }
 
@@ -944,6 +948,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     customerVpsProxyDispatcher,
     createApp,
     checkUnsafeDefaultSecrets,
+    checkCustomerVpsPrimaryStorageEnv,
     checkHomeMirrorS3Env,
     checkHostBundleStorageEnv,
     collectTenantPublicTelemetryEnv,

--- a/packages/platform/src/platform-startup-env.ts
+++ b/packages/platform/src/platform-startup-env.ts
@@ -54,6 +54,45 @@ export function checkUnsafeDefaultSecrets(
   return problems;
 }
 
+export function checkCustomerVpsPrimaryStorageEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  log: (msg: string) => void = console.error,
+): string[] {
+  if (env.NODE_ENV !== 'production' || env.CUSTOMER_VPS_ENABLED !== 'true') return [];
+
+  const problems: string[] = [];
+  const accountId = env.R2_ACCOUNT_ID?.trim();
+  const endpoint = env.R2_ENDPOINT?.trim();
+  if (!endpoint || !accountId || (env.S3_ENDPOINT?.trim() && env.S3_ENDPOINT.trim() !== endpoint)) {
+    problems.push('R2_ENDPOINT');
+  } else {
+    try {
+      const parsed = new URL(endpoint);
+      const expectedHost = `${accountId}.eu.r2.cloudflarestorage.com`;
+      if (
+        parsed.protocol !== 'https:' ||
+        parsed.hostname !== expectedHost ||
+        parsed.port !== '' ||
+        parsed.username !== '' ||
+        parsed.password !== '' ||
+        parsed.pathname !== '/' ||
+        parsed.search !== '' ||
+        parsed.hash !== ''
+      ) {
+        problems.push('R2_ENDPOINT');
+      }
+    } catch (error: unknown) {
+      if (!(error instanceof TypeError)) throw error;
+      problems.push('R2_ENDPOINT');
+    }
+  }
+
+  if (problems.length > 0) {
+    log('[platform] Production customer VPS provisioning requires the canonical EU primary R2 endpoint.');
+  }
+  return problems;
+}
+
 export function checkHostBundleStorageEnv(
   env: NodeJS.ProcessEnv = process.env,
   log: (msg: string) => void = console.warn,

--- a/packages/platform/src/platform-startup.ts
+++ b/packages/platform/src/platform-startup.ts
@@ -40,6 +40,11 @@ import { backfillFirstRunRecords } from './journey.js';
 import { logPlatformRouteError } from './platform-route-utils.js';
 import { CustomerVpsError } from './customer-vps-errors.js';
 import { registerPlatformWebSocketUpgradeHandler } from './platform-websocket-upgrade.js';
+import {
+  createR2CapabilityGate,
+  createStorageGatedHetznerClient,
+  type R2CapabilityGate,
+} from './r2-capability.js';
 
 interface GatewayPlatformUser {
   id: string;
@@ -119,7 +124,11 @@ interface GatewayR2Client {
     body: string | Uint8Array | ReadableStream<Uint8Array>,
     options?: { signal?: AbortSignal },
   ): Promise<{ etag?: string }>;
-  deleteObject(key: string): Promise<void>;
+  headObject(
+    key: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<{ exists: boolean; etag?: string }>;
+  deleteObject(key: string, options?: { signal?: AbortSignal }): Promise<void>;
   destroy(): void;
 }
 
@@ -150,6 +159,7 @@ type CreatePlatformApp = (deps: {
   goldenSnapshotConfig?: GoldenSnapshotRuntimeConfig;
   customerVpsObjectStore?: CustomerVpsObjectStore;
   hostBundleObjectStore?: CustomerVpsObjectStore;
+  assertPrimaryStorageReady?: (options?: { force?: boolean }) => Promise<void>;
   env?: NodeJS.ProcessEnv;
 }) => PlatformApp;
 
@@ -162,6 +172,7 @@ export interface StartPlatformServerOptions {
   customerVpsProxyDispatcher: Agent;
   createApp: CreatePlatformApp;
   checkUnsafeDefaultSecrets(): string[];
+  checkCustomerVpsPrimaryStorageEnv(): string[];
   checkHomeMirrorS3Env(): string[];
   checkHostBundleStorageEnv(): string[];
   collectTenantPublicTelemetryEnv(): string[];
@@ -197,6 +208,7 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
     customerVpsProxyDispatcher,
     createApp: createPlatformApp,
     checkUnsafeDefaultSecrets,
+    checkCustomerVpsPrimaryStorageEnv,
     checkHomeMirrorS3Env,
     checkHostBundleStorageEnv,
     collectTenantPublicTelemetryEnv,
@@ -209,6 +221,10 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
   if (checkUnsafeDefaultSecrets().length > 0) {
     process.exit(1);
   }
+  if (checkCustomerVpsPrimaryStorageEnv().length > 0) {
+    process.exit(1);
+  }
+  const backgroundWorkersEnabled = process.env.PLATFORM_BACKGROUND_WORKERS_ENABLED !== 'false';
   let runtimeConfig;
   try {
     runtimeConfig = loadPlatformRuntimeConfig();
@@ -258,7 +274,7 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
 
     const maxRunning = Number(process.env.MAX_RUNNING_CONTAINERS) || 20;
     const lifecycle = createLifecycleManager({ db, orchestrator, maxRunning });
-    lifecycle.start();
+    if (backgroundWorkersEnabled) lifecycle.start();
 
     const statsCollector = createStatsCollector({
       docker,
@@ -267,7 +283,7 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
         await updateContainerStatus(db, handle, 'running', containerId);
       },
     });
-    statsCollector.start();
+    if (backgroundWorkersEnabled) statsCollector.start();
   } else {
     const { createDisabledOrchestrator } = await import('./orchestrator.js');
     orchestrator = createDisabledOrchestrator({
@@ -378,6 +394,7 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
   let internalSyncRoutes: Hono | undefined;
   let customerVpsObjectStore: CustomerVpsObjectStore | undefined;
   let hostBundleObjectStore: CustomerVpsObjectStore | undefined;
+  let primaryStorageGate: R2CapabilityGate | undefined;
   const s3Endpoint = process.env.S3_ENDPOINT ?? process.env.R2_ENDPOINT;
   const s3AccessKey = process.env.S3_ACCESS_KEY_ID ?? process.env.R2_ACCESS_KEY_ID;
   const s3SecretKey = process.env.S3_SECRET_ACCESS_KEY ?? process.env.R2_SECRET_ACCESS_KEY;
@@ -406,6 +423,7 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
     });
     customerVpsObjectStore = r2;
     hostBundleObjectStore = r2;
+    primaryStorageGate = createR2CapabilityGate({ storage: r2 });
   }
 
   const bundleS3Bucket = process.env.S3_BUNDLES_BUCKET ?? process.env.R2_BUNDLES_BUCKET;
@@ -449,7 +467,11 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
     ]);
     const customerVpsConfig = loadCustomerVpsConfig();
     const cloudInitTemplate = await loadCustomerVpsCloudInitTemplate();
-    const hetzner = createHetznerClient(customerVpsConfig);
+    const baseHetzner = createHetznerClient(customerVpsConfig);
+    const hetzner = createStorageGatedHetznerClient(baseHetzner, async () => {
+      if (!primaryStorageGate) throw new Error('Primary storage unavailable');
+      await primaryStorageGate.assertReady();
+    });
     customerVpsService = createCustomerVpsService({
       db,
       config: customerVpsConfig,
@@ -614,14 +636,14 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
       const intervalMs = parseGoldenSnapshotReconciliationInterval(
         process.env.GOLDEN_SNAPSHOT_RECONCILIATION_INTERVAL_MS,
       );
-      if (intervalMs !== undefined) {
+      if (backgroundWorkersEnabled && intervalMs !== undefined) {
         void runGoldenSnapshotWorker();
         goldenSnapshotInterval = setInterval(runGoldenSnapshotWorker, intervalMs);
         goldenSnapshotInterval.unref();
       }
     }
     const reconciliationIntervalMs = Number(process.env.CUSTOMER_VPS_RECONCILIATION_INTERVAL_MS ?? 60_000);
-    if (reconciliationIntervalMs > 0) {
+    if (backgroundWorkersEnabled && reconciliationIntervalMs > 0) {
       let reconciliationRunning = false;
       const runCustomerVpsReconciliation = async () => {
         if (reconciliationRunning || !customerVpsService) return;
@@ -709,6 +731,7 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
     goldenSnapshotConfig,
     customerVpsObjectStore,
     hostBundleObjectStore,
+    assertPrimaryStorageReady: primaryStorageGate?.assertReady,
     env: appEnv,
   });
   const processPosthogErrorTracker = createPostHogErrorTracker({

--- a/packages/platform/src/r2-capability.ts
+++ b/packages/platform/src/r2-capability.ts
@@ -1,0 +1,116 @@
+import { randomUUID } from 'node:crypto';
+import type { HetznerClient } from './customer-vps-hetzner.js';
+
+const DEFAULT_CACHE_TTL_MS = 30_000;
+const READ_TIMEOUT_MS = 10_000;
+const WRITE_TIMEOUT_MS = 30_000;
+const CANARY_BODY = 'matrix-os-primary-storage-capability-check';
+
+export interface R2CapabilityStorage {
+  headObject(
+    key: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<{ exists: boolean; etag?: string }>;
+  putObject(
+    key: string,
+    body: string | Uint8Array | ReadableStream<Uint8Array>,
+    options?: { signal?: AbortSignal },
+  ): Promise<{ etag?: string }>;
+  deleteObject(key: string, options?: { signal?: AbortSignal }): Promise<void>;
+}
+
+export interface R2CapabilityGate {
+  assertReady(options?: { force?: boolean }): Promise<void>;
+}
+
+export function createR2CapabilityGate(options: {
+  storage: R2CapabilityStorage;
+  cacheTtlMs?: number;
+  now?: () => number;
+  keyFactory?: () => string;
+}): R2CapabilityGate {
+  const cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+  const now = options.now ?? Date.now;
+  const keyFactory = options.keyFactory ?? (() => `_platform/canary/${randomUUID()}`);
+  let lastSuccessAt: number | null = null;
+  let inFlight: Promise<void> | null = null;
+
+  async function probe(): Promise<void> {
+    const key = keyFactory();
+    let deleteError: unknown;
+    let probeError: unknown;
+
+    try {
+      const initial = await options.storage.headObject(key, {
+        signal: AbortSignal.timeout(READ_TIMEOUT_MS),
+      });
+      if (initial.exists) throw new Error('reserved canary key already exists');
+
+      await options.storage.putObject(key, CANARY_BODY, {
+        signal: AbortSignal.timeout(WRITE_TIMEOUT_MS),
+      });
+      const written = await options.storage.headObject(key, {
+        signal: AbortSignal.timeout(READ_TIMEOUT_MS),
+      });
+      if (!written.exists) throw new Error('canary write was not visible');
+    } catch (error: unknown) {
+      probeError = error;
+    } finally {
+      try {
+        await options.storage.deleteObject(key, {
+          signal: AbortSignal.timeout(WRITE_TIMEOUT_MS),
+        });
+      } catch (error: unknown) {
+        deleteError = error;
+      }
+
+      try {
+        const final = await options.storage.headObject(key, {
+          signal: AbortSignal.timeout(READ_TIMEOUT_MS),
+        });
+        if (final.exists && deleteError === undefined) {
+          deleteError = new Error('canary cleanup was not visible');
+        }
+      } catch (error: unknown) {
+        if (deleteError === undefined) deleteError = error;
+      }
+    }
+
+    if (probeError !== undefined || deleteError !== undefined) {
+      throw new Error('Primary storage unavailable', {
+        cause: probeError ?? deleteError,
+      });
+    }
+  }
+
+  return {
+    async assertReady({ force = false } = {}): Promise<void> {
+      if (!force && lastSuccessAt !== null && now() - lastSuccessAt <= cacheTtlMs) {
+        return;
+      }
+      if (inFlight) return inFlight;
+
+      inFlight = probe()
+        .then(() => {
+          lastSuccessAt = now();
+        })
+        .finally(() => {
+          inFlight = null;
+        });
+      return inFlight;
+    },
+  };
+}
+
+export function createStorageGatedHetznerClient(
+  base: HetznerClient,
+  assertStorageReady: () => Promise<void>,
+): HetznerClient {
+  return {
+    ...base,
+    async createServer(input) {
+      await assertStorageReady();
+      return base.createServer(input);
+    },
+  };
+}

--- a/packages/platform/src/r2-client.ts
+++ b/packages/platform/src/r2-client.ts
@@ -36,7 +36,11 @@ export interface R2Client {
     body: string | Uint8Array | ReadableStream<Uint8Array>,
     options?: { signal?: AbortSignal },
   ): Promise<{ etag?: string }>;
-  deleteObject(key: string): Promise<void>;
+  headObject(
+    key: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<{ exists: boolean; etag?: string }>;
+  deleteObject(key: string, options?: { signal?: AbortSignal }): Promise<void>;
   destroy(): void;
 }
 
@@ -65,6 +69,7 @@ export async function createR2Client(config: R2ClientConfig): Promise<R2Client> 
     S3Client,
     GetObjectCommand,
     PutObjectCommand,
+    HeadObjectCommand,
     DeleteObjectCommand,
     CreateMultipartUploadCommand,
     UploadPartCommand,
@@ -179,10 +184,39 @@ export async function createR2Client(config: R2ClientConfig): Promise<R2Client> 
       return { etag: response.ETag ?? undefined };
     },
 
-    async deleteObject(key: string): Promise<void> {
+    async headObject(
+      key: string,
+      options?: { signal?: AbortSignal },
+    ): Promise<{ exists: boolean; etag?: string }> {
+      const command = new HeadObjectCommand({ Bucket: bucket, Key: key });
+      try {
+        const response = await s3.send(command, {
+          abortSignal: options?.signal ?? AbortSignal.timeout(R2_READ_TIMEOUT_MS),
+        });
+        return { exists: true, etag: response.ETag ?? undefined };
+      } catch (error: unknown) {
+        const providerError = error as {
+          name?: string;
+          $metadata?: { httpStatusCode?: number };
+        };
+        if (
+          providerError.name === "NoSuchKey" ||
+          providerError.name === "NotFound" ||
+          providerError.$metadata?.httpStatusCode === 404
+        ) {
+          return { exists: false };
+        }
+        throw error;
+      }
+    },
+
+    async deleteObject(
+      key: string,
+      options?: { signal?: AbortSignal },
+    ): Promise<void> {
       const command = new DeleteObjectCommand({ Bucket: bucket, Key: key });
       await s3.send(command, {
-        abortSignal: AbortSignal.timeout(R2_WRITE_TIMEOUT_MS),
+        abortSignal: options?.signal ?? AbortSignal.timeout(R2_WRITE_TIMEOUT_MS),
       });
     },
 

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -417,13 +417,14 @@ describe('CI workflows', () => {
     expect(workflow).toContain('- ".github/workflows/platform-cloud-run.yml"');
   });
 
-  it('verifies platform Cloud Run promotion sends all traffic to the candidate revision', () => {
+  it('verifies platform Cloud Run promotion sends all traffic to the production-role revision', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
 
     expect(workflow).toContain('Verify promoted revision traffic');
-    expect(workflow).toContain('select(.revisionName == env.CANDIDATE_REVISION) | .percent');
-    expect(workflow).toContain('select(.revisionName != env.CANDIDATE_REVISION and (.percent // 0) > 0)');
+    expect(workflow).toContain('select(.revisionName == env.PRODUCTION_REVISION) | .percent');
+    expect(workflow).toContain('select(.revisionName != env.PRODUCTION_REVISION and (.percent // 0) > 0)');
+    expect(workflow).toContain('--image "$IMAGE_DIGEST"');
   });
 
   it('uses a registry-backed BuildKit cache for platform Cloud Build', () => {

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -708,10 +708,14 @@ exit 99
     expect(operationalError.restoreFlagExists).toBe(false);
     expect(operationalError.result.stderr).toContain('matrix-restore: failed to check VPS metadata');
 
-    const ambiguous = runRestoreWithFakeMatrixctl({ vpsMeta: 0, latestPointer: 44 });
-    expect(ambiguous.result.status).toBe(1);
-    expect(ambiguous.restoreFlagExists).toBe(false);
-    expect(ambiguous.result.stderr).toContain('matrix-restore: owner restore state is incomplete');
+    const registeredBeforeBackup = runRestoreWithFakeMatrixctl({ vpsMeta: 0, latestPointer: 44 });
+    expect(registeredBeforeBackup.result.status, registeredBeforeBackup.result.stderr).toBe(0);
+    expect(registeredBeforeBackup.restoreFlagExists).toBe(true);
+
+    const backupWithoutMetadata = runRestoreWithFakeMatrixctl({ vpsMeta: 44, latestPointer: 0 });
+    expect(backupWithoutMetadata.result.status).toBe(1);
+    expect(backupWithoutMetadata.restoreFlagExists).toBe(false);
+    expect(backupWithoutMetadata.result.stderr).toContain('matrix-restore: failed to fetch latest pointer');
   });
 
   it('fails customer-host R2 operations for unreadable config or a non-EU endpoint', () => {

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -842,5 +842,12 @@ exit 99
       'An error occurred (404) when calling the HeadObject operation: Not Found',
     );
     expect(notFoundResult.status).toBe(44);
+
+    const unrelatedNotFound = runMatrixctlExistsWithFakeAws(
+      1,
+      'configuration endpoint Not Found',
+    );
+    expect(unrelatedNotFound.status).toBe(2);
+    expect(unrelatedNotFound.stderr).toContain('matrixctl: r2 exists failed');
   });
 });

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -92,6 +92,8 @@ describe('platform/customer-vps-cloud-init', () => {
           R2_BUCKET: 'matrixos-sync',
           R2_PREFIX: 'matrixos-sync/user_123/',
           R2_ENDPOINT: 'https://r2.example',
+          AWS_ACCESS_KEY_ID: 'test-access-key',
+          AWS_SECRET_ACCESS_KEY: 'test-secret-key',
         },
       });
     } finally {
@@ -99,7 +101,9 @@ describe('platform/customer-vps-cloud-init', () => {
     }
   }
 
-  function runRestoreWithFakeMatrixctl(existsStatus: number) {
+  function runRestoreWithFakeMatrixctl(
+    existsStatus: number | { vpsMeta: number; latestPointer: number },
+  ) {
     const root = process.cwd();
     const tempDir = mkdtempSync(join(tmpdir(), 'second-restore-r2-'));
     const fakeMatrixctlPath = join(tempDir, 'matrixctl');
@@ -110,7 +114,10 @@ describe('platform/customer-vps-cloud-init', () => {
       fakeMatrixctlPath,
       `#!/usr/bin/env bash
 if [ "$1" = "r2" ] && [ "$2" = "exists" ]; then
-  exit ${existsStatus}
+  if [ "$3" = "system/vps-meta.json" ]; then
+    exit ${typeof existsStatus === 'number' ? existsStatus : existsStatus.vpsMeta}
+  fi
+  exit ${typeof existsStatus === 'number' ? existsStatus : existsStatus.latestPointer}
 fi
 echo "unexpected matrixctl call: $*" >&2
 exit 99
@@ -671,10 +678,10 @@ exit 99
     const bundled = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-restore.sh'), 'utf8');
 
     for (const script of [restore, bundled]) {
-      expect(script).toContain('check_r2_exists_or_skip_restore()');
+      expect(script).toContain('check_r2_exists()');
       expect(script).toContain('local status');
       expect(script).toMatch(/else\n\s+status="\$[?]"/);
-      expect(script).toContain('if [ "$status" -eq 1 ]; then');
+      expect(script).toContain('if [ "$status" -eq 44 ]; then');
       expect(script).toContain('touch "$restore_flag"');
       expect(script).toContain('matrix-restore: failed to check');
       expect(script).not.toContain('if ! /opt/matrix/bin/matrixctl r2 exists system/vps-meta.json; then');
@@ -683,9 +690,13 @@ exit 99
   });
 
   it('executes restore skip only for not-found R2 exists status', () => {
-    const notFound = runRestoreWithFakeMatrixctl(1);
+    const notFound = runRestoreWithFakeMatrixctl(44);
     expect(notFound.result.status, notFound.result.stderr).toBe(0);
     expect(notFound.restoreFlagExists).toBe(true);
+
+    const genericFailure = runRestoreWithFakeMatrixctl(1);
+    expect(genericFailure.result.status).toBe(1);
+    expect(genericFailure.restoreFlagExists).toBe(false);
 
     const timeout = runRestoreWithFakeMatrixctl(124);
     expect(timeout.result.status).toBe(1);
@@ -696,6 +707,55 @@ exit 99
     expect(operationalError.result.status).toBe(1);
     expect(operationalError.restoreFlagExists).toBe(false);
     expect(operationalError.result.stderr).toContain('matrix-restore: failed to check VPS metadata');
+
+    const ambiguous = runRestoreWithFakeMatrixctl({ vpsMeta: 0, latestPointer: 44 });
+    expect(ambiguous.result.status).toBe(1);
+    expect(ambiguous.restoreFlagExists).toBe(false);
+    expect(ambiguous.result.stderr).toContain('matrix-restore: owner restore state is incomplete');
+  });
+
+  it('fails customer-host R2 operations for unreadable config or a non-EU endpoint', () => {
+    const root = process.cwd();
+    const tempDir = mkdtempSync(join(tmpdir(), 'matrixctl-r2-config-'));
+    const r2Env = join(tempDir, 'r2.env');
+    const commonEnv = {
+      ...process.env,
+      MATRIX_MACHINE_ID: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      MATRIX_R2_ENV_FILE: r2Env,
+      MATRIX_HOST_ENV_FILE: join(tempDir, 'missing-host.env'),
+    };
+
+    try {
+      writeFileSync(r2Env, 'R2_BUCKET=matrixos-sync\n');
+      chmodSync(r2Env, 0o000);
+      const unreadable = spawnSync(
+        'bash',
+        [join(root, 'distro/customer-vps/matrixctl'), 'r2', 'exists', 'system/db/latest'],
+        { cwd: root, encoding: 'utf8', env: commonEnv },
+      );
+      expect(unreadable.status).toBe(2);
+      expect(unreadable.stderr).toContain('matrixctl: r2 configuration unreadable');
+
+      chmodSync(r2Env, 0o600);
+      writeFileSync(r2Env, [
+        'AWS_ACCESS_KEY_ID=test-access-key',
+        'AWS_SECRET_ACCESS_KEY=test-secret-key',
+        'R2_BUCKET=matrixos-sync',
+        'R2_PREFIX=matrixos-sync/user_123/',
+        'R2_ACCOUNT_ID=current-account',
+        'R2_ENDPOINT=https://current-account.r2.cloudflarestorage.com',
+      ].join('\n'));
+      const wrongEndpoint = spawnSync(
+        'bash',
+        [join(root, 'distro/customer-vps/matrixctl'), 'r2', 'exists', 'system/db/latest'],
+        { cwd: root, encoding: 'utf8', env: commonEnv },
+      );
+      expect(wrongEndpoint.status).toBe(1);
+      expect(wrongEndpoint.stderr).toContain('matrixctl: r2 endpoint invalid');
+    } finally {
+      chmodSync(r2Env, 0o600);
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('runs DB backup on an hourly systemd timer', () => {
@@ -781,6 +841,6 @@ exit 99
       255,
       'An error occurred (404) when calling the HeadObject operation: Not Found',
     );
-    expect(notFoundResult.status).toBe(1);
+    expect(notFoundResult.status).toBe(44);
   });
 });

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -1240,7 +1240,7 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     const restore = readFileSync(join(root, 'distro/customer-vps/matrix-restore.sh'), 'utf8');
 
     expect(restore).toContain('if /opt/matrix/bin/matrixctl r2 exists "$key"; then');
-    expect(restore).toContain('check_r2_exists_or_skip_restore system/vps-meta.json "VPS metadata"');
+    expect(restore).toContain('check_r2_exists system/vps-meta.json "VPS metadata"');
     expect(restore).toContain('latest_pointer_key="system/db/latest"');
     expect(restore).toContain('/opt/matrix/bin/matrixctl r2 get "$latest_pointer_key" "$latest_file"');
   });
@@ -1262,5 +1262,11 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(workflow).toContain("grep -Fq 'r2.cloudflarestorage.com'");
     expect(workflow).toContain('Candidate host bundle signer returned a native R2 URL outside the bundle bucket; refusing to promote.');
     expect(workflow).toContain('curl --fail --silent --show-error --max-time 20 --range 0-0 "$bundle_url"');
+    expect(workflow).toContain('R2_ENDPOINT=r2-endpoint:latest');
+    expect(workflow).toContain('PLATFORM_BACKGROUND_WORKERS_ENABLED=false');
+    expect(workflow).toContain('PLATFORM_BACKGROUND_WORKERS_ENABLED=true');
+    expect(workflow).toContain('$CANDIDATE_URL/vps/storage-check');
+    expect(workflow).toContain('PRODUCTION_REVISION');
+    expect(workflow).toContain('--to-revisions "$PRODUCTION_REVISION=100"');
   });
 });

--- a/tests/platform/customer-vps-routes.test.ts
+++ b/tests/platform/customer-vps-routes.test.ts
@@ -61,6 +61,37 @@ describe('platform/customer-vps-routes', () => {
     expect(status.status).toBe(401);
   });
 
+  it('exposes only an authenticated, coarse primary-storage capability check', async () => {
+    const service = {} as Parameters<typeof createCustomerVpsRoutes>[0]['service'];
+    const assertPrimaryStorageReady = vi.fn().mockResolvedValue(undefined);
+    const app = new Hono();
+    app.route('/vps', createCustomerVpsRoutes({
+      service,
+      platformSecret,
+      assertPrimaryStorageReady,
+    }));
+
+    const unauthorized = await app.request('/vps/storage-check', { method: 'POST' });
+    expect(unauthorized.status).toBe(401);
+    expect(assertPrimaryStorageReady).not.toHaveBeenCalled();
+
+    const ok = await app.request('/vps/storage-check', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${platformSecret}` },
+    });
+    expect(ok.status).toBe(200);
+    expect(await ok.json()).toEqual({ status: 'ok' });
+    expect(assertPrimaryStorageReady).toHaveBeenCalledWith({ force: true });
+
+    assertPrimaryStorageReady.mockRejectedValueOnce(new Error('private provider detail'));
+    const unavailable = await app.request('/vps/storage-check', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${platformSecret}` },
+    });
+    expect(unavailable.status).toBe(503);
+    expect(await unavailable.json()).toEqual({ error: 'Storage unavailable' });
+  });
+
   it('protects and validates the preview provision route contract', async () => {
     const provision = vi.fn();
     const provisionPreview = vi.fn().mockResolvedValue({

--- a/tests/platform/golden-snapshot-worker-wiring.test.ts
+++ b/tests/platform/golden-snapshot-worker-wiring.test.ts
@@ -3,6 +3,13 @@ import { describe, expect, it } from 'vitest';
 import { parseGoldenSnapshotReconciliationInterval } from '../../packages/platform/src/platform-startup.js';
 
 describe('golden snapshot worker wiring', () => {
+  it('starts no recurring platform workers when background workers are disabled', async () => {
+    const source = await readFile('packages/platform/src/platform-startup.ts', 'utf8');
+    expect(source).toContain("process.env.PLATFORM_BACKGROUND_WORKERS_ENABLED !== 'false'");
+    expect(source).toMatch(/if \(backgroundWorkersEnabled && intervalMs !== undefined\)/);
+    expect(source).toMatch(/if \(backgroundWorkersEnabled && reconciliationIntervalMs > 0\)/);
+  });
+
   it('bounds the reconciliation timer to a safe interval', () => {
     expect(parseGoldenSnapshotReconciliationInterval(undefined)).toBe(15_000);
     expect(parseGoldenSnapshotReconciliationInterval('1000')).toBe(1_000);

--- a/tests/platform/home-mirror-env-check.test.ts
+++ b/tests/platform/home-mirror-env-check.test.ts
@@ -1,9 +1,52 @@
 import { describe, it, expect, vi } from "vitest";
 import {
+  checkCustomerVpsPrimaryStorageEnv,
   checkHostBundleStorageEnv,
   checkHomeMirrorS3Env,
   checkUnsafeDefaultSecrets,
 } from "../../packages/platform/src/main.js";
+
+describe('checkCustomerVpsPrimaryStorageEnv', () => {
+  const productionBase = {
+    NODE_ENV: 'production',
+    CUSTOMER_VPS_ENABLED: 'true',
+    R2_ACCOUNT_ID: 'current-account',
+    R2_ACCESS_KEY_ID: 'access',
+    R2_SECRET_ACCESS_KEY: 'secret',
+    R2_BUCKET: 'matrixos-sync',
+  };
+
+  it('requires an explicit primary endpoint for production customer provisioning', () => {
+    expect(checkCustomerVpsPrimaryStorageEnv(productionBase, vi.fn()))
+      .toContain('R2_ENDPOINT');
+  });
+
+  it.each([
+    'http://current-account.eu.r2.cloudflarestorage.com',
+    'https://current-account.r2.cloudflarestorage.com',
+    'https://other-account.eu.r2.cloudflarestorage.com',
+    'https://current-account.eu.r2.cloudflarestorage.com/path',
+    'https://user@current-account.eu.r2.cloudflarestorage.com',
+  ])('rejects a non-canonical production endpoint: %s', (endpoint) => {
+    expect(checkCustomerVpsPrimaryStorageEnv({ ...productionBase, R2_ENDPOINT: endpoint }, vi.fn()))
+      .toContain('R2_ENDPOINT');
+  });
+
+  it('accepts the exact EU endpoint for the configured account', () => {
+    expect(checkCustomerVpsPrimaryStorageEnv({
+      ...productionBase,
+      R2_ENDPOINT: 'https://current-account.eu.r2.cloudflarestorage.com',
+    }, vi.fn())).toEqual([]);
+  });
+
+  it('preserves account-id fallback outside production customer provisioning', () => {
+    expect(checkCustomerVpsPrimaryStorageEnv({
+      NODE_ENV: 'development',
+      CUSTOMER_VPS_ENABLED: 'true',
+      R2_ACCOUNT_ID: 'local-account',
+    }, vi.fn())).toEqual([]);
+  });
+});
 
 describe("checkHomeMirrorS3Env (startup assertion for silent-failure #6)", () => {
   it("returns [] and does not log when MATRIX_HOME_MIRROR is not 'true'", () => {

--- a/tests/platform/r2-capability.test.ts
+++ b/tests/platform/r2-capability.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createR2CapabilityGate,
+  createStorageGatedHetznerClient,
+} from '../../packages/platform/src/r2-capability.js';
+import { createMockHetznerClient } from './customer-vps-fixtures.js';
+
+function createStorage() {
+  let exists = false;
+  return {
+    headObject: vi.fn(async () => ({ exists, etag: exists ? 'canary-etag' : undefined })),
+    putObject: vi.fn(async () => {
+      exists = true;
+      return { etag: 'canary-etag' };
+    }),
+    deleteObject: vi.fn(async () => {
+      exists = false;
+    }),
+  };
+}
+
+describe('primary R2 capability gate', () => {
+  it('requires absence, put, head, delete, and final absence in order', async () => {
+    const storage = createStorage();
+    const gate = createR2CapabilityGate({
+      storage,
+      keyFactory: () => '_platform/canary/123',
+    });
+
+    await expect(gate.assertReady({ force: true })).resolves.toBeUndefined();
+
+    expect(storage.headObject).toHaveBeenNthCalledWith(
+      1,
+      '_platform/canary/123',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(storage.putObject).toHaveBeenCalledTimes(1);
+    expect(storage.headObject).toHaveBeenCalledTimes(3);
+    expect(storage.deleteObject).toHaveBeenCalledTimes(1);
+    expect(storage.deleteObject.mock.invocationCallOrder[0])
+      .toBeLessThan(storage.headObject.mock.invocationCallOrder[2]);
+  });
+
+  it('attempts final absence verification after deletion fails and rejects the probe', async () => {
+    const storage = createStorage();
+    storage.deleteObject.mockRejectedValueOnce(new Error('delete denied'));
+    const gate = createR2CapabilityGate({
+      storage,
+      keyFactory: () => '_platform/canary/456',
+    });
+
+    await expect(gate.assertReady({ force: true })).rejects.toThrow('Primary storage unavailable');
+    expect(storage.deleteObject).toHaveBeenCalledTimes(1);
+    expect(storage.headObject).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps one successful result for thirty seconds and never caches failures', async () => {
+    let now = 1_000;
+    const storage = createStorage();
+    const gate = createR2CapabilityGate({
+      storage,
+      now: () => now,
+      keyFactory: () => `_platform/canary/${now}`,
+    });
+
+    await gate.assertReady();
+    await gate.assertReady();
+    expect(storage.putObject).toHaveBeenCalledTimes(1);
+
+    now += 30_001;
+    await gate.assertReady();
+    expect(storage.putObject).toHaveBeenCalledTimes(2);
+
+    storage.putObject.mockRejectedValueOnce(new Error('write denied'));
+    now += 30_001;
+    await expect(gate.assertReady()).rejects.toThrow('Primary storage unavailable');
+    await expect(gate.assertReady()).resolves.toBeUndefined();
+    expect(storage.putObject).toHaveBeenCalledTimes(4);
+  });
+
+  it('guards the centralized Hetzner createServer call before provider mutation', async () => {
+    const order: string[] = [];
+    const base = createMockHetznerClient({
+      createServer: vi.fn(async () => {
+        order.push('create');
+        return {
+          id: 123,
+          status: 'running',
+          serverType: 'cpx22',
+          publicIPv4: '203.0.113.10',
+          publicIPv6: null,
+        };
+      }),
+    });
+    const guarded = createStorageGatedHetznerClient(base, async () => {
+      order.push('storage');
+    });
+
+    await guarded.createServer({
+      name: 'test',
+      serverType: 'cpx22',
+      location: 'nbg1',
+      userData: '#cloud-config',
+      labels: { app: 'matrix-os' },
+    });
+
+    expect(order).toEqual(['storage', 'create']);
+  });
+});


### PR DESCRIPTION
## Summary

- require the canonical EU-jurisdiction primary R2 endpoint whenever production customer VPS provisioning is enabled
- bind `R2_ENDPOINT` from `r2-endpoint:latest` and validate its Secret Manager version and runtime IAM before deployment
- gate the centralized Hetzner `createServer` path on a bounded R2 head/put/head/delete/head capability probe with a 30-second success cache
- reserve exit status `44` for confirmed object absence; keep unreadable config, 403s, timeouts, malformed endpoints, and generic status `1` fatal
- require both owner metadata and the runtime-slot backup pointer to be confirmed absent before a host treats the installation as fresh
- preserve the valid registered-before-first-backup reboot state while restoring whenever a backup pointer exists
- smoke a worker-disabled candidate revision, then promote a production-role revision from the identical image digest

No R2 credential rotation is required. Golden snapshots did not provision the incident machine; the golden work exposed this pre-existing endpoint defect by making `r2.env` readable.

## Tests

- `pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json`
- `./scripts/review/check-patterns.sh --diff origin/main` — zero violations; scanner warnings were reviewed
- `pnpm exec vitest run tests/platform/r2-client.test.ts tests/platform/r2-capability.test.ts tests/platform/home-mirror-env-check.test.ts tests/platform/customer-vps-hetzner.test.ts tests/platform/customer-vps-routes.test.ts tests/platform/customer-vps-cloud-init.test.ts tests/platform/customer-vps-host-bundle.test.ts tests/platform/golden-snapshot-worker-wiring.test.ts tests/platform/ci-workflows.test.ts` — 180 passed
- `pnpm exec vitest run tests/platform/customer-vps.test.ts` as part of the focused platform selection — 79 passed
- workflow YAML parse, `bash -n` for changed host scripts, and `git diff --check`

## Review/Monitoring

- review commit: `90a391335aae6ea983c0b7ee23b77eee1abc2c0b`
- do not add `ready-for-ci` until trusted Greptile reports 5/5 on the current head
- do not merge, deploy, create secrets, provision a test VPS, repair fleet hosts, or delete diagnostic machines without explicit approval

## Invariants

### Source of truth

- Secret Manager remains the source of runtime R2 configuration; the account-specific EU endpoint is explicit and must match `R2_ACCOUNT_ID`
- owner-scoped R2 objects remain the source of restore metadata and backup pointers
- provider creation continues through the single injected Hetzner client, now wrapped by the storage capability gate

### Lock/transaction scope

- no database transaction or lock scope changes
- the R2 capability probe runs before the external Hetzner create call and outside database transactions
- one in-flight probe is shared in-process; only a successful result is cached, for at most 30 seconds

### Acceptable orphan states

- every probe uses a unique reserved canary key and attempts deletion plus final absence verification even after failures
- deletion or final verification failure fails the gate; the reserved canary prefix needs a bounded Cloudflare lifecycle rule before production rollout as defense in depth
- no provider server is created when storage validation fails

### Auth source of truth

- `/vps/storage-check` uses the existing constant-time platform bearer authentication
- unauthorized callers receive 401; storage failures return only a generic 503 response
- the workflow reads the smoke credential from Secret Manager, masks it, and never prints endpoint contents, account IDs, credentials, customer identifiers, or object keys

### Deferred scope

- registration protocol compatibility and durable platform-controlled restore intent
- broader candidate startup-mutation isolation beyond the incident-scoped background-worker switch
- failed-host diagnostic retention infrastructure and golden validation redesign
- existing-fleet classification/repair, which remains a separately approved operational rollout
- live clean-image first-user E2E, secret/IAM creation, lifecycle policy, deployment, and host deletion are post-review rollout actions
