### PR TITLE
fix(platform): gate golden snapshot enqueue

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -384,7 +384,7 @@ jobs:
   enqueue-golden-snapshot:
     name: Enqueue golden snapshot build
     needs: [dev-bundle-gate, build, publish]
-    if: ${{ needs.dev-bundle-gate.outputs.should_build == 'true' && ((github.event_name == 'push' && ((github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag')) || (github.event_name == 'workflow_dispatch' && inputs.channel != '')) }}
+    if: ${{ vars.GOLDEN_SNAPSHOT_BUILDS_ENABLED == 'true' && needs.dev-bundle-gate.outputs.should_build == 'true' && ((github.event_name == 'push' && ((github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag')) || (github.event_name == 'workflow_dispatch' && inputs.channel != '')) }}
     continue-on-error: true
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -54,6 +54,7 @@ jobs:
       MATRIX_APP_DOMAIN_HOSTS: ${{ vars.MATRIX_APP_DOMAIN_HOSTS }}
       MATRIX_CODE_DOMAIN_HOSTS: ${{ vars.MATRIX_CODE_DOMAIN_HOSTS }}
       CUSTOMER_VPS_IMAGE_VERSION: ${{ vars.CUSTOMER_VPS_IMAGE_VERSION }}
+      GOLDEN_SNAPSHOT_BUILDS_ENABLED: ${{ vars.GOLDEN_SNAPSHOT_BUILDS_ENABLED || 'false' }}
       POSTHOG_PUBLIC_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.posthog.com' }}
       POSTHOG_PUBLIC_API_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_API_HOST || '/relay' }}
       DEPLOY_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'production' }}
@@ -85,6 +86,13 @@ jobs:
             printf 'Missing required GitHub environment variable(s): %s\n' "${missing[*]}" >&2
             exit 1
           fi
+          case "$GOLDEN_SNAPSHOT_BUILDS_ENABLED" in
+            true|false) ;;
+            *)
+              echo "GOLDEN_SNAPSHOT_BUILDS_ENABLED must be true or false." >&2
+              exit 1
+              ;;
+          esac
 
       - name: Authenticate to Google Cloud
         # google-github-actions v4 tags are not published yet; v3 is the latest
@@ -447,7 +455,7 @@ jobs:
             --ingress all \
             --allow-unauthenticated \
             "${traffic_flags[@]}" \
-            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_BACKGROUND_WORKERS_ENABLED=false,PLATFORM_PORT=8080,PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL},MATRIX_API_ORIGIN=${MATRIX_API_ORIGIN},CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_TLS_VERIFY=false,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_APP_DOMAIN_HOSTS=${MATRIX_APP_DOMAIN_HOSTS},MATRIX_CODE_DOMAIN_HOSTS=${MATRIX_CODE_DOMAIN_HOSTS},NEXT_PUBLIC_MATRIX_APP_URL=${MATRIX_APP_URL},MATRIX_BILLING_PROVIDER=stripe,POSTHOG_HOST=https://eu.i.posthog.com,POSTHOG_API_HOST=https://eu.i.posthog.com,NEXT_PUBLIC_POSTHOG_HOST=${POSTHOG_PUBLIC_HOST},NEXT_PUBLIC_POSTHOG_API_HOST=${POSTHOG_PUBLIC_API_HOST},R2_PREFIX_ROOT=matrixos-sync" \
+            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_BACKGROUND_WORKERS_ENABLED=false,PLATFORM_PORT=8080,PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL},MATRIX_API_ORIGIN=${MATRIX_API_ORIGIN},CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_TLS_VERIFY=false,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_APP_DOMAIN_HOSTS=${MATRIX_APP_DOMAIN_HOSTS},MATRIX_CODE_DOMAIN_HOSTS=${MATRIX_CODE_DOMAIN_HOSTS},NEXT_PUBLIC_MATRIX_APP_URL=${MATRIX_APP_URL},MATRIX_BILLING_PROVIDER=stripe,POSTHOG_HOST=https://eu.i.posthog.com,POSTHOG_API_HOST=https://eu.i.posthog.com,NEXT_PUBLIC_POSTHOG_HOST=${POSTHOG_PUBLIC_HOST},NEXT_PUBLIC_POSTHOG_API_HOST=${POSTHOG_PUBLIC_API_HOST},R2_PREFIX_ROOT=matrixos-sync,GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED},GOLDEN_SNAPSHOTS_ENABLED=false,GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0" \
             --set-secrets "PLATFORM_DATABASE_URL=platform-database-url:latest,PLATFORM_SECRET=platform-secret:latest,GOLDEN_SNAPSHOT_OPERATOR_SECRET=golden-snapshot-operator-secret:latest,PLATFORM_JWT_SECRET=platform-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,STRIPE_SECRET_KEY=stripe-secret-key:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual:latest,PIPEDREAM_CLIENT_ID=pipedream-client-id:latest,PIPEDREAM_CLIENT_SECRET=pipedream-client-secret:latest,PIPEDREAM_PROJECT_ID=pipedream-project-id:latest,PIPEDREAM_ENVIRONMENT=pipedream-environment:latest,R2_ACCOUNT_ID=r2-account-id:latest,R2_BUCKET=r2-bucket:latest,R2_ENDPOINT=r2-endpoint:latest,R2_ACCESS_KEY_ID=r2-access-key-id:latest,R2_SECRET_ACCESS_KEY=r2-secret-access-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,HETZNER_API_TOKEN=hetzner-api-token:latest,POSTHOG_TOKEN=posthog-token:latest,POSTHOG_PROJECT_TOKEN=posthog-project-token:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,NEXT_PUBLIC_POSTHOG_KEY=next-public-posthog-key:latest,NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=next-public-posthog-project-token:latest" \
             --format=json); then
             exit 1
@@ -576,7 +584,7 @@ jobs:
             --tag production-candidate \
             --no-traffic \
             --min-instances "$min_instances" \
-            --update-env-vars "PLATFORM_BACKGROUND_WORKERS_ENABLED=true" \
+            --update-env-vars "PLATFORM_BACKGROUND_WORKERS_ENABLED=true,GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED},GOLDEN_SNAPSHOTS_ENABLED=false,GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0" \
             --format=json)"
           production_revision="$(printf '%s\n' "$deploy_json" | jq -r '.status.traffic[]? | select(.tag == "production-candidate") | .revisionName // empty' | head -1)"
           if [ -z "$production_revision" ]; then

--- a/docs/dev/golden-vps-snapshots.md
+++ b/docs/dev/golden-vps-snapshots.md
@@ -41,7 +41,7 @@ Related state changes use Postgres transactions. Provider requests are always ou
 
 ## Build and Validation
 
-The release workflow enqueues the immutable bundle version only after publication. Enqueue failure is non-blocking, and the existing `deploy` job does not depend on snapshot success.
+The release workflow enqueues the immutable bundle version only after publication and only when the GitHub Actions variable `GOLDEN_SNAPSHOT_BUILDS_ENABLED` is exactly `true`. The platform deployment workflow passes the same variable to both candidate and production roles, defaults it to `false`, and keeps snapshot selection disabled with rollout `0%`. Enqueue failure is non-blocking, and the existing `deploy` job does not depend on snapshot success.
 
 The worker uses bounded batches and leases. Ephemeral builders and validation clones carry exact labels for build ID, snapshot ID, and role. Those labels are also the only allowed basis for adopting a resource after an ambiguous create result. Zero matches means wait; multiple exact matches quarantine the build. Cleanup verifies the recorded resource ID and labels before deletion.
 

--- a/scripts/enqueue-golden-snapshot.mjs
+++ b/scripts/enqueue-golden-snapshot.mjs
@@ -27,6 +27,24 @@ const EnqueueResponseSchema = z.object({
   reused: z.boolean(),
 }).passthrough();
 
+export class GoldenSnapshotEnqueueError extends Error {
+  constructor(category) {
+    super('Snapshot build enqueue failed');
+    this.name = 'GoldenSnapshotEnqueueError';
+    this.category = category;
+  }
+}
+
+const SAFE_FAILURE_CATEGORIES = new Set(['disabled', 'unauthorized', 'conflict', 'unavailable']);
+
+export function formatGoldenSnapshotEnqueueFailure(error) {
+  const category = error instanceof GoldenSnapshotEnqueueError
+    && SAFE_FAILURE_CATEGORIES.has(error.category)
+    ? error.category
+    : 'unavailable';
+  return `Golden snapshot build enqueue failed (${category}). Host bundle publication and fleet deployment are unaffected.`;
+}
+
 export function isEligibleSnapshotRelease(input) {
   const parsed = ReleaseContextSchema.safeParse(input);
   if (!parsed.success) return false;
@@ -59,6 +77,18 @@ async function readBoundedJson(response) {
   }
 }
 
+async function classifyFailure(response) {
+  if (response.status === 401 || response.status === 403) return 'unauthorized';
+  if (response.status === 409) return 'conflict';
+  if (response.status !== 503) return 'unavailable';
+  try {
+    const body = await readBoundedJson(response);
+    return body?.error === 'Snapshot builds disabled' ? 'disabled' : 'unavailable';
+  } catch {
+    return 'unavailable';
+  }
+}
+
 export async function enqueueGoldenSnapshot(input) {
   const { fetchImpl = fetch, ...untrusted } = input;
   const parsed = EnqueueInputSchema.safeParse(untrusted);
@@ -81,9 +111,11 @@ export async function enqueueGoldenSnapshot(input) {
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
   } catch {
-    throw new Error('Snapshot build enqueue failed');
+    throw new GoldenSnapshotEnqueueError('unavailable');
   }
-  if (response.status !== 202) throw new Error('Snapshot build enqueue failed');
+  if (response.status !== 202) {
+    throw new GoldenSnapshotEnqueueError(await classifyFailure(response));
+  }
   const result = EnqueueResponseSchema.safeParse(await readBoundedJson(response));
   if (!result.success) throw new Error('Snapshot build enqueue failed');
   return { status: result.data.status, reused: result.data.reused };
@@ -114,8 +146,8 @@ async function main() {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main().catch(() => {
-    process.stderr.write('Golden snapshot build enqueue failed. Host bundle publication and fleet deployment are unaffected.\n');
+  main().catch((error) => {
+    process.stderr.write(`${formatGoldenSnapshotEnqueueFailure(error)}\n`);
     process.exitCode = 1;
   });
 }

--- a/scripts/enqueue-golden-snapshot.mjs
+++ b/scripts/enqueue-golden-snapshot.mjs
@@ -37,6 +37,14 @@ export class GoldenSnapshotEnqueueError extends Error {
 
 const SAFE_FAILURE_CATEGORIES = new Set(['disabled', 'unauthorized', 'conflict', 'unavailable']);
 
+class EnqueueResponseReadError extends Error {
+  constructor(reason) {
+    super('Snapshot build enqueue response unavailable');
+    this.name = 'EnqueueResponseReadError';
+    this.reason = reason;
+  }
+}
+
 export function formatGoldenSnapshotEnqueueFailure(error) {
   const category = error instanceof GoldenSnapshotEnqueueError
     && SAFE_FAILURE_CATEGORIES.has(error.category)
@@ -55,7 +63,7 @@ export function isEligibleSnapshotRelease(input) {
 }
 
 async function readBoundedJson(response) {
-  if (!response.body) throw new Error('Snapshot build enqueue failed');
+  if (!response.body) throw new EnqueueResponseReadError('missing_body');
   const reader = response.body.getReader();
   const chunks = [];
   let total = 0;
@@ -64,7 +72,7 @@ async function readBoundedJson(response) {
       const { done, value } = await reader.read();
       if (done) break;
       total += value.byteLength;
-      if (total > MAX_RESPONSE_BYTES) throw new Error('Snapshot build enqueue failed');
+      if (total > MAX_RESPONSE_BYTES) throw new EnqueueResponseReadError('response_too_large');
       chunks.push(value);
     }
   } finally {
@@ -72,8 +80,9 @@ async function readBoundedJson(response) {
   }
   try {
     return JSON.parse(Buffer.concat(chunks).toString('utf8'));
-  } catch {
-    throw new Error('Snapshot build enqueue failed');
+  } catch (error) {
+    if (error instanceof SyntaxError) throw new EnqueueResponseReadError('invalid_json');
+    throw new EnqueueResponseReadError('unreadable');
   }
 }
 
@@ -84,7 +93,9 @@ async function classifyFailure(response) {
   try {
     const body = await readBoundedJson(response);
     return body?.error === 'Snapshot builds disabled' ? 'disabled' : 'unavailable';
-  } catch {
+  } catch (error) {
+    const reason = error instanceof EnqueueResponseReadError ? error.reason : 'unreadable';
+    console.warn(`[golden-snapshot-enqueue] Response classification failed (${reason}).`);
     return 'unavailable';
   }
 }

--- a/tests/platform/host-bundle-snapshot-workflow.test.ts
+++ b/tests/platform/host-bundle-snapshot-workflow.test.ts
@@ -97,6 +97,26 @@ describe('host bundle golden snapshot release hook', () => {
     expect(String(failure)).not.toContain('must not escape');
   });
 
+  it('records a coarse diagnostic when a disabled response cannot be classified', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const failure = await enqueueGoldenSnapshot({
+      platformUrl: 'https://app.matrix-os.com',
+      platformSecret: 'test-secret',
+      bundleVersion: 'v2026.07.19-1053',
+      fetchImpl: vi.fn(async () => new Response('provider secret: malformed', { status: 503 })),
+    }).catch((error: unknown) => error);
+
+    expect(failure).toMatchObject({
+      message: 'Snapshot build enqueue failed',
+      category: 'unavailable',
+    });
+    expect(warn).toHaveBeenCalledWith(
+      '[golden-snapshot-enqueue] Response classification failed (invalid_json).',
+    );
+    expect(warn.mock.calls.flat().join(' ')).not.toContain('provider secret');
+  });
+
   it('formats only allowlisted enqueue diagnostics for CI', () => {
     expect(formatGoldenSnapshotEnqueueFailure(new GoldenSnapshotEnqueueError('disabled')))
       .toBe('Golden snapshot build enqueue failed (disabled). Host bundle publication and fleet deployment are unaffected.');

--- a/tests/platform/host-bundle-snapshot-workflow.test.ts
+++ b/tests/platform/host-bundle-snapshot-workflow.test.ts
@@ -17,6 +17,8 @@ import {
 import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
 import {
   enqueueGoldenSnapshot,
+  formatGoldenSnapshotEnqueueFailure,
+  GoldenSnapshotEnqueueError,
   isEligibleSnapshotRelease,
 } from '../../scripts/enqueue-golden-snapshot.mjs';
 import { resolveReleaseSnapshotEligibility } from '../../scripts/release-snapshot-eligibility.mjs';
@@ -74,6 +76,54 @@ describe('host bundle golden snapshot release hook', () => {
     })).rejects.toThrow('Snapshot build enqueue failed');
   });
 
+  it('reports a safe disabled category without exposing response details', async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      error: 'Snapshot builds disabled',
+      providerError: 'must not escape',
+    }), { status: 503, headers: { 'content-type': 'application/json' } }));
+
+    const failure = await enqueueGoldenSnapshot({
+      platformUrl: 'https://app.matrix-os.com',
+      platformSecret: 'test-secret',
+      bundleVersion: 'v2026.07.19-1053',
+      fetchImpl,
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(GoldenSnapshotEnqueueError);
+    expect(failure).toMatchObject({
+      message: 'Snapshot build enqueue failed',
+      category: 'disabled',
+    });
+    expect(String(failure)).not.toContain('must not escape');
+  });
+
+  it('formats only allowlisted enqueue diagnostics for CI', () => {
+    expect(formatGoldenSnapshotEnqueueFailure(new GoldenSnapshotEnqueueError('disabled')))
+      .toBe('Golden snapshot build enqueue failed (disabled). Host bundle publication and fleet deployment are unaffected.');
+    expect(formatGoldenSnapshotEnqueueFailure(new Error('provider quota secret')))
+      .toBe('Golden snapshot build enqueue failed (unavailable). Host bundle publication and fleet deployment are unaffected.');
+  });
+
+  it.each([
+    [401, 'unauthorized'],
+    [403, 'unauthorized'],
+    [409, 'conflict'],
+    [500, 'unavailable'],
+  ])('maps HTTP %i to the safe %s category', async (status, category) => {
+    const failure = await enqueueGoldenSnapshot({
+      platformUrl: 'https://app.matrix-os.com',
+      platformSecret: 'test-secret',
+      bundleVersion: 'v2026.07.19-1053',
+      fetchImpl: vi.fn(async () => new Response('provider details must not escape', { status })),
+    }).catch((error: unknown) => error);
+
+    expect(failure).toMatchObject({
+      message: 'Snapshot build enqueue failed',
+      category,
+    });
+    expect(String(failure)).not.toContain('provider details');
+  });
+
   it('keeps snapshot enqueue failure isolated from existing fleet deployment', () => {
     const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
     const enqueueJob = workflow.slice(
@@ -84,6 +134,7 @@ describe('host bundle golden snapshot release hook', () => {
 
     expect(enqueueJob).toContain('needs: [dev-bundle-gate, build, publish]');
     expect(enqueueJob).toContain('continue-on-error: true');
+    expect(enqueueJob).toContain("vars.GOLDEN_SNAPSHOT_BUILDS_ENABLED == 'true'");
     expect(enqueueJob).toContain("github.event_name == 'push'");
     expect(enqueueJob).toContain("(github.event_name == 'workflow_dispatch' && inputs.channel != '')");
     expect(enqueueJob).toContain("github.ref_name == 'main'");
@@ -94,6 +145,28 @@ describe('host bundle golden snapshot release hook', () => {
     expect(enqueueJob).not.toContain('--version "${{ needs.build.outputs.version }}"');
     expect(deployJob).toContain('needs: [dev-bundle-gate, build, publish]');
     expect(deployJob).not.toContain('enqueue-golden-snapshot');
+  });
+
+  it('deploys an explicit disabled-by-default golden build contract without enabling selection', () => {
+    const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
+    const candidateDeploy = workflow.slice(
+      workflow.indexOf('      - name: Deploy tagged revision'),
+      workflow.indexOf('      - name: Smoke candidate revision'),
+    );
+    const productionDeploy = workflow.slice(
+      workflow.indexOf('      - name: Deploy production-role revision'),
+      workflow.indexOf('      - name: Promote revision'),
+    );
+
+    expect(workflow).toContain(
+      "GOLDEN_SNAPSHOT_BUILDS_ENABLED: ${{ vars.GOLDEN_SNAPSHOT_BUILDS_ENABLED || 'false' }}",
+    );
+    expect(candidateDeploy).toContain('GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED}');
+    expect(candidateDeploy).toContain('GOLDEN_SNAPSHOTS_ENABLED=false');
+    expect(candidateDeploy).toContain('GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0');
+    expect(productionDeploy).toContain('GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED}');
+    expect(productionDeploy).toContain('GOLDEN_SNAPSHOTS_ENABLED=false');
+    expect(productionDeploy).toContain('GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0');
   });
 
   it('uses the same manual-channel eligibility rule for durable release registration', () => {


### PR DESCRIPTION
## Summary

- gate host-bundle golden snapshot enqueue on the exact repository variable `GOLDEN_SNAPSHOT_BUILDS_ENABLED == 'true'`
- pass that build flag explicitly to candidate and production Cloud Run roles, defaulting it to `false`
- keep golden snapshot selection disabled and rollout fixed at `0%`
- classify enqueue failures into safe CI categories without exposing provider response details
- record only a coarse allowlisted diagnostic when a disabled response cannot be classified
- document and contract-test the disabled-by-default workflow

## Tests

- `pnpm exec vitest run tests/platform/host-bundle-snapshot-workflow.test.ts tests/platform/customer-vps-host-bundle.test.ts tests/platform/ci-workflows.test.ts` (102 passed)
- `bun run check:patterns` (0 violations; 5 existing warnings)
- `bun run typecheck`
- `git diff --check`

## Review and monitoring

- Greptile 5/5 is required against the current head before `ready-for-ci`
- all triggered CI must be green before review handoff
- this PR must not be merged without explicit owner approval

## Invariants

- **Source of truth:** the GitHub Actions repository variable controls build enqueue and the platform build-worker flag; an absent value resolves to disabled
- **Lock and transaction scope:** no database writes, migrations, locks, or transaction behavior are changed
- **Acceptable orphan states:** enqueue remains best-effort and non-blocking after immutable bundle publication; failed enqueue cannot block publication or fleet deployment
- **Auth source of truth:** the existing platform secret remains the enqueue credential; no secret, IAM, or authentication behavior changes
- **Selection safety:** golden snapshot selection remains explicitly disabled with rollout `0%`
- **Deferred scope:** builder activation, snapshot selection, rollout, deployment, and provider resource creation are not part of this PR

No deployment, enqueue request, repository-variable change, build activation, secret change, or provider operation was performed while preparing this PR.
