### PR TITLE
test(desktop): add handoff regression matrix

### DIFF
--- a/tests/desktop/handoff-regression-matrix.test.ts
+++ b/tests/desktop/handoff-regression-matrix.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   HANDOFF_REGRESSION_MATRIX,
@@ -39,7 +41,7 @@ const REQUIRED_PER_SURFACE: HandoffRequirement[] = [
 ];
 
 describe("Desktop handoff regression matrix", () => {
-  it("covers every handoff surface and required cross-surface QA dimension", () => {
+  it("documents every handoff dimension with an explicit verification disposition", () => {
     expect(() => assertHandoffMatrixCoverage(HANDOFF_REGRESSION_MATRIX)).not.toThrow();
 
     for (const surface of SURFACES) {
@@ -50,6 +52,20 @@ describe("Desktop handoff regression matrix", () => {
       );
       for (const requirement of REQUIRED_PER_SURFACE) {
         expect(covered.has(requirement), `${surface}:${requirement}`).toBe(true);
+      }
+    }
+
+    for (const scenario of HANDOFF_REGRESSION_MATRIX) {
+      if (scenario.verification === "automated") {
+        expect(scenario.evidence.length, scenario.id).toBeGreaterThan(0);
+        for (const evidence of scenario.evidence) {
+          const source = readFileSync(resolve(evidence.file), "utf8");
+          expect(source, `${scenario.id}:${evidence.testName}`).toContain(
+            `it("${evidence.testName}"`,
+          );
+        }
+      } else {
+        expect(scenario.note.trim().length, scenario.id).toBeGreaterThan(0);
       }
     }
   });

--- a/tests/desktop/handoff-regression-matrix.test.ts
+++ b/tests/desktop/handoff-regression-matrix.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  HANDOFF_REGRESSION_MATRIX,
+  assertHandoffMatrixCoverage,
+  type HandoffRequirement,
+  type HandoffSurface,
+} from "../e2e/desktop/handoff-regression-matrix";
+
+const SURFACES: HandoffSurface[] = ["navigation", "chat", "terminal", "files"];
+const REQUIRED_PER_SURFACE: HandoffRequirement[] = [
+  "first-load",
+  "loading",
+  "ready",
+  "empty",
+  "search-empty",
+  "offline",
+  "reconnecting",
+  "error",
+  "retry",
+  "runtime-switch",
+  "auth-replacement",
+  "sign-out",
+  "reconnect",
+  "stale-live-resource",
+  "light-theme",
+  "dark-theme",
+  "default-window",
+  "narrow-window",
+  "resize",
+  "zoom",
+  "keyboard-navigation",
+  "focus-restoration",
+  "screen-reader-names",
+  "reduced-motion",
+  "contrast",
+  "long-content",
+  "bounded-errors",
+  "electron",
+];
+
+describe("Desktop handoff regression matrix", () => {
+  it("covers every handoff surface and required cross-surface QA dimension", () => {
+    expect(() => assertHandoffMatrixCoverage(HANDOFF_REGRESSION_MATRIX)).not.toThrow();
+
+    for (const surface of SURFACES) {
+      const covered = new Set(
+        HANDOFF_REGRESSION_MATRIX
+          .filter((scenario) => scenario.surface === surface)
+          .flatMap((scenario) => scenario.requirements),
+      );
+      for (const requirement of REQUIRED_PER_SURFACE) {
+        expect(covered.has(requirement), `${surface}:${requirement}`).toBe(true);
+      }
+    }
+  });
+
+  it("reports actionable missing coverage instead of silently accepting a partial matrix", () => {
+    const withoutFiles = HANDOFF_REGRESSION_MATRIX.filter(
+      (scenario) => scenario.surface !== "files",
+    );
+
+    expect(() => assertHandoffMatrixCoverage(withoutFiles)).toThrow(
+      /surface:files/,
+    );
+  });
+
+  it("keeps blocked feature semantics assigned to their owning dependency", () => {
+    const dependencyOwners = new Set(
+      HANDOFF_REGRESSION_MATRIX
+        .filter((scenario) => scenario.execution === "dependency")
+        .map((scenario) => scenario.owner),
+    );
+
+    expect(dependencyOwners).toEqual(
+      new Set(["MAT-298", "MAT-299", "MAT-300", "MAT-301"]),
+    );
+    expect(
+      HANDOFF_REGRESSION_MATRIX.some((scenario) => scenario.owner === "MAT-268"),
+    ).toBe(false);
+  });
+});

--- a/tests/e2e/desktop/handoff-electron-baseline.ts
+++ b/tests/e2e/desktop/handoff-electron-baseline.ts
@@ -1,0 +1,124 @@
+import type { Page } from "playwright";
+
+const NAVIGATION_NAMES = ["Home", "Chat", "Terminal", "Files"] as const;
+
+export interface DesktopHandoffBaselineEvidence {
+  navigationNames: string[];
+  focusTargets: Record<(typeof NAVIGATION_NAMES)[number], string>;
+  hiddenPanesMissingInert: number;
+  narrowViewport: {
+    width: number;
+    hasHorizontalDocumentOverflow: boolean;
+  };
+  reducedMotion: "no-preference" | "reduce";
+}
+
+async function ensureSignedIn(page: Page): Promise<void> {
+  const continueButton = page.getByRole("button", {
+    name: /continue in browser/i,
+  });
+  const terminalNavigation = page
+    .locator("aside button", { hasText: "Terminal" })
+    .first();
+  const bootState = await Promise.race([
+    continueButton
+      .waitFor({ state: "visible", timeout: 15_000 })
+      .then(() => "signed-out" as const),
+    terminalNavigation
+      .waitFor({ state: "visible", timeout: 15_000 })
+      .then(() => "signed-in" as const),
+  ]);
+  if (bootState === "signed-out") {
+    await continueButton.click();
+  }
+  await terminalNavigation.waitFor({ timeout: 15_000 });
+}
+
+async function waitForSurface(page: Page, name: (typeof NAVIGATION_NAMES)[number]) {
+  switch (name) {
+    case "Home":
+      await page.locator("aside").waitFor();
+      return;
+    case "Chat":
+      await page
+        .getByRole("region", { name: "Hermes conversation" })
+        .waitFor({ timeout: 10_000 });
+      return;
+    case "Terminal":
+      await page.getByText("Shells").first().waitFor({ timeout: 10_000 });
+      await page.getByLabel("Terminal input").waitFor({ timeout: 10_000 });
+      return;
+    case "Files":
+      await page
+        .getByRole("heading", { name: "Files" })
+        .waitFor({ timeout: 10_000 });
+  }
+}
+
+export async function inspectDesktopHandoffBaseline(
+  page: Page,
+): Promise<DesktopHandoffBaselineEvidence> {
+  await ensureSignedIn(page);
+  await page.emulateMedia({ reducedMotion: "reduce" });
+
+  const navigationNames: string[] = [];
+  const focusTargets = {
+    Home: "",
+    Chat: "",
+    Terminal: "",
+    Files: "",
+  };
+
+  for (const name of NAVIGATION_NAMES) {
+    const button = page
+      .locator("aside")
+      .getByRole("button", { name, exact: true })
+      .first();
+    await button.waitFor({ state: "visible" });
+    navigationNames.push(name);
+    await button.focus();
+    await page.keyboard.press("Enter");
+    await waitForSurface(page, name);
+    focusTargets[name] = await page.evaluate(() => {
+      const active = document.activeElement;
+      if (!(active instanceof HTMLElement)) return "";
+      return (
+        active.getAttribute("aria-label") ??
+        active.getAttribute("placeholder") ??
+        active.textContent?.trim() ??
+        ""
+      );
+    });
+  }
+
+  const hiddenPanesMissingInert = await page.evaluate(
+    () =>
+      document.querySelectorAll(
+        '[aria-hidden="true"][style*="visibility: hidden"]:not([inert])',
+      ).length,
+  );
+
+  await page.setViewportSize({ width: 820, height: 720 });
+  const narrowViewport = await page.evaluate(() => ({
+    width: window.innerWidth,
+    hasHorizontalDocumentOverflow:
+      document.documentElement.scrollWidth >
+      document.documentElement.clientWidth,
+  }));
+  const reducedMotion = await page.evaluate(() =>
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      ? "reduce"
+      : "no-preference",
+  );
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.emulateMedia({ reducedMotion: "no-preference" });
+
+  return {
+    navigationNames,
+    focusTargets,
+    hiddenPanesMissingInert,
+    narrowViewport,
+    reducedMotion,
+  };
+}

--- a/tests/e2e/desktop/handoff-electron-baseline.ts
+++ b/tests/e2e/desktop/handoff-electron-baseline.ts
@@ -48,8 +48,9 @@ async function waitForSurface(page: Page, name: (typeof NAVIGATION_NAMES)[number
         .waitFor({ timeout: 10_000 });
       return;
     case "Terminal":
-      await page.getByText("Shells").first().waitFor({ timeout: 10_000 });
-      await page.getByLabel("Terminal input").waitFor({ timeout: 10_000 });
+      await page
+        .getByRole("heading", { name: "Terminal" })
+        .waitFor({ timeout: 10_000 });
       return;
     case "Files":
       await page

--- a/tests/e2e/desktop/handoff-electron-baseline.ts
+++ b/tests/e2e/desktop/handoff-electron-baseline.ts
@@ -41,7 +41,10 @@ async function waitForSurface(page: Page, name: (typeof NAVIGATION_NAMES)[number
       return;
     case "Chat":
       await page
-        .getByRole("region", { name: "Hermes conversation" })
+        .locator(
+          '[role="region"][aria-label="Hermes conversation"], #conversation-index-title',
+        )
+        .first()
         .waitFor({ timeout: 10_000 });
       return;
     case "Terminal":

--- a/tests/e2e/desktop/handoff-electron-baseline.ts
+++ b/tests/e2e/desktop/handoff-electron-baseline.ts
@@ -5,6 +5,8 @@ const NAVIGATION_NAMES = ["Home", "Chat", "Terminal", "Files"] as const;
 export interface DesktopHandoffBaselineEvidence {
   navigationNames: string[];
   focusTargets: Record<(typeof NAVIGATION_NAMES)[number], string>;
+  historyTargets: { back: string; forward: string } | null;
+  recentConversationTarget: string | null;
   hiddenPanesMissingInert: number;
   narrowViewport: {
     width: number;
@@ -48,9 +50,12 @@ async function waitForSurface(page: Page, name: (typeof NAVIGATION_NAMES)[number
         .waitFor({ timeout: 10_000 });
       return;
     case "Terminal":
-      await page
-        .getByRole("heading", { name: "Terminal" })
-        .waitFor({ timeout: 10_000 });
+      await Promise.race([
+        page
+          .getByRole("heading", { name: "Terminal" })
+          .waitFor({ timeout: 10_000 }),
+        page.getByText("Shells").first().waitFor({ timeout: 10_000 }),
+      ]);
       return;
     case "Files":
       await page
@@ -95,6 +100,32 @@ export async function inspectDesktopHandoffBaseline(
     });
   }
 
+  let historyTargets: DesktopHandoffBaselineEvidence["historyTargets"] = null;
+  const hasCombinedNavigation =
+    (await page.getByRole("navigation", { name: "Breadcrumb" }).count()) > 0;
+  const goBack = page.getByRole("button", { name: "Go back" });
+  if ((await goBack.count()) > 0 && await goBack.isEnabled()) {
+    await goBack.click();
+    await waitForSurface(page, "Terminal");
+    await page.getByRole("button", { name: "Go forward" }).click();
+    await waitForSurface(page, "Files");
+    historyTargets = { back: "Terminal", forward: "Files" };
+  } else if (hasCombinedNavigation) {
+    throw new Error("Combined Desktop navigation did not expose usable Back/Forward history");
+  }
+
+  let recentConversationTarget: string | null = null;
+  const recentConversation = page.getByRole("button", {
+    name: "Open recent Hermes",
+  });
+  if ((await recentConversation.count()) > 0) {
+    await recentConversation.click();
+    await waitForSurface(page, "Chat");
+    recentConversationTarget = "Conversations";
+  } else if (hasCombinedNavigation) {
+    throw new Error("Combined Desktop navigation did not expose the Hermes Recent");
+  }
+
   const hiddenPanesMissingInert = await page.evaluate(
     () =>
       document.querySelectorAll(
@@ -121,6 +152,8 @@ export async function inspectDesktopHandoffBaseline(
   return {
     navigationNames,
     focusTargets,
+    historyTargets,
+    recentConversationTarget,
     hiddenPanesMissingInert,
     narrowViewport,
     reducedMotion,

--- a/tests/e2e/desktop/handoff-regression-matrix.ts
+++ b/tests/e2e/desktop/handoff-regression-matrix.ts
@@ -1,6 +1,7 @@
 export type HandoffSurface = "navigation" | "chat" | "terminal" | "files";
 export type HandoffOwner = "MAT-298" | "MAT-299" | "MAT-300" | "MAT-301" | "MAT-302";
 export type HandoffExecution = "baseline" | "dependency" | "combined-head";
+export type HandoffVerification = "automated" | "manual" | "deferred";
 
 export type HandoffRequirement =
   | "first-load"
@@ -44,7 +45,12 @@ export type HandoffRequirement =
   | "shutdown-drain"
   | "electron";
 
-export interface HandoffRegressionScenario {
+export interface HandoffTestEvidence {
+  file: string;
+  testName: string;
+}
+
+interface HandoffRegressionScenarioBase {
   id: string;
   surface: HandoffSurface;
   owner: HandoffOwner;
@@ -53,6 +59,19 @@ export interface HandoffRegressionScenario {
   requirements: readonly HandoffRequirement[];
   assertion: string;
 }
+
+export type HandoffRegressionScenario = HandoffRegressionScenarioBase & (
+  | {
+      verification: "automated";
+      evidence: readonly HandoffTestEvidence[];
+      note?: never;
+    }
+  | {
+      verification: "manual" | "deferred";
+      evidence?: never;
+      note: string;
+    }
+);
 
 const COMMON_STATE_REQUIREMENTS: readonly HandoffRequirement[] = [
   "first-load",
@@ -81,7 +100,6 @@ const ACCESSIBILITY_REQUIREMENTS: readonly HandoffRequirement[] = [
   "focus-restoration",
   "screen-reader-names",
   "reduced-motion",
-  "contrast",
 ];
 
 const VISUAL_REQUIREMENTS: readonly HandoffRequirement[] = [
@@ -90,7 +108,11 @@ const VISUAL_REQUIREMENTS: readonly HandoffRequirement[] = [
   "default-window",
   "narrow-window",
   "resize",
+];
+
+const MANUAL_VISUAL_REQUIREMENTS: readonly HandoffRequirement[] = [
   "zoom",
+  "contrast",
 ];
 
 const PER_SURFACE_REQUIREMENTS: readonly HandoffRequirement[] = [
@@ -98,6 +120,7 @@ const PER_SURFACE_REQUIREMENTS: readonly HandoffRequirement[] = [
   ...IDENTITY_REQUIREMENTS,
   ...ACCESSIBILITY_REQUIREMENTS,
   ...VISUAL_REQUIREMENTS,
+  ...MANUAL_VISUAL_REQUIREMENTS,
   "electron",
 ];
 
@@ -116,12 +139,27 @@ const GLOBAL_REQUIREMENTS: readonly HandoffRequirement[] = [
   "shutdown-drain",
 ];
 
+function testEvidence(file: string, testName: string): HandoffTestEvidence {
+  return { file, testName };
+}
+
 export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
   {
     id: "navigation-states",
     surface: "navigation",
     owner: "MAT-301",
     execution: "dependency",
+    verification: "automated",
+    evidence: [
+      testEvidence(
+        "tests/desktop/sidebar-navigation-shell.test.tsx",
+        "filters bounded Recents by conversation, terminal, and project type",
+      ),
+      testEvidence(
+        "tests/desktop/sidebar-navigation-shell.test.tsx",
+        "offers the approved account actions and routes them through current behavior",
+      ),
+    ],
     figmaNode: "67:4368",
     requirements: COMMON_STATE_REQUIREMENTS,
     assertion: "Navigation, Recents filtering, account actions, and retry states use bounded generic copy.",
@@ -131,6 +169,13 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
     surface: "navigation",
     owner: "MAT-301",
     execution: "dependency",
+    verification: "automated",
+    evidence: [
+      testEvidence(
+        "tests/e2e/desktop/operator.e2e.test.ts",
+        "keeps the handoff surfaces named, keyboard reachable, and resize safe",
+      ),
+    ],
     figmaNode: "67:4368",
     requirements: ACCESSIBILITY_REQUIREMENTS,
     assertion: "Sidebar, history, breadcrumbs, Recents, and account menu remain named and keyboard operable.",
@@ -140,6 +185,17 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
     surface: "navigation",
     owner: "MAT-302",
     execution: "combined-head",
+    verification: "automated",
+    evidence: [
+      testEvidence(
+        "tests/desktop/runtime-transition.test.ts",
+        "atomically removes identifiers and attachments owned by the previous computer",
+      ),
+      testEvidence(
+        "tests/desktop/sidebar-navigation-shell.test.tsx",
+        "opens a canonical Hermes recent through the Gateway-backed loader",
+      ),
+    ],
     requirements: [
       ...IDENTITY_REQUIREMENTS,
       "canonical-navigation",
@@ -155,6 +211,17 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
     surface: "navigation",
     owner: "MAT-302",
     execution: "baseline",
+    verification: "automated",
+    evidence: [
+      testEvidence(
+        "tests/e2e/desktop/operator.e2e.test.ts",
+        "keeps the handoff surfaces named, keyboard reachable, and resize safe",
+      ),
+      testEvidence(
+        "tests/e2e/desktop/operator.e2e.test.ts",
+        "switches unified themes from Appearance settings",
+      ),
+    ],
     requirements: [
       ...VISUAL_REQUIREMENTS,
       "sidebar-collapse",
@@ -164,10 +231,31 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
     assertion: "The built Electron shell preserves named navigation and usable chrome across supported window sizes.",
   },
   {
+    id: "navigation-manual-visual-audit",
+    surface: "navigation",
+    owner: "MAT-302",
+    execution: "baseline",
+    verification: "manual",
+    requirements: MANUAL_VISUAL_REQUIREMENTS,
+    assertion: "Zoom and contrast require a human comparison against the approved Figma handoff.",
+    note: "macOS screenshots were inspected; automated pixel and contrast thresholds are not implemented.",
+  },
+  {
     id: "chat-states",
     surface: "chat",
     owner: "MAT-299",
     execution: "dependency",
+    verification: "automated",
+    evidence: [
+      testEvidence(
+        "tests/desktop/chat-tab-render.test.tsx",
+        "shows loading, empty, and safe recovery states for conversation discovery",
+      ),
+      testEvidence(
+        "tests/desktop/hermes-chat.test.ts",
+        "keeps the current conversation visible when switching fails",
+      ),
+    ],
     figmaNode: "67:4472",
     requirements: [
       ...COMMON_STATE_REQUIREMENTS,
@@ -184,6 +272,17 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
     surface: "chat",
     owner: "MAT-299",
     execution: "dependency",
+    verification: "automated",
+    evidence: [
+      testEvidence(
+        "tests/desktop/hermes-conversation-index.test.tsx",
+        "keeps row opening separate from the hover and focus delete action",
+      ),
+      testEvidence(
+        "tests/desktop/chat-tab-render.test.tsx",
+        "opens the selected canonical conversation and exposes a Chat breadcrumb",
+      ),
+    ],
     figmaNode: "67:4472",
     requirements: ACCESSIBILITY_REQUIREMENTS,
     assertion: "Conversation switching, messages, tools, attachments, and composer expose deterministic focus and names.",
@@ -193,6 +292,17 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
     surface: "chat",
     owner: "MAT-302",
     execution: "combined-head",
+    verification: "automated",
+    evidence: [
+      testEvidence(
+        "tests/desktop/runtime-transition.test.ts",
+        "discards a conversation index response that settles after the computer changes",
+      ),
+      testEvidence(
+        "tests/desktop/hermes-chat.test.ts",
+        "allowlists delete errors and discards a late success after runtime reset",
+      ),
+    ],
     requirements: [...IDENTITY_REQUIREMENTS, "mounted-resource", "shutdown-drain"],
     assertion: "Late history and stream events cannot repopulate a replaced runtime or authentication generation.",
   },
@@ -201,14 +311,46 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
     surface: "chat",
     owner: "MAT-302",
     execution: "baseline",
+    verification: "automated",
+    evidence: [
+      testEvidence(
+        "tests/e2e/desktop/operator.e2e.test.ts",
+        "keeps the handoff surfaces named, keyboard reachable, and resize safe",
+      ),
+      testEvidence(
+        "tests/e2e/desktop/hermes-conversations.e2e.test.ts",
+        "discovers, switches, searches, deletes, and restores canonical conversations",
+      ),
+    ],
     requirements: [...VISUAL_REQUIREMENTS, "electron"],
     assertion: "Chat remains reachable by accessible name and usable after live Electron resize and theme changes.",
+  },
+  {
+    id: "chat-manual-visual-audit",
+    surface: "chat",
+    owner: "MAT-302",
+    execution: "baseline",
+    verification: "manual",
+    requirements: MANUAL_VISUAL_REQUIREMENTS,
+    assertion: "Chat zoom and contrast require a human comparison against the approved Figma handoff.",
+    note: "Figma nodes 145:2309 and 67:4551 were inspected directly; automated pixel and contrast thresholds are not implemented.",
   },
   {
     id: "terminal-states",
     surface: "terminal",
     owner: "MAT-300",
     execution: "dependency",
+    verification: "automated",
+    evidence: [
+      testEvidence(
+        "tests/desktop/terminals-tab.test.tsx",
+        "renders canonical active, waiting, and closed lifecycle badges with relative activity",
+      ),
+      testEvidence(
+        "tests/desktop/terminals-tab.test.tsx",
+        "bounds loading and load-error states in the list surface",
+      ),
+    ],
     figmaNode: "67:5290",
     requirements: [
       ...COMMON_STATE_REQUIREMENTS,
@@ -225,6 +367,17 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
     surface: "terminal",
     owner: "MAT-300",
     execution: "dependency",
+    verification: "automated",
+    evidence: [
+      testEvidence(
+        "tests/desktop/terminals-tab.test.tsx",
+        "keeps secondary row actions in an accessible overflow menu",
+      ),
+      testEvidence(
+        "tests/desktop/terminals-tab.test.tsx",
+        "uses the Figma list toolbar and reveals a bounded search-empty state",
+      ),
+    ],
     figmaNode: "67:5290",
     requirements: ACCESSIBILITY_REQUIREMENTS,
     assertion: "Session actions and detail controls remain named, keyboard operable, and focus-visible.",
@@ -234,6 +387,17 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
     surface: "terminal",
     owner: "MAT-302",
     execution: "combined-head",
+    verification: "automated",
+    evidence: [
+      testEvidence(
+        "tests/desktop/runtime-transition.test.ts",
+        "discards an in-flight shell create that settles after the computer changes",
+      ),
+      testEvidence(
+        "tests/desktop/shell-sessions-store.test.ts",
+        "drops a reorder response that settles after a runtime switch",
+      ),
+    ],
     requirements: [...IDENTITY_REQUIREMENTS, "mounted-resource", "shutdown-drain"],
     assertion: "Navigation preserves the intended live attachment, while runtime and auth changes drain the old one.",
   },
@@ -242,14 +406,46 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
     surface: "terminal",
     owner: "MAT-302",
     execution: "baseline",
+    verification: "automated",
+    evidence: [
+      testEvidence(
+        "tests/e2e/desktop/terminal-sessions.e2e.test.ts",
+        "renders the Figma-aligned list and preserves the mounted terminal buffer across list-detail navigation",
+      ),
+      testEvidence(
+        "tests/e2e/desktop/operator.e2e.test.ts",
+        "switches unified themes from Appearance settings",
+      ),
+    ],
     requirements: [...VISUAL_REQUIREMENTS, "electron"],
-    assertion: "Terminal list/detail remains reachable and fitted after Electron resize, zoom, and theme changes.",
+    assertion: "Terminal list/detail remains reachable and fitted after Electron resize and theme changes.",
+  },
+  {
+    id: "terminal-manual-visual-audit",
+    surface: "terminal",
+    owner: "MAT-302",
+    execution: "baseline",
+    verification: "manual",
+    requirements: MANUAL_VISUAL_REQUIREMENTS,
+    assertion: "Terminal zoom and contrast require a human comparison against the approved Figma handoff.",
+    note: "macOS list/detail screenshots were inspected; automated pixel and contrast thresholds are not implemented.",
   },
   {
     id: "files-states",
     surface: "files",
     owner: "MAT-298",
     execution: "dependency",
+    verification: "automated",
+    evidence: [
+      testEvidence(
+        "tests/desktop/files-workspace.test.tsx",
+        "shows the designed empty-folder preview state",
+      ),
+      testEvidence(
+        "tests/desktop/files-workspace.test.tsx",
+        "retries a recoverable preview failure in place",
+      ),
+    ],
     figmaNode: "67:5663",
     requirements: COMMON_STATE_REQUIREMENTS,
     assertion: "Listing and preview cover loading, empty, unsupported, oversized, offline, error, and retry states.",
@@ -259,6 +455,13 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
     surface: "files",
     owner: "MAT-298",
     execution: "dependency",
+    verification: "automated",
+    evidence: [
+      testEvidence(
+        "tests/desktop/files-workspace.test.tsx",
+        "enters directories with the keyboard",
+      ),
+    ],
     figmaNode: "67:5663",
     requirements: ACCESSIBILITY_REQUIREMENTS,
     assertion: "List/grid navigation, sorting, breadcrumbs, upload, selection, and preview actions expose stable names.",
@@ -268,6 +471,17 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
     surface: "files",
     owner: "MAT-302",
     execution: "combined-head",
+    verification: "automated",
+    evidence: [
+      testEvidence(
+        "tests/desktop/files-workspace.test.tsx",
+        "clears the file preview and issues no stale request when the selected computer changes",
+      ),
+      testEvidence(
+        "tests/desktop/files-workspace.test.tsx",
+        "clears the preview when the session identity changes on the same computer",
+      ),
+    ],
     requirements: [...IDENTITY_REQUIREMENTS, "shutdown-drain"],
     assertion: "Selection, listing, preview, and late responses cannot cross a runtime or authentication boundary.",
   },
@@ -276,8 +490,29 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
     surface: "files",
     owner: "MAT-302",
     execution: "baseline",
+    verification: "automated",
+    evidence: [
+      testEvidence(
+        "tests/e2e/desktop/files-handoff.e2e.test.ts",
+        "captures the full-width list and grid overview states",
+      ),
+      testEvidence(
+        "tests/e2e/desktop/operator.e2e.test.ts",
+        "keeps the handoff surfaces named, keyboard reachable, and resize safe",
+      ),
+    ],
     requirements: [...VISUAL_REQUIREMENTS, "electron"],
-    assertion: "List/grid and preview panes remain reachable after Electron resize, zoom, and theme changes.",
+    assertion: "List/grid and preview panes remain reachable after Electron resize and theme changes.",
+  },
+  {
+    id: "files-manual-visual-audit",
+    surface: "files",
+    owner: "MAT-302",
+    execution: "baseline",
+    verification: "manual",
+    requirements: MANUAL_VISUAL_REQUIREMENTS,
+    assertion: "Files zoom and contrast require a human comparison against the approved Figma handoff.",
+    note: "macOS Files screenshots were inspected; automated pixel and contrast thresholds are not implemented.",
   },
 ];
 
@@ -299,6 +534,13 @@ export function assertHandoffMatrixCoverage(
     ids.add(scenario.id);
     if (scenario.assertion.trim().length === 0) {
       missing.push(`assertion:${scenario.id}`);
+    }
+    if (scenario.verification === "automated") {
+      if (scenario.evidence.length === 0) {
+        missing.push(`evidence:${scenario.id}`);
+      }
+    } else if (scenario.note.trim().length === 0) {
+      missing.push(`note:${scenario.id}`);
     }
   }
 

--- a/tests/e2e/desktop/handoff-regression-matrix.ts
+++ b/tests/e2e/desktop/handoff-regression-matrix.ts
@@ -1,0 +1,327 @@
+export type HandoffSurface = "navigation" | "chat" | "terminal" | "files";
+export type HandoffOwner = "MAT-298" | "MAT-299" | "MAT-300" | "MAT-301" | "MAT-302";
+export type HandoffExecution = "baseline" | "dependency" | "combined-head";
+
+export type HandoffRequirement =
+  | "first-load"
+  | "loading"
+  | "ready"
+  | "empty"
+  | "search-empty"
+  | "offline"
+  | "reconnecting"
+  | "error"
+  | "retry"
+  | "active"
+  | "idle"
+  | "waiting"
+  | "completed"
+  | "stopped"
+  | "stale-live-resource"
+  | "runtime-switch"
+  | "auth-replacement"
+  | "sign-out"
+  | "reconnect"
+  | "light-theme"
+  | "dark-theme"
+  | "default-window"
+  | "narrow-window"
+  | "sidebar-collapse"
+  | "resize"
+  | "zoom"
+  | "macos-titlebar"
+  | "keyboard-navigation"
+  | "focus-restoration"
+  | "screen-reader-names"
+  | "reduced-motion"
+  | "contrast"
+  | "long-content"
+  | "bounded-errors"
+  | "canonical-navigation"
+  | "back-forward"
+  | "recents"
+  | "mounted-resource"
+  | "shutdown-drain"
+  | "electron";
+
+export interface HandoffRegressionScenario {
+  id: string;
+  surface: HandoffSurface;
+  owner: HandoffOwner;
+  execution: HandoffExecution;
+  figmaNode?: string;
+  requirements: readonly HandoffRequirement[];
+  assertion: string;
+}
+
+const COMMON_STATE_REQUIREMENTS: readonly HandoffRequirement[] = [
+  "first-load",
+  "loading",
+  "ready",
+  "empty",
+  "search-empty",
+  "offline",
+  "reconnecting",
+  "error",
+  "retry",
+  "long-content",
+  "bounded-errors",
+];
+
+const IDENTITY_REQUIREMENTS: readonly HandoffRequirement[] = [
+  "runtime-switch",
+  "auth-replacement",
+  "sign-out",
+  "reconnect",
+  "stale-live-resource",
+];
+
+const ACCESSIBILITY_REQUIREMENTS: readonly HandoffRequirement[] = [
+  "keyboard-navigation",
+  "focus-restoration",
+  "screen-reader-names",
+  "reduced-motion",
+  "contrast",
+];
+
+const VISUAL_REQUIREMENTS: readonly HandoffRequirement[] = [
+  "light-theme",
+  "dark-theme",
+  "default-window",
+  "narrow-window",
+  "resize",
+  "zoom",
+];
+
+const PER_SURFACE_REQUIREMENTS: readonly HandoffRequirement[] = [
+  ...COMMON_STATE_REQUIREMENTS,
+  ...IDENTITY_REQUIREMENTS,
+  ...ACCESSIBILITY_REQUIREMENTS,
+  ...VISUAL_REQUIREMENTS,
+  "electron",
+];
+
+const GLOBAL_REQUIREMENTS: readonly HandoffRequirement[] = [
+  "active",
+  "idle",
+  "waiting",
+  "completed",
+  "stopped",
+  "sidebar-collapse",
+  "macos-titlebar",
+  "canonical-navigation",
+  "back-forward",
+  "recents",
+  "mounted-resource",
+  "shutdown-drain",
+];
+
+export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
+  {
+    id: "navigation-states",
+    surface: "navigation",
+    owner: "MAT-301",
+    execution: "dependency",
+    figmaNode: "67:4368",
+    requirements: COMMON_STATE_REQUIREMENTS,
+    assertion: "Navigation, Recents filtering, account actions, and retry states use bounded generic copy.",
+  },
+  {
+    id: "navigation-accessibility",
+    surface: "navigation",
+    owner: "MAT-301",
+    execution: "dependency",
+    figmaNode: "67:4368",
+    requirements: ACCESSIBILITY_REQUIREMENTS,
+    assertion: "Sidebar, history, breadcrumbs, Recents, and account menu remain named and keyboard operable.",
+  },
+  {
+    id: "navigation-identity",
+    surface: "navigation",
+    owner: "MAT-302",
+    execution: "combined-head",
+    requirements: [
+      ...IDENTITY_REQUIREMENTS,
+      "canonical-navigation",
+      "back-forward",
+      "recents",
+      "mounted-resource",
+      "shutdown-drain",
+    ],
+    assertion: "History and Recents never retain prior-computer identities while cached resources follow lifecycle rules.",
+  },
+  {
+    id: "navigation-visual-electron",
+    surface: "navigation",
+    owner: "MAT-302",
+    execution: "baseline",
+    requirements: [
+      ...VISUAL_REQUIREMENTS,
+      "sidebar-collapse",
+      "macos-titlebar",
+      "electron",
+    ],
+    assertion: "The built Electron shell preserves named navigation and usable chrome across supported window sizes.",
+  },
+  {
+    id: "chat-states",
+    surface: "chat",
+    owner: "MAT-299",
+    execution: "dependency",
+    figmaNode: "67:4472",
+    requirements: [
+      ...COMMON_STATE_REQUIREMENTS,
+      "active",
+      "idle",
+      "waiting",
+      "completed",
+      "stopped",
+    ],
+    assertion: "Conversation index, history, composer, stop, error, offline, and recovery states remain bounded.",
+  },
+  {
+    id: "chat-accessibility",
+    surface: "chat",
+    owner: "MAT-299",
+    execution: "dependency",
+    figmaNode: "67:4472",
+    requirements: ACCESSIBILITY_REQUIREMENTS,
+    assertion: "Conversation switching, messages, tools, attachments, and composer expose deterministic focus and names.",
+  },
+  {
+    id: "chat-identity",
+    surface: "chat",
+    owner: "MAT-302",
+    execution: "combined-head",
+    requirements: [...IDENTITY_REQUIREMENTS, "mounted-resource", "shutdown-drain"],
+    assertion: "Late history and stream events cannot repopulate a replaced runtime or authentication generation.",
+  },
+  {
+    id: "chat-visual-electron",
+    surface: "chat",
+    owner: "MAT-302",
+    execution: "baseline",
+    requirements: [...VISUAL_REQUIREMENTS, "electron"],
+    assertion: "Chat remains reachable by accessible name and usable after live Electron resize and theme changes.",
+  },
+  {
+    id: "terminal-states",
+    surface: "terminal",
+    owner: "MAT-300",
+    execution: "dependency",
+    figmaNode: "67:5290",
+    requirements: [
+      ...COMMON_STATE_REQUIREMENTS,
+      "active",
+      "idle",
+      "waiting",
+      "completed",
+      "stopped",
+    ],
+    assertion: "Session list and detail cover running, waiting, idle, ended, search, failure, and retry states.",
+  },
+  {
+    id: "terminal-accessibility",
+    surface: "terminal",
+    owner: "MAT-300",
+    execution: "dependency",
+    figmaNode: "67:5290",
+    requirements: ACCESSIBILITY_REQUIREMENTS,
+    assertion: "Session actions and detail controls remain named, keyboard operable, and focus-visible.",
+  },
+  {
+    id: "terminal-identity",
+    surface: "terminal",
+    owner: "MAT-302",
+    execution: "combined-head",
+    requirements: [...IDENTITY_REQUIREMENTS, "mounted-resource", "shutdown-drain"],
+    assertion: "Navigation preserves the intended live attachment, while runtime and auth changes drain the old one.",
+  },
+  {
+    id: "terminal-visual-electron",
+    surface: "terminal",
+    owner: "MAT-302",
+    execution: "baseline",
+    requirements: [...VISUAL_REQUIREMENTS, "electron"],
+    assertion: "Terminal list/detail remains reachable and fitted after Electron resize, zoom, and theme changes.",
+  },
+  {
+    id: "files-states",
+    surface: "files",
+    owner: "MAT-298",
+    execution: "dependency",
+    figmaNode: "67:5663",
+    requirements: COMMON_STATE_REQUIREMENTS,
+    assertion: "Listing and preview cover loading, empty, unsupported, oversized, offline, error, and retry states.",
+  },
+  {
+    id: "files-accessibility",
+    surface: "files",
+    owner: "MAT-298",
+    execution: "dependency",
+    figmaNode: "67:5663",
+    requirements: ACCESSIBILITY_REQUIREMENTS,
+    assertion: "List/grid navigation, sorting, breadcrumbs, upload, selection, and preview actions expose stable names.",
+  },
+  {
+    id: "files-identity",
+    surface: "files",
+    owner: "MAT-302",
+    execution: "combined-head",
+    requirements: [...IDENTITY_REQUIREMENTS, "shutdown-drain"],
+    assertion: "Selection, listing, preview, and late responses cannot cross a runtime or authentication boundary.",
+  },
+  {
+    id: "files-visual-electron",
+    surface: "files",
+    owner: "MAT-302",
+    execution: "baseline",
+    requirements: [...VISUAL_REQUIREMENTS, "electron"],
+    assertion: "List/grid and preview panes remain reachable after Electron resize, zoom, and theme changes.",
+  },
+];
+
+const SURFACES: readonly HandoffSurface[] = [
+  "navigation",
+  "chat",
+  "terminal",
+  "files",
+];
+
+export function assertHandoffMatrixCoverage(
+  matrix: readonly HandoffRegressionScenario[],
+): void {
+  const missing: string[] = [];
+  const ids = new Set<string>();
+
+  for (const scenario of matrix) {
+    if (ids.has(scenario.id)) missing.push(`duplicate-id:${scenario.id}`);
+    ids.add(scenario.id);
+    if (scenario.assertion.trim().length === 0) {
+      missing.push(`assertion:${scenario.id}`);
+    }
+  }
+
+  for (const surface of SURFACES) {
+    const scenarios = matrix.filter((scenario) => scenario.surface === surface);
+    if (scenarios.length === 0) {
+      missing.push(`surface:${surface}`);
+      continue;
+    }
+    const covered = new Set(scenarios.flatMap((scenario) => scenario.requirements));
+    for (const requirement of PER_SURFACE_REQUIREMENTS) {
+      if (!covered.has(requirement)) missing.push(`${surface}:${requirement}`);
+    }
+  }
+
+  const globallyCovered = new Set(
+    matrix.flatMap((scenario) => scenario.requirements),
+  );
+  for (const requirement of GLOBAL_REQUIREMENTS) {
+    if (!globallyCovered.has(requirement)) missing.push(`global:${requirement}`);
+  }
+
+  if (missing.length > 0) {
+    throw new Error(`Desktop handoff matrix coverage missing: ${missing.join(", ")}`);
+  }
+}

--- a/tests/e2e/desktop/operator.e2e.test.ts
+++ b/tests/e2e/desktop/operator.e2e.test.ts
@@ -300,7 +300,12 @@ suite("operator desktop e2e", () => {
     await page.getByRole("button", { name: /^Expand sidebar/ }).click();
 
     await page.locator("aside button", { hasText: "Chat" }).first().click();
-    await page.getByRole("heading", { name: "Chats" }).waitFor({ timeout: 10_000 });
+    await page
+      .locator(
+        '[role="region"][aria-label="Hermes conversation"], #conversation-index-title',
+      )
+      .first()
+      .waitFor({ timeout: 10_000 });
     await expect.poll(attachedNativeViewCount).toBe(0);
     await page.screenshot({ path: join(SCREENSHOT_DIR, "10-chat-no-shell-overlay.png") });
 

--- a/tests/e2e/desktop/operator.e2e.test.ts
+++ b/tests/e2e/desktop/operator.e2e.test.ts
@@ -402,6 +402,15 @@ suite("operator desktop e2e", () => {
       evidence.focusTargets.Terminal,
     );
     expect(evidence.focusTargets.Files).toBe("Files");
+    if (evidence.historyTargets) {
+      expect(evidence.historyTargets).toEqual({
+        back: "Terminal",
+        forward: "Files",
+      });
+    }
+    if (evidence.recentConversationTarget) {
+      expect(evidence.recentConversationTarget).toBe("Conversations");
+    }
     expect(evidence.hiddenPanesMissingInert).toBe(0);
     expect(evidence.narrowViewport).toEqual({
       width: 820,

--- a/tests/e2e/desktop/operator.e2e.test.ts
+++ b/tests/e2e/desktop/operator.e2e.test.ts
@@ -292,12 +292,12 @@ suite("operator desktop e2e", () => {
     await page.getByRole("listbox", { name: "Choose computer" }).waitFor({ timeout: 10_000 });
     await page.screenshot({ path: join(SCREENSHOT_DIR, "09d-computer-menu.png") });
     await page.keyboard.press("Escape");
-    await page.getByRole("button", { name: "Collapse sidebar (⌘B)" }).click();
+    await page.getByRole("button", { name: /^Collapse sidebar/ }).click();
     await page.getByRole("button", { name: /Change computer, currently/ }).click();
     await page.getByRole("listbox", { name: "Choose computer" }).waitFor({ timeout: 10_000 });
     await page.screenshot({ path: join(SCREENSHOT_DIR, "09e-computer-menu-collapsed.png") });
     await page.keyboard.press("Escape");
-    await page.getByRole("button", { name: "Expand sidebar (⌘B)" }).click();
+    await page.getByRole("button", { name: /^Expand sidebar/ }).click();
 
     await page.locator("aside button", { hasText: "Chat" }).first().click();
     await page.getByRole("heading", { name: "Chats" }).waitFor({ timeout: 10_000 });

--- a/tests/e2e/desktop/operator.e2e.test.ts
+++ b/tests/e2e/desktop/operator.e2e.test.ts
@@ -8,6 +8,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { _electron, type ElectronApplication, type Page } from "playwright";
+import { inspectDesktopHandoffBaseline } from "./handoff-electron-baseline";
 import { startStubGateway, type StubGateway } from "./fixtures/stub-gateway";
 
 const DESKTOP_MAIN = resolve(__dirname, "../../../desktop/out/main/index.js");
@@ -356,5 +357,28 @@ suite("operator desktop e2e", () => {
     await page.screenshot({ path: join(SCREENSHOT_DIR, "20-delete-project-confirmation.png") });
     await page.getByRole("button", { name: "Delete project" }).click();
     await page.getByRole("button", { name: "Open Matrix OS" }).waitFor({ state: "detached", timeout: 10_000 });
+  }, 40_000);
+
+  it("keeps the handoff surfaces named, keyboard reachable, and resize safe", async () => {
+    const evidence = await inspectDesktopHandoffBaseline(page);
+
+    expect(evidence.navigationNames).toEqual([
+      "Home",
+      "Chat",
+      "Terminal",
+      "Files",
+    ]);
+    expect(evidence.focusTargets.Home).toBe("Home");
+    expect(["Chat", "Do anything"]).toContain(evidence.focusTargets.Chat);
+    expect(["Terminal", "Terminal input"]).toContain(
+      evidence.focusTargets.Terminal,
+    );
+    expect(evidence.focusTargets.Files).toBe("Files");
+    expect(evidence.hiddenPanesMissingInert).toBe(0);
+    expect(evidence.narrowViewport).toEqual({
+      width: 820,
+      hasHorizontalDocumentOverflow: false,
+    });
+    expect(evidence.reducedMotion).toBe("reduce");
   }, 40_000);
 });

--- a/tests/e2e/desktop/operator.e2e.test.ts
+++ b/tests/e2e/desktop/operator.e2e.test.ts
@@ -19,6 +19,27 @@ const hasBuild = existsSync(DESKTOP_MAIN);
 
 const suite = hasBuild ? describe : describe.skip;
 
+async function openSettings(page: Page): Promise<void> {
+  const sidebar = page.locator("aside");
+  const directSettings = sidebar
+    .getByRole("button", { name: "Settings", exact: true })
+    .first();
+
+  if ((await directSettings.count()) > 0 && await directSettings.isVisible()) {
+    await directSettings.click();
+  } else {
+    await sidebar.getByRole("button", { name: "Open account menu" }).click();
+    await page
+      .getByRole("menu", { name: "Account" })
+      .getByRole("button", { name: "Settings" })
+      .click();
+  }
+
+  await page
+    .getByRole("heading", { name: "Settings" })
+    .waitFor({ timeout: 10_000 });
+}
+
 suite("operator desktop e2e", () => {
   let gateway: StubGateway;
   let app: ElectronApplication;
@@ -165,8 +186,7 @@ suite("operator desktop e2e", () => {
   }, 30_000);
 
   it("shows provider and integration settings for the selected computer", async () => {
-    await page.locator("aside button", { hasText: "Settings" }).first().click();
-    await page.getByRole("heading", { name: "Settings" }).waitFor({ timeout: 10_000 });
+    await openSettings(page);
 
     await page.getByRole("button", { name: "Providers" }).click();
     await page.getByText("Coding agents on this computer").waitFor({ timeout: 10_000 });
@@ -229,8 +249,14 @@ suite("operator desktop e2e", () => {
     await page.getByText("Notes").first().waitFor({ timeout: 10_000 });
     await page.getByText("Pomodoro").first().waitFor({ timeout: 10_000 });
     await page.getByText("Notes").first().click();
-    // The app opens in its own tab (tab chip with the app name).
-    await page.locator('[role="tab"]', { hasText: "Notes" }).first().waitFor({ timeout: 10_000 });
+    // Legacy Desktop exposes a tab chip; the navigation handoff keeps that
+    // cached tab mounted behind a breadcrumb-only header.
+    const breadcrumb = page.getByRole("navigation", { name: "Breadcrumb" });
+    if ((await breadcrumb.count()) > 0) {
+      await breadcrumb.getByText("Notes", { exact: true }).waitFor({ timeout: 10_000 });
+    } else {
+      await page.locator('[role="tab"]', { hasText: "Notes" }).first().waitFor({ timeout: 10_000 });
+    }
     await page.screenshot({ path: join(SCREENSHOT_DIR, "07-apps.png") });
   }, 30_000);
 
@@ -239,8 +265,7 @@ suite("operator desktop e2e", () => {
     await expect.poll(attachedNativeViewCount).toBe(1);
     await page.screenshot({ path: join(SCREENSHOT_DIR, "08-home-shell-active.png") });
 
-    await page.locator("aside button", { hasText: "Settings" }).first().click();
-    await page.getByRole("heading", { name: "Settings" }).waitFor({ timeout: 10_000 });
+    await openSettings(page);
     await expect.poll(attachedNativeViewCount).toBe(0);
     await page.getByRole("button", { name: "Computers" }).click();
     await page.getByText("Additional Computer").waitFor({ timeout: 10_000 });
@@ -255,8 +280,7 @@ suite("operator desktop e2e", () => {
 
     // Reopening Settings must mark the server-reported slot as current and
     // leave the other computer selectable.
-    await page.locator("aside button", { hasText: "Settings" }).first().click();
-    await page.getByRole("heading", { name: "Settings" }).waitFor({ timeout: 10_000 });
+    await openSettings(page);
     await page.getByRole("button", { name: "Computers" }).click();
     await page.getByRole("button", { name: "Current computer" }).waitFor({ timeout: 10_000 });
     await page.getByRole("button", { name: "Use Main Computer" }).waitFor({ timeout: 10_000 });
@@ -291,8 +315,7 @@ suite("operator desktop e2e", () => {
   }, 40_000);
 
   it("switches unified themes from Appearance settings", async () => {
-    await page.locator("aside button", { hasText: "Settings" }).first().click();
-    await page.getByRole("heading", { name: "Settings" }).waitFor({ timeout: 10_000 });
+    await openSettings(page);
     await page.getByRole("button", { name: "Appearance" }).click();
     await page.getByRole("radiogroup", { name: "Theme" }).waitFor({ timeout: 10_000 });
     await page.screenshot({ path: join(SCREENSHOT_DIR, "13-appearance-theme-picker.png") });
@@ -307,7 +330,7 @@ suite("operator desktop e2e", () => {
     await page.screenshot({ path: join(SCREENSHOT_DIR, "15-theme-dracula-terminal.png") });
 
     // Restore the default so later suites see the stock palette.
-    await page.locator("aside button", { hasText: "Settings" }).first().click();
+    await openSettings(page);
     await page.getByRole("button", { name: "Appearance" }).click();
     await page.getByRole("radio", { name: "Use Operator theme" }).click();
     await page.waitForFunction(() => document.documentElement.getAttribute("data-theme-id") === "operator");
@@ -340,7 +363,7 @@ suite("operator desktop e2e", () => {
     await page.getByText("Archive project", { exact: true }).click();
     await expect.poll(() => page.getByRole("button", { name: "Open Matrix OS" }).count()).toBe(0);
 
-    await page.locator("aside button", { hasText: "Settings" }).first().click();
+    await openSettings(page);
     const settingsNav = page.locator("nav", { has: page.getByRole("heading", { name: "Settings" }) });
     await settingsNav.getByRole("button", { name: "Projects" }).click();
     await page.getByRole("heading", { name: "Archived projects" }).waitFor({ timeout: 10_000 });


### PR DESCRIPTION
## Summary

- define a Desktop handoff ledger across navigation, Chat, Terminal, and Files
- bind every automated matrix scenario to concrete test-file and test-name evidence
- adapt the built-Electron harness to the merged MAT-298 through MAT-301 behavior
- keep manual and deferred dimensions explicit instead of treating requirement labels as passing tests

## Scope boundary

This is a test-only MAT-302 change. It does not duplicate production behavior from MAT-298, MAT-299, MAT-300, or MAT-301. MAT-268 remains explicitly excluded and was not modified, merged, copied, cherry-picked, or used.

Linear: [MAT-302](https://linear.app/matrix-os/issue/MAT-302/harden-desktop-handoff-states-accessibility-and-electron-regression)

## Landing state

The branch was rebuilt cleanly from current `main` after MAT-301 merged. The PR diff contains only four test/harness files:

- `tests/desktop/handoff-regression-matrix.test.ts`
- `tests/e2e/desktop/handoff-electron-baseline.ts`
- `tests/e2e/desktop/handoff-regression-matrix.ts`
- `tests/e2e/desktop/operator.e2e.test.ts`

## Final validation

- complete Desktop unit suite: 168 files, 1672/1672 passed
- built-Electron macOS stack: 5 files, 22/22 passed
  - operator navigation/runtime/theme/accessibility: 16/16
  - Files handoff: 2/2
  - Hermes conversations: 1/1
  - Terminal sessions: 2/2
  - Terminal links: 1/1
- Desktop typecheck: passed
- Desktop production build: passed
- evidence-linked clean-head smoke: 12/12 passed

The built app verifies Home/Chat/Terminal/Files keyboard activation and names, deterministic focus, Back/Forward, scoped Recents, runtime computer switching, canonical Hermes discovery/create/switch/delete/restore, canonical Terminal sessions and mounted-session preservation, Files list/grid/previews, hidden-pane inertness, 820x720 overflow safety, reduced motion, and light/dark theme transitions.

Automated matrix entries name the concrete test file and behavior assertion that supplies their evidence. The matrix test reads those files and fails if an evidence link becomes stale. Zoom and contrast are explicitly marked manual for every surface because no automated pixel/contrast threshold exists.

## Figma verification

The restored full Figma seat was used to read the current design context directly for:

- Chat conversation list `145:2309`
- Chat conversation detail `67:4551`
- Sandbox Chat section `105:11178`

The current handoff confirms the single Chat surface, 64 px conversation rows, hover-only delete action, canonical breadcrumb, bottom composer, and harness badge semantics. The separate owner-persistence and final harness-neutral Chat implementation remain tracked in MAT-321 and MAT-322.

## Remaining gaps

- zoom and contrast remain manual screenshot/a11y review dimensions rather than automated gates
- Windows and Linux Electron paths remain unverified; runtime evidence is macOS only
