### PR TITLE
fix(desktop): add terminal sessions to recents

### DIFF
--- a/desktop/src/renderer/src/features/mission-control/RecentViews.tsx
+++ b/desktop/src/renderer/src/features/mission-control/RecentViews.tsx
@@ -35,7 +35,9 @@ export default function RecentViews() {
   const recentViews = useTabs((state) => state.recentViews);
   const recentFilter = useTabs((state) => state.recentFilter);
   const setRecentFilter = useTabs((state) => state.setRecentFilter);
+  const tabs = useTabs((state) => state.tabs);
   const openTab = useTabs((state) => state.openTab);
+  const requestTerminalSession = useTabs((state) => state.requestTerminalSession);
   const api = useConnection((state) => state.api);
   const threads = useThreads((state) => state.threads);
   const setActiveThread = useThreads((state) => state.setActiveThread);
@@ -68,6 +70,17 @@ export default function RecentViews() {
       return;
     }
     if (recent.kind === "terminal") {
+      const nativeTab = tabs.find((tab) => tab.kind === "terminal" && tab.sessionName === recent.id);
+      if (nativeTab) {
+        openTab({ kind: "terminal", sessionName: recent.id, title: recent.label });
+        return;
+      }
+      const terminalsWorkspace = tabs.find((tab) => tab.kind === "terminals");
+      if (terminalsWorkspace) {
+        requestTerminalSession(recent.id);
+        openTab({ kind: "terminals", title: terminalsWorkspace.title });
+        return;
+      }
       openTab({ kind: "terminal", sessionName: recent.id, title: recent.label });
       return;
     }

--- a/desktop/src/renderer/src/features/mission-control/RecentViews.tsx
+++ b/desktop/src/renderer/src/features/mission-control/RecentViews.tsx
@@ -70,15 +70,15 @@ export default function RecentViews() {
       return;
     }
     if (recent.kind === "terminal") {
-      const nativeTab = tabs.find((tab) => tab.kind === "terminal" && tab.sessionName === recent.id);
-      if (nativeTab) {
-        openTab({ kind: "terminal", sessionName: recent.id, title: recent.label });
-        return;
-      }
       const terminalsWorkspace = tabs.find((tab) => tab.kind === "terminals");
       if (terminalsWorkspace) {
         requestTerminalSession(recent.id);
         openTab({ kind: "terminals", title: terminalsWorkspace.title });
+        return;
+      }
+      const nativeTab = tabs.find((tab) => tab.kind === "terminal" && tab.sessionName === recent.id);
+      if (nativeTab) {
+        openTab({ kind: "terminal", sessionName: recent.id, title: recent.label });
         return;
       }
       openTab({ kind: "terminal", sessionName: recent.id, title: recent.label });

--- a/desktop/src/renderer/src/features/mission-control/TabContent.tsx
+++ b/desktop/src/renderer/src/features/mission-control/TabContent.tsx
@@ -52,7 +52,7 @@ function TabPane({ tab, active }: { tab: Tab; active: boolean }) {
     case "chat":
       return <ChatTab />;
     case "terminals":
-      return <TerminalsTab />;
+      return <TerminalsTab active={active} />;
     case "files":
       return <FilesWorkspace />;
     case "apps":

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -92,7 +92,7 @@ function normalizeBusyNames(names: string[]): string[] {
 }
 
 // react-doctor-disable-next-line react-doctor/no-giant-component, react-doctor/prefer-useReducer -- TerminalsTab is the cohesive shell-session workspace: network load/create, selection, rename, delete confirmation, search, and drag refs are independent UI concerns. A reducer would couple unrelated state transitions without reducing render risk; extracting subcomponents below keeps the row/empty states isolated.
-export default function TerminalsTab() {
+export default function TerminalsTab({ active = true }: { active?: boolean }) {
   const api = useConnection((s) => s.api);
   const runtimeSlot = useConnection((s) => s.runtimeSlot);
   const shells = useShellSessions((s) => s.sessions);
@@ -210,7 +210,8 @@ export default function TerminalsTab() {
   useEffect(() => {
     if (!terminalSessionRequest) return;
     const requestedShell = shells.find((shell) => shell.name === terminalSessionRequest.sessionName);
-    if (requestedShell) showShellDetail(requestedShell);
+    if (!requestedShell) return;
+    showShellDetail(requestedShell);
     consumeTerminalSessionRequest(terminalSessionRequest.requestId);
   }, [consumeTerminalSessionRequest, shells, showShellDetail, terminalSessionRequest]);
 
@@ -497,7 +498,7 @@ export default function TerminalsTab() {
                 {shellStatusLabel(shell)}
               </span>
             </header>
-            <TerminalView sessionName={sessionName} active={liveSessionName === sessionName} />
+            <TerminalView sessionName={sessionName} active={active && liveSessionName === sessionName} />
           </section>
         );
       })}

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -99,6 +99,7 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
   const loading = useShellSessions((s) => s.loading);
   const creating = useShellSessions((s) => s.creating);
   const error = useShellSessions((s) => s.error);
+  const loadSequence = useShellSessions((s) => s.loadSequence);
   const load = useShellSessions((s) => s.load);
   const create = useShellSessions((s) => s.create);
   const deleteSession = useShellSessions((s) => s.deleteSession);
@@ -210,10 +211,23 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
   useEffect(() => {
     if (!terminalSessionRequest) return;
     const requestedShell = shells.find((shell) => shell.name === terminalSessionRequest.sessionName);
-    if (!requestedShell) return;
+    if (!requestedShell) {
+      if (!loading && !error && loadSequence > 0) {
+        consumeTerminalSessionRequest(terminalSessionRequest.requestId);
+      }
+      return;
+    }
     showShellDetail(requestedShell);
     consumeTerminalSessionRequest(terminalSessionRequest.requestId);
-  }, [consumeTerminalSessionRequest, shells, showShellDetail, terminalSessionRequest]);
+  }, [
+    consumeTerminalSessionRequest,
+    error,
+    loading,
+    loadSequence,
+    shells,
+    showShellDetail,
+    terminalSessionRequest,
+  ]);
 
   const showShellList = () => {
     setSelectedName(null);

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -212,7 +212,7 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
     if (!terminalSessionRequest) return;
     const requestedShell = shells.find((shell) => shell.name === terminalSessionRequest.sessionName);
     if (!requestedShell) {
-      if (!loading && !error && loadSequence > 0) {
+      if (!loading && !creating && !error && loadSequence > 0) {
         consumeTerminalSessionRequest(terminalSessionRequest.requestId);
       }
       return;
@@ -221,6 +221,7 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
     consumeTerminalSessionRequest(terminalSessionRequest.requestId);
   }, [
     consumeTerminalSessionRequest,
+    creating,
     error,
     loading,
     loadSequence,

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -15,7 +15,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button, Dialog, EmptyState, IconButton, StatusDot } from "../../design/primitives";
 import { DESKTOP_Z_INDEX } from "../../design/layering";
 import { categoryMessage } from "../../../../shared/app-error";
@@ -107,6 +107,9 @@ export default function TerminalsTab() {
   const patchUiState = useShellSessions((s) => s.patchUiState);
   const tabs = useTabs((s) => s.tabs);
   const openTab = useTabs((s) => s.openTab);
+  const recordRecentTerminal = useTabs((s) => s.recordRecentTerminal);
+  const terminalSessionRequest = useTabs((s) => s.terminalSessionRequest);
+  const consumeTerminalSessionRequest = useTabs((s) => s.consumeTerminalSessionRequest);
   const renameTerminalSession = useTabs((s) => s.renameTerminalSession);
   const [selectedName, setSelectedName] = useState<string | null>(null);
   const [liveSessionName, setLiveSessionName] = useState<string | null>(null);
@@ -191,7 +194,8 @@ export default function TerminalsTab() {
     showShellDetail(created);
   };
 
-  const showShellDetail = (shell: ShellSessionSummary) => {
+  const showShellDetail = useCallback((shell: ShellSessionSummary) => {
+    recordRecentTerminal(shell.name, shell.name);
     setOpenedSessionNames((current) => [
       ...current.filter((name) => name !== shell.name),
       shell.name,
@@ -201,7 +205,14 @@ export default function TerminalsTab() {
     if (shell.latestSeq !== undefined && shell.latestSeq !== null && shell.lastSeenSeq !== shell.latestSeq && api) {
       void patchUiState(api, shell.name, { lastSeenSeq: shell.latestSeq });
     }
-  };
+  }, [api, patchUiState, recordRecentTerminal]);
+
+  useEffect(() => {
+    if (!terminalSessionRequest) return;
+    const requestedShell = shells.find((shell) => shell.name === terminalSessionRequest.sessionName);
+    if (requestedShell) showShellDetail(requestedShell);
+    consumeTerminalSessionRequest(terminalSessionRequest.requestId);
+  }, [consumeTerminalSessionRequest, shells, showShellDetail, terminalSessionRequest]);
 
   const showShellList = () => {
     setSelectedName(null);

--- a/desktop/src/renderer/src/stores/runtime-transition.ts
+++ b/desktop/src/renderer/src/stores/runtime-transition.ts
@@ -56,6 +56,8 @@ export function reconcileDesktopRuntimeChange(options: RuntimeChangeOptions = {}
     canGoForward: false,
     recentViews: [],
     recentFilter: "all",
+    terminalSessionRequest: null,
+    terminalSessionRequestSequence: 0,
   });
   // MissionControl only opens Home in its mount-only effect, so reopen it here
   // or a successful switch leaves the already-mounted desktop with no active tab.

--- a/desktop/src/renderer/src/stores/tabs.ts
+++ b/desktop/src/renderer/src/stores/tabs.ts
@@ -40,6 +40,11 @@ export interface RecentView {
   visitedAt: number;
 }
 
+export interface TerminalSessionRequest {
+  sessionName: string;
+  requestId: number;
+}
+
 export const FILES_WORKSPACE_TAB_SPEC = {
   kind: "files" as const,
   title: "Files",
@@ -121,6 +126,8 @@ interface TabsState {
   canGoForward: boolean;
   recentViews: RecentView[];
   recentFilter: RecentViewFilter;
+  terminalSessionRequest: TerminalSessionRequest | null;
+  terminalSessionRequestSequence: number;
   openTab(spec: Omit<Tab, "id" | "closable"> & { closable?: boolean }): string;
   closeTab(id: string): void;
   closeProjectTabs(projectSlug: string): void;
@@ -129,6 +136,9 @@ interface TabsState {
   goForward(): void;
   ensureNavigationScope(scope: string): void;
   recordRecentConversation(id: string, label: string): void;
+  recordRecentTerminal(id: string, label: string): void;
+  requestTerminalSession(sessionName: string): void;
+  consumeTerminalSessionRequest(requestId: number): void;
   setRecentFilter(filter: RecentViewFilter): void;
   renameTab(id: string, title: string): void;
   renameTerminalSession(fromName: string, toName: string): void;
@@ -146,6 +156,8 @@ export const useTabs = create<TabsState>()((set, get) => ({
   canGoForward: false,
   recentViews: [],
   recentFilter: "all",
+  terminalSessionRequest: null,
+  terminalSessionRequestSequence: 0,
 
   openTab: (spec) => {
     const key = identityKey(spec);
@@ -263,6 +275,8 @@ export const useTabs = create<TabsState>()((set, get) => ({
       ...historyPatch(soleHome ? [soleHome.id] : [], soleHome ? 0 : -1),
       recentViews: [],
       recentFilter: "all",
+      terminalSessionRequest: null,
+      terminalSessionRequestSequence: 0,
     };
   }),
 
@@ -274,6 +288,29 @@ export const useTabs = create<TabsState>()((set, get) => ({
       visitedAt: Date.now(),
     }),
   })),
+
+  recordRecentTerminal: (id, label) => set((state) => ({
+    recentViews: recordRecent(state.recentViews, {
+      kind: "terminal",
+      id,
+      label,
+      visitedAt: Date.now(),
+    }),
+  })),
+
+  requestTerminalSession: (sessionName) => set((state) => {
+    const requestId = state.terminalSessionRequestSequence + 1;
+    return {
+      terminalSessionRequest: { sessionName, requestId },
+      terminalSessionRequestSequence: requestId,
+    };
+  }),
+
+  consumeTerminalSessionRequest: (requestId) => set((state) => (
+    state.terminalSessionRequest?.requestId === requestId
+      ? { terminalSessionRequest: null }
+      : state
+  )),
 
   setRecentFilter: (recentFilter) => set({ recentFilter }),
 
@@ -292,5 +329,8 @@ export const useTabs = create<TabsState>()((set, get) => ({
           ? { ...recent, id: toName, label: toName }
           : recent,
       ),
+      terminalSessionRequest: state.terminalSessionRequest?.sessionName === fromName
+        ? { ...state.terminalSessionRequest, sessionName: toName }
+        : state.terminalSessionRequest,
     })),
 }));

--- a/tests/desktop/runtime-transition.test.ts
+++ b/tests/desktop/runtime-transition.test.ts
@@ -109,7 +109,11 @@ describe("desktop runtime transition", () => {
 
   it("reopens the Home tab so the desktop is never left blank after a switch", () => {
     useTabs.getState().ensureNavigationScope("old-runtime");
+    useTabs.getState().openTab({ kind: "terminal", sessionName: "old-shell", title: "old-shell" });
     useTabs.getState().recordRecentConversation("thread-old", "Old private thread");
+    useTabs.setState({
+      terminalSessionRequest: { sessionName: "old-shell", requestId: 1 },
+    });
 
     reconcileDesktopRuntimeChange({ disposeRuntimeAttachments: vi.fn() });
 
@@ -119,6 +123,7 @@ describe("desktop runtime transition", () => {
     expect(activeTabId).toBe(tabs[0]?.id);
     expect(recentViews).toEqual([]);
     expect(viewHistory).toEqual([tabs[0]?.id]);
+    expect(useTabs.getState().terminalSessionRequest).toBeNull();
   });
 
   it("clears the Hermes chat transcript and session owned by the previous computer", () => {

--- a/tests/desktop/sidebar-navigation-shell.test.tsx
+++ b/tests/desktop/sidebar-navigation-shell.test.tsx
@@ -120,6 +120,18 @@ describe("Desktop sidebar navigation shell", () => {
     expect(useTabs.getState().tabs.filter((tab) => tab.kind === "terminal")).toHaveLength(0);
   });
 
+  it("routes a Terminal recent through the mounted workspace when a native tab also exists", () => {
+    const terminalsWorkspace = useTabs.getState().openTab({ kind: "terminals", title: "Terminal" });
+    useTabs.getState().openTab({ kind: "home", title: "Home", closable: false });
+    renderSidebar();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open recent dev" }));
+
+    expect(useTabs.getState().activeTabId).toBe(terminalsWorkspace);
+    expect(useTabs.getState().terminalSessionRequest).toMatchObject({ sessionName: "dev" });
+    expect(useTabs.getState().tabs.filter((tab) => tab.kind === "terminal" && tab.sessionName === "dev")).toHaveLength(1);
+  });
+
   it("opens a recent conversation in Chat and restores its selection", () => {
     renderSidebar();
 

--- a/tests/desktop/sidebar-navigation-shell.test.tsx
+++ b/tests/desktop/sidebar-navigation-shell.test.tsx
@@ -80,6 +80,9 @@ describe("Desktop sidebar navigation shell", () => {
     expect(screen.getByText("Fix navigation")).toBeTruthy();
     expect(screen.getByText("dev")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Open recent Matrix OS" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open recent Fix navigation" }).querySelector(".lucide-message-circle")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open recent dev" }).querySelector(".lucide-square-terminal")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open recent Matrix OS" }).querySelector(".lucide-folder-kanban")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Filter recents" }));
     fireEvent.click(screen.getByRole("button", { name: "Terminals" }));
@@ -87,6 +90,34 @@ describe("Desktop sidebar navigation shell", () => {
     expect(screen.queryByText("Fix navigation")).toBeNull();
     expect(screen.getByText("dev")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Open recent Matrix OS" })).toBeNull();
+  });
+
+  it("focuses the existing canonical Terminal tab from Recents without duplication", () => {
+    const terminal = useTabs.getState().tabs.find((tab) => tab.kind === "terminal");
+    expect(terminal).toBeTruthy();
+    useTabs.getState().openTab({ kind: "home", title: "Home", closable: false });
+    const mountedTabs = useTabs.getState().tabs;
+    renderSidebar();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open recent dev" }));
+
+    expect(useTabs.getState().activeTabId).toBe(terminal?.id);
+    expect(useTabs.getState().tabs).toBe(mountedTabs);
+    expect(useTabs.getState().tabs.filter((tab) => tab.kind === "terminal" && tab.sessionName === "dev")).toHaveLength(1);
+  });
+
+  it("routes a Terminal recent without a native tab through the mounted Terminal workspace", () => {
+    useTabs.setState(useTabs.getInitialState(), true);
+    useTabs.getState().ensureNavigationScope("runtime-a");
+    const terminalsWorkspace = useTabs.getState().openTab({ kind: "terminals", title: "Terminal" });
+    useTabs.getState().openTab({ kind: "home", title: "Home", closable: false });
+    useTabs.getState().recordRecentTerminal("matrix-main", "matrix-main");
+    renderSidebar();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open recent matrix-main" }));
+
+    expect(useTabs.getState().activeTabId).toBe(terminalsWorkspace);
+    expect(useTabs.getState().tabs.filter((tab) => tab.kind === "terminal")).toHaveLength(0);
   });
 
   it("opens a recent conversation in Chat and restores its selection", () => {

--- a/tests/desktop/tab-content.test.tsx
+++ b/tests/desktop/tab-content.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import TabContent, { TabErrorBoundary } from "@desktop/renderer/src/features/mission-control/TabContent";
 import { useConnection } from "@desktop/renderer/src/stores/connection";
@@ -12,6 +12,11 @@ const taskWorkspaceMock = vi.hoisted(() =>
     <button type="button">
       Task {taskId} {projectSlug}
     </button>
+  )),
+);
+const terminalsTabMock = vi.hoisted(() =>
+  vi.fn(({ active }: { active: boolean }) => (
+    <button type="button" data-active={String(active)}>Terminal workspace</button>
   )),
 );
 
@@ -25,6 +30,9 @@ vi.mock("@desktop/renderer/src/features/workspace/TaskWorkspace", () => ({
 }));
 vi.mock("@desktop/renderer/src/features/terminal/TerminalView", () => ({
   default: () => <button type="button">Terminal body</button>,
+}));
+vi.mock("@desktop/renderer/src/features/terminal/TerminalsTab", () => ({
+  default: terminalsTabMock,
 }));
 
 describe("TabContent", () => {
@@ -74,6 +82,22 @@ describe("TabContent", () => {
       expect.objectContaining({ taskId: "task_a", projectSlug: "alpha", active: true }),
       undefined,
     );
+  });
+
+  it("propagates active ownership to the mounted Terminal workspace across native focus changes", () => {
+    const workspaceId = useTabs.getState().openTab({ kind: "terminals", title: "Terminal" });
+    const nativeId = useTabs.getState().openTab({ kind: "terminal", sessionName: "dev", title: "dev" });
+    useTabs.getState().focusTab(workspaceId);
+    render(<TabContent />);
+
+    const workspace = screen.getByRole("button", { name: "Terminal workspace" });
+    expect(workspace.getAttribute("data-active")).toBe("true");
+
+    act(() => useTabs.getState().focusTab(nativeId));
+    expect(workspace.getAttribute("data-active")).toBe("false");
+
+    act(() => useTabs.getState().focusTab(workspaceId));
+    expect(workspace.getAttribute("data-active")).toBe("true");
   });
 
   it("renders the apps tab through the tracked AppLauncher module", () => {

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -192,6 +192,30 @@ describe("TerminalsTab", () => {
     expect(terminalMounts.get("matrix-main")).toBe(1);
   });
 
+  it("keeps a requested Recent pending until the canonical session load provides it", () => {
+    useTabs.setState(useTabs.getInitialState(), true);
+    useTabs.getState().requestTerminalSession("matrix-delayed");
+    useShellSessions.setState({
+      sessions: [],
+      loading: true,
+    });
+
+    renderTab();
+
+    expect(useTabs.getState().terminalSessionRequest).toMatchObject({ sessionName: "matrix-delayed" });
+    expect(screen.queryByTestId("terminal-view-matrix-delayed")).toBeNull();
+
+    act(() => {
+      useShellSessions.setState({
+        sessions: [{ name: "matrix-delayed", status: "active", placement: "active" }],
+        loading: false,
+      });
+    });
+
+    expect(screen.getByRole("navigation", { name: "Terminal breadcrumb" }).textContent).toContain("matrix-delayed");
+    expect(useTabs.getState().terminalSessionRequest).toBeNull();
+  });
+
   it("bounds preserved terminal buffers to the eight most recently opened sessions", () => {
     useShellSessions.setState({
       sessions: Array.from({ length: 9 }, (_, index) => ({

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -216,6 +216,30 @@ describe("TerminalsTab", () => {
     expect(useTabs.getState().terminalSessionRequest).toBeNull();
   });
 
+  it("retires a missing Recent after canonical loading completes so a reused name does not open", () => {
+    useTabs.setState(useTabs.getInitialState(), true);
+    useTabs.getState().requestTerminalSession("matrix-deleted");
+    useShellSessions.setState({
+      sessions: [],
+      loading: false,
+      error: null,
+      loadSequence: 1,
+    });
+
+    renderTab();
+
+    expect(useTabs.getState().terminalSessionRequest).toBeNull();
+
+    act(() => {
+      useShellSessions.setState({
+        sessions: [{ name: "matrix-deleted", status: "active", placement: "active" }],
+      });
+    });
+
+    expect(screen.getByRole("heading", { name: "Terminal" })).toBeTruthy();
+    expect(screen.queryByTestId("terminal-view-matrix-deleted")).toBeNull();
+  });
+
   it("bounds preserved terminal buffers to the eight most recently opened sessions", () => {
     useShellSessions.setState({
       sessions: Array.from({ length: 9 }, (_, index) => ({

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -147,6 +147,51 @@ describe("TerminalsTab", () => {
     expect(terminalMounts.get("matrix-main")).toBe(1);
   });
 
+  it("records and refreshes opened canonical session details in global Recents without remounting", () => {
+    useTabs.setState(useTabs.getInitialState(), true);
+    useTabs.getState().ensureNavigationScope("primary|operator|1");
+    useShellSessions.setState({
+      sessions: [
+        { name: "matrix-one", status: "active", placement: "active" },
+        { name: "matrix-two", status: "active", placement: "active" },
+      ],
+    });
+
+    renderTab();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open matrix-one" }));
+    fireEvent.click(screen.getByRole("button", { name: "Back to terminal sessions" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open matrix-two" }));
+    fireEvent.click(screen.getByRole("button", { name: "Back to terminal sessions" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open matrix-one" }));
+
+    expect(useTabs.getState().recentViews).toEqual([
+      expect.objectContaining({ kind: "terminal", id: "matrix-one", label: "matrix-one" }),
+      expect.objectContaining({ kind: "terminal", id: "matrix-two", label: "matrix-two" }),
+    ]);
+    expect(terminalMounts.get("matrix-one")).toBe(1);
+    expect(terminalMounts.get("matrix-two")).toBe(1);
+  });
+
+  it("reopens a requested canonical detail from its mounted cache without remounting", () => {
+    useTabs.setState(useTabs.getInitialState(), true);
+    useShellSessions.setState({
+      sessions: [{ name: "matrix-main", status: "active", placement: "active" }],
+    });
+    renderTab();
+    fireEvent.click(screen.getByRole("button", { name: "Open matrix-main" }));
+    fireEvent.click(screen.getByRole("button", { name: "Back to terminal sessions" }));
+
+    act(() => {
+      useTabs.setState({
+        terminalSessionRequest: { sessionName: "matrix-main", requestId: 1 },
+      });
+    });
+
+    expect(screen.getByRole("navigation", { name: "Terminal breadcrumb" }).textContent).toContain("matrix-main");
+    expect(terminalMounts.get("matrix-main")).toBe(1);
+  });
+
   it("bounds preserved terminal buffers to the eight most recently opened sessions", () => {
     useShellSessions.setState({
       sessions: Array.from({ length: 9 }, (_, index) => ({

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -216,6 +216,39 @@ describe("TerminalsTab", () => {
     expect(useTabs.getState().terminalSessionRequest).toBeNull();
   });
 
+  it("keeps a requested Recent pending during a create-triggered canonical refresh", () => {
+    useTabs.setState(useTabs.getInitialState(), true);
+    useTabs.getState().requestTerminalSession("matrix-created");
+    useShellSessions.setState({
+      sessions: [{ name: "matrix-main", status: "active", placement: "active" }],
+      loading: false,
+      creating: true,
+      error: null,
+      loadSequence: 2,
+    });
+
+    renderTab();
+
+    expect(useTabs.getState().terminalSessionRequest).toMatchObject({
+      sessionName: "matrix-created",
+    });
+
+    act(() => {
+      useShellSessions.setState({
+        sessions: [
+          { name: "matrix-created", status: "active", placement: "active" },
+          { name: "matrix-main", status: "active", placement: "active" },
+        ],
+        creating: false,
+      });
+    });
+
+    expect(screen.getByRole("navigation", { name: "Terminal breadcrumb" }).textContent).toContain(
+      "matrix-created",
+    );
+    expect(useTabs.getState().terminalSessionRequest).toBeNull();
+  });
+
   it("retires a missing Recent after canonical loading completes so a reused name does not open", () => {
     useTabs.setState(useTabs.getInitialState(), true);
     useTabs.getState().requestTerminalSession("matrix-deleted");


### PR DESCRIPTION
## Summary

- record canonical `/api/terminal/sessions` detail opens in the existing bounded, serializable global Recents projection
- refresh reopened sessions without duplication and route Recent selection through the mounted Terminal workspace when available
- keep delayed Recent requests pending until canonical loading and post-create refreshes complete, retire confirmed-absent targets, and transfer live attachment ownership across workspace/native-tab focus
- clear stale Terminal Recents and pending requests on runtime/auth-generation changes
- preserve PR #1227 inactive-pane containment and centered Terminal dialogs after merging `origin/main` at `7caa9b0fd0804e6450e50e8db2210b1ab06f925b`

## Root cause

The default Desktop Terminal detail path updated only component-local selection/live state, so ordinary canonical session opens never crossed the global navigation/Recents seam. A Recent request could also be consumed before sessions loaded, remain armed after a successful load proved its target absent, or route native-tab-first and strand ownership away from the mounted workspace.

## Tests and validation

- focused navigation, Terminal, tab-content, TerminalView, and runtime tests: 63/63
- repository typecheck: passed
- repository pattern scan: 0 violations; existing warning categories only
- React Doctor changed Desktop scope: no findings
- Desktop production build: passed; 2578 renderer modules
- built Desktop Terminal E2E: 2/2
- exact built Electron owner proof: socket count 3 to 4, workspace owner reacquired, mounted viewport marker preserved
- broad local `bun run test`: timed out after 12 minutes without a terminal summary and was interrupted with exit 130; not counted as passed
- exact-head GitHub CI is the authoritative broad-suite gate before landing

## Design

Figma annotation `67:4369` defines a mixed Recents list with distinct work-item icons. Terminal entries use the existing `SquareTerminal` glyph.

## Invariants and residual risks

- source of truth: canonical shell-session names from `/api/terminal/sessions`; `useTabs` stores only the bounded Recent projection and one-shot navigation signal
- ownership: mounted Terminal views are preserved; only the focused owner holds the live attachment
- orphan behavior: requests remain pending during loading, post-create canonical refresh, or a failed refresh, but a successful completed snapshot that confirms absence retires them so a future reused name cannot satisfy an obsolete action
- integration: PR #1227 is merged into this branch; inactive panes remain contained and Terminal delete dialogs remain centered
- excluded: MAT-268, Terminal lifecycle/persistence changes, renderer-owned xterm persistence, and any unrelated issue scope

![MAT-324 exact-build Electron evidence](https://uploads.linear.app/9d7c8ca2-ff8b-42ea-8321-35892cc887d8/3b80f6d7-52f8-432d-a606-158a704266fb/3df24e56-797e-475d-b69e-153da06bc5a4)

![MAT-324 owner reacquisition Electron evidence](https://uploads.linear.app/9d7c8ca2-ff8b-42ea-8321-35892cc887d8/69eb28a6-673c-4208-aa98-0039cc4058f7/0bdf8693-b3e0-45a0-8b61-81bb8da70427)

Linear: MAT-324
