### PR TITLE
fix(terminal): release hidden Canvas sizing clients

### DIFF
--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -497,6 +497,7 @@ export function CanvasWindow({ win, hidden = false, deferAppContent = false }: C
           launchTargetId={win.id}
           embeddedChrome
           canvasZoom={isFullscreen ? 1 : zoom}
+          suspended={hidden}
           windowControls={{
             close: () => closeWindow(win.id),
             minimize: animateMinimize,

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -226,10 +226,15 @@ interface TerminalAppProps {
    * mouse-to-cell mapping. Defaults to 1 (no correction needed).
    */
   canvasZoom?: number;
+  /**
+   * Keep Terminal app state mounted while releasing pane resources such as
+   * canonical-sizing WebSockets. Canvas uses this while a window is minimized.
+   */
+  suspended?: boolean;
 }
 
 // react-doctor-disable-next-line react-doctor/no-giant-component, react-doctor/prefer-useReducer -- no-giant-component: cohesive core terminal shell component; extraction tracked separately. prefer-useReducer: the 6 useState fields are independent, not one related cluster: tabs/activeTabId/focusedPaneId are mutated through many distinct code paths (split, close, rename, reorder, session-attach) using nested functional updaters that read prev and call sibling setters, while sidebarOpen/sidebarSelectedPath are sidebar UI and initialized is a one-time bootstrap gate; a single reducer would not be a mechanical, behavior-identical change.
-export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = false, initialSessionId, launchTargetId, mobile = false, windowControls, embeddedChrome = false, canvasZoom = 1 }: TerminalAppProps = {}) {
+export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = false, initialSessionId, launchTargetId, mobile = false, windowControls, embeddedChrome = false, canvasZoom = 1, suspended = false }: TerminalAppProps = {}) {
   const theme = useTheme();
   const themeId = useTerminalSettings((s) => s.themeId);
   const setThemeId = useTerminalSettings((s) => s.setThemeId);
@@ -960,18 +965,20 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
                     }
                   : {})}
               >
-                <PaneGrid
-                  paneTree={activeTab.paneTree}
-                  theme={designTheme}
-                  focusedPaneId={focusedPaneId}
-                  onFocusPane={setFocusedPaneId}
-                  onSessionAttached={handleSessionAttached}
-                  shouldCachePane={shouldCachePane}
-                  shouldDestroyPane={shouldDestroyPane}
-                  allowRemoteResize={!mobile}
-                  suppressNativeKeyboard={mobile}
-                  canvasZoom={canvasZoom}
-                />
+                {!suspended ? (
+                  <PaneGrid
+                    paneTree={activeTab.paneTree}
+                    theme={designTheme}
+                    focusedPaneId={focusedPaneId}
+                    onFocusPane={setFocusedPaneId}
+                    onSessionAttached={handleSessionAttached}
+                    shouldCachePane={shouldCachePane}
+                    shouldDestroyPane={shouldDestroyPane}
+                    allowRemoteResize={!mobile}
+                    suppressNativeKeyboard={mobile}
+                    canvasZoom={canvasZoom}
+                  />
+                ) : null}
                 {mobile && (
                   <>
                     <MobileTerminalActions

--- a/tests/shell/canvas-window-terminal-overlay.test.tsx
+++ b/tests/shell/canvas-window-terminal-overlay.test.tsx
@@ -225,6 +225,22 @@ describe("CanvasWindow terminal interactivity", () => {
     }));
   });
 
+  it("suspends a hidden Canvas terminal so it releases canonical sizing", () => {
+    const { rerender } = render(<CanvasWindow win={terminalWindow} hidden />);
+
+    expect(terminalRender).toHaveBeenLastCalledWith(expect.objectContaining({
+      launchTargetId: "win-terminal",
+      suspended: true,
+    }));
+
+    rerender(<CanvasWindow win={terminalWindow} hidden={false} />);
+
+    expect(terminalRender).toHaveBeenLastCalledWith(expect.objectContaining({
+      launchTargetId: "win-terminal",
+      suspended: false,
+    }));
+  });
+
   it("moves terminal Canvas windows through the delegated Terminal chrome drag handle", () => {
     useWindowManager.setState({
       windows: [terminalWindow],

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -682,6 +682,26 @@ describe("TerminalApp", () => {
     expect(contentSurface.style.background).toBe("rgb(28, 32, 25)");
   });
 
+  it("unmounts only the pane grid while a Canvas terminal is suspended", async () => {
+    const { rerender } = render(
+      <TerminalApp initialSessionId="canvas-session-123" suspended />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByTestId("terminal-pane-grid")).toBeNull();
+    expect(screen.getByRole("application", { name: "Terminal" })).toBeTruthy();
+
+    act(() => {
+      rerender(<TerminalApp initialSessionId="canvas-session-123" suspended={false} />);
+    });
+
+    expect(screen.getByTestId("terminal-pane-grid")).toBeTruthy();
+  });
+
   it("uses the selected non-system terminal theme background for the flush content surface", async () => {
     terminalSettingsState.themeId = "dark";
 

--- a/tests/shell/terminal-pane-scrolling.test.tsx
+++ b/tests/shell/terminal-pane-scrolling.test.tsx
@@ -90,6 +90,8 @@ const restorePlan = vi.hoisted(() => ({
   },
 }));
 
+const useActualRestorePlan = vi.hoisted(() => ({ current: false }));
+
 vi.mock("@xterm/xterm", () => ({
   Terminal: class MockTerminal {
     element: HTMLElement | null = null;
@@ -236,18 +238,27 @@ vi.mock("@xterm/addon-image", () => ({
   ImageAddon: class MockImageAddon {},
 }));
 
-vi.mock("../../shell/src/components/terminal/terminal-cache.js", () => ({
-  cacheTerminal: vi.fn(),
-  takeCached: vi.fn(() => null),
-  removeCached: vi.fn(),
-  hasCached: vi.fn(() => false),
-}));
+vi.mock("../../shell/src/components/terminal/terminal-cache.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../shell/src/components/terminal/terminal-cache.js")>();
+  return {
+    ...actual,
+    cacheTerminal: vi.fn(actual.cacheTerminal),
+    takeCached: vi.fn(actual.takeCached),
+    removeCached: vi.fn(actual.removeCached),
+    hasCached: vi.fn(actual.hasCached),
+  };
+});
 
-vi.mock("../../shell/src/components/terminal/terminal-restore.js", () => ({
-  getCachedTerminalRestorePlan: vi.fn(() => restorePlan.current),
-  discardStaleCachedTerminal: vi.fn(),
-  closeStaleCachedSocket: vi.fn(),
-}));
+vi.mock("../../shell/src/components/terminal/terminal-restore.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../shell/src/components/terminal/terminal-restore.js")>();
+  return {
+    getCachedTerminalRestorePlan: vi.fn((cached) => (
+      useActualRestorePlan.current ? actual.getCachedTerminalRestorePlan(cached) : restorePlan.current
+    )),
+    discardStaleCachedTerminal: vi.fn(actual.discardStaleCachedTerminal),
+    closeStaleCachedSocket: vi.fn(actual.closeStaleCachedSocket),
+  };
+});
 
 vi.mock("../../shell/src/components/terminal/terminal-appearance.js", () => ({
   applyTerminalAppearance: vi.fn(),
@@ -414,6 +425,7 @@ describe("TerminalPane scrolling", () => {
       lastSeq: 0,
       hasReplayCursor: false,
     };
+    useActualRestorePlan.current = false;
     globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
     globalThis.WebSocket = WebSocketMock as unknown as typeof WebSocket;
     globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) =>
@@ -1468,6 +1480,7 @@ describe("TerminalPane scrolling", () => {
     const firstMount = render(<TerminalPane {...props} />);
 
     await waitFor(() => expect(WebSocketMock.instances).toHaveLength(1));
+    await waitFor(() => expect(createdWebglAddons).toHaveLength(1));
     const firstSocket = WebSocketMock.instances[0]!;
     const terminal = createdTerminals[0]!;
     await act(async () => {
@@ -1475,6 +1488,8 @@ describe("TerminalPane scrolling", () => {
         data: JSON.stringify({ type: "attached", session: "main", state: "running", fromSeq: 7 }),
       });
       firstSocket.onmessage?.({ data: JSON.stringify({ type: "output", seq: 7, data: "cached-output\r\n" }) });
+    });
+    await act(async () => {
       firstMount.unmount();
       await Promise.resolve();
     });
@@ -1510,6 +1525,63 @@ describe("TerminalPane scrolling", () => {
     expect(createdTerminals).toHaveLength(1);
     expect(terminal.write.mock.calls.filter(([data]) => data === "cached-output\r\n")).toHaveLength(1);
     expect(new URL(WebSocketMock.instances[1]!.url).searchParams.get("fromSeq")).toBe("8");
+  });
+
+  it("detaches and restores a suspended canonical pane with replay and current dimensions", async () => {
+    const props = {
+      paneId: "pane-suspension-lifecycle-test",
+      cwd: "",
+      theme,
+      isFocused: false,
+      isClosing: false,
+      sessionId: "main",
+      shouldCacheOnUnmount: () => true,
+      shouldDestroyOnUnmount: () => false,
+      onFocus: () => {},
+    } satisfies Parameters<typeof TerminalPane>[0];
+    useActualRestorePlan.current = true;
+    const firstMount = render(<TerminalPane {...props} />);
+
+    await waitFor(() => expect(WebSocketMock.instances).toHaveLength(1));
+    await waitFor(() => expect(createdWebglAddons).toHaveLength(1));
+    const firstSocket = WebSocketMock.instances[0]!;
+    await waitFor(() => expect(firstSocket.onmessage).not.toBeNull());
+    const terminal = createdTerminals[0]!;
+    await act(async () => {
+      firstMount.unmount();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(mockedCacheTerminal).toHaveBeenCalled());
+    const cachedEntry = mockedCacheTerminal.mock.calls.at(-1)![1];
+    expect(cachedEntry.terminal).toBe(terminal);
+    expect(cachedEntry.lastSeq).toBe(0);
+    expect(cachedEntry.hasReplayCursor).toBe(false);
+    expect(mockedCacheTerminal.mock.calls.at(-1)![2]).toEqual({ retainSocket: false });
+    expect(firstSocket.send).toHaveBeenCalledWith(JSON.stringify({ type: "detach" }));
+    expect(firstSocket.close).toHaveBeenCalledOnce();
+
+    render(<TerminalPane {...props} />);
+    await waitFor(() => expect(WebSocketMock.instances).toHaveLength(2));
+
+    expect(createdTerminals).toHaveLength(1);
+    const restoredSocket = WebSocketMock.instances[1]!;
+    expect(new URL(restoredSocket.url).searchParams.get("fromSeq")).toBe("0");
+
+    await act(async () => {
+      restoredSocket.onmessage?.({
+        data: JSON.stringify({ type: "attached", session: "main", state: "running", fromSeq: 0 }),
+      });
+      restoredSocket.onmessage?.({ data: JSON.stringify({ type: "replay-start", fromSeq: 0 }) });
+      restoredSocket.onmessage?.({
+        data: JSON.stringify({ type: "output", seq: 0, data: "replayed-after-restore\r\n" }),
+      });
+      restoredSocket.onmessage?.({ data: JSON.stringify({ type: "canonical-size", cols: 132, rows: 36 }) });
+      restoredSocket.onmessage?.({ data: JSON.stringify({ type: "replay-end", toSeq: 0 }) });
+    });
+
+    expect(terminal.write.mock.calls.filter(([data]) => data === "replayed-after-restore\r\n")).toHaveLength(1);
+    expect(terminal.resize).toHaveBeenLastCalledWith(132, 36);
   });
 
   it.each([0, 60])("uses attached fromSeq %i as the reconnect cursor before output arrives", async (fromSeq) => {


### PR DESCRIPTION
## Summary

- suspend the pane grid for minimized Canvas terminal windows while preserving the surrounding Terminal app state
- release hidden terminals' canonical-sizing WebSockets so they no longer constrain visible terminal rows
- remount and reconnect the pane grid with current dimensions when the Canvas window is restored
- add focused regression coverage for the Canvas-to-Terminal suspension contract and pane-grid lifecycle

## Root cause

Canvas keeps minimized windows mounted with `display: none` to preserve application state. That also kept each hidden terminal's hard sizing client attached. Since the gateway chooses the component-wise minimum across attached hard clients, a smaller minimized terminal could constrain a taller visible terminal and leave unused space below its writable grid.

## Tests

- `pnpm exec vitest run tests/shell/canvas-window-terminal-overlay.test.tsx` — 15 passed
- `pnpm exec vitest run tests/shell/terminal-app-component.test.tsx` — 97 passed
- `pnpm exec vitest run tests/shell/terminal-pane-scrolling.test.tsx` — 27 passed
- `pnpm exec vitest run tests/shell/terminal-cache.test.ts tests/gateway/shell-sizing.test.ts` — 22 passed
- `./scripts/review/check-patterns.sh` — 0 violations; 5 existing repository-wide warning categories
- `git diff --check` — passed

### Environment limitations

- Shell TypeScript checking currently reports unrelated existing errors in `Desktop.tsx`, `VocalPanel.tsx`, and `MobileShell.tsx`; none are touched by this PR.
- The shell production build is currently blocked in this worktree by existing Langium/Mermaid dependency-resolution errors.
- ESLint could not start because the linked `eslint-config-next` package could not resolve `next/dist/compiled/babel/eslint-parser` in this environment.

## Invariants

### Source of truth

- The gateway remains the source of truth for canonical terminal sizing.
- Only visible hard clients participate; minimized Canvas terminals detach until restored.
- Terminal tab, sidebar, and layout state remain owned by the mounted `TerminalApp`.

### Lock/transaction scope

- No database, file-persistence, lock, or transaction behavior changes.
- No network call is introduced inside a critical section.

### Acceptable orphan states

- A minimized terminal may retain its bounded cached xterm buffer without a live socket.
- If restore/reconnect is interrupted, existing terminal reconnect handling remains responsible for retrying; the backing shell session is not destroyed.

### Auth source of truth

- Existing authenticated terminal WebSocket URL/token handling is unchanged.
- This PR only changes whether a hidden Canvas terminal keeps its pane mounted.

### Deferred scope

- Simultaneously visible hard clients still use the existing component-wise minimum policy.
- This PR does not change gateway wire schemas, sizing arbitration, or mobile soft-client behavior.
