### PR TITLE
fix(desktop): finish sidebar and computer selector parity

### DIFF
--- a/desktop/src/renderer/src/design/tokens.css
+++ b/desktop/src/renderer/src/design/tokens.css
@@ -85,6 +85,11 @@
   --radius-xl: 16px;
   --titlebar-height: 40px;
   --tabbar-height: 38px;
+  --sidebar-expanded-width: 240px;
+  --sidebar-collapsed-width: 56px;
+  --sidebar-row-height: 32px;
+  --sidebar-menu-width: 248px;
+  --sidebar-account-menu-width: 224px;
 
   /* ── Elevation ──────────────────────────────────────────────── */
   --shadow-1: 0 1px 2px rgba(40, 44, 37, 0.06);

--- a/desktop/src/renderer/src/features/mission-control/AccountMenu.tsx
+++ b/desktop/src/renderer/src/features/mission-control/AccountMenu.tsx
@@ -1,3 +1,4 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import {
   ChevronRight,
   CircleHelp,
@@ -5,7 +6,8 @@ import {
   LogOut,
   Settings,
 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
+import { DESKTOP_Z_INDEX } from "../../design/layering";
 import { invoke } from "../../lib/operator";
 import { useConnection } from "../../stores/connection";
 import { useTabs } from "../../stores/tabs";
@@ -37,32 +39,30 @@ function AccountAvatar({
 function MenuRow({
   icon,
   label,
-  onClick,
+  onSelect,
   trailing = false,
   danger = false,
 }: {
   icon: React.ReactNode;
   label: string;
-  onClick: () => void;
+  onSelect: () => void;
   trailing?: boolean;
   danger?: boolean;
 }) {
   return (
-    <button
-      type="button"
-      className="flex h-9 w-full items-center gap-2 rounded-md px-2 text-left text-[13px] hover:bg-[var(--bg-hover)]"
+    <DropdownMenu.Item
+      className="flex h-9 cursor-default items-center gap-2 rounded-md px-2 text-left text-[13px] outline-none data-[highlighted]:bg-[var(--bg-hover)]"
       style={{ color: danger ? "var(--danger)" : "var(--text-primary)" }}
-      onClick={onClick}
+      onSelect={onSelect}
     >
-      <span style={{ color: danger ? "var(--danger)" : "var(--text-tertiary)" }}>{icon}</span>
+      <span aria-hidden="true" style={{ color: danger ? "var(--danger)" : "var(--text-tertiary)" }}>{icon}</span>
       <span className="min-w-0 flex-1 truncate">{label}</span>
-      {trailing ? <ChevronRight size={13} style={{ color: "var(--text-tertiary)" }} /> : null}
-    </button>
+      {trailing ? <ChevronRight aria-hidden="true" size={13} style={{ color: "var(--text-tertiary)" }} /> : null}
+    </DropdownMenu.Item>
   );
 }
 
 export default function AccountMenu({ collapsed }: { collapsed: boolean }) {
-  const rootRef = useRef<HTMLDivElement | null>(null);
   const [open, setOpen] = useState(false);
   const handle = useConnection((state) => state.handle);
   const displayName = useConnection((state) => state.displayName);
@@ -73,22 +73,6 @@ export default function AccountMenu({ collapsed }: { collapsed: boolean }) {
   const primaryLabel = displayName ?? (handle ? `@${handle}` : "Signed in");
   const secondaryLabel = displayName && handle ? `@${handle}` : null;
 
-  useEffect(() => {
-    if (!open) return;
-    const closeOnPointer = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
-    };
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("pointerdown", closeOnPointer);
-    document.addEventListener("keydown", closeOnEscape);
-    return () => {
-      document.removeEventListener("pointerdown", closeOnPointer);
-      document.removeEventListener("keydown", closeOnEscape);
-    };
-  }, [open]);
-
   const openSettings = (section: "account" | "billing") => {
     setOpen(false);
     requestSettingsSection(section);
@@ -96,43 +80,74 @@ export default function AccountMenu({ collapsed }: { collapsed: boolean }) {
   };
 
   return (
-    <div ref={rootRef} className="relative p-2 pt-1">
-      {open ? (
-        <div
-          role="menu"
-          aria-label="Account"
-          className="absolute bottom-full left-2 mb-1 w-56 rounded-xl border p-1 shadow-lg"
-          style={{ zIndex: 30, borderColor: "var(--border-default)", background: "var(--bg-overlay)" }}
-        >
-          <div className="px-2 py-2">
-            <span className="block text-[10px] font-semibold uppercase tracking-[0.1em]" style={{ color: "var(--text-tertiary)" }}>
-              Personal account
+    <div className="p-2 pt-1">
+      <DropdownMenu.Root open={open} onOpenChange={setOpen}>
+        <DropdownMenu.Trigger asChild>
+          <button
+            type="button"
+            aria-label="Open account menu"
+            title={collapsed ? primaryLabel : undefined}
+            className={`flex h-10 w-full items-center rounded-md outline-none transition-colors hover:bg-[var(--bg-hover)] focus-visible:bg-[var(--bg-hover)] ${collapsed ? "justify-center" : "gap-2 px-1"}`}
+          >
+            <span
+              className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-full text-xs font-semibold"
+              style={{ background: "var(--accent-muted)", color: "var(--accent)" }}
+            >
+              <AccountAvatar key={imageUrl} imageUrl={imageUrl} label={primaryLabel} />
             </span>
-            <span className="block truncate text-xs" style={{ color: "var(--text-secondary)" }}>
-              {secondaryLabel ?? primaryLabel}
-            </span>
-          </div>
-          <div className="border-t p-1" style={{ borderColor: "var(--border-subtle)" }}>
-            <MenuRow icon={<Settings size={14} />} label="Settings" trailing onClick={() => openSettings("account")} />
+            {!collapsed ? (
+              <span className="min-w-0 flex-1 text-left leading-tight">
+                <span className="block truncate text-sm font-medium" style={{ color: "var(--text-primary)" }}>{primaryLabel}</span>
+                {secondaryLabel ? (
+                  <span className="block truncate text-xs" style={{ color: "var(--text-tertiary)" }}>{secondaryLabel}</span>
+                ) : null}
+              </span>
+            ) : null}
+          </button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            aria-label="Account"
+            aria-labelledby={undefined}
+            side="top"
+            align="start"
+            sideOffset={4}
+            className="rounded-xl border p-1 outline-none"
+            style={{
+              zIndex: DESKTOP_Z_INDEX.popover,
+              width: "var(--sidebar-account-menu-width)",
+              borderColor: "var(--border-default)",
+              background: "var(--bg-overlay)",
+              boxShadow: "var(--shadow-2)",
+            }}
+          >
+            <DropdownMenu.Label className="px-2 py-2">
+              <span className="block text-[10px] font-semibold uppercase tracking-[0.1em]" style={{ color: "var(--text-tertiary)" }}>
+                Personal account
+              </span>
+              <span className="block truncate text-xs" style={{ color: "var(--text-secondary)" }}>
+                {secondaryLabel ?? primaryLabel}
+              </span>
+            </DropdownMenu.Label>
+            <DropdownMenu.Separator className="my-1 h-px" style={{ background: "var(--border-subtle)" }} />
+            <MenuRow icon={<Settings size={14} />} label="Settings" trailing onSelect={() => openSettings("account")} />
             <MenuRow
               icon={<CircleHelp size={14} />}
               label="Get help"
               trailing
-              onClick={() => {
+              onSelect={() => {
                 setOpen(false);
                 void invoke("shell:open-external", { url: "https://matrix-os.com/docs" });
               }}
             />
-          </div>
-          <div className="border-t p-1" style={{ borderColor: "var(--border-subtle)" }}>
-            <MenuRow icon={<CreditCard size={14} />} label="View all plans" onClick={() => openSettings("billing")} />
-          </div>
-          <div className="border-t p-1" style={{ borderColor: "var(--border-subtle)" }}>
+            <DropdownMenu.Separator className="my-1 h-px" style={{ background: "var(--border-subtle)" }} />
+            <MenuRow icon={<CreditCard size={14} />} label="View all plans" onSelect={() => openSettings("billing")} />
+            <DropdownMenu.Separator className="my-1 h-px" style={{ background: "var(--border-subtle)" }} />
             <MenuRow
               icon={<LogOut size={14} />}
               label="Log out"
               danger
-              onClick={() => {
+              onSelect={() => {
                 setOpen(false);
                 void signOut().catch((error: unknown) => {
                   console.warn(
@@ -142,34 +157,9 @@ export default function AccountMenu({ collapsed }: { collapsed: boolean }) {
                 });
               }}
             />
-          </div>
-        </div>
-      ) : null}
-
-      <button
-        type="button"
-        aria-label="Open account menu"
-        aria-haspopup="menu"
-        aria-expanded={open}
-        title={collapsed ? primaryLabel : undefined}
-        className={`flex w-full items-center rounded-md hover:bg-[var(--bg-hover)] ${collapsed ? "h-9 justify-center" : "gap-2 px-1 py-1"}`}
-        onClick={() => setOpen((value) => !value)}
-      >
-        <span
-          className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-full text-xs font-semibold"
-          style={{ background: "var(--accent-muted)", color: "var(--accent)" }}
-        >
-          <AccountAvatar key={imageUrl} imageUrl={imageUrl} label={primaryLabel} />
-        </span>
-        {!collapsed ? (
-          <span className="min-w-0 flex-1 text-left leading-tight">
-            <span className="block truncate text-sm" style={{ color: "var(--text-primary)" }}>{primaryLabel}</span>
-            {secondaryLabel ? (
-              <span className="block truncate text-xs" style={{ color: "var(--text-tertiary)" }}>{secondaryLabel}</span>
-            ) : null}
-          </span>
-        ) : null}
-      </button>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
     </div>
   );
 }

--- a/desktop/src/renderer/src/features/mission-control/ProjectSidebarRow.tsx
+++ b/desktop/src/renderer/src/features/mission-control/ProjectSidebarRow.tsx
@@ -1,5 +1,5 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { Archive, MoreHorizontal, Trash2 } from "lucide-react";
+import { Archive, Folder, MoreHorizontal, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button, Dialog } from "../../design/primitives";
 import type { Project } from "../../stores/board";
@@ -49,17 +49,19 @@ export default function ProjectSidebarRow({
   return (
     <>
       <div
-        className="group/project-row flex w-full items-center rounded-md transition-colors duration-100"
+        data-active={active ? "true" : "false"}
+        className="group/project-row flex w-full items-center rounded-md transition-colors duration-100 hover:bg-[var(--bg-hover)]"
         style={{ background: active ? "var(--bg-selected)" : "transparent" }}
       >
         <button
           type="button"
-          aria-label={`Open ${project.name}`}
-          className="flex min-w-0 flex-1 items-center gap-2.5 py-1.5 pl-2.5 text-sm font-medium"
-          style={{ color: active ? "var(--text-primary)" : "var(--text-secondary)" }}
+          aria-label={`Open ${project.name || project.slug}`}
+          aria-current={active ? "page" : undefined}
+          className="flex min-w-0 flex-1 items-center gap-2.5 pl-2.5 text-sm font-medium outline-none"
+          style={{ height: "var(--sidebar-row-height)", color: active ? "var(--text-primary)" : "var(--text-secondary)" }}
           onClick={onOpen}
         >
-          <span className="text-xs" style={{ color: active ? "var(--accent)" : "var(--text-tertiary)" }}>▣</span>
+          <Folder size={14} aria-hidden="true" className="shrink-0" style={{ color: active ? "var(--accent)" : "var(--text-tertiary)" }} />
           <span className="min-w-0 flex-1 truncate text-left">{project.name || project.slug}</span>
           {attention > 0 ? (
             <span className="rounded-full px-1.5 text-xs" style={{ background: "var(--highlight-muted)", color: "var(--highlight)" }}>

--- a/desktop/src/renderer/src/features/mission-control/RecentViews.tsx
+++ b/desktop/src/renderer/src/features/mission-control/RecentViews.tsx
@@ -1,3 +1,4 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import {
   Check,
   Filter,
@@ -5,7 +6,8 @@ import {
   MessageCircle,
   SquareTerminal,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
+import { DESKTOP_Z_INDEX } from "../../design/layering";
 import { openCodingAgentThread } from "../../lib/project-chat";
 import {
   useTabs,
@@ -30,39 +32,25 @@ function RecentIcon({ kind }: { kind: RecentView["kind"] }) {
 }
 
 export default function RecentViews() {
-  const rootRef = useRef<HTMLDivElement | null>(null);
-  const [filterOpen, setFilterOpen] = useState(false);
   const recentViews = useTabs((state) => state.recentViews);
   const recentFilter = useTabs((state) => state.recentFilter);
   const setRecentFilter = useTabs((state) => state.setRecentFilter);
   const tabs = useTabs((state) => state.tabs);
+  const activeTabId = useTabs((state) => state.activeTabId);
   const openTab = useTabs((state) => state.openTab);
   const requestTerminalSession = useTabs((state) => state.requestTerminalSession);
   const api = useConnection((state) => state.api);
   const threads = useThreads((state) => state.threads);
+  const activeThreadId = useThreads((state) => state.activeThreadId);
   const setActiveThread = useThreads((state) => state.setActiveThread);
   const openHermesConversation = useHermesChat((state) => state.openConversation);
   const showHermesIndex = useHermesChat((state) => state.showIndex);
+  const hermesSessionId = useHermesChat((state) => state.sessionId);
+  const activeTab = tabs.find((tab) => tab.id === activeTabId);
   const visible = useMemo(
     () => recentViews.filter((recent) => recentFilter === "all" || recent.kind === recentFilter).slice(0, 8),
     [recentFilter, recentViews],
   );
-
-  useEffect(() => {
-    if (!filterOpen) return;
-    const closeOnPointer = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) setFilterOpen(false);
-    };
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setFilterOpen(false);
-    };
-    document.addEventListener("pointerdown", closeOnPointer);
-    document.addEventListener("keydown", closeOnEscape);
-    return () => {
-      document.removeEventListener("pointerdown", closeOnPointer);
-      document.removeEventListener("keydown", closeOnEscape);
-    };
-  }, [filterOpen]);
 
   const openRecent = (recent: RecentView) => {
     if (recent.kind === "project") {
@@ -103,66 +91,102 @@ export default function RecentViews() {
     }
   };
 
+  const isActive = (recent: RecentView) => {
+    if (recent.kind === "project") {
+      return activeTab?.kind === "project" && activeTab.projectSlug === recent.id;
+    }
+    if (recent.kind === "terminal") {
+      return activeTab?.kind === "terminal" && activeTab.sessionName === recent.id;
+    }
+    return activeTab?.kind === "chat"
+      && (recent.id === activeThreadId || recent.id === hermesSessionId);
+  };
+
   return (
-    <div ref={rootRef} className="relative mt-4">
+    <div className="relative mt-4">
       <div className="flex items-center justify-between px-2.5 pb-1">
         <span className="text-xs font-semibold tracking-wide uppercase" style={{ color: "var(--text-tertiary)" }}>
           Recents
         </span>
-        <button
-          type="button"
-          aria-label="Filter recents"
-          aria-haspopup="menu"
-          aria-expanded={filterOpen}
-          className="flex h-5 w-5 items-center justify-center rounded hover:bg-[var(--bg-hover)]"
-          style={{ color: recentFilter === "all" ? "var(--text-tertiary)" : "var(--accent)" }}
-          onClick={() => setFilterOpen((value) => !value)}
-        >
-          <Filter size={12} />
-        </button>
-      </div>
-
-      {filterOpen ? (
-        <div
-          role="menu"
-          aria-label="Recent type"
-          className="absolute right-1 top-6 z-20 w-40 rounded-lg border p-1 shadow-lg"
-          style={{ borderColor: "var(--border-default)", background: "var(--bg-overlay)" }}
-        >
-          {FILTER_OPTIONS.map((option) => (
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger asChild>
             <button
-              key={option.filter}
               type="button"
-              className="flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-xs hover:bg-[var(--bg-hover)]"
-              style={{ color: "var(--text-primary)" }}
-              onClick={() => {
-                setRecentFilter(option.filter);
-                setFilterOpen(false);
+              aria-label="Filter recents"
+              className="flex h-5 w-5 items-center justify-center rounded outline-none hover:bg-[var(--bg-hover)] focus-visible:bg-[var(--bg-hover)]"
+              style={{ color: recentFilter === "all" ? "var(--text-tertiary)" : "var(--accent)" }}
+            >
+              <Filter size={12} aria-hidden="true" />
+            </button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content
+              aria-label="Recent type"
+              aria-labelledby={undefined}
+              align="end"
+              sideOffset={4}
+              className="w-40 rounded-lg border p-1 shadow-lg outline-none"
+              style={{
+                zIndex: DESKTOP_Z_INDEX.popover,
+                borderColor: "var(--border-default)",
+                background: "var(--bg-overlay)",
+                boxShadow: "var(--shadow-2)",
               }}
             >
-              <span className="flex w-3 items-center justify-center">
-                {recentFilter === option.filter ? <Check size={12} /> : null}
-              </span>
-              {option.label}
-            </button>
-          ))}
-        </div>
-      ) : null}
+              <DropdownMenu.RadioGroup
+                value={recentFilter}
+                onValueChange={(value) => setRecentFilter(value as RecentViewFilter)}
+              >
+                {FILTER_OPTIONS.map((option) => (
+                  <DropdownMenu.RadioItem
+                    key={option.filter}
+                    value={option.filter}
+                    className="flex h-8 cursor-default items-center gap-2 rounded-md px-2 text-xs outline-none data-[highlighted]:bg-[var(--bg-hover)]"
+                    style={{ color: "var(--text-primary)" }}
+                  >
+                    <span className="flex w-3 items-center justify-center">
+                      <DropdownMenu.ItemIndicator>
+                        <Check size={12} aria-hidden="true" />
+                      </DropdownMenu.ItemIndicator>
+                    </span>
+                    {option.label}
+                  </DropdownMenu.RadioItem>
+                ))}
+              </DropdownMenu.RadioGroup>
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Root>
+      </div>
 
       <div className="flex flex-col gap-0.5">
-        {visible.map((recent) => (
-          <button
-            key={`${recent.kind}:${recent.id}`}
-            type="button"
-            aria-label={`Open recent ${recent.label}`}
-            className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm hover:bg-[var(--bg-hover)]"
-            style={{ color: "var(--text-secondary)" }}
-            onClick={() => openRecent(recent)}
-          >
-            <span className="shrink-0" style={{ color: "var(--text-tertiary)" }}><RecentIcon kind={recent.kind} /></span>
-            <span className="min-w-0 flex-1 truncate">{recent.label}</span>
-          </button>
-        ))}
+        {visible.map((recent) => {
+          const active = isActive(recent);
+          return (
+            <button
+              key={`${recent.kind}:${recent.id}`}
+              type="button"
+              aria-label={`Open recent ${recent.label}`}
+              aria-current={active ? "page" : undefined}
+              data-active={active ? "true" : "false"}
+              className="flex w-full items-center gap-2 rounded-md px-2.5 text-left text-sm outline-none transition-colors hover:bg-[var(--bg-hover)] focus-visible:bg-[var(--bg-hover)]"
+              style={{
+                height: "var(--sidebar-row-height)",
+                color: active ? "var(--text-primary)" : "var(--text-secondary)",
+                background: active ? "var(--bg-selected)" : undefined,
+              }}
+              onClick={() => openRecent(recent)}
+            >
+              <span
+                aria-hidden="true"
+                className="shrink-0"
+                style={{ color: active ? "var(--accent)" : "var(--text-tertiary)" }}
+              >
+                <RecentIcon kind={recent.kind} />
+              </span>
+              <span className="min-w-0 flex-1 truncate">{recent.label}</span>
+            </button>
+          );
+        })}
         {visible.length === 0 ? (
           <span className="px-2.5 py-1 text-xs" style={{ color: "var(--text-tertiary)" }}>
             No recent {recentFilter === "all" ? "views" : FILTER_OPTIONS.find((option) => option.filter === recentFilter)?.label.toLowerCase()}.

--- a/desktop/src/renderer/src/features/mission-control/RecentViews.tsx
+++ b/desktop/src/renderer/src/features/mission-control/RecentViews.tsx
@@ -15,6 +15,7 @@ import {
   type RecentViewFilter,
 } from "../../stores/tabs";
 import { useConnection } from "../../stores/connection";
+import { useCodingAgentWorkspace } from "../../stores/coding-agent-workspace";
 import { useHermesChat } from "../../stores/hermes-chat";
 import { useThreads } from "../../stores/threads";
 
@@ -42,6 +43,7 @@ export default function RecentViews() {
   const api = useConnection((state) => state.api);
   const threads = useThreads((state) => state.threads);
   const activeThreadId = useThreads((state) => state.activeThreadId);
+  const activeCodingAgentThreadId = useCodingAgentWorkspace((state) => state.activeThreadId);
   const setActiveThread = useThreads((state) => state.setActiveThread);
   const openHermesConversation = useHermesChat((state) => state.openConversation);
   const showHermesIndex = useHermesChat((state) => state.showIndex);
@@ -98,8 +100,13 @@ export default function RecentViews() {
     if (recent.kind === "terminal") {
       return activeTab?.kind === "terminal" && activeTab.sessionName === recent.id;
     }
-    return activeTab?.kind === "chat"
-      && (recent.id === activeThreadId || recent.id === hermesSessionId);
+    if (recent.conversationType === "coding-agent") {
+      return activeTab?.kind === "project" && recent.id === activeCodingAgentThreadId;
+    }
+    if (recent.conversationType === "hermes") {
+      return activeTab?.kind === "chat" && activeThreadId === null && recent.id === hermesSessionId;
+    }
+    return activeTab?.kind === "chat" && recent.id === activeThreadId;
   };
 
   return (

--- a/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
+++ b/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
@@ -1,6 +1,5 @@
 import {
   Blocks,
-  ChevronRight,
   Home,
   FolderTree,
   LayoutGrid,
@@ -22,49 +21,7 @@ import DesktopUpdateButton from "../updates/DesktopUpdateButton";
 import AccountMenu from "./AccountMenu";
 import ProjectSidebarRow from "./ProjectSidebarRow";
 import RecentViews from "./RecentViews";
-
-function NavRow({
-  icon,
-  label,
-  active,
-  badge,
-  collapsed,
-  onClick,
-}: {
-  icon: React.ReactNode;
-  label: string;
-  active: boolean;
-  badge?: number;
-  collapsed: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      title={collapsed ? label : undefined}
-      className={`flex w-full items-center rounded-md py-1.5 text-sm font-medium transition-colors duration-100 ${collapsed ? "justify-center px-0" : "gap-2.5 px-2.5"}`}
-      style={{
-        color: active ? "var(--text-primary)" : "var(--text-secondary)",
-        background: active ? "var(--bg-selected)" : "transparent",
-      }}
-      onMouseEnter={(e) => {
-        if (!active) e.currentTarget.style.background = "var(--bg-hover)";
-      }}
-      onMouseLeave={(e) => {
-        if (!active) e.currentTarget.style.background = "transparent";
-      }}
-      onClick={onClick}
-    >
-      <span style={{ color: active ? "var(--accent)" : "var(--text-tertiary)" }}>{icon}</span>
-      {!collapsed ? <span className="min-w-0 flex-1 truncate text-left">{label}</span> : null}
-      {!collapsed && badge ? (
-        <span className="rounded-full px-1.5 text-xs" style={{ background: "var(--highlight-muted)", color: "var(--highlight)" }}>
-          {badge}
-        </span>
-      ) : null}
-    </button>
-  );
-}
+import { SidebarNavRow, SidebarSectionHeader } from "./SidebarPrimitives";
 
 function SidebarAppIcon({ iconUrl, name }: { iconUrl?: string; name: string }) {
   const url =
@@ -100,12 +57,17 @@ export default function Sidebar() {
   const [appsOpen, setAppsOpen] = useState(true);
 
   const activeTab = tabs.find((t) => t.id === activeTabId);
-  const width = collapsed ? 56 : 240;
-
   return (
     <aside
+      aria-label="Matrix OS navigation"
+      data-sidebar-state={collapsed ? "collapsed" : "expanded"}
       className="flex shrink-0 flex-col"
-      style={{ width, background: "var(--bg-sunken)", borderRight: "1px solid var(--border-subtle)", transition: "width 140ms var(--ease-out)" }}
+      style={{
+        width: collapsed ? "var(--sidebar-collapsed-width)" : "var(--sidebar-expanded-width)",
+        background: "var(--bg-sunken)",
+        borderRight: "1px solid var(--border-subtle)",
+        transition: "width 140ms var(--ease-out)",
+      }}
     >
       {/* The collapsed rail stays empty beneath the macOS traffic lights; the
           shared navigation header owns the collapse/expand control. */}
@@ -114,7 +76,7 @@ export default function Sidebar() {
         style={{ height: "var(--titlebar-height)", paddingLeft: collapsed ? 0 : 76, justifyContent: collapsed ? "center" : "flex-start" }}
       >
         {collapsed ? null : (
-          <div className="flex items-center gap-2.5">
+          <div className="flex items-center gap-2.5" data-testid="matrix-sidebar-logo">
             <BrandLogo size={22} />
             <span className="text-[15px] font-semibold tracking-tight" style={{ color: "var(--text-primary)" }}>Matrix OS</span>
           </div>
@@ -122,71 +84,120 @@ export default function Sidebar() {
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-2 pb-2">
-        <nav className="flex flex-col gap-0.5">
-          <NavRow icon={<Home size={15} />} label="Home" collapsed={collapsed} active={activeTab?.kind === "home"} onClick={() => openTab({ kind: "home", title: "Home", closable: false })} />
-          <NavRow icon={<Sparkles size={15} />} label="Chat" collapsed={collapsed} active={activeTab?.kind === "chat"} badge={chatAttention} onClick={() => { useThreads.getState().setActiveThread(null); useHermesChat.getState().showIndex(); openTab({ kind: "chat", title: "Hermes", closable: false }); }} />
-          <NavRow icon={<SquareTerminal size={15} />} label="Terminal" collapsed={collapsed} active={activeTab?.kind === "terminals"} onClick={() => openTab({ kind: "terminals", title: "Terminal" })} />
-          <NavRow icon={<FolderTree size={15} />} label="Files" collapsed={collapsed} active={activeTab?.kind === "files"} onClick={() => openTab(FILES_WORKSPACE_TAB_SPEC)} />
-          <NavRow icon={<LayoutGrid size={15} />} label="Apps" collapsed={collapsed} active={activeTab?.kind === "apps" || activeTab?.kind === "app"} onClick={() => openTab({ kind: "apps", title: "Apps" })} />
-          <NavRow icon={<Blocks size={15} />} label="Plugins" collapsed={collapsed} active={activeTab?.kind === "plugins"} onClick={() => openTab({ kind: "plugins", title: "Plugins" })} />
+        <nav aria-label="Primary" className="flex flex-col gap-0.5">
+          <SidebarNavRow
+            icon={<Home size={15} />}
+            label="Home"
+            collapsed={collapsed}
+            active={activeTab?.kind === "home"}
+            onClick={() => openTab({ kind: "home", title: "Home", closable: false })}
+          />
+          <SidebarNavRow
+            icon={<Sparkles size={15} />}
+            label="Chat"
+            collapsed={collapsed}
+            active={activeTab?.kind === "chat"}
+            badge={chatAttention}
+            onClick={() => {
+              useThreads.getState().setActiveThread(null);
+              useHermesChat.getState().showIndex();
+              openTab({ kind: "chat", title: "Hermes", closable: false });
+            }}
+          />
+          <SidebarNavRow
+            icon={<SquareTerminal size={15} />}
+            label="Terminal"
+            collapsed={collapsed}
+            active={activeTab?.kind === "terminals" || activeTab?.kind === "terminal"}
+            onClick={() => openTab({ kind: "terminals", title: "Terminal" })}
+          />
+          <SidebarNavRow
+            icon={<FolderTree size={15} />}
+            label="Files"
+            collapsed={collapsed}
+            active={activeTab?.kind === "files"}
+            onClick={() => openTab(FILES_WORKSPACE_TAB_SPEC)}
+          />
+          <SidebarNavRow
+            icon={<LayoutGrid size={15} />}
+            label="Apps"
+            collapsed={collapsed}
+            active={activeTab?.kind === "apps" || activeTab?.kind === "app"}
+            onClick={() => openTab({ kind: "apps", title: "Apps" })}
+          />
+          <SidebarNavRow
+            icon={<Blocks size={15} />}
+            label="Plugins"
+            collapsed={collapsed}
+            active={activeTab?.kind === "plugins"}
+            onClick={() => openTab({ kind: "plugins", title: "Plugins" })}
+          />
         </nav>
 
         {!collapsed ? (
           <>
             <RecentViews />
-            <div className="group/projects mt-4 mb-1 flex items-center px-2.5">
-              <button type="button" className="flex flex-1 items-center gap-1" onClick={() => setProjectsOpen((v) => !v)}>
-                <ChevronRight size={12} style={{ color: "var(--text-tertiary)", transform: projectsOpen ? "rotate(90deg)" : "none", transition: "transform 120ms" }} />
-                <span className="text-xs font-semibold tracking-wide uppercase" style={{ color: "var(--text-tertiary)" }}>Projects</span>
-              </button>
-              <button
-                type="button"
-                aria-label="Add project"
-                title="Add project"
-                className="flex h-5 w-5 items-center justify-center rounded opacity-0 transition-opacity hover:bg-[var(--bg-hover)] group-hover/projects:opacity-100"
-                style={{ color: "var(--text-tertiary)" }}
-                onClick={() => setCreateProjectOpen(true)}
-              >
-                <Plus size={13} />
-              </button>
+            <SidebarSectionHeader
+              label="Projects"
+              open={projectsOpen}
+              controls="sidebar-projects"
+              onToggle={() => setProjectsOpen((value) => !value)}
+              action={(
+                <button
+                  type="button"
+                  aria-label="Add project"
+                  title="Add project"
+                  className="flex h-5 w-5 items-center justify-center rounded opacity-0 transition-opacity hover:bg-[var(--bg-hover)] focus:opacity-100 group-hover/sidebar-section:opacity-100"
+                  style={{ color: "var(--text-tertiary)" }}
+                  onClick={() => setCreateProjectOpen(true)}
+                >
+                  <Plus size={13} aria-hidden="true" />
+                </button>
+              )}
+            />
+            <div id="sidebar-projects">
+              {projectsOpen
+                ? projects.map((project) => {
+                    const isActive = activeTab?.kind === "project" && activeTab.projectSlug === project.slug;
+                    const attention = summaryProjects?.find((candidate) => candidate.id === project.slug)?.attentionCount ?? 0;
+                    return (
+                      <ProjectSidebarRow
+                        key={project.slug}
+                        project={project}
+                        active={isActive}
+                        attention={attention}
+                        onOpen={() => openTab({ kind: "project", projectSlug: project.slug, title: project.name || project.slug })}
+                      />
+                    );
+                  })
+                : null}
+              {projectsOpen && projects.length === 0 ? (
+                <p className="px-2.5 py-1 text-xs" style={{ color: "var(--text-tertiary)" }}>No projects yet.</p>
+              ) : null}
             </div>
-            {projectsOpen
-              ? projects.map((project) => {
-                  const isActive = activeTab?.kind === "project" && activeTab.projectSlug === project.slug;
-                  const attention = summaryProjects?.find((candidate) => candidate.id === project.slug)?.attentionCount ?? 0;
-                  return (
-                    <ProjectSidebarRow
-                      key={project.slug}
-                      project={project}
-                      active={isActive}
-                      attention={attention}
-                      onOpen={() => openTab({ kind: "project", projectSlug: project.slug, title: project.name || project.slug })}
-                    />
-                  );
-                })
-              : null}
-            {projectsOpen && projects.length === 0 ? (
-              <p className="px-2.5 py-1 text-xs" style={{ color: "var(--text-tertiary)" }}>No projects yet.</p>
-            ) : null}
 
             {openApps.length > 0 ? (
               <>
-                <button type="button" className="mt-4 mb-1 flex w-full items-center gap-1 px-2.5" onClick={() => setAppsOpen((v) => !v)}>
-                  <ChevronRight size={12} style={{ color: "var(--text-tertiary)", transform: appsOpen ? "rotate(90deg)" : "none", transition: "transform 120ms" }} />
-                  <span className="text-xs font-semibold tracking-wide uppercase" style={{ color: "var(--text-tertiary)" }}>Open apps</span>
-                </button>
-                {appsOpen
-                  ? openApps.map((tab) => (
-                      <NavRow
-                        key={tab.id}
-                        icon={<SidebarAppIcon iconUrl={tab.icon} name={tab.title} />}
-                        label={tab.title}
-                        collapsed={false}
-                        active={tab.id === activeTabId}
-                        onClick={() => focusTab(tab.id)}
-                      />
-                    ))
-                  : null}
+                <SidebarSectionHeader
+                  label="Open apps"
+                  open={appsOpen}
+                  controls="sidebar-open-apps"
+                  onToggle={() => setAppsOpen((value) => !value)}
+                />
+                <div id="sidebar-open-apps">
+                  {appsOpen
+                    ? openApps.map((tab) => (
+                        <SidebarNavRow
+                          key={tab.id}
+                          icon={<SidebarAppIcon iconUrl={tab.icon} name={tab.title} />}
+                          label={tab.title}
+                          collapsed={false}
+                          active={tab.id === activeTabId}
+                          onClick={() => focusTab(tab.id)}
+                        />
+                      ))
+                    : null}
+                </div>
               </>
             ) : null}
           </>

--- a/desktop/src/renderer/src/features/mission-control/SidebarPrimitives.tsx
+++ b/desktop/src/renderer/src/features/mission-control/SidebarPrimitives.tsx
@@ -1,0 +1,90 @@
+import { ChevronRight } from "lucide-react";
+import type { ReactNode } from "react";
+
+export function SidebarNavRow({
+  icon,
+  label,
+  active,
+  badge,
+  collapsed,
+  onClick,
+}: {
+  icon: ReactNode;
+  label: string;
+  active: boolean;
+  badge?: number;
+  collapsed: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={badge ? `${label} ${badge}` : label}
+      aria-current={active ? "page" : undefined}
+      data-active={active ? "true" : "false"}
+      title={collapsed ? label : undefined}
+      className={`group/sidebar-row flex w-full items-center rounded-md text-sm font-medium outline-none transition-colors duration-100 hover:bg-[var(--bg-hover)] focus-visible:bg-[var(--bg-hover)] ${collapsed ? "justify-center px-0" : "gap-2.5 px-2.5"}`}
+      style={{
+        height: "var(--sidebar-row-height)",
+        color: active ? "var(--text-primary)" : "var(--text-secondary)",
+        background: active ? "var(--bg-selected)" : undefined,
+      }}
+      onClick={onClick}
+    >
+      <span
+        aria-hidden="true"
+        className="flex shrink-0 items-center justify-center transition-colors"
+        style={{ color: active ? "var(--accent)" : "var(--text-tertiary)" }}
+      >
+        {icon}
+      </span>
+      {!collapsed ? <span className="min-w-0 flex-1 truncate text-left">{label}</span> : null}
+      {!collapsed && badge ? (
+        <span
+          aria-hidden="true"
+          className="min-w-5 rounded-full px-1.5 text-center text-xs"
+          style={{ background: "var(--highlight-muted)", color: "var(--highlight)" }}
+        >
+          {badge}
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+export function SidebarSectionHeader({
+  label,
+  open,
+  controls,
+  onToggle,
+  action,
+}: {
+  label: string;
+  open: boolean;
+  controls: string;
+  onToggle: () => void;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="group/sidebar-section mt-4 mb-1 flex items-center px-2.5">
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-controls={controls}
+        className="flex min-w-0 flex-1 items-center gap-1 rounded-sm text-left outline-none"
+        onClick={onToggle}
+      >
+        <ChevronRight
+          size={12}
+          aria-hidden="true"
+          className="shrink-0 transition-transform duration-100"
+          style={{ color: "var(--text-tertiary)", transform: open ? "rotate(90deg)" : undefined }}
+        />
+        <span className="truncate text-xs font-semibold tracking-wide uppercase" style={{ color: "var(--text-tertiary)" }}>
+          {label}
+        </span>
+      </button>
+      {action}
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/runtime/RuntimeComputerMenu.tsx
+++ b/desktop/src/renderer/src/features/runtime/RuntimeComputerMenu.tsx
@@ -1,6 +1,6 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Check, ChevronUp, LoaderCircle, Monitor, RefreshCw } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { DESKTOP_Z_INDEX } from "../../design/layering";
 import { useConnection } from "../../stores/connection";
 import { useRuntimeComputers } from "../../stores/runtime-computers";
@@ -30,6 +30,7 @@ export default function RuntimeComputerMenu({ collapsed }: { collapsed: boolean 
   const refresh = useRuntimeComputers((state) => state.refresh);
   const select = useRuntimeComputers((state) => state.select);
   const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
   // The token can be on a different slot than the persisted profile (stale
   // profile write); the inventory response's selectedSlot is authoritative.
   const selectedSlot = serverSelectedSlot ?? runtimeSlot;
@@ -47,12 +48,21 @@ export default function RuntimeComputerMenu({ collapsed }: { collapsed: boolean 
   const buttonLabel = loadStatus === "error"
     ? "Computer list unavailable"
     : `Change computer, currently ${currentLabel}`;
+  const switchComputer = async (runtimeSlotValue: string) => {
+    const computer = computers.find((candidate) => candidate.runtimeSlot === runtimeSlotValue);
+    if (!computer || runtimeSlotValue === selectedSlot || computer.availability !== "available" || switchingSlot) return;
+    if (await select(runtimeSlotValue)) {
+      setOpen(false);
+      triggerRef.current?.focus();
+    }
+  };
 
   return (
     <div className="px-2 py-1">
       <DropdownMenu.Root open={open} onOpenChange={setOpen}>
         <DropdownMenu.Trigger asChild>
           <button
+            ref={triggerRef}
             type="button"
             aria-label={buttonLabel}
             title={collapsed ? currentLabel : undefined}
@@ -118,12 +128,6 @@ export default function RuntimeComputerMenu({ collapsed }: { collapsed: boolean 
             <DropdownMenu.RadioGroup
               value={selectedSlot}
               className="max-h-72 overflow-y-auto"
-              onValueChange={(runtimeSlotValue) => {
-                const computer = computers.find((candidate) => candidate.runtimeSlot === runtimeSlotValue);
-                if (!computer || runtimeSlotValue === selectedSlot || computer.availability !== "available" || switchingSlot) return;
-                setOpen(false);
-                void select(runtimeSlotValue);
-              }}
             >
               {computers.map((computer) => {
                 const selected = computer.runtimeSlot === selectedSlot;
@@ -135,6 +139,10 @@ export default function RuntimeComputerMenu({ collapsed }: { collapsed: boolean 
                     value={computer.runtimeSlot}
                     disabled={disabled}
                     className="flex cursor-default items-center gap-2 rounded-lg px-2 py-2 text-left outline-none data-[disabled]:opacity-60 data-[highlighted]:bg-[var(--bg-hover)]"
+                    onSelect={(event) => {
+                      event.preventDefault();
+                      void switchComputer(computer.runtimeSlot);
+                    }}
                   >
                     <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md" style={{ background: selected ? "var(--accent-muted)" : "var(--bg-hover)", color: selected ? "var(--accent)" : "var(--text-secondary)" }}>
                       {switching ? <LoaderCircle size={14} className="animate-spin" aria-hidden="true" /> : <Monitor size={14} aria-hidden="true" />}

--- a/desktop/src/renderer/src/features/runtime/RuntimeComputerMenu.tsx
+++ b/desktop/src/renderer/src/features/runtime/RuntimeComputerMenu.tsx
@@ -1,5 +1,7 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Check, ChevronUp, LoaderCircle, Monitor, RefreshCw } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { DESKTOP_Z_INDEX } from "../../design/layering";
 import { useConnection } from "../../stores/connection";
 import { useRuntimeComputers } from "../../stores/runtime-computers";
 
@@ -28,7 +30,6 @@ export default function RuntimeComputerMenu({ collapsed }: { collapsed: boolean 
   const refresh = useRuntimeComputers((state) => state.refresh);
   const select = useRuntimeComputers((state) => state.select);
   const [open, setOpen] = useState(false);
-  const rootRef = useRef<HTMLDivElement | null>(null);
   // The token can be on a different slot than the persisted profile (stale
   // profile write); the inventory response's selectedSlot is authoritative.
   const selectedSlot = serverSelectedSlot ?? runtimeSlot;
@@ -36,22 +37,6 @@ export default function RuntimeComputerMenu({ collapsed }: { collapsed: boolean 
   useEffect(() => {
     void refresh();
   }, [authGeneration, connectionStatus, handle, platformHost, refresh, runtimeSlot]);
-
-  useEffect(() => {
-    if (!open) return;
-    const closeOnPointer = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
-    };
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("pointerdown", closeOnPointer);
-    document.addEventListener("keydown", closeOnEscape);
-    return () => {
-      document.removeEventListener("pointerdown", closeOnPointer);
-      document.removeEventListener("keydown", closeOnEscape);
-    };
-  }, [open]);
 
   const current = useMemo(
     () => computers.find((computer) => computer.runtimeSlot === selectedSlot)
@@ -64,96 +49,127 @@ export default function RuntimeComputerMenu({ collapsed }: { collapsed: boolean 
     : `Change computer, currently ${currentLabel}`;
 
   return (
-    <div ref={rootRef} className="relative px-2 py-1">
-      {open ? (
-        <div
-          role="listbox"
-          aria-label="Choose computer"
-          className={`absolute bottom-full left-2 mb-1 overflow-hidden rounded-xl border p-1 shadow-lg ${collapsed ? "w-64" : "right-2"}`}
-          style={{ zIndex: 20, borderColor: "var(--border-default)", background: "var(--bg-overlay)" }}
-        >
-          <div className="flex items-center justify-between gap-2 px-2 py-1.5">
-            <span className="text-[10px] font-semibold uppercase tracking-[0.1em]" style={{ color: "var(--text-tertiary)" }}>
-              Computers
+    <div className="px-2 py-1">
+      <DropdownMenu.Root open={open} onOpenChange={setOpen}>
+        <DropdownMenu.Trigger asChild>
+          <button
+            type="button"
+            aria-label={buttonLabel}
+            title={collapsed ? currentLabel : undefined}
+            className={`flex w-full items-center rounded-md outline-none transition-colors hover:bg-[var(--bg-hover)] focus-visible:bg-[var(--bg-hover)] ${collapsed ? "justify-center" : "gap-2 px-2"}`}
+            style={{ height: "var(--sidebar-row-height)", color: "var(--text-secondary)" }}
+          >
+            <span className="relative flex h-6 w-6 shrink-0 items-center justify-center rounded-md" style={{ background: "var(--bg-hover)" }}>
+              <Monitor size={14} aria-hidden="true" />
+              <span
+                aria-hidden="true"
+                className="absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full border"
+                style={{
+                  background: current?.availability === "available"
+                    ? "var(--success)"
+                    : loadStatus === "error"
+                      ? "var(--danger)"
+                      : "var(--warning)",
+                  borderColor: "var(--bg-sunken)",
+                }}
+              />
             </span>
-            <button
-              type="button"
+            {!collapsed ? (
+              <>
+                <span className="min-w-0 flex-1 text-left">
+                  <span className="block truncate text-xs font-medium" style={{ color: "var(--text-primary)" }}>{currentLabel}</span>
+                  <span className="block truncate text-[10px]" style={{ color: "var(--text-tertiary)" }}>{current?.handle ?? handle ?? "Select computer"}</span>
+                </span>
+                <ChevronUp size={13} className="shrink-0 transition-transform" style={{ transform: open ? "rotate(180deg)" : undefined }} aria-hidden="true" />
+              </>
+            ) : null}
+          </button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            aria-label="Choose computer"
+            aria-labelledby={undefined}
+            side="top"
+            align="start"
+            sideOffset={4}
+            className="relative overflow-hidden rounded-xl border p-1 outline-none"
+            style={{
+              zIndex: DESKTOP_Z_INDEX.popover,
+              width: "var(--sidebar-menu-width)",
+              borderColor: "var(--border-default)",
+              background: "var(--bg-overlay)",
+              boxShadow: "var(--shadow-2)",
+            }}
+          >
+            <div className="flex items-center px-2 py-1.5 pr-8">
+              <span className="text-[10px] font-semibold uppercase tracking-[0.1em]" style={{ color: "var(--text-tertiary)" }}>
+                Computers
+              </span>
+            </div>
+            <DropdownMenu.Separator className="mb-1 h-px" style={{ background: "var(--border-subtle)" }} />
+            {loadStatus === "error" ? (
+              <p aria-live="polite" className="px-2 py-3 text-xs" style={{ color: "var(--text-secondary)" }}>Computers unavailable</p>
+            ) : null}
+            {loadStatus === "loading" && computers.length === 0 ? (
+              <p aria-live="polite" className="flex items-center gap-2 px-2 py-3 text-xs" style={{ color: "var(--text-secondary)" }}>
+                <LoaderCircle size={13} className="animate-spin" aria-hidden="true" /> Loading computers…
+              </p>
+            ) : null}
+            <DropdownMenu.RadioGroup
+              value={selectedSlot}
+              className="max-h-72 overflow-y-auto"
+              onValueChange={(runtimeSlotValue) => {
+                const computer = computers.find((candidate) => candidate.runtimeSlot === runtimeSlotValue);
+                if (!computer || runtimeSlotValue === selectedSlot || computer.availability !== "available" || switchingSlot) return;
+                setOpen(false);
+                void select(runtimeSlotValue);
+              }}
+            >
+              {computers.map((computer) => {
+                const selected = computer.runtimeSlot === selectedSlot;
+                const switching = switchingSlot === computer.runtimeSlot;
+                const disabled = computer.availability !== "available" || Boolean(switchingSlot);
+                return (
+                  <DropdownMenu.RadioItem
+                    key={computer.runtimeSlot}
+                    value={computer.runtimeSlot}
+                    disabled={disabled}
+                    className="flex cursor-default items-center gap-2 rounded-lg px-2 py-2 text-left outline-none data-[disabled]:opacity-60 data-[highlighted]:bg-[var(--bg-hover)]"
+                  >
+                    <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md" style={{ background: selected ? "var(--accent-muted)" : "var(--bg-hover)", color: selected ? "var(--accent)" : "var(--text-secondary)" }}>
+                      {switching ? <LoaderCircle size={14} className="animate-spin" aria-hidden="true" /> : <Monitor size={14} aria-hidden="true" />}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-xs font-medium" style={{ color: "var(--text-primary)" }}>{computer.label}</span>
+                      <span className="block truncate text-[10px]" style={{ color: "var(--text-tertiary)" }}>
+                        {selected ? "Current" : STATUS_LABEL[computer.availability]} · {computer.handle}
+                      </span>
+                    </span>
+                    <span className="flex w-4 items-center justify-center">
+                      <DropdownMenu.ItemIndicator>
+                        <Check size={13} className="shrink-0" style={{ color: "var(--accent)" }} aria-hidden="true" />
+                      </DropdownMenu.ItemIndicator>
+                    </span>
+                  </DropdownMenu.RadioItem>
+                );
+              })}
+            </DropdownMenu.RadioGroup>
+            <DropdownMenu.Item
               aria-label="Retry computers"
               disabled={loadStatus === "loading"}
-              className="rounded p-1 hover:bg-[var(--bg-hover)] disabled:opacity-40"
+              className="absolute right-2 top-1.5 rounded p-1 outline-none data-[disabled]:opacity-40 data-[highlighted]:bg-[var(--bg-hover)]"
               style={{ color: "var(--text-tertiary)" }}
-              onClick={() => void refresh({ force: true })}
+              onSelect={(event) => {
+                event.preventDefault();
+                void refresh({ force: true });
+              }}
             >
               <RefreshCw size={12} className={loadStatus === "loading" ? "animate-spin" : ""} aria-hidden="true" />
-            </button>
-          </div>
-          {loadStatus === "error" ? (
-            <p className="px-2 py-3 text-xs" style={{ color: "var(--text-secondary)" }}>Computers unavailable</p>
-          ) : null}
-          {loadStatus === "loading" && computers.length === 0 ? (
-            <p className="flex items-center gap-2 px-2 py-3 text-xs" style={{ color: "var(--text-secondary)" }}>
-              <LoaderCircle size={13} className="animate-spin" aria-hidden="true" /> Loading computers…
-            </p>
-          ) : null}
-          <div className="max-h-72 overflow-y-auto">
-            {computers.map((computer) => {
-              const selected = computer.runtimeSlot === selectedSlot;
-              const switching = switchingSlot === computer.runtimeSlot;
-              const disabled = selected || computer.availability !== "available" || Boolean(switchingSlot);
-              return (
-                <button
-                  key={computer.runtimeSlot}
-                  type="button"
-                  role="option"
-                  aria-selected={selected}
-                  disabled={disabled}
-                  className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left outline-none hover:bg-[var(--bg-hover)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:opacity-60"
-                  onClick={() => {
-                    setOpen(false);
-                    void select(computer.runtimeSlot);
-                  }}
-                >
-                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md" style={{ background: selected ? "var(--accent-muted)" : "var(--bg-hover)", color: selected ? "var(--accent)" : "var(--text-secondary)" }}>
-                    {switching ? <LoaderCircle size={14} className="animate-spin" aria-hidden="true" /> : <Monitor size={14} aria-hidden="true" />}
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate text-xs font-medium" style={{ color: "var(--text-primary)" }}>{computer.label}</span>
-                    <span className="block truncate text-[10px]" style={{ color: "var(--text-tertiary)" }}>
-                      {selected ? "Current" : STATUS_LABEL[computer.availability]} · {computer.handle}
-                    </span>
-                  </span>
-                  {selected ? <Check size={13} className="shrink-0" style={{ color: "var(--accent)" }} aria-hidden="true" /> : null}
-                </button>
-              );
-            })}
-          </div>
-          {switchError ? <p className="px-2 py-2 text-[11px]" style={{ color: "var(--danger)" }}>Couldn&apos;t switch computers. Try again.</p> : null}
-        </div>
-      ) : null}
-      <button
-        type="button"
-        aria-label={buttonLabel}
-        title={collapsed ? currentLabel : undefined}
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        className={`flex h-9 w-full items-center rounded-md transition-colors hover:bg-[var(--bg-hover)] ${collapsed ? "justify-center" : "gap-2 px-2"}`}
-        style={{ color: "var(--text-secondary)" }}
-        onClick={() => setOpen((value) => !value)}
-      >
-        <span className="relative flex h-6 w-6 shrink-0 items-center justify-center rounded-md" style={{ background: "var(--bg-hover)" }}>
-          <Monitor size={14} aria-hidden="true" />
-          <span className="absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full border" style={{ background: current?.availability === "available" ? "var(--success)" : loadStatus === "error" ? "var(--danger)" : "var(--warning)", borderColor: "var(--bg-sunken)" }} />
-        </span>
-        {!collapsed ? (
-          <>
-            <span className="min-w-0 flex-1 text-left">
-              <span className="block truncate text-xs font-medium" style={{ color: "var(--text-primary)" }}>{currentLabel}</span>
-              <span className="block truncate text-[10px]" style={{ color: "var(--text-tertiary)" }}>{current?.handle ?? handle ?? "Select computer"}</span>
-            </span>
-            <ChevronUp size={13} className="shrink-0 transition-transform" style={{ transform: open ? "rotate(180deg)" : undefined }} aria-hidden="true" />
-          </>
-        ) : null}
-      </button>
+            </DropdownMenu.Item>
+            {switchError ? <p aria-live="polite" className="px-2 py-2 text-[11px]" style={{ color: "var(--danger)" }}>Couldn&apos;t switch computers. Try again.</p> : null}
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
     </div>
   );
 }

--- a/tests/desktop/design-tokens.test.ts
+++ b/tests/desktop/design-tokens.test.ts
@@ -136,6 +136,18 @@ describe("tailwind text scale bridge", () => {
   });
 });
 
+describe("Desktop sidebar geometry tokens", () => {
+  const tokensCss = readRendererFile("design", "tokens.css");
+  const root = themeBlock(tokensCss, ":root");
+
+  it("defines the shared expanded, collapsed, row, and menu geometry", () => {
+    expect(tokenValue(root, "--sidebar-expanded-width")).toBe("240px");
+    expect(tokenValue(root, "--sidebar-collapsed-width")).toBe("56px");
+    expect(tokenValue(root, "--sidebar-row-height")).toBe("32px");
+    expect(tokenValue(root, "--sidebar-menu-width")).toBe("248px");
+  });
+});
+
 describe("tertiary text contrast (WCAG AA)", () => {
   const MIN_AA_CONTRAST = 4.5;
   const tokensCss = readRendererFile("design", "tokens.css");

--- a/tests/desktop/runtime-computer-menu.test.tsx
+++ b/tests/desktop/runtime-computer-menu.test.tsx
@@ -70,12 +70,34 @@ describe("sidebar computer menu", () => {
     render(<RuntimeComputerMenu collapsed={false} />);
 
     await waitFor(() => expect(screen.getByRole("button", { name: "Change computer, currently Main Computer" })).not.toBeNull());
-    fireEvent.click(screen.getByRole("button", { name: "Change computer, currently Main Computer" }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Change computer, currently Main Computer" }), { button: 0, ctrlKey: false });
 
-    expect(screen.getByRole("listbox", { name: "Choose computer" })).not.toBeNull();
-    expect(screen.getByRole("option", { name: /Main Computer.*Current/i })).not.toBeNull();
-    expect(screen.getByRole("option", { name: /Additional Computer.*Available/i })).not.toBeNull();
-    expect(screen.getByRole("option", { name: /Preview Computer.*Starting/i }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("menu", { name: "Choose computer" })).not.toBeNull();
+    expect(screen.getByRole("menuitemradio", { name: /Main Computer.*Current/i }).getAttribute("aria-checked")).toBe("true");
+    expect(screen.getByRole("menuitemradio", { name: /Additional Computer.*Available/i })).not.toBeNull();
+    expect(screen.getByRole("menuitemradio", { name: /Preview Computer.*Starting/i }).hasAttribute("data-disabled")).toBe(true);
+  });
+
+  it("opens from the keyboard and traverses computer choices", async () => {
+    const selectRuntime = vi.fn(async () => undefined);
+    useConnection.setState({ selectRuntime });
+    render(<RuntimeComputerMenu collapsed={false} />);
+
+    const trigger = await screen.findByRole("button", { name: /Change computer, currently Main Computer/i });
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    const menu = await screen.findByRole("menu", { name: "Choose computer" });
+    expect(menu).toBeTruthy();
+    const choices = screen.getAllByRole("menuitemradio");
+    expect(choices).toHaveLength(3);
+    expect(choices[0]?.getAttribute("aria-checked")).toBe("true");
+    await waitFor(() => expect(document.activeElement).toBe(choices[0]));
+
+    fireEvent.keyDown(choices[0]!, { key: "ArrowDown" });
+    await waitFor(() => expect(document.activeElement).toBe(choices[1]));
+    fireEvent.keyDown(choices[1]!, { key: "Enter" });
+    await waitFor(() => expect(selectRuntime).toHaveBeenCalledWith("review"));
+    expect(document.activeElement).toBe(trigger);
   });
 
   it("switches through trusted runtime selection and closes the menu", async () => {
@@ -83,11 +105,11 @@ describe("sidebar computer menu", () => {
     useConnection.setState({ selectRuntime });
     render(<RuntimeComputerMenu collapsed={false} />);
     await waitFor(() => expect(screen.getByText("Main Computer")).not.toBeNull());
-    fireEvent.click(screen.getByRole("button", { name: /Change computer/i }));
-    fireEvent.click(screen.getByRole("option", { name: /Additional Computer.*Available/i }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: /Change computer/i }), { button: 0, ctrlKey: false });
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /Additional Computer.*Available/i }));
 
     await waitFor(() => expect(selectRuntime).toHaveBeenCalledWith("review"));
-    expect(screen.queryByRole("listbox", { name: "Choose computer" })).toBeNull();
+    expect(screen.queryByRole("menu", { name: "Choose computer" })).toBeNull();
   });
 
   it("keeps failures safe and offers an inline retry", async () => {
@@ -96,10 +118,10 @@ describe("sidebar computer menu", () => {
     });
     render(<RuntimeComputerMenu collapsed={false} />);
     await waitFor(() => expect(screen.getByRole("button", { name: /Computer list unavailable/i })).not.toBeNull());
-    fireEvent.click(screen.getByRole("button", { name: /Computer list unavailable/i }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: /Computer list unavailable/i }), { button: 0, ctrlKey: false });
 
     expect(screen.getByText("Computers unavailable")).not.toBeNull();
-    expect(screen.getByRole("button", { name: "Retry computers" })).not.toBeNull();
+    expect(screen.getByRole("menuitem", { name: "Retry computers" })).not.toBeNull();
     expect(screen.queryByText(/raw-secret|\/home\/matrix/i)).toBeNull();
   });
 
@@ -186,11 +208,11 @@ describe("sidebar computer menu", () => {
 
     render(<RuntimeComputerMenu collapsed={false} />);
     await waitFor(() => expect(screen.getByRole("button", { name: "Change computer, currently Additional Computer" })).not.toBeNull());
-    fireEvent.click(screen.getByRole("button", { name: /Change computer/i }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: /Change computer/i }), { button: 0, ctrlKey: false });
 
-    expect(screen.getByRole("option", { name: /Additional Computer.*Current/i }).hasAttribute("disabled")).toBe(true);
-    const staleProfileOption = screen.getByRole("option", { name: /Main Computer.*Available/i });
-    expect(staleProfileOption.hasAttribute("disabled")).toBe(false);
+    expect(screen.getByRole("menuitemradio", { name: /Additional Computer.*Current/i }).getAttribute("aria-checked")).toBe("true");
+    const staleProfileOption = screen.getByRole("menuitemradio", { name: /Main Computer.*Available/i });
+    expect(staleProfileOption.hasAttribute("data-disabled")).toBe(false);
     fireEvent.click(staleProfileOption);
     await waitFor(() => expect(selectRuntime).toHaveBeenCalledWith("primary"));
   });
@@ -214,23 +236,22 @@ describe("sidebar computer menu", () => {
 
     render(<RuntimeComputerMenu collapsed={false} />);
     await waitFor(() => expect(screen.getByText("operator-0")).not.toBeNull());
-    fireEvent.click(screen.getByRole("button", { name: /Change computer/i }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: /Change computer/i }), { button: 0, ctrlKey: false });
 
-    const listbox = screen.getByRole("listbox", { name: "Choose computer" });
-    const scrollRegion = listbox.querySelector(".overflow-y-auto");
+    const menu = screen.getByRole("menu", { name: "Choose computer" });
+    const scrollRegion = menu.querySelector(".overflow-y-auto");
     expect(scrollRegion).not.toBeNull();
     expect(scrollRegion?.className).toMatch(/max-h-/);
-    expect(screen.getAllByRole("option")).toHaveLength(20);
+    expect(screen.getAllByRole("menuitemradio")).toHaveLength(20);
   });
 
   it("keeps the collapsed rail menu wide enough to read computer labels", async () => {
     render(<RuntimeComputerMenu collapsed />);
     await waitFor(() => expect(window.operator.invoke).toHaveBeenCalledWith("runtime:list-computers", {}));
-    fireEvent.click(screen.getByRole("button", { name: /Change computer/i }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: /Change computer/i }), { button: 0, ctrlKey: false });
 
-    const listbox = screen.getByRole("listbox", { name: "Choose computer" });
-    expect(listbox.className).toMatch(/w-64/);
-    expect(listbox.className).not.toMatch(/right-2/);
+    const menu = screen.getByRole("menu", { name: "Choose computer" });
+    expect(menu.style.width).toBe("var(--sidebar-menu-width)");
   });
 
   it("clears owner-scoped inventory when a signed-in session is replaced in place", async () => {

--- a/tests/desktop/runtime-computer-menu.test.tsx
+++ b/tests/desktop/runtime-computer-menu.test.tsx
@@ -97,7 +97,7 @@ describe("sidebar computer menu", () => {
     await waitFor(() => expect(document.activeElement).toBe(choices[1]));
     fireEvent.keyDown(choices[1]!, { key: "Enter" });
     await waitFor(() => expect(selectRuntime).toHaveBeenCalledWith("review"));
-    expect(document.activeElement).toBe(trigger);
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
   });
 
   it("switches through trusted runtime selection and closes the menu", async () => {
@@ -110,6 +110,21 @@ describe("sidebar computer menu", () => {
 
     await waitFor(() => expect(selectRuntime).toHaveBeenCalledWith("review"));
     expect(screen.queryByRole("menu", { name: "Choose computer" })).toBeNull();
+  });
+
+  it("keeps the menu open with generic feedback when runtime selection fails", async () => {
+    const selectRuntime = vi.fn(async () => {
+      throw new Error("/home/matrix/private token=raw-secret");
+    });
+    useConnection.setState({ selectRuntime });
+    render(<RuntimeComputerMenu collapsed={false} />);
+    await waitFor(() => expect(screen.getByText("Main Computer")).not.toBeNull());
+    fireEvent.pointerDown(screen.getByRole("button", { name: /Change computer/i }), { button: 0, ctrlKey: false });
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /Additional Computer.*Available/i }));
+
+    expect(await screen.findByText("Couldn't switch computers. Try again.")).not.toBeNull();
+    expect(screen.getByRole("menu", { name: "Choose computer" })).not.toBeNull();
+    expect(screen.queryByText(/raw-secret|\/home\/matrix/i)).toBeNull();
   });
 
   it("keeps failures safe and offers an inline retry", async () => {

--- a/tests/desktop/sidebar-navigation-shell.test.tsx
+++ b/tests/desktop/sidebar-navigation-shell.test.tsx
@@ -83,7 +83,7 @@ describe("Desktop sidebar navigation shell", () => {
     return render(<Tooltip.Provider><Sidebar /></Tooltip.Provider>);
   }
 
-  it("filters bounded Recents by conversation, terminal, and project type", () => {
+  it("filters bounded Recents by conversation, terminal, and project type", async () => {
     renderSidebar();
 
     expect(screen.getByText("Fix navigation")).toBeTruthy();
@@ -93,8 +93,8 @@ describe("Desktop sidebar navigation shell", () => {
     expect(screen.getByRole("button", { name: "Open recent dev" }).querySelector(".lucide-square-terminal")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Open recent Matrix OS" }).querySelector(".lucide-folder-kanban")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Filter recents" }));
-    fireEvent.click(screen.getByRole("button", { name: "Terminals" }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Filter recents" }), { button: 0, ctrlKey: false });
+    fireEvent.click(await screen.findByRole("menuitemradio", { name: "Terminals" }));
 
     expect(screen.queryByText("Fix navigation")).toBeNull();
     expect(screen.getByText("dev")).toBeTruthy();
@@ -175,25 +175,77 @@ describe("Desktop sidebar navigation shell", () => {
       .toBe(false);
   });
 
-  it("offers the approved account actions and routes them through current behavior", () => {
+  it("exposes the persistent navigation hierarchy and selected row semantics", () => {
+    useBoard.setState({
+      projects: [{ slug: "matrix-os", name: "Matrix OS", kind: "scratch" }],
+    });
+    renderSidebar();
+
+    const sidebar = screen.getByRole("complementary", { name: "Matrix OS navigation" });
+    expect(sidebar.getAttribute("data-sidebar-state")).toBe("expanded");
+    expect(sidebar.style.width).toBe("var(--sidebar-expanded-width)");
+    expect(screen.getByTestId("matrix-sidebar-logo")).toBeTruthy();
+
+    expect(screen.getByRole("button", { name: "Terminal" }).getAttribute("aria-current")).toBe("page");
+    expect(screen.getByRole("button", { name: "Home" }).getAttribute("aria-current")).toBeNull();
+
+    const projects = screen.getByRole("button", { name: "Projects" });
+    expect(projects.getAttribute("aria-expanded")).toBe("true");
+    expect(projects.getAttribute("aria-controls")).toBe("sidebar-projects");
+    expect(screen.getByRole("button", { name: "Open Matrix OS" })).toBeTruthy();
+
+    fireEvent.click(projects);
+    expect(projects.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByRole("button", { name: "Open Matrix OS" })).toBeNull();
+  });
+
+  it("keeps the collapsed rail labelled while hiding expanded-only chrome", () => {
+    useUi.setState({ sidebarCollapsed: true });
+    renderSidebar();
+
+    const sidebar = screen.getByRole("complementary", { name: "Matrix OS navigation" });
+    expect(sidebar.getAttribute("data-sidebar-state")).toBe("collapsed");
+    expect(sidebar.style.width).toBe("var(--sidebar-collapsed-width)");
+    expect(screen.queryByTestId("matrix-sidebar-logo")).toBeNull();
+    expect(screen.queryByText("Recents")).toBeNull();
+    expect(screen.queryByText("Projects")).toBeNull();
+    expect(screen.getByRole("button", { name: "Home" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open account menu" })).toBeTruthy();
+  });
+
+  it("opens Recents and account menus from the keyboard", async () => {
+    renderSidebar();
+
+    const recentsTrigger = screen.getByRole("button", { name: "Filter recents" });
+    fireEvent.keyDown(recentsTrigger, { key: "ArrowDown" });
+    expect(await screen.findByRole("menu", { name: "Recent type" })).toBeTruthy();
+    fireEvent.keyDown(document.activeElement ?? document, { key: "Escape" });
+
+    const accountTrigger = screen.getByRole("button", { name: "Open account menu" });
+    fireEvent.keyDown(accountTrigger, { key: "ArrowDown" });
+    expect(await screen.findByRole("menu", { name: "Account" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Settings" })).toBeTruthy();
+  });
+
+  it("offers the approved account actions and routes them through current behavior", async () => {
     renderSidebar();
     const trigger = screen.getByRole("button", { name: "Open account menu" });
 
-    fireEvent.click(trigger);
-    expect(screen.getByText("ada operator", { exact: false })).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    expect(await screen.findByText("ada operator", { exact: false })).toBeTruthy();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Settings" }));
     expect(useTabs.getState().tabs.find((tab) => tab.id === useTabs.getState().activeTabId)).toMatchObject({ kind: "settings" });
 
-    fireEvent.click(trigger);
-    fireEvent.click(screen.getByRole("button", { name: "View all plans" }));
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "View all plans" }));
     expect(useUi.getState().requestedSettingsSection).toBe("billing");
 
-    fireEvent.click(trigger);
-    fireEvent.click(screen.getByRole("button", { name: "Get help" }));
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Get help" }));
     expect(invoke).toHaveBeenCalledWith("shell:open-external", { url: "https://matrix-os.com/docs" });
 
-    fireEvent.click(trigger);
-    fireEvent.click(screen.getByRole("button", { name: "Log out" }));
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Log out" }));
     expect(signOut).toHaveBeenCalledOnce();
   });
 });

--- a/tests/desktop/sidebar-navigation-shell.test.tsx
+++ b/tests/desktop/sidebar-navigation-shell.test.tsx
@@ -163,6 +163,18 @@ describe("Desktop sidebar navigation shell", () => {
     expect(useThreads.getState().activeThreadId).toBeNull();
   });
 
+  it("marks only the active conversation type current when retained identifiers coexist", () => {
+    useTabs.getState().recordRecentHermesConversation("conversation-two", "Trip planning");
+    useTabs.getState().openTab({ kind: "chat", title: "Hermes", closable: false });
+    useThreads.setState({ activeThreadId: "thread-1" });
+    useHermesChat.setState({ view: "conversation", sessionId: "conversation-two" });
+
+    renderSidebar();
+
+    expect(screen.getByRole("button", { name: "Open recent Fix navigation" }).getAttribute("aria-current")).toBe("page");
+    expect(screen.getByRole("button", { name: "Open recent Trip planning" }).getAttribute("aria-current")).toBeNull();
+  });
+
   it("uses the global Chat navigation to return to the canonical inbox", () => {
     useHermesChat.setState({ view: "conversation", sessionId: "conversation-two" });
     renderSidebar();

--- a/tests/e2e/desktop/operator.e2e.test.ts
+++ b/tests/e2e/desktop/operator.e2e.test.ts
@@ -16,6 +16,7 @@ const desktopRequire = createRequire(resolve(__dirname, "../../../desktop/packag
 const ELECTRON_EXECUTABLE = desktopRequire("electron") as string;
 const SCREENSHOT_DIR = resolve(__dirname, "../../../desktop/screenshots");
 const MAT_322_SCREENSHOT_DIR = resolve(__dirname, "../../../output/playwright/mat-322");
+const MAT_327_SCREENSHOT_DIR = resolve(__dirname, "../../../output/playwright/mat-327");
 const hasBuild = existsSync(DESKTOP_MAIN);
 
 const suite = hasBuild ? describe : describe.skip;
@@ -32,7 +33,7 @@ async function openSettings(page: Page): Promise<void> {
     await sidebar.getByRole("button", { name: "Open account menu" }).click();
     await page
       .getByRole("menu", { name: "Account" })
-      .getByRole("button", { name: "Settings" })
+      .getByRole("menuitem", { name: "Settings" })
       .click();
   }
 
@@ -57,6 +58,7 @@ suite("operator desktop e2e", () => {
   beforeAll(async () => {
     mkdirSync(SCREENSHOT_DIR, { recursive: true });
     mkdirSync(MAT_322_SCREENSHOT_DIR, { recursive: true });
+    mkdirSync(MAT_327_SCREENSHOT_DIR, { recursive: true });
     gateway = await startStubGateway();
     userDataDir = mkdtempSync(join(tmpdir(), "operator-e2e-"));
     app = await _electron.launch({
@@ -291,12 +293,12 @@ suite("operator desktop e2e", () => {
     // Sidebar computer menu evidence: expanded rail, then the collapsed rail
     // popup that must keep a readable fixed width.
     await page.getByRole("button", { name: /Change computer, currently/ }).click();
-    await page.getByRole("listbox", { name: "Choose computer" }).waitFor({ timeout: 10_000 });
+    await page.getByRole("menu", { name: "Choose computer" }).waitFor({ timeout: 10_000 });
     await page.screenshot({ path: join(SCREENSHOT_DIR, "09d-computer-menu.png") });
     await page.keyboard.press("Escape");
     await page.getByRole("button", { name: /^Collapse sidebar/ }).click();
     await page.getByRole("button", { name: /Change computer, currently/ }).click();
-    await page.getByRole("listbox", { name: "Choose computer" }).waitFor({ timeout: 10_000 });
+    await page.getByRole("menu", { name: "Choose computer" }).waitFor({ timeout: 10_000 });
     await page.screenshot({ path: join(SCREENSHOT_DIR, "09e-computer-menu-collapsed.png") });
     await page.keyboard.press("Escape");
     await page.getByRole("button", { name: /^Expand sidebar/ }).click();
@@ -338,6 +340,12 @@ suite("operator desktop e2e", () => {
       name: "Plan the persistent Desktop conversation experience conversation",
     }).click();
     await page.getByText("The canonical Gateway conversation is ready to continue.").waitFor();
+    const hermesConversation = page.getByRole("region", { name: "Hermes conversation" });
+    await hermesConversation.getByLabel("Reply to Hermes…").fill("Plan the persistent Desktop conversation experience");
+    await hermesConversation.getByRole("button", { name: "Send" }).click();
+    await page.getByRole("button", {
+      name: "Open recent Plan the persistent Desktop conversation experience",
+    }).waitFor({ timeout: 10_000 });
 
     // The terminal palette follows the unified theme.
     await page.locator("aside button", { hasText: "Terminal" }).first().click();
@@ -352,14 +360,62 @@ suite("operator desktop e2e", () => {
     await page.screenshot({ path: join(SCREENSHOT_DIR, "16-theme-operator-default.png") });
   }, 40_000);
 
+  it("captures sidebar and computer-menu parity in light and dark at both widths", async () => {
+    const sidebar = page.getByRole("complementary", { name: "Matrix OS navigation" });
+
+    for (const mode of ["Light", "Dark"] as const) {
+      await openSettings(page);
+      await page.getByRole("button", { name: "Appearance" }).click();
+      await page.getByRole("button", { name: mode, exact: true }).click();
+      await page.waitForFunction(
+        (expected) => document.documentElement.getAttribute("data-theme") === expected,
+        mode.toLowerCase(),
+      );
+      await page.locator("aside button", { hasText: "Chat" }).first().click();
+
+      if (await sidebar.getAttribute("data-sidebar-state") === "collapsed") {
+        await page.getByRole("button", { name: /^Expand sidebar/ }).click();
+      }
+      await page.screenshot({
+        path: join(MAT_327_SCREENSHOT_DIR, `${mode.toLowerCase()}-expanded.png`),
+      });
+      await page.getByRole("button", { name: /Change computer, currently/ }).click();
+      await page.getByRole("menu", { name: "Choose computer" }).waitFor({ timeout: 10_000 });
+      await page.screenshot({
+        path: join(MAT_327_SCREENSHOT_DIR, `${mode.toLowerCase()}-expanded-menu.png`),
+      });
+      await page.keyboard.press("Escape");
+
+      await page.getByRole("button", { name: /^Collapse sidebar/ }).click();
+      await page.screenshot({
+        path: join(MAT_327_SCREENSHOT_DIR, `${mode.toLowerCase()}-collapsed.png`),
+      });
+      await page.getByRole("button", { name: /Change computer, currently/ }).click();
+      await page.getByRole("menu", { name: "Choose computer" }).waitFor({ timeout: 10_000 });
+      await page.screenshot({
+        path: join(MAT_327_SCREENSHOT_DIR, `${mode.toLowerCase()}-collapsed-menu.png`),
+      });
+      await page.keyboard.press("Escape");
+      await page.getByRole("button", { name: /^Expand sidebar/ }).click();
+    }
+
+    await openSettings(page);
+    await page.getByRole("button", { name: "Appearance" }).click();
+    await page.getByRole("button", { name: "System", exact: true }).last().click();
+  }, 40_000);
+
   it("keeps coding-agent navigation in global Recents instead of a Chat rail", async () => {
-    // The earlier computer switch cleared the workspace summary; opening the
-    // project refreshes it before selecting the canonical project chat.
+    // The earlier computer switch cleared the workspace summary. Create a
+    // project chat through the fixture-supported path so the successful run
+    // is promoted into the shared Recents section.
     await page.locator("aside button", { hasText: "Matrix OS" }).last().click();
     await page.getByRole("button", { name: "Board", exact: true }).waitFor({ timeout: 10_000 });
     await page.getByRole("button", { name: "Chats" }).click();
-    await page.getByRole("button", { name: "Chat fix the failing auth tests" }).click();
-    const recent = page.getByRole("button", { name: "Open recent fix the failing auth tests" });
+    await page.getByRole("button", { name: "New chat in Matrix OS" }).click();
+    await page.getByLabel("Message new chat").fill("verify global Recents navigation");
+    await page.getByRole("button", { name: "Send" }).focus();
+    await page.keyboard.press("Enter");
+    const recent = page.getByRole("button", { name: "Open recent verify global Recents navigation" });
     await recent.waitFor({ timeout: 10_000 });
 
     await page.locator("aside button", { hasText: "Chat" }).first().click();
@@ -370,7 +426,7 @@ suite("operator desktop e2e", () => {
     // Global Recents owns the route back to the project conversation.
     await recent.click();
     await page.getByRole("button", { name: "New chat in Matrix OS" }).waitFor({ timeout: 10_000 });
-    await page.getByRole("region", { name: "Conversation fix the failing auth tests" }).waitFor({ timeout: 10_000 });
+    await page.getByRole("region", { name: "Conversation verify global Recents navigation" }).waitFor({ timeout: 10_000 });
     await page.screenshot({ path: join(SCREENSHOT_DIR, "18-global-recent-routes-to-project.png") });
   }, 30_000);
 


### PR DESCRIPTION
## Summary

- Bring the persistent Desktop sidebar chrome to Figma parity: Matrix OS branding, navigation icons and selected states, Recents/Projects styling, and the user profile block.
- Restyle the Main Computer trigger and opened selector menu across expanded/collapsed sidebar states and light/dark themes.
- Replace hand-rolled popup behavior with accessible Radix menus while preserving existing tab, runtime-switching, account, and mounted-resource behavior.
- Add focused regression coverage and Electron screenshot evidence for all eight theme/width/menu combinations.

Linear: [MAT-327](https://linear.app/matrix-os/issue/MAT-327/finish-desktop-sidebar-and-computer-selector-figma-parity)

## Tests

- `bun run test -- --reporter=dot tests/desktop/sidebar-navigation-shell.test.tsx tests/desktop/runtime-computer-menu.test.tsx tests/desktop/design-tokens.test.ts` — 28 passed
- `bun run test:e2e -- tests/e2e/desktop/operator.e2e.test.ts` — 17 passed
- `bun run typecheck` — passed
- `bun run check:patterns:diff` — 0 violations
- `bun run build:desktop` — passed
- `git diff --check` — passed

The repo-wide `bun run test` was attempted, but this local environment has unrelated existing failures in default-app suites that require browser globals/canvas support; it was stopped after the affected Desktop suites passed independently.

## Review/Monitoring

- Monitor GitHub review threads and Greptile feedback on the latest commit.
- Resolve actionable findings until the latest trusted Greptile result is 5/5.
- Add `ready-for-ci` only after that result, then wait for label-triggered CI to pass.
- Do not merge as part of this workflow.
