### PR TITLE
fix(desktop): synchronize terminal session deletions

### DIFF
--- a/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
+++ b/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
@@ -18,6 +18,7 @@ import { invoke } from "../../lib/operator";
 import { wireKernel } from "../../lib/kernel-wiring";
 import { codingAgentRuntimeScope } from "../../../../shared/coding-agent-project-workspace";
 import DesktopUpdateExperience from "../updates/DesktopUpdateExperience";
+import { useShellSessionSync } from "../../lib/shell-session-sync";
 
 export default function MissionControl() {
   const api = useConnection((s) => s.api);
@@ -32,6 +33,7 @@ export default function MissionControl() {
   const setCreateProjectOpen = useUi((s) => s.setCreateProjectOpen);
 
   useGlobalShortcuts();
+  useShellSessionSync(api, `${runtimeScope}|${authGeneration}|${runtimeSlot}`);
 
   useEffect(() => {
     const { configure, hydrate } = useWorkspace.getState();

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -28,6 +28,10 @@ import {
 } from "../../stores/shell-sessions";
 import { useConnection } from "../../stores/connection";
 import { useTabs } from "../../stores/tabs";
+import {
+  reconcileShellSessionSnapshot,
+  syncShellSessions,
+} from "../../lib/shell-session-sync";
 import TerminalView from "./TerminalView";
 
 const RENAME_HELP = "Use lowercase letters, numbers, and hyphens. Start and end with a letter or number.";
@@ -101,7 +105,7 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
   const creating = useShellSessions((s) => s.creating);
   const error = useShellSessions((s) => s.error);
   const loadSequence = useShellSessions((s) => s.loadSequence);
-  const load = useShellSessions((s) => s.load);
+  const authoritativeRevision = useShellSessions((s) => s.authoritativeRevision);
   const create = useShellSessions((s) => s.create);
   const deleteSession = useShellSessions((s) => s.deleteSession);
   const rename = useShellSessions((s) => s.rename);
@@ -110,7 +114,6 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
   const tabs = useTabs((s) => s.tabs);
   const openTab = useTabs((s) => s.openTab);
   const recordRecentTerminal = useTabs((s) => s.recordRecentTerminal);
-  const removeRecentView = useTabs((s) => s.removeRecentView);
   const reconcileRecentTerminals = useTabs((s) => s.reconcileRecentTerminals);
   const terminalSessionRequest = useTabs((s) => s.terminalSessionRequest);
   const consumeTerminalSessionRequest = useTabs((s) => s.consumeTerminalSessionRequest);
@@ -130,13 +133,16 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
   const draggingPlacementRef = useRef<ShellSessionPlacement | null>(null);
 
   useEffect(() => {
-    if (api) void load(api);
-  }, [api, load]);
-
-  useEffect(() => {
-    if (loading || error || loadSequence === 0) return;
-    reconcileRecentTerminals(shells.map((shell) => shell.name));
-  }, [error, loading, loadSequence, reconcileRecentTerminals, shells]);
+    if (loading || error || authoritativeRevision === 0) return;
+    const liveNames = new Set(shells.map((shell) => shell.name));
+    reconcileRecentTerminals([...liveNames]);
+    setOpenedSessionNames((current) => {
+      const retained = current.filter((name) => liveNames.has(name));
+      return retained.length === current.length ? current : retained;
+    });
+    setLiveSessionName((current) => current && liveNames.has(current) ? current : null);
+    setSelectedName((current) => current && liveNames.has(current) ? current : null);
+  }, [authoritativeRevision, error, loading, reconcileRecentTerminals, shells]);
 
   const openShellNames = useMemo(
     () => new Set([
@@ -321,7 +327,9 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
       setActionError("Could not delete shell");
       return;
     }
-    removeRecentView("terminal", name);
+    reconcileShellSessionSnapshot(
+      useShellSessions.getState().sessions.filter((session) => session.name !== name),
+    );
     if (selectedRef.current === name) {
       setSelectedName(null);
     }
@@ -383,6 +391,13 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
             >
               <Search size={14} />
             </IconButton>
+            <IconButton
+              label="Refresh terminal sessions"
+              disabled={!api || loading}
+              onClick={() => api && void syncShellSessions(api)}
+            >
+              <RefreshCw size={14} />
+            </IconButton>
             <Button variant="primary" disabled={!api || creating} onClick={() => void createShell()} aria-label="New shell">
               <Plus size={13} />
               {creating ? "Starting" : "New"}
@@ -425,7 +440,12 @@ export default function TerminalsTab({ active = true }: { active?: boolean }) {
                 headline="Terminal sessions unavailable"
                 description={categoryMessage(error)}
                 action={
-                  <Button variant="subtle" aria-label="Retry terminal sessions" disabled={!api} onClick={() => api && void load(api)}>
+                  <Button
+                    variant="subtle"
+                    aria-label="Retry terminal sessions"
+                    disabled={!api}
+                    onClick={() => api && void syncShellSessions(api)}
+                  >
                     <RefreshCw size={13} />
                     Retry
                   </Button>

--- a/desktop/src/renderer/src/lib/shell-session-sync.ts
+++ b/desktop/src/renderer/src/lib/shell-session-sync.ts
@@ -1,0 +1,63 @@
+import { useEffect } from "react";
+import type { ApiClient } from "./api";
+import type { ShellSessionSummary } from "../stores/shell-sessions";
+import { useShellSessions } from "../stores/shell-sessions";
+import { useTabs } from "../stores/tabs";
+
+export const SHELL_SESSION_SYNC_INTERVAL_MS = 5_000;
+
+type AcceptSnapshot = () => boolean;
+
+export function reconcileShellSessionSnapshot(sessions: ShellSessionSummary[]): void {
+  useTabs.getState().reconcileTerminalSessions(sessions.map((session) => session.name));
+}
+
+export async function syncShellSessions(
+  api: ApiClient,
+  acceptSnapshot: AcceptSnapshot = () => true,
+): Promise<ShellSessionSummary[] | null> {
+  const sessions = await useShellSessions.getState().load(api);
+  if (sessions === null || !acceptSnapshot()) return null;
+  reconcileShellSessionSnapshot(sessions);
+  return sessions;
+}
+
+export function startShellSessionSync(api: ApiClient): () => void {
+  let stopped = false;
+  let refreshInFlight = false;
+
+  const refresh = (requireVisible: boolean) => {
+    if (stopped || refreshInFlight) return;
+    if (requireVisible && document.visibilityState !== "visible") return;
+    refreshInFlight = true;
+    void syncShellSessions(api, () => !stopped)
+      .catch(() => {
+        // The store normalizes expected request failures. This guard prevents
+        // an unexpected implementation error from becoming an unhandled task.
+        console.error("[shell-session-sync] Unexpected refresh failure");
+      })
+      .finally(() => {
+        refreshInFlight = false;
+      });
+  };
+
+  const refreshWhenVisible = () => refresh(true);
+  refresh(false);
+  const interval = window.setInterval(refreshWhenVisible, SHELL_SESSION_SYNC_INTERVAL_MS);
+  window.addEventListener("focus", refreshWhenVisible);
+  document.addEventListener("visibilitychange", refreshWhenVisible);
+
+  return () => {
+    stopped = true;
+    window.clearInterval(interval);
+    window.removeEventListener("focus", refreshWhenVisible);
+    document.removeEventListener("visibilitychange", refreshWhenVisible);
+  };
+}
+
+export function useShellSessionSync(api: ApiClient | null, runtimeScope: string): void {
+  useEffect(() => {
+    if (!api) return;
+    return startShellSessionSync(api);
+  }, [api, runtimeScope]);
+}

--- a/desktop/src/renderer/src/stores/runtime-transition.ts
+++ b/desktop/src/renderer/src/stores/runtime-transition.ts
@@ -80,6 +80,7 @@ export function reconcileDesktopRuntimeChange(options: RuntimeChangeOptions = {}
     creating: false,
     error: null,
     loadSequence: state.loadSequence + 1,
+    authoritativeRevision: 0,
   }));
   useGit.setState({
     branches: [],

--- a/desktop/src/renderer/src/stores/shell-sessions.ts
+++ b/desktop/src/renderer/src/stores/shell-sessions.ts
@@ -40,7 +40,8 @@ interface ShellSessionsState {
   creating: boolean;
   error: AppErrorCategory | null;
   loadSequence: number;
-  load(api: ApiClient): Promise<void>;
+  authoritativeRevision: number;
+  load(api: ApiClient): Promise<ShellSessionSummary[] | null>;
   create(api: ApiClient): Promise<ShellSessionSummary | null>;
   deleteSession(api: ApiClient, name: string): Promise<boolean>;
   rename(api: ApiClient, name: string, nextName: string): Promise<boolean>;
@@ -220,7 +221,10 @@ function rollbackUiPatch(
 }
 
 async function fetchShellSessions(api: ApiClient): Promise<ShellSessionSummary[]> {
-  const response = await api.get<{ sessions: unknown }>("/api/terminal/sessions");
+  const response = await api.get<{ sessions?: unknown }>("/api/terminal/sessions");
+  if (!response || !Array.isArray(response.sessions)) {
+    throw new AppError("server", { detail: "invalid_sessions_response" });
+  }
   return parseShellSessions(response.sessions);
 }
 
@@ -230,18 +234,27 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
   creating: false,
   error: null,
   loadSequence: 0,
+  authoritativeRevision: 0,
 
   load: async (api) => {
+    const generation = captureRuntimeGeneration();
     const sequence = get().loadSequence + 1;
     set({ loading: true, error: null, loadSequence: sequence });
     try {
       const sessions = await fetchShellSessions(api);
-      if (sequence !== get().loadSequence) return;
-      set({ sessions, loading: false, error: null });
+      if (!isCurrentRuntimeGeneration(generation) || sequence !== get().loadSequence) return null;
+      set((state) => ({
+        sessions,
+        loading: false,
+        error: null,
+        authoritativeRevision: state.authoritativeRevision + 1,
+      }));
+      return sessions;
     } catch (err: unknown) {
-      if (sequence !== get().loadSequence) return;
+      if (!isCurrentRuntimeGeneration(generation) || sequence !== get().loadSequence) return null;
       console.error("[shell-sessions] Failed to load shell sessions:", err);
       set({ loading: false, error: errorCategory(err) });
+      return null;
     }
   },
 
@@ -279,6 +292,7 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
             creating: false,
             loading: false,
             error: null,
+            authoritativeRevision: state.authoritativeRevision + 1,
           }));
         } catch (refreshErr: unknown) {
           if (!isCurrentRuntimeGeneration(generation)) return null;

--- a/desktop/src/renderer/src/stores/tabs.ts
+++ b/desktop/src/renderer/src/stores/tabs.ts
@@ -134,6 +134,7 @@ interface TabsState {
   removeRecentView(kind: RecentViewKind, id: string): void;
   reconcileRecentHermesConversations(ids: string[]): void;
   reconcileRecentTerminals(ids: string[]): void;
+  reconcileTerminalSessions(liveSessionNames: string[]): void;
   requestTerminalSession(sessionName: string): void;
   consumeTerminalSessionRequest(requestId: number): void;
   setRecentFilter(filter: RecentViewFilter): void;
@@ -329,10 +330,70 @@ export const useTabs = create<TabsState>()((set, get) => ({
 
   reconcileRecentTerminals: (ids) => set((state) => {
     const authoritativeIds = new Set(ids);
+    const hasStaleRecent = state.recentViews.some((recent) =>
+      recent.kind === "terminal" && !authoritativeIds.has(recent.id),
+    );
+    if (!hasStaleRecent) return state;
     return {
       recentViews: state.recentViews.filter((recent) =>
         recent.kind !== "terminal" || authoritativeIds.has(recent.id),
       ),
+    };
+  }),
+
+  reconcileTerminalSessions: (liveSessionNames) => set((state) => {
+    const liveNames = new Set(liveSessionNames);
+    const removedIds: Record<string, true> = {};
+    for (const tab of state.tabs) {
+      if (tab.kind === "terminal" && (!tab.sessionName || !liveNames.has(tab.sessionName))) {
+        removedIds[tab.id] = true;
+      }
+    }
+
+    const hasRemovedTabs = Object.keys(removedIds).length > 0;
+    const tabs = hasRemovedTabs
+      ? state.tabs.filter((tab) => !removedIds[tab.id])
+      : state.tabs;
+    let activeTabId = state.activeTabId;
+    if (activeTabId && removedIds[activeTabId]) {
+      const activeIndex = state.tabs.findIndex((tab) => tab.id === activeTabId);
+      const left = state.tabs
+        .slice(0, Math.max(0, activeIndex))
+        .reverse()
+        .find((tab) => !removedIds[tab.id]);
+      const right = state.tabs
+        .slice(Math.max(0, activeIndex + 1))
+        .find((tab) => !removedIds[tab.id]);
+      activeTabId = left?.id ?? right?.id ?? null;
+    }
+
+    const hasStaleRecent = state.recentViews.some((recent) =>
+      recent.kind === "terminal" && !liveNames.has(recent.id),
+    );
+    const recentViews = hasStaleRecent
+      ? state.recentViews.filter((recent) => recent.kind !== "terminal" || liveNames.has(recent.id))
+      : state.recentViews;
+    const terminalSessionRequest = state.terminalSessionRequest
+      && !liveNames.has(state.terminalSessionRequest.sessionName)
+      ? null
+      : state.terminalSessionRequest;
+    if (!hasRemovedTabs && !hasStaleRecent && terminalSessionRequest === state.terminalSessionRequest) {
+      return state;
+    }
+
+    const pruned = hasRemovedTabs
+      ? pruneHistory(state.viewHistory, state.historyIndex, removedIds)
+      : historyPatch(state.viewHistory, state.historyIndex);
+    const navigation = activeTabId
+      ? recordHistory(pruned.viewHistory, pruned.historyIndex, activeTabId)
+      : pruned;
+
+    return {
+      tabs,
+      activeTabId,
+      ...navigation,
+      recentViews,
+      terminalSessionRequest,
     };
   }),
 

--- a/tests/desktop/mission-control.test.tsx
+++ b/tests/desktop/mission-control.test.tsx
@@ -8,6 +8,7 @@ import { codingAgentRuntimeScope } from "../../desktop/src/shared/coding-agent-p
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 import { useBoard, type Project } from "../../desktop/src/renderer/src/stores/board";
 import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
+import { useShellSessions } from "../../desktop/src/renderer/src/stores/shell-sessions";
 import { useUi } from "../../desktop/src/renderer/src/stores/ui";
 
 vi.mock("../../desktop/src/renderer/src/features/mission-control/Sidebar", () => ({
@@ -53,6 +54,10 @@ vi.mock("../../desktop/src/renderer/src/lib/kernel-wiring", () => ({
 describe("MissionControl", () => {
   beforeEach(() => {
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    useShellSessions.setState({
+      ...useShellSessions.getInitialState(),
+      load: vi.fn().mockResolvedValue([]),
+    });
   });
 
   afterEach(() => {
@@ -120,6 +125,45 @@ describe("MissionControl", () => {
       "[mission-control] restore last project failed:",
       "project refresh failed",
     );
+  });
+
+  it("loads canonical shell sessions immediately for the signed-in desktop", async () => {
+    const api = { get: vi.fn() };
+    const load = vi.fn().mockResolvedValue([]);
+    useShellSessions.setState({ load });
+    useBoard.setState({ loadProjects: vi.fn(async () => undefined) });
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: api as never,
+    });
+
+    render(<MissionControl />);
+
+    await waitFor(() => expect(load).toHaveBeenCalledWith(api));
+  });
+
+  it("restarts shell synchronization when the selected runtime changes", async () => {
+    const api = { get: vi.fn() };
+    const load = vi.fn().mockResolvedValue([]);
+    useShellSessions.setState({ load });
+    useBoard.setState({ loadProjects: vi.fn(async () => undefined) });
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: api as never,
+    });
+
+    render(<MissionControl />);
+    await waitFor(() => expect(load).toHaveBeenCalledTimes(1));
+
+    act(() => useConnection.setState({ runtimeSlot: "preview" }));
+
+    await waitFor(() => expect(load).toHaveBeenCalledTimes(2));
   });
 
   it("selects a valid project from the new runtime instead of restoring a stale slug", async () => {

--- a/tests/desktop/shell-session-sync.test.ts
+++ b/tests/desktop/shell-session-sync.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "@desktop/renderer/src/lib/api";
+import {
+  SHELL_SESSION_SYNC_INTERVAL_MS,
+  startShellSessionSync,
+  syncShellSessions,
+} from "@desktop/renderer/src/lib/shell-session-sync";
+import { useShellSessions } from "@desktop/renderer/src/stores/shell-sessions";
+import { useTabs } from "@desktop/renderer/src/stores/tabs";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+describe("desktop shell-session synchronization", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useShellSessions.setState(useShellSessions.getInitialState(), true);
+    useTabs.setState(useTabs.getInitialState(), true);
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("reconciles tabs only from an accepted authoritative snapshot", async () => {
+    const home = useTabs.getState().openTab({ kind: "home", title: "Home", closable: false });
+    useTabs.getState().openTab({ kind: "terminal", sessionName: "matrix-deleted", title: "matrix-deleted" });
+    const load = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce([]);
+    useShellSessions.setState({ load });
+
+    expect(await syncShellSessions({} as ApiClient)).toBeNull();
+    expect(useTabs.getState().tabs).toHaveLength(2);
+
+    expect(await syncShellSessions({} as ApiClient)).toEqual([]);
+    expect(useTabs.getState().tabs.map((tab) => tab.id)).toEqual([home]);
+  });
+
+  it("polls every five seconds while visible and applies external deletion", async () => {
+    const api = {} as ApiClient;
+    const home = useTabs.getState().openTab({ kind: "home", title: "Home", closable: false });
+    useTabs.getState().openTab({ kind: "terminal", sessionName: "matrix-main", title: "matrix-main" });
+    const load = vi.fn()
+      .mockResolvedValueOnce([{ name: "matrix-main", status: "active" }])
+      .mockResolvedValueOnce([]);
+    useShellSessions.setState({ load });
+
+    const stop = startShellSessionSync(api);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(useTabs.getState().tabs).toHaveLength(2);
+
+    await vi.advanceTimersByTimeAsync(SHELL_SESSION_SYNC_INTERVAL_MS);
+    expect(load).toHaveBeenCalledTimes(2);
+    expect(useTabs.getState().tabs.map((tab) => tab.id)).toEqual([home]);
+    stop();
+  });
+
+  it("refreshes on focus and visibility restoration, but pauses hidden polling", async () => {
+    const load = vi.fn().mockResolvedValue([]);
+    useShellSessions.setState({ load });
+    const stop = startShellSessionSync({} as ApiClient);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(load).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+    await vi.advanceTimersByTimeAsync(SHELL_SESSION_SYNC_INTERVAL_MS * 2);
+    window.dispatchEvent(new Event("focus"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(load).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(load).toHaveBeenCalledTimes(2);
+
+    window.dispatchEvent(new Event("focus"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(load).toHaveBeenCalledTimes(3);
+    stop();
+  });
+
+  it("does not overlap slow refreshes and stops timers and listeners on cleanup", async () => {
+    const pending = deferred<[]>();
+    const load = vi.fn().mockReturnValueOnce(pending.promise).mockResolvedValue([]);
+    useShellSessions.setState({ load });
+    const stop = startShellSessionSync({} as ApiClient);
+    await vi.advanceTimersByTimeAsync(0);
+
+    await vi.advanceTimersByTimeAsync(SHELL_SESSION_SYNC_INTERVAL_MS * 2);
+    window.dispatchEvent(new Event("focus"));
+    expect(load).toHaveBeenCalledTimes(1);
+
+    pending.resolve([]);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(SHELL_SESSION_SYNC_INTERVAL_MS);
+    expect(load).toHaveBeenCalledTimes(2);
+
+    stop();
+    await vi.advanceTimersByTimeAsync(SHELL_SESSION_SYNC_INTERVAL_MS * 2);
+    window.dispatchEvent(new Event("focus"));
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/desktop/shell-sessions-store.test.ts
+++ b/tests/desktop/shell-sessions-store.test.ts
@@ -89,7 +89,7 @@ describe("useShellSessions", () => {
       return { sessions: [] };
     });
 
-    await useShellSessions.getState().load(makeApi({ get }));
+    const accepted = await useShellSessions.getState().load(makeApi({ get }));
 
     expect(get).toHaveBeenCalledTimes(1);
     expect(get).toHaveBeenCalledWith("/api/terminal/sessions");
@@ -108,6 +108,39 @@ describe("useShellSessions", () => {
       branch: "codex/session-context",
       pullRequest: { number: 1032, url: "https://github.com/HamedMP/matrix-os/pull/1032" },
     });
+    expect(accepted?.map((session) => session.name)).toEqual(["matrix-main"]);
+  });
+
+  it("preserves the last authoritative snapshot when the sessions payload is malformed", async () => {
+    const previous = [{ name: "matrix-existing", status: "active" as const }];
+    useShellSessions.setState({ sessions: previous });
+
+    const accepted = await useShellSessions.getState().load(makeApi({
+      get: vi.fn().mockResolvedValue({ sessions: null }),
+    }));
+
+    expect(accepted).toBeNull();
+    expect(useShellSessions.getState()).toMatchObject({
+      sessions: previous,
+      loading: false,
+      error: "server",
+    });
+  });
+
+  it("preserves the last authoritative snapshot when loading fails", async () => {
+    const previous = [{ name: "matrix-existing", status: "active" as const }];
+    useShellSessions.setState({ sessions: previous });
+
+    const accepted = await useShellSessions.getState().load(makeApi({
+      get: vi.fn().mockRejectedValue(new AppError("offline")),
+    }));
+
+    expect(accepted).toBeNull();
+    expect(useShellSessions.getState()).toMatchObject({
+      sessions: previous,
+      loading: false,
+      error: "offline",
+    });
   });
 
   it("ignores stale load results with a resettable store sequence", async () => {
@@ -118,11 +151,13 @@ describe("useShellSessions", () => {
       .mockResolvedValueOnce({ sessions: [{ name: "matrix-fresh" }] });
 
     const staleLoad = useShellSessions.getState().load(makeApi({ get }));
-    await useShellSessions.getState().load(makeApi({ get }));
+    const freshResult = await useShellSessions.getState().load(makeApi({ get }));
     staleResponse.resolve({ sessions: [{ name: "matrix-stale" }] });
-    await staleLoad;
+    const staleResult = await staleLoad;
 
     expect(useShellSessions.getState().sessions.map((session) => session.name)).toEqual(["matrix-fresh"]);
+    expect(freshResult?.map((session) => session.name)).toEqual(["matrix-fresh"]);
+    expect(staleResult).toBeNull();
 
     useShellSessions.setState(useShellSessions.getInitialState(), true);
     await useShellSessions.getState().load(makeApi({
@@ -130,6 +165,24 @@ describe("useShellSessions", () => {
     }));
 
     expect(useShellSessions.getState().sessions.map((session) => session.name)).toEqual(["matrix-reset"]);
+  });
+
+  it("drops an in-flight load from the previous runtime without clearing the current snapshot", async () => {
+    const oldRuntimeResponse = deferred<{ sessions: Array<{ name: string }> }>();
+    const pending = useShellSessions.getState().load(makeApi({
+      get: vi.fn().mockReturnValue(oldRuntimeResponse.promise),
+    }));
+
+    advanceRuntimeGeneration();
+    useShellSessions.setState({
+      sessions: [{ name: "matrix-current", status: "active" }],
+      loading: false,
+      error: null,
+    });
+    oldRuntimeResponse.resolve({ sessions: [{ name: "matrix-old" }] });
+
+    expect(await pending).toBeNull();
+    expect(useShellSessions.getState().sessions.map((session) => session.name)).toEqual(["matrix-current"]);
   });
 
   it("creates shell sessions with two-word names, projects cwd, and retries one 409 conflict", async () => {

--- a/tests/desktop/tabs-store.test.ts
+++ b/tests/desktop/tabs-store.test.ts
@@ -126,6 +126,30 @@ describe("tabs store", () => {
     expect(useTabs.getState().recentViews.map((recent) => recent.id)).toEqual(["thread-live"]);
   });
 
+  it("atomically closes every missing terminal tab and focuses the nearest retained tab", () => {
+    useTabs.getState().ensureNavigationScope("runtime-a");
+    const home = useTabs.getState().openTab({ kind: "home", title: "Home", closable: false });
+    const live = useTabs.getState().openTab({ kind: "terminal", sessionName: "matrix-live", title: "matrix-live" });
+    const missing = useTabs.getState().openTab({ kind: "terminal", sessionName: "matrix-missing", title: "matrix-missing" });
+    const alsoMissing = useTabs.getState().openTab({
+      kind: "terminal",
+      sessionName: "matrix-also-missing",
+      title: "matrix-also-missing",
+    });
+    useTabs.getState().recordRecentTerminal("matrix-live", "matrix-live");
+    useTabs.getState().recordRecentTerminal("matrix-missing", "matrix-missing");
+    useTabs.getState().requestTerminalSession("matrix-missing");
+
+    useTabs.getState().reconcileTerminalSessions(["matrix-live"]);
+
+    expect(useTabs.getState().tabs.map((tab) => tab.id)).toEqual([home, live]);
+    expect(useTabs.getState().activeTabId).toBe(live);
+    expect(useTabs.getState().viewHistory).not.toContain(missing);
+    expect(useTabs.getState().viewHistory).not.toContain(alsoMissing);
+    expect(useTabs.getState().recentViews.map((recent) => recent.id)).toEqual(["matrix-live"]);
+    expect(useTabs.getState().terminalSessionRequest).toBeNull();
+  });
+
   it("seeds the safe Home root after a runtime transition changes navigation scope", () => {
     const homeId = useTabs.getState().openTab({ kind: "home", title: "Home", closable: false });
 

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -71,7 +71,7 @@ describe("TerminalsTab", () => {
     });
     useShellSessions.setState({
       ...useShellSessions.getInitialState(),
-      load: vi.fn().mockResolvedValue(undefined),
+      load: vi.fn().mockResolvedValue([]),
       create: vi.fn().mockResolvedValue({ name: "matrix-created", status: "active" }),
       deleteSession: vi.fn().mockResolvedValue(true),
       rename: vi.fn().mockResolvedValue(true),
@@ -112,6 +112,50 @@ describe("TerminalsTab", () => {
     openShellActions("matrix-active");
     expect(screen.getByRole("menuitem", { name: "Move to background" })).toBeTruthy();
     expect(screen.queryByText("Workspace Only")).toBeNull();
+  });
+
+  it("leaves loading ownership to MissionControl and reconciles a manual retry", async () => {
+    const load = vi.fn().mockResolvedValue([]);
+    useShellSessions.setState({ sessions: [], loading: false, error: "network", load });
+    useTabs.setState(useTabs.getInitialState(), true);
+    const home = useTabs.getState().openTab({ kind: "home", title: "Home", closable: false });
+    useTabs.getState().openTab({
+      kind: "terminal",
+      sessionName: "matrix-deleted",
+      title: "matrix-deleted",
+    });
+
+    renderTab();
+
+    expect(load).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Retry terminal sessions" }));
+
+    await waitFor(() => expect(load).toHaveBeenCalledOnce());
+    expect(useTabs.getState().tabs.map((tab) => tab.id)).toEqual([home]);
+    expect(useTabs.getState().activeTabId).toBe(home);
+  });
+
+  it("routes the list refresh button through authoritative tab reconciliation", async () => {
+    const load = vi.fn().mockResolvedValue([{ name: "matrix-live", status: "active" }]);
+    useShellSessions.setState({
+      sessions: [{ name: "matrix-live", status: "active" }],
+      loading: false,
+      error: null,
+      load,
+    });
+    useTabs.setState(useTabs.getInitialState(), true);
+    const home = useTabs.getState().openTab({ kind: "home", title: "Home", closable: false });
+    useTabs.getState().openTab({
+      kind: "terminal",
+      sessionName: "matrix-deleted",
+      title: "matrix-deleted",
+    });
+
+    renderTab();
+    fireEvent.click(screen.getByRole("button", { name: "Refresh terminal sessions" }));
+
+    await waitFor(() => expect(load).toHaveBeenCalledOnce());
+    expect(useTabs.getState().tabs.map((tab) => tab.id)).toEqual([home]);
   });
 
   it("opens the Figma-aligned session detail and releases its live attachment while preserving the mounted terminal on return", () => {
@@ -301,6 +345,7 @@ describe("TerminalsTab", () => {
       loading: false,
       error: null,
       loadSequence: 1,
+      authoritativeRevision: 1,
     });
 
     renderTab();
@@ -338,6 +383,33 @@ describe("TerminalsTab", () => {
     for (let index = 2; index <= 9; index += 1) {
       expect(screen.getByTestId(`terminal-view-matrix-${index}`)).toBeTruthy();
     }
+  });
+
+  it("unmounts cached terminal detail after an authoritative snapshot deletes it", async () => {
+    useShellSessions.setState({
+      sessions: [{ name: "matrix-main", status: "active", placement: "active" }],
+      loading: false,
+      error: null,
+      loadSequence: 1,
+      authoritativeRevision: 1,
+    });
+    renderTab();
+    fireEvent.click(screen.getByRole("button", { name: "Open matrix-main" }));
+    expect(terminalMounts.get("matrix-main")).toBe(1);
+
+    act(() => {
+      useShellSessions.setState({
+        sessions: [],
+        loading: false,
+        error: null,
+        loadSequence: 2,
+        authoritativeRevision: 2,
+      });
+    });
+
+    await waitFor(() => expect(screen.queryByTestId("terminal-view-matrix-main")).toBeNull());
+    expect(screen.getByRole("heading", { name: "Terminal" })).toBeTruthy();
+    expect(terminalMounts.get("matrix-main")).toBe(0);
   });
 
   it("uses the Figma list toolbar and reveals a bounded search-empty state", () => {
@@ -588,6 +660,34 @@ describe("TerminalsTab", () => {
     await waitFor(() => expect(useTabs.getState().recentViews).toEqual([]));
   });
 
+  it("reconciles open terminal tabs after a successful desktop deletion", async () => {
+    const deleteSession = vi.fn(async () => {
+      useShellSessions.setState({
+        sessions: [{ name: "matrix-live", status: "active", placement: "active" }],
+      });
+      return true;
+    });
+    useShellSessions.setState({
+      sessions: [
+        { name: "matrix-live", status: "active", placement: "active" },
+        { name: "matrix-delete", status: "active", placement: "active" },
+      ],
+      deleteSession,
+    });
+    useTabs.setState(useTabs.getInitialState(), true);
+    const home = useTabs.getState().openTab({ kind: "home", title: "Home", closable: false });
+    useTabs.getState().openTab({ kind: "terminal", sessionName: "matrix-delete", title: "matrix-delete" });
+
+    renderTab();
+    openShellActions("matrix-delete");
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+    fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() => expect(deleteSession).toHaveBeenCalledOnce());
+    await waitFor(() => expect(useTabs.getState().tabs.map((tab) => tab.id)).toEqual([home]));
+    expect(useTabs.getState().activeTabId).toBe(home);
+  });
+
   it("removes stale terminal Recents after an authoritative session load", async () => {
     useTabs.getState().recordRecentTerminal("matrix-live", "matrix-live");
     useTabs.getState().recordRecentTerminal("matrix-deleted", "matrix-deleted");
@@ -596,6 +696,7 @@ describe("TerminalsTab", () => {
       loading: false,
       error: null,
       loadSequence: 1,
+      authoritativeRevision: 1,
     });
 
     renderTab();


### PR DESCRIPTION
## Summary
- make MissionControl own canonical terminal-session synchronization with immediate, five-second, focus, and visibility refreshes
- accept only authoritative session snapshots and protect state across failures, stale requests, and runtime changes
- atomically close tabs and cached terminal views for externally deleted sessions, including manual refresh and desktop delete flows

## Tests
- pnpm exec vitest run tests/desktop/shell-session-sync.test.ts tests/desktop/shell-sessions-store.test.ts tests/desktop/tabs-store.test.ts tests/desktop/terminals-tab.test.tsx tests/desktop/mission-control.test.tsx tests/desktop/runtime-transition.test.ts (91 passed)
- pnpm --filter desktop typecheck
- bun run typecheck
- bun run check:patterns (0 violations)
- env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false pnpm exec vitest run tests/gateway/coding-agents-summary.test.ts (52 passed)
- repository-wide bun run test was attempted and stopped after unrelated baseline environment failures: git fixture commits inherited local GPG signing, and default-app suites had unavailable Node 24 localStorage

## Invariants
- Source of truth: /api/terminal/sessions remains the canonical list for every terminal surface.
- Lock/transaction scope: no database or API mutation changes; one desktop synchronizer coalesces its own refreshes, while store sequence and runtime-generation checks reject stale results.
- Acceptable orphan states: request, malformed-response, and stale-runtime failures retain the prior session list and tabs; only an accepted authoritative snapshot removes terminal UI state.
- Auth source of truth: the existing runtime-scoped ApiClient and connection runtime generation remain authoritative.
- Deferred scope: server-pushed lifecycle events and workspace-history records under /api/sessions are unchanged.

## Review / Monitoring
- Monitor Greptile until the latest trusted review reaches 5/5.
- Add ready-for-ci only after Greptile reaches 5/5, then wait for all triggered CI checks.