### PR TITLE
fix(terminal): verify activation rollout integrity

### DIFF
--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -386,6 +386,52 @@ jobs:
               -H "content-type: application/json" \
               -d "{\"version\":\"${VERSION}\",\"handle\":\"${HANDLE}\"}"
           }
+          runtime_token="$(PLATFORM_SIGNING_SECRET="$PLATFORM_SECRET" node --input-type=module -e '
+            import { createHmac } from "node:crypto";
+            process.stdout.write(createHmac("sha256", process.env.PLATFORM_SIGNING_SECRET).update(process.argv[1]).digest("hex"));
+          ' "$HANDLE")"
+          echo "::add-mask::$runtime_token"
+          send_runtime_command() {
+            local body="$1" response="$2"
+            curl --fail --silent --show-error --max-time 45 --insecure \
+              --resolve "app.matrix-os.com:443:${address}" \
+              -o "$response" -X POST 'https://app.matrix-os.com/api/terminal/run' \
+              -H "authorization: Bearer ${runtime_token}" \
+              -H 'content-type: application/json' --data-binary "$body" &&
+              jq -e 'select(.exitCode==0 and .timedOut==false and .truncated==false and .signal==null)' \
+                "$response" >/dev/null
+          }
+          probe_active_bundle_version() {
+            local body response=/tmp/preview-active-bundle-version.json probe_script
+            read -r -d '' probe_script <<'PYTHON' || true
+          import os
+          import re
+          import stat
+
+          path = "/opt/matrix/app/BUNDLE_VERSION"
+          fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+          try:
+              metadata = os.fstat(fd)
+              if not stat.S_ISREG(metadata.st_mode) or metadata.st_size < 2 or metadata.st_size > 256:
+                  raise ValueError("invalid bundle version marker")
+              value = os.read(fd, 257).decode("utf-8").strip()
+              if not re.fullmatch(r"(?:v[0-9]|main-[A-Za-z0-9])[A-Za-z0-9._-]{0,127}", value):
+                  raise ValueError("invalid bundle version")
+              print(value)
+          finally:
+              os.close(fd)
+          PYTHON
+            body="$(jq -cn --arg script "$probe_script" \
+              '{command:["/usr/bin/python3","-c",$script],timeoutMs:10000}')"
+            send_runtime_command "$body" "$response"
+            jq -er '.stdout | select(test("^(v[0-9]|main-[A-Za-z0-9])[A-Za-z0-9._-]{0,127}\\n$")) | rtrimstr("\n")' \
+              "$response"
+          }
+          restart_preview_sync_agent() {
+            local body response=/tmp/preview-sync-agent-restart.json
+            body='{"command":["/usr/bin/sudo","/usr/bin/systemctl","restart","matrix-sync-agent.service"],"timeoutMs":30000}'
+            send_runtime_command "$body" "$response"
+          }
           code="$(attempt)"
           if [ "$code" != "200" ]; then
             echo "Deploy returned HTTP ${code}; retrying once in 30s..."
@@ -401,6 +447,7 @@ jobs:
 
           echo "Waiting for ${HANDLE} to install ${VERSION}"
           deadline=$((SECONDS + 600))
+          transition_repair_attempted=false
           while true; do
             runtime="$(curl -fsS --max-time 30 \
               -H "authorization: Bearer ${PLATFORM_SECRET}" \
@@ -419,12 +466,43 @@ jobs:
             status="$(jq -r '.status' <<< "$runtime")"
             healthy="$(jq -r '.healthy == true' <<< "$runtime")"
             runtime_version="$(jq -r '.runtimeVersion // "pending"' <<< "$runtime")"
+            address="$(jq -r '.publicIPv4 // ""' <<< "$runtime")"
             echo "Runtime for ${HANDLE}: status=${status} healthy=${healthy} version=${runtime_version}"
 
             if jq -e --arg v "$VERSION" \
               '.healthy == true and .runtimeVersion == $v' <<< "$runtime" > /dev/null; then
-              echo "Preview ready: ${HANDLE} is healthy on ${VERSION}"
-              break
+              if ! printf '%s' "$address" | grep -Eq '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then
+                echo "Preview runtime address is invalid." >&2
+                exit 1
+              fi
+              active_bundle_version=""
+              if active_bundle_version="$(probe_active_bundle_version 2>/dev/null)"; then
+                echo "Active app version for ${HANDLE}: ${active_bundle_version:-unavailable}"
+                if [ "$active_bundle_version" = "$VERSION" ]; then
+                  echo "Preview ready: ${HANDLE} is healthy on ${VERSION}"
+                  break
+                fi
+                if [ "$active_bundle_version" != "$VERSION" ]; then
+                  if ! [[ "$HANDLE" =~ ^pr-[1-9][0-9]{0,9}$ ]] || [ "$transition_repair_attempted" != false ]; then
+                    echo "Preview release metadata diverged from its active app after bounded repair." >&2
+                    exit 1
+                  fi
+                  echo "Recovering the disposable preview from a pre-terminal-runtime updater transition."
+                  restart_preview_sync_agent
+                  transition_repair_attempted=true
+                  sleep 10
+                  code="$(attempt)"
+                  if [ "$code" != "200" ]; then
+                    echo "Exact-version transition repair deploy failed with HTTP ${code}." >&2
+                    exit 1
+                  fi
+                  deadline=$((SECONDS + 600))
+                  sleep 15
+                  continue
+                fi
+              else
+                echo "Active app version for ${HANDLE}: unavailable"
+              fi
             fi
             if [ "$status" = "failed" ]; then
               echo "Preview ${HANDLE} failed while installing ${VERSION}." >&2

--- a/.github/workflows/user-systemd-terminal-production-acceptance.yml
+++ b/.github/workflows/user-systemd-terminal-production-acceptance.yml
@@ -429,7 +429,7 @@ jobs:
           PYTHON
             )"
             case "$error" in
-              apply_failed|apply_interrupted|bundle_extract_failed|bundle_layout_invalid|checksum_mismatch|download_failed|download_metadata_changed|insufficient_disk_space|post_install_health_failed|post_install_host_bin_failed|post_install_rollback_failed|post_install_service_start_failed|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|update_target_mismatch) ;;
+              apply_failed|apply_interrupted|bundle_extract_failed|bundle_layout_invalid|checksum_mismatch|download_failed|download_metadata_changed|insufficient_disk_space|post_install_health_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_rollback_failed|post_install_service_start_failed|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|update_target_mismatch) ;;
               *) error=invalid ;;
             esac
           fi
@@ -438,7 +438,7 @@ jobs:
             body="$(jq -cn --arg script "$diagnostic_script" \
               '{command:["/usr/bin/sudo","/bin/bash","-c",$script],timeoutMs:45000}')"
             send_signed_command "$body" "$response"
-            jq -er '.stdout | select(test("^phase=(idle|prepare|download|verify|extract|terminal-runtime|app-install|host-bin|health|invalid) error=(none|apply_failed|apply_interrupted|bundle_extract_failed|bundle_layout_invalid|checksum_mismatch|download_failed|download_metadata_changed|insufficient_disk_space|post_install_health_failed|post_install_host_bin_failed|post_install_rollback_failed|post_install_service_start_failed|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|update_target_mismatch|invalid)\\n$")) | rtrimstr("\n")' \
+            jq -er '.stdout | select(test("^phase=(idle|prepare|download|verify|extract|terminal-runtime|app-install|host-bin|health|invalid) error=(none|apply_failed|apply_interrupted|bundle_extract_failed|bundle_layout_invalid|checksum_mismatch|download_failed|download_metadata_changed|insufficient_disk_space|post_install_health_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_rollback_failed|post_install_service_start_failed|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|update_target_mismatch|invalid)\\n$")) | rtrimstr("\n")' \
               "$response"
           }
           response="$RUNNER_TEMP/user-systemd-recovery.json"

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -16,6 +16,7 @@ readonly STAGING_DIR="/opt/matrix/staging"
 readonly BIN_DIR="/opt/matrix/bin"
 readonly VERSION_FILE="$APP_DIR/BUNDLE_VERSION"
 readonly RELEASE_FILE="/opt/matrix/release.json"
+readonly RELEASE_ROLLBACK_FILE="/opt/matrix/release.json.rollback"
 readonly UPDATE_MARKER="$APP_DIR/.update-available.json"
 readonly UPDATE_TRIGGER="$APP_DIR/.update-now"
 readonly UPDATE_CHANNEL_FILE="$APP_DIR/.update-channel"
@@ -44,6 +45,113 @@ readonly SYMPHONY_MANAGED_KEYS="MATRIX_HANDLE PLATFORM_INTERNAL_URL UPGRADE_TOKE
 log() { echo "matrix-sync-agent: $(date -u +%Y-%m-%dT%H:%M:%SZ) $*"; }
 current_version() { cat "$VERSION_FILE" 2>/dev/null || echo "unknown"; }
 platform_url() { echo "${MATRIX_UPDATE_MANIFEST_BASE_URL:-${PLATFORM_INTERNAL_URL:-https://app.matrix-os.com}}"; }
+staged_release_metadata=""
+
+cleanup_staged_release_metadata() {
+  if [ -n "$staged_release_metadata" ]; then
+    sudo rm -f -- "$staged_release_metadata" || true
+    staged_release_metadata=""
+  fi
+}
+
+stage_release_metadata() {
+  local source="$1" expected_version="$2" actual_version incoming
+  staged_release_metadata=""
+  [ -f "$source" ] && [ ! -L "$source" ] || {
+    log "ERROR: bundle release metadata is missing or invalid"
+    return 1
+  }
+  actual_version="$(python3 - "$source" <<'PY'
+import json
+import os
+import stat
+import sys
+
+fd = os.open(sys.argv[1], os.O_RDONLY | os.O_NOFOLLOW)
+try:
+    metadata = os.fstat(fd)
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_size < 2 or metadata.st_size > 65536:
+        raise ValueError("invalid release metadata")
+    payload = os.read(fd, 65537)
+    if len(payload) > 65536:
+        raise ValueError("oversized release metadata")
+    version = json.loads(payload).get("version")
+    if not isinstance(version, str):
+        raise ValueError("missing release version")
+    print(version)
+finally:
+    os.close(fd)
+PY
+  )" || return 1
+  [ "$actual_version" = "$expected_version" ] || {
+    log "ERROR: bundle release metadata does not match the requested version"
+    return 1
+  }
+  if [ -L "$RELEASE_FILE" ] || { [ -e "$RELEASE_FILE" ] && [ ! -f "$RELEASE_FILE" ]; }; then
+    log "ERROR: installed release metadata has an invalid file type"
+    return 1
+  fi
+  incoming="$RELEASE_FILE.incoming.$$"
+  sudo rm -f -- "$incoming" || return 1
+  if ! sudo install -o root -g matrix -m 0644 "$source" "$incoming"; then
+    sudo rm -f -- "$incoming"
+    return 1
+  fi
+  staged_release_metadata="$incoming"
+}
+
+commit_release_metadata() {
+  local rollback_incoming
+  [ -n "$staged_release_metadata" ] && [ -f "$staged_release_metadata" ] && [ ! -L "$staged_release_metadata" ] || return 1
+  rollback_incoming="$RELEASE_ROLLBACK_FILE.incoming.$$"
+  sudo rm -f -- "$rollback_incoming" || return 1
+  if [ -f "$RELEASE_FILE" ] && [ ! -L "$RELEASE_FILE" ]; then
+    if ! sudo install -o root -g matrix -m 0644 "$RELEASE_FILE" "$rollback_incoming" \
+      || ! sudo mv -Tf "$rollback_incoming" "$RELEASE_ROLLBACK_FILE"; then
+      sudo rm -f -- "$rollback_incoming"
+      return 1
+    fi
+  else
+    sudo rm -f -- "$RELEASE_ROLLBACK_FILE" || return 1
+  fi
+  sudo mv -Tf "$staged_release_metadata" "$RELEASE_FILE" || return 1
+  staged_release_metadata=""
+}
+
+restore_rollback_release_metadata() {
+  [ -f "$RELEASE_ROLLBACK_FILE" ] && [ ! -L "$RELEASE_ROLLBACK_FILE" ] || return 1
+  sudo mv -Tf "$RELEASE_ROLLBACK_FILE" "$RELEASE_FILE" || return 1
+}
+
+rollback_release_metadata_is_ready() {
+  local rollback_app="$1" expected_version actual_version
+  [ -d "$rollback_app" ] && [ ! -L "$rollback_app" ] || return 1
+  [ -f "$rollback_app/BUNDLE_VERSION" ] && [ ! -L "$rollback_app/BUNDLE_VERSION" ] || return 1
+  IFS= read -r expected_version <"$rollback_app/BUNDLE_VERSION" || return 1
+  actual_version="$(python3 - "$RELEASE_ROLLBACK_FILE" <<'PY'
+import json
+import os
+import stat
+import sys
+
+fd = os.open(sys.argv[1], os.O_RDONLY | os.O_NOFOLLOW)
+try:
+    metadata = os.fstat(fd)
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_size < 2 or metadata.st_size > 65536:
+        raise ValueError("invalid rollback release metadata")
+    payload = os.read(fd, 65537)
+    if len(payload) > 65536:
+        raise ValueError("oversized rollback release metadata")
+    version = json.loads(payload).get("version")
+    if not isinstance(version, str):
+        raise ValueError("missing rollback release version")
+    print(version)
+finally:
+    os.close(fd)
+PY
+  )" || return 1
+  [ "$actual_version" = "$expected_version" ]
+}
 
 # Echo the lines of an existing symphony.env that this agent does not manage so
 # operator-set configuration survives a host bundle update. Blank and comment
@@ -675,9 +783,18 @@ apply_update() {
     rm -rf "$extract_dir" "$bundle_file"
     return 1
   fi
+  if ! stage_release_metadata "$extract_dir/release.json" "$version"; then
+    log "ERROR: Release metadata staging failed; aborting before app replacement"
+    write_update_error "release_metadata_invalid" "The release metadata could not be staged safely." "$version"
+    rm -rf "$extract_dir" "$bundle_file"
+    return 1
+  fi
 
   # Stop services, backup, install
-  write_update_phase app-install || return 1
+  if ! write_update_phase app-install; then
+    cleanup_staged_release_metadata
+    return 1
+  fi
   log "Stopping services..."
   sudo systemctl stop matrix-symphony matrix-gateway matrix-shell || true
   sudo rm -rf "$APP_DIR.rollback"
@@ -689,18 +806,15 @@ apply_update() {
   sudo chown -R matrix:matrix "$APP_DIR"
   echo "$version" | sudo tee "$VERSION_FILE" >/dev/null
   log "Installed app $version"
-  if [ -f "$extract_dir/release.json" ]; then
-    sudo install -o root -g matrix -m 0644 "$extract_dir/release.json" "$RELEASE_FILE"
-    log "Updated release metadata"
-  fi
   if [ -d "$extract_dir/bin" ]; then
     if ! write_update_phase host-bin || ! install_host_bin_payload "$extract_dir/bin"; then
       log "ERROR: host-bin installation failed — rolling back"
-      if do_rollback; then
+      if do_rollback false; then
         write_update_error "post_install_host_bin_failed" "The host update helpers could not be installed and the previous release was restored." "$version"
       else
         write_update_error "post_install_rollback_failed" "The host update helpers could not be installed and rollback did not complete." "$version"
       fi
+      cleanup_staged_release_metadata
       rm -rf "$extract_dir" "$bundle_file"
       return 1
     fi
@@ -752,11 +866,12 @@ apply_update() {
   log "Starting services..."
   if ! sudo systemctl start matrix-gateway matrix-shell; then
     log "ERROR: updated services failed to start — rolling back"
-    if do_rollback; then
+    if do_rollback false; then
       write_update_error "post_install_service_start_failed" "The updated services failed to start and the previous release was restored." "$version"
     else
       write_update_error "post_install_rollback_failed" "The updated services failed to start and rollback did not complete." "$version"
     fi
+    cleanup_staged_release_metadata
     rm -rf "$extract_dir" "$bundle_file"
     return 1
   fi
@@ -770,15 +885,29 @@ apply_update() {
     sleep 5
   done
   if [ "$healthy" = true ]; then
-    log "Health check passed — update to $version complete"
-    rm -f "$UPDATE_MARKER" "$UPDATE_ERROR_MARKER"
+    if commit_release_metadata; then
+      log "Updated release metadata"
+      log "Health check passed — update to $version complete"
+      rm -f "$UPDATE_MARKER" "$UPDATE_ERROR_MARKER"
+    else
+      log "ERROR: release metadata commit failed — rolling back"
+      if do_rollback false; then
+        write_update_error "post_install_release_metadata_failed" "The release metadata could not be committed and the previous release was restored." "$version"
+      else
+        write_update_error "post_install_rollback_failed" "The release metadata could not be committed and rollback did not complete." "$version"
+      fi
+      cleanup_staged_release_metadata
+      rm -rf "$extract_dir" "$bundle_file"
+      return 1
+    fi
   else
     log "ERROR: health check failed — rolling back"
-    if do_rollback; then
+    if do_rollback false; then
       write_update_error "post_install_health_failed" "The updated gateway failed its health check and the previous release was restored." "$version"
     else
       write_update_error "post_install_rollback_failed" "The updated gateway failed its health check and rollback did not complete." "$version"
     fi
+    cleanup_staged_release_metadata
     rm -rf "$extract_dir" "$bundle_file"
     return 1
   fi
@@ -806,8 +935,13 @@ run_apply_update() {
 
 # ── Rollback ─────────────────────────────────────────────────────────
 do_rollback() {
+  local restore_release_metadata="${1:-true}"
   if [ ! -d "$APP_DIR.rollback" ]; then
     log "ERROR: no rollback available at $APP_DIR.rollback"; return 1
+  fi
+  if [ "$restore_release_metadata" = true ] && ! rollback_release_metadata_is_ready "$APP_DIR.rollback"; then
+    log "ERROR: rollback release metadata is unavailable or inconsistent"
+    return 1
   fi
   log "Rolling back..."
   sudo systemctl stop matrix-symphony matrix-gateway matrix-shell || true
@@ -818,6 +952,12 @@ do_rollback() {
   fi
   sudo mv "$APP_DIR.rollback" "$APP_DIR"
   sudo chown -R matrix:matrix "$APP_DIR"
+  if [ "$restore_release_metadata" = true ]; then
+    restore_rollback_release_metadata || {
+      log "ERROR: rollback release metadata restore failed"
+      return 1
+    }
+  fi
   if [ -f "$APP_DIR/$TERMINAL_RUNTIME_GENERATION_FILE" ]; then
     activate_terminal_runtime_generation "$(cat "$APP_DIR/$TERMINAL_RUNTIME_GENERATION_FILE")"
   fi

--- a/docs/dev/user-systemd-terminal-activation.md
+++ b/docs/dev/user-systemd-terminal-activation.md
@@ -26,6 +26,26 @@ The environment variable is an operator override:
   diagnosis.
 - Any other explicit value fails closed.
 
+## Fail-closed installation readiness
+
+Activation never falls back to the legacy gateway-owned terminal runtime. When
+the marker or the exact `=1` override requests activation, gateway startup also
+requires all of the following:
+
+- the descriptor generation has a regular `GENERATION` marker whose value
+  matches the app marker;
+- the pinned generation contains regular, executable Zellij, keeper, and
+  attach assets;
+- `terminal-runtime/current` resolves to that exact generation;
+- `matrix-zellij@.service` and `matrix-terminal.slice` are installed as regular
+  static user-unit files; and
+- the matrix user's systemd manager can discover both unit definitions.
+
+Missing, malformed, symlink-substituted, or undiscoverable prerequisites abort
+gateway startup with a generic terminal-runtime error. The host updater then
+treats `/health` as failed and rolls back the app. It must not advertise a
+healthy activation bundle while serving legacy terminals.
+
 ## Rollout
 
 1. Build and register an immutable bundle without promoting a channel.
@@ -37,6 +57,31 @@ The environment variable is an operator override:
 5. Reboot the canary and confirm no terminal unit, command, or coding agent
    starts automatically.
 6. Promote channels separately only after the canary evidence is accepted.
+
+### New signups
+
+Provision only from a golden image or clean-image bootstrap that installs the
+complete bundle layout (`app`, `terminal-runtime`, and `user-systemd`) before
+starting the gateway. A provision whose activated gateway fails the readiness
+checks is failed, not silently downgraded. Refresh and verify the golden image
+before making an activation release available to new customers.
+
+### Existing users
+
+VPSes whose installed updater predates the terminal-runtime bundle sections
+must use a two-stage migration:
+
+1. Deploy a dormant user-systemd bootstrap bundle, such as the bundle produced
+   from PR #1129. Verify the VPS has the new updater while the activation marker
+   remains absent.
+2. Deploy the activation bundle. Verify the exact immutable generation, both
+   user units, user-manager discovery, and a real `matrix-zellij@<runtime-id>`
+   terminal before moving the rollout forward.
+
+A direct old-updater-to-activation jump is intentionally rejected. The old
+updater may retain the newer host helper after rolling the app back, allowing a
+subsequent exact-version retry to repair a disposable canary, but that recovery
+behavior is not the supported fleet migration plan.
 
 This layer does not adopt an already-running legacy Zellij process into a user
 unit. Exact-version rollout must therefore start with fresh/disposable hosts or

--- a/docs/dev/user-systemd-terminal-activation.md
+++ b/docs/dev/user-systemd-terminal-activation.md
@@ -46,6 +46,16 @@ gateway startup with a generic terminal-runtime error. The host updater then
 treats `/health` as failed and rolls back the app. It must not advertise a
 healthy activation bundle while serving legacy terminals.
 
+The updater stages bounded, validated release metadata before replacing the app,
+but commits `/opt/matrix/release.json` only after health succeeds. Preview and
+acceptance automation additionally verifies the active `/opt/matrix/app/BUNDLE_VERSION`;
+a release marker alone is not installation
+evidence. A disposable `pr-<number>` preview may perform one bounded updater
+restart and exact-version reapply when a pre-terminal-runtime updater process
+has retained the new host helper after a deliberate fail-closed rollback. That
+repair is restricted to disposable validation and does not replace the existing
+user migration below.
+
 ## Rollout
 
 1. Build and register an immutable bundle without promoting a channel.

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -374,6 +374,9 @@ export async function createGateway(config: GatewayConfig) {
         generationLockHelperPath: "/opt/matrix/bin/matrix-terminal-generation-gc.py",
       })
     : null;
+  if (userSystemdTerminalController) {
+    await userSystemdTerminalController.assertInstallationReady();
+  }
   const workspaceZellijRuntime = userSystemdTerminalController && terminalRuntimeGeneration
     ? createUserSystemdZellijRuntime({
         homePath,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -1791,7 +1791,7 @@ export async function createGateway(config: GatewayConfig) {
     && process.env.MATRIX_RUNTIME_SLOT === runtimeHandle;
   if (terminalAcceptanceEnabled) {
     app.route("/api/internal/terminal-acceptance", createTerminalAcceptanceRoutes({
-      secret: process.env.UPGRADE_TOKEN ?? "",
+      secret: () => process.env.UPGRADE_TOKEN ?? "",
       run: (input) => shellCommandRunner.run(input),
     }));
   }

--- a/packages/gateway/src/shell/terminal-acceptance-routes.ts
+++ b/packages/gateway/src/shell/terminal-acceptance-routes.ts
@@ -39,7 +39,7 @@ function signatureMatches(actual: string | undefined, expected: string): boolean
 }
 
 export function createTerminalAcceptanceRoutes(options: {
-  secret: string;
+  secret: () => string;
   run: (input: ShellCommandRunInput) => Promise<ShellCommandRunResult | Record<string, unknown>>;
   now?: () => number;
 }): Hono {
@@ -48,7 +48,8 @@ export function createTerminalAcceptanceRoutes(options: {
   const now = options.now ?? Date.now;
 
   app.post("/run", bodyLimit({ maxSize: ACCEPTANCE_BODY_LIMIT }), async (c) => {
-    if (!options.secret) return c.json({ error: "Acceptance authentication unavailable" }, 503);
+    const secret = options.secret();
+    if (!secret) return c.json({ error: "Acceptance authentication unavailable" }, 503);
     const timestamp = c.req.header("x-matrix-acceptance-timestamp") ?? "";
     const nonce = c.req.header("x-matrix-acceptance-nonce") ?? "";
     const signature = c.req.header("x-matrix-acceptance-signature");
@@ -65,7 +66,7 @@ export function createTerminalAcceptanceRoutes(options: {
     }
 
     const rawBody = await c.req.text();
-    if (!signatureMatches(signature, requestSignature(options.secret, timestamp, nonce, rawBody))) {
+    if (!signatureMatches(signature, requestSignature(secret, timestamp, nonce, rawBody))) {
       return c.json({ error: "Unauthorized" }, 401);
     }
     let parsedBody: unknown;
@@ -98,7 +99,7 @@ export function createTerminalAcceptanceRoutes(options: {
           "content-type": "application/json; charset=UTF-8",
           "cache-control": "no-store",
           "x-matrix-acceptance-response-signature": responseSignature(
-            options.secret,
+            secret,
             timestamp,
             nonce,
             responseBody,

--- a/packages/gateway/src/shell/user-systemd-terminal-runtime.ts
+++ b/packages/gateway/src/shell/user-systemd-terminal-runtime.ts
@@ -58,8 +58,42 @@ const READINESS_TIMEOUT_MS = 10_000;
 const READINESS_INTERVAL_MS = 100;
 const INACTIVE_RECOVERY_RETRY_DELAY_MS = 250;
 const MAX_RUNTIME_DESCRIPTORS = 256;
-export async function loadInstalledTerminalRuntimeGeneration(appDir = "/opt/matrix/app"): Promise<string> {
+const MAX_TERMINAL_RUNTIME_ASSET_BYTES = 256 * 1024 * 1024;
+const MAX_USER_UNIT_BYTES = 64 * 1024;
+
+async function requireInstalledDirectory(path: string): Promise<void> {
+  const stats = await lstat(path);
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new TerminalRuntimeUnavailableError();
+  }
+}
+
+async function requireInstalledFile(
+  path: string,
+  options: { executable?: boolean; maxBytes: number },
+): Promise<void> {
+  const stats = await lstat(path);
+  if (
+    !stats.isFile()
+    || stats.isSymbolicLink()
+    || stats.size < 1
+    || stats.size > options.maxBytes
+    || (options.executable === true && (stats.mode & 0o111) === 0)
+  ) {
+    throw new TerminalRuntimeUnavailableError();
+  }
+}
+
+export async function loadInstalledTerminalRuntimeGeneration(
+  appDir = "/opt/matrix/app",
+  options: {
+    terminalRuntimeRoot?: string;
+    userUnitRoot?: string;
+  } = {},
+): Promise<string> {
   const markerPath = join(resolve(appDir), "TERMINAL_RUNTIME_GENERATION");
+  const terminalRuntimeRoot = resolve(options.terminalRuntimeRoot ?? "/opt/matrix/terminal-runtime");
+  const userUnitRoot = resolve(options.userUnitRoot ?? "/etc/systemd/user");
   try {
     const stats = await lstat(markerPath);
     if (!stats.isFile() || stats.isSymbolicLink() || stats.size > 256) {
@@ -67,6 +101,43 @@ export async function loadInstalledTerminalRuntimeGeneration(appDir = "/opt/matr
     }
     const parsed = GenerationSchema.safeParse((await readFile(markerPath, "utf8")).trim());
     if (!parsed.success) throw new TerminalRuntimeUnavailableError();
+
+    const generationDir = join(terminalRuntimeRoot, "generations", parsed.data);
+    await Promise.all([
+      requireInstalledDirectory(terminalRuntimeRoot),
+      requireInstalledDirectory(join(terminalRuntimeRoot, "generations")),
+      requireInstalledDirectory(generationDir),
+      requireInstalledDirectory(userUnitRoot),
+      requireInstalledFile(join(generationDir, "zellij"), {
+        executable: true,
+        maxBytes: MAX_TERMINAL_RUNTIME_ASSET_BYTES,
+      }),
+      requireInstalledFile(join(generationDir, "matrix-terminal-user-keeper.mjs"), {
+        executable: true,
+        maxBytes: MAX_TERMINAL_RUNTIME_ASSET_BYTES,
+      }),
+      requireInstalledFile(join(generationDir, "matrix-terminal-attach.mjs"), {
+        executable: true,
+        maxBytes: MAX_TERMINAL_RUNTIME_ASSET_BYTES,
+      }),
+      requireInstalledFile(join(generationDir, "GENERATION"), { maxBytes: 256 }),
+      requireInstalledFile(join(userUnitRoot, "matrix-zellij@.service"), {
+        maxBytes: MAX_USER_UNIT_BYTES,
+      }),
+      requireInstalledFile(join(userUnitRoot, "matrix-terminal.slice"), {
+        maxBytes: MAX_USER_UNIT_BYTES,
+      }),
+    ]);
+    if ((await readFile(join(generationDir, "GENERATION"), "utf8")).trim() !== parsed.data) {
+      throw new TerminalRuntimeUnavailableError();
+    }
+    const currentStats = await lstat(join(terminalRuntimeRoot, "current"));
+    if (!currentStats.isSymbolicLink()) throw new TerminalRuntimeUnavailableError();
+    const [currentReal, generationReal] = await Promise.all([
+      realpath(join(terminalRuntimeRoot, "current")),
+      realpath(generationDir),
+    ]);
+    if (currentReal !== generationReal) throw new TerminalRuntimeUnavailableError();
     return parsed.data;
   } catch (err: unknown) {
     if (err instanceof TerminalRuntimeUnavailableError) throw err;
@@ -493,6 +564,25 @@ export function createUserSystemdTerminalRuntime(options: {
   }
 
   return {
+    async assertInstallationReady(): Promise<void> {
+      const { stdout } = await runSystemctl([
+        "list-unit-files",
+        "matrix-zellij@.service",
+        "matrix-terminal.slice",
+        "--no-legend",
+        "--no-pager",
+      ]);
+      const loadedUnits = stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim().split(/\s+/)[0]);
+      if (
+        !loadedUnits.includes("matrix-zellij@.service")
+        || !loadedUnits.includes("matrix-terminal.slice")
+      ) {
+        throw new TerminalRuntimeUnavailableError();
+      }
+    },
+
     async create(input: CreateUserSystemdRuntimeInput): Promise<UserSystemdRuntimeResult> {
       const parsed = z.object({
         runtimeId: RuntimeIdSchema,

--- a/scripts/spikes/user-systemd-terminal/production-acceptance.sh
+++ b/scripts/spikes/user-systemd-terminal/production-acceptance.sh
@@ -1066,7 +1066,7 @@ diagnose_update_failure() {
   if [ -e /opt/matrix/app/.update-error.json ] || [ -L /opt/matrix/app/.update-error.json ]; then
     error_code="$(read_update_error_code 2>/dev/null || true)"
     case "$error_code" in
-      download_failed|download_metadata_changed|update_target_mismatch|insufficient_disk_space|checksum_mismatch|bundle_extract_failed|bundle_layout_invalid|terminal_runtime_install_failed|post_install_host_bin_failed|post_install_service_start_failed|post_install_health_failed|post_install_rollback_failed|apply_failed|apply_interrupted|unknown) ;;
+      download_failed|download_metadata_changed|update_target_mismatch|insufficient_disk_space|checksum_mismatch|bundle_extract_failed|bundle_layout_invalid|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_service_start_failed|post_install_health_failed|post_install_rollback_failed|apply_failed|apply_interrupted|unknown) ;;
       *) error_code=unknown ;;
     esac
   fi
@@ -1109,7 +1109,7 @@ wait_update() {
       { [ -e /opt/matrix/app/.update-error.json ] || [ -L /opt/matrix/app/.update-error.json ]; }; then
       error_code="$(read_update_error_code 2>/dev/null || true)"
       case "$error_code" in
-        download_failed|download_metadata_changed|update_target_mismatch|insufficient_disk_space|checksum_mismatch|bundle_extract_failed|bundle_layout_invalid|terminal_runtime_install_failed|post_install_host_bin_failed|post_install_service_start_failed|post_install_health_failed|post_install_rollback_failed|apply_failed|apply_interrupted|unknown) ;;
+        download_failed|download_metadata_changed|update_target_mismatch|insufficient_disk_space|checksum_mismatch|bundle_extract_failed|bundle_layout_invalid|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_service_start_failed|post_install_health_failed|post_install_rollback_failed|apply_failed|apply_interrupted|unknown) ;;
         *) error_code=unknown ;;
       esac
       if [ "$error_code" != none ]; then

--- a/specs/109-persist-terminal-sessions/user-systemd-alternative.md
+++ b/specs/109-persist-terminal-sessions/user-systemd-alternative.md
@@ -104,8 +104,13 @@ unit installation is forward-only. Keeping the exact activation marker inside
 the app payload therefore makes rollback to a pre-activation bundle remove the
 marker before the old gateway starts. The gateway opens the marker with
 `O_NOFOLLOW`, requires a two-byte regular file containing exactly `1\n`, and
-fails closed for missing, malformed, or symlinked state. A bundle must be
-explicitly deployed to a canary or channel before this activation reaches a VPS.
+fails closed for missing, malformed, or symlinked state. Once activation is
+requested, gateway startup also requires the marker-pinned immutable generation,
+the exact `current` link, all three executable runtime assets, both regular
+static user-unit files, and discovery of those units through the owner's user
+manager. An incomplete installation aborts startup so updater health fails and
+the app rolls back; it never falls back to the legacy terminal owner. A bundle
+must be explicitly deployed to a canary or channel before this activation reaches a VPS.
 The activation layer does not adopt a live legacy Zellij process into a user
 unit. Initial rollout is therefore limited to fresh/disposable hosts or canaries
 whose legacy sessions have been deliberately drained; an automatic customer
@@ -113,12 +118,15 @@ fleet rollout is not implied by merging the activation code.
 
 The first bundle that introduces this installer can be applied by an older,
 already-running sync-agent process that does not yet know about terminal
-generations. Before the dormant flag is activated, the activation/acceptance
-path must reload the newly installed sync agent and perform one supported
-exact-version reapply. That idempotent reapply installs and verifies the
-generation and user units; it is an explicit activation prerequisite, not a
-default-on or customer rollout side effect. Later updates use the loaded
-installer directly.
+generations. Existing customer VPSes must therefore first receive a dormant
+bootstrap bundle and verify the new updater before receiving an activation
+bundle. A direct jump to activation is intentionally rejected and rolled back.
+The newer installed updater can repair a disposable canary through one supported
+exact-version reapply, which installs and verifies the generation and user
+units; that repair is evidence, not the supported customer migration plan.
+Fresh signups must boot from a refreshed golden image or clean-image path that
+installs the complete app, immutable runtime, and user-unit payload before
+starting the gateway. Later updates use the loaded installer directly.
 
 Full-bundle transfer is independently bounded from runtime continuity. If the
 first transfer fails, the sync agent refreshes the exact-version signed

--- a/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
+++ b/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
@@ -170,6 +170,8 @@ describe("customer VPS user-systemd terminal runtime", () => {
     expect(activation).toContain("### New signups");
     expect(activation).toContain("### Existing users");
     expect(activation).toContain("two-stage migration");
+    expect(activation).toContain("commits `/opt/matrix/release.json` only after health succeeds");
+    expect(activation).toContain("active `/opt/matrix/app/BUNDLE_VERSION`");
     expect(decision).toContain("A direct jump to activation is intentionally rejected and rolled back");
     expect(decision).toContain("it never falls back to the legacy terminal owner");
   });
@@ -442,7 +444,7 @@ describe("customer VPS user-systemd terminal runtime", () => {
     expect(acceptance).toContain('classify_installed_updater_protocol');
     expect(acceptance).toContain('systemctl show matrix-sync-agent.service -p NRestarts --value');
     expect(acceptance).toContain('case "$error_code" in');
-    expect(acceptance).toContain('download_failed|download_metadata_changed|update_target_mismatch|insufficient_disk_space|checksum_mismatch|bundle_extract_failed|bundle_layout_invalid|terminal_runtime_install_failed|post_install_host_bin_failed|post_install_service_start_failed|post_install_health_failed|post_install_rollback_failed|apply_failed|apply_interrupted|unknown)');
+    expect(acceptance).toContain('download_failed|download_metadata_changed|update_target_mismatch|insufficient_disk_space|checksum_mismatch|bundle_extract_failed|bundle_layout_invalid|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_service_start_failed|post_install_health_failed|post_install_rollback_failed|apply_failed|apply_interrupted|unknown)');
     expect(acceptance).not.toContain("journalctl -u matrix-sync-agent");
     expect(workflow).toContain("Acceptance stalled at ${state:-unavailable}");
     expect(workflow).toContain("Acceptance failed at ${state}");

--- a/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
+++ b/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
@@ -101,6 +101,7 @@ describe("customer VPS user-systemd terminal runtime", () => {
     expect(server).toContain("loadInstalledTerminalRuntimeGeneration");
     expect(server).toContain("createUserSystemdZellijRuntime");
     expect(server).toContain("createUserSystemdZellijAdapter");
+    expect(server).toContain("await userSystemdTerminalController.assertInstallationReady()");
     expect(server).not.toContain('MATRIX_TERMINAL_USER_SYSTEMD_ENABLED !== "0"');
   });
 
@@ -152,6 +153,24 @@ describe("customer VPS user-systemd terminal runtime", () => {
     expect(updater).not.toMatch(/systemctl restart[^\n]*(matrix-zellij|matrix-terminal\.slice|user@)/);
     expect(decision).toContain("ordered content digests");
     expect(decision).toContain("exact-version reapply");
+  });
+
+  it("documents separate fail-closed rollout paths for new and existing VPSes", () => {
+    const activation = readFileSync(
+      join(root, "docs/dev/user-systemd-terminal-activation.md"),
+      "utf8",
+    );
+    const decision = readFileSync(
+      join(root, "specs/109-persist-terminal-sessions/user-systemd-alternative.md"),
+      "utf8",
+    );
+
+    expect(activation).toContain("Activation never falls back to the legacy");
+    expect(activation).toContain("### New signups");
+    expect(activation).toContain("### Existing users");
+    expect(activation).toContain("two-stage migration");
+    expect(decision).toContain("A direct jump to activation is intentionally rejected and rolled back");
+    expect(decision).toContain("it never falls back to the legacy terminal owner");
   });
 
   it("gates exact-head disposable-VPS acceptance behind an explicit same-repository label", () => {

--- a/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
+++ b/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
@@ -98,6 +98,7 @@ describe("customer VPS user-systemd terminal runtime", () => {
     expect(build).toContain('printf \'1\\n\' > "$STAGE_DIR/app/TERMINAL_USER_SYSTEMD_ENABLED"');
     expect(server).toContain('const terminalAcceptanceEnabled = /^pr-[1-9][0-9]{0,9}$/.test(runtimeHandle)');
     expect(server).toContain('process.env.MATRIX_RUNTIME_SLOT === runtimeHandle');
+    expect(server).toContain('secret: () => process.env.UPGRADE_TOKEN ?? ""');
     expect(server).toContain("loadInstalledTerminalRuntimeGeneration");
     expect(server).toContain("createUserSystemdZellijRuntime");
     expect(server).toContain("createUserSystemdZellijAdapter");

--- a/tests/gateway/terminal-acceptance-auth.test.ts
+++ b/tests/gateway/terminal-acceptance-auth.test.ts
@@ -5,30 +5,58 @@ import { createTerminalAcceptanceRoutes } from "../../packages/gateway/src/shell
 
 const SECRET = "acceptance-secret-that-is-never-sent";
 
-function sign(body: string, timestamp: string, nonce: string): string {
+function sign(body: string, timestamp: string, nonce: string, secret = SECRET): string {
   const digest = createHash("sha256").update(body).digest("hex");
-  return createHmac("sha256", SECRET)
+  return createHmac("sha256", secret)
     .update(`v1\n${timestamp}\n${nonce}\n${digest}`)
     .digest("hex");
 }
 
-function request(body: string, timestamp = String(Math.floor(Date.now() / 1000)), nonce = randomBytes(16).toString("hex")) {
+function request(
+  body: string,
+  timestamp = String(Math.floor(Date.now() / 1000)),
+  nonce = randomBytes(16).toString("hex"),
+  secret = SECRET,
+) {
   return new Request("http://localhost/run", {
     method: "POST",
     headers: {
       "content-type": "application/json",
       "x-matrix-acceptance-timestamp": timestamp,
       "x-matrix-acceptance-nonce": nonce,
-      "x-matrix-acceptance-signature": sign(body, timestamp, nonce),
+      "x-matrix-acceptance-signature": sign(body, timestamp, nonce, secret),
     },
     body,
   });
 }
 
 describe("terminal production acceptance request authentication", () => {
+  it("resolves a reconciled host secret at request time", async () => {
+    let activeSecret = "stale-host-secret";
+    const run = vi.fn(async () => ({
+      stdout: "ok\n",
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      truncated: false,
+    }));
+    const app = new Hono().route("/", createTerminalAcceptanceRoutes({
+      secret: () => activeSecret,
+      run,
+    }));
+    activeSecret = SECRET;
+    const body = JSON.stringify({ command: ["/usr/bin/true"] });
+
+    const response = await app.request(request(body));
+
+    expect(response.status).toBe(200);
+    expect(run).toHaveBeenCalledOnce();
+  });
+
   it("authenticates a bounded command without transmitting the reusable secret and signs the response", async () => {
     const run = vi.fn(async () => ({ stdout: "ok\n", stderr: "", exitCode: 0, signal: null, timedOut: false, truncated: false }));
-    const app = new Hono().route("/", createTerminalAcceptanceRoutes({ secret: SECRET, run }));
+    const app = new Hono().route("/", createTerminalAcceptanceRoutes({ secret: () => SECRET, run }));
     const body = JSON.stringify({ command: ["/usr/bin/true"], timeoutMs: 1_000 });
     const requestTimestamp = String(Math.floor(Date.now() / 1000));
     const nonce = randomBytes(16).toString("hex");
@@ -45,7 +73,7 @@ describe("terminal production acceptance request authentication", () => {
 
   it("rejects stale, forged, and replayed requests before command execution", async () => {
     const run = vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0, signal: null, timedOut: false, truncated: false }));
-    const app = new Hono().route("/", createTerminalAcceptanceRoutes({ secret: SECRET, run }));
+    const app = new Hono().route("/", createTerminalAcceptanceRoutes({ secret: () => SECRET, run }));
     const body = JSON.stringify({ command: ["/usr/bin/true"] });
     const valid = request(body);
     expect((await app.request(valid.clone())).status).toBe(200);
@@ -66,7 +94,7 @@ describe("terminal production acceptance request authentication", () => {
       timedOut: false,
       truncated: false,
     }));
-    const app = new Hono().route("/", createTerminalAcceptanceRoutes({ secret: SECRET, run }));
+    const app = new Hono().route("/", createTerminalAcceptanceRoutes({ secret: () => SECRET, run }));
     const body = JSON.stringify({ command: ["/usr/bin/true"] });
     const valid = request(body);
 

--- a/tests/gateway/user-systemd-terminal-runtime.test.ts
+++ b/tests/gateway/user-systemd-terminal-runtime.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -32,14 +32,120 @@ describe("user-systemd terminal runtime", () => {
     vi.restoreAllMocks();
   });
 
+  async function installRuntimeActivationPrerequisites(): Promise<{
+    terminalRuntimeRoot: string;
+    userUnitRoot: string;
+  }> {
+    const terminalRuntimeRoot = join(homePath, "terminal-runtime");
+    const generationDir = join(terminalRuntimeRoot, "generations", GENERATION);
+    const userUnitRoot = join(homePath, "systemd-user");
+    await mkdir(generationDir, { recursive: true });
+    await mkdir(userUnitRoot, { recursive: true });
+    for (const asset of [
+      "zellij",
+      "matrix-terminal-user-keeper.mjs",
+      "matrix-terminal-attach.mjs",
+    ]) {
+      const path = join(generationDir, asset);
+      await writeFile(path, `${asset}\n`);
+      await chmod(path, 0o755);
+    }
+    await writeFile(join(generationDir, "GENERATION"), `${GENERATION}\n`);
+    await symlink(join("generations", GENERATION), join(terminalRuntimeRoot, "current"));
+    await writeFile(join(userUnitRoot, "matrix-zellij@.service"), "[Service]\n");
+    await writeFile(join(userUnitRoot, "matrix-terminal.slice"), "[Slice]\n");
+    return { terminalRuntimeRoot, userUnitRoot };
+  }
+
   it("loads only an exact generation marker from the installed app", async () => {
     const appDir = join(homePath, "installed-app");
     await mkdir(appDir);
     await writeFile(join(appDir, "TERMINAL_RUNTIME_GENERATION"), `${GENERATION}\n`);
+    const prerequisites = await installRuntimeActivationPrerequisites();
 
-    await expect(loadInstalledTerminalRuntimeGeneration(appDir)).resolves.toBe(GENERATION);
+    await expect(loadInstalledTerminalRuntimeGeneration(appDir, prerequisites)).resolves.toBe(GENERATION);
     await writeFile(join(appDir, "TERMINAL_RUNTIME_GENERATION"), "../../unsafe\n");
-    await expect(loadInstalledTerminalRuntimeGeneration(appDir)).rejects.toThrow("Terminal runtime unavailable");
+    await expect(loadInstalledTerminalRuntimeGeneration(appDir, prerequisites)).rejects.toThrow(
+      "Terminal runtime unavailable",
+    );
+  });
+
+  it("rejects activation applied by an old updater before immutable assets and user units exist", async () => {
+    const appDir = join(homePath, "old-updater-activation");
+    const terminalRuntimeRoot = join(homePath, "missing-terminal-runtime");
+    const userUnitRoot = join(homePath, "missing-systemd-user");
+    await mkdir(appDir);
+    await writeFile(join(appDir, "TERMINAL_RUNTIME_GENERATION"), `${GENERATION}\n`);
+
+    await expect(loadInstalledTerminalRuntimeGeneration(appDir, {
+      terminalRuntimeRoot,
+      userUnitRoot,
+    })).rejects.toThrow("Terminal runtime unavailable");
+  });
+
+  it("rejects incomplete or symlink-substituted activation prerequisites", async () => {
+    const appDir = join(homePath, "incomplete-activation");
+    await mkdir(appDir);
+    await writeFile(join(appDir, "TERMINAL_RUNTIME_GENERATION"), `${GENERATION}\n`);
+    const prerequisites = await installRuntimeActivationPrerequisites();
+    const generationDir = join(prerequisites.terminalRuntimeRoot, "generations", GENERATION);
+
+    await rm(join(generationDir, "matrix-terminal-user-keeper.mjs"));
+    await expect(loadInstalledTerminalRuntimeGeneration(appDir, prerequisites)).rejects.toThrow(
+      "Terminal runtime unavailable",
+    );
+
+    await writeFile(join(generationDir, "keeper-target"), "keeper\n");
+    await symlink("keeper-target", join(generationDir, "matrix-terminal-user-keeper.mjs"));
+    await expect(loadInstalledTerminalRuntimeGeneration(appDir, prerequisites)).rejects.toThrow(
+      "Terminal runtime unavailable",
+    );
+
+    await rm(join(generationDir, "matrix-terminal-user-keeper.mjs"));
+    await writeFile(join(generationDir, "matrix-terminal-user-keeper.mjs"), "keeper\n");
+    await chmod(join(generationDir, "matrix-terminal-user-keeper.mjs"), 0o755);
+    await rm(join(prerequisites.userUnitRoot, "matrix-zellij@.service"));
+    await writeFile(join(prerequisites.userUnitRoot, "unit-target"), "[Service]\n");
+    await symlink("unit-target", join(prerequisites.userUnitRoot, "matrix-zellij@.service"));
+    await expect(loadInstalledTerminalRuntimeGeneration(appDir, prerequisites)).rejects.toThrow(
+      "Terminal runtime unavailable",
+    );
+  });
+
+  it("requires the owner user manager to have loaded both static unit definitions", async () => {
+    const runCommand = vi.fn<UserSystemdCommandRunner>(async () => ({
+      stdout: "matrix-zellij@.service static -\nmatrix-terminal.slice static -\n",
+      stderr: "",
+    }));
+    const runtime = createUserSystemdTerminalRuntime({
+      homePath,
+      uid: 1001,
+      generation: GENERATION,
+      runCommand,
+    });
+
+    await expect(runtime.assertInstallationReady()).resolves.toBeUndefined();
+    expect(runCommand).toHaveBeenCalledWith(
+      "systemctl",
+      [
+        "--user",
+        "list-unit-files",
+        "matrix-zellij@.service",
+        "matrix-terminal.slice",
+        "--no-legend",
+        "--no-pager",
+      ],
+      expect.objectContaining({
+        timeoutMs: 10_000,
+        env: expect.objectContaining({
+          XDG_RUNTIME_DIR: "/run/user/1001",
+          DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/1001/bus",
+        }),
+      }),
+    );
+
+    runCommand.mockResolvedValueOnce({ stdout: "matrix-terminal.slice static -\n", stderr: "" });
+    await expect(runtime.assertInstallationReady()).rejects.toThrow("Terminal runtime unavailable");
   });
 
   it("creates an owner descriptor atomically and starts only the derived user unit", async () => {

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -797,6 +797,28 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
       .toBeLessThan(workflow.indexOf('name: Comment preview URL on PR'));
   });
 
+  it('preview VPS workflow verifies the active app version and repairs only its disposable updater transition', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
+
+    expect(workflow).toContain('probe_active_bundle_version()');
+    expect(workflow).toContain('/opt/matrix/app/BUNDLE_VERSION');
+    expect(workflow).toContain('os.O_RDONLY | os.O_NOFOLLOW');
+    expect(workflow).toContain('PLATFORM_SIGNING_SECRET="$PLATFORM_SECRET" node');
+    expect(workflow).not.toContain("' \"$HANDLE\" \"$PLATFORM_SECRET\")");
+    expect(workflow).toContain('active_bundle_version="$(probe_active_bundle_version 2>/dev/null)"');
+    expect(workflow).toContain('if [ "$active_bundle_version" != "$VERSION" ]; then');
+    expect(workflow).toContain('[[ "$HANDLE" =~ ^pr-[1-9][0-9]{0,9}$ ]]');
+    expect(workflow).toContain('transition_repair_attempted=false');
+    expect(workflow).toContain('[ "$transition_repair_attempted" != false ]');
+    expect(workflow).toContain('["/usr/bin/sudo","/usr/bin/systemctl","restart","matrix-sync-agent.service"]');
+    expect(workflow.match(/code="\$\(attempt\)"/g)).toHaveLength(3);
+    expect(workflow).toContain('Active app version for ${HANDLE}: ${active_bundle_version:-unavailable}');
+    expect(workflow).toContain('.healthy == true and .runtimeVersion == $v');
+    expect(workflow).toContain('[ "$active_bundle_version" = "$VERSION" ]');
+    expect(workflow).toContain("printf '%s' \"$address\" | grep -Eq '^([0-9]{1,3}\\.){3}[0-9]{1,3}$'");
+  });
+
   it('user-systemd acceptance recovers only its exact disposable preview updater', () => {
     const root = process.cwd();
     const workflow = readFileSync(
@@ -821,7 +843,7 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(workflow).toContain('classify_recovery_phase');
     expect(workflow).toContain('diagnose_recovery_state');
     expect(workflow).toContain('phase=(idle|prepare|download|verify|extract|terminal-runtime|app-install|host-bin|health|invalid)');
-    expect(workflow).toContain('error=(none|apply_failed|apply_interrupted|bundle_extract_failed|bundle_layout_invalid|checksum_mismatch|download_failed|download_metadata_changed|insufficient_disk_space|post_install_health_failed|post_install_host_bin_failed|post_install_rollback_failed|post_install_service_start_failed|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|update_target_mismatch|invalid)');
+    expect(workflow).toContain('error=(none|apply_failed|apply_interrupted|bundle_extract_failed|bundle_layout_invalid|checksum_mismatch|download_failed|download_metadata_changed|insufficient_disk_space|post_install_health_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_rollback_failed|post_install_service_start_failed|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|update_target_mismatch|invalid)');
     expect(workflow).toContain('recovery_diagnostic="$(diagnose_recovery_state 2>/dev/null || printf \'phase=invalid error=invalid\\n\')"');
     expect(workflow).toContain('initial_recovery_diagnostic="$(diagnose_recovery_state 2>/dev/null || printf \'phase=invalid error=invalid\\n\')"');
     expect(workflow).toContain('/usr/bin/python3 - "$error_path"');
@@ -1316,14 +1338,14 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(syncAgent).toContain('run_apply_update');
 
     const hostBinFailure = syncAgent.indexOf('log "ERROR: host-bin installation failed — rolling back"');
-    const hostBinRollback = syncAgent.indexOf('if do_rollback; then', hostBinFailure);
+    const hostBinRollback = syncAgent.indexOf('if do_rollback false; then', hostBinFailure);
     const durableHostBinError = syncAgent.indexOf('write_update_error "post_install_host_bin_failed"', hostBinFailure);
     expect(hostBinFailure).toBeGreaterThan(-1);
     expect(hostBinRollback).toBeGreaterThan(hostBinFailure);
     expect(durableHostBinError).toBeGreaterThan(hostBinRollback);
 
     const healthFailure = syncAgent.indexOf('log "ERROR: health check failed — rolling back"');
-    const healthRollback = syncAgent.indexOf('if do_rollback; then', healthFailure);
+    const healthRollback = syncAgent.indexOf('if do_rollback false; then', healthFailure);
     const durableHealthError = syncAgent.indexOf('write_update_error "post_install_health_failed"', healthFailure);
     expect(healthFailure).toBeGreaterThan(-1);
     expect(healthRollback).toBeGreaterThan(healthFailure);
@@ -1495,7 +1517,8 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(syncAgent).toContain('No update available on ${target} — nothing to apply');
     expect(syncAgent).toContain('Requested release metadata fetch failed — skipping apply');
     expect(syncAgent).toContain('readonly RELEASE_FILE="/opt/matrix/release.json"');
-    expect(syncAgent).toContain('sudo install -o root -g matrix -m 0644 "$extract_dir/release.json" "$RELEASE_FILE"');
+    expect(syncAgent).toContain('stage_release_metadata "$extract_dir/release.json" "$version"');
+    expect(syncAgent).toContain('commit_release_metadata');
     expect(syncAgent).toContain('rm -f "$UPDATE_MARKER"');
     expect(syncAgent).toContain('Update failed — will retry on next trigger');
     expect(syncAgent).toContain('Update (via SIGUSR1) failed — will retry on next trigger');
@@ -1505,6 +1528,33 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(syncAgent).toContain('for _ in $(seq 1 18); do');
     expect(syncAgent).toContain('sudo mv "$APP_DIR" "$STAGING_DIR/failed-$(date +%s)"');
     expect(syncAgent).toContain('sudo mv "$APP_DIR.rollback" "$APP_DIR"');
+  });
+
+  it('publishes installed release metadata only after the candidate app passes health', () => {
+    const root = process.cwd();
+    const syncAgent = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-sync-agent'), 'utf8');
+
+    const stageFunction = syncAgent.indexOf('stage_release_metadata()');
+    const stagedInstall = syncAgent.indexOf(
+      'sudo install -o root -g matrix -m 0644 "$source" "$incoming"',
+      stageFunction,
+    );
+    const appReplacement = syncAgent.indexOf('sudo mv "$extract_dir/app" "$APP_DIR"');
+    const healthPassed = syncAgent.indexOf('if [ "$healthy" = true ]; then');
+    const releaseCommit = syncAgent.indexOf('commit_release_metadata', healthPassed);
+    const installedLog = syncAgent.indexOf('Updated release metadata', releaseCommit);
+
+    expect(stageFunction).toBeGreaterThan(-1);
+    expect(stagedInstall).toBeGreaterThan(stageFunction);
+    expect(stagedInstall).toBeLessThan(appReplacement);
+    expect(releaseCommit).toBeGreaterThan(healthPassed);
+    expect(installedLog).toBeGreaterThan(releaseCommit);
+    expect(syncAgent.slice(appReplacement, healthPassed)).not.toContain(
+      'sudo install -o root -g matrix -m 0644 "$extract_dir/release.json" "$RELEASE_FILE"',
+    );
+    expect(syncAgent).toContain('write_update_error "post_install_release_metadata_failed"');
+    expect(syncAgent).toContain('rollback_release_metadata_is_ready "$APP_DIR.rollback"');
+    expect(syncAgent).toContain('restore_rollback_release_metadata');
   });
 
   it('sync agent atomically replaces host-bin scripts without truncating itself', () => {


### PR DESCRIPTION
## Summary

- fail gateway startup when user-systemd activation is requested but its immutable runtime assets or static user units are incomplete
- verify the matrix user manager can discover both terminal unit definitions before the gateway advertises health
- resolve the preview acceptance HMAC secret once per request so reconciled host credentials cannot diverge from construction-time state
- stage bounded release metadata before app replacement and commit it only after candidate health succeeds; explicit rollback restores matching app and release metadata together
- make Preview VPS verify the active `/opt/matrix/app/BUNDLE_VERSION` instead of treating `/opt/matrix/release.json` as installation proof
- permit one bounded updater restart and exact-version reapply only on a disposable `pr-<number>` preview when a pre-terminal-runtime updater process retained the new helper after fail-closed rollback
- document complete-bootstrap rollout for new signups and dormant-bootstrap then activation for existing users, with no legacy terminal fallback

## Root cause and live reproduction

The preserved `pr-1215` canary proved the candidate app payload was complete, but the process performing the first activation update had started from pre-#1129 updater code. That old in-memory process skipped `terminal-runtime/` and `user-systemd/`, installed the activated app and new host helper, then rolled the app back when gateway readiness failed. It had already advanced `/opt/matrix/release.json`, so fleet and Preview VPS falsely reported the candidate version while `/opt/matrix/app/BUNDLE_VERSION` and the running gateway were still `v2026.08.08-920`.

Without deleting or reprovisioning the VPS, a bounded restart of the newly installed sync agent followed by an exact-version c902 reapply installed the immutable generation and both user units. The active app then matched c902 and the signed acceptance route returned HTTP 200 with zero clock skew. This is prior-head diagnostic evidence, not acceptance evidence for the current head.

## Tests

- TDD red/green: activation rejects missing assets, unit files, symlink substitution, and missing user-manager discovery
- TDD red/green: acceptance HMAC resolves the live host secret once per request
- TDD red/green: Preview VPS requires the active app version and bounds updater-transition repair to disposable PR handles
- TDD red/green: updater publishes release metadata only after health and keeps rollback metadata aligned
- `pnpm exec vitest run tests/gateway/auth.test.ts tests/gateway/terminal-acceptance-auth.test.ts tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts tests/gateway/user-systemd-terminal-runtime.test.ts tests/gateway/user-systemd-terminal-activation.test.ts` — 83/83 passed at `7e66e38bf2e63a56f0c05040107d45de2ccb8a1b`
- focused updater/preview regression selection — 3/3 passed
- `tests/platform/customer-vps-host-bundle.test.ts` — 64/65 passed; the pre-existing root-permission simulation cannot induce its expected log-write denial in this environment, while all changed-area assertions pass
- all package TypeScript checks passed using the pnpm commands equivalent to `bun run typecheck`; Bun is unavailable locally
- `pnpm run check:patterns` — 0 violations, five existing warnings outside this diff
- Bash syntax and `git diff --check` — passed
- no React files changed; React Doctor and screenshot evidence are not applicable

## Exact-head production evidence

- accepted commit: `7e66e38bf2e63a56f0c05040107d45de2ccb8a1b`
- Preview VPS run: [31650820030](https://github.com/HamedMP/matrix-os/actions/runs/31650820030) — passed
- Preview bundle: `v2026.08.12-pr1215-31650820030-1-7e66e38`
- Preview target: disposable `pr-1215`; active `/opt/matrix/app/BUNDLE_VERSION` independently matched the exact bundle, with no update error
- Production acceptance run: [31651693765](https://github.com/HamedMP/matrix-os/actions/runs/31651693765) — passed
- Acceptance bundle A: `v0.0.0-user-systemd-accept-7e66e38-31651693765-1-a`
- Acceptance bundle B: `v0.0.0-user-systemd-accept-7e66e38-31651693765-1-b`
- Evidence artifact: `user-systemd-terminal-production-7e66e38bf2e63a56f0c05040107d45de2ccb8a1b`
- Evidence summary SHA-256: `f548bea9fc12bfacebbe06725a54e3001c513a182cbadd020903f22740c46e46`
- Evidence JSON file SHA-256: `7fdf9c57f053d1dc4b20ca592a6d5ebd68250be5163e973033762d5ad96dc1e2`

The exact-head matrix passed ordinary shell and real Codex runtime creation, browser detach, gateway graceful restart and SIGKILL, two exact-head updates, rollback, generation pinning/current-generation creation, gateway memory isolation, runtime and aggregate resource controls, isolated bounded limit breach, exact/idempotent deletion, malformed/symlink/conflicting state rejection, bounded generation GC, and reboot with no runtime restart, replacement PID, or new output. The artifact is privacy-bounded to assertion names and immutable identifiers; it excludes terminal contents, credentials, host addresses, user files, and unrestricted logs.

No release channel was promoted, no stable deployment occurred, and no customer VPS was touched.

## Review / monitoring

- current exact head: `7e66e38bf2e63a56f0c05040107d45de2ccb8a1b`
- exact-head Preview VPS and production acceptance are green
- latest trusted Greptile result: 5/5 on `7e66e38bf2e63a56f0c05040107d45de2ccb8a1b`; no blocking or non-blocking findings
- review threads: zero open or unresolved; no human review objections are present
- `ready-for-ci`: applied
- exact-head CI run: [31653480039](https://github.com/HamedMP/matrix-os/actions/runs/31653480039) — passed (typecheck, pattern scan, docs contracts, sync package, shell production build, four unit-test shards, E2E, aggregate result)
- exact-head Docker run: [31653480018](https://github.com/HamedMP/matrix-os/actions/runs/31653480018) — passed (relevance detection, image build, PR fresh-install smoke)
- Docker scenario matrix: intentionally skipped because `.github/workflows/docker-test.yml` restricts the full upgrade/customized-files/channels/recovery matrix to non-PR events; PR events run the fresh-install smoke path
- earlier preview and acceptance runs are diagnostic history only and are not counted for this head

## Invariants

- **Source of truth:** activation requires agreement between the installed app marker, marker-pinned immutable generation, exact `current` link, runtime assets, regular static user units, and owner-manager discovery. `/opt/matrix/app/BUNDLE_VERSION` is the active installation version; release metadata is published only after candidate health.
- **Lock/transaction scope:** release metadata is validated and staged before service interruption, then atomically renamed only after health. The prior release metadata remains unchanged on pre-commit failure. Existing descriptor creation/deletion locks and generation GC locks are unchanged; no network call occurs inside gateway readiness.
- **Acceptable orphan states:** a pre-terminal-runtime updater process may retain the newer host helper after the activated app rolls back. The disposable preview workflow may restart that exact helper once and reapply the same immutable version. Customer migration does not rely on this state and uses a dormant bootstrap first. Failed candidates remain bounded staging artifacts under the existing cleanup policy.
- **Auth source of truth:** platform-authenticated preview deployment derives the scoped runtime token from `PLATFORM_SECRET` without passing the reusable secret in command arguments. Acceptance uses the live host `UPGRADE_TOKEN`, resolved once per request; nonce, timestamp, body-limit, request-signature, and response-signature controls remain in force.
- **Deferred scope:** this PR does not promote any channel, deploy a customer VPS, migrate a live legacy session, introduce a legacy fallback, refresh a production golden image, or change the approved reduced reboot behavior.

## Rollout contract

- **New signups:** use a refreshed golden image or clean bootstrap that installs app, immutable terminal runtime, and user units before gateway startup.
- **Existing users:** deploy and verify a dormant #1129-era bootstrap/updater first, then deploy activation. A direct old-process-to-activation jump remains fail closed and is not the customer migration path.
- **Fallback:** activation never falls back to gateway-owned legacy terminal supervision.
