### PR TITLE
feat(desktop): add file operation state

### DIFF
--- a/desktop/src/renderer/src/features/files/browser-entries.ts
+++ b/desktop/src/renderer/src/features/files/browser-entries.ts
@@ -9,7 +9,21 @@ export interface BrowserEntry {
   sizeBytes?: number;
   modifiedAt?: string;
   children?: number;
+  capabilities: BrowserEntryCapabilities;
 }
+
+export interface BrowserEntryCapabilities {
+  canRename: boolean;
+  canMove: boolean;
+  canTrash: boolean;
+  readOnlyReason?: "protected" | "policy";
+}
+
+export const NO_FILE_CAPABILITIES: BrowserEntryCapabilities = Object.freeze({
+  canRename: false,
+  canMove: false,
+  canTrash: false,
+});
 
 export type BrowserSortKey = "name" | "size" | "modified";
 export type BrowserSortDirection = "asc" | "desc";
@@ -27,12 +41,17 @@ export function parseBrowserEntries(value: unknown): BrowserEntry[] {
       !raw ||
       typeof raw !== "object" ||
       typeof (raw as BrowserEntry).name !== "string" ||
+      !isSafeEntryName((raw as BrowserEntry).name) ||
       ((raw as BrowserEntry).type !== "file" && (raw as BrowserEntry).type !== "directory")
     ) {
       continue;
     }
     const record = raw as Record<string, unknown>;
-    const entry: BrowserEntry = { name: record.name as string, type: record.type as BrowserEntry["type"] };
+    const entry: BrowserEntry = {
+      name: record.name as string,
+      type: record.type as BrowserEntry["type"],
+      capabilities: parseBrowserEntryCapabilities(record.capabilities),
+    };
     if (typeof record.size === "number" && Number.isFinite(record.size) && record.size >= 0) {
       entry.sizeBytes = record.size;
     }
@@ -45,6 +64,41 @@ export function parseBrowserEntries(value: unknown): BrowserEntry[] {
     entries.push(entry);
   }
   return sortBrowserEntries(entries, "name", "asc");
+}
+
+function isSafeEntryName(name: string): boolean {
+  return name.length > 0
+    && name.length <= 255
+    && new TextEncoder().encode(name).byteLength <= 255
+    && name !== "."
+    && name !== ".."
+    && !name.includes("/")
+    && !name.includes("\\")
+    && !/[\u0000-\u001f\u007f]/.test(name);
+}
+
+export function parseBrowserEntryCapabilities(value: unknown): BrowserEntryCapabilities {
+  if (!value || typeof value !== "object") return NO_FILE_CAPABILITIES;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (
+    keys.some((key) => !["canRename", "canMove", "canTrash", "readOnlyReason"].includes(key))
+    || keys.length < 3
+    || typeof record.canRename !== "boolean"
+    || typeof record.canMove !== "boolean"
+    || typeof record.canTrash !== "boolean"
+    || (record.readOnlyReason !== undefined
+      && record.readOnlyReason !== "protected"
+      && record.readOnlyReason !== "policy")
+  ) {
+    return NO_FILE_CAPABILITIES;
+  }
+  return {
+    canRename: record.canRename,
+    canMove: record.canMove,
+    canTrash: record.canTrash,
+    ...(record.readOnlyReason ? { readOnlyReason: record.readOnlyReason } : {}),
+  };
 }
 
 // Finder-style ordering: directories always group first, the active key sorts

--- a/desktop/src/renderer/src/features/files/file-management-api.ts
+++ b/desktop/src/renderer/src/features/files/file-management-api.ts
@@ -1,0 +1,220 @@
+import { z } from "zod/v4";
+import { AppError } from "../../../../shared/app-error";
+import type { ApiClient } from "../../lib/api";
+import {
+  MAX_BROWSER_ENTRIES,
+  type BrowserEntry,
+  parseBrowserEntryCapabilities,
+} from "./browser-entries";
+import {
+  FileEntryNameSchema,
+  FileMutationNameSchema,
+  OwnerDirectoryPathSchema,
+  OwnerRelativePathSchema,
+  RendererFileEntryCapabilitiesSchema,
+} from "./file-management-contracts";
+
+export const FILE_MUTATION_TIMEOUT_MS = 60_000;
+
+const SMALL_STRING_MAX = 512;
+const ResponseDirectorySchema = z.union([OwnerDirectoryPathSchema, z.literal(".")]).transform(
+  (value) => value === "." ? "" : value,
+);
+const RequestIdSchema = z.uuid();
+
+const ListingEntrySchema = z.object({
+  name: FileEntryNameSchema,
+  type: z.enum(["file", "directory"]),
+  size: z.number().finite().nonnegative().optional(),
+  modified: z.string().min(1).max(128).optional(),
+  created: z.string().min(1).max(128).optional(),
+  children: z.number().int().nonnegative().optional(),
+  changedCount: z.number().int().nonnegative().optional(),
+  gitStatus: z.string().max(64).nullable().optional(),
+  mime: z.string().max(256).optional(),
+  capabilities: z.unknown().optional(),
+}).strict();
+const ListingSchema = z.object({
+  path: OwnerDirectoryPathSchema,
+  entries: z.array(ListingEntrySchema).max(MAX_BROWSER_ENTRIES),
+}).strict();
+
+const MutationResultSchema = z.object({
+  ok: z.literal(true),
+  path: OwnerRelativePathSchema,
+  resultCode: z.enum(["created", "renamed"]),
+  capabilities: RendererFileEntryCapabilitiesSchema,
+}).strict();
+const InvalidCodeSchema = z.enum(["source_missing", "protected", "invalid_destination"]);
+const PreflightSchema = z.object({
+  sources: z.array(OwnerRelativePathSchema).min(1).max(100),
+  destinationDirectory: OwnerRelativePathSchema,
+  conflicts: z.array(z.object({ source: OwnerRelativePathSchema, destination: OwnerRelativePathSchema }).strict()).max(100),
+  invalid: z.array(z.object({ source: OwnerRelativePathSchema, code: InvalidCodeSchema }).strict()).max(100),
+  preflightFingerprint: z.string().min(1).max(SMALL_STRING_MAX),
+}).strict();
+const MoveResultCodeSchema = z.enum([
+  "moved", "skipped", "source_missing", "destination_conflict", "protected", "invalid_destination", "failed",
+]);
+const ExecuteSchema = z.object({
+  results: z.array(z.object({
+    source: OwnerRelativePathSchema,
+    destination: OwnerRelativePathSchema.optional(),
+    code: MoveResultCodeSchema,
+  }).strict()).max(100),
+  affectedDirectories: z.array(ResponseDirectorySchema).max(100),
+}).strict();
+const TrashSchema = z.object({
+  results: z.array(z.object({
+    source: OwnerRelativePathSchema,
+    code: z.enum(["trashed", "source_missing", "protected", "invalid_destination", "failed"]),
+  }).strict()).max(100),
+  sourceDirectory: ResponseDirectorySchema,
+}).strict();
+
+const SourcesSchema = z.array(OwnerRelativePathSchema).min(1).max(100).refine(
+  (sources) => new Set(sources).size === sources.length,
+).refine((sources) => sources.every((source) => parentDirectory(source) === parentDirectory(sources[0]!)));
+const ConflictChoicesSchema = z.array(z.object({
+  source: OwnerRelativePathSchema,
+  resolution: z.enum(["keep-both", "skip"]),
+}).strict()).max(100);
+
+export type FileMutationResult = z.infer<typeof MutationResultSchema>;
+export type FileMovePreflight = z.infer<typeof PreflightSchema>;
+export type FileMoveExecution = z.infer<typeof ExecuteSchema>;
+export type FileTrashExecution = z.infer<typeof TrashSchema>;
+export type FileConflictChoice = z.infer<typeof ConflictChoicesSchema>[number];
+
+export interface FileManagementApi {
+  list(directory: string): Promise<{ path: string; entries: BrowserEntry[] }>;
+  create(input: { requestId: string; parentDirectory: string; name: string; kind: "file" | "directory" }): Promise<FileMutationResult>;
+  rename(input: { requestId: string; path: string; name: string }): Promise<FileMutationResult>;
+  preflightMove(input: { requestId: string; sources: string[]; destinationDirectory: string }): Promise<FileMovePreflight>;
+  executeMove(input: {
+    requestId: string;
+    sources: string[];
+    preflightFingerprint: string;
+    conflictChoices?: FileConflictChoice[];
+  }): Promise<FileMoveExecution>;
+  trash(input: { requestId: string; sources: string[] }): Promise<FileTrashExecution>;
+}
+
+export function createFileManagementApi(client: ApiClient): FileManagementApi {
+  return {
+    async list(directory) {
+      const normalized = parseInput(OwnerDirectoryPathSchema, directory);
+      const response = parseResponse(ListingSchema, await client.get(
+        `/api/files/list?path=${encodeURIComponent(normalized)}`,
+      ));
+      if (response.path !== normalized) throw new AppError("server");
+      return {
+        path: response.path,
+        entries: response.entries.map((entry) => toBrowserEntry(entry)),
+      };
+    },
+    async create(input) {
+      const body = parseInput(z.object({
+        requestId: RequestIdSchema, parentDirectory: OwnerDirectoryPathSchema, name: FileMutationNameSchema,
+        kind: z.enum(["file", "directory"]),
+      }).strict(), input);
+      const response = parseResponse(MutationResultSchema, await client.post(
+        "/api/files/create", body, { timeoutMs: FILE_MUTATION_TIMEOUT_MS },
+      ));
+      if (response.path !== joinPath(body.parentDirectory, body.name) || response.resultCode !== "created") throw new AppError("server");
+      return response;
+    },
+    async rename(input) {
+      const body = parseInput(z.object({
+        requestId: RequestIdSchema, path: OwnerRelativePathSchema, name: FileMutationNameSchema,
+      }).strict(), input);
+      const response = parseResponse(MutationResultSchema, await client.post(
+        "/api/files/rename", body, { timeoutMs: FILE_MUTATION_TIMEOUT_MS },
+      ));
+      if (response.path !== joinPath(parentDirectory(body.path), body.name) || response.resultCode !== "renamed") throw new AppError("server");
+      return response;
+    },
+    async preflightMove(input) {
+      const body = parseInput(z.object({
+        requestId: RequestIdSchema, sources: SourcesSchema, destinationDirectory: OwnerRelativePathSchema,
+      }).strict(), input);
+      const response = parseResponse(PreflightSchema, await client.post(
+        "/api/files/batch/move", { ...body, phase: "preflight" }, { timeoutMs: FILE_MUTATION_TIMEOUT_MS },
+      ));
+      const conflictSources = response.conflicts.map((item) => item.source);
+      const invalidSources = response.invalid.map((item) => item.source);
+      if (!sameOrderedPaths(response.sources, body.sources) || response.destinationDirectory !== body.destinationDirectory
+        || !orderedSubset(conflictSources, body.sources) || !orderedSubset(invalidSources, body.sources)
+        || conflictSources.some((source) => invalidSources.includes(source))
+        || response.conflicts.some((item) => item.destination !== joinPath(body.destinationDirectory, basename(item.source)))) {
+        throw new AppError("server");
+      }
+      return response;
+    },
+    async executeMove(input) {
+      const body = parseInput(z.object({
+        requestId: RequestIdSchema,
+        sources: SourcesSchema,
+        preflightFingerprint: z.string().min(1).max(SMALL_STRING_MAX),
+        conflictChoices: ConflictChoicesSchema.optional(),
+      }).strict(), input);
+      const { sources, ...wireBody } = body;
+      const response = parseResponse(ExecuteSchema, await client.post(
+        "/api/files/batch/move", { ...wireBody, phase: "execute" }, { timeoutMs: FILE_MUTATION_TIMEOUT_MS },
+      ));
+      if (!sameOrderedPaths(response.results.map((item) => item.source), sources)) throw new AppError("server");
+      return response;
+    },
+    async trash(input) {
+      const body = parseInput(z.object({ requestId: RequestIdSchema, sources: SourcesSchema }).strict(), input);
+      const response = parseResponse(TrashSchema, await client.post(
+        "/api/files/batch/trash", body, { timeoutMs: FILE_MUTATION_TIMEOUT_MS },
+      ));
+      if (!sameOrderedPaths(response.results.map((item) => item.source), body.sources)
+        || response.sourceDirectory !== parentDirectory(body.sources[0]!)) throw new AppError("server");
+      return response;
+    },
+  };
+}
+
+function parseInput<T>(schema: z.ZodType<T>, value: unknown): T {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) throw new AppError("server");
+  return parsed.data;
+}
+
+function parseResponse<T>(schema: z.ZodType<T>, value: unknown): T {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) throw new AppError("server");
+  return parsed.data;
+}
+
+function toBrowserEntry(entry: z.infer<typeof ListingEntrySchema>): BrowserEntry {
+  return {
+    name: entry.name,
+    type: entry.type,
+    capabilities: parseBrowserEntryCapabilities(entry.capabilities),
+    ...(entry.size !== undefined ? { sizeBytes: entry.size } : {}),
+    ...(entry.modified !== undefined ? { modifiedAt: entry.modified } : {}),
+    ...(entry.children !== undefined ? { children: entry.children } : {}),
+  };
+}
+
+function parentDirectory(path: string): string {
+  const separator = path.lastIndexOf("/");
+  return separator < 0 ? "" : path.slice(0, separator);
+}
+function basename(path: string): string { return path.slice(path.lastIndexOf("/") + 1); }
+function joinPath(parent: string, name: string): string { return parent ? `${parent}/${name}` : name; }
+function sameOrderedPaths(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((path, index) => path === right[index]);
+}
+function orderedSubset(candidate: readonly string[], source: readonly string[]): boolean {
+  let previous = -1;
+  for (const path of candidate) {
+    const index = source.indexOf(path);
+    if (index <= previous) return false;
+    previous = index;
+  }
+  return true;
+}

--- a/desktop/src/renderer/src/features/files/file-management-api.ts
+++ b/desktop/src/renderer/src/features/files/file-management-api.ts
@@ -75,7 +75,7 @@ const TrashSchema = z.object({
 const SourcesSchema = z.array(OwnerRelativePathSchema).min(1).max(100).refine(
   (sources) => new Set(sources).size === sources.length,
 ).refine((sources) => sources.every((source) => parentDirectory(source) === parentDirectory(sources[0]!)));
-const ConflictChoicesSchema = z.array(z.object({
+export const FileConflictChoicesSchema = z.array(z.object({
   source: OwnerRelativePathSchema,
   resolution: z.enum(["keep-both", "skip"]),
 }).strict()).max(100);
@@ -84,7 +84,7 @@ export type FileMutationResult = z.infer<typeof MutationResultSchema>;
 export type FileMovePreflight = z.infer<typeof PreflightSchema>;
 export type FileMoveExecution = z.infer<typeof ExecuteSchema>;
 export type FileTrashExecution = z.infer<typeof TrashSchema>;
-export type FileConflictChoice = z.infer<typeof ConflictChoicesSchema>[number];
+export type FileConflictChoice = z.infer<typeof FileConflictChoicesSchema>[number];
 
 export interface FileManagementApi {
   list(directory: string): Promise<{ path: string; entries: BrowserEntry[] }>;
@@ -158,7 +158,7 @@ export function createFileManagementApi(client: ApiClient): FileManagementApi {
         sources: SourcesSchema,
         destinationDirectory: OwnerRelativePathSchema,
         preflightFingerprint: z.string().min(1).max(SMALL_STRING_MAX),
-        conflictChoices: ConflictChoicesSchema.optional(),
+        conflictChoices: FileConflictChoicesSchema.optional(),
       }).strict(), input);
       const { sources, destinationDirectory, ...wireBody } = body;
       const response = parseResponse(ExecuteSchema, await client.post(

--- a/desktop/src/renderer/src/features/files/file-management-api.ts
+++ b/desktop/src/renderer/src/features/files/file-management-api.ts
@@ -94,6 +94,7 @@ export interface FileManagementApi {
   executeMove(input: {
     requestId: string;
     sources: string[];
+    destinationDirectory: string;
     preflightFingerprint: string;
     conflictChoices?: FileConflictChoice[];
   }): Promise<FileMoveExecution>;
@@ -155,14 +156,22 @@ export function createFileManagementApi(client: ApiClient): FileManagementApi {
       const body = parseInput(z.object({
         requestId: RequestIdSchema,
         sources: SourcesSchema,
+        destinationDirectory: OwnerRelativePathSchema,
         preflightFingerprint: z.string().min(1).max(SMALL_STRING_MAX),
         conflictChoices: ConflictChoicesSchema.optional(),
       }).strict(), input);
-      const { sources, ...wireBody } = body;
+      const { sources, destinationDirectory, ...wireBody } = body;
       const response = parseResponse(ExecuteSchema, await client.post(
         "/api/files/batch/move", { ...wireBody, phase: "execute" }, { timeoutMs: FILE_MUTATION_TIMEOUT_MS },
       ));
-      if (!sameOrderedPaths(response.results.map((item) => item.source), sources)) throw new AppError("server");
+      const expectedDirectories = firstSeen([...sources.map(parentDirectory), destinationDirectory]);
+      if (!sameOrderedPaths(response.results.map((item) => item.source), sources)
+        || !sameOrderedPaths(response.affectedDirectories, expectedDirectories)
+        || response.results.some((item) => item.code === "moved"
+          ? item.destination === undefined || parentDirectory(item.destination) !== destinationDirectory
+          : item.destination !== undefined)) {
+        throw new AppError("server");
+      }
       return response;
     },
     async trash(input) {
@@ -218,3 +227,4 @@ function orderedSubset(candidate: readonly string[], source: readonly string[]):
   }
   return true;
 }
+function firstSeen(values: readonly string[]): string[] { return [...new Set(values)]; }

--- a/desktop/src/renderer/src/features/files/file-management-contracts.ts
+++ b/desktop/src/renderer/src/features/files/file-management-contracts.ts
@@ -1,0 +1,42 @@
+import { z } from "zod/v4";
+
+const utf8 = new TextEncoder();
+const CONTROL_CHARACTER = /[\u0000-\u001f\u007f]/;
+const INVALID_PORTABLE_NAME_CHARACTER = /[\\/:*?"<>|]/;
+const RESERVED_PLATFORM_NAME = /^(con|prn|aux|nul|clock\$|com[1-9]|lpt[1-9])(?:\..*)?$/i;
+
+export const OwnerRelativePathSchema = z.string().min(1).max(4_096).refine((value) =>
+  utf8.encode(value).byteLength <= 4_096
+  && !value.startsWith("/")
+  && !value.includes("\\")
+  && !/^[a-zA-Z]:\//.test(value)
+  && !CONTROL_CHARACTER.test(value)
+  && value.split("/").every((part) => part.length > 0 && part !== "." && part !== ".."),
+);
+
+export const OwnerDirectoryPathSchema = z.union([z.literal(""), OwnerRelativePathSchema]);
+
+export const FileEntryNameSchema = z.string().min(1).max(255).refine((value) =>
+  utf8.encode(value).byteLength <= 255
+  && value !== "."
+  && value !== ".."
+  && !value.includes("/")
+  && !value.includes("\\")
+  && !CONTROL_CHARACTER.test(value),
+);
+
+export const FileMutationNameSchema = FileEntryNameSchema.refine((value) =>
+  value.trim().length > 0
+  && !INVALID_PORTABLE_NAME_CHARACTER.test(value)
+  && !/[ .]$/.test(value)
+  && !RESERVED_PLATFORM_NAME.test(value),
+);
+
+export const RendererFileEntryCapabilitiesSchema = z.object({
+  canRename: z.boolean(),
+  canMove: z.boolean(),
+  canTrash: z.boolean(),
+  readOnlyReason: z.enum(["protected", "policy"]).optional(),
+}).strict();
+
+export type RendererFileEntryCapabilities = z.infer<typeof RendererFileEntryCapabilitiesSchema>;

--- a/desktop/src/renderer/src/features/files/file-operation-controller.ts
+++ b/desktop/src/renderer/src/features/files/file-operation-controller.ts
@@ -164,7 +164,8 @@ export function createFileOperationController(options: FileOperationControllerOp
     syncScope();
     const current = options.getScope();
     const predicateCurrent = options.isScopeCurrent?.(token.scope) ?? true;
-    return !closed && token.epoch === epoch && sameScope(token.scope, current) && predicateCurrent;
+    return !closed && token.epoch === epoch && validScope(current)
+      && sameScope(token.scope, current) && predicateCurrent;
   };
 
   const begin = (paths: readonly string[]): OperationToken | FileOperationOutcome => {

--- a/desktop/src/renderer/src/features/files/file-operation-controller.ts
+++ b/desktop/src/renderer/src/features/files/file-operation-controller.ts
@@ -1,0 +1,458 @@
+import { AppError } from "../../../../shared/app-error";
+import type {
+  FileConflictChoice,
+  FileManagementApi,
+  FileMovePreflight,
+} from "./file-management-api";
+
+const LISTENER_CAP = 32;
+const ACTIVE_OPERATION_CAP = 8;
+const STORED_PREFLIGHT_CAP = 16;
+const RECENT_REQUEST_ID_CAP = 512;
+const MAX_ROWS = 100;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export interface FileOperationScope {
+  directory: string;
+  runtimeSlot: string;
+  authGeneration: number;
+}
+
+export type FileOperationNotice =
+  | "authoritative_reconciliation_required"
+  | "operation_failed"
+  | "operation_unavailable"
+  | "request_conflict"
+  | "request_mismatch";
+
+export type FileOperationFailureCode =
+  | "failed"
+  | "skipped"
+  | "source_missing"
+  | "destination_conflict"
+  | "protected"
+  | "invalid_destination";
+
+export interface FileOperationFailure {
+  source: string;
+  code: FileOperationFailureCode;
+}
+
+export interface ControllerMovePreflight extends FileMovePreflight {
+  requestId: string;
+}
+
+export type FileOperationStatus =
+  | "idle"
+  | "pending"
+  | "ready"
+  | "needs-resolution"
+  | "completed"
+  | "cancelled"
+  | "uncertain"
+  | "failed"
+  | "stale";
+
+export interface FileOperationSnapshot {
+  scope: FileOperationScope;
+  status: FileOperationStatus;
+  pendingPaths: string[];
+  retainedPaths: string[];
+  failures: FileOperationFailure[];
+  notice: FileOperationNotice | null;
+  preflight: ControllerMovePreflight | null;
+}
+
+export interface FileOperationOutcome {
+  status: FileOperationStatus;
+  requestId: string;
+  succeededPaths: string[];
+  retainedPaths: string[];
+  failures: FileOperationFailure[];
+  affectedDirectories: string[];
+  notice: FileOperationNotice | null;
+  preflight?: ControllerMovePreflight;
+}
+
+export interface FileOperationControllerOptions {
+  getApi(): FileManagementApi | null;
+  createRequestId(): string;
+  getScope(): FileOperationScope;
+  loadDirectory(directory: string, scope: FileOperationScope): Promise<readonly string[]>;
+  isScopeCurrent?(scope: FileOperationScope): boolean;
+  now?: () => number;
+}
+
+export interface FileOperationController {
+  readonly snapshot: FileOperationSnapshot;
+  subscribe(listener: (snapshot: FileOperationSnapshot) => void): () => void;
+  syncScope(): void;
+  create(input: { parentDirectory: string; name: string; kind: "file" | "directory" }): Promise<FileOperationOutcome>;
+  rename(input: { path: string; name: string }): Promise<FileOperationOutcome>;
+  preflightMove(input: { sources: string[]; destinationDirectory: string }): Promise<FileOperationOutcome>;
+  executeMove(input: { preflight: ControllerMovePreflight; conflictChoices: FileConflictChoice[] }): Promise<FileOperationOutcome>;
+  cancelMove(preflight: ControllerMovePreflight): FileOperationOutcome;
+  trash(input: { sources: string[] }): Promise<FileOperationOutcome>;
+  close(): void;
+}
+
+interface OperationToken { requestId: string; scope: FileOperationScope; epoch: number }
+type ReconciliationPlan =
+  | { kind: "create"; target: string }
+  | { kind: "rename"; target: string }
+  | { kind: "move"; destinationDirectory: string; ambiguousSources: string[] }
+  | { kind: "trash" };
+
+export function createFileOperationController(options: FileOperationControllerOptions): FileOperationController {
+  let snapshot = emptySnapshot(options.getScope());
+  let epoch = 0;
+  let closed = false;
+  const listeners = new Map<number, (snapshot: FileOperationSnapshot) => void>();
+  let nextListenerId = 1;
+  const active = new Map<string, string[]>();
+  const preflights = new Map<string, ControllerMovePreflight>();
+  const recentIds: string[] = [];
+
+  const publish = (next: FileOperationSnapshot) => {
+    if (closed) return;
+    snapshot = next;
+    for (const listener of [...listeners.values()]) {
+      try { listener(snapshot); } catch (error: unknown) {
+        console.warn("[file-operation-controller] listener failed:", error instanceof Error ? error.name : typeof error);
+      }
+    }
+  };
+
+  const syncScope = () => {
+    if (closed) return;
+    const current = options.getScope();
+    if (sameScope(snapshot.scope, current)) return;
+    epoch++;
+    active.clear();
+    preflights.clear();
+    publish(emptySnapshot(current));
+  };
+
+  const isCurrent = (token: OperationToken) => {
+    const current = options.getScope();
+    if (!sameScope(snapshot.scope, current)) syncScope();
+    const predicateCurrent = options.isScopeCurrent?.(token.scope) ?? true;
+    if (!predicateCurrent && !closed) {
+      epoch++;
+      active.clear();
+      preflights.clear();
+      publish(emptySnapshot(current));
+    }
+    return !closed && token.epoch === epoch && sameScope(token.scope, current) && predicateCurrent;
+  };
+
+  const begin = (paths: readonly string[]): OperationToken | FileOperationOutcome => {
+    syncScope();
+    if (closed || active.size >= ACTIVE_OPERATION_CAP) {
+      return failedOutcome("", paths, "operation_unavailable");
+    }
+    const requestId = nextRequestId(options.createRequestId, recentIds);
+    if (!requestId) return failedOutcome("", paths, "operation_unavailable");
+    const token = { requestId, scope: { ...snapshot.scope }, epoch };
+    active.set(requestId, boundedPaths(paths));
+    publish({ ...snapshot, status: "pending", pendingPaths: pendingPaths(active), notice: null });
+    return token;
+  };
+
+  const finish = (token: OperationToken, outcome: FileOperationOutcome) => {
+    if (!isCurrent(token)) return staleOutcome(token.requestId);
+    active.delete(token.requestId);
+    publish({
+      scope: snapshot.scope,
+      status: outcome.status,
+      pendingPaths: pendingPaths(active),
+      retainedPaths: outcome.retainedPaths,
+      failures: outcome.failures,
+      notice: outcome.notice,
+      preflight: outcome.preflight ?? null,
+    });
+    return outcome;
+  };
+
+  const load = async (directories: readonly string[], token: OperationToken) => {
+    const listings: Record<string, string[]> = {};
+    for (const directory of firstSeen(directories)) {
+      if (!isCurrent(token)) return null;
+      const result = await options.loadDirectory(directory, token.scope);
+      if (!isCurrent(token)) return null;
+      listings[directory] = boundedPaths(result, 1_000);
+    }
+    return listings;
+  };
+
+  async function create(input: { parentDirectory: string; name: string; kind: "file" | "directory" }) {
+    const expectedPath = joinPath(input.parentDirectory, input.name);
+    const started = begin([expectedPath]);
+    if (!("scope" in started)) return started;
+    const api = options.getApi();
+    if (!api) return finish(started, failedOutcome(started.requestId, [expectedPath], "operation_unavailable"));
+    try {
+      const result = await api.create({ requestId: started.requestId, ...input });
+      if (!isCurrent(started)) return staleOutcome(started.requestId);
+      if (!await load([input.parentDirectory], started)) return staleOutcome(started.requestId);
+      return finish(started, completedOutcome(started.requestId, [result.path], [input.parentDirectory]));
+    } catch (error: unknown) {
+      return handleUncertain(started, [expectedPath], [input.parentDirectory], { kind: "create", target: expectedPath }, error);
+    }
+  }
+
+  async function rename(input: { path: string; name: string }) {
+    const parent = parentDirectory(input.path);
+    const expectedPath = joinPath(parent, input.name);
+    const started = begin([input.path]);
+    if (!("scope" in started)) return started;
+    const api = options.getApi();
+    if (!api) return finish(started, failedOutcome(started.requestId, [input.path], "operation_unavailable"));
+    try {
+      const result = await api.rename({ requestId: started.requestId, ...input });
+      if (!isCurrent(started)) return staleOutcome(started.requestId);
+      if (!await load([parent], started)) return staleOutcome(started.requestId);
+      return finish(started, completedOutcome(started.requestId, [result.path], [parent]));
+    } catch (error: unknown) {
+      return handleUncertain(started, [input.path], [parent], { kind: "rename", target: expectedPath }, error);
+    }
+  }
+
+  async function preflightMove(input: { sources: string[]; destinationDirectory: string }) {
+    if (!validBatchSources(input.sources)) return failedOutcome("", input.sources, "request_mismatch");
+    const sources = boundedPaths(input.sources);
+    const started = begin(sources);
+    if (!("scope" in started)) return started;
+    const api = options.getApi();
+    if (!api) return finish(started, failedOutcome(started.requestId, sources, "operation_unavailable"));
+    try {
+      const result = await api.preflightMove({ requestId: started.requestId, sources, destinationDirectory: input.destinationDirectory });
+      if (!isCurrent(started)) return staleOutcome(started.requestId);
+      if (!sameOrderedPaths(result.sources, sources) || result.destinationDirectory !== input.destinationDirectory) {
+        throw new AppError("server");
+      }
+      const preflight = { requestId: started.requestId, ...result };
+      if (preflights.size >= STORED_PREFLIGHT_CAP) preflights.delete(preflights.keys().next().value!);
+      preflights.set(started.requestId, preflight);
+      const failures = result.invalid.map((item) => ({ source: item.source, code: item.code }));
+      return finish(started, {
+        status: result.conflicts.length ? "needs-resolution" : "ready",
+        requestId: started.requestId,
+        succeededPaths: [], retainedPaths: failures.map((item) => item.source), failures,
+        affectedDirectories: [], notice: null, preflight,
+      });
+    } catch (error: unknown) {
+      return finish(started, failedOutcome(started.requestId, sources, noticeForError(error)));
+    }
+  }
+
+  async function executeMove(input: { preflight: ControllerMovePreflight; conflictChoices: FileConflictChoice[] }) {
+    syncScope();
+    const stored = preflights.get(input.preflight.requestId);
+    if (!stored || !samePreflight(stored, input.preflight) || !validChoices(stored, input.conflictChoices)) {
+      return failedOutcome(input.preflight.requestId, input.preflight.sources, "request_mismatch");
+    }
+    if (active.size >= ACTIVE_OPERATION_CAP) return failedOutcome(stored.requestId, stored.sources, "operation_unavailable");
+    const token = { requestId: stored.requestId, scope: { ...snapshot.scope }, epoch };
+    active.set(token.requestId, boundedPaths(stored.sources));
+    publish({ ...snapshot, status: "pending", pendingPaths: pendingPaths(active), notice: null });
+    const api = options.getApi();
+    if (!api) return finish(token, failedOutcome(token.requestId, stored.sources, "operation_unavailable"));
+    const directories = firstSeen([...stored.sources.map(parentDirectory), stored.destinationDirectory]);
+    try {
+      const result = await api.executeMove({
+        requestId: token.requestId,
+        sources: stored.sources,
+        preflightFingerprint: stored.preflightFingerprint,
+        ...(input.conflictChoices.length ? { conflictChoices: input.conflictChoices } : {}),
+      });
+      if (!isCurrent(token)) return staleOutcome(token.requestId);
+      if (!sameOrderedPaths(result.results.map((item) => item.source), stored.sources)) throw new AppError("server");
+      const affected = firstSeen([...directories, ...result.affectedDirectories]);
+      if (!await load(affected, token)) return staleOutcome(token.requestId);
+      const failures = result.results
+        .filter((item) => item.code !== "moved")
+        .map((item) => ({ source: item.source, code: item.code as FileOperationFailureCode }));
+      const succeeded = result.results.filter((item) => item.code === "moved").map((item) => item.source);
+      preflights.delete(token.requestId);
+      return finish(token, {
+        status: "completed", requestId: token.requestId, succeededPaths: boundedPaths(succeeded),
+        retainedPaths: failures.map((item) => item.source), failures: failures.slice(0, MAX_ROWS),
+        affectedDirectories: affected, notice: null,
+      });
+    } catch (error: unknown) {
+      return handleUncertain(token, stored.sources, directories, {
+        kind: "move",
+        destinationDirectory: stored.destinationDirectory,
+        ambiguousSources: input.conflictChoices.map((choice) => choice.source),
+      }, error);
+    }
+  }
+
+  function cancelMove(preflight: ControllerMovePreflight): FileOperationOutcome {
+    syncScope();
+    const stored = preflights.get(preflight.requestId);
+    if (!stored || !samePreflight(stored, preflight)) return failedOutcome(preflight.requestId, preflight.sources, "request_mismatch");
+    preflights.delete(preflight.requestId);
+    const outcome: FileOperationOutcome = {
+      status: "cancelled", requestId: preflight.requestId, succeededPaths: [], retainedPaths: boundedPaths(preflight.sources),
+      failures: [], affectedDirectories: [], notice: null,
+    };
+    publish({ ...snapshot, status: "cancelled", preflight: null, retainedPaths: outcome.retainedPaths });
+    return outcome;
+  }
+
+  async function trash(input: { sources: string[] }) {
+    if (!validBatchSources(input.sources)) return failedOutcome("", input.sources, "request_mismatch");
+    const sources = boundedPaths(input.sources);
+    const started = begin(sources);
+    if (!("scope" in started)) return started;
+    const api = options.getApi();
+    if (!api) return finish(started, failedOutcome(started.requestId, sources, "operation_unavailable"));
+    const sourceDirectories = firstSeen(sources.map(parentDirectory));
+    try {
+      const result = await api.trash({ requestId: started.requestId, sources });
+      if (!isCurrent(started)) return staleOutcome(started.requestId);
+      if (!sameOrderedPaths(result.results.map((item) => item.source), sources)) throw new AppError("server");
+      const affected = firstSeen([...sourceDirectories, result.sourceDirectory]);
+      if (!await load(affected, started)) return staleOutcome(started.requestId);
+      const failures = result.results.filter((item) => item.code !== "trashed")
+        .map((item) => ({ source: item.source, code: item.code as FileOperationFailureCode }));
+      return finish(started, {
+        status: "completed", requestId: started.requestId,
+        succeededPaths: result.results.filter((item) => item.code === "trashed").map((item) => item.source),
+        retainedPaths: failures.map((item) => item.source), failures, affectedDirectories: affected, notice: null,
+      });
+    } catch (error: unknown) {
+      return handleUncertain(started, sources, sourceDirectories, { kind: "trash" }, error);
+    }
+  }
+
+  async function handleUncertain(
+    token: OperationToken,
+    sources: readonly string[],
+    directories: readonly string[],
+    plan: ReconciliationPlan,
+    error: unknown,
+  ): Promise<FileOperationOutcome> {
+    if (!isCurrent(token)) return staleOutcome(token.requestId);
+    let listings: Record<string, string[]> | null = null;
+    try {
+      listings = await load(directories, token);
+    } catch (error: unknown) {
+      console.warn(
+        "[file-operation-controller] authoritative reload failed:",
+        error instanceof Error ? error.name : typeof error,
+      );
+      listings = null;
+    }
+    if (!isCurrent(token)) return staleOutcome(token.requestId);
+    const notice = noticeForError(error);
+    if (notice === "request_conflict") return finish(token, failedOutcome(token.requestId, sources, notice));
+    const succeeded: string[] = [];
+    const retained: string[] = [];
+    for (const source of boundedPaths(sources)) {
+      if (listings === null || (plan.kind === "move" && plan.ambiguousSources.includes(source))) {
+        retained.push(source);
+        continue;
+      }
+      const sourcePresent = listings?.[parentDirectory(source)]?.includes(source) ?? false;
+      const target = plan.kind === "move"
+        ? joinPath(plan.destinationDirectory, basename(source))
+        : plan.kind === "create" || plan.kind === "rename" ? plan.target : null;
+      const targetPresent = target
+        ? listings?.[parentDirectory(target)]?.includes(target) ?? false
+        : false;
+      const safelySucceeded = plan.kind === "create"
+        ? targetPresent
+        : plan.kind === "trash" ? !sourcePresent : !sourcePresent && targetPresent;
+      if (safelySucceeded) succeeded.push(source);
+      else retained.push(source);
+    }
+    const failures = retained.map((source) => ({ source, code: "failed" as const }));
+    return finish(token, {
+      status: "uncertain", requestId: token.requestId, succeededPaths: succeeded,
+      retainedPaths: retained, failures, affectedDirectories: firstSeen(directories),
+      notice: "authoritative_reconciliation_required",
+    });
+  }
+
+  return {
+    get snapshot() { return snapshot; },
+    subscribe(listener) {
+      if (closed) throw new Error("File operation controller is closed");
+      if (listeners.size >= LISTENER_CAP) throw new Error(`File operation listener cap (${LISTENER_CAP}) exceeded`);
+      const id = nextListenerId++;
+      listeners.set(id, listener);
+      return () => { listeners.delete(id); };
+    },
+    syncScope,
+    create,
+    rename,
+    preflightMove,
+    executeMove,
+    cancelMove,
+    trash,
+    close() {
+      if (closed) return;
+      closed = true;
+      epoch++;
+      active.clear();
+      preflights.clear();
+      listeners.clear();
+      snapshot = emptySnapshot(options.getScope());
+    },
+  };
+}
+
+function emptySnapshot(scope: FileOperationScope): FileOperationSnapshot {
+  return { scope: { ...scope }, status: "idle", pendingPaths: [], retainedPaths: [], failures: [], notice: null, preflight: null };
+}
+function boundedPaths(paths: readonly string[], max = MAX_ROWS): string[] { return [...new Set(paths)].slice(0, max); }
+function pendingPaths(active: Map<string, string[]>): string[] { return boundedPaths([...active.values()].flat()); }
+function firstSeen(values: readonly string[]): string[] { return [...new Set(values)].slice(0, MAX_ROWS); }
+function validBatchSources(paths: readonly string[]): boolean {
+  if (paths.length < 1 || paths.length > MAX_ROWS || new Set(paths).size !== paths.length) return false;
+  return paths.every((path) => parentDirectory(path) === parentDirectory(paths[0]!));
+}
+function parentDirectory(path: string): string { const at = path.lastIndexOf("/"); return at < 0 ? "" : path.slice(0, at); }
+function basename(path: string): string { return path.slice(path.lastIndexOf("/") + 1); }
+function joinPath(parent: string, name: string): string { return parent ? `${parent}/${name}` : name; }
+function sameScope(a: FileOperationScope, b: FileOperationScope): boolean { return a.directory === b.directory && a.runtimeSlot === b.runtimeSlot && a.authGeneration === b.authGeneration; }
+function sameOrderedPaths(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((path, index) => path === b[index]);
+}
+function samePreflight(a: ControllerMovePreflight, b: ControllerMovePreflight): boolean {
+  return a.requestId === b.requestId && a.preflightFingerprint === b.preflightFingerprint
+    && a.destinationDirectory === b.destinationDirectory && a.sources.join("\0") === b.sources.join("\0");
+}
+function validChoices(preflight: ControllerMovePreflight, choices: FileConflictChoice[]): boolean {
+  return choices.length === preflight.conflicts.length
+    && choices.every((choice, index) => choice.source === preflight.conflicts[index]?.source);
+}
+function nextRequestId(generate: () => string, recent: string[]): string | null {
+  for (let attempt = 0; attempt < 16; attempt++) {
+    const id = generate();
+    if (!UUID.test(id) || recent.includes(id)) continue;
+    recent.push(id);
+    if (recent.length > RECENT_REQUEST_ID_CAP) recent.shift();
+    return id;
+  }
+  return null;
+}
+function noticeForError(error: unknown): FileOperationNotice {
+  if (error instanceof AppError && error.detail === "request_id_conflict") return "request_conflict";
+  if (error instanceof AppError && error.detail === "operation_unavailable") return "authoritative_reconciliation_required";
+  return error instanceof AppError ? "authoritative_reconciliation_required" : "operation_failed";
+}
+function staleOutcome(requestId: string): FileOperationOutcome {
+  return { status: "stale", requestId, succeededPaths: [], retainedPaths: [], failures: [], affectedDirectories: [], notice: null };
+}
+function failedOutcome(requestId: string, paths: readonly string[], notice: FileOperationNotice): FileOperationOutcome {
+  const retainedPaths = boundedPaths(paths);
+  return { status: "failed", requestId, succeededPaths: [], retainedPaths,
+    failures: retainedPaths.map((source) => ({ source, code: "failed" })), affectedDirectories: [], notice };
+}
+function completedOutcome(requestId: string, succeededPaths: string[], affectedDirectories: string[]): FileOperationOutcome {
+  return { status: "completed", requestId, succeededPaths: boundedPaths(succeededPaths), retainedPaths: [], failures: [], affectedDirectories: firstSeen(affectedDirectories), notice: null };
+}

--- a/desktop/src/renderer/src/features/files/file-operation-controller.ts
+++ b/desktop/src/renderer/src/features/files/file-operation-controller.ts
@@ -4,13 +4,36 @@ import type {
   FileManagementApi,
   FileMovePreflight,
 } from "./file-management-api";
+import {
+  MAX_OPERATION_ROWS,
+  boundedPaths,
+  completedOutcome,
+  failedOutcome,
+  firstSeen,
+  joinPath,
+  nextRequestId,
+  noticeForError,
+  parentDirectory,
+  pendingPaths,
+  reconcileAuthoritative,
+  sameOrderedPaths,
+  samePreflight,
+  sameScope,
+  sanitizeScope,
+  staleOutcome,
+  typedFailureCode,
+  validCreateInput,
+  validChoices,
+  validMoveDestination,
+  validRenameInput,
+  validScope,
+  validScopedSources,
+  type ReconciliationPlan,
+} from "./file-operation-reconciliation";
 
 const LISTENER_CAP = 32;
 const ACTIVE_OPERATION_CAP = 8;
 const STORED_PREFLIGHT_CAP = 16;
-const RECENT_REQUEST_ID_CAP = 512;
-const MAX_ROWS = 100;
-const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export interface FileOperationScope {
   directory: string;
@@ -27,6 +50,7 @@ export type FileOperationNotice =
 
 export type FileOperationFailureCode =
   | "failed"
+  | "cleanup_failed"
   | "skipped"
   | "source_missing"
   | "destination_conflict"
@@ -97,14 +121,9 @@ export interface FileOperationController {
 }
 
 interface OperationToken { requestId: string; scope: FileOperationScope; epoch: number }
-type ReconciliationPlan =
-  | { kind: "create"; target: string }
-  | { kind: "rename"; target: string }
-  | { kind: "move"; destinationDirectory: string; ambiguousSources: string[] }
-  | { kind: "trash" };
 
 export function createFileOperationController(options: FileOperationControllerOptions): FileOperationController {
-  let snapshot = emptySnapshot(options.getScope());
+  let snapshot = emptySnapshot(sanitizeScope(options.getScope()));
   let epoch = 0;
   let closed = false;
   const listeners = new Map<number, (snapshot: FileOperationSnapshot) => void>();
@@ -126,28 +145,31 @@ export function createFileOperationController(options: FileOperationControllerOp
   const syncScope = () => {
     if (closed) return;
     const current = options.getScope();
-    if (sameScope(snapshot.scope, current)) return;
+    const safeCurrent = sanitizeScope(current);
+    const predicateCurrent = validScope(current) && (options.isScopeCurrent?.(current) ?? true);
+    if (sameScope(snapshot.scope, safeCurrent) && predicateCurrent) return;
     epoch++;
     active.clear();
     preflights.clear();
-    publish(emptySnapshot(current));
+    publish(emptySnapshot(safeCurrent));
+  };
+
+  const entryScopeCurrent = () => {
+    const current = options.getScope();
+    return validScope(current) && sameScope(snapshot.scope, current)
+      && (options.isScopeCurrent?.(current) ?? true);
   };
 
   const isCurrent = (token: OperationToken) => {
+    syncScope();
     const current = options.getScope();
-    if (!sameScope(snapshot.scope, current)) syncScope();
     const predicateCurrent = options.isScopeCurrent?.(token.scope) ?? true;
-    if (!predicateCurrent && !closed) {
-      epoch++;
-      active.clear();
-      preflights.clear();
-      publish(emptySnapshot(current));
-    }
     return !closed && token.epoch === epoch && sameScope(token.scope, current) && predicateCurrent;
   };
 
   const begin = (paths: readonly string[]): OperationToken | FileOperationOutcome => {
     syncScope();
+    if (!entryScopeCurrent()) return staleOutcome("");
     if (closed || active.size >= ACTIVE_OPERATION_CAP) {
       return failedOutcome("", paths, "operation_unavailable");
     }
@@ -185,41 +207,73 @@ export function createFileOperationController(options: FileOperationControllerOp
     return listings;
   };
 
+  const captureBaseline = async (directory: string, token: OperationToken) => {
+    try {
+      const listings = await load([directory], token);
+      return listings?.[directory] ?? null;
+    } catch (error: unknown) {
+      console.warn(
+        "[file-operation-controller] pre-operation reload failed:",
+        error instanceof Error ? error.name : typeof error,
+      );
+      return null;
+    }
+  };
+
   async function create(input: { parentDirectory: string; name: string; kind: "file" | "directory" }) {
+    syncScope();
+    if (!entryScopeCurrent()) return staleOutcome("");
+    if (!validCreateInput(input, snapshot.scope)) return failedOutcome("", [], "request_mismatch");
     const expectedPath = joinPath(input.parentDirectory, input.name);
     const started = begin([expectedPath]);
     if (!("scope" in started)) return started;
     const api = options.getApi();
     if (!api) return finish(started, failedOutcome(started.requestId, [expectedPath], "operation_unavailable"));
+    const baseline = await captureBaseline(input.parentDirectory, started);
+    if (!isCurrent(started)) return staleOutcome(started.requestId);
     try {
       const result = await api.create({ requestId: started.requestId, ...input });
       if (!isCurrent(started)) return staleOutcome(started.requestId);
       if (!await load([input.parentDirectory], started)) return staleOutcome(started.requestId);
       return finish(started, completedOutcome(started.requestId, [result.path], [input.parentDirectory]));
     } catch (error: unknown) {
-      return handleUncertain(started, [expectedPath], [input.parentDirectory], { kind: "create", target: expectedPath }, error);
+      return handleUncertain(started, [expectedPath], [input.parentDirectory], {
+        kind: "create", target: expectedPath, baseline,
+      }, error);
     }
   }
 
   async function rename(input: { path: string; name: string }) {
+    syncScope();
+    if (!entryScopeCurrent()) return staleOutcome("");
+    if (!validRenameInput(input, snapshot.scope)) return failedOutcome("", [], "request_mismatch");
     const parent = parentDirectory(input.path);
     const expectedPath = joinPath(parent, input.name);
     const started = begin([input.path]);
     if (!("scope" in started)) return started;
     const api = options.getApi();
     if (!api) return finish(started, failedOutcome(started.requestId, [input.path], "operation_unavailable"));
+    const baseline = await captureBaseline(parent, started);
+    if (!isCurrent(started)) return staleOutcome(started.requestId);
     try {
       const result = await api.rename({ requestId: started.requestId, ...input });
       if (!isCurrent(started)) return staleOutcome(started.requestId);
       if (!await load([parent], started)) return staleOutcome(started.requestId);
       return finish(started, completedOutcome(started.requestId, [result.path], [parent]));
     } catch (error: unknown) {
-      return handleUncertain(started, [input.path], [parent], { kind: "rename", target: expectedPath }, error);
+      return handleUncertain(started, [input.path], [parent], {
+        kind: "rename", target: expectedPath, baseline,
+      }, error);
     }
   }
 
   async function preflightMove(input: { sources: string[]; destinationDirectory: string }) {
-    if (!validBatchSources(input.sources)) return failedOutcome("", input.sources, "request_mismatch");
+    syncScope();
+    if (!entryScopeCurrent()) return staleOutcome("");
+    if (!validScopedSources(input.sources, snapshot.scope)
+      || !validMoveDestination(input.destinationDirectory, input.sources, snapshot.scope)) {
+      return failedOutcome("", [], "request_mismatch");
+    }
     const sources = boundedPaths(input.sources);
     const started = begin(sources);
     if (!("scope" in started)) return started;
@@ -248,6 +302,14 @@ export function createFileOperationController(options: FileOperationControllerOp
 
   async function executeMove(input: { preflight: ControllerMovePreflight; conflictChoices: FileConflictChoice[] }) {
     syncScope();
+    if (!entryScopeCurrent()) return staleOutcome(input.preflight.requestId);
+    if (!validScopedSources(input.preflight.sources, snapshot.scope)
+      || !validMoveDestination(input.preflight.destinationDirectory, input.preflight.sources, snapshot.scope)) {
+      return failedOutcome(input.preflight.requestId, [], "request_mismatch");
+    }
+    if (active.has(input.preflight.requestId)) {
+      return failedOutcome(input.preflight.requestId, input.preflight.sources, "operation_unavailable");
+    }
     const stored = preflights.get(input.preflight.requestId);
     if (!stored || !samePreflight(stored, input.preflight) || !validChoices(stored, input.conflictChoices)) {
       return failedOutcome(input.preflight.requestId, input.preflight.sources, "request_mismatch");
@@ -255,6 +317,7 @@ export function createFileOperationController(options: FileOperationControllerOp
     if (active.size >= ACTIVE_OPERATION_CAP) return failedOutcome(stored.requestId, stored.sources, "operation_unavailable");
     const token = { requestId: stored.requestId, scope: { ...snapshot.scope }, epoch };
     active.set(token.requestId, boundedPaths(stored.sources));
+    preflights.delete(token.requestId);
     publish({ ...snapshot, status: "pending", pendingPaths: pendingPaths(active), notice: null });
     const api = options.getApi();
     if (!api) return finish(token, failedOutcome(token.requestId, stored.sources, "operation_unavailable"));
@@ -263,12 +326,13 @@ export function createFileOperationController(options: FileOperationControllerOp
       const result = await api.executeMove({
         requestId: token.requestId,
         sources: stored.sources,
+        destinationDirectory: stored.destinationDirectory,
         preflightFingerprint: stored.preflightFingerprint,
         ...(input.conflictChoices.length ? { conflictChoices: input.conflictChoices } : {}),
       });
       if (!isCurrent(token)) return staleOutcome(token.requestId);
       if (!sameOrderedPaths(result.results.map((item) => item.source), stored.sources)) throw new AppError("server");
-      const affected = firstSeen([...directories, ...result.affectedDirectories]);
+      const affected = directories;
       if (!await load(affected, token)) return staleOutcome(token.requestId);
       const failures = result.results
         .filter((item) => item.code !== "moved")
@@ -277,7 +341,7 @@ export function createFileOperationController(options: FileOperationControllerOp
       preflights.delete(token.requestId);
       return finish(token, {
         status: "completed", requestId: token.requestId, succeededPaths: boundedPaths(succeeded),
-        retainedPaths: failures.map((item) => item.source), failures: failures.slice(0, MAX_ROWS),
+        retainedPaths: failures.map((item) => item.source), failures: failures.slice(0, MAX_OPERATION_ROWS),
         affectedDirectories: affected, notice: null,
       });
     } catch (error: unknown) {
@@ -291,6 +355,14 @@ export function createFileOperationController(options: FileOperationControllerOp
 
   function cancelMove(preflight: ControllerMovePreflight): FileOperationOutcome {
     syncScope();
+    if (!entryScopeCurrent()) return staleOutcome(preflight.requestId);
+    if (!validScopedSources(preflight.sources, snapshot.scope)
+      || !validMoveDestination(preflight.destinationDirectory, preflight.sources, snapshot.scope)) {
+      return failedOutcome(preflight.requestId, [], "request_mismatch");
+    }
+    if (active.has(preflight.requestId)) {
+      return failedOutcome(preflight.requestId, preflight.sources, "operation_unavailable");
+    }
     const stored = preflights.get(preflight.requestId);
     if (!stored || !samePreflight(stored, preflight)) return failedOutcome(preflight.requestId, preflight.sources, "request_mismatch");
     preflights.delete(preflight.requestId);
@@ -303,7 +375,9 @@ export function createFileOperationController(options: FileOperationControllerOp
   }
 
   async function trash(input: { sources: string[] }) {
-    if (!validBatchSources(input.sources)) return failedOutcome("", input.sources, "request_mismatch");
+    syncScope();
+    if (!entryScopeCurrent()) return staleOutcome("");
+    if (!validScopedSources(input.sources, snapshot.scope)) return failedOutcome("", [], "request_mismatch");
     const sources = boundedPaths(input.sources);
     const started = begin(sources);
     if (!("scope" in started)) return started;
@@ -336,6 +410,10 @@ export function createFileOperationController(options: FileOperationControllerOp
     error: unknown,
   ): Promise<FileOperationOutcome> {
     if (!isCurrent(token)) return staleOutcome(token.requestId);
+    const notice = noticeForError(error);
+    if (notice === "request_conflict") return finish(token, failedOutcome(token.requestId, sources, notice));
+    const typedFailure = typedFailureCode(error);
+    if (typedFailure) return finish(token, failedOutcome(token.requestId, sources, "operation_failed", typedFailure));
     let listings: Record<string, string[]> | null = null;
     try {
       listings = await load(directories, token);
@@ -347,28 +425,7 @@ export function createFileOperationController(options: FileOperationControllerOp
       listings = null;
     }
     if (!isCurrent(token)) return staleOutcome(token.requestId);
-    const notice = noticeForError(error);
-    if (notice === "request_conflict") return finish(token, failedOutcome(token.requestId, sources, notice));
-    const succeeded: string[] = [];
-    const retained: string[] = [];
-    for (const source of boundedPaths(sources)) {
-      if (listings === null || (plan.kind === "move" && plan.ambiguousSources.includes(source))) {
-        retained.push(source);
-        continue;
-      }
-      const sourcePresent = listings?.[parentDirectory(source)]?.includes(source) ?? false;
-      const target = plan.kind === "move"
-        ? joinPath(plan.destinationDirectory, basename(source))
-        : plan.kind === "create" || plan.kind === "rename" ? plan.target : null;
-      const targetPresent = target
-        ? listings?.[parentDirectory(target)]?.includes(target) ?? false
-        : false;
-      const safelySucceeded = plan.kind === "create"
-        ? targetPresent
-        : plan.kind === "trash" ? !sourcePresent : !sourcePresent && targetPresent;
-      if (safelySucceeded) succeeded.push(source);
-      else retained.push(source);
-    }
+    const { succeeded, retained } = reconcileAuthoritative(sources, listings, plan);
     const failures = retained.map((source) => ({ source, code: "failed" as const }));
     return finish(token, {
       status: "uncertain", requestId: token.requestId, succeededPaths: succeeded,
@@ -400,59 +457,11 @@ export function createFileOperationController(options: FileOperationControllerOp
       active.clear();
       preflights.clear();
       listeners.clear();
-      snapshot = emptySnapshot(options.getScope());
+      snapshot = emptySnapshot(sanitizeScope(options.getScope()));
     },
   };
 }
 
 function emptySnapshot(scope: FileOperationScope): FileOperationSnapshot {
   return { scope: { ...scope }, status: "idle", pendingPaths: [], retainedPaths: [], failures: [], notice: null, preflight: null };
-}
-function boundedPaths(paths: readonly string[], max = MAX_ROWS): string[] { return [...new Set(paths)].slice(0, max); }
-function pendingPaths(active: Map<string, string[]>): string[] { return boundedPaths([...active.values()].flat()); }
-function firstSeen(values: readonly string[]): string[] { return [...new Set(values)].slice(0, MAX_ROWS); }
-function validBatchSources(paths: readonly string[]): boolean {
-  if (paths.length < 1 || paths.length > MAX_ROWS || new Set(paths).size !== paths.length) return false;
-  return paths.every((path) => parentDirectory(path) === parentDirectory(paths[0]!));
-}
-function parentDirectory(path: string): string { const at = path.lastIndexOf("/"); return at < 0 ? "" : path.slice(0, at); }
-function basename(path: string): string { return path.slice(path.lastIndexOf("/") + 1); }
-function joinPath(parent: string, name: string): string { return parent ? `${parent}/${name}` : name; }
-function sameScope(a: FileOperationScope, b: FileOperationScope): boolean { return a.directory === b.directory && a.runtimeSlot === b.runtimeSlot && a.authGeneration === b.authGeneration; }
-function sameOrderedPaths(a: readonly string[], b: readonly string[]): boolean {
-  return a.length === b.length && a.every((path, index) => path === b[index]);
-}
-function samePreflight(a: ControllerMovePreflight, b: ControllerMovePreflight): boolean {
-  return a.requestId === b.requestId && a.preflightFingerprint === b.preflightFingerprint
-    && a.destinationDirectory === b.destinationDirectory && a.sources.join("\0") === b.sources.join("\0");
-}
-function validChoices(preflight: ControllerMovePreflight, choices: FileConflictChoice[]): boolean {
-  return choices.length === preflight.conflicts.length
-    && choices.every((choice, index) => choice.source === preflight.conflicts[index]?.source);
-}
-function nextRequestId(generate: () => string, recent: string[]): string | null {
-  for (let attempt = 0; attempt < 16; attempt++) {
-    const id = generate();
-    if (!UUID.test(id) || recent.includes(id)) continue;
-    recent.push(id);
-    if (recent.length > RECENT_REQUEST_ID_CAP) recent.shift();
-    return id;
-  }
-  return null;
-}
-function noticeForError(error: unknown): FileOperationNotice {
-  if (error instanceof AppError && error.detail === "request_id_conflict") return "request_conflict";
-  if (error instanceof AppError && error.detail === "operation_unavailable") return "authoritative_reconciliation_required";
-  return error instanceof AppError ? "authoritative_reconciliation_required" : "operation_failed";
-}
-function staleOutcome(requestId: string): FileOperationOutcome {
-  return { status: "stale", requestId, succeededPaths: [], retainedPaths: [], failures: [], affectedDirectories: [], notice: null };
-}
-function failedOutcome(requestId: string, paths: readonly string[], notice: FileOperationNotice): FileOperationOutcome {
-  const retainedPaths = boundedPaths(paths);
-  return { status: "failed", requestId, succeededPaths: [], retainedPaths,
-    failures: retainedPaths.map((source) => ({ source, code: "failed" })), affectedDirectories: [], notice };
-}
-function completedOutcome(requestId: string, succeededPaths: string[], affectedDirectories: string[]): FileOperationOutcome {
-  return { status: "completed", requestId, succeededPaths: boundedPaths(succeededPaths), retainedPaths: [], failures: [], affectedDirectories: firstSeen(affectedDirectories), notice: null };
 }

--- a/desktop/src/renderer/src/features/files/file-operation-reconciliation.ts
+++ b/desktop/src/renderer/src/features/files/file-operation-reconciliation.ts
@@ -1,5 +1,7 @@
 import { AppError } from "../../../../shared/app-error";
-import type { FileConflictChoice } from "./file-management-api";
+import { MatrixComputerRuntimeSlotSchema } from "@matrix-os/contracts";
+import { z } from "zod/v4";
+import { FileConflictChoicesSchema, type FileConflictChoice } from "./file-management-api";
 import type {
   ControllerMovePreflight,
   FileOperationFailureCode,
@@ -16,6 +18,17 @@ import {
 export const MAX_OPERATION_ROWS = 100;
 const RECENT_REQUEST_ID_CAP = 512;
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const ControllerCreateInputSchema = z.object({
+  parentDirectory: OwnerDirectoryPathSchema,
+  name: FileMutationNameSchema,
+  kind: z.enum(["file", "directory"]),
+}).strict();
+const AuthGenerationSchema = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
+const ControllerScopeSchema = z.object({
+  directory: OwnerDirectoryPathSchema,
+  runtimeSlot: MatrixComputerRuntimeSlotSchema,
+  authGeneration: AuthGenerationSchema,
+}).strict();
 
 export type ReconciliationPlan =
   | { kind: "create"; target: string; baseline: readonly string[] | null }
@@ -69,20 +82,27 @@ export function validBatchSources(paths: readonly string[]): boolean {
     && parentDirectory(path) === parentDirectory(paths[0]!));
 }
 export function sanitizeScope(scope: FileOperationScope): FileOperationScope {
-  return OwnerDirectoryPathSchema.safeParse(scope.directory).success
-    ? { ...scope }
-    : { ...scope, directory: "" };
+  const candidate = typeof scope === "object" && scope !== null
+    ? scope as unknown as Record<string, unknown>
+    : {};
+  const directory = OwnerDirectoryPathSchema.safeParse(candidate.directory);
+  const runtimeSlot = MatrixComputerRuntimeSlotSchema.safeParse(candidate.runtimeSlot);
+  const authGeneration = AuthGenerationSchema.safeParse(candidate.authGeneration);
+  return {
+    directory: directory.success ? directory.data : "",
+    runtimeSlot: runtimeSlot.success ? runtimeSlot.data : "",
+    authGeneration: authGeneration.success ? authGeneration.data : 0,
+  };
 }
 export function validScope(scope: FileOperationScope): boolean {
-  return OwnerDirectoryPathSchema.safeParse(scope.directory).success;
+  return ControllerScopeSchema.safeParse(scope).success;
 }
 export function validCreateInput(
-  input: { parentDirectory: string; name: string },
+  input: { parentDirectory: string; name: string; kind: "file" | "directory" },
   scope: FileOperationScope,
 ): boolean {
-  return OwnerDirectoryPathSchema.safeParse(input.parentDirectory).success
-    && FileMutationNameSchema.safeParse(input.name).success
-    && input.parentDirectory === scope.directory;
+  const parsed = ControllerCreateInputSchema.safeParse(input);
+  return parsed.success && parsed.data.parentDirectory === scope.directory;
 }
 export function validRenameInput(
   input: { path: string; name: string },
@@ -117,8 +137,9 @@ export function samePreflight(a: ControllerMovePreflight, b: ControllerMovePrefl
     && a.destinationDirectory === b.destinationDirectory && a.sources.join("\0") === b.sources.join("\0");
 }
 export function validChoices(preflight: ControllerMovePreflight, choices: FileConflictChoice[]): boolean {
-  return choices.length === preflight.conflicts.length
-    && choices.every((choice, index) => choice.source === preflight.conflicts[index]?.source);
+  const parsed = FileConflictChoicesSchema.safeParse(choices);
+  return parsed.success && parsed.data.length === preflight.conflicts.length
+    && parsed.data.every((choice, index) => choice.source === preflight.conflicts[index]?.source);
 }
 export function nextRequestId(generate: () => string, recent: string[]): string | null {
   for (let attempt = 0; attempt < 16; attempt++) {

--- a/desktop/src/renderer/src/features/files/file-operation-reconciliation.ts
+++ b/desktop/src/renderer/src/features/files/file-operation-reconciliation.ts
@@ -1,0 +1,169 @@
+import { AppError } from "../../../../shared/app-error";
+import type { FileConflictChoice } from "./file-management-api";
+import type {
+  ControllerMovePreflight,
+  FileOperationFailureCode,
+  FileOperationNotice,
+  FileOperationOutcome,
+  FileOperationScope,
+} from "./file-operation-controller";
+import {
+  FileMutationNameSchema,
+  OwnerDirectoryPathSchema,
+  OwnerRelativePathSchema,
+} from "./file-management-contracts";
+
+export const MAX_OPERATION_ROWS = 100;
+const RECENT_REQUEST_ID_CAP = 512;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export type ReconciliationPlan =
+  | { kind: "create"; target: string; baseline: readonly string[] | null }
+  | { kind: "rename"; target: string; baseline: readonly string[] | null }
+  | { kind: "move"; destinationDirectory: string; ambiguousSources: string[] }
+  | { kind: "trash" };
+
+export function reconcileAuthoritative(
+  sources: readonly string[],
+  listings: Record<string, string[]> | null,
+  plan: ReconciliationPlan,
+): { succeeded: string[]; retained: string[] } {
+  const succeeded: string[] = [];
+  const retained: string[] = [];
+  for (const source of boundedPaths(sources)) {
+    if (listings === null || (plan.kind === "move" && plan.ambiguousSources.includes(source))) {
+      retained.push(source);
+      continue;
+    }
+    const sourcePresent = listings[parentDirectory(source)]?.includes(source) ?? false;
+    const target = plan.kind === "move"
+      ? joinPath(plan.destinationDirectory, basename(source))
+      : plan.kind === "create" || plan.kind === "rename" ? plan.target : null;
+    const targetPresent = target
+      ? listings[parentDirectory(target)]?.includes(target) ?? false
+      : false;
+    const safelySucceeded = plan.kind === "create"
+      ? plan.baseline !== null && !plan.baseline.includes(plan.target) && targetPresent
+      : plan.kind === "rename"
+        ? plan.baseline !== null && plan.baseline.includes(source)
+          && !plan.baseline.includes(plan.target) && !sourcePresent && targetPresent
+        : plan.kind === "trash" ? !sourcePresent : !sourcePresent && targetPresent;
+    if (safelySucceeded) succeeded.push(source);
+    else retained.push(source);
+  }
+  return { succeeded, retained };
+}
+
+export function boundedPaths(paths: readonly string[], max = MAX_OPERATION_ROWS): string[] {
+  return [...new Set(paths)].slice(0, max);
+}
+export function pendingPaths(active: Map<string, string[]>): string[] {
+  return boundedPaths([...active.values()].flat());
+}
+export function firstSeen(values: readonly string[]): string[] {
+  return [...new Set(values)].slice(0, MAX_OPERATION_ROWS);
+}
+export function validBatchSources(paths: readonly string[]): boolean {
+  if (paths.length < 1 || paths.length > MAX_OPERATION_ROWS || new Set(paths).size !== paths.length) return false;
+  return paths.every((path) => OwnerRelativePathSchema.safeParse(path).success
+    && parentDirectory(path) === parentDirectory(paths[0]!));
+}
+export function sanitizeScope(scope: FileOperationScope): FileOperationScope {
+  return OwnerDirectoryPathSchema.safeParse(scope.directory).success
+    ? { ...scope }
+    : { ...scope, directory: "" };
+}
+export function validScope(scope: FileOperationScope): boolean {
+  return OwnerDirectoryPathSchema.safeParse(scope.directory).success;
+}
+export function validCreateInput(
+  input: { parentDirectory: string; name: string },
+  scope: FileOperationScope,
+): boolean {
+  return OwnerDirectoryPathSchema.safeParse(input.parentDirectory).success
+    && FileMutationNameSchema.safeParse(input.name).success
+    && input.parentDirectory === scope.directory;
+}
+export function validRenameInput(
+  input: { path: string; name: string },
+  scope: FileOperationScope,
+): boolean {
+  return OwnerRelativePathSchema.safeParse(input.path).success
+    && FileMutationNameSchema.safeParse(input.name).success
+    && parentDirectory(input.path) === scope.directory;
+}
+export function validScopedSources(paths: readonly string[], scope: FileOperationScope): boolean {
+  return validBatchSources(paths) && paths.every((path) => parentDirectory(path) === scope.directory);
+}
+export function validMoveDestination(destination: string, sources: readonly string[], scope: FileOperationScope): boolean {
+  return OwnerRelativePathSchema.safeParse(destination).success
+    && destination !== scope.directory
+    && sources.every((source) => destination !== source && !destination.startsWith(`${source}/`));
+}
+export function parentDirectory(path: string): string {
+  const at = path.lastIndexOf("/");
+  return at < 0 ? "" : path.slice(0, at);
+}
+export function basename(path: string): string { return path.slice(path.lastIndexOf("/") + 1); }
+export function joinPath(parent: string, name: string): string { return parent ? `${parent}/${name}` : name; }
+export function sameScope(a: FileOperationScope, b: FileOperationScope): boolean {
+  return a.directory === b.directory && a.runtimeSlot === b.runtimeSlot && a.authGeneration === b.authGeneration;
+}
+export function sameOrderedPaths(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((path, index) => path === b[index]);
+}
+export function samePreflight(a: ControllerMovePreflight, b: ControllerMovePreflight): boolean {
+  return a.requestId === b.requestId && a.preflightFingerprint === b.preflightFingerprint
+    && a.destinationDirectory === b.destinationDirectory && a.sources.join("\0") === b.sources.join("\0");
+}
+export function validChoices(preflight: ControllerMovePreflight, choices: FileConflictChoice[]): boolean {
+  return choices.length === preflight.conflicts.length
+    && choices.every((choice, index) => choice.source === preflight.conflicts[index]?.source);
+}
+export function nextRequestId(generate: () => string, recent: string[]): string | null {
+  for (let attempt = 0; attempt < 16; attempt++) {
+    const id = generate();
+    if (!UUID.test(id) || recent.includes(id)) continue;
+    recent.push(id);
+    if (recent.length > RECENT_REQUEST_ID_CAP) recent.shift();
+    return id;
+  }
+  return null;
+}
+export function noticeForError(error: unknown): FileOperationNotice {
+  if (error instanceof AppError && error.detail === "request_id_conflict") return "request_conflict";
+  if (error instanceof AppError && error.detail === "operation_unavailable") return "authoritative_reconciliation_required";
+  return error instanceof AppError ? "authoritative_reconciliation_required" : "operation_failed";
+}
+export function typedFailureCode(error: unknown): FileOperationFailureCode | null {
+  if (!(error instanceof AppError)) return null;
+  if (error.detail === "destination_conflict") return "destination_conflict";
+  if (error.detail === "protected") return "protected";
+  if (error.detail === "invalid_path" || error.detail === "invalid_destination") return "invalid_destination";
+  if (error.detail === "source_missing") return "source_missing";
+  if (error.detail === "cleanup_failed") return "cleanup_failed";
+  if (error.detail === "failed") return "failed";
+  if (error.detail === "invalid_request") return "invalid_destination";
+  return null;
+}
+export function staleOutcome(requestId: string): FileOperationOutcome {
+  return { status: "stale", requestId, succeededPaths: [], retainedPaths: [], failures: [], affectedDirectories: [], notice: null };
+}
+export function failedOutcome(
+  requestId: string,
+  paths: readonly string[],
+  notice: FileOperationNotice,
+  code: FileOperationFailureCode = "failed",
+): FileOperationOutcome {
+  const retainedPaths = boundedPaths(paths);
+  return { status: "failed", requestId, succeededPaths: [], retainedPaths,
+    failures: retainedPaths.map((source) => ({ source, code })), affectedDirectories: [], notice };
+}
+export function completedOutcome(
+  requestId: string,
+  succeededPaths: string[],
+  affectedDirectories: string[],
+): FileOperationOutcome {
+  return { status: "completed", requestId, succeededPaths: boundedPaths(succeededPaths), retainedPaths: [],
+    failures: [], affectedDirectories: firstSeen(affectedDirectories), notice: null };
+}

--- a/desktop/src/renderer/src/features/files/file-selection.ts
+++ b/desktop/src/renderer/src/features/files/file-selection.ts
@@ -1,4 +1,7 @@
-export const MAX_FILE_SELECTION = 100;
+import { MAX_BROWSER_ENTRIES } from "./browser-entries";
+
+export const MAX_FILE_BATCH_SIZE = 100;
+export const MAX_FILE_SELECTION = MAX_BROWSER_ENTRIES;
 
 export interface FileSelectionScope {
   directory: string;
@@ -104,10 +107,8 @@ export function beginFileDrag(
     .filter((selectedPath) => parentDirectory(selectedPath) === state.scope.directory)
     .slice(0, MAX_FILE_SELECTION);
   if (siblingSelection.includes(path)) {
-    const nextState = siblingSelection === state.selectedPaths
-      ? state
-      : { ...state, selectedPaths: siblingSelection };
-    return { state: nextState, dragPaths: [...siblingSelection] };
+    if (siblingSelection.length > MAX_FILE_BATCH_SIZE) return { state, dragPaths: [] };
+    return { state: { ...state, selectedPaths: siblingSelection }, dragPaths: [...siblingSelection] };
   }
   const nextState = singleSelection(state.scope, path);
   return { state: nextState, dragPaths: [path] };
@@ -118,7 +119,7 @@ function singleSelection(scope: FileSelectionScope, path: string): FileSelection
 }
 
 function orderSelected(renderedPaths: readonly string[], selectedPaths: readonly string[]): string[] {
-  const selected = new Set(selectedPaths.slice(0, MAX_FILE_SELECTION * 2));
+  const selected = new Set(selectedPaths.slice(0, MAX_FILE_SELECTION));
   return renderedPaths.filter((path) => selected.has(path)).slice(0, MAX_FILE_SELECTION);
 }
 

--- a/desktop/src/renderer/src/features/files/file-selection.ts
+++ b/desktop/src/renderer/src/features/files/file-selection.ts
@@ -1,0 +1,134 @@
+export const MAX_FILE_SELECTION = 100;
+
+export interface FileSelectionScope {
+  directory: string;
+  runtimeSlot: string;
+  authGeneration: number;
+}
+
+export interface FileSelectionState {
+  scope: FileSelectionScope;
+  selectedPaths: string[];
+  anchorPath: string | null;
+  focusedPath: string | null;
+}
+
+export type FileSelectionPlatform = "mac" | "windows" | "linux";
+
+export interface FileSelectionModifiers {
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+}
+
+export function createFileSelection(scope: FileSelectionScope): FileSelectionState {
+  return {
+    scope: { ...scope },
+    selectedPaths: [],
+    anchorPath: null,
+    focusedPath: null,
+  };
+}
+
+export function resetFileSelectionScope(
+  state: FileSelectionState,
+  scope: FileSelectionScope,
+): FileSelectionState {
+  return sameScope(state.scope, scope) ? state : createFileSelection(scope);
+}
+
+export function updateFileSelection(
+  state: FileSelectionState,
+  renderedPaths: readonly string[],
+  clickedPath: string,
+  modifiers: FileSelectionModifiers,
+  platform: FileSelectionPlatform,
+): FileSelectionState {
+  const visible = renderedPaths.filter((path) => parentDirectory(path) === state.scope.directory);
+  const clickedIndex = visible.indexOf(clickedPath);
+  if (clickedIndex < 0 || parentDirectory(clickedPath) !== state.scope.directory) return state;
+
+  const additive = platform === "mac" ? modifiers.metaKey === true : modifiers.ctrlKey === true;
+  if (modifiers.shiftKey) {
+    const anchorIndex = state.anchorPath ? visible.indexOf(state.anchorPath) : -1;
+    if (anchorIndex < 0) return singleSelection(state.scope, clickedPath);
+    const start = Math.min(anchorIndex, clickedIndex);
+    const end = Math.max(anchorIndex, clickedIndex);
+    const range = visible.slice(start, end + 1);
+    const selected = additive
+      ? orderSelected(visible, [...state.selectedPaths, ...range])
+      : range.slice(0, MAX_FILE_SELECTION);
+    return {
+      scope: state.scope,
+      selectedPaths: selected,
+      anchorPath: state.anchorPath,
+      focusedPath: clickedPath,
+    };
+  }
+
+  if (!additive) return singleSelection(state.scope, clickedPath);
+  const next = state.selectedPaths.includes(clickedPath)
+    ? state.selectedPaths.filter((path) => path !== clickedPath)
+    : [...state.selectedPaths, clickedPath];
+  return {
+    scope: state.scope,
+    selectedPaths: orderSelected(visible, next),
+    anchorPath: clickedPath,
+    focusedPath: clickedPath,
+  };
+}
+
+export function reconcileFileSelection(
+  state: FileSelectionState,
+  scope: FileSelectionScope,
+  renderedPaths: readonly string[],
+): FileSelectionState {
+  if (!sameScope(state.scope, scope)) return createFileSelection(scope);
+  const visibleSiblings = renderedPaths.filter((path) => parentDirectory(path) === scope.directory);
+  const selectedPaths = orderSelected(visibleSiblings, state.selectedPaths);
+  const anchorPath = state.anchorPath && selectedPaths.includes(state.anchorPath)
+    ? state.anchorPath
+    : selectedPaths[0] ?? null;
+  const focusedPath = state.focusedPath && visibleSiblings.includes(state.focusedPath)
+    ? state.focusedPath
+    : selectedPaths[0] ?? null;
+  return { scope: state.scope, selectedPaths, anchorPath, focusedPath };
+}
+
+export function beginFileDrag(
+  state: FileSelectionState,
+  path: string,
+): { state: FileSelectionState; dragPaths: string[] } {
+  if (parentDirectory(path) !== state.scope.directory) return { state, dragPaths: [] };
+  const siblingSelection = state.selectedPaths
+    .filter((selectedPath) => parentDirectory(selectedPath) === state.scope.directory)
+    .slice(0, MAX_FILE_SELECTION);
+  if (siblingSelection.includes(path)) {
+    const nextState = siblingSelection === state.selectedPaths
+      ? state
+      : { ...state, selectedPaths: siblingSelection };
+    return { state: nextState, dragPaths: [...siblingSelection] };
+  }
+  const nextState = singleSelection(state.scope, path);
+  return { state: nextState, dragPaths: [path] };
+}
+
+function singleSelection(scope: FileSelectionScope, path: string): FileSelectionState {
+  return { scope, selectedPaths: [path], anchorPath: path, focusedPath: path };
+}
+
+function orderSelected(renderedPaths: readonly string[], selectedPaths: readonly string[]): string[] {
+  const selected = new Set(selectedPaths.slice(0, MAX_FILE_SELECTION * 2));
+  return renderedPaths.filter((path) => selected.has(path)).slice(0, MAX_FILE_SELECTION);
+}
+
+function sameScope(left: FileSelectionScope, right: FileSelectionScope): boolean {
+  return left.directory === right.directory
+    && left.runtimeSlot === right.runtimeSlot
+    && left.authGeneration === right.authGeneration;
+}
+
+function parentDirectory(path: string): string {
+  const separator = path.lastIndexOf("/");
+  return separator < 0 ? "" : path.slice(0, separator);
+}

--- a/desktop/src/renderer/src/features/files/use-directory-sync.ts
+++ b/desktop/src/renderer/src/features/files/use-directory-sync.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useRef } from "react";
+import type {
+  FileDirectoryHandler,
+  FileDirectoryServerMessage,
+} from "../../lib/kernel-socket";
+
+export const DIRECTORY_CHANGE_DEBOUNCE_MS = 150;
+
+export interface DirectorySyncSocket {
+  subscribeDirectory(directory: string, handler: FileDirectoryHandler): () => void;
+  touchDirectory(directory: string): boolean;
+}
+
+export interface DirectorySyncScope {
+  runtimeSlot: string;
+  authGeneration: number;
+}
+
+export interface UseDirectorySyncOptions<T> extends DirectorySyncScope {
+  socket: DirectorySyncSocket;
+  directory: string;
+  loadDirectory(directory: string, scope: DirectorySyncScope): Promise<T>;
+  onReconciled(value: T): void;
+}
+
+export interface DirectorySyncHandle {
+  touch(): boolean;
+}
+
+export function useDirectorySync<T>(options: UseDirectorySyncOptions<T>): DirectorySyncHandle {
+  const activeRef = useRef(false);
+
+  useEffect(() => {
+    let active = true;
+    let revision: number | null = null;
+    let reloadGeneration = 0;
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    activeRef.current = true;
+    const scope = {
+      runtimeSlot: options.runtimeSlot,
+      authGeneration: options.authGeneration,
+    };
+
+    const cancelDebounce = () => {
+      if (debounceTimer !== null) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
+    };
+
+    const reload = async () => {
+      const generation = ++reloadGeneration;
+      try {
+        const value = await options.loadDirectory(options.directory, scope);
+        if (!active || generation !== reloadGeneration) return;
+        options.onReconciled(value);
+      } catch (error: unknown) {
+        if (!active || generation !== reloadGeneration) return;
+        console.warn(
+          "[directory-sync] authoritative reload failed:",
+          error instanceof Error ? error.name : typeof error,
+        );
+      }
+    };
+
+    const reloadImmediately = () => {
+      cancelDebounce();
+      void reload();
+    };
+
+    const scheduleReload = () => {
+      cancelDebounce();
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        void reload();
+      }, DIRECTORY_CHANGE_DEBOUNCE_MS);
+    };
+
+    const onMessage = (message: FileDirectoryServerMessage) => {
+      if (!active) return;
+      if (message.type === "files:shutdown") {
+        revision = null;
+        reloadImmediately();
+        return;
+      }
+      if (message.directory !== options.directory) return;
+      if (message.type === "files:subscribed") {
+        revision = message.revision;
+        reloadImmediately();
+        return;
+      }
+      if (revision === null || message.revision !== revision + 1) {
+        revision = message.revision;
+        reloadImmediately();
+        return;
+      }
+      revision = message.revision;
+      scheduleReload();
+    };
+
+    const unsubscribe = options.socket.subscribeDirectory(options.directory, onMessage);
+    return () => {
+      active = false;
+      activeRef.current = false;
+      reloadGeneration++;
+      cancelDebounce();
+      unsubscribe();
+    };
+  }, [
+    options.socket,
+    options.directory,
+    options.runtimeSlot,
+    options.authGeneration,
+    options.loadDirectory,
+    options.onReconciled,
+  ]);
+
+  const touch = useCallback(() => {
+    return activeRef.current && options.socket.touchDirectory(options.directory);
+  }, [options.socket, options.directory, options.runtimeSlot, options.authGeneration]);
+
+  return { touch };
+}

--- a/desktop/src/renderer/src/lib/api.ts
+++ b/desktop/src/renderer/src/lib/api.ts
@@ -67,9 +67,11 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
       // callers can surface a specific reason instead of only the generic copy.
       let detail: string | undefined;
       try {
-        const body = (await response.clone().json()) as { error?: unknown };
+        const body = (await response.clone().json()) as { error?: unknown; code?: unknown };
         const err = body.error;
-        detail = safeErrorDetail(typeof err === "object" && err ? (err as { code?: unknown }).code : err);
+        detail = safeErrorDetail(
+          typeof err === "object" && err ? (err as { code?: unknown }).code : body.code ?? err,
+        );
       } catch {
         // Non-JSON / empty body — no detail to surface.
       }

--- a/desktop/src/renderer/src/lib/api.ts
+++ b/desktop/src/renderer/src/lib/api.ts
@@ -67,10 +67,17 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
       // callers can surface a specific reason instead of only the generic copy.
       let detail: string | undefined;
       try {
-        const body = (await response.clone().json()) as { error?: unknown; code?: unknown };
+        const body = (await response.clone().json()) as {
+          error?: unknown;
+          code?: unknown;
+          errorCode?: unknown;
+        };
         const err = body.error;
         detail = safeErrorDetail(
-          typeof err === "object" && err ? (err as { code?: unknown }).code : body.code ?? err,
+          (typeof err === "object" && err ? (err as { code?: unknown }).code : undefined)
+            ?? body.code
+            ?? body.errorCode
+            ?? (typeof err !== "object" ? err : undefined),
         );
       } catch {
         // Non-JSON / empty body — no detail to surface.

--- a/desktop/src/renderer/src/lib/kernel-socket.ts
+++ b/desktop/src/renderer/src/lib/kernel-socket.ts
@@ -61,8 +61,10 @@ const BACKOFF_BASE_MS = 500;
 const BACKOFF_MAX_MS = 30_000;
 const OFFLINE_AFTER_FAILURES = 3;
 const MAX_FRAME_CHARS = 1_000_000;
+const MAX_FRAME_BYTES = 1_000_000;
 const FILE_DIRECTORY_CAP = 8;
 const FILE_HANDLER_CAP = 64;
+const UTF8_ENCODER = new TextEncoder();
 
 const RevisionSchema = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
 const FileDirectoryClientMessageSchema = z.discriminatedUnion("type", [
@@ -350,6 +352,7 @@ export class KernelSocket {
     if (typeof data !== "string" || data.length === 0 || data.length > MAX_FRAME_CHARS) {
       return;
     }
+    if (UTF8_ENCODER.encode(data).byteLength > MAX_FRAME_BYTES) return;
     let parsed: unknown;
     try {
       parsed = JSON.parse(data);

--- a/desktop/src/renderer/src/lib/kernel-socket.ts
+++ b/desktop/src/renderer/src/lib/kernel-socket.ts
@@ -3,6 +3,10 @@
 // are injectable for tests. Known message types are validated with zod;
 // unknown types pass through to subscribers for forward compatibility.
 import { z } from "zod/v4";
+import {
+  FileEntryNameSchema,
+  OwnerDirectoryPathSchema,
+} from "../features/files/file-management-contracts";
 
 export type KernelConnectionState = "connecting" | "connected" | "reconnecting" | "offline";
 
@@ -15,7 +19,18 @@ export type KernelClientMessage =
   | { type: "message"; text: string; sessionId?: string; requestId: string }
   | { type: "abort"; requestId: string }
   | { type: "approval_response"; id: string; approved: boolean }
-  | { type: "ping" };
+  | { type: "ping" }
+  | FileDirectoryClientMessage;
+
+export type FileDirectoryClientMessage =
+  | { type: "files:subscribe"; directory: string }
+  | { type: "files:unsubscribe"; directory: string }
+  | { type: "files:touch"; directory: string };
+
+export type FileDirectoryServerMessage =
+  | { type: "files:subscribed"; directory: string; revision: number }
+  | { type: "files:change"; directory: string; entry: string; event: "add" | "change" | "unlink"; revision: number }
+  | { type: "files:shutdown" };
 
 // Structurally identical to the browser WebSocket subset the socket needs.
 export interface WebSocketLike {
@@ -46,6 +61,15 @@ const BACKOFF_BASE_MS = 500;
 const BACKOFF_MAX_MS = 30_000;
 const OFFLINE_AFTER_FAILURES = 3;
 const MAX_FRAME_CHARS = 1_000_000;
+const FILE_DIRECTORY_CAP = 8;
+const FILE_HANDLER_CAP = 64;
+
+const RevisionSchema = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
+const FileDirectoryClientMessageSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("files:subscribe"), directory: OwnerDirectoryPathSchema }).strict(),
+  z.object({ type: z.literal("files:unsubscribe"), directory: OwnerDirectoryPathSchema }).strict(),
+  z.object({ type: z.literal("files:touch"), directory: OwnerDirectoryPathSchema }).strict(),
+]);
 
 const requestIdField = z.string().min(1).max(256).optional();
 
@@ -75,6 +99,15 @@ export const KnownKernelMessageSchema = z.discriminatedUnion("type", [
     timeout: z.number(),
   }),
   z.looseObject({ type: z.literal("pong") }),
+  z.object({ type: z.literal("files:subscribed"), directory: OwnerDirectoryPathSchema, revision: RevisionSchema }).strict(),
+  z.object({
+    type: z.literal("files:change"),
+    directory: OwnerDirectoryPathSchema,
+    entry: FileEntryNameSchema,
+    event: z.enum(["add", "change", "unlink"]),
+    revision: RevisionSchema,
+  }).strict(),
+  z.object({ type: z.literal("files:shutdown") }).strict(),
 ]);
 
 export type KnownKernelMessage = z.infer<typeof KnownKernelMessageSchema>;
@@ -104,6 +137,11 @@ export function buildKernelWsUrl(baseUrl: string, runtimeSlot: string): string {
 
 type MessageHandler = (msg: KernelServerMessage) => void;
 type StateHandler = (state: KernelConnectionState) => void;
+export type FileDirectoryHandler = (message: FileDirectoryServerMessage) => void;
+
+interface DirectorySubscription {
+  handlers: Map<number, FileDirectoryHandler>;
+}
 
 export class KernelSocket {
   private readonly baseUrl: string;
@@ -117,6 +155,9 @@ export class KernelSocket {
   private readonly handlers = new Set<MessageHandler>();
   private readonly stateHandlers = new Set<StateHandler>();
   private readonly sendQueue: string[] = [];
+  private readonly directorySubscriptions = new Map<string, DirectorySubscription>();
+  private nextDirectoryHandlerId = 1;
+  private directoryHandlerCount = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private attempt = 0;
   private consecutiveFailures = 0;
@@ -168,6 +209,7 @@ export class KernelSocket {
     socket.onopen = () => {
       this.attempt = 0;
       this.consecutiveFailures = 0;
+      this.resubscribeDirectories();
       this.setState("connected");
       this.drainQueue();
     };
@@ -214,7 +256,50 @@ export class KernelSocket {
     };
   }
 
+  subscribeDirectory(directory: string, handler: FileDirectoryHandler): () => void {
+    if (this.disposed) throw new Error("KernelSocket is disposed");
+    const parsed = OwnerDirectoryPathSchema.safeParse(directory);
+    if (!parsed.success) throw new Error("Invalid file directory subscription");
+    if (this.directoryHandlerCount >= FILE_HANDLER_CAP) {
+      throw new Error(`KernelSocket file handler cap (${FILE_HANDLER_CAP}) exceeded`);
+    }
+    let subscription = this.directorySubscriptions.get(parsed.data);
+    if (!subscription) {
+      if (this.directorySubscriptions.size >= FILE_DIRECTORY_CAP) {
+        throw new Error(`KernelSocket file directory cap (${FILE_DIRECTORY_CAP}) exceeded`);
+      }
+      subscription = { handlers: new Map() };
+      this.directorySubscriptions.set(parsed.data, subscription);
+      this.sendDirectoryFrame({ type: "files:subscribe", directory: parsed.data });
+    }
+    const id = this.nextDirectoryHandlerId++;
+    subscription.handlers.set(id, handler);
+    this.directoryHandlerCount++;
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+      const current = this.directorySubscriptions.get(parsed.data);
+      if (!current?.handlers.delete(id)) return;
+      this.directoryHandlerCount--;
+      if (current.handlers.size === 0) {
+        this.directorySubscriptions.delete(parsed.data);
+        this.sendDirectoryFrame({ type: "files:unsubscribe", directory: parsed.data });
+      }
+    };
+  }
+
+  touchDirectory(directory: string): boolean {
+    const parsed = OwnerDirectoryPathSchema.safeParse(directory);
+    if (!parsed.success || !this.directorySubscriptions.has(parsed.data)) return false;
+    return this.sendDirectoryFrame({ type: "files:touch", directory: parsed.data });
+  }
+
   send(msg: KernelClientMessage): void {
+    if (msg.type.startsWith("files:")) {
+      if (msg.type === "files:touch") this.touchDirectory(msg.directory);
+      return;
+    }
     const data = JSON.stringify(msg);
     if (this.socket?.readyState === WS_OPEN) {
       try {
@@ -255,6 +340,8 @@ export class KernelSocket {
       }
     }
     this.setState("offline");
+    this.directorySubscriptions.clear();
+    this.directoryHandlerCount = 0;
     this.handlers.clear();
     this.stateHandlers.clear();
   }
@@ -269,12 +356,13 @@ export class KernelSocket {
     } catch (err: unknown) {
       console.warn(
         "[kernel-socket] dropping unparseable frame:",
-        err instanceof Error ? err.message : err,
+        err instanceof Error ? err.name : typeof err,
       );
       return;
     }
     const msg = parseKernelServerMessage(parsed);
     if (!msg) return;
+    if (isFileDirectoryServerMessage(msg)) this.routeDirectoryMessage(msg);
     for (const handler of [...this.handlers]) {
       try {
         handler(msg);
@@ -321,6 +409,47 @@ export class KernelSocket {
     }
   }
 
+  private resubscribeDirectories(): void {
+    for (const directory of this.directorySubscriptions.keys()) {
+      this.sendDirectoryFrame({ type: "files:subscribe", directory });
+    }
+  }
+
+  private sendDirectoryFrame(message: FileDirectoryClientMessage): boolean {
+    if (!FileDirectoryClientMessageSchema.safeParse(message).success) return false;
+    if (this.socket?.readyState !== WS_OPEN) return false;
+    try {
+      this.socket.send(JSON.stringify(message));
+      return true;
+    } catch (err: unknown) {
+      console.warn(
+        "[kernel-socket] file directory send failed:",
+        err instanceof Error ? err.name : typeof err,
+      );
+      return false;
+    }
+  }
+
+  private routeDirectoryMessage(message: FileDirectoryServerMessage): void {
+    const subscriptions = message.type === "files:shutdown"
+      ? [...this.directorySubscriptions.values()]
+      : [this.directorySubscriptions.get(message.directory)].filter(
+          (entry): entry is DirectorySubscription => entry !== undefined,
+        );
+    for (const subscription of subscriptions) {
+      for (const handler of [...subscription.handlers.values()]) {
+        try {
+          handler(message);
+        } catch (err: unknown) {
+          console.warn(
+            "[kernel-socket] file directory handler failed:",
+            err instanceof Error ? err.name : typeof err,
+          );
+        }
+      }
+    }
+  }
+
   private setState(state: KernelConnectionState): void {
     if (this.currentState === state) return;
     this.currentState = state;
@@ -342,4 +471,10 @@ export class KernelSocket {
       this.reconnectTimer = null;
     }
   }
+}
+
+function isFileDirectoryServerMessage(message: KernelServerMessage): message is FileDirectoryServerMessage {
+  return message.type === "files:subscribed"
+    || message.type === "files:change"
+    || message.type === "files:shutdown";
 }

--- a/tests/desktop/api-client.test.ts
+++ b/tests/desktop/api-client.test.ts
@@ -81,8 +81,11 @@ describe("createApiClient", () => {
     expect(onUnauthorized).not.toHaveBeenCalled();
   });
 
-  it("preserves a safe top-level Gateway error code without surfacing raw detail", async () => {
+  it("preserves safe Gateway error codes in nested, top-level, legacy, then scalar order", async () => {
     const fetchFn = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(409, { error: { code: "protected" }, code: "destination_conflict" }))
+      .mockResolvedValueOnce(jsonResponse(409, { error: {}, code: "destination_conflict" }))
+      .mockResolvedValueOnce(jsonResponse(400, { errorCode: "invalid_path" }))
       .mockResolvedValueOnce(jsonResponse(409, { error: "Request conflict", code: "request_id_conflict" }))
       .mockResolvedValueOnce(jsonResponse(500, { error: "/private/provider raw", code: "/private/provider raw" }));
     const client = createApiClient({
@@ -91,10 +94,9 @@ describe("createApiClient", () => {
       fetchFn,
     });
 
-    await expect(client.post("/api/files/batch/move", {})).rejects.toMatchObject({
-      category: "server",
-      detail: "request_id_conflict",
-    });
+    for (const detail of ["protected", "destination_conflict", "invalid_path", "request_id_conflict"]) {
+      await expect(client.post("/api/files/batch/move", {})).rejects.toMatchObject({ category: "server", detail });
+    }
     await expect(client.post("/api/files/batch/move", {})).rejects.toMatchObject({
       category: "server",
       detail: undefined,

--- a/tests/desktop/api-client.test.ts
+++ b/tests/desktop/api-client.test.ts
@@ -81,6 +81,26 @@ describe("createApiClient", () => {
     expect(onUnauthorized).not.toHaveBeenCalled();
   });
 
+  it("preserves a safe top-level Gateway error code without surfacing raw detail", async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(409, { error: "Request conflict", code: "request_id_conflict" }))
+      .mockResolvedValueOnce(jsonResponse(500, { error: "/private/provider raw", code: "/private/provider raw" }));
+    const client = createApiClient({
+      baseUrl: "https://x.test",
+      getRuntimeSlot: () => "primary",
+      fetchFn,
+    });
+
+    await expect(client.post("/api/files/batch/move", {})).rejects.toMatchObject({
+      category: "server",
+      detail: "request_id_conflict",
+    });
+    await expect(client.post("/api/files/batch/move", {})).rejects.toMatchObject({
+      category: "server",
+      detail: undefined,
+    });
+  });
+
   it("maps network failure to offline", async () => {
     const fetchFn = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
     const client = createApiClient({

--- a/tests/desktop/file-directory-sync.test.tsx
+++ b/tests/desktop/file-directory-sync.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useDirectorySync,
+  type DirectorySyncSocket,
+} from "@desktop/renderer/src/features/files/use-directory-sync";
+import type { FileDirectoryServerMessage } from "@desktop/renderer/src/lib/kernel-socket";
+
+class FakeDirectorySocket implements DirectorySyncSocket {
+  readonly subscriptions: Array<{ directory: string; handler: (message: FileDirectoryServerMessage) => void; active: boolean }> = [];
+  readonly subscribeDirectory = vi.fn((directory: string, handler: (message: FileDirectoryServerMessage) => void) => {
+    const record = { directory, handler, active: true };
+    this.subscriptions.push(record);
+    return () => { record.active = false; };
+  });
+  readonly touchDirectory = vi.fn(() => true);
+
+  emit(message: FileDirectoryServerMessage): void {
+    for (const subscription of this.subscriptions) {
+      if (subscription.active && (message.type === "files:shutdown" || message.directory === subscription.directory)) {
+        subscription.handler(message);
+      }
+    }
+  }
+}
+
+async function flush(): Promise<void> {
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe("useDirectorySync", () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { cleanup(); vi.useRealTimers(); vi.restoreAllMocks(); });
+
+  it("subscribes the current scope, exposes best-effort touch, and unsubscribes on cleanup", () => {
+    const socket = new FakeDirectorySocket();
+    const { result, unmount } = renderHook(() => useDirectorySync({
+      socket, directory: "projects", runtimeSlot: "primary", authGeneration: 1,
+      loadDirectory: async () => [], onReconciled: () => {},
+    }));
+
+    expect(socket.subscribeDirectory).toHaveBeenCalledWith("projects", expect.any(Function));
+    expect(result.current.touch()).toBe(true);
+    expect(socket.touchDirectory).toHaveBeenCalledWith("projects");
+    unmount();
+    expect(socket.subscriptions[0]?.active).toBe(false);
+    expect(result.current.touch()).toBe(false);
+  });
+
+  it("establishes each subscribed baseline with an authoritative reload", async () => {
+    const socket = new FakeDirectorySocket();
+    const loadDirectory = vi.fn().mockResolvedValue(["projects/a"]);
+    const onReconciled = vi.fn();
+    renderHook(() => useDirectorySync({
+      socket, directory: "projects", runtimeSlot: "primary", authGeneration: 1,
+      loadDirectory, onReconciled,
+    }));
+
+    act(() => socket.emit({ type: "files:subscribed", directory: "projects", revision: 4 }));
+    await flush();
+    act(() => socket.emit({ type: "files:subscribed", directory: "projects", revision: 0 }));
+    await flush();
+
+    expect(loadDirectory).toHaveBeenCalledTimes(2);
+    expect(onReconciled).toHaveBeenNthCalledWith(1, ["projects/a"]);
+    expect(onReconciled).toHaveBeenNthCalledWith(2, ["projects/a"]);
+  });
+
+  it("debounces an exact revision burst for exactly 150 ms", async () => {
+    const socket = new FakeDirectorySocket();
+    const loadDirectory = vi.fn().mockResolvedValue([]);
+    renderHook(() => useDirectorySync({
+      socket, directory: "projects", runtimeSlot: "primary", authGeneration: 1,
+      loadDirectory, onReconciled: () => {},
+    }));
+    act(() => socket.emit({ type: "files:subscribed", directory: "projects", revision: 0 }));
+    await flush();
+    loadDirectory.mockClear();
+
+    act(() => {
+      socket.emit({ type: "files:change", directory: "projects", entry: "a", event: "add", revision: 1 });
+      vi.advanceTimersByTime(75);
+      socket.emit({ type: "files:change", directory: "projects", entry: "b", event: "change", revision: 2 });
+      socket.emit({ type: "files:change", directory: "projects", entry: "c", event: "unlink", revision: 3 });
+      vi.advanceTimersByTime(149);
+    });
+    expect(loadDirectory).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(1));
+    await flush();
+    expect(loadDirectory).toHaveBeenCalledOnce();
+  });
+
+  it("reloads immediately on a revision gap, decrease/reset, missing baseline, or shutdown", async () => {
+    const socket = new FakeDirectorySocket();
+    const loadDirectory = vi.fn().mockResolvedValue([]);
+    renderHook(() => useDirectorySync({
+      socket, directory: "projects", runtimeSlot: "primary", authGeneration: 1,
+      loadDirectory, onReconciled: () => {},
+    }));
+
+    act(() => socket.emit({ type: "files:change", directory: "projects", entry: "a", event: "add", revision: 5 }));
+    await flush();
+    act(() => socket.emit({ type: "files:change", directory: "projects", entry: "b", event: "add", revision: 7 }));
+    await flush();
+    act(() => socket.emit({ type: "files:change", directory: "projects", entry: "c", event: "change", revision: 2 }));
+    await flush();
+    act(() => socket.emit({ type: "files:shutdown" }));
+    await flush();
+
+    expect(loadDirectory).toHaveBeenCalledTimes(4);
+  });
+
+  it("cancels a stale debounce on directory/runtime/auth changes", async () => {
+    const socket = new FakeDirectorySocket();
+    const loadDirectory = vi.fn().mockResolvedValue([]);
+    const props = { directory: "projects", runtimeSlot: "primary", authGeneration: 1 };
+    const { rerender } = renderHook(
+      (current: typeof props) => useDirectorySync({ socket, ...current, loadDirectory, onReconciled: () => {} }),
+      { initialProps: props },
+    );
+    act(() => socket.emit({ type: "files:subscribed", directory: "projects", revision: 0 }));
+    await flush();
+    loadDirectory.mockClear();
+    act(() => socket.emit({ type: "files:change", directory: "projects", entry: "a", event: "add", revision: 1 }));
+
+    rerender({ directory: "archive", runtimeSlot: "preview", authGeneration: 2 });
+    act(() => vi.advanceTimersByTime(150));
+    await flush();
+
+    expect(loadDirectory).not.toHaveBeenCalled();
+    expect(socket.subscriptions.map((subscription) => [subscription.directory, subscription.active])).toEqual([
+      ["projects", false], ["archive", true],
+    ]);
+  });
+
+  it("suppresses a stale reload promise from a previous scope", async () => {
+    let resolveOld!: (value: string[]) => void;
+    const oldLoad = new Promise<string[]>((resolve) => { resolveOld = resolve; });
+    const socket = new FakeDirectorySocket();
+    const loadDirectory = vi.fn()
+      .mockReturnValueOnce(oldLoad)
+      .mockResolvedValueOnce(["archive/new"]);
+    const onReconciled = vi.fn();
+    const { rerender } = renderHook(
+      (props: { directory: string; runtimeSlot: string; authGeneration: number }) =>
+        useDirectorySync({ socket, ...props, loadDirectory, onReconciled }),
+      { initialProps: { directory: "projects", runtimeSlot: "primary", authGeneration: 1 } },
+    );
+    act(() => socket.emit({ type: "files:subscribed", directory: "projects", revision: 0 }));
+    rerender({ directory: "archive", runtimeSlot: "preview", authGeneration: 2 });
+    act(() => socket.emit({ type: "files:subscribed", directory: "archive", revision: 0 }));
+    await flush();
+    expect(onReconciled).toHaveBeenCalledWith(["archive/new"]);
+
+    resolveOld(["projects/stale"]);
+    await flush();
+    expect(onReconciled).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/desktop/file-management-api.test.ts
+++ b/tests/desktop/file-management-api.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  FILE_MUTATION_TIMEOUT_MS,
+  createFileManagementApi,
+} from "@desktop/renderer/src/features/files/file-management-api";
+import { AppError } from "@desktop/renderer/src/lib/errors";
+import type { ApiClient } from "@desktop/renderer/src/lib/api";
+import { parseBrowserEntries } from "@desktop/renderer/src/features/files/browser-entries";
+
+const REQUEST_ID = "123e4567-e89b-42d3-a456-426614174000";
+
+function makeClient(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    baseUrl: "https://matrix.test",
+    get: vi.fn(),
+    getText: vi.fn(),
+    getBlob: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    putText: vi.fn(),
+    ...overrides,
+  } as ApiClient;
+}
+
+const capabilities = { canRename: true, canMove: true, canTrash: true };
+
+describe("FileManagementApi", () => {
+  it("treats missing or malformed legacy listing capabilities as all false", () => {
+    const [missing, malformed] = parseBrowserEntries([
+      { name: "legacy.md", type: "file" },
+      { name: "untrusted.md", type: "file", capabilities: { ...capabilities, futureFlag: true } },
+    ]);
+
+    expect(missing?.capabilities).toEqual({ canRename: false, canMove: false, canTrash: false });
+    expect(malformed?.capabilities).toEqual({ canRename: false, canMove: false, canTrash: false });
+  });
+
+  it("lists a normalized directory through the exact route and parses bounded capabilities", async () => {
+    const get = vi.fn().mockResolvedValue({
+      path: "projects",
+      entries: [{
+        name: "notes.md",
+        type: "file",
+        size: 12,
+        gitStatus: null,
+        modified: "2026-08-11T00:00:00.000Z",
+        capabilities,
+      }],
+    });
+    const api = createFileManagementApi(makeClient({ get }));
+
+    await expect(api.list("projects")).resolves.toEqual({
+      path: "projects",
+      entries: [{
+        name: "notes.md",
+        type: "file",
+        sizeBytes: 12,
+        modifiedAt: "2026-08-11T00:00:00.000Z",
+        capabilities,
+      }],
+    });
+    expect(get).toHaveBeenCalledWith("/api/files/list?path=projects");
+  });
+
+  it("keeps legacy listings readable and treats missing or malformed capabilities as all false", async () => {
+    const get = vi.fn().mockResolvedValue({
+      path: "projects",
+      entries: [
+        { name: "legacy.md", type: "file", gitStatus: null },
+        { name: "malformed.md", type: "file", gitStatus: null, capabilities: { ...capabilities, extra: true } },
+      ],
+    });
+    const api = createFileManagementApi(makeClient({ get }));
+
+    const result = await api.list("projects");
+    expect(result.entries.map((entry) => entry.capabilities)).toEqual([
+      { canRename: false, canMove: false, canTrash: false },
+      { canRename: false, canMove: false, canTrash: false },
+    ]);
+  });
+
+  it("rejects paths/names over their UTF-8 byte limits and mixed-parent batches before transport", async () => {
+    const get = vi.fn();
+    const post = vi.fn();
+    const api = createFileManagementApi(makeClient({ get, post }));
+
+    await expect(api.list(`projects/${"界".repeat(1_365)}`)).rejects.toMatchObject({ category: "server" });
+    await expect(api.create({ requestId: REQUEST_ID, parentDirectory: "projects", name: "界".repeat(86), kind: "file" }))
+      .rejects.toMatchObject({ category: "server" });
+    await expect(api.preflightMove({ requestId: REQUEST_ID, sources: ["projects/a", "archive/b"], destinationDirectory: "dest" }))
+      .rejects.toMatchObject({ category: "server" });
+    expect(get).not.toHaveBeenCalled();
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("uses exact create/rename payloads and explicit bounded mutation timeouts", async () => {
+    const post = vi.fn()
+      .mockResolvedValueOnce({ ok: true, path: "projects/new.md", resultCode: "created", capabilities })
+      .mockResolvedValueOnce({ ok: true, path: "projects/final.md", resultCode: "renamed", capabilities });
+    const api = createFileManagementApi(makeClient({ post }));
+
+    await api.create({ requestId: REQUEST_ID, parentDirectory: "projects", name: "new.md", kind: "file" });
+    await api.rename({ requestId: REQUEST_ID, path: "projects/new.md", name: "final.md" });
+
+    expect(post).toHaveBeenNthCalledWith(1, "/api/files/create", {
+      requestId: REQUEST_ID,
+      parentDirectory: "projects",
+      name: "new.md",
+      kind: "file",
+    }, { timeoutMs: FILE_MUTATION_TIMEOUT_MS });
+    expect(post).toHaveBeenNthCalledWith(2, "/api/files/rename", {
+      requestId: REQUEST_ID,
+      path: "projects/new.md",
+      name: "final.md",
+    }, { timeoutMs: FILE_MUTATION_TIMEOUT_MS });
+  });
+
+  it("reuses one move request id across exact preflight and execute payloads", async () => {
+    const post = vi.fn()
+      .mockResolvedValueOnce({
+        sources: ["projects/a.md"], destinationDirectory: "archive",
+        conflicts: [{ source: "projects/a.md", destination: "archive/a.md" }],
+        invalid: [], preflightFingerprint: "fingerprint-a",
+      })
+      .mockResolvedValueOnce({
+        results: [{ source: "projects/a.md", destination: "archive/a copy.md", code: "moved" }],
+        affectedDirectories: ["projects", "archive"],
+      });
+    const api = createFileManagementApi(makeClient({ post }));
+
+    const preflight = await api.preflightMove({
+      requestId: REQUEST_ID,
+      sources: ["projects/a.md"],
+      destinationDirectory: "archive",
+    });
+    await api.executeMove({
+      requestId: REQUEST_ID,
+      sources: ["projects/a.md"],
+      preflightFingerprint: preflight.preflightFingerprint,
+      conflictChoices: [{ source: "projects/a.md", resolution: "keep-both" }],
+    });
+
+    expect(post).toHaveBeenNthCalledWith(1, "/api/files/batch/move", {
+      requestId: REQUEST_ID, phase: "preflight", sources: ["projects/a.md"], destinationDirectory: "archive",
+    }, { timeoutMs: FILE_MUTATION_TIMEOUT_MS });
+    expect(post).toHaveBeenNthCalledWith(2, "/api/files/batch/move", {
+      requestId: REQUEST_ID, phase: "execute", preflightFingerprint: "fingerprint-a",
+      conflictChoices: [{ source: "projects/a.md", resolution: "keep-both" }],
+    }, { timeoutMs: FILE_MUTATION_TIMEOUT_MS });
+  });
+
+  it.each([" ", ".", "..", "a:b", "trail.", "CON"])("rejects the invalid portable mutation name %j before transport", async (name) => {
+    const post = vi.fn();
+    const api = createFileManagementApi(makeClient({ post }));
+    await expect(api.create({ requestId: REQUEST_ID, parentDirectory: "projects", name, kind: "file" }))
+      .rejects.toMatchObject({ category: "server" });
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("correlates list, preflight, execute, and Trash responses to the exact request", async () => {
+    const get = vi.fn().mockResolvedValue({ path: "archive", entries: [] });
+    const post = vi.fn()
+      .mockResolvedValueOnce({
+        sources: ["projects/foreign"], destinationDirectory: "archive", conflicts: [], invalid: [], preflightFingerprint: "fp",
+      })
+      .mockResolvedValueOnce({
+        results: [{ source: "projects/b", destination: "archive/b", code: "moved" }],
+        affectedDirectories: ["projects", "archive"],
+      })
+      .mockResolvedValueOnce({
+        results: [{ source: "projects/foreign", code: "trashed" }], sourceDirectory: "projects",
+      });
+    const api = createFileManagementApi(makeClient({ get, post }));
+
+    await expect(api.list("projects")).rejects.toMatchObject({ category: "server" });
+    await expect(api.preflightMove({ requestId: REQUEST_ID, sources: ["projects/a"], destinationDirectory: "archive" }))
+      .rejects.toMatchObject({ category: "server" });
+    await expect(api.executeMove({ requestId: REQUEST_ID, sources: ["projects/a", "projects/b"], preflightFingerprint: "fp", conflictChoices: [] }))
+      .rejects.toMatchObject({ category: "server" });
+    await expect(api.trash({ requestId: REQUEST_ID, sources: ["projects/a"] }))
+      .rejects.toMatchObject({ category: "server" });
+  });
+
+  it("rejects preflight conflicts outside the requested target and overlapping invalid rows", async () => {
+    const post = vi.fn()
+      .mockResolvedValueOnce({
+        sources: ["projects/a"], destinationDirectory: "archive",
+        conflicts: [{ source: "projects/a", destination: "other/a" }], invalid: [], preflightFingerprint: "fp",
+      })
+      .mockResolvedValueOnce({
+        sources: ["projects/a"], destinationDirectory: "archive",
+        conflicts: [{ source: "projects/a", destination: "archive/a" }],
+        invalid: [{ source: "projects/a", code: "invalid_destination" }], preflightFingerprint: "fp",
+      });
+    const api = createFileManagementApi(makeClient({ post }));
+
+    await expect(api.preflightMove({ requestId: REQUEST_ID, sources: ["projects/a"], destinationDirectory: "archive" }))
+      .rejects.toMatchObject({ category: "server" });
+    await expect(api.preflightMove({ requestId: REQUEST_ID, sources: ["projects/a"], destinationDirectory: "archive" }))
+      .rejects.toMatchObject({ category: "server" });
+  });
+
+  it("posts ordered batch Trash sources with a UUID", async () => {
+    const post = vi.fn().mockResolvedValue({
+      results: [
+        { source: "projects/a.md", code: "trashed" },
+        { source: "projects/b.md", code: "source_missing" },
+      ],
+      sourceDirectory: "projects",
+    });
+    const api = createFileManagementApi(makeClient({ post }));
+
+    const result = await api.trash({ requestId: REQUEST_ID, sources: ["projects/a.md", "projects/b.md"] });
+
+    expect(result.results.map((item) => item.source)).toEqual(["projects/a.md", "projects/b.md"]);
+    expect(post).toHaveBeenCalledWith("/api/files/batch/trash", {
+      requestId: REQUEST_ID,
+      sources: ["projects/a.md", "projects/b.md"],
+    }, { timeoutMs: FILE_MUTATION_TIMEOUT_MS });
+  });
+
+  it.each([
+    { path: "/absolute" },
+    { path: "projects", entries: Array.from({ length: 1001 }, (_, index) => ({ name: `f${index}`, type: "file", capabilities })) },
+    { path: "projects", entries: [{ name: "raw/escape", type: "file", capabilities }] },
+  ])("fails malformed or oversized list responses closed", async (response) => {
+    const api = createFileManagementApi(makeClient({ get: vi.fn().mockResolvedValue(response) }));
+    await expect(api.list("projects")).rejects.toMatchObject({ category: "server" });
+  });
+
+  it("fails unknown result codes, oversized fingerprints, and malformed response paths closed", async () => {
+    const post = vi.fn()
+      .mockResolvedValueOnce({ results: [{ source: "projects/a", code: "provider_raw" }], sourceDirectory: "projects" })
+      .mockResolvedValueOnce({ sources: ["projects/a"], destinationDirectory: "archive", conflicts: [], invalid: [], preflightFingerprint: "x".repeat(513) })
+      .mockResolvedValueOnce({ ok: true, path: "/private/result", resultCode: "created", capabilities });
+    const api = createFileManagementApi(makeClient({ post }));
+
+    await expect(api.trash({ requestId: REQUEST_ID, sources: ["projects/a"] })).rejects.toBeInstanceOf(AppError);
+    await expect(api.preflightMove({ requestId: REQUEST_ID, sources: ["projects/a"], destinationDirectory: "archive" })).rejects.toMatchObject({ category: "server" });
+    await expect(api.create({ requestId: REQUEST_ID, parentDirectory: "projects", name: "a", kind: "file" })).rejects.toMatchObject({ category: "server" });
+  });
+});

--- a/tests/desktop/file-management-api.test.ts
+++ b/tests/desktop/file-management-api.test.ts
@@ -138,6 +138,7 @@ describe("FileManagementApi", () => {
     await api.executeMove({
       requestId: REQUEST_ID,
       sources: ["projects/a.md"],
+      destinationDirectory: "archive",
       preflightFingerprint: preflight.preflightFingerprint,
       conflictChoices: [{ source: "projects/a.md", resolution: "keep-both" }],
     });
@@ -177,7 +178,10 @@ describe("FileManagementApi", () => {
     await expect(api.list("projects")).rejects.toMatchObject({ category: "server" });
     await expect(api.preflightMove({ requestId: REQUEST_ID, sources: ["projects/a"], destinationDirectory: "archive" }))
       .rejects.toMatchObject({ category: "server" });
-    await expect(api.executeMove({ requestId: REQUEST_ID, sources: ["projects/a", "projects/b"], preflightFingerprint: "fp", conflictChoices: [] }))
+    await expect(api.executeMove({
+      requestId: REQUEST_ID, sources: ["projects/a", "projects/b"], destinationDirectory: "archive",
+      preflightFingerprint: "fp", conflictChoices: [],
+    }))
       .rejects.toMatchObject({ category: "server" });
     await expect(api.trash({ requestId: REQUEST_ID, sources: ["projects/a"] }))
       .rejects.toMatchObject({ category: "server" });
@@ -219,6 +223,31 @@ describe("FileManagementApi", () => {
       requestId: REQUEST_ID,
       sources: ["projects/a.md", "projects/b.md"],
     }, { timeoutMs: FILE_MUTATION_TIMEOUT_MS });
+  });
+
+  it("rejects foreign move destinations, non-moved destinations, and affected directories", async () => {
+    const post = vi.fn()
+      .mockResolvedValueOnce({
+        results: [{ source: "projects/a", destination: "foreign/a", code: "moved" }],
+        affectedDirectories: ["projects", "archive"],
+      })
+      .mockResolvedValueOnce({
+        results: [{ source: "projects/a", destination: "archive/a", code: "failed" }],
+        affectedDirectories: ["projects", "archive"],
+      })
+      .mockResolvedValueOnce({
+        results: [{ source: "projects/a", destination: "archive/a", code: "moved" }],
+        affectedDirectories: ["projects", "foreign"],
+      });
+    const api = createFileManagementApi(makeClient({ post }));
+    const execute = () => api.executeMove({
+      requestId: REQUEST_ID, sources: ["projects/a"], destinationDirectory: "archive",
+      preflightFingerprint: "fp", conflictChoices: [],
+    });
+
+    await expect(execute()).rejects.toMatchObject({ category: "server" });
+    await expect(execute()).rejects.toMatchObject({ category: "server" });
+    await expect(execute()).rejects.toMatchObject({ category: "server" });
   });
 
   it.each([

--- a/tests/desktop/file-operation-controller-fixture.ts
+++ b/tests/desktop/file-operation-controller-fixture.ts
@@ -1,0 +1,50 @@
+import { vi } from "vitest";
+import {
+  createFileOperationController,
+  type FileOperationScope,
+} from "@desktop/renderer/src/features/files/file-operation-controller";
+import type { FileManagementApi } from "@desktop/renderer/src/features/files/file-management-api";
+
+export const CAPS = { canRename: true, canMove: true, canTrash: true };
+export const IDS = Array.from(
+  { length: 20 },
+  (_, index) => `123e4567-e89b-42d3-a456-${(426614174000 + index).toString()}`,
+);
+
+export function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+export function makeApi(overrides: Partial<FileManagementApi> = {}): FileManagementApi {
+  return {
+    list: vi.fn(), create: vi.fn(), rename: vi.fn(), preflightMove: vi.fn(),
+    executeMove: vi.fn(), trash: vi.fn(), ...overrides,
+  } as FileManagementApi;
+}
+
+export function makeHarness(overrides: {
+  api?: FileManagementApi;
+  loadDirectory?: (directory: string, scope: FileOperationScope) => Promise<readonly string[]>;
+  isScopeCurrent?: (scope: FileOperationScope) => boolean;
+  createRequestId?: () => string;
+} = {}) {
+  let scope: FileOperationScope = { directory: "projects", runtimeSlot: "primary", authGeneration: 1 };
+  let idIndex = 0;
+  const api = overrides.api ?? makeApi();
+  const loadDirectory = vi.fn(overrides.loadDirectory ?? (async () => []));
+  const controller = createFileOperationController({
+    getApi: () => api,
+    createRequestId: overrides.createRequestId ?? (() => IDS[idIndex++]!),
+    getScope: () => scope,
+    loadDirectory,
+    ...(overrides.isScopeCurrent ? { isScopeCurrent: overrides.isScopeCurrent } : {}),
+  });
+  return {
+    api, controller, loadDirectory,
+    get scope() { return scope; },
+    setScope(next: FileOperationScope) { scope = next; controller.syncScope(); },
+  };
+}

--- a/tests/desktop/file-operation-controller-inputs.test.ts
+++ b/tests/desktop/file-operation-controller-inputs.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+import { createFileOperationController } from "@desktop/renderer/src/features/files/file-operation-controller";
+import { CAPS, IDS, makeApi, makeHarness } from "./file-operation-controller-fixture";
+
+describe("FileOperationController public input validation", () => {
+  it("rejects an unsupported create kind before allocating or mutating state", async () => {
+    const create = vi.fn().mockResolvedValue({
+      ok: true,
+      path: "projects/link",
+      resultCode: "created",
+      capabilities: CAPS,
+    });
+    const createRequestId = vi.fn(() => IDS[0]!);
+    const h = makeHarness({ api: makeApi({ create }), createRequestId });
+    const before = h.controller.snapshot;
+
+    await expect(h.controller.create({
+      parentDirectory: "projects",
+      name: "link",
+      kind: "symlink",
+    } as never)).resolves.toMatchObject({
+      status: "failed",
+      requestId: "",
+      retainedPaths: [],
+      notice: "request_mismatch",
+    });
+
+    expect(createRequestId).not.toHaveBeenCalled();
+    expect(h.loadDirectory).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+    expect(h.controller.snapshot).toBe(before);
+  });
+
+  it.each([
+    ["unsupported resolution", { source: "projects/a", resolution: "overwrite" }],
+    ["unknown property", { source: "projects/a", resolution: "keep-both", unexpected: true }],
+  ])("rejects a conflict choice with %s without consuming the preflight", async (_case, choice) => {
+    const executeMove = vi.fn().mockResolvedValue({
+      results: [{ source: "projects/a", destination: "archive/a", code: "moved" }],
+      affectedDirectories: ["projects", "archive"],
+    });
+    const api = makeApi({
+      preflightMove: vi.fn().mockResolvedValue({
+        sources: ["projects/a"],
+        destinationDirectory: "archive",
+        conflicts: [{ source: "projects/a", destination: "archive/a" }],
+        invalid: [],
+        preflightFingerprint: "fp",
+      }),
+      executeMove,
+    });
+    const h = makeHarness({ api });
+    const prepared = await h.controller.preflightMove({
+      sources: ["projects/a"],
+      destinationDirectory: "archive",
+    });
+    const before = h.controller.snapshot;
+
+    await expect(h.controller.executeMove({
+      preflight: prepared.preflight!,
+      conflictChoices: [choice],
+    } as never)).resolves.toMatchObject({
+      status: "failed",
+      notice: "request_mismatch",
+      retainedPaths: ["projects/a"],
+    });
+
+    expect(executeMove).not.toHaveBeenCalled();
+    expect(h.loadDirectory).not.toHaveBeenCalled();
+    expect(h.controller.snapshot).toBe(before);
+
+    await expect(h.controller.executeMove({
+      preflight: prepared.preflight!,
+      conflictChoices: [{ source: "projects/a", resolution: "keep-both" }],
+    })).resolves.toMatchObject({ status: "completed", succeededPaths: ["projects/a"] });
+    expect(executeMove).toHaveBeenCalledOnce();
+  });
+
+  it("bounds scope primitives and strips non-serializable unknown properties", async () => {
+    const create = vi.fn().mockResolvedValue({
+      ok: true,
+      path: "projects/new",
+      resultCode: "created",
+      capabilities: CAPS,
+    });
+    const api = makeApi({ create });
+    const createRequestId = vi.fn(() => IDS[0]!);
+    const controller = createFileOperationController({
+      getApi: () => api,
+      createRequestId,
+      getScope: () => ({
+        directory: "projects",
+        runtimeSlot: "x".repeat(65),
+        authGeneration: Number.NaN,
+        unexpected: 1n,
+      } as never),
+      loadDirectory: vi.fn(),
+    });
+
+    expect(controller.snapshot.scope).toEqual({
+      directory: "projects",
+      runtimeSlot: "",
+      authGeneration: 0,
+    });
+    expect(() => JSON.stringify(controller.snapshot)).not.toThrow();
+    await expect(controller.create({ parentDirectory: "projects", name: "new", kind: "file" }))
+      .resolves.toMatchObject({ status: "stale", requestId: "" });
+    expect(createRequestId).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/tests/desktop/file-operation-controller.test.ts
+++ b/tests/desktop/file-operation-controller.test.ts
@@ -1,0 +1,381 @@
+import { describe, expect, it, vi } from "vitest";
+import { AppError } from "@desktop/renderer/src/lib/errors";
+import {
+  createFileOperationController,
+  type FileOperationScope,
+} from "@desktop/renderer/src/features/files/file-operation-controller";
+import type { FileManagementApi } from "@desktop/renderer/src/features/files/file-management-api";
+
+const CAPS = { canRename: true, canMove: true, canTrash: true };
+const IDS = Array.from({ length: 20 }, (_, index) => `123e4567-e89b-42d3-a456-${(426614174000 + index).toString()}`);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+function makeApi(overrides: Partial<FileManagementApi> = {}): FileManagementApi {
+  return {
+    list: vi.fn(),
+    create: vi.fn(),
+    rename: vi.fn(),
+    preflightMove: vi.fn(),
+    executeMove: vi.fn(),
+    trash: vi.fn(),
+    ...overrides,
+  } as FileManagementApi;
+}
+
+function makeHarness(overrides: {
+  api?: FileManagementApi;
+  loadDirectory?: (directory: string, scope: FileOperationScope) => Promise<readonly string[]>;
+} = {}) {
+  let scope: FileOperationScope = { directory: "projects", runtimeSlot: "primary", authGeneration: 1 };
+  let idIndex = 0;
+  const api = overrides.api ?? makeApi();
+  const loadDirectory = vi.fn(overrides.loadDirectory ?? (async () => []));
+  const controller = createFileOperationController({
+    getApi: () => api,
+    createRequestId: () => IDS[idIndex++]!,
+    getScope: () => scope,
+    loadDirectory,
+  });
+  return {
+    api,
+    controller,
+    loadDirectory,
+    get scope() { return scope; },
+    setScope(next: FileOperationScope) { scope = next; controller.syncScope(); },
+  };
+}
+
+describe("FileOperationController", () => {
+  it("uses unique UUIDs for create/rename and reconciles each authoritative parent", async () => {
+    const api = makeApi({
+      create: vi.fn().mockResolvedValue({ ok: true, path: "projects/new.md", resultCode: "created", capabilities: CAPS }),
+      rename: vi.fn().mockResolvedValue({ ok: true, path: "projects/final.md", resultCode: "renamed", capabilities: CAPS }),
+    });
+    const h = makeHarness({ api, loadDirectory: async (directory) => [`${directory}/authoritative`] });
+
+    const created = await h.controller.create({ parentDirectory: "projects", name: "new.md", kind: "file" });
+    const renamed = await h.controller.rename({ path: "projects/new.md", name: "final.md" });
+
+    expect(api.create).toHaveBeenCalledWith({
+      requestId: IDS[0], parentDirectory: "projects", name: "new.md", kind: "file",
+    });
+    expect(api.rename).toHaveBeenCalledWith({ requestId: IDS[1], path: "projects/new.md", name: "final.md" });
+    expect(created).toMatchObject({ status: "completed", requestId: IDS[0], succeededPaths: ["projects/new.md"] });
+    expect(renamed).toMatchObject({ status: "completed", requestId: IDS[1], succeededPaths: ["projects/final.md"] });
+    expect(h.loadDirectory.mock.calls.map(([directory]) => directory)).toEqual(["projects", "projects"]);
+  });
+
+  it("keeps one move UUID/fingerprint, exposes ordered conflicts, and executes explicit ordered choices", async () => {
+    const executeGate = deferred<{
+      results: Array<{ source: string; destination: string; code: "moved" }>;
+      affectedDirectories: string[];
+    }>();
+    const api = makeApi({
+      preflightMove: vi.fn().mockResolvedValue({
+        sources: ["projects/a", "projects/b"], destinationDirectory: "archive",
+        conflicts: [
+          { source: "projects/a", destination: "archive/a" },
+          { source: "projects/b", destination: "archive/b" },
+        ],
+        invalid: [], preflightFingerprint: "fp-1",
+      }),
+      executeMove: vi.fn(() => executeGate.promise),
+    });
+    const h = makeHarness({ api });
+    const preflight = await h.controller.preflightMove({ sources: ["projects/a", "projects/b"], destinationDirectory: "archive" });
+    expect(preflight.status).toBe("needs-resolution");
+    expect(preflight.preflight?.conflicts.map((item) => item.source)).toEqual(["projects/a", "projects/b"]);
+
+    const execution = h.controller.executeMove({
+      preflight: preflight.preflight!,
+      conflictChoices: [
+        { source: "projects/a", resolution: "keep-both" },
+        { source: "projects/b", resolution: "skip" },
+      ],
+    });
+    expect(h.controller.snapshot.pendingPaths).toEqual(["projects/a", "projects/b"]);
+    executeGate.resolve({
+      results: [
+        { source: "projects/a", destination: "archive/a copy", code: "moved" },
+        { source: "projects/b", destination: "archive/b", code: "moved" },
+      ],
+      affectedDirectories: ["projects", "archive"],
+    });
+    await execution;
+
+    expect(api.executeMove).toHaveBeenCalledWith({
+      requestId: IDS[0], preflightFingerprint: "fp-1",
+      sources: ["projects/a", "projects/b"],
+      conflictChoices: [
+        { source: "projects/a", resolution: "keep-both" },
+        { source: "projects/b", resolution: "skip" },
+      ],
+    });
+  });
+
+  it("does not execute a cancelled or mismatched preflight", async () => {
+    const api = makeApi({
+      preflightMove: vi.fn().mockResolvedValue({
+        sources: ["projects/a"], destinationDirectory: "archive", conflicts: [], invalid: [], preflightFingerprint: "fp",
+      }),
+    });
+    const h = makeHarness({ api });
+    const prepared = await h.controller.preflightMove({ sources: ["projects/a"], destinationDirectory: "archive" });
+
+    expect(h.controller.cancelMove(prepared.preflight!)).toMatchObject({ status: "cancelled", requestId: IDS[0] });
+    await expect(h.controller.executeMove({ preflight: prepared.preflight!, conflictChoices: [] })).resolves.toMatchObject({
+      status: "failed", notice: "request_mismatch",
+    });
+    expect(api.executeMove).not.toHaveBeenCalled();
+  });
+
+  it("retains failed/skipped/invalid rows and reloads source then destination in first-seen order", async () => {
+    const api = makeApi({
+      preflightMove: vi.fn().mockResolvedValue({
+        sources: ["projects/a", "projects/b", "projects/c"], destinationDirectory: "archive",
+        conflicts: [], invalid: [{ source: "projects/c", code: "protected" }], preflightFingerprint: "fp",
+      }),
+      executeMove: vi.fn().mockResolvedValue({
+        results: [
+          { source: "projects/a", destination: "archive/a", code: "moved" },
+          { source: "projects/b", code: "failed" },
+          { source: "projects/c", code: "skipped" },
+        ],
+        affectedDirectories: ["projects", "archive", "projects"],
+      }),
+    });
+    const h = makeHarness({ api });
+    const prepared = await h.controller.preflightMove({ sources: ["projects/a", "projects/b", "projects/c"], destinationDirectory: "archive" });
+    const result = await h.controller.executeMove({ preflight: prepared.preflight!, conflictChoices: [] });
+
+    expect(result).toMatchObject({
+      status: "completed",
+      succeededPaths: ["projects/a"],
+      retainedPaths: ["projects/b", "projects/c"],
+      failures: [
+        { source: "projects/b", code: "failed" },
+        { source: "projects/c", code: "skipped" },
+      ],
+      affectedDirectories: ["projects", "archive"],
+    });
+    expect(h.loadDirectory.mock.calls.map(([directory]) => directory)).toEqual(["projects", "archive"]);
+    expect(h.controller.snapshot.retainedPaths).toEqual(["projects/b", "projects/c"]);
+  });
+
+  it("keeps only failed Trash rows and performs no permanent-delete retry", async () => {
+    const trash = vi.fn().mockResolvedValue({
+      results: [
+        { source: "projects/a", code: "trashed" },
+        { source: "projects/b", code: "source_missing" },
+      ],
+      sourceDirectory: "projects",
+    });
+    const h = makeHarness({ api: makeApi({ trash }) });
+    const result = await h.controller.trash({ sources: ["projects/a", "projects/b"] });
+
+    expect(result).toMatchObject({ succeededPaths: ["projects/a"], retainedPaths: ["projects/b"] });
+    expect(trash).toHaveBeenCalledOnce();
+    expect(h.loadDirectory).toHaveBeenCalledOnce();
+  });
+
+  it("retains every Trash row when authoritative reconciliation itself fails", async () => {
+    const trash = vi.fn().mockRejectedValue(new AppError("timeout"));
+    const h = makeHarness({
+      api: makeApi({ trash }),
+      loadDirectory: async () => { throw new Error("filesystem unavailable"); },
+    });
+
+    await expect(h.controller.trash({ sources: ["projects/a"] })).resolves.toMatchObject({
+      status: "uncertain", succeededPaths: [], retainedPaths: ["projects/a"],
+      notice: "authoritative_reconciliation_required",
+    });
+  });
+
+  it("keeps an uncertain Keep Both source ambiguous instead of trusting the pre-existing target", async () => {
+    const api = makeApi({
+      preflightMove: vi.fn().mockResolvedValue({
+        sources: ["projects/a"], destinationDirectory: "archive",
+        conflicts: [{ source: "projects/a", destination: "archive/a" }], invalid: [], preflightFingerprint: "fp",
+      }),
+      executeMove: vi.fn().mockRejectedValue(new AppError("offline")),
+    });
+    const h = makeHarness({
+      api,
+      loadDirectory: async (directory) => directory === "archive" ? ["archive/a"] : [],
+    });
+    const prepared = await h.controller.preflightMove({ sources: ["projects/a"], destinationDirectory: "archive" });
+    const result = await h.controller.executeMove({
+      preflight: prepared.preflight!,
+      conflictChoices: [{ source: "projects/a", resolution: "keep-both" }],
+    });
+
+    expect(result).toMatchObject({ status: "uncertain", succeededPaths: [], retainedPaths: ["projects/a"] });
+  });
+
+  it.each(["timeout", "offline", "server"] as const)("reconciles an uncertain %s move without blind retry", async (category) => {
+    const executeMove = vi.fn().mockRejectedValue(new AppError(category));
+    const api = makeApi({
+      preflightMove: vi.fn().mockResolvedValue({
+        sources: ["projects/a", "projects/b", "projects/c"], destinationDirectory: "archive",
+        conflicts: [], invalid: [], preflightFingerprint: "fp",
+      }),
+      executeMove,
+    });
+    const listings: Record<string, string[]> = {
+      projects: ["projects/b"],
+      archive: ["archive/a", "archive/b"],
+    };
+    const h = makeHarness({ api, loadDirectory: async (directory) => listings[directory] ?? [] });
+    const prepared = await h.controller.preflightMove({ sources: ["projects/a", "projects/b", "projects/c"], destinationDirectory: "archive" });
+    const result = await h.controller.executeMove({ preflight: prepared.preflight!, conflictChoices: [] });
+
+    expect(result).toMatchObject({
+      status: "uncertain",
+      succeededPaths: ["projects/a"],
+      retainedPaths: ["projects/b", "projects/c"],
+      notice: "authoritative_reconciliation_required",
+    });
+    expect(executeMove).toHaveBeenCalledOnce();
+    expect(h.loadDirectory.mock.calls.map(([directory]) => directory)).toEqual(["projects", "archive"]);
+  });
+
+  it("classifies uncertain create and rename from their operation-specific authoritative targets", async () => {
+    const api = makeApi({
+      create: vi.fn().mockRejectedValue(new AppError("timeout")),
+      rename: vi.fn().mockRejectedValue(new AppError("offline")),
+    });
+    const h = makeHarness({
+      api,
+      loadDirectory: async () => ["projects/new.md", "projects/final.md"],
+    });
+
+    const created = await h.controller.create({ parentDirectory: "projects", name: "new.md", kind: "file" });
+    const renamed = await h.controller.rename({ path: "projects/old.md", name: "final.md" });
+
+    expect(created).toMatchObject({ status: "uncertain", succeededPaths: ["projects/new.md"], retainedPaths: [] });
+    expect(renamed).toMatchObject({ status: "uncertain", succeededPaths: ["projects/old.md"], retainedPaths: [] });
+    expect(api.create).toHaveBeenCalledOnce();
+    expect(api.rename).toHaveBeenCalledOnce();
+  });
+
+  it("maps a request-id conflict to a bounded safe result", async () => {
+    const h = makeHarness({ api: makeApi({ trash: vi.fn().mockRejectedValue(new AppError("server", { detail: "request_id_conflict" })) }) });
+    await expect(h.controller.trash({ sources: ["projects/a"] })).resolves.toMatchObject({
+      status: "failed", retainedPaths: ["projects/a"], notice: "request_conflict",
+    });
+  });
+
+  it("suppresses stale runtime/auth writes after API and reload async boundaries", async () => {
+    const mutation = deferred<{ ok: true; path: string; resultCode: "created"; capabilities: typeof CAPS }>();
+    const reload = deferred<readonly string[]>();
+    const h = makeHarness({
+      api: makeApi({ create: vi.fn(() => mutation.promise) }),
+      loadDirectory: () => reload.promise,
+    });
+    const seen: string[] = [];
+    h.controller.subscribe((snapshot) => seen.push(`${snapshot.scope.runtimeSlot}:${snapshot.notice ?? "none"}`));
+    const resultPromise = h.controller.create({ parentDirectory: "projects", name: "new", kind: "file" });
+    mutation.resolve({ ok: true, path: "projects/new", resultCode: "created", capabilities: CAPS });
+    await Promise.resolve();
+    h.setScope({ directory: "", runtimeSlot: "preview", authGeneration: 2 });
+    reload.resolve(["projects/new"]);
+
+    await expect(resultPromise).resolves.toMatchObject({ status: "stale" });
+    expect(h.controller.snapshot).toMatchObject({
+      scope: { directory: "", runtimeSlot: "preview", authGeneration: 2 },
+      pendingPaths: [], retainedPaths: [], notice: null,
+    });
+    expect(seen.at(-1)).toBe("preview:none");
+  });
+
+  it("synchronously resets an observed replacement scope at the next async boundary", async () => {
+    const mutation = deferred<{ ok: true; path: string; resultCode: "created"; capabilities: typeof CAPS }>();
+    let scope: FileOperationScope = { directory: "projects", runtimeSlot: "primary", authGeneration: 1 };
+    const controller = createFileOperationController({
+      getApi: () => makeApi({ create: vi.fn(() => mutation.promise) }),
+      createRequestId: () => IDS[0]!,
+      getScope: () => scope,
+      loadDirectory: async () => [],
+    });
+    const pending = controller.create({ parentDirectory: "projects", name: "new", kind: "file" });
+    scope = { directory: "", runtimeSlot: "preview", authGeneration: 2 };
+    mutation.resolve({ ok: true, path: "projects/new", resultCode: "created", capabilities: CAPS });
+
+    await expect(pending).resolves.toMatchObject({ status: "stale" });
+    expect(controller.snapshot).toEqual(expect.objectContaining({ scope, status: "idle", pendingPaths: [] }));
+  });
+
+  it("clears pending state when the injected current-scope predicate alone becomes stale", async () => {
+    const mutation = deferred<{ ok: true; path: string; resultCode: "created"; capabilities: typeof CAPS }>();
+    let current = true;
+    const scope: FileOperationScope = { directory: "projects", runtimeSlot: "primary", authGeneration: 1 };
+    const controller = createFileOperationController({
+      getApi: () => makeApi({ create: vi.fn(() => mutation.promise) }),
+      createRequestId: () => IDS[0]!,
+      getScope: () => scope,
+      isScopeCurrent: () => current,
+      loadDirectory: async () => [],
+    });
+    const pending = controller.create({ parentDirectory: "projects", name: "new", kind: "file" });
+    current = false;
+    mutation.resolve({ ok: true, path: "projects/new", resultCode: "created", capabilities: CAPS });
+
+    await expect(pending).resolves.toMatchObject({ status: "stale" });
+    expect(controller.snapshot).toMatchObject({ status: "idle", pendingPaths: [], retainedPaths: [], notice: null });
+  });
+
+  it("rejects oversized batch inputs without silently operating on a truncated prefix", async () => {
+    const preflightMove = vi.fn();
+    const trash = vi.fn();
+    const h = makeHarness({ api: makeApi({ preflightMove, trash }) });
+    const sources = Array.from({ length: 101 }, (_, index) => `projects/${index}`);
+
+    await expect(h.controller.preflightMove({ sources, destinationDirectory: "archive" })).resolves.toMatchObject({
+      status: "failed", retainedPaths: expect.any(Array), notice: "request_mismatch",
+    });
+    await expect(h.controller.trash({ sources })).resolves.toMatchObject({ status: "failed", notice: "request_mismatch" });
+    expect(preflightMove).not.toHaveBeenCalled();
+    expect(trash).not.toHaveBeenCalled();
+  });
+
+  it("closes idempotently, clears listeners/active state, and suppresses late writes", async () => {
+    const gate = deferred<{ ok: true; path: string; resultCode: "created"; capabilities: typeof CAPS }>();
+    const h = makeHarness({ api: makeApi({ create: vi.fn(() => gate.promise) }) });
+    const listener = vi.fn();
+    h.controller.subscribe(listener);
+    const pending = h.controller.create({ parentDirectory: "projects", name: "new", kind: "file" });
+    h.controller.close();
+    h.controller.close();
+    gate.resolve({ ok: true, path: "projects/new", resultCode: "created", capabilities: CAPS });
+
+    await expect(pending).resolves.toMatchObject({ status: "stale" });
+    const callsAtClose = listener.mock.calls.length;
+    await Promise.resolve();
+    expect(listener).toHaveBeenCalledTimes(callsAtClose);
+    expect(() => h.controller.subscribe(() => {})).toThrow(/closed/i);
+  });
+
+  it("caps listeners, active operations, pending rows, and returned failures", async () => {
+    const gate = deferred<{ ok: true; path: string; resultCode: "created"; capabilities: typeof CAPS }>();
+    const create = vi.fn(() => gate.promise);
+    const h = makeHarness({ api: makeApi({ create }) });
+    for (let index = 0; index < 32; index++) h.controller.subscribe(() => {});
+    expect(() => h.controller.subscribe(() => {})).toThrow(/listener cap/i);
+
+    const active = Array.from({ length: 8 }, (_, index) =>
+      h.controller.create({ parentDirectory: "projects", name: `f${index}`, kind: "file" }));
+    await expect(h.controller.create({ parentDirectory: "projects", name: "overflow", kind: "file" })).resolves.toMatchObject({
+      status: "failed", notice: "operation_unavailable",
+    });
+    expect(create).toHaveBeenCalledTimes(8);
+    expect(h.controller.snapshot.pendingPaths).toHaveLength(8);
+    gate.resolve({ ok: true, path: "projects/done", resultCode: "created", capabilities: CAPS });
+    await Promise.all(active);
+  });
+});

--- a/tests/desktop/file-operation-controller.test.ts
+++ b/tests/desktop/file-operation-controller.test.ts
@@ -4,52 +4,7 @@ import {
   createFileOperationController,
   type FileOperationScope,
 } from "@desktop/renderer/src/features/files/file-operation-controller";
-import type { FileManagementApi } from "@desktop/renderer/src/features/files/file-management-api";
-
-const CAPS = { canRename: true, canMove: true, canTrash: true };
-const IDS = Array.from({ length: 20 }, (_, index) => `123e4567-e89b-42d3-a456-${(426614174000 + index).toString()}`);
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason: unknown) => void;
-  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
-  return { promise, resolve, reject };
-}
-
-function makeApi(overrides: Partial<FileManagementApi> = {}): FileManagementApi {
-  return {
-    list: vi.fn(),
-    create: vi.fn(),
-    rename: vi.fn(),
-    preflightMove: vi.fn(),
-    executeMove: vi.fn(),
-    trash: vi.fn(),
-    ...overrides,
-  } as FileManagementApi;
-}
-
-function makeHarness(overrides: {
-  api?: FileManagementApi;
-  loadDirectory?: (directory: string, scope: FileOperationScope) => Promise<readonly string[]>;
-} = {}) {
-  let scope: FileOperationScope = { directory: "projects", runtimeSlot: "primary", authGeneration: 1 };
-  let idIndex = 0;
-  const api = overrides.api ?? makeApi();
-  const loadDirectory = vi.fn(overrides.loadDirectory ?? (async () => []));
-  const controller = createFileOperationController({
-    getApi: () => api,
-    createRequestId: () => IDS[idIndex++]!,
-    getScope: () => scope,
-    loadDirectory,
-  });
-  return {
-    api,
-    controller,
-    loadDirectory,
-    get scope() { return scope; },
-    setScope(next: FileOperationScope) { scope = next; controller.syncScope(); },
-  };
-}
+import { CAPS, IDS, deferred, makeApi, makeHarness } from "./file-operation-controller-fixture";
 
 describe("FileOperationController", () => {
   it("uses unique UUIDs for create/rename and reconciles each authoritative parent", async () => {
@@ -68,12 +23,14 @@ describe("FileOperationController", () => {
     expect(api.rename).toHaveBeenCalledWith({ requestId: IDS[1], path: "projects/new.md", name: "final.md" });
     expect(created).toMatchObject({ status: "completed", requestId: IDS[0], succeededPaths: ["projects/new.md"] });
     expect(renamed).toMatchObject({ status: "completed", requestId: IDS[1], succeededPaths: ["projects/final.md"] });
-    expect(h.loadDirectory.mock.calls.map(([directory]) => directory)).toEqual(["projects", "projects"]);
+    expect(h.loadDirectory.mock.calls.map(([directory]) => directory)).toEqual([
+      "projects", "projects", "projects", "projects",
+    ]);
   });
 
   it("keeps one move UUID/fingerprint, exposes ordered conflicts, and executes explicit ordered choices", async () => {
     const executeGate = deferred<{
-      results: Array<{ source: string; destination: string; code: "moved" }>;
+      results: Array<{ source: string; destination?: string; code: "moved" | "skipped" }>;
       affectedDirectories: string[];
     }>();
     const api = makeApi({
@@ -103,7 +60,7 @@ describe("FileOperationController", () => {
     executeGate.resolve({
       results: [
         { source: "projects/a", destination: "archive/a copy", code: "moved" },
-        { source: "projects/b", destination: "archive/b", code: "moved" },
+        { source: "projects/b", code: "skipped" },
       ],
       affectedDirectories: ["projects", "archive"],
     });
@@ -112,6 +69,7 @@ describe("FileOperationController", () => {
     expect(api.executeMove).toHaveBeenCalledWith({
       requestId: IDS[0], preflightFingerprint: "fp-1",
       sources: ["projects/a", "projects/b"],
+      destinationDirectory: "archive",
       conflictChoices: [
         { source: "projects/a", resolution: "keep-both" },
         { source: "projects/b", resolution: "skip" },
@@ -135,6 +93,39 @@ describe("FileOperationController", () => {
     expect(api.executeMove).not.toHaveBeenCalled();
   });
 
+  it("atomically consumes a preflight so double execute and cancel cannot disturb the active promise", async () => {
+    const gate = deferred<{
+      results: Array<{ source: string; destination: string; code: "moved" }>;
+      affectedDirectories: string[];
+    }>();
+    const executeMove = vi.fn(() => gate.promise);
+    const api = makeApi({
+      preflightMove: vi.fn().mockResolvedValue({
+        sources: ["projects/a"], destinationDirectory: "archive", conflicts: [], invalid: [], preflightFingerprint: "fp",
+      }),
+      executeMove,
+    });
+    const h = makeHarness({ api });
+    const prepared = await h.controller.preflightMove({ sources: ["projects/a"], destinationDirectory: "archive" });
+
+    const first = h.controller.executeMove({ preflight: prepared.preflight!, conflictChoices: [] });
+    const second = h.controller.executeMove({ preflight: prepared.preflight!, conflictChoices: [] });
+    await expect(second).resolves.toMatchObject({ status: "failed", notice: "operation_unavailable" });
+    expect(executeMove).toHaveBeenCalledOnce();
+    expect(h.controller.snapshot).toMatchObject({ status: "pending", pendingPaths: ["projects/a"] });
+    expect(h.controller.cancelMove(prepared.preflight!)).toMatchObject({
+      status: "failed", notice: "operation_unavailable",
+    });
+    expect(h.controller.snapshot).toMatchObject({ status: "pending", pendingPaths: ["projects/a"] });
+
+    gate.resolve({
+      results: [{ source: "projects/a", destination: "archive/a", code: "moved" }],
+      affectedDirectories: ["projects", "archive"],
+    });
+    await expect(first).resolves.toMatchObject({ status: "completed", succeededPaths: ["projects/a"] });
+    expect(h.controller.snapshot).toMatchObject({ status: "completed", pendingPaths: [] });
+  });
+
   it("retains failed/skipped/invalid rows and reloads source then destination in first-seen order", async () => {
     const api = makeApi({
       preflightMove: vi.fn().mockResolvedValue({
@@ -147,7 +138,7 @@ describe("FileOperationController", () => {
           { source: "projects/b", code: "failed" },
           { source: "projects/c", code: "skipped" },
         ],
-        affectedDirectories: ["projects", "archive", "projects"],
+        affectedDirectories: ["foreign"],
       }),
     });
     const h = makeHarness({ api });
@@ -245,23 +236,53 @@ describe("FileOperationController", () => {
     expect(h.loadDirectory.mock.calls.map(([directory]) => directory)).toEqual(["projects", "archive"]);
   });
 
-  it("classifies uncertain create and rename from their operation-specific authoritative targets", async () => {
-    const api = makeApi({
-      create: vi.fn().mockRejectedValue(new AppError("timeout")),
-      rename: vi.fn().mockRejectedValue(new AppError("offline")),
+  it("requires a trustworthy pre-operation baseline to reconcile uncertain create and rename", async () => {
+    const create = vi.fn().mockRejectedValue(new AppError("timeout"));
+    const rename = vi.fn().mockRejectedValue(new AppError("offline"));
+    const loadDirectory = vi.fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(["projects/new.md"])
+      .mockResolvedValueOnce(["projects/old.md"])
+      .mockResolvedValueOnce(["projects/final.md"]);
+    const h = makeHarness({ api: makeApi({ create, rename }), loadDirectory });
+
+    await expect(h.controller.create({ parentDirectory: "projects", name: "new.md", kind: "file" })).resolves.toMatchObject({
+      status: "uncertain", succeededPaths: ["projects/new.md"], retainedPaths: [],
     });
+    await expect(h.controller.rename({ path: "projects/old.md", name: "final.md" })).resolves.toMatchObject({
+      status: "uncertain", succeededPaths: ["projects/old.md"], retainedPaths: [],
+    });
+    expect(loadDirectory).toHaveBeenCalledTimes(4);
+  });
+
+  it("retains uncertain create when its pre-operation baseline is unavailable", async () => {
+    const loadDirectory = vi.fn()
+      .mockRejectedValueOnce(new Error("baseline unavailable"))
+      .mockResolvedValueOnce(["projects/new.md"]);
     const h = makeHarness({
-      api,
-      loadDirectory: async () => ["projects/new.md", "projects/final.md"],
+      api: makeApi({ create: vi.fn().mockRejectedValue(new AppError("timeout")) }),
+      loadDirectory,
     });
 
-    const created = await h.controller.create({ parentDirectory: "projects", name: "new.md", kind: "file" });
-    const renamed = await h.controller.rename({ path: "projects/old.md", name: "final.md" });
+    await expect(h.controller.create({ parentDirectory: "projects", name: "new.md", kind: "file" })).resolves.toMatchObject({
+      status: "uncertain", succeededPaths: [], retainedPaths: ["projects/new.md"],
+    });
+    expect(loadDirectory).toHaveBeenCalledTimes(2);
+  });
 
-    expect(created).toMatchObject({ status: "uncertain", succeededPaths: ["projects/new.md"], retainedPaths: [] });
-    expect(renamed).toMatchObject({ status: "uncertain", succeededPaths: ["projects/old.md"], retainedPaths: [] });
-    expect(api.create).toHaveBeenCalledOnce();
-    expect(api.rename).toHaveBeenCalledOnce();
+  it.each([
+    ["destination_conflict", "destination_conflict"],
+    ["protected", "protected"],
+    ["invalid_path", "invalid_destination"],
+    ["cleanup_failed", "cleanup_failed"],
+  ] as const)("keeps typed %s failed even when the target already exists", async (detail, code) => {
+    const create = vi.fn().mockRejectedValue(new AppError("server", { detail }));
+    const h = makeHarness({ api: makeApi({ create }), loadDirectory: async () => ["projects/new.md"] });
+
+    await expect(h.controller.create({ parentDirectory: "projects", name: "new.md", kind: "file" })).resolves.toMatchObject({
+      status: "failed", succeededPaths: [], retainedPaths: ["projects/new.md"],
+      failures: [{ source: "projects/new.md", code }],
+    });
   });
 
   it("maps a request-id conflict to a bounded safe result", async () => {
@@ -330,6 +351,45 @@ describe("FileOperationController", () => {
     expect(controller.snapshot).toMatchObject({ status: "idle", pendingPaths: [], retainedPaths: [], notice: null });
   });
 
+  it.each(["create", "rename", "preflight", "trash"] as const)(
+    "gates start-stale %s before UUID, pending state, reload, or transport",
+    async (operation) => {
+      const api = makeApi();
+      const createRequestId = vi.fn(() => IDS[0]!);
+      const h = makeHarness({ api, createRequestId, isScopeCurrent: () => false });
+      const calls = {
+        create: () => h.controller.create({ parentDirectory: "projects", name: "new", kind: "file" }),
+        rename: () => h.controller.rename({ path: "projects/a", name: "b" }),
+        preflight: () => h.controller.preflightMove({ sources: ["projects/a"], destinationDirectory: "archive" }),
+        trash: () => h.controller.trash({ sources: ["projects/a"] }),
+      };
+
+      await expect(calls[operation]()).resolves.toMatchObject({ status: "stale" });
+      expect(createRequestId).not.toHaveBeenCalled();
+      expect(h.loadDirectory).not.toHaveBeenCalled();
+      expect(api[operation === "preflight" ? "preflightMove" : operation]).not.toHaveBeenCalled();
+      expect(h.controller.snapshot).toMatchObject({ status: "idle", pendingPaths: [], preflight: null });
+    },
+  );
+
+  it("gates start-stale execute and cancel before transport and clears the stored preflight", async () => {
+    let current = true;
+    const api = makeApi({
+      preflightMove: vi.fn().mockResolvedValue({
+        sources: ["projects/a"], destinationDirectory: "archive", conflicts: [], invalid: [], preflightFingerprint: "fp",
+      }),
+    });
+    const h = makeHarness({ api, isScopeCurrent: () => current });
+    const prepared = await h.controller.preflightMove({ sources: ["projects/a"], destinationDirectory: "archive" });
+    current = false;
+
+    await expect(h.controller.executeMove({ preflight: prepared.preflight!, conflictChoices: [] }))
+      .resolves.toMatchObject({ status: "stale" });
+    expect(h.controller.cancelMove(prepared.preflight!)).toMatchObject({ status: "stale" });
+    expect(api.executeMove).not.toHaveBeenCalled();
+    expect(h.controller.snapshot).toMatchObject({ status: "idle", pendingPaths: [], preflight: null });
+  });
+
   it("rejects oversized batch inputs without silently operating on a truncated prefix", async () => {
     const preflightMove = vi.fn();
     const trash = vi.fn();
@@ -342,6 +402,54 @@ describe("FileOperationController", () => {
     await expect(h.controller.trash({ sources })).resolves.toMatchObject({ status: "failed", notice: "request_mismatch" });
     expect(preflightMove).not.toHaveBeenCalled();
     expect(trash).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid, foreign, duplicate, and self-descendant inputs before UUID or snapshot writes", async () => {
+    const oversizedPath = `projects/${"界".repeat(1_366)}`;
+    const operations = [
+      (controller: ReturnType<typeof makeHarness>["controller"]) => controller.create({ parentDirectory: "archive", name: "new", kind: "file" }),
+      (controller: ReturnType<typeof makeHarness>["controller"]) => controller.create({ parentDirectory: "projects", name: "CON", kind: "file" }),
+      (controller: ReturnType<typeof makeHarness>["controller"]) => controller.rename({ path: "archive/a", name: "b" }),
+      (controller: ReturnType<typeof makeHarness>["controller"]) => controller.rename({ path: oversizedPath, name: "b" }),
+      (controller: ReturnType<typeof makeHarness>["controller"]) => controller.preflightMove({ sources: ["archive/a"], destinationDirectory: "dest" }),
+      (controller: ReturnType<typeof makeHarness>["controller"]) => controller.preflightMove({ sources: ["projects/a"], destinationDirectory: "projects" }),
+      (controller: ReturnType<typeof makeHarness>["controller"]) => controller.preflightMove({ sources: ["projects/a"], destinationDirectory: "projects/a/child" }),
+      (controller: ReturnType<typeof makeHarness>["controller"]) => controller.trash({ sources: ["projects/a", "projects/a"] }),
+    ];
+
+    for (const operation of operations) {
+      const createRequestId = vi.fn(() => IDS[0]!);
+      const h = makeHarness({ api: makeApi(), createRequestId });
+      const before = h.controller.snapshot;
+      await expect(operation(h.controller)).resolves.toMatchObject({
+        status: "failed", notice: "request_mismatch", retainedPaths: [],
+      });
+      expect(createRequestId).not.toHaveBeenCalled();
+      expect(h.loadDirectory).not.toHaveBeenCalled();
+      for (const transport of [h.api.create, h.api.rename, h.api.preflightMove, h.api.executeMove, h.api.trash]) {
+        expect(transport).not.toHaveBeenCalled();
+      }
+      expect(h.controller.snapshot).toBe(before);
+    }
+  });
+
+  it("sanitizes an invalid scope directory and fails closed before UUID or transport", async () => {
+    const api = makeApi();
+    const createRequestId = vi.fn(() => IDS[0]!);
+    const controller = createFileOperationController({
+      getApi: () => api,
+      createRequestId,
+      getScope: () => ({ directory: "../foreign", runtimeSlot: "primary", authGeneration: 1 }),
+      loadDirectory: vi.fn(),
+    });
+
+    expect(controller.snapshot.scope.directory).toBe("");
+    await expect(controller.create({ parentDirectory: "", name: "new", kind: "file" }))
+      .resolves.toMatchObject({ status: "stale" });
+    expect(createRequestId).not.toHaveBeenCalled();
+    expect(api.create).not.toHaveBeenCalled();
+    controller.close();
+    expect(controller.snapshot.scope.directory).toBe("");
   });
 
   it("closes idempotently, clears listeners/active state, and suppresses late writes", async () => {

--- a/tests/desktop/file-selection.test.ts
+++ b/tests/desktop/file-selection.test.ts
@@ -98,7 +98,7 @@ describe("file selection", () => {
     expect(ranged.selectedPaths).toEqual(["projects/a", "projects/c"]);
   });
 
-  it("hard-caps selected and dragged rows at 100", () => {
+  it("keeps selections above the batch limit and refuses a partial drag", () => {
     const many = Array.from({ length: 140 }, (_, index) => `projects/${index.toString().padStart(3, "0")}`);
     const selected = updateFileSelection(
       { ...createFileSelection(scope), anchorPath: many[0] },
@@ -107,8 +107,23 @@ describe("file selection", () => {
       { shiftKey: true },
       "mac",
     );
-    expect(selected.selectedPaths).toHaveLength(100);
-    expect(beginFileDrag(selected, selected.selectedPaths[10]!).dragPaths).toHaveLength(100);
+    expect(selected.selectedPaths).toEqual(many);
+    expect(beginFileDrag(selected, selected.selectedPaths[10]!)).toEqual({
+      state: selected,
+      dragPaths: [],
+    });
+  });
+
+  it("caps serializable selection state at the bounded listing size", () => {
+    const many = Array.from({ length: 1_100 }, (_, index) => `projects/${index.toString().padStart(4, "0")}`);
+    const selected = updateFileSelection(
+      { ...createFileSelection(scope), anchorPath: many[0] },
+      many,
+      many.at(-1)!,
+      { shiftKey: true },
+      "mac",
+    );
+    expect(selected.selectedPaths).toEqual(many.slice(0, 1_000));
   });
 
   it.each([

--- a/tests/desktop/file-selection.test.ts
+++ b/tests/desktop/file-selection.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  beginFileDrag,
+  createFileSelection,
+  reconcileFileSelection,
+  resetFileSelectionScope,
+  updateFileSelection,
+  type FileSelectionScope,
+} from "@desktop/renderer/src/features/files/file-selection";
+
+const scope: FileSelectionScope = { directory: "projects", runtimeSlot: "primary", authGeneration: 3 };
+const order = ["projects/a", "projects/b", "projects/c", "projects/d"];
+
+describe("file selection", () => {
+  it("plain click selects exactly one and establishes anchor/focus", () => {
+    const initial = createFileSelection(scope);
+    const selected = updateFileSelection(initial, order, "projects/b", {}, "mac");
+    const replaced = updateFileSelection(selected, order, "projects/d", {}, "mac");
+
+    expect(replaced).toEqual({
+      scope,
+      selectedPaths: ["projects/d"],
+      anchorPath: "projects/d",
+      focusedPath: "projects/d",
+    });
+  });
+
+  it("uses Command on macOS and Control on Windows/Linux for additive toggles", () => {
+    const initial = updateFileSelection(createFileSelection(scope), order, "projects/a", {}, "mac");
+    const mac = updateFileSelection(initial, order, "projects/c", { metaKey: true }, "mac");
+    const windows = updateFileSelection(initial, order, "projects/c", { ctrlKey: true }, "windows");
+    const linux = updateFileSelection(initial, order, "projects/c", { ctrlKey: true }, "linux");
+
+    expect(mac.selectedPaths).toEqual(["projects/a", "projects/c"]);
+    expect(windows.selectedPaths).toEqual(["projects/a", "projects/c"]);
+    expect(linux.selectedPaths).toEqual(["projects/a", "projects/c"]);
+    expect(updateFileSelection(mac, order, "projects/a", { metaKey: true }, "mac").selectedPaths).toEqual(["projects/c"]);
+  });
+
+  it("does not let the non-platform modifier accidentally toggle", () => {
+    const initial = updateFileSelection(createFileSelection(scope), order, "projects/a", {}, "mac");
+    expect(updateFileSelection(initial, order, "projects/c", { ctrlKey: true }, "mac").selectedPaths).toEqual(["projects/c"]);
+    expect(updateFileSelection(initial, order, "projects/c", { metaKey: true }, "windows").selectedPaths).toEqual(["projects/c"]);
+    expect(updateFileSelection(initial, order, "projects/c", { metaKey: true }, "linux").selectedPaths).toEqual(["projects/c"]);
+  });
+
+  it("plain Shift replaces with the inclusive anchor range", () => {
+    const anchored = updateFileSelection(createFileSelection(scope), order, "projects/b", {}, "mac");
+    const ranged = updateFileSelection(anchored, order, "projects/d", { shiftKey: true }, "mac");
+    expect(ranged.selectedPaths).toEqual(["projects/b", "projects/c", "projects/d"]);
+    expect(ranged.anchorPath).toBe("projects/b");
+    expect(ranged.focusedPath).toBe("projects/d");
+  });
+
+  it("Shift plus the platform additive modifier unions the range in rendered order", () => {
+    let state = updateFileSelection(createFileSelection(scope), order, "projects/a", {}, "windows");
+    state = updateFileSelection(state, order, "projects/d", { ctrlKey: true }, "windows");
+    const ranged = updateFileSelection(state, order, "projects/b", { shiftKey: true, ctrlKey: true }, "windows");
+    expect(ranged.selectedPaths).toEqual(["projects/a", "projects/b", "projects/c", "projects/d"]);
+    expect(ranged.anchorPath).toBe("projects/d");
+  });
+
+  it("falls back deterministically when the anchor vanished", () => {
+    const stale = {
+      ...createFileSelection(scope),
+      selectedPaths: ["projects/a"],
+      anchorPath: "projects/missing",
+      focusedPath: "projects/a",
+    };
+    expect(updateFileSelection(stale, order, "projects/c", { shiftKey: true }, "mac")).toEqual({
+      scope,
+      selectedPaths: ["projects/c"],
+      anchorPath: "projects/c",
+      focusedPath: "projects/c",
+    });
+  });
+
+  it("drags the selected siblings or first collapses an unselected row", () => {
+    let state = updateFileSelection(createFileSelection(scope), order, "projects/a", {}, "mac");
+    state = updateFileSelection(state, order, "projects/c", { metaKey: true }, "mac");
+
+    expect(beginFileDrag(state, "projects/c")).toEqual({ state, dragPaths: ["projects/a", "projects/c"] });
+    expect(beginFileDrag(state, "projects/b")).toEqual({
+      state: { ...state, selectedPaths: ["projects/b"], anchorPath: "projects/b", focusedPath: "projects/b" },
+      dragPaths: ["projects/b"],
+    });
+  });
+
+  it("fails closed instead of creating a drag selection from another directory", () => {
+    const state = updateFileSelection(createFileSelection(scope), order, "projects/a", {}, "mac");
+    expect(beginFileDrag(state, "archive/a")).toEqual({ state, dragPaths: [] });
+  });
+
+  it("never admits another directory from a mixed rendered range", () => {
+    const mixed = ["projects/a", "archive/foreign", "projects/c"];
+    const anchored = updateFileSelection(createFileSelection(scope), mixed, "projects/a", {}, "mac");
+    const ranged = updateFileSelection(anchored, mixed, "projects/c", { shiftKey: true }, "mac");
+    expect(ranged.selectedPaths).toEqual(["projects/a", "projects/c"]);
+  });
+
+  it("hard-caps selected and dragged rows at 100", () => {
+    const many = Array.from({ length: 140 }, (_, index) => `projects/${index.toString().padStart(3, "0")}`);
+    const selected = updateFileSelection(
+      { ...createFileSelection(scope), anchorPath: many[0] },
+      many,
+      many.at(-1)!,
+      { shiftKey: true },
+      "mac",
+    );
+    expect(selected.selectedPaths).toHaveLength(100);
+    expect(beginFileDrag(selected, selected.selectedPaths[10]!).dragPaths).toHaveLength(100);
+  });
+
+  it.each([
+    [{ ...scope, directory: "archive" }, "navigation"],
+    [{ ...scope, runtimeSlot: "preview" }, "runtime"],
+    [{ ...scope, authGeneration: 4 }, "auth"],
+  ] as const)("clears synchronously on %s scope changes", (nextScope) => {
+    const selected = updateFileSelection(createFileSelection(scope), order, "projects/b", {}, "mac");
+    expect(resetFileSelectionScope(selected, nextScope)).toEqual(createFileSelection(nextScope));
+  });
+
+  it("preserves selection when the scope is exactly unchanged", () => {
+    const selected = updateFileSelection(createFileSelection(scope), order, "projects/b", {}, "mac");
+    expect(resetFileSelectionScope(selected, { ...scope })).toBe(selected);
+  });
+
+  it("reconciles authoritative refresh in listing order and repairs anchor/focus", () => {
+    const state = {
+      ...createFileSelection(scope),
+      selectedPaths: ["projects/c", "projects/a", "projects/missing"],
+      anchorPath: "projects/missing",
+      focusedPath: "projects/missing",
+    };
+    expect(reconcileFileSelection(state, scope, ["projects/b", "projects/a", "projects/c"])).toEqual({
+      scope,
+      selectedPaths: ["projects/a", "projects/c"],
+      anchorPath: "projects/a",
+      focusedPath: "projects/a",
+    });
+  });
+
+  it("never retains paths while reconciling a different directory", () => {
+    const state = updateFileSelection(createFileSelection(scope), order, "projects/a", {}, "mac");
+    const nextScope = { ...scope, directory: "archive" };
+    expect(reconcileFileSelection(state, nextScope, ["archive/a"])).toEqual(createFileSelection(nextScope));
+  });
+});

--- a/tests/desktop/kernel-socket-fixture.ts
+++ b/tests/desktop/kernel-socket-fixture.ts
@@ -1,0 +1,60 @@
+import type { WebSocketLike } from "@desktop/renderer/src/lib/kernel-socket";
+import { KernelSocket } from "@desktop/renderer/src/lib/kernel-socket";
+
+export class FakeWebSocket implements WebSocketLike {
+  readyState = 0;
+  sent: string[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  send(data: string): void { this.sent.push(data); }
+  close(): void { if (this.readyState !== 3) { this.readyState = 3; this.onclose?.(); } }
+  open(): void { this.readyState = 1; this.onopen?.(); }
+  message(data: unknown): void { this.onmessage?.({ data }); }
+  fail(): void { this.close(); }
+}
+
+interface ScheduledTimer { id: number; fn: () => void; delay: number; cleared: boolean; fired: boolean }
+
+function createFakeTimers() {
+  const scheduled: ScheduledTimer[] = [];
+  let nextId = 1;
+  const setTimeoutFn = ((fn: () => void, delay?: number) => {
+    const timer = { id: nextId++, fn, delay: delay ?? 0, cleared: false, fired: false };
+    scheduled.push(timer);
+    return timer.id as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+  const clearTimeoutFn = ((id?: unknown) => {
+    const timer = scheduled.find((candidate) => candidate.id === id);
+    if (timer) timer.cleared = true;
+  }) as typeof clearTimeout;
+  const runNext = () => {
+    const timer = scheduled.find((candidate) => !candidate.cleared && !candidate.fired);
+    if (!timer) throw new Error("no pending timer");
+    timer.fired = true;
+    timer.fn();
+  };
+  const pending = () => scheduled.filter((candidate) => !candidate.cleared && !candidate.fired);
+  return { scheduled, setTimeoutFn, clearTimeoutFn, runNext, pending };
+}
+
+export function createKernelSocketHarness(overrides?: { runtimeSlot?: string; random?: () => number }) {
+  const sockets: FakeWebSocket[] = [];
+  const urls: string[] = [];
+  const timers = createFakeTimers();
+  const socket = new KernelSocket({
+    baseUrl: "https://app.matrix-os.com",
+    runtimeSlot: overrides?.runtimeSlot ?? "primary",
+    createWebSocket: (url) => {
+      urls.push(url);
+      const ws = new FakeWebSocket();
+      sockets.push(ws);
+      return ws;
+    },
+    setTimeoutFn: timers.setTimeoutFn,
+    clearTimeoutFn: timers.clearTimeoutFn,
+    random: overrides?.random ?? (() => 1),
+  });
+  return { socket, sockets, urls, timers, last: () => sockets[sockets.length - 1]! };
+}

--- a/tests/desktop/kernel-socket.test.ts
+++ b/tests/desktop/kernel-socket.test.ts
@@ -6,66 +6,8 @@ import {
   type KernelConnectionState,
   type FileDirectoryServerMessage,
   type KernelServerMessage,
-  type WebSocketLike,
 } from "@desktop/renderer/src/lib/kernel-socket";
-
-class FakeWebSocket implements WebSocketLike {
-  readyState = 0;
-  sent: string[] = [];
-  onopen: (() => void) | null = null;
-  onmessage: ((event: { data: unknown }) => void) | null = null;
-  onclose: (() => void) | null = null;
-  onerror: (() => void) | null = null;
-  send(data: string): void { this.sent.push(data); }
-  close(): void { if (this.readyState !== 3) { this.readyState = 3; this.onclose?.(); } }
-  open(): void { this.readyState = 1; this.onopen?.(); }
-  message(data: unknown): void { this.onmessage?.({ data }); }
-  fail(): void { this.close(); }
-}
-
-interface ScheduledTimer { id: number; fn: () => void; delay: number; cleared: boolean; fired: boolean }
-
-function createFakeTimers() {
-  const scheduled: ScheduledTimer[] = [];
-  let nextId = 1;
-  const setTimeoutFn = ((fn: () => void, delay?: number) => {
-    const timer = { id: nextId++, fn, delay: delay ?? 0, cleared: false, fired: false };
-    scheduled.push(timer);
-    return timer.id as unknown as ReturnType<typeof setTimeout>;
-  }) as typeof setTimeout;
-  const clearTimeoutFn = ((id?: unknown) => {
-    const timer = scheduled.find((candidate) => candidate.id === id);
-    if (timer) timer.cleared = true;
-  }) as typeof clearTimeout;
-  const runNext = () => {
-    const timer = scheduled.find((candidate) => !candidate.cleared && !candidate.fired);
-    if (!timer) throw new Error("no pending timer");
-    timer.fired = true;
-    timer.fn();
-  };
-  const pending = () => scheduled.filter((candidate) => !candidate.cleared && !candidate.fired);
-  return { scheduled, setTimeoutFn, clearTimeoutFn, runNext, pending };
-}
-
-function createHarness(overrides?: { runtimeSlot?: string; random?: () => number }) {
-  const sockets: FakeWebSocket[] = [];
-  const urls: string[] = [];
-  const timers = createFakeTimers();
-  const socket = new KernelSocket({
-    baseUrl: "https://app.matrix-os.com",
-    runtimeSlot: overrides?.runtimeSlot ?? "primary",
-    createWebSocket: (url) => {
-      urls.push(url);
-      const ws = new FakeWebSocket();
-      sockets.push(ws);
-      return ws;
-    },
-    setTimeoutFn: timers.setTimeoutFn,
-    clearTimeoutFn: timers.clearTimeoutFn,
-    random: overrides?.random ?? (() => 1),
-  });
-  return { socket, sockets, urls, timers, last: () => sockets[sockets.length - 1]! };
-}
+import { createKernelSocketHarness as createHarness, FakeWebSocket } from "./kernel-socket-fixture";
 
 beforeEach(() => {
   vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -175,6 +117,19 @@ describe("KernelSocket: connection and routing", () => {
     h.last().message(JSON.stringify(["array"]));
     h.last().message(12345);
     expect(seen).toEqual([]);
+  });
+
+  it("drops whole known and unknown frames over one million UTF-8 bytes before delivery", () => {
+    const h = createHarness();
+    const seen: KernelServerMessage[] = [];
+    h.socket.subscribe((message) => seen.push(message));
+    h.socket.connect();
+    h.last().open();
+    const multibyte = "界".repeat(340_000);
+    h.last().message(JSON.stringify({ type: "future:event", payload: multibyte }));
+    h.last().message(JSON.stringify({ type: "kernel:text", text: multibyte }));
+    expect(seen).toHaveLength(0);
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
   it("isolates subscriber failures so later subscribers still receive", () => {

--- a/tests/desktop/kernel-socket.test.ts
+++ b/tests/desktop/kernel-socket.test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildKernelWsUrl,
   KernelSocket,
+  parseKernelServerMessage,
   type KernelConnectionState,
+  type FileDirectoryServerMessage,
   type KernelServerMessage,
   type WebSocketLike,
 } from "@desktop/renderer/src/lib/kernel-socket";
@@ -14,66 +16,34 @@ class FakeWebSocket implements WebSocketLike {
   onmessage: ((event: { data: unknown }) => void) | null = null;
   onclose: (() => void) | null = null;
   onerror: (() => void) | null = null;
-
-  send(data: string): void {
-    this.sent.push(data);
-  }
-
-  close(): void {
-    if (this.readyState === 3) return;
-    this.readyState = 3;
-    this.onclose?.();
-  }
-
-  open(): void {
-    this.readyState = 1;
-    this.onopen?.();
-  }
-
-  message(data: unknown): void {
-    this.onmessage?.({ data });
-  }
-
-  fail(): void {
-    this.close();
-  }
+  send(data: string): void { this.sent.push(data); }
+  close(): void { if (this.readyState !== 3) { this.readyState = 3; this.onclose?.(); } }
+  open(): void { this.readyState = 1; this.onopen?.(); }
+  message(data: unknown): void { this.onmessage?.({ data }); }
+  fail(): void { this.close(); }
 }
 
-interface ScheduledTimer {
-  id: number;
-  fn: () => void;
-  delay: number;
-  cleared: boolean;
-  fired: boolean;
-}
+interface ScheduledTimer { id: number; fn: () => void; delay: number; cleared: boolean; fired: boolean }
 
 function createFakeTimers() {
   const scheduled: ScheduledTimer[] = [];
   let nextId = 1;
   const setTimeoutFn = ((fn: () => void, delay?: number) => {
-    const timer: ScheduledTimer = {
-      id: nextId++,
-      fn,
-      delay: delay ?? 0,
-      cleared: false,
-      fired: false,
-    };
+    const timer = { id: nextId++, fn, delay: delay ?? 0, cleared: false, fired: false };
     scheduled.push(timer);
     return timer.id as unknown as ReturnType<typeof setTimeout>;
   }) as typeof setTimeout;
   const clearTimeoutFn = ((id?: unknown) => {
-    const timer = scheduled.find((t) => t.id === id);
+    const timer = scheduled.find((candidate) => candidate.id === id);
     if (timer) timer.cleared = true;
   }) as typeof clearTimeout;
-  function runNext(): void {
-    const timer = scheduled.find((t) => !t.cleared && !t.fired);
+  const runNext = () => {
+    const timer = scheduled.find((candidate) => !candidate.cleared && !candidate.fired);
     if (!timer) throw new Error("no pending timer");
     timer.fired = true;
     timer.fn();
-  }
-  function pending(): ScheduledTimer[] {
-    return scheduled.filter((t) => !t.cleared && !t.fired);
-  }
+  };
+  const pending = () => scheduled.filter((candidate) => !candidate.cleared && !candidate.fired);
   return { scheduled, setTimeoutFn, clearTimeoutFn, runNext, pending };
 }
 
@@ -380,5 +350,146 @@ describe("KernelSocket: dispose", () => {
     expect(h.sockets).toHaveLength(1);
     h.socket.connect();
     expect(h.sockets).toHaveLength(1);
+  });
+});
+
+describe("KernelSocket: file directory subscriptions", () => {
+  it("strictly parses known file frames and drops malformed variants", () => {
+    expect(parseKernelServerMessage({ type: "files:subscribed", directory: "projects", revision: 0 })).toEqual({
+      type: "files:subscribed", directory: "projects", revision: 0,
+    });
+    expect(parseKernelServerMessage({ type: "files:change", directory: "projects", entry: "a.md", event: "add", revision: 1 })).toEqual({
+      type: "files:change", directory: "projects", entry: "a.md", event: "add", revision: 1,
+    });
+    expect(parseKernelServerMessage({ type: "files:shutdown" })).toEqual({ type: "files:shutdown" });
+    expect(parseKernelServerMessage({ type: "files:change", directory: "projects", entry: "../raw", event: "add", revision: 1 })).toBeNull();
+    expect(parseKernelServerMessage({ type: "files:subscribed", directory: "projects", revision: -1 })).toBeNull();
+    expect(parseKernelServerMessage({ type: "files:shutdown", raw: "provider" })).toBeNull();
+    expect(parseKernelServerMessage({ type: "files:subscribed", directory: "界".repeat(1_366), revision: 0 })).toBeNull();
+    expect(parseKernelServerMessage({ type: "files:change", directory: "projects", entry: "界".repeat(86), event: "add", revision: 1 })).toBeNull();
+  });
+
+  it("reference-counts one wire subscription across two local surfaces", () => {
+    const h = createHarness();
+    h.socket.connect();
+    h.last().open();
+    const first = h.socket.subscribeDirectory("projects", () => {});
+    const second = h.socket.subscribeDirectory("projects", () => {});
+    expect(h.last().sent.map(JSON.parse)).toEqual([{ type: "files:subscribe", directory: "projects" }]);
+
+    first();
+    expect(h.last().sent).toHaveLength(1);
+    second();
+    expect(h.last().sent.map(JSON.parse)).toEqual([
+      { type: "files:subscribe", directory: "projects" },
+      { type: "files:unsubscribe", directory: "projects" },
+    ]);
+  });
+
+  it("caps eight distinct directories and the total file-handler count", () => {
+    const h = createHarness();
+    for (let index = 0; index < 8; index++) h.socket.subscribeDirectory(`d${index}`, () => {});
+    expect(() => h.socket.subscribeDirectory("d8", () => {})).toThrow(/directory cap/i);
+
+    const same = createHarness();
+    for (let index = 0; index < 64; index++) same.socket.subscribeDirectory("projects", () => {});
+    expect(() => same.socket.subscribeDirectory("projects", () => {})).toThrow(/handler cap/i);
+  });
+
+  it("does not emit a wire subscribe when a new directory exceeds the handler cap", () => {
+    const h = createHarness();
+    for (let index = 0; index < 64; index++) h.socket.subscribeDirectory("projects", () => {});
+    h.socket.connect();
+    h.last().open();
+    h.last().sent.length = 0;
+    expect(() => h.socket.subscribeDirectory("archive", () => {})).toThrow(/handler cap/i);
+    expect(h.last().sent).toEqual([]);
+  });
+
+  it("sends touch only for a connected active scope and rejects invalid direct file frames", () => {
+    const h = createHarness();
+    h.socket.subscribeDirectory("projects", () => {});
+    h.socket.connect();
+    h.last().open();
+    h.last().sent.length = 0;
+    expect(h.socket.touchDirectory("projects")).toBe(true);
+    h.socket.send({ type: "files:touch", directory: "../raw" });
+    h.socket.send({ type: "files:subscribe", directory: "archive" });
+    h.socket.send({ type: "files:unsubscribe", directory: "projects" });
+    expect(h.last().sent.map(JSON.parse)).toEqual([{ type: "files:touch", directory: "projects" }]);
+  });
+
+  it("logs only a safe error kind when a directory wire send throws", () => {
+    const h = createHarness();
+    h.socket.connect();
+    h.last().open();
+    h.last().send = () => { throw new Error("/private/token provider failure"); };
+    h.socket.subscribeDirectory("projects", () => {});
+    expect(vi.mocked(console.warn).mock.calls.flat().join(" ")).not.toContain("/private/token");
+  });
+
+  it("resubscribes every current directory once before queued kernel messages on reconnect", () => {
+    const h = createHarness();
+    h.socket.subscribeDirectory("projects", () => {});
+    h.socket.subscribeDirectory("archive", () => {});
+    h.socket.send({ type: "message", text: "queued", requestId: "r1" });
+    h.socket.connect();
+    h.last().open();
+    expect(h.last().sent.map(JSON.parse)).toEqual([
+      { type: "files:subscribe", directory: "projects" },
+      { type: "files:subscribe", directory: "archive" },
+      { type: "message", text: "queued", requestId: "r1" },
+    ]);
+
+    h.last().fail();
+    h.timers.runNext();
+    h.last().open();
+    expect(h.last().sent.map(JSON.parse)).toEqual([
+      { type: "files:subscribe", directory: "projects" },
+      { type: "files:subscribe", directory: "archive" },
+    ]);
+  });
+
+  it("never replays stale unsubscribe or touch frames after reconnect", () => {
+    const h = createHarness();
+    const cleanup = h.socket.subscribeDirectory("projects", () => {});
+    h.socket.connect();
+    h.last().open();
+    h.last().fail();
+    expect(h.socket.touchDirectory("projects")).toBe(false);
+    cleanup();
+    h.timers.runNext();
+    h.last().open();
+    expect(h.last().sent).toEqual([]);
+  });
+
+  it("routes only matching directory frames, isolates handlers, and broadcasts shutdown", () => {
+    const h = createHarness();
+    const seen: FileDirectoryServerMessage[] = [];
+    h.socket.subscribeDirectory("projects", () => { throw new Error("boom"); });
+    h.socket.subscribeDirectory("projects", (message) => seen.push(message));
+    h.socket.subscribeDirectory("archive", () => {});
+    h.socket.connect();
+    h.last().open();
+    h.last().message(JSON.stringify({ type: "files:change", directory: "projects", entry: "a.md", event: "change", revision: 1 }));
+    h.last().message(JSON.stringify({ type: "files:shutdown" }));
+    expect(seen).toEqual([
+      { type: "files:change", directory: "projects", entry: "a.md", event: "change", revision: 1 },
+      { type: "files:shutdown" },
+    ]);
+    expect(console.warn).toHaveBeenCalled();
+    expect(vi.mocked(console.warn).mock.calls.flat().join(" ")).not.toContain("boom");
+  });
+
+  it("dispose clears directory subscriptions and suppresses later delivery", () => {
+    const h = createHarness();
+    const seen: FileDirectoryServerMessage[] = [];
+    h.socket.subscribeDirectory("projects", (message) => seen.push(message));
+    h.socket.connect();
+    const wire = h.last();
+    wire.open();
+    h.socket.dispose();
+    wire.message(JSON.stringify({ type: "files:subscribed", directory: "projects", revision: 0 }));
+    expect(seen).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- add strict Desktop file-management API and shared portable contracts
- add serializable selection, scoped operation controller, and authoritative reconciliation
- extend KernelSocket with bounded directory subscription registration and stale-scope guards

## Stack

6 of 8. Base: directory subscriptions. Next: Files CRUD and selection UI.

## Validation

- Desktop API, controller, selection, socket, and directory-sync suites pass
- Desktop typecheck passes

## Invariants

- **Source of truth:** active runtime API plus authoritative directory listings.
- **Lock/transaction scope:** one bounded active operation per request identity; no local optimistic filesystem mutation.
- **Acceptable orphan states:** uncertain outcomes remain selected and require a fresh user action.
- **Auth source of truth:** committed API/runtime/auth generation scope.
- **Deferred scope:** rendered CRUD and move UI land in subsequent stacked PRs.

Related: MAT-268, #1183, #1186

## Latest validation (2026-08-12)

- Selection remains serializable and bounded by the 1,000-entry listing contract.
- More than 100 selected rows are preserved; batch drag fails closed instead of truncating to the first 100.
- Exactly 100 remains accepted. Pure selection coverage is green.