### PR TITLE
fix(golden-snapshots): overwrite ext4 reserved clusters

### DIFF
--- a/distro/customer-vps/host-bin/matrix-golden-snapshot-sanitize
+++ b/distro/customer-vps/host-bin/matrix-golden-snapshot-sanitize
@@ -34,11 +34,42 @@ remove_path() {
 
 patterns_file=""
 dd_error_file=""
+zero_fill=""
+reserved_clusters_file=""
+reserved_clusters_original=""
+reserved_clusters_changed=0
+
+restore_reserved_clusters() {
+  local restored
+  [ "$reserved_clusters_changed" -eq 1 ] || return 0
+  if ! printf '%s\n' "$reserved_clusters_original" > "$reserved_clusters_file"; then
+    return 1
+  fi
+  restored="$(<"$reserved_clusters_file")" || return 1
+  [ "$restored" = "$reserved_clusters_original" ] || return 1
+  reserved_clusters_changed=0
+}
+
 cleanup_runtime_evidence() {
+  local exit_status=$? cleanup_status=0
+  trap - EXIT HUP INT TERM
+  set +e
+  [ -z "$zero_fill" ] || rm -f -- "$zero_fill"
+  [ "$?" -eq 0 ] || cleanup_status=1
+  restore_reserved_clusters
+  [ "$?" -eq 0 ] || cleanup_status=1
   [ -z "$patterns_file" ] || rm -f -- "$patterns_file"
+  [ "$?" -eq 0 ] || cleanup_status=1
   [ -z "$dd_error_file" ] || rm -f -- "$dd_error_file"
+  [ "$?" -eq 0 ] || cleanup_status=1
+  if [ "$cleanup_status" -ne 0 ]; then
+    echo "golden snapshot free-block overwrite cleanup failed" >&2
+    exit 70
+  fi
+  exit "$exit_status"
 }
 trap cleanup_runtime_evidence EXIT
+trap 'exit 70' HUP INT TERM
 
 # Production builders seed one synthetic disk canary before deleting cloud-init
 # state. Both it and the phase callback token must be absent from the raw root
@@ -246,6 +277,54 @@ if [ "$root" = "/" ]; then
     exit 69
   fi
 
+  root_device_major_minor="$(findmnt -n -o MAJ:MIN --target /)"
+  case "$root_device_major_minor" in
+    ""|*[!0-9:]*|:*|*:|*:*:*)
+      echo "golden snapshot free-block overwrite setup failed" >&2
+      exit 70
+      ;;
+  esac
+  if ! root_device_sysfs="$(readlink -f -- "/sys/dev/block/$root_device_major_minor")"; then
+    echo "golden snapshot free-block overwrite setup failed" >&2
+    exit 70
+  fi
+  root_device_name="${root_device_sysfs##*/}"
+  case "$root_device_name" in
+    ""|*[!a-zA-Z0-9._-]*)
+      echo "golden snapshot free-block overwrite setup failed" >&2
+      exit 70
+      ;;
+  esac
+  reserved_clusters_file="/sys/fs/ext4/$root_device_name/reserved_clusters"
+  if [ ! -f "$reserved_clusters_file" ] || [ -L "$reserved_clusters_file" ]; then
+    echo "golden snapshot free-block overwrite setup failed" >&2
+    exit 70
+  fi
+  if ! reserved_clusters_original="$(<"$reserved_clusters_file")"; then
+    echo "golden snapshot free-block overwrite setup failed" >&2
+    exit 70
+  fi
+  case "$reserved_clusters_original" in
+    ""|*[!0-9]*)
+      echo "golden snapshot free-block overwrite setup failed" >&2
+      exit 70
+      ;;
+  esac
+
+  # ext4's runtime reserved_clusters pool is separate from tune2fs reserved
+  # blocks and remains untouched when a normal fill reaches ENOSPC. Expose it
+  # only for this overwrite, then restore the exact value before raw scanning.
+  reserved_clusters_changed=1
+  if ! printf '0\n' > "$reserved_clusters_file"; then
+    echo "golden snapshot free-block overwrite setup failed" >&2
+    exit 70
+  fi
+  reserved_clusters_current="$(<"$reserved_clusters_file")" || reserved_clusters_current=""
+  if [ "$reserved_clusters_current" != 0 ]; then
+    echo "golden snapshot free-block overwrite setup failed" >&2
+    exit 70
+  fi
+
   zero_fill=/var/lib/matrix-golden-snapshot-zero-fill
   dd_error_file=/run/matrix-golden-snapshot-zero-fill.err
   set +e
@@ -254,7 +333,12 @@ if [ "$root" = "/" ]; then
   set -e
   sync
   rm -f -- "$zero_fill"
+  zero_fill=""
   sync
+  if ! restore_reserved_clusters; then
+    echo "golden snapshot free-block overwrite cleanup failed" >&2
+    exit 70
+  fi
   if [ "$dd_status" -eq 0 ] || ! grep -Fq 'No space left on device' "$dd_error_file"; then
     echo "golden snapshot free-block overwrite failed" >&2
     exit 70

--- a/tests/platform/golden-snapshot-host-scripts.test.ts
+++ b/tests/platform/golden-snapshot-host-scripts.test.ts
@@ -252,6 +252,45 @@ describe('golden snapshot host scripts', () => {
     expect(source).toContain('*) echo "golden snapshot raw-device scan failed" >&2; exit 72');
   });
 
+  it('overwrites ext4 runtime-reserved clusters and restores the exact reservation', async () => {
+    const source = await readFile(sanitizePath, 'utf8');
+    const locateRootDevice = source.indexOf('findmnt -n -o MAJ:MIN --target /');
+    const locateExt4Control = source.indexOf('/sys/fs/ext4/$root_device_name/reserved_clusters');
+    const saveReservation = source.indexOf('reserved_clusters_original="$(<"$reserved_clusters_file")"');
+    const exposeReservation = source.indexOf('printf \'0\\n\' > "$reserved_clusters_file"');
+    const fillFreeBlocks = source.indexOf('dd if=/dev/zero');
+    const removeFill = source.indexOf('rm -f -- "$zero_fill"', fillFreeBlocks);
+    const restoreReservation = source.indexOf('if ! restore_reserved_clusters; then', removeFill);
+
+    expect(locateRootDevice).toBeGreaterThan(-1);
+    expect(locateExt4Control).toBeGreaterThan(locateRootDevice);
+    expect(saveReservation).toBeGreaterThan(locateExt4Control);
+    expect(exposeReservation).toBeGreaterThan(saveReservation);
+    expect(fillFreeBlocks).toBeGreaterThan(exposeReservation);
+    expect(removeFill).toBeGreaterThan(fillFreeBlocks);
+    expect(restoreReservation).toBeGreaterThan(removeFill);
+    expect(source).toContain('reserved_clusters_changed=1');
+    expect(source).toContain('restore_reserved_clusters');
+    expect(source).toContain(
+      'printf \'%s\\n\' "$reserved_clusters_original" > "$reserved_clusters_file"',
+    );
+    expect(source).not.toContain('/sys/fs/ext4/sda1/');
+  });
+
+  it('restores the ext4 runtime reservation when sanitation is interrupted', async () => {
+    const source = await readFile(sanitizePath, 'utf8');
+    const exitCleanup = source.indexOf('trap cleanup_runtime_evidence EXIT');
+    const signalExit = source.indexOf("trap 'exit 70' HUP INT TERM");
+    const cleanupFunction = source.slice(
+      source.indexOf('cleanup_runtime_evidence() {'),
+      exitCleanup,
+    );
+
+    expect(exitCleanup).toBeGreaterThan(-1);
+    expect(signalExit).toBeGreaterThan(exitCleanup);
+    expect(cleanupFunction).toContain('restore_reserved_clusters');
+  });
+
   it('uses one credential-free activation path for builders and validation clones', async () => {
     const source = await readFile(activatePath, 'utf8');
     expect(source).toContain('matrix-golden-validation');


### PR DESCRIPTION
## Summary

- temporarily expose ext4 runtime `reserved_clusters` while the golden builder overwrites free blocks
- restore and verify the exact reservation on success, errors, and termination signals
- resolve the root filesystem dynamically through `MAJ:MIN` and fail closed when the control cannot be validated
- add regression coverage for overwrite ordering, exact restoration, interruption cleanup, and device independence

## Why

The sanitizer's existing zero fill could leave data in ext4's runtime-reserved cluster pool. A disposable builder reproduced the residue and showed that setting the runtime reservation to zero for the fill removes it; `tune2fs` reserved-block settings do not cover this allocator pool. The raw-device verification remains fail-closed.

## Tests

- `bun run test -- tests/platform/golden-snapshot-host-scripts.test.ts` — 14 passed
- `bun run test:golden-snapshots` — 510 passed
- `bun run typecheck` — passed
- `bun run check:patterns` — passed, zero violations
- `bash -n distro/customer-vps/host-bin/matrix-golden-snapshot-sanitize` — passed
- `bun run test` — relevant golden suites passed; repository-wide run exposed 22 unrelated baseline/concurrency failures across 10 files. `tests/gateway/session-registry.test.ts` passed 51/51 when isolated, while two UI suites independently reproduce a dependency-layout failure where `@testing-library/jest-dom` cannot resolve its Vitest peer.
- GitHub CI — all triggered checks passed, including four unit-test shards, typecheck, shell production build, sync-client packaging, patterns, React Doctor, docs contracts, and E2E.

## Invariants

- **Source of truth:** the mounted root device is resolved from `findmnt` `MAJ:MIN`; the kernel ext4 `reserved_clusters` control is authoritative for the runtime allocator reservation.
- **Lock/transaction scope:** sanitation is single-builder host work. The original reservation is captured once and restored exactly through the normal path and the EXIT/signal cleanup path; no database writes are introduced.
- **Acceptable orphan states:** none. Setup or restoration ambiguity exits with status 70, so the builder cannot report sanitation success or become selectable.
- **Auth source of truth:** unchanged. Existing authenticated golden-builder callbacks and platform controls remain authoritative; this PR adds no route or credential handling.
- **Deferred scope:** deploying, enabling builds, running the first post-merge production builder, and deleting preserved diagnostic VPSes remain separate operator-approved actions.

## Review and monitoring

- Trusted Greptile: 5/5 on `ae473275a495b8bf290168331e9ea2290482ff86`.
- `ready-for-ci` applied after the 5/5 result.
- All triggered CI checks are green.

No keys, customer data, production flags, deployments, builders, or provider resources are changed by this PR.
