### PR TITLE
fix(updates): verify running gateway version

### DIFF
--- a/.github/workflows/user-systemd-terminal-production-acceptance.yml
+++ b/.github/workflows/user-systemd-terminal-production-acceptance.yml
@@ -429,7 +429,7 @@ jobs:
           PYTHON
             )"
             case "$error" in
-              apply_failed|apply_interrupted|bundle_extract_failed|bundle_layout_invalid|checksum_mismatch|download_failed|download_metadata_changed|insufficient_disk_space|post_install_health_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_rollback_failed|post_install_service_start_failed|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|update_target_mismatch) ;;
+              apply_failed|apply_interrupted|bundle_extract_failed|bundle_layout_invalid|checksum_mismatch|download_failed|download_metadata_changed|insufficient_disk_space|post_install_health_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_rollback_failed|post_install_runtime_version_mismatch|post_install_service_start_failed|pre_install_service_stop_failed|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|update_target_mismatch) ;;
               *) error=invalid ;;
             esac
           fi
@@ -438,7 +438,7 @@ jobs:
             body="$(jq -cn --arg script "$diagnostic_script" \
               '{command:["/usr/bin/sudo","/bin/bash","-c",$script],timeoutMs:45000}')"
             send_signed_command "$body" "$response"
-            jq -er '.stdout | select(test("^phase=(idle|prepare|download|verify|extract|terminal-runtime|app-install|host-bin|health|invalid) error=(none|apply_failed|apply_interrupted|bundle_extract_failed|bundle_layout_invalid|checksum_mismatch|download_failed|download_metadata_changed|insufficient_disk_space|post_install_health_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_rollback_failed|post_install_service_start_failed|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|update_target_mismatch|invalid)\\n$")) | rtrimstr("\n")' \
+            jq -er '.stdout | select(test("^phase=(idle|prepare|download|verify|extract|terminal-runtime|app-install|host-bin|health|invalid) error=(none|apply_failed|apply_interrupted|bundle_extract_failed|bundle_layout_invalid|checksum_mismatch|download_failed|download_metadata_changed|insufficient_disk_space|post_install_health_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_rollback_failed|post_install_runtime_version_mismatch|post_install_service_start_failed|pre_install_service_stop_failed|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|update_target_mismatch|invalid)\\n$")) | rtrimstr("\n")' \
               "$response"
           }
           response="$RUNNER_TEMP/user-systemd-recovery.json"

--- a/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { readSystemVersionIdentity } from "../../../lib/system-version";
 import { useConnection } from "../../../stores/connection";
 import { captureRuntimeGeneration, isCurrentRuntimeGeneration } from "../../../stores/runtime-generation";
 import { AlertTriangle, ArrowUpCircleIcon, LoaderCircle, RefreshCw } from "../../../lib/hugeicons";
@@ -19,7 +20,8 @@ interface SystemRelease {
 }
 
 interface SystemInfo {
-  version?: string;
+  version?: unknown;
+  runningVersion?: unknown;
   updateChannel?: string;
   runtime?: { handle?: string; runtimeSlot?: string; machineId?: string };
   resources?: { cpuCount?: number; memoryTotal?: number; memoryFree?: number; diskTotal?: number; diskFree?: number };
@@ -206,9 +208,13 @@ export default function SystemSection() {
   };
 
   const info = state.info;
-  const currentVersion = info?.release?.version ?? info?.version;
+  const { installedVersion, runningVersion } = readSystemVersionIdentity(info);
+  const currentVersion = installedVersion ?? info?.release?.version;
   const releases = releaseList?.releases ?? [];
   const latest = update?.latest;
+  const versionMismatch = Boolean(
+    installedVersion && runningVersion && installedVersion !== runningVersion,
+  );
 
   return (
     <>
@@ -216,12 +222,18 @@ export default function SystemSection() {
       <Card>
         {state.error ? <Empty text="System info unavailable." /> : (
           <>
-            <Row label="OS version" value={info?.version ?? "–"} />
-            <Row label="Release channel" value={info?.release?.channel ?? "–"} />
-            <Row label="Machine" value={info?.runtime?.machineId ?? info?.runtime?.handle ?? "–"} />
-            <Row label="CPU cores" value={info?.resources?.cpuCount ?? "–"} />
-            <Row label="Memory free" value={`${gb(info?.resources?.memoryFree)} of ${gb(info?.resources?.memoryTotal)}`} />
-            <Row label="Disk free" value={`${gb(info?.resources?.diskFree)} of ${gb(info?.resources?.diskTotal)}`} />
+            <Row label="Installed version" value={installedVersion ?? "–"} />
+            <Row label="Running version" value={runningVersion ?? "–"} />
+            {versionMismatch ? (
+              <p role="status" className="text-sm" style={{ color: "var(--warning)" }}>
+                The running services do not match the installed update. Restart Matrix services to finish applying it.
+              </p>
+            ) : null}
+            <Row label="Release channel" value={state.info?.release?.channel ?? "–"} />
+            <Row label="Machine" value={state.info?.runtime?.machineId ?? state.info?.runtime?.handle ?? "–"} />
+            <Row label="CPU cores" value={state.info?.resources?.cpuCount ?? "–"} />
+            <Row label="Memory free" value={`${gb(state.info?.resources?.memoryFree)} of ${gb(state.info?.resources?.memoryTotal)}`} />
+            <Row label="Disk free" value={`${gb(state.info?.resources?.diskFree)} of ${gb(state.info?.resources?.diskTotal)}`} />
           </>
         )}
       </Card>

--- a/desktop/src/renderer/src/lib/system-version.ts
+++ b/desktop/src/renderer/src/lib/system-version.ts
@@ -7,9 +7,13 @@ export interface SystemVersionIdentity {
 
 export function readSystemVersionIdentity(value: unknown): SystemVersionIdentity {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
-  const info = value as { version?: unknown; runningVersion?: unknown };
+  const info = value as {
+    version?: unknown;
+    runningVersion?: unknown;
+    release?: { version?: unknown };
+  };
   return {
-    installedVersion: safeSystemVersion(info.version),
+    installedVersion: safeSystemVersion(info.release?.version) ?? safeSystemVersion(info.version),
     runningVersion: safeSystemVersion(info.runningVersion),
   };
 }

--- a/desktop/src/renderer/src/lib/system-version.ts
+++ b/desktop/src/renderer/src/lib/system-version.ts
@@ -1,0 +1,21 @@
+const SAFE_SYSTEM_VERSION = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+export interface SystemVersionIdentity {
+  installedVersion?: string;
+  runningVersion?: string;
+}
+
+export function readSystemVersionIdentity(value: unknown): SystemVersionIdentity {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const info = value as { version?: unknown; runningVersion?: unknown };
+  return {
+    installedVersion: safeSystemVersion(info.version),
+    runningVersion: safeSystemVersion(info.runningVersion),
+  };
+}
+
+export function safeSystemVersion(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return SAFE_SYSTEM_VERSION.test(trimmed) ? trimmed : undefined;
+}

--- a/desktop/src/renderer/src/stores/project-lifecycle.ts
+++ b/desktop/src/renderer/src/stores/project-lifecycle.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { AppError, categoryMessage } from "../../../shared/app-error";
 import type { ApiClient } from "../lib/api";
+import { readSystemVersionIdentity } from "../lib/system-version";
 import { parseProject, type Project, useBoard } from "./board";
 import { useCodingAgentWorkspace } from "./coding-agent-workspace";
 import { clearProjectView } from "./project-view";
@@ -20,10 +21,24 @@ const SAFE_ACTION_ERRORS: Record<string, string> = {
   delete_incomplete: "Project deletion could not be completed. Try again.",
 };
 
-function safeActionError(error: unknown): string {
+const PROJECT_ACTIONS_UNAVAILABLE =
+  "Project management is unavailable on this computer. Restart Matrix services and try again.";
+const PROJECT_UPDATE_INCOMPLETE =
+  "This computer has not finished applying its update. Restart Matrix services, then try again.";
+
+async function safeActionError(api: ApiClient, error: unknown): Promise<string> {
   if (error instanceof AppError) {
     if (error.category === "notFound" && !error.detail) {
-      return "Update this Matrix computer before managing projects.";
+      try {
+        const info = await api.get<unknown>("/api/system/info");
+        const { installedVersion, runningVersion } = readSystemVersionIdentity(info);
+        if (installedVersion && runningVersion && installedVersion !== runningVersion) {
+          return PROJECT_UPDATE_INCOMPLETE;
+        }
+      } catch (_diagnosticError: unknown) {
+        console.warn("[project-lifecycle] Gateway runtime identity could not be inspected");
+      }
+      return PROJECT_ACTIONS_UNAVAILABLE;
     }
     return (error.detail && SAFE_ACTION_ERRORS[error.detail]) || categoryMessage(error.category);
   }
@@ -60,7 +75,9 @@ export const useProjectLifecycle = create<ProjectLifecycleState>()((set, get) =>
       return true;
     } catch (error: unknown) {
       if (!isCurrentRuntimeGeneration(generation)) return false;
-      set({ loading: false, error: safeActionError(error) });
+      const message = await safeActionError(api, error);
+      if (!isCurrentRuntimeGeneration(generation)) return false;
+      set({ loading: false, error: message });
       return false;
     }
   }
@@ -92,7 +109,9 @@ export const useProjectLifecycle = create<ProjectLifecycleState>()((set, get) =>
       return true;
     } catch (error: unknown) {
       if (!isCurrentRuntimeGeneration(generation)) return false;
-      set({ pendingProjectSlug: null, error: safeActionError(error) });
+      const message = await safeActionError(api, error);
+      if (!isCurrentRuntimeGeneration(generation)) return false;
+      set({ pendingProjectSlug: null, error: message });
       return false;
     }
   }

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -50,6 +50,27 @@ current_version() { cat "$VERSION_FILE" 2>/dev/null || echo "unknown"; }
 platform_url() { echo "${MATRIX_UPDATE_MANIFEST_BASE_URL:-${PLATFORM_INTERNAL_URL:-https://app.matrix-os.com}}"; }
 staged_release_metadata=""
 
+stop_runtime_services() {
+  local service state
+  if ! sudo systemctl stop matrix-symphony matrix-gateway matrix-shell; then
+    log "ERROR: systemd could not stop all runtime services"
+    return 1
+  fi
+  for service in matrix-symphony matrix-gateway matrix-shell; do
+    if ! state="$(sudo systemctl show --property=ActiveState --value "$service")"; then
+      log "ERROR: systemd could not inspect $service after stopping it"
+      return 1
+    fi
+    case "$state" in
+      inactive|failed) ;;
+      *)
+        log "ERROR: $service remained in state ${state:-unknown} after stopping it"
+        return 1
+        ;;
+    esac
+  done
+}
+
 cleanup_staged_release_metadata() {
   if [ -n "$staged_release_metadata" ]; then
     sudo rm -f -- "$staged_release_metadata" || true
@@ -341,6 +362,12 @@ release_url_for_version() { echo "$(platform_url)/system-bundles/releases/$1.jso
 release_url_for_channel() { echo "$(platform_url)/system-bundles/channels/$1.json"; }
 
 json_field() { python3 -c "import json,sys; print(json.load(sys.stdin).get(sys.argv[1],''))" "$2" <<< "$1"; }
+
+running_gateway_version() {
+  local response
+  response="$(curl --fail --silent --max-time 5 "$HEALTH_URL")" || return 1
+  json_field "$response" runningVersion
+}
 
 compare_host_bundle_versions() {
   local candidate="$1" current="$2"
@@ -880,7 +907,13 @@ apply_update() {
     return 1
   fi
   log "Stopping services..."
-  sudo systemctl stop matrix-symphony matrix-gateway matrix-shell || true
+  if ! stop_runtime_services; then
+    log "ERROR: runtime services did not stop; aborting before app replacement"
+    write_update_error "pre_install_service_stop_failed" "The running services could not be stopped safely, so the update was not installed." "$version"
+    cleanup_staged_release_metadata
+    rm -rf "$extract_dir" "$bundle_file"
+    return 1
+  fi
   sudo rm -rf "$APP_DIR.rollback"
   if [ -d "$APP_DIR" ]; then
     sudo mv "$APP_DIR" "$APP_DIR.rollback"
@@ -973,10 +1006,13 @@ apply_update() {
   fi
   log "Running health check..."
   write_update_phase health || return 1
-  local healthy=false
+  local healthy=false gateway_reached=false observed_running_version=""
   for _ in $(seq 1 18); do
-    if curl --fail --silent --max-time 5 "$HEALTH_URL" >/dev/null 2>&1; then
-      healthy=true; break
+    if observed_running_version="$(running_gateway_version)"; then
+      gateway_reached=true
+      if [ "$observed_running_version" = "$version" ]; then
+        healthy=true; break
+      fi
     fi
     sleep 5
   done
@@ -1003,9 +1039,18 @@ apply_update() {
       return 1
     fi
   else
-    log "ERROR: health check failed — rolling back"
+    local verification_error_code verification_error_message
+    if [ "$gateway_reached" = true ]; then
+      log "ERROR: gateway running version did not match the candidate release — rolling back"
+      verification_error_code="post_install_runtime_version_mismatch"
+      verification_error_message="The updated gateway did not report the expected running version and the previous release was restored."
+    else
+      log "ERROR: health check failed — rolling back"
+      verification_error_code="post_install_health_failed"
+      verification_error_message="The updated gateway failed its health check and the previous release was restored."
+    fi
     if do_rollback false; then
-      write_update_error "post_install_health_failed" "The updated gateway failed its health check and the previous release was restored." "$version"
+      write_update_error "$verification_error_code" "$verification_error_message" "$version"
     else
       write_update_error "post_install_rollback_failed" "The updated gateway failed its health check and rollback did not complete." "$version"
     fi
@@ -1046,7 +1091,10 @@ do_rollback() {
     return 1
   fi
   log "Rolling back..."
-  sudo systemctl stop matrix-symphony matrix-gateway matrix-shell || true
+  if ! stop_runtime_services; then
+    log "ERROR: rollback could not stop the runtime services safely"
+    return 1
+  fi
   if [ -d "$APP_DIR" ]; then
     sudo mkdir -p "$STAGING_DIR"
     sudo chown matrix:matrix "$STAGING_DIR"

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -176,7 +176,7 @@ import { resolveDefaultAppIconUrl, resolveSystemIconUrl } from "./default-icons.
 import { registerIconRoutes } from "./icon-routes.js";
 import { buildShellBootstrap } from "./shell-bootstrap.js";
 import { securityHeadersMiddleware } from "./security/headers.js";
-import { getSystemInfo } from "./system-info.js";
+import { getSystemInfo, getVersion } from "./system-info.js";
 import { collectSystemActivity } from "./system-activity/collector.js";
 import { CleanupCandidateRegistry, executeCleanupAction } from "./system-activity/cleanup.js";
 import { ActivityHistoryStore, AutoCleanupPolicyStore } from "./system-activity/history.js";
@@ -381,6 +381,9 @@ const MAX_MAIN_WS_CLIENTS = 100;
 export async function createGateway(config: GatewayConfig) {
   const { homePath: rawHomePath, port = 4000, syncReport } = config;
   const homePath = resolve(rawHomePath);
+  const runningVersion = getVersion(
+    config.runningVersion ? { version: config.runningVersion } : undefined,
+  );
   let syncReportSent = false;
   const allowedOriginController = createAllowedOriginController({
     shellOrigin: process.env.SHELL_ORIGIN,
@@ -3876,13 +3879,13 @@ export async function createGateway(config: GatewayConfig) {
   });
 
   app.get("/api/system/info", (c) => {
-    const info = getSystemInfo(homePath, { model: config.model });
+    const info = getSystemInfo(homePath, { model: config.model, runningVersion });
     const today = new Date().toISOString().slice(0, 10);
     return c.json({ ...info, todayCost: interactionLogger.totalCost(today) });
   });
 
   app.get("/api/system/update", async (c) => {
-    const info = getSystemInfo(homePath, { model: config.model });
+    const info = getSystemInfo(homePath, { model: config.model, runningVersion });
     const channel = resolveSystemUpdateChannel(c.req.query("channel"), {
       envChannel: process.env.MATRIX_UPDATE_CHANNEL,
       installedChannel: info.release?.channel,
@@ -3903,7 +3906,7 @@ export async function createGateway(config: GatewayConfig) {
   });
 
   app.get("/api/system/releases", async (c) => {
-    const info = getSystemInfo(homePath, { model: config.model });
+    const info = getSystemInfo(homePath, { model: config.model, runningVersion });
     const channel = resolveSystemUpdateChannel(c.req.query("channel"), {
       envChannel: process.env.MATRIX_UPDATE_CHANNEL,
       installedChannel: info.release?.channel,
@@ -3938,7 +3941,7 @@ export async function createGateway(config: GatewayConfig) {
         console.warn("[system-update] Failed to parse update request:", err);
       }
     }
-    const info = getSystemInfo(homePath, { model: config.model });
+    const info = getSystemInfo(homePath, { model: config.model, runningVersion });
     const parsedTarget = resolveInternalUpgradeStartTarget(body, {
       envChannel: process.env.MATRIX_UPDATE_CHANNEL,
       installedChannel: info.release?.channel,
@@ -4367,6 +4370,7 @@ export async function createGateway(config: GatewayConfig) {
 
   app.get("/health", (c) => c.json({
     status: "ok",
+    runningVersion,
     cronJobs: cronService.listJobs().length,
     channels: channelManager.status(),
     plugins: loadedPlugins.length,

--- a/packages/gateway/src/server/types.ts
+++ b/packages/gateway/src/server/types.ts
@@ -6,6 +6,7 @@ export interface GatewayConfig {
   model?: string;
   maxTurns?: number;
   spawnFn?: SpawnFn;
+  runningVersion?: string;
   syncReport?: { added: string[]; updated: string[]; skipped: string[] };
 }
 

--- a/packages/gateway/src/system-info.ts
+++ b/packages/gateway/src/system-info.ts
@@ -161,6 +161,7 @@ export function getVersion(release?: HostBundleRelease): string {
 
 export interface SystemInfo {
   version: string;
+  runningVersion: string;
   channel?: string;
   updateChannel: string;
   model: string;
@@ -337,7 +338,7 @@ function readDiskUsage(path: string): { totalBytes: number; freeBytes: number } 
 
 export function getSystemInfo(
   homePath: string,
-  kernelOverrides: { model?: string } = {},
+  kernelOverrides: { model?: string; runningVersion?: string } = {},
 ): SystemInfo {
   const kernel = resolveKernelConfigFile(homePath);
   let modules = 0;
@@ -405,9 +406,12 @@ export function getSystemInfo(
     ?? parseReleaseChannel(process.env.MATRIX_UPDATE_CHANNEL)
     ?? channel
     ?? "stable";
+  const version = getVersion(release);
+  const runningVersion = parseSafeSystemVersion(kernelOverrides.runningVersion) ?? version;
 
   return {
-    version: getVersion(release),
+    version,
+    runningVersion,
     ...(channel ? { channel } : {}),
     updateChannel,
     model: kernelOverrides.model ?? kernel.model,

--- a/scripts/spikes/user-systemd-terminal/production-acceptance.sh
+++ b/scripts/spikes/user-systemd-terminal/production-acceptance.sh
@@ -1066,7 +1066,7 @@ diagnose_update_failure() {
   if [ -e /opt/matrix/app/.update-error.json ] || [ -L /opt/matrix/app/.update-error.json ]; then
     error_code="$(read_update_error_code 2>/dev/null || true)"
     case "$error_code" in
-      download_failed|download_metadata_changed|update_target_mismatch|insufficient_disk_space|checksum_mismatch|bundle_extract_failed|bundle_layout_invalid|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_service_start_failed|post_install_health_failed|post_install_rollback_failed|apply_failed|apply_interrupted|unknown) ;;
+      download_failed|download_metadata_changed|update_target_mismatch|insufficient_disk_space|checksum_mismatch|bundle_extract_failed|bundle_layout_invalid|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|pre_install_service_stop_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_service_start_failed|post_install_health_failed|post_install_runtime_version_mismatch|post_install_rollback_failed|apply_failed|apply_interrupted|unknown) ;;
       *) error_code=unknown ;;
     esac
   fi
@@ -1109,7 +1109,7 @@ wait_update() {
       { [ -e /opt/matrix/app/.update-error.json ] || [ -L /opt/matrix/app/.update-error.json ]; }; then
       error_code="$(read_update_error_code 2>/dev/null || true)"
       case "$error_code" in
-        download_failed|download_metadata_changed|update_target_mismatch|insufficient_disk_space|checksum_mismatch|bundle_extract_failed|bundle_layout_invalid|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_service_start_failed|post_install_health_failed|post_install_rollback_failed|apply_failed|apply_interrupted|unknown) ;;
+        download_failed|download_metadata_changed|update_target_mismatch|insufficient_disk_space|checksum_mismatch|bundle_extract_failed|bundle_layout_invalid|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|pre_install_service_stop_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_service_start_failed|post_install_health_failed|post_install_runtime_version_mismatch|post_install_rollback_failed|apply_failed|apply_interrupted|unknown) ;;
         *) error_code=unknown ;;
       esac
       if [ "$error_code" != none ]; then

--- a/shell/src/components/settings/sections/SystemSection.tsx
+++ b/shell/src/components/settings/sections/SystemSection.tsx
@@ -708,7 +708,7 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
         </CardHeader>
         <CardContent className="space-y-2">
           {[
-            ["Version", info.version ?? "0.1.0"],
+            ["Version", installedVersion ?? "0.1.0"],
             ["Host Bundle", info.release?.version],
             ["Channel", info.release?.channel],
             ["Build ID", formatReleaseBuildShortId(info.release?.gitCommit)],

--- a/shell/src/components/settings/sections/SystemSection.tsx
+++ b/shell/src/components/settings/sections/SystemSection.tsx
@@ -13,7 +13,8 @@ const UPDATE_INSTALL_POLL_MS = 5_000;
 const UPDATE_INSTALL_TIMEOUT_MS = 5 * 60_000;
 
 interface SystemInfo {
-  version?: string;
+  version?: unknown;
+  runningVersion?: unknown;
   image?: string;
   updateChannel?: string;
   release?: {
@@ -99,6 +100,7 @@ import {
   resolveUpgradeInstallCopy,
   severityBadgeStyle,
   resolveSystemUpdateState,
+  safeSystemVersion,
 } from "./system-update-state";
 
 const RELEASE_CHANNELS = ["stable", "canary", "beta", "dev"] as const;
@@ -203,8 +205,17 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
 
   }, [refreshReleaseData]);
 
+  const installedVersion = safeSystemVersion(info.release?.version ?? info.version);
+  const runningVersion = safeSystemVersion(info.runningVersion);
+  const runningVersionMatchesInstalled = Boolean(
+    installedVersion && runningVersion && installedVersion === runningVersion,
+  );
+  const runningVersionMismatch = Boolean(
+    installedVersion && runningVersion && installedVersion !== runningVersion,
+  );
+  const runningVersionUnavailable = Boolean(installedVersion && !runningVersion);
   const resolvedUpdate = resolveSystemUpdateState({
-    installedVersion: info.release?.version ?? info.version,
+    installedVersion,
     latestVersion: updateStatus?.latest?.version ?? null,
     updateAvailable: updateStatus?.updateAvailable,
     severity: updateStatus?.latest?.severity,
@@ -241,14 +252,18 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
         if (!res.ok) continue;
         // react-doctor-disable-next-line react-doctor/async-defer-await -- the post-await mount/install guards operate on the parsed poll result and on state that can only change during this await; they cannot be hoisted before parsing the response body, so this is intentional polling, not a skippable synchronous guard.
         const nextInfo = await res.json() as SystemInfo;
-        const installedVersion = nextInfo.release?.version ?? nextInfo.version;
+        const installedVersion = safeSystemVersion(nextInfo.release?.version ?? nextInfo.version);
+        const runningVersion = safeSystemVersion(nextInfo.runningVersion);
         const polledChannel = coerceReleaseChannel(nextInfo.release?.channel);
         const channelInstalled = target.channel ? polledChannel === target.channel : true;
-        const installed = target.version
+        const runtimeVerified = Boolean(
+          installedVersion && runningVersion && installedVersion === runningVersion,
+        );
+        const installed = runtimeVerified && (target.version
           ? installedVersion === target.version && channelInstalled
           : target.channel
             ? channelInstalled && (installedVersion !== currentVersion || target.channel !== installedChannel)
-            : installedVersion !== currentVersion;
+            : installedVersion !== currentVersion);
         if (!mountedRef.current) return false;
         if (installed) {
           setInfo(nextInfo);
@@ -480,8 +495,12 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
 
           <div className="grid gap-2 text-sm">
             <div className="flex items-center justify-between gap-3">
-              <span className="text-muted-foreground">Current version</span>
+              <span className="text-muted-foreground">Installed version</span>
               <span className="font-mono text-xs text-right">{currentVersion}</span>
+            </div>
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-muted-foreground">Running version</span>
+              <span className="font-mono text-xs text-right">{runningVersion ?? "unavailable"}</span>
             </div>
             <div className="flex items-center justify-between gap-3">
               <span className="text-muted-foreground">Installed channel</span>
@@ -501,6 +520,17 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
               </div>
             )}
           </div>
+
+          {(runningVersionMismatch || runningVersionUnavailable) && (
+            <div
+              role="alert"
+              className="rounded-lg border border-amber-500/25 bg-amber-500/10 p-3 text-xs leading-5 text-amber-800 dark:text-amber-300"
+            >
+              {runningVersionMismatch
+                ? "The running services do not match the installed update. Restart Matrix services to finish applying it."
+                : "The running version could not be verified. Restart Matrix services before managing projects."}
+            </div>
+          )}
 
           {(updateStatus?.error || releaseList?.error) && (
             <p className="text-xs text-muted-foreground">{updateStatus?.error ?? releaseList?.error}</p>
@@ -602,7 +632,7 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
               </button>
             </div>
           )}
-          {latestVersion && !canInstallSelectedChannel && (
+          {latestVersion && !canInstallSelectedChannel && runningVersionMatchesInstalled && (
             <p className="text-xs text-muted-foreground pt-1">
               You are running the latest release for this channel.
             </p>

--- a/shell/src/components/settings/sections/system-update-state.ts
+++ b/shell/src/components/settings/sections/system-update-state.ts
@@ -4,6 +4,14 @@ export function parseSemver(value: string): [number, number, number] | null {
   return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
+const SAFE_SYSTEM_VERSION = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+export function safeSystemVersion(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return SAFE_SYSTEM_VERSION.test(trimmed) ? trimmed : undefined;
+}
+
 export function normalizeMatrixReleaseTag(tagName: string): string | null {
   if (tagName.startsWith("cli-")) return null;
   const parsed = parseSemver(tagName);

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -148,7 +148,10 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(syncAgent).toContain("return \"$status\"");
     expect(syncAgent).toContain("sudo systemctl enable matrix-symphony.service");
     expect(syncAgent).toContain("sudo systemctl start --no-block matrix-symphony.service");
-    expect(syncAgent).toContain("sudo systemctl stop matrix-symphony matrix-gateway matrix-shell || true");
+    expect(syncAgent).toContain("stop_runtime_services()");
+    expect(syncAgent).toContain("if ! sudo systemctl stop matrix-symphony matrix-gateway matrix-shell; then");
+    expect(syncAgent).toContain('sudo systemctl show --property=ActiveState --value "$service"');
+    expect(syncAgent).not.toContain("sudo systemctl stop matrix-symphony matrix-gateway matrix-shell || true");
   });
 
   it("keeps observability failures distinct from missing issues", async () => {

--- a/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
+++ b/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
@@ -463,7 +463,7 @@ describe("customer VPS user-systemd terminal runtime", () => {
     expect(acceptance).toContain('classify_installed_updater_protocol');
     expect(acceptance).toContain('systemctl show matrix-sync-agent.service -p NRestarts --value');
     expect(acceptance).toContain('case "$error_code" in');
-    expect(acceptance).toContain('download_failed|download_metadata_changed|update_target_mismatch|insufficient_disk_space|checksum_mismatch|bundle_extract_failed|bundle_layout_invalid|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_service_start_failed|post_install_health_failed|post_install_rollback_failed|apply_failed|apply_interrupted|unknown)');
+    expect(acceptance).toContain('download_failed|download_metadata_changed|update_target_mismatch|insufficient_disk_space|checksum_mismatch|bundle_extract_failed|bundle_layout_invalid|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|pre_install_service_stop_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_service_start_failed|post_install_health_failed|post_install_runtime_version_mismatch|post_install_rollback_failed|apply_failed|apply_interrupted|unknown)');
     expect(acceptance).not.toContain("journalctl -u matrix-sync-agent");
     expect(workflow).toContain("Acceptance stalled at ${state:-unavailable}");
     expect(workflow).toContain("Acceptance failed at ${state}");

--- a/tests/desktop/project-lifecycle-store.test.ts
+++ b/tests/desktop/project-lifecycle-store.test.ts
@@ -6,6 +6,7 @@ import { useCodingAgentWorkspace } from "@desktop/renderer/src/stores/coding-age
 import { useProjectLifecycle } from "@desktop/renderer/src/stores/project-lifecycle";
 import { useProjectView } from "@desktop/renderer/src/stores/project-view";
 import { useProjectWorkspaces } from "@desktop/renderer/src/stores/project-workspaces";
+import { advanceRuntimeGeneration } from "@desktop/renderer/src/stores/runtime-generation";
 import { useTabs } from "@desktop/renderer/src/stores/tabs";
 
 function deferred<T>() {
@@ -133,8 +134,12 @@ describe("project lifecycle store", () => {
     expect(useProjectLifecycle.getState().error).toBe("Stop active project work before continuing.");
   });
 
-  it("explains when the selected computer predates project lifecycle routes", async () => {
+  it("explains when an installed update is not the bundle serving project actions", async () => {
     const client = api({
+      get: vi.fn(async () => ({
+        version: "v2026.08.19-1002",
+        runningVersion: "v2026.08.18-997",
+      })),
       post: vi.fn(async () => {
         throw new AppError("notFound");
       }),
@@ -143,8 +148,79 @@ describe("project lifecycle store", () => {
     await expect(useProjectLifecycle.getState().archiveProject(client, "repo")).resolves.toBe(false);
 
     expect(useProjectLifecycle.getState().error).toBe(
-      "Update this Matrix computer before managing projects.",
+      "This computer has not finished applying its update. Restart Matrix services, then try again.",
     );
+    expect(client.get).toHaveBeenCalledWith("/api/system/info");
+  });
+
+  it("does not claim an update is missing when installed and running versions match", async () => {
+    const client = api({
+      get: vi.fn(async () => ({
+        version: "v2026.08.19-1002",
+        runningVersion: "v2026.08.19-1002",
+      })),
+      post: vi.fn(async () => {
+        throw new AppError("notFound");
+      }),
+    });
+
+    await expect(useProjectLifecycle.getState().archiveProject(client, "repo")).resolves.toBe(false);
+
+    expect(useProjectLifecycle.getState().error).toBe(
+      "Project management is unavailable on this computer. Restart Matrix services and try again.",
+    );
+  });
+
+  it("preserves structured not-found errors without probing system identity", async () => {
+    const client = api({
+      post: vi.fn(async () => {
+        throw new AppError("notFound", { detail: "not_found" });
+      }),
+    });
+
+    await expect(useProjectLifecycle.getState().archiveProject(client, "repo")).resolves.toBe(false);
+
+    expect(useProjectLifecycle.getState().error).toBe("That item could not be found.");
+    expect(client.get).not.toHaveBeenCalledWith("/api/system/info");
+  });
+
+  it("falls back to safe restart guidance when runtime identity cannot be inspected", async () => {
+    const client = api({
+      get: vi.fn(async () => {
+        throw new AppError("offline");
+      }),
+      post: vi.fn(async () => {
+        throw new AppError("notFound");
+      }),
+    });
+
+    await expect(useProjectLifecycle.getState().archiveProject(client, "repo")).resolves.toBe(false);
+
+    expect(useProjectLifecycle.getState().error).toBe(
+      "Project management is unavailable on this computer. Restart Matrix services and try again.",
+    );
+  });
+
+  it("does not apply a stale diagnostic after the active runtime changes", async () => {
+    const systemInfo = deferred<unknown>();
+    const client = api({
+      get: vi.fn(() => systemInfo.promise),
+      post: vi.fn(async () => {
+        throw new AppError("notFound");
+      }),
+    });
+
+    const action = useProjectLifecycle.getState().archiveProject(client, "repo");
+    await vi.waitFor(() => expect(client.get).toHaveBeenCalledWith("/api/system/info"));
+    advanceRuntimeGeneration();
+    useProjectLifecycle.setState(useProjectLifecycle.getInitialState(), true);
+    systemInfo.resolve({
+      version: "v2026.08.19-1002",
+      runningVersion: "v2026.08.18-997",
+    });
+
+    await expect(action).resolves.toBe(false);
+    expect(useProjectLifecycle.getState().error).toBeNull();
   });
 
   it("sends exact typed confirmation when permanently deleting a project", async () => {

--- a/tests/desktop/project-sidebar-row.test.tsx
+++ b/tests/desktop/project-sidebar-row.test.tsx
@@ -102,7 +102,10 @@ describe("ProjectSidebarRow", () => {
       status: "signed-in",
       api: {
         baseUrl: "https://matrix.test",
-        get: vi.fn(),
+        get: vi.fn(async () => ({
+          version: "v2026.08.19-1002",
+          runningVersion: "v2026.08.18-997",
+        })),
         post: vi.fn(async () => { throw new AppError("notFound"); }),
         patch: vi.fn(),
         put: vi.fn(),
@@ -126,7 +129,9 @@ describe("ProjectSidebarRow", () => {
     fireEvent.click(await screen.findByText("Archive project"));
 
     await screen.findByRole("heading", { name: "Project couldn't be archived" });
-    expect(screen.getByText("Update this Matrix computer before managing projects.")).not.toBeNull();
+    expect(screen.getByText(
+      "This computer has not finished applying its update. Restart Matrix services, then try again.",
+    )).not.toBeNull();
     expect(useUi.getState().rendererOverlayCount).toBe(1);
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
     await waitFor(() => expect(useUi.getState().rendererOverlayCount).toBe(0));

--- a/tests/desktop/settings-sections-error.test.tsx
+++ b/tests/desktop/settings-sections-error.test.tsx
@@ -107,4 +107,21 @@ describe("settings data sections", () => {
     expect(screen.queryByText(loading)).not.toBeNull();
     expect(screen.queryByText(empty)).toBeNull();
   });
+
+  it("shows installed and running bundle versions when an update is only partially applied", async () => {
+    useConnection.setState({
+      api: makeApi({
+        version: "v2026.08.19-1002",
+        runningVersion: "v2026.08.18-997",
+      }),
+    });
+
+    render(<SystemSection />);
+
+    expect(await screen.findByText("Installed version")).not.toBeNull();
+    expect(screen.getByText("Running version")).not.toBeNull();
+    expect(screen.getByText(
+      "The running services do not match the installed update. Restart Matrix services to finish applying it.",
+    )).not.toBeNull();
+  });
 });

--- a/tests/desktop/system-version.test.ts
+++ b/tests/desktop/system-version.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { readSystemVersionIdentity } from "../../desktop/src/renderer/src/lib/system-version";
+
+describe("desktop system version identity", () => {
+  it("prefers installed release provenance over the legacy app version field", () => {
+    expect(readSystemVersionIdentity({
+      version: "0.1.0",
+      runningVersion: "v2026.08.20",
+      release: { version: "v2026.08.20" },
+    })).toEqual({
+      installedVersion: "v2026.08.20",
+      runningVersion: "v2026.08.20",
+    });
+  });
+
+  it("falls back to the legacy app version when release metadata is absent", () => {
+    expect(readSystemVersionIdentity({
+      version: "v2026.08.18-997",
+      runningVersion: "v2026.08.18-997",
+    })).toEqual({
+      installedVersion: "v2026.08.18-997",
+      runningVersion: "v2026.08.18-997",
+    });
+  });
+});

--- a/tests/e2e/api/health.e2e.test.ts
+++ b/tests/e2e/api/health.e2e.test.ts
@@ -5,7 +5,7 @@ describe("E2E: Health endpoint", () => {
   let gw: TestGateway;
 
   beforeAll(async () => {
-    gw = await startTestGateway();
+    gw = await startTestGateway({ runningVersion: "v2026.08.18-997" });
   });
 
   afterAll(async () => {
@@ -17,5 +17,13 @@ describe("E2E: Health endpoint", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.status).toBe("ok");
+    expect(body.runningVersion).toBe("v2026.08.18-997");
+  });
+
+  it("reports the same startup-captured version through authenticated system info", async () => {
+    const res = await gw.request("/api/system/info");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.runningVersion).toBe("v2026.08.18-997");
   });
 });

--- a/tests/e2e/fixtures/gateway.ts
+++ b/tests/e2e/fixtures/gateway.ts
@@ -38,6 +38,7 @@ export interface TestGatewayOptions {
   authToken?: string;
   config?: Record<string, unknown>;
   spawnFn?: SpawnFn;
+  runningVersion?: string;
 }
 
 export async function startTestGateway(
@@ -89,7 +90,12 @@ export async function startTestGateway(
 
   let gateway: Awaited<ReturnType<typeof createGateway>>;
   try {
-    gateway = await createGateway({ homePath, port, spawnFn: options.spawnFn });
+    gateway = await createGateway({
+      homePath,
+      port,
+      spawnFn: options.spawnFn,
+      runningVersion: options.runningVersion,
+    });
   } catch (error) {
     if (usesInsecureDevAuth) {
       releaseInsecureDevAuth();

--- a/tests/gateway/system-info.test.ts
+++ b/tests/gateway/system-info.test.ts
@@ -278,6 +278,30 @@ describe("T135: System info", () => {
     }
   });
 
+  it("reports the startup-captured running bundle separately from installed provenance", () => {
+    const homePath = tmpHome();
+    const releasePath = join(homePath, "release.json");
+    const previousReleasePath = process.env.MATRIX_RELEASE_FILE;
+    process.env.MATRIX_RELEASE_FILE = releasePath;
+    writeFileSync(
+      releasePath,
+      JSON.stringify({ version: "v2026.08.19-1002", channel: "dev" }),
+    );
+
+    try {
+      const info = getSystemInfo(homePath, {
+        runningVersion: "v2026.08.18-997",
+      });
+
+      expect(info.version).toBe("v2026.08.19-1002");
+      expect(info.runningVersion).toBe("v2026.08.18-997");
+    } finally {
+      if (previousReleasePath === undefined) delete process.env.MATRIX_RELEASE_FILE;
+      else process.env.MATRIX_RELEASE_FILE = previousReleasePath;
+      rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
   it("reports the persistent update channel separately from bundle provenance", () => {
     const homePath = tmpHome();
     const releasePath = join(homePath, "release.json");

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -64,6 +64,21 @@ function compareSyncAgentVersions(candidate: string, current: string): string {
   return result.stdout.trim();
 }
 
+function extractSyncAgentFunction(name: string): string {
+  const root = process.cwd();
+  const syncAgent = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-sync-agent'), 'utf8');
+  const functionSource = syncAgent.match(new RegExp(`${name}\\(\\) \\{[\\s\\S]*?\\n\\}`))?.[0];
+  expect(functionSource).toBeDefined();
+  return functionSource!;
+}
+
+function runSyncAgentFunction(source: string, invocation: string, setup: string) {
+  return spawnSync('bash', ['-c', `${setup}\n${source}\n${invocation}`], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+}
+
 describe('customer VPS host bundle', () => {
   it('build script packages the systemd entrypoint binaries', () => {
     const root = process.cwd();
@@ -844,7 +859,7 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(workflow).toContain('classify_recovery_phase');
     expect(workflow).toContain('diagnose_recovery_state');
     expect(workflow).toContain('phase=(idle|prepare|download|verify|extract|terminal-runtime|app-install|host-bin|health|invalid)');
-    expect(workflow).toContain('error=(none|apply_failed|apply_interrupted|bundle_extract_failed|bundle_layout_invalid|checksum_mismatch|download_failed|download_metadata_changed|insufficient_disk_space|post_install_health_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_rollback_failed|post_install_service_start_failed|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|update_target_mismatch|invalid)');
+    expect(workflow).toContain('error=(none|apply_failed|apply_interrupted|bundle_extract_failed|bundle_layout_invalid|checksum_mismatch|download_failed|download_metadata_changed|insufficient_disk_space|post_install_health_failed|post_install_host_bin_failed|post_install_release_metadata_failed|post_install_rollback_failed|post_install_runtime_version_mismatch|post_install_service_start_failed|pre_install_service_stop_failed|release_metadata_invalid|terminal_runtime_helper_install_failed|terminal_runtime_install_failed|update_target_mismatch|invalid)');
     expect(workflow).toContain('recovery_diagnostic="$(diagnose_recovery_state 2>/dev/null || printf \'phase=invalid error=invalid\\n\')"');
     expect(workflow).toContain('initial_recovery_diagnostic="$(diagnose_recovery_state 2>/dev/null || printf \'phase=invalid error=invalid\\n\')"');
     expect(workflow).toContain('/usr/bin/python3 - "$error_path"');
@@ -1371,9 +1386,11 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(syncAgent).toContain('write_update_error "bundle_extract_failed"');
     expect(syncAgent).toContain('write_update_error "bundle_layout_invalid"');
     expect(syncAgent).toContain('write_update_error "terminal_runtime_install_failed"');
+    expect(syncAgent).toContain('write_update_error "pre_install_service_stop_failed"');
     expect(syncAgent).toContain('write_update_error "post_install_service_start_failed"');
     expect(syncAgent).toContain('write_update_error "post_install_host_bin_failed"');
-    expect(syncAgent).toContain('write_update_error "post_install_health_failed"');
+    expect(syncAgent).toContain('verification_error_code="post_install_health_failed"');
+    expect(syncAgent).toContain('verification_error_code="post_install_runtime_version_mismatch"');
     expect(syncAgent).toContain('write_update_error "post_install_rollback_failed"');
     expect(syncAgent).toContain('write_update_error "apply_failed"');
     expect(syncAgent).toContain('write_update_error "apply_interrupted"');
@@ -1400,10 +1417,80 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
 
     const healthFailure = syncAgent.indexOf('log "ERROR: health check failed — rolling back"');
     const healthRollback = syncAgent.indexOf('if do_rollback false; then', healthFailure);
-    const durableHealthError = syncAgent.indexOf('write_update_error "post_install_health_failed"', healthFailure);
+    const durableHealthError = syncAgent.indexOf(
+      'write_update_error "$verification_error_code" "$verification_error_message"',
+      healthFailure,
+    );
     expect(healthFailure).toBeGreaterThan(-1);
     expect(healthRollback).toBeGreaterThan(healthFailure);
     expect(durableHealthError).toBeGreaterThan(healthRollback);
+  });
+
+  it('sync agent refuses to replace the app until runtime services are confirmed stopped', () => {
+    const source = extractSyncAgentFunction('stop_runtime_services');
+    const setup = `
+log() { :; }
+sudo() { "$@"; }
+systemctl() {
+  if [ "$1" = stop ]; then return "${'$'}{STOP_STATUS:-0}"; fi
+  if [ "$1" = show ]; then printf '%s\\n' "${'$'}{SERVICE_STATE:-inactive}"; return 0; fi
+  return 1
+}`;
+
+    const stopped = runSyncAgentFunction(source, 'stop_runtime_services', setup);
+    expect(stopped.status, stopped.stderr || stopped.stdout).toBe(0);
+
+    const stopFailed = runSyncAgentFunction(
+      source,
+      'STOP_STATUS=1 stop_runtime_services',
+      setup,
+    );
+    expect(stopFailed.status).not.toBe(0);
+
+    const stillActive = runSyncAgentFunction(
+      source,
+      'SERVICE_STATE=active stop_runtime_services',
+      setup,
+    );
+    expect(stillActive.status).not.toBe(0);
+  });
+
+  it('sync agent requires the new gateway process to report the expected running version', () => {
+    const source = extractSyncAgentFunction('running_gateway_version');
+    const setup = `
+readonly HEALTH_URL="http://127.0.0.1:4000/health"
+curl() { printf '%s\\n' "${'$'}{HEALTH_RESPONSE}"; }
+json_field() { python3 -c "import json,sys; print(json.load(sys.stdin).get(sys.argv[1],''))" "$2" <<< "$1"; }`;
+
+    const matching = runSyncAgentFunction(
+      source,
+      'HEALTH_RESPONSE=\'{"status":"ok","runningVersion":"v2026.08.19-1002"}\' running_gateway_version',
+      setup,
+    );
+    expect(matching.status, matching.stderr || matching.stdout).toBe(0);
+    expect(matching.stdout.trim()).toBe('v2026.08.19-1002');
+
+    const legacy = runSyncAgentFunction(
+      source,
+      'HEALTH_RESPONSE=\'{"status":"ok"}\' running_gateway_version',
+      setup,
+    );
+    expect(legacy.status, legacy.stderr || legacy.stdout).toBe(0);
+    expect(legacy.stdout.trim()).toBe('');
+  });
+
+  it('verifies running identity before committing installed release metadata', () => {
+    const root = process.cwd();
+    const syncAgent = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-sync-agent'), 'utf8');
+    const stopCall = syncAgent.indexOf('if ! stop_runtime_services; then');
+    const appBackup = syncAgent.indexOf('sudo rm -rf "$APP_DIR.rollback"');
+    const versionProbe = syncAgent.indexOf('observed_running_version="$(running_gateway_version)"');
+    const metadataCommit = syncAgent.indexOf('if commit_release_metadata; then');
+
+    expect(stopCall).toBeGreaterThan(-1);
+    expect(stopCall).toBeLessThan(appBackup);
+    expect(versionProbe).toBeGreaterThan(appBackup);
+    expect(versionProbe).toBeLessThan(metadataCommit);
   });
 
   it('keeps explicit update triggers durable until the apply phase is recorded', () => {

--- a/tests/shell/system-section-refresh.test.tsx
+++ b/tests/shell/system-section-refresh.test.tsx
@@ -79,6 +79,52 @@ describe("SystemSection release refresh", () => {
     );
   });
 
+  it("distinguishes installed release metadata from the gateway process serving requests", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/system/info")) {
+        return Promise.resolve(jsonResponse({
+          version: "v2026.08.19-1002",
+          runningVersion: "v2026.08.18-997",
+          updateChannel: "dev",
+          release: {
+            version: "v2026.08.19-1002",
+            channel: "dev",
+          },
+        }));
+      }
+      if (url.endsWith("/health")) {
+        return Promise.resolve(jsonResponse({
+          status: "ok",
+          runningVersion: "v2026.08.18-997",
+          cronJobs: 0,
+          channels: {},
+        }));
+      }
+      if (url.endsWith("/api/system/update?channel=dev")) {
+        return Promise.resolve(jsonResponse({
+          channel: "dev",
+          latest: { version: "v2026.08.19-1002" },
+          updateAvailable: false,
+        }));
+      }
+      if (url.endsWith("/api/system/releases?channel=dev")) {
+        return Promise.resolve(jsonResponse({ channel: "dev", releases: [] }));
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SystemSection />);
+
+    expect(await screen.findByText("Installed version")).toBeTruthy();
+    expect(screen.getByText("Running version")).toBeTruthy();
+    expect(screen.getAllByText("v2026.08.19-1002").length).toBeGreaterThan(0);
+    expect(screen.getByText("v2026.08.18-997")).toBeTruthy();
+    expect(screen.getByText(/running services do not match the installed update/i)).toBeTruthy();
+    expect(screen.queryByText("You are running the latest release for this channel.")).toBeNull();
+  });
+
   it("ignores stale release metadata when the selected channel changes", async () => {
     const stableUpdate = deferred<Response>();
     const stableReleases = deferred<Response>();
@@ -178,9 +224,12 @@ describe("SystemSection release refresh", () => {
         if (updateStarted) {
           infoPollsAfterUpdate += 1;
         }
-        if (infoPollsAfterUpdate >= 4) {
+        if (infoPollsAfterUpdate >= 2) {
           return Promise.resolve(jsonResponse({
             version: "v2026.05.28-151",
+            runningVersion: infoPollsAfterUpdate >= 4
+              ? "v2026.05.28-151"
+              : "v2026.05.28-145",
             release: {
               version: "v2026.05.28-151",
               channel: "stable",
@@ -270,7 +319,14 @@ describe("SystemSection release refresh", () => {
     expect(screen.getByText("Installing stable. This can take a few minutes...")).toBeTruthy();
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(13_000);
+      await vi.advanceTimersByTimeAsync(6_000);
+    });
+
+    expect(screen.getByText("Installing... checking status")).toBeTruthy();
+    expect(screen.queryByText("Installed. Reloading...")).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(7_000);
     });
 
     expect(screen.getByText("Installed. Reloading...")).toBeTruthy();
@@ -284,6 +340,7 @@ describe("SystemSection release refresh", () => {
         if (updateStarted) {
           return Promise.resolve(jsonResponse({
             version: "v2026.05.28-152",
+            runningVersion: "v2026.05.28-152",
             release: {
               version: "v2026.05.28-152",
               channel: "stable",
@@ -447,6 +504,7 @@ describe("SystemSection release refresh", () => {
         if (updateStarted) {
           return Promise.resolve(jsonResponse({
             version: "v2026.05.28-151",
+            runningVersion: "v2026.05.28-151",
             release: {
               version: "v2026.05.28-151",
               channel: "stable",
@@ -614,6 +672,7 @@ describe("SystemSection release refresh", () => {
     await act(async () => {
       successfulPoll.resolve(jsonResponse({
         version: "v2026.05.28-151",
+        runningVersion: "v2026.05.28-151",
         release: {
           version: "v2026.05.28-151",
           channel: "stable",


### PR DESCRIPTION
## Summary

- report startup-captured running gateway identity separately from installed release metadata
- diagnose project lifecycle 404s without falsely claiming that the computer lacks an update
- show installed and running versions in both Settings renderers and keep update polling active until they match
- make the VPS updater stop services safely, verify the expected gateway version, and roll back before committing mismatched release metadata
- prefer desktop installed release provenance over the legacy app version field when comparing selectable releases

## Tests

- focused unit/UI/updater suite: 8 files, 149 tests passed
- focused gateway E2E: 2 tests passed
- focused Settings regression suite: 26 tests passed
- focused CI-failure reproduction: systemd contract plus terminal scrolling, 41 tests passed
- `PATH=/tmp/matrix-corepack-bin:$PATH corepack pnpm run test tests/desktop/system-version.test.ts tests/desktop/system-section.test.tsx`
- `corepack pnpm exec vitest run tests/desktop/project-lifecycle-store.test.ts tests/desktop/settings-sections-error.test.tsx tests/shell/system-section-version.test.ts tests/shell/system-section-refresh.test.tsx`
- `corepack pnpm --filter desktop run typecheck`
- `./scripts/review/check-patterns.sh --diff origin/main`: 0 violations, 4 warnings in pre-existing PR-touched gateway paths
- `git diff --check`
- label-triggered GitHub CI on `b096dcff34952549f248aecac384f97d4ad8467e`: passed
- label-triggered Docker Tests on `b096dcff34952549f248aecac384f97d4ad8467e`: passed

## Review/Monitoring

- Greptile latest trusted result: 5/5 on `b096dcff34952549f248aecac384f97d4ad8467e`
- `ready-for-ci` is present and the triggered CI run passed
- unresolved GitHub review threads: none
- Claude review: passed

The first full unit run exposed one outdated systemd contract assertion caused by this PR and one unrelated terminal scrolling flake. Commit 703bb97 updates the contract to require the new fail-closed stop helper; both failed files pass locally, all four CI shards pass, and the terminal flake did not recur.

The earlier workflow had an infrastructure-only cancellation: actions/checkout hung for five minutes in Pattern Scan before the scanner ran. Failed-path attempt 2 passed Pattern Scan in 51 seconds and completed all downstream checks green.

The local fresh-worktree production build still stops earlier in the Langium global-virtual-store graph tracked in MAT-444; GitHub does not reproduce that dependency-resolution failure.

## Invariants

- Source of truth: `/opt/matrix/release.json` remains installed-artifact provenance; the running gateway version is captured once at process startup from the bundle it is executing.
- Lock and transaction scope: no database writes, transactions, or locks are added or changed.
- Acceptable orphan states: staged metadata and downloaded artifacts are cleaned when services cannot stop; a failed candidate may remain only in the bounded staging/rollback flow until normal updater cleanup.
- Auth source of truth: existing gateway authentication is unchanged; public health exposes only a bounded parsed version string.
- Deferred scope: no legacy project DELETE fallback and no mutation of a primary customer computer. The unrelated local fresh-worktree Langium dependency failure is tracked in MAT-444.

Linear: https://linear.app/matrix-os/issue/MAT-443/fix-false-update-required-errors-for-desktop-project-lifecycle-actions
