### PR TITLE
feat(desktop): add drag-and-drop and paste attachments

### DIFF
--- a/desktop/src/main/auth/header-injection.ts
+++ b/desktop/src/main/auth/header-injection.ts
@@ -172,7 +172,9 @@ export function installGatewayCors(
     if (isGatewayResponse) {
       responseHeaders["Access-Control-Allow-Origin"] = [rendererOrigin];
       responseHeaders["Access-Control-Allow-Methods"] = ["GET, POST, PATCH, PUT, DELETE, OPTIONS"];
-      responseHeaders["Access-Control-Allow-Headers"] = ["Authorization, Content-Type, x-runtime-slot"];
+      responseHeaders["Access-Control-Allow-Headers"] = [
+        "Authorization, Content-Type, x-runtime-slot, X-Matrix-Filename",
+      ];
       responseHeaders["Access-Control-Allow-Credentials"] = ["true"];
     }
     if (isGatewayResponse && details.method === "OPTIONS") {

--- a/desktop/src/renderer/src/features/chat/ChatTab.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatTab.tsx
@@ -18,6 +18,9 @@ import { Bubble, BubbleContent } from "./elements/bubble";
 import { Conversation, ConversationContent, ConversationItem } from "./elements/conversation";
 import { Message, MessageContent, MessageResponse } from "./elements/message";
 import { PromptInput } from "./elements/prompt-input";
+import { AttachmentPreviewRow } from "./attachments/AttachmentPreviewRow";
+import { appendHermesAttachmentPaths } from "./attachments/local-attachment-controller";
+import { useConversationAttachments } from "./attachments/use-conversation-attachments";
 import { Reasoning } from "./elements/reasoning";
 import { Tool } from "./elements/tool";
 
@@ -55,8 +58,8 @@ function ConnectCard({ title, body, icon, done }: { title: string; body: string;
   );
 }
 
-export function canSubmitChatDraft(draft: string, status: HermesStatus): boolean {
-  return draft.trim().length > 0 && status === "idle";
+export function canSubmitChatDraft(draft: string, status: HermesStatus, attachmentCount = 0): boolean {
+  return (draft.trim().length > 0 || attachmentCount > 0) && status === "idle";
 }
 
 // The Hermes (OS agent) conversation — the default pane when no agent thread is
@@ -68,16 +71,35 @@ function HermesPane() {
   const abort = useHermesChat((s) => s.abort);
   const projects = useBoard((s) => s.projects);
   const [draft, setDraft] = useState("");
+  const [uploadingAttachments, setUploadingAttachments] = useState(false);
+  const attachments = useConversationAttachments();
 
   const projectName = projects[0]?.name ?? projects[0]?.slug ?? "Matrix OS";
   const groups = groupMessages(messages);
   const empty = messages.length === 0;
 
-  const submit = () => {
-    if (!canSubmitChatDraft(draft, status)) return;
-    send(draft);
-    setDraft("");
+  const submit = async () => {
+    if (uploadingAttachments || !canSubmitChatDraft(draft, status, attachments.items.length)) return;
+    setUploadingAttachments(true);
+    try {
+      const uploaded = await attachments.uploadAll();
+      if (!uploaded.ok) return;
+      send(appendHermesAttachmentPaths(draft, uploaded.paths));
+      setDraft("");
+      attachments.clear();
+    } finally {
+      setUploadingAttachments(false);
+    }
   };
+
+  const attachmentPreviews = (
+    <AttachmentPreviewRow
+      items={attachments.items}
+      onRemove={attachments.remove}
+      onRetry={(localId) => void attachments.retry(localId)}
+    />
+  );
+  const composerReady = canSubmitChatDraft(draft, status, attachments.items.length);
 
   const composerFooter = (
     <>
@@ -89,12 +111,12 @@ function HermesPane() {
 
   if (empty) {
     return (
-      <div className="flex min-h-0 flex-1 flex-col">
+      <div role="region" aria-label="Hermes conversation" className="flex min-h-0 flex-1 flex-col" {...attachments.paneProps}>
         <div className="mx-auto flex w-full max-w-[760px] flex-1 flex-col justify-center px-5">
           <h1 className="mb-8 text-center text-2xl font-semibold tracking-tight" style={{ color: "var(--text-primary)", fontSize: "var(--text-2xl)" }}>
             What should we build in {projectName}?
           </h1>
-          <PromptInput value={draft} onChange={setDraft} onSubmit={submit} onAbort={abort} busy={status !== "idle"} autoFocus footer={composerFooter} />
+          <PromptInput value={draft} onChange={setDraft} onSubmit={() => void submit()} onAbort={status !== "idle" ? abort : undefined} busy={status !== "idle" || uploadingAttachments} disabled={uploadingAttachments} canSubmit={composerReady} attachments={attachmentPreviews} autoFocus footer={composerFooter} />
           <div className="mt-6 grid grid-cols-1 gap-3 md:grid-cols-3">
             <ConnectCard title="Connect messaging" body="Get context from recent team discussions" icon={<MessageSquare size={13} aria-hidden />} />
             <ConnectCard title="Connect email" body="Summarize stakeholder asks from email" icon={<Mail size={13} aria-hidden />} />
@@ -106,7 +128,7 @@ function HermesPane() {
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
+    <div role="region" aria-label="Hermes conversation" className="flex min-h-0 flex-1 flex-col" {...attachments.paneProps}>
       <Conversation>
         <ConversationContent>
           {groups.map((group) =>
@@ -154,7 +176,7 @@ function HermesPane() {
         </ConversationContent>
       </Conversation>
       <div className="mx-auto w-full max-w-[760px] px-5 pb-5">
-        <PromptInput value={draft} onChange={setDraft} onSubmit={submit} onAbort={abort} busy={status !== "idle"} placeholder="Reply to Hermes…" footer={composerFooter} />
+        <PromptInput value={draft} onChange={setDraft} onSubmit={() => void submit()} onAbort={status !== "idle" ? abort : undefined} busy={status !== "idle" || uploadingAttachments} disabled={uploadingAttachments} canSubmit={composerReady} attachments={attachmentPreviews} placeholder="Reply to Hermes…" footer={composerFooter} />
       </div>
     </div>
   );

--- a/desktop/src/renderer/src/features/chat/ChatTab.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatTab.tsx
@@ -95,6 +95,7 @@ function HermesPane() {
   const attachmentPreviews = (
     <AttachmentPreviewRow
       items={attachments.items}
+      disabled={uploadingAttachments}
       onRemove={attachments.remove}
       onRetry={(localId) => void attachments.retry(localId)}
     />

--- a/desktop/src/renderer/src/features/chat/attachments/AttachmentPreviewRow.tsx
+++ b/desktop/src/renderer/src/features/chat/attachments/AttachmentPreviewRow.tsx
@@ -1,0 +1,64 @@
+import { FileText, Image as ImageIcon, RotateCcw, X } from "lucide-react";
+import {
+  Attachment,
+  AttachmentAction,
+  AttachmentActions,
+  AttachmentContent,
+  AttachmentDescription,
+  AttachmentGroup,
+  AttachmentMedia,
+  AttachmentTitle,
+} from "../elements/attachment";
+import {
+  MAX_ATTACHMENT_FILE_BYTES,
+  type LocalConversationAttachment,
+} from "./local-attachment-controller";
+
+function sizeLabel(size: number): string {
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${Math.round(size / 1024)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function AttachmentPreviewRow({
+  items,
+  onRemove,
+  onRetry,
+}: {
+  items: readonly LocalConversationAttachment[];
+  onRemove: (localId: string) => void;
+  onRetry: (localId: string) => void;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <AttachmentGroup role="group" aria-label="Attachments" className="px-3 pt-2">
+      {items.slice(0, 8).map((item) => (
+        <Attachment
+          key={item.localId}
+          size="sm"
+          state={item.status === "failed" ? "error" : item.status === "uploading" ? "uploading" : "done"}
+        >
+          <AttachmentMedia variant={item.previewUrl ? "image" : "icon"}>
+            {item.previewUrl ? <img src={item.previewUrl} alt={item.file.name} /> : item.file.type.startsWith("image/") ? <ImageIcon /> : <FileText />}
+          </AttachmentMedia>
+          <AttachmentContent>
+            <AttachmentTitle>{item.file.name}</AttachmentTitle>
+            <AttachmentDescription>
+              {item.status === "failed" ? item.error : item.status === "uploading" ? "Uploading…" : sizeLabel(item.file.size)}
+            </AttachmentDescription>
+          </AttachmentContent>
+          <AttachmentActions>
+            {item.status === "failed" && item.file.size <= MAX_ATTACHMENT_FILE_BYTES ? (
+              <AttachmentAction aria-label={`Retry ${item.file.name}`} onClick={() => onRetry(item.localId)}>
+                <RotateCcw size={14} />
+              </AttachmentAction>
+            ) : null}
+            <AttachmentAction aria-label={`Remove ${item.file.name}`} onClick={() => onRemove(item.localId)}>
+              <X size={14} />
+            </AttachmentAction>
+          </AttachmentActions>
+        </Attachment>
+      ))}
+    </AttachmentGroup>
+  );
+}

--- a/desktop/src/renderer/src/features/chat/attachments/AttachmentPreviewRow.tsx
+++ b/desktop/src/renderer/src/features/chat/attachments/AttachmentPreviewRow.tsx
@@ -22,10 +22,12 @@ function sizeLabel(size: number): string {
 
 export function AttachmentPreviewRow({
   items,
+  disabled = false,
   onRemove,
   onRetry,
 }: {
   items: readonly LocalConversationAttachment[];
+  disabled?: boolean;
   onRemove: (localId: string) => void;
   onRetry: (localId: string) => void;
 }) {
@@ -49,11 +51,11 @@ export function AttachmentPreviewRow({
           </AttachmentContent>
           <AttachmentActions>
             {item.status === "failed" && item.file.size <= MAX_ATTACHMENT_FILE_BYTES ? (
-              <AttachmentAction aria-label={`Retry ${item.file.name}`} onClick={() => onRetry(item.localId)}>
+              <AttachmentAction disabled={disabled} aria-label={`Retry ${item.file.name}`} onClick={() => onRetry(item.localId)}>
                 <RotateCcw size={14} />
               </AttachmentAction>
             ) : null}
-            <AttachmentAction aria-label={`Remove ${item.file.name}`} onClick={() => onRemove(item.localId)}>
+            <AttachmentAction disabled={disabled} aria-label={`Remove ${item.file.name}`} onClick={() => onRemove(item.localId)}>
               <X size={14} />
             </AttachmentAction>
           </AttachmentActions>

--- a/desktop/src/renderer/src/features/chat/attachments/local-attachment-controller.ts
+++ b/desktop/src/renderer/src/features/chat/attachments/local-attachment-controller.ts
@@ -143,7 +143,7 @@ export function createLocalAttachmentController(options: {
         items.push({
           localId: `local_${uploadId}`,
           uploadId,
-          uploadPath: `uploads/desktop-chat/${uploadId}-${file.name}`,
+          uploadPath: `temporary/desktop-chat/${uploadId}-${file.name}`,
           file,
           ...(shouldPreview(file) ? { previewUrl: URL.createObjectURL(file) } : {}),
           status: file.size <= MAX_ATTACHMENT_FILE_BYTES ? "ready" : "failed",

--- a/desktop/src/renderer/src/features/chat/attachments/local-attachment-controller.ts
+++ b/desktop/src/renderer/src/features/chat/attachments/local-attachment-controller.ts
@@ -82,6 +82,7 @@ export function createLocalAttachmentController(options: {
   let items: InternalAttachment[] = [];
   let snapshot: readonly LocalConversationAttachment[] = [];
   let disposed = false;
+  let uploadInFlight = false;
   const listeners = new Set<() => void>();
 
   const emit = () => {
@@ -114,7 +115,8 @@ export function createLocalAttachmentController(options: {
       item.status = "ready";
       emit();
       return true;
-    } catch {
+    } catch (err: unknown) {
+      console.warn("[desktop attachments] upload failed:", err instanceof Error ? err.message : String(err));
       if (!disposed && items.includes(item)) {
         item.status = "failed";
         item.error = "Upload failed. Try again.";
@@ -132,7 +134,7 @@ export function createLocalAttachmentController(options: {
       return () => listeners.delete(listener);
     },
     add(files) {
-      if (disposed) return;
+      if (disposed || uploadInFlight) return;
       for (const file of files) {
         if (items.length >= MAX_ATTACHMENTS) break;
         if (!validFile(file)) continue;
@@ -151,6 +153,7 @@ export function createLocalAttachmentController(options: {
       emit();
     },
     remove(localId) {
+      if (uploadInFlight) return;
       const item = items.find((candidate) => candidate.localId === localId);
       if (!item) return;
       items = items.filter((candidate) => candidate !== item);
@@ -158,33 +161,44 @@ export function createLocalAttachmentController(options: {
       emit();
     },
     async retry(localId) {
+      if (uploadInFlight) return;
       const item = items.find((candidate) => candidate.localId === localId);
       if (!item || item.status !== "failed" || item.file.size > MAX_ATTACHMENT_FILE_BYTES) return;
       await uploadOne(item);
     },
     async uploadAll() {
-      const pending = items.filter((item) => !item.uploadedPath && item.status !== "failed");
-      let cursor = 0;
-      const worker = async () => {
-        while (cursor < pending.length) {
-          const index = cursor++;
-          await uploadOne(pending[index]!);
-        }
-      };
-      await Promise.all(Array.from(
-        { length: Math.min(MAX_CONCURRENT_UPLOADS, pending.length) },
-        () => worker(),
-      ));
-      if (disposed || items.some((item) => !item.uploadedPath)) return { ok: false };
-      const attachments = items.map(attachmentReference);
-      if (attachments.some((attachment) => !attachment)) return { ok: false };
-      return {
-        ok: true,
-        paths: items.map((item) => item.uploadedPath!),
-        attachments: attachments as AgentAttachment[],
-      };
+      if (uploadInFlight) return { ok: false };
+      uploadInFlight = true;
+      const batch = [...items];
+      try {
+        const pending = batch.filter((item) => !item.uploadedPath && item.status !== "failed");
+        let cursor = 0;
+        const worker = async () => {
+          while (cursor < pending.length) {
+            const index = cursor++;
+            await uploadOne(pending[index]!);
+          }
+        };
+        await Promise.all(Array.from(
+          { length: Math.min(MAX_CONCURRENT_UPLOADS, pending.length) },
+          () => worker(),
+        ));
+        const batchStillCurrent = items.length === batch.length
+          && batch.every((item, index) => items[index] === item);
+        if (disposed || !batchStillCurrent || batch.some((item) => !item.uploadedPath)) return { ok: false };
+        const attachments = batch.map(attachmentReference);
+        if (attachments.some((attachment) => !attachment)) return { ok: false };
+        return {
+          ok: true,
+          paths: batch.map((item) => item.uploadedPath!),
+          attachments: attachments as AgentAttachment[],
+        };
+      } finally {
+        uploadInFlight = false;
+      }
     },
     clear() {
+      if (uploadInFlight) return;
       for (const item of items) revoke(item);
       items = [];
       emit();

--- a/desktop/src/renderer/src/features/chat/attachments/local-attachment-controller.ts
+++ b/desktop/src/renderer/src/features/chat/attachments/local-attachment-controller.ts
@@ -1,0 +1,201 @@
+import type { AgentAttachment } from "@matrix-os/contracts";
+import type { ApiClient } from "../../../lib/api";
+
+export const MAX_ATTACHMENT_FILE_BYTES = 10 * 1024 * 1024;
+const MAX_ATTACHMENTS = 8;
+const MAX_SUBSCRIBERS = 16;
+const MAX_CONCURRENT_UPLOADS = 3;
+const UPLOAD_TIMEOUT_MS = 30_000;
+const SAFE_FILE_NAME = /^[^/\\\u0000-\u001f\u007f]+$/;
+const SAFE_RASTER_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+
+export interface LocalConversationAttachment {
+  localId: string;
+  uploadId: string;
+  uploadPath: string;
+  file: File;
+  previewUrl?: string;
+  status: "ready" | "uploading" | "failed";
+  error?: string;
+  uploadedPath?: string;
+}
+
+export type UploadedConversationAttachments = {
+  ok: true;
+  paths: string[];
+  attachments: AgentAttachment[];
+};
+
+export interface LocalAttachmentController {
+  getSnapshot(): readonly LocalConversationAttachment[];
+  subscribe(listener: () => void): () => void;
+  add(files: readonly File[]): void;
+  remove(localId: string): void;
+  retry(localId: string): Promise<void>;
+  uploadAll(): Promise<UploadedConversationAttachments | { ok: false }>;
+  clear(): void;
+  dispose(): void;
+}
+
+type InternalAttachment = LocalConversationAttachment;
+
+function defaultId(): string {
+  return crypto.randomUUID().replaceAll("-", "");
+}
+
+function shouldPreview(file: File): boolean {
+  return SAFE_RASTER_TYPES.has(file.type);
+}
+
+function validFile(file: File): boolean {
+  return file.name.length > 0
+    && file.name.length <= 255
+    && file.name !== "."
+    && file.name !== ".."
+    && SAFE_FILE_NAME.test(file.name)
+    && !(file.name === ".." || file.name.includes("/"))
+    && !("webkitRelativePath" in file && file.webkitRelativePath.length > 0);
+}
+
+function attachmentReference(item: InternalAttachment): AgentAttachment | null {
+  if (!item.uploadedPath) return null;
+  return {
+    id: `desktop_upload_${item.uploadId}`,
+    kind: "structured_ref",
+    label: item.file.name,
+    path: item.uploadedPath,
+    ...(item.file.type ? { mimeType: item.file.type } : {}),
+  };
+}
+
+export function appendHermesAttachmentPaths(prompt: string, paths: readonly string[]): string {
+  if (paths.length === 0) return prompt.trim();
+  const body = prompt.trim() || "Please inspect the attached files.";
+  const references = paths.map((path) => `- ~/${path} (/home/matrix/home/${path})`).join("\n");
+  return `${body}\n\nAttached files (available on your Matrix computer):\n${references}`;
+}
+
+export function createLocalAttachmentController(options: {
+  api: ApiClient | null;
+  createId?: () => string;
+}): LocalAttachmentController {
+  let items: InternalAttachment[] = [];
+  let snapshot: readonly LocalConversationAttachment[] = [];
+  let disposed = false;
+  const listeners = new Set<() => void>();
+
+  const emit = () => {
+    snapshot = items.map((item) => ({ ...item }));
+    for (const listener of listeners) listener();
+  };
+
+  const revoke = (item: InternalAttachment) => {
+    if (item.previewUrl) URL.revokeObjectURL(item.previewUrl);
+  };
+
+  const uploadOne = async (item: InternalAttachment): Promise<boolean> => {
+    if (disposed || !options.api || item.file.size > MAX_ATTACHMENT_FILE_BYTES) return false;
+    if (item.uploadedPath) return true;
+    item.status = "uploading";
+    item.error = undefined;
+    emit();
+    try {
+      const response = await options.api.putBytes<{ ok?: boolean; path?: unknown; size?: unknown }>(
+        `/api/files/blob?path=${encodeURIComponent(item.uploadPath)}`,
+        item.file,
+        { "content-type": item.file.type || "application/octet-stream" },
+        { timeoutMs: UPLOAD_TIMEOUT_MS },
+      );
+      if (response.path !== item.uploadPath || typeof response.size !== "number") {
+        throw new Error("invalid upload response");
+      }
+      if (disposed || !items.includes(item)) return false;
+      item.uploadedPath = response.path;
+      item.status = "ready";
+      emit();
+      return true;
+    } catch {
+      if (!disposed && items.includes(item)) {
+        item.status = "failed";
+        item.error = "Upload failed. Try again.";
+        emit();
+      }
+      return false;
+    }
+  };
+
+  return {
+    getSnapshot: () => snapshot,
+    subscribe(listener) {
+      if (listeners.size >= MAX_SUBSCRIBERS) throw new Error("attachment subscribers unavailable");
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    add(files) {
+      if (disposed) return;
+      for (const file of files) {
+        if (items.length >= MAX_ATTACHMENTS) break;
+        if (!validFile(file)) continue;
+        const uploadId = (options.createId ?? defaultId)().replace(/[^A-Za-z0-9_.:-]/g, "_").slice(0, 96);
+        if (!uploadId || uploadId.includes("..")) continue;
+        items.push({
+          localId: `local_${uploadId}`,
+          uploadId,
+          uploadPath: `uploads/desktop-chat/${uploadId}-${file.name}`,
+          file,
+          ...(shouldPreview(file) ? { previewUrl: URL.createObjectURL(file) } : {}),
+          status: file.size <= MAX_ATTACHMENT_FILE_BYTES ? "ready" : "failed",
+          ...(file.size > MAX_ATTACHMENT_FILE_BYTES ? { error: "Files are limited to 10 MB." } : {}),
+        });
+      }
+      emit();
+    },
+    remove(localId) {
+      const item = items.find((candidate) => candidate.localId === localId);
+      if (!item) return;
+      items = items.filter((candidate) => candidate !== item);
+      revoke(item);
+      emit();
+    },
+    async retry(localId) {
+      const item = items.find((candidate) => candidate.localId === localId);
+      if (!item || item.status !== "failed" || item.file.size > MAX_ATTACHMENT_FILE_BYTES) return;
+      await uploadOne(item);
+    },
+    async uploadAll() {
+      const pending = items.filter((item) => !item.uploadedPath && item.status !== "failed");
+      let cursor = 0;
+      const worker = async () => {
+        while (cursor < pending.length) {
+          const index = cursor++;
+          await uploadOne(pending[index]!);
+        }
+      };
+      await Promise.all(Array.from(
+        { length: Math.min(MAX_CONCURRENT_UPLOADS, pending.length) },
+        () => worker(),
+      ));
+      if (disposed || items.some((item) => !item.uploadedPath)) return { ok: false };
+      const attachments = items.map(attachmentReference);
+      if (attachments.some((attachment) => !attachment)) return { ok: false };
+      return {
+        ok: true,
+        paths: items.map((item) => item.uploadedPath!),
+        attachments: attachments as AgentAttachment[],
+      };
+    },
+    clear() {
+      for (const item of items) revoke(item);
+      items = [];
+      emit();
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      for (const item of items) revoke(item);
+      items = [];
+      snapshot = [];
+      listeners.clear();
+    },
+  };
+}

--- a/desktop/src/renderer/src/features/chat/attachments/use-conversation-attachments.ts
+++ b/desktop/src/renderer/src/features/chat/attachments/use-conversation-attachments.ts
@@ -1,0 +1,81 @@
+import { useEffect, useMemo, useRef, useSyncExternalStore, type ClipboardEvent, type DragEvent } from "react";
+import { useConnection } from "../../../stores/connection";
+import { createLocalAttachmentController } from "./local-attachment-controller";
+
+export function useConversationAttachments(scopeKey?: string | null) {
+  const api = useConnection((state) => state.api);
+  const runtimeSlot = useConnection((state) => state.runtimeSlot);
+  const authGeneration = useConnection((state) => state.authGeneration);
+  const controller = useMemo(
+    () => createLocalAttachmentController({ api }),
+    [api, runtimeSlot, authGeneration, scopeKey],
+  );
+  const pendingDispose = useRef<{ controller: typeof controller; timer: number } | null>(null);
+  const items = useSyncExternalStore(controller.subscribe, controller.getSnapshot, controller.getSnapshot);
+
+  useEffect(() => {
+    const pending = pendingDispose.current;
+    if (pending?.controller === controller) {
+      window.clearTimeout(pending.timer);
+      pendingDispose.current = null;
+    }
+    return () => {
+      const timer = window.setTimeout(() => {
+        controller.dispose();
+        if (pendingDispose.current?.timer === timer) pendingDispose.current = null;
+      }, 0);
+      pendingDispose.current = { controller, timer };
+    };
+  }, [controller]);
+
+  const addDroppedFiles = (dataTransfer: DataTransfer) => {
+    const transferItems = Array.from(dataTransfer.items ?? []);
+    if (transferItems.length === 0) {
+      controller.add(Array.from(dataTransfer.files ?? []));
+      return;
+    }
+    const files = transferItems.flatMap((item) => {
+      if (item.kind !== "file") return [];
+      const entry = (item as DataTransferItem & {
+        webkitGetAsEntry?: () => { isDirectory?: boolean } | null;
+      }).webkitGetAsEntry?.();
+      if (entry?.isDirectory) return [];
+      const file = item.getAsFile();
+      return file ? [file] : [];
+    });
+    controller.add(files);
+  };
+
+  const paneProps = {
+    onDragOver: (event: DragEvent<HTMLElement>) => {
+      const files = Array.from(event.dataTransfer.items ?? []).some((item) => item.kind === "file")
+        || (event.dataTransfer.files?.length ?? 0) > 0;
+      if (!files) return;
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "copy";
+    },
+    onDrop: (event: DragEvent<HTMLElement>) => {
+      const hasFiles = Array.from(event.dataTransfer.items ?? []).some((item) => item.kind === "file")
+        || (event.dataTransfer.files?.length ?? 0) > 0;
+      if (!hasFiles) return;
+      event.preventDefault();
+      addDroppedFiles(event.dataTransfer);
+    },
+    onPaste: (event: ClipboardEvent<HTMLElement>) => {
+      const files = Array.from(event.clipboardData.files ?? []);
+      if (files.length === 0) return;
+      event.preventDefault();
+      controller.add(files);
+    },
+  };
+
+  return {
+    items,
+    add: controller.add,
+    remove: controller.remove,
+    retry: controller.retry,
+    uploadAll: controller.uploadAll,
+    clear: controller.clear,
+    paneProps,
+  };
+}

--- a/desktop/src/renderer/src/features/chat/elements/attachment.tsx
+++ b/desktop/src/renderer/src/features/chat/elements/attachment.tsx
@@ -146,7 +146,7 @@ function AttachmentAction({ className, type = "button", ...props }: React.Compon
       data-slot="attachment-action"
       type={type}
       className={cn(
-        "flex h-6 w-6 items-center justify-center rounded-md text-[var(--text-tertiary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]",
+        "flex h-6 w-6 items-center justify-center rounded-md text-[var(--text-tertiary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-[var(--text-tertiary)]",
         className,
       )}
       {...props}

--- a/desktop/src/renderer/src/features/chat/elements/prompt-input.tsx
+++ b/desktop/src/renderer/src/features/chat/elements/prompt-input.tsx
@@ -17,6 +17,8 @@ export function PromptInput({
   ariaLabel,
   footer,
   controls,
+  attachments,
+  canSubmit,
   focusRequestId,
 }: {
   value: string;
@@ -30,6 +32,8 @@ export function PromptInput({
   placeholder?: string;
   ariaLabel?: string;
   footer?: ReactNode;
+  attachments?: ReactNode;
+  canSubmit?: boolean;
   // Left side of the bottom row: compact pickers (provider, mode) rendered
   // Codex-style next to the send/stop control. Purely presentational slot.
   controls?: ReactNode;
@@ -37,6 +41,7 @@ export function PromptInput({
   focusRequestId?: number;
 }) {
   const ref = useRef<HTMLTextAreaElement>(null);
+  const submissionReady = canSubmit ?? value.trim().length > 0;
 
   useEffect(() => {
     if (!focusRequestId || focusRequestId <= 0) return;
@@ -47,7 +52,9 @@ export function PromptInput({
     const el = ref.current;
     if (!el) return;
     el.style.height = "0px";
-    el.style.height = `${Math.min(el.scrollHeight, 220)}px`;
+    const contentHeight = el.scrollHeight;
+    el.style.height = `${Math.min(contentHeight, 220)}px`;
+    el.style.overflowY = contentHeight > 220 ? "auto" : "hidden";
   }, [value]);
 
   return (
@@ -55,6 +62,7 @@ export function PromptInput({
       className="prompt-card flex flex-col overflow-hidden rounded-[var(--radius-xl)] border"
       style={{ background: "var(--bg-surface)" }}
     >
+      {attachments}
       <textarea
         ref={ref}
         autoFocus={autoFocus}
@@ -93,10 +101,10 @@ export function PromptInput({
             <button
               type="button"
               aria-label="Send"
-              disabled={disabled || value.trim().length === 0}
+              disabled={disabled || !submissionReady}
               onClick={onSubmit}
               className="flex h-8 w-8 items-center justify-center rounded-full transition-colors disabled:opacity-40"
-              style={{ background: value.trim().length ? "var(--accent)" : "var(--bg-active)", color: value.trim().length ? "var(--text-on-accent)" : "var(--text-tertiary)" }}
+              style={{ background: submissionReady ? "var(--accent)" : "var(--bg-active)", color: submissionReady ? "var(--text-on-accent)" : "var(--text-tertiary)" }}
             >
               <ArrowUp size={16} />
             </button>

--- a/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
@@ -46,6 +46,8 @@ import { Conversation, ConversationContent, ConversationItem } from "../chat/ele
 import { Marker, MarkerContent, MarkerIcon } from "../chat/elements/marker";
 import { Message, MessageContent, MessageFooter } from "../chat/elements/message";
 import { PromptInput } from "../chat/elements/prompt-input";
+import { AttachmentPreviewRow } from "../chat/attachments/AttachmentPreviewRow";
+import { useConversationAttachments } from "../chat/attachments/use-conversation-attachments";
 import { abortAgentThread, agentThreadAbortSupported } from "./abort-thread";
 import { AgentComposerPickers } from "./composer-pickers";
 import { ToolCallDetailMeta } from "./tool-call-detail";
@@ -610,14 +612,17 @@ function ConversationComposer({
   waitingForAction,
   threadBusy,
   composerControls,
+  attachments,
 }: {
   threadId: string;
   waitingForAction: boolean;
   threadBusy: boolean;
   // Left side of the composer bottom row (provider/mode pickers).
   composerControls?: ReactNode;
+  attachments: ReturnType<typeof useConversationAttachments>;
 }) {
   const [message, setMessage] = useState("");
+  const [uploadingAttachments, setUploadingAttachments] = useState(false);
   const turnStatus = useCodingAgentWorkspace((state) => state.turnStatus);
   const turnThreadId = useCodingAgentWorkspace((state) => state.turnThreadId);
   const turnError = useCodingAgentWorkspace((state) => state.turnError);
@@ -628,15 +633,29 @@ function ConversationComposer({
   const abortSupported = agentThreadAbortSupported();
 
   async function submit() {
-    if (!message.trim() || waitingForAction || submitting) return;
+    if ((!message.trim() && attachments.items.length === 0) || waitingForAction || submitting || uploadingAttachments) return;
     // Every submit is a direct send. A follow-up aimed at a busy conversation
     // returns a safe recoverable conflict, which surfaces through turnError.
     // Pending messages are durable server-owned records (SPEC 105 FR-100), and
     // queueing must be explicit rather than silent (FR-027, FR-101), so this
     // client deliberately keeps no local queue: a renderer-only queue would be
     // lost on reload and invisible to the mobile, browser, and CLI shells.
-    const sent = await send({ threadId, message });
-    if (sent) setMessage("");
+    setUploadingAttachments(true);
+    try {
+      const uploaded = await attachments.uploadAll();
+      if (!uploaded.ok) return;
+      const sent = await send({
+        threadId,
+        message: message.trim() || "Please inspect the attached files.",
+        ...(uploaded.attachments.length > 0 ? { attachments: uploaded.attachments } : {}),
+      });
+      if (sent) {
+        setMessage("");
+        attachments.clear();
+      }
+    } finally {
+      setUploadingAttachments(false);
+    }
   }
 
   return (
@@ -651,9 +670,17 @@ function ConversationComposer({
           value={message}
           onChange={setMessage}
           onSubmit={() => void submit()}
-          onAbort={abortSupported ? () => void abortAgentThread(threadId) : undefined}
-          busy={submitting || threadBusy}
-          disabled={waitingForAction}
+          onAbort={abortSupported && (submitting || threadBusy) ? () => void abortAgentThread(threadId) : undefined}
+          busy={submitting || threadBusy || uploadingAttachments}
+          disabled={waitingForAction || uploadingAttachments}
+          canSubmit={!waitingForAction && !uploadingAttachments && (message.trim().length > 0 || attachments.items.length > 0)}
+          attachments={(
+            <AttachmentPreviewRow
+              items={attachments.items}
+              onRemove={attachments.remove}
+              onRetry={(localId) => void attachments.retry(localId)}
+            />
+          )}
           // Matches the CreateAgentTurnRequestSchema message cap so oversized
           // drafts are prevented client-side instead of failing generically.
           maxLength={24_000}
@@ -692,6 +719,7 @@ export function AgentConversationView({
   const threadActive = threadRunning
     || snapshot?.thread.status === "waiting_for_approval"
     || snapshot?.thread.status === "waiting_for_input";
+  const attachments = useConversationAttachments(snapshot?.thread.id ?? null);
   const items = useMemo(() => timelineItems(conversationItems(snapshot?.events.items ?? [])), [snapshot?.events.items]);
   // Per-turn "Worked for Xs" rows, derived from event timestamps only.
   const turnSummaryByItemKey = useMemo(() => {
@@ -732,7 +760,7 @@ export function AgentConversationView({
   const showWorking = running && !streamingAssistant;
 
   return (
-    <section aria-label={`Conversation ${snapshot.thread.title}`} className="ph-no-capture flex min-h-[460px] min-w-0 flex-1 flex-col overflow-hidden" style={{ background: "var(--bg-app)" }}>
+    <section aria-label={`Conversation ${snapshot.thread.title}`} className="ph-no-capture flex min-h-[460px] min-w-0 flex-1 flex-col overflow-hidden" style={{ background: "var(--bg-app)" }} {...attachments.paneProps}>
       {/* pr-12 reserves the top-right corner for the floating inspector
           toggle (ProjectChatsView overlays it at right-2.5 top-2.5), so the
           attention pill is never clipped beneath it; the title column is the
@@ -800,6 +828,7 @@ export function AgentConversationView({
           threadId={snapshot.thread.id}
           waitingForAction={snapshot.thread.status === "waiting_for_approval" || snapshot.thread.status === "waiting_for_input"}
           threadBusy={running}
+          attachments={attachments}
           composerControls={
             summary ? (
               <AgentComposerPickers

--- a/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
@@ -677,6 +677,7 @@ function ConversationComposer({
           attachments={(
             <AttachmentPreviewRow
               items={attachments.items}
+              disabled={uploadingAttachments}
               onRemove={attachments.remove}
               onRetry={(localId) => void attachments.retry(localId)}
             />

--- a/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
+++ b/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
@@ -5,6 +5,8 @@ import {
   useMemo,
   useRef,
   useState,
+  type ClipboardEvent,
+  type DragEvent,
   type KeyboardEvent,
   type ReactNode,
 } from "react";
@@ -22,9 +24,15 @@ import { useBrowserViewPreference } from "./browser-view-preference";
 import {
   BrowserToolbar,
   EntryButton,
+  hasRegularDroppedFiles,
   measureGridColumns,
+  regularDroppedFiles,
   SortHeader,
 } from "./browser-views";
+import {
+  createFileUploadController,
+  type FileUploadRow,
+} from "./file-upload-controller";
 
 type BrowserStatus = "loading" | "ready" | "error";
 
@@ -76,6 +84,11 @@ export default function ComputerFileBrowser({
   // <body>, arrow keys stop working, and a keyboard user is stranded outside
   // the listing with no way back in except the mouse.
   const restoreFocusRef = useRef(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const dragDepth = useRef(0);
+  const uploadControllerRef = useRef<ReturnType<typeof createFileUploadController> | null>(null);
+  const [dragActive, setDragActive] = useState(false);
+  const [uploads, setUploads] = useState<FileUploadRow[]>([]);
 
   const markFocusForRestore = useCallback(() => {
     const active = document.activeElement;
@@ -87,6 +100,10 @@ export default function ComputerFileBrowser({
   // or replacement session never shows the previous owner's directory names or
   // lets stale rows fire onOpenFile/onChooseFolder against the new API.
   const browserScope = `${runtimeSlot}|${authGeneration}`;
+  const scopeRef = useRef(browserScope);
+  const currentPathRef = useRef(currentPath);
+  scopeRef.current = browserScope;
+  currentPathRef.current = currentPath;
   const [loadedScope, setLoadedScope] = useState(browserScope);
   const scoped = loadedScope === browserScope;
   const viewCurrentPath = scoped ? currentPath : "";
@@ -126,6 +143,48 @@ export default function ComputerFileBrowser({
       setError(toUserMessage(err));
     }
   }, [api]);
+
+  useEffect(() => {
+    if (!api || mode !== "browse") {
+      uploadControllerRef.current = null;
+      setUploads([]);
+      return;
+    }
+    const controller = createFileUploadController({
+      api,
+      getScope: () => scopeRef.current,
+      onUploaded: (directory) => {
+        if (directory === currentPathRef.current) void load(directory);
+      },
+    });
+    uploadControllerRef.current = controller;
+    const unsubscribe = controller.subscribe(setUploads);
+    return () => {
+      if (uploadControllerRef.current === controller) uploadControllerRef.current = null;
+      unsubscribe();
+      controller.dispose();
+    };
+  }, [api, browserScope, load, mode]);
+
+  const enqueueFiles = useCallback((files: File[], destination = viewCurrentPath) => {
+    uploadControllerRef.current?.enqueue(files, destination);
+  }, [viewCurrentPath]);
+
+  const onListingDrop = useCallback((event: DragEvent<HTMLDivElement>) => {
+    if (mode !== "browse" || !hasRegularDroppedFiles(event.dataTransfer)) return;
+    event.preventDefault();
+    dragDepth.current = 0;
+    setDragActive(false);
+    enqueueFiles(regularDroppedFiles(event.dataTransfer));
+  }, [enqueueFiles, mode]);
+
+  const onListingPaste = useCallback((event: ClipboardEvent<HTMLDivElement>) => {
+    if (mode !== "browse") return;
+    const files = Array.from(event.clipboardData.files ?? []);
+    if (files.length === 0) return;
+    event.preventDefault();
+    enqueueFiles(files);
+  }, [enqueueFiles, mode]);
 
   useEffect(() => {
     setLoadedScope(browserScope);
@@ -276,6 +335,9 @@ export default function ComputerFileBrowser({
             if (entry.type === "directory") navigate(path);
           }}
           onKeyDown={(event) => onEntryKeyDown(event, entry, path, index)}
+          onDropFiles={mode === "browse" && entry.type === "directory"
+            ? (files) => enqueueFiles(files, path)
+            : undefined}
         />
       );
     });
@@ -340,9 +402,66 @@ export default function ComputerFileBrowser({
         onUp={goUp}
         onNavigate={navigate}
         onRefresh={() => void load(viewCurrentPath)}
+        onUpload={mode === "browse" ? () => fileInputRef.current?.click() : undefined}
       />
 
-      <div className={`${compact ? "h-52" : "min-h-0 flex-1"} overflow-y-auto p-1.5`}>{content}</div>
+      {mode === "browse" ? (
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          className="sr-only"
+          aria-label="Choose files to upload"
+          onChange={(event) => {
+            enqueueFiles(Array.from(event.currentTarget.files ?? []));
+            event.currentTarget.value = "";
+          }}
+        />
+      ) : null}
+      <div
+        data-files-listing
+        className={`${compact ? "h-52" : "min-h-0 flex-1"} relative overflow-y-auto p-1.5`}
+        onDragEnter={mode === "browse" ? (event) => {
+          if (!hasRegularDroppedFiles(event.dataTransfer)) return;
+          event.preventDefault();
+          dragDepth.current += 1;
+          setDragActive(true);
+        } : undefined}
+        onDragLeave={mode === "browse" ? () => {
+          dragDepth.current = Math.max(0, dragDepth.current - 1);
+          if (dragDepth.current === 0) setDragActive(false);
+        } : undefined}
+        onDragOver={mode === "browse" ? (event) => {
+          if (hasRegularDroppedFiles(event.dataTransfer)) event.preventDefault();
+        } : undefined}
+        onDrop={mode === "browse" ? onListingDrop : undefined}
+        onPaste={mode === "browse" ? onListingPaste : undefined}
+      >
+        {content}
+        {dragActive ? (
+          <div className="pointer-events-none absolute inset-2 flex items-center justify-center rounded-lg border border-dashed text-sm" style={{ borderColor: "var(--accent)", color: "var(--accent)", background: "var(--bg-surface)" }}>
+            Drop files to upload
+          </div>
+        ) : null}
+      </div>
+
+      {uploads.length > 0 ? (
+        <div className="shrink-0 space-y-1 border-t px-3 py-2 text-xs" style={{ borderColor: "var(--border-subtle)" }} aria-live="polite">
+          {uploads.slice(0, 4).map((upload) => (
+            <div key={upload.id} className="flex min-h-7 items-center justify-between gap-2">
+              <span className="min-w-0 truncate">{upload.name}: {upload.error ?? upload.status}</span>
+              {upload.status === "failed" ? (
+                <span className="flex shrink-0 items-center gap-1">
+                  {upload.error !== "Files are limited to 10 MB." ? (
+                    <Button variant="subtle" className="h-7 text-xs" onClick={() => uploadControllerRef.current?.retry(upload.id)}>Retry</Button>
+                  ) : null}
+                  <Button variant="ghost" className="h-7 text-xs" onClick={() => uploadControllerRef.current?.remove(upload.id)}>Remove</Button>
+                </span>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
 
       {onChooseFolder ? (
         <div className="flex shrink-0 items-center justify-between gap-3 border-t px-3 py-2" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }}>

--- a/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
+++ b/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
@@ -29,10 +29,7 @@ import {
   regularDroppedFiles,
   SortHeader,
 } from "./browser-views";
-import {
-  createFileUploadController,
-  type FileUploadRow,
-} from "./file-upload-controller";
+import { useFileUploads } from "./use-file-uploads";
 
 type BrowserStatus = "loading" | "ready" | "error";
 
@@ -86,9 +83,7 @@ export default function ComputerFileBrowser({
   const restoreFocusRef = useRef(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const dragDepth = useRef(0);
-  const uploadControllerRef = useRef<ReturnType<typeof createFileUploadController> | null>(null);
   const [dragActive, setDragActive] = useState(false);
-  const [uploads, setUploads] = useState<FileUploadRow[]>([]);
 
   const markFocusForRestore = useCallback(() => {
     const active = document.activeElement;
@@ -100,10 +95,6 @@ export default function ComputerFileBrowser({
   // or replacement session never shows the previous owner's directory names or
   // lets stale rows fire onOpenFile/onChooseFolder against the new API.
   const browserScope = `${runtimeSlot}|${authGeneration}`;
-  const scopeRef = useRef(browserScope);
-  const currentPathRef = useRef(currentPath);
-  scopeRef.current = browserScope;
-  currentPathRef.current = currentPath;
   const [loadedScope, setLoadedScope] = useState(browserScope);
   const scoped = loadedScope === browserScope;
   const viewCurrentPath = scoped ? currentPath : "";
@@ -144,31 +135,17 @@ export default function ComputerFileBrowser({
     }
   }, [api]);
 
-  useEffect(() => {
-    if (!api || mode !== "browse") {
-      uploadControllerRef.current = null;
-      setUploads([]);
-      return;
-    }
-    const controller = createFileUploadController({
-      api,
-      getScope: () => scopeRef.current,
-      onUploaded: (directory) => {
-        if (directory === currentPathRef.current) void load(directory);
-      },
-    });
-    uploadControllerRef.current = controller;
-    const unsubscribe = controller.subscribe(setUploads);
-    return () => {
-      if (uploadControllerRef.current === controller) uploadControllerRef.current = null;
-      unsubscribe();
-      controller.dispose();
-    };
-  }, [api, browserScope, load, mode]);
+  const fileUploads = useFileUploads({
+    api,
+    browserScope,
+    currentPath,
+    enabled: mode === "browse",
+    onUploaded: load,
+  });
 
   const enqueueFiles = useCallback((files: File[], destination = viewCurrentPath) => {
-    uploadControllerRef.current?.enqueue(files, destination);
-  }, [viewCurrentPath]);
+    fileUploads.enqueue(files, destination);
+  }, [fileUploads.enqueue, viewCurrentPath]);
 
   const onListingDrop = useCallback((event: DragEvent<HTMLDivElement>) => {
     if (mode !== "browse" || !hasRegularDroppedFiles(event.dataTransfer)) return;
@@ -445,17 +422,17 @@ export default function ComputerFileBrowser({
         ) : null}
       </div>
 
-      {uploads.length > 0 ? (
+      {fileUploads.uploads.length > 0 ? (
         <div className="shrink-0 space-y-1 border-t px-3 py-2 text-xs" style={{ borderColor: "var(--border-subtle)" }} aria-live="polite">
-          {uploads.slice(0, 4).map((upload) => (
+          {fileUploads.uploads.slice(0, 4).map((upload) => (
             <div key={upload.id} className="flex min-h-7 items-center justify-between gap-2">
               <span className="min-w-0 truncate">{upload.name}: {upload.error ?? upload.status}</span>
               {upload.status === "failed" ? (
                 <span className="flex shrink-0 items-center gap-1">
                   {upload.error !== "Files are limited to 10 MB." ? (
-                    <Button variant="subtle" className="h-7 text-xs" onClick={() => uploadControllerRef.current?.retry(upload.id)}>Retry</Button>
+                    <Button variant="subtle" className="h-7 text-xs" onClick={() => fileUploads.retry(upload.id)}>Retry</Button>
                   ) : null}
-                  <Button variant="ghost" className="h-7 text-xs" onClick={() => uploadControllerRef.current?.remove(upload.id)}>Remove</Button>
+                  <Button variant="ghost" className="h-7 text-xs" onClick={() => fileUploads.remove(upload.id)}>Remove</Button>
                 </span>
               ) : null}
             </div>

--- a/desktop/src/renderer/src/features/files/browser-views.tsx
+++ b/desktop/src/renderer/src/features/files/browser-views.tsx
@@ -10,8 +10,9 @@ import {
   LayoutGrid,
   List,
   RefreshCw,
+  Upload,
 } from "lucide-react";
-import type { KeyboardEvent } from "react";
+import type { DragEvent, KeyboardEvent } from "react";
 import { IconButton } from "../../design/primitives";
 import type { BrowserEntry, BrowserSortDirection } from "./browser-entries";
 import type { BrowserViewMode } from "./browser-view-preference";
@@ -22,6 +23,30 @@ const VIEW_OPTIONS: Array<{ mode: BrowserViewMode; label: string; icon: typeof L
   { mode: "grid", label: "Grid view", icon: LayoutGrid },
   { mode: "list", label: "List view", icon: List },
 ];
+
+export function hasRegularDroppedFiles(dataTransfer: DataTransfer): boolean {
+  if (!dataTransfer.items || dataTransfer.items.length === 0) return dataTransfer.files.length > 0;
+  return Array.from(dataTransfer.items).some((item) => {
+    if (item.kind !== "file") return false;
+    const entry = "webkitGetAsEntry" in item
+      ? (item as DataTransferItem & { webkitGetAsEntry?: () => { isDirectory?: boolean } | null }).webkitGetAsEntry?.()
+      : null;
+    return !entry?.isDirectory;
+  });
+}
+
+export function regularDroppedFiles(dataTransfer: DataTransfer): File[] {
+  if (!dataTransfer.items || dataTransfer.items.length === 0) return Array.from(dataTransfer.files);
+  return Array.from(dataTransfer.items).flatMap((item) => {
+    if (item.kind !== "file") return [];
+    const entry = "webkitGetAsEntry" in item
+      ? (item as DataTransferItem & { webkitGetAsEntry?: () => { isDirectory?: boolean } | null }).webkitGetAsEntry?.()
+      : null;
+    if (entry?.isDirectory) return [];
+    const file = item.getAsFile();
+    return file ? [file] : [];
+  });
+}
 
 // ArrowUp/ArrowDown in grid view move by a visual row. Columns are measured
 // from the rendered tiles; jsdom (offsetWidth 0) and unmeasured layouts fall
@@ -128,6 +153,7 @@ export function EntryButton({
   onSelect,
   onNavigate,
   onKeyDown,
+  onDropFiles,
 }: {
   entry: BrowserEntry;
   grid: boolean;
@@ -138,6 +164,7 @@ export function EntryButton({
   onSelect: () => void;
   onNavigate: () => void;
   onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
+  onDropFiles?: (files: File[]) => void;
 }) {
   const kind = kindForEntry(entry);
   const glyphColor = entry.type === "directory" ? "var(--accent)" : "var(--text-tertiary)";
@@ -155,6 +182,16 @@ export function EntryButton({
         onClick={onSelect}
         onDoubleClick={onNavigate}
         onKeyDown={onKeyDown}
+        onDragOver={(event) => {
+          if (!onDropFiles || !hasRegularDroppedFiles(event.dataTransfer)) return;
+          event.preventDefault();
+        }}
+        onDrop={(event: DragEvent<HTMLButtonElement>) => {
+          if (!onDropFiles || !hasRegularDroppedFiles(event.dataTransfer)) return;
+          event.preventDefault();
+          event.stopPropagation();
+          onDropFiles(regularDroppedFiles(event.dataTransfer));
+        }}
       >
         <span style={{ color: glyphColor }}>
           <FileGlyph kind={kind} size={34} />
@@ -185,6 +222,16 @@ export function EntryButton({
       onClick={onSelect}
       onDoubleClick={onNavigate}
       onKeyDown={onKeyDown}
+      onDragOver={(event) => {
+        if (!onDropFiles || !hasRegularDroppedFiles(event.dataTransfer)) return;
+        event.preventDefault();
+      }}
+      onDrop={(event) => {
+        if (!onDropFiles || !hasRegularDroppedFiles(event.dataTransfer)) return;
+        event.preventDefault();
+        event.stopPropagation();
+        onDropFiles(regularDroppedFiles(event.dataTransfer));
+      }}
     >
       <span className="flex min-w-0 items-center gap-2">
         <span className="shrink-0" style={{ color: glyphColor }}>
@@ -211,6 +258,7 @@ export function BrowserToolbar({
   onUp,
   onNavigate,
   onRefresh,
+  onUpload,
 }: {
   compact: boolean;
   currentPath: string;
@@ -220,6 +268,7 @@ export function BrowserToolbar({
   onUp: () => void;
   onNavigate: (path: string) => void;
   onRefresh: () => void;
+  onUpload?: () => void;
 }) {
   return (
     <div className="flex h-10 shrink-0 items-center gap-1 border-b px-2" style={{ borderColor: "var(--border-subtle)" }}>
@@ -257,6 +306,11 @@ export function BrowserToolbar({
         ))}
       </div>
       <ViewSwitcher view={view} onChange={onViewChange} />
+      {onUpload ? (
+        <IconButton label="Upload files" className="shrink-0" onClick={onUpload}>
+          <Upload size={13} />
+        </IconButton>
+      ) : null}
       <IconButton label="Refresh folder" className="shrink-0" onClick={onRefresh}>
         <RefreshCw size={13} />
       </IconButton>

--- a/desktop/src/renderer/src/features/files/file-upload-controller.ts
+++ b/desktop/src/renderer/src/features/files/file-upload-controller.ts
@@ -1,0 +1,131 @@
+import type { ApiClient } from "../../lib/api";
+import { AppError } from "../../lib/errors";
+
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+const MAX_QUEUE = 32;
+const MAX_CONCURRENT = 3;
+const MAX_SUBSCRIBERS = 16;
+const UPLOAD_TIMEOUT_MS = 30_000;
+const SAFE_FILE_NAME = /^[^/\\\u0000-\u001f\u007f]+$/;
+
+export type FileUploadRow = {
+  id: string;
+  name: string;
+  destination: string;
+  status: "queued" | "uploading" | "failed";
+  error?: string;
+};
+
+type PendingUpload = FileUploadRow & { file: File; scope: string };
+
+function joinUploadPath(destination: string, fileName: string): string {
+  return destination ? `${destination}/${fileName}` : fileName;
+}
+
+function validFileName(fileName: string): boolean {
+  return fileName.length > 0
+    && fileName.length <= 255
+    && fileName !== "."
+    && fileName !== ".."
+    && SAFE_FILE_NAME.test(fileName);
+}
+
+function uploadErrorMessage(error: unknown): string {
+  if (error instanceof AppError && error.detail === "file_exists") {
+    return "A file with this name already exists.";
+  }
+  return "Upload failed. Try again.";
+}
+
+export function createFileUploadController(options: {
+  api: ApiClient;
+  getScope: () => string;
+  onUploaded: (directory: string) => void;
+}) {
+  let pending: PendingUpload[] = [];
+  let active = 0;
+  let disposed = false;
+  let sequence = 0;
+  const listeners = new Set<(rows: FileUploadRow[]) => void>();
+
+  const emit = () => {
+    const rows = pending.map(({ file: _file, scope: _scope, ...row }) => row);
+    for (const listener of listeners) listener(rows);
+  };
+
+  const pump = () => {
+    while (!disposed && active < MAX_CONCURRENT) {
+      const item = pending.find((candidate) => candidate.status === "queued");
+      if (!item) return;
+      item.status = "uploading";
+      active += 1;
+      emit();
+      const path = joinUploadPath(item.destination, item.file.name);
+      void options.api.putBytes<{ path: string }>(
+        `/api/files/blob?path=${encodeURIComponent(path)}`,
+        item.file,
+        { "content-type": item.file.type || "application/octet-stream" },
+        { timeoutMs: UPLOAD_TIMEOUT_MS },
+      ).then(() => {
+        pending = pending.filter((candidate) => candidate.id !== item.id);
+        if (!disposed && options.getScope() === item.scope) options.onUploaded(item.destination);
+      }).catch((error: unknown) => {
+        item.status = "failed";
+        item.error = uploadErrorMessage(error);
+      }).finally(() => {
+        active -= 1;
+        emit();
+        pump();
+      });
+    }
+  };
+
+  return {
+    subscribe(listener: (rows: FileUploadRow[]) => void) {
+      if (listeners.size >= MAX_SUBSCRIBERS) throw new Error("upload subscribers unavailable");
+      listeners.add(listener);
+      emit();
+      return () => listeners.delete(listener);
+    },
+    enqueue(files: readonly File[], destination: string) {
+      if (disposed) return;
+      const scope = options.getScope();
+      for (const file of files) {
+        if (pending.length >= MAX_QUEUE) break;
+        if (!validFileName(file.name)) continue;
+        sequence += 1;
+        const tooLarge = file.size > MAX_FILE_BYTES;
+        pending.push({
+          id: `upload-${sequence}`,
+          name: file.name,
+          destination,
+          status: tooLarge ? "failed" : "queued",
+          ...(tooLarge ? { error: "Files are limited to 10 MB." } : {}),
+          file,
+          scope,
+        });
+      }
+      emit();
+      pump();
+    },
+    retry(id: string) {
+      const item = pending.find((candidate) => candidate.id === id && candidate.status === "failed");
+      if (!item || item.file.size > MAX_FILE_BYTES) return;
+      item.status = "queued";
+      item.error = undefined;
+      emit();
+      pump();
+    },
+    remove(id: string) {
+      const next = pending.filter((candidate) => candidate.id !== id || candidate.status === "uploading");
+      if (next.length === pending.length) return;
+      pending = next;
+      emit();
+    },
+    dispose() {
+      disposed = true;
+      pending = [];
+      listeners.clear();
+    },
+  };
+}

--- a/desktop/src/renderer/src/features/files/file-upload-controller.ts
+++ b/desktop/src/renderer/src/features/files/file-upload-controller.ts
@@ -54,9 +54,10 @@ export function createFileUploadController(options: {
   };
 
   const pump = () => {
-    while (!disposed && active < MAX_CONCURRENT) {
-      const item = pending.find((candidate) => candidate.status === "queued");
-      if (!item) return;
+    if (disposed || active >= MAX_CONCURRENT) return;
+    const availableSlots = MAX_CONCURRENT - active;
+    const queued = pending.filter((candidate) => candidate.status === "queued").slice(0, availableSlots);
+    for (const item of queued) {
       item.status = "uploading";
       active += 1;
       emit();

--- a/desktop/src/renderer/src/features/files/use-file-uploads.ts
+++ b/desktop/src/renderer/src/features/files/use-file-uploads.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ApiClient } from "../../lib/api";
+import { createFileUploadController, type FileUploadRow } from "./file-upload-controller";
+
+export function useFileUploads({
+  api,
+  browserScope,
+  currentPath,
+  enabled,
+  onUploaded,
+}: {
+  api: ApiClient | null;
+  browserScope: string;
+  currentPath: string;
+  enabled: boolean;
+  onUploaded: (directory: string) => void;
+}) {
+  const controllerRef = useRef<ReturnType<typeof createFileUploadController> | null>(null);
+  const currentPathRef = useRef(currentPath);
+  const [uploads, setUploads] = useState<FileUploadRow[]>([]);
+
+  useEffect(() => {
+    currentPathRef.current = currentPath;
+  }, [currentPath]);
+
+  useEffect(() => {
+    if (!api || !enabled) {
+      controllerRef.current = null;
+      setUploads([]);
+      return;
+    }
+    const controller = createFileUploadController({
+      api,
+      getScope: () => browserScope,
+      onUploaded: (directory) => {
+        if (directory === currentPathRef.current) onUploaded(directory);
+      },
+    });
+    controllerRef.current = controller;
+    const unsubscribe = controller.subscribe(setUploads);
+    return () => {
+      if (controllerRef.current === controller) controllerRef.current = null;
+      unsubscribe();
+      controller.dispose();
+    };
+  }, [api, browserScope, enabled, onUploaded]);
+
+  const enqueue = useCallback((files: readonly File[], destination: string) => {
+    controllerRef.current?.enqueue(files, destination);
+  }, []);
+  const retry = useCallback((id: string) => controllerRef.current?.retry(id), []);
+  const remove = useCallback((id: string) => controllerRef.current?.remove(id), []);
+
+  return { uploads, enqueue, retry, remove };
+}

--- a/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
@@ -12,6 +12,8 @@ import { useDraftChat } from "../../stores/draft-chat";
 import { useProjectWorkspaces } from "../../stores/project-workspaces";
 import { useProviderPreferences } from "../settings/provider-preferences";
 import { PromptInput } from "../chat/elements/prompt-input";
+import { AttachmentPreviewRow } from "../chat/attachments/AttachmentPreviewRow";
+import { useConversationAttachments } from "../chat/attachments/use-conversation-attachments";
 import { AgentComposerPickers } from "../coding-agents/composer-pickers";
 import { capabilityEnabled } from "../coding-agents/capabilities";
 import { isTypeToStartInteractiveTarget } from "../coding-agents/type-to-start";
@@ -75,6 +77,7 @@ export function ProjectChatDraft({
     return seed ? mergeComposerSeed(initialDraft, seed.draft) : initialDraft;
   });
   const providerSelectionTouchedRef = useRef(restoredEntry?.pickerTouched ?? false);
+  const attachments = useConversationAttachments();
 
   useEffect(() => {
     const store = useDraftChat.getState();
@@ -145,7 +148,7 @@ export function ProjectChatDraft({
   async function submit() {
     if (submitting || submitInFlightRef.current) return;
     let effective = effectiveDraft;
-    if (!effective.prompt.trim()) return;
+    if (!effective.prompt.trim() && attachments.items.length === 0) return;
     submitInFlightRef.current = true;
     setResolvingTarget(true);
     try {
@@ -162,7 +165,14 @@ export function ProjectChatDraft({
         effective = { ...effective, ...relation };
         setDraft(effective);
       }
-      const threadId = await createThread(effective);
+      const uploaded = await attachments.uploadAll();
+      if (!uploaded.ok) return;
+      const prompt = effective.prompt.trim() || "Please inspect the attached files.";
+      const threadId = await createThread({
+        ...effective,
+        prompt,
+        ...(uploaded.attachments.length > 0 ? { attachments: uploaded.attachments } : {}),
+      });
       if (!threadId) {
         // Keep the prompt for retry; drop one-shot launch context (review
         // references, task targeting) exactly like the legacy form did.
@@ -172,6 +182,7 @@ export function ProjectChatDraft({
       providerSelectionTouchedRef.current = false;
       useDraftChat.getState().clearDraft(projectId);
       setDraft(initialDraft);
+      attachments.clear();
       onCreated();
     } finally {
       submitInFlightRef.current = false;
@@ -181,7 +192,7 @@ export function ProjectChatDraft({
 
   const selectedProvider = summary.providers.find((provider) => provider.id === effectiveDraft.providerId)
     ?? summary.providers[0];
-  const promptEmpty = effectiveDraft.prompt.trim().length === 0;
+  const promptEmpty = effectiveDraft.prompt.trim().length === 0 && attachments.items.length === 0;
 
   return (
     <section
@@ -189,6 +200,7 @@ export function ProjectChatDraft({
       className="ph-no-capture flex min-h-[460px] min-w-0 flex-1 flex-col overflow-hidden"
       style={{ background: "var(--bg-app)" }}
       data-slot="project-chat-draft"
+      {...attachments.paneProps}
     >
       <ProjectChatHero
         projectLabel={projectLabel}
@@ -211,6 +223,14 @@ export function ProjectChatDraft({
               onSubmit={() => void submit()}
               busy={busy}
               disabled={busy}
+              canSubmit={!busy && (effectiveDraft.prompt.trim().length > 0 || attachments.items.length > 0)}
+              attachments={(
+                <AttachmentPreviewRow
+                  items={attachments.items}
+                  onRemove={attachments.remove}
+                  onRetry={(localId) => void attachments.retry(localId)}
+                />
+              )}
               autoFocus={active}
               focusRequestId={active ? focusRequestId + localFocusBumps : 0}
               maxLength={24_000}

--- a/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
@@ -227,6 +227,7 @@ export function ProjectChatDraft({
               attachments={(
                 <AttachmentPreviewRow
                   items={attachments.items}
+                  disabled={busy}
                   onRemove={attachments.remove}
                   onRetry={(localId) => void attachments.retry(localId)}
                 />

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -182,9 +182,8 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
         if (!cancelled) setPasteError("Image paste is unavailable. Reconnect and try again.");
         return;
       }
-      const paths: string[] = [];
       try {
-        for (const { file, mimeType } of files) {
+        const paths = await Promise.all(files.map(async ({ file, mimeType }) => {
           const response = await api.postBytes<{ terminalPath?: unknown }>(
             `/api/terminal/sessions/${encodeURIComponent(sessionName)}/paste-assets`,
             file,
@@ -194,7 +193,6 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
             },
             { timeoutMs: 30_000 },
           );
-          if (cancelled) return;
           if (
             typeof response.terminalPath !== "string"
             || !response.terminalPath.startsWith("/home/matrix/home/")
@@ -202,8 +200,8 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
           ) {
             throw new Error("invalid terminal paste response");
           }
-          paths.push(response.terminalPath);
-        }
+          return response.terminalPath;
+        }));
         if (paths.length === 0 || cancelled) return;
         const payload = bracketTerminalPaths(paths);
         if (payload === "\x1b[200~\x1b[201~") throw new Error("invalid terminal paste paths");

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -8,10 +8,17 @@ import { Button } from "../../design/primitives";
 import { getThemeTerminalColors } from "../../design/themes";
 import { resolveThemeMode } from "../../design/themes/apply";
 import { useAppearance } from "../../stores/appearance";
+import { useConnection } from "../../stores/connection";
 import { buildTerminalFontStack } from "../../lib/terminal/terminal-fonts";
 import type { ActiveAttachment } from "./attach-manager";
 import type { ShellSocketState } from "../../lib/shell-socket";
 import { getAttachManager } from "./terminal-runtime";
+import {
+  bracketTerminalPaths,
+  MAX_TERMINAL_PASTE_FILE_BYTES,
+  safeTerminalUploadFilename,
+  terminalPasteFiles,
+} from "./terminal-rich-paste";
 
 const GAP_MARKER = "\r\n\x1b[2m── output gap ──\x1b[0m\r\n";
 
@@ -24,6 +31,7 @@ interface TerminalViewProps {
 }
 
 export default function TerminalView({ sessionName, active = true, onRecreate }: TerminalViewProps) {
+  const api = useConnection((state) => state.api);
   const hostRef = useRef<HTMLDivElement>(null);
   const [stateSessionName, setStateSessionName] = useState(sessionName);
   const termRef = useRef<Terminal | null>(null);
@@ -33,6 +41,7 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
   const endedRef = useRef(false);
   const [socketState, setSocketState] = useState<ShellSocketState>("connecting");
   const [exitCode, setExitCode] = useState<number | null>(null);
+  const [pasteError, setPasteError] = useState<string | null>(null);
 
   if (stateSessionName !== sessionName) {
     setStateSessionName(sessionName);
@@ -146,6 +155,90 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
     };
   }, [sessionName, active]);
 
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host || !active) return;
+    let cancelled = false;
+
+    const filesForEvent = (event: ClipboardEvent | DragEvent) => terminalPasteFiles(
+      "clipboardData" in event ? event.clipboardData : event.dataTransfer,
+    );
+
+    const captureFiles = (event: ClipboardEvent | DragEvent) => {
+      const files = filesForEvent(event);
+      if (files.length === 0) return [];
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      return files;
+    };
+
+    const uploadAndPaste = async (files: ReturnType<typeof terminalPasteFiles>) => {
+      if (files.some(({ file }) => file.size > MAX_TERMINAL_PASTE_FILE_BYTES)) {
+        if (!cancelled) setPasteError("Images are limited to 10 MB.");
+        return;
+      }
+      if (!api || !attachmentRef.current) {
+        if (!cancelled) setPasteError("Image paste is unavailable. Reconnect and try again.");
+        return;
+      }
+      const paths: string[] = [];
+      try {
+        for (const { file, mimeType } of files) {
+          const response = await api.postBytes<{ terminalPath?: unknown }>(
+            `/api/terminal/sessions/${encodeURIComponent(sessionName)}/paste-assets`,
+            file,
+            {
+              "Content-Type": mimeType,
+              "X-Matrix-Filename": safeTerminalUploadFilename(file.name),
+            },
+            { timeoutMs: 30_000 },
+          );
+          if (cancelled) return;
+          if (
+            typeof response.terminalPath !== "string"
+            || !response.terminalPath.startsWith("/home/matrix/home/")
+            || /[\u0000\r\n]/.test(response.terminalPath)
+          ) {
+            throw new Error("invalid terminal paste response");
+          }
+          paths.push(response.terminalPath);
+        }
+        if (paths.length === 0 || cancelled) return;
+        const payload = bracketTerminalPaths(paths);
+        if (payload === "\x1b[200~\x1b[201~") throw new Error("invalid terminal paste paths");
+        attachmentRef.current?.write(payload);
+        setPasteError(null);
+      } catch {
+        if (!cancelled) setPasteError("Image paste failed. Try again.");
+      }
+    };
+
+    const onPaste = (event: ClipboardEvent) => {
+      const files = captureFiles(event);
+      if (files.length > 0) void uploadAndPaste(files);
+    };
+    const onDrag = (event: DragEvent) => {
+      captureFiles(event);
+    };
+    const onDrop = (event: DragEvent) => {
+      const files = captureFiles(event);
+      if (files.length > 0) void uploadAndPaste(files);
+    };
+
+    host.addEventListener("paste", onPaste, { capture: true });
+    host.addEventListener("dragenter", onDrag, { capture: true });
+    host.addEventListener("dragover", onDrag, { capture: true });
+    host.addEventListener("drop", onDrop, { capture: true });
+    return () => {
+      cancelled = true;
+      host.removeEventListener("paste", onPaste, { capture: true });
+      host.removeEventListener("dragenter", onDrag, { capture: true });
+      host.removeEventListener("dragover", onDrag, { capture: true });
+      host.removeEventListener("drop", onDrop, { capture: true });
+    };
+  }, [active, api, sessionName]);
+
   const banner = (() => {
     if (socketState === "fatal") {
       return { text: "This session has ended on your computer.", action: onRecreate ? <Button variant="primary" onClick={onRecreate}>Start new session</Button> : null };
@@ -159,7 +252,14 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
 
   return (
     <div className="relative flex min-h-0 flex-1 flex-col" style={{ background: "#0d1017" }}>
-      <div ref={hostRef} className="min-h-0 flex-1 px-2 pt-1.5" data-selectable />
+      <div ref={hostRef} className="min-h-0 flex-1 px-2 pt-1.5" data-terminal-viewport data-selectable />
+      {pasteError ? (
+        <div className="pointer-events-none absolute inset-x-0 bottom-3 flex justify-center px-3" aria-live="polite">
+          <span className="rounded-md px-3 py-1.5 text-xs" style={{ background: "var(--danger-muted)", color: "var(--danger)" }}>
+            {pasteError}
+          </span>
+        </div>
+      ) : null}
       {active && (socketState === "connecting" || socketState === "reconnecting") ? (
         <div className="pointer-events-none absolute inset-x-0 top-0 flex justify-center pt-2" aria-live="polite">
           <span className="status-pulse rounded-full px-3 py-1 text-xs" style={{ background: "var(--bg-overlay)", color: "var(--text-secondary)" }}>

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -207,7 +207,8 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
         if (payload === "\x1b[200~\x1b[201~") throw new Error("invalid terminal paste paths");
         attachmentRef.current?.write(payload);
         setPasteError(null);
-      } catch {
+      } catch (err: unknown) {
+        console.warn("[terminal] image paste failed:", err instanceof Error ? err.message : String(err));
         if (!cancelled) setPasteError("Image paste failed. Try again.");
       }
     };

--- a/desktop/src/renderer/src/features/terminal/terminal-rich-paste.ts
+++ b/desktop/src/renderer/src/features/terminal/terminal-rich-paste.ts
@@ -1,0 +1,65 @@
+const BRACKETED_PASTE_OPEN = "\x1b[200~";
+const BRACKETED_PASTE_CLOSE = "\x1b[201~";
+const MAX_TERMINAL_INPUT = 65_536;
+export const MAX_TERMINAL_PASTE_FILE_BYTES = 10 * 1024 * 1024;
+const MAX_TERMINAL_PASTE_FILES = 8;
+const SUPPORTED_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+const MIME_BY_EXTENSION = new Map([
+  [".png", "image/png"],
+  [".jpg", "image/jpeg"],
+  [".jpeg", "image/jpeg"],
+  [".gif", "image/gif"],
+  [".webp", "image/webp"],
+]);
+
+export type TerminalPasteFile = { file: File; mimeType: string };
+
+export function terminalPasteMimeType(file: File): string | null {
+  const typed = file.type.trim().toLowerCase();
+  if (SUPPORTED_MIME_TYPES.has(typed)) return typed;
+  const dot = file.name.lastIndexOf(".");
+  if (dot < 0) return null;
+  return MIME_BY_EXTENSION.get(file.name.slice(dot).toLowerCase()) ?? null;
+}
+
+function supportedFile(file: File | null | undefined): TerminalPasteFile | null {
+  if (!file) return null;
+  const mimeType = terminalPasteMimeType(file);
+  return mimeType ? { file, mimeType } : null;
+}
+
+export function terminalPasteFiles(
+  payload: Pick<DataTransfer, "files" | "items"> | DataTransfer | null,
+): TerminalPasteFile[] {
+  if (!payload) return [];
+  const fromItems = Array.from(payload.items ?? []).flatMap((item) => {
+    if (item.kind !== "file") return [];
+    const entry = (item as DataTransferItem & {
+      webkitGetAsEntry?: () => { isDirectory?: boolean } | null;
+    }).webkitGetAsEntry?.();
+    if (entry?.isDirectory) return [];
+    const supported = supportedFile(item.getAsFile());
+    return supported ? [supported] : [];
+  });
+  const files = fromItems.length > 0
+    ? fromItems
+    : Array.from(payload.files ?? []).flatMap((file) => {
+        const supported = supportedFile(file);
+        return supported ? [supported] : [];
+      });
+  return files.slice(0, MAX_TERMINAL_PASTE_FILES);
+}
+
+export function bracketTerminalPaths(paths: readonly string[]): string {
+  const safe = paths
+    .filter((path) => /^\/home\/matrix\/home\/[^\u0000\r\n]*$/.test(path))
+    .join(" ")
+    .replace(/\x1b\[20[01]~/g, "");
+  const maxPayload = MAX_TERMINAL_INPUT - BRACKETED_PASTE_OPEN.length - BRACKETED_PASTE_CLOSE.length;
+  return `${BRACKETED_PASTE_OPEN}${safe.slice(0, maxPayload)}${BRACKETED_PASTE_CLOSE}`;
+}
+
+export function safeTerminalUploadFilename(fileName: string): string {
+  const safe = fileName.replace(/[/\\\u0000-\u001f\u007f]+/g, "-").slice(0, 255);
+  return safe && safe !== "." && safe !== ".." ? safe : "paste-image";
+}

--- a/desktop/src/renderer/src/lib/api.ts
+++ b/desktop/src/renderer/src/lib/api.ts
@@ -40,8 +40,10 @@ export interface ApiClient {
   getText(path: string, options?: BoundedReadOptions): Promise<string>;
   getBlob(path: string, options?: BoundedReadOptions): Promise<Blob>;
   post<T>(path: string, body: unknown, options?: RequestTimeoutOptions): Promise<T>;
+  postBytes<T>(path: string, body: Blob, headers: Record<string, string>, options?: RequestTimeoutOptions): Promise<T>;
   patch<T>(path: string, body: unknown): Promise<T>;
   put<T>(path: string, body: unknown): Promise<T>;
+  putBytes<T>(path: string, body: Blob, headers: Record<string, string>, options?: RequestTimeoutOptions): Promise<T>;
   delete<T>(path: string): Promise<T>;
   putText<T>(path: string, body: string): Promise<T>;
   baseUrl: string;
@@ -156,6 +158,8 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
         headers: { "content-type": "application/json" },
         body: JSON.stringify(body),
       }, requestOptions),
+    postBytes: (path, body, headers, requestOptions) =>
+      request(path, { method: "POST", headers, body }, requestOptions),
     patch: (path, body) =>
       request(path, {
         method: "PATCH",
@@ -168,6 +172,8 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
         headers: { "content-type": "application/json" },
         body: JSON.stringify(body),
       }),
+    putBytes: (path, body, headers, requestOptions) =>
+      request(path, { method: "PUT", headers, body }, requestOptions),
     // The gateway task DELETE route parses the JSON body unconditionally, so a
     // body-less DELETE 400s; always send an empty JSON object.
     delete: (path) =>

--- a/desktop/src/renderer/src/stores/coding-agent-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-workspace.ts
@@ -1,6 +1,7 @@
 import {
   buildCreateAgentThreadRequestFromComposer,
   type AgentThreadSummary,
+  type AgentAttachment,
   type ApprovalDecisionRequest,
   type AgentThreadSnapshot,
   type AgentThreadComposerDraft,
@@ -43,7 +44,7 @@ type CreateStatus = "idle" | "submitting";
 type TurnStatus = "idle" | "submitting" | "error";
 type ActionStatus = "idle" | "submitting";
 type AttentionPushPreferences = CodingAgentNotificationPreferences["attentionPush"];
-type TurnRetry = { threadId: string; message: string; clientRequestId: string };
+type TurnRetry = { threadId: string; message: string; attachments?: AgentAttachment[]; clientRequestId: string };
 type ReviewSummaryList = {
   items: ReviewSummary[];
   hasMore: boolean;
@@ -135,7 +136,7 @@ interface CodingAgentWorkspaceState {
   requestComposerFocus: () => void;
   consumeReviewFocusRequest: (requestId: number) => void;
   createThread: (draft: AgentThreadComposerDraft) => Promise<string | null>;
-  sendThreadMessage: (input: { threadId: string; message: string }) => Promise<boolean>;
+  sendThreadMessage: (input: { threadId: string; message: string; attachments?: AgentAttachment[] }) => Promise<boolean>;
 }
 
 let refreshSeq = 0;
@@ -1007,7 +1008,7 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
     }
   },
 
-  sendThreadMessage: async ({ threadId, message }) => {
+  sendThreadMessage: async ({ threadId, message, attachments }) => {
     const initial = useCodingAgentWorkspace.getState();
     if (
       initial.turnStatus === "submitting"
@@ -1016,9 +1017,11 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
     ) {
       return false;
     }
-    const retry = initial.turnRetry?.threadId === threadId && initial.turnRetry.message === message
+    const retry = initial.turnRetry?.threadId === threadId
+      && initial.turnRetry.message === message
+      && JSON.stringify(initial.turnRetry.attachments ?? []) === JSON.stringify(attachments ?? [])
       ? initial.turnRetry
-      : { threadId, message, clientRequestId: nextActionRequestId() };
+      : { threadId, message, ...(attachments?.length ? { attachments } : {}), clientRequestId: nextActionRequestId() };
     const selectionSeq = threadSnapshotSeq;
     set({
       turnStatus: "submitting",

--- a/packages/gateway/src/shell/paste-assets.ts
+++ b/packages/gateway/src/shell/paste-assets.ts
@@ -50,7 +50,7 @@ export async function saveTerminalPasteAsset(input: TerminalPasteAssetInput): Pr
   }
 
   const date = formatPasteAssetDate(input.now ?? new Date());
-  const relativeDir = join(input.cwd, ".matrix-terminal-pastes", date);
+  const relativeDir = join("temporary", "terminal-pastes", date);
   const filename = `${Date.now()}-${randomUUID()}${kind.extension}`;
   const relativePath = join(relativeDir, filename);
   const absolutePath = resolveWritableFileApiPath(input.homePath, relativePath);

--- a/specs/106-terminal-rich-paste/contracts/paste-assets.md
+++ b/specs/106-terminal-rich-paste/contracts/paste-assets.md
@@ -39,8 +39,8 @@ Status: `201 Created`
   "assets": [
     {
       "assetId": "paste_01H...",
-      "path": "/home/matrix/home/projects/.matrix-terminal-pastes/main/2026-07-08/paste_01H.png",
-      "homeRelativePath": "projects/.matrix-terminal-pastes/main/2026-07-08/paste_01H.png",
+      "path": "/home/matrix/home/temporary/terminal-pastes/2026-07-08/paste_01H.png",
+      "homeRelativePath": "temporary/terminal-pastes/2026-07-08/paste_01H.png",
       "mimeType": "image/png",
       "size": 184203
     }
@@ -79,9 +79,9 @@ Server logs may include diagnostics, but client responses must remain generic.
 
 ## Storage Contract
 
-- Destination root: `projects/.matrix-terminal-pastes/`.
-- Session segment: sanitized terminal session name.
+- Destination root: `temporary/terminal-pastes/`.
 - Date segment: UTC date.
 - Filename: server-generated ID plus extension derived from validated image type.
 - Write policy: exclusive temp create, write, chmod, atomic rename.
-- Cleanup: recurring, symlink-safe pruning by max age and max count.
+- Cleanup: not automatic in the current contract; bounded, symlink-safe pruning is
+  deferred to `MAT-269`.

--- a/specs/106-terminal-rich-paste/data-model.md
+++ b/specs/106-terminal-rich-paste/data-model.md
@@ -76,7 +76,8 @@ Represents a copied image inside the user's Matrix environment.
 **Validation rules**:
 
 - Filename is generated server-side and must not include local path fragments.
-- Path must stay under `projects/.matrix-terminal-pastes/`.
+- Path must stay under `temporary/terminal-pastes/` in the authenticated owner's
+  Matrix home.
 - Writes must be atomic and exclusive.
 - Assets are owned by the authenticated Matrix user.
 
@@ -100,9 +101,11 @@ collecting -> validating -> failed
 collecting -> validating -> uploading -> failed
 ```
 
-## PasteAssetCleanupPolicy
+## PasteAssetCleanupPolicy (Deferred)
 
-Represents retention limits for remote paste assets.
+Represents the planned retention limits for remote paste assets. The current upload
+contract does not delete files automatically; Linear issue `MAT-269` owns this
+follow-up.
 
 **Fields**:
 
@@ -112,7 +115,7 @@ Represents retention limits for remote paste assets.
 
 **Validation rules**:
 
-- Cleanup must use `lstat()` and skip symlinks.
-- Cleanup must only operate under the paste asset directory.
-- Cleanup must run at startup or first use and recur while the gateway is alive.
-- Shutdown must clear cleanup timers.
+- A future cleanup implementation must use `lstat()` and skip symlinks.
+- A future cleanup implementation must only operate under `~/temporary/`.
+- A future cleanup implementation must run on a bounded recurring schedule.
+- Gateway shutdown must clear any future cleanup timers.

--- a/specs/106-terminal-rich-paste/pr-invariants.md
+++ b/specs/106-terminal-rich-paste/pr-invariants.md
@@ -3,7 +3,8 @@
 ## Source of truth
 
 - Local files and macOS clipboard bytes are read only by the local CLI during an observed paste transaction.
-- Remote paste assets are owner-controlled files under `~/projects/.matrix-terminal-pastes/` in the authenticated Matrix home.
+- Remote paste assets are owner-controlled files under
+  `~/temporary/terminal-pastes/` in the authenticated Matrix home.
 - No database or platform-owned object store is added for paste assets.
 
 ## Lock/Transaction Scope
@@ -14,8 +15,11 @@
 
 ## Acceptable Orphan States
 
-- If one asset write succeeds and a later write fails, the completed file may remain under `.matrix-terminal-pastes/`.
-- Orphaned paste files are acceptable because they are owner-visible temporary files and are pruned by max-age and max-count cleanup.
+- If one asset write succeeds and a later write fails, the completed file may remain
+  under `~/temporary/terminal-pastes/`.
+- Orphaned paste files are acceptable because they remain visible owner data. The
+  current contract does not delete them automatically; bounded cleanup is deferred to
+  `MAT-269`.
 - Failed local validation or upload returns local feedback and forwards no detected local image path.
 
 ## Auth Source of Truth
@@ -29,10 +33,12 @@
 - Mutating paste asset upload uses Hono `bodyLimit` before multipart parsing.
 - A paste transaction accepts at most five images.
 - Each image is capped at 10 MB and must match a supported image signature.
-- Cleanup skips symlinks with `lstat()` and clears its recurring timer on gateway shutdown.
+- Any future cleanup must skip symlinks with `lstat()`, stay confined to
+  `~/temporary/`, and clear its recurring timer on gateway shutdown (`MAT-269`).
 
 ## Deferred Scope
 
 - Browser shell and mobile rich image paste are not included.
 - Terminals that emit no stdin bytes and no bracketed paste boundary cannot trigger image-only clipboard upload.
 - Clipboard image reading is macOS best-effort through `pngpaste`; no global clipboard polling or keyboard hooks are added.
+- Automatic retention and deletion for `~/temporary/` is deferred to `MAT-269`.

--- a/specs/106-terminal-rich-paste/quickstart.md
+++ b/specs/106-terminal-rich-paste/quickstart.md
@@ -60,7 +60,9 @@ Extend the attach loop so rich paste processing happens before `{ type: "input",
    "/var/folders/.../Screenshot 2026-07-08 at 10.31.00.png" what about this?
    ```
 
-4. Verify the remote terminal receives a prompt with a `/home/matrix/home/projects/.matrix-terminal-pastes/...` path and the original question text.
+4. Verify the remote terminal receives a prompt with a
+   `/home/matrix/home/temporary/terminal-pastes/...` path and the original question
+   text.
 5. Copy an image to the macOS clipboard and paste during attach.
 6. Verify best-effort upload succeeds when the terminal emits an observable paste transaction, or local feedback explains that the paste event was not observable.
 

--- a/specs/106-terminal-rich-paste/tasks.md
+++ b/specs/106-terminal-rich-paste/tasks.md
@@ -57,7 +57,9 @@
 
 - [X] T012 [US1] Implement local image path tokenization for quoted and unquoted embedded paths in `packages/sync-client/src/cli/rich-paste.ts`
 - [X] T013 [US1] Implement per-transaction dedupe and prompt rewrite output preserving text order and line breaks in `packages/sync-client/src/cli/rich-paste.ts`
-- [X] T014 [US1] Implement gateway paste asset storage with server-generated owner-scoped paths under `projects/.matrix-terminal-pastes/` in `packages/gateway/src/shell/paste-assets.ts`
+- [X] T014 [US1] Implement gateway paste asset storage with server-generated
+  owner-scoped paths, now consolidated under `temporary/terminal-pastes/`, in
+  `packages/gateway/src/shell/paste-assets.ts`
 - [X] T015 [US1] Wire `POST /api/terminal/sessions/:name/paste-assets` into terminal routes with session-name validation in `packages/gateway/src/shell/routes.ts`
 - [X] T016 [US1] Implement CLI multipart upload and response parsing for terminal paste assets in `packages/sync-client/src/cli/rich-paste.ts`
 - [X] T017 [US1] Integrate rich paste rewriting into the attached-session input path before WebSocket input frames in `packages/sync-client/src/cli/shell-client.ts`

--- a/specs/110-desktop-drag-drop-and-paste/plan.md
+++ b/specs/110-desktop-drag-drop-and-paste/plan.md
@@ -1,0 +1,54 @@
+# Desktop Drag, Drop, and Paste Implementation Plan
+
+## Invariants
+
+- Diff scope is `desktop/`, Desktop tests, and this spec directory only.
+- Reuse `PUT /api/files/blob` and `POST /api/terminal/sessions/:name/paste-assets`
+  unchanged.
+- Implement one vertical Red -> Green slice at a time.
+- Keep the current full Gateway implementation preserved on
+  `codex/mat-261-full-gateway-backup` until Preview validation completes.
+
+## Task 1: Desktop binary upload seam
+
+- [x] Add failing `ApiClient` tests for bounded Blob PUT/POST requests.
+- [x] Add the minimal binary request methods.
+- [x] Add failing Electron CORS coverage for `X-Matrix-Filename`.
+- [x] Allow that existing Gateway request header.
+
+## Task 2: Files drag/drop and paste
+
+- [x] Add failing `ComputerFileBrowser` behavior tests.
+- [x] Implement a bounded Desktop file upload controller over `/api/files/blob`.
+- [x] Wire drop and clipboard-file paste only in browse mode.
+- [x] Show ordered progress, conflict, Retry, and Remove states.
+
+## Task 3: Shared Desktop composer previews
+
+- [x] Add failing preview-row and local controller tests.
+- [x] Implement ordered horizontal previews, image object-URL lifecycle, remove/retry,
+  eight-file cap, three-upload concurrency, and runtime invalidation.
+- [x] Keep the implementation renderer-local and serializable at store boundaries.
+
+## Task 4: Chat and Project Chat submission
+
+- [x] Add failing Chat tests for path-prompt submission and failure retention.
+- [x] Add failing Project Chat tests for existing `structured_ref` payloads.
+- [x] Wire new thread, follow-up turn, and Hermes Send without changing shared contracts.
+
+## Task 5: Terminal image paste/drop
+
+- [x] Add failing `TerminalView` tests for paste and drop.
+- [x] Add Desktop-local MIME/size, response, and bracketed-paste helpers.
+- [x] Upload sequentially to preserve order and write exactly once per completed batch.
+- [x] Verify no Enter and normal text paste fallback.
+
+## Task 6: Verification and PR replacement
+
+- [x] Run all changed-area tests.
+- [x] Run Desktop and Gateway type checks plus diff pattern checks.
+- [x] Build the production Desktop app.
+- [ ] Exercise all four surfaces in the real Electron app.
+- [ ] Force-update PR #1174 with `--force-with-lease` only after local verification.
+- [ ] Deploy and verify the Preview VPS before marking the PR ready.
+- [ ] Prepare the separate public documentation PR after implementation approval.

--- a/specs/110-desktop-drag-drop-and-paste/plan.md
+++ b/specs/110-desktop-drag-drop-and-paste/plan.md
@@ -102,7 +102,7 @@ but selects `temporary/terminal-pastes/<date>/` independently of terminal cwd.
   `temporary/desktop-chat/<uploadId>-<safe filename>` for both Hermes paths and
   Project Chat `structured_ref.path` values.
 
-- [ ] **Step 1: RED — change the controller contract expectations**
+- [x] **Step 1: RED — change the controller contract expectations**
 
   Update the stable expected upload path and URL assertions in
   `tests/desktop/local-attachment-controller.test.ts` from
@@ -118,7 +118,7 @@ but selects `temporary/terminal-pastes/<date>/` independently of terminal cwd.
   );
   ```
 
-- [ ] **Step 2: Run RED and confirm the old prefix is the failure**
+- [x] **Step 2: Run RED and confirm the old prefix is the failure**
 
   Run:
 
@@ -129,7 +129,7 @@ but selects `temporary/terminal-pastes/<date>/` independently of terminal cwd.
   Expected: FAIL because the controller still sends and returns
   `uploads/desktop-chat/...`.
 
-- [ ] **Step 3: GREEN — change only the composer upload prefix**
+- [x] **Step 3: GREEN — change only the composer upload prefix**
 
   In `local-attachment-controller.ts`, construct new items with:
 
@@ -137,7 +137,7 @@ but selects `temporary/terminal-pastes/<date>/` independently of terminal cwd.
   uploadPath: `temporary/desktop-chat/${uploadId}-${file.name}`,
   ```
 
-- [ ] **Step 4: Run the composer and Files tests**
+- [x] **Step 4: Run the composer and Files tests**
 
   Run:
 

--- a/specs/110-desktop-drag-drop-and-paste/plan.md
+++ b/specs/110-desktop-drag-drop-and-paste/plan.md
@@ -232,7 +232,7 @@ but selects `temporary/terminal-pastes/<date>/` independently of terminal cwd.
 - Consumes: the new paths proven by Tasks 7 and 8.
 - Produces: one consistent documented storage contract and verification record.
 
-- [ ] **Step 1: Replace authoritative path examples**
+- [x] **Step 1: Replace authoritative path examples**
 
   Change current server-owned destination examples from
   `projects/.matrix-terminal-pastes/...` to
@@ -240,7 +240,7 @@ but selects `temporary/terminal-pastes/<date>/` independently of terminal cwd.
   fixtures: they intentionally prove clients accept authenticated owner-home paths
   independent of the server's current destination convention.
 
-- [ ] **Step 2: Run focused regression tests**
+- [x] **Step 2: Run focused regression tests**
 
   Run:
 
@@ -254,7 +254,7 @@ but selects `temporary/terminal-pastes/<date>/` independently of terminal cwd.
     tests/shell/terminal-pane-privacy.test.tsx
   ```
 
-- [ ] **Step 3: Run static and production verification**
+- [x] **Step 3: Run static and production verification**
 
   Run:
 
@@ -265,7 +265,7 @@ but selects `temporary/terminal-pastes/<date>/` independently of terminal cwd.
   git diff --check
   ```
 
-- [ ] **Step 4: Run the repository-wide suite and classify failures**
+- [x] **Step 4: Run the repository-wide suite and classify failures**
 
   Run:
 

--- a/specs/110-desktop-drag-drop-and-paste/plan.md
+++ b/specs/110-desktop-drag-drop-and-paste/plan.md
@@ -165,7 +165,7 @@ but selects `temporary/terminal-pastes/<date>/` independently of terminal cwd.
   `path` rooted at `temporary/terminal-pastes/<YYYY-MM-DD>/` and `terminalPath`
   rooted at `/home/matrix/home/temporary/terminal-pastes/<YYYY-MM-DD>/` in production.
 
-- [ ] **Step 1: RED — change the Gateway route expectation**
+- [x] **Step 1: RED — change the Gateway route expectation**
 
   Rename the route test to `uploads pasted terminal image assets into the owner
   temporary directory` and assert:
@@ -182,7 +182,7 @@ but selects `temporary/terminal-pastes/<date>/` independently of terminal cwd.
   The temporary directory must not be pre-created in test setup; the successful
   `readFile` assertion proves recursive creation and the final atomic file write.
 
-- [ ] **Step 2: Run RED and confirm the old cwd-scoped path is the failure**
+- [x] **Step 2: Run RED and confirm the old cwd-scoped path is the failure**
 
   Run:
 
@@ -193,7 +193,7 @@ but selects `temporary/terminal-pastes/<date>/` independently of terminal cwd.
   Expected: FAIL because the response still starts with
   `projects/app/.matrix-terminal-pastes/`.
 
-- [ ] **Step 3: GREEN — select the owner temporary directory**
+- [x] **Step 3: GREEN — select the owner temporary directory**
 
   In `saveTerminalPasteAsset`, preserve all validation and atomic write code and
   change only the directory selection:
@@ -205,7 +205,7 @@ but selects `temporary/terminal-pastes/<date>/` independently of terminal cwd.
   Keep `cwd` in `TerminalPasteAssetInput` and keep route-level cwd validation for
   backward compatibility; storage must no longer depend on its value.
 
-- [ ] **Step 4: Run the focused Gateway route test**
+- [x] **Step 4: Run the focused Gateway route test**
 
   Run:
 

--- a/specs/110-desktop-drag-drop-and-paste/plan.md
+++ b/specs/110-desktop-drag-drop-and-paste/plan.md
@@ -1,9 +1,40 @@
 # Desktop Drag, Drop, and Paste Implementation Plan
 
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:subagent-driven-development` (recommended) or
+> `superpowers:executing-plans` to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Store transient Desktop composer and Terminal uploads under the owner's
+`~/temporary/` directory without changing upload endpoint schemas or Files-browser
+destinations.
+
+**Architecture:** The Desktop composer continues using `PUT /api/files/blob`, but
+selects the `temporary/desktop-chat/` owner-relative prefix. The existing Gateway
+Terminal paste helper continues validating and atomically writing uploaded images,
+but selects `temporary/terminal-pastes/<date>/` independently of terminal cwd.
+
+**Tech Stack:** TypeScript 5.9 strict, React 19, Electron 41, Hono, Node.js 24
+`fs/promises`, Vitest 4, pnpm 10, bun scripts.
+
+## Global Constraints
+
+- Keep each file at or below 10 MiB and existing upload concurrency/timeouts unchanged.
+- Keep `PUT /api/files/blob` and
+  `POST /api/terminal/sessions/:name/paste-assets` request/response schemas unchanged.
+- Keep Files-browser uploads in the user-visible target directory.
+- Keep path confinement, magic-byte validation, exclusive temporary writes, and
+  atomic rename behavior unchanged.
+- Do not add cleanup behavior; `MAT-269` owns that follow-up.
+- Do not modify CLI, Shell, Mobile, conversation, or terminal-session code.
+
+---
+
 ## Invariants
 
 - Diff scope is `desktop/`, the existing Gateway Terminal paste-asset storage helper
-  and its focused tests, and this spec directory only.
+  and its focused tests, this spec directory, and canonical Terminal paste contract
+  documents under `specs/106-terminal-rich-paste/` only.
 - Reuse `PUT /api/files/blob` and `POST /api/terminal/sessions/:name/paste-assets`
   without changing either endpoint contract.
 - Implement one vertical Red -> Green slice at a time.
@@ -55,16 +86,206 @@
 - [ ] Deploy and verify the Preview VPS before marking the PR ready.
 - [ ] Prepare the separate public documentation PR after implementation approval.
 
-## Task 7: Consolidate transient VPS uploads
+## Task 7: Move composer uploads into owner temporary storage
 
-- [ ] Add failing controller coverage proving Chat and Project Chat paths use
-  `temporary/desktop-chat/` while Files-browser destinations remain unchanged.
-- [ ] Change the Desktop composer upload prefix from `uploads/desktop-chat/` to
-  `temporary/desktop-chat/`.
-- [ ] Add failing Gateway helper coverage for
-  `temporary/terminal-pastes/<YYYY-MM-DD>/`, recursive creation, and cwd independence.
-- [ ] Move Terminal paste-asset storage to the common owner-home temporary directory
-  without changing the endpoint request or response schema.
-- [ ] Keep automatic cleanup out of this PR; track it in `MAT-269`.
-- [ ] Re-run focused Desktop/Gateway tests, typechecks, pattern checks, production
-  Desktop build, exact-head Preview deployment, and live path validation.
+**Files:**
+
+- Modify: `tests/desktop/local-attachment-controller.test.ts`
+- Verify unchanged: `tests/desktop/files-upload.test.tsx`
+- Modify: `desktop/src/renderer/src/features/chat/attachments/local-attachment-controller.ts`
+
+**Interfaces:**
+
+- Consumes: existing `createLocalAttachmentController({ api, createId })` and
+  `ApiClient.putBytes()` contracts.
+- Produces: owner-relative paths matching
+  `temporary/desktop-chat/<uploadId>-<safe filename>` for both Hermes paths and
+  Project Chat `structured_ref.path` values.
+
+- [ ] **Step 1: RED — change the controller contract expectations**
+
+  Update the stable expected upload path and URL assertions in
+  `tests/desktop/local-attachment-controller.test.ts` from
+  `uploads/desktop-chat/...` to `temporary/desktop-chat/...`, including:
+
+  ```ts
+  expect(putBytes).toHaveBeenNthCalledWith(
+    1,
+    "/api/files/blob?path=temporary%2Fdesktop-chat%2Fstable_0-first.txt",
+    expect.any(File),
+    { "content-type": "text/plain" },
+    { timeoutMs: 30_000 },
+  );
+  ```
+
+- [ ] **Step 2: Run RED and confirm the old prefix is the failure**
+
+  Run:
+
+  ```bash
+  bun run test -- tests/desktop/local-attachment-controller.test.ts
+  ```
+
+  Expected: FAIL because the controller still sends and returns
+  `uploads/desktop-chat/...`.
+
+- [ ] **Step 3: GREEN — change only the composer upload prefix**
+
+  In `local-attachment-controller.ts`, construct new items with:
+
+  ```ts
+  uploadPath: `temporary/desktop-chat/${uploadId}-${file.name}`,
+  ```
+
+- [ ] **Step 4: Run the composer and Files tests**
+
+  Run:
+
+  ```bash
+  bun run test -- \
+    tests/desktop/local-attachment-controller.test.ts \
+    tests/desktop/files-upload.test.tsx
+  ```
+
+  Expected: PASS. The Files tests must continue asserting visible destinations such
+  as `projects/notes.md` and root `pasted.txt`, never `temporary/...`.
+
+## Task 8: Move Terminal paste assets into owner temporary storage
+
+**Files:**
+
+- Modify: `tests/gateway/shell-routes.test.ts`
+- Modify: `packages/gateway/src/shell/paste-assets.ts`
+
+**Interfaces:**
+
+- Consumes: existing `saveTerminalPasteAsset(TerminalPasteAssetInput)` and
+  `POST /api/terminal/sessions/:name/paste-assets` contracts.
+- Produces: unchanged `{ path, terminalPath, size, mimeType }` response shape with
+  `path` rooted at `temporary/terminal-pastes/<YYYY-MM-DD>/` and `terminalPath`
+  rooted at `/home/matrix/home/temporary/terminal-pastes/<YYYY-MM-DD>/` in production.
+
+- [ ] **Step 1: RED — change the Gateway route expectation**
+
+  Rename the route test to `uploads pasted terminal image assets into the owner
+  temporary directory` and assert:
+
+  ```ts
+  expect(body.path).toMatch(
+    /^temporary\/terminal-pastes\/\d{4}-\d{2}-\d{2}\//,
+  );
+  expect(body.path).not.toContain("projects/app");
+  expect(body.terminalPath).toBe(join(root, body.path));
+  await expect(readFile(body.terminalPath)).resolves.toEqual(Buffer.from(PNG_BYTES));
+  ```
+
+  The temporary directory must not be pre-created in test setup; the successful
+  `readFile` assertion proves recursive creation and the final atomic file write.
+
+- [ ] **Step 2: Run RED and confirm the old cwd-scoped path is the failure**
+
+  Run:
+
+  ```bash
+  bun run test -- tests/gateway/shell-routes.test.ts
+  ```
+
+  Expected: FAIL because the response still starts with
+  `projects/app/.matrix-terminal-pastes/`.
+
+- [ ] **Step 3: GREEN — select the owner temporary directory**
+
+  In `saveTerminalPasteAsset`, preserve all validation and atomic write code and
+  change only the directory selection:
+
+  ```ts
+  const relativeDir = join("temporary", "terminal-pastes", date);
+  ```
+
+  Keep `cwd` in `TerminalPasteAssetInput` and keep route-level cwd validation for
+  backward compatibility; storage must no longer depend on its value.
+
+- [ ] **Step 4: Run the focused Gateway route test**
+
+  Run:
+
+  ```bash
+  bun run test -- tests/gateway/shell-routes.test.ts
+  ```
+
+  Expected: PASS, including unsafe magic bytes, traversal cwd, unsafe filename,
+  missing-session, and body-limit cases.
+
+## Task 9: Synchronize contracts and verify the complete change
+
+**Files:**
+
+- Modify: `specs/106-terminal-rich-paste/data-model.md`
+- Modify: `specs/106-terminal-rich-paste/quickstart.md`
+- Modify: `specs/106-terminal-rich-paste/pr-invariants.md`
+- Modify: `specs/106-terminal-rich-paste/contracts/paste-assets.md`
+- Modify: `specs/106-terminal-rich-paste/tasks.md`
+- Modify: `specs/110-desktop-drag-drop-and-paste/plan.md`
+
+**Interfaces:**
+
+- Consumes: the new paths proven by Tasks 7 and 8.
+- Produces: one consistent documented storage contract and verification record.
+
+- [ ] **Step 1: Replace authoritative path examples**
+
+  Change current server-owned destination examples from
+  `projects/.matrix-terminal-pastes/...` to
+  `temporary/terminal-pastes/...`. Do not mechanically rewrite sync-client test
+  fixtures: they intentionally prove clients accept authenticated owner-home paths
+  independent of the server's current destination convention.
+
+- [ ] **Step 2: Run focused regression tests**
+
+  Run:
+
+  ```bash
+  bun run test -- \
+    tests/desktop/local-attachment-controller.test.ts \
+    tests/desktop/files-upload.test.tsx \
+    tests/desktop/terminal-view.test.tsx \
+    tests/gateway/shell-routes.test.ts \
+    tests/cli/shell-client.test.ts \
+    tests/shell/terminal-pane-privacy.test.tsx
+  ```
+
+- [ ] **Step 3: Run static and production verification**
+
+  Run:
+
+  ```bash
+  bun run typecheck
+  bun run check:patterns:diff
+  bun run build:desktop
+  git diff --check
+  ```
+
+- [ ] **Step 4: Run the repository-wide suite and classify failures**
+
+  Run:
+
+  ```bash
+  bun run test
+  ```
+
+  Compare any failures with the pre-change baseline recorded in the PR. Do not report
+  unrelated baseline failures as regressions.
+
+- [ ] **Step 5: Commit, push, and validate exact-head Preview**
+
+  Commit the implementation with a Conventional Commit message, push to
+  `codex/mat-261-gateway-attachments`, update PR #1174 and MAT-261 in English, then
+  deploy and verify the exact Preview bundle. Confirm:
+
+  ```text
+  Chat / Project Chat: ~/temporary/desktop-chat/...
+  Terminal: ~/temporary/terminal-pastes/<date>/...
+  Files browser: the user-visible destination remains unchanged
+  ```
+
+  Do not merge until Greptile reviews the new head at 5/5.

--- a/specs/110-desktop-drag-drop-and-paste/plan.md
+++ b/specs/110-desktop-drag-drop-and-paste/plan.md
@@ -2,9 +2,10 @@
 
 ## Invariants
 
-- Diff scope is `desktop/`, Desktop tests, and this spec directory only.
+- Diff scope is `desktop/`, the existing Gateway Terminal paste-asset storage helper
+  and its focused tests, and this spec directory only.
 - Reuse `PUT /api/files/blob` and `POST /api/terminal/sessions/:name/paste-assets`
-  unchanged.
+  without changing either endpoint contract.
 - Implement one vertical Red -> Green slice at a time.
 - Keep the current full Gateway implementation preserved on
   `codex/mat-261-full-gateway-backup` until Preview validation completes.
@@ -40,7 +41,8 @@
 
 - [x] Add failing `TerminalView` tests for paste and drop.
 - [x] Add Desktop-local MIME/size, response, and bracketed-paste helpers.
-- [x] Upload sequentially to preserve order and write exactly once per completed batch.
+- [x] Start bounded uploads concurrently, preserve input order in the returned paths,
+  and write exactly once per completed batch.
 - [x] Verify no Enter and normal text paste fallback.
 
 ## Task 6: Verification and PR replacement
@@ -52,3 +54,17 @@
 - [ ] Force-update PR #1174 with `--force-with-lease` only after local verification.
 - [ ] Deploy and verify the Preview VPS before marking the PR ready.
 - [ ] Prepare the separate public documentation PR after implementation approval.
+
+## Task 7: Consolidate transient VPS uploads
+
+- [ ] Add failing controller coverage proving Chat and Project Chat paths use
+  `temporary/desktop-chat/` while Files-browser destinations remain unchanged.
+- [ ] Change the Desktop composer upload prefix from `uploads/desktop-chat/` to
+  `temporary/desktop-chat/`.
+- [ ] Add failing Gateway helper coverage for
+  `temporary/terminal-pastes/<YYYY-MM-DD>/`, recursive creation, and cwd independence.
+- [ ] Move Terminal paste-asset storage to the common owner-home temporary directory
+  without changing the endpoint request or response schema.
+- [ ] Keep automatic cleanup out of this PR; track it in `MAT-269`.
+- [ ] Re-run focused Desktop/Gateway tests, typechecks, pattern checks, production
+  Desktop build, exact-head Preview deployment, and live path validation.

--- a/specs/110-desktop-drag-drop-and-paste/spec.md
+++ b/specs/110-desktop-drag-drop-and-paste/spec.md
@@ -35,7 +35,8 @@ and non-active terminals are not drop zones.
 ## Requirements
 
 - **FR-001**: The change MUST remain inside `desktop/`, the existing Gateway Terminal
-  paste-asset storage helper and its focused tests, and this spec directory.
+  paste-asset storage helper and its focused tests, this spec directory, and the
+  canonical Terminal paste contract documents under `specs/106-terminal-rich-paste/`.
 - **FR-002**: Existing Gateway routes and contracts MUST be consumed unchanged.
 - **FR-003**: Each accepted file MUST be a regular browser `File` no larger than
   `10 * 1024 * 1024` bytes.

--- a/specs/110-desktop-drag-drop-and-paste/spec.md
+++ b/specs/110-desktop-drag-drop-and-paste/spec.md
@@ -5,25 +5,28 @@
 
 ## Scope
 
-Improve the Electron Desktop experience without changing shared Gateway, CLI, Shell,
-Mobile, coding-agent, conversation, or terminal-session contracts.
+Improve the Electron Desktop experience while keeping shared CLI, Shell, Mobile,
+coding-agent, conversation, and terminal-session contracts unchanged. One narrow
+Gateway implementation change moves existing Terminal paste assets into the common
+owner-home directory `/home/matrix/home/temporary/`; the endpoint and response
+contract remain unchanged.
 
 The implementation is a thin Desktop renderer over two existing authenticated APIs:
 
 - `PUT /api/files/blob` for Files, Chat, and Project Chat uploads.
 - `POST /api/terminal/sessions/:name/paste-assets` for Terminal image paste/drop.
 
-No new endpoint, database, durable attachment lifecycle, thread identifier, session
-identifier, or provider contract is introduced.
+No new endpoint, database, cleanup lifecycle, thread identifier, session identifier,
+or provider contract is introduced.
 
 ## Surface Contract
 
 | Surface | Input | Result |
 |---|---|---|
 | Files browser | Dropped or pasted regular files, at most 10 MiB each | Upload to the visible owner-home directory and refresh the listing |
-| Chat | Dropped or pasted regular files, at most 10 MiB each | Show one Codex-style horizontal preview row; upload on Send and append owner-readable paths to the Hermes prompt |
-| Project Chat | Same as Chat | Upload on thread/turn Send and pass existing `structured_ref` attachments with owner-relative paths |
-| Standalone Terminal | Dropped or pasted PNG/JPEG/GIF/WebP, at most 10 MiB each | Upload through the existing terminal paste endpoint and bracketed-paste returned paths without Enter |
+| Chat | Dropped or pasted regular files, at most 10 MiB each | Show one Codex-style horizontal preview row; upload on Send under `~/temporary/desktop-chat/` and append owner-readable paths to the Hermes prompt |
+| Project Chat | Same as Chat | Upload on thread/turn Send under `~/temporary/desktop-chat/` and pass existing `structured_ref` attachments with owner-relative paths |
+| Standalone Terminal | Dropped or pasted PNG/JPEG/GIF/WebP, at most 10 MiB each | Upload through the existing terminal paste endpoint under `~/temporary/terminal-pastes/<date>/` and bracketed-paste returned paths without Enter |
 | Inspector Terminal | Same as standalone Terminal | Reuse the same `TerminalView` implementation |
 
 Folder pickers, file preview panes, terminal session lists, chat rails, project inspectors,
@@ -31,7 +34,8 @@ and non-active terminals are not drop zones.
 
 ## Requirements
 
-- **FR-001**: All behavior MUST remain inside `desktop/` and Desktop tests/specs.
+- **FR-001**: The change MUST remain inside `desktop/`, the existing Gateway Terminal
+  paste-asset storage helper and its focused tests, and this spec directory.
 - **FR-002**: Existing Gateway routes and contracts MUST be consumed unchanged.
 - **FR-003**: Each accepted file MUST be a regular browser `File` no larger than
   `10 * 1024 * 1024` bytes.
@@ -47,9 +51,9 @@ and non-active terminals are not drop zones.
   Matrix computer cannot be submitted to another.
 - **FR-010**: Files conflicts MUST surface a safe conflict error; Desktop MUST NOT
   silently overwrite an existing owner file.
-- **FR-011**: Chat uploads MUST be placed under a collision-resistant Desktop upload
-  directory in owner home, and Hermes MUST receive both `~/...` and absolute Matrix-home
-  path forms in plain text.
+- **FR-011**: Chat and Project Chat uploads MUST be placed under the
+  collision-resistant `temporary/desktop-chat/` directory in owner home, and Hermes
+  MUST receive both `~/...` and absolute Matrix-home path forms in plain text.
 - **FR-012**: Project Chat MUST reuse `AgentAttachmentSchema` with
   `kind: "structured_ref"`; it MUST NOT add new attachment contract fields.
 - **FR-013**: Terminal paste/drop MUST accept only PNG, JPEG, GIF, and WebP and MUST use
@@ -59,8 +63,17 @@ and non-active terminals are not drop zones.
 - **FR-015**: Unsupported paste data MUST fall through to normal xterm text paste.
 - **FR-016**: Drag/drop interception MUST occur only when at least one supported file is
   present; ordinary terminal/chat/file interactions MUST remain unchanged.
-- **FR-017**: No local absolute path, credential, raw Gateway error, or hidden runtime
-  identifier may be rendered or logged.
+- **FR-017**: No local Desktop absolute path, credential, raw Gateway error, or hidden
+  runtime identifier may be rendered or logged. Authenticated owner paths returned by
+  the VPS remain valid prompt and terminal input.
+- **FR-018**: Terminal paste assets MUST be placed under
+  `temporary/terminal-pastes/<YYYY-MM-DD>/` in owner home regardless of terminal cwd.
+  The existing Gateway helper MUST create missing directories recursively and retain
+  its path-confinement, exclusive-write, and magic-byte validation behavior.
+- **FR-019**: Files-browser uploads MUST continue targeting the owner-home directory
+  currently visible to the user; they MUST NOT be redirected into `temporary/`.
+- **FR-020**: This change MUST NOT introduce automatic deletion or retention behavior.
+  Bounded cleanup is deferred to Linear issue `MAT-269`.
 
 ## Existing Endpoint Security
 
@@ -70,7 +83,8 @@ and non-active terminals are not drop zones.
 | `POST /api/terminal/sessions/:name/paste-assets` | Desktop trusted-core Authorization injection | 10 MiB | Terminal images only |
 
 Desktop adds only the CORS request header needed by the existing terminal endpoint:
-`X-Matrix-Filename`.
+`X-Matrix-Filename`. The Gateway endpoint keeps the same request and response schema;
+only its owner-home storage path changes.
 
 ## Testing Seams
 
@@ -80,13 +94,17 @@ Desktop adds only the CORS request header needed by the existing terminal endpoi
   `structured_ref` create/turn payloads.
 - `TerminalView`: active xterm viewport paste/drop, upload, bracketed write, no Enter,
   unsupported/disconnected behavior, standalone/Inspector reuse.
+- `saveTerminalPasteAsset`: owner-home `temporary/terminal-pastes/<date>/` placement,
+  recursive directory creation, path confinement, exclusive writes, and unchanged
+  response shape.
 - `ApiClient` and Electron CORS: binary PUT/POST timeout and allowed request headers.
 
 ## Success Criteria
 
-- All four Desktop surfaces work in a production Electron build against an unchanged
-  `origin/main` Gateway bundle.
+- All four Desktop surfaces work in a production Electron build against the exact PR
+  Gateway bundle while consuming unchanged upload endpoint contracts.
 - Focused Desktop tests, typecheck, pattern checks, and production build pass.
 - A Preview VPS demonstrates Files, Chat, Project Chat, standalone Terminal, and
-  Inspector Terminal behavior without changing Shell, CLI, Mobile, or Gateway code.
-
+  Inspector Terminal behavior with all transient composer and terminal assets under
+  `~/temporary/`, Files uploads still targeting the visible directory, and no changes
+  to Shell, CLI, Mobile, or terminal-session behavior.

--- a/specs/110-desktop-drag-drop-and-paste/spec.md
+++ b/specs/110-desktop-drag-drop-and-paste/spec.md
@@ -1,0 +1,92 @@
+# Desktop Drag, Drop, and Paste
+
+**Status**: Approved  
+**Linear Issue**: `MAT-261`
+
+## Scope
+
+Improve the Electron Desktop experience without changing shared Gateway, CLI, Shell,
+Mobile, coding-agent, conversation, or terminal-session contracts.
+
+The implementation is a thin Desktop renderer over two existing authenticated APIs:
+
+- `PUT /api/files/blob` for Files, Chat, and Project Chat uploads.
+- `POST /api/terminal/sessions/:name/paste-assets` for Terminal image paste/drop.
+
+No new endpoint, database, durable attachment lifecycle, thread identifier, session
+identifier, or provider contract is introduced.
+
+## Surface Contract
+
+| Surface | Input | Result |
+|---|---|---|
+| Files browser | Dropped or pasted regular files, at most 10 MiB each | Upload to the visible owner-home directory and refresh the listing |
+| Chat | Dropped or pasted regular files, at most 10 MiB each | Show one Codex-style horizontal preview row; upload on Send and append owner-readable paths to the Hermes prompt |
+| Project Chat | Same as Chat | Upload on thread/turn Send and pass existing `structured_ref` attachments with owner-relative paths |
+| Standalone Terminal | Dropped or pasted PNG/JPEG/GIF/WebP, at most 10 MiB each | Upload through the existing terminal paste endpoint and bracketed-paste returned paths without Enter |
+| Inspector Terminal | Same as standalone Terminal | Reuse the same `TerminalView` implementation |
+
+Folder pickers, file preview panes, terminal session lists, chat rails, project inspectors,
+and non-active terminals are not drop zones.
+
+## Requirements
+
+- **FR-001**: All behavior MUST remain inside `desktop/` and Desktop tests/specs.
+- **FR-002**: Existing Gateway routes and contracts MUST be consumed unchanged.
+- **FR-003**: Each accepted file MUST be a regular browser `File` no larger than
+  `10 * 1024 * 1024` bytes.
+- **FR-004**: Chat and Project Chat MUST accept at most eight pending files.
+- **FR-005**: Preview items MUST preserve selection order in one non-wrapping,
+  horizontally scrollable row.
+- **FR-006**: Image previews MUST use bounded object URLs that are revoked on removal,
+  clear, runtime change, and unmount.
+- **FR-007**: Uploads MUST be bounded by a 30-second timeout and a maximum of three
+  concurrent requests per composer or Files browser.
+- **FR-008**: Failed uploads MUST retain their preview and offer Retry or Remove.
+- **FR-009**: Runtime changes MUST invalidate pending completions so files from one
+  Matrix computer cannot be submitted to another.
+- **FR-010**: Files conflicts MUST surface a safe conflict error; Desktop MUST NOT
+  silently overwrite an existing owner file.
+- **FR-011**: Chat uploads MUST be placed under a collision-resistant Desktop upload
+  directory in owner home, and Hermes MUST receive both `~/...` and absolute Matrix-home
+  path forms in plain text.
+- **FR-012**: Project Chat MUST reuse `AgentAttachmentSchema` with
+  `kind: "structured_ref"`; it MUST NOT add new attachment contract fields.
+- **FR-013**: Terminal paste/drop MUST accept only PNG, JPEG, GIF, and WebP and MUST use
+  the existing Gateway magic-byte validation as the final authority.
+- **FR-014**: Terminal insertion MUST use bracketed paste, strip nested bracket markers,
+  remain under the terminal input cap, and never append Enter.
+- **FR-015**: Unsupported paste data MUST fall through to normal xterm text paste.
+- **FR-016**: Drag/drop interception MUST occur only when at least one supported file is
+  present; ordinary terminal/chat/file interactions MUST remain unchanged.
+- **FR-017**: No local absolute path, credential, raw Gateway error, or hidden runtime
+  identifier may be rendered or logged.
+
+## Existing Endpoint Security
+
+| Route | Existing auth | Existing body limit | Desktop use |
+|---|---|---:|---|
+| `PUT /api/files/blob` | Desktop trusted-core Authorization injection | 10 MiB | Files and composer uploads |
+| `POST /api/terminal/sessions/:name/paste-assets` | Desktop trusted-core Authorization injection | 10 MiB | Terminal images only |
+
+Desktop adds only the CORS request header needed by the existing terminal endpoint:
+`X-Matrix-Filename`.
+
+## Testing Seams
+
+- `ComputerFileBrowser`: user-visible drop/paste, upload rows, conflict, retry, refresh.
+- `ChatTab`: local preview row, ordered Send, failure retention, path prompt.
+- `ProjectChatDraft` and `AgentConversationView`: preview row and existing
+  `structured_ref` create/turn payloads.
+- `TerminalView`: active xterm viewport paste/drop, upload, bracketed write, no Enter,
+  unsupported/disconnected behavior, standalone/Inspector reuse.
+- `ApiClient` and Electron CORS: binary PUT/POST timeout and allowed request headers.
+
+## Success Criteria
+
+- All four Desktop surfaces work in a production Electron build against an unchanged
+  `origin/main` Gateway bundle.
+- Focused Desktop tests, typecheck, pattern checks, and production build pass.
+- A Preview VPS demonstrates Files, Chat, Project Chat, standalone Terminal, and
+  Inspector Terminal behavior without changing Shell, CLI, Mobile, or Gateway code.
+

--- a/tests/desktop/api-client.test.ts
+++ b/tests/desktop/api-client.test.ts
@@ -131,6 +131,57 @@ describe("createApiClient", () => {
     expect(timeout).toHaveBeenCalledWith(310_000);
   });
 
+  it("uploads binary blobs with caller headers and a bounded timeout", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(201, {
+      terminalPath: "/home/matrix/home/projects/paste.png",
+    }));
+    const timeout = vi.spyOn(AbortSignal, "timeout");
+    const client = createApiClient({
+      baseUrl: "https://x.test",
+      getRuntimeSlot: () => "vm-2",
+      fetchFn,
+    });
+    const image = new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], { type: "image/png" });
+
+    await client.postBytes(
+      "/api/terminal/sessions/main/paste-assets",
+      image,
+      { "Content-Type": "image/png", "X-Matrix-Filename": "shot.png" },
+      { timeoutMs: 30_000 },
+    );
+
+    const [url, init] = fetchFn.mock.calls[0]!;
+    expect(url).toBe("https://x.test/api/terminal/sessions/main/paste-assets?runtime=vm-2");
+    expect(init).toMatchObject({ method: "POST", body: image });
+    expect((init as RequestInit).headers).toEqual({
+      "Content-Type": "image/png",
+      "X-Matrix-Filename": "shot.png",
+    });
+    expect(timeout).toHaveBeenCalledWith(30_000);
+  });
+
+  it("uploads file blobs with PUT without JSON encoding", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(200, {
+      ok: true,
+      path: "projects/demo/readme.txt",
+      size: 5,
+    }));
+    const client = createApiClient({
+      baseUrl: "https://x.test",
+      getRuntimeSlot: () => "primary",
+      fetchFn,
+    });
+    const file = new Blob(["hello"], { type: "text/plain" });
+
+    await client.putBytes("/api/files/blob?path=projects%2Fdemo%2Freadme.txt", file, {
+      "Content-Type": "text/plain",
+    });
+
+    const [, init] = fetchFn.mock.calls[0]!;
+    expect(init).toMatchObject({ method: "PUT", body: file });
+    expect((init as RequestInit).headers).toEqual({ "Content-Type": "text/plain" });
+  });
+
   it("treats non-JSON success bodies as server errors", async () => {
     const fetchFn = vi.fn().mockResolvedValue(new Response("<html>", { status: 200 }));
     const client = createApiClient({

--- a/tests/desktop/attachment-preview-row.test.tsx
+++ b/tests/desktop/attachment-preview-row.test.tsx
@@ -55,4 +55,24 @@ describe("AttachmentPreviewRow", () => {
     expect(onRemove).toHaveBeenCalledWith("local_1");
     expect(onRetry).toHaveBeenCalledWith("local_3");
   });
+
+  it("disables Retry and Remove while the composer is submitting", () => {
+    const onRemove = vi.fn();
+    const onRetry = vi.fn();
+    render(<AttachmentPreviewRow
+      items={[item(1, { status: "failed", error: "Upload failed. Try again." })]}
+      disabled
+      onRemove={onRemove}
+      onRetry={onRetry}
+    />);
+
+    const retry = screen.getByRole("button", { name: "Retry file-1.txt" });
+    const remove = screen.getByRole("button", { name: "Remove file-1.txt" });
+    expect((retry as HTMLButtonElement).disabled).toBe(true);
+    expect((remove as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(retry);
+    fireEvent.click(remove);
+    expect(onRetry).not.toHaveBeenCalled();
+    expect(onRemove).not.toHaveBeenCalled();
+  });
 });

--- a/tests/desktop/attachment-preview-row.test.tsx
+++ b/tests/desktop/attachment-preview-row.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AttachmentPreviewRow } from "../../desktop/src/renderer/src/features/chat/attachments/AttachmentPreviewRow";
+import type { LocalConversationAttachment } from "../../desktop/src/renderer/src/features/chat/attachments/local-attachment-controller";
+
+function item(index: number, overrides: Partial<LocalConversationAttachment> = {}): LocalConversationAttachment {
+  return {
+    localId: `local_${index}`,
+    uploadId: `upload_${index}`,
+    uploadPath: `uploads/desktop-chat/upload_${index}-file-${index}.txt`,
+    file: new File(["x"], `file-${index}.txt`, { type: "text/plain" }),
+    status: "ready",
+    ...overrides,
+  };
+}
+
+afterEach(cleanup);
+
+describe("AttachmentPreviewRow", () => {
+  it("renders at most eight previews in one horizontal non-wrapping row", () => {
+    render(<AttachmentPreviewRow items={Array.from({ length: 9 }, (_, index) => item(index))} onRemove={vi.fn()} onRetry={vi.fn()} />);
+
+    const group = screen.getByRole("group", { name: "Attachments" });
+    expect(group.className).toContain("overflow-x-auto");
+    expect(group.className).not.toContain("flex-wrap");
+    expect(screen.getAllByRole("button", { name: /remove/i })).toHaveLength(8);
+  });
+
+  it("uses safe raster thumbnails and gives Retry and Remove equal-size actions", () => {
+    const onRemove = vi.fn();
+    const onRetry = vi.fn();
+    render(<AttachmentPreviewRow
+      items={[
+        item(1, { file: new File(["png"], "screen.png", { type: "image/png" }), previewUrl: "blob:safe" }),
+        item(2, { file: new File(["svg"], "vector.svg", { type: "image/svg+xml" }), previewUrl: undefined }),
+        item(3, { status: "failed", error: "Upload failed. Try again." }),
+      ]}
+      onRemove={onRemove}
+      onRetry={onRetry}
+    />);
+
+    expect(screen.getByRole("img", { name: "screen.png" }).getAttribute("src")).toBe("blob:safe");
+    expect(screen.queryByRole("img", { name: "vector.svg" })).toBeNull();
+    const retry = screen.getByRole("button", { name: "Retry file-3.txt" });
+    const remove = screen.getByRole("button", { name: "Remove file-3.txt" });
+    expect(retry.className).toContain("h-6 w-6");
+    expect(remove.className).toContain("h-6 w-6");
+    expect(retry.querySelector("svg")?.getAttribute("width")).toBe("14");
+    expect(remove.querySelector("svg")?.getAttribute("width")).toBe("14");
+    fireEvent.click(screen.getByRole("button", { name: "Remove screen.png" }));
+    fireEvent.click(retry);
+    expect(onRemove).toHaveBeenCalledWith("local_1");
+    expect(onRetry).toHaveBeenCalledWith("local_3");
+  });
+});

--- a/tests/desktop/attachment-preview-row.test.tsx
+++ b/tests/desktop/attachment-preview-row.test.tsx
@@ -10,7 +10,7 @@ function item(index: number, overrides: Partial<LocalConversationAttachment> = {
   return {
     localId: `local_${index}`,
     uploadId: `upload_${index}`,
-    uploadPath: `uploads/desktop-chat/upload_${index}-file-${index}.txt`,
+    uploadPath: `temporary/desktop-chat/upload_${index}-file-${index}.txt`,
     file: new File(["x"], `file-${index}.txt`, { type: "text/plain" }),
     status: "ready",
     ...overrides,

--- a/tests/desktop/chat-tab-render.test.tsx
+++ b/tests/desktop/chat-tab-render.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ChatTab from "../../desktop/src/renderer/src/features/chat/ChatTab";
 import { useBoard } from "../../desktop/src/renderer/src/stores/board";
 import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 import { useHermesChat } from "../../desktop/src/renderer/src/stores/hermes-chat";
 import { useProjectView } from "../../desktop/src/renderer/src/stores/project-view";
 import { useProjectWorkspaces } from "../../desktop/src/renderer/src/stores/project-workspaces";
@@ -89,6 +90,14 @@ describe("ChatTab", () => {
     useProjectView.setState({ entries: {}, runtimeScope: null });
     useProjectWorkspaces.setState({ entries: {} });
     useTabs.setState({ tabs: [], activeTabId: null });
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      authGeneration: 1,
+      api: null,
+    });
     Object.defineProperty(window, "operator", {
       configurable: true,
       value: {
@@ -184,5 +193,63 @@ describe("ChatTab", () => {
 
     expect(screen.queryByTestId("thread-view")).toBeNull();
     expect(screen.getByText("hello")).toBeTruthy();
+  });
+
+  it("previews pasted files horizontally, uploads on Send, and sends Hermes readable paths", async () => {
+    const send = vi.fn();
+    const putBytes = vi.fn(async (path: string, file: File) => ({
+      ok: true,
+      path: decodeURIComponent(path.split("path=")[1] ?? ""),
+      size: file.size,
+    }));
+    useHermesChat.setState({ messages: [], status: "idle", send, abort: vi.fn() });
+    useConnection.setState({ api: { putBytes } as never });
+    render(<React.StrictMode><ChatTab /></React.StrictMode>);
+
+    const pane = screen.getByRole("region", { name: "Hermes conversation" });
+    const pasted = new File(["screen"], "screen.png", { type: "image/png" });
+    fireEvent.paste(pane, { clipboardData: { files: [pasted] } });
+
+    expect(await screen.findByRole("button", { name: "Remove screen.png" })).toBeTruthy();
+    const previewRow = screen.getByRole("group", { name: "Attachments" });
+    expect(previewRow.className).toContain("overflow-x-auto");
+    const input = screen.getByLabelText("Do anything");
+    fireEvent.change(input, { target: { value: "Review this screenshot" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => expect(putBytes).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(send).toHaveBeenCalledWith(expect.stringMatching(
+      /^Review this screenshot\n\nAttached files[\s\S]*~\/uploads\/desktop-chat\/[A-Za-z0-9]+-screen\.png \(\/home\/matrix\/home\/uploads\/desktop-chat\/[A-Za-z0-9]+-screen\.png\)$/,
+    )));
+    expect(screen.queryByRole("button", { name: "Remove screen.png" })).toBeNull();
+  });
+
+  it("does not intercept a text-only drop in Chat", () => {
+    useHermesChat.setState({ messages: [], status: "idle", send: vi.fn(), abort: vi.fn() });
+    render(<ChatTab />);
+
+    const pane = screen.getByRole("region", { name: "Hermes conversation" });
+    const drop = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(drop, "dataTransfer", {
+      value: { items: [{ kind: "string" }], files: [] },
+    });
+    pane.dispatchEvent(drop);
+
+    expect(drop.defaultPrevented).toBe(false);
+    expect(screen.queryByRole("group", { name: "Attachments" })).toBeNull();
+  });
+
+  it("retains a failed Chat preview instead of sending", async () => {
+    const send = vi.fn();
+    useHermesChat.setState({ messages: [], status: "idle", send, abort: vi.fn() });
+    useConnection.setState({ api: { putBytes: vi.fn().mockRejectedValue(new Error("offline")) } as never });
+    render(<ChatTab />);
+    const pane = screen.getByRole("region", { name: "Hermes conversation" });
+    fireEvent.drop(pane, { dataTransfer: { files: [new File(["x"], "notes.txt", { type: "text/plain" })] } });
+    fireEvent.click(await screen.findByRole("button", { name: "Send" }));
+
+    expect(await screen.findByText("Upload failed. Try again.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry notes.txt" })).toBeTruthy();
+    expect(send).not.toHaveBeenCalled();
   });
 });

--- a/tests/desktop/chat-tab-render.test.tsx
+++ b/tests/desktop/chat-tab-render.test.tsx
@@ -219,7 +219,7 @@ describe("ChatTab", () => {
 
     await waitFor(() => expect(putBytes).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(send).toHaveBeenCalledWith(expect.stringMatching(
-      /^Review this screenshot\n\nAttached files[\s\S]*~\/uploads\/desktop-chat\/[A-Za-z0-9]+-screen\.png \(\/home\/matrix\/home\/uploads\/desktop-chat\/[A-Za-z0-9]+-screen\.png\)$/,
+      /^Review this screenshot\n\nAttached files[\s\S]*~\/temporary\/desktop-chat\/[A-Za-z0-9]+-screen\.png \(\/home\/matrix\/home\/temporary\/desktop-chat\/[A-Za-z0-9]+-screen\.png\)$/,
     )));
     expect(screen.queryByRole("button", { name: "Remove screen.png" })).toBeNull();
   });

--- a/tests/desktop/chat-tab.test.ts
+++ b/tests/desktop/chat-tab.test.ts
@@ -12,4 +12,9 @@ describe("canSubmitChatDraft", () => {
     expect(canSubmitChatDraft("", "idle")).toBe(false);
     expect(canSubmitChatDraft("   ", "idle")).toBe(false);
   });
+
+  it("allows attachment-only drafts while Hermes is idle", () => {
+    expect(canSubmitChatDraft("", "idle", 1)).toBe(true);
+    expect(canSubmitChatDraft("", "thinking", 1)).toBe(false);
+  });
 });

--- a/tests/desktop/coding-agent-chat-transcript.test.tsx
+++ b/tests/desktop/coding-agent-chat-transcript.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentThreadEvent, AgentThreadSnapshot } from "@matrix-os/contracts";
 import { AgentConversationView } from "../../desktop/src/renderer/src/features/coding-agents/AgentConversationView";
 import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 
 function snapshot(events: AgentThreadEvent[], threadOverrides: Record<string, unknown> = {}): AgentThreadSnapshot {
   return {
@@ -77,6 +78,14 @@ describe("AgentConversationView transcript", () => {
     }
     globalThis.ResizeObserver = MockResizeObserver as typeof ResizeObserver;
     useCodingAgentWorkspace.setState({ turnStatus: "idle", turnError: null, turnThreadId: null });
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      authGeneration: 1,
+      api: null,
+    });
   });
 
   afterEach(cleanup);
@@ -249,6 +258,45 @@ describe("AgentConversationView transcript", () => {
 
     const input = screen.getByLabelText("Message conversation") as HTMLTextAreaElement;
     expect(input.maxLength).toBe(24_000);
+  });
+
+  it("uploads dropped files and sends a follow-up with existing structured refs", async () => {
+    const sendThreadMessage = vi.fn().mockResolvedValue(true);
+    const putBytes = vi.fn(async (path: string, file: File) => ({
+      ok: true,
+      path: decodeURIComponent(path.split("path=")[1] ?? ""),
+      size: file.size,
+    }));
+    useCodingAgentWorkspace.setState({ sendThreadMessage });
+    useConnection.setState({ api: { putBytes } as never });
+    render(
+      <AgentConversationView
+        status="ready"
+        snapshot={snapshot([], { status: "completed" })}
+        error={null}
+        canSendTurns
+      />,
+    );
+
+    const pane = screen.getByRole("region", { name: "Conversation Fix settings route" });
+    fireEvent.drop(pane, {
+      dataTransfer: { files: [new File(["context"], "context.txt", { type: "text/plain" })] },
+    });
+    const input = screen.getByLabelText("Message conversation");
+    fireEvent.change(input, { target: { value: "Continue with this context" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => expect(sendThreadMessage).toHaveBeenCalledWith({
+      threadId: "thread_alpha",
+      message: "Continue with this context",
+      attachments: [expect.objectContaining({
+        id: expect.stringMatching(/^desktop_upload_[A-Za-z0-9]+$/),
+        kind: "structured_ref",
+        label: "context.txt",
+        path: expect.stringMatching(/^uploads\/desktop-chat\/[A-Za-z0-9]+-context\.txt$/),
+      })],
+    }));
+    expect(screen.queryByRole("button", { name: "Remove context.txt" })).toBeNull();
   });
 
   it("clears an unsent draft when switching threads", () => {

--- a/tests/desktop/coding-agent-chat-transcript.test.tsx
+++ b/tests/desktop/coding-agent-chat-transcript.test.tsx
@@ -293,7 +293,7 @@ describe("AgentConversationView transcript", () => {
         id: expect.stringMatching(/^desktop_upload_[A-Za-z0-9]+$/),
         kind: "structured_ref",
         label: "context.txt",
-        path: expect.stringMatching(/^uploads\/desktop-chat\/[A-Za-z0-9]+-context\.txt$/),
+        path: expect.stringMatching(/^temporary\/desktop-chat\/[A-Za-z0-9]+-context\.txt$/),
       })],
     }));
     expect(screen.queryByRole("button", { name: "Remove context.txt" })).toBeNull();

--- a/tests/desktop/draft-chat-send.test.tsx
+++ b/tests/desktop/draft-chat-send.test.tsx
@@ -345,4 +345,40 @@ describe("draft chat implicit thread creation", () => {
     expect(screen.getByLabelText("Message new chat")).toBeTruthy();
     expect(useProjectView.getState().selectedThreadFor("matrix-os")).toBeNull();
   });
+
+  it("uploads dropped files and creates a project chat with existing structured refs", async () => {
+    const putBytes = vi.fn(async (path: string, file: File) => ({
+      ok: true,
+      path: decodeURIComponent(path.split("path=")[1] ?? ""),
+      size: file.size,
+    }));
+    useConnection.setState({ api: { putBytes } as never });
+    const { invoke } = mockOperator();
+    const composer = await openDraft();
+    const pane = screen.getByRole("region", { name: "New chat in Matrix OS" });
+    fireEvent.drop(pane, {
+      dataTransfer: { files: [new File(["context"], "context.txt", { type: "text/plain" })] },
+    });
+
+    expect(await screen.findByRole("button", { name: "Remove context.txt" })).toBeTruthy();
+    fireEvent.change(composer, { target: { value: "Use this context" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(
+        "runtime:create-thread",
+        expect.objectContaining({
+          prompt: "Use this context",
+          attachments: [expect.objectContaining({
+            id: expect.stringMatching(/^desktop_upload_[A-Za-z0-9]+$/),
+            kind: "structured_ref",
+            label: "context.txt",
+            path: expect.stringMatching(/^uploads\/desktop-chat\/[A-Za-z0-9]+-context\.txt$/),
+            mimeType: "text/plain",
+          })],
+        }),
+      );
+    });
+    expect(screen.queryByRole("button", { name: "Remove context.txt" })).toBeNull();
+  });
 });

--- a/tests/desktop/draft-chat-send.test.tsx
+++ b/tests/desktop/draft-chat-send.test.tsx
@@ -373,7 +373,7 @@ describe("draft chat implicit thread creation", () => {
             id: expect.stringMatching(/^desktop_upload_[A-Za-z0-9]+$/),
             kind: "structured_ref",
             label: "context.txt",
-            path: expect.stringMatching(/^uploads\/desktop-chat\/[A-Za-z0-9]+-context\.txt$/),
+            path: expect.stringMatching(/^temporary\/desktop-chat\/[A-Za-z0-9]+-context\.txt$/),
             mimeType: "text/plain",
           })],
         }),

--- a/tests/desktop/files-upload.test.tsx
+++ b/tests/desktop/files-upload.test.tsx
@@ -1,0 +1,233 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ComputerFileBrowser from "../../desktop/src/renderer/src/features/files/ComputerFileBrowser";
+import { createFileUploadController } from "../../desktop/src/renderer/src/features/files/file-upload-controller";
+import { AppError } from "../../desktop/src/renderer/src/lib/errors";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+describe("Files upload controller", () => {
+  it("uses the existing blob route, runs at most three uploads, and ignores stale-scope refreshes", async () => {
+    const calls = Array.from({ length: 4 }, () => deferred<{ path: string }>());
+    const putBytes = vi.fn((..._args: unknown[]) => calls[putBytes.mock.calls.length - 1]!.promise);
+    let scope = "primary|1";
+    const onUploaded = vi.fn();
+    const controller = createFileUploadController({
+      api: { putBytes } as never,
+      getScope: () => scope,
+      onUploaded,
+    });
+
+    const files = Array.from({ length: 4 }, (_, index) => new File([String(index)], `f${index}.txt`));
+    controller.enqueue(files, "projects");
+    expect(putBytes).toHaveBeenCalledTimes(3);
+    expect(putBytes).toHaveBeenNthCalledWith(
+      1,
+      "/api/files/blob?path=projects%2Ff0.txt",
+      files[0],
+      { "content-type": "application/octet-stream" },
+      { timeoutMs: 30_000 },
+    );
+
+    scope = "vm-2|2";
+    calls[0]!.resolve({ path: "projects/f0.txt" });
+    await waitFor(() => expect(putBytes).toHaveBeenCalledTimes(4));
+    calls.slice(1).forEach((call) => call.resolve({ path: "projects/done.txt" }));
+    await waitFor(() => expect(onUploaded).not.toHaveBeenCalled());
+    controller.dispose();
+  });
+
+  it("retains conflicts for Retry or Remove and never sends an overwrite flag", async () => {
+    const putBytes = vi.fn()
+      .mockRejectedValueOnce(new AppError("server", { detail: "file_exists" }))
+      .mockResolvedValueOnce({ path: "retry.txt" });
+    const rows = vi.fn();
+    const controller = createFileUploadController({
+      api: { putBytes } as never,
+      getScope: () => "primary|1",
+      onUploaded: vi.fn(),
+    });
+    controller.subscribe(rows);
+    controller.enqueue([new File(["x"], "retry.txt")], "");
+
+    await waitFor(() => expect(rows).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        name: "retry.txt",
+        status: "failed",
+        error: "A file with this name already exists.",
+      }),
+    ]));
+    expect(putBytes.mock.calls[0]?.[0]).not.toContain("force=");
+
+    const id = rows.mock.calls.at(-1)?.[0][0].id as string;
+    controller.retry(id);
+    await waitFor(() => expect(putBytes).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(rows).toHaveBeenLastCalledWith([]));
+
+    controller.enqueue([new File([new Uint8Array(10 * 1024 * 1024 + 1)], "remove.txt")], "");
+    const removeId = rows.mock.calls.at(-1)?.[0][0].id as string;
+    controller.remove(removeId);
+    expect(rows).toHaveBeenLastCalledWith([]);
+    controller.dispose();
+  });
+
+  it("rejects files larger than 10 MB without uploading them", () => {
+    const putBytes = vi.fn();
+    const rows = vi.fn();
+    const controller = createFileUploadController({
+      api: { putBytes } as never,
+      getScope: () => "primary|1",
+      onUploaded: vi.fn(),
+    });
+    controller.subscribe(rows);
+
+    controller.enqueue([new File([new Uint8Array(10 * 1024 * 1024 + 1)], "large.bin")], "");
+
+    expect(putBytes).not.toHaveBeenCalled();
+    expect(rows).toHaveBeenLastCalledWith([
+      expect.objectContaining({ status: "failed", error: "Files are limited to 10 MB." }),
+    ]);
+    controller.dispose();
+  });
+
+  it("ignores unsafe local filenames before constructing an upload path", () => {
+    const putBytes = vi.fn();
+    const controller = createFileUploadController({
+      api: { putBytes } as never,
+      getScope: () => "primary|1",
+      onUploaded: vi.fn(),
+    });
+
+    controller.enqueue([new File(["x"], "../escape.txt")], "projects");
+
+    expect(putBytes).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
+  it("caps upload-row subscribers", () => {
+    const controller = createFileUploadController({
+      api: { putBytes: vi.fn() } as never,
+      getScope: () => "primary|1",
+      onUploaded: vi.fn(),
+    });
+    Array.from({ length: 16 }, () => controller.subscribe(() => {}));
+
+    expect(() => controller.subscribe(() => {})).toThrow("upload subscribers unavailable");
+    controller.dispose();
+  });
+});
+
+describe("ComputerFileBrowser uploads", () => {
+  const get = vi.fn(async () => ({
+    entries: [{ name: "projects", type: "directory", modified: new Date().toISOString() }],
+  }));
+  const putBytes = vi.fn(async () => ({ path: "uploaded" }));
+
+  beforeEach(() => {
+    get.mockClear();
+    putBytes.mockClear();
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://app.matrix-os.com",
+      runtimeSlot: "primary",
+      authGeneration: 1,
+      api: { get, putBytes, baseUrl: "https://app.matrix-os.com" } as never,
+    });
+  });
+
+  afterEach(() => cleanup());
+
+  function renderBrowser(mode: "browse" | "folder-picker" = "browse") {
+    return render(<Tooltip.Provider><ComputerFileBrowser mode={mode} /></Tooltip.Provider>);
+  }
+
+  it("uploads a file dropped on a directory row to that directory", async () => {
+    renderBrowser();
+    const folder = await screen.findByRole("button", { name: "Open projects" });
+    const file = new File(["hello"], "notes.md", { type: "text/markdown" });
+    fireEvent.drop(folder, { dataTransfer: { files: [file] } });
+
+    await waitFor(() => expect(putBytes).toHaveBeenCalledWith(
+      "/api/files/blob?path=projects%2Fnotes.md",
+      file,
+      { "content-type": "text/markdown" },
+      { timeoutMs: 30_000 },
+    ));
+  });
+
+  it("uploads clipboard files to the current listing without intercepting text paste", async () => {
+    const { container } = renderBrowser();
+    await screen.findByRole("button", { name: "Open projects" });
+    const listing = container.querySelector("[data-files-listing]") as HTMLElement;
+    const file = new File(["clipboard"], "pasted.txt", { type: "text/plain" });
+    const filePaste = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(filePaste, "clipboardData", { value: { files: [file] } });
+    listing.dispatchEvent(filePaste);
+
+    await waitFor(() => expect(putBytes).toHaveBeenCalledWith(
+      "/api/files/blob?path=pasted.txt",
+      file,
+      { "content-type": "text/plain" },
+      { timeoutMs: 30_000 },
+    ));
+    expect(filePaste.defaultPrevented).toBe(true);
+
+    const textPaste = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(textPaste, "clipboardData", { value: { files: [] } });
+    listing.dispatchEvent(textPaste);
+    expect(textPaste.defaultPrevented).toBe(false);
+  });
+
+  it("keeps nested drag depth stable and uploads to the current listing", async () => {
+    const { container } = renderBrowser();
+    await screen.findByRole("button", { name: "Open projects" });
+    const listing = container.querySelector("[data-files-listing]") as HTMLElement;
+    const child = screen.getByRole("button", { name: "Open projects" });
+    const file = new File(["x"], "root.txt");
+    const transfer = { items: [{ kind: "file", getAsFile: () => file }], files: [file] };
+    fireEvent.dragEnter(listing, { dataTransfer: transfer });
+    fireEvent.dragEnter(child, { dataTransfer: transfer });
+    fireEvent.dragLeave(child);
+    expect(screen.getByText("Drop files to upload")).toBeTruthy();
+    fireEvent.drop(listing, { dataTransfer: transfer });
+    await waitFor(() => expect(putBytes).toHaveBeenCalledWith(
+      "/api/files/blob?path=root.txt",
+      expect.any(File),
+      { "content-type": "application/octet-stream" },
+      { timeoutMs: 30_000 },
+    ));
+  });
+
+  it("does not intercept text-only drag and drop in the file listing", async () => {
+    const { container } = renderBrowser();
+    await screen.findByRole("button", { name: "Open projects" });
+    const listing = container.querySelector("[data-files-listing]") as HTMLElement;
+    const transfer = { items: [{ kind: "string" }], files: [] };
+
+    expect(fireEvent.dragEnter(listing, { dataTransfer: transfer })).toBe(true);
+    expect(fireEvent.drop(listing, { dataTransfer: transfer })).toBe(true);
+    expect(screen.queryByText("Drop files to upload")).toBeNull();
+    expect(putBytes).not.toHaveBeenCalled();
+  });
+
+  it("does not expose upload controls or drop/paste behavior in folder-picker mode", async () => {
+    const { container } = renderBrowser("folder-picker");
+    await screen.findByRole("button", { name: "Open projects" });
+    expect(screen.queryByRole("button", { name: "Upload files" })).toBeNull();
+    const listing = container.querySelector("[data-files-listing]") as HTMLElement;
+    fireEvent.drop(listing, { dataTransfer: { files: [new File(["x"], "no.txt")] } });
+    fireEvent.paste(listing, { clipboardData: { files: [new File(["x"], "no-paste.txt")] } });
+    expect(putBytes).not.toHaveBeenCalled();
+  });
+});

--- a/tests/desktop/header-injection.test.ts
+++ b/tests/desktop/header-injection.test.ts
@@ -62,6 +62,7 @@ describe("installGatewayCors", () => {
     expect(res.responseHeaders?.["Access-Control-Allow-Origin"]).toEqual(["http://localhost:5173"]);
     expect(res.responseHeaders?.["Access-Control-Allow-Headers"]?.[0]).toContain("Authorization");
     expect(res.responseHeaders?.["Access-Control-Allow-Headers"]?.[0]).toContain("x-runtime-slot");
+    expect(res.responseHeaders?.["Access-Control-Allow-Headers"]?.[0]).toContain("X-Matrix-Filename");
     expect(res.responseHeaders?.["Access-Control-Allow-Credentials"]).toEqual(["true"]);
     expect(res.responseHeaders?.["content-type"]).toEqual(["application/json"]);
   });

--- a/tests/desktop/local-attachment-controller.test.ts
+++ b/tests/desktop/local-attachment-controller.test.ts
@@ -100,30 +100,30 @@ describe("local Desktop attachment controller", () => {
 
     const upload = controller.uploadAll();
     await vi.waitFor(() => expect(putBytes).toHaveBeenCalledTimes(3));
-    resolvers.get("second.txt")?.({ ok: true, path: "uploads/desktop-chat/stable_1-second.txt", size: 1 });
+    resolvers.get("second.txt")?.({ ok: true, path: "temporary/desktop-chat/stable_1-second.txt", size: 1 });
     await vi.waitFor(() => expect(putBytes).toHaveBeenCalledTimes(4));
-    resolvers.get("fourth.txt")?.({ ok: true, path: "uploads/desktop-chat/stable_3-fourth.txt", size: 1 });
-    resolvers.get("third.txt")?.({ ok: true, path: "uploads/desktop-chat/stable_2-third.txt", size: 1 });
-    resolvers.get("first.txt")?.({ ok: true, path: "uploads/desktop-chat/stable_0-first.txt", size: 1 });
+    resolvers.get("fourth.txt")?.({ ok: true, path: "temporary/desktop-chat/stable_3-fourth.txt", size: 1 });
+    resolvers.get("third.txt")?.({ ok: true, path: "temporary/desktop-chat/stable_2-third.txt", size: 1 });
+    resolvers.get("first.txt")?.({ ok: true, path: "temporary/desktop-chat/stable_0-first.txt", size: 1 });
 
     await expect(upload).resolves.toEqual({
       ok: true,
       paths: [
-        "uploads/desktop-chat/stable_0-first.txt",
-        "uploads/desktop-chat/stable_1-second.txt",
-        "uploads/desktop-chat/stable_2-third.txt",
-        "uploads/desktop-chat/stable_3-fourth.txt",
+        "temporary/desktop-chat/stable_0-first.txt",
+        "temporary/desktop-chat/stable_1-second.txt",
+        "temporary/desktop-chat/stable_2-third.txt",
+        "temporary/desktop-chat/stable_3-fourth.txt",
       ],
       attachments: [
-        expect.objectContaining({ id: "desktop_upload_stable_0", kind: "structured_ref", label: "first.txt", path: "uploads/desktop-chat/stable_0-first.txt" }),
-        expect.objectContaining({ id: "desktop_upload_stable_1", kind: "structured_ref", label: "second.txt", path: "uploads/desktop-chat/stable_1-second.txt" }),
-        expect.objectContaining({ id: "desktop_upload_stable_2", kind: "structured_ref", label: "third.txt", path: "uploads/desktop-chat/stable_2-third.txt" }),
-        expect.objectContaining({ id: "desktop_upload_stable_3", kind: "structured_ref", label: "fourth.txt", path: "uploads/desktop-chat/stable_3-fourth.txt" }),
+        expect.objectContaining({ id: "desktop_upload_stable_0", kind: "structured_ref", label: "first.txt", path: "temporary/desktop-chat/stable_0-first.txt" }),
+        expect.objectContaining({ id: "desktop_upload_stable_1", kind: "structured_ref", label: "second.txt", path: "temporary/desktop-chat/stable_1-second.txt" }),
+        expect.objectContaining({ id: "desktop_upload_stable_2", kind: "structured_ref", label: "third.txt", path: "temporary/desktop-chat/stable_2-third.txt" }),
+        expect.objectContaining({ id: "desktop_upload_stable_3", kind: "structured_ref", label: "fourth.txt", path: "temporary/desktop-chat/stable_3-fourth.txt" }),
       ],
     });
     expect(putBytes).toHaveBeenNthCalledWith(
       1,
-      "/api/files/blob?path=uploads%2Fdesktop-chat%2Fstable_0-first.txt",
+      "/api/files/blob?path=temporary%2Fdesktop-chat%2Fstable_0-first.txt",
       expect.any(File),
       { "content-type": "text/plain" },
       { timeoutMs: 30_000 },
@@ -153,12 +153,12 @@ describe("local Desktop attachment controller", () => {
     expect(controller.getSnapshot().map((item) => item.file.name)).toEqual(["submitted.txt"]);
     resolveUpload({
       ok: true,
-      path: "uploads/desktop-chat/locked_0-submitted.txt",
+      path: "temporary/desktop-chat/locked_0-submitted.txt",
       size: 1,
     });
     await expect(upload).resolves.toMatchObject({
       ok: true,
-      paths: ["uploads/desktop-chat/locked_0-submitted.txt"],
+      paths: ["temporary/desktop-chat/locked_0-submitted.txt"],
     });
   });
 
@@ -166,7 +166,7 @@ describe("local Desktop attachment controller", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const putBytes = vi.fn()
       .mockRejectedValueOnce(new Error("offline"))
-      .mockResolvedValueOnce({ ok: true, path: "uploads/desktop-chat/stable_retry-retry.txt", size: 1 });
+      .mockResolvedValueOnce({ ok: true, path: "temporary/desktop-chat/stable_retry-retry.txt", size: 1 });
     const controller = createLocalAttachmentController({
       api: { putBytes } as never,
       createId: () => "stable_retry",
@@ -185,11 +185,11 @@ describe("local Desktop attachment controller", () => {
   });
 
   it("appends both owner-readable path forms to the Hermes prompt", () => {
-    expect(appendHermesAttachmentPaths("Review these", ["uploads/desktop-chat/a.png", "uploads/desktop-chat/b.txt"])).toBe(
+    expect(appendHermesAttachmentPaths("Review these", ["temporary/desktop-chat/a.png", "temporary/desktop-chat/b.txt"])).toBe(
       "Review these\n\nAttached files (available on your Matrix computer):\n"
-      + "- ~/uploads/desktop-chat/a.png (/home/matrix/home/uploads/desktop-chat/a.png)\n"
-      + "- ~/uploads/desktop-chat/b.txt (/home/matrix/home/uploads/desktop-chat/b.txt)",
+      + "- ~/temporary/desktop-chat/a.png (/home/matrix/home/temporary/desktop-chat/a.png)\n"
+      + "- ~/temporary/desktop-chat/b.txt (/home/matrix/home/temporary/desktop-chat/b.txt)",
     );
-    expect(appendHermesAttachmentPaths("", ["uploads/desktop-chat/a.png"])).toContain("Please inspect the attached files.");
+    expect(appendHermesAttachmentPaths("", ["temporary/desktop-chat/a.png"])).toContain("Please inspect the attached files.");
   });
 });

--- a/tests/desktop/local-attachment-controller.test.ts
+++ b/tests/desktop/local-attachment-controller.test.ts
@@ -130,7 +130,40 @@ describe("local Desktop attachment controller", () => {
     );
   });
 
+  it("freezes attachment mutations while the submitted batch is uploading", async () => {
+    let resolveUpload!: (value: { ok: true; path: string; size: number }) => void;
+    const putBytes = vi.fn(() => new Promise((resolve) => {
+      resolveUpload = resolve;
+    }));
+    const controller = createLocalAttachmentController({
+      api: { putBytes } as never,
+      createId: (() => {
+        let next = 0;
+        return () => `locked_${next++}`;
+      })(),
+    });
+    controller.add([file("submitted.txt", 1, "text/plain")]);
+    const submittedId = controller.getSnapshot()[0]!.localId;
+
+    const upload = controller.uploadAll();
+    await vi.waitFor(() => expect(putBytes).toHaveBeenCalledTimes(1));
+    controller.add([file("late.txt", 1, "text/plain")]);
+    controller.remove(submittedId);
+
+    expect(controller.getSnapshot().map((item) => item.file.name)).toEqual(["submitted.txt"]);
+    resolveUpload({
+      ok: true,
+      path: "uploads/desktop-chat/locked_0-submitted.txt",
+      size: 1,
+    });
+    await expect(upload).resolves.toMatchObject({
+      ok: true,
+      paths: ["uploads/desktop-chat/locked_0-submitted.txt"],
+    });
+  });
+
   it("retains failed previews for Retry and reuses the stable destination", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const putBytes = vi.fn()
       .mockRejectedValueOnce(new Error("offline"))
       .mockResolvedValueOnce({ ok: true, path: "uploads/desktop-chat/stable_retry-retry.txt", size: 1 });
@@ -147,6 +180,7 @@ describe("local Desktop attachment controller", () => {
 
     expect(putBytes).toHaveBeenCalledTimes(2);
     expect(putBytes.mock.calls[1]?.[0]).toBe(putBytes.mock.calls[0]?.[0]);
+    expect(warn).toHaveBeenCalledWith("[desktop attachments] upload failed:", "offline");
     await expect(controller.uploadAll()).resolves.toMatchObject({ ok: true });
   });
 

--- a/tests/desktop/local-attachment-controller.test.ts
+++ b/tests/desktop/local-attachment-controller.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  appendHermesAttachmentPaths,
+  createLocalAttachmentController,
+} from "../../desktop/src/renderer/src/features/chat/attachments/local-attachment-controller";
+
+const MiB = 1024 * 1024;
+
+function file(name: string, size: number, type = "application/octet-stream"): File {
+  return new File([new Uint8Array(size)], name, { type });
+}
+
+describe("local Desktop attachment controller", () => {
+  const createObjectURL = vi.fn((value: Blob) => `blob:preview/${value.size}`);
+  const revokeObjectURL = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("URL", { ...URL, createObjectURL, revokeObjectURL });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("accepts exactly 10 MiB, rejects one byte over, caps eight, and preserves order", () => {
+    const controller = createLocalAttachmentController({ api: {} as never });
+    controller.add([
+      file("exact.bin", 10 * MiB),
+      file("too-large.bin", 10 * MiB + 1),
+      ...Array.from({ length: 8 }, (_, index) => file(`item-${index}.txt`, 1, "text/plain")),
+    ]);
+
+    const items = controller.getSnapshot();
+    expect(items).toHaveLength(8);
+    expect(items.map((item) => item.file.name)).toEqual([
+      "exact.bin",
+      "too-large.bin",
+      "item-0.txt",
+      "item-1.txt",
+      "item-2.txt",
+      "item-3.txt",
+      "item-4.txt",
+      "item-5.txt",
+    ]);
+    expect(items[0]?.status).toBe("ready");
+    expect(items[1]).toMatchObject({ status: "failed", error: "Files are limited to 10 MB." });
+  });
+
+  it("creates previews only for safe raster images and revokes them on remove and dispose", () => {
+    const controller = createLocalAttachmentController({ api: {} as never });
+    controller.add([
+      file("screen.png", 8, "image/png"),
+      file("vector.svg", 8, "image/svg+xml"),
+      file("notes.txt", 8, "text/plain"),
+    ]);
+    const [png, svg, notes] = controller.getSnapshot();
+
+    expect(png?.previewUrl).toBe("blob:preview/8");
+    expect(svg?.previewUrl).toBeUndefined();
+    expect(notes?.previewUrl).toBeUndefined();
+    controller.remove(png!.localId);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:preview/8");
+
+    controller.add([file("second.webp", 4, "image/webp")]);
+    controller.dispose();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:preview/4");
+  });
+
+  it("rejects folder entries and unsafe filenames", () => {
+    const controller = createLocalAttachmentController({ api: {} as never });
+    const folderFile = file("inside.txt", 1, "text/plain");
+    Object.defineProperty(folderFile, "webkitRelativePath", { value: "folder/inside.txt" });
+
+    controller.add([folderFile, file("../secret.txt", 1, "text/plain")]);
+
+    expect(controller.getSnapshot()).toEqual([]);
+  });
+
+  it("uploads at most three files concurrently, preserves order, and returns structured refs", async () => {
+    const resolvers = new Map<string, (value: unknown) => void>();
+    const putBytes = vi.fn((_path: string, uploaded: File) => new Promise((resolve) => {
+      resolvers.set(uploaded.name, resolve);
+    }));
+    const controller = createLocalAttachmentController({
+      api: { putBytes } as never,
+      createId: (() => {
+        let next = 0;
+        return () => `stable_${next++}`;
+      })(),
+    });
+    controller.add([
+      file("first.txt", 1, "text/plain"),
+      file("second.txt", 1, "text/plain"),
+      file("third.txt", 1, "text/plain"),
+      file("fourth.txt", 1, "text/plain"),
+    ]);
+
+    const upload = controller.uploadAll();
+    await vi.waitFor(() => expect(putBytes).toHaveBeenCalledTimes(3));
+    resolvers.get("second.txt")?.({ ok: true, path: "uploads/desktop-chat/stable_1-second.txt", size: 1 });
+    await vi.waitFor(() => expect(putBytes).toHaveBeenCalledTimes(4));
+    resolvers.get("fourth.txt")?.({ ok: true, path: "uploads/desktop-chat/stable_3-fourth.txt", size: 1 });
+    resolvers.get("third.txt")?.({ ok: true, path: "uploads/desktop-chat/stable_2-third.txt", size: 1 });
+    resolvers.get("first.txt")?.({ ok: true, path: "uploads/desktop-chat/stable_0-first.txt", size: 1 });
+
+    await expect(upload).resolves.toEqual({
+      ok: true,
+      paths: [
+        "uploads/desktop-chat/stable_0-first.txt",
+        "uploads/desktop-chat/stable_1-second.txt",
+        "uploads/desktop-chat/stable_2-third.txt",
+        "uploads/desktop-chat/stable_3-fourth.txt",
+      ],
+      attachments: [
+        expect.objectContaining({ id: "desktop_upload_stable_0", kind: "structured_ref", label: "first.txt", path: "uploads/desktop-chat/stable_0-first.txt" }),
+        expect.objectContaining({ id: "desktop_upload_stable_1", kind: "structured_ref", label: "second.txt", path: "uploads/desktop-chat/stable_1-second.txt" }),
+        expect.objectContaining({ id: "desktop_upload_stable_2", kind: "structured_ref", label: "third.txt", path: "uploads/desktop-chat/stable_2-third.txt" }),
+        expect.objectContaining({ id: "desktop_upload_stable_3", kind: "structured_ref", label: "fourth.txt", path: "uploads/desktop-chat/stable_3-fourth.txt" }),
+      ],
+    });
+    expect(putBytes).toHaveBeenNthCalledWith(
+      1,
+      "/api/files/blob?path=uploads%2Fdesktop-chat%2Fstable_0-first.txt",
+      expect.any(File),
+      { "content-type": "text/plain" },
+      { timeoutMs: 30_000 },
+    );
+  });
+
+  it("retains failed previews for Retry and reuses the stable destination", async () => {
+    const putBytes = vi.fn()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce({ ok: true, path: "uploads/desktop-chat/stable_retry-retry.txt", size: 1 });
+    const controller = createLocalAttachmentController({
+      api: { putBytes } as never,
+      createId: () => "stable_retry",
+    });
+    controller.add([file("retry.txt", 1, "text/plain")]);
+    const id = controller.getSnapshot()[0]!.localId;
+
+    await expect(controller.uploadAll()).resolves.toEqual({ ok: false });
+    expect(controller.getSnapshot()[0]).toMatchObject({ status: "failed", error: "Upload failed. Try again." });
+    await controller.retry(id);
+
+    expect(putBytes).toHaveBeenCalledTimes(2);
+    expect(putBytes.mock.calls[1]?.[0]).toBe(putBytes.mock.calls[0]?.[0]);
+    await expect(controller.uploadAll()).resolves.toMatchObject({ ok: true });
+  });
+
+  it("appends both owner-readable path forms to the Hermes prompt", () => {
+    expect(appendHermesAttachmentPaths("Review these", ["uploads/desktop-chat/a.png", "uploads/desktop-chat/b.txt"])).toBe(
+      "Review these\n\nAttached files (available on your Matrix computer):\n"
+      + "- ~/uploads/desktop-chat/a.png (/home/matrix/home/uploads/desktop-chat/a.png)\n"
+      + "- ~/uploads/desktop-chat/b.txt (/home/matrix/home/uploads/desktop-chat/b.txt)",
+    );
+    expect(appendHermesAttachmentPaths("", ["uploads/desktop-chat/a.png"])).toContain("Please inspect the attached files.");
+  });
+});

--- a/tests/desktop/panels-prompt-input.test.tsx
+++ b/tests/desktop/panels-prompt-input.test.tsx
@@ -35,4 +35,18 @@ describe("PromptInput actions", () => {
     expect(onAbort).toHaveBeenCalledTimes(1);
     expect(screen.queryByRole("button", { name: "Send" })).toBeNull();
   });
+
+  it("hides the textarea scrollbar until the composer reaches its height cap", () => {
+    const view = render(
+      <PromptInput value="short" onChange={() => {}} onSubmit={() => {}} busy={false} />,
+    );
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea.style.overflowY).toBe("hidden");
+
+    Object.defineProperty(textarea, "scrollHeight", { configurable: true, value: 300 });
+    view.rerender(
+      <PromptInput value="a longer draft" onChange={() => {}} onSubmit={() => {}} busy={false} />,
+    );
+    expect(textarea.style.overflowY).toBe("auto");
+  });
 });

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -229,6 +229,22 @@ describe("TerminalView session switching", () => {
     expect(postBytes).toHaveBeenCalledTimes(1);
   });
 
+  it("logs terminal image upload failures while keeping the user error generic", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const postBytes = vi.fn().mockRejectedValue(new Error("preview gateway offline"));
+    useConnection.setState({ api: { postBytes } as never });
+    const { container } = render(<TerminalView sessionName="alpha" />);
+    const host = container.querySelector("[data-terminal-viewport]") as HTMLElement;
+
+    fireEvent.paste(host, {
+      clipboardData: { files: [new File(["png"], "failed.png", { type: "image/png" })] },
+    });
+
+    expect(await screen.findByText("Image paste failed. Try again.")).toBeTruthy();
+    expect(warn).toHaveBeenCalledWith("[terminal] image paste failed:", "preview gateway offline");
+    expect(attachmentWrite).not.toHaveBeenCalled();
+  });
+
   it("shows a safe error and does not upload an image over 10 MB", async () => {
     const postBytes = vi.fn();
     useConnection.setState({ api: { postBytes } as never });

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -167,8 +167,13 @@ describe("TerminalView session switching", () => {
       "/home/matrix/home/projects/.matrix-terminal-pastes/first.png",
       "/home/matrix/home/projects/.matrix-terminal-pastes/second.png",
     ];
-    let call = 0;
-    const postBytes = vi.fn(async () => ({ terminalPath: paths[call++] }));
+    let resolveFirst!: (value: { terminalPath: string }) => void;
+    let resolveSecond!: (value: { terminalPath: string }) => void;
+    const firstUpload = new Promise<{ terminalPath: string }>((resolve) => { resolveFirst = resolve; });
+    const secondUpload = new Promise<{ terminalPath: string }>((resolve) => { resolveSecond = resolve; });
+    const postBytes = vi.fn()
+      .mockReturnValueOnce(firstUpload)
+      .mockReturnValueOnce(secondUpload);
     useConnection.setState({ api: { postBytes } as never });
     const { container } = render(<TerminalView sessionName="alpha" />);
     const host = container.querySelector("[data-terminal-viewport]") as HTMLElement;
@@ -177,7 +182,11 @@ describe("TerminalView session switching", () => {
 
     fireEvent.paste(host, { clipboardData: { files: [first, second] } });
 
+    // Multiple clipboard images start together, while Promise.all preserves
+    // their original clipboard order even when the second upload settles first.
     await waitFor(() => expect(postBytes).toHaveBeenCalledTimes(2));
+    resolveSecond({ terminalPath: paths[1]! });
+    resolveFirst({ terminalPath: paths[0]! });
     expect(postBytes).toHaveBeenNthCalledWith(
       1,
       "/api/terminal/sessions/alpha/paste-assets",

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -1,13 +1,19 @@
 // @vitest-environment jsdom
 import React from "react";
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ShellSocketEvents } from "@desktop/renderer/src/lib/shell-socket";
 import TerminalView from "@desktop/renderer/src/features/terminal/TerminalView";
 import { getThemeTerminalColors } from "@desktop/renderer/src/design/themes";
 import { useAppearance } from "@desktop/renderer/src/stores/appearance";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+import {
+  bracketTerminalPaths,
+  terminalPasteFiles,
+} from "@desktop/renderer/src/features/terminal/terminal-rich-paste";
 
 const attachMock = vi.fn();
+const attachmentWrite = vi.fn();
 const { createdTerminals } = vi.hoisted(() => ({
   createdTerminals: [] as Array<{ options: { theme?: unknown } }>,
 }));
@@ -67,8 +73,17 @@ describe("TerminalView session switching", () => {
     attachMock.mockReset();
     attachMock.mockImplementation((_sessionName: string, _events: ShellSocketEvents) => ({
       resize: vi.fn(),
-      write: vi.fn(),
+      write: attachmentWrite,
     }));
+    attachmentWrite.mockReset();
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      authGeneration: 1,
+      api: null,
+    });
     vi.stubGlobal(
       "ResizeObserver",
       class FakeResizeObserver {
@@ -132,5 +147,89 @@ describe("TerminalView session switching", () => {
     expect(terminal.options.theme).toMatchObject({
       background: getThemeTerminalColors("dracula", "dark").background,
     });
+  });
+
+  it("filters terminal files to supported image formats and strips nested paste markers", () => {
+    const png = new File(["png"], "screen.png", { type: "image/png" });
+    const extensionFallback = new File(["jpeg"], "photo.JPG", { type: "" });
+    const text = new File(["text"], "notes.txt", { type: "text/plain" });
+    expect(terminalPasteFiles({ files: [png, extensionFallback, text] } as unknown as DataTransfer)).toEqual([
+      { file: png, mimeType: "image/png" },
+      { file: extensionFallback, mimeType: "image/jpeg" },
+    ]);
+    expect(bracketTerminalPaths(["/home/matrix/home/a\u001b[200~.png\u001b[201~"])).toBe(
+      "\u001b[200~/home/matrix/home/a.png\u001b[201~",
+    );
+  });
+
+  it("pastes uploaded images into the active terminal once, in order, without Enter", async () => {
+    const paths = [
+      "/home/matrix/home/projects/.matrix-terminal-pastes/first.png",
+      "/home/matrix/home/projects/.matrix-terminal-pastes/second.png",
+    ];
+    let call = 0;
+    const postBytes = vi.fn(async () => ({ terminalPath: paths[call++] }));
+    useConnection.setState({ api: { postBytes } as never });
+    const { container } = render(<TerminalView sessionName="alpha" />);
+    const host = container.querySelector("[data-terminal-viewport]") as HTMLElement;
+    const first = new File(["first"], "first.png", { type: "image/png" });
+    const second = new File(["second"], "second.png", { type: "image/png" });
+
+    fireEvent.paste(host, { clipboardData: { files: [first, second] } });
+
+    await waitFor(() => expect(postBytes).toHaveBeenCalledTimes(2));
+    expect(postBytes).toHaveBeenNthCalledWith(
+      1,
+      "/api/terminal/sessions/alpha/paste-assets",
+      first,
+      { "Content-Type": "image/png", "X-Matrix-Filename": "first.png" },
+      { timeoutMs: 30_000 },
+    );
+    await waitFor(() => expect(attachmentWrite).toHaveBeenCalledWith(
+      `\u001b[200~${paths.join(" ")}\u001b[201~`,
+    ));
+    expect(attachmentWrite).toHaveBeenCalledTimes(1);
+    expect(attachmentWrite.mock.calls[0]?.[0]).not.toMatch(/\r|\n/);
+  });
+
+  it("supports drop but leaves unsupported and inactive terminal paste untouched", async () => {
+    const postBytes = vi.fn(async () => ({ terminalPath: "/home/matrix/home/projects/drop.webp" }));
+    useConnection.setState({ api: { postBytes } as never });
+    const { container, rerender } = render(<TerminalView sessionName="alpha" />);
+    const host = container.querySelector("[data-terminal-viewport]") as HTMLElement;
+    const unsupported = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(unsupported, "clipboardData", {
+      value: { files: [new File(["text"], "notes.txt", { type: "text/plain" })] },
+    });
+    host.dispatchEvent(unsupported);
+    expect(unsupported.defaultPrevented).toBe(false);
+    expect(postBytes).not.toHaveBeenCalled();
+
+    fireEvent.drop(host, {
+      dataTransfer: { files: [new File(["webp"], "drop.webp", { type: "image/webp" })] },
+    });
+    await waitFor(() => expect(attachmentWrite).toHaveBeenCalledTimes(1));
+
+    rerender(<TerminalView sessionName="alpha" active={false} />);
+    const inactivePaste = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(inactivePaste, "clipboardData", {
+      value: { files: [new File(["png"], "inactive.png", { type: "image/png" })] },
+    });
+    host.dispatchEvent(inactivePaste);
+    expect(inactivePaste.defaultPrevented).toBe(false);
+    expect(postBytes).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a safe error and does not upload an image over 10 MB", async () => {
+    const postBytes = vi.fn();
+    useConnection.setState({ api: { postBytes } as never });
+    const { container } = render(<TerminalView sessionName="alpha" />);
+    const host = container.querySelector("[data-terminal-viewport]") as HTMLElement;
+    const large = new File([new Uint8Array(10 * 1024 * 1024 + 1)], "large.png", { type: "image/png" });
+    fireEvent.paste(host, { clipboardData: { files: [large] } });
+
+    expect(await screen.findByText("Images are limited to 10 MB.")).toBeTruthy();
+    expect(postBytes).not.toHaveBeenCalled();
+    expect(attachmentWrite).not.toHaveBeenCalled();
   });
 });

--- a/tests/gateway/shell-routes.test.ts
+++ b/tests/gateway/shell-routes.test.ts
@@ -274,7 +274,7 @@ describe("gateway shell routes", () => {
     expect(commandRunner.run).toHaveBeenCalledWith({ command: ["ls"], cwd: "projects/app" });
   });
 
-  it("uploads pasted terminal image assets into the project-local paste directory", async () => {
+  it("uploads pasted terminal image assets into the owner temporary directory", async () => {
     const root = await tempRoot();
     await mkdir(join(root, "projects", "app"), { recursive: true });
     const registry = {
@@ -305,7 +305,8 @@ describe("gateway shell routes", () => {
       size: PNG_BYTES.length,
       mimeType: "image/png",
     });
-    expect(body.path).toMatch(/^projects\/app\/\.matrix-terminal-pastes\/\d{4}-\d{2}-\d{2}\//);
+    expect(body.path).toMatch(/^temporary\/terminal-pastes\/\d{4}-\d{2}-\d{2}\//);
+    expect(body.path).not.toContain("projects/app");
     expect(body.path.endsWith(".png")).toBe(true);
     expect(body.terminalPath).toBe(join(root, body.path));
     await expect(readFile(body.terminalPath)).resolves.toEqual(Buffer.from(PNG_BYTES));


### PR DESCRIPTION
## Summary

- add bounded drag-and-drop, clipboard paste, and picker uploads to the Desktop Files browser
- add Codex-style horizontal previews, attachment-only sends, Retry, and Remove to Chat and Project Chat
- reuse the existing terminal paste-assets protocol for PNG, JPEG, GIF, and WebP paste/drop in every Desktop `TerminalView`
- store transient Chat and Project Chat uploads under `~/temporary/desktop-chat/`
- store transient Terminal paste assets under `~/temporary/terminal-pastes/<date>/`, independently of terminal cwd
- keep Files browser uploads in the user-selected directory

Linear: MAT-261

## Scope

This revision reuses the existing authenticated contracts without changing their request or response schemas:

- `PUT /api/files/blob`
- `POST /api/terminal/sessions/:name/paste-assets`

The only Gateway implementation change selects the owner-home temporary directory for Terminal paste assets. It does not change Gateway routes, authentication, validation, terminal session models, CLI behavior, or Mobile behavior.

Each file is limited to 10 MiB. Composer queues accept at most eight files, uploads are bounded to three concurrent requests, and all outbound requests have a 30-second timeout. Multi-image Terminal uploads start together while their pasted paths preserve the original clipboard order.

The submitted chat attachment batch is frozen while uploads are in flight. Add, Remove, Retry, and Clear mutations are ignored at the controller boundary during that interval, and the visible Retry/Remove controls are disabled while the composer submits.

## Tests

- focused attachment and Terminal regression suite: **10 files / 141 tests passed**
- workspace typecheck: passed
- diff pattern check: **0 violations** (repository warnings only)
- Desktop production build: passed
- `git diff --check`: passed
- repository-wide suite before the final assertion-only synchronization: **900 files passed / 21 failed / 3 skipped; 10,393 tests passed / 27 failed / 20 skipped**
- three failures were stale Desktop assertions for the old Chat upload directory; after updating them, the complete changed-surface suite above passed. The other 24 failures match the recorded repository baseline and remain outside this diff: dependency resolution, Codex socket/timeout, date-boundary, cloud-init fixture, workspace-provider, onboarding-tool, Zellij-prefix, and generated-shell timing failures.

## Preview validation

- [x] Build and deploy commit `eea84112f53530e3774b2a3c6b7537cebda42547` to the isolated `pr-1174` Preview Computer
- [x] Verify `/api/system/info` reports bundle `v2026.08.10-pr1174-eea8411` and the exact commit above
- [x] Exercise Files drag/drop and paste against the real Preview VPS
- [x] Exercise Chat and Project Chat preview, Remove, and Send against the real Preview VPS
- [x] Exercise standalone Terminal multi-image paste/drop and Inspector Terminal paste/drop against the real Preview VPS
- [x] Deploy and smoke-check review-fix head `e9dd8bca45a3e2027f1a0617a70c3dbe1fc912d4` as bundle `v2026.08.10-pr1174-e9dd8bc`
- [x] Deploy current head `ff5919104b387446fef467f02f47963b7c1ccf96` as bundle `v2026.08.10-pr1174-ff59191`; the Preview workflow reports `pr-1174` healthy on that exact version
- [x] Verify the new temporary path selection in the focused Desktop/Gateway regression suite

## Review/Monitoring

- The PR is Ready for review and is awaiting human review; do not merge yet.
- Current-head PR CI and Preview VPS deployment passed.
- The separately dispatched Desktop Canary Release passed for Linux x64, macOS x64, and macOS arm64, including macOS signature/notarization verification, DMG mount/launch smoke tests, and canary prerelease publication.
- [Greptile reviewed current head `ff5919104b387446fef467f02f47963b7c1ccf96` at 5/5](https://github.com/HamedMP/matrix-os/pull/1174#issuecomment-5237303841) with no blocking failure; all review threads are resolved.
- The previous full Gateway implementation is preserved on `codex/mat-261-full-gateway-backup` for audit only and is not part of this PR.

## Invariants

### Source of truth

- Owner files in Matrix home remain authoritative after the existing Gateway upload routes accept them.
- Pending Desktop previews are renderer-local, bounded, and invalidated on runtime or authentication changes.
- Existing coding-agent `structured_ref` attachments remain the only Project Chat attachment contract.

### Lock/transaction scope

- No database writes, locks, transactions, or shared persistence models are added.
- Upload requests complete before the associated Desktop send action; no network call is performed inside a database lock.
- The renderer-local attachment batch is snapshotted and mutation-locked only for the duration of `uploadAll()`.

### Acceptable orphan states

- A successfully uploaded Chat or Project Chat file may remain under `~/temporary/desktop-chat/` if a later send fails. It remains visible owner data, and a retry reuses the same reference.
- A successfully uploaded Terminal paste asset may remain under `~/temporary/terminal-pastes/` if a later paste or send fails.
- Automatic bounded cleanup is intentionally deferred to [MAT-269](https://linear.app/matrix-os/issue/MAT-269/add-bounded-cleanup-for-vps-temporary-attachments).

### Auth source of truth

- Existing Desktop trusted-core authorization injection and the Gateway request principal remain authoritative.
- Renderer-provided filenames and paths are validated as input only and are never trusted as an authorization identity.
- `X-Matrix-Filename` is added only to the Gateway-scoped Electron CORS allowlist; it grants no authority.

### Deferred scope

- Automatic age/count-based cleanup for `~/temporary/` is deferred to MAT-269.
- Ordinary non-image Terminal file drop remains unsupported by design.
- New session identifiers, provider-specific storage, CLI changes, Shell source changes, and Mobile changes are explicitly out of scope.
- Public documentation will be prepared as a separate site-repository PR after Preview validation is approved.
