### PR TITLE
fix(shell): restore reliable terminal input focus

### DIFF
--- a/shell/src/components/canvas/CanvasTransform.tsx
+++ b/shell/src/components/canvas/CanvasTransform.tsx
@@ -37,7 +37,9 @@ export function CanvasTransform({
   const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastPointer = useRef({ x: 0, y: 0 });
   const spaceDown = useRef(false);
+  const interactionOverlayActiveRef = useRef(false);
   const [grabCursor, setGrabCursor] = useState(false);
+  const [interactionOverlayActive, setInteractionOverlayActive] = useState(false);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -168,37 +170,48 @@ export function CanvasTransform({
     return () => window.removeEventListener("message", onMessage);
   }, [panEnabled]);
 
-  // Track space (for pan) and ctrl/cmd (for zoom overlay over iframes)
-  // react-doctor-disable-next-line react-doctor/exhaustive-deps -- run-once mount setup for global window/document key + visibility listeners; the body only touches stable setters (setGrabCursor), refs (spaceDown, scrollTimeoutRef), and the mount-captured overlay element. Re-running would detach/reattach the global listeners on every render with no behavior change.
+  // Track space (for pan) and ctrl/cmd (for zoom overlay over iframes).
+  // System shortcuts such as macOS Cmd+Shift+5 are not guaranteed to deliver
+  // their matching keyup to the browser, so pointer movement without an active
+  // modifier is also an authoritative release signal.
   useEffect(() => {
-    const overlay = zoomOverlayRef.current;
+    const updateInteractionOverlay = (active: boolean) => {
+      if (interactionOverlayActiveRef.current === active) return;
+      interactionOverlayActiveRef.current = active;
+      setInteractionOverlayActive(active);
+    };
+
     const onKeyDown = (e: KeyboardEvent) => {
+      if (!panEnabled) return;
       if (e.code === "Space" && !e.repeat) {
         spaceDown.current = true;
         setGrabCursor(true);
-        if (overlay) overlay.style.pointerEvents = "all";
+        updateInteractionOverlay(true);
       }
-      if ((e.ctrlKey || e.metaKey) && overlay) {
-        overlay.style.pointerEvents = "all";
+      if (e.ctrlKey || e.metaKey) {
+        updateInteractionOverlay(true);
       }
     };
     const onKeyUp = (e: KeyboardEvent) => {
       if (e.code === "Space") {
         spaceDown.current = false;
         setGrabCursor(false);
-        if (!e.ctrlKey && !e.metaKey && overlay) {
-          overlay.style.pointerEvents = "none";
-        }
       }
-      if (!e.ctrlKey && !e.metaKey && !spaceDown.current && overlay) {
-        overlay.style.pointerEvents = "none";
+      if (!e.ctrlKey && !e.metaKey && !spaceDown.current) {
+        updateInteractionOverlay(false);
       }
     };
 
     const resetOverlay = () => {
       spaceDown.current = false;
       setGrabCursor(false);
-      if (overlay) overlay.style.pointerEvents = "none";
+      updateInteractionOverlay(false);
+    };
+
+    const releaseStaleModifierOverlay = (e: PointerEvent) => {
+      if (!e.ctrlKey && !e.metaKey && !spaceDown.current) {
+        updateInteractionOverlay(false);
+      }
     };
 
     const onVisibilityChange = () => {
@@ -208,15 +221,24 @@ export function CanvasTransform({
     window.addEventListener("keydown", onKeyDown);
     window.addEventListener("keyup", onKeyUp);
     window.addEventListener("blur", resetOverlay);
+    window.addEventListener("focus", resetOverlay);
+    window.addEventListener("pointermove", releaseStaleModifierOverlay);
     document.addEventListener("visibilitychange", onVisibilityChange);
+
+    if (!panEnabled) resetOverlay();
 
     return () => {
       window.removeEventListener("keydown", onKeyDown);
       window.removeEventListener("keyup", onKeyUp);
       window.removeEventListener("blur", resetOverlay);
+      window.removeEventListener("focus", resetOverlay);
+      window.removeEventListener("pointermove", releaseStaleModifierOverlay);
       document.removeEventListener("visibilitychange", onVisibilityChange);
-      if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current);
     };
+  }, [panEnabled]);
+
+  useEffect(() => () => {
+    if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current);
   }, []);
 
   return (
@@ -238,7 +260,7 @@ export function CanvasTransform({
       <div
         ref={zoomOverlayRef}
         className="absolute inset-0 z-50"
-        style={{ pointerEvents: "none" }}
+        style={{ pointerEvents: panEnabled && interactionOverlayActive ? "all" : "none" }}
       />
       <div
         ref={transformRef}

--- a/shell/src/components/terminal/PaneGrid.tsx
+++ b/shell/src/components/terminal/PaneGrid.tsx
@@ -9,6 +9,7 @@ interface PaneGridProps {
   paneTree: PaneNode;
   theme: Theme;
   focusedPaneId?: string | null;
+  focusRequestId?: number;
   onFocusPane?: (paneId: string) => void;
   onSessionAttached?: (paneId: string, sessionId: string) => void;
   shouldCachePane?: (paneId: string) => boolean;
@@ -18,13 +19,14 @@ interface PaneGridProps {
   canvasZoom?: number;
 }
 
-export function PaneGrid({ paneTree, theme, focusedPaneId, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane, allowRemoteResize = true, suppressNativeKeyboard = false, canvasZoom = 1 }: PaneGridProps) {
+export function PaneGrid({ paneTree, theme, focusedPaneId, focusRequestId = 0, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane, allowRemoteResize = true, suppressNativeKeyboard = false, canvasZoom = 1 }: PaneGridProps) {
   return (
     <div className="flex-1 min-h-0 min-w-0 overflow-hidden">
       <PaneNodeRenderer
         node={paneTree}
         theme={theme}
         focusedPaneId={focusedPaneId}
+        focusRequestId={focusRequestId}
         onFocusPane={onFocusPane}
         onSessionAttached={onSessionAttached}
         shouldCachePane={shouldCachePane}
@@ -41,6 +43,7 @@ interface PaneNodeRendererProps {
   node: PaneNode;
   theme: Theme;
   focusedPaneId?: string | null;
+  focusRequestId?: number;
   onFocusPane?: (paneId: string) => void;
   onSessionAttached?: (paneId: string, sessionId: string) => void;
   shouldCachePane?: (paneId: string) => boolean;
@@ -50,7 +53,7 @@ interface PaneNodeRendererProps {
   canvasZoom?: number;
 }
 
-function PaneNodeRenderer({ node, theme, focusedPaneId, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane, allowRemoteResize = true, suppressNativeKeyboard = false, canvasZoom = 1 }: PaneNodeRendererProps) {
+function PaneNodeRenderer({ node, theme, focusedPaneId, focusRequestId = 0, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane, allowRemoteResize = true, suppressNativeKeyboard = false, canvasZoom = 1 }: PaneNodeRendererProps) {
   if (node.type === "pane") {
     const focused = focusedPaneId === node.id;
     return (
@@ -70,6 +73,7 @@ function PaneNodeRenderer({ node, theme, focusedPaneId, onFocusPane, onSessionAt
           cwd={node.cwd}
           theme={theme}
           isFocused={focused}
+          focusRequestId={focusRequestId}
           sessionId={node.sessionId}
           claudeMode={node.claudeMode === true}
           startupCommand={node.startupCommand}
@@ -94,6 +98,7 @@ function PaneNodeRenderer({ node, theme, focusedPaneId, onFocusPane, onSessionAt
       right={node.children[1]}
       theme={theme}
       focusedPaneId={focusedPaneId}
+      focusRequestId={focusRequestId}
       onFocusPane={onFocusPane}
       onSessionAttached={onSessionAttached}
       shouldCachePane={shouldCachePane}
@@ -112,6 +117,7 @@ interface SplitContainerProps {
   right: PaneNode;
   theme: Theme;
   focusedPaneId?: string | null;
+  focusRequestId?: number;
   onFocusPane?: (paneId: string) => void;
   onSessionAttached?: (paneId: string, sessionId: string) => void;
   shouldCachePane?: (paneId: string) => boolean;
@@ -121,7 +127,7 @@ interface SplitContainerProps {
   canvasZoom?: number;
 }
 
-function SplitContainer({ direction, ratio, left, right, theme, focusedPaneId, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane, allowRemoteResize = true, suppressNativeKeyboard = false, canvasZoom = 1 }: SplitContainerProps) {
+function SplitContainer({ direction, ratio, left, right, theme, focusedPaneId, focusRequestId = 0, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane, allowRemoteResize = true, suppressNativeKeyboard = false, canvasZoom = 1 }: SplitContainerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   // react-doctor-disable-next-line react-doctor/no-derived-useState -- local drag buffer, not a mirror of `ratio`: it is seeded from the prop, then diverges live as the user drags the split divider (setCurrentRatio in onMouseMove). It must NOT stay in sync with `ratio` or the divider would snap back mid-drag; it holds uncommitted pointer-driven layout state.
   const [currentRatio, setCurrentRatio] = useState(ratio);
@@ -169,6 +175,7 @@ function SplitContainer({ direction, ratio, left, right, theme, focusedPaneId, o
           node={left}
           theme={theme}
           focusedPaneId={focusedPaneId}
+          focusRequestId={focusRequestId}
           onFocusPane={onFocusPane}
           onSessionAttached={onSessionAttached}
           shouldCachePane={shouldCachePane}
@@ -189,6 +196,7 @@ function SplitContainer({ direction, ratio, left, right, theme, focusedPaneId, o
           node={right}
           theme={theme}
           focusedPaneId={focusedPaneId}
+          focusRequestId={focusRequestId}
           onFocusPane={onFocusPane}
           onSessionAttached={onSessionAttached}
           shouldCachePane={shouldCachePane}

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -266,6 +266,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
   const [tabs, setTabs] = useState<Tab[]>([]);
   const [activeTabId, setActiveTabId] = useState("");
   const [focusedPaneId, setFocusedPaneId] = useState<string | null>(null);
+  const [focusRequestId, setFocusRequestId] = useState(0);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_TERMINAL_SIDEBAR_WIDTH);
   const [sidebarSelectedPath, setSidebarSelectedPath] = useState<string | null>(null);
@@ -375,6 +376,21 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     loadGlobalShellThemePreference(setThemeId);
   }, [setThemeId]);
 
+  const requestPaneFocus = (paneId: string | null) => {
+    setFocusedPaneId(paneId);
+    if (paneId) setFocusRequestId((current) => current + 1);
+  };
+
+  const activateTab = (tabId: string) => {
+    const tab = tabsRef.current.find((candidate) => candidate.id === tabId);
+    if (!tab) return;
+    setActiveTabId(tabId);
+    setFocusedPaneId((current) => (
+      current && hasPaneId(tab.paneTree, current) ? current : getFirstPaneId(tab.paneTree)
+    ));
+    setFocusRequestId((current) => current + 1);
+  };
+
   const addTab = (cwd: string, label?: string, claude?: boolean, startupCommand?: string, sessionId?: string) => {
     const id = genId();
     const paneId = genId();
@@ -394,7 +410,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     };
     setTabs((prev) => [...prev, tab]);
     setActiveTabId(id);
-    setFocusedPaneId(paneId);
+    requestPaneFocus(paneId);
     return id;
   };
 
@@ -419,7 +435,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     };
     setTabs((prev) => [...prev, tab]);
     setActiveTabId(id);
-    setFocusedPaneId(paneId);
+    requestPaneFocus(paneId);
     return id;
   };
 
@@ -557,7 +573,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
                 setTabs(applyCompatModeToTabs(data.tabs));
                 setActiveTabId(nextActiveTabId);
                 setSidebarOpen(initialMobileRef.current ? false : data.sidebarOpen ?? true);
-                setFocusedPaneId(nextActiveTab ? getFirstPaneId(nextActiveTab.paneTree) : null);
+                requestPaneFocus(nextActiveTab ? getFirstPaneId(nextActiveTab.paneTree) : null);
                 setInitialized(true);
                 return;
               }
@@ -705,15 +721,15 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
       tabId,
       paneIds: tabsRef.current.find((tab) => tab.id === tabId)?.paneTree ? getAllPaneIds(tabsRef.current.find((tab) => tab.id === tabId)!.paneTree) : [],
     });
-    setTabs(prev => {
-      const next = prev.filter(t => t.id !== tabId);
-      setActiveTabId(curr => {
-        if (curr !== tabId) return curr;
-        const idx = prev.findIndex(t => t.id === tabId);
-        return next[Math.min(idx, next.length - 1)]?.id ?? "";
-      });
-      return next;
-    });
+    const prev = tabsRef.current;
+    const next = prev.filter((tab) => tab.id !== tabId);
+    setTabs(next);
+    if (activeTabIdRef.current === tabId) {
+      const idx = prev.findIndex((tab) => tab.id === tabId);
+      const replacement = next[Math.min(idx, next.length - 1)];
+      setActiveTabId(replacement?.id ?? "");
+      requestPaneFocus(replacement ? getFirstPaneId(replacement.paneTree) : null);
+    }
   };
 
   const splitPane = (paneId: string, dir: "horizontal" | "vertical") => {
@@ -739,11 +755,12 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
       const newTree = closePaneInTree(tab.paneTree, paneId);
       if (!newTree) {
         const next = prev.filter(t => t.id !== activeTabId);
-        setActiveTabId(next[0]?.id ?? "");
-        setFocusedPaneId(null);
+        const replacement = next[0];
+        setActiveTabId(replacement?.id ?? "");
+        requestPaneFocus(replacement ? getFirstPaneId(replacement.paneTree) : null);
         return next;
       }
-      setFocusedPaneId(getFirstPaneId(newTree));
+      requestPaneFocus(getFirstPaneId(newTree));
       return prev.map(t => t.id === activeTabId ? { ...t, paneTree: newTree } : t);
     });
   };
@@ -884,7 +901,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     },
     setActiveTab: (tabId: string) => {
       markTerminalLayoutDirty();
-      setActiveTabId(tabId);
+      activateTab(tabId);
     },
     renameTab: (...args: Parameters<typeof renameTab>) => {
       markTerminalLayoutDirty();
@@ -970,6 +987,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
                     paneTree={activeTab.paneTree}
                     theme={designTheme}
                     focusedPaneId={focusedPaneId}
+                    focusRequestId={focusRequestId}
                     onFocusPane={setFocusedPaneId}
                     onSessionAttached={handleSessionAttached}
                     shouldCachePane={shouldCachePane}

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -55,6 +55,7 @@ import {
 import { createXtermLogger } from "./xterm-logger";
 import { createColdReplayVisibility, type ColdReplayVisibility } from "./cold-replay-visibility";
 import { parseTerminalServerMessage, stripTerminalControls } from "./terminal-server-message";
+import { useTerminalFocusRequest } from "./useTerminalFocusRequest";
 import type { TerminalCompatMode } from "@/stores/terminal-store";
 
 const MAX_OSC52_BASE64_LENGTH = 1_000_000;
@@ -305,6 +306,7 @@ interface TerminalPaneProps {
   cwd: string;
   theme: Theme;
   isFocused: boolean;
+  focusRequestId?: number;
   sessionId?: string;
   claudeMode?: boolean;
   startupCommand?: string;
@@ -333,6 +335,7 @@ export function TerminalPane({
   cwd,
   theme,
   isFocused,
+  focusRequestId = 0,
   sessionId: initialSessionId,
   claudeMode,
   startupCommand,
@@ -2065,11 +2068,7 @@ export function TerminalPane({
     theme,
   ]);
 
-  useEffect(() => {
-    if (isFocused && !suppressNativeKeyboard && termRef.current) {
-      (termRef.current as { focus: () => void }).focus();
-    }
-  }, [isFocused, suppressNativeKeyboard]);
+  useTerminalFocusRequest(termRef, focusRequestId, isFocused, suppressNativeKeyboard);
 
   // Re-fit the terminal whenever the visual viewport changes (soft keyboard
   // open/close, URL-bar collapse, orientation). The document viewport is

--- a/shell/src/components/terminal/useTerminalFocusRequest.ts
+++ b/shell/src/components/terminal/useTerminalFocusRequest.ts
@@ -6,15 +6,28 @@ interface FocusableTerminal {
   focus(): void;
 }
 
-export function useTerminalFocusRequest<T extends FocusableTerminal>(
-  terminalRef: RefObject<T | null>,
+function isFocusableTerminal(value: unknown): value is FocusableTerminal {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "focus" in value &&
+    typeof value.focus === "function"
+  );
+}
+
+export function useTerminalFocusRequest(
+  terminalRef: RefObject<unknown>,
   focusRequestId: number,
   isFocused: boolean,
   suppressNativeKeyboard: boolean,
 ) {
   useEffect(() => {
-    if (isFocused && !suppressNativeKeyboard) {
-      terminalRef.current?.focus();
+    if (
+      isFocused &&
+      !suppressNativeKeyboard &&
+      isFocusableTerminal(terminalRef.current)
+    ) {
+      terminalRef.current.focus();
     }
   }, [focusRequestId, isFocused, suppressNativeKeyboard, terminalRef]);
 }

--- a/shell/src/components/terminal/useTerminalFocusRequest.ts
+++ b/shell/src/components/terminal/useTerminalFocusRequest.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect, type RefObject } from "react";
+
+interface FocusableTerminal {
+  focus(): void;
+}
+
+export function useTerminalFocusRequest<T extends FocusableTerminal>(
+  terminalRef: RefObject<T | null>,
+  focusRequestId: number,
+  isFocused: boolean,
+  suppressNativeKeyboard: boolean,
+) {
+  useEffect(() => {
+    if (isFocused && !suppressNativeKeyboard) {
+      terminalRef.current?.focus();
+    }
+  }, [focusRequestId, isFocused, suppressNativeKeyboard, terminalRef]);
+}

--- a/tests/shell/canvas-transform-interaction.test.tsx
+++ b/tests/shell/canvas-transform-interaction.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from "react";
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CanvasTransform } from "../../shell/src/components/canvas/CanvasTransform.js";
 import { useCanvasTransform } from "../../shell/src/hooks/useCanvasTransform.js";
@@ -37,6 +37,55 @@ describe("CanvasTransform app focus interactions", () => {
 
     expect(preventDefault).not.toHaveBeenCalled();
     expect(useCanvasTransform.getState().panY).toBe(0);
+  });
+
+  it("does not enable the canvas interaction overlay while app focus owns input", () => {
+    const { container } = render(
+      <CanvasTransform panEnabled={false}>
+        <div>App content</div>
+      </CanvasTransform>,
+    );
+    const overlay = container.querySelector(".absolute.inset-0.z-50") as HTMLElement;
+
+    fireEvent.keyDown(window, { code: "MetaLeft", key: "Meta", metaKey: true });
+
+    expect(overlay.style.pointerEvents).toBe("none");
+  });
+
+  it("releases a stale modifier overlay when pointer input resumes without modifiers", () => {
+    const { container } = render(
+      <CanvasTransform panEnabled>
+        <div>App content</div>
+      </CanvasTransform>,
+    );
+    const overlay = container.querySelector(".absolute.inset-0.z-50") as HTMLElement;
+
+    fireEvent.keyDown(window, { code: "MetaLeft", key: "Meta", metaKey: true });
+    expect(overlay.style.pointerEvents).toBe("all");
+
+    fireEvent.pointerMove(overlay, { ctrlKey: false, metaKey: false });
+
+    expect(overlay.style.pointerEvents).toBe("none");
+  });
+
+  it("releases the modifier overlay when an app takes canvas input ownership", () => {
+    const { container, rerender } = render(
+      <CanvasTransform panEnabled>
+        <div>App content</div>
+      </CanvasTransform>,
+    );
+    const overlay = container.querySelector(".absolute.inset-0.z-50") as HTMLElement;
+
+    fireEvent.keyDown(window, { code: "MetaLeft", key: "Meta", metaKey: true });
+    expect(overlay.style.pointerEvents).toBe("all");
+
+    rerender(
+      <CanvasTransform panEnabled={false}>
+        <div>App content</div>
+      </CanvasTransform>,
+    );
+
+    expect(overlay.style.pointerEvents).toBe("none");
   });
 
   it("pans wheel input after the canvas background is unfocused", () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -2296,7 +2296,7 @@ describe("TerminalApp", () => {
     ))).toHaveLength(0);
   });
 
-  it("focuses active shell rows without creating duplicate attached tabs or layout save noise", async () => {
+  it("re-requests focus for active shell rows without creating duplicate attached tabs or layout save noise", async () => {
     render(<TerminalApp />);
 
     await act(async () => {
@@ -2308,6 +2308,9 @@ describe("TerminalApp", () => {
     const fetchMock = vi.mocked(global.fetch);
     fetchMock.mockClear();
     const paneRenderCount = paneGridSpy.mock.calls.length;
+    const focusRequestBeforeClick = (paneGridSpy.mock.lastCall?.[0] as {
+      focusRequestId: number;
+    }).focusRequestId;
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Open matrix-main" }));
@@ -2316,7 +2319,11 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
-    expect(paneGridSpy.mock.calls).toHaveLength(paneRenderCount);
+    expect(paneGridSpy.mock.calls).toHaveLength(paneRenderCount + 1);
+    expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
+      focusRequestId: focusRequestBeforeClick + 1,
+      paneTree: { sessionId: "main" },
+    });
     const layoutSaveCalls = fetchMock.mock.calls.filter(([input, init]) => (
       String(input).includes("/api/terminal/layout") && init?.method === "PUT"
     ));

--- a/tests/shell/terminal-design-tab-strip.test.tsx
+++ b/tests/shell/terminal-design-tab-strip.test.tsx
@@ -233,6 +233,47 @@ describe("TerminalApp per-design interior chrome", () => {
     expect(within(tablist).getByRole("tab", { name: "Shell" }).getAttribute("aria-selected")).toBe("true");
   });
 
+  it("requests xterm focus for changed, repeated, and replacement tab activation", async () => {
+    setThemeStyle("win11");
+    render(<TerminalApp initialSessionId="canvas-session-123" />);
+    await flushAsync();
+
+    const readGridProps = () => paneGridSpy.mock.lastCall?.[0] as {
+      focusRequestId: number;
+      focusedPaneId: string | null;
+      paneTree: { type: "pane"; id: string };
+    };
+    const tablist = screen.getByRole("tablist", { name: "Terminal tabs" });
+    const canvasTab = within(tablist).getByRole("tab", { name: "Canvas Terminal" });
+    const initialRequest = readGridProps().focusRequestId;
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "New tab" }));
+      await Promise.resolve();
+    });
+    await flushAsync();
+
+    const afterCreate = readGridProps();
+    expect(afterCreate.focusRequestId).toBeGreaterThan(initialRequest);
+    expect(afterCreate.focusedPaneId).toBe(afterCreate.paneTree.id);
+
+    fireEvent.click(canvasTab);
+    const afterSwitch = readGridProps();
+    expect(afterSwitch.focusRequestId).toBeGreaterThan(afterCreate.focusRequestId);
+    expect(afterSwitch.focusedPaneId).toBe(afterSwitch.paneTree.id);
+
+    fireEvent.click(canvasTab);
+    const afterRepeatedActivation = readGridProps();
+    expect(afterRepeatedActivation.focusRequestId).toBeGreaterThan(afterSwitch.focusRequestId);
+    expect(afterRepeatedActivation.focusedPaneId).toBe(afterRepeatedActivation.paneTree.id);
+
+    fireEvent.click(within(tablist).getByRole("button", { name: "Close Canvas Terminal" }));
+    const afterClose = readGridProps();
+    expect(within(tablist).getByRole("tab", { name: "Shell" }).getAttribute("aria-selected")).toBe("true");
+    expect(afterClose.focusRequestId).toBeGreaterThan(afterRepeatedActivation.focusRequestId);
+    expect(afterClose.focusedPaneId).toBe(afterClose.paneTree.id);
+  });
+
   it("links design tabs to the terminal panel with ARIA containment and controls", async () => {
     setThemeStyle("win11");
     render(<TerminalApp initialSessionId="canvas-session-123" />);

--- a/tests/shell/terminal-focus-request.test.tsx
+++ b/tests/shell/terminal-focus-request.test.tsx
@@ -20,6 +20,12 @@ function FocusHarness({
   return null;
 }
 
+function UnknownTerminalHarness({ terminal }: { terminal: unknown }) {
+  const terminalRef = useRef<unknown>(terminal);
+  useTerminalFocusRequest(terminalRef, 1, true, false);
+  return null;
+}
+
 describe("useTerminalFocusRequest", () => {
   it("refocuses an already-focused terminal only for a new focus request", () => {
     const focus = vi.fn();
@@ -45,5 +51,9 @@ describe("useTerminalFocusRequest", () => {
     );
 
     expect(focus).not.toHaveBeenCalled();
+  });
+
+  it("safely ignores a terminal ref that is not focusable yet", () => {
+    expect(() => render(<UnknownTerminalHarness terminal={{}} />)).not.toThrow();
   });
 });

--- a/tests/shell/terminal-focus-request.test.tsx
+++ b/tests/shell/terminal-focus-request.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import React, { useRef } from "react";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useTerminalFocusRequest } from "../../shell/src/components/terminal/useTerminalFocusRequest.js";
+
+function FocusHarness({
+  focus,
+  focusRequestId,
+  isFocused = true,
+  suppressNativeKeyboard = false,
+}: {
+  focus: () => void;
+  focusRequestId: number;
+  isFocused?: boolean;
+  suppressNativeKeyboard?: boolean;
+}) {
+  const terminalRef = useRef({ focus });
+  useTerminalFocusRequest(terminalRef, focusRequestId, isFocused, suppressNativeKeyboard);
+  return null;
+}
+
+describe("useTerminalFocusRequest", () => {
+  it("refocuses an already-focused terminal only for a new focus request", () => {
+    const focus = vi.fn();
+    const { rerender } = render(<FocusHarness focus={focus} focusRequestId={0} />);
+
+    expect(focus).toHaveBeenCalledOnce();
+
+    rerender(<FocusHarness focus={focus} focusRequestId={0} />);
+    expect(focus).toHaveBeenCalledOnce();
+
+    rerender(<FocusHarness focus={focus} focusRequestId={1} />);
+    expect(focus).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not claim native keyboard focus for inactive or mobile terminals", () => {
+    const focus = vi.fn();
+    const { rerender } = render(
+      <FocusHarness focus={focus} focusRequestId={0} isFocused={false} />,
+    );
+
+    rerender(
+      <FocusHarness focus={focus} focusRequestId={1} suppressNativeKeyboard />,
+    );
+
+    expect(focus).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- recover Canvas pointer ownership after screen-recording and tab-focus transitions
- request xterm DOM focus for new, restored, switched, repeated, and replacement Terminal tabs
- preserve the existing non-focus-stealing background-session behavior
- add focused regression coverage for both failure modes

Fixes MAT-442.

## Tests

- PASS: pinned Node 24/Flox focused suite — 4 files, 120 tests
- PASS: full repository typecheck
- PASS: pattern scan — 0 violations, 5 existing warnings
- PASS: git diff check
- PASS: CI-discovered Terminal focus ref boundary now ignores non-focusable unknown values safely; the original Next build type error is absent from local shell TypeScript output
- BASELINE BLOCKED: broad unit suite — 43 files failed / 911 passed / 3 skipped; 304 tests failed / 10,645 passed / 20 skipped, primarily localStorage environment failures plus unrelated CLI/platform timeouts
- BASELINE BLOCKED: existing TerminalPane scroll suite — 27/29 failures because its xterm mock does not intercept the dynamic import after a frozen install and real xterm requires window.matchMedia; the unchanged suite fails before changed behavior
- BASELINE BLOCKED: shell lint cannot resolve next/dist/compiled/babel/eslint-parser
- BASELINE BLOCKED: local production build and runtime fail before changed modules compile in the local Mermaid/Langium dependency tree, including missing vscode-languageserver-types and internal export mismatches

## Review and monitoring

- Greptile review required at 5/5 for the latest head before ready-for-ci
- ready-for-ci was removed after the first CI run exposed the stricter Next build type boundary
- ready-for-ci will be restored only after the new head reaches Greptile 5/5
- fresh exact-head manual recording remains pending until the unrelated local shell dependency baseline compiles

## Invariants

- Source of truth: canonical shell sessions remain in /api/terminal/sessions; this patch adds only ephemeral UI focus requests.
- Lock and transaction scope: no database, lock, persistence, or transaction behavior changes.
- Acceptable orphan states: none introduced; focus request counters are component-local and disappear with the Terminal surface.
- Auth source of truth: unchanged; existing gateway and shell session authentication remains authoritative.
- Deferred scope: PTY and WebSocket lifecycle, session architecture, hover-card layout, clipboard behavior, and the unrelated local dependency baseline are intentionally unchanged.