### PR TITLE
feat(desktop): add terminal session rail and writable inset

### DIFF
--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -345,7 +345,8 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
 
   return (
     <div
-      className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+      className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden p-2"
+      data-terminal-surface
       style={{ backgroundColor: terminalBackground }}
     >
       <div

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -345,7 +345,7 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
 
   return (
     <div
-      className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden py-2 pl-3 pr-2"
+      className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden p-2"
       data-terminal-surface
       style={{ backgroundColor: terminalBackground }}
     >

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -345,7 +345,7 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
 
   return (
     <div
-      className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden py-2 pl-4 pr-2"
+      className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden py-2 pl-3 pr-2"
       data-terminal-surface
       style={{ backgroundColor: terminalBackground }}
     >

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -345,7 +345,7 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
 
   return (
     <div
-      className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden p-2"
+      className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden py-2 pl-4 pr-2"
       data-terminal-surface
       style={{ backgroundColor: terminalBackground }}
     >

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -531,7 +531,7 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
                 {shellStatusLabel(shell)}
               </span>
             </header>
-            <div data-terminal-detail className="flex min-h-0 flex-1 gap-3 p-3">
+            <div data-terminal-detail className="flex min-h-0 flex-1 gap-3">
               {sessionRailOpen ? (
                 <nav
                   aria-label="Terminal session switcher"

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -531,11 +531,11 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
                 {shellStatusLabel(shell)}
               </span>
             </header>
-            <div data-terminal-detail className="flex min-h-0 flex-1 gap-3">
+            <div data-terminal-detail className="flex min-h-0 flex-1">
               {sessionRailOpen ? (
                 <nav
                   aria-label="Terminal session switcher"
-                  className="flex w-48 shrink-0 flex-col overflow-hidden rounded-lg border"
+                  className="flex w-48 shrink-0 flex-col overflow-hidden border-r"
                   style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }}
                 >
                   <div
@@ -575,8 +575,8 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
               ) : null}
               <div
                 data-terminal-viewport
-                className="flex min-h-0 min-w-0 flex-1 overflow-hidden rounded-lg border"
-                style={{ borderColor: "var(--border-subtle)", background: "var(--bg-app)" }}
+                className="flex min-h-0 min-w-0 flex-1 overflow-hidden"
+                style={{ background: "var(--bg-app)" }}
               >
                 <TerminalView sessionName={sessionName} active={active && liveSessionName === sessionName} />
               </div>

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -8,6 +8,8 @@ import {
   GripVertical,
   Layers,
   MoreHorizontal,
+  PanelLeftClose,
+  PanelLeftOpen,
   Plus,
   RefreshCw,
   Search,
@@ -118,6 +120,7 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
   const [selectedName, setSelectedName] = useState<string | null>(null);
   const [liveSessionName, setLiveSessionName] = useState<string | null>(null);
   const [openedSessionNames, setOpenedSessionNames] = useState<string[]>([]);
+  const [sessionRailOpen, setSessionRailOpen] = useState(true);
   const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [busyNames, setBusyNames] = useState<string[]>([]);
@@ -517,12 +520,67 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
                   Started at {sessionStart(shell.createdAt)} · {runtimeSlot === "primary" ? "main computer" : runtimeSlot}
                 </p>
               </div>
+              <IconButton
+                label={sessionRailOpen ? "Collapse terminal sessions" : "Show terminal sessions"}
+                onClick={() => setSessionRailOpen((open) => !open)}
+              >
+                {sessionRailOpen ? <PanelLeftClose size={14} /> : <PanelLeftOpen size={14} />}
+              </IconButton>
               <span className="inline-flex items-center gap-1.5 rounded-full border px-2 py-1 text-xs" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
                 <StatusDot color={statusColor(shell)} pulse={shell.status !== "exited" && shell.visualStatus === "running"} />
                 {shellStatusLabel(shell)}
               </span>
             </header>
-            <TerminalView sessionName={sessionName} active={active && liveSessionName === sessionName} />
+            <div data-terminal-detail className="flex min-h-0 flex-1 gap-3 p-3">
+              {sessionRailOpen ? (
+                <nav
+                  aria-label="Terminal session switcher"
+                  className="flex w-48 shrink-0 flex-col overflow-hidden rounded-lg border"
+                  style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }}
+                >
+                  <div
+                    className="shrink-0 border-b px-3 py-2 text-[11px] font-semibold uppercase tracking-wide"
+                    style={{ borderColor: "var(--border-subtle)", color: "var(--text-tertiary)" }}
+                  >
+                    Sessions
+                  </div>
+                  <div className="min-h-0 flex-1 overflow-y-auto p-1.5">
+                    {shells.map((candidate) => {
+                      const current = candidate.name === sessionName;
+                      return (
+                        <button
+                          key={candidate.name}
+                          type="button"
+                          aria-label={`Switch to ${candidate.name}`}
+                          aria-current={current ? "page" : undefined}
+                          className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left outline-none transition-colors hover:bg-[var(--bg-hover)] focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
+                          style={{
+                            background: current ? "var(--bg-selected)" : "transparent",
+                            color: current ? "var(--text-primary)" : "var(--text-secondary)",
+                          }}
+                          onClick={() => showShellDetail(candidate)}
+                        >
+                          <StatusDot
+                            color={statusColor(candidate)}
+                            pulse={candidate.status !== "exited" && candidate.visualStatus === "running"}
+                          />
+                          <span className="min-w-0 flex-1 truncate text-xs font-medium">
+                            {candidate.name}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </nav>
+              ) : null}
+              <div
+                data-terminal-viewport
+                className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-lg border"
+                style={{ borderColor: "var(--border-subtle)", background: "var(--bg-canvas)" }}
+              >
+                <TerminalView sessionName={sessionName} active={active && liveSessionName === sessionName} />
+              </div>
+            </div>
           </RetainedPane>
         );
       })}

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -576,7 +576,7 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
               <div
                 data-terminal-viewport
                 className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-lg border"
-                style={{ borderColor: "var(--border-subtle)", background: "var(--bg-canvas)" }}
+                style={{ borderColor: "var(--border-subtle)", background: "var(--bg-app)" }}
               >
                 <TerminalView sessionName={sessionName} active={active && liveSessionName === sessionName} />
               </div>

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -575,7 +575,7 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
               ) : null}
               <div
                 data-terminal-viewport
-                className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-lg border"
+                className="flex min-h-0 min-w-0 flex-1 overflow-hidden rounded-lg border"
                 style={{ borderColor: "var(--border-subtle)", background: "var(--bg-app)" }}
               >
                 <TerminalView sessionName={sessionName} active={active && liveSessionName === sessionName} />

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -168,7 +168,7 @@ describe("TerminalView session switching", () => {
     vi.unstubAllGlobals();
   });
 
-  it("fills the terminal content area without an inset or mismatched xterm surface", () => {
+  it("insets terminal glyphs while keeping the xterm surface fitted and theme-matched", () => {
     const { container } = render(<TerminalView sessionName="alpha" />);
     const host = container.querySelector<HTMLElement>("[data-terminal-viewport]")!;
     const frame = host.parentElement!;
@@ -181,6 +181,8 @@ describe("TerminalView session switching", () => {
 
     expect(host.className).not.toMatch(/\b(?:px-2|pt-1\.5)\b/);
     expect(host.className).toContain("overflow-hidden");
+    expect(frame.getAttribute("data-terminal-surface")).not.toBeNull();
+    expect(frame.className).toContain("p-2");
     expect(frame.className).toContain("overflow-hidden");
     expect(frame.style.backgroundColor).toBe(colorProbe.style.backgroundColor);
     expect(root.style.width).toBe("100%");

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -182,10 +182,9 @@ describe("TerminalView session switching", () => {
     expect(host.className).not.toMatch(/\b(?:px-2|pt-1\.5)\b/);
     expect(host.className).toContain("overflow-hidden");
     expect(frame.getAttribute("data-terminal-surface")).not.toBeNull();
-    expect(frame.className).toContain("py-2");
-    expect(frame.className).toContain("pl-3");
+    expect(frame.className).toContain("p-2");
+    expect(frame.className).not.toContain("pl-3");
     expect(frame.className).not.toContain("pl-4");
-    expect(frame.className).toContain("pr-2");
     expect(frame.className).toContain("overflow-hidden");
     expect(frame.style.backgroundColor).toBe(colorProbe.style.backgroundColor);
     expect(root.style.width).toBe("100%");

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -182,7 +182,9 @@ describe("TerminalView session switching", () => {
     expect(host.className).not.toMatch(/\b(?:px-2|pt-1\.5)\b/);
     expect(host.className).toContain("overflow-hidden");
     expect(frame.getAttribute("data-terminal-surface")).not.toBeNull();
-    expect(frame.className).toContain("p-2");
+    expect(frame.className).toContain("py-2");
+    expect(frame.className).toContain("pl-4");
+    expect(frame.className).toContain("pr-2");
     expect(frame.className).toContain("overflow-hidden");
     expect(frame.style.backgroundColor).toBe(colorProbe.style.backgroundColor);
     expect(root.style.width).toBe("100%");

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -183,7 +183,8 @@ describe("TerminalView session switching", () => {
     expect(host.className).toContain("overflow-hidden");
     expect(frame.getAttribute("data-terminal-surface")).not.toBeNull();
     expect(frame.className).toContain("py-2");
-    expect(frame.className).toContain("pl-4");
+    expect(frame.className).toContain("pl-3");
+    expect(frame.className).not.toContain("pl-4");
     expect(frame.className).toContain("pr-2");
     expect(frame.className).toContain("overflow-hidden");
     expect(frame.style.backgroundColor).toBe(colorProbe.style.backgroundColor);

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -164,7 +164,7 @@ describe("TerminalsTab", () => {
       .toBe("page");
     const terminalDetail = screen.getByTestId("terminal-view-matrix-main")
       .closest("[data-terminal-detail]");
-    expect(terminalDetail?.className).toContain("p-3");
+    expect(terminalDetail?.className.split(/\s+/)).not.toContain("p-3");
     const terminalViewport = screen.getByTestId("terminal-view-matrix-main")
       .closest("[data-terminal-viewport]");
     expect(terminalViewport?.className).toContain("rounded-lg");

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -148,6 +148,36 @@ describe("TerminalsTab", () => {
     expect(terminalMounts.get("matrix-main")).toBe(1);
   });
 
+  it("switches retained sessions from a collapsible rail with a terminal gutter", () => {
+    useShellSessions.setState({
+      sessions: [
+        { name: "matrix-main", status: "active", placement: "active" },
+        { name: "matrix-other", status: "active", placement: "active" },
+      ],
+    });
+
+    renderTab();
+    fireEvent.click(screen.getByRole("button", { name: "Open matrix-main" }));
+
+    expect(screen.getByRole("navigation", { name: "Terminal session switcher" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Switch to matrix-main" }).getAttribute("aria-current"))
+      .toBe("page");
+    const terminalDetail = screen.getByTestId("terminal-view-matrix-main")
+      .closest("[data-terminal-detail]");
+    expect(terminalDetail?.className).toContain("p-3");
+    expect(screen.getByTestId("terminal-view-matrix-main")
+      .closest("[data-terminal-viewport]")?.className).toContain("rounded-lg");
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to matrix-other" }));
+    expect(screen.getByTestId("terminal-view-matrix-other").getAttribute("data-active")).toBe("true");
+    expect(terminalMounts.get("matrix-main")).toBe(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse terminal sessions" }));
+    expect(screen.queryByRole("navigation", { name: "Terminal session switcher" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Show terminal sessions" }));
+    expect(screen.getByRole("navigation", { name: "Terminal session switcher" })).toBeTruthy();
+  });
+
   it("fully contains cached session chrome and terminal output while the Terminal route is inactive", () => {
     useShellSessions.setState({
       sessions: [{

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -148,7 +148,7 @@ describe("TerminalsTab", () => {
     expect(terminalMounts.get("matrix-main")).toBe(1);
   });
 
-  it("switches retained sessions from a collapsible rail with a terminal gutter", () => {
+  it("switches retained sessions from a flush collapsible rail", () => {
     useShellSessions.setState({
       sessions: [
         { name: "matrix-main", status: "active", placement: "active" },
@@ -165,9 +165,15 @@ describe("TerminalsTab", () => {
     const terminalDetail = screen.getByTestId("terminal-view-matrix-main")
       .closest("[data-terminal-detail]");
     expect(terminalDetail?.className.split(/\s+/)).not.toContain("p-3");
+    expect(terminalDetail?.className.split(/\s+/)).not.toContain("gap-3");
+    const terminalRail = screen.getByRole("navigation", { name: "Terminal session switcher" });
+    expect(terminalRail.className.split(/\s+/)).not.toContain("rounded-lg");
+    expect(terminalRail.className.split(/\s+/)).not.toContain("border");
+    expect(terminalRail.className.split(/\s+/)).toContain("border-r");
     const terminalViewport = screen.getByTestId("terminal-view-matrix-main")
       .closest("[data-terminal-viewport]");
-    expect(terminalViewport?.className).toContain("rounded-lg");
+    expect(terminalViewport?.className.split(/\s+/)).not.toContain("rounded-lg");
+    expect(terminalViewport?.className.split(/\s+/)).not.toContain("border");
     expect(terminalViewport?.className).toContain("flex");
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to matrix-other" }));

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -165,8 +165,10 @@ describe("TerminalsTab", () => {
     const terminalDetail = screen.getByTestId("terminal-view-matrix-main")
       .closest("[data-terminal-detail]");
     expect(terminalDetail?.className).toContain("p-3");
-    expect(screen.getByTestId("terminal-view-matrix-main")
-      .closest("[data-terminal-viewport]")?.className).toContain("rounded-lg");
+    const terminalViewport = screen.getByTestId("terminal-view-matrix-main")
+      .closest("[data-terminal-viewport]");
+    expect(terminalViewport?.className).toContain("rounded-lg");
+    expect(terminalViewport?.className).toContain("flex");
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to matrix-other" }));
     expect(screen.getByTestId("terminal-view-matrix-other").getAttribute("data-active")).toBe("true");


### PR DESCRIPTION
## Summary

- add a compact collapsible session rail to Desktop terminal detail
- switch between canonical terminal sessions without returning to the index
- retain mounted terminal panes while keeping the rail flush with the terminal surface
- remove the separate rounded viewport frame and external detail gap to match the Figma active-session structure
- keep a uniform 8px inset inside the writable terminal character surface

## Test plan

- `flox activate -- pnpm exec vitest run tests/desktop/terminal-view.test.tsx tests/desktop/terminals-tab.test.tsx --reporter=dot` (45 tests pass)
- `flox activate -- pnpm --dir desktop exec tsc --noEmit -p tsconfig.json` (passes)
- `flox activate -- pnpm --filter desktop run build` (passes)
- `flox activate -- bun run check:patterns`
- `flox activate -- bun run typecheck`
- broad repository suite completed with 935 test files / 10,812 tests passing and 18 files / 25 tests failing in unrelated environment and pre-existing areas (long Unix socket paths, interactive agent/Codex timeouts, zellij/tool-pack timeouts, and unrelated UI import failures); focused MAT-336 coverage is green

## Invariants

- Source of truth: `/api/terminal/sessions` and the existing shell store remain canonical.
- Lock/transaction scope: N/A; no persistence contract changes.
- Acceptable orphan states: closed sessions disappear through the existing refresh/delete path.
- Auth source of truth: existing Gateway session authorization remains unchanged.
- Deferred scope: terminal reordering and cross-window session management are not included.

Closes MAT-336
