### PR TITLE
feat(desktop): add one-click OTA updates and What's New

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -275,9 +275,8 @@ if (!gotLock) {
           return { release, shouldOpen: !shown };
         },
         acknowledgeWhatsNew: async (version) => {
-          const stored = await store.get("desktopUpdateRelease");
-          if (!stored || stored.version !== version || version !== app.getVersion()) return;
-          await store.set("desktopUpdateRelease", { ...stored, shown: true });
+          if (version !== app.getVersion()) return;
+          await store.acknowledgeDesktopUpdateRelease(version);
         },
         fetchRuntimeSummary: () => fetchCodingAgentRuntimeSummary(auth),
         fetchProjectWorkspace: (request) => fetchCodingAgentProjectWorkspace(auth, request),

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -216,11 +216,18 @@ if (!gotLock) {
         onAvailable: (version) => {
           console.info(`[updates] downloading Matrix OS ${version}`);
         },
+        onStateChanged: (snapshot) => {
+          sendEvent("update:state-changed", snapshot);
+        },
+        onReleaseReady: (release) => store.set("desktopUpdateRelease", {
+          ...release,
+          shown: false,
+        }),
         onReady: (version) => {
           if (!Notification.isSupported()) return;
           new Notification({
             title: "Matrix OS update ready",
-            body: `Version ${version} will install after you quit and reopen the app.`,
+            body: `Use Update in the sidebar to restart and install version ${version}.`,
             silent: false,
           }).show();
         },
@@ -257,6 +264,21 @@ if (!gotLock) {
           sendEvent("runtime:changed", { slot });
         },
         getUpdateStatus: () => updater.status(),
+        getUpdateSnapshot: () => updater.snapshot(),
+        installUpdate: () => updater.install(),
+        getWhatsNew: async () => {
+          const stored = await store.get("desktopUpdateRelease");
+          if (!stored || stored.version !== app.getVersion()) {
+            return { release: null, shouldOpen: false };
+          }
+          const { shown, ...release } = stored;
+          return { release, shouldOpen: !shown };
+        },
+        acknowledgeWhatsNew: async (version) => {
+          const stored = await store.get("desktopUpdateRelease");
+          if (!stored || stored.version !== version || version !== app.getVersion()) return;
+          await store.set("desktopUpdateRelease", { ...stored, shown: true });
+        },
         fetchRuntimeSummary: () => fetchCodingAgentRuntimeSummary(auth),
         fetchProjectWorkspace: (request) => fetchCodingAgentProjectWorkspace(auth, request),
         fetchNotificationPreferences: () => fetchCodingAgentNotificationPreferences(auth),

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -6,6 +6,7 @@ import type { AuthService } from "../auth/auth-service";
 import type { EmbedService } from "../embeds/embed-service";
 import type { LocalStore, LocalStoreKey } from "../persistence/local-store";
 import type { UpdateStatus } from "../updates";
+import type { DesktopReleaseNotes, DesktopUpdateSnapshot } from "../../shared/desktop-update";
 import type { CodingAgentNotificationPreferences, CodingAgentNotificationPreferencesUpdate, CreateAgentThreadRequest, FileBrowseRequest, FileBrowseResponse, FileReadRequest, FileReadResponse, FileSearchRequest, FileSearchResponse, FileWriteRequest, FileWriteResponse, ProjectAgentWorkspace, ReviewSnapshot, ReviewSummary, RuntimeSummary, SourceControlCreatePullRequestRequest, SourceControlCreatePullRequestResponse, SourceControlPrepareCommitRequest, SourceControlPrepareCommitResponse } from "@matrix-os/contracts";
 import type { CodingAgentProjectWorkspaceRequest } from "../../shared/coding-agent-project-workspace";
 import type { z } from "zod/v4";
@@ -28,6 +29,13 @@ export interface HandlerContext {
   notify: (input: { threadId: string; title: string; body: string; kind: string }) => void;
   onRuntimeChanged: (slot: string) => void;
   getUpdateStatus: () => UpdateStatus;
+  getUpdateSnapshot: () => DesktopUpdateSnapshot;
+  installUpdate: () => Promise<boolean> | boolean;
+  getWhatsNew: () => Promise<{
+    release: DesktopReleaseNotes | null;
+    shouldOpen: boolean;
+  }>;
+  acknowledgeWhatsNew: (version: string) => Promise<void>;
   fetchRuntimeSummary: () => Promise<RuntimeSummary>;
   fetchProjectWorkspace: (
     request: CodingAgentProjectWorkspaceRequest,
@@ -262,4 +270,11 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
   });
 
   handle("update:check", () => ({ status: ctx.getUpdateStatus() }));
+  handle("update:get-state", () => ctx.getUpdateSnapshot());
+  handle("update:install", async () => ({ ok: await ctx.installUpdate() }));
+  handle("update:get-whats-new", () => ctx.getWhatsNew());
+  handle("update:acknowledge-whats-new", async ({ version }) => {
+    await ctx.acknowledgeWhatsNew(version);
+    return { ok: true };
+  });
 }

--- a/desktop/src/main/persistence/local-store.ts
+++ b/desktop/src/main/persistence/local-store.ts
@@ -6,7 +6,10 @@ import { join } from "node:path";
 import { randomBytes } from "node:crypto";
 import { z } from "zod/v4";
 import { ProjectViewsStateSchema } from "../../shared/project-views";
-import { DesktopReleaseNotesSchema } from "../../shared/desktop-update";
+import {
+  DesktopReleaseNotesSchema,
+  DesktopUpdateVersionSchema,
+} from "../../shared/desktop-update";
 
 export const PANEL_LAYOUT_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000;
 
@@ -93,6 +96,7 @@ export interface LocalStore {
   setUnknown(key: LocalStoreKey, value: unknown): Promise<void>;
   delete(key: LocalStoreKey): Promise<void>;
   setPanelLayout(taskKey: string, layout: PanelLayout): Promise<void>;
+  acknowledgeDesktopUpdateRelease(version: string): Promise<boolean>;
 }
 
 export function createLocalStore(options: LocalStoreOptions): LocalStore {
@@ -191,6 +195,18 @@ export function createLocalStore(options: LocalStoreOptions): LocalStore {
         layouts[taskKey.slice(0, 256)] = parsedLayout;
         state.panelLayouts = prunePanelLayouts(layouts, clock());
       });
+    },
+
+    async acknowledgeDesktopUpdateRelease(version) {
+      const parsedVersion = DesktopUpdateVersionSchema.parse(version);
+      let acknowledged = false;
+      await enqueue((state) => {
+        const existing = DesktopUpdateReleaseSchema.safeParse(state.desktopUpdateRelease);
+        if (!existing.success || existing.data.version !== parsedVersion) return;
+        state.desktopUpdateRelease = { ...existing.data, shown: true };
+        acknowledged = true;
+      });
+      return acknowledged;
     },
   };
 }

--- a/desktop/src/main/persistence/local-store.ts
+++ b/desktop/src/main/persistence/local-store.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { randomBytes } from "node:crypto";
 import { z } from "zod/v4";
 import { ProjectViewsStateSchema } from "../../shared/project-views";
+import { DesktopReleaseNotesSchema } from "../../shared/desktop-update";
 
 export const PANEL_LAYOUT_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000;
 
@@ -61,6 +62,10 @@ const ProfileSchema = z
   })
   .strict();
 
+const DesktopUpdateReleaseSchema = DesktopReleaseNotesSchema.extend({
+  shown: z.boolean(),
+}).strict();
+
 const KEY_SCHEMAS = {
   profile: ProfileSchema,
   windowBounds: WindowBoundsSchema,
@@ -70,6 +75,7 @@ const KEY_SCHEMAS = {
   recents: RecentsSchema,
   projectViews: ProjectViewsStateSchema,
   providerPreferences: ProviderPreferencesSchema,
+  desktopUpdateRelease: DesktopUpdateReleaseSchema,
 } as const;
 
 export type LocalStoreKey = keyof typeof KEY_SCHEMAS;

--- a/desktop/src/main/updates.ts
+++ b/desktop/src/main/updates.ts
@@ -1,53 +1,114 @@
-// Auto-update (FR-091): background download, apply on relaunch, never
-// force-restarts attached work. Packaged builds default to GitHub release
-// manifests; OPERATOR_UPDATE_FEED remains as a generic-provider override.
+// Auto-update (FR-091): packaged builds download in the background. Once the
+// update is ready, the renderer offers the explicit restart-and-install action.
 import { app } from "electron";
+import {
+  DesktopReleaseNotesSchema,
+  DesktopUpdateVersionSchema,
+  MAX_DESKTOP_RELEASE_NOTES_LENGTH,
+  type DesktopReleaseNotes,
+  type DesktopUpdateSnapshot,
+  type DesktopUpdateStatus,
+} from "../shared/desktop-update";
 import { resolveUpdateFeedConfig } from "./update-config";
 
-export type UpdateStatus =
-  | "disabled"
-  | "checking"
-  | "up-to-date"
-  | "downloading"
-  | "ready"
-  | "error";
+export type UpdateStatus = DesktopUpdateStatus;
 
 interface UpdateEvents {
   onAvailable: (version: string) => void;
   onReady: (version: string) => void;
+  onStateChanged?: (snapshot: DesktopUpdateSnapshot) => void;
+  onReleaseReady?: (release: DesktopReleaseNotes) => Promise<void> | void;
 }
 
 const UPDATER_EVENT_NAMES = [
   "update-available",
+  "download-progress",
   "update-downloaded",
   "update-not-available",
   "error",
 ] as const;
 
+interface InstallableUpdater {
+  quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void;
+}
+
 export interface Updater {
   check(): Promise<void>;
+  install(): Promise<boolean>;
+  snapshot(): DesktopUpdateSnapshot;
   status(): UpdateStatus;
 }
 
-export function createUpdater(events: UpdateEvents): Updater {
-  let status: UpdateStatus = "disabled";
-  const feed = resolveUpdateFeedConfig(process.env, app.isPackaged);
+function readVersion(info: unknown): string | null {
+  if (!info || typeof info !== "object") return null;
+  const parsed = DesktopUpdateVersionSchema.safeParse((info as { version?: unknown }).version);
+  return parsed.success ? parsed.data : null;
+}
 
-  if (!feed.enabled) {
-    return {
-      check: async () => {
-        status = "disabled";
-      },
-      status: () => status,
-    };
+function releaseNotesText(value: unknown): string {
+  let notes = "";
+  if (typeof value === "string") {
+    notes = value;
+  } else if (Array.isArray(value)) {
+    notes = value
+      .map((entry) => {
+        if (typeof entry === "string") return entry;
+        if (!entry || typeof entry !== "object") return "";
+        const note = (entry as { note?: unknown }).note;
+        return typeof note === "string" ? note : "";
+      })
+      .filter(Boolean)
+      .join("\n\n");
   }
 
-  return {
+  const fallback = "This update includes the latest improvements and fixes.";
+  return (notes.trim() || fallback).slice(0, MAX_DESKTOP_RELEASE_NOTES_LENGTH);
+}
+
+function readRelease(info: unknown, version: string): DesktopReleaseNotes {
+  const candidate = info && typeof info === "object" ? info as {
+    releaseDate?: unknown;
+    releaseNotes?: unknown;
+  } : {};
+  const releaseDate = typeof candidate.releaseDate === "string"
+    ? candidate.releaseDate
+    : undefined;
+  const parsed = DesktopReleaseNotesSchema.safeParse({
+    version,
+    ...(releaseDate ? { releaseDate } : {}),
+    notes: releaseNotesText(candidate.releaseNotes),
+  });
+  if (parsed.success) return parsed.data;
+  return { version, notes: releaseNotesText(candidate.releaseNotes) };
+}
+
+export function createUpdater(events: UpdateEvents): Updater {
+  let current: DesktopUpdateSnapshot = { status: "disabled" };
+  let activeAutoUpdater: InstallableUpdater | null = null;
+  let pendingReleaseSave: Promise<void> = Promise.resolve();
+  const feed = resolveUpdateFeedConfig(process.env, app.isPackaged);
+
+  const setSnapshot = (next: DesktopUpdateSnapshot): void => {
+    current = next;
+    events.onStateChanged?.({ ...current });
+  };
+
+  const updater: Updater = {
     async check() {
-      if (status === "checking" || status === "downloading" || status === "ready") return;
-      status = "checking";
+      if (!feed.enabled) {
+        setSnapshot({ status: "disabled" });
+        return;
+      }
+      if (
+        current.status === "checking" ||
+        current.status === "downloading" ||
+        current.status === "ready"
+      ) return;
+
+      setSnapshot({ status: "checking" });
       try {
         const { autoUpdater } = await import("electron-updater");
+        activeAutoUpdater = autoUpdater;
         autoUpdater.autoDownload = true;
         autoUpdater.autoInstallOnAppQuit = true;
         autoUpdater.allowPrerelease = feed.allowPrerelease;
@@ -65,22 +126,47 @@ export function createUpdater(events: UpdateEvents): Updater {
           autoUpdater.removeAllListeners(eventName);
         }
         autoUpdater.once("update-available", (info) => {
-          status = "downloading";
-          events.onAvailable(info.version);
+          const version = readVersion(info);
+          if (!version) {
+            setSnapshot({ status: "error" });
+            return;
+          }
+          setSnapshot({ status: "downloading", version, progress: 0 });
+          events.onAvailable(version);
+        });
+        autoUpdater.on("download-progress", (progress) => {
+          if (current.status !== "downloading") return;
+          const rawPercent = Number(progress.percent);
+          const percent = Number.isFinite(rawPercent)
+            ? Math.min(100, Math.max(0, rawPercent))
+            : current.progress ?? 0;
+          setSnapshot({ ...current, progress: percent });
         });
         autoUpdater.once("update-downloaded", (info) => {
-          status = "ready";
-          events.onReady(info.version);
+          const version = readVersion(info);
+          if (!version) {
+            setSnapshot({ status: "error" });
+            return;
+          }
+          setSnapshot({ status: "ready", version, progress: 100 });
+          events.onReady(version);
+          pendingReleaseSave = Promise.resolve(events.onReleaseReady?.(readRelease(info, version)))
+            .catch((err: unknown) => {
+              console.warn(
+                "[updates] could not persist release notes:",
+                err instanceof Error ? err.message : String(err),
+              );
+            });
         });
         autoUpdater.once("update-not-available", () => {
-          status = "up-to-date";
+          setSnapshot({ status: "up-to-date" });
         });
         autoUpdater.once("error", (err) => {
           console.warn(
             "[updates] download failed:",
             err instanceof Error ? err.message : String(err),
           );
-          status = "error";
+          setSnapshot({ status: "error" });
         });
         await autoUpdater.checkForUpdates();
       } catch (err: unknown) {
@@ -88,9 +174,20 @@ export function createUpdater(events: UpdateEvents): Updater {
           "[updates] check failed:",
           err instanceof Error ? err.message : String(err),
         );
-        status = "error";
+        setSnapshot({ status: "error" });
       }
     },
-    status: () => status,
+    async install() {
+      if (current.status !== "ready") return false;
+      await pendingReleaseSave;
+      const installable = activeAutoUpdater ?? (await import("electron-updater")).autoUpdater;
+      activeAutoUpdater = installable;
+      installable.quitAndInstall(false, true);
+      return true;
+    },
+    snapshot: () => ({ ...current }),
+    status: () => current.status,
   };
+
+  return updater;
 }

--- a/desktop/src/renderer/src/design/primitives.tsx
+++ b/desktop/src/renderer/src/design/primitives.tsx
@@ -75,11 +75,13 @@ export function Dialog({
   onClose,
   children,
   width = 480,
+  top = "18vh",
 }: {
   open: boolean;
   onClose: () => void;
   children: ReactNode;
   width?: number;
+  top?: string;
 }) {
   return (
     <RadixDialog.Root open={open} onOpenChange={(next) => { if (!next) onClose(); }}>
@@ -88,7 +90,7 @@ export function Dialog({
         <RadixDialog.Content
           aria-describedby={undefined}
           className="fade-in fixed top-[18vh] left-1/2 z-50 -translate-x-1/2 rounded-xl border focus:outline-none"
-          style={{ width, background: "var(--bg-overlay)", borderColor: "var(--border-default)", boxShadow: "var(--shadow-3)" }}
+          style={{ width, maxWidth: "calc(100vw - 32px)", top, background: "var(--bg-overlay)", borderColor: "var(--border-default)", boxShadow: "var(--shadow-3)" }}
         >
           <RadixDialog.Title className="sr-only">Dialog</RadixDialog.Title>
           {children}

--- a/desktop/src/renderer/src/design/tokens.css
+++ b/desktop/src/renderer/src/design/tokens.css
@@ -55,6 +55,8 @@
   --danger-muted: rgba(200, 85, 61, 0.12);
   --info: #4a7c92;
   --info-muted: rgba(74, 124, 146, 0.12);
+  --update-action: #5965e8;
+  --update-action-muted: rgba(89, 101, 232, 0.12);
 
   /* ── Status (tasks / threads / sessions) ────────────────────── */
   --status-todo: #8a8576;
@@ -141,6 +143,8 @@
   --accent-muted: rgba(140, 199, 190, 0.16);
   --highlight: #d8853f;
   --highlight-muted: rgba(216, 133, 63, 0.18);
+  --update-action: #7c83ff;
+  --update-action-muted: rgba(124, 131, 255, 0.18);
 
   --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.4);
   --shadow-2: 0 6px 20px rgba(0, 0, 0, 0.5);

--- a/desktop/src/renderer/src/features/editor/MarkdownPreview.tsx
+++ b/desktop/src/renderer/src/features/editor/MarkdownPreview.tsx
@@ -5,23 +5,13 @@ import { useEffect, useState } from "react";
 import { toUserMessage } from "../../lib/errors";
 import { useConnection } from "../../stores/connection";
 import { createFilesApi, openFile } from "./editor-save";
+export { safeUrlTransform } from "../../lib/markdown";
+import { safeUrlTransform } from "../../lib/markdown";
 
 type PreviewState =
   | { path: string; status: "loading" }
   | { path: string; status: "ready"; content: string }
   | { path: string; status: "error"; error: string };
-
-export function safeUrlTransform(url: string): string {
-  try {
-    const parsed = new URL(url, "https://matrix.local");
-    if (parsed.protocol === "http:" || parsed.protocol === "https:" || parsed.protocol === "mailto:") {
-      return url;
-    }
-  } catch {
-    return "";
-  }
-  return "";
-}
 
 export const MARKDOWN_PREVIEW_CLASS_NAME =
   "prose-sm mx-auto max-w-[760px] text-sm leading-relaxed [&_a]:text-[var(--highlight)] [&_blockquote]:border-l-2 [&_blockquote]:border-[var(--border-default)] [&_blockquote]:pl-3 [&_blockquote]:text-[var(--text-secondary)] [&_code]:rounded [&_code]:bg-[var(--bg-sunken)] [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[12px] [&_h1]:mt-4 [&_h1]:mb-2 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:mt-4 [&_h2]:mb-2 [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1.5 [&_h3]:font-semibold [&_hr]:my-4 [&_hr]:border-[var(--border-subtle)] [&_li]:my-0.5 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:my-2 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:border [&_pre]:border-[var(--border-subtle)] [&_pre]:bg-[var(--bg-sunken)] [&_pre]:p-3 [&_pre_code]:bg-transparent [&_table]:my-3 [&_table]:w-full [&_table]:border-collapse [&_td]:border [&_td]:border-[var(--border-subtle)] [&_td]:px-2 [&_td]:py-1 [&_th]:border [&_th]:border-[var(--border-subtle)] [&_th]:bg-[var(--bg-sunken)] [&_th]:px-2 [&_th]:py-1 [&_th]:text-left [&_ul]:list-disc [&_ul]:pl-5 [&_ul.contains-task-list]:!list-none [&_li.task-list-item]:!list-none [&_input]:mr-1.5";

--- a/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
+++ b/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
@@ -17,6 +17,7 @@ import { useGlobalShortcuts } from "./shortcuts";
 import { invoke } from "../../lib/operator";
 import { wireKernel } from "../../lib/kernel-wiring";
 import { codingAgentRuntimeScope } from "../../../../shared/coding-agent-project-workspace";
+import DesktopUpdateExperience from "../updates/DesktopUpdateExperience";
 
 export default function MissionControl() {
   const api = useConnection((s) => s.api);
@@ -126,6 +127,7 @@ export default function MissionControl() {
       <CommandPalette />
       <QuickOpen />
       <CreateProjectDialog open={createProjectOpen} onClose={() => setCreateProjectOpen(false)} />
+      <DesktopUpdateExperience />
     </div>
   );
 }

--- a/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
+++ b/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
@@ -225,6 +225,7 @@ export default function Sidebar() {
         <div className={`flex items-center ${collapsed ? "justify-center" : "justify-between"} px-2 pt-1`}>
           <NavRow icon={<Settings size={15} />} label="Settings" collapsed={collapsed} active={activeTab?.kind === "settings"} onClick={() => openTab({ kind: "settings", title: "Settings" })} />
         </div>
+        <DesktopUpdateButton collapsed={collapsed} />
         <div className={`flex gap-2 p-2 ${collapsed ? "flex-col items-center" : "items-center"}`}>
           <button
             type="button"
@@ -245,7 +246,6 @@ export default function Sidebar() {
               avatarInitial
             )}
           </button>
-          <DesktopUpdateButton />
           {collapsed ? (
             // Collapsed: the expand toggle lives here too (same place as the
             // collapse toggle when open), so open/close is one consistent spot.

--- a/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
+++ b/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
@@ -24,6 +24,7 @@ import { useThreads } from "../../stores/threads";
 import { kernelThreadAttentionCount } from "../../stores/unified-threads";
 import { useUi } from "../../stores/ui";
 import RuntimeComputerMenu from "../runtime/RuntimeComputerMenu";
+import DesktopUpdateButton from "../updates/DesktopUpdateButton";
 
 function NavRow({
   icon,
@@ -244,6 +245,7 @@ export default function Sidebar() {
               avatarInitial
             )}
           </button>
+          <DesktopUpdateButton />
           {collapsed ? (
             // Collapsed: the expand toggle lives here too (same place as the
             // collapse toggle when open), so open/close is one consistent spot.

--- a/desktop/src/renderer/src/features/updates/DesktopUpdateButton.tsx
+++ b/desktop/src/renderer/src/features/updates/DesktopUpdateButton.tsx
@@ -1,0 +1,25 @@
+import { Download, LoaderCircle } from "lucide-react";
+import { useDesktopUpdate } from "../../stores/desktop-update";
+
+export default function DesktopUpdateButton() {
+  const snapshot = useDesktopUpdate((state) => state.snapshot);
+  const installing = useDesktopUpdate((state) => state.installing);
+  const install = useDesktopUpdate((state) => state.install);
+
+  if (snapshot.status !== "ready" || !snapshot.version) return null;
+
+  const label = `Update Matrix OS to ${snapshot.version}`;
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      disabled={installing}
+      className="no-drag flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-white shadow-sm transition-[transform,filter] duration-150 hover:brightness-110 active:scale-95 disabled:cursor-wait disabled:opacity-80"
+      style={{ background: "var(--update-action)" }}
+      onClick={() => void install()}
+    >
+      {installing ? <LoaderCircle size={14} className="animate-spin" /> : <Download size={14} />}
+    </button>
+  );
+}

--- a/desktop/src/renderer/src/features/updates/DesktopUpdateButton.tsx
+++ b/desktop/src/renderer/src/features/updates/DesktopUpdateButton.tsx
@@ -1,7 +1,11 @@
 import { Download, LoaderCircle } from "lucide-react";
 import { useDesktopUpdate } from "../../stores/desktop-update";
 
-export default function DesktopUpdateButton() {
+interface DesktopUpdateButtonProps {
+  collapsed: boolean;
+}
+
+export default function DesktopUpdateButton({ collapsed }: DesktopUpdateButtonProps) {
   const snapshot = useDesktopUpdate((state) => state.snapshot);
   const installing = useDesktopUpdate((state) => state.installing);
   const install = useDesktopUpdate((state) => state.install);
@@ -10,16 +14,24 @@ export default function DesktopUpdateButton() {
 
   const label = `Update Matrix OS to ${snapshot.version}`;
   return (
-    <button
-      type="button"
-      aria-label={label}
-      title={label}
-      disabled={installing}
-      className="no-drag flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-white shadow-sm transition-[transform,filter] duration-150 hover:brightness-110 active:scale-95 disabled:cursor-wait disabled:opacity-80"
-      style={{ background: "var(--update-action)" }}
-      onClick={() => void install()}
-    >
-      {installing ? <LoaderCircle size={14} className="animate-spin" /> : <Download size={14} />}
-    </button>
+    <div className={`px-2 pt-1 ${collapsed ? "flex justify-center" : ""}`}>
+      <button
+        type="button"
+        aria-label={label}
+        title={label}
+        disabled={installing}
+        className={`no-drag flex h-7 items-center rounded-md text-white shadow-sm transition-[transform,filter] duration-150 hover:brightness-110 active:scale-[0.99] disabled:cursor-wait disabled:opacity-80 ${collapsed ? "w-7 justify-center" : "w-full gap-2 px-2.5 text-xs font-semibold"}`}
+        style={{ background: "var(--update-action)" }}
+        onClick={() => void install()}
+      >
+        {installing ? <LoaderCircle size={14} className="shrink-0 animate-spin" /> : <Download size={14} className="shrink-0" />}
+        {!collapsed ? (
+          <>
+            <span>Update</span>
+            <span className="ml-auto opacity-75">v{snapshot.version}</span>
+          </>
+        ) : null}
+      </button>
+    </div>
   );
 }

--- a/desktop/src/renderer/src/features/updates/DesktopUpdateExperience.tsx
+++ b/desktop/src/renderer/src/features/updates/DesktopUpdateExperience.tsx
@@ -1,0 +1,8 @@
+import { useEffect } from "react";
+import { useDesktopUpdate } from "../../stores/desktop-update";
+import WhatsNewDialog from "./WhatsNewDialog";
+
+export default function DesktopUpdateExperience() {
+  useEffect(() => useDesktopUpdate.getState().initialize(), []);
+  return <WhatsNewDialog />;
+}

--- a/desktop/src/renderer/src/features/updates/WhatsNewDialog.tsx
+++ b/desktop/src/renderer/src/features/updates/WhatsNewDialog.tsx
@@ -1,0 +1,104 @@
+import { X } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { Dialog } from "../../design/primitives";
+import { safeUrlTransform } from "../../lib/markdown";
+import { invoke } from "../../lib/operator";
+import { useDesktopUpdate } from "../../stores/desktop-update";
+
+function releaseDateLabel(value?: string): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return null;
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}
+
+export default function WhatsNewDialog() {
+  const open = useDesktopUpdate((state) => state.whatsNewOpen);
+  const release = useDesktopUpdate((state) => state.release);
+  const close = useDesktopUpdate((state) => state.closeWhatsNew);
+
+  if (!release) return null;
+  const date = releaseDateLabel(release.releaseDate);
+
+  return (
+    <Dialog open={open} onClose={close} width={860} top="8vh">
+      <div
+        className="flex flex-col overflow-hidden"
+        style={{ height: "min(76vh, 680px)", minHeight: "min(520px, 84vh)" }}
+      >
+        <header className="flex items-start justify-between px-8 pt-7 pb-5">
+          <div>
+            <h1 className="text-xl font-semibold tracking-tight" style={{ color: "var(--text-primary)" }}>
+              What's New
+            </h1>
+            <p className="mt-1 text-sm" style={{ color: "var(--text-tertiary)" }}>
+              Matrix OS was updated successfully.
+            </p>
+          </div>
+          <button
+            type="button"
+            aria-label="Close What's New"
+            className="flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-[var(--bg-hover)]"
+            style={{ color: "var(--text-tertiary)" }}
+            onClick={close}
+          >
+            <X size={16} />
+          </button>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-y-auto border-t px-8 py-6" style={{ borderColor: "var(--border-subtle)" }}>
+          <div className="mb-5 flex items-center gap-2.5">
+            <span className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+              v{release.version}
+            </span>
+            <span
+              className="rounded-full px-2 py-0.5 text-[10px] font-bold tracking-wide uppercase"
+              style={{ background: "var(--update-action-muted)", color: "var(--update-action)" }}
+            >
+              Latest
+            </span>
+            {date ? (
+              <span className="ml-auto text-xs" style={{ color: "var(--text-tertiary)" }}>
+                {date}
+              </span>
+            ) : null}
+          </div>
+
+          <div
+            data-selectable
+            className="text-sm leading-6 [&_a]:font-medium [&_a]:text-[var(--accent)] [&_code]:rounded [&_code]:bg-[var(--bg-sunken)] [&_code]:px-1 [&_h1]:mt-6 [&_h1]:mb-3 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:mt-6 [&_h2]:mb-3 [&_h2]:text-base [&_h2]:font-semibold [&_h3]:mt-5 [&_h3]:mb-2 [&_h3]:font-semibold [&_li]:my-1.5 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:my-2 [&_ul]:list-disc [&_ul]:pl-5"
+            style={{ color: "var(--text-secondary)" }}
+          >
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              urlTransform={safeUrlTransform}
+              components={{
+                img: () => null,
+                a: ({ href, children }) => (
+                  <a
+                    href={href}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      if (href?.startsWith("https://")) {
+                        void invoke("shell:open-external", { url: href });
+                      }
+                    }}
+                  >
+                    {children}
+                  </a>
+                ),
+              }}
+            >
+              {release.notes}
+            </ReactMarkdown>
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/desktop/src/renderer/src/lib/markdown.ts
+++ b/desktop/src/renderer/src/lib/markdown.ts
@@ -1,0 +1,11 @@
+export function safeUrlTransform(url: string): string {
+  try {
+    const parsed = new URL(url, "https://matrix.local");
+    if (parsed.protocol === "http:" || parsed.protocol === "https:" || parsed.protocol === "mailto:") {
+      return url;
+    }
+  } catch {
+    return "";
+  }
+  return "";
+}

--- a/desktop/src/renderer/src/stores/desktop-update.ts
+++ b/desktop/src/renderer/src/stores/desktop-update.ts
@@ -1,0 +1,83 @@
+import { create } from "zustand";
+import type {
+  DesktopReleaseNotes,
+  DesktopUpdateSnapshot,
+} from "../../../shared/desktop-update";
+import { invoke, onEvent } from "../lib/operator";
+
+interface DesktopUpdateState {
+  snapshot: DesktopUpdateSnapshot;
+  release: DesktopReleaseNotes | null;
+  whatsNewOpen: boolean;
+  installing: boolean;
+  initialize: () => () => void;
+  install: () => Promise<void>;
+  closeWhatsNew: () => void;
+}
+
+export const useDesktopUpdate = create<DesktopUpdateState>()((set, get) => ({
+  snapshot: { status: "disabled" },
+  release: null,
+  whatsNewOpen: false,
+  installing: false,
+
+  initialize: () => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.operator?.invoke !== "function" ||
+      typeof window.operator?.on !== "function"
+    ) {
+      return () => undefined;
+    }
+    let active = true;
+    let eventReceived = false;
+    const unsubscribe = onEvent("update:state-changed", (snapshot) => {
+      eventReceived = true;
+      if (active) set({ snapshot });
+    });
+
+    void Promise.all([
+      invoke("update:get-state", {}),
+      invoke("update:get-whats-new", {}),
+    ])
+      .then(async ([snapshot, whatsNew]) => {
+        if (!active) return;
+        set({
+          ...(!eventReceived ? { snapshot } : {}),
+          release: whatsNew.release,
+          whatsNewOpen: whatsNew.shouldOpen && Boolean(whatsNew.release),
+        });
+        if (whatsNew.shouldOpen && whatsNew.release) {
+          try {
+            await invoke("update:acknowledge-whats-new", {
+              version: whatsNew.release.version,
+            });
+          } catch {
+            console.warn("[desktop-update] could not acknowledge What's New");
+          }
+        }
+      })
+      .catch(() => {
+        console.warn("[desktop-update] could not initialize update state");
+      });
+
+    return () => {
+      active = false;
+      if (typeof unsubscribe === "function") unsubscribe();
+    };
+  },
+
+  install: async () => {
+    if (get().snapshot.status !== "ready" || get().installing) return;
+    set({ installing: true });
+    try {
+      const result = await invoke("update:install", {});
+      if (!result.ok) set({ installing: false });
+    } catch {
+      set({ installing: false });
+      console.warn("[desktop-update] restart and install failed");
+    }
+  },
+
+  closeWhatsNew: () => set({ whatsNewOpen: false }),
+}));

--- a/desktop/src/renderer/src/stores/desktop-update.ts
+++ b/desktop/src/renderer/src/stores/desktop-update.ts
@@ -40,22 +40,13 @@ export const useDesktopUpdate = create<DesktopUpdateState>()((set, get) => ({
       invoke("update:get-state", {}),
       invoke("update:get-whats-new", {}),
     ])
-      .then(async ([snapshot, whatsNew]) => {
+      .then(([snapshot, whatsNew]) => {
         if (!active) return;
         set({
           ...(!eventReceived ? { snapshot } : {}),
           release: whatsNew.release,
           whatsNewOpen: whatsNew.shouldOpen && Boolean(whatsNew.release),
         });
-        if (whatsNew.shouldOpen && whatsNew.release) {
-          try {
-            await invoke("update:acknowledge-whats-new", {
-              version: whatsNew.release.version,
-            });
-          } catch {
-            console.warn("[desktop-update] could not acknowledge What's New");
-          }
-        }
       })
       .catch(() => {
         console.warn("[desktop-update] could not initialize update state");
@@ -79,5 +70,12 @@ export const useDesktopUpdate = create<DesktopUpdateState>()((set, get) => ({
     }
   },
 
-  closeWhatsNew: () => set({ whatsNewOpen: false }),
+  closeWhatsNew: () => {
+    const release = get().release;
+    set({ whatsNewOpen: false });
+    if (!release) return;
+    void invoke("update:acknowledge-whats-new", { version: release.version }).catch(() => {
+      console.warn("[desktop-update] could not acknowledge What's New");
+    });
+  },
 }));

--- a/desktop/src/shared/desktop-update.ts
+++ b/desktop/src/shared/desktop-update.ts
@@ -1,0 +1,38 @@
+import { z } from "zod/v4";
+
+export const MAX_DESKTOP_RELEASE_NOTES_LENGTH = 32 * 1024;
+
+export const DesktopUpdateVersionSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/);
+
+export const DesktopUpdateStatusSchema = z.enum([
+  "disabled",
+  "checking",
+  "up-to-date",
+  "downloading",
+  "ready",
+  "error",
+]);
+
+export const DesktopUpdateSnapshotSchema = z
+  .object({
+    status: DesktopUpdateStatusSchema,
+    version: DesktopUpdateVersionSchema.optional(),
+    progress: z.number().min(0).max(100).optional(),
+  })
+  .strict();
+
+export const DesktopReleaseNotesSchema = z
+  .object({
+    version: DesktopUpdateVersionSchema,
+    releaseDate: z.string().datetime().optional(),
+    notes: z.string().max(MAX_DESKTOP_RELEASE_NOTES_LENGTH),
+  })
+  .strict();
+
+export type DesktopUpdateStatus = z.infer<typeof DesktopUpdateStatusSchema>;
+export type DesktopUpdateSnapshot = z.infer<typeof DesktopUpdateSnapshotSchema>;
+export type DesktopReleaseNotes = z.infer<typeof DesktopReleaseNotesSchema>;

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -40,6 +40,12 @@ import {
   boundedListSchema,
 } from "@matrix-os/contracts";
 import { CodingAgentProjectWorkspaceRequestSchema } from "./coding-agent-project-workspace";
+import {
+  DesktopReleaseNotesSchema,
+  DesktopUpdateSnapshotSchema,
+  DesktopUpdateStatusSchema,
+  DesktopUpdateVersionSchema,
+} from "./desktop-update";
 
 const Empty = z.object({}).strict();
 
@@ -331,9 +337,28 @@ export const INVOKE_CHANNELS = {
   },
   "update:check": {
     request: Empty,
+    response: z.object({ status: DesktopUpdateStatusSchema }).strict(),
+  },
+  "update:get-state": {
+    request: Empty,
+    response: DesktopUpdateSnapshotSchema,
+  },
+  "update:install": {
+    request: Empty,
+    response: Ok,
+  },
+  "update:get-whats-new": {
+    request: Empty,
     response: z
-      .object({ status: z.enum(["disabled", "checking", "up-to-date", "downloading", "ready", "error"]) })
+      .object({
+        release: DesktopReleaseNotesSchema.nullable(),
+        shouldOpen: z.boolean(),
+      })
       .strict(),
+  },
+  "update:acknowledge-whats-new": {
+    request: z.object({ version: DesktopUpdateVersionSchema }).strict(),
+    response: Ok,
   },
 } as const;
 
@@ -364,6 +389,7 @@ export const EVENT_CHANNELS = {
   }).strict(),
   "update:available": z.object({ version: z.string().max(64) }).strict(),
   "update:ready": z.object({ version: z.string().max(64) }).strict(),
+  "update:state-changed": DesktopUpdateSnapshotSchema,
   "window:focus-changed": z.object({ focused: z.boolean() }).strict(),
   "app:zoom-changed": ZoomFactorResultSchema,
   "menu:action": z

--- a/docs/dev/desktop-release.md
+++ b/docs/dev/desktop-release.md
@@ -76,17 +76,25 @@ the DMG; and launches the copied app in an isolated profile.
 ## Updates
 
 Packaged desktop builds default to GitHub releases as the update feed. The app
-checks on launch and then hourly. Downloads happen in the background and install
-only after the user quits and reopens the app.
+checks on launch and then hourly. Downloads happen in the background. Once a
+download is ready, a blue **Update** control appears beside the account avatar;
+selecting it immediately restarts the app and installs the downloaded version.
+Quitting normally also installs a ready update.
+
+Release notes from the downloaded artifact are bounded and persisted in the
+desktop's local recreatable state before restart. On the first launch of that
+exact version, the signed-in desktop opens **What's New** once and renders those
+notes as sanitized Markdown. Remote images are never loaded from release notes,
+and external links only open through the trusted HTTPS shell boundary.
 
 Environment overrides:
 
-- `MATRIX_DESKTOP_UPDATE_CHANNEL=stable|beta|canary`
+- `MATRIX_DESKTOP_UPDATE_CHANNEL=dev|canary|beta|stable`
 - `OPERATOR_UPDATE_FEED=https://...` for a generic-provider break-glass feed
 - `MATRIX_DESKTOP_RELEASE_OWNER` / `MATRIX_DESKTOP_RELEASE_REPO` for forks
 
-Never force-restart the app for an update; attached terminal/session work must
-survive until the user intentionally relaunches.
+Never restart automatically for an update; attached terminal/session work must
+survive until the user explicitly selects **Update** or quits the app.
 
 ## Verification
 
@@ -100,4 +108,6 @@ gh release download desktop-v0.1.0 --pattern SHA256SUMS.txt --pattern desktop-re
 Install the DMG on a clean macOS user, confirm Gatekeeper opens it without an
 unidentified-developer warning, sign in, then leave it running long enough to
 observe the update check in logs. For a canary smoke, install the canary DMG and
-confirm `MATRIX_DESKTOP_UPDATE_CHANNEL=canary` allows prerelease updates.
+confirm `MATRIX_DESKTOP_UPDATE_CHANNEL=canary` allows prerelease updates. Publish
+a newer canary, wait for the blue **Update** control, select it, verify the app
+relaunches on the new version, and confirm **What's New** opens exactly once.

--- a/specs/110-desktop-ota-update/plan.md
+++ b/specs/110-desktop-ota-update/plan.md
@@ -1,0 +1,390 @@
+# Desktop OTA Update Entry Placement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the ready-to-install Desktop update action into its own footer row below Settings, preserving one-click installation and a compact collapsed-sidebar control.
+
+**Architecture:** Keep update state and installation behavior inside the existing `DesktopUpdateButton`; add a required `collapsed` presentation prop so that component owns both expanded and collapsed renderings. `Sidebar` remains responsible only for footer ordering and passes its existing collapsed state into the update component. No IPC, updater, persistence, or What's New logic changes.
+
+**Tech Stack:** React 19, TypeScript 5.9 strict mode, Zustand 5, Tailwind CSS 4, Vitest 4, Testing Library, Playwright Electron.
+
+## Global Constraints
+
+- Use the existing `ready` snapshot state and `update:install` IPC operation; do not change the update protocol.
+- Selecting Update immediately restarts and installs the downloaded release; do not add confirmation UI.
+- Render no update chrome unless the snapshot is `ready` with a valid version.
+- Expanded footer order is Runtime computer selector, Settings, Update, Account.
+- Expanded mode displays `Update` and `v{version}`; collapsed mode displays only the icon while retaining the accessible label and tooltip `Update Matrix OS to {version}`.
+- Keep the account row composition and width independent of update availability.
+- Use TDD: every production change follows a verified failing test.
+- Use pnpm for package management and bun for repository scripts; do not use npm.
+
+---
+
+## File Map
+
+- Modify `desktop/src/renderer/src/features/updates/DesktopUpdateButton.tsx`: own the ready-state footer slot, expanded row, collapsed icon, accessible label, and existing install action.
+- Modify `desktop/src/renderer/src/features/mission-control/Sidebar.tsx`: pass `collapsed` and place the update component between Settings and the account row.
+- Modify `tests/desktop/desktop-update-ui.test.tsx`: specify expanded/collapsed update-button rendering and retain immediate-install coverage.
+- Modify `tests/desktop/sidebar-attention-badges.test.tsx`: specify footer DOM order and separation from the account row.
+- Modify `tests/e2e/desktop/update-experience.e2e.test.ts`: verify the real Electron layout in expanded and collapsed sidebar modes and refresh evidence screenshots.
+
+### Task 1: Give the update control expanded and collapsed renderings
+
+**Files:**
+- Modify: `tests/desktop/desktop-update-ui.test.tsx`
+- Modify: `desktop/src/renderer/src/features/updates/DesktopUpdateButton.tsx`
+
+**Interfaces:**
+- Consumes: `useDesktopUpdate((state) => state.snapshot | state.installing | state.install)`.
+- Produces: `DesktopUpdateButton({ collapsed }: { collapsed: boolean }): JSX.Element | null`.
+
+- [ ] **Step 1: Add the failing responsive-rendering test**
+
+Append a focused test to `tests/desktop/desktop-update-ui.test.tsx` after the existing blue-control test:
+
+```tsx
+it("renders a full update row when expanded and an icon-only control when collapsed", () => {
+  vi.stubGlobal("operator", { invoke: vi.fn(), on: vi.fn() });
+  useDesktopUpdate.setState({
+    snapshot: { status: "ready", version: "1.2.3", progress: 100 },
+  });
+
+  const view = render(
+    <Tooltip.Provider>
+      <DesktopUpdateButton collapsed={false} />
+    </Tooltip.Provider>,
+  );
+
+  expect(screen.getByText("Update")).toBeTruthy();
+  expect(screen.getByText("v1.2.3")).toBeTruthy();
+
+  view.rerender(
+    <Tooltip.Provider>
+      <DesktopUpdateButton collapsed />
+    </Tooltip.Provider>,
+  );
+
+  const collapsedButton = screen.getByRole("button", {
+    name: "Update Matrix OS to 1.2.3",
+  });
+  expect(collapsedButton.getAttribute("title")).toBe("Update Matrix OS to 1.2.3");
+  expect(screen.queryByText("Update")).toBeNull();
+  expect(screen.queryByText("v1.2.3")).toBeNull();
+});
+```
+
+Update the two existing direct renders in the blue-control test to pass `collapsed={false}` so the public component contract is explicit.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+bun run test tests/desktop/desktop-update-ui.test.tsx
+```
+
+Expected: FAIL because `DesktopUpdateButton` ignores the new presentation prop and does not render the `Update` or `v1.2.3` text.
+
+- [ ] **Step 3: Implement the minimal responsive component**
+
+Change `DesktopUpdateButton.tsx` to accept the required prop, return no wrapper before the update is ready, and own its footer padding only when visible:
+
+```tsx
+import { Download, LoaderCircle } from "lucide-react";
+import { useDesktopUpdate } from "../../stores/desktop-update";
+
+interface DesktopUpdateButtonProps {
+  collapsed: boolean;
+}
+
+export default function DesktopUpdateButton({ collapsed }: DesktopUpdateButtonProps) {
+  const snapshot = useDesktopUpdate((state) => state.snapshot);
+  const installing = useDesktopUpdate((state) => state.installing);
+  const install = useDesktopUpdate((state) => state.install);
+
+  if (snapshot.status !== "ready" || !snapshot.version) return null;
+
+  const label = `Update Matrix OS to ${snapshot.version}`;
+  return (
+    <div className={`px-2 pt-1 ${collapsed ? "flex justify-center" : ""}`}>
+      <button
+        type="button"
+        aria-label={label}
+        title={label}
+        disabled={installing}
+        className={`no-drag flex h-7 items-center rounded-md text-white shadow-sm transition-[transform,filter] duration-150 hover:brightness-110 active:scale-[0.99] disabled:cursor-wait disabled:opacity-80 ${collapsed ? "w-7 justify-center" : "w-full gap-2 px-2.5 text-xs font-semibold"}`}
+        style={{ background: "var(--update-action)" }}
+        onClick={() => void install()}
+      >
+        {installing ? <LoaderCircle size={14} className="shrink-0 animate-spin" /> : <Download size={14} className="shrink-0" />}
+        {!collapsed ? (
+          <>
+            <span>Update</span>
+            <span className="ml-auto opacity-75">v{snapshot.version}</span>
+          </>
+        ) : null}
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+bun run test tests/desktop/desktop-update-ui.test.tsx
+```
+
+Expected: all desktop update UI tests PASS, including existing immediate-install and ready-only assertions.
+
+- [ ] **Step 5: Commit the responsive control**
+
+```bash
+git add tests/desktop/desktop-update-ui.test.tsx desktop/src/renderer/src/features/updates/DesktopUpdateButton.tsx
+git commit -m "refactor(desktop): make update action responsive"
+```
+
+### Task 2: Move Update below Settings and prove the footer order
+
+**Files:**
+- Modify: `tests/desktop/sidebar-attention-badges.test.tsx`
+- Modify: `desktop/src/renderer/src/features/mission-control/Sidebar.tsx`
+
+**Interfaces:**
+- Consumes: `DesktopUpdateButton({ collapsed })` from Task 1 and `useUi((state) => state.sidebarCollapsed)`.
+- Produces: footer DOM order Runtime, Settings, Update, Account without changing any navigation or account handlers.
+
+- [ ] **Step 1: Add the failing footer-order test**
+
+Import the update store in `tests/desktop/sidebar-attention-badges.test.tsx`:
+
+```tsx
+import { useDesktopUpdate } from "../../desktop/src/renderer/src/stores/desktop-update";
+```
+
+Reset it in `beforeEach`:
+
+```tsx
+useDesktopUpdate.setState({
+  snapshot: { status: "disabled" },
+  installing: false,
+});
+```
+
+Then append:
+
+```tsx
+it("places a ready update after Settings and outside the account row", () => {
+  useDesktopUpdate.setState({
+    snapshot: { status: "ready", version: "1.2.3", progress: 100 },
+  });
+
+  render(
+    <Tooltip.Provider>
+      <Sidebar />
+    </Tooltip.Provider>,
+  );
+
+  const settings = screen.getByRole("button", { name: "Settings" });
+  const update = screen.getByRole("button", { name: "Update Matrix OS to 1.2.3" });
+  const account = screen.getByTitle("Manage account");
+
+  expect(settings.compareDocumentPosition(update) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  expect(update.compareDocumentPosition(account) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  expect(update.parentElement).not.toBe(account.parentElement);
+});
+```
+
+- [ ] **Step 2: Run the sidebar test and verify RED**
+
+Run:
+
+```bash
+bun run test tests/desktop/sidebar-attention-badges.test.tsx
+```
+
+Expected: FAIL because the current Update button remains inside the account row after the avatar instead of between Settings and Account.
+
+- [ ] **Step 3: Move the component in `Sidebar.tsx`**
+
+Remove `DesktopUpdateButton` from the account-row `<div>`. Render it directly after the Settings row wrapper and before the account-row wrapper:
+
+```tsx
+<div className={`flex items-center ${collapsed ? "justify-center" : "justify-between"} px-2 pt-1`}>
+  <NavRow
+    icon={<Settings size={15} />}
+    label="Settings"
+    collapsed={collapsed}
+    active={activeTab?.kind === "settings"}
+    onClick={() => openTab({ kind: "settings", title: "Settings" })}
+  />
+</div>
+<DesktopUpdateButton collapsed={collapsed} />
+<div className={`flex gap-2 p-2 ${collapsed ? "flex-col items-center" : "items-center"}`}>
+  <button
+    type="button"
+    title="Manage account"
+    className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-full text-xs font-semibold"
+    style={{ background: "var(--accent-muted)", color: "var(--accent)" }}
+    onClick={() => void invoke("shell:open-external", { url: platformHost.startsWith("https://") ? platformHost : "https://app.matrix-os.com" })}
+  >
+    {showAvatar && imageUrl ? (
+      <img
+        src={imageUrl}
+        alt=""
+        className="h-full w-full object-cover"
+        referrerPolicy="no-referrer"
+        onError={() => setImgFailed(true)}
+      />
+    ) : (
+      avatarInitial
+    )}
+  </button>
+  {collapsed ? (
+    <IconButton label="Expand sidebar (⌘B)" onClick={toggleSidebar}>
+      <PanelLeftOpen size={15} />
+    </IconButton>
+  ) : (
+    <>
+      <div className="flex min-w-0 flex-1 flex-col leading-tight">
+        <span className="truncate text-sm" style={{ color: "var(--text-primary)" }}>{primaryLabel}</span>
+        {secondaryLabel ? (
+          <span className="truncate text-xs" style={{ color: "var(--text-tertiary)" }}>{secondaryLabel}</span>
+        ) : null}
+      </div>
+      <IconButton label="Collapse sidebar (⌘B)" onClick={toggleSidebar}>
+        <PanelLeftClose size={15} />
+      </IconButton>
+      <IconButton
+        label="Sign out"
+        onClick={() => {
+          void signOut().catch((err: unknown) => {
+            console.warn(
+              "[sidebar] sign-out failed:",
+              err instanceof Error ? err.message : String(err),
+            );
+          });
+        }}
+      >
+        <LogOut size={14} />
+      </IconButton>
+    </>
+  )}
+</div>
+```
+
+- [ ] **Step 4: Run focused update and sidebar tests and verify GREEN**
+
+Run:
+
+```bash
+bun run test tests/desktop/desktop-update-ui.test.tsx tests/desktop/sidebar-attention-badges.test.tsx
+```
+
+Expected: both files PASS; the account row behavior and existing attention badges remain green.
+
+- [ ] **Step 5: Commit the footer placement**
+
+```bash
+git add tests/desktop/sidebar-attention-badges.test.tsx desktop/src/renderer/src/features/mission-control/Sidebar.tsx
+git commit -m "fix(desktop): separate update action from account row"
+```
+
+### Task 3: Verify the real Electron layout and refresh evidence
+
+**Files:**
+- Modify: `tests/e2e/desktop/update-experience.e2e.test.ts`
+- Generated evidence: `desktop/screenshots/mat-291-update-ready.png`
+- Generated evidence: `desktop/screenshots/mat-291-update-ready-collapsed.png`
+
+**Interfaces:**
+- Consumes: the accessible update name, Sidebar Settings control, Manage account control, and Collapse sidebar control.
+- Produces: an E2E regression proving vertical footer order, expanded full-row geometry, and collapsed icon geometry.
+
+- [ ] **Step 1: Change the E2E assertion and verify RED against the existing build**
+
+Rename the test to:
+
+```ts
+it("shows What's New after launch and places Update below Settings", async () => {
+```
+
+Replace the old avatar-x proximity assertion with:
+
+```ts
+const settings = page.getByRole("button", { name: "Settings" });
+const avatar = page.getByTitle("Manage account");
+const settingsBox = await settings.boundingBox();
+const updateBox = await update.boundingBox();
+const avatarBox = await avatar.boundingBox();
+expect(settingsBox).not.toBeNull();
+expect(updateBox).not.toBeNull();
+expect(avatarBox).not.toBeNull();
+expect(updateBox?.y ?? 0).toBeGreaterThan((settingsBox?.y ?? 0) + (settingsBox?.height ?? 0));
+expect((updateBox?.y ?? 0) + (updateBox?.height ?? 0)).toBeLessThanOrEqual(avatarBox?.y ?? 0);
+expect(updateBox?.width ?? 0).toBeGreaterThan((avatarBox?.width ?? 0) * 4);
+```
+
+Run the existing build without rebuilding product code:
+
+```bash
+bun run test:e2e tests/e2e/desktop/update-experience.e2e.test.ts
+```
+
+Expected: FAIL because the built renderer still places Update beside the avatar and renders it as a small circle.
+
+- [ ] **Step 2: Add collapsed-sidebar geometry coverage**
+
+After capturing `mat-291-update-ready.png`, add:
+
+```ts
+await page.getByRole("button", { name: "Collapse sidebar (⌘B)" }).click();
+const collapsedUpdateBox = await update.boundingBox();
+expect(collapsedUpdateBox).not.toBeNull();
+expect(Math.abs((collapsedUpdateBox?.width ?? 0) - (collapsedUpdateBox?.height ?? 0))).toBeLessThanOrEqual(2);
+expect(collapsedUpdateBox?.width ?? 0).toBeLessThan(40);
+await page.screenshot({ path: join(SCREENSHOT_DIR, "mat-291-update-ready-collapsed.png") });
+```
+
+- [ ] **Step 3: Build Desktop and verify the E2E test GREEN**
+
+Run:
+
+```bash
+bun run build:desktop
+bun run test:e2e tests/e2e/desktop/update-experience.e2e.test.ts
+```
+
+Expected: Desktop build succeeds and the E2E file reports 1 PASS with both refreshed screenshots written.
+
+- [ ] **Step 4: Run proportional regression checks**
+
+Run:
+
+```bash
+bun run test tests/desktop/desktop-update-ui.test.tsx tests/desktop/sidebar-attention-badges.test.tsx tests/desktop/updater.test.ts tests/desktop/update-config.test.ts tests/desktop/local-store.test.ts tests/desktop/ipc-handlers.test.ts tests/desktop/ipc-contract.test.ts
+bun run test tests/desktop
+pnpm --filter desktop run typecheck
+bun run check:patterns:diff
+git diff --check
+```
+
+Expected: focused update tests, complete Desktop tests, Desktop typecheck, pattern scan, and whitespace validation all PASS. Any unrelated repository-wide baseline failure must be reported separately rather than attributed to this placement change.
+
+- [ ] **Step 5: Commit E2E coverage**
+
+```bash
+git add tests/e2e/desktop/update-experience.e2e.test.ts
+git commit -m "test(desktop): cover update footer placement"
+```
+
+- [ ] **Step 6: Inspect the real Electron screenshots and relaunch the preview**
+
+Inspect `desktop/screenshots/mat-291-update-ready.png` and `desktop/screenshots/mat-291-update-ready-collapsed.png` at original resolution. Confirm that the expanded action is between Settings and Account, the account name is not compressed, and the collapsed action is centered at the same footer position. Relaunch the MAT-291 build with an isolated `OPERATOR_USER_DATA_DIR` and a dedicated remote-debugging port, then read back the Electron process command, worktree path, commit, listener port, and active page URL before handing it to the user. Keep unrelated Electron applications running.
+
+- [ ] **Step 7: Update the existing review handoff**
+
+Push the branch, update GitHub PR #1192 and Linear MAT-291 in English with the final commit, test counts, screenshots, and exact-head CI/Greptile status. Do not merge either PR.

--- a/specs/110-desktop-ota-update/spec.md
+++ b/specs/110-desktop-ota-update/spec.md
@@ -1,0 +1,75 @@
+# Desktop OTA Update Entry Placement
+
+**Linear:** MAT-291  
+**Status:** Approved for implementation  
+**Scope:** Renderer-only placement refinement for the existing Desktop OTA flow
+
+## Problem
+
+The ready-to-install update action currently shares the account row with the avatar, identity text, sidebar toggle, and sign-out action. At the expanded sidebar width, the extra circular action compresses the identity area and makes the footer feel crowded. The account row should remain stable regardless of update availability.
+
+## Goals
+
+- Keep the ready-to-install update action discoverable in the familiar lower-left utility area.
+- Restore the full account row width and prevent update state from shifting account controls.
+- Preserve the existing one-click behavior: selecting Update immediately restarts and installs the downloaded release.
+- Preserve a useful update entry when the sidebar is collapsed.
+- Avoid adding persistent chrome when no update is ready.
+
+## Approved Design
+
+When the update snapshot is `ready`, render the update action as its own footer row between Settings and the account row.
+
+Expanded footer order:
+
+1. Runtime computer selector
+2. Settings
+3. Update action, only while an update is ready
+4. Account row
+
+The expanded action is a compact blue row with a download icon, the label `Update`, and the target version aligned to the trailing edge. The button uses the same footer width and corner radius as the surrounding utility rows, while its blue treatment communicates that it is a temporary primary action.
+
+In the collapsed sidebar, the same footer position renders as a centered blue icon button. Its accessible name and tooltip include the target version.
+
+## Interaction and State
+
+- `disabled`, `idle`, `checking`, `available`, `downloading`, and `error` states render no update action.
+- `ready` with a valid target version renders the action.
+- Selecting the action calls the existing install operation immediately; no confirmation dialog is added.
+- While installation is starting, the action is disabled and shows the existing spinner treatment.
+- The OTA download, IPC contract, persistence, restart/install behavior, and post-update What's New flow do not change.
+
+## Accessibility
+
+- The expanded and collapsed controls use the accessible label `Update Matrix OS to {version}`.
+- The collapsed control exposes the same text as a tooltip.
+- Disabled installation state remains perceivable through the spinner and disabled semantics.
+- Keyboard activation follows native button behavior.
+
+## Responsive Behavior
+
+- Expanded mode uses the complete row with label and version.
+- Collapsed mode uses a fixed-size icon button centered in the footer.
+- The account row does not change width or composition when the update action appears or disappears.
+
+## Testing
+
+- Add a failing renderer test proving the ready action is rendered after Settings and before the account row.
+- Prove the update action is absent outside the `ready` state.
+- Prove expanded mode shows the label and target version.
+- Prove collapsed mode keeps the accessible label while omitting visible text.
+- Preserve existing tests for immediate installation and installing-state feedback.
+- Run the focused update and sidebar suites, the complete Desktop suite, typecheck, production Desktop build, and the existing Desktop update-experience E2E test.
+- Manually inspect expanded and collapsed layouts in the packaged-style Desktop preview.
+
+## Non-goals
+
+- Moving update controls into Settings.
+- Adding a confirmation dialog or deferring installation after a click.
+- Changing the update feed, release channels, download behavior, or changelog schema.
+- Adding update progress to the sidebar before the release is ready.
+- Refactoring unrelated sidebar navigation or account behavior.
+
+## Documentation
+
+The existing public documentation PR for MAT-291 already describes background download, one-click restart/install, and post-update What's New. This placement-only refinement does not change that public behavior, so no additional public documentation text is required.

--- a/tests/desktop/desktop-update-ui.test.tsx
+++ b/tests/desktop/desktop-update-ui.test.tsx
@@ -24,7 +24,7 @@ describe("desktop update experience", () => {
     vi.unstubAllGlobals();
   });
 
-  it("subscribes to background update state and opens the new release once", async () => {
+  it("subscribes to background update state without acknowledging before dismissal", async () => {
     let updateListener: ((payload: unknown) => void) | null = null;
     const invoke = vi.fn(async (channel: string) => {
       if (channel === "update:get-state") return { status: "downloading", version: "1.2.3", progress: 48 };
@@ -54,7 +54,7 @@ describe("desktop update experience", () => {
     await waitFor(() => {
       expect(useDesktopUpdate.getState().whatsNewOpen).toBe(true);
     });
-    expect(invoke).toHaveBeenCalledWith("update:acknowledge-whats-new", { version: "1.2.2" });
+    expect(invoke).not.toHaveBeenCalledWith("update:acknowledge-whats-new", { version: "1.2.2" });
 
     act(() => {
       updateListener?.({ status: "ready", version: "1.2.3", progress: 100 });
@@ -100,7 +100,9 @@ describe("desktop update experience", () => {
     expect(screen.queryByRole("button", { name: /Update Matrix OS/ })).toBeNull();
   });
 
-  it("renders the installed version changelog in a focused What's New dialog", () => {
+  it("renders the installed version changelog and acknowledges it on dismissal", async () => {
+    const invoke = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal("operator", { invoke, on: vi.fn() });
     useDesktopUpdate.setState({
       release: {
         version: "1.2.3",
@@ -120,6 +122,11 @@ describe("desktop update experience", () => {
     expect(screen.getByText("v1.2.3")).toBeTruthy();
     expect(screen.getByText("Latest")).toBeTruthy();
     expect(screen.getByText("Faster project loading")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Close What's New" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Close What's New" }));
+
+    expect(useDesktopUpdate.getState().whatsNewOpen).toBe(false);
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("update:acknowledge-whats-new", { version: "1.2.3" });
+    });
   });
 });

--- a/tests/desktop/desktop-update-ui.test.tsx
+++ b/tests/desktop/desktop-update-ui.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import DesktopUpdateButton from "../../desktop/src/renderer/src/features/updates/DesktopUpdateButton";
+import WhatsNewDialog from "../../desktop/src/renderer/src/features/updates/WhatsNewDialog";
+import { useDesktopUpdate } from "../../desktop/src/renderer/src/stores/desktop-update";
+
+describe("desktop update experience", () => {
+  beforeEach(() => {
+    useDesktopUpdate.setState({
+      snapshot: { status: "disabled" },
+      release: null,
+      whatsNewOpen: false,
+      installing: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("subscribes to background update state and opens the new release once", async () => {
+    let updateListener: ((payload: unknown) => void) | null = null;
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === "update:get-state") return { status: "downloading", version: "1.2.3", progress: 48 };
+      if (channel === "update:get-whats-new") {
+        return {
+          release: {
+            version: "1.2.2",
+            releaseDate: "2026-08-11T09:00:00.000Z",
+            notes: "## Improved\n\n- Faster project loading",
+          },
+          shouldOpen: true,
+        };
+      }
+      return { ok: true };
+    });
+    const unsubscribe = vi.fn();
+    vi.stubGlobal("operator", {
+      invoke,
+      on: vi.fn((channel: string, listener: (payload: unknown) => void) => {
+        if (channel === "update:state-changed") updateListener = listener;
+        return unsubscribe;
+      }),
+    });
+
+    const dispose = useDesktopUpdate.getState().initialize();
+
+    await waitFor(() => {
+      expect(useDesktopUpdate.getState().whatsNewOpen).toBe(true);
+    });
+    expect(invoke).toHaveBeenCalledWith("update:acknowledge-whats-new", { version: "1.2.2" });
+
+    act(() => {
+      updateListener?.({ status: "ready", version: "1.2.3", progress: 100 });
+    });
+    expect(useDesktopUpdate.getState().snapshot).toEqual({
+      status: "ready",
+      version: "1.2.3",
+      progress: 100,
+    });
+
+    dispose();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("shows a blue Update control only when the download is ready and installs immediately", async () => {
+    const invoke = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal("operator", { invoke, on: vi.fn() });
+    useDesktopUpdate.setState({
+      snapshot: { status: "ready", version: "1.2.3", progress: 100 },
+    });
+
+    const view = render(
+      <Tooltip.Provider>
+        <DesktopUpdateButton />
+      </Tooltip.Provider>,
+    );
+
+    const button = screen.getByRole("button", { name: "Update Matrix OS to 1.2.3" });
+    expect(button.style.background).toBe("var(--update-action)");
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("update:install", {});
+    });
+
+    view.unmount();
+    useDesktopUpdate.setState({ snapshot: { status: "downloading", version: "1.2.4", progress: 99 } });
+    render(
+      <Tooltip.Provider>
+        <DesktopUpdateButton />
+      </Tooltip.Provider>,
+    );
+    expect(screen.queryByRole("button", { name: /Update Matrix OS/ })).toBeNull();
+  });
+
+  it("renders the installed version changelog in a focused What's New dialog", () => {
+    useDesktopUpdate.setState({
+      release: {
+        version: "1.2.3",
+        releaseDate: "2026-08-11T09:00:00.000Z",
+        notes: "## Improved\n\n- Faster project loading\n- Clearer update status",
+      },
+      whatsNewOpen: true,
+    });
+
+    render(
+      <Tooltip.Provider>
+        <WhatsNewDialog />
+      </Tooltip.Provider>,
+    );
+
+    expect(screen.getByRole("heading", { name: "What's New" })).toBeTruthy();
+    expect(screen.getByText("v1.2.3")).toBeTruthy();
+    expect(screen.getByText("Latest")).toBeTruthy();
+    expect(screen.getByText("Faster project loading")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Close What's New" })).toBeTruthy();
+  });
+});

--- a/tests/desktop/desktop-update-ui.test.tsx
+++ b/tests/desktop/desktop-update-ui.test.tsx
@@ -78,7 +78,7 @@ describe("desktop update experience", () => {
 
     const view = render(
       <Tooltip.Provider>
-        <DesktopUpdateButton />
+        <DesktopUpdateButton collapsed={false} />
       </Tooltip.Provider>,
     );
 
@@ -94,10 +94,39 @@ describe("desktop update experience", () => {
     useDesktopUpdate.setState({ snapshot: { status: "downloading", version: "1.2.4", progress: 99 } });
     render(
       <Tooltip.Provider>
-        <DesktopUpdateButton />
+        <DesktopUpdateButton collapsed={false} />
       </Tooltip.Provider>,
     );
     expect(screen.queryByRole("button", { name: /Update Matrix OS/ })).toBeNull();
+  });
+
+  it("renders a full update row when expanded and an icon-only control when collapsed", () => {
+    vi.stubGlobal("operator", { invoke: vi.fn(), on: vi.fn() });
+    useDesktopUpdate.setState({
+      snapshot: { status: "ready", version: "1.2.3", progress: 100 },
+    });
+
+    const view = render(
+      <Tooltip.Provider>
+        <DesktopUpdateButton collapsed={false} />
+      </Tooltip.Provider>,
+    );
+
+    expect(screen.getByText("Update")).toBeTruthy();
+    expect(screen.getByText("v1.2.3")).toBeTruthy();
+
+    view.rerender(
+      <Tooltip.Provider>
+        <DesktopUpdateButton collapsed />
+      </Tooltip.Provider>,
+    );
+
+    const collapsedButton = screen.getByRole("button", {
+      name: "Update Matrix OS to 1.2.3",
+    });
+    expect(collapsedButton.getAttribute("title")).toBe("Update Matrix OS to 1.2.3");
+    expect(screen.queryByText("Update")).toBeNull();
+    expect(screen.queryByText("v1.2.3")).toBeNull();
   });
 
   it("renders the installed version changelog and acknowledges it on dismissal", async () => {

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -43,6 +43,10 @@ describe("IPC contract", () => {
       "badge:set",
       "shell:open-external",
       "update:check",
+      "update:get-state",
+      "update:install",
+      "update:get-whats-new",
+      "update:acknowledge-whats-new",
       "app:get-zoom",
       "app:set-zoom",
     ];
@@ -862,6 +866,7 @@ describe("IPC contract", () => {
       "notification:clicked",
       "update:available",
       "update:ready",
+      "update:state-changed",
       "window:focus-changed",
     ] as const) {
       expect(EVENT_CHANNELS[ch], ch).toBeDefined();
@@ -873,5 +878,43 @@ describe("IPC contract", () => {
     expect(EVENT_CHANNELS["menu:navigate"].safeParse({ kind: "project" }).success).toBe(true);
     expect(EVENT_CHANNELS["menu:navigate"].safeParse({ kind: "agents" }).success).toBe(false);
     expect(EVENT_CHANNELS["menu:navigate"].safeParse({ kind: "terminals" }).success).toBe(true);
+  });
+
+  it("bounds desktop update state and changelog payloads", () => {
+    const state = {
+      status: "ready",
+      version: "1.2.3",
+      progress: 100,
+    };
+    const release = {
+      version: "1.2.3",
+      releaseDate: "2026-08-11T09:00:00.000Z",
+      notes: "## Fixed\n\n- Terminal focus",
+    };
+
+    expect(INVOKE_CHANNELS["update:get-state"].response.safeParse(state).success).toBe(true);
+    expect(
+      INVOKE_CHANNELS["update:acknowledge-whats-new"].request.safeParse({
+        version: "1.2.3-beta.1+arm64.7",
+      }).success,
+    ).toBe(true);
+    expect(EVENT_CHANNELS["update:state-changed"].safeParse(state).success).toBe(true);
+    expect(
+      INVOKE_CHANNELS["update:get-whats-new"].response.safeParse({
+        release,
+        shouldOpen: true,
+      }).success,
+    ).toBe(true);
+    expect(
+      INVOKE_CHANNELS["update:get-whats-new"].response.safeParse({
+        release: { ...release, notes: "x".repeat(40_000) },
+        shouldOpen: true,
+      }).success,
+    ).toBe(false);
+    expect(
+      INVOKE_CHANNELS["update:acknowledge-whats-new"].request.safeParse({
+        version: "../../private",
+      }).success,
+    ).toBe(false);
   });
 });

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -36,6 +36,10 @@ function makeHarness(overrides: Partial<HandlerContext> = {}) {
     notify: vi.fn(),
     onRuntimeChanged: vi.fn(),
     getUpdateStatus: vi.fn(() => "disabled"),
+    getUpdateSnapshot: vi.fn(() => ({ status: "disabled" })),
+    installUpdate: vi.fn(() => false),
+    getWhatsNew: vi.fn(async () => ({ release: null, shouldOpen: false })),
+    acknowledgeWhatsNew: vi.fn(async () => undefined),
     fetchRuntimeSummary: vi.fn(),
     fetchProjectWorkspace: vi.fn(),
     fetchReviewSummaries: vi.fn(),
@@ -122,6 +126,42 @@ describe("registerIpcHandlers", () => {
     const harness = makeHarness({ getUpdateStatus: vi.fn(() => "ready") });
 
     await expect(harness.invoke("update:check")).resolves.toEqual({ status: "ready" });
+  });
+
+  it("exposes typed update state and performs the user-authorized install", async () => {
+    const getUpdateSnapshot = vi.fn(() => ({
+      status: "ready" as const,
+      version: "1.2.3",
+      progress: 100,
+    }));
+    const installUpdate = vi.fn(() => true);
+    const harness = makeHarness({ getUpdateSnapshot, installUpdate });
+
+    await expect(harness.invoke("update:get-state")).resolves.toEqual({
+      status: "ready",
+      version: "1.2.3",
+      progress: 100,
+    });
+    await expect(harness.invoke("update:install")).resolves.toEqual({ ok: true });
+  });
+
+  it("returns the current release once and acknowledges it through a bounded version", async () => {
+    const release = {
+      version: "1.2.3",
+      releaseDate: "2026-08-11T09:00:00.000Z",
+      notes: "## New\n\n- Automatic desktop updates",
+    };
+    const getWhatsNew = vi.fn(async () => ({ release, shouldOpen: true }));
+    const acknowledgeWhatsNew = vi.fn(async () => undefined);
+    const harness = makeHarness({ getWhatsNew, acknowledgeWhatsNew });
+
+    await expect(harness.invoke("update:get-whats-new")).resolves.toEqual({
+      release,
+      shouldOpen: true,
+    });
+    await expect(
+      harness.invoke("update:acknowledge-whats-new", { version: "1.2.3" }),
+    ).resolves.toEqual({ ok: true });
   });
 
   it("returns the runtime summary through a strict trusted-core IPC channel", async () => {

--- a/tests/desktop/local-store.test.ts
+++ b/tests/desktop/local-store.test.ts
@@ -36,6 +36,33 @@ describe("local store", () => {
     })).rejects.toThrow();
   });
 
+  it("acknowledges only the matching release inside the serialized mutation", async () => {
+    const store = createLocalStore({ dir: await makeDir() });
+    const currentRelease = {
+      version: "1.2.3",
+      notes: "## Fixed\n\n- Current release",
+      shown: false,
+    };
+    const newerRelease = {
+      version: "1.2.4",
+      notes: "## New\n\n- Newer downloaded release",
+      shown: false,
+    };
+    await store.set("desktopUpdateRelease", currentRelease);
+
+    const replaceWithNewer = store.set("desktopUpdateRelease", newerRelease);
+    const staleAcknowledgement = store.acknowledgeDesktopUpdateRelease("1.2.3");
+
+    await expect(staleAcknowledgement).resolves.toBe(false);
+    await replaceWithNewer;
+    expect(await store.get("desktopUpdateRelease")).toEqual(newerRelease);
+    await expect(store.acknowledgeDesktopUpdateRelease("1.2.4")).resolves.toBe(true);
+    expect(await store.get("desktopUpdateRelease")).toEqual({
+      ...newerRelease,
+      shown: true,
+    });
+  });
+
   it("returns null for unset keys", async () => {
     const store = createLocalStore({ dir: await makeDir() });
     expect(await store.get("lastProjectSlug")).toBeNull();

--- a/tests/desktop/local-store.test.ts
+++ b/tests/desktop/local-store.test.ts
@@ -18,6 +18,24 @@ describe("local store", () => {
     expect(await store.get("lastProjectSlug")).toBe("matrix-os");
   });
 
+  it("persists bounded desktop release notes for the post-update What's New dialog", async () => {
+    const store = createLocalStore({ dir: await makeDir() });
+    const release = {
+      version: "1.2.3",
+      releaseDate: "2026-08-11T09:00:00.000Z",
+      notes: "## Improved\n\n- Faster project loading",
+      shown: false,
+    };
+
+    await store.set("desktopUpdateRelease", release);
+
+    expect(await store.get("desktopUpdateRelease")).toEqual(release);
+    await expect(store.setUnknown("desktopUpdateRelease", {
+      ...release,
+      notes: "x".repeat(40_000),
+    })).rejects.toThrow();
+  });
+
   it("returns null for unset keys", async () => {
     const store = createLocalStore({ dir: await makeDir() });
     expect(await store.get("lastProjectSlug")).toBeNull();

--- a/tests/desktop/sidebar-attention-badges.test.tsx
+++ b/tests/desktop/sidebar-attention-badges.test.tsx
@@ -8,6 +8,7 @@ import Sidebar from "../../desktop/src/renderer/src/features/mission-control/Sid
 import { useBoard } from "../../desktop/src/renderer/src/stores/board";
 import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useDesktopUpdate } from "../../desktop/src/renderer/src/stores/desktop-update";
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 import { useThreads, type AgentThread } from "../../desktop/src/renderer/src/stores/threads";
 import { useUi } from "../../desktop/src/renderer/src/stores/ui";
@@ -72,6 +73,10 @@ describe("Sidebar attention badges", () => {
     useTabs.setState({ tabs: [], activeTabId: null });
     useThreads.setState({ threads: [], activeThreadId: null });
     useCodingAgentWorkspace.setState({ summary: null, activeThreadId: null });
+    useDesktopUpdate.setState({
+      snapshot: { status: "disabled" },
+      installing: false,
+    });
     useUi.setState({ sidebarCollapsed: false });
   });
 
@@ -133,5 +138,25 @@ describe("Sidebar attention badges", () => {
 
     expect(screen.getByRole("button", { name: "Chat" })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Matrix OS$/ })).toBeTruthy();
+  });
+
+  it("places a ready update after Settings and outside the account row", () => {
+    useDesktopUpdate.setState({
+      snapshot: { status: "ready", version: "1.2.3", progress: 100 },
+    });
+
+    render(
+      <Tooltip.Provider>
+        <Sidebar />
+      </Tooltip.Provider>,
+    );
+
+    const settings = screen.getByRole("button", { name: "Settings" });
+    const update = screen.getByRole("button", { name: "Update Matrix OS to 1.2.3" });
+    const account = screen.getByTitle("Manage account");
+
+    expect(settings.compareDocumentPosition(update) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(update.compareDocumentPosition(account) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(update.parentElement).not.toBe(account.parentElement);
   });
 });

--- a/tests/desktop/updater.test.ts
+++ b/tests/desktop/updater.test.ts
@@ -6,7 +6,7 @@ const electronMock = vi.hoisted(() => ({
 }));
 
 const updaterMock = vi.hoisted(() => {
-  type UpdateHandler = (info: { version: string } | Error) => void;
+  type UpdateHandler = (info: unknown) => void;
   const handlers = new Map<string, UpdateHandler>();
   const autoUpdater = {
     autoDownload: false,
@@ -20,7 +20,12 @@ const updaterMock = vi.hoisted(() => {
       handlers.set(eventName, handler);
       return autoUpdater;
     }),
+    on: vi.fn((eventName: string, handler: UpdateHandler) => {
+      handlers.set(eventName, handler);
+      return autoUpdater;
+    }),
     checkForUpdates: vi.fn(),
+    quitAndInstall: vi.fn(),
   };
   return { autoUpdater, handlers };
 });
@@ -38,7 +43,9 @@ beforeEach(() => {
   updaterMock.autoUpdater.setFeedURL.mockClear();
   updaterMock.autoUpdater.removeAllListeners.mockClear();
   updaterMock.autoUpdater.once.mockClear();
+  updaterMock.autoUpdater.on.mockClear();
   updaterMock.autoUpdater.checkForUpdates.mockReset().mockResolvedValue({});
+  updaterMock.autoUpdater.quitAndInstall.mockReset();
 });
 
 describe("createUpdater", () => {
@@ -175,5 +182,62 @@ describe("createUpdater", () => {
 
     expect(updater.status()).toBe("disabled");
     expect(updaterMock.autoUpdater.checkForUpdates).not.toHaveBeenCalled();
+  });
+
+  it("publishes bounded download progress and release metadata in its snapshot", async () => {
+    const onStateChanged = vi.fn();
+    const updater = createUpdater({
+      onAvailable: vi.fn(),
+      onReady: vi.fn(),
+      onStateChanged,
+    });
+
+    await updater.check();
+    updaterMock.handlers.get("update-available")?.({
+      version: "1.2.3",
+      releaseDate: "2026-08-11T09:00:00.000Z",
+      releaseNotes: "## Improved\n\n- Faster project loading",
+    });
+    updaterMock.handlers.get("download-progress")?.({ percent: 42.75 });
+
+    expect(updater.snapshot()).toEqual({
+      status: "downloading",
+      version: "1.2.3",
+      progress: 42.75,
+    });
+
+    updaterMock.handlers.get("download-progress")?.({ percent: 250 });
+    expect(updater.snapshot().progress).toBe(100);
+
+    updaterMock.handlers.get("update-downloaded")?.({
+      version: "1.2.3",
+      releaseDate: "2026-08-11T09:00:00.000Z",
+      releaseNotes: "## Improved\n\n- Faster project loading",
+    });
+
+    expect(updater.snapshot()).toEqual({
+      status: "ready",
+      version: "1.2.3",
+      progress: 100,
+    });
+    expect(onStateChanged).toHaveBeenLastCalledWith({
+      status: "ready",
+      version: "1.2.3",
+      progress: 100,
+    });
+  });
+
+  it("installs immediately only after the background download is ready", async () => {
+    const updater = createUpdater({ onAvailable: vi.fn(), onReady: vi.fn() });
+
+    expect(await updater.install()).toBe(false);
+    expect(updaterMock.autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+
+    await updater.check();
+    updaterMock.handlers.get("update-downloaded")?.({ version: "1.2.3" });
+
+    expect(await updater.install()).toBe(true);
+    expect(updaterMock.autoUpdater.quitAndInstall).toHaveBeenCalledOnce();
+    expect(updaterMock.autoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true);
   });
 });

--- a/tests/e2e/desktop/update-experience.e2e.test.ts
+++ b/tests/e2e/desktop/update-experience.e2e.test.ts
@@ -45,7 +45,7 @@ suite("desktop update experience", () => {
     gateway = await startStubGateway();
     app = await _electron.launch({
       executablePath: ELECTRON_PATH,
-      args: [DESKTOP_MAIN, "--remote-debugging-port=9226"],
+      args: [DESKTOP_MAIN],
       env: {
         ...process.env,
         OPERATOR_GATEWAY_URL: gateway.url,

--- a/tests/e2e/desktop/update-experience.e2e.test.ts
+++ b/tests/e2e/desktop/update-experience.e2e.test.ts
@@ -66,7 +66,7 @@ suite("desktop update experience", () => {
     if (userDataDir) rmSync(userDataDir, { recursive: true, force: true });
   });
 
-  it("shows What's New after launch and places Update next to the account avatar", async () => {
+  it("shows What's New after launch and places Update below Settings", async () => {
     await page.getByRole("heading", { name: "What's New" }).waitFor({ timeout: 10_000 });
     await page.getByText("Automatic background downloads for Matrix OS updates").waitFor();
     await page.mouse.move(80, 400);
@@ -92,11 +92,24 @@ suite("desktop update experience", () => {
 
     const update = page.getByRole("button", { name: "Update Matrix OS to 0.2.0" });
     await update.waitFor({ timeout: 10_000 });
-    const avatarBox = await page.getByTitle("Manage account").boundingBox();
+    const settings = page.getByRole("button", { name: "Settings" });
+    const avatar = page.getByTitle("Manage account");
+    const settingsBox = await settings.boundingBox();
     const updateBox = await update.boundingBox();
+    const avatarBox = await avatar.boundingBox();
+    expect(settingsBox).not.toBeNull();
     expect(avatarBox).not.toBeNull();
     expect(updateBox).not.toBeNull();
-    expect(Math.abs((updateBox?.x ?? 0) - (avatarBox?.x ?? 0))).toBeLessThan(48);
+    expect(updateBox?.y ?? 0).toBeGreaterThan((settingsBox?.y ?? 0) + (settingsBox?.height ?? 0));
+    expect((updateBox?.y ?? 0) + (updateBox?.height ?? 0)).toBeLessThanOrEqual(avatarBox?.y ?? 0);
+    expect(updateBox?.width ?? 0).toBeGreaterThan((avatarBox?.width ?? 0) * 4);
     await page.screenshot({ path: join(SCREENSHOT_DIR, "mat-291-update-ready.png") });
+
+    await page.getByRole("button", { name: "Collapse sidebar (⌘B)" }).click();
+    const collapsedUpdateBox = await update.boundingBox();
+    expect(collapsedUpdateBox).not.toBeNull();
+    expect(Math.abs((collapsedUpdateBox?.width ?? 0) - (collapsedUpdateBox?.height ?? 0))).toBeLessThanOrEqual(2);
+    expect(collapsedUpdateBox?.width ?? 0).toBeLessThan(40);
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "mat-291-update-ready-collapsed.png") });
   }, 30_000);
 });

--- a/tests/e2e/desktop/update-experience.e2e.test.ts
+++ b/tests/e2e/desktop/update-experience.e2e.test.ts
@@ -1,0 +1,102 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { _electron, type ElectronApplication, type Page } from "playwright";
+import { startStubGateway, type StubGateway } from "./fixtures/stub-gateway";
+
+const DESKTOP_MAIN = resolve(__dirname, "../../../desktop/out/main/index.js");
+const SCREENSHOT_DIR = resolve(__dirname, "../../../desktop/screenshots");
+const requireDesktop = createRequire(resolve(__dirname, "../../../desktop/package.json"));
+const ELECTRON_PATH = requireDesktop("electron") as string;
+const suite = existsSync(DESKTOP_MAIN) ? describe : describe.skip;
+
+suite("desktop update experience", () => {
+  let app: ElectronApplication;
+  let gateway: StubGateway;
+  let page: Page;
+  let userDataDir: string;
+
+  function seedRelease(version: string): void {
+    writeFileSync(join(userDataDir, "state.json"), JSON.stringify({
+      desktopUpdateRelease: {
+        version,
+        releaseDate: "2026-08-11T09:00:00.000Z",
+        notes: [
+          "## New",
+          "",
+          "- Automatic background downloads for Matrix OS updates",
+          "- One-click restart and install from the sidebar",
+          "",
+          "## Improved",
+          "",
+          "- Release notes now open inside the desktop app after an update",
+        ].join("\n"),
+        shown: false,
+      },
+    }));
+  }
+
+  beforeAll(async () => {
+    mkdirSync(SCREENSHOT_DIR, { recursive: true });
+    userDataDir = mkdtempSync(join(tmpdir(), "matrix-os-update-evidence-"));
+    seedRelease("0.1.0");
+    gateway = await startStubGateway();
+    app = await _electron.launch({
+      executablePath: ELECTRON_PATH,
+      args: [DESKTOP_MAIN, "--remote-debugging-port=9226"],
+      env: {
+        ...process.env,
+        OPERATOR_GATEWAY_URL: gateway.url,
+        OPERATOR_USER_DATA_DIR: userDataDir,
+      },
+    });
+    page = await app.firstWindow();
+    const runningVersion = await app.evaluate(({ app: electronApp }) => electronApp.getVersion());
+    seedRelease(runningVersion);
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.getByRole("button", { name: /continue with github/i }).click();
+    await page.locator("aside button", { hasText: "Terminal" }).first().waitFor({ timeout: 15_000 });
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.close();
+    await gateway?.close();
+    if (userDataDir) rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  it("shows What's New after launch and places Update next to the account avatar", async () => {
+    await page.getByRole("heading", { name: "What's New" }).waitFor({ timeout: 10_000 });
+    await page.getByText("Automatic background downloads for Matrix OS updates").waitFor();
+    await page.mouse.move(80, 400);
+    await page.waitForTimeout(200);
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "mat-291-whats-new.png") });
+
+    await page.setViewportSize({ width: 880, height: 560 });
+    const compactDialog = await page.getByRole("dialog").boundingBox();
+    expect(compactDialog).not.toBeNull();
+    expect(compactDialog?.x ?? 0).toBeGreaterThanOrEqual(16);
+    expect((compactDialog?.x ?? 0) + (compactDialog?.width ?? 0)).toBeLessThanOrEqual(864);
+    expect((compactDialog?.y ?? 0) + (compactDialog?.height ?? 0)).toBeLessThanOrEqual(560);
+    await page.setViewportSize({ width: 1280, height: 800 });
+
+    await page.getByRole("button", { name: "Close What's New" }).click();
+    await app.evaluate(({ BrowserWindow }) => {
+      BrowserWindow.getAllWindows()[0]?.webContents.send("update:state-changed", {
+        status: "ready",
+        version: "0.2.0",
+        progress: 100,
+      });
+    });
+
+    const update = page.getByRole("button", { name: "Update Matrix OS to 0.2.0" });
+    await update.waitFor({ timeout: 10_000 });
+    const avatarBox = await page.getByTitle("Manage account").boundingBox();
+    const updateBox = await update.boundingBox();
+    expect(avatarBox).not.toBeNull();
+    expect(updateBox).not.toBeNull();
+    expect(Math.abs((updateBox?.x ?? 0) - (avatarBox?.x ?? 0))).toBeLessThan(48);
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "mat-291-update-ready.png") });
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- keep Electron updates downloading automatically in the background
- show a standalone blue **Update** row below **Settings** and above the account row only when the bundle is ready
- render the action as a full-width `Update` + version row when expanded and a centered square icon when the sidebar is collapsed
- restart and install immediately on click without compressing the account controls
- persist bounded release notes before restart and open a sanitized **What's New** dialog once on the newly installed version
- acknowledge release notes only on dismissal and atomically preserve metadata for any newer downloaded update
- add strict update IPC contracts, responsive UI coverage, isolated Electron E2E evidence, release workflow documentation, and a separate public docs PR

Closes #1190
Linear: [MAT-291](https://linear.app/matrix-os/issue/MAT-291/add-codex-style-one-click-desktop-ota-updates-and-post-update-whats)
Public docs: [FinnaAI/matrix-os-site#19](https://github.com/FinnaAI/matrix-os-site/pull/19)

## Tests

- `bun run typecheck` — passed
- `bun run check:patterns` — 0 violations; 5 pre-existing scanner warning groups outside this diff
- `pnpm exec vitest run tests/desktop --silent=passed-only --reporter=dot` — 151 files / 1,508 tests passed
- focused OTA/Desktop integration — 7 files / 107 tests passed
- `pnpm exec vitest run --config vitest.e2e.config.ts tests/e2e/desktop/update-experience.e2e.test.ts` — passed; verifies footer order, expanded full-width action, and collapsed square action in a real Electron build
- `bun run build:desktop` — passed
- `bun run test` — broader baseline run completed with 901 files / 10,374 tests passing and 24 unrelated failures in existing test-environment resolution, date-sensitive Todo fixtures, Codex app-server/runtime timing, macOS Unix-socket path limits, zellij/tool-pack shell timing, and customer VPS cloud-init coverage; the complete Desktop suite above is green
- [CI run 31495930553](https://github.com/HamedMP/matrix-os/actions/runs/31495930553) — all required jobs passed on `63288e97e`, including all four unit-test shards and E2E

## Review / Monitoring

- Visual target: Codex-style background download, a dedicated update entry below Settings, and a post-restart changelog
- Exact implementation head: `63288e97e49c84a61db35e83255fc608de0c746f`
- Greptile: **5/5** on the exact implementation head, with no blocking findings
- Claude review and all required exact-head CI jobs passed
- All review threads are resolved
- `ready-for-ci` is set

## Invariants

### Source of truth

- `electron-updater` state in the Electron main process is authoritative for update readiness and installation.
- `desktopUpdateRelease` is recreatable local UI state used only to decide whether the installed version's release notes should open once; it cannot make an update installable.

### Lock/transaction scope

- No database transaction is involved.
- The existing local store serializes writes and commits them with temp-file + atomic rename.
- Release acknowledgement compares the version and marks it shown inside the same serialized store mutation, so it cannot overwrite a newer downloaded release.
- Explicit install waits for the release-note write to settle before calling `quitAndInstall`; update network activity remains outside the write queue.

### Acceptable orphan states

- If release-note persistence fails, installation may still proceed and the next launch simply has no **What's New** dialog; the failure is logged without exposing it to the renderer.
- If acknowledgement fails, the release remains unshown and **What's New** is offered again on the next launch.
- If restart/install fails, the renderer clears its installing state and the already-downloaded update remains ready for retry or normal quit installation.

### Auth source of truth

- Update commands use the existing context-isolated preload bridge and strict Zod request/response validation in preload and main.
- No credential, bearer token, filesystem path, or provider error crosses the new IPC contract.

### Deferred scope

- Browsing historical releases manually is not included; this PR shows the exact release installed by the completed update.
- Manual update checks, a persistent download-progress surface, restart confirmation, and a Later action remain deferred.
- Release publishing, signing, notarization, artifact selection, and rollout-channel promotion remain owned by the existing desktop release workflows.
