### PR TITLE
fix(platform): recertify golden snapshot prerequisites

### DIFF
--- a/distro/customer-vps/golden-snapshot-builder-cloud-init.yaml
+++ b/distro/customer-vps/golden-snapshot-builder-cloud-init.yaml
@@ -160,6 +160,11 @@ runcmd:
     systemctl disable docker.service containerd.service || true
     failureStage='sanitization'
     MATRIX_GOLDEN_SNAPSHOT_ROOT=/ /opt/matrix/bin/matrix-golden-snapshot-sanitize
+    # Re-certify the marker at the final disk boundary. Validation treats this
+    # as authoritative proof that the prerequisite binaries survived cleanup.
+    failureStage='host_prerequisites'
+    timeout --kill-after=10 60 /opt/matrix/bin/matrix-prepare-host-prerequisites --certify-only
+    sync
     failureStage='callback_delivery'
     printf 'header = "authorization: Bearer %s"\n' "$callbackToken" |
       curl --config - --fail --silent --show-error --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 60 --connect-timeout 10 --max-time 10 -H 'content-type: application/json' --data-binary @/run/golden-snapshot-callback.json '{{callbackUrl}}'

--- a/distro/customer-vps/host-bin/matrix-golden-snapshot-activate
+++ b/distro/customer-vps/host-bin/matrix-golden-snapshot-activate
@@ -112,13 +112,14 @@ EOF
     fi
     rmdir -- /root/.ssh
   fi
-  set_activation_stage activation_preflight_runtime_state
+  set_activation_stage activation_preflight_host_prerequisites
   if [ ! -f /opt/matrix/HOST_PREREQUISITES_READY ] \
     || [ -L /opt/matrix/HOST_PREREQUISITES_READY ] \
     || [ "$(tr -d '\r\n' </opt/matrix/HOST_PREREQUISITES_READY)" != 'version=1' ]; then
     echo "matrix host prerequisites are not ready" >&2
     exit 67
   fi
+  set_activation_stage activation_preflight_user_state
   matrix_uid="$(id -u matrix)"
   matrix_linger="$(loginctl show-user matrix --property=Linger --value 2>/dev/null || true)"
   if [ -e /var/lib/systemd/linger/matrix ] || [ -L /var/lib/systemd/linger/matrix ] \
@@ -127,6 +128,7 @@ EOF
     echo "golden snapshot inherited matrix linger state found" >&2
     exit 67
   fi
+  set_activation_stage activation_preflight_runtime_state
   for forbidden in \
     /etc/matrix \
     /opt/matrix/env \

--- a/distro/customer-vps/host-bin/matrix-prepare-host-prerequisites
+++ b/distro/customer-vps/host-bin/matrix-prepare-host-prerequisites
@@ -2,7 +2,29 @@
 set -euo pipefail
 
 HOST_PREREQUISITES_VERSION=1
-marker=/opt/matrix/HOST_PREREQUISITES_READY
+root="${MATRIX_HOST_PREREQUISITES_ROOT:-/}"
+case "$root" in
+  /*) ;;
+  *) echo "matrix host prerequisites root must be absolute" >&2; exit 64 ;;
+esac
+root="${root%/}"
+[ -n "$root" ] || root="/"
+if [ -L "$root" ]; then
+  echo "matrix host prerequisites root must not be a symlink" >&2
+  exit 64
+fi
+
+if [ "$root" = / ]; then
+  matrix_dir=/opt/matrix
+else
+  matrix_dir="$root/opt/matrix"
+fi
+marker="$matrix_dir/HOST_PREREQUISITES_READY"
+mode="${1:-install}"
+case "$mode" in
+  install|--certify-only) ;;
+  *) echo "usage: matrix-prepare-host-prerequisites [--certify-only]" >&2; exit 64 ;;
+esac
 required_commands=(
   add-apt-repository
   apparmor_parser
@@ -24,15 +46,48 @@ required_commands=(
   zsh
 )
 
-prerequisites_ready() {
-  [ -f "$marker" ] && [ ! -L "$marker" ] \
-    && [ "$(tr -d '\r\n' <"$marker")" = "version=$HOST_PREREQUISITES_VERSION" ] \
-    || return 1
+prerequisites_present() {
   local command
   for command in "${required_commands[@]}"; do
     command -v "$command" >/dev/null 2>&1 || return 1
   done
 }
+
+write_readiness_marker() {
+  install -d -m 0770 "$matrix_dir"
+  if [ "$root" = / ]; then
+    chown root:root "$matrix_dir"
+  fi
+  local marker_tmp
+  marker_tmp="$(mktemp "$matrix_dir/.host-prerequisites.XXXXXX")"
+  trap 'rm -f -- "$marker_tmp"' EXIT HUP INT TERM
+  printf 'version=%s\n' "$HOST_PREREQUISITES_VERSION" >"$marker_tmp"
+  chmod 0644 "$marker_tmp"
+  mv -f -- "$marker_tmp" "$marker"
+  trap - EXIT HUP INT TERM
+}
+
+certify_prerequisites() {
+  local command
+  for command in "${required_commands[@]}"; do
+    command -v "$command" >/dev/null 2>&1 || {
+      echo "matrix host prerequisite missing: $command" >&2
+      return 1
+    }
+  done
+  write_readiness_marker
+}
+
+prerequisites_ready() {
+  [ -f "$marker" ] && [ ! -L "$marker" ] \
+    && [ "$(tr -d '\r\n' <"$marker")" = "version=$HOST_PREREQUISITES_VERSION" ] \
+    && prerequisites_present
+}
+
+if [ "$mode" = --certify-only ]; then
+  certify_prerequisites
+  exit 0
+fi
 
 if prerequisites_ready; then
   exit 0
@@ -94,17 +149,4 @@ if ! command -v aws >/dev/null 2>&1; then
   trap - EXIT HUP INT TERM
 fi
 
-for command in "${required_commands[@]}"; do
-  command -v "$command" >/dev/null 2>&1 || {
-    echo "matrix host prerequisite missing: $command" >&2
-    exit 1
-  }
-done
-
-install -d -o root -g root -m 0770 /opt/matrix
-marker_tmp="$(mktemp /opt/matrix/.host-prerequisites.XXXXXX)"
-trap 'rm -f -- "$marker_tmp"' EXIT HUP INT TERM
-printf 'version=%s\n' "$HOST_PREREQUISITES_VERSION" >"$marker_tmp"
-chmod 0644 "$marker_tmp"
-mv -f -- "$marker_tmp" "$marker"
-trap - EXIT HUP INT TERM
+certify_prerequisites

--- a/packages/platform/src/golden-snapshot-service.ts
+++ b/packages/platform/src/golden-snapshot-service.ts
@@ -36,6 +36,8 @@ const GoldenSnapshotFailureStageSchema = z.enum([
   'activation',
   'activation_preflight_evidence',
   'activation_preflight_forbidden_state',
+  'activation_preflight_host_prerequisites',
+  'activation_preflight_user_state',
   'activation_preflight_runtime_state',
   'activation_preflight_owner_state',
   'activation_preflight_root_ssh_state',
@@ -286,7 +288,7 @@ runcmd:
         && [ ! -L /run/matrix-golden-activation-stage ]; then
         activationStage="$(cat /run/matrix-golden-activation-stage)"
         case "$activationStage" in
-          activation_preflight_evidence|activation_preflight_forbidden_state|activation_preflight_runtime_state|activation_preflight_owner_state|activation_preflight_root_ssh_state|activation_preflight_root_local_state|activation_preflight_log_state|activation_preflight_cloud_init|activation_preflight_container_state|activation_runtime_setup|activation_terminal_runtime|activation_docker_start|activation_postgres_pull|activation_postgres_start|activation_postgres_ready|activation_services_start|activation_services_ready|activation_gateway_ready|activation_shell_ready|activation_sync_agent_ready|activation_gateway_health) reportedStage="$activationStage" ;;
+          activation_preflight_evidence|activation_preflight_forbidden_state|activation_preflight_host_prerequisites|activation_preflight_user_state|activation_preflight_runtime_state|activation_preflight_owner_state|activation_preflight_root_ssh_state|activation_preflight_root_local_state|activation_preflight_log_state|activation_preflight_cloud_init|activation_preflight_container_state|activation_runtime_setup|activation_terminal_runtime|activation_docker_start|activation_postgres_pull|activation_postgres_start|activation_postgres_ready|activation_services_start|activation_services_ready|activation_gateway_ready|activation_shell_ready|activation_sync_agent_ready|activation_gateway_health) reportedStage="$activationStage" ;;
         esac
       fi
       callbackToken="$(cat /run/matrix-golden-snapshot-callback-token 2>/dev/null)"

--- a/tests/platform/golden-snapshot-builder-wiring.test.ts
+++ b/tests/platform/golden-snapshot-builder-wiring.test.ts
@@ -29,4 +29,20 @@ describe('golden snapshot builder orchestration wiring', () => {
     expect(service).toContain('/run/matrix-golden-activation-stage');
     expect(service).toContain("'activation_terminal_runtime'");
   });
+
+  it('reports prerequisite and user-state preflight failures separately', async () => {
+    const [activation, service] = await Promise.all([
+      readFile('distro/customer-vps/host-bin/matrix-golden-snapshot-activate', 'utf8'),
+      readFile('packages/platform/src/golden-snapshot-service.ts', 'utf8'),
+    ]);
+
+    for (const stage of [
+      'activation_preflight_host_prerequisites',
+      'activation_preflight_user_state',
+    ]) {
+      expect(activation).toContain(`set_activation_stage ${stage}`);
+      expect(service).toContain(`'${stage}'`);
+      expect(service).toContain(`|${stage}`);
+    }
+  });
 });

--- a/tests/platform/golden-snapshot-host-scripts.test.ts
+++ b/tests/platform/golden-snapshot-host-scripts.test.ts
@@ -220,7 +220,7 @@ describe('golden snapshot host scripts', () => {
 
   it('rejects a validation clone with baked matrix linger state before activation', async () => {
     const activationSource = await readFile(activatePath, 'utf8');
-    const preflight = activationSource.indexOf('set_activation_stage activation_preflight_runtime_state');
+    const preflight = activationSource.indexOf('set_activation_stage activation_preflight_user_state');
     const lingerMarker = activationSource.indexOf('/var/lib/systemd/linger/matrix', preflight);
     const lingerState = activationSource.indexOf('loginctl show-user matrix --property=Linger --value');
     const userManager = activationSource.indexOf('systemctl is-active --quiet "user@${matrix_uid}.service"');
@@ -311,7 +311,8 @@ describe('golden snapshot host scripts', () => {
     expect(prepare).toBeGreaterThan(-1);
     expect(prepare).toBeLessThan(activation);
     expect(prerequisites).toContain('HOST_PREREQUISITES_VERSION=1');
-    expect(prerequisites).toContain('/opt/matrix/HOST_PREREQUISITES_READY');
+    expect(prerequisites).toContain('matrix_dir=/opt/matrix');
+    expect(prerequisites).toContain('marker="$matrix_dir/HOST_PREREQUISITES_READY"');
     expect(prerequisites).toContain('timeout --kill-after=30 600 env DEBIAN_FRONTEND=noninteractive');
     expect(prerequisites).toContain('timeout --kill-after=30 120 add-apt-repository -y universe');
     expect(prerequisites).toContain('https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip');
@@ -327,6 +328,46 @@ describe('golden snapshot host scripts', () => {
     const buildScript = await readFile('scripts/build-host-bundle.sh', 'utf8');
     expect(buildScript).toContain('matrix-golden-snapshot-fast-path');
     expect(buildScript).toContain('$STAGE_DIR/bin/matrix-prepare-host-prerequisites');
+  });
+
+  it('re-certifies host prerequisites after sanitation before requesting a snapshot', async () => {
+    const source = await readFile('distro/customer-vps/golden-snapshot-builder-cloud-init.yaml', 'utf8');
+    const sanitize = source.indexOf(
+      'MATRIX_GOLDEN_SNAPSHOT_ROOT=/ /opt/matrix/bin/matrix-golden-snapshot-sanitize',
+    );
+    const certify = source.indexOf(
+      '/opt/matrix/bin/matrix-prepare-host-prerequisites --certify-only',
+      sanitize,
+    );
+    const callback = source.indexOf("curl --config - --fail --silent --show-error", certify);
+
+    expect(sanitize).toBeGreaterThan(-1);
+    expect(certify).toBeGreaterThan(sanitize);
+    expect(callback).toBeGreaterThan(certify);
+  });
+
+  it('certifies prerequisite evidence without package or network work', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'matrix-host-prerequisites-'));
+    const fakeBin = join(root, 'bin');
+    await mkdir(fakeBin, { recursive: true });
+    for (const command of [
+      'add-apt-repository', 'apparmor_parser', 'aws', 'bwrap', 'cmatrix', 'curl', 'docker',
+      'elixir', 'erl', 'file', 'git', 'nginx', 'openssl', 'psql', 'socat', 'sudo', 'unzip', 'zsh',
+    ]) {
+      await symlink('/bin/true', join(fakeBin, command));
+    }
+    await chmod(prerequisitesPath, 0o755);
+
+    await execFileAsync(prerequisitesPath, ['--certify-only'], {
+      env: {
+        ...process.env,
+        MATRIX_HOST_PREREQUISITES_ROOT: root,
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+      },
+    });
+
+    expect(await readFile(join(root, 'opt/matrix/HOST_PREREQUISITES_READY'), 'utf8'))
+      .toBe('version=1\n');
   });
 
   it('functionally certifies the baked AWS CLI before snapshot readiness and validation', async () => {

--- a/tests/platform/golden-snapshot-service.test.ts
+++ b/tests/platform/golden-snapshot-service.test.ts
@@ -98,6 +98,8 @@ describe('golden snapshot build service', () => {
     for (const stage of [
       'activation_preflight_evidence',
       'activation_preflight_forbidden_state',
+      'activation_preflight_host_prerequisites',
+      'activation_preflight_user_state',
       'activation_preflight_runtime_state',
       'activation_preflight_owner_state',
       'activation_preflight_root_ssh_state',


### PR DESCRIPTION
## Summary

- re-certify `HOST_PREREQUISITES_READY` after golden-snapshot sanitation and immediately before the callback that authorizes image creation
- keep the final certification network-free and fail closed if any required host binary is missing
- split validation preflight reporting into prerequisite, Matrix user-state, and remaining runtime-state failure codes
- regression boundary: `v2026.08.19-977` passed both validators; the first bundle containing #1266 (`v2026.08.19-981`) failed at the newly introduced prerequisite/runtime preflight

## Tests

- `pnpm exec vitest run tests/platform/golden-snapshot-host-scripts.test.ts tests/platform/golden-snapshot-builder-wiring.test.ts`
- `pnpm exec vitest run tests/platform/golden-snapshot-service.test.ts -t "accepts the bounded validation failure stages" --no-file-parallelism`
- `bash -n distro/customer-vps/host-bin/matrix-prepare-host-prerequisites distro/customer-vps/host-bin/matrix-golden-snapshot-activate`
- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing warnings only)
- `git diff --check`

## Review/Monitoring

- Greptile review pending
- `ready-for-ci` will be added only after trusted Greptile reaches 5/5 on the current head
- live snapshot rebuild and disposable onboarding validation remain post-merge deployment checks

## Invariants

- **Source of truth:** installed prerequisite binaries plus the atomic `HOST_PREREQUISITES_READY` marker; the marker is refreshed only after every required binary is present
- **Lock/transaction scope:** no database writes or lock boundaries changed
- **Acceptable orphan states:** certification failure occurs before the sanitized callback, so the existing builder failure callback and cleanup workflow retain ownership of provider resources
- **Auth source of truth:** golden-snapshot callback bearer tokens and operator authentication are unchanged
- **Deferred scope:** safe dev/test snapshot selection for preview onboarding is separate; this PR fixes image certification and makes any remaining preflight failure exact