### PR TITLE
fix(platform): eliminate provisioning worker idle waits

### DIFF
--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -677,6 +677,7 @@ jobs:
             --tag production-candidate \
             --no-traffic \
             --min-instances "$min_instances" \
+            --no-cpu-throttling \
             --update-env-vars "PLATFORM_BACKGROUND_WORKERS_ENABLED=true,GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED},GOLDEN_SNAPSHOTS_ENABLED=false,GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0" \
             --format=json)"
           production_revision="$(printf '%s\n' "$deploy_json" | jq -r '.status.traffic[]? | select(.tag == "production-candidate") | .revisionName // empty' | head -1)"

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -257,6 +257,8 @@ const PROVIDER_DELETION_RETRY_MAX_MS = 60 * 60_000;
 const RESIZE_STATUS_POLL_INTERVAL_MS = 1_000;
 const RESIZE_STATUS_POLL_TIMEOUT_MS = 90_000;
 const PROVISIONING_JOB_LEASE_MS = 5 * 60_000;
+const PROVISIONING_CREATE_ACTION_POLL_ATTEMPTS = 31;
+const PROVISIONING_CREATE_ACTION_POLL_INTERVAL_MS = 1_000;
 const RECOVERY_CREATE_ACTION_POLL_ATTEMPTS = 6;
 const RECOVERY_CREATE_ACTION_POLL_INTERVAL_MS = 1_000;
 
@@ -642,6 +644,24 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       }
       if (attempt + 1 < RECOVERY_CREATE_ACTION_POLL_ATTEMPTS) {
         await sleep(RECOVERY_CREATE_ACTION_POLL_INTERVAL_MS);
+      }
+    }
+    return 'pending';
+  }
+
+  async function waitForProvisioningCreateAction(actionId: number): Promise<'success' | 'error' | 'pending'> {
+    for (let attempt = 0; attempt < PROVISIONING_CREATE_ACTION_POLL_ATTEMPTS; attempt += 1) {
+      let action;
+      try {
+        action = await deps.hetzner.getAction(actionId);
+      } catch (err: unknown) {
+        logCustomerVpsError(`provision create action refresh failed actionId=${actionId}`, err);
+        return 'pending';
+      }
+      if (action?.status === 'success') return 'success';
+      if (action?.status === 'error') return 'error';
+      if (attempt + 1 < PROVISIONING_CREATE_ACTION_POLL_ATTEMPTS) {
+        await sleep(PROVISIONING_CREATE_ACTION_POLL_INTERVAL_MS);
       }
     }
     return 'pending';
@@ -1441,15 +1461,9 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
             }).where('job_id', '=', job.jobId).where('status', '=', 'running').executeTakeFirstOrThrow();
           });
         }
-        let action;
-        try {
-          action = await deps.hetzner.getAction(createActionId);
-        } catch (actionErr: unknown) {
-          logCustomerVpsError('provision create action refresh failed', actionErr);
-          return 'pending';
-        }
-        if (!action || action.status === 'running') return 'pending';
-        if (action.status === 'error') {
+        const createResult = await waitForProvisioningCreateAction(createActionId);
+        if (createResult === 'pending') return 'pending';
+        if (createResult === 'error') {
           if (imageDecision.imageSource !== 'snapshot') {
             throw new Error('Provider create action failed');
           }

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -384,6 +384,17 @@ describe('CI workflows', () => {
     expect(workflow).toContain('--min-instances "$min_instances"');
   });
 
+  it('allocates CPU outside requests for production background workers', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
+    const productionRoleDeploy = workflow.match(
+      /- name: Deploy production-role revision[\s\S]*?- name: Promote revision/,
+    )?.[0] ?? '';
+
+    expect(productionRoleDeploy).toContain('PLATFORM_BACKGROUND_WORKERS_ENABLED=true');
+    expect(productionRoleDeploy).toContain('--no-cpu-throttling');
+  });
+
   it('smokes the pre-VPS auth and onboarding shell surface before promotion', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');

--- a/tests/platform/customer-vps-provisioning-durability.test.ts
+++ b/tests/platform/customer-vps-provisioning-durability.test.ts
@@ -30,6 +30,7 @@ describe('platform/customer-vps provisioning durability', () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     await destroyTestPlatformDb(db);
   });
 
@@ -172,6 +173,48 @@ describe('platform/customer-vps provisioning durability', () => {
       failed: 0,
     });
     expect(hetzner.createServer).toHaveBeenCalledOnce();
+    await expect(listProvisioningJobs(db, 10)).resolves.toEqual([
+      expect.objectContaining({ status: 'completed', attempts: 1, encryptedPayload: null }),
+    ]);
+  });
+
+  it('keeps polling a running provider create action instead of holding the lease idle', async () => {
+    vi.useFakeTimers();
+    let currentTime = new Date('2026-07-12T01:00:00.000Z');
+    const enqueueProvisioningJob = vi.fn(async (transaction: PlatformDB, job: NewProvisioningJob) => {
+      await insertProvisioningJob(transaction, {
+        ...job,
+        availableAt: '2026-07-12T01:01:00.000Z',
+      });
+    });
+    let actionReads = 0;
+    const getAction = vi.fn(async () => ({
+      id: 1777,
+      status: ++actionReads <= 8 ? 'running' as const : 'success' as const,
+      command: 'create_server',
+    }));
+    const { app, service } = createHarness({
+      enqueueProvisioningJob,
+      hetzner: {
+        createServer: vi.fn().mockResolvedValue({
+          id: 654321,
+          status: 'initializing',
+          publicIPv4: '203.0.113.20',
+          publicIPv6: '2001:db8::20',
+          createActionId: 1777,
+        }),
+        getAction,
+      },
+      now: () => currentTime,
+    });
+
+    expect((await previewProvision(app)).status).toBe(202);
+    currentTime = new Date('2026-07-12T01:02:00.000Z');
+    const dispatching = service.dispatchProvisioningJobs();
+    await vi.advanceTimersByTimeAsync(8_000);
+
+    await expect(dispatching).resolves.toEqual({ checked: 1, completed: 1, failed: 0 });
+    expect(getAction).toHaveBeenCalledTimes(9);
     await expect(listProvisioningJobs(db, 10)).resolves.toEqual([
       expect.objectContaining({ status: 'completed', attempts: 1, encryptedPayload: null }),
     ]);

--- a/tests/platform/golden-snapshot-provisioning.test.ts
+++ b/tests/platform/golden-snapshot-provisioning.test.ts
@@ -70,7 +70,10 @@ describe('golden snapshot provisioning activation', () => {
     await db.executor.updateTable('provisioning_jobs').set({ status: 'running' })
       .where('job_id', '=', '50000000-0000-4000-8000-000000000001').execute();
   });
-  afterEach(async () => destroyTestPlatformDb(db));
+  afterEach(async () => {
+    vi.useRealTimers();
+    await destroyTestPlatformDb(db);
+  });
 
   async function readySnapshot(version: 'v1' | 'v2', imageId: number) {
     const suffix = version === 'v1' ? '1' : '2';
@@ -712,6 +715,7 @@ describe('golden snapshot provisioning activation', () => {
   });
 
   it('holds the leased exact image through create completion and releases it only after registration', async () => {
+    vi.useFakeTimers();
     await readySnapshot('v2', 302);
     let currentNow = new Date('2026-07-03T00:10:00.000Z');
     let created = false;
@@ -739,11 +743,14 @@ describe('golden snapshot provisioning activation', () => {
       now: () => currentNow,
     });
 
-    await service.provision({ clerkUserId: 'user_2', handle: 'bob', runtimeSlot: 'primary' });
+    const provisioning = service.provision({ clerkUserId: 'user_2', handle: 'bob', runtimeSlot: 'primary' });
+    await vi.advanceTimersByTimeAsync(1_000);
+    await provisioning;
 
     expect(hetzner.createServer).toHaveBeenCalledWith(expect.objectContaining({ image: 302 }));
     expect(await getProvisioningJob(db, '50000000-0000-4000-8000-000000000002')).toMatchObject({
-      status: 'running', imageSource: 'snapshot', providerCreateActionId: 777,
+      status: 'completed', imageSource: 'snapshot', providerCreateActionId: 777,
+      activationStep: 'created',
     });
     expect((await db.executor.selectFrom('golden_snapshot_leases').selectAll()
       .where('machine_id', '=', '30000000-0000-4000-8000-000000000002').executeTakeFirstOrThrow()).released_at).toBeNull();
@@ -971,6 +978,7 @@ describe('golden snapshot provisioning activation', () => {
   });
 
   it('records clean fallback creation while the provider action is still running', async () => {
+    vi.useFakeTimers();
     await readySnapshot('v2', 302);
     const machineId = '30000000-0000-4000-8000-000000000023';
     const jobId = '50000000-0000-4000-8000-000000000023';
@@ -1000,7 +1008,11 @@ describe('golden snapshot provisioning activation', () => {
       now: () => new Date('2026-07-03T00:20:00.000Z'),
     });
 
-    await service.provision({ clerkUserId: 'user_23', handle: 'fallback-running', runtimeSlot: 'primary' });
+    const provisioning = service.provision({
+      clerkUserId: 'user_23', handle: 'fallback-running', runtimeSlot: 'primary',
+    });
+    await vi.advanceTimersByTimeAsync(30_000);
+    await provisioning;
 
     await expect(getProvisioningJob(db, jobId)).resolves.toMatchObject({
       status: 'running', imageSource: 'clean_image', activationStep: 'creating',


### PR DESCRIPTION
## Summary

- allocate CPU outside HTTP request handling for the production-role Cloud Run revision so reconciliation keeps running between requests
- poll a claimed Hetzner create action for up to 30 seconds instead of leaving the provisioning job idle on its five-minute crash-recovery lease
- preserve durable action IDs, snapshot leases, exact-label adoption, and the existing no-traffic deployment promotion sequence

Production evidence showed both failure modes on the same exact release. Request-throttled Cloud Run stopped recurring snapshot work between requests. After restoring instance CPU, an exact snapshot clone completed at Hetzner in 8 seconds, but its provisioning job was not reclaimed until the five-minute lease expired. The new bounded poll completes that normal path on the original fenced claim.

## Tests

- `pnpm exec vitest run tests/platform/ci-workflows.test.ts` (31 passed)
- `pnpm exec vitest run tests/platform/golden-snapshot-worker-wiring.test.ts` (9 passed)
- `pnpm exec vitest run tests/platform/host-bundle-snapshot-workflow.test.ts` (24 passed)
- `pnpm exec vitest run tests/platform/customer-vps-provisioning-durability.test.ts tests/platform/customer-vps.test.ts` (89 passed)
- `pnpm exec vitest run tests/platform/golden-snapshot-provisioning.test.ts tests/platform/golden-snapshot-recovery.test.ts` (45 passed)
- `pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json`
- `bun run check:patterns` (0 violations; existing scanner warnings only)

Repository-wide `bun run typecheck` reaches unchanged gateway code and currently fails on pre-existing `@matrix-os/contracts` export mismatches; the changed platform package passes its scoped TypeScript check.

## Review/Monitoring

- monitor Greptile on the latest head until trusted `5/5`
- add `ready-for-ci` only after the trusted `5/5` result
- monitor label-triggered CI to completion

## Invariants

- **Source of truth:** `.github/workflows/platform-cloud-run.yml` owns production Cloud Run revision flags; `provisioning_jobs.provider_create_action_id` remains the durable provider-operation source of truth.
- **Lock/transaction scope:** the existing five-minute provisioning lease remains the crash-recovery fence. The worker performs bounded read-only provider polling while holding that lease; no concurrent claim or database transaction is held across network calls.
- **Acceptable orphan states:** ambiguous or unavailable provider responses still leave the durable job pending for exact-label reconciliation; no second server is created while the original lease is live.
- **Auth source of truth:** unchanged; GitHub environment OIDC, Secret Manager bindings, and the existing platform/provider clients remain authoritative.
- **Deferred scope:** pre-baking immutable host prerequisites and skipping redundant clean-image bootstrap on snapshot clones will ship in a follow-up PR; this PR fixes worker execution and the five-minute control-plane idle wait.
