### PR TITLE
fix(desktop): restore chat files and recents behavior

### DIFF
--- a/desktop/src/main/coding-agents/thread-event-stream.ts
+++ b/desktop/src/main/coding-agents/thread-event-stream.ts
@@ -55,6 +55,7 @@ export interface DesktopCodingAgentThreadWebSocket {
 interface ThreadSubscription {
   threadId: string;
   ws: DesktopCodingAgentThreadWebSocket;
+  failureEmitted: boolean;
 }
 
 export interface CodingAgentThreadEventStreamer {
@@ -101,6 +102,19 @@ export function createCodingAgentThreadEventStreamer(options: {
     if (!subscription) return;
     subscriptions.delete(threadId);
     closeSubscription(subscription);
+  }
+
+  function emitStreamUnavailable(subscription: ThreadSubscription): void {
+    if (subscription.failureEmitted) return;
+    subscription.failureEmitted = true;
+    options.emit("runtime:thread-stream-error", {
+      threadId: subscription.threadId,
+      error: {
+        code: "stream_unavailable",
+        safeMessage: "Thread stream unavailable",
+        retryable: true,
+      },
+    });
   }
 
   function unsubscribe(threadId: string): void {
@@ -162,7 +176,11 @@ export function createCodingAgentThreadEventStreamer(options: {
       }
       return;
     }
-    const subscription: ThreadSubscription = { threadId: parsedThreadId.data, ws };
+    const subscription: ThreadSubscription = {
+      threadId: parsedThreadId.data,
+      ws,
+      failureEmitted: false,
+    };
     subscriptions.set(parsedThreadId.data, subscription);
     evictIfNeeded();
 
@@ -199,10 +217,14 @@ export function createCodingAgentThreadEventStreamer(options: {
 
     ws.onerror = () => {
       console.warn("[desktop] coding-agent thread stream unavailable");
+      if (subscriptions.get(parsedThreadId.data) === subscription) {
+        emitStreamUnavailable(subscription);
+      }
     };
     ws.onclose = () => {
       if (subscriptions.get(parsedThreadId.data) === subscription) {
         subscriptions.delete(parsedThreadId.data);
+        emitStreamUnavailable(subscription);
       }
     };
   }

--- a/desktop/src/renderer/src/features/chat/ChatTab.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatTab.tsx
@@ -1,9 +1,12 @@
-import { FileText, Paperclip, PanelRight } from "lucide-react";
+import { FileText, FolderOpen, GitBranch, Plus } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { BrandLogo } from "../../design/BrandPanel";
 import { groupMessages } from "../../lib/chat";
 import { useConnection } from "../../stores/connection";
 import { useHermesChat, type HermesStatus } from "../../stores/hermes-chat";
+import { useTabs } from "../../stores/tabs";
+import { defaultProjectId, openProjectChat } from "../../lib/project-chat";
+import { useProviderPreferences } from "../settings/provider-preferences";
 import { AttachmentPreviewRow } from "./attachments/AttachmentPreviewRow";
 import { appendHermesAttachmentPaths } from "./attachments/local-attachment-controller";
 import { useConversationAttachments } from "./attachments/use-conversation-attachments";
@@ -27,9 +30,12 @@ function HermesPane() {
   const loadError = useHermesChat((state) => state.loadError);
   const send = useHermesChat((state) => state.send);
   const abort = useHermesChat((state) => state.abort);
+  const recordRecentHermesConversation = useTabs((state) => state.recordRecentHermesConversation);
+  const setDefaultProvider = useProviderPreferences((state) => state.setDefaultProvider);
   const [draft, setDraft] = useState("");
   const [uploadingAttachments, setUploadingAttachments] = useState(false);
   const [resourcesOpen, setResourcesOpen] = useState(false);
+  const [harnessError, setHarnessError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const resourcesTriggerRef = useRef<HTMLButtonElement>(null);
   const attachments = useConversationAttachments(sessionId);
@@ -50,13 +56,35 @@ function HermesPane() {
     try {
       const uploaded = await attachments.uploadAll();
       if (!uploaded.ok) return;
+      const submittedDraft = draft.trim();
       send(appendHermesAttachmentPaths(draft, uploaded.paths));
+      if (sessionId) {
+        const knownTitle = useHermesChat.getState().conversations
+          .find((conversation) => conversation.id === sessionId)?.title;
+        const label = submittedDraft.replace(/\s+/g, " ").slice(0, 80)
+          || knownTitle
+          || "Shared files";
+        recordRecentHermesConversation(sessionId, label);
+      }
       setDraft("");
       attachments.clear();
     } finally {
       setUploadingAttachments(false);
     }
   };
+
+  const startCodexChat = useCallback(async () => {
+    const projectId = defaultProjectId();
+    if (!projectId) {
+      setHarnessError("Create a project before starting a Codex chat.");
+      return;
+    }
+    setHarnessError(null);
+    setDefaultProvider("codex");
+    if (!await openProjectChat(projectId, { compose: true })) {
+      setHarnessError("Codex chat could not be opened. Try again from the project.");
+    }
+  }, [setDefaultProvider]);
 
   const attachmentPreviews = (
     <AttachmentPreviewRow
@@ -77,7 +105,7 @@ function HermesPane() {
         disabled={uploadingAttachments}
         onClick={() => fileInputRef.current?.click()}
       >
-        <Paperclip size={16} aria-hidden />
+        <Plus size={16} aria-hidden />
       </button>
       <button
         ref={resourcesTriggerRef}
@@ -88,19 +116,33 @@ function HermesPane() {
         style={{ color: "var(--text-secondary)" }}
         onClick={() => setResourcesOpen((open) => !open)}
       >
-        <PanelRight size={15} aria-hidden />
-        <span className="hidden sm:inline">Resources</span>
+        <FolderOpen size={15} aria-hidden />
+      </button>
+      <button
+        type="button"
+        aria-label="Use Codex for a project chat"
+        className="flex h-8 w-8 items-center justify-center rounded-lg hover:bg-[var(--bg-hover)] focus-visible:outline-2 focus-visible:outline-[var(--accent)]"
+        style={{ color: "var(--text-secondary)" }}
+        onClick={() => void startCodexChat()}
+      >
+        <GitBranch size={15} aria-hidden />
       </button>
     </>
   );
   const harnessBadge = (
-    <span
-      className="rounded-full border px-2 py-1 text-xs font-medium"
+    <select
+      aria-label="Chat harness"
+      value="hermes"
+      className="h-7 appearance-none rounded-full border bg-transparent px-2 text-xs font-medium outline-none hover:bg-[var(--bg-hover)] focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
       style={{ borderColor: "var(--border-default)", color: "var(--text-secondary)" }}
-      title="Current chat harness"
+      title="Choose chat harness"
+      onChange={(event) => {
+        if (event.currentTarget.value === "codex") void startCodexChat();
+      }}
     >
-      Hermes
-    </span>
+      <option value="hermes">Hermes</option>
+      <option value="codex">Codex</option>
+    </select>
   );
   const renderComposer = (placeholder: string, autoFocus = false) => (
     <>
@@ -147,10 +189,15 @@ function HermesPane() {
       {...attachments.paneProps}
     >
       {loadErrorBanner}
+      {harnessError ? (
+        <div role="alert" className="mx-auto mt-3 w-[calc(100%-2.5rem)] max-w-[868px] rounded-lg border px-3 py-2 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
+          {harnessError}
+        </div>
+      ) : null}
       {empty ? (
-        <div className="mx-auto flex min-h-0 w-full max-w-[868px] flex-1 flex-col px-5 pb-5">
-          <div className="flex min-h-[180px] flex-1 flex-col items-center justify-center pb-8 text-center">
-            <BrandLogo size={48} color="var(--text-primary)" className="mb-5" />
+        <div data-testid="chat-empty-content" className="mx-auto flex min-h-0 w-full max-w-[868px] flex-1 flex-col justify-center gap-[26px] px-5 py-8">
+          <div className="flex shrink-0 flex-col items-center gap-[26px] text-center">
+            <BrandLogo size={208} color="var(--text-primary)" testId="chat-empty-logo" />
             <h1
               className="text-[32px] font-medium leading-tight tracking-[-0.02em] sm:text-[36px]"
               style={{ color: "var(--text-primary)", fontFamily: '"Instrument Serif", Georgia, serif' }}
@@ -163,7 +210,7 @@ function HermesPane() {
       ) : (
         <>
           <Conversation>
-            <ConversationContent className="justify-start pt-[clamp(72px,30vh,280px)]">
+            <ConversationContent className="justify-start pt-8 sm:pt-12">
               {groups.map((group) =>
                 group.type === "tool_group" ? (
                   <ConversationItem key={group.messages[0]?.id ?? "tools"} messageId={group.messages[0]?.id}>

--- a/desktop/src/renderer/src/features/chat/HermesConversationIndex.tsx
+++ b/desktop/src/renderer/src/features/chat/HermesConversationIndex.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   MessageSquare,
   MessageSquarePlus,
@@ -43,16 +43,13 @@ function ConversationRow({
   const loadingConversationId = useHermesChat((state) => state.loadingConversationId);
   const deletingConversationId = useHermesChat((state) => state.deletingConversationId);
   const openConversation = useHermesChat((state) => state.openConversation);
-  const recordRecentConversation = useTabs((state) => state.recordRecentConversation);
   const running = conversation.id === sessionId && status !== "idle";
   const loading = loadingConversationId === conversation.id;
   const deleting = deletingConversationId === conversation.id;
   const runningDescriptionId = `delete-running-${conversation.id}`;
   const openSelectedConversation = async () => {
     if (!api) return;
-    if (await openConversation(api, conversation.id)) {
-      recordRecentConversation(conversation.id, conversation.title);
-    }
+    await openConversation(api, conversation.id);
   };
 
   return (
@@ -120,11 +117,17 @@ function HermesConversationIndexContent({ api }: { api: ApiClient | null }) {
   const createConversation = useHermesChat((state) => state.createConversation);
   const deleteConversation = useHermesChat((state) => state.deleteConversation);
   const clearDeleteError = useHermesChat((state) => state.clearDeleteError);
-  const recordRecentConversation = useTabs((state) => state.recordRecentConversation);
+  const removeRecentView = useTabs((state) => state.removeRecentView);
+  const reconcileRecentHermesConversations = useTabs((state) => state.reconcileRecentHermesConversations);
   const filteredConversations = useMemo(
     () => filterConversations(conversations, query),
     [conversations, query],
   );
+
+  useEffect(() => {
+    if (indexStatus !== "ready") return;
+    reconcileRecentHermesConversations(conversations.map((conversation) => conversation.id));
+  }, [conversations, indexStatus, reconcileRecentHermesConversations]);
 
   const closeSearch = () => {
     setQuery("");
@@ -138,15 +141,13 @@ function HermesConversationIndexContent({ api }: { api: ApiClient | null }) {
   const confirmDelete = async () => {
     if (!api || !deleteTarget) return;
     if (await deleteConversation(api, deleteTarget.id)) {
+      removeRecentView("conversation", deleteTarget.id);
       setDeleteTarget(null);
     }
   };
   const startConversation = async () => {
     if (!api) return;
-    const id = await createConversation(api);
-    if (!id) return;
-    const created = useHermesChat.getState().conversations.find((item) => item.id === id);
-    recordRecentConversation(id, created?.title ?? "New chat");
+    await createConversation(api);
   };
 
   return (

--- a/desktop/src/renderer/src/features/chat/HermesConversationIndex.tsx
+++ b/desktop/src/renderer/src/features/chat/HermesConversationIndex.tsx
@@ -109,6 +109,7 @@ function HermesConversationIndexContent({ api }: { api: ApiClient | null }) {
   const [query, setQuery] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<HermesConversationSummary | null>(null);
   const conversations = useHermesChat((state) => state.conversations);
+  const isConversationIndexComplete = useHermesChat((state) => state.isConversationIndexComplete);
   const indexStatus = useHermesChat((state) => state.indexStatus);
   const indexError = useHermesChat((state) => state.indexError);
   const deletingConversationId = useHermesChat((state) => state.deletingConversationId);
@@ -125,9 +126,9 @@ function HermesConversationIndexContent({ api }: { api: ApiClient | null }) {
   );
 
   useEffect(() => {
-    if (indexStatus !== "ready") return;
+    if (indexStatus !== "ready" || !isConversationIndexComplete) return;
     reconcileRecentHermesConversations(conversations.map((conversation) => conversation.id));
-  }, [conversations, indexStatus, reconcileRecentHermesConversations]);
+  }, [conversations, indexStatus, isConversationIndexComplete, reconcileRecentHermesConversations]);
 
   const closeSearch = () => {
     setQuery("");

--- a/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
@@ -32,6 +32,7 @@ import {
   codingAgentInputActionKey,
   useCodingAgentWorkspace,
 } from "../../stores/coding-agent-workspace";
+import { useTabs } from "../../stores/tabs";
 import { safeUrlTransform } from "../editor/MarkdownPreview";
 import {
   Attachment,
@@ -609,12 +610,14 @@ function SystemEvent({ event, answeredInputs, resolvedApprovals }: {
 
 function ConversationComposer({
   threadId,
+  threadLabel,
   waitingForAction,
   threadBusy,
   composerControls,
   attachments,
 }: {
   threadId: string;
+  threadLabel: string;
   waitingForAction: boolean;
   threadBusy: boolean;
   // Left side of the composer bottom row (provider/mode pickers).
@@ -650,6 +653,7 @@ function ConversationComposer({
         ...(uploaded.attachments.length > 0 ? { attachments: uploaded.attachments } : {}),
       });
       if (sent) {
+        useTabs.getState().recordRecentConversation(threadId, threadLabel);
         setMessage("");
         attachments.clear();
       }
@@ -827,6 +831,7 @@ export function AgentConversationView({
         <ConversationComposer
           key={`composer:${snapshot.thread.id}`}
           threadId={snapshot.thread.id}
+          threadLabel={snapshot.thread.title}
           waitingForAction={snapshot.thread.status === "waiting_for_approval" || snapshot.thread.status === "waiting_for_input"}
           threadBusy={running}
           attachments={attachments}

--- a/desktop/src/renderer/src/features/files/FilePreviewPane.tsx
+++ b/desktop/src/renderer/src/features/files/FilePreviewPane.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowLeft,
   FileCode2,
   FileQuestion,
   Folder,
@@ -229,7 +230,17 @@ function ImagePreview({ path, name }: { path: string; name: string }) {
   );
 }
 
-function FolderPreview({ path }: { path: string }) {
+function childBrowserPath(parent: string, name: string): string {
+  return parent ? `${parent}/${name}` : name;
+}
+
+function FolderPreview({
+  path,
+  onOpen,
+}: {
+  path: string;
+  onOpen: (selection: PreviewSelection) => void;
+}) {
   const api = useConnection((state) => state.api);
   const [attempt, setAttempt] = useState(0);
   const [state, setState] = useState<
@@ -261,29 +272,45 @@ function FolderPreview({ path }: { path: string }) {
   return (
     <div className="grid min-h-0 flex-1 auto-rows-min grid-cols-[repeat(auto-fill,minmax(92px,1fr))] content-start gap-2 overflow-auto p-4">
       {state.entries.map((entry) => (
-        <div
+        <button
+          type="button"
           key={`${entry.type}:${entry.name}`}
-          className="flex min-w-0 flex-col items-center gap-2 rounded-lg border px-2 py-3 text-center"
+          aria-label={`Open ${entry.name} in preview`}
+          className="flex min-w-0 flex-col items-center gap-2 rounded-lg border px-2 py-3 text-center transition-colors hover:bg-[var(--bg-hover)] focus-visible:outline-2 focus-visible:outline-[var(--accent)]"
           style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }}
           title={entry.name}
+          onClick={() => onOpen({
+            path: childBrowserPath(path, entry.name),
+            entry,
+          })}
         >
           <span style={{ color: entry.type === "directory" ? "var(--accent)" : "var(--text-tertiary)" }}>
             <FileGlyph kind={kindForEntry(entry)} size={28} />
           </span>
           <span className="w-full truncate text-xs" style={{ color: "var(--text-primary)" }}>{entry.name}</span>
-        </div>
+        </button>
       ))}
     </div>
   );
 }
 
 // Renders below a Suspense boundary (markdown preview is lazy-loaded).
-export function FilePreview({ path, entry }: { path: string | null; entry?: BrowserEntry }) {
+export function FilePreview({
+  path,
+  entry,
+  onOpen,
+}: {
+  path: string | null;
+  entry?: BrowserEntry;
+  onOpen?: (selection: PreviewSelection) => void;
+}) {
   const api = useConnection((state) => state.api);
   if (path === null || !api) {
     return <EmptyState icon={<FileCode2 size={26} />} headline="Choose a file" description="Preview images, Markdown, and code from this computer." />;
   }
-  if (entry?.type === "directory") return <FolderPreview key={path} path={path} />;
+  if (entry?.type === "directory") {
+    return <FolderPreview key={path} path={path} onOpen={onOpen ?? (() => undefined)} />;
+  }
   const name = path.split("/").pop() ?? path;
   const kind = previewKindForPath(path);
   if (kind === "image") return <ImagePreview key={path} path={path} name={name} />;
@@ -293,7 +320,14 @@ export function FilePreview({ path, entry }: { path: string | null; entry?: Brow
 }
 
 export function PreviewPane({ selection }: { selection: PreviewSelection }) {
-  const { entry, path } = selection;
+  const [history, setHistory] = useState<PreviewSelection[]>([selection]);
+  const activeSelection = history.at(-1) ?? selection;
+  const { entry, path } = activeSelection;
+
+  useEffect(() => {
+    setHistory([selection]);
+  }, [selection.entry, selection.path]);
+
   const metadata = isManagedBrowserPath(path)
     ? "Managed · Read only"
     : entry.type === "directory"
@@ -306,6 +340,17 @@ export function PreviewPane({ selection }: { selection: PreviewSelection }) {
       style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
     >
       <header className="flex min-h-16 shrink-0 items-center gap-3 border-b px-4 py-3" style={{ borderColor: "var(--border-subtle)" }}>
+        {history.length > 1 ? (
+          <button
+            type="button"
+            aria-label="Back in preview"
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md hover:bg-[var(--bg-hover)] focus-visible:outline-2 focus-visible:outline-[var(--accent)]"
+            style={{ color: "var(--text-secondary)" }}
+            onClick={() => setHistory((current) => current.slice(0, -1))}
+          >
+            <ArrowLeft size={16} aria-hidden />
+          </button>
+        ) : null}
         <span className="shrink-0" style={{ color: entry.type === "directory" ? "var(--accent)" : "var(--text-tertiary)" }}>
           <FileGlyph kind={kindForEntry(entry)} size={20} />
         </span>
@@ -314,7 +359,11 @@ export function PreviewPane({ selection }: { selection: PreviewSelection }) {
           {metadata ? <p className="mt-0.5 truncate text-xs" style={{ color: "var(--text-tertiary)" }}>{metadata}</p> : null}
         </div>
       </header>
-      <FilePreview path={path} entry={entry} />
+      <FilePreview
+        path={path}
+        entry={entry}
+        onOpen={(next) => setHistory((current) => [...current, next])}
+      />
     </section>
   );
 }

--- a/desktop/src/renderer/src/features/mission-control/RecentViews.tsx
+++ b/desktop/src/renderer/src/features/mission-control/RecentViews.tsx
@@ -84,13 +84,13 @@ export default function RecentViews() {
       openTab({ kind: "terminal", sessionName: recent.id, title: recent.label });
       return;
     }
-    if (recent.id.startsWith("thread_")) {
+    const legacyThread = threads.find((candidate) => candidate.id === recent.id);
+    if (recent.conversationType === "coding-agent") {
       void openCodingAgentThread(recent.id);
       return;
     }
-    const thread = threads.find((candidate) => candidate.id === recent.id);
-    if (thread) {
-      setActiveThread(thread.id);
+    if (legacyThread) {
+      setActiveThread(legacyThread.id);
       openTab({ kind: "chat", title: "Hermes", closable: false });
       return;
     }

--- a/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
@@ -50,7 +50,7 @@ export function ProjectChatDraft({
   seed: ComposerSeed | null;
   focusRequestId: number;
   typeToStartEnabled: boolean;
-  onCreated: () => void;
+  onCreated: (threadId: string, label: string) => void;
 }) {
   const preferredProviderId = useProviderPreferences((s) => s.defaultProviderId);
   const initialDraft = useMemo(() => {
@@ -183,7 +183,7 @@ export function ProjectChatDraft({
       useDraftChat.getState().clearDraft(projectId);
       setDraft(initialDraft);
       attachments.clear();
-      onCreated();
+      onCreated(threadId, prompt.replace(/\s+/g, " ").slice(0, 80) || "Agent conversation");
     } finally {
       submitInFlightRef.current = false;
       setResolvingTarget(false);

--- a/desktop/src/renderer/src/features/project/ProjectChatsView.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatsView.tsx
@@ -74,7 +74,6 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
   const resolveNewChatTarget = useProjectWorkspaces((s) => s.resolveNewChatTarget);
   const selectedThreadId = useProjectView((s) => s.entries[projectId]?.selectedThreadId ?? null);
   const setSelectedThread = useProjectView((s) => s.setSelectedThread);
-  const recordRecentConversation = useTabs((s) => s.recordRecentConversation);
   const composerRequest = useProjectChatLauncher((s) => s.composerRequest);
   const runtimeScope = useConnection(codingAgentRuntimeScope);
   const inspectorEntry = useInspectorLayout((s) => s.entries[projectId]);
@@ -340,31 +339,20 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
     activity: summary.attentionThreads.items.length + summary.activeThreads.items.length,
   };
 
-  // Global Recents owns cross-surface conversation navigation. Same-project
-  // selections stay local, while cross-project selections use the canonical
-  // launcher. Both paths record the stable thread id only after the owning
-  // project and matching snapshot have loaded successfully.
+  // Selecting a thread is navigation only. Recents is promoted by successful
+  // message sends, never by opening or re-opening a conversation.
   const openListedThread = async (
     threadId: string,
     threadProjectId?: string,
-    threadTitle?: string,
   ): Promise<void> => {
     newChatRequestIdRef.current += 1;
     setComposerSeed(null);
-    const listedTitle = threadTitle ?? [
-      ...summary.attentionThreads.items,
-      ...summary.activeThreads.items,
-      ...(workspace?.projectThreads.items ?? []),
-      ...(workspace?.taskThreads.items ?? []),
-    ].find((thread) => thread.id === threadId)?.title ?? "Agent conversation";
     if (threadProjectId && threadProjectId !== projectId) {
       await openCodingAgentThread(threadId);
       return;
     }
     setSelectedThread(projectId, threadId);
-    if (await loadCodingAgentConversation(projectId, threadId)) {
-      recordRecentConversation(threadId, listedTitle);
-    }
+    await loadCodingAgentConversation(projectId, threadId);
   };
 
   // Slice 2 hero layout: the conversation and the tools inspector sit in a
@@ -394,11 +382,20 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
   // A created chat must always surface: select it, drop the draft seed, and
   // refresh the rail. Shared by the draft pane (project workspace path) and
   // the legacy inspector composer (no project-workspace capability).
-  const handleComposerCreated = () => {
-    const createdId = useCodingAgentWorkspace.getState().activeThreadId;
-    if (createdId) setSelectedThread(projectId, createdId);
+  const handleComposerCreated = (threadId: string, label: string) => {
+    setSelectedThread(projectId, threadId);
+    useTabs.getState().recordRecentConversation(threadId, label);
     setComposerSeed(null);
     if (projectWorkspaceEnabled) void refreshWorkspace(projectId);
+  };
+  const handleLegacyComposerCreated = () => {
+    const state = useCodingAgentWorkspace.getState();
+    const threadId = state.activeThreadId;
+    if (!threadId) return;
+    const label = state.threadSnapshot?.thread.id === threadId
+      ? state.threadSnapshot.thread.title
+      : "Agent conversation";
+    handleComposerCreated(threadId, label);
   };
 
   const conversationColumn = (
@@ -480,7 +477,7 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
               summary={summary}
               seed={composerSeed}
               focusRequestId={composerFocusRequestId}
-              onCreated={handleComposerCreated}
+              onCreated={handleLegacyComposerCreated}
             />
           ) : undefined
         }
@@ -522,15 +519,15 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
           <div className="space-y-4">
             <AttentionThreadList
               summary={summary}
-              onOpenThread={(thread) => openListedThread(thread.id, thread.projectId, thread.title)}
+              onOpenThread={(thread) => openListedThread(thread.id, thread.projectId)}
             />
             <ThreadList
               summary={summary}
-              onOpenThread={(thread) => openListedThread(thread.id, thread.projectId, thread.title)}
+              onOpenThread={(thread) => openListedThread(thread.id, thread.projectId)}
             />
             <CreatedThreadHandleList
               summary={summary}
-              onOpenThread={(thread) => openListedThread(thread.id, thread.projectId, thread.title)}
+              onOpenThread={(thread) => openListedThread(thread.id, thread.projectId)}
             />
             <ProviderList summary={summary} />
             <NotificationPreferencesPanel />

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -9,6 +9,7 @@ import { getThemeTerminalColors } from "../../design/themes";
 import { resolveThemeMode } from "../../design/themes/apply";
 import { useAppearance } from "../../stores/appearance";
 import { useConnection } from "../../stores/connection";
+import { useTabs } from "../../stores/tabs";
 import { buildTerminalFontStack } from "../../lib/terminal/terminal-fonts";
 import type { ActiveAttachment } from "./attach-manager";
 import type { ShellSocketState } from "../../lib/shell-socket";
@@ -31,6 +32,7 @@ import {
 } from "./terminal-rich-paste";
 
 const GAP_MARKER = "\r\n\x1b[2m── output gap ──\x1b[0m\r\n";
+const RECENT_ACTIVITY_THROTTLE_MS = 30_000;
 
 interface TerminalViewProps {
   sessionName: string;
@@ -200,7 +202,15 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
       },
     });
     attachmentRef.current = attachment;
-    const dataDisposable = terminal.onData((data) => attachment.write(data));
+    let lastRecentActivityAt = 0;
+    const dataDisposable = terminal.onData((data) => {
+      const now = Date.now();
+      if (now - lastRecentActivityAt >= RECENT_ACTIVITY_THROTTLE_MS) {
+        lastRecentActivityAt = now;
+        useTabs.getState().recordRecentTerminal(sessionName, sessionName);
+      }
+      attachment.write(data);
+    });
     fit?.fit();
     attachment.resize(terminal.cols, terminal.rows);
     terminal.focus();

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -109,6 +109,8 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
   const tabs = useTabs((s) => s.tabs);
   const openTab = useTabs((s) => s.openTab);
   const recordRecentTerminal = useTabs((s) => s.recordRecentTerminal);
+  const removeRecentView = useTabs((s) => s.removeRecentView);
+  const reconcileRecentTerminals = useTabs((s) => s.reconcileRecentTerminals);
   const terminalSessionRequest = useTabs((s) => s.terminalSessionRequest);
   const consumeTerminalSessionRequest = useTabs((s) => s.consumeTerminalSessionRequest);
   const renameTerminalSession = useTabs((s) => s.renameTerminalSession);
@@ -129,6 +131,11 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
   useEffect(() => {
     if (api) void load(api);
   }, [api, load]);
+
+  useEffect(() => {
+    if (loading || error || loadSequence === 0) return;
+    reconcileRecentTerminals(shells.map((shell) => shell.name));
+  }, [error, loading, loadSequence, reconcileRecentTerminals, shells]);
 
   const openShellNames = useMemo(
     () => new Set([
@@ -192,11 +199,11 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
       setActionError("Could not create shell");
       return;
     }
+    recordRecentTerminal(created.name, created.name);
     showShellDetail(created);
   };
 
   const showShellDetail = useCallback((shell: ShellSessionSummary) => {
-    recordRecentTerminal(shell.name, shell.name);
     setOpenedSessionNames((current) => [
       ...current.filter((name) => name !== shell.name),
       shell.name,
@@ -206,7 +213,7 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
     if (shell.latestSeq !== undefined && shell.latestSeq !== null && shell.lastSeenSeq !== shell.latestSeq && api) {
       void patchUiState(api, shell.name, { lastSeenSeq: shell.latestSeq });
     }
-  }, [api, patchUiState, recordRecentTerminal]);
+  }, [api, patchUiState]);
 
   useEffect(() => {
     if (!terminalSessionRequest) return;
@@ -313,6 +320,7 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
       setActionError("Could not delete shell");
       return;
     }
+    removeRecentView("terminal", name);
     if (selectedRef.current === name) {
       setSelectedName(null);
     }

--- a/desktop/src/renderer/src/lib/project-chat.ts
+++ b/desktop/src/renderer/src/lib/project-chat.ts
@@ -18,9 +18,6 @@ export interface OpenProjectChatOptions {
   threadId?: string | null;
   // Open the new-chat composer for the project once the view is visible.
   compose?: boolean;
-  // Unknown threads may still open under a best-effort fallback project, but
-  // that unverified route must never become a persistent global Recent.
-  recordRecent?: boolean;
 }
 
 interface ProjectChatLauncherState {
@@ -67,28 +64,6 @@ function projectTitleFor(projectId: string): string {
     .getState()
     .summary?.projects.items.find((project) => project.id === projectId);
   return summaryProject?.label ?? projectId;
-}
-
-function conversationTitleFor(threadId: string): string {
-  const workspace = useCodingAgentWorkspace.getState();
-  const summaryThread = [
-    ...(workspace.summary?.attentionThreads.items ?? []),
-    ...(workspace.summary?.activeThreads.items ?? []),
-  ].find((thread) => thread.id === threadId);
-  if (summaryThread?.title) return summaryThread.title;
-  if (workspace.threadSnapshot?.thread.id === threadId) {
-    return workspace.threadSnapshot.thread.title;
-  }
-  for (const entry of Object.values(useProjectWorkspaces.getState().entries)) {
-    const projectWorkspace = entry.workspace;
-    if (!projectWorkspace) continue;
-    const listed = [
-      ...projectWorkspace.projectThreads.items,
-      ...projectWorkspace.taskThreads.items,
-    ].find((thread) => thread.id === threadId);
-    if (listed?.title) return listed.title;
-  }
-  return "Agent conversation";
 }
 
 /**
@@ -161,14 +136,7 @@ export async function openProjectChat(
     void useProjectWorkspaces.getState().ensure(projectId);
     return true;
   }
-  const opened = await loadCodingAgentConversation(projectId, options.threadId);
-  if (opened && options.recordRecent !== false) {
-    useTabs.getState().recordRecentConversation(
-      options.threadId,
-      conversationTitleFor(options.threadId),
-    );
-  }
-  return opened;
+  return loadCodingAgentConversation(projectId, options.threadId);
 }
 
 /**
@@ -219,7 +187,6 @@ export async function openCodingAgentThread(threadId: string): Promise<void> {
   // to be active; the snapshot later reveals the real projectId but nothing
   // reroutes, so the chat stays selected and persisted under the wrong project.
   const known = listed?.projectId ?? snapshotProjectId ?? workspaceProjectId;
-  let resolvedAuthoritatively = known !== undefined;
   let projectId = known;
   if (!projectId) {
     const runtimeGeneration = captureRuntimeGeneration();
@@ -231,14 +198,10 @@ export async function openCodingAgentThread(threadId: string): Promise<void> {
     // Only guess when the runtime genuinely could not resolve it. The guess
     // opens the chat under whichever project is active and nothing reroutes.
     projectId = resolved ?? defaultProjectId() ?? undefined;
-    resolvedAuthoritatively = resolved !== undefined;
   }
   if (!projectId) {
     console.warn("[project-chat] cannot open a thread before any project exists");
     return;
   }
-  await openProjectChat(projectId, {
-    threadId,
-    recordRecent: resolvedAuthoritatively,
-  });
+  await openProjectChat(projectId, { threadId });
 }

--- a/desktop/src/renderer/src/stores/coding-agent-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-workspace.ts
@@ -31,6 +31,7 @@ import {
   withoutRecordKey,
   type FileReference,
 } from "./coding-agent/thread-model";
+import { createThreadSnapshotPoller } from "./coding-agent/thread-snapshot-poller";
 import { captureRuntimeGeneration, isCurrentRuntimeGeneration } from "./runtime-generation";
 
 type WorkspaceStatus = "idle" | "loading" | "ready" | "error";
@@ -53,6 +54,14 @@ type ReviewSummaryList = {
 };
 
 const MAX_LOCAL_CREATED_THREAD_HANDLES = 10;
+const THREAD_SNAPSHOT_POLL_INTERVAL_MS = 2_000;
+const SETTLED_THREAD_STATUSES = new Set<AgentThreadSummary["status"]>([
+  "completed",
+  "failed",
+  "aborted",
+  "stale",
+  "archived",
+]);
 
 interface CodingAgentWorkspaceState {
   status: WorkspaceStatus;
@@ -151,6 +160,7 @@ let createRequestSeq = 0;
 let actionRequestSeq = 0;
 let activeThreadEventSubscription: (() => void) | null = null;
 let activeThreadEventSubscriptionId: string | null = null;
+const activeThreadSnapshotPoller = createThreadSnapshotPoller(THREAD_SNAPSHOT_POLL_INTERVAL_MS);
 
 function clearReviewSelectionState() {
   reviewSnapshotSeq += 1;
@@ -206,6 +216,7 @@ function nextActionRequestId(): string {
 }
 
 function detachActiveThreadEventStream(): void {
+  activeThreadSnapshotPoller.stop();
   const threadId = activeThreadEventSubscriptionId;
   activeThreadEventSubscription?.();
   activeThreadEventSubscription = null;
@@ -213,6 +224,39 @@ function detachActiveThreadEventStream(): void {
   if (!threadId) return;
   void invoke("runtime:unsubscribe-thread-events", { threadId }).catch(() => {
     console.warn("[coding-agents] thread stream detach failed");
+  });
+}
+
+function scheduleActiveThreadSnapshotPoll(threadId: string): void {
+  const current = useCodingAgentWorkspace.getState();
+  if (
+    current.activeThreadId !== threadId
+    || current.threadSnapshot?.thread.id !== threadId
+    || SETTLED_THREAD_STATUSES.has(current.threadSnapshot.thread.status)
+  ) {
+    return;
+  }
+
+  activeThreadSnapshotPoller.start(async () => {
+    try {
+      const snapshot = await invoke("runtime:get-thread-snapshot", { threadId });
+      useCodingAgentWorkspace.setState((state) => {
+        if (state.activeThreadId !== threadId || state.threadSnapshot?.thread.id !== threadId) return {};
+        const merged = mergeSelectedThreadSnapshot(state.threadSnapshot, snapshot);
+        return {
+          threadSnapshotStatus: "ready",
+          threadSnapshot: merged,
+          threadSnapshotError: null,
+          summary: state.summary ? reconcileSummaryThread(state.summary, merged.thread) : state.summary,
+        };
+      });
+    } catch {
+      console.warn("[coding-agents] thread snapshot poll unavailable");
+    }
+    const latest = useCodingAgentWorkspace.getState();
+    return latest.activeThreadId === threadId
+      && latest.threadSnapshot?.thread.id === threadId
+      && !SETTLED_THREAD_STATUSES.has(latest.threadSnapshot.thread.status);
   });
 }
 
@@ -276,7 +320,7 @@ function attachActiveThreadEventStream(snapshot: AgentThreadSnapshot): void {
   });
   const detachErrorListener = onEvent("runtime:thread-stream-error", (payload) => {
     if (payload.threadId !== activeThreadEventSubscriptionId) return;
-    void useCodingAgentWorkspace.getState().loadThreadSnapshot(payload.threadId);
+    scheduleActiveThreadSnapshotPoll(payload.threadId);
   });
   activeThreadEventSubscription = () => {
     detachEventListener();
@@ -292,8 +336,12 @@ function attachActiveThreadEventStream(snapshot: AgentThreadSnapshot): void {
       activeThreadEventSubscription?.();
       activeThreadEventSubscription = null;
       activeThreadEventSubscriptionId = null;
+      scheduleActiveThreadSnapshotPoll(threadId);
     }
   });
+  // Live streams can remain open while silently dropping events. Keep one
+  // bounded selected-thread poll as a safety net until the thread settles.
+  scheduleActiveThreadSnapshotPoll(threadId);
 }
 
 export function codingAgentApprovalActionKey(threadId: string, approvalId: string): string {
@@ -999,6 +1047,7 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
           },
         };
       });
+      attachActiveThreadEventStream(snapshot);
       return thread.id;
     } catch {
       if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;

--- a/desktop/src/renderer/src/stores/coding-agent/thread-snapshot-poller.ts
+++ b/desktop/src/renderer/src/stores/coding-agent/thread-snapshot-poller.ts
@@ -1,0 +1,34 @@
+export interface ThreadSnapshotPoller {
+  start(poll: () => Promise<boolean>): void;
+  stop(): void;
+}
+
+export function createThreadSnapshotPoller(intervalMs: number): ThreadSnapshotPoller {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let generation = 0;
+
+  function stop(): void {
+    generation += 1;
+    if (timer) clearTimeout(timer);
+    timer = null;
+  }
+
+  function start(poll: () => Promise<boolean>): void {
+    stop();
+    const activeGeneration = generation;
+
+    const schedule = () => {
+      timer = setTimeout(() => {
+        timer = null;
+        void poll().then((continuePolling) => {
+          if (generation !== activeGeneration || !continuePolling) return;
+          schedule();
+        });
+      }, intervalMs);
+    };
+
+    schedule();
+  }
+
+  return { start, stop };
+}

--- a/desktop/src/renderer/src/stores/hermes-chat.ts
+++ b/desktop/src/renderer/src/stores/hermes-chat.ts
@@ -60,6 +60,11 @@ export interface HermesConversationSummary {
   updatedAt: number;
 }
 
+interface ConversationIndexSnapshot {
+  conversations: HermesConversationSummary[];
+  complete: boolean;
+}
+
 function normalizedPreview(value: string): string {
   return value.replace(/\s+/g, " ").trim().slice(0, CONVERSATION_PREVIEW_CAP).trimEnd();
 }
@@ -85,12 +90,16 @@ function safeConversationDeleteMessage(error: unknown): string {
   }
 }
 
-export function normalizeConversationIndex(raw: unknown): HermesConversationSummary[] | null {
+function normalizeConversationIndexSnapshot(raw: unknown): ConversationIndexSnapshot | null {
   if (!Array.isArray(raw)) return null;
   const summaries: HermesConversationSummary[] = [];
+  let complete = raw.length <= CONVERSATION_INDEX_CAP;
   for (const candidate of raw.slice(0, CONVERSATION_INDEX_CAP)) {
     const parsed = ConversationSummaryWireSchema.safeParse(candidate);
-    if (!parsed.success) continue;
+    if (!parsed.success) {
+      complete = false;
+      continue;
+    }
     const preview = normalizedPreview(parsed.data.preview);
     summaries.push({
       ...parsed.data,
@@ -98,9 +107,16 @@ export function normalizeConversationIndex(raw: unknown): HermesConversationSumm
       title: titleFromPreview(preview),
     });
   }
-  return summaries.toSorted((left, right) =>
-    right.updatedAt - left.updatedAt || right.createdAt - left.createdAt || left.id.localeCompare(right.id),
-  );
+  return {
+    conversations: summaries.toSorted((left, right) =>
+      right.updatedAt - left.updatedAt || right.createdAt - left.createdAt || left.id.localeCompare(right.id),
+    ),
+    complete,
+  };
+}
+
+export function normalizeConversationIndex(raw: unknown): HermesConversationSummary[] | null {
+  return normalizeConversationIndexSnapshot(raw)?.conversations ?? null;
 }
 
 function historyMessages(
@@ -125,6 +141,7 @@ interface HermesChatState {
   activeRequestId: string | null;
   view: HermesConversationView;
   conversations: HermesConversationSummary[];
+  isConversationIndexComplete: boolean;
   indexStatus: HermesLoadStatus;
   indexError: string | null;
   loadStatus: HermesLoadStatus;
@@ -160,6 +177,7 @@ export const useHermesChat = create<HermesChatState>()((set, get) => ({
   activeRequestId: null,
   view: "index",
   conversations: [],
+  isConversationIndexComplete: false,
   indexStatus: "idle",
   indexError: null,
   loadStatus: "idle",
@@ -245,13 +263,20 @@ export const useHermesChat = create<HermesChatState>()((set, get) => ({
       indexError: null,
     }));
     try {
-      const normalized = normalizeConversationIndex(await api.get<unknown>("/api/conversations"));
+      const snapshot = normalizeConversationIndexSnapshot(
+        await api.get<unknown>("/api/conversations"),
+      );
       if (!isCurrentRuntimeGeneration(generation) || get().indexSequence !== sequence) return;
-      if (!normalized) {
+      if (!snapshot) {
         set({ indexStatus: "error", indexError: INDEX_ERROR_MESSAGE });
         return;
       }
-      set({ conversations: normalized, indexStatus: "ready", indexError: null });
+      set({
+        conversations: snapshot.conversations,
+        isConversationIndexComplete: snapshot.complete,
+        indexStatus: "ready",
+        indexError: null,
+      });
     } catch (error: unknown) {
       if (!isCurrentRuntimeGeneration(generation) || get().indexSequence !== sequence) return;
       console.warn("[hermes-chat] conversation index request failed", error instanceof Error ? error.name : typeof error);
@@ -423,6 +448,7 @@ export const useHermesChat = create<HermesChatState>()((set, get) => ({
       activeRequestId: null,
       view: "index",
       conversations: [],
+      isConversationIndexComplete: false,
       indexStatus: "idle",
       indexError: null,
       loadStatus: "idle",

--- a/desktop/src/renderer/src/stores/tabs.ts
+++ b/desktop/src/renderer/src/stores/tabs.ts
@@ -32,12 +32,14 @@ export interface Tab {
 
 export type RecentViewKind = "conversation" | "terminal" | "project";
 export type RecentViewFilter = "all" | RecentViewKind;
+export type RecentConversationType = "hermes" | "coding-agent";
 
 export interface RecentView {
   kind: RecentViewKind;
   id: string;
   label: string;
   visitedAt: number;
+  conversationType?: RecentConversationType;
 }
 
 export interface TerminalSessionRequest {
@@ -98,16 +100,6 @@ function pruneHistory(
   return historyPatch(next, nextIndex);
 }
 
-function recentFromTab(tab: Tab): RecentView | null {
-  if (tab.kind === "project" && tab.projectSlug) {
-    return { kind: "project", id: tab.projectSlug, label: tab.title, visitedAt: Date.now() };
-  }
-  if (tab.kind === "terminal" && tab.sessionName) {
-    return { kind: "terminal", id: tab.sessionName, label: tab.title, visitedAt: Date.now() };
-  }
-  return null;
-}
-
 function recordRecent(recentViews: RecentView[], recent: RecentView | null): RecentView[] {
   if (!recent) return recentViews;
   return [
@@ -135,8 +127,13 @@ interface TabsState {
   goBack(): void;
   goForward(): void;
   ensureNavigationScope(scope: string): void;
+  recordRecentProject(id: string, label: string): void;
   recordRecentConversation(id: string, label: string): void;
+  recordRecentHermesConversation(id: string, label: string): void;
   recordRecentTerminal(id: string, label: string): void;
+  removeRecentView(kind: RecentViewKind, id: string): void;
+  reconcileRecentHermesConversations(ids: string[]): void;
+  reconcileRecentTerminals(ids: string[]): void;
   requestTerminalSession(sessionName: string): void;
   consumeTerminalSessionRequest(requestId: number): void;
   setRecentFilter(filter: RecentViewFilter): void;
@@ -166,7 +163,6 @@ export const useTabs = create<TabsState>()((set, get) => ({
       set((state) => ({
         activeTabId: existing.id,
         ...recordHistory(state.viewHistory, state.historyIndex, existing.id),
-        recentViews: recordRecent(state.recentViews, recentFromTab(existing)),
       }));
       return existing.id;
     }
@@ -192,7 +188,6 @@ export const useTabs = create<TabsState>()((set, get) => ({
         tabs,
         activeTabId: id,
         ...recordHistory(pruned.viewHistory, pruned.historyIndex, id),
-        recentViews: recordRecent(state.recentViews, recentFromTab(tab)),
       };
     });
     return id;
@@ -240,7 +235,6 @@ export const useTabs = create<TabsState>()((set, get) => ({
     return {
       activeTabId: id,
       ...recordHistory(state.viewHistory, state.historyIndex, id),
-      recentViews: recordRecent(state.recentViews, recentFromTab(tab)),
     };
   }),
 
@@ -280,12 +274,32 @@ export const useTabs = create<TabsState>()((set, get) => ({
     };
   }),
 
+  recordRecentProject: (id, label) => set((state) => ({
+    recentViews: recordRecent(state.recentViews, {
+      kind: "project",
+      id,
+      label,
+      visitedAt: Date.now(),
+    }),
+  })),
+
   recordRecentConversation: (id, label) => set((state) => ({
     recentViews: recordRecent(state.recentViews, {
       kind: "conversation",
       id,
       label,
       visitedAt: Date.now(),
+      conversationType: "coding-agent",
+    }),
+  })),
+
+  recordRecentHermesConversation: (id, label) => set((state) => ({
+    recentViews: recordRecent(state.recentViews, {
+      kind: "conversation",
+      id,
+      label,
+      visitedAt: Date.now(),
+      conversationType: "hermes",
     }),
   })),
 
@@ -297,6 +311,30 @@ export const useTabs = create<TabsState>()((set, get) => ({
       visitedAt: Date.now(),
     }),
   })),
+
+  removeRecentView: (kind, id) => set((state) => ({
+    recentViews: state.recentViews.filter((recent) => recent.kind !== kind || recent.id !== id),
+  })),
+
+  reconcileRecentHermesConversations: (ids) => set((state) => {
+    const authoritativeIds = new Set(ids);
+    return {
+      recentViews: state.recentViews.filter((recent) =>
+        recent.kind !== "conversation"
+        || recent.conversationType === "coding-agent"
+        || authoritativeIds.has(recent.id),
+      ),
+    };
+  }),
+
+  reconcileRecentTerminals: (ids) => set((state) => {
+    const authoritativeIds = new Set(ids);
+    return {
+      recentViews: state.recentViews.filter((recent) =>
+        recent.kind !== "terminal" || authoritativeIds.has(recent.id),
+      ),
+    };
+  }),
 
   requestTerminalSession: (sessionName) => set((state) => {
     const requestId = state.terminalSessionRequestSequence + 1;

--- a/tests/desktop/chat-tab-render.test.tsx
+++ b/tests/desktop/chat-tab-render.test.tsx
@@ -387,6 +387,7 @@ describe("ChatTab", () => {
     useHermesChat.setState({
       view: "index",
       indexStatus: "ready",
+      isConversationIndexComplete: true,
       conversations: [{
         id: "conversation-live",
         title: "Live chat",

--- a/tests/desktop/chat-tab-render.test.tsx
+++ b/tests/desktop/chat-tab-render.test.tsx
@@ -96,6 +96,8 @@ describe("ChatTab", () => {
     expect(container.querySelector(".h-full.items-center.justify-center")).toBeNull();
     expect(container.querySelector('[data-slot="message-scroller-content"]')?.className)
       .toContain("justify-start");
+    expect(container.querySelector('[data-slot="message-scroller-content"]')?.className)
+      .not.toContain("30vh");
   });
 
   it("renders the approved centered empty state and only working composer controls", () => {
@@ -106,7 +108,10 @@ describe("ChatTab", () => {
     expect(screen.getByRole("textbox", { name: "How can I help you today?" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Attach files" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Resources" })).toBeTruthy();
-    expect(screen.getByText("Hermes", { selector: "span" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Use Codex for a project chat" })).toBeTruthy();
+    expect(screen.getByRole("combobox", { name: "Chat harness" })).toHaveProperty("value", "hermes");
+    expect(screen.getByTestId("chat-empty-logo").style.height).toBe("208px");
+    expect(screen.getByTestId("chat-empty-content").className).toContain("justify-center");
     expect(screen.getByRole("button", { name: "Send" }).hasAttribute("disabled")).toBe(true);
     expect(screen.queryByText("Connect messaging")).toBeNull();
     expect(screen.queryByRole("button", { name: /voice|microphone/i })).toBeNull();
@@ -269,6 +274,45 @@ describe("ChatTab", () => {
     expect(screen.queryByRole("button", { name: "Remove screen.png" })).toBeNull();
   });
 
+  it("promotes a Hermes conversation only after the user sends a message", async () => {
+    const send = vi.fn();
+    useHermesChat.setState({
+      messages: [],
+      sessionId: "conversation-active",
+      status: "idle",
+      send,
+      abort: vi.fn(),
+    });
+    render(<ChatTab />);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "How can I help you today?" }), {
+      target: { value: "Continue the release check" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => expect(send).toHaveBeenCalledWith("Continue the release check"));
+    expect(useTabs.getState().recentViews[0]).toMatchObject({
+      kind: "conversation",
+      conversationType: "hermes",
+      id: "conversation-active",
+      label: "Continue the release check",
+    });
+  });
+
+  it("routes the Codex harness to a project-bound durable chat", async () => {
+    useHermesChat.setState({ messages: [], status: "idle" });
+    render(<ChatTab />);
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Chat harness" }), {
+      target: { value: "codex" },
+    });
+
+    await waitFor(() => expect(useTabs.getState().tabs).toContainEqual(expect.objectContaining({
+      kind: "project",
+      projectSlug: "matrix-os",
+    })));
+  });
+
   it("does not intercept a text-only drop in Chat", () => {
     useHermesChat.setState({ messages: [], status: "idle", send: vi.fn(), abort: vi.fn() });
     render(<ChatTab />);
@@ -334,6 +378,29 @@ describe("ChatTab", () => {
     expect(newest.textContent).not.toContain("Review the final launch checklist");
     expect(older.textContent).toContain("Earlier notes");
     expect(screen.queryByText("hello")).toBeNull();
+  });
+
+  it("reconciles stale Hermes Recents without removing coding-agent chats", async () => {
+    useTabs.getState().recordRecentHermesConversation("conversation-live", "Live chat");
+    useTabs.getState().recordRecentHermesConversation("conversation-deleted", "Deleted chat");
+    useTabs.getState().recordRecentConversation("thread-live", "Coding agent run");
+    useHermesChat.setState({
+      view: "index",
+      indexStatus: "ready",
+      conversations: [{
+        id: "conversation-live",
+        title: "Live chat",
+        preview: "Still here",
+        messageCount: 1,
+        createdAt: 1,
+        updatedAt: 2,
+      }],
+    });
+
+    render(<ChatTab />);
+
+    await waitFor(() => expect(useTabs.getState().recentViews.map((recent) => recent.id))
+      .toEqual(["thread-live", "conversation-live"]));
   });
 
   it("shows loading, empty, and safe recovery states for conversation discovery", () => {
@@ -410,10 +477,7 @@ describe("ChatTab", () => {
       sessionId: "conversation-created",
       messages: [],
     });
-    expect(useTabs.getState().recentViews[0]).toMatchObject({
-      kind: "conversation",
-      id: "conversation-created",
-    });
+    expect(useTabs.getState().recentViews).toEqual([]);
   });
 
   it("opens the selected canonical conversation without duplicating global navigation", async () => {
@@ -448,10 +512,6 @@ describe("ChatTab", () => {
     expect(await screen.findByText("persistent hello")).toBeTruthy();
     expect(screen.queryByRole("navigation", { name: "Chat breadcrumb" })).toBeNull();
     expect(useHermesChat.getState().sessionId).toBe("conversation-one");
-    expect(useTabs.getState().recentViews[0]).toMatchObject({
-      kind: "conversation",
-      id: "conversation-one",
-      label: "Persistent plan",
-    });
+    expect(useTabs.getState().recentViews).toEqual([]);
   });
 });

--- a/tests/desktop/coding-agent-thread-stream.test.ts
+++ b/tests/desktop/coding-agent-thread-stream.test.ts
@@ -35,6 +35,15 @@ class FakeThreadWebSocket implements DesktopCodingAgentThreadWebSocket {
   emitMessage(data: unknown): void {
     this.onmessage?.({ data });
   }
+
+  emitError(): void {
+    this.onerror?.();
+  }
+
+  emitClose(): void {
+    this.readyState = 3;
+    this.onclose?.();
+  }
 }
 
 function deferred<T>() {
@@ -189,6 +198,37 @@ describe("desktop coding-agent thread event streamer", () => {
         retryable: true,
       },
     }));
+
+    expect(emitted).toEqual([{
+      channel: "runtime:thread-stream-error",
+      payload: {
+        threadId: "thread_desktop_1",
+        error: {
+          code: "stream_unavailable",
+          safeMessage: "Thread stream unavailable",
+          retryable: true,
+        },
+      },
+    }]);
+  });
+
+  it("emits a safe stream error when an established websocket fails", async () => {
+    const emitted: unknown[] = [];
+    const sockets: FakeThreadWebSocket[] = [];
+    const streamer = createCodingAgentThreadEventStreamer({
+      auth: auth(),
+      emit: (channel, payload) => emitted.push({ channel, payload }),
+      fetchFn: vi.fn().mockResolvedValue(new Response(JSON.stringify({ token: "ws-token" }), { status: 200 })),
+      createWebSocket: (url) => {
+        const socket = new FakeThreadWebSocket(url);
+        sockets.push(socket);
+        return socket;
+      },
+    });
+
+    await streamer.subscribe({ threadId: "thread_desktop_1" });
+    sockets[0]?.emitError();
+    sockets[0]?.emitClose();
 
     expect(emitted).toEqual([{
       channel: "runtime:thread-stream-error",

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -7,7 +7,10 @@ import ProjectChatsView, {
   clearComposerLaunchContext,
   mergeComposerSeed,
 } from "../../desktop/src/renderer/src/features/project/ProjectChatsView";
-import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
+import {
+  clearCodingAgentThreadSelection,
+  useCodingAgentWorkspace,
+} from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
 import { useProjectView } from "../../desktop/src/renderer/src/stores/project-view";
 import { clearDraftChats } from "../../desktop/src/renderer/src/stores/draft-chat";
 import { useProjectWorkspaces } from "../../desktop/src/renderer/src/stores/project-workspaces";
@@ -761,8 +764,10 @@ describe("ProjectChatsView", () => {
   });
 
   afterEach(() => {
+    clearCodingAgentThreadSelection();
     cleanup();
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("renders provider, thread, and terminal summaries from trusted IPC", async () => {
@@ -1687,6 +1692,126 @@ describe("ProjectChatsView", () => {
     expect(state.threadSnapshot?.thread.status).toBe("running");
     expect(state.threadSnapshot?.thread.attention).toBe("none");
     expect(state.threadSnapshot?.events.items.map((event) => event.eventId)).toContain("evt_approval_desktop_stream");
+  });
+
+  it("polls the selected running thread until completion when the live stream is unavailable", async () => {
+    vi.useFakeTimers();
+    const completedSnapshot = {
+      ...threadSnapshotFixture(),
+      thread: {
+        ...threadSnapshotFixture().thread,
+        status: "completed" as const,
+        attention: "completed" as const,
+        updatedAt: "2026-07-06T00:08:00.000Z",
+      },
+      events: {
+        ...threadSnapshotFixture().events,
+        items: [
+          ...threadSnapshotFixture().events.items,
+          {
+            type: "thread.completed" as const,
+            eventId: "evt_desktop_completed_poll",
+            threadId: "thread_alpha",
+            occurredAt: "2026-07-06T00:08:00.000Z",
+            outcome: "completed" as const,
+          },
+        ],
+      },
+    };
+    let snapshotCalls = 0;
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-thread-snapshot") {
+        snapshotCalls += 1;
+        return Promise.resolve(snapshotCalls === 1 ? threadSnapshotFixture() : completedSnapshot);
+      }
+      if (channel === "runtime:subscribe-thread-events") {
+        return Promise.reject(new Error("stream unavailable"));
+      }
+      if (channel === "runtime:unsubscribe-thread-events") return Promise.resolve({ ok: true });
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    await useCodingAgentWorkspace.getState().loadThreadSnapshot("thread_alpha");
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(snapshotCalls).toBe(2);
+    expect(useCodingAgentWorkspace.getState().threadSnapshot?.thread.status).toBe("completed");
+
+    await vi.runOnlyPendingTimersAsync();
+    expect(snapshotCalls).toBe(2);
+  });
+
+  it("falls back to snapshot polling when an established thread stream reports an error", async () => {
+    vi.useFakeTimers();
+    const listeners: Record<string, (payload: unknown) => void> = {};
+    const completedSnapshot = {
+      ...threadSnapshotFixture(),
+      thread: {
+        ...threadSnapshotFixture().thread,
+        status: "completed" as const,
+        attention: "completed" as const,
+        updatedAt: "2026-07-06T00:08:00.000Z",
+      },
+    };
+    let snapshotCalls = 0;
+    window.operator.on = vi.fn((channel: string, callback: (payload: unknown) => void) => {
+      listeners[channel] = callback;
+      return () => {
+        delete listeners[channel];
+      };
+    });
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-thread-snapshot") {
+        snapshotCalls += 1;
+        return Promise.resolve(snapshotCalls === 1 ? threadSnapshotFixture() : completedSnapshot);
+      }
+      if (channel === "runtime:subscribe-thread-events") return Promise.resolve({ ok: true });
+      if (channel === "runtime:unsubscribe-thread-events") return Promise.resolve({ ok: true });
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    await useCodingAgentWorkspace.getState().loadThreadSnapshot("thread_alpha");
+    listeners["runtime:thread-stream-error"]?.({
+      threadId: "thread_alpha",
+      error: {
+        code: "stream_unavailable",
+        safeMessage: "Thread stream unavailable",
+        retryable: true,
+      },
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(snapshotCalls).toBe(2);
+    expect(useCodingAgentWorkspace.getState().threadSnapshot?.thread.status).toBe("completed");
+  });
+
+  it("keeps a snapshot safety poll while an established thread stream is silent", async () => {
+    vi.useFakeTimers();
+    const completedSnapshot = {
+      ...threadSnapshotFixture(),
+      thread: {
+        ...threadSnapshotFixture().thread,
+        status: "completed" as const,
+        attention: "completed" as const,
+        updatedAt: "2026-07-06T00:08:00.000Z",
+      },
+    };
+    let snapshotCalls = 0;
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-thread-snapshot") {
+        snapshotCalls += 1;
+        return Promise.resolve(snapshotCalls === 1 ? threadSnapshotFixture() : completedSnapshot);
+      }
+      if (channel === "runtime:subscribe-thread-events") return Promise.resolve({ ok: true });
+      if (channel === "runtime:unsubscribe-thread-events") return Promise.resolve({ ok: true });
+      return Promise.reject(new Error("unexpected channel"));
+    });
+
+    await useCodingAgentWorkspace.getState().loadThreadSnapshot("thread_alpha");
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(snapshotCalls).toBe(2);
+    expect(useCodingAgentWorkspace.getState().threadSnapshot?.thread.status).toBe("completed");
   });
 
   it("does not let older replayed stream events regress a newer thread snapshot", async () => {
@@ -3463,6 +3588,57 @@ describe("ProjectChatsView", () => {
     expect(useCodingAgentWorkspace.getState().activeThreadId).toBe("thread_desktop_1");
     expect(await screen.findByText("Thread details")).toBeTruthy();
     expect(useTabs.getState().tabs.some((tab) => tab.kind === "thread")).toBe(false);
+  });
+
+  it("attaches updates and safety polling immediately after creating a thread", async () => {
+    vi.useFakeTimers();
+    const runningSnapshot = {
+      thread: {
+        id: "thread_created_live",
+        providerId: "codex",
+        title: "Verify created thread updates",
+        status: "running" as const,
+        attention: "none" as const,
+        createdAt: "2026-07-06T00:00:00.000Z",
+        updatedAt: "2026-07-06T00:00:00.000Z",
+      },
+      events: {
+        items: [],
+        hasMore: false,
+        limit: 200,
+      },
+    };
+    const completedSnapshot = {
+      ...runningSnapshot,
+      thread: {
+        ...runningSnapshot.thread,
+        status: "completed" as const,
+        attention: "completed" as const,
+        updatedAt: "2026-07-06T00:00:09.000Z",
+      },
+    };
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:create-thread") return Promise.resolve(runningSnapshot);
+      if (channel === "runtime:subscribe-thread-events") return Promise.resolve({ ok: true });
+      if (channel === "runtime:get-thread-snapshot") return Promise.resolve(completedSnapshot);
+      if (channel === "runtime:unsubscribe-thread-events") return Promise.resolve({ ok: true });
+      return Promise.reject(new Error("unexpected channel"));
+    });
+    useCodingAgentWorkspace.setState({ summary: summaryFixture({ threadCreate: true }) });
+
+    await useCodingAgentWorkspace.getState().createThread({
+      providerId: "codex",
+      prompt: "Verify created thread updates",
+      mode: "default",
+      approvalPolicy: "on_request",
+      sandboxMode: "workspace_write",
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(window.operator.invoke).toHaveBeenCalledWith("runtime:subscribe-thread-events", {
+      threadId: "thread_created_live",
+    });
+    expect(useCodingAgentWorkspace.getState().threadSnapshot?.thread.status).toBe("completed");
   });
 
   it("keeps a desktop-created thread detail when the active summary window drops it", async () => {

--- a/tests/desktop/composer-busy-conflict.test.tsx
+++ b/tests/desktop/composer-busy-conflict.test.tsx
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentThreadEvent, AgentThreadSnapshot } from "@matrix-os/contracts";
 import { AgentConversationView } from "../../desktop/src/renderer/src/features/coding-agents/AgentConversationView";
 import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
+import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 
 function snapshot(events: AgentThreadEvent[], threadOverrides: Record<string, unknown> = {}): AgentThreadSnapshot {
   return {
@@ -80,6 +81,7 @@ describe("AgentConversationView composer busy conflict", () => {
       turnRetry: null,
       turnThreadId: null,
     });
+    useTabs.setState(useTabs.getInitialState(), true);
   });
 
   afterEach(() => {
@@ -98,6 +100,12 @@ describe("AgentConversationView composer busy conflict", () => {
       expect(invoke).toHaveBeenCalledWith("runtime:create-turn", expect.objectContaining({ threadId: "thread_alpha" })),
     );
     expect(screen.queryByLabelText("Queued follow-ups")).toBeNull();
+    expect(useTabs.getState().recentViews[0]).toMatchObject({
+      kind: "conversation",
+      conversationType: "coding-agent",
+      id: "thread_alpha",
+      label: "Fix settings route",
+    });
   });
 
   it("keeps the draft and surfaces the safe conflict when the runtime reports the thread busy", async () => {

--- a/tests/desktop/draft-chat-send.test.tsx
+++ b/tests/desktop/draft-chat-send.test.tsx
@@ -13,6 +13,7 @@ import { useProjectView } from "../../desktop/src/renderer/src/stores/project-vi
 import { useProjectWorkspaces } from "../../desktop/src/renderer/src/stores/project-workspaces";
 import { clearDraftChats, useDraftChat } from "../../desktop/src/renderer/src/stores/draft-chat";
 import { useProjectChatLauncher } from "../../desktop/src/renderer/src/lib/project-chat";
+import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 
 const NOW = "2026-07-12T12:00:00.000Z";
 const defaultResolveNewChatTarget = useProjectWorkspaces.getState().resolveNewChatTarget;
@@ -147,6 +148,7 @@ function resetStores() {
   useProjectView.setState({ entries: {}, runtimeScope: null });
   useProjectWorkspaces.setState({ entries: {}, resolveNewChatTarget: defaultResolveNewChatTarget });
   useProjectChatLauncher.setState({ composerRequest: null });
+  useTabs.setState(useTabs.getInitialState(), true);
   useInspectorLayout.setState({ entries: {}, runtimeScope: null });
   useProviderPreferences.setState({ defaultProviderId: null, hydrated: false });
   useCodingAgentWorkspace.setState({
@@ -215,6 +217,12 @@ describe("draft chat implicit thread creation", () => {
     // The created thread replaces the draft in place.
     await waitFor(() => {
       expect(useProjectView.getState().selectedThreadFor("matrix-os")).toBe("thread_new_draft");
+    });
+    expect(useTabs.getState().recentViews[0]).toMatchObject({
+      kind: "conversation",
+      conversationType: "coding-agent",
+      id: "thread_new_draft",
+      label: "Investigate the flaky desktop check",
     });
     expect(useDraftChat.getState().draftFor("matrix-os")).toBeNull();
     expect(await screen.findByRole("region", { name: /Conversation/ })).toBeTruthy();

--- a/tests/desktop/files-workspace.test.tsx
+++ b/tests/desktop/files-workspace.test.tsx
@@ -129,6 +129,31 @@ describe("Files workspace", () => {
     expect(within(panes).getByText("hero.png")).toBeTruthy();
   });
 
+  it("opens nested folders and file previews from the preview grid", async () => {
+    render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Open workspaces" }));
+    const preview = await screen.findByRole("region", { name: "File preview" });
+
+    fireEvent.click(await within(preview).findByRole("button", {
+      name: "Open matrix-os in preview",
+    }));
+    expect(await within(preview).findByRole("heading", { name: "matrix-os" })).toBeTruthy();
+
+    fireEvent.click(await within(preview).findByRole("button", {
+      name: "Open packages in preview",
+    }));
+    expect(await within(preview).findByRole("heading", { name: "packages" })).toBeTruthy();
+    expect(api.get).toHaveBeenCalledWith("/api/files/list?path=workspaces%2Fmatrix-os%2Fpackages");
+
+    fireEvent.click(within(preview).getByRole("button", { name: "Back in preview" }));
+    fireEvent.click(within(preview).getByRole("button", { name: "Back in preview" }));
+    fireEvent.click(await within(preview).findByRole("button", {
+      name: "Open app.ts in preview",
+    }));
+    expect(await within(preview).findByText(/A remote home you can inspect/)).toBeTruthy();
+  });
+
   it("shows the designed empty-folder preview state", async () => {
     render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
     fireEvent.click(await screen.findByRole("button", { name: "Open empty" }));

--- a/tests/desktop/hermes-conversation-index.test.tsx
+++ b/tests/desktop/hermes-conversation-index.test.tsx
@@ -95,6 +95,48 @@ describe("conversation search", () => {
 });
 
 describe("HermesConversationIndex", () => {
+  it("does not delete a valid Recent outside the bounded renderer index", async () => {
+    const gatewayConversations = Array.from({ length: 101 }, (_, index) => ({
+      id: `conversation-${index}`,
+      preview: `Conversation ${index}`,
+      messageCount: 1,
+      createdAt: index,
+      updatedAt: index,
+    }));
+    const client = api({ get: vi.fn(async () => gatewayConversations) });
+    useTabs.getState().recordRecentHermesConversation(
+      "conversation-100",
+      "Conversation 100",
+    );
+    useHermesChat.setState({ conversations: [], indexStatus: "idle" });
+
+    await act(async () => {
+      await useHermesChat.getState().refreshConversations(client);
+    });
+    render(<HermesConversationIndex api={client} />);
+
+    expect(useHermesChat.getState().conversations).toHaveLength(100);
+    await waitFor(() => expect(
+      useTabs.getState().recentViews.some((recent) => recent.id === "conversation-100"),
+    ).toBe(true));
+  });
+
+  it("reconciles deleted Recents when the complete Gateway index is available", async () => {
+    const gatewayConversations = conversations.map(({ title: _title, ...conversation }) => conversation);
+    const client = api({ get: vi.fn(async () => gatewayConversations) });
+    useTabs.getState().recordRecentHermesConversation("launch-plan", "Launch plan");
+    useTabs.getState().recordRecentHermesConversation("deleted-chat", "Deleted chat");
+    useHermesChat.setState({ conversations: [], indexStatus: "idle" });
+
+    await act(async () => {
+      await useHermesChat.getState().refreshConversations(client);
+    });
+    render(<HermesConversationIndex api={client} />);
+
+    await waitFor(() => expect(useTabs.getState().recentViews.map((recent) => recent.id))
+      .toEqual(["launch-plan"]));
+  });
+
   it("renders the approved header and focuses an ephemeral Search field", () => {
     render(<HermesConversationIndex api={api()} />);
 

--- a/tests/desktop/hermes-conversation-index.test.tsx
+++ b/tests/desktop/hermes-conversation-index.test.tsx
@@ -183,7 +183,7 @@ describe("HermesConversationIndex", () => {
     expect(dialog.style.transform).toBe("translate(-50%, -50%)");
   });
 
-  it("records the canonical Gateway conversation in global Recents only after opening succeeds", async () => {
+  it("does not promote a canonical Gateway conversation when it is only opened", async () => {
     const openConversation = vi.fn(async () => true);
     useHermesChat.setState({ openConversation });
     render(<HermesConversationIndex api={api()} />);
@@ -194,11 +194,7 @@ describe("HermesConversationIndex", () => {
       expect.anything(),
       "launch-plan",
     ));
-    await waitFor(() => expect(useTabs.getState().recentViews[0]).toMatchObject({
-      kind: "conversation",
-      id: "launch-plan",
-      label: "Launch plan",
-    }));
+    expect(useTabs.getState().recentViews).toEqual([]);
 
     openConversation.mockResolvedValue(false);
     fireEvent.click(screen.getByRole("button", { name: "Customer notes conversation" }));
@@ -236,6 +232,18 @@ describe("HermesConversationIndex", () => {
     pending.resolve({ ok: true });
     await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
     expect(screen.queryByRole("button", { name: "Launch plan conversation" })).toBeNull();
+  });
+
+  it("removes a deleted conversation from global Recents", async () => {
+    useTabs.getState().recordRecentHermesConversation("launch-plan", "Launch plan");
+    render(<HermesConversationIndex api={api()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete Launch plan" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete chat" }));
+
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+    expect(useTabs.getState().recentViews.some((recent) => recent.id === "launch-plan"))
+      .toBe(false);
   });
 
   it("disables deletion for a known running chat with recovery guidance", () => {

--- a/tests/desktop/project-chat.test.ts
+++ b/tests/desktop/project-chat.test.ts
@@ -105,7 +105,7 @@ describe("openProjectChat", () => {
     expect(loadThreadSnapshot).toHaveBeenCalledWith("thread_alpha");
   });
 
-  it("records an opened agent conversation in global Recents", async () => {
+  it("does not promote an agent conversation when it is merely opened", async () => {
     Object.defineProperty(window, "operator", {
       configurable: true,
       value: {
@@ -146,11 +146,9 @@ describe("openProjectChat", () => {
 
     await opened;
 
-    expect(useTabs.getState().recentViews[0]).toMatchObject({
-      kind: "conversation",
-      id: "thread_alpha",
-      label: "Fix settings route",
-    });
+    expect(useTabs.getState().recentViews).not.toContainEqual(
+      expect.objectContaining({ kind: "conversation", id: "thread_alpha" }),
+    );
   });
 
   it("does not record a Recent when the project workspace cannot load", async () => {
@@ -260,11 +258,9 @@ describe("openProjectChat", () => {
     });
     await Promise.all([loadingWorkspace, openingConversation]);
 
-    expect(useTabs.getState().recentViews[0]).toMatchObject({
-      kind: "conversation",
-      id: "thread_alpha",
-      label: "Fix settings route",
-    });
+    expect(useTabs.getState().recentViews).not.toContainEqual(
+      expect.objectContaining({ kind: "conversation", id: "thread_alpha" }),
+    );
   });
 
   it("waits for the authoritative replacement when an in-flight workspace load is superseded", async () => {
@@ -323,11 +319,9 @@ describe("openProjectChat", () => {
     await Promise.all([replacementLoad, openingConversation]);
 
     expect(settledBeforeReplacement).toBe(false);
-    expect(useTabs.getState().recentViews[0]).toMatchObject({
-      kind: "conversation",
-      id: "thread_alpha",
-      label: "Fix settings route",
-    });
+    expect(useTabs.getState().recentViews).not.toContainEqual(
+      expect.objectContaining({ kind: "conversation", id: "thread_alpha" }),
+    );
   });
 
   it("does not record a Recent when the project refreshes while the thread snapshot loads", async () => {

--- a/tests/desktop/sidebar-navigation-shell.test.tsx
+++ b/tests/desktop/sidebar-navigation-shell.test.tsx
@@ -61,7 +61,16 @@ describe("Desktop sidebar navigation shell", () => {
     useTabs.getState().ensureNavigationScope("runtime-a");
     useTabs.getState().openTab({ kind: "project", projectSlug: "matrix-os", title: "Matrix OS" });
     useTabs.getState().openTab({ kind: "terminal", sessionName: "dev", title: "dev" });
-    useTabs.getState().recordRecentConversation("thread-1", "Fix navigation");
+    useTabs.setState((state) => ({
+      recentViews: [{
+        kind: "conversation",
+        id: "thread-1",
+        label: "Fix navigation",
+        visitedAt: Date.now(),
+      }, ...state.recentViews],
+    }));
+    useTabs.getState().recordRecentTerminal("dev", "dev");
+    useTabs.getState().recordRecentProject("matrix-os", "Matrix OS");
     useUi.setState({ sidebarCollapsed: false, requestedSettingsSection: null });
   });
 
@@ -142,7 +151,7 @@ describe("Desktop sidebar navigation shell", () => {
   });
 
   it("opens a canonical Hermes recent through the Gateway-backed loader", () => {
-    useTabs.getState().recordRecentConversation("conversation-two", "Trip planning");
+    useTabs.getState().recordRecentHermesConversation("conversation-two", "Trip planning");
     renderSidebar();
 
     fireEvent.click(screen.getByRole("button", { name: "Open recent Trip planning" }));

--- a/tests/desktop/tabs-store.test.ts
+++ b/tests/desktop/tabs-store.test.ts
@@ -57,13 +57,9 @@ describe("tabs store", () => {
   it("keeps Recents bounded, serializable, filterable, and scoped to one runtime", () => {
     useTabs.getState().ensureNavigationScope("runtime-a");
     for (let index = 0; index < 20; index += 1) {
-      useTabs.getState().openTab({
-        kind: "project",
-        projectSlug: `project-${index}`,
-        title: `Project ${index}`,
-      });
+      useTabs.getState().recordRecentProject(`project-${index}`, `Project ${index}`);
     }
-    useTabs.getState().openTab({ kind: "terminal", sessionName: "dev", title: "dev" });
+    useTabs.getState().recordRecentTerminal("dev", "dev");
     useTabs.getState().recordRecentConversation("thread-1", "Fix navigation");
 
     const state = useTabs.getState();
@@ -81,6 +77,53 @@ describe("tabs store", () => {
       historyIndex: -1,
       recentFilter: "all",
     });
+  });
+
+  it("keeps navigation separate from meaningful Recent activity", () => {
+    useTabs.getState().ensureNavigationScope("runtime-a");
+    const terminal = useTabs.getState().openTab({
+      kind: "terminal",
+      sessionName: "vivid-otter",
+      title: "vivid-otter",
+    });
+    const project = useTabs.getState().openTab({
+      kind: "project",
+      projectSlug: "matrix-os",
+      title: "Matrix OS",
+    });
+
+    useTabs.getState().focusTab(terminal);
+    useTabs.getState().focusTab(project);
+
+    expect(useTabs.getState().recentViews).toEqual([]);
+
+    useTabs.getState().recordRecentTerminal("vivid-otter", "vivid-otter");
+    useTabs.getState().recordRecentProject("matrix-os", "Matrix OS");
+    expect(useTabs.getState().recentViews.map((recent) => recent.id)).toEqual([
+      "matrix-os",
+      "vivid-otter",
+    ]);
+  });
+
+  it("removes deleted resources and reconciles authoritative Hermes and terminal lists", () => {
+    useTabs.getState().recordRecentHermesConversation("hermes-live", "Live chat");
+    useTabs.getState().recordRecentHermesConversation("hermes-deleted", "Deleted chat");
+    useTabs.getState().recordRecentConversation("thread-live", "Coding agent run");
+    useTabs.getState().recordRecentTerminal("terminal-live", "terminal-live");
+    useTabs.getState().recordRecentTerminal("terminal-deleted", "terminal-deleted");
+
+    useTabs.getState().reconcileRecentHermesConversations(["hermes-live"]);
+    useTabs.getState().reconcileRecentTerminals(["terminal-live"]);
+
+    expect(useTabs.getState().recentViews.map((recent) => recent.id)).toEqual([
+      "terminal-live",
+      "thread-live",
+      "hermes-live",
+    ]);
+
+    useTabs.getState().removeRecentView("conversation", "hermes-live");
+    useTabs.getState().removeRecentView("terminal", "terminal-live");
+    expect(useTabs.getState().recentViews.map((recent) => recent.id)).toEqual(["thread-live"]);
   });
 
   it("seeds the safe Home root after a runtime transition changes navigation scope", () => {

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -7,6 +7,7 @@ import TerminalView from "@desktop/renderer/src/features/terminal/TerminalView";
 import { getThemeTerminalColors } from "@desktop/renderer/src/design/themes";
 import { useAppearance } from "@desktop/renderer/src/stores/appearance";
 import { useConnection } from "@desktop/renderer/src/stores/connection";
+import { useTabs } from "@desktop/renderer/src/stores/tabs";
 import {
   bracketTerminalPaths,
   terminalPasteFiles,
@@ -23,6 +24,7 @@ const { createdTerminals } = vi.hoisted(() => ({
     };
     options: { theme?: unknown };
     registeredProviders: unknown[];
+    dataCallback?: (data: string) => void;
     element: HTMLElement | null;
   }>,
 }));
@@ -65,7 +67,8 @@ vi.mock("@xterm/xterm", () => ({
     clear(): void {}
     focus(): void {}
     dispose(): void {}
-    onData(): { dispose: () => void } {
+    onData(callback: (data: string) => void): { dispose: () => void } {
+      this.dataCallback = callback;
       return { dispose: () => {} };
     }
     registerLinkProvider(provider: unknown): { dispose: () => void } {
@@ -119,6 +122,7 @@ describe("TerminalView session switching", () => {
       authGeneration: 1,
       api: null,
     });
+    useTabs.setState(useTabs.getInitialState(), true);
     vi.stubGlobal(
       "ResizeObserver",
       class FakeResizeObserver {
@@ -146,6 +150,27 @@ describe("TerminalView session switching", () => {
 
     expect(screen.queryByText("Session exited (code 7).")).toBeNull();
     expect(screen.getByText(/Connecting/)).toBeTruthy();
+  });
+
+  it("promotes a terminal in Recents only after user input", () => {
+    render(<TerminalView sessionName="alpha" />);
+    const terminal = createdTerminals.at(-1)!;
+    const recentUpdates = vi.fn();
+    const unsubscribe = useTabs.subscribe(recentUpdates);
+
+    expect(useTabs.getState().recentViews).toEqual([]);
+    act(() => terminal.dataCallback?.("pwd\r"));
+    act(() => terminal.dataCallback?.("ls\r"));
+
+    expect(attachmentWrite).toHaveBeenCalledWith("pwd\r");
+    expect(attachmentWrite).toHaveBeenCalledWith("ls\r");
+    expect(recentUpdates).toHaveBeenCalledTimes(1);
+    expect(useTabs.getState().recentViews[0]).toMatchObject({
+      kind: "terminal",
+      id: "alpha",
+      label: "alpha",
+    });
+    unsubscribe();
   });
 
   it("preserves the ended banner when re-activating an ended terminal", () => {

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -78,6 +78,7 @@ describe("TerminalsTab", () => {
       reorder: vi.fn().mockResolvedValue(true),
       patchUiState: vi.fn().mockResolvedValue(true),
     });
+    useTabs.setState(useTabs.getInitialState(), true);
     useTabs.setState({
       tabs: [],
       activeTabId: null,
@@ -147,7 +148,7 @@ describe("TerminalsTab", () => {
     expect(terminalMounts.get("matrix-main")).toBe(1);
   });
 
-  it("records and refreshes opened canonical session details in global Recents without remounting", () => {
+  it("does not promote canonical sessions that are only opened", () => {
     useTabs.setState(useTabs.getInitialState(), true);
     useTabs.getState().ensureNavigationScope("primary|operator|1");
     useShellSessions.setState({
@@ -165,10 +166,7 @@ describe("TerminalsTab", () => {
     fireEvent.click(screen.getByRole("button", { name: "Back to terminal sessions" }));
     fireEvent.click(screen.getByRole("button", { name: "Open matrix-one" }));
 
-    expect(useTabs.getState().recentViews).toEqual([
-      expect.objectContaining({ kind: "terminal", id: "matrix-one", label: "matrix-one" }),
-      expect.objectContaining({ kind: "terminal", id: "matrix-two", label: "matrix-two" }),
-    ]);
+    expect(useTabs.getState().recentViews).toEqual([]);
     expect(terminalMounts.get("matrix-one")).toBe(1);
     expect(terminalMounts.get("matrix-two")).toBe(1);
   });
@@ -526,6 +524,7 @@ describe("TerminalsTab", () => {
       sessions: [{ name: "matrix-main", status: "active", placement: "active" }],
       deleteSession,
     });
+    useTabs.getState().recordRecentTerminal("matrix-main", "matrix-main");
 
     renderTab();
 
@@ -540,6 +539,23 @@ describe("TerminalsTab", () => {
     fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
 
     await waitFor(() => expect(deleteSession).toHaveBeenCalledWith(useConnection.getState().api, "matrix-main"));
+    await waitFor(() => expect(useTabs.getState().recentViews).toEqual([]));
+  });
+
+  it("removes stale terminal Recents after an authoritative session load", async () => {
+    useTabs.getState().recordRecentTerminal("matrix-live", "matrix-live");
+    useTabs.getState().recordRecentTerminal("matrix-deleted", "matrix-deleted");
+    useShellSessions.setState({
+      sessions: [{ name: "matrix-live", status: "active", placement: "active" }],
+      loading: false,
+      error: null,
+      loadSequence: 1,
+    });
+
+    renderTab();
+
+    await waitFor(() => expect(useTabs.getState().recentViews.map((recent) => recent.id))
+      .toEqual(["matrix-live"]));
   });
 
   it("keeps a newer shell selection when delete finishes after the user changes selection", async () => {


### PR DESCRIPTION
## Summary

- align the Desktop Chat empty and active conversation states with the approved Figma layout
- make the visible Chat controls functional and route project-bound coding-agent conversations through Codex
- keep selected Codex threads live when a WebSocket becomes silent by falling back to one bounded snapshot poller
- restore nested folder navigation and nested file preview in Files
- make Recents interaction-driven instead of click-driven, and reconcile deleted Chat and Terminal entries against authoritative lists
- preserve valid Hermes Recents outside the renderer's bounded conversation display cache

## Manual Desktop validation

- navigated `apps/calculator/dist/index.html` through multiple nested levels and rendered its HTML preview
- verified that opening a Terminal session does not promote it, while actual terminal input does
- created and deleted a temporary Terminal session and confirmed that it disappeared from Recents immediately
- verified that opening a Chat does not promote it
- ran multiple real project-bound Codex tasks; the final task completed and updated in-place without a renderer refresh
- compared both the empty Chat state and the post-send state against the approved Figma frames

## Tests

- `flox activate -- pnpm exec vitest run tests/desktop`: 168 files passed, 1,718 tests passed
- focused Hermes/Recents regression suite: 3 files passed, 47 tests passed
- `flox activate -- pnpm --dir desktop typecheck`: passed
- `flox activate -- bun run typecheck`: passed
- `flox activate -- bun run check:patterns`: 0 violations
- `flox activate -- bun run build:desktop`: passed
- `git diff --check`: passed
- `flox activate -- bun run test`: 935 files / 10,789 tests passed; 18 files / 24 tests failed in untouched Gateway suites on macOS. The failures are local environment/baseline failures dominated by Unix-domain socket path `EINVAL` and process/time-budget timeouts. No failing suite is under `desktop/` or touches this diff. Linux CI remains the merge authority.

## Review follow-up

Greptile's bounded-cache finding was fixed in `1ed5c01de`: the renderer now records whether the raw Gateway conversation index is complete and fully validated. Deletion-style Recent reconciliation only runs for a complete index. A 101-conversation regression test verifies that a valid Recent outside the 100-item display cache is retained, while the complete-index case still removes deleted entries.

## Invariants

- **Source of truth:** Gateway conversation, terminal-session, and coding-agent thread lists/snapshots remain authoritative. Desktop Recents is only a reconciled projection. A bounded renderer conversation cache is not treated as deletion authority.
- **Lock / transaction scope:** no database writes or transaction boundaries were added. The renderer owns at most one generation-guarded poller for the currently selected coding-agent thread; the main process emits one safe stream-error signal per failed stream.
- **Acceptable orphan states:** stale Recents entries are removed after complete authoritative list refreshes or confirmed successful deletion. A truncated or partially invalid Hermes cache preserves unknown Recents until a complete refresh. A transient coding-agent stream failure may temporarily fall back to polling, but no remote resource is created or deleted outside the existing Gateway operations.
- **Auth source of truth:** existing authenticated Desktop IPC, Gateway auth, and WebSocket token flows remain unchanged. No provider credential is exposed to the renderer.
- **Deferred scope:** Hermes still requires a valid Claude/API configuration; this PR does not migrate Hermes to Codex. MAT-268 remains explicitly excluded: this PR does not include, modify, merge, or depend on its Files CRUD, multi-select, or drag-to-move stack.

## Scope note

This PR only restores nested navigation and preview behavior already present on `main`. MAT-268 is not included, modified, merged, or depended on.
