### PR TITLE
fix(platform): restore golden builder working directory access

### DIFF
--- a/distro/customer-vps/host-bin/matrix-golden-snapshot-activate
+++ b/distro/customer-vps/host-bin/matrix-golden-snapshot-activate
@@ -234,6 +234,7 @@ set_activation_stage activation_runtime_setup
 # is removed by matrix-golden-snapshot-sanitize before image creation.
 getent group matrix >/dev/null || groupadd --system matrix
 id matrix >/dev/null 2>&1 || useradd --system --gid matrix --home-dir /home/matrix --shell /bin/bash matrix
+install -d -o root -g matrix -m 0770 /opt/matrix
 install -d -o matrix -g matrix -m 0750 /home/matrix
 install -d -o matrix -g matrix -m 0750 /home/matrix/home /home/matrix/projects
 install -d -o matrix -g matrix -m 0750 /opt/matrix/staging

--- a/tests/platform/golden-snapshot-host-scripts.test.ts
+++ b/tests/platform/golden-snapshot-host-scripts.test.ts
@@ -637,6 +637,21 @@ for i in $(seq 1 45); do printf 'line-%s DATABASE_URL=postgresql://matrix:${secr
     expect(source.indexOf(parentHome)).toBeLessThan(source.indexOf(ownerDirectories));
   });
 
+  it('restores matrix traversal access before starting synthetic services', async () => {
+    const source = await readFile(activatePath, 'utf8');
+    const matrixUser = source.indexOf(
+      'id matrix >/dev/null 2>&1 || useradd --system --gid matrix --home-dir /home/matrix --shell /bin/bash matrix',
+    );
+    const accessibleWorkingDirectory = source.indexOf(
+      'install -d -o root -g matrix -m 0770 /opt/matrix',
+    );
+    const serviceStart = source.indexOf('set_activation_stage activation_services_start');
+
+    expect(matrixUser).toBeGreaterThan(-1);
+    expect(accessibleWorkingDirectory).toBeGreaterThan(matrixUser);
+    expect(accessibleWorkingDirectory).toBeLessThan(serviceStart);
+  });
+
   it('installs activated user-systemd terminal prerequisites before starting the gateway', async () => {
     const source = await readFile(activatePath, 'utf8');
     const runtimeSetup = source.indexOf('set_activation_stage activation_terminal_runtime');


### PR DESCRIPTION
## Summary

- restore root:matrix ownership and group traversal on /opt/matrix during golden synthetic activation
- perform the repair only after the matrix group exists and before any Matrix service starts
- add a regression test that locks the required activation ordering

The retained builder diagnostics showed matrix-gateway repeatedly exiting with systemd status 200/CHDIR because matrix-prepare-host-prerequisites had left /opt/matrix as root:root 0770. This prevented the matrix service user from entering its configured working directory.

## Tests

- bun run test -- tests/platform/golden-snapshot-host-scripts.test.ts (26 passed)
- bash -n distro/customer-vps/host-bin/matrix-golden-snapshot-activate
- bun run typecheck
- bun run check:patterns (0 violations; existing warnings only)
- git diff --check

## Review/Monitoring

- wait for trusted Greptile 5/5 on the exact PR head
- add ready-for-ci only after Greptile reaches 5/5
- rerun one disposable golden builder after merge, main deployment, and host-bundle publication

## Invariants

- Source of truth: matrix-golden-snapshot-activate owns permissions needed by its credential-free synthetic runtime.
- Lock/transaction scope: none; this changes local filesystem mode and ownership before service startup.
- Acceptable orphan states: activation remains fail-closed; a failed synthetic service start prevents snapshot creation and is cleaned up by the bounded builder workflow.
- Auth source of truth: unchanged; no credentials, registration, or customer identity are introduced.
- Deferred scope: production timing and exact snapshot provenance are validated on one disposable builder after this fix is merged and deployed.