### PR TITLE
refactor(gateway): separate project registry from workspaces

### DIFF
--- a/desktop/src/renderer/src/features/board/AddProjectStepFields.tsx
+++ b/desktop/src/renderer/src/features/board/AddProjectStepFields.tsx
@@ -131,7 +131,13 @@ export function ExistingFolderStepFields({
     // for those already-connected legacy projects during lazy migration.
     const segments = normalized.split("/");
     if (segments.length !== 2 || segments[0] !== "projects") return undefined;
-    return projects.find((project) => project.slug === segments[1]);
+    return projects.find((project) => {
+      if (project.slug !== segments[1] || project.kind === "folder") return false;
+      const localPath = normalizePath(project.localPath ?? "");
+      return localPath === normalized
+        || localPath.endsWith(`/${normalized}`)
+        || localPath.includes(`/${normalized}/`);
+    });
   };
   const resolveFolderChoice = (path: string): FolderPickerChoice => {
     const project = projectForPath(path);

--- a/desktop/src/renderer/src/features/board/AddProjectStepFields.tsx
+++ b/desktop/src/renderer/src/features/board/AddProjectStepFields.tsx
@@ -117,30 +117,35 @@ export function ExistingFolderStepFields({
   onOpenProject: (slug: string) => void;
   submitting: boolean;
 }) {
-  const projectForRegistryPath = (path: string): Project | undefined => {
-    const segments = path.replace(/^\.\/+/, "").replace(/\/+$/, "").split("/");
+  const normalizePath = (path: string) => path.replaceAll("\\", "/").replace(/^\.\/+/, "").replace(/\/+$/, "");
+  const projectForPath = (path: string): Project | undefined => {
+    const normalized = normalizePath(path);
+    const exact = projects.find((project) => {
+      const localPath = normalizePath(project.localPath ?? "");
+      return localPath === normalized || localPath.endsWith(`/${normalized}`);
+    });
+    if (exact) return exact;
+
+    // Compatibility only: before MAT-340, projects/<slug> held Matrix-owned
+    // metadata while the real checkout lived below it. Keep the Open action
+    // for those already-connected legacy projects during lazy migration.
+    const segments = normalized.split("/");
     if (segments.length !== 2 || segments[0] !== "projects") return undefined;
     return projects.find((project) => project.slug === segments[1]);
   };
   const resolveFolderChoice = (path: string): FolderPickerChoice => {
-    const normalized = path.replace(/^\.\/+/, "").replace(/\/+$/, "");
-    const segments = normalized.split("/");
-    if (segments[0] !== "projects") return { kind: "choose" };
-    // projects/<slug> is Matrix-owned registry state. Only the repo checkout
-    // beneath it (and its descendants) is a user workspace.
-    if (segments.length >= 3 && segments[2] === "repo") return { kind: "choose" };
-    const project = projectForRegistryPath(normalized);
+    const project = projectForPath(path);
     if (project) {
       return {
         kind: "alternate",
         label: `Open ${project.name}`,
-        message: "This folder contains Matrix project data, not a workspace.",
+        message: "This folder is already connected to Matrix OS.",
       };
     }
-    return {
-      kind: "blocked",
-      message: "This folder is managed by Matrix and can't be used as a workspace.",
-    };
+    // Matrix-owned project metadata now lives in system/projects. Every
+    // ordinary owner folder is selectable here; the Gateway remains the
+    // authority for protected paths and managed worktree boundaries.
+    return { kind: "choose" };
   };
 
   return (
@@ -164,7 +169,7 @@ export function ExistingFolderStepFields({
           onChooseFolder={onChooseFolder}
           resolveFolderChoice={resolveFolderChoice}
           onAlternateFolderAction={(path) => {
-            const project = projectForRegistryPath(path);
+            const project = projectForPath(path);
             if (project) onOpenProject(project.slug);
           }}
         />

--- a/desktop/src/renderer/src/features/runtime/RuntimeComputerMenu.tsx
+++ b/desktop/src/renderer/src/features/runtime/RuntimeComputerMenu.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { DESKTOP_Z_INDEX } from "../../design/layering";
 import { useConnection } from "../../stores/connection";
 import { useRuntimeComputers } from "../../stores/runtime-computers";
+import { useUi } from "../../stores/ui";
 
 const STATUS_LABEL = {
   available: "Available",
@@ -29,6 +30,8 @@ export default function RuntimeComputerMenu({ collapsed }: { collapsed: boolean 
   const switchError = useRuntimeComputers((state) => state.switchError);
   const refresh = useRuntimeComputers((state) => state.refresh);
   const select = useRuntimeComputers((state) => state.select);
+  const acquireRendererOverlay = useUi((state) => state.acquireRendererOverlay);
+  const releaseRendererOverlay = useUi((state) => state.releaseRendererOverlay);
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   // The token can be on a different slot than the persisted profile (stale
@@ -38,6 +41,12 @@ export default function RuntimeComputerMenu({ collapsed }: { collapsed: boolean 
   useEffect(() => {
     void refresh();
   }, [authGeneration, connectionStatus, handle, platformHost, refresh, runtimeSlot]);
+
+  useEffect(() => {
+    if (!open) return;
+    acquireRendererOverlay();
+    return releaseRendererOverlay;
+  }, [acquireRendererOverlay, open, releaseRendererOverlay]);
 
   const current = useMemo(
     () => computers.find((computer) => computer.runtimeSlot === selectedSlot)

--- a/packages/gateway/src/agent-session-manager.ts
+++ b/packages/gateway/src/agent-session-manager.ts
@@ -15,6 +15,7 @@ import {
 import { MAX_PROMPT_CONTENT_LENGTH, PromptContentSchema } from "./prompt-validation.js";
 import { PROJECT_SLUG_REGEX, type ProjectConfig, type WorkspaceError } from "./project-manager.js";
 import { atomicWriteJson, readJsonFile } from "./state-ops.js";
+import { createProjectRegistry } from "./project-registry.js";
 import type { createAgentLauncher } from "./agent-launcher.js";
 import type { createWorktreeManager, WorktreeRecord } from "./worktree-manager.js";
 import type { createZellijRuntime } from "./zellij-runtime.js";
@@ -175,14 +176,7 @@ function sessionPath(homePath: string, sessionId: string): string {
 }
 
 async function readProject(homePath: string, projectSlug: string): Promise<ProjectConfig | null> {
-  try {
-    return await readJsonFile<ProjectConfig>(join(homePath, "projects", projectSlug, "config.json"));
-  } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
-    }
-    throw err;
-  }
+  return await createProjectRegistry({ homePath }).readConfig<ProjectConfig>(projectSlug);
 }
 
 async function readSession(homePath: string, sessionId: string): Promise<WorkspaceSession | null> {

--- a/packages/gateway/src/bounded-json-file.ts
+++ b/packages/gateway/src/bounded-json-file.ts
@@ -1,0 +1,198 @@
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { link, lstat, mkdir, open, opendir, rename, unlink } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+
+const RECOVERY_FILE_PREFIX = "project-state-";
+const MAX_RECOVERY_FILES = 100;
+const MAX_RECOVERY_SCAN_ENTRIES = 10_000;
+let recoveryMutationTail: Promise<void> = Promise.resolve();
+
+export interface FileIdentity {
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+}
+
+function isErrnoCode(err: unknown, code: string): boolean {
+  return err instanceof Error
+    && "code" in err
+    && (err as NodeJS.ErrnoException).code === code;
+}
+
+function matchesIdentity(stats: FileIdentity, identity: FileIdentity): boolean {
+  return stats.dev === identity.dev
+    && stats.ino === identity.ino
+    && stats.size === identity.size
+    && stats.mtimeMs === identity.mtimeMs;
+}
+
+export async function readBoundedJsonFileWithIdentity(
+  path: string,
+  maxBytes: number,
+): Promise<{ value: unknown; identity: FileIdentity } | null> {
+  let handle;
+  try {
+    const pathStats = await lstat(path);
+    if (!pathStats.isFile() || pathStats.isSymbolicLink() || pathStats.size > maxBytes) return null;
+    handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const stats = await handle.stat();
+    if (!stats.isFile() || stats.size > maxBytes) return null;
+    const buffer = Buffer.alloc(stats.size + 1);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    if (bytesRead > maxBytes) return null;
+    let value: unknown;
+    try {
+      value = JSON.parse(buffer.subarray(0, bytesRead).toString("utf-8"));
+    } catch (err: unknown) {
+      if (err instanceof SyntaxError) return null;
+      throw err;
+    }
+    return {
+      value,
+      identity: {
+        dev: stats.dev,
+        ino: stats.ino,
+        size: stats.size,
+        mtimeMs: stats.mtimeMs,
+      },
+    };
+  } catch (err: unknown) {
+    if (isErrnoCode(err, "ENOENT") || isErrnoCode(err, "ELOOP")) return null;
+    throw err;
+  } finally {
+    await handle?.close();
+  }
+}
+
+export function projectStateRecoveryDir(homePath: string): string {
+  return join(homePath, "system", "recovery", "project-state");
+}
+
+async function cleanupRecoveryDir(recoveryDir: string): Promise<void> {
+  let directory;
+  try {
+    directory = await opendir(recoveryDir);
+  } catch (err: unknown) {
+    if (isErrnoCode(err, "ENOENT")) return;
+    throw err;
+  }
+
+  const retained: Array<{ path: string; mtimeMs: number }> = [];
+  let visited = 0;
+  for await (const entry of directory) {
+    visited += 1;
+    if (visited > MAX_RECOVERY_SCAN_ENTRIES) break;
+    if (!entry.isFile() || entry.isSymbolicLink() || !entry.name.startsWith(RECOVERY_FILE_PREFIX)) continue;
+    const path = join(recoveryDir, entry.name);
+    try {
+      const stats = await lstat(path);
+      if (!stats.isFile() || stats.isSymbolicLink()) continue;
+      retained.push({ path, mtimeMs: stats.mtimeMs });
+      if (retained.length > MAX_RECOVERY_FILES - 1) {
+        retained.sort((a, b) => a.mtimeMs - b.mtimeMs);
+        const oldest = retained.shift();
+        if (oldest) await unlink(oldest.path);
+      }
+    } catch (err: unknown) {
+      if (!isErrnoCode(err, "ENOENT")) throw err;
+    }
+  }
+}
+
+async function preserveQuarantinedFile(quarantinePath: string, recoveryDir: string): Promise<void> {
+  const previous = recoveryMutationTail;
+  let release!: () => void;
+  recoveryMutationTail = new Promise<void>((resolve) => { release = resolve; });
+  await previous;
+  try {
+    await mkdir(recoveryDir, { recursive: true });
+    await cleanupRecoveryDir(recoveryDir);
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const recoveryPath = join(recoveryDir, `${RECOVERY_FILE_PREFIX}${Date.now()}-${randomUUID()}.json`);
+      try {
+        await link(quarantinePath, recoveryPath);
+        await unlink(quarantinePath);
+        return;
+      } catch (err: unknown) {
+        if (isErrnoCode(err, "EEXIST")) continue;
+        throw err;
+      }
+    }
+    throw new Error("Unable to preserve quarantined project state");
+  } finally {
+    release();
+  }
+}
+
+async function restoreQuarantinedFile(
+  quarantinePath: string,
+  path: string,
+  recoveryDir: string,
+): Promise<void> {
+  try {
+    await link(quarantinePath, path);
+    await unlink(quarantinePath);
+  } catch (err: unknown) {
+    if (isErrnoCode(err, "EEXIST")) {
+      // A concurrently published pathname wins. Preserve the displaced file
+      // in bounded Matrix-owned recovery state, never in the owner workspace.
+      await preserveQuarantinedFile(quarantinePath, recoveryDir);
+      return;
+    }
+    if (isErrnoCode(err, "ENOENT")) return;
+    throw err;
+  }
+}
+
+export async function removeFileIfUnchanged(
+  path: string,
+  identity: FileIdentity,
+  options: {
+    recoveryDir: string;
+    /** @internal deterministic concurrency-test seams */
+    onValidatedBeforeQuarantine?: () => Promise<void>;
+    onRenamed?: () => Promise<void>;
+    onQuarantined?: () => Promise<void>;
+  },
+): Promise<boolean> {
+  try {
+    const current = await lstat(path);
+    if (!current.isFile() || current.isSymbolicLink() || !matchesIdentity(current, identity)) return false;
+  } catch (err: unknown) {
+    if (isErrnoCode(err, "ENOENT")) return false;
+    throw err;
+  }
+  await options.onValidatedBeforeQuarantine?.();
+
+  const quarantinePath = join(dirname(path), `.${basename(path)}-${randomUUID()}.quarantine`);
+  try {
+    // Rename first so later validation and deletion operate on the exact inode
+    // removed from the public pathname, not on a replaceable path target.
+    await rename(path, quarantinePath);
+  } catch (err: unknown) {
+    if (isErrnoCode(err, "ENOENT")) return false;
+    throw err;
+  }
+
+  try {
+    await options.onRenamed?.();
+    const quarantined = await lstat(quarantinePath);
+    if (
+      !quarantined.isFile()
+      || quarantined.isSymbolicLink()
+      || !matchesIdentity(quarantined, identity)
+    ) {
+      await restoreQuarantinedFile(quarantinePath, path, options.recoveryDir);
+      return false;
+    }
+
+    await options.onQuarantined?.();
+    await unlink(quarantinePath);
+    return true;
+  } catch (err: unknown) {
+    await restoreQuarantinedFile(quarantinePath, path, options.recoveryDir);
+    throw err;
+  }
+}

--- a/packages/gateway/src/coding-agents/file-read.ts
+++ b/packages/gateway/src/coding-agents/file-read.ts
@@ -23,7 +23,7 @@ import {
 } from "@matrix-os/contracts";
 import { createProjectRegistry } from "../project-registry.js";
 import type { RequestPrincipal } from "../request-principal.js";
-import { resolveWorktreeCheckoutPath } from "../worktree-manager.js";
+import { resolveOwnedWorktree, type OwnerScopedWorktreeSource } from "./owned-worktree.js";
 
 const DEFAULT_FILE_READ_LIMIT_BYTES = 64 * 1024;
 const DEFAULT_FILE_WRITE_LIMIT_BYTES = 64 * 1024;
@@ -86,10 +86,23 @@ function isWithin(base: string, target: string): boolean {
 
 async function checkoutRootFor(
   homePath: string,
+  principal: RequestPrincipal,
   request: Pick<FileReadRequest, "projectId" | "worktreeId">,
+  worktrees?: OwnerScopedWorktreeSource,
 ): Promise<string | null> {
   if (request.worktreeId) {
-    return await resolveWorktreeCheckoutPath(homePath, request.projectId, request.worktreeId);
+    const resolved = await resolveOwnedWorktree(
+      worktrees,
+      principal,
+      request.projectId,
+      request.worktreeId,
+    );
+    if (!resolved.ok) {
+      throw new CodingAgentFileReadError(
+        resolved.reason === "unavailable" ? "file_unavailable" : "file_not_found",
+      );
+    }
+    return resolve(resolved.path);
   }
   const project = await createProjectRegistry({ homePath }).readConfig(request.projectId);
   return project
@@ -97,12 +110,11 @@ async function checkoutRootFor(
     : resolve(homePath, "projects", request.projectId, "repo");
 }
 
-async function assertPrimaryProjectAccess(input: {
+async function assertProjectAccess(input: {
   principal: RequestPrincipal;
   request: Pick<FileReadRequest, "projectId" | "worktreeId">;
   projects?: ProjectOwnershipSource;
 }): Promise<void> {
-  if (input.request.worktreeId) return;
   if (!input.projects) {
     throw new CodingAgentFileReadError("file_unavailable");
   }
@@ -316,6 +328,7 @@ export function createCodingAgentFileStore(options: {
   ownerId?: string;
   principalOwnerIds?: readonly string[];
   projects?: ProjectOwnershipSource;
+  worktrees?: OwnerScopedWorktreeSource;
   readLimitBytes?: number;
   writeLimitBytes?: number;
 }): CodingAgentFileStore {
@@ -331,9 +344,9 @@ export function createCodingAgentFileStore(options: {
         throw new CodingAgentFileReadError("file_not_found");
       }
       const request = FileBrowseRequestSchema.parse(rawRequest);
-      await assertPrimaryProjectAccess({ principal, request, projects: options.projects });
+      await assertProjectAccess({ principal, request, projects: options.projects });
       const limit = Math.min(request.limit, MAX_FILE_LIST_LIMIT);
-      const worktreeRoot = await checkoutRootFor(homePath, request);
+      const worktreeRoot = await checkoutRootFor(homePath, principal, request, options.worktrees);
       if (!worktreeRoot) throw new CodingAgentFileReadError("file_not_found");
       const target = pathForRequest(worktreeRoot, request.path);
       if (!isWithin(worktreeRoot, target)) {
@@ -416,8 +429,8 @@ export function createCodingAgentFileStore(options: {
         throw new CodingAgentFileReadError("file_not_found");
       }
       const request = FileReadRequestSchema.parse(rawRequest);
-      await assertPrimaryProjectAccess({ principal, request, projects: options.projects });
-      const worktreeRoot = await checkoutRootFor(homePath, request);
+      await assertProjectAccess({ principal, request, projects: options.projects });
+      const worktreeRoot = await checkoutRootFor(homePath, principal, request, options.worktrees);
       if (!worktreeRoot) throw new CodingAgentFileReadError("file_not_found");
       const target = resolve(worktreeRoot, request.path);
       if (!isWithin(worktreeRoot, target)) {
@@ -499,9 +512,9 @@ export function createCodingAgentFileStore(options: {
         throw new CodingAgentFileReadError("file_not_found");
       }
       const request = FileSearchRequestSchema.parse(rawRequest);
-      await assertPrimaryProjectAccess({ principal, request, projects: options.projects });
+      await assertProjectAccess({ principal, request, projects: options.projects });
       const limit = Math.min(request.limit, MAX_FILE_LIST_LIMIT);
-      const worktreeRoot = await checkoutRootFor(homePath, request);
+      const worktreeRoot = await checkoutRootFor(homePath, principal, request, options.worktrees);
       if (!worktreeRoot) throw new CodingAgentFileReadError("file_not_found");
       const start = pathForRequest(worktreeRoot, request.path);
       if (!isWithin(worktreeRoot, start)) {
@@ -621,7 +634,16 @@ export function createCodingAgentFileStore(options: {
       if (contentBuffer.byteLength > writeLimitBytes) {
         throw new CodingAgentFileWriteError("invalid_request");
       }
-      const worktreeRoot = await checkoutRootFor(homePath, request);
+      let worktreeRoot: string | null;
+      try {
+        await assertProjectAccess({ principal, request, projects: options.projects });
+        worktreeRoot = await checkoutRootFor(homePath, principal, request, options.worktrees);
+      } catch (err: unknown) {
+        if (err instanceof CodingAgentFileReadError) {
+          throw new CodingAgentFileWriteError(err.code);
+        }
+        throw err;
+      }
       if (!worktreeRoot) throw new CodingAgentFileWriteError("file_not_found");
       const target = resolve(worktreeRoot, request.path);
       if (!isWithin(worktreeRoot, target)) {

--- a/packages/gateway/src/coding-agents/file-read.ts
+++ b/packages/gateway/src/coding-agents/file-read.ts
@@ -21,7 +21,9 @@ import {
   type FileWriteRequest,
   type FileWriteResponse,
 } from "@matrix-os/contracts";
+import { createProjectRegistry } from "../project-registry.js";
 import type { RequestPrincipal } from "../request-principal.js";
+import { resolveWorktreeCheckoutPath } from "../worktree-manager.js";
 
 const DEFAULT_FILE_READ_LIMIT_BYTES = 64 * 1024;
 const DEFAULT_FILE_WRITE_LIMIT_BYTES = 64 * 1024;
@@ -82,9 +84,16 @@ function isWithin(base: string, target: string): boolean {
   return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }
 
-function checkoutRootFor(homePath: string, request: Pick<FileReadRequest, "projectId" | "worktreeId">): string {
-  return request.worktreeId
-    ? resolve(homePath, "projects", request.projectId, "worktrees", request.worktreeId)
+async function checkoutRootFor(
+  homePath: string,
+  request: Pick<FileReadRequest, "projectId" | "worktreeId">,
+): Promise<string | null> {
+  if (request.worktreeId) {
+    return await resolveWorktreeCheckoutPath(homePath, request.projectId, request.worktreeId);
+  }
+  const project = await createProjectRegistry({ homePath }).readConfig(request.projectId);
+  return project
+    ? resolve(project.localPath)
     : resolve(homePath, "projects", request.projectId, "repo");
 }
 
@@ -324,7 +333,8 @@ export function createCodingAgentFileStore(options: {
       const request = FileBrowseRequestSchema.parse(rawRequest);
       await assertPrimaryProjectAccess({ principal, request, projects: options.projects });
       const limit = Math.min(request.limit, MAX_FILE_LIST_LIMIT);
-      const worktreeRoot = checkoutRootFor(homePath, request);
+      const worktreeRoot = await checkoutRootFor(homePath, request);
+      if (!worktreeRoot) throw new CodingAgentFileReadError("file_not_found");
       const target = pathForRequest(worktreeRoot, request.path);
       if (!isWithin(worktreeRoot, target)) {
         throw new CodingAgentFileReadError("file_not_found");
@@ -407,7 +417,8 @@ export function createCodingAgentFileStore(options: {
       }
       const request = FileReadRequestSchema.parse(rawRequest);
       await assertPrimaryProjectAccess({ principal, request, projects: options.projects });
-      const worktreeRoot = checkoutRootFor(homePath, request);
+      const worktreeRoot = await checkoutRootFor(homePath, request);
+      if (!worktreeRoot) throw new CodingAgentFileReadError("file_not_found");
       const target = resolve(worktreeRoot, request.path);
       if (!isWithin(worktreeRoot, target)) {
         throw new CodingAgentFileReadError("file_not_found");
@@ -490,7 +501,8 @@ export function createCodingAgentFileStore(options: {
       const request = FileSearchRequestSchema.parse(rawRequest);
       await assertPrimaryProjectAccess({ principal, request, projects: options.projects });
       const limit = Math.min(request.limit, MAX_FILE_LIST_LIMIT);
-      const worktreeRoot = checkoutRootFor(homePath, request);
+      const worktreeRoot = await checkoutRootFor(homePath, request);
+      if (!worktreeRoot) throw new CodingAgentFileReadError("file_not_found");
       const start = pathForRequest(worktreeRoot, request.path);
       if (!isWithin(worktreeRoot, start)) {
         throw new CodingAgentFileReadError("file_not_found");
@@ -609,7 +621,8 @@ export function createCodingAgentFileStore(options: {
       if (contentBuffer.byteLength > writeLimitBytes) {
         throw new CodingAgentFileWriteError("invalid_request");
       }
-      const worktreeRoot = checkoutRootFor(homePath, request);
+      const worktreeRoot = await checkoutRootFor(homePath, request);
+      if (!worktreeRoot) throw new CodingAgentFileWriteError("file_not_found");
       const target = resolve(worktreeRoot, request.path);
       if (!isWithin(worktreeRoot, target)) {
         throw new CodingAgentFileWriteError("file_not_found");

--- a/packages/gateway/src/coding-agents/owned-worktree.ts
+++ b/packages/gateway/src/coding-agents/owned-worktree.ts
@@ -1,0 +1,29 @@
+import type { RequestPrincipal } from "../request-principal.js";
+
+export interface OwnerScopedWorktreeSource {
+  listWorktrees(
+    projectSlug: string,
+    ownerScope: { type: "user"; id: string },
+  ): Promise<
+    | { ok: true; worktrees: Array<{ id: string; path: string }> }
+    | { ok: false; status: number; error: unknown }
+  >;
+}
+
+export async function resolveOwnedWorktree(
+  source: OwnerScopedWorktreeSource | undefined,
+  principal: RequestPrincipal,
+  projectSlug: string,
+  worktreeId: string,
+): Promise<
+  | { ok: true; path: string }
+  | { ok: false; reason: "not_found" | "unavailable" }
+> {
+  if (!source) return { ok: false, reason: "unavailable" };
+  const listed = await source.listWorktrees(projectSlug, { type: "user", id: principal.userId });
+  if (!listed.ok) {
+    return { ok: false, reason: listed.status >= 500 ? "unavailable" : "not_found" };
+  }
+  const worktree = listed.worktrees.find((candidate) => candidate.id === worktreeId);
+  return worktree ? { ok: true, path: worktree.path } : { ok: false, reason: "not_found" };
+}

--- a/packages/gateway/src/coding-agents/review-summary.ts
+++ b/packages/gateway/src/coding-agents/review-summary.ts
@@ -11,6 +11,7 @@ import { resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import type { RequestPrincipal } from "../request-principal.js";
 import type { ReviewLoopRecord } from "../review-loop.js";
+import { resolveWorktreeCheckoutPath } from "../worktree-manager.js";
 import {
   parseFindingsFile,
   type FindingsParseFailure,
@@ -143,23 +144,28 @@ function reviewOwnerMatchesPrincipal(review: ReviewLoopRecord, principal: Reques
   return ownerIds.includes(review.ownerId);
 }
 
-function safeFindingsPath(input: { homePath?: string; review: ReviewLoopRecord; round: number; findingsPath?: string }): string | null {
+async function safeFindingsPath(input: { homePath?: string; review: ReviewLoopRecord; round: number; findingsPath?: string }): Promise<string | null> {
   if (!input.homePath || !input.findingsPath) return null;
   if (input.findingsPath !== `.matrix/review-round-${input.round}.md`) return null;
   const safeProject = /^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$/.test(input.review.projectSlug);
   const safeWorktree = /^wt_[A-Za-z0-9_-]{1,128}$/.test(input.review.worktreeId);
   if (!safeProject || !safeWorktree) return null;
-  const worktreeRoot = resolve(input.homePath, "projects", input.review.projectSlug, "worktrees", input.review.worktreeId);
+  const worktreeRoot = await resolveWorktreeCheckoutPath(
+    input.homePath,
+    input.review.projectSlug,
+    input.review.worktreeId,
+  );
+  if (!worktreeRoot) return null;
   const resolved = resolve(worktreeRoot, input.findingsPath);
   return resolved.startsWith(`${worktreeRoot}${sep}`) ? resolved : null;
 }
 
-function safeWorktreeRoot(input: { homePath?: string; review: ReviewLoopRecord }): string | null {
+async function safeWorktreeRoot(input: { homePath?: string; review: ReviewLoopRecord }): Promise<string | null> {
   if (!input.homePath) return null;
   const safeProject = /^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$/.test(input.review.projectSlug);
   const safeWorktree = /^wt_[A-Za-z0-9_-]{1,128}$/.test(input.review.worktreeId);
   if (!safeProject || !safeWorktree) return null;
-  return resolve(input.homePath, "projects", input.review.projectSlug, "worktrees", input.review.worktreeId);
+  return await resolveWorktreeCheckoutPath(input.homePath, input.review.projectSlug, input.review.worktreeId);
 }
 
 function hunkIdFor(path: string, index: number): string {
@@ -606,7 +612,7 @@ async function toPartialReviewSnapshot(
   if (!summary) return null;
   const findingsRound = latestSuccessfulFindingsRound(review);
   const findingsPath = findingsRound
-    ? safeFindingsPath({
+    ? await safeFindingsPath({
       homePath: options.homePath,
       review,
       round: findingsRound.round,
@@ -614,7 +620,7 @@ async function toPartialReviewSnapshot(
     })
     : null;
   const parsedFindings = findingsPath ? await options.findingsReader(findingsPath) : null;
-  const worktreeRoot = safeWorktreeRoot({ homePath: options.homePath, review });
+  const worktreeRoot = await safeWorktreeRoot({ homePath: options.homePath, review });
   const parsedDiff = worktreeRoot ? await options.diffReader(worktreeRoot) : null;
   const findingsFiles = parsedFindings?.ok ? snapshotFilesFromFindings(review, parsedFindings.findings) : { items: [], hasMore: false };
   const files = mergeDiffAndFindings({ diff: parsedDiff, findings: findingsFiles });

--- a/packages/gateway/src/coding-agents/source-control.ts
+++ b/packages/gateway/src/coding-agents/source-control.ts
@@ -14,6 +14,7 @@ import {
 } from "@matrix-os/contracts";
 import { GIT_ENV } from "../git-env.js";
 import type { RequestPrincipal } from "../request-principal.js";
+import { resolveWorktreeCheckoutPath } from "../worktree-manager.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -67,10 +68,6 @@ function isWithin(base: string, target: string): boolean {
 }
 
 type SourceControlWorktreeRequest = Pick<SourceControlPrepareCommitRequest, "projectId" | "worktreeId">;
-
-function worktreeRootFor(homePath: string, request: SourceControlWorktreeRequest): string {
-  return resolve(homePath, "projects", request.projectId, "worktrees", request.worktreeId);
-}
 
 function fsErrorCode(err: unknown): string {
   return typeof err === "object" && err !== null && "code" in err ? String(err.code) : "";
@@ -221,7 +218,14 @@ export function createCodingAgentSourceControlStore(options: {
   }
 
   async function resolveWorktree(request: SourceControlWorktreeRequest): Promise<string> {
-    const worktreeRoot = worktreeRootFor(homePath, request);
+    const worktreeRoot = await resolveWorktreeCheckoutPath(
+      homePath,
+      request.projectId,
+      request.worktreeId,
+    );
+    if (!worktreeRoot) {
+      throw new CodingAgentSourceControlError("source_control_not_found");
+    }
     if (!isWithin(homePath, worktreeRoot)) {
       throw new CodingAgentSourceControlError("source_control_not_found");
     }

--- a/packages/gateway/src/coding-agents/source-control.ts
+++ b/packages/gateway/src/coding-agents/source-control.ts
@@ -14,7 +14,7 @@ import {
 } from "@matrix-os/contracts";
 import { GIT_ENV } from "../git-env.js";
 import type { RequestPrincipal } from "../request-principal.js";
-import { resolveWorktreeCheckoutPath } from "../worktree-manager.js";
+import { resolveOwnedWorktree, type OwnerScopedWorktreeSource } from "./owned-worktree.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -136,6 +136,7 @@ export function createCodingAgentSourceControlStore(options: {
   gitCommand?: string;
   ghCommand?: string;
   maxQueueDepth?: number;
+  worktrees?: OwnerScopedWorktreeSource;
 }): CodingAgentSourceControlStore {
   const homePath = resolve(options.homePath);
   const ownerIds = ownerIdsFor(options);
@@ -217,15 +218,22 @@ export function createCodingAgentSourceControlStore(options: {
     });
   }
 
-  async function resolveWorktree(request: SourceControlWorktreeRequest): Promise<string> {
-    const worktreeRoot = await resolveWorktreeCheckoutPath(
-      homePath,
+  async function resolveWorktree(
+    principal: RequestPrincipal,
+    request: SourceControlWorktreeRequest,
+  ): Promise<string> {
+    const owned = await resolveOwnedWorktree(
+      options.worktrees,
+      principal,
       request.projectId,
       request.worktreeId,
     );
-    if (!worktreeRoot) {
-      throw new CodingAgentSourceControlError("source_control_not_found");
+    if (!owned.ok) {
+      throw new CodingAgentSourceControlError(
+        owned.reason === "unavailable" ? "source_control_unavailable" : "source_control_not_found",
+      );
     }
+    const worktreeRoot = resolve(owned.path);
     if (!isWithin(homePath, worktreeRoot)) {
       throw new CodingAgentSourceControlError("source_control_not_found");
     }
@@ -361,7 +369,7 @@ export function createCodingAgentSourceControlStore(options: {
         throw new CodingAgentSourceControlError("source_control_not_found");
       }
       const request = SourceControlPrepareCommitRequestSchema.parse(rawRequest);
-      const root = await resolveWorktree(request);
+      const root = await resolveWorktree(principal, request);
       const pathspecs = pathspecsFor(root, request);
 
       return withSourceControlLock(locks, root, maxQueueDepth, async () => {
@@ -419,7 +427,7 @@ export function createCodingAgentSourceControlStore(options: {
         throw new CodingAgentSourceControlError("source_control_not_found");
       }
       const request = SourceControlCreatePullRequestRequestSchema.parse(rawRequest);
-      const root = await resolveWorktree(request);
+      const root = await resolveWorktree(principal, request);
 
       return withSourceControlLock(locks, root, maxQueueDepth, async () => {
         let branch: string;

--- a/packages/gateway/src/git-log.ts
+++ b/packages/gateway/src/git-log.ts
@@ -114,10 +114,8 @@ interface ProjectRepoConfig {
 
 async function readProjectRepoConfig(homePath: string, slug: string): Promise<ProjectRepoConfig | null> {
   const raw = await createProjectRegistry({ homePath })
-    .readConfig<{ id: string; slug: string; localPath?: unknown }>(slug);
-  if (typeof raw !== "object" || raw === null) return null;
-  const localPath = (raw as Record<string, unknown>).localPath;
-  return typeof localPath === "string" && localPath.length > 0 ? { localPath } : null;
+    .readConfig(slug);
+  return raw ? { localPath: raw.localPath } : null;
 }
 
 function parseRefList(raw: string): { refs: string[]; tags: string[]; head: boolean } {

--- a/packages/gateway/src/git-log.ts
+++ b/packages/gateway/src/git-log.ts
@@ -1,16 +1,16 @@
 // Bounded git history/diff reads for project repositories (desktop commit DAG).
 // Mirrors project-manager.ts patterns: injectable CommandRunner (execFile with
 // timeout + maxBuffer, arg arrays only), slug/config resolution from
-// `<home>/projects/<slug>/config.json`, not-a-git-repo degradation to empty
+// the canonical project registry (with lazy legacy adoption), not-a-git-repo degradation to empty
 // results, and generic client-facing error messages with server-side logging.
 import { execFile } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { realpath } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { resolve } from "node:path";
 import { promisify } from "node:util";
 import { z } from "zod/v4";
 import { PROJECT_SLUG_REGEX } from "./project-manager.js";
-import { readJsonFile } from "./state-ops.js";
+import { createProjectRegistry } from "./project-registry.js";
 
 export interface GitCommitSummary {
   sha: string;
@@ -113,15 +113,8 @@ interface ProjectRepoConfig {
 }
 
 async function readProjectRepoConfig(homePath: string, slug: string): Promise<ProjectRepoConfig | null> {
-  let raw: unknown;
-  try {
-    raw = await readJsonFile<unknown>(join(homePath, "projects", slug, "config.json"));
-  } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
-    }
-    throw err;
-  }
+  const raw = await createProjectRegistry({ homePath })
+    .readConfig<{ id: string; slug: string; localPath?: unknown }>(slug);
   if (typeof raw !== "object" || raw === null) return null;
   const localPath = (raw as Record<string, unknown>).localPath;
   return typeof localPath === "string" && localPath.length > 0 ? { localPath } : null;

--- a/packages/gateway/src/legacy-project-state.ts
+++ b/packages/gateway/src/legacy-project-state.ts
@@ -1,0 +1,161 @@
+import { open, opendir } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod/v4";
+import { removeFileIfUnchanged } from "./bounded-json-file.js";
+
+const MAX_LEGACY_STATE_ENTRIES = 10_000;
+const MAX_LEGACY_RECORD_BYTES = 256 * 1024;
+const ProjectSlugSchema = z.string().regex(/^[a-z0-9][a-z0-9-]{0,62}$/);
+const TaskIdSchema = z.string().regex(/^task_[A-Za-z0-9_-]{1,128}$/);
+const PreviewIdSchema = z.string().regex(/^prev_[A-Za-z0-9_-]{1,128}$/);
+const SessionIdSchema = z.string().regex(/^sess_[A-Za-z0-9_-]{1,128}$/);
+const WorktreeIdSchema = z.string().regex(/^wt_[A-Za-z0-9_-]{1,128}$/);
+
+const LegacyTaskRecordSchema = z.object({
+  id: TaskIdSchema,
+  projectSlug: ProjectSlugSchema,
+  title: z.string().min(1).max(200),
+  description: z.string().max(10_000).optional(),
+  status: z.enum(["todo", "running", "waiting", "blocked", "complete", "archived"]),
+  priority: z.enum(["low", "normal", "high", "urgent"]),
+  order: z.number().finite(),
+  parentTaskId: TaskIdSchema.optional(),
+  dueAt: z.string().min(1).max(64).optional(),
+  linkedSessionId: SessionIdSchema.optional(),
+  linkedWorktreeId: WorktreeIdSchema.optional(),
+  previewIds: z.array(PreviewIdSchema).max(20),
+  createdAt: z.string().min(1).max(64),
+  updatedAt: z.string().min(1).max(64),
+  archivedAt: z.string().max(64).optional(),
+});
+
+const LegacyPreviewRecordSchema = z.object({
+  id: PreviewIdSchema,
+  projectSlug: ProjectSlugSchema,
+  taskId: TaskIdSchema.optional(),
+  sessionId: SessionIdSchema.optional(),
+  label: z.string().min(1).max(120),
+  url: z.string().min(1).max(2_048),
+  lastStatus: z.enum(["unknown", "ok", "failed"]),
+  displayPreference: z.enum(["panel", "external"]),
+  createdAt: z.string().min(1).max(64),
+  updatedAt: z.string().min(1).max(64),
+});
+
+type LegacyRecord = { id: string; projectSlug: string };
+type Candidate = { path: string; dev: number; ino: number; size: number; mtimeMs: number };
+
+function isMissing(err: unknown): boolean {
+  return err instanceof Error
+    && "code" in err
+    && (err as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+async function collectValidatedRecords(
+  directory: string,
+  projectSlug: string,
+  schema: z.ZodType<LegacyRecord>,
+): Promise<Candidate[]> {
+  let entries;
+  try {
+    entries = await opendir(directory);
+  } catch (err: unknown) {
+    if (isMissing(err)) return [];
+    throw err;
+  }
+  const candidates: Candidate[] = [];
+  let visited = 0;
+  for await (const entry of entries) {
+    visited += 1;
+    if (visited > MAX_LEGACY_STATE_ENTRIES) {
+      throw new Error("Legacy project state exceeds the safe deletion limit");
+    }
+    if (!entry.isFile() || entry.isSymbolicLink() || !entry.name.endsWith(".json")) continue;
+    const path = join(directory, entry.name);
+    let handle;
+    try {
+      handle = await open(path, "r");
+      const stats = await handle.stat();
+      if (!stats.isFile() || stats.size > MAX_LEGACY_RECORD_BYTES) continue;
+      const buffer = Buffer.alloc(stats.size + 1);
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+      if (bytesRead > MAX_LEGACY_RECORD_BYTES) continue;
+      let value: unknown;
+      try {
+        value = JSON.parse(buffer.subarray(0, bytesRead).toString("utf-8"));
+      } catch (err: unknown) {
+        if (err instanceof SyntaxError) continue;
+        throw err;
+      }
+      const parsed = schema.safeParse(value);
+      if (!parsed.success || parsed.data.projectSlug !== projectSlug || entry.name !== `${parsed.data.id}.json`) continue;
+      candidates.push({
+        path,
+        dev: stats.dev,
+        ino: stats.ino,
+        size: stats.size,
+        mtimeMs: stats.mtimeMs,
+      });
+    } catch (err: unknown) {
+      if (!isMissing(err)) throw err;
+    } finally {
+      await handle?.close();
+    }
+  }
+  return candidates;
+}
+
+async function removeCandidate(
+  candidate: Candidate,
+  recoveryDir: string,
+  onValidatedBeforeQuarantine?: () => Promise<void>,
+): Promise<void> {
+  await removeFileIfUnchanged(candidate.path, candidate, {
+    recoveryDir,
+    onValidatedBeforeQuarantine,
+  });
+}
+
+export async function removeValidatedLegacyProjectState(input: {
+  projectSlug: string;
+  tasksDir: string;
+  previewsDir: string;
+  recoveryDir: string;
+  /** @internal deterministic concurrency-test seam */
+  onCandidateValidated?: () => Promise<void>;
+}): Promise<void> {
+  const candidates = await validatedLegacyProjectStateCandidates(input);
+  for (const [index, candidate] of candidates.entries()) {
+    await removeCandidate(
+      candidate,
+      input.recoveryDir,
+      index === 0 ? input.onCandidateValidated : undefined,
+    );
+  }
+}
+
+async function validatedLegacyProjectStateCandidates(input: {
+  projectSlug: string;
+  tasksDir: string;
+  previewsDir: string;
+}): Promise<Candidate[]> {
+  const taskCandidates = await collectValidatedRecords(
+    input.tasksDir,
+    input.projectSlug,
+    LegacyTaskRecordSchema,
+  );
+  const previewCandidates = await collectValidatedRecords(
+    input.previewsDir,
+    input.projectSlug,
+    LegacyPreviewRecordSchema,
+  );
+  return [...taskCandidates, ...previewCandidates];
+}
+
+export async function listValidatedLegacyProjectStateFiles(input: {
+  projectSlug: string;
+  tasksDir: string;
+  previewsDir: string;
+}): Promise<string[]> {
+  return (await validatedLegacyProjectStateCandidates(input)).map((candidate) => candidate.path);
+}

--- a/packages/gateway/src/preview-manager.ts
+++ b/packages/gateway/src/preview-manager.ts
@@ -1,12 +1,17 @@
 import { randomUUID } from "node:crypto";
 import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
-import { readdir, rm } from "node:fs/promises";
+import { opendir, rm } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { z } from "zod/v4";
 import { PROJECT_SLUG_REGEX, type WorkspaceError } from "./project-manager.js";
 import { atomicCreateJson, atomicWriteJson, readJsonFile, type OwnerScope } from "./state-ops.js";
 import { createProjectRegistry } from "./project-registry.js";
+import {
+  projectStateRecoveryDir,
+  readBoundedJsonFileWithIdentity,
+  removeFileIfUnchanged,
+} from "./bounded-json-file.js";
 
 export type PreviewStatus = "unknown" | "ok" | "failed";
 export type PreviewDisplayPreference = "panel" | "external";
@@ -39,6 +44,8 @@ type Result<T> = { ok: true; status?: number } & T;
 const DEFAULT_PROJECT_CAP = 100;
 const DEFAULT_TASK_CAP = 20;
 const PROBE_TIMEOUT_MS = 10_000;
+const MAX_LEGACY_PREVIEW_RECORD_BYTES = 256 * 1024;
+const MAX_PREVIEW_DISCOVERY_IDS = 512;
 
 const ProjectSlugSchema = z.string().regex(PROJECT_SLUG_REGEX);
 const PreviewIdSchema = z.string().regex(/^prev_[A-Za-z0-9_-]{1,128}$/);
@@ -214,15 +221,33 @@ async function readPreview(homePath: string, projectSlug: string, previewId: str
   return null;
 }
 
-async function listPreviewRecords(homePath: string, projectSlug: string): Promise<PreviewRecord[]> {
+async function removeValidatedLegacyPreview(
+  homePath: string,
+  projectSlug: string,
+  previewId: string,
+): Promise<void> {
+  const path = legacyPreviewPath(homePath, projectSlug, previewId);
+  const candidate = await readBoundedJsonFileWithIdentity(path, MAX_LEGACY_PREVIEW_RECORD_BYTES);
+  if (!candidate) return;
+  const parsed = PreviewRecordSchema.safeParse(candidate.value);
+  if (!parsed.success || parsed.data.projectSlug !== projectSlug || parsed.data.id !== previewId) return;
+  await removeFileIfUnchanged(path, candidate.identity, {
+    recoveryDir: projectStateRecoveryDir(homePath),
+  });
+}
+
+async function listPreviewRecords(homePath: string, projectSlug: string): Promise<PreviewRecord[] | null> {
   const ids = new Set<string>();
   for (const root of [previewsDir(homePath, projectSlug), createProjectRegistry({ homePath }).legacyPreviewsDir(projectSlug)]) {
+    let directory: Awaited<ReturnType<typeof opendir>>;
     try {
-      const entries = await readdir(root, { withFileTypes: true });
-      for (const entry of entries) {
+      directory = await opendir(root);
+      for await (const entry of directory) {
         if (!entry.isFile() || entry.isSymbolicLink() || !entry.name.endsWith(".json")) continue;
         const previewId = entry.name.slice(0, -".json".length);
-        if (PreviewIdSchema.safeParse(previewId).success) ids.add(previewId);
+        if (!PreviewIdSchema.safeParse(previewId).success || ids.has(previewId)) continue;
+        if (ids.size >= MAX_PREVIEW_DISCOVERY_IDS) return null;
+        ids.add(previewId);
       }
     } catch (err: unknown) {
       if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") continue;
@@ -297,6 +322,7 @@ export function createPreviewManager(options: {
       }
 
       const existing = await listPreviewRecords(homePath, projectSlug);
+      if (!existing) return failure(409, "preview_limit_exceeded", "Preview limit exceeded");
       if (existing.length >= projectCap) {
         return failure(409, "preview_limit_exceeded", "Preview limit exceeded");
       }
@@ -332,7 +358,9 @@ export function createPreviewManager(options: {
       const parsed = ListPreviewSchema.safeParse(input);
       if (!parsed.success) return failure(400, "invalid_preview_query", "Preview query is invalid");
       const query = parsed.data;
-      const previews = (await listPreviewRecords(homePath, projectSlug))
+      const records = await listPreviewRecords(homePath, projectSlug);
+      if (!records) return failure(409, "preview_limit_exceeded", "Preview limit exceeded");
+      const previews = records
         .filter((preview) => !query.taskId || preview.taskId === query.taskId)
         .filter((preview) => !query.sessionId || preview.sessionId === query.sessionId)
         .sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
@@ -349,7 +377,9 @@ export function createPreviewManager(options: {
       const parsed = ListPreviewSchema.safeParse(input);
       if (!parsed.success) return failure(400, "invalid_preview_query", "Preview query is invalid");
       const query = parsed.data;
-      const previews = (await listPreviewRecords(homePath, projectSlug))
+      const records = await listPreviewRecords(homePath, projectSlug);
+      if (!records) return failure(409, "preview_limit_exceeded", "Preview limit exceeded");
+      const previews = records
         .filter((preview) => !query.taskId || preview.taskId === query.taskId)
         .filter((preview) => !query.sessionId || preview.sessionId === query.sessionId)
         .sort((a, b) =>
@@ -398,10 +428,8 @@ export function createPreviewManager(options: {
       if (!await readPreview(homePath, projectSlug, previewId)) {
         return failure(404, "not_found", "Preview was not found");
       }
-      await Promise.all([
-        rm(previewPath(homePath, projectSlug, previewId), { force: true }),
-        rm(legacyPreviewPath(homePath, projectSlug, previewId), { force: true }),
-      ]);
+      await rm(previewPath(homePath, projectSlug, previewId), { force: true });
+      await removeValidatedLegacyPreview(homePath, projectSlug, previewId);
       return { ok: true };
     },
   };

--- a/packages/gateway/src/preview-manager.ts
+++ b/packages/gateway/src/preview-manager.ts
@@ -1,12 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { lookup } from "node:dns/promises";
-import { constants } from "node:fs";
 import { isIP } from "node:net";
-import { access, readdir, rm } from "node:fs/promises";
+import { readdir, rm } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { z } from "zod/v4";
 import { PROJECT_SLUG_REGEX, type WorkspaceError } from "./project-manager.js";
-import { atomicWriteJson, readJsonFile } from "./state-ops.js";
+import { atomicCreateJson, atomicWriteJson, readJsonFile, type OwnerScope } from "./state-ops.js";
 import { createProjectRegistry } from "./project-registry.js";
 
 export type PreviewStatus = "unknown" | "ok" | "failed";
@@ -67,6 +66,19 @@ const ListPreviewSchema = z.object({
   limit: z.number().int().min(1).max(100).default(100),
 });
 
+const PreviewRecordSchema = z.object({
+  id: PreviewIdSchema,
+  projectSlug: ProjectSlugSchema,
+  taskId: TaskIdSchema.optional(),
+  sessionId: SessionIdSchema.optional(),
+  label: z.string().min(1).max(120),
+  url: z.string().min(1).max(2_048),
+  lastStatus: z.enum(["unknown", "ok", "failed"]),
+  displayPreference: z.enum(["panel", "external"]),
+  createdAt: z.string().min(1).max(64),
+  updatedAt: z.string().min(1).max(64),
+});
+
 function paginatePreviews(
   previews: PreviewRecord[],
   query: z.infer<typeof ListPreviewSchema>,
@@ -86,23 +98,15 @@ function failure(status: number, code: string, message: string): Failure {
 }
 
 function previewsDir(homePath: string, projectSlug: string): string {
-  return join(createProjectRegistry({ homePath }).recordDir(projectSlug), "previews");
+  return createProjectRegistry({ homePath }).previewsDir(projectSlug);
 }
 
 function previewPath(homePath: string, projectSlug: string, previewId: string): string {
   return join(previewsDir(homePath, projectSlug), `${previewId}.json`);
 }
 
-async function pathExists(path: string): Promise<boolean> {
-  try {
-    await access(path, constants.F_OK);
-    return true;
-  } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      return false;
-    }
-    throw err;
-  }
+function legacyPreviewPath(homePath: string, projectSlug: string, previewId: string): string {
+  return join(createProjectRegistry({ homePath }).legacyPreviewsDir(projectSlug), `${previewId}.json`);
 }
 
 function parsePreviewUrl(value: string): URL | null {
@@ -190,32 +194,44 @@ async function defaultProbeUrl(url: string, options: { timeoutMs: number }): Pro
 }
 
 async function readPreview(homePath: string, projectSlug: string, previewId: string): Promise<PreviewRecord | null> {
-  try {
-    return await readJsonFile<PreviewRecord>(previewPath(homePath, projectSlug, previewId));
-  } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
+  for (const path of [
+    previewPath(homePath, projectSlug, previewId),
+    legacyPreviewPath(homePath, projectSlug, previewId),
+  ]) {
+    try {
+      const parsed = PreviewRecordSchema.safeParse(await readJsonFile(path));
+      if (!parsed.success || parsed.data.projectSlug !== projectSlug || parsed.data.id !== previewId) continue;
+      if (path === legacyPreviewPath(homePath, projectSlug, previewId)) {
+        await atomicCreateJson(previewPath(homePath, projectSlug, previewId), parsed.data);
+      }
+      return parsed.data;
+    } catch (err: unknown) {
+      if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") continue;
+      if (err instanceof SyntaxError) continue;
+      throw err;
     }
-    throw err;
   }
+  return null;
 }
 
 async function listPreviewRecords(homePath: string, projectSlug: string): Promise<PreviewRecord[]> {
-  let entries;
-  try {
-    entries = await readdir(previewsDir(homePath, projectSlug), { withFileTypes: true });
-  } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      return [];
+  const ids = new Set<string>();
+  for (const root of [previewsDir(homePath, projectSlug), createProjectRegistry({ homePath }).legacyPreviewsDir(projectSlug)]) {
+    try {
+      const entries = await readdir(root, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isFile() || entry.isSymbolicLink() || !entry.name.endsWith(".json")) continue;
+        const previewId = entry.name.slice(0, -".json".length);
+        if (PreviewIdSchema.safeParse(previewId).success) ids.add(previewId);
+      }
+    } catch (err: unknown) {
+      if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw err;
     }
-    throw err;
   }
 
   const previews: PreviewRecord[] = [];
-  for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
-    const previewId = entry.name.slice(0, -".json".length);
-    if (!PreviewIdSchema.safeParse(previewId).success) continue;
+  for (const previewId of ids) {
     const preview = await readPreview(homePath, projectSlug, previewId);
     if (preview) previews.push(preview);
   }
@@ -228,8 +244,10 @@ function validateProjectSlug(projectSlug: string): Failure | null {
     : failure(400, "invalid_project_slug", "Project slug is invalid");
 }
 
-async function requireProject(homePath: string, projectSlug: string): Promise<Failure | null> {
-  return await createProjectRegistry({ homePath }).readConfig(projectSlug)
+async function requireProject(homePath: string, projectSlug: string, ownerScope?: OwnerScope): Promise<Failure | null> {
+  const project = await createProjectRegistry({ homePath }).readConfig(projectSlug);
+  return project && (!ownerScope
+    || (project.ownerScope.type === ownerScope.type && project.ownerScope.id === ownerScope.id))
     ? null
     : failure(404, "not_found", "Project was not found");
 }
@@ -266,10 +284,10 @@ export function createPreviewManager(options: {
   return {
     detectPreviewUrls,
 
-    async createPreview(projectSlug: string, input: unknown): Promise<Result<{ preview: PreviewRecord }> | Failure> {
+    async createPreview(projectSlug: string, input: unknown, ownerScope?: OwnerScope): Promise<Result<{ preview: PreviewRecord }> | Failure> {
       const projectError = validateProjectSlug(projectSlug);
       if (projectError) return projectError;
-      const missingProject = await requireProject(homePath, projectSlug);
+      const missingProject = await requireProject(homePath, projectSlug, ownerScope);
       if (missingProject) return missingProject;
       const parsed = CreatePreviewSchema.safeParse(input);
       if (!parsed.success) return failure(400, "invalid_preview", "Preview payload is invalid");
@@ -304,12 +322,12 @@ export function createPreviewManager(options: {
       return { ok: true, status: 201, preview };
     },
 
-    async listPreviews(projectSlug: string, input: unknown = {}): Promise<
+    async listPreviews(projectSlug: string, input: unknown = {}, ownerScope?: OwnerScope): Promise<
       Result<{ previews: PreviewRecord[]; nextCursor: string | null }> | Failure
     > {
       const projectError = validateProjectSlug(projectSlug);
       if (projectError) return projectError;
-      const missingProject = await requireProject(homePath, projectSlug);
+      const missingProject = await requireProject(homePath, projectSlug, ownerScope);
       if (missingProject) return missingProject;
       const parsed = ListPreviewSchema.safeParse(input);
       if (!parsed.success) return failure(400, "invalid_preview_query", "Preview query is invalid");
@@ -342,10 +360,10 @@ export function createPreviewManager(options: {
       return { ok: true, ...paginatePreviews(previews, query) };
     },
 
-    async updatePreview(projectSlug: string, previewId: string, input: unknown): Promise<Result<{ preview: PreviewRecord }> | Failure> {
+    async updatePreview(projectSlug: string, previewId: string, input: unknown, ownerScope?: OwnerScope): Promise<Result<{ preview: PreviewRecord }> | Failure> {
       const projectError = validateProjectSlug(projectSlug);
       if (projectError) return projectError;
-      const missingProject = await requireProject(homePath, projectSlug);
+      const missingProject = await requireProject(homePath, projectSlug, ownerScope);
       if (missingProject) return missingProject;
       const previewError = validatePreviewId(previewId);
       if (previewError) return previewError;
@@ -370,16 +388,20 @@ export function createPreviewManager(options: {
       return { ok: true, preview };
     },
 
-    async deletePreview(projectSlug: string, previewId: string): Promise<{ ok: true } | Failure> {
+    async deletePreview(projectSlug: string, previewId: string, ownerScope?: OwnerScope): Promise<{ ok: true } | Failure> {
       const projectError = validateProjectSlug(projectSlug);
       if (projectError) return projectError;
-      const missingProject = await requireProject(homePath, projectSlug);
+      const missingProject = await requireProject(homePath, projectSlug, ownerScope);
       if (missingProject) return missingProject;
       const previewError = validatePreviewId(previewId);
       if (previewError) return previewError;
-      const path = previewPath(homePath, projectSlug, previewId);
-      if (!await pathExists(path)) return failure(404, "not_found", "Preview was not found");
-      await rm(path, { force: true });
+      if (!await readPreview(homePath, projectSlug, previewId)) {
+        return failure(404, "not_found", "Preview was not found");
+      }
+      await Promise.all([
+        rm(previewPath(homePath, projectSlug, previewId), { force: true }),
+        rm(legacyPreviewPath(homePath, projectSlug, previewId), { force: true }),
+      ]);
       return { ok: true };
     },
   };

--- a/packages/gateway/src/preview-manager.ts
+++ b/packages/gateway/src/preview-manager.ts
@@ -7,6 +7,7 @@ import { join, resolve } from "node:path";
 import { z } from "zod/v4";
 import { PROJECT_SLUG_REGEX, type WorkspaceError } from "./project-manager.js";
 import { atomicWriteJson, readJsonFile } from "./state-ops.js";
+import { createProjectRegistry } from "./project-registry.js";
 
 export type PreviewStatus = "unknown" | "ok" | "failed";
 export type PreviewDisplayPreference = "panel" | "external";
@@ -85,15 +86,11 @@ function failure(status: number, code: string, message: string): Failure {
 }
 
 function previewsDir(homePath: string, projectSlug: string): string {
-  return join(homePath, "projects", projectSlug, "previews");
+  return join(createProjectRegistry({ homePath }).recordDir(projectSlug), "previews");
 }
 
 function previewPath(homePath: string, projectSlug: string, previewId: string): string {
   return join(previewsDir(homePath, projectSlug), `${previewId}.json`);
-}
-
-function projectConfigPath(homePath: string, projectSlug: string): string {
-  return join(homePath, "projects", projectSlug, "config.json");
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -232,7 +229,7 @@ function validateProjectSlug(projectSlug: string): Failure | null {
 }
 
 async function requireProject(homePath: string, projectSlug: string): Promise<Failure | null> {
-  return await pathExists(projectConfigPath(homePath, projectSlug))
+  return await createProjectRegistry({ homePath }).readConfig(projectSlug)
     ? null
     : failure(404, "not_found", "Project was not found");
 }

--- a/packages/gateway/src/project-folders.ts
+++ b/packages/gateway/src/project-folders.ts
@@ -1,17 +1,9 @@
-// Exclusive folder creation for the desktop add-project flow. Mirrors
-// project-manager.ts patterns: zod-validated names, home-scoped path
-// resolution with symlink/protected-subtree guards, atomic mkdir for
-// conflict semantics, and generic client-facing errors with server-side
-// logging. Two layouts are supported:
-//   - default ("projects" root): projects/<name>/repo, the same checkout
-//     layout scratch projects use, so the result can be bound as a folder
-//     project (the registry only allows projects/<slug>/repo bindings);
-//   - custom parent: <parent>/<name> anywhere else non-protected in the
-//     home. The projects registry itself is manager-owned metadata and is
-//     rejected as a custom parent.
+// Exclusive owner-folder creation for the Desktop add-project flow. Matrix
+// registry metadata lives separately in system/projects; projects/<name> is
+// therefore an ordinary owner workspace and may be selected or created.
 import { createHash } from "node:crypto";
 import { lstat, mkdir, readdir, realpath, rm } from "node:fs/promises";
-import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { join, relative, resolve, sep } from "node:path";
 import { z } from "zod/v4";
 import { PROJECT_SLUG_REGEX } from "./project-manager.js";
 import {
@@ -52,14 +44,6 @@ function failure(status: number, code: string, message: string): Failure {
 
 function toHomeRelative(homePath: string, target: string): string {
   return relative(homePath, target).split(sep).join("/");
-}
-
-// True when `path` is `root`, inside it, or an ancestor of it.
-function overlapsRoot(root: string, path: string): boolean {
-  const fromRoot = relative(root, path);
-  if (fromRoot === "" || (!fromRoot.startsWith("..") && !isAbsolute(fromRoot))) return true;
-  const toRoot = relative(path, root);
-  return toRoot === "" || (!toRoot.startsWith("..") && !isAbsolute(toRoot));
 }
 
 export function createProjectFolders(options: { homePath: string }) {
@@ -148,14 +132,12 @@ export function createProjectFolders(options: { homePath: string }) {
     return null;
   }
 
-  // Creates projects/<name>/repo atomically: mkdir without recursive fails
+  // Creates the owner workspace at projects/<name> atomically: mkdir without recursive fails
   // with EEXIST when the slug slot is taken, so a conflict can never
-  // overwrite an existing project. The slot is rolled back if the inner
-  // checkout dir cannot be created.
+  // overwrite an existing project. Matrix registry state lives in system.
   async function createRegistryFolder(name: string): Promise<Result<{ path: string }> | Failure> {
     const projectsRoot = join(homePath, "projects");
     const slotPath = join(projectsRoot, name);
-    const repoPath = join(slotPath, "repo");
     try {
       await mkdir(projectsRoot, { recursive: true });
       await mkdir(slotPath);
@@ -166,14 +148,7 @@ export function createProjectFolders(options: { homePath: string }) {
       console.warn("[project-folders] Failed to create project slot:", err instanceof Error ? err.message : err);
       return failure(500, "folder_create_failed", "The folder could not be created");
     }
-    try {
-      await mkdir(repoPath);
-    } catch (err: unknown) {
-      console.warn("[project-folders] Failed to create checkout dir:", err instanceof Error ? err.message : err);
-      await rm(slotPath, { recursive: true, force: true });
-      return failure(500, "folder_create_failed", "The folder could not be created");
-    }
-    return { ok: true, status: 201, path: toHomeRelative(homePath, repoPath) };
+    return { ok: true, status: 201, path: toHomeRelative(homePath, slotPath) };
   }
 
   async function createNestedFolder(name: string, parent: string): Promise<Result<{ path: string }> | Failure> {
@@ -199,11 +174,14 @@ export function createProjectFolders(options: { homePath: string }) {
       console.warn("[project-folders] Failed to inspect parent:", err instanceof Error ? err.message : err);
       return failure(400, "invalid_parent", "Parent folder is invalid");
     }
+    if (realParent === realHome) {
+      return failure(400, "invalid_parent", "Parent folder is invalid");
+    }
     // Check the lexical path AND the fully resolved path against the same
     // rules so a symlinked ancestor cannot alias a protected subtree. The
-    // projects registry is manager-owned metadata (config.json, sibling
-    // projects): creating loose folders inside it would squat on slug
-    // namespaces, so only the default registry layout may write there.
+    // Matrix-owned registry state lives under system/projects. The owner may
+    // create ordinary workspaces under projects, while system/agents and
+    // denied browser state remain protected.
     for (const candidate of [
       { base: homePath, path: resolvedParent },
       { base: realHome, path: realParent },
@@ -213,7 +191,6 @@ export function createProjectFolders(options: { homePath: string }) {
         isProtectedHomeSubpath(candidate.base, target)
         || containsDeniedFileApiPath(candidate.base, target)
         || isDeniedFileApiPath(candidate.base, toHomeRelative(candidate.base, target))
-        || overlapsRoot(join(candidate.base, "projects"), candidate.path)
       ) {
         return failure(400, "invalid_parent", "Parent folder is invalid");
       }

--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -7,7 +7,10 @@ import { promisify } from "node:util";
 import { z } from "zod/v4";
 import { atomicWriteJson, readJsonFile, withProjectLock, type OwnerScope } from "./state-ops.js";
 import { containsDeniedFileApiPath, resolveExistingFileApiPath } from "./path-security.js";
+import { isMatrixManagedProjectSource } from "./project-registry-layout.js";
 import { createProjectRegistry, PROJECT_SLUG_REGEX } from "./project-registry.js";
+import { removeValidatedLegacyProjectState } from "./legacy-project-state.js";
+import { projectStateRecoveryDir } from "./bounded-json-file.js";
 
 export { PROJECT_SLUG_REGEX } from "./project-registry.js";
 
@@ -29,6 +32,7 @@ export interface ProjectConfig {
   deletingAt?: string;
   createRequestId?: string;
   createRequestFingerprint?: string;
+  legacyKindInferred?: true;
   github?: {
     owner: string;
     repo: string;
@@ -259,7 +263,7 @@ function normalizeProjectConfig(homePath: string, config: ProjectConfig | Omit<P
   if ("kind" in config && (config.kind === "scratch" || config.kind === "github" || config.kind === "folder")) {
     return config;
   }
-  return { ...config, kind: classifyLegacyProject(homePath, config) };
+  return { ...config, kind: classifyLegacyProject(homePath, config), legacyKindInferred: true };
 }
 
 function ownerScopeMatches(actual: OwnerScope, expected?: OwnerScope): boolean {
@@ -591,12 +595,12 @@ export function createProjectManager(options: {
       return { projects, nextCursor: null };
     },
 
-    async getProject(slug: string): Promise<Result<{ project: ProjectConfig }> | Failure> {
+    async getProject(slug: string, ownerScope?: OwnerScope): Promise<Result<{ project: ProjectConfig }> | Failure> {
       if (!SlugSchema.safeParse(slug).success) {
         return genericError(400, "invalid_slug", "Project slug is invalid");
       }
       const project = await readProjectConfig(homePath, slug);
-      if (!project || project.archivedAt || project.deletingAt) {
+      if (!project || !ownerScopeMatches(project.ownerScope, ownerScope) || project.archivedAt || project.deletingAt) {
         return genericError(404, "not_found", "Project was not found");
       }
       return { ok: true, project };
@@ -641,7 +645,7 @@ export function createProjectManager(options: {
       if (updated.deletingAt) {
         await registry.writeTombstone(input.slug, updated);
       } else {
-        await registry.removeTombstone(input.slug);
+        await registry.removeTombstone(input.slug, current.project);
       }
       return { ok: true, project: updated };
     },
@@ -655,11 +659,17 @@ export function createProjectManager(options: {
       if (current.project.deletingAt) {
         await registry.writeTombstone(input.slug, current.project);
       }
-      if (current.project.kind !== "folder") {
+      if (isMatrixManagedProjectSource(homePath, current.project)) {
         await rm(projectPath(homePath, input.slug), { recursive: true, force: true });
       }
+      await removeValidatedLegacyProjectState({
+        projectSlug: input.slug,
+        tasksDir: registry.legacyTasksDir(input.slug),
+        previewsDir: registry.legacyPreviewsDir(input.slug),
+        recoveryDir: projectStateRecoveryDir(homePath),
+      });
       await registry.removeConfig(input.slug);
-      await registry.removeTombstone(input.slug);
+      await registry.removeTombstone(input.slug, current.project);
       return { ok: true };
     },
 
@@ -683,8 +693,8 @@ export function createProjectManager(options: {
       }
     },
 
-    async listPullRequests(slug: string): Promise<Result<{ prs: PullRequestSummary[]; refreshedAt: string }> | Failure> {
-      const projectResult = await this.getProject(slug);
+    async listPullRequests(slug: string, ownerScope?: OwnerScope): Promise<Result<{ prs: PullRequestSummary[]; refreshedAt: string }> | Failure> {
+      const projectResult = await this.getProject(slug, ownerScope);
       if (!projectResult.ok) return projectResult;
       const project = projectResult.project;
       if (!project.github) {
@@ -708,8 +718,8 @@ export function createProjectManager(options: {
       }
     },
 
-    async listBranches(slug: string): Promise<Result<{ branches: BranchSummary[]; refreshedAt: string }> | Failure> {
-      const projectResult = await this.getProject(slug);
+    async listBranches(slug: string, ownerScope?: OwnerScope): Promise<Result<{ branches: BranchSummary[]; refreshedAt: string }> | Failure> {
+      const projectResult = await this.getProject(slug, ownerScope);
       if (!projectResult.ok) return projectResult;
       const refreshedAt = nowIso(options.now);
       // Probe Git itself instead of checking for a local .git entry: a folder

--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { constants, type Dirent } from "node:fs";
+import { constants } from "node:fs";
 import { access, lstat, mkdir, readdir, realpath, rename, rm } from "node:fs/promises";
 import { join, relative, resolve, sep } from "node:path";
 import { promisify } from "node:util";
@@ -235,8 +235,13 @@ async function isManagedProjectContainer(homePath: string, resolvedPath: string)
   const segments = rel.split(sep);
   if (rel === "" || rel.startsWith("..") || segments.length < 1) return false;
   const registry = createProjectRegistry({ homePath });
-  const projectExists = await registry.readConfig<ProjectConfig | Omit<ProjectConfig, "kind">>(segments[0]!) !== null;
-  if (!projectExists) return false;
+  const project = await registry.readConfig<ProjectConfig | Omit<ProjectConfig, "kind">>(segments[0]!);
+  if (!project) return false;
+  const kind = normalizeProjectConfig(homePath, project).kind;
+  if (kind === "folder") return false;
+  const managedRoot = join(resolve(homePath), "projects", segments[0]!);
+  const localPath = resolve(project.localPath);
+  if (localPath !== managedRoot && !localPath.startsWith(`${managedRoot}${sep}`)) return false;
   // A legacy managed container and its managed worktree roots stay behind
   // the project/worktree APIs. An unrelated owner checkout is not blocked
   // merely because one of its own directories happens to be named worktrees.
@@ -268,17 +273,9 @@ async function readProjectConfig(homePath: string, slug: string): Promise<Projec
 }
 
 async function readProjectDeletionTombstone(homePath: string, slug: string): Promise<ProjectConfig | null> {
-  try {
-    const config = await readJsonFile<ProjectConfig | Omit<ProjectConfig, "kind">>(
-      createProjectRegistry({ homePath }).tombstonePath(slug),
-    );
-    return normalizeProjectConfig(homePath, config);
-  } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
-    }
-    throw err;
-  }
+  const config = await createProjectRegistry({ homePath })
+    .readTombstone<ProjectConfig | Omit<ProjectConfig, "kind">>(slug);
+  return config ? normalizeProjectConfig(homePath, config) : null;
 }
 
 function normalizePr(raw: unknown): PullRequestSummary | null {
@@ -583,19 +580,7 @@ export function createProjectManager(options: {
         const project = await readProjectConfig(homePath, slug);
         if (project?.deletingAt) projects.push(project);
       }
-      let tombstoneEntries: Dirent[];
-      try {
-        tombstoneEntries = await readdir(registry.tombstoneDir(), { withFileTypes: true });
-      } catch (err: unknown) {
-        if (!(err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT")) {
-          throw err;
-        }
-        tombstoneEntries = [];
-      }
-      for (const entry of tombstoneEntries) {
-        if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
-        const slug = entry.name.slice(0, -".json".length);
-        if (!PROJECT_SLUG_REGEX.test(slug)) continue;
+      for (const slug of await registry.listTombstoneSlugs()) {
         const project = await readProjectDeletionTombstone(homePath, slug);
         if (!project?.deletingAt) continue;
         const duplicateIndex = projects.findIndex((candidate) => candidate.slug === project.slug);
@@ -654,9 +639,9 @@ export function createProjectManager(options: {
       }
       await registry.writeConfig(input.slug, updated);
       if (updated.deletingAt) {
-        await atomicWriteJson(registry.tombstonePath(input.slug), updated);
+        await registry.writeTombstone(input.slug, updated);
       } else {
-        await rm(registry.tombstonePath(input.slug), { force: true });
+        await registry.removeTombstone(input.slug);
       }
       return { ok: true, project: updated };
     },
@@ -668,16 +653,13 @@ export function createProjectManager(options: {
       const current = await this.getProjectForLifecycle(input);
       if (!current.ok) return current;
       if (current.project.deletingAt) {
-        await atomicWriteJson(
-          registry.tombstonePath(input.slug),
-          current.project,
-        );
+        await registry.writeTombstone(input.slug, current.project);
       }
       if (current.project.kind !== "folder") {
         await rm(projectPath(homePath, input.slug), { recursive: true, force: true });
       }
       await registry.removeConfig(input.slug);
-      await rm(registry.tombstonePath(input.slug), { force: true });
+      await registry.removeTombstone(input.slug);
       return { ok: true };
     },
 

--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -5,10 +5,11 @@ import { access, lstat, mkdir, readdir, realpath, rename, rm } from "node:fs/pro
 import { join, relative, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import { z } from "zod/v4";
-import { atomicCreateJson, atomicWriteJson, readJsonFile, withProjectLock, type OwnerScope } from "./state-ops.js";
+import { atomicWriteJson, readJsonFile, withProjectLock, type OwnerScope } from "./state-ops.js";
 import { containsDeniedFileApiPath, resolveExistingFileApiPath } from "./path-security.js";
+import { createProjectRegistry, PROJECT_SLUG_REGEX } from "./project-registry.js";
 
-export const PROJECT_SLUG_REGEX = /^[a-z0-9][a-z0-9-]{0,62}$/;
+export { PROJECT_SLUG_REGEX } from "./project-registry.js";
 
 export type ProjectKind = "scratch" | "github" | "folder";
 export type ProjectVisibility = "active" | "archived" | "all";
@@ -209,14 +210,6 @@ function projectPath(homePath: string, slug: string): string {
   return join(homePath, "projects", slug);
 }
 
-function projectDeletionTombstoneDir(homePath: string): string {
-  return join(homePath, "projects", ".deleting");
-}
-
-function projectDeletionTombstonePath(homePath: string, slug: string): string {
-  return join(projectDeletionTombstoneDir(homePath), `${slug}.json`);
-}
-
 // OS-owned subtrees that must never become an agent-accessible project root.
 // A folder project's localPath is handed to shells and coding-agent sandboxes
 // as a workspace cwd, so granting these would expose kernel/agent state.
@@ -231,7 +224,23 @@ function isProtectedFolderProjectPath(homePath: string, resolvedPath: string): b
   // state (.trash, .hermes, .claude, .codex, .ssh, ...), never a user
   // workspace; deny the whole class instead of chasing individual names.
   if (firstSegment.startsWith(".")) return true;
+  // Selecting the whole workspace root would make every sibling project
+  // writable. Direct children remain valid owner workspaces.
+  if (rel === "projects") return true;
   return PROTECTED_FOLDER_PROJECT_PREFIXES.includes(firstSegment);
+}
+
+async function isManagedProjectContainer(homePath: string, resolvedPath: string): Promise<boolean> {
+  const rel = relative(join(resolve(homePath), "projects"), resolvedPath);
+  const segments = rel.split(sep);
+  if (rel === "" || rel.startsWith("..") || segments.length < 1) return false;
+  const registry = createProjectRegistry({ homePath });
+  const projectExists = await registry.readConfig<ProjectConfig | Omit<ProjectConfig, "kind">>(segments[0]!) !== null;
+  if (!projectExists) return false;
+  // A legacy managed container and its managed worktree roots stay behind
+  // the project/worktree APIs. An unrelated owner checkout is not blocked
+  // merely because one of its own directories happens to be named worktrees.
+  return segments.length === 1 || segments[1] === "worktrees";
 }
 
 function classifyLegacyProject(homePath: string, config: Omit<ProjectConfig, "kind">): ProjectKind {
@@ -253,23 +262,15 @@ function ownerScopeMatches(actual: OwnerScope, expected?: OwnerScope): boolean {
 }
 
 async function readProjectConfig(homePath: string, slug: string): Promise<ProjectConfig | null> {
-  try {
-    const config = await readJsonFile<ProjectConfig | Omit<ProjectConfig, "kind">>(
-      join(projectPath(homePath, slug), "config.json"),
-    );
-    return normalizeProjectConfig(homePath, config);
-  } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
-    }
-    throw err;
-  }
+  const config = await createProjectRegistry({ homePath })
+    .readConfig<ProjectConfig | Omit<ProjectConfig, "kind">>(slug);
+  return config ? normalizeProjectConfig(homePath, config) : null;
 }
 
 async function readProjectDeletionTombstone(homePath: string, slug: string): Promise<ProjectConfig | null> {
   try {
     const config = await readJsonFile<ProjectConfig | Omit<ProjectConfig, "kind">>(
-      projectDeletionTombstonePath(homePath, slug),
+      createProjectRegistry({ homePath }).tombstonePath(slug),
     );
     return normalizeProjectConfig(homePath, config);
   } catch (err: unknown) {
@@ -304,6 +305,7 @@ export function createProjectManager(options: {
 }) {
   const homePath = resolve(options.homePath);
   const runCommand = options.runCommand ?? defaultRunCommand;
+  const registry = createProjectRegistry({ homePath });
 
   return {
     async createProject(input: {
@@ -351,20 +353,16 @@ export function createProjectManager(options: {
           return genericError(400, "invalid_project_path", "Project folder is invalid");
         }
         // Check the lexical path AND the fully resolved path against the same
-        // rules so a symlinked ancestor cannot alias a protected subtree, and
-        // reject any root that would contain the project registry: metadata
-        // (config.json, sibling projects) must never live inside an
-        // agent-writable workspace.
+        // rules so a symlinked ancestor cannot alias a protected subtree. The
+        // registry now lives under system/projects, so ordinary owner folders
+        // below projects are valid workspaces.
         for (const candidate of [
           { base: homePath, path: localPath },
           { base: realHomePath, path: realLocalPath },
         ]) {
-          const registryEntry = join(candidate.base, "projects", slug);
           if (
-            candidate.path === registryEntry
-            || candidate.path.startsWith(`${registryEntry}${sep}`)
-            || registryEntry.startsWith(`${candidate.path}${sep}`)
-            || isProtectedFolderProjectPath(candidate.base, candidate.path)
+            isProtectedFolderProjectPath(candidate.base, candidate.path)
+            || await isManagedProjectContainer(candidate.base, candidate.path)
             // An ancestor of a denied subtree (data/browser-profiles holds
             // persistent browser login state) would expose it as part of the
             // agent-writable workspace.
@@ -372,27 +370,13 @@ export function createProjectManager(options: {
           ) {
             return genericError(400, "invalid_project_path", "Project folder is invalid");
           }
-          // Inside the registry only the repo checkout (projects/<slug>/repo
-          // and below) is user content. The project root holds config.json,
-          // and worktrees/ holds Matrix-owned leases and .matrix metadata;
-          // none of it may become an agent-writable workspace root.
-          const relFromRegistry = relative(join(candidate.base, "projects"), candidate.path);
-          const insideRegistry = relFromRegistry !== "" && !relFromRegistry.startsWith("..");
-          if (insideRegistry) {
-            const segments = relFromRegistry.split(sep);
-            if (segments.length === 1 || segments[1] !== "repo") {
-              return genericError(400, "invalid_project_path", "Project folder is invalid");
-            }
-          }
         }
-        const metadataPath = projectPath(homePath, slug);
         const ownerScope = input.ownerScope ?? { type: "user" as const, id: "local" };
         const fingerprint = createRequestFingerprint({ mode, slug, name, localPath: realLocalPath, ownerScope });
         return withProjectLock(slug, async () => {
-          if (await pathExists(projectDeletionTombstonePath(homePath, slug))) {
+          if (await registry.hasTombstone(slug)) {
             return genericError(409, "slug_conflict", "Project slug already exists");
           }
-          await mkdir(metadataPath, { recursive: true });
           const timestamp = nowIso(options.now);
           const project: ProjectConfig = {
             id: `proj_${randomUUID()}`,
@@ -410,7 +394,7 @@ export function createProjectManager(options: {
             createRequestId: input.clientRequestId,
             createRequestFingerprint: input.clientRequestId ? fingerprint : undefined,
           };
-          const created = await atomicCreateJson(join(metadataPath, "config.json"), project);
+          const created = await registry.createConfig(slug, project);
           if (!created) {
             const existing = await readProjectConfig(homePath, slug);
             const idempotentProject = isIdempotentProjectRetry({
@@ -441,7 +425,7 @@ export function createProjectManager(options: {
           const targetProjectPath = projectPath(homePath, slug);
           if (
             await pathExists(targetProjectPath)
-            || await pathExists(projectDeletionTombstonePath(homePath, slug))
+            || await registry.hasTombstone(slug)
           ) {
             const existing = await readProjectConfig(homePath, slug);
             const idempotentProject = isIdempotentProjectRetry({
@@ -469,7 +453,7 @@ export function createProjectManager(options: {
             createRequestId: input.clientRequestId,
             createRequestFingerprint: input.clientRequestId ? fingerprint : undefined,
           };
-          await atomicWriteJson(join(targetProjectPath, "config.json"), project);
+          await registry.writeConfig(slug, project);
           return { ok: true, status: 201, project };
         });
       }
@@ -497,7 +481,7 @@ export function createProjectManager(options: {
         const targetProjectPath = projectPath(homePath, slug);
         if (
           await pathExists(targetProjectPath)
-          || await pathExists(projectDeletionTombstonePath(homePath, slug))
+          || await registry.hasTombstone(slug)
         ) {
           const existing = await readProjectConfig(homePath, slug);
           const idempotentProject = isIdempotentProjectRetry({
@@ -570,7 +554,7 @@ export function createProjectManager(options: {
             authState: "ok",
           },
         };
-        await atomicWriteJson(join(targetProjectPath, "config.json"), project);
+        await registry.writeConfig(slug, project);
         return { ok: true, status: 201, project };
       });
     },
@@ -579,21 +563,10 @@ export function createProjectManager(options: {
       visibility?: ProjectVisibility;
       ownerScope?: OwnerScope;
     } = {}): Promise<{ projects: ProjectConfig[]; nextCursor: null }> {
-      let entries;
-      try {
-        entries = await readdir(join(homePath, "projects"), { withFileTypes: true });
-      } catch (err: unknown) {
-        if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-          return { projects: [], nextCursor: null };
-        }
-        throw err;
-      }
-
       const projects: ProjectConfig[] = [];
       const visibility = input.visibility ?? "active";
-      for (const entry of entries) {
-        if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
-        const project = await readProjectConfig(homePath, entry.name);
+      for (const slug of await registry.listSlugs()) {
+        const project = await readProjectConfig(homePath, slug);
         if (!project || !ownerScopeMatches(project.ownerScope, input.ownerScope) || project.deletingAt) continue;
         const archived = project.archivedAt !== undefined;
         if (visibility === "active" && archived) continue;
@@ -605,24 +578,14 @@ export function createProjectManager(options: {
     },
 
     async listDeletingProjects(): Promise<{ projects: ProjectConfig[]; nextCursor: null }> {
-      let entries;
-      try {
-        entries = await readdir(join(homePath, "projects"), { withFileTypes: true });
-      } catch (err: unknown) {
-        if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-          return { projects: [], nextCursor: null };
-        }
-        throw err;
-      }
       const projects: ProjectConfig[] = [];
-      for (const entry of entries) {
-        if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
-        const project = await readProjectConfig(homePath, entry.name);
+      for (const slug of await registry.listSlugs()) {
+        const project = await readProjectConfig(homePath, slug);
         if (project?.deletingAt) projects.push(project);
       }
       let tombstoneEntries: Dirent[];
       try {
-        tombstoneEntries = await readdir(projectDeletionTombstoneDir(homePath), { withFileTypes: true });
+        tombstoneEntries = await readdir(registry.tombstoneDir(), { withFileTypes: true });
       } catch (err: unknown) {
         if (!(err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT")) {
           throw err;
@@ -689,11 +652,11 @@ export function createProjectManager(options: {
         if (input.deletingAt === null) delete updated.deletingAt;
         else updated.deletingAt = input.deletingAt;
       }
-      await atomicWriteJson(join(projectPath(homePath, input.slug), "config.json"), updated);
+      await registry.writeConfig(input.slug, updated);
       if (updated.deletingAt) {
-        await atomicWriteJson(projectDeletionTombstonePath(homePath, input.slug), updated);
+        await atomicWriteJson(registry.tombstonePath(input.slug), updated);
       } else {
-        await rm(projectDeletionTombstonePath(homePath, input.slug), { force: true });
+        await rm(registry.tombstonePath(input.slug), { force: true });
       }
       return { ok: true, project: updated };
     },
@@ -706,12 +669,15 @@ export function createProjectManager(options: {
       if (!current.ok) return current;
       if (current.project.deletingAt) {
         await atomicWriteJson(
-          projectDeletionTombstonePath(homePath, input.slug),
+          registry.tombstonePath(input.slug),
           current.project,
         );
       }
-      await rm(projectPath(homePath, input.slug), { recursive: true, force: true });
-      await rm(projectDeletionTombstonePath(homePath, input.slug), { force: true });
+      if (current.project.kind !== "folder") {
+        await rm(projectPath(homePath, input.slug), { recursive: true, force: true });
+      }
+      await registry.removeConfig(input.slug);
+      await rm(registry.tombstonePath(input.slug), { force: true });
       return { ok: true };
     },
 

--- a/packages/gateway/src/project-registry-layout.ts
+++ b/packages/gateway/src/project-registry-layout.ts
@@ -1,0 +1,25 @@
+import { join, resolve } from "node:path";
+
+export interface ManagedProjectSourceRecord {
+  slug: string;
+  kind?: "scratch" | "github" | "folder";
+  localPath: string;
+  legacyKindInferred?: true;
+}
+
+/**
+ * Proves that a project record points at the Matrix-managed checkout layout.
+ * A kind label alone is not authority to delete an owner-visible directory.
+ */
+export function isMatrixManagedProjectSource(
+  homePath: string,
+  project: ManagedProjectSourceRecord,
+): boolean {
+  if (
+    (project.kind !== "scratch" && project.kind !== "github")
+    || project.legacyKindInferred === true
+  ) {
+    return false;
+  }
+  return resolve(project.localPath) === join(resolve(homePath), "projects", project.slug, "repo");
+}

--- a/packages/gateway/src/project-registry.ts
+++ b/packages/gateway/src/project-registry.ts
@@ -19,6 +19,13 @@ function isProjectRecord(value: unknown, slug: string): value is ProjectRecord {
     && PROJECT_SLUG_REGEX.test(slug);
 }
 
+function validatedSlug(slug: string): string {
+  if (!PROJECT_SLUG_REGEX.test(slug)) {
+    throw new Error("Invalid project registry slug");
+  }
+  return slug;
+}
+
 function isErrnoCode(error: unknown, code: string): boolean {
   return error instanceof Error
     && "code" in error
@@ -65,12 +72,12 @@ export function createProjectRegistry(options: { homePath: string }) {
   const root = join(homePath, "system", "projects");
   const ownerProjectsRoot = join(homePath, "projects");
 
-  const recordDir = (slug: string) => join(root, slug);
+  const recordDir = (slug: string) => join(root, validatedSlug(slug));
   const configPath = (slug: string) => join(recordDir(slug), "config.json");
-  const legacyConfigPath = (slug: string) => join(ownerProjectsRoot, slug, "config.json");
+  const legacyConfigPath = (slug: string) => join(ownerProjectsRoot, validatedSlug(slug), "config.json");
   const legacyBackupPath = (slug: string) => join(recordDir(slug), "legacy-config.json");
   const tombstoneDir = () => join(root, ".deleting");
-  const tombstonePath = (slug: string) => join(tombstoneDir(), `${slug}.json`);
+  const tombstonePath = (slug: string) => join(tombstoneDir(), `${validatedSlug(slug)}.json`);
   const tasksDir = (slug: string) => join(recordDir(slug), "tasks");
   const worktreesDir = (slug: string) => join(recordDir(slug), "worktrees");
 

--- a/packages/gateway/src/project-registry.ts
+++ b/packages/gateway/src/project-registry.ts
@@ -1,22 +1,67 @@
 import { constants } from "node:fs";
 import { access, link, lstat, mkdir, readdir, rm, unlink } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import { z } from "zod/v4";
 import { atomicCreateJson, atomicWriteJson, readJsonFile } from "./state-ops.js";
 
 export const PROJECT_SLUG_REGEX = /^[a-z0-9][a-z0-9-]{0,62}$/;
 
-type ProjectRecord = {
+const ProjectRecordSchema = z.object({
+  id: z.string().regex(/^proj_[A-Za-z0-9_-]{1,128}$/),
+  name: z.string().min(1).max(200),
+  slug: z.string().regex(PROJECT_SLUG_REGEX),
+  kind: z.enum(["scratch", "github", "folder"]).optional(),
+  remote: z.string().max(2_048).optional(),
+  localPath: z.string().min(1).max(4_096),
+  defaultBranch: z.string().max(200).optional(),
+  addedAt: z.string().min(1).max(64),
+  updatedAt: z.string().min(1).max(64),
+  ownerScope: z.object({
+    type: z.enum(["user", "org"]),
+    id: z.string().min(1).max(256),
+  }),
+  archivedAt: z.string().max(64).optional(),
+  deletingAt: z.string().max(64).optional(),
+  createRequestId: z.string().max(132).optional(),
+  createRequestFingerprint: z.string().max(128).optional(),
+  github: z.object({
+    owner: z.string().min(1).max(256),
+    repo: z.string().min(1).max(256),
+    htmlUrl: z.string().min(1).max(2_048),
+    authState: z.enum(["unknown", "ok", "required", "rate_limited", "error"]),
+    lastPrRefreshAt: z.string().max(64).optional(),
+    lastBranchRefreshAt: z.string().max(64).optional(),
+  }).optional(),
+}).passthrough();
+
+export interface ProjectRecord {
   id: string;
+  name: string;
   slug: string;
-};
+  kind?: "scratch" | "github" | "folder";
+  remote?: string;
+  localPath: string;
+  defaultBranch?: string;
+  addedAt: string;
+  updatedAt: string;
+  ownerScope: { type: "user" | "org"; id: string };
+  archivedAt?: string;
+  deletingAt?: string;
+  createRequestId?: string;
+  createRequestFingerprint?: string;
+  github?: {
+    owner: string;
+    repo: string;
+    htmlUrl: string;
+    authState: "unknown" | "ok" | "required" | "rate_limited" | "error";
+    lastPrRefreshAt?: string;
+    lastBranchRefreshAt?: string;
+  };
+}
 
 function isProjectRecord(value: unknown, slug: string): value is ProjectRecord {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-  const record = value as Record<string, unknown>;
-  return typeof record.id === "string"
-    && record.id.length > 0
-    && record.slug === slug
-    && PROJECT_SLUG_REGEX.test(slug);
+  const parsed = ProjectRecordSchema.safeParse(value);
+  return parsed.success && parsed.data.slug === slug;
 }
 
 function validatedSlug(slug: string): string {
@@ -63,6 +108,18 @@ async function listDirectoryNames(path: string): Promise<string[]> {
   }
 }
 
+async function listJsonNames(path: string): Promise<string[]> {
+  try {
+    const entries = await readdir(path, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isFile() && !entry.isSymbolicLink() && entry.name.endsWith(".json"))
+      .map((entry) => entry.name.slice(0, -".json".length));
+  } catch (error: unknown) {
+    if (isErrnoCode(error, "ENOENT")) return [];
+    throw error;
+  }
+}
+
 /**
  * Matrix-owned project state. Callers use this module instead of rebuilding
  * paths so compatibility adoption and the owner-workspace seam stay local.
@@ -78,10 +135,15 @@ export function createProjectRegistry(options: { homePath: string }) {
   const legacyBackupPath = (slug: string) => join(recordDir(slug), "legacy-config.json");
   const tombstoneDir = () => join(root, ".deleting");
   const tombstonePath = (slug: string) => join(tombstoneDir(), `${validatedSlug(slug)}.json`);
+  const legacyTombstoneDir = () => join(ownerProjectsRoot, ".deleting");
+  const legacyTombstonePath = (slug: string) => join(legacyTombstoneDir(), `${validatedSlug(slug)}.json`);
   const tasksDir = (slug: string) => join(recordDir(slug), "tasks");
+  const legacyTasksDir = (slug: string) => join(ownerProjectsRoot, validatedSlug(slug), "tasks");
+  const previewsDir = (slug: string) => join(recordDir(slug), "previews");
+  const legacyPreviewsDir = (slug: string) => join(ownerProjectsRoot, validatedSlug(slug), "previews");
   const worktreesDir = (slug: string) => join(recordDir(slug), "worktrees");
 
-  const readLegacyConfig = async <T extends ProjectRecord>(slug: string): Promise<T | null> => {
+  const readLegacyConfig = async <T extends ProjectRecord = ProjectRecord>(slug: string): Promise<T | null> => {
     const legacyPath = legacyConfigPath(slug);
     let stats;
     try {
@@ -130,19 +192,31 @@ export function createProjectRegistry(options: { homePath: string }) {
     });
   };
 
-  const readConfig = async <T extends ProjectRecord>(slug: string): Promise<T | null> => {
-    const canonical = await readIfPresent<T>(configPath(slug));
+  const readConfig = async <T extends ProjectRecord = ProjectRecord>(slug: string): Promise<T | null> => {
+    const canonical = await readIfPresent<unknown>(configPath(slug));
     if (canonical) {
+      if (!isProjectRecord(canonical, slug)) return null;
       await archiveMatchingLegacy(slug, canonical);
-      return canonical;
+      return canonical as T;
     }
 
     const legacy = await readLegacyConfig<T>(slug);
     if (!legacy) return null;
     const created = await atomicCreateJson(configPath(slug), legacy);
-    const winner = created ? legacy : await readJsonFile<T>(configPath(slug));
+    const winner: unknown = created ? legacy : await readJsonFile(configPath(slug));
+    if (!isProjectRecord(winner, slug)) return null;
     await archiveMatchingLegacy(slug, winner);
-    return winner;
+    return winner as T;
+  };
+
+  const readTombstone = async <T extends ProjectRecord = ProjectRecord>(slug: string): Promise<T | null> => {
+    const canonical = await readIfPresent<unknown>(tombstonePath(slug));
+    if (canonical) return isProjectRecord(canonical, slug) ? canonical as T : null;
+    const legacy = await readIfPresent<unknown>(legacyTombstonePath(slug));
+    if (!legacy || !isProjectRecord(legacy, slug)) return null;
+    const created = await atomicCreateJson(tombstonePath(slug), legacy);
+    const winner: unknown = created ? legacy : await readJsonFile(tombstonePath(slug));
+    return isProjectRecord(winner, slug) ? winner as T : null;
   };
 
   return {
@@ -153,16 +227,23 @@ export function createProjectRegistry(options: { homePath: string }) {
     legacyBackupPath,
     tombstoneDir,
     tombstonePath,
+    legacyTombstoneDir,
+    legacyTombstonePath,
     tasksDir,
+    legacyTasksDir,
+    previewsDir,
+    legacyPreviewsDir,
     worktreesDir,
 
     readConfig,
 
     async createConfig<T extends ProjectRecord>(slug: string, value: T): Promise<boolean> {
+      if (!isProjectRecord(value, slug)) throw new Error("Invalid project registry record");
       return await atomicCreateJson(configPath(slug), value);
     },
 
     async writeConfig<T extends ProjectRecord>(slug: string, value: T): Promise<void> {
+      if (!isProjectRecord(value, slug)) throw new Error("Invalid project registry record");
       await atomicWriteJson(configPath(slug), value);
       await archiveMatchingLegacy(slug, value);
     },
@@ -172,7 +253,30 @@ export function createProjectRegistry(options: { homePath: string }) {
     },
 
     async hasTombstone(slug: string): Promise<boolean> {
-      return await pathExists(tombstonePath(slug));
+      return await readTombstone(slug) !== null;
+    },
+
+    readTombstone,
+
+    async writeTombstone<T extends ProjectRecord>(slug: string, value: T): Promise<void> {
+      if (!isProjectRecord(value, slug)) throw new Error("Invalid project tombstone record");
+      await atomicWriteJson(tombstonePath(slug), value);
+      await rm(legacyTombstonePath(slug), { force: true });
+    },
+
+    async removeTombstone(slug: string): Promise<void> {
+      await Promise.all([
+        rm(tombstonePath(slug), { force: true }),
+        rm(legacyTombstonePath(slug), { force: true }),
+      ]);
+    },
+
+    async listTombstoneSlugs(): Promise<string[]> {
+      const names = await Promise.all([
+        listJsonNames(tombstoneDir()),
+        listJsonNames(legacyTombstoneDir()),
+      ]);
+      return [...new Set(names.flat())].filter((slug) => PROJECT_SLUG_REGEX.test(slug)).sort();
     },
 
     async listSlugs(): Promise<string[]> {

--- a/packages/gateway/src/project-registry.ts
+++ b/packages/gateway/src/project-registry.ts
@@ -1,0 +1,189 @@
+import { constants } from "node:fs";
+import { access, link, lstat, mkdir, readdir, rm, unlink } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { atomicCreateJson, atomicWriteJson, readJsonFile } from "./state-ops.js";
+
+export const PROJECT_SLUG_REGEX = /^[a-z0-9][a-z0-9-]{0,62}$/;
+
+type ProjectRecord = {
+  id: string;
+  slug: string;
+};
+
+function isProjectRecord(value: unknown, slug: string): value is ProjectRecord {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.id === "string"
+    && record.id.length > 0
+    && record.slug === slug
+    && PROJECT_SLUG_REGEX.test(slug);
+}
+
+function isErrnoCode(error: unknown, code: string): boolean {
+  return error instanceof Error
+    && "code" in error
+    && (error as NodeJS.ErrnoException).code === code;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (error: unknown) {
+    if (isErrnoCode(error, "ENOENT")) return false;
+    throw error;
+  }
+}
+
+async function readIfPresent<T>(path: string): Promise<T | null> {
+  try {
+    return await readJsonFile<T>(path);
+  } catch (error: unknown) {
+    if (isErrnoCode(error, "ENOENT")) return null;
+    throw error;
+  }
+}
+
+async function listDirectoryNames(path: string): Promise<string[]> {
+  try {
+    const entries = await readdir(path, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory() && !entry.isSymbolicLink())
+      .map((entry) => entry.name);
+  } catch (error: unknown) {
+    if (isErrnoCode(error, "ENOENT")) return [];
+    throw error;
+  }
+}
+
+/**
+ * Matrix-owned project state. Callers use this module instead of rebuilding
+ * paths so compatibility adoption and the owner-workspace seam stay local.
+ */
+export function createProjectRegistry(options: { homePath: string }) {
+  const homePath = resolve(options.homePath);
+  const root = join(homePath, "system", "projects");
+  const ownerProjectsRoot = join(homePath, "projects");
+
+  const recordDir = (slug: string) => join(root, slug);
+  const configPath = (slug: string) => join(recordDir(slug), "config.json");
+  const legacyConfigPath = (slug: string) => join(ownerProjectsRoot, slug, "config.json");
+  const legacyBackupPath = (slug: string) => join(recordDir(slug), "legacy-config.json");
+  const tombstoneDir = () => join(root, ".deleting");
+  const tombstonePath = (slug: string) => join(tombstoneDir(), `${slug}.json`);
+  const tasksDir = (slug: string) => join(recordDir(slug), "tasks");
+  const worktreesDir = (slug: string) => join(recordDir(slug), "worktrees");
+
+  const readLegacyConfig = async <T extends ProjectRecord>(slug: string): Promise<T | null> => {
+    const legacyPath = legacyConfigPath(slug);
+    let stats;
+    try {
+      stats = await lstat(legacyPath);
+    } catch (error: unknown) {
+      if (isErrnoCode(error, "ENOENT")) return null;
+      throw error;
+    }
+    if (!stats.isFile() || stats.isSymbolicLink()) return null;
+    let value: unknown;
+    try {
+      value = await readJsonFile(legacyPath);
+    } catch (error: unknown) {
+      // projects/<folder> is owner space. A same-named application config is
+      // legacy Matrix metadata only when it has the expected record identity.
+      if (error instanceof SyntaxError) return null;
+      throw error;
+    }
+    return isProjectRecord(value, slug) ? value as T : null;
+  };
+
+  const archiveMatchingLegacy = async (slug: string, canonical: ProjectRecord): Promise<void> => {
+    const legacyPath = legacyConfigPath(slug);
+    let stats;
+    try {
+      stats = await lstat(legacyPath);
+    } catch (error: unknown) {
+      if (isErrnoCode(error, "ENOENT")) return;
+      throw error;
+    }
+    if (!stats.isFile() || stats.isSymbolicLink()) return;
+    const legacy = await readLegacyConfig<ProjectRecord>(slug);
+    if (!legacy || legacy.id !== canonical.id || legacy.slug !== canonical.slug) return;
+
+    await mkdir(recordDir(slug), { recursive: true });
+    const backupPath = legacyBackupPath(slug);
+    try {
+      await link(legacyPath, backupPath);
+    } catch (error: unknown) {
+      if (!isErrnoCode(error, "EEXIST")) throw error;
+      const backup = await readIfPresent<ProjectRecord>(backupPath);
+      if (!backup || backup.id !== legacy.id || backup.slug !== legacy.slug) return;
+    }
+    await unlink(legacyPath).catch((error: unknown) => {
+      if (!isErrnoCode(error, "ENOENT")) throw error;
+    });
+  };
+
+  const readConfig = async <T extends ProjectRecord>(slug: string): Promise<T | null> => {
+    const canonical = await readIfPresent<T>(configPath(slug));
+    if (canonical) {
+      await archiveMatchingLegacy(slug, canonical);
+      return canonical;
+    }
+
+    const legacy = await readLegacyConfig<T>(slug);
+    if (!legacy) return null;
+    const created = await atomicCreateJson(configPath(slug), legacy);
+    const winner = created ? legacy : await readJsonFile<T>(configPath(slug));
+    await archiveMatchingLegacy(slug, winner);
+    return winner;
+  };
+
+  return {
+    root,
+    recordDir,
+    configPath,
+    legacyConfigPath,
+    legacyBackupPath,
+    tombstoneDir,
+    tombstonePath,
+    tasksDir,
+    worktreesDir,
+
+    readConfig,
+
+    async createConfig<T extends ProjectRecord>(slug: string, value: T): Promise<boolean> {
+      return await atomicCreateJson(configPath(slug), value);
+    },
+
+    async writeConfig<T extends ProjectRecord>(slug: string, value: T): Promise<void> {
+      await atomicWriteJson(configPath(slug), value);
+      await archiveMatchingLegacy(slug, value);
+    },
+
+    async removeConfig(slug: string): Promise<void> {
+      await rm(recordDir(slug), { recursive: true, force: true });
+    },
+
+    async hasTombstone(slug: string): Promise<boolean> {
+      return await pathExists(tombstonePath(slug));
+    },
+
+    async listSlugs(): Promise<string[]> {
+      const [canonicalNames, legacyNames] = await Promise.all([
+        listDirectoryNames(root),
+        listDirectoryNames(ownerProjectsRoot),
+      ]);
+      const candidates = [...new Set([...canonicalNames, ...legacyNames])]
+        .filter((slug) => PROJECT_SLUG_REGEX.test(slug));
+      const present: string[] = [];
+      for (const slug of candidates) {
+        if (await pathExists(configPath(slug)) || await readLegacyConfig(slug)) {
+          present.push(slug);
+        }
+      }
+      return present.sort();
+    },
+  };
+}
+
+export type ProjectRegistry = ReturnType<typeof createProjectRegistry>;

--- a/packages/gateway/src/project-registry.ts
+++ b/packages/gateway/src/project-registry.ts
@@ -1,8 +1,20 @@
-import { constants } from "node:fs";
-import { access, link, lstat, mkdir, readdir, rm, unlink } from "node:fs/promises";
+import { constants, type Dirent } from "node:fs";
+import { access, link, lstat, mkdir, opendir, realpath, rm } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { z } from "zod/v4";
-import { atomicCreateJson, atomicWriteJson, readJsonFile } from "./state-ops.js";
+import { atomicCreateJson, atomicWriteJson } from "./state-ops.js";
+import {
+  projectStateRecoveryDir,
+  readBoundedJsonFileWithIdentity,
+  removeFileIfUnchanged,
+  type FileIdentity,
+} from "./bounded-json-file.js";
+import {
+  containsDeniedFileApiPath,
+  isProtectedHomeSubpath,
+  resolveWithinHome,
+  resolveWritableFileApiPath,
+} from "./path-security.js";
 
 export const PROJECT_SLUG_REGEX = /^[a-z0-9][a-z0-9-]{0,62}$/;
 
@@ -24,6 +36,7 @@ const ProjectRecordSchema = z.object({
   deletingAt: z.string().max(64).optional(),
   createRequestId: z.string().max(132).optional(),
   createRequestFingerprint: z.string().max(128).optional(),
+  legacyKindInferred: z.literal(true).optional(),
   github: z.object({
     owner: z.string().min(1).max(256),
     repo: z.string().min(1).max(256),
@@ -32,7 +45,10 @@ const ProjectRecordSchema = z.object({
     lastPrRefreshAt: z.string().max(64).optional(),
     lastBranchRefreshAt: z.string().max(64).optional(),
   }).optional(),
-}).passthrough();
+});
+
+const MAX_PROJECT_RECORD_BYTES = 256 * 1024;
+const MAX_PROJECT_DISCOVERY_ENTRIES = 10_000;
 
 export interface ProjectRecord {
   id: string;
@@ -49,6 +65,7 @@ export interface ProjectRecord {
   deletingAt?: string;
   createRequestId?: string;
   createRequestFingerprint?: string;
+  legacyKindInferred?: true;
   github?: {
     owner: string;
     repo: string;
@@ -59,9 +76,45 @@ export interface ProjectRecord {
   };
 }
 
-function isProjectRecord(value: unknown, slug: string): value is ProjectRecord {
+async function parseProjectRecord(
+  value: unknown,
+  slug: string,
+  homePath: string,
+): Promise<ProjectRecord | null> {
   const parsed = ProjectRecordSchema.safeParse(value);
-  return parsed.success && parsed.data.slug === slug;
+  if (!parsed.success || parsed.data.slug !== slug) return null;
+  const localPath = resolve(parsed.data.localPath);
+  const realHomePath = await realpath(homePath);
+  const validationBase = resolveWithinHome(homePath, localPath)
+    ? homePath
+    : resolveWithinHome(realHomePath, localPath)
+      ? realHomePath
+      : null;
+  if (
+    !validationBase
+    || isProtectedHomeSubpath(validationBase, localPath)
+    || containsDeniedFileApiPath(validationBase, localPath)
+    || !resolveWritableFileApiPath(validationBase, localPath)
+  ) {
+    return null;
+  }
+  try {
+    const stats = await lstat(localPath);
+    if (stats.isSymbolicLink()) return null;
+    const realLocalPath = await realpath(localPath);
+    if (
+      !resolveWithinHome(realHomePath, realLocalPath)
+      || isProtectedHomeSubpath(realHomePath, realLocalPath)
+      || containsDeniedFileApiPath(realHomePath, realLocalPath)
+    ) {
+      return null;
+    }
+  } catch (error: unknown) {
+    // Missing owner code stays representable for recovery and diagnostics;
+    // existing paths must resolve inside the owner-controlled Matrix home.
+    if (!isErrnoCode(error, "ENOENT")) throw error;
+  }
+  return parsed.data;
 }
 
 function validatedSlug(slug: string): string {
@@ -88,36 +141,43 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 async function readIfPresent<T>(path: string): Promise<T | null> {
+  const candidate = await readBoundedJsonFileWithIdentity(path, MAX_PROJECT_RECORD_BYTES);
+  return candidate ? candidate.value as T : null;
+}
+
+async function listBoundedNames(
+  path: string,
+  include: (entry: Dirent) => boolean,
+  mapName: (name: string) => string = (name) => name,
+): Promise<string[]> {
   try {
-    return await readJsonFile<T>(path);
+    const directory = await opendir(path);
+    const names: string[] = [];
+    let visited = 0;
+    for await (const entry of directory) {
+      visited += 1;
+      if (visited > MAX_PROJECT_DISCOVERY_ENTRIES) {
+        throw new Error("Project registry discovery limit exceeded");
+      }
+      if (include(entry)) names.push(mapName(entry.name));
+    }
+    return names;
   } catch (error: unknown) {
-    if (isErrnoCode(error, "ENOENT")) return null;
+    if (isErrnoCode(error, "ENOENT")) return [];
     throw error;
   }
 }
 
 async function listDirectoryNames(path: string): Promise<string[]> {
-  try {
-    const entries = await readdir(path, { withFileTypes: true });
-    return entries
-      .filter((entry) => entry.isDirectory() && !entry.isSymbolicLink())
-      .map((entry) => entry.name);
-  } catch (error: unknown) {
-    if (isErrnoCode(error, "ENOENT")) return [];
-    throw error;
-  }
+  return await listBoundedNames(path, (entry) => entry.isDirectory() && !entry.isSymbolicLink());
 }
 
 async function listJsonNames(path: string): Promise<string[]> {
-  try {
-    const entries = await readdir(path, { withFileTypes: true });
-    return entries
-      .filter((entry) => entry.isFile() && !entry.isSymbolicLink() && entry.name.endsWith(".json"))
-      .map((entry) => entry.name.slice(0, -".json".length));
-  } catch (error: unknown) {
-    if (isErrnoCode(error, "ENOENT")) return [];
-    throw error;
-  }
+  return await listBoundedNames(
+    path,
+    (entry) => entry.isFile() && !entry.isSymbolicLink() && entry.name.endsWith(".json"),
+    (name) => name.slice(0, -".json".length),
+  );
 }
 
 /**
@@ -143,80 +203,114 @@ export function createProjectRegistry(options: { homePath: string }) {
   const legacyPreviewsDir = (slug: string) => join(ownerProjectsRoot, validatedSlug(slug), "previews");
   const worktreesDir = (slug: string) => join(recordDir(slug), "worktrees");
 
-  const readLegacyConfig = async <T extends ProjectRecord = ProjectRecord>(slug: string): Promise<T | null> => {
+  const readLegacyConfigCandidate = async <T extends ProjectRecord = ProjectRecord>(slug: string): Promise<{
+    record: T;
+    identity: FileIdentity;
+  } | null> => {
     const legacyPath = legacyConfigPath(slug);
-    let stats;
-    try {
-      stats = await lstat(legacyPath);
-    } catch (error: unknown) {
-      if (isErrnoCode(error, "ENOENT")) return null;
-      throw error;
-    }
-    if (!stats.isFile() || stats.isSymbolicLink()) return null;
-    let value: unknown;
-    try {
-      value = await readJsonFile(legacyPath);
-    } catch (error: unknown) {
-      // projects/<folder> is owner space. A same-named application config is
-      // legacy Matrix metadata only when it has the expected record identity.
-      if (error instanceof SyntaxError) return null;
-      throw error;
-    }
-    return isProjectRecord(value, slug) ? value as T : null;
+    const candidate = await readBoundedJsonFileWithIdentity(legacyPath, MAX_PROJECT_RECORD_BYTES);
+    if (!candidate) return null;
+    const parsed = await parseProjectRecord(candidate.value, slug, homePath);
+    return parsed ? { record: parsed as T, identity: candidate.identity } : null;
   };
+
+  const readLegacyConfig = async <T extends ProjectRecord = ProjectRecord>(slug: string): Promise<T | null> =>
+    (await readLegacyConfigCandidate<T>(slug))?.record ?? null;
+
+  const readLegacyTombstoneCandidate = async (slug: string): Promise<{
+    record: ProjectRecord;
+    identity: FileIdentity;
+  } | null> => {
+    const candidate = await readBoundedJsonFileWithIdentity(
+      legacyTombstonePath(slug),
+      MAX_PROJECT_RECORD_BYTES,
+    );
+    if (!candidate) return null;
+    const parsed = await parseProjectRecord(candidate.value, slug, homePath);
+    return parsed ? { record: parsed, identity: candidate.identity } : null;
+  };
+
+  const readCanonicalTombstoneCandidate = async (slug: string): Promise<{
+    record: ProjectRecord;
+    identity: FileIdentity;
+  } | null> => {
+    const candidate = await readBoundedJsonFileWithIdentity(tombstonePath(slug), MAX_PROJECT_RECORD_BYTES);
+    if (!candidate) return null;
+    const parsed = await parseProjectRecord(candidate.value, slug, homePath);
+    return parsed ? { record: parsed, identity: candidate.identity } : null;
+  };
+
+  const sameProjectOwner = (record: ProjectRecord, expected: ProjectRecord): boolean => (
+    record.id === expected.id
+    && record.ownerScope.type === expected.ownerScope.type
+    && record.ownerScope.id === expected.ownerScope.id
+  );
 
   const archiveMatchingLegacy = async (slug: string, canonical: ProjectRecord): Promise<void> => {
     const legacyPath = legacyConfigPath(slug);
-    let stats;
-    try {
-      stats = await lstat(legacyPath);
-    } catch (error: unknown) {
-      if (isErrnoCode(error, "ENOENT")) return;
-      throw error;
-    }
-    if (!stats.isFile() || stats.isSymbolicLink()) return;
-    const legacy = await readLegacyConfig<ProjectRecord>(slug);
-    if (!legacy || legacy.id !== canonical.id || legacy.slug !== canonical.slug) return;
+    const candidate = await readLegacyConfigCandidate<ProjectRecord>(slug);
+    if (!candidate) return;
+    const legacy = candidate.record;
+    if (legacy.id !== canonical.id || legacy.slug !== canonical.slug) return;
 
     await mkdir(recordDir(slug), { recursive: true });
     const backupPath = legacyBackupPath(slug);
+    let createdBackup = false;
     try {
       await link(legacyPath, backupPath);
+      createdBackup = true;
     } catch (error: unknown) {
       if (!isErrnoCode(error, "EEXIST")) throw error;
-      const backup = await readIfPresent<ProjectRecord>(backupPath);
-      if (!backup || backup.id !== legacy.id || backup.slug !== legacy.slug) return;
     }
-    await unlink(legacyPath).catch((error: unknown) => {
-      if (!isErrnoCode(error, "ENOENT")) throw error;
+    const backupCandidate = await readBoundedJsonFileWithIdentity(backupPath, MAX_PROJECT_RECORD_BYTES);
+    const backup = backupCandidate
+      ? await parseProjectRecord(backupCandidate.value, slug, homePath)
+      : null;
+    if (!backup || backup.id !== legacy.id || backup.slug !== legacy.slug) {
+      if (createdBackup && backupCandidate) {
+        await removeFileIfUnchanged(backupPath, backupCandidate.identity, {
+          recoveryDir: projectStateRecoveryDir(homePath),
+        });
+      }
+      return;
+    }
+    await removeFileIfUnchanged(legacyPath, candidate.identity, {
+      recoveryDir: projectStateRecoveryDir(homePath),
     });
   };
 
   const readConfig = async <T extends ProjectRecord = ProjectRecord>(slug: string): Promise<T | null> => {
     const canonical = await readIfPresent<unknown>(configPath(slug));
     if (canonical) {
-      if (!isProjectRecord(canonical, slug)) return null;
-      await archiveMatchingLegacy(slug, canonical);
-      return canonical as T;
+      const parsed = await parseProjectRecord(canonical, slug, homePath);
+      if (!parsed) return null;
+      await archiveMatchingLegacy(slug, parsed);
+      return parsed as T;
     }
 
-    const legacy = await readLegacyConfig<T>(slug);
-    if (!legacy) return null;
+    const legacyCandidate = await readLegacyConfigCandidate<T>(slug);
+    if (!legacyCandidate) return null;
+    const legacy = legacyCandidate.record;
     const created = await atomicCreateJson(configPath(slug), legacy);
-    const winner: unknown = created ? legacy : await readJsonFile(configPath(slug));
-    if (!isProjectRecord(winner, slug)) return null;
-    await archiveMatchingLegacy(slug, winner);
-    return winner as T;
+    const winner: unknown = created ? legacy : await readIfPresent(configPath(slug));
+    const parsed = await parseProjectRecord(winner, slug, homePath);
+    if (!parsed) return null;
+    await archiveMatchingLegacy(slug, parsed);
+    return parsed as T;
   };
 
   const readTombstone = async <T extends ProjectRecord = ProjectRecord>(slug: string): Promise<T | null> => {
     const canonical = await readIfPresent<unknown>(tombstonePath(slug));
-    if (canonical) return isProjectRecord(canonical, slug) ? canonical as T : null;
-    const legacy = await readIfPresent<unknown>(legacyTombstonePath(slug));
-    if (!legacy || !isProjectRecord(legacy, slug)) return null;
-    const created = await atomicCreateJson(tombstonePath(slug), legacy);
-    const winner: unknown = created ? legacy : await readJsonFile(tombstonePath(slug));
-    return isProjectRecord(winner, slug) ? winner as T : null;
+    if (canonical) {
+      const parsed = await parseProjectRecord(canonical, slug, homePath);
+      return parsed ? parsed as T : null;
+    }
+    const legacyCandidate = await readLegacyTombstoneCandidate(slug);
+    if (!legacyCandidate) return null;
+    const created = await atomicCreateJson(tombstonePath(slug), legacyCandidate.record);
+    const winner: unknown = created ? legacyCandidate.record : await readIfPresent(tombstonePath(slug));
+    const parsedWinner = await parseProjectRecord(winner, slug, homePath);
+    return parsedWinner ? parsedWinner as T : null;
   };
 
   return {
@@ -238,14 +332,16 @@ export function createProjectRegistry(options: { homePath: string }) {
     readConfig,
 
     async createConfig<T extends ProjectRecord>(slug: string, value: T): Promise<boolean> {
-      if (!isProjectRecord(value, slug)) throw new Error("Invalid project registry record");
-      return await atomicCreateJson(configPath(slug), value);
+      const parsed = await parseProjectRecord(value, slug, homePath);
+      if (!parsed) throw new Error("Invalid project registry record");
+      return await atomicCreateJson(configPath(slug), parsed);
     },
 
     async writeConfig<T extends ProjectRecord>(slug: string, value: T): Promise<void> {
-      if (!isProjectRecord(value, slug)) throw new Error("Invalid project registry record");
-      await atomicWriteJson(configPath(slug), value);
-      await archiveMatchingLegacy(slug, value);
+      const parsed = await parseProjectRecord(value, slug, homePath);
+      if (!parsed) throw new Error("Invalid project registry record");
+      await atomicWriteJson(configPath(slug), parsed);
+      await archiveMatchingLegacy(slug, parsed);
     },
 
     async removeConfig(slug: string): Promise<void> {
@@ -259,16 +355,30 @@ export function createProjectRegistry(options: { homePath: string }) {
     readTombstone,
 
     async writeTombstone<T extends ProjectRecord>(slug: string, value: T): Promise<void> {
-      if (!isProjectRecord(value, slug)) throw new Error("Invalid project tombstone record");
-      await atomicWriteJson(tombstonePath(slug), value);
-      await rm(legacyTombstonePath(slug), { force: true });
+      const parsed = await parseProjectRecord(value, slug, homePath);
+      if (!parsed) throw new Error("Invalid project tombstone record");
+      const legacy = await readLegacyTombstoneCandidate(slug);
+      await atomicWriteJson(tombstonePath(slug), parsed);
+      if (legacy && sameProjectOwner(legacy.record, parsed)) {
+        await removeFileIfUnchanged(legacyTombstonePath(slug), legacy.identity, {
+          recoveryDir: projectStateRecoveryDir(homePath),
+        });
+      }
     },
 
-    async removeTombstone(slug: string): Promise<void> {
-      await Promise.all([
-        rm(tombstonePath(slug), { force: true }),
-        rm(legacyTombstonePath(slug), { force: true }),
-      ]);
+    async removeTombstone(slug: string, expected: ProjectRecord): Promise<void> {
+      const canonical = await readCanonicalTombstoneCandidate(slug);
+      const legacy = await readLegacyTombstoneCandidate(slug);
+      if (canonical && sameProjectOwner(canonical.record, expected)) {
+        await removeFileIfUnchanged(tombstonePath(slug), canonical.identity, {
+          recoveryDir: projectStateRecoveryDir(homePath),
+        });
+      }
+      if (legacy && sameProjectOwner(legacy.record, expected)) {
+        await removeFileIfUnchanged(legacyTombstonePath(slug), legacy.identity, {
+          recoveryDir: projectStateRecoveryDir(homePath),
+        });
+      }
     },
 
     async listTombstoneSlugs(): Promise<string[]> {

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -592,6 +592,7 @@ export async function createGateway(config: GatewayConfig) {
     (id): id is string => Boolean(id),
   );
   const codingAgentProjectManager = createProjectManager({ homePath });
+  const codingAgentWorktreeManager = createWorktreeManager({ homePath });
   const codingAgentFileStore = createCodingAgentFileStore({
     homePath,
     ownerId: process.env.MATRIX_USER_ID,
@@ -599,11 +600,13 @@ export async function createGateway(config: GatewayConfig) {
     projects: {
       getProjectBySlug: (projectSlug) => codingAgentProjectManager.getProject(projectSlug),
     },
+    worktrees: codingAgentWorktreeManager,
   });
   const codingAgentSourceControlStore = createCodingAgentSourceControlStore({
     homePath,
     ownerId: process.env.MATRIX_USER_ID,
     principalOwnerIds: codingAgentOwnerIds,
+    worktrees: codingAgentWorktreeManager,
   });
   const codingAgentNotificationPreferenceStore = createCodingAgentNotificationPreferenceStore({ homePath });
   const workspaceEventPublisher = createWorkspaceEventPublisher({
@@ -617,7 +620,6 @@ export async function createGateway(config: GatewayConfig) {
     codexEventBridge = codexExecutable
       ? createCodexEventBridge({ homePath, codexExecutable })
       : undefined;
-    const codingAgentWorktreeManager = createWorktreeManager({ homePath });
     const codingAgentSessionManager = createAgentSessionManager({
       homePath,
       worktreeManager: codingAgentWorktreeManager,

--- a/packages/gateway/src/shell/terminal-git-context.ts
+++ b/packages/gateway/src/shell/terminal-git-context.ts
@@ -5,6 +5,7 @@ import { promisify } from "node:util";
 import { z } from "zod/v4";
 import { createProjectRegistry } from "../project-registry.js";
 import { PROJECT_SLUG_REGEX } from "../project-manager.js";
+import { createWorktreeManager } from "../worktree-manager.js";
 
 const MAX_CACHE_ENTRIES = 128;
 const MAX_SESSION_FILES = 256;
@@ -222,11 +223,15 @@ export class TerminalGitContextResolver {
       if (!project.success) return null;
       let worktree: z.infer<typeof WorktreeMetadataSchema> | undefined;
       if (parsed.data.worktreeId) {
-        const value = await readJson(join(
-          registry.worktreesDir(parsed.data.projectSlug),
-          parsed.data.worktreeId,
-          "worktree.json",
-        ));
+        // WorktreeManager owns both canonical registry reads and lazy adoption
+        // of legacy projects/<slug>/worktrees/<id>/.matrix metadata. Reading
+        // the new path directly here would make existing terminal sessions
+        // lose branch/PR context until another feature happened to migrate it.
+        const selected = await createWorktreeManager({
+          homePath: this.homePath,
+          runCommand: this.runCommand,
+        }).getWorktree(parsed.data.projectSlug, parsed.data.worktreeId);
+        const value = selected.ok ? selected.worktree : undefined;
         const parsedWorktree = WorktreeMetadataSchema.safeParse(value);
         if (parsedWorktree.success) worktree = parsedWorktree.data;
       }

--- a/packages/gateway/src/shell/terminal-git-context.ts
+++ b/packages/gateway/src/shell/terminal-git-context.ts
@@ -3,6 +3,7 @@ import { readdir, readFile } from "node:fs/promises";
 import { basename, join, relative, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import { z } from "zod/v4";
+import { createProjectRegistry } from "../project-registry.js";
 import { PROJECT_SLUG_REGEX } from "../project-manager.js";
 
 const MAX_CACHE_ENTRIES = 128;
@@ -215,18 +216,15 @@ export class TerminalGitContextResolver {
       if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
       const parsed = WorkspaceSessionMetadataSchema.safeParse(await readJson(join(sessionsDir, entry.name)));
       if (!parsed.success || parsed.data.runtime.zellijSession !== sessionName || !parsed.data.projectSlug) continue;
-      const projectValue = await readJson(join(this.homePath, "projects", parsed.data.projectSlug, "config.json"));
+      const registry = createProjectRegistry({ homePath: this.homePath });
+      const projectValue = await registry.readConfig(parsed.data.projectSlug);
       const project = ProjectMetadataSchema.safeParse(projectValue);
       if (!project.success) return null;
       let worktree: z.infer<typeof WorktreeMetadataSchema> | undefined;
       if (parsed.data.worktreeId) {
         const value = await readJson(join(
-          this.homePath,
-          "projects",
-          parsed.data.projectSlug,
-          "worktrees",
+          registry.worktreesDir(parsed.data.projectSlug),
           parsed.data.worktreeId,
-          ".matrix",
           "worktree.json",
         ));
         const parsedWorktree = WorktreeMetadataSchema.safeParse(value);

--- a/packages/gateway/src/state-ops.ts
+++ b/packages/gateway/src/state-ops.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
 import { access, link, mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { dirname, join, relative, resolve } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import { resolveWithinHome } from "./path-security.js";
 
 export type OwnerScope = { type: "user" | "org"; id: string };
@@ -155,6 +155,16 @@ async function listOwnedProjectFiles(
       files.push(relative(homePath, legacyConfigPath));
     }
 
+    for (const tombstonePath of [
+      join(registryRoot, ".deleting", `${slug}.json`),
+      join(projectsRoot, ".deleting", `${slug}.json`),
+    ]) {
+      if (await pathExists(tombstonePath)
+        && ownerMatches(await readOwnerScope(tombstonePath), ownerScope)) {
+        files.push(relative(homePath, tombstonePath));
+      }
+    }
+
     let config: Record<string, unknown> | null = null;
     try {
       const value = await readJsonFile(configPath);
@@ -164,6 +174,19 @@ async function listOwnedProjectFiles(
     }
     const localPath = typeof config?.localPath === "string" ? resolve(config.localPath) : null;
     if (!localPath) continue;
+    const legacyProjectRoot = join(projectsRoot, slug);
+    const legacyManaged = config?.kind === "scratch"
+      || config?.kind === "github"
+      || (config?.kind === undefined
+        && (localPath === legacyProjectRoot || localPath.startsWith(`${legacyProjectRoot}${sep}`)));
+    if (legacyManaged) {
+      for (const stateName of ["tasks", "previews"]) {
+        const legacyStateDir = join(legacyProjectRoot, stateName);
+        if (await pathExists(legacyStateDir)) {
+          files.push(...await listFilesRecursive(legacyStateDir, homePath));
+        }
+      }
+    }
     const resolvedHome = resolve(homePath);
     const rel = relative(resolvedHome, localPath);
     if (rel.startsWith("..") || rel === "" || resolve(rel) === rel || !await pathExists(localPath)) continue;
@@ -334,9 +357,11 @@ export function createStateOps(options: { homePath: string; now?: () => string }
         };
       }
       const config = await readJsonFile<Record<string, unknown>>(configPath);
-      if (config.kind !== "folder") {
+      if (config.kind === "scratch" || config.kind === "github") {
         await rm(legacyProjectPath, { recursive: true, force: true });
       } else if (configPath === legacyConfigPath) {
+        // Missing kind is legacy ambiguous state. Prefer leaving owner source
+        // behind over guessing that the whole directory is Matrix-managed.
         await rm(legacyConfigPath, { force: true });
       }
       await rm(registryPath, { recursive: true, force: true });

--- a/packages/gateway/src/state-ops.ts
+++ b/packages/gateway/src/state-ops.ts
@@ -113,27 +113,63 @@ async function listFilesRecursive(root: string, homePath: string): Promise<strin
   return files;
 }
 
-async function listOwnedProjectFiles(homePath: string, ownerScope?: OwnerScope): Promise<string[]> {
+async function listOwnedProjectFiles(
+  homePath: string,
+  ownerScope?: OwnerScope,
+  projectSlug?: string,
+): Promise<string[]> {
+  const registryRoot = join(homePath, "system", "projects");
   const projectsRoot = join(homePath, "projects");
-  let entries;
-  try {
-    entries = await readdir(projectsRoot, { withFileTypes: true });
-  } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      return [];
+  const slugs = projectSlug && PROJECT_SLUG_REGEX.test(projectSlug)
+    ? new Set([projectSlug])
+    : new Set<string>();
+  if (!projectSlug) {
+    for (const root of [registryRoot, projectsRoot]) {
+      try {
+        const entries = await readdir(root, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isDirectory() && !entry.isSymbolicLink() && PROJECT_SLUG_REGEX.test(entry.name)) {
+            slugs.add(entry.name);
+          }
+        }
+      } catch (err: unknown) {
+        if (!(err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT")) {
+          throw err;
+        }
+      }
     }
-    throw err;
   }
 
   const files: string[] = [];
-  for (const entry of entries) {
-    if (!entry.isDirectory() || entry.isSymbolicLink() || entry.name.startsWith(".")) continue;
-    const projectPath = join(projectsRoot, entry.name);
-    const owner = await readOwnerScope(join(projectPath, "config.json"));
+  for (const slug of slugs) {
+    const canonicalDir = join(registryRoot, slug);
+    const canonicalConfigPath = join(canonicalDir, "config.json");
+    const legacyConfigPath = join(projectsRoot, slug, "config.json");
+    const configPath = await pathExists(canonicalConfigPath) ? canonicalConfigPath : legacyConfigPath;
+    const owner = await readOwnerScope(configPath);
     if (!ownerMatches(owner, ownerScope)) continue;
-    files.push(...await listFilesRecursive(projectPath, homePath));
+
+    if (await pathExists(canonicalDir)) {
+      files.push(...await listFilesRecursive(canonicalDir, homePath));
+    } else if (await pathExists(legacyConfigPath)) {
+      files.push(relative(homePath, legacyConfigPath));
+    }
+
+    let config: Record<string, unknown> | null = null;
+    try {
+      const value = await readJsonFile(configPath);
+      config = isRecord(value) ? value : null;
+    } catch (err: unknown) {
+      if (!(err instanceof SyntaxError)) throw err;
+    }
+    const localPath = typeof config?.localPath === "string" ? resolve(config.localPath) : null;
+    if (!localPath) continue;
+    const resolvedHome = resolve(homePath);
+    const rel = relative(resolvedHome, localPath);
+    if (rel.startsWith("..") || rel === "" || resolve(rel) === rel || !await pathExists(localPath)) continue;
+    files.push(...await listFilesRecursive(localPath, homePath));
   }
-  return files;
+  return [...new Set(files)];
 }
 
 async function readOwnerScope(configPath: string): Promise<OwnerScope | null> {
@@ -245,22 +281,15 @@ export function createStateOps(options: { homePath: string; now?: () => string }
       if (request.scope === "all") {
         const systemPath = resolveWithinHome(homePath, "system");
         if (systemPath && await pathExists(systemPath)) {
-          files.push(...await listFilesRecursive(systemPath, homePath));
+          files.push(...(await listFilesRecursive(systemPath, homePath))
+            .filter((path) => !path.startsWith("system/projects/")));
         }
         files.push(...await listOwnedProjectFiles(homePath, request.ownerScope));
       } else if (request.scope === "project") {
         if (!request.projectSlug) {
           return { id: `export_${randomUUID()}`, createdAt, scope: request.scope, files };
         }
-        const projectPath = resolveWithinHome(homePath, `projects/${request.projectSlug}`);
-        if (!projectPath || !await pathExists(projectPath)) {
-          return { id: `export_${randomUUID()}`, createdAt, scope: request.scope, files };
-        }
-        const owner = await readOwnerScope(join(projectPath, "config.json"));
-        if (!ownerMatches(owner, request.ownerScope)) {
-          return { id: `export_${randomUUID()}`, createdAt, scope: request.scope, files };
-        }
-        files.push(...await listFilesRecursive(projectPath, homePath));
+        files.push(...await listOwnedProjectFiles(homePath, request.ownerScope, request.projectSlug));
       }
 
       files.sort();
@@ -284,15 +313,19 @@ export function createStateOps(options: { homePath: string; now?: () => string }
           error: { code: "delete_scope_invalid", message: "Delete scope is invalid" },
         };
       }
-      const projectPath = resolveWithinHome(homePath, `projects/${request.projectSlug}`);
-      if (!projectPath) {
+      const registryPath = resolveWithinHome(homePath, `system/projects/${request.projectSlug}`);
+      const legacyProjectPath = resolveWithinHome(homePath, `projects/${request.projectSlug}`);
+      if (!registryPath || !legacyProjectPath) {
         return {
           ok: false,
           status: 400,
           error: { code: "delete_scope_invalid", message: "Delete scope is invalid" },
         };
       }
-      const owner = await readOwnerScope(join(projectPath, "config.json"));
+      const canonicalConfigPath = join(registryPath, "config.json");
+      const legacyConfigPath = join(legacyProjectPath, "config.json");
+      const configPath = await pathExists(canonicalConfigPath) ? canonicalConfigPath : legacyConfigPath;
+      const owner = await readOwnerScope(configPath);
       if (!ownerMatches(owner, request.ownerScope)) {
         return {
           ok: false,
@@ -300,7 +333,13 @@ export function createStateOps(options: { homePath: string; now?: () => string }
           error: { code: "not_found", message: "Workspace data was not found" },
         };
       }
-      await rm(projectPath, { recursive: true, force: true });
+      const config = await readJsonFile<Record<string, unknown>>(configPath);
+      if (config.kind !== "folder") {
+        await rm(legacyProjectPath, { recursive: true, force: true });
+      } else if (configPath === legacyConfigPath) {
+        await rm(legacyConfigPath, { force: true });
+      }
+      await rm(registryPath, { recursive: true, force: true });
       return { ok: true };
     },
   };

--- a/packages/gateway/src/state-ops.ts
+++ b/packages/gateway/src/state-ops.ts
@@ -1,8 +1,15 @@
 import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
 import { access, link, mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { dirname, join, relative, resolve, sep } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { resolveWithinHome } from "./path-security.js";
+import { isMatrixManagedProjectSource } from "./project-registry-layout.js";
+import type { ProjectRegistry } from "./project-registry.js";
+import {
+  listValidatedLegacyProjectStateFiles,
+  removeValidatedLegacyProjectState,
+} from "./legacy-project-state.js";
+import { projectStateRecoveryDir } from "./bounded-json-file.js";
 
 export type OwnerScope = { type: "user" | "org"; id: string };
 
@@ -43,12 +50,15 @@ const PROJECT_SLUG_REGEX = /^[a-z0-9][a-z0-9-]{0,62}$/;
 
 const projectLocks = new Map<string, Promise<unknown>>();
 
-function nowIso(now?: () => string): string {
-  return now ? now() : new Date().toISOString();
+export class ProjectLockCapacityError extends Error {
+  constructor() {
+    super("Project operation capacity reached");
+    this.name = "ProjectLockCapacityError";
+  }
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+function nowIso(now?: () => string): string {
+  return now ? now() : new Date().toISOString();
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -118,75 +128,43 @@ async function listOwnedProjectFiles(
   ownerScope?: OwnerScope,
   projectSlug?: string,
 ): Promise<string[]> {
-  const registryRoot = join(homePath, "system", "projects");
+  const registry = await getProjectRegistry(homePath);
   const projectsRoot = join(homePath, "projects");
   const slugs = projectSlug && PROJECT_SLUG_REGEX.test(projectSlug)
     ? new Set([projectSlug])
-    : new Set<string>();
-  if (!projectSlug) {
-    for (const root of [registryRoot, projectsRoot]) {
-      try {
-        const entries = await readdir(root, { withFileTypes: true });
-        for (const entry of entries) {
-          if (entry.isDirectory() && !entry.isSymbolicLink() && PROJECT_SLUG_REGEX.test(entry.name)) {
-            slugs.add(entry.name);
-          }
-        }
-      } catch (err: unknown) {
-        if (!(err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT")) {
-          throw err;
-        }
-      }
-    }
-  }
+    : new Set([
+        ...await registry.listSlugs(),
+        ...await registry.listTombstoneSlugs(),
+      ]);
 
   const files: string[] = [];
   for (const slug of slugs) {
-    const canonicalDir = join(registryRoot, slug);
-    const canonicalConfigPath = join(canonicalDir, "config.json");
-    const legacyConfigPath = join(projectsRoot, slug, "config.json");
-    const configPath = await pathExists(canonicalConfigPath) ? canonicalConfigPath : legacyConfigPath;
-    const owner = await readOwnerScope(configPath);
-    if (!ownerMatches(owner, ownerScope)) continue;
+    const config = await registry.readConfig(slug);
+    const tombstone = await registry.readTombstone(slug);
+    const configOwned = config && ownerMatches(config.ownerScope, ownerScope);
+    const tombstoneOwned = tombstone && ownerMatches(tombstone.ownerScope, ownerScope);
+    if (!configOwned && !tombstoneOwned) continue;
 
-    if (await pathExists(canonicalDir)) {
+    const canonicalDir = registry.recordDir(slug);
+    if (configOwned && await pathExists(canonicalDir)) {
       files.push(...await listFilesRecursive(canonicalDir, homePath));
-    } else if (await pathExists(legacyConfigPath)) {
-      files.push(relative(homePath, legacyConfigPath));
     }
 
-    for (const tombstonePath of [
-      join(registryRoot, ".deleting", `${slug}.json`),
-      join(projectsRoot, ".deleting", `${slug}.json`),
-    ]) {
-      if (await pathExists(tombstonePath)
-        && ownerMatches(await readOwnerScope(tombstonePath), ownerScope)) {
-        files.push(relative(homePath, tombstonePath));
-      }
+    const canonicalTombstonePath = registry.tombstonePath(slug);
+    if (tombstoneOwned && await pathExists(canonicalTombstonePath)) {
+      files.push(relative(homePath, canonicalTombstonePath));
     }
 
-    let config: Record<string, unknown> | null = null;
-    try {
-      const value = await readJsonFile(configPath);
-      config = isRecord(value) ? value : null;
-    } catch (err: unknown) {
-      if (!(err instanceof SyntaxError)) throw err;
+    if (!configOwned) continue;
+
+    for (const legacyStatePath of await listValidatedLegacyProjectStateFiles({
+      projectSlug: slug,
+      tasksDir: registry.legacyTasksDir(slug),
+      previewsDir: registry.legacyPreviewsDir(slug),
+    })) {
+      files.push(relative(homePath, legacyStatePath));
     }
-    const localPath = typeof config?.localPath === "string" ? resolve(config.localPath) : null;
-    if (!localPath) continue;
-    const legacyProjectRoot = join(projectsRoot, slug);
-    const legacyManaged = config?.kind === "scratch"
-      || config?.kind === "github"
-      || (config?.kind === undefined
-        && (localPath === legacyProjectRoot || localPath.startsWith(`${legacyProjectRoot}${sep}`)));
-    if (legacyManaged) {
-      for (const stateName of ["tasks", "previews"]) {
-        const legacyStateDir = join(legacyProjectRoot, stateName);
-        if (await pathExists(legacyStateDir)) {
-          files.push(...await listFilesRecursive(legacyStateDir, homePath));
-        }
-      }
-    }
+    const localPath = resolve(config.localPath);
     const resolvedHome = resolve(homePath);
     const rel = relative(resolvedHome, localPath);
     if (rel.startsWith("..") || rel === "" || resolve(rel) === rel || !await pathExists(localPath)) continue;
@@ -195,27 +173,12 @@ async function listOwnedProjectFiles(
   return [...new Set(files)];
 }
 
-async function readOwnerScope(configPath: string): Promise<OwnerScope | null> {
-  try {
-    const config = await readJsonFile(configPath);
-    if (
-      isRecord(config) &&
-      isRecord(config.ownerScope) &&
-      (config.ownerScope.type === "user" || config.ownerScope.type === "org") &&
-      typeof config.ownerScope.id === "string"
-    ) {
-      return { type: config.ownerScope.type, id: config.ownerScope.id };
-    }
-  } catch (err: unknown) {
-    if (err instanceof SyntaxError) {
-      return null;
-    }
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
-    }
-    throw err;
-  }
-  return null;
+async function getProjectRegistry(homePath: string): Promise<ProjectRegistry> {
+  // project-registry owns validation and compatibility adoption, while it
+  // imports the atomic JSON primitives above. Resolve it lazily to avoid a
+  // runtime module cycle without duplicating the project-record schema here.
+  const { createProjectRegistry } = await import("./project-registry.js");
+  return createProjectRegistry({ homePath });
 }
 
 function ownerMatches(actual: OwnerScope | null, expected?: OwnerScope): boolean {
@@ -223,20 +186,17 @@ function ownerMatches(actual: OwnerScope | null, expected?: OwnerScope): boolean
   return actual?.type === expected.type && actual.id === expected.id;
 }
 
-function evictOldestLockIfNeeded(): void {
-  if (projectLocks.size < MAX_LOCKS) return;
-  const oldest = projectLocks.keys().next().value as string | undefined;
-  if (oldest) projectLocks.delete(oldest);
-}
-
 export async function withProjectLock<T>(projectSlug: string, callback: () => Promise<T>): Promise<T> {
-  const previous = projectLocks.get(projectSlug) ?? Promise.resolve();
+  const existing = projectLocks.get(projectSlug);
+  if (!existing && projectLocks.size >= MAX_LOCKS) {
+    throw new ProjectLockCapacityError();
+  }
+  const previous = existing ?? Promise.resolve();
   let release!: () => void;
   const current = new Promise<void>((resolveRelease) => {
     release = resolveRelease;
   });
   const chained = previous.then(() => current);
-  evictOldestLockIfNeeded();
   projectLocks.set(projectSlug, chained);
 
   try {
@@ -336,36 +296,42 @@ export function createStateOps(options: { homePath: string; now?: () => string }
           error: { code: "delete_scope_invalid", message: "Delete scope is invalid" },
         };
       }
-      const registryPath = resolveWithinHome(homePath, `system/projects/${request.projectSlug}`);
-      const legacyProjectPath = resolveWithinHome(homePath, `projects/${request.projectSlug}`);
-      if (!registryPath || !legacyProjectPath) {
-        return {
-          ok: false,
-          status: 400,
-          error: { code: "delete_scope_invalid", message: "Delete scope is invalid" },
-        };
-      }
-      const canonicalConfigPath = join(registryPath, "config.json");
-      const legacyConfigPath = join(legacyProjectPath, "config.json");
-      const configPath = await pathExists(canonicalConfigPath) ? canonicalConfigPath : legacyConfigPath;
-      const owner = await readOwnerScope(configPath);
-      if (!ownerMatches(owner, request.ownerScope)) {
-        return {
-          ok: false,
-          status: 404,
-          error: { code: "not_found", message: "Workspace data was not found" },
-        };
-      }
-      const config = await readJsonFile<Record<string, unknown>>(configPath);
-      if (config.kind === "scratch" || config.kind === "github") {
-        await rm(legacyProjectPath, { recursive: true, force: true });
-      } else if (configPath === legacyConfigPath) {
-        // Missing kind is legacy ambiguous state. Prefer leaving owner source
-        // behind over guessing that the whole directory is Matrix-managed.
-        await rm(legacyConfigPath, { force: true });
-      }
-      await rm(registryPath, { recursive: true, force: true });
-      return { ok: true };
+      return await withProjectLock(request.projectSlug, async () => {
+        const registry = await getProjectRegistry(homePath);
+        const config = await registry.readConfig(request.projectSlug);
+        const tombstone = await registry.readTombstone(request.projectSlug);
+        if (
+          (!config && !tombstone)
+          || (config && !ownerMatches(config.ownerScope, request.ownerScope))
+          || (tombstone && !ownerMatches(tombstone.ownerScope, request.ownerScope))
+        ) {
+          return {
+            ok: false as const,
+            status: 404,
+            error: { code: "not_found", message: "Workspace data was not found" },
+          };
+        }
+        const legacyProjectPath = resolveWithinHome(homePath, `projects/${request.projectSlug}`);
+        if (!legacyProjectPath) {
+          return {
+            ok: false as const,
+            status: 400,
+            error: { code: "delete_scope_invalid", message: "Delete scope is invalid" },
+          };
+        }
+        if (config && isMatrixManagedProjectSource(homePath, config)) {
+          await rm(legacyProjectPath, { recursive: true, force: true });
+        }
+        await removeValidatedLegacyProjectState({
+          projectSlug: request.projectSlug,
+          tasksDir: registry.legacyTasksDir(request.projectSlug),
+          previewsDir: registry.legacyPreviewsDir(request.projectSlug),
+          recoveryDir: projectStateRecoveryDir(homePath),
+        });
+        await registry.removeConfig(request.projectSlug);
+        await registry.removeTombstone(request.projectSlug, tombstone ?? config!);
+        return { ok: true as const };
+      });
     },
   };
 }

--- a/packages/gateway/src/task-manager.ts
+++ b/packages/gateway/src/task-manager.ts
@@ -1,10 +1,15 @@
 import { randomUUID } from "node:crypto";
-import { readdir, rm } from "node:fs/promises";
+import { opendir, rm } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { z } from "zod/v4";
 import { PROJECT_SLUG_REGEX, type WorkspaceError } from "./project-manager.js";
 import { atomicCreateJson, atomicWriteJson, readJsonFile, type OwnerScope } from "./state-ops.js";
 import { createProjectRegistry } from "./project-registry.js";
+import {
+  projectStateRecoveryDir,
+  readBoundedJsonFileWithIdentity,
+  removeFileIfUnchanged,
+} from "./bounded-json-file.js";
 
 export type TaskStatus = "todo" | "running" | "waiting" | "blocked" | "complete" | "archived";
 export type TaskPriority = "low" | "normal" | "high" | "urgent";
@@ -40,6 +45,8 @@ const ProjectSlugSchema = z.string().regex(PROJECT_SLUG_REGEX);
 const SessionIdSchema = z.string().regex(/^sess_[A-Za-z0-9_-]{1,128}$/);
 const WorktreeIdSchema = z.string().regex(/^wt_[A-Za-z0-9_-]{1,128}$/);
 const PreviewIdSchema = z.string().regex(/^prev_[A-Za-z0-9_-]{1,128}$/);
+const MAX_LEGACY_TASK_RECORD_BYTES = 256 * 1024;
+const MAX_TASK_DISCOVERY_IDS = 512;
 
 const CreateTaskSchema = z.object({
   title: z.string().trim().min(1).max(200),
@@ -143,15 +150,33 @@ async function readTask(homePath: string, projectSlug: string, taskId: string): 
   return null;
 }
 
-async function listTaskRecords(homePath: string, projectSlug: string): Promise<TaskRecord[]> {
+async function removeValidatedLegacyTask(
+  homePath: string,
+  projectSlug: string,
+  taskId: string,
+): Promise<void> {
+  const path = legacyTaskPath(homePath, projectSlug, taskId);
+  const candidate = await readBoundedJsonFileWithIdentity(path, MAX_LEGACY_TASK_RECORD_BYTES);
+  if (!candidate) return;
+  const parsed = TaskRecordSchema.safeParse(candidate.value);
+  if (!parsed.success || parsed.data.projectSlug !== projectSlug || parsed.data.id !== taskId) return;
+  await removeFileIfUnchanged(path, candidate.identity, {
+    recoveryDir: projectStateRecoveryDir(homePath),
+  });
+}
+
+async function listTaskRecords(homePath: string, projectSlug: string): Promise<TaskRecord[] | null> {
   const ids = new Set<string>();
   for (const root of [tasksDir(homePath, projectSlug), createProjectRegistry({ homePath }).legacyTasksDir(projectSlug)]) {
+    let directory: Awaited<ReturnType<typeof opendir>>;
     try {
-      const entries = await readdir(root, { withFileTypes: true });
-      for (const entry of entries) {
+      directory = await opendir(root);
+      for await (const entry of directory) {
         if (!entry.isFile() || entry.isSymbolicLink() || !entry.name.endsWith(".json")) continue;
         const taskId = entry.name.slice(0, -".json".length);
-        if (TaskIdSchema.safeParse(taskId).success) ids.add(taskId);
+        if (!TaskIdSchema.safeParse(taskId).success || ids.has(taskId)) continue;
+        if (ids.size >= MAX_TASK_DISCOVERY_IDS) return null;
+        ids.add(taskId);
       }
     } catch (err: unknown) {
       if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") continue;
@@ -214,7 +239,9 @@ export function createTaskManager(options: { homePath: string; now?: () => strin
       if (!parsed.success) return failure(400, "invalid_task_query", "Task query is invalid");
 
       const query = parsed.data;
-      const allTasks = (await listTaskRecords(homePath, projectSlug))
+      const records = await listTaskRecords(homePath, projectSlug);
+      if (!records) return failure(409, "task_limit_exceeded", "Task limit exceeded");
+      const allTasks = records
         .filter((task) => query.includeArchived || task.status !== "archived")
         .sort((a, b) => a.order - b.order || a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
       const startIndex = query.cursor ? allTasks.findIndex((task) => task.id === query.cursor) + 1 : 0;
@@ -258,10 +285,8 @@ export function createTaskManager(options: { homePath: string; now?: () => strin
       if (!await readTask(homePath, projectSlug, taskId)) {
         return failure(404, "not_found", "Task was not found");
       }
-      await Promise.all([
-        rm(taskPath(homePath, projectSlug, taskId), { force: true }),
-        rm(legacyTaskPath(homePath, projectSlug, taskId), { force: true }),
-      ]);
+      await rm(taskPath(homePath, projectSlug, taskId), { force: true });
+      await removeValidatedLegacyTask(homePath, projectSlug, taskId);
       return { ok: true };
     },
   };

--- a/packages/gateway/src/task-manager.ts
+++ b/packages/gateway/src/task-manager.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path";
 import { z } from "zod/v4";
 import { PROJECT_SLUG_REGEX, type WorkspaceError } from "./project-manager.js";
 import { atomicWriteJson, readJsonFile } from "./state-ops.js";
+import { createProjectRegistry } from "./project-registry.js";
 
 export type TaskStatus = "todo" | "running" | "waiting" | "blocked" | "complete" | "archived";
 export type TaskPriority = "low" | "normal" | "high" | "urgent";
@@ -85,15 +86,11 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 function tasksDir(homePath: string, projectSlug: string): string {
-  return join(homePath, "projects", projectSlug, "tasks");
+  return createProjectRegistry({ homePath }).tasksDir(projectSlug);
 }
 
 function taskPath(homePath: string, projectSlug: string, taskId: string): string {
   return join(tasksDir(homePath, projectSlug), `${taskId}.json`);
-}
-
-function projectConfigPath(homePath: string, projectSlug: string): string {
-  return join(homePath, "projects", projectSlug, "config.json");
 }
 
 function validateProjectSlug(projectSlug: string): Failure | null {
@@ -103,7 +100,7 @@ function validateProjectSlug(projectSlug: string): Failure | null {
 }
 
 async function requireProject(homePath: string, projectSlug: string): Promise<Failure | null> {
-  return await pathExists(projectConfigPath(homePath, projectSlug))
+  return await createProjectRegistry({ homePath }).readConfig(projectSlug)
     ? null
     : failure(404, "not_found", "Project was not found");
 }

--- a/packages/gateway/src/task-manager.ts
+++ b/packages/gateway/src/task-manager.ts
@@ -1,10 +1,9 @@
 import { randomUUID } from "node:crypto";
-import { constants } from "node:fs";
-import { access, readdir, rm } from "node:fs/promises";
+import { readdir, rm } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { z } from "zod/v4";
 import { PROJECT_SLUG_REGEX, type WorkspaceError } from "./project-manager.js";
-import { atomicWriteJson, readJsonFile } from "./state-ops.js";
+import { atomicCreateJson, atomicWriteJson, readJsonFile, type OwnerScope } from "./state-ops.js";
 import { createProjectRegistry } from "./project-registry.js";
 
 export type TaskStatus = "todo" | "running" | "waiting" | "blocked" | "complete" | "archived";
@@ -59,6 +58,24 @@ const UpdateTaskSchema = CreateTaskSchema.partial().extend({
   status: z.enum(["todo", "running", "waiting", "blocked", "complete", "archived"]).optional(),
 });
 
+const TaskRecordSchema = z.object({
+  id: TaskIdSchema,
+  projectSlug: ProjectSlugSchema,
+  title: z.string().min(1).max(200),
+  description: z.string().max(10_000).optional(),
+  status: z.enum(["todo", "running", "waiting", "blocked", "complete", "archived"]),
+  priority: z.enum(["low", "normal", "high", "urgent"]),
+  order: z.number().finite(),
+  parentTaskId: TaskIdSchema.optional(),
+  dueAt: z.string().min(1).max(64).optional(),
+  linkedSessionId: SessionIdSchema.optional(),
+  linkedWorktreeId: WorktreeIdSchema.optional(),
+  previewIds: z.array(PreviewIdSchema).max(20),
+  createdAt: z.string().min(1).max(64),
+  updatedAt: z.string().min(1).max(64),
+  archivedAt: z.string().max(64).optional(),
+});
+
 const ListTasksSchema = z.object({
   includeArchived: z.boolean().default(false),
   limit: z.number().int().min(1).max(100).default(100),
@@ -73,18 +90,6 @@ function failure(status: number, code: string, message: string): Failure {
   return { ok: false, status, error: { code, message } };
 }
 
-async function pathExists(path: string): Promise<boolean> {
-  try {
-    await access(path, constants.F_OK);
-    return true;
-  } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      return false;
-    }
-    throw err;
-  }
-}
-
 function tasksDir(homePath: string, projectSlug: string): string {
   return createProjectRegistry({ homePath }).tasksDir(projectSlug);
 }
@@ -93,14 +98,20 @@ function taskPath(homePath: string, projectSlug: string, taskId: string): string
   return join(tasksDir(homePath, projectSlug), `${taskId}.json`);
 }
 
+function legacyTaskPath(homePath: string, projectSlug: string, taskId: string): string {
+  return join(createProjectRegistry({ homePath }).legacyTasksDir(projectSlug), `${taskId}.json`);
+}
+
 function validateProjectSlug(projectSlug: string): Failure | null {
   return ProjectSlugSchema.safeParse(projectSlug).success
     ? null
     : failure(400, "invalid_project_slug", "Project slug is invalid");
 }
 
-async function requireProject(homePath: string, projectSlug: string): Promise<Failure | null> {
-  return await createProjectRegistry({ homePath }).readConfig(projectSlug)
+async function requireProject(homePath: string, projectSlug: string, ownerScope?: OwnerScope): Promise<Failure | null> {
+  const project = await createProjectRegistry({ homePath }).readConfig(projectSlug);
+  return project && (!ownerScope
+    || (project.ownerScope.type === ownerScope.type && project.ownerScope.id === ownerScope.id))
     ? null
     : failure(404, "not_found", "Project was not found");
 }
@@ -112,32 +123,44 @@ function validateTaskId(taskId: string): Failure | null {
 }
 
 async function readTask(homePath: string, projectSlug: string, taskId: string): Promise<TaskRecord | null> {
-  try {
-    return await readJsonFile<TaskRecord>(taskPath(homePath, projectSlug, taskId));
-  } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
+  for (const path of [
+    taskPath(homePath, projectSlug, taskId),
+    legacyTaskPath(homePath, projectSlug, taskId),
+  ]) {
+    try {
+      const parsed = TaskRecordSchema.safeParse(await readJsonFile(path));
+      if (!parsed.success || parsed.data.projectSlug !== projectSlug || parsed.data.id !== taskId) continue;
+      if (path === legacyTaskPath(homePath, projectSlug, taskId)) {
+        await atomicCreateJson(taskPath(homePath, projectSlug, taskId), parsed.data);
+      }
+      return parsed.data;
+    } catch (err: unknown) {
+      if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") continue;
+      if (err instanceof SyntaxError) continue;
+      throw err;
     }
-    throw err;
   }
+  return null;
 }
 
 async function listTaskRecords(homePath: string, projectSlug: string): Promise<TaskRecord[]> {
-  let entries;
-  try {
-    entries = await readdir(tasksDir(homePath, projectSlug), { withFileTypes: true });
-  } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      return [];
+  const ids = new Set<string>();
+  for (const root of [tasksDir(homePath, projectSlug), createProjectRegistry({ homePath }).legacyTasksDir(projectSlug)]) {
+    try {
+      const entries = await readdir(root, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isFile() || entry.isSymbolicLink() || !entry.name.endsWith(".json")) continue;
+        const taskId = entry.name.slice(0, -".json".length);
+        if (TaskIdSchema.safeParse(taskId).success) ids.add(taskId);
+      }
+    } catch (err: unknown) {
+      if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw err;
     }
-    throw err;
   }
 
   const tasks: TaskRecord[] = [];
-  for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
-    const taskId = entry.name.slice(0, -".json".length);
-    if (!TaskIdSchema.safeParse(taskId).success) continue;
+  for (const taskId of ids) {
     const task = await readTask(homePath, projectSlug, taskId);
     if (task) tasks.push(task);
   }
@@ -148,10 +171,10 @@ export function createTaskManager(options: { homePath: string; now?: () => strin
   const homePath = resolve(options.homePath);
 
   return {
-    async createTask(projectSlug: string, input: unknown): Promise<Result<{ task: TaskRecord }> | Failure> {
+    async createTask(projectSlug: string, input: unknown, ownerScope?: OwnerScope): Promise<Result<{ task: TaskRecord }> | Failure> {
       const projectError = validateProjectSlug(projectSlug);
       if (projectError) return projectError;
-      const missingProject = await requireProject(homePath, projectSlug);
+      const missingProject = await requireProject(homePath, projectSlug, ownerScope);
       if (missingProject) return missingProject;
       const parsed = CreateTaskSchema.safeParse(input);
       if (!parsed.success) {
@@ -180,12 +203,12 @@ export function createTaskManager(options: { homePath: string; now?: () => strin
       return { ok: true, status: 201, task };
     },
 
-    async listTasks(projectSlug: string, input: unknown = {}): Promise<
+    async listTasks(projectSlug: string, input: unknown = {}, ownerScope?: OwnerScope): Promise<
       Result<{ tasks: TaskRecord[]; nextCursor: string | null }> | Failure
     > {
       const projectError = validateProjectSlug(projectSlug);
       if (projectError) return projectError;
-      const missingProject = await requireProject(homePath, projectSlug);
+      const missingProject = await requireProject(homePath, projectSlug, ownerScope);
       if (missingProject) return missingProject;
       const parsed = ListTasksSchema.safeParse(input);
       if (!parsed.success) return failure(400, "invalid_task_query", "Task query is invalid");
@@ -200,10 +223,10 @@ export function createTaskManager(options: { homePath: string; now?: () => strin
       return { ok: true, tasks: page, nextCursor };
     },
 
-    async updateTask(projectSlug: string, taskId: string, input: unknown): Promise<Result<{ task: TaskRecord }> | Failure> {
+    async updateTask(projectSlug: string, taskId: string, input: unknown, ownerScope?: OwnerScope): Promise<Result<{ task: TaskRecord }> | Failure> {
       const projectError = validateProjectSlug(projectSlug);
       if (projectError) return projectError;
-      const missingProject = await requireProject(homePath, projectSlug);
+      const missingProject = await requireProject(homePath, projectSlug, ownerScope);
       if (missingProject) return missingProject;
       const taskError = validateTaskId(taskId);
       if (taskError) return taskError;
@@ -225,16 +248,20 @@ export function createTaskManager(options: { homePath: string; now?: () => strin
       return { ok: true, task };
     },
 
-    async deleteTask(projectSlug: string, taskId: string): Promise<{ ok: true } | Failure> {
+    async deleteTask(projectSlug: string, taskId: string, ownerScope?: OwnerScope): Promise<{ ok: true } | Failure> {
       const projectError = validateProjectSlug(projectSlug);
       if (projectError) return projectError;
-      const missingProject = await requireProject(homePath, projectSlug);
+      const missingProject = await requireProject(homePath, projectSlug, ownerScope);
       if (missingProject) return missingProject;
       const taskError = validateTaskId(taskId);
       if (taskError) return taskError;
-      const path = taskPath(homePath, projectSlug, taskId);
-      if (!await pathExists(path)) return failure(404, "not_found", "Task was not found");
-      await rm(path, { force: true });
+      if (!await readTask(homePath, projectSlug, taskId)) {
+        return failure(404, "not_found", "Task was not found");
+      }
+      await Promise.all([
+        rm(taskPath(homePath, projectSlug, taskId), { force: true }),
+        rm(legacyTaskPath(homePath, projectSlug, taskId), { force: true }),
+      ]);
       return { ok: true };
     },
   };

--- a/packages/gateway/src/workspace-routes.ts
+++ b/packages/gateway/src/workspace-routes.ts
@@ -548,8 +548,11 @@ export function createWorkspaceRoutes(options: {
   app.post("/api/projects/:slug/worktrees", limited, async (c) => {
     const body = await parseJson(c, CreateWorktreeSchema);
     if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
     const result = await worktreeManager.createWorktree({
       projectSlug: c.req.param("slug"),
+      ownerScope,
       branch: body.value.branch,
       pr: body.value.pr,
     });
@@ -558,7 +561,9 @@ export function createWorkspaceRoutes(options: {
   });
 
   app.get("/api/projects/:slug/worktrees", async (c) => {
-    const result = await worktreeManager.listWorktrees(c.req.param("slug"));
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
+    const result = await worktreeManager.listWorktrees(c.req.param("slug"), ownerScope);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     return c.json({ worktrees: result.worktrees });
   });
@@ -570,10 +575,13 @@ export function createWorkspaceRoutes(options: {
       if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
       confirmDirtyDelete = body.value.confirmDirtyDelete;
     }
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
     const result = await worktreeManager.deleteWorktree({
       projectSlug: c.req.param("slug"),
       worktreeId: c.req.param("worktreeId"),
       confirmDirtyDelete,
+      ownerScope,
     });
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     return c.json({ ok: true });
@@ -583,19 +591,23 @@ export function createWorkspaceRoutes(options: {
     const body = await parseJson(c, CreateTaskSchema);
     if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
     const projectSlug = c.req.param("slug");
-    const result = await taskManager.createTask(projectSlug, body.value);
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
+    const result = await taskManager.createTask(projectSlug, body.value, ownerScope);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     await eventPublisher.publishTaskCreated(result.task);
     return c.json({ task: result.task }, status(result.status ?? 201));
   });
 
   app.get("/api/projects/:slug/tasks", async (c) => {
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
     const limitRaw = c.req.query("limit");
     const result = await taskManager.listTasks(c.req.param("slug"), {
       includeArchived: c.req.query("includeArchived") === "true",
       limit: limitRaw ? Number.parseInt(limitRaw, 10) : undefined,
       cursor: c.req.query("cursor"),
-    });
+    }, ownerScope);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     return c.json({ tasks: result.tasks, nextCursor: result.nextCursor });
   });
@@ -604,7 +616,9 @@ export function createWorkspaceRoutes(options: {
     const body = await parseJson(c, UpdateTaskSchema);
     if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
     const projectSlug = c.req.param("slug");
-    const result = await taskManager.updateTask(projectSlug, c.req.param("taskId"), body.value);
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
+    const result = await taskManager.updateTask(projectSlug, c.req.param("taskId"), body.value, ownerScope);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     await eventPublisher.publishTaskUpdated(result.task);
     return c.json({ task: result.task });
@@ -615,7 +629,9 @@ export function createWorkspaceRoutes(options: {
     if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
     const projectSlug = c.req.param("slug");
     const taskId = c.req.param("taskId");
-    const result = await taskManager.deleteTask(projectSlug, taskId);
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
+    const result = await taskManager.deleteTask(projectSlug, taskId, ownerScope);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     await eventPublisher.publishTaskDeleted(projectSlug, taskId);
     return c.json({ ok: true });
@@ -625,20 +641,24 @@ export function createWorkspaceRoutes(options: {
     const body = await parseJson(c, CreatePreviewSchema);
     if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
     const projectSlug = c.req.param("slug");
-    const result = await previewManager.createPreview(projectSlug, body.value);
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
+    const result = await previewManager.createPreview(projectSlug, body.value, ownerScope);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     await eventPublisher.publishPreviewCreated(result.preview);
     return c.json({ preview: result.preview }, status(result.status ?? 201));
   });
 
   app.get("/api/projects/:slug/previews", async (c) => {
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
     const limitRaw = c.req.query("limit");
     const result = await previewManager.listPreviews(c.req.param("slug"), {
       taskId: c.req.query("taskId"),
       sessionId: c.req.query("sessionId"),
       limit: limitRaw ? Number.parseInt(limitRaw, 10) : undefined,
       cursor: c.req.query("cursor"),
-    });
+    }, ownerScope);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     return c.json({ previews: result.previews, nextCursor: result.nextCursor });
   });
@@ -647,7 +667,9 @@ export function createWorkspaceRoutes(options: {
     const body = await parseJson(c, UpdatePreviewSchema);
     if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
     const projectSlug = c.req.param("slug");
-    const result = await previewManager.updatePreview(projectSlug, c.req.param("previewId"), body.value);
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
+    const result = await previewManager.updatePreview(projectSlug, c.req.param("previewId"), body.value, ownerScope);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     await eventPublisher.publishPreviewUpdated(result.preview);
     return c.json({ preview: result.preview });
@@ -658,7 +680,9 @@ export function createWorkspaceRoutes(options: {
     if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
     const projectSlug = c.req.param("slug");
     const previewId = c.req.param("previewId");
-    const result = await previewManager.deletePreview(projectSlug, previewId);
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
+    const result = await previewManager.deletePreview(projectSlug, previewId, ownerScope);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     await eventPublisher.publishPreviewDeleted(projectSlug, previewId);
     return c.json({ ok: true });

--- a/packages/gateway/src/workspace-routes.ts
+++ b/packages/gateway/src/workspace-routes.ts
@@ -457,7 +457,9 @@ export function createWorkspaceRoutes(options: {
   });
 
   app.get("/api/projects/:slug", async (c) => {
-    const result = await projectManager.getProject(c.req.param("slug"));
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
+    const result = await projectManager.getProject(c.req.param("slug"), ownerScope);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     return c.json({ project: result.project });
   });
@@ -499,13 +501,17 @@ export function createWorkspaceRoutes(options: {
   });
 
   app.get("/api/projects/:slug/prs", async (c) => {
-    const result = await projectManager.listPullRequests(c.req.param("slug"));
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
+    const result = await projectManager.listPullRequests(c.req.param("slug"), ownerScope);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     return c.json({ prs: result.prs, refreshedAt: result.refreshedAt });
   });
 
   app.get("/api/projects/:slug/branches", async (c) => {
-    const result = await projectManager.listBranches(c.req.param("slug"));
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
+    const result = await projectManager.listBranches(c.req.param("slug"), ownerScope);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     return c.json({ branches: result.branches, refreshedAt: result.refreshedAt });
   });
@@ -518,6 +524,10 @@ export function createWorkspaceRoutes(options: {
   app.get("/api/projects/:slug/commits", async (c) => {
     const query = ListCommitsQuerySchema.safeParse(c.req.query());
     if (!query.success) return c.json(errorBody("invalid_request", "Query parameters are invalid"), 400);
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
+    const project = await projectManager.getProject(c.req.param("slug"), ownerScope);
+    if (!project.ok) return c.json({ error: project.error }, status(project.status));
     const result = await gitLog.listCommits(c.req.param("slug"), {
       limit: query.data.limit,
       cursor: query.data.cursor,
@@ -537,6 +547,10 @@ export function createWorkspaceRoutes(options: {
     if (!sha.success || !query.success) {
       return c.json(errorBody("invalid_request", "Request parameters are invalid"), 400);
     }
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
+    const project = await projectManager.getProject(c.req.param("slug"), ownerScope);
+    if (!project.ok) return c.json({ error: project.error }, status(project.status));
     const result = await gitLog.getCommitDiff(c.req.param("slug"), sha.data, {
       maxFiles: query.data.maxFiles,
       maxLines: query.data.maxLines,
@@ -852,14 +866,18 @@ export function createWorkspaceRoutes(options: {
   app.post("/api/workspace/export", limited, async (c) => {
     const body = await parseJson(c, ExportWorkspaceSchema);
     if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
-    const manifest = await stateOps.exportWorkspace(body.value);
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
+    const manifest = await stateOps.exportWorkspace({ ...body.value, ownerScope });
     return c.json({ export: { id: manifest.id, status: "complete", files: manifest.files } }, 202);
   });
 
   app.delete("/api/workspace/data", limited, async (c) => {
     const body = await parseJson(c, DeleteWorkspaceSchema);
     if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
-    const result = await stateOps.deleteWorkspaceData(body.value);
+    let ownerScope: OwnerScope;
+    try { ownerScope = getOwnerScope(c); } catch (err: unknown) { return principalError(c, err); }
+    const result = await stateOps.deleteWorkspaceData({ ...body.value, ownerScope });
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     return c.json({ ok: true });
   });

--- a/packages/gateway/src/workspace-session-orchestrator.ts
+++ b/packages/gateway/src/workspace-session-orchestrator.ts
@@ -63,10 +63,11 @@ function failure(status: number, code: string, message: string): Failure {
 
 async function resolveRequestedWorktree(
   worktreeManager: WorktreeManager,
+  ownerScope: OwnerScope,
   projectSlug: string,
   worktreeId: string,
 ): Promise<{ ok: true; worktree: WorktreeRecord } | Failure> {
-  const listed = await worktreeManager.listWorktrees(projectSlug);
+  const listed = await worktreeManager.listWorktrees(projectSlug, ownerScope);
   if (!listed.ok) return listed;
   const worktree = listed.worktrees.find((entry) => entry.id === worktreeId);
   return worktree ? { ok: true, worktree } : failure(404, "not_found", "Worktree was not found");
@@ -80,7 +81,7 @@ async function resolveAgentWorkspaceRoot(
   worktreeId: string | undefined,
 ): Promise<{ ok: true; path: string; worktreeId?: string } | Failure> {
   if (worktreeId) {
-    const resolved = await resolveRequestedWorktree(worktreeManager, projectSlug, worktreeId);
+    const resolved = await resolveRequestedWorktree(worktreeManager, ownerScope, projectSlug, worktreeId);
     return resolved.ok
       ? { ok: true, path: resolved.worktree.path, worktreeId: resolved.worktree.id }
       : resolved;

--- a/packages/gateway/src/worktree-manager.ts
+++ b/packages/gateway/src/worktree-manager.ts
@@ -6,7 +6,7 @@ import { promisify } from "node:util";
 import { execFile } from "node:child_process";
 import { z } from "zod/v4";
 import { PROJECT_SLUG_REGEX, type ProjectConfig, type WorkspaceError } from "./project-manager.js";
-import { atomicCreateJson, atomicWriteJson, readJsonFile, withProjectLock } from "./state-ops.js";
+import { atomicCreateJson, atomicWriteJson, readJsonFile, withProjectLock, type OwnerScope } from "./state-ops.js";
 import { createProjectRegistry } from "./project-registry.js";
 
 export interface WorktreeRecord {
@@ -121,8 +121,33 @@ async function readProject(homePath: string, projectSlug: string): Promise<Proje
   return await createProjectRegistry({ homePath }).readConfig<ProjectConfig>(projectSlug);
 }
 
-function worktreePath(homePath: string, projectSlug: string, id: string): string {
-  return join(homePath, "projects", projectSlug, "worktrees", id);
+export function managedWorktreePath(homePath: string, projectSlug: string, id: string): string {
+  if (!SlugSchema.safeParse(projectSlug).success || !WorktreeIdSchema.safeParse(id).success) {
+    throw new Error("Invalid managed worktree identity");
+  }
+  return join(resolve(homePath), "worktrees", projectSlug, id);
+}
+
+function legacyWorktreePath(homePath: string, projectSlug: string, id: string): string {
+  return join(resolve(homePath), "projects", projectSlug, "worktrees", id);
+}
+
+export async function resolveWorktreeCheckoutPath(
+  homePath: string,
+  projectSlug: string,
+  id: string,
+): Promise<string | null> {
+  const candidates = [
+    managedWorktreePath(homePath, projectSlug, id),
+    legacyWorktreePath(homePath, projectSlug, id),
+  ];
+  for (const candidate of candidates) {
+    if (await pathExists(candidate)) return candidate;
+  }
+  // Preserve the pre-separation deterministic path for legacy callers and
+  // test doubles that resolve the filesystem later. New manager-created
+  // worktrees always materialize the canonical candidate first.
+  return candidates[1]!;
 }
 
 function worktreeRecordPath(homePath: string, projectSlug: string, id: string): string {
@@ -134,7 +159,7 @@ function worktreeLeasePath(homePath: string, projectSlug: string, id: string): s
 }
 
 function legacyWorktreeMetadataPath(homePath: string, projectSlug: string, id: string, name: string): string {
-  return join(worktreePath(homePath, projectSlug, id), ".matrix", name);
+  return join(legacyWorktreePath(homePath, projectSlug, id), ".matrix", name);
 }
 
 async function migrateLegacyMetadata<T extends { id: string }>(input: {
@@ -200,8 +225,20 @@ export function createWorktreeManager(options: {
   const runCommand = options.runCommand ?? defaultRunCommand;
 
   return {
+    async getWorktree(projectSlug: string, id: string): Promise<{ ok: true; worktree: WorktreeRecord } | Failure> {
+      if (!SlugSchema.safeParse(projectSlug).success || !WorktreeIdSchema.safeParse(id).success) {
+        return failure(400, "invalid_ref", "Worktree reference is invalid");
+      }
+      const project = await readProject(homePath, projectSlug);
+      const worktree = project ? await readWorktree(homePath, projectSlug, id) : null;
+      return worktree
+        ? { ok: true, worktree }
+        : failure(404, "not_found", "Worktree was not found");
+    },
+
     async createWorktree(input: {
       projectSlug: string;
+      ownerScope?: OwnerScope;
       branch?: string;
       createBranch?: boolean;
       baseRef?: string;
@@ -224,11 +261,14 @@ export function createWorktreeManager(options: {
       }
       return withProjectLock(input.projectSlug, async () => {
         const project = await readProject(homePath, input.projectSlug);
-        if (!project) return failure(404, "not_found", "Project was not found");
+        if (!project || (input.ownerScope
+          && (project.ownerScope.type !== input.ownerScope.type || project.ownerScope.id !== input.ownerScope.id))) {
+          return failure(404, "not_found", "Project was not found");
+        }
 
         const source = typeof input.pr === "number" ? `pull/${input.pr}/head` : input.branch!;
         const id = worktreeId(input.projectSlug, source);
-        const path = worktreePath(homePath, input.projectSlug, id);
+        const path = managedWorktreePath(homePath, input.projectSlug, id);
         const currentBranch = typeof input.pr === "number" ? `pr-${input.pr}` : input.branch!;
         const configuredBaseRef = input.baseRef ?? project.defaultBranch ?? "main";
         const baseRef = BranchSchema.safeParse(configuredBaseRef).success ? configuredBaseRef : "main";
@@ -279,9 +319,14 @@ export function createWorktreeManager(options: {
       });
     },
 
-    async listWorktrees(projectSlug: string): Promise<{ ok: true; worktrees: WorktreeRecord[] } | Failure> {
+    async listWorktrees(projectSlug: string, ownerScope?: OwnerScope): Promise<{ ok: true; worktrees: WorktreeRecord[] } | Failure> {
       if (!SlugSchema.safeParse(projectSlug).success) {
         return failure(400, "invalid_slug", "Project slug is invalid");
+      }
+      const project = await readProject(homePath, projectSlug);
+      if (!project || (ownerScope
+        && (project.ownerScope.type !== ownerScope.type || project.ownerScope.id !== ownerScope.id))) {
+        return failure(404, "not_found", "Project was not found");
       }
       const roots = [
         createProjectRegistry({ homePath }).worktreesDir(projectSlug),
@@ -395,17 +440,27 @@ export function createWorktreeManager(options: {
       projectSlug: string;
       worktreeId: string;
       confirmDirtyDelete?: boolean;
+      ownerScope?: OwnerScope;
     }): Promise<{ ok: true } | Failure> {
       if (!SlugSchema.safeParse(input.projectSlug).success || !WorktreeIdSchema.safeParse(input.worktreeId).success) {
         return failure(400, "invalid_ref", "Branch or PR reference is invalid");
       }
       return withProjectLock(input.projectSlug, async () => {
-        const path = worktreePath(homePath, input.projectSlug, input.worktreeId);
         const project = await readProject(homePath, input.projectSlug);
         const record = await readWorktree(homePath, input.projectSlug, input.worktreeId);
-        if (!project || !record || !await pathExists(path)) {
+        const allowedPaths = project ? new Set([
+          managedWorktreePath(homePath, input.projectSlug, input.worktreeId),
+          legacyWorktreePath(homePath, input.projectSlug, input.worktreeId),
+        ]) : new Set<string>();
+        if (!project
+          || (input.ownerScope
+            && (project.ownerScope.type !== input.ownerScope.type || project.ownerScope.id !== input.ownerScope.id))
+          || !record
+          || !allowedPaths.has(resolve(record.path))
+          || !await pathExists(record.path)) {
           return failure(404, "not_found", "Worktree was not found");
         }
+        const path = resolve(record.path);
         const lease = await readLease(homePath, input.projectSlug, input.worktreeId);
         if (lease) return failure(409, "worktree_locked", "Worktree is locked");
 

--- a/packages/gateway/src/worktree-manager.ts
+++ b/packages/gateway/src/worktree-manager.ts
@@ -1,12 +1,13 @@
 import { createHash, randomUUID } from "node:crypto";
 import { constants } from "node:fs";
-import { access, mkdir, readdir, rm, unlink, writeFile } from "node:fs/promises";
+import { access, lstat, mkdir, readdir, rm, unlink, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { execFile } from "node:child_process";
 import { z } from "zod/v4";
 import { PROJECT_SLUG_REGEX, type ProjectConfig, type WorkspaceError } from "./project-manager.js";
-import { atomicWriteJson, readJsonFile, withProjectLock } from "./state-ops.js";
+import { atomicCreateJson, atomicWriteJson, readJsonFile, withProjectLock } from "./state-ops.js";
+import { createProjectRegistry } from "./project-registry.js";
 
 export interface WorktreeRecord {
   id: string;
@@ -116,43 +117,76 @@ function worktreeId(projectSlug: string, source: string): string {
   return `wt_${createHash("sha256").update(`${projectSlug}:${source}`).digest("hex").slice(0, 16)}`;
 }
 
-function projectConfigPath(homePath: string, projectSlug: string): string {
-  return join(homePath, "projects", projectSlug, "config.json");
-}
-
 async function readProject(homePath: string, projectSlug: string): Promise<ProjectConfig | null> {
-  try {
-    return await readJsonFile<ProjectConfig>(projectConfigPath(homePath, projectSlug));
-  } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
-    }
-    throw err;
-  }
+  return await createProjectRegistry({ homePath }).readConfig<ProjectConfig>(projectSlug);
 }
 
 function worktreePath(homePath: string, projectSlug: string, id: string): string {
   return join(homePath, "projects", projectSlug, "worktrees", id);
 }
 
+function worktreeRecordPath(homePath: string, projectSlug: string, id: string): string {
+  return join(createProjectRegistry({ homePath }).worktreesDir(projectSlug), id, "worktree.json");
+}
+
+function worktreeLeasePath(homePath: string, projectSlug: string, id: string): string {
+  return join(createProjectRegistry({ homePath }).worktreesDir(projectSlug), id, "lease.json");
+}
+
+function legacyWorktreeMetadataPath(homePath: string, projectSlug: string, id: string, name: string): string {
+  return join(worktreePath(homePath, projectSlug, id), ".matrix", name);
+}
+
+async function migrateLegacyMetadata<T extends { id: string }>(input: {
+  legacyPath: string;
+  canonicalPath: string;
+  backupName: string;
+}): Promise<T | null> {
+  let stats;
+  try {
+    stats = await lstat(input.legacyPath);
+  } catch (err: unknown) {
+    if (isErrnoCode(err, "ENOENT")) return null;
+    throw err;
+  }
+  if (!stats.isFile() || stats.isSymbolicLink()) return null;
+
+  const legacy = await readJsonFile<T>(input.legacyPath);
+  const created = await atomicCreateJson(input.canonicalPath, legacy);
+  const canonical = created ? legacy : await readJsonFile<T>(input.canonicalPath);
+  if (canonical.id !== legacy.id) return canonical;
+
+  const backupPath = join(dirname(input.canonicalPath), input.backupName);
+  await atomicCreateJson(backupPath, legacy);
+  await unlink(input.legacyPath).catch((err: unknown) => {
+    if (!isErrnoCode(err, "ENOENT")) throw err;
+  });
+  return canonical;
+}
+
 async function readWorktree(homePath: string, projectSlug: string, id: string): Promise<WorktreeRecord | null> {
   try {
-    return await readJsonFile<WorktreeRecord>(join(worktreePath(homePath, projectSlug, id), ".matrix", "worktree.json"));
+    return await readJsonFile<WorktreeRecord>(worktreeRecordPath(homePath, projectSlug, id));
   } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
-    }
+    if (isErrnoCode(err, "ENOENT")) return await migrateLegacyMetadata<WorktreeRecord>({
+      legacyPath: legacyWorktreeMetadataPath(homePath, projectSlug, id, "worktree.json"),
+      canonicalPath: worktreeRecordPath(homePath, projectSlug, id),
+      backupName: "legacy-worktree.json",
+    });
     throw err;
   }
 }
 
-async function readLease(path: string): Promise<WorktreeLease | null> {
+async function readLease(homePath: string, projectSlug: string, id: string): Promise<WorktreeLease | null> {
+  const path = worktreeLeasePath(homePath, projectSlug, id);
   try {
     return await readJsonFile<WorktreeLease>(path);
   } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
-    }
+    if (isErrnoCode(err, "ENOENT")) return await migrateLegacyMetadata<WorktreeLease>({
+      legacyPath: legacyWorktreeMetadataPath(homePath, projectSlug, id, "lease.json"),
+      canonicalPath: path,
+      backupName: "legacy-lease.json",
+    });
     throw err;
   }
 }
@@ -240,7 +274,7 @@ export function createWorktreeManager(options: {
           dirtyState: "unknown",
           createdAt: timestamp,
         };
-        await atomicWriteJson(join(path, ".matrix", "worktree.json"), record);
+        await atomicWriteJson(worktreeRecordPath(homePath, input.projectSlug, id), record);
         return { ok: true, status: 201, worktree: record };
       });
     },
@@ -249,20 +283,24 @@ export function createWorktreeManager(options: {
       if (!SlugSchema.safeParse(projectSlug).success) {
         return failure(400, "invalid_slug", "Project slug is invalid");
       }
-      const root = join(homePath, "projects", projectSlug, "worktrees");
-      let entries;
-      try {
-        entries = await readdir(root, { withFileTypes: true });
-      } catch (err: unknown) {
-        if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-          return { ok: true, worktrees: [] };
+      const roots = [
+        createProjectRegistry({ homePath }).worktreesDir(projectSlug),
+        join(homePath, "projects", projectSlug, "worktrees"),
+      ];
+      const ids = new Set<string>();
+      for (const root of roots) {
+        try {
+          const entries = await readdir(root, { withFileTypes: true });
+          for (const entry of entries) {
+            if (entry.isDirectory() && !entry.isSymbolicLink()) ids.add(entry.name);
+          }
+        } catch (err: unknown) {
+          if (!isErrnoCode(err, "ENOENT")) throw err;
         }
-        throw err;
       }
       const worktrees: WorktreeRecord[] = [];
-      for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
-        const record = await readWorktree(homePath, projectSlug, entry.name);
+      for (const id of ids) {
+        const record = await readWorktree(homePath, projectSlug, id);
         if (record) worktrees.push(record);
       }
       return { ok: true, worktrees };
@@ -274,7 +312,7 @@ export function createWorktreeManager(options: {
       const leases: WorktreeLease[] = [];
       const timestamp = nowIso(options.now);
       for (const worktree of listed.worktrees) {
-        const lease = await readLease(join(worktree.path, ".matrix", "lease.json"));
+        const lease = await readLease(homePath, projectSlug, worktree.id);
         if (lease && !isLeaseStale(lease, timestamp)) leases.push(lease);
       }
       return { ok: true, leases };
@@ -290,9 +328,9 @@ export function createWorktreeManager(options: {
         return failure(400, "invalid_ref", "Branch or PR reference is invalid");
       }
       return withProjectLock(input.projectSlug, async () => {
-        const leasePath = join(worktreePath(homePath, input.projectSlug, input.worktreeId), ".matrix", "lease.json");
+        const leasePath = worktreeLeasePath(homePath, input.projectSlug, input.worktreeId);
         const timestamp = nowIso(options.now);
-        const existing = await readLease(leasePath);
+        const existing = await readLease(homePath, input.projectSlug, input.worktreeId);
         if (existing) {
           if (existing.holderId !== input.holderId && !isLeaseStale(existing, timestamp)) {
             return { ok: false, status: 409, holderId: existing.holderId };
@@ -324,7 +362,7 @@ export function createWorktreeManager(options: {
           return { ok: true, lease };
         } catch (err: unknown) {
           if (!isErrnoCode(err, "EEXIST")) throw err;
-          const winner = await readLease(leasePath);
+          const winner = await readLease(homePath, input.projectSlug, input.worktreeId);
           if (winner?.holderId === input.holderId) return { ok: true, lease: winner };
           return { ok: false, status: 409, holderId: winner?.holderId ?? "unknown" };
         }
@@ -340,8 +378,8 @@ export function createWorktreeManager(options: {
         return failure(400, "invalid_ref", "Branch or PR reference is invalid");
       }
       return withProjectLock(input.projectSlug, async () => {
-        const leasePath = join(worktreePath(homePath, input.projectSlug, input.worktreeId), ".matrix", "lease.json");
-        const existing = await readLease(leasePath);
+        const leasePath = worktreeLeasePath(homePath, input.projectSlug, input.worktreeId);
+        const existing = await readLease(homePath, input.projectSlug, input.worktreeId);
         if (existing && existing.holderId !== input.holderId) {
           return failure(409, "worktree_locked", "Worktree is locked");
         }
@@ -363,8 +401,12 @@ export function createWorktreeManager(options: {
       }
       return withProjectLock(input.projectSlug, async () => {
         const path = worktreePath(homePath, input.projectSlug, input.worktreeId);
-        if (!await pathExists(path)) return failure(404, "not_found", "Worktree was not found");
-        const lease = await readLease(join(path, ".matrix", "lease.json"));
+        const project = await readProject(homePath, input.projectSlug);
+        const record = await readWorktree(homePath, input.projectSlug, input.worktreeId);
+        if (!project || !record || !await pathExists(path)) {
+          return failure(404, "not_found", "Worktree was not found");
+        }
+        const lease = await readLease(homePath, input.projectSlug, input.worktreeId);
         if (lease) return failure(409, "worktree_locked", "Worktree is locked");
 
         let dirtyCount = 0;
@@ -386,7 +428,7 @@ export function createWorktreeManager(options: {
         }
         try {
           await runCommand("git", ["worktree", "remove", "--force", "--", path], {
-            cwd: join(homePath, "projects", input.projectSlug, "repo"),
+            cwd: project.localPath,
             timeout: DEFAULT_TIMEOUT_MS,
           });
           if (await pathExists(path)) await rm(path, { recursive: true, force: true });
@@ -394,6 +436,10 @@ export function createWorktreeManager(options: {
           if (err instanceof Error) console.warn("[worktree-manager] Failed to remove git worktree metadata:", err.message);
           await rm(path, { recursive: true, force: true });
         }
+        await rm(join(createProjectRegistry({ homePath }).worktreesDir(input.projectSlug), input.worktreeId), {
+          recursive: true,
+          force: true,
+        });
         return { ok: true };
       });
     },

--- a/packages/gateway/src/worktree-manager.ts
+++ b/packages/gateway/src/worktree-manager.ts
@@ -1,12 +1,17 @@
 import { createHash, randomUUID } from "node:crypto";
 import { constants } from "node:fs";
-import { access, lstat, mkdir, readdir, rm, unlink, writeFile } from "node:fs/promises";
+import { access, lstat, mkdir, readdir, rename, rm, unlink, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { execFile } from "node:child_process";
 import { z } from "zod/v4";
 import { PROJECT_SLUG_REGEX, type ProjectConfig, type WorkspaceError } from "./project-manager.js";
-import { atomicCreateJson, atomicWriteJson, readJsonFile, withProjectLock, type OwnerScope } from "./state-ops.js";
+import { atomicCreateJson, atomicWriteJson, withProjectLock, type OwnerScope } from "./state-ops.js";
+import {
+  projectStateRecoveryDir,
+  readBoundedJsonFileWithIdentity,
+  removeFileIfUnchanged,
+} from "./bounded-json-file.js";
 import { createProjectRegistry } from "./project-registry.js";
 
 export interface WorktreeRecord {
@@ -55,8 +60,41 @@ const BranchSchema = z.string()
   .refine((value) => !value.includes("..") && !value.endsWith("/") && !value.endsWith(".lock"));
 const SlugSchema = z.string().regex(PROJECT_SLUG_REGEX);
 const WorktreeIdSchema = z.string().regex(/^wt_[a-z0-9]{12,40}$/);
+const TimestampSchema = z.string()
+  .min(1)
+  .max(64)
+  .refine((value) => Number.isFinite(Date.parse(value)));
+const WorktreeRecordSchema = z.object({
+  id: WorktreeIdSchema,
+  projectSlug: SlugSchema,
+  path: z.string().min(1).max(4_096),
+  sourceBranch: BranchSchema,
+  currentBranch: BranchSchema,
+  pr: z.object({
+    number: z.number().int().positive().max(10_000_000),
+    title: z.string().max(500).optional(),
+    headRef: BranchSchema.optional(),
+    baseRef: BranchSchema.optional(),
+  }).optional(),
+  dirtyState: z.enum(["unknown", "clean", "dirty"]),
+  dirtyCount: z.number().int().nonnegative().max(1_000_000).optional(),
+  createdAt: TimestampSchema,
+  lastGitRefreshAt: TimestampSchema.optional(),
+});
+const WorktreeLeaseSchema = z.object({
+  id: z.string().regex(/^lease_[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i),
+  projectSlug: SlugSchema,
+  worktreeId: WorktreeIdSchema,
+  holderType: z.enum(["session", "review"]),
+  holderId: z.string().min(1).max(256),
+  mode: z.literal("write"),
+  acquiredAt: TimestampSchema,
+  heartbeatAt: TimestampSchema,
+  recoverableAfter: TimestampSchema.optional(),
+});
 const DEFAULT_TIMEOUT_MS = 10_000;
 const LEASE_TTL_MS = 30 * 60_000;
+const MAX_WORKTREE_RECORD_BYTES = 256 * 1024;
 
 const execFileAsync = promisify(execFile);
 
@@ -86,6 +124,16 @@ async function pathExists(path: string): Promise<boolean> {
     if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
       return false;
     }
+    throw err;
+  }
+}
+
+async function pathEntryExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (err: unknown) {
+    if (isErrnoCode(err, "ENOENT")) return false;
     throw err;
   }
 }
@@ -162,58 +210,128 @@ function legacyWorktreeMetadataPath(homePath: string, projectSlug: string, id: s
   return join(legacyWorktreePath(homePath, projectSlug, id), ".matrix", name);
 }
 
+function parseWorktreeRecord(
+  value: unknown,
+  homePath: string,
+  projectSlug: string,
+  id: string,
+): WorktreeRecord | null {
+  const parsed = WorktreeRecordSchema.safeParse(value);
+  if (!parsed.success || parsed.data.projectSlug !== projectSlug || parsed.data.id !== id) return null;
+  const recordPath = resolve(parsed.data.path);
+  const allowedPaths = [
+    managedWorktreePath(homePath, projectSlug, id),
+    legacyWorktreePath(homePath, projectSlug, id),
+  ];
+  return allowedPaths.includes(recordPath) ? parsed.data : null;
+}
+
+function parseWorktreeLease(
+  value: unknown,
+  projectSlug: string,
+  worktreeId: string,
+): WorktreeLease | null {
+  const parsed = WorktreeLeaseSchema.safeParse(value);
+  if (
+    !parsed.success
+    || parsed.data.projectSlug !== projectSlug
+    || parsed.data.worktreeId !== worktreeId
+  ) {
+    return null;
+  }
+  return parsed.data;
+}
+
 async function migrateLegacyMetadata<T extends { id: string }>(input: {
+  homePath: string;
   legacyPath: string;
   canonicalPath: string;
   backupName: string;
+  parse: (value: unknown) => T | null;
 }): Promise<T | null> {
-  let stats;
-  try {
-    stats = await lstat(input.legacyPath);
-  } catch (err: unknown) {
-    if (isErrnoCode(err, "ENOENT")) return null;
-    throw err;
-  }
-  if (!stats.isFile() || stats.isSymbolicLink()) return null;
-
-  const legacy = await readJsonFile<T>(input.legacyPath);
+  const legacyCandidate = await readBoundedJsonFileWithIdentity(
+    input.legacyPath,
+    MAX_WORKTREE_RECORD_BYTES,
+  );
+  if (!legacyCandidate) return null;
+  const legacy = input.parse(legacyCandidate.value);
+  if (!legacy) return null;
   const created = await atomicCreateJson(input.canonicalPath, legacy);
-  const canonical = created ? legacy : await readJsonFile<T>(input.canonicalPath);
+  const canonicalCandidate = created
+    ? { value: legacy }
+    : await readBoundedJsonFileWithIdentity(input.canonicalPath, MAX_WORKTREE_RECORD_BYTES);
+  const canonical = input.parse(canonicalCandidate?.value);
+  if (!canonical) return null;
   if (canonical.id !== legacy.id) return canonical;
 
   const backupPath = join(dirname(input.canonicalPath), input.backupName);
   await atomicCreateJson(backupPath, legacy);
-  await unlink(input.legacyPath).catch((err: unknown) => {
-    if (!isErrnoCode(err, "ENOENT")) throw err;
+  await removeFileIfUnchanged(input.legacyPath, legacyCandidate.identity, {
+    recoveryDir: projectStateRecoveryDir(input.homePath),
   });
   return canonical;
 }
 
 async function readWorktree(homePath: string, projectSlug: string, id: string): Promise<WorktreeRecord | null> {
-  try {
-    return await readJsonFile<WorktreeRecord>(worktreeRecordPath(homePath, projectSlug, id));
-  } catch (err: unknown) {
-    if (isErrnoCode(err, "ENOENT")) return await migrateLegacyMetadata<WorktreeRecord>({
-      legacyPath: legacyWorktreeMetadataPath(homePath, projectSlug, id, "worktree.json"),
-      canonicalPath: worktreeRecordPath(homePath, projectSlug, id),
-      backupName: "legacy-worktree.json",
-    });
-    throw err;
-  }
+  const canonicalPath = worktreeRecordPath(homePath, projectSlug, id);
+  const candidate = await readBoundedJsonFileWithIdentity(canonicalPath, MAX_WORKTREE_RECORD_BYTES);
+  if (candidate) return parseWorktreeRecord(candidate.value, homePath, projectSlug, id);
+  if (await pathEntryExists(canonicalPath)) return null;
+  return await migrateLegacyMetadata<WorktreeRecord>({
+    homePath,
+    legacyPath: legacyWorktreeMetadataPath(homePath, projectSlug, id, "worktree.json"),
+    canonicalPath,
+    backupName: "legacy-worktree.json",
+    parse: (value) => parseWorktreeRecord(value, homePath, projectSlug, id),
+  });
 }
 
 async function readLease(homePath: string, projectSlug: string, id: string): Promise<WorktreeLease | null> {
   const path = worktreeLeasePath(homePath, projectSlug, id);
+  const candidate = await readBoundedJsonFileWithIdentity(path, MAX_WORKTREE_RECORD_BYTES);
+  if (candidate) return parseWorktreeLease(candidate.value, projectSlug, id);
+  if (await pathEntryExists(path)) return null;
+  return await migrateLegacyMetadata<WorktreeLease>({
+    homePath,
+    legacyPath: legacyWorktreeMetadataPath(homePath, projectSlug, id, "lease.json"),
+    canonicalPath: path,
+    backupName: "legacy-lease.json",
+    parse: (value) => parseWorktreeLease(value, projectSlug, id),
+  });
+}
+
+async function recoverInvalidLeaseUnderLock(
+  homePath: string,
+  projectSlug: string,
+  id: string,
+): Promise<WorktreeLease | null> {
+  const path = worktreeLeasePath(homePath, projectSlug, id);
+  const quarantinePath = join(dirname(path), `.lease-${randomUUID()}.quarantine`);
   try {
-    return await readJsonFile<WorktreeLease>(path);
+    await rename(path, quarantinePath);
   } catch (err: unknown) {
-    if (isErrnoCode(err, "ENOENT")) return await migrateLegacyMetadata<WorktreeLease>({
-      legacyPath: legacyWorktreeMetadataPath(homePath, projectSlug, id, "lease.json"),
-      canonicalPath: path,
-      backupName: "legacy-lease.json",
-    });
+    if (isErrnoCode(err, "ENOENT")) return null;
     throw err;
   }
+
+  let quarantined: WorktreeLease | null = null;
+  const candidate = await readBoundedJsonFileWithIdentity(
+    quarantinePath,
+    MAX_WORKTREE_RECORD_BYTES,
+  );
+  if (candidate) quarantined = parseWorktreeLease(candidate.value, projectSlug, id);
+
+  if (!quarantined) {
+    await rm(quarantinePath, { force: true });
+    return null;
+  }
+
+  // A valid lease may have replaced the invalid pathname after the pure read.
+  // Restore it exclusively; if another process already published a winner,
+  // observe that winner instead of overwriting it.
+  const restored = await atomicCreateJson(path, quarantined);
+  await rm(quarantinePath, { force: true });
+  return restored ? quarantined : await readLease(homePath, projectSlug, id);
 }
 
 export function createWorktreeManager(options: {
@@ -274,6 +392,9 @@ export function createWorktreeManager(options: {
         const baseRef = BranchSchema.safeParse(configuredBaseRef).success ? configuredBaseRef : "main";
         const existing = await readWorktree(homePath, input.projectSlug, id);
         if (existing) return { ok: true, status: 200, worktree: existing };
+        if (await pathEntryExists(path)) {
+          return failure(409, "worktree_path_conflict", "Worktree checkout requires recovery");
+        }
 
         try {
           if (typeof input.pr === "number") {
@@ -300,7 +421,9 @@ export function createWorktreeManager(options: {
         } catch (err: unknown) {
           if (err instanceof Error) console.warn("[worktree-manager] Failed to add worktree:", err.message);
           else console.warn("[worktree-manager] Failed to add worktree:", err);
-          await rm(path, { recursive: true, force: true });
+          // Git may have left a recoverable checkout, or another actor may
+          // have created the deterministic path after our preflight. Never
+          // recursively delete an unproven path from this failure boundary.
           return failure(502, "checkout_failed", "Worktree checkout failed");
         }
         const timestamp = nowIso(options.now);
@@ -375,7 +498,10 @@ export function createWorktreeManager(options: {
       return withProjectLock(input.projectSlug, async () => {
         const leasePath = worktreeLeasePath(homePath, input.projectSlug, input.worktreeId);
         const timestamp = nowIso(options.now);
-        const existing = await readLease(homePath, input.projectSlug, input.worktreeId);
+        let existing = await readLease(homePath, input.projectSlug, input.worktreeId);
+        if (!existing && await pathEntryExists(leasePath)) {
+          existing = await recoverInvalidLeaseUnderLock(homePath, input.projectSlug, input.worktreeId);
+        }
         if (existing) {
           if (existing.holderId !== input.holderId && !isLeaseStale(existing, timestamp)) {
             return { ok: false, status: 409, holderId: existing.holderId };
@@ -424,7 +550,10 @@ export function createWorktreeManager(options: {
       }
       return withProjectLock(input.projectSlug, async () => {
         const leasePath = worktreeLeasePath(homePath, input.projectSlug, input.worktreeId);
-        const existing = await readLease(homePath, input.projectSlug, input.worktreeId);
+        let existing = await readLease(homePath, input.projectSlug, input.worktreeId);
+        if (!existing && await pathEntryExists(leasePath)) {
+          existing = await recoverInvalidLeaseUnderLock(homePath, input.projectSlug, input.worktreeId);
+        }
         if (existing && existing.holderId !== input.holderId) {
           return failure(409, "worktree_locked", "Worktree is locked");
         }
@@ -461,7 +590,10 @@ export function createWorktreeManager(options: {
           return failure(404, "not_found", "Worktree was not found");
         }
         const path = resolve(record.path);
-        const lease = await readLease(homePath, input.projectSlug, input.worktreeId);
+        let lease = await readLease(homePath, input.projectSlug, input.worktreeId);
+        if (!lease && await pathEntryExists(worktreeLeasePath(homePath, input.projectSlug, input.worktreeId))) {
+          lease = await recoverInvalidLeaseUnderLock(homePath, input.projectSlug, input.worktreeId);
+        }
         if (lease) return failure(409, "worktree_locked", "Worktree is locked");
 
         let dirtyCount = 0;

--- a/specs/114-project-registry-separation/spec.md
+++ b/specs/114-project-registry-separation/spec.md
@@ -22,6 +22,8 @@ cannot distinguish that owner folder from the registry.
   link to owner code wherever that code already lives.
 - Existing `~/projects/<slug>/config.json` homes remain readable and migrate
   idempotently without moving or deleting project code.
+- New Matrix-created Git worktrees live below `~/worktrees/<project-slug>`;
+  existing worktrees below `~/projects/<slug>/worktrees` remain readable.
 - Agent cwd and writable roots are derived only from the selected config's
   `localPath`; the registry and sibling workspaces are never exposed.
 
@@ -50,6 +52,9 @@ interface.
    config into the canonical registry as `legacy-config.json` for rollback.
 5. If records conflict, keep both, prefer canonical, and leave the legacy file
    untouched for operator recovery.
+6. Valid legacy task, preview, worktree, lease, and deletion-tombstone records
+   remain readable and are copied into canonical registry state lazily. Owner
+   files that do not match the bounded Matrix record schemas are untouched.
 
 Migration is lazy and retry-safe. No workspace directory or repository is
 moved. Existing managed checkouts at `~/projects/<slug>/repo` keep that path.
@@ -61,6 +66,9 @@ moved. Existing managed checkouts at `~/projects/<slug>/repo` keep that path.
 - A project may not select the canonical registry or an ancestor containing it.
 - Direct folders under `~/projects` are no longer rejected merely because of
   their location.
+- A canonical folder-project record does not turn its `localPath` into a
+  managed container; idempotent retries and unrelated same-slug folders remain
+  selectable.
 - Owner scope checks happen against the canonical/compatibility record before
   lifecycle, task, worktree, preview, export, or delete mutations.
 - No new HTTP route is introduced; existing workspace route authentication and
@@ -77,7 +85,19 @@ registry classification after the Gateway behavior is available.
 
 - Direct checkout: `~/projects/<folder>` connects and no `config.json` is
   written into the checkout.
+- Owner `config.json` files remain untouched even when they contain generic
+  `id` and `slug` fields; only a complete legacy Matrix project record is
+  eligible for adoption.
 - Legacy home: existing config is readable, adopted once, and backed up.
+- Legacy worktree metadata remains visible to existing terminal sessions while
+  it is lazily adopted into the canonical registry.
+- Legacy task, preview, and deletion-tombstone records remain readable and are
+  present in owner exports before or after lazy adoption.
+- New worktrees and coding-agent file/source-control/review reads use the
+  separated checkout root or the canonical project's `localPath`, while legacy
+  worktree paths remain a compatibility fallback.
+- Legacy project records without an explicit `kind` never authorize recursive
+  deletion of a potentially owner-controlled source directory.
 - Conflict/retry: canonical winner is stable and legacy data is not destroyed.
 - Existing managed checkout: `localPath` and project ID are unchanged.
 - Protected paths, symlink aliases, owner-scope mismatch, and sibling access

--- a/specs/114-project-registry-separation/spec.md
+++ b/specs/114-project-registry-separation/spec.md
@@ -1,0 +1,99 @@
+# MAT-340: Project registry separation
+
+**Status:** Implementing  
+**Linear:** MAT-340  
+**Decision source:** MAT-338 (Option 2)
+
+## Problem
+
+`~/projects` is presented as the user's developer workspace root, but the current
+Gateway also stores Matrix-owned `config.json`, deletion tombstones, task state,
+and worktree lease state below `~/projects/<slug>`. Desktop therefore has to
+reject a normal checkout cloned directly into `~/projects/<folder>` because it
+cannot distinguish that owner folder from the registry.
+
+## Required behavior
+
+- `~/projects/<folder>` is an ordinary owner-controlled workspace and can be
+  connected as a folder project.
+- Matrix-owned project records live below `~/system/projects/<slug>` and retain
+  the stable `ProjectConfig.id` inside the record.
+- `ProjectConfig.id` remains the durable identity and `localPath` remains the
+  link to owner code wherever that code already lives.
+- Existing `~/projects/<slug>/config.json` homes remain readable and migrate
+  idempotently without moving or deleting project code.
+- Agent cwd and writable roots are derived only from the selected config's
+  `localPath`; the registry and sibling workspaces are never exposed.
+
+## Registry module
+
+`project-registry.ts` is the deep module at the filesystem seam. Its interface
+owns:
+
+- canonical and legacy record paths;
+- canonical create/write/read/delete operations;
+- union discovery across canonical and legacy records;
+- idempotent legacy adoption and rollback backup placement;
+- canonical paths for tasks, worktree records, leases, and deletion tombstones.
+
+Callers do not reconstruct registry paths. Project code placement remains the
+responsibility of project/worktree managers and is not part of the registry
+interface.
+
+## Compatibility migration
+
+1. Read the canonical record first.
+2. If absent, read and validate the legacy record.
+3. Atomically create the canonical record. Concurrent adopters reconcile with
+   the winning canonical record.
+4. When the canonical and legacy project IDs match, atomically move the legacy
+   config into the canonical registry as `legacy-config.json` for rollback.
+5. If records conflict, keep both, prefer canonical, and leave the legacy file
+   untouched for operator recovery.
+
+Migration is lazy and retry-safe. No workspace directory or repository is
+moved. Existing managed checkouts at `~/projects/<slug>/repo` keep that path.
+
+## Security invariants
+
+- `~/system`, `~/agents`, top-level dot directories, and denied file-browser
+  paths remain invalid folder-project roots after symlink resolution.
+- A project may not select the canonical registry or an ancestor containing it.
+- Direct folders under `~/projects` are no longer rejected merely because of
+  their location.
+- Owner scope checks happen against the canonical/compatibility record before
+  lifecycle, task, worktree, preview, export, or delete mutations.
+- No new HTTP route is introduced; existing workspace route authentication and
+  body limits remain unchanged.
+
+## Wiring
+
+Gateway project, task, worktree, preview, lifecycle, session, git-context, and
+owner export/delete paths consume the registry module. Desktop consumes the
+existing Gateway project contract and removes its local `projects/<slug>`
+registry classification after the Gateway behavior is available.
+
+## Verification
+
+- Direct checkout: `~/projects/<folder>` connects and no `config.json` is
+  written into the checkout.
+- Legacy home: existing config is readable, adopted once, and backed up.
+- Conflict/retry: canonical winner is stable and legacy data is not destroyed.
+- Existing managed checkout: `localPath` and project ID are unchanged.
+- Protected paths, symlink aliases, owner-scope mismatch, and sibling access
+  remain rejected.
+- Focused Gateway/Desktop tests, typecheck, production Desktop build, and exact
+  packaged Electron validation pass before merge.
+
+## Rollback
+
+Code rollback can read `legacy-config.json` from the canonical record directory
+and restore it to the legacy location if that location has no config. Project
+code is never moved by this migration, so rollback does not touch owner files.
+
+## Explicit exclusions
+
+- Do not modify, merge, or depend on MAT-268.
+- No general Files CRUD changes.
+- No destructive one-way migration.
+- Public documentation is a separate `FinnaAI/matrix-os-site` PR deliverable.

--- a/tests/desktop/create-project-dialog.test.tsx
+++ b/tests/desktop/create-project-dialog.test.tsx
@@ -143,8 +143,7 @@ describe("CreateProjectDialog", () => {
     fireEvent.doubleClick(screen.getByRole("button", { name: "Open apps" }));
     await waitFor(() => expect(screen.getByRole("button", { name: "Open matrix-os" })).not.toBeNull());
     fireEvent.click(screen.getByRole("button", { name: "Open matrix-os" }));
-    fireEvent.click(screen.getByRole("button", { name: "Choose matrix-os" }));
-    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open Matrix OS" }));
 
     await waitFor(() => expect(selectProject).toHaveBeenCalledWith(expect.anything(), "matrix-os"));
     expect(createProject).not.toHaveBeenCalled();
@@ -156,7 +155,7 @@ describe("CreateProjectDialog", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("opens the existing project instead of connecting its Matrix-managed registry folder", async () => {
+  it("opens the existing project instead of reconnecting its legacy project container", async () => {
     const existingProject = {
       slug: "matrix-os",
       name: "Matrix OS",
@@ -187,7 +186,7 @@ describe("CreateProjectDialog", () => {
     await waitFor(() => expect(screen.getByRole("button", { name: "Open matrix-os" })).not.toBeNull());
     fireEvent.click(screen.getByRole("button", { name: "Open matrix-os" }));
 
-    expect(screen.getByText("This folder contains Matrix project data, not a workspace.")).toBeTruthy();
+    expect(screen.getByText("This folder is already connected to Matrix OS.")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Open Matrix OS" }));
 
     await waitFor(() => expect(selectProject).toHaveBeenCalledWith(expect.anything(), "matrix-os"));
@@ -200,7 +199,7 @@ describe("CreateProjectDialog", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("blocks Matrix registry metadata folders while keeping repo workspaces selectable", async () => {
+  it("connects an ordinary checkout directly under Projects", async () => {
     const get = vi.fn(async (requestPath: string) => {
       if (requestPath === "/api/files/list?path=") {
         return { entries: [{ name: "projects", type: "directory" }] };
@@ -208,18 +207,16 @@ describe("CreateProjectDialog", () => {
       if (requestPath === "/api/files/list?path=projects") {
         return { entries: [{ name: "unregistered", type: "directory" }] };
       }
-      if (requestPath === "/api/files/list?path=projects%2Funregistered") {
-        return {
-          entries: [
-            { name: "repo", type: "directory" },
-            { name: "worktrees", type: "directory" },
-          ],
-        };
-      }
       return { entries: [] };
     });
+    const createProject = vi.fn(async () => ({
+      slug: "unregistered",
+      name: "Unregistered",
+      localPath: "/home/matrix/home/projects/unregistered",
+      githubBacked: false,
+    }));
     useConnection.setState({ api: { post: vi.fn(), get, baseUrl: "https://gateway.test" } as never });
-    useBoard.setState({ projects: [] });
+    useBoard.setState({ projects: [], createProject, selectProject: vi.fn(async () => undefined) });
 
     render(<Tooltip.Provider><CreateProjectDialog open onClose={vi.fn()} /></Tooltip.Provider>);
     fireEvent.click(screen.getByRole("button", { name: /Existing folder/ }));
@@ -227,18 +224,16 @@ describe("CreateProjectDialog", () => {
     fireEvent.doubleClick(screen.getByRole("button", { name: "Open projects" }));
     const registryFolder = await screen.findByRole("button", { name: "Open unregistered" });
     fireEvent.click(registryFolder);
+    expect(screen.getByRole("button", { name: "Choose unregistered" }).hasAttribute("disabled")).toBe(false);
+    fireEvent.click(screen.getByRole("button", { name: "Choose unregistered" }));
+    fireEvent.change(screen.getByPlaceholderText("Project name"), { target: { value: "Unregistered" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
-    expect(screen.getByText("This folder is managed by Matrix and can't be used as a workspace.")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Choose unregistered" }).hasAttribute("disabled")).toBe(true);
-
-    fireEvent.doubleClick(registryFolder);
-    const worktrees = await screen.findByRole("button", { name: "Open worktrees" });
-    fireEvent.click(worktrees);
-    expect(screen.getByRole("button", { name: "Choose worktrees" }).hasAttribute("disabled")).toBe(true);
-
-    fireEvent.click(screen.getByRole("button", { name: "Open repo" }));
-    expect(screen.queryByText("This folder is managed by Matrix and can't be used as a workspace.")).toBeNull();
-    expect(screen.getByRole("button", { name: "Choose repo" }).hasAttribute("disabled")).toBe(false);
+    await waitFor(() => expect(createProject).toHaveBeenCalledWith(expect.anything(), {
+      name: "Unregistered",
+      mode: "folder",
+      path: "projects/unregistered",
+    }));
   });
 
   it("opens an existing project when its selected repo workspace has a different folder name", async () => {
@@ -276,9 +271,7 @@ describe("CreateProjectDialog", () => {
     fireEvent.doubleClick(registryFolder);
     const repo = await screen.findByRole("button", { name: "Open repo" });
     fireEvent.click(repo);
-    fireEvent.click(screen.getByRole("button", { name: "Choose repo" }));
-    expect(screen.getByPlaceholderText("Project name")).toHaveProperty("value", "repo");
-    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open Scratch Project" }));
 
     await waitFor(() => expect(selectProject).toHaveBeenCalledWith(expect.anything(), "scratch-project"));
     expect(createProject).not.toHaveBeenCalled();

--- a/tests/desktop/create-project-dialog.test.tsx
+++ b/tests/desktop/create-project-dialog.test.tsx
@@ -159,8 +159,9 @@ describe("CreateProjectDialog", () => {
     const existingProject = {
       slug: "matrix-os",
       name: "Matrix OS",
-      localPath: "/home/matrix/home/apps/matrix-os",
-      githubBacked: false,
+      kind: "github" as const,
+      localPath: "/home/matrix/home/projects/matrix-os/repo",
+      githubBacked: true,
     };
     const get = vi.fn(async (requestPath: string) => {
       if (requestPath === "/api/files/list?path=") {
@@ -197,6 +198,43 @@ describe("CreateProjectDialog", () => {
       title: "Matrix OS",
     });
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("allows an unrelated same-slug folder under Projects to be connected", async () => {
+    const existingProject = {
+      slug: "foo",
+      name: "Foo",
+      kind: "folder" as const,
+      localPath: "/home/matrix/home/workspaces/foo",
+      githubBacked: false,
+    };
+    const get = vi.fn(async (requestPath: string) => {
+      if (requestPath === "/api/files/list?path=") {
+        return { entries: [{ name: "projects", type: "directory" }] };
+      }
+      if (requestPath === "/api/files/list?path=projects") {
+        return { entries: [{ name: "foo", type: "directory" }] };
+      }
+      return { entries: [] };
+    });
+    const createProject = vi.fn(async () => ({
+      slug: "projects-foo",
+      name: "Projects Foo",
+      kind: "folder" as const,
+      localPath: "/home/matrix/home/projects/foo",
+      githubBacked: false,
+    }));
+    useConnection.setState({ api: { post: vi.fn(), get, baseUrl: "https://gateway.test" } as never });
+    useBoard.setState({ projects: [existingProject], createProject, selectProject: vi.fn(async () => undefined) });
+
+    render(<Tooltip.Provider><CreateProjectDialog open onClose={vi.fn()} /></Tooltip.Provider>);
+    fireEvent.click(screen.getByRole("button", { name: /Existing folder/ }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open projects" })).not.toBeNull());
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Open projects" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open foo" }));
+
+    expect(screen.queryByRole("button", { name: "Open Foo" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Choose foo" }).hasAttribute("disabled")).toBe(false);
   });
 
   it("connects an ordinary checkout directly under Projects", async () => {

--- a/tests/desktop/runtime-computer-menu.test.tsx
+++ b/tests/desktop/runtime-computer-menu.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import RuntimeComputerMenu from "../../desktop/src/renderer/src/features/runtime/RuntimeComputerMenu";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 import { useRuntimeComputers } from "../../desktop/src/renderer/src/stores/runtime-computers";
+import { useUi } from "../../desktop/src/renderer/src/stores/ui";
 
 const computers = {
   items: [
@@ -46,6 +47,7 @@ describe("sidebar computer menu", () => {
   beforeEach(() => {
     useConnection.setState(useConnection.getInitialState(), true);
     useRuntimeComputers.setState(useRuntimeComputers.getInitialState(), true);
+    useUi.setState(useUi.getInitialState(), true);
     useConnection.setState({
       status: "signed-in",
       handle: "operator",
@@ -76,6 +78,19 @@ describe("sidebar computer menu", () => {
     expect(screen.getByRole("menuitemradio", { name: /Main Computer.*Current/i }).getAttribute("aria-checked")).toBe("true");
     expect(screen.getByRole("menuitemradio", { name: /Additional Computer.*Available/i })).not.toBeNull();
     expect(screen.getByRole("menuitemradio", { name: /Preview Computer.*Starting/i }).hasAttribute("data-disabled")).toBe(true);
+  });
+
+  it("keeps native embeds detached while the computer menu crosses the sidebar edge", async () => {
+    render(<RuntimeComputerMenu collapsed={false} />);
+
+    const trigger = await screen.findByRole("button", { name: /Change computer, currently Main Computer/i });
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+
+    await screen.findByRole("menu", { name: "Choose computer" });
+    await waitFor(() => expect(useUi.getState().rendererOverlayCount).toBe(1));
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(useUi.getState().rendererOverlayCount).toBe(0));
   });
 
   it("opens from the keyboard and traverses computer choices", async () => {

--- a/tests/gateway/coding-agents-file-read.test.ts
+++ b/tests/gateway/coding-agents-file-read.test.ts
@@ -8,6 +8,7 @@ import { createCodingAgentFileStore } from "../../packages/gateway/src/coding-ag
 import { createCodingAgentRoutes } from "../../packages/gateway/src/coding-agents/routes.js";
 import type { RequestPrincipal } from "../../packages/gateway/src/request-principal.js";
 import { MissingRequestPrincipalError } from "../../packages/gateway/src/request-principal.js";
+import { atomicWriteJson } from "../../packages/gateway/src/state-ops.js";
 import { testPrincipal } from "../helpers/activation-readiness.js";
 
 const now = "2026-07-06T12:00:00.000Z";
@@ -106,6 +107,34 @@ describe("coding agent file read route", () => {
         metadata: { path: "src/primary.ts", kind: "file" },
         content: "export const checkout = 'primary';\n",
       });
+    } finally {
+      await rm(harness.homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the canonical project localPath for a directly connected owner folder", async () => {
+    const harness = await createRouteHarness({ ownerIds: [testPrincipal.userId] });
+    const directRoot = join(harness.homePath, "projects", "direct-checkout");
+    try {
+      await mkdir(join(directRoot, "src"), { recursive: true });
+      await writeFile(join(directRoot, "src", "direct.ts"), "export const direct = true;\n");
+      await atomicWriteJson(join(harness.homePath, "system", "projects", projectId, "config.json"), {
+        id: "proj_matrix_os",
+        name: "Matrix OS",
+        slug: projectId,
+        kind: "folder",
+        localPath: directRoot,
+        addedAt: now,
+        updatedAt: now,
+        ownerScope: { type: "user", id: testPrincipal.userId },
+      });
+
+      const read = await harness.app.request(
+        `/api/coding-agents/files/read?projectId=${projectId}&path=src%2Fdirect.ts`,
+      );
+
+      expect(read.status).toBe(200);
+      expect(await read.json()).toMatchObject({ content: "export const direct = true;\n" });
     } finally {
       await rm(harness.homePath, { recursive: true, force: true });
     }

--- a/tests/gateway/coding-agents-file-read.test.ts
+++ b/tests/gateway/coding-agents-file-read.test.ts
@@ -66,6 +66,14 @@ async function createRouteHarness(options: {
           },
         }),
       },
+      worktrees: {
+        listWorktrees: async (_projectSlug, ownerScope) => (
+          (options.projectOwnerType ?? "user") === "user"
+          && ownerScope.id === (options.projectOwnerId ?? testPrincipal.userId)
+            ? { ok: true as const, worktrees: [{ id: worktreeId, path: worktreeRoot }] }
+            : { ok: false as const, status: 404, error: { code: "not_found" } }
+        ),
+      },
       readLimitBytes: options.readLimitBytes,
     }),
     getPrincipal: () => {
@@ -140,6 +148,34 @@ describe("coding agent file read route", () => {
     }
   });
 
+  it("rejects a persisted project root that resolves outside Matrix home", async () => {
+    const harness = await createRouteHarness({ ownerIds: [testPrincipal.userId] });
+    const outsideRoot = await mkdtemp(join(tmpdir(), "matrix-coding-agent-outside-"));
+    try {
+      await writeFile(join(outsideRoot, "secret.txt"), "outside secret");
+      await atomicWriteJson(join(harness.homePath, "projects", projectId, "config.json"), {
+        id: "proj_matrix_os",
+        name: "Matrix OS",
+        slug: projectId,
+        kind: "folder",
+        localPath: outsideRoot,
+        addedAt: now,
+        updatedAt: now,
+        ownerScope: { type: "user", id: testPrincipal.userId },
+      });
+
+      const response = await harness.app.request(
+        `/api/coding-agents/files/read?projectId=${projectId}&path=secret.txt`,
+      );
+
+      expect(response.status).toBe(404);
+      expect(JSON.stringify(await response.json())).not.toContain("outside secret");
+    } finally {
+      await rm(harness.homePath, { recursive: true, force: true });
+      await rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
   it("keeps primary project checkout access owner-scoped and traversal-safe", async () => {
     const harness = await createRouteHarness({
       principal: { userId: "other_user", source: "jwt" },
@@ -177,6 +213,40 @@ describe("coding agent file read route", () => {
 
       expect(response.status).toBe(404);
       expect(JSON.stringify(await response.json())).not.toMatch(/other_project_owner|primary\.ts|\/tmp/i);
+    } finally {
+      await rm(harness.homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects worktree reads and writes when the authenticated user does not own the project", async () => {
+    const harness = await createRouteHarness({
+      ownerIds: [testPrincipal.userId],
+      projectOwnerId: "other_project_owner",
+    });
+    try {
+      const filePath = join(harness.worktreeRoot, "src", "private.ts");
+      await writeFile(filePath, "owner content\n");
+
+      const read = await harness.app.request(
+        `/api/coding-agents/files/read?projectId=${projectId}&worktreeId=${worktreeId}&path=src%2Fprivate.ts`,
+      );
+      const write = await harness.app.request("/api/coding-agents/files/write", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          projectId,
+          worktreeId,
+          path: "src/private.ts",
+          content: "intruder content\n",
+          encoding: "utf8",
+          baseEtag: null,
+          clientRequestId: "req_cross_owner_write",
+        }),
+      });
+
+      expect(read.status).toBe(404);
+      expect(write.status).toBe(404);
+      expect(await readFile(filePath, "utf8")).toBe("owner content\n");
     } finally {
       await rm(harness.homePath, { recursive: true, force: true });
     }

--- a/tests/gateway/coding-agents-source-control.test.ts
+++ b/tests/gateway/coding-agents-source-control.test.ts
@@ -41,6 +41,7 @@ async function createRouteHarness(options: {
   gitCommandFactory?: (homePath: string) => Promise<string>;
   ghCommandFactory?: (homePath: string) => Promise<string>;
   maxQueueDepth?: number;
+  projectOwnerId?: string;
 } = {}) {
   const homePath = await mkdtemp(join(tmpdir(), "matrix-coding-agent-source-control-"));
   const worktreeRoot = join(homePath, "projects", projectId, "worktrees", worktreeId);
@@ -62,6 +63,13 @@ async function createRouteHarness(options: {
       gitCommand,
       ghCommand,
       maxQueueDepth: options.maxQueueDepth,
+      worktrees: {
+        listWorktrees: async (_projectSlug, ownerScope) => (
+          ownerScope.id === (options.projectOwnerId ?? testPrincipal.userId)
+            ? { ok: true as const, worktrees: [{ id: worktreeId, path: worktreeRoot }] }
+            : { ok: false as const, status: 404, error: { code: "not_found" } }
+        ),
+      },
     }),
     getPrincipal: () => {
       if (options.principal === null) throw new MissingRequestPrincipalError();
@@ -290,6 +298,37 @@ describe("coding agent source-control route", () => {
     } finally {
       await rm(ownerHarness.homePath, { recursive: true, force: true });
       await rm(otherHarness.homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects prepare-commit when the project belongs to another owner", async () => {
+    const harness = await createRouteHarness({
+      ownerIds: [testPrincipal.userId],
+      projectOwnerId: "other_project_owner",
+    });
+    try {
+      const filePath = join(harness.worktreeRoot, "src", "index.ts");
+      await writeFile(filePath, "export const answer = 99;\n");
+
+      const response = await harness.app.request("/api/coding-agents/source-control/prepare-commit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          projectId,
+          worktreeId,
+          message: "fix: cross owner attempt",
+          paths: ["src/index.ts"],
+          clientRequestId: "req_cross_owner_commit",
+        }),
+      });
+
+      expect(response.status).toBe(404);
+      expect(execFileSync("git", ["status", "--porcelain"], {
+        cwd: harness.worktreeRoot,
+        encoding: "utf8",
+      })).toContain("src/index.ts");
+    } finally {
+      await rm(harness.homePath, { recursive: true, force: true });
     }
   });
 

--- a/tests/gateway/git-log.test.ts
+++ b/tests/gateway/git-log.test.ts
@@ -90,12 +90,12 @@ describe("git-log service", () => {
 
   beforeEach(async () => {
     homePath = await mkdtemp(join(tmpdir(), "matrix-git-log-home-"));
-    repoPath = await mkdtemp(join(tmpdir(), "matrix-git-log-repo-"));
+    repoPath = join(homePath, "workspaces", "repo");
+    await mkdir(repoPath, { recursive: true });
   });
 
   afterEach(() => {
     rmSync(homePath, { recursive: true, force: true });
-    rmSync(repoPath, { recursive: true, force: true });
     vi.restoreAllMocks();
   });
 
@@ -164,13 +164,19 @@ describe("git-log service", () => {
       expect(result).toEqual({ ok: true, commits: [], nextCursor: null, refreshedAt: NOW });
     });
 
-    it("never exposes the Matrix home repository history", async () => {
+    it("rejects a project record that points at the Matrix home repository", async () => {
       await seedProject(homePath, "homeish", homePath);
-      const gitLog = makeService(probeAwareRunCommand({ probe: { stdout: `${homePath}\n` } }));
+      const runCommand = probeAwareRunCommand({ probe: { stdout: `${homePath}\n` } });
+      const gitLog = makeService(runCommand);
 
       const result = await gitLog.listCommits("homeish", { limit: 10, offset: 0 });
 
-      expect(result).toEqual({ ok: true, commits: [], nextCursor: null, refreshedAt: NOW });
+      expect(result).toEqual({
+        ok: false,
+        status: 404,
+        error: { code: "not_found", message: "Project was not found" },
+      });
+      expect(runCommand).not.toHaveBeenCalled();
     });
 
     it("parses commits with parents, refs, tags, and HEAD markers", async () => {

--- a/tests/gateway/git-log.test.ts
+++ b/tests/gateway/git-log.test.ts
@@ -72,7 +72,15 @@ async function seedProject(homePath: string, slug: string, localPath: string): P
   await mkdir(join(homePath, "projects", slug), { recursive: true });
   await writeFile(
     join(homePath, "projects", slug, "config.json"),
-    JSON.stringify({ id: "proj_1", name: slug, slug, localPath, addedAt: NOW, updatedAt: NOW }),
+    JSON.stringify({
+      id: "proj_1",
+      name: slug,
+      slug,
+      localPath,
+      addedAt: NOW,
+      updatedAt: NOW,
+      ownerScope: { type: "user", id: "user_a" },
+    }),
   );
 }
 

--- a/tests/gateway/preview-manager.test.ts
+++ b/tests/gateway/preview-manager.test.ts
@@ -11,9 +11,11 @@ describe("preview-manager", () => {
 
   beforeEach(async () => {
     homePath = await mkdtemp(join(tmpdir(), "matrix-preview-manager-"));
-    await atomicWriteJson(join(homePath, "projects", "repo", "config.json"), {
+    await atomicWriteJson(join(homePath, "system", "projects", "repo", "config.json"), {
+      id: "proj_repo",
       slug: "repo",
       name: "repo",
+      localPath: join(homePath, "projects", "repo"),
       ownerScope: { type: "user", id: "user_a" },
     });
   });
@@ -65,7 +67,7 @@ describe("preview-manager", () => {
       preview: { label: "External app", displayPreference: "external", lastStatus: "failed" },
     });
     await expect(manager.deletePreview("repo", created.preview.id)).resolves.toMatchObject({ ok: true });
-    await expect(stat(join(homePath, "projects", "repo", "previews", `${created.preview.id}.json`))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(join(homePath, "system", "projects", "repo", "previews", `${created.preview.id}.json`))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("rejects unsafe preview URLs and exposes probe failures as recoverable status", async () => {
@@ -128,7 +130,7 @@ describe("preview-manager", () => {
   it("lists recent previews newest-first across large project history", async () => {
     const manager = createPreviewManager({ homePath });
     for (let index = 0; index < 260; index += 1) {
-      await atomicWriteJson(join(homePath, "projects", "repo", "previews", `prev_old_${index}.json`), {
+      await atomicWriteJson(join(homePath, "system", "projects", "repo", "previews", `prev_old_${index}.json`), {
         id: `prev_old_${index}`,
         projectSlug: "repo",
         label: `Old preview ${index}`,
@@ -139,7 +141,7 @@ describe("preview-manager", () => {
         updatedAt: new Date(Date.UTC(2026, 3, 26, 0, 0, index % 60)).toISOString(),
       });
     }
-    await atomicWriteJson(join(homePath, "projects", "repo", "previews", "prev_newest.json"), {
+    await atomicWriteJson(join(homePath, "system", "projects", "repo", "previews", "prev_newest.json"), {
       id: "prev_newest",
       projectSlug: "repo",
       label: "Newest preview",

--- a/tests/gateway/preview-manager.test.ts
+++ b/tests/gateway/preview-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtemp, readFile, stat } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -128,6 +128,28 @@ describe("preview-manager", () => {
     await expect(manager.listPreviews("repo")).resolves.toMatchObject({ previews: [] });
   });
 
+  it("preserves an unvalidated owner file that collides with a canonical preview id", async () => {
+    const manager = createPreviewManager({
+      homePath,
+      probeUrl: vi.fn(async () => ({ ok: true as const })),
+    });
+    const created = await manager.createPreview("repo", {
+      label: "Canonical preview",
+      url: "http://localhost:3000",
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    const ownerFile = join(homePath, "projects", "repo", "previews", `${created.preview.id}.json`);
+    await atomicWriteJson(ownerFile, { ownerNote: "keep me" });
+
+    await expect(manager.deletePreview("repo", created.preview.id)).resolves.toEqual({ ok: true });
+    await expect(readFile(ownerFile, "utf-8")).resolves.toContain("keep me");
+    await expect(stat(
+      join(homePath, "system", "projects", "repo", "previews", `${created.preview.id}.json`),
+    )).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("rejects preview mutations from a different owner scope", async () => {
     const manager = createPreviewManager({
       homePath,
@@ -202,6 +224,21 @@ describe("preview-manager", () => {
     expect(result.ok && result.previews[0]).toMatchObject({
       id: "prev_newest",
       label: "Newest preview",
+    });
+  });
+
+  it("fails safely when preview identifier discovery exceeds its memory bound", async () => {
+    const directory = join(homePath, "system", "projects", "repo", "previews");
+    await mkdir(directory, { recursive: true });
+    await Promise.all(Array.from({ length: 513 }, (_, index) => (
+      writeFile(join(directory, `prev_untrusted_${index}.json`), "{}", "utf-8")
+    )));
+    const manager = createPreviewManager({ homePath });
+
+    await expect(manager.listPreviews("repo")).resolves.toMatchObject({
+      ok: false,
+      status: 409,
+      error: { code: "preview_limit_exceeded" },
     });
   });
 });

--- a/tests/gateway/preview-manager.test.ts
+++ b/tests/gateway/preview-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtemp, stat } from "node:fs/promises";
+import { mkdtemp, readFile, stat } from "node:fs/promises";
 import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -16,6 +16,8 @@ describe("preview-manager", () => {
       slug: "repo",
       name: "repo",
       localPath: join(homePath, "projects", "repo"),
+      addedAt: "2026-04-26T00:00:00.000Z",
+      updatedAt: "2026-04-26T00:00:00.000Z",
       ownerScope: { type: "user", id: "user_a" },
     });
   });
@@ -98,6 +100,45 @@ describe("preview-manager", () => {
       preview: { lastStatus: "failed" },
     });
     expect(probeUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps legacy previews readable and adopts valid records into the registry", async () => {
+    const legacy = {
+      id: "prev_legacy123",
+      projectSlug: "repo",
+      label: "Legacy preview",
+      url: "http://localhost:3000",
+      lastStatus: "ok",
+      displayPreference: "panel",
+      createdAt: "2026-04-25T00:00:00.000Z",
+      updatedAt: "2026-04-25T00:00:00.000Z",
+    };
+    await atomicWriteJson(join(homePath, "projects", "repo", "previews", `${legacy.id}.json`), legacy);
+    const manager = createPreviewManager({ homePath, probeUrl: vi.fn(async () => ({ ok: true as const })) });
+
+    await expect(manager.listPreviews("repo")).resolves.toMatchObject({
+      ok: true,
+      previews: [expect.objectContaining({ id: legacy.id, label: "Legacy preview" })],
+    });
+    await expect(readFile(
+      join(homePath, "system", "projects", "repo", "previews", `${legacy.id}.json`),
+      "utf-8",
+    )).resolves.toContain("Legacy preview");
+    await expect(manager.deletePreview("repo", legacy.id)).resolves.toEqual({ ok: true });
+    await expect(manager.listPreviews("repo")).resolves.toMatchObject({ previews: [] });
+  });
+
+  it("rejects preview mutations from a different owner scope", async () => {
+    const manager = createPreviewManager({
+      homePath,
+      probeUrl: vi.fn(async () => ({ ok: true as const })),
+    });
+
+    await expect(manager.createPreview(
+      "repo",
+      { label: "Do not create", url: "http://localhost:3000" },
+      { type: "user", id: "user_b" },
+    )).resolves.toMatchObject({ ok: false, status: 404, error: { code: "not_found" } });
   });
 
   it("enforces project and task preview caps and detects preview URLs from session output", async () => {

--- a/tests/gateway/project-clone-mkdir.test.ts
+++ b/tests/gateway/project-clone-mkdir.test.ts
@@ -410,14 +410,14 @@ describe("project clone and mkdir routes", () => {
   });
 
   describe("POST /api/projects/mkdir", () => {
-    it("creates projects/<name>/repo by default", async () => {
+    it("creates an owner workspace directly under projects by default", async () => {
       const app = createWorkspaceRoutes({ homePath });
 
       const res = await app.request(jsonRequest("/api/projects/mkdir", { name: "fresh-app" }));
 
       expect(res.status).toBe(201);
-      await expect(res.json()).resolves.toEqual({ path: "projects/fresh-app/repo" });
-      const created = await stat(join(homePath, "projects", "fresh-app", "repo"));
+      await expect(res.json()).resolves.toEqual({ path: "projects/fresh-app" });
+      const created = await stat(join(homePath, "projects", "fresh-app"));
       expect(created.isDirectory()).toBe(true);
     });
 
@@ -449,9 +449,9 @@ describe("project clone and mkdir routes", () => {
 
     it("connects a custom-parent folder returned by mkdir as a project", async () => {
       await mkdir(join(homePath, "apps"), { recursive: true });
-      // A legacy/unmanaged directory may already occupy the registry slug.
-      // Folder binding should publish config.json into that slot instead of
-      // reporting a false slug conflict after mkdir has already succeeded.
+      // An owner directory may already use the same name as the registry key.
+      // Folder binding publishes Matrix metadata under system/projects rather
+      // than reporting a false slug conflict or writing into owner space.
       await mkdir(join(homePath, "projects", "matrix-os", "symphony-workspaces"), { recursive: true });
       const app = createWorkspaceRoutes({ homePath });
 
@@ -477,7 +477,7 @@ describe("project clone and mkdir routes", () => {
           localPath: expect.stringMatching(/[/\\]apps[/\\]matrix-os$/),
         },
       });
-      await expect(stat(join(homePath, "projects", "matrix-os", "config.json"))).resolves.toBeTruthy();
+      await expect(stat(join(homePath, "system", "projects", "matrix-os", "config.json"))).resolves.toBeTruthy();
     });
 
     it("returns the same custom folder for an idempotent mkdir retry", async () => {
@@ -617,13 +617,13 @@ describe("project clone and mkdir routes", () => {
       expect(body.error.code).toBe("folder_conflict");
     });
 
-    it("treats an explicit projects parent like the default registry layout", async () => {
+    it("treats an explicit projects parent like the default owner workspace root", async () => {
       const app = createWorkspaceRoutes({ homePath });
 
       const res = await app.request(jsonRequest("/api/projects/mkdir", { name: "fresh-app", parent: "projects" }));
 
       expect(res.status).toBe(201);
-      await expect(res.json()).resolves.toEqual({ path: "projects/fresh-app/repo" });
+      await expect(res.json()).resolves.toEqual({ path: "projects/fresh-app" });
     });
 
     it.each(["../outside", "/etc", "code/../../escape", "projects/foo", ".", "system", ".hermes", "agents", "data/browser-profiles"])(

--- a/tests/gateway/project-lifecycle.test.ts
+++ b/tests/gateway/project-lifecycle.test.ts
@@ -200,7 +200,7 @@ describe("project lifecycle", () => {
       join(homePath, "projects", "customer-app", "repo", "residual.txt"),
       "partial deletion residue",
     );
-    await rm(join(homePath, "projects", "customer-app", "config.json"));
+    await rm(join(homePath, "system", "projects", "customer-app", "config.json"));
 
     const cleanupRelatedState = vi.fn(async () => undefined);
     const service = createProjectLifecycleService({

--- a/tests/gateway/project-manager.test.ts
+++ b/tests/gateway/project-manager.test.ts
@@ -248,6 +248,46 @@ describe("project-manager", () => {
     await expect(readFile(join(existing, "README.md"), "utf-8")).resolves.toBe("owner data");
   });
 
+  it("removes validated legacy Matrix state when deleting a folder project", async () => {
+    const existing = join(homePath, "workspaces", "legacy-state-folder");
+    const legacyTask = join(
+      homePath,
+      "projects",
+      "legacy-state-folder",
+      "tasks",
+      "task_owned123.json",
+    );
+    await mkdir(existing, { recursive: true });
+    await writeFile(join(existing, "README.md"), "owner data");
+    const manager = createProjectManager({ homePath, runCommand: vi.fn(), now: () => "2026-04-26T00:00:00.000Z" });
+    await manager.createProject({
+      mode: "folder",
+      name: "Legacy state folder",
+      slug: "legacy-state-folder",
+      path: "workspaces/legacy-state-folder",
+      ownerScope: { type: "user", id: "user_123" },
+    });
+    await atomicWriteJson(legacyTask, {
+      id: "task_owned123",
+      projectSlug: "legacy-state-folder",
+      title: "Owned task",
+      status: "todo",
+      priority: "normal",
+      order: 0,
+      previewIds: [],
+      createdAt: "2026-04-26T00:00:00.000Z",
+      updatedAt: "2026-04-26T00:00:00.000Z",
+    });
+
+    await expect(manager.removeManagedProject({
+      slug: "legacy-state-folder",
+      ownerScope: { type: "user", id: "user_123" },
+    })).resolves.toEqual({ ok: true });
+
+    await expect(stat(legacyTask)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(join(existing, "README.md"), "utf-8")).resolves.toBe("owner data");
+  });
+
   it("connects a checkout directly under projects while keeping registry metadata in system", async () => {
     const checkout = join(homePath, "projects", "matrix-os-repo");
     await mkdir(checkout, { recursive: true });
@@ -410,6 +450,26 @@ describe("project-manager", () => {
     });
   });
 
+  it("rejects a missing persisted project path beneath a symlinked outside ancestor", async () => {
+    await symlink(tmpdir(), join(homePath, "outside-alias"));
+    await atomicWriteJson(join(homePath, "system", "projects", "escaped", "config.json"), {
+      id: "proj_escaped",
+      name: "Escaped",
+      slug: "escaped",
+      kind: "folder",
+      localPath: join(homePath, "outside-alias", "not-created-yet"),
+      addedAt: "2026-08-06T10:00:00.000Z",
+      updatedAt: "2026-08-06T10:00:00.000Z",
+      ownerScope: { type: "user", id: "user_123" },
+    });
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    await expect(manager.listManagedProjects({
+      visibility: "active",
+      ownerScope: { type: "user", id: "user_123" },
+    })).resolves.toEqual({ projects: [], nextCursor: null });
+  });
+
   it("classifies legacy project records without making the renderer infer their kind", async () => {
     const root = join(homePath, "projects", "legacy-scratch");
     await mkdir(join(root, "repo"), { recursive: true });
@@ -445,6 +505,7 @@ describe("project-manager", () => {
       addedAt: "2026-08-01T10:00:00.000Z",
       updatedAt: "2026-08-01T10:00:00.000Z",
       ownerScope: { type: "user" as const, id: "user_123" },
+      padding: "owner application field",
     };
     await writeFile(join(root, "config.json"), JSON.stringify(legacy));
     const manager = createProjectManager({ homePath, runCommand: vi.fn() });
@@ -462,6 +523,36 @@ describe("project-manager", () => {
     await expect(
       readFile(join(homePath, "system", "projects", "legacy-repo", "legacy-config.json"), "utf-8"),
     ).resolves.toContain("proj_legacy_repo");
+    const canonical = JSON.parse(await readFile(
+      join(homePath, "system", "projects", "legacy-repo", "config.json"),
+      "utf-8",
+    ));
+    expect(canonical).not.toHaveProperty("padding");
+  });
+
+  it("refuses to adopt an oversized legacy project record", async () => {
+    const root = join(homePath, "projects", "oversized-legacy");
+    const workspace = join(root, "repo");
+    await mkdir(workspace, { recursive: true });
+    await atomicWriteJson(join(root, "config.json"), {
+      id: "proj_oversized_legacy",
+      name: "Oversized legacy",
+      slug: "oversized-legacy",
+      kind: "github",
+      localPath: workspace,
+      addedAt: "2026-08-01T10:00:00.000Z",
+      updatedAt: "2026-08-01T10:00:00.000Z",
+      ownerScope: { type: "user", id: "user_123" },
+      padding: "x".repeat(300 * 1024),
+    });
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    await expect(manager.getProject("oversized-legacy")).resolves.toMatchObject({
+      ok: false,
+      status: 404,
+    });
+    await expect(stat(join(homePath, "system", "projects", "oversized-legacy", "config.json")))
+      .rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("keeps legacy deletion tombstones recoverable and adopts them into the registry", async () => {
@@ -566,6 +657,129 @@ describe("project-manager", () => {
       "utf-8",
     ));
     expect(persisted).toMatchObject({ kind: "scratch", archivedAt: "2026-08-06T12:00:00.000Z" });
+  });
+
+  it("preserves a conflicting tombstone when the authorized project clears deletion state", async () => {
+    const workspace = join(homePath, "workspaces", "repo");
+    await mkdir(workspace, { recursive: true });
+    const config = {
+      id: "proj_owner_a",
+      name: "Owner A",
+      slug: "repo",
+      kind: "folder",
+      localPath: workspace,
+      addedAt: "2026-08-06T10:00:00.000Z",
+      updatedAt: "2026-08-06T10:00:00.000Z",
+      ownerScope: { type: "user", id: "user_a" },
+    };
+    const tombstonePath = join(homePath, "system", "projects", ".deleting", "repo.json");
+    await atomicWriteJson(join(homePath, "system", "projects", "repo", "config.json"), config);
+    await atomicWriteJson(tombstonePath, {
+      ...config,
+      id: "proj_owner_b",
+      name: "Owner B",
+      ownerScope: { type: "user", id: "user_b" },
+      deletingAt: "2026-08-06T11:00:00.000Z",
+    });
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    await expect(manager.setProjectLifecycleState({
+      slug: "repo",
+      ownerScope: { type: "user", id: "user_a" },
+      deletingAt: null,
+    })).resolves.toMatchObject({ ok: true });
+
+    await expect(readFile(tombstonePath, "utf-8")).resolves.toContain("proj_owner_b");
+  });
+
+  it("preserves a legacy tombstone owned by another scope when setting deletion state", async () => {
+    const workspace = join(homePath, "workspaces", "repo");
+    await mkdir(workspace, { recursive: true });
+    const config = {
+      id: "proj_shared_id",
+      name: "Owner A",
+      slug: "repo",
+      kind: "folder",
+      localPath: workspace,
+      addedAt: "2026-08-06T10:00:00.000Z",
+      updatedAt: "2026-08-06T10:00:00.000Z",
+      ownerScope: { type: "user", id: "user_a" },
+    };
+    const legacyTombstonePath = join(homePath, "projects", ".deleting", "repo.json");
+    await atomicWriteJson(join(homePath, "system", "projects", "repo", "config.json"), config);
+    await atomicWriteJson(legacyTombstonePath, {
+      ...config,
+      name: "Owner B",
+      ownerScope: { type: "user", id: "user_b" },
+      deletingAt: "2026-08-06T11:00:00.000Z",
+    });
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    await expect(manager.setProjectLifecycleState({
+      slug: "repo",
+      ownerScope: { type: "user", id: "user_a" },
+      deletingAt: "2026-08-06T12:00:00.000Z",
+    })).resolves.toMatchObject({ ok: true });
+
+    await expect(readFile(legacyTombstonePath, "utf-8")).resolves.toContain("user_b");
+  });
+
+  it("never recursively deletes owner source for a kindless legacy project", async () => {
+    const source = join(homePath, "projects", "legacy-kindless");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "README.md"), "owner source");
+    await atomicWriteJson(join(homePath, "system", "projects", "legacy-kindless", "config.json"), {
+      id: "proj_legacy_kindless",
+      name: "Legacy kindless",
+      slug: "legacy-kindless",
+      localPath: source,
+      addedAt: "2026-08-06T10:00:00.000Z",
+      updatedAt: "2026-08-06T10:00:00.000Z",
+      ownerScope: { type: "user", id: "user_123" },
+    });
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    await expect(manager.setProjectLifecycleState({
+      slug: "legacy-kindless",
+      ownerScope: { type: "user", id: "user_123" },
+      deletingAt: "2026-08-18T00:00:00.000Z",
+    })).resolves.toMatchObject({ ok: true });
+    await expect(manager.removeManagedProject({
+      slug: "legacy-kindless",
+      ownerScope: { type: "user", id: "user_123" },
+    })).resolves.toEqual({ ok: true });
+
+    await expect(readFile(join(source, "README.md"), "utf-8")).resolves.toBe("owner source");
+    await expect(stat(join(homePath, "system", "projects", "legacy-kindless")))
+      .rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("preserves a same-slug owner folder when managed kind and local path disagree", async () => {
+    const ownerFolder = join(homePath, "projects", "mismatched");
+    const recordedSource = join(homePath, "projects", "elsewhere", "repo");
+    await mkdir(ownerFolder, { recursive: true });
+    await mkdir(recordedSource, { recursive: true });
+    await writeFile(join(ownerFolder, "keep.txt"), "owner source");
+    await atomicWriteJson(join(homePath, "system", "projects", "mismatched", "config.json"), {
+      id: "proj_mismatched",
+      name: "Mismatched",
+      slug: "mismatched",
+      kind: "github",
+      localPath: recordedSource,
+      addedAt: "2026-08-06T10:00:00.000Z",
+      updatedAt: "2026-08-06T10:00:00.000Z",
+      ownerScope: { type: "user", id: "user_123" },
+    });
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    await expect(manager.removeManagedProject({
+      slug: "mismatched",
+      ownerScope: { type: "user", id: "user_123" },
+    })).resolves.toEqual({ ok: true });
+
+    await expect(readFile(join(ownerFolder, "keep.txt"), "utf-8")).resolves.toBe("owner source");
+    await expect(stat(join(homePath, "system", "projects", "mismatched")))
+      .rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("removes only the owned Matrix project registry and preserves a folder project's source directory", async () => {

--- a/tests/gateway/project-manager.test.ts
+++ b/tests/gateway/project-manager.test.ts
@@ -275,6 +275,27 @@ describe("project-manager", () => {
     expect(config).toMatchObject({ slug: "matrix-os-repo", localPath: await realpath(checkout) });
   });
 
+  it("allows an idempotent retry after connecting a checkout directly under projects", async () => {
+    const checkout = join(homePath, "projects", "retry-repo");
+    await mkdir(checkout, { recursive: true });
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+    const request = {
+      mode: "folder" as const,
+      name: "Retry repo",
+      slug: "retry-repo",
+      path: "projects/retry-repo",
+      ownerScope: { type: "user" as const, id: "user_123" },
+      clientRequestId: "req_retry_repo",
+    };
+
+    await expect(manager.createProject(request)).resolves.toMatchObject({ ok: true, status: 201 });
+    await expect(manager.createProject(request)).resolves.toMatchObject({
+      ok: true,
+      status: 200,
+      project: { slug: "retry-repo", kind: "folder", localPath: await realpath(checkout) },
+    });
+  });
+
   it("does not mistake an owner repository config.json for legacy Matrix metadata", async () => {
     const checkout = join(homePath, "projects", "configured-repo");
     await mkdir(checkout, { recursive: true });
@@ -294,6 +315,34 @@ describe("project-manager", () => {
       .resolves.toContain("compilerOptions");
     await expect(manager.listManagedProjects({ ownerScope: { type: "user", id: "user_123" } }))
       .resolves.toMatchObject({ projects: [{ slug: "configured-repo" }] });
+  });
+
+  it("preserves an owner config.json that happens to contain id and slug fields", async () => {
+    const checkout = join(homePath, "projects", "configured-app");
+    const ownerConfig = {
+      id: "configured-app",
+      slug: "configured-app",
+      theme: "dark",
+    };
+    await mkdir(checkout, { recursive: true });
+    await writeFile(join(checkout, "config.json"), JSON.stringify(ownerConfig));
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    const created = await manager.createProject({
+      mode: "folder",
+      name: "Configured app",
+      slug: "configured-app",
+      path: "projects/configured-app",
+      ownerScope: { type: "user", id: "user_123" },
+    });
+
+    expect(created).toMatchObject({ ok: true, status: 201 });
+    await expect(readFile(join(checkout, "config.json"), "utf-8"))
+      .resolves.toBe(JSON.stringify(ownerConfig));
+    await expect(readFile(
+      join(homePath, "system", "projects", "configured-app", "config.json"),
+      "utf-8",
+    )).resolves.toContain('"kind": "folder"');
   });
 
   it("returns owner-scoped active and archived project projections without exposing deletion tombstones", async () => {
@@ -413,6 +462,30 @@ describe("project-manager", () => {
     await expect(
       readFile(join(homePath, "system", "projects", "legacy-repo", "legacy-config.json"), "utf-8"),
     ).resolves.toContain("proj_legacy_repo");
+  });
+
+  it("keeps legacy deletion tombstones recoverable and adopts them into the registry", async () => {
+    const tombstone = {
+      id: "proj_deleting_legacy",
+      name: "Deleting legacy",
+      slug: "deleting-legacy",
+      kind: "scratch" as const,
+      localPath: join(homePath, "projects", "deleting-legacy", "repo"),
+      addedAt: "2026-08-16T00:00:00.000Z",
+      updatedAt: "2026-08-17T00:00:00.000Z",
+      deletingAt: "2026-08-17T00:00:00.000Z",
+      ownerScope: { type: "user" as const, id: "user_123" },
+    };
+    await atomicWriteJson(join(homePath, "projects", ".deleting", "deleting-legacy.json"), tombstone);
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    await expect(manager.listDeletingProjects()).resolves.toMatchObject({
+      projects: [expect.objectContaining({ slug: "deleting-legacy", deletingAt: tombstone.deletingAt })],
+    });
+    await expect(readFile(
+      join(homePath, "system", "projects", ".deleting", "deleting-legacy.json"),
+      "utf-8",
+    )).resolves.toContain("Deleting legacy");
   });
 
   it("keeps a conflicting legacy record for operator recovery while preferring canonical state", async () => {

--- a/tests/gateway/project-manager.test.ts
+++ b/tests/gateway/project-manager.test.ts
@@ -4,6 +4,7 @@ import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createProjectManager, validateGitHubUrl } from "../../packages/gateway/src/project-manager.js";
+import { atomicWriteJson } from "../../packages/gateway/src/state-ops.js";
 
 describe("project-manager", () => {
   let homePath: string;
@@ -65,7 +66,7 @@ describe("project-manager", () => {
       github: { owner: "Owner", repo: "Repo", authState: "ok" },
     });
     await expect(stat(join(homePath, "projects", "repo", "repo", ".git"))).resolves.toBeTruthy();
-    const config = JSON.parse(await readFile(join(homePath, "projects", "repo", "config.json"), "utf-8"));
+    const config = JSON.parse(await readFile(join(homePath, "system", "projects", "repo", "config.json"), "utf-8"));
     expect(config.localPath).toBe(join(homePath, "projects", "repo", "repo"));
   });
 
@@ -92,7 +93,7 @@ describe("project-manager", () => {
     expect(result.project.remote).toBeUndefined();
     expect(result.project.github).toBeUndefined();
     await expect(stat(join(homePath, "projects", "empty-workspace", "repo"))).resolves.toBeTruthy();
-    const config = JSON.parse(await readFile(join(homePath, "projects", "empty-workspace", "config.json"), "utf-8"));
+    const config = JSON.parse(await readFile(join(homePath, "system", "projects", "empty-workspace", "config.json"), "utf-8"));
     expect(config.localPath).toBe(join(homePath, "projects", "empty-workspace", "repo"));
   });
 
@@ -247,6 +248,54 @@ describe("project-manager", () => {
     await expect(readFile(join(existing, "README.md"), "utf-8")).resolves.toBe("owner data");
   });
 
+  it("connects a checkout directly under projects while keeping registry metadata in system", async () => {
+    const checkout = join(homePath, "projects", "matrix-os-repo");
+    await mkdir(checkout, { recursive: true });
+    await writeFile(join(checkout, "README.md"), "owner checkout");
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    const created = await manager.createProject({
+      mode: "folder",
+      name: "Matrix OS repo",
+      slug: "matrix-os-repo",
+      path: "projects/matrix-os-repo",
+      ownerScope: { type: "user", id: "user_123" },
+    });
+
+    expect(created).toMatchObject({
+      ok: true,
+      status: 201,
+      project: { localPath: await realpath(checkout) },
+    });
+    await expect(readFile(join(checkout, "README.md"), "utf-8")).resolves.toBe("owner checkout");
+    await expect(stat(join(checkout, "config.json"))).rejects.toMatchObject({ code: "ENOENT" });
+    const config = JSON.parse(
+      await readFile(join(homePath, "system", "projects", "matrix-os-repo", "config.json"), "utf-8"),
+    );
+    expect(config).toMatchObject({ slug: "matrix-os-repo", localPath: await realpath(checkout) });
+  });
+
+  it("does not mistake an owner repository config.json for legacy Matrix metadata", async () => {
+    const checkout = join(homePath, "projects", "configured-repo");
+    await mkdir(checkout, { recursive: true });
+    await writeFile(join(checkout, "config.json"), JSON.stringify({ compilerOptions: { strict: true } }));
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    const created = await manager.createProject({
+      mode: "folder",
+      name: "Configured repo",
+      slug: "configured-repo",
+      path: "projects/configured-repo",
+      ownerScope: { type: "user", id: "user_123" },
+    });
+
+    expect(created).toMatchObject({ ok: true, status: 201 });
+    await expect(readFile(join(checkout, "config.json"), "utf-8"))
+      .resolves.toContain("compilerOptions");
+    await expect(manager.listManagedProjects({ ownerScope: { type: "user", id: "user_123" } }))
+      .resolves.toMatchObject({ projects: [{ slug: "configured-repo" }] });
+  });
+
   it("returns owner-scoped active and archived project projections without exposing deletion tombstones", async () => {
     const projects = [
       {
@@ -334,6 +383,74 @@ describe("project-manager", () => {
     expect(result.projects).toMatchObject([{ slug: "legacy-scratch", kind: "scratch" }]);
   });
 
+  it("adopts a legacy registry record once without moving its workspace", async () => {
+    const root = join(homePath, "projects", "legacy-repo");
+    const workspace = join(root, "repo");
+    await mkdir(workspace, { recursive: true });
+    const legacy = {
+      id: "proj_legacy_repo",
+      name: "Legacy repo",
+      slug: "legacy-repo",
+      kind: "github" as const,
+      localPath: workspace,
+      addedAt: "2026-08-01T10:00:00.000Z",
+      updatedAt: "2026-08-01T10:00:00.000Z",
+      ownerScope: { type: "user" as const, id: "user_123" },
+    };
+    await writeFile(join(root, "config.json"), JSON.stringify(legacy));
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    const first = await manager.getProject("legacy-repo");
+    const second = await manager.getProject("legacy-repo");
+
+    expect(first).toMatchObject({ ok: true, project: { id: "proj_legacy_repo", localPath: workspace } });
+    expect(second).toEqual(first);
+    await expect(stat(workspace)).resolves.toBeTruthy();
+    await expect(stat(join(root, "config.json"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      readFile(join(homePath, "system", "projects", "legacy-repo", "config.json"), "utf-8"),
+    ).resolves.toContain("proj_legacy_repo");
+    await expect(
+      readFile(join(homePath, "system", "projects", "legacy-repo", "legacy-config.json"), "utf-8"),
+    ).resolves.toContain("proj_legacy_repo");
+  });
+
+  it("keeps a conflicting legacy record for operator recovery while preferring canonical state", async () => {
+    const legacyRoot = join(homePath, "projects", "conflicted-repo");
+    const workspace = join(legacyRoot, "repo");
+    await mkdir(workspace, { recursive: true });
+    await atomicWriteJson(join(legacyRoot, "config.json"), {
+      id: "proj_legacy_conflict",
+      name: "Legacy conflict",
+      slug: "conflicted-repo",
+      kind: "github",
+      localPath: workspace,
+      addedAt: "2026-08-01T10:00:00.000Z",
+      updatedAt: "2026-08-01T10:00:00.000Z",
+      ownerScope: { type: "user", id: "user_123" },
+    });
+    await atomicWriteJson(join(homePath, "system", "projects", "conflicted-repo", "config.json"), {
+      id: "proj_canonical_conflict",
+      name: "Canonical conflict",
+      slug: "conflicted-repo",
+      kind: "folder",
+      localPath: workspace,
+      addedAt: "2026-08-02T10:00:00.000Z",
+      updatedAt: "2026-08-02T10:00:00.000Z",
+      ownerScope: { type: "user", id: "user_123" },
+    });
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+
+    await expect(manager.getProject("conflicted-repo")).resolves.toMatchObject({
+      ok: true,
+      project: { id: "proj_canonical_conflict", name: "Canonical conflict" },
+    });
+    await expect(readFile(join(legacyRoot, "config.json"), "utf-8"))
+      .resolves.toContain("proj_legacy_conflict");
+    await expect(stat(join(homePath, "system", "projects", "conflicted-repo", "legacy-config.json")))
+      .rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("updates lifecycle state only for the owning scope and persists legacy kind classification", async () => {
     const root = join(homePath, "projects", "legacy-owned");
     await mkdir(join(root, "repo"), { recursive: true });
@@ -371,7 +488,10 @@ describe("project-manager", () => {
       },
     });
 
-    const persisted = JSON.parse(await readFile(join(root, "config.json"), "utf-8"));
+    const persisted = JSON.parse(await readFile(
+      join(homePath, "system", "projects", "legacy-owned", "config.json"),
+      "utf-8",
+    ));
     expect(persisted).toMatchObject({ kind: "scratch", archivedAt: "2026-08-06T12:00:00.000Z" });
   });
 
@@ -456,7 +576,16 @@ describe("project-manager", () => {
 
   it("rejects other managed project roots as folder projects", async () => {
     await mkdir(join(homePath, "projects", "other"), { recursive: true });
-    await writeFile(join(homePath, "projects", "other", "config.json"), "{}");
+    await atomicWriteJson(join(homePath, "system", "projects", "other", "config.json"), {
+      id: "proj_other",
+      name: "Other",
+      slug: "other",
+      kind: "scratch",
+      localPath: join(homePath, "projects", "other"),
+      addedAt: "2026-08-17T00:00:00.000Z",
+      updatedAt: "2026-08-17T00:00:00.000Z",
+      ownerScope: { type: "user", id: "local" },
+    });
     const manager = createProjectManager({ homePath, runCommand: vi.fn() });
 
     await expect(manager.createProject({
@@ -506,6 +635,16 @@ describe("project-manager", () => {
 
   it("rejects managed worktree and metadata areas as folder project roots", async () => {
     await mkdir(join(homePath, "projects", "other", "worktrees", "wt-1"), { recursive: true });
+    await atomicWriteJson(join(homePath, "system", "projects", "other", "config.json"), {
+      id: "proj_other",
+      name: "Other",
+      slug: "other",
+      kind: "scratch",
+      localPath: join(homePath, "projects", "other"),
+      addedAt: "2026-08-17T00:00:00.000Z",
+      updatedAt: "2026-08-17T00:00:00.000Z",
+      ownerScope: { type: "user", id: "local" },
+    });
     const manager = createProjectManager({ homePath, runCommand: vi.fn() });
 
     for (const path of ["projects/other/worktrees", "projects/other/worktrees/wt-1"]) {

--- a/tests/gateway/state-ops.test.ts
+++ b/tests/gateway/state-ops.test.ts
@@ -51,33 +51,39 @@ describe("state-ops", () => {
   it("exports and deletes only the requested owner-scoped project data", async () => {
     await mkdir(join(homePath, "projects", "keep"), { recursive: true });
     await mkdir(join(homePath, "projects", "drop"), { recursive: true });
-    await atomicWriteJson(join(homePath, "projects", "keep", "config.json"), {
+    await atomicWriteJson(join(homePath, "system", "projects", "keep", "config.json"), {
       slug: "keep",
+      kind: "folder",
+      localPath: join(homePath, "projects", "keep"),
       ownerScope: { type: "user", id: "user_a" },
     });
-    await atomicWriteJson(join(homePath, "projects", "drop", "config.json"), {
+    await atomicWriteJson(join(homePath, "system", "projects", "drop", "config.json"), {
       slug: "drop",
+      kind: "folder",
+      localPath: join(homePath, "projects", "drop"),
       ownerScope: { type: "user", id: "user_a" },
     });
-    await atomicWriteJson(join(homePath, "projects", "drop", "tasks", "task_abc123.json"), {
+    await atomicWriteJson(join(homePath, "system", "projects", "drop", "tasks", "task_abc123.json"), {
       id: "task_abc123",
       title: "Exported task",
     });
-    await atomicWriteJson(join(homePath, "projects", "drop", "previews", "prev_abc123.json"), {
+    await atomicWriteJson(join(homePath, "system", "projects", "drop", "previews", "prev_abc123.json"), {
       id: "prev_abc123",
       url: "http://localhost:3000",
     });
+    await writeFile(join(homePath, "projects", "drop", "README.md"), "owner workspace");
     const outside = await mkdtemp(join(tmpdir(), "matrix-state-outside-"));
     await writeFile(join(outside, "secret.txt"), "secret");
     await symlink(outside, join(homePath, "projects", "drop", "outside-link"));
     const ops = createStateOps({ homePath });
 
     const manifest = await ops.exportWorkspace({ scope: "project", projectSlug: "drop", ownerScope: { type: "user", id: "user_a" } });
-    expect(manifest.files).toContain("projects/drop/config.json");
-    expect(manifest.files).toContain("projects/drop/tasks/task_abc123.json");
-    expect(manifest.files).toContain("projects/drop/previews/prev_abc123.json");
+    expect(manifest.files).toContain("system/projects/drop/config.json");
+    expect(manifest.files).toContain("system/projects/drop/tasks/task_abc123.json");
+    expect(manifest.files).toContain("system/projects/drop/previews/prev_abc123.json");
+    expect(manifest.files).toContain("projects/drop/README.md");
     expect(manifest.files).not.toContain("projects/drop/outside-link/secret.txt");
-    expect(manifest.files).not.toContain("projects/keep/config.json");
+    expect(manifest.files).not.toContain("system/projects/keep/config.json");
 
     await expect(ops.deleteWorkspaceData({
       scope: "project",
@@ -85,12 +91,13 @@ describe("state-ops", () => {
       ownerScope: { type: "user", id: "user_a" },
       confirmation: "delete project workspace data",
     })).resolves.toMatchObject({ ok: true });
-    await expect(stat(join(homePath, "projects", "drop"))).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(readFile(join(homePath, "projects", "keep", "config.json"), "utf-8")).resolves.toContain("keep");
+    await expect(readFile(join(homePath, "projects", "drop", "README.md"), "utf-8")).resolves.toBe("owner workspace");
+    await expect(stat(join(homePath, "system", "projects", "drop"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(join(homePath, "system", "projects", "keep", "config.json"), "utf-8")).resolves.toContain("keep");
   });
 
   it("rejects invalid project slugs before deleting workspace data", async () => {
-    await atomicWriteJson(join(homePath, "projects", "keep", "config.json"), {
+    await atomicWriteJson(join(homePath, "system", "projects", "keep", "config.json"), {
       slug: "keep",
       ownerScope: { type: "user", id: "user_a" },
     });
@@ -105,7 +112,7 @@ describe("state-ops", () => {
       status: 400,
       error: { code: "delete_scope_invalid" },
     });
-    await expect(readFile(join(homePath, "projects", "keep", "config.json"), "utf-8")).resolves.toContain("keep");
+    await expect(readFile(join(homePath, "system", "projects", "keep", "config.json"), "utf-8")).resolves.toContain("keep");
   });
 
   it("exports all owner-scoped workspace data for full backups", async () => {
@@ -113,18 +120,22 @@ describe("state-ops", () => {
       id: "sess_abc123",
       status: "running",
     });
-    await atomicWriteJson(join(homePath, "projects", "owned", "config.json"), {
+    await atomicWriteJson(join(homePath, "system", "projects", "owned", "config.json"), {
       slug: "owned",
+      kind: "folder",
+      localPath: join(homePath, "projects", "owned"),
       ownerScope: { type: "user", id: "user_a" },
     });
-    await atomicWriteJson(join(homePath, "projects", "owned", "tasks", "task_abc123.json"), {
+    await atomicWriteJson(join(homePath, "system", "projects", "owned", "tasks", "task_abc123.json"), {
       id: "task_abc123",
     });
-    await atomicWriteJson(join(homePath, "projects", "other", "config.json"), {
+    await atomicWriteJson(join(homePath, "system", "projects", "other", "config.json"), {
       slug: "other",
+      kind: "folder",
+      localPath: join(homePath, "projects", "other"),
       ownerScope: { type: "user", id: "user_b" },
     });
-    await atomicWriteJson(join(homePath, "projects", "other", "tasks", "task_def456.json"), {
+    await atomicWriteJson(join(homePath, "system", "projects", "other", "tasks", "task_def456.json"), {
       id: "task_def456",
     });
     const ops = createStateOps({ homePath });
@@ -132,9 +143,31 @@ describe("state-ops", () => {
     const manifest = await ops.exportWorkspace({ scope: "all", ownerScope: { type: "user", id: "user_a" } });
 
     expect(manifest.files).toContain("system/sessions/sess_abc123.json");
-    expect(manifest.files).toContain("projects/owned/config.json");
-    expect(manifest.files).toContain("projects/owned/tasks/task_abc123.json");
-    expect(manifest.files).not.toContain("projects/other/config.json");
-    expect(manifest.files).not.toContain("projects/other/tasks/task_def456.json");
+    expect(manifest.files).toContain("system/projects/owned/config.json");
+    expect(manifest.files).toContain("system/projects/owned/tasks/task_abc123.json");
+    expect(manifest.files).not.toContain("system/projects/other/config.json");
+    expect(manifest.files).not.toContain("system/projects/other/tasks/task_def456.json");
+  });
+
+  it("exports an owner workspace outside the projects registry path", async () => {
+    const workspacePath = join(homePath, "workspaces", "external-checkout");
+    await mkdir(workspacePath, { recursive: true });
+    await writeFile(join(workspacePath, "README.md"), "external owner workspace");
+    await atomicWriteJson(join(homePath, "system", "projects", "external", "config.json"), {
+      slug: "external",
+      kind: "folder",
+      localPath: workspacePath,
+      ownerScope: { type: "user", id: "user_a" },
+    });
+    const ops = createStateOps({ homePath });
+
+    const manifest = await ops.exportWorkspace({
+      scope: "project",
+      projectSlug: "external",
+      ownerScope: { type: "user", id: "user_a" },
+    });
+
+    expect(manifest.files).toContain("system/projects/external/config.json");
+    expect(manifest.files).toContain("workspaces/external-checkout/README.md");
   });
 });

--- a/tests/gateway/state-ops.test.ts
+++ b/tests/gateway/state-ops.test.ts
@@ -115,6 +115,33 @@ describe("state-ops", () => {
     await expect(readFile(join(homePath, "system", "projects", "keep", "config.json"), "utf-8")).resolves.toContain("keep");
   });
 
+  it("preserves owner source when deleting a legacy folder record without kind", async () => {
+    const source = join(homePath, "projects", "legacy-folder");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "README.md"), "owner source");
+    await atomicWriteJson(join(homePath, "system", "projects", "legacy-folder", "config.json"), {
+      id: "proj_legacy_folder",
+      name: "Legacy folder",
+      slug: "legacy-folder",
+      localPath: source,
+      addedAt: "2026-04-26T00:00:00.000Z",
+      updatedAt: "2026-04-26T00:00:00.000Z",
+      ownerScope: { type: "user", id: "user_a" },
+    });
+    const ops = createStateOps({ homePath });
+
+    await expect(ops.deleteWorkspaceData({
+      scope: "project",
+      projectSlug: "legacy-folder",
+      ownerScope: { type: "user", id: "user_a" },
+      confirmation: "delete project workspace data",
+    })).resolves.toEqual({ ok: true });
+
+    await expect(readFile(join(source, "README.md"), "utf-8")).resolves.toBe("owner source");
+    await expect(stat(join(homePath, "system", "projects", "legacy-folder")))
+      .rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("exports all owner-scoped workspace data for full backups", async () => {
     await atomicWriteJson(join(homePath, "system", "sessions", "sess_abc123.json"), {
       id: "sess_abc123",
@@ -169,5 +196,37 @@ describe("state-ops", () => {
 
     expect(manifest.files).toContain("system/projects/external/config.json");
     expect(manifest.files).toContain("workspaces/external-checkout/README.md");
+  });
+
+  it("exports legacy Matrix task, preview, and tombstone state before lazy adoption", async () => {
+    const projectRoot = join(homePath, "projects", "legacy-state");
+    const config = {
+      id: "proj_legacy_state",
+      name: "Legacy state",
+      slug: "legacy-state",
+      kind: "scratch",
+      localPath: join(projectRoot, "repo"),
+      addedAt: "2026-04-26T00:00:00.000Z",
+      updatedAt: "2026-04-26T00:00:00.000Z",
+      ownerScope: { type: "user", id: "user_a" },
+    };
+    await atomicWriteJson(join(homePath, "system", "projects", "legacy-state", "config.json"), config);
+    await atomicWriteJson(join(projectRoot, "tasks", "task_legacy123.json"), { id: "task_legacy123" });
+    await atomicWriteJson(join(projectRoot, "previews", "prev_legacy123.json"), { id: "prev_legacy123" });
+    await atomicWriteJson(join(homePath, "projects", ".deleting", "legacy-state.json"), {
+      ...config,
+      deletingAt: "2026-04-27T00:00:00.000Z",
+    });
+    const ops = createStateOps({ homePath });
+
+    const manifest = await ops.exportWorkspace({
+      scope: "project",
+      projectSlug: "legacy-state",
+      ownerScope: { type: "user", id: "user_a" },
+    });
+
+    expect(manifest.files).toContain("projects/legacy-state/tasks/task_legacy123.json");
+    expect(manifest.files).toContain("projects/legacy-state/previews/prev_legacy123.json");
+    expect(manifest.files).toContain("projects/.deleting/legacy-state.json");
   });
 });

--- a/tests/gateway/state-ops.test.ts
+++ b/tests/gateway/state-ops.test.ts
@@ -1,16 +1,41 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdir, mkdtemp, readdir, readFile, stat, symlink, writeFile } from "node:fs/promises";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdir, mkdtemp, readdir, readFile, rename, stat, symlink, writeFile } from "node:fs/promises";
 import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   atomicWriteJson,
   createStateOps,
+  ProjectLockCapacityError,
   readJsonFile,
+  withProjectLock,
 } from "../../packages/gateway/src/state-ops.js";
+import {
+  readBoundedJsonFileWithIdentity,
+  removeFileIfUnchanged,
+} from "../../packages/gateway/src/bounded-json-file.js";
+import { removeValidatedLegacyProjectState } from "../../packages/gateway/src/legacy-project-state.js";
 
 describe("state-ops", () => {
   let homePath: string;
+
+  function projectRecord(
+    slug: string,
+    ownerId = "user_a",
+    overrides: Record<string, unknown> = {},
+  ) {
+    return {
+      id: `proj_${slug}`,
+      name: slug,
+      slug,
+      kind: "folder",
+      localPath: join(homePath, "projects", slug),
+      addedAt: "2026-04-26T00:00:00.000Z",
+      updatedAt: "2026-04-26T00:00:00.000Z",
+      ownerScope: { type: "user", id: ownerId },
+      ...overrides,
+    };
+  }
 
   beforeEach(async () => {
     homePath = await mkdtemp(join(tmpdir(), "matrix-state-ops-"));
@@ -27,6 +52,119 @@ describe("state-ops", () => {
 
     await expect(readJsonFile(target)).resolves.toEqual({ id: "sess_1", ok: true });
     await expect(readdir(join(homePath, "system", "sessions"))).resolves.toEqual(["sess_1.json"]);
+  });
+
+  it("does not delete a file that was replaced after bounded validation", async () => {
+    const target = join(homePath, "legacy.json");
+    const replacement = join(homePath, "replacement.json");
+    await writeFile(target, JSON.stringify({ id: "original" }));
+    const candidate = await readBoundedJsonFileWithIdentity(target, 1024);
+    expect(candidate?.value).toEqual({ id: "original" });
+    await writeFile(replacement, JSON.stringify({ id: "replacement" }));
+    await rename(replacement, target);
+
+    await expect(removeFileIfUnchanged(target, candidate!.identity, {
+      recoveryDir: join(homePath, "system", "recovery", "project-state"),
+    })).resolves.toBe(false);
+    await expect(readFile(target, "utf-8")).resolves.toContain("replacement");
+  });
+
+  it("preserves a replacement published while a validated file is quarantined", async () => {
+    const target = join(homePath, "legacy.json");
+    await writeFile(target, JSON.stringify({ id: "original" }));
+    const candidate = await readBoundedJsonFileWithIdentity(target, 1024);
+    expect(candidate?.value).toEqual({ id: "original" });
+
+    await expect(removeFileIfUnchanged(target, candidate!.identity, {
+      recoveryDir: join(homePath, "system", "recovery", "project-state"),
+      onQuarantined: async () => {
+        await writeFile(target, JSON.stringify({ id: "replacement" }));
+      },
+    })).resolves.toBe(true);
+
+    await expect(readFile(target, "utf-8")).resolves.toContain("replacement");
+  });
+
+  it("moves a raced quarantine out of the owner workspace without deleting either winner", async () => {
+    const target = join(homePath, "legacy.json");
+    const replacement = join(homePath, "replacement.json");
+    const recoveryDir = join(homePath, "system", "recovery", "project-state");
+    await writeFile(target, JSON.stringify({ id: "original" }));
+    const candidate = await readBoundedJsonFileWithIdentity(target, 1024);
+    await writeFile(replacement, JSON.stringify({ id: "replacement" }));
+
+    await expect(removeFileIfUnchanged(target, candidate!.identity, {
+      recoveryDir,
+      onValidatedBeforeQuarantine: async () => {
+        await rename(replacement, target);
+      },
+      onRenamed: async () => {
+        await writeFile(target, JSON.stringify({ id: "winner" }));
+      },
+    })).resolves.toBe(false);
+
+    await expect(readFile(target, "utf-8")).resolves.toContain("winner");
+    await expect(readdir(homePath)).resolves.not.toEqual(expect.arrayContaining([
+      expect.stringContaining(".quarantine"),
+    ]));
+    const recovered = await readdir(recoveryDir);
+    expect(recovered).toHaveLength(1);
+    await expect(readFile(join(recoveryDir, recovered[0]!), "utf-8")).resolves.toContain("replacement");
+  });
+
+  it("keeps concurrent project-state recovery bounded", async () => {
+    const recoveryDir = join(homePath, "system", "recovery", "project-state");
+    const candidates = await Promise.all(Array.from({ length: 105 }, async (_, index) => {
+      const target = join(homePath, `legacy-${index}.json`);
+      const replacement = join(homePath, `replacement-${index}.json`);
+      await writeFile(target, JSON.stringify({ id: `original-${index}` }));
+      const candidate = await readBoundedJsonFileWithIdentity(target, 1024);
+      await writeFile(replacement, JSON.stringify({ id: `replacement-${index}` }));
+      return { target, replacement, candidate: candidate! };
+    }));
+
+    await Promise.all(candidates.map(({ target, replacement, candidate }, index) => (
+      removeFileIfUnchanged(target, candidate.identity, {
+        recoveryDir,
+        onValidatedBeforeQuarantine: async () => rename(replacement, target),
+        onRenamed: async () => writeFile(target, JSON.stringify({ id: `winner-${index}` })),
+      })
+    )));
+
+    await expect(readdir(recoveryDir)).resolves.toHaveLength(100);
+  });
+
+  it("does not delete a legacy task replaced after record validation", async () => {
+    const tasksDir = join(homePath, "projects", "repo", "tasks");
+    const previewsDir = join(homePath, "projects", "repo", "previews");
+    const taskPath = join(tasksDir, "task_owned123.json");
+    const replacementPath = join(homePath, "replacement-task.json");
+    await mkdir(tasksDir, { recursive: true });
+    await mkdir(previewsDir, { recursive: true });
+    await atomicWriteJson(taskPath, {
+      id: "task_owned123",
+      projectSlug: "repo",
+      title: "Owned task",
+      status: "todo",
+      priority: "normal",
+      order: 1,
+      previewIds: [],
+      createdAt: "2026-04-26T00:00:00.000Z",
+      updatedAt: "2026-04-26T00:00:00.000Z",
+    });
+    await writeFile(replacementPath, JSON.stringify({ id: "owner-replacement" }));
+
+    await removeValidatedLegacyProjectState({
+      projectSlug: "repo",
+      tasksDir,
+      previewsDir,
+      recoveryDir: join(homePath, "system", "recovery", "project-state"),
+      onCandidateValidated: async () => {
+        await rename(replacementPath, taskPath);
+      },
+    });
+
+    await expect(readFile(taskPath, "utf-8")).resolves.toContain("owner-replacement");
   });
 
   it("replays clone staging operation logs by deleting abandoned staging directories", async () => {
@@ -48,21 +186,44 @@ describe("state-ops", () => {
     await expect(stat(staged)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("keeps an active same-project lock mutually exclusive at the lock capacity", async () => {
+    const releases: Array<() => void> = [];
+    const entered = new Set<string>();
+    const holders = Array.from({ length: 256 }, (_, index) => {
+      const slug = `capacity-${index}`;
+      return withProjectLock(slug, async () => {
+        entered.add(slug);
+        await new Promise<void>((resolve) => releases.push(resolve));
+      });
+    });
+    await vi.waitFor(() => expect(entered.size).toBe(256));
+
+    await expect(withProjectLock("capacity-overflow", async () => undefined))
+      .rejects.toBeInstanceOf(ProjectLockCapacityError);
+
+    let duplicateEntered = false;
+    const duplicate = withProjectLock("capacity-0", async () => {
+      duplicateEntered = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(duplicateEntered).toBe(false);
+
+    for (const release of releases) release();
+    await Promise.all([...holders, duplicate]);
+    expect(duplicateEntered).toBe(true);
+  });
+
   it("exports and deletes only the requested owner-scoped project data", async () => {
     await mkdir(join(homePath, "projects", "keep"), { recursive: true });
     await mkdir(join(homePath, "projects", "drop"), { recursive: true });
-    await atomicWriteJson(join(homePath, "system", "projects", "keep", "config.json"), {
-      slug: "keep",
-      kind: "folder",
-      localPath: join(homePath, "projects", "keep"),
-      ownerScope: { type: "user", id: "user_a" },
-    });
-    await atomicWriteJson(join(homePath, "system", "projects", "drop", "config.json"), {
-      slug: "drop",
-      kind: "folder",
-      localPath: join(homePath, "projects", "drop"),
-      ownerScope: { type: "user", id: "user_a" },
-    });
+    await atomicWriteJson(
+      join(homePath, "system", "projects", "keep", "config.json"),
+      projectRecord("keep"),
+    );
+    await atomicWriteJson(
+      join(homePath, "system", "projects", "drop", "config.json"),
+      projectRecord("drop"),
+    );
     await atomicWriteJson(join(homePath, "system", "projects", "drop", "tasks", "task_abc123.json"), {
       id: "task_abc123",
       title: "Exported task",
@@ -142,26 +303,188 @@ describe("state-ops", () => {
       .rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("removes validated legacy Matrix state while preserving arbitrary owner files", async () => {
+    const source = join(homePath, "projects", "legacy-state-delete");
+    const tasksDir = join(source, "tasks");
+    const previewsDir = join(source, "previews");
+    await mkdir(tasksDir, { recursive: true });
+    await mkdir(previewsDir, { recursive: true });
+    await writeFile(join(tasksDir, "README.md"), "owner notes");
+    await atomicWriteJson(join(tasksDir, "task_unknown123.json"), {
+      id: "task_unknown123",
+      projectSlug: "legacy-state-delete",
+      title: "missing required Matrix fields",
+    });
+    await atomicWriteJson(join(tasksDir, "task_other123.json"), {
+      id: "task_other123",
+      projectSlug: "another-project",
+      title: "Other project",
+      status: "todo",
+      priority: "normal",
+      order: 0,
+      previewIds: [],
+      createdAt: "2026-08-18T00:00:00.000Z",
+      updatedAt: "2026-08-18T00:00:00.000Z",
+    });
+    const taskPath = join(tasksDir, "task_owned123.json");
+    await atomicWriteJson(taskPath, {
+      id: "task_owned123",
+      projectSlug: "legacy-state-delete",
+      title: "Owned task",
+      status: "todo",
+      priority: "normal",
+      order: 0,
+      previewIds: [],
+      createdAt: "2026-08-18T00:00:00.000Z",
+      updatedAt: "2026-08-18T00:00:00.000Z",
+    });
+    const previewPath = join(previewsDir, "prev_owned123.json");
+    await atomicWriteJson(previewPath, {
+      id: "prev_owned123",
+      projectSlug: "legacy-state-delete",
+      label: "Owned preview",
+      url: "http://localhost:3000",
+      lastStatus: "unknown",
+      displayPreference: "panel",
+      createdAt: "2026-08-18T00:00:00.000Z",
+      updatedAt: "2026-08-18T00:00:00.000Z",
+    });
+    await atomicWriteJson(
+      join(homePath, "system", "projects", "legacy-state-delete", "config.json"),
+      projectRecord("legacy-state-delete"),
+    );
+    const ops = createStateOps({ homePath });
+
+    await expect(ops.deleteWorkspaceData({
+      scope: "project",
+      projectSlug: "legacy-state-delete",
+      ownerScope: { type: "user", id: "user_a" },
+      confirmation: "delete project workspace data",
+    })).resolves.toEqual({ ok: true });
+
+    await expect(stat(taskPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(previewPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(join(tasksDir, "README.md"), "utf-8")).resolves.toBe("owner notes");
+    await expect(stat(join(tasksDir, "task_unknown123.json"))).resolves.toMatchObject({ isFile: expect.any(Function) });
+    await expect(stat(join(tasksDir, "task_other123.json"))).resolves.toMatchObject({ isFile: expect.any(Function) });
+  });
+
+  it("refuses to delete owner source from an invalid project registry record", async () => {
+    const source = join(homePath, "projects", "malformed");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "README.md"), "owner source");
+    await atomicWriteJson(join(homePath, "system", "projects", "malformed", "config.json"), {
+      id: "proj_malformed",
+      name: "Malformed",
+      slug: "different-slug",
+      kind: "github",
+      localPath: source,
+      addedAt: "2026-04-26T00:00:00.000Z",
+      updatedAt: "2026-04-26T00:00:00.000Z",
+      ownerScope: { type: "user", id: "user_a" },
+    });
+    const ops = createStateOps({ homePath });
+
+    await expect(ops.deleteWorkspaceData({
+      scope: "project",
+      projectSlug: "malformed",
+      ownerScope: { type: "user", id: "user_a" },
+      confirmation: "delete project workspace data",
+    })).resolves.toMatchObject({
+      ok: false,
+      status: 404,
+      error: { code: "not_found" },
+    });
+    await expect(readFile(join(source, "README.md"), "utf-8")).resolves.toBe("owner source");
+  });
+
+  it("preserves a same-slug owner folder when managed kind and local path disagree", async () => {
+    const ownerFolder = join(homePath, "projects", "mismatched");
+    const recordedSource = join(homePath, "projects", "elsewhere", "repo");
+    await mkdir(ownerFolder, { recursive: true });
+    await mkdir(recordedSource, { recursive: true });
+    await writeFile(join(ownerFolder, "keep.txt"), "owner source");
+    await atomicWriteJson(
+      join(homePath, "system", "projects", "mismatched", "config.json"),
+      projectRecord("mismatched", "user_a", {
+        kind: "github",
+        localPath: recordedSource,
+      }),
+    );
+    const ops = createStateOps({ homePath });
+
+    await expect(ops.deleteWorkspaceData({
+      scope: "project",
+      projectSlug: "mismatched",
+      ownerScope: { type: "user", id: "user_a" },
+      confirmation: "delete project workspace data",
+    })).resolves.toEqual({ ok: true });
+
+    await expect(readFile(join(ownerFolder, "keep.txt"), "utf-8")).resolves.toBe("owner source");
+    await expect(stat(join(homePath, "system", "projects", "mismatched")))
+      .rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("removes the owner-scoped project tombstone with its registry config", async () => {
+    const record = projectRecord("delete-with-tombstone");
+    await atomicWriteJson(
+      join(homePath, "system", "projects", "delete-with-tombstone", "config.json"),
+      record,
+    );
+    const tombstonePath = join(
+      homePath,
+      "system",
+      "projects",
+      ".deleting",
+      "delete-with-tombstone.json",
+    );
+    await atomicWriteJson(tombstonePath, { ...record, deletingAt: "2026-04-27T00:00:00.000Z" });
+    const ops = createStateOps({ homePath });
+
+    await expect(ops.deleteWorkspaceData({
+      scope: "project",
+      projectSlug: "delete-with-tombstone",
+      ownerScope: { type: "user", id: "user_a" },
+      confirmation: "delete project workspace data",
+    })).resolves.toEqual({ ok: true });
+
+    await expect(stat(tombstonePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("removes an owner-scoped tombstone when the project config is already gone", async () => {
+    const tombstonePath = join(homePath, "system", "projects", ".deleting", "tombstone-delete.json");
+    await atomicWriteJson(tombstonePath, {
+      ...projectRecord("tombstone-delete"),
+      deletingAt: "2026-04-27T00:00:00.000Z",
+    });
+    const ops = createStateOps({ homePath });
+
+    await expect(ops.deleteWorkspaceData({
+      scope: "project",
+      projectSlug: "tombstone-delete",
+      ownerScope: { type: "user", id: "user_a" },
+      confirmation: "delete project workspace data",
+    })).resolves.toEqual({ ok: true });
+
+    await expect(stat(tombstonePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("exports all owner-scoped workspace data for full backups", async () => {
     await atomicWriteJson(join(homePath, "system", "sessions", "sess_abc123.json"), {
       id: "sess_abc123",
       status: "running",
     });
-    await atomicWriteJson(join(homePath, "system", "projects", "owned", "config.json"), {
-      slug: "owned",
-      kind: "folder",
-      localPath: join(homePath, "projects", "owned"),
-      ownerScope: { type: "user", id: "user_a" },
-    });
+    await atomicWriteJson(
+      join(homePath, "system", "projects", "owned", "config.json"),
+      projectRecord("owned"),
+    );
     await atomicWriteJson(join(homePath, "system", "projects", "owned", "tasks", "task_abc123.json"), {
       id: "task_abc123",
     });
-    await atomicWriteJson(join(homePath, "system", "projects", "other", "config.json"), {
-      slug: "other",
-      kind: "folder",
-      localPath: join(homePath, "projects", "other"),
-      ownerScope: { type: "user", id: "user_b" },
-    });
+    await atomicWriteJson(
+      join(homePath, "system", "projects", "other", "config.json"),
+      projectRecord("other", "user_b"),
+    );
     await atomicWriteJson(join(homePath, "system", "projects", "other", "tasks", "task_def456.json"), {
       id: "task_def456",
     });
@@ -180,12 +503,10 @@ describe("state-ops", () => {
     const workspacePath = join(homePath, "workspaces", "external-checkout");
     await mkdir(workspacePath, { recursive: true });
     await writeFile(join(workspacePath, "README.md"), "external owner workspace");
-    await atomicWriteJson(join(homePath, "system", "projects", "external", "config.json"), {
-      slug: "external",
-      kind: "folder",
-      localPath: workspacePath,
-      ownerScope: { type: "user", id: "user_a" },
-    });
+    await atomicWriteJson(
+      join(homePath, "system", "projects", "external", "config.json"),
+      projectRecord("external", "user_a", { localPath: workspacePath }),
+    );
     const ops = createStateOps({ homePath });
 
     const manifest = await ops.exportWorkspace({
@@ -211,8 +532,27 @@ describe("state-ops", () => {
       ownerScope: { type: "user", id: "user_a" },
     };
     await atomicWriteJson(join(homePath, "system", "projects", "legacy-state", "config.json"), config);
-    await atomicWriteJson(join(projectRoot, "tasks", "task_legacy123.json"), { id: "task_legacy123" });
-    await atomicWriteJson(join(projectRoot, "previews", "prev_legacy123.json"), { id: "prev_legacy123" });
+    await atomicWriteJson(join(projectRoot, "tasks", "task_legacy123.json"), {
+      id: "task_legacy123",
+      projectSlug: "legacy-state",
+      title: "Legacy task",
+      status: "todo",
+      priority: "normal",
+      order: 0,
+      previewIds: [],
+      createdAt: "2026-04-26T00:00:00.000Z",
+      updatedAt: "2026-04-26T00:00:00.000Z",
+    });
+    await atomicWriteJson(join(projectRoot, "previews", "prev_legacy123.json"), {
+      id: "prev_legacy123",
+      projectSlug: "legacy-state",
+      label: "Legacy preview",
+      url: "http://localhost:3000",
+      lastStatus: "unknown",
+      displayPreference: "panel",
+      createdAt: "2026-04-26T00:00:00.000Z",
+      updatedAt: "2026-04-26T00:00:00.000Z",
+    });
     await atomicWriteJson(join(homePath, "projects", ".deleting", "legacy-state.json"), {
       ...config,
       deletingAt: "2026-04-27T00:00:00.000Z",
@@ -227,6 +567,68 @@ describe("state-ops", () => {
 
     expect(manifest.files).toContain("projects/legacy-state/tasks/task_legacy123.json");
     expect(manifest.files).toContain("projects/legacy-state/previews/prev_legacy123.json");
-    expect(manifest.files).toContain("projects/.deleting/legacy-state.json");
+    expect(manifest.files).toContain("system/projects/.deleting/legacy-state.json");
+  });
+
+  it("exports validated legacy Matrix state for a folder project with an external workspace", async () => {
+    const workspace = join(homePath, "workspaces", "external-folder");
+    await mkdir(workspace, { recursive: true });
+    await writeFile(join(workspace, "README.md"), "owner workspace");
+    await atomicWriteJson(
+      join(homePath, "system", "projects", "external-folder", "config.json"),
+      projectRecord("external-folder", "user_a", { kind: "folder", localPath: workspace }),
+    );
+    await atomicWriteJson(
+      join(homePath, "projects", "external-folder", "tasks", "task_external123.json"),
+      {
+        id: "task_external123",
+        projectSlug: "external-folder",
+        title: "External task",
+        status: "todo",
+        priority: "normal",
+        order: 0,
+        previewIds: [],
+        createdAt: "2026-04-26T00:00:00.000Z",
+        updatedAt: "2026-04-26T00:00:00.000Z",
+      },
+    );
+    const ops = createStateOps({ homePath });
+
+    const manifest = await ops.exportWorkspace({
+      scope: "project",
+      projectSlug: "external-folder",
+      ownerScope: { type: "user", id: "user_a" },
+    });
+
+    expect(manifest.files).toContain("projects/external-folder/tasks/task_external123.json");
+    expect(manifest.files).toContain("workspaces/external-folder/README.md");
+  });
+
+  it.each([
+    ["canonical", "system/projects/.deleting/tombstone-only.json"],
+    ["legacy", "projects/.deleting/tombstone-only.json"],
+  ])("exports a %s deletion tombstone even when the project config is gone", async (_source, tombstoneFile) => {
+    const source = join(homePath, "projects", "tombstone-only");
+    const tombstone = {
+      id: "proj_tombstone_only",
+      name: "Tombstone only",
+      slug: "tombstone-only",
+      kind: "folder",
+      localPath: source,
+      addedAt: "2026-04-26T00:00:00.000Z",
+      updatedAt: "2026-04-26T00:00:00.000Z",
+      deletingAt: "2026-04-27T00:00:00.000Z",
+      ownerScope: { type: "user", id: "user_a" },
+    };
+    await atomicWriteJson(join(homePath, tombstoneFile), tombstone);
+    const ops = createStateOps({ homePath });
+
+    const manifest = await ops.exportWorkspace({
+      scope: "project",
+      projectSlug: "tombstone-only",
+      ownerScope: { type: "user", id: "user_a" },
+    });
+
+    expect(manifest.files).toContain("system/projects/.deleting/tombstone-only.json");
   });
 });

--- a/tests/gateway/task-manager.test.ts
+++ b/tests/gateway/task-manager.test.ts
@@ -16,6 +16,8 @@ describe("task-manager", () => {
       slug: "repo",
       name: "repo",
       localPath: join(homePath, "projects", "repo"),
+      addedAt: "2026-04-26T00:00:00.000Z",
+      updatedAt: "2026-04-26T00:00:00.000Z",
       ownerScope: { type: "user", id: "user_a" },
     });
   });
@@ -114,5 +116,42 @@ describe("task-manager", () => {
     if (!created.ok) return;
 
     await expect(readFile(join(homePath, "system", "projects", "repo", "tasks", `${created.task.id}.json`), "utf-8")).resolves.toContain("Export me");
+  });
+
+  it("keeps legacy project tasks readable and adopts valid records into the registry", async () => {
+    const legacy = {
+      id: "task_legacy123",
+      projectSlug: "repo",
+      title: "Legacy task",
+      status: "todo",
+      priority: "normal",
+      order: 0,
+      previewIds: [],
+      createdAt: "2026-04-25T00:00:00.000Z",
+      updatedAt: "2026-04-25T00:00:00.000Z",
+    };
+    await atomicWriteJson(join(homePath, "projects", "repo", "tasks", `${legacy.id}.json`), legacy);
+    const manager = createTaskManager({ homePath });
+
+    await expect(manager.listTasks("repo", { includeArchived: true })).resolves.toMatchObject({
+      ok: true,
+      tasks: [expect.objectContaining({ id: legacy.id, title: "Legacy task" })],
+    });
+    await expect(readFile(
+      join(homePath, "system", "projects", "repo", "tasks", `${legacy.id}.json`),
+      "utf-8",
+    )).resolves.toContain("Legacy task");
+    await expect(manager.deleteTask("repo", legacy.id)).resolves.toEqual({ ok: true });
+    await expect(manager.listTasks("repo", { includeArchived: true })).resolves.toMatchObject({ tasks: [] });
+  });
+
+  it("rejects task mutations from a different owner scope", async () => {
+    const manager = createTaskManager({ homePath });
+
+    await expect(manager.createTask(
+      "repo",
+      { title: "Do not create" },
+      { type: "user", id: "user_b" },
+    )).resolves.toMatchObject({ ok: false, status: 404, error: { code: "not_found" } });
   });
 });

--- a/tests/gateway/task-manager.test.ts
+++ b/tests/gateway/task-manager.test.ts
@@ -11,9 +11,11 @@ describe("task-manager", () => {
 
   beforeEach(async () => {
     homePath = await mkdtemp(join(tmpdir(), "matrix-task-manager-"));
-    await atomicWriteJson(join(homePath, "projects", "repo", "config.json"), {
+    await atomicWriteJson(join(homePath, "system", "projects", "repo", "config.json"), {
+      id: "proj_repo",
       slug: "repo",
       name: "repo",
+      localPath: join(homePath, "projects", "repo"),
       ownerScope: { type: "user", id: "user_a" },
     });
   });
@@ -81,7 +83,7 @@ describe("task-manager", () => {
       tasks: [expect.objectContaining({ title: "Review previews" })],
     });
     await expect(manager.deleteTask("repo", first.task.id)).resolves.toMatchObject({ ok: true });
-    await expect(stat(join(homePath, "projects", "repo", "tasks", `${first.task.id}.json`))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(join(homePath, "system", "projects", "repo", "tasks", `${first.task.id}.json`))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("validates project and task identifiers before filesystem access", async () => {
@@ -111,6 +113,6 @@ describe("task-manager", () => {
     expect(created.ok).toBe(true);
     if (!created.ok) return;
 
-    await expect(readFile(join(homePath, "projects", "repo", "tasks", `${created.task.id}.json`), "utf-8")).resolves.toContain("Export me");
+    await expect(readFile(join(homePath, "system", "projects", "repo", "tasks", `${created.task.id}.json`), "utf-8")).resolves.toContain("Export me");
   });
 });

--- a/tests/gateway/task-manager.test.ts
+++ b/tests/gateway/task-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, readFile, stat } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -145,6 +145,22 @@ describe("task-manager", () => {
     await expect(manager.listTasks("repo", { includeArchived: true })).resolves.toMatchObject({ tasks: [] });
   });
 
+  it("preserves an unvalidated owner file that collides with a canonical task id", async () => {
+    const manager = createTaskManager({ homePath });
+    const created = await manager.createTask("repo", { title: "Canonical task" });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    const ownerFile = join(homePath, "projects", "repo", "tasks", `${created.task.id}.json`);
+    await atomicWriteJson(ownerFile, { ownerNote: "keep me" });
+
+    await expect(manager.deleteTask("repo", created.task.id)).resolves.toEqual({ ok: true });
+    await expect(readFile(ownerFile, "utf-8")).resolves.toContain("keep me");
+    await expect(stat(
+      join(homePath, "system", "projects", "repo", "tasks", `${created.task.id}.json`),
+    )).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("rejects task mutations from a different owner scope", async () => {
     const manager = createTaskManager({ homePath });
 
@@ -153,5 +169,20 @@ describe("task-manager", () => {
       { title: "Do not create" },
       { type: "user", id: "user_b" },
     )).resolves.toMatchObject({ ok: false, status: 404, error: { code: "not_found" } });
+  });
+
+  it("fails safely when task identifier discovery exceeds its memory bound", async () => {
+    const directory = join(homePath, "system", "projects", "repo", "tasks");
+    await mkdir(directory, { recursive: true });
+    await Promise.all(Array.from({ length: 513 }, (_, index) => (
+      writeFile(join(directory, `task_untrusted_${index}.json`), "{}", "utf-8")
+    )));
+    const manager = createTaskManager({ homePath });
+
+    await expect(manager.listTasks("repo", { includeArchived: true })).resolves.toMatchObject({
+      ok: false,
+      status: 409,
+      error: { code: "task_limit_exceeded" },
+    });
   });
 });

--- a/tests/gateway/terminal-git-context.test.ts
+++ b/tests/gateway/terminal-git-context.test.ts
@@ -25,10 +25,13 @@ describe("terminal Git context", () => {
     await mkdir(join(worktreePath, ".matrix"), { recursive: true });
     await mkdir(join(homePath, "system", "sessions"), { recursive: true });
     await writeFile(join(projectRoot, "config.json"), JSON.stringify({
-      id: "project_matrix",
+      id: "proj_matrix",
       name: "Matrix OS",
       slug: "matrix-os",
       localPath: join(projectRoot, "repo"),
+      addedAt: "2026-07-19T09:00:00.000Z",
+      updatedAt: "2026-07-19T09:00:00.000Z",
+      ownerScope: { type: "user", id: "local" },
       github: {
         owner: "HamedMP",
         repo: "matrix-os",

--- a/tests/gateway/workspace-routes.test.ts
+++ b/tests/gateway/workspace-routes.test.ts
@@ -218,6 +218,7 @@ describe("workspace API routes", () => {
       projectSlug: "repo",
       worktreeId: "wt_abc123def456",
       confirmDirtyDelete: undefined,
+      ownerScope: { type: "user", id: "default" },
     });
   });
 
@@ -235,6 +236,7 @@ describe("workspace API routes", () => {
       projectSlug: "repo",
       worktreeId: "wt_abc123def456",
       confirmDirtyDelete: undefined,
+      ownerScope: { type: "user", id: "default" },
     });
   });
 
@@ -281,7 +283,12 @@ describe("workspace API routes", () => {
     expect(projectManager.listManagedProjects).toHaveBeenCalled();
     const res = await app.request(jsonRequest("/api/projects/repo/worktrees", { branch: "main" }));
     expect(res.status).toBe(201);
-    expect(worktreeManager.createWorktree).toHaveBeenCalledWith({ projectSlug: "repo", branch: "main" });
+    expect(worktreeManager.createWorktree).toHaveBeenCalledWith({
+      projectSlug: "repo",
+      branch: "main",
+      pr: undefined,
+      ownerScope: { type: "user", id: "default" },
+    });
   });
 
   it("derives project owner scope from the injected principal owner scope", async () => {
@@ -681,7 +688,11 @@ exit 1
 
     const createdTask = await app.request(jsonRequest("/api/projects/repo/tasks", { title: "Fix auth", priority: "high" }));
     expect(createdTask.status).toBe(201);
-    expect(taskManager.createTask).toHaveBeenCalledWith("repo", { title: "Fix auth", priority: "high" });
+    expect(taskManager.createTask).toHaveBeenCalledWith(
+      "repo",
+      { title: "Fix auth", priority: "high" },
+      { type: "user", id: "default" },
+    );
     expect(eventStore.publishEvent).toHaveBeenCalledWith(expect.objectContaining({ type: "task.created" }));
     await expect((await app.request("/api/projects/repo/tasks?includeArchived=true")).json()).resolves.toMatchObject({
       tasks: [expect.objectContaining({ id: "task_abc123" })],
@@ -697,7 +708,11 @@ exit 1
       url: "http://localhost:3000",
     }));
     expect(createdPreview.status).toBe(201);
-    expect(previewManager.createPreview).toHaveBeenCalledWith("repo", expect.objectContaining({ url: "http://localhost:3000" }));
+    expect(previewManager.createPreview).toHaveBeenCalledWith(
+      "repo",
+      expect.objectContaining({ url: "http://localhost:3000" }),
+      { type: "user", id: "default" },
+    );
     await expect((await app.request("/api/projects/repo/previews?taskId=task_abc123")).json()).resolves.toMatchObject({
       previews: [expect.objectContaining({ id: "prev_abc123" })],
     });

--- a/tests/gateway/workspace-routes.test.ts
+++ b/tests/gateway/workspace-routes.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createWorkspaceRoutes } from "../../packages/gateway/src/workspace-routes.js";
 import { MissingRequestPrincipalError } from "../../packages/gateway/src/request-principal.js";
+import { atomicWriteJson } from "../../packages/gateway/src/state-ops.js";
 import { createZellijRuntime } from "../../packages/gateway/src/zellij-runtime.js";
 
 function jsonRequest(path: string, body: unknown): Request {
@@ -204,6 +205,64 @@ describe("workspace API routes", () => {
     expect(invalid.status).toBe(400);
   });
 
+  it("owner-scopes project detail, pull-request, and branch reads", async () => {
+    const ownerScope = { type: "user" as const, id: "user_workspace" };
+    const getProject = vi.fn(async () => ({ ok: true as const, project: { slug: "repo" } }));
+    const listPullRequests = vi.fn(async () => ({ ok: true as const, prs: [], refreshedAt: "2026-08-18T00:00:00.000Z" }));
+    const listBranches = vi.fn(async () => ({ ok: true as const, branches: [], refreshedAt: "2026-08-18T00:00:00.000Z" }));
+    const projectManager = {
+      getGithubStatus: vi.fn(),
+      createProject: vi.fn(),
+      listManagedProjects: vi.fn(),
+      getProject,
+      deleteProject: vi.fn(),
+      listPullRequests,
+      listBranches,
+    };
+    const app = createWorkspaceRoutes({ homePath, projectManager, getOwnerScope: () => ownerScope });
+
+    expect((await app.request("/api/projects/repo")).status).toBe(200);
+    expect((await app.request("/api/projects/repo/prs")).status).toBe(200);
+    expect((await app.request("/api/projects/repo/branches")).status).toBe(200);
+
+    expect(getProject).toHaveBeenCalledWith("repo", ownerScope);
+    expect(listPullRequests).toHaveBeenCalledWith("repo", ownerScope);
+    expect(listBranches).toHaveBeenCalledWith("repo", ownerScope);
+  });
+
+  it("rejects commit reads before touching git when the principal does not own the project", async () => {
+    const getProject = vi.fn(async () => ({
+      ok: false as const,
+      status: 404,
+      error: { code: "not_found", message: "Project was not found" },
+    }));
+    const listCommits = vi.fn();
+    const getCommitDiff = vi.fn();
+    const projectManager = {
+      getGithubStatus: vi.fn(),
+      createProject: vi.fn(),
+      listManagedProjects: vi.fn(),
+      getProject,
+      deleteProject: vi.fn(),
+      listPullRequests: vi.fn(),
+      listBranches: vi.fn(),
+    };
+    const app = createWorkspaceRoutes({
+      homePath,
+      projectManager,
+      gitLog: { listCommits, getCommitDiff },
+      getOwnerScope: () => ({ type: "user", id: "user_a" }),
+    });
+
+    const commits = await app.request("/api/projects/repo/commits");
+    const diff = await app.request("/api/projects/repo/commits/abcdef1/diff");
+
+    expect(commits.status).toBe(404);
+    expect(diff.status).toBe(404);
+    expect(listCommits).not.toHaveBeenCalled();
+    expect(getCommitDiff).not.toHaveBeenCalled();
+  });
+
   it("allows bodyless worktree deletes even when clients send JSON headers", async () => {
     const worktreeManager = {
       createWorktree: vi.fn(),
@@ -252,6 +311,46 @@ describe("workspace API routes", () => {
 
     expect(res.status).toBe(400);
     await expect(stat(join(homePath, "projects", "keep"))).resolves.toMatchObject({ isDirectory: expect.any(Function) });
+  });
+
+  it("derives workspace export and delete ownership from the authenticated principal", async () => {
+    const source = join(homePath, "projects", "repo");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "README.md"), "owner workspace");
+    await atomicWriteJson(join(homePath, "system", "projects", "repo", "config.json"), {
+      id: "proj_repo",
+      name: "Repo",
+      slug: "repo",
+      kind: "folder",
+      localPath: source,
+      addedAt: "2026-08-18T00:00:00.000Z",
+      updatedAt: "2026-08-18T00:00:00.000Z",
+      ownerScope: { type: "user", id: "owner_from_principal" },
+    });
+    const app = createWorkspaceRoutes({
+      homePath,
+      getOwnerScope: () => ({ type: "user", id: "owner_from_principal" }),
+    });
+
+    const exported = await app.request(jsonRequest("/api/workspace/export", {
+      scope: "project",
+      projectSlug: "repo",
+      ownerScope: { type: "user", id: "attacker" },
+    }));
+    const deleted = await app.request(deleteJsonRequest("/api/workspace/data", {
+      scope: "project",
+      projectSlug: "repo",
+      confirmation: "delete project workspace data",
+      ownerScope: { type: "user", id: "attacker" },
+    }));
+
+    expect(exported.status).toBe(202);
+    await expect(exported.json()).resolves.toMatchObject({
+      export: { files: expect.arrayContaining(["system/projects/repo/config.json"]) },
+    });
+    expect(deleted.status).toBe(200);
+    await expect(stat(join(homePath, "system", "projects", "repo"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(join(source, "README.md"))).resolves.toMatchObject({ isFile: expect.any(Function) });
   });
 
   it("routes GitHub status and worktree creation through injected managers", async () => {

--- a/tests/gateway/workspace-session-orchestrator.test.ts
+++ b/tests/gateway/workspace-session-orchestrator.test.ts
@@ -88,7 +88,10 @@ describe("workspace session orchestrator", () => {
     });
 
     expect(result).toMatchObject({ ok: true, status: 201, session: { id: "sess_fixed" } });
-    expect(d.worktreeManager.listWorktrees).toHaveBeenCalledWith("repo");
+    expect(d.worktreeManager.listWorktrees).toHaveBeenCalledWith("repo", {
+      type: "user",
+      id: "user_workspace",
+    });
     expect(d.agentSandbox.preflight).toHaveBeenCalledWith({
       agent: "codex",
       sessionId: "sess_fixed",
@@ -163,6 +166,32 @@ describe("workspace session orchestrator", () => {
     });
 
     expect(result).toMatchObject({ ok: false, status: 404 });
+    expect(d.agentSandbox.preflight).not.toHaveBeenCalled();
+    expect(d.agentSessionManager.startSession).not.toHaveBeenCalled();
+  });
+
+  it("rejects a requested worktree when its project owner does not match", async () => {
+    const listWorktrees = vi.fn(async (
+      _projectSlug: string,
+      ownerScope?: { type: "user" | "org"; id: string },
+    ) => ownerScope?.id === "owner_a"
+      ? { ok: true as const, worktrees: [worktree] }
+      : { ok: false as const, status: 404, error: { code: "not_found", message: "Project was not found" } });
+    const d = deps({ worktreeManager: { listWorktrees } });
+    const orchestrator = createWorkspaceSessionOrchestrator({ ...d });
+
+    const result = await orchestrator.startSession({
+      ownerScope: { type: "user", id: "owner_b" },
+      request: {
+        projectSlug: "repo",
+        worktreeId: worktree.id,
+        kind: "agent",
+        agent: "codex",
+      },
+    });
+
+    expect(result).toMatchObject({ ok: false, status: 404 });
+    expect(listWorktrees).toHaveBeenCalledWith("repo", { type: "user", id: "owner_b" });
     expect(d.agentSandbox.preflight).not.toHaveBeenCalled();
     expect(d.agentSessionManager.startSession).not.toHaveBeenCalled();
   });

--- a/tests/gateway/worktree-manager.test.ts
+++ b/tests/gateway/worktree-manager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -148,6 +149,37 @@ describe("worktree-manager", () => {
     });
   });
 
+  it("rejects malformed canonical worktree metadata", async () => {
+    const manager = createWorktreeManager({ homePath, runCommand: successfulRunCommand() });
+    const created = await manager.createWorktree({ projectSlug: "repo", branch: "main" });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    const metadataPath = join(
+      homePath,
+      "system",
+      "projects",
+      "repo",
+      "worktrees",
+      created.worktree.id,
+      "worktree.json",
+    );
+    await atomicWriteJson(metadataPath, {
+      id: created.worktree.id,
+      projectSlug: "repo",
+      path: created.worktree.path,
+      sourceBranch: "main",
+      currentBranch: "main",
+      dirtyState: "not-a-real-state",
+      createdAt: "2026-04-26T00:00:00.000Z",
+    });
+
+    await expect(manager.getWorktree("repo", created.worktree.id)).resolves.toMatchObject({
+      ok: false,
+      status: 404,
+      error: { code: "not_found" },
+    });
+  });
+
   it("serializes concurrent creation for the same worktree", async () => {
     const runCommand = successfulRunCommand();
     const manager = createWorktreeManager({ homePath, runCommand });
@@ -161,6 +193,26 @@ describe("worktree-manager", () => {
     expect(results.filter((result) => result.ok && result.status === 200)).toHaveLength(1);
     expect(runCommand).toHaveBeenCalledTimes(1);
     expect(runCommand).toHaveBeenCalledWith("git", ["worktree", "add", "--", expect.any(String), "feature/concurrent"], expect.any(Object));
+  });
+
+  it("preserves a pre-existing worktree directory when metadata is missing", async () => {
+    const branch = "feature/recovery";
+    const id = `wt_${createHash("sha256").update(`repo:${branch}`).digest("hex").slice(0, 16)}`;
+    const existingPath = join(homePath, "worktrees", "repo", id);
+    await mkdir(existingPath, { recursive: true });
+    await writeFile(join(existingPath, "UNCOMMITTED.txt"), "owner changes");
+    const runCommand = vi.fn(async () => {
+      throw new Error("destination already exists");
+    });
+    const manager = createWorktreeManager({ homePath, runCommand });
+
+    await expect(manager.createWorktree({ projectSlug: "repo", branch })).resolves.toMatchObject({
+      ok: false,
+      status: 409,
+      error: { code: "worktree_path_conflict" },
+    });
+    await expect(readFile(join(existingPath, "UNCOMMITTED.txt"), "utf-8")).resolves.toBe("owner changes");
+    expect(runCommand).not.toHaveBeenCalled();
   });
 
   it("rejects invalid refs before invoking git", async () => {
@@ -209,6 +261,87 @@ describe("worktree-manager", () => {
       worktreeId: created.worktree.id,
       holderId: "sess_1",
     })).resolves.toMatchObject({ ok: true });
+  });
+
+  it("ignores malformed lease metadata so it cannot block a worktree forever", async () => {
+    const manager = createWorktreeManager({
+      homePath,
+      runCommand: successfulRunCommand(),
+      now: () => "2026-04-26T01:00:00.000Z",
+    });
+    const created = await manager.createWorktree({ projectSlug: "repo", branch: "lease-validation" });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    const leasePath = join(
+      homePath,
+      "system",
+      "projects",
+      "repo",
+      "worktrees",
+      created.worktree.id,
+      "lease.json",
+    );
+    await atomicWriteJson(leasePath, {
+      id: "lease_00000000-0000-4000-8000-000000000000",
+      projectSlug: "repo",
+      worktreeId: created.worktree.id,
+      holderType: "session",
+      holderId: "sess_stuck",
+      mode: "write",
+      acquiredAt: "2026-04-26T00:00:00.000Z",
+      heartbeatAt: "not-a-timestamp",
+    });
+
+    await expect(manager.listActiveLeases("repo")).resolves.toEqual({ ok: true, leases: [] });
+    await expect(stat(leasePath)).resolves.toMatchObject({ isFile: expect.any(Function) });
+    await expect(manager.acquireLease({
+      projectSlug: "repo",
+      worktreeId: created.worktree.id,
+      holderType: "session",
+      holderId: "sess_recovered",
+    })).resolves.toMatchObject({ ok: true, lease: { holderId: "sess_recovered" } });
+    await expect(manager.listActiveLeases("repo")).resolves.toMatchObject({
+      ok: true,
+      leases: [{ holderId: "sess_recovered" }],
+    });
+  });
+
+  it("discards oversized lease metadata without parsing it during recovery", async () => {
+    const manager = createWorktreeManager({
+      homePath,
+      runCommand: successfulRunCommand(),
+      now: () => "2026-04-26T01:00:00.000Z",
+    });
+    const created = await manager.createWorktree({ projectSlug: "repo", branch: "oversized-lease" });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    const leasePath = join(
+      homePath,
+      "system",
+      "projects",
+      "repo",
+      "worktrees",
+      created.worktree.id,
+      "lease.json",
+    );
+    await writeFile(leasePath, JSON.stringify({
+      id: "lease_00000000-0000-4000-8000-000000000000",
+      projectSlug: "repo",
+      worktreeId: created.worktree.id,
+      holderType: "session",
+      holderId: "sess_oversized",
+      mode: "write",
+      acquiredAt: "2026-04-26T00:00:00.000Z",
+      heartbeatAt: "2026-04-26T01:00:00.000Z",
+      padding: "x".repeat(300 * 1024),
+    }));
+
+    await expect(manager.acquireLease({
+      projectSlug: "repo",
+      worktreeId: created.worktree.id,
+      holderType: "session",
+      holderId: "sess_recovered",
+    })).resolves.toMatchObject({ ok: true, lease: { holderId: "sess_recovered" } });
   });
 
   it("allows only one concurrent writer to acquire a new worktree lease", async () => {

--- a/tests/gateway/worktree-manager.test.ts
+++ b/tests/gateway/worktree-manager.test.ts
@@ -9,6 +9,20 @@ import { createWorktreeManager } from "../../packages/gateway/src/worktree-manag
 describe("worktree-manager", () => {
   let homePath: string;
 
+  async function materializeAddedWorktree(args: string[]): Promise<void> {
+    if (args[0] !== "worktree" || args[1] !== "add") return;
+    const separator = args.indexOf("--");
+    const path = separator >= 0 ? args[separator + 1] : undefined;
+    if (path) await mkdir(path, { recursive: true });
+  }
+
+  function successfulRunCommand(stdout = "") {
+    return vi.fn(async (_command: string, args: string[]) => {
+      await materializeAddedWorktree(args);
+      return { stdout, stderr: "" };
+    });
+  }
+
   beforeEach(async () => {
     homePath = await mkdtemp(join(tmpdir(), "matrix-worktree-manager-"));
     await mkdir(join(homePath, "projects", "repo", "repo", ".git"), { recursive: true });
@@ -31,6 +45,7 @@ describe("worktree-manager", () => {
   it("creates stable opaque worktree IDs for PR and branch refs", async () => {
     const runCommand = vi.fn(async (_command: string, args: string[]) => {
       expect(args.join(" ")).not.toContain(";rm");
+      await materializeAddedWorktree(args);
       return { stdout: "", stderr: "" };
     });
     const manager = createWorktreeManager({ homePath, runCommand, now: () => "2026-04-26T00:00:00.000Z" });
@@ -44,12 +59,15 @@ describe("worktree-manager", () => {
     expect(first.worktree.id).toMatch(/^wt_[a-z0-9]+$/);
     expect(first.worktree.id).toBe(second.worktree.id);
     expect(first.worktree.currentBranch).toBe("pr-42");
-    const metadata = JSON.parse(await readFile(join(first.worktree.path, ".matrix", "worktree.json"), "utf-8"));
+    const metadata = JSON.parse(await readFile(
+      join(homePath, "system", "projects", "repo", "worktrees", first.worktree.id, "worktree.json"),
+      "utf-8",
+    ));
     expect(metadata.pr.number).toBe(42);
   });
 
   it("fetches GitHub PR refs before creating a PR worktree", async () => {
-    const runCommand = vi.fn(async () => ({ stdout: "", stderr: "" }));
+    const runCommand = successfulRunCommand();
     const manager = createWorktreeManager({ homePath, runCommand });
 
     const result = await manager.createWorktree({ projectSlug: "repo", pr: 42 });
@@ -62,6 +80,7 @@ describe("worktree-manager", () => {
   it("creates a missing branch worktree from the project base ref when requested", async () => {
     const runCommand = vi.fn(async (_command: string, args: string[]) => {
       if (args[0] === "rev-parse") throw new Error("missing branch");
+      await materializeAddedWorktree(args);
       return { stdout: "", stderr: "" };
     });
     const manager = createWorktreeManager({ homePath, runCommand });
@@ -77,6 +96,7 @@ describe("worktree-manager", () => {
   it("tracks an existing remote branch when creating a missing local branch worktree", async () => {
     const runCommand = vi.fn(async (_command: string, args: string[]) => {
       if (args[0] === "rev-parse" && args[3] === "refs/heads/symphony/mat-1") throw new Error("missing local branch");
+      await materializeAddedWorktree(args);
       return { stdout: "", stderr: "" };
     });
     const manager = createWorktreeManager({ homePath, runCommand });
@@ -93,7 +113,7 @@ describe("worktree-manager", () => {
     const now = () => "2026-04-26T00:00:00.000Z";
     const manager = createWorktreeManager({
       homePath,
-      runCommand: vi.fn(async () => ({ stdout: "", stderr: "" })),
+      runCommand: successfulRunCommand(),
       now,
     });
     const created = await manager.createWorktree({ projectSlug: "repo", branch: "feature/lifecycle" });
@@ -114,7 +134,7 @@ describe("worktree-manager", () => {
   });
 
   it("serializes concurrent creation for the same worktree", async () => {
-    const runCommand = vi.fn(async () => ({ stdout: "", stderr: "" }));
+    const runCommand = successfulRunCommand();
     const manager = createWorktreeManager({ homePath, runCommand });
 
     const results = await Promise.all([
@@ -139,7 +159,7 @@ describe("worktree-manager", () => {
   });
 
   it("enforces write leases and allows the holder to release them", async () => {
-    const manager = createWorktreeManager({ homePath, runCommand: vi.fn(async () => ({ stdout: "", stderr: "" })) });
+    const manager = createWorktreeManager({ homePath, runCommand: successfulRunCommand() });
     const created = await manager.createWorktree({ projectSlug: "repo", branch: "main" });
     expect(created.ok).toBe(true);
     if (!created.ok) return;
@@ -165,7 +185,7 @@ describe("worktree-manager", () => {
   });
 
   it("allows only one concurrent writer to acquire a new worktree lease", async () => {
-    const manager = createWorktreeManager({ homePath, runCommand: vi.fn(async () => ({ stdout: "", stderr: "" })) });
+    const manager = createWorktreeManager({ homePath, runCommand: successfulRunCommand() });
     const created = await manager.createWorktree({ projectSlug: "repo", branch: "race" });
     expect(created.ok).toBe(true);
     if (!created.ok) return;
@@ -182,7 +202,7 @@ describe("worktree-manager", () => {
   });
 
   it("requires explicit confirmation before deleting dirty worktrees", async () => {
-    const runCommand = vi.fn(async () => ({ stdout: " M file.ts\n", stderr: "" }));
+    const runCommand = successfulRunCommand(" M file.ts\n");
     const manager = createWorktreeManager({ homePath, runCommand });
     const created = await manager.createWorktree({ projectSlug: "repo", branch: "dirty" });
     expect(created.ok).toBe(true);
@@ -207,6 +227,7 @@ describe("worktree-manager", () => {
   it("fails closed when dirty-state inspection fails without confirmation", async () => {
     const runCommand = vi.fn(async (_command: string, args: string[]) => {
       if (args[0] === "status") throw new Error("git status timed out");
+      await materializeAddedWorktree(args);
       return { stdout: "", stderr: "" };
     });
     const manager = createWorktreeManager({ homePath, runCommand });

--- a/tests/gateway/worktree-manager.test.ts
+++ b/tests/gateway/worktree-manager.test.ts
@@ -64,6 +64,9 @@ describe("worktree-manager", () => {
       "utf-8",
     ));
     expect(metadata.pr.number).toBe(42);
+    expect(first.worktree.path).toBe(join(homePath, "worktrees", "repo", first.worktree.id));
+    await expect(stat(join(homePath, "projects", "repo", "worktrees")))
+      .rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("fetches GitHub PR refs before creating a PR worktree", async () => {
@@ -133,6 +136,18 @@ describe("worktree-manager", () => {
     });
   });
 
+  it("reads one canonical worktree without scanning sibling records", async () => {
+    const manager = createWorktreeManager({ homePath, runCommand: successfulRunCommand() });
+    const created = await manager.createWorktree({ projectSlug: "repo", branch: "feature/one" });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    await expect(manager.getWorktree("repo", created.worktree.id)).resolves.toEqual({
+      ok: true,
+      worktree: created.worktree,
+    });
+  });
+
   it("serializes concurrent creation for the same worktree", async () => {
     const runCommand = successfulRunCommand();
     const manager = createWorktreeManager({ homePath, runCommand });
@@ -155,6 +170,18 @@ describe("worktree-manager", () => {
     const result = await manager.createWorktree({ projectSlug: "repo", branch: "feature;rm -rf /" });
 
     expect(result).toMatchObject({ ok: false, status: 400, error: { code: "invalid_ref" } });
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("rejects worktree creation from a different owner scope", async () => {
+    const runCommand = successfulRunCommand();
+    const manager = createWorktreeManager({ homePath, runCommand });
+
+    await expect(manager.createWorktree({
+      projectSlug: "repo",
+      branch: "main",
+      ownerScope: { type: "user", id: "user_b" },
+    })).resolves.toMatchObject({ ok: false, status: 404, error: { code: "not_found" } });
     expect(runCommand).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- move Matrix-owned project records, tasks, previews, worktree records, leases, and deletion tombstones to `~/system/projects/<slug>`
- make `~/projects/<folder>` ordinary owner-controlled workspace space, including direct checkouts created from Terminal
- place newly created worktrees under `~/worktrees/<project-slug>/<worktree-id>` so Matrix runtime state cannot collide with owner source folders
- lazily adopt bounded, validated legacy state without moving code, deleting concurrent replacements, or losing conflicting owner records
- enforce owner scope across project lifecycle, task, preview, coding-agent file/source-control, Git read, and worktree routes
- validate legacy task/preview records before cleanup so unrelated owner files are preserved
- stream and cap task/preview identifier discovery instead of accumulating unbounded in-memory sets
- keep direct-folder create retries idempotent and preserve owner source during project deletion

## Invariants

- **Source of truth:** canonical project state is `~/system/projects/<slug>`; `ProjectConfig.id` remains the durable identity and `localPath` links to owner code
- **Lock/atomicity scope:** project writes remain serialized by slug; recovery publication is globally serialized and capped; legacy removal uses identity-checked quarantine
- **Recovery:** displaced legacy metadata is kept in bounded Matrix-owned recovery state, never left in owner workspaces
- **Authorization:** every lifecycle/read/worktree mutation checks the validated canonical project identity and owner scope
- **Deferred scope:** no broad Files CRUD work, no MAT-268 changes or dependency, no one-way source-code migration, and no public documentation change

## Verification

- 15 focused Gateway/Desktop test files: **310 tests passed**
- Gateway TypeScript check passed
- Desktop production build passed on the preceding feature head; the final Gateway-only cleanup commit does not touch Desktop
- `git diff --check` and repository pattern scan passed
- repository-wide test run completed: **903 files / 10,272 tests passed**; **51 files / 31 tests failed** in pre-existing unrelated platform dependency resolution, long socket-path/runtime timing, terminal-agent timing, and legacy route fixture areas
- repository-wide typecheck still reaches the existing Vite 6.4.2 / 7.3.5 plugin mismatch; focused Gateway check passes

Linear: [MAT-340](https://linear.app/matrix-os/issue/MAT-340/move-matrix-owned-project-registry-metadata-out-of-projects)

## MAT-343 preview acceptance fix

- keep hosted `WebContentsView` surfaces detached while the runtime computer selector is open, so the portaled menu can cross the sidebar boundary without being covered
- release the shared renderer-overlay lease on close/unmount so native embeds reattach through the existing overlay coordinator
- add a regression test for open and Escape-close behavior
- validate the fix in real Electron against the `pr-1247` Preview Computer and attach the screenshot to Linear

Linear: [MAT-343](https://linear.app/matrix-os/issue/MAT-343/prevent-the-desktop-computer-selector-from-being-covered-by-native)
