### PR TITLE
docs(chat): define provider-neutral architecture

### DIFF
--- a/docs/superpowers/plans/2026-08-13-provider-neutral-chat-architecture.md
+++ b/docs/superpowers/plans/2026-08-13-provider-neutral-chat-architecture.md
@@ -76,7 +76,8 @@ until its PR exists, then `PR In Review`, and never `Done` before merge.
 - `packages/gateway/src/chat/repository.ts`: owner-scoped reads/mutations,
   transactions, optimistic revisions, and outbox insertion.
 - `packages/gateway/src/chat/project-resolver.ts`: immutable-ID ProjectConfig
-  resolution with safe public projection and internal working root.
+  resolution with safe public projection plus exact direct-project/registered-
+  worktree execution-root references and fingerprints.
 - `packages/gateway/src/chat/service.ts`: authorization-independent orchestration
   over repository/project resolver; no Hono or provider code.
 - `packages/gateway/src/chat/routes.ts`: Hono validation, auth principal mapping,
@@ -219,12 +220,14 @@ git commit -m "feat(contracts): define canonical chat model"
 - Create: `tests/gateway/chat-project-resolver.test.ts`
 
 **Interfaces:**
-- Consumes: `ProjectConfig`, `OwnerScope`, and existing safe project reads.
+- Consumes: `ProjectConfig`, `OwnerScope`, existing safe project reads, and
+  WorktreeManager's validated records.
 - Produces: `ProjectLookupResult`,
   `ProjectManager.getProjectById(input: { ownerScope: OwnerScope;
   projectId: string }): Promise<ProjectLookupResult>` and
-  `ChatProjectResolver.resolve(ownerScope, projectId)` returning separate
-  internal `workingDirectory` and safe `ChatProjectProjection`.
+  `ChatProjectResolver.resolve(ownerScope, projectId)` returning a safe
+  `ChatProjectProjection`, plus `resolveExecutionRoot(ownerScope,
+  { projectId, worktreeId? })` returning an internal exact root and fingerprint.
 
 - [ ] **Step 1: Write failing immutable-ID tests**
 
@@ -235,10 +238,19 @@ const after = await projects.getProjectById({ ownerScope, projectId: created.id 
 expect(before.ok && after.ok && after.project.id).toBe(created.id);
 expect(JSON.stringify((await resolver.resolve(ownerScope, created.id)).projection))
   .not.toContain(created.localPath);
+
+expect(await resolver.resolveExecutionRoot(ownerScope, {
+  projectId: githubProject.id,
+  worktreeId: registeredSiblingWorktree.id,
+})).toMatchObject({ ref: { kind: "worktree", projectId: githubProject.id } });
 ```
 
 Cover duplicate IDs, archived/deleting configs, owner mismatch, unreadable
-paths, cache eviction, and reconciliation after file changes.
+paths, cache eviction, and reconciliation after file changes. Add fixtures for
+a managed repository root, an owner-approved external folder project's exact
+`localPath`, a registered sibling worktree, an unregistered sibling with the
+same prefix, mismatched project/worktree metadata, deleted/moved worktrees, and
+symlink retargeting. Public projections must contain neither root path.
 
 - [ ] **Step 2: Run tests and verify Red**
 
@@ -252,6 +264,10 @@ export type ProjectLookupResult =
   | { ok: true; project: ProjectConfig }
   | { ok: false; status: number; error: WorkspaceError };
 
+export type ChatExecutionRootRef =
+  | { kind: "project"; projectId: string }
+  | { kind: "worktree"; projectId: string; worktreeId: string };
+
 async getProjectById(input: { ownerScope: OwnerScope; projectId: string }) {
   const project = await immutableIdIndex.resolve(input.projectId);
   if (!project || !ownerScopeMatches(project.ownerScope, input.ownerScope)) {
@@ -264,7 +280,14 @@ async getProjectById(input: { ownerScope: OwnerScope; projectId: string }) {
 Build the index only from validated owner file configs, cap entries to the
 existing project maximum, invalidate it on create/lifecycle/delete/file-watch
 changes, and fail closed on duplicate immutable IDs. Do not store ProjectConfig
-in PostgreSQL.
+in PostgreSQL. Resolve direct roots by exact realpath equality with the current
+`ProjectConfig.localPath`; resolve worktrees only from an exact WorktreeManager
+record for that ProjectConfig's slug and canonical managed worktree metadata.
+Never approve a path merely because it shares an ancestor or string prefix.
+Fingerprint the canonical safe reference, owner scope, immutable project ID,
+validated project realpath, and, for worktrees, the record ID/project slug/
+validated realpath/creation timestamp. Persist only that fingerprint and safe
+reference with the Run, then require an exact match on pre-dispatch re-resolution.
 
 - [ ] **Step 4: Run tests and verify Green**
 
@@ -497,10 +520,12 @@ expect(await migration.hasCutoverMarker()).toBe(false);
 ```
 
 Cover symlinks, oversized/invalid JSON, duplicate IDs, crash after each phase,
-valid/invalid resume state, preservation of Pi `cwd` inside the resolved owner
-project root, quarantine outside that root, transcript ordering, active Run
-drain, final delta, marker atomicity, old-release startup refusal, and legacy-ID
-translation before, exactly at, and after the immutable 90-day expiry.
+valid/invalid resume state, preservation of Pi `cwd` for the exact current
+project root, owner-approved external folder root, and registered sibling
+worktree, quarantine of arbitrary/unregistered/ambiguous sibling paths,
+transcript ordering, active Run drain, final delta, marker atomicity,
+old-release startup refusal, and legacy-ID translation before, exactly at, and
+after the immutable 90-day expiry.
 
 - [ ] **Step 2: Run tests and verify Red**
 
@@ -683,7 +708,7 @@ git commit -m "feat(chat): define harness capability registry"
 
 **Interfaces:**
 - Consumes: accepted Runs from Slice A, harness/model registries, adapter-only
-  state repository, canonical history pages.
+  state repository, canonical history pages, and exact execution-root resolver.
 - Produces: `startAcceptedRun`, `resumeRun`, `cancelRun`, and `forkChat`.
 
 - [ ] **Step 1: Write failing lifecycle tests**
@@ -694,12 +719,16 @@ await expect(orchestrator.resumeRun(codexRun.id, { harnessId: "pi" }))
   .rejects.toMatchObject({ code: "run_not_resumable" });
 expect(pi.start).not.toHaveBeenCalledWith(expect.objectContaining({ adapterState: expect.anything() }));
 expect((await repository.getRun(piRun.id)).baseMessageSeq).toBe(committedBoundary);
+await moveRegisteredWorktree(piRun.executionRootRef);
+await expect(orchestrator.resumeRun(piRun.id, { harnessId: "pi" }))
+  .rejects.toMatchObject({ code: "run_not_resumable" });
 ```
 
 Cover same-harness/version resume, incompatible version, Run retry attempt,
 failed partial output exclusion, 200-message/2-MiB history window metadata,
 late events, 500-event backpressure, explicit fork provenance, no active state
-copy, cancellation timeout, and restart interruption.
+copy, cancellation timeout, restart interruption, and execution-root
+fingerprint revalidation immediately before adapter start/resume.
 
 - [ ] **Step 2: Run tests and verify Red**
 
@@ -829,7 +858,8 @@ await expect(runWith({ harnessId: "pi", stateFrom: "codex" }))
 Cover tool/approval/input projection, provider event ownership, secret/path
 sanitization, cancellation, project requirement, exact adapter-state version,
 valid Pi `cwd` preservation and resume after owner-project revalidation,
-out-of-root/stale path quarantine, no path projection, and compatibility
+registered sibling-worktree and external-folder fixtures, unregistered or
+ambiguous sibling/stale path quarantine, no path projection, and compatibility
 projection parity.
 
 - [ ] **Step 2: Run tests and verify Red**

--- a/docs/superpowers/plans/2026-08-13-provider-neutral-chat-architecture.md
+++ b/docs/superpowers/plans/2026-08-13-provider-neutral-chat-architecture.md
@@ -1,0 +1,1189 @@
+# Provider-Neutral Chat Architecture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the JSON/provider-typed Chat rails with one owner-scoped,
+PostgreSQL-backed Chat model, pluggable harness/model adapters, and canonical
+Gateway projections used by every shell.
+
+**Architecture:** The Gateway owns strict Chat contracts and a typed repository
+in the existing customer-VPS Kysely connection. A transactional outbox keeps
+shells convergent; harness adapters keep provider state opaque; file-backed
+ProjectConfig remains authoritative through immutable project IDs. Delivery is
+split into three independently reviewed PRs: persistence/cutover, adapters, and
+shell migration.
+
+**Tech Stack:** Node.js 24+, TypeScript 5.5+ strict ESM, Hono, Zod 4 via
+`zod/v4`, PostgreSQL, Kysely, React 19, Zustand, Vitest, Playwright/Electron,
+Flox, pnpm 10, bun.
+
+## Global Constraints
+
+- Read `AGENTS.md` and `.specify/memory/constitution.md` at the start of every
+  implementation session and after compaction.
+- TDD is mandatory: every runtime task follows Red -> Green -> Refactor and
+  records the failing and passing command output.
+- Owner-local PostgreSQL through the existing Gateway-owned Kysely instance is
+  the only durable Chat authority after cutover. Never create or close a second
+  pool from a Chat repository.
+- Platform PostgreSQL never stores owner Chat content.
+- Chat ID is independent of harness, model, provider session, shell, project
+  slug, and filesystem path.
+- Provider state is accessible only through the matching harness adapter ID and
+  state schema version. Cross-harness resume is forbidden.
+- Project context stores immutable `ProjectConfig.id` only. Project paths,
+  slugs, branches, remotes, owner scope, and runtime identity are not accepted
+  from clients or persisted as Chat identity.
+- Run admission, project-context mutation, archive/delete, and active-run checks
+  lock the same Chat row in one transaction. External calls stay outside locks.
+- Every mutating endpoint uses Hono `bodyLimit`, including DELETE.
+- Cross-shell events are inserted transactionally and published after commit.
+- No indefinite dual write: JSON is authoritative before the cutover marker;
+  PostgreSQL is the sole read/write authority after it.
+- Preserve MAT-299/PR #1213 and MAT-318 as separate work. Do not add behavior to
+  their current PRs.
+- Do not modify, depend on, or create a Linear relation to MAT-268.
+- Figma direct parity remains unverified until the Matrix OS View-seat MCP limit
+  is restored. Do not retry the blocked MCP during these slices.
+- Public user documentation is a separate PR in `FinnaAI/matrix-os-site`; do
+  not create a local `www/` tree.
+
+---
+
+## Follow-up slice map
+
+| Slice | Deliverable | Dependency | Suggested conventional PR title |
+|---|---|---|---|
+| A | Typed owner-Postgres repository, immutable project-ID resolver, Gateway API/outbox, idempotent JSON cutover, export/delete/shutdown | Architecture spec approved | `feat(chat): add owner-owned canonical persistence` |
+| B | Harness/model registries, adapter-only provider state, Hermes/OpenClaw/Codex/Pi/OpenCode adapters, resume/switch/fork orchestration | Slice A merged | `feat(chat): add provider-neutral harness adapters` |
+| C | Browser/Desktop/CLI/channel projections on `/api/chats`, event replay, renderer rail removal, cutover evidence | Slices A and B merged | `feat(chat): migrate shells to canonical chats` |
+
+Create a separate Linear child/follow-up issue for each slice under MAT-319.
+Relations may connect only these Chat slices and the existing MAT-299/MAT-318
+sequencing; no MAT-268 relation is permitted. Keep every issue `In Progress`
+until its PR exists, then `PR In Review`, and never `Done` before merge.
+
+## File structure
+
+### Slice A — persistence and cutover
+
+- `packages/contracts/src/chat.ts`: strict provider-neutral Chat, message, Turn,
+  Run, project projection, request, response, event, and error schemas.
+- `packages/contracts/src/index.ts`: exports only; do not add another large Chat
+  implementation block to this already-large file.
+- `packages/gateway/src/chat/database.ts`: typed Kysely table interfaces and
+  migration/bootstrap DDL.
+- `packages/gateway/src/chat/repository.ts`: owner-scoped reads/mutations,
+  transactions, optimistic revisions, and outbox insertion.
+- `packages/gateway/src/chat/project-resolver.ts`: immutable-ID ProjectConfig
+  resolution with safe public projection and internal working root.
+- `packages/gateway/src/chat/service.ts`: authorization-independent orchestration
+  over repository/project resolver; no Hono or provider code.
+- `packages/gateway/src/chat/routes.ts`: Hono validation, auth principal mapping,
+  body limits, safe errors, and HTTP projections.
+- `packages/gateway/src/chat/subscriptions.ts`: bounded, owner-authorized outbox
+  replay/live delivery and shutdown drain.
+- `packages/gateway/src/chat/migration.ts`: JSON enumeration, hashing, import,
+  verification, advisory lock, maintenance barrier, and cutover marker.
+- `packages/gateway/src/chat/export.ts`: streamed export and symlink-safe temp
+  cleanup policy.
+- `packages/gateway/src/project-manager.ts`: owner-scoped immutable-ID lookup;
+  file config remains authoritative.
+- `packages/gateway/src/server.ts`: dependency wiring and shutdown ordering only.
+- Focused tests in `tests/contracts/chat.test.ts` and
+  `tests/gateway/chat-*.test.ts`.
+
+### Slice B — harness and model adapters
+
+- `packages/gateway/src/chat/harness-contract.ts`: adapter-only internal types,
+  normalized event validation, and state envelope limits.
+- `packages/gateway/src/chat/harness-registry.ts`: bounded adapter catalog,
+  duplicate detection, health/setup cache, and invalidation.
+- `packages/gateway/src/chat/model-registry.ts`: model plugin catalog and
+  capability resolution.
+- `packages/gateway/src/chat/run-orchestrator.ts`: Run start/resume/cancel,
+  canonical history windows, failure reconciliation, switching, and fork.
+- `packages/gateway/src/chat/adapters/hermes.ts`: Kernel/Hermes adapter.
+- `packages/gateway/src/chat/adapters/openclaw.ts`: OpenClaw adapter over the
+  existing agent-config/runtime seam.
+- `packages/gateway/src/chat/adapters/coding-agent.ts`: bridge for existing
+  Codex/Pi/OpenCode coding-agent adapters without making provider ID Chat
+  identity.
+- `packages/gateway/src/server.ts`: registry/orchestrator wiring and drain.
+- Focused tests in `tests/gateway/chat-harness-*.test.ts` and
+  `tests/gateway/chat-run-orchestrator.test.ts`.
+
+### Slice C — shell migration
+
+- `shell/src/lib/chat-contract.ts`: shared validated API/event client helpers.
+- `shell/src/stores/chat-context.tsx`: canonical Chat list/detail/replay state.
+- `shell/src/hooks/useConversation.ts`: temporary compatibility wrapper removed
+  after all callers use the canonical store.
+- `desktop/src/renderer/src/stores/chats.ts`: runtime-scoped canonical Chat
+  projection and safe mutations.
+- `desktop/src/renderer/src/features/chat/ChatTab.tsx`: one Chat rail labeled by
+  capabilities/project, not by source type.
+- `desktop/src/renderer/src/stores/hermes-chat.ts`, `stores/threads.ts`, and
+  `stores/unified-threads.ts`: delete renderer identity/history ownership after
+  parity; keep only transient composer/stream projection where needed.
+- `desktop/src/main/` Chat IPC/event bridge files: validated native access to
+  the same Gateway contract, no main-process persistence.
+- `packages/gateway/src/channels/` and CLI Chat commands: bind channel/CLI
+  principals to the canonical API rather than direct JSON files.
+- Shell/Desktop/Electron/CLI tests listed in Tasks 12-15.
+
+## Slice A — owner persistence and cutover
+
+### Task 1: Define strict Chat contracts
+
+**Files:**
+- Create: `packages/contracts/src/chat.ts`
+- Modify: `packages/contracts/src/index.ts`
+- Create: `tests/contracts/chat.test.ts`
+
+**Interfaces:**
+- Consumes: `SafeDisplayStringSchema`, `RequestIdSchema`, `ProjectIdSchema`,
+  `IsoTimestampSchema`, and bounded helpers from `packages/contracts/src/index.ts`.
+- Produces: `ChatIdSchema`, `ChatMessageIdSchema`, `ChatTurnIdSchema`,
+  `ChatRunIdSchema`, `ChatSummarySchema`, `ChatDetailSchema`,
+  `CreateChatRequestSchema`, `UpdateChatRequestSchema`,
+  `CreateChatTurnRequestSchema`, `ForkChatRequestSchema`,
+  `ChatHarnessDescriptorSchema`, `ChatModelDescriptorSchema`, and
+  `ChatOutboxEventSchema`.
+
+- [ ] **Step 1: Write failing contract tests**
+
+```ts
+expect(CreateChatRequestSchema.safeParse({
+  clientRequestId: "req_chat_1",
+  projectId: "proj_123",
+  ownerId: "attacker",
+}).success).toBe(false);
+
+expect(CreateChatTurnRequestSchema.safeParse({
+  clientRequestId: "req_turn_1",
+  message: "Ship the owner-local repository",
+  harnessId: "codex",
+  modelId: "gpt-5",
+  providerResumeState: { conversationId: "foreign" },
+}).success).toBe(false);
+
+expect(ChatIdSchema.parse("chat_123")).toBe("chat_123");
+```
+
+- [ ] **Step 2: Run the test and verify Red**
+
+Run: `flox activate -- bun run test tests/contracts/chat.test.ts`
+Expected: FAIL because `packages/contracts/src/chat.ts` and its exports do not
+exist.
+
+- [ ] **Step 3: Add strict discriminated schemas and limits**
+
+```ts
+export const ChatIdSchema = z.string().regex(/^chat_[A-Za-z0-9_-]{1,128}$/);
+export const ChatMessageStateSchema = z.enum(["pending", "committed", "failed"]);
+export const ChatExecutionSelectionSchema = z.object({
+  harnessId: ProviderIdSchema,
+  modelId: ProviderIdSchema.optional(),
+}).strict();
+export const CreateChatRequestSchema = z.object({
+  clientRequestId: RequestIdSchema,
+  title: SafeDisplayStringSchema.optional(),
+  projectId: ProjectIdSchema.optional(),
+  defaultSelection: ChatExecutionSelectionSchema.optional(),
+}).strict();
+```
+
+Define the message-parts discriminated union, 100-item Chat pages, 200-message
+pages, 64 parts, 24,000-character/96-KiB input, safe errors, harness/model
+descriptors, and outbox event shapes exactly as specified.
+
+- [ ] **Step 4: Run contract tests and typecheck**
+
+Run: `flox activate -- bun run test tests/contracts/chat.test.ts && bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/contracts/src/chat.ts packages/contracts/src/index.ts tests/contracts/chat.test.ts
+git commit -m "feat(contracts): define canonical chat model"
+```
+
+### Task 2: Resolve immutable ProjectConfig IDs
+
+**Files:**
+- Modify: `packages/gateway/src/project-manager.ts`
+- Create: `packages/gateway/src/chat/project-resolver.ts`
+- Modify: `tests/gateway/project-manager.test.ts`
+- Create: `tests/gateway/chat-project-resolver.test.ts`
+
+**Interfaces:**
+- Consumes: `ProjectConfig`, `OwnerScope`, and existing safe project reads.
+- Produces: `ProjectLookupResult`,
+  `ProjectManager.getProjectById(input: { ownerScope: OwnerScope;
+  projectId: string }): Promise<ProjectLookupResult>` and
+  `ChatProjectResolver.resolve(ownerScope, projectId)` returning separate
+  internal `workingDirectory` and safe `ChatProjectProjection`.
+
+- [ ] **Step 1: Write failing immutable-ID tests**
+
+```ts
+const before = await projects.getProjectById({ ownerScope, projectId: created.id });
+await renameProjectSlugOnDisk(created.slug, "renamed-project");
+const after = await projects.getProjectById({ ownerScope, projectId: created.id });
+expect(before.ok && after.ok && after.project.id).toBe(created.id);
+expect(JSON.stringify((await resolver.resolve(ownerScope, created.id)).projection))
+  .not.toContain(created.localPath);
+```
+
+Cover duplicate IDs, archived/deleting configs, owner mismatch, unreadable
+paths, cache eviction, and reconciliation after file changes.
+
+- [ ] **Step 2: Run tests and verify Red**
+
+Run: `flox activate -- bun run test tests/gateway/project-manager.test.ts tests/gateway/chat-project-resolver.test.ts`
+Expected: FAIL because immutable-ID lookup does not exist.
+
+- [ ] **Step 3: Add a bounded reconciled ID index**
+
+```ts
+export type ProjectLookupResult =
+  | { ok: true; project: ProjectConfig }
+  | { ok: false; status: number; error: WorkspaceError };
+
+async getProjectById(input: { ownerScope: OwnerScope; projectId: string }) {
+  const project = await immutableIdIndex.resolve(input.projectId);
+  if (!project || !ownerScopeMatches(project.ownerScope, input.ownerScope)) {
+    return genericError(404, "not_found", "Project was not found");
+  }
+  return { ok: true as const, project };
+}
+```
+
+Build the index only from validated owner file configs, cap entries to the
+existing project maximum, invalidate it on create/lifecycle/delete/file-watch
+changes, and fail closed on duplicate immutable IDs. Do not store ProjectConfig
+in PostgreSQL.
+
+- [ ] **Step 4: Run tests and verify Green**
+
+Run: `flox activate -- bun run test tests/gateway/project-manager.test.ts tests/gateway/chat-project-resolver.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/project-manager.ts packages/gateway/src/chat/project-resolver.ts tests/gateway/project-manager.test.ts tests/gateway/chat-project-resolver.test.ts
+git commit -m "feat(projects): resolve immutable project identities"
+```
+
+### Task 3: Bootstrap the typed Chat schema and repository
+
+**Files:**
+- Create: `packages/gateway/src/chat/database.ts`
+- Create: `packages/gateway/src/chat/repository.ts`
+- Create: `tests/gateway/chat-repository.test.ts`
+- Modify: `packages/gateway/src/server.ts`
+
+**Interfaces:**
+- Consumes: injected `Kysely<OwnerDatabase>` from `createAppDb`.
+- Produces: `migrateChatTables(db)`, `ChatRepository`,
+  `createChatRepository(db)`, and owner-scoped paginated read/create methods.
+
+- [ ] **Step 1: Write failing repository tests with the existing Kysely test dialect**
+
+```ts
+const first = await repository.create(owner, request);
+const retry = await repository.create(owner, request);
+expect(retry.id).toBe(first.id);
+await expect(repository.get(otherOwner, first.id)).resolves.toBeNull();
+expect(await repository.list(owner, { limit: 100 })).toMatchObject({
+  items: [expect.objectContaining({ id: first.id })],
+});
+```
+
+Also assert schema migration idempotency, message pagination, full-text owner
+isolation, partial unique active Run, and that `repository.close()` does not
+destroy the injected Kysely instance.
+
+- [ ] **Step 2: Run tests and verify Red**
+
+Run: `flox activate -- bun run test tests/gateway/chat-repository.test.ts`
+Expected: FAIL because the repository is absent.
+
+- [ ] **Step 3: Implement typed tables and idempotent bootstrap**
+
+```ts
+export interface ChatRepository {
+  create(owner: ChatOwner, request: CreateChatRequest): Promise<ChatRecord>;
+  get(owner: ChatOwner, chatId: string): Promise<ChatRecord | null>;
+  list(owner: ChatOwner, query: ChatListQuery): Promise<ChatPage>;
+  pageMessages(owner: ChatOwner, chatId: string, query: MessagePageQuery): Promise<MessagePage>;
+}
+
+export function createChatRepository(db: Kysely<OwnerDatabase>): ChatRepository {
+  return new KyselyChatRepository(db); // injected, non-owning dependency
+}
+```
+
+Create all tables/indexes from the spec with `CREATE TABLE/INDEX IF NOT EXISTS`
+or the repository's versioned migration pattern. Use `ON CONFLICT` for logical
+singleton/idempotency keys and filter deleted content on normal reads.
+
+- [ ] **Step 4: Run repository tests and typecheck**
+
+Run: `flox activate -- bun run test tests/gateway/chat-repository.test.ts && bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/chat/database.ts packages/gateway/src/chat/repository.ts packages/gateway/src/server.ts tests/gateway/chat-repository.test.ts
+git commit -m "feat(chat): add owner-local repository"
+```
+
+### Task 4: Make admission, context, and deletion atomic
+
+**Files:**
+- Modify: `packages/gateway/src/chat/repository.ts`
+- Create: `packages/gateway/src/chat/service.ts`
+- Create: `tests/gateway/chat-concurrency.test.ts`
+
+**Interfaces:**
+- Consumes: Chat repository, project resolver, strict requests.
+- Produces: `ChatService.admitTurn`, `updateChat`, `archiveChat`, `deleteChat`,
+  and transactionally inserted outbox events.
+
+- [ ] **Step 1: Write failing race and idempotency tests**
+
+```ts
+const admission = service.admitTurn(owner, chat.id, turnRequest);
+const contextChange = service.updateChat(owner, chat.id, {
+  baseRevision: chat.revision,
+  projectId: otherProject.id,
+});
+const [turnResult, updateResult] = await Promise.allSettled([admission, contextChange]);
+expect([turnResult, updateResult].filter((result) => result.status === "fulfilled"))
+  .toHaveLength(1);
+
+await expect(service.deleteChat(owner, chat.id, deleteRequest))
+  .rejects.toMatchObject({ code: "chat_busy" });
+```
+
+Also cover two simultaneous Turns, late finalization after delete, stale
+revision, repeated request IDs, transaction rollback, and outbox rollback.
+
+- [ ] **Step 2: Run tests and verify Red**
+
+Run: `flox activate -- bun run test tests/gateway/chat-concurrency.test.ts`
+Expected: FAIL because mutation methods do not exist.
+
+- [ ] **Step 3: Implement the shared row-lock boundary**
+
+```ts
+await db.transaction().execute(async (trx) => {
+  const chat = await lockOwnedChat(trx, owner, chatId); // SELECT ... FOR UPDATE
+  assertRevision(chat, request.baseRevision);
+  await assertNoActiveRun(trx, chat.id);
+  await insertTurnMessageRunAndOutbox(trx, chat, request);
+  await bumpChatRevision(trx, chat.id, chat.revision);
+});
+```
+
+Keep project resolution inputs fixed before the external call and re-check the
+file-backed project under the admission flow before commit. Do not call a
+harness inside the transaction. Hard delete content, create a content-free
+tombstone, and append the deletion event atomically.
+
+- [ ] **Step 4: Run concurrency and repository tests**
+
+Run: `flox activate -- bun run test tests/gateway/chat-concurrency.test.ts tests/gateway/chat-repository.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/chat/repository.ts packages/gateway/src/chat/service.ts tests/gateway/chat-concurrency.test.ts
+git commit -m "feat(chat): serialize canonical mutations"
+```
+
+### Task 5: Add authenticated routes and replayable subscriptions
+
+**Files:**
+- Create: `packages/gateway/src/chat/routes.ts`
+- Create: `packages/gateway/src/chat/subscriptions.ts`
+- Modify: `packages/gateway/src/server.ts`
+- Create: `tests/gateway/chat-routes.test.ts`
+- Create: `tests/gateway/chat-subscriptions.test.ts`
+- Modify: `tests/gateway/auth.test.ts`
+
+**Interfaces:**
+- Consumes: ChatService, ChatRepository outbox reads, verified
+  `RequestPrincipal`.
+- Produces: `/api/chats` HTTP routes and authenticated Chat event WebSocket.
+
+- [ ] **Step 1: Write failing route/auth/subscriber tests**
+
+```ts
+expect((await app.request(oversizedPost("/api/chats", 97 * 1024))).status).toBe(413);
+expect((await app.request(authenticatedDelete(`/api/chats/${chat.id}`, { ownerId: "fake" }))).status).toBe(400);
+expect((await otherOwnerApp.request(`/api/chats/${chat.id}`)).status).toBe(404);
+expect(subscription.sent.at(-1)).toMatchObject({ type: "chat.updated", chatId: chat.id });
+```
+
+Cover every path/query schema, DELETE body limit, personal/org roles, browser
+query-token allowlist, malformed/oversized WS frames, replay cursor/gap, stale
+TTL eviction, failed-sender eviction, per-owner/global caps, and shutdown drain.
+
+- [ ] **Step 2: Run tests and verify Red**
+
+Run: `flox activate -- bun run test tests/gateway/chat-routes.test.ts tests/gateway/chat-subscriptions.test.ts tests/gateway/auth.test.ts`
+Expected: FAIL because routes/subscriptions are absent.
+
+- [ ] **Step 3: Implement safe routes and outbox delivery**
+
+```ts
+app.post("/api/chats/:chatId/turns", chatBodyLimit, async (c) => {
+  const principal = requireRequestPrincipal(c);
+  const chatId = ChatIdSchema.parse(c.req.param("chatId"));
+  const body = CreateChatTurnRequestSchema.parse(await c.req.json());
+  return c.json(await service.admitTurn(ownerFrom(principal), chatId, body), 202);
+});
+```
+
+Map typed errors once to generic codes. Await subscription authorization before
+success, isolate sends, remove dead senders after broadcast, and publish only
+committed outbox rows.
+
+- [ ] **Step 4: Run route/subscription/auth tests**
+
+Run: `flox activate -- bun run test tests/gateway/chat-routes.test.ts tests/gateway/chat-subscriptions.test.ts tests/gateway/auth.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/chat/routes.ts packages/gateway/src/chat/subscriptions.ts packages/gateway/src/server.ts tests/gateway/chat-routes.test.ts tests/gateway/chat-subscriptions.test.ts tests/gateway/auth.test.ts
+git commit -m "feat(chat): expose canonical gateway contracts"
+```
+
+### Task 6: Import JSON idempotently and cut over once
+
+**Files:**
+- Create: `packages/gateway/src/chat/migration.ts`
+- Create: `tests/gateway/chat-migration.test.ts`
+- Modify: `packages/gateway/src/server.ts`
+
+**Interfaces:**
+- Consumes: Conversation JSON, coding-agent `threads.json`, ChatRepository,
+  migration advisory lock, Gateway admission barrier.
+- Produces: `ChatMigrationCoordinator.inspect`, `importBatch`, `verify`,
+  `cutover`, and `assertCompatibleStartup`.
+
+- [ ] **Step 1: Write failing migration matrix tests**
+
+```ts
+await migration.importBatch();
+await migration.importBatch();
+expect(await counts()).toEqual({ chats: 2, turns: 3, duplicateImports: 0 });
+
+await writeChangedLegacyRecord();
+await migration.importBatch();
+expect(await importedHash(sourceId)).toBe(expectedChangedHash);
+
+await expect(migration.cutover()).rejects.toMatchObject({ code: "migration_verification_failed" });
+expect(await migration.hasCutoverMarker()).toBe(false);
+```
+
+Cover symlinks, oversized/invalid JSON, duplicate IDs, crash after each phase,
+valid/invalid resume state, transcript ordering, active Run drain, final delta,
+marker atomicity, old-release startup refusal, and 30-day/two-release legacy ID
+translation from PostgreSQL.
+
+- [ ] **Step 2: Run tests and verify Red**
+
+Run: `flox activate -- bun run test tests/gateway/chat-migration.test.ts`
+Expected: FAIL because the coordinator is absent.
+
+- [ ] **Step 3: Implement phased importer and explicit marker**
+
+```ts
+export type ChatMigrationPhase =
+  | "not_started" | "importing" | "verified" | "cutting_over" | "complete" | "failed";
+
+await db.transaction().execute(async (trx) => {
+  await verifyFinalFingerprint(trx, fingerprint);
+  await setCutoverMarker(trx, { version: CHAT_SCHEMA_VERSION, fingerprint });
+  await appendMigrationOutbox(trx);
+});
+```
+
+Use normalized hashes and unique source mappings with `ON CONFLICT`. Keep JSON
+untouched and read-only after marker. Never add a JSON/Postgres dual writer or a
+post-marker filesystem read fallback.
+
+- [ ] **Step 4: Run migration/repository/concurrency tests**
+
+Run: `flox activate -- bun run test tests/gateway/chat-migration.test.ts tests/gateway/chat-repository.test.ts tests/gateway/chat-concurrency.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/chat/migration.ts packages/gateway/src/server.ts tests/gateway/chat-migration.test.ts
+git commit -m "feat(chat): add idempotent postgres cutover"
+```
+
+### Task 7: Add export, delete cleanup, and shutdown evidence
+
+**Files:**
+- Create: `packages/gateway/src/chat/export.ts`
+- Modify: `packages/gateway/src/chat/routes.ts`
+- Modify: `packages/gateway/src/server.ts`
+- Create: `tests/gateway/chat-export.test.ts`
+- Create: `tests/gateway/chat-shutdown.test.ts`
+
+**Interfaces:**
+- Consumes: repository snapshot/export reads, attachment reference service,
+  subscription hub, migration coordinator.
+- Produces: bounded export jobs, symlink-safe recurring cleanup, and ordered
+  Chat shutdown.
+
+- [ ] **Step 1: Write failing export/delete/shutdown tests**
+
+```ts
+expect(exported).toMatchObject({ chat: { id: chat.id }, turns: expect.any(Array) });
+expect(JSON.stringify(exported)).not.toMatch(/providerResumeState|access[_-]?token/i);
+await gateway.close();
+expect(order).toEqual([
+  "admission.stop", "runs.drain", "runs.interrupt", "subscribers.drain",
+  "exports.stop", "shared-kysely.destroy",
+]);
+```
+
+Cover 20-export cap, 24-hour TTL, recurring timer cleanup, `lstat` symlink skip,
+shared attachment preservation, exclusive attachment deletion, repeated delete,
+10-second Run drain, restart reconciliation, and no double Kysely destroy.
+
+- [ ] **Step 2: Run tests and verify Red**
+
+Run: `flox activate -- bun run test tests/gateway/chat-export.test.ts tests/gateway/chat-shutdown.test.ts`
+Expected: FAIL because export and shutdown wiring are incomplete.
+
+- [ ] **Step 3: Implement streamed export and ordered cleanup**
+
+```ts
+const cleanupPolicy = { maxFilesPerOwner: 20, ttlMs: 24 * 60 * 60 * 1000 };
+await chatAdmissions.stop();
+await runOrchestrator.drain({ timeoutMs: 10_000 });
+await chatSubscriptions.shutdown();
+chatExportCleanup.stop();
+// appDb.destroy() remains the only shared Kysely owner close.
+```
+
+- [ ] **Step 4: Run Slice A validation**
+
+Run:
+`flox activate -- bun run test tests/contracts/chat.test.ts tests/gateway/chat-*.test.ts tests/gateway/project-manager.test.ts tests/gateway/auth.test.ts`
+Then: `flox activate -- bun run typecheck && bun run check:patterns:diff`
+Expected: all focused tests pass, typecheck passes, and the diff adds no pattern
+violations.
+
+- [ ] **Step 5: Commit and open the Slice A PR**
+
+```bash
+git add packages/gateway/src/chat packages/gateway/src/server.ts packages/gateway/src/project-manager.ts tests/gateway tests/contracts
+git commit -m "feat(chat): complete owner-owned persistence"
+git push -u origin HEAD
+gh pr create --title "feat(chat): add owner-owned canonical persistence" --body-file /tmp/mat-319-slice-a.md
+```
+
+The PR body must include the review-pipeline Invariants section, exact migration
+cutover/rollback proof, and MAT-299/MAT-318/MAT-268 boundaries.
+
+## Slice B — harness and model adapters
+
+### Task 8: Define bounded harness/model registries
+
+**Files:**
+- Create: `packages/gateway/src/chat/harness-contract.ts`
+- Create: `packages/gateway/src/chat/harness-registry.ts`
+- Create: `packages/gateway/src/chat/model-registry.ts`
+- Create: `tests/gateway/chat-harness-registry.test.ts`
+- Create: `tests/gateway/chat-model-registry.test.ts`
+
+**Interfaces:**
+- Consumes: shared harness/model descriptor schemas and verified principal.
+- Produces: `ChatHarnessAdapter<State>`, `ChatHarnessRegistry`,
+  `ChatModelRegistry`, adapter state parsing, and capability resolution.
+
+- [ ] **Step 1: Write failing registry tests**
+
+```ts
+expect(() => createHarnessRegistry(duplicateAdapters)).toThrow(/duplicate/i);
+expect(() => createHarnessRegistry(twentyOneAdapters)).toThrow(/at most 20/i);
+await expect(registry.resolve({ harnessId: "codex", modelId: "vision-only", rootChat: true }))
+  .rejects.toMatchObject({ code: "capability_mismatch" });
+```
+
+Cover 64-model/128-tool caps, 2-second health timeout, bounded owner cache,
+invalidation, secret/path-shaped metadata rejection, state 64-KiB limit, and
+schema-version mismatch.
+
+- [ ] **Step 2: Run tests and verify Red**
+
+Run: `flox activate -- bun run test tests/gateway/chat-harness-registry.test.ts tests/gateway/chat-model-registry.test.ts`
+Expected: FAIL because registries are absent.
+
+- [ ] **Step 3: Implement registries and adapter-only state envelope**
+
+```ts
+export interface AdapterStateEnvelope {
+  harnessId: string;
+  schemaVersion: number;
+  state: unknown;
+  encodedBytes: number;
+}
+
+resolve(input: ChatExecutionRequest): ResolvedHarnessModel {
+  const harness = this.requireHarness(input.harnessId);
+  const model = this.models.requireCompatible(harness, input.modelId);
+  return { harness, model };
+}
+```
+
+- [ ] **Step 4: Run registry tests and typecheck**
+
+Run: `flox activate -- bun run test tests/gateway/chat-harness-registry.test.ts tests/gateway/chat-model-registry.test.ts && bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/chat/harness-contract.ts packages/gateway/src/chat/harness-registry.ts packages/gateway/src/chat/model-registry.ts tests/gateway/chat-harness-registry.test.ts tests/gateway/chat-model-registry.test.ts
+git commit -m "feat(chat): define harness capability registry"
+```
+
+### Task 9: Orchestrate start, resume, cancel, switch, and fork
+
+**Files:**
+- Create: `packages/gateway/src/chat/run-orchestrator.ts`
+- Modify: `packages/gateway/src/chat/service.ts`
+- Create: `tests/gateway/chat-run-orchestrator.test.ts`
+
+**Interfaces:**
+- Consumes: accepted Runs from Slice A, harness/model registries, adapter-only
+  state repository, canonical history pages.
+- Produces: `startAcceptedRun`, `resumeRun`, `cancelRun`, and `forkChat`.
+
+- [ ] **Step 1: Write failing lifecycle tests**
+
+```ts
+await orchestrator.startAcceptedRun(codexRun.id);
+await expect(orchestrator.resumeRun(codexRun.id, { harnessId: "pi" }))
+  .rejects.toMatchObject({ code: "run_not_resumable" });
+expect(pi.start).not.toHaveBeenCalledWith(expect.objectContaining({ adapterState: expect.anything() }));
+expect((await repository.getRun(piRun.id)).baseMessageSeq).toBe(committedBoundary);
+```
+
+Cover same-harness/version resume, incompatible version, Run retry attempt,
+failed partial output exclusion, 200-message/2-MiB history window metadata,
+late events, 500-event backpressure, explicit fork provenance, no active state
+copy, cancellation timeout, and restart interruption.
+
+- [ ] **Step 2: Run tests and verify Red**
+
+Run: `flox activate -- bun run test tests/gateway/chat-run-orchestrator.test.ts`
+Expected: FAIL because orchestration is absent.
+
+- [ ] **Step 3: Implement lifecycle guards**
+
+```ts
+if (resume.harnessId !== run.harnessId || envelope.schemaVersion !== adapter.stateSchemaVersion) {
+  throw new ChatRunError("run_not_resumable");
+}
+const history = await repository.readCanonicalHistory(run.chatId, {
+  throughSeq: run.baseMessageSeq,
+  maxMessages: 200,
+  maxBytes: 2 * 1024 * 1024,
+});
+```
+
+Persist each normalized event/status/outbox mutation transactionally. Call the
+adapter outside the transaction and map failures to generic client state.
+
+- [ ] **Step 4: Run orchestration and concurrency tests**
+
+Run: `flox activate -- bun run test tests/gateway/chat-run-orchestrator.test.ts tests/gateway/chat-concurrency.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/chat/run-orchestrator.ts packages/gateway/src/chat/service.ts tests/gateway/chat-run-orchestrator.test.ts
+git commit -m "feat(chat): orchestrate provider-neutral runs"
+```
+
+### Task 10: Adapt Hermes and OpenClaw
+
+**Files:**
+- Create: `packages/gateway/src/chat/adapters/hermes.ts`
+- Create: `packages/gateway/src/chat/adapters/openclaw.ts`
+- Modify: `packages/gateway/src/server.ts`
+- Create: `tests/gateway/chat-hermes-adapter.test.ts`
+- Create: `tests/gateway/chat-openclaw-adapter.test.ts`
+
+**Interfaces:**
+- Consumes: existing Kernel query/resume seam, Hermes configuration source,
+  OpenClaw configuration/runtime seam, normalized Run events.
+- Produces: two `ChatHarnessAdapter` registrations; Hermes supports root/project
+  Chat, OpenClaw advertises only proven capabilities.
+
+- [ ] **Step 1: Write failing adapter contract tests**
+
+```ts
+expect((await hermes.describe(input)).supports.rootChat).toBe(true);
+expect(await collect(hermes.start(runInput))).toEqual(expect.arrayContaining([
+  expect.objectContaining({ type: "assistant.text.completed" }),
+]));
+expect(JSON.stringify(await collect(openclaw.start(runInput))))
+  .not.toMatch(/\/home\/|token|raw stderr/i);
+```
+
+Cover session state validation, project working root, homePath preservation,
+model capability projection, attachment/tool bounds, timeout/cancel, and generic
+failure mapping.
+
+- [ ] **Step 2: Run tests and verify Red**
+
+Run: `flox activate -- bun run test tests/gateway/chat-hermes-adapter.test.ts tests/gateway/chat-openclaw-adapter.test.ts`
+Expected: FAIL because adapters are absent.
+
+- [ ] **Step 3: Implement adapters over existing runtime seams**
+
+```ts
+export const hermesChatAdapter: ChatHarnessAdapter<HermesResumeState> = {
+  id: "hermes",
+  stateSchemaVersion: 1,
+  parseState: (value) => HermesResumeStateSchema.parse(value),
+  serializeState: (value) => HermesResumeStateSchema.parse(value),
+  describe,
+  start,
+  resume,
+  cancel,
+};
+```
+
+Do not move provider credentials or raw config into Chat state.
+
+- [ ] **Step 4: Run adapter and Kernel tests**
+
+Run: `flox activate -- bun run test tests/gateway/chat-hermes-adapter.test.ts tests/gateway/chat-openclaw-adapter.test.ts tests/kernel`
+Expected: PASS for focused adapter tests and the repository's focused Kernel
+suite.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/chat/adapters packages/gateway/src/server.ts tests/gateway/chat-hermes-adapter.test.ts tests/gateway/chat-openclaw-adapter.test.ts
+git commit -m "feat(chat): adapt os chat harnesses"
+```
+
+### Task 11: Bridge Codex, Pi, and OpenCode adapters
+
+**Files:**
+- Create: `packages/gateway/src/chat/adapters/coding-agent.ts`
+- Modify: `packages/gateway/src/coding-agents/provider-adapter.ts`
+- Modify: `packages/gateway/src/coding-agents/provider-registry.ts`
+- Modify: `packages/gateway/src/server.ts`
+- Create: `tests/gateway/chat-coding-agent-adapter.test.ts`
+
+**Interfaces:**
+- Consumes: existing bounded coding-agent adapter events and provider resume
+  state.
+- Produces: Chat harness registrations for Codex, Pi, and OpenCode while legacy
+  thread routes remain compatibility projections until Slice C.
+
+- [ ] **Step 1: Write failing bridge tests**
+
+```ts
+for (const harnessId of ["codex", "pi", "opencode"]) {
+  const descriptor = await registry.describe(owner, harnessId);
+  expect(descriptor.id).toBe(harnessId);
+  expect(descriptor.workspaceRequirement).toBe("project_required");
+}
+await expect(runWith({ harnessId: "pi", stateFrom: "codex" }))
+  .rejects.toMatchObject({ code: "run_not_resumable" });
+```
+
+Cover tool/approval/input projection, provider event ownership, secret/path
+sanitization, cancellation, project requirement, exact adapter-state version,
+and compatibility projection parity.
+
+- [ ] **Step 2: Run tests and verify Red**
+
+Run: `flox activate -- bun run test tests/gateway/chat-coding-agent-adapter.test.ts`
+Expected: FAIL because the bridge is absent.
+
+- [ ] **Step 3: Add one generic coding-agent bridge with registrations**
+
+```ts
+export function createCodingAgentChatAdapter(
+  provider: CodingAgentProviderAdapter,
+): ChatHarnessAdapter<CodingAgentProviderResumeState> {
+  return {
+    id: provider.providerId,
+    stateSchemaVersion: 1,
+    parseState: (value) => CodingAgentProviderResumeStateSchema.parse(value),
+    serializeState: (value) => CodingAgentProviderResumeStateSchema.parse(value),
+    describe: (input) => describeCodingHarness(provider, input),
+    start: (input) => bridgeStart(provider, input),
+    resume: provider.resumeTurn ? (input) => bridgeResume(provider, input) : undefined,
+    cancel: provider.abortThread ? (input) => bridgeCancel(provider, input) : undefined,
+  };
+}
+```
+
+- [ ] **Step 4: Run Slice B validation**
+
+Run: `flox activate -- bun run test tests/gateway/chat-harness-*.test.ts tests/gateway/chat-model-registry.test.ts tests/gateway/chat-run-orchestrator.test.ts tests/gateway/chat-coding-agent-adapter.test.ts`
+Then: `flox activate -- bun run typecheck && bun run check:patterns:diff`
+Expected: PASS with no new pattern violations.
+
+- [ ] **Step 5: Commit and open Slice B PR**
+
+```bash
+git add packages/gateway/src/chat packages/gateway/src/coding-agents packages/gateway/src/server.ts tests/gateway
+git commit -m "feat(chat): complete harness adapter bridge"
+git push -u origin HEAD
+gh pr create --title "feat(chat): add provider-neutral harness adapters" --body-file /tmp/mat-319-slice-b.md
+```
+
+## Slice C — shell and UI migration
+
+### Task 12: Move browser Shell to canonical Chat APIs/events
+
+**Files:**
+- Create: `shell/src/lib/chat-contract.ts`
+- Modify: `shell/src/stores/chat-context.tsx`
+- Modify: `shell/src/hooks/useConversation.ts`
+- Modify: `shell/src/hooks/useChatState.ts`
+- Create: `tests/shell/chat-context.test.tsx`
+
+**Interfaces:**
+- Consumes: `/api/chats`, Chat event replay, strict shared schemas.
+- Produces: one runtime-scoped browser Chat store with list/detail/create/switch,
+  Turn, cancel, fork, export, delete, and replay actions.
+
+- [ ] **Step 1: Write failing browser store tests**
+
+```ts
+expect(fetchMock).not.toHaveBeenCalledWith(expect.stringContaining("/files/system/conversations"), expect.anything());
+await store.switchRuntime("next-runtime");
+oldListRequest.resolve(oldRuntimeChats);
+expect(store.getState().items).toEqual([]);
+expect(store.getState().error).toBeNull();
+```
+
+Cover loading/empty/error/reconnect/replay gap, mutation failure preservation,
+safe error allowlist, same Chat after harness change, export/delete, and no
+filesystem watcher authority.
+
+- [ ] **Step 2: Run tests and verify Red**
+
+Run: `flox activate -- bun run test tests/shell/chat-context.test.tsx`
+Expected: FAIL because canonical browser state is absent.
+
+- [ ] **Step 3: Implement validated API/event client and store**
+
+```ts
+const page = ChatPageSchema.parse(await response.json());
+if (generation !== currentGeneration()) return;
+set({ items: page.items, status: "ready", error: null });
+```
+
+Remove direct transcript JSON reads and use the outbox replay cursor. Keep any
+compatibility hook as a pure projection over the canonical store.
+
+- [ ] **Step 4: Run browser focused tests and typecheck**
+
+Run: `flox activate -- bun run test tests/shell/chat-context.test.tsx && bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shell/src/lib/chat-contract.ts shell/src/stores/chat-context.tsx shell/src/hooks/useConversation.ts shell/src/hooks/useChatState.ts tests/shell/chat-context.test.tsx
+git commit -m "feat(shell): use canonical chat contracts"
+```
+
+### Task 13: Replace Desktop source-typed rails with Chat projections
+
+**Files:**
+- Create: `desktop/src/renderer/src/stores/chats.ts`
+- Modify: `desktop/src/renderer/src/features/chat/ChatTab.tsx`
+- Modify: `desktop/src/renderer/src/stores/hermes-chat.ts`
+- Modify: `desktop/src/renderer/src/stores/threads.ts`
+- Delete: `desktop/src/renderer/src/stores/unified-threads.ts`
+- Modify: `desktop/src/main/index.ts`
+- Create: `desktop/src/main/chat/event-stream.ts`
+- Create: `tests/desktop/chat-store.test.ts`
+- Modify: `tests/desktop/chat-tab.test.tsx`
+
+**Interfaces:**
+- Consumes: canonical Chat HTTP/event contracts through authenticated Desktop
+  main-process wiring.
+- Produces: one bounded runtime-scoped Chat rail; harness/model/project are
+  labels/capabilities, never item source types.
+
+- [ ] **Step 1: Write failing Desktop store/UI tests**
+
+```ts
+expect(railItems.map((item) => item.id)).toEqual([chatA.id, chatB.id]);
+expect(railItems.map((item) => item)).not.toEqual(expect.arrayContaining([
+  expect.objectContaining({ source: "kernel" }),
+]));
+expect(screen.getByText("Codex")).toBeInTheDocument(); // capability label
+expect(activeChat.id).toBe(chatA.id); // unchanged after harness switch
+```
+
+Cover create/list/load/switch, root/project unavailable state, model/harness
+capability menus, active Run, approval/input attention, reconnect/replay gap,
+runtime generation invalidation, failed mutation preservation, export/delete,
+and stable Zustand selectors.
+
+- [ ] **Step 2: Run tests and verify Red**
+
+Run: `flox activate -- bun run test tests/desktop/chat-store.test.ts tests/desktop/chat-tab.test.tsx`
+Expected: FAIL because Desktop still owns source-typed rails.
+
+- [ ] **Step 3: Implement the canonical projection and remove identity ownership**
+
+```ts
+interface DesktopChatsState {
+  runtimeScope: string | null;
+  items: ChatSummary[];
+  activeChatId: string | null;
+  activeChat: ChatDetail | null;
+  eventCursor: string | null;
+}
+```
+
+Keep composer draft/optimistic stream state transient. Remove `AgentThread.id`
+and Hermes session identity as rail authorities only after their canonical Chat
+mapping exists. Do not add localStorage, IndexedDB, or main-process files.
+
+- [ ] **Step 4: Run Desktop focused tests and React checks**
+
+Run: `flox activate -- bun run test tests/desktop/chat-store.test.ts tests/desktop/chat-tab.test.tsx && bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add desktop/src/renderer/src desktop/src/main tests/desktop
+git commit -m "feat(desktop): unify canonical chat rail"
+```
+
+### Task 14: Migrate CLI and channel shells
+
+**Files:**
+- Modify: `bin/cli.ts`
+- Modify: `bin/matrixos.ts`
+- Modify: `packages/gateway/src/server.ts`
+- Modify: `packages/gateway/src/channels/types.ts`
+- Modify: `packages/gateway/src/channels/manager.ts`
+- Create: `packages/gateway/src/chat/channel-bindings.ts`
+- Create: `tests/cli/chat.test.ts`
+- Create: `tests/gateway/chat-channel-bindings.test.ts`
+
+**Interfaces:**
+- Consumes: canonical Chat service/API and authenticated principal-to-owner
+  mapping.
+- Produces: CLI list/open/send/export/delete and server-owned channel-thread to
+  Chat bindings.
+
+- [ ] **Step 1: Write failing CLI and channel-binding tests**
+
+```ts
+expect(await cli.run(["chat", "list"])).toContain(chat.id);
+expect(await channelBinding.resolve(channelPrincipal, externalThreadId)).toEqual({ chatId: chat.id });
+expect(channelRequest).not.toHaveProperty("ownerId");
+```
+
+- [ ] **Step 2: Run tests and verify Red**
+
+Run: `flox activate -- bun run test tests/cli/chat.test.ts tests/gateway/chat-channel-bindings.test.ts`
+Expected: FAIL because canonical commands/bindings are absent.
+
+- [ ] **Step 3: Route both shells through canonical Gateway/service seams**
+
+```ts
+const owner = ownerFromVerifiedPrincipal(principal);
+const binding = await chatBindings.resolveOrCreate(owner, {
+  channelId,
+  externalThreadId,
+  clientRequestId,
+});
+return chatService.admitTurn(owner, binding.chatId, request);
+```
+
+Persist safe channel binding IDs owner-locally; no provider session, credential,
+or owner override enters a client payload.
+
+- [ ] **Step 4: Run CLI/channel tests**
+
+Run: `flox activate -- bun run test tests/cli/chat.test.ts tests/gateway/chat-channel-bindings.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/cli.ts bin/matrixos.ts packages/gateway/src/server.ts packages/gateway/src/channels packages/gateway/src/chat/channel-bindings.ts tests/cli/chat.test.ts tests/gateway/chat-channel-bindings.test.ts
+git commit -m "feat(chat): converge cli and channel shells"
+```
+
+### Task 15: Prove cutover and remove legacy runtime writes
+
+**Files:**
+- Modify/delete: `packages/gateway/src/conversations.ts` after import/cutover
+  compatibility has no remaining runtime caller.
+- Modify: `packages/gateway/src/coding-agents/thread-store.ts` to expose only the
+  compatibility projection or remove JSON persistence after all callers move.
+- Modify: `packages/gateway/src/server.ts`
+- Modify: `packages/kernel/src/boot.ts`
+- Create: `tests/e2e/chat-cutover.test.ts`
+- Create: `desktop/e2e/chat-provider-neutral.spec.ts`
+
+**Interfaces:**
+- Consumes: completed migration marker, canonical shells, adapter bridge.
+- Produces: no post-marker JSON writes and runtime proof across Browser,
+  Desktop, CLI, restart, harness switch, export, and delete.
+
+- [ ] **Step 1: Write failing no-dual-write and E2E tests**
+
+```ts
+await sendTurnAfterCutover(chat.id);
+expect(await legacyConversationFiles()).toEqual(beforeFiles);
+expect(await canonicalMessages(chat.id)).toContainEqual(expect.objectContaining({ role: "user" }));
+await switchHarness(chat.id, "pi");
+expect(await currentChatId()).toBe(chat.id);
+expect(await resumedForeignProviderState()).toBe(false);
+```
+
+Cover repeated migration, browser/Desktop/CLI convergence, project-bound cwd,
+root harness rejection when project-required, restart same-harness resume,
+cross-harness fresh Run, unavailable project, replay gap, hard delete, export
+parity, and old-binary startup refusal.
+
+- [ ] **Step 2: Run E2E tests and verify Red before removals**
+
+Run: `flox activate -- bun run test tests/e2e/chat-cutover.test.ts`
+Expected: FAIL while legacy writers/callers remain.
+
+- [ ] **Step 3: Remove post-marker writers and direct JSON readers**
+
+```ts
+if (await migrations.hasCutoverMarker()) {
+  return createCanonicalChatServices(sharedKysely);
+}
+return createPreCutoverMigrationServices();
+```
+
+Delete compatibility code only when `rg` proves no supported caller. Keep
+original owner JSON files untouched as backup material; remove runtime writes,
+not owner data.
+
+- [ ] **Step 4: Run Slice C and full proportional validation**
+
+Run:
+
+```bash
+flox activate -- bun run test tests/contracts/chat.test.ts tests/gateway/chat-*.test.ts tests/shell/chat-context.test.tsx tests/desktop/chat-store.test.ts tests/cli/chat.test.ts tests/e2e/chat-cutover.test.ts
+flox activate -- bun run typecheck
+flox activate -- bun run check:patterns
+flox activate -- bun run test
+flox activate -- bun run build:shell:production
+flox activate -- bun run build:desktop
+```
+
+Then run `desktop/e2e/chat-provider-neutral.spec.ts` against the exact built
+Electron worktree/commit and record screenshots plus database/JSON fingerprints.
+Expected: focused suites, typecheck, pattern scan, and builds pass. Report any
+pre-existing full-suite failures separately with exact counts; never call the
+repository green from focused evidence alone.
+
+- [ ] **Step 5: Commit and open Slice C PR**
+
+```bash
+git add packages/gateway packages/kernel shell desktop bin packages/cli tests
+git commit -m "feat(chat): complete canonical shell cutover"
+git push -u origin HEAD
+gh pr create --title "feat(chat): migrate shells to canonical chats" --body-file /tmp/mat-319-slice-c.md
+```
+
+The PR body must include exact worktree/commit/runtime evidence, no-dual-write
+proof, MAT-299/MAT-318 sequencing, MAT-268 exclusion, and the Invariants section.
+
+### Task 16: Publish public documentation separately
+
+**Repository:** `FinnaAI/matrix-os-site` in its own worktree and PR.
+
+**Files:** Resolve the current Fumadocs Chat guide path in that repository with
+`rg --files content/docs | rg 'chat|conversation|project'` before editing.
+
+**Interfaces:**
+- Consumes: merged runtime behavior and verified screenshots/evidence.
+- Produces: public-safe Chat ownership, harness switching, project context,
+  export/delete, and migration-facing user guidance.
+
+- [ ] **Step 1: Write a documentation acceptance checklist**
+
+```md
+- Chat identity remains stable when harness/model changes.
+- Chat content stays on the owner's Matrix computer/VPS.
+- Project context references an owner project without exposing local paths.
+- Export/delete and unavailable-project recovery are explained.
+```
+
+- [ ] **Step 2: Run the site repository's documented docs test before edits**
+
+Run the exact command from that repository's `AGENTS.md`; record the baseline
+exit code and do not invent a monorepo `www/` command.
+
+- [ ] **Step 3: Add public-safe content and verified images**
+
+Use product behavior only. Exclude customer identifiers, private hostnames,
+tokens, database credentials, incident details, and operator-only migration
+commands.
+
+- [ ] **Step 4: Run the site docs build/link checks**
+
+Expected: PASS with no broken links or missing images.
+
+- [ ] **Step 5: Open the separate conventional documentation PR**
+
+Use a title such as `docs(chat): explain durable chats and harness switching`,
+attach it to the relevant Chat follow-up issue, and keep it separate from the
+Matrix OS runtime PRs.
+
+## Final verification and review gates for every slice
+
+Before claiming a slice complete:
+
+1. Re-read `specs/113-provider-neutral-chat-architecture/spec.md` and map every
+   changed requirement to a fresh command or inspected artifact.
+2. Run `git diff --check`, `bun run typecheck`, `bun run check:patterns:diff`,
+   and all focused tests for the slice.
+3. Run the broader `bun run test` gate before push; report unrelated baseline
+   failures separately with exact counts and logs.
+4. Perform the review-pipeline mechanical, trust-boundary, and
+   atomicity/failure-mode passes.
+5. Freeze the review commit range and request Greptile. Resolve all Critical and
+   Important findings, especially auth, row-lock, outbox, cutover, shutdown,
+   and provider-state findings.
+6. Read back the GitHub PR title/body/files/checks/reviewer state and Linear
+   attachment/state. A wrapper success response is not completion evidence.
+7. Never merge without explicit user approval. Keep Linear at `PR In Review`
+   until merge.

--- a/docs/superpowers/plans/2026-08-13-provider-neutral-chat-architecture.md
+++ b/docs/superpowers/plans/2026-08-13-provider-neutral-chat-architecture.md
@@ -497,9 +497,10 @@ expect(await migration.hasCutoverMarker()).toBe(false);
 ```
 
 Cover symlinks, oversized/invalid JSON, duplicate IDs, crash after each phase,
-valid/invalid resume state, transcript ordering, active Run drain, final delta,
-marker atomicity, old-release startup refusal, and 30-day/two-release legacy ID
-translation from PostgreSQL.
+valid/invalid resume state, preservation of Pi `cwd` inside the resolved owner
+project root, quarantine outside that root, transcript ordering, active Run
+drain, final delta, marker atomicity, old-release startup refusal, and legacy-ID
+translation before, exactly at, and after the immutable 90-day expiry.
 
 - [ ] **Step 2: Run tests and verify Red**
 
@@ -514,7 +515,13 @@ export type ChatMigrationPhase =
 
 await db.transaction().execute(async (trx) => {
   await verifyFinalFingerprint(trx, fingerprint);
-  await setCutoverMarker(trx, { version: CHAT_SCHEMA_VERSION, fingerprint });
+  const cutoverAt = clock.now();
+  await setCutoverMarker(trx, {
+    version: CHAT_SCHEMA_VERSION,
+    fingerprint,
+    cutoverAt,
+    legacyAliasExpiresAt: addDays(cutoverAt, 90),
+  });
   await appendMigrationOutbox(trx);
 });
 ```
@@ -628,8 +635,10 @@ await expect(registry.resolve({ harnessId: "codex", modelId: "vision-only", root
 ```
 
 Cover 64-model/128-tool caps, 2-second health timeout, bounded owner cache,
-invalidation, secret/path-shaped metadata rejection, state 64-KiB limit, and
-schema-version mismatch.
+invalidation, secret/path-shaped descriptor metadata rejection, state 64-KiB
+limit, schema-version mismatch, and the adapter-state rule that only a
+schema-declared execution root validated against the owner project may contain
+an absolute path.
 
 - [ ] **Step 2: Run tests and verify Red**
 
@@ -819,7 +828,9 @@ await expect(runWith({ harnessId: "pi", stateFrom: "codex" }))
 
 Cover tool/approval/input projection, provider event ownership, secret/path
 sanitization, cancellation, project requirement, exact adapter-state version,
-and compatibility projection parity.
+valid Pi `cwd` preservation and resume after owner-project revalidation,
+out-of-root/stale path quarantine, no path projection, and compatibility
+projection parity.
 
 - [ ] **Step 2: Run tests and verify Red**
 

--- a/specs/113-provider-neutral-chat-architecture/spec.md
+++ b/specs/113-provider-neutral-chat-architecture/spec.md
@@ -1,0 +1,608 @@
+# Provider-Neutral Chat Architecture and Owner-Owned Persistence
+
+**Linear issue:** MAT-319
+**Created:** 2026-08-13
+**Status:** Proposed for architecture review
+**Scope:** Canonical contracts, persistence, migration, and implementation sequencing
+**Related delivery:** MAT-299 and MAT-318 remain independent
+
+## Purpose
+
+Matrix OS needs one durable user-facing Chat abstraction. A Chat is the task the
+user returns to, shares, searches, exports, or deletes. Hermes, OpenClaw, Codex,
+Pi, OpenCode, and future execution systems are harness adapters that run work
+inside a Chat; they are not Chat identities or Chat types. Models are selected
+through capability-aware model plugins and are not part of Chat identity.
+
+The canonical Chat record and all relational Chat state live in the owner's
+PostgreSQL database on the user's Matrix computer/VPS through Kysely. Project
+code and `ProjectConfig` stay in owner-controlled files. Chat links to a project
+only by the immutable `ProjectConfig.id`.
+
+This specification records the public seams before implementation. It does not
+authorize a broad migration in this PR.
+
+## Non-goals
+
+- Implementing the PostgreSQL repository, migration, adapters, or shell UI in
+  this architecture PR.
+- Expanding MAT-299's current Hermes lifecycle PR or MAT-318's project-context
+  implementation.
+- Platform-owned storage of owner Chat content.
+- Translating provider-native session formats between harnesses.
+- Voice, multi-repository project UX, branch switching, or worktree-management
+  UI.
+- Files CRUD or any MAT-268 behavior, dependency, or issue relation.
+- Merge or release operations.
+
+## Current-state audit
+
+| Area | Current source of truth | Useful seam | Gap to close |
+|---|---|---|---|
+| Gateway kernel conversations | `packages/gateway/src/conversations.ts` writes synchronous `system/conversations/*.json` files | Existing list/get/create/delete/search and kernel session IDs | No owner scope, Kysely repository, transaction, turn/run model, strict persisted schema, or safe cross-shell event contract |
+| Coding-agent threads | `packages/gateway/src/coding-agents/thread-store.ts` writes one bounded `system/coding-agents/threads.json` aggregate | Owner checks, turns, events, idempotent request IDs, shutdown recovery, bounded adapter events | Provider ID is part of thread identity; opaque resume state is embedded in the aggregate; whole-file serialization limits concurrency and migration |
+| Harness/provider boundary | `provider-adapter.ts` and `provider-registry.ts` validate provider output and bound health/cache state | Adapter lifecycle, normalized events, timeouts, generic client errors | Catalog lacks a provider-neutral harness capability contract and independent model plugin registry |
+| Desktop Chat | `useHermesChat`, `useThreads`, `useCodingAgentWorkspace`, and `unified-threads.ts` merge one Hermes transcript, renderer-memory kernel runs, and server coding-agent projections | Bounded serializable projections and runtime invalidation patterns | Renderer memory still determines local thread identity/history; one rail hides multiple incompatible durable sources |
+| Browser Shell Chat | `useConversation.ts` lists through Gateway but reads transcript JSON through `/files` and refreshes from filesystem watcher events | Existing persistent conversation discovery and switch-session flow | File-path coupling bypasses a provider-neutral headless Chat contract |
+| Owner PostgreSQL | Gateway creates one shared Kysely connection from the VPS-local `DATABASE_URL`; messaging and canvas inject it | Owner-local database lifecycle, migrations, transactions, shared shutdown | Chat has no typed repository or schema; it must reuse this Kysely owner and must not create or destroy another pool |
+| Projects | `ProjectConfig` is an owner file and new configs receive immutable `proj_*` IDs | Stable file-backed identity and validated `localPath` | ProjectManager's public lookup is slug-addressed. Chat must resolve by immutable ID and owner scope without copying path/config into PostgreSQL |
+| Cross-shell activity | Coding-agent projections publish bounded workspace events | Event projection pattern and shutdown hooks | Filesystem events are not a transactional Chat outbox and cannot guarantee replay/convergence |
+
+The audit also incorporates two valid races reported on PR #1216: run admission
+can overlap deletion, and run admission can overlap project-context mutation.
+Both are resolved by one database admission boundary described below.
+
+## Terminology and identity
+
+### Chat
+
+A Chat is a durable, owner-scoped task. Its immutable identity is `chatId`.
+Neither `harnessId`, `modelId`, provider session ID, shell, channel, project
+slug, nor filesystem path participates in Chat identity.
+
+A Chat contains:
+
+- lifecycle and title;
+- owner scope and optional membership/collaboration state;
+- optional immutable project ID;
+- optional default harness and model preferences;
+- canonical messages and attachment references;
+- turns and one or more run attempts;
+- attention, read, pinned, and shell projection state; and
+- fork provenance when explicitly created from another Chat.
+
+### Turn
+
+A Turn is one accepted user action in a Chat. It owns the canonical user input,
+an immutable `baseMessageSeq`, an idempotency key, and one or more Run attempts.
+Only one Run may be active for a Chat at a time.
+
+### Run
+
+A Run is one execution attempt by exactly one harness with exactly one resolved
+model selection. The Run records what was actually used, the bounded capability
+snapshot, lifecycle timestamps, and canonical-history boundary. Provider-native
+session/resume state is stored separately behind the owning harness adapter.
+
+### Harness and model plugins
+
+A harness adapter implements execution semantics for Hermes, OpenClaw, Codex,
+Pi, OpenCode, or another runtime. A model plugin describes a selectable model
+and its capabilities/credentials. A harness declares which model capabilities
+it accepts. The orchestration layer resolves the pair; it never infers
+compatibility from names.
+
+## Non-negotiable invariants
+
+1. Owner-local PostgreSQL is the only durable Chat source of truth after
+   cutover. Platform PostgreSQL never stores owner transcript content.
+2. Gateway/headless contracts are canonical. Shell stores are bounded caches
+   and never create a persistence format.
+3. `chatId` survives harness/model changes. Provider session IDs never replace,
+   alias, or determine it.
+4. A Run may resume only through the same `harnessId` and adapter-state schema
+   version that created its resume state.
+5. A harness change starts a new Run from canonical history or creates an
+   explicit fork. Cross-harness resume is forbidden.
+6. Project references use immutable `ProjectConfig.id`; slugs, paths, branches,
+   and repository URLs are derived owner-file data.
+7. Turn admission, context mutation, archive/delete, and active-run checks lock
+   the same Chat row. No check-then-write race is allowed.
+8. Multiple related writes and every outbox event are committed in one Kysely
+   transaction. External harness/model calls occur outside the transaction.
+9. Provider output, capability metadata, model metadata, and adapter state are
+   strictly validated and bounded before persistence or renderer projection.
+10. Raw provider, filesystem, database, credential, or path errors never reach
+    clients. Detailed diagnostics stay in owner-controlled logs.
+
+## Public contracts
+
+The shared package will define strict Zod 4 schemas for these shapes. Names are
+illustrative but normative in responsibility.
+
+```ts
+type OwnerScope =
+  | { type: "personal"; ownerId: string }
+  | { type: "organization"; ownerId: string };
+
+interface ChatSummary {
+  id: string;
+  title: string;
+  lifecycle: "active" | "archived";
+  project?: ChatProjectProjection;
+  defaultSelection?: ChatExecutionSelection;
+  activeRun?: ChatRunProjection;
+  attention: "none" | "approval_required" | "input_required" | "failed";
+  lastMessagePreview: string;
+  messageCount: number;
+  revision: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ChatExecutionSelection {
+  harnessId: string;
+  modelId?: string;
+}
+
+interface ChatProjectProjection {
+  projectId: string;
+  name: string;
+  kind: "scratch" | "github" | "folder";
+  repositoryLabel?: string;
+  status: "ready" | "unavailable";
+}
+```
+
+The client never sends `OwnerScope`, a filesystem path, provider resume state,
+provider credentials, repository URL, or runtime identity. Gateway derives
+owner scope from the verified principal and resolves project/runtime state.
+
+### Canonical messages
+
+Messages are immutable in sequence and provider-neutral. `parts` is a strict,
+bounded discriminated union: text, tool request/result, attachment reference,
+approval request/result, structured status, and explicit summary. Provider raw
+events and transport frames are not message parts.
+
+User messages commit at Turn admission. Assistant/tool output begins as
+`pending` and becomes `committed` when the Run reaches a valid terminal result.
+Failed or interrupted partial output remains inspectable as `failed` Run output
+but is excluded from future canonical history unless the user explicitly
+promotes or quotes it. Canonical history therefore never silently treats a
+failed provider stream as trusted context.
+
+### Harness capability contract
+
+```ts
+interface HarnessDescriptor {
+  id: string;
+  displayName: string;
+  adapterVersion: string;
+  availability: "available" | "setup_required" | "auth_required" | "unavailable";
+  workspaceRequirement: "none" | "project_optional" | "project_required";
+  supports: {
+    rootChat: boolean;
+    resume: boolean;
+    cancellation: boolean;
+    attachments: readonly ChatAttachmentKind[];
+    tools: readonly string[];
+    approvals: boolean;
+    userInput: boolean;
+    worktrees: "none" | "optional" | "required";
+  };
+  acceptedModelCapabilities: readonly ModelCapability[];
+  defaultModelId?: string;
+}
+
+interface ChatHarnessAdapter<State> {
+  readonly id: string;
+  describe(input: HarnessDescribeInput): Promise<HarnessDescriptor>;
+  start(input: StartRunInput): AsyncIterable<NormalizedRunEvent>;
+  resume?(input: ResumeRunInput<State>): AsyncIterable<NormalizedRunEvent>;
+  cancel?(input: CancelRunInput<State>): Promise<void>;
+  stateSchemaVersion: number;
+  parseState(value: unknown): State;
+  serializeState(value: State): unknown;
+}
+```
+
+The adapter-state store exposes state only to the registered adapter whose ID
+and schema version match the Run. Adapters must not place access tokens,
+credentials, raw stderr, absolute paths, or unbounded transcripts in state.
+
+### Model plugin contract
+
+```ts
+interface ModelDescriptor {
+  id: string;
+  displayName: string;
+  availability: "available" | "auth_required" | "unavailable";
+  capabilities: readonly ModelCapability[];
+  contextWindow?: number;
+  supportsVision: boolean;
+  supportsToolUse: boolean;
+}
+```
+
+The model registry resolves a model only when both plugin availability and
+harness capability predicates pass. The Chat may store a preferred default;
+each Run stores the resolved actual IDs. Removing a model plugin does not make
+the Chat unreadable.
+
+## Owner-local PostgreSQL model
+
+The Chat repository receives the Gateway-owned `Kysely<OwnerDatabase>` used by
+other owner-local services. It does not create a pool and does not call
+`destroy()`; the Gateway closes the shared owner after Chat subscribers and
+Run orchestration have drained.
+
+| Table | Purpose and key invariants |
+|---|---|
+| `chats` | Immutable `id`; `owner_type + owner_id`; optional immutable `project_id`; lifecycle; title; default harness/model; fork provenance; `revision`; timestamps |
+| `chat_members` | Collaboration principals and role (`owner`, `editor`, `viewer`); unique by Chat/principal; personal Chats still have one owner row |
+| `chat_user_state` | Per-principal read cursor, pinned/muted state, attention acknowledgement, last-opened timestamp; serializable durable UI state |
+| `chat_messages` | Per-Chat monotonic `seq`; role; strict parts JSONB; state; optional Turn/Run IDs; byte count; timestamps; unique `(chat_id, seq)` |
+| `chat_attachments` | Owner-file/object references and safe metadata; never embeds arbitrary local paths or attachment bytes in renderer projections |
+| `chat_turns` | User action, `base_message_seq`, input message, idempotency key, status, timestamps; unique `(chat_id, client_request_id)` |
+| `chat_runs` | Attempt number, actual harness/model, capability snapshot, history boundary, status/outcome, timestamps; one active Run per Chat via a partial unique index |
+| `chat_run_events` | Bounded normalized replay events for streaming, approvals, tool progress, and recovery; provider raw frames are forbidden |
+| `chat_run_adapter_state` | Opaque, bounded, schema-versioned state keyed by Run and harness; repository API is adapter-only |
+| `chat_outbox` | Monotonic owner/Chat event cursor inserted transactionally with mutations for cross-shell replay |
+| `chat_deletions` | Content-free idempotency tombstone for hard deletes; contains only owner, Chat ID, request ID, and deletion time |
+| `chat_legacy_imports` | Unique source kind/source ID to Chat mapping, source hash, import version, and verification status |
+| `chat_migrations` | Migration phase, cutover marker/version, source fingerprint, counts, errors, and timestamps |
+
+`project_id` intentionally has no relational foreign key because ProjectConfig
+is file-backed. The ProjectManager is authoritative. The Chat repository stores
+only the stable ID and treats missing/archived/deleting projects as unavailable.
+
+### Index and search requirements
+
+- Owner/lifecycle/updated-time index for bounded Chat listing.
+- Unique owner-scoped idempotency indexes for create, Turn admission, fork, and
+  delete requests.
+- Partial unique index allowing at most one accepted/running/waiting Run per
+  Chat.
+- Message pagination by `(chat_id, seq)`; no unbounded transcript reads.
+- Owner-scoped PostgreSQL full-text search over committed canonical message
+  text. Search metadata remains owner-local and is removed with the Chat.
+- Every normal read filters deleted content. Deletion tombstones are available
+  only to the idempotency path.
+
+## Transaction and concurrency model
+
+### Turn admission
+
+One transaction:
+
+1. derive owner from the verified principal and lock the Chat row `FOR UPDATE`;
+2. validate membership, lifecycle, base revision, project availability, and no
+   active Run;
+3. resolve harness/model capability selection and canonical history boundary;
+4. insert the user message, Turn, accepted Run, initial adapter-state envelope,
+   and outbox event; and
+5. increment Chat revision and commit.
+
+Only after commit may orchestration call the external harness/model. A failed
+call transitions the persisted Run to `failed` in a new transaction. It never
+rolls back the accepted user input or holds a database lock across I/O.
+
+### Context, lifecycle, and deletion
+
+Project-context update, archive, delete, and Run admission all lock the same
+Chat row and re-check active Run state inside the transaction. Context changes
+use `WHERE revision = :baseRevision` or the row lock plus revision increment.
+This prevents a Turn from executing in one project while the Chat displays
+another and prevents a deleted Chat from being recreated by late finalization.
+
+Provider callbacks update only the matching active Run with guarded status and
+sequence predicates. Late events after cancel/delete are rejected and logged;
+they cannot resurrect content. Each normalized event/message mutation and its
+outbox record commit together.
+
+## Root and project-bound semantics
+
+### Root Chat
+
+- `project_id IS NULL`.
+- The Chat is a Matrix OS task, not an unowned task.
+- A harness may run only when its descriptor supports `rootChat` and its
+  workspace requirement is not `project_required`.
+- The Gateway supplies a capability-filtered root execution context. It never
+  accepts a client path and never grants a coding harness implicit access to all
+  owner system data.
+- A project-required harness is displayed as unavailable with a safe action to
+  attach a project; there is no silent fallback or auto-created project.
+
+### Project-bound Chat
+
+- `project_id` is the immutable `ProjectConfig.id`.
+- ProjectManager adds `getProjectById(ownerScope, projectId)` and builds a
+  bounded, reconciled in-memory index from owner file configs. The file config
+  remains authoritative; PostgreSQL never becomes a second ProjectConfig.
+- Slug changes do not affect the Chat link. Duplicate/missing IDs fail closed
+  and require owner-visible repair.
+- At Run admission, Gateway resolves the current active ProjectConfig and fixes
+  its validated working root for that Run. The renderer sends no path.
+- Archived, deleting, missing, inaccessible, or owner-mismatched context keeps
+  history readable but blocks new Runs until context is repaired or cleared.
+- Worktree requirements are capability metadata only in the first delivery.
+  No worktree UI or implicit worktree creation is introduced.
+
+## Harness switching, retry, resume, and fork
+
+1. Changing the Chat's default harness/model affects future Runs only.
+2. A new Turn may use the selected harness with a bounded canonical history
+   window. The Run records the exact included message sequence boundary.
+3. Retrying the same Turn creates another Run attempt. Failed prior attempts
+   remain auditable; their partial output is not canonical input.
+4. Same-harness resume is allowed only when the adapter supports it, the stored
+   state parses under the exact adapter schema version, owner/project context
+   still matches, and the prior Run is in a resumable state.
+5. A harness change always creates a fresh Run from canonical history. The
+   orchestration layer never passes another harness's state to it.
+6. `Fork Chat` creates a new `chatId` with explicit parent Chat/message
+   provenance and copies canonical history through the selected committed
+   message. It does not copy active Runs or adapter resume state.
+7. History windowing is explicit and bounded. If full history exceeds adapter
+   limits, orchestration passes a recorded sequence range and persisted explicit
+   summaries; it never deletes or silently rewrites owner history.
+
+## Gateway API and auth matrix
+
+All schemas are strict and bounded. Every mutating HTTP endpoint uses Hono
+`bodyLimit`, including DELETE. Owner scope is derived, not supplied.
+
+| Contract | Principal | Authorization | Notes |
+|---|---|---|---|
+| `GET /api/chats` | Browser/native/CLI verified principal | Owner/member read | Bounded cursor list and filters |
+| `POST /api/chats` | Verified principal | Owner create | Idempotent request ID; optional project/default selection |
+| `GET /api/chats/:chatId` | Verified principal | Owner/member read | Summary plus bounded message page |
+| `PATCH /api/chats/:chatId` | Verified principal | Owner/editor | Title, default selection, context, lifecycle with base revision |
+| `DELETE /api/chats/:chatId` | Verified principal | Owner/org admin | Reject active Run unless an explicit cancel-and-delete flow completed |
+| `POST /api/chats/:chatId/turns` | Verified principal | Owner/editor | Transactional Turn/Run admission; idempotent request ID |
+| `POST /api/chats/:chatId/runs/:runId/cancel` | Verified principal | Owner/editor | Same-harness cancellation only |
+| `POST /api/chats/:chatId/forks` | Verified principal | Owner/editor | Explicit committed message boundary |
+| `POST /api/chats/:chatId/exports` | Verified principal | Owner/org admin | Bounded temp export with cleanup policy |
+| `GET /api/chat-harnesses` | Verified principal | Owner/member read | Safe capability/model projection only |
+| Chat event WebSocket | Browser query token or native/CLI bearer path | Owner/member read | Exact query-token allowlist, bounded frame schema, replay cursor |
+| Channel adapter dispatch | Authenticated internal channel principal | Mapped owner/member action | Channel/thread binding resolved server-side; no owner override |
+
+Auth failure is fail-closed. Missing database, ProjectManager, harness registry,
+or owner principal is service misconfiguration (`503`-style), never not-found.
+
+## Cross-shell events and convergence
+
+Every state-changing transaction appends a safe `chat_outbox` event containing
+Chat ID, revision, event type, timestamp, and the minimum safe projection. It
+does not contain transcript content, adapter state, provider errors, or paths.
+
+The Gateway subscription hub:
+
+- authorizes before subscribe and revalidates on replay;
+- caps connections per owner and globally;
+- tracks `lastTouched`, sweeps stale connections, and evicts failed senders;
+- isolates each send failure;
+- supports replay after a monotonic cursor and signals a replay gap;
+- publishes only after transaction commit; and
+- drains/clears subscribers before repository/shared-Kysely shutdown.
+
+Desktop, browser Shell, CLI, and channel shells refresh the canonical Chat
+projection from Gateway after an event. A local optimistic state may render,
+but failure preserves the prior confirmed Chat and exposes safe recovery copy.
+
+## Resource limits
+
+Initial hard maxima; lower deployment-specific limits may be configured.
+
+| Resource | Maximum / policy |
+|---|---|
+| Chat list page | 100 |
+| Message page | 200 |
+| Title | 200 characters and 1 KiB |
+| User message | 24,000 characters and 96 KiB |
+| Message parts | 64; total encoded message 128 KiB |
+| Attachments per Turn | 8; existing 5 MiB item limit; bytes remain in owner storage |
+| Active Runs | 1 per Chat, 8 per owner by default |
+| Provider event batch | 100 normalized events |
+| Persisted normalized events | 500 per Run before adapter aggregation/backpressure must occur |
+| Adapter state | 64 KiB JSON envelope after serialization |
+| Harness registry | 20 harnesses; duplicate IDs fail startup |
+| Model catalog | 64 models per harness projection; 128 tool capability IDs |
+| Dispatch history window | 200 messages or 2 MiB encoded; explicit range and truncation metadata required |
+| WebSocket frame | Existing bounded Chat frame limit; schema validation after JSON parsing |
+| Event subscribers | 32 per owner and a configured global cap; TTL sweep plus explicit shutdown drain |
+| Exports | Streamed; at most 20 retained temporary exports per owner; 24-hour TTL with symlink-safe recurring cleanup |
+| External capability/health calls | `AbortSignal.timeout`, 2 seconds default and 30 seconds hard maximum |
+
+Exceeding a provider/event/state bound fails or backpressures the Run with a
+generic safe error. It never silently truncates canonical messages.
+
+## Error contract
+
+Clients receive allowlisted codes such as:
+
+- `chat_not_found`, `chat_conflict`, `chat_busy`, `chat_unavailable`;
+- `project_required`, `project_unavailable`;
+- `harness_unavailable`, `model_unavailable`, `capability_mismatch`;
+- `run_not_found`, `run_not_resumable`, `run_unavailable`;
+- `history_window_required`; and
+- `migration_in_progress`.
+
+Renderer stores allowlist and cap server strings, falling back to generic copy.
+Provider IDs may appear as user-selected labels, but raw provider errors,
+stderr, credentials, database details, and paths remain only in bounded
+owner-controlled logs.
+
+## Shutdown and restart
+
+Gateway shutdown order:
+
+1. stop new Chat/Turn admissions and emit a safe service-closing signal;
+2. stop accepting event subscriptions;
+3. request cancellation from active harness adapters with a 10-second total
+   drain budget;
+4. transactionally mark unresolved Runs `interrupted` and append outbox events;
+5. drain/clear Chat subscribers and timers;
+6. stop migration workers/export cleanup; and
+7. release Chat repository references before the Gateway owner closes the one
+   shared Kysely pool.
+
+On startup, reconciliation finds accepted/running/waiting Runs. It may offer
+resume only through the same adapter and valid state version. Otherwise it
+marks the Run interrupted/failed with safe recovery actions. It never resumes
+through another harness or claims an external process is still live based only
+on timestamps.
+
+## Export and delete
+
+Export uses a consistent owner-authorized database snapshot and includes Chat
+metadata, canonical messages, Turns, Run outcomes, capability selections,
+collaboration/read state, and attachment manifests. Adapter resume state and
+credentials are excluded by default; an explicit advanced export may include
+validated non-secret adapter state with a warning. Export never sends content
+to platform PostgreSQL.
+
+Delete requires owner/org-admin authorization and an idempotency key. One
+transaction locks the Chat, rejects an active Run, deletes all content and
+adapter/collaboration/UI state through explicit cascades, writes a content-free
+deletion tombstone, and emits an outbox deletion event. Attachment bytes are
+deleted only when the reference is exclusively owned by that Chat; shared
+owner files remain. Repeated delete returns success from the tombstone without
+refreshing it or recreating content.
+
+## JSON-to-PostgreSQL migration and cutover
+
+### Sources
+
+- `system/conversations/*.json` (Gateway kernel/Hermes history and session IDs);
+- `system/coding-agents/threads.json` (threads, turns, normalized events,
+  relations, and valid provider resume state); and
+- no renderer-owned rail import. Current Desktop `useHermesChat`/`useThreads`
+  state is process memory, so there is no durable record to discover. The
+  maintenance barrier drains live renderer/Gateway Runs before final cutover.
+
+### Idempotent import
+
+1. Bootstrap schema and a versioned migration row without changing legacy
+   authority.
+2. Enumerate only validated source files; reject symlinks, oversized files,
+   invalid JSON, duplicate IDs, and schema violations into an owner-visible
+   migration report.
+3. Hash each normalized source record. Upsert a unique
+   `(source_kind, source_id)` mapping with `ON CONFLICT`; the same hash is a
+   no-op, and a changed hash is re-imported transactionally before cutover.
+4. Map legacy conversation IDs to new Chat IDs while preserving a compatibility
+   alias. Convert messages to canonical parts. Map each coding-agent thread to
+   a Chat, its accepted inputs to Turns, and provider attempts/events to Runs.
+5. Preserve valid Hermes/coding provider session state only in the matching
+   adapter-state envelope. Invalid or secret-shaped state is quarantined from
+   execution but reported; transcript import still proceeds.
+6. Validate counts, sequence ordering, owner scope, hashes, orphan references,
+   and sample transcript parity. Partial batch failure rolls back that batch and
+   leaves the cutover marker unset.
+
+### Explicit cutover
+
+1. Enter a bounded maintenance barrier: new mutations return retryable
+   `migration_in_progress`; active Runs drain or become interrupted.
+2. Acquire the migration advisory lock, take a final source fingerprint, and
+   rerun the idempotent delta import.
+3. In one transaction verify counts/hashes, set the immutable cutover marker,
+   and append a migration-complete outbox event.
+4. Release the barrier with PostgreSQL as the sole read/write authority.
+
+There is no dual write. Before the marker, legacy JSON is authoritative. After
+the marker, all reads and writes use PostgreSQL. Legacy API IDs resolve through
+`chat_legacy_imports` for a bounded compatibility window of two stable releases
+or 30 days, whichever is longer; this translation reads PostgreSQL, not JSON.
+The original JSON files remain untouched, read-only owner backup material until
+the documented retention/export step. Runtime code never falls back to them.
+
+Rollback before cutover is safe. After cutover, rollback is allowed only to a
+release that understands the marker and PostgreSQL schema; an older JSON writer
+must refuse startup. This prevents split-brain and indefinite compatibility.
+
+## Delivery slices and issue sequencing
+
+### Slice A — persistence and migration
+
+Add contracts, typed Kysely repository/migrations, immutable ProjectConfig ID
+lookup, transactions/outbox, JSON importer, cutover/recovery, export/delete,
+and repository/Gateway tests. This is the prerequisite for the other slices.
+
+### Slice B — harness and model adapters
+
+Add harness/model registries and capability contracts, then adapt Hermes,
+OpenClaw, Codex, Pi, and OpenCode incrementally. Move valid provider state
+behind adapter-only storage. Prove same-harness resume and cross-harness
+non-resume with contract tests.
+
+### Slice C — shell/UI migration
+
+Move Desktop, browser Shell, CLI, and channel shells to `/api/chats` and the
+outbox event stream. Replace source/provider-typed rails with one Chat
+projection and capability labels. Remove renderer-owned thread identity only
+after parity and cutover evidence.
+
+MAT-299 continues to provide the current canonical Hermes lifecycle and remains
+in PR #1213. It does not absorb the PostgreSQL migration. MAT-318 remains a
+separate project-context delivery, but its durable target is the immutable
+`ProjectConfig.id`/canonical Chat seam from Slice A rather than a slug or JSON
+record. Neither existing PR is silently expanded.
+
+A separate public documentation PR is required in the private
+`FinnaAI/matrix-os-site` repository after runtime behavior exists. No local
+`www/` tree is created.
+
+## TDD and verification strategy
+
+Implementation tests are written first after these public seams are approved.
+
+- **Contracts:** strict Chat/message/Turn/Run/harness/model schemas; reserved
+  fields; byte/count bounds; safe errors; provider-state opacity.
+- **Repository:** migrations; owner isolation; row-lock races; optimistic
+  revision; partial unique active Run; transactional outbox; hard delete;
+  export snapshot; shared Kysely ownership/shutdown.
+- **Migration:** repeated import, changed hashes, invalid sources, symlinks,
+  crash/restart per phase, pre/post-marker rollback, no dual writes, legacy ID
+  compatibility expiry, transcript and resume-state parity.
+- **Harnesses:** capability discovery; model resolution; event/state bounds;
+  same-harness resume; cross-harness resume rejection; cancel timeout; generic
+  failures; project/root requirements.
+- **Gateway/auth:** route/body/query validation, `bodyLimit` including DELETE,
+  personal/org membership matrix, browser WebSocket query-token path, replay
+  gaps, stale subscriber eviction, shutdown drain.
+- **Concurrency:** Turn admission versus context update/delete/archive; late
+  provider callbacks; duplicate requests; two-shell mutation conflicts.
+- **Shells:** runtime-scope invalidation, loading/error/reconnect/replay, failed
+  mutation preservation, capability-driven labels, no provider-specific Chat
+  types, export/delete flows.
+- **Real runtime:** owner-VPS PostgreSQL evidence, Gateway/browser/CLI/Desktop
+  convergence, same-harness resume, harness switch from canonical history,
+  project removal recovery, restart reconciliation, and exact export/delete.
+
+Direct Figma parity is explicitly unverified because the Matrix OS View-seat
+MCP call limit is exhausted. Existing saved screenshots/spec evidence may guide
+later shell work, but no direct Figma-inspection claim may be made until access
+is restored.
+
+## Acceptance criteria
+
+- [x] One provider-neutral Chat contract represents durable user-facing tasks.
+- [x] Harness/model selection is capability-driven and extensible without
+  changing Chat identity.
+- [x] Provider session/resume state is adapter-only and cannot replace Chat ID.
+- [x] Owner-local PostgreSQL/Kysely is the durable relational source of truth.
+- [x] Project files remain authoritative and are linked by immutable project ID.
+- [x] Root and project-bound execution semantics are explicit and testable.
+- [x] Harness switching, retry, resume, and explicit fork behavior are defined.
+- [x] JSON and coding-agent sources have an idempotent, recoverable, bounded
+  cutover plan with no indefinite dual write.
+- [x] Auth, validation, resource limits, shutdown, export/delete, and cross-shell
+  convergence are specified.
+- [x] Focused TDD layers and three independent implementation slices are
+  defined.
+- [x] Public documentation is a separate follow-up PR.
+- [x] MAT-268 is excluded without modification, dependency, or new relation.

--- a/specs/113-provider-neutral-chat-architecture/spec.md
+++ b/specs/113-provider-neutral-chat-architecture/spec.md
@@ -209,7 +209,14 @@ interface ChatHarnessAdapter<State> {
 
 The adapter-state store exposes state only to the registered adapter whose ID
 and schema version match the Run. Adapters must not place access tokens,
-credentials, raw stderr, absolute paths, or unbounded transcripts in state.
+credentials, raw stderr, or unbounded transcripts in state. A provider-native
+absolute execution root such as Pi's `cwd` is the sole path exception: the
+exact adapter schema must declare the field, and Gateway must realpath-resolve
+and validate it against the current owner-scoped `ProjectConfig.id` at import,
+write, and resume. It remains encrypted, adapter-private, and excluded from
+logs, renderer projections, and default exports. Client-supplied paths and
+paths outside the resolved project root are rejected; a moved or unavailable
+project makes the Run non-resumable rather than silently rebinding the path.
 
 ### Model plugin contract
 
@@ -251,7 +258,7 @@ Run orchestration have drained.
 | `chat_outbox` | Monotonic owner/Chat event cursor inserted transactionally with mutations for cross-shell replay |
 | `chat_deletions` | Content-free idempotency tombstone for hard deletes; contains only owner, Chat ID, request ID, and deletion time |
 | `chat_legacy_imports` | Unique source kind/source ID to Chat mapping, source hash, import version, and verification status |
-| `chat_migrations` | Migration phase, cutover marker/version, source fingerprint, counts, errors, and timestamps |
+| `chat_migrations` | Migration phase, cutover marker/version, source fingerprint, counts, errors, timestamps, and the immutable legacy-alias expiry |
 
 `project_id` intentionally has no relational foreign key because ProjectConfig
 is file-backed. The ProjectManager is authoritative. The Chat repository stores
@@ -497,8 +504,11 @@ refreshing it or recreating content.
    alias. Convert messages to canonical parts. Map each coding-agent thread to
    a Chat, its accepted inputs to Turns, and provider attempts/events to Runs.
 5. Preserve valid Hermes/coding provider session state only in the matching
-   adapter-state envelope. Invalid or secret-shaped state is quarantined from
-   execution but reported; transcript import still proceeds.
+   adapter-state envelope. Pi's absolute `cwd` remains resumable only when its
+   adapter schema accepts it and Gateway binds its realpath to the imported
+   Chat's current owner-scoped project root. Secrets, undeclared path fields,
+   and paths outside that root are quarantined from execution but reported;
+   transcript import still proceeds.
 6. Validate counts, sequence ordering, owner scope, hashes, orphan references,
    and sample transcript parity. Partial batch failure rolls back that batch and
    leaves the cutover marker unset.
@@ -510,15 +520,21 @@ refreshing it or recreating content.
 2. Acquire the migration advisory lock, take a final source fingerprint, and
    rerun the idempotent delta import.
 3. In one transaction verify counts/hashes, set the immutable cutover marker,
-   and append a migration-complete outbox event.
+   persist `legacy_alias_expires_at = cutover_at + interval '90 days'`, and
+   append a migration-complete outbox event.
 4. Release the barrier with PostgreSQL as the sole read/write authority.
 
 There is no dual write. Before the marker, legacy JSON is authoritative. After
 the marker, all reads and writes use PostgreSQL. Legacy API IDs resolve through
-`chat_legacy_imports` for a bounded compatibility window of two stable releases
-or 30 days, whichever is longer; this translation reads PostgreSQL, not JSON.
-The original JSON files remain untouched, read-only owner backup material until
-the documented retention/export step. Runtime code never falls back to them.
+`chat_legacy_imports` only while the database clock is strictly earlier than the
+immutable `legacy_alias_expires_at`, exactly 90 days after cutover. At and after
+that instant the resolver returns the safe expired/not-found result and a
+recurring cleanup may delete alias rows. Tests use an injected clock at the
+89-day, exact-expiry, and post-expiry boundaries. This rule needs no platform
+release history and cannot remain active indefinitely. The translation reads
+PostgreSQL, not JSON. The original JSON files remain untouched, read-only owner
+backup material until the documented retention/export step. Runtime code never
+falls back to them.
 
 Rollback before cutover is safe. After cutover, rollback is allowed only to a
 release that understands the marker and PostgreSQL schema; an older JSON writer

--- a/specs/113-provider-neutral-chat-architecture/spec.md
+++ b/specs/113-provider-neutral-chat-architecture/spec.md
@@ -152,11 +152,17 @@ interface ChatProjectProjection {
   repositoryLabel?: string;
   status: "ready" | "unavailable";
 }
+
+type ChatExecutionRootRef =
+  | { kind: "project"; projectId: string }
+  | { kind: "worktree"; projectId: string; worktreeId: string };
 ```
 
 The client never sends `OwnerScope`, a filesystem path, provider resume state,
 provider credentials, repository URL, or runtime identity. Gateway derives
-owner scope from the verified principal and resolves project/runtime state.
+owner scope from the verified principal and resolves project/runtime state. A
+client may select an opaque existing `worktreeId` where the harness supports
+it, but only Gateway constructs and validates `ChatExecutionRootRef`.
 
 ### Canonical messages
 
@@ -212,11 +218,34 @@ and schema version match the Run. Adapters must not place access tokens,
 credentials, raw stderr, or unbounded transcripts in state. A provider-native
 absolute execution root such as Pi's `cwd` is the sole path exception: the
 exact adapter schema must declare the field, and Gateway must realpath-resolve
-and validate it against the current owner-scoped `ProjectConfig.id` at import,
-write, and resume. It remains encrypted, adapter-private, and excluded from
-logs, renderer projections, and default exports. Client-supplied paths and
-paths outside the resolved project root are rejected; a moved or unavailable
-project makes the Run non-resumable rather than silently rebinding the path.
+it through an owner-scoped `ChatExecutionRootResolver` at import, write, and
+resume. Validation is exact provenance, not lexical containment:
+
+- a `project` root must equal the current realpath of
+  `ProjectConfig.localPath`; this includes owner-approved external folder
+  projects that ProjectManager already accepted; or
+- a `worktree` root must equal the current realpath of the exact live
+  `WorktreeRecord` resolved by the same ProjectConfig's slug and `worktreeId`,
+  and that record must remain under Matrix's canonical
+  `projects/<slug>/worktrees/<worktreeId>` root with matching `.matrix`
+  metadata.
+
+The adapter envelope stores the safe execution-root reference alongside the
+provider `cwd`. A legacy Pi state with only `cwd` is preserved only when it
+exactly matches the project root or exactly one registered worktree for that
+project; import backfills that reference. Arbitrary siblings, unregistered
+worktrees, subpaths, owner mismatches, and ambiguous matches are quarantined.
+The path remains encrypted, adapter-private, and excluded from logs, renderer
+projections, and default exports. A moved/deleted root or changed provenance
+makes the Run non-resumable rather than silently rebinding it.
+
+The resolver returns a non-secret fingerprint derived from a canonical encoding
+of the safe reference, owner scope, `ProjectConfig.id`, its validated current
+`localPath` realpath, and, for worktrees, the `WorktreeRecord` ID, project slug,
+validated realpath, and creation timestamp. The fingerprint is stored with the
+Run; raw paths are not. Re-resolution must reproduce the same reference and
+fingerprint before start/resume. Any file-config or worktree-record change that
+alters those inputs requires a new Run instead of reusing adapter state.
 
 ### Model plugin contract
 
@@ -252,7 +281,7 @@ Run orchestration have drained.
 | `chat_messages` | Per-Chat monotonic `seq`; role; strict parts JSONB; state; optional Turn/Run IDs; byte count; timestamps; unique `(chat_id, seq)` |
 | `chat_attachments` | Owner-file/object references and safe metadata; never embeds arbitrary local paths or attachment bytes in renderer projections |
 | `chat_turns` | User action, `base_message_seq`, input message, idempotency key, status, timestamps; unique `(chat_id, client_request_id)` |
-| `chat_runs` | Attempt number, actual harness/model, capability snapshot, history boundary, status/outcome, timestamps; one active Run per Chat via a partial unique index |
+| `chat_runs` | Attempt number, actual harness/model, safe execution-root reference, capability snapshot, history boundary, status/outcome, timestamps; one active Run per Chat via a partial unique index |
 | `chat_run_events` | Bounded normalized replay events for streaming, approvals, tool progress, and recovery; provider raw frames are forbidden |
 | `chat_run_adapter_state` | Opaque, bounded, schema-versioned state keyed by Run and harness; repository API is adapter-only |
 | `chat_outbox` | Monotonic owner/Chat event cursor inserted transactionally with mutations for cross-shell replay |
@@ -281,19 +310,24 @@ only the stable ID and treats missing/archived/deleting projects as unavailable.
 
 ### Turn admission
 
-One transaction:
+Before opening the transaction, Gateway resolves any execution-root reference
+through ProjectManager/WorktreeManager and records a root fingerprint without
+holding a database lock across filesystem I/O. One transaction then:
 
 1. derive owner from the verified principal and lock the Chat row `FOR UPDATE`;
-2. validate membership, lifecycle, base revision, project availability, and no
-   active Run;
+2. validate membership, lifecycle, base revision, the same project/root
+   reference, and no active Run;
 3. resolve harness/model capability selection and canonical history boundary;
 4. insert the user message, Turn, accepted Run, initial adapter-state envelope,
    and outbox event; and
 5. increment Chat revision and commit.
 
-Only after commit may orchestration call the external harness/model. A failed
-call transitions the persisted Run to `failed` in a new transaction. It never
-rolls back the accepted user input or holds a database lock across I/O.
+Only after commit may orchestration call the external harness/model. Immediately
+before that call it re-resolves the exact execution-root reference and compares
+the fingerprint; a changed, deleted, moved, or owner-mismatched root fails the
+Run safely. A failed call transitions the persisted Run to `failed` in a new
+transaction. It never rolls back the accepted user input or holds a database
+lock across I/O.
 
 ### Context, lifecycle, and deletion
 
@@ -331,7 +365,11 @@ outbox record commit together.
 - Slug changes do not affect the Chat link. Duplicate/missing IDs fail closed
   and require owner-visible repair.
 - At Run admission, Gateway resolves the current active ProjectConfig and fixes
-  its validated working root for that Run. The renderer sends no path.
+  a safe `ChatExecutionRootRef` for that Run. Direct project execution resolves
+  exactly to `ProjectConfig.localPath`, including an approved external folder.
+  Worktree execution resolves only through the existing WorktreeManager record
+  for the same project; managed sibling worktrees are valid without being
+  descendants of `localPath`. The renderer sends no path.
 - Archived, deleting, missing, inaccessible, or owner-mismatched context keeps
   history readable but blocks new Runs until context is repaired or cleared.
 - Worktree requirements are capability metadata only in the first delivery.
@@ -505,10 +543,12 @@ refreshing it or recreating content.
    a Chat, its accepted inputs to Turns, and provider attempts/events to Runs.
 5. Preserve valid Hermes/coding provider session state only in the matching
    adapter-state envelope. Pi's absolute `cwd` remains resumable only when its
-   adapter schema accepts it and Gateway binds its realpath to the imported
-   Chat's current owner-scoped project root. Secrets, undeclared path fields,
-   and paths outside that root are quarantined from execution but reported;
-   transcript import still proceeds.
+   adapter schema accepts it and Gateway binds its realpath to either the exact
+   current `ProjectConfig.localPath` or one exact registered WorktreeRecord for
+   the imported Chat's owner-scoped project, backfilling the corresponding safe
+   execution-root reference. Secrets, undeclared path fields, arbitrary sibling
+   paths, and unregistered/ambiguous roots are quarantined from execution but
+   reported; transcript import still proceeds.
 6. Validate counts, sequence ordering, owner scope, hashes, orphan references,
    and sample transcript parity. Partial batch failure rolls back that batch and
    leaves the cutover marker unset.


### PR DESCRIPTION
## Summary

- audit the current Gateway conversation JSON store, coding-agent thread aggregate, Browser/Desktop renderer rails, owner-local Kysely lifecycle, immutable `ProjectConfig.id`, and provider/harness seams
- define one durable owner-scoped Chat identity with canonical messages, Turns, Runs, adapter-private resume state, capability-selected model plugins, and immutable project references
- specify authenticated Gateway APIs, bounded replayable outbox events, resource and shutdown rules, export/delete behavior, and an idempotent one-way JSON-to-Postgres cutover
- provide a TDD implementation plan split into independent persistence, harness-adapter, and shell/UI follow-up slices

## Invariants

- **Source of truth:** before the cutover marker, legacy owner JSON remains authoritative; after the marker, the owner VPS PostgreSQL/Kysely Chat schema is authoritative. Platform PostgreSQL never stores owner Chat content, and no indefinite dual writer is allowed.
- **Lock and transaction scope:** Turn admission, project-context mutation, archive/delete, and active-Run checks lock the same owned Chat row in one transaction. Canonical state and its outbox event commit together; no external harness call occurs inside that transaction.
- **Acceptable orphans:** provider-side sessions may become unreachable after cancellation, crash, or delete. They are adapter-private best-effort cleanup targets and never authorize recreating canonical Chat content. Canonical Postgres rows, export temp files, and owner attachments all have explicit cleanup/reconciliation rules.
- **Auth source:** every owner and membership scope is derived from the verified Gateway principal or an authenticated internal channel binding. Client-supplied owner overrides are rejected. Browser WebSocket query-token auth must use the explicit allowlist and replay remains owner-authorized.
- **Deferred scope:** this PR records architecture and executable TDD seams only. It performs no runtime migration, does not expand MAT-299 or MAT-318, and does not modify, depend on, or create a Linear relation to MAT-268.

## Architecture decisions

- Chat is the durable user-facing task; Hermes, OpenClaw, Codex, Pi, OpenCode, and future harnesses are adapters rather than Chat types.
- Models are separate capability descriptors selected per Run.
- Provider session/resume state is versioned, schema-validated, encrypted at rest, and accessible only through its exact harness adapter.
- Harness switching creates a fresh Run from canonical history; cross-provider resume is forbidden. Explicit fork creates a new Chat with provenance.
- Root Chats have no project ID. Project-bound Chats store only immutable `ProjectConfig.id` and resolve current owner-file configuration at Run admission.
- The cutover uses a maintenance barrier, deterministic legacy IDs, idempotent import ledger, validation, one atomic authority marker, and a time-bounded compatibility translator backed by Postgres.

## Follow-up slices

1. `feat(chat): add owner-owned canonical persistence`
2. `feat(chat): add provider-neutral harness adapters`
3. `feat(chat): migrate shells to canonical tasks`

Each slice starts with failing tests at the recorded public seams. No broad implementation migration begins in this PR.

## Validation

- `flox activate -- bun run typecheck` — passed
- `flox activate -- bun run check:patterns` — passed with 5 existing warnings and 0 violations
- `flox activate -- bun run test` — baseline gate did not pass: 10,649 passed, 20 skipped, 26 failed, and 9 suite-load failures across 950 files. Failures are outside this two-file docs-only diff and include load-sensitive timeouts, macOS Unix-socket path limits, timezone-sensitive Todo assertions, and missing `vitest` resolution from `@testing-library/jest-dom` in nine UI suites.
- final diff review — 2 documentation files, 1,894 insertions, no whitespace errors

## Automated review follow-up

- Greptile initially reported two valid findings on commit `efd6b294c`: valid Pi `cwd` resume state conflicted with the path ban, and legacy alias expiry depended on indeterminate release history.
- Commit `910c99257` allows only schema-declared execution roots after owner-project realpath validation and replaces release-count retention with an immutable 90-day database-clock expiry plus exact-boundary tests.
- Greptile's second pass identified that valid managed worktrees are siblings of the configured repository and therefore need explicit provenance rather than a descendant check.
- Commit `3b3184832` defines exact direct-project and registered-worktree references, accepts owner-approved external-folder projects, persists a non-secret provenance fingerprint, quarantines arbitrary siblings, and requires pre-dispatch revalidation with corresponding TDD fixtures.
- All three review threads were answered in English and resolved. Greptile completed its third review on `3b3184832` at 5/5 with zero unresolved threads; Claude review, conventional-title, and preview-gate checks also passed.

## Review focus

- owner boundary and local-Postgres lifecycle
- row-lock and transaction admission model
- adapter-private resume state and cross-harness switching
- outbox replay authorization, caps, stale eviction, and shutdown drain
- one-way migration barrier, restart behavior, and rollback boundary
- export/delete data ownership and cleanup

Direct Figma parity is explicitly unverified because the Matrix OS View-seat MCP call limit is currently blocking access; no retry was made. Existing saved product/spec evidence was used instead.

Linear: MAT-319
Related context only: MAT-299, MAT-318
