### PR TITLE
fix(platform): preserve recruiting ATS deployment wiring

### DIFF
--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -154,6 +154,48 @@ jobs:
             exit 1
           fi
 
+      - name: Verify recruiting ATS secrets
+        if: ${{ env.DEPLOY_ENVIRONMENT == 'production' }}
+        run: |
+          set -euo pipefail
+          required_ats_secrets=(
+            ATS_DATABASE_URL=ats-database-url
+            ATS_INGEST_SECRET=ats-ingest-secret
+            ATS_ADMIN_SECRET=ats-admin-secret
+          )
+
+          for entry in "${required_ats_secrets[@]}"; do
+            env_name="${entry%%=*}"
+            secret_name="${entry#*=}"
+            gcloud secrets describe "$secret_name" \
+              --project "$GCP_PROJECT_ID" >/dev/null
+            ats_secret_tmpfile="$(mktemp)"
+            if ! gcloud secrets versions access latest --secret "$secret_name" \
+              --project "$GCP_PROJECT_ID" >"$ats_secret_tmpfile"; then
+              rm -f "$ats_secret_tmpfile"
+              echo "$secret_name must have an accessible latest version for $env_name." >&2
+              exit 1
+            fi
+            if [ ! -s "$ats_secret_tmpfile" ]; then
+              rm -f "$ats_secret_tmpfile"
+              echo "$secret_name must not be empty for $env_name." >&2
+              exit 1
+            fi
+            rm -f "$ats_secret_tmpfile"
+            accessor_member="$(
+              gcloud secrets get-iam-policy "$secret_name" \
+                --project "$GCP_PROJECT_ID" \
+                --flatten='bindings[].members' \
+                --filter="bindings.role:roles/secretmanager.secretAccessor AND bindings.members:serviceAccount:${CLOUD_RUN_SERVICE_ACCOUNT}" \
+                --format='value(bindings.members)' \
+                | head -1
+            )"
+            if [ "$accessor_member" != "serviceAccount:${CLOUD_RUN_SERVICE_ACCOUNT}" ]; then
+              echo "$secret_name must grant roles/secretmanager.secretAccessor to ${CLOUD_RUN_SERVICE_ACCOUNT}" >&2
+              exit 1
+            fi
+          done
+
       - name: Verify Stripe billing secrets
         run: |
           set -euo pipefail
@@ -438,6 +480,11 @@ jobs:
             traffic_flags+=(--no-traffic)
           fi
 
+          ats_secret_bindings=""
+          if [ "$DEPLOY_ENVIRONMENT" = "production" ]; then
+            ats_secret_bindings=",ATS_DATABASE_URL=ats-database-url:latest,ATS_INGEST_SECRET=ats-ingest-secret:latest,ATS_ADMIN_SECRET=ats-admin-secret:latest"
+          fi
+
           # TODO(#410): flip CUSTOMER_VPS_TLS_VERIFY back to true once customer VPS origins present trusted certs.
           if ! deploy_json=$(gcloud run deploy "$CLOUD_RUN_SERVICE" \
             --project "$GCP_PROJECT_ID" \
@@ -456,7 +503,7 @@ jobs:
             --allow-unauthenticated \
             "${traffic_flags[@]}" \
             --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_BACKGROUND_WORKERS_ENABLED=false,PLATFORM_PORT=8080,PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL},MATRIX_API_ORIGIN=${MATRIX_API_ORIGIN},CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_TLS_VERIFY=false,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_APP_DOMAIN_HOSTS=${MATRIX_APP_DOMAIN_HOSTS},MATRIX_CODE_DOMAIN_HOSTS=${MATRIX_CODE_DOMAIN_HOSTS},NEXT_PUBLIC_MATRIX_APP_URL=${MATRIX_APP_URL},MATRIX_BILLING_PROVIDER=stripe,POSTHOG_HOST=https://eu.i.posthog.com,POSTHOG_API_HOST=https://eu.i.posthog.com,NEXT_PUBLIC_POSTHOG_HOST=${POSTHOG_PUBLIC_HOST},NEXT_PUBLIC_POSTHOG_API_HOST=${POSTHOG_PUBLIC_API_HOST},R2_PREFIX_ROOT=matrixos-sync,GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED},GOLDEN_SNAPSHOTS_ENABLED=false,GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0" \
-            --set-secrets "PLATFORM_DATABASE_URL=platform-database-url:latest,PLATFORM_SECRET=platform-secret:latest,GOLDEN_SNAPSHOT_OPERATOR_SECRET=golden-snapshot-operator-secret:latest,PLATFORM_JWT_SECRET=platform-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,STRIPE_SECRET_KEY=stripe-secret-key:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual:latest,PIPEDREAM_CLIENT_ID=pipedream-client-id:latest,PIPEDREAM_CLIENT_SECRET=pipedream-client-secret:latest,PIPEDREAM_PROJECT_ID=pipedream-project-id:latest,PIPEDREAM_ENVIRONMENT=pipedream-environment:latest,R2_ACCOUNT_ID=r2-account-id:latest,R2_BUCKET=r2-bucket:latest,R2_ENDPOINT=r2-endpoint:latest,R2_ACCESS_KEY_ID=r2-access-key-id:latest,R2_SECRET_ACCESS_KEY=r2-secret-access-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,HETZNER_API_TOKEN=hetzner-api-token:latest,POSTHOG_TOKEN=posthog-token:latest,POSTHOG_PROJECT_TOKEN=posthog-project-token:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,NEXT_PUBLIC_POSTHOG_KEY=next-public-posthog-key:latest,NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=next-public-posthog-project-token:latest" \
+            --set-secrets "PLATFORM_DATABASE_URL=platform-database-url:latest,PLATFORM_SECRET=platform-secret:latest,GOLDEN_SNAPSHOT_OPERATOR_SECRET=golden-snapshot-operator-secret:latest,PLATFORM_JWT_SECRET=platform-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,STRIPE_SECRET_KEY=stripe-secret-key:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual:latest,PIPEDREAM_CLIENT_ID=pipedream-client-id:latest,PIPEDREAM_CLIENT_SECRET=pipedream-client-secret:latest,PIPEDREAM_PROJECT_ID=pipedream-project-id:latest,PIPEDREAM_ENVIRONMENT=pipedream-environment:latest,R2_ACCOUNT_ID=r2-account-id:latest,R2_BUCKET=r2-bucket:latest,R2_ENDPOINT=r2-endpoint:latest,R2_ACCESS_KEY_ID=r2-access-key-id:latest,R2_SECRET_ACCESS_KEY=r2-secret-access-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,HETZNER_API_TOKEN=hetzner-api-token:latest,POSTHOG_TOKEN=posthog-token:latest,POSTHOG_PROJECT_TOKEN=posthog-project-token:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,NEXT_PUBLIC_POSTHOG_KEY=next-public-posthog-key:latest,NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=next-public-posthog-project-token:latest${ats_secret_bindings}" \
             --format=json); then
             exit 1
           fi
@@ -490,6 +537,42 @@ jobs:
             exit 1
           fi
           curl --fail --silent --show-error --max-time 10 "$CANDIDATE_URL/health" >/dev/null
+          if [ "$DEPLOY_ENVIRONMENT" = "production" ]; then
+            ats_ingest_secret="$(gcloud secrets versions access latest \
+              --secret ats-ingest-secret \
+              --project "$GCP_PROJECT_ID" | tr -d '\r\n')"
+            ats_admin_secret="$(gcloud secrets versions access latest \
+              --secret ats-admin-secret \
+              --project "$GCP_PROJECT_ID" | tr -d '\r\n')"
+            if [ -z "$ats_ingest_secret" ] || [ -z "$ats_admin_secret" ]; then
+              echo "ATS smoke could not read the required scoped secrets." >&2
+              exit 1
+            fi
+            echo "::add-mask::$ats_ingest_secret"
+            echo "::add-mask::$ats_admin_secret"
+            ats_ingest_body="$(mktemp)"
+            ats_admin_body="$(mktemp)"
+            trap 'rm -f "$ats_ingest_body" "$ats_admin_body"' EXIT
+            ats_ingest_status="$(curl --silent --show-error --max-time 10 \
+              --output "$ats_ingest_body" \
+              --write-out '%{http_code}' \
+              --request POST \
+              --header "authorization: Bearer ${ats_ingest_secret}" \
+              --form "source=deployment_smoke" \
+              "$CANDIDATE_URL/api/ats/applications")"
+            if [ "$ats_ingest_status" != "422" ]; then
+              echo "ATS ingest smoke expected validation status 422, received ${ats_ingest_status}." >&2
+              exit 1
+            fi
+            curl --fail --silent --show-error --max-time 10 \
+              --output "$ats_admin_body" \
+              --header "authorization: Bearer ${ats_admin_secret}" \
+              "$CANDIDATE_URL/api/ats/admin/applications?search=__deployment_smoke__"
+            if ! jq -e '.applications | type == "array"' "$ats_admin_body" >/dev/null; then
+              echo "ATS admin database smoke did not return an application list." >&2
+              exit 1
+            fi
+          fi
           # /sign-in is only served as the pre-VPS auth shell on app-domain hosts.
           # The raw candidate tag URL is not an app-domain host, so simulate the
           # edge router with x-forwarded-host + x-matrix-edge-secret instead of

--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -54,6 +54,7 @@ jobs:
       MATRIX_APP_DOMAIN_HOSTS: ${{ vars.MATRIX_APP_DOMAIN_HOSTS }}
       MATRIX_CODE_DOMAIN_HOSTS: ${{ vars.MATRIX_CODE_DOMAIN_HOSTS }}
       CUSTOMER_VPS_IMAGE_VERSION: ${{ vars.CUSTOMER_VPS_IMAGE_VERSION }}
+      ATS_BOOKING_BASE_URL: ${{ vars.ATS_BOOKING_BASE_URL }}
       GOLDEN_SNAPSHOT_BUILDS_ENABLED: ${{ vars.GOLDEN_SNAPSHOT_BUILDS_ENABLED || 'false' }}
       POSTHOG_PUBLIC_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.posthog.com' }}
       POSTHOG_PUBLIC_API_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_API_HOST || '/relay' }}
@@ -82,6 +83,9 @@ jobs:
               missing+=("$name")
             fi
           done
+          if [ "$DEPLOY_ENVIRONMENT" = "production" ] && [ -z "${ATS_BOOKING_BASE_URL:-}" ]; then
+            missing+=("ATS_BOOKING_BASE_URL")
+          fi
           if [ "${#missing[@]}" -gt 0 ]; then
             printf 'Missing required GitHub environment variable(s): %s\n' "${missing[*]}" >&2
             exit 1
@@ -480,8 +484,10 @@ jobs:
             traffic_flags+=(--no-traffic)
           fi
 
+          ats_env_bindings=""
           ats_secret_bindings=""
           if [ "$DEPLOY_ENVIRONMENT" = "production" ]; then
+            ats_env_bindings=",ATS_BOOKING_BASE_URL=${ATS_BOOKING_BASE_URL}"
             ats_secret_bindings=",ATS_DATABASE_URL=ats-database-url:latest,ATS_INGEST_SECRET=ats-ingest-secret:latest,ATS_ADMIN_SECRET=ats-admin-secret:latest"
           fi
 
@@ -502,7 +508,7 @@ jobs:
             --ingress all \
             --allow-unauthenticated \
             "${traffic_flags[@]}" \
-            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_BACKGROUND_WORKERS_ENABLED=false,PLATFORM_PORT=8080,PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL},MATRIX_API_ORIGIN=${MATRIX_API_ORIGIN},CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_TLS_VERIFY=false,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_APP_DOMAIN_HOSTS=${MATRIX_APP_DOMAIN_HOSTS},MATRIX_CODE_DOMAIN_HOSTS=${MATRIX_CODE_DOMAIN_HOSTS},NEXT_PUBLIC_MATRIX_APP_URL=${MATRIX_APP_URL},MATRIX_BILLING_PROVIDER=stripe,POSTHOG_HOST=https://eu.i.posthog.com,POSTHOG_API_HOST=https://eu.i.posthog.com,NEXT_PUBLIC_POSTHOG_HOST=${POSTHOG_PUBLIC_HOST},NEXT_PUBLIC_POSTHOG_API_HOST=${POSTHOG_PUBLIC_API_HOST},R2_PREFIX_ROOT=matrixos-sync,GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED},GOLDEN_SNAPSHOTS_ENABLED=false,GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0" \
+            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_BACKGROUND_WORKERS_ENABLED=false,PLATFORM_PORT=8080,PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL},MATRIX_API_ORIGIN=${MATRIX_API_ORIGIN},CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_TLS_VERIFY=false,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_APP_DOMAIN_HOSTS=${MATRIX_APP_DOMAIN_HOSTS},MATRIX_CODE_DOMAIN_HOSTS=${MATRIX_CODE_DOMAIN_HOSTS},NEXT_PUBLIC_MATRIX_APP_URL=${MATRIX_APP_URL},MATRIX_BILLING_PROVIDER=stripe,POSTHOG_HOST=https://eu.i.posthog.com,POSTHOG_API_HOST=https://eu.i.posthog.com,NEXT_PUBLIC_POSTHOG_HOST=${POSTHOG_PUBLIC_HOST},NEXT_PUBLIC_POSTHOG_API_HOST=${POSTHOG_PUBLIC_API_HOST},R2_PREFIX_ROOT=matrixos-sync,GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED},GOLDEN_SNAPSHOTS_ENABLED=false,GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0${ats_env_bindings}" \
             --set-secrets "PLATFORM_DATABASE_URL=platform-database-url:latest,PLATFORM_SECRET=platform-secret:latest,GOLDEN_SNAPSHOT_OPERATOR_SECRET=golden-snapshot-operator-secret:latest,PLATFORM_JWT_SECRET=platform-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,STRIPE_SECRET_KEY=stripe-secret-key:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual:latest,PIPEDREAM_CLIENT_ID=pipedream-client-id:latest,PIPEDREAM_CLIENT_SECRET=pipedream-client-secret:latest,PIPEDREAM_PROJECT_ID=pipedream-project-id:latest,PIPEDREAM_ENVIRONMENT=pipedream-environment:latest,R2_ACCOUNT_ID=r2-account-id:latest,R2_BUCKET=r2-bucket:latest,R2_ENDPOINT=r2-endpoint:latest,R2_ACCESS_KEY_ID=r2-access-key-id:latest,R2_SECRET_ACCESS_KEY=r2-secret-access-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,HETZNER_API_TOKEN=hetzner-api-token:latest,POSTHOG_TOKEN=posthog-token:latest,POSTHOG_PROJECT_TOKEN=posthog-project-token:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,NEXT_PUBLIC_POSTHOG_KEY=next-public-posthog-key:latest,NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=next-public-posthog-project-token:latest${ats_secret_bindings}" \
             --format=json); then
             exit 1
@@ -562,6 +568,10 @@ jobs:
               "$CANDIDATE_URL/api/ats/applications")"
             if [ "$ats_ingest_status" != "422" ]; then
               echo "ATS ingest smoke expected validation status 422, received ${ats_ingest_status}." >&2
+              exit 1
+            fi
+            if ! jq -e '.error == "Invalid application" and keys == ["error"]' "$ats_ingest_body" >/dev/null; then
+              echo "ATS ingest smoke did not return the expected safe validation response." >&2
               exit 1
             fi
             curl --fail --silent --show-error --max-time 10 \

--- a/docs/platform/dev/deployment.md
+++ b/docs/platform/dev/deployment.md
@@ -52,6 +52,7 @@ PLATFORM_JWT_SECRET=...
 ATS_DATABASE_URL=postgresql://.../matrix_ats
 ATS_INGEST_SECRET=...
 ATS_ADMIN_SECRET=...
+ATS_BOOKING_BASE_URL=https://booking-provider.example/...
 
 CUSTOMER_VPS_ENABLED=true
 CUSTOMER_VPS_IMAGE_VERSION=matrix-os-host-dev
@@ -80,9 +81,10 @@ endpoint parameters in its connection URL, and store the three settings in
 Secret Manager as `ats-database-url`, `ats-ingest-secret`, and
 `ats-admin-secret`. Grant the Cloud Run service account
 `roles/secretmanager.secretAccessor` on each secret. The production deployment
-preflights all three, mounts them into the candidate revision, checks the
-authenticated ingest route, and performs a read against the ATS database before
-promotion. Staging does not mount the production ATS secrets.
+preflights all three and requires `ATS_BOOKING_BASE_URL` as a production GitHub
+environment variable, mounts the ATS settings into the candidate revision,
+checks the authenticated ingest route, and performs a read against the ATS
+database before promotion. Staging does not mount the production ATS settings.
 
 Platform-owned integrations also need:
 

--- a/docs/platform/dev/deployment.md
+++ b/docs/platform/dev/deployment.md
@@ -49,6 +49,10 @@ CLERK_SECRET_KEY=sk_live_or_test_...
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_or_test_...
 PLATFORM_JWT_SECRET=...
 
+ATS_DATABASE_URL=postgresql://.../matrix_ats
+ATS_INGEST_SECRET=...
+ATS_ADMIN_SECRET=...
+
 CUSTOMER_VPS_ENABLED=true
 CUSTOMER_VPS_IMAGE_VERSION=matrix-os-host-dev
 HETZNER_API_TOKEN=...
@@ -69,6 +73,16 @@ bearer-returning runtime-selection exchange fails closed when this value is
 missing or aliases a renderer-accessible host.
 
 `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is required at host-bundle build time because it is baked into the Next.js shell bundle.
+
+Production recruiting uses a dedicated database in the production Neon project.
+Create the database beside the platform database, preserve the same TLS and
+endpoint parameters in its connection URL, and store the three settings in
+Secret Manager as `ats-database-url`, `ats-ingest-secret`, and
+`ats-admin-secret`. Grant the Cloud Run service account
+`roles/secretmanager.secretAccessor` on each secret. The production deployment
+preflights all three, mounts them into the candidate revision, checks the
+authenticated ingest route, and performs a read against the ATS database before
+promotion. Staging does not mount the production ATS secrets.
 
 Platform-owned integrations also need:
 

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -330,6 +330,8 @@ describe('CI workflows', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
 
+    expect(workflow).toContain('ATS_BOOKING_BASE_URL: ${{ vars.ATS_BOOKING_BASE_URL }}');
+    expect(workflow).toContain('ATS_BOOKING_BASE_URL=${ATS_BOOKING_BASE_URL}');
     expect(workflow).toContain('Verify recruiting ATS secrets');
     expect(workflow).toContain('ATS_DATABASE_URL=ats-database-url');
     expect(workflow).toContain('ATS_INGEST_SECRET=ats-ingest-secret');
@@ -340,6 +342,7 @@ describe('CI workflows', () => {
     expect(workflow).toContain('ats_secret_tmpfile="$(mktemp)"');
     expect(workflow).toContain('ATS ingest smoke');
     expect(workflow).toContain('/api/ats/applications');
+    expect(workflow).toContain(".error == \"Invalid application\" and keys == [\"error\"]");
     expect(workflow).toContain('ATS admin database smoke');
     expect(workflow).toContain('/api/ats/admin/applications');
   });

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -326,6 +326,24 @@ describe('CI workflows', () => {
     expect(workflow).toContain('pipedream_secret_tmpfile="$(mktemp)"');
   });
 
+  it('preflights, mounts, and smokes the dedicated recruiting ATS dependencies', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
+
+    expect(workflow).toContain('Verify recruiting ATS secrets');
+    expect(workflow).toContain('ATS_DATABASE_URL=ats-database-url');
+    expect(workflow).toContain('ATS_INGEST_SECRET=ats-ingest-secret');
+    expect(workflow).toContain('ATS_ADMIN_SECRET=ats-admin-secret');
+    expect(workflow).toContain('ATS_DATABASE_URL=ats-database-url:latest');
+    expect(workflow).toContain('ATS_INGEST_SECRET=ats-ingest-secret:latest');
+    expect(workflow).toContain('ATS_ADMIN_SECRET=ats-admin-secret:latest');
+    expect(workflow).toContain('ats_secret_tmpfile="$(mktemp)"');
+    expect(workflow).toContain('ATS ingest smoke');
+    expect(workflow).toContain('/api/ats/applications');
+    expect(workflow).toContain('ATS admin database smoke');
+    expect(workflow).toContain('/api/ats/admin/applications');
+  });
+
   it('preflights billing price secrets before deploying platform Cloud Run', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');


### PR DESCRIPTION
## Summary

- preflight the dedicated production ATS database and scoped ingest/admin secrets
- mount ATS database, ingest, admin, and booking configuration on production candidates while keeping staging isolated
- smoke authenticated ingest validation and a read-only ATS database/admin query before promotion
- preserve the verified image digest, worker-disabled zero-traffic candidate, production-role promotion, and traffic verification flow

## Incident fixed

The production careers form returned 503 because the revision serving `api.matrix-os.com` did not have `ATS_DATABASE_URL`, `ATS_INGEST_SECRET`, or `ATS_ADMIN_SECRET` mounted. Requests fell through to general platform authentication and returned 401. Production was repaired manually on 2026-08-13 and verified end to end with HTTP 201, a receipt, and persisted ATS lookup. This PR makes the required wiring durable in the normal reviewed push-to-main deployment workflow.

## Tests

- workflow YAML parsed successfully
- all 14 workflow `run` blocks passed `bash -n`
- `tests/platform/ci-workflows.test.ts`: 30 passed
- ATS route, database-isolation, and repository suites: 20 passed
- `bun run typecheck`: passed
- `bun run check:patterns`: passed with zero violations
- `git diff --check`: passed
- local `bun run test`: 10,658 passed; 18 unrelated macOS failures in existing coding-agent/UI suites caused by Unix socket, interactive shell, and pnpm global-link resolution behavior
- exact-head GitHub CI: passed, including all four unit-test shards, E2E, typecheck, pattern scan, docs contracts, React Doctor, shell production build, sync-client packaging, and the aggregate CI Results gate

## Review / monitoring

- exact head: `a01189dd407d62aeac467d9f8d3b5e9fc3cd8bbf`
- addressed and resolved the Codex finding that `--set-env-vars` would otherwise erase `ATS_BOOKING_BASE_URL`
- exact-head Greptile review: 5/5 with no blocking findings
- `ready-for-ci`: applied after exact-head Greptile reached 5/5
- exact-head label-gated CI: fully passed

## Invariants

- **Source of truth:** production ATS credentials remain Secret Manager secrets (`ats-database-url`, `ats-ingest-secret`, and `ats-admin-secret`); the booking URL remains the production GitHub environment variable `ATS_BOOKING_BASE_URL`; this workflow is the deployment source of truth.
- **Lock/transaction scope:** no application data mutation is added. GitHub workflow concurrency serializes platform deployments; the ingest smoke is deliberately rejected by validation before application creation, and the admin smoke is read-only.
- **Acceptable orphan states:** a failed preflight or smoke may leave a tagged candidate revision with workers disabled and no production traffic. The production-role revision also remains at no traffic until the existing explicit promotion step succeeds.
- **Auth source of truth:** Cloud Run reads ATS secrets through the configured service account's Secret Manager accessor grants; smoke requests use the scoped ingest/admin bearer secrets and never print secret values or response bodies.
- **Deferred scope:** this PR does not create or edit secrets or IAM grants, deploy revisions, change traffic, modify production, merge the PR, or enable golden snapshot builds or selection.

## Prior manual verification

- zero-traffic Cloud Run candidate: authenticated ingest returned the expected 422 validation response
- zero-traffic Cloud Run candidate: authenticated ATS admin database read passed
- public `matrix-os.com/api/careers/apply`: HTTP 201
- returned receipt persisted in the ATS database
