### PR TITLE
feat(desktop): add contextual Project Chat workbench

### DIFF
--- a/desktop/src/renderer/src/features/coding-agents/AgentConversationInspector.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentConversationInspector.tsx
@@ -14,6 +14,7 @@ interface InspectorCounts {
 
 interface AgentConversationInspectorProps {
   defaultTab: AgentConversationInspectorTab;
+  tabs?: readonly AgentConversationInspectorTab[];
   // Optional controlled selection. When both are provided the parent owns the
   // active tab (e.g. to gate live resources like an embedded terminal socket
   // on the Terminal surface being visible).
@@ -59,6 +60,7 @@ const TAB_LABEL_MIN_WIDTH_PX = 96;
 
 export function AgentConversationInspector({
   defaultTab,
+  tabs: requestedTabs,
   selectedTab: controlledTab,
   onTabChange,
   changesFocusRequestId = 0,
@@ -73,17 +75,20 @@ export function AgentConversationInspector({
   preview,
   activity,
 }: AgentConversationInspectorProps) {
-  const [internalTab, setInternalTab] = useState<AgentConversationInspectorTab>(defaultTab);
-  const selectedTab = controlledTab ?? internalTab;
+  const defaultTabs: AgentConversationInspectorTab[] = files === undefined
+    ? ["changes", "terminal", "preview", "activity"]
+    : ["changes", "files", "terminal", "preview", "activity"];
+  const tabs = requestedTabs && requestedTabs.length > 0 ? [...requestedTabs] : defaultTabs;
+  const safeDefaultTab = tabs.includes(defaultTab) ? defaultTab : tabs[0]!;
+  const [internalTab, setInternalTab] = useState<AgentConversationInspectorTab>(safeDefaultTab);
+  const requestedSelectedTab = controlledTab ?? internalTab;
+  const selectedTab = tabs.includes(requestedSelectedTab) ? requestedSelectedTab : safeDefaultTab;
   const instanceId = useId();
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const tablistRef = useRef<HTMLDivElement | null>(null);
   // Icon-only until the tablist proves it has room for full labels.
   const [labelsVisible, setLabelsVisible] = useState(false);
 
-  const tabs: AgentConversationInspectorTab[] = files === undefined
-    ? ["changes", "terminal", "preview", "activity"]
-    : ["changes", "files", "terminal", "preview", "activity"];
   const content: Record<AgentConversationInspectorTab, ReactNode> = {
     changes,
     files,
@@ -96,9 +101,11 @@ export function AgentConversationInspector({
   // live previews) costs nothing; once visited a surface stays mounted across
   // switches so local state (drafts, scrollback, selection) survives.
   const [visitedTabs, setVisitedTabs] = useState<AgentConversationInspectorTab[]>(() =>
-    controlledTab === undefined || controlledTab === defaultTab
-      ? [defaultTab]
-      : [defaultTab, controlledTab],
+    controlledTab !== undefined
+      && controlledTab !== safeDefaultTab
+      && tabs.includes(controlledTab)
+      ? [safeDefaultTab, controlledTab]
+      : [safeDefaultTab],
   );
   const visitedTabSet = useMemo(() => new Set(visitedTabs), [visitedTabs]);
 
@@ -131,7 +138,7 @@ export function AgentConversationInspector({
   useEffect(() => {
     if (changesFocusRequestId <= changesFocusConsumedId) return;
     onChangesFocusConsumed?.(changesFocusRequestId);
-    selectTab("changes");
+    if (tabs.includes("changes")) selectTab("changes");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [changesFocusConsumedId, changesFocusRequestId, onChangesFocusConsumed]);
 
@@ -155,26 +162,26 @@ export function AgentConversationInspector({
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div
-        className="shrink-0 space-y-3 border-b px-4 pb-3 pt-4"
-        style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
-      >
-        {toolbar}
-        {composer}
-      </div>
-      <div
-        ref={tablistRef}
-        role="tablist"
-        aria-label="Conversation tools"
-        className="grid shrink-0 gap-1 border-b p-1.5"
-        style={{
-          gridTemplateColumns: `repeat(${tabs.length}, minmax(0, 1fr))`,
-          borderColor: "var(--border-subtle)",
-          background: "var(--bg-sunken)",
-        }}
-      >
-        <RadixTooltip.Provider delayDuration={400}>
+    <RadixTooltip.Provider delayDuration={400}>
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div
+          className="shrink-0 space-y-3 border-b px-4 pb-3 pt-4"
+          style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+        >
+          {toolbar}
+          {composer}
+        </div>
+        <div
+          ref={tablistRef}
+          role="tablist"
+          aria-label="Conversation tools"
+          className="grid shrink-0 gap-1 border-b p-1.5"
+          style={{
+            gridTemplateColumns: `repeat(${tabs.length}, minmax(0, 1fr))`,
+            borderColor: "var(--border-subtle)",
+            background: "var(--bg-sunken)",
+          }}
+        >
         {tabs.map((tabId, index) => {
           const selected = tabId === selectedTab;
           const label = TAB_LABELS[tabId];
@@ -230,26 +237,26 @@ export function AgentConversationInspector({
             </RadixTooltip.Root>
           );
         })}
-        </RadixTooltip.Provider>
+        </div>
+        {tabs.map((tabId) => {
+          const selected = tabId === selectedTab;
+          return (
+            <div
+              key={tabId}
+              id={`${instanceId}-${tabId}-panel`}
+              role="tabpanel"
+              aria-labelledby={`${instanceId}-${tabId}-tab`}
+              tabIndex={selected ? 0 : -1}
+              hidden={!selected}
+              className="flex min-h-0 flex-1 flex-col overflow-y-auto outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--accent)]"
+            >
+              {selected || visitedTabSet.has(tabId) ? (
+                <div className="flex min-h-0 flex-1 flex-col p-4">{content[tabId]}</div>
+              ) : null}
+            </div>
+          );
+        })}
       </div>
-      {tabs.map((tabId) => {
-        const selected = tabId === selectedTab;
-        return (
-          <div
-            key={tabId}
-            id={`${instanceId}-${tabId}-panel`}
-            role="tabpanel"
-            aria-labelledby={`${instanceId}-${tabId}-tab`}
-            tabIndex={selected ? 0 : -1}
-            hidden={!selected}
-            className="flex min-h-0 flex-1 flex-col overflow-y-auto outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--accent)]"
-          >
-            {selected || visitedTabSet.has(tabId) ? (
-              <div className="flex min-h-0 flex-1 flex-col p-4">{content[tabId]}</div>
-            ) : null}
-          </div>
-        );
-      })}
-    </div>
+    </RadixTooltip.Provider>
   );
 }

--- a/desktop/src/renderer/src/features/coding-agents/AgentReviewPanel.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentReviewPanel.tsx
@@ -7,6 +7,7 @@ import {
   type FileReadRequest,
   type FileReadResponse,
   type FileSearchResponse,
+  type ReviewSummary,
   type ReviewSnapshot,
   type RuntimeSummary,
   type SourceControlCreatePullRequestRequest,
@@ -50,11 +51,15 @@ export function ReviewList({
   canPrepareCommit,
   canCreateFollowUp,
   onAskHunkFollowUp,
+  items: scopedItems,
+  projectId,
 }: {
   canReadFiles: boolean;
   canPrepareCommit: boolean;
   canCreateFollowUp: boolean;
   onAskHunkFollowUp: (snapshot: ReviewSnapshot, selected: SelectedReviewHunk) => void;
+  items?: readonly ReviewSummary[];
+  projectId?: string;
 }) {
   const reviewsStatus = useCodingAgentWorkspace((s) => s.reviewsStatus);
   const reviews = useCodingAgentWorkspace((s) => s.reviews);
@@ -79,7 +84,10 @@ export function ReviewList({
   const saveFileContent = useCodingAgentWorkspace((s) => s.saveFileContent);
   const prepareSourceCommit = useCodingAgentWorkspace((s) => s.prepareSourceCommit);
   const createSourcePullRequest = useCodingAgentWorkspace((s) => s.createSourcePullRequest);
-  const items = reviews?.items ?? [];
+  const items = scopedItems ?? reviews?.items ?? [];
+  const visibleReviewSnapshot = projectId === undefined || reviewSnapshot?.review.projectId === projectId
+    ? reviewSnapshot
+    : null;
 
   return (
     <Section title="Review" count={items.length}>
@@ -125,7 +133,7 @@ export function ReviewList({
         ))}
         <ReviewSnapshotPanel
           status={reviewSnapshotStatus}
-          snapshot={reviewSnapshot}
+          snapshot={visibleReviewSnapshot}
           error={reviewSnapshotError}
           canReadFiles={canReadFiles}
           fileReadStatus={fileReadStatus}

--- a/desktop/src/renderer/src/features/coding-agents/AgentReviewPanel.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentReviewPanel.tsx
@@ -85,7 +85,12 @@ export function ReviewList({
   const prepareSourceCommit = useCodingAgentWorkspace((s) => s.prepareSourceCommit);
   const createSourcePullRequest = useCodingAgentWorkspace((s) => s.createSourcePullRequest);
   const items = scopedItems ?? reviews?.items ?? [];
-  const visibleReviewSnapshot = projectId === undefined || reviewSnapshot?.review.projectId === projectId
+  const selectedReview = selectedReviewId
+    ? reviews?.items.find((review) => review.id === selectedReviewId)
+    : undefined;
+  const reviewSelectionInScope = projectId === undefined || selectedReview?.projectId === projectId;
+  const visibleReviewSnapshot = reviewSelectionInScope
+    && (projectId === undefined || reviewSnapshot?.review.projectId === projectId)
     ? reviewSnapshot
     : null;
 
@@ -132,9 +137,9 @@ export function ReviewList({
           </button>
         ))}
         <ReviewSnapshotPanel
-          status={reviewSnapshotStatus}
+          status={reviewSelectionInScope ? reviewSnapshotStatus : "idle"}
           snapshot={visibleReviewSnapshot}
-          error={reviewSnapshotError}
+          error={reviewSelectionInScope ? reviewSnapshotError : null}
           canReadFiles={canReadFiles}
           fileReadStatus={fileReadStatus}
           fileRead={fileRead}

--- a/desktop/src/renderer/src/features/coding-agents/AgentThreadLists.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentThreadLists.tsx
@@ -89,9 +89,11 @@ export function ThreadList({
 export function CreatedThreadHandleList({
   summary,
   onOpenThread,
+  projectId,
 }: {
   summary: RuntimeSummary;
   onOpenThread?: (thread: AgentThreadSummary) => void;
+  projectId?: string;
 }) {
   const createdThreadHandles = useCodingAgentWorkspace((s) => s.createdThreadHandles);
   const activeThreadId = useCodingAgentWorkspace((s) => s.activeThreadId);
@@ -100,7 +102,10 @@ export function CreatedThreadHandleList({
     ...summary.activeThreads.items.map((thread) => thread.id),
     ...summary.attentionThreads.items.map((thread) => thread.id),
   ]);
-  const visibleHandles = createdThreadHandles.filter((thread) => !summaryThreadIds.has(thread.id));
+  const visibleHandles = createdThreadHandles.filter((thread) =>
+    !summaryThreadIds.has(thread.id)
+    && (projectId === undefined || thread.projectId === projectId)
+  );
   const openThread = onOpenThread ?? ((thread: AgentThreadSummary) => void loadThreadSnapshot(thread.id));
 
   if (visibleHandles.length === 0) return null;

--- a/desktop/src/renderer/src/features/panels/InspectorFilesPanel.tsx
+++ b/desktop/src/renderer/src/features/panels/InspectorFilesPanel.tsx
@@ -9,7 +9,11 @@ import { FilePreview, resolveActivePath, type FileSelection } from "../files/Fil
  * rendered) below. Selection is scoped to the current computer/session so a
  * runtime switch can never preview another owner's path.
  */
-export function InspectorFilesPanel() {
+export function InspectorFilesPanel({
+  scopeLabel = "Matrix Home",
+}: {
+  scopeLabel?: string;
+}) {
   const runtimeSlot = useConnection((state) => state.runtimeSlot);
   const authGeneration = useConnection((state) => state.authGeneration);
   const [selection, setSelection] = useState<FileSelection | null>(null);
@@ -31,6 +35,15 @@ export function InspectorFilesPanel() {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-2">
+      <div
+        className="rounded-md border px-3 py-2"
+        style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+      >
+        <p className="text-xs font-medium" style={{ color: "var(--text-primary)" }}>{scopeLabel}</p>
+        <p className="text-[11px]" style={{ color: "var(--text-tertiary)" }}>
+          Browse this computer&apos;s files. This view is not limited to the selected project.
+        </p>
+      </div>
       <div className="shrink-0">
         <ComputerFileBrowser compact onOpenFile={handleOpenFile} />
       </div>

--- a/desktop/src/renderer/src/features/panels/InspectorTerminalPanel.tsx
+++ b/desktop/src/renderer/src/features/panels/InspectorTerminalPanel.tsx
@@ -22,9 +22,11 @@ const STATUS_COLOR: Record<string, string> = {
 export function InspectorTerminalPanel({
   summary,
   active = true,
+  emptyMessage = "No terminal sessions.",
 }: {
   summary: RuntimeSummary;
   active?: boolean;
+  emptyMessage?: string;
 }) {
   const [embeddedId, setEmbeddedId] = useState<string | null>(null);
   const sessions = summary.terminalSessions.items;
@@ -79,7 +81,7 @@ export function InspectorTerminalPanel({
           className="rounded-md border p-3 text-sm"
           style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}
         >
-          No terminal sessions.
+          {emptyMessage}
         </p>
       ) : null}
     </div>

--- a/desktop/src/renderer/src/features/panels/inspector-layout-store.ts
+++ b/desktop/src/renderer/src/features/panels/inspector-layout-store.ts
@@ -53,11 +53,13 @@ type PanelLayout = z.infer<typeof PanelLayoutSchema>;
 export interface InspectorLayout {
   widthPct: number;
   collapsed: boolean;
+  maximized: boolean;
 }
 
 const DEFAULT_LAYOUT: InspectorLayout = {
   widthPct: DEFAULT_INSPECTOR_WIDTH_PCT,
-  collapsed: false,
+  collapsed: true,
+  maximized: false,
 };
 
 interface InspectorLayoutState {
@@ -68,6 +70,7 @@ interface InspectorLayoutState {
   layoutFor: (projectId: string) => InspectorLayout;
   setWidthPct: (projectId: string, widthPct: number) => void;
   setCollapsed: (projectId: string, collapsed: boolean) => void;
+  setMaximized: (projectId: string, maximized: boolean) => void;
 }
 
 function clampWidthPct(widthPct: number): number {
@@ -93,7 +96,11 @@ function envelopeFor(entry: InspectorLayout, now: number): PanelLayout {
   const widthPct = clampWidthPct(entry.widthPct);
   return {
     order: ["conversation", "inspector"],
-    visible: { conversation: true, inspector: !entry.collapsed },
+    visible: {
+      conversation: true,
+      inspector: !entry.collapsed,
+      inspectorMaximized: entry.maximized,
+    },
     sizes: { conversation: 100 - widthPct, inspector: widthPct },
     touchedAt: now,
   };
@@ -104,9 +111,11 @@ function envelopeFor(entry: InspectorLayout, now: number): PanelLayout {
 function entryFromEnvelope(layout: PanelLayout): InspectorLayout | null {
   const widthPct = layout.sizes.inspector;
   if (typeof widthPct !== "number" || !Number.isFinite(widthPct)) return null;
+  const collapsed = layout.visible.inspector === false;
   return {
     widthPct: clampWidthPct(widthPct),
-    collapsed: layout.visible.inspector === false,
+    collapsed,
+    maximized: !collapsed && layout.visible.inspectorMaximized === true,
   };
 }
 
@@ -184,8 +193,24 @@ export const useInspectorLayout = create<InspectorLayoutState>()((set, get) => (
 
   setCollapsed: (projectId, collapsed) => {
     const current = get().entries[projectId] ?? DEFAULT_LAYOUT;
-    if (current.collapsed === collapsed) return;
-    const next: InspectorLayout = { ...current, collapsed };
+    if (current.collapsed === collapsed && (!collapsed || !current.maximized)) return;
+    const next: InspectorLayout = {
+      ...current,
+      collapsed,
+      maximized: collapsed ? false : current.maximized,
+    };
+    set((state) => ({ entries: { ...state.entries, [projectId]: next } }));
+    persistEntry(projectId, next);
+  },
+
+  setMaximized: (projectId, maximized) => {
+    const current = get().entries[projectId] ?? DEFAULT_LAYOUT;
+    if (current.maximized === maximized && (!maximized || !current.collapsed)) return;
+    const next: InspectorLayout = {
+      ...current,
+      collapsed: maximized ? false : current.collapsed,
+      maximized,
+    };
     set((state) => ({ entries: { ...state.entries, [projectId]: next } }));
     persistEntry(projectId, next);
   },

--- a/desktop/src/renderer/src/features/project/ProjectChatsView.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatsView.tsx
@@ -1,5 +1,5 @@
-import { MessageSquare, PanelRightClose, PanelRightOpen, Server } from "lucide-react";
-import { useCallback, useEffect, useEffectEvent, useRef, useState } from "react";
+import { Maximize2, MessageSquare, Minimize2, PanelRightOpen, Server, X } from "lucide-react";
+import { useCallback, useEffect, useEffectEvent, useRef, useState, type ReactNode } from "react";
 import { Group, Panel, Separator, type Layout as SplitLayout } from "react-resizable-panels";
 import { defaultAgentThreadComposerDraft } from "@matrix-os/contracts";
 import { codingAgentRuntimeScope } from "../../../../shared/coding-agent-project-workspace";
@@ -30,8 +30,6 @@ import type { ComposerSeed } from "../coding-agents/composer-seed";
 import {
   AttentionThreadList,
   InspectorEmptyState,
-  NotificationPreferencesPanel,
-  ProviderList,
 } from "../coding-agents/AgentWorkspacePanels";
 import { capabilityEnabled } from "../coding-agents/capabilities";
 import { isTypeToStartInteractiveTarget } from "../coding-agents/type-to-start";
@@ -39,6 +37,7 @@ import { CreatedThreadHandleList, ThreadList } from "../coding-agents/AgentThrea
 import { ReviewList, reviewHunkFollowUpDraft } from "../coding-agents/AgentReviewPanel";
 import { loadCodingAgentConversation, openCodingAgentThread } from "../../lib/project-chat";
 import { ProjectChatDraft } from "./ProjectChatDraft";
+import { buildProjectInspectorContext } from "./project-inspector-context";
 import { ProjectThreadList } from "./ProjectThreadList";
 
 export { mergeAttachments, mergeComposerSeed, clearComposerLaunchContext } from "../coding-agents/composer-seed";
@@ -115,7 +114,8 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
     void ensureWorkspace(projectId);
   }, [ensureWorkspace, projectId, projectWorkspaceEnabled, runtimeScope]);
 
-  const inspectorCollapsed = inspectorEntry?.collapsed ?? false;
+  const inspectorCollapsed = inspectorEntry?.collapsed ?? true;
+  const inspectorMaximized = inspectorEntry?.maximized ?? false;
   const inspectorWidthPct = inspectorEntry?.widthPct ?? DEFAULT_INSPECTOR_WIDTH_PCT;
 
   // Review focus can originate outside the inspector (for example, from a
@@ -332,12 +332,16 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
   const snapshotMatches = selectedThreadId !== null
     && threadSnapshot?.thread.id === selectedThreadId
     && activeThreadId === selectedThreadId;
-  const inspectorCounts = {
-    changes: reviewEnabled ? (reviews?.items.length ?? 0) : 0,
-    terminal: summary.terminalSessions.items.length,
-    preview: previewEnabled ? (summary.previewSessions?.items.length ?? 0) : 0,
-    activity: summary.attentionThreads.items.length + summary.activeThreads.items.length,
-  };
+  const selectedThreadContext = snapshotMatches
+    ? threadSnapshot.thread
+    : [...(workspace?.projectThreads.items ?? []), ...(workspace?.taskThreads.items ?? [])]
+      .find((thread) => thread.id === selectedThreadId) ?? null;
+  const inspectorContext = buildProjectInspectorContext({
+    projectId,
+    summary,
+    selectedThread: selectedThreadContext,
+    reviews: reviews?.items ?? [],
+  });
 
   // Selecting a thread is navigation only. Recents is promoted by successful
   // message sends, never by opening or re-opening a conversation.
@@ -368,8 +372,10 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
   // The inspector tab is controlled so live surfaces can gate on visibility:
   // the embedded terminal releases the single app-wide socket attachment
   // while another surface (or a background project tab) is showing.
-  const inspectorDefaultTab: AgentConversationInspectorTab = reviewEnabled ? "changes" : "terminal";
-  const inspectorTab = inspectorTabOverride ?? inspectorDefaultTab;
+  const inspectorDefaultTab: AgentConversationInspectorTab = inspectorContext.defaultTab;
+  const inspectorTab = inspectorTabOverride && inspectorContext.tabs.includes(inspectorTabOverride)
+    ? inspectorTabOverride
+    : inspectorDefaultTab;
 
   const handleSplitLayout = (layout: SplitLayout) => {
     const pct = layout["inspector"];
@@ -443,30 +449,45 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
     >
       <AgentConversationInspector
         defaultTab={inspectorDefaultTab}
+        tabs={inspectorContext.tabs}
         selectedTab={inspectorTab}
         onTabChange={setInspectorTabOverride}
         changesFocusRequestId={reviewFocusRequestId}
         changesFocusConsumedId={reviewFocusConsumedId}
         onChangesFocusConsumed={consumeReviewFocusRequest}
-        counts={inspectorCounts}
+        counts={inspectorContext.counts}
         toolbar={(
           <div className="flex items-center justify-between gap-3">
             <div className="min-w-0 flex-1">
               <h2 className="truncate text-sm font-semibold" style={{ color: "var(--text-primary)" }}>Conversation tools</h2>
               <p className="truncate text-xs" style={{ color: "var(--text-tertiary)" }}>Inspect the current project without leaving the chat</p>
             </div>
-            {projectWorkspaceEnabled ? (
-              <Button
-                variant="primary"
-                className="h-7 shrink-0 whitespace-nowrap"
-                aria-label="New chat in selected project"
-                onClick={() => {
-                  void openNewChat();
-                }}
+            <div className="flex shrink-0 items-center gap-1">
+              {projectWorkspaceEnabled ? (
+                <Button
+                  variant="primary"
+                  className="mr-1 h-7 shrink-0 whitespace-nowrap"
+                  aria-label="New chat in selected project"
+                  onClick={() => {
+                    void openNewChat();
+                  }}
+                >
+                  New chat
+                </Button>
+              ) : null}
+              <InspectorHeaderButton
+                label={inspectorMaximized ? "Restore conversation tools" : "Maximize conversation tools"}
+                onClick={() => useInspectorLayout.getState().setMaximized(projectId, !inspectorMaximized)}
               >
-                New chat
-              </Button>
-            ) : null}
+                {inspectorMaximized ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+              </InspectorHeaderButton>
+              <InspectorHeaderButton
+                label="Close conversation tools"
+                onClick={() => useInspectorLayout.getState().setCollapsed(projectId, true)}
+              >
+                <X size={14} />
+              </InspectorHeaderButton>
+            </div>
           </div>
         )}
         composer={
@@ -483,6 +504,8 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
         }
         changes={reviewEnabled ? (
           <ReviewList
+            projectId={projectId}
+            items={inspectorContext.reviews}
             canReadFiles={capabilityEnabled(summary, "codingAgentsFiles")}
             canPrepareCommit={capabilityEnabled(summary, "codingAgentsSourceControl")}
             canCreateFollowUp={canCreate}
@@ -503,34 +526,36 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
         ) : (
           <InspectorEmptyState message="Change review is not available on this computer." />
         )}
-        files={<InspectorFilesPanel />}
+        files={inspectorContext.tabs.includes("files") ? <InspectorFilesPanel scopeLabel="Matrix Home files" /> : undefined}
         terminal={(
           <InspectorTerminalPanel
-            summary={summary}
+            summary={inspectorContext.summary}
             active={inspectorTab === "terminal" && active && !inspectorCollapsed}
+            emptyMessage={inspectorContext.terminalState === "unavailable"
+              ? "The linked terminal session is no longer available."
+              : "This chat has no linked terminal session."}
           />
         )}
         preview={previewEnabled ? (
-          <InspectorPreviewPanel summary={summary} />
+          <InspectorPreviewPanel summary={inspectorContext.summary} />
         ) : (
           <InspectorEmptyState message="No preview capability is available for this project." />
         )}
         activity={(
           <div className="space-y-4">
             <AttentionThreadList
-              summary={summary}
+              summary={inspectorContext.summary}
               onOpenThread={(thread) => openListedThread(thread.id, thread.projectId)}
             />
             <ThreadList
-              summary={summary}
+              summary={inspectorContext.summary}
               onOpenThread={(thread) => openListedThread(thread.id, thread.projectId)}
             />
             <CreatedThreadHandleList
-              summary={summary}
+              summary={inspectorContext.summary}
+              projectId={projectId}
               onOpenThread={(thread) => openListedThread(thread.id, thread.projectId)}
             />
-            <ProviderList summary={summary} />
-            <NotificationPreferencesPanel />
           </div>
         )}
       />
@@ -560,13 +585,24 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
         <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
           {conversationColumn}
         </div>
+      ) : inspectorMaximized ? (
+        <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+          <div data-testid="conversation-underlay" className="invisible flex min-h-0 min-w-0 flex-1 flex-col">
+            {conversationColumn}
+          </div>
+          <div
+            data-testid="inspector-maximized"
+            className="absolute inset-0 z-20 flex min-h-0 min-w-0 flex-col overflow-hidden"
+          >
+            {inspectorPanel}
+          </div>
+        </div>
       ) : inspectorCollapsed ? (
         <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
           {conversationColumn}
-          <InspectorToggle
-            collapsed
+          <InspectorOpenButton
             controls={inspectorRegionId}
-            onToggle={() => useInspectorLayout.getState().setCollapsed(projectId, false)}
+            onOpen={() => useInspectorLayout.getState().setCollapsed(projectId, false)}
           />
         </div>
       ) : (
@@ -587,11 +623,6 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
           >
             <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
               {conversationColumn}
-              <InspectorToggle
-                collapsed={false}
-                controls={inspectorRegionId}
-                onToggle={() => useInspectorLayout.getState().setCollapsed(projectId, true)}
-              />
             </div>
           </Panel>
           <Separator
@@ -619,6 +650,29 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
   );
 }
 
+function InspectorHeaderButton({
+  label,
+  onClick,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      onClick={onClick}
+      className="no-drag flex h-7 w-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-[var(--bg-hover)] focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+      style={{ color: "var(--text-tertiary)" }}
+    >
+      {children}
+    </button>
+  );
+}
+
 const NARROW_INSPECTOR_MEDIA_QUERY = "(max-width: 1099px)";
 
 function useNarrowInspectorLayout(): boolean {
@@ -640,27 +694,24 @@ function useNarrowInspectorLayout(): boolean {
   return narrow;
 }
 
-// Collapse toggle for the tools inspector. Lives in the conversation pane's
-// top-right corner so the hero transcript keeps one persistent, keyboard-
-// reachable control in both states.
-function InspectorToggle({
-  collapsed,
+// The closed inspector leaves one persistent, keyboard-reachable control in
+// the conversation pane's top-right corner.
+function InspectorOpenButton({
   controls,
-  onToggle,
+  onOpen,
 }: {
-  collapsed: boolean;
   controls: string;
-  onToggle: () => void;
+  onOpen: () => void;
 }) {
-  const label = collapsed ? "Show conversation tools" : "Hide conversation tools";
+  const label = "Show conversation tools";
   return (
     <button
       type="button"
       aria-label={label}
-      aria-expanded={!collapsed}
+      aria-expanded={false}
       aria-controls={controls}
       title={label}
-      onClick={onToggle}
+      onClick={onOpen}
       className="no-drag absolute right-2.5 top-2.5 z-10 flex h-7 w-7 shrink-0 items-center justify-center rounded-md border outline-none transition-colors hover:brightness-105 focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
       style={{
         borderColor: "var(--border-subtle)",
@@ -668,7 +719,7 @@ function InspectorToggle({
         color: "var(--text-tertiary)",
       }}
     >
-      {collapsed ? <PanelRightOpen size={14} /> : <PanelRightClose size={14} />}
+      <PanelRightOpen size={14} />
     </button>
   );
 }

--- a/desktop/src/renderer/src/features/project/ProjectChatsView.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatsView.tsx
@@ -332,10 +332,7 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
   const snapshotMatches = selectedThreadId !== null
     && threadSnapshot?.thread.id === selectedThreadId
     && activeThreadId === selectedThreadId;
-  const selectedThreadContext = snapshotMatches
-    ? threadSnapshot.thread
-    : [...(workspace?.projectThreads.items ?? []), ...(workspace?.taskThreads.items ?? [])]
-      .find((thread) => thread.id === selectedThreadId) ?? null;
+  const selectedThreadContext = snapshotMatches ? threadSnapshot.thread : null;
   const inspectorContext = buildProjectInspectorContext({
     projectId,
     summary,

--- a/desktop/src/renderer/src/features/project/project-inspector-context.ts
+++ b/desktop/src/renderer/src/features/project/project-inspector-context.ts
@@ -1,0 +1,125 @@
+import type {
+  AgentThreadSummary,
+  ReviewSummary,
+  RuntimeSummary,
+} from "@matrix-os/contracts";
+import type { AgentConversationInspectorTab } from "../coding-agents/AgentConversationInspector";
+import { capabilityEnabled } from "../coding-agents/capabilities";
+
+export type ProjectInspectorTerminalState = "linked" | "unavailable" | "unbound";
+
+export interface ProjectInspectorContext {
+  summary: RuntimeSummary;
+  reviews: ReviewSummary[];
+  tabs: AgentConversationInspectorTab[];
+  defaultTab: AgentConversationInspectorTab;
+  terminalState: ProjectInspectorTerminalState;
+  counts: {
+    changes: number;
+    files: undefined;
+    terminal: number;
+    preview: number;
+    activity: number;
+  };
+}
+
+interface BuildProjectInspectorContextInput {
+  projectId: string;
+  summary: RuntimeSummary;
+  selectedThread: AgentThreadSummary | null;
+  reviews: readonly ReviewSummary[];
+}
+
+function projectThreads(
+  items: readonly AgentThreadSummary[],
+  projectId: string,
+): AgentThreadSummary[] {
+  return items.filter((thread) => thread.projectId === projectId);
+}
+
+/**
+ * Produces the only data Project Chat tools may render. Runtime-wide records
+ * without a validated project/thread relation are deliberately excluded.
+ * This stays pure so capability and empty-state behavior can be verified
+ * without mounting the large Project Chats composition.
+ */
+export function buildProjectInspectorContext({
+  projectId,
+  summary,
+  selectedThread,
+  reviews,
+}: BuildProjectInspectorContextInput): ProjectInspectorContext {
+  const reviewEnabled = capabilityEnabled(summary, "codingAgentsReview");
+  const previewEnabled = capabilityEnabled(summary, "codingAgentsPreview");
+  const filesEnabled = capabilityEnabled(summary, "codingAgentsFiles");
+
+  const scopedReviews = reviewEnabled
+    ? reviews.filter((review) => review.projectId === projectId)
+    : [];
+  const scopedPreviews = previewEnabled
+    ? summary.previewSessions.items.filter((preview) => preview.projectId === projectId)
+    : [];
+  const scopedActiveThreads = projectThreads(summary.activeThreads.items, projectId);
+  const scopedAttentionThreads = projectThreads(summary.attentionThreads.items, projectId);
+
+  const terminalSessionId = selectedThread?.projectId === projectId
+    ? selectedThread.terminalSessionId
+    : undefined;
+  const linkedTerminal = terminalSessionId
+    ? summary.terminalSessions.items.find((session) => session.id === terminalSessionId) ?? null
+    : null;
+  const terminalState: ProjectInspectorTerminalState = linkedTerminal
+    ? "linked"
+    : terminalSessionId
+      ? "unavailable"
+      : "unbound";
+
+  const activityIds = new Set([
+    ...scopedActiveThreads.map((thread) => thread.id),
+    ...scopedAttentionThreads.map((thread) => thread.id),
+  ]);
+  const tabs: AgentConversationInspectorTab[] = [
+    ...(reviewEnabled ? ["changes" as const] : []),
+    ...(filesEnabled ? ["files" as const] : []),
+    "terminal",
+    ...(previewEnabled ? ["preview" as const] : []),
+    "activity",
+  ];
+  const defaultTab = scopedReviews.length > 0
+    ? "changes"
+    : linkedTerminal
+      ? "terminal"
+      : scopedPreviews.length > 0
+        ? "preview"
+        : filesEnabled
+          ? "files"
+          : "activity";
+
+  return {
+    reviews: scopedReviews,
+    tabs,
+    defaultTab,
+    terminalState,
+    counts: {
+      changes: scopedReviews.length,
+      files: undefined,
+      terminal: linkedTerminal ? 1 : 0,
+      preview: scopedPreviews.length,
+      activity: activityIds.size,
+    },
+    summary: {
+      ...summary,
+      activeThreads: { ...summary.activeThreads, items: scopedActiveThreads, hasMore: false },
+      attentionThreads: { ...summary.attentionThreads, items: scopedAttentionThreads, hasMore: false },
+      terminalSessions: {
+        ...summary.terminalSessions,
+        items: linkedTerminal ? [linkedTerminal] : [],
+        hasMore: false,
+      },
+      previewSessions: { ...summary.previewSessions, items: scopedPreviews, hasMore: false },
+      // Activity records currently carry no project relation. Rendering them
+      // here would falsely present runtime-global events as project context.
+      recentActivity: { ...summary.recentActivity, items: [], hasMore: false },
+    },
+  };
+}

--- a/tests/desktop/coding-agent-context-inspector.test.tsx
+++ b/tests/desktop/coding-agent-context-inspector.test.tsx
@@ -268,4 +268,25 @@ describe("AgentConversationInspector", () => {
     });
     expect(within(tablist).queryByText("Terminal")).toBeNull();
   });
+
+  it("renders only the contextual surfaces supplied by the project model", () => {
+    render(
+      <AgentConversationInspector
+        defaultTab="files"
+        tabs={["files", "terminal", "activity"]}
+        counts={{ changes: 0, files: undefined, terminal: 1, preview: 0, activity: 2 }}
+        toolbar={<div>Tools</div>}
+        changes={<div>Reviews</div>}
+        files={<div>Matrix Home files</div>}
+        terminal={<div>Linked terminal</div>}
+        preview={<div>Project preview</div>}
+        activity={<div>Project activity</div>}
+      />,
+    );
+
+    expect(screen.queryByRole("tab", { name: /^Changes\b/ })).toBeNull();
+    expect(screen.queryByRole("tab", { name: /^Preview\b/ })).toBeNull();
+    expect(screen.getByRole("tab", { name: /^Files\b/ })).toBeTruthy();
+    expect(screen.getByText("Matrix Home files")).toBeTruthy();
+  });
 });

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -19,7 +19,15 @@ import { reconcileDesktopRuntimeChange } from "../../desktop/src/renderer/src/st
 import { useBoard } from "../../desktop/src/renderer/src/stores/board";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
+import { useInspectorLayout } from "../../desktop/src/renderer/src/features/panels/inspector-layout-store";
 import { toast } from "sonner";
+import { codingAgentRuntimeScope } from "../../desktop/src/shared/coding-agent-project-workspace";
+
+const RUNTIME_SCOPE = codingAgentRuntimeScope({
+  handle: "operator",
+  platformHost: "https://platform.test",
+  runtimeSlot: "primary",
+});
 
 vi.mock("sonner", () => ({
   toast: { error: vi.fn(), success: vi.fn(), message: vi.fn() },
@@ -101,6 +109,7 @@ function summaryFixture({
           providerId: "codex",
           title: "Fix settings route",
           status: "running",
+          projectId: "matrix-os",
           ...(threadTerminalSessionId ? { terminalSessionId: threadTerminalSessionId } : {}),
           createdAt: "2026-07-06T00:00:00.000Z",
           updatedAt: "2026-07-06T00:01:00.000Z",
@@ -189,6 +198,7 @@ function previewSummaryFixture() {
       items: [
         {
           id: "prev_local",
+          projectId: "matrix-os",
           label: "Local web app",
           status: "running",
           origin: "http://localhost:3000",
@@ -196,12 +206,14 @@ function previewSummaryFixture() {
         },
         {
           id: "prev_internal",
+          projectId: "matrix-os",
           label: "Internal service",
           status: "running",
           updatedAt: "2026-07-06T00:03:00.000Z",
         },
         {
           id: "prev_secure",
+          projectId: "matrix-os",
           label: "Secure app",
           status: "running",
           origin: "https://preview.matrix-os.test",
@@ -341,6 +353,7 @@ function threadSnapshotFixture() {
       title: "Fix settings route",
       status: "waiting_for_approval",
       attention: "approval_required",
+      projectId: "matrix-os",
       terminalSessionId: "matrix-abc1234",
       createdAt: "2026-07-06T00:00:00.000Z",
       updatedAt: "2026-07-06T00:04:00.000Z",
@@ -693,6 +706,15 @@ describe("ProjectChatsView", () => {
     useBoard.setState(useBoard.getInitialState(), true);
     useProjectView.setState({ entries: {}, runtimeScope: null });
     useProjectWorkspaces.setState({ entries: {} });
+    // This suite exercises the inspector's panels, not its default-closed
+    // disclosure behavior (covered by project-chats-view-layout.test.tsx).
+    useInspectorLayout.setState({
+      entries: {
+        "matrix-os": { widthPct: 34, collapsed: false, maximized: false },
+      },
+      runtimeScope: RUNTIME_SCOPE,
+      hydratedScope: RUNTIME_SCOPE,
+    });
     useCodingAgentWorkspace.setState({
       status: "idle",
       summary: null,
@@ -770,15 +792,15 @@ describe("ProjectChatsView", () => {
     vi.useRealTimers();
   });
 
-  it("renders provider, thread, and terminal summaries from trusted IPC", async () => {
+  it("renders project thread activity without borrowing an unrelated terminal", async () => {
     render(<ProjectChatsView projectId="matrix-os" active />);
 
     expect(screen.getByText("Loading workspace...")).toBeTruthy();
     await selectInspectorTab("Activity");
-    expect(screen.getByText("Codex")).toBeTruthy();
-    expect(screen.getByText("Fix settings route")).toBeTruthy();
+    expect(screen.getAllByText("Fix settings route").length).toBeGreaterThan(0);
     await selectInspectorTab("Terminal");
-    expect(screen.getByText("matrix-abc1234")).toBeTruthy();
+    expect(screen.getByText("This chat has no linked terminal session.")).toBeTruthy();
+    expect(screen.queryByText("matrix-abc1234")).toBeNull();
     expect(window.operator.invoke).toHaveBeenCalledWith("runtime:get-summary", {});
   });
 
@@ -825,7 +847,7 @@ describe("ProjectChatsView", () => {
 
     render(<ProjectChatsView projectId="matrix-os" active />);
     await selectInspectorTab("Activity");
-    await screen.findByText("Fix settings route");
+    await screen.findAllByText("Fix settings route");
     act(() => {
       useCodingAgentWorkspace.setState({
         createdThreadHandles: [...firstSummary.activeThreads.items],
@@ -895,8 +917,9 @@ describe("ProjectChatsView", () => {
       resolveSecondSummary?.(secondSummary);
       await pendingSecondSummary;
     });
+    fireEvent.click(screen.getByRole("button", { name: "Show conversation tools" }));
     await selectInspectorTab("Activity");
-    await screen.findByText("Second account thread");
+    await screen.findAllByText("Second account thread");
     expect(useCodingAgentWorkspace.getState().reviews).toBeNull();
 
     await act(async () => {
@@ -1438,7 +1461,7 @@ describe("ProjectChatsView", () => {
     expect(screen.queryByText(/Output was truncated for display/)).toBeNull();
   });
 
-  it("hydrates and updates notification preferences through trusted IPC", async () => {
+  it("keeps runtime-wide notification preferences out of project activity", async () => {
     let preferenceReads = 0;
     window.operator.invoke = vi.fn((channel: string, payload?: unknown) => {
       if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture());
@@ -1459,17 +1482,11 @@ describe("ProjectChatsView", () => {
 
     await selectInspectorTab("Activity");
 
-    const failedToggle = await screen.findByRole("checkbox", { name: "Failed run alerts" });
-    expect((failedToggle as HTMLInputElement).checked).toBe(false);
-
-    fireEvent.click(failedToggle);
-
-    await waitFor(() => {
-      expect(window.operator.invoke).toHaveBeenCalledWith("runtime:update-notification-preferences", {
-        attentionPush: { approval: false, input: true, failed: true, completed: true },
-      });
-    });
-    expect((await screen.findByRole("checkbox", { name: "Failed run alerts" }) as HTMLInputElement).checked).toBe(true);
+    expect(screen.queryByRole("checkbox", { name: "Failed run alerts" })).toBeNull();
+    expect(window.operator.invoke).not.toHaveBeenCalledWith(
+      "runtime:update-notification-preferences",
+      expect.anything(),
+    );
     expect(screen.queryByText(/token|bearer|secret|\/home\/matrix/i)).toBeNull();
   });
 
@@ -1496,10 +1513,10 @@ describe("ProjectChatsView", () => {
     await selectInspectorTab("Activity");
 
     expect(await screen.findByText("Needs Attention")).toBeTruthy();
-    expect(screen.getByText("Approve deployment")).toBeTruthy();
-    expect(screen.getByText("Repair failed run")).toBeTruthy();
+    expect(screen.getAllByText("Approve deployment").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Repair failed run").length).toBeGreaterThan(0);
     expect(screen.getByText("Approval needed")).toBeTruthy();
-    expect(screen.getByText("Failed")).toBeTruthy();
+    expect(screen.getAllByText("Failed").length).toBeGreaterThan(0);
     expect(screen.getByText("No active threads.")).toBeTruthy();
   });
 
@@ -2247,33 +2264,26 @@ describe("ProjectChatsView", () => {
     expect(screen.getByText("No active threads.")).toBeTruthy();
   });
 
-  it("opens a bound thread terminal in the existing terminal tab model", async () => {
+  it("shows only the selected chat's bound terminal", async () => {
+    useProjectView.getState().setSelectedThread("matrix-os", "thread_alpha");
     window.operator.invoke = vi.fn((channel: string) => {
       if (channel === "runtime:get-summary") {
         return Promise.resolve(summaryFixture({ threadTerminalSessionId: "matrix-abc1234" }));
       }
       if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-thread-snapshot") return Promise.resolve(threadSnapshotFixture());
       return Promise.reject(new Error("unexpected channel"));
     });
 
     render(<ProjectChatsView projectId="matrix-os" active />);
 
-    await selectInspectorTab("Activity");
-
-    await screen.findByText("Fix settings route");
-    fireEvent.click(screen.getByRole("button", { name: "Open terminal for Fix settings route" }));
-
-    const tabs = useTabs.getState().tabs;
-    expect(tabs).toHaveLength(1);
-    expect(tabs[0]).toMatchObject({
-      kind: "terminal",
-      sessionName: "matrix-abc1234",
-      title: "matrix-abc1234",
-    });
-    expect(useTabs.getState().activeTabId).toBe(tabs[0]?.id);
+    await selectInspectorTab("Terminal");
+    expect(await screen.findByText("matrix-abc1234")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open terminal matrix-abc1234" })).toBeTruthy();
   });
 
-  it("opens a bound thread terminal by canonical session id when the display name differs", async () => {
+  it("resolves the selected chat terminal by canonical session id when its display name differs", async () => {
+    useProjectView.getState().setSelectedThread("matrix-os", "thread_alpha");
     window.operator.invoke = vi.fn((channel: string) => {
       if (channel === "runtime:get-summary") {
         return Promise.resolve(summaryFixture({
@@ -2282,41 +2292,37 @@ describe("ProjectChatsView", () => {
         }));
       }
       if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-thread-snapshot") return Promise.resolve(threadSnapshotFixture());
       return Promise.reject(new Error("unexpected channel"));
     });
 
     render(<ProjectChatsView projectId="matrix-os" active />);
 
-    await selectInspectorTab("Activity");
-
-    await screen.findByText("Fix settings route");
-    fireEvent.click(screen.getByRole("button", { name: "Open terminal for Fix settings route" }));
-
-    const tabs = useTabs.getState().tabs;
-    expect(tabs).toHaveLength(1);
-    expect(tabs[0]).toMatchObject({
-      kind: "terminal",
-      sessionName: "matrix-abc1234",
-      title: "friendly-shell",
-    });
+    await selectInspectorTab("Terminal");
+    expect(await screen.findByText("friendly-shell")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open terminal friendly-shell" })).toBeTruthy();
   });
 
-  it("does not open stale thread terminal bindings", async () => {
+  it("shows an unavailable state for a stale selected-chat terminal binding", async () => {
+    useProjectView.getState().setSelectedThread("matrix-os", "thread_alpha");
     window.operator.invoke = vi.fn((channel: string) => {
       if (channel === "runtime:get-summary") {
         return Promise.resolve(summaryFixture({ threadTerminalSessionId: "matrix-missing" }));
       }
       if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-thread-snapshot") {
+        return Promise.resolve({
+          ...threadSnapshotFixture(),
+          thread: { ...threadSnapshotFixture().thread, terminalSessionId: "matrix-missing" },
+        });
+      }
       return Promise.reject(new Error("unexpected channel"));
     });
 
     render(<ProjectChatsView projectId="matrix-os" active />);
 
-    await selectInspectorTab("Activity");
-
-    await screen.findByText("Fix settings route");
-    expect(screen.queryByRole("button", { name: "Open terminal for Fix settings route" })).toBeNull();
-    expect(useTabs.getState().tabs).toHaveLength(0);
+    await selectInspectorTab("Terminal");
+    expect(await screen.findByText("The linked terminal session is no longer available.")).toBeTruthy();
   });
 
   it("renders read-only review summaries through trusted IPC", async () => {
@@ -3452,6 +3458,7 @@ describe("ProjectChatsView", () => {
 
     render(<ProjectChatsView projectId="matrix-os" active />);
 
+    await selectInspectorTab("Changes");
     expect(await screen.findByText("Review state unavailable")).toBeTruthy();
     expect(screen.queryByText(/home\/matrix|token|secret/i)).toBeNull();
   });
@@ -3654,6 +3661,7 @@ describe("ProjectChatsView", () => {
             title: "Investigate retained workspace handle",
             status: "queued",
             attention: "none",
+            projectId: "matrix-os",
             createdAt: "2026-07-06T00:00:00.000Z",
             updatedAt: "2026-07-06T00:00:00.000Z",
           },
@@ -3708,6 +3716,7 @@ describe("ProjectChatsView", () => {
         title: "Investigate retained workspace handle",
         status: "queued",
         attention: "none",
+        projectId: "matrix-os",
         createdAt: "2026-07-06T00:00:00.000Z",
         updatedAt: "2026-07-06T00:00:00.000Z",
       },
@@ -4067,7 +4076,7 @@ describe("ProjectChatsView", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     await selectInspectorTab("Activity");
-    await screen.findByText("Fix settings route");
+    await screen.findAllByText("Fix settings route");
   });
 
   function projectWorkspaceReadySummary() {

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -2336,6 +2336,32 @@ describe("ProjectChatsView", () => {
     expect(window.operator.invoke).toHaveBeenCalledWith("runtime:get-reviews", {});
   });
 
+  it("does not render another project's review detail status", async () => {
+    render(<ProjectChatsView projectId="matrix-os" active />);
+
+    await screen.findByText("matrix-os");
+
+    act(() => {
+      useCodingAgentWorkspace.setState({
+        selectedReviewId: "rev_other_project",
+        reviewSnapshotStatus: "loading",
+        reviewSnapshot: null,
+        reviewSnapshotError: null,
+      });
+    });
+
+    expect(screen.queryByText("Loading review details...")).toBeNull();
+
+    act(() => {
+      useCodingAgentWorkspace.setState({
+        reviewSnapshotStatus: "error",
+        reviewSnapshotError: "Review details unavailable",
+      });
+    });
+
+    expect(screen.queryByText("Review details unavailable")).toBeNull();
+  });
+
   it("loads a read-only review snapshot when a review is selected", async () => {
     render(<ProjectChatsView projectId="matrix-os" active />);
 

--- a/tests/desktop/draft-chat-replaces-selection.test.tsx
+++ b/tests/desktop/draft-chat-replaces-selection.test.tsx
@@ -13,8 +13,14 @@ import { useProjectView } from "../../desktop/src/renderer/src/stores/project-vi
 import { useProjectWorkspaces } from "../../desktop/src/renderer/src/stores/project-workspaces";
 import { useProjectChatLauncher } from "../../desktop/src/renderer/src/lib/project-chat";
 import { clearDraftChats, useDraftChat } from "../../desktop/src/renderer/src/stores/draft-chat";
+import { codingAgentRuntimeScope } from "../../desktop/src/shared/coding-agent-project-workspace";
 
 const NOW = "2026-07-12T12:00:00.000Z";
+const RUNTIME_SCOPE = codingAgentRuntimeScope({
+  handle: "operator",
+  platformHost: "https://platform.test",
+  runtimeSlot: "primary",
+});
 const defaultResolveNewChatTarget = useProjectWorkspaces.getState().resolveNewChatTarget;
 
 function summaryFixture(): RuntimeSummary {
@@ -206,7 +212,15 @@ function resetStores() {
   useProjectView.setState({ entries: {}, runtimeScope: null });
   useProjectWorkspaces.setState({ entries: {}, resolveNewChatTarget: defaultResolveNewChatTarget });
   useProjectChatLauncher.setState({ composerRequest: null });
-  useInspectorLayout.setState({ entries: {}, runtimeScope: null });
+  // Most of this suite covers draft replacement; keep the inspector expanded
+  // for the one review-follow-up case that intentionally enters that surface.
+  useInspectorLayout.setState({
+    entries: {
+      "matrix-os": { widthPct: 34, collapsed: false, maximized: false },
+    },
+    runtimeScope: RUNTIME_SCOPE,
+    hydratedScope: RUNTIME_SCOPE,
+  });
   useProviderPreferences.setState({ defaultProviderId: null, hydrated: false });
   useCodingAgentWorkspace.setState({
     status: "idle",

--- a/tests/desktop/inspector-files-panel.test.tsx
+++ b/tests/desktop/inspector-files-panel.test.tsx
@@ -143,6 +143,8 @@ describe("InspectorFilesPanel", () => {
   it("opens with the browser and a preview placeholder", async () => {
     renderPanel();
 
+    expect(screen.getByText("Matrix Home")).toBeTruthy();
+    expect(screen.getByText("Browse this computer's files. This view is not limited to the selected project.")).toBeTruthy();
     expect(await screen.findByRole("button", { name: "Open README.md" })).toBeTruthy();
     expect(screen.getByText("Choose a file")).toBeTruthy();
   });

--- a/tests/desktop/inspector-layout-store.test.ts
+++ b/tests/desktop/inspector-layout-store.test.ts
@@ -51,10 +51,30 @@ describe("inspector-layout-store", () => {
     vi.restoreAllMocks();
   });
 
-  it("defaults to an expanded inspector at the default width", () => {
+  it("defaults to a closed contextual inspector at the default width", () => {
+    expect(useInspectorLayout.getState().layoutFor("matrix-os")).toEqual({
+      widthPct: DEFAULT_INSPECTOR_WIDTH_PCT,
+      collapsed: true,
+      maximized: false,
+    });
+  });
+
+  it("persists maximize state and restores the inspector before maximizing", async () => {
+    const { saved } = mockOperator();
+    await useInspectorLayout.getState().hydrate("scope-a");
+
+    useInspectorLayout.getState().setMaximized("matrix-os", true);
+
     expect(useInspectorLayout.getState().layoutFor("matrix-os")).toEqual({
       widthPct: DEFAULT_INSPECTOR_WIDTH_PCT,
       collapsed: false,
+      maximized: true,
+    });
+    await vi.waitFor(() => expect(saved.length).toBe(1));
+    expect(saved[0]!.layout.visible).toEqual({
+      conversation: true,
+      inspector: true,
+      inspectorMaximized: true,
     });
   });
 
@@ -67,7 +87,11 @@ describe("inspector-layout-store", () => {
     await vi.waitFor(() => expect(saved.length).toBe(1));
     expect(saved[0]!.taskKey).toBe(taskKeyFor("scope-a", "matrix-os"));
     expect(saved[0]!.layout.sizes).toEqual({ conversation: 58, inspector: 42 });
-    expect(saved[0]!.layout.visible).toEqual({ conversation: true, inspector: true });
+    expect(saved[0]!.layout.visible).toEqual({
+      conversation: true,
+      inspector: false,
+      inspectorMaximized: false,
+    });
   });
 
   it("clamps the width to the supported range", () => {
@@ -81,18 +105,27 @@ describe("inspector-layout-store", () => {
   it("keeps the last width when collapsing so re-expand restores it", async () => {
     const { saved } = mockOperator();
     await useInspectorLayout.getState().hydrate("scope-a");
+    useInspectorLayout.getState().setCollapsed("matrix-os", false);
     useInspectorLayout.getState().setWidthPct("matrix-os", 40);
     useInspectorLayout.getState().setCollapsed("matrix-os", true);
 
     const entry = useInspectorLayout.getState().layoutFor("matrix-os");
-    expect(entry).toEqual({ widthPct: 40, collapsed: true });
-    await vi.waitFor(() => expect(saved.length).toBe(2));
+    expect(entry).toEqual({ widthPct: 40, collapsed: true, maximized: false });
+    await vi.waitFor(() => expect(saved.length).toBe(3));
     // The envelope still carries the width so expansion restores it.
-    expect(saved[1]!.layout.visible).toEqual({ conversation: true, inspector: false });
-    expect(saved[1]!.layout.sizes.inspector).toBe(40);
+    expect(saved[2]!.layout.visible).toEqual({
+      conversation: true,
+      inspector: false,
+      inspectorMaximized: false,
+    });
+    expect(saved[2]!.layout.sizes.inspector).toBe(40);
 
     useInspectorLayout.getState().setCollapsed("matrix-os", false);
-    expect(useInspectorLayout.getState().layoutFor("matrix-os")).toEqual({ widthPct: 40, collapsed: false });
+    expect(useInspectorLayout.getState().layoutFor("matrix-os")).toEqual({
+      widthPct: 40,
+      collapsed: false,
+      maximized: false,
+    });
   });
 
   it("hydrates persisted entries and ignores foreign or invalid layouts", async () => {
@@ -105,16 +138,39 @@ describe("inspector-layout-store", () => {
 
     await useInspectorLayout.getState().hydrate("scope-a");
 
-    expect(useInspectorLayout.getState().layoutFor("matrix-os")).toEqual({ widthPct: 45, collapsed: false });
+    expect(useInspectorLayout.getState().layoutFor("matrix-os")).toEqual({ widthPct: 45, collapsed: false, maximized: false });
     expect(useInspectorLayout.getState().hydratedScope).toBe("scope-a");
-    expect(useInspectorLayout.getState().layoutFor("website")).toEqual({ widthPct: 25, collapsed: true });
+    expect(useInspectorLayout.getState().layoutFor("website")).toEqual({ widthPct: 25, collapsed: true, maximized: false });
     expect(useInspectorLayout.getState().layoutFor("some-task")).toEqual({
       widthPct: DEFAULT_INSPECTOR_WIDTH_PCT,
-      collapsed: false,
+      collapsed: true,
+      maximized: false,
     });
     expect(useInspectorLayout.getState().layoutFor("broken")).toEqual({
       widthPct: DEFAULT_INSPECTOR_WIDTH_PCT,
-      collapsed: false,
+      collapsed: true,
+      maximized: false,
+    });
+  });
+
+  it("does not restore an impossible maximized state for a closed inspector", async () => {
+    mockOperator({
+      [taskKeyFor("scope-a", "matrix-os")]: {
+        ...persistedLayout(45, true),
+        visible: {
+          conversation: true,
+          inspector: false,
+          inspectorMaximized: true,
+        },
+      },
+    });
+
+    await useInspectorLayout.getState().hydrate("scope-a");
+
+    expect(useInspectorLayout.getState().layoutFor("matrix-os")).toEqual({
+      widthPct: 45,
+      collapsed: true,
+      maximized: false,
     });
   });
 
@@ -136,7 +192,8 @@ describe("inspector-layout-store", () => {
     expect(first.invoke.mock.calls.filter(([channel]) => channel === "state:get").length).toBe(2);
     expect(useInspectorLayout.getState().layoutFor("matrix-os")).toEqual({
       widthPct: DEFAULT_INSPECTOR_WIDTH_PCT,
-      collapsed: false,
+      collapsed: true,
+      maximized: false,
     });
   });
 
@@ -156,7 +213,8 @@ describe("inspector-layout-store", () => {
 
     expect(useInspectorLayout.getState().layoutFor("matrix-os")).toEqual({
       widthPct: DEFAULT_INSPECTOR_WIDTH_PCT,
-      collapsed: false,
+      collapsed: true,
+      maximized: false,
     });
   });
 
@@ -173,14 +231,15 @@ describe("inspector-layout-store", () => {
 
     expect(useInspectorLayout.getState().layoutFor("matrix-os")).toEqual({
       widthPct: DEFAULT_INSPECTOR_WIDTH_PCT,
-      collapsed: false,
+      collapsed: true,
+      maximized: false,
     });
   });
 
   it("persists under a runtime-scoped key so runtimes cannot overwrite each other", async () => {
     const { saved } = mockOperator();
     await useInspectorLayout.getState().hydrate("scope-b");
-    useInspectorLayout.getState().setCollapsed("matrix-os", true);
+    useInspectorLayout.getState().setCollapsed("matrix-os", false);
 
     await vi.waitFor(() => expect(saved.length).toBe(1));
     expect(saved[0]!.taskKey).toBe(taskKeyFor("scope-b", "matrix-os"));

--- a/tests/desktop/inspector-terminal-embed.test.tsx
+++ b/tests/desktop/inspector-terminal-embed.test.tsx
@@ -86,6 +86,18 @@ describe("InspectorTerminalPanel", () => {
     expect(screen.getByText(/No terminal sessions/)).toBeTruthy();
   });
 
+  it("explains when the selected chat has no canonical terminal binding", () => {
+    renderPanel(
+      <InspectorTerminalPanel
+        summary={summaryWith([])}
+        emptyMessage="This chat has no linked terminal session."
+      />,
+    );
+
+    expect(screen.getByText("This chat has no linked terminal session.")).toBeTruthy();
+    expect(screen.queryByText("No terminal sessions.")).toBeNull();
+  });
+
   it("embeds a live terminal for the picked session and returns to the list", () => {
     renderPanel(
       <InspectorTerminalPanel

--- a/tests/desktop/project-chats-view-layout.test.tsx
+++ b/tests/desktop/project-chats-view-layout.test.tsx
@@ -208,6 +208,11 @@ function resetStores() {
   });
 }
 
+async function openInspector(): Promise<void> {
+  fireEvent.click(await screen.findByRole("button", { name: "Show conversation tools" }));
+  await screen.findByTestId("inspector-split");
+}
+
 describe("ProjectChatsView hero layout", () => {
   beforeEach(() => {
     globalThis.ResizeObserver = MockResizeObserver as typeof ResizeObserver;
@@ -230,28 +235,47 @@ describe("ProjectChatsView hero layout", () => {
     vi.restoreAllMocks();
   });
 
-  it("shows the conversation and inspector in a resizable split by default", async () => {
+  it("keeps the conversation full width until contextual tools are requested", async () => {
     mockOperator();
     render(<ProjectChatsView projectId="matrix-os" active />);
+
+    expect(await screen.findByRole("button", { name: "Show conversation tools" })).toBeTruthy();
+    expect(screen.queryByTestId("inspector-split")).toBeNull();
+    expect(screen.queryByRole("complementary", { name: "Conversation tools" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show conversation tools" }));
 
     expect(await screen.findByTestId("inspector-split")).toBeTruthy();
     expect(screen.getByTestId("panel-conversation")).toBeTruthy();
     expect(screen.getByTestId("panel-inspector")).toBeTruthy();
     expect(screen.getByRole("separator")).toBeTruthy();
-    // The inspector starts open at the default width with a visible toggle.
     expect(panelsMock.lastDefaultLayout).toEqual({ conversation: 66, inspector: 34 });
     expect(screen.getByRole("complementary", { name: "Conversation tools" })).toBeTruthy();
-    const toggle = screen.getByRole("button", { name: "Hide conversation tools" });
-    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("button", { name: "Close conversation tools" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Maximize conversation tools" })).toBeTruthy();
+  });
+
+  it("maximizes the contextual workbench without unmounting the conversation", async () => {
+    mockOperator();
+    render(<ProjectChatsView projectId="matrix-os" active />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Show conversation tools" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Maximize conversation tools" }));
+
+    expect(await screen.findByTestId("inspector-maximized")).toBeTruthy();
+    expect(screen.getByTestId("conversation-underlay")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Restore conversation tools" })).toBeTruthy();
+    expect(useInspectorLayout.getState().layoutFor("matrix-os").maximized).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore conversation tools" }));
+    expect(await screen.findByTestId("inspector-split")).toBeTruthy();
   });
 
   it("hides the inspector entirely while the draft pane is showing", async () => {
     mockOperator();
     render(<ProjectChatsView projectId="matrix-os" active />);
 
-    // The first listed chat auto-selects, so the inspector split appears once
-    // the workspace finishes loading.
-    expect(await screen.findByTestId("inspector-split")).toBeTruthy();
+    expect(await screen.findByRole("button", { name: "Show conversation tools" })).toBeTruthy();
 
     act(() => {
       useProjectView.getState().setSelectedThread("matrix-os", null);
@@ -266,10 +290,10 @@ describe("ProjectChatsView hero layout", () => {
     expect(screen.queryByRole("button", { name: "Show conversation tools" })).toBeNull();
   });
 
-  it("brings the inspector back when a thread is selected from the rail", async () => {
+  it("keeps contextual tools closed when a thread is selected from the rail", async () => {
     mockOperator();
     render(<ProjectChatsView projectId="matrix-os" active />);
-    await screen.findByTestId("inspector-split");
+    await screen.findByRole("button", { name: "Show conversation tools" });
 
     act(() => {
       useProjectView.getState().setSelectedThread("matrix-os", null);
@@ -279,9 +303,8 @@ describe("ProjectChatsView hero layout", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Chat Plan the auth work" }));
 
-    expect(await screen.findByTestId("inspector-split")).toBeTruthy();
-    expect(screen.getByRole("complementary", { name: "Conversation tools" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Hide conversation tools" })).toBeTruthy();
+    expect(await screen.findByRole("button", { name: "Show conversation tools" })).toBeTruthy();
+    expect(screen.queryByRole("complementary", { name: "Conversation tools" })).toBeNull();
   });
 
   it("does not record a rail selection when its snapshot fails to load", async () => {
@@ -296,7 +319,7 @@ describe("ProjectChatsView hero layout", () => {
     });
     useCodingAgentWorkspace.setState({ loadThreadSnapshot });
     render(<ProjectChatsView projectId="matrix-os" active />);
-    await screen.findByTestId("inspector-split");
+    await screen.findByRole("button", { name: "Show conversation tools" });
 
     act(() => {
       useProjectView.getState().setSelectedThread("matrix-os", null);
@@ -317,7 +340,8 @@ describe("ProjectChatsView hero layout", () => {
     const { saved } = mockOperator();
     render(<ProjectChatsView projectId="matrix-os" active />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Hide conversation tools" }));
+    await openInspector();
+    fireEvent.click(screen.getByRole("button", { name: "Close conversation tools" }));
 
     expect(screen.queryByTestId("inspector-split")).toBeNull();
     expect(screen.queryByRole("complementary", { name: "Conversation tools" })).toBeNull();
@@ -385,7 +409,7 @@ describe("ProjectChatsView hero layout", () => {
 
     act(() => useCodingAgentWorkspace.setState({ reviewFocusRequestId: 1, reviewFocusConsumedId: 0 }));
 
-    expect(await screen.findByRole("button", { name: "Hide conversation tools" })).toBeTruthy();
+    expect(await screen.findByRole("button", { name: "Close conversation tools" })).toBeTruthy();
     expect(useInspectorLayout.getState().layoutFor("matrix-os").collapsed).toBe(false);
   });
 
@@ -402,7 +426,7 @@ describe("ProjectChatsView hero layout", () => {
 
     render(<ProjectChatsView projectId="matrix-os" active />);
 
-    await screen.findByTestId("inspector-split");
+    await openInspector();
     expect(panelsMock.lastOrientation).toBe("vertical");
     expect(panelsMock.lastDefaultLayout).toEqual({ conversation: 55, inspector: 45 });
   });
@@ -410,7 +434,7 @@ describe("ProjectChatsView hero layout", () => {
   it("persists inspector width changes from the split", async () => {
     mockOperator();
     render(<ProjectChatsView projectId="matrix-os" active />);
-    await screen.findByTestId("inspector-split");
+    await openInspector();
 
     act(() => {
       panelsMock.lastOnLayoutChange?.({ conversation: 55, inspector: 45 });
@@ -422,7 +446,7 @@ describe("ProjectChatsView hero layout", () => {
   it("keeps layouts independent per project", async () => {
     mockOperator();
     render(<ProjectChatsView projectId="matrix-os" active />);
-    await screen.findByTestId("inspector-split");
+    await openInspector();
 
     act(() => {
       panelsMock.lastOnLayoutChange?.({ conversation: 50, inspector: 50 });

--- a/tests/desktop/project-chats-view-layout.test.tsx
+++ b/tests/desktop/project-chats-view-layout.test.tsx
@@ -336,6 +336,55 @@ describe("ProjectChatsView hero layout", () => {
     );
   });
 
+  it("does not bind a cached workspace terminal while the selected thread snapshot is loading", async () => {
+    const { invoke } = mockOperator();
+    const defaultInvoke = invoke.getMockImplementation()!;
+    const pendingSnapshot = new Promise<never>(() => undefined);
+    invoke.mockImplementation(async (channel: string, payload: unknown) => {
+      if (channel === "runtime:get-summary") {
+        return {
+          ...summaryFixture(),
+          terminalSessions: {
+            items: [{
+              id: "term_cached",
+              name: "cached-shell",
+              status: "running",
+              attachable: true,
+              createdAt: NOW,
+              updatedAt: NOW,
+            }],
+            hasMore: false,
+            limit: 20,
+          },
+        };
+      }
+      if (channel === "runtime:get-project-workspace") {
+        const workspace = workspaceFixture();
+        return {
+          ...workspace,
+          projectThreads: {
+            ...workspace.projectThreads,
+            items: workspace.projectThreads.items.map((thread) => ({
+              ...thread,
+              terminalSessionId: "term_cached",
+            })),
+          },
+        };
+      }
+      if (channel === "runtime:get-thread-snapshot") return pendingSnapshot;
+      return defaultInvoke(channel, payload);
+    });
+
+    useProjectView.getState().setSelectedThread("matrix-os", "thread_plan");
+    render(<ProjectChatsView projectId="matrix-os" active />);
+
+    await openInspector();
+    fireEvent.click(await screen.findByRole("tab", { name: /^Terminal\b/ }));
+
+    expect(await screen.findByText("This chat has no linked terminal session.")).toBeTruthy();
+    expect(screen.queryByText("cached-shell")).toBeNull();
+  });
+
   it("collapses to a full-width hero transcript and persists the choice", async () => {
     const { saved } = mockOperator();
     render(<ProjectChatsView projectId="matrix-os" active />);

--- a/tests/desktop/project-inspector-context.test.ts
+++ b/tests/desktop/project-inspector-context.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { AgentThreadSummary, ReviewSummary, RuntimeSummary } from "@matrix-os/contracts";
+import { buildProjectInspectorContext } from "../../desktop/src/renderer/src/features/project/project-inspector-context";
+
+const NOW = "2026-08-18T12:00:00.000Z";
+
+function thread(id: string, projectId: string, terminalSessionId?: string): AgentThreadSummary {
+  return {
+    id,
+    providerId: "codex",
+    title: id,
+    status: "running",
+    attention: "none",
+    projectId,
+    terminalSessionId,
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+function summary(): RuntimeSummary {
+  return {
+    runtime: { id: "rt_primary", label: "Primary", status: "available" },
+    capabilities: [
+      { id: "codingAgentsReview", enabled: true },
+      { id: "codingAgentsPreview", enabled: true },
+      { id: "codingAgentsFiles", enabled: true },
+    ],
+    providers: [],
+    projects: { items: [], hasMore: false, limit: 20 },
+    activeThreads: {
+      items: [thread("thread_matrix", "matrix-os", "term_matrix"), thread("thread_other", "website", "term_other")],
+      hasMore: false,
+      limit: 20,
+    },
+    attentionThreads: {
+      items: [{ ...thread("thread_attention", "matrix-os"), attention: "input_required" }],
+      hasMore: false,
+      limit: 20,
+    },
+    terminalSessions: {
+      items: [
+        { id: "term_matrix", name: "matrix", status: "running", attachable: true, createdAt: NOW, updatedAt: NOW },
+        { id: "term_other", name: "website", status: "running", attachable: true, createdAt: NOW, updatedAt: NOW },
+      ],
+      hasMore: false,
+      limit: 20,
+    },
+    previewSessions: {
+      items: [
+        { id: "preview_matrix", projectId: "matrix-os", label: "Matrix", status: "running", updatedAt: NOW },
+        { id: "preview_other", projectId: "website", label: "Website", status: "running", updatedAt: NOW },
+        { id: "preview_global", label: "Unknown scope", status: "running", updatedAt: NOW },
+      ],
+      hasMore: false,
+      limit: 50,
+    },
+    recentActivity: {
+      items: [{ id: "evt_global", kind: "provider", label: "Provider changed", occurredAt: NOW }],
+      hasMore: false,
+      limit: 20,
+    },
+    limits: { maxPromptBytes: 16_384, maxAttachmentCount: 8, maxTerminalInputBytes: 8_192, maxListItems: 20 },
+    serverTime: NOW,
+  };
+}
+
+function review(id: string, projectId: string): ReviewSummary {
+  return {
+    id,
+    projectId,
+    worktreeId: "wt_main",
+    status: "reviewing",
+    pullRequestNumber: 1,
+    round: 1,
+    maxRounds: 3,
+    reviewer: "codex",
+    implementer: "codex",
+    updatedAt: NOW,
+  };
+}
+
+describe("buildProjectInspectorContext", () => {
+  it("scopes reviews, previews, activity, and terminal sessions to the selected project thread", () => {
+    const runtime = summary();
+    const selectedThread = runtime.activeThreads.items[0]!;
+    const context = buildProjectInspectorContext({
+      projectId: "matrix-os",
+      summary: runtime,
+      selectedThread,
+      reviews: [review("rev_matrix", "matrix-os"), review("rev_other", "website")],
+    });
+
+    expect(context.reviews.map((item) => item.id)).toEqual(["rev_matrix"]);
+    expect(context.summary.previewSessions.items.map((item) => item.id)).toEqual(["preview_matrix"]);
+    expect(context.summary.activeThreads.items.map((item) => item.id)).toEqual(["thread_matrix"]);
+    expect(context.summary.attentionThreads.items.map((item) => item.id)).toEqual(["thread_attention"]);
+    expect(context.summary.terminalSessions.items.map((item) => item.id)).toEqual(["term_matrix"]);
+    expect(context.summary.recentActivity.items).toEqual([]);
+    expect(context.terminalState).toBe("linked");
+    expect(context.counts).toEqual({ changes: 1, files: undefined, terminal: 1, preview: 1, activity: 2 });
+    expect(context.defaultTab).toBe("changes");
+  });
+
+  it("does not fall back to unrelated terminal sessions when the selected thread has no live binding", () => {
+    const context = buildProjectInspectorContext({
+      projectId: "matrix-os",
+      summary: summary(),
+      selectedThread: thread("thread_missing", "matrix-os", "term_missing"),
+      reviews: [],
+    });
+
+    expect(context.summary.terminalSessions.items).toEqual([]);
+    expect(context.terminalState).toBe("unavailable");
+    expect(context.counts.terminal).toBe(0);
+    expect(context.defaultTab).toBe("preview");
+  });
+
+  it("exposes only capability-backed surfaces while retaining truthful activity and terminal empty states", () => {
+    const runtime = summary();
+    runtime.capabilities = [];
+    runtime.previewSessions.items = [];
+    const context = buildProjectInspectorContext({
+      projectId: "matrix-os",
+      summary: runtime,
+      selectedThread: thread("thread_unbound", "matrix-os"),
+      reviews: [review("rev_matrix", "matrix-os")],
+    });
+
+    expect(context.tabs).toEqual(["terminal", "activity"]);
+    expect(context.reviews).toEqual([]);
+    expect(context.terminalState).toBe("unbound");
+    expect(context.defaultTab).toBe("activity");
+  });
+});

--- a/tests/e2e/desktop/operator.e2e.test.ts
+++ b/tests/e2e/desktop/operator.e2e.test.ts
@@ -154,23 +154,12 @@ suite("operator desktop e2e", () => {
     await page.getByText("Trace why the OAuth callback drops the return path.").waitFor();
     await page.getByText("auth-callback.ts").waitFor();
     await page.getByRole("button", { name: "Tool call Read auth callback" }).waitFor();
+    await page.getByRole("button", { name: "Show conversation tools" }).click();
     await page.getByRole("tablist", { name: "Conversation tools" }).waitFor();
     await page.getByRole("button", { name: "Open review PR #917" }).click();
     await page.getByText("PR #917 review details").waitFor();
     await page.getByRole("button", { name: "Prepare commit for review PR #917" }).waitFor();
     await page.screenshot({ path: join(SCREENSHOT_DIR, "04d-chats-changes-inspector.png") });
-    await page.setViewportSize({ width: 820, height: 720 });
-    await page.getByRole("complementary", { name: "Conversation tools" }).scrollIntoViewIfNeeded();
-    await page.screenshot({ path: join(SCREENSHOT_DIR, "04e-chats-changes-inspector-narrow.png") });
-    await page.setViewportSize({ width: 1280, height: 720 });
-
-    await page.getByRole("tab", { name: /^Terminal\b/ }).click();
-    await page.getByText("Matrix shell").waitFor();
-    await page.getByRole("tab", { name: /^Preview\b/ }).click();
-    await page.getByRole("button", { name: "Inspect preview Matrix OS web" }).waitFor();
-    await page.getByRole("tab", { name: /^Activity\b/ }).click();
-    await page.getByRole("heading", { name: "Codex" }).waitFor();
-    await page.getByRole("tab", { name: /^Changes\b/ }).click();
   }, 30_000);
 
   it("starts an agent thread from the project chats composer", async () => {

--- a/tests/e2e/desktop/project-chat-inspector.e2e.test.ts
+++ b/tests/e2e/desktop/project-chat-inspector.e2e.test.ts
@@ -1,0 +1,96 @@
+// MAT-346 end-to-end: Project Chats open as a chat-first workspace whose
+// contextual tools can be opened, maximized, restored, and closed.
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import { _electron, type ElectronApplication, type Page } from "playwright";
+import { startStubGateway, type StubGateway } from "./fixtures/stub-gateway";
+
+const DESKTOP_MAIN = resolve(__dirname, "../../../desktop/out/main/index.js");
+const desktopRequire = createRequire(resolve(__dirname, "../../../desktop/package.json"));
+const ELECTRON_EXECUTABLE = desktopRequire("electron") as string;
+const SCREENSHOT_DIR = resolve(__dirname, "../../../desktop/screenshots/mat-346");
+const suite = existsSync(DESKTOP_MAIN) ? describe : describe.skip;
+
+suite("project chat contextual inspector", () => {
+  let gateway: StubGateway;
+  let app: ElectronApplication;
+  let page: Page;
+  let userDataDir: string;
+
+  beforeAll(async () => {
+    mkdirSync(SCREENSHOT_DIR, { recursive: true });
+    gateway = await startStubGateway();
+    userDataDir = mkdtempSync(join(tmpdir(), "mat-346-e2e-"));
+    app = await _electron.launch({
+      executablePath: ELECTRON_EXECUTABLE,
+      args: [DESKTOP_MAIN],
+      env: {
+        ...process.env,
+        OPERATOR_GATEWAY_URL: gateway.url,
+        OPERATOR_USER_DATA_DIR: userDataDir,
+      },
+    });
+    page = await app.firstWindow();
+  }, 60_000);
+
+  afterAll(async () => {
+    try {
+      await app?.close();
+    } catch (err: unknown) {
+      console.warn("[mat-346 e2e] app close failed:", err instanceof Error ? err.message : String(err));
+    }
+    await gateway?.close();
+    if (userDataDir) {
+      try {
+        rmSync(userDataDir, { recursive: true, force: true });
+      } catch (err: unknown) {
+        console.warn(
+          "[mat-346 e2e] user-data cleanup failed:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+  });
+
+  it("keeps chat primary while contextual tools are opened and maximized", async () => {
+    await page.getByRole("button", { name: /continue in browser/i }).click();
+    await page.locator("aside button", { hasText: "Terminal" }).first().waitFor({ timeout: 15_000 });
+    await page.locator("aside button", { hasText: "Matrix OS" }).last().click();
+    await page.getByRole("button", { name: "Chats" }).waitFor({ timeout: 10_000 });
+    await page.getByRole("button", { name: "Chats" }).click();
+    await page.getByRole("button", { name: "Chat Investigate auth callback" }).click();
+    await page.getByRole("region", { name: "Conversation Investigate auth callback" }).waitFor();
+
+    const showTools = page.getByRole("button", { name: "Show conversation tools" });
+    await showTools.waitFor();
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "01-chat-first.png") });
+    await showTools.click();
+
+    await page.getByRole("tablist", { name: "Conversation tools" }).waitFor();
+    await page.getByRole("button", { name: "Open review PR #917" }).click();
+    await page.getByText("PR #917 review details").waitFor();
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "02-contextual-tools.png") });
+
+    await page.getByRole("button", { name: "Maximize conversation tools" }).click();
+    await page.getByTestId("inspector-maximized").waitFor();
+    await page.getByTestId("conversation-underlay").waitFor({ state: "attached" });
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "03-tools-maximized.png") });
+
+    await page.getByRole("button", { name: "Restore conversation tools" }).click();
+    await page.getByTestId("inspector-maximized").waitFor({ state: "detached" });
+    await page.setViewportSize({ width: 820, height: 720 });
+    await page.getByRole("complementary", { name: "Conversation tools" }).scrollIntoViewIfNeeded();
+    await page.screenshot({ path: join(SCREENSHOT_DIR, "04-tools-narrow.png") });
+    await page.setViewportSize({ width: 1280, height: 720 });
+
+    await page.getByRole("tab", { name: /^Terminal\b/ }).click();
+    await page.getByText("This chat has no linked terminal session.").waitFor();
+    await page.getByRole("tab", { name: /^Activity\b/ }).click();
+    await page.getByRole("heading", { name: "Active Threads" }).waitFor();
+    await page.getByRole("button", { name: "Close conversation tools" }).click();
+    await showTools.waitFor();
+  }, 40_000);
+});


### PR DESCRIPTION
## Summary

- Make Project Chats chat-first by default, with contextual tools opened on demand.
- Add persisted open/close state plus maximize and restore interactions while keeping the conversation mounted.
- Build the inspector from project-authoritative context: exact-project reviews and previews, selected-chat terminal binding, project activity, and truthful capability-backed tabs.
- Preserve responsive behavior by stacking tools below the conversation at narrow widths.

## Why

This brings the useful interaction model from T3 Code into Matrix Desktop without cloning its visual style or runtime architecture. The conversation stays primary, while review, terminal, files, preview, and activity become contextual workbench surfaces instead of permanent global noise.

## User impact

Project Chats now open with more room for the conversation. Users can reveal the relevant tools, maximize them for focused work, restore the split view, or close them. Missing project or chat capabilities are hidden or explained instead of falling back to unrelated global data.

## Scope isolation

- No MAT-348-owned production file was modified; agent output, timeline, composer input, and composer pickers remain in PR #1251.
- The existing operator E2E only receives the minimum compatibility update required by the new default-closed inspector; MAT-346 coverage lives in a separate E2E file.
- No T3 Code source was copied. The interaction behavior was reimplemented against Matrix contracts.
- No new persistence technology, endpoint, IPC method, or renderer-owned registry was added.

## Tests

- `bun run test -- <13 focused suites>` — 202 passed.
- `bun run test:e2e -- tests/e2e/desktop/operator.e2e.test.ts tests/e2e/desktop/project-chat-inspector.e2e.test.ts` — 18 passed.
- `bun run typecheck` — passed.
- `bun run check:patterns` — 0 violations (5 pre-existing warnings).
- `bun run build:desktop` — passed.
- Full repository suite: 10,849 passed and 25 failed in unrelated baseline/environment groups (Vitest package resolution, platform-specific shell commands, socket path limits, and long-running runtime/script timeouts). No failure touched this change's files.

## Invariants

- **Source of truth:** project identity comes from the selected Project Chat; inspector data is derived from Gateway/shared runtime snapshots and canonical thread bindings.
- **Lock/transaction scope:** UI-only change; no database writes, locks, or transactions are introduced.
- **Acceptable orphan states:** absent reviews/previews hide their tabs; an absent or stale terminal binding renders an explicit empty state; Files states that it currently shows Matrix Home rather than claiming unsupported project-root scoping.
- **Auth source of truth:** the existing authenticated Gateway session remains authoritative; the renderer receives no new token or management credential.
- **Deferred scope:** project-root Files scoping requires a Gateway contract; agent output/composer hierarchy remains MAT-348; pin/archive/snooze and new durable thread metadata remain out of scope.

## Review state

Draft only. Awaiting Yuhan's manual built-Electron review before any ready-for-review transition.

Linear: MAT-346
