### PR TITLE
feat(desktop): add Files move picker and drag

### DIFF
--- a/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
+++ b/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
@@ -345,7 +345,7 @@ export default function ComputerFileBrowser({
         : [path];
       const trashDisabled = selectedForAction.length > MAX_FILE_BATCH_SIZE || selectedForAction.some((selected) =>
         management.snapshot.pendingPaths.includes(selected) || !entriesByPath.get(selected)?.capabilities.canTrash);
-      const moveDisabled = selectedForAction.length < 1 || selectedForAction.length > 100 || selectedForAction.some((selected) =>
+      const moveDisabled = selectedForAction.length < 1 || selectedForAction.length > MAX_FILE_BATCH_SIZE || selectedForAction.some((selected) =>
         management.snapshot.pendingPaths.includes(selected) || !entriesByPath.get(selected)?.capabilities.canMove);
       return (
         <ManagedFileActionMenu

--- a/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
+++ b/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
@@ -30,6 +30,7 @@ import {
   measureGridColumns,
 } from "./browser-views";
 import { useFileManagement } from "./use-file-management";
+import { MoveFilesDialog } from "./MoveFilesDialog";
 import { useAuthoritativeListing, type BrowserListingStatus } from "./use-authoritative-listing";
 import { MAX_FILE_BATCH_SIZE, type FileSelectionPlatform } from "./file-selection";
 import { getKernelSocket } from "../../lib/kernel-wiring";
@@ -147,6 +148,9 @@ export default function ComputerFileBrowser({
     () => new Set(management.selection.selectedPaths),
     [management.selection.selectedPaths],
   );
+  const movablePaths = useMemo(() => renderedPaths.filter((path) =>
+    entriesByPath.get(path)?.capabilities.canMove && !management.snapshot.pendingPaths.includes(path)),
+  [entriesByPath, management.snapshot.pendingPaths, renderedPaths]);
   useEffect(() => management.reconcilePaths(renderedPaths), [management.reconcilePaths, renderedPaths]);
 
   const load = useCallback((path: string) => {
@@ -331,6 +335,7 @@ export default function ComputerFileBrowser({
             if (entry.type === "directory") navigate(path);
           }}
           onKeyDown={(event) => onEntryKeyDown(event, entry, path, index)}
+          {...(mode === "browse" ? management.move.entryDragProps(path, entry.type === "directory", movablePaths) : {})}
         />
       );
       if (mode === "folder-picker") return entryButton;
@@ -340,6 +345,8 @@ export default function ComputerFileBrowser({
         : [path];
       const trashDisabled = selectedForAction.length > MAX_FILE_BATCH_SIZE || selectedForAction.some((selected) =>
         management.snapshot.pendingPaths.includes(selected) || !entriesByPath.get(selected)?.capabilities.canTrash);
+      const moveDisabled = selectedForAction.length < 1 || selectedForAction.length > 100 || selectedForAction.some((selected) =>
+        management.snapshot.pendingPaths.includes(selected) || !entriesByPath.get(selected)?.capabilities.canMove);
       return (
         <ManagedFileActionMenu
           key={`${entry.type}:${path}`}
@@ -348,10 +355,12 @@ export default function ComputerFileBrowser({
           disabled={pending}
           selectedCount={management.selection.selectedPaths.length}
           canRename={entry.capabilities.canRename}
+          canMove={!moveDisabled}
           canTrash={!trashDisabled}
           onOpen={() => activateEntry(entry, path)}
           onOpenInEditor={onOpenInEditor && entry.type === "file" ? () => onOpenInEditor(path) : undefined}
           onRename={() => management.startRename(path, entry.name)}
+          onMove={() => management.move.requestMenuMove(selectedForAction)}
           onTrash={() => management.requestTrash(selectedForAction)}
           onMenuOpen={() => {
             if (!selectedPathSet.has(path)) {
@@ -405,6 +414,7 @@ export default function ComputerFileBrowser({
         onRefresh={() => void load(viewCurrentPath)}
         onNewFile={mode === "browse" && managementEnabled ? () => management.startCreate("file") : undefined}
         onNewFolder={mode === "browse" && managementEnabled ? () => management.startCreate("directory") : undefined}
+        dropHandlers={mode === "browse" ? management.move.dropHandlers : undefined}
       />
 
       <FileOperationNotice snapshot={management.snapshot} localNotice={management.localNotice} />
@@ -436,6 +446,7 @@ export default function ComputerFileBrowser({
         onCancel={management.cancelTrash}
         onConfirm={() => void management.confirmTrash()}
       />
+      <MoveFilesDialog controls={management.move} />
     </div>
   );
 }

--- a/desktop/src/renderer/src/features/files/FileActionMenu.tsx
+++ b/desktop/src/renderer/src/features/files/FileActionMenu.tsx
@@ -61,19 +61,21 @@ export function FileActionMenu({
 }
 
 export function ManagedFileActionMenu({
-  label, selected, disabled, selectedCount, canRename, canTrash,
-  onMenuOpen, onOpen, onOpenInEditor, onRename, onTrash, children,
+  label, selected, disabled, selectedCount, canRename, canMove, canTrash,
+  onMenuOpen, onOpen, onOpenInEditor, onRename, onMove, onTrash, children,
 }: {
   label: string;
   selected: boolean;
   disabled: boolean;
   selectedCount: number;
   canRename: boolean;
+  canMove: boolean;
   canTrash: boolean;
   onMenuOpen: () => void;
   onOpen: () => void;
   onOpenInEditor?: () => void;
   onRename: () => void;
+  onMove: () => void;
   onTrash: () => void;
   children: ReactNode;
 }) {
@@ -81,6 +83,7 @@ export function ManagedFileActionMenu({
     { label: "Open", onSelect: onOpen },
     ...(onOpenInEditor ? [{ label: "Open in Editor", onSelect: onOpenInEditor }] : []),
     { label: "Rename", disabled: selectedCount > 1 || disabled || !canRename, onSelect: onRename },
+    { label: "Move to…", disabled: !canMove, onSelect: onMove },
     { label: "Move to Trash", danger: true, disabled: !canTrash, onSelect: onTrash },
   ];
   return (

--- a/desktop/src/renderer/src/features/files/MoveFilesDialog.tsx
+++ b/desktop/src/renderer/src/features/files/MoveFilesDialog.tsx
@@ -9,10 +9,17 @@ import { isValidFileDropTarget } from "./file-drag";
 import type { FileMoveSession } from "./use-file-move";
 
 const NO_DIRECTORIES: BrowserEntry[] = [];
+const IGNORE_CLOSE = () => {};
+const INVALID_MOVE_REASON = {
+  source_missing: "This item is no longer available.",
+  protected: "This item is protected and cannot be moved.",
+  invalid_destination: "This item cannot be moved to that destination.",
+} as const;
 
 interface MoveDialogControls {
   session: FileMoveSession | null;
   cancelMove: () => void;
+  chooseCandidate: (destination: string) => void;
   chooseDestination: (destination: string) => void;
   setApplyToRemaining: (apply: boolean) => void;
   chooseConflict: (source: string, resolution: "keep-both" | "skip") => void;
@@ -32,6 +39,7 @@ function ActiveMoveFilesDialog({
   const {
     session,
     cancelMove: onCancel,
+    chooseCandidate: onChooseCandidate,
     chooseDestination: onMove,
     setApplyToRemaining: onApplyToRemaining,
     chooseConflict: onChooseConflict,
@@ -41,17 +49,20 @@ function ActiveMoveFilesDialog({
   const runtimeSlot = useConnection((state) => state.runtimeSlot);
   const authGeneration = useConnection((state) => state.authGeneration);
   const [directory, setDirectory] = useState("");
-  const [candidate, setCandidate] = useState<string | null>(null);
   const [directories, setDirectories] = useState<BrowserEntry[]>(NO_DIRECTORIES);
   const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState(false);
   const loadGeneration = useRef(0);
+  const requestedDirectory = useRef("");
   const picking = session?.stage === "picking";
   const fileApi = useMemo(() => api ? createFileManagementApi(api) : null, [api]);
 
   const load = useCallback(async (nextDirectory: string) => {
     if (!fileApi || !picking) return;
     const generation = ++loadGeneration.current;
+    requestedDirectory.current = nextDirectory;
     setLoading(true);
+    setLoadError(false);
     try {
       const response = await fileApi.list(nextDirectory);
       if (generation !== loadGeneration.current) return;
@@ -61,6 +72,7 @@ function ActiveMoveFilesDialog({
       if (generation !== loadGeneration.current) return;
       console.warn("[move-files-dialog] folder listing failed:", diagnosticErrorKind(error));
       setDirectories(NO_DIRECTORIES);
+      setLoadError(true);
     } finally {
       if (generation === loadGeneration.current) setLoading(false);
     }
@@ -69,8 +81,8 @@ function ActiveMoveFilesDialog({
   useEffect(() => {
     loadGeneration.current += 1;
     setDirectory("");
-    setCandidate(null);
     setDirectories(NO_DIRECTORIES);
+    setLoadError(false);
     if (picking) void load("");
     return () => { loadGeneration.current += 1; };
   }, [api, runtimeSlot, authGeneration, picking, session?.sources, load]);
@@ -82,6 +94,14 @@ function ActiveMoveFilesDialog({
         <div className="flex max-h-[64vh] flex-col gap-3 p-4">
           <h2 className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>Resolve move conflicts</h2>
           <div className="min-h-0 space-y-2 overflow-y-auto">
+            {session.preflight?.invalid.map((item) => (
+              <div key={item.source} className="rounded-md border p-2" style={{ borderColor: "var(--border-subtle)" }}>
+                <span data-testid="move-invalid-source" className="block truncate text-sm">{item.source}</span>
+                <span className="block text-xs" style={{ color: "var(--text-secondary)" }}>
+                  {INVALID_MOVE_REASON[item.code]}
+                </span>
+              </div>
+            ))}
             {session.choices.map((choice) => (
               <div key={choice.source} className="flex items-center justify-between gap-3 rounded-md border p-2" style={{ borderColor: "var(--border-subtle)" }}>
                 <span data-testid="move-conflict-source" className="min-w-0 truncate text-sm">{choice.source}</span>
@@ -120,11 +140,12 @@ function ActiveMoveFilesDialog({
   }
   if (!picking) {
     return (
-      <Dialog open onClose={onCancel} width={360}>
+      <Dialog open onClose={session.stage === "executing" ? IGNORE_CLOSE : onCancel} width={360}>
         <div className="p-4 text-sm" role="status">Preparing move…</div>
       </Dialog>
     );
   }
+  const candidate = session.destination;
   const scope = { directory: parentDirectory(session.sources[0]!), runtimeSlot, authGeneration };
   const candidateValid = candidate !== null && isValidFileDropTarget({
     version: 1,
@@ -158,7 +179,12 @@ function ActiveMoveFilesDialog({
           ))}
         </div>
         <div className="min-h-40 overflow-y-auto p-2">
-          {loading ? <p className="p-2 text-xs">Loading folders…</p> : directories.length === 0 ? (
+          {loading ? <p className="p-2 text-xs">Loading folders…</p> : loadError ? (
+            <div className="flex flex-col items-center gap-2 p-3 text-xs">
+              <span role="alert">Folders could not be loaded.</span>
+              <Button variant="subtle" aria-label="Retry folders" onClick={() => void load(requestedDirectory.current)}>Retry</Button>
+            </div>
+          ) : directories.length === 0 ? (
             <p className="p-2 text-xs" style={{ color: "var(--text-tertiary)" }}>No subfolders here.</p>
           ) : directories.map((entry) => {
             const path = joinPath(directory, entry.name);
@@ -170,7 +196,7 @@ function ActiveMoveFilesDialog({
                 aria-pressed={candidate === path}
                 className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm"
                 style={{ background: candidate === path ? "var(--bg-selected)" : "transparent" }}
-                onClick={() => setCandidate(path)}
+                onClick={() => onChooseCandidate(path)}
                 onDoubleClick={() => void load(path)}
               >
                 <Folder size={16} aria-hidden />{entry.name}

--- a/desktop/src/renderer/src/features/files/MoveFilesDialog.tsx
+++ b/desktop/src/renderer/src/features/files/MoveFilesDialog.tsx
@@ -1,0 +1,207 @@
+import { ArrowUp, ChevronRight, Folder } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Button, Dialog } from "../../design/primitives";
+import { diagnosticErrorKind } from "../../lib/errors";
+import { useConnection } from "../../stores/connection";
+import { parseBrowserEntries, type BrowserEntry } from "./browser-entries";
+import { createFileManagementApi } from "./file-management-api";
+import { isValidFileDropTarget } from "./file-drag";
+import type { FileMoveSession } from "./use-file-move";
+
+const NO_DIRECTORIES: BrowserEntry[] = [];
+
+interface MoveDialogControls {
+  session: FileMoveSession | null;
+  cancelMove: () => void;
+  chooseDestination: (destination: string) => void;
+  setApplyToRemaining: (apply: boolean) => void;
+  chooseConflict: (source: string, resolution: "keep-both" | "skip") => void;
+  confirmMove: () => void;
+}
+
+export function MoveFilesDialog({ controls }: { controls: MoveDialogControls }) {
+  if (!controls.session) return null;
+  return <ActiveMoveFilesDialog controls={{ ...controls, session: controls.session }} />;
+}
+
+function ActiveMoveFilesDialog({
+  controls,
+}: {
+  controls: MoveDialogControls & { session: FileMoveSession };
+}) {
+  const {
+    session,
+    cancelMove: onCancel,
+    chooseDestination: onMove,
+    setApplyToRemaining: onApplyToRemaining,
+    chooseConflict: onChooseConflict,
+    confirmMove: onConfirm,
+  } = controls;
+  const api = useConnection((state) => state.api);
+  const runtimeSlot = useConnection((state) => state.runtimeSlot);
+  const authGeneration = useConnection((state) => state.authGeneration);
+  const [directory, setDirectory] = useState("");
+  const [candidate, setCandidate] = useState<string | null>(null);
+  const [directories, setDirectories] = useState<BrowserEntry[]>(NO_DIRECTORIES);
+  const [loading, setLoading] = useState(false);
+  const loadGeneration = useRef(0);
+  const picking = session?.stage === "picking";
+  const fileApi = useMemo(() => api ? createFileManagementApi(api) : null, [api]);
+
+  const load = useCallback(async (nextDirectory: string) => {
+    if (!fileApi || !picking) return;
+    const generation = ++loadGeneration.current;
+    setLoading(true);
+    try {
+      const response = await fileApi.list(nextDirectory);
+      if (generation !== loadGeneration.current) return;
+      setDirectories(parseBrowserEntries(response.entries).filter((entry) => entry.type === "directory"));
+      setDirectory(nextDirectory);
+    } catch (error: unknown) {
+      if (generation !== loadGeneration.current) return;
+      console.warn("[move-files-dialog] folder listing failed:", diagnosticErrorKind(error));
+      setDirectories(NO_DIRECTORIES);
+    } finally {
+      if (generation === loadGeneration.current) setLoading(false);
+    }
+  }, [fileApi, picking]);
+
+  useEffect(() => {
+    loadGeneration.current += 1;
+    setDirectory("");
+    setCandidate(null);
+    setDirectories(NO_DIRECTORIES);
+    if (picking) void load("");
+    return () => { loadGeneration.current += 1; };
+  }, [api, runtimeSlot, authGeneration, picking, session?.sources, load]);
+
+  if (session.stage === "resolving") {
+    const complete = session.choices.every((choice) => choice.resolution !== null);
+    return (
+      <Dialog open onClose={onCancel} width={520}>
+        <div className="flex max-h-[64vh] flex-col gap-3 p-4">
+          <h2 className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>Resolve move conflicts</h2>
+          <div className="min-h-0 space-y-2 overflow-y-auto">
+            {session.choices.map((choice) => (
+              <div key={choice.source} className="flex items-center justify-between gap-3 rounded-md border p-2" style={{ borderColor: "var(--border-subtle)" }}>
+                <span data-testid="move-conflict-source" className="min-w-0 truncate text-sm">{choice.source}</span>
+                <div className="flex shrink-0 gap-1">
+                  <Button
+                    variant={choice.resolution === "keep-both" ? "primary" : "subtle"}
+                    aria-label={`Keep Both for ${choice.source}`}
+                    aria-pressed={choice.resolution === "keep-both"}
+                    onClick={() => onChooseConflict(choice.source, "keep-both")}
+                  >Keep Both</Button>
+                  <Button
+                    variant={choice.resolution === "skip" ? "primary" : "subtle"}
+                    aria-label={`Skip ${choice.source}`}
+                    aria-pressed={choice.resolution === "skip"}
+                    onClick={() => onChooseConflict(choice.source, "skip")}
+                  >Skip</Button>
+                </div>
+              </div>
+            ))}
+          </div>
+          <label className="flex items-center gap-2 text-xs">
+            <input
+              type="checkbox"
+              checked={session.applyToRemaining}
+              onChange={(event) => onApplyToRemaining(event.currentTarget.checked)}
+            />
+            Apply to remaining conflicts
+          </label>
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" aria-label="Cancel move" onClick={onCancel}>Cancel</Button>
+            <Button variant="primary" disabled={!complete} onClick={onConfirm}>Move selected items</Button>
+          </div>
+        </div>
+      </Dialog>
+    );
+  }
+  if (!picking) {
+    return (
+      <Dialog open onClose={onCancel} width={360}>
+        <div className="p-4 text-sm" role="status">Preparing move…</div>
+      </Dialog>
+    );
+  }
+  const scope = { directory: parentDirectory(session.sources[0]!), runtimeSlot, authGeneration };
+  const candidateValid = candidate !== null && isValidFileDropTarget({
+    version: 1,
+    paths: session.sources,
+    scope,
+  }, candidate);
+  const candidateInvalid = candidate !== null && !candidateValid;
+  const crumbs = directory ? directory.split("/").map((label, index, segments) => ({
+    label,
+    path: segments.slice(0, index + 1).join("/"),
+  })) : [];
+
+  return (
+    <Dialog open onClose={onCancel} width={520}>
+      <div className="flex max-h-[64vh] flex-col">
+        <div className="border-b px-4 py-3" style={{ borderColor: "var(--border-subtle)" }}>
+          <h2 className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+            Move {session.sources.length === 1 ? "1 item" : `${session.sources.length} items`}
+          </h2>
+        </div>
+        <div className="flex items-center gap-1 border-b px-3 py-2" style={{ borderColor: "var(--border-subtle)" }}>
+          <Button variant="ghost" aria-label="Up one level" disabled={!directory} onClick={() => void load(parentDirectory(directory))}>
+            <ArrowUp size={13} aria-hidden />Up
+          </Button>
+          <button type="button" className="rounded px-2 py-1 text-xs" onClick={() => void load("")}>Matrix home</button>
+          {crumbs.map((crumb) => (
+            <span key={crumb.path} className="flex items-center gap-1">
+              <ChevronRight size={11} aria-hidden />
+              <button type="button" className="rounded px-1.5 py-1 text-xs" onClick={() => void load(crumb.path)}>{crumb.label}</button>
+            </span>
+          ))}
+        </div>
+        <div className="min-h-40 overflow-y-auto p-2">
+          {loading ? <p className="p-2 text-xs">Loading folders…</p> : directories.length === 0 ? (
+            <p className="p-2 text-xs" style={{ color: "var(--text-tertiary)" }}>No subfolders here.</p>
+          ) : directories.map((entry) => {
+            const path = joinPath(directory, entry.name);
+            return (
+              <button
+                key={path}
+                type="button"
+                aria-label={`Choose ${entry.name}`}
+                aria-pressed={candidate === path}
+                className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm"
+                style={{ background: candidate === path ? "var(--bg-selected)" : "transparent" }}
+                onClick={() => setCandidate(path)}
+                onDoubleClick={() => void load(path)}
+              >
+                <Folder size={16} aria-hidden />{entry.name}
+              </button>
+            );
+          })}
+        </div>
+        <div className="flex items-center justify-between gap-3 border-t px-4 py-3" style={{ borderColor: "var(--border-subtle)" }}>
+          <div className="min-w-0">
+            <span className="block truncate text-xs" style={{ color: "var(--text-secondary)" }}>{candidate ?? "Choose a destination folder"}</span>
+            {candidateInvalid ? (
+              <span role="alert" className="block text-xs" style={{ color: "var(--danger)" }}>
+                Choose a folder outside the selected folder.
+              </span>
+            ) : null}
+          </div>
+          <div className="flex gap-2">
+            <Button variant="ghost" aria-label="Cancel move" onClick={onCancel}>Cancel</Button>
+            <Button variant="primary" disabled={!candidateValid} onClick={() => candidate && onMove(candidate)}>Move</Button>
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+function parentDirectory(path: string): string {
+  const separator = path.lastIndexOf("/");
+  return separator < 0 ? "" : path.slice(0, separator);
+}
+
+function joinPath(parent: string, name: string): string {
+  return parent ? `${parent}/${name}` : name;
+}

--- a/desktop/src/renderer/src/features/files/browser-views.tsx
+++ b/desktop/src/renderer/src/features/files/browser-views.tsx
@@ -13,7 +13,7 @@ import {
   FolderPlus,
   RefreshCw,
 } from "lucide-react";
-import type { KeyboardEvent, MouseEvent, ReactNode, RefObject } from "react";
+import type { DragEvent, KeyboardEvent, MouseEvent, ReactNode, RefObject } from "react";
 import { Button, IconButton } from "../../design/primitives";
 import type { BrowserEntry, BrowserSortDirection, BrowserSortKey } from "./browser-entries";
 import type { BrowserViewMode } from "./browser-view-preference";
@@ -137,6 +137,13 @@ export function EntryButton({
   onNavigate,
   onKeyDown,
   disabled = false,
+  draggable = false,
+  dropTarget = false,
+  onDragStart,
+  onDragEnd,
+  onDragOver,
+  onDragLeave,
+  onDrop,
 }: {
   entry: BrowserEntry;
   grid: boolean;
@@ -148,6 +155,13 @@ export function EntryButton({
   onNavigate: () => void;
   onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
   disabled?: boolean;
+  draggable?: boolean;
+  dropTarget?: boolean;
+  onDragStart?: (event: DragEvent<HTMLButtonElement>) => void;
+  onDragEnd?: (event: DragEvent<HTMLButtonElement>) => void;
+  onDragOver?: (event: DragEvent<HTMLButtonElement>) => void;
+  onDragLeave?: (event: DragEvent<HTMLButtonElement>) => void;
+  onDrop?: (event: DragEvent<HTMLButtonElement>) => void;
 }) {
   const kind = kindForEntry(entry);
   const glyphColor = entry.type === "directory" ? "var(--accent)" : "var(--text-tertiary)";
@@ -161,11 +175,18 @@ export function EntryButton({
         aria-label={`Open ${entry.name}`}
         aria-pressed={pressed}
         data-grid-tile
+        data-file-drop-target={dropTarget}
+        draggable={draggable}
         className="flex w-24 flex-col items-center gap-1.5 rounded-lg px-1.5 py-2.5 outline-none hover:bg-[var(--bg-hover)] focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
-        style={{ background: selected ? "var(--bg-selected)" : "transparent" }}
+        style={{ background: dropTarget ? "var(--accent-muted)" : selected ? "var(--bg-selected)" : "transparent" }}
         onClick={onSelect}
         onDoubleClick={onNavigate}
         onKeyDown={onKeyDown}
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
       >
         <span style={{ color: glyphColor }}>
           <FileGlyph kind={kind} size={34} />
@@ -188,15 +209,22 @@ export function EntryButton({
       disabled={disabled}
       aria-label={`Open ${entry.name}`}
       aria-pressed={pressed}
+      data-file-drop-target={dropTarget}
+      draggable={draggable}
       className="grid h-9 w-full items-center gap-2 rounded-md px-2 text-left text-sm outline-none hover:bg-[var(--bg-hover)] focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
       style={{
         gridTemplateColumns: listColumns,
-        background: selected ? "var(--bg-selected)" : "transparent",
+        background: dropTarget ? "var(--accent-muted)" : selected ? "var(--bg-selected)" : "transparent",
         color: "var(--text-primary)",
       }}
       onClick={onSelect}
       onDoubleClick={onNavigate}
       onKeyDown={onKeyDown}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
     >
       <span className="flex min-w-0 items-center gap-2">
         <span className="shrink-0" style={{ color: glyphColor }}>
@@ -226,6 +254,7 @@ export function BrowserToolbar({
   onRefresh,
   onNewFile,
   onNewFolder,
+  dropHandlers,
 }: {
   compact: boolean;
   currentPath: string;
@@ -237,7 +266,23 @@ export function BrowserToolbar({
   onRefresh: () => void;
   onNewFile?: () => void;
   onNewFolder?: () => void;
+  dropHandlers?: {
+    activePath: string | null;
+    onDragOver(path: string, transfer: DataTransfer): boolean;
+    onDragLeave(path: string): void;
+    onDrop(path: string, transfer: DataTransfer): boolean;
+  };
 }) {
+  const dropProps = (path: string) => !dropHandlers ? {} : {
+    "data-file-drop-target": dropHandlers.activePath === path,
+    onDragOver: (event: DragEvent<HTMLButtonElement>) => {
+      if (dropHandlers.onDragOver(path, event.dataTransfer)) event.preventDefault();
+    },
+    onDragLeave: () => dropHandlers.onDragLeave(path),
+    onDrop: (event: DragEvent<HTMLButtonElement>) => {
+      if (dropHandlers.onDrop(path, event.dataTransfer)) event.preventDefault();
+    },
+  };
   return (
     <div className="flex h-10 shrink-0 items-center gap-1 border-b px-2" style={{ borderColor: "var(--border-subtle)" }}>
       <IconButton
@@ -255,6 +300,7 @@ export function BrowserToolbar({
           className="flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium hover:bg-[var(--bg-hover)]"
           style={{ color: currentPath ? "var(--text-secondary)" : "var(--text-primary)" }}
           onClick={() => onNavigate("")}
+          {...dropProps("")}
         >
           <Home size={13} />
           {!compact ? "Matrix home" : "Home"}
@@ -267,6 +313,7 @@ export function BrowserToolbar({
               className="max-w-[150px] truncate rounded px-1.5 py-1 text-xs hover:bg-[var(--bg-hover)]"
               style={{ color: crumb.path === currentPath ? "var(--text-primary)" : "var(--text-secondary)" }}
               onClick={() => onNavigate(crumb.path)}
+              {...dropProps(crumb.path)}
             >
               {crumb.label}
             </button>

--- a/desktop/src/renderer/src/features/files/file-drag.ts
+++ b/desktop/src/renderer/src/features/files/file-drag.ts
@@ -1,0 +1,131 @@
+import { MatrixComputerRuntimeSlotSchema } from "@matrix-os/contracts";
+import { z } from "zod/v4";
+import {
+  OwnerDirectoryPathSchema,
+  OwnerRelativePathSchema,
+} from "./file-management-contracts";
+import { beginFileDrag, type FileSelectionState } from "./file-selection";
+
+export const FILE_MOVE_MIME = "application/x-matrix-os-file-move+json";
+export const MAX_FILE_DRAG_BYTES = 128 * 1_024;
+
+const FileDragScopeSchema = z.object({
+  directory: OwnerDirectoryPathSchema,
+  runtimeSlot: MatrixComputerRuntimeSlotSchema,
+  authGeneration: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+}).strict();
+
+const FileDragPayloadSchema = z.object({
+  version: z.literal(1),
+  paths: z.array(OwnerRelativePathSchema).min(1).max(100),
+  scope: FileDragScopeSchema,
+}).strict().refine((payload) => new Set(payload.paths).size === payload.paths.length)
+  .refine((payload) => payload.paths.every((path) => parentDirectory(path) === payload.scope.directory));
+
+export type FileDragPayload = z.infer<typeof FileDragPayloadSchema>;
+export interface FileDragSession {
+  selection: FileSelectionState;
+  paths: string[];
+  preview: { label: string; additionalCount: number };
+}
+
+export function mountFileDragPreview(
+  document: Document,
+  preview: FileDragSession["preview"],
+): { element: HTMLDivElement; cleanup(): void } {
+  document.querySelectorAll("[data-file-drag-preview]").forEach((node) => node.remove());
+  const element = document.createElement("div");
+  element.dataset.fileDragPreview = "true";
+  element.style.cssText = [
+    "position:fixed",
+    "left:-10000px",
+    "top:-10000px",
+    "pointer-events:none",
+    "padding:6px 10px",
+    "border-radius:8px",
+    "background:var(--bg-overlay)",
+    "color:var(--text-primary)",
+  ].join(";");
+  element.append(document.createTextNode(preview.label));
+  if (preview.additionalCount > 0) {
+    const badge = document.createElement("span");
+    badge.textContent = `+${preview.additionalCount}`;
+    element.append(badge);
+  }
+  document.body.append(element);
+  return { element, cleanup: () => element.remove() };
+}
+
+export function createFileDragSession(
+  selection: FileSelectionState,
+  path: string,
+): FileDragSession | null {
+  const started = beginFileDrag(selection, path);
+  if (started.dragPaths.length === 0) return null;
+  const focusedPath = started.state.focusedPath && started.dragPaths.includes(started.state.focusedPath)
+    ? started.state.focusedPath
+    : started.dragPaths[0]!;
+  return {
+    selection: started.state,
+    paths: started.dragPaths,
+    preview: {
+      label: basename(focusedPath),
+      additionalCount: started.dragPaths.length - 1,
+    },
+  };
+}
+
+export function writeFileDragData(
+  transfer: DataTransfer,
+  paths: readonly string[],
+  scope: FileDragPayload["scope"],
+): boolean {
+  const parsed = FileDragPayloadSchema.safeParse({ version: 1, paths: [...paths], scope });
+  if (!parsed.success) return false;
+  const serialized = JSON.stringify(parsed.data);
+  if (new TextEncoder().encode(serialized).byteLength > MAX_FILE_DRAG_BYTES) return false;
+  transfer.setData(FILE_MOVE_MIME, serialized);
+  transfer.effectAllowed = "move";
+  return true;
+}
+
+export function readFileDragData(
+  transfer: DataTransfer,
+  expectedScope: FileDragPayload["scope"],
+): FileDragPayload | null {
+  if (transfer.files.length > 0 || transfer.types.length !== 1 || transfer.types[0] !== FILE_MOVE_MIME) return null;
+  const serialized = transfer.getData(FILE_MOVE_MIME);
+  if (!serialized || new TextEncoder().encode(serialized).byteLength > MAX_FILE_DRAG_BYTES) return null;
+  let value: unknown;
+  try {
+    value = JSON.parse(serialized);
+  } catch (error: unknown) {
+    if (!(error instanceof SyntaxError)) return null;
+    return null;
+  }
+  const parsed = FileDragPayloadSchema.safeParse(value);
+  if (!parsed.success || !sameScope(parsed.data.scope, expectedScope)) return null;
+  return parsed.data;
+}
+
+export function isValidFileDropTarget(payload: FileDragPayload, destination: string): boolean {
+  return FileDragPayloadSchema.safeParse(payload).success
+    && OwnerRelativePathSchema.safeParse(destination).success
+    && destination !== payload.scope.directory
+    && payload.paths.every((source) => destination !== source && !destination.startsWith(`${source}/`));
+}
+
+function parentDirectory(path: string): string {
+  const separator = path.lastIndexOf("/");
+  return separator < 0 ? "" : path.slice(0, separator);
+}
+
+function basename(path: string): string {
+  return path.slice(path.lastIndexOf("/") + 1);
+}
+
+function sameScope(left: FileDragPayload["scope"], right: FileDragPayload["scope"]): boolean {
+  return left.directory === right.directory
+    && left.runtimeSlot === right.runtimeSlot
+    && left.authGeneration === right.authGeneration;
+}

--- a/desktop/src/renderer/src/features/files/file-drag.ts
+++ b/desktop/src/renderer/src/features/files/file-drag.ts
@@ -93,7 +93,7 @@ export function readFileDragData(
   transfer: DataTransfer,
   expectedScope: FileDragPayload["scope"],
 ): FileDragPayload | null {
-  if (transfer.files.length > 0 || transfer.types.length !== 1 || transfer.types[0] !== FILE_MOVE_MIME) return null;
+  if (!hasOnlyInternalFileMoveType(transfer)) return null;
   const serialized = transfer.getData(FILE_MOVE_MIME);
   if (!serialized || new TextEncoder().encode(serialized).byteLength > MAX_FILE_DRAG_BYTES) return null;
   let value: unknown;
@@ -106,6 +106,12 @@ export function readFileDragData(
   const parsed = FileDragPayloadSchema.safeParse(value);
   if (!parsed.success || !sameScope(parsed.data.scope, expectedScope)) return null;
   return parsed.data;
+}
+
+export function hasOnlyInternalFileMoveType(transfer: DataTransfer): boolean {
+  return transfer.files.length === 0
+    && transfer.types.length === 1
+    && transfer.types[0] === FILE_MOVE_MIME;
 }
 
 export function isValidFileDropTarget(payload: FileDragPayload, destination: string): boolean {

--- a/desktop/src/renderer/src/features/files/use-file-management.ts
+++ b/desktop/src/renderer/src/features/files/use-file-management.ts
@@ -20,6 +20,7 @@ import {
   type FileSelectionState,
 } from "./file-selection";
 import { useDirectorySync, type DirectorySyncSocket } from "./use-directory-sync";
+import { useFileMove } from "./use-file-move";
 
 export type FileNameDraft =
   | { mode: "create"; kind: "file" | "directory"; name: string }
@@ -112,6 +113,37 @@ export function useFileManagement(options: {
     },
   }), [managementApi, options.api, options.runtimeSlot, options.authGeneration, options.loadAuthoritativeDirectory, fetchEntries]);
   const [snapshot, setSnapshot] = useState<FileOperationSnapshot>(controller.snapshot);
+  const settleMoveOutcome = useCallback((outcome: { retainedPaths: string[] }) => {
+    const nextSelection: FileSelectionState = {
+      scope: { ...scopeRef.current },
+      selectedPaths: [...outcome.retainedPaths],
+      anchorPath: outcome.retainedPaths[0] ?? null,
+      focusedPath: outcome.retainedPaths[0] ?? null,
+    };
+    selectionRef.current = nextSelection;
+    setStoredSelection(nextSelection);
+    onFocusRef.current?.(nextSelection.focusedPath);
+  }, []);
+  const getMoveSelection = useCallback(() => selectionRef.current, []);
+  const setMoveSelection = useCallback((nextSelection: FileSelectionState) => {
+    selectionRef.current = nextSelection;
+    setStoredSelection(nextSelection);
+    onFocusRef.current?.(nextSelection.focusedPath);
+  }, []);
+  const move = useFileMove({
+    api: options.api,
+    controller,
+    directory: options.directory,
+    runtimeSlot: options.runtimeSlot,
+    authGeneration: options.authGeneration,
+    onOutcome: settleMoveOutcome,
+    getSelection: getMoveSelection,
+    onSelectionChange: setMoveSelection,
+  });
+  const requestMenuMove = useCallback((paths: readonly string[]) => {
+    setLocalNotice(null);
+    return move.requestMenuMove(paths);
+  }, [move.requestMenuMove]);
 
   useEffect(() => {
     setSnapshot(controller.snapshot);
@@ -270,6 +302,7 @@ export function useFileManagement(options: {
     draft, draftError, draftSubmitting, localNotice, snapshot, selection, trashPaths,
     startCreate, startRename, updateDraftName, cancelDraft, submitDraft, selectPath,
     reconcilePaths, requestTrash, cancelTrash, confirmTrash,
+    move: { ...move, requestMenuMove },
   };
 }
 

--- a/desktop/src/renderer/src/features/files/use-file-move.ts
+++ b/desktop/src/renderer/src/features/files/use-file-move.ts
@@ -3,6 +3,7 @@ import type { ApiClient } from "../../lib/api";
 import type { FileConflictChoice } from "./file-management-api";
 import {
   createFileDragSession,
+  hasOnlyInternalFileMoveType,
   isValidFileDropTarget,
   mountFileDragPreview,
   readFileDragData,
@@ -121,7 +122,7 @@ export function useFileMove(options: MoveOwner & {
       return;
     }
     const prepared = { ...base, destination, preflight };
-    if (preflight.conflicts.length === 0) {
+    if (preflight.conflicts.length === 0 && preflight.invalid.length === 0) {
       await finishExecute(prepared, preflight, [], owner, epoch);
       return;
     }
@@ -167,10 +168,15 @@ export function useFileMove(options: MoveOwner & {
   const dragOverTarget = useCallback((destination: string, transfer: DataTransfer) => {
     const owner = dragOwnerRef.current;
     const expected = owner && sameOwner(owner, currentRef.current) ? owner : null;
-    if (!expected) return false;
-    const scope = { directory: expected.directory, runtimeSlot: expected.runtimeSlot, authGeneration: expected.authGeneration };
-    const payload = readFileDragData(transfer, scope);
-    if (!payload || !samePayload(payload, dragPayloadRef.current) || !isValidFileDropTarget(payload, destination)) return false;
+    if (!expected) {
+      setStoredDropTarget(null);
+      return false;
+    }
+    const payload = dragPayloadRef.current;
+    if (!payload || !hasOnlyInternalFileMoveType(transfer) || !isValidFileDropTarget(payload, destination)) {
+      setStoredDropTarget(null);
+      return false;
+    }
     transfer.dropEffect = "move";
     setStoredDropTarget(destination);
     return true;
@@ -231,6 +237,12 @@ export function useFileMove(options: MoveOwner & {
     void beginPreflight(session, destination);
   }, [beginPreflight, session]);
 
+  const chooseCandidate = useCallback((destination: string) => {
+    setStoredSession((current) => current?.stage === "picking"
+      ? { ...current, destination }
+      : current);
+  }, []);
+
   const setApplyToRemaining = useCallback((apply: boolean) => {
     setStoredSession((current) => current?.stage === "resolving"
       ? { ...current, applyToRemaining: apply }
@@ -266,14 +278,15 @@ export function useFileMove(options: MoveOwner & {
   }, [finishExecute, session]);
 
   const cancelMove = useCallback(() => {
+    if (session?.stage === "executing") return;
     epochRef.current += 1;
-    if (session?.preflight && session.stage !== "executing") options.controller.cancelMove(session.preflight);
+    if (session?.preflight) options.controller.cancelMove(session.preflight);
     setStoredSession(null);
     ownerRef.current = null;
   }, [options.controller, session]);
 
   return {
-    session, requestMenuMove, chooseDestination, setApplyToRemaining,
+    session, requestMenuMove, chooseCandidate, chooseDestination, setApplyToRemaining,
     chooseConflict, confirmMove, cancelMove, dropTarget,
     beginDrag, dragOverTarget, leaveDropTarget, dropOnTarget,
     endDrag: cleanupDrag, entryDragProps,

--- a/desktop/src/renderer/src/features/files/use-file-move.ts
+++ b/desktop/src/renderer/src/features/files/use-file-move.ts
@@ -1,0 +1,310 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type DragEvent } from "react";
+import type { ApiClient } from "../../lib/api";
+import type { FileConflictChoice } from "./file-management-api";
+import {
+  createFileDragSession,
+  isValidFileDropTarget,
+  mountFileDragPreview,
+  readFileDragData,
+  writeFileDragData,
+  type FileDragPayload,
+} from "./file-drag";
+import type { FileSelectionState } from "./file-selection";
+import type {
+  ControllerMovePreflight,
+  FileOperationController,
+  FileOperationOutcome,
+} from "./file-operation-controller";
+import { parentDirectory, validBatchSources } from "./file-operation-reconciliation";
+
+export type FileMoveOrigin = "menu" | "drag";
+export type FileMoveStage = "picking" | "preflighting" | "resolving" | "executing";
+
+export interface FileMoveSession {
+  origin: FileMoveOrigin;
+  stage: FileMoveStage;
+  sources: string[];
+  destination: string | null;
+  preflight: ControllerMovePreflight | null;
+  choices: Array<{ source: string; resolution: "keep-both" | "skip" | null }>;
+  applyToRemaining: boolean;
+}
+
+interface MoveOwner {
+  api: ApiClient | null;
+  directory: string;
+  runtimeSlot: string;
+  authGeneration: number;
+}
+
+export function useFileMove(options: MoveOwner & {
+  controller: FileOperationController;
+  onOutcome(outcome: FileOperationOutcome): void;
+  getSelection(): FileSelectionState;
+  onSelectionChange(selection: FileSelectionState): void;
+}) {
+  const [storedSession, setStoredSession] = useState<FileMoveSession | null>(null);
+  const [storedDropTarget, setStoredDropTarget] = useState<string | null>(null);
+  const ownerRef = useRef<MoveOwner | null>(null);
+  const dragOwnerRef = useRef<MoveOwner | null>(null);
+  const dragPayloadRef = useRef<FileDragPayload | null>(null);
+  const previewCleanupRef = useRef<(() => void) | null>(null);
+  const currentRef = useRef<MoveOwner>(options);
+  const epochRef = useRef(0);
+  useLayoutEffect(() => { currentRef.current = options; }, [options.api, options.directory, options.runtimeSlot, options.authGeneration]);
+
+  const session = storedSession && sameOwner(ownerRef.current, options) ? storedSession : null;
+  const dropTarget = sameOwner(dragOwnerRef.current, options) ? storedDropTarget : null;
+
+  const cleanupDrag = useCallback((clearTarget = true) => {
+    previewCleanupRef.current?.();
+    previewCleanupRef.current = null;
+    dragPayloadRef.current = null;
+    dragOwnerRef.current = null;
+    if (clearTarget) setStoredDropTarget(null);
+  }, []);
+
+  useEffect(() => {
+    epochRef.current += 1;
+    setStoredSession(null);
+    ownerRef.current = null;
+    cleanupDrag();
+    return () => cleanupDrag(false);
+  }, [cleanupDrag, options.api, options.controller, options.directory, options.runtimeSlot, options.authGeneration]);
+
+  const stillCurrent = useCallback((owner: MoveOwner, epoch: number) =>
+    epoch === epochRef.current && sameOwner(owner, currentRef.current), []);
+
+  const finishExecute = useCallback(async (
+    base: FileMoveSession,
+    preflight: ControllerMovePreflight,
+    conflictChoices: FileConflictChoice[],
+    owner: MoveOwner,
+    epoch: number,
+  ) => {
+    if (!stillCurrent(owner, epoch)) return;
+    setStoredSession({ ...base, stage: "executing", preflight });
+    const outcome = await options.controller.executeMove({ preflight, conflictChoices });
+    if (!stillCurrent(owner, epoch) || outcome.status === "stale") return;
+    setStoredSession(null);
+    ownerRef.current = null;
+    options.onOutcome(outcome);
+  }, [options.controller, options.onOutcome, stillCurrent]);
+
+  const beginPreflight = useCallback(async (
+    base: FileMoveSession,
+    destination: string,
+  ) => {
+    const owner = ownerRef.current;
+    if (!owner || !sameOwner(owner, currentRef.current)) return;
+    const payload = {
+      version: 1 as const,
+      paths: base.sources,
+      scope: {
+        directory: owner.directory,
+        runtimeSlot: owner.runtimeSlot,
+        authGeneration: owner.authGeneration,
+      },
+    };
+    if (!isValidFileDropTarget(payload, destination)) return;
+    const epoch = epochRef.current;
+    setStoredSession({ ...base, stage: "preflighting", destination });
+    const outcome = await options.controller.preflightMove({ sources: base.sources, destinationDirectory: destination });
+    if (!stillCurrent(owner, epoch)) {
+      if (outcome.preflight) options.controller.cancelMove(outcome.preflight);
+      return;
+    }
+    const preflight = outcome.preflight;
+    if (!preflight || outcome.status === "stale" || outcome.status === "failed") {
+      setStoredSession(null);
+      ownerRef.current = null;
+      return;
+    }
+    const prepared = { ...base, destination, preflight };
+    if (preflight.conflicts.length === 0) {
+      await finishExecute(prepared, preflight, [], owner, epoch);
+      return;
+    }
+    setStoredSession({
+      ...prepared,
+      stage: "resolving",
+      choices: preflight.conflicts.map((conflict) => ({ source: conflict.source, resolution: null })),
+    });
+  }, [finishExecute, options.controller, stillCurrent]);
+
+  const requestMenuMove = useCallback((sources: readonly string[]) => {
+    if (!validBatchSources(sources) || sources.some((source) => parentDirectory(source) !== options.directory)) return false;
+    const owner = captureOwner(options);
+    ownerRef.current = owner;
+    epochRef.current += 1;
+    setStoredSession({
+      origin: "menu", stage: "picking", sources: [...sources], destination: null,
+      preflight: null, choices: [], applyToRemaining: false,
+    });
+    return true;
+  }, [options.api, options.directory, options.runtimeSlot, options.authGeneration]);
+
+  const beginDrag = useCallback((path: string, transfer: DataTransfer, allowedPaths: readonly string[]) => {
+    const started = createFileDragSession(options.getSelection(), path);
+    if (!started || started.paths.some((source) => !allowedPaths.includes(source))) return false;
+    const owner = captureOwner(options);
+    const scope = {
+      directory: owner.directory,
+      runtimeSlot: owner.runtimeSlot,
+      authGeneration: owner.authGeneration,
+    };
+    if (!writeFileDragData(transfer, started.paths, scope)) return false;
+    cleanupDrag();
+    const preview = mountFileDragPreview(document, started.preview);
+    transfer.setDragImage(preview.element, 12, 12);
+    previewCleanupRef.current = preview.cleanup;
+    dragOwnerRef.current = owner;
+    dragPayloadRef.current = { version: 1, paths: started.paths, scope };
+    options.onSelectionChange(started.selection);
+    return true;
+  }, [cleanupDrag, options]);
+
+  const dragOverTarget = useCallback((destination: string, transfer: DataTransfer) => {
+    const owner = dragOwnerRef.current;
+    const expected = owner && sameOwner(owner, currentRef.current) ? owner : null;
+    if (!expected) return false;
+    const scope = { directory: expected.directory, runtimeSlot: expected.runtimeSlot, authGeneration: expected.authGeneration };
+    const payload = readFileDragData(transfer, scope);
+    if (!payload || !samePayload(payload, dragPayloadRef.current) || !isValidFileDropTarget(payload, destination)) return false;
+    transfer.dropEffect = "move";
+    setStoredDropTarget(destination);
+    return true;
+  }, []);
+
+  const leaveDropTarget = useCallback((destination: string) => {
+    setStoredDropTarget((current) => current === destination ? null : current);
+  }, []);
+
+  const dropOnTarget = useCallback((destination: string, transfer: DataTransfer) => {
+    const owner = dragOwnerRef.current;
+    if (!owner || !sameOwner(owner, currentRef.current)) {
+      cleanupDrag();
+      return false;
+    }
+    const scope = { directory: owner.directory, runtimeSlot: owner.runtimeSlot, authGeneration: owner.authGeneration };
+    const payload = readFileDragData(transfer, scope);
+    if (!payload || !samePayload(payload, dragPayloadRef.current) || !isValidFileDropTarget(payload, destination)) {
+      cleanupDrag();
+      return false;
+    }
+    cleanupDrag();
+    ownerRef.current = owner;
+    epochRef.current += 1;
+    const base: FileMoveSession = {
+      origin: "drag", stage: "preflighting", sources: [...payload.paths], destination,
+      preflight: null, choices: [], applyToRemaining: false,
+    };
+    setStoredSession(base);
+    void beginPreflight(base, destination);
+    return true;
+  }, [beginPreflight, cleanupDrag]);
+
+  const entryDragProps = useCallback((path: string, directory: boolean, allowedPaths: readonly string[]) => {
+    const candidate = createFileDragSession(options.getSelection(), path);
+    const draggable = candidate !== null && candidate.paths.every((source) => allowedPaths.includes(source));
+    return {
+      draggable,
+      dropTarget: directory && dropTarget === path,
+      onDragStart: (event: DragEvent<HTMLButtonElement>) => {
+        if (!beginDrag(path, event.dataTransfer, allowedPaths)) event.preventDefault();
+      },
+      onDragEnd: () => cleanupDrag(),
+      ...(directory ? {
+        onDragOver: (event: DragEvent<HTMLButtonElement>) => {
+          if (dragOverTarget(path, event.dataTransfer)) event.preventDefault();
+        },
+        onDragLeave: () => leaveDropTarget(path),
+        onDrop: (event: DragEvent<HTMLButtonElement>) => {
+          if (dropOnTarget(path, event.dataTransfer)) event.preventDefault();
+        },
+      } : {}),
+    };
+  }, [beginDrag, cleanupDrag, dragOverTarget, dropOnTarget, dropTarget, leaveDropTarget, options]);
+
+  const chooseDestination = useCallback((destination: string) => {
+    if (session?.stage !== "picking") return;
+    void beginPreflight(session, destination);
+  }, [beginPreflight, session]);
+
+  const setApplyToRemaining = useCallback((apply: boolean) => {
+    setStoredSession((current) => current?.stage === "resolving"
+      ? { ...current, applyToRemaining: apply }
+      : current);
+  }, []);
+
+  const chooseConflict = useCallback((source: string, resolution: "keep-both" | "skip") => {
+    setStoredSession((current) => {
+      if (current?.stage !== "resolving") return current;
+      const at = current.choices.findIndex((choice) => choice.source === source);
+      if (at < 0) return current;
+      return {
+        ...current,
+        choices: current.choices.map((choice, index) => ({
+          ...choice,
+          resolution: index === at || (current.applyToRemaining && index > at)
+            ? resolution
+            : choice.resolution,
+        })),
+      };
+    });
+  }, []);
+
+  const confirmMove = useCallback(() => {
+    if (session?.stage !== "resolving" || !session.preflight || session.choices.some((choice) => choice.resolution === null)) return;
+    const owner = ownerRef.current;
+    if (!owner || !sameOwner(owner, currentRef.current)) return;
+    const choices = session.choices.map((choice) => ({
+      source: choice.source,
+      resolution: choice.resolution!,
+    }));
+    void finishExecute(session, session.preflight, choices, owner, epochRef.current);
+  }, [finishExecute, session]);
+
+  const cancelMove = useCallback(() => {
+    epochRef.current += 1;
+    if (session?.preflight && session.stage !== "executing") options.controller.cancelMove(session.preflight);
+    setStoredSession(null);
+    ownerRef.current = null;
+  }, [options.controller, session]);
+
+  return {
+    session, requestMenuMove, chooseDestination, setApplyToRemaining,
+    chooseConflict, confirmMove, cancelMove, dropTarget,
+    beginDrag, dragOverTarget, leaveDropTarget, dropOnTarget,
+    endDrag: cleanupDrag, entryDragProps,
+    dropHandlers: {
+      activePath: dropTarget,
+      onDragOver: dragOverTarget,
+      onDragLeave: leaveDropTarget,
+      onDrop: dropOnTarget,
+    },
+  };
+}
+
+function captureOwner(owner: MoveOwner): MoveOwner {
+  return {
+    api: owner.api,
+    directory: owner.directory,
+    runtimeSlot: owner.runtimeSlot,
+    authGeneration: owner.authGeneration,
+  };
+}
+
+function sameOwner(left: MoveOwner | null, right: MoveOwner): boolean {
+  return left !== null && left.api === right.api && left.directory === right.directory
+    && left.runtimeSlot === right.runtimeSlot && left.authGeneration === right.authGeneration;
+}
+
+function samePayload(left: FileDragPayload, right: FileDragPayload | null): boolean {
+  return right !== null && left.version === right.version
+    && left.scope.directory === right.scope.directory
+    && left.scope.runtimeSlot === right.scope.runtimeSlot
+    && left.scope.authGeneration === right.scope.authGeneration
+    && left.paths.length === right.paths.length
+    && left.paths.every((path, index) => path === right.paths[index]);
+}

--- a/tests/desktop/file-drag.test.ts
+++ b/tests/desktop/file-drag.test.ts
@@ -75,6 +75,22 @@ describe("internal Files drag payload", () => {
     });
   });
 
+  it("accepts the exact path-count, UTF-8 path, and serialized payload boundaries", () => {
+    const exactPath = `projects/${"é".repeat(2_043)}x`;
+    expect(new TextEncoder().encode(exactPath).byteLength).toBe(4_096);
+    expect(writeFileDragData(dragTransfer(), [exactPath], scope)).toBe(true);
+
+    const paths = Array.from({ length: 100 }, (_, index) =>
+      `projects/${String(index).padStart(2, "0")}-${"x".repeat(index === 99 ? 1_367 : 1_294)}`,
+    );
+    expect(paths).toHaveLength(100);
+    expect(new TextEncoder().encode(JSON.stringify({ version: 1, paths, scope })).byteLength)
+      .toBe(MAX_FILE_DRAG_BYTES);
+    const transfer = dragTransfer();
+    expect(writeFileDragData(transfer, paths, scope)).toBe(true);
+    expect(readFileDragData(transfer, scope)?.paths).toEqual(paths);
+  });
+
   it("rejects path count, path bytes, duplicates, mixed parents, scope, and total bytes", () => {
     expect(writeFileDragData(dragTransfer(), Array.from({ length: 101 }, (_, index) => `projects/${index}`), scope)).toBe(false);
     expect(writeFileDragData(dragTransfer(), [`projects/${"é".repeat(2_050)}`], scope)).toBe(false);

--- a/tests/desktop/file-drag.test.ts
+++ b/tests/desktop/file-drag.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  createFileDragSession,
+  FILE_MOVE_MIME,
+  isValidFileDropTarget,
+  MAX_FILE_DRAG_BYTES,
+  mountFileDragPreview,
+  readFileDragData,
+  writeFileDragData,
+} from "@desktop/renderer/src/features/files/file-drag";
+import { createFileSelection, updateFileSelection } from "@desktop/renderer/src/features/files/file-selection";
+
+const scope = { directory: "projects", runtimeSlot: "primary", authGeneration: 3 };
+
+function dragTransfer(types: string[] = []) {
+  const values: Record<string, string> = {};
+  return {
+    effectAllowed: "uninitialized",
+    dropEffect: "none",
+    files: [] as unknown as FileList,
+    get types() { return types.length ? types : Object.keys(values); },
+    getData: vi.fn((type: string) => values[type] ?? ""),
+    setData: vi.fn((type: string, value: string) => { values[type] = value; }),
+    setDragImage: vi.fn(),
+  } as unknown as DataTransfer;
+}
+
+describe("internal Files drag payload", () => {
+  it("round-trips normalized selected siblings through the one internal MIME type", () => {
+    const transfer = dragTransfer();
+
+    expect(writeFileDragData(transfer, ["projects/a.md", "projects/b.md"], scope)).toBe(true);
+    expect(transfer.effectAllowed).toBe("move");
+    expect(transfer.setData).toHaveBeenCalledWith(FILE_MOVE_MIME, expect.any(String));
+    expect(readFileDragData(transfer, scope)).toEqual({
+      version: 1,
+      paths: ["projects/a.md", "projects/b.md"],
+      scope,
+    });
+  });
+
+  it("drags an already selected row as the ordered selection with focused preview text", () => {
+    const selection = {
+      ...createFileSelection(scope),
+      selectedPaths: ["projects/a.md", "projects/b.md"],
+      anchorPath: "projects/a.md",
+      focusedPath: "projects/b.md",
+    };
+
+    expect(createFileDragSession(selection, "projects/a.md")).toEqual({
+      selection,
+      paths: ["projects/a.md", "projects/b.md"],
+      preview: { label: "b.md", additionalCount: 1 },
+    });
+  });
+
+  it("collapses an unselected drag row before building its preview", () => {
+    const selection = {
+      ...createFileSelection(scope),
+      selectedPaths: ["projects/a.md", "projects/b.md"],
+      anchorPath: "projects/a.md",
+      focusedPath: "projects/b.md",
+    };
+
+    expect(createFileDragSession(selection, "projects/c.md")).toMatchObject({
+      selection: {
+        selectedPaths: ["projects/c.md"],
+        anchorPath: "projects/c.md",
+        focusedPath: "projects/c.md",
+      },
+      paths: ["projects/c.md"],
+      preview: { label: "c.md", additionalCount: 0 },
+    });
+  });
+
+  it("rejects path count, path bytes, duplicates, mixed parents, scope, and total bytes", () => {
+    expect(writeFileDragData(dragTransfer(), Array.from({ length: 101 }, (_, index) => `projects/${index}`), scope)).toBe(false);
+    expect(writeFileDragData(dragTransfer(), [`projects/${"é".repeat(2_050)}`], scope)).toBe(false);
+    expect(writeFileDragData(dragTransfer(), ["projects/a", "projects/a"], scope)).toBe(false);
+    expect(writeFileDragData(dragTransfer(), ["projects/a", "archive/b"], scope)).toBe(false);
+    expect(writeFileDragData(dragTransfer(), ["projects/a"], { ...scope, runtimeSlot: "Preview Computer" })).toBe(false);
+    const large = Array.from({ length: 35 }, (_, index) => `projects/${index}-${"x".repeat(3_800)}`);
+    expect(writeFileDragData(dragTransfer(), large, scope)).toBe(false);
+  });
+
+  it("fails closed for malformed, oversized, external, unknown, and cross-scope drops", () => {
+    const malformed = dragTransfer([FILE_MOVE_MIME]);
+    vi.mocked(malformed.getData).mockReturnValue("{");
+    expect(readFileDragData(malformed, scope)).toBeNull();
+
+    const oversized = dragTransfer([FILE_MOVE_MIME]);
+    vi.mocked(oversized.getData).mockReturnValue("x".repeat(MAX_FILE_DRAG_BYTES + 1));
+    expect(readFileDragData(oversized, scope)).toBeNull();
+
+    const external = dragTransfer(["Files"]);
+    Object.defineProperty(external, "files", { value: { length: 1 } });
+    expect(readFileDragData(external, scope)).toBeNull();
+    expect(readFileDragData(dragTransfer(["text/plain"]), scope)).toBeNull();
+    expect(readFileDragData(dragTransfer(["text/html"]), scope)).toBeNull();
+
+    const unknownField = dragTransfer([FILE_MOVE_MIME]);
+    vi.mocked(unknownField.getData).mockReturnValue(JSON.stringify({
+      version: 1,
+      paths: ["projects/a"],
+      scope,
+      overwrite: true,
+    }));
+    expect(readFileDragData(unknownField, scope)).toBeNull();
+
+    const wrongVersion = dragTransfer([FILE_MOVE_MIME]);
+    vi.mocked(wrongVersion.getData).mockReturnValue(JSON.stringify({
+      version: 2,
+      paths: ["projects/a"],
+      scope,
+    }));
+    expect(readFileDragData(wrongVersion, scope)).toBeNull();
+
+    const crossScope = dragTransfer();
+    expect(writeFileDragData(crossScope, ["projects/a"], scope)).toBe(true);
+    expect(readFileDragData(crossScope, { ...scope, authGeneration: 4 })).toBeNull();
+  });
+
+  it("preserves explicit mac Command and Windows Control selection before drag", () => {
+    const order = ["projects/a.md", "projects/b.md"];
+    const mac = updateFileSelection(
+      updateFileSelection(createFileSelection(scope), order, order[0]!, {}, "mac"),
+      order, order[1]!, { metaKey: true }, "mac",
+    );
+    const windows = updateFileSelection(
+      updateFileSelection(createFileSelection(scope), order, order[0]!, {}, "windows"),
+      order, order[1]!, { ctrlKey: true }, "windows",
+    );
+
+    expect(createFileDragSession(mac, order[1]!)?.paths).toEqual(order);
+    expect(createFileDragSession(windows, order[1]!)?.paths).toEqual(order);
+  });
+
+  it("mounts at most one drag preview node and removes it deterministically", () => {
+    const first = mountFileDragPreview(document, { label: "a.md", additionalCount: 0 });
+    expect(document.querySelectorAll("[data-file-drag-preview]")).toHaveLength(1);
+    expect(first.element.textContent).toBe("a.md");
+
+    const second = mountFileDragPreview(document, { label: "b.md", additionalCount: 2 });
+    expect(document.querySelectorAll("[data-file-drag-preview]")).toHaveLength(1);
+    expect(document.body.contains(first.element)).toBe(false);
+    expect(second.element.textContent).toBe("b.md+2");
+
+    second.cleanup();
+    expect(document.querySelector("[data-file-drag-preview]")).toBeNull();
+    first.cleanup();
+  });
+
+  it("accepts a normalized destination and rejects current, source, and descendant targets", () => {
+    const payload = {
+      version: 1 as const,
+      paths: ["projects/Folder", "projects/a.md"],
+      scope,
+    };
+
+    expect(isValidFileDropTarget(payload, "archive")).toBe(true);
+    expect(isValidFileDropTarget(payload, "projects")).toBe(false);
+    expect(isValidFileDropTarget(payload, "projects/Folder")).toBe(false);
+    expect(isValidFileDropTarget(payload, "projects/Folder/nested")).toBe(false);
+  });
+});

--- a/tests/desktop/file-drag.test.ts
+++ b/tests/desktop/file-drag.test.ts
@@ -151,6 +151,18 @@ describe("internal Files drag payload", () => {
 
     expect(createFileDragSession(mac, order[1]!)?.paths).toEqual(order);
     expect(createFileDragSession(windows, order[1]!)?.paths).toEqual(order);
+
+    const exactBatch = Array.from({ length: 100 }, (_, index) => `projects/${index}.md`);
+    const exactSelection = {
+      ...createFileSelection(scope),
+      selectedPaths: exactBatch,
+      anchorPath: exactBatch[0]!,
+      focusedPath: exactBatch[0]!,
+    };
+    expect(createFileDragSession(exactSelection, exactBatch[0]!)?.paths).toEqual(exactBatch);
+
+    const oversized = [...exactBatch, "projects/100.md"];
+    expect(createFileDragSession({ ...exactSelection, selectedPaths: oversized }, oversized[0]!)).toBeNull();
   });
 
   it("mounts at most one drag preview node and removes it deterministically", () => {

--- a/tests/desktop/files-management-ui.test.tsx
+++ b/tests/desktop/files-management-ui.test.tsx
@@ -300,6 +300,7 @@ describe("Files management UI", () => {
     expect(screen.getByRole("status").textContent).toMatch(/batch actions support up to 100/i);
 
     fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for file-000.md" }));
+    expect((await screen.findByRole("menuitem", { name: "Move to…" })).hasAttribute("data-disabled")).toBe(true);
     expect((await screen.findByRole("menuitem", { name: "Move to Trash" })).hasAttribute("data-disabled")).toBe(true);
     fireEvent.keyDown(document, { key: "Escape" });
 
@@ -312,6 +313,7 @@ describe("Files management UI", () => {
     await waitFor(() => expect(screen.queryByRole("button", { name: "Open file-100.md" })).toBeNull());
     expect(screen.queryByRole("status")).toBeNull();
     fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for file-000.md" }));
+    expect((await screen.findByRole("menuitem", { name: "Move to…" })).hasAttribute("data-disabled")).toBe(false);
     expect((await screen.findByRole("menuitem", { name: "Move to Trash" })).hasAttribute("data-disabled")).toBe(false);
   });
 

--- a/tests/desktop/files-move-test-fixture.tsx
+++ b/tests/desktop/files-move-test-fixture.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import ComputerFileBrowser from "@desktop/renderer/src/features/files/ComputerFileBrowser";
+import { useBrowserViewPreference } from "@desktop/renderer/src/features/files/browser-view-preference";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+
+const CAPABILITIES = { canRename: true, canMove: true, canTrash: true };
+
+export function folderListing(path: string, names: string[]) {
+  return { path, entries: names.map((name) => ({ name, type: "directory" as const, capabilities: CAPABILITIES })) };
+}
+
+export function dragTransfer(types: string[] = []) {
+  const values: Record<string, string> = {};
+  return {
+    effectAllowed: "uninitialized",
+    dropEffect: "none",
+    files: [] as unknown as FileList,
+    get types() { return types.length ? types : Object.keys(values); },
+    getData: vi.fn((type: string) => values[type] ?? ""),
+    setData: vi.fn((type: string, value: string) => { values[type] = value; }),
+    setDragImage: vi.fn(),
+  } as unknown as DataTransfer;
+}
+
+export function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => { resolve = next; });
+  return { promise, resolve };
+}
+
+export function makeApi() {
+  const listings: Record<string, Array<{ name: string; type: "file" | "directory"; capabilities: typeof CAPABILITIES }>> = {
+    "": [
+      { name: "Archive", type: "directory", capabilities: CAPABILITIES },
+      { name: "Folder", type: "directory", capabilities: CAPABILITIES },
+      { name: "note.md", type: "file", capabilities: CAPABILITIES },
+      { name: "todo.md", type: "file", capabilities: CAPABILITIES },
+      { name: "locked.md", type: "file", capabilities: { canRename: false, canMove: false, canTrash: false } },
+    ],
+    Archive: [{ name: "Nested", type: "directory", capabilities: CAPABILITIES }],
+    Folder: [{ name: "Child", type: "directory", capabilities: CAPABILITIES }],
+    "Archive/Nested": [{ name: "deep.md", type: "file", capabilities: CAPABILITIES }],
+  };
+  let prepared: { requestId: string; sources: string[]; destinationDirectory: string } | null = null;
+  let conflictSources: string[] = [];
+  let invalidItems: Array<{ source: string; code: "source_missing" | "protected" | "invalid_destination" }> = [];
+  let resultCodes: Record<string, "moved" | "skipped" | "source_missing" | "protected" | "failed"> = {};
+  let executeError: unknown = null;
+  const listingErrors: Record<string, unknown> = {};
+  const listingPromises: Record<string, Array<Promise<unknown>>> = {};
+  let preflightPromise: Promise<unknown> | null = null;
+  let executePromise: Promise<unknown> | null = null;
+  return {
+    baseUrl: "https://app.matrix-os.com",
+    get: vi.fn(async (path: string) => {
+      const directory = new URLSearchParams(path.split("?")[1]).get("path") ?? "";
+      if (listingErrors[directory]) throw listingErrors[directory];
+      const queued = listingPromises[directory]?.shift();
+      if (queued) return queued;
+      return { path: directory, entries: listings[directory] ?? [] };
+    }),
+    post: vi.fn(async (path: string, body: Record<string, unknown>) => {
+      if (path !== "/api/files/batch/move") throw new Error("unexpected mutation");
+      if (body.phase === "preflight") {
+        prepared = body as unknown as typeof prepared;
+        if (preflightPromise) return preflightPromise;
+        return {
+          sources: body.sources,
+          destinationDirectory: body.destinationDirectory,
+          conflicts: conflictSources.map((source) => ({ source, destination: `Archive/${source}` })),
+          invalid: invalidItems,
+          preflightFingerprint: "move-fingerprint",
+        };
+      }
+      if (!prepared) throw new Error("execute without preflight");
+      if (executePromise) return executePromise;
+      if (executeError) {
+        const error = executeError;
+        executeError = null;
+        throw error;
+      }
+      const sources = prepared.sources;
+      for (const source of sources) {
+        if ((resultCodes[source] ?? "moved") !== "moved") continue;
+        const name = source.split("/").pop()!;
+        const sourceDirectory = source.split("/").slice(0, -1).join("/");
+        listings[sourceDirectory] = listings[sourceDirectory]!.filter((entry) => entry.name !== name);
+        listings[prepared.destinationDirectory] ??= [];
+        listings[prepared.destinationDirectory]!.push({ name, type: "file", capabilities: CAPABILITIES });
+      }
+      return {
+        results: sources.map((source) => (resultCodes[source] ?? "moved") === "moved" ? {
+          source,
+          destination: `${prepared!.destinationDirectory}/${source.split("/").pop()!}`,
+          code: "moved",
+        } : { source, code: resultCodes[source] }),
+        affectedDirectories: [...new Set([...sources.map((source) => source.split("/").slice(0, -1).join("/")), prepared.destinationDirectory])],
+      };
+    }),
+    setConflicts(sources: string[]) { conflictSources = sources; },
+    setInvalid(items: typeof invalidItems) { invalidItems = items; },
+    setResultCodes(next: typeof resultCodes) { resultCodes = next; },
+    setExecuteError(error: unknown) { executeError = error; },
+    setListingError(directory: string, error: unknown) { listingErrors[directory] = error; },
+    queueListing(directory: string, promise: Promise<unknown>) {
+      (listingPromises[directory] ??= []).push(promise);
+    },
+    setPreflightPromise(promise: Promise<unknown>) { preflightPromise = promise; },
+    setExecutePromise(promise: Promise<unknown>) { executePromise = promise; },
+    settleListing(source: string, destination: string) {
+      const name = source.split("/").pop()!;
+      const sourceDirectory = source.split("/").slice(0, -1).join("/");
+      listings[sourceDirectory] = listings[sourceDirectory]!.filter((entry) => entry.name !== name);
+      listings[destination] ??= [];
+      listings[destination]!.push({ name, type: "file", capabilities: CAPABILITIES });
+    },
+  };
+}
+
+export function installMoveApi(api: ReturnType<typeof makeApi>) {
+  useBrowserViewPreference.setState({ view: "list" });
+  useConnection.setState({
+    status: "signed-in",
+    handle: "operator",
+    platformHost: "https://app.matrix-os.com",
+    runtimeSlot: "primary",
+    authGeneration: 1,
+    api: api as never,
+  });
+}
+
+export function renderBrowser(props: Record<string, unknown> = {}) {
+  return render(<Tooltip.Provider><ComputerFileBrowser directorySocket={null} {...props as never} /></Tooltip.Provider>);
+}
+
+export async function openMoveFor(name: string) {
+  fireEvent.pointerDown(screen.getByRole("button", { name: `More actions for ${name}` }), { button: 0 });
+  fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
+}
+
+export async function startArchiveMove(name: string) {
+  await openMoveFor(name);
+  fireEvent.click(await screen.findByRole("button", { name: "Choose Archive" }));
+  fireEvent.click(screen.getByRole("button", { name: "Move" }));
+}

--- a/tests/desktop/files-move-ui.test.tsx
+++ b/tests/desktop/files-move-ui.test.tsx
@@ -1,0 +1,442 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ComputerFileBrowser from "@desktop/renderer/src/features/files/ComputerFileBrowser";
+import { useBrowserViewPreference } from "@desktop/renderer/src/features/files/browser-view-preference";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+import { FILE_MOVE_MIME } from "@desktop/renderer/src/features/files/file-drag";
+import { AppError } from "@desktop/renderer/src/lib/errors";
+
+const CAPABILITIES = { canRename: true, canMove: true, canTrash: true };
+
+function dragTransfer(types: string[] = []) {
+  const values: Record<string, string> = {};
+  return {
+    effectAllowed: "uninitialized",
+    dropEffect: "none",
+    files: [] as unknown as FileList,
+    get types() { return types.length ? types : Object.keys(values); },
+    getData: vi.fn((type: string) => values[type] ?? ""),
+    setData: vi.fn((type: string, value: string) => { values[type] = value; }),
+    setDragImage: vi.fn(),
+  } as unknown as DataTransfer;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => { resolve = next; });
+  return { promise, resolve };
+}
+
+function makeApi() {
+  const listings: Record<string, Array<{ name: string; type: "file" | "directory"; capabilities: typeof CAPABILITIES }>> = {
+    "": [
+      { name: "Archive", type: "directory", capabilities: CAPABILITIES },
+      { name: "Folder", type: "directory", capabilities: CAPABILITIES },
+      { name: "note.md", type: "file", capabilities: CAPABILITIES },
+      { name: "todo.md", type: "file", capabilities: CAPABILITIES },
+      { name: "locked.md", type: "file", capabilities: { canRename: false, canMove: false, canTrash: false } },
+    ],
+    Archive: [{ name: "Nested", type: "directory", capabilities: CAPABILITIES }],
+    Folder: [{ name: "Child", type: "directory", capabilities: CAPABILITIES }],
+    "Archive/Nested": [{ name: "deep.md", type: "file", capabilities: CAPABILITIES }],
+  };
+  let prepared: { requestId: string; sources: string[]; destinationDirectory: string } | null = null;
+  let conflictSources: string[] = [];
+  let resultCodes: Record<string, "moved" | "skipped" | "protected" | "failed"> = {};
+  let executeError: unknown = null;
+  let preflightPromise: Promise<unknown> | null = null;
+  let executePromise: Promise<unknown> | null = null;
+  return {
+    baseUrl: "https://app.matrix-os.com",
+    get: vi.fn(async (path: string) => {
+      const directory = new URLSearchParams(path.split("?")[1]).get("path") ?? "";
+      return { path: directory, entries: listings[directory] ?? [] };
+    }),
+    post: vi.fn(async (path: string, body: Record<string, unknown>) => {
+      if (path !== "/api/files/batch/move") throw new Error("unexpected mutation");
+      if (body.phase === "preflight") {
+        prepared = body as unknown as typeof prepared;
+        if (preflightPromise) return preflightPromise;
+        return {
+          sources: body.sources,
+          destinationDirectory: body.destinationDirectory,
+          conflicts: conflictSources.map((source) => ({ source, destination: `Archive/${source}` })),
+          invalid: [],
+          preflightFingerprint: "move-fingerprint",
+        };
+      }
+      if (!prepared) throw new Error("execute without preflight");
+      if (executePromise) return executePromise;
+      if (executeError) {
+        const error = executeError;
+        executeError = null;
+        throw error;
+      }
+      const sources = prepared.sources;
+      for (const source of sources) {
+        if ((resultCodes[source] ?? "moved") !== "moved") continue;
+        const name = source.split("/").pop()!;
+        const sourceDirectory = source.split("/").slice(0, -1).join("/");
+        listings[sourceDirectory] = listings[sourceDirectory]!.filter((entry) => entry.name !== name);
+        listings[prepared.destinationDirectory] ??= [];
+        listings[prepared.destinationDirectory]!.push({ name, type: "file", capabilities: CAPABILITIES });
+      }
+      return {
+        results: sources.map((source) => (resultCodes[source] ?? "moved") === "moved" ? {
+          source,
+          destination: `${prepared!.destinationDirectory}/${source.split("/").pop()!}`,
+          code: "moved",
+        } : { source, code: resultCodes[source] }),
+        affectedDirectories: [...new Set([...sources.map((source) => source.split("/").slice(0, -1).join("/")), prepared.destinationDirectory])],
+      };
+    }),
+    setConflicts(sources: string[]) { conflictSources = sources; },
+    setResultCodes(next: typeof resultCodes) { resultCodes = next; },
+    setExecuteError(error: unknown) { executeError = error; },
+    setPreflightPromise(promise: Promise<unknown>) { preflightPromise = promise; },
+    setExecutePromise(promise: Promise<unknown>) { executePromise = promise; },
+  };
+}
+
+function renderBrowser(props: Record<string, unknown> = {}) {
+  return render(<Tooltip.Provider><ComputerFileBrowser directorySocket={null} {...props as never} /></Tooltip.Provider>);
+}
+
+describe("Files move UI", () => {
+  let api: ReturnType<typeof makeApi>;
+
+  beforeEach(() => {
+    api = makeApi();
+    useBrowserViewPreference.setState({ view: "list" });
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://app.matrix-os.com",
+      runtimeSlot: "primary",
+      authGeneration: 1,
+      api: api as never,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("opens an accessible directory-only Move to picker and cancels without transport", async () => {
+    renderBrowser({ selectionPlatform: "mac" });
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    fireEvent.click(note);
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
+
+    expect(screen.getByRole("heading", { name: "Move 1 item" })).not.toBeNull();
+    expect(await screen.findByRole("button", { name: "Choose Archive" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Open note.md" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "New File" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Move" }).hasAttribute("disabled")).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel move" }));
+    expect(screen.queryByRole("heading", { name: "Move 1 item" })).toBeNull();
+    expect(api.post).not.toHaveBeenCalled();
+  });
+
+  it("offers the same Move to picker from the row context menu", async () => {
+    renderBrowser();
+    fireEvent.contextMenu(await screen.findByRole("button", { name: "Open note.md" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
+    expect(screen.getByRole("heading", { name: "Move 1 item" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel move" }));
+  });
+
+  it("navigates picker breadcrumbs and executes one no-conflict batch with the preflight identity", async () => {
+    renderBrowser();
+    fireEvent.click(await screen.findByRole("button", { name: "Open note.md" }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
+
+    const archive = await screen.findByRole("button", { name: "Choose Archive" });
+    fireEvent.doubleClick(archive);
+    expect(await screen.findByRole("button", { name: "Choose Nested" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Archive" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Up one level" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Choose Archive" }));
+    expect(screen.getByRole("button", { name: "Move" }).hasAttribute("disabled")).toBe(false);
+    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(2));
+    const preflight = api.post.mock.calls[0]![1] as Record<string, unknown>;
+    const execute = api.post.mock.calls[1]![1] as Record<string, unknown>;
+    expect(preflight).toMatchObject({ phase: "preflight", sources: ["note.md"], destinationDirectory: "Archive" });
+    expect(execute).toEqual({
+      phase: "execute",
+      requestId: preflight.requestId,
+      preflightFingerprint: "move-fingerprint",
+    });
+    await waitFor(() => expect(screen.queryByRole("heading", { name: "Move 1 item" })).toBeNull());
+    expect(screen.queryByRole("button", { name: "Open note.md" })).toBeNull();
+  });
+
+  it("explains and rejects source and descendant picker destinations before preflight", async () => {
+    renderBrowser();
+    fireEvent.click(await screen.findByRole("button", { name: "Open Folder" }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for Folder" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Choose Folder" }));
+    expect(screen.getByRole("alert").textContent).toMatch(/outside the selected folder/i);
+    expect(screen.getByRole("button", { name: "Move" }).hasAttribute("disabled")).toBe(true);
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Choose Folder" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Choose Child" }));
+    expect(screen.getByRole("alert").textContent).toMatch(/outside the selected folder/i);
+    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+    expect(api.post).not.toHaveBeenCalled();
+  });
+
+  it("resolves conflicts in source order and applies one allowed choice to remaining rows", async () => {
+    api.setConflicts(["note.md", "todo.md"]);
+    renderBrowser({ selectionPlatform: "mac" });
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    const todo = screen.getByRole("button", { name: "Open todo.md" });
+    fireEvent.click(note);
+    fireEvent.click(todo, { metaKey: true });
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for todo.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Choose Archive" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+
+    expect(await screen.findByRole("heading", { name: "Resolve move conflicts" })).not.toBeNull();
+    expect(screen.getAllByTestId("move-conflict-source").map((row) => row.textContent)).toEqual(["note.md", "todo.md"]);
+    expect(screen.queryByText(/overwrite|merge/i)).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Skip todo.md" }));
+    expect(screen.getByRole("button", { name: "Skip todo.md" }).getAttribute("aria-pressed")).toBe("true");
+    fireEvent.click(screen.getByRole("checkbox", { name: "Apply to remaining conflicts" }));
+    fireEvent.click(screen.getByRole("button", { name: "Keep Both for note.md" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move selected items" }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(2));
+    expect(api.post.mock.calls[1]![1]).toMatchObject({
+      phase: "execute",
+      conflictChoices: [
+        { source: "note.md", resolution: "keep-both" },
+        { source: "todo.md", resolution: "keep-both" },
+      ],
+    });
+  });
+
+  it("drags the ordered selection to a folder through the same batch controller path", async () => {
+    const transfer = dragTransfer();
+    renderBrowser({ selectionPlatform: "mac" });
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    const todo = screen.getByRole("button", { name: "Open todo.md" });
+    const archive = screen.getByRole("button", { name: "Open Archive" });
+    fireEvent.click(note);
+    fireEvent.click(todo, { metaKey: true });
+
+    fireEvent.dragStart(todo, { dataTransfer: transfer });
+    expect(transfer.effectAllowed).toBe("move");
+    expect(transfer.setData).toHaveBeenCalledWith(FILE_MOVE_MIME, expect.any(String));
+    expect(document.querySelector("[data-file-drag-preview]")?.textContent).toBe("todo.md+1");
+    fireEvent.dragOver(archive, { dataTransfer: transfer });
+    expect(archive.getAttribute("data-file-drop-target")).toBe("true");
+    expect(transfer.dropEffect).toBe("move");
+    fireEvent.dragLeave(archive, { dataTransfer: transfer });
+    expect(archive.getAttribute("data-file-drop-target")).toBe("false");
+    fireEvent.dragOver(archive, { dataTransfer: transfer });
+    fireEvent.drop(archive, { dataTransfer: transfer });
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(2));
+    expect(api.post.mock.calls[0]![1]).toMatchObject({
+      phase: "preflight",
+      sources: ["note.md", "todo.md"],
+      destinationDirectory: "Archive",
+    });
+    expect(document.querySelector("[data-file-drag-preview]")).toBeNull();
+  });
+
+  it("accepts an ancestor breadcrumb drop but never highlights the current directory", async () => {
+    const transfer = dragTransfer();
+    renderBrowser();
+    fireEvent.doubleClick(await screen.findByRole("button", { name: "Open Archive" }));
+    fireEvent.doubleClick(await screen.findByRole("button", { name: "Open Nested" }));
+    const deep = await screen.findByRole("button", { name: "Open deep.md" });
+    fireEvent.click(deep);
+    fireEvent.dragStart(deep, { dataTransfer: transfer });
+
+    const current = screen.getByRole("button", { name: "Nested" });
+    fireEvent.dragOver(current, { dataTransfer: transfer });
+    expect(current.getAttribute("data-file-drop-target")).toBe("false");
+    expect(api.post).not.toHaveBeenCalled();
+
+    const ancestor = screen.getByRole("button", { name: "Archive" });
+    fireEvent.dragOver(ancestor, { dataTransfer: transfer });
+    expect(ancestor.getAttribute("data-file-drop-target")).toBe("true");
+    fireEvent.drop(ancestor, { dataTransfer: transfer });
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(2));
+    expect(api.post.mock.calls[0]![1]).toMatchObject({
+      sources: ["Archive/Nested/deep.md"],
+      destinationDirectory: "Archive",
+    });
+  });
+
+  it("cancels a prepared conflict without execute and disables Move to for any incapable selection", async () => {
+    renderBrowser({ selectionPlatform: "mac" });
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    const locked = screen.getByRole("button", { name: "Open locked.md" });
+    fireEvent.click(note);
+    fireEvent.click(locked, { metaKey: true });
+    expect(note.getAttribute("draggable")).toBe("false");
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for locked.md" }), { button: 0 });
+    expect((await screen.findByRole("menuitem", { name: "Move to…" })).hasAttribute("data-disabled")).toBe(true);
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
+
+    fireEvent.click(note);
+    api.setConflicts(["note.md"]);
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Choose Archive" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+    expect(await screen.findByRole("heading", { name: "Resolve move conflicts" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel move" }));
+    expect(api.post).toHaveBeenCalledOnce();
+  });
+
+  it("retains skipped rows and focused preview after a partial authoritative move", async () => {
+    api.setResultCodes({ "todo.md": "skipped" });
+    const onPreviewPathChange = vi.fn();
+    renderBrowser({ selectionPlatform: "mac", onPreviewPathChange });
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    const todo = screen.getByRole("button", { name: "Open todo.md" });
+    fireEvent.click(note);
+    fireEvent.click(todo, { metaKey: true });
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for todo.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Choose Archive" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Open note.md" })).toBeNull());
+    expect(screen.getByRole("button", { name: "Open todo.md" }).getAttribute("aria-pressed")).toBe("true");
+    expect(onPreviewPathChange).toHaveBeenLastCalledWith("todo.md");
+    expect(screen.getByRole("status").textContent).toMatch(/skipped/i);
+    expect(api.get.mock.calls.some(([path]) => path === "/api/files/list?path=Archive")).toBe(true);
+  });
+
+  it("keeps an uncertain move selected and never retries until a fresh user action", async () => {
+    api.setExecuteError(new AppError("timeout", { cause: new Error("provider /home/operator") }));
+    renderBrowser();
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    fireEvent.click(note);
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Choose Archive" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(2));
+    expect(screen.getByRole("button", { name: "Open note.md" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("status").textContent).toMatch(/could not be confirmed/i);
+    expect(screen.getByRole("status").textContent).not.toMatch(/provider|\/home/i);
+    await Promise.resolve();
+    expect(api.post).toHaveBeenCalledTimes(2);
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Choose Archive" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(4));
+  });
+
+  it("rejects external drops and clears a live internal drag on auth scope change", async () => {
+    const view = renderBrowser();
+    const archive = await screen.findByRole("button", { name: "Open Archive" });
+    const external = dragTransfer(["Files"]);
+    Object.defineProperty(external, "files", { value: { length: 1 } });
+    fireEvent.dragOver(archive, { dataTransfer: external });
+    fireEvent.drop(archive, { dataTransfer: external });
+    expect(archive.getAttribute("data-file-drop-target")).toBe("false");
+    expect(api.post).not.toHaveBeenCalled();
+
+    const note = screen.getByRole("button", { name: "Open note.md" });
+    const internal = dragTransfer();
+    fireEvent.click(note);
+    fireEvent.dragStart(note, { dataTransfer: internal });
+    expect(document.querySelector("[data-file-drag-preview]")).not.toBeNull();
+    fireEvent.dragEnd(note, { dataTransfer: internal });
+    expect(document.querySelector("[data-file-drag-preview]")).toBeNull();
+    fireEvent.dragStart(note, { dataTransfer: internal });
+    act(() => useConnection.setState({ authGeneration: 2 }));
+    await waitFor(() => expect(document.querySelector("[data-file-drag-preview]")).toBeNull());
+    fireEvent.drop(archive, { dataTransfer: internal });
+    expect(api.post).not.toHaveBeenCalled();
+    const refreshed = await screen.findByRole("button", { name: "Open note.md" });
+    const finalTransfer = dragTransfer();
+    fireEvent.dragStart(refreshed, { dataTransfer: finalTransfer });
+    view.unmount();
+    expect(document.querySelector("[data-file-drag-preview]")).toBeNull();
+  });
+
+  it("closes synchronously and suppresses a held preflight after API/runtime/auth replacement", async () => {
+    const held = deferred<{
+      sources: string[];
+      destinationDirectory: string;
+      conflicts: [];
+      invalid: [];
+      preflightFingerprint: string;
+    }>();
+    api.setPreflightPromise(held.promise);
+    const onPreviewPathChange = vi.fn();
+    renderBrowser({ onPreviewPathChange });
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    fireEvent.click(note);
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Choose Archive" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+    await waitFor(() => expect(api.post).toHaveBeenCalledOnce());
+    expect(screen.getByText("Preparing move…")).not.toBeNull();
+
+    const replacement = makeApi();
+    act(() => useConnection.setState({ api: replacement as never, runtimeSlot: "preview", authGeneration: 2 }));
+    expect(screen.queryByText("Preparing move…")).toBeNull();
+    held.resolve({
+      sources: ["note.md"], destinationDirectory: "Archive", conflicts: [], invalid: [],
+      preflightFingerprint: "old-fingerprint",
+    });
+    await act(async () => { await held.promise; await Promise.resolve(); });
+
+    expect(api.post).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("heading", { name: "Resolve move conflicts" })).toBeNull();
+    expect((await screen.findByRole("button", { name: "Open note.md" })).getAttribute("aria-pressed")).toBe("false");
+    expect(onPreviewPathChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it("keeps pending rows disabled and suppresses a held execute after auth changes", async () => {
+    const held = deferred<{
+      results: Array<{ source: string; destination: string; code: "moved" }>;
+      affectedDirectories: string[];
+    }>();
+    api.setExecutePromise(held.promise);
+    renderBrowser();
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    fireEvent.click(note);
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Choose Archive" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(2));
+    expect(screen.getByRole("button", { name: "Open note.md", hidden: true }).hasAttribute("disabled")).toBe(true);
+
+    act(() => useConnection.setState({ authGeneration: 2 }));
+    held.resolve({
+      results: [{ source: "note.md", destination: "Archive/note.md", code: "moved" }],
+      affectedDirectories: ["", "Archive"],
+    });
+    await act(async () => { await held.promise; await Promise.resolve(); });
+    expect(api.post).toHaveBeenCalledTimes(2);
+    expect((await screen.findByRole("button", { name: "Open note.md" })).getAttribute("aria-pressed")).toBe("false");
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});

--- a/tests/desktop/files-move-ui.test.tsx
+++ b/tests/desktop/files-move-ui.test.tsx
@@ -1,125 +1,23 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import * as Tooltip from "@radix-ui/react-tooltip";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import ComputerFileBrowser from "@desktop/renderer/src/features/files/ComputerFileBrowser";
-import { useBrowserViewPreference } from "@desktop/renderer/src/features/files/browser-view-preference";
 import { useConnection } from "@desktop/renderer/src/stores/connection";
 import { FILE_MOVE_MIME } from "@desktop/renderer/src/features/files/file-drag";
 import { AppError } from "@desktop/renderer/src/lib/errors";
-
-const CAPABILITIES = { canRename: true, canMove: true, canTrash: true };
-
-function dragTransfer(types: string[] = []) {
-  const values: Record<string, string> = {};
-  return {
-    effectAllowed: "uninitialized",
-    dropEffect: "none",
-    files: [] as unknown as FileList,
-    get types() { return types.length ? types : Object.keys(values); },
-    getData: vi.fn((type: string) => values[type] ?? ""),
-    setData: vi.fn((type: string, value: string) => { values[type] = value; }),
-    setDragImage: vi.fn(),
-  } as unknown as DataTransfer;
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((next) => { resolve = next; });
-  return { promise, resolve };
-}
-
-function makeApi() {
-  const listings: Record<string, Array<{ name: string; type: "file" | "directory"; capabilities: typeof CAPABILITIES }>> = {
-    "": [
-      { name: "Archive", type: "directory", capabilities: CAPABILITIES },
-      { name: "Folder", type: "directory", capabilities: CAPABILITIES },
-      { name: "note.md", type: "file", capabilities: CAPABILITIES },
-      { name: "todo.md", type: "file", capabilities: CAPABILITIES },
-      { name: "locked.md", type: "file", capabilities: { canRename: false, canMove: false, canTrash: false } },
-    ],
-    Archive: [{ name: "Nested", type: "directory", capabilities: CAPABILITIES }],
-    Folder: [{ name: "Child", type: "directory", capabilities: CAPABILITIES }],
-    "Archive/Nested": [{ name: "deep.md", type: "file", capabilities: CAPABILITIES }],
-  };
-  let prepared: { requestId: string; sources: string[]; destinationDirectory: string } | null = null;
-  let conflictSources: string[] = [];
-  let resultCodes: Record<string, "moved" | "skipped" | "protected" | "failed"> = {};
-  let executeError: unknown = null;
-  let preflightPromise: Promise<unknown> | null = null;
-  let executePromise: Promise<unknown> | null = null;
-  return {
-    baseUrl: "https://app.matrix-os.com",
-    get: vi.fn(async (path: string) => {
-      const directory = new URLSearchParams(path.split("?")[1]).get("path") ?? "";
-      return { path: directory, entries: listings[directory] ?? [] };
-    }),
-    post: vi.fn(async (path: string, body: Record<string, unknown>) => {
-      if (path !== "/api/files/batch/move") throw new Error("unexpected mutation");
-      if (body.phase === "preflight") {
-        prepared = body as unknown as typeof prepared;
-        if (preflightPromise) return preflightPromise;
-        return {
-          sources: body.sources,
-          destinationDirectory: body.destinationDirectory,
-          conflicts: conflictSources.map((source) => ({ source, destination: `Archive/${source}` })),
-          invalid: [],
-          preflightFingerprint: "move-fingerprint",
-        };
-      }
-      if (!prepared) throw new Error("execute without preflight");
-      if (executePromise) return executePromise;
-      if (executeError) {
-        const error = executeError;
-        executeError = null;
-        throw error;
-      }
-      const sources = prepared.sources;
-      for (const source of sources) {
-        if ((resultCodes[source] ?? "moved") !== "moved") continue;
-        const name = source.split("/").pop()!;
-        const sourceDirectory = source.split("/").slice(0, -1).join("/");
-        listings[sourceDirectory] = listings[sourceDirectory]!.filter((entry) => entry.name !== name);
-        listings[prepared.destinationDirectory] ??= [];
-        listings[prepared.destinationDirectory]!.push({ name, type: "file", capabilities: CAPABILITIES });
-      }
-      return {
-        results: sources.map((source) => (resultCodes[source] ?? "moved") === "moved" ? {
-          source,
-          destination: `${prepared!.destinationDirectory}/${source.split("/").pop()!}`,
-          code: "moved",
-        } : { source, code: resultCodes[source] }),
-        affectedDirectories: [...new Set([...sources.map((source) => source.split("/").slice(0, -1).join("/")), prepared.destinationDirectory])],
-      };
-    }),
-    setConflicts(sources: string[]) { conflictSources = sources; },
-    setResultCodes(next: typeof resultCodes) { resultCodes = next; },
-    setExecuteError(error: unknown) { executeError = error; },
-    setPreflightPromise(promise: Promise<unknown>) { preflightPromise = promise; },
-    setExecutePromise(promise: Promise<unknown>) { executePromise = promise; },
-  };
-}
-
-function renderBrowser(props: Record<string, unknown> = {}) {
-  return render(<Tooltip.Provider><ComputerFileBrowser directorySocket={null} {...props as never} /></Tooltip.Provider>);
-}
+import { MoveFilesDialog } from "@desktop/renderer/src/features/files/MoveFilesDialog";
+import {
+  deferred, dragTransfer, folderListing, installMoveApi, makeApi,
+  openMoveFor, renderBrowser, startArchiveMove,
+} from "./files-move-test-fixture";
 
 describe("Files move UI", () => {
   let api: ReturnType<typeof makeApi>;
 
   beforeEach(() => {
     api = makeApi();
-    useBrowserViewPreference.setState({ view: "list" });
-    useConnection.setState({
-      status: "signed-in",
-      handle: "operator",
-      platformHost: "https://app.matrix-os.com",
-      runtimeSlot: "primary",
-      authGeneration: 1,
-      api: api as never,
-    });
+    installMoveApi(api);
   });
 
   afterEach(() => {
@@ -131,8 +29,7 @@ describe("Files move UI", () => {
     renderBrowser({ selectionPlatform: "mac" });
     const note = await screen.findByRole("button", { name: "Open note.md" });
     fireEvent.click(note);
-    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
-    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
+    await openMoveFor("note.md");
 
     expect(screen.getByRole("heading", { name: "Move 1 item" })).not.toBeNull();
     expect(await screen.findByRole("button", { name: "Choose Archive" })).not.toBeNull();
@@ -143,6 +40,65 @@ describe("Files move UI", () => {
     fireEvent.click(screen.getByRole("button", { name: "Cancel move" }));
     expect(screen.queryByRole("heading", { name: "Move 1 item" })).toBeNull();
     expect(api.post).not.toHaveBeenCalled();
+  });
+
+  it("reports picker candidates to the serializable move session", async () => {
+    const chooseCandidate = vi.fn();
+    const controls = (destination: string | null) => ({
+      session: {
+        origin: "menu", stage: "picking", sources: ["note.md"], destination,
+        preflight: null, choices: [], applyToRemaining: false,
+      },
+      chooseCandidate,
+      cancelMove: vi.fn(),
+      chooseDestination: vi.fn(),
+      setApplyToRemaining: vi.fn(),
+      chooseConflict: vi.fn(),
+      confirmMove: vi.fn(),
+    });
+    const view = render(<MoveFilesDialog controls={controls(null) as never} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Choose Archive" }));
+
+    expect(chooseCandidate).toHaveBeenCalledWith("Archive");
+    expect(screen.getByRole("button", { name: "Move" }).hasAttribute("disabled")).toBe(true);
+    view.rerender(<MoveFilesDialog controls={controls("Archive") as never} />);
+    expect((await screen.findByRole("button", { name: "Choose Archive" })).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: "Move" }).hasAttribute("disabled")).toBe(false);
+  });
+
+  it("shows a safe picker listing error and retries instead of appearing empty", async () => {
+    renderBrowser();
+    fireEvent.click(await screen.findByRole("button", { name: "Open note.md" }));
+    api.setListingError("", new Error("provider /home/operator unavailable"));
+    await openMoveFor("note.md");
+
+    expect((await screen.findByRole("alert")).textContent).toBe("Folders could not be loaded.");
+    expect(screen.queryByText(/provider|\/home\/operator/i)).toBeNull();
+    expect(screen.queryByText("No subfolders here.")).toBeNull();
+    api.setListingError("", null);
+    fireEvent.click(screen.getByRole("button", { name: "Retry folders" }));
+    expect(await screen.findByRole("button", { name: "Choose Archive" })).not.toBeNull();
+  });
+
+  it("keeps the newest picker folder when listing responses arrive out of order", async () => {
+    renderBrowser();
+    fireEvent.click(await screen.findByRole("button", { name: "Open note.md" }));
+    await openMoveFor("note.md");
+    const archive = deferred<ReturnType<typeof folderListing>>();
+    const home = deferred<ReturnType<typeof folderListing>>();
+    api.queueListing("Archive", archive.promise);
+    api.queueListing("", home.promise);
+
+    fireEvent.doubleClick(await screen.findByRole("button", { name: "Choose Archive" }));
+    fireEvent.click(screen.getByRole("button", { name: "Matrix home" }));
+    home.resolve(folderListing("", ["Home only"]));
+    await act(async () => { await home.promise; });
+    expect(await screen.findByRole("button", { name: "Choose Home only" })).not.toBeNull();
+
+    archive.resolve(folderListing("Archive", ["Stale folder"]));
+    await act(async () => { await archive.promise; });
+    expect(screen.queryByRole("button", { name: "Choose Stale folder" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Choose Home only" })).not.toBeNull();
   });
 
   it("offers the same Move to picker from the row context menu", async () => {
@@ -156,8 +112,7 @@ describe("Files move UI", () => {
   it("navigates picker breadcrumbs and executes one no-conflict batch with the preflight identity", async () => {
     renderBrowser();
     fireEvent.click(await screen.findByRole("button", { name: "Open note.md" }));
-    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
-    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
+    await openMoveFor("note.md");
 
     const archive = await screen.findByRole("button", { name: "Choose Archive" });
     fireEvent.doubleClick(archive);
@@ -184,8 +139,7 @@ describe("Files move UI", () => {
   it("explains and rejects source and descendant picker destinations before preflight", async () => {
     renderBrowser();
     fireEvent.click(await screen.findByRole("button", { name: "Open Folder" }));
-    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for Folder" }), { button: 0 });
-    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
+    await openMoveFor("Folder");
 
     fireEvent.click(await screen.findByRole("button", { name: "Choose Folder" }));
     expect(screen.getByRole("alert").textContent).toMatch(/outside the selected folder/i);
@@ -204,10 +158,7 @@ describe("Files move UI", () => {
     const todo = screen.getByRole("button", { name: "Open todo.md" });
     fireEvent.click(note);
     fireEvent.click(todo, { metaKey: true });
-    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for todo.md" }), { button: 0 });
-    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Choose Archive" }));
-    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+    await startArchiveMove("todo.md");
 
     expect(await screen.findByRole("heading", { name: "Resolve move conflicts" })).not.toBeNull();
     expect(screen.getAllByTestId("move-conflict-source").map((row) => row.textContent)).toEqual(["note.md", "todo.md"]);
@@ -258,6 +209,30 @@ describe("Files move UI", () => {
     expect(document.querySelector("[data-file-drag-preview]")).toBeNull();
   });
 
+  it("accepts Chromium protected-mode dragover before strict payload parsing on drop", async () => {
+    const transfer = dragTransfer();
+    renderBrowser();
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    const archive = screen.getByRole("button", { name: "Open Archive" });
+    fireEvent.click(note);
+    fireEvent.dragStart(note, { dataTransfer: transfer });
+    const serialized = vi.mocked(transfer.setData).mock.calls[0]![1];
+    vi.mocked(transfer.getData).mockReturnValue("");
+
+    fireEvent.dragOver(archive, { dataTransfer: transfer });
+    expect(archive.getAttribute("data-file-drop-target")).toBe("true");
+    expect(transfer.dropEffect).toBe("move");
+
+    fireEvent.dragOver(archive, { dataTransfer: dragTransfer(["text/plain"]) });
+    expect(archive.getAttribute("data-file-drop-target")).toBe("false");
+    fireEvent.dragOver(archive, { dataTransfer: transfer });
+    expect(archive.getAttribute("data-file-drop-target")).toBe("true");
+
+    vi.mocked(transfer.getData).mockReturnValue(serialized);
+    fireEvent.drop(archive, { dataTransfer: transfer });
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(2));
+  });
+
   it("accepts an ancestor breadcrumb drop but never highlights the current directory", async () => {
     const transfer = dragTransfer();
     renderBrowser();
@@ -296,10 +271,7 @@ describe("Files move UI", () => {
 
     fireEvent.click(note);
     api.setConflicts(["note.md"]);
-    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
-    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Choose Archive" }));
-    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+    await startArchiveMove("note.md");
     expect(await screen.findByRole("heading", { name: "Resolve move conflicts" })).not.toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Cancel move" }));
     expect(api.post).toHaveBeenCalledOnce();
@@ -313,10 +285,7 @@ describe("Files move UI", () => {
     const todo = screen.getByRole("button", { name: "Open todo.md" });
     fireEvent.click(note);
     fireEvent.click(todo, { metaKey: true });
-    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for todo.md" }), { button: 0 });
-    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Choose Archive" }));
-    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+    await startArchiveMove("todo.md");
 
     await waitFor(() => expect(screen.queryByRole("button", { name: "Open note.md" })).toBeNull());
     expect(screen.getByRole("button", { name: "Open todo.md" }).getAttribute("aria-pressed")).toBe("true");
@@ -330,10 +299,7 @@ describe("Files move UI", () => {
     renderBrowser();
     const note = await screen.findByRole("button", { name: "Open note.md" });
     fireEvent.click(note);
-    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
-    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Choose Archive" }));
-    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+    await startArchiveMove("note.md");
 
     await waitFor(() => expect(api.post).toHaveBeenCalledTimes(2));
     expect(screen.getByRole("button", { name: "Open note.md" }).getAttribute("aria-pressed")).toBe("true");
@@ -342,10 +308,7 @@ describe("Files move UI", () => {
     await Promise.resolve();
     expect(api.post).toHaveBeenCalledTimes(2);
 
-    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
-    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Choose Archive" }));
-    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+    await startArchiveMove("note.md");
     await waitFor(() => expect(api.post).toHaveBeenCalledTimes(4));
   });
 
@@ -378,7 +341,7 @@ describe("Files move UI", () => {
     expect(document.querySelector("[data-file-drag-preview]")).toBeNull();
   });
 
-  it("closes synchronously and suppresses a held preflight after API/runtime/auth replacement", async () => {
+  it("suppresses a held preflight after main navigation and API/runtime/auth replacement", async () => {
     const held = deferred<{
       sources: string[];
       destinationDirectory: string;
@@ -391,13 +354,13 @@ describe("Files move UI", () => {
     renderBrowser({ onPreviewPathChange });
     const note = await screen.findByRole("button", { name: "Open note.md" });
     fireEvent.click(note);
-    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
-    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Choose Archive" }));
-    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+    await startArchiveMove("note.md");
     await waitFor(() => expect(api.post).toHaveBeenCalledOnce());
     expect(screen.getByText("Preparing move…")).not.toBeNull();
 
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Open Archive", hidden: true }));
+    expect(screen.queryByText("Preparing move…")).toBeNull();
+    expect(await screen.findByRole("button", { name: "Open Nested" })).not.toBeNull();
     const replacement = makeApi();
     act(() => useConnection.setState({ api: replacement as never, runtimeSlot: "preview", authGeneration: 2 }));
     expect(screen.queryByText("Preparing move…")).toBeNull();
@@ -409,26 +372,27 @@ describe("Files move UI", () => {
 
     expect(api.post).toHaveBeenCalledOnce();
     expect(screen.queryByRole("heading", { name: "Resolve move conflicts" })).toBeNull();
-    expect((await screen.findByRole("button", { name: "Open note.md" })).getAttribute("aria-pressed")).toBe("false");
+    expect((await screen.findByRole("button", { name: "Open note.md" })).getAttribute("aria-selected")).not.toBe("true");
     expect(onPreviewPathChange).toHaveBeenLastCalledWith(null);
   });
 
-  it("keeps pending rows disabled and suppresses a held execute after auth changes", async () => {
+  it("suppresses a held execute after main navigation and auth changes", async () => {
     const held = deferred<{
       results: Array<{ source: string; destination: string; code: "moved" }>;
       affectedDirectories: string[];
     }>();
     api.setExecutePromise(held.promise);
-    renderBrowser();
+    const onPreviewPathChange = vi.fn();
+    renderBrowser({ onPreviewPathChange });
     const note = await screen.findByRole("button", { name: "Open note.md" });
     fireEvent.click(note);
-    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
-    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to…" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Choose Archive" }));
-    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+    await startArchiveMove("note.md");
     await waitFor(() => expect(api.post).toHaveBeenCalledTimes(2));
     expect(screen.getByRole("button", { name: "Open note.md", hidden: true }).hasAttribute("disabled")).toBe(true);
 
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Open Archive", hidden: true }));
+    expect(screen.queryByText("Preparing move…")).toBeNull();
+    expect(await screen.findByRole("button", { name: "Open Nested" })).not.toBeNull();
     act(() => useConnection.setState({ authGeneration: 2 }));
     held.resolve({
       results: [{ source: "note.md", destination: "Archive/note.md", code: "moved" }],
@@ -436,7 +400,63 @@ describe("Files move UI", () => {
     });
     await act(async () => { await held.promise; await Promise.resolve(); });
     expect(api.post).toHaveBeenCalledTimes(2);
-    expect((await screen.findByRole("button", { name: "Open note.md" })).getAttribute("aria-pressed")).toBe("false");
+    expect((await screen.findByRole("button", { name: "Open note.md" })).getAttribute("aria-selected")).not.toBe("true");
+    expect(onPreviewPathChange).toHaveBeenLastCalledWith(null);
     expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("does not dismiss an executing move with Escape or an outside pointer", async () => {
+    const held = deferred<{
+      results: Array<{ source: string; destination: string; code: "moved" }>;
+      affectedDirectories: string[];
+    }>();
+    api.setExecutePromise(held.promise);
+    const onPreviewPathChange = vi.fn();
+    renderBrowser({ onPreviewPathChange });
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    fireEvent.click(note);
+    await startArchiveMove("note.md");
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(2));
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    fireEvent.pointerDown(document.body);
+    expect(screen.getByText("Preparing move…")).not.toBeNull();
+
+    api.settleListing("note.md", "Archive");
+    held.resolve({
+      results: [{ source: "note.md", destination: "Archive/note.md", code: "moved" }],
+      affectedDirectories: ["", "Archive"],
+    });
+    await act(async () => { await held.promise; await Promise.resolve(); });
+    expect(api.post).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole("button", { name: "Open note.md" })).toBeNull();
+    expect(onPreviewPathChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it("shows allowlisted invalid reasons in source order and retains those rows", async () => {
+    api.setInvalid([
+      { source: "note.md", code: "source_missing" },
+      { source: "todo.md", code: "protected" },
+    ]);
+    api.setResultCodes({ "note.md": "source_missing", "todo.md": "protected" });
+    const onPreviewPathChange = vi.fn();
+    renderBrowser({ selectionPlatform: "mac", onPreviewPathChange });
+    fireEvent.click(await screen.findByRole("button", { name: "Open note.md" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open todo.md" }), { metaKey: true });
+    await startArchiveMove("todo.md");
+
+    expect(await screen.findByRole("heading", { name: "Resolve move conflicts" })).not.toBeNull();
+    expect(screen.getAllByTestId("move-invalid-source").map((row) => row.textContent)).toEqual([
+      "note.md", "todo.md",
+    ]);
+    expect(screen.getByText("This item is no longer available.")).not.toBeNull();
+    expect(screen.getByText("This item is protected and cannot be moved.")).not.toBeNull();
+    expect(screen.queryByText(/^(source_missing|protected|invalid_destination)$/i)).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Move selected items" }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(2));
+    expect(screen.getByRole("button", { name: "Open note.md" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: "Open todo.md" }).getAttribute("aria-pressed")).toBe("true");
+    expect(onPreviewPathChange).toHaveBeenLastCalledWith("note.md");
   });
 });


### PR DESCRIPTION
## Summary

- add the folder picker and internal drag-to-move interaction to Desktop Files
- route menu and drag moves through the same typed preflight, conflict, and execute controller
- reconcile source and destination listings while retaining partial or uncertain items

## Stack

8 of 8. Base: #1203 (`feat(desktop): add Files management interactions`).

- #1197 safe file-management core
- #1198 Linux native capability and immutable CI action pins
- #1199 batch preflight and move
- #1200 Trash and typed routes
- #1201 authenticated directory subscriptions
- #1202 Desktop file-operation state
- #1203 Desktop CRUD, selection, and Trash UI
- #1186 move picker and drag

## Validation

- focused Gateway: 321 passed; 63 Linux-native cases honestly skipped on macOS
- focused Desktop: 273 passed
- aggregate repository typecheck passed
- pattern scanner passed with 0 violations; four broad warnings were manually reviewed
- exact Linux x64 glibc CI compiled the addon and passed the real native capability/Gateway integration: https://github.com/HamedMP/matrix-os/actions/runs/31596860419
- Preview VPS `pr-1186` bundle `v2026.08.12-pr1186-58cb07a`: create, rename, Command multi-select, two-file picker move, internal drag move, Keep Both conflict, Trash, and Terminal-to-Files live refresh passed
- test content was moved to Preview Trash; permanent deletion was intentionally not exercised

## Invariants

- **Source of truth:** authoritative source and destination listings from the active Matrix computer.
- **Lock/transaction scope:** one typed preflight/execute operation; native no-replace semantics remain in the lower stack.
- **Acceptable orphan states:** skipped, failed, or uncertain items remain selected; no blind retry or silent overwrite.
- **Auth source of truth:** committed Desktop API/runtime/auth scope and authenticated Gateway principal.
- **Deferred scope:** permanent deletion and user-facing Trash management are tracked separately; external Finder upload is not part of drag-to-move.

## Documentation

- FinnaAI/matrix-os-site#22

## Latest validation (2026-08-12)

- internal drag accepts exactly 100 paths and rejects 101 as one unit; it never moves a silent prefix
- batch move keeps execution capacity after 512 accepted preflights
- partial Trash settlement is cached after a committed item if queue admission is later lost
- directory watchers bind acquisition to the authorized device/inode identity
- exact production-build visual geometry: Modified ends at x=604.59, the action button starts at x=620.59, horizontal overlap is 0 px
- the full repository suite remains red only in 18 files unchanged from `origin/main`, as recorded by the Task 11 baseline audit
