### PR TITLE
fix(desktop): contain terminal panes and center dialogs

### DIFF
--- a/desktop/src/renderer/src/design/index.css
+++ b/desktop/src/renderer/src/design/index.css
@@ -188,6 +188,21 @@ textarea,
   animation: operator-fade-in var(--duration-base) var(--ease-out);
 }
 
+/* Dialog positioning also uses transform, so its entrance must not animate
+   transform or the content visibly jumps when the animation releases it. */
+@keyframes operator-dialog-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.dialog-fade-in {
+  animation: operator-dialog-fade-in var(--duration-base) var(--ease-out);
+}
+
 @keyframes operator-pulse {
   0%,
   100% {

--- a/desktop/src/renderer/src/design/primitives.tsx
+++ b/desktop/src/renderer/src/design/primitives.tsx
@@ -96,7 +96,7 @@ export function Dialog({
         <RadixDialog.Content
           role={role}
           aria-describedby={undefined}
-          className={`fade-in fixed left-1/2 z-50 rounded-xl border focus:outline-none ${
+          className={`dialog-fade-in fixed left-1/2 z-50 rounded-xl border focus:outline-none ${
             placement === "center" ? "" : "-translate-x-1/2"
           }`}
           style={{

--- a/desktop/src/renderer/src/features/mission-control/TabContent.tsx
+++ b/desktop/src/renderer/src/features/mission-control/TabContent.tsx
@@ -114,7 +114,11 @@ export default function TabContent() {
           <div
             key={tab.id}
             className="absolute inset-0 flex min-h-0 flex-col"
-            style={{ visibility: active ? "visible" : "hidden", zIndex: active ? 1 : 0 }}
+            style={{
+              display: active ? "flex" : "none",
+              visibility: active ? "visible" : "hidden",
+              zIndex: active ? 1 : 0,
+            }}
             aria-hidden={!active}
             // `inert` keeps keyboard focus out of cached-but-hidden panes.
             inert={!active}

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -491,7 +491,12 @@ export default function TerminalsTab() {
         );
       })}
 
-      <Dialog open={deleteTarget !== null} onClose={() => setDeleteTarget(null)} width={360}>
+      <Dialog
+        open={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        width={360}
+        placement="center"
+      >
         <div className="flex flex-col gap-3 p-4">
           <div>
             <h2 className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>

--- a/tests/desktop/hermes-conversation-index.test.tsx
+++ b/tests/desktop/hermes-conversation-index.test.tsx
@@ -161,7 +161,10 @@ describe("HermesConversationIndex", () => {
     fireEvent.click(remove);
 
     expect(openConversation).not.toHaveBeenCalled();
-    expect(screen.getByRole("alertdialog", { name: "Delete Launch plan?" })).toBeTruthy();
+    const dialog = screen.getByRole("alertdialog", { name: "Delete Launch plan?" });
+    expect(dialog.className).toContain("dialog-fade-in");
+    expect([...dialog.classList]).not.toContain("fade-in");
+    expect(dialog.style.transform).toBe("translate(-50%, -50%)");
   });
 
   it("cancels without a request and confirms only once while pending", async () => {

--- a/tests/desktop/tab-content.test.tsx
+++ b/tests/desktop/tab-content.test.tsx
@@ -55,8 +55,10 @@ describe("TabContent", () => {
     const hiddenPane = getByText("Terminal body").parentElement;
 
     expect(activePane?.hasAttribute("inert")).toBe(false);
+    expect(activePane?.style.display).toBe("flex");
     expect(hiddenPane?.hasAttribute("inert")).toBe(true);
     expect(hiddenPane?.getAttribute("aria-hidden")).toBe("true");
+    expect(hiddenPane?.style.display).toBe("none");
   });
 
   it("forwards task project slugs into the task workspace", () => {

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -407,6 +407,9 @@ describe("TerminalsTab", () => {
     fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
     expect(deleteSession).not.toHaveBeenCalled();
     expect(screen.getByText("Delete matrix-main?")).toBeTruthy();
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.style.top).toBe("50%");
+    expect(dialog.style.transform).toBe("translate(-50%, -50%)");
 
     fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
 

--- a/tests/e2e/api/conversations.e2e.test.ts
+++ b/tests/e2e/api/conversations.e2e.test.ts
@@ -80,7 +80,7 @@ describe("E2E: Conversation Management", () => {
     });
     expect(res.status).toBe(404);
     const body = await res.json();
-    expect(body.error).toBe("Not found");
+    expect(body.error).toEqual({ code: "conversation_not_found" });
   });
 
   it("conversation list shrinks after delete", async () => {


### PR DESCRIPTION
## Summary

- prevent retained inactive Desktop panes from painting through the active tab
- preserve mounted Terminal state while removing inactive panes from layout and paint
- replace transform-based dialog entrance motion with opacity-only fading
- center the Terminal session deletion confirmation in the viewport
- align the pre-existing conversation-delete E2E assertion with the structured response introduced by merged PR #1213

## Root cause

Inactive tab panes used inherited `visibility: hidden`, but Terminal descendants set
their own `visibility: visible`. CSS permits descendants to override inherited
visibility, so the retained Terminal overview continued painting underneath every
other tab.

The shared dialog entrance animation also animated `transform`, temporarily
overriding the transform used for viewport centering. When the animation ended,
the centering transform returned and the Chat confirmation visibly jumped.

## CI baseline correction

Merged PR #1213 changed missing-conversation DELETE responses from the legacy
`"Not found"` string to `{ error: { code: "conversation_not_found" } }`, but left
the repository E2E assertion on the old contract. The separate test-only commit
`03a7566f9` updates that one assertion; it does not change Gateway production code.

## Validation

- `flox activate -- bun run typecheck`
- `flox activate -- bun run check:patterns` (0 violations)
- `flox activate -- bun run test`
- `flox activate -- bun run test:e2e` (137/137 executed tests passed; 24 environment-gated tests skipped)
- `pnpm --filter desktop run build`
- real built Electron validation through CDP on port 9231
  - Terminal -> Apps / Plugins: zero visible Terminal elements and zero-size retained pane geometry
  - Terminal deletion dialog: viewport center delta `(0, 0)`
  - Chat deletion dialog: 12 animation-frame samples with position range `x=0, y=0`

## Scope

- Linear: [MAT-323](https://linear.app/matrix-os/issue/MAT-323/fix-desktop-terminal-view-bleed-through-and-confirmation-dialog-positioning)
- MAT-268 remains frozen and is not modified or depended on
- MAT-321 chat architecture work is not included
