### PR TITLE
feat(terminal): activate user-systemd runtimes

### DIFF
--- a/docs/dev/user-systemd-terminal-activation.md
+++ b/docs/dev/user-systemd-terminal-activation.md
@@ -1,0 +1,57 @@
+# User-systemd terminal activation
+
+Matrix OS host bundles built from the activation layer enable persistent
+terminal ownership through static `matrix-zellij@<runtime-id>.service` user
+units. The release remains controlled by the normal immutable host-bundle
+channel and exact-version deployment paths; merging code does not promote a
+stable channel or deploy a customer VPS.
+
+## Activation source of truth
+
+The installed app payload is authoritative:
+
+```text
+/opt/matrix/app/TERMINAL_USER_SYSTEMD_ENABLED
+```
+
+The gateway enables the user-systemd adapter only when this is a regular,
+non-symlink file containing exactly `1\n`. The host-bundle build creates that
+marker. Earlier bundles do not contain it and remain dormant.
+
+The environment variable is an operator override:
+
+- `MATRIX_TERMINAL_USER_SYSTEMD_ENABLED=1` forces activation for exact-head
+  acceptance.
+- `MATRIX_TERMINAL_USER_SYSTEMD_ENABLED=0` disables activation for emergency
+  diagnosis.
+- Any other explicit value fails closed.
+
+## Rollout
+
+1. Build and register an immutable bundle without promoting a channel.
+2. Deploy that exact version to a disposable or canary VPS.
+3. Verify ordinary shell and coding-agent runtimes survive browser disconnect,
+   gateway restart, and an in-place bundle update with unchanged runtime PIDs.
+4. Verify deleting a runtime removes its user unit, cgroup, descendants,
+   socket, descriptor, and launch snapshot.
+5. Reboot the canary and confirm no terminal unit, command, or coding agent
+   starts automatically.
+6. Promote channels separately only after the canary evidence is accepted.
+
+This layer does not adopt an already-running legacy Zellij process into a user
+unit. Exact-version rollout must therefore start with fresh/disposable hosts or
+with a canary whose legacy terminal sessions have been deliberately drained.
+Do not interpret an activation merge as authority for an automatic customer
+fleet deployment.
+
+## Rollback
+
+Use the supported host updater rollback or deploy an earlier exact bundle. The
+updater restores the previous `/opt/matrix/app`, which removes the activation
+marker before the earlier gateway starts. Existing user terminal units are not
+stopped by bundle update or rollback; they remain pinned to their immutable
+runtime generations.
+
+Reboot recovery is deliberately not provided. After reboot, descriptors are
+interrupted metadata only: commands, coding agents, viewport, and scrollback do
+not resume automatically.

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -49,6 +49,7 @@ import { createWorkspaceEventStore } from "./workspace-events.js";
 import { createWorkspaceEventPublisher } from "./workspace-event-publisher.js";
 import { createZellijRuntime } from "./zellij-runtime.js";
 import { createUserSystemdZellijRuntime } from "./user-systemd-zellij-runtime.js";
+import { resolveUserSystemdTerminalActivation } from "./terminal-user-systemd-activation.js";
 import { createSessionRuntimeBridge } from "./session-runtime-bridge.js";
 import { createWorkspaceStartupRecovery } from "./workspace-startup-recovery.js";
 import { createChannelManager, type ChannelManager } from "./channels/manager.js";
@@ -358,9 +359,13 @@ export async function createGateway(config: GatewayConfig) {
     persistPath: terminalSessionsPersistPath,
     autoRestore: false,
   });
-  const userSystemdTerminalsEnabled = process.env.MATRIX_TERMINAL_USER_SYSTEMD_ENABLED === "1";
+  const appDir = process.env.MATRIX_APP_DIR ?? process.cwd();
+  const userSystemdTerminalsEnabled = await resolveUserSystemdTerminalActivation({
+    appDir,
+    envValue: process.env.MATRIX_TERMINAL_USER_SYSTEMD_ENABLED,
+  });
   const terminalRuntimeGeneration = userSystemdTerminalsEnabled
-    ? await loadInstalledTerminalRuntimeGeneration(process.env.MATRIX_APP_DIR ?? process.cwd())
+    ? await loadInstalledTerminalRuntimeGeneration(appDir)
     : null;
   const userSystemdTerminalController = terminalRuntimeGeneration
     ? createUserSystemdTerminalRuntime({

--- a/packages/gateway/src/terminal-user-systemd-activation.ts
+++ b/packages/gateway/src/terminal-user-systemd-activation.ts
@@ -1,0 +1,45 @@
+import { constants } from "node:fs";
+import { open } from "node:fs/promises";
+import { join } from "node:path";
+
+export const TERMINAL_USER_SYSTEMD_ACTIVATION_MARKER = "TERMINAL_USER_SYSTEMD_ENABLED";
+
+function hasCode(err: unknown, code: string): boolean {
+  return err instanceof Error && "code" in err && err.code === code;
+}
+
+export async function resolveUserSystemdTerminalActivation(options: {
+  appDir: string;
+  envValue?: string;
+}): Promise<boolean> {
+  if (options.envValue !== undefined) {
+    return options.envValue === "1";
+  }
+
+  const markerPath = join(options.appDir, TERMINAL_USER_SYSTEMD_ACTIVATION_MARKER);
+  let marker: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    marker = await open(markerPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const stat = await marker.stat();
+    if (!stat.isFile() || stat.size !== 2) return false;
+    return (await marker.readFile("utf8")) === "1\n";
+  } catch (err: unknown) {
+    if (hasCode(err, "ENOENT") || hasCode(err, "ENOTDIR") || hasCode(err, "ELOOP")) {
+      return false;
+    }
+    console.warn(
+      "[terminal-runtime] Activation marker check failed closed:",
+      err instanceof Error ? err.name : typeof err,
+    );
+    return false;
+  } finally {
+    if (marker) {
+      await marker.close().catch((err: unknown) => {
+        console.warn(
+          "[terminal-runtime] Activation marker close failed:",
+          err instanceof Error ? err.name : typeof err,
+        );
+      });
+    }
+  }
+}

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -141,6 +141,9 @@ cp -a "$ROOT_DIR/scripts/sync-matrix-agent-skills.sh" "$STAGE_DIR/app/scripts/sy
 cp -a "$ROOT_DIR/skills" "$STAGE_DIR/app/skills"
 cp -a "$ROOT_DIR/package.json" "$ROOT_DIR/pnpm-workspace.yaml" "$ROOT_DIR/pnpm-lock.yaml" "$STAGE_DIR/app/"
 printf '%s\n' "$TERMINAL_RUNTIME_GENERATION" > "$STAGE_DIR/app/TERMINAL_RUNTIME_GENERATION"
+# Activation follows the installed app payload so the supported updater's
+# app rollback atomically returns pre-activation bundles to dormant behavior.
+printf '1\n' > "$STAGE_DIR/app/TERMINAL_USER_SYSTEMD_ENABLED"
 if [ -f "$ROOT_DIR/.npmrc" ]; then
   cp -a "$ROOT_DIR/.npmrc" "$STAGE_DIR/app/.npmrc"
 fi

--- a/specs/109-persist-terminal-sessions/user-systemd-alternative.md
+++ b/specs/109-persist-terminal-sessions/user-systemd-alternative.md
@@ -1,9 +1,11 @@
 # User-systemd terminal runtime alternative
 
-Status: production candidate; fully wired but dormant unless the exact
-`MATRIX_TERMINAL_USER_SYSTEMD_ENABLED=1` activation flag is set. Production
-activation, legacy migration, and public documentation remain a separate final
-layer. This document does not replace the accepted terminal persistence
+Status: accepted production architecture. Host bundles built from the activation
+layer carry `/opt/matrix/app/TERMINAL_USER_SYSTEMD_ENABLED` with the exact contents
+`1\n`; earlier bundles remain dormant. `MATRIX_TERMINAL_USER_SYSTEMD_ENABLED=1`
+remains the exact acceptance override and `MATRIX_TERMINAL_USER_SYSTEMD_ENABLED=0`
+is the emergency disable override. Legacy migration and reboot recovery are not
+required. This document does not replace the accepted terminal persistence
 specification.
 
 ## Decision being tested
@@ -95,6 +97,19 @@ directories. The helper rejects symlinked or non-regular inputs.
 Rollback switches `current` to the generation recorded by the restored app.
 No update or rollback stops `matrix-zellij@*`, `matrix-terminal.slice`, or
 `user@<uid>.service`.
+
+Activation is app-payload-scoped rather than system-unit-scoped. The updater
+backs up and restores `/opt/matrix/app` as its rollback boundary, while systemd
+unit installation is forward-only. Keeping the exact activation marker inside
+the app payload therefore makes rollback to a pre-activation bundle remove the
+marker before the old gateway starts. The gateway opens the marker with
+`O_NOFOLLOW`, requires a two-byte regular file containing exactly `1\n`, and
+fails closed for missing, malformed, or symlinked state. A bundle must be
+explicitly deployed to a canary or channel before this activation reaches a VPS.
+The activation layer does not adopt a live legacy Zellij process into a user
+unit. Initial rollout is therefore limited to fresh/disposable hosts or canaries
+whose legacy sessions have been deliberately drained; an automatic customer
+fleet rollout is not implied by merging the activation code.
 
 The first bundle that introduces this installer can be applied by an older,
 already-running sync-agent process that does not yet know about terminal

--- a/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
+++ b/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
@@ -88,10 +88,14 @@ describe("customer VPS user-systemd terminal runtime", () => {
     expect(generationId).not.toContain("sha256sum \"$@\"");
   });
 
-  it("keeps the production adapter dormant behind one exact activation flag", () => {
+  it("activates the production adapter from the rollback-scoped bundle marker", () => {
     const server = readFileSync(join(root, "packages/gateway/src/server.ts"), "utf8");
+    const build = readFileSync(join(root, "scripts/build-host-bundle.sh"), "utf8");
 
-    expect(server).toContain('process.env.MATRIX_TERMINAL_USER_SYSTEMD_ENABLED === "1"');
+    expect(server).toContain("resolveUserSystemdTerminalActivation");
+    expect(server).toContain("process.env.MATRIX_TERMINAL_USER_SYSTEMD_ENABLED");
+    expect(build).toContain('TERMINAL_USER_SYSTEMD_ENABLED');
+    expect(build).toContain('printf \'1\\n\' > "$STAGE_DIR/app/TERMINAL_USER_SYSTEMD_ENABLED"');
     expect(server).toContain('const terminalAcceptanceEnabled = /^pr-[1-9][0-9]{0,9}$/.test(runtimeHandle)');
     expect(server).toContain('process.env.MATRIX_RUNTIME_SLOT === runtimeHandle');
     expect(server).toContain("loadInstalledTerminalRuntimeGeneration");

--- a/tests/gateway/user-systemd-terminal-activation.test.ts
+++ b/tests/gateway/user-systemd-terminal-activation.test.ts
@@ -1,0 +1,57 @@
+import { mkdtemp, mkdir, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { rm } from "node:fs/promises";
+import {
+  TERMINAL_USER_SYSTEMD_ACTIVATION_MARKER,
+  resolveUserSystemdTerminalActivation,
+} from "../../packages/gateway/src/terminal-user-systemd-activation.js";
+
+describe("user-systemd terminal activation", () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  async function createAppDir(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), "matrix-terminal-activation-"));
+    roots.push(root);
+    return root;
+  }
+
+  it("uses exact environment overrides for acceptance and emergency rollback", async () => {
+    const appDir = await createAppDir();
+    await writeFile(join(appDir, TERMINAL_USER_SYSTEMD_ACTIVATION_MARKER), "1\n");
+
+    await expect(resolveUserSystemdTerminalActivation({ appDir, envValue: "1" })).resolves.toBe(true);
+    await expect(resolveUserSystemdTerminalActivation({ appDir, envValue: "0" })).resolves.toBe(false);
+    await expect(resolveUserSystemdTerminalActivation({ appDir, envValue: "true" })).resolves.toBe(false);
+  });
+
+  it("activates only from the exact regular bundle marker when no override exists", async () => {
+    const appDir = await createAppDir();
+    await writeFile(join(appDir, TERMINAL_USER_SYSTEMD_ACTIVATION_MARKER), "1\n");
+
+    await expect(resolveUserSystemdTerminalActivation({ appDir })).resolves.toBe(true);
+  });
+
+  it("fails closed for missing, malformed, symlinked, and non-file markers", async () => {
+    const missingDir = await createAppDir();
+    await expect(resolveUserSystemdTerminalActivation({ appDir: missingDir })).resolves.toBe(false);
+
+    const malformedDir = await createAppDir();
+    await writeFile(join(malformedDir, TERMINAL_USER_SYSTEMD_ACTIVATION_MARKER), "enabled\n");
+    await expect(resolveUserSystemdTerminalActivation({ appDir: malformedDir })).resolves.toBe(false);
+
+    const symlinkDir = await createAppDir();
+    await writeFile(join(symlinkDir, "target"), "1\n");
+    await symlink("target", join(symlinkDir, TERMINAL_USER_SYSTEMD_ACTIVATION_MARKER));
+    await expect(resolveUserSystemdTerminalActivation({ appDir: symlinkDir })).resolves.toBe(false);
+
+    const directoryDir = await createAppDir();
+    await mkdir(join(directoryDir, TERMINAL_USER_SYSTEMD_ACTIVATION_MARKER));
+    await expect(resolveUserSystemdTerminalActivation({ appDir: directoryDir })).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Activate the accepted user-systemd terminal runtime through an immutable
  app-payload marker included in newly built host bundles.
- Resolve activation at gateway startup with exact `1`/`0` environment
  overrides and a symlink-safe, exact-content marker check that fails closed.
- Keep rollback aligned with the supported updater's `/opt/matrix/app`
  rollback boundary, without stopping active `matrix-zellij@*` units.
- Document the controlled canary rollout, the lack of live legacy-session
  adoption, and the accepted no-reboot-recovery behavior.

This is the separate activation layer authorized after the technical
acceptance and merge of #1129. Merging this PR does not promote a release
channel, deploy stable, or deploy a customer VPS.

## Activation and rollback

New bundles contain:

```text
/opt/matrix/app/TERMINAL_USER_SYSTEMD_ENABLED
```

The marker must be a regular, non-symlink file containing exactly `1\n`.
Earlier bundles lack the marker and remain dormant. An explicit
`MATRIX_TERMINAL_USER_SYSTEMD_ENABLED=0` is the emergency disable override;
`=1` remains the exact-head acceptance override.

The activation layer does not adopt an already-running legacy Zellij process
into a user unit. Initial rollout is therefore limited to fresh/disposable
hosts or a deliberately drained canary. Automatic customer-fleet rollout is
not part of this PR.

## Exact-head production evidence

- Frozen head: `a41bae07b08dee1ab8cc433e4980df95476853cc`
- Preview workflow: [31617292258](https://github.com/HamedMP/matrix-os/actions/runs/31617292258) — passed
- Preview bundle: `v2026.08.12-pr1207-31617292258-1-a41bae0`
- Preview target: disposable `pr-1207`; healthy; bundle registered without
  release-channel promotion
- Production acceptance workflow:
  [31618643811](https://github.com/HamedMP/matrix-os/actions/runs/31618643811) — passed
- Acceptance bundle A:
  `v0.0.0-user-systemd-accept-a41bae0-31618643811-1-a`
- Acceptance bundle B:
  `v0.0.0-user-systemd-accept-a41bae0-31618643811-1-b`
- Evidence artifact:
  `user-systemd-terminal-production-a41bae07b08dee1ab8cc433e4980df95476853cc`
- Evidence SHA-256:
  `f039b13cc631685219a54cbb32abc458ede8f255c950d4737759397965fbac10`
- CI workflow: [31621954534](https://github.com/HamedMP/matrix-os/actions/runs/31621954534) — passed on unchanged-head retry attempt 2
- Docker workflow: [31621954480](https://github.com/HamedMP/matrix-os/actions/runs/31621954480) — image build and PR smoke passed
- Claude Code Review: [31621573447](https://github.com/HamedMP/matrix-os/actions/runs/31621573447) — passed on infrastructure retry attempt 2
- Greptile: 5/5 on exact commit `a41bae07b08dee1ab8cc433e4980df95476853cc`

The bounded evidence contains assertion names only. It contains no terminal
contents, prompts, commands, credentials, environment values, user files,
host addresses, names, or raw logs.

### Acceptance scenarios

- Runtime creation — passed for an ordinary shell and a real Codex agent;
  immutable IDs, separate user units/cgroups, and gateway-owned attachment
  PTYs were verified.
- Browser disconnect/reattach — passed with original workloads preserved.
- Gateway graceful restart and `SIGKILL` restart — passed with runtime PID and
  cgroup continuity and successful reattachment.
- Two exact-head bundle updates — passed; existing runtimes remained pinned
  and new runtimes used the current generation.
- Supported rollback — passed; existing runtimes survived and a new runtime
  used rollback-compatible assets.
- Gateway memory isolation — passed; runtime cgroups remained outside the
  gateway.
- Resource enforcement — passed; effective runtime/aggregate controls were
  present and a bounded breach was isolated to its intended runtime.
- Exact deletion — passed, including socket/snapshot removal and idempotent
  repeat deletion without affecting the other runtime.
- Hostile/corrupt state — passed closed for malformed/symlinked descriptors,
  invalid IDs, conflicting reuse, and hostile descriptor fields.
- Generation garbage collection — passed with safe reference retention,
  bounded generations, and malformed/symlink skipping.
- Reboot behavior — passed the explicitly accepted reduced guarantee: no unit,
  shell command, or coding agent automatically restarted; no replacement PID
  or new output appeared. Reboot recovery is intentionally not provided.

## Tests

- `pnpm exec vitest run tests/gateway/user-systemd-terminal-activation.test.ts tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts`
  — 15/15 passed.
- Full TypeScript typecheck equivalent to `bun run typecheck` — passed locally.
- `pnpm run check:patterns` — passed locally with zero violations.
- `git diff --check` — passed.
- `pnpm test` reached a terminal local result: 10,525 passed, 20 skipped, 143
  failed. The failures were in unchanged broad-suite areas and were dominated
  by this sandbox denying child process creation and loopback/socket listeners
  (`spawnSync ... EPERM`, `listen EPERM`) plus resulting build/test timeouts.
  Exact-head GitHub CI is the authoritative broad result and passed all four
  unit shards plus E2E.
- No React files changed; React Doctor and screenshot evidence are not
  applicable. CI's no-changed-React audit passed.

The first ready-for-CI attempt had transient GitHub runner `socket hang up`
errors while downloading Bun, before any project command ran. Failed jobs were
rerun on the unchanged head; typecheck, shell production build, and the CI
aggregate then passed.

## Technical acceptance basis

- #1129 merged as the accepted replacement for the root terminal-supervisor
  layers.
- The requester explicitly accepted its reduced reboot behavior, confirmed
  reboot recovery is not required, and authorized stopping root
  terminal-supervisor development.
- Post-merge provisioning validated the merged architecture on a fresh VPS
  with exact dev bundle `v2026.08.12-923`; the disposable VPS was deleted after
  validation.

## Invariants

### Source of truth

The installed app payload marker is the production activation source of
truth. An explicitly set environment override has precedence. Runtime owner
descriptors and immutable generation records remain the runtime lifecycle
sources of truth established by #1129.

### Lock/transaction scope

No database writes or network calls are introduced. Activation is a bounded
startup read. The marker lives inside the same app payload that the supported
updater backs up and restores, so restoring a pre-activation app removes the
marker before the prior gateway starts.

### Acceptable orphan states

Missing, malformed, symlinked, unreadable, or non-file activation state fails
closed to the dormant adapter. Bundle update or rollback does not stop active
user terminal units; they remain pinned to immutable generations. Existing
legacy sessions are not adopted and must be drained before canary activation.

### Auth source of truth

No endpoint or authentication contract changes. The preview-only production
acceptance control remains restricted by the existing signed/HMAC preview
contract from #1129.

### Deferred scope

- Stable/channel promotion and customer-fleet deployment.
- Live legacy-session activation or migration.
- Reboot command/agent recovery and automatic terminal-unit restart.
- Patched-Zellij viewport or bounded scrollback resurrection after reboot.
- Typed updater and unrestricted-sudo removal; these remain independent
  security work.

## Review and rollout gates

- [x] Exact-head Preview VPS bundle built, registered without promotion,
  deployed to the disposable PR preview, and healthy.
- [x] Exact-head user-systemd production acceptance matrix green.
- [x] Latest trusted Greptile review is 5/5 on the frozen head.
- [x] Exact-head CI and Docker workflows green with feature-relevant jobs
  executed.
- [x] All review threads resolved (none opened).

### Intentional skips

- Preview Platform deploy/remove — skipped because this backend/host-bundle PR
  does not change the platform preview surface.
- Docs contract test execution — skipped because no canonical public-docs
  contract files changed; its classifier job passed.
- Docker full five-scenario matrix — skipped by workflow design on
  `pull_request`; exact-head PR image build and Docker smoke/scenario test
  executed and passed. The full matrix is reserved for push, schedule,
  workflow dispatch, and merge-group events.
- React Doctor project scan and screenshot evidence — no React or user-visible
  frontend changes.
