### PR TITLE
fix(desktop): contain inactive terminal routes

### DIFF
--- a/desktop/src/renderer/src/design/RetainedPane.tsx
+++ b/desktop/src/renderer/src/design/RetainedPane.tsx
@@ -1,0 +1,37 @@
+import type { CSSProperties, HTMLAttributes } from "react";
+
+interface RetainedPaneProps extends Omit<HTMLAttributes<HTMLElement>, "aria-hidden" | "inert"> {
+  active: boolean;
+  as?: "div" | "section";
+  background?: CSSProperties["background"];
+}
+
+/**
+ * Keeps stateful UI mounted while making inactive siblings unable to paint or
+ * participate in pointer, keyboard, or accessibility interaction.
+ */
+export default function RetainedPane({
+  active,
+  as: Element = "div",
+  background,
+  style,
+  ...props
+}: RetainedPaneProps) {
+  return (
+    <Element
+      {...props}
+      data-retained-pane
+      data-active={String(active)}
+      aria-hidden={!active}
+      inert={!active}
+      style={{
+        ...style,
+        display: active ? "flex" : "none",
+        visibility: active ? "visible" : "hidden",
+        pointerEvents: active ? "auto" : "none",
+        zIndex: active ? 1 : 0,
+        ...(background ? { background } : {}),
+      }}
+    />
+  );
+}

--- a/desktop/src/renderer/src/features/mission-control/TabContent.tsx
+++ b/desktop/src/renderer/src/features/mission-control/TabContent.tsx
@@ -1,6 +1,7 @@
 import { Sparkles } from "lucide-react";
 import { Component, type ErrorInfo, type ReactNode } from "react";
 import { Button, EmptyState } from "../../design/primitives";
+import RetainedPane from "../../design/RetainedPane";
 import { useTabs, type Tab } from "../../stores/tabs";
 import { useUi } from "../../stores/ui";
 import ProjectTab from "../project/ProjectTab";
@@ -111,22 +112,18 @@ export default function TabContent() {
         const isEmbed = tab.kind === "home" || tab.kind === "app";
         const paneActive = active && !(isEmbed && overlayOpen);
         return (
-          <div
+          <RetainedPane
             key={tab.id}
+            active={active}
             className="absolute inset-0 flex min-h-0 flex-col"
-            style={{
-              display: active ? "flex" : "none",
-              visibility: active ? "visible" : "hidden",
-              zIndex: active ? 1 : 0,
-            }}
-            aria-hidden={!active}
-            // `inert` keeps keyboard focus out of cached-but-hidden panes.
-            inert={!active}
+            background="var(--bg-app)"
+            data-tab-id={tab.id}
+            data-tab-kind={tab.kind}
           >
             <TabErrorBoundary tabTitle={tab.title} onClose={() => closeTab(tab.id)}>
               <TabPane tab={tab} active={paneActive} />
             </TabErrorBoundary>
-          </div>
+          </RetainedPane>
         );
       })}
     </div>

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -185,7 +185,14 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
   useEffect(() => {
     const terminal = termRef.current;
     const fit = fitRef.current;
-    if (!terminal || !active || endedRef.current) return;
+    if (!terminal) return;
+    if (!active) {
+      terminal.blur();
+      hoveredLinkRef.current = null;
+      closeLinkContextMenu();
+      return;
+    }
+    if (endedRef.current) return;
 
     const manager = getAttachManager();
     const attachment = manager.attach(sessionName, {
@@ -220,7 +227,7 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
       attachmentRef.current = null;
       if (manager.activeSessionName === sessionName) manager.detachActive();
     };
-  }, [sessionName, active]);
+  }, [sessionName, active, closeLinkContextMenu]);
 
   useEffect(() => {
     const host = hostRef.current;

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button, Dialog, EmptyState, IconButton, StatusDot } from "../../design/primitives";
+import RetainedPane from "../../design/RetainedPane";
 import { DESKTOP_Z_INDEX } from "../../design/layering";
 import { categoryMessage } from "../../../../shared/app-error";
 import {
@@ -348,15 +349,15 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
     finishDrag();
   };
 
-  const overviewVisible = selectedName === null;
+  const overviewVisible = active && selectedName === null;
 
   return (
     <div className="relative flex min-h-0 flex-1 overflow-hidden" style={{ background: "var(--bg-surface)" }}>
-      <section
+      <RetainedPane
+        as="section"
+        active={overviewVisible}
         className="absolute inset-0 flex min-h-0 flex-col"
-        style={{ visibility: overviewVisible ? "visible" : "hidden" }}
-        aria-hidden={!overviewVisible}
-        inert={!overviewVisible}
+        background="var(--bg-surface)"
       >
         <nav
           aria-label="Terminal breadcrumb"
@@ -473,18 +474,18 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
             )}
           </div>
         </div>
-      </section>
+      </RetainedPane>
 
       {openedSessionNames.map((sessionName) => {
         const shell = shells.find((candidate) => candidate.name === sessionName) ?? { name: sessionName, status: "active" as const };
-        const visible = selectedName === sessionName;
+        const visible = active && selectedName === sessionName;
         return (
-          <section
+          <RetainedPane
+            as="section"
             key={sessionName}
+            active={visible}
             className="absolute inset-0 flex min-h-0 flex-col"
-            style={{ visibility: visible ? "visible" : "hidden" }}
-            aria-hidden={!visible}
-            inert={!visible}
+            background="var(--bg-surface)"
           >
             <nav
               aria-label="Terminal breadcrumb"
@@ -522,7 +523,7 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
               </span>
             </header>
             <TerminalView sessionName={sessionName} active={active && liveSessionName === sessionName} />
-          </section>
+          </RetainedPane>
         );
       })}
 

--- a/tests/desktop/tab-content.test.tsx
+++ b/tests/desktop/tab-content.test.tsx
@@ -34,6 +34,18 @@ vi.mock("@desktop/renderer/src/features/terminal/TerminalView", () => ({
 vi.mock("@desktop/renderer/src/features/terminal/TerminalsTab", () => ({
   default: terminalsTabMock,
 }));
+vi.mock("@desktop/renderer/src/features/mission-control/HomeTab", () => ({
+  default: () => <button type="button">Home workspace</button>,
+}));
+vi.mock("@desktop/renderer/src/features/chat/ChatTab", () => ({
+  default: () => <button type="button">Chat workspace</button>,
+}));
+vi.mock("@desktop/renderer/src/features/files/FilesWorkspace", () => ({
+  default: () => <button type="button">Files workspace</button>,
+}));
+vi.mock("@desktop/renderer/src/features/plugins/PluginsHub", () => ({
+  default: () => <button type="button">Plugins workspace</button>,
+}));
 
 describe("TabContent", () => {
   beforeEach(() => {
@@ -64,9 +76,47 @@ describe("TabContent", () => {
 
     expect(activePane?.hasAttribute("inert")).toBe(false);
     expect(activePane?.style.display).toBe("flex");
+    expect(activePane?.style.visibility).toBe("visible");
+    expect(activePane?.style.pointerEvents).toBe("auto");
+    expect(activePane?.style.background).toBe("var(--bg-app)");
     expect(hiddenPane?.hasAttribute("inert")).toBe(true);
     expect(hiddenPane?.getAttribute("aria-hidden")).toBe("true");
     expect(hiddenPane?.style.display).toBe("none");
+    expect(hiddenPane?.style.visibility).toBe("hidden");
+    expect(hiddenPane?.style.pointerEvents).toBe("none");
+  });
+
+  it.each([
+    ["apps", { kind: "apps" as const, title: "Apps" }],
+    ["plugins", { kind: "plugins" as const, title: "Plugins" }],
+    ["chat", { kind: "chat" as const, title: "Chat" }],
+    ["files", { kind: "files" as const, title: "Files" }],
+    ["home", { kind: "home" as const, title: "Home" }],
+    ["project", { kind: "project" as const, projectSlug: "alpha", title: "Alpha" }],
+  ])("fully contains the retained Terminal workspace beneath the %s route", (_route, target) => {
+    const terminalId = useTabs.getState().openTab({ kind: "terminals", title: "Terminal" });
+    const targetId = useTabs.getState().openTab(target);
+    useTabs.getState().focusTab(targetId);
+
+    const { container } = render(<TabContent />);
+    const terminalPane = container.querySelector<HTMLElement>(`[data-tab-id="${terminalId}"]`);
+    const activePane = container.querySelector<HTMLElement>(`[data-tab-id="${targetId}"]`);
+
+    expect(terminalPane).toBeTruthy();
+    expect(terminalPane?.dataset.tabKind).toBe("terminals");
+    expect(terminalPane?.style.display).toBe("none");
+    expect(terminalPane?.style.visibility).toBe("hidden");
+    expect(terminalPane?.style.pointerEvents).toBe("none");
+    expect(terminalPane?.getAttribute("aria-hidden")).toBe("true");
+    expect(terminalPane?.hasAttribute("inert")).toBe(true);
+
+    expect(activePane).toBeTruthy();
+    expect(activePane?.style.display).toBe("flex");
+    expect(activePane?.style.visibility).toBe("visible");
+    expect(activePane?.style.pointerEvents).toBe("auto");
+    expect(activePane?.style.background).toBe("var(--bg-app)");
+    expect(activePane?.getAttribute("aria-hidden")).toBe("false");
+    expect(activePane?.hasAttribute("inert")).toBe(false);
   });
 
   it("forwards task project slugs into the task workspace", () => {

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -26,6 +26,8 @@ const { createdTerminals } = vi.hoisted(() => ({
     registeredProviders: unknown[];
     dataCallback?: (data: string) => void;
     element: HTMLElement | null;
+    focus: ReturnType<typeof vi.fn>;
+    blur: ReturnType<typeof vi.fn>;
   }>,
 }));
 
@@ -65,7 +67,8 @@ vi.mock("@xterm/xterm", () => ({
     }
     write(): void {}
     clear(): void {}
-    focus(): void {}
+    focus = vi.fn();
+    blur = vi.fn();
     dispose(): void {}
     onData(callback: (data: string) => void): { dispose: () => void } {
       this.dataCallback = callback;
@@ -187,6 +190,23 @@ describe("TerminalView session switching", () => {
     expect(screen.getByText("Session exited (code 7).")).toBeTruthy();
     expect(screen.queryByText(/Connecting/)).toBeNull();
     expect(attachMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases keyboard focus when a retained terminal becomes inactive", () => {
+    const { rerender } = render(<TerminalView sessionName="alpha" active />);
+    const terminal = createdTerminals.at(-1)!;
+
+    expect(terminal.focus).toHaveBeenCalledOnce();
+    expect(terminal.blur).not.toHaveBeenCalled();
+
+    rerender(<TerminalView sessionName="alpha" active={false} />);
+
+    expect(terminal.blur).toHaveBeenCalledOnce();
+
+    rerender(<TerminalView sessionName="alpha" active />);
+
+    expect(terminal.focus).toHaveBeenCalledTimes(2);
+    expect(terminal.blur).toHaveBeenCalledOnce();
   });
 
   it("announces reconnecting, disconnected, and ended lifecycle states", () => {

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -28,10 +28,10 @@ vi.mock("../../desktop/src/renderer/src/features/terminal/TerminalView", () => (
   },
 }));
 
-function renderTab() {
+function renderTab(active = true) {
   return render(
     <Tooltip.Provider>
-      <TerminalsTab />
+      <TerminalsTab active={active} />
     </Tooltip.Provider>,
   );
 }
@@ -145,6 +145,52 @@ describe("TerminalsTab", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open matrix-main" }));
 
     expect(screen.getByTestId("terminal-view-matrix-main").getAttribute("data-active")).toBe("true");
+    expect(terminalMounts.get("matrix-main")).toBe(1);
+  });
+
+  it("fully contains cached session chrome and terminal output while the Terminal route is inactive", () => {
+    useShellSessions.setState({
+      sessions: [{
+        name: "matrix-main",
+        status: "active",
+        placement: "active",
+        createdAt: "2026-08-12T09:30:00.000Z",
+      }],
+    });
+
+    const { rerender } = renderTab();
+    fireEvent.click(screen.getByRole("button", { name: "Open matrix-main" }));
+    const terminal = screen.getByTestId("terminal-view-matrix-main");
+    const sessionPane = terminal.closest("section");
+
+    expect(sessionPane?.style.display).toBe("flex");
+    expect(sessionPane?.style.visibility).toBe("visible");
+    expect(sessionPane?.style.pointerEvents).toBe("auto");
+    expect(terminalMounts.get("matrix-main")).toBe(1);
+
+    rerender(
+      <Tooltip.Provider>
+        <TerminalsTab active={false} />
+      </Tooltip.Provider>,
+    );
+
+    expect(sessionPane?.style.display).toBe("none");
+    expect(sessionPane?.style.visibility).toBe("hidden");
+    expect(sessionPane?.style.pointerEvents).toBe("none");
+    expect(sessionPane?.getAttribute("aria-hidden")).toBe("true");
+    expect(sessionPane?.hasAttribute("inert")).toBe(true);
+    expect(terminal.getAttribute("data-active")).toBe("false");
+    expect(terminalMounts.get("matrix-main")).toBe(1);
+
+    rerender(
+      <Tooltip.Provider>
+        <TerminalsTab active />
+      </Tooltip.Provider>,
+    );
+
+    expect(sessionPane?.style.display).toBe("flex");
+    expect(sessionPane?.style.visibility).toBe("visible");
+    expect(terminal.getAttribute("data-active")).toBe("true");
     expect(terminalMounts.get("matrix-main")).toBe(1);
   });
 

--- a/tests/e2e/desktop/terminal-containment.e2e.test.ts
+++ b/tests/e2e/desktop/terminal-containment.e2e.test.ts
@@ -1,0 +1,119 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { _electron, type ElectronApplication, type Page } from "playwright";
+import { startStubGateway, type StubGateway } from "./fixtures/stub-gateway";
+
+const DESKTOP_MAIN = resolve(__dirname, "../../../desktop/out/main/index.js");
+const desktopRequire = createRequire(resolve(__dirname, "../../../desktop/package.json"));
+const ELECTRON_EXECUTABLE = desktopRequire("electron") as string;
+const SCREENSHOT_DIR = resolve(__dirname, "../../../desktop/screenshots/mat-328");
+const suite = existsSync(DESKTOP_MAIN) ? describe : describe.skip;
+
+suite("MAT-328 retained Terminal route containment", () => {
+  let gateway: StubGateway;
+  let app: ElectronApplication;
+  let page: Page;
+  let userDataDir: string;
+
+  beforeAll(async () => {
+    mkdirSync(SCREENSHOT_DIR, { recursive: true });
+    gateway = await startStubGateway();
+    userDataDir = mkdtempSync(join(tmpdir(), "mat-328-e2e-"));
+    app = await _electron.launch({
+      executablePath: ELECTRON_EXECUTABLE,
+      args: [DESKTOP_MAIN],
+      env: {
+        ...process.env,
+        OPERATOR_GATEWAY_URL: gateway.url,
+        OPERATOR_USER_DATA_DIR: userDataDir,
+      },
+    });
+    page = await app.firstWindow();
+  }, 60_000);
+
+  afterAll(async () => {
+    try {
+      await app?.close();
+    } catch (err: unknown) {
+      console.warn("[mat-328-e2e] app close failed:", err instanceof Error ? err.message : String(err));
+    }
+    await gateway?.close();
+    if (userDataDir) {
+      try {
+        rmSync(userDataDir, { recursive: true, force: true });
+      } catch (err: unknown) {
+        console.warn("[mat-328-e2e] user-data cleanup failed:", err instanceof Error ? err.message : String(err));
+      }
+    }
+  });
+
+  it("keeps a live Terminal mounted without painting or receiving interaction beneath peer routes", async () => {
+    await page.getByRole("button", { name: /continue in browser/i }).click();
+    await page.locator("aside button", { hasText: "Terminal" }).first().waitFor({ timeout: 15_000 });
+    await page.locator("aside button", { hasText: "Terminal" }).first().click();
+    await page.getByRole("button", { name: "Open matrix-task-1" }).click();
+
+    const terminalPane = page.locator('[data-tab-kind="terminals"]');
+    const terminalViewport = terminalPane.locator("[data-terminal-viewport]");
+    await expect.poll(() => terminalViewport.textContent(), { timeout: 10_000 }).toContain("stub-shell$");
+    await terminalViewport.click();
+    await page.keyboard.type("mat328-retained");
+    await page.keyboard.press("Enter");
+    await expect.poll(() => terminalViewport.textContent(), { timeout: 10_000 }).toContain("mat328-retained");
+    await expect.poll(() => terminalViewport.textContent(), { timeout: 10_000 }).toContain("ran!");
+    expect(gateway.state.terminalInputs.join("")).toContain("mat328-retained");
+
+    const routes = [
+      { label: "Apps", kind: "apps", screenshot: "01-apps-contained.png" },
+      { label: "Plugins", kind: "plugins", screenshot: "02-plugins-contained.png" },
+      { label: "Chat", kind: "chat", screenshot: "03-chat-contained.png" },
+    ];
+
+    for (const route of routes) {
+      await page.locator("aside button", { hasText: route.label }).first().click();
+      const routePane = page.locator(`[data-tab-kind="${route.kind}"][data-active="true"]`);
+      await routePane.waitFor({ state: "visible", timeout: 10_000 });
+
+      const retainedState = await terminalPane.evaluate((pane) => {
+        const style = getComputedStyle(pane);
+        const artifactSelector = [
+          'nav[aria-label="Terminal breadcrumb"]',
+          "header",
+          "[data-terminal-viewport]",
+          ".xterm-cursor-layer",
+        ].join(",");
+        return {
+          display: style.display,
+          visibility: style.visibility,
+          pointerEvents: style.pointerEvents,
+          ariaHidden: pane.getAttribute("aria-hidden"),
+          inert: pane.hasAttribute("inert"),
+          ownsFocus: pane.contains(document.activeElement),
+          paintedArtifacts: Array.from(pane.querySelectorAll(artifactSelector))
+            .filter((element) => element.getClientRects().length > 0).length,
+        };
+      });
+      const routeBackground = await routePane.evaluate((pane) => getComputedStyle(pane).backgroundColor);
+
+      expect(retainedState).toEqual({
+        display: "none",
+        visibility: "hidden",
+        pointerEvents: "none",
+        ariaHidden: "true",
+        inert: true,
+        ownsFocus: false,
+        paintedArtifacts: 0,
+      });
+      expect(routeBackground).not.toBe("transparent");
+      expect(routeBackground).not.toBe("rgba(0, 0, 0, 0)");
+      await page.screenshot({ path: join(SCREENSHOT_DIR, route.screenshot) });
+
+      await page.locator("aside button", { hasText: "Terminal" }).first().click();
+      await expect.poll(() => terminalPane.getAttribute("data-active")).toBe("true");
+      await expect.poll(() => terminalViewport.textContent(), { timeout: 10_000 }).toContain("mat328-retained");
+    }
+  }, 40_000);
+});


### PR DESCRIPTION
## Summary

- fix MAT-328 by applying one retained-pane containment contract to Desktop route siblings and Terminal's nested session cache
- keep inactive live terminals mounted for buffer/state preservation while disabling paint, pointer input, keyboard focus, and accessibility traversal
- give active Desktop route panes an opaque app background and explicitly blur xterm on deactivation
- add unit route-matrix coverage plus an isolated built-Electron regression for Terminal → Apps, Plugins, and Chat

## Relationship to MAT-323

MAT-323 established mount-preserving inactive-pane behavior at the outer Desktop tab boundary. This follow-up hardens that contract, reuses it for the nested Terminal cache introduced around the same area, and verifies the recorded cross-route bleed-through does not recur.

Linear: https://linear.app/matrix-os/issue/MAT-328/regression-prevent-inactive-terminal-bleed-through-across-desktop

## Tests

- `pnpm exec vitest run tests/desktop/tab-content.test.tsx tests/desktop/terminals-tab.test.tsx tests/desktop/terminal-view.test.tsx`
- `pnpm exec vitest run tests/desktop` (168 files, 1,726 tests)
- `bun run typecheck`
- `bun run build:desktop`
- `bun run check:patterns` (0 violations)
- `bun run test:e2e -- tests/e2e/desktop/terminal-containment.e2e.test.ts`

## Invariants

- **Source of truth:** `activeTabId` owns outer route visibility; `TerminalsTab.active` plus `selectedName` owns nested Terminal visibility.
- **State retention:** cached Terminal React/xterm instances remain mounted and preserve their buffers across route changes; inactive instances release the live attachment as before.
- **Interaction containment:** inactive retained panes use `display: none`, `visibility: hidden`, `pointer-events: none`, `aria-hidden`, and `inert`; xterm is explicitly blurred.
- **Lock/transaction scope:** not applicable; this is renderer-only state and presentation logic.
- **Acceptable orphan states:** none introduced. Closing a tab still unmounts/disposes its resource; switching tabs only deactivates it.
- **Auth source of truth:** unchanged; Desktop connection/runtime authentication remains authoritative.
- **Deferred scope:** none.

## Review monitoring

- Greptile: 5/5 with no actionable findings; approved commit `01939048a0c8e1ef82098624a76b4d32c5816843`
- CI: passed Type Check, Pattern Scan, React Doctor, Shell Production Build, Sync Client Package, four unit-test shards, E2E Tests, and the aggregate CI Results gate
