### PR TITLE
fix(desktop): surface Hermes chat failures

### DIFF
--- a/desktop/src/renderer/src/features/chat/ChatTab.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatTab.tsx
@@ -190,6 +190,7 @@ export default function ChatTab() {
   const threads = useThreads((s) => s.threads);
   const activeThreadId = useThreads((s) => s.activeThreadId);
   const setActiveThread = useThreads((s) => s.setActiveThread);
+  const newHermesChat = useHermesChat((s) => s.newChat);
   // Short-circuit inside the selector so a disabled workspace never re-renders
   // the rail on coding-agent store updates.
   const summary = useCodingAgentWorkspace((s) => (CODING_AGENTS_DESKTOP_WORKSPACE ? s.summary : null));
@@ -236,7 +237,10 @@ export default function ChatTab() {
             type="button"
             className="flex items-center gap-1.5 rounded-md px-2 py-1 text-sm hover:bg-[var(--bg-hover)]"
             style={{ color: "var(--text-secondary)" }}
-            onClick={() => setActiveThread(null)}
+            onClick={() => {
+              newHermesChat();
+              setActiveThread(null);
+            }}
             title="New chat with Hermes"
           >
             <MessageSquarePlus size={13} />

--- a/desktop/src/renderer/src/stores/hermes-chat.ts
+++ b/desktop/src/renderer/src/stores/hermes-chat.ts
@@ -115,7 +115,11 @@ export const useHermesChat = create<HermesChatState>()((set, get) => ({
       let status = state.status;
       let active: string | null = state.activeRequestId;
       if (event.type === "kernel:text") status = "streaming";
-      if (event.type === "kernel:result" || event.type === "kernel:error" || event.type === "kernel:aborted") {
+      if (matchesActiveRequest && (
+        event.type === "kernel:result"
+        || event.type === "kernel:error"
+        || event.type === "kernel:aborted"
+      )) {
         status = "idle";
         active = null;
       }

--- a/desktop/src/renderer/src/stores/hermes-chat.ts
+++ b/desktop/src/renderer/src/stores/hermes-chat.ts
@@ -83,14 +83,18 @@ export const useHermesChat = create<HermesChatState>()((set, get) => ({
   },
 
   ingest: (event) => {
-    // Bind the session from init/switch even before a request is active.
-    if (event.type === "kernel:init" && event.sessionId) {
-      set({ sessionId: event.sessionId });
-    }
     const { activeRequestId, messages } = get();
     const matchesActiveRequest = Boolean(
       activeRequestId && event.requestId === activeRequestId,
     );
+    // Only the current request may bind a resumable session. A late init from
+    // an aborted request must not resurrect the conversation after New.
+    if (event.type === "kernel:init") {
+      if (matchesActiveRequest && event.sessionId) {
+        set({ sessionId: event.sessionId });
+      }
+      return;
+    }
     // A provider can emit a terminal-looking result before its process exits
     // unsuccessfully. Preserve a later error when it belongs to a request that
     // is still visible, while ignoring stale errors after New clears the chat.

--- a/desktop/src/renderer/src/stores/hermes-chat.ts
+++ b/desktop/src/renderer/src/stores/hermes-chat.ts
@@ -83,13 +83,28 @@ export const useHermesChat = create<HermesChatState>()((set, get) => ({
   },
 
   ingest: (event) => {
-    const { activeRequestId } = get();
     // Bind the session from init/switch even before a request is active.
     if (event.type === "kernel:init" && event.sessionId) {
       set({ sessionId: event.sessionId });
     }
-    // Only fold events for the in-flight request into this transcript.
-    if (!activeRequestId || event.requestId !== activeRequestId) return;
+    const { activeRequestId, messages } = get();
+    const matchesActiveRequest = Boolean(
+      activeRequestId && event.requestId === activeRequestId,
+    );
+    // A provider can emit a terminal-looking result before its process exits
+    // unsuccessfully. Preserve a later error when it belongs to a request that
+    // is still visible, while ignoring stale errors after New clears the chat.
+    const matchesVisibleCompletedRequest = event.type === "kernel:error"
+      && typeof event.requestId === "string"
+      && messages.some((message) => (
+        message.role === "user" && message.requestId === event.requestId
+      ))
+      && !messages.some((message) => (
+        message.role === "system"
+        && !message.tool
+        && message.requestId === event.requestId
+      ));
+    if (!matchesActiveRequest && !matchesVisibleCompletedRequest) return;
 
     set((state) => {
       const messages = reduceChat(state.messages, event).slice(-TRANSCRIPT_CAP);

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -112,7 +112,10 @@ export async function* spawnKernel(
         if (msg.subtype === "success") {
           yield { type: "result", data: { ...base, result: msg.result } };
         } else {
-          yield { type: "result", data: { ...base, errors: msg.errors } };
+          // A non-success SDK result is a failed dispatch, not a successful
+          // terminal event. Keep provider details server-side; the gateway
+          // maps this generic failure to safe client copy.
+          throw new Error("Kernel query failed");
         }
       }
     }

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -27,6 +27,13 @@ export type KernelEvent =
   | { type: "result"; data: KernelResult }
   | { type: "aborted" };
 
+class KernelQueryFailedError extends Error {
+  constructor() {
+    super("Kernel query failed");
+    this.name = "KernelQueryFailedError";
+  }
+}
+
 export async function* spawnKernel(
   message: string,
   config: KernelConfig,
@@ -115,7 +122,11 @@ export async function* spawnKernel(
           // A non-success SDK result is a failed dispatch, not a successful
           // terminal event. Keep provider details server-side; the gateway
           // maps this generic failure to safe client copy.
-          throw new Error("Kernel query failed");
+          console.error("[kernel] Query returned a non-success result:", {
+            subtype: msg.subtype,
+            errors: msg.errors,
+          });
+          throw new KernelQueryFailedError();
         }
       }
     }
@@ -132,7 +143,7 @@ export async function* spawnKernel(
       return;
     }
     // If we were resuming a session and it failed, retry without resume
-    if (!retried && opts.resume) {
+    if (!retried && opts.resume && !(error instanceof KernelQueryFailedError)) {
       retried = true;
       const { resume: _, ...optsWithoutResume } = opts;
       yield* run(optsWithoutResume);

--- a/tests/desktop/chat-tab-render.test.tsx
+++ b/tests/desktop/chat-tab-render.test.tsx
@@ -122,6 +122,21 @@ describe("ChatTab", () => {
     expect(container.querySelector(".h-full.items-center.justify-center")).toBeNull();
   });
 
+  it("starts a fresh Hermes conversation from New", () => {
+    useHermesChat.setState({ sessionId: "session-1" });
+    render(<ChatTab />);
+
+    fireEvent.click(screen.getByRole("button", { name: "New" }));
+
+    expect(screen.queryByText("hello")).toBeNull();
+    expect(useHermesChat.getState()).toMatchObject({
+      messages: [],
+      sessionId: null,
+      status: "idle",
+      activeRequestId: null,
+    });
+  });
+
   it("renders connect cards with real lucide icons instead of placeholder squares", () => {
     useHermesChat.setState({ messages: [], status: "idle", send: vi.fn(), abort: vi.fn() });
     render(<ChatTab />);

--- a/tests/desktop/hermes-chat.test.ts
+++ b/tests/desktop/hermes-chat.test.ts
@@ -82,4 +82,31 @@ describe("useHermesChat", () => {
       ],
     });
   });
+
+  it("binds the kernel session only for the active request", () => {
+    useHermesChat.getState().send("hello");
+    const requestId = useHermesChat.getState().activeRequestId!;
+
+    useHermesChat.getState().ingest({
+      type: "kernel:init",
+      sessionId: "session-current",
+      requestId,
+    });
+
+    expect(useHermesChat.getState().sessionId).toBe("session-current");
+  });
+
+  it("ignores a late init after New clears the active request", () => {
+    useHermesChat.getState().send("hello");
+    const requestId = useHermesChat.getState().activeRequestId!;
+    useHermesChat.getState().newChat();
+
+    useHermesChat.getState().ingest({
+      type: "kernel:init",
+      sessionId: "session-stale",
+      requestId,
+    });
+
+    expect(useHermesChat.getState().sessionId).toBeNull();
+  });
 });

--- a/tests/desktop/hermes-chat.test.ts
+++ b/tests/desktop/hermes-chat.test.ts
@@ -83,6 +83,33 @@ describe("useHermesChat", () => {
     });
   });
 
+  it("keeps a newer request active when an older request reports a late error", () => {
+    useHermesChat.getState().send("first");
+    const firstRequestId = useHermesChat.getState().activeRequestId!;
+    useHermesChat.getState().ingest({
+      type: "kernel:result",
+      requestId: firstRequestId,
+    });
+
+    useHermesChat.getState().send("second");
+    const secondRequestId = useHermesChat.getState().activeRequestId!;
+    useHermesChat.getState().ingest({
+      type: "kernel:error",
+      message: "First request failed",
+      requestId: firstRequestId,
+    });
+
+    expect(useHermesChat.getState()).toMatchObject({
+      status: "thinking",
+      activeRequestId: secondRequestId,
+      messages: [
+        expect.objectContaining({ role: "user", content: "first", requestId: firstRequestId }),
+        expect.objectContaining({ role: "user", content: "second", requestId: secondRequestId }),
+        expect.objectContaining({ role: "system", content: "First request failed", requestId: firstRequestId }),
+      ],
+    });
+  });
+
   it("binds the kernel session only for the active request", () => {
     useHermesChat.getState().send("hello");
     const requestId = useHermesChat.getState().activeRequestId!;

--- a/tests/desktop/hermes-chat.test.ts
+++ b/tests/desktop/hermes-chat.test.ts
@@ -61,4 +61,25 @@ describe("useHermesChat", () => {
       activeRequestId: null,
     });
   });
+
+  it("shows a late error for the visible request after an earlier result event", () => {
+    useHermesChat.getState().send("hello");
+    const requestId = useHermesChat.getState().activeRequestId!;
+
+    useHermesChat.getState().ingest({ type: "kernel:result", requestId });
+    useHermesChat.getState().ingest({
+      type: "kernel:error",
+      message: "Request failed",
+      requestId,
+    });
+
+    expect(useHermesChat.getState()).toMatchObject({
+      status: "idle",
+      activeRequestId: null,
+      messages: [
+        expect.objectContaining({ role: "user", content: "hello", requestId }),
+        expect.objectContaining({ role: "system", content: "Request failed", requestId }),
+      ],
+    });
+  });
 });

--- a/tests/kernel/kernel-runtime.test.ts
+++ b/tests/kernel/kernel-runtime.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  kernelOptions: vi.fn(async () => ({})),
+  query: vi.fn(),
+}));
+
+vi.mock("../../packages/kernel/src/options.js", () => ({
+  kernelOptions: mocks.kernelOptions,
+}));
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: mocks.query,
+}));
+
+import { spawnKernel, type KernelEvent } from "../../packages/kernel/src/kernel.js";
+
+async function collectKernelEvents(): Promise<KernelEvent[]> {
+  const events: KernelEvent[] = [];
+  for await (const event of spawnKernel("hello", {
+    db: {} as never,
+    homePath: "/tmp/matrix-kernel-test",
+  })) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe("spawnKernel runtime results", () => {
+  beforeEach(() => {
+    mocks.kernelOptions.mockClear();
+    mocks.query.mockReset();
+  });
+
+  it("rejects a non-success SDK result instead of emitting successful completion", async () => {
+    mocks.query.mockReturnValue((async function* () {
+      yield { type: "system", subtype: "init", session_id: "session-1" };
+      yield {
+        type: "result",
+        subtype: "error_during_execution",
+        session_id: "session-1",
+        total_cost_usd: 0,
+        num_turns: 1,
+        usage: { input_tokens: 0, output_tokens: 0 },
+        errors: ["provider detail must stay server-side"],
+      };
+    })());
+
+    const events: KernelEvent[] = [];
+    await expect((async () => {
+      for await (const event of spawnKernel("hello", {
+        db: {} as never,
+        homePath: "/tmp/matrix-kernel-test",
+      })) {
+        events.push(event);
+      }
+    })()).rejects.toThrow("Kernel query failed");
+    expect(events).toEqual([{ type: "init", sessionId: "session-1" }]);
+  });
+
+  it("continues to emit a successful SDK result", async () => {
+    mocks.query.mockReturnValue((async function* () {
+      yield { type: "system", subtype: "init", session_id: "session-2" };
+      yield {
+        type: "result",
+        subtype: "success",
+        session_id: "session-2",
+        result: "done",
+        total_cost_usd: 0,
+        num_turns: 1,
+        usage: { input_tokens: 3, output_tokens: 2 },
+      };
+    })());
+
+    await expect(collectKernelEvents()).resolves.toEqual([
+      { type: "init", sessionId: "session-2" },
+      {
+        type: "result",
+        data: {
+          sessionId: "session-2",
+          result: "done",
+          cost: 0,
+          turns: 1,
+          tokensIn: 3,
+          tokensOut: 2,
+        },
+      },
+    ]);
+  });
+});

--- a/tests/kernel/kernel-runtime.test.ts
+++ b/tests/kernel/kernel-runtime.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SDKResultError } from "@anthropic-ai/claude-agent-sdk";
 
 const mocks = vi.hoisted(() => ({
   kernelOptions: vi.fn(async () => ({})),
@@ -28,23 +29,33 @@ async function collectKernelEvents(): Promise<KernelEvent[]> {
 
 describe("spawnKernel runtime results", () => {
   beforeEach(() => {
-    mocks.kernelOptions.mockClear();
+    mocks.kernelOptions.mockReset();
+    mocks.kernelOptions.mockResolvedValue({});
     mocks.query.mockReset();
   });
 
   it("rejects a non-success SDK result instead of emitting successful completion", async () => {
+    const errorResult = {
+      type: "result",
+      subtype: "error_during_execution",
+      session_id: "session-1",
+      uuid: "result-1",
+      duration_ms: 1,
+      duration_api_ms: 1,
+      is_error: true,
+      total_cost_usd: 0,
+      num_turns: 1,
+      stop_reason: null,
+      usage: { input_tokens: 0, output_tokens: 0 },
+      modelUsage: {},
+      permission_denials: [],
+      errors: ["provider detail must stay server-side"],
+    } satisfies SDKResultError;
     mocks.query.mockReturnValue((async function* () {
       yield { type: "system", subtype: "init", session_id: "session-1" };
-      yield {
-        type: "result",
-        subtype: "error_during_execution",
-        session_id: "session-1",
-        total_cost_usd: 0,
-        num_turns: 1,
-        usage: { input_tokens: 0, output_tokens: 0 },
-        errors: ["provider detail must stay server-side"],
-      };
+      yield errorResult;
     })());
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 
     const events: KernelEvent[] = [];
     await expect((async () => {
@@ -56,6 +67,34 @@ describe("spawnKernel runtime results", () => {
       }
     })()).rejects.toThrow("Kernel query failed");
     expect(events).toEqual([{ type: "init", sessionId: "session-1" }]);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[kernel] Query returned a non-success result:",
+      {
+        subtype: "error_during_execution",
+        errors: ["provider detail must stay server-side"],
+      },
+    );
+    consoleError.mockRestore();
+  });
+
+  it("does not retry a resumed session after a non-success SDK result", async () => {
+    mocks.kernelOptions.mockResolvedValue({ resume: "session-old" });
+    mocks.query.mockImplementation(() => (async function* () {
+      yield {
+        type: "result",
+        subtype: "error_during_execution",
+        session_id: "session-old",
+        total_cost_usd: 0,
+        num_turns: 1,
+        usage: { input_tokens: 0, output_tokens: 0 },
+        errors: ["provider failure"],
+      };
+    })());
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(collectKernelEvents()).rejects.toThrow("Kernel query failed");
+    expect(mocks.query).toHaveBeenCalledTimes(1);
+    consoleError.mockRestore();
   });
 
   it("continues to emit a successful SDK result", async () => {


### PR DESCRIPTION
## Summary

- make Desktop **New** reset the Hermes transcript and resumable session while aborting active work
- treat non-success Claude Agent SDK results as failures, with detailed server logging and generic client copy
- preserve late request failures without allowing stale init/error events to corrupt a new or newer active chat
- add regression coverage for the UI action, SDK result contract, resumed-session behavior, and cross-request races

## Root cause

The Desktop **New** button only cleared the selected rail item and never reset the Hermes store. Separately, the kernel classified every Claude SDK `result` message as successful, even when its subtype represented execution failure. Desktop could then clear the active request on the apparent success and discard or misapply the later failure event.

## Validation

- `flox activate -- bun run typecheck`
- `flox activate -- bun run check:patterns` — 0 violations; 5 pre-existing warning groups
- `flox activate -- bun run build:desktop`
- 60 focused Desktop, Kernel, and Gateway tests passed
- two-axis Spec and Standards review completed with no remaining findings
- full repository baseline: 10,645 passed, 20 skipped, 24 failed across 18 unrelated files due existing process timeouts, date-sensitive expectations, and UI module-import failures

## Invariants

### Source of truth
- The Desktop Hermes Zustand store is the renderer source of truth for the visible transcript, active request, and resumable kernel session ID.
- The kernel event stream remains the source of truth for provider lifecycle and completion status.

### Lock/transaction scope
- No database writes, locks, or transactions are added.
- Request isolation is enforced by matching each incoming event to its request ID before mutating active renderer state.

### Acceptable orphan states
- A provider process may emit a late terminal event after the renderer has started another request or cleared the chat.
- Late errors may be attached only to their still-visible original request; stale init events are ignored, and neither event can clear or resume newer work.

### Auth source of truth
- Authentication and provider credentials remain owned by the existing Gateway/kernel credential flow.
- This change does not alter auth, credential storage, or fallback behavior.

### Deferred scope
- Provider installation/login UX and Hermes provider selection are unchanged.
- Manual validation against a deployed VPS remains a post-review step.

Linear: [MAT-297](https://linear.app/matrix-os/issue/MAT-297/fix-desktop-hermes-chat-failures-and-new-action)
