### PR TITLE
fix(desktop): keep shell preview fitted when zooming

### DIFF
--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -102,6 +102,21 @@ function zoomTarget(event: unknown): ZoomTarget | null {
   return null;
 }
 
+function toWebContentsViewBounds(
+  bounds: InvokeRequest<"embed:set-bounds">["bounds"],
+  event: unknown,
+): InvokeRequest<"embed:set-bounds">["bounds"] {
+  const factor = clampZoomFactor(
+    zoomTarget(event)?.getZoomFactor() ?? DEFAULT_ZOOM_FACTOR,
+  );
+  return {
+    x: Math.round(bounds.x * factor),
+    y: Math.round(bounds.y * factor),
+    width: Math.round(bounds.width * factor),
+    height: Math.round(bounds.height * factor),
+  };
+}
+
 export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): void {
   function handle<C extends InvokeChannel>(channel: C, handler: Handler<C>): void {
     ipcMain.handle(channel, async (_event, rawPayload) => {
@@ -231,9 +246,14 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
     return { ok: true };
   });
 
-  handle("embed:open", async ({ kind, slug, bounds, active }) => {
+  handle("embed:open", async ({ kind, slug, bounds, active }, event) => {
     try {
-      return await ctx.embeds.open({ kind, slug, bounds, active });
+      return await ctx.embeds.open({
+        kind,
+        slug,
+        bounds: toWebContentsViewBounds(bounds, event),
+        active,
+      });
     } catch (err: unknown) {
       console.warn(
         "[ipc] embed:open failed:",
@@ -242,8 +262,8 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
       throw new Error("embed unavailable");
     }
   });
-  handle("embed:set-bounds", ({ embedId, bounds }) => ({
-    ok: ctx.embeds.setBounds(embedId, bounds),
+  handle("embed:set-bounds", ({ embedId, bounds }, event) => ({
+    ok: ctx.embeds.setBounds(embedId, toWebContentsViewBounds(bounds, event)),
   }));
   handle("embed:set-active", ({ embedId, active }) => ({
     ok: ctx.embeds.setActive(embedId, active),

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -108,6 +108,63 @@ describe("registerIpcHandlers", () => {
     ).rejects.toThrow("embed unavailable");
   });
 
+  it.each([
+    {
+      factor: 1.5,
+      expected: { x: 360, y: 57, width: 920, height: 764 },
+    },
+    {
+      factor: 0.8,
+      expected: { x: 192, y: 30, width: 490, height: 407 },
+    },
+  ])("converts embed bounds at $factor zoom to native view coordinates", async ({
+    factor,
+    expected,
+  }) => {
+    const harness = makeHarness();
+    const sender = { getZoomFactor: vi.fn(() => factor), setZoomFactor: vi.fn() };
+    vi.mocked(harness.ctx.embeds.setBounds).mockReturnValue(true);
+
+    await expect(
+      harness.invoke(
+        "embed:set-bounds",
+        {
+          embedId: "embed-1",
+          bounds: { x: 240, y: 38, width: 613, height: 509 },
+        },
+        { sender },
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect(harness.ctx.embeds.setBounds).toHaveBeenCalledWith("embed-1", expected);
+  });
+
+  it("converts initial embed bounds from renderer CSS pixels to native view coordinates", async () => {
+    const harness = makeHarness();
+    const sender = { getZoomFactor: vi.fn(() => 1.5), setZoomFactor: vi.fn() };
+    vi.mocked(harness.ctx.embeds.open).mockResolvedValue({
+      embedId: "embed-1",
+      state: "loading",
+    });
+
+    await expect(
+      harness.invoke(
+        "embed:open",
+        {
+          kind: "hosted-shell",
+          bounds: { x: 240, y: 38, width: 613, height: 509 },
+          active: true,
+        },
+        { sender },
+      ),
+    ).resolves.toEqual({ embedId: "embed-1", state: "loading" });
+    expect(harness.ctx.embeds.open).toHaveBeenCalledWith({
+      kind: "hosted-shell",
+      slug: undefined,
+      bounds: { x: 360, y: 57, width: 920, height: 764 },
+      active: true,
+    });
+  });
+
   it("returns a failed retry-auth result when embed retry throws", async () => {
     const harness = makeHarness();
     vi.mocked(harness.ctx.embeds.retryAuth).mockRejectedValue(new Error("handoff unavailable"));


### PR DESCRIPTION
## Summary

- Convert renderer CSS bounds to `WebContentsView` coordinates using the
  authoritative Electron sender zoom factor.
- Apply the conversion to both initial embed creation and subsequent bounds
  updates so the shell preview remains fitted without a refresh.
- Add IPC regression coverage for zooming in to 150% and out to 80%.

## Tests

- `pnpm exec vitest run tests/desktop/embed-host.test.tsx tests/desktop/app-zoom.test.ts tests/desktop/ipc-handlers.test.ts tests/desktop/appearance-store.test.ts` — 61 passed
- `bun run typecheck` — passed
- `bun run check:patterns` — 0 violations (existing repository warnings only)
- `bun run build:desktop` — passed (existing MarkdownPreview chunk warning only)
- Real Electron validation against the stub gateway:
  - 150%: renderer `240,38,613x509` -> native child `360,57,920x764`
  - 80%: renderer `240,38,1360x987` -> native child `192,30,1088x790`
  - 80% after resize to `1100x700`: native child `192,30,908x670`
  - All right/bottom edges remained aligned without a refresh.
- The initial local `bun run test` was stopped after unrelated suites outside
  this diff failed; the changed Desktop IPC test passed 42/42 in that run.
- Authoritative GitHub CI is green: type check, pattern scan, React Doctor,
  docs contracts, sync client package, shell production build, all four unit
  test shards, E2E tests, and the aggregate CI result passed.

## Review / Monitoring

- Local standards review: no hard violations; helper naming feedback resolved.
- Local MAT-288 spec review: all acceptance criteria covered; no scope creep.
- Greptile approved commit `332b113d4d966a2bdcce14dec9afad3a6a8bdabd`
  with confidence 5/5 and no actionable defects.
- Claude review passed with no comments; GitHub has zero review threads.
- `ready-for-ci` is applied and all triggered checks passed or were correctly
  skipped as out of scope.

## Invariants

### Source of truth

- The renderer remains the source of CSS layout bounds.
- `event.sender.getZoomFactor()` is the authoritative applied Electron zoom.
- Main converts those validated bounds once before calling the native embed
  service; no second bounds store or reconciliation path is introduced.

### Lock/transaction scope

- No locks, transactions, database writes, filesystem writes, or network calls
  are added. Conversion is synchronous inside the validated IPC handler.

### Acceptable orphan states

- No resources are created by the conversion. Existing embed open failures
  retain their generic `embed unavailable` handling.

### Auth source of truth

- Existing typed IPC contracts and the trusted Electron sender remain the
  boundary. No authentication or authorization behavior changes.

### Deferred scope

- `tests/desktop/ipc-handlers.test.ts` now exceeds 1000 lines. A follow-up
  extraction should move embed/zoom IPC cases and their focused harness into a
  dedicated test file; this PR avoids mixing that structural refactor into the
  bug fix.
- No changes to app zoom controls or renderer layout are included.

Closes MAT-288.
