### PR TITLE
fix(golden-snapshots): sanitize lingering user state

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -529,6 +529,22 @@ runcmd:
     printf 'matrix ALL=(ALL) NOPASSWD:ALL\n' >/etc/sudoers.d/matrix
     chmod 0440 /etc/sudoers.d/matrix
     visudo -cf /etc/sudoers.d/matrix
+    # A golden builder may have enabled linger while validating the bundled
+    # user-systemd terminal runtime. Quiesce any inherited user manager before
+    # changing the clone-specific home; usermod refuses users with live
+    # processes and would otherwise abort cloud-init before restore starts.
+    matrix_uid="$(id -u matrix)"
+    timeout --kill-after=5 30 loginctl disable-linger matrix >/dev/null 2>&1 || true
+    timeout --kill-after=5 30 loginctl terminate-user matrix >/dev/null 2>&1 || true
+    timeout --kill-after=5 30 systemctl stop "user@${matrix_uid}.service" >/dev/null 2>&1 || true
+    for _ in $(seq 1 30); do
+      pgrep -u matrix >/dev/null 2>&1 || break
+      sleep 1
+    done
+    if pgrep -u matrix >/dev/null 2>&1; then
+      echo "matrix-host: matrix user quiescence failed" >&2
+      exit 1
+    fi
     usermod -d /home/matrix/home matrix
     install -d -o matrix -g matrix -m 0750 /home/matrix/home /home/matrix/home/projects /home/matrix/projects /var/lib/matrix/db /var/lib/matrix/db/snapshots /var/lib/matrix/logs
     ensure_owner_link() {

--- a/distro/customer-vps/host-bin/matrix-golden-snapshot-activate
+++ b/distro/customer-vps/host-bin/matrix-golden-snapshot-activate
@@ -43,6 +43,7 @@ if [ "$mode" = validation ]; then
     /root/.zsh_history
     /root/.npmrc
     /root/.netrc
+    /var/lib/systemd/linger/matrix
     /var/lib/systemd/random-seed
     /var/lib/cloud
     /var/lib/dhcp
@@ -110,6 +111,15 @@ EOF
       rm -f -- /root/.ssh/authorized_keys
     fi
     rmdir -- /root/.ssh
+  fi
+  set_activation_stage activation_preflight_runtime_state
+  matrix_uid="$(id -u matrix)"
+  matrix_linger="$(loginctl show-user matrix --property=Linger --value 2>/dev/null || true)"
+  if [ -e /var/lib/systemd/linger/matrix ] || [ -L /var/lib/systemd/linger/matrix ] \
+    || [ "$matrix_linger" = yes ] \
+    || systemctl is-active --quiet "user@${matrix_uid}.service"; then
+    echo "golden snapshot inherited matrix linger state found" >&2
+    exit 67
   fi
   for forbidden in \
     /etc/matrix \

--- a/distro/customer-vps/host-bin/matrix-golden-snapshot-sanitize
+++ b/distro/customer-vps/host-bin/matrix-golden-snapshot-sanitize
@@ -120,6 +120,7 @@ remove_targets=(
   root/.zsh_history
   root/.npmrc
   root/.netrc
+  var/lib/systemd/linger/matrix
   var/lib/systemd/random-seed
   var/lib/cloud
   var/lib/dhcp
@@ -180,6 +181,24 @@ sensitive_targets=(
   var/crash
   var/lib/systemd/coredump
 )
+
+if [ "$root" = "/" ] && id matrix >/dev/null 2>&1; then
+  matrix_uid="$(id -u matrix)"
+  if ! timeout --kill-after=5 30 loginctl disable-linger matrix; then
+    echo "golden snapshot matrix user quiescence failed" >&2
+    exit 67
+  fi
+  timeout --kill-after=5 30 loginctl terminate-user matrix >/dev/null 2>&1 || true
+  timeout --kill-after=5 30 systemctl stop "user@${matrix_uid}.service" >/dev/null 2>&1 || true
+  for _ in $(seq 1 30); do
+    pgrep -u matrix >/dev/null 2>&1 || break
+    sleep 1
+  done
+  if pgrep -u matrix >/dev/null 2>&1; then
+    echo "golden snapshot matrix user quiescence failed" >&2
+    exit 67
+  fi
+fi
 
 if [ "$root" = "/" ]; then
   swapoff -a

--- a/distro/customer-vps/host-bin/matrix-golden-snapshot-validate
+++ b/distro/customer-vps/host-bin/matrix-golden-snapshot-validate
@@ -71,6 +71,7 @@ required_clean_evidence=(
   /root/.zsh_history
   /root/.npmrc
   /root/.netrc
+  /var/lib/systemd/linger/matrix
   /var/lib/systemd/random-seed
   /var/lib/cloud
   /var/lib/dhcp

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -184,6 +184,26 @@ exit 99
     expect(swapIndex).toBeLessThan(aptIndex);
   });
 
+  it('quiesces inherited matrix user processes before changing the clone home', () => {
+    const cloudInit = readFileSync(
+      join(process.cwd(), 'distro/customer-vps/cloud-init.yaml'),
+      'utf8',
+    );
+    const disableLinger = cloudInit.indexOf('loginctl disable-linger matrix');
+    const terminateUser = cloudInit.indexOf('loginctl terminate-user matrix');
+    const stopUserManager = cloudInit.indexOf('systemctl stop "user@${matrix_uid}.service"');
+    const verifyStopped = cloudInit.indexOf('matrix-host: matrix user quiescence failed');
+    const changeHome = cloudInit.indexOf('usermod -d /home/matrix/home matrix');
+
+    expect(disableLinger).toBeGreaterThan(-1);
+    expect(terminateUser).toBeGreaterThan(disableLinger);
+    expect(stopUserManager).toBeGreaterThan(terminateUser);
+    expect(verifyStopped).toBeGreaterThan(stopUserManager);
+    expect(changeHome).toBeGreaterThan(verifyStopped);
+    expect(cloudInit).toContain('timeout --kill-after=5 30 loginctl disable-linger matrix');
+    expect(cloudInit).toContain('pgrep -u matrix');
+  });
+
   it('ships matrix-ensure-swap in the host bundle and runs it from the sync agent', () => {
     const root = process.cwd();
     const ensureSwap = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-ensure-swap'), 'utf8');

--- a/tests/platform/golden-snapshot-host-scripts.test.ts
+++ b/tests/platform/golden-snapshot-host-scripts.test.ts
@@ -21,6 +21,7 @@ describe('golden snapshot host scripts', () => {
       'etc/ssh/ssh_host_ed25519_key',
       'etc/matrix/tls/server.key',
       'var/lib/systemd/random-seed',
+      'var/lib/systemd/linger/matrix',
       'var/lib/cloud/instances/i-123/state',
       'var/lib/dhcp/dhclient.leases',
       'etc/netplan/50-cloud-init.yaml',
@@ -68,6 +69,7 @@ describe('golden snapshot host scripts', () => {
     const evidence = await readFile(join(root, 'var/lib/matrix/golden-snapshot-sanitized'), 'utf8');
     expect(evidence).toContain('sanitized=true');
     expect(evidence).toContain('clean:/etc/matrix');
+    expect(evidence).toContain('clean:/var/lib/systemd/linger/matrix');
     expect(evidence).toContain('clean:/var/lib/docker/volumes');
     expect(evidence).toContain('clean:/etc/machine-id');
     expect(evidence).toContain('clean:/etc/netplan/50-cloud-init.yaml');
@@ -92,6 +94,23 @@ describe('golden snapshot host scripts', () => {
     expect(runtimeState.mode & 0o777).toBe(0o755);
   });
 
+  it('quiesces the lingering matrix user manager before removing snapshot state', async () => {
+    const source = await readFile(sanitizePath, 'utf8');
+    const disableLinger = source.indexOf('loginctl disable-linger matrix');
+    const terminateUser = source.indexOf('loginctl terminate-user matrix');
+    const stopUserManager = source.indexOf('systemctl stop "user@${matrix_uid}.service"');
+    const verifyStopped = source.indexOf('pgrep -u matrix');
+    const removeState = source.indexOf('for relative in "${remove_targets[@]}"; do');
+
+    expect(disableLinger).toBeGreaterThan(-1);
+    expect(terminateUser).toBeGreaterThan(disableLinger);
+    expect(stopUserManager).toBeGreaterThan(terminateUser);
+    expect(verifyStopped).toBeGreaterThan(stopUserManager);
+    expect(removeState).toBeGreaterThan(verifyStopped);
+    expect(source).toContain('timeout --kill-after=5 30 loginctl disable-linger matrix');
+    expect(source).toContain('golden snapshot matrix user quiescence failed');
+  });
+
   it('fails closed when a forbidden path survives and emits only coarse validation evidence', async () => {
     const source = await readFile(validatePath, 'utf8');
     const activationSource = await readFile(activatePath, 'utf8');
@@ -110,6 +129,7 @@ describe('golden snapshot host scripts', () => {
       '/etc/matrix', '/opt/matrix/env', '/opt/matrix/config', '/opt/matrix/secrets',
       '/opt/matrix/tls', '/home/matrix/home', '/home/matrix/.hermes',
       '/home/matrix/.ssh', '/root/.ssh', '/home/matrix/.npmrc', '/root/.npmrc',
+      '/var/lib/systemd/linger/matrix',
       '/var/lib/docker/volumes', '/var/lib/containerd', '/var/log/matrix',
       '/var/log/matrix-builder.log', '/var/crash', '/var/lib/systemd/coredump',
     ]) {
@@ -127,6 +147,23 @@ describe('golden snapshot host scripts', () => {
       expect(script).toContain('crash_dump_dirs=(/var/crash /var/lib/systemd/coredump)');
       expect(script).toContain('find -P "$crash_dir" -mindepth 1 -print -quit');
     }
+  });
+
+  it('rejects a validation clone with baked matrix linger state before activation', async () => {
+    const activationSource = await readFile(activatePath, 'utf8');
+    const preflight = activationSource.indexOf('set_activation_stage activation_preflight_runtime_state');
+    const lingerMarker = activationSource.indexOf('/var/lib/systemd/linger/matrix', preflight);
+    const lingerState = activationSource.indexOf('loginctl show-user matrix --property=Linger --value');
+    const userManager = activationSource.indexOf('systemctl is-active --quiet "user@${matrix_uid}.service"');
+    const runtimeSetup = activationSource.indexOf('set_activation_stage activation_runtime_setup');
+
+    expect(preflight).toBeGreaterThan(-1);
+    expect(lingerState).toBeGreaterThan(preflight);
+    expect(lingerMarker).toBeGreaterThan(preflight);
+    expect(userManager).toBeGreaterThan(lingerState);
+    expect(userManager).toBeGreaterThan(lingerMarker);
+    expect(runtimeSetup).toBeGreaterThan(userManager);
+    expect(activationSource).toContain('golden snapshot inherited matrix linger state found');
   });
 
   it('emits schema-valid sentinel digests when validation identity files are missing', async () => {


### PR DESCRIPTION
## Summary

- remove the `matrix` linger marker and quiesce its user manager before golden snapshot sanitation
- reject validation clones that still contain baked linger state or an active `user@matrix` manager
- defensively quiesce inherited `matrix` processes before customer cloud-init changes the cloned home directory
- fail closed if the user processes do not stop within the bounded drain window

## Root cause

Golden activation enables linger to validate the user-systemd terminal runtime. The sanitizer previously left `/var/lib/systemd/linger/matrix` behind. A clone therefore started `systemd --user` for `matrix` before cloud-init, and `usermod -d /home/matrix/home matrix` aborted because that user owned a live process. Restore, gateway startup, and registration never ran.

## Tests

- TDD red: the synthetic sanitized root retained `/var/lib/systemd/linger/matrix`
- TDD red: sanitizer source did not stop inherited linger/user-manager state
- TDD red: customer cloud-init changed the home without draining inherited user processes
- TDD red: validation activation accepted baked linger state
- `bun run test tests/platform/golden-snapshot-host-scripts.test.ts tests/platform/customer-vps-cloud-init.test.ts` (53 passed)
- `bun run test tests/platform/golden-snapshot-*.test.ts tests/platform/host-bundle-snapshot-workflow.test.ts tests/platform/customer-vps-cloud-init.test.ts` (294 passed)
- `bun run typecheck`
- `bun run check:patterns` (0 violations)
- `bash -n` for sanitizer, activation, and validation scripts
- `git diff --check`

## Review / monitoring

- [ ] Trusted Greptile review reaches 5/5 on the current head
- [ ] Add `ready-for-ci` only after Greptile 5/5
- [ ] All triggered CI checks pass
- [ ] Human approval before merge

## Invariants

- **Source of truth:** the sanitizer evidence records forbidden-state removal; validation activation independently checks on-host linger and user-manager state; customer cloud-init remains authoritative for clone-specific home setup.
- **Lock / transaction scope:** none; this changes host boot/sanitization scripts and their contract tests only.
- **Acceptable orphan states:** sanitation and clone boot fail closed with coarse errors when `matrix` processes survive the bounded drain. No snapshot is accepted and no customer restore is skipped.
- **Auth source of truth:** unchanged; no endpoint, credential, or authorization behavior changes.
- **Deferred scope:** rebuilding and enabling production golden snapshots, rollout selection, and disposal of the protected diagnostic VPS remain separate operator-authorized actions. No public docs change is needed because this restores the existing provisioning contract without changing user-facing behavior.
