### PR TITLE
fix(desktop): restore terminal copy actions

### DIFF
--- a/desktop/src/renderer/src/features/terminal/TerminalLinkContextMenu.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalLinkContextMenu.tsx
@@ -1,19 +1,22 @@
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
-import { Copy, ExternalLink } from "lucide-react";
+import { Copy, ExternalLink, TextSelect } from "lucide-react";
 import type { TerminalLinkEntry } from "./terminal-link-actions";
 
-export interface DesktopTerminalLinkMenuState {
+export interface DesktopTerminalMenuState {
   x: number;
   y: number;
-  link: TerminalLinkEntry;
+  link: TerminalLinkEntry | null;
+  selection: string;
 }
 
 interface TerminalLinkContextMenuProps {
-  menu: DesktopTerminalLinkMenuState | null;
+  menu: DesktopTerminalMenuState | null;
   onClose: () => void;
   onOpen: (link: TerminalLinkEntry) => void;
   onCopy: (link: TerminalLinkEntry) => void;
+  onCopySelection: (selection: string) => void;
+  onSelectAll: () => void;
 }
 
 function openLabel(link: TerminalLinkEntry): string {
@@ -25,6 +28,8 @@ export default function TerminalLinkContextMenu({
   onClose,
   onOpen,
   onCopy,
+  onCopySelection,
+  onSelectAll,
 }: TerminalLinkContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const firstActionRef = useRef<HTMLButtonElement>(null);
@@ -52,9 +57,17 @@ export default function TerminalLinkContextMenu({
   if (!menu) return null;
 
   const x = Math.max(8, Math.min(menu.x, window.innerWidth - 228));
-  const y = Math.max(8, Math.min(menu.y, window.innerHeight - 132));
+  const y = Math.max(8, Math.min(menu.y, window.innerHeight - (menu.link ? 248 : 104)));
   const perform = (action: (link: TerminalLinkEntry) => void) => {
-    action(menu.link);
+    if (menu.link) action(menu.link);
+    onClose();
+  };
+  const performSelectionCopy = () => {
+    if (menu.selection) onCopySelection(menu.selection);
+    onClose();
+  };
+  const performSelectAll = () => {
+    onSelectAll();
     onClose();
   };
   const itemClass =
@@ -64,7 +77,7 @@ export default function TerminalLinkContextMenu({
     <div
       ref={menuRef}
       role="menu"
-      aria-label="Link actions"
+      aria-label="Terminal actions"
       className="fade-in fixed z-[100] w-[220px] overflow-hidden rounded-lg border p-1"
       style={{
         left: x,
@@ -75,35 +88,64 @@ export default function TerminalLinkContextMenu({
         boxShadow: "var(--shadow-2)",
       }}
     >
-      <div className="border-b px-2 py-1.5" style={{ borderColor: "var(--border-subtle)" }}>
-        <div className="truncate text-xs font-semibold">
-          {menu.link.kind === "web" ? menu.link.hostname : menu.link.providerLabel}
+      {menu.link ? (
+        <div className="border-b px-2 py-1.5" style={{ borderColor: "var(--border-subtle)" }}>
+          <div className="truncate text-xs font-semibold">
+            {menu.link.kind === "web" ? menu.link.hostname : menu.link.providerLabel}
+          </div>
+          <div className="truncate text-[11px]" style={{ color: "var(--text-tertiary)" }}>
+            {menu.link.displayPath}
+          </div>
         </div>
-        <div className="truncate text-[11px]" style={{ color: "var(--text-tertiary)" }}>
-          {menu.link.displayPath}
-        </div>
-      </div>
+      ) : null}
       <button
-        ref={firstActionRef}
+        ref={menu.selection ? firstActionRef : undefined}
         type="button"
         role="menuitem"
-        aria-label={openLabel(menu.link)}
-        onClick={() => perform(onOpen)}
-        className={itemClass}
-      >
-        <ExternalLink aria-hidden="true" className="size-4" style={{ color: "var(--text-tertiary)" }} />
-        {openLabel(menu.link)}
-      </button>
-      <button
-        type="button"
-        role="menuitem"
-        aria-label="Copy Link"
-        onClick={() => perform(onCopy)}
-        className={itemClass}
+        aria-label="Copy"
+        disabled={!menu.selection}
+        onClick={performSelectionCopy}
+        className={`${itemClass} disabled:opacity-40`}
       >
         <Copy aria-hidden="true" className="size-4" style={{ color: "var(--text-tertiary)" }} />
-        Copy Link
+        Copy
       </button>
+      <button
+        ref={menu.selection ? undefined : firstActionRef}
+        type="button"
+        role="menuitem"
+        aria-label="Select All"
+        onClick={performSelectAll}
+        className={itemClass}
+      >
+        <TextSelect aria-hidden="true" className="size-4" style={{ color: "var(--text-tertiary)" }} />
+        Select All
+      </button>
+      {menu.link ? (
+        <>
+          <div className="my-1 border-t" style={{ borderColor: "var(--border-subtle)" }} />
+          <button
+            type="button"
+            role="menuitem"
+            aria-label={openLabel(menu.link)}
+            onClick={() => perform(onOpen)}
+            className={itemClass}
+          >
+            <ExternalLink aria-hidden="true" className="size-4" style={{ color: "var(--text-tertiary)" }} />
+            {openLabel(menu.link)}
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            aria-label="Copy Link"
+            onClick={() => perform(onCopy)}
+            className={itemClass}
+          >
+            <Copy aria-hidden="true" className="size-4" style={{ color: "var(--text-tertiary)" }} />
+            Copy Link
+          </button>
+        </>
+      ) : null}
     </div>,
     document.body,
   );

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -14,11 +14,12 @@ import { buildTerminalFontStack } from "../../lib/terminal/terminal-fonts";
 import type { ActiveAttachment } from "./attach-manager";
 import type { ShellSocketState } from "../../lib/shell-socket";
 import { getAttachManager } from "./terminal-runtime";
-import TerminalLinkContextMenu, { type DesktopTerminalLinkMenuState } from "./TerminalLinkContextMenu";
+import TerminalLinkContextMenu, { type DesktopTerminalMenuState } from "./TerminalLinkContextMenu";
 import {
   DesktopWebLinkProvider,
   activateDesktopTerminalLink,
   copyDesktopTerminalLink,
+  copyDesktopTerminalText,
   findDesktopTerminalLinkAtPointer,
   openDesktopTerminalLink,
   resolveDesktopTerminalLink,
@@ -71,8 +72,8 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
   const hoveredLinkRef = useRef<TerminalLinkEntry | null>(null);
   const [socketState, setSocketState] = useState<ShellSocketState>("connecting");
   const [exitCode, setExitCode] = useState<number | null>(null);
-  const [linkContextMenu, setLinkContextMenu] = useState<DesktopTerminalLinkMenuState | null>(null);
-  const closeLinkContextMenu = useCallback(() => setLinkContextMenu(null), []);
+  const [terminalContextMenu, setTerminalContextMenu] = useState<DesktopTerminalMenuState | null>(null);
+  const closeTerminalContextMenu = useCallback(() => setTerminalContextMenu(null), []);
   const [pasteError, setPasteError] = useState<string | null>(null);
 
   if (stateSessionName !== sessionName) {
@@ -114,6 +115,24 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
     terminal.loadAddon(fit);
     terminal.loadAddon(serialize);
     terminal.open(host);
+    terminal.attachCustomKeyEventHandler((event) => {
+      if (event.type !== "keydown" || !terminal.hasSelection()) return true;
+      const key = event.key.toLowerCase();
+      const isMacCopy = key === "c"
+        && event.metaKey
+        && !event.ctrlKey
+        && !event.altKey
+        && !event.shiftKey;
+      const isTerminalCopy = key === "c"
+        && event.ctrlKey
+        && event.shiftKey
+        && !event.metaKey
+        && !event.altKey;
+      if (!isMacCopy && !isTerminalCopy) return true;
+      event.preventDefault();
+      copyDesktopTerminalText(terminal.getSelection());
+      return false;
+    });
     applyTerminalSurfaceTheme(terminal.element, theme.background);
     const linkProviderDisposable = terminal.registerLinkProvider(
       new DesktopWebLinkProvider(terminal, (link) => {
@@ -136,15 +155,19 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
       event.stopPropagation();
       if (event.button === 0) openDesktopTerminalLink(link);
     };
-    const onLinkContextMenu = (event: MouseEvent) => {
+    const onTerminalContextMenu = (event: MouseEvent) => {
       const link = linkAtPointer(event);
-      if (!link) return;
       event.preventDefault();
       event.stopPropagation();
-      setLinkContextMenu({ x: event.clientX, y: event.clientY, link });
+      setTerminalContextMenu({
+        x: event.clientX,
+        y: event.clientY,
+        link,
+        selection: terminal.getSelection(),
+      });
     };
     host.addEventListener("mouseup", onLinkMouseUp, true);
-    host.addEventListener("contextmenu", onLinkContextMenu);
+    host.addEventListener("contextmenu", onTerminalContextMenu);
     try {
       terminal.loadAddon(new WebglAddon());
     } catch (err: unknown) {
@@ -178,10 +201,10 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
     observer.observe(host);
 
     return () => {
-      closeLinkContextMenu();
+      closeTerminalContextMenu();
       hoveredLinkRef.current = null;
       host.removeEventListener("mouseup", onLinkMouseUp, true);
-      host.removeEventListener("contextmenu", onLinkContextMenu);
+      host.removeEventListener("contextmenu", onTerminalContextMenu);
       linkProviderDisposable.dispose();
       unsubscribeAppearance();
       observer.disconnect();
@@ -199,7 +222,7 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
       terminal.dispose();
       termRef.current = null;
     };
-  }, [closeLinkContextMenu, sessionName]);
+  }, [closeTerminalContextMenu, sessionName]);
 
   // Attach lifecycle — only the active tab holds the live socket (L4).
   useEffect(() => {
@@ -209,7 +232,7 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
     if (!active) {
       terminal.blur();
       hoveredLinkRef.current = null;
-      closeLinkContextMenu();
+      closeTerminalContextMenu();
       return;
     }
     if (endedRef.current) return;
@@ -247,7 +270,7 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
       attachmentRef.current = null;
       if (manager.activeSessionName === sessionName) manager.detachActive();
     };
-  }, [sessionName, active, closeLinkContextMenu]);
+  }, [sessionName, active, closeTerminalContextMenu]);
 
   useEffect(() => {
     const host = hostRef.current;
@@ -375,10 +398,12 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
         </div>
       ) : null}
       <TerminalLinkContextMenu
-        menu={linkContextMenu}
-        onClose={closeLinkContextMenu}
+        menu={terminalContextMenu}
+        onClose={closeTerminalContextMenu}
         onOpen={openDesktopTerminalLink}
         onCopy={copyDesktopTerminalLink}
+        onCopySelection={copyDesktopTerminalText}
+        onSelectAll={() => termRef.current?.selectAll()}
       />
     </div>
   );

--- a/desktop/src/renderer/src/features/terminal/terminal-link-actions.ts
+++ b/desktop/src/renderer/src/features/terminal/terminal-link-actions.ts
@@ -110,24 +110,28 @@ function tryFallbackCopy(text: string): void {
     fallbackCopy(text);
   } catch (err: unknown) {
     console.warn(
-      "Desktop terminal link fallback copy failed:",
+      "Desktop terminal fallback copy failed:",
       err instanceof Error ? err.message : err,
     );
   }
 }
 
-export function copyDesktopTerminalLink(link: TerminalLinkEntry): void {
+export function copyDesktopTerminalText(text: string): void {
   if (navigator.clipboard?.writeText) {
-    navigator.clipboard.writeText(link.url).catch((err: unknown) => {
+    navigator.clipboard.writeText(text).catch((err: unknown) => {
       console.warn(
         "Desktop terminal clipboard write failed, using fallback:",
         err instanceof Error ? err.message : err,
       );
-      tryFallbackCopy(link.url);
+      tryFallbackCopy(text);
     });
     return;
   }
-  tryFallbackCopy(link.url);
+  tryFallbackCopy(text);
+}
+
+export function copyDesktopTerminalLink(link: TerminalLinkEntry): void {
+  copyDesktopTerminalText(link.url);
 }
 
 export function activateDesktopTerminalLink(

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -13,6 +13,7 @@ import {
   terminalPasteFiles,
 } from "@desktop/renderer/src/features/terminal/terminal-rich-paste";
 
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
 const attachMock = vi.fn();
 const attachmentWrite = vi.fn();
 const attachmentResize = vi.fn();
@@ -30,6 +31,9 @@ const { createdFitAddons, createdTerminals, resizeObserverCallbacks } = vi.hoist
     element: HTMLElement | null;
     focus: ReturnType<typeof vi.fn>;
     blur: ReturnType<typeof vi.fn>;
+    selection: string;
+    customKeyEventHandler?: (event: KeyboardEvent) => boolean;
+    selectAll: ReturnType<typeof vi.fn>;
   }>,
   resizeObserverCallbacks: [] as ResizeObserverCallback[],
 }));
@@ -58,6 +62,9 @@ vi.mock("@xterm/xterm", () => ({
       };
     };
     registeredProviders: unknown[] = [];
+    selection = "";
+    customKeyEventHandler?: (event: KeyboardEvent) => boolean;
+    selectAll = vi.fn();
 
     constructor(options: FakeTerminal["initialOptions"]) {
       this.initialOptions = options;
@@ -85,6 +92,15 @@ vi.mock("@xterm/xterm", () => ({
     onData(callback: (data: string) => void): { dispose: () => void } {
       this.dataCallback = callback;
       return { dispose: () => {} };
+    }
+    attachCustomKeyEventHandler(callback: (event: KeyboardEvent) => boolean): void {
+      this.customKeyEventHandler = callback;
+    }
+    hasSelection(): boolean {
+      return this.selection.length > 0;
+    }
+    getSelection(): string {
+      return this.selection;
     }
     registerLinkProvider(provider: unknown): { dispose: () => void } {
       this.registeredProviders.push(provider);
@@ -166,6 +182,11 @@ describe("TerminalView session switching", () => {
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
+    if (originalClipboardDescriptor) {
+      Object.defineProperty(navigator, "clipboard", originalClipboardDescriptor);
+    } else {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
   });
 
   it("fills the terminal content area without an inset or mismatched xterm surface", () => {
@@ -377,6 +398,65 @@ describe("TerminalView session switching", () => {
       "_blank",
       "noopener,noreferrer",
     );
+  });
+
+  it("copies the xterm selection with the desktop copy shortcut", () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    render(<TerminalView sessionName="alpha" />);
+    const terminal = createdTerminals.at(-1)!;
+    terminal.selection = "HTTP/1.1 401 Unauthorized";
+    const preventDefault = vi.fn();
+
+    const handled = terminal.customKeyEventHandler?.({
+      type: "keydown",
+      key: "c",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      preventDefault,
+    } as unknown as KeyboardEvent);
+
+    expect(handled).toBe(false);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(writeText).toHaveBeenCalledWith("HTTP/1.1 401 Unauthorized");
+    expect(attachmentWrite).not.toHaveBeenCalled();
+  });
+
+  it("opens terminal actions on right click and copies the xterm selection", () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const { container } = render(<TerminalView sessionName="alpha" />);
+    const terminal = createdTerminals.at(-1)!;
+    terminal.selection = "content-type: application/json";
+    const host = container.querySelector<HTMLElement>("[data-terminal-viewport]")!;
+
+    expect(fireEvent.contextMenu(host, { clientX: 120, clientY: 80 })).toBe(false);
+    expect(screen.getByRole("menu", { name: "Terminal actions" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy" }));
+
+    expect(writeText).toHaveBeenCalledWith("content-type: application/json");
+  });
+
+  it("opens terminal actions without a selection and can select the buffer", () => {
+    const { container } = render(<TerminalView sessionName="alpha" />);
+    const terminal = createdTerminals.at(-1)!;
+    const host = container.querySelector<HTMLElement>("[data-terminal-viewport]")!;
+
+    expect(fireEvent.contextMenu(host, { clientX: 120, clientY: 80 })).toBe(false);
+    expect((screen.getByRole("menuitem", { name: "Copy" }) as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Select All" }));
+
+    expect(terminal.selectAll).toHaveBeenCalledOnce();
   });
 
   it("filters terminal files to supported image formats and strips nested paste markers", () => {


### PR DESCRIPTION
## Summary
- copy the active xterm selection with Cmd+C and Ctrl+Shift+C
- add a terminal-wide right-click menu with Copy and Select All
- preserve validated Open Link and Copy Link actions

## Tests
- bun run test -- tests/desktop/terminal-view.test.tsx tests/desktop/terminal-link-actions.test.ts tests/desktop/menu-template.test.ts
- pnpm --filter desktop exec tsc --noEmit -p tsconfig.json
- pnpm --filter desktop build
- git diff --check

## Review/Monitoring
- focused renderer regression coverage added for keyboard copy, right-click copy, and right-click without a selection
- full desktop typecheck Node-config phase is affected by the existing worktree Vite 6/Vite 7 dependency skew; renderer typecheck and production build pass

## Invariants
- Source of truth: xterm remains the owner of terminal selection and buffer state
- Lock/transaction scope: not applicable; renderer-only interaction change with no persistence
- Acceptable orphan states: none introduced
- Auth source of truth: unchanged
- Deferred scope: no clipboard paste action added