### PR TITLE
feat(gateway): add directory subscriptions

### DIFF
--- a/packages/gateway/src/file-management/directory-subscriptions.ts
+++ b/packages/gateway/src/file-management/directory-subscriptions.ts
@@ -1,6 +1,6 @@
 import { lstat, realpath } from "node:fs/promises";
 import { isAbsolute, posix, relative, resolve, sep } from "node:path";
-import type { FileChangeEvent } from "../watcher.js";
+import type { DirectoryScopeIdentity, FileChangeEvent } from "../watcher.js";
 import { resolveWithinHome } from "../path-security.js";
 import { FileManagementDirectoryPathSchema } from "./contracts.js";
 import { isFileManagementParentAllowed } from "./policy.js";
@@ -24,8 +24,13 @@ export interface FileDirectoryAuthorization {
 }
 
 export interface FileDirectorySubscriptionHubOptions {
-  acquireScope: (directory: string) => (() => void | Promise<void>) | Promise<() => void | Promise<void>>;
-  authorize?: (input: FileDirectoryAuthorization) => boolean | Promise<boolean>;
+  acquireScope: (
+    directory: string,
+    authorization?: DirectoryScopeIdentity,
+  ) => (() => void | Promise<void>) | Promise<() => void | Promise<void>>;
+  authorize?: (
+    input: FileDirectoryAuthorization,
+  ) => boolean | DirectoryScopeIdentity | Promise<boolean | DirectoryScopeIdentity>;
   maxSubscriptions?: number;
   maxDirectoriesPerConnection?: number;
   maxConnectionsPerOwner?: number;
@@ -41,6 +46,7 @@ interface SubscriptionState extends FileDirectorySubscriber {
   release: (() => void | Promise<void>) | null;
   scopeReady: Promise<void> | null;
   cleanupPromise: Promise<void> | null;
+  authorization: DirectoryScopeIdentity | null;
 }
 
 function subscriptionKey(ownerId: string, connectionId: string, directory: string): string {
@@ -71,6 +77,13 @@ export async function authorizeFileDirectory(
   homePath: string,
   directory: string,
 ): Promise<boolean> {
+  return (await authorizeFileDirectoryScope(homePath, directory)) !== false;
+}
+
+export async function authorizeFileDirectoryScope(
+  homePath: string,
+  directory: string,
+): Promise<DirectoryScopeIdentity | false> {
   const parsed = FileManagementDirectoryPathSchema.safeParse(directory);
   if (!parsed.success
     || /^[a-zA-Z]:\//.test(parsed.data)
@@ -85,11 +98,12 @@ export async function authorizeFileDirectory(
     realpath(resolved),
   ]);
   const realRelative = relative(homeReal, directoryReal);
-  if (realRelative === "") return true;
+  if (realRelative === "") return verifyDirectoryIdentity(resolved, stats);
   if (realRelative.startsWith("..") || isAbsolute(realRelative)) return false;
   const normalizedRealRelative = realRelative.split(sep).join(posix.sep);
-  return !normalizedRealRelative.split("/").some((segment) => segment.startsWith("."))
-    && isFileManagementParentAllowed(homePath, normalizedRealRelative);
+  if (normalizedRealRelative.split("/").some((segment) => segment.startsWith("."))
+    || !isFileManagementParentAllowed(homePath, normalizedRealRelative)) return false;
+  return verifyDirectoryIdentity(resolved, stats);
 }
 
 export class FileDirectorySubscriptionHub {
@@ -164,6 +178,7 @@ export class FileDirectorySubscriptionHub {
       release: null,
       scopeReady: null,
       cleanupPromise: null,
+      authorization: null,
     };
     this.subscriptions.set(key, state);
     const scopeReady = this.initializeSubscription(key, state);
@@ -328,6 +343,7 @@ export class FileDirectorySubscriptionHub {
     key: string,
     state: SubscriptionState,
   ): Promise<void> {
+    let scopeAuthorization: DirectoryScopeIdentity | undefined;
     if (this.authorize) {
       const authorized = await this.authorize({
         ownerId: state.ownerId,
@@ -335,9 +351,11 @@ export class FileDirectorySubscriptionHub {
       });
       this.assertCurrent(key, state);
       if (!authorized) throw new Error("Directory subscription is not authorized");
+      if (typeof authorized === "object") scopeAuthorization = authorized;
     }
-    const release = await this.acquireScope(state.directory);
+    const release = await this.acquireScope(state.directory, scopeAuthorization);
     state.release = release;
+    state.authorization = scopeAuthorization ?? null;
     try {
       this.assertCurrent(key, state);
     } catch (error: unknown) {
@@ -363,7 +381,31 @@ export class FileDirectorySubscriptionHub {
       });
       this.assertCurrent(key, existing);
       if (!authorized) throw new Error("Directory subscription is not authorized");
+      if (typeof authorized === "object"
+        && existing.authorization
+        && !sameDirectoryIdentity(authorized, existing.authorization)) {
+        throw new Error("Directory subscription is not authorized");
+      }
     }
     return existing.revision;
   }
+}
+
+async function verifyDirectoryIdentity(
+  resolved: string,
+  expected: { dev: number; ino: number },
+): Promise<DirectoryScopeIdentity | false> {
+  const verified = await lstat(resolved);
+  if (verified.isSymbolicLink()
+    || !verified.isDirectory()
+    || verified.dev !== expected.dev
+    || verified.ino !== expected.ino) return false;
+  return { device: verified.dev, inode: verified.ino };
+}
+
+function sameDirectoryIdentity(
+  first: DirectoryScopeIdentity,
+  second: DirectoryScopeIdentity,
+): boolean {
+  return first.device === second.device && first.inode === second.inode;
 }

--- a/packages/gateway/src/file-management/directory-subscriptions.ts
+++ b/packages/gateway/src/file-management/directory-subscriptions.ts
@@ -40,6 +40,7 @@ interface SubscriptionState extends FileDirectorySubscriber {
   canceled: boolean;
   release: (() => void | Promise<void>) | null;
   scopeReady: Promise<void> | null;
+  cleanupPromise: Promise<void> | null;
 }
 
 function subscriptionKey(ownerId: string, connectionId: string, directory: string): string {
@@ -66,11 +67,6 @@ async function releaseScope(subscription: SubscriptionState): Promise<void> {
   }
 }
 
-async function awaitAndReleaseScope(subscription: SubscriptionState): Promise<void> {
-  if (subscription.scopeReady) await Promise.allSettled([subscription.scopeReady]);
-  await releaseScope(subscription);
-}
-
 export async function authorizeFileDirectory(
   homePath: string,
   directory: string,
@@ -94,13 +90,6 @@ export async function authorizeFileDirectory(
 
 export class FileDirectorySubscriptionHub {
   private readonly subscriptions = new Map<string, SubscriptionState>();
-  // One acquisition per reserved subscription, so this set is hard-capped by
-  // maxSubscriptions and is drained explicitly during shutdown.
-  private readonly pendingScopeAcquisitions = new Set<Promise<void>>();
-  // Released subscriptions continue to consume a bounded scope slot until
-  // their asynchronous watcher cleanup settles. This also gives close() a
-  // complete drain set after a record has left the active registry.
-  private readonly pendingScopeReleases = new Set<Promise<void>>();
   private readonly acquireScope: FileDirectorySubscriptionHubOptions["acquireScope"];
   private readonly authorize?: FileDirectorySubscriptionHubOptions["authorize"];
   private readonly maxSubscriptions: number;
@@ -142,32 +131,27 @@ export class FileDirectorySubscriptionHub {
     if (!parsed.success) throw new Error("Invalid directory subscription");
     const normalizedSubscriber = { ...subscriber, directory: parsed.data };
     const key = subscriptionKey(subscriber.ownerId, subscriber.connectionId, parsed.data);
-    const existing = this.subscriptions.get(key);
-    if (existing) {
-      if (existing.canceled) throw new Error("Directory subscription is no longer active");
-      const wasActive = existing.release !== null;
-      existing.lastTouched = this.now();
-      existing.send = subscriber.send;
-      if (existing.scopeReady) await existing.scopeReady;
-      this.assertCurrent(key, existing);
-      if (wasActive && this.authorize) {
-        const authorized = await this.authorize({
-          ownerId: existing.ownerId,
-          directory: existing.directory,
-        });
-        this.assertCurrent(key, existing);
-        if (!authorized) throw new Error("Directory subscription is not authorized");
-      }
-      return existing.revision;
+    const existingBeforeSweep = this.subscriptions.get(key);
+    if (existingBeforeSweep && !existingBeforeSweep.canceled) {
+      return this.resumeSubscription(key, existingBeforeSweep, subscriber.send);
     }
 
-    const staleCleanup = this.sweepStale(false);
-    try {
-      this.assertCapacity(normalizedSubscriber);
-    } catch (error: unknown) {
-      this.trackRelease(staleCleanup);
-      throw error;
+    await this.sweepStale();
+    if (this.closed) throw new Error("Directory subscription hub is closed");
+    const existing = this.subscriptions.get(key);
+    if (existing) {
+      if (!existing.canceled) return this.resumeSubscription(key, existing, subscriber.send);
+      await this.cleanupSubscription(existing);
+      if (this.closed) throw new Error("Directory subscription hub is closed");
+      const replacement = this.subscriptions.get(key);
+      if (replacement) {
+        if (!replacement.canceled) {
+          return this.resumeSubscription(key, replacement, subscriber.send);
+        }
+        return this.subscribe(normalizedSubscriber);
+      }
     }
+    this.assertCapacity(normalizedSubscriber);
     const state: SubscriptionState = {
       ...normalizedSubscriber,
       revision: 0,
@@ -175,24 +159,18 @@ export class FileDirectorySubscriptionHub {
       canceled: false,
       release: null,
       scopeReady: null,
+      cleanupPromise: null,
     };
     this.subscriptions.set(key, state);
-    if (this.pendingScopeAcquisitions.size >= this.maxSubscriptions) {
-      this.subscriptions.delete(key);
-      throw new Error("Directory scope acquisition limit reached");
-    }
-    const scopeReady = this.initializeSubscription(key, state, staleCleanup);
+    const scopeReady = this.initializeSubscription(key, state);
     state.scopeReady = scopeReady;
-    this.pendingScopeAcquisitions.add(scopeReady);
     try {
       await scopeReady;
       this.assertCurrent(key, state);
       return state.revision;
     } catch (error: unknown) {
-      if (this.subscriptions.get(key) === state) this.subscriptions.delete(key);
+      await this.cleanupSubscription(state);
       throw error;
-    } finally {
-      this.pendingScopeAcquisitions.delete(scopeReady);
     }
   }
 
@@ -208,9 +186,7 @@ export class FileDirectorySubscriptionHub {
     const key = subscriptionKey(ownerId, connectionId, directory);
     const subscription = this.subscriptions.get(key);
     if (!subscription) return false;
-    subscription.canceled = true;
-    await this.releaseSubscription(subscription);
-    if (this.subscriptions.get(key) === subscription) this.subscriptions.delete(key);
+    await this.cleanupSubscription(subscription);
     return true;
   }
 
@@ -218,15 +194,10 @@ export class FileDirectorySubscriptionHub {
     const removed: SubscriptionState[] = [];
     for (const [key, subscription] of this.subscriptions) {
       if (subscription.ownerId === ownerId && subscription.connectionId === connectionId) {
-        subscription.canceled = true;
         removed.push(subscription);
       }
     }
-    await Promise.all(removed.map((subscription) => this.releaseSubscription(subscription)));
-    for (const subscription of removed) {
-      const key = subscriptionKey(subscription.ownerId, subscription.connectionId, subscription.directory);
-      if (this.subscriptions.get(key) === subscription) this.subscriptions.delete(key);
-    }
+    await Promise.all(removed.map((subscription) => this.cleanupSubscription(subscription)));
   }
 
   async broadcast(change: FileChangeEvent): Promise<void> {
@@ -262,22 +233,9 @@ export class FileDirectorySubscriptionHub {
     }
 
     for (const subscription of failed) {
-      const key = subscriptionKey(
-        subscription.ownerId,
-        subscription.connectionId,
-        subscription.directory,
-      );
       subscription.canceled = true;
     }
-    await Promise.all(failed.map((subscription) => this.releaseSubscription(subscription)));
-    for (const subscription of failed) {
-      const key = subscriptionKey(
-        subscription.ownerId,
-        subscription.connectionId,
-        subscription.directory,
-      );
-      if (this.subscriptions.get(key) === subscription) this.subscriptions.delete(key);
-    }
+    await Promise.all(failed.map((subscription) => this.cleanupSubscription(subscription)));
   }
 
   close(): Promise<void> {
@@ -285,10 +243,7 @@ export class FileDirectorySubscriptionHub {
     this.closed = true;
     clearInterval(this.sweepTimer);
     const subscriptions = [...this.subscriptions.values()];
-    const pendingScopeAcquisitions = [...this.pendingScopeAcquisitions];
-    const pendingScopeReleases = [...this.pendingScopeReleases];
-    for (const subscription of subscriptions) subscription.canceled = true;
-    this.subscriptions.clear();
+    const cleanups = subscriptions.map((subscription) => this.cleanupSubscription(subscription));
     this.closePromise = (async () => {
       for (const subscription of subscriptions) {
         try {
@@ -302,15 +257,13 @@ export class FileDirectorySubscriptionHub {
           });
         }
       }
-      await Promise.allSettled(pendingScopeAcquisitions);
-      await Promise.allSettled(pendingScopeReleases);
-      await Promise.all(subscriptions.map(releaseScope));
+      await Promise.allSettled(cleanups);
     })();
     return this.closePromise;
   }
 
   private assertCapacity(subscriber: FileDirectorySubscriber): void {
-    if (this.subscriptions.size + this.pendingScopeReleases.size >= this.maxSubscriptions) {
+    if (this.subscriptions.size >= this.maxSubscriptions) {
       throw new Error("Directory subscription limit reached");
     }
     let connectionDirectories = 0;
@@ -332,32 +285,32 @@ export class FileDirectorySubscriptionHub {
     }
   }
 
-  private async sweepStale(track = true): Promise<void> {
+  private async sweepStale(): Promise<void> {
     if (this.closed) return;
     const cutoff = this.now() - this.staleTtlMs;
     const stale: SubscriptionState[] = [];
-    for (const [key, subscription] of this.subscriptions) {
+    for (const subscription of this.subscriptions.values()) {
       if (subscription.lastTouched <= cutoff) {
-        this.subscriptions.delete(key);
-        subscription.canceled = true;
         stale.push(subscription);
       }
     }
-    const cleanup = Promise.all(stale.map((subscription) => awaitAndReleaseScope(subscription)))
-      .then(() => undefined);
-    if (track) this.trackRelease(cleanup);
-    await cleanup;
+    await Promise.all(stale.map((subscription) => this.cleanupSubscription(subscription)));
   }
 
-  private releaseSubscription(subscription: SubscriptionState): Promise<void> {
-    const releasePromise = awaitAndReleaseScope(subscription);
-    this.trackRelease(releasePromise);
-    return releasePromise;
-  }
-
-  private trackRelease(releasePromise: Promise<void>): void {
-    this.pendingScopeReleases.add(releasePromise);
-    void releasePromise.finally(() => this.pendingScopeReleases.delete(releasePromise));
+  private cleanupSubscription(subscription: SubscriptionState): Promise<void> {
+    subscription.canceled = true;
+    if (subscription.cleanupPromise) return subscription.cleanupPromise;
+    const key = subscriptionKey(
+      subscription.ownerId,
+      subscription.connectionId,
+      subscription.directory,
+    );
+    subscription.cleanupPromise = (async () => {
+      if (subscription.scopeReady) await Promise.allSettled([subscription.scopeReady]);
+      await releaseScope(subscription);
+      if (this.subscriptions.get(key) === subscription) this.subscriptions.delete(key);
+    })();
+    return subscription.cleanupPromise;
   }
 
   private assertCurrent(key: string, state: SubscriptionState): void {
@@ -370,10 +323,7 @@ export class FileDirectorySubscriptionHub {
   private async initializeSubscription(
     key: string,
     state: SubscriptionState,
-    staleCleanup: Promise<void>,
   ): Promise<void> {
-    await staleCleanup;
-    this.assertCurrent(key, state);
     if (this.authorize) {
       const authorized = await this.authorize({
         ownerId: state.ownerId,
@@ -390,5 +340,26 @@ export class FileDirectorySubscriptionHub {
       await releaseScope(state);
       throw error;
     }
+  }
+
+  private async resumeSubscription(
+    key: string,
+    existing: SubscriptionState,
+    send: FileDirectorySubscriber["send"],
+  ): Promise<number> {
+    const wasActive = existing.release !== null;
+    existing.lastTouched = this.now();
+    existing.send = send;
+    if (existing.scopeReady) await existing.scopeReady;
+    this.assertCurrent(key, existing);
+    if (wasActive && this.authorize) {
+      const authorized = await this.authorize({
+        ownerId: existing.ownerId,
+        directory: existing.directory,
+      });
+      this.assertCurrent(key, existing);
+      if (!authorized) throw new Error("Directory subscription is not authorized");
+    }
+    return existing.revision;
   }
 }

--- a/packages/gateway/src/file-management/directory-subscriptions.ts
+++ b/packages/gateway/src/file-management/directory-subscriptions.ts
@@ -37,6 +37,7 @@ export interface FileDirectorySubscriptionHubOptions {
 interface SubscriptionState extends FileDirectorySubscriber {
   revision: number;
   lastTouched: number;
+  canceled: boolean;
   release: (() => void | Promise<void>) | null;
   scopeReady: Promise<void> | null;
 }
@@ -50,9 +51,11 @@ function safeErrorKind(error: unknown): string {
 }
 
 async function releaseScope(subscription: SubscriptionState): Promise<void> {
-  if (!subscription.release) return;
+  const release = subscription.release;
+  if (!release) return;
+  subscription.release = null;
   try {
-    await subscription.release();
+    await release();
   } catch (error: unknown) {
     console.error("[files/realtime] Directory scope release failed", {
       ownerId: subscription.ownerId,
@@ -73,7 +76,10 @@ export async function authorizeFileDirectory(
   directory: string,
 ): Promise<boolean> {
   const parsed = FileManagementDirectoryPathSchema.safeParse(directory);
-  if (!parsed.success || !isFileManagementParentAllowed(homePath, parsed.data)) return false;
+  if (!parsed.success
+    || /^[a-zA-Z]:\//.test(parsed.data)
+    || parsed.data.split("/").some((segment) => segment.startsWith("."))
+    || !isFileManagementParentAllowed(homePath, parsed.data)) return false;
   const resolved = resolveWithinHome(homePath, parsed.data);
   if (!resolved) return false;
   const stats = await lstat(resolved);
@@ -135,29 +141,38 @@ export class FileDirectorySubscriptionHub {
     const parsed = FileManagementDirectoryPathSchema.safeParse(subscriber.directory);
     if (!parsed.success) throw new Error("Invalid directory subscription");
     const normalizedSubscriber = { ...subscriber, directory: parsed.data };
-    if (this.authorize && !await this.authorize({
-      ownerId: subscriber.ownerId,
-      directory: parsed.data,
-    })) {
-      throw new Error("Directory subscription is not authorized");
-    }
-    if (this.closed) throw new Error("Directory subscription hub is closed");
-    await this.sweepStale();
-    if (this.closed) throw new Error("Directory subscription hub is closed");
-
     const key = subscriptionKey(subscriber.ownerId, subscriber.connectionId, parsed.data);
     const existing = this.subscriptions.get(key);
     if (existing) {
+      if (existing.canceled) throw new Error("Directory subscription is no longer active");
+      const wasActive = existing.release !== null;
       existing.lastTouched = this.now();
       existing.send = subscriber.send;
+      if (existing.scopeReady) await existing.scopeReady;
+      this.assertCurrent(key, existing);
+      if (wasActive && this.authorize) {
+        const authorized = await this.authorize({
+          ownerId: existing.ownerId,
+          directory: existing.directory,
+        });
+        this.assertCurrent(key, existing);
+        if (!authorized) throw new Error("Directory subscription is not authorized");
+      }
       return existing.revision;
     }
 
-    this.assertCapacity(normalizedSubscriber);
+    const staleCleanup = this.sweepStale(false);
+    try {
+      this.assertCapacity(normalizedSubscriber);
+    } catch (error: unknown) {
+      this.trackRelease(staleCleanup);
+      throw error;
+    }
     const state: SubscriptionState = {
       ...normalizedSubscriber,
       revision: 0,
       lastTouched: this.now(),
+      canceled: false,
       release: null,
       scopeReady: null,
     };
@@ -166,19 +181,12 @@ export class FileDirectorySubscriptionHub {
       this.subscriptions.delete(key);
       throw new Error("Directory scope acquisition limit reached");
     }
-    const scopeReady = (async () => {
-      const release = await this.acquireScope(parsed.data);
-      if (this.closed || this.subscriptions.get(key) !== state) {
-        await release();
-        return;
-      }
-      state.release = release;
-    })();
+    const scopeReady = this.initializeSubscription(key, state, staleCleanup);
     state.scopeReady = scopeReady;
     this.pendingScopeAcquisitions.add(scopeReady);
     try {
       await scopeReady;
-      if (!state.release) throw new Error("Directory subscription is no longer active");
+      this.assertCurrent(key, state);
       return state.revision;
     } catch (error: unknown) {
       if (this.subscriptions.get(key) === state) this.subscriptions.delete(key);
@@ -191,7 +199,7 @@ export class FileDirectorySubscriptionHub {
   touch(ownerId: string, connectionId: string, directory: string): boolean {
     if (this.closed) return false;
     const subscription = this.subscriptions.get(subscriptionKey(ownerId, connectionId, directory));
-    if (!subscription || !subscription.release) return false;
+    if (!subscription || subscription.canceled || !subscription.release) return false;
     subscription.lastTouched = this.now();
     return true;
   }
@@ -200,8 +208,9 @@ export class FileDirectorySubscriptionHub {
     const key = subscriptionKey(ownerId, connectionId, directory);
     const subscription = this.subscriptions.get(key);
     if (!subscription) return false;
-    this.subscriptions.delete(key);
+    subscription.canceled = true;
     await this.releaseSubscription(subscription);
+    if (this.subscriptions.get(key) === subscription) this.subscriptions.delete(key);
     return true;
   }
 
@@ -209,11 +218,15 @@ export class FileDirectorySubscriptionHub {
     const removed: SubscriptionState[] = [];
     for (const [key, subscription] of this.subscriptions) {
       if (subscription.ownerId === ownerId && subscription.connectionId === connectionId) {
-        this.subscriptions.delete(key);
+        subscription.canceled = true;
         removed.push(subscription);
       }
     }
     await Promise.all(removed.map((subscription) => this.releaseSubscription(subscription)));
+    for (const subscription of removed) {
+      const key = subscriptionKey(subscription.ownerId, subscription.connectionId, subscription.directory);
+      if (this.subscriptions.get(key) === subscription) this.subscriptions.delete(key);
+    }
   }
 
   async broadcast(change: FileChangeEvent): Promise<void> {
@@ -224,7 +237,7 @@ export class FileDirectorySubscriptionHub {
     const failed: SubscriptionState[] = [];
 
     for (const subscription of this.subscriptions.values()) {
-      if (!subscription.release || subscription.directory !== directory) continue;
+      if (subscription.canceled || !subscription.release || subscription.directory !== directory) continue;
       const revision = subscription.revision + 1;
       try {
         const sent = subscription.send(JSON.stringify({
@@ -254,9 +267,17 @@ export class FileDirectorySubscriptionHub {
         subscription.connectionId,
         subscription.directory,
       );
-      if (this.subscriptions.get(key) === subscription) this.subscriptions.delete(key);
+      subscription.canceled = true;
     }
     await Promise.all(failed.map((subscription) => this.releaseSubscription(subscription)));
+    for (const subscription of failed) {
+      const key = subscriptionKey(
+        subscription.ownerId,
+        subscription.connectionId,
+        subscription.directory,
+      );
+      if (this.subscriptions.get(key) === subscription) this.subscriptions.delete(key);
+    }
   }
 
   close(): Promise<void> {
@@ -266,6 +287,7 @@ export class FileDirectorySubscriptionHub {
     const subscriptions = [...this.subscriptions.values()];
     const pendingScopeAcquisitions = [...this.pendingScopeAcquisitions];
     const pendingScopeReleases = [...this.pendingScopeReleases];
+    for (const subscription of subscriptions) subscription.canceled = true;
     this.subscriptions.clear();
     this.closePromise = (async () => {
       for (const subscription of subscriptions) {
@@ -310,25 +332,63 @@ export class FileDirectorySubscriptionHub {
     }
   }
 
-  private async sweepStale(): Promise<void> {
+  private async sweepStale(track = true): Promise<void> {
     if (this.closed) return;
     const cutoff = this.now() - this.staleTtlMs;
     const stale: SubscriptionState[] = [];
     for (const [key, subscription] of this.subscriptions) {
       if (subscription.lastTouched <= cutoff) {
         this.subscriptions.delete(key);
+        subscription.canceled = true;
         stale.push(subscription);
       }
     }
-    await Promise.all(stale.map((subscription) => this.releaseSubscription(subscription)));
+    const cleanup = Promise.all(stale.map((subscription) => awaitAndReleaseScope(subscription)))
+      .then(() => undefined);
+    if (track) this.trackRelease(cleanup);
+    await cleanup;
   }
 
   private releaseSubscription(subscription: SubscriptionState): Promise<void> {
     const releasePromise = awaitAndReleaseScope(subscription);
-    this.pendingScopeReleases.add(releasePromise);
-    void releasePromise.finally(() => {
-      this.pendingScopeReleases.delete(releasePromise);
-    });
+    this.trackRelease(releasePromise);
     return releasePromise;
+  }
+
+  private trackRelease(releasePromise: Promise<void>): void {
+    this.pendingScopeReleases.add(releasePromise);
+    void releasePromise.finally(() => this.pendingScopeReleases.delete(releasePromise));
+  }
+
+  private assertCurrent(key: string, state: SubscriptionState): void {
+    if (this.closed) throw new Error("Directory subscription hub is closed");
+    if (state.canceled || this.subscriptions.get(key) !== state) {
+      throw new Error("Directory subscription is no longer active");
+    }
+  }
+
+  private async initializeSubscription(
+    key: string,
+    state: SubscriptionState,
+    staleCleanup: Promise<void>,
+  ): Promise<void> {
+    await staleCleanup;
+    this.assertCurrent(key, state);
+    if (this.authorize) {
+      const authorized = await this.authorize({
+        ownerId: state.ownerId,
+        directory: state.directory,
+      });
+      this.assertCurrent(key, state);
+      if (!authorized) throw new Error("Directory subscription is not authorized");
+    }
+    const release = await this.acquireScope(state.directory);
+    state.release = release;
+    try {
+      this.assertCurrent(key, state);
+    } catch (error: unknown) {
+      await releaseScope(state);
+      throw error;
+    }
   }
 }

--- a/packages/gateway/src/file-management/directory-subscriptions.ts
+++ b/packages/gateway/src/file-management/directory-subscriptions.ts
@@ -85,7 +85,11 @@ export async function authorizeFileDirectory(
     realpath(resolved),
   ]);
   const realRelative = relative(homeReal, directoryReal);
-  return realRelative === "" || (!realRelative.startsWith("..") && !isAbsolute(realRelative));
+  if (realRelative === "") return true;
+  if (realRelative.startsWith("..") || isAbsolute(realRelative)) return false;
+  const normalizedRealRelative = realRelative.split(sep).join(posix.sep);
+  return !normalizedRealRelative.split("/").some((segment) => segment.startsWith("."))
+    && isFileManagementParentAllowed(homePath, normalizedRealRelative);
 }
 
 export class FileDirectorySubscriptionHub {

--- a/packages/gateway/src/file-management/directory-subscriptions.ts
+++ b/packages/gateway/src/file-management/directory-subscriptions.ts
@@ -1,0 +1,334 @@
+import { lstat, realpath } from "node:fs/promises";
+import { isAbsolute, posix, relative, resolve, sep } from "node:path";
+import type { FileChangeEvent } from "../watcher.js";
+import { resolveWithinHome } from "../path-security.js";
+import { FileManagementDirectoryPathSchema } from "./contracts.js";
+import { isFileManagementParentAllowed } from "./policy.js";
+
+export const FILE_DIRECTORY_MAX_SUBSCRIPTIONS = 1_024;
+export const FILE_DIRECTORY_MAX_DIRECTORIES_PER_CONNECTION = 8;
+export const FILE_DIRECTORY_MAX_CONNECTIONS_PER_OWNER = 32;
+export const FILE_DIRECTORY_STALE_TTL_MS = 5 * 60_000;
+const DEFAULT_SWEEP_INTERVAL_MS = 60_000;
+
+export interface FileDirectorySubscriber {
+  ownerId: string;
+  connectionId: string;
+  directory: string;
+  send: (message: string) => void | boolean;
+}
+
+export interface FileDirectoryAuthorization {
+  ownerId: string;
+  directory: string;
+}
+
+export interface FileDirectorySubscriptionHubOptions {
+  acquireScope: (directory: string) => (() => void | Promise<void>) | Promise<() => void | Promise<void>>;
+  authorize?: (input: FileDirectoryAuthorization) => boolean | Promise<boolean>;
+  maxSubscriptions?: number;
+  maxDirectoriesPerConnection?: number;
+  maxConnectionsPerOwner?: number;
+  staleTtlMs?: number;
+  sweepIntervalMs?: number;
+  now?: () => number;
+}
+
+interface SubscriptionState extends FileDirectorySubscriber {
+  revision: number;
+  lastTouched: number;
+  release: (() => void | Promise<void>) | null;
+  scopeReady: Promise<void> | null;
+}
+
+function subscriptionKey(ownerId: string, connectionId: string, directory: string): string {
+  return JSON.stringify([ownerId, connectionId, directory]);
+}
+
+function safeErrorKind(error: unknown): string {
+  return error instanceof Error ? error.name : typeof error;
+}
+
+async function releaseScope(subscription: SubscriptionState): Promise<void> {
+  if (!subscription.release) return;
+  try {
+    await subscription.release();
+  } catch (error: unknown) {
+    console.error("[files/realtime] Directory scope release failed", {
+      ownerId: subscription.ownerId,
+      connectionId: subscription.connectionId,
+      directory: subscription.directory,
+      errorKind: safeErrorKind(error),
+    });
+  }
+}
+
+async function awaitAndReleaseScope(subscription: SubscriptionState): Promise<void> {
+  if (subscription.scopeReady) await Promise.allSettled([subscription.scopeReady]);
+  await releaseScope(subscription);
+}
+
+export async function authorizeFileDirectory(
+  homePath: string,
+  directory: string,
+): Promise<boolean> {
+  const parsed = FileManagementDirectoryPathSchema.safeParse(directory);
+  if (!parsed.success || !isFileManagementParentAllowed(homePath, parsed.data)) return false;
+  const resolved = resolveWithinHome(homePath, parsed.data);
+  if (!resolved) return false;
+  const stats = await lstat(resolved);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) return false;
+  const [homeReal, directoryReal] = await Promise.all([
+    realpath(resolve(homePath)),
+    realpath(resolved),
+  ]);
+  const realRelative = relative(homeReal, directoryReal);
+  return realRelative === "" || (!realRelative.startsWith("..") && !isAbsolute(realRelative));
+}
+
+export class FileDirectorySubscriptionHub {
+  private readonly subscriptions = new Map<string, SubscriptionState>();
+  // One acquisition per reserved subscription, so this set is hard-capped by
+  // maxSubscriptions and is drained explicitly during shutdown.
+  private readonly pendingScopeAcquisitions = new Set<Promise<void>>();
+  // Released subscriptions continue to consume a bounded scope slot until
+  // their asynchronous watcher cleanup settles. This also gives close() a
+  // complete drain set after a record has left the active registry.
+  private readonly pendingScopeReleases = new Set<Promise<void>>();
+  private readonly acquireScope: FileDirectorySubscriptionHubOptions["acquireScope"];
+  private readonly authorize?: FileDirectorySubscriptionHubOptions["authorize"];
+  private readonly maxSubscriptions: number;
+  private readonly maxDirectoriesPerConnection: number;
+  private readonly maxConnectionsPerOwner: number;
+  private readonly staleTtlMs: number;
+  private readonly now: () => number;
+  private readonly sweepTimer: ReturnType<typeof setInterval>;
+  private closed = false;
+  private closePromise: Promise<void> | null = null;
+
+  constructor(options: FileDirectorySubscriptionHubOptions) {
+    this.acquireScope = options.acquireScope;
+    this.authorize = options.authorize;
+    this.maxSubscriptions = options.maxSubscriptions ?? FILE_DIRECTORY_MAX_SUBSCRIPTIONS;
+    this.maxDirectoriesPerConnection = options.maxDirectoriesPerConnection
+      ?? FILE_DIRECTORY_MAX_DIRECTORIES_PER_CONNECTION;
+    this.maxConnectionsPerOwner = options.maxConnectionsPerOwner
+      ?? FILE_DIRECTORY_MAX_CONNECTIONS_PER_OWNER;
+    this.staleTtlMs = options.staleTtlMs ?? FILE_DIRECTORY_STALE_TTL_MS;
+    this.now = options.now ?? Date.now;
+    this.sweepTimer = setInterval(() => {
+      void this.sweepStale().catch((error: unknown) => {
+        console.error("[files/realtime] Stale subscription sweep failed", {
+          errorKind: safeErrorKind(error),
+        });
+      });
+    }, options.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS);
+    this.sweepTimer.unref?.();
+  }
+
+  get subscriberCount(): number {
+    return this.subscriptions.size;
+  }
+
+  async subscribe(subscriber: FileDirectorySubscriber): Promise<number> {
+    if (this.closed) throw new Error("Directory subscription hub is closed");
+    const parsed = FileManagementDirectoryPathSchema.safeParse(subscriber.directory);
+    if (!parsed.success) throw new Error("Invalid directory subscription");
+    const normalizedSubscriber = { ...subscriber, directory: parsed.data };
+    if (this.authorize && !await this.authorize({
+      ownerId: subscriber.ownerId,
+      directory: parsed.data,
+    })) {
+      throw new Error("Directory subscription is not authorized");
+    }
+    if (this.closed) throw new Error("Directory subscription hub is closed");
+    await this.sweepStale();
+    if (this.closed) throw new Error("Directory subscription hub is closed");
+
+    const key = subscriptionKey(subscriber.ownerId, subscriber.connectionId, parsed.data);
+    const existing = this.subscriptions.get(key);
+    if (existing) {
+      existing.lastTouched = this.now();
+      existing.send = subscriber.send;
+      return existing.revision;
+    }
+
+    this.assertCapacity(normalizedSubscriber);
+    const state: SubscriptionState = {
+      ...normalizedSubscriber,
+      revision: 0,
+      lastTouched: this.now(),
+      release: null,
+      scopeReady: null,
+    };
+    this.subscriptions.set(key, state);
+    if (this.pendingScopeAcquisitions.size >= this.maxSubscriptions) {
+      this.subscriptions.delete(key);
+      throw new Error("Directory scope acquisition limit reached");
+    }
+    const scopeReady = (async () => {
+      const release = await this.acquireScope(parsed.data);
+      if (this.closed || this.subscriptions.get(key) !== state) {
+        await release();
+        return;
+      }
+      state.release = release;
+    })();
+    state.scopeReady = scopeReady;
+    this.pendingScopeAcquisitions.add(scopeReady);
+    try {
+      await scopeReady;
+      if (!state.release) throw new Error("Directory subscription is no longer active");
+      return state.revision;
+    } catch (error: unknown) {
+      if (this.subscriptions.get(key) === state) this.subscriptions.delete(key);
+      throw error;
+    } finally {
+      this.pendingScopeAcquisitions.delete(scopeReady);
+    }
+  }
+
+  touch(ownerId: string, connectionId: string, directory: string): boolean {
+    if (this.closed) return false;
+    const subscription = this.subscriptions.get(subscriptionKey(ownerId, connectionId, directory));
+    if (!subscription || !subscription.release) return false;
+    subscription.lastTouched = this.now();
+    return true;
+  }
+
+  async unsubscribe(ownerId: string, connectionId: string, directory: string): Promise<boolean> {
+    const key = subscriptionKey(ownerId, connectionId, directory);
+    const subscription = this.subscriptions.get(key);
+    if (!subscription) return false;
+    this.subscriptions.delete(key);
+    await this.releaseSubscription(subscription);
+    return true;
+  }
+
+  async removeConnection(ownerId: string, connectionId: string): Promise<void> {
+    const removed: SubscriptionState[] = [];
+    for (const [key, subscription] of this.subscriptions) {
+      if (subscription.ownerId === ownerId && subscription.connectionId === connectionId) {
+        this.subscriptions.delete(key);
+        removed.push(subscription);
+      }
+    }
+    await Promise.all(removed.map((subscription) => this.releaseSubscription(subscription)));
+  }
+
+  async broadcast(change: FileChangeEvent): Promise<void> {
+    if (this.closed) return;
+    const directory = posix.dirname(change.path) === "." ? "" : posix.dirname(change.path);
+    const entry = posix.basename(change.path);
+    if (!entry || entry.startsWith(".") || entry === "/") return;
+    const failed: SubscriptionState[] = [];
+
+    for (const subscription of this.subscriptions.values()) {
+      if (!subscription.release || subscription.directory !== directory) continue;
+      const revision = subscription.revision + 1;
+      try {
+        const sent = subscription.send(JSON.stringify({
+          type: "files:change",
+          directory,
+          entry,
+          event: change.event,
+          revision,
+        }));
+        if (sent === false) throw new Error("WebSocket send rejected");
+        subscription.revision = revision;
+        subscription.lastTouched = this.now();
+      } catch (error: unknown) {
+        console.error("[files/realtime] Change delivery failed", {
+          ownerId: subscription.ownerId,
+          connectionId: subscription.connectionId,
+          directory: subscription.directory,
+          errorKind: safeErrorKind(error),
+        });
+        failed.push(subscription);
+      }
+    }
+
+    for (const subscription of failed) {
+      const key = subscriptionKey(
+        subscription.ownerId,
+        subscription.connectionId,
+        subscription.directory,
+      );
+      if (this.subscriptions.get(key) === subscription) this.subscriptions.delete(key);
+    }
+    await Promise.all(failed.map((subscription) => this.releaseSubscription(subscription)));
+  }
+
+  close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    this.closed = true;
+    clearInterval(this.sweepTimer);
+    const subscriptions = [...this.subscriptions.values()];
+    const pendingScopeAcquisitions = [...this.pendingScopeAcquisitions];
+    const pendingScopeReleases = [...this.pendingScopeReleases];
+    this.subscriptions.clear();
+    this.closePromise = (async () => {
+      for (const subscription of subscriptions) {
+        try {
+          subscription.send(JSON.stringify({ type: "files:shutdown" }));
+        } catch (error: unknown) {
+          console.error("[files/realtime] Shutdown notice failed", {
+            ownerId: subscription.ownerId,
+            connectionId: subscription.connectionId,
+            directory: subscription.directory,
+            errorKind: safeErrorKind(error),
+          });
+        }
+      }
+      await Promise.allSettled(pendingScopeAcquisitions);
+      await Promise.allSettled(pendingScopeReleases);
+      await Promise.all(subscriptions.map(releaseScope));
+    })();
+    return this.closePromise;
+  }
+
+  private assertCapacity(subscriber: FileDirectorySubscriber): void {
+    if (this.subscriptions.size + this.pendingScopeReleases.size >= this.maxSubscriptions) {
+      throw new Error("Directory subscription limit reached");
+    }
+    let connectionDirectories = 0;
+    const ownerConnections: string[] = [];
+    for (const existing of this.subscriptions.values()) {
+      if (existing.ownerId === subscriber.ownerId && existing.connectionId === subscriber.connectionId) {
+        connectionDirectories += 1;
+      }
+      if (existing.ownerId === subscriber.ownerId && !ownerConnections.includes(existing.connectionId)) {
+        ownerConnections.push(existing.connectionId);
+      }
+    }
+    if (connectionDirectories >= this.maxDirectoriesPerConnection) {
+      throw new Error("Directory limit reached for connection");
+    }
+    if (!ownerConnections.includes(subscriber.connectionId)
+      && ownerConnections.length >= this.maxConnectionsPerOwner) {
+      throw new Error("Connection limit reached for owner");
+    }
+  }
+
+  private async sweepStale(): Promise<void> {
+    if (this.closed) return;
+    const cutoff = this.now() - this.staleTtlMs;
+    const stale: SubscriptionState[] = [];
+    for (const [key, subscription] of this.subscriptions) {
+      if (subscription.lastTouched <= cutoff) {
+        this.subscriptions.delete(key);
+        stale.push(subscription);
+      }
+    }
+    await Promise.all(stale.map((subscription) => this.releaseSubscription(subscription)));
+  }
+
+  private releaseSubscription(subscription: SubscriptionState): Promise<void> {
+    const releasePromise = awaitAndReleaseScope(subscription);
+    this.pendingScopeReleases.add(releasePromise);
+    void releasePromise.finally(() => {
+      this.pendingScopeReleases.delete(releasePromise);
+    });
+    return releasePromise;
+  }
+}

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -234,6 +234,16 @@ import {
 import { registerAppRuntimeRoutes } from "./server/app-runtime-routes.js";
 import { registerFileRoutes } from "./server/file-routes.js";
 import { registerFileManagementRoutes } from "./server/file-management-routes.js";
+import {
+  authorizeFileDirectory,
+  FileDirectorySubscriptionHub,
+} from "./file-management/directory-subscriptions.js";
+import {
+  bindFileDirectoryWatcher,
+  closeFileDirectoryResources,
+  createFileDirectoryWsConnection,
+  isFileDirectoryFrameCandidate,
+} from "./server/file-directory-ws.js";
 import { registerConversationHistoryRoutes } from "./server/conversation-history-routes.js";
 import {
   metricsRegistry,
@@ -432,6 +442,11 @@ export async function createGateway(config: GatewayConfig) {
   });
 
   const watcher: Watcher = createWatcher(homePath);
+  const fileDirectorySubscriptionHub = new FileDirectorySubscriptionHub({
+    authorize: ({ directory }) => authorizeFileDirectory(homePath, directory),
+    acquireScope: (directory) => watcher.acquireDirectoryScope(directory),
+  });
+  bindFileDirectoryWatcher(fileDirectorySubscriptionHub, watcher);
   const conversations: ConversationStore = createConversationStore(homePath);
   const conversationRuns = new ConversationRunRegistry();
   const reconnectableAbortControllers = new Map<string, ReconnectableAbortEntry>();
@@ -1833,24 +1848,28 @@ export async function createGateway(config: GatewayConfig) {
       // sync:subscribe branch below keys peers off the same principal as the
       // HTTP sync routes. authMiddleware ran on the upgrade request and
       // stashed claims if a JWT was presented.
+      const wsOwnerId = requireRequestPrincipal(c).userId;
       let syncPeerLifecycle = null;
       let syncPeerSocket: WSContext | null = null;
-      try {
-        const wsSyncUserId = requireRequestPrincipal(c).userId;
-        syncPeerLifecycle = syncPeerRegistry
-          ? createSyncPeerLifecycle(syncPeerRegistry, wsSyncUserId, {
-              send: (data: string) => syncPeerSocket?.send(data),
-              get readyState() {
-                return syncPeerSocket?.readyState ?? 3;
-              },
-            })
-          : null;
-      } catch (err) {
-        if (!isRequestPrincipalError(err)) {
-          throw err;
-        }
-        console.warn("[sync/ws] Missing or invalid sync request principal on websocket upgrade");
-      }
+      syncPeerLifecycle = syncPeerRegistry
+        ? createSyncPeerLifecycle(syncPeerRegistry, wsOwnerId, {
+            send: (data: string) => syncPeerSocket?.send(data),
+            get readyState() {
+              return syncPeerSocket?.readyState ?? 3;
+            },
+          })
+        : null;
+      let mainWsSocket: WSContext | null = null;
+      const fileDirectoryConnection = createFileDirectoryWsConnection({
+        ownerId: wsOwnerId,
+        connectionId: randomUUID(),
+        hub: fileDirectorySubscriptionHub,
+        send: (message) => {
+          if (!mainWsSocket) throw new Error("Main WebSocket is not open");
+          mainWsSocket.send(message);
+        },
+        closeSocket: () => mainWsSocket?.close(1008, "File subscription closed"),
+      });
       let pendingText: string | undefined;
       let activeSessionId: string | undefined;
       let approvalBridge: ApprovalBridge | undefined;
@@ -1920,6 +1939,7 @@ export async function createGateway(config: GatewayConfig) {
 
       return {
         onOpen(_evt, ws) {
+          mainWsSocket = ws;
           syncPeerSocket = ws;
           evictOldestMainWsClientIfNeeded();
           clients.add(ws);
@@ -1961,11 +1981,22 @@ export async function createGateway(config: GatewayConfig) {
           const parsedResult = MainWsClientMessageSchema.safeParse(rawMessage);
           if (!parsedResult.success) {
             captureGatewayProductEvent("shell_ws_invalid_message");
+            if (isFileDirectoryFrameCandidate(rawMessage)) {
+              fileDirectoryConnection.rejectInvalidFrame();
+              return;
+            }
             send(ws, { type: "kernel:error", message: "Invalid message format" });
             return;
           }
 
           const parsed: MainWsClientMessage = parsedResult.data;
+
+          if (parsed.type === "files:subscribe"
+            || parsed.type === "files:unsubscribe"
+            || parsed.type === "files:touch") {
+            fileDirectoryConnection.enqueue(parsed);
+            return;
+          }
 
           if (parsed.type === "ping") {
             send(ws, { type: "pong" } as ServerMessage);
@@ -2176,9 +2207,15 @@ export async function createGateway(config: GatewayConfig) {
         },
 
         onClose(_evt, ws) {
+          void fileDirectoryConnection.close().catch((err: unknown) => {
+            console.error("[files/realtime] Connection cleanup failed", {
+              errorKind: err instanceof Error ? err.name : typeof err,
+            });
+          });
           clearConversationRunAttachment();
           syncPeerLifecycle?.close();
           syncPeerSocket = null;
+          mainWsSocket = null;
           // Abort inactive in-flight runs so the kernel doesn't keep burning
           // tokens forever, while still allowing short browser reconnects to
           // replay and reattach runs that still have an active subscriber.
@@ -4280,7 +4317,11 @@ export async function createGateway(config: GatewayConfig) {
       await zellijShellWs.dispose();
       await sessionRegistry.shutdown();
       await fileManagementRoutes.close();
-      await watcher.close();
+      await closeFileDirectoryResources(fileDirectorySubscriptionHub, {
+        close: async () => {
+          await watcher.close();
+        },
+      });
       await homeMirror?.stop();
       await homeMirrorStart?.catch((err: unknown) => {
         logBestEffortFailure("Home mirror startup failed during shutdown", err);

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -235,7 +235,7 @@ import { registerAppRuntimeRoutes } from "./server/app-runtime-routes.js";
 import { registerFileRoutes } from "./server/file-routes.js";
 import { registerFileManagementRoutes } from "./server/file-management-routes.js";
 import {
-  authorizeFileDirectory,
+  authorizeFileDirectoryScope,
   FileDirectorySubscriptionHub,
 } from "./file-management/directory-subscriptions.js";
 import {
@@ -444,8 +444,11 @@ export async function createGateway(config: GatewayConfig) {
 
   const watcher: Watcher = createWatcher(homePath);
   const fileDirectorySubscriptionHub = new FileDirectorySubscriptionHub({
-    authorize: ({ directory }) => authorizeFileDirectory(homePath, directory),
-    acquireScope: (directory) => watcher.acquireDirectoryScope(directory),
+    authorize: ({ directory }) => authorizeFileDirectoryScope(homePath, directory),
+    acquireScope: (directory, authorization) => watcher.acquireDirectoryScope(
+      directory,
+      authorization,
+    ),
   });
   bindFileDirectoryWatcher(fileDirectorySubscriptionHub, watcher);
   const conversations: ConversationStore = createConversationStore(homePath);

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -242,6 +242,7 @@ import {
   bindFileDirectoryWatcher,
   closeFileDirectoryResources,
   createAuthenticatedFileDirectoryWsConnection,
+  createFileDirectoryWsLifecycle,
   isFileDirectoryFrameCandidate,
 } from "./server/file-directory-ws.js";
 import { registerConversationHistoryRoutes } from "./server/conversation-history-routes.js";
@@ -1869,6 +1870,7 @@ export async function createGateway(config: GatewayConfig) {
         },
         closeSocket: () => mainWsSocket?.close(1008, "File subscription closed"),
       });
+      const fileDirectoryLifecycle = createFileDirectoryWsLifecycle(fileDirectoryConnection);
       let pendingText: string | undefined;
       let activeSessionId: string | undefined;
       let approvalBridge: ApprovalBridge | undefined;
@@ -2206,11 +2208,7 @@ export async function createGateway(config: GatewayConfig) {
         },
 
         onClose(_evt, ws) {
-          void fileDirectoryConnection.close().catch((err: unknown) => {
-            console.error("[files/realtime] Connection cleanup failed", {
-              errorKind: err instanceof Error ? err.name : typeof err,
-            });
-          });
+          void fileDirectoryLifecycle.onClose();
           clearConversationRunAttachment();
           syncPeerLifecycle?.close();
           syncPeerSocket = null;

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -241,7 +241,7 @@ import {
 import {
   bindFileDirectoryWatcher,
   closeFileDirectoryResources,
-  createFileDirectoryWsConnection,
+  createAuthenticatedFileDirectoryWsConnection,
   isFileDirectoryFrameCandidate,
 } from "./server/file-directory-ws.js";
 import { registerConversationHistoryRoutes } from "./server/conversation-history-routes.js";
@@ -1860,8 +1860,7 @@ export async function createGateway(config: GatewayConfig) {
           })
         : null;
       let mainWsSocket: WSContext | null = null;
-      const fileDirectoryConnection = createFileDirectoryWsConnection({
-        ownerId: wsOwnerId,
+      const fileDirectoryConnection = createAuthenticatedFileDirectoryWsConnection(c, {
         connectionId: randomUUID(),
         hub: fileDirectorySubscriptionHub,
         send: (message) => {

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -196,7 +196,7 @@ import { createManifestDb, createKyselySharingDb } from "./sync/db-impl.js";
 import { createHomeMirror, type HomeMirror } from "./sync/home-mirror.js";
 import { deriveHomeMirrorSyncIdentity } from "./sync/runtime-scope.js";
 import { createPeerRegistry, type PeerRegistry } from "./sync/ws-events.js";
-import { createSyncPeerLifecycle } from "./sync/ws-peer-lifecycle.js";
+import { createSyncPeerLifecycle, subscribeSyncPeerOrReject } from "./sync/ws-peer-lifecycle.js";
 import { createSharingService, type SharingService } from "./sync/sharing.js";
 import { sanitizePeerId } from "./sync/peer-id.js";
 import {
@@ -241,7 +241,7 @@ import {
 import {
   bindFileDirectoryWatcher,
   closeFileDirectoryResources,
-  createOptionalAuthenticatedFileDirectoryWsConnection,
+  createMainWsFileDirectoryRouter,
   createFileDirectoryWsLifecycle,
   isFileDirectoryFrameCandidate,
 } from "./server/file-directory-ws.js";
@@ -1861,7 +1861,7 @@ export async function createGateway(config: GatewayConfig) {
           })
         : null;
       let mainWsSocket: WSContext | null = null;
-      const fileDirectoryConnection = createOptionalAuthenticatedFileDirectoryWsConnection(c, {
+      const fileDirectoryRouter = createMainWsFileDirectoryRouter(c, {
         connectionId: randomUUID(),
         hub: fileDirectorySubscriptionHub,
         send: (message) => {
@@ -1870,9 +1870,7 @@ export async function createGateway(config: GatewayConfig) {
         },
         closeSocket: () => mainWsSocket?.close(1008, "File subscription closed"),
       });
-      const fileDirectoryLifecycle = fileDirectoryConnection
-        ? createFileDirectoryWsLifecycle(fileDirectoryConnection)
-        : null;
+      const fileDirectoryLifecycle = createFileDirectoryWsLifecycle(fileDirectoryRouter);
       let pendingText: string | undefined;
       let activeSessionId: string | undefined;
       let approvalBridge: ApprovalBridge | undefined;
@@ -1985,8 +1983,7 @@ export async function createGateway(config: GatewayConfig) {
           if (!parsedResult.success) {
             captureGatewayProductEvent("shell_ws_invalid_message");
             if (isFileDirectoryFrameCandidate(rawMessage)) {
-              if (fileDirectoryConnection) fileDirectoryConnection.rejectInvalidFrame();
-              else send(ws, { type: "kernel:error", message: "File directory subscription failed" });
+              fileDirectoryRouter.rejectInvalidFrame();
               return;
             }
             send(ws, { type: "kernel:error", message: "Invalid message format" });
@@ -1998,8 +1995,7 @@ export async function createGateway(config: GatewayConfig) {
           if (parsed.type === "files:subscribe"
             || parsed.type === "files:unsubscribe"
             || parsed.type === "files:touch") {
-            if (fileDirectoryConnection) fileDirectoryConnection.enqueue(parsed);
-            else send(ws, { type: "kernel:error", message: "File directory subscription failed" });
+            fileDirectoryRouter.handleFrame(parsed);
             return;
           }
 
@@ -2055,16 +2051,21 @@ export async function createGateway(config: GatewayConfig) {
             return;
           }
 
-          if (parsed.type === "sync:subscribe" && syncPeerRegistry) {
+          if (parsed.type === "sync:subscribe") {
+            const subscribed = subscribeSyncPeerOrReject(
+              syncPeerLifecycle,
+              {
+                peerId: parsed.peerId,
+                hostname: parsed.hostname,
+                platform: parsed.platform,
+                clientVersion: parsed.clientVersion,
+              },
+              () => send(ws, { type: "kernel:error", message: "Sync subscription failed" }),
+            );
+            if (!subscribed) return;
             captureGatewayProductEvent("sync_peer_subscribe", {
               shell_surface: "gateway_ws",
               client_version_present: Boolean(parsed.clientVersion),
-            });
-            syncPeerLifecycle?.subscribe({
-              peerId: parsed.peerId,
-              hostname: parsed.hostname,
-              platform: parsed.platform,
-              clientVersion: parsed.clientVersion,
             });
             return;
           }
@@ -2212,7 +2213,7 @@ export async function createGateway(config: GatewayConfig) {
         },
 
         onClose(_evt, ws) {
-          if (fileDirectoryLifecycle) void fileDirectoryLifecycle.onClose();
+          void fileDirectoryLifecycle.onClose();
           clearConversationRunAttachment();
           syncPeerLifecycle?.close();
           syncPeerSocket = null;

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -87,7 +87,7 @@ import { createProvisioner } from "./provisioner.js";
 import {
   authMiddleware,
 } from "./auth.js";
-import { isRequestPrincipalError, mapRequestPrincipalError, requireRequestPrincipal } from "./request-principal.js";
+import { getOptionalRequestPrincipal, isRequestPrincipalError, mapRequestPrincipalError, requireRequestPrincipal } from "./request-principal.js";
 import { createOnboardingHandler } from "./onboarding/ws-handler.js";
 import { InMemoryReadinessRepository } from "./onboarding/readiness-repository.js";
 import { createReadinessService } from "./onboarding/readiness-service.js";
@@ -241,7 +241,7 @@ import {
 import {
   bindFileDirectoryWatcher,
   closeFileDirectoryResources,
-  createAuthenticatedFileDirectoryWsConnection,
+  createOptionalAuthenticatedFileDirectoryWsConnection,
   createFileDirectoryWsLifecycle,
   isFileDirectoryFrameCandidate,
 } from "./server/file-directory-ws.js";
@@ -1849,10 +1849,10 @@ export async function createGateway(config: GatewayConfig) {
       // sync:subscribe branch below keys peers off the same principal as the
       // HTTP sync routes. authMiddleware ran on the upgrade request and
       // stashed claims if a JWT was presented.
-      const wsOwnerId = requireRequestPrincipal(c).userId;
+      const wsOwnerId = getOptionalRequestPrincipal(c)?.userId;
       let syncPeerLifecycle = null;
       let syncPeerSocket: WSContext | null = null;
-      syncPeerLifecycle = syncPeerRegistry
+      syncPeerLifecycle = syncPeerRegistry && wsOwnerId
         ? createSyncPeerLifecycle(syncPeerRegistry, wsOwnerId, {
             send: (data: string) => syncPeerSocket?.send(data),
             get readyState() {
@@ -1861,7 +1861,7 @@ export async function createGateway(config: GatewayConfig) {
           })
         : null;
       let mainWsSocket: WSContext | null = null;
-      const fileDirectoryConnection = createAuthenticatedFileDirectoryWsConnection(c, {
+      const fileDirectoryConnection = createOptionalAuthenticatedFileDirectoryWsConnection(c, {
         connectionId: randomUUID(),
         hub: fileDirectorySubscriptionHub,
         send: (message) => {
@@ -1870,7 +1870,9 @@ export async function createGateway(config: GatewayConfig) {
         },
         closeSocket: () => mainWsSocket?.close(1008, "File subscription closed"),
       });
-      const fileDirectoryLifecycle = createFileDirectoryWsLifecycle(fileDirectoryConnection);
+      const fileDirectoryLifecycle = fileDirectoryConnection
+        ? createFileDirectoryWsLifecycle(fileDirectoryConnection)
+        : null;
       let pendingText: string | undefined;
       let activeSessionId: string | undefined;
       let approvalBridge: ApprovalBridge | undefined;
@@ -1983,7 +1985,8 @@ export async function createGateway(config: GatewayConfig) {
           if (!parsedResult.success) {
             captureGatewayProductEvent("shell_ws_invalid_message");
             if (isFileDirectoryFrameCandidate(rawMessage)) {
-              fileDirectoryConnection.rejectInvalidFrame();
+              if (fileDirectoryConnection) fileDirectoryConnection.rejectInvalidFrame();
+              else send(ws, { type: "kernel:error", message: "File directory subscription failed" });
               return;
             }
             send(ws, { type: "kernel:error", message: "Invalid message format" });
@@ -1995,7 +1998,8 @@ export async function createGateway(config: GatewayConfig) {
           if (parsed.type === "files:subscribe"
             || parsed.type === "files:unsubscribe"
             || parsed.type === "files:touch") {
-            fileDirectoryConnection.enqueue(parsed);
+            if (fileDirectoryConnection) fileDirectoryConnection.enqueue(parsed);
+            else send(ws, { type: "kernel:error", message: "File directory subscription failed" });
             return;
           }
 
@@ -2208,7 +2212,7 @@ export async function createGateway(config: GatewayConfig) {
         },
 
         onClose(_evt, ws) {
-          void fileDirectoryLifecycle.onClose();
+          if (fileDirectoryLifecycle) void fileDirectoryLifecycle.onClose();
           clearConversationRunAttachment();
           syncPeerLifecycle?.close();
           syncPeerSocket = null;

--- a/packages/gateway/src/server/file-directory-ws.ts
+++ b/packages/gateway/src/server/file-directory-ws.ts
@@ -1,0 +1,165 @@
+import type {
+  FileDirectoryClientMessage,
+} from "../ws-message-schema.js";
+import type { Watcher } from "../watcher.js";
+import type {
+  FileDirectorySubscriptionHub,
+} from "../file-management/directory-subscriptions.js";
+
+const DEFAULT_MAX_PENDING_FILE_FRAMES = 16;
+const GENERIC_FILE_SUBSCRIPTION_ERROR = "File directory subscription failed";
+
+export interface FileDirectoryWsConnectionOptions {
+  ownerId: string;
+  connectionId: string;
+  hub: FileDirectorySubscriptionHub;
+  send: (message: string) => void | boolean;
+  closeSocket: () => void;
+  maxPendingFrames?: number;
+}
+
+export interface FileDirectoryWsConnection {
+  enqueue(frame: FileDirectoryClientMessage): boolean;
+  rejectInvalidFrame(): void;
+  idle(): Promise<void>;
+  close(): Promise<void>;
+}
+
+function safeSend(
+  send: FileDirectoryWsConnectionOptions["send"],
+  message: unknown,
+): boolean {
+  try {
+    return send(JSON.stringify(message)) !== false;
+  } catch (error: unknown) {
+    console.error("[files/realtime] Error response send failed", {
+      errorKind: error instanceof Error ? error.name : typeof error,
+    });
+    return false;
+  }
+}
+
+export function createFileDirectoryWsConnection(
+  options: FileDirectoryWsConnectionOptions,
+): FileDirectoryWsConnection {
+  const maxPendingFrames = options.maxPendingFrames ?? DEFAULT_MAX_PENDING_FILE_FRAMES;
+  let tail = Promise.resolve();
+  let pendingFrames = 0;
+  let failed = false;
+  let closing = false;
+  let closePromise: Promise<void> | null = null;
+
+  const failConnection = (error: unknown) => {
+    if (failed || closing) return;
+    failed = true;
+    console.error("[files/realtime] File frame failed", {
+      ownerId: options.ownerId,
+      connectionId: options.connectionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    safeSend(options.send, {
+      type: "kernel:error",
+      message: GENERIC_FILE_SUBSCRIPTION_ERROR,
+    });
+    try {
+      options.closeSocket();
+    } catch (closeError: unknown) {
+      console.error("[files/realtime] WebSocket close failed", {
+        errorKind: closeError instanceof Error ? closeError.name : typeof closeError,
+      });
+    }
+  };
+
+  const processFrame = async (frame: FileDirectoryClientMessage) => {
+    if (closing || failed) return;
+    if (frame.type === "files:subscribe") {
+      const revision = await options.hub.subscribe({
+        ownerId: options.ownerId,
+        connectionId: options.connectionId,
+        directory: frame.directory,
+        send: options.send,
+      });
+      if (closing || failed) return;
+      if (!safeSend(options.send, {
+        type: "files:subscribed",
+        directory: frame.directory,
+        revision,
+      })) {
+        throw new Error("Subscription acknowledgement send failed");
+      }
+      return;
+    }
+    if (frame.type === "files:touch") {
+      if (!options.hub.touch(options.ownerId, options.connectionId, frame.directory)) {
+        throw new Error("Directory subscription not found");
+      }
+      return;
+    }
+    await options.hub.unsubscribe(options.ownerId, options.connectionId, frame.directory);
+  };
+
+  return {
+    enqueue(frame) {
+      if (closing || failed) return false;
+      if (pendingFrames >= maxPendingFrames) {
+        failConnection(new Error("Pending file frame limit reached"));
+        return false;
+      }
+      pendingFrames += 1;
+      tail = tail
+        .then(() => processFrame(frame))
+        .catch((error: unknown) => {
+          failConnection(error);
+        })
+        .finally(() => {
+          pendingFrames -= 1;
+        });
+      return true;
+    },
+
+    rejectInvalidFrame() {
+      failConnection(new Error("Invalid file directory frame"));
+    },
+
+    idle() {
+      return tail;
+    },
+
+    close() {
+      if (closePromise) return closePromise;
+      closing = true;
+      closePromise = tail.then(() => options.hub.removeConnection(
+        options.ownerId,
+        options.connectionId,
+      ));
+      return closePromise;
+    },
+  };
+}
+
+export function isFileDirectoryFrameCandidate(frame: unknown): boolean {
+  if (!frame || typeof frame !== "object") return false;
+  const type = Reflect.get(frame, "type");
+  return typeof type === "string" && type.startsWith("files:");
+}
+
+export function bindFileDirectoryWatcher(
+  hub: FileDirectorySubscriptionHub,
+  watcher: Pick<Watcher, "on">,
+): void {
+  watcher.on((event) => {
+    void hub.broadcast(event).catch((error: unknown) => {
+      console.error("[files/realtime] Watcher event delivery failed", {
+        errorKind: error instanceof Error ? error.name : typeof error,
+      });
+    });
+  });
+}
+
+export async function closeFileDirectoryResources(
+  hub: Pick<FileDirectorySubscriptionHub, "close">,
+  watcher: Pick<Watcher, "close">,
+): Promise<void> {
+  await hub.close();
+  await watcher.close();
+}

--- a/packages/gateway/src/server/file-directory-ws.ts
+++ b/packages/gateway/src/server/file-directory-ws.ts
@@ -143,7 +143,10 @@ export function createFileDirectoryWsConnection(
         options.ownerId,
         options.connectionId,
       );
-      closePromise = Promise.all([tail, cleanup]).then(() => undefined);
+      closePromise = Promise.all([tail, cleanup]).then(() => options.hub.removeConnection(
+        options.ownerId,
+        options.connectionId,
+      ));
       return closePromise;
     },
   };

--- a/packages/gateway/src/server/file-directory-ws.ts
+++ b/packages/gateway/src/server/file-directory-ws.ts
@@ -31,6 +31,12 @@ export interface FileDirectoryWsLifecycle {
   onClose(): Promise<void>;
 }
 
+export interface MainWsFileDirectoryRouter {
+  handleFrame(frame: FileDirectoryClientMessage): void;
+  rejectInvalidFrame(): void;
+  close(): Promise<void>;
+}
+
 export type AuthenticatedFileDirectoryWsConnectionOptions = Omit<
   FileDirectoryWsConnectionOptions,
   "ownerId"
@@ -168,6 +174,32 @@ export function createOptionalAuthenticatedFileDirectoryWsConnection(
 ): FileDirectoryWsConnection | null {
   const principal = getOptionalRequestPrincipal(context);
   return principal ? createFileDirectoryWsConnection({ ...options, ownerId: principal.userId }) : null;
+}
+
+export function createMainWsFileDirectoryRouter(
+  context: Context,
+  options: AuthenticatedFileDirectoryWsConnectionOptions,
+): MainWsFileDirectoryRouter {
+  const connection = createOptionalAuthenticatedFileDirectoryWsConnection(context, options);
+  const rejectUnavailable = () => {
+    safeSend(options.send, {
+      type: "kernel:error",
+      message: GENERIC_FILE_SUBSCRIPTION_ERROR,
+    });
+  };
+  return {
+    handleFrame(frame) {
+      if (connection) connection.enqueue(frame);
+      else rejectUnavailable();
+    },
+    rejectInvalidFrame() {
+      if (connection) connection.rejectInvalidFrame();
+      else rejectUnavailable();
+    },
+    close() {
+      return connection ? connection.close() : Promise.resolve();
+    },
+  };
 }
 
 export function createFileDirectoryWsLifecycle(

--- a/packages/gateway/src/server/file-directory-ws.ts
+++ b/packages/gateway/src/server/file-directory-ws.ts
@@ -3,7 +3,7 @@ import type {
   FileDirectoryClientMessage,
 } from "../ws-message-schema.js";
 import type { Watcher } from "../watcher.js";
-import { requireRequestPrincipal } from "../request-principal.js";
+import { getOptionalRequestPrincipal, requireRequestPrincipal } from "../request-principal.js";
 import type {
   FileDirectorySubscriptionHub,
 } from "../file-management/directory-subscriptions.js";
@@ -160,6 +160,14 @@ export function createAuthenticatedFileDirectoryWsConnection(
     ...options,
     ownerId: requireRequestPrincipal(context).userId,
   });
+}
+
+export function createOptionalAuthenticatedFileDirectoryWsConnection(
+  context: Context,
+  options: AuthenticatedFileDirectoryWsConnectionOptions,
+): FileDirectoryWsConnection | null {
+  const principal = getOptionalRequestPrincipal(context);
+  return principal ? createFileDirectoryWsConnection({ ...options, ownerId: principal.userId }) : null;
 }
 
 export function createFileDirectoryWsLifecycle(

--- a/packages/gateway/src/server/file-directory-ws.ts
+++ b/packages/gateway/src/server/file-directory-ws.ts
@@ -1,7 +1,9 @@
+import type { Context } from "hono";
 import type {
   FileDirectoryClientMessage,
 } from "../ws-message-schema.js";
 import type { Watcher } from "../watcher.js";
+import { requireRequestPrincipal } from "../request-principal.js";
 import type {
   FileDirectorySubscriptionHub,
 } from "../file-management/directory-subscriptions.js";
@@ -24,6 +26,11 @@ export interface FileDirectoryWsConnection {
   idle(): Promise<void>;
   close(): Promise<void>;
 }
+
+export type AuthenticatedFileDirectoryWsConnectionOptions = Omit<
+  FileDirectoryWsConnectionOptions,
+  "ownerId"
+>;
 
 function safeSend(
   send: FileDirectoryWsConnectionOptions["send"],
@@ -135,6 +142,16 @@ export function createFileDirectoryWsConnection(
       return closePromise;
     },
   };
+}
+
+export function createAuthenticatedFileDirectoryWsConnection(
+  context: Context,
+  options: AuthenticatedFileDirectoryWsConnectionOptions,
+): FileDirectoryWsConnection {
+  return createFileDirectoryWsConnection({
+    ...options,
+    ownerId: requireRequestPrincipal(context).userId,
+  });
 }
 
 export function isFileDirectoryFrameCandidate(frame: unknown): boolean {

--- a/packages/gateway/src/server/file-directory-ws.ts
+++ b/packages/gateway/src/server/file-directory-ws.ts
@@ -27,6 +27,10 @@ export interface FileDirectoryWsConnection {
   close(): Promise<void>;
 }
 
+export interface FileDirectoryWsLifecycle {
+  onClose(): Promise<void>;
+}
+
 export type AuthenticatedFileDirectoryWsConnectionOptions = Omit<
   FileDirectoryWsConnectionOptions,
   "ownerId"
@@ -135,10 +139,11 @@ export function createFileDirectoryWsConnection(
     close() {
       if (closePromise) return closePromise;
       closing = true;
-      closePromise = tail.then(() => options.hub.removeConnection(
+      const cleanup = options.hub.removeConnection(
         options.ownerId,
         options.connectionId,
-      ));
+      );
+      closePromise = Promise.all([tail, cleanup]).then(() => undefined);
       return closePromise;
     },
   };
@@ -152,6 +157,22 @@ export function createAuthenticatedFileDirectoryWsConnection(
     ...options,
     ownerId: requireRequestPrincipal(context).userId,
   });
+}
+
+export function createFileDirectoryWsLifecycle(
+  connection: Pick<FileDirectoryWsConnection, "close">,
+): FileDirectoryWsLifecycle {
+  return {
+    async onClose() {
+      try {
+        await connection.close();
+      } catch (error: unknown) {
+        console.error("[files/realtime] Connection cleanup failed", {
+          errorKind: error instanceof Error ? error.name : typeof error,
+        });
+      }
+    },
+  };
 }
 
 export function isFileDirectoryFrameCandidate(frame: unknown): boolean {

--- a/packages/gateway/src/server/types.ts
+++ b/packages/gateway/src/server/types.ts
@@ -9,6 +9,11 @@ export interface GatewayConfig {
   syncReport?: { added: string[]; updated: string[]; skipped: string[] };
 }
 
+export type FileDirectoryServerMessage =
+  | { type: "files:subscribed"; directory: string; revision: number }
+  | { type: "files:change"; directory: string; entry: string; event: "add" | "change" | "unlink"; revision: number }
+  | { type: "files:shutdown" };
+
 export type ServerMessage =
   | { type: "kernel:init"; sessionId: string; requestId?: string; eventId?: string }
   | { type: "kernel:text"; text: string; requestId?: string; eventId?: string }
@@ -18,6 +23,7 @@ export type ServerMessage =
   | { type: "kernel:error"; message: string; requestId?: string; eventId?: string }
   | { type: "kernel:aborted"; requestId?: string; eventId?: string }
   | { type: "file:change"; path: string; event: string }
+  | FileDirectoryServerMessage
   | { type: "task:created"; task: { id: string; type: string; status: string; input: string } }
   | { type: "task:updated"; taskId: string; status: string }
   | { type: "provision:start"; appCount: number }

--- a/packages/gateway/src/sync/ws-peer-lifecycle.ts
+++ b/packages/gateway/src/sync/ws-peer-lifecycle.ts
@@ -9,6 +9,36 @@ export interface SyncPeerLifecycle {
   close(): void;
 }
 
+export function subscribeSyncPeerOrReject(
+  lifecycle: SyncPeerLifecycle | null,
+  params: PeerParams,
+  reject: () => void,
+): boolean {
+  const rejectSubscription = () => {
+    try {
+      reject();
+    } catch (error: unknown) {
+      console.error("[sync/realtime] Subscription error response failed", {
+        errorKind: error instanceof Error ? error.name : typeof error,
+      });
+    }
+  };
+  if (!lifecycle) {
+    rejectSubscription();
+    return false;
+  }
+  try {
+    lifecycle.subscribe(params);
+    return true;
+  } catch (error: unknown) {
+    console.error("[sync/realtime] Peer subscription failed", {
+      errorKind: error instanceof Error ? error.name : typeof error,
+    });
+    rejectSubscription();
+    return false;
+  }
+}
+
 export function createSyncPeerLifecycle(
   registry: PeerRegistry,
   userId: string,

--- a/packages/gateway/src/watcher.ts
+++ b/packages/gateway/src/watcher.ts
@@ -26,8 +26,16 @@ export type WatcherFactory = (
 
 export interface Watcher {
   on(listener: (event: FileChangeEvent) => void): void;
-  acquireDirectoryScope(directory: string): Promise<() => Promise<void>>;
+  acquireDirectoryScope(
+    directory: string,
+    authorization?: DirectoryScopeIdentity,
+  ): Promise<() => Promise<void>>;
   close(): Promise<void>;
+}
+
+export interface DirectoryScopeIdentity {
+  device: number;
+  inode: number;
 }
 
 export interface WatcherIgnoredOptions {
@@ -44,6 +52,7 @@ export interface CreateWatcherOptions {
 interface ScopedReferenceState {
   count: number;
   removePromise: Promise<void> | null;
+  identity: DirectoryScopeIdentity;
 }
 
 const MAX_SCOPED_DIRECTORIES = 1_024;
@@ -106,7 +115,7 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
     ?? ((paths, watchOptions) => watch(paths, watchOptions) as FSWatcher);
   const listeners: Array<(event: FileChangeEvent) => void> = [];
   const scopedReferences = new Map<string, ScopedReferenceState>();
-  const scopeAcquisitions = new Map<string, Promise<void>>();
+  const scopeAcquisitions = new Map<string, Promise<DirectoryScopeIdentity>>();
   const rootCorrelations = new Map<string, RootCorrelationTokens>();
   const now = options.now ?? Date.now;
   const rootCorrelationWindowMs = options.rootCorrelationWindowMs
@@ -210,7 +219,7 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
       listeners.push(listener);
     },
 
-    async acquireDirectoryScope(directory) {
+    async acquireDirectoryScope(directory, authorization) {
       if (closed) throw new Error("Watcher is closed");
       const parsed = FileManagementDirectoryPathSchema.safeParse(directory);
       if (!parsed.success) throw new Error("Invalid directory scope");
@@ -225,6 +234,7 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
         acquisition = (async () => {
           await validateDirectoryScope(parsed.data, absolutePath);
           if (closed) throw new Error("Watcher is closed");
+          return readDirectoryScopeIdentity(absolutePath);
         })();
         scopeAcquisitions.set(absolutePath, acquisition);
         void acquisition.then(
@@ -233,7 +243,10 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
         );
       }
       try {
-        await acquisition;
+        const acquiredIdentity = await acquisition;
+        if (authorization && !sameDirectoryIdentity(acquiredIdentity, authorization)) {
+          throw new Error("Directory scope identity changed");
+        }
       } catch (error: unknown) {
         if (closed && error instanceof Error && error.message === "Watcher is closed") throw error;
         console.error("[watcher] Directory scope validation failed", {
@@ -244,7 +257,13 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
       }
       if (closed) throw new Error("Watcher is closed");
 
+      const acquiredIdentity = await acquisition;
+
       if (isCoveredByGlobalWatcher(parsed.data)) {
+        const currentIdentity = await readDirectoryScopeIdentity(absolutePath);
+        if (!sameDirectoryIdentity(currentIdentity, acquiredIdentity)) {
+          throw new Error("Invalid directory scope");
+        }
         let released = false;
         return async () => { released = true; void released; };
       }
@@ -255,32 +274,49 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
         if (closed) throw new Error("Watcher is closed");
         scopeState = scopedReferences.get(absolutePath);
       }
+      if (scopeState && !sameDirectoryIdentity(scopeState.identity, acquiredIdentity)) {
+        throw new Error("Invalid directory scope");
+      }
       if (!scopeState) {
         if (scopedReferences.size >= MAX_SCOPED_DIRECTORIES) {
           throw new Error("Scoped watcher limit reached");
         }
         if (closed) throw new Error("Watcher is closed");
-        if (!scopedWatcher) {
-          const createdWatcher = watchFactory(absolutePath, {
-            depth: 0,
-            ignoreInitial: true,
-            followSymlinks: false,
-            usePolling: true,
-            interval: 2_000,
-            binaryInterval: 5_000,
-            ignored: createWatcherIgnored({ watchProjects: true }),
-          });
-          bindEvents(createdWatcher, "scoped");
-          if (closed) {
-            await createdWatcher.close();
-            throw new Error("Watcher is closed");
+        let createdWatcher: WatcherBackend | null = null;
+        let addedToWatcher = false;
+        try {
+          if (!scopedWatcher) {
+            createdWatcher = watchFactory(absolutePath, {
+              depth: 0,
+              ignoreInitial: true,
+              followSymlinks: false,
+              usePolling: true,
+              interval: 2_000,
+              binaryInterval: 5_000,
+              ignored: createWatcherIgnored({ watchProjects: true }),
+            });
+            bindEvents(createdWatcher, "scoped");
+            if (closed) throw new Error("Watcher is closed");
+            scopedWatcher = createdWatcher;
+          } else {
+            scopedWatcher.add(absolutePath);
+            addedToWatcher = true;
+            if (closed) throw new Error("Watcher is closed");
           }
-          scopedWatcher = createdWatcher;
-        } else {
-          scopedWatcher.add(absolutePath);
-          if (closed) throw new Error("Watcher is closed");
+          const watchedIdentity = await readDirectoryScopeIdentity(absolutePath);
+          if (!sameDirectoryIdentity(watchedIdentity, acquiredIdentity)) {
+            throw new Error("Directory scope identity changed");
+          }
+        } catch (error: unknown) {
+          if (createdWatcher) {
+            if (scopedWatcher === createdWatcher) scopedWatcher = null;
+            await createdWatcher.close();
+          } else if (addedToWatcher && scopedWatcher) {
+            await scopedWatcher.unwatch(absolutePath);
+          }
+          throw error;
         }
-        scopeState = { count: 0, removePromise: null };
+        scopeState = { count: 0, removePromise: null, identity: acquiredIdentity };
         scopedReferences.set(absolutePath, scopeState);
       }
       scopeState.count += 1;
@@ -335,4 +371,19 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
       return closePromise;
     },
   };
+}
+
+async function readDirectoryScopeIdentity(absolutePath: string): Promise<DirectoryScopeIdentity> {
+  const stats = await lstat(absolutePath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new Error("Scope is not a concrete directory");
+  }
+  return { device: stats.dev, inode: stats.ino };
+}
+
+function sameDirectoryIdentity(
+  first: DirectoryScopeIdentity,
+  second: DirectoryScopeIdentity,
+): boolean {
+  return first.device === second.device && first.inode === second.inode;
 }

--- a/packages/gateway/src/watcher.ts
+++ b/packages/gateway/src/watcher.ts
@@ -37,6 +37,8 @@ export interface WatcherIgnoredOptions {
 export interface CreateWatcherOptions {
   watchFactory?: WatcherFactory;
   validateDirectoryScope?: (directory: string, absolutePath: string) => Promise<string>;
+  rootCorrelationWindowMs?: number;
+  now?: () => number;
 }
 
 interface ScopedReferenceState {
@@ -61,6 +63,8 @@ const ROOT_GLOBAL_OVERLAP = new Set([
   ...WATCHED_HOME_DIRECTORIES,
   ...WATCHED_HOME_FILES,
 ]);
+const ROOT_CORRELATION_WINDOW_MS = 5_000;
+const ROOT_CORRELATION_MAX_ENTRIES = ROOT_GLOBAL_OVERLAP.size * 3;
 
 export function createWatcherIgnored(
   options: WatcherIgnoredOptions = {},
@@ -95,8 +99,16 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
   const listeners: Array<(event: FileChangeEvent) => void> = [];
   const scopedReferences = new Map<string, ScopedReferenceState>();
   const scopeAcquisitions = new Map<string, Promise<void>>();
+  const rootCorrelations = new Map<
+    string,
+    { source: "global" | "scoped"; expiresAt: number }
+  >();
+  const now = options.now ?? Date.now;
+  const rootCorrelationWindowMs = options.rootCorrelationWindowMs
+    ?? ROOT_CORRELATION_WINDOW_MS;
   let scopedWatcher: WatcherBackend | null = null;
   let closed = false;
+  let closePromise: Promise<void> | null = null;
 
   const globalWatcher = watchFactory(createWatcherPaths(basePath), {
     ignoreInitial: true,
@@ -106,12 +118,39 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
     ignored: createWatcherIgnored(),
   });
 
+  const isCorrelatedRootDuplicate = (
+    source: "global" | "scoped",
+    path: string,
+    event: FileEvent,
+  ): boolean => {
+    if (!scopedReferences.has(basePath) || !ROOT_GLOBAL_OVERLAP.has(path)) return false;
+    const timestamp = now();
+    for (const [key, correlation] of rootCorrelations) {
+      if (correlation.expiresAt < timestamp) rootCorrelations.delete(key);
+    }
+    const key = `${event}\u0000${path}`;
+    const existing = rootCorrelations.get(key);
+    if (existing && existing.source !== source) {
+      rootCorrelations.delete(key);
+      return true;
+    }
+    if (!existing && rootCorrelations.size >= ROOT_CORRELATION_MAX_ENTRIES) {
+      const oldestKey = rootCorrelations.keys().next().value;
+      if (oldestKey !== undefined) rootCorrelations.delete(oldestKey);
+    }
+    rootCorrelations.set(key, {
+      source,
+      expiresAt: timestamp + rootCorrelationWindowMs,
+    });
+    return false;
+  };
+
   const emit = (source: "global" | "scoped", event: FileEvent, absolutePath: string) => {
     const homeRelative = relative(basePath, resolve(absolutePath));
     if (homeRelative === "" || homeRelative.startsWith("..") || homeRelative.startsWith(sep)) return;
     const normalizedPath = homeRelative.split(sep).join("/");
-    if (source === "scoped" && !normalizedPath.includes("/")
-      && ROOT_GLOBAL_OVERLAP.has(normalizedPath)) return;
+    if (!normalizedPath.includes("/")
+      && isCorrelatedRootDuplicate(source, normalizedPath, event)) return;
     const change: FileChangeEvent = {
       type: "file:change",
       path: normalizedPath,
@@ -250,6 +289,7 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
             if (scopedReferences.get(absolutePath) === scopeState) {
               scopedReferences.delete(absolutePath);
             }
+            if (absolutePath === basePath) rootCorrelations.clear();
             scopeState.removePromise = null;
           }
         })();
@@ -258,20 +298,24 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
       };
     },
 
-    async close() {
-      if (closed) return;
+    close() {
+      if (closePromise) return closePromise;
       closed = true;
-      const pendingAcquisitions = [...scopeAcquisitions.values()];
-      await Promise.allSettled(pendingAcquisitions);
-      const pendingUnwatches = [...scopedReferences.values()]
-        .flatMap((state) => state.removePromise ? [state.removePromise] : []);
-      await Promise.allSettled(pendingUnwatches);
-      scopedReferences.clear();
-      const scopedClose = scopedWatcher?.close();
-      scopedWatcher = null;
-      await scopedClose;
-      await globalWatcher.close();
-      listeners.length = 0;
+      closePromise = (async () => {
+        const pendingAcquisitions = [...scopeAcquisitions.values()];
+        await Promise.allSettled(pendingAcquisitions);
+        const pendingUnwatches = [...scopedReferences.values()]
+          .flatMap((state) => state.removePromise ? [state.removePromise] : []);
+        await Promise.allSettled(pendingUnwatches);
+        scopedReferences.clear();
+        rootCorrelations.clear();
+        const scopedClose = scopedWatcher?.close();
+        scopedWatcher = null;
+        await scopedClose;
+        await globalWatcher.close();
+        listeners.length = 0;
+      })();
+      return closePromise;
     },
   };
 }

--- a/packages/gateway/src/watcher.ts
+++ b/packages/gateway/src/watcher.ts
@@ -36,6 +36,7 @@ export interface WatcherIgnoredOptions {
 
 export interface CreateWatcherOptions {
   watchFactory?: WatcherFactory;
+  validateDirectoryScope?: (directory: string, absolutePath: string) => Promise<string>;
 }
 
 interface ScopedReferenceState {
@@ -56,6 +57,10 @@ const WATCHED_HOME_DIRECTORIES = [
 const WATCHED_HOME_FILES = [
   ".matrix-version", ".syncignore", ".template-manifest.json", "CLAUDE.md",
 ];
+const ROOT_GLOBAL_OVERLAP = new Set([
+  ...WATCHED_HOME_DIRECTORIES,
+  ...WATCHED_HOME_FILES,
+]);
 
 export function createWatcherIgnored(
   options: WatcherIgnoredOptions = {},
@@ -89,6 +94,7 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
     ?? ((paths, watchOptions) => watch(paths, watchOptions) as FSWatcher);
   const listeners: Array<(event: FileChangeEvent) => void> = [];
   const scopedReferences = new Map<string, ScopedReferenceState>();
+  const scopeAcquisitions = new Map<string, Promise<void>>();
   let scopedWatcher: WatcherBackend | null = null;
   let closed = false;
 
@@ -100,25 +106,47 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
     ignored: createWatcherIgnored(),
   });
 
-  const emit = (event: FileEvent, absolutePath: string) => {
+  const emit = (source: "global" | "scoped", event: FileEvent, absolutePath: string) => {
     const homeRelative = relative(basePath, resolve(absolutePath));
     if (homeRelative === "" || homeRelative.startsWith("..") || homeRelative.startsWith(sep)) return;
+    const normalizedPath = homeRelative.split(sep).join("/");
+    if (source === "scoped" && !normalizedPath.includes("/")
+      && ROOT_GLOBAL_OVERLAP.has(normalizedPath)) return;
     const change: FileChangeEvent = {
       type: "file:change",
-      path: homeRelative.split(sep).join("/"),
+      path: normalizedPath,
       event,
     };
     for (const listener of listeners) listener(change);
   };
 
-  const bindEvents = (backend: WatcherBackend) => {
-    backend.on("add", (path) => emit("add", path));
-    backend.on("change", (path) => emit("change", path));
-    backend.on("unlink", (path) => emit("unlink", path));
-    backend.on("addDir", (path) => emit("add", path));
-    backend.on("unlinkDir", (path) => emit("unlink", path));
+  const bindEvents = (backend: WatcherBackend, source: "global" | "scoped") => {
+    backend.on("add", (path) => emit(source, "add", path));
+    backend.on("change", (path) => emit(source, "change", path));
+    backend.on("unlink", (path) => emit(source, "unlink", path));
+    backend.on("addDir", (path) => emit(source, "add", path));
+    backend.on("unlinkDir", (path) => emit(source, "unlink", path));
   };
-  bindEvents(globalWatcher);
+  bindEvents(globalWatcher, "global");
+
+  const validateDirectoryScope = options.validateDirectoryScope ?? (async (
+    _directory: string,
+    absolutePath: string,
+  ) => {
+    const scopeStats = await lstat(absolutePath);
+    if (scopeStats.isSymbolicLink() || !scopeStats.isDirectory()) {
+      throw new Error("Scope is not a concrete directory");
+    }
+    const [baseRealPath, scopeRealPath] = await Promise.all([
+      realpath(basePath),
+      realpath(absolutePath),
+    ]);
+    const scopeRelative = relative(baseRealPath, scopeRealPath);
+    if (scopeRelative.startsWith("..") || scopeRelative.startsWith(sep)) {
+      throw new Error("Scope resolves outside owner home");
+    }
+    return absolutePath;
+  });
 
   return {
     on(listener) {
@@ -132,26 +160,33 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
       if (!parsed.success) throw new Error("Invalid directory scope");
       const absolutePath = resolveWithinHome(basePath, parsed.data);
       if (!absolutePath) throw new Error("Invalid directory scope");
+      let acquisition = scopeAcquisitions.get(absolutePath);
+      if (!acquisition) {
+        if (!scopedReferences.has(absolutePath)
+          && scopedReferences.size + scopeAcquisitions.size >= MAX_SCOPED_DIRECTORIES) {
+          throw new Error("Scoped watcher limit reached");
+        }
+        acquisition = (async () => {
+          await validateDirectoryScope(parsed.data, absolutePath);
+          if (closed) throw new Error("Watcher is closed");
+        })();
+        scopeAcquisitions.set(absolutePath, acquisition);
+        void acquisition.then(
+          () => scopeAcquisitions.delete(absolutePath),
+          () => scopeAcquisitions.delete(absolutePath),
+        );
+      }
       try {
-        const scopeStats = await lstat(absolutePath);
-        if (scopeStats.isSymbolicLink() || !scopeStats.isDirectory()) {
-          throw new Error("Scope is not a concrete directory");
-        }
-        const [baseRealPath, scopeRealPath] = await Promise.all([
-          realpath(basePath),
-          realpath(absolutePath),
-        ]);
-        const scopeRelative = relative(baseRealPath, scopeRealPath);
-        if (scopeRelative.startsWith("..") || scopeRelative.startsWith(sep)) {
-          throw new Error("Scope resolves outside owner home");
-        }
+        await acquisition;
       } catch (error: unknown) {
+        if (closed && error instanceof Error && error.message === "Watcher is closed") throw error;
         console.error("[watcher] Directory scope validation failed", {
           directory: parsed.data,
           error: error instanceof Error ? error.message : String(error),
         });
         throw new Error("Invalid directory scope");
       }
+      if (closed) throw new Error("Watcher is closed");
 
       if (isCoveredByGlobalWatcher(parsed.data)) {
         let released = false;
@@ -168,8 +203,9 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
         if (scopedReferences.size >= MAX_SCOPED_DIRECTORIES) {
           throw new Error("Scoped watcher limit reached");
         }
+        if (closed) throw new Error("Watcher is closed");
         if (!scopedWatcher) {
-          scopedWatcher = watchFactory(absolutePath, {
+          const createdWatcher = watchFactory(absolutePath, {
             depth: 0,
             ignoreInitial: true,
             followSymlinks: false,
@@ -178,9 +214,15 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
             binaryInterval: 5_000,
             ignored: createWatcherIgnored({ watchProjects: true }),
           });
-          bindEvents(scopedWatcher);
+          bindEvents(createdWatcher, "scoped");
+          if (closed) {
+            await createdWatcher.close();
+            throw new Error("Watcher is closed");
+          }
+          scopedWatcher = createdWatcher;
         } else {
           scopedWatcher.add(absolutePath);
+          if (closed) throw new Error("Watcher is closed");
         }
         scopeState = { count: 0, removePromise: null };
         scopedReferences.set(absolutePath, scopeState);
@@ -219,6 +261,8 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
     async close() {
       if (closed) return;
       closed = true;
+      const pendingAcquisitions = [...scopeAcquisitions.values()];
+      await Promise.allSettled(pendingAcquisitions);
       const pendingUnwatches = [...scopedReferences.values()]
         .flatMap((state) => state.removePromise ? [state.removePromise] : []);
       await Promise.allSettled(pendingUnwatches);

--- a/packages/gateway/src/watcher.ts
+++ b/packages/gateway/src/watcher.ts
@@ -1,5 +1,8 @@
-import { join } from "node:path";
-import { watch, type FSWatcher } from "chokidar";
+import { join, relative, resolve, sep } from "node:path";
+import { lstat, realpath } from "node:fs/promises";
+import { watch, type ChokidarOptions, type FSWatcher } from "chokidar";
+import { FileManagementDirectoryPathSchema } from "./file-management/contracts.js";
+import { resolveWithinHome } from "./path-security.js";
 
 export type FileEvent = "add" | "change" | "unlink";
 
@@ -9,8 +12,21 @@ export interface FileChangeEvent {
   event: FileEvent;
 }
 
+export interface WatcherBackend {
+  on(event: string, listener: (path: string) => void): WatcherBackend;
+  add(paths: string | string[]): WatcherBackend;
+  unwatch(paths: string | string[]): WatcherBackend | Promise<WatcherBackend>;
+  close(): Promise<void>;
+}
+
+export type WatcherFactory = (
+  paths: string | string[],
+  options: ChokidarOptions,
+) => WatcherBackend;
+
 export interface Watcher {
   on(listener: (event: FileChangeEvent) => void): void;
+  acquireDirectoryScope(directory: string): Promise<() => Promise<void>>;
   close(): Promise<void>;
 }
 
@@ -18,53 +34,27 @@ export interface WatcherIgnoredOptions {
   watchProjects?: boolean;
 }
 
-// Directories to skip entirely - prevents chokidar from readdir-ing into
-// large trees (node_modules, .git, etc.) which starves the event loop
-// during the initial poll scan even when ignoreInitial is true.
-//
-// Glob patterns like `**/node_modules/**` only match paths *inside* the
-// directory, not the directory entry itself, so chokidar still recurses
-// into it before filtering contents. A function check on path segments
-// catches the directory before readdir runs.
+export interface CreateWatcherOptions {
+  watchFactory?: WatcherFactory;
+}
+
+interface ScopedReferenceState {
+  count: number;
+  removePromise: Promise<void> | null;
+}
+
+const MAX_SCOPED_DIRECTORIES = 1_024;
 const ALWAYS_IGNORED_DIRS = new Set([
-  "node_modules",
-  ".git",
-  ".next",
-  ".turbo",
-  ".cache",
-  ".trash",
-  "dist",
-  "build",
-  ".claude",
-  ".codex",
-  ".hermes",
-  ".local",
-  ".npm",
+  "node_modules", ".git", ".next", ".turbo", ".cache", ".trash", "dist",
+  "build", ".claude", ".codex", ".hermes", ".local", ".npm",
 ]);
-
-const PROJECT_IGNORED_DIRS = new Set([
-  "projects",
-  "matrix-os",
-]);
-
+const PROJECT_IGNORED_DIRS = new Set(["projects", "matrix-os"]);
 const WATCHED_HOME_DIRECTORIES = [
-  "agents",
-  "apps",
-  "data",
-  "modules",
-  "plugins",
-  "sessions",
-  "system",
-  "templates",
-  "themes",
-  "tools",
+  "agents", "apps", "data", "modules", "plugins", "sessions", "system",
+  "templates", "themes", "tools",
 ];
-
 const WATCHED_HOME_FILES = [
-  ".matrix-version",
-  ".syncignore",
-  ".template-manifest.json",
-  "CLAUDE.md",
+  ".matrix-version", ".syncignore", ".template-manifest.json", "CLAUDE.md",
 ];
 
 export function createWatcherIgnored(
@@ -76,11 +66,7 @@ export function createWatcherIgnored(
       if (ALWAYS_IGNORED_DIRS.has(segment)) return true;
       if (!options.watchProjects && PROJECT_IGNORED_DIRS.has(segment)) return true;
     }
-
-    const name = segments.at(-1) ?? "";
-    if (name.startsWith("matrix.db")) return true;
-
-    return false;
+    return (segments.at(-1) ?? "").startsWith("matrix.db");
   };
 }
 
@@ -91,42 +77,157 @@ export function createWatcherPaths(homePath: string): string[] {
   ];
 }
 
-export function createWatcher(homePath: string): Watcher {
-  const listeners: Array<(event: FileChangeEvent) => void> = [];
+function isCoveredByGlobalWatcher(directory: string): boolean {
+  if (directory === "") return false;
+  const firstSegment = directory.split("/")[0];
+  return firstSegment !== undefined && WATCHED_HOME_DIRECTORIES.includes(firstSegment);
+}
 
-  // Watch Matrix-owned home roots explicitly. Watching the whole home and
-  // relying on ignores still lets chokidar traverse large user/project trees
-  // during startup on customer VPSes.
-  const fsWatcher: FSWatcher = watch(createWatcherPaths(homePath), {
+export function createWatcher(homePath: string, options: CreateWatcherOptions = {}): Watcher {
+  const basePath = resolve(homePath);
+  const watchFactory: WatcherFactory = options.watchFactory
+    ?? ((paths, watchOptions) => watch(paths, watchOptions) as FSWatcher);
+  const listeners: Array<(event: FileChangeEvent) => void> = [];
+  const scopedReferences = new Map<string, ScopedReferenceState>();
+  let scopedWatcher: WatcherBackend | null = null;
+  let closed = false;
+
+  const globalWatcher = watchFactory(createWatcherPaths(basePath), {
     ignoreInitial: true,
     usePolling: true,
-    interval: 2000,
-    binaryInterval: 5000,
-    ignored: createWatcherIgnored({
-      watchProjects: process.env.MATRIX_WATCH_PROJECTS === "true",
-    }),
+    interval: 2_000,
+    binaryInterval: 5_000,
+    ignored: createWatcherIgnored(),
   });
 
-  const emit = (event: FileEvent, path: string) => {
-    const relative = path.startsWith(homePath)
-      ? path.slice(homePath.length + 1)
-      : path;
-    const change: FileChangeEvent = { type: "file:change", path: relative, event };
-    for (const listener of listeners) {
-      listener(change);
-    }
+  const emit = (event: FileEvent, absolutePath: string) => {
+    const homeRelative = relative(basePath, resolve(absolutePath));
+    if (homeRelative === "" || homeRelative.startsWith("..") || homeRelative.startsWith(sep)) return;
+    const change: FileChangeEvent = {
+      type: "file:change",
+      path: homeRelative.split(sep).join("/"),
+      event,
+    };
+    for (const listener of listeners) listener(change);
   };
 
-  fsWatcher.on("add", (path) => emit("add", path));
-  fsWatcher.on("change", (path) => emit("change", path));
-  fsWatcher.on("unlink", (path) => emit("unlink", path));
+  const bindEvents = (backend: WatcherBackend) => {
+    backend.on("add", (path) => emit("add", path));
+    backend.on("change", (path) => emit("change", path));
+    backend.on("unlink", (path) => emit("unlink", path));
+    backend.on("addDir", (path) => emit("add", path));
+    backend.on("unlinkDir", (path) => emit("unlink", path));
+  };
+  bindEvents(globalWatcher);
 
   return {
     on(listener) {
+      if (closed) throw new Error("Watcher is closed");
       listeners.push(listener);
     },
+
+    async acquireDirectoryScope(directory) {
+      if (closed) throw new Error("Watcher is closed");
+      const parsed = FileManagementDirectoryPathSchema.safeParse(directory);
+      if (!parsed.success) throw new Error("Invalid directory scope");
+      const absolutePath = resolveWithinHome(basePath, parsed.data);
+      if (!absolutePath) throw new Error("Invalid directory scope");
+      try {
+        const scopeStats = await lstat(absolutePath);
+        if (scopeStats.isSymbolicLink() || !scopeStats.isDirectory()) {
+          throw new Error("Scope is not a concrete directory");
+        }
+        const [baseRealPath, scopeRealPath] = await Promise.all([
+          realpath(basePath),
+          realpath(absolutePath),
+        ]);
+        const scopeRelative = relative(baseRealPath, scopeRealPath);
+        if (scopeRelative.startsWith("..") || scopeRelative.startsWith(sep)) {
+          throw new Error("Scope resolves outside owner home");
+        }
+      } catch (error: unknown) {
+        console.error("[watcher] Directory scope validation failed", {
+          directory: parsed.data,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw new Error("Invalid directory scope");
+      }
+
+      if (isCoveredByGlobalWatcher(parsed.data)) {
+        let released = false;
+        return async () => { released = true; void released; };
+      }
+
+      let scopeState = scopedReferences.get(absolutePath);
+      if (scopeState?.removePromise) {
+        await scopeState.removePromise;
+        if (closed) throw new Error("Watcher is closed");
+        scopeState = scopedReferences.get(absolutePath);
+      }
+      if (!scopeState) {
+        if (scopedReferences.size >= MAX_SCOPED_DIRECTORIES) {
+          throw new Error("Scoped watcher limit reached");
+        }
+        if (!scopedWatcher) {
+          scopedWatcher = watchFactory(absolutePath, {
+            depth: 0,
+            ignoreInitial: true,
+            followSymlinks: false,
+            usePolling: true,
+            interval: 2_000,
+            binaryInterval: 5_000,
+            ignored: createWatcherIgnored({ watchProjects: true }),
+          });
+          bindEvents(scopedWatcher);
+        } else {
+          scopedWatcher.add(absolutePath);
+        }
+        scopeState = { count: 0, removePromise: null };
+        scopedReferences.set(absolutePath, scopeState);
+      }
+      scopeState.count += 1;
+
+      let released = false;
+      return async () => {
+        if (released) return;
+        released = true;
+        if (scopedReferences.get(absolutePath) !== scopeState) return;
+        scopeState.count -= 1;
+        if (scopeState.count > 0) {
+          return;
+        }
+        if (!scopedWatcher || closed) {
+          scopedReferences.delete(absolutePath);
+          return;
+        }
+        const backend = scopedWatcher;
+        const removePromise = (async () => {
+          try {
+            await backend.unwatch(absolutePath);
+          } finally {
+            if (scopedReferences.get(absolutePath) === scopeState) {
+              scopedReferences.delete(absolutePath);
+            }
+            scopeState.removePromise = null;
+          }
+        })();
+        scopeState.removePromise = removePromise;
+        await removePromise;
+      };
+    },
+
     async close() {
-      await fsWatcher.close();
+      if (closed) return;
+      closed = true;
+      const pendingUnwatches = [...scopedReferences.values()]
+        .flatMap((state) => state.removePromise ? [state.removePromise] : []);
+      await Promise.allSettled(pendingUnwatches);
+      scopedReferences.clear();
+      const scopedClose = scopedWatcher?.close();
+      scopedWatcher = null;
+      await scopedClose;
+      await globalWatcher.close();
+      listeners.length = 0;
     },
   };
 }

--- a/packages/gateway/src/watcher.ts
+++ b/packages/gateway/src/watcher.ts
@@ -65,6 +65,14 @@ const ROOT_GLOBAL_OVERLAP = new Set([
 ]);
 const ROOT_CORRELATION_WINDOW_MS = 5_000;
 const ROOT_CORRELATION_MAX_ENTRIES = ROOT_GLOBAL_OVERLAP.size * 3;
+const ROOT_CORRELATION_MAX_TOKENS_PER_SOURCE = 8;
+
+type WatcherSource = "global" | "scoped";
+
+interface RootCorrelationTokens {
+  global: number[];
+  scoped: number[];
+}
 
 export function createWatcherIgnored(
   options: WatcherIgnoredOptions = {},
@@ -99,10 +107,7 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
   const listeners: Array<(event: FileChangeEvent) => void> = [];
   const scopedReferences = new Map<string, ScopedReferenceState>();
   const scopeAcquisitions = new Map<string, Promise<void>>();
-  const rootCorrelations = new Map<
-    string,
-    { source: "global" | "scoped"; expiresAt: number }
-  >();
+  const rootCorrelations = new Map<string, RootCorrelationTokens>();
   const now = options.now ?? Date.now;
   const rootCorrelationWindowMs = options.rootCorrelationWindowMs
     ?? ROOT_CORRELATION_WINDOW_MS;
@@ -119,33 +124,45 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
   });
 
   const isCorrelatedRootDuplicate = (
-    source: "global" | "scoped",
+    source: WatcherSource,
     path: string,
     event: FileEvent,
   ): boolean => {
     if (!scopedReferences.has(basePath) || !ROOT_GLOBAL_OVERLAP.has(path)) return false;
     const timestamp = now();
-    for (const [key, correlation] of rootCorrelations) {
-      if (correlation.expiresAt < timestamp) rootCorrelations.delete(key);
+    for (const [correlationKey, tokens] of rootCorrelations) {
+      tokens.global = tokens.global.filter((expiresAt) => expiresAt > timestamp);
+      tokens.scoped = tokens.scoped.filter((expiresAt) => expiresAt > timestamp);
+      if (tokens.global.length === 0 && tokens.scoped.length === 0) {
+        rootCorrelations.delete(correlationKey);
+      }
     }
     const key = `${event}\u0000${path}`;
-    const existing = rootCorrelations.get(key);
-    if (existing && existing.source !== source) {
-      rootCorrelations.delete(key);
+    let tokens = rootCorrelations.get(key);
+    const oppositeSource = source === "global" ? "scoped" : "global";
+    const oppositeTokens = tokens?.[oppositeSource];
+    if (tokens && oppositeTokens && oppositeTokens.length > 0) {
+      oppositeTokens.shift();
+      if (tokens.global.length === 0 && tokens.scoped.length === 0) {
+        rootCorrelations.delete(key);
+      }
       return true;
     }
-    if (!existing && rootCorrelations.size >= ROOT_CORRELATION_MAX_ENTRIES) {
+    if (!tokens && rootCorrelations.size >= ROOT_CORRELATION_MAX_ENTRIES) {
       const oldestKey = rootCorrelations.keys().next().value;
       if (oldestKey !== undefined) rootCorrelations.delete(oldestKey);
     }
-    rootCorrelations.set(key, {
-      source,
-      expiresAt: timestamp + rootCorrelationWindowMs,
-    });
+    tokens ??= { global: [], scoped: [] };
+    const sourceTokens = tokens[source];
+    if (sourceTokens.length >= ROOT_CORRELATION_MAX_TOKENS_PER_SOURCE) {
+      sourceTokens.shift();
+    }
+    sourceTokens.push(timestamp + rootCorrelationWindowMs);
+    rootCorrelations.set(key, tokens);
     return false;
   };
 
-  const emit = (source: "global" | "scoped", event: FileEvent, absolutePath: string) => {
+  const emit = (source: WatcherSource, event: FileEvent, absolutePath: string) => {
     const homeRelative = relative(basePath, resolve(absolutePath));
     if (homeRelative === "" || homeRelative.startsWith("..") || homeRelative.startsWith(sep)) return;
     const normalizedPath = homeRelative.split(sep).join("/");
@@ -159,7 +176,7 @@ export function createWatcher(homePath: string, options: CreateWatcherOptions = 
     for (const listener of listeners) listener(change);
   };
 
-  const bindEvents = (backend: WatcherBackend, source: "global" | "scoped") => {
+  const bindEvents = (backend: WatcherBackend, source: WatcherSource) => {
     backend.on("add", (path) => emit(source, "add", path));
     backend.on("change", (path) => emit(source, "change", path));
     backend.on("unlink", (path) => emit(source, "unlink", path));

--- a/packages/gateway/src/ws-message-schema.ts
+++ b/packages/gateway/src/ws-message-schema.ts
@@ -1,5 +1,28 @@
 import { z } from "zod/v4";
 import { KernelEffortSchema, KernelModelSchema } from "./kernel-settings.js";
+import { FileManagementDirectoryPathSchema } from "./file-management/contracts.js";
+
+const FileDirectoryPathSchema = FileManagementDirectoryPathSchema.refine(
+  (directory) => !/^[a-zA-Z]:\//.test(directory),
+  "Directory must not be an absolute Windows path",
+);
+
+export const FileDirectoryClientMessageSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("files:subscribe"),
+    directory: FileDirectoryPathSchema,
+  }).strict(),
+  z.object({
+    type: z.literal("files:unsubscribe"),
+    directory: FileDirectoryPathSchema,
+  }).strict(),
+  z.object({
+    type: z.literal("files:touch"),
+    directory: FileDirectoryPathSchema,
+  }).strict(),
+]);
+
+export type FileDirectoryClientMessage = z.infer<typeof FileDirectoryClientMessageSchema>;
 
 export const MainWsClientMessageSchema = z.discriminatedUnion("type", [
   z.object({
@@ -34,6 +57,7 @@ export const MainWsClientMessageSchema = z.discriminatedUnion("type", [
     type: z.literal("abort"),
     requestId: z.string().min(1).max(256),
   }),
+  ...FileDirectoryClientMessageSchema.options,
 ]);
 
 export type MainWsClientMessage = z.infer<typeof MainWsClientMessageSchema>;

--- a/tests/gateway/file-directory-subscriptions.test.ts
+++ b/tests/gateway/file-directory-subscriptions.test.ts
@@ -187,6 +187,66 @@ describe("FileDirectorySubscriptionHub", () => {
     await hub.close();
   });
 
+  it("memoizes exact cleanup across repeated unsubscribe and cap rejection", async () => {
+    const releaseGate = deferred<void>();
+    const release = vi.fn(async () => releaseGate.promise);
+    const hub = new FileDirectorySubscriptionHub({
+      maxSubscriptions: 1,
+      acquireScope: async () => release,
+    });
+    await hub.subscribe(subscriber("owner", "connection", "projects"));
+
+    const repeatedCleanup = Array.from({ length: 100 }, () => (
+      hub.unsubscribe("owner", "connection", "projects")
+    ));
+    await vi.waitFor(() => expect(release).toHaveBeenCalledOnce());
+    expect(hub.subscriberCount).toBe(1);
+    const rejected = await Promise.allSettled(Array.from({ length: 1_000 }, (_, index) => (
+      hub.subscribe(subscriber(`owner-${index}`, `connection-${index}`, "projects"))
+    )));
+    expect(rejected.every((result) => result.status === "rejected")).toBe(true);
+    expect(release).toHaveBeenCalledOnce();
+    expect(hub.subscriberCount).toBe(1);
+
+    releaseGate.resolve();
+    await expect(Promise.all(repeatedCleanup)).resolves.toEqual(Array(100).fill(true));
+    expect(hub.subscriberCount).toBe(0);
+    await hub.close();
+  });
+
+  it("keeps stale releasing scopes counted until replacements acquire", async () => {
+    let now = 0;
+    let liveScopes = 0;
+    let peakLiveScopes = 0;
+    const releaseGate = deferred<void>();
+    const hub = new FileDirectorySubscriptionHub({
+      maxSubscriptions: 2,
+      now: () => now,
+      acquireScope: async () => {
+        liveScopes += 1;
+        peakLiveScopes = Math.max(peakLiveScopes, liveScopes);
+        return async () => {
+          await releaseGate.promise;
+          liveScopes -= 1;
+        };
+      },
+    });
+    await hub.subscribe(subscriber("owner-a", "connection-a", "projects"));
+    await hub.subscribe(subscriber("owner-b", "connection-b", "projects"));
+
+    now = FILE_DIRECTORY_STALE_TTL_MS;
+    const firstReplacement = hub.subscribe(subscriber("owner-c", "connection-c", "projects"));
+    const secondReplacement = hub.subscribe(subscriber("owner-d", "connection-d", "projects"));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(peakLiveScopes).toBe(2);
+    expect(liveScopes).toBe(2);
+
+    releaseGate.resolve();
+    await Promise.all([firstReplacement, secondReplacement]);
+    expect(peakLiveScopes).toBe(2);
+    await hub.close();
+  });
+
   it("drains a pending scope acquisition during close", async () => {
     const acquisitionGate = deferred<() => void>();
     const release = vi.fn();
@@ -289,6 +349,24 @@ describe("FileDirectorySubscriptionHub", () => {
     authorizationGate.resolve(true);
     await expect(Promise.all([first, second])).resolves.toEqual([0, 0]);
     expect(acquireScope).toHaveBeenCalledOnce();
+    expect(hub.subscriberCount).toBe(1);
+    await hub.close();
+  });
+
+  it("shares one replacement after concurrent exact-key cleanup waiters", async () => {
+    const releaseGate = deferred<void>();
+    const acquireScope = vi.fn()
+      .mockResolvedValueOnce(async () => releaseGate.promise)
+      .mockResolvedValue(async () => vi.fn());
+    const hub = new FileDirectorySubscriptionHub({ acquireScope });
+    await hub.subscribe(subscriber("owner", "connection", "projects"));
+    const cleanup = hub.unsubscribe("owner", "connection", "projects");
+    const first = hub.subscribe(subscriber("owner", "connection", "projects"));
+    const second = hub.subscribe(subscriber("owner", "connection", "projects"));
+
+    releaseGate.resolve();
+    await Promise.all([cleanup, first, second]);
+    expect(acquireScope).toHaveBeenCalledTimes(2);
     expect(hub.subscriberCount).toBe(1);
     await hub.close();
   });

--- a/tests/gateway/file-directory-subscriptions.test.ts
+++ b/tests/gateway/file-directory-subscriptions.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  authorizeFileDirectory,
+  FILE_DIRECTORY_MAX_CONNECTIONS_PER_OWNER,
+  FILE_DIRECTORY_MAX_DIRECTORIES_PER_CONNECTION,
+  FILE_DIRECTORY_MAX_SUBSCRIPTIONS,
+  FILE_DIRECTORY_STALE_TTL_MS,
+  FileDirectorySubscriptionHub,
+} from "../../packages/gateway/src/file-management/directory-subscriptions.js";
+
+function subscriber(
+  ownerId: string,
+  connectionId: string,
+  directory: string,
+  send = vi.fn(),
+) {
+  return { ownerId, connectionId, directory, send };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => { resolve = next; });
+  return { promise, resolve };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("FileDirectorySubscriptionHub", () => {
+  it("authorizes existing owner directories but rejects protected, denied, file, and symlink scopes", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-directory-auth-"));
+    const outsidePath = await mkdtemp(join(tmpdir(), "matrix-directory-outside-"));
+    try {
+      await mkdir(join(homePath, "projects"));
+      await mkdir(join(homePath, "system"));
+      await mkdir(join(homePath, "data", "browser-profiles"), { recursive: true });
+      await writeFile(join(homePath, "readme.md"), "file");
+      await symlink(outsidePath, join(homePath, "escaped"));
+
+      await expect(authorizeFileDirectory(homePath, "")).resolves.toBe(true);
+      await expect(authorizeFileDirectory(homePath, "projects")).resolves.toBe(true);
+      await expect(authorizeFileDirectory(homePath, "system")).resolves.toBe(false);
+      await expect(authorizeFileDirectory(homePath, "data")).resolves.toBe(false);
+      await expect(authorizeFileDirectory(homePath, "readme.md")).resolves.toBe(false);
+      await expect(authorizeFileDirectory(homePath, "escaped")).resolves.toBe(false);
+    } finally {
+      await rm(homePath, { recursive: true });
+      await rm(outsidePath, { recursive: true });
+    }
+  });
+
+  it("keys touch and unsubscribe by exact owner, connection, and directory", async () => {
+    let now = 1;
+    const release = vi.fn();
+    const hub = new FileDirectorySubscriptionHub({
+      now: () => now,
+      acquireScope: vi.fn(async () => release),
+    });
+    await hub.subscribe(subscriber("owner-a", "connection-a", "projects"));
+
+    now = 2;
+    expect(hub.touch("owner-b", "connection-a", "projects")).toBe(false);
+    expect(await hub.unsubscribe("owner-a", "connection-b", "projects")).toBe(false);
+    expect(await hub.unsubscribe("owner-a", "connection-a", "other")).toBe(false);
+    expect(hub.subscriberCount).toBe(1);
+
+    expect(hub.touch("owner-a", "connection-a", "projects")).toBe(true);
+    expect(await hub.unsubscribe("owner-a", "connection-a", "projects")).toBe(true);
+    expect(release).toHaveBeenCalledOnce();
+    await hub.close();
+  });
+
+  it("enforces the exact default global, per-connection, and per-owner bounds", async () => {
+    const globalHub = new FileDirectorySubscriptionHub({ acquireScope: async () => () => {} });
+    for (let index = 0; index < FILE_DIRECTORY_MAX_SUBSCRIPTIONS; index += 1) {
+      await globalHub.subscribe(subscriber(`owner-${index}`, `connection-${index}`, "projects"));
+    }
+    await expect(globalHub.subscribe(subscriber("overflow", "overflow", "projects")))
+      .rejects.toThrow("subscription limit");
+    expect(globalHub.subscriberCount).toBe(1_024);
+    await globalHub.close();
+
+    const connectionHub = new FileDirectorySubscriptionHub({ acquireScope: async () => () => {} });
+    for (let index = 0; index < FILE_DIRECTORY_MAX_DIRECTORIES_PER_CONNECTION; index += 1) {
+      await connectionHub.subscribe(subscriber("owner", "connection", `projects/${index}`));
+    }
+    await expect(connectionHub.subscribe(subscriber("owner", "connection", "projects/overflow")))
+      .rejects.toThrow(/directory limit/i);
+    expect(connectionHub.subscriberCount).toBe(8);
+    await connectionHub.close();
+
+    const ownerHub = new FileDirectorySubscriptionHub({ acquireScope: async () => () => {} });
+    for (let index = 0; index < FILE_DIRECTORY_MAX_CONNECTIONS_PER_OWNER; index += 1) {
+      await ownerHub.subscribe(subscriber("owner", `connection-${index}`, "projects"));
+    }
+    await expect(ownerHub.subscribe(subscriber("owner", "connection-overflow", "projects")))
+      .rejects.toThrow(/connection limit/i);
+    expect(ownerHub.subscriberCount).toBe(32);
+    await ownerHub.close();
+  });
+
+  it("sweeps five-minute stale entries before caps and on a closeable timer", async () => {
+    vi.useFakeTimers();
+    let now = 0;
+    const releases: Array<ReturnType<typeof vi.fn>> = [];
+    const hub = new FileDirectorySubscriptionHub({
+      maxSubscriptions: 1,
+      now: () => now,
+      sweepIntervalMs: 1_000,
+      acquireScope: async () => {
+        const release = vi.fn();
+        releases.push(release);
+        return release;
+      },
+    });
+    await hub.subscribe(subscriber("owner-a", "connection-a", "projects"));
+
+    now = FILE_DIRECTORY_STALE_TTL_MS;
+    await hub.subscribe(subscriber("owner-b", "connection-b", "projects"));
+    expect(releases[0]).toHaveBeenCalledOnce();
+    expect(hub.subscriberCount).toBe(1);
+
+    now += FILE_DIRECTORY_STALE_TTL_MS;
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(releases[1]).toHaveBeenCalledOnce();
+    expect(hub.subscriberCount).toBe(0);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await hub.close();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("drains an active stale release and prevents its waiting subscribe after close", async () => {
+    let now = 0;
+    const releaseGate = deferred<void>();
+    const release = vi.fn(async () => releaseGate.promise);
+    const acquireScope = vi.fn(async () => release);
+    const hub = new FileDirectorySubscriptionHub({
+      maxSubscriptions: 1,
+      now: () => now,
+      acquireScope,
+    });
+    await hub.subscribe(subscriber("owner-a", "connection-a", "projects"));
+
+    now = FILE_DIRECTORY_STALE_TTL_MS;
+    const waitingSubscribe = hub.subscribe(subscriber("owner-b", "connection-b", "projects"));
+    await vi.waitFor(() => expect(release).toHaveBeenCalledOnce());
+    let closeSettled = false;
+    const closePromise = hub.close().then(() => { closeSettled = true; });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(closeSettled).toBe(false);
+
+    releaseGate.resolve();
+    await closePromise;
+    await expect(waitingSubscribe).rejects.toThrow("closed");
+    expect(acquireScope).toHaveBeenCalledOnce();
+    expect(hub.subscriberCount).toBe(0);
+  });
+
+  it("keeps releasing scopes inside the global resource budget", async () => {
+    const releaseGate = deferred<void>();
+    const hub = new FileDirectorySubscriptionHub({
+      maxSubscriptions: 1,
+      acquireScope: async () => async () => releaseGate.promise,
+    });
+    await hub.subscribe(subscriber("owner-a", "connection-a", "projects"));
+
+    const unsubscribePromise = hub.unsubscribe("owner-a", "connection-a", "projects");
+    await expect(hub.subscribe(subscriber("owner-b", "connection-b", "projects")))
+      .rejects.toThrow("subscription limit");
+    releaseGate.resolve();
+    await unsubscribePromise;
+    await expect(hub.subscribe(subscriber("owner-b", "connection-b", "projects")))
+      .resolves.toBe(0);
+    await hub.close();
+  });
+
+  it("drains a pending scope acquisition during close", async () => {
+    const acquisitionGate = deferred<() => void>();
+    const release = vi.fn();
+    const hub = new FileDirectorySubscriptionHub({
+      acquireScope: async () => acquisitionGate.promise,
+    });
+    const subscribePromise = hub.subscribe(subscriber("owner", "connection", "projects"));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    let closeSettled = false;
+    const closePromise = hub.close().then(() => { closeSettled = true; });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(closeSettled).toBe(false);
+
+    acquisitionGate.resolve(release);
+    await closePromise;
+    await expect(subscribePromise).rejects.toThrow(/closed|no longer active/);
+    expect(release).toHaveBeenCalledOnce();
+    expect(hub.subscriberCount).toBe(0);
+  });
+
+  it("authorizes before scope installation and resubscribes idempotently", async () => {
+    const authorize = vi.fn(async () => true);
+    const acquireScope = vi.fn(async () => vi.fn());
+    const firstSend = vi.fn();
+    const hub = new FileDirectorySubscriptionHub({ authorize, acquireScope });
+
+    expect(await hub.subscribe(subscriber("owner", "connection", "projects", firstSend))).toBe(0);
+    expect(await hub.subscribe(subscriber("owner", "connection", "projects", vi.fn()))).toBe(0);
+    expect(authorize).toHaveBeenCalledTimes(2);
+    expect(acquireScope).toHaveBeenCalledOnce();
+    expect(hub.subscriberCount).toBe(1);
+    await hub.close();
+  });
+
+  it("delivers only direct-child hints with monotonic revisions and resets on reconnect", async () => {
+    const firstSend = vi.fn();
+    const hub = new FileDirectorySubscriptionHub({ acquireScope: async () => () => {} });
+    expect(await hub.subscribe(subscriber("owner", "connection-a", "projects", firstSend))).toBe(0);
+
+    await hub.broadcast({ type: "file:change", path: "projects/demo", event: "add" });
+    await hub.broadcast({ type: "file:change", path: "projects/demo/nested.txt", event: "change" });
+    await hub.broadcast({ type: "file:change", path: "other/file.txt", event: "unlink" });
+    await hub.broadcast({ type: "file:change", path: "projects/.env", event: "change" });
+    await hub.broadcast({ type: "file:change", path: "projects/readme.md", event: "change" });
+    expect(firstSend.mock.calls.map(([message]) => JSON.parse(message))).toEqual([
+      { type: "files:change", directory: "projects", entry: "demo", event: "add", revision: 1 },
+      { type: "files:change", directory: "projects", entry: "readme.md", event: "change", revision: 2 },
+    ]);
+    expect(await hub.subscribe(subscriber("owner", "connection-a", "projects", firstSend))).toBe(2);
+
+    await hub.removeConnection("owner", "connection-a");
+    const reconnectSend = vi.fn();
+    expect(await hub.subscribe(subscriber("owner", "connection-b", "projects", reconnectSend))).toBe(0);
+    await hub.broadcast({ type: "file:change", path: "projects/again", event: "unlink" });
+    expect(JSON.parse(reconnectSend.mock.calls[0][0]).revision).toBe(1);
+    await hub.close();
+  });
+
+  it("isolates failed sends, evicts their scopes, and continues broadcasting", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const failedRelease = vi.fn();
+    const healthyRelease = vi.fn();
+    const releases = [failedRelease, healthyRelease];
+    const failedSend = vi.fn(() => { throw new Error("/private/owner/socket failed"); });
+    const healthySend = vi.fn();
+    const hub = new FileDirectorySubscriptionHub({
+      acquireScope: async () => releases.shift() ?? vi.fn(),
+    });
+    await hub.subscribe(subscriber("owner-a", "connection-a", "projects", failedSend));
+    await hub.subscribe(subscriber("owner-b", "connection-b", "projects", healthySend));
+
+    await hub.broadcast({ type: "file:change", path: "projects/readme.md", event: "change" });
+    expect(healthySend).toHaveBeenCalledOnce();
+    expect(failedRelease).toHaveBeenCalledOnce();
+    expect(healthyRelease).not.toHaveBeenCalled();
+    expect(hub.subscriberCount).toBe(1);
+
+    await hub.broadcast({ type: "file:change", path: "projects/again.md", event: "change" });
+    expect(failedSend).toHaveBeenCalledOnce();
+    expect(healthySend).toHaveBeenCalledTimes(2);
+    expect(consoleSpy.mock.calls.flat().join(" ")).not.toContain("/private/owner");
+    await hub.close();
+  });
+
+  it("removes whole connections and drains shutdown once with no post-close work", async () => {
+    const sends = [vi.fn(), vi.fn()];
+    const firstRelease = vi.fn();
+    const secondRelease = vi.fn();
+    const pendingReleases = [firstRelease, secondRelease];
+    const acquireScope = vi.fn(async () => pendingReleases.shift()!);
+    const hub = new FileDirectorySubscriptionHub({ acquireScope });
+    await hub.subscribe(subscriber("owner", "connection", "projects", sends[0]));
+    await hub.subscribe(subscriber("owner", "connection", "apps", sends[1]));
+
+    await hub.close();
+    await hub.close();
+    expect(sends.map((send) => JSON.parse(send.mock.calls[0][0]))).toEqual([
+      { type: "files:shutdown" },
+      { type: "files:shutdown" },
+    ]);
+    expect(firstRelease).toHaveBeenCalledOnce();
+    expect(secondRelease).toHaveBeenCalledOnce();
+    expect(hub.subscriberCount).toBe(0);
+    await expect(hub.subscribe(subscriber("owner", "connection", "projects")))
+      .rejects.toThrow("closed");
+    await hub.broadcast({ type: "file:change", path: "projects/nope", event: "add" });
+    expect(acquireScope).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/gateway/file-directory-subscriptions.test.ts
+++ b/tests/gateway/file-directory-subscriptions.test.ts
@@ -41,6 +41,7 @@ describe("FileDirectorySubscriptionHub", () => {
       await mkdir(join(homePath, "projects", "visible", ".hidden"), { recursive: true });
       await mkdir(join(homePath, "system"));
       await mkdir(join(homePath, "data", "browser-profiles"), { recursive: true });
+      await symlink(join(homePath, "data"), join(homePath, "projects", "data-link"));
       await writeFile(join(homePath, "readme.md"), "file");
       await symlink(outsidePath, join(homePath, "escaped"));
 
@@ -55,6 +56,7 @@ describe("FileDirectorySubscriptionHub", () => {
       await expect(authorizeFileDirectory(homePath, "data")).resolves.toBe(false);
       await expect(authorizeFileDirectory(homePath, "readme.md")).resolves.toBe(false);
       await expect(authorizeFileDirectory(homePath, "escaped")).resolves.toBe(false);
+      await expect(authorizeFileDirectory(homePath, "projects/data-link/browser-profiles")).resolves.toBe(false);
     } finally {
       await rm(homePath, { recursive: true });
       await rm(outsidePath, { recursive: true });

--- a/tests/gateway/file-directory-subscriptions.test.ts
+++ b/tests/gateway/file-directory-subscriptions.test.ts
@@ -37,6 +37,8 @@ describe("FileDirectorySubscriptionHub", () => {
     const outsidePath = await mkdtemp(join(tmpdir(), "matrix-directory-outside-"));
     try {
       await mkdir(join(homePath, "projects"));
+      await mkdir(join(homePath, "projects", ".secret"));
+      await mkdir(join(homePath, "projects", "visible", ".hidden"), { recursive: true });
       await mkdir(join(homePath, "system"));
       await mkdir(join(homePath, "data", "browser-profiles"), { recursive: true });
       await writeFile(join(homePath, "readme.md"), "file");
@@ -44,6 +46,11 @@ describe("FileDirectorySubscriptionHub", () => {
 
       await expect(authorizeFileDirectory(homePath, "")).resolves.toBe(true);
       await expect(authorizeFileDirectory(homePath, "projects")).resolves.toBe(true);
+      await expect(authorizeFileDirectory(homePath, ".secret")).resolves.toBe(false);
+      await expect(authorizeFileDirectory(homePath, "projects/.secret")).resolves.toBe(false);
+      await expect(authorizeFileDirectory(homePath, "projects/visible/.hidden")).resolves.toBe(false);
+      await expect(authorizeFileDirectory(homePath, "projects\\.secret")).resolves.toBe(false);
+      await expect(authorizeFileDirectory(homePath, "C:/projects")).resolves.toBe(false);
       await expect(authorizeFileDirectory(homePath, "system")).resolves.toBe(false);
       await expect(authorizeFileDirectory(homePath, "data")).resolves.toBe(false);
       await expect(authorizeFileDirectory(homePath, "readme.md")).resolves.toBe(false);
@@ -199,6 +206,111 @@ describe("FileDirectorySubscriptionHub", () => {
     await expect(subscribePromise).rejects.toThrow(/closed|no longer active/);
     expect(release).toHaveBeenCalledOnce();
     expect(hub.subscriberCount).toBe(0);
+  });
+
+  it("reserves before authorization so connection removal cancels pending work", async () => {
+    const authorizationGate = deferred<boolean>();
+    const acquireScope = vi.fn(async () => vi.fn());
+    const hub = new FileDirectorySubscriptionHub({
+      authorize: async () => authorizationGate.promise,
+      acquireScope,
+    });
+    const pending = hub.subscribe(subscriber("owner", "connection", "projects"));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    const removal = hub.removeConnection("owner", "connection");
+    authorizationGate.resolve(true);
+    await removal;
+    await expect(pending).rejects.toThrow(/no longer active|cancel/i);
+    expect(acquireScope).not.toHaveBeenCalled();
+    expect(hub.subscriberCount).toBe(0);
+    await hub.close();
+  });
+
+  it("lets exact unsubscribe cancel a pending authorization atomically", async () => {
+    const authorizationGate = deferred<boolean>();
+    const acquireScope = vi.fn(async () => vi.fn());
+    const hub = new FileDirectorySubscriptionHub({
+      authorize: async () => authorizationGate.promise,
+      acquireScope,
+    });
+    const pending = hub.subscribe(subscriber("owner", "connection", "projects"));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    const unsubscribe = hub.unsubscribe("owner", "connection", "projects");
+    authorizationGate.resolve(true);
+    await expect(unsubscribe).resolves.toBe(true);
+    await expect(pending).rejects.toThrow(/no longer active|cancel/i);
+    expect(acquireScope).not.toHaveBeenCalled();
+    await hub.close();
+  });
+
+  it("counts pending authorizations against global, connection, and owner caps", async () => {
+    const authorizationGate = deferred<boolean>();
+    const authorize = vi.fn(async ({ directory }: { directory: string }) => (
+      directory === "projects" ? authorizationGate.promise : true
+    ));
+    const hub = new FileDirectorySubscriptionHub({
+      authorize,
+      acquireScope: async () => vi.fn(),
+      maxSubscriptions: 3,
+      maxDirectoriesPerConnection: 1,
+      maxConnectionsPerOwner: 1,
+    });
+    const pending = hub.subscribe(subscriber("owner", "connection", "projects"));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    await expect(hub.subscribe(subscriber("owner", "connection", "other")))
+      .rejects.toThrow(/directory limit/i);
+    await expect(hub.subscribe(subscriber("owner", "other-connection", "other")))
+      .rejects.toThrow(/connection limit/i);
+    await expect(hub.subscribe(subscriber("other-owner", "other-connection", "other")))
+      .resolves.toBe(0);
+    await expect(hub.subscribe(subscriber("third-owner", "third-connection", "other")))
+      .resolves.toBe(0);
+    await expect(hub.subscribe(subscriber("overflow-owner", "overflow-connection", "other")))
+      .rejects.toThrow(/subscription limit/i);
+
+    authorizationGate.resolve(true);
+    await pending;
+    await hub.close();
+  });
+
+  it("shares one pending initialization for concurrent exact-key subscribes", async () => {
+    const authorizationGate = deferred<boolean>();
+    const authorize = vi.fn(async () => authorizationGate.promise);
+    const acquireScope = vi.fn(async () => vi.fn());
+    const hub = new FileDirectorySubscriptionHub({ authorize, acquireScope });
+    const first = hub.subscribe(subscriber("owner", "connection", "projects"));
+    const second = hub.subscribe(subscriber("owner", "connection", "projects"));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(authorize).toHaveBeenCalledOnce();
+    authorizationGate.resolve(true);
+    await expect(Promise.all([first, second])).resolves.toEqual([0, 0]);
+    expect(acquireScope).toHaveBeenCalledOnce();
+    expect(hub.subscriberCount).toBe(1);
+    await hub.close();
+  });
+
+  it("waits for and cancels authorization when close begins", async () => {
+    const authorizationGate = deferred<boolean>();
+    const acquireScope = vi.fn(async () => vi.fn());
+    const hub = new FileDirectorySubscriptionHub({
+      authorize: async () => authorizationGate.promise,
+      acquireScope,
+    });
+    const pending = hub.subscribe(subscriber("owner", "connection", "projects"));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    let closeSettled = false;
+    const closePromise = hub.close().then(() => { closeSettled = true; });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(closeSettled).toBe(false);
+
+    authorizationGate.resolve(true);
+    await closePromise;
+    await expect(pending).rejects.toThrow(/closed|no longer active|cancel/i);
+    expect(acquireScope).not.toHaveBeenCalled();
   });
 
   it("authorizes before scope installation and resubscribes idempotently", async () => {

--- a/tests/gateway/file-directory-subscriptions.test.ts
+++ b/tests/gateway/file-directory-subscriptions.test.ts
@@ -84,6 +84,20 @@ describe("FileDirectorySubscriptionHub", () => {
     await hub.close();
   });
 
+  it("binds the authorized directory identity to scope acquisition", async () => {
+    const authorization = { device: 42, inode: 84 };
+    const acquireScope = vi.fn(async () => () => {});
+    const hub = new FileDirectorySubscriptionHub({
+      authorize: async () => authorization,
+      acquireScope,
+    });
+
+    await hub.subscribe(subscriber("owner-a", "connection-a", "projects"));
+
+    expect(acquireScope).toHaveBeenCalledWith("projects", authorization);
+    await hub.close();
+  });
+
   it("enforces the exact default global, per-connection, and per-owner bounds", async () => {
     const globalHub = new FileDirectorySubscriptionHub({ acquireScope: async () => () => {} });
     for (let index = 0; index < FILE_DIRECTORY_MAX_SUBSCRIPTIONS; index += 1) {

--- a/tests/gateway/file-directory-ws-integration.test.ts
+++ b/tests/gateway/file-directory-ws-integration.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import WebSocket from "ws";
+import { startTestGateway } from "../e2e/fixtures/gateway.js";
+
+function waitForOpen(socket: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    socket.once("open", resolve);
+    socket.once("error", reject);
+  });
+}
+
+function waitForClose(socket: WebSocket): Promise<void> {
+  return new Promise((resolve) => socket.once("close", () => resolve()));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("production main websocket file-directory lifecycle", () => {
+  it("keeps ownerless sockets usable while rejecting file and sync scopes", async () => {
+    vi.stubEnv("MATRIX_AUTH_TOKEN", "legacy-static-token");
+    vi.stubEnv("MATRIX_USER_ID", "");
+    const gateway = await startTestGateway({ authToken: "legacy-static-token" });
+    const socket = new WebSocket(`${gateway.url.replace("http", "ws")}/ws?token=legacy-static-token`);
+    const messages: Array<Record<string, unknown>> = [];
+    const closed = waitForClose(socket);
+    socket.on("message", (data) => messages.push(JSON.parse(data.toString()) as Record<string, unknown>));
+
+    try {
+      await waitForOpen(socket);
+      socket.send(JSON.stringify({ type: "ping" }));
+      socket.send(JSON.stringify({ type: "files:subscribe", directory: "projects" }));
+      socket.send(JSON.stringify({ type: "files:subscribe", directory: "../outside" }));
+      socket.send(JSON.stringify({
+        type: "sync:subscribe",
+        peerId: "peer",
+        hostname: "host",
+        platform: "linux",
+        clientVersion: "1",
+      }));
+
+      await vi.waitFor(() => {
+        expect(messages).toEqual(expect.arrayContaining([
+          { type: "pong" },
+          { type: "kernel:error", message: "File directory subscription failed" },
+          { type: "kernel:error", message: "Sync subscription failed" },
+        ]));
+        expect(messages.filter((message) => message.message === "File directory subscription failed")).toHaveLength(2);
+      });
+      expect(socket.readyState).toBe(WebSocket.OPEN);
+    } finally {
+      if (socket.readyState !== WebSocket.CLOSED) socket.close();
+      await closed;
+      await gateway.close();
+    }
+  }, 30_000);
+
+  it("releases configured-owner subscriptions on every production websocket close", async () => {
+    vi.stubEnv("MATRIX_AUTH_TOKEN", "legacy-static-token");
+    vi.stubEnv("MATRIX_USER_ID", "configured-owner");
+    const gateway = await startTestGateway({ authToken: "legacy-static-token" });
+
+    try {
+      for (let index = 0; index < 33; index += 1) {
+        const socket = new WebSocket(`${gateway.url.replace("http", "ws")}/ws?token=legacy-static-token`);
+        const messages: Array<Record<string, unknown>> = [];
+        const closed = waitForClose(socket);
+        socket.on("message", (data) => messages.push(JSON.parse(data.toString()) as Record<string, unknown>));
+        await waitForOpen(socket);
+        socket.send(JSON.stringify({ type: "files:subscribe", directory: "projects" }));
+        await vi.waitFor(() => {
+          expect(messages).toContainEqual(expect.objectContaining({
+            type: "files:subscribed",
+            directory: "projects",
+          }));
+        });
+        socket.close();
+        await closed;
+      }
+    } finally {
+      await gateway.close();
+    }
+  }, 30_000);
+});

--- a/tests/gateway/file-directory-ws.test.ts
+++ b/tests/gateway/file-directory-ws.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import { authMiddleware } from "../../packages/gateway/src/auth.js";
-import { FileDirectorySubscriptionHub } from "../../packages/gateway/src/file-management/directory-subscriptions.js";
+import {
+  FILE_DIRECTORY_STALE_TTL_MS,
+  FileDirectorySubscriptionHub,
+} from "../../packages/gateway/src/file-management/directory-subscriptions.js";
 import { issueSyncJwt } from "../../packages/platform/src/sync-jwt.js";
 import * as fileDirectoryWs from "../../packages/gateway/src/server/file-directory-ws.js";
 import {
@@ -322,6 +325,45 @@ describe("main websocket file-directory behavior", () => {
     acquisition.resolve(release);
     await closePromise;
     expect(release).toHaveBeenCalledOnce();
+    expect(hub.subscriberCount).toBe(0);
+    await hub.close();
+  });
+
+  it("cleans a subscription reserved after close waits on a stale sweep", async () => {
+    let now = 0;
+    const staleReleaseGate = deferred<void>();
+    const staleRelease = vi.fn(async () => staleReleaseGate.promise);
+    const lateRelease = vi.fn();
+    const acquireScope = vi.fn()
+      .mockResolvedValueOnce(staleRelease)
+      .mockResolvedValueOnce(lateRelease);
+    const hub = new FileDirectorySubscriptionHub({
+      maxSubscriptions: 1,
+      now: () => now,
+      acquireScope,
+    });
+    await hub.subscribe({
+      ownerId: "stale-owner",
+      connectionId: "stale-connection",
+      directory: "projects",
+      send: vi.fn(),
+    });
+    now = FILE_DIRECTORY_STALE_TTL_MS;
+    const connection = createFileDirectoryWsConnection({
+      ownerId: "owner",
+      connectionId: "connection",
+      hub,
+      send: vi.fn(),
+      closeSocket: vi.fn(),
+    });
+    connection.enqueue({ type: "files:subscribe", directory: "projects" });
+    await vi.waitFor(() => expect(staleRelease).toHaveBeenCalledOnce());
+
+    const closePromise = connection.close();
+    staleReleaseGate.resolve();
+    await closePromise;
+    expect(acquireScope).toHaveBeenCalledTimes(2);
+    expect(lateRelease).toHaveBeenCalledOnce();
     expect(hub.subscriberCount).toBe(0);
     await hub.close();
   });

--- a/tests/gateway/file-directory-ws.test.ts
+++ b/tests/gateway/file-directory-ws.test.ts
@@ -269,13 +269,81 @@ describe("main websocket file-directory behavior", () => {
     authorization.resolve(true);
     await connection.close();
     expect(hub.subscriberCount).toBe(0);
+    expect(release).not.toHaveBeenCalled();
+  });
+
+  it("cancels pending authorization synchronously when socket close begins", async () => {
+    const authorization = deferred<boolean>();
+    const acquireScope = vi.fn(async () => vi.fn());
+    const hub = new FileDirectorySubscriptionHub({
+      authorize: async () => authorization.promise,
+      acquireScope,
+    });
+    const removeConnection = vi.spyOn(hub, "removeConnection");
+    const connection = createFileDirectoryWsConnection({
+      ownerId: "owner",
+      connectionId: "connection",
+      hub,
+      send: vi.fn(),
+      closeSocket: vi.fn(),
+    });
+    connection.enqueue({ type: "files:subscribe", directory: "projects" });
+    await flushAsyncWork();
+
+    const closePromise = connection.close();
+    expect(removeConnection).toHaveBeenCalledOnce();
+    expect(hub.touch("owner", "connection", "projects")).toBe(false);
+    expect(hub.subscriberCount).toBe(1);
+    authorization.resolve(true);
+    await closePromise;
+    expect(acquireScope).not.toHaveBeenCalled();
+    expect(hub.subscriberCount).toBe(0);
+    await hub.close();
+  });
+
+  it("releases an acquisition that commits after socket close begins", async () => {
+    const acquisition = deferred<() => void>();
+    const release = vi.fn();
+    const hub = new FileDirectorySubscriptionHub({
+      acquireScope: async () => acquisition.promise,
+    });
+    const connection = createFileDirectoryWsConnection({
+      ownerId: "owner",
+      connectionId: "connection",
+      hub,
+      send: vi.fn(),
+      closeSocket: vi.fn(),
+    });
+    connection.enqueue({ type: "files:subscribe", directory: "projects" });
+    await flushAsyncWork();
+
+    const closePromise = connection.close();
+    expect(hub.touch("owner", "connection", "projects")).toBe(false);
+    acquisition.resolve(release);
+    await closePromise;
     expect(release).toHaveBeenCalledOnce();
+    expect(hub.subscriberCount).toBe(0);
+    await hub.close();
   });
 
   it("detects only files-prefixed malformed frames for generic-close handling", () => {
     expect(isFileDirectoryFrameCandidate({ type: "files:subscribe", directory: "/bad" })).toBe(true);
     expect(isFileDirectoryFrameCandidate({ type: "ping", extra: true })).toBe(false);
     expect(isFileDirectoryFrameCandidate(null)).toBe(false);
+  });
+
+  it("exposes the onClose lifecycle callback used by the websocket route", async () => {
+    const createLifecycle = Reflect.get(fileDirectoryWs, "createFileDirectoryWsLifecycle");
+    expect(createLifecycle).toBeTypeOf("function");
+    if (typeof createLifecycle !== "function") return;
+    const closeGate = deferred<void>();
+    const close = vi.fn(async () => closeGate.promise);
+    const lifecycle = createLifecycle({ close });
+
+    const closeResult = lifecycle.onClose();
+    expect(close).toHaveBeenCalledOnce();
+    closeGate.resolve();
+    await closeResult;
   });
 
   it("binds one watcher listener and shuts the hub down before the shared watcher", async () => {

--- a/tests/gateway/file-directory-ws.test.ts
+++ b/tests/gateway/file-directory-ws.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { authMiddleware } from "../../packages/gateway/src/auth.js";
 import {
   FILE_DIRECTORY_STALE_TTL_MS,
@@ -11,6 +13,7 @@ import {
   bindFileDirectoryWatcher,
   closeFileDirectoryResources,
   createFileDirectoryWsConnection,
+  createOptionalAuthenticatedFileDirectoryWsConnection,
   isFileDirectoryFrameCandidate,
 } from "../../packages/gateway/src/server/file-directory-ws.js";
 
@@ -30,6 +33,33 @@ afterEach(() => {
 });
 
 describe("main websocket file-directory behavior", () => {
+  it("keeps a legacy static-token websocket usable without granting file subscriptions", async () => {
+    vi.stubEnv("MATRIX_AUTH_TOKEN", "legacy-static-token");
+    const hub = new FileDirectorySubscriptionHub({ acquireScope: async () => () => {} });
+    const app = new Hono();
+    app.use("*", authMiddleware("legacy-static-token"));
+    app.get("/ws", (c) => c.json({
+      hasFileConnection: createOptionalAuthenticatedFileDirectoryWsConnection(c, {
+        connectionId: "connection",
+        hub,
+        send: vi.fn(),
+        closeSocket: vi.fn(),
+      }) !== null,
+    }));
+
+    const response = await app.request("/ws?token=legacy-static-token");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ hasFileConnection: false });
+    await hub.close();
+  });
+
+  it("wires the optional principal seam into the production main websocket", () => {
+    const source = readFileSync(join(process.cwd(), "packages/gateway/src/server.ts"), "utf8");
+    expect(source).toContain("createOptionalAuthenticatedFileDirectoryWsConnection(c");
+    expect(source).not.toContain("const wsOwnerId = requireRequestPrincipal(c).userId");
+  });
+
   it("derives the websocket owner from real JWT middleware and removes it on close", async () => {
     const createAuthenticatedConnection = Reflect.get(
       fileDirectoryWs,

--- a/tests/gateway/file-directory-ws.test.ts
+++ b/tests/gateway/file-directory-ws.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import { authMiddleware } from "../../packages/gateway/src/auth.js";
 import { FileDirectorySubscriptionHub } from "../../packages/gateway/src/file-management/directory-subscriptions.js";
+import { issueSyncJwt } from "../../packages/platform/src/sync-jwt.js";
+import * as fileDirectoryWs from "../../packages/gateway/src/server/file-directory-ws.js";
 import {
   bindFileDirectoryWatcher,
   closeFileDirectoryResources,
@@ -19,9 +23,75 @@ async function flushAsyncWork(): Promise<void> {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 describe("main websocket file-directory behavior", () => {
+  it("derives the websocket owner from real JWT middleware and removes it on close", async () => {
+    const createAuthenticatedConnection = Reflect.get(
+      fileDirectoryWs,
+      "createAuthenticatedFileDirectoryWsConnection",
+    );
+    expect(createAuthenticatedConnection).toBeTypeOf("function");
+    if (typeof createAuthenticatedConnection !== "function") return;
+
+    const jwtSecret = "file-directory-ws-test-secret-32-chars";
+    vi.stubEnv("PLATFORM_JWT_SECRET", jwtSecret);
+    vi.stubEnv("MATRIX_HANDLE", "alice");
+    vi.stubEnv("MATRIX_RUNTIME_SLOT", "primary");
+    const issued = await issueSyncJwt({
+      secret: jwtSecret,
+      clerkUserId: "canonical-owner",
+      handle: "alice",
+      gatewayUrl: "https://app.matrix-os.com/vm/alice",
+      runtimeSlot: "primary",
+    });
+    const authorize = vi.fn(async ({ ownerId }: { ownerId: string }) => ownerId === "canonical-owner");
+    const hub = new FileDirectorySubscriptionHub({
+      authorize,
+      acquireScope: async () => () => {},
+    });
+    const removeConnection = vi.spyOn(hub, "removeConnection");
+    const sent: string[] = [];
+    let routeCalls = 0;
+    const app = new Hono();
+    app.use("*", authMiddleware("legacy-shared-secret"));
+    app.get("/ws", async (c) => {
+      routeCalls += 1;
+      const connection = createAuthenticatedConnection(c, {
+        connectionId: "server-connection",
+        hub,
+        send: (message: string) => { sent.push(message); },
+        closeSocket: vi.fn(),
+      });
+      connection.enqueue({ type: "files:subscribe", directory: "projects" });
+      await connection.idle();
+      await connection.close();
+      return c.json({ ok: true });
+    });
+
+    const unauthenticated = await app.request("/ws?ownerId=forged-owner");
+    expect(unauthenticated.status).toBe(401);
+    expect(routeCalls).toBe(0);
+
+    const authenticated = await app.request(
+      `/ws?token=${encodeURIComponent(issued.token)}&ownerId=forged-owner`,
+    );
+    expect(authenticated.status).toBe(200);
+    expect(routeCalls).toBe(1);
+    expect(authorize).toHaveBeenCalledWith(expect.objectContaining({
+      ownerId: "canonical-owner",
+    }));
+    expect(authorize).not.toHaveBeenCalledWith(expect.objectContaining({ ownerId: "forged-owner" }));
+    expect(removeConnection).toHaveBeenCalledWith("canonical-owner", "server-connection");
+    expect(sent.map((message) => JSON.parse(message))).toContainEqual({
+      type: "files:subscribed",
+      directory: "projects",
+      revision: 0,
+    });
+    await hub.close();
+  });
+
   it("binds subscriptions to the canonical principal and awaits authorization before ack", async () => {
     const authorization = deferred<boolean>();
     const send = vi.fn();

--- a/tests/gateway/file-directory-ws.test.ts
+++ b/tests/gateway/file-directory-ws.test.ts
@@ -1,7 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { authMiddleware } from "../../packages/gateway/src/auth.js";
 import {
   FILE_DIRECTORY_STALE_TTL_MS,
@@ -13,7 +11,7 @@ import {
   bindFileDirectoryWatcher,
   closeFileDirectoryResources,
   createFileDirectoryWsConnection,
-  createOptionalAuthenticatedFileDirectoryWsConnection,
+  createMainWsFileDirectoryRouter,
   isFileDirectoryFrameCandidate,
 } from "../../packages/gateway/src/server/file-directory-ws.js";
 
@@ -35,29 +33,34 @@ afterEach(() => {
 describe("main websocket file-directory behavior", () => {
   it("keeps a legacy static-token websocket usable without granting file subscriptions", async () => {
     vi.stubEnv("MATRIX_AUTH_TOKEN", "legacy-static-token");
+    vi.stubEnv("MATRIX_USER_ID", "");
     const hub = new FileDirectorySubscriptionHub({ acquireScope: async () => () => {} });
+    const send = vi.fn();
     const app = new Hono();
     app.use("*", authMiddleware("legacy-static-token"));
-    app.get("/ws", (c) => c.json({
-      hasFileConnection: createOptionalAuthenticatedFileDirectoryWsConnection(c, {
+    app.get("/ws", async (c) => {
+      const router = createMainWsFileDirectoryRouter(c, {
         connectionId: "connection",
         hub,
-        send: vi.fn(),
+        send,
         closeSocket: vi.fn(),
-      }) !== null,
-    }));
+      });
+      router.handleFrame({ type: "files:subscribe", directory: "projects" });
+      router.rejectInvalidFrame();
+      await router.close();
+      return c.json({ subscriberCount: hub.subscriberCount });
+    });
 
     const response = await app.request("/ws?token=legacy-static-token");
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ hasFileConnection: false });
+    await expect(response.json()).resolves.toEqual({ subscriberCount: 0 });
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send.mock.calls.map(([message]) => JSON.parse(message))).toEqual([
+      { type: "kernel:error", message: "File directory subscription failed" },
+      { type: "kernel:error", message: "File directory subscription failed" },
+    ]);
     await hub.close();
-  });
-
-  it("wires the optional principal seam into the production main websocket", () => {
-    const source = readFileSync(join(process.cwd(), "packages/gateway/src/server.ts"), "utf8");
-    expect(source).toContain("createOptionalAuthenticatedFileDirectoryWsConnection(c");
-    expect(source).not.toContain("const wsOwnerId = requireRequestPrincipal(c).userId");
   });
 
   it("derives the websocket owner from real JWT middleware and removes it on close", async () => {

--- a/tests/gateway/file-directory-ws.test.ts
+++ b/tests/gateway/file-directory-ws.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FileDirectorySubscriptionHub } from "../../packages/gateway/src/file-management/directory-subscriptions.js";
+import {
+  bindFileDirectoryWatcher,
+  closeFileDirectoryResources,
+  createFileDirectoryWsConnection,
+  isFileDirectoryFrameCandidate,
+} from "../../packages/gateway/src/server/file-directory-ws.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => { resolve = next; });
+  return { promise, resolve };
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("main websocket file-directory behavior", () => {
+  it("binds subscriptions to the canonical principal and awaits authorization before ack", async () => {
+    const authorization = deferred<boolean>();
+    const send = vi.fn();
+    const hub = new FileDirectorySubscriptionHub({
+      authorize: vi.fn(async ({ ownerId }) => {
+        expect(ownerId).toBe("canonical-owner");
+        return authorization.promise;
+      }),
+      acquireScope: async () => () => {},
+    });
+    const connection = createFileDirectoryWsConnection({
+      ownerId: "canonical-owner",
+      connectionId: "connection-a",
+      hub,
+      send,
+      closeSocket: vi.fn(),
+    });
+
+    expect(connection.enqueue({ type: "files:subscribe", directory: "projects" })).toBe(true);
+    await flushAsyncWork();
+    expect(send).not.toHaveBeenCalled();
+    authorization.resolve(true);
+    await connection.idle();
+    expect(send).toHaveBeenCalledWith(JSON.stringify({
+      type: "files:subscribed",
+      directory: "projects",
+      revision: 0,
+    }));
+    await connection.close();
+    await hub.close();
+  });
+
+  it("serializes subscribe, touch, and unsubscribe in arrival order", async () => {
+    const operations: string[] = [];
+    const hub = new FileDirectorySubscriptionHub({
+      authorize: async () => {
+        operations.push("authorize");
+        return true;
+      },
+      acquireScope: async () => {
+        operations.push("acquire");
+        return async () => { operations.push("release"); };
+      },
+    });
+    const connection = createFileDirectoryWsConnection({
+      ownerId: "owner",
+      connectionId: "connection",
+      hub,
+      send: vi.fn(() => { operations.push("ack"); }),
+      closeSocket: vi.fn(),
+    });
+
+    connection.enqueue({ type: "files:subscribe", directory: "projects" });
+    connection.enqueue({ type: "files:touch", directory: "projects" });
+    connection.enqueue({ type: "files:unsubscribe", directory: "projects" });
+    await connection.idle();
+    expect(operations).toEqual(["authorize", "acquire", "ack", "release"]);
+    expect(hub.subscriberCount).toBe(0);
+    await connection.close();
+    await hub.close();
+  });
+
+  it("closes generically on authorization errors without leaking raw paths", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const send = vi.fn();
+    const closeSocket = vi.fn();
+    const hub = new FileDirectorySubscriptionHub({
+      authorize: async () => { throw new Error("EACCES /home/private/projects"); },
+      acquireScope: async () => () => {},
+    });
+    const connection = createFileDirectoryWsConnection({
+      ownerId: "owner",
+      connectionId: "connection",
+      hub,
+      send,
+      closeSocket,
+    });
+
+    connection.enqueue({ type: "files:subscribe", directory: "projects" });
+    await connection.idle();
+    expect(send).toHaveBeenCalledWith(JSON.stringify({
+      type: "kernel:error",
+      message: "File directory subscription failed",
+    }));
+    expect(JSON.stringify(send.mock.calls)).not.toContain("/home/private");
+    expect(closeSocket).toHaveBeenCalledOnce();
+    expect(consoleSpy).toHaveBeenCalled();
+    await connection.close();
+    await hub.close();
+  });
+
+  it("closes generically for invalid file frames", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const send = vi.fn();
+    const closeSocket = vi.fn();
+    const hub = new FileDirectorySubscriptionHub({ acquireScope: async () => () => {} });
+    const connection = createFileDirectoryWsConnection({
+      ownerId: "owner",
+      connectionId: "connection",
+      hub,
+      send,
+      closeSocket,
+    });
+
+    connection.rejectInvalidFrame();
+    expect(send).toHaveBeenCalledWith(JSON.stringify({
+      type: "kernel:error",
+      message: "File directory subscription failed",
+    }));
+    expect(closeSocket).toHaveBeenCalledOnce();
+    expect(connection.enqueue({ type: "files:subscribe", directory: "projects" })).toBe(false);
+    await connection.close();
+    await hub.close();
+    consoleSpy.mockRestore();
+  });
+
+  it("resets the acknowledged revision on a new websocket connection", async () => {
+    const hub = new FileDirectorySubscriptionHub({ acquireScope: async () => () => {} });
+    const firstSend = vi.fn();
+    const first = createFileDirectoryWsConnection({
+      ownerId: "owner",
+      connectionId: "connection-a",
+      hub,
+      send: firstSend,
+      closeSocket: vi.fn(),
+    });
+    first.enqueue({ type: "files:subscribe", directory: "projects" });
+    await first.idle();
+    await hub.broadcast({ type: "file:change", path: "projects/readme.md", event: "change" });
+    await first.close();
+
+    const secondSend = vi.fn();
+    const second = createFileDirectoryWsConnection({
+      ownerId: "owner",
+      connectionId: "connection-b",
+      hub,
+      send: secondSend,
+      closeSocket: vi.fn(),
+    });
+    second.enqueue({ type: "files:subscribe", directory: "projects" });
+    await second.idle();
+    expect(JSON.parse(secondSend.mock.calls[0][0])).toEqual({
+      type: "files:subscribed",
+      directory: "projects",
+      revision: 0,
+    });
+    await second.close();
+    await hub.close();
+  });
+
+  it("bounds pending async frames and cleans up on socket close", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const authorization = deferred<boolean>();
+    const send = vi.fn();
+    const closeSocket = vi.fn();
+    const release = vi.fn();
+    const hub = new FileDirectorySubscriptionHub({
+      authorize: async () => authorization.promise,
+      acquireScope: async () => release,
+    });
+    const connection = createFileDirectoryWsConnection({
+      ownerId: "owner",
+      connectionId: "connection",
+      hub,
+      send,
+      closeSocket,
+      maxPendingFrames: 2,
+    });
+
+    expect(connection.enqueue({ type: "files:subscribe", directory: "projects" })).toBe(true);
+    await flushAsyncWork();
+    expect(connection.enqueue({ type: "files:touch", directory: "projects" })).toBe(true);
+    expect(connection.enqueue({ type: "files:touch", directory: "projects" })).toBe(false);
+    expect(closeSocket).toHaveBeenCalledOnce();
+    authorization.resolve(true);
+    await connection.close();
+    expect(hub.subscriberCount).toBe(0);
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("detects only files-prefixed malformed frames for generic-close handling", () => {
+    expect(isFileDirectoryFrameCandidate({ type: "files:subscribe", directory: "/bad" })).toBe(true);
+    expect(isFileDirectoryFrameCandidate({ type: "ping", extra: true })).toBe(false);
+    expect(isFileDirectoryFrameCandidate(null)).toBe(false);
+  });
+
+  it("binds one watcher listener and shuts the hub down before the shared watcher", async () => {
+    const order: string[] = [];
+    const listeners: Array<(event: { type: "file:change"; path: string; event: "add" }) => void> = [];
+    const watcher = {
+      on: vi.fn((listener) => { listeners.push(listener); }),
+      acquireDirectoryScope: vi.fn(async () => () => {}),
+      close: vi.fn(async () => { order.push("watcher"); }),
+    };
+    const hub = new FileDirectorySubscriptionHub({
+      acquireScope: (directory) => watcher.acquireDirectoryScope(directory),
+    });
+    const hubClose = vi.spyOn(hub, "close").mockImplementation(async () => { order.push("hub"); });
+
+    bindFileDirectoryWatcher(hub, watcher);
+    expect(watcher.on).toHaveBeenCalledOnce();
+    expect(listeners).toHaveLength(1);
+    await closeFileDirectoryResources(hub, watcher);
+    expect(order).toEqual(["hub", "watcher"]);
+    expect(hubClose).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/gateway/sync/ws-peer-lifecycle.test.ts
+++ b/tests/gateway/sync/ws-peer-lifecycle.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
-import { createSyncPeerLifecycle } from "../../../packages/gateway/src/sync/ws-peer-lifecycle.js";
+import {
+  createSyncPeerLifecycle,
+  subscribeSyncPeerOrReject,
+} from "../../../packages/gateway/src/sync/ws-peer-lifecycle.js";
 
 function createRegistry() {
   return {
@@ -13,6 +16,30 @@ function createRegistry() {
 }
 
 describe("createSyncPeerLifecycle", () => {
+  it("rejects subscription failures with a coarse diagnostic", () => {
+    const reject = vi.fn();
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const lifecycle = {
+      subscribe: vi.fn(() => {
+        throw new Error("sensitive peer failure");
+      }),
+      close: vi.fn(),
+    };
+
+    expect(subscribeSyncPeerOrReject(lifecycle, {
+      peerId: "peer-1",
+      hostname: "mbp",
+      platform: "darwin",
+      clientVersion: "0.1.0",
+    }, reject)).toBe(false);
+
+    expect(reject).toHaveBeenCalledOnce();
+    expect(error).toHaveBeenCalledWith("[sync/realtime] Peer subscription failed", {
+      errorKind: "Error",
+    });
+    expect(JSON.stringify(error.mock.calls)).not.toContain("sensitive peer failure");
+  });
+
   it("proxies the live websocket readyState when registering peers", () => {
     const registry = createRegistry();
     const ws = {

--- a/tests/gateway/watcher.test.ts
+++ b/tests/gateway/watcher.test.ts
@@ -313,6 +313,32 @@ describe("gateway home watcher", () => {
     await rm(homePath, { recursive: true });
   });
 
+  it("correlates every opposite-source token in both source orders", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-watcher-"));
+    const fake = createFakeWatcherFactory();
+    const watcher = createWatcher(homePath, { watchFactory: fake.factory });
+    const listener = vi.fn();
+    watcher.on(listener);
+    const release = await watcher.acquireDirectoryScope("");
+    const claudePath = join(homePath, "CLAUDE.md");
+
+    fake.backends[0].emit("change", claudePath);
+    fake.backends[0].emit("change", claudePath);
+    fake.backends[1].emit("change", claudePath);
+    fake.backends[1].emit("change", claudePath);
+    fake.backends[1].emit("unlink", claudePath);
+    fake.backends[1].emit("unlink", claudePath);
+    fake.backends[0].emit("unlink", claudePath);
+    fake.backends[0].emit("unlink", claudePath);
+    expect(listener.mock.calls.map(([event]) => event.event)).toEqual([
+      "change", "change", "unlink", "unlink",
+    ]);
+
+    await release();
+    await watcher.close();
+    await rm(homePath, { recursive: true });
+  });
+
   it("does not correlate opposite-source root hints after the bounded window", async () => {
     let now = 0;
     const homePath = await mkdtemp(join(tmpdir(), "matrix-watcher-"));

--- a/tests/gateway/watcher.test.ts
+++ b/tests/gateway/watcher.test.ts
@@ -243,12 +243,15 @@ describe("gateway home watcher", () => {
     await vi.waitFor(() => expect(validateDirectoryScope).toHaveBeenCalledOnce());
 
     let closeSettled = false;
-    const closePromise = watcher.close().then(() => { closeSettled = true; });
+    const closeDrain = watcher.close();
+    const closePromise = closeDrain.then(() => { closeSettled = true; });
+    const sharedClosePromise = watcher.close();
     await new Promise<void>((resolve) => setImmediate(resolve));
     expect(closeSettled).toBe(false);
+    expect(sharedClosePromise).toBe(closeDrain);
     validationGate.resolve(join(homePath, "projects"));
 
-    await closePromise;
+    await Promise.all([closePromise, sharedClosePromise]);
     await expect(acquisition).rejects.toThrow("closed");
     await expect(duplicateAcquisition).rejects.toThrow("closed");
     expect(validateDirectoryScope).toHaveBeenCalledOnce();
@@ -270,12 +273,63 @@ describe("gateway home watcher", () => {
     fake.backends[1].emit("add", join(homePath, "notes.txt"));
     fake.backends[1].emit("addDir", join(homePath, "projects"));
     fake.backends[1].emit("unlinkDir", join(homePath, "projects"));
+    fake.backends[0].emit("unlinkDir", join(homePath, "apps"));
+    fake.backends[1].emit("unlinkDir", join(homePath, "apps"));
+    fake.backends[1].emit("addDir", join(homePath, "apps"));
+    fake.backends[0].emit("addDir", join(homePath, "apps"));
     expect(listener.mock.calls.map(([event]) => event)).toEqual([
       { type: "file:change", path: "CLAUDE.md", event: "change" },
       { type: "file:change", path: "notes.txt", event: "add" },
       { type: "file:change", path: "projects", event: "add" },
       { type: "file:change", path: "projects", event: "unlink" },
+      { type: "file:change", path: "apps", event: "unlink" },
+      { type: "file:change", path: "apps", event: "add" },
     ]);
+
+    await release();
+    await watcher.close();
+    await rm(homePath, { recursive: true });
+  });
+
+  it("keeps unmatched, same-source, and different-event root hints", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-watcher-"));
+    const fake = createFakeWatcherFactory();
+    const watcher = createWatcher(homePath, { watchFactory: fake.factory });
+    const listener = vi.fn();
+    watcher.on(listener);
+    const release = await watcher.acquireDirectoryScope("");
+
+    fake.backends[1].emit("change", join(homePath, "CLAUDE.md"));
+    fake.backends[1].emit("change", join(homePath, "CLAUDE.md"));
+    fake.backends[1].emit("unlink", join(homePath, "CLAUDE.md"));
+    expect(listener.mock.calls.map(([event]) => event)).toEqual([
+      { type: "file:change", path: "CLAUDE.md", event: "change" },
+      { type: "file:change", path: "CLAUDE.md", event: "change" },
+      { type: "file:change", path: "CLAUDE.md", event: "unlink" },
+    ]);
+
+    await release();
+    await watcher.close();
+    await rm(homePath, { recursive: true });
+  });
+
+  it("does not correlate opposite-source root hints after the bounded window", async () => {
+    let now = 0;
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-watcher-"));
+    const fake = createFakeWatcherFactory();
+    const watcher = createWatcher(homePath, {
+      watchFactory: fake.factory,
+      now: () => now,
+      rootCorrelationWindowMs: 100,
+    });
+    const listener = vi.fn();
+    watcher.on(listener);
+    const release = await watcher.acquireDirectoryScope("");
+
+    fake.backends[0].emit("change", join(homePath, "CLAUDE.md"));
+    now = 101;
+    fake.backends[1].emit("change", join(homePath, "CLAUDE.md"));
+    expect(listener).toHaveBeenCalledTimes(2);
 
     await release();
     await watcher.close();

--- a/tests/gateway/watcher.test.ts
+++ b/tests/gateway/watcher.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { watch as chokidarWatch } from "chokidar";
 import {
   createWatcher,
   createWatcherIgnored,
@@ -224,6 +225,85 @@ describe("gateway home watcher", () => {
     await Promise.all([releasePromise, closePromise]);
     expect(fake.backends[1].close).toHaveBeenCalledOnce();
     expect(fake.backends[0].close).toHaveBeenCalledOnce();
+    await rm(homePath, { recursive: true });
+  });
+
+  it("drains gated scope validation and prevents a late backend after close", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-watcher-"));
+    await mkdir(join(homePath, "projects"));
+    const fake = createFakeWatcherFactory();
+    const validationGate = deferred<string>();
+    const validateDirectoryScope = vi.fn(async () => validationGate.promise);
+    const watcher = createWatcher(homePath, {
+      watchFactory: fake.factory,
+      validateDirectoryScope,
+    } as never);
+    const acquisition = watcher.acquireDirectoryScope("projects");
+    const duplicateAcquisition = watcher.acquireDirectoryScope("projects");
+    await vi.waitFor(() => expect(validateDirectoryScope).toHaveBeenCalledOnce());
+
+    let closeSettled = false;
+    const closePromise = watcher.close().then(() => { closeSettled = true; });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(closeSettled).toBe(false);
+    validationGate.resolve(join(homePath, "projects"));
+
+    await closePromise;
+    await expect(acquisition).rejects.toThrow("closed");
+    await expect(duplicateAcquisition).rejects.toThrow("closed");
+    expect(validateDirectoryScope).toHaveBeenCalledOnce();
+    expect(fake.backends).toHaveLength(1);
+    expect(fake.backends[0].close).toHaveBeenCalledOnce();
+    await rm(homePath, { recursive: true });
+  });
+
+  it("suppresses only exact root overlap emitted by global and scoped backends", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-watcher-"));
+    const fake = createFakeWatcherFactory();
+    const watcher = createWatcher(homePath, { watchFactory: fake.factory });
+    const listener = vi.fn();
+    watcher.on(listener);
+    const release = await watcher.acquireDirectoryScope("");
+
+    fake.backends[0].emit("change", join(homePath, "CLAUDE.md"));
+    fake.backends[1].emit("change", join(homePath, "CLAUDE.md"));
+    fake.backends[1].emit("add", join(homePath, "notes.txt"));
+    fake.backends[1].emit("addDir", join(homePath, "projects"));
+    fake.backends[1].emit("unlinkDir", join(homePath, "projects"));
+    expect(listener.mock.calls.map(([event]) => event)).toEqual([
+      { type: "file:change", path: "CLAUDE.md", event: "change" },
+      { type: "file:change", path: "notes.txt", event: "add" },
+      { type: "file:change", path: "projects", event: "add" },
+      { type: "file:change", path: "projects", event: "unlink" },
+    ]);
+
+    await release();
+    await watcher.close();
+    await rm(homePath, { recursive: true });
+  });
+
+  it("emits one real hint for a root file covered by both watcher backends", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-watcher-real-"));
+    await writeFile(join(homePath, "CLAUDE.md"), "one");
+    const ready: Array<Promise<void>> = [];
+    const realFactory: WatcherFactory = (paths, options) => {
+      const backend = chokidarWatch(paths, { ...options, usePolling: false });
+      ready.push(new Promise<void>((resolve) => { backend.once("ready", () => resolve()); }));
+      return backend as WatcherBackend;
+    };
+    const watcher = createWatcher(homePath, { watchFactory: realFactory });
+    const listener = vi.fn();
+    watcher.on(listener);
+    const release = await watcher.acquireDirectoryScope("");
+    await Promise.all(ready);
+
+    await writeFile(join(homePath, "CLAUDE.md"), "two");
+    await vi.waitFor(() => {
+      expect(listener.mock.calls.filter(([event]) => event.path === "CLAUDE.md")).toHaveLength(1);
+    }, { timeout: 2_000 });
+
+    await release();
+    await watcher.close();
     await rm(homePath, { recursive: true });
   });
 

--- a/tests/gateway/watcher.test.ts
+++ b/tests/gateway/watcher.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { watch as chokidarWatch } from "chokidar";
@@ -10,6 +10,7 @@ import {
   type WatcherBackend,
   type WatcherFactory,
 } from "../../packages/gateway/src/watcher.js";
+import { authorizeFileDirectoryScope } from "../../packages/gateway/src/file-management/directory-subscriptions.js";
 
 function createFakeWatcherFactory() {
   const backends: Array<WatcherBackend & {
@@ -139,6 +140,28 @@ describe("gateway home watcher", () => {
 
     await release();
     expect(fake.backends[1].unwatch).toHaveBeenCalledWith(join(homePath, "projects"));
+    await watcher.close();
+    await rm(homePath, { recursive: true });
+  });
+
+  it("rejects a directory replaced after authorization but before scope acquisition", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-watcher-identity-"));
+    await mkdir(join(homePath, "projects", "allowed"), { recursive: true });
+    await mkdir(join(homePath, "data", "browser-profiles"), { recursive: true });
+    const authorization = await authorizeFileDirectoryScope(homePath, "projects/allowed");
+    expect(authorization).not.toBe(false);
+    await rename(join(homePath, "projects", "allowed"), join(homePath, "projects", "original"));
+    await rename(join(homePath, "data", "browser-profiles"), join(homePath, "projects", "allowed"));
+    const fake = createFakeWatcherFactory();
+    const watcher = createWatcher(homePath, { watchFactory: fake.factory });
+
+    await expect(watcher.acquireDirectoryScope(
+      "projects/allowed",
+      authorization || undefined,
+    )).rejects.toThrow("Invalid directory scope");
+    expect(fake.calls).toHaveLength(1);
+
     await watcher.close();
     await rm(homePath, { recursive: true });
   });

--- a/tests/gateway/watcher.test.ts
+++ b/tests/gateway/watcher.test.ts
@@ -1,8 +1,55 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
+  createWatcher,
   createWatcherIgnored,
   createWatcherPaths,
+  type WatcherBackend,
+  type WatcherFactory,
 } from "../../packages/gateway/src/watcher.js";
+
+function createFakeWatcherFactory() {
+  const backends: Array<WatcherBackend & {
+    emit(event: string, path: string): void;
+    add: ReturnType<typeof vi.fn>;
+    unwatch: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+  }> = [];
+  const calls: Array<{ paths: string | string[]; options: Record<string, unknown> }> = [];
+  const factory: WatcherFactory = (paths, options) => {
+    const listeners = new Map<string, Array<(path: string) => void>>();
+    const backend = {
+      on: vi.fn((event: string, listener: (path: string) => void) => {
+        const registered = listeners.get(event) ?? [];
+        registered.push(listener);
+        listeners.set(event, registered);
+        return backend;
+      }),
+      add: vi.fn(() => backend),
+      unwatch: vi.fn(async () => backend),
+      close: vi.fn(async () => undefined),
+      emit(event: string, path: string) {
+        for (const listener of listeners.get(event) ?? []) listener(path);
+      },
+    } satisfies WatcherBackend & { emit(event: string, path: string): void };
+    calls.push({ paths, options: options as unknown as Record<string, unknown> });
+    backends.push(backend);
+    return backend;
+  };
+  return { factory, backends, calls };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => { resolve = next; });
+  return { promise, resolve };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("gateway home watcher", () => {
   it("ignores large development and cache directories by default", () => {
@@ -66,5 +113,138 @@ describe("gateway home watcher", () => {
     expect(createWatcherPaths("/home/matrix/home")).not.toContain("/home/matrix/home");
     expect(createWatcherPaths("/home/matrix/home")).not.toContain("/home/matrix/home/projects");
     expect(createWatcherPaths("/home/matrix/home")).not.toContain("/home/matrix/home/matrix-os");
+  });
+
+  it("lazily watches only the exact projects directory at depth zero", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-watcher-"));
+    await mkdir(join(homePath, "projects"));
+    const fake = createFakeWatcherFactory();
+    const watcher = createWatcher(homePath, { watchFactory: fake.factory });
+
+    expect(fake.calls).toHaveLength(1);
+    expect(fake.calls[0].paths).not.toContain(join(homePath, "projects"));
+
+    const release = await watcher.acquireDirectoryScope("projects");
+    expect(fake.calls).toHaveLength(2);
+    expect(fake.calls[1].paths).toBe(join(homePath, "projects"));
+    expect(fake.calls[1].options).toMatchObject({
+      depth: 0,
+      ignoreInitial: true,
+      followSymlinks: false,
+    });
+    const ignored = fake.calls[1].options.ignored as (path: string) => boolean;
+    expect(ignored(join(homePath, "projects", "demo"))).toBe(false);
+    expect(ignored(join(homePath, "projects", "demo", "node_modules"))).toBe(true);
+
+    await release();
+    expect(fake.backends[1].unwatch).toHaveBeenCalledWith(join(homePath, "projects"));
+    await watcher.close();
+    await rm(homePath, { recursive: true });
+  });
+
+  it("reference-counts exact scopes and emits direct file and directory hints", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-watcher-"));
+    await mkdir(join(homePath, "projects"));
+    const fake = createFakeWatcherFactory();
+    const watcher = createWatcher(homePath, { watchFactory: fake.factory });
+    const listener = vi.fn();
+    watcher.on(listener);
+
+    const firstRelease = await watcher.acquireDirectoryScope("projects");
+    const secondRelease = await watcher.acquireDirectoryScope("projects");
+    expect(fake.calls).toHaveLength(2);
+
+    fake.backends[1].emit("add", join(homePath, "projects", "file.txt"));
+    fake.backends[1].emit("change", join(homePath, "projects", "file.txt"));
+    fake.backends[1].emit("unlink", join(homePath, "projects", "file.txt"));
+    fake.backends[1].emit("addDir", join(homePath, "projects", "new-folder"));
+    fake.backends[1].emit("unlinkDir", join(homePath, "projects", "old-folder"));
+    expect(listener.mock.calls.map(([event]) => event)).toEqual([
+      { type: "file:change", path: "projects/file.txt", event: "add" },
+      { type: "file:change", path: "projects/file.txt", event: "change" },
+      { type: "file:change", path: "projects/file.txt", event: "unlink" },
+      { type: "file:change", path: "projects/new-folder", event: "add" },
+      { type: "file:change", path: "projects/old-folder", event: "unlink" },
+    ]);
+
+    await firstRelease();
+    expect(fake.backends[1].unwatch).not.toHaveBeenCalled();
+    await secondRelease();
+    expect(fake.backends[1].unwatch).toHaveBeenCalledOnce();
+    await watcher.close();
+    await rm(homePath, { recursive: true });
+  });
+
+  it("waits for the last unwatch before reacquiring the same exact scope", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-watcher-"));
+    await mkdir(join(homePath, "projects"));
+    const fake = createFakeWatcherFactory();
+    const watcher = createWatcher(homePath, { watchFactory: fake.factory });
+    const release = await watcher.acquireDirectoryScope("projects");
+    const unwatchGate = deferred<WatcherBackend>();
+    fake.backends[1].unwatch.mockImplementationOnce(() => unwatchGate.promise);
+
+    const releasePromise = release();
+    await vi.waitFor(() => expect(fake.backends[1].unwatch).toHaveBeenCalledOnce());
+    const reacquirePromise = watcher.acquireDirectoryScope("projects");
+    const reacquiredBeforeUnwatch = await Promise.race([
+      reacquirePromise.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 50)),
+    ]);
+    expect(reacquiredBeforeUnwatch).toBe(false);
+    expect(fake.backends[1].add).not.toHaveBeenCalled();
+
+    unwatchGate.resolve(fake.backends[1]);
+    await releasePromise;
+    const reacquiredRelease = await reacquirePromise;
+    expect(fake.backends[1].add).toHaveBeenCalledOnce();
+    await reacquiredRelease();
+    await watcher.close();
+    await rm(homePath, { recursive: true });
+  });
+
+  it("drains an in-flight scoped unwatch before closing watcher backends", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-watcher-"));
+    await mkdir(join(homePath, "projects"));
+    const fake = createFakeWatcherFactory();
+    const watcher = createWatcher(homePath, { watchFactory: fake.factory });
+    const release = await watcher.acquireDirectoryScope("projects");
+    const unwatchGate = deferred<WatcherBackend>();
+    fake.backends[1].unwatch.mockImplementationOnce(() => unwatchGate.promise);
+    const releasePromise = release();
+    await vi.waitFor(() => expect(fake.backends[1].unwatch).toHaveBeenCalledOnce());
+
+    let closeSettled = false;
+    const closePromise = watcher.close().then(() => { closeSettled = true; });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(closeSettled).toBe(false);
+    expect(fake.backends[1].close).not.toHaveBeenCalled();
+
+    unwatchGate.resolve(fake.backends[1]);
+    await Promise.all([releasePromise, closePromise]);
+    expect(fake.backends[1].close).toHaveBeenCalledOnce();
+    expect(fake.backends[0].close).toHaveBeenCalledOnce();
+    await rm(homePath, { recursive: true });
+  });
+
+  it("uses existing global coverage and closes both watcher backends", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-watcher-"));
+    await mkdir(join(homePath, "apps", "todo"), { recursive: true });
+    const fake = createFakeWatcherFactory();
+    const watcher = createWatcher(homePath, { watchFactory: fake.factory });
+
+    const releaseCovered = await watcher.acquireDirectoryScope("apps/todo");
+    expect(fake.calls).toHaveLength(1);
+    await releaseCovered();
+    await expect(watcher.acquireDirectoryScope("missing")).rejects.toThrow("Invalid directory scope");
+    expect(fake.calls).toHaveLength(1);
+
+    await watcher.acquireDirectoryScope("");
+    expect(fake.calls).toHaveLength(2);
+    await watcher.close();
+    expect(fake.backends[0].close).toHaveBeenCalledOnce();
+    expect(fake.backends[1].close).toHaveBeenCalledOnce();
+    await rm(homePath, { recursive: true });
   });
 });

--- a/tests/gateway/ws-message-schema.test.ts
+++ b/tests/gateway/ws-message-schema.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { MainWsClientMessageSchema } from "../../packages/gateway/src/ws-message-schema.js";
+
+describe("main websocket file-directory frames", () => {
+  it.each([
+    { type: "files:subscribe", directory: "" },
+    { type: "files:subscribe", directory: "projects/demo" },
+    { type: "files:unsubscribe", directory: "projects/demo" },
+    { type: "files:touch", directory: "projects/demo" },
+  ])("accepts the strict $type contract", (frame) => {
+    expect(MainWsClientMessageSchema.safeParse(frame)).toEqual(
+      expect.objectContaining({ success: true }),
+    );
+  });
+
+  it.each([
+    { type: "files:subscribe" },
+    { type: "files:subscribe", directory: "projects", ownerId: "attacker" },
+    { type: "files:subscribe", directory: "/projects" },
+    { type: "files:subscribe", directory: "C:/projects" },
+    { type: "files:subscribe", directory: "projects/../system" },
+    { type: "files:subscribe", directory: "projects\\demo" },
+    { type: "files:subscribe", directory: "projects\u0000demo" },
+    { type: "files:unknown", directory: "projects" },
+  ])("rejects malformed or non-canonical file frames %#", (frame) => {
+    expect(MainWsClientMessageSchema.safeParse(frame).success).toBe(false);
+  });
+
+  it("enforces the shared 4,096 UTF-8 byte directory boundary", () => {
+    const atLimit = `p/${"a".repeat(4_094)}`;
+    const overLimit = `${atLimit}a`;
+    const multibyteOverLimit = `p/${"界".repeat(1_365)}`;
+
+    expect(Buffer.byteLength(atLimit, "utf8")).toBe(4_096);
+    expect(MainWsClientMessageSchema.safeParse({
+      type: "files:subscribe",
+      directory: atLimit,
+    }).success).toBe(true);
+    expect(MainWsClientMessageSchema.safeParse({
+      type: "files:subscribe",
+      directory: overLimit,
+    }).success).toBe(false);
+    expect(MainWsClientMessageSchema.safeParse({
+      type: "files:subscribe",
+      directory: multibyteOverLimit,
+    }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- add authenticated per-directory WebSocket subscriptions
- bound subscribers, pending authorization, handlers, revisions, and cleanup work
- close authorization, unsubscribe, reconnect, root-overlap, and shutdown races

## Stack

5 of 8. Base: typed routes and Trash. Next: Desktop state foundation.

## Validation

- subscription hub, watcher, schema, auth, reconnect, and race suites pass
- cross-surface refresh was exercised on Preview VPS `pr-1186`

## Invariants

- **Source of truth:** canonical owner directory listing and monotonic subscription revision.
- **Lock/transaction scope:** bounded in-memory reservation and memoized cleanup per exact subscription.
- **Acceptable orphan states:** none; close drains pending acquisition and release before dependencies shut down.
- **Auth source of truth:** authenticated WebSocket principal and file policy, never frame-supplied ownership.
- **Deferred scope:** Desktop subscription consumption lands in the next stacked PR.

Related: MAT-268, #1183, #1186