### PR TITLE
fix(onboarding): avoid false provisioning timeouts

### DIFF
--- a/packages/platform/src/app-session-routes.ts
+++ b/packages/platform/src/app-session-routes.ts
@@ -197,14 +197,17 @@ export function createAppSessionRoutes(opts: {
           ? checkoutAttempt.developerTools
           : undefined
       );
-      const provisioned = await opts.customerVpsService.provision({
-        handle: identity.handle,
-        clerkUserId: result.userId,
-        runtimeSlot: parsed.data.runtime,
-        ...(developerTools ? { developerTools } : {}),
-        ...(parsed.data.serverType ? { serverType: parsed.data.serverType } : {}),
-        ...(parsed.data.location ? { location: parsed.data.location } : {}),
-      });
+      const provisioned = await opts.customerVpsService.provision(
+        {
+          handle: identity.handle,
+          clerkUserId: result.userId,
+          runtimeSlot: parsed.data.runtime,
+          ...(developerTools ? { developerTools } : {}),
+          ...(parsed.data.serverType ? { serverType: parsed.data.serverType } : {}),
+          ...(parsed.data.location ? { location: parsed.data.location } : {}),
+        },
+        { dispatch: 'detached' },
+      );
       await opts.ensureProvisionedPlatformUser(opts.db, {
         clerkUserId: result.userId,
         handle: identity.handle,

--- a/packages/platform/src/auth-pages.ts
+++ b/packages/platform/src/auth-pages.ts
@@ -1128,6 +1128,11 @@ export function getAuthPage(
         })
         .catch(function(err) {
           console.error('[matrix] Runtime provisioning failed', err instanceof Error ? err.name : String(typeof err));
+          if (err && (err.name === 'AbortError' || err.name === 'TimeoutError')) {
+            billingConfirmationPolls = 0;
+            continueWithClerkSession(true);
+            return;
+          }
           showProvisionRetryError();
         });
     }

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -109,6 +109,10 @@ export interface ProvisionResponse {
   etaSeconds: number;
 }
 
+export interface ProvisionOptions {
+  dispatch?: 'wait' | 'detached';
+}
+
 export interface RegisterResponse {
   registered: true;
   status: 'running';
@@ -164,7 +168,7 @@ export interface DeployTarget {
 }
 
 export interface CustomerVpsService {
-  provision(input: ProvisionRequest): Promise<ProvisionResponse>;
+  provision(input: ProvisionRequest, options?: ProvisionOptions): Promise<ProvisionResponse>;
   provisionPreview(input: PreviewProvisionInput): Promise<ProvisionResponse>;
   register(token: string | undefined, input: RegisterRequest): Promise<RegisterResponse>;
   recover(input: RecoverRequest): Promise<RecoverResponse>;
@@ -189,6 +193,7 @@ export interface CustomerVpsServiceDeps {
   now?: () => Date;
   provisioningJobIdFactory?: () => string;
   enqueueProvisioningJob?: (db: PlatformDB, job: NewProvisioningJob) => Promise<void>;
+  scheduleProvisioningDispatch?: (dispatch: () => Promise<void>) => void;
   fetchDispatcher?: import('undici').Dispatcher;
   resolveBillingEntitlement?: (
     db: PlatformDB,
@@ -558,6 +563,8 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     }
   }
   const enqueueProvisioningJob = deps.enqueueProvisioningJob ?? insertProvisioningJob;
+  const scheduleProvisioningDispatch = deps.scheduleProvisioningDispatch
+    ?? ((dispatch: () => Promise<void>) => queueMicrotask(() => { void dispatch(); }));
   const tokenFactory = deps.tokenFactory ?? createRegistrationToken;
   const postgresPasswordFactory = deps.postgresPasswordFactory ?? (() => randomBytes(24).toString('base64url'));
   const now = deps.now ?? (() => new Date());
@@ -1556,9 +1563,33 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     }
   }
 
+  async function dispatchProvisioningJobForRequest(
+    jobId: string,
+    dispatch: NonNullable<ProvisionOptions['dispatch']>,
+  ): Promise<void> {
+    if (dispatch === 'wait') {
+      await dispatchProvisioningJobBestEffort(jobId);
+      return;
+    }
+    try {
+      scheduleProvisioningDispatch(async () => {
+        try {
+          await dispatchProvisioningJobBestEffort(jobId);
+        } catch (err: unknown) {
+          logCustomerVpsError('detached provisioning job dispatch failed', err);
+        }
+      });
+    } catch (err: unknown) {
+      // The job is durable and the reconciliation worker will claim it even if
+      // this best-effort low-latency kick cannot be scheduled in this process.
+      logCustomerVpsError('detached provisioning job scheduling failed', err);
+    }
+  }
+
   async function provision(
     input: ProvisionRequest | PreviewProvisionRequest,
     provisioningClass: UserMachineProvisioningClass,
+    dispatch: NonNullable<ProvisionOptions['dispatch']>,
   ): Promise<ProvisionResponse> {
     const request = {
       ...input,
@@ -1608,7 +1639,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       const reconciled = await reconcilePreviewAccess(deps.db, existingBeforeBundleResolve);
       const existingJob = await getProvisioningJobByMachineId(deps.db, existingBeforeBundleResolve.machineId);
       if (existingJob && (existingJob.status === 'queued' || existingJob.status === 'running')) {
-        await dispatchProvisioningJobBestEffort(existingJob.jobId);
+        await dispatchProvisioningJobForRequest(existingJob.jobId, dispatch);
       }
       return activeProvisionResponse(reconciled, deps.config.provisionEtaSeconds);
     }
@@ -1762,7 +1793,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         const reconciled = await reconcilePreviewAccess(deps.db, concurrent);
         const concurrentJob = await getProvisioningJobByMachineId(deps.db, concurrent.machineId);
         if (concurrentJob && (concurrentJob.status === 'queued' || concurrentJob.status === 'running')) {
-          await dispatchProvisioningJobBestEffort(concurrentJob.jobId);
+          await dispatchProvisioningJobForRequest(concurrentJob.jobId, dispatch);
         }
         return activeProvisionResponse(reconciled, deps.config.provisionEtaSeconds);
       }
@@ -1771,12 +1802,12 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     if (provisionRow.existing) {
       const existingJob = await getProvisioningJobByMachineId(deps.db, provisionRow.existing.machineId);
       if (existingJob && (existingJob.status === 'queued' || existingJob.status === 'running')) {
-        await dispatchProvisioningJobBestEffort(existingJob.jobId);
+        await dispatchProvisioningJobForRequest(existingJob.jobId, dispatch);
       }
       return activeProvisionResponse(provisionRow.existing, deps.config.provisionEtaSeconds);
     }
 
-    await dispatchProvisioningJobBestEffort(jobId);
+    await dispatchProvisioningJobForRequest(jobId, dispatch);
 
     return {
       machineId,
@@ -1786,10 +1817,10 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
   }
 
   return {
-    async provision(input) {
+    async provision(input, options) {
       return withLocalProvisionLock(
         `${input.clerkUserId}:${input.runtimeSlot ?? 'primary'}`,
-        () => provision(input, 'customer'),
+        () => provision(input, 'customer', options?.dispatch ?? 'wait'),
       );
     },
 
@@ -1797,7 +1828,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       const request = PreviewProvisionRequestSchema.parse(input);
       return withLocalProvisionLock(
         `${request.clerkUserId}:${request.runtimeSlot}`,
-        () => provision(request, 'preview'),
+        () => provision(request, 'preview', 'wait'),
       );
     },
 

--- a/shell/src/components/BootSequence.tsx
+++ b/shell/src/components/BootSequence.tsx
@@ -16,6 +16,7 @@ import { MatrixBootMark } from "@/components/MatrixBootMark";
 import {
   PROVISIONING_RETRY_ERROR,
   isAcceptedProvisionResponse,
+  isAmbiguousProvisioningTimeout,
 } from "@/lib/provisioning-handoff";
 import type { DeveloperToolId } from "@/components/onboarding/developer-tools";
 import { Settings } from "@/components/Settings";
@@ -185,6 +186,11 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
       finishProvision();
     } catch (err: unknown) {
       console.warn("[boot] provision start failed", err instanceof Error ? err.name : typeof err);
+      if (isAmbiguousProvisioningTimeout(err)) {
+        finishProvision();
+        refreshJourney();
+        return;
+      }
       finishProvision(PROVISIONING_RETRY_ERROR);
     }
   }

--- a/shell/src/components/BootSequence.tsx
+++ b/shell/src/components/BootSequence.tsx
@@ -25,7 +25,6 @@ import { navigateForOnboarding } from "@/lib/onboarding-navigation";
 // Phases where the shell (Desktop) takes over — first-run UI is owned by Desktop,
 // ready is the running shell. BootSequence only renders the billing/build steps.
 const PASSTHROUGH_PHASES = new Set<JourneyState["phase"]>(["first_run", "ready"]);
-const AMBIGUOUS_PROVISIONING_POLL_MS = 1_000;
 const AMBIGUOUS_PROVISIONING_WINDOW_MS = 30_000;
 
 const STAGE_LABEL: Record<string, string> = {
@@ -145,10 +144,13 @@ export function BootSequence({
 
 function BootSequenceInner({ children }: { children: ReactNode }) {
   const { isLoaded, isSignedIn, getToken } = useAuth();
-  const { state, status, refreshJourney } = useJourney({ enabled: isLoaded && isSignedIn });
+  const [provisioningOutcomeAmbiguous, setProvisioningOutcomeAmbiguous] = useState(false);
+  const { state, status, refreshJourney } = useJourney({
+    enabled: isLoaded && isSignedIn,
+    keepPolling: provisioningOutcomeAmbiguous,
+  });
   const [working, setWorking] = useState(false);
   const [installError, setInstallError] = useState<string | null>(null);
-  const [provisioningOutcomeAmbiguous, setProvisioningOutcomeAmbiguous] = useState(false);
 
   useEffect(() => {
     if (!provisioningOutcomeAmbiguous) return;
@@ -158,17 +160,15 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
       setWorking(false);
       return;
     }
-    const pollTimer = window.setInterval(refreshJourney, AMBIGUOUS_PROVISIONING_POLL_MS);
     const timeoutTimer = window.setTimeout(() => {
       setProvisioningOutcomeAmbiguous(false);
       setWorking(false);
       setInstallError(PROVISIONING_RETRY_ERROR);
     }, AMBIGUOUS_PROVISIONING_WINDOW_MS);
     return () => {
-      window.clearInterval(pollTimer);
       window.clearTimeout(timeoutTimer);
     };
-  }, [provisioningOutcomeAmbiguous, refreshJourney, state?.phase]);
+  }, [provisioningOutcomeAmbiguous, state?.phase]);
 
   async function startProvision(developerTools: DeveloperToolId[]): Promise<void> {
     setWorking(true);

--- a/shell/src/components/BootSequence.tsx
+++ b/shell/src/components/BootSequence.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
 import { palette as c, fonts, lightFg } from "@matrix-os/brand";
 import {
@@ -25,6 +25,8 @@ import { navigateForOnboarding } from "@/lib/onboarding-navigation";
 // Phases where the shell (Desktop) takes over — first-run UI is owned by Desktop,
 // ready is the running shell. BootSequence only renders the billing/build steps.
 const PASSTHROUGH_PHASES = new Set<JourneyState["phase"]>(["first_run", "ready"]);
+const AMBIGUOUS_PROVISIONING_POLL_MS = 1_000;
+const AMBIGUOUS_PROVISIONING_WINDOW_MS = 30_000;
 
 const STAGE_LABEL: Record<string, string> = {
   creating_server: "Creating your server",
@@ -146,6 +148,27 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
   const { state, status, refreshJourney } = useJourney({ enabled: isLoaded && isSignedIn });
   const [working, setWorking] = useState(false);
   const [installError, setInstallError] = useState<string | null>(null);
+  const [provisioningOutcomeAmbiguous, setProvisioningOutcomeAmbiguous] = useState(false);
+
+  useEffect(() => {
+    if (!provisioningOutcomeAmbiguous) return;
+    if (state?.phase !== "install_choices_required") {
+      // react-doctor-disable-next-line react-doctor/no-cascading-set-state -- authoritative journey state has resolved the previously ambiguous request outcome.
+      setProvisioningOutcomeAmbiguous(false);
+      setWorking(false);
+      return;
+    }
+    const pollTimer = window.setInterval(refreshJourney, AMBIGUOUS_PROVISIONING_POLL_MS);
+    const timeoutTimer = window.setTimeout(() => {
+      setProvisioningOutcomeAmbiguous(false);
+      setWorking(false);
+      setInstallError(PROVISIONING_RETRY_ERROR);
+    }, AMBIGUOUS_PROVISIONING_WINDOW_MS);
+    return () => {
+      window.clearInterval(pollTimer);
+      window.clearTimeout(timeoutTimer);
+    };
+  }, [provisioningOutcomeAmbiguous, refreshJourney, state?.phase]);
 
   async function startProvision(developerTools: DeveloperToolId[]): Promise<void> {
     setWorking(true);
@@ -187,7 +210,7 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
     } catch (err: unknown) {
       console.warn("[boot] provision start failed", err instanceof Error ? err.name : typeof err);
       if (isAmbiguousProvisioningTimeout(err)) {
-        finishProvision();
+        setProvisioningOutcomeAmbiguous(true);
         refreshJourney();
         return;
       }

--- a/shell/src/hooks/useJourney.ts
+++ b/shell/src/hooks/useJourney.ts
@@ -51,12 +51,15 @@ const ACTIVE_PHASES = new Set<JourneyPhase>(["payment_settling", "provisioning"]
 
 /**
  * Polls GET /api/journey for the signed-in user. Polls only while the phase is
- * still moving (settling/provisioning) and stops in terminal phases; on a 503 or
- * network failure it reports `unreachable` rather than guessing a phase. The
- * request is same-origin (proxied to the platform) and Clerk-bearer authed.
+ * still moving (settling/provisioning), or while a caller explicitly requests
+ * reconciliation polling, and stops in terminal phases otherwise. Each poll is
+ * scheduled only after the preceding request settles. On a 503 or network
+ * failure it reports `unreachable` rather than guessing a phase. The request is
+ * same-origin (proxied to the platform) and Clerk-bearer authed.
  */
-export function useJourney(options: { enabled?: boolean } = {}): UseJourneyResult {
+export function useJourney(options: { enabled?: boolean; keepPolling?: boolean } = {}): UseJourneyResult {
   const enabled = options.enabled ?? true;
+  const keepPolling = options.keepPolling ?? false;
   const { isLoaded, isSignedIn, getToken } = useAuth();
   const [state, setState] = useState<JourneyState | null>(null);
   const [status, setStatus] = useState<JourneyStatus>("loading");
@@ -107,7 +110,7 @@ export function useJourney(options: { enabled?: boolean } = {}): UseJourneyResul
         if (disposed) return;
         setState(body);
         setStatus("ready");
-        if (ACTIVE_PHASES.has(body.phase)) scheduleNext(ACTIVE_POLL_MS);
+        if (keepPolling || ACTIVE_PHASES.has(body.phase)) scheduleNext(ACTIVE_POLL_MS);
       } catch (err: unknown) {
         if (disposed) return;
         // Network/timeout/abort -> unreachable; keep trying while mounted.
@@ -133,7 +136,7 @@ export function useJourney(options: { enabled?: boolean } = {}): UseJourneyResul
       if (pollTimer !== undefined) window.clearTimeout(pollTimer);
       inFlightController?.abort();
     };
-  }, [enabled, isLoaded, isSignedIn, getToken, nonce]);
+  }, [enabled, isLoaded, isSignedIn, getToken, keepPolling, nonce]);
 
   return { state, status, refreshJourney };
 }

--- a/shell/src/lib/provisioning-handoff.ts
+++ b/shell/src/lib/provisioning-handoff.ts
@@ -1,5 +1,11 @@
 export const PROVISIONING_RETRY_ERROR = "Matrix could not start building this VPS. Try again.";
 
+export function isAmbiguousProvisioningTimeout(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("name" in error)) return false;
+  const name = (error as { name?: unknown }).name;
+  return name === "AbortError" || name === "TimeoutError";
+}
+
 export async function isAcceptedProvisionResponse(response: Response): Promise<boolean> {
   if (response.ok) return true;
   if (response.status !== 409) return false;

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -21,6 +21,7 @@ import { createCustomerVpsService } from '../../packages/platform/src/customer-v
 import { loadCustomerVpsConfig } from '../../packages/platform/src/customer-vps-config.js';
 import { hashRegistrationToken } from '../../packages/platform/src/customer-vps-auth.js';
 import { CustomerVpsError } from '../../packages/platform/src/customer-vps-errors.js';
+import { getProvisioningJobByMachineId } from '../../packages/platform/src/customer-vps-provisioning-jobs.js';
 import { ProvisionRequestSchema } from '../../packages/platform/src/customer-vps-schema.js';
 import { isPreviewMachine } from '../../packages/platform/src/customer-vps-preview.js';
 import type { BillingEntitlement } from '../../packages/platform/src/billing.js';
@@ -238,6 +239,55 @@ describe('platform/customer-vps', () => {
     expect(row?.developerTools).toEqual(['codex', 'pi']);
     const createInput = vi.mocked(hetzner.createServer).mock.calls[0]?.[0];
     expect(createInput?.userData).toContain("MATRIX_DEVELOPER_TOOLS='codex pi'");
+  });
+
+  it('returns after durable enqueue when provider dispatch is detached', async () => {
+    let dispatch!: () => Promise<void>;
+    let finishCreate!: (server: Awaited<ReturnType<ReturnType<typeof createMockHetznerClient>['createServer']>>) => void;
+    const createStarted = Promise.withResolvers<void>();
+    const createFinished = new Promise<Awaited<ReturnType<ReturnType<typeof createMockHetznerClient>['createServer']>>>((resolve) => {
+      finishCreate = resolve;
+    });
+    const { service, hetzner } = createService({
+      hetzner: {
+        createServer: vi.fn(async () => {
+          createStarted.resolve();
+          return createFinished;
+        }),
+      },
+      scheduleProvisioningDispatch: (scheduled) => {
+        dispatch = scheduled;
+      },
+    });
+
+    const response = await service.provision(
+      { clerkUserId: 'user_123', handle: 'alice' },
+      { dispatch: 'detached' },
+    );
+    expect(hetzner.createServer).not.toHaveBeenCalled();
+    await expect(getProvisioningJobByMachineId(db, response.machineId)).resolves.toMatchObject({
+      status: 'queued',
+    });
+
+    const dispatching = dispatch();
+    await createStarted.promise;
+    finishCreate({
+      id: 123456,
+      status: 'running',
+      publicIPv4: '203.0.113.10',
+      publicIPv6: '2001:db8::1',
+    });
+    await dispatching;
+
+    expect(response).toEqual({
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      status: 'provisioning',
+      etaSeconds: 90,
+    });
+    expect(hetzner.createServer).toHaveBeenCalledOnce();
+    await expect(getActiveUserMachineByClerkId(db, 'user_123')).resolves.toMatchObject({
+      hetznerServerId: 123456,
+    });
   });
 
   it('preserves an intentional empty developer tool selection', async () => {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -34,6 +34,8 @@ import {
   stubOrchestrator,
 } from "./proxy-routing-test-utils.js";
 
+const DETACHED_PROVISION_OPTIONS = { dispatch: "detached" } as const;
+
 describe("platform proxy routing", () => {
   let db: PlatformDB;
 
@@ -1921,7 +1923,7 @@ describe("platform proxy routing", () => {
       handle: "newuser",
       clerkUserId: "user_new",
       runtimeSlot: "primary",
-    });
+    }, DETACHED_PROVISION_OPTIONS);
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.clerk.com/v1/users/user_new",
       expect.objectContaining({
@@ -1995,7 +1997,7 @@ describe("platform proxy routing", () => {
       developerTools: ["opencode", "pi"],
       serverType: "cpx22",
       location: "hil",
-    });
+    }, DETACHED_PROVISION_OPTIONS);
   });
 
   it("falls back to settling checkout-attempt developer tools when provisioning after payment", async () => {
@@ -2060,7 +2062,7 @@ describe("platform proxy routing", () => {
       clerkUserId: "user_paid_tools",
       runtimeSlot: "primary",
       developerTools: ["claude-code"],
-    });
+    }, DETACHED_PROVISION_OPTIONS);
   });
 
   it("does not block hosted runtime provisioning when Clerk returns an empty avatar URL", async () => {
@@ -2109,7 +2111,7 @@ describe("platform proxy routing", () => {
       handle: "newuser",
       clerkUserId: "user_new_avatar",
       runtimeSlot: "primary",
-    });
+    }, DETACHED_PROVISION_OPTIONS);
     await expect(getPlatformUserByClerkId(db, "user_new_avatar")).resolves.toMatchObject({
       clerkId: "user_new_avatar",
       handle: "newuser",
@@ -2170,7 +2172,7 @@ describe("platform proxy routing", () => {
       handle: "new",
       clerkUserId: "user_new",
       runtimeSlot: "primary",
-    });
+    }, DETACHED_PROVISION_OPTIONS);
     await expect(getPlatformUserByClerkId(db, "user_new")).resolves.toMatchObject({
       clerkId: "user_new",
       handle: "new",
@@ -2222,7 +2224,7 @@ describe("platform proxy routing", () => {
       handle: "newuser",
       clerkUserId: "user_new",
       runtimeSlot: "primary",
-    });
+    }, DETACHED_PROVISION_OPTIONS);
     await expect(getPlatformUserByClerkId(db, "user_new")).resolves.toMatchObject({
       handle: "newuser",
       displayName: "New User",
@@ -2274,7 +2276,7 @@ describe("platform proxy routing", () => {
       handle: "very-long-username-with-hyphen",
       clerkUserId: "user_new",
       runtimeSlot: "primary",
-    });
+    }, DETACHED_PROVISION_OPTIONS);
   });
 
   it("blocks signed-in runtime provisioning before Stripe checkout creates an entitlement", async () => {
@@ -2378,7 +2380,7 @@ describe("platform proxy routing", () => {
       handle: fallbackHandle,
       clerkUserId: "user_new",
       runtimeSlot: "primary",
-    });
+    }, DETACHED_PROVISION_OPTIONS);
   });
 
   it("falls back instead of claiming another user's active handle in another slot", async () => {
@@ -2440,7 +2442,7 @@ describe("platform proxy routing", () => {
       handle: fallbackHandle,
       clerkUserId: "user_new",
       runtimeSlot: "primary",
-    });
+    }, DETACHED_PROVISION_OPTIONS);
   });
 
   it("keeps a same-user active machine handle even with a stale legacy container row", async () => {
@@ -2500,7 +2502,7 @@ describe("platform proxy routing", () => {
       handle: "alice",
       clerkUserId: "user_new",
       runtimeSlot: "primary",
-    });
+    }, DETACHED_PROVISION_OPTIONS);
   });
 
   it("keeps a same-user handle when another runtime slot already uses it", async () => {
@@ -2561,7 +2563,7 @@ describe("platform proxy routing", () => {
       handle: "alice",
       clerkUserId: "user_new",
       runtimeSlot: "primary",
-    });
+    }, DETACHED_PROVISION_OPTIONS);
   });
 
   it("falls back instead of claiming another user's legacy container handle", async () => {
@@ -2610,7 +2612,7 @@ describe("platform proxy routing", () => {
       handle: fallbackHandle,
       clerkUserId: "user_new",
       runtimeSlot: "primary",
-    });
+    }, DETACHED_PROVISION_OPTIONS);
   });
 
   it("continues signed-in auth pages through a Clerk token exchange", async () => {
@@ -2689,6 +2691,8 @@ describe("platform proxy routing", () => {
     expect(html).not.toContain("Loading your Matrix computer");
     expect(html).not.toContain("function pollProvisioningSession()");
     expect(html).toContain("continueWithClerkSession(true);");
+    expect(html).toContain("if (err && (err.name === 'AbortError' || err.name === 'TimeoutError')) {");
+    expect(html).toContain("billingConfirmationPolls = 0;\n            continueWithClerkSession(true);\n            return;");
     expect(html).toContain("setProvisionControls(true, null);");
     expect(html).toContain("setProvisionControls(false, provisioningRetryError);");
     expect(html).not.toContain("ask the operator to provision this account");

--- a/tests/shell/boot-sequence.test.tsx
+++ b/tests/shell/boot-sequence.test.tsx
@@ -186,6 +186,45 @@ describe("BootSequence", () => {
     expect(screen.queryByText(/Starting|Preparing|Loading your Matrix computer/i)).toBeNull();
   });
 
+  it("reconciles journey state instead of reporting failure after an ambiguous provisioning timeout", async () => {
+    let provisionTimedOut = false;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/journey")) {
+        const state: JourneyState = provisionTimedOut
+          ? {
+              phase: "provisioning",
+              detail: "Building your Matrix computer…",
+              nextAction: { kind: "wait" },
+              progress: { stage: "creating_server", startedAt: "2026-08-15T11:04:17.965Z" },
+            }
+          : {
+              phase: "install_choices_required",
+              detail: "Choose default installs before building your Matrix computer.",
+              nextAction: { kind: "choose_default_installs" },
+            };
+        return new Response(JSON.stringify(state), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === "/api/auth/provision-runtime") {
+        provisionTimedOut = true;
+        throw new DOMException("The operation timed out", "TimeoutError");
+      }
+      return new Response("{}", { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<BootSequence><div data-testid="shell">SHELL</div></BootSequence>);
+    await answerAcquisitionSource();
+    fireEvent.click(await screen.findByRole("button", { name: "Build VPS" }));
+
+    expect(await screen.findByText("Building your Matrix computer")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(fetchMock.mock.calls.filter(([url]) => String(url).includes("/api/journey")).length).toBeGreaterThan(1);
+  });
+
   it("accepts only a recognized provisioning conflict before the immediate session handoff", async () => {
     const journeyState: JourneyState = {
       phase: "install_choices_required",

--- a/tests/shell/boot-sequence.test.tsx
+++ b/tests/shell/boot-sequence.test.tsx
@@ -188,11 +188,11 @@ describe("BootSequence", () => {
 
   it("reconciles journey state instead of reporting failure after an ambiguous provisioning timeout", async () => {
     let provisionTimedOut = false;
-    let postTimeoutJourneyCalls = 0;
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    let staleRefreshCompleted = false;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/api/journey")) {
-        const state: JourneyState = provisionTimedOut && postTimeoutJourneyCalls++ > 0
+        const state: JourneyState = provisionTimedOut && staleRefreshCompleted
           ? {
               phase: "provisioning",
               detail: "Building your Matrix computer…",
@@ -204,6 +204,18 @@ describe("BootSequence", () => {
               detail: "Choose default installs before building your Matrix computer.",
               nextAction: { kind: "choose_default_installs" },
             };
+        if (provisionTimedOut && !staleRefreshCompleted) {
+          return await new Promise<Response>((resolve, reject) => {
+            const timer = window.setTimeout(() => {
+              staleRefreshCompleted = true;
+              resolve(Response.json(state));
+            }, 1_500);
+            init?.signal?.addEventListener("abort", () => {
+              window.clearTimeout(timer);
+              reject(new DOMException("The operation was aborted", "AbortError"));
+            }, { once: true });
+          });
+        }
         return new Response(JSON.stringify(state), {
           status: 200,
           headers: { "content-type": "application/json" },
@@ -221,7 +233,7 @@ describe("BootSequence", () => {
     await answerAcquisitionSource();
     fireEvent.click(await screen.findByRole("button", { name: "Build VPS" }));
 
-    expect(await screen.findByText("Building your Matrix computer", {}, { timeout: 3_000 })).toBeTruthy();
+    expect(await screen.findByText("Building your Matrix computer", {}, { timeout: 8_000 })).toBeTruthy();
     expect(screen.queryByRole("alert")).toBeNull();
     expect(fetchMock.mock.calls.filter(([url]) => String(url).includes("/api/journey")).length).toBeGreaterThan(1);
   });

--- a/tests/shell/boot-sequence.test.tsx
+++ b/tests/shell/boot-sequence.test.tsx
@@ -188,10 +188,11 @@ describe("BootSequence", () => {
 
   it("reconciles journey state instead of reporting failure after an ambiguous provisioning timeout", async () => {
     let provisionTimedOut = false;
+    let postTimeoutJourneyCalls = 0;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes("/api/journey")) {
-        const state: JourneyState = provisionTimedOut
+        const state: JourneyState = provisionTimedOut && postTimeoutJourneyCalls++ > 0
           ? {
               phase: "provisioning",
               detail: "Building your Matrix computer…",
@@ -220,7 +221,7 @@ describe("BootSequence", () => {
     await answerAcquisitionSource();
     fireEvent.click(await screen.findByRole("button", { name: "Build VPS" }));
 
-    expect(await screen.findByText("Building your Matrix computer")).toBeTruthy();
+    expect(await screen.findByText("Building your Matrix computer", {}, { timeout: 3_000 })).toBeTruthy();
     expect(screen.queryByRole("alert")).toBeNull();
     expect(fetchMock.mock.calls.filter(([url]) => String(url).includes("/api/journey")).length).toBeGreaterThan(1);
   });


### PR DESCRIPTION
## Summary

- Return `202` after the customer VPS machine and provisioning job are durably queued instead of waiting for Hetzner provider work.
- Keep operator and preview provisioning synchronous by default; only the authenticated signup route opts into detached dispatch.
- Reconcile authoritative journey state after an ambiguous browser timeout rather than showing a false provisioning failure.
- Preserve the inline auth-page fallback behavior by continuing through the Clerk session handoff after the same timeout class.

## Why

Provider creation can legitimately exceed the browser's 10-second timeout. The request then appeared to fail even though the durable job continued and the VPS successfully registered. This separates request acknowledgement from provider execution while retaining the existing durable reconciliation worker as the recovery path.

## Invariants

- Source of truth remains the existing `user_machines` row plus durable `provisioning_jobs` record.
- Existing provisioning transaction, per-user lock, idempotent job claim, and cleanup behavior are unchanged.
- A detached scheduling failure leaves a queued job for the existing reconciliation worker; no provider create occurs before durable enqueue.
- Authentication and customer-facing error redaction are unchanged.
- No deployment, provisioning, secret, database, or infrastructure mutation is included.

## Validation

- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing repository warnings only)
- 334 affected platform, customer-VPS, deployment, and shell tests
- Focused durable-enqueue and authenticated route regressions

Shell ESLint was also attempted, but current `main` dependency resolution cannot load `next/dist/compiled/babel/eslint-parser`; CI remains the authoritative lint environment.

## Review/Monitoring

- Await trusted Greptile `5/5` on the exact PR head.
- Add `ready-for-ci` only after that result, then require all triggered CI to pass.
- Do not merge without explicit approval.
