### PR TITLE
fix(desktop): align sign-in with device approval

### DIFF
--- a/desktop/src/renderer/src/features/signin/SignIn.tsx
+++ b/desktop/src/renderer/src/features/signin/SignIn.tsx
@@ -1,36 +1,15 @@
-import { Cloud, GitBranch, Sparkles, Terminal } from "lucide-react";
+import { Cloud, ExternalLink, GitBranch, MonitorCheck, ShieldCheck, Sparkles } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { BrandPanel } from "../../design/BrandPanel";
 import { invoke } from "../../lib/operator";
 import { useConnection } from "../../stores/connection";
 
-type Tab = "signin" | "create";
 type Phase = "idle" | "starting" | "waiting" | "expired" | "error";
 
 const POLL_INTERVAL_MS = 2000;
 
-function GoogleGlyph() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 18 18" aria-hidden>
-      <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.71-1.57 2.68-3.89 2.68-6.62Z" />
-      <path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.81.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.96v2.33A9 9 0 0 0 9 18Z" />
-      <path fill="#FBBC05" d="M3.97 10.72a5.4 5.4 0 0 1 0-3.44V4.95H.96a9 9 0 0 0 0 8.1l3.01-2.33Z" />
-      <path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58A9 9 0 0 0 .96 4.95l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58Z" />
-    </svg>
-  );
-}
-
-function GitHubGlyph() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
-      <path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8 8 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
-    </svg>
-  );
-}
-
 export default function SignIn() {
   const refresh = useConnection((s) => s.refresh);
-  const [tab, setTab] = useState<Tab>("signin");
   const [phase, setPhase] = useState<Phase>("idle");
   const [userCode, setUserCode] = useState<string | null>(null);
   const [verificationUri, setVerificationUri] = useState<string | null>(null);
@@ -44,9 +23,6 @@ export default function SignIn() {
   }, []);
   useEffect(() => stopPolling, [stopPolling]);
 
-  // Every provider button opens the same device-auth browser flow; the browser
-  // presents Google/GitHub/email via Clerk. The desktop app never handles a
-  // password directly.
   const start = useCallback(async () => {
     setPhase("starting");
     try {
@@ -54,6 +30,9 @@ export default function SignIn() {
       setUserCode(code.userCode);
       setVerificationUri(code.verificationUri);
       setPhase("waiting");
+      // Browser launch is best-effort. The verification code and reopen action
+      // remain available if the OS blocks the first attempt.
+      void invoke("shell:open-external", { url: code.verificationUri }).catch(() => undefined);
       stopPolling();
       pollTimer.current = setInterval(() => {
         void invoke("auth:poll", {})
@@ -76,20 +55,7 @@ export default function SignIn() {
     }
   }, [refresh, stopPolling]);
 
-  const oauthButton = (glyph: React.ReactNode, label: string) => (
-    <button
-      type="button"
-      disabled={phase === "starting"}
-      onClick={() => void start()}
-      className="no-drag flex h-11 w-full items-center justify-center gap-2.5 rounded-lg border text-sm font-medium transition-colors duration-100 disabled:opacity-60"
-      style={{ borderColor: "var(--border-default)", background: "var(--bg-surface)", color: "var(--text-primary)" }}
-      onMouseEnter={(e) => (e.currentTarget.style.background = "var(--bg-hover)")}
-      onMouseLeave={(e) => (e.currentTarget.style.background = "var(--bg-surface)")}
-    >
-      {glyph}
-      {label}
-    </button>
-  );
+  const waitingForApproval = phase === "waiting" && userCode !== null;
 
   return (
     <div className="flex h-full flex-col" style={{ background: "var(--bg-app)" }}>
@@ -109,17 +75,19 @@ export default function SignIn() {
           <div className="fade-in flex w-[360px] flex-col gap-5">
             <div className="flex flex-col items-center gap-1.5 text-center">
               <h2 className="text-xl font-semibold tracking-tight" style={{ color: "var(--text-primary)" }}>
-                Welcome to Matrix OS
+                {waitingForApproval ? "Finish in your browser" : "Connect Matrix Desktop"}
               </h2>
               <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
-                Sign in to your account or create a new one to get started.
+                {waitingForApproval
+                  ? "Approve this desktop from the Matrix OS page opened in your browser."
+                  : "Sign in or create an account in your browser, then choose a Matrix computer to connect."}
               </p>
             </div>
 
-            {phase === "waiting" && userCode ? (
+            {waitingForApproval ? (
               <div className="flex flex-col items-center gap-4 rounded-xl border p-6" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-sunken)" }}>
                 <span className="text-sm" style={{ color: "var(--text-secondary)" }}>
-                  Approve this code in your browser:
+                  Confirm this code on the approval page:
                 </span>
                 <div
                   className="rounded-lg border px-5 py-3 font-mono text-xl tracking-[0.25em]"
@@ -141,69 +109,62 @@ export default function SignIn() {
                   </button>
                 ) : null}
                 <span className="status-pulse text-xs" style={{ color: "var(--text-tertiary)" }}>
-                  Waiting for approval…
+                  Waiting for browser approval…
                 </span>
               </div>
             ) : (
               <>
-                <div className="flex rounded-lg border p-1" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-sunken)" }}>
-                  {(["signin", "create"] as const).map((t) => (
-                    <button
-                      key={t}
-                      type="button"
-                      onClick={() => setTab(t)}
-                      className="flex-1 rounded-md py-1.5 text-sm font-medium transition-colors duration-100"
-                      style={{
-                        background: tab === t ? "var(--bg-surface)" : "transparent",
-                        color: tab === t ? "var(--text-primary)" : "var(--text-secondary)",
-                        boxShadow: tab === t ? "var(--shadow-1)" : "none",
-                      }}
-                    >
-                      {t === "signin" ? "Sign in" : "Create account"}
-                    </button>
-                  ))}
-                </div>
-
-                <div className="flex flex-col gap-2.5">
-                  {oauthButton(<GoogleGlyph />, "Continue with Google")}
-                  {oauthButton(<GitHubGlyph />, "Continue with GitHub")}
-                </div>
-
-                <div className="flex items-center gap-3">
-                  <div className="h-px flex-1" style={{ background: "var(--border-subtle)" }} />
-                  <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>or continue with email</span>
-                  <div className="h-px flex-1" style={{ background: "var(--border-subtle)" }} />
+                <div
+                  className="flex flex-col gap-4 rounded-xl border p-5"
+                  style={{ borderColor: "var(--border-subtle)", background: "var(--bg-sunken)" }}
+                >
+                  <div className="flex gap-3">
+                    <ShieldCheck className="mt-0.5 shrink-0" size={18} aria-hidden style={{ color: "var(--accent)" }} />
+                    <div className="flex flex-col gap-0.5">
+                      <span className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+                        Secure browser sign-in
+                      </span>
+                      <span className="text-xs leading-relaxed" style={{ color: "var(--text-secondary)" }}>
+                        Use your preferred sign-in method. Matrix Desktop never handles your password.
+                      </span>
+                    </div>
+                  </div>
+                  <div className="flex gap-3">
+                    <MonitorCheck className="mt-0.5 shrink-0" size={18} aria-hidden style={{ color: "var(--accent)" }} />
+                    <div className="flex flex-col gap-0.5">
+                      <span className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+                        Choose your Matrix computer
+                      </span>
+                      <span className="text-xs leading-relaxed" style={{ color: "var(--text-secondary)" }}>
+                        Review the connection in your browser, then return here automatically.
+                      </span>
+                    </div>
+                  </div>
                 </div>
 
                 <button
                   type="button"
                   disabled={phase === "starting"}
                   onClick={() => void start()}
-                  className="no-drag flex h-11 w-full items-center justify-center rounded-lg text-sm font-semibold transition-colors duration-100 disabled:opacity-60"
+                  className="no-drag flex h-11 w-full items-center justify-center gap-2 rounded-lg text-sm font-semibold transition-colors duration-100 disabled:opacity-60"
                   style={{ background: "var(--accent)", color: "var(--text-on-accent)" }}
                   onMouseEnter={(e) => (e.currentTarget.style.background = "var(--accent-hover)")}
                   onMouseLeave={(e) => (e.currentTarget.style.background = "var(--accent)")}
                 >
-                  {phase === "starting" ? "Starting…" : tab === "signin" ? "Sign in" : "Create account"}
+                  {phase === "starting" ? null : <ExternalLink size={16} aria-hidden />}
+                  {phase === "starting" ? "Opening browser…" : "Continue in browser"}
                 </button>
 
                 {phase === "expired" ? (
                   <p className="text-center text-sm" style={{ color: "var(--warning)" }}>
-                    Sign-in request expired. Try again.
+                    Browser approval expired. Start a new request to try again.
                   </p>
                 ) : null}
                 {phase === "error" ? (
                   <p className="text-center text-sm" style={{ color: "var(--danger)" }}>
-                    Can't reach Matrix OS. Check your connection.
+                    Couldn't start browser approval. Check your connection and try again.
                   </p>
                 ) : null}
-
-                <p className="text-center text-sm" style={{ color: "var(--text-secondary)" }}>
-                  {tab === "signin" ? "New to Matrix OS? " : "Already have an account? "}
-                  <button type="button" className="font-medium" style={{ color: "var(--highlight)" }} onClick={() => setTab(tab === "signin" ? "create" : "signin")}>
-                    {tab === "signin" ? "Create an account" : "Sign in"}
-                  </button>
-                </p>
               </>
             )}
           </div>

--- a/desktop/src/renderer/src/features/signin/SignIn.tsx
+++ b/desktop/src/renderer/src/features/signin/SignIn.tsx
@@ -32,7 +32,12 @@ export default function SignIn() {
       setPhase("waiting");
       // Browser launch is best-effort. The verification code and reopen action
       // remain available if the OS blocks the first attempt.
-      void invoke("shell:open-external", { url: code.verificationUri }).catch(() => undefined);
+      void invoke("shell:open-external", { url: code.verificationUri }).catch((error: unknown) => {
+        console.warn(
+          "[signin] browser approval open failed",
+          error instanceof Error ? error.name : "Unknown error",
+        );
+      });
       stopPolling();
       pollTimer.current = setInterval(() => {
         void invoke("auth:poll", {})

--- a/tests/desktop/signin-device-auth.test.tsx
+++ b/tests/desktop/signin-device-auth.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import SignIn from "../../desktop/src/renderer/src/features/signin/SignIn";
+import { invoke } from "../../desktop/src/renderer/src/lib/operator";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+
+vi.mock("../../desktop/src/renderer/src/assets/matrix-logo.svg", () => ({
+  default: "matrix-logo.svg",
+}));
+
+vi.mock("../../desktop/src/renderer/src/lib/operator", () => ({
+  invoke: vi.fn(),
+}));
+
+describe("desktop device authorization sign-in", () => {
+  beforeEach(() => {
+    useConnection.setState(useConnection.getInitialState(), true);
+    useConnection.setState({ refresh: vi.fn(async () => undefined) });
+    vi.mocked(invoke).mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("presents one browser approval action instead of provider-specific authentication", async () => {
+    vi.mocked(invoke)
+      .mockResolvedValue(undefined as never)
+      .mockResolvedValueOnce({
+        userCode: "ABCD-EFGH",
+        verificationUri: "https://app.matrix-os.com/auth/device?user_code=ABCD-EFGH",
+        expiresIn: 2700,
+      } as never);
+
+    render(<SignIn />);
+
+    expect(screen.getByText(/sign in or create an account in your browser/i)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Continue with Google" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Continue with GitHub" })).toBeNull();
+    expect(screen.queryByText(/or continue with email/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Sign in" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Create account" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue in browser" }));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenNthCalledWith(1, "auth:start-device-flow", {});
+      expect(invoke).toHaveBeenNthCalledWith(2, "shell:open-external", {
+        url: "https://app.matrix-os.com/auth/device?user_code=ABCD-EFGH",
+      });
+    });
+    expect(await screen.findByText("ABCD-EFGH")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open approval page" })).toBeTruthy();
+  });
+});

--- a/tests/desktop/signin-device-auth.test.tsx
+++ b/tests/desktop/signin-device-auth.test.tsx
@@ -24,6 +24,7 @@ describe("desktop device authorization sign-in", () => {
 
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
   });
 
   it("presents one browser approval action instead of provider-specific authentication", async () => {
@@ -52,6 +53,34 @@ describe("desktop device authorization sign-in", () => {
         url: "https://app.matrix-os.com/auth/device?user_code=ABCD-EFGH",
       });
     });
+    expect(await screen.findByText("ABCD-EFGH")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open approval page" })).toBeTruthy();
+  });
+
+  it("records a sanitized diagnostic when the approval page cannot open", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.mocked(invoke)
+      .mockResolvedValue(undefined as never)
+      .mockResolvedValueOnce({
+        userCode: "ABCD-EFGH",
+        verificationUri: "https://app.matrix-os.com/auth/device?user_code=ABCD-EFGH",
+        expiresIn: 2700,
+      } as never)
+      .mockRejectedValueOnce(new Error("sensitive operating-system details"));
+
+    render(<SignIn />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue in browser" }));
+
+    await waitFor(() => {
+      expect(warn).toHaveBeenCalledWith(
+        "[signin] browser approval open failed",
+        "Error",
+      );
+    });
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining("sensitive operating-system details"),
+    );
     expect(await screen.findByText("ABCD-EFGH")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Open approval page" })).toBeTruthy();
   });


### PR DESCRIPTION
## Summary

- replace the provider-style desktop sign-in form with one **Continue in browser** action
- explain that account sign-in or creation, computer selection, and approval happen in the browser
- open the approval page automatically while preserving the verification code and manual reopen fallback
- keep expiry, retry, polling, credential storage, and the underlying device authorization protocol unchanged
- add a renderer regression test for the copy, provider-action removal, browser launch, and pending state

Closes #1189
Linear: https://linear.app/matrix-os/issue/MAT-290/align-desktop-sign-in-with-the-device-authorization-flow

## Tests

- `bun run test -- tests/desktop --silent=passed-only --reporter=dot` — 151 files / 1,498 tests passed
- `bun run typecheck` — passed, including Desktop renderer and main-process typechecks
- `bun run build:desktop` — passed
- manual Electron validation from this exact worktree on remote debugging port 9225 — signed-out screen and real device-request waiting state passed
- `bun run test --silent=passed-only --reporter=dot` — 901 files / 10,363 tests passed; 18 unrelated files / 24 tests failed outside this diff. Failures are in pre-existing UI/Shell Vitest resolution, date-sensitive default-app fixtures, Gateway Codex Unix-socket/timeouts, onboarding/Zellij timing, and a Platform shell fixture. The focused Desktop suite remains fully green.
- `check-patterns.sh --diff origin/main` — not applicable to this diff because the scanner currently covers `packages/` and `shell/`, not `desktop/`

## Review / Monitoring

- addressed Greptile's sanitized browser-launch diagnostics finding in `937e2ca76`
- current-head Greptile review: 5/5, safe to merge
- `ready-for-ci` applied; label-triggered Unit Tests (4/4), E2E Tests, Type Check, Shell Production Build, React Doctor, Pattern Scan, Sync Client Package, and final CI Results all passed
- no authentication screenshots are attached because the validated pending state contains an ephemeral verification code

## Invariants

- **Source of truth:** the existing main-process `AuthService` and platform device-approval flow remain authoritative; this PR only changes how the renderer presents and launches that flow.
- **Lock / transaction scope:** not applicable; no database, filesystem persistence, or multi-write workflow changes.
- **Acceptable orphan states:** if opening the system browser fails after a device request is created, the verification code and **Open approval page** action remain visible until the existing request expires.
- **Auth source of truth:** Clerk-backed browser authentication, platform approval, device polling, and trusted credential storage remain unchanged.
- **Deferred scope:** no endpoint, device-request lifetime, desktop credential lifetime, deep-link, credential-storage, or provider configuration changes.
