### PR TITLE
fix(desktop): protect collapsed sidebar from traffic lights

### DIFF
--- a/desktop/src/renderer/src/features/mission-control/NavigationHeader.tsx
+++ b/desktop/src/renderer/src/features/mission-control/NavigationHeader.tsx
@@ -120,6 +120,9 @@ export default function NavigationHeader() {
       className="titlebar-drag flex shrink-0 items-center gap-1 border-b px-2"
       style={{
         height: "var(--tabbar-height)",
+        // The collapsed 56px rail ends inside the macOS traffic-light cluster.
+        // Continue the established 76px titlebar safe area before controls.
+        paddingLeft: collapsed ? 20 : undefined,
         borderColor: "var(--border-subtle)",
         background: "var(--bg-sunken)",
       }}

--- a/tests/e2e/desktop/sidebar-titlebar-safe-area.e2e.test.ts
+++ b/tests/e2e/desktop/sidebar-titlebar-safe-area.e2e.test.ts
@@ -1,0 +1,92 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { _electron, type ElectronApplication, type Page } from "playwright";
+import { startStubGateway, type StubGateway } from "./fixtures/stub-gateway";
+
+const DESKTOP_MAIN = resolve(__dirname, "../../../desktop/out/main/index.js");
+const desktopRequire = createRequire(resolve(__dirname, "../../../desktop/package.json"));
+const ELECTRON_EXECUTABLE = desktopRequire("electron") as string;
+const SCREENSHOT_DIR = resolve(__dirname, "../../../desktop/screenshots");
+const MACOS_TITLEBAR_SAFE_X = 76;
+const suite = existsSync(DESKTOP_MAIN) ? describe : describe.skip;
+
+suite("Desktop sidebar macOS titlebar safe area", () => {
+  let app: ElectronApplication;
+  let gateway: StubGateway;
+  let page: Page;
+  let userDataDir: string;
+
+  beforeAll(async () => {
+    mkdirSync(SCREENSHOT_DIR, { recursive: true });
+    gateway = await startStubGateway();
+    userDataDir = mkdtempSync(join(tmpdir(), "matrix-os-sidebar-safe-area-"));
+    app = await _electron.launch({
+      executablePath: ELECTRON_EXECUTABLE,
+      args: [DESKTOP_MAIN],
+      env: {
+        ...process.env,
+        OPERATOR_GATEWAY_URL: gateway.url,
+        OPERATOR_USER_DATA_DIR: userDataDir,
+      },
+    });
+    page = await app.firstWindow();
+    await page.getByRole("button", { name: /continue in browser/i }).click();
+    await page.locator("aside button", { hasText: "Terminal" }).first().waitFor({
+      timeout: 15_000,
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.close();
+    await gateway?.close();
+    if (userDataDir) rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  async function expectSidebarLayoutsClearOfTrafficLights(
+    viewport: { width: number; height: number },
+    viewportName: "normal" | "narrow",
+  ): Promise<void> {
+    await page.setViewportSize(viewport);
+    await expect.poll(async () => (await page.locator("aside").boundingBox())?.width).toBe(240);
+    await page.screenshot({
+      path: join(SCREENSHOT_DIR, `mat-325-sidebar-expanded-${viewportName}.png`),
+    });
+
+    const collapse = page.getByRole("button", { name: "Collapse sidebar" });
+    await collapse.focus();
+    await page.keyboard.press("Enter");
+
+    await expect.poll(async () => (await page.locator("aside").boundingBox())?.width).toBe(56);
+    const sidebarBox = await page.locator("aside").boundingBox();
+    const expand = page.getByRole("button", { name: "Expand sidebar" });
+    const expandBox = await expand.boundingBox();
+    await page.screenshot({
+      path: join(SCREENSHOT_DIR, `mat-325-sidebar-collapsed-${viewportName}.png`),
+    });
+
+    expect(sidebarBox).not.toBeNull();
+    expect(sidebarBox?.width).toBe(56);
+    expect(expandBox).not.toBeNull();
+    expect(expandBox?.x ?? 0).toBeGreaterThanOrEqual(MACOS_TITLEBAR_SAFE_X);
+    expect(await expand.isVisible()).toBe(true);
+
+    await expand.focus();
+    await page.keyboard.press("Enter");
+    await page.getByRole("button", { name: "Collapse sidebar" }).waitFor();
+    await expect.poll(async () => (await page.locator("aside").boundingBox())?.width).toBe(240);
+  }
+
+  it("keeps the 56px collapsed rail and expand control outside native traffic lights", async () => {
+    await expectSidebarLayoutsClearOfTrafficLights(
+      { width: 1280, height: 820 },
+      "normal",
+    );
+    await expectSidebarLayoutsClearOfTrafficLights(
+      { width: 880, height: 560 },
+      "narrow",
+    );
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- Reserve the established 76px macOS titlebar safe boundary when the Desktop sidebar is collapsed.
- Preserve the existing visual language, 56px compact rail, 240px expanded sidebar, and current keyboard interaction.
- Add a built-Electron regression that verifies expanded and collapsed layouts at 1280×820 and the supported 880×560 minimum.

## Root cause

The native BrowserWindow positions macOS traffic lights at the top-left. When the sidebar collapsed to 56px, the adjacent navigation header retained only its existing 8px horizontal padding, so the expand button began at x=64—inside the native traffic-light footprint. The expanded layout already cleared the titlebar controls.

The fix applies a collapsed-only 20px left inset to the header, placing its first control at x=76 without changing the rail width or expanded layout.

## TDD evidence

- RED: the new built-Electron seam test failed with `expected 64 to be greater than or equal to 76`.
- GREEN: `pnpm exec vitest run --config vitest.e2e.config.ts tests/e2e/desktop/sidebar-titlebar-safe-area.e2e.test.ts` — 1/1 passed.
- Desktop suite: `pnpm exec vitest run tests/desktop` — 168 files, 1,674 tests passed.
- Focused component coverage: 3 files, 14 tests passed.
- Desktop and repository typechecks passed.
- `bun run build:desktop` passed.
- React Doctor scanned 26 changed-scope files with no issues.
- Pattern scan reported 0 violations and 5 existing baseline warnings.

The full repository Vitest run completed with 10,747 passed, 24 failed, and 20 skipped. All failures are outside MAT-325. The initially observed VPS assertion was rerun independently once and reproduced: `customer-vps-cloud-init` expected exit 124 but received 127.

## Built-Electron evidence

![Native macOS collapsed sidebar evidence](https://uploads.linear.app/9d7c8ca2-ff8b-42ea-8321-35892cc887d8/52a6ceb7-cb5a-419c-9f9a-0dba3c434862/a46c8ef9-8301-4ba1-aabb-5e1668b2fc0d)

The native screenshot shows the macOS traffic lights and the collapsed 56px rail at 1280×820 logical size. Renderer screenshots also cover expanded/collapsed states at 1280×820 and 880×560.

## Invariants

### Source of truth

Existing `useUi().sidebarCollapsed` state remains authoritative. No new state or persistence was added.

### Lock / transaction scope

None. This is a presentational Desktop-only change.

### Acceptable orphan states

None introduced.

### Auth source of truth

Unchanged.

### Deferred scope and remaining risks

- Greptile and GitHub CI are pending.
- Native Windows/Linux window chrome was not visually verified; the change is macOS-specific and does not alter cross-platform state or behavior.
- MAT-268, Files CRUD, broad navigation redesigns, and merge/release work are explicitly excluded.