### PR TITLE
fix(desktop): preserve project chat stream order

### DIFF
--- a/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
@@ -145,10 +145,12 @@ function timelineItems(items: ConversationItem[]): TimelineItem[] {
 }
 
 function assistantText(events: AssistantEvent[]): { text: string; completed: boolean } {
-  const deltas = events.filter(
+  const completedIndex = events.findIndex((event) => event.type === "assistant.text.completed");
+  const messageEvents = completedIndex >= 0 ? events.slice(0, completedIndex) : events;
+  const deltas = messageEvents.filter(
     (event): event is Extract<AssistantEvent, { type: "assistant.text.delta" }> => event.type === "assistant.text.delta",
   );
-  const completed = events.some((event) => event.type === "assistant.text.completed");
+  const completed = completedIndex >= 0;
   // Redact BEFORE the defensive tail slice: truncation can sever a credential
   // prefix (e.g. password=) while its value survives in the retained tail.
   let text = redactCredentialsForDisplay(deltas.map((event) => event.delta).join(""));

--- a/desktop/src/renderer/src/stores/coding-agent/thread-model.ts
+++ b/desktop/src/renderer/src/stores/coding-agent/thread-model.ts
@@ -31,9 +31,41 @@ export function fileReferenceMatches(reference: FileReference | null, request: F
     && reference.path === request.path;
 }
 
-export function compareThreadEvents(left: AgentThreadSnapshotEvent, right: AgentThreadSnapshotEvent): number {
-  const occurredAt = left.occurredAt.localeCompare(right.occurredAt);
-  return occurredAt === 0 ? left.eventId.localeCompare(right.eventId) : occurredAt;
+function uniqueThreadEvents(events: AgentThreadSnapshotEvent[]): AgentThreadSnapshotEvent[] {
+  const seen: Record<string, true> = {};
+  return events.filter((event) => {
+    if (seen[event.eventId]) return false;
+    seen[event.eventId] = true;
+    return true;
+  });
+}
+
+function reconcileThreadEventOrder(
+  current: AgentThreadSnapshotEvent[],
+  authoritative: AgentThreadSnapshotEvent[],
+  limit: number,
+  currentIsNewer: boolean,
+): AgentThreadSnapshotEvent[] {
+  const next = uniqueThreadEvents(authoritative);
+  const currentLastId = current.at(-1)?.eventId;
+  if (!currentLastId || next.some((event) => event.eventId === currentLastId)) {
+    return next.slice(-limit);
+  }
+
+  const authoritativeLastId = next.at(-1)?.eventId;
+  const authoritativeEndInCurrent = authoritativeLastId
+    ? current.findIndex((event) => event.eventId === authoritativeLastId)
+    : -1;
+  if (authoritativeEndInCurrent >= 0) {
+    return uniqueThreadEvents([
+      ...next,
+      ...current.slice(authoritativeEndInCurrent + 1),
+    ]).slice(-limit);
+  }
+
+  // With no shared cursor in the bounded windows, the thread summary timestamp
+  // decides which complete window is newer. Never concatenate disjoint windows.
+  return uniqueThreadEvents(currentIsNewer ? current : next).slice(-limit);
 }
 
 export function mergeSelectedThreadSnapshot(
@@ -41,13 +73,13 @@ export function mergeSelectedThreadSnapshot(
   next: AgentThreadSnapshot,
 ): AgentThreadSnapshot {
   if (!current || current.thread.id !== next.thread.id) return next;
-  const eventById = new Map<string, AgentThreadSnapshotEvent>();
-  for (const event of current.events.items) eventById.set(event.eventId, event);
-  for (const event of next.events.items) eventById.set(event.eventId, event);
   const limit = Math.max(current.events.limit, next.events.limit);
-  const items = Array.from(eventById.values())
-    .sort(compareThreadEvents)
-    .slice(-limit);
+  const items = reconcileThreadEventOrder(
+    current.events.items,
+    next.events.items,
+    limit,
+    current.thread.updatedAt > next.thread.updatedAt,
+  );
   const thread = current.thread.updatedAt > next.thread.updatedAt ? current.thread : next.thread;
   return {
     ...next,
@@ -167,12 +199,9 @@ export function mergeLiveThreadEvent(
   event: AgentThreadEvent,
 ): AgentThreadSnapshot {
   if (event.threadId !== current.thread.id) return current;
-  const existing = new Map(current.events.items.map((item) => [item.eventId, item]));
-  existing.set(event.eventId, event);
+  if (current.events.items.some((item) => item.eventId === event.eventId)) return current;
   const limit = current.events.limit;
-  const items = Array.from(existing.values())
-    .sort(compareThreadEvents)
-    .slice(-limit);
+  const items = [...current.events.items, event].slice(-limit);
   return {
     ...current,
     thread: event.occurredAt.localeCompare(current.thread.updatedAt) >= 0

--- a/tests/desktop/coding-agent-chat-transcript.test.tsx
+++ b/tests/desktop/coding-agent-chat-transcript.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentThreadEvent, AgentThreadSnapshot } from "@matrix-os/contracts";
 import { AgentConversationView } from "../../desktop/src/renderer/src/features/coding-agents/AgentConversationView";
 import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
+import { mergeLiveThreadEvent } from "../../desktop/src/renderer/src/stores/coding-agent/thread-model";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 
 function snapshot(events: AgentThreadEvent[], threadOverrides: Record<string, unknown> = {}): AgentThreadSnapshot {
@@ -187,6 +188,81 @@ describe("AgentConversationView transcript", () => {
     );
 
     expect(screen.getByText("Reading the failing test now.")).toBeTruthy();
+  });
+
+  it("preserves whitespace, Markdown code boundaries, and multibyte text across same-timestamp live chunks", () => {
+    const occurredAt = "2026-07-15T00:01:00.000Z";
+    const chunks = [
+      { eventId: "evt_z", text: "# Result\n\n你好" },
+      { eventId: "evt_y", text: " 👋\n\n```ts\n" },
+      { eventId: "evt_x", text: "const greeting = \"你好 👋\";\n" },
+      { eventId: "evt_w", text: "```\n\nDone." },
+    ];
+    const live = chunks.reduce(
+      (current, chunk) => mergeLiveThreadEvent(current, {
+        type: "assistant.text.delta",
+        eventId: chunk.eventId,
+        threadId: "thread_alpha",
+        occurredAt,
+        messageId: "msg_multibyte",
+        delta: chunk.text,
+      }),
+      snapshot([]),
+    );
+
+    render(
+      <AgentConversationView status="ready" snapshot={live} error={null} canSendTurns />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Result" })).toBeTruthy();
+    expect(screen.getByText("你好 👋")).toBeTruthy();
+    expect(document.querySelector("pre code")?.textContent).toContain('const greeting = "你好 👋";');
+    expect(screen.getByText("Done.")).toBeTruthy();
+  });
+
+  it("does not let a late delta for completed A mutate A after turn B starts", () => {
+    render(
+      <AgentConversationView
+        status="ready"
+        snapshot={snapshot([
+          delta("msg_a", "Stable answer.", 1),
+          completedEvent("msg_a"),
+          {
+            type: "turn.accepted",
+            eventId: "evt_turn_b",
+            threadId: "thread_alpha",
+            occurredAt: "2026-07-15T00:03:00.000Z",
+            turnId: "turn_b",
+            clientRequestId: "req_b",
+            acceptedAt: "2026-07-15T00:03:00.000Z",
+          },
+          {
+            type: "user.message",
+            eventId: "evt_user_b",
+            threadId: "thread_alpha",
+            occurredAt: "2026-07-15T00:03:00.000Z",
+            messageId: "msg_user_b",
+            text: "Follow-up B",
+            clientRequestId: "req_b",
+            turnId: "turn_b",
+          },
+          {
+            type: "assistant.text.delta",
+            eventId: "evt_late_a",
+            threadId: "thread_alpha",
+            occurredAt: "2026-07-15T00:04:00.000Z",
+            messageId: "msg_a",
+            delta: " STALE",
+          },
+        ])}
+        error={null}
+        canSendTurns
+      />,
+    );
+
+    expect(screen.getByText("Stable answer.")).toBeTruthy();
+    expect(screen.queryByText(/STALE/)).toBeNull();
+    expect(screen.getByText("Follow-up B")).toBeTruthy();
   });
 
   it("collapses long user messages behind a show-more toggle", () => {

--- a/tests/desktop/coding-agent-thread-model.test.ts
+++ b/tests/desktop/coding-agent-thread-model.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
-import type { AgentThreadSummary, RuntimeSummary } from "@matrix-os/contracts";
-import { reconcileSummaryThread } from "../../desktop/src/renderer/src/stores/coding-agent/thread-model";
+import type {
+  AgentThreadEvent,
+  AgentThreadSnapshot,
+  AgentThreadSummary,
+  RuntimeSummary,
+} from "@matrix-os/contracts";
+import {
+  mergeLiveThreadEvent,
+  mergeSelectedThreadSnapshot,
+  reconcileSummaryThread,
+} from "../../desktop/src/renderer/src/stores/coding-agent/thread-model";
 
 function thread(overrides: Partial<AgentThreadSummary> = {}): AgentThreadSummary {
   return {
@@ -43,6 +52,137 @@ function summary(overrides: {
     serverTime: "2026-07-06T00:03:00.000Z",
   } as RuntimeSummary;
 }
+
+function threadSnapshot(events: AgentThreadEvent[] = [], threadId = "thread_alpha"): AgentThreadSnapshot {
+  return {
+    thread: thread({ id: threadId }),
+    events: {
+      items: events,
+      hasMore: false,
+      limit: 200,
+    },
+  };
+}
+
+function assistantDelta(
+  eventId: string,
+  delta: string,
+  options: { messageId?: string; threadId?: string; occurredAt?: string } = {},
+): AgentThreadEvent {
+  return {
+    type: "assistant.text.delta",
+    eventId,
+    threadId: options.threadId ?? "thread_alpha",
+    occurredAt: options.occurredAt ?? "2026-07-06T00:02:00.000Z",
+    messageId: options.messageId ?? "msg_alpha",
+    delta,
+  };
+}
+
+describe("thread event projection", () => {
+  it("preserves sequential same-timestamp deltas in Gateway arrival order without mutating prior snapshots", () => {
+    const initial = threadSnapshot();
+    const first = assistantDelta("evt_z", "first ");
+    const second = assistantDelta("evt_a", "second");
+
+    const afterFirst = mergeLiveThreadEvent(initial, first);
+    const afterSecond = mergeLiveThreadEvent(afterFirst, second);
+
+    expect(afterSecond.events.items.map((event) => event.eventId)).toEqual(["evt_z", "evt_a"]);
+    expect(afterSecond.events.items.map((event) => event.type === "assistant.text.delta" ? event.delta : "").join(""))
+      .toBe("first second");
+    expect(initial.events.items).toEqual([]);
+    expect(afterFirst.events.items).toEqual([first]);
+  });
+
+  it("preserves tool and assistant interleaving instead of sorting opaque event IDs", () => {
+    const occurredAt = "2026-07-06T00:02:00.000Z";
+    const events: AgentThreadEvent[] = [
+      assistantDelta("evt_z", "before", { occurredAt }),
+      {
+        type: "tool.started",
+        eventId: "evt_y",
+        threadId: "thread_alpha",
+        occurredAt,
+        toolCallId: "tool_alpha",
+        displayName: "Read file",
+        kind: "read",
+      },
+      {
+        type: "tool.output",
+        eventId: "evt_x",
+        threadId: "thread_alpha",
+        occurredAt,
+        toolCallId: "tool_alpha",
+        text: "result",
+      },
+      assistantDelta("evt_w", "after", { occurredAt }),
+    ];
+
+    const projected = events.reduce(mergeLiveThreadEvent, threadSnapshot());
+
+    expect(projected.events.items.map((event) => event.eventId))
+      .toEqual(["evt_z", "evt_y", "evt_x", "evt_w"]);
+  });
+
+  it("treats a duplicate event identity as an idempotent no-op", () => {
+    const first = assistantDelta("evt_same", "canonical");
+    const current = mergeLiveThreadEvent(threadSnapshot(), first);
+
+    const duplicate = mergeLiveThreadEvent(current, { ...first, delta: "corrupted duplicate" });
+
+    expect(duplicate).toBe(current);
+    expect(duplicate.events.items).toEqual([first]);
+  });
+
+  it("lets authoritative snapshot order replace a divergent live order", () => {
+    const first = assistantDelta("evt_z", "first ");
+    const second = assistantDelta("evt_a", "second");
+    const divergentLive = threadSnapshot([second, first]);
+    const authoritativeReload = threadSnapshot([first, second]);
+
+    const reconciled = mergeSelectedThreadSnapshot(divergentLive, authoritativeReload);
+
+    expect(reconciled.events.items.map((event) => event.eventId)).toEqual(["evt_z", "evt_a"]);
+    expect(authoritativeReload.events.items).toEqual([first, second]);
+  });
+
+  it("reconciles a stale reconnect snapshot before retaining unseen live tail events", () => {
+    const first = assistantDelta("evt_z", "first ");
+    const second = assistantDelta("evt_y", "second ");
+    const unseenLive = assistantDelta("evt_a", "third");
+    const current = threadSnapshot([first, second, unseenLive]);
+    const staleSnapshot = threadSnapshot([first, second]);
+
+    const reconciled = mergeSelectedThreadSnapshot(current, staleSnapshot);
+
+    expect(reconciled.events.items.map((event) => event.eventId)).toEqual(["evt_z", "evt_y", "evt_a"]);
+    expect(reconciled.events.items).toHaveLength(3);
+  });
+
+  it("keeps a newer live window when a stale bounded snapshot no longer overlaps it", () => {
+    const live = {
+      ...threadSnapshot([assistantDelta("evt_live", "new")]),
+      thread: thread({ updatedAt: "2026-07-06T00:03:00.000Z" }),
+    };
+    const stale = {
+      ...threadSnapshot([assistantDelta("evt_stale", "old")]),
+      thread: thread({ updatedAt: "2026-07-06T00:02:00.000Z" }),
+    };
+
+    const reconciled = mergeSelectedThreadSnapshot(live, stale);
+
+    expect(reconciled.events.items.map((event) => event.eventId)).toEqual(["evt_live"]);
+    expect(reconciled.thread.updatedAt).toBe("2026-07-06T00:03:00.000Z");
+  });
+
+  it("ignores a stale event from a previously selected thread", () => {
+    const current = threadSnapshot([], "thread_beta");
+    const stale = assistantDelta("evt_old", "stale", { threadId: "thread_alpha" });
+
+    expect(mergeLiveThreadEvent(current, stale)).toBe(current);
+  });
+});
 
 describe("reconcileSummaryThread", () => {
   it("updates a thread in place in both lists", () => {


### PR DESCRIPTION
## Summary

- preserve Gateway append/arrival order for live Project Chat events instead of sorting equal-timestamp events by opaque event IDs
- make identified event application immutable and idempotent, and reconcile stale snapshots against the authoritative replay sequence without concatenating disjoint windows
- treat assistant completion as terminal so a late delta for completed turn A cannot mutate A after turn B starts

Closes MAT-349.

## Root cause

The Gateway persists and replays coding-agent events in append/cursor order, and the Desktop main process forwards validated WebSocket frames in arrival order. The renderer then re-sorted every event by `occurredAt` and `eventId`. Codex bridge batches can share one timestamp across sequential events, while event IDs are hashes/UUIDs and do not encode order. A deterministic reproduction delivered `evt_z` and then `evt_a` at one timestamp: live rendered `secondfirst `, while authoritative reload rendered `first second`.

## TDD and validation

- Red: 7 focused failures on the original `c8a26d35ec8efbe21f882f215ef73001d2429f06` base
- Green: focused reducer/transcript tests, 33/33
- Green: surrounding Desktop thread-stream/workspace tests, 119/119
- Green: `flox activate -- bun run typecheck`
- Green: `flox activate -- bun run check:patterns` (0 violations; 5 warnings in unchanged files)
- Green: `flox activate -- bun run build:desktop`
- Green: React Doctor changed scope, no issues
- Green: built Electron 41.7.1 with isolated user data; 18 authoritative events, one shared timestamp, opaque reverse-sorted IDs, tool/text interleaving, and 11 Markdown/code/multibyte chunks
- Green: live and post-reload rendered projections deep-equaled; the captured transcript screenshots are byte-identical (`sha256:78912c6d8e74560ce2c9ea56bd1fae423e0b4cfca4d4d19acb1f5a315652cc95`)

Full repository test disclosure: `bun run test` completed with 10,837 passing, 27 failing, and 20 skipped tests. The failures do not touch this four-file diff and include existing environment/concurrency failures: 20-120 second process/build timeouts, macOS long Unix socket paths, date-sensitive Todo assertions, Linux-only `mv -T`, and Vitest worker package-resolution failures. A serial `TMPDIR=/tmp` rerun restored the adjacent Codex reliability suite (8/8) and control client suite (2/2); 3 unrelated baseline failures persisted in workspace-provider/app-server runtime tests. The scoped 119-test owning path is green.

## Electron evidence

![Live Project Chat projection](https://uploads.linear.app/9d7c8ca2-ff8b-42ea-8321-35892cc887d8/aa1ae16a-f163-4686-b9ff-e310ff0b4240/24522645-81cc-4bae-a969-252f2a053654)

![Post-reload authoritative projection](https://uploads.linear.app/9d7c8ca2-ff8b-42ea-8321-35892cc887d8/0ba00545-12de-4aa9-816b-e76036e7f78b/9c6e3933-ebbb-4a09-ac13-e83880cea624)

[Machine-readable parity evidence](https://uploads.linear.app/9d7c8ca2-ff8b-42ea-8321-35892cc887d8/5a5c9b91-55ea-4fff-98b0-9bff4b3141d1/47bf4927-d11a-4bfb-8450-ddbf4361d803)

## Invariants

- **Source of truth:** Gateway thread append/cursor order and shared event identities remain authoritative. The renderer keeps only an ephemeral projection and adds no persistence or second registry.
- **Lock/transaction scope:** no database, filesystem, lock, or transaction behavior changes. Reconciliation is a bounded pure reducer operation over the existing maximum 200-event snapshot window.
- **Acceptable orphan states:** a stale snapshot may temporarily omit a live tail; when it shares the authoritative last cursor, the unseen current tail is retained. Disjoint bounded windows are never concatenated; the complete newer window wins until the next authoritative refresh.
- **Auth source of truth:** unchanged. Desktop auth and the Gateway-issued WebSocket token continue to own access; no renderer auth or trust decision was added.
- **Deferred scope:** MAT-345/346/347/348 remain independent. Visual grouping, composer, rail, focus layout, keyboard navigation, progress UI, and speculative reconnect UX are explicitly excluded; MAT-350 and MAT-351 own the broader UX follow-ups.

## Review state

This PR must remain Draft. Do not merge until required CI is green, every required reviewer has approved the exact head, and Greptile is 5/5.
