### PR TITLE
test(gateway): restore git route ownership fixture

### DIFF
--- a/tests/gateway/git-routes.test.ts
+++ b/tests/gateway/git-routes.test.ts
@@ -37,6 +37,20 @@ function makeGitLog(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function makeProjectManager(
+  getProject = vi.fn(async () => ({ ok: true as const, project: { slug: "repo" } })),
+) {
+  return {
+    getGithubStatus: vi.fn(),
+    createProject: vi.fn(),
+    listManagedProjects: vi.fn(),
+    getProject,
+    deleteProject: vi.fn(),
+    listPullRequests: vi.fn(),
+    listBranches: vi.fn(),
+  };
+}
+
 describe("git log routes", () => {
   let homePath: string;
 
@@ -52,7 +66,7 @@ describe("git log routes", () => {
   describe("GET /api/projects/:slug/commits", () => {
     it("returns commits with defaults for limit and cursor", async () => {
       const gitLog = makeGitLog();
-      const app = createWorkspaceRoutes({ homePath, gitLog });
+      const app = createWorkspaceRoutes({ homePath, gitLog, projectManager: makeProjectManager() });
 
       const res = await app.request("/api/projects/repo/commits");
 
@@ -67,7 +81,7 @@ describe("git log routes", () => {
 
     it("passes bounded limit and cursor through to the service", async () => {
       const gitLog = makeGitLog();
-      const app = createWorkspaceRoutes({ homePath, gitLog });
+      const app = createWorkspaceRoutes({ homePath, gitLog, projectManager: makeProjectManager() });
 
       const cursor = `${"a".repeat(24)}.120`;
       const res = await app.request(`/api/projects/repo/commits?limit=50&cursor=${cursor}`);
@@ -84,7 +98,7 @@ describe("git log routes", () => {
       "/api/projects/repo/commits?cursor=-5",
     ])("rejects invalid query parameters: %s", async (path) => {
       const gitLog = makeGitLog();
-      const app = createWorkspaceRoutes({ homePath, gitLog });
+      const app = createWorkspaceRoutes({ homePath, gitLog, projectManager: makeProjectManager() });
 
       const res = await app.request(path);
 
@@ -92,6 +106,31 @@ describe("git log routes", () => {
       const body = await res.json();
       expect(body.error.code).toBe("invalid_request");
       expect(body.error.message).not.toMatch(/limit|cursor|Expected/i);
+      expect(gitLog.listCommits).not.toHaveBeenCalled();
+    });
+
+    it("rejects a missing or unauthorized project before reading git", async () => {
+      const ownerScope = { type: "user" as const, id: "user_a" };
+      const getProject = vi.fn(async () => ({
+        ok: false as const,
+        status: 404,
+        error: { code: "not_found", message: "Project was not found" },
+      }));
+      const gitLog = makeGitLog();
+      const app = createWorkspaceRoutes({
+        homePath,
+        gitLog,
+        projectManager: makeProjectManager(getProject),
+        getOwnerScope: () => ownerScope,
+      });
+
+      const res = await app.request("/api/projects/repo/commits");
+
+      expect(res.status).toBe(404);
+      await expect(res.json()).resolves.toEqual({
+        error: { code: "not_found", message: "Project was not found" },
+      });
+      expect(getProject).toHaveBeenCalledWith("repo", ownerScope);
       expect(gitLog.listCommits).not.toHaveBeenCalled();
     });
 
@@ -103,19 +142,20 @@ describe("git log routes", () => {
           error: { code: "not_found", message: "Project was not found" },
         })),
       });
-      const app = createWorkspaceRoutes({ homePath, gitLog });
+      const app = createWorkspaceRoutes({ homePath, gitLog, projectManager: makeProjectManager() });
 
-      const res = await app.request("/api/projects/missing/commits");
+      const res = await app.request("/api/projects/repo/commits");
 
       expect(res.status).toBe(404);
       await expect(res.json()).resolves.toEqual({ error: { code: "not_found", message: "Project was not found" } });
+      expect(gitLog.listCommits).toHaveBeenCalledWith("repo", { limit: 200, cursor: undefined });
     });
   });
 
   describe("GET /api/projects/:slug/commits/:sha/diff", () => {
     it("returns parsed diff files", async () => {
       const gitLog = makeGitLog();
-      const app = createWorkspaceRoutes({ homePath, gitLog });
+      const app = createWorkspaceRoutes({ homePath, gitLog, projectManager: makeProjectManager() });
 
       const res = await app.request(`/api/projects/repo/commits/${SHA}/diff`);
 
@@ -130,7 +170,7 @@ describe("git log routes", () => {
 
     it("accepts bounded maxFiles and maxLines overrides", async () => {
       const gitLog = makeGitLog();
-      const app = createWorkspaceRoutes({ homePath, gitLog });
+      const app = createWorkspaceRoutes({ homePath, gitLog, projectManager: makeProjectManager() });
 
       const res = await app.request(`/api/projects/repo/commits/${SHA}/diff?maxFiles=50&maxLines=100`);
 
@@ -146,7 +186,7 @@ describe("git log routes", () => {
       `/api/projects/repo/commits/${SHA}/diff?maxLines=2001`,
     ])("rejects invalid parameters: %s", async (path) => {
       const gitLog = makeGitLog();
-      const app = createWorkspaceRoutes({ homePath, gitLog });
+      const app = createWorkspaceRoutes({ homePath, gitLog, projectManager: makeProjectManager() });
 
       const res = await app.request(path);
 
@@ -164,7 +204,7 @@ describe("git log routes", () => {
           error: { code: "not_found", message: "Commit was not found" },
         })),
       });
-      const app = createWorkspaceRoutes({ homePath, gitLog });
+      const app = createWorkspaceRoutes({ homePath, gitLog, projectManager: makeProjectManager() });
 
       const res = await app.request(`/api/projects/repo/commits/${SHA}/diff`);
 


### PR DESCRIPTION
## Summary

- inject the owner-aware project-manager seam into the git-route test fixture so valid commit requests reach the mocked Git service
- add explicit coverage that a missing or unauthorized project returns 404 without touching Git
- make the Git-service failure test prove it passed the project preflight
- leave the production ownership guard unchanged

Fixes MAT-432
Related to #1247

## Tests

- `pnpm exec vitest run tests/gateway/git-routes.test.ts` — 17/17 passed
- `pnpm --filter '@matrix-os/gateway' exec tsc --noEmit` — passed
- `bun run typecheck` — passed
- `bun run check:patterns` — 0 violations (existing scanner warnings only)
- `git diff --check` — passed
- `bun run test` — the changed suite passed, but the monolithic local run was stopped after unrelated suites timed out or lost shared test globals under full parallel load; the four isolated GitHub CI shards remain the authoritative full-suite result

## Review/Monitoring

- Greptile review pending
- add `ready-for-ci` only after the latest Greptile review is 5/5
- monitor all label-triggered CI shards before handoff

## Invariants

- **Source of truth:** `projectManager.getProject(slug, ownerScope)` remains authoritative for whether a commit route may read a project.
- **Lock/transaction scope:** none; this PR changes test fixtures only and performs no persistence.
- **Acceptable orphan states:** none introduced; no runtime resources are created.
- **Auth source of truth:** the request-derived owner scope and project-manager ownership result remain unchanged; tests do not bypass the production preflight.
- **Deferred scope:** merge-queue or branch-up-to-date policy changes, host-bundle workflow changes, and unrelated local full-suite instability are outside MAT-432.
