### PR TITLE
fix(terminal): stop keeper from constraining zellij size

### DIFF
--- a/distro/customer-vps/host-bin/matrix-terminal-user-keeper.mjs
+++ b/distro/customer-vps/host-bin/matrix-terminal-user-keeper.mjs
@@ -186,14 +186,24 @@ function exitAfterChild(code, signal) {
   if (forcedKillTimer) clearTimeout(forcedKillTimer);
   const exitSignal = requestedSignal ?? signal;
   if (exitSignal) {
+    process.off("SIGTERM", handleSigterm);
+    process.off("SIGINT", handleSigint);
     process.kill(process.pid, exitSignal);
     return;
   }
   process.exit(code ?? 1);
 }
 
-process.on("SIGTERM", () => forwardSignal("SIGTERM"));
-process.on("SIGINT", () => forwardSignal("SIGINT"));
+function handleSigterm() {
+  forwardSignal("SIGTERM");
+}
+
+function handleSigint() {
+  forwardSignal("SIGINT");
+}
+
+process.on("SIGTERM", handleSigterm);
+process.on("SIGINT", handleSigint);
 
 // Start the server without a persistent interactive client. Zellij computes its
 // shared grid as the component-wise minimum across interactive clients, so the

--- a/distro/customer-vps/host-bin/matrix-terminal-user-keeper.mjs
+++ b/distro/customer-vps/host-bin/matrix-terminal-user-keeper.mjs
@@ -5,6 +5,8 @@ import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const MAX_DESCRIPTOR_BYTES = 64 * 1024;
+const SESSION_START_TIMEOUT_MS = 10_000;
+const FORCED_KILL_DELAY_MS = 2_000;
 const RUNTIME_ID_PATTERN = /^rt_[0-9a-f]{32}$/;
 const GENERATION_PATTERN = /^gen_[0-9a-f]{64}$/;
 const DESCRIPTOR_KEYS = new Set([
@@ -148,16 +150,8 @@ try {
   fail("runtime_asset_unavailable");
 }
 
-const zellijArgs = [
-  zellijPath,
-  "--session",
-  descriptor.sessionName,
-  "--new-session-with-layout",
-  layoutPath,
-];
-const command = zellijArgs.map(shellQuote).join(" ");
 const configDir = join(homePath, "system", "zellij");
-const child = spawn("/usr/bin/script", ["-qefc", command, "/dev/null"], {
+const childOptions = {
   cwd,
   env: {
     ...process.env,
@@ -173,27 +167,77 @@ const child = spawn("/usr/bin/script", ["-qefc", command, "/dev/null"], {
       ? launchEnvironment.PATH
       : `${homePath}/.local/bin:/opt/matrix/bin:/opt/matrix/runtime/node/bin:/usr/local/bin:/usr/bin:/bin`,
   },
-  stdio: "ignore",
-});
+};
 
+let child;
 let forcedKillTimer;
+let requestedSignal;
 function forwardSignal(signal) {
-  if (child.exitCode !== null || child.signalCode !== null) return;
+  requestedSignal ??= signal;
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
   child.kill(signal);
   if (!forcedKillTimer) {
-    forcedKillTimer = setTimeout(() => child.kill("SIGKILL"), 2_000);
+    forcedKillTimer = setTimeout(() => child?.kill("SIGKILL"), FORCED_KILL_DELAY_MS);
     forcedKillTimer.unref();
   }
 }
 
-process.on("SIGTERM", () => forwardSignal("SIGTERM"));
-process.on("SIGINT", () => forwardSignal("SIGINT"));
-child.once("error", () => fail("pty_start_failed"));
-child.once("exit", (code, signal) => {
+function exitAfterChild(code, signal) {
   if (forcedKillTimer) clearTimeout(forcedKillTimer);
-  if (signal) {
-    process.kill(process.pid, signal);
+  const exitSignal = requestedSignal ?? signal;
+  if (exitSignal) {
+    process.kill(process.pid, exitSignal);
     return;
   }
   process.exit(code ?? 1);
+}
+
+process.on("SIGTERM", () => forwardSignal("SIGTERM"));
+process.on("SIGINT", () => forwardSignal("SIGINT"));
+
+// Start the server without a persistent interactive client. Zellij computes its
+// shared grid as the component-wise minimum across interactive clients, so the
+// old headless 80x24 client permanently constrained every browser attachment.
+const starterArgs = [
+  "--new-session-with-layout",
+  layoutPath,
+  "attach", "--create-background", descriptor.sessionName,
+];
+const starterCommand = [zellijPath, ...starterArgs].map(shellQuote).join(" ");
+child = spawn("/usr/bin/script", ["-qefc", starterCommand, "/dev/null"], {
+  ...childOptions,
+  stdio: "ignore",
 });
+
+await new Promise((resolveStart) => {
+  let startTimedOut = false;
+  const startTimer = setTimeout(() => {
+    startTimedOut = true;
+    child.kill("SIGKILL");
+  }, SESSION_START_TIMEOUT_MS);
+  startTimer.unref();
+
+  child.once("error", () => {
+    clearTimeout(startTimer);
+    fail("session_start_failed");
+  });
+  child.once("exit", (_code, signal) => {
+    clearTimeout(startTimer);
+    if (requestedSignal || signal) exitAfterChild(null, signal);
+    if (startTimedOut) fail("session_start_timeout");
+    resolveStart();
+  });
+});
+if (requestedSignal) exitAfterChild(null, null);
+
+// A watcher keeps the user unit active and the Zellij server in its cgroup,
+// while remaining excluded from Zellij's interactive-client size arbitration.
+const watcherCommand = [zellijPath, "watch", descriptor.sessionName]
+  .map(shellQuote)
+  .join(" ");
+child = spawn("/usr/bin/script", ["-qefc", watcherCommand, "/dev/null"], {
+  ...childOptions,
+  stdio: "ignore",
+});
+child.once("error", () => fail("pty_start_failed"));
+child.once("exit", (code, signal) => exitAfterChild(code, signal));

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -92,6 +92,7 @@ ZELLIJ_ACTUAL_VERSION="$("$STAGE_DIR/bin/zellij" --version)"
   exit 1
 }
 timeout --signal=KILL 15s node "$ROOT_DIR/scripts/smoke-zellij-host-query.mjs" "$STAGE_DIR/bin/zellij"
+timeout --signal=KILL 15s node "$ROOT_DIR/scripts/smoke-zellij-watcher-sizing.mjs" "$STAGE_DIR/bin/zellij"
 TERMINAL_RUNTIME_GENERATION="$(
   "$ROOT_DIR/distro/customer-vps/host-bin/matrix-terminal-generation-id" \
     "$STAGE_DIR/bin/zellij" \

--- a/scripts/smoke-zellij-watcher-sizing.mjs
+++ b/scripts/smoke-zellij-watcher-sizing.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { spawn } from "node-pty";
+
+const execFileAsync = promisify(execFile);
+const TEST_TIMEOUT_MS = 10_000;
+const MAX_CAPTURE_BYTES = 64 * 1024;
+const INITIAL_SIZE = { cols: 160, rows: 60 };
+const RESIZED_SIZE = { cols: 132, rows: 44 };
+
+const zellijBinary = resolve(process.argv[2] ?? "");
+if (!process.argv[2]) {
+  console.error("usage: smoke-zellij-watcher-sizing.mjs <path-to-staged-zellij>");
+  process.exit(2);
+}
+await access(zellijBinary);
+
+const { stdout: versionOutput } = await execFileAsync(zellijBinary, ["--version"], {
+  timeout: 2_000,
+});
+const version = versionOutput.trim().replace(/^zellij\s+/, "");
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  throw new Error(`unexpected Zellij version output: ${versionOutput.trim()}`);
+}
+
+const testRoot = await mkdtemp(join(tmpdir(), "mzw-"));
+const homeDir = join(testRoot, "home");
+const configDir = join(testRoot, "config", "zellij");
+const cacheDir = join(testRoot, "cache");
+const dataDir = join(testRoot, "data");
+const runtimeDir = join(testRoot, "runtime");
+const tempDir = join(testRoot, "tmp");
+const configPath = join(configDir, "config.kdl");
+const layoutPath = join(testRoot, "layout.kdl");
+const probePath = join(testRoot, "pane-size-probe.mjs");
+const resultPath = join(testRoot, "pane-size.json");
+const sessionName = `mzw-${randomUUID().slice(0, 8)}`;
+const socketDir = join("/tmp", `${sessionName}-sockets`);
+
+await Promise.all([
+  mkdir(homeDir, { recursive: true }),
+  mkdir(configDir, { recursive: true }),
+  mkdir(cacheDir, { recursive: true }),
+  mkdir(dataDir, { recursive: true }),
+  mkdir(runtimeDir, { recursive: true }),
+  mkdir(tempDir, { recursive: true }),
+  mkdir(join(cacheDir, "zellij", version), { recursive: true }),
+]);
+await writeFile(join(cacheDir, "zellij", version, "seen_release_notes"), "");
+await writeFile(configPath, [
+  "pane_frames false",
+  "simplified_ui true",
+  "show_startup_tips false",
+  "session_serialization false",
+  "disable_session_metadata true",
+  "copy_on_select false",
+  "",
+].join("\n"));
+await writeFile(probePath, `
+import { writeFileSync } from "node:fs";
+
+const resultPath = process.argv[2];
+function recordSize() {
+  writeFileSync(resultPath, JSON.stringify({
+    cols: process.stdout.columns,
+    rows: process.stdout.rows,
+  }));
+}
+process.on("SIGWINCH", recordSize);
+setInterval(recordSize, 50);
+recordSize();
+`);
+await writeFile(layoutPath, `layout {
+  pane command="${process.execPath}" {
+    args "${probePath}" "${resultPath}"
+  }
+}
+`);
+
+const isolatedEnv = {
+  COLORTERM: "truecolor",
+  HOME: homeDir,
+  LANG: "C.UTF-8",
+  PATH: process.env.PATH ?? "/usr/bin:/bin",
+  SHELL: "/bin/sh",
+  TERM: "xterm-256color",
+  TMPDIR: tempDir,
+  XDG_CACHE_HOME: cacheDir,
+  XDG_CONFIG_HOME: join(testRoot, "config"),
+  XDG_DATA_HOME: dataDir,
+  XDG_RUNTIME_DIR: runtimeDir,
+  ZELLIJ_SOCKET_DIR: socketDir,
+  ZELLIJ_CONFIG_DIR: configDir,
+  ZELLIJ_CONFIG_FILE: configPath,
+};
+
+function answerHostQueries(terminal) {
+  let answered = false;
+  let capture = "";
+  return terminal.onData((data) => {
+    capture = (capture + data).slice(-MAX_CAPTURE_BYTES);
+    if (answered || !capture.includes("\x1b]4;255;?\x1b\\")) return;
+    answered = true;
+    const paletteReplies = Array.from({ length: 256 }, (_, index) => (
+      `\x1b]4;${index};rgb:ffff/0000/ffff\x1b\\`
+    )).join("");
+    terminal.write([
+      "\x1b[4;960;1440t",
+      "\x1b[6;24;12t",
+      "\x1b]11;rgb:0000/0000/0000\x1b\\",
+      "\x1b]10;rgb:ffff/ffff/ffff\x1b\\",
+      paletteReplies,
+    ].join(""));
+  });
+}
+
+async function waitForSize(expected) {
+  const deadline = Date.now() + TEST_TIMEOUT_MS;
+  let observed = null;
+  while (Date.now() < deadline) {
+    try {
+      observed = JSON.parse(await readFile(resultPath, "utf8"));
+      if (observed.cols === expected.cols && observed.rows === expected.rows) return;
+    } catch (error) {
+      const retryable = error instanceof SyntaxError
+        || (error instanceof Error && "code" in error && error.code === "ENOENT");
+      if (!retryable) throw error;
+    }
+    await new Promise((resolveWait) => setTimeout(resolveWait, 50));
+  }
+  throw new Error(
+    `pane size did not reach ${expected.cols}x${expected.rows}; observed ${JSON.stringify(observed)}`,
+  );
+}
+
+async function sessionExists() {
+  try {
+    const { stdout } = await execFileAsync(zellijBinary, ["list-sessions", "--short"], {
+      cwd: homeDir,
+      env: isolatedEnv,
+      timeout: 1_000,
+      maxBuffer: 64 * 1024,
+    });
+    return stdout.split("\n").includes(sessionName);
+  } catch (error) {
+    const diagnostic = error && typeof error === "object"
+      ? `${"stdout" in error ? error.stdout : ""} ${"stderr" in error ? error.stderr : ""}`
+      : String(error);
+    if (/No active (?:zellij )?sessions|failed to receive message/i.test(diagnostic)) return false;
+    throw error;
+  }
+}
+
+async function startDetachedSession() {
+  const starter = spawn(zellijBinary, [
+    "--new-session-with-layout", layoutPath,
+    "attach", "--create-background", sessionName,
+  ], {
+    name: "xterm-256color",
+    cols: 80,
+    rows: 24,
+    cwd: homeDir,
+    env: isolatedEnv,
+  });
+  const hostReplies = answerHostQueries(starter);
+  let exit;
+  starter.onExit((event) => {
+    exit = event;
+  });
+  const deadline = Date.now() + 5_000;
+  let created = false;
+  while (Date.now() < deadline) {
+    if (await sessionExists()) {
+      created = true;
+      break;
+    }
+    if (exit) {
+      hostReplies.dispose();
+      throw new Error(`detached Zellij startup exited with ${exit.signal ?? exit.exitCode}`);
+    }
+    await new Promise((resolveWait) => setTimeout(resolveWait, 50));
+  }
+  if (created) {
+    const exitDeadline = Date.now() + 2_000;
+    while (!exit && Date.now() < exitDeadline) {
+      await new Promise((resolveWait) => setTimeout(resolveWait, 25));
+    }
+    hostReplies.dispose();
+    if (!exit) {
+      starter.kill();
+      throw new Error("detached Zellij startup did not exit");
+    }
+    if (exit.exitCode !== 0) {
+      throw new Error(`detached Zellij startup exited with ${exit.signal ?? exit.exitCode}`);
+    }
+    return;
+  }
+  hostReplies.dispose();
+  starter.kill();
+  throw new Error("detached Zellij startup timed out");
+}
+
+async function assertTerminalStaysAlive(terminal, label) {
+  let exit;
+  const exitListener = terminal.onExit((event) => {
+    exit = event;
+  });
+  await new Promise((resolveWait) => setTimeout(resolveWait, 1_000));
+  exitListener.dispose();
+  if (exit) throw new Error(`${label} exited with ${exit.signal ?? exit.exitCode}`);
+}
+
+let watcher;
+let interactive;
+let watcherHostReplies;
+let interactiveHostReplies;
+try {
+  await startDetachedSession();
+
+  interactive = spawn(zellijBinary, ["attach", sessionName], {
+    name: "xterm-256color",
+    ...INITIAL_SIZE,
+    cwd: homeDir,
+    env: isolatedEnv,
+  });
+  interactiveHostReplies = answerHostQueries(interactive);
+  await waitForSize(INITIAL_SIZE);
+
+  watcher = spawn(zellijBinary, ["watch", sessionName], {
+    name: "xterm-256color",
+    cols: 80,
+    rows: 24,
+    cwd: homeDir,
+    env: isolatedEnv,
+  });
+  watcherHostReplies = answerHostQueries(watcher);
+  await assertTerminalStaysAlive(watcher, "watcher");
+
+  await waitForSize(INITIAL_SIZE);
+  interactive.resize(RESIZED_SIZE.cols, RESIZED_SIZE.rows);
+  await waitForSize(RESIZED_SIZE);
+
+  console.log(`Zellij watcher sizing smoke test passed for ${zellijBinary}`);
+} finally {
+  watcherHostReplies?.dispose();
+  interactiveHostReplies?.dispose();
+  watcher?.kill();
+  interactive?.kill();
+  try {
+    await execFileAsync(zellijBinary, ["kill-session", sessionName], {
+      cwd: homeDir,
+      env: isolatedEnv,
+      timeout: 2_000,
+    });
+  } catch (error) {
+    const diagnostic = error && typeof error === "object"
+      ? `${"message" in error ? error.message : ""} ${"stdout" in error ? error.stdout : ""} ${"stderr" in error ? error.stderr : ""}`
+      : String(error);
+    if (!/does not exist|failed to receive message|No active (?:zellij )?sessions|No session named/i.test(diagnostic)) {
+      throw error;
+    }
+  }
+  await Promise.all([
+    rm(testRoot, { recursive: true, force: true }),
+    rm(socketDir, { recursive: true, force: true }),
+  ]);
+}

--- a/scripts/spikes/user-systemd-terminal/production-acceptance.sh
+++ b/scripts/spikes/user-systemd-terminal/production-acceptance.sh
@@ -355,7 +355,7 @@ with os.fdopen(descriptor, encoding="utf-8") as source:
 after = json.loads(sys.argv[2])
 fields = (
     "runtimeId", "generation", "unit", "cgroup", "mainPid",
-    "zellijServerPid", "workloadPid",
+    "zellijServerPid", "zellijWatcherPid", "workloadPid",
 )
 if any(before.get(field) != after.get(field) for field in fields):
     raise SystemExit(1)
@@ -1328,6 +1328,7 @@ verify_deleted() {
   fi
   for pid in "$(json_field "$snapshot_file" mainPid)" \
     "$(json_field "$snapshot_file" zellijServerPid)" \
+    "$(json_field "$snapshot_file" zellijWatcherPid)" \
     "$(json_field "$snapshot_file" workloadPid)"; do
     if [ -r "/proc/${pid}/cgroup" ]; then
       ! grep -F -- "$cgroup" "/proc/${pid}/cgroup" >/dev/null
@@ -1630,6 +1631,7 @@ phase2() {
     write_progress "reboot-${role}-old-pids-detached"
     for pid in "$(json_field "$baseline" mainPid)" \
       "$(json_field "$baseline" zellijServerPid)" \
+      "$(json_field "$baseline" zellijWatcherPid)" \
       "$(json_field "$baseline" workloadPid)"; do
       if [ -r "/proc/${pid}/cgroup" ]; then
         ! grep -F -- "$old_cgroup" "/proc/${pid}/cgroup" >/dev/null

--- a/scripts/spikes/user-systemd-terminal/production-probe.mjs
+++ b/scripts/spikes/user-systemd-terminal/production-probe.mjs
@@ -222,6 +222,10 @@ const processes = (await Promise.all(pids.map(processEntry))).filter(Boolean);
 const zellij = processes
   .filter((entry) => entry.comm === "zellij" && !entry.args.includes("list-sessions"))
   .sort((left, right) => left.pid - right.pid);
+const zellijWatcher = zellij.find((entry) => (
+  entry.args.includes("watch") && entry.args.includes(descriptor.sessionName)
+));
+const zellijServer = zellij.find((entry) => entry.args.includes("--server"));
 const workload = workloadKind === "shell"
   ? processes.find((entry) => entry.args.some((argument) => argument.endsWith("/production-loop.mjs")))
   : processes.find((entry) => (
@@ -232,6 +236,8 @@ const mainPid = Number(properties.MainPID);
 if (!processes.some((entry) => entry.pid === mainPid)) fail("production_probe_roles_main_missing");
 if (zellij.length === 0) fail("production_probe_roles_zellij_0");
 if (zellij.length === 1) fail("production_probe_roles_zellij_1");
+if (!zellijServer) fail("production_probe_roles_server_missing");
+if (!zellijWatcher) fail("production_probe_roles_watcher_missing");
 if (!workload) fail("production_probe_roles_workload_missing");
 
 process.stdout.write(`${JSON.stringify({
@@ -244,7 +250,8 @@ process.stdout.write(`${JSON.stringify({
   unit,
   cgroup: properties.ControlGroup,
   mainPid,
-  zellijServerPid: zellij.at(-1).pid,
+  zellijServerPid: zellijServer.pid,
+  zellijWatcherPid: zellijWatcher.pid,
   workloadPid: workload.pid,
   memoryMax: properties.MemoryMax,
   tasksMax: properties.TasksMax,

--- a/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
+++ b/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
@@ -42,6 +42,8 @@ describe("customer VPS user-systemd terminal runtime", () => {
     expect(keeper).toContain('"attach", "--create-background", descriptor.sessionName');
     expect(keeper).toContain('"watch", descriptor.sessionName');
     expect(keeper).toContain("SESSION_START_TIMEOUT_MS");
+    expect(keeper).toContain('process.off("SIGTERM", handleSigterm)');
+    expect(keeper).toContain('process.off("SIGINT", handleSigint)');
     expect(keeper).not.toContain('"--session",');
     expect(keeper).not.toContain("descriptor.command");
     expect(keeper).not.toContain("descriptor.args");

--- a/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
+++ b/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
@@ -28,7 +28,7 @@ describe("customer VPS user-systemd terminal runtime", () => {
     expect(slice).toContain("TasksMax=");
   });
 
-  it("keeps command argv out of the descriptor-to-keeper boundary", () => {
+  it("creates runtimes detached and keeps them alive with a non-sizing watcher", () => {
     const keeper = readFileSync(
       join(root, "distro/customer-vps/host-bin/matrix-terminal-user-keeper.mjs"),
       "utf8",
@@ -39,6 +39,10 @@ describe("customer VPS user-systemd terminal runtime", () => {
     expect(keeper).toContain("generation");
     expect(keeper).toContain("/usr/bin/script");
     expect(keeper).toContain("--new-session-with-layout");
+    expect(keeper).toContain('"attach", "--create-background", descriptor.sessionName');
+    expect(keeper).toContain('"watch", descriptor.sessionName');
+    expect(keeper).toContain("SESSION_START_TIMEOUT_MS");
+    expect(keeper).not.toContain('"--session",');
     expect(keeper).not.toContain("descriptor.command");
     expect(keeper).not.toContain("descriptor.args");
     expect(keeper).not.toContain("eval(");
@@ -57,12 +61,20 @@ describe("customer VPS user-systemd terminal runtime", () => {
   it("ships immutable helper/Zellij generations and globally installed user units", () => {
     const build = readFileSync(join(root, "scripts/build-host-bundle.sh"), "utf8");
     const cloudInit = readFileSync(join(root, "distro/customer-vps/cloud-init.yaml"), "utf8");
+    const sizingSmoke = readFileSync(
+      join(root, "scripts/smoke-zellij-watcher-sizing.mjs"),
+      "utf8",
+    );
 
     expect(build).toContain('"$STAGE_DIR/terminal-runtime/generations/$TERMINAL_RUNTIME_GENERATION"');
     expect(build).toContain('"$STAGE_DIR/user-systemd"');
     expect(build).toContain("TERMINAL_RUNTIME_GENERATION");
     expect(build).toContain("matrix-terminal-generation-id");
     expect(build).toContain("matrix-terminal-attach.mjs");
+    expect(build).toContain("smoke-zellij-watcher-sizing.mjs");
+    expect(sizingSmoke).toContain('spawn(zellijBinary, ["watch", sessionName]');
+    expect(sizingSmoke).toContain("const INITIAL_SIZE = { cols: 160, rows: 60 }");
+    expect(sizingSmoke).toContain("interactive.resize(RESIZED_SIZE.cols, RESIZED_SIZE.rows)");
     expect(build).toContain("bin app runtime systemd user-systemd terminal-runtime release.json");
     expect(cloudInit).toContain("/etc/systemd/user");
     expect(cloudInit).toContain("systemctl --user daemon-reload");
@@ -315,6 +327,9 @@ describe("customer VPS user-systemd terminal runtime", () => {
     expect(probe).toContain("/ws/terminal");
     expect(probe).toContain('message?.type === "attached"');
     expect(probe).toContain('message?.type === "error"');
+    expect(probe).toContain("production_probe_roles_server_missing");
+    expect(probe).toContain("production_probe_roles_watcher_missing");
+    expect(probe).toContain("zellijWatcherPid");
     expect(probe).toContain('`server-${safeCode}`');
     expect(probe).toContain("production_probe_runtime_unavailable");
     expect(probe).toContain("recordAttachStatus");


### PR DESCRIPTION
## Summary
- create user-systemd Zellij sessions detached, then keep each unit alive with a read-only `zellij watch` client that does not participate in terminal size arbitration
- add a real-Zellij bundle smoke test covering a 160x60 interactive client, an 80x24 watcher, and an interactive resize to 132x44
- make production acceptance identify and preserve both the Zellij server and watcher roles across continuity, deletion, and reboot checks
- preserve shutdown semantics by removing keeper signal handlers before re-raising a terminating signal

## Tests
- `bun run test -- tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts tests/gateway/user-systemd-terminal-runtime.test.ts tests/gateway/user-systemd-zellij-runtime.test.ts tests/gateway/user-systemd-zellij-adapter.test.ts tests/platform/customer-vps-host-bundle.test.ts` — passed, 107 tests
- `bun run typecheck` — passed
- `bun run check:patterns` — passed with 0 violations and 5 pre-existing warnings
- `node scripts/smoke-zellij-watcher-sizing.mjs /opt/homebrew/bin/zellij` — passed against Zellij 0.44.3
- syntax checks and `git diff --check` — passed
- local `bun run test` — attempted; the full suite is not green in this Node 26 environment because unrelated browser suites cannot initialize localStorage, along with existing git-fixture failures and runtime timeouts. The run was stopped after the unrelated failure pattern was established.
- label-gated GitHub CI — passed: pattern scan, docs contracts, React Doctor, typecheck, sync client package, production shell build, all four unit-test shards, E2E, and aggregate CI result

## Review/Monitoring
- Greptile: 5/5 on `fefa408b4`
- reviewer P1 shutdown-race finding fixed, acknowledged, and resolved
- Claude review: passed with no actionable comments
- `ready-for-ci`: applied; all triggered CI passed

## Invariants
- **Source of truth:** the descriptor-pinned immutable Zellij generation and its user-systemd unit remain authoritative for each terminal runtime
- **Lock/transaction scope:** no database writes or locks changed; the systemd unit cgroup remains the runtime owner
- **Acceptable orphan states:** none added; detached startup is bounded to 10 seconds, startup failure fails the unit, and `KillMode=control-group` drains descendants
- **Auth source of truth:** unchanged; gateway and terminal-session authentication remain authoritative
- **Deferred scope:** already-running generations and sessions require the normal host-bundle deployment and runtime recreation path to pick up the keeper behavior