### PR TITLE
fix(terminal): scale session hover cards with canvas zoom

### DIFF
--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -936,7 +936,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
           className={mobile ? "relative flex flex-1 min-h-0 flex-col" : "relative flex flex-1 min-h-0"}
           style={{ background: "var(--terminal-app-body-bg)" }}
         >
-          <LocalTerminalSidebar />
+          <LocalTerminalSidebar canvasZoom={canvasZoom} />
           {activeTab ? (
             <div
               data-testid="terminal-content-surface"

--- a/shell/src/components/terminal/TerminalSessionHoverCard.tsx
+++ b/shell/src/components/terminal/TerminalSessionHoverCard.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState, type CSSProperties, type ReactElement, type RefObject } from "react";
 import { HoverCard as HoverCardPrimitive } from "radix-ui";
 import { SHELL_Z_INDEX } from "@/lib/shell-layering";
-import { useCanvasTransform } from "@/hooks/useCanvasTransform";
 import { TerminalAgentLogo } from "./TerminalAgentLogo";
 import { getShellVisualStatus, type ShellSessionSummary } from "./terminal-session-state";
 import { TERMINAL_MONO_FONT_FAMILY, TERMINAL_UI_FONT_FAMILY } from "./terminal-typography";
@@ -125,6 +124,7 @@ export function TerminalSessionHoverCard({
   shell,
   displayName,
   cardRef,
+  canvasZoom = 1,
   open,
   suppressed,
   onOpenChange,
@@ -133,13 +133,13 @@ export function TerminalSessionHoverCard({
   shell: ShellSessionSummary;
   displayName: string;
   cardRef: RefObject<HTMLDivElement | null>;
+  canvasZoom?: number;
   open: boolean;
   suppressed: boolean;
   onOpenChange: (open: boolean) => void;
   children: ReactElement;
 }) {
   const [theme, setTheme] = useState(FALLBACK_HOVER_CARD_THEME);
-  const canvasZoom = useCanvasTransform((state) => state.zoom);
   const agentName = shell.agent ? formatTerminalAgentName(shell.agent) : "Terminal";
   const liveState = getShellVisualStatus(shell);
   const updatedAt = shell.agent ? shell.agentUpdatedAt : shell.updatedAt;

--- a/shell/src/components/terminal/TerminalSessionHoverCard.tsx
+++ b/shell/src/components/terminal/TerminalSessionHoverCard.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, type CSSProperties, type ReactElement, type RefObject } from "react";
 import { HoverCard as HoverCardPrimitive } from "radix-ui";
 import { SHELL_Z_INDEX } from "@/lib/shell-layering";
+import { useCanvasTransform } from "@/hooks/useCanvasTransform";
 import { TerminalAgentLogo } from "./TerminalAgentLogo";
 import { getShellVisualStatus, type ShellSessionSummary } from "./terminal-session-state";
 import { TERMINAL_MONO_FONT_FAMILY, TERMINAL_UI_FONT_FAMILY } from "./terminal-typography";
@@ -80,9 +81,12 @@ function formatAgentUpdatedAt(value: string | undefined): string {
   return `Updated ${Math.floor(elapsedHours / 24)}d ago`;
 }
 
-function canOpenToRight(card: HTMLElement | null): boolean {
+function canOpenToRight(card: HTMLElement | null, canvasZoom: number): boolean {
   if (!card || typeof window === "undefined") return false;
-  return card.getBoundingClientRect().right + HOVER_CARD_GAP + HOVER_CARD_WIDTH <= window.innerWidth - 12;
+  return card.getBoundingClientRect().right
+    + HOVER_CARD_GAP * canvasZoom
+    + HOVER_CARD_WIDTH * canvasZoom
+    <= window.innerWidth - 12;
 }
 
 function safePullRequestUrl(value: string | undefined): string | null {
@@ -135,12 +139,13 @@ export function TerminalSessionHoverCard({
   children: ReactElement;
 }) {
   const [theme, setTheme] = useState(FALLBACK_HOVER_CARD_THEME);
+  const canvasZoom = useCanvasTransform((state) => state.zoom);
   const agentName = shell.agent ? formatTerminalAgentName(shell.agent) : "Terminal";
   const liveState = getShellVisualStatus(shell);
   const updatedAt = shell.agent ? shell.agentUpdatedAt : shell.updatedAt;
   const pullRequestUrl = safePullRequestUrl(shell.pullRequest?.url);
   const hasProjectContext = Boolean(shell.project || shell.repository || shell.branch || shell.pullRequest);
-  const canDisplay = open && !suppressed && canOpenToRight(cardRef.current);
+  const canDisplay = open && !suppressed && canOpenToRight(cardRef.current, canvasZoom);
   useEffect(() => {
     if (canDisplay) setTheme(readHoverCardTheme(cardRef.current));
   }, [canDisplay, cardRef]);
@@ -148,7 +153,7 @@ export function TerminalSessionHoverCard({
     <HoverCardPrimitive.Root
       open={canDisplay}
       onOpenChange={(nextOpen) => {
-        const canOpen = nextOpen && canOpenToRight(cardRef.current);
+        const canOpen = nextOpen && canOpenToRight(cardRef.current, canvasZoom);
         if (canOpen) setTheme(readHoverCardTheme(cardRef.current));
         onOpenChange(canOpen);
       }}
@@ -172,6 +177,8 @@ export function TerminalSessionHoverCard({
             border: `1px solid ${theme.border}`,
             boxShadow: `0 18px 42px ${theme.shadow}`,
             color: theme.foreground,
+            transform: `scale(${canvasZoom})`,
+            transformOrigin: "left top",
           }}
         >
           <div style={{ alignItems: "center", display: "flex", justifyContent: "space-between", gap: 12 }}>

--- a/shell/src/components/terminal/TerminalSidebar.tsx
+++ b/shell/src/components/terminal/TerminalSidebar.tsx
@@ -258,7 +258,7 @@ function workspaceSessionsEqual(left: WorkspaceSessionSummary[], right: Workspac
 }
 
 // react-doctor-disable-next-line react-doctor/no-giant-component, react-doctor/prefer-useReducer -- no-giant-component: cohesive core terminal sidebar component; extraction tracked separately. prefer-useReducer: the 16 useState fields are several independent clusters, not one related cluster: projects/shells/sessions/files each carry their own data+loading+error triplet with separate fetch lifecycles, plus orthogonal tab/filter/rootPath/tree/agent-status UI state; collapsing them into one reducer would obscure the independent update sites and would not be a mechanical, behavior-identical change.
-export function LocalTerminalSidebar() {
+export function LocalTerminalSidebar({ canvasZoom = 1 }: { canvasZoom?: number } = {}) {
   const ctx = useTerminalAppContext();
   const [tab, setTab] = useState<SidebarTab>("shells");
   const [projects, setProjects] = useState<ProjectInfo[]>([]);
@@ -1246,6 +1246,7 @@ export function LocalTerminalSidebar() {
           <ShellSessionGroup
             label="Active"
             shells={activeShells}
+            canvasZoom={canvasZoom}
             pending={creatingShell}
             deletingShellNames={deletingShellNames}
             foreground
@@ -1266,6 +1267,7 @@ export function LocalTerminalSidebar() {
           <ShellSessionGroup
             label="Background"
             shells={backgroundShells}
+            canvasZoom={canvasZoom}
             expanded={backgroundSessionsExpanded}
             onToggleExpanded={() => setBackgroundSessionsExpanded((expanded) => !expanded)}
             deletingShellNames={deletingShellNames}

--- a/shell/src/components/terminal/TerminalSidebarItems.tsx
+++ b/shell/src/components/terminal/TerminalSidebarItems.tsx
@@ -682,6 +682,7 @@ export function ShellSessionGroup({
   pending = false,
   expanded = true,
   onToggleExpanded,
+  canvasZoom = 1,
   deletingShellNames,
   foreground,
   selectedShellName,
@@ -701,6 +702,7 @@ export function ShellSessionGroup({
   pending?: boolean;
   expanded?: boolean;
   onToggleExpanded?: () => void;
+  canvasZoom?: number;
   deletingShellNames: string[];
   foreground: boolean;
   selectedShellName: string | null;
@@ -772,6 +774,7 @@ export function ShellSessionGroup({
               <ShellCard
                 key={`${label}-${shell.name}`}
                 shell={shell}
+                canvasZoom={canvasZoom}
                 foreground={foreground}
                 deleting={deletingShellNames.includes(shell.name)}
                 selected={shell.name === selectedShellName}
@@ -858,6 +861,7 @@ function ShellPendingCard() {
 
 function ShellCard({
   shell,
+  canvasZoom = 1,
   foreground,
   deleting,
   selected,
@@ -873,6 +877,7 @@ function ShellCard({
   onDragEnd,
 }: {
   shell: ShellSessionSummary;
+  canvasZoom?: number;
   foreground: boolean;
   deleting?: boolean;
   selected: boolean;
@@ -1469,6 +1474,7 @@ function ShellCard({
       shell={shell}
       displayName={displayName}
       cardRef={cardRef}
+      canvasZoom={canvasZoom}
       open={hoverCardOpen}
       suppressed={hoverSuppressed}
       onOpenChange={setHoverCardOpen}

--- a/tests/shell/terminal-session-hover-card.test.tsx
+++ b/tests/shell/terminal-session-hover-card.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { TerminalSessionHoverCard } from "../../shell/src/components/terminal/TerminalSessionHoverCard.js";
 import type { ShellSessionSummary } from "../../shell/src/components/terminal/terminal-session-state.js";
+import { useCanvasTransform } from "../../shell/src/hooks/useCanvasTransform.js";
 
 function renderHoverCard(shell: ShellSessionSummary) {
   const anchor = document.createElement("div");
@@ -42,6 +43,24 @@ function renderHoverCard(shell: ShellSessionSummary) {
 }
 
 describe("TerminalSessionHoverCard", () => {
+  it("scales portal content with the canvas zoom", () => {
+    useCanvasTransform.setState({ zoom: 0.5 });
+    renderHoverCard({
+      name: "claude-zoomed",
+      status: "active",
+      placement: "active",
+      visualStatus: "idle",
+      agent: "claude",
+      model: "claude-opus-4-20250514",
+      tabs: [],
+    });
+
+    const hoverCard = screen.getByTestId("terminal-session-hover-card-claude-zoomed");
+    expect(hoverCard.style.transform).toContain("scale(0.5)");
+    expect(hoverCard.style.transformOrigin).toBe("left top");
+    act(() => useCanvasTransform.setState({ zoom: 1 }));
+  });
+
   it("gives model-only metadata the full available row", () => {
     const metadataGrid = renderHoverCard({
       name: "claude-model-only",

--- a/tests/shell/terminal-session-hover-card.test.tsx
+++ b/tests/shell/terminal-session-hover-card.test.tsx
@@ -2,12 +2,12 @@
 
 import React from "react";
 import { act, render, screen, within } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { TerminalSessionHoverCard } from "../../shell/src/components/terminal/TerminalSessionHoverCard.js";
 import type { ShellSessionSummary } from "../../shell/src/components/terminal/terminal-session-state.js";
 import { useCanvasTransform } from "../../shell/src/hooks/useCanvasTransform.js";
 
-function renderHoverCard(shell: ShellSessionSummary) {
+function renderHoverCard(shell: ShellSessionSummary, canvasZoom = 1) {
   const anchor = document.createElement("div");
   Object.defineProperty(anchor, "getBoundingClientRect", {
     configurable: true,
@@ -32,6 +32,7 @@ function renderHoverCard(shell: ShellSessionSummary) {
       cardRef={{ current: anchor }}
       open
       suppressed={false}
+      canvasZoom={canvasZoom}
       onOpenChange={vi.fn()}
     >
       <button type="button">Session</button>
@@ -43,7 +44,11 @@ function renderHoverCard(shell: ShellSessionSummary) {
 }
 
 describe("TerminalSessionHoverCard", () => {
-  it("scales portal content with the canvas zoom", () => {
+  afterEach(() => {
+    act(() => useCanvasTransform.setState({ zoom: 1 }));
+  });
+
+  it("uses the renderer's effective zoom instead of stale global canvas zoom", () => {
     useCanvasTransform.setState({ zoom: 0.5 });
     renderHoverCard({
       name: "claude-zoomed",
@@ -53,12 +58,27 @@ describe("TerminalSessionHoverCard", () => {
       agent: "claude",
       model: "claude-opus-4-20250514",
       tabs: [],
-    });
+    }, 1);
 
     const hoverCard = screen.getByTestId("terminal-session-hover-card-claude-zoomed");
+    expect(hoverCard.style.transform).toContain("scale(1)");
+    expect(hoverCard.style.transformOrigin).toBe("left top");
+  });
+
+  it("scales portal content with the renderer's effective canvas zoom", () => {
+    renderHoverCard({
+      name: "claude-canvas-zoomed",
+      status: "active",
+      placement: "active",
+      visualStatus: "idle",
+      agent: "claude",
+      model: "claude-opus-4-20250514",
+      tabs: [],
+    }, 0.5);
+
+    const hoverCard = screen.getByTestId("terminal-session-hover-card-claude-canvas-zoomed");
     expect(hoverCard.style.transform).toContain("scale(0.5)");
     expect(hoverCard.style.transformOrigin).toBe("left top");
-    act(() => useCanvasTransform.setState({ zoom: 1 }));
   });
 
   it("gives model-only metadata the full available row", () => {


### PR DESCRIPTION
## Summary
- scale the terminal session hover card with the current terminal renderer's effective Canvas zoom even though Radix renders it through a body portal
- use the scaled dimensions when deciding whether the card fits to the right of its session row
- keep Desktop, mobile, and fullscreen terminal cards at scale 1 even when persistent Canvas state retains another zoom
- add regression coverage for 50% Canvas zoom and stale global zoom

## Root cause
The terminal window is inside the transformed Canvas tree, but the Radix hover card is portaled to `document.body`. It therefore escaped the Canvas transform and stayed at its unzoomed CSS-pixel size while the terminal window changed size. The first fix read persistent global Canvas zoom directly, which did not represent the effective renderer scale in Desktop, mobile, or fullscreen Canvas terminals.

## Tests
- [x] `pnpm exec vitest run tests/shell/terminal-session-hover-card.test.tsx` (5 tests)
- [x] `pnpm exec vitest run tests/shell/terminal-session-hover-card.test.tsx tests/shell/terminal-app-component.test.tsx --maxWorkers=1 --no-file-parallelism` (101 tests)
- [x] `bun run typecheck`
- [x] `bun run check:patterns` (0 violations)
- [x] `git diff --check`
- [x] label-gated GitHub CI: type check, pattern scan, React Doctor, shell production build, sync client package, all four unit-test shards, E2E, aggregate CI, Docker image build, and Docker smoke
- [ ] `bun run test` was attempted locally and stopped after unrelated baseline/environment failures in default-app suites (Node `localStorage` unavailable) and unrelated timeout cases; the changed terminal suites passed within the run

## Review/Monitoring
- addressed Greptile's 4/5 P1 and Codex's matching P2 by threading `TerminalApp.canvasZoom` through the sidebar/session-card path
- latest trusted Greptile review approved commit `18fd4f8ac13239f29e3993688492a733c03181fc` at an exact 5/5; both prior threads are resolved and outdated
- re-added `ready-for-ci` only after the 5/5 review, then monitored the triggered CI and Docker workflows through successful completion

## Invariants
- **Source of truth:** `TerminalApp.canvasZoom` is the terminal renderer's effective scale; `CanvasWindow` derives it from Canvas zoom and forces 1 for fullscreen, while Desktop and mobile use the default 1.
- **Lock/transaction scope:** Not applicable; UI-only change with no persistence.
- **Acceptable orphan states:** None; the hover card is still controlled by the existing Radix root and session state.
- **Auth source of truth:** Unchanged; no auth or network behavior is touched.
- **Deferred scope:** Other global shell overlays are unchanged; this PR fixes the reproduced terminal session hover-card path.
