### PR TITLE
test(desktop): update terminal context menu coverage

### DIFF
--- a/tests/desktop/terminal-link-context-menu.test.tsx
+++ b/tests/desktop/terminal-link-context-menu.test.tsx
@@ -14,23 +14,31 @@ const LINK = {
 };
 
 describe("Desktop TerminalLinkContextMenu", () => {
-  it("offers Open and Copy for the resolved URL without showing the full URL", () => {
+  it("offers terminal and link actions without showing the full URL", () => {
     const onOpen = vi.fn();
     const onCopy = vi.fn();
+    const onCopySelection = vi.fn();
+    const onSelectAll = vi.fn();
     render(
       <TerminalLinkContextMenu
-        menu={{ x: 120, y: 140, link: LINK }}
+        menu={{ x: 120, y: 140, link: LINK, selection: "selected output" }}
         onClose={vi.fn()}
         onOpen={onOpen}
         onCopy={onCopy}
+        onCopySelection={onCopySelection}
+        onSelectAll={onSelectAll}
       />,
     );
 
-    expect(screen.getByRole("menu", { name: "Link actions" })).toBeTruthy();
+    expect(screen.getByRole("menu", { name: "Terminal actions" })).toBeTruthy();
     expect(screen.queryByText(LINK.url)).toBeNull();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Select All" }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Open Link" }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Copy Link" }));
 
+    expect(onCopySelection).toHaveBeenCalledWith("selected output");
+    expect(onSelectAll).toHaveBeenCalledOnce();
     expect(onOpen).toHaveBeenCalledWith(LINK);
     expect(onCopy).toHaveBeenCalledWith(LINK);
   });
@@ -41,6 +49,7 @@ describe("Desktop TerminalLinkContextMenu", () => {
         menu={{
           x: 120,
           y: 140,
+          selection: "",
           link: {
             url: "https://auth.openai.com/codex/device",
             hostname: "auth.openai.com",
@@ -52,6 +61,8 @@ describe("Desktop TerminalLinkContextMenu", () => {
         onClose={vi.fn()}
         onOpen={vi.fn()}
         onCopy={vi.fn()}
+        onCopySelection={vi.fn()}
+        onSelectAll={vi.fn()}
       />,
     );
 
@@ -62,10 +73,12 @@ describe("Desktop TerminalLinkContextMenu", () => {
     const onClose = vi.fn();
     render(
       <TerminalLinkContextMenu
-        menu={{ x: 120, y: 140, link: LINK }}
+        menu={{ x: 120, y: 140, link: LINK, selection: "" }}
         onClose={onClose}
         onOpen={vi.fn()}
         onCopy={vi.fn()}
+        onCopySelection={vi.fn()}
+        onSelectAll={vi.fn()}
       />,
     );
 


### PR DESCRIPTION
## Summary

- Align the desktop terminal context-menu test with the terminal-wide accessible name and selection-aware component contract introduced in #1246.
- Exercise Copy and Select All callbacks while retaining the existing link-action assertions.
- Repair the Unit Tests 3/4 failure currently blocking main CI and the downstream host-bundle gate.

## Tests

- PASS: flox activate -- bunx vitest run tests/desktop/terminal-link-context-menu.test.tsx tests/desktop/terminal-view.test.tsx tests/desktop/terminal-link-actions.test.ts tests/shell/terminal-link-context-menu.test.tsx tests/shell/terminal-link-actions.test.ts (40 tests)
- PASS: bun run typecheck
- PASS: bun run check:patterns (0 violations; existing warnings only)
- NOTE: the full 3/4 shard was attempted locally, but the worktree dependencies were initially installed with unsupported Node 26 and native better-sqlite3 artifacts could not load after switching to Node 24. Clean GitHub CI is the authoritative full-shard run.

## Review/Monitoring

- Awaiting the latest trusted Greptile review.
- Add ready-for-ci only after Greptile reaches 5/5, then monitor the label-triggered full CI.

## Invariants

- Source of truth: the TerminalLinkContextMenu component contract and its Terminal actions accessible name.
- Lock/transaction scope: not applicable; test-only change.
- Acceptable orphan states: not applicable; no persisted state changes.
- Auth source of truth: unchanged.
- Deferred scope: none.