### PR TITLE
fix(desktop): preserve chat metadata on hover

### DIFF
--- a/desktop/src/renderer/src/features/chat/HermesConversationIndex.tsx
+++ b/desktop/src/renderer/src/features/chat/HermesConversationIndex.tsx
@@ -69,7 +69,11 @@ function ConversationRow({
           <span className="min-w-0 flex-1 truncate text-base font-medium" style={{ color: "var(--text-primary)" }}>
             {conversation.title}
           </span>
-          <span className="flex shrink-0 items-center gap-5 text-xs transition-opacity group-hover:opacity-0 group-focus-within:opacity-0" style={{ color: "var(--text-tertiary)" }}>
+          <span
+            data-conversation-metadata
+            className="flex shrink-0 items-center gap-5 text-xs"
+            style={{ color: "var(--text-tertiary)" }}
+          >
             <span className="rounded-full border px-2 py-1 font-medium" style={{ borderColor: "var(--border-default)" }}>Hermes</span>
             {running ? (
               <span className="flex items-center gap-1.5" style={{ color: "var(--accent)" }}>

--- a/tests/desktop/hermes-conversation-index.test.tsx
+++ b/tests/desktop/hermes-conversation-index.test.tsx
@@ -229,16 +229,24 @@ describe("HermesConversationIndex", () => {
     render(<HermesConversationIndex api={api()} />);
 
     const launch = screen.getByRole("button", { name: "Launch plan conversation" });
+    const remove = screen.getByRole("button", { name: "Delete Launch plan" });
     const row = launch.closest("[data-conversation-row]");
     const metadata = row?.querySelector("[data-conversation-metadata]");
 
+    launch.focus();
+    expect(document.activeElement).toBe(launch);
     expect(metadata).not.toBeNull();
     expect(metadata?.textContent).toContain("Hermes");
     expect(metadata?.querySelector("time")).not.toBeNull();
     expect(metadata?.className).not.toContain("group-hover:opacity-0");
     expect(metadata?.className).not.toContain("group-focus-within:opacity-0");
-    expect(screen.getByRole("button", { name: "Delete Launch plan" }).className)
-      .toContain("group-hover:opacity-100");
+    expect(remove.className).toContain("group-hover:opacity-100");
+
+    remove.focus();
+    expect(document.activeElement).toBe(remove);
+    expect(remove.className).toContain("focus:opacity-100");
+    expect(metadata?.textContent).toContain("Hermes");
+    expect(metadata?.querySelector("time")).not.toBeNull();
   });
 
   it("does not promote a canonical Gateway conversation when it is only opened", async () => {

--- a/tests/desktop/hermes-conversation-index.test.tsx
+++ b/tests/desktop/hermes-conversation-index.test.tsx
@@ -225,6 +225,22 @@ describe("HermesConversationIndex", () => {
     expect(dialog.style.transform).toBe("translate(-50%, -50%)");
   });
 
+  it("keeps harness and activity metadata visible when delete is revealed", () => {
+    render(<HermesConversationIndex api={api()} />);
+
+    const launch = screen.getByRole("button", { name: "Launch plan conversation" });
+    const row = launch.closest("[data-conversation-row]");
+    const metadata = row?.querySelector("[data-conversation-metadata]");
+
+    expect(metadata).not.toBeNull();
+    expect(metadata?.textContent).toContain("Hermes");
+    expect(metadata?.querySelector("time")).not.toBeNull();
+    expect(metadata?.className).not.toContain("group-hover:opacity-0");
+    expect(metadata?.className).not.toContain("group-focus-within:opacity-0");
+    expect(screen.getByRole("button", { name: "Delete Launch plan" }).className)
+      .toContain("group-hover:opacity-100");
+  });
+
   it("does not promote a canonical Gateway conversation when it is only opened", async () => {
     const openConversation = vi.fn(async () => true);
     useHermesChat.setState({ openConversation });


### PR DESCRIPTION
## Summary

- keep harness and activity metadata visible when a Chat row is hovered or keyboard-focused
- reveal the destructive action without replacing context needed to identify the conversation
- preserve existing deletion behavior and responsive layout

## Test plan

- `flox activate -- pnpm exec vitest run tests/desktop/hermes-conversation-index.test.tsx`
- `flox activate -- pnpm --filter desktop run typecheck`
- combined Desktop production build with MAT-334, MAT-335, and MAT-336

## Invariants

- Source of truth: Gateway conversation summaries remain canonical.
- Lock/transaction scope: N/A; presentation-only change.
- Acceptable orphan states: deletion still waits for the existing Gateway-backed flow.
- Auth source of truth: unchanged.
- Deferred scope: harness-neutral Chat persistence and architecture are not included.

Closes MAT-337
