### PR TITLE
fix(desktop): fit terminal viewport to session detail

### DIFF
--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -34,6 +34,17 @@ import {
 const GAP_MARKER = "\r\n\x1b[2m── output gap ──\x1b[0m\r\n";
 const RECENT_ACTIVITY_THROTTLE_MS = 30_000;
 
+function applyTerminalSurfaceTheme(element: HTMLElement | undefined, background: string): void {
+  if (!element) return;
+  element.style.width = "100%";
+  element.style.height = "100%";
+  element.style.backgroundColor = background;
+  for (const selector of [".xterm-viewport", ".xterm-scrollable-element"]) {
+    const surface = element.querySelector<HTMLElement>(selector);
+    if (surface) surface.style.backgroundColor = background;
+  }
+}
+
 interface TerminalViewProps {
   sessionName: string;
   // When false, the xterm stays mounted (buffer preserved) but the live socket
@@ -44,6 +55,12 @@ interface TerminalViewProps {
 
 export default function TerminalView({ sessionName, active = true, onRecreate }: TerminalViewProps) {
   const api = useConnection((state) => state.api);
+  const appearanceMode = useAppearance((state) => state.mode);
+  const appearanceThemeId = useAppearance((state) => state.themeId);
+  const terminalBackground = getThemeTerminalColors(
+    appearanceThemeId,
+    resolveThemeMode(appearanceMode),
+  ).background;
   const hostRef = useRef<HTMLDivElement>(null);
   const [stateSessionName, setStateSessionName] = useState(sessionName);
   const termRef = useRef<Terminal | null>(null);
@@ -97,6 +114,7 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
     terminal.loadAddon(fit);
     terminal.loadAddon(serialize);
     terminal.open(host);
+    applyTerminalSurfaceTheme(terminal.element, theme.background);
     const linkProviderDisposable = terminal.registerLinkProvider(
       new DesktopWebLinkProvider(terminal, (link) => {
         hoveredLinkRef.current = link;
@@ -143,7 +161,9 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
     // writes (hydration) must not reassign the palette.
     const unsubscribeAppearance = useAppearance.subscribe((state, previous) => {
       if (state.themeId === previous.themeId && state.mode === previous.mode) return;
-      terminal.options.theme = getThemeTerminalColors(state.themeId, resolveThemeMode(state.mode));
+      const nextTheme = getThemeTerminalColors(state.themeId, resolveThemeMode(state.mode));
+      terminal.options.theme = nextTheme;
+      applyTerminalSurfaceTheme(terminal.element, nextTheme.background);
     });
 
     let rafId: number | null = null;
@@ -317,8 +337,16 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
   })();
 
   return (
-    <div className="relative flex min-h-0 flex-1 flex-col" style={{ background: "#0d1017" }}>
-      <div ref={hostRef} className="min-h-0 flex-1 px-2 pt-1.5" data-terminal-viewport data-selectable />
+    <div
+      className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+      style={{ backgroundColor: terminalBackground }}
+    >
+      <div
+        ref={hostRef}
+        className="h-full min-h-0 w-full min-w-0 flex-1 overflow-hidden"
+        data-terminal-viewport
+        data-selectable
+      />
       {pasteError ? (
         <div className="pointer-events-none absolute inset-x-0 bottom-3 flex justify-center px-3" aria-live="polite">
           <span className="rounded-md px-3 py-1.5 text-xs" style={{ background: "var(--danger-muted)", color: "var(--danger)" }}>

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -15,7 +15,9 @@ import {
 
 const attachMock = vi.fn();
 const attachmentWrite = vi.fn();
-const { createdTerminals } = vi.hoisted(() => ({
+const attachmentResize = vi.fn();
+const { createdFitAddons, createdTerminals, resizeObserverCallbacks } = vi.hoisted(() => ({
+  createdFitAddons: [] as Array<{ fitCalls: number }>,
   createdTerminals: [] as Array<{
     initialOptions: {
       linkHandler?: {
@@ -26,7 +28,9 @@ const { createdTerminals } = vi.hoisted(() => ({
     registeredProviders: unknown[];
     dataCallback?: (data: string) => void;
     element: HTMLElement | null;
+    focusCalls: number;
   }>,
+  resizeObserverCallbacks: [] as ResizeObserverCallback[],
 }));
 
 vi.mock("@xterm/xterm", () => ({
@@ -53,6 +57,7 @@ vi.mock("@xterm/xterm", () => ({
       };
     };
     registeredProviders: unknown[] = [];
+    focusCalls = 0;
 
     constructor(options: FakeTerminal["initialOptions"]) {
       this.initialOptions = options;
@@ -61,11 +66,22 @@ vi.mock("@xterm/xterm", () => ({
 
     loadAddon(): void {}
     open(host: HTMLElement): void {
-      this.element = host;
+      const root = document.createElement("div");
+      root.className = "xterm";
+      const viewport = document.createElement("div");
+      viewport.className = "xterm-viewport";
+      const scrollable = document.createElement("div");
+      scrollable.className = "xterm-scrollable-element";
+      viewport.append(scrollable);
+      root.append(viewport);
+      host.append(root);
+      this.element = root;
     }
     write(): void {}
     clear(): void {}
-    focus(): void {}
+    focus(): void {
+      this.focusCalls += 1;
+    }
     dispose(): void {}
     onData(callback: (data: string) => void): { dispose: () => void } {
       this.dataCallback = callback;
@@ -80,7 +96,15 @@ vi.mock("@xterm/xterm", () => ({
 
 vi.mock("@xterm/addon-fit", () => ({
   FitAddon: class FakeFitAddon {
-    fit(): void {}
+    fitCalls = 0;
+
+    constructor() {
+      createdFitAddons.push(this);
+    }
+
+    fit(): void {
+      this.fitCalls += 1;
+    }
   },
 }));
 
@@ -108,12 +132,17 @@ vi.mock("@desktop/renderer/src/features/terminal/terminal-runtime", () => ({
 
 describe("TerminalView session switching", () => {
   beforeEach(() => {
+    createdFitAddons.length = 0;
+    createdTerminals.length = 0;
+    resizeObserverCallbacks.length = 0;
     attachMock.mockReset();
     attachMock.mockImplementation((_sessionName: string, _events: ShellSocketEvents) => ({
-      resize: vi.fn(),
+      resize: attachmentResize,
       write: attachmentWrite,
     }));
+    attachmentResize.mockReset();
     attachmentWrite.mockReset();
+    useAppearance.setState({ mode: "dark", themeId: "operator", hydrated: true });
     useConnection.setState({
       status: "signed-in",
       handle: "operator",
@@ -126,6 +155,9 @@ describe("TerminalView session switching", () => {
     vi.stubGlobal(
       "ResizeObserver",
       class FakeResizeObserver {
+        constructor(callback: ResizeObserverCallback) {
+          resizeObserverCallbacks.push(callback);
+        }
         observe(): void {}
         disconnect(): void {}
       },
@@ -135,6 +167,64 @@ describe("TerminalView session switching", () => {
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
+  });
+
+  it("fills the terminal content area without an inset or mismatched xterm surface", () => {
+    const { container } = render(<TerminalView sessionName="alpha" />);
+    const host = container.querySelector<HTMLElement>("[data-terminal-viewport]")!;
+    const frame = host.parentElement!;
+    const root = host.querySelector<HTMLElement>(".xterm")!;
+    const viewport = host.querySelector<HTMLElement>(".xterm-viewport")!;
+    const scrollable = host.querySelector<HTMLElement>(".xterm-scrollable-element")!;
+    const background = getThemeTerminalColors("operator", "dark").background;
+    const colorProbe = document.createElement("div");
+    colorProbe.style.backgroundColor = background;
+
+    expect(host.className).not.toMatch(/\b(?:px-2|pt-1\.5)\b/);
+    expect(host.className).toContain("overflow-hidden");
+    expect(frame.className).toContain("overflow-hidden");
+    expect(frame.style.backgroundColor).toBe(colorProbe.style.backgroundColor);
+    expect(root.style.width).toBe("100%");
+    expect(root.style.height).toBe("100%");
+    expect(root.style.backgroundColor).toBe(colorProbe.style.backgroundColor);
+    expect(viewport.style.backgroundColor).toBe(colorProbe.style.backgroundColor);
+    expect(scrollable.style.backgroundColor).toBe(colorProbe.style.backgroundColor);
+  });
+
+  it("refits the existing viewport and forwards its dimensions after a host resize", () => {
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    render(<TerminalView sessionName="alpha" />);
+    const fit = createdFitAddons.at(-1)!;
+    const fitCallsBeforeResize = fit.fitCalls;
+    attachmentResize.mockClear();
+
+    act(() => {
+      resizeObserverCallbacks.at(-1)?.([], {} as ResizeObserver);
+    });
+
+    expect(fit.fitCalls).toBe(fitCallsBeforeResize + 1);
+    expect(attachmentResize).toHaveBeenCalledOnce();
+    expect(attachmentResize).toHaveBeenCalledWith(80, 24);
+  });
+
+  it("keeps xterm mounted and refits it when the terminal becomes active again", () => {
+    const { rerender } = render(<TerminalView sessionName="alpha" active />);
+    const terminal = createdTerminals.at(-1)!;
+    const fit = createdFitAddons.at(-1)!;
+    const fitCallsBeforeNavigation = fit.fitCalls;
+
+    rerender(<TerminalView sessionName="alpha" active={false} />);
+    rerender(<TerminalView sessionName="alpha" active />);
+
+    expect(createdTerminals).toHaveLength(1);
+    expect(fit.fitCalls).toBe(fitCallsBeforeNavigation + 1);
+    expect(terminal.focusCalls).toBe(2);
+    expect(attachMock).toHaveBeenCalledTimes(2);
+    expect(attachmentResize).toHaveBeenCalledTimes(2);
   });
 
   it("clears the ended banner before the next session emits state", () => {
@@ -218,9 +308,13 @@ describe("TerminalView session switching", () => {
     act(() => {
       useAppearance.setState({ themeId: "dracula" });
     });
-    expect(terminal.options.theme).toMatchObject({
-      background: getThemeTerminalColors("dracula", "dark").background,
-    });
+    const background = getThemeTerminalColors("dracula", "dark").background;
+    const colorProbe = document.createElement("div");
+    colorProbe.style.backgroundColor = background;
+    expect(terminal.options.theme).toMatchObject({ background });
+    expect(terminal.element?.style.backgroundColor).toBe(colorProbe.style.backgroundColor);
+    expect(terminal.element?.querySelector<HTMLElement>(".xterm-viewport")?.style.backgroundColor)
+      .toBe(colorProbe.style.backgroundColor);
   });
 
   it("overrides xterm OSC activation and registers plain-text URL detection", () => {

--- a/tests/e2e/desktop/terminal-sessions.e2e.test.ts
+++ b/tests/e2e/desktop/terminal-sessions.e2e.test.ts
@@ -3,7 +3,7 @@ import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { _electron, type ElectronApplication, type Page } from "playwright";
+import { _electron, type ElectronApplication, type Locator, type Page } from "playwright";
 import { startStubGateway, type StubGateway } from "./fixtures/stub-gateway";
 
 const REPOSITORY_ROOT = resolve(__dirname, "../../..");
@@ -13,6 +13,75 @@ const desktopRequire = createRequire(join(DESKTOP_ROOT, "package.json"));
 const ELECTRON_EXECUTABLE = desktopRequire("electron") as string;
 const SCREENSHOT_DIR = join(REPOSITORY_ROOT, "docs/review-assets");
 const DEBUG_PORT = 9232;
+
+interface TerminalViewportGeometry {
+  frameBackground: string;
+  headerBottom: number;
+  hostBottom: number;
+  hostHeight: number;
+  hostLeft: number;
+  hostPaddingLeft: string;
+  hostPaddingTop: string;
+  hostTop: number;
+  hostWidth: number;
+  rootBackground: string;
+  rootBottom: number;
+  rootHeight: number;
+  rootLeft: number;
+  rootTop: number;
+  rootWidth: number;
+  viewportBackground: string;
+}
+
+async function readTerminalViewportGeometry(viewport: Locator): Promise<TerminalViewportGeometry> {
+  await viewport.locator(".xterm").waitFor();
+  return viewport.evaluate((host) => {
+    const frame = host.parentElement;
+    const header = frame?.previousElementSibling;
+    const root = host.querySelector<HTMLElement>(".xterm");
+    const xtermViewport = host.querySelector<HTMLElement>(".xterm-viewport");
+    if (!(frame instanceof HTMLElement) || !(header instanceof HTMLElement) || !root || !xtermViewport) {
+      throw new Error("terminal viewport geometry is incomplete");
+    }
+    const headerRect = header.getBoundingClientRect();
+    const hostRect = host.getBoundingClientRect();
+    const rootRect = root.getBoundingClientRect();
+    const hostStyle = getComputedStyle(host);
+    return {
+      frameBackground: getComputedStyle(frame).backgroundColor,
+      headerBottom: headerRect.bottom,
+      hostBottom: hostRect.bottom,
+      hostHeight: hostRect.height,
+      hostLeft: hostRect.left,
+      hostPaddingLeft: hostStyle.paddingLeft,
+      hostPaddingTop: hostStyle.paddingTop,
+      hostTop: hostRect.top,
+      hostWidth: hostRect.width,
+      rootBackground: getComputedStyle(root).backgroundColor,
+      rootBottom: rootRect.bottom,
+      rootHeight: rootRect.height,
+      rootLeft: rootRect.left,
+      rootTop: rootRect.top,
+      rootWidth: rootRect.width,
+      viewportBackground: getComputedStyle(xtermViewport).backgroundColor,
+    };
+  });
+}
+
+async function expectTerminalViewportToFill(viewport: Locator): Promise<TerminalViewportGeometry> {
+  const geometry = await readTerminalViewportGeometry(viewport);
+  expect(Math.abs(geometry.hostTop - geometry.headerBottom)).toBeLessThanOrEqual(1);
+  expect(Math.abs(geometry.rootTop - geometry.hostTop)).toBeLessThanOrEqual(1);
+  expect(Math.abs(geometry.rootLeft - geometry.hostLeft)).toBeLessThanOrEqual(1);
+  expect(Math.abs(geometry.rootBottom - geometry.hostBottom)).toBeLessThanOrEqual(1);
+  expect(Math.abs(geometry.rootWidth - geometry.hostWidth)).toBeLessThanOrEqual(1);
+  expect(Math.abs(geometry.rootHeight - geometry.hostHeight)).toBeLessThanOrEqual(1);
+  expect(geometry.hostPaddingLeft).toBe("0px");
+  expect(geometry.hostPaddingTop).toBe("0px");
+  expect(geometry.rootBackground).toBe(geometry.frameBackground);
+  expect(geometry.viewportBackground).toBe(geometry.frameBackground);
+  return geometry;
+}
 
 const suite = existsSync(DESKTOP_MAIN) ? describe : describe.skip;
 
@@ -64,7 +133,7 @@ suite("Desktop terminal session handoff", () => {
     }).toBe(true);
   });
 
-  it("renders the Figma-aligned list and preserves the mounted terminal buffer across list-detail navigation", async () => {
+  it("fills and refits the terminal detail while preserving its mounted buffer across navigation", async () => {
     await page.locator("aside button", { hasText: "Terminal" }).first().click();
     await page.getByRole("heading", { name: "Terminal" }).waitFor({ timeout: 10_000 });
     await page.getByText("Active", { exact: true }).waitFor();
@@ -77,11 +146,39 @@ suite("Desktop terminal session handoff", () => {
     await page.getByText(/Started at .*main computer/).waitFor();
     const viewport = page.locator("[data-terminal-viewport]");
     await viewport.evaluate((element) => { element.setAttribute("data-mat-300-identity", "preserved"); });
+    const initialGeometry = await expectTerminalViewportToFill(viewport);
     await page.screenshot({ path: join(SCREENSHOT_DIR, "mat-300-terminal-session-detail.png") });
+
+    await page.getByRole("button", { name: "Collapse sidebar" }).click();
+    await expect.poll(async () => (await readTerminalViewportGeometry(viewport)).hostWidth)
+      .toBeGreaterThan(initialGeometry.hostWidth + 20);
+    const collapsedGeometry = await expectTerminalViewportToFill(viewport);
+
+    await app.evaluate(({ BrowserWindow }) => {
+      const window = BrowserWindow.getAllWindows()[0];
+      if (!window) throw new Error("desktop window is unavailable");
+      const [width, height] = window.getSize();
+      window.setSize(Math.max(900, width - 140), Math.max(650, height - 100));
+    });
+    await expect.poll(async () => {
+      const resized = await readTerminalViewportGeometry(viewport);
+      return Math.abs(resized.hostWidth - collapsedGeometry.hostWidth)
+        + Math.abs(resized.hostHeight - collapsedGeometry.hostHeight);
+    }).toBeGreaterThan(20);
+    await expectTerminalViewportToFill(viewport);
 
     await page.getByRole("button", { name: "Back to terminal sessions" }).click();
     await page.getByRole("heading", { name: "Terminal" }).waitFor();
     await page.getByRole("button", { name: "Open matrix-task-1" }).click();
     await expect.poll(() => viewport.getAttribute("data-mat-300-identity")).toBe("preserved");
+    await expectTerminalViewportToFill(viewport);
+
+    await page.getByRole("button", { name: "Back to terminal sessions" }).click();
+    await page.getByRole("button", { name: "New shell" }).click();
+    const newSessionViewport = page.locator(
+      'section[aria-hidden="false"] [data-terminal-viewport]',
+    );
+    await newSessionViewport.waitFor();
+    await expectTerminalViewportToFill(newSessionViewport);
   }, 30_000);
 });

--- a/tests/e2e/desktop/terminal-sessions.e2e.test.ts
+++ b/tests/e2e/desktop/terminal-sessions.e2e.test.ts
@@ -133,7 +133,7 @@ suite("Desktop terminal session handoff", () => {
     }).toBe(true);
   });
 
-  it("fills and refits the terminal detail while preserving its mounted buffer across navigation", async () => {
+  it("renders the Figma-aligned list and preserves the mounted terminal buffer across list-detail navigation", async () => {
     await page.locator("aside button", { hasText: "Terminal" }).first().click();
     await page.getByRole("heading", { name: "Terminal" }).waitFor({ timeout: 10_000 });
     await page.getByText("Active", { exact: true }).waitFor();


### PR DESCRIPTION
## Summary

- remove the inset and hard-coded dark backing around the Desktop xterm viewport
- make the xterm root, scroll surfaces, and host fill the session detail with the active terminal palette
- cover initial and newly created sessions, navigation, sidebar changes, window resize, focus, and mounted-buffer preservation

Fixes MAT-329

- Linear: https://linear.app/matrix-os/issue/MAT-329/fix-desktop-terminal-viewport-height-and-top-offset
- Evidence: https://screen.studio/share/dnPz3JSX

## Tests

- `node_modules/.bin/vitest run tests/desktop/handoff-regression-matrix.test.ts tests/desktop/terminal-view.test.tsx tests/desktop/terminals-tab.test.tsx tests/desktop/tab-content.test.tsx` (58 passed after merging latest `origin/main`)
- `pnpm --filter desktop run typecheck`
- `bun run typecheck`
- `pnpm --filter desktop build`
- `node_modules/.bin/vitest run --config vitest.e2e.config.ts tests/e2e/desktop/terminal-sessions.e2e.test.ts tests/e2e/desktop/terminal-containment.e2e.test.ts` (3 passed after merging latest `origin/main`)
- `bun run check:patterns:diff` (0 violations)
- `git diff --check`
- `bun run test` (not green in this local Node 26 environment: 893 files / 10,355 tests passed; 60 files / 464 tests failed in unrelated suites due unavailable localStorage, a Node ABI mismatch for better-sqlite3, pnpm virtual-store resolution, Node deprecation output, and existing timeout/environment assumptions; the MAT-329 suites passed)

## Review Monitoring

- Greptile review must reach 5/5 before `ready-for-ci` is added
- broader CI will be monitored after the review gate

## Invariants

- Source of truth: the existing mounted xterm `Terminal` instance and the appearance theme store remain authoritative
- Lock/transaction scope: not applicable; this is renderer-only layout and theme synchronization
- Acceptable orphan states: not applicable; no persistence or session ownership behavior changed
- Auth source: unchanged; terminal attachment continues through the existing authenticated runtime connection
- Deferred scope: no terminal/Zellij lifecycle redesign and no changes to the web terminal surface
