### PR TITLE
feat(desktop): align Chat with approved Figma

### DIFF
--- a/desktop/src/renderer/src/features/chat/ChatResourcesPanel.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatResourcesPanel.tsx
@@ -1,0 +1,213 @@
+import { FileText, Link2, Plug, Upload, X } from "lucide-react";
+import { useEffect, useMemo, useRef } from "react";
+import type { ChatMessage } from "../../lib/chat";
+import { useConnection } from "../../stores/connection";
+import { useTabs } from "../../stores/tabs";
+import { useUi } from "../../stores/ui";
+import { useIntegrations } from "../integrations/integrations-store";
+
+const RESOURCE_CAP = 50;
+const ATTACHMENT_HEADING = "Attached files (available on your Matrix computer):\n";
+const ATTACHMENT_LINE = /^- ~\/temporary\/desktop-chat\/(.+) \(\/home\/matrix\/home\/temporary\/desktop-chat\/(.+)\)$/;
+
+function readableAttachmentName(storedName: string): string {
+  const decoded = (() => {
+    try {
+      return decodeURIComponent(storedName);
+    } catch {
+      return storedName;
+    }
+  })();
+  const basename = decoded.split(/[\\/]/).at(-1) ?? "";
+  return basename.replace(/^[A-Za-z0-9]+-/, "").slice(0, 180) || "Attachment";
+}
+
+export function sharedConversationResources(messages: ChatMessage[]): string[] {
+  const resources: string[] = [];
+  const seen = new Set<string>();
+  for (const message of messages) {
+    if (message.role !== "user") continue;
+    for (const name of conversationMessageDisplay(message.content).attachments) {
+      if (!seen.has(name)) {
+        seen.add(name);
+        resources.push(name);
+      }
+      if (resources.length >= RESOURCE_CAP) return resources;
+    }
+  }
+  return resources;
+}
+
+export function conversationMessageDisplay(content: string): {
+  text: string;
+  attachments: string[];
+} {
+  const headingIndex = content.lastIndexOf(ATTACHMENT_HEADING);
+  if (headingIndex < 0 || (headingIndex > 1 && content.slice(headingIndex - 2, headingIndex) !== "\n\n")) {
+    return { text: content, attachments: [] };
+  }
+  const attachments: string[] = [];
+  const seen = new Set<string>();
+  for (const line of content.slice(headingIndex + ATTACHMENT_HEADING.length).split("\n")) {
+    const match = ATTACHMENT_LINE.exec(line);
+    if (!match || match[1] !== match[2]) continue;
+    const storedName = match[1];
+    if (!storedName) continue;
+    const name = readableAttachmentName(storedName);
+    if (seen.has(name)) continue;
+    seen.add(name);
+    attachments.push(name);
+    if (attachments.length >= RESOURCE_CAP) break;
+  }
+  if (attachments.length === 0) return { text: content, attachments: [] };
+  return {
+    text: content.slice(0, headingIndex).trim(),
+    attachments,
+  };
+}
+
+function connectedToolsCopy(status: ReturnType<typeof useIntegrations.getState>["status"]): string {
+  if (status === "loading" || status === "idle") return "Loading connected tools…";
+  if (status === "unavailable") return "Connected tools are not available from this Gateway.";
+  if (status === "error") return "Connected tools could not be loaded. Try again from Integrations.";
+  return "No connected tools.";
+}
+
+export function ChatResourcesPanel({
+  messages,
+  onClose,
+  onUpload,
+}: {
+  messages: ChatMessage[];
+  onClose: (restoreFocus?: boolean) => void;
+  onUpload: () => void;
+}) {
+  const api = useConnection((state) => state.api);
+  const connections = useIntegrations((state) => state.connections);
+  const integrationsStatus = useIntegrations((state) => state.status);
+  const refreshIntegrations = useIntegrations((state) => state.refresh);
+  const requestSettingsSection = useUi((state) => state.requestSettingsSection);
+  const openTab = useTabs((state) => state.openTab);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const sharedResources = useMemo(() => sharedConversationResources(messages), [messages]);
+
+  useEffect(() => {
+    closeButtonRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (api && integrationsStatus === "idle") void refreshIntegrations(api);
+  }, [api, integrationsStatus, refreshIntegrations]);
+
+  useEffect(() => {
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", closeOnEscape);
+    return () => document.removeEventListener("keydown", closeOnEscape);
+  }, [onClose]);
+
+  const openIntegrations = () => {
+    requestSettingsSection("integrations");
+    openTab({ kind: "settings", title: "Settings" });
+    onClose(false);
+  };
+
+  return (
+    <div className="absolute inset-0 z-20 flex justify-end">
+      <button
+        type="button"
+        aria-label="Dismiss Resources"
+        className="absolute inset-0 cursor-default bg-black/10"
+        onClick={() => onClose()}
+      />
+      <aside
+        aria-label="Resources"
+        className="relative flex h-full w-[min(380px,calc(100%-24px))] flex-col border-l shadow-[var(--shadow-3)]"
+        style={{ background: "var(--bg-overlay)", borderColor: "var(--border-subtle)" }}
+      >
+        <header className="flex h-[78px] shrink-0 items-center justify-between border-b px-5" style={{ borderColor: "var(--border-subtle)" }}>
+          <h2 className="text-base font-semibold" style={{ color: "var(--text-primary)" }}>Resources</h2>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            aria-label="Close Resources"
+            className="flex h-8 w-8 items-center justify-center rounded-lg hover:bg-[var(--bg-hover)] focus-visible:outline-2 focus-visible:outline-[var(--accent)]"
+            style={{ color: "var(--text-secondary)" }}
+            onClick={() => onClose()}
+          >
+            <X size={16} aria-hidden />
+          </button>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
+          <ResourceSection title="Shared with agent">
+            {sharedResources.length > 0 ? sharedResources.map((name) => (
+              <div key={name} className="flex h-[52px] items-center gap-3 border-b last:border-b-0" style={{ borderColor: "var(--border-subtle)" }}>
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg" style={{ background: "var(--bg-sunken)", color: "var(--text-secondary)" }}>
+                  <FileText size={15} aria-hidden />
+                </span>
+                <span className="min-w-0 truncate text-sm" style={{ color: "var(--text-primary)" }}>{name}</span>
+              </div>
+            )) : (
+              <EmptyResourceCopy>No files have been shared in this chat.</EmptyResourceCopy>
+            )}
+          </ResourceSection>
+
+          <ResourceSection title="Created by agent">
+            <EmptyResourceCopy>Agent-created resources are not available from this Gateway yet.</EmptyResourceCopy>
+          </ResourceSection>
+
+          <ResourceSection title="Connected tools">
+            {connections.length > 0 ? connections.map((connection) => (
+              <div key={connection.id} className="flex min-h-10 items-center gap-3 border-b py-2 last:border-b-0" style={{ borderColor: "var(--border-subtle)" }}>
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg" style={{ background: "var(--bg-sunken)", color: "var(--text-secondary)" }}>
+                  <Link2 size={14} aria-hidden />
+                </span>
+                <span className="min-w-0 truncate text-sm" style={{ color: "var(--text-primary)" }}>{connection.accountLabel}</span>
+              </div>
+            )) : (
+              <EmptyResourceCopy>
+                {connectedToolsCopy(integrationsStatus)}
+              </EmptyResourceCopy>
+            )}
+          </ResourceSection>
+        </div>
+
+        <footer className="grid shrink-0 grid-cols-2 gap-2 border-t p-4" style={{ borderColor: "var(--border-subtle)" }}>
+          <button
+            type="button"
+            className="flex h-9 items-center justify-center gap-2 rounded-lg border text-sm font-medium hover:bg-[var(--bg-hover)] focus-visible:outline-2 focus-visible:outline-[var(--accent)]"
+            style={{ borderColor: "var(--border-default)", color: "var(--text-primary)" }}
+            onClick={onUpload}
+          >
+            <Upload size={14} aria-hidden />
+            Upload file
+          </button>
+          <button
+            type="button"
+            className="flex h-9 items-center justify-center gap-2 rounded-lg border text-sm font-medium hover:bg-[var(--bg-hover)] focus-visible:outline-2 focus-visible:outline-[var(--accent)]"
+            style={{ borderColor: "var(--border-default)", color: "var(--text-primary)" }}
+            onClick={openIntegrations}
+          >
+            <Plug size={14} aria-hidden />
+            Connect tool
+          </button>
+        </footer>
+      </aside>
+    </div>
+  );
+}
+
+function ResourceSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-7 last:mb-0">
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-[0.08em]" style={{ color: "var(--text-tertiary)" }}>{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function EmptyResourceCopy({ children }: { children: React.ReactNode }) {
+  return <p className="rounded-lg border px-3 py-3 text-sm leading-5" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>{children}</p>;
+}

--- a/desktop/src/renderer/src/features/chat/ChatResourcesPanel.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatResourcesPanel.tsx
@@ -14,7 +14,11 @@ function readableAttachmentName(storedName: string): string {
   const decoded = (() => {
     try {
       return decodeURIComponent(storedName);
-    } catch {
+    } catch (error: unknown) {
+      console.warn(
+        "[chat-resources] attachment name decode failed:",
+        error instanceof URIError ? error.name : "Unknown error",
+      );
       return storedName;
     }
   })();

--- a/desktop/src/renderer/src/features/chat/ChatTab.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatTab.tsx
@@ -1,118 +1,48 @@
-import { ChevronRight, FolderOpen, GitBranch, Laptop, Mail, MessageSquare, MessageSquarePlus, Sparkles, SquareTerminal } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
-import { StatusDot } from "../../design/primitives";
+import { FileText, Paperclip, PanelRight } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { BrandLogo } from "../../design/BrandPanel";
 import { groupMessages } from "../../lib/chat";
-import { CODING_AGENTS_DESKTOP_WORKSPACE } from "../../lib/feature-flags";
-import { openCodingAgentThread } from "../../lib/project-chat";
-import { useBoard } from "../../stores/board";
-import { useCodingAgentWorkspace } from "../../stores/coding-agent-workspace";
 import { useConnection } from "../../stores/connection";
 import { useHermesChat, type HermesStatus } from "../../stores/hermes-chat";
-import { useThreads } from "../../stores/threads";
-import { useTabs } from "../../stores/tabs";
-import {
-  listUnifiedThreads,
-  UNIFIED_THREAD_STATUS_META,
-  type UnifiedThreadItem,
-} from "../../stores/unified-threads";
-import ThreadView from "../threads/ThreadView";
+import { AttachmentPreviewRow } from "./attachments/AttachmentPreviewRow";
+import { appendHermesAttachmentPaths } from "./attachments/local-attachment-controller";
+import { useConversationAttachments } from "./attachments/use-conversation-attachments";
 import { Bubble, BubbleContent } from "./elements/bubble";
 import { Conversation, ConversationContent, ConversationItem } from "./elements/conversation";
 import { Message, MessageContent, MessageResponse } from "./elements/message";
 import { PromptInput } from "./elements/prompt-input";
-import { AttachmentPreviewRow } from "./attachments/AttachmentPreviewRow";
-import { appendHermesAttachmentPaths } from "./attachments/local-attachment-controller";
-import { useConversationAttachments } from "./attachments/use-conversation-attachments";
 import { Reasoning } from "./elements/reasoning";
 import { Tool } from "./elements/tool";
+import { ChatResourcesPanel, conversationMessageDisplay } from "./ChatResourcesPanel";
 import { HermesConversationIndex } from "./HermesConversationIndex";
-
-function Pill({ icon, label }: { icon: React.ReactNode; label: string }) {
-  return (
-    <button
-      type="button"
-      className="flex items-center gap-1.5 rounded-md px-2 py-1 text-sm transition-colors hover:bg-[var(--bg-hover)]"
-      style={{ color: "var(--text-secondary)" }}
-    >
-      {icon}
-      {label}
-    </button>
-  );
-}
-
-function ConnectCard({ title, body, icon, done }: { title: string; body: string; icon: React.ReactNode; done?: boolean }) {
-  return (
-    <div
-      className="flex flex-col gap-1.5 rounded-xl border p-4 text-left"
-      style={{ background: "var(--bg-surface)", borderColor: "var(--border-subtle)", opacity: done ? 0.55 : 1 }}
-    >
-      <div className="flex items-center justify-between">
-        <div
-          className="flex h-6 w-6 items-center justify-center rounded"
-          style={{ background: "var(--bg-sunken)", color: "var(--text-secondary)" }}
-        >
-          {icon}
-        </div>
-        {done ? <span className="text-xs" style={{ color: "var(--success)" }}>✓</span> : null}
-      </div>
-      <span className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>{title}</span>
-      <span className="text-xs leading-relaxed" style={{ color: "var(--text-secondary)" }}>{body}</span>
-    </div>
-  );
-}
 
 export function canSubmitChatDraft(draft: string, status: HermesStatus, attachmentCount = 0): boolean {
   return (draft.trim().length > 0 || attachmentCount > 0) && status === "idle";
 }
 
-function RailButton({
-  active,
-  onClick,
-  dot,
-  label,
-  bold = false,
-}: {
-  active: boolean;
-  onClick: () => void;
-  dot: React.ReactNode;
-  label: string;
-  bold?: boolean;
-}) {
-  return (
-    <button
-      type="button"
-      className="flex items-center gap-2 rounded-md px-2.5 py-2 text-left transition-colors duration-100"
-      style={{ background: active ? "var(--bg-selected)" : "transparent" }}
-      onMouseEnter={(event) => { if (!active) event.currentTarget.style.background = "var(--bg-hover)"; }}
-      onMouseLeave={(event) => { if (!active) event.currentTarget.style.background = "transparent"; }}
-      onClick={onClick}
-    >
-      <span className="flex w-4 shrink-0 items-center justify-center">{dot}</span>
-      <span className="min-w-0 flex-1 truncate text-sm" style={{ color: "var(--text-primary)", fontWeight: bold ? 600 : 400 }}>{label}</span>
-    </button>
-  );
-}
-
-// The Hermes (OS agent) conversation — the default pane when no agent thread is
-// selected in the rail.
 function HermesPane() {
-  const messages = useHermesChat((s) => s.messages);
-  const sessionId = useHermesChat((s) => s.sessionId);
-  const status = useHermesChat((s) => s.status);
-  const conversations = useHermesChat((s) => s.conversations);
-  const loadError = useHermesChat((s) => s.loadError);
-  const showIndex = useHermesChat((s) => s.showIndex);
-  const send = useHermesChat((s) => s.send);
-  const abort = useHermesChat((s) => s.abort);
-  const projects = useBoard((s) => s.projects);
+  const messages = useHermesChat((state) => state.messages);
+  const sessionId = useHermesChat((state) => state.sessionId);
+  const status = useHermesChat((state) => state.status);
+  const loadError = useHermesChat((state) => state.loadError);
+  const send = useHermesChat((state) => state.send);
+  const abort = useHermesChat((state) => state.abort);
   const [draft, setDraft] = useState("");
   const [uploadingAttachments, setUploadingAttachments] = useState(false);
-  const attachments = useConversationAttachments();
+  const [resourcesOpen, setResourcesOpen] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const resourcesTriggerRef = useRef<HTMLButtonElement>(null);
+  const attachments = useConversationAttachments(sessionId);
 
-  const projectName = projects[0]?.name ?? projects[0]?.slug ?? "Matrix OS";
-  const conversationTitle = conversations.find((conversation) => conversation.id === sessionId)?.title ?? "New conversation";
   const groups = groupMessages(messages);
   const empty = messages.length === 0;
+
+  const closeResources = useCallback((restoreFocus = true) => {
+    setResourcesOpen(false);
+    if (restoreFocus) {
+      window.requestAnimationFrame(() => resourcesTriggerRef.current?.focus());
+    }
+  }, []);
 
   const submit = async () => {
     if (uploadingAttachments || !canSubmitChatDraft(draft, status, attachments.items.length)) return;
@@ -137,229 +67,197 @@ function HermesPane() {
     />
   );
   const composerReady = canSubmitChatDraft(draft, status, attachments.items.length);
-
-  const composerFooter = (
+  const composerControls = (
     <>
-      <Pill icon={<SquareTerminal size={13} />} label={projectName} />
-      <Pill icon={<Laptop size={13} />} label="On VPS" />
-      <Pill icon={<GitBranch size={13} />} label="main" />
+      <button
+        type="button"
+        aria-label="Attach files"
+        className="flex h-8 w-8 items-center justify-center rounded-lg hover:bg-[var(--bg-hover)] focus-visible:outline-2 focus-visible:outline-[var(--accent)]"
+        style={{ color: "var(--text-secondary)" }}
+        disabled={uploadingAttachments}
+        onClick={() => fileInputRef.current?.click()}
+      >
+        <Paperclip size={16} aria-hidden />
+      </button>
+      <button
+        ref={resourcesTriggerRef}
+        type="button"
+        aria-label="Resources"
+        aria-expanded={resourcesOpen}
+        className="flex h-8 items-center gap-1.5 rounded-lg px-2 text-sm hover:bg-[var(--bg-hover)] focus-visible:outline-2 focus-visible:outline-[var(--accent)]"
+        style={{ color: "var(--text-secondary)" }}
+        onClick={() => setResourcesOpen((open) => !open)}
+      >
+        <PanelRight size={15} aria-hidden />
+        <span className="hidden sm:inline">Resources</span>
+      </button>
+    </>
+  );
+  const harnessBadge = (
+    <span
+      className="rounded-full border px-2 py-1 text-xs font-medium"
+      style={{ borderColor: "var(--border-default)", color: "var(--text-secondary)" }}
+      title="Current chat harness"
+    >
+      Hermes
+    </span>
+  );
+  const renderComposer = (placeholder: string, autoFocus = false) => (
+    <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        aria-label="Choose files"
+        className="sr-only"
+        onChange={(event) => {
+          attachments.add(Array.from(event.currentTarget.files ?? []));
+          event.currentTarget.value = "";
+        }}
+      />
+      <PromptInput
+        value={draft}
+        onChange={setDraft}
+        onSubmit={() => void submit()}
+        onAbort={status !== "idle" ? abort : undefined}
+        busy={status !== "idle" || uploadingAttachments}
+        disabled={uploadingAttachments}
+        canSubmit={composerReady}
+        attachments={attachmentPreviews}
+        autoFocus={autoFocus}
+        placeholder={placeholder}
+        ariaLabel={placeholder}
+        controls={composerControls}
+        trailingControls={harnessBadge}
+      />
     </>
   );
 
-  const breadcrumb = (
-    <nav
-      aria-label="Chat breadcrumb"
-      className="flex h-10 shrink-0 items-center gap-1.5 border-b px-5 text-sm"
-      style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}
-    >
-      <button type="button" className="rounded px-1.5 py-1 hover:bg-[var(--bg-hover)]" onClick={showIndex}>
-        Chat
-      </button>
-      <ChevronRight size={12} aria-hidden style={{ color: "var(--text-tertiary)" }} />
-      <span className="min-w-0 truncate font-medium" style={{ color: "var(--text-primary)" }}>{conversationTitle}</span>
-    </nav>
-  );
-
   const loadErrorBanner = loadError ? (
-    <div role="alert" className="mx-auto mt-3 w-[calc(100%-2.5rem)] max-w-[760px] rounded-lg border px-3 py-2 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
+    <div role="alert" className="mx-auto mt-3 w-[calc(100%-2.5rem)] max-w-[868px] rounded-lg border px-3 py-2 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
       {loadError}
     </div>
   ) : null;
 
-  if (empty) {
-    return (
-      <div role="region" aria-label="Hermes conversation" className="flex min-h-0 flex-1 flex-col" {...attachments.paneProps}>
-        {breadcrumb}
-        {loadErrorBanner}
-        <div className="mx-auto flex w-full max-w-[760px] flex-1 flex-col justify-center px-5">
-          <h1 className="mb-8 text-center text-2xl font-semibold tracking-tight" style={{ color: "var(--text-primary)", fontSize: "var(--text-2xl)" }}>
-            What should we build in {projectName}?
-          </h1>
-          <PromptInput value={draft} onChange={setDraft} onSubmit={() => void submit()} onAbort={status !== "idle" ? abort : undefined} busy={status !== "idle" || uploadingAttachments} disabled={uploadingAttachments} canSubmit={composerReady} attachments={attachmentPreviews} autoFocus footer={composerFooter} />
-          <div className="mt-6 grid grid-cols-1 gap-3 md:grid-cols-3">
-            <ConnectCard title="Connect messaging" body="Get context from recent team discussions" icon={<MessageSquare size={13} aria-hidden />} />
-            <ConnectCard title="Connect email" body="Summarize stakeholder asks from email" icon={<Mail size={13} aria-hidden />} />
-            <ConnectCard title="Connect files" body="Review results, research, and plans" icon={<FolderOpen size={13} aria-hidden />} />
-          </div>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div role="region" aria-label="Hermes conversation" className="flex min-h-0 flex-1 flex-col" {...attachments.paneProps}>
-      {breadcrumb}
+    <div
+      role="region"
+      aria-label="Hermes conversation"
+      className="relative flex min-h-0 flex-1 flex-col overflow-hidden"
+      {...attachments.paneProps}
+    >
       {loadErrorBanner}
-      <Conversation>
-        <ConversationContent>
-          {groups.map((group) =>
-            group.type === "tool_group" ? (
-              <ConversationItem key={group.messages[0]?.id ?? "tools"} messageId={group.messages[0]?.id}>
-                <div className="flex flex-col gap-1.5">
-                  {group.messages.map((m) => (
-                    <Tool key={m.id} name={m.content} detail={m.toolInput ? JSON.stringify(m.toolInput, null, 2) : undefined} />
-                  ))}
-                </div>
-              </ConversationItem>
-            ) : group.message.role === "user" ? (
-              <ConversationItem key={group.message.id} messageId={`user:${group.message.id}`} scrollAnchor>
-                <Message align="end">
-                  <MessageContent>
-                    <Bubble variant="secondary" align="end">
-                      <BubbleContent className="whitespace-pre-wrap" data-selectable>
-                        {group.message.content}
-                      </BubbleContent>
-                    </Bubble>
-                  </MessageContent>
-                </Message>
-              </ConversationItem>
-            ) : (
-              <ConversationItem key={group.message.id} messageId={`assistant:${group.message.id}`}>
-                <Message>
-                  <MessageContent>
-                    <Bubble variant="ghost">
-                      <BubbleContent className="overflow-visible">
-                        <MessageResponse>{group.message.content}</MessageResponse>
-                      </BubbleContent>
-                    </Bubble>
-                  </MessageContent>
-                </Message>
-              </ConversationItem>
-            ),
-          )}
-          {status === "thinking" ? (
-            <ConversationItem messageId="hermes:working">
-              <Reasoning streaming>
-                <span className="shimmer">Working on it…</span>
-              </Reasoning>
-            </ConversationItem>
-          ) : null}
-        </ConversationContent>
-      </Conversation>
-      <div className="mx-auto w-full max-w-[760px] px-5 pb-5">
-        <PromptInput value={draft} onChange={setDraft} onSubmit={() => void submit()} onAbort={status !== "idle" ? abort : undefined} busy={status !== "idle" || uploadingAttachments} disabled={uploadingAttachments} canSubmit={composerReady} attachments={attachmentPreviews} placeholder="Reply to Hermes…" footer={composerFooter} />
-      </div>
+      {empty ? (
+        <div className="mx-auto flex min-h-0 w-full max-w-[868px] flex-1 flex-col px-5 pb-5">
+          <div className="flex min-h-[180px] flex-1 flex-col items-center justify-center pb-8 text-center">
+            <BrandLogo size={48} color="var(--text-primary)" className="mb-5" />
+            <h1
+              className="text-[32px] font-medium leading-tight tracking-[-0.02em] sm:text-[36px]"
+              style={{ color: "var(--text-primary)", fontFamily: '"Instrument Serif", Georgia, serif' }}
+            >
+              How can I help you?
+            </h1>
+          </div>
+          <div className="shrink-0">{renderComposer("How can I help you today?", true)}</div>
+        </div>
+      ) : (
+        <>
+          <Conversation>
+            <ConversationContent className="justify-start pt-[clamp(72px,30vh,280px)]">
+              {groups.map((group) =>
+                group.type === "tool_group" ? (
+                  <ConversationItem key={group.messages[0]?.id ?? "tools"} messageId={group.messages[0]?.id}>
+                    <div className="flex flex-col gap-1.5">
+                      {group.messages.map((message) => (
+                        <Tool key={message.id} name={message.content} detail={message.toolInput ? JSON.stringify(message.toolInput, null, 2) : undefined} />
+                      ))}
+                    </div>
+                  </ConversationItem>
+                ) : group.message.role === "user" ? (
+                  <ConversationItem key={group.message.id} messageId={`user:${group.message.id}`} scrollAnchor>
+                    <Message align="end">
+                      <MessageContent>
+                        <Bubble variant="secondary" align="end">
+                          {(() => {
+                            const display = conversationMessageDisplay(group.message.content);
+                            return (
+                              <BubbleContent className="max-w-[580px] whitespace-pre-wrap" data-selectable>
+                                {display.text}
+                                {display.attachments.length > 0 ? (
+                                  <span className="mt-2 flex flex-wrap justify-end gap-1.5">
+                                    {display.attachments.map((name) => (
+                                      <span
+                                        key={name}
+                                        className="inline-flex max-w-full items-center gap-1.5 rounded-md border px-2 py-1 text-xs"
+                                        style={{ borderColor: "var(--border-default)", color: "var(--text-secondary)" }}
+                                      >
+                                        <FileText size={12} aria-hidden className="shrink-0" />
+                                        <span className="truncate">{name}</span>
+                                      </span>
+                                    ))}
+                                  </span>
+                                ) : null}
+                              </BubbleContent>
+                            );
+                          })()}
+                        </Bubble>
+                      </MessageContent>
+                    </Message>
+                  </ConversationItem>
+                ) : (
+                  <ConversationItem key={group.message.id} messageId={`assistant:${group.message.id}`}>
+                    <Message>
+                      <MessageContent>
+                        <Bubble variant="ghost">
+                          <BubbleContent className="max-w-[620px] overflow-visible">
+                            <MessageResponse>{group.message.content}</MessageResponse>
+                          </BubbleContent>
+                        </Bubble>
+                      </MessageContent>
+                    </Message>
+                  </ConversationItem>
+                ),
+              )}
+              {status === "thinking" ? (
+                <ConversationItem messageId="hermes:working">
+                  <Reasoning streaming><span className="shimmer">Working on it…</span></Reasoning>
+                </ConversationItem>
+              ) : null}
+            </ConversationContent>
+          </Conversation>
+          <div className="mx-auto w-full max-w-[868px] shrink-0 px-5 pb-5">
+            {renderComposer("Reply to Hermes…")}
+          </div>
+        </>
+      )}
+
+      {resourcesOpen ? (
+        <ChatResourcesPanel
+          messages={messages}
+          onClose={closeResources}
+          onUpload={() => {
+            fileInputRef.current?.click();
+            closeResources(false);
+          }}
+        />
+      ) : null}
     </div>
   );
 }
 
-// Unified chat: a Codex-style rail listing Hermes + every agent thread on the
-// left, the selected conversation on the right. Kernel runs open in-pane;
-// coding-agent threads route into their project tab's Chats view.
 export default function ChatTab() {
-  const threads = useThreads((s) => s.threads);
-  const activeThreadId = useThreads((s) => s.activeThreadId);
-  const setActiveThread = useThreads((s) => s.setActiveThread);
-  const recordRecentConversation = useTabs((s) => s.recordRecentConversation);
-  // Short-circuit inside the selector so a disabled workspace never re-renders
-  // the rail on coding-agent store updates.
-  const summary = useCodingAgentWorkspace((s) => (CODING_AGENTS_DESKTOP_WORKSPACE ? s.summary : null));
-  const api = useConnection((s) => s.api);
-  const conversationView = useHermesChat((s) => s.view);
-  const sessionId = useHermesChat((s) => s.sessionId);
-  const conversations = useHermesChat((s) => s.conversations);
-  const indexStatus = useHermesChat((s) => s.indexStatus);
-  const refreshConversations = useHermesChat((s) => s.refreshConversations);
-  const createConversation = useHermesChat((s) => s.createConversation);
-  const showIndex = useHermesChat((s) => s.showIndex);
+  const api = useConnection((state) => state.api);
+  const conversationView = useHermesChat((state) => state.view);
+  const indexStatus = useHermesChat((state) => state.indexStatus);
+  const refreshConversations = useHermesChat((state) => state.refreshConversations);
 
   useEffect(() => {
     if (api && indexStatus === "idle") void refreshConversations(api);
   }, [api, indexStatus, refreshConversations]);
 
-  const railThreads = useMemo(
-    () => listUnifiedThreads(threads, summary),
-    [threads, summary],
-  );
-
-  const selectRailThread = (item: UnifiedThreadItem) => {
-    recordRecentConversation(item.id, item.title);
-    if (item.source === "kernel") {
-      setActiveThread(item.id);
-      return;
-    }
-    void openCodingAgentThread(item.id);
-  };
-
-  // activeThreadId is the single source of truth: null → Hermes, otherwise the
-  // selected agent run (the composer and sidebar Chat both drive it).
-  const activeThread = activeThreadId ? threads.find((t) => t.id === activeThreadId) ?? null : null;
-  const showHermes = !activeThread;
-  const activeConversationTitle = conversations.find((conversation) => conversation.id === sessionId)?.title ?? "Hermes";
-
-  const openConversationIndex = () => {
-    setActiveThread(null);
-    showIndex();
-  };
-
-  const startConversation = () => {
-    setActiveThread(null);
-    if (api) void createConversation(api);
-  };
-
   return (
-    <div className="flex min-h-0 flex-1">
-      <div className="flex w-[260px] shrink-0 flex-col border-r" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}>
-        <div className="flex items-center justify-between border-b px-3 py-2.5" style={{ borderColor: "var(--border-subtle)" }}>
-          <span className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>Chat</span>
-          <button
-            type="button"
-            className="flex items-center gap-1.5 rounded-md px-2 py-1 text-sm hover:bg-[var(--bg-hover)]"
-            style={{ color: "var(--text-secondary)" }}
-            onClick={startConversation}
-            title="New conversation with Hermes"
-            aria-label="New conversation"
-            disabled={!api}
-          >
-            <MessageSquarePlus size={13} />
-            New
-          </button>
-        </div>
-        <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-1.5">
-          <RailButton
-            active={showHermes && conversationView === "index"}
-            onClick={openConversationIndex}
-            dot={<MessageSquare size={14} style={{ color: showHermes && conversationView === "index" ? "var(--accent)" : "var(--text-tertiary)" }} />}
-            label="Conversations"
-          />
-          {conversationView === "conversation" ? (
-            <RailButton
-              active={showHermes}
-              onClick={() => {
-                setActiveThread(null);
-                if (sessionId) recordRecentConversation(sessionId, activeConversationTitle);
-              }}
-              dot={<Sparkles size={14} style={{ color: showHermes ? "var(--accent)" : "var(--text-tertiary)" }} />}
-              label={activeConversationTitle}
-            />
-          ) : null}
-          {railThreads.length > 0 ? (
-            <span className="px-2.5 pt-2 pb-0.5 text-xs font-semibold tracking-wide uppercase" style={{ color: "var(--text-tertiary)" }}>
-              Agent runs
-            </span>
-          ) : null}
-          {railThreads.map((item) => (
-            <RailButton
-              key={`${item.source}:${item.id}`}
-              active={item.source === "kernel" && item.id === activeThreadId}
-              onClick={() => selectRailThread(item)}
-              dot={<StatusDot color={UNIFIED_THREAD_STATUS_META[item.status].color} pulse={item.status === "running"} />}
-              label={item.title}
-              bold={item.unread}
-            />
-          ))}
-        </div>
-      </div>
-
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-        {activeThread ? (
-          <ThreadView threadId={activeThread.id} embedded />
-        ) : conversationView === "index" ? (
-          <HermesConversationIndex api={api} />
-        ) : (
-          <HermesPane />
-        )}
-      </div>
+    <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
+      {conversationView === "index" ? <HermesConversationIndex api={api} /> : <HermesPane />}
     </div>
   );
 }

--- a/desktop/src/renderer/src/features/chat/HermesConversationIndex.tsx
+++ b/desktop/src/renderer/src/features/chat/HermesConversationIndex.tsx
@@ -13,6 +13,7 @@ import {
   useHermesChat,
   type HermesConversationSummary,
 } from "../../stores/hermes-chat";
+import { useTabs } from "../../stores/tabs";
 import { DeleteConversationDialog } from "./DeleteConversationDialog";
 import { filterConversations } from "./conversation-search";
 
@@ -42,54 +43,54 @@ function ConversationRow({
   const loadingConversationId = useHermesChat((state) => state.loadingConversationId);
   const deletingConversationId = useHermesChat((state) => state.deletingConversationId);
   const openConversation = useHermesChat((state) => state.openConversation);
+  const recordRecentConversation = useTabs((state) => state.recordRecentConversation);
   const running = conversation.id === sessionId && status !== "idle";
   const loading = loadingConversationId === conversation.id;
   const deleting = deletingConversationId === conversation.id;
   const runningDescriptionId = `delete-running-${conversation.id}`;
+  const openSelectedConversation = async () => {
+    if (!api) return;
+    if (await openConversation(api, conversation.id)) {
+      recordRecentConversation(conversation.id, conversation.title);
+    }
+  };
 
   return (
     <div
-      className="group flex min-h-[76px] items-stretch border-b last:border-b-0"
+      data-conversation-row
+      className="group relative flex h-16 items-stretch border-b last:border-b-0"
       style={{ borderColor: "var(--border-subtle)" }}
     >
       <button
         type="button"
         aria-label={`${conversation.title} conversation`}
-        className="min-w-0 flex-1 px-3 py-3 text-left transition-colors hover:bg-[var(--bg-hover)] focus-visible:bg-[var(--bg-hover)] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-[-2px]"
+        className="min-w-0 flex-1 px-4 pr-14 text-left transition-colors hover:bg-[var(--bg-hover)] focus-visible:bg-[var(--bg-hover)] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-[-2px]"
         disabled={loading || !api}
-        onClick={() => {
-          if (api) void openConversation(api, conversation.id);
-        }}
+        onClick={() => void openSelectedConversation()}
       >
-        <span className="flex min-w-0 items-start gap-4">
-          <span className="min-w-0 flex-1">
-            <span className="block truncate text-sm font-medium" style={{ color: "var(--text-primary)" }}>
-              {conversation.title}
-            </span>
-            <span className="mt-1 block truncate text-sm" style={{ color: "var(--text-secondary)" }}>
-              {conversation.preview || "No messages yet"}
-            </span>
+        <span className="flex h-full min-w-0 items-center gap-4">
+          <span className="min-w-0 flex-1 truncate text-base font-medium" style={{ color: "var(--text-primary)" }}>
+            {conversation.title}
           </span>
-          <span className="flex w-28 shrink-0 flex-col items-start gap-1 text-xs" style={{ color: "var(--text-tertiary)" }}>
-            <span>Hermes</span>
-            <span>{conversation.messageCount} {conversation.messageCount === 1 ? "message" : "messages"}</span>
-          </span>
-          <span className="flex w-20 shrink-0 justify-end text-xs" style={{ color: "var(--text-tertiary)" }}>
+          <span className="flex shrink-0 items-center gap-5 text-xs transition-opacity group-hover:opacity-0 group-focus-within:opacity-0" style={{ color: "var(--text-tertiary)" }}>
+            <span className="rounded-full border px-2 py-1 font-medium" style={{ borderColor: "var(--border-default)" }}>Hermes</span>
             {running ? (
               <span className="flex items-center gap-1.5" style={{ color: "var(--accent)" }}>
                 <span className="h-1.5 w-1.5 rounded-full bg-[var(--accent)]" aria-hidden />
                 Running
               </span>
-            ) : loading ? "Opening…" : relativeActivity(conversation.updatedAt)}
+            ) : loading ? <span>Opening…</span> : (
+              <time dateTime={new Date(conversation.updatedAt).toISOString()}>{relativeActivity(conversation.updatedAt)}</time>
+            )}
           </span>
         </span>
       </button>
-      <span className="flex w-10 shrink-0 items-center justify-center">
+      <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center justify-center">
         <button
           type="button"
           aria-label={`Delete ${conversation.title}`}
           aria-describedby={running ? runningDescriptionId : undefined}
-          className="pointer-events-none inline-flex h-7 w-7 items-center justify-center rounded-md opacity-0 transition-colors hover:bg-[var(--danger-muted)] focus:bg-[var(--danger-muted)] focus:opacity-100 focus:pointer-events-auto focus-visible:outline-2 focus-visible:outline-[var(--danger)] group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto disabled:cursor-not-allowed disabled:opacity-40"
+          className="pointer-events-none inline-flex h-8 w-8 items-center justify-center rounded-md opacity-0 transition-colors hover:bg-[var(--danger-muted)] focus:bg-[var(--danger-muted)] focus:opacity-100 focus:pointer-events-auto focus-visible:outline-2 focus-visible:outline-[var(--danger)] group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto disabled:cursor-not-allowed disabled:opacity-40"
           style={{ color: "var(--danger)" }}
           disabled={!api || running || deleting || deletingConversationId !== null}
           onClick={() => onRequestDelete(conversation)}
@@ -119,6 +120,7 @@ function HermesConversationIndexContent({ api }: { api: ApiClient | null }) {
   const createConversation = useHermesChat((state) => state.createConversation);
   const deleteConversation = useHermesChat((state) => state.deleteConversation);
   const clearDeleteError = useHermesChat((state) => state.clearDeleteError);
+  const recordRecentConversation = useTabs((state) => state.recordRecentConversation);
   const filteredConversations = useMemo(
     () => filterConversations(conversations, query),
     [conversations, query],
@@ -139,12 +141,19 @@ function HermesConversationIndexContent({ api }: { api: ApiClient | null }) {
       setDeleteTarget(null);
     }
   };
+  const startConversation = async () => {
+    if (!api) return;
+    const id = await createConversation(api);
+    if (!id) return;
+    const created = useHermesChat.getState().conversations.find((item) => item.id === id);
+    recordRecentConversation(id, created?.title ?? "New chat");
+  };
 
   return (
-    <section className="flex min-h-0 flex-1 flex-col overflow-y-auto px-6 py-6" aria-labelledby="conversation-index-title">
-      <div className="mx-auto flex w-full max-w-[840px] flex-col">
-        <div className="mb-5 flex min-h-9 min-w-0 items-center justify-between gap-4">
-          <h1 id="conversation-index-title" className="text-xl font-semibold tracking-tight" style={{ color: "var(--text-primary)" }}>
+    <section className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 py-6 sm:px-8" aria-labelledby="conversation-index-title">
+      <div className="mx-auto flex w-full max-w-[1020px] flex-col">
+        <div className="mb-6 flex min-h-10 min-w-0 items-center justify-between gap-4">
+          <h1 id="conversation-index-title" className="text-[36px] font-medium leading-none tracking-[-0.02em]" style={{ color: "var(--text-primary)", fontFamily: '"Instrument Serif", Georgia, serif' }}>
             Chats
           </h1>
           <div className="flex min-w-0 flex-1 items-center justify-end gap-2">
@@ -193,7 +202,7 @@ function HermesConversationIndexContent({ api }: { api: ApiClient | null }) {
               variant="subtle"
               className="h-8"
               disabled={!api}
-              onClick={() => { if (api) void createConversation(api); }}
+              onClick={() => void startConversation()}
             >
               <MessageSquarePlus size={14} aria-hidden />
               New chat
@@ -206,7 +215,7 @@ function HermesConversationIndexContent({ api }: { api: ApiClient | null }) {
             {[0, 1, 2].map((item) => (
               <div
                 key={item}
-                className="h-[76px] animate-pulse border-b last:border-b-0"
+                className="h-16 animate-pulse border-b last:border-b-0"
                 style={{ background: "var(--bg-surface)", borderColor: "var(--border-subtle)" }}
               />
             ))}

--- a/desktop/src/renderer/src/features/chat/elements/conversation.tsx
+++ b/desktop/src/renderer/src/features/chat/elements/conversation.tsx
@@ -182,16 +182,17 @@ export function Conversation({ children, ref }: { children: ReactNode; ref?: Ref
   );
 }
 
-export function ConversationContent({ children }: { children: ReactNode }) {
-  // min-h-full + justify-end bottom-anchors short conversations (latest message
-  // sits just above the composer) while longer ones scroll normally. The log
+export function ConversationContent({ children, className }: { children: ReactNode; className?: string }) {
+  // min-h-full + the default justify-end bottom-anchors short conversations;
+  // callers with an approved transcript layout can override that alignment.
+  // Longer conversations scroll normally. The log
   // role marks the transcript as a live region whose streamed text mutations
   // are not announced token by token (aria-relevant=additions only).
   // The 46rem centered column keeps line length readable (Codex-style) while
   // the scroll viewport itself stays full-width for the edge fade.
   return (
     <div
-      className="mx-auto flex min-h-full w-full max-w-[46rem] flex-col justify-end gap-5 px-6 py-6"
+      className={cn("mx-auto flex min-h-full w-full max-w-[46rem] flex-col gap-5 px-6 py-6", className ?? "justify-end")}
       role="log"
       aria-relevant="additions"
       data-slot="message-scroller-content"

--- a/desktop/src/renderer/src/features/chat/elements/prompt-input.tsx
+++ b/desktop/src/renderer/src/features/chat/elements/prompt-input.tsx
@@ -17,6 +17,7 @@ export function PromptInput({
   ariaLabel,
   footer,
   controls,
+  trailingControls,
   attachments,
   canSubmit,
   focusRequestId,
@@ -37,6 +38,8 @@ export function PromptInput({
   // Left side of the bottom row: compact pickers (provider, mode) rendered
   // Codex-style next to the send/stop control. Purely presentational slot.
   controls?: ReactNode;
+  // Compact, real actions or status placed immediately before Send/Stop.
+  trailingControls?: ReactNode;
   // Bumping this id focuses the textarea (type-to-start, ⌘J, chip seeds).
   focusRequestId?: number;
 }) {
@@ -87,6 +90,7 @@ export function PromptInput({
           {controls}
         </div>
         <div className="flex shrink-0 items-center gap-1.5">
+          {trailingControls}
           {busy && onAbort ? (
             <button
               type="button"

--- a/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
+++ b/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
@@ -12,6 +12,7 @@ import { useMemo, useRef, useState } from "react";
 import { BrandLogo } from "../../design/BrandPanel";
 import { useBoard } from "../../stores/board";
 import { useCodingAgentWorkspace } from "../../stores/coding-agent-workspace";
+import { useHermesChat } from "../../stores/hermes-chat";
 import { FILES_WORKSPACE_TAB_SPEC, useTabs } from "../../stores/tabs";
 import { useThreads } from "../../stores/threads";
 import { kernelThreadAttentionCount } from "../../stores/unified-threads";
@@ -89,7 +90,6 @@ export default function Sidebar() {
   const activeTabId = useTabs((s) => s.activeTabId);
   const openTab = useTabs((s) => s.openTab);
   const focusTab = useTabs((s) => s.focusTab);
-  const recordRecentConversation = useTabs((s) => s.recordRecentConversation);
   const projects = useBoard((s) => s.projects);
   const openApps = useMemo(() => tabs.filter((t) => t.kind === "app"), [tabs]);
   const chatAttention = useThreads((s) => kernelThreadAttentionCount(s.threads));
@@ -124,7 +124,7 @@ export default function Sidebar() {
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-2 pb-2">
         <nav className="flex flex-col gap-0.5">
           <NavRow icon={<Home size={15} />} label="Home" collapsed={collapsed} active={activeTab?.kind === "home"} onClick={() => openTab({ kind: "home", title: "Home", closable: false })} />
-          <NavRow icon={<Sparkles size={15} />} label="Chat" collapsed={collapsed} active={activeTab?.kind === "chat"} badge={chatAttention} onClick={() => { useThreads.getState().setActiveThread(null); recordRecentConversation("hermes", "Hermes"); openTab({ kind: "chat", title: "Hermes", closable: false }); }} />
+          <NavRow icon={<Sparkles size={15} />} label="Chat" collapsed={collapsed} active={activeTab?.kind === "chat"} badge={chatAttention} onClick={() => { useThreads.getState().setActiveThread(null); useHermesChat.getState().showIndex(); openTab({ kind: "chat", title: "Hermes", closable: false }); }} />
           <NavRow icon={<SquareTerminal size={15} />} label="Terminal" collapsed={collapsed} active={activeTab?.kind === "terminals"} onClick={() => openTab({ kind: "terminals", title: "Terminal" })} />
           <NavRow icon={<FolderTree size={15} />} label="Files" collapsed={collapsed} active={activeTab?.kind === "files"} onClick={() => openTab(FILES_WORKSPACE_TAB_SPEC)} />
           <NavRow icon={<LayoutGrid size={15} />} label="Apps" collapsed={collapsed} active={activeTab?.kind === "apps" || activeTab?.kind === "app"} onClick={() => openTab({ kind: "apps", title: "Apps" })} />

--- a/desktop/src/renderer/src/features/mission-control/shortcuts.ts
+++ b/desktop/src/renderer/src/features/mission-control/shortcuts.ts
@@ -142,7 +142,7 @@ export function handleNewAgentRunShortcut(
   // project's Chats view still opens either way.
   const canCompose = canRequestAgentComposerFocus(workspace.summary);
   if (canCompose) workspace.requestComposerFocus();
-  openProjectChat(projectId, { compose: canCompose });
+  void openProjectChat(projectId, { compose: canCompose });
 }
 
 export function useGlobalShortcuts(): void {

--- a/desktop/src/renderer/src/features/palette/CommandPalette.tsx
+++ b/desktop/src/renderer/src/features/palette/CommandPalette.tsx
@@ -300,7 +300,7 @@ export default function CommandPalette() {
                       // Reviews surface in the Changes tab of their project's
                       // Chats view; the review focus request forces the pane.
                       const projectId = review.projectId ?? defaultProjectId();
-                      if (projectId) openProjectChat(projectId);
+                      if (projectId) void openProjectChat(projectId);
                       void selectReview(review.id);
                     })
                   }

--- a/desktop/src/renderer/src/features/project/ProjectChatsView.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatsView.tsx
@@ -37,7 +37,7 @@ import { capabilityEnabled } from "../coding-agents/capabilities";
 import { isTypeToStartInteractiveTarget } from "../coding-agents/type-to-start";
 import { CreatedThreadHandleList, ThreadList } from "../coding-agents/AgentThreadLists";
 import { ReviewList, reviewHunkFollowUpDraft } from "../coding-agents/AgentReviewPanel";
-import { openCodingAgentThread } from "../../lib/project-chat";
+import { loadCodingAgentConversation, openCodingAgentThread } from "../../lib/project-chat";
 import { ProjectChatDraft } from "./ProjectChatDraft";
 import { ProjectThreadList } from "./ProjectThreadList";
 
@@ -66,7 +66,6 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
   const reviewFocusRequestId = useCodingAgentWorkspace((s) => s.reviewFocusRequestId);
   const reviewFocusConsumedId = useCodingAgentWorkspace((s) => s.reviewFocusConsumedId);
   const consumeReviewFocusRequest = useCodingAgentWorkspace((s) => s.consumeReviewFocusRequest);
-  const loadThreadSnapshot = useCodingAgentWorkspace((s) => s.loadThreadSnapshot);
   const requestComposerFocus = useCodingAgentWorkspace((s) => s.requestComposerFocus);
   const composerFocusRequestId = useCodingAgentWorkspace((s) => s.composerFocusRequestId);
   const workspaceEntry = useProjectWorkspaces((s) => s.entries[projectId]);
@@ -343,8 +342,13 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
 
   // Global Recents owns cross-surface conversation navigation. Same-project
   // selections stay local, while cross-project selections use the canonical
-  // launcher. Both paths record the stable thread id and a bounded title.
-  const openListedThread = (threadId: string, threadProjectId?: string, threadTitle?: string) => {
+  // launcher. Both paths record the stable thread id only after the owning
+  // project and matching snapshot have loaded successfully.
+  const openListedThread = async (
+    threadId: string,
+    threadProjectId?: string,
+    threadTitle?: string,
+  ): Promise<void> => {
     newChatRequestIdRef.current += 1;
     setComposerSeed(null);
     const listedTitle = threadTitle ?? [
@@ -353,14 +357,13 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
       ...(workspace?.projectThreads.items ?? []),
       ...(workspace?.taskThreads.items ?? []),
     ].find((thread) => thread.id === threadId)?.title ?? "Agent conversation";
-    recordRecentConversation(threadId, listedTitle);
     if (threadProjectId && threadProjectId !== projectId) {
-      void openCodingAgentThread(threadId);
+      await openCodingAgentThread(threadId);
       return;
     }
     setSelectedThread(projectId, threadId);
-    if (useCodingAgentWorkspace.getState().activeThreadId !== threadId) {
-      void loadThreadSnapshot(threadId);
+    if (await loadCodingAgentConversation(projectId, threadId)) {
+      recordRecentConversation(threadId, listedTitle);
     }
   };
 

--- a/desktop/src/renderer/src/features/project/ProjectChatsView.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatsView.tsx
@@ -9,6 +9,7 @@ import { useCodingAgentWorkspace } from "../../stores/coding-agent-workspace";
 import { useConnection } from "../../stores/connection";
 import { useProjectView } from "../../stores/project-view";
 import { useProjectWorkspaces } from "../../stores/project-workspaces";
+import { useTabs } from "../../stores/tabs";
 import {
   DEFAULT_INSPECTOR_WIDTH_PCT,
   MAX_INSPECTOR_WIDTH_PCT,
@@ -74,6 +75,7 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
   const resolveNewChatTarget = useProjectWorkspaces((s) => s.resolveNewChatTarget);
   const selectedThreadId = useProjectView((s) => s.entries[projectId]?.selectedThreadId ?? null);
   const setSelectedThread = useProjectView((s) => s.setSelectedThread);
+  const recordRecentConversation = useTabs((s) => s.recordRecentConversation);
   const composerRequest = useProjectChatLauncher((s) => s.composerRequest);
   const runtimeScope = useConnection(codingAgentRuntimeScope);
   const inspectorEntry = useInspectorLayout((s) => s.entries[projectId]);
@@ -339,16 +341,23 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
     activity: summary.attentionThreads.items.length + summary.activeThreads.items.length,
   };
 
-  // Threads opened from the runtime-wide inspector lists open in their own
-  // project context when they belong elsewhere. Selecting a thread also drops
-  // any pending draft seed so a remounted draft never reapplies a stale one.
-  const openListedThread = (threadId: string, threadProjectId?: string) => {
+  // Global Recents owns cross-surface conversation navigation. Same-project
+  // selections stay local, while cross-project selections use the canonical
+  // launcher. Both paths record the stable thread id and a bounded title.
+  const openListedThread = (threadId: string, threadProjectId?: string, threadTitle?: string) => {
+    newChatRequestIdRef.current += 1;
+    setComposerSeed(null);
+    const listedTitle = threadTitle ?? [
+      ...summary.attentionThreads.items,
+      ...summary.activeThreads.items,
+      ...(workspace?.projectThreads.items ?? []),
+      ...(workspace?.taskThreads.items ?? []),
+    ].find((thread) => thread.id === threadId)?.title ?? "Agent conversation";
+    recordRecentConversation(threadId, listedTitle);
     if (threadProjectId && threadProjectId !== projectId) {
       void openCodingAgentThread(threadId);
       return;
     }
-    newChatRequestIdRef.current += 1;
-    setComposerSeed(null);
     setSelectedThread(projectId, threadId);
     if (useCodingAgentWorkspace.getState().activeThreadId !== threadId) {
       void loadThreadSnapshot(threadId);
@@ -510,15 +519,15 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
           <div className="space-y-4">
             <AttentionThreadList
               summary={summary}
-              onOpenThread={(thread) => openListedThread(thread.id, thread.projectId)}
+              onOpenThread={(thread) => openListedThread(thread.id, thread.projectId, thread.title)}
             />
             <ThreadList
               summary={summary}
-              onOpenThread={(thread) => openListedThread(thread.id, thread.projectId)}
+              onOpenThread={(thread) => openListedThread(thread.id, thread.projectId, thread.title)}
             />
             <CreatedThreadHandleList
               summary={summary}
-              onOpenThread={(thread) => openListedThread(thread.id, thread.projectId)}
+              onOpenThread={(thread) => openListedThread(thread.id, thread.projectId, thread.title)}
             />
             <ProviderList summary={summary} />
             <NotificationPreferencesPanel />

--- a/desktop/src/renderer/src/lib/project-chat.ts
+++ b/desktop/src/renderer/src/lib/project-chat.ts
@@ -18,6 +18,9 @@ export interface OpenProjectChatOptions {
   threadId?: string | null;
   // Open the new-chat composer for the project once the view is visible.
   compose?: boolean;
+  // Unknown threads may still open under a best-effort fallback project, but
+  // that unverified route must never become a persistent global Recent.
+  recordRecent?: boolean;
 }
 
 interface ProjectChatLauncherState {
@@ -88,7 +91,53 @@ function conversationTitleFor(threadId: string): string {
   return "Agent conversation";
 }
 
-export function openProjectChat(projectId: string, options: OpenProjectChatOptions = {}): void {
+/**
+ * Loads the project and thread projections that make a coding-agent route
+ * durable. The stores normalize failures into explicit state, so success must
+ * be verified after both awaited operations instead of inferred from a
+ * resolved Promise.
+ */
+export async function loadCodingAgentConversation(
+  projectId: string,
+  threadId: string,
+): Promise<boolean> {
+  const runtimeGeneration = captureRuntimeGeneration();
+  let workspaceReady = false;
+  try {
+    await useProjectWorkspaces.getState().ensure(projectId);
+  } catch (err: unknown) {
+    console.warn("[project-chat] project workspace open failed:", diagnosticErrorKind(err));
+  }
+  if (!isCurrentRuntimeGeneration(runtimeGeneration)) return false;
+  const projectWorkspace = useProjectWorkspaces.getState().entries[projectId];
+  workspaceReady = projectWorkspace?.status === "ready"
+    && projectWorkspace.workspace?.project.id === projectId;
+
+  const current = useCodingAgentWorkspace.getState();
+  const alreadyLoaded = current.activeThreadId === threadId
+    && current.threadSnapshotStatus === "ready"
+    && current.threadSnapshot?.thread.id === threadId;
+  if (!alreadyLoaded) {
+    try {
+      await current.loadThreadSnapshot(threadId);
+    } catch (err: unknown) {
+      console.warn("[project-chat] thread open failed:", diagnosticErrorKind(err));
+      return false;
+    }
+  }
+  if (!isCurrentRuntimeGeneration(runtimeGeneration)) return false;
+  const loaded = useCodingAgentWorkspace.getState();
+  return workspaceReady
+    && loaded.activeThreadId === threadId
+    && loaded.threadSnapshotStatus === "ready"
+    && loaded.threadSnapshot?.thread.id === threadId
+    && loaded.threadSnapshot.thread.projectId === projectId;
+}
+
+export async function openProjectChat(
+  projectId: string,
+  options: OpenProjectChatOptions = {},
+): Promise<boolean> {
   const projectView = useProjectView.getState();
   projectView.setView(projectId, "chats");
   // Only an explicit thread updates the selection; a bare open keeps the
@@ -101,28 +150,23 @@ export function openProjectChat(projectId: string, options: OpenProjectChatOptio
     projectSlug: projectId,
     title: projectTitleFor(projectId),
   });
-  if (options.threadId) {
+  if (options.compose) {
+    useProjectChatLauncher.getState().requestComposer(projectId);
+  }
+  if (!options.threadId) {
+    // Preserve the existing fire-and-forget project bootstrap for non-thread
+    // navigation; there is no conversation Recent to gate in this path.
+    void useProjectWorkspaces.getState().ensure(projectId);
+    return true;
+  }
+  const opened = await loadCodingAgentConversation(projectId, options.threadId);
+  if (opened && options.recordRecent !== false) {
     useTabs.getState().recordRecentConversation(
       options.threadId,
       conversationTitleFor(options.threadId),
     );
   }
-  // ensure() records load failures in its own entry state and never rejects.
-  void useProjectWorkspaces.getState().ensure(projectId);
-  if (options.threadId) {
-    const workspace = useCodingAgentWorkspace.getState();
-    if (workspace.activeThreadId !== options.threadId) {
-      workspace.loadThreadSnapshot(options.threadId).catch((err: unknown) => {
-        console.warn(
-          "[project-chat] thread open failed:",
-          diagnosticErrorKind(err),
-        );
-      });
-    }
-  }
-  if (options.compose) {
-    useProjectChatLauncher.getState().requestComposer(projectId);
-  }
+  return opened;
 }
 
 /**
@@ -173,6 +217,7 @@ export async function openCodingAgentThread(threadId: string): Promise<void> {
   // to be active; the snapshot later reveals the real projectId but nothing
   // reroutes, so the chat stays selected and persisted under the wrong project.
   const known = listed?.projectId ?? snapshotProjectId ?? workspaceProjectId;
+  let resolvedAuthoritatively = known !== undefined;
   let projectId = known;
   if (!projectId) {
     const runtimeGeneration = captureRuntimeGeneration();
@@ -184,10 +229,14 @@ export async function openCodingAgentThread(threadId: string): Promise<void> {
     // Only guess when the runtime genuinely could not resolve it. The guess
     // opens the chat under whichever project is active and nothing reroutes.
     projectId = resolved ?? defaultProjectId() ?? undefined;
+    resolvedAuthoritatively = resolved !== undefined;
   }
   if (!projectId) {
     console.warn("[project-chat] cannot open a thread before any project exists");
     return;
   }
-  openProjectChat(projectId, { threadId });
+  await openProjectChat(projectId, {
+    threadId,
+    recordRecent: resolvedAuthoritatively,
+  });
 }

--- a/desktop/src/renderer/src/lib/project-chat.ts
+++ b/desktop/src/renderer/src/lib/project-chat.ts
@@ -102,16 +102,12 @@ export async function loadCodingAgentConversation(
   threadId: string,
 ): Promise<boolean> {
   const runtimeGeneration = captureRuntimeGeneration();
-  let workspaceReady = false;
   try {
     await useProjectWorkspaces.getState().ensure(projectId);
   } catch (err: unknown) {
     console.warn("[project-chat] project workspace open failed:", diagnosticErrorKind(err));
   }
   if (!isCurrentRuntimeGeneration(runtimeGeneration)) return false;
-  const projectWorkspace = useProjectWorkspaces.getState().entries[projectId];
-  workspaceReady = projectWorkspace?.status === "ready"
-    && projectWorkspace.workspace?.project.id === projectId;
 
   const current = useCodingAgentWorkspace.getState();
   const alreadyLoaded = current.activeThreadId === threadId
@@ -126,8 +122,14 @@ export async function loadCodingAgentConversation(
     }
   }
   if (!isCurrentRuntimeGeneration(runtimeGeneration)) return false;
+  // A same-project refresh can supersede the workspace after ensure() settles
+  // while the thread snapshot is still loading. Re-read the authoritative
+  // entry here so a transient loading/error state cannot persist a broken
+  // conversation Recent.
+  const projectWorkspace = useProjectWorkspaces.getState().entries[projectId];
   const loaded = useCodingAgentWorkspace.getState();
-  return workspaceReady
+  return projectWorkspace?.status === "ready"
+    && projectWorkspace.workspace?.project.id === projectId
     && loaded.activeThreadId === threadId
     && loaded.threadSnapshotStatus === "ready"
     && loaded.threadSnapshot?.thread.id === threadId

--- a/desktop/src/renderer/src/lib/project-chat.ts
+++ b/desktop/src/renderer/src/lib/project-chat.ts
@@ -1,6 +1,6 @@
 // Canonical routing for opening coding-agent chats in the project-centric
 // shell. A chat always opens inside its project tab (Chats view active) —
-// notifications, the command palette, the chat rail, and future panels all
+// notifications, global Recents, the command palette, and future panels all
 // funnel through openProjectChat so there is exactly one way to land on a
 // conversation.
 import { create } from "zustand";
@@ -66,6 +66,28 @@ function projectTitleFor(projectId: string): string {
   return summaryProject?.label ?? projectId;
 }
 
+function conversationTitleFor(threadId: string): string {
+  const workspace = useCodingAgentWorkspace.getState();
+  const summaryThread = [
+    ...(workspace.summary?.attentionThreads.items ?? []),
+    ...(workspace.summary?.activeThreads.items ?? []),
+  ].find((thread) => thread.id === threadId);
+  if (summaryThread?.title) return summaryThread.title;
+  if (workspace.threadSnapshot?.thread.id === threadId) {
+    return workspace.threadSnapshot.thread.title;
+  }
+  for (const entry of Object.values(useProjectWorkspaces.getState().entries)) {
+    const projectWorkspace = entry.workspace;
+    if (!projectWorkspace) continue;
+    const listed = [
+      ...projectWorkspace.projectThreads.items,
+      ...projectWorkspace.taskThreads.items,
+    ].find((thread) => thread.id === threadId);
+    if (listed?.title) return listed.title;
+  }
+  return "Agent conversation";
+}
+
 export function openProjectChat(projectId: string, options: OpenProjectChatOptions = {}): void {
   const projectView = useProjectView.getState();
   projectView.setView(projectId, "chats");
@@ -79,6 +101,12 @@ export function openProjectChat(projectId: string, options: OpenProjectChatOptio
     projectSlug: projectId,
     title: projectTitleFor(projectId),
   });
+  if (options.threadId) {
+    useTabs.getState().recordRecentConversation(
+      options.threadId,
+      conversationTitleFor(options.threadId),
+    );
+  }
   // ensure() records load failures in its own entry state and never rejects.
   void useProjectWorkspaces.getState().ensure(projectId);
   if (options.threadId) {
@@ -98,7 +126,7 @@ export function openProjectChat(projectId: string, options: OpenProjectChatOptio
 }
 
 /**
- * Routes a coding-agent thread (notification, palette, chat rail) into its
+ * Routes a coding-agent thread (notification, palette, or Recents) into its
  * project context. The project is resolved from the runtime summary or the
  * already-loaded snapshot; when neither knows it, the default project is a
  * best-effort fallback so the conversation still opens somewhere sensible.

--- a/desktop/src/renderer/src/stores/project-workspaces.ts
+++ b/desktop/src/renderer/src/stores/project-workspaces.ts
@@ -194,12 +194,17 @@ export const useProjectWorkspaces = create<ProjectWorkspacesState>()((set, get) 
   ensure: async (projectId) => {
     const entry = get().entries[projectId];
     if (entry?.status === "ready") return;
-    const activeLoad = activeLoadPromises[projectId];
-    if (activeLoad) {
-      await activeLoad;
+    let joinedLoad = activeLoadPromises[projectId];
+    if (!joinedLoad) {
+      await loadWorkspace(projectId);
       return;
     }
-    await loadWorkspace(projectId);
+    while (joinedLoad) {
+      await joinedLoad;
+      const authoritativeLoad = activeLoadPromises[projectId];
+      if (!authoritativeLoad || authoritativeLoad === joinedLoad) return;
+      joinedLoad = authoritativeLoad;
+    }
   },
 
   refresh: async (projectId) => {

--- a/desktop/src/renderer/src/stores/project-workspaces.ts
+++ b/desktop/src/renderer/src/stores/project-workspaces.ts
@@ -45,6 +45,10 @@ interface ProjectWorkspacesState {
 // Per-project load generations: a load that settles after a newer load for the
 // same project started is stale and must be dropped.
 const loadGenerations: Record<string, number> = {};
+// Tracks only currently running loads and deletes each entry on settlement.
+// ensure() joins the authoritative in-flight request instead of treating a
+// transient `loading` projection as either success or failure.
+const activeLoadPromises: Record<string, Promise<void> | undefined> = {};
 
 
 function nextGeneration(projectId: string): number {
@@ -55,11 +59,13 @@ function nextGeneration(projectId: string): number {
 
 export function clearProjectWorkspaces(): void {
   for (const key of Object.keys(loadGenerations)) delete loadGenerations[key];
+  for (const key of Object.keys(activeLoadPromises)) delete activeLoadPromises[key];
   useProjectWorkspaces.setState({ entries: {}, runtimeScope: null });
 }
 
 export function clearProjectWorkspace(projectId: string): void {
   nextGeneration(projectId);
+  delete activeLoadPromises[projectId];
   useProjectWorkspaces.setState((state) => {
     if (!(projectId in state.entries)) return state;
     const entries = { ...state.entries };
@@ -105,7 +111,7 @@ function isStaleLoad(projectId: string, runtimeGeneration: number, generation: n
   return !isCurrentRuntimeGeneration(runtimeGeneration) || loadGenerations[projectId] !== generation;
 }
 
-async function loadWorkspace(projectId: string): Promise<void> {
+async function performWorkspaceLoad(projectId: string): Promise<void> {
   const runtimeGeneration = captureRuntimeGeneration();
   const generation = nextGeneration(projectId);
   useProjectWorkspaces.setState((state) => ({
@@ -162,6 +168,16 @@ async function loadWorkspace(projectId: string): Promise<void> {
   }
 }
 
+function loadWorkspace(projectId: string): Promise<void> {
+  const pending = performWorkspaceLoad(projectId).finally(() => {
+    if (activeLoadPromises[projectId] === pending) {
+      delete activeLoadPromises[projectId];
+    }
+  });
+  activeLoadPromises[projectId] = pending;
+  return pending;
+}
+
 export const useProjectWorkspaces = create<ProjectWorkspacesState>()((set, get) => ({
   entries: {},
   runtimeScope: null,
@@ -171,12 +187,18 @@ export const useProjectWorkspaces = create<ProjectWorkspacesState>()((set, get) 
     // Drop the previous owner's projections before anything new loads, and
     // reset the per-project sequences so the new scope starts clean.
     for (const key of Object.keys(loadGenerations)) delete loadGenerations[key];
+    for (const key of Object.keys(activeLoadPromises)) delete activeLoadPromises[key];
     set({ runtimeScope: scope, entries: {} });
   },
 
   ensure: async (projectId) => {
     const entry = get().entries[projectId];
-    if (entry && (entry.status === "ready" || entry.status === "loading")) return;
+    if (entry?.status === "ready") return;
+    const activeLoad = activeLoadPromises[projectId];
+    if (activeLoad) {
+      await activeLoad;
+      return;
+    }
     await loadWorkspace(projectId);
   },
 

--- a/tests/desktop/chat-tab-render.test.tsx
+++ b/tests/desktop/chat-tab-render.test.tsx
@@ -4,7 +4,10 @@ import React from "react";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ChatTab from "../../desktop/src/renderer/src/features/chat/ChatTab";
-import { sharedConversationResources } from "../../desktop/src/renderer/src/features/chat/ChatResourcesPanel";
+import {
+  conversationMessageDisplay,
+  sharedConversationResources,
+} from "../../desktop/src/renderer/src/features/chat/ChatResourcesPanel";
 import { useIntegrations } from "../../desktop/src/renderer/src/features/integrations/integrations-store";
 import { useBoard } from "../../desktop/src/renderer/src/stores/board";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
@@ -195,6 +198,20 @@ describe("ChatTab", () => {
     fireEvent.click(screen.getByRole("button", { name: "Resources" }));
     expect(screen.getByRole("complementary", { name: "Resources" }).textContent)
       .toContain("final report.pdf");
+  });
+
+  it("reports malformed attachment-name encoding before using a safe fallback", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect(conversationMessageDisplay(
+      "Review this\n\nAttached files (available on your Matrix computer):\n"
+      + "- ~/temporary/desktop-chat/abc-report%ZZ.pdf "
+      + "(/home/matrix/home/temporary/desktop-chat/abc-report%ZZ.pdf)",
+    )).toEqual({ text: "Review this", attachments: ["report%ZZ.pdf"] });
+    expect(warn).toHaveBeenCalledWith(
+      "[chat-resources] attachment name decode failed:",
+      "URIError",
+    );
   });
 
   it("states unavailable and failed connected-tool Gateway capabilities explicitly", () => {

--- a/tests/desktop/chat-tab-render.test.tsx
+++ b/tests/desktop/chat-tab-render.test.tsx
@@ -4,20 +4,14 @@ import React from "react";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ChatTab from "../../desktop/src/renderer/src/features/chat/ChatTab";
+import { sharedConversationResources } from "../../desktop/src/renderer/src/features/chat/ChatResourcesPanel";
+import { useIntegrations } from "../../desktop/src/renderer/src/features/integrations/integrations-store";
 import { useBoard } from "../../desktop/src/renderer/src/stores/board";
-import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 import { useHermesChat } from "../../desktop/src/renderer/src/stores/hermes-chat";
-import { useProjectView } from "../../desktop/src/renderer/src/stores/project-view";
-import { useProjectWorkspaces } from "../../desktop/src/renderer/src/stores/project-workspaces";
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 import { useThreads, type AgentThread } from "../../desktop/src/renderer/src/stores/threads";
-
-vi.mock("../../desktop/src/renderer/src/features/threads/ThreadView", () => ({
-  default: ({ threadId }: { threadId: string }) => (
-    <div data-testid="thread-view">thread:{threadId}</div>
-  ),
-}));
+import { useUi } from "../../desktop/src/renderer/src/stores/ui";
 
 function thread(id: string, title: string): AgentThread {
   return {
@@ -31,40 +25,6 @@ function thread(id: string, title: string): AgentThread {
     unread: false,
     createdAt: 1,
     updatedAt: 1,
-  };
-}
-
-function codingAgentSummaryFixture() {
-  return {
-    runtime: { id: "rt_primary", label: "Primary", status: "available" },
-    capabilities: [],
-    providers: [],
-    projects: { items: [], hasMore: false, limit: 20 },
-    activeThreads: {
-      items: [
-        {
-          id: "thread_server",
-          providerId: "codex",
-          title: "Server-backed run",
-          status: "running",
-          attention: "none",
-          createdAt: "2026-07-06T00:00:00.000Z",
-          updatedAt: "2026-07-06T00:01:00.000Z",
-        },
-      ],
-      hasMore: false,
-      limit: 20,
-    },
-    attentionThreads: { items: [], hasMore: false, limit: 20 },
-    terminalSessions: { items: [], hasMore: false, limit: 20 },
-    recentActivity: { items: [], hasMore: false, limit: 20 },
-    limits: {
-      maxPromptBytes: 16384,
-      maxAttachmentCount: 8,
-      maxTerminalInputBytes: 8192,
-      maxListItems: 20,
-    },
-    serverTime: "2026-07-06T00:03:00.000Z",
   };
 }
 
@@ -93,10 +53,14 @@ describe("ChatTab", () => {
       abort: vi.fn(),
     });
     useThreads.setState({ threads: [], activeThreadId: null });
-    useCodingAgentWorkspace.setState({ summary: null, activeThreadId: null });
-    useProjectView.setState({ entries: {}, runtimeScope: null });
-    useProjectWorkspaces.setState({ entries: {} });
-    useTabs.setState({ tabs: [], activeTabId: null });
+    useTabs.setState(useTabs.getInitialState(), true);
+    useUi.setState({ requestedSettingsSection: null });
+    useIntegrations.setState({
+      available: [],
+      connections: [],
+      status: "idle",
+      errorMessage: null,
+    });
     useConnection.setState({
       status: "signed-in",
       handle: "operator",
@@ -127,79 +91,136 @@ describe("ChatTab", () => {
 
     expect(container.textContent).toContain("hello");
     expect(container.querySelector(".h-full.items-center.justify-center")).toBeNull();
+    expect(container.querySelector('[data-slot="message-scroller-content"]')?.className)
+      .toContain("justify-start");
   });
 
-  it("renders connect cards with real lucide icons instead of placeholder squares", () => {
+  it("renders the approved centered empty state and only working composer controls", () => {
     useHermesChat.setState({ messages: [], status: "idle", send: vi.fn(), abort: vi.fn() });
     render(<ChatTab />);
 
-    // Each onboarding connect card carries a glyph matching its label
-    // semantics — no empty gray placeholder tiles.
-    for (const title of ["Connect messaging", "Connect email", "Connect files"]) {
-      const card = screen.getByText(title).parentElement;
-      expect(card).not.toBeNull();
-      expect(card?.querySelector("svg")).not.toBeNull();
-    }
+    expect(screen.getByRole("heading", { name: "How can I help you?" })).toBeTruthy();
+    expect(screen.getByRole("textbox", { name: "How can I help you today?" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Attach files" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Resources" })).toBeTruthy();
+    expect(screen.getByText("Hermes", { selector: "span" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Send" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.queryByText("Connect messaging")).toBeNull();
+    expect(screen.queryByRole("button", { name: /voice|microphone/i })).toBeNull();
   });
 
-  it("switches from Hermes to an agent thread from the rail", () => {
+  it("removes the redundant internal Chat rail and leaves agent-run navigation to global Recents", () => {
     useThreads.setState({
       threads: [thread("t1", "Build parser")],
       activeThreadId: null,
     });
 
     render(<ChatTab />);
-    expect(screen.queryByTestId("thread-view")).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Build parser" }));
-
-    expect(useThreads.getState().activeThreadId).toBe("t1");
-    expect(screen.getByTestId("thread-view").textContent).toBe("thread:t1");
-  });
-
-  it("lists coding-agent workspace threads in the rail", () => {
-    useCodingAgentWorkspace.setState({ summary: codingAgentSummaryFixture() });
-
-    render(<ChatTab />);
-
-    expect(screen.getByRole("button", { name: "Server-backed run" })).toBeTruthy();
-  });
-
-  it("routes a coding-agent rail selection into the project's chats view", async () => {
-    const loadThreadSnapshot = vi.fn().mockResolvedValue(undefined);
-    useCodingAgentWorkspace.setState({
-      summary: codingAgentSummaryFixture(),
-      loadThreadSnapshot,
-    });
-
-    render(<ChatTab />);
-    fireEvent.click(screen.getByRole("button", { name: "Server-backed run" }));
-
-    await waitFor(() => expect(loadThreadSnapshot).toHaveBeenCalledWith("thread_server"));
-    const tabs = useTabs.getState();
-    const active = tabs.tabs.find((tab) => tab.id === tabs.activeTabId);
-    expect(active).toMatchObject({ kind: "project", projectSlug: "matrix-os" });
-    expect(useProjectView.getState().viewFor("matrix-os")).toBe("chats");
-    expect(useProjectView.getState().selectedThreadFor("matrix-os")).toBe("thread_server");
-    // The chat pane itself stays on Hermes; the transcript renders in the project.
-    expect(screen.queryByTestId("thread-view")).toBeNull();
-  });
-
-  it("falls back to Hermes when the active agent thread is removed", () => {
-    useThreads.setState({
-      threads: [thread("t1", "Build parser")],
-      activeThreadId: "t1",
-    });
-
-    render(<ChatTab />);
-    expect(screen.getByTestId("thread-view").textContent).toBe("thread:t1");
-
-    act(() => {
-      useThreads.setState({ threads: [], activeThreadId: "t1" });
-    });
-
-    expect(screen.queryByTestId("thread-view")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Build parser" })).toBeNull();
+    expect(screen.queryByText("Agent runs")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Conversations" })).toBeNull();
     expect(screen.getByText("hello")).toBeTruthy();
+  });
+
+  it("adds files from the visible attachment control", async () => {
+    useHermesChat.setState({ messages: [], status: "idle", send: vi.fn(), abort: vi.fn() });
+    render(<ChatTab />);
+
+    const picker = screen.getByLabelText("Choose files") as HTMLInputElement;
+    const file = new File(["notes"], "notes.md", { type: "text/markdown" });
+    fireEvent.change(picker, { target: { files: [file] } });
+
+    expect(await screen.findByRole("button", { name: "Remove notes.md" })).toBeTruthy();
+  });
+
+  it("shows canonical shared files and Gateway-backed connected tools in Resources", () => {
+    useHermesChat.setState({
+      messages: [{
+        id: "m1",
+        role: "user",
+        content: "Review this\n\nAttached files (available on your Matrix computer):\n- ~/temporary/desktop-chat/abc-screen.png (/home/matrix/home/temporary/desktop-chat/abc-screen.png)",
+        timestamp: 1,
+      }],
+    });
+    useIntegrations.setState({
+      status: "ready",
+      connections: [{
+        id: "00000000-0000-4000-8000-000000000001",
+        service: "google_drive",
+        accountLabel: "Design Drive",
+        accountEmail: null,
+        status: "active",
+        connectedAt: "2026-08-16T00:00:00.000Z",
+      }],
+    });
+
+    render(<ChatTab />);
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+
+    const panel = screen.getByRole("complementary", { name: "Resources" });
+    expect(panel.textContent).toContain("Shared with agent");
+    expect(panel.textContent).toContain("screen.png");
+    expect(panel.textContent).not.toContain("/home/matrix");
+    expect(panel.textContent).toContain("Design Drive");
+    expect(panel.textContent).toContain("Agent-created resources are not available from this Gateway yet.");
+  });
+
+  it("reduces canonical resource paths to bounded basenames", () => {
+    expect(sharedConversationResources([{
+      id: "m1",
+      role: "user",
+      content: "Attached files (available on your Matrix computer):\n- ~/temporary/desktop-chat/abc-folder/secrets.txt (/home/matrix/home/temporary/desktop-chat/abc-folder/secrets.txt)",
+      timestamp: 1,
+    }])).toEqual(["secrets.txt"]);
+  });
+
+  it("keeps spaced attachment names readable without exposing transport paths", () => {
+    useHermesChat.setState({
+      messages: [{
+        id: "m1",
+        role: "user",
+        content: "Review the final draft\n\nAttached files (available on your Matrix computer):\n- ~/temporary/desktop-chat/abc-final report.pdf (/home/matrix/home/temporary/desktop-chat/abc-final report.pdf)",
+        timestamp: 1,
+      }],
+    });
+
+    render(<ChatTab />);
+
+    expect(screen.getByText("Review the final draft")).toBeTruthy();
+    expect(screen.getByText("final report.pdf")).toBeTruthy();
+    expect(document.body.textContent).not.toContain("temporary/desktop-chat");
+    expect(document.body.textContent).not.toContain("/home/matrix");
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    expect(screen.getByRole("complementary", { name: "Resources" }).textContent)
+      .toContain("final report.pdf");
+  });
+
+  it("states unavailable and failed connected-tool Gateway capabilities explicitly", () => {
+    useIntegrations.setState({ status: "unavailable", connections: [] });
+    const { rerender } = render(<ChatTab />);
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    expect(screen.getByText("Connected tools are not available from this Gateway.")).toBeTruthy();
+
+    act(() => useIntegrations.setState({ status: "error", connections: [] }));
+    rerender(<ChatTab />);
+    expect(screen.getByText("Connected tools could not be loaded. Try again from Integrations.")).toBeTruthy();
+  });
+
+  it("toggles Resources, closes it with Escape, and routes Connect tool to Integrations", () => {
+    render(<ChatTab />);
+    const trigger = screen.getByRole("button", { name: "Resources" });
+
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("complementary", { name: "Resources" })).toBeNull();
+
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole("button", { name: "Connect tool" }));
+    expect(useUi.getState().requestedSettingsSection).toBe("integrations");
+    expect(useTabs.getState().tabs.some((tab) => tab.kind === "settings")).toBe(true);
   });
 
   it("previews pasted files horizontally, uploads on Send, and sends Hermes readable paths", async () => {
@@ -220,7 +241,7 @@ describe("ChatTab", () => {
     expect(await screen.findByRole("button", { name: "Remove screen.png" })).toBeTruthy();
     const previewRow = screen.getByRole("group", { name: "Attachments" });
     expect(previewRow.className).toContain("overflow-x-auto");
-    const input = screen.getByLabelText("Do anything");
+    const input = screen.getByLabelText("How can I help you today?");
     fireEvent.change(input, { target: { value: "Review this screenshot" } });
     fireEvent.click(screen.getByRole("button", { name: "Send" }));
 
@@ -291,7 +312,9 @@ describe("ChatTab", () => {
     const newest = screen.getByRole("button", { name: "Plan the launch conversation" });
     const older = screen.getByRole("button", { name: "Earlier notes conversation" });
     expect(newest.textContent).toContain("Plan the launch");
-    expect(newest.textContent).toContain("4 messages");
+    expect(newest.textContent).toContain("Hermes");
+    expect(newest.textContent).not.toContain("4 messages");
+    expect(newest.textContent).not.toContain("Review the final launch checklist");
     expect(older.textContent).toContain("Earlier notes");
     expect(screen.queryByText("hello")).toBeNull();
   });
@@ -362,7 +385,7 @@ describe("ChatTab", () => {
     useHermesChat.setState({ view: "index", indexStatus: "ready", conversations: [] });
 
     render(<ChatTab />);
-    fireEvent.click(screen.getAllByRole("button", { name: "New conversation" })[0]!);
+    fireEvent.click(screen.getByRole("button", { name: "New chat" }));
 
     expect(await screen.findByRole("region", { name: "Hermes conversation" })).toBeTruthy();
     expect(useHermesChat.getState()).toMatchObject({
@@ -370,9 +393,13 @@ describe("ChatTab", () => {
       sessionId: "conversation-created",
       messages: [],
     });
+    expect(useTabs.getState().recentViews[0]).toMatchObject({
+      kind: "conversation",
+      id: "conversation-created",
+    });
   });
 
-  it("opens the selected canonical conversation and exposes a Chat breadcrumb", async () => {
+  it("opens the selected canonical conversation without duplicating global navigation", async () => {
     const get = vi.fn().mockResolvedValue({
       id: "conversation-one",
       createdAt: 10,
@@ -402,7 +429,12 @@ describe("ChatTab", () => {
     fireEvent.click(screen.getByRole("button", { name: /persistent plan conversation/i }));
 
     expect(await screen.findByText("persistent hello")).toBeTruthy();
-    expect(screen.getByRole("navigation", { name: "Chat breadcrumb" }).textContent).toContain("Persistent plan");
+    expect(screen.queryByRole("navigation", { name: "Chat breadcrumb" })).toBeNull();
     expect(useHermesChat.getState().sessionId).toBe("conversation-one");
+    expect(useTabs.getState().recentViews[0]).toMatchObject({
+      kind: "conversation",
+      id: "conversation-one",
+      label: "Persistent plan",
+    });
   });
 });

--- a/tests/desktop/command-palette.test.tsx
+++ b/tests/desktop/command-palette.test.tsx
@@ -307,7 +307,7 @@ describe("CommandPalette", () => {
       projectSlug: "matrix-os",
       title: "matrix-os",
     });
-    expect(loadThreadSnapshot).toHaveBeenCalledWith("thread_alpha");
+    await waitFor(() => expect(loadThreadSnapshot).toHaveBeenCalledWith("thread_alpha"));
   });
 
   it("opens attachable coding-agent terminal sessions from the command palette", async () => {
@@ -403,7 +403,7 @@ describe("CommandPalette", () => {
       projectSlug: "matrix-os",
       title: "matrix-os",
     });
-    expect(loadThreadSnapshot).toHaveBeenCalledWith("thread_duplicate");
+    await waitFor(() => expect(loadThreadSnapshot).toHaveBeenCalledWith("thread_duplicate"));
   });
 
   it("prioritizes current reviews before slicing loaded command-palette reviews", async () => {

--- a/tests/desktop/hermes-conversation-index.test.tsx
+++ b/tests/desktop/hermes-conversation-index.test.tsx
@@ -15,6 +15,7 @@ import {
   useHermesChat,
   type HermesConversationSummary,
 } from "@desktop/renderer/src/stores/hermes-chat";
+import { useTabs } from "@desktop/renderer/src/stores/tabs";
 
 const conversations: HermesConversationSummary[] = [
   {
@@ -69,6 +70,7 @@ function deferred<T>() {
 }
 
 beforeEach(() => {
+  useTabs.setState(useTabs.getInitialState(), true);
   useHermesChat.setState(useHermesChat.getInitialState(), true);
   useHermesChat.setState({
     conversations,
@@ -111,6 +113,20 @@ describe("HermesConversationIndex", () => {
     fireEvent.keyDown(search, { key: "Escape" });
     expect(screen.queryByRole("searchbox", { name: "Search chats" })).toBeNull();
     expect(screen.getByRole("button", { name: "Launch plan conversation" })).toBeTruthy();
+  });
+
+  it("renders 64px rows with a harness badge, timestamp, and no preview metadata", () => {
+    render(<HermesConversationIndex api={api()} />);
+
+    const launch = screen.getByRole("button", { name: "Launch plan conversation" });
+    const row = launch.closest("[data-conversation-row]");
+    expect(row).not.toBeNull();
+    expect(row?.className).toContain("h-16");
+    expect(launch.textContent).toContain("Launch plan");
+    expect(launch.textContent).toContain("Hermes");
+    expect(launch.textContent).not.toContain("Prepare the release checklist");
+    expect(launch.textContent).not.toContain("4 messages");
+    expect(row?.querySelector("time")).not.toBeNull();
   });
 
   it("distinguishes no matches from an empty canonical index", () => {
@@ -162,6 +178,33 @@ describe("HermesConversationIndex", () => {
 
     expect(openConversation).not.toHaveBeenCalled();
     expect(screen.getByRole("alertdialog", { name: "Delete Launch plan?" })).toBeTruthy();
+  });
+
+  it("records the canonical Gateway conversation in global Recents only after opening succeeds", async () => {
+    const openConversation = vi.fn(async () => true);
+    useHermesChat.setState({ openConversation });
+    render(<HermesConversationIndex api={api()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Launch plan conversation" }));
+
+    await waitFor(() => expect(openConversation).toHaveBeenCalledWith(
+      expect.anything(),
+      "launch-plan",
+    ));
+    await waitFor(() => expect(useTabs.getState().recentViews[0]).toMatchObject({
+      kind: "conversation",
+      id: "launch-plan",
+      label: "Launch plan",
+    }));
+
+    openConversation.mockResolvedValue(false);
+    fireEvent.click(screen.getByRole("button", { name: "Customer notes conversation" }));
+    await waitFor(() => expect(openConversation).toHaveBeenCalledWith(
+      expect.anything(),
+      "support-notes",
+    ));
+    expect(useTabs.getState().recentViews.some((recent) => recent.id === "support-notes"))
+      .toBe(false);
   });
 
   it("cancels without a request and confirms only once while pending", async () => {

--- a/tests/desktop/project-chat.test.ts
+++ b/tests/desktop/project-chat.test.ts
@@ -330,6 +330,80 @@ describe("openProjectChat", () => {
     });
   });
 
+  it("does not record a Recent when the project refreshes while the thread snapshot loads", async () => {
+    let resolveWorkspace!: (workspace: ProjectAgentWorkspace) => void;
+    let markThreadSnapshotStarted!: () => void;
+    let resolveThreadSnapshot!: () => void;
+    const workspaceResponse = new Promise<ProjectAgentWorkspace>((resolve) => {
+      resolveWorkspace = resolve;
+    });
+    const threadSnapshotResponse = new Promise<void>((resolve) => {
+      resolveThreadSnapshot = resolve;
+    });
+    const threadSnapshotStarted = new Promise<void>((resolve) => {
+      markThreadSnapshotStarted = resolve;
+    });
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: {
+        invoke: vi.fn(async (channel: string) => {
+          if (channel === "runtime:get-project-workspace") return workspaceResponse;
+          if (channel === "state:set") return { ok: true };
+          throw new Error(`unexpected channel ${channel}`);
+        }),
+        on: vi.fn(() => () => undefined),
+      },
+    });
+    const workspace = {
+      project: summaryWithThreads().projects.items[0]!,
+      tasks: { items: [], hasMore: false, limit: 100 },
+      projectThreads: { items: summaryWithThreads().activeThreads.items, hasMore: false, limit: 100 },
+      taskThreads: { items: [], hasMore: false, limit: 100 },
+      updatedAt: NOW,
+    } satisfies ProjectAgentWorkspace;
+    useProjectWorkspaces.setState({
+      entries: {
+        "matrix-os": {
+          status: "ready",
+          workspace,
+          error: null,
+          fetchedAt: 1,
+        },
+      },
+    });
+    useCodingAgentWorkspace.setState({
+      summary: summaryWithThreads(),
+      status: "ready",
+      loadThreadSnapshot: vi.fn(async (threadId: string) => {
+        markThreadSnapshotStarted();
+        await threadSnapshotResponse;
+        useCodingAgentWorkspace.setState({
+          activeThreadId: threadId,
+          threadSnapshotStatus: "ready",
+          threadSnapshot: {
+            thread: summaryWithThreads().activeThreads.items[0]!,
+            events: { items: [], hasMore: false, limit: 200 },
+          },
+        });
+      }),
+    });
+
+    const openingConversation = openProjectChat("matrix-os", { threadId: "thread_alpha" });
+    await threadSnapshotStarted;
+    const replacementLoad = useProjectWorkspaces.getState().refresh("matrix-os");
+    expect(useProjectWorkspaces.getState().entries["matrix-os"]?.status).toBe("loading");
+
+    resolveThreadSnapshot();
+    const opened = await openingConversation;
+
+    resolveWorkspace(workspace);
+    await replacementLoad;
+    expect(opened).toBe(false);
+    expect(useTabs.getState().recentViews).not.toContainEqual(
+      expect.objectContaining({ kind: "conversation", id: "thread_alpha" }),
+    );
+  });
+
   it("does not reload the snapshot for the already-active thread", () => {
     const loadThreadSnapshot = vi.fn(async () => undefined);
     useCodingAgentWorkspace.setState({ loadThreadSnapshot, activeThreadId: "thread_alpha" });

--- a/tests/desktop/project-chat.test.ts
+++ b/tests/desktop/project-chat.test.ts
@@ -267,6 +267,69 @@ describe("openProjectChat", () => {
     });
   });
 
+  it("waits for the authoritative replacement when an in-flight workspace load is superseded", async () => {
+    const workspaceResolvers: Array<(workspace: ProjectAgentWorkspace) => void> = [];
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: {
+        invoke: vi.fn(async (channel: string) => {
+          if (channel === "runtime:get-project-workspace") {
+            return new Promise<ProjectAgentWorkspace>((resolve) => {
+              workspaceResolvers.push(resolve);
+            });
+          }
+          if (channel === "state:set") return { ok: true };
+          throw new Error(`unexpected channel ${channel}`);
+        }),
+        on: vi.fn(() => () => undefined),
+      },
+    });
+    useCodingAgentWorkspace.setState({
+      summary: summaryWithThreads(),
+      status: "ready",
+      loadThreadSnapshot: vi.fn(async (threadId: string) => {
+        useCodingAgentWorkspace.setState({
+          activeThreadId: threadId,
+          threadSnapshotStatus: "ready",
+          threadSnapshot: {
+            thread: summaryWithThreads().activeThreads.items[0]!,
+            events: { items: [], hasMore: false, limit: 200 },
+          },
+        });
+      }),
+    });
+    const workspace = {
+      project: summaryWithThreads().projects.items[0]!,
+      tasks: { items: [], hasMore: false, limit: 100 },
+      projectThreads: { items: summaryWithThreads().activeThreads.items, hasMore: false, limit: 100 },
+      taskThreads: { items: [], hasMore: false, limit: 100 },
+      updatedAt: NOW,
+    } satisfies ProjectAgentWorkspace;
+
+    const firstLoad = useProjectWorkspaces.getState().refresh("matrix-os");
+    const openingConversation = openProjectChat("matrix-os", { threadId: "thread_alpha" });
+    let openSettled = false;
+    void openingConversation.then(() => {
+      openSettled = true;
+    });
+    const replacementLoad = useProjectWorkspaces.getState().refresh("matrix-os");
+
+    workspaceResolvers[0]!(workspace);
+    await firstLoad;
+    await Promise.resolve();
+    const settledBeforeReplacement = openSettled;
+
+    workspaceResolvers[1]!(workspace);
+    await Promise.all([replacementLoad, openingConversation]);
+
+    expect(settledBeforeReplacement).toBe(false);
+    expect(useTabs.getState().recentViews[0]).toMatchObject({
+      kind: "conversation",
+      id: "thread_alpha",
+      label: "Fix settings route",
+    });
+  });
+
   it("does not reload the snapshot for the already-active thread", () => {
     const loadThreadSnapshot = vi.fn(async () => undefined);
     useCodingAgentWorkspace.setState({ loadThreadSnapshot, activeThreadId: "thread_alpha" });

--- a/tests/desktop/project-chat.test.ts
+++ b/tests/desktop/project-chat.test.ts
@@ -50,7 +50,7 @@ function summaryWithThreads(): RuntimeSummary {
 }
 
 function resetStores(): void {
-  useTabs.setState({ tabs: [], activeTabId: null });
+  useTabs.setState(useTabs.getInitialState(), true);
   useBoard.setState({ projects: [], activeProjectSlug: null });
   useProjectView.setState({ entries: {}, runtimeScope: null });
   useProjectWorkspaces.setState({ entries: {} });
@@ -95,26 +95,124 @@ describe("openProjectChat", () => {
     expect(useTabs.getState().activeTabId).toBe(first);
   });
 
-  it("selects the requested thread and loads its snapshot", () => {
+  it("selects the requested thread and loads its snapshot", async () => {
     const loadThreadSnapshot = vi.fn(async () => undefined);
     useCodingAgentWorkspace.setState({ loadThreadSnapshot });
 
-    openProjectChat("matrix-os", { threadId: "thread_alpha" });
+    await openProjectChat("matrix-os", { threadId: "thread_alpha" });
 
     expect(useProjectView.getState().selectedThreadFor("matrix-os")).toBe("thread_alpha");
     expect(loadThreadSnapshot).toHaveBeenCalledWith("thread_alpha");
   });
 
-  it("records an opened agent conversation in global Recents", () => {
+  it("records an opened agent conversation in global Recents", async () => {
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: {
+        invoke: vi.fn(async (channel: string) => {
+          if (channel === "runtime:get-project-workspace") {
+            return {
+              project: summaryWithThreads().projects.items[0],
+              tasks: { items: [], hasMore: false, limit: 100 },
+              projectThreads: { items: summaryWithThreads().activeThreads.items, hasMore: false, limit: 100 },
+              taskThreads: { items: [], hasMore: false, limit: 100 },
+              updatedAt: NOW,
+            };
+          }
+          if (channel === "state:set") return { ok: true };
+          throw new Error(`unexpected channel ${channel}`);
+        }),
+        on: vi.fn(() => () => undefined),
+      },
+    });
+    const loadThreadSnapshot = vi.fn(async (threadId: string) => {
+      useCodingAgentWorkspace.setState({
+        activeThreadId: threadId,
+        threadSnapshotStatus: "ready",
+        threadSnapshot: {
+          thread: summaryWithThreads().activeThreads.items[0]!,
+          events: { items: [], hasMore: false, limit: 200 },
+        },
+      });
+    });
     useCodingAgentWorkspace.setState({ summary: summaryWithThreads(), status: "ready" });
+    useCodingAgentWorkspace.setState({ loadThreadSnapshot });
 
-    openProjectChat("matrix-os", { threadId: "thread_alpha" });
+    const opened = openProjectChat("matrix-os", { threadId: "thread_alpha" });
+
+    expect(useTabs.getState().recentViews).not.toContainEqual(
+      expect.objectContaining({ kind: "conversation", id: "thread_alpha" }),
+    );
+
+    await opened;
 
     expect(useTabs.getState().recentViews[0]).toMatchObject({
       kind: "conversation",
       id: "thread_alpha",
       label: "Fix settings route",
     });
+  });
+
+  it("does not record a Recent when the project workspace cannot load", async () => {
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: {
+        invoke: vi.fn(async (channel: string) => {
+          if (channel === "runtime:get-project-workspace") throw new Error("offline");
+          if (channel === "state:set") return { ok: true };
+          throw new Error(`unexpected channel ${channel}`);
+        }),
+        on: vi.fn(() => () => undefined),
+      },
+    });
+    useCodingAgentWorkspace.setState({
+      summary: summaryWithThreads(),
+      status: "ready",
+      loadThreadSnapshot: vi.fn(async () => undefined),
+    });
+
+    await openProjectChat("matrix-os", { threadId: "thread_alpha" });
+
+    expect(useTabs.getState().recentViews).not.toContainEqual(
+      expect.objectContaining({ kind: "conversation", id: "thread_alpha" }),
+    );
+  });
+
+  it("does not record a Recent when the thread snapshot cannot load", async () => {
+    useProjectWorkspaces.setState({
+      entries: {
+        "matrix-os": {
+          status: "ready",
+          workspace: {
+            project: summaryWithThreads().projects.items[0]!,
+            tasks: { items: [], hasMore: false, limit: 100 },
+            projectThreads: { items: summaryWithThreads().activeThreads.items, hasMore: false, limit: 100 },
+            taskThreads: { items: [], hasMore: false, limit: 100 },
+            updatedAt: NOW,
+          },
+          error: null,
+          fetchedAt: 1,
+        },
+      },
+    });
+    useCodingAgentWorkspace.setState({
+      summary: summaryWithThreads(),
+      status: "ready",
+      loadThreadSnapshot: vi.fn(async (threadId: string) => {
+        useCodingAgentWorkspace.setState({
+          activeThreadId: threadId,
+          threadSnapshotStatus: "error",
+          threadSnapshot: null,
+          threadSnapshotError: "Thread state unavailable",
+        });
+      }),
+    });
+
+    await openProjectChat("matrix-os", { threadId: "thread_alpha" });
+
+    expect(useTabs.getState().recentViews).not.toContainEqual(
+      expect.objectContaining({ kind: "conversation", id: "thread_alpha" }),
+    );
   });
 
   it("does not reload the snapshot for the already-active thread", () => {
@@ -154,12 +252,12 @@ describe("openCodingAgentThread", () => {
     resetStores();
   });
 
-  it("routes a thread into its project from the runtime summary", () => {
+  it("routes a thread into its project from the runtime summary", async () => {
     const loadThreadSnapshot = vi.fn(async () => undefined);
     useCodingAgentWorkspace.setState({ summary: summaryWithThreads(), status: "ready", loadThreadSnapshot });
     useBoard.setState({ projects: [{ slug: "matrix-os", name: "Matrix OS" }] });
 
-    openCodingAgentThread("thread_alpha");
+    await openCodingAgentThread("thread_alpha");
 
     expect(useTabs.getState().tabs[0]).toMatchObject({ kind: "project", projectSlug: "matrix-os" });
     expect(useProjectView.getState().selectedThreadFor("matrix-os")).toBe("thread_alpha");
@@ -246,6 +344,51 @@ describe("openCodingAgentThread", () => {
 
     expect(useTabs.getState().tabs[0]).toMatchObject({ kind: "project", projectSlug: "matrix-os" });
     expect(loadThreadSnapshot).toHaveBeenCalledWith("thread_unknown");
+  });
+
+  it("does not record a fallback Recent when authoritative project resolution fails", async () => {
+    let snapshotCalls = 0;
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === "runtime:get-thread-snapshot") {
+        snapshotCalls += 1;
+        if (snapshotCalls === 1) throw new Error("offline");
+        return {
+          thread: {
+            id: "thread_unknown",
+            providerId: "codex",
+            title: "Unknown",
+            status: "running",
+            attention: "none",
+            projectId: "matrix-os",
+            createdAt: NOW,
+            updatedAt: NOW,
+          },
+          events: { items: [], hasMore: false, limit: 200 },
+        };
+      }
+      if (channel === "runtime:get-project-workspace") {
+        return {
+          project: summaryWithThreads().projects.items[0],
+          tasks: { items: [], hasMore: false, limit: 100 },
+          projectThreads: { items: [], hasMore: false, limit: 100 },
+          taskThreads: { items: [], hasMore: false, limit: 100 },
+          updatedAt: NOW,
+        };
+      }
+      if (channel === "state:set") return { ok: true };
+      throw new Error(`unexpected channel ${channel}`);
+    });
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: { invoke, on: vi.fn(() => () => undefined) },
+    });
+    useBoard.setState({ projects: [{ slug: "matrix-os", name: "Matrix OS" }] });
+
+    await openCodingAgentThread("thread_unknown");
+
+    expect(useTabs.getState().recentViews).not.toContainEqual(
+      expect.objectContaining({ kind: "conversation", id: "thread_unknown" }),
+    );
   });
 });
 

--- a/tests/desktop/project-chat.test.ts
+++ b/tests/desktop/project-chat.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { RuntimeSummary } from "@matrix-os/contracts";
+import type { ProjectAgentWorkspace, RuntimeSummary } from "@matrix-os/contracts";
 import {
   defaultProjectId,
   openCodingAgentThread,
@@ -213,6 +213,58 @@ describe("openProjectChat", () => {
     expect(useTabs.getState().recentViews).not.toContainEqual(
       expect.objectContaining({ kind: "conversation", id: "thread_alpha" }),
     );
+  });
+
+  it("waits for an in-flight project workspace before recording a successful open", async () => {
+    let resolveWorkspace!: (workspace: ProjectAgentWorkspace) => void;
+    const workspaceResponse = new Promise<ProjectAgentWorkspace>((resolve) => {
+      resolveWorkspace = resolve;
+    });
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: {
+        invoke: vi.fn(async (channel: string) => {
+          if (channel === "runtime:get-project-workspace") return workspaceResponse;
+          if (channel === "state:set") return { ok: true };
+          throw new Error(`unexpected channel ${channel}`);
+        }),
+        on: vi.fn(() => () => undefined),
+      },
+    });
+    const loadThreadSnapshot = vi.fn(async (threadId: string) => {
+      useCodingAgentWorkspace.setState({
+        activeThreadId: threadId,
+        threadSnapshotStatus: "ready",
+        threadSnapshot: {
+          thread: summaryWithThreads().activeThreads.items[0]!,
+          events: { items: [], hasMore: false, limit: 200 },
+        },
+      });
+    });
+    useCodingAgentWorkspace.setState({
+      summary: summaryWithThreads(),
+      status: "ready",
+      loadThreadSnapshot,
+    });
+
+    const loadingWorkspace = useProjectWorkspaces.getState().refresh("matrix-os");
+    const openingConversation = openProjectChat("matrix-os", { threadId: "thread_alpha" });
+    expect(useProjectWorkspaces.getState().entries["matrix-os"]?.status).toBe("loading");
+
+    resolveWorkspace({
+      project: summaryWithThreads().projects.items[0]!,
+      tasks: { items: [], hasMore: false, limit: 100 },
+      projectThreads: { items: summaryWithThreads().activeThreads.items, hasMore: false, limit: 100 },
+      taskThreads: { items: [], hasMore: false, limit: 100 },
+      updatedAt: NOW,
+    });
+    await Promise.all([loadingWorkspace, openingConversation]);
+
+    expect(useTabs.getState().recentViews[0]).toMatchObject({
+      kind: "conversation",
+      id: "thread_alpha",
+      label: "Fix settings route",
+    });
   });
 
   it("does not reload the snapshot for the already-active thread", () => {

--- a/tests/desktop/project-chat.test.ts
+++ b/tests/desktop/project-chat.test.ts
@@ -105,6 +105,18 @@ describe("openProjectChat", () => {
     expect(loadThreadSnapshot).toHaveBeenCalledWith("thread_alpha");
   });
 
+  it("records an opened agent conversation in global Recents", () => {
+    useCodingAgentWorkspace.setState({ summary: summaryWithThreads(), status: "ready" });
+
+    openProjectChat("matrix-os", { threadId: "thread_alpha" });
+
+    expect(useTabs.getState().recentViews[0]).toMatchObject({
+      kind: "conversation",
+      id: "thread_alpha",
+      label: "Fix settings route",
+    });
+  });
+
   it("does not reload the snapshot for the already-active thread", () => {
     const loadThreadSnapshot = vi.fn(async () => undefined);
     useCodingAgentWorkspace.setState({ loadThreadSnapshot, activeThreadId: "thread_alpha" });

--- a/tests/desktop/project-chats-view-layout.test.tsx
+++ b/tests/desktop/project-chats-view-layout.test.tsx
@@ -25,6 +25,7 @@ import { useProjectView } from "../../desktop/src/renderer/src/stores/project-vi
 import { useProjectWorkspaces } from "../../desktop/src/renderer/src/stores/project-workspaces";
 import { clearDraftChats } from "../../desktop/src/renderer/src/stores/draft-chat";
 import { useProjectChatLauncher } from "../../desktop/src/renderer/src/lib/project-chat";
+import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 
 const NOW = "2026-07-12T12:00:00.000Z";
 
@@ -179,6 +180,7 @@ function resetStores() {
   useProjectView.setState({ entries: {}, runtimeScope: null });
   useProjectWorkspaces.setState({ entries: {} });
   useProjectChatLauncher.setState({ composerRequest: null });
+  useTabs.setState(useTabs.getInitialState(), true);
   useInspectorLayout.setState({ entries: {}, runtimeScope: null, hydratedScope: null });
   useCodingAgentWorkspace.setState({
     status: "idle",
@@ -280,6 +282,35 @@ describe("ProjectChatsView hero layout", () => {
     expect(await screen.findByTestId("inspector-split")).toBeTruthy();
     expect(screen.getByRole("complementary", { name: "Conversation tools" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Hide conversation tools" })).toBeTruthy();
+  });
+
+  it("does not record a rail selection when its snapshot fails to load", async () => {
+    mockOperator();
+    const loadThreadSnapshot = vi.fn(async (threadId: string) => {
+      useCodingAgentWorkspace.setState({
+        activeThreadId: threadId,
+        threadSnapshotStatus: "error",
+        threadSnapshot: null,
+        threadSnapshotError: "Thread state unavailable",
+      });
+    });
+    useCodingAgentWorkspace.setState({ loadThreadSnapshot });
+    render(<ProjectChatsView projectId="matrix-os" active />);
+    await screen.findByTestId("inspector-split");
+
+    act(() => {
+      useProjectView.getState().setSelectedThread("matrix-os", null);
+      useTabs.setState({ recentViews: [] });
+    });
+    await screen.findByText("What should we work on?");
+    loadThreadSnapshot.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "Chat Plan the auth work" }));
+
+    await waitFor(() => expect(loadThreadSnapshot).toHaveBeenCalledWith("thread_plan"));
+    expect(useTabs.getState().recentViews).not.toContainEqual(
+      expect.objectContaining({ kind: "conversation", id: "thread_plan" }),
+    );
   });
 
   it("collapses to a full-width hero transcript and persists the choice", async () => {

--- a/tests/desktop/sidebar-navigation-shell.test.tsx
+++ b/tests/desktop/sidebar-navigation-shell.test.tsx
@@ -111,6 +111,18 @@ describe("Desktop sidebar navigation shell", () => {
     expect(useThreads.getState().activeThreadId).toBeNull();
   });
 
+  it("uses the global Chat navigation to return to the canonical inbox", () => {
+    useHermesChat.setState({ view: "conversation", sessionId: "conversation-two" });
+    renderSidebar();
+
+    fireEvent.click(screen.getByRole("button", { name: "Chat" }));
+
+    expect(useHermesChat.getState().view).toBe("index");
+    expect(useThreads.getState().activeThreadId).toBeNull();
+    expect(useTabs.getState().recentViews.some((recent) => recent.id === "hermes"))
+      .toBe(false);
+  });
+
   it("offers the approved account actions and routes them through current behavior", () => {
     renderSidebar();
     const trigger = screen.getByRole("button", { name: "Open account menu" });

--- a/tests/e2e/desktop/handoff-electron-baseline.ts
+++ b/tests/e2e/desktop/handoff-electron-baseline.ts
@@ -116,14 +116,14 @@ export async function inspectDesktopHandoffBaseline(
 
   let recentConversationTarget: string | null = null;
   const recentConversation = page.getByRole("button", {
-    name: "Open recent Hermes",
+    name: "Open recent Plan the persistent Desktop conversation experience",
   });
   if ((await recentConversation.count()) > 0) {
     await recentConversation.click();
     await waitForSurface(page, "Chat");
     recentConversationTarget = "Conversations";
   } else if (hasCombinedNavigation) {
-    throw new Error("Combined Desktop navigation did not expose the Hermes Recent");
+    throw new Error("Combined Desktop navigation did not expose the canonical Gateway conversation Recent");
   }
 
   const hiddenPanesMissingInert = await page.evaluate(

--- a/tests/e2e/desktop/handoff-regression-matrix.ts
+++ b/tests/e2e/desktop/handoff-regression-matrix.ts
@@ -280,7 +280,7 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
       ),
       testEvidence(
         "tests/desktop/chat-tab-render.test.tsx",
-        "opens the selected canonical conversation and exposes a Chat breadcrumb",
+        "opens the selected canonical conversation without duplicating global navigation",
       ),
     ],
     figmaNode: "67:4472",

--- a/tests/e2e/desktop/hermes-conversations-responsive.e2e.test.ts
+++ b/tests/e2e/desktop/hermes-conversations-responsive.e2e.test.ts
@@ -10,6 +10,7 @@ const DESKTOP_MAIN = resolve(__dirname, "../../../desktop/out/main/index.js");
 const desktopRequire = createRequire(resolve(__dirname, "../../../desktop/package.json"));
 const ELECTRON_EXECUTABLE = desktopRequire("electron") as string;
 const SCREENSHOT_DIR = resolve(__dirname, "../../../output/playwright/mat-299-responsive");
+const MAT_322_SCREENSHOT_DIR = resolve(__dirname, "../../../output/playwright/mat-322");
 const MINIMUM_VIEWPORT = { width: 880, height: 560 } as const;
 const suite = existsSync(DESKTOP_MAIN) ? describe : describe.skip;
 
@@ -54,6 +55,7 @@ suite("responsive Hermes Desktop conversations", () => {
 
   beforeAll(async () => {
     mkdirSync(SCREENSHOT_DIR, { recursive: true });
+    mkdirSync(MAT_322_SCREENSHOT_DIR, { recursive: true });
     gateway = await startStubGateway();
     userDataDir = mkdtempSync(join(tmpdir(), "mat-299-responsive-"));
     app = await _electron.launch({
@@ -97,9 +99,14 @@ suite("responsive Hermes Desktop conversations", () => {
     const conversation = page.getByRole("region", { name: "Hermes conversation" });
     await conversation.waitFor();
     const conversationOverflow = await measureOverflow(conversation);
+    await page.getByRole("button", { name: "Resources" }).click();
+    const resources = page.getByRole("complementary", { name: "Resources" });
+    await resources.waitFor();
+    const resourcesOverflow = await measureOverflow(conversation);
+    await page.screenshot({ path: join(MAT_322_SCREENSHOT_DIR, "05-resources-constrained.png") });
+    await page.getByRole("button", { name: "Close Resources" }).click();
 
-    await page.getByRole("navigation", { name: "Chat breadcrumb" })
-      .getByRole("button", { name: "Chat" }).click();
+    await page.locator("aside button", { hasText: "Chat" }).first().click();
     await providerRow.hover();
     await page.getByRole("button", {
       name: "Delete Verify provider switching remains intact",
@@ -113,6 +120,7 @@ suite("responsive Hermes Desktop conversations", () => {
     expectNoHorizontalOverflow(indexOverflow);
     expectNoHorizontalOverflow(searchOverflow);
     expectNoHorizontalOverflow(conversationOverflow);
+    expectNoHorizontalOverflow(resourcesOverflow);
     expectNoHorizontalOverflow(dialogOverflow);
   }, 30_000);
 });

--- a/tests/e2e/desktop/hermes-conversations.e2e.test.ts
+++ b/tests/e2e/desktop/hermes-conversations.e2e.test.ts
@@ -10,6 +10,7 @@ const DESKTOP_MAIN = resolve(__dirname, "../../../desktop/out/main/index.js");
 const desktopRequire = createRequire(resolve(__dirname, "../../../desktop/package.json"));
 const ELECTRON_EXECUTABLE = desktopRequire("electron") as string;
 const SCREENSHOT_DIR = resolve(__dirname, "../../../output/playwright/mat-299");
+const MAT_322_SCREENSHOT_DIR = resolve(__dirname, "../../../output/playwright/mat-322");
 const VIEWPORT = { width: 1440, height: 900 } as const;
 const suite = existsSync(DESKTOP_MAIN) ? describe : describe.skip;
 
@@ -21,6 +22,7 @@ suite("persistent Hermes Desktop conversations", () => {
 
   beforeAll(async () => {
     mkdirSync(SCREENSHOT_DIR, { recursive: true });
+    mkdirSync(MAT_322_SCREENSHOT_DIR, { recursive: true });
     gateway = await startStubGateway();
     userDataDir = mkdtempSync(join(tmpdir(), "mat-299-desktop-"));
     app = await _electron.launch({
@@ -55,6 +57,7 @@ suite("persistent Hermes Desktop conversations", () => {
       name: "Verify provider switching remains intact conversation",
     }).waitFor();
     await page.screenshot({ path: join(SCREENSHOT_DIR, "01-conversation-index.png") });
+    await page.screenshot({ path: join(MAT_322_SCREENSHOT_DIR, "01-chats-index-wide.png") });
 
     await page.getByRole("button", { name: "Search chats" }).click();
     await page.getByRole("searchbox", { name: "Search chats" }).fill("provider");
@@ -73,15 +76,18 @@ suite("persistent Hermes Desktop conversations", () => {
     await page.getByRole("button", {
       name: "Plan the persistent Desktop conversation experience conversation",
     }).click();
-    await page.getByRole("navigation", { name: "Chat breadcrumb" }).waitFor();
     await page.getByText("The canonical Gateway conversation is ready to continue.").waitFor();
+    await page.screenshot({ path: join(MAT_322_SCREENSHOT_DIR, "02-active-conversation-wide.png") });
+    await page.getByRole("button", { name: "Resources" }).click();
+    await page.getByRole("complementary", { name: "Resources" }).waitFor();
+    await page.screenshot({ path: join(MAT_322_SCREENSHOT_DIR, "03-resources-wide.png") });
+    await page.getByRole("button", { name: "Close Resources" }).click();
     await expect.poll(() => gateway.state.kernelMessages).toContainEqual({
       type: "switch_session",
       sessionId: "hermes-desktop-index",
     });
 
-    await page.getByRole("navigation", { name: "Chat breadcrumb" })
-      .getByRole("button", { name: "Chat" }).click();
+    await page.locator("aside button", { hasText: "Chat" }).first().click();
     await page.getByRole("button", {
       name: "Verify provider switching remains intact conversation",
     }).click();
@@ -91,13 +97,12 @@ suite("persistent Hermes Desktop conversations", () => {
       sessionId: "hermes-provider-check",
     });
 
-    await page.getByRole("navigation", { name: "Chat breadcrumb" })
-      .getByRole("button", { name: "Chat" }).click();
+    await page.locator("aside button", { hasText: "Chat" }).first().click();
     await page.locator('section[aria-labelledby="conversation-index-title"]')
       .getByRole("button", { name: "New chat" }).click();
-    await page.getByRole("textbox", { name: "Do anything" }).waitFor();
-    await page.getByRole("navigation", { name: "Chat breadcrumb" })
-      .getByRole("button", { name: "Chat" }).click();
+    await page.getByRole("textbox", { name: "How can I help you today?" }).waitFor();
+    await page.screenshot({ path: join(MAT_322_SCREENSHOT_DIR, "04-empty-conversation-wide.png") });
+    await page.locator("aside button", { hasText: "Chat" }).first().click();
     await page.getByRole("button", { name: "New conversation conversation" }).waitFor();
 
     const providerRow = page.getByRole("button", {

--- a/tests/e2e/desktop/operator.e2e.test.ts
+++ b/tests/e2e/desktop/operator.e2e.test.ts
@@ -15,6 +15,7 @@ const DESKTOP_MAIN = resolve(__dirname, "../../../desktop/out/main/index.js");
 const desktopRequire = createRequire(resolve(__dirname, "../../../desktop/package.json"));
 const ELECTRON_EXECUTABLE = desktopRequire("electron") as string;
 const SCREENSHOT_DIR = resolve(__dirname, "../../../desktop/screenshots");
+const MAT_322_SCREENSHOT_DIR = resolve(__dirname, "../../../output/playwright/mat-322");
 const hasBuild = existsSync(DESKTOP_MAIN);
 
 const suite = hasBuild ? describe : describe.skip;
@@ -55,6 +56,7 @@ suite("operator desktop e2e", () => {
 
   beforeAll(async () => {
     mkdirSync(SCREENSHOT_DIR, { recursive: true });
+    mkdirSync(MAT_322_SCREENSHOT_DIR, { recursive: true });
     gateway = await startStubGateway();
     userDataDir = mkdtempSync(join(tmpdir(), "operator-e2e-"));
     app = await _electron.launch({
@@ -329,6 +331,14 @@ suite("operator desktop e2e", () => {
     await page.waitForFunction(() => document.documentElement.getAttribute("data-theme-id") === "dracula");
     await page.screenshot({ path: join(SCREENSHOT_DIR, "14-theme-dracula.png") });
 
+    await page.locator("aside button", { hasText: "Chat" }).first().click();
+    await page.getByRole("heading", { name: "Chats" }).waitFor({ timeout: 10_000 });
+    await page.screenshot({ path: join(MAT_322_SCREENSHOT_DIR, "06-chats-dark.png") });
+    await page.getByRole("button", {
+      name: "Plan the persistent Desktop conversation experience conversation",
+    }).click();
+    await page.getByText("The canonical Gateway conversation is ready to continue.").waitFor();
+
     // The terminal palette follows the unified theme.
     await page.locator("aside button", { hasText: "Terminal" }).first().click();
     await page.getByRole("heading", { name: "Terminal" }).waitFor({ timeout: 10_000 });
@@ -342,22 +352,26 @@ suite("operator desktop e2e", () => {
     await page.screenshot({ path: join(SCREENSHOT_DIR, "16-theme-operator-default.png") });
   }, 40_000);
 
-  it("lists coding-agent threads in the unified chat rail and routes selection to the project", async () => {
+  it("keeps coding-agent navigation in global Recents instead of a Chat rail", async () => {
     // The earlier computer switch cleared the workspace summary; opening the
-    // project refreshes it before the rail is inspected.
+    // project refreshes it before selecting the canonical project chat.
     await page.locator("aside button", { hasText: "Matrix OS" }).last().click();
     await page.getByRole("button", { name: "Board", exact: true }).waitFor({ timeout: 10_000 });
-    await page.locator("aside button", { hasText: "Chat" }).first().click();
-    // The rail lists the server-backed run alongside Hermes under "Agent runs".
-    await page.getByText("Agent runs").waitFor({ timeout: 10_000 });
-    const railItem = page.getByRole("button", { name: "fix the failing auth tests" }).first();
-    await railItem.waitFor({ timeout: 10_000 });
-    await page.screenshot({ path: join(SCREENSHOT_DIR, "17-chat-unified-rail.png") });
+    await page.getByRole("button", { name: "Chats" }).click();
+    await page.getByRole("button", { name: "Chat fix the failing auth tests" }).click();
+    const recent = page.getByRole("button", { name: "Open recent fix the failing auth tests" });
+    await recent.waitFor({ timeout: 10_000 });
 
-    // Selecting a coding-agent thread routes to its project tab's Chats view.
-    await railItem.click();
+    await page.locator("aside button", { hasText: "Chat" }).first().click();
+    await page.getByRole("heading", { name: "Chats" }).waitFor({ timeout: 10_000 });
+    await expect.poll(() => page.getByText("Agent runs").count()).toBe(0);
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "17-chat-without-internal-rail.png") });
+
+    // Global Recents owns the route back to the project conversation.
+    await recent.click();
     await page.getByRole("button", { name: "New chat in Matrix OS" }).waitFor({ timeout: 10_000 });
-    await page.screenshot({ path: join(SCREENSHOT_DIR, "18-chat-rail-routes-to-project.png") });
+    await page.getByRole("region", { name: "Conversation fix the failing auth tests" }).waitFor({ timeout: 10_000 });
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "18-global-recent-routes-to-project.png") });
   }, 30_000);
 
   it("archives, restores, and permanently deletes a project through Desktop lifecycle controls", async () => {
@@ -397,7 +411,7 @@ suite("operator desktop e2e", () => {
       "Files",
     ]);
     expect(evidence.focusTargets.Home).toBe("Home");
-    expect(["Chat", "Do anything"]).toContain(evidence.focusTargets.Chat);
+    expect(["Chat", "How can I help you today?"]).toContain(evidence.focusTargets.Chat);
     expect(["Terminal", "Terminal input"]).toContain(
       evidence.focusTargets.Terminal,
     );


### PR DESCRIPTION
## Summary

- Removes the redundant internal Chat rail so the global Sidebar and Recents own conversation navigation.
- Aligns the Gateway-backed Chats inbox, centered empty state, bottom composer, active transcript, and Sandbox Resources panel with the approved Desktop Figma.
- Keeps attachments, connected tools, uploads, Settings navigation, send/stop, conversation create/open/delete, and Recents round trips wired to existing authoritative actions. Unsupported controls are absent and unavailable Gateway capabilities use explicit safe copy.
- Preserves canonical Gateway conversation IDs and owner-owned persistence; no renderer-local durable Chat state was added.

## Figma mapping

- `67:4472` Chat overview: global shell navigation retained; internal 260px Chat rail removed.
- `145:2309` conversation list: `Chats`, Search, New chat, 64px rows, Hermes harness badge, relative timestamp, and hover/focus-only delete.
- `67:4518` new conversation: centered Matrix mark and `How can I help you?` empty state with the constrained bottom composer.
- `67:4551` active conversation: readable constrained transcript widths, bottom reply composer, canonical Recents recording after successful Gateway open/create.
- `46:1575` under `105:11178` Sandbox Chat: theme-aware Resources panel for shared attachments and connected tools, with real Upload and Integrations actions.

## Screenshots (built Electron)

| Surface | Evidence |
| --- | --- |
| Chats inbox, light, 1440×900 | ![Chats inbox](https://uploads.linear.app/9d7c8ca2-ff8b-42ea-8321-35892cc887d8/f748b180-4ff0-49c7-87c1-93fd28c7700d/b881cb1d-cdc9-4a57-8416-f17869cdfe54) |
| Empty conversation and composer, 1440×900 | ![Empty conversation](https://uploads.linear.app/9d7c8ca2-ff8b-42ea-8321-35892cc887d8/8049e85f-c071-49c4-8712-3b5d6b8c1725/63eeed4c-da65-49ca-a16a-687036b015b6) |
| Resources, 1440×900 | ![Resources wide](https://uploads.linear.app/9d7c8ca2-ff8b-42ea-8321-35892cc887d8/65b8f792-2977-4db8-9009-af638904d765/4c446a43-1765-43bf-b7ff-ca8768caa0d1) |
| Resources, constrained 880×560 | ![Resources constrained](https://uploads.linear.app/9d7c8ca2-ff8b-42ea-8321-35892cc887d8/24a926e7-4aa7-43b2-9ee8-1afa7c346a92/740254f3-5d7a-4a63-b647-ab26c30c6327) |
| Chats inbox, dark, 1440×900 | ![Chats dark](https://uploads.linear.app/9d7c8ca2-ff8b-42ea-8321-35892cc887d8/872e6e48-c7ca-4f2e-99e7-939a0e0ba580/17a41638-efea-4dca-90c9-5c69ceef23e3) |

## Tests

- Latest post-review focused Desktop coverage passed `325/325` across 23 files, including MAT-322 Chat/Resources/Recents races and the exact #1227/#1228 dialog, Sidebar, and Terminal lifecycle seams.
- The pre-merge MAT-322 feature slice passed `294/294` affected Desktop tests.
- `bun run typecheck` passed, including Desktop TypeScript projects.
- `bun run check:patterns` passed with `0` violations (existing repository warnings only).
- `bun run build:desktop` passed.
- The rebuilt Electron operator suite passed `16/16` at exact head `5bb62a01929aa4827d46cce86c8d4714dcbfab8a`.
- React Doctor changed-source scan reported no MAT-322 findings; its three findings are existing and outside this PR diff.
- The supplemental repository-wide `bun run test` did not pass and was interrupted after 8m45s once its failure status was definitive. Emitted out-of-scope failures included `tests/platform/customer-vps-cloud-init.test.ts` (1), `tests/gateway/shell-zellij.test.ts` (1), `tests/shell/agent-settings.test.tsx` (suite load / 0 tests), `tests/gateway/coding-agents-workspace-provider.test.ts` (1 timeout), and `tests/gateway/coding-agents-codex-app-server-reliability.test.ts` (8). None is in the MAT-322 diff; no unrelated test or infrastructure code was changed. Exact-head GitHub CI is the authoritative full gate.

## Invariants

- **Source of truth:** Figma owns presentation mapping; Gateway/store contracts own conversations, canonical IDs, attachments, tools, and persistence.
- **Lock/transaction scope:** renderer-only change; no new database writes, transactions, durable renderer state, or persistence owner was introduced.
- **Acceptable orphan states:** no new durable entities are created. Existing upload/create/delete actions retain their existing Gateway-owned failure and cleanup behavior, and Recents are recorded only after successful canonical conversation open/create.
- **Auth source of truth:** existing Desktop session and Gateway/Integrations authorization paths remain authoritative; no auth bypass or alternate credential state was added.
- **Deferred scope:** artifact manifests, project/repository context selection, voice, and provider-neutral harness/model selection remain deferred until authoritative Gateway capabilities exist.

## Gateway-authoritative and deferred gaps

- The Gateway does not expose a per-conversation manifest for agent-created artifacts, so the panel states that this section is unavailable instead of fabricating resources.
- Project/repository context selection is deferred until an authoritative Chat capability/action exists.
- Voice input is absent because no Desktop Chat voice capability is exposed.
- Per-chat harness/model selection is absent because no provider-neutral Gateway selector is exposed; `Hermes` is informational status only.
- Connected tools use the existing Integrations store and Settings action; local attachment uploads use the existing Gateway file action.

## Documentation

- This change aligns an existing internal Desktop presentation and adds no public API or new user capability. No public docs claim is included here; future public Desktop Chat documentation belongs in the constitution-required separate `matrix-os-site` PR.

## Scope and landed overlap

- MAT-268 and all Files CRUD work are strict exclusions and remain untouched, unmerged, uncopied, and independent.
- Harness-neutral persistence and adapters remain MAT-321 and are excluded from this PR.
- Current `origin/main` (`12ab6161f0f5756c438546001aa510cf42b85ab6`) was merged into the feature branch with `zdiff3`; no rebase or cherry-pick was used.
- The merge preserves #1227 inactive-pane/dialog behavior, including centered `dialog-fade-in` delete confirmation coverage. The MAT-322 diff relative to current main does not touch `design/primitives.tsx`.
- The merge preserves #1228 canonical Terminal Recents and lifecycle behavior, including existing-tab focus, mounted Terminal workspace routing, runtime transition cleanup, and Terminal session coverage.

## Review and CI status

- Current exact head: `5bb62a01929aa4827d46cce86c8d4714dcbfab8a`.
- Exact-head Greptile completed at `5/5` on `5bb62a01929aa4827d46cce86c8d4714dcbfab8a`, and the paginated review-thread source reads back zero unresolved threads.
- Exact-head GitHub CI completed with 18 successful checks, 15 intentional change-detected skips, and zero failed, cancelled, or pending checks; the PR is ready to mark Ready and squash-merge.