### PR TITLE
test(shell): stabilize terminal resize observer timing

### DIFF
--- a/tests/shell/terminal-pane-scrolling.test.tsx
+++ b/tests/shell/terminal-pane-scrolling.test.tsx
@@ -511,6 +511,7 @@ describe("TerminalPane scrolling", () => {
     Object.defineProperty(pane, "clientWidth", { configurable: true, value: 1_010 });
     Object.defineProperty(pane, "clientHeight", { configurable: true, value: 660 });
     createdFitAddons[0].proposeDimensions.mockReturnValue({ cols: 999, rows: 999 });
+    await waitFor(() => expect(ResizeObserverMock.instances).not.toHaveLength(0));
     await act(async () => {
       ResizeObserverMock.instances.at(-1)!.trigger();
       await new Promise((resolve) => setTimeout(resolve, 10));


### PR DESCRIPTION
## Summary
- wait for the terminal ResizeObserver mock to be registered before triggering it
- remove the CI timing race that failed main unit-test shard 4
- leave production terminal behavior unchanged

## Tests
- focused failing CI case used as RED evidence
- focused test repeated 10 times: 10/10 passed
- terminal-pane-scrolling test file: 28/28 passed
- bun run typecheck
- bun run check:patterns: 0 violations, 5 existing warnings

## Review / Monitoring
- require current-head Greptile 5/5 before ready-for-ci
- add ready-for-ci only after review completion and monitor triggered CI

## Invariants
- Source of truth: the component-created ResizeObserver remains the readiness signal exercised by this test
- Lock/transaction scope: not applicable; test-only change
- Acceptable orphan states: not applicable
- Auth source of truth: unchanged
- Deferred scope: none