### PR TITLE
revert(platform): remove stable golden snapshot trigger

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -368,6 +368,7 @@ jobs:
           PUBLISH_VERSION: ${{ needs.build.outputs.version }}
           PUBLISH_SEVERITY: ${{ steps.meta.outputs.severity }}
           PUBLISH_CHANGELOG: ${{ steps.meta.outputs.changelog }}
+          GOLDEN_SNAPSHOT_ELIGIBLE: ${{ (github.event_name == 'push' && ((github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag')) || (github.event_name == 'workflow_dispatch' && inputs.channel != '') }}
         run: |
           set -euo pipefail
           ARGS=("$PUBLISH_VERSION")
@@ -379,6 +380,34 @@ jobs:
           fi
 
           ./scripts/publish-release.sh "${ARGS[@]}"
+
+  enqueue-golden-snapshot:
+    name: Enqueue golden snapshot build
+    needs: [dev-bundle-gate, build, publish]
+    if: ${{ vars.GOLDEN_SNAPSHOT_BUILDS_ENABLED == 'true' && needs.dev-bundle-gate.outputs.should_build == 'true' && ((github.event_name == 'push' && ((github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag')) || (github.event_name == 'workflow_dispatch' && inputs.channel != '')) }}
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      PLATFORM_PUBLIC_URL: ${{ vars.PLATFORM_PUBLIC_URL || 'https://app.matrix-os.com' }}
+      PLATFORM_SECRET: ${{ secrets.PLATFORM_SECRET }}
+      PUBLISH_CHANNEL: ${{ needs.build.outputs.channel }}
+      PUBLISH_VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install enqueue dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Enqueue idempotent snapshot build
+        run: node scripts/enqueue-golden-snapshot.mjs --version "$PUBLISH_VERSION"
 
   deploy:
     name: Deploy published host bundle

--- a/docs/dev/golden-vps-snapshots.md
+++ b/docs/dev/golden-vps-snapshots.md
@@ -6,8 +6,9 @@ The approved product invariants and policy are defined by [spec 109](../../specs
 
 ## V1 Invariants
 
-- Build a new sanitized candidate only when an eligible immutable host bundle is promoted to `stable`. Do not keep running or powered-off warm customer VPSes.
-- Select only a snapshot whose immutable bundle SHA-256 exactly matches the requested bundle. Otherwise use clean Ubuntu.
+- Build a new sanitized candidate for each eligible immutable main or tag host bundle. Do not keep running or powered-off warm customer VPSes.
+- Select an exact snapshot first. A compatible older snapshot may be used only when first boot updates it to the requested exact bundle before health, registration, or routing succeeds.
+- Never select a newer snapshot for an older requested bundle.
 - Keep snapshot building, publication, existing-fleet deployment, and customer provisioning as separate failure domains.
 - Fall back to the existing clean Ubuntu/full cloud-init path whenever lookup, compatibility, cloning, activation, or validation is definitely unsafe.
 - Do not issue a second provider create after an ambiguous timeout. Reconcile exact immutable labels first.
@@ -21,8 +22,6 @@ The feature ships disabled. `GOLDEN_SNAPSHOT_BUILDS_ENABLED` controls candidate 
 Platform Postgres is authoritative for immutable bundle provenance, snapshot state, build attempts, leases, cleanup work, and release/channel protection. Hetzner holds provider resources but is not the lifecycle source of truth. R2 holds immutable host-bundle bytes and checksums.
 
 Each logical image is keyed by the host bundle SHA-256 plus a compatibility key containing provider, architecture, region policy, base image/generation, boot mode, activation ABI, and minimum disk size. Re-registering a channel does not create a new identity. Preview/PR artifacts are not eligible for the release hook.
-
-The stable channel promotion is the forward-only build trigger. Stable releases default to snapshot-eligible and may explicitly opt out. Dev, canary, beta, preview, and register-only releases default to ineligible. The platform commits the stable pointer, exact eligibility value, and build enqueue in one transaction. A newer stable promotion quarantines unfinished older production builds and queues exact-resource cleanup. Startup workers do not scan or backfill release history, so releases that predate this contract remain historical unless promoted again through an explicitly authorized operation.
 
 The durable lifecycle is:
 
@@ -42,9 +41,9 @@ Related state changes use Postgres transactions. Provider requests are always ou
 
 ## Build and Validation
 
-The release publisher registers immutable metadata after upload. When that same operation promotes the bundle to `stable`, the platform transaction records eligibility and enqueues the exact bundle build. The release workflow has no separate enqueue job, and platform startup performs no historical lookback. `GOLDEN_SNAPSHOT_BUILDS_ENABLED` gates worker claims, not durable stable-promotion enqueue. The platform deployment workflow defaults workers to `false` and keeps snapshot selection disabled with rollout `0%`.
+The release workflow enqueues the immutable bundle version only after publication and only when the GitHub Actions variable `GOLDEN_SNAPSHOT_BUILDS_ENABLED` is exactly `true`. The platform deployment workflow passes the same variable to both candidate and production roles, defaults it to `false`, and keeps snapshot selection disabled with rollout `0%`. Enqueue failure is non-blocking, and the existing `deploy` job does not depend on snapshot success.
 
-The worker uses bounded batches and leases and claims production capacity only for the current eligible stable release. Ephemeral builders and validation clones carry exact labels for build ID, snapshot ID, and role. Those labels are also the only allowed basis for adopting a resource after an ambiguous create result. Zero matches means wait; multiple exact matches quarantine the build. Cleanup verifies the recorded resource ID and labels before deletion.
+The worker uses bounded batches and leases. Ephemeral builders and validation clones carry exact labels for build ID, snapshot ID, and role. Those labels are also the only allowed basis for adopting a resource after an ambiguous create result. Zero matches means wait; multiple exact matches quarantine the build. Cleanup verifies the recorded resource ID and labels before deletion.
 
 The sanitizer must remove or reset all of the following before shutdown:
 
@@ -69,7 +68,7 @@ Validation callbacks use a short-lived per-phase token stored only as a hash. Fa
 
 ## Provisioning and Recovery
 
-Selection order is exact compatible image, then clean Ubuntu. Compatibility includes the exact bundle SHA-256, architecture, region policy, boot mode, activation ABI, minimum disk, and base generation. Older or merely compatible bundle snapshots are never selected for a different target release.
+Selection order is exact compatible image, compatible older image, then clean Ubuntu. Compatibility includes architecture, region policy, boot mode, activation ABI, minimum disk, and base generation. A compatible older image is not healthy until exact-bundle activation completes.
 
 The snapshot lease remains active while the provider clone is in flight. Owner identity, platform registration material, tunnel credentials, TLS material, and runtime secrets are injected only through first-boot cloud-init after the clone. First boot regenerates machine ID, SSH host keys, cloud-init instance state, and runtime registration before routing.
 

--- a/docs/dev/releases.md
+++ b/docs/dev/releases.md
@@ -33,7 +33,7 @@ that image.
 - Host-bundle updates must never overwrite owner data. Do not delete or replace `/home/matrix/home`, `/opt/matrix/env`, or the local Postgres data directory during deploys or rollbacks.
 - `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` and CI/release paths use `pnpm install --frozen-lockfile`; do not bypass either during releases.
 - Host bundle release validation is blocking. If typecheck, tests, public build-env validation, build, publish, or registration fails, do not publish or deploy the bundle.
-- Promoting an eligible release to `stable` transactionally requests its golden snapshot build. Other channels do not enqueue builds, and workers do not look back through release history. See [Golden VPS Snapshots](golden-vps-snapshots.md).
+- Eligible main/tag releases request a golden snapshot build after publication. This request is an optional acceleration path: enqueue/build failure does not block publication or a separately authorized deployment. See [Golden VPS Snapshots](golden-vps-snapshots.md).
 - CLI releases are manual through `.github/workflows/release.yml`; bump `packages/sync-client/package.json`, run the sync-client checks, and dispatch the workflow with the same semver.
 - Fleet upgrade operations, blocked-machine handling, and the durable control-plane setup are documented in [Fleet Upgrade Operations](fleet-upgrade-operations.md).
 - Staging platform containers and disposable feature VPSes are temporary test

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -3392,7 +3392,7 @@ export async function promoteHostBundleChannel(
   return db.transaction((trx) => promoteHostBundleChannelInTransaction(trx, channel, version, updatedAt));
 }
 
-export async function promoteHostBundleChannelInTransaction(
+async function promoteHostBundleChannelInTransaction(
   db: PlatformDB,
   channel: string,
   version: string,

--- a/packages/platform/src/golden-snapshot-release-repository.ts
+++ b/packages/platform/src/golden-snapshot-release-repository.ts
@@ -1,19 +1,7 @@
 import { randomUUID } from 'node:crypto';
-import { sql } from 'kysely';
 import { z } from 'zod/v4';
-import {
-  getHostBundleRelease,
-  promoteHostBundleChannelInTransaction,
-  upsertHostBundleRelease,
-  type HostBundleChannelRecord,
-  type HostBundleReleaseRecord,
-  type NewHostBundleRelease,
-  type PlatformDB,
-} from './db.js';
-import {
-  appendGoldenSnapshotAuditEvent,
-  enqueueGoldenSnapshotBuildInTransaction,
-} from './golden-snapshot-repository.js';
+import type { PlatformDB } from './db.js';
+import { enqueueGoldenSnapshotBuild } from './golden-snapshot-repository.js';
 import {
   compatibilityKey,
   GoldenSnapshotCompatibilitySchema,
@@ -31,189 +19,6 @@ const CoarseStatusFreshnessSchema = z.object({
   now: IsoDateSchema,
   freshnessMaxAgeMs: z.number().int().min(60_000).max(365 * 24 * 60 * 60 * 1000),
 }).strict();
-
-const StableSnapshotRegistrationSchema = z.object({
-  compatibility: GoldenSnapshotCompatibilitySchema.optional(),
-  snapshotId: z.uuid().optional(),
-  buildId: z.uuid().optional(),
-  now: IsoDateSchema,
-}).strict();
-
-const StableSnapshotPromotionSchema = StableSnapshotRegistrationSchema.extend({
-  snapshotEligible: z.boolean().optional(),
-}).strict();
-
-const SUPERSEDED_STABLE_RELEASE = 'superseded_stable_release';
-
-function requireStableSnapshotBuildInput(
-  input: z.output<typeof StableSnapshotRegistrationSchema>,
-): {
-  compatibility: z.output<typeof GoldenSnapshotCompatibilitySchema>;
-  snapshotId: string;
-  buildId: string;
-} {
-  if (!input.compatibility || !input.snapshotId || !input.buildId) {
-    throw new Error('Eligible stable promotion requires golden snapshot configuration');
-  }
-  return {
-    compatibility: input.compatibility,
-    snapshotId: input.snapshotId,
-    buildId: input.buildId,
-  };
-}
-
-async function supersedeUnfinishedStableSnapshotBuilds(
-  trx: PlatformDB,
-  currentBundleSha256: string,
-  preserveCurrentBundleDigest: boolean,
-  now: string,
-): Promise<void> {
-  let query = trx.executor.selectFrom('golden_snapshots')
-    .innerJoin('golden_snapshot_builds', 'golden_snapshot_builds.snapshot_id', 'golden_snapshots.snapshot_id')
-    .select([
-      'golden_snapshots.snapshot_id', 'golden_snapshots.state', 'golden_snapshots.revision',
-      'golden_snapshots.provider_image_id', 'golden_snapshot_builds.build_id',
-      'golden_snapshot_builds.provider_builder_id', 'golden_snapshot_builds.provider_validation_id',
-    ])
-    .where('golden_snapshots.test_mode', '=', false)
-    .where('golden_snapshots.state', 'in', ['candidate', 'building', 'sanitizing', 'validating'])
-    .where('golden_snapshot_builds.status', 'in', ['queued', 'running']);
-  if (preserveCurrentBundleDigest) {
-    query = query.where('golden_snapshots.bundle_sha256', '!=', currentBundleSha256);
-  }
-  const rows = await query.orderBy('golden_snapshots.snapshot_id').forUpdate().execute();
-  for (const row of rows) {
-    const unreleasedLease = await trx.executor.selectFrom('golden_snapshot_leases').select('lease_id')
-      .where('snapshot_id', '=', row.snapshot_id).where('released_at', 'is', null)
-      .executeTakeFirst();
-    await trx.executor.updateTable('golden_snapshots').set({
-      state: 'quarantined', failure_code: SUPERSEDED_STABLE_RELEASE,
-      quarantined_at: now, updated_at: now, revision: sql<number>`revision + 1`,
-    }).where('snapshot_id', '=', row.snapshot_id).where('revision', '=', row.revision)
-      .executeTakeFirstOrThrow();
-    await trx.executor.updateTable('golden_snapshot_builds').set({
-      phase: 'failed', status: 'failed', last_error_code: SUPERSEDED_STABLE_RELEASE,
-      lease_expires_at: null, callback_phase: null, callback_token_hash: null,
-      callback_expires_at: null, completed_at: now, updated_at: now,
-    }).where('build_id', '=', row.build_id).where('status', 'in', ['queued', 'running'])
-      .executeTakeFirstOrThrow();
-    await trx.executor.updateTable('golden_snapshot_create_intents').set({
-      state: 'denied', updated_at: now,
-    }).where('snapshot_id', '=', row.snapshot_id).where('state', 'in', ['pending', 'accepted'])
-      .where('completed_at', 'is', null).execute();
-    await appendGoldenSnapshotAuditEvent(trx, {
-      snapshotId: row.snapshot_id, buildId: row.build_id,
-      eventType: 'snapshot_revoked', actorType: 'release',
-      fromState: row.state, toState: 'quarantined', reason: SUPERSEDED_STABLE_RELEASE, now,
-    });
-    const resources = [
-      row.provider_builder_id === null ? undefined : {
-        type: 'builder_server' as const, id: row.provider_builder_id,
-      },
-      row.provider_validation_id === null ? undefined : {
-        type: 'validation_server' as const, id: row.provider_validation_id,
-      },
-      row.provider_image_id === null || unreleasedLease ? undefined : {
-        type: 'snapshot_image' as const, id: row.provider_image_id,
-      },
-    ].filter((resource): resource is {
-      type: 'builder_server' | 'validation_server' | 'snapshot_image'; id: number;
-    } => resource !== undefined);
-    for (const resource of resources) {
-      await trx.executor.insertInto('golden_snapshot_cleanup').values({
-        cleanup_id: randomUUID(), snapshot_id: row.snapshot_id, build_id: row.build_id,
-        resource_type: resource.type, provider_resource_id: resource.id,
-        provenance_key: `supersede:${row.snapshot_id}:${resource.type}`,
-        reason: SUPERSEDED_STABLE_RELEASE, status: 'queued', attempts: 0,
-        next_attempt_at: now, lease_expires_at: null, last_error_code: null,
-        created_at: now, completed_at: null,
-      }).onConflict((oc) => oc.columns(['resource_type', 'provider_resource_id'])
-        .where('completed_at', 'is', null).doNothing()).execute();
-    }
-  }
-}
-
-export async function registerHostBundleReleaseWithStableSnapshot(
-  db: PlatformDB,
-  record: NewHostBundleRelease,
-  channel: string | undefined,
-  rawInput: z.input<typeof StableSnapshotRegistrationSchema>,
-): Promise<{ release: HostBundleReleaseRecord; channel?: HostBundleChannelRecord }> {
-  const input = StableSnapshotRegistrationSchema.parse(rawInput);
-  await db.ready;
-  return db.transaction(async (trx) => {
-    await sql`SELECT pg_advisory_xact_lock(hashtext('golden_snapshot_stable_promotion'))`
-      .execute(trx.executor);
-    const snapshotEligible = record.snapshotEligible ?? channel === 'stable';
-    let release = await upsertHostBundleRelease(trx, { ...record, snapshotEligible });
-    if (!channel) return { release };
-    if (channel === 'stable') {
-      await trx.executor.updateTable('host_bundle_releases').set({
-        snapshot_eligible: snapshotEligible,
-        snapshot_eligibility_source: 'explicit',
-      }).where('version', '=', release.version).executeTakeFirstOrThrow();
-      const registered = await getHostBundleRelease(trx, release.version);
-      if (!registered) throw new Error('Cannot load registered host bundle release');
-      release = registered;
-    }
-    const promoted = await promoteHostBundleChannelInTransaction(
-      trx, channel, release.version, input.now,
-    );
-    if (channel === 'stable') {
-      await supersedeUnfinishedStableSnapshotBuilds(
-        trx, release.sha256, release.snapshotEligible, input.now,
-      );
-    }
-    if (channel === 'stable' && release.snapshotEligible) {
-      const buildInput = requireStableSnapshotBuildInput(input);
-      await enqueueGoldenSnapshotBuildInTransaction(trx, {
-        bundleVersion: release.version,
-        ...buildInput,
-        now: input.now,
-      });
-    }
-    return { release, channel: promoted };
-  });
-}
-
-export async function promoteHostBundleChannelWithStableSnapshot(
-  db: PlatformDB,
-  channel: string,
-  version: string,
-  rawInput: z.input<typeof StableSnapshotPromotionSchema>,
-): Promise<{ release: HostBundleReleaseRecord; channel: HostBundleChannelRecord }> {
-  const input = StableSnapshotPromotionSchema.parse(rawInput);
-  await db.ready;
-  return db.transaction(async (trx) => {
-    await sql`SELECT pg_advisory_xact_lock(hashtext('golden_snapshot_stable_promotion'))`
-      .execute(trx.executor);
-    const existing = await getHostBundleRelease(trx, version);
-    if (!existing) throw new Error('Cannot promote unknown host bundle release');
-    if (channel === 'stable') {
-      await trx.executor.updateTable('host_bundle_releases').set({
-        snapshot_eligible: input.snapshotEligible ?? true,
-        snapshot_eligibility_source: 'explicit',
-      }).where('version', '=', version).executeTakeFirstOrThrow();
-    }
-    const release = await getHostBundleRelease(trx, version);
-    if (!release) throw new Error('Cannot promote unknown host bundle release');
-    const promoted = await promoteHostBundleChannelInTransaction(trx, channel, version, input.now);
-    if (channel === 'stable') {
-      await supersedeUnfinishedStableSnapshotBuilds(
-        trx, release.sha256, release.snapshotEligible, input.now,
-      );
-    }
-    if (channel === 'stable' && release.snapshotEligible) {
-      const buildInput = requireStableSnapshotBuildInput(input);
-      await enqueueGoldenSnapshotBuildInTransaction(trx, {
-        bundleVersion: release.version,
-        ...buildInput,
-        now: input.now,
-      });
-    }
-    return { release, channel: promoted };
-  });
-}
 
 export type GoldenSnapshotCoarseStatus =
   | 'not_requested'
@@ -290,4 +95,74 @@ export async function getGoldenSnapshotCoarseStatuses(
   }
   for (const [version, states] of grouped) result.set(version, coarseStatus(states));
   return result;
+}
+
+const MissingBuildReconciliationInputSchema = z.object({
+  compatibility: GoldenSnapshotCompatibilitySchema,
+  now: IsoDateSchema,
+  limit: z.number().int().min(1).max(100),
+  freshnessMaxAgeMs: z.number().int().min(60_000).max(365 * 24 * 60 * 60 * 1000),
+}).strict();
+
+export async function reconcileMissingGoldenSnapshotBuilds(
+  db: PlatformDB,
+  rawInput: z.input<typeof MissingBuildReconciliationInputSchema>,
+): Promise<{ enqueued: number }> {
+  const input = MissingBuildReconciliationInputSchema.parse(rawInput);
+  const key = compatibilityKey(input.compatibility);
+  const freshnessCutoff = new Date(
+    new Date(input.now).getTime() - input.freshnessMaxAgeMs,
+  ).toISOString();
+  await db.ready;
+  // During the first rollout, an old platform revision can accept and promote
+  // a release while stripping the new eligibility field. Only legacy rows are
+  // repaired; an explicit false remains an authoritative opt-out.
+  await db.executor.updateTable('host_bundle_releases').set({ snapshot_eligible: true })
+    .where('snapshot_eligible', '=', false)
+    .where('snapshot_eligibility_source', '=', 'legacy')
+    .where((eb) => eb.exists(
+      eb.selectFrom('host_bundle_channels').select('channel')
+        .whereRef('host_bundle_channels.version', '=', 'host_bundle_releases.version')
+        .where('host_bundle_channels.channel', 'in', ['dev', 'canary', 'beta', 'stable']),
+    )).execute();
+  const missing = await db.executor.selectFrom('host_bundle_releases')
+    .select('version')
+    .where('snapshot_eligible', '=', true)
+    .where((eb) => eb.not(eb.exists(
+      eb.selectFrom('golden_snapshots').select('snapshot_id')
+        .whereRef('golden_snapshots.bundle_sha256', '=', 'host_bundle_releases.sha256')
+        .where('golden_snapshots.compatibility_key', '=', key)
+        .where('golden_snapshots.test_mode', '=', false)
+        .where('golden_snapshots.state', '=', 'ready')
+        .where('golden_snapshots.ready_at', '>', freshnessCutoff),
+    )))
+    .where((eb) => eb.not(eb.exists(
+      eb.selectFrom('golden_snapshots').select('snapshot_id')
+        .whereRef('golden_snapshots.bundle_sha256', '=', 'host_bundle_releases.sha256')
+        .where('golden_snapshots.compatibility_key', '=', key)
+        .where('golden_snapshots.test_mode', '=', false)
+        .where('golden_snapshots.state', 'in', [
+          'candidate', 'building', 'sanitizing', 'validating', 'failed', 'quarantined',
+        ]),
+    )))
+    .orderBy('build_time', 'desc').limit(input.limit).execute();
+  let enqueued = 0;
+  for (const release of missing) {
+    try {
+      const result = await enqueueGoldenSnapshotBuild(db, {
+        bundleVersion: release.version,
+        compatibility: input.compatibility,
+        replaceReady: true,
+        snapshotId: randomUUID(),
+        buildId: randomUUID(),
+        now: input.now,
+      });
+      if (!result.reused) enqueued += 1;
+    } catch (err: unknown) {
+      console.error(
+        `[golden-snapshot] missing-build enqueue failed release=${release.version}: ${err instanceof Error ? err.name : typeof err}`,
+      );
+    }
+  }
+  return { enqueued };
 }

--- a/packages/platform/src/golden-snapshot-repository.ts
+++ b/packages/platform/src/golden-snapshot-repository.ts
@@ -418,15 +418,9 @@ export async function enqueueGoldenSnapshotBuild(
   db: PlatformDB,
   rawInput: z.input<typeof EnqueueInputSchema>,
 ): Promise<{ snapshot: GoldenSnapshotRecord; build: GoldenSnapshotBuildRecord; reused: boolean }> {
+  const input = EnqueueInputSchema.parse(rawInput);
   await db.ready;
-  return db.transaction((trx) => enqueueGoldenSnapshotBuildInTransaction(trx, rawInput));
-}
-
-export async function enqueueGoldenSnapshotBuildInTransaction(
-  trx: PlatformDB,
-  rawInput: z.input<typeof EnqueueInputSchema>,
-): Promise<{ snapshot: GoldenSnapshotRecord; build: GoldenSnapshotBuildRecord; reused: boolean }> {
-    const input = EnqueueInputSchema.parse(rawInput);
+  return db.transaction(async (trx) => {
     await sql`SELECT pg_advisory_xact_lock(hashtext(${input.compatibility.baseGeneration}))`.execute(trx.executor);
     const revokedGeneration = await trx.executor.selectFrom('golden_snapshot_revoked_base_generations')
       .select('base_generation').where('base_generation', '=', input.compatibility.baseGeneration)
@@ -537,6 +531,7 @@ export async function enqueueGoldenSnapshotBuildInTransaction(
       });
     }
     return { snapshot, build, reused: insertedSnapshot === undefined };
+  });
 }
 
 async function countGoldenSnapshotInfrastructure(
@@ -782,22 +777,6 @@ export async function claimGoldenSnapshotBuildBatch(
           .whereRef('golden_snapshots.snapshot_id', '=', 'golden_snapshot_builds.snapshot_id')
           .where('golden_snapshots.state', 'in', ['candidate', 'building', 'sanitizing', 'validating']),
       ))
-      .where((eb) => eb.exists(
-        eb.selectFrom('golden_snapshots')
-          .leftJoin('host_bundle_releases', 'host_bundle_releases.version', 'golden_snapshots.bundle_version')
-          .leftJoin('host_bundle_channels', (join) => join
-            .onRef('host_bundle_channels.version', '=', 'host_bundle_releases.version')
-            .on('host_bundle_channels.channel', '=', 'stable'))
-          .select('golden_snapshots.snapshot_id')
-          .whereRef('golden_snapshots.snapshot_id', '=', 'golden_snapshot_builds.snapshot_id')
-          .where((snapshotEb) => snapshotEb.or([
-            snapshotEb('golden_snapshots.test_mode', '=', true),
-            snapshotEb.and([
-              snapshotEb('host_bundle_releases.snapshot_eligible', '=', true),
-              snapshotEb('host_bundle_channels.channel', '=', 'stable'),
-            ]),
-          ])),
-      ))
       .where('status', '=', 'running')
       .where('lease_expires_at', '<=', now)
       .where((eb) => eb.or([
@@ -840,22 +819,6 @@ export async function claimGoldenSnapshotBuildBatch(
         eb.selectFrom('golden_snapshots').select('snapshot_id')
           .whereRef('golden_snapshots.snapshot_id', '=', 'golden_snapshot_builds.snapshot_id')
           .where('golden_snapshots.state', 'in', ['candidate', 'building', 'sanitizing', 'validating']),
-      ))
-      .where((eb) => eb.exists(
-        eb.selectFrom('golden_snapshots')
-          .leftJoin('host_bundle_releases', 'host_bundle_releases.version', 'golden_snapshots.bundle_version')
-          .leftJoin('host_bundle_channels', (join) => join
-            .onRef('host_bundle_channels.version', '=', 'host_bundle_releases.version')
-            .on('host_bundle_channels.channel', '=', 'stable'))
-          .select('golden_snapshots.snapshot_id')
-          .whereRef('golden_snapshots.snapshot_id', '=', 'golden_snapshot_builds.snapshot_id')
-          .where((snapshotEb) => snapshotEb.or([
-            snapshotEb('golden_snapshots.test_mode', '=', true),
-            snapshotEb.and([
-              snapshotEb('host_bundle_releases.snapshot_eligible', '=', true),
-              snapshotEb('host_bundle_channels.channel', '=', 'stable'),
-            ]),
-          ])),
       ))
       .where('status', '=', 'queued')
       .where('available_at', '<=', now)
@@ -921,22 +884,6 @@ export async function listRunnableGoldenSnapshotBuildIds(
     const rows = await trx.executor.selectFrom('golden_snapshot_builds').select('build_id')
       .where('status', '=', 'running')
       .where('lease_expires_at', '>', now)
-      .where((eb) => eb.exists(
-        eb.selectFrom('golden_snapshots')
-          .leftJoin('host_bundle_releases', 'host_bundle_releases.version', 'golden_snapshots.bundle_version')
-          .leftJoin('host_bundle_channels', (join) => join
-            .onRef('host_bundle_channels.version', '=', 'host_bundle_releases.version')
-            .on('host_bundle_channels.channel', '=', 'stable'))
-          .select('golden_snapshots.snapshot_id')
-          .whereRef('golden_snapshots.snapshot_id', '=', 'golden_snapshot_builds.snapshot_id')
-          .where((snapshotEb) => snapshotEb.or([
-            snapshotEb('golden_snapshots.test_mode', '=', true),
-            snapshotEb.and([
-              snapshotEb('host_bundle_releases.snapshot_eligible', '=', true),
-              snapshotEb('host_bundle_channels.channel', '=', 'stable'),
-            ]),
-          ])),
-      ))
       .where('phase', 'in', [
         'requested', 'builder_create', 'snapshot_create', 'snapshot_wait', 'validation_create',
       ])
@@ -1344,10 +1291,6 @@ export async function selectAndLeaseGoldenSnapshot(
         ? leasedSnapshotRow
         : undefined;
       const existingSnapshot = snapshotRow ? mapSnapshot(snapshotRow) : undefined;
-      const existingTarget = sameTarget
-        ? await trx.executor.selectFrom('host_bundle_releases').select('sha256')
-          .where('version', '=', input.targetBundleVersion).executeTakeFirst()
-        : undefined;
       const revokedGeneration = existingSnapshot
         ? await trx.executor.selectFrom('golden_snapshot_revoked_base_generations')
           .select('base_generation').where('base_generation', '=', existingSnapshot.compatibility.baseGeneration)
@@ -1360,8 +1303,6 @@ export async function selectAndLeaseGoldenSnapshot(
         && existingSnapshot.readyAt !== null
         && existingSnapshot.readyAt > freshnessCutoff
         && !existingSnapshot.testMode
-        && existingTarget !== undefined
-        && existingSnapshot.bundleSha256 === existingTarget.sha256.toLowerCase()
         && existingSnapshot.compatibilityKey === key
         && existingSnapshot.compatibility.activationAbi === input.compatibility.activationAbi
         && existingSnapshot.compatibility.minimumDiskGb <= input.serverDiskGb
@@ -1397,11 +1338,12 @@ export async function selectAndLeaseGoldenSnapshot(
         await retireQuarantinedSnapshotAfterLeaseDrain(trx, leasedSnapshotRow, input.now);
       }
     }
-    const target = await trx.executor.selectFrom('host_bundle_releases').select('sha256')
+    const target = await trx.executor.selectFrom('host_bundle_releases').select(['sha256', 'build_time'])
       .where('version', '=', input.targetBundleVersion).executeTakeFirstOrThrow();
     const targetSha256 = Sha256Schema.parse(target.sha256.toLowerCase());
     const candidates = await trx.executor.selectFrom('golden_snapshots')
-      .selectAll()
+      .innerJoin('host_bundle_releases', 'host_bundle_releases.version', 'golden_snapshots.bundle_version')
+      .selectAll('golden_snapshots').select('host_bundle_releases.build_time as source_release_build_time')
       .where('golden_snapshots.state', '=', 'ready').where('golden_snapshots.compatibility_key', '=', key)
       .where('golden_snapshots.ready_at', '>', freshnessCutoff)
       .where('golden_snapshots.test_mode', '=', false)
@@ -1410,14 +1352,20 @@ export async function selectAndLeaseGoldenSnapshot(
           .whereRef('golden_snapshot_revoked_base_generations.base_generation', '=', 'golden_snapshots.base_generation'),
       )))
       .where('golden_snapshots.minimum_disk_gb', '<=', input.serverDiskGb)
-      .where('golden_snapshots.bundle_sha256', '=', targetSha256)
+      .where((eb) => eb.or([
+        eb('golden_snapshots.bundle_sha256', '=', targetSha256),
+        sql<boolean>`${sql.ref('host_bundle_releases.build_time')}::timestamptz < ${target.build_time}::timestamptz`,
+      ]))
       .where((eb) => eb.or([
         eb('golden_snapshots.image_disk_gb', 'is', null),
         eb('golden_snapshots.image_disk_gb', '<=', input.serverDiskGb),
       ]))
+      .orderBy(sql<number>`CASE WHEN ${sql.ref('golden_snapshots.bundle_sha256')} = ${targetSha256} THEN 0 ELSE 1 END`)
+      .orderBy(sql`${sql.ref('host_bundle_releases.build_time')}::timestamptz`, 'desc')
       .orderBy('golden_snapshots.ready_at', 'desc').limit(100).execute();
     const chosen = chooseGoldenSnapshot({
       targetBundleSha256: targetSha256,
+      targetReleaseBuildTime: target.build_time,
       compatibilityKey: key,
       serverDiskGb: input.serverDiskGb,
       activationAbi: input.compatibility.activationAbi,
@@ -1426,6 +1374,7 @@ export async function selectAndLeaseGoldenSnapshot(
       bundleVersion: row.bundle_version,
       bundleSha256: row.bundle_sha256,
       compatibilityKey: row.compatibility_key,
+      sourceReleaseBuildTime: row.source_release_build_time,
       state: GoldenSnapshotStateSchema.parse(row.state),
       minimumDiskGb: row.minimum_disk_gb,
       imageDiskGb: row.image_disk_gb,

--- a/packages/platform/src/golden-snapshot-selection.ts
+++ b/packages/platform/src/golden-snapshot-selection.ts
@@ -2,6 +2,7 @@ import type { GoldenSnapshotState } from './golden-snapshot-schema.js';
 
 export interface GoldenSnapshotSelectionTarget {
   targetBundleSha256: string;
+  targetReleaseBuildTime: string;
   compatibilityKey: string;
   serverDiskGb: number;
   activationAbi: string;
@@ -12,6 +13,7 @@ export interface GoldenSnapshotSelectionCandidate {
   bundleVersion: string;
   bundleSha256: string;
   compatibilityKey: string;
+  sourceReleaseBuildTime: string;
   state: GoldenSnapshotState;
   minimumDiskGb: number;
   imageDiskGb: number | null;
@@ -40,5 +42,17 @@ export function chooseGoldenSnapshot(
   const exact = eligible
     .filter((candidate) => candidate.bundleSha256 === target.targetBundleSha256)
     .toSorted((left, right) => right.readyAt.localeCompare(left.readyAt));
-  return exact[0];
+  if (exact[0]) return exact[0];
+
+  const targetBuildTime = Date.parse(target.targetReleaseBuildTime);
+  if (!Number.isFinite(targetBuildTime)) return undefined;
+  return eligible
+    .map((candidate) => ({ candidate, buildTime: Date.parse(candidate.sourceReleaseBuildTime) }))
+    .filter(({ buildTime }) => Number.isFinite(buildTime) && buildTime < targetBuildTime)
+    .toSorted((left, right) => {
+      const releaseOrder = right.buildTime - left.buildTime;
+      return releaseOrder !== 0
+        ? releaseOrder
+        : right.candidate.readyAt.localeCompare(left.candidate.readyAt);
+    })[0]?.candidate;
 }

--- a/packages/platform/src/host-bundle-routes.ts
+++ b/packages/platform/src/host-bundle-routes.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { Hono, type Context } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { z } from 'zod/v4';
@@ -20,8 +19,6 @@ import { timingSafeTokenEquals } from './platform-token.js';
 import {
   getGoldenSnapshotCoarseStatus,
   getGoldenSnapshotCoarseStatuses,
-  promoteHostBundleChannelWithStableSnapshot,
-  registerHostBundleReleaseWithStableSnapshot,
 } from './golden-snapshot-release-repository.js';
 import {
   GoldenSnapshotBundleVersionSchema,
@@ -69,7 +66,6 @@ const HostBundleReleaseBodySchema = z.object({
 
 const HostBundleChannelBodySchema = z.object({
   version: z.string().regex(HOST_BUNDLE_IMAGE_VERSION_PATTERN),
-  snapshotEligible: z.boolean().optional(),
 });
 
 function isObjectNotFoundError(err: unknown): boolean {
@@ -252,24 +248,7 @@ export function createHostBundleRoutes(opts: {
       return c.json({ error: 'Invalid request' }, 400);
     }
     try {
-      const stableEligible = parsed.data.channel === 'stable'
-        && (parsed.data.snapshotEligible ?? true);
-      if (stableEligible && !opts.goldenSnapshotCompatibility) {
-        return c.json({ error: 'Host bundle unavailable' }, 503);
-      }
-      const registered = parsed.data.channel === 'stable'
-        ? await registerHostBundleReleaseWithStableSnapshot(db, parsed.data, parsed.data.channel, {
-          ...(opts.goldenSnapshotCompatibility ? {
-            compatibility: opts.goldenSnapshotCompatibility,
-            snapshotId: randomUUID(),
-            buildId: randomUUID(),
-          } : {}),
-          now: new Date().toISOString(),
-        })
-        : await registerHostBundleRelease(db, {
-          ...parsed.data,
-          snapshotEligible: parsed.data.snapshotEligible ?? false,
-        }, parsed.data.channel);
+      const registered = await registerHostBundleRelease(db, parsed.data, parsed.data.channel);
       const { release, channel } = registered;
       if (channel && parsed.data.channel) {
         capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.HOST_BUNDLE_CHANNEL_PROMOTED, {
@@ -325,23 +304,7 @@ export function createHostBundleRoutes(opts: {
       return c.json({ error: 'Invalid request' }, 400);
     }
     try {
-      const stableEligible = channel === 'stable' && (parsed.data.snapshotEligible ?? true);
-      if (stableEligible && !opts.goldenSnapshotCompatibility) {
-        return c.json({ error: 'Host bundle unavailable' }, 503);
-      }
-      const promotedResult = channel === 'stable'
-        ? await promoteHostBundleChannelWithStableSnapshot(db, channel, parsed.data.version, {
-          ...(opts.goldenSnapshotCompatibility ? {
-            compatibility: opts.goldenSnapshotCompatibility,
-            snapshotId: randomUUID(),
-            buildId: randomUUID(),
-          } : {}),
-          snapshotEligible: parsed.data.snapshotEligible,
-          now: new Date().toISOString(),
-        })
-        : undefined;
-      const promoted = promotedResult?.channel
-        ?? await promoteHostBundleChannel(db, channel, parsed.data.version);
+      const promoted = await promoteHostBundleChannel(db, channel, parsed.data.version);
       capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.HOST_BUNDLE_CHANNEL_PROMOTED, {
         channel,
         version: promoted.version,

--- a/packages/platform/src/platform-startup.ts
+++ b/packages/platform/src/platform-startup.ts
@@ -508,9 +508,11 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
           listUnresolvedGoldenSnapshotBuildIds,
           reconcileRevokedGoldenSnapshotBaseGeneration,
         },
+        { reconcileMissingGoldenSnapshotBuilds },
       ] = await Promise.all([
         import('./golden-snapshot-service.js'),
         import('./golden-snapshot-repository.js'),
+        import('./golden-snapshot-release-repository.js'),
       ]);
       const builderTemplate = await readFile(
         process.env.GOLDEN_SNAPSHOT_BUILDER_CLOUD_INIT_PATH
@@ -548,6 +550,16 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
               }
             }
             if (goldenSnapshotConfig.buildsEnabled) {
+              try {
+                await reconcileMissingGoldenSnapshotBuilds(db, {
+                  compatibility: goldenSnapshotConfig.compatibility,
+                  now: workerNow,
+                  limit: goldenSnapshotConfig.reconciliationBatchSize,
+                  freshnessMaxAgeMs: goldenSnapshotConfig.freshnessMaxAgeMs,
+                });
+              } catch (err: unknown) {
+                logPlatformRouteError('golden snapshot release reconciliation', err);
+              }
               await claimGoldenSnapshotBuildBatch(
                 db,
                 workerNow,

--- a/scripts/release-snapshot-eligibility.mjs
+++ b/scripts/release-snapshot-eligibility.mjs
@@ -1,3 +1,5 @@
+const CUSTOMER_RELEASE_CHANNELS = new Set(['dev', 'canary', 'beta', 'stable']);
+
 export function resolveReleaseSnapshotEligibility(channel, explicitValue) {
   if (explicitValue !== undefined) {
     if (explicitValue !== 'true' && explicitValue !== 'false') {
@@ -5,5 +7,5 @@ export function resolveReleaseSnapshotEligibility(channel, explicitValue) {
     }
     return explicitValue === 'true';
   }
-  return channel === 'stable';
+  return CUSTOMER_RELEASE_CHANNELS.has(channel);
 }

--- a/specs/109-golden-vps-snapshots/plan.md
+++ b/specs/109-golden-vps-snapshots/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Build one sanitized, validated Hetzner snapshot for each forward-looking eligible stable host bundle and supported compatibility class. Platform Postgres is authoritative for immutable bundle provenance, lifecycle, build leases, validation evidence, selection leases, cleanup, and revocation. Stable pointer promotion, eligibility, and enqueue are one transaction; startup performs no historical backfill. New and recovery VPSes use only an exact ready snapshot and otherwise fall back to the unchanged Ubuntu/full cloud-init path. Snapshot automation is asynchronous and cannot block existing-fleet deployment.
+Build one sanitized, validated Hetzner snapshot for every eligible immutable customer host bundle and supported compatibility class. Platform Postgres is authoritative for immutable bundle provenance, lifecycle, build leases, validation evidence, selection leases, cleanup, and revocation. New and recovery VPSes are created just in time from an exact ready snapshot, or the newest compatible older snapshot followed by the existing exact-bundle activation path. A newer snapshot is never selected for an older target. Any unsafe or unknown condition falls back to the unchanged Ubuntu/full cloud-init path. Snapshot automation is asynchronous and cannot block host-bundle publication or existing-fleet deployment.
 
 V1 does not keep running or powered-off warm customer VPSes. Builders and validation clones are ephemeral provider resources with synthetic, single-use identities. Customer credentials and owner state are injected only through the newly created customer VPS's cloud-init activation.
 
@@ -341,8 +341,8 @@ Rollback disables selection immediately and preserves clean-image provisioning. 
 - Provider contract tests: request timeouts, bounded validation, Action polling, response loss, exact label reconciliation, architecture/disk/location rejection, protected/missing deletion.
 - Builder tests: exact digest install, all sanitation categories, quiescence, callback token erasure, forbidden-path/secret scan fail-closed.
 - Validation tests: fresh cloud-init, unique machine/SSH identity, exact bundle, no builder/customer state, health success required before ready.
-- Provisioning tests: exact selection, non-exact clean fallback, lease protection, lost response adoption, duplicate cleanup, recovery parity, existing-fleet independence.
-- Workflow tests: eligible stable-promotion enqueue, explicit stable opt-out, non-stable exclusion, channel-promotion dedupe, no historical scan, and deploy independence.
+- Provisioning tests: exact selection, older-safe update, newer rejection, lease protection, lost response adoption, duplicate cleanup, clean fallback, recovery parity, existing-fleet independence.
+- Workflow tests: eligible main/tag/manual-dispatch enqueue, preview exclusion, channel-promotion dedupe, enqueue failure does not block publish/deploy.
 - Baseline-aware gates: `bun run check:patterns`, focused Vitest suites, `bun run typecheck`, and `bun run test`; record the known unrelated baseline failures without mixing fixes into the stack.
 
 ## Post-Design Constitution Re-check

--- a/specs/109-golden-vps-snapshots/quickstart.md
+++ b/specs/109-golden-vps-snapshots/quickstart.md
@@ -70,8 +70,8 @@ migration work.
 Required scenarios:
 
 1. exact ready snapshot selected and leased;
-2. compatible but non-exact snapshots fall back to clean Ubuntu;
-3. a snapshot for a different target is never selected;
+2. newest compatible older snapshot updates to exact target before registration;
+3. newer snapshot rejected for older target;
 4. missing/rejected/quarantined/incompatible image uses clean Ubuntu fallback;
 5. lost create response adopts one exact-labeled server; if adoption is impossible,
    the possible server's credentials are revoked and it is proven powered off or

--- a/specs/109-golden-vps-snapshots/spec.md
+++ b/specs/109-golden-vps-snapshots/spec.md
@@ -430,22 +430,25 @@ straightforward billing, and one-owner-per-VPS isolation.
   FR-018 for an eligible release, provided those resources cannot serve customers and
   follow their mandatory cleanup lifecycle.
 - **FR-021**: Before creating the VPS, the system MUST resolve the exact target host
-  bundle and choose only a ready, non-quarantined, compatible snapshot whose immutable
-  bundle SHA-256 exactly matches the target. When no exact image exists, the system MUST
-  use the clean Ubuntu path.
+  bundle and choose only a ready, non-quarantined, compatible snapshot that is not newer
+  than the target. Older/newer ordering MUST compare the chronological instants in the
+  immutable host-bundle release `build_time` provenance, normalized before comparison;
+  version labels, release registration time, and snapshot creation time MUST NOT define
+  ordering.
 - **FR-022**: Snapshot compatibility MUST account for architecture, base-system and boot
   compatibility, minimum disk requirement, and any release-declared activation
   constraint.
-- **FR-023**: The platform MUST NOT select an older or merely compatible snapshot for a
-  different target bundle.
+- **FR-023**: The platform SHOULD prefer an exact-version compatible snapshot; otherwise
+  it MAY select the newest compatible older snapshot that can safely activate to the
+  exact target version.
 - **FR-024**: A new VPS MUST receive customer identity and secrets only during its own
   activation, never from the shared snapshot.
 - **FR-025**: Customer-specific configuration MUST become visible atomically to services,
   and partial activation MUST NOT start customer-facing services.
 - **FR-026**: The machine MUST NOT be marked running or become routable until it reports
   the exact target bundle version and passes the established runtime health checks.
-- **FR-027**: A target without an exact snapshot MUST use clean-image provisioning rather
-  than updating a different snapshot during first boot.
+- **FR-027**: A snapshot clone that contains an older version MUST complete a verified
+  update before health registration; failure MUST leave the machine unavailable.
 - **FR-028**: A snapshot newer than the requested release MUST NOT be selected or
   downgraded in place.
 - **FR-029**: Recovery MUST preserve existing backup-availability, ownership, restore,

--- a/specs/109-golden-vps-snapshots/tasks.md
+++ b/specs/109-golden-vps-snapshots/tasks.md
@@ -91,16 +91,16 @@
 
 ## Phase 4: User Story 1 - Fast Fresh Computer Provisioning (Priority: P1) MVP
 
-**Goal**: Use only an exact ready snapshot for a newly authorized customer VPS, fall back clean for non-exact targets, inject owner secrets only after clone creation, and route only after exact-version health registration.
+**Goal**: Use an exact or compatible older ready snapshot for a newly authorized customer VPS, inject owner secrets only after clone creation, and route only after exact-version health registration.
 
 **Independent Test**: Seed an exact ready synthetic snapshot, provision two customers concurrently, and verify separate servers, unique identities/credentials/stores/host keys, exact bundle registration, snapshot lease release, and improved readiness instrumentation.
 
 ### Tests for User Story 1
 
 - [ ] T040 [P] [US1] Write failing exact snapshot selection/lease and image-override tests in `tests/platform/golden-snapshot-provisioning.test.ts`
-- [ ] T041 [P] [US1] Write failing non-exact clean-fallback and exact-target registration tests in `tests/platform/golden-snapshot-provisioning.test.ts`
+- [ ] T041 [P] [US1] Write failing compatible-older activation and exact-target registration tests in `tests/platform/golden-snapshot-provisioning.test.ts`
 - [ ] T042 [P] [US1] Write failing concurrent owner isolation, idempotent runtime-slot, secret-injection-boundary, deterministic compatibility-scoped durable-rollout cohort, one-intent-per-lease worker takeover, authorization/billing-revocation, rollout-disable/create-intent, and snapshot/base-generation-revocation races that pause a durable job before every provider create, after an accepted or ambiguous create, and before routing in `tests/platform/golden-snapshot-provisioning.test.ts`
-- [ ] T043 [P] [US1] Write failing cloud-init exact-snapshot fast path and non-exact clean-fallback tests in `tests/platform/golden-snapshot-host-scripts.test.ts`
+- [ ] T043 [P] [US1] Write failing cloud-init exact-snapshot fast path and older-snapshot update tests in `tests/platform/golden-snapshot-host-scripts.test.ts`
 
 ### Implementation for User Story 1
 
@@ -194,20 +194,20 @@
 
 ## Phase 8: User Story 6 - Existing Computers Continue Normal Updates (Priority: P3)
 
-**Goal**: Enqueue only forward-looking eligible stable promotions without scanning release history or blocking the unchanged existing-fleet deployment path.
+**Goal**: Automatically enqueue every eligible main/tag/trusted manual-dispatch bundle without blocking publication or the unchanged existing-fleet deployment path.
 
-**Independent Test**: Simulate stable, non-stable, explicit opt-out, repeated-promotion, and superseding releases; the current eligible stable identity enqueues once, historical and non-stable releases do not, and `/vps/deploy` still runs for existing machines.
+**Independent Test**: Simulate eligible, preview, repeated-promotion, enqueue-failed, and build-failed releases; eligible identities enqueue once, previews do not, and `/vps/deploy` still runs for existing machines.
 
 ### Tests for User Story 6
 
 - [ ] T079 [P] [US6] Write failing enqueue script tests for immutable metadata, eligibility, bounded timeout, generic output, and non-zero internal failure in `tests/platform/host-bundle-snapshot-workflow.test.ts`
-- [ ] T080 [P] [US6] Write failing workflow and transaction tests proving stable promotion is the only automatic enqueue trigger, explicit opt-out is preserved, older unfinished work is superseded, startup performs no historical scan, and production plus preview platform Cloud Run deployments bind `GOLDEN_SNAPSHOT_OPERATOR_SECRET` from Secret Manager in `tests/platform/host-bundle-snapshot-workflow.test.ts` and `tests/platform/ci-workflows.test.ts`
+- [ ] T080 [P] [US6] Write failing workflow and durable-reconciliation tests proving snapshot enqueue depends on publish but deploy does not depend on snapshot success, stale/deleted identities receive exactly one replacement generation, repeated scans reuse it, and production plus preview platform Cloud Run deployments bind `GOLDEN_SNAPSHOT_OPERATOR_SECRET` from Secret Manager in `tests/platform/host-bundle-snapshot-workflow.test.ts` and `tests/platform/ci-workflows.test.ts`
 - [ ] T081 [P] [US6] Write failing route tests proving channel promotion reuses bundle identity and preview artifacts are excluded in `tests/platform/golden-snapshot-routes.test.ts`
 
 ### Implementation for User Story 6
 
 - [ ] T082 [US6] Implement bounded authenticated idempotent enqueue CLI with `AbortSignal.timeout()` in `scripts/enqueue-golden-snapshot.mjs`
-- [ ] T083 [US6] Atomically enqueue the exact eligible stable release during channel promotion, supersede unfinished older builds with durable exact-resource cleanup, remove workflow enqueue and startup history scans, and keep existing-fleet deploy independent; bind `GOLDEN_SNAPSHOT_OPERATOR_SECRET` into production and preview Cloud Run revisions and validate secret access/startup without exposing its value
+- [ ] T083 [US6] Add non-blocking post-publish snapshot enqueue plus a bounded reconciler for eligible main/tag/trusted manual-dispatch bundles without a fresh ready or active candidate; enqueue immutable replacements for stale/deleted identities while keeping existing-fleet deploy independent in `.github/workflows/host-bundle-release.yml` and platform startup; bind `GOLDEN_SNAPSHOT_OPERATOR_SECRET` into production and preview Cloud Run revisions and validate secret access/startup without exposing its value
 - [ ] T084 [US6] Preserve release/channel registration semantics and expose coarse snapshot status alongside release metadata in `packages/platform/src/host-bundle-routes.ts`
 - [ ] T085 [US6] Add package script wiring for the enqueue helper in `package.json`
 - [ ] T086 [US6] Run workflow/route tests and verify a snapshot enqueue/build failure cannot prevent exact-version `/vps/deploy`
@@ -290,7 +290,7 @@ Task T026: validation clone tests
 
 ```text
 Task T040: exact selection and lease tests
-Task T041: non-exact clean-fallback tests
+Task T041: compatible older update tests
 Task T042: concurrent owner isolation tests
 Task T043: host activation script tests
 ```

--- a/tests/platform/golden-snapshot-provisioning.test.ts
+++ b/tests/platform/golden-snapshot-provisioning.test.ts
@@ -143,16 +143,14 @@ describe('golden snapshot provisioning activation', () => {
       .resolves.toMatchObject({ snapshotCreateIntentId: intentId });
   });
 
-  it('falls back to a clean image when no exact snapshot exists', async () => {
+  it('uses only a compatible older snapshot and records that exact update is required', async () => {
     await readySnapshot('v1', 301);
     const selected = await chooseProvisioningImage(db, config, {
       jobId: '50000000-0000-4000-8000-000000000001', machineId: '30000000-0000-4000-8000-000000000001',
       targetBundleVersion: 'v2', serverType: 'cpx22', purpose: 'provision',
       leaseId: '40000000-0000-4000-8000-000000000001', now: '2026-07-03T00:01:00.000Z',
     });
-    expect(selected).toEqual({
-      imageSource: 'clean_image', targetBundleVersion: 'v2', targetBundleSha256: '2'.repeat(64),
-    });
+    expect(selected).toMatchObject({ imageSource: 'snapshot', providerImageId: 301, exact: false, requiresExactUpdate: true });
   });
 
   it('never selects a snapshot outside the configured freshness window', async () => {
@@ -666,7 +664,7 @@ describe('golden snapshot provisioning activation', () => {
   });
 
   it('enforces exact bundle provenance when a snapshot recovery registers', async () => {
-    await readySnapshot('v2', 302);
+    await readySnapshot('v1', 301);
     const machineId = '30000000-0000-4000-8000-000000000009';
     const decision = await chooseRecoveryImage(db, config, {
       machineId, targetBundleVersion: 'v2', serverType: 'cpx22', purpose: 'recover',

--- a/tests/platform/golden-snapshot-repository.test.ts
+++ b/tests/platform/golden-snapshot-repository.test.ts
@@ -67,7 +67,6 @@ describe('golden snapshot repository', () => {
     await upsertHostBundleRelease(db, {
       version: 'v1',
       gitCommit: '1111111',
-      snapshotEligible: true,
       buildTime: '2026-07-01T00:00:00.000Z',
       bundleKey: 'system-bundles/v1/matrix-host-bundle.tar.gz',
       checksumKey: 'system-bundles/v1/matrix-host-bundle.tar.gz.sha256',
@@ -75,7 +74,6 @@ describe('golden snapshot repository', () => {
       size: 100,
       createdAt: '2026-07-01T00:00:00.000Z',
     });
-    await promoteHostBundleChannel(db, 'stable', 'v1', '2026-07-01T00:01:00.000Z');
     await upsertHostBundleRelease(db, {
       version: 'v2',
       gitCommit: '2222222',
@@ -322,27 +320,6 @@ describe('golden snapshot repository', () => {
     await expect(claimGoldenSnapshotBuildBatch(
       db, '2026-07-03T00:00:03.000Z', '2026-07-03T00:10:03.000Z', 5, 10, 1,
     )).resolves.toEqual([]);
-  });
-
-  it('claims capacity only for the current eligible stable release', async () => {
-    const queued = await enqueueGoldenSnapshotBuild(db, {
-      bundleVersion: 'v2', compatibility,
-      snapshotId: '10000000-0000-4000-8000-000000000034',
-      buildId: '20000000-0000-4000-8000-000000000034', now: '2026-07-03T00:00:00.000Z',
-    });
-
-    await expect(claimGoldenSnapshotBuildBatch(
-      db, '2026-07-03T00:00:01.000Z', '2026-07-03T00:10:01.000Z', 5, 10, 1,
-    )).resolves.toEqual([]);
-
-    await db.executor.updateTable('host_bundle_releases').set({ snapshot_eligible: true })
-      .where('version', '=', 'v2').execute();
-    await promoteHostBundleChannel(db, 'stable', 'v2', '2026-07-03T00:00:02.000Z');
-    await expect(claimGoldenSnapshotBuildBatch(
-      db, '2026-07-03T00:00:03.000Z', '2026-07-03T00:10:03.000Z', 5, 10, 1,
-    )).resolves.toEqual([
-      expect.objectContaining({ buildId: queued.build.buildId, status: 'running' }),
-    ]);
   });
 
   it('counts callback-wait infrastructure against the durable concurrency cap', async () => {
@@ -829,7 +806,7 @@ describe('golden snapshot repository', () => {
       buildId: '20000000-0000-4000-8000-000000000054', now: '2026-07-03T00:00:00.000Z',
     });
     const second = await enqueueGoldenSnapshotBuild(db, {
-      bundleVersion: 'v2', compatibility, testMode: true,
+      bundleVersion: 'v2', compatibility,
       snapshotId: '10000000-0000-4000-8000-000000000055',
       buildId: '20000000-0000-4000-8000-000000000055', now: '2026-07-03T00:00:00.000Z',
     });
@@ -1071,20 +1048,23 @@ describe('golden snapshot repository', () => {
       leaseId: '40000000-0000-4000-8000-000000000008',
       now: '2026-07-03T00:27:00.000Z', expiresAt: '2026-07-03T00:37:00.000Z',
     });
-    expect(retargeted).toBeUndefined();
+    expect(retargeted).toMatchObject({
+      snapshot: { snapshotId: enqueued.snapshot.snapshotId },
+      lease: { leaseId: '40000000-0000-4000-8000-000000000008', targetBundleVersion: 'v2' },
+    });
     await expect(db.executor.selectFrom('golden_snapshot_leases').select('released_at')
       .where('lease_id', '=', selected!.lease.leaseId).executeTakeFirstOrThrow())
       .resolves.toEqual({ released_at: '2026-07-03T00:27:00.000Z' });
   });
 
-  it('pre-filters reusable candidates by exact immutable provenance only', async () => {
+  it('pre-filters bounded reusable candidates by exact or chronologically older provenance', async () => {
     const source = await readFile('packages/platform/src/golden-snapshot-repository.ts', 'utf8');
     const start = source.indexOf('export async function selectAndLeaseGoldenSnapshot');
     const end = source.indexOf('export async function releaseGoldenSnapshotLease', start);
     const selection = source.slice(start, end);
-    expect(selection).toContain(".where('golden_snapshots.bundle_sha256', '=', targetSha256)");
-    expect(selection).not.toContain("sql.ref('host_bundle_releases.build_time')}::timestamptz <");
-    expect(selection).not.toContain("CASE WHEN ${sql.ref('golden_snapshots.bundle_sha256')}");
+    expect(selection).toContain("eb('golden_snapshots.bundle_sha256', '=', targetSha256)");
+    expect(selection).toContain("sql.ref('host_bundle_releases.build_time')}::timestamptz <");
+    expect(selection).toContain("CASE WHEN ${sql.ref('golden_snapshots.bundle_sha256')}");
   });
 
   it('preserves the first exact provider image and quarantines a conflicting observation', async () => {

--- a/tests/platform/golden-snapshot-selection.test.ts
+++ b/tests/platform/golden-snapshot-selection.test.ts
@@ -9,7 +9,7 @@ const compatibilityKey = 'a'.repeat(64);
 function candidate(
   id: string,
   bundleSha256: string,
-  readyAt: string,
+  sourceReleaseBuildTime: string,
   overrides: Partial<GoldenSnapshotSelectionCandidate> = {},
 ): GoldenSnapshotSelectionCandidate {
   return {
@@ -17,11 +17,12 @@ function candidate(
     bundleVersion: id,
     bundleSha256,
     compatibilityKey,
+    sourceReleaseBuildTime,
     state: 'ready',
     minimumDiskGb: 40,
     imageDiskGb: 40,
     activationAbi: 'host-v1',
-    readyAt,
+    readyAt: sourceReleaseBuildTime,
     ...overrides,
   };
 }
@@ -30,6 +31,7 @@ describe('golden snapshot selection', () => {
   it('prefers exact immutable provenance over a compatible older image', () => {
     const selected = chooseGoldenSnapshot({
       targetBundleSha256: '2'.repeat(64),
+      targetReleaseBuildTime: '2026-07-02T00:00:00.000Z',
       compatibilityKey,
       serverDiskGb: 80,
       activationAbi: 'host-v1',
@@ -40,9 +42,10 @@ describe('golden snapshot selection', () => {
     expect(selected?.snapshotId).toBe('exact');
   });
 
-  it('rejects compatible snapshots without exact immutable provenance', () => {
+  it('chooses the newest compatible older release and never a newer one', () => {
     const selected = chooseGoldenSnapshot({
       targetBundleSha256: '4'.repeat(64),
+      targetReleaseBuildTime: '2026-07-03T00:00:00.000Z',
       compatibilityKey,
       serverDiskGb: 80,
       activationAbi: 'host-v1',
@@ -51,12 +54,13 @@ describe('golden snapshot selection', () => {
       candidate('older', '2'.repeat(64), '2026-07-02T00:00:00.000Z'),
       candidate('newer', '5'.repeat(64), '2026-07-04T00:00:00.000Z'),
     ]);
-    expect(selected).toBeUndefined();
+    expect(selected?.snapshotId).toBe('older');
   });
 
   it('rejects non-ready, incompatible, revoked, and too-large images', () => {
     const selected = chooseGoldenSnapshot({
       targetBundleSha256: '9'.repeat(64),
+      targetReleaseBuildTime: '2026-07-10T00:00:00.000Z',
       compatibilityKey,
       serverDiskGb: 40,
       activationAbi: 'host-v1',
@@ -73,6 +77,7 @@ describe('golden snapshot selection', () => {
   it('orders compatible snapshots by immutable build provenance, not registration time', () => {
     const selected = chooseGoldenSnapshot({
       targetBundleSha256: '1'.repeat(64),
+      targetReleaseBuildTime: '2026-07-01T00:00:00.000Z',
       compatibilityKey,
       serverDiskGb: 80,
       activationAbi: 'host-v1',
@@ -80,9 +85,10 @@ describe('golden snapshot selection', () => {
     expect(selected).toBeUndefined();
   });
 
-  it('does not use release timestamps as a fallback selector', () => {
+  it('compares release build times as instants across timezone offsets', () => {
     const selected = chooseGoldenSnapshot({
       targetBundleSha256: '9'.repeat(64),
+      targetReleaseBuildTime: '2026-07-03T00:00:00.000Z',
       compatibilityKey,
       serverDiskGb: 80,
       activationAbi: 'host-v1',
@@ -91,6 +97,6 @@ describe('golden snapshot selection', () => {
       candidate('actually-older', '2'.repeat(64), '2026-07-03T01:00:00.000+02:00'),
     ]);
 
-    expect(selected).toBeUndefined();
+    expect(selected?.snapshotId).toBe('actually-older');
   });
 });

--- a/tests/platform/golden-snapshot-worker-wiring.test.ts
+++ b/tests/platform/golden-snapshot-worker-wiring.test.ts
@@ -67,12 +67,6 @@ describe('golden snapshot worker wiring', () => {
     expect(worker).not.toContain('listClaimableGoldenSnapshotBuildIds(');
   });
 
-  it('does not scan release history or backfill golden snapshot builds', async () => {
-    const source = await readFile('packages/platform/src/platform-startup.ts', 'utf8');
-    expect(source).not.toContain('reconcileMissingGoldenSnapshotBuilds');
-    expect(source).not.toContain('golden snapshot release reconciliation');
-  });
-
   it('reconciles durable base-generation revocations in bounded pages even when builds are disabled', async () => {
     const source = await readFile('packages/platform/src/platform-startup.ts', 'utf8');
     const worker = source.slice(
@@ -83,6 +77,8 @@ describe('golden snapshot worker wiring', () => {
     expect(worker).toContain('reconcileRevokedGoldenSnapshotBaseGeneration');
     expect(worker.indexOf('listRevokedGoldenSnapshotBaseGenerations'))
       .toBeLessThan(worker.indexOf('if (goldenSnapshotConfig.buildsEnabled)'));
+    expect(worker.indexOf('listRevokedGoldenSnapshotBaseGenerations'))
+      .toBeLessThan(worker.indexOf('reconcileMissingGoldenSnapshotBuilds'));
     expect(worker.indexOf('listRevokedGoldenSnapshotBaseGenerations'))
       .toBeLessThan(worker.indexOf('claimGoldenSnapshotBuildBatch'));
     expect(worker.indexOf('listRevokedGoldenSnapshotBaseGenerations'))

--- a/tests/platform/host-bundle-route.test.ts
+++ b/tests/platform/host-bundle-route.test.ts
@@ -11,27 +11,7 @@ import {
 } from '../../packages/platform/src/db.js';
 import type { Orchestrator } from '../../packages/platform/src/orchestrator.js';
 import { enqueueGoldenSnapshotBuild } from '../../packages/platform/src/golden-snapshot-repository.js';
-import type { GoldenSnapshotRuntimeConfig } from '../../packages/platform/src/golden-snapshot-schema.js';
 import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
-
-const goldenSnapshotConfig: GoldenSnapshotRuntimeConfig = {
-  enabled: false,
-  buildsEnabled: false,
-  rolloutPercent: 0,
-  compatibility: {
-    provider: 'hetzner', architecture: 'x86', region: 'eu-central', baseImage: 'ubuntu-24.04',
-    baseGeneration: 'ubuntu-24.04-v1', bootMode: 'bios', activationAbi: 'host-v1', minimumDiskGb: 40,
-  },
-  maxBuildAttempts: 5,
-  maxConcurrentBuilds: 2,
-  buildLeaseMs: 300_000,
-  provisioningLeaseMs: 600_000,
-  retentionLimit: 20,
-  freshnessMaxAgeMs: 7 * 24 * 60 * 60 * 1000,
-  reconciliationBatchSize: 25,
-  testModeTtlMs: 24 * 60 * 60 * 1000,
-  auditRetentionMs: 90 * 24 * 60 * 60 * 1000,
-};
 
 describe('platform host bundle route', () => {
   let db: PlatformDB;
@@ -509,7 +489,6 @@ describe('platform host bundle route', () => {
       db,
       orchestrator,
       platformSecret: 'secret',
-      goldenSnapshotConfig,
       customerVpsObjectStore: {
         getObject: vi.fn(),
         putObject: vi.fn(),
@@ -583,8 +562,6 @@ describe('platform host bundle route', () => {
       body: JSON.stringify({ version: 'v2026.05.12-2' }),
     });
     expect(promoteRes.status).toBe(200);
-    await expect(db.executor.selectFrom('golden_snapshot_builds').select('status').execute())
-      .resolves.toEqual([{ status: 'queued' }]);
 
     const promotedStableRes = await app.request('/system-bundles/releases?channel=stable');
     await expect(promotedStableRes.json()).resolves.toMatchObject({
@@ -617,33 +594,11 @@ describe('platform host bundle route', () => {
       }),
     });
     expect(reRegisterRes.status).toBe(200);
-    await expect(db.executor.selectFrom('golden_snapshot_builds').select('status').execute())
-      .resolves.toEqual([{ status: 'queued' }]);
 
     const canaryAfterReRegisterRes = await app.request('/system-bundles/releases?channel=canary');
     await expect(canaryAfterReRegisterRes.json()).resolves.toMatchObject({
       releases: [{ version: 'v2026.05.12-2', channel: 'canary' }],
     });
-  });
-
-  it('allows stable snapshot opt-out without golden build configuration', async () => {
-    await seedRelease('v2026.05.12-opt-out');
-    const app = createApp({
-      db, orchestrator, platformSecret: 'secret',
-      customerVpsObjectStore: { getObject: vi.fn(), putObject: vi.fn() } as unknown as CustomerVpsObjectStore,
-    });
-
-    const response = await app.request('/system-bundles/channels/stable', {
-      method: 'POST',
-      headers: { authorization: 'Bearer secret', 'content-type': 'application/json' },
-      body: JSON.stringify({ version: 'v2026.05.12-opt-out', snapshotEligible: false }),
-    });
-
-    expect(response.status).toBe(200);
-    await expect(getHostBundleRelease(db, 'v2026.05.12-opt-out'))
-      .resolves.toMatchObject({ snapshotEligible: false });
-    await expect(db.executor.selectFrom('golden_snapshot_builds').select('build_id').execute())
-      .resolves.toEqual([]);
   });
 
   it('rejects snapshot eligibility for a version outside the snapshot identity schema', async () => {

--- a/tests/platform/host-bundle-snapshot-workflow.test.ts
+++ b/tests/platform/host-bundle-snapshot-workflow.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  getHostBundleChannel,
+  getHostBundleRelease,
   promoteHostBundleChannel,
   upsertHostBundleRelease,
   type PlatformDB,
@@ -12,8 +12,7 @@ import {
 } from '../../packages/platform/src/golden-snapshot-repository.js';
 import {
   getGoldenSnapshotCoarseStatuses,
-  promoteHostBundleChannelWithStableSnapshot,
-  registerHostBundleReleaseWithStableSnapshot,
+  reconcileMissingGoldenSnapshotBuilds,
 } from '../../packages/platform/src/golden-snapshot-release-repository.js';
 import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
 import {
@@ -145,12 +144,25 @@ describe('host bundle golden snapshot release hook', () => {
     expect(String(failure)).not.toContain('provider details');
   });
 
-  it('uses platform stable promotion as the only snapshot enqueue trigger', () => {
+  it('keeps snapshot enqueue failure isolated from existing fleet deployment', () => {
     const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
+    const enqueueJob = workflow.slice(
+      workflow.indexOf('\n  enqueue-golden-snapshot:'),
+      workflow.indexOf('\n  deploy:'),
+    );
     const deployJob = workflow.slice(workflow.indexOf('\n  deploy:'));
 
-    expect(workflow).not.toContain('\n  enqueue-golden-snapshot:');
-    expect(workflow).not.toContain('scripts/enqueue-golden-snapshot.mjs');
+    expect(enqueueJob).toContain('needs: [dev-bundle-gate, build, publish]');
+    expect(enqueueJob).toContain('continue-on-error: true');
+    expect(enqueueJob).toContain("vars.GOLDEN_SNAPSHOT_BUILDS_ENABLED == 'true'");
+    expect(enqueueJob).toContain("github.event_name == 'push'");
+    expect(enqueueJob).toContain("(github.event_name == 'workflow_dispatch' && inputs.channel != '')");
+    expect(enqueueJob).toContain("github.ref_name == 'main'");
+    expect(enqueueJob).toContain("github.ref_type == 'tag'");
+    expect(enqueueJob).toContain('PUBLISH_CHANNEL: ${{ needs.build.outputs.channel }}');
+    expect(enqueueJob).toContain('PUBLISH_VERSION: ${{ needs.build.outputs.version }}');
+    expect(enqueueJob).toContain('scripts/enqueue-golden-snapshot.mjs --version "$PUBLISH_VERSION"');
+    expect(enqueueJob).not.toContain('--version "${{ needs.build.outputs.version }}"');
     expect(deployJob).toContain('needs: [dev-bundle-gate, build, publish]');
     expect(deployJob).not.toContain('enqueue-golden-snapshot');
   });
@@ -177,10 +189,12 @@ describe('host bundle golden snapshot release hook', () => {
     expect(productionDeploy).toContain('GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0');
   });
 
-  it('lets durable release registration derive eligibility from the promoted channel', () => {
+  it('uses the same manual-channel eligibility rule for durable release registration', () => {
     const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
 
-    expect(workflow).not.toContain('GOLDEN_SNAPSHOT_ELIGIBLE:');
+    expect(workflow).toContain(
+      "GOLDEN_SNAPSHOT_ELIGIBLE: ${{ (github.event_name == 'push' && ((github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag')) || (github.event_name == 'workflow_dispatch' && inputs.channel != '') }}",
+    );
   });
 
   it('resolves enqueue validation from the platform package and preserves eligibility in both publishers', () => {
@@ -193,10 +207,9 @@ describe('host bundle golden snapshot release hook', () => {
     expect(nodePublisher).toContain('resolveReleaseSnapshotEligibility');
   });
 
-  it('defaults only stable eligible while preserving explicit overrides', () => {
-    expect(resolveReleaseSnapshotEligibility('stable')).toBe(true);
-    for (const channel of ['dev', 'canary', 'beta']) {
-      expect(resolveReleaseSnapshotEligibility(channel)).toBe(false);
+  it('defaults customer channels eligible while keeping preview and explicit opt-out ineligible', () => {
+    for (const channel of ['dev', 'canary', 'beta', 'stable']) {
+      expect(resolveReleaseSnapshotEligibility(channel)).toBe(true);
     }
     expect(resolveReleaseSnapshotEligibility('none')).toBe(false);
     expect(resolveReleaseSnapshotEligibility('preview')).toBe(false);
@@ -206,273 +219,142 @@ describe('host bundle golden snapshot release hook', () => {
   });
 });
 
-describe('forward-only stable golden snapshot promotion', () => {
+describe('durable golden snapshot release reconciliation', () => {
   let db: PlatformDB;
   beforeEach(async () => ({ db } = await createTestPlatformDb()));
   afterEach(async () => destroyTestPlatformDb(db));
 
-  it('atomically registers an eligible stable release and queues its exact snapshot build', async () => {
-    const compatibility = {
-      provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
-      baseImage: 'ubuntu-24.04', baseGeneration: 'ubuntu-24.04-v1',
-      bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
-    };
-
-    await expect(registerHostBundleReleaseWithStableSnapshot(db, {
-      version: 'v-stable', gitCommit: '1111111', gitRef: 'main',
-      buildTime: '2026-07-01T00:00:00.000Z',
-      bundleKey: 'system-bundles/v-stable/matrix-host-bundle.tar.gz', checksumKey: null,
-      sha256: '1'.repeat(64), size: 100, createdAt: '2026-07-01T00:00:00.000Z',
-    }, 'stable', {
-      compatibility,
-      snapshotId: '10000000-0000-4000-8000-000000000001',
-      buildId: '20000000-0000-4000-8000-000000000001',
-      now: '2026-07-01T00:01:00.000Z',
-    })).resolves.toMatchObject({
-      release: { version: 'v-stable', snapshotEligible: true },
-      channel: { channel: 'stable', version: 'v-stable' },
-    });
-
-    expect(Object.fromEntries(await getGoldenSnapshotCoarseStatuses(db, ['v-stable'])))
-      .toEqual({ 'v-stable': 'requested' });
-  });
-
-  it('queues an existing release only when it is promoted to stable', async () => {
-    const compatibility = {
-      provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
-      baseImage: 'ubuntu-24.04', baseGeneration: 'ubuntu-24.04-v1',
-      bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
-    };
+  it('enqueues eligible durable releases missing a candidate and batches coarse status reads', async () => {
     await upsertHostBundleRelease(db, {
-      version: 'v-promoted', gitCommit: '2222222', gitRef: 'main', snapshotEligible: false,
-      buildTime: '2026-07-02T00:00:00.000Z',
-      bundleKey: 'system-bundles/v-promoted/matrix-host-bundle.tar.gz', checksumKey: null,
+      version: 'v1', gitCommit: '1111111', gitRef: 'main', snapshotEligible: true, buildTime: '2026-07-01T00:00:00.000Z',
+      bundleKey: 'system-bundles/v1/matrix-host-bundle.tar.gz', checksumKey: null,
+      sha256: '1'.repeat(64), size: 100, createdAt: '2026-07-01T00:00:00.000Z',
+    });
+    await upsertHostBundleRelease(db, {
+      version: 'preview-1', gitCommit: '2222222', gitRef: 'preview-1', buildTime: '2026-07-02T00:00:00.000Z',
+      bundleKey: 'system-bundles/preview-1/matrix-host-bundle.tar.gz', checksumKey: null,
       sha256: '2'.repeat(64), size: 100, createdAt: '2026-07-02T00:00:00.000Z',
     });
-    await promoteHostBundleChannel(db, 'dev', 'v-promoted', '2026-07-02T00:01:00.000Z');
-
-    await expect(promoteHostBundleChannelWithStableSnapshot(db, 'stable', 'v-promoted', {
-      compatibility,
-      snapshotId: '10000000-0000-4000-8000-000000000002',
-      buildId: '20000000-0000-4000-8000-000000000002',
-      now: '2026-07-02T00:02:00.000Z',
-    })).resolves.toMatchObject({
-      release: { version: 'v-promoted', snapshotEligible: true },
-      channel: { channel: 'stable', version: 'v-promoted' },
-    });
-    expect(Object.fromEntries(await getGoldenSnapshotCoarseStatuses(db, ['v-promoted'])))
-      .toEqual({ 'v-promoted': 'requested' });
-  });
-
-  it('quarantines and cleans unfinished work when a newer stable release supersedes it', async () => {
-    const compatibility = {
-      provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
-      baseImage: 'ubuntu-24.04', baseGeneration: 'ubuntu-24.04-v1',
-      bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
-    };
-    const release = (version: string, digit: string, buildTime: string) => ({
-      version, gitCommit: digit.repeat(7), gitRef: 'main', buildTime,
-      bundleKey: `system-bundles/${version}/matrix-host-bundle.tar.gz`, checksumKey: null,
-      sha256: digit.repeat(64), size: 100, createdAt: buildTime,
-    });
-    await registerHostBundleReleaseWithStableSnapshot(db, release(
-      'v-old-stable', '3', '2026-07-03T00:00:00.000Z',
-    ), 'stable', {
-      compatibility,
-      snapshotId: '10000000-0000-4000-8000-000000000003',
-      buildId: '20000000-0000-4000-8000-000000000003',
-      now: '2026-07-03T00:01:00.000Z',
-    });
-    await db.executor.updateTable('golden_snapshots').set({ state: 'building' })
-      .where('snapshot_id', '=', '10000000-0000-4000-8000-000000000003').execute();
-    await db.executor.updateTable('golden_snapshot_builds').set({
-      status: 'running', phase: 'builder_create', provider_builder_id: 42,
-      lease_expires_at: '2026-07-03T00:10:00.000Z',
-    }).where('build_id', '=', '20000000-0000-4000-8000-000000000003').execute();
-
-    await registerHostBundleReleaseWithStableSnapshot(db, release(
-      'v-new-stable', '4', '2026-07-04T00:00:00.000Z',
-    ), 'stable', {
-      compatibility,
-      snapshotId: '10000000-0000-4000-8000-000000000004',
-      buildId: '20000000-0000-4000-8000-000000000004',
-      now: '2026-07-04T00:01:00.000Z',
-    });
-
-    await expect(db.executor.selectFrom('golden_snapshots').select(['state', 'failure_code'])
-      .where('snapshot_id', '=', '10000000-0000-4000-8000-000000000003').executeTakeFirst())
-      .resolves.toEqual({ state: 'quarantined', failure_code: 'superseded_stable_release' });
-    await expect(db.executor.selectFrom('golden_snapshot_builds').select(['status', 'phase', 'last_error_code'])
-      .where('build_id', '=', '20000000-0000-4000-8000-000000000003').executeTakeFirst())
-      .resolves.toEqual({ status: 'failed', phase: 'failed', last_error_code: 'superseded_stable_release' });
-    await expect(db.executor.selectFrom('golden_snapshot_cleanup').select(['resource_type', 'provider_resource_id'])
-      .where('snapshot_id', '=', '10000000-0000-4000-8000-000000000003').execute())
-      .resolves.toEqual([{ resource_type: 'builder_server', provider_resource_id: 42 }]);
-    expect(Object.fromEntries(await getGoldenSnapshotCoarseStatuses(db, ['v-new-stable'])))
-      .toEqual({ 'v-new-stable': 'requested' });
-  });
-
-  it('preserves unfinished work when a stable alias has the same immutable bundle digest', async () => {
-    const compatibility = {
-      provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
-      baseImage: 'ubuntu-24.04', baseGeneration: 'ubuntu-24.04-v1',
-      bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
-    };
-    const release = (version: string, buildTime: string) => ({
-      version, gitCommit: '5555555', gitRef: 'main', buildTime,
-      bundleKey: `system-bundles/${version}/matrix-host-bundle.tar.gz`, checksumKey: null,
-      sha256: '5'.repeat(64), size: 100, createdAt: buildTime,
-    });
-    await registerHostBundleReleaseWithStableSnapshot(db, release(
-      'v-original-stable', '2026-07-04T00:00:00.000Z',
-    ), 'stable', {
-      compatibility,
-      snapshotId: '10000000-0000-4000-8000-000000000005',
-      buildId: '20000000-0000-4000-8000-000000000005',
-      now: '2026-07-04T00:01:00.000Z',
-    });
-    await db.executor.updateTable('golden_snapshots').set({ state: 'building' })
-      .where('snapshot_id', '=', '10000000-0000-4000-8000-000000000005').execute();
-    await db.executor.updateTable('golden_snapshot_builds').set({ status: 'running' })
-      .where('build_id', '=', '20000000-0000-4000-8000-000000000005').execute();
-
-    await expect(registerHostBundleReleaseWithStableSnapshot(db, release(
-      'v-stable-alias', '2026-07-04T01:00:00.000Z',
-    ), 'stable', {
-      compatibility,
-      snapshotId: '10000000-0000-4000-8000-000000000006',
-      buildId: '20000000-0000-4000-8000-000000000006',
-      now: '2026-07-04T01:01:00.000Z',
-    })).resolves.toMatchObject({
-      release: { version: 'v-stable-alias', snapshotEligible: true },
-      channel: { channel: 'stable', version: 'v-stable-alias' },
-    });
-
-    await expect(db.executor.selectFrom('golden_snapshots').select(['state', 'failure_code'])
-      .where('snapshot_id', '=', '10000000-0000-4000-8000-000000000005').executeTakeFirst())
-      .resolves.toEqual({ state: 'building', failure_code: null });
-    await expect(db.executor.selectFrom('golden_snapshot_builds').select('status')
-      .where('build_id', '=', '20000000-0000-4000-8000-000000000005').executeTakeFirst())
-      .resolves.toEqual({ status: 'running' });
-    await expect(db.executor.selectFrom('golden_snapshot_cleanup').select('cleanup_id')
-      .where('snapshot_id', '=', '10000000-0000-4000-8000-000000000005').execute())
-      .resolves.toEqual([]);
-    expect(Object.fromEntries(await getGoldenSnapshotCoarseStatuses(db, ['v-stable-alias'])))
-      .toEqual({ 'v-stable-alias': 'building' });
-  });
-
-  it('does not scan or backfill previously registered eligible releases', async () => {
     await upsertHostBundleRelease(db, {
-      version: 'v-historical', gitCommit: '4444444', gitRef: 'main', snapshotEligible: true,
+      version: 'manual-main', gitCommit: '3333333', gitRef: 'main', snapshotEligible: false,
+      buildTime: '2026-07-02T01:00:00.000Z', bundleKey: 'system-bundles/manual-main/matrix-host-bundle.tar.gz',
+      checksumKey: null, sha256: '3'.repeat(64), size: 100, createdAt: '2026-07-02T01:00:00.000Z',
+    });
+    const compatibility = {
+      provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
+      baseImage: 'ubuntu-24.04', baseGeneration: 'ubuntu-24.04-v1',
+      bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
+    };
+
+    await expect(reconcileMissingGoldenSnapshotBuilds(db, {
+      compatibility, now: '2026-07-03T00:00:00.000Z', limit: 25, freshnessMaxAgeMs: 86_400_000,
+    })).resolves.toEqual({ enqueued: 1 });
+    await expect(reconcileMissingGoldenSnapshotBuilds(db, {
+      compatibility, now: '2026-07-03T00:01:00.000Z', limit: 25, freshnessMaxAgeMs: 86_400_000,
+    })).resolves.toEqual({ enqueued: 0 });
+    const statuses = await getGoldenSnapshotCoarseStatuses(db, ['v1', 'preview-1', 'manual-main', 'missing']);
+    expect(Object.fromEntries(statuses)).toEqual({
+      v1: 'requested', 'preview-1': 'not_requested', 'manual-main': 'not_requested', missing: 'not_requested',
+    });
+  });
+
+  it('backfills a legacy release promoted before the new platform becomes authoritative', async () => {
+    await upsertHostBundleRelease(db, {
+      version: 'legacy-main-race', gitCommit: 'aaaaaaa', gitRef: 'main',
+      buildTime: '2026-07-02T02:00:00.000Z',
+      bundleKey: 'system-bundles/legacy-main-race/matrix-host-bundle.tar.gz', checksumKey: null,
+      sha256: 'a'.repeat(64), size: 100, createdAt: '2026-07-02T02:00:00.000Z',
+    });
+    await promoteHostBundleChannel(db, 'dev', 'legacy-main-race', '2026-07-02T02:01:00.000Z');
+    await upsertHostBundleRelease(db, {
+      version: 'explicit-opt-out', gitCommit: 'bbbbbbb', gitRef: 'main', snapshotEligible: false,
+      buildTime: '2026-07-02T03:00:00.000Z',
+      bundleKey: 'system-bundles/explicit-opt-out/matrix-host-bundle.tar.gz', checksumKey: null,
+      sha256: 'b'.repeat(64), size: 100, createdAt: '2026-07-02T03:00:00.000Z',
+    });
+    await promoteHostBundleChannel(db, 'beta', 'explicit-opt-out', '2026-07-02T03:01:00.000Z');
+    const compatibility = {
+      provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
+      baseImage: 'ubuntu-24.04', baseGeneration: 'ubuntu-24.04-v1',
+      bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
+    };
+
+    await expect(reconcileMissingGoldenSnapshotBuilds(db, {
+      compatibility, now: '2026-07-03T00:00:00.000Z', limit: 25, freshnessMaxAgeMs: 86_400_000,
+    })).resolves.toEqual({ enqueued: 1 });
+    await expect(getHostBundleRelease(db, 'legacy-main-race'))
+      .resolves.toMatchObject({ snapshotEligible: true });
+    await expect(getHostBundleRelease(db, 'explicit-opt-out'))
+      .resolves.toMatchObject({ snapshotEligible: false });
+  });
+
+  it('never lets test-mode snapshots satisfy production reconciliation or public status', async () => {
+    await upsertHostBundleRelease(db, {
+      version: 'v-test-isolation', gitCommit: '4444444', gitRef: 'main', snapshotEligible: true,
       buildTime: '2026-07-04T00:00:00.000Z',
-      bundleKey: 'system-bundles/v-historical/matrix-host-bundle.tar.gz', checksumKey: null,
+      bundleKey: 'system-bundles/v-test-isolation/matrix-host-bundle.tar.gz', checksumKey: null,
       sha256: '4'.repeat(64), size: 100, createdAt: '2026-07-04T00:00:00.000Z',
     });
-    await promoteHostBundleChannel(db, 'stable', 'v-historical', '2026-07-04T00:01:00.000Z');
-
-    expect(Object.fromEntries(await getGoldenSnapshotCoarseStatuses(db, ['v-historical'])))
-      .toEqual({ 'v-historical': 'not_requested' });
-  });
-
-  it('persists an explicit stable opt-out and supersedes unfinished older work without enqueueing', async () => {
     const compatibility = {
       provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
       baseImage: 'ubuntu-24.04', baseGeneration: 'ubuntu-24.04-v1',
       bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
     };
-    await registerHostBundleReleaseWithStableSnapshot(db, {
-      version: 'v-old-opt-out', gitCommit: '8888888', gitRef: 'main',
-      buildTime: '2026-07-05T00:00:00.000Z',
-      bundleKey: 'system-bundles/v-old-opt-out/matrix-host-bundle.tar.gz', checksumKey: null,
-      sha256: '8'.repeat(64), size: 100, createdAt: '2026-07-05T00:00:00.000Z',
-    }, 'stable', {
-      compatibility, snapshotId: '10000000-0000-4000-8000-000000000088',
-      buildId: '20000000-0000-4000-8000-000000000088', now: '2026-07-05T00:01:00.000Z',
-    });
-    await db.executor.updateTable('golden_snapshot_builds').set({ status: 'running' })
-      .where('build_id', '=', '20000000-0000-4000-8000-000000000088').execute();
-
-    const optedOut = await registerHostBundleReleaseWithStableSnapshot(db, {
-      version: 'v-stable-opt-out', gitCommit: '9999999', gitRef: 'main', snapshotEligible: false,
-      buildTime: '2026-07-06T00:00:00.000Z',
-      bundleKey: 'system-bundles/v-stable-opt-out/matrix-host-bundle.tar.gz', checksumKey: null,
-      sha256: '9'.repeat(64), size: 100, createdAt: '2026-07-06T00:00:00.000Z',
-    }, 'stable', {
-      compatibility, snapshotId: '10000000-0000-4000-8000-000000000089',
-      buildId: '20000000-0000-4000-8000-000000000089', now: '2026-07-06T00:01:00.000Z',
+    await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: 'v-test-isolation', compatibility, testMode: true,
+      snapshotId: '10000000-0000-4000-8000-000000000099',
+      buildId: '20000000-0000-4000-8000-000000000099',
+      now: '2026-07-04T00:01:00.000Z',
     });
 
-    expect(optedOut.release.snapshotEligible).toBe(false);
-    expect(Object.fromEntries(await getGoldenSnapshotCoarseStatuses(db, ['v-stable-opt-out'])))
-      .toEqual({ 'v-stable-opt-out': 'not_requested' });
-    await expect(db.executor.selectFrom('golden_snapshot_builds').select('status')
-      .where('build_id', '=', '20000000-0000-4000-8000-000000000088').executeTakeFirst())
-      .resolves.toEqual({ status: 'failed' });
+    expect(Object.fromEntries(await getGoldenSnapshotCoarseStatuses(db, ['v-test-isolation'])))
+      .toEqual({ 'v-test-isolation': 'not_requested' });
+    await expect(reconcileMissingGoldenSnapshotBuilds(db, {
+      compatibility, now: '2026-07-04T00:02:00.000Z', limit: 25, freshnessMaxAgeMs: 86_400_000,
+    })).resolves.toEqual({ enqueued: 1 });
   });
 
-  it('cancels the current release build when that stable release opts out', async () => {
+  it('enqueues one immutable replacement for a stale ready snapshot and reuses it on reconciliation', async () => {
+    await upsertHostBundleRelease(db, {
+      version: 'v-stale', gitCommit: '8888888', gitRef: 'main', snapshotEligible: true,
+      buildTime: '2026-07-01T00:00:00.000Z',
+      bundleKey: 'system-bundles/v-stale/matrix-host-bundle.tar.gz', checksumKey: null,
+      sha256: '8'.repeat(64), size: 100, createdAt: '2026-07-01T00:00:00.000Z',
+    });
     const compatibility = {
       provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
       baseImage: 'ubuntu-24.04', baseGeneration: 'ubuntu-24.04-v1',
       bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
     };
-    await registerHostBundleReleaseWithStableSnapshot(db, {
-      version: 'v-current-opt-out', gitCommit: 'aaaaaaa', gitRef: 'main',
-      buildTime: '2026-07-07T00:00:00.000Z',
-      bundleKey: 'system-bundles/v-current-opt-out/matrix-host-bundle.tar.gz', checksumKey: null,
-      sha256: 'a'.repeat(64), size: 100, createdAt: '2026-07-07T00:00:00.000Z',
-    }, 'stable', {
-      compatibility, snapshotId: '10000000-0000-4000-8000-000000000090',
-      buildId: '20000000-0000-4000-8000-000000000090', now: '2026-07-07T00:01:00.000Z',
+    const original = await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: 'v-stale', compatibility,
+      snapshotId: '10000000-0000-4000-8000-000000000088',
+      buildId: '20000000-0000-4000-8000-000000000088', now: '2026-07-01T00:01:00.000Z',
     });
+    await db.executor.updateTable('golden_snapshots').set({
+      state: 'ready', ready_at: '2026-07-01T00:02:00.000Z', provider_image_id: 88,
+    }).where('snapshot_id', '=', original.snapshot.snapshotId).execute();
 
-    await promoteHostBundleChannelWithStableSnapshot(db, 'stable', 'v-current-opt-out', {
-      snapshotEligible: false, now: '2026-07-07T00:02:00.000Z',
-    });
-
-    await expect(db.executor.selectFrom('golden_snapshot_builds').select('status')
-      .where('build_id', '=', '20000000-0000-4000-8000-000000000090').executeTakeFirst())
-      .resolves.toEqual({ status: 'failed' });
-    expect(Object.fromEntries(await getGoldenSnapshotCoarseStatuses(db, ['v-current-opt-out'])))
-      .toEqual({ 'v-current-opt-out': 'failed' });
-  });
-
-  it('rolls back the stable pointer and eligibility when enqueue fails', async () => {
-    const compatibility = {
-      provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
-      baseImage: 'ubuntu-24.04', baseGeneration: 'revoked-generation',
-      bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
-    };
-    await upsertHostBundleRelease(db, {
-      version: 'v-existing-stable', gitCommit: 'bbbbbbb', gitRef: 'main', snapshotEligible: false,
-      buildTime: '2026-07-08T00:00:00.000Z',
-      bundleKey: 'system-bundles/v-existing-stable/matrix-host-bundle.tar.gz', checksumKey: null,
-      sha256: 'b'.repeat(64), size: 100, createdAt: '2026-07-08T00:00:00.000Z',
-    });
-    await upsertHostBundleRelease(db, {
-      version: 'v-revoked-target', gitCommit: 'ccccccc', gitRef: 'main', snapshotEligible: false,
-      buildTime: '2026-07-09T00:00:00.000Z',
-      bundleKey: 'system-bundles/v-revoked-target/matrix-host-bundle.tar.gz', checksumKey: null,
-      sha256: 'c'.repeat(64), size: 100, createdAt: '2026-07-09T00:00:00.000Z',
-    });
-    await promoteHostBundleChannel(db, 'stable', 'v-existing-stable', '2026-07-08T00:01:00.000Z');
-    await db.executor.insertInto('golden_snapshot_revoked_base_generations').values({
-      base_generation: compatibility.baseGeneration,
-      reason: 'test_revocation',
-      revoked_at: '2026-07-08T00:02:00.000Z',
-      updated_at: '2026-07-08T00:02:00.000Z',
-    }).execute();
-
-    await expect(promoteHostBundleChannelWithStableSnapshot(db, 'stable', 'v-revoked-target', {
-      compatibility, snapshotId: '10000000-0000-4000-8000-000000000091',
-      buildId: '20000000-0000-4000-8000-000000000091', now: '2026-07-09T00:01:00.000Z',
-    })).rejects.toThrow('Base generation is revoked');
-
-    await expect(getHostBundleChannel(db, 'stable'))
-      .resolves.toMatchObject({ version: 'v-existing-stable' });
-    await expect(db.executor.selectFrom('host_bundle_releases').select('snapshot_eligible')
-      .where('version', '=', 'v-revoked-target').executeTakeFirst())
-      .resolves.toEqual({ snapshot_eligible: false });
+    await expect(reconcileMissingGoldenSnapshotBuilds(db, {
+      compatibility, now: '2026-07-03T00:00:00.000Z', limit: 25,
+      freshnessMaxAgeMs: 24 * 60 * 60 * 1000,
+    })).resolves.toEqual({ enqueued: 1 });
+    await expect(reconcileMissingGoldenSnapshotBuilds(db, {
+      compatibility, now: '2026-07-03T00:01:00.000Z', limit: 25,
+      freshnessMaxAgeMs: 24 * 60 * 60 * 1000,
+    })).resolves.toEqual({ enqueued: 0 });
+    await expect(db.executor.selectFrom('golden_snapshots')
+      .select(['image_generation', 'state']).where('bundle_sha256', '=', '8'.repeat(64))
+      .orderBy('image_generation').execute()).resolves.toEqual([
+      { image_generation: 1, state: 'ready' },
+      { image_generation: 2, state: 'candidate' },
+    ]);
+    expect(Object.fromEntries(await getGoldenSnapshotCoarseStatuses(
+      db,
+      ['v-stale'],
+      compatibility,
+      { now: '2026-07-03T00:01:00.000Z', freshnessMaxAgeMs: 24 * 60 * 60 * 1000 },
+    ))).toEqual({ 'v-stale': 'requested' });
   });
 
   it('reports status only for the active provisioning compatibility', async () => {
@@ -506,4 +388,54 @@ describe('forward-only stable golden snapshot promotion', () => {
     ))).toEqual({ 'v-active-compatibility': 'requested' });
   });
 
+  it('prioritizes the newest missing eligible release within each bounded reconciliation batch', async () => {
+    for (const [version, day, sha] of [['v-backlog-old', '01', '6'], ['v-backlog-new', '02', '7']] as const) {
+      await upsertHostBundleRelease(db, {
+        version, gitCommit: sha.repeat(7), gitRef: 'main', snapshotEligible: true,
+        buildTime: `2026-07-${day}T00:00:00.000Z`,
+        bundleKey: `system-bundles/${version}/matrix-host-bundle.tar.gz`, checksumKey: null,
+        sha256: sha.repeat(64), size: 100, createdAt: `2026-07-${day}T00:00:00.000Z`,
+      });
+    }
+    const compatibility = {
+      provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
+      baseImage: 'ubuntu-24.04', baseGeneration: 'ubuntu-24.04-v1',
+      bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
+    };
+
+    await expect(reconcileMissingGoldenSnapshotBuilds(db, {
+      compatibility, now: '2026-07-03T00:00:00.000Z', limit: 1, freshnessMaxAgeMs: 86_400_000,
+    })).resolves.toEqual({ enqueued: 1 });
+    await expect(db.executor.selectFrom('golden_snapshots').select('bundle_version').execute())
+      .resolves.toEqual([{ bundle_version: 'v-backlog-new' }]);
+  });
+
+  it('continues the bounded reconciliation batch after one release cannot enqueue', async () => {
+    for (const [version, day, sha] of [['v-reconcile-old', '01', '6'], ['v-reconcile-corrupt', '02', '7']] as const) {
+      await upsertHostBundleRelease(db, {
+        version, gitCommit: sha.repeat(7), gitRef: 'main', snapshotEligible: true,
+        buildTime: `2026-07-${day}T00:00:00.000Z`,
+        bundleKey: `system-bundles/${version}/matrix-host-bundle.tar.gz`, checksumKey: null,
+        sha256: sha.repeat(64), size: 100, createdAt: `2026-07-${day}T00:00:00.000Z`,
+      });
+    }
+    await db.executor.updateTable('host_bundle_releases').set({ sha256: 'invalid-provenance' })
+      .where('version', '=', 'v-reconcile-corrupt').execute();
+    const compatibility = {
+      provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central',
+      baseImage: 'ubuntu-24.04', baseGeneration: 'ubuntu-24.04-v1',
+      bootMode: 'bios' as const, activationAbi: 'host-v1', minimumDiskGb: 40,
+    };
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(reconcileMissingGoldenSnapshotBuilds(db, {
+      compatibility, now: '2026-07-03T00:00:00.000Z', limit: 25, freshnessMaxAgeMs: 86_400_000,
+    })).resolves.toEqual({ enqueued: 1 });
+    await expect(db.executor.selectFrom('golden_snapshots').select('bundle_version').execute())
+      .resolves.toEqual([{ bundle_version: 'v-reconcile-old' }]);
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining(
+      '[golden-snapshot] missing-build enqueue failed release=v-reconcile-corrupt',
+    ));
+    consoleError.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary

- revert merged PR #1219 exactly
- restore the Matrix OS tree to the pre-#1219 state
- create an attribution-correction boundary before a clean Nima-authored reapplication

This PR exists only to provide the requested revert/reapply history. It does not deploy or enable golden snapshot builds or selection.

## Tests

- reverted tree hash exactly matches PR #1219's first-parent tree
- `git diff --cached --check`

## Review/Monitoring

- merge this revert before the stacked reapply PR
- do not deploy or enable golden builds between layers
- do not merge without explicit owner approval

## Invariants

- no credentials, provider resources, database rows, releases, or runtime flags are changed by opening this PR
- the reapply layer restores the byte-identical approved feature tree
- commit author and committer are both GitHub-linked `Nima-Naderi`
