### PR TITLE
feat(desktop): add Files management interactions

### DIFF
--- a/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
+++ b/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
@@ -9,7 +9,7 @@ import {
   type ReactNode,
 } from "react";
 import { Button } from "../../design/primitives";
-import { toUserMessage } from "../../lib/errors";
+import { diagnosticErrorKind } from "../../lib/errors";
 import { useConnection } from "../../stores/connection";
 import {
   parseBrowserEntries,
@@ -29,11 +29,10 @@ import {
   measureGridColumns,
 } from "./browser-views";
 import { useFileManagement } from "./use-file-management";
+import { useAuthoritativeListing, type BrowserListingStatus } from "./use-authoritative-listing";
 import type { FileSelectionPlatform } from "./file-selection";
 import { getKernelSocket } from "../../lib/kernel-wiring";
 import type { DirectorySyncSocket } from "./use-directory-sync";
-
-type BrowserStatus = "loading" | "ready" | "error";
 
 const NO_ENTRIES: BrowserEntry[] = [];
 
@@ -79,12 +78,8 @@ export default function ComputerFileBrowser({
   const [currentPath, setCurrentPath] = useState("");
   const [candidatePath, setCandidatePath] = useState("");
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
-  const [entries, setEntries] = useState<BrowserEntry[]>([]);
-  const [status, setStatus] = useState<BrowserStatus>("loading");
-  const [error, setError] = useState<string | null>(null);
   const [sortKey, setSortKey] = useState<BrowserSortKey>("name");
   const [sortDirection, setSortDirection] = useState<BrowserSortDirection>("asc");
-  const requestGeneration = useRef(0);
   const entryRefs = useRef<Array<HTMLButtonElement | null>>([]);
   // Navigating into a directory or switching between the grid and list
   // branches unmounts the focused row. Without restoring focus it falls to
@@ -92,11 +87,11 @@ export default function ComputerFileBrowser({
   // the listing with no way back in except the mouse.
   const restoreFocusRef = useRef(false);
 
-  const applyAuthoritativeEntries = useCallback((next: BrowserEntry[]) => {
-    setEntries(next);
-    setStatus("ready");
-    setError(null);
-  }, []);
+  const listing = useAuthoritativeListing({ api, runtimeSlot, authGeneration, directory: currentPath });
+  const loadAuthoritativeDirectory = useCallback((
+    directory: string,
+    fetchEntries: () => Promise<BrowserEntry[]>,
+  ) => listing.run(directory, fetchEntries, false), [listing.run]);
   const management = useFileManagement({
     api,
     directory: currentPath,
@@ -104,7 +99,7 @@ export default function ComputerFileBrowser({
     authGeneration,
     socket: directorySocket,
     onFocusedPathChange: onPreviewPathChange,
-    onAuthoritativeEntries: applyAuthoritativeEntries,
+    loadAuthoritativeDirectory,
   });
 
   const markFocusForRestore = useCallback(() => {
@@ -116,14 +111,13 @@ export default function ComputerFileBrowser({
   // synchronously from the scope they were loaded under, so a runtime switch
   // or replacement session never shows the previous owner's directory names or
   // lets stale rows fire onOpenFile/onChooseFolder against the new API.
-  const browserScope = `${runtimeSlot}|${authGeneration}`;
-  const [loadedScope, setLoadedScope] = useState(browserScope);
-  const scoped = loadedScope === browserScope;
+  const { entries, status, error, scoped } = listing;
   const viewCurrentPath = scoped ? currentPath : "";
   const viewCandidatePath = scoped ? candidatePath : "";
   const viewSelectedPath = scoped ? selectedPath : null;
-  const viewStatus: BrowserStatus = scoped ? status : "loading";
+  const viewStatus: BrowserListingStatus = scoped ? status : "loading";
   const viewError = scoped ? error : null;
+  const managementEnabled = scoped && status === "ready";
   const viewEntries = useMemo(
     () =>
       scoped
@@ -148,34 +142,25 @@ export default function ComputerFileBrowser({
   );
   useEffect(() => management.reconcilePaths(renderedPaths), [management.reconcilePaths, renderedPaths]);
 
-  const load = useCallback(async (path: string) => {
+  const load = useCallback((path: string) => {
     if (!api) return;
-    const generation = ++requestGeneration.current;
-    setStatus("loading");
-    setError(null);
-    try {
+    void listing.run(path, async () => {
       const response = await api.get<{ entries: unknown }>(`/api/files/list?path=${encodeURIComponent(path)}`);
-      if (generation !== requestGeneration.current) return;
-      setEntries(parseBrowserEntries(response.entries));
-      setStatus("ready");
-    } catch (err: unknown) {
-      if (generation !== requestGeneration.current) return;
-      setEntries([]);
-      setStatus("error");
-      setError(toUserMessage(err));
-    }
-  }, [api]);
+      return parseBrowserEntries(response.entries);
+    }, true).catch((caught: unknown) => {
+      console.warn("[computer-file-browser] authoritative listing failed:", diagnosticErrorKind(caught));
+    });
+  }, [api, listing.run]);
 
   useEffect(() => {
-    setLoadedScope(browserScope);
     setCurrentPath("");
     setCandidatePath("");
     setSelectedPath(null);
     void load("");
     return () => {
-      requestGeneration.current += 1;
+      listing.invalidate();
     };
-  }, [browserScope, load]);
+  }, [api, runtimeSlot, authGeneration, load, listing.invalidate]);
 
   const navigate = useCallback((path: string) => {
     markFocusForRestore();
@@ -190,23 +175,25 @@ export default function ComputerFileBrowser({
     if (viewCurrentPath) navigate(parentPath(viewCurrentPath));
   }, [navigate, viewCurrentPath]);
 
+  const previewFile = useCallback((path: string) => {
+    onOpenFile?.(path);
+    onPreviewPathChange?.(path);
+  }, [onOpenFile, onPreviewPathChange]);
+
   // Single click selects; files also open their preview immediately so the
   // browser/preview split behaves like a Finder column with Quick Look.
   const selectEntry = useCallback((entry: BrowserEntry, path: string, modifiers: { metaKey?: boolean; ctrlKey?: boolean; shiftKey?: boolean }) => {
     setSelectedPath(path);
     management.selectPath(renderedPaths, path, modifiers, selectionPlatform);
     if (entry.type === "directory") setCandidatePath(path);
-    else {
-      onOpenFile?.(path);
-      onPreviewPathChange?.(path);
-    }
-  }, [management, onOpenFile, onPreviewPathChange, renderedPaths, selectionPlatform]);
+    else previewFile(path);
+  }, [management, previewFile, renderedPaths, selectionPlatform]);
 
   // Double-click or Enter "opens": directories navigate, files preview.
   const activateEntry = useCallback((entry: BrowserEntry, path: string) => {
     if (entry.type === "directory") navigate(path);
-    else onOpenFile?.(path);
-  }, [navigate, onOpenFile]);
+    else previewFile(path);
+  }, [navigate, previewFile]);
 
   // Grid and list render distinct entry branches, so a view switch remounts
   // every row; this restores focus once the new rows exist.
@@ -410,13 +397,13 @@ export default function ComputerFileBrowser({
         onUp={goUp}
         onNavigate={navigate}
         onRefresh={() => void load(viewCurrentPath)}
-        onNewFile={mode === "browse" ? () => management.startCreate("file") : undefined}
-        onNewFolder={mode === "browse" ? () => management.startCreate("directory") : undefined}
+        onNewFile={mode === "browse" && managementEnabled ? () => management.startCreate("file") : undefined}
+        onNewFolder={mode === "browse" && managementEnabled ? () => management.startCreate("directory") : undefined}
       />
 
       <FileOperationNotice snapshot={management.snapshot} localNotice={management.localNotice} />
 
-      {mode === "browse" ? (
+      {mode === "browse" && managementEnabled ? (
         <FileCreationContextMenu
           onNewFile={() => management.startCreate("file")}
           onNewFolder={() => management.startCreate("directory")}

--- a/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
+++ b/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
@@ -19,12 +19,19 @@ import {
   type BrowserSortKey,
 } from "./browser-entries";
 import { useBrowserViewPreference } from "./browser-view-preference";
+import { InlineNameEditor } from "./InlineNameEditor";
+import { FileCreationContextMenu, ManagedFileActionMenu } from "./FileActionMenu";
+import { FileOperationNotice, MoveToTrashDialog } from "./FileOperationNotice";
 import {
   BrowserToolbar,
+  BrowserListing,
   EntryButton,
   measureGridColumns,
-  SortHeader,
 } from "./browser-views";
+import { useFileManagement } from "./use-file-management";
+import type { FileSelectionPlatform } from "./file-selection";
+import { getKernelSocket } from "../../lib/kernel-wiring";
+import type { DirectorySyncSocket } from "./use-directory-sync";
 
 type BrowserStatus = "loading" | "ready" | "error";
 
@@ -43,7 +50,11 @@ export default function ComputerFileBrowser({
   framed = true,
   mode = "browse",
   onOpenFile,
+  onPreviewPathChange,
   onChooseFolder,
+  onOpenInEditor,
+  directorySocket = getKernelSocket(),
+  selectionPlatform = defaultSelectionPlatform(),
 }: {
   compact?: boolean;
   // framed renders the browser as its own bordered card (dialogs, pickers).
@@ -54,7 +65,11 @@ export default function ComputerFileBrowser({
   // competes with files. The default "browse" mode is unchanged.
   mode?: "browse" | "folder-picker";
   onOpenFile?: (path: string) => void;
+  onPreviewPathChange?: (path: string | null) => void;
   onChooseFolder?: (path: string) => void;
+  onOpenInEditor?: (path: string) => void;
+  directorySocket?: DirectorySyncSocket | null;
+  selectionPlatform?: FileSelectionPlatform;
 }) {
   const api = useConnection((state) => state.api);
   const runtimeSlot = useConnection((state) => state.runtimeSlot);
@@ -76,6 +91,21 @@ export default function ComputerFileBrowser({
   // <body>, arrow keys stop working, and a keyboard user is stranded outside
   // the listing with no way back in except the mouse.
   const restoreFocusRef = useRef(false);
+
+  const applyAuthoritativeEntries = useCallback((next: BrowserEntry[]) => {
+    setEntries(next);
+    setStatus("ready");
+    setError(null);
+  }, []);
+  const management = useFileManagement({
+    api,
+    directory: currentPath,
+    runtimeSlot,
+    authGeneration,
+    socket: directorySocket,
+    onFocusedPathChange: onPreviewPathChange,
+    onAuthoritativeEntries: applyAuthoritativeEntries,
+  });
 
   const markFocusForRestore = useCallback(() => {
     const active = document.activeElement;
@@ -108,6 +138,15 @@ export default function ComputerFileBrowser({
     () => sortBrowserEntries(viewEntries, sortKey, sortDirection),
     [viewEntries, sortKey, sortDirection],
   );
+  const renderedPaths = useMemo(
+    () => sortedEntries.map((entry) => joinPath(viewCurrentPath, entry.name)),
+    [sortedEntries, viewCurrentPath],
+  );
+  const entriesByPath = useMemo(
+    () => new Map(sortedEntries.map((entry) => [joinPath(viewCurrentPath, entry.name), entry])),
+    [sortedEntries, viewCurrentPath],
+  );
+  useEffect(() => management.reconcilePaths(renderedPaths), [management.reconcilePaths, renderedPaths]);
 
   const load = useCallback(async (path: string) => {
     if (!api) return;
@@ -143,8 +182,9 @@ export default function ComputerFileBrowser({
     setCurrentPath(path);
     setCandidatePath(path);
     setSelectedPath(null);
+    onPreviewPathChange?.(null);
     void load(path);
-  }, [load, markFocusForRestore]);
+  }, [load, markFocusForRestore, onPreviewPathChange]);
 
   const goUp = useCallback(() => {
     if (viewCurrentPath) navigate(parentPath(viewCurrentPath));
@@ -152,11 +192,15 @@ export default function ComputerFileBrowser({
 
   // Single click selects; files also open their preview immediately so the
   // browser/preview split behaves like a Finder column with Quick Look.
-  const selectEntry = useCallback((entry: BrowserEntry, path: string) => {
+  const selectEntry = useCallback((entry: BrowserEntry, path: string, modifiers: { metaKey?: boolean; ctrlKey?: boolean; shiftKey?: boolean }) => {
     setSelectedPath(path);
+    management.selectPath(renderedPaths, path, modifiers, selectionPlatform);
     if (entry.type === "directory") setCandidatePath(path);
-    else onOpenFile?.(path);
-  }, [onOpenFile]);
+    else {
+      onOpenFile?.(path);
+      onPreviewPathChange?.(path);
+    }
+  }, [management, onOpenFile, onPreviewPathChange, renderedPaths, selectionPlatform]);
 
   // Double-click or Enter "opens": directories navigate, files preview.
   const activateEntry = useCallback((entry: BrowserEntry, path: string) => {
@@ -249,7 +293,7 @@ export default function ComputerFileBrowser({
         <Button variant="subtle" onClick={() => void load(viewCurrentPath)}>Try again</Button>
       </div>
     );
-  } else if (sortedEntries.length === 0) {
+  } else if (sortedEntries.length === 0 && management.draft?.mode !== "create") {
     content = (
       <div className="flex h-full flex-col items-center justify-center gap-2 text-sm" style={{ color: "var(--text-tertiary)" }}>
         <FolderOpen size={22} aria-hidden />
@@ -260,67 +304,93 @@ export default function ComputerFileBrowser({
     const buttons = sortedEntries.map((entry, index) => {
       const path = joinPath(viewCurrentPath, entry.name);
       const isCandidate = entry.type === "directory" && viewCandidatePath === path;
-      return (
+      if (management.draft?.mode === "rename" && management.draft.path === path) {
+        return (
+          <InlineNameEditor
+            key={`rename:${path}`}
+            mode="rename"
+            originalName={entry.name}
+            kind={entry.type}
+            value={management.draft.name}
+            error={management.draftError}
+            disabled={management.draftSubmitting}
+            onChange={management.updateDraftName}
+            onSubmit={() => void management.submitDraft()}
+            onCancel={management.cancelDraft}
+          />
+        );
+      }
+      const entryButton = (
         <EntryButton
           key={`${entry.type}:${path}`}
           entry={entry}
           grid={view === "grid"}
           listColumns={listColumns}
-          selected={viewSelectedPath === path || isCandidate}
-          pressed={mode === "folder-picker" && entry.type === "directory" ? isCandidate : undefined}
+          selected={mode === "folder-picker" ? viewSelectedPath === path || isCandidate : management.selection.selectedPaths.includes(path)}
+          pressed={mode === "folder-picker" && entry.type === "directory"
+            ? isCandidate
+            : mode === "browse" ? management.selection.selectedPaths.includes(path) : undefined}
           buttonRef={(el) => {
             entryRefs.current[index] = el;
           }}
-          onSelect={() => selectEntry(entry, path)}
+          onSelect={(event) => selectEntry(entry, path, event)}
+          disabled={management.snapshot.pendingPaths.includes(path)}
           onNavigate={() => {
             if (entry.type === "directory") navigate(path);
           }}
           onKeyDown={(event) => onEntryKeyDown(event, entry, path, index)}
         />
       );
-    });
-    content =
-      view === "grid" ? (
-        <div ref={gridRef} className="flex flex-wrap content-start gap-1">
-          {buttons}
-        </div>
-      ) : (
-        <div>
-          <div
-            className="sticky top-0 z-10 grid items-center gap-2 border-b px-2 pb-1 text-[11px] font-medium"
-            style={{
-              gridTemplateColumns: listColumns,
-              borderColor: "var(--border-subtle)",
-              background: "var(--bg-surface)",
-            }}
-          >
-            <SortHeader
-              label="Name"
-              sortLabel="Sort by name"
-              active={sortKey === "name"}
-              direction={sortDirection}
-              onClick={() => toggleSort("name")}
-            />
-            <SortHeader
-              label="Size"
-              sortLabel="Sort by size"
-              active={sortKey === "size"}
-              direction={sortDirection}
-              alignEnd
-              onClick={() => toggleSort("size")}
-            />
-            <SortHeader
-              label="Modified"
-              sortLabel="Sort by modified"
-              active={sortKey === "modified"}
-              direction={sortDirection}
-              alignEnd
-              onClick={() => toggleSort("modified")}
-            />
-          </div>
-          <div className="grid grid-cols-1 gap-0.5 pt-0.5">{buttons}</div>
-        </div>
+      if (mode === "folder-picker") return entryButton;
+      const pending = management.snapshot.pendingPaths.includes(path);
+      const selectedForAction = management.selection.selectedPaths.includes(path)
+        ? management.selection.selectedPaths
+        : [path];
+      const trashDisabled = selectedForAction.some((selected) =>
+        management.snapshot.pendingPaths.includes(selected) || !entriesByPath.get(selected)?.capabilities.canTrash);
+      return (
+        <ManagedFileActionMenu
+          key={`${entry.type}:${path}`}
+          label={entry.name}
+          disabled={pending}
+          selectedCount={management.selection.selectedPaths.length}
+          canRename={entry.capabilities.canRename}
+          canTrash={!trashDisabled}
+          onOpen={() => activateEntry(entry, path)}
+          onOpenInEditor={onOpenInEditor && entry.type === "file" ? () => onOpenInEditor(path) : undefined}
+          onRename={() => management.startRename(path, entry.name)}
+          onTrash={() => management.requestTrash(selectedForAction)}
+          onMenuOpen={() => {
+            if (!management.selection.selectedPaths.includes(path)) {
+              management.selectPath(
+                renderedPaths,
+                path, {}, selectionPlatform,
+              );
+            }
+          }}
+        >
+          {entryButton}
+        </ManagedFileActionMenu>
       );
+    });
+    const draftRow = management.draft?.mode === "create" ? (
+      <InlineNameEditor
+        kind={management.draft.kind}
+        value={management.draft.name}
+        error={management.draftError}
+        disabled={management.draftSubmitting}
+        onChange={management.updateDraftName}
+        onSubmit={() => void management.submitDraft()}
+        onCancel={management.cancelDraft}
+      />
+    ) : null;
+    content = (
+      <BrowserListing
+        grid={view === "grid"} gridRef={gridRef} listColumns={listColumns}
+        draftRow={draftRow} buttons={buttons} sortKey={sortKey}
+        sortDirection={sortDirection} onSort={toggleSort}
+      />
+    );
   }
 
   return (
@@ -340,9 +410,22 @@ export default function ComputerFileBrowser({
         onUp={goUp}
         onNavigate={navigate}
         onRefresh={() => void load(viewCurrentPath)}
+        onNewFile={mode === "browse" ? () => management.startCreate("file") : undefined}
+        onNewFolder={mode === "browse" ? () => management.startCreate("directory") : undefined}
       />
 
-      <div className={`${compact ? "h-52" : "min-h-0 flex-1"} overflow-y-auto p-1.5`}>{content}</div>
+      <FileOperationNotice snapshot={management.snapshot} localNotice={management.localNotice} />
+
+      {mode === "browse" ? (
+        <FileCreationContextMenu
+          onNewFile={() => management.startCreate("file")}
+          onNewFolder={() => management.startCreate("directory")}
+        >
+          <div data-testid="files-listing" className={`${compact ? "h-52" : "min-h-0 flex-1"} overflow-y-auto p-1.5`}>{content}</div>
+        </FileCreationContextMenu>
+      ) : (
+        <div className={`${compact ? "h-52" : "min-h-0 flex-1"} overflow-y-auto p-1.5`}>{content}</div>
+      )}
 
       {onChooseFolder ? (
         <div className="flex shrink-0 items-center justify-between gap-3 border-t px-3 py-2" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }}>
@@ -354,6 +437,19 @@ export default function ComputerFileBrowser({
           </Button>
         </div>
       ) : null}
+      <MoveToTrashDialog
+        paths={management.trashPaths}
+        pending={management.snapshot.status === "pending"}
+        onCancel={management.cancelTrash}
+        onConfirm={() => void management.confirmTrash()}
+      />
     </div>
   );
+}
+
+function defaultSelectionPlatform(): FileSelectionPlatform {
+  const platform = globalThis.navigator?.platform ?? "";
+  if (/mac/i.test(platform)) return "mac";
+  if (/win/i.test(platform)) return "windows";
+  return "linux";
 }

--- a/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
+++ b/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
@@ -31,7 +31,7 @@ import {
 } from "./browser-views";
 import { useFileManagement } from "./use-file-management";
 import { useAuthoritativeListing, type BrowserListingStatus } from "./use-authoritative-listing";
-import type { FileSelectionPlatform } from "./file-selection";
+import { MAX_FILE_BATCH_SIZE, type FileSelectionPlatform } from "./file-selection";
 import { getKernelSocket } from "../../lib/kernel-wiring";
 import type { DirectorySyncSocket } from "./use-directory-sync";
 
@@ -141,8 +141,8 @@ export default function ComputerFileBrowser({
     () => new Map(sortedEntries.map((entry) => [joinPath(viewCurrentPath, entry.name), entry])),
     [sortedEntries, viewCurrentPath],
   );
-  // Selection contracts cap this collection at 100 paths; a derived Set keeps
-  // per-row state checks constant-time without entering shared/store state.
+  // Selection is bounded by the 1,000-entry listing contract; a derived Set
+  // keeps per-row checks constant-time without entering shared/store state.
   const selectedPathSet = useMemo(
     () => new Set(management.selection.selectedPaths),
     [management.selection.selectedPaths],
@@ -338,7 +338,7 @@ export default function ComputerFileBrowser({
       const selectedForAction = selectedPathSet.has(path)
         ? management.selection.selectedPaths
         : [path];
-      const trashDisabled = selectedForAction.some((selected) =>
+      const trashDisabled = selectedForAction.length > MAX_FILE_BATCH_SIZE || selectedForAction.some((selected) =>
         management.snapshot.pendingPaths.includes(selected) || !entriesByPath.get(selected)?.capabilities.canTrash);
       return (
         <ManagedFileActionMenu

--- a/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
+++ b/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
@@ -26,6 +26,7 @@ import {
   BrowserToolbar,
   BrowserListing,
   EntryButton,
+  getFileListColumns,
   measureGridColumns,
 } from "./browser-views";
 import { useFileManagement } from "./use-file-management";
@@ -139,6 +140,12 @@ export default function ComputerFileBrowser({
   const entriesByPath = useMemo(
     () => new Map(sortedEntries.map((entry) => [joinPath(viewCurrentPath, entry.name), entry])),
     [sortedEntries, viewCurrentPath],
+  );
+  // Selection contracts cap this collection at 100 paths; a derived Set keeps
+  // per-row state checks constant-time without entering shared/store state.
+  const selectedPathSet = useMemo(
+    () => new Set(management.selection.selectedPaths),
+    [management.selection.selectedPaths],
   );
   useEffect(() => management.reconcilePaths(renderedPaths), [management.reconcilePaths, renderedPaths]);
 
@@ -263,10 +270,8 @@ export default function ComputerFileBrowser({
   }, [viewCurrentPath]);
 
   const chosenName = (viewCandidatePath.split("/").pop() || "Matrix home");
-  // Name flexes (minmax(0,1fr) + truncate); Size/Modified are fixed-width
-  // right-aligned columns sized to the format.ts outputs, so long names only
-  // truncate once the pane is genuinely out of room.
-  const listColumns = compact ? "minmax(0,1fr) 64px 88px" : "minmax(0,1fr) 72px 104px";
+  // Name flexes while Size, Modified, and row actions keep aligned tracks.
+  const listColumns = getFileListColumns(compact);
 
   let content: ReactNode;
   if (viewStatus === "loading") {
@@ -313,10 +318,10 @@ export default function ComputerFileBrowser({
           entry={entry}
           grid={view === "grid"}
           listColumns={listColumns}
-          selected={mode === "folder-picker" ? viewSelectedPath === path || isCandidate : management.selection.selectedPaths.includes(path)}
+          selected={mode === "folder-picker" ? viewSelectedPath === path || isCandidate : selectedPathSet.has(path)}
           pressed={mode === "folder-picker" && entry.type === "directory"
             ? isCandidate
-            : mode === "browse" ? management.selection.selectedPaths.includes(path) : undefined}
+            : mode === "browse" ? selectedPathSet.has(path) : undefined}
           buttonRef={(el) => {
             entryRefs.current[index] = el;
           }}
@@ -330,7 +335,7 @@ export default function ComputerFileBrowser({
       );
       if (mode === "folder-picker") return entryButton;
       const pending = management.snapshot.pendingPaths.includes(path);
-      const selectedForAction = management.selection.selectedPaths.includes(path)
+      const selectedForAction = selectedPathSet.has(path)
         ? management.selection.selectedPaths
         : [path];
       const trashDisabled = selectedForAction.some((selected) =>
@@ -339,6 +344,7 @@ export default function ComputerFileBrowser({
         <ManagedFileActionMenu
           key={`${entry.type}:${path}`}
           label={entry.name}
+          selected={selectedPathSet.has(path)}
           disabled={pending}
           selectedCount={management.selection.selectedPaths.length}
           canRename={entry.capabilities.canRename}
@@ -348,7 +354,7 @@ export default function ComputerFileBrowser({
           onRename={() => management.startRename(path, entry.name)}
           onTrash={() => management.requestTrash(selectedForAction)}
           onMenuOpen={() => {
-            if (!management.selection.selectedPaths.includes(path)) {
+            if (!selectedPathSet.has(path)) {
               management.selectPath(
                 renderedPaths,
                 path, {}, selectionPlatform,

--- a/desktop/src/renderer/src/features/files/FileActionMenu.tsx
+++ b/desktop/src/renderer/src/features/files/FileActionMenu.tsx
@@ -1,0 +1,105 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { MoreHorizontal } from "lucide-react";
+import type { ReactNode } from "react";
+import { ContextMenu, IconButton, type MenuItem } from "../../design/primitives";
+
+export function FileActionMenu({
+  label,
+  items,
+  onMenuOpen,
+  children,
+  disabled = false,
+}: {
+  label: string;
+  items: MenuItem[];
+  onMenuOpen: () => void;
+  children: ReactNode;
+  disabled?: boolean;
+}) {
+  const content = (
+    <div className="group relative" onContextMenu={disabled ? undefined : onMenuOpen}>
+        {children}
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger asChild>
+            <IconButton
+              label={`More actions for ${label}`}
+              disabled={disabled}
+              className="absolute top-1 right-1 opacity-70 group-hover:opacity-100 focus:opacity-100"
+              onPointerDown={onMenuOpen}
+            >
+              <MoreHorizontal size={14} aria-hidden />
+            </IconButton>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content
+              align="end"
+              sideOffset={4}
+              className="fade-in z-[100] min-w-[180px] rounded-lg border p-1"
+              style={{ background: "var(--bg-overlay)", borderColor: "var(--border-default)", boxShadow: "var(--shadow-2)" }}
+            >
+              {items.map((item) => (
+                <DropdownMenu.Item
+                  key={item.label}
+                  disabled={item.disabled}
+                  onSelect={item.onSelect}
+                  className="flex cursor-default items-center rounded-md px-2.5 py-1.5 text-sm outline-none data-[highlighted]:bg-[var(--bg-hover)] data-[disabled]:opacity-40"
+                  style={{ color: item.danger ? "var(--danger)" : "var(--text-primary)" }}
+                >
+                  {item.label}
+                </DropdownMenu.Item>
+              ))}
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Root>
+    </div>
+  );
+  return disabled ? content : <ContextMenu items={items}>{content}</ContextMenu>;
+}
+
+export function ManagedFileActionMenu({
+  label, disabled, selectedCount, canRename, canTrash,
+  onMenuOpen, onOpen, onOpenInEditor, onRename, onTrash, children,
+}: {
+  label: string;
+  disabled: boolean;
+  selectedCount: number;
+  canRename: boolean;
+  canTrash: boolean;
+  onMenuOpen: () => void;
+  onOpen: () => void;
+  onOpenInEditor?: () => void;
+  onRename: () => void;
+  onTrash: () => void;
+  children: ReactNode;
+}) {
+  const items: MenuItem[] = [
+    { label: "Open", onSelect: onOpen },
+    ...(onOpenInEditor ? [{ label: "Open in Editor", onSelect: onOpenInEditor }] : []),
+    { label: "Rename", disabled: selectedCount > 1 || disabled || !canRename, onSelect: onRename },
+    { label: "Move to Trash", danger: true, disabled: !canTrash, onSelect: onTrash },
+  ];
+  return (
+    <FileActionMenu label={label} items={items} disabled={disabled} onMenuOpen={onMenuOpen}>
+      {children}
+    </FileActionMenu>
+  );
+}
+
+export function FileCreationContextMenu({
+  onNewFile,
+  onNewFolder,
+  children,
+}: {
+  onNewFile: () => void;
+  onNewFolder: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <ContextMenu items={[
+      { label: "New File", onSelect: onNewFile },
+      { label: "New Folder", onSelect: onNewFolder },
+    ]}>
+      {children}
+    </ContextMenu>
+  );
+}

--- a/desktop/src/renderer/src/features/files/FileActionMenu.tsx
+++ b/desktop/src/renderer/src/features/files/FileActionMenu.tsx
@@ -8,12 +8,14 @@ export function FileActionMenu({
   items,
   onMenuOpen,
   children,
+  selected = false,
   disabled = false,
 }: {
   label: string;
   items: MenuItem[];
   onMenuOpen: () => void;
   children: ReactNode;
+  selected?: boolean;
   disabled?: boolean;
 }) {
   const content = (
@@ -24,7 +26,9 @@ export function FileActionMenu({
             <IconButton
               label={`More actions for ${label}`}
               disabled={disabled}
-              className="absolute top-1 right-1 opacity-70 group-hover:opacity-100 focus:opacity-100"
+              className={`absolute top-1 right-1 group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100 ${
+                selected ? "opacity-100" : "opacity-0"
+              }`}
               onPointerDown={onMenuOpen}
             >
               <MoreHorizontal size={14} aria-hidden />
@@ -57,10 +61,11 @@ export function FileActionMenu({
 }
 
 export function ManagedFileActionMenu({
-  label, disabled, selectedCount, canRename, canTrash,
+  label, selected, disabled, selectedCount, canRename, canTrash,
   onMenuOpen, onOpen, onOpenInEditor, onRename, onTrash, children,
 }: {
   label: string;
+  selected: boolean;
   disabled: boolean;
   selectedCount: number;
   canRename: boolean;
@@ -79,7 +84,7 @@ export function ManagedFileActionMenu({
     { label: "Move to Trash", danger: true, disabled: !canTrash, onSelect: onTrash },
   ];
   return (
-    <FileActionMenu label={label} items={items} disabled={disabled} onMenuOpen={onMenuOpen}>
+    <FileActionMenu label={label} items={items} selected={selected} disabled={disabled} onMenuOpen={onMenuOpen}>
       {children}
     </FileActionMenu>
   );

--- a/desktop/src/renderer/src/features/files/FileOperationNotice.tsx
+++ b/desktop/src/renderer/src/features/files/FileOperationNotice.tsx
@@ -1,0 +1,53 @@
+import { Button, Dialog } from "../../design/primitives";
+import type { FileOperationSnapshot } from "./file-operation-controller";
+
+export function FileOperationNotice({ snapshot, localNotice }: {
+  snapshot: FileOperationSnapshot;
+  localNotice?: string | null;
+}) {
+  const message = localNotice ?? safeOperationMessage(snapshot);
+  if (!message) return null;
+  return (
+    <div role="status" className="border-b px-3 py-2 text-xs" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)", background: "var(--bg-raised)" }}>
+      {message}
+    </div>
+  );
+}
+
+export function MoveToTrashDialog({ paths, pending, onCancel, onConfirm }: {
+  paths: readonly string[];
+  pending: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const count = paths.length;
+  return (
+    <Dialog open={count > 0} onClose={onCancel} width={380}>
+      <div className="flex flex-col gap-3 p-4">
+        <div>
+          <h2 className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+            Move {count === 1 ? "this item" : `${count} items`} to Trash?
+          </h2>
+          <p className="mt-1 text-sm" style={{ color: "var(--text-secondary)" }}>
+            The selected {count === 1 ? "item" : "items"} will be moved to Trash.
+          </p>
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" disabled={pending} onClick={onCancel}>Cancel</Button>
+          <Button variant="danger" disabled={pending} onClick={onConfirm}>Move to Trash</Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+function safeOperationMessage(snapshot: FileOperationSnapshot): string | null {
+  if (snapshot.notice === "authoritative_reconciliation_required") return "The result could not be confirmed. Refresh before trying again.";
+  if (snapshot.failures.some((failure) => failure.code === "protected")) return "Some selected items are protected and were not moved to Trash.";
+  if (snapshot.failures.some((failure) => failure.code === "skipped")) return "Some selected items were skipped.";
+  if (snapshot.failures.length > 0) return "Some selected items could not be changed.";
+  if (snapshot.notice === "operation_unavailable") return "File actions are temporarily unavailable.";
+  if (snapshot.notice === "request_mismatch" || snapshot.notice === "request_conflict") return "This file action is no longer valid. Refresh and try again.";
+  if (snapshot.notice === "operation_failed") return "The file action could not be completed.";
+  return null;
+}

--- a/desktop/src/renderer/src/features/files/FilesWorkspace.tsx
+++ b/desktop/src/renderer/src/features/files/FilesWorkspace.tsx
@@ -28,8 +28,8 @@ export default function FilesWorkspace() {
     );
   }, [runtimeSlot, authGeneration]);
 
-  const handleOpenFile = useCallback(
-    (path: string) => setSelection({ slot: runtimeSlot, authGeneration, path }),
+  const handlePreviewPathChange = useCallback(
+    (path: string | null) => setSelection(path ? { slot: runtimeSlot, authGeneration, path } : null),
     [runtimeSlot, authGeneration],
   );
 
@@ -54,7 +54,7 @@ export default function FilesWorkspace() {
         className="m-3 grid min-h-0 flex-1 grid-cols-1 grid-rows-[minmax(220px,40%)_minmax(0,1fr)] overflow-hidden rounded-lg border md:grid-cols-[minmax(280px,2fr)_minmax(0,3fr)] md:grid-rows-1"
         style={{ background: "var(--bg-surface)", borderColor: "var(--border-subtle)" }}
       >
-        <ComputerFileBrowser onOpenFile={handleOpenFile} framed={false} />
+        <ComputerFileBrowser onPreviewPathChange={handlePreviewPathChange} framed={false} />
         <section
           className="flex min-h-0 min-w-0 flex-col border-t md:border-t-0 md:border-l"
           style={{ borderColor: "var(--border-subtle)" }}

--- a/desktop/src/renderer/src/features/files/InlineNameEditor.tsx
+++ b/desktop/src/renderer/src/features/files/InlineNameEditor.tsx
@@ -1,0 +1,54 @@
+import { Check, X } from "lucide-react";
+import { IconButton } from "../../design/primitives";
+
+export function InlineNameEditor({
+  kind,
+  value,
+  error,
+  onChange,
+  onSubmit,
+  onCancel,
+  mode = "create",
+  originalName,
+  disabled = false,
+}: {
+  kind: "file" | "directory";
+  value: string;
+  error?: string | null;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+  mode?: "create" | "rename";
+  originalName?: string;
+  disabled?: boolean;
+}) {
+  const noun = kind === "directory" ? "folder" : "file";
+  const rename = mode === "rename";
+  return (
+    <div className="rounded-md px-2 py-1.5" style={{ background: "var(--bg-selected)" }}>
+      <div className="flex items-center gap-1.5">
+        <input
+          autoFocus
+          disabled={disabled}
+          aria-label={rename ? `Rename ${originalName ?? noun}` : `New ${noun} name`}
+          value={value}
+          onChange={(event) => onChange(event.currentTarget.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              onSubmit();
+            } else if (event.key === "Escape") {
+              event.preventDefault();
+              onCancel();
+            }
+          }}
+          className="min-w-0 flex-1 rounded border px-2 py-1 text-sm outline-none focus:ring-1 focus:ring-[var(--accent)]"
+          style={{ background: "var(--bg-surface)", borderColor: "var(--border-default)", color: "var(--text-primary)" }}
+        />
+        <IconButton label={rename ? "Save rename" : `Create ${noun}`} disabled={disabled} onClick={onSubmit}><Check size={13} /></IconButton>
+        <IconButton label={rename ? "Cancel rename" : `Cancel new ${noun}`} disabled={disabled} onClick={onCancel}><X size={13} /></IconButton>
+      </div>
+      {error ? <p role="alert" className="mt-1 text-xs" style={{ color: "var(--danger)" }}>{error}</p> : null}
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/files/browser-views.tsx
+++ b/desktop/src/renderer/src/features/files/browser-views.tsx
@@ -25,6 +25,12 @@ const VIEW_OPTIONS: Array<{ mode: BrowserViewMode; label: string; icon: typeof L
   { mode: "list", label: "List view", icon: List },
 ];
 
+export function getFileListColumns(compact: boolean): string {
+  return compact
+    ? "minmax(0,1fr) 64px 88px 32px"
+    : "minmax(0,1fr) 72px 104px 32px";
+}
+
 // ArrowUp/ArrowDown in grid view move by a visual row. Columns are measured
 // from the rendered tiles; jsdom (offsetWidth 0) and unmeasured layouts fall
 // back to single-step movement.
@@ -204,6 +210,7 @@ export function EntryButton({
       <span className="truncate text-right text-xs" style={{ color: "var(--text-tertiary)" }}>
         {formatModified(entry.modifiedAt)}
       </span>
+      <span aria-hidden="true" />
     </button>
   );
 }
@@ -308,6 +315,7 @@ export function BrowserListing({
         <SortHeader label="Name" sortLabel="Sort by name" active={sortKey === "name"} direction={sortDirection} onClick={() => onSort("name")} />
         <SortHeader label="Size" sortLabel="Sort by size" active={sortKey === "size"} direction={sortDirection} alignEnd onClick={() => onSort("size")} />
         <SortHeader label="Modified" sortLabel="Sort by modified" active={sortKey === "modified"} direction={sortDirection} alignEnd onClick={() => onSort("modified")} />
+        <span aria-hidden="true" />
       </div>
       <div className="grid grid-cols-1 gap-0.5 pt-0.5">{draftRow}{buttons}</div>
     </div>

--- a/desktop/src/renderer/src/features/files/browser-views.tsx
+++ b/desktop/src/renderer/src/features/files/browser-views.tsx
@@ -9,11 +9,13 @@ import {
   Home,
   LayoutGrid,
   List,
+  FilePlus,
+  FolderPlus,
   RefreshCw,
 } from "lucide-react";
-import type { KeyboardEvent } from "react";
-import { IconButton } from "../../design/primitives";
-import type { BrowserEntry, BrowserSortDirection } from "./browser-entries";
+import type { KeyboardEvent, MouseEvent, ReactNode, RefObject } from "react";
+import { Button, IconButton } from "../../design/primitives";
+import type { BrowserEntry, BrowserSortDirection, BrowserSortKey } from "./browser-entries";
 import type { BrowserViewMode } from "./browser-view-preference";
 import { FileGlyph, kindForEntry } from "./file-kind";
 import { formatEntrySize, formatModified } from "./format";
@@ -128,6 +130,7 @@ export function EntryButton({
   onSelect,
   onNavigate,
   onKeyDown,
+  disabled = false,
 }: {
   entry: BrowserEntry;
   grid: boolean;
@@ -135,9 +138,10 @@ export function EntryButton({
   selected: boolean;
   pressed: boolean | undefined;
   buttonRef: (el: HTMLButtonElement | null) => void;
-  onSelect: () => void;
+  onSelect: (event: MouseEvent<HTMLButtonElement>) => void;
   onNavigate: () => void;
   onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
+  disabled?: boolean;
 }) {
   const kind = kindForEntry(entry);
   const glyphColor = entry.type === "directory" ? "var(--accent)" : "var(--text-tertiary)";
@@ -147,6 +151,7 @@ export function EntryButton({
       <button
         ref={buttonRef}
         type="button"
+        disabled={disabled}
         aria-label={`Open ${entry.name}`}
         aria-pressed={pressed}
         data-grid-tile
@@ -174,6 +179,7 @@ export function EntryButton({
     <button
       ref={buttonRef}
       type="button"
+      disabled={disabled}
       aria-label={`Open ${entry.name}`}
       aria-pressed={pressed}
       className="grid h-9 w-full items-center gap-2 rounded-md px-2 text-left text-sm outline-none hover:bg-[var(--bg-hover)] focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
@@ -211,6 +217,8 @@ export function BrowserToolbar({
   onUp,
   onNavigate,
   onRefresh,
+  onNewFile,
+  onNewFolder,
 }: {
   compact: boolean;
   currentPath: string;
@@ -220,6 +228,8 @@ export function BrowserToolbar({
   onUp: () => void;
   onNavigate: (path: string) => void;
   onRefresh: () => void;
+  onNewFile?: () => void;
+  onNewFolder?: () => void;
 }) {
   return (
     <div className="flex h-10 shrink-0 items-center gap-1 border-b px-2" style={{ borderColor: "var(--border-subtle)" }}>
@@ -256,10 +266,50 @@ export function BrowserToolbar({
           </span>
         ))}
       </div>
+      {onNewFile ? (
+        <Button variant="ghost" className="shrink-0 text-xs" onClick={onNewFile}>
+          <FilePlus size={13} aria-hidden />New File
+        </Button>
+      ) : null}
+      {onNewFolder ? (
+        <Button variant="ghost" className="shrink-0 text-xs" onClick={onNewFolder}>
+          <FolderPlus size={13} aria-hidden />New Folder
+        </Button>
+      ) : null}
       <ViewSwitcher view={view} onChange={onViewChange} />
       <IconButton label="Refresh folder" className="shrink-0" onClick={onRefresh}>
         <RefreshCw size={13} />
       </IconButton>
+    </div>
+  );
+}
+
+export function BrowserListing({
+  grid, gridRef, listColumns, draftRow, buttons, sortKey, sortDirection, onSort,
+}: {
+  grid: boolean;
+  gridRef: RefObject<HTMLDivElement | null>;
+  listColumns: string;
+  draftRow: ReactNode;
+  buttons: ReactNode;
+  sortKey: BrowserSortKey;
+  sortDirection: BrowserSortDirection;
+  onSort: (key: BrowserSortKey) => void;
+}) {
+  if (grid) {
+    return <div ref={gridRef} className="flex flex-wrap content-start gap-1">{draftRow}{buttons}</div>;
+  }
+  return (
+    <div>
+      <div
+        className="sticky top-0 z-10 grid items-center gap-2 border-b px-2 pb-1 text-[11px] font-medium"
+        style={{ gridTemplateColumns: listColumns, borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+      >
+        <SortHeader label="Name" sortLabel="Sort by name" active={sortKey === "name"} direction={sortDirection} onClick={() => onSort("name")} />
+        <SortHeader label="Size" sortLabel="Sort by size" active={sortKey === "size"} direction={sortDirection} alignEnd onClick={() => onSort("size")} />
+        <SortHeader label="Modified" sortLabel="Sort by modified" active={sortKey === "modified"} direction={sortDirection} alignEnd onClick={() => onSort("modified")} />
+      </div>
+      <div className="grid grid-cols-1 gap-0.5 pt-0.5">{draftRow}{buttons}</div>
     </div>
   );
 }

--- a/desktop/src/renderer/src/features/files/use-authoritative-listing.ts
+++ b/desktop/src/renderer/src/features/files/use-authoritative-listing.ts
@@ -1,0 +1,89 @@
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import type { ApiClient } from "../../lib/api";
+import { toUserMessage } from "../../lib/errors";
+import { useConnection } from "../../stores/connection";
+import type { BrowserEntry } from "./browser-entries";
+
+export type BrowserListingStatus = "loading" | "ready" | "error";
+
+interface ListingScope {
+  api: ApiClient | null;
+  runtimeSlot: string;
+  authGeneration: number;
+  directory: string;
+}
+
+export function useAuthoritativeListing(options: ListingScope) {
+  const { api, runtimeSlot, authGeneration, directory: currentDirectory } = options;
+  const [entries, setEntries] = useState<BrowserEntry[]>([]);
+  const [status, setStatus] = useState<BrowserListingStatus>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [loadedScope, setLoadedScope] = useState<ListingScope>(() => ({
+    api, runtimeSlot, authGeneration, directory: currentDirectory,
+  }));
+  const committedScopeRef = useRef<ListingScope>({
+    api, runtimeSlot, authGeneration, directory: currentDirectory,
+  });
+  const requestGeneration = useRef(0);
+
+  useLayoutEffect(() => {
+    committedScopeRef.current = { api, runtimeSlot, authGeneration, directory: currentDirectory };
+  }, [api, runtimeSlot, authGeneration, currentDirectory]);
+
+  useLayoutEffect(() => {
+    requestGeneration.current += 1;
+  }, [api, runtimeSlot, authGeneration]);
+
+  const run = useCallback(async (
+    directory: string,
+    fetchEntries: () => Promise<BrowserEntry[]>,
+    surfaceStatus: boolean,
+  ) => {
+    if (!api) return [];
+    const generation = ++requestGeneration.current;
+    const requestScope = { api, runtimeSlot, authGeneration, directory };
+    if (surfaceStatus) {
+      setStatus("loading");
+      setError(null);
+    }
+    try {
+      const next = await fetchEntries();
+      const connection = useConnection.getState();
+      if (generation === requestGeneration.current
+        && sameScope(committedScopeRef.current, requestScope)
+        && connection.api === requestScope.api
+        && connection.runtimeSlot === requestScope.runtimeSlot
+        && connection.authGeneration === requestScope.authGeneration) {
+        setEntries(next);
+        setLoadedScope(requestScope);
+        setStatus("ready");
+        setError(null);
+      }
+      return next;
+    } catch (caught: unknown) {
+      if (surfaceStatus && generation === requestGeneration.current
+        && sameScope(committedScopeRef.current, requestScope)) {
+        setEntries([]);
+        setLoadedScope(requestScope);
+        setStatus("error");
+        setError(toUserMessage(caught));
+      }
+      throw caught;
+    }
+  }, [api, runtimeSlot, authGeneration]);
+
+  const invalidate = useCallback(() => {
+    requestGeneration.current += 1;
+  }, []);
+  const scoped = api !== null && sameScope(loadedScope, {
+    api, runtimeSlot, authGeneration, directory: currentDirectory,
+  });
+  return { entries, status, error, scoped, run, invalidate };
+}
+
+function sameScope(left: ListingScope, right: ListingScope): boolean {
+  return left.api === right.api
+    && left.runtimeSlot === right.runtimeSlot
+    && left.authGeneration === right.authGeneration
+    && left.directory === right.directory;
+}

--- a/desktop/src/renderer/src/features/files/use-authoritative-listing.ts
+++ b/desktop/src/renderer/src/features/files/use-authoritative-listing.ts
@@ -13,6 +13,11 @@ interface ListingScope {
   directory: string;
 }
 
+interface AuthoritativeSnapshot {
+  scope: ListingScope;
+  entries: BrowserEntry[];
+}
+
 export function useAuthoritativeListing(options: ListingScope) {
   const { api, runtimeSlot, authGeneration, directory: currentDirectory } = options;
   const [entries, setEntries] = useState<BrowserEntry[]>([]);
@@ -24,6 +29,7 @@ export function useAuthoritativeListing(options: ListingScope) {
   const committedScopeRef = useRef<ListingScope>({
     api, runtimeSlot, authGeneration, directory: currentDirectory,
   });
+  const authoritativeSnapshotRef = useRef<AuthoritativeSnapshot | null>(null);
   const requestGeneration = useRef(0);
 
   useLayoutEffect(() => {
@@ -54,6 +60,7 @@ export function useAuthoritativeListing(options: ListingScope) {
         && connection.api === requestScope.api
         && connection.runtimeSlot === requestScope.runtimeSlot
         && connection.authGeneration === requestScope.authGeneration) {
+        authoritativeSnapshotRef.current = { scope: requestScope, entries: next };
         setEntries(next);
         setLoadedScope(requestScope);
         setStatus("ready");
@@ -61,12 +68,24 @@ export function useAuthoritativeListing(options: ListingScope) {
       }
       return next;
     } catch (caught: unknown) {
-      if (surfaceStatus && generation === requestGeneration.current
-        && sameScope(committedScopeRef.current, requestScope)) {
-        setEntries([]);
-        setLoadedScope(requestScope);
-        setStatus("error");
-        setError(toUserMessage(caught));
+      const connection = useConnection.getState();
+      if (generation === requestGeneration.current
+        && sameScope(committedScopeRef.current, requestScope)
+        && connection.api === requestScope.api
+        && connection.runtimeSlot === requestScope.runtimeSlot
+        && connection.authGeneration === requestScope.authGeneration) {
+        const snapshot = authoritativeSnapshotRef.current;
+        if (snapshot && sameScope(snapshot.scope, requestScope)) {
+          setEntries(snapshot.entries);
+          setLoadedScope(snapshot.scope);
+          setStatus("ready");
+          setError(null);
+        } else {
+          setEntries([]);
+          setLoadedScope(requestScope);
+          setStatus("error");
+          setError(toUserMessage(caught));
+        }
       }
       throw caught;
     }

--- a/desktop/src/renderer/src/features/files/use-file-management.ts
+++ b/desktop/src/renderer/src/features/files/use-file-management.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ApiClient } from "../../lib/api";
 import { useConnection } from "../../stores/connection";
 import type { BrowserEntry } from "./browser-entries";
@@ -37,7 +37,10 @@ export function useFileManagement(options: {
   authGeneration: number;
   socket: DirectorySyncSocket | null;
   onFocusedPathChange?(path: string | null): void;
-  onAuthoritativeEntries(entries: BrowserEntry[]): void;
+  loadAuthoritativeDirectory(
+    directory: string,
+    fetchEntries: () => Promise<BrowserEntry[]>,
+  ): Promise<BrowserEntry[]>;
 }) {
   const [draft, setDraft] = useState<FileNameDraft | null>(null);
   const [draftSubmitting, setDraftSubmitting] = useState(false);
@@ -58,18 +61,20 @@ export function useFileManagement(options: {
     runtimeSlot: options.runtimeSlot,
     authGeneration: options.authGeneration,
   });
-  const onEntriesRef = useRef(options.onAuthoritativeEntries);
   const onFocusRef = useRef(options.onFocusedPathChange);
   const selectionRef = useRef(storedSelection);
   const nextSubmissionRef = useRef(0);
   const activeSubmissionRef = useRef<number | null>(null);
-  scopeRef.current = {
-    directory: options.directory,
-    runtimeSlot: options.runtimeSlot,
-    authGeneration: options.authGeneration,
-  };
-  onEntriesRef.current = options.onAuthoritativeEntries;
-  onFocusRef.current = options.onFocusedPathChange;
+  useLayoutEffect(() => {
+    scopeRef.current = {
+      directory: options.directory,
+      runtimeSlot: options.runtimeSlot,
+      authGeneration: options.authGeneration,
+    };
+  }, [options.directory, options.runtimeSlot, options.authGeneration]);
+  useLayoutEffect(() => {
+    onFocusRef.current = options.onFocusedPathChange;
+  }, [options.onFocusedPathChange]);
 
   const managementApi = useMemo(
     () => options.api ? createFileManagementApi(options.api) : null,
@@ -92,17 +97,13 @@ export function useFileManagement(options: {
         && connection.authGeneration === scope.authGeneration;
     },
     loadDirectory: async (directory, operationScope) => {
-      const entries = await fetchEntries(directory);
-      const connection = useConnection.getState();
-      if (sameScope(scopeRef.current, operationScope)
-        && connection.api === options.api
-        && connection.runtimeSlot === operationScope.runtimeSlot
-        && connection.authGeneration === operationScope.authGeneration) {
-        onEntriesRef.current(entries);
-      }
+      const entries = await options.loadAuthoritativeDirectory(
+        directory,
+        () => fetchEntries(directory),
+      );
       return entries.map((entry) => directory ? `${directory}/${entry.name}` : entry.name);
     },
-  }), [managementApi, options.api, options.runtimeSlot, options.authGeneration, fetchEntries]);
+  }), [managementApi, options.api, options.runtimeSlot, options.authGeneration, options.loadAuthoritativeDirectory, fetchEntries]);
   const [snapshot, setSnapshot] = useState<FileOperationSnapshot>(controller.snapshot);
 
   useEffect(() => {
@@ -129,10 +130,10 @@ export function useFileManagement(options: {
     onFocusRef.current?.(null);
   }, [controller, options.directory, options.runtimeSlot, options.authGeneration]);
 
-  const loadSyncEntries = useCallback((directory: string) => fetchEntries(directory), [fetchEntries]);
-  const applySyncEntries = useCallback((entries: BrowserEntry[]) => {
-    onEntriesRef.current(entries);
-  }, []);
+  const loadSyncEntries = useCallback((directory: string) =>
+    options.loadAuthoritativeDirectory(directory, () => fetchEntries(directory)),
+  [fetchEntries, options.loadAuthoritativeDirectory]);
+  const applySyncEntries = useCallback(() => {}, []);
   useDirectorySync({
     socket: options.socket ?? NO_DIRECTORY_SOCKET,
     directory: options.directory,
@@ -177,7 +178,8 @@ export function useFileManagement(options: {
       const outcome = draft.mode === "create"
         ? await controller.create({ parentDirectory: options.directory, name: draft.name, kind: draft.kind })
         : await controller.rename({ path: draft.path, name: draft.name });
-      if (outcome.status === "completed" || outcome.succeededPaths.includes(expectedPath)) {
+      const reconciledIdentity = draft.mode === "rename" ? draft.path : expectedPath;
+      if (outcome.status === "completed" || outcome.succeededPaths.includes(reconciledIdentity)) {
         setDraft(null);
         setDraftError(null);
         return;
@@ -251,6 +253,7 @@ export function useFileManagement(options: {
     };
     selectionRef.current = nextSelection;
     setStoredSelection(nextSelection);
+    onFocusRef.current?.(nextSelection.focusedPath);
   }, [controller, trashPaths]);
 
   return {

--- a/desktop/src/renderer/src/features/files/use-file-management.ts
+++ b/desktop/src/renderer/src/features/files/use-file-management.ts
@@ -10,6 +10,7 @@ import {
 } from "./file-operation-controller";
 import {
   createFileSelection,
+  MAX_FILE_BATCH_SIZE,
   MAX_FILE_SELECTION,
   reconcileFileSelection,
   resetFileSelectionScope,
@@ -25,6 +26,7 @@ export type FileNameDraft =
   | { mode: "rename"; path: string; name: string };
 
 const INVALID_NAME_NOTICE = "Choose a valid portable name.";
+const BATCH_SELECTION_NOTICE = `Batch actions support up to ${MAX_FILE_BATCH_SIZE} selected items.`;
 const NO_DIRECTORY_SOCKET: DirectorySyncSocket = {
   subscribeDirectory: () => () => {},
   touchDirectory: () => false,
@@ -47,6 +49,11 @@ export function useFileManagement(options: {
   const [draftError, setDraftError] = useState<string | null>(null);
   const [localNotice, setLocalNotice] = useState<string | null>(null);
   const [trashPaths, setTrashPaths] = useState<string[]>([]);
+  const syncBatchSelectionNotice = useCallback((selectedCount: number) => {
+    setLocalNotice((notice) => selectedCount > MAX_FILE_BATCH_SIZE
+      ? BATCH_SELECTION_NOTICE
+      : notice === BATCH_SELECTION_NOTICE ? null : notice);
+  }, []);
   const selectionScope = {
     directory: options.directory,
     runtimeSlot: options.runtimeSlot,
@@ -216,21 +223,23 @@ export function useFileManagement(options: {
       modifiers,
       platform,
     );
+    syncBatchSelectionNotice(next.selectedPaths.length);
     selectionRef.current = next;
     setStoredSelection(next);
-  }, []);
+  }, [syncBatchSelectionNotice]);
 
   const reconcilePaths = useCallback((renderedPaths: readonly string[]) => {
     const current = resetFileSelectionScope(selectionRef.current, scopeRef.current);
     const next = reconcileFileSelection(current, scopeRef.current, renderedPaths);
     selectionRef.current = next;
+    syncBatchSelectionNotice(next.selectedPaths.length);
     if (current.focusedPath && !renderedPaths.includes(current.focusedPath)) onFocusRef.current?.(null);
     if (!sameSelection(current, next)) setStoredSelection(next);
-  }, []);
+  }, [syncBatchSelectionNotice]);
 
   const requestTrash = useCallback((paths: readonly string[]) => {
-    if (paths.length < 1 || paths.length > 100) {
-      setLocalNotice("Select between 1 and 100 items to move to Trash.");
+    if (paths.length < 1 || paths.length > MAX_FILE_BATCH_SIZE) {
+      setLocalNotice(`Select between 1 and ${MAX_FILE_BATCH_SIZE} items to move to Trash.`);
       return;
     }
     setLocalNotice(null);
@@ -252,9 +261,10 @@ export function useFileManagement(options: {
       focusedPath: outcome.retainedPaths[0] ?? null,
     };
     selectionRef.current = nextSelection;
+    syncBatchSelectionNotice(nextSelection.selectedPaths.length);
     setStoredSelection(nextSelection);
     onFocusRef.current?.(nextSelection.focusedPath);
-  }, [controller, trashPaths]);
+  }, [controller, syncBatchSelectionNotice, trashPaths]);
 
   return {
     draft, draftError, draftSubmitting, localNotice, snapshot, selection, trashPaths,

--- a/desktop/src/renderer/src/features/files/use-file-management.ts
+++ b/desktop/src/renderer/src/features/files/use-file-management.ts
@@ -1,0 +1,283 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ApiClient } from "../../lib/api";
+import { useConnection } from "../../stores/connection";
+import type { BrowserEntry } from "./browser-entries";
+import { createFileManagementApi } from "./file-management-api";
+import { FileMutationNameSchema } from "./file-management-contracts";
+import {
+  createFileOperationController,
+  type FileOperationSnapshot,
+} from "./file-operation-controller";
+import {
+  createFileSelection,
+  MAX_FILE_SELECTION,
+  reconcileFileSelection,
+  resetFileSelectionScope,
+  updateFileSelection,
+  type FileSelectionModifiers,
+  type FileSelectionPlatform,
+  type FileSelectionState,
+} from "./file-selection";
+import { useDirectorySync, type DirectorySyncSocket } from "./use-directory-sync";
+
+export type FileNameDraft =
+  | { mode: "create"; kind: "file" | "directory"; name: string }
+  | { mode: "rename"; path: string; name: string };
+
+const INVALID_NAME_NOTICE = "Choose a valid portable name.";
+const NO_DIRECTORY_SOCKET: DirectorySyncSocket = {
+  subscribeDirectory: () => () => {},
+  touchDirectory: () => false,
+};
+
+export function useFileManagement(options: {
+  api: ApiClient | null;
+  directory: string;
+  runtimeSlot: string;
+  authGeneration: number;
+  socket: DirectorySyncSocket | null;
+  onFocusedPathChange?(path: string | null): void;
+  onAuthoritativeEntries(entries: BrowserEntry[]): void;
+}) {
+  const [draft, setDraft] = useState<FileNameDraft | null>(null);
+  const [draftSubmitting, setDraftSubmitting] = useState(false);
+  const [draftError, setDraftError] = useState<string | null>(null);
+  const [localNotice, setLocalNotice] = useState<string | null>(null);
+  const [trashPaths, setTrashPaths] = useState<string[]>([]);
+  const selectionScope = {
+    directory: options.directory,
+    runtimeSlot: options.runtimeSlot,
+    authGeneration: options.authGeneration,
+  };
+  const [storedSelection, setStoredSelection] = useState<FileSelectionState>(
+    () => createFileSelection(selectionScope),
+  );
+  const selection = resetFileSelectionScope(storedSelection, selectionScope);
+  const scopeRef = useRef({
+    directory: options.directory,
+    runtimeSlot: options.runtimeSlot,
+    authGeneration: options.authGeneration,
+  });
+  const onEntriesRef = useRef(options.onAuthoritativeEntries);
+  const onFocusRef = useRef(options.onFocusedPathChange);
+  const selectionRef = useRef(storedSelection);
+  const nextSubmissionRef = useRef(0);
+  const activeSubmissionRef = useRef<number | null>(null);
+  scopeRef.current = {
+    directory: options.directory,
+    runtimeSlot: options.runtimeSlot,
+    authGeneration: options.authGeneration,
+  };
+  onEntriesRef.current = options.onAuthoritativeEntries;
+  onFocusRef.current = options.onFocusedPathChange;
+
+  const managementApi = useMemo(
+    () => options.api ? createFileManagementApi(options.api) : null,
+    [options.api],
+  );
+  const fetchEntries = useCallback(async (directory: string) => {
+    if (!managementApi) return [];
+    return (await managementApi.list(directory)).entries;
+  }, [managementApi]);
+  const controller = useMemo(() => createFileOperationController({
+    getApi: () => managementApi,
+    createRequestId: () => globalThis.crypto.randomUUID(),
+    getScope: () => scopeRef.current,
+    isScopeCurrent: (scope) => {
+      const connection = useConnection.getState();
+      const current = scopeRef.current;
+      return connection.api === options.api
+        && current.directory === scope.directory
+        && connection.runtimeSlot === scope.runtimeSlot
+        && connection.authGeneration === scope.authGeneration;
+    },
+    loadDirectory: async (directory, operationScope) => {
+      const entries = await fetchEntries(directory);
+      const connection = useConnection.getState();
+      if (sameScope(scopeRef.current, operationScope)
+        && connection.api === options.api
+        && connection.runtimeSlot === operationScope.runtimeSlot
+        && connection.authGeneration === operationScope.authGeneration) {
+        onEntriesRef.current(entries);
+      }
+      return entries.map((entry) => directory ? `${directory}/${entry.name}` : entry.name);
+    },
+  }), [managementApi, options.api, options.runtimeSlot, options.authGeneration, fetchEntries]);
+  const [snapshot, setSnapshot] = useState<FileOperationSnapshot>(controller.snapshot);
+
+  useEffect(() => {
+    setSnapshot(controller.snapshot);
+    const unsubscribe = controller.subscribe(setSnapshot);
+    return () => {
+      unsubscribe();
+      controller.close();
+    };
+  }, [controller]);
+
+  useEffect(() => {
+    controller.syncScope();
+    setSnapshot(controller.snapshot);
+    setDraft(null);
+    activeSubmissionRef.current = null;
+    setDraftSubmitting(false);
+    setDraftError(null);
+    setLocalNotice(null);
+    setTrashPaths([]);
+    const nextSelection = resetFileSelectionScope(selectionRef.current, scopeRef.current);
+    selectionRef.current = nextSelection;
+    setStoredSelection(nextSelection);
+    onFocusRef.current?.(null);
+  }, [controller, options.directory, options.runtimeSlot, options.authGeneration]);
+
+  const loadSyncEntries = useCallback((directory: string) => fetchEntries(directory), [fetchEntries]);
+  const applySyncEntries = useCallback((entries: BrowserEntry[]) => {
+    onEntriesRef.current(entries);
+  }, []);
+  useDirectorySync({
+    socket: options.socket ?? NO_DIRECTORY_SOCKET,
+    directory: options.directory,
+    runtimeSlot: options.runtimeSlot,
+    authGeneration: options.authGeneration,
+    loadDirectory: loadSyncEntries,
+    onReconciled: applySyncEntries,
+  });
+
+  const startCreate = useCallback((kind: "file" | "directory") => {
+    setDraft({ mode: "create", kind, name: "" });
+    setDraftError(null);
+  }, []);
+
+  const updateDraftName = useCallback((name: string) => {
+    setDraft((current) => current ? { ...current, name } : null);
+  }, []);
+
+  const startRename = useCallback((path: string, name: string) => {
+    setDraft({ mode: "rename", path, name });
+    setDraftError(null);
+  }, []);
+
+  const cancelDraft = useCallback(() => {
+    setDraft(null);
+    setDraftError(null);
+  }, []);
+
+  const submitDraft = useCallback(async () => {
+    if (!draft || activeSubmissionRef.current !== null) return;
+    if (!FileMutationNameSchema.safeParse(draft.name).success) {
+      setDraftError(INVALID_NAME_NOTICE);
+      return;
+    }
+    const submission = ++nextSubmissionRef.current;
+    activeSubmissionRef.current = submission;
+    setDraftSubmitting(true);
+    const expectedPath = draft.mode === "create"
+      ? joinPath(options.directory, draft.name)
+      : joinPath(parentDirectory(draft.path), draft.name);
+    try {
+      const outcome = draft.mode === "create"
+        ? await controller.create({ parentDirectory: options.directory, name: draft.name, kind: draft.kind })
+        : await controller.rename({ path: draft.path, name: draft.name });
+      if (outcome.status === "completed" || outcome.succeededPaths.includes(expectedPath)) {
+        setDraft(null);
+        setDraftError(null);
+        return;
+      }
+      if (outcome.failures.some((failure) => failure.code === "destination_conflict")) {
+        setDraftError("An item with that name already exists.");
+      }
+    } finally {
+      if (activeSubmissionRef.current === submission) {
+        activeSubmissionRef.current = null;
+        setDraftSubmitting(false);
+      }
+    }
+  }, [controller, draft, options.directory]);
+
+  const selectPath = useCallback((
+    renderedPaths: readonly string[],
+    path: string,
+    modifiers: FileSelectionModifiers,
+    platform: FileSelectionPlatform,
+  ) => {
+    const current = resetFileSelectionScope(selectionRef.current, scopeRef.current);
+    const anchorIndex = current.anchorPath ? renderedPaths.indexOf(current.anchorPath) : -1;
+    const clickedIndex = renderedPaths.indexOf(path);
+    const additive = platform === "mac" ? modifiers.metaKey : modifiers.ctrlKey;
+    const overLimit = (modifiers.shiftKey && anchorIndex >= 0 && clickedIndex >= 0
+      && Math.abs(anchorIndex - clickedIndex) + 1 > MAX_FILE_SELECTION)
+      || (additive && !current.selectedPaths.includes(path) && current.selectedPaths.length >= MAX_FILE_SELECTION);
+    if (overLimit) setLocalNotice(`Select up to ${MAX_FILE_SELECTION} items at a time.`);
+    const next = updateFileSelection(
+      current,
+      renderedPaths,
+      path,
+      modifiers,
+      platform,
+    );
+    selectionRef.current = next;
+    setStoredSelection(next);
+  }, []);
+
+  const reconcilePaths = useCallback((renderedPaths: readonly string[]) => {
+    const current = resetFileSelectionScope(selectionRef.current, scopeRef.current);
+    const next = reconcileFileSelection(current, scopeRef.current, renderedPaths);
+    selectionRef.current = next;
+    if (current.focusedPath && !renderedPaths.includes(current.focusedPath)) onFocusRef.current?.(null);
+    if (!sameSelection(current, next)) setStoredSelection(next);
+  }, []);
+
+  const requestTrash = useCallback((paths: readonly string[]) => {
+    if (paths.length < 1 || paths.length > 100) {
+      setLocalNotice("Select between 1 and 100 items to move to Trash.");
+      return;
+    }
+    setLocalNotice(null);
+    setTrashPaths([...paths]);
+  }, []);
+
+  const cancelTrash = useCallback(() => setTrashPaths([]), []);
+
+  const confirmTrash = useCallback(async () => {
+    const paths = [...trashPaths];
+    if (paths.length < 1) return;
+    setTrashPaths([]);
+    const outcome = await controller.trash({ sources: paths });
+    if (outcome.status === "stale") return;
+    const nextSelection: FileSelectionState = {
+      scope: { ...scopeRef.current },
+      selectedPaths: [...outcome.retainedPaths],
+      anchorPath: outcome.retainedPaths[0] ?? null,
+      focusedPath: outcome.retainedPaths[0] ?? null,
+    };
+    selectionRef.current = nextSelection;
+    setStoredSelection(nextSelection);
+  }, [controller, trashPaths]);
+
+  return {
+    draft, draftError, draftSubmitting, localNotice, snapshot, selection, trashPaths,
+    startCreate, startRename, updateDraftName, cancelDraft, submitDraft, selectPath,
+    reconcilePaths, requestTrash, cancelTrash, confirmTrash,
+  };
+}
+
+function sameSelection(left: FileSelectionState, right: FileSelectionState): boolean {
+  return left.anchorPath === right.anchorPath
+    && left.focusedPath === right.focusedPath
+    && left.selectedPaths.length === right.selectedPaths.length
+    && left.selectedPaths.every((path, index) => path === right.selectedPaths[index]);
+}
+
+function sameScope(left: FileSelectionState["scope"], right: FileSelectionState["scope"]): boolean {
+  return left.directory === right.directory
+    && left.runtimeSlot === right.runtimeSlot
+    && left.authGeneration === right.authGeneration;
+}
+
+function joinPath(parent: string, name: string): string {
+  return parent ? `${parent}/${name}` : name;
+}
+
+function parentDirectory(path: string): string {
+  const separator = path.lastIndexOf("/");
+  return separator < 0 ? "" : path.slice(0, separator);
+}

--- a/specs/268-desktop-file-management/file-actions-layout-design.md
+++ b/specs/268-desktop-file-management/file-actions-layout-design.md
@@ -1,0 +1,57 @@
+# Files List Action Layout Design
+
+## Problem
+
+In Desktop Files list view, the per-entry `More actions` button is absolutely
+positioned at the row's right edge. The row grid currently ends with the
+`Modified` column, so the button and the timestamp compete for the same pixels.
+This makes the timestamp difficult to read and makes the action target feel
+detached from the list structure.
+
+## Approved Design
+
+List view reserves a dedicated 32 px action column after `Modified`. The header
+and every entry use the same four-column template: flexible name, fixed size,
+fixed modified timestamp, and fixed actions. Grid view keeps its existing
+top-right overlay because it has no tabular metadata columns.
+
+The action button is visually quiet by default. It becomes fully visible when
+the row is hovered, keyboard-focused, or selected. Its accessible name and
+keyboard reachability remain unchanged, so hiding it visually must not remove
+it from the accessibility tree.
+
+## Alternatives Considered
+
+1. Hide `Modified` while hovering the row. Rejected because metadata should not
+   move or disappear when the user approaches an action.
+2. Add right padding only. Rejected because the header and row would still have
+   different alignment models, and narrow layouts could regress again.
+3. Reserve a real action column. Selected because it gives the table one stable
+   layout contract and works in compact and regular widths.
+
+## Components and Data Flow
+
+- `browser-views.tsx` defines the compact and regular four-column templates;
+  `ComputerFileBrowser` selects the template for its compact state.
+- `BrowserListing` renders an empty action header cell after `Modified`.
+- `EntryButton` renders a matching empty action cell after the timestamp.
+- `ManagedFileActionMenu` receives whether its entry is selected and forwards
+  that visual state to `FileActionMenu`.
+- `FileActionMenu` controls only button visibility; menu commands, capability
+  gates, selection behavior, and right-click behavior do not change.
+
+## Error and Boundary Behavior
+
+There is no new network or filesystem behavior. Pending rows remain disabled.
+Compact list view still truncates name/metadata within their own columns; the
+action column never shrinks below 32 px. Grid view is unchanged except for the
+same hover/focus/selected visibility treatment.
+
+## Verification
+
+- A failing rendered regression first proves the current list template has no
+  action column and the button lacks the approved visibility states.
+- The focused Desktop Files suites verify list/grid actions, keyboard focus,
+  selection, pending disablement, and menu behavior.
+- Desktop TypeScript, pattern checks, React Doctor, and production build remain
+  required before the stacked PR is handed off.

--- a/specs/268-desktop-file-management/file-actions-layout-plan.md
+++ b/specs/268-desktop-file-management/file-actions-layout-plan.md
@@ -1,0 +1,117 @@
+# Files List Action Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent the Desktop Files list `More actions` button from overlapping the `Modified` value while preserving grid behavior and accessibility.
+
+**Architecture:** Extend the existing shared list grid template with a fixed 32 px action column, then give the action button explicit hover, focus, and selected visibility states. Keep all operation/controller behavior unchanged.
+
+**Tech Stack:** React 19, TypeScript strict mode, Tailwind utility classes, Radix Dropdown Menu, Vitest, React Testing Library.
+
+## Global Constraints
+
+- Use the existing Desktop Files components; add no dependency.
+- Preserve accessible button names, keyboard focus, context menus, and disabled behavior.
+- List view must use the same four-column template for header and rows.
+- Grid view must keep its existing top-right action placement.
+- Focused production and test files must remain below 500 lines.
+
+---
+
+### Task 1: Lock the list action-column contract
+
+**Files:**
+- Test: `tests/desktop/files-actions-layout.test.tsx`
+- Modify: `desktop/src/renderer/src/features/files/browser-views.tsx`
+- Modify: `desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx`
+
+**Interfaces:**
+- Consumes: `ComputerFileBrowser` public rendered UI and `EntryButton` list layout.
+- Produces: one four-column `listColumns` string used by list header and rows.
+
+- [ ] **Step 1: Write the failing rendered test**
+
+Render Files in list mode and assert that the list header and the `Open note.md`
+row both expose a fourth 32 px action track after `Modified`.
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run: `flox activate -- pnpm exec vitest run tests/desktop/files-actions-layout.test.tsx`
+
+Expected: FAIL because the current template has only name, size, and modified tracks.
+
+- [ ] **Step 3: Implement the action track**
+
+Change the compact template to `minmax(0,1fr) 64px 88px 32px` and the regular
+template to `minmax(0,1fr) 72px 104px 32px`. Add one inert final cell to both
+the header and list entry grid.
+
+- [ ] **Step 4: Run the focused test to verify GREEN**
+
+Run: `flox activate -- pnpm exec vitest run tests/desktop/files-actions-layout.test.tsx`
+
+Expected: PASS.
+
+### Task 2: Add quiet but accessible action visibility
+
+**Files:**
+- Test: `tests/desktop/files-actions-layout.test.tsx`
+- Modify: `desktop/src/renderer/src/features/files/FileActionMenu.tsx`
+- Modify: `desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx`
+
+**Interfaces:**
+- Consumes: current entry selection from `useFileManagement`.
+- Produces: `selected: boolean` on `ManagedFileActionMenu` and `FileActionMenu`.
+
+- [ ] **Step 1: Write the failing visibility test**
+
+Assert that an unselected action button is visually quiet, and that the class
+contract includes hover and focus-within reveal states. Select the row and
+assert its action button becomes fully visible without losing its accessible
+name or focusability.
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run: `flox activate -- pnpm exec vitest run tests/desktop/files-actions-layout.test.tsx`
+
+Expected: FAIL because the current button is always `opacity-70` and has no selected state.
+
+- [ ] **Step 3: Implement the visibility contract**
+
+Forward the row's selected boolean through `ManagedFileActionMenu` to
+`FileActionMenu`. Use `opacity-0 group-hover:opacity-100 group-focus-within:opacity-100`
+for inactive rows and `opacity-100` for selected rows; retain focus and pointer handlers.
+
+- [ ] **Step 4: Run the focused test to verify GREEN**
+
+Run: `flox activate -- pnpm exec vitest run tests/desktop/files-actions-layout.test.tsx`
+
+Expected: PASS.
+
+### Task 3: Verify the Desktop Files surface
+
+**Files:**
+- Verify only: Desktop Files production/tests changed by Tasks 1–2.
+
+**Interfaces:**
+- Consumes: Tasks 1–2.
+- Produces: fresh evidence for the UI-layer stacked PR.
+
+- [ ] **Step 1: Run focused regressions**
+
+Run the new layout test plus `files-browser-views`, `files-management-ui`,
+`files-management-concurrency`, `files-workspace`, and `file-selection` suites.
+
+- [ ] **Step 2: Run Desktop typecheck and React Doctor**
+
+Run the repository's Desktop TypeScript command and changed-scope React Doctor.
+
+- [ ] **Step 3: Run pattern, whitespace, and LOC gates**
+
+Require zero new pattern violations, `git diff --check` success, and every
+focused production/test file below 500 lines.
+
+- [ ] **Step 4: Commit the verified change**
+
+Create a Conventional Commit on `codex/mat-268-desktop-files-ui`, then propagate
+the new commit through the remaining stacked Desktop move/drag PR without merge.

--- a/tests/desktop/files-actions-layout.test.tsx
+++ b/tests/desktop/files-actions-layout.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FileActionMenu } from "../../desktop/src/renderer/src/features/files/FileActionMenu";
+import {
+  BrowserListing,
+  EntryButton,
+  getFileListColumns,
+} from "../../desktop/src/renderer/src/features/files/browser-views";
+
+const entry = {
+  name: "note.md",
+  type: "file" as const,
+  sizeBytes: 12,
+  modifiedAt: "2026-08-12T07:00:00.000Z",
+  capabilities: { canRename: true, canMove: true, canTrash: true },
+};
+
+describe("Files list action layout", () => {
+  it("reserves a fixed action column after Modified in regular and compact lists", () => {
+    expect(getFileListColumns(false)).toBe("minmax(0,1fr) 72px 104px 32px");
+    expect(getFileListColumns(true)).toBe("minmax(0,1fr) 64px 88px 32px");
+
+    const columns = getFileListColumns(false);
+    render(
+      <BrowserListing
+        grid={false}
+        gridRef={{ current: null }}
+        listColumns={columns}
+        draftRow={null}
+        buttons={(
+          <EntryButton
+            entry={entry}
+            grid={false}
+            listColumns={columns}
+            selected={false}
+            pressed={false}
+            buttonRef={() => {}}
+            onSelect={() => {}}
+            onNavigate={() => {}}
+            onKeyDown={() => {}}
+          />
+        )}
+        sortKey="name"
+        sortDirection="asc"
+        onSort={() => {}}
+      />,
+    );
+
+    const modifiedHeader = screen.getByRole("button", { name: "Sort by modified" });
+    const header = modifiedHeader.parentElement;
+    const row = screen.getByRole("button", { name: "Open note.md" });
+    expect(header?.style.gridTemplateColumns).toBe(columns);
+    expect(row.style.gridTemplateColumns).toBe(columns);
+    expect(header?.lastElementChild?.getAttribute("aria-hidden")).toBe("true");
+    expect(row.lastElementChild?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("reveals the accessible action button on hover, focus-within, or selection", () => {
+    const onMenuOpen = vi.fn();
+    const view = render(
+      <Tooltip.Provider>
+        <FileActionMenu label="note.md" items={[]} selected={false} onMenuOpen={onMenuOpen}>
+          <button type="button">Open note.md</button>
+        </FileActionMenu>
+      </Tooltip.Provider>,
+    );
+
+    const action = screen.getByRole("button", { name: "More actions for note.md" });
+    expect(action.className).toContain("opacity-0");
+    expect(action.className).toContain("group-hover:opacity-100");
+    expect(action.className).toContain("group-focus-within:opacity-100");
+    expect(action.getAttribute("tabindex")).not.toBe("-1");
+
+    view.rerender(
+      <Tooltip.Provider>
+        <FileActionMenu label="note.md" items={[]} selected onMenuOpen={onMenuOpen}>
+          <button type="button">Open note.md</button>
+        </FileActionMenu>
+      </Tooltip.Provider>,
+    );
+    expect(screen.getByRole("button", { name: "More actions for note.md" }).className).toContain("opacity-100");
+  });
+});

--- a/tests/desktop/files-browser-views.test.tsx
+++ b/tests/desktop/files-browser-views.test.tsx
@@ -399,4 +399,45 @@ describe("ComputerFileBrowser view options", () => {
     fireEvent.click(screen.getByRole("button", { name: "Grid view" }));
     expect(screen.getByText("This folder is empty.")).toBeTruthy();
   });
+
+  it("synchronously hides rows and management actions when the API is absent or replaced", async () => {
+    renderBrowser();
+    await screen.findByRole("button", { name: "Open README.md" });
+
+    act(() => useConnection.setState({ api: null }));
+    expect(screen.queryByRole("button", { name: "Open README.md" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "New File" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "More actions for README.md" })).toBeNull();
+
+    let resolveReplacement!: (value: { entries: typeof ROOT_ENTRIES }) => void;
+    const replacement = {
+      baseUrl: "https://app.matrix-os.com",
+      get: vi.fn(() => new Promise<{ entries: typeof ROOT_ENTRIES }>((resolve) => {
+        resolveReplacement = resolve;
+      })),
+    };
+    act(() => useConnection.setState({ api: replacement as never }));
+    expect(screen.queryByRole("button", { name: "Open README.md" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "New Folder" })).toBeNull();
+
+    await act(async () => resolveReplacement({ entries: ROOT_ENTRIES }));
+    expect(await screen.findByRole("button", { name: "Open README.md" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "New File" })).not.toBeNull();
+  });
+
+  it("shows a safe error when a replacement API cannot load its first listing", async () => {
+    renderBrowser();
+    await screen.findByRole("button", { name: "Open README.md" });
+    const replacement = {
+      baseUrl: "https://app.matrix-os.com",
+      get: vi.fn(async () => { throw new Error("provider failed at /home/operator"); }),
+    };
+
+    act(() => useConnection.setState({ api: replacement as never }));
+
+    expect(screen.queryByRole("button", { name: "Open README.md" })).toBeNull();
+    expect(await screen.findByText("Something went wrong. Please try again.")).not.toBeNull();
+    expect(screen.queryByText(/provider|\/home|operator/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: "New File" })).toBeNull();
+  });
 });

--- a/tests/desktop/files-browser-views.test.tsx
+++ b/tests/desktop/files-browser-views.test.tsx
@@ -370,6 +370,8 @@ describe("ComputerFileBrowser view options", () => {
 
     // Files never appear as pick targets.
     expect(screen.queryByRole("button", { name: "Open README.md" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "New File" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "New Folder" })).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Open assets" }));
     expect(

--- a/tests/desktop/files-management-concurrency.test.tsx
+++ b/tests/desktop/files-management-concurrency.test.tsx
@@ -69,6 +69,40 @@ describe("Files listing publication ordering", () => {
     expect(screen.getByRole("button", { name: "Open socket-new.md" })).not.toBeNull();
   });
 
+  it("settles a held Refresh when the newer socket reconciliation fails", async () => {
+    let resolveRefresh!: (value: Listing) => void;
+    const api = {
+      baseUrl: "https://app.matrix-os.com",
+      get: vi.fn()
+        .mockResolvedValueOnce(listing("initial.md"))
+        .mockImplementationOnce(() => new Promise<Listing>((resolve) => { resolveRefresh = resolve; }))
+        .mockRejectedValueOnce(new Error("provider failed at /home/operator")),
+      post: vi.fn(),
+    };
+    const socket = new FakeDirectorySocket();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    useConnection.setState({
+      status: "signed-in",
+      runtimeSlot: "primary",
+      authGeneration: 1,
+      api: api as never,
+    });
+    render(<Tooltip.Provider><ComputerFileBrowser directorySocket={socket} /></Tooltip.Provider>);
+    await screen.findByRole("button", { name: "Open initial.md" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh folder" }));
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(2));
+    expect(screen.getByText("Loading folder…")).not.toBeNull();
+    act(() => socket.emit({ type: "files:subscribed", directory: "", revision: 2 }));
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(3));
+
+    await act(async () => resolveRefresh(listing("refresh-old.md")));
+    expect(screen.queryByText("Loading folder…")).toBeNull();
+    expect(screen.getByRole("button", { name: "Open initial.md" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Open refresh-old.md" })).toBeNull();
+    expect(warn.mock.calls.flat().join(" ")).not.toMatch(/provider|\/home\/operator/);
+  });
+
   it("forgets an authoritatively successful uncertain rename even if the old path returns later", async () => {
     let current = listing("note.md");
     const api = {

--- a/tests/desktop/files-management-concurrency.test.tsx
+++ b/tests/desktop/files-management-concurrency.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+
+import React, { startTransition } from "react";
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ComputerFileBrowser from "@desktop/renderer/src/features/files/ComputerFileBrowser";
+import { useBrowserViewPreference } from "@desktop/renderer/src/features/files/browser-view-preference";
+import type { FileDirectoryServerMessage } from "@desktop/renderer/src/lib/kernel-socket";
+import { AppError } from "@desktop/renderer/src/lib/errors";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+
+const CAPABILITIES = { canRename: true, canMove: true, canTrash: true };
+type Listing = { path: string; entries: Array<{ name: string; type: "file"; capabilities: typeof CAPABILITIES }> };
+
+class FakeDirectorySocket {
+  private handlers: Array<(message: FileDirectoryServerMessage) => void> = [];
+  subscribeDirectory = vi.fn((_directory: string, handler: (message: FileDirectoryServerMessage) => void) => {
+    this.handlers.push(handler);
+    return () => { this.handlers = this.handlers.filter((candidate) => candidate !== handler); };
+  });
+  touchDirectory = vi.fn(() => true);
+  emit(message: FileDirectoryServerMessage) {
+    for (const handler of this.handlers) handler(message);
+  }
+}
+
+function listing(name: string): Listing {
+  return { path: "", entries: [{ name, type: "file", capabilities: CAPABILITIES }] };
+}
+
+describe("Files listing publication ordering", () => {
+  beforeEach(() => {
+    useBrowserViewPreference.setState({ view: "list" });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("does not let an older held Refresh overwrite a newer socket reconciliation", async () => {
+    let resolveRefresh!: (value: Listing) => void;
+    const api = {
+      baseUrl: "https://app.matrix-os.com",
+      get: vi.fn()
+        .mockResolvedValueOnce(listing("initial.md"))
+        .mockImplementationOnce(() => new Promise<Listing>((resolve) => { resolveRefresh = resolve; }))
+        .mockResolvedValueOnce(listing("socket-new.md")),
+      post: vi.fn(),
+    };
+    const socket = new FakeDirectorySocket();
+    useConnection.setState({
+      status: "signed-in",
+      runtimeSlot: "primary",
+      authGeneration: 1,
+      api: api as never,
+    });
+    render(<Tooltip.Provider><ComputerFileBrowser directorySocket={socket} /></Tooltip.Provider>);
+    await screen.findByRole("button", { name: "Open initial.md" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh folder" }));
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(2));
+    act(() => socket.emit({ type: "files:subscribed", directory: "", revision: 2 }));
+    expect(await screen.findByRole("button", { name: "Open socket-new.md" })).not.toBeNull();
+
+    await act(async () => resolveRefresh(listing("refresh-old.md")));
+    expect(screen.queryByRole("button", { name: "Open refresh-old.md" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Open socket-new.md" })).not.toBeNull();
+  });
+
+  it("forgets an authoritatively successful uncertain rename even if the old path returns later", async () => {
+    let current = listing("note.md");
+    const api = {
+      baseUrl: "https://app.matrix-os.com",
+      get: vi.fn(async () => current),
+      post: vi.fn(async (path: string) => {
+        if (path !== "/api/files/rename") throw new Error("unexpected mutation");
+        current = listing("renamed.md");
+        throw new AppError("timeout");
+      }),
+    };
+    useConnection.setState({
+      status: "signed-in",
+      runtimeSlot: "primary",
+      authGeneration: 1,
+      api: api as never,
+    });
+    render(<Tooltip.Provider><ComputerFileBrowser directorySocket={null} /></Tooltip.Provider>);
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    const refresh = screen.getByRole("button", { name: "Refresh folder" });
+    fireEvent.contextMenu(note);
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Rename" }));
+    const input = screen.getByRole("textbox", { name: "Rename note.md" });
+    fireEvent.change(input, { target: { value: "renamed.md" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save rename" }));
+
+    expect(await screen.findByRole("button", { name: "Open renamed.md" })).not.toBeNull();
+    expect(screen.queryByRole("textbox", { name: "Rename note.md" })).toBeNull();
+
+    current = {
+      path: "",
+      entries: [
+        { name: "note.md", type: "file", capabilities: CAPABILITIES },
+        { name: "renamed.md", type: "file", capabilities: CAPABILITIES },
+      ],
+    };
+    fireEvent.click(refresh);
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(4));
+    expect(screen.queryByRole("textbox", { name: "Rename note.md" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Open note.md" })).not.toBeNull();
+  });
+
+  it("does not let a held Refresh overwrite a later Trash reload", async () => {
+    let resolveRefresh!: (value: Listing) => void;
+    let current = listing("note.md");
+    const api = {
+      baseUrl: "https://app.matrix-os.com",
+      get: vi.fn()
+        .mockImplementationOnce(async () => current)
+        .mockImplementationOnce(() => new Promise<Listing>((resolve) => { resolveRefresh = resolve; }))
+        .mockImplementation(async () => current),
+      post: vi.fn(async (path: string, body: { sources: string[] }) => {
+        if (path !== "/api/files/batch/trash") throw new Error("unexpected mutation");
+        current = listing("after-trash.md");
+        return {
+          results: body.sources.map((source) => ({ source, code: "trashed" as const })),
+          sourceDirectory: "",
+        };
+      }),
+    };
+    useConnection.setState({
+      status: "signed-in",
+      runtimeSlot: "primary",
+      authGeneration: 1,
+      api: api as never,
+    });
+    render(<Tooltip.Provider><ComputerFileBrowser directorySocket={null} /></Tooltip.Provider>);
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    const refresh = screen.getByRole("button", { name: "Refresh folder" });
+    fireEvent.click(note);
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to Trash" }));
+
+    fireEvent.click(refresh);
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(2));
+    fireEvent.click(screen.getByRole("button", { name: "Move to Trash" }));
+    expect(await screen.findByRole("button", { name: "Open after-trash.md" })).not.toBeNull();
+
+    await act(async () => resolveRefresh(listing("refresh-old.md")));
+    expect(screen.queryByRole("button", { name: "Open refresh-old.md" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Open after-trash.md" })).not.toBeNull();
+  });
+
+  it("rejects interrupted async publication across an API scope transition", async () => {
+    let resolveOld!: (value: Listing) => void;
+    const oldApi = {
+      baseUrl: "https://app.matrix-os.com",
+      get: vi.fn()
+        .mockResolvedValueOnce(listing("old-initial.md"))
+        .mockImplementationOnce(() => new Promise<Listing>((resolve) => { resolveOld = resolve; })),
+      post: vi.fn(),
+    };
+    const newApi = {
+      baseUrl: "https://app.matrix-os.com",
+      get: vi.fn(async () => listing("new-scope.md")),
+      post: vi.fn(),
+    };
+    useConnection.setState({
+      status: "signed-in",
+      runtimeSlot: "primary",
+      authGeneration: 1,
+      api: oldApi as never,
+    });
+    render(<Tooltip.Provider><ComputerFileBrowser directorySocket={null} /></Tooltip.Provider>);
+    await screen.findByRole("button", { name: "Open old-initial.md" });
+    fireEvent.click(screen.getByRole("button", { name: "Refresh folder" }));
+    await waitFor(() => expect(oldApi.get).toHaveBeenCalledTimes(2));
+
+    act(() => startTransition(() => {
+      useConnection.setState({ api: newApi as never, authGeneration: 2 });
+    }));
+    expect(await screen.findByRole("button", { name: "Open new-scope.md" })).not.toBeNull();
+
+    await act(async () => resolveOld(listing("interrupted-old.md")));
+    expect(screen.queryByRole("button", { name: "Open interrupted-old.md" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Open new-scope.md" })).not.toBeNull();
+  });
+});

--- a/tests/desktop/files-management-ui.test.tsx
+++ b/tests/desktop/files-management-ui.test.tsx
@@ -186,7 +186,8 @@ describe("Files management UI", () => {
 
   it("confirms one visible-order Trash batch and retains a partial failed selection with a safe notice", async () => {
     api.setTrashCodes({ "todo.md": "protected" });
-    renderBrowser({ selectionPlatform: "mac" });
+    const onPreviewPathChange = vi.fn();
+    renderBrowser({ selectionPlatform: "mac", onPreviewPathChange });
     const note = await screen.findByRole("button", { name: "Open note.md" });
     const todo = screen.getByRole("button", { name: "Open todo.md" });
     fireEvent.click(note);
@@ -195,6 +196,7 @@ describe("Files management UI", () => {
     fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for todo.md" }), { button: 0 });
     fireEvent.click(await screen.findByRole("menuitem", { name: "Move to Trash" }));
     expect(screen.getByRole("heading", { name: "Move 2 items to Trash?" })).not.toBeNull();
+    onPreviewPathChange.mockClear();
     fireEvent.click(screen.getByRole("button", { name: "Move to Trash" }));
 
     await waitFor(() => expect(api.post).toHaveBeenCalledWith(
@@ -204,6 +206,7 @@ describe("Files management UI", () => {
     ));
     await waitFor(() => expect(screen.queryByRole("button", { name: "Open note.md" })).toBeNull());
     expect(screen.getByRole("button", { name: "Open todo.md" }).getAttribute("aria-pressed")).toBe("true");
+    expect(onPreviewPathChange).toHaveBeenLastCalledWith("todo.md");
     expect(screen.getByRole("status").textContent).toMatch(/protected/i);
     expect(screen.getByRole("status").textContent).not.toMatch(/provider|\/home|todo\.md/i);
   });
@@ -444,13 +447,16 @@ describe("Files management UI", () => {
 
   it("keeps the internal selection ref aligned after successful Trash reconciliation", async () => {
     api.post.mockResolvedValueOnce({ results: [{ source: "note.md", code: "trashed" }], sourceDirectory: "" });
-    renderBrowser({ selectionPlatform: "mac" });
+    const onPreviewPathChange = vi.fn();
+    renderBrowser({ selectionPlatform: "mac", onPreviewPathChange });
     const note = await screen.findByRole("button", { name: "Open note.md" });
     fireEvent.click(note);
     fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
     fireEvent.click(await screen.findByRole("menuitem", { name: "Move to Trash" }));
+    onPreviewPathChange.mockClear();
     fireEvent.click(screen.getByRole("button", { name: "Move to Trash" }));
     await waitFor(() => expect(screen.getByRole("button", { name: "Open note.md" }).getAttribute("aria-pressed")).toBe("false"));
+    expect(onPreviewPathChange).toHaveBeenLastCalledWith(null);
     fireEvent.click(screen.getByRole("button", { name: "Open todo.md" }), { metaKey: true });
     expect(screen.getByRole("button", { name: "Open note.md" }).getAttribute("aria-pressed")).toBe("false");
   });

--- a/tests/desktop/files-management-ui.test.tsx
+++ b/tests/desktop/files-management-ui.test.tsx
@@ -285,7 +285,7 @@ describe("Files management UI", () => {
     expect(onPreviewPathChange).toHaveBeenLastCalledWith(null);
   });
 
-  it("shows a bounded explanation instead of silently extending Shift selection beyond 100", async () => {
+  it("keeps oversized Shift selections and disables batch actions with an explanation", async () => {
     api.setEntries(Array.from({ length: 101 }, (_, index) => ({
       name: `file-${String(index).padStart(3, "0")}.md`,
       type: "file" as const,
@@ -295,7 +295,24 @@ describe("Files management UI", () => {
     const first = await screen.findByRole("button", { name: "Open file-000.md" });
     fireEvent.click(first);
     fireEvent.click(screen.getByRole("button", { name: "Open file-100.md" }), { shiftKey: true });
-    expect(screen.getByRole("status").textContent).toMatch(/up to 100/i);
+    expect(screen.getAllByRole("button", { pressed: true })
+      .filter((button) => button.getAttribute("aria-label")?.startsWith("Open file-"))).toHaveLength(101);
+    expect(screen.getByRole("status").textContent).toMatch(/batch actions support up to 100/i);
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for file-000.md" }));
+    expect((await screen.findByRole("menuitem", { name: "Move to Trash" })).hasAttribute("data-disabled")).toBe(true);
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    api.setEntries(Array.from({ length: 100 }, (_, index) => ({
+      name: `file-${String(index).padStart(3, "0")}.md`,
+      type: "file" as const,
+      capabilities: CAPABILITIES,
+    })));
+    fireEvent.click(screen.getByRole("button", { name: "Refresh folder" }));
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Open file-100.md" })).toBeNull());
+    expect(screen.queryByRole("status")).toBeNull();
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for file-000.md" }));
+    expect((await screen.findByRole("menuitem", { name: "Move to Trash" })).hasAttribute("data-disabled")).toBe(false);
   });
 
   it("rejects invalid portable names locally and keeps typed conflicts safe and editable", async () => {

--- a/tests/desktop/files-management-ui.test.tsx
+++ b/tests/desktop/files-management-ui.test.tsx
@@ -1,0 +1,457 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ComputerFileBrowser from "@desktop/renderer/src/features/files/ComputerFileBrowser";
+import { useBrowserViewPreference } from "@desktop/renderer/src/features/files/browser-view-preference";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+import type { FileDirectoryServerMessage } from "@desktop/renderer/src/lib/kernel-socket";
+import { AppError } from "@desktop/renderer/src/lib/errors";
+
+const CAPABILITIES = { canRename: true, canMove: true, canTrash: true };
+
+class FakeDirectorySocket {
+  records: Array<{ directory: string; active: boolean; handler: (message: FileDirectoryServerMessage) => void }> = [];
+  subscribeDirectory = vi.fn((directory: string, handler: (message: FileDirectoryServerMessage) => void) => {
+    const record = { directory, active: true, handler };
+    this.records.push(record);
+    return () => { record.active = false; };
+  });
+  touchDirectory = vi.fn(() => true);
+  emit(message: FileDirectoryServerMessage) {
+    for (const record of this.records) if (record.active) record.handler(message);
+  }
+}
+
+function makeApi() {
+  const entries = [
+    { name: "Folder", type: "directory", capabilities: CAPABILITIES },
+    { name: "note.md", type: "file", capabilities: CAPABILITIES },
+    { name: "todo.md", type: "file", capabilities: CAPABILITIES },
+  ];
+  let trashCodes: Record<string, "trashed" | "protected" | "failed"> = {};
+  const api = {
+    baseUrl: "https://app.matrix-os.com",
+    get: vi.fn(async (path: string) => ({
+      path: new URLSearchParams(path.split("?")[1]).get("path") ?? "",
+      entries,
+    })),
+    post: vi.fn(async (path: string, body: { parentDirectory: string; path?: string; name: string; kind: "file" | "directory"; sources?: string[] }) => {
+      if (path === "/api/files/batch/trash") {
+        const results = body.sources!.map((source) => ({ source, code: trashCodes[source] ?? "trashed" }));
+        for (const result of results) {
+          if (result.code === "trashed") entries.splice(entries.findIndex((entry) => entry.name === result.source), 1);
+        }
+        return { results, sourceDirectory: "" };
+      }
+      if (path === "/api/files/rename") {
+        const oldName = body.path!.split("/").pop();
+        const entry = entries.find((candidate) => candidate.name === oldName)!;
+        entry.name = body.name;
+        return {
+          ok: true,
+          path: body.path!.includes("/") ? `${body.path!.split("/").slice(0, -1).join("/")}/${body.name}` : body.name,
+          resultCode: "renamed",
+          capabilities: CAPABILITIES,
+        };
+      }
+      entries.push({ name: body.name, type: body.kind, capabilities: CAPABILITIES });
+      return {
+        ok: true,
+        path: body.parentDirectory ? `${body.parentDirectory}/${body.name}` : body.name,
+        resultCode: "created",
+        capabilities: CAPABILITIES,
+      };
+    }),
+    setTrashCodes(next: typeof trashCodes) { trashCodes = next; },
+    setEntries(next: typeof entries) { entries.splice(0, entries.length, ...next); },
+  };
+  return api;
+}
+
+function renderBrowser(props: Record<string, unknown> = {}) {
+  return render(
+    <Tooltip.Provider>
+      <ComputerFileBrowser {...props as never} />
+    </Tooltip.Provider>,
+  );
+}
+
+describe("Files management UI", () => {
+  let api: ReturnType<typeof makeApi>;
+
+  beforeEach(() => {
+    api = makeApi();
+    useBrowserViewPreference.setState({ view: "list" });
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://app.matrix-os.com",
+      runtimeSlot: "primary",
+      authGeneration: 1,
+      api: api as never,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps a renderer-only New File editor open on blur and cancels without a request", async () => {
+    renderBrowser();
+    await screen.findByRole("button", { name: "Open note.md" });
+
+    fireEvent.click(screen.getByRole("button", { name: "New File" }));
+    const input = screen.getByRole("textbox", { name: "New file name" });
+    expect(api.post).not.toHaveBeenCalled();
+
+    fireEvent.change(input, { target: { value: "draft.md" } });
+    fireEvent.blur(input);
+    expect(screen.getByRole("textbox", { name: "New file name" })).toBe(input);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel new file" }));
+    expect(screen.queryByRole("textbox", { name: "New file name" })).toBeNull();
+    expect(api.post).not.toHaveBeenCalled();
+  });
+
+  it("submits a New Folder with Enter and replaces the temporary row from an authoritative listing", async () => {
+    renderBrowser();
+    await screen.findByRole("button", { name: "Open note.md" });
+    fireEvent.click(screen.getByRole("button", { name: "New Folder" }));
+    const input = screen.getByRole("textbox", { name: "New folder name" });
+    fireEvent.change(input, { target: { value: "Assets" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith(
+      "/api/files/create",
+      expect.objectContaining({
+        requestId: expect.stringMatching(/^[0-9a-f-]{36}$/i),
+        parentDirectory: "",
+        name: "Assets",
+        kind: "directory",
+      }),
+      { timeoutMs: 60_000 },
+    ));
+    expect(await screen.findByRole("button", { name: "Open Assets" })).not.toBeNull();
+    expect(screen.queryByRole("textbox", { name: "New folder name" })).toBeNull();
+  });
+
+  it("keeps focused preview separate while mac Command and Shift build an ordered selection", async () => {
+    const onOpenFile = vi.fn();
+    renderBrowser({ selectionPlatform: "mac", onOpenFile });
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    const todo = screen.getByRole("button", { name: "Open todo.md" });
+    const folder = screen.getByRole("button", { name: "Open Folder" });
+
+    fireEvent.click(note);
+    expect(note.getAttribute("aria-pressed")).toBe("true");
+    expect(onOpenFile).toHaveBeenLastCalledWith("note.md");
+
+    fireEvent.click(todo, { metaKey: true });
+    expect(note.getAttribute("aria-pressed")).toBe("true");
+    expect(todo.getAttribute("aria-pressed")).toBe("true");
+    expect(onOpenFile).toHaveBeenLastCalledWith("todo.md");
+
+    fireEvent.click(folder, { shiftKey: true });
+    expect(folder.getAttribute("aria-pressed")).toBe("true");
+    expect(note.getAttribute("aria-pressed")).toBe("true");
+    expect(todo.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("offers context and ellipsis actions, including real editor and single-item rename seams", async () => {
+    const onOpenInEditor = vi.fn();
+    renderBrowser({ onOpenInEditor });
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Open in Editor" }));
+    expect(onOpenInEditor).toHaveBeenCalledWith("note.md");
+
+    fireEvent.contextMenu(note);
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Rename" }));
+    const input = screen.getByRole("textbox", { name: "Rename note.md" });
+    fireEvent.change(input, { target: { value: "renamed.md" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save rename" }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith(
+      "/api/files/rename",
+      expect.objectContaining({ path: "note.md", name: "renamed.md" }),
+      { timeoutMs: 60_000 },
+    ));
+    expect(await screen.findByRole("button", { name: "Open renamed.md" })).not.toBeNull();
+  });
+
+  it("confirms one visible-order Trash batch and retains a partial failed selection with a safe notice", async () => {
+    api.setTrashCodes({ "todo.md": "protected" });
+    renderBrowser({ selectionPlatform: "mac" });
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    const todo = screen.getByRole("button", { name: "Open todo.md" });
+    fireEvent.click(note);
+    fireEvent.click(todo, { metaKey: true });
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for todo.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to Trash" }));
+    expect(screen.getByRole("heading", { name: "Move 2 items to Trash?" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Move to Trash" }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith(
+      "/api/files/batch/trash",
+      expect.objectContaining({ sources: ["note.md", "todo.md"] }),
+      { timeoutMs: 60_000 },
+    ));
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Open note.md" })).toBeNull());
+    expect(screen.getByRole("button", { name: "Open todo.md" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("status").textContent).toMatch(/protected/i);
+    expect(screen.getByRole("status").textContent).not.toMatch(/provider|\/home|todo\.md/i);
+  });
+
+  it("subscribes the authenticated directory and reloads its authoritative baseline without stale cleanup", async () => {
+    const socket = new FakeDirectorySocket();
+    const view = renderBrowser({ directorySocket: socket });
+    await screen.findByRole("button", { name: "Open note.md" });
+    expect(socket.subscribeDirectory).toHaveBeenCalledWith("", expect.any(Function));
+    api.get.mockClear();
+
+    socket.emit({ type: "files:subscribed", directory: "", revision: 4 });
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith("/api/files/list?path="));
+    view.unmount();
+    expect(socket.records[0]?.active).toBe(false);
+  });
+
+  it("disables both a pending row and its ellipsis until the single Trash promise settles", async () => {
+    let resolveTrash!: (value: { results: Array<{ source: string; code: "trashed" }>; sourceDirectory: string }) => void;
+    const trashPromise = new Promise<{ results: Array<{ source: string; code: "trashed" }>; sourceDirectory: string }>(
+      (resolve) => { resolveTrash = resolve; },
+    );
+    api.post.mockImplementation(async (path: string) => {
+      if (path === "/api/files/batch/trash") return trashPromise;
+      throw new Error("unexpected mutation");
+    });
+    renderBrowser();
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    fireEvent.click(note);
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to Trash" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move to Trash" }));
+    await waitFor(() => expect(api.post).toHaveBeenCalledOnce());
+
+    expect(screen.getByRole("button", { name: "Open note.md" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "More actions for note.md" }).hasAttribute("disabled")).toBe(true);
+
+    resolveTrash({ results: [{ source: "note.md", code: "trashed" }], sourceDirectory: "" });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open note.md" }).hasAttribute("disabled")).toBe(false));
+  });
+
+  it("starts New File and New Folder from the empty-space context menu, including an empty folder", async () => {
+    api.setEntries([]);
+    renderBrowser();
+    await screen.findByText("This folder is empty.");
+    fireEvent.contextMenu(screen.getByTestId("files-listing"));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "New File" }));
+    expect(screen.getByRole("textbox", { name: "New file name" })).not.toBeNull();
+    fireEvent.keyDown(screen.getByRole("textbox", { name: "New file name" }), { key: "Escape" });
+
+    fireEvent.contextMenu(screen.getByTestId("files-listing"));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "New Folder" }));
+    expect(screen.getByRole("textbox", { name: "New folder name" })).not.toBeNull();
+  });
+
+  it("retains visible selection on refresh and clears focused preview when the row disappears", async () => {
+    const onPreviewPathChange = vi.fn();
+    renderBrowser({ onPreviewPathChange });
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    fireEvent.click(note);
+    expect(onPreviewPathChange).toHaveBeenLastCalledWith("note.md");
+
+    const initialLoads = api.get.mock.calls.length;
+    fireEvent.click(screen.getByRole("button", { name: "Refresh folder" }));
+    await waitFor(() => expect(api.get.mock.calls.length).toBeGreaterThan(initialLoads));
+    expect(screen.getByRole("button", { name: "Open note.md" }).getAttribute("aria-pressed")).toBe("true");
+
+    api.setEntries([
+      { name: "Folder", type: "directory", capabilities: CAPABILITIES },
+      { name: "todo.md", type: "file", capabilities: CAPABILITIES },
+    ]);
+    const retainedLoads = api.get.mock.calls.length;
+    fireEvent.click(screen.getByRole("button", { name: "Refresh folder" }));
+    await waitFor(() => expect(api.get.mock.calls.length).toBeGreaterThan(retainedLoads));
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Open note.md" })).toBeNull());
+    expect(onPreviewPathChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it("shows a bounded explanation instead of silently extending Shift selection beyond 100", async () => {
+    api.setEntries(Array.from({ length: 101 }, (_, index) => ({
+      name: `file-${String(index).padStart(3, "0")}.md`,
+      type: "file" as const,
+      capabilities: CAPABILITIES,
+    })));
+    renderBrowser({ selectionPlatform: "linux" });
+    const first = await screen.findByRole("button", { name: "Open file-000.md" });
+    fireEvent.click(first);
+    fireEvent.click(screen.getByRole("button", { name: "Open file-100.md" }), { shiftKey: true });
+    expect(screen.getByRole("status").textContent).toMatch(/up to 100/i);
+  });
+
+  it("rejects invalid portable names locally and keeps typed conflicts safe and editable", async () => {
+    renderBrowser();
+    await screen.findByRole("button", { name: "Open note.md" });
+    fireEvent.click(screen.getByRole("button", { name: "New File" }));
+    const input = screen.getByRole("textbox", { name: "New file name" });
+    fireEvent.change(input, { target: { value: "CON" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(screen.getByRole("alert").textContent).toBe("Choose a valid portable name.");
+    expect(api.post).not.toHaveBeenCalled();
+
+    api.post.mockRejectedValueOnce(new AppError("server", {
+      detail: "destination_conflict",
+      cause: new Error("provider failed at /home/operator/secret"),
+    }));
+    fireEvent.change(input, { target: { value: "safe.md" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create file" }));
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toBe("An item with that name already exists."));
+    expect(screen.getByRole("alert").textContent).not.toMatch(/provider|\/home|secret/i);
+    expect(screen.getByRole("textbox", { name: "New file name" })).not.toBeNull();
+  });
+
+  it("uses Windows Control, ignores the wrong modifier, and disables unavailable or multi-item actions", async () => {
+    renderBrowser({ selectionPlatform: "windows" });
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    const todo = screen.getByRole("button", { name: "Open todo.md" });
+    fireEvent.click(note);
+    fireEvent.click(todo, { ctrlKey: true });
+    expect(note.getAttribute("aria-pressed")).toBe("true");
+    expect(todo.getAttribute("aria-pressed")).toBe("true");
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for todo.md" }), { button: 0 });
+    expect((await screen.findByRole("menuitem", { name: "Rename" })).hasAttribute("data-disabled")).toBe(true);
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Open Folder" }), { metaKey: true });
+    expect(note.getAttribute("aria-pressed")).toBe("false");
+    expect(todo.getAttribute("aria-pressed")).toBe("false");
+
+    cleanup();
+    api.setEntries([{ name: "locked.md", type: "file", capabilities: { canRename: false, canMove: false, canTrash: false } }]);
+    renderBrowser();
+    await screen.findByRole("button", { name: "Open locked.md" });
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for locked.md" }), { button: 0 });
+    expect((await screen.findByRole("menuitem", { name: "Rename" })).hasAttribute("data-disabled")).toBe(true);
+    expect(screen.getByRole("menuitem", { name: "Move to Trash" }).hasAttribute("data-disabled")).toBe(true);
+  });
+
+  it("retains an uncertain Trash result without retrying until a fresh user action", async () => {
+    api.post.mockRejectedValueOnce(new AppError("timeout", { cause: new Error("/home/operator/provider") }));
+    renderBrowser();
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    fireEvent.click(note);
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to Trash" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move to Trash" }));
+    await waitFor(() => expect(api.post).toHaveBeenCalledOnce());
+    expect(screen.getByRole("button", { name: "Open note.md" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("status").textContent).toMatch(/could not be confirmed/i);
+    expect(screen.getByRole("status").textContent).not.toMatch(/provider|\/home|operator/i);
+    await Promise.resolve();
+    expect(api.post).toHaveBeenCalledOnce();
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to Trash" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move to Trash" }));
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(2));
+  });
+
+  it("clears editor, selection, and pending state when runtime and auth become stale", async () => {
+    let resolveTrash!: (value: { results: Array<{ source: string; code: "trashed" }>; sourceDirectory: string }) => void;
+    api.post.mockImplementation(async (path: string) => {
+      if (path !== "/api/files/batch/trash") throw new Error("unexpected mutation");
+      return new Promise((resolve) => { resolveTrash = resolve; });
+    });
+    renderBrowser();
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    fireEvent.click(screen.getByRole("button", { name: "New File" }));
+    fireEvent.click(note);
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to Trash" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move to Trash" }));
+    await waitFor(() => expect(api.post).toHaveBeenCalledOnce());
+
+    act(() => useConnection.setState({ runtimeSlot: "preview", authGeneration: 2 }));
+    await waitFor(() => expect(screen.queryByRole("textbox", { name: "New file name" })).toBeNull());
+    expect((await screen.findByRole("button", { name: "Open note.md" })).getAttribute("aria-pressed")).toBe("false");
+    resolveTrash({ results: [{ source: "note.md", code: "trashed" }], sourceDirectory: "" });
+    await act(async () => { await Promise.resolve(); });
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.getByRole("button", { name: "Open note.md" }).hasAttribute("disabled")).toBe(false);
+  });
+
+  it("rejects an old API reload that settles after the runtime and auth scope changes", async () => {
+    let resolveOld!: (value: { path: string; entries: Array<{ name: string; type: "file"; capabilities: typeof CAPABILITIES }> }) => void;
+    renderBrowser();
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    api.get.mockImplementationOnce(() => new Promise((resolve) => { resolveOld = resolve; }));
+    fireEvent.click(note);
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to Trash" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move to Trash" }));
+    await waitFor(() => expect(api.post).toHaveBeenCalledOnce());
+
+    const newApi = makeApi();
+    newApi.setEntries([{ name: "fresh.md", type: "file", capabilities: CAPABILITIES }]);
+    act(() => useConnection.setState({ api: newApi as never, runtimeSlot: "preview", authGeneration: 2 }));
+    await screen.findByRole("button", { name: "Open fresh.md" });
+    resolveOld({ path: "", entries: [{ name: "stale.md", type: "file", capabilities: CAPABILITIES }] });
+    await act(async () => { await Promise.resolve(); });
+    expect(screen.queryByRole("button", { name: "Open stale.md" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Open fresh.md" })).not.toBeNull();
+  });
+
+  it("guards a pending rename from repeated submit actions", async () => {
+    let resolveRename!: (value: unknown) => void;
+    api.post.mockImplementation(() => new Promise((resolve) => { resolveRename = resolve; }));
+    renderBrowser();
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    fireEvent.contextMenu(note);
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Rename" }));
+    const input = screen.getByRole("textbox", { name: "Rename note.md" });
+    fireEvent.change(input, { target: { value: "final.md" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save rename" }));
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(api.post).toHaveBeenCalledOnce());
+    expect(screen.getByRole("button", { name: "Save rename" }).hasAttribute("disabled")).toBe(true);
+    await act(async () => {
+      resolveRename({ ok: true, path: "final.md", resultCode: "renamed", capabilities: CAPABILITIES });
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.queryByRole("textbox", { name: "Rename note.md" })).toBeNull());
+  });
+
+  it("replaces an uncertain create draft when the authoritative reload proves success", async () => {
+    api.post.mockImplementationOnce(async () => {
+      api.setEntries([{ name: "recovered.md", type: "file", capabilities: CAPABILITIES }]);
+      throw new AppError("timeout");
+    });
+    renderBrowser();
+    await screen.findByRole("button", { name: "Open note.md" });
+    fireEvent.click(screen.getByRole("button", { name: "New File" }));
+    const input = screen.getByRole("textbox", { name: "New file name" });
+    fireEvent.change(input, { target: { value: "recovered.md" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(await screen.findByRole("button", { name: "Open recovered.md" })).not.toBeNull();
+    expect(screen.queryByRole("textbox", { name: "New file name" })).toBeNull();
+  });
+
+  it("keeps the internal selection ref aligned after successful Trash reconciliation", async () => {
+    api.post.mockResolvedValueOnce({ results: [{ source: "note.md", code: "trashed" }], sourceDirectory: "" });
+    renderBrowser({ selectionPlatform: "mac" });
+    const note = await screen.findByRole("button", { name: "Open note.md" });
+    fireEvent.click(note);
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for note.md" }), { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to Trash" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move to Trash" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open note.md" }).getAttribute("aria-pressed")).toBe("false"));
+    fireEvent.click(screen.getByRole("button", { name: "Open todo.md" }), { metaKey: true });
+    expect(screen.getByRole("button", { name: "Open note.md" }).getAttribute("aria-pressed")).toBe("false");
+  });
+});

--- a/tests/desktop/files-workspace.test.tsx
+++ b/tests/desktop/files-workspace.test.tsx
@@ -28,6 +28,7 @@ const LIST: Record<string, { entries: Array<{ name: string; type: string }> }> =
 };
 
 interface ApiOverrides {
+  listFor?: (path: string) => unknown;
   statFor?: (path: string) => { size?: number };
   statImpl?: (path: string) => Promise<{ size?: number }>;
   textFor?: (path: string) => string;
@@ -35,7 +36,7 @@ interface ApiOverrides {
 
 function makeApi(overrides?: ApiOverrides) {
   const get = vi.fn(async (path: string) => {
-    if (path.startsWith("/api/files/list?path=")) return LIST[path] ?? { entries: [] };
+    if (path.startsWith("/api/files/list?path=")) return overrides?.listFor?.(path) ?? LIST[path] ?? { entries: [] };
     if (path.startsWith("/api/files/stat?path=")) {
       if (overrides?.statImpl) return overrides.statImpl(path);
       return overrides?.statFor ? overrides.statFor(path) : { size: 128 };
@@ -122,6 +123,20 @@ describe("Files workspace", () => {
     await waitFor(() => expect(api.get).toHaveBeenCalledWith("/api/files/list?path=workspaces"));
     expect(screen.getByRole("button", { name: "Matrix home" })).not.toBeNull();
     expect(screen.getByRole("button", { name: "workspaces" })).not.toBeNull();
+  });
+
+  it("clears the focused preview when an authoritative refresh removes its row", async () => {
+    let entries = [{ name: "README.md", type: "file", capabilities: { canRename: true, canMove: true, canTrash: true } }];
+    api = makeApi({ listFor: () => ({ path: "", entries }) });
+    useConnection.setState({ api: api as never });
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+    fireEvent.click(await screen.findByRole("button", { name: "Open README.md" }));
+    expect(await screen.findByRole("heading", { name: "Matrix files" })).not.toBeNull();
+
+    entries = [];
+    fireEvent.click(screen.getByRole("button", { name: "Refresh folder" }));
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Open README.md" })).toBeNull());
+    expect(screen.getByText("Preview")).not.toBeNull();
   });
 
   it("previews bounded code as selectable text", async () => {

--- a/tests/desktop/files-workspace.test.tsx
+++ b/tests/desktop/files-workspace.test.tsx
@@ -339,6 +339,25 @@ describe("Files workspace", () => {
     expect(await screen.findByRole("button", { name: "Open app.ts" })).not.toBeNull();
   });
 
+  it("previews a file activated with Enter", async () => {
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+    const readme = await screen.findByRole("button", { name: "Open README.md" });
+
+    fireEvent.keyDown(readme, { key: "Enter" });
+
+    expect(await screen.findByRole("heading", { name: "Matrix files" })).not.toBeNull();
+  });
+
+  it("previews a file activated from its Open menu action", async () => {
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+    await screen.findByRole("button", { name: "Open README.md" });
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for README.md" }), { button: 0 });
+
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Open" }));
+
+    expect(await screen.findByRole("heading", { name: "Matrix files" })).not.toBeNull();
+  });
+
   it("hides browser entries loaded under a previous session scope", async () => {
     render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
     await waitFor(() => expect(screen.getByRole("button", { name: "Open workspaces" })).toBeTruthy());


### PR DESCRIPTION
## Summary

- add inline file and folder creation and rename
- add macOS multi-selection, entry and empty-space menus, and capability gating
- add confirmed Move to Trash with safe partial and uncertain outcome reconciliation

## Stack

7 of 8. Base: Desktop state foundation. Next: move picker and drag in #1186.

## Validation

- rendered Files management, concurrency, workspace, and browser-view suites pass
- create, rename, multi-select, and Trash were exercised on Preview VPS `pr-1186`

## Invariants

- **Source of truth:** authoritative listing publication after each operation.
- **Lock/transaction scope:** UI delegates one typed operation to the scoped controller.
- **Acceptable orphan states:** failed or ambiguous rows remain visible and selected with bounded copy.
- **Auth source of truth:** committed API/runtime/auth identity; stale completions cannot publish.
- **Deferred scope:** move picker and internal drag land in #1186; permanent deletion remains follow-up work.

Related: MAT-268, #1183, #1186

## Latest validation (2026-08-12)

- Oversized selections stay visibly selected while Move and Trash actions are disabled with a bounded explanation.
- Authoritative reconciliation from 101 to exactly 100 clears the notice and re-enables actions.
- The Files list reserves a dedicated 32 px action column; the three-dot control no longer overlaps Modified.