### PR TITLE
fix(desktop): add hosted Home refresh recovery

### DIFF
--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -58,8 +58,8 @@ export class EmbedService {
   private readonly pendingActive = new Map<string, boolean>();
   private readonly hostedShellIds = new Set<string>();
   private hostedShellRefreshTimer: ReturnType<typeof setTimeout> | null = null;
-  private hostedShellRefreshInFlight: Promise<HandoffResult> | null = null;
-  private hostedShellRefreshInFlightGeneration: number | null = null;
+  private hostedShellHandoffInFlight: Promise<HandoffResult> | null = null;
+  private hostedShellHandoffInFlightGeneration: number | null = null;
   private hostedShellRefreshGatewayOrigin: string | null = null;
   private hostedShellGeneration = 0;
 
@@ -145,7 +145,7 @@ export class EmbedService {
     if (this.pendingHostedShells.has(embedId)) {
       const bounds = this.pendingHostedShells.get(embedId)!;
       const gatewayOrigin = this.deps.getGatewayOrigin();
-      const handoff = await this.performHostedShellHandoff(gatewayOrigin);
+      const handoff = await this.runHostedShellHandoff(gatewayOrigin);
       if (!handoff.ok) {
         if (this.pendingHostedShells.has(embedId)) {
           this.deps.emitState(embedId, "auth-required");
@@ -183,7 +183,8 @@ export class EmbedService {
     }
     if (!this.manager.has(embedId)) return false;
     if (this.hostedShellIds.has(embedId)) {
-      const handoff = await this.performHostedShellHandoff(this.deps.getGatewayOrigin());
+      const handoff = await this.runHostedShellHandoff(this.deps.getGatewayOrigin());
+      if (!this.manager.has(embedId) || !this.hostedShellIds.has(embedId)) return false;
       if (!handoff.ok) {
         this.deps.emitState(embedId, "auth-required");
         return false;
@@ -226,7 +227,11 @@ export class EmbedService {
 
   private async openHostedShell(gatewayOrigin: string, bounds: Bounds, active: boolean): Promise<OpenResult> {
     const embedId = randomUUID();
+    const generation = this.hostedShellGeneration;
     const opened = await this.createHostedShellEmbed(gatewayOrigin, bounds, embedId, active);
+    if (generation !== this.hostedShellGeneration) {
+      return { embedId, state: "failed" };
+    }
     if (!opened) {
       this.rememberPendingHostedShell(embedId, bounds, active);
       return { embedId, state: "auth-required" };
@@ -253,7 +258,7 @@ export class EmbedService {
     embedId: string,
     active: boolean,
   ): Promise<boolean> {
-    const handoff = await this.performHostedShellHandoff(gatewayOrigin);
+    const handoff = await this.runHostedShellHandoff(gatewayOrigin);
     if (!handoff.ok) return false;
     this.attachHostedShellEmbed(gatewayOrigin, bounds, embedId, active);
     return true;
@@ -282,6 +287,49 @@ export class EmbedService {
       },
       "/",
     );
+  }
+
+  private async runHostedShellHandoff(gatewayOrigin: string): Promise<HandoffResult> {
+    const generation = this.hostedShellGeneration;
+    if (
+      this.hostedShellHandoffInFlight &&
+      this.hostedShellHandoffInFlightGeneration === generation
+    ) {
+      return this.hostedShellHandoffInFlight;
+    }
+    const priorHandoff = this.hostedShellHandoffInFlight;
+    const priorGeneration = this.hostedShellHandoffInFlightGeneration;
+    let handoff!: Promise<HandoffResult>;
+    handoff = (async () => {
+      try {
+        if (priorHandoff && priorGeneration !== generation) {
+          try {
+            await priorHandoff;
+          } catch (err: unknown) {
+            console.warn(
+              "[embed-service] prior hosted-shell handoff failed during runtime reset:",
+              err instanceof Error ? err.message : String(err),
+            );
+          }
+        }
+        if (generation !== this.hostedShellGeneration) {
+          return { ok: false, reason: "unavailable" };
+        }
+        const result = await this.performHostedShellHandoff(gatewayOrigin);
+        if (generation !== this.hostedShellGeneration) {
+          return { ok: false, reason: "unavailable" };
+        }
+        return result;
+      } finally {
+        if (this.hostedShellHandoffInFlight === handoff) {
+          this.hostedShellHandoffInFlight = null;
+          this.hostedShellHandoffInFlightGeneration = null;
+        }
+      }
+    })();
+    this.hostedShellHandoffInFlight = handoff;
+    this.hostedShellHandoffInFlightGeneration = generation;
+    return handoff;
   }
 
   private clearHostedShellRefreshTimer(): void {
@@ -356,57 +404,23 @@ export class EmbedService {
 
   private async refreshHostedShellSession(gatewayOrigin: string): Promise<HandoffResult> {
     const generation = this.hostedShellGeneration;
-    if (
-      this.hostedShellRefreshInFlight &&
-      this.hostedShellRefreshInFlightGeneration === generation
-    ) {
-      return this.hostedShellRefreshInFlight;
-    }
     if (this.hostedShellIds.size === 0) {
       this.clearHostedShellRefreshTimer();
       return { ok: false, reason: "unavailable" };
     }
-    const priorRefresh = this.hostedShellRefreshInFlight;
-    const priorGeneration = this.hostedShellRefreshInFlightGeneration;
-    let refresh!: Promise<HandoffResult>;
-    refresh = (async () => {
-      try {
-        if (priorRefresh && priorGeneration !== generation) {
-          try {
-            await priorRefresh;
-          } catch (err: unknown) {
-            console.warn(
-              "[embed-service] prior hosted-shell refresh failed during runtime reset:",
-              err instanceof Error ? err.message : String(err),
-            );
-          }
-          if (generation !== this.hostedShellGeneration || this.hostedShellIds.size === 0) {
-            return { ok: false, reason: "unavailable" };
-          }
-        }
-        const result = await this.performHostedShellHandoff(gatewayOrigin);
-        if (generation !== this.hostedShellGeneration || this.hostedShellIds.size === 0) {
-          return { ok: false, reason: "unavailable" };
-        }
-        if (result.ok) {
-          this.scheduleHostedShellSessionRefresh(gatewayOrigin);
-        } else if (result.reason === "unavailable") {
-          this.scheduleHostedShellSessionRefresh(gatewayOrigin, HOSTED_SHELL_SESSION_REFRESH_RETRY_MS);
-        } else {
-          this.clearHostedShellRefreshTimer();
-          this.emitHostedShellAuthRequired();
-        }
-        return result;
-      } finally {
-        if (this.hostedShellRefreshInFlight === refresh) {
-          this.hostedShellRefreshInFlight = null;
-          this.hostedShellRefreshInFlightGeneration = null;
-        }
-      }
-    })();
-    this.hostedShellRefreshInFlight = refresh;
-    this.hostedShellRefreshInFlightGeneration = generation;
-    return refresh;
+    const result = await this.runHostedShellHandoff(gatewayOrigin);
+    if (generation !== this.hostedShellGeneration || this.hostedShellIds.size === 0) {
+      return { ok: false, reason: "unavailable" };
+    }
+    if (result.ok) {
+      this.scheduleHostedShellSessionRefresh(gatewayOrigin);
+    } else if (result.reason === "unavailable") {
+      this.scheduleHostedShellSessionRefresh(gatewayOrigin, HOSTED_SHELL_SESSION_REFRESH_RETRY_MS);
+    } else {
+      this.clearHostedShellRefreshTimer();
+      this.emitHostedShellAuthRequired();
+    }
+    return result;
   }
 
   private async openApp(gatewayOrigin: string, slug: string, bounds: Bounds, active: boolean): Promise<OpenResult> {

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -59,7 +59,9 @@ export class EmbedService {
   private readonly hostedShellIds = new Set<string>();
   private hostedShellRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   private hostedShellRefreshInFlight: Promise<HandoffResult> | null = null;
+  private hostedShellRefreshInFlightGeneration: number | null = null;
   private hostedShellRefreshGatewayOrigin: string | null = null;
+  private hostedShellGeneration = 0;
 
   constructor(deps: EmbedServiceDeps) {
     this.deps = deps;
@@ -104,8 +106,12 @@ export class EmbedService {
 
   async reload(embedId: string): Promise<boolean> {
     if (this.hostedShellIds.has(embedId)) {
+      const generation = this.hostedShellGeneration;
       const refreshed = await this.refreshHostedShellSession(this.deps.getGatewayOrigin());
       if (!refreshed.ok) return false;
+      if (generation !== this.hostedShellGeneration || !this.hostedShellIds.has(embedId)) {
+        return false;
+      }
     }
     return this.manager.reload(embedId);
   }
@@ -114,14 +120,16 @@ export class EmbedService {
     const wasPending = this.pendingHostedShells.delete(embedId);
     const wasPendingApp = this.pendingApps.delete(embedId);
     this.pendingActive.delete(embedId);
-    this.hostedShellIds.delete(embedId);
-    if (this.hostedShellIds.size === 0) {
+    const wasHostedShell = this.hostedShellIds.delete(embedId);
+    if (wasHostedShell && this.hostedShellIds.size === 0) {
+      this.hostedShellGeneration += 1;
       this.clearHostedShellRefreshTimer();
     }
     return this.manager.close(embedId) || wasPending || wasPendingApp;
   }
 
   closeAll(): void {
+    this.hostedShellGeneration += 1;
     this.pendingHostedShells.clear();
     this.pendingApps.clear();
     this.pendingActive.clear();
@@ -283,20 +291,24 @@ export class EmbedService {
   }
 
   private scheduleHostedShellSessionRefresh(gatewayOrigin: string, delayMs?: number): void {
+    const generation = this.hostedShellGeneration;
     this.hostedShellRefreshGatewayOrigin = gatewayOrigin;
     if (this.hostedShellRefreshTimer) clearTimeout(this.hostedShellRefreshTimer);
     this.hostedShellRefreshTimer = null;
     if (this.hostedShellIds.size === 0) return;
 
     if (delayMs !== undefined) {
-      this.armHostedShellRefreshTimer(gatewayOrigin, delayMs);
+      this.armHostedShellRefreshTimer(gatewayOrigin, delayMs, generation);
       return;
     }
 
     void this.readHostedShellRefreshDelay()
       .then((delay) => {
-        if (this.hostedShellRefreshGatewayOrigin === gatewayOrigin) {
-          this.armHostedShellRefreshTimer(gatewayOrigin, delay);
+        if (
+          generation === this.hostedShellGeneration &&
+          this.hostedShellRefreshGatewayOrigin === gatewayOrigin
+        ) {
+          this.armHostedShellRefreshTimer(gatewayOrigin, delay, generation);
         }
       })
       .catch((err: unknown) => {
@@ -304,16 +316,30 @@ export class EmbedService {
           "[embed-service] unable to read hosted-shell session expiry:",
           err instanceof Error ? err.message : String(err),
         );
-        if (this.hostedShellRefreshGatewayOrigin === gatewayOrigin) {
-          this.armHostedShellRefreshTimer(gatewayOrigin, HOSTED_SHELL_SESSION_REFRESH_RETRY_MS);
+        if (
+          generation === this.hostedShellGeneration &&
+          this.hostedShellRefreshGatewayOrigin === gatewayOrigin
+        ) {
+          this.armHostedShellRefreshTimer(
+            gatewayOrigin,
+            HOSTED_SHELL_SESSION_REFRESH_RETRY_MS,
+            generation,
+          );
         }
       });
   }
 
-  private armHostedShellRefreshTimer(gatewayOrigin: string, delayMs: number): void {
+  private armHostedShellRefreshTimer(
+    gatewayOrigin: string,
+    delayMs: number,
+    generation = this.hostedShellGeneration,
+  ): void {
+    if (generation !== this.hostedShellGeneration || this.hostedShellIds.size === 0) return;
     if (this.hostedShellRefreshTimer) clearTimeout(this.hostedShellRefreshTimer);
     this.hostedShellRefreshTimer = setTimeout(() => {
-      void this.refreshHostedShellSession(gatewayOrigin);
+      if (generation === this.hostedShellGeneration) {
+        void this.refreshHostedShellSession(gatewayOrigin);
+      }
     }, Math.max(0, delayMs));
   }
 
@@ -329,15 +355,39 @@ export class EmbedService {
   }
 
   private async refreshHostedShellSession(gatewayOrigin: string): Promise<HandoffResult> {
-    if (this.hostedShellRefreshInFlight) return this.hostedShellRefreshInFlight;
+    const generation = this.hostedShellGeneration;
+    if (
+      this.hostedShellRefreshInFlight &&
+      this.hostedShellRefreshInFlightGeneration === generation
+    ) {
+      return this.hostedShellRefreshInFlight;
+    }
     if (this.hostedShellIds.size === 0) {
       this.clearHostedShellRefreshTimer();
       return { ok: false, reason: "unavailable" };
     }
+    const priorRefresh = this.hostedShellRefreshInFlight;
+    const priorGeneration = this.hostedShellRefreshInFlightGeneration;
     let refresh!: Promise<HandoffResult>;
     refresh = (async () => {
       try {
+        if (priorRefresh && priorGeneration !== generation) {
+          try {
+            await priorRefresh;
+          } catch (err: unknown) {
+            console.warn(
+              "[embed-service] prior hosted-shell refresh failed during runtime reset:",
+              err instanceof Error ? err.message : String(err),
+            );
+          }
+          if (generation !== this.hostedShellGeneration || this.hostedShellIds.size === 0) {
+            return { ok: false, reason: "unavailable" };
+          }
+        }
         const result = await this.performHostedShellHandoff(gatewayOrigin);
+        if (generation !== this.hostedShellGeneration || this.hostedShellIds.size === 0) {
+          return { ok: false, reason: "unavailable" };
+        }
         if (result.ok) {
           this.scheduleHostedShellSessionRefresh(gatewayOrigin);
         } else if (result.reason === "unavailable") {
@@ -350,10 +400,12 @@ export class EmbedService {
       } finally {
         if (this.hostedShellRefreshInFlight === refresh) {
           this.hostedShellRefreshInFlight = null;
+          this.hostedShellRefreshInFlightGeneration = null;
         }
       }
     })();
     this.hostedShellRefreshInFlight = refresh;
+    this.hostedShellRefreshInFlightGeneration = generation;
     return refresh;
   }
 

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -58,7 +58,7 @@ export class EmbedService {
   private readonly pendingActive = new Map<string, boolean>();
   private readonly hostedShellIds = new Set<string>();
   private hostedShellRefreshTimer: ReturnType<typeof setTimeout> | null = null;
-  private hostedShellRefreshInFlight = false;
+  private hostedShellRefreshInFlight: Promise<HandoffResult> | null = null;
   private hostedShellRefreshGatewayOrigin: string | null = null;
 
   constructor(deps: EmbedServiceDeps) {
@@ -102,9 +102,10 @@ export class EmbedService {
     return this.manager.setActive(embedId, active) || pending;
   }
 
-  reload(embedId: string): boolean {
+  async reload(embedId: string): Promise<boolean> {
     if (this.hostedShellIds.has(embedId)) {
-      this.scheduleHostedShellSessionRefresh(this.deps.getGatewayOrigin());
+      const refreshed = await this.refreshHostedShellSession(this.deps.getGatewayOrigin());
+      if (!refreshed.ok) return false;
     }
     return this.manager.reload(embedId);
   }
@@ -328,26 +329,32 @@ export class EmbedService {
   }
 
   private async refreshHostedShellSession(gatewayOrigin: string): Promise<HandoffResult> {
-    if (this.hostedShellRefreshInFlight) return { ok: false, reason: "unavailable" };
+    if (this.hostedShellRefreshInFlight) return this.hostedShellRefreshInFlight;
     if (this.hostedShellIds.size === 0) {
       this.clearHostedShellRefreshTimer();
       return { ok: false, reason: "unavailable" };
     }
-    this.hostedShellRefreshInFlight = true;
-    try {
-      const result = await this.performHostedShellHandoff(gatewayOrigin);
-      if (result.ok) {
-        this.scheduleHostedShellSessionRefresh(gatewayOrigin);
-      } else if (result.reason === "unavailable") {
-        this.scheduleHostedShellSessionRefresh(gatewayOrigin, HOSTED_SHELL_SESSION_REFRESH_RETRY_MS);
-      } else {
-        this.clearHostedShellRefreshTimer();
-        this.emitHostedShellAuthRequired();
+    let refresh!: Promise<HandoffResult>;
+    refresh = (async () => {
+      try {
+        const result = await this.performHostedShellHandoff(gatewayOrigin);
+        if (result.ok) {
+          this.scheduleHostedShellSessionRefresh(gatewayOrigin);
+        } else if (result.reason === "unavailable") {
+          this.scheduleHostedShellSessionRefresh(gatewayOrigin, HOSTED_SHELL_SESSION_REFRESH_RETRY_MS);
+        } else {
+          this.clearHostedShellRefreshTimer();
+          this.emitHostedShellAuthRequired();
+        }
+        return result;
+      } finally {
+        if (this.hostedShellRefreshInFlight === refresh) {
+          this.hostedShellRefreshInFlight = null;
+        }
       }
-      return result;
-    } finally {
-      this.hostedShellRefreshInFlight = false;
-    }
+    })();
+    this.hostedShellRefreshInFlight = refresh;
+    return refresh;
   }
 
   private async openApp(gatewayOrigin: string, slug: string, bounds: Bounds, active: boolean): Promise<OpenResult> {

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -102,6 +102,13 @@ export class EmbedService {
     return this.manager.setActive(embedId, active) || pending;
   }
 
+  reload(embedId: string): boolean {
+    if (this.hostedShellIds.has(embedId)) {
+      this.scheduleHostedShellSessionRefresh(this.deps.getGatewayOrigin());
+    }
+    return this.manager.reload(embedId);
+  }
+
   close(embedId: string): boolean {
     const wasPending = this.pendingHostedShells.delete(embedId);
     const wasPendingApp = this.pendingApps.delete(embedId);

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -292,6 +292,7 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
   handle("embed:set-active", ({ embedId, active }) => ({
     ok: ctx.embeds.setActive(embedId, active),
   }));
+  handle("embed:reload", ({ embedId }) => ({ ok: ctx.embeds.reload(embedId) }));
   handle("embed:close", ({ embedId }) => ({ ok: ctx.embeds.close(embedId) }));
   handle("embed:retry-auth", async ({ embedId }) => {
     try {

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -292,7 +292,7 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
   handle("embed:set-active", ({ embedId, active }) => ({
     ok: ctx.embeds.setActive(embedId, active),
   }));
-  handle("embed:reload", ({ embedId }) => ({ ok: ctx.embeds.reload(embedId) }));
+  handle("embed:reload", async ({ embedId }) => ({ ok: await ctx.embeds.reload(embedId) }));
   handle("embed:close", ({ embedId }) => ({ ok: ctx.embeds.close(embedId) }));
   handle("embed:retry-auth", async ({ embedId }) => {
     try {

--- a/desktop/src/main/platform/menu-template.ts
+++ b/desktop/src/main/platform/menu-template.ts
@@ -34,6 +34,11 @@ export function createAppMenuTemplate({
       accelerator: "Cmd+Alt+T",
       click: () => send("menu:navigate", { kind: "terminals" }),
     },
+    {
+      label: "Refresh Home",
+      accelerator: "CmdOrCtrl+R",
+      click: () => send("menu:action", { action: "refresh-home" }),
+    },
   ];
 
   viewSubmenu.push(
@@ -60,7 +65,7 @@ export function createAppMenuTemplate({
     { role: "togglefullscreen" },
     ...(isPackaged
       ? []
-      : ([{ type: "separator" }, { role: "reload" }, { role: "toggleDevTools" }] as MenuItemConstructorOptions[])),
+      : ([{ type: "separator" }, { role: "toggleDevTools" }] as MenuItemConstructorOptions[])),
   );
 
   return [

--- a/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
+++ b/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
@@ -12,15 +12,18 @@ export default function EmbedHost({
   kind,
   slug,
   active = true,
+  refreshRequest,
 }: {
   kind: "hosted-shell" | "app";
   slug?: string;
   active?: boolean;
+  refreshRequest?: number;
 }) {
   const runtimeSlot = useConnection((connection) => connection.runtimeSlot);
   const hostRef = useRef<HTMLDivElement>(null);
   const embedIdRef = useRef<string | null>(null);
   const activeRef = useRef(active);
+  const lastRefreshRequestRef = useRef(refreshRequest);
   activeRef.current = active;
   const [state, setState] = useState<"loading" | "ready" | "auth-required" | "failed">("loading");
 
@@ -110,6 +113,24 @@ export default function EmbedHost({
     if (active) reportBounds();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active]);
+
+  useEffect(() => {
+    if (refreshRequest === undefined || refreshRequest === lastRefreshRequestRef.current) return;
+    lastRefreshRequestRef.current = refreshRequest;
+    const id = embedIdRef.current;
+    if (!id || !activeRef.current) return;
+    setState("loading");
+    void invoke("embed:reload", { embedId: id })
+      .then((result) => {
+        if (embedIdRef.current !== id) return;
+        if (result.ok) reportBounds();
+        else setState("failed");
+      })
+      .catch(() => {
+        if (embedIdRef.current === id) setState("failed");
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refreshRequest]);
 
   return (
     <div ref={hostRef} className="relative min-h-0 flex-1" style={{ background: "var(--bg-app)" }}>

--- a/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
+++ b/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
@@ -25,6 +25,7 @@ export default function EmbedHost({
   const activeRef = useRef(active);
   const lastRefreshRequestRef = useRef(refreshRequest);
   activeRef.current = active;
+  const [openedEmbedRevision, setOpenedEmbedRevision] = useState(0);
   const [state, setState] = useState<"loading" | "ready" | "auth-required" | "failed">("loading");
 
   function reportBounds(): void {
@@ -75,6 +76,7 @@ export default function EmbedHost({
           return;
         }
         embedIdRef.current = embedId;
+        setOpenedEmbedRevision((revision) => revision + 1);
         setState(pendingStates.get(embedId) ?? initialState);
         pendingStates.delete(embedId);
         // Apply the current active state (handles a tab switch mid-open).
@@ -116,9 +118,9 @@ export default function EmbedHost({
 
   useEffect(() => {
     if (refreshRequest === undefined || refreshRequest === lastRefreshRequestRef.current) return;
-    lastRefreshRequestRef.current = refreshRequest;
     const id = embedIdRef.current;
     if (!id || !activeRef.current) return;
+    lastRefreshRequestRef.current = refreshRequest;
     setState("loading");
     void invoke("embed:reload", { embedId: id })
       .then((result) => {
@@ -130,7 +132,7 @@ export default function EmbedHost({
         if (embedIdRef.current === id) setState("failed");
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshRequest]);
+  }, [active, openedEmbedRevision, refreshRequest]);
 
   return (
     <div ref={hostRef} className="relative min-h-0 flex-1" style={{ background: "var(--bg-app)" }}>

--- a/desktop/src/renderer/src/features/mission-control/HomeTab.tsx
+++ b/desktop/src/renderer/src/features/mission-control/HomeTab.tsx
@@ -1,14 +1,18 @@
 import { useConnection } from "../../stores/connection";
+import { useUi } from "../../stores/ui";
 import EmbedHost from "../embeds/EmbedHost";
 
 // Home is just the user's live hosted Matrix OS shell, full-bleed. Navigation
 // (Chat, Board, Apps, Terminal) lives in the sidebar — no extra chrome here.
 export default function HomeTab({ active = true }: { active?: boolean }) {
   const signedIn = useConnection((s) => s.status === "signed-in");
+  const refreshRequest = useUi((state) => state.homeRefreshRequest);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {signedIn ? <EmbedHost kind="hosted-shell" active={active} /> : null}
+      {signedIn ? (
+        <EmbedHost kind="hosted-shell" active={active} refreshRequest={refreshRequest} />
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/renderer/src/features/mission-control/NavigationHeader.tsx
+++ b/desktop/src/renderer/src/features/mission-control/NavigationHeader.tsx
@@ -5,6 +5,7 @@ import {
   MoreHorizontal,
   PanelLeftClose,
   PanelLeftOpen,
+  RefreshCw,
 } from "lucide-react";
 import { Fragment } from "react";
 import { useHermesChat } from "../../stores/hermes-chat";
@@ -102,6 +103,7 @@ export default function NavigationHeader() {
   const closeTab = useTabs((state) => state.closeTab);
   const collapsed = useUi((state) => state.sidebarCollapsed);
   const toggleSidebar = useUi((state) => state.toggleSidebar);
+  const requestHomeRefresh = useUi((state) => state.requestHomeRefresh);
   const activeTab = tabs.find((tab) => tab.id === activeTabId);
   const activeThreadId = useThreads((state) => state.activeThreadId);
   const activeThreadTitle = useThreads((state) =>
@@ -160,6 +162,14 @@ export default function NavigationHeader() {
           </Fragment>
         ))}
       </nav>
+
+      {activeTab?.kind === "home" ? (
+        <div className="no-drag ml-auto">
+          <HeaderButton label="Refresh Home" onClick={requestHomeRefresh}>
+            <RefreshCw size={15} />
+          </HeaderButton>
+        </div>
+      ) : null}
 
       {activeTab?.closable ? (
         <DropdownMenu.Root>

--- a/desktop/src/renderer/src/features/mission-control/NavigationHeader.tsx
+++ b/desktop/src/renderer/src/features/mission-control/NavigationHeader.tsx
@@ -164,7 +164,7 @@ export default function NavigationHeader() {
       </nav>
 
       {activeTab?.kind === "home" ? (
-        <div className="no-drag ml-auto">
+        <div className="no-drag ml-1 shrink-0">
           <HeaderButton label="Refresh Home" onClick={requestHomeRefresh}>
             <RefreshCw size={15} />
           </HeaderButton>

--- a/desktop/src/renderer/src/features/mission-control/shortcuts.ts
+++ b/desktop/src/renderer/src/features/mission-control/shortcuts.ts
@@ -214,6 +214,11 @@ export function useGlobalShortcuts(): void {
       }
       if (action === "palette") ui.setPaletteOpen(!ui.paletteOpen);
       if (action === "quick-open") ui.setQuickOpenOpen(!ui.quickOpenOpen);
+      if (action === "refresh-home") {
+        const tabs = useTabs.getState();
+        const activeTab = tabs.tabs.find((tab) => tab.id === tabs.activeTabId);
+        if (activeTab?.kind === "home") ui.requestHomeRefresh();
+      }
     });
     const offNavigate = onEvent("menu:navigate", ({ kind }) => {
       handleMenuNavigate(kind);

--- a/desktop/src/renderer/src/stores/ui.ts
+++ b/desktop/src/renderer/src/stores/ui.ts
@@ -16,6 +16,7 @@ interface UiState {
   // active embed can detach until that surface closes.
   rendererOverlayCount: number;
   sidebarCollapsed: boolean;
+  homeRefreshRequest: number;
   // One-shot request for which Settings section the next Settings render
   // should select (consumed and cleared by SettingsView).
   requestedSettingsSection: string | null;
@@ -30,6 +31,7 @@ interface UiState {
   releaseRendererOverlay: () => void;
   toggleSidebar: () => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
+  requestHomeRefresh: () => void;
   requestSettingsSection: (section: string) => void;
   clearRequestedSettingsSection: () => void;
 }
@@ -43,6 +45,7 @@ export const useUi = create<UiState>()((set) => ({
   quickOpenOpen: false,
   rendererOverlayCount: 0,
   sidebarCollapsed: false,
+  homeRefreshRequest: 0,
   requestedSettingsSection: null,
   setCreateProjectOpen: (open) => set({ createProjectOpen: open }),
   openCreateProject: () => set({ createProjectOpen: true }),
@@ -59,6 +62,9 @@ export const useUi = create<UiState>()((set) => ({
   })),
   toggleSidebar: () => set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
   setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
+  requestHomeRefresh: () => set((state) => ({
+    homeRefreshRequest: (state.homeRefreshRequest + 1) % 1_000_000,
+  })),
   requestSettingsSection: (section) => set({ requestedSettingsSection: section }),
   clearRequestedSettingsSection: () => set({ requestedSettingsSection: null }),
 }));

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -322,6 +322,10 @@ export const INVOKE_CHANNELS = {
     request: z.object({ embedId: z.string().min(1).max(64), active: z.boolean() }).strict(),
     response: Ok,
   },
+  "embed:reload": {
+    request: z.object({ embedId: z.string().min(1).max(64) }).strict(),
+    response: Ok,
+  },
   "embed:close": {
     request: z.object({ embedId: z.string().min(1).max(64) }).strict(),
     response: Ok,
@@ -420,7 +424,7 @@ export const EVENT_CHANNELS = {
   "window:focus-changed": z.object({ focused: z.boolean() }).strict(),
   "app:zoom-changed": ZoomFactorResultSchema,
   "menu:action": z
-    .object({ action: z.enum(["new-task", "new-thread", "palette", "quick-open"]) })
+    .object({ action: z.enum(["new-task", "new-thread", "palette", "quick-open", "refresh-home"]) })
     .strict(),
   "menu:navigate": z.object({ kind: z.enum(["settings", "board", "project", "terminals"]) }).strict(),
 } as const;

--- a/tests/desktop/embed-host.test.tsx
+++ b/tests/desktop/embed-host.test.tsx
@@ -152,4 +152,18 @@ describe("EmbedHost", () => {
       );
     });
   });
+
+  it("reloads the retained native embed when the host receives a refresh request", async () => {
+    const view = render(<EmbedHost kind="hosted-shell" refreshRequest={0} />);
+    await act(async () => {
+      openResolve?.({ embedId: "embed-1", state: "loading" });
+    });
+    vi.mocked(invoke).mockClear();
+
+    view.rerender(<EmbedHost kind="hosted-shell" refreshRequest={1} />);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("embed:reload", { embedId: "embed-1" });
+    });
+  });
 });

--- a/tests/desktop/embed-host.test.tsx
+++ b/tests/desktop/embed-host.test.tsx
@@ -17,6 +17,7 @@ describe("EmbedHost", () => {
   let rect = { left: 10, top: 20, width: 300, height: 200 };
 
   beforeEach(() => {
+    vi.mocked(invoke).mockClear();
     useConnection.setState(useConnection.getInitialState(), true);
     useConnection.setState({ runtimeSlot: "primary" });
     openResolve = null;
@@ -161,6 +162,36 @@ describe("EmbedHost", () => {
     vi.mocked(invoke).mockClear();
 
     view.rerender(<EmbedHost kind="hosted-shell" refreshRequest={1} />);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("embed:reload", { embedId: "embed-1" });
+    });
+  });
+
+  it("keeps a refresh request pending until the retained embed finishes opening", async () => {
+    const view = render(<EmbedHost kind="hosted-shell" refreshRequest={0} />);
+    view.rerender(<EmbedHost kind="hosted-shell" refreshRequest={1} />);
+    expect(invoke).not.toHaveBeenCalledWith("embed:reload", expect.anything());
+
+    await act(async () => {
+      openResolve?.({ embedId: "embed-1", state: "loading" });
+    });
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("embed:reload", { embedId: "embed-1" });
+    });
+  });
+
+  it("keeps a refresh request pending while the retained embed is inactive", async () => {
+    const view = render(<EmbedHost kind="hosted-shell" active={false} refreshRequest={0} />);
+    await act(async () => {
+      openResolve?.({ embedId: "embed-1", state: "loading" });
+    });
+    vi.mocked(invoke).mockClear();
+
+    view.rerender(<EmbedHost kind="hosted-shell" active={false} refreshRequest={1} />);
+    expect(invoke).not.toHaveBeenCalledWith("embed:reload", expect.anything());
+    view.rerender(<EmbedHost kind="hosted-shell" active refreshRequest={1} />);
 
     await waitFor(() => {
       expect(invoke).toHaveBeenCalledWith("embed:reload", { embedId: "embed-1" });

--- a/tests/desktop/embed-service.test.ts
+++ b/tests/desktop/embed-service.test.ts
@@ -18,7 +18,7 @@ describe("EmbedService", () => {
     vi.restoreAllMocks();
   });
 
-  it("reloads a live embed through the existing bounded manager", () => {
+  it("reloads a live embed through the existing bounded manager", async () => {
     const service = new EmbedService({
       getWindow: () => null,
       getGatewayOrigin: () => "https://gateway.test",
@@ -30,7 +30,34 @@ describe("EmbedService", () => {
     };
     const reload = vi.spyOn(internals.manager, "reload").mockReturnValue(true);
 
-    expect(service.reload("embed-shell")).toBe(true);
+    await expect(service.reload("embed-shell")).resolves.toBe(true);
+    expect(reload).toHaveBeenCalledWith("embed-shell");
+  });
+
+  it("refreshes hosted-shell cookies before navigating the retained embed", async () => {
+    const service = new EmbedService({
+      getWindow: () => null,
+      getGatewayOrigin: () => "https://gateway.test",
+      getToken: () => "token",
+      emitState: vi.fn(),
+    });
+    const internals = service as unknown as {
+      hostedShellIds: Set<string>;
+      refreshHostedShellSession: (gatewayOrigin: string) => Promise<HandoffResult>;
+      manager: { reload: (embedId: string) => boolean };
+    };
+    let resolveRefresh!: (result: HandoffResult) => void;
+    vi.spyOn(internals, "refreshHostedShellSession").mockImplementation(
+      () => new Promise((resolve) => { resolveRefresh = resolve; }),
+    );
+    const reload = vi.spyOn(internals.manager, "reload").mockReturnValue(true);
+    internals.hostedShellIds.add("embed-shell");
+
+    const result = service.reload("embed-shell");
+    expect(reload).not.toHaveBeenCalled();
+    resolveRefresh({ ok: true });
+
+    await expect(result).resolves.toBe(true);
     expect(reload).toHaveBeenCalledWith("embed-shell");
   });
 

--- a/tests/desktop/embed-service.test.ts
+++ b/tests/desktop/embed-service.test.ts
@@ -61,6 +61,46 @@ describe("EmbedService", () => {
     expect(reload).toHaveBeenCalledWith("embed-shell");
   });
 
+  it("does not reuse or apply a stale hosted-shell handoff after runtime reset", async () => {
+    const service = new EmbedService({
+      getWindow: () => null,
+      getGatewayOrigin: () => "https://gateway.test",
+      getToken: () => "token",
+      emitState: vi.fn(),
+    });
+    const internals = service as unknown as {
+      hostedShellIds: Set<string>;
+      performHostedShellHandoff: (gatewayOrigin: string) => Promise<HandoffResult>;
+      scheduleHostedShellSessionRefresh: (gatewayOrigin: string) => void;
+      manager: { reload: (embedId: string) => boolean };
+    };
+    const handoffResolvers: Array<(result: HandoffResult) => void> = [];
+    const handoff = vi
+      .spyOn(internals, "performHostedShellHandoff")
+      .mockImplementation(
+        () => new Promise((resolve) => { handoffResolvers.push(resolve); }),
+      );
+    const reload = vi.spyOn(internals.manager, "reload").mockReturnValue(true);
+    vi.spyOn(internals, "scheduleHostedShellSessionRefresh").mockImplementation(() => {});
+
+    internals.hostedShellIds.add("old-shell");
+    const oldReload = service.reload("old-shell");
+
+    service.closeAll();
+    internals.hostedShellIds.add("new-shell");
+    const newReload = service.reload("new-shell");
+
+    expect(handoff).toHaveBeenCalledTimes(1);
+    handoffResolvers[0]?.({ ok: true });
+    await expect(oldReload).resolves.toBe(false);
+    expect(reload).not.toHaveBeenCalledWith("old-shell");
+
+    await vi.waitFor(() => expect(handoff).toHaveBeenCalledTimes(2));
+    handoffResolvers[1]?.({ ok: true });
+    await expect(newReload).resolves.toBe(true);
+    expect(reload).toHaveBeenCalledWith("new-shell");
+  });
+
   it("honors pending hosted-shell inactive state when retry auth finishes", async () => {
     const emitState = vi.fn();
     const service = new EmbedService({

--- a/tests/desktop/embed-service.test.ts
+++ b/tests/desktop/embed-service.test.ts
@@ -101,6 +101,107 @@ describe("EmbedService", () => {
     expect(reload).toHaveBeenCalledWith("new-shell");
   });
 
+  it("does not attach a stale hosted-shell open after runtime reset", async () => {
+    const service = new EmbedService({
+      getWindow: () => null,
+      getGatewayOrigin: () => "https://gateway.test",
+      getToken: () => "token",
+      emitState: vi.fn(),
+    });
+    const internals = service as unknown as {
+      performHostedShellHandoff: (gatewayOrigin: string) => Promise<HandoffResult>;
+      scheduleHostedShellSessionRefresh: (gatewayOrigin: string) => void;
+      manager: {
+        open: (
+          kind: string,
+          slug: string | null,
+          bounds: Bounds,
+          url: string,
+          options: { id?: string },
+        ) => string;
+      };
+    };
+    const handoffResolvers: Array<(result: HandoffResult) => void> = [];
+    const handoff = vi
+      .spyOn(internals, "performHostedShellHandoff")
+      .mockImplementation(
+        () => new Promise((resolve) => { handoffResolvers.push(resolve); }),
+      );
+    const open = vi
+      .spyOn(internals.manager, "open")
+      .mockImplementation((_kind, _slug, _bounds, _url, options) => options.id ?? "missing");
+    vi.spyOn(internals, "scheduleHostedShellSessionRefresh").mockImplementation(() => {});
+
+    const oldOpen = service.open({ kind: "hosted-shell", bounds: BOUNDS });
+    service.closeAll();
+    const newOpen = service.open({ kind: "hosted-shell", bounds: BOUNDS });
+
+    expect(handoff).toHaveBeenCalledTimes(1);
+    handoffResolvers[0]?.({ ok: true });
+    await expect(oldOpen).resolves.toEqual(expect.objectContaining({ state: "failed" }));
+    expect(open).not.toHaveBeenCalled();
+
+    await vi.waitFor(() => expect(handoff).toHaveBeenCalledTimes(2));
+    handoffResolvers[1]?.({ ok: true });
+    await expect(newOpen).resolves.toEqual(expect.objectContaining({ state: "loading" }));
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not attach a stale hosted-shell auth retry after runtime reset", async () => {
+    const service = new EmbedService({
+      getWindow: () => null,
+      getGatewayOrigin: () => "https://gateway.test",
+      getToken: () => "token",
+      emitState: vi.fn(),
+    });
+    const internals = service as unknown as {
+      pendingHostedShells: Map<string, Bounds>;
+      performHostedShellHandoff: (gatewayOrigin: string) => Promise<HandoffResult>;
+      scheduleHostedShellSessionRefresh: (gatewayOrigin: string) => void;
+      manager: {
+        open: (
+          kind: string,
+          slug: string | null,
+          bounds: Bounds,
+          url: string,
+          options: { id?: string },
+        ) => string;
+      };
+    };
+    const handoffResolvers: Array<(result: HandoffResult) => void> = [];
+    const handoff = vi
+      .spyOn(internals, "performHostedShellHandoff")
+      .mockImplementation(
+        () => new Promise((resolve) => { handoffResolvers.push(resolve); }),
+      );
+    const open = vi
+      .spyOn(internals.manager, "open")
+      .mockImplementation((_kind, _slug, _bounds, _url, options) => options.id ?? "missing");
+    vi.spyOn(internals, "scheduleHostedShellSessionRefresh").mockImplementation(() => {});
+
+    internals.pendingHostedShells.set("old-shell", BOUNDS);
+    const oldRetry = service.retryAuth("old-shell");
+    service.closeAll();
+    internals.pendingHostedShells.set("new-shell", BOUNDS);
+    const newRetry = service.retryAuth("new-shell");
+
+    expect(handoff).toHaveBeenCalledTimes(1);
+    handoffResolvers[0]?.({ ok: true });
+    await expect(oldRetry).resolves.toBe(false);
+    expect(open).not.toHaveBeenCalled();
+
+    await vi.waitFor(() => expect(handoff).toHaveBeenCalledTimes(2));
+    handoffResolvers[1]?.({ ok: true });
+    await expect(newRetry).resolves.toBe(true);
+    expect(open).toHaveBeenCalledWith(
+      "hosted-shell",
+      null,
+      BOUNDS,
+      "https://gateway.test/",
+      expect.objectContaining({ id: "new-shell" }),
+    );
+  });
+
   it("honors pending hosted-shell inactive state when retry auth finishes", async () => {
     const emitState = vi.fn();
     const service = new EmbedService({

--- a/tests/desktop/embed-service.test.ts
+++ b/tests/desktop/embed-service.test.ts
@@ -18,6 +18,22 @@ describe("EmbedService", () => {
     vi.restoreAllMocks();
   });
 
+  it("reloads a live embed through the existing bounded manager", () => {
+    const service = new EmbedService({
+      getWindow: () => null,
+      getGatewayOrigin: () => "https://gateway.test",
+      getToken: () => "token",
+      emitState: vi.fn(),
+    });
+    const internals = service as unknown as {
+      manager: { reload: (embedId: string) => boolean };
+    };
+    const reload = vi.spyOn(internals.manager, "reload").mockReturnValue(true);
+
+    expect(service.reload("embed-shell")).toBe(true);
+    expect(reload).toHaveBeenCalledWith("embed-shell");
+  });
+
   it("honors pending hosted-shell inactive state when retry auth finishes", async () => {
     const emitState = vi.fn();
     const service = new EmbedService({

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -42,6 +42,7 @@ describe("IPC contract", () => {
       "state:set",
       "embed:open",
       "embed:set-bounds",
+      "embed:reload",
       "embed:close",
       "embed:retry-auth",
       "notify",
@@ -858,6 +859,15 @@ describe("IPC contract", () => {
     expect(
       schema.safeParse({ embedId: "e1", bounds: { x: 0.5, y: 0, width: 10, height: 10 } }).success,
     ).toBe(false);
+  });
+
+  it("bounds embed reload identifiers", () => {
+    const schema = INVOKE_CHANNELS["embed:reload"].request;
+
+    expect(schema.safeParse({ embedId: "embed-1" }).success).toBe(true);
+    expect(schema.safeParse({ embedId: "" }).success).toBe(false);
+    expect(schema.safeParse({ embedId: "x".repeat(65) }).success).toBe(false);
+    expect(schema.safeParse({ embedId: "embed-1", extra: true }).success).toBe(false);
   });
 
   it("requires embed:open to return the initial embed state", () => {

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -187,7 +187,7 @@ describe("registerIpcHandlers", () => {
 
   it("reloads an existing embed through the trusted core", async () => {
     const harness = makeHarness();
-    vi.mocked(harness.ctx.embeds.reload).mockReturnValue(true);
+    vi.mocked(harness.ctx.embeds.reload).mockResolvedValue(true);
 
     await expect(harness.invoke("embed:reload", { embedId: "embed-1" })).resolves.toEqual({
       ok: true,

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -28,6 +28,7 @@ function makeHarness(overrides: Partial<HandlerContext> = {}) {
       open: vi.fn(),
       setBounds: vi.fn(),
       setActive: vi.fn(),
+      reload: vi.fn(),
       close: vi.fn(),
       retryAuth: vi.fn(),
     },
@@ -182,6 +183,16 @@ describe("registerIpcHandlers", () => {
       ok: false,
     });
     expect(console.warn).toHaveBeenCalledWith("[ipc] embed:retry-auth failed:", "handoff unavailable");
+  });
+
+  it("reloads an existing embed through the trusted core", async () => {
+    const harness = makeHarness();
+    vi.mocked(harness.ctx.embeds.reload).mockReturnValue(true);
+
+    await expect(harness.invoke("embed:reload", { embedId: "embed-1" })).resolves.toEqual({
+      ok: true,
+    });
+    expect(harness.ctx.embeds.reload).toHaveBeenCalledWith("embed-1");
   });
 
   it("reports the live updater status from the handler context", async () => {

--- a/tests/desktop/menu-template.test.ts
+++ b/tests/desktop/menu-template.test.ts
@@ -2,6 +2,32 @@ import { describe, expect, it, vi } from "vitest";
 import { createAppMenuTemplate } from "../../desktop/src/main/platform/menu-template";
 
 describe("createAppMenuTemplate", () => {
+  it("maps Cmd+R to hosted Home refresh in packaged and development builds", () => {
+    for (const isPackaged of [true, false]) {
+      const send = vi.fn();
+      const template = createAppMenuTemplate({
+        appName: "Matrix OS",
+        isPackaged,
+        openExternal: vi.fn(),
+        send,
+        adjustZoom: vi.fn(),
+      });
+      const viewMenu = template.find((item) => item.label === "View");
+      const submenu = Array.isArray(viewMenu?.submenu) ? viewMenu.submenu : [];
+      const refreshItem = submenu.find((item) => "label" in item && item.label === "Refresh Home");
+
+      expect(refreshItem).toBeTruthy();
+      expect(refreshItem && "accelerator" in refreshItem ? refreshItem.accelerator : null)
+        .toBe("CmdOrCtrl+R");
+      expect(submenu.some((item) => "role" in item && item.role === "reload")).toBe(false);
+      if (!refreshItem || !("click" in refreshItem) || typeof refreshItem.click !== "function") {
+        throw new Error("Refresh Home menu item is not clickable");
+      }
+      refreshItem.click({} as never, {} as never, {} as never);
+      expect(send).toHaveBeenCalledWith("menu:action", { action: "refresh-home" });
+    }
+  });
+
   it("adds a Terminal menu entry that navigates to the terminal workspace", () => {
     const send = vi.fn();
     const template = createAppMenuTemplate({

--- a/tests/desktop/navigation-header.test.tsx
+++ b/tests/desktop/navigation-header.test.tsx
@@ -17,7 +17,7 @@ describe("Desktop navigation header", () => {
   beforeEach(() => {
     useTabs.setState(useTabs.getInitialState(), true);
     useTabs.getState().ensureNavigationScope("runtime-a");
-    useUi.setState({ sidebarCollapsed: false });
+    useUi.setState(useUi.getInitialState(), true);
     useThreads.setState(useThreads.getInitialState(), true);
     useHermesChat.setState(useHermesChat.getInitialState(), true);
   });
@@ -100,6 +100,19 @@ describe("Desktop navigation header", () => {
 
     act(() => useUi.getState().toggleSidebar());
     expect(useUi.getState().sidebarCollapsed).toBe(false);
+  });
+
+  it("shows a refresh control only for Home and requests a hosted-shell reload", () => {
+    useTabs.getState().openTab({ kind: "home", title: "Home", closable: false });
+    render(<Tooltip.Provider><NavigationHeader /></Tooltip.Provider>);
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh Home" }));
+    expect(useUi.getState().homeRefreshRequest).toBe(1);
+
+    act(() => {
+      useTabs.getState().openTab({ kind: "terminals", title: "Terminal", closable: false });
+    });
+    expect(screen.queryByRole("button", { name: "Refresh Home" })).toBeNull();
   });
 
   it("shows the active canonical Hermes conversation in the Chat breadcrumb", () => {

--- a/tests/desktop/navigation-header.test.tsx
+++ b/tests/desktop/navigation-header.test.tsx
@@ -106,7 +106,12 @@ describe("Desktop navigation header", () => {
     useTabs.getState().openTab({ kind: "home", title: "Home", closable: false });
     render(<Tooltip.Provider><NavigationHeader /></Tooltip.Provider>);
 
-    fireEvent.click(screen.getByRole("button", { name: "Refresh Home" }));
+    const breadcrumb = screen.getByRole("navigation", { name: "Breadcrumb" });
+    const refresh = screen.getByRole("button", { name: "Refresh Home" });
+    expect(breadcrumb.nextElementSibling).toContain(refresh);
+    expect(refresh.parentElement?.className).not.toContain("ml-auto");
+
+    fireEvent.click(refresh);
     expect(useUi.getState().homeRefreshRequest).toBe(1);
 
     act(() => {


### PR DESCRIPTION
## Summary

- add a visible Refresh Home control for the active hosted Home surface
- route Cmd+R through typed menu and IPC contracts to the retained native embed
- reuse the bounded EmbedManager reload path and preserve hosted-shell session refresh

## Test plan

- `flox activate -- pnpm exec vitest run tests/desktop/ipc-contract.test.ts tests/desktop/ipc-handlers.test.ts tests/desktop/menu-template.test.ts tests/desktop/navigation-header.test.tsx tests/desktop/embed-host.test.tsx tests/desktop/embed-service.test.ts`
- `flox activate -- pnpm --filter desktop run typecheck`
- combined Desktop production build with MAT-335, MAT-336, and MAT-337

## Invariants

- Source of truth: the main-process EmbedManager remains authoritative for native embed lifecycle.
- Lock/transaction scope: N/A; this change is bounded Desktop UI and IPC wiring.
- Acceptable orphan states: a reload request for a closed or inactive embed fails safely without creating a second embed.
- Auth source of truth: native app-session handoff remains unchanged; renderer credentials are never introduced.
- Deferred scope: automatic retry/backoff for upstream 502s is not included.

Closes MAT-334
