### PR TITLE
fix(desktop): load updater in packaged builds

### DIFF
--- a/desktop/src/main/updates.ts
+++ b/desktop/src/main/updates.ts
@@ -28,8 +28,11 @@ const UPDATER_EVENT_NAMES = [
   "error",
 ] as const;
 
-interface InstallableUpdater {
-  quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void;
+type ElectronAutoUpdater = typeof import("electron-updater")["autoUpdater"];
+
+interface ElectronUpdaterModuleNamespace {
+  autoUpdater?: unknown;
+  default?: unknown;
 }
 
 export interface Updater {
@@ -37,6 +40,37 @@ export interface Updater {
   install(): Promise<boolean>;
   snapshot(): DesktopUpdateSnapshot;
   status(): UpdateStatus;
+}
+
+function hasAutoUpdaterShape(value: unknown): value is ElectronAutoUpdater {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.checkForUpdates === "function" &&
+    typeof candidate.quitAndInstall === "function" &&
+    typeof candidate.setFeedURL === "function" &&
+    typeof candidate.removeAllListeners === "function" &&
+    typeof candidate.once === "function" &&
+    typeof candidate.on === "function"
+  );
+}
+
+async function loadAutoUpdater(): Promise<ElectronAutoUpdater> {
+  const updaterModule = await import("electron-updater") as ElectronUpdaterModuleNamespace;
+  const directAutoUpdater = "autoUpdater" in updaterModule
+    ? updaterModule.autoUpdater
+    : undefined;
+  const defaultExport = "default" in updaterModule
+    ? updaterModule.default
+    : undefined;
+  const defaultAutoUpdater = defaultExport && typeof defaultExport === "object"
+    ? (defaultExport as Record<string, unknown>).autoUpdater
+    : undefined;
+  const autoUpdater = directAutoUpdater ?? defaultAutoUpdater;
+  if (!hasAutoUpdaterShape(autoUpdater)) {
+    throw new Error("Desktop updater module is unavailable");
+  }
+  return autoUpdater;
 }
 
 function readVersion(info: unknown): string | null {
@@ -84,7 +118,7 @@ function readRelease(info: unknown, version: string): DesktopReleaseNotes {
 
 export function createUpdater(events: UpdateEvents): Updater {
   let current: DesktopUpdateSnapshot = { status: "disabled" };
-  let activeAutoUpdater: InstallableUpdater | null = null;
+  let activeAutoUpdater: ElectronAutoUpdater | null = null;
   let pendingReleaseSave: Promise<void> = Promise.resolve();
   const feed = resolveUpdateFeedConfig(process.env, app.isPackaged);
 
@@ -107,7 +141,7 @@ export function createUpdater(events: UpdateEvents): Updater {
 
       setSnapshot({ status: "checking" });
       try {
-        const { autoUpdater } = await import("electron-updater");
+        const autoUpdater = await loadAutoUpdater();
         activeAutoUpdater = autoUpdater;
         autoUpdater.autoDownload = true;
         autoUpdater.autoInstallOnAppQuit = true;
@@ -180,7 +214,7 @@ export function createUpdater(events: UpdateEvents): Updater {
     async install() {
       if (current.status !== "ready") return false;
       await pendingReleaseSave;
-      const installable = activeAutoUpdater ?? (await import("electron-updater")).autoUpdater;
+      const installable = activeAutoUpdater ?? await loadAutoUpdater();
       activeAutoUpdater = installable;
       installable.quitAndInstall(false, true);
       return true;

--- a/tests/desktop/updater-module-interop.test.ts
+++ b/tests/desktop/updater-module-interop.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const updaterMock = vi.hoisted(() => {
+  const autoUpdater = {
+    autoDownload: false,
+    autoInstallOnAppQuit: false,
+    allowPrerelease: false,
+    setFeedURL: vi.fn(),
+    removeAllListeners: vi.fn(() => autoUpdater),
+    once: vi.fn(() => autoUpdater),
+    on: vi.fn(() => autoUpdater),
+    checkForUpdates: vi.fn().mockResolvedValue({}),
+    quitAndInstall: vi.fn(),
+  };
+  const moduleDefault: { autoUpdater?: typeof autoUpdater } = { autoUpdater };
+  return { autoUpdater, moduleDefault };
+});
+
+vi.mock("electron", () => ({ app: { isPackaged: true } }));
+vi.mock("electron-updater", () => ({
+  default: updaterMock.moduleDefault,
+}));
+
+import { createUpdater } from "@desktop/main/updates";
+
+describe("packaged electron-updater module interop", () => {
+  beforeEach(() => {
+    updaterMock.moduleDefault.autoUpdater = updaterMock.autoUpdater;
+    updaterMock.autoUpdater.autoDownload = false;
+    updaterMock.autoUpdater.autoInstallOnAppQuit = false;
+    updaterMock.autoUpdater.checkForUpdates.mockClear();
+  });
+
+  it("checks for updates through a default-wrapped CommonJS module", async () => {
+    process.env.OPERATOR_UPDATE_FEED = "https://updates.example.com";
+    const updater = createUpdater({ onAvailable: vi.fn(), onReady: vi.fn() });
+
+    await updater.check();
+
+    expect(updaterMock.autoUpdater.autoDownload).toBe(true);
+    expect(updaterMock.autoUpdater.autoInstallOnAppQuit).toBe(true);
+    expect(updaterMock.autoUpdater.checkForUpdates).toHaveBeenCalledOnce();
+    expect(updater.status()).toBe("checking");
+  });
+
+  it("fails safely when the updater module has no usable export", async () => {
+    updaterMock.moduleDefault.autoUpdater = undefined;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const updater = createUpdater({ onAvailable: vi.fn(), onReady: vi.fn() });
+
+    await updater.check();
+
+    expect(updater.status()).toBe("error");
+    expect(warn).toHaveBeenCalledWith(
+      "[updates] check failed:",
+      "Desktop updater module is unavailable",
+    );
+    warn.mockRestore();
+  });
+});

--- a/tests/e2e/desktop/update-experience.e2e.test.ts
+++ b/tests/e2e/desktop/update-experience.e2e.test.ts
@@ -66,7 +66,7 @@ suite("desktop update experience", () => {
     if (userDataDir) rmSync(userDataDir, { recursive: true, force: true });
   });
 
-  it("shows What's New after launch and places Update below Settings", async () => {
+  it("shows What's New after launch and places Update above the account row", async () => {
     await page.getByRole("heading", { name: "What's New", level: 1 }).waitFor({ timeout: 10_000 });
     await page.getByText("Automatic background downloads for Matrix OS updates").waitFor();
     await page.mouse.move(80, 400);
@@ -92,20 +92,24 @@ suite("desktop update experience", () => {
 
     const update = page.getByRole("button", { name: "Update Matrix OS to 0.2.0" });
     await update.waitFor({ timeout: 10_000 });
-    const settings = page.getByRole("button", { name: "Settings" });
-    const avatar = page.getByTitle("Manage account");
-    const settingsBox = await settings.boundingBox();
+    const computer = page.locator("aside").getByRole("button", { name: /computer/i }).first();
+    const account = page.getByRole("button", { name: "Open account menu" });
+    const computerBox = await computer.boundingBox();
     const updateBox = await update.boundingBox();
-    const avatarBox = await avatar.boundingBox();
-    expect(settingsBox).not.toBeNull();
-    expect(avatarBox).not.toBeNull();
+    const accountBox = await account.boundingBox();
+    expect(computerBox).not.toBeNull();
+    expect(accountBox).not.toBeNull();
     expect(updateBox).not.toBeNull();
-    expect(updateBox?.y ?? 0).toBeGreaterThan((settingsBox?.y ?? 0) + (settingsBox?.height ?? 0));
-    expect((updateBox?.y ?? 0) + (updateBox?.height ?? 0)).toBeLessThanOrEqual(avatarBox?.y ?? 0);
-    expect(updateBox?.width ?? 0).toBeGreaterThan((avatarBox?.width ?? 0) * 4);
+    expect(updateBox?.y ?? 0).toBeGreaterThanOrEqual(
+      (computerBox?.y ?? 0) + (computerBox?.height ?? 0),
+    );
+    expect((updateBox?.y ?? 0) + (updateBox?.height ?? 0)).toBeLessThanOrEqual(
+      accountBox?.y ?? 0,
+    );
+    expect(updateBox?.width ?? 0).toBeGreaterThanOrEqual((accountBox?.width ?? 0) - 8);
     await page.screenshot({ path: join(SCREENSHOT_DIR, "mat-291-update-ready.png") });
 
-    await page.getByRole("button", { name: "Collapse sidebar (⌘B)" }).click();
+    await page.getByRole("button", { name: "Collapse sidebar" }).click();
     const collapsedUpdateBox = await update.boundingBox();
     expect(collapsedUpdateBox).not.toBeNull();
     expect(Math.abs((collapsedUpdateBox?.width ?? 0) - (collapsedUpdateBox?.height ?? 0))).toBeLessThanOrEqual(2);


### PR DESCRIPTION
## Summary

- resolve `electron-updater` from both its named ESM shape and the default-wrapped CommonJS shape emitted in packaged Desktop builds
- validate the updater object at the main-process boundary and reuse the same loader for check and install
- add a regression test that reproduces the packaged namespace mismatch
- align the MAT-291 Desktop E2E with the current footer structure after Settings moved into the account menu

## Root cause

The packaged macOS app exposes `electron-updater` through `module.default.autoUpdater`. The main process destructured only the named `autoUpdater` export, so it assigned `undefined` and failed before the first update check:

```
[updates] check failed: Cannot set properties of undefined (setting 'autoDownload')
```

The previous unit mock exposed only the named form, so it did not cover the packaged runtime seam.

## Validation

- RED: the new default-wrapped CommonJS regression test failed on the old code at `autoDownload`
- `bun run test -- tests/desktop/updater-module-interop.test.ts tests/desktop/updater.test.ts tests/desktop/update-config.test.ts tests/desktop/desktop-update-ui.test.tsx` — 23 passed
- `pnpm --filter desktop run typecheck` — passed
- `bun run build:desktop` — passed
- `bun run test:e2e -- tests/e2e/desktop/update-experience.e2e.test.ts` — passed
- unsigned arm64 packaged app launched with isolated `userData` and an intentionally unreachable local feed; it reached the feed and logged `ERR_CONNECTION_REFUSED` without the old `autoDownload` interop error
- the already-running installed Matrix OS process remained untouched during packaged validation

## Invariants

- **Source of truth:** `electron-updater` remains owned by the Electron main process; renderer state and commands still cross the existing typed IPC contract.
- **Lock / transaction scope:** not applicable; this change adds no database, file-locking, or multi-write workflow.
- **Acceptable orphan states:** unchanged. A failed update check remains a non-blocking in-memory error state; release-note persistence still occurs only after `update-downloaded`.
- **Auth source of truth:** unchanged. OTA provider/channel configuration and Desktop authentication are not modified.
- **Deferred scope:** the full signed Canary A → Canary B download/install/relaunch lifecycle must run after this fix is merged and published. No channel, signing, Update button, or What's New behavior is changed here.

## Documentation

No public documentation change is required: this restores the already documented MAT-291 behavior and does not add or change user-facing functionality.

Closes #1259

Linear: [MAT-441](https://linear.app/matrix-os/issue/MAT-441/fix-packaged-desktop-updater-module-interop)
