### PR TITLE
fix(vps): preserve local state across reboot updates

### DIFF
--- a/distro/customer-vps/host-bin/matrix-restore.sh
+++ b/distro/customer-vps/host-bin/matrix-restore.sh
@@ -21,8 +21,39 @@ else
   snapshot_key_pattern="system/runtime-slots/${runtime_slot}/db/snapshots/*.dump"
 fi
 
+if [ -L "$restore_flag" ] || { [ -e "$restore_flag" ] && [ ! -f "$restore_flag" ]; }; then
+  echo "matrix-restore: invalid restore completion marker" >&2
+  exit 1
+fi
+if [ -f "$restore_flag" ]; then
+  echo "matrix-restore: local restore already completed"
+  exit 0
+fi
+
 mkdir -p /home/matrix/home /home/matrix/projects /var/lib/matrix/db
-rm -f "$restore_flag"
+
+mark_restore_complete() {
+  local incoming=""
+  cleanup_restore_marker() {
+    if [ -n "$incoming" ]; then
+      rm -f -- "$incoming"
+    fi
+  }
+  trap cleanup_restore_marker EXIT
+  trap 'cleanup_restore_marker; exit 1' HUP INT TERM
+  incoming="$(mktemp "${restore_flag}.incoming.XXXXXX")" || {
+    echo "matrix-restore: failed to create restore completion marker" >&2
+    exit 1
+  }
+  chmod 0644 "$incoming"
+  if ! mv -Tf -- "$incoming" "$restore_flag"; then
+    rm -f -- "$incoming"
+    echo "matrix-restore: failed to commit restore completion marker" >&2
+    exit 1
+  fi
+  incoming=""
+  trap - EXIT HUP INT TERM
+}
 
 check_r2_exists() {
   local key="$1"
@@ -47,13 +78,13 @@ check_r2_exists "$latest_pointer_key" "latest snapshot pointer" || latest_pointe
 
 if [ "$vps_meta_status" -eq 44 ] && [ "$latest_pointer_status" -eq 44 ]; then
   # First installation: neither registration metadata nor a backup exists.
-  touch "$restore_flag"
+  mark_restore_complete
   exit 0
 fi
 if [ "$vps_meta_status" -eq 0 ] && [ "$latest_pointer_status" -eq 44 ]; then
   # A registered host may reboot before its first scheduled backup. Its local
   # Postgres volume remains authoritative until the first pointer is written.
-  touch "$restore_flag"
+  mark_restore_complete
   exit 0
 fi
 
@@ -121,4 +152,4 @@ if ! timeout 300 pg_restore \
   exit 1
 fi
 
-touch "$restore_flag"
+mark_restore_complete

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -828,6 +828,13 @@ apply_update() {
     sudo find "$extract_dir/systemd" -maxdepth 1 -name 'matrix-*.service' -exec install -o root -g root -m 0644 {} /etc/systemd/system/ \;
     sudo systemctl daemon-reload
     log "Installed systemd units"
+    if [ -f "$extract_dir/systemd/matrix-sync-agent.service" ]; then
+      if sudo systemctl enable matrix-sync-agent.service; then
+        log "Sync agent service enabled"
+      else
+        log "WARN: failed to enable matrix-sync-agent.service"
+      fi
+    fi
     if [ -f "$extract_dir/systemd/matrix-code-server.service" ]; then
       sudo systemctl enable matrix-code-server.service
       sudo systemctl start --no-block matrix-code-server.service || true
@@ -1121,6 +1128,11 @@ maybe_clean_staging() {
 
 # ── Main loop ────────────────────────────────────────────────────────
 log "Started for ${MATRIX_MACHINE_ID} (version: $(current_version))"
+if sudo systemctl enable matrix-sync-agent.service; then
+  log "Sync agent boot persistence ensured"
+else
+  log "WARN: failed to enable matrix-sync-agent.service"
+fi
 if [ -x "$BIN_DIR/matrix-ensure-swap" ]; then
   sudo "$BIN_DIR/matrix-ensure-swap" || log "WARN: swap ensure failed (non-fatal)"
 fi

--- a/distro/customer-vps/matrix-restore.sh
+++ b/distro/customer-vps/matrix-restore.sh
@@ -21,8 +21,39 @@ else
   snapshot_key_pattern="system/runtime-slots/${runtime_slot}/db/snapshots/*.dump"
 fi
 
+if [ -L "$restore_flag" ] || { [ -e "$restore_flag" ] && [ ! -f "$restore_flag" ]; }; then
+  echo "matrix-restore: invalid restore completion marker" >&2
+  exit 1
+fi
+if [ -f "$restore_flag" ]; then
+  echo "matrix-restore: local restore already completed"
+  exit 0
+fi
+
 mkdir -p /home/matrix/home /home/matrix/projects /var/lib/matrix/db
-rm -f "$restore_flag"
+
+mark_restore_complete() {
+  local incoming=""
+  cleanup_restore_marker() {
+    if [ -n "$incoming" ]; then
+      rm -f -- "$incoming"
+    fi
+  }
+  trap cleanup_restore_marker EXIT
+  trap 'cleanup_restore_marker; exit 1' HUP INT TERM
+  incoming="$(mktemp "${restore_flag}.incoming.XXXXXX")" || {
+    echo "matrix-restore: failed to create restore completion marker" >&2
+    exit 1
+  }
+  chmod 0644 "$incoming"
+  if ! mv -Tf -- "$incoming" "$restore_flag"; then
+    rm -f -- "$incoming"
+    echo "matrix-restore: failed to commit restore completion marker" >&2
+    exit 1
+  fi
+  incoming=""
+  trap - EXIT HUP INT TERM
+}
 
 check_r2_exists() {
   local key="$1"
@@ -47,13 +78,13 @@ check_r2_exists "$latest_pointer_key" "latest snapshot pointer" || latest_pointe
 
 if [ "$vps_meta_status" -eq 44 ] && [ "$latest_pointer_status" -eq 44 ]; then
   # First installation: neither registration metadata nor a backup exists.
-  touch "$restore_flag"
+  mark_restore_complete
   exit 0
 fi
 if [ "$vps_meta_status" -eq 0 ] && [ "$latest_pointer_status" -eq 44 ]; then
   # A registered host may reboot before its first scheduled backup. Its local
   # Postgres volume remains authoritative until the first pointer is written.
-  touch "$restore_flag"
+  mark_restore_complete
   exit 0
 fi
 
@@ -121,4 +152,4 @@ if ! timeout 300 pg_restore \
   exit 1
 fi
 
-touch "$restore_flag"
+mark_restore_complete

--- a/specs/070-vps-per-user/contracts/customer-host.md
+++ b/specs/070-vps-per-user/contracts/customer-host.md
@@ -52,7 +52,7 @@ Secrets under `/opt/matrix/env/` must be owned by `root:matrix` and mode `0640` 
 
 | Unit | Type | Required Ordering |
 |------|------|-------------------|
-| `matrix-restore.service` | oneshot | Runs before gateway/shell; writes restore-complete flag. |
+| `matrix-restore.service` | oneshot | Runs before gateway/shell; preserves or atomically writes the durable restore-complete flag. |
 | `matrix-gateway.service` | service | Requires restore-complete flag and Postgres container. |
 | `matrix-shell.service` | service | Starts after gateway dependencies. |
 | `matrix-sync-agent.service` | service | Starts on boot; handles files and heartbeat. |
@@ -85,13 +85,16 @@ The callback must retry with bounded exponential backoff for transient network f
 
 ## Restore-Or-Fresh Contract
 
-On every boot before gateway start:
+Before gateway start:
 
-1. Fetch `system/vps-meta.json`.
-2. If absent, create fresh home/projects dirs and write restore-complete flag.
-3. If present, sync files from spec 066 layout.
-4. If `system/db/latest` exists, download latest snapshot, stop Postgres if needed, restore DB, and only then write restore-complete flag.
-5. If restore fails, do not start gateway. Log locally and expose failure through status/heartbeat when possible.
+1. Treat a regular `/opt/matrix/restore-complete` file as durable proof that this installed host already completed its restore-or-fresh decision. Preserve it and use the machine-local Postgres volume without contacting R2.
+2. Reject symlinked or non-regular completion markers and keep the gateway stopped.
+3. When the marker is absent on a sanitized clean or replacement image, fetch `system/vps-meta.json` and `system/db/latest`.
+4. If neither object exists, or registration exists before the first backup, initialize from the machine-local state and atomically write the completion marker.
+5. If a latest snapshot exists, download it, restore Postgres, and atomically write the completion marker only after `pg_restore` succeeds.
+6. If the first-boot/replacement restore fails, do not start the gateway. Log locally and expose failure through status/heartbeat when possible.
+
+Golden-image sanitization must remove the completion marker. Ordinary service restarts, host reboots, and bundle updates must not remove it or replace newer local state with an older remote snapshot.
 
 ## Backup Contract
 

--- a/specs/070-vps-per-user/spec.md
+++ b/specs/070-vps-per-user/spec.md
@@ -181,12 +181,12 @@ Reuses the spec 066 sync engine. Runs as `matrix-sync-agent.service`. Two respon
 - **Files**: bidirectional sync of `~/home` and `~/projects` against `{userId}/manifest.json`, exactly per 066.
 - **System state**: pushes `system/vps-meta.json` heartbeat every 5 min, updates `lastSyncAt`. DB backup goes through `matrix-db-backup.timer` (separate unit) but writes into the same R2 prefix.
 
-On boot, sync agent runs a **restore-or-fresh** decision:
-1. Fetch `system/vps-meta.json`. If absent: fresh user, mark complete, signal gateway to start.
-2. If present, check `system/db/latest`. If absent: file-only user, sync files, signal gateway.
-3. If both present: stop postgres if running, download latest snapshot, `pg_restore`, write `/var/run/matrix-restore-complete`, signal gateway.
+Before gateway startup, `matrix-restore.service` runs a **restore-or-fresh** decision:
+1. If the durable regular `/opt/matrix/restore-complete` marker exists, preserve it and keep the machine-local Postgres volume authoritative. Ordinary reboots and bundle updates do not contact R2 or replay an older snapshot.
+2. If the marker is absent on a sanitized clean or replacement host, fetch `system/vps-meta.json` and `system/db/latest`. Confirmed absence initializes from local state; an available snapshot is restored with `pg_restore`.
+3. Atomically write the marker only after the fresh/restore decision succeeds. Reject invalid marker types and fail closed on operational R2 or restore errors.
 
-Gateway systemd unit has `ConditionPathExists=/var/run/matrix-restore-complete` so it cannot serve traffic mid-restore.
+Gateway systemd units require `matrix-restore.service` and use `ConditionPathExists=/opt/matrix/restore-complete`, so they cannot serve traffic during a clean/replacement restore.
 
 ### 5. DB backup (customer VPS)
 

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -103,16 +103,27 @@ describe('platform/customer-vps-cloud-init', () => {
 
   function runRestoreWithFakeMatrixctl(
     existsStatus: number | { vpsMeta: number; latestPointer: number },
+    options: { preexistingRestoreFlag?: 'file' | 'symlink' } = {},
   ) {
     const root = process.cwd();
     const tempDir = mkdtempSync(join(tmpdir(), 'second-restore-r2-'));
     const fakeMatrixctlPath = join(tempDir, 'matrixctl');
     const restorePath = join(tempDir, 'matrix-restore.sh');
     const restoreFlag = join(tempDir, 'restore-complete');
+    const matrixctlCalls = join(tempDir, 'matrixctl-calls');
+
+    if (options.preexistingRestoreFlag === 'file') {
+      writeFileSync(restoreFlag, 'completed\n');
+    } else if (options.preexistingRestoreFlag === 'symlink') {
+      const symlinkTarget = join(tempDir, 'restore-marker-target');
+      writeFileSync(symlinkTarget, 'untrusted\n');
+      symlinkSync(symlinkTarget, restoreFlag);
+    }
 
     writeFileSync(
       fakeMatrixctlPath,
       `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> ${JSON.stringify(matrixctlCalls)}
 if [ "$1" = "r2" ] && [ "$2" = "exists" ]; then
   if [ "$3" = "system/vps-meta.json" ]; then
     exit ${typeof existsStatus === 'number' ? existsStatus : existsStatus.vpsMeta}
@@ -150,6 +161,7 @@ exit 99
       return {
         result,
         restoreFlagExists: existsSync(restoreFlag),
+        matrixctlCalls: existsSync(matrixctlCalls) ? readFileSync(matrixctlCalls, 'utf8') : '',
       };
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
@@ -702,11 +714,15 @@ exit 99
       expect(script).toContain('local status');
       expect(script).toMatch(/else\n\s+status="\$[?]"/);
       expect(script).toContain('if [ "$status" -eq 44 ]; then');
-      expect(script).toContain('touch "$restore_flag"');
+      expect(script).toContain('mark_restore_complete()');
+      expect(script).toContain('mv -Tf -- "$incoming" "$restore_flag"');
+      expect(script).toContain('trap cleanup_restore_marker EXIT');
+      expect(script).toContain("trap 'cleanup_restore_marker; exit 1' HUP INT TERM");
       expect(script).toContain('matrix-restore: failed to check');
       expect(script).not.toContain('if ! /opt/matrix/bin/matrixctl r2 exists system/vps-meta.json; then');
       expect(script).not.toContain('if ! /opt/matrix/bin/matrixctl r2 exists "$latest_pointer_key"; then');
     }
+    expect(bundled).toBe(restore);
   });
 
   it('executes restore skip only for not-found R2 exists status', () => {
@@ -736,6 +752,22 @@ exit 99
     expect(backupWithoutMetadata.result.status).toBe(1);
     expect(backupWithoutMetadata.restoreFlagExists).toBe(false);
     expect(backupWithoutMetadata.result.stderr).toContain('matrix-restore: failed to fetch latest pointer');
+  });
+
+  it('keeps a completed local restore authoritative across ordinary reboots', () => {
+    const reboot = runRestoreWithFakeMatrixctl(1, { preexistingRestoreFlag: 'file' });
+
+    expect(reboot.result.status, reboot.result.stderr).toBe(0);
+    expect(reboot.restoreFlagExists).toBe(true);
+    expect(reboot.matrixctlCalls).toBe('');
+  });
+
+  it('rejects a symlinked restore marker without contacting R2', () => {
+    const reboot = runRestoreWithFakeMatrixctl(1, { preexistingRestoreFlag: 'symlink' });
+
+    expect(reboot.result.status).toBe(1);
+    expect(reboot.result.stderr).toContain('matrix-restore: invalid restore completion marker');
+    expect(reboot.matrixctlCalls).toBe('');
   });
 
   it('fails customer-host R2 operations for unreadable config or a non-EU endpoint', () => {

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -1233,6 +1233,15 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(syncAgent).toContain('rm -f "$temp_file"');
     expect(syncAgent).toContain("sudo find \"$extract_dir/systemd\" -maxdepth 1 -name 'matrix-*.service'");
     expect(syncAgent).toContain('sudo systemctl daemon-reload');
+    expect(syncAgent).toContain([
+      'if [ -f "$extract_dir/systemd/matrix-sync-agent.service" ]; then',
+      '      if sudo systemctl enable matrix-sync-agent.service; then',
+      '        log "Sync agent service enabled"',
+      '      else',
+      '        log "WARN: failed to enable matrix-sync-agent.service"',
+      '      fi',
+      '    fi',
+    ].join('\n'));
     expect(syncAgent).toContain('sudo systemctl enable matrix-code-server.service');
     expect(syncAgent).toContain('sudo systemctl start --no-block matrix-code-server.service || true');
     expect(syncAgent).toContain('sudo systemctl enable matrix-developer-tools.service');
@@ -1245,8 +1254,11 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(syncAgent).toContain('sudo systemctl enable matrix-homeserver.service matrix-bridge-telegram.service matrix-bridge-whatsapp.service');
     const daemonReload = syncAgent.indexOf('sudo systemctl daemon-reload');
     const gatewayStart = syncAgent.indexOf('sudo systemctl start matrix-gateway matrix-shell', daemonReload);
+    const mainLoop = syncAgent.indexOf('# ── Main loop');
+    const startupEnable = syncAgent.indexOf('sudo systemctl enable matrix-sync-agent.service', mainLoop);
     expect(daemonReload).toBeGreaterThan(-1);
     expect(gatewayStart).toBeGreaterThan(daemonReload);
+    expect(startupEnable).toBeGreaterThan(mainLoop);
   });
 
   it('bounds the terminal user-manager reload before app replacement', () => {


### PR DESCRIPTION
## Summary

- preserve `/opt/matrix/restore-complete` as a durable same-host restore decision so ordinary reboots and bundle service restarts keep the newer machine-local PostgreSQL volume authoritative
- atomically create the marker on clean/replacement initialization, reject symlinked or non-regular markers, and clean interrupted marker temp files
- make `matrix-sync-agent.service` enable itself both while installing units and when the newly installed agent starts, so the release carrying this fix heals legacy disabled agents immediately
- align the customer-host restore contract with the implemented same-host versus clean/replacement boundary

## Tests

- `pnpm exec vitest run tests/platform/customer-vps-cloud-init.test.ts tests/platform/customer-vps-host-bundle.test.ts` (104 passed on the final head)
- `bun run test:golden-snapshots` (517 passed before the cleanup-only marker hardening; the affected 104 tests were rerun on the final head)
- `bun run check:patterns:diff` (0 violations; repository-wide pre-existing warnings only)
- `bash -n distro/customer-vps/matrix-restore.sh distro/customer-vps/host-bin/matrix-restore.sh distro/customer-vps/host-bin/matrix-sync-agent`
- `git diff --check`

## Review / Monitoring

- opened through the `worktree-pr-monitor` workflow from a clean manual worktree based on the exact `origin/main` head
- do not add `ready-for-ci` until trusted Greptile reports 5/5 on the current PR head and all actionable review feedback is resolved

## Invariants

- **Source of truth:** a regular root-controlled `/opt/matrix/restore-complete` marks a completed restore-or-fresh decision for this installed host. The local PostgreSQL volume remains authoritative afterward. A sanitized clean/replacement image has no marker and must make the fail-closed R2 restore decision before serving.
- **Lock / transaction scope:** no database or control-plane writes are added. Marker persistence uses a same-directory temporary file plus atomic rename; systemd's oneshot restore unit serializes normal execution.
- **Acceptable orphan states:** interrupted marker writes are removed by exit/signal traps. If the process is killed without trap execution, an `.incoming.*` file is ignored and cannot satisfy the exact completion-marker gate; a later run creates a distinct temporary file. A failed service enable is logged and the running sync agent continues retrying updates.
- **Auth source of truth:** unchanged. The restore unit remains root-owned/systemd-controlled, and the sync agent uses the existing `matrix` service identity and provisioned sudo policy. No endpoint or customer authorization boundary changes.
- **Deferred scope:** repairing invalid legacy R2 endpoint/backup configuration on existing VPSes and deploying the resulting release fleet-wide remain separate operator actions. This PR prevents that configuration issue from blocking ordinary reboot/update service startup once a host has completed restore; it does not weaken clean/replacement restore failure handling.
