### PR TITLE
fix(platform): ignore retired preview fleet records

### DIFF
--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -274,7 +274,7 @@ jobs:
             "${PLATFORM_PUBLIC_URL}/vps/fleet" |
             jq -c --arg h "$HANDLE" \
               '[.machines[]
-                | select(.handle == $h and .status != "deleted")
+                | select(.handle == $h and .status != "deleted" and .deletedAt == null)
                 | . + { _preview_rank:
                     (if .status == "running" then 0
                      elif .status == "provisioning" then 1
@@ -336,7 +336,7 @@ jobs:
             -H "authorization: Bearer ${PLATFORM_SECRET}" \
             "${PLATFORM_PUBLIC_URL}/vps/fleet" |
             jq -r --arg h "$HANDLE" --arg id "$accepted_machine_id" \
-              '[.machines[] | select(.handle == $h and .machineId == $id and .runtimeSlot == $h)] | .[0].status // "absent"')"
+              '[.machines[] | select(.handle == $h and .machineId == $id and .runtimeSlot == $h and .deletedAt == null)] | .[0].status // "absent"')"
           echo "Immediate fleet visibility for ${HANDLE}: ${status}"
           if [ "$status" != "provisioning" ] && [ "$status" != "running" ]; then
             echo "Accepted preview machine is not durably visible in the fleet." >&2
@@ -352,7 +352,7 @@ jobs:
                 -H "authorization: Bearer ${PLATFORM_SECRET}" \
                 "${PLATFORM_PUBLIC_URL}/vps/fleet" |
                 jq -r --arg h "$HANDLE" --arg id "$accepted_machine_id" \
-                  '[.machines[] | select(.handle == $h and .machineId == $id)] | .[0].status // "absent"')"
+                  '[.machines[] | select(.handle == $h and .machineId == $id and .deletedAt == null)] | .[0].status // "absent"')"
               [ "$status" = "running" ] && break
               if [ "$status" = "failed" ]; then
                 echo "Provisioning failed for ${HANDLE}" >&2
@@ -397,7 +397,7 @@ jobs:
               "${PLATFORM_PUBLIC_URL}/vps/fleet" |
               jq -c --arg h "$HANDLE" \
                 '[.machines[]
-                  | select(.handle == $h and .runtimeSlot == $h and .status != "deleted")
+                  | select(.handle == $h and .runtimeSlot == $h and .status != "deleted" and .deletedAt == null)
                   | . + { _preview_rank:
                       (if .status == "running" then 0
                        elif .status == "provisioning" then 1
@@ -551,7 +551,7 @@ jobs:
             -H "authorization: Bearer ${PLATFORM_SECRET}" \
             "${PLATFORM_PUBLIC_URL}/vps/fleet" |
             jq -r --arg h "$HANDLE" \
-              '[.machines[] | select(.handle == $h and .status != "deleted")] | .[0].machineId // ""')"
+              '[.machines[] | select(.handle == $h and .status != "deleted" and .deletedAt == null)] | .[0].machineId // ""')"
           if [ -z "$machine_id" ]; then
             echo "No active VPS for ${HANDLE}; nothing to tear down."
             exit 0
@@ -588,7 +588,7 @@ jobs:
           curl -fsS --max-time 30 \
             -H "authorization: Bearer ${PLATFORM_SECRET}" \
             "${PLATFORM_PUBLIC_URL}/vps/fleet" |
-            jq -c '.machines[] | select((.handle | test("^pr-[0-9]+$")) and .status != "deleted")' |
+            jq -c '.machines[] | select((.handle | test("^pr-[0-9]+$")) and .status != "deleted" and .deletedAt == null)' |
             while IFS= read -r machine; do
               handle="$(jq -r .handle <<< "$machine")"
               machine_id="$(jq -r .machineId <<< "$machine")"

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -3296,6 +3296,7 @@ export async function listAllUserMachines(
     .selectFrom('user_machines')
     .selectAll()
     .where('status', '!=', 'deleted')
+    .where('deleted_at', 'is', null)
     .orderBy('last_seen_at', 'desc')
     .limit(limit)
     .execute();

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -783,7 +783,9 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
 
     expect(workflow).toContain('Waiting for ${HANDLE} to install ${VERSION}');
-    expect(workflow).toContain('select(.handle == $h and .runtimeSlot == $h and .status != "deleted")');
+    expect(workflow).toContain(
+      'select(.handle == $h and .runtimeSlot == $h and .status != "deleted" and .deletedAt == null)',
+    );
     expect(workflow).toContain('.healthy == true and .runtimeVersion == $v');
     expect(workflow).toContain('Preview ready: ${HANDLE} is healthy on ${VERSION}');
     expect(workflow).toContain('Timed out waiting for ${HANDLE} to install ${VERSION}');
@@ -821,7 +823,9 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
 
     expect(workflow).toContain('Immediate fleet visibility for ${HANDLE}: ${status}');
-    expect(workflow).toContain('select(.handle == $h and .machineId == $id and .runtimeSlot == $h)');
+    expect(workflow).toContain(
+      'select(.handle == $h and .machineId == $id and .runtimeSlot == $h and .deletedAt == null)',
+    );
     expect(workflow).toContain('if [ "$status" != "provisioning" ] && [ "$status" != "running" ]; then');
     expect(workflow.indexOf('Immediate fleet visibility for ${HANDLE}: ${status}'))
       .toBeLessThan(workflow.indexOf('deadline=$((SECONDS + 600))'));
@@ -849,6 +853,24 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(workflow).toContain('elif .status == "provisioning" then 1');
     expect(workflow).toContain('elif .status == "failed" then 2');
     expect(workflow).toContain('sort_by(._preview_rank, (if .runtimeSlot == $h then 0 else 1 end), .provisionedAt)');
+  });
+
+  it('preview VPS workflow excludes soft-retired rows from every fleet lookup', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
+
+    expect(workflow.match(/select\(\.handle == \$h and \.status != "deleted" and \.deletedAt == null\)/g))
+      .toHaveLength(2);
+    expect(workflow).toContain(
+      'select(.handle == $h and .machineId == $id and .runtimeSlot == $h and .deletedAt == null)',
+    );
+    expect(workflow).toContain('select(.handle == $h and .machineId == $id and .deletedAt == null)');
+    expect(workflow).toContain(
+      'select(.handle == $h and .runtimeSlot == $h and .status != "deleted" and .deletedAt == null)',
+    );
+    expect(workflow).toContain(
+      'select((.handle | test("^pr-[0-9]+$")) and .status != "deleted" and .deletedAt == null)',
+    );
   });
 
   it('manual preview dispatch resolves the target PR head and validates a pinned version', () => {

--- a/tests/platform/customer-vps-reliability.test.ts
+++ b/tests/platform/customer-vps-reliability.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   getActiveUserMachineByClerkId,
   getUserMachine,
+  listAllUserMachines,
   listUserMachines,
   listPendingProviderDeletions,
   retireUserMachine,
@@ -165,6 +166,23 @@ describe('platform/customer-vps reliability', () => {
 
     const pending = await listPendingProviderDeletions(db, '2099-01-01T00:00:00.000Z', 50);
     expect(pending.some((d) => d.reason === 'failed_retry_retire' && d.providerServerId === 123456)).toBe(true);
+  });
+
+  it('excludes soft-retired failed attempts from the operator fleet', async () => {
+    const { service } = createHarness();
+    const first = await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+    await updateUserMachine(db, first.machineId, {
+      status: 'failed',
+      failureCode: 'registration_timeout',
+      failureAt: '2026-04-26T12:05:00.000Z',
+    });
+
+    const retry = await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+    expect((await getUserMachine(db, first.machineId))?.status).toBe('failed');
+    expect((await getUserMachine(db, first.machineId))?.deletedAt).not.toBeNull();
+
+    const fleet = await listAllUserMachines(db, 50);
+    expect(fleet.map((machine) => machine.machineId)).toEqual([retry.machineId]);
   });
 
   it('converges concurrent retries on a failed row to a single live machine', async () => {


### PR DESCRIPTION
## Summary

- exclude soft-retired `user_machines` rows from the operator `/vps/fleet` read model
- require `deletedAt == null` in every preview provisioning, health, teardown, and reaper fleet lookup
- add regressions covering failed-attempt retirement and preview workflow selectors

This prevents a historical failed attempt from being selected as the active preview machine, which previously made teardown issue `DELETE` for an already-retired ID and receive `404 Machine not found`.

## Tests

- `bun run test -- tests/platform/customer-vps-reliability.test.ts tests/platform/customer-vps-host-bundle.test.ts`
- `bun run test` — 918 files passed, 10,467 tests passed, 20 intentionally skipped
- `pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json`
- `bun run check:patterns` — 0 violations; 5 pre-existing warnings outside this diff
- `bun run typecheck` reaches the desktop package but the isolated worktree's shared dependency tree has a pre-existing Vite 6/Vite 7 type mismatch in `desktop/electron.vite.config.ts`; the changed platform package typecheck passes

## Review and monitoring

- TDD: both new regressions failed before the implementation and pass afterward
- Do not merge until trusted Greptile reports 5/5 for the current head
- Add `ready-for-ci` only after that 5/5 result, then require all triggered CI to pass

## Invariants

- **Source of truth:** an active machine row has `deleted_at IS NULL`; soft-retired rows remain durable audit history but are not active fleet members
- **Lock/transaction scope:** this changes only operator/workflow selection; existing retry-retirement transactions and uniqueness enforcement are unchanged
- **Acceptable orphan state:** a soft-retired failed row may remain for audit, but must never be selected for provisioning, health polling, teardown, or reaping
- **Auth source of truth:** preview workflows continue using the existing authenticated platform bearer token; no auth behavior changes
- **Deferred scope:** same-day immutable preview artifact version collisions remain outside this stale-record fix; the existing exact-version `deploy_existing` path is the current safe recovery path

## Operational context

The two affected preview slots were recovered separately through exact, guarded production operations and now run healthy on their PR-head bundles. This PR prevents the stale selection failure from recurring; it does not delete historical audit rows or touch the recovered VPSes.
