### PR TITLE
fix(golden-snapshots): read raw root device numbers

### DIFF
--- a/distro/customer-vps/host-bin/matrix-golden-snapshot-sanitize
+++ b/distro/customer-vps/host-bin/matrix-golden-snapshot-sanitize
@@ -277,7 +277,7 @@ if [ "$root" = "/" ]; then
     exit 69
   fi
 
-  root_device_major_minor="$(findmnt -n -o MAJ:MIN --target /)"
+  root_device_major_minor="$(findmnt -n -r -o MAJ:MIN --target /)"
   case "$root_device_major_minor" in
     ""|*[!0-9:]*|:*|*:|*:*:*)
       echo "golden snapshot free-block overwrite setup failed" >&2

--- a/tests/platform/golden-snapshot-host-scripts.test.ts
+++ b/tests/platform/golden-snapshot-host-scripts.test.ts
@@ -254,7 +254,7 @@ describe('golden snapshot host scripts', () => {
 
   it('overwrites ext4 runtime-reserved clusters and restores the exact reservation', async () => {
     const source = await readFile(sanitizePath, 'utf8');
-    const locateRootDevice = source.indexOf('findmnt -n -o MAJ:MIN --target /');
+    const locateRootDevice = source.indexOf('findmnt -n -r -o MAJ:MIN --target /');
     const locateExt4Control = source.indexOf('/sys/fs/ext4/$root_device_name/reserved_clusters');
     const saveReservation = source.indexOf('reserved_clusters_original="$(<"$reserved_clusters_file")"');
     const exposeReservation = source.indexOf('printf \'0\\n\' > "$reserved_clusters_file"');
@@ -275,6 +275,7 @@ describe('golden snapshot host scripts', () => {
       'printf \'%s\\n\' "$reserved_clusters_original" > "$reserved_clusters_file"',
     );
     expect(source).not.toContain('/sys/fs/ext4/sda1/');
+    expect(source).not.toContain('findmnt -n -o MAJ:MIN --target /');
   });
 
   it('restores the ext4 runtime reservation when sanitation is interrupted', async () => {


### PR DESCRIPTION
## Summary

- request raw `MAJ:MIN` output from `findmnt` in the golden snapshot sanitizer
- keep strict device-number validation while avoiding util-linux column padding
- add a regression assertion that prevents restoring the padded-output command

## Root cause

Without raw output, util-linux may pad `findmnt -o MAJ:MIN` with spaces. The sanitizer's strict validation correctly rejects those non-numeric characters, so sanitation exits before resolving the root block device and overwriting free blocks.

## Tests

- red/green focused host-script regression: 14 tests passed
- golden snapshot platform suites: 510 tests passed
- TypeScript typecheck passed
- shell syntax check passed
- pattern checks passed with no new violations
- full suite reached 10,683 passing tests; nine unrelated UI suites hit an offline worktree peer-link collection issue, while the same unchanged UI test passes from the root install

## Review/Monitoring

- awaiting trusted Greptile review before applying `ready-for-ci`
- broader CI will be monitored after the label gate is satisfied

## Invariants

- `findmnt --raw` remains the source of truth for the root device major/minor value
- strict validation and fail-closed sanitizer behavior remain unchanged
- no database, locking, transaction, authentication, provisioning, or orphan-state behavior changes
- live golden build validation remains a separate post-merge operator step; this PR does not deploy or enable builds
