### PR TITLE
feat(platform): add exact snapshot onboarding test path

### DIFF
--- a/docs/dev/golden-vps-snapshots.md
+++ b/docs/dev/golden-vps-snapshots.md
@@ -79,6 +79,8 @@ The snapshot lease remains active while the provider clone is in flight. Owner i
 
 A definite provider rejection that proves the snapshot cannot be cloned may fall back to clean Ubuntu. Timeouts, connection loss, and other ambiguous results must reconcile the labeled provider resource; they must not create a second server. The existing clean-image path remains authoritative when the feature is disabled or no safe snapshot is available.
 
+Before customer rollout is enabled, an operator can exercise the real preview provisioning and registration path against one exact disposable test-mode snapshot by sending `testSnapshotId` to `POST /vps/preview/provision`. That field changes the route credential from `PLATFORM_SECRET` to `GOLDEN_SNAPSHOT_OPERATOR_SECRET`; release automation cannot invoke it. The transaction accepts only a `ready`, fresh, provider-available, exact-bundle test image compatible with the preview server, and atomically binds its lease to a preview-class machine and durable provisioning job. This override does not change the compatibility rollout row and cannot select a snapshot for an ordinary customer job. Unlike customer rollout, an exact preview test fails closed instead of silently falling back to clean Ubuntu, so its resulting provenance and timing cannot be misclassified.
+
 Recovery uses the same image decision and lease rules, but a golden snapshot is never treated as owner backup data. Existing backup ownership checks remain unchanged. After replacement creation succeeds, platform atomically replaces the machine/provider identity, marks the replacement `recovering`, and begins exact old-server cleanup. The replacement remains unroutable until registration proves the requested bundle version, SHA-256, and health and moves the machine to `running`; persisted provenance keeps those checks mandatory even if the bounded snapshot lease has expired. The previous server is not retained as a rollback after replacement adoption. A later registration timeout marks and reaps the unroutable replacement; an operator or customer must retry recovery. Disable snapshot selection or revoke the candidate before that retry when the next attempt must use clean Ubuntu.
 
 ## Configuration
@@ -129,6 +131,7 @@ codes only; raw provider responses are logged server-side and never returned.
 
 | Route | Authorization | Body limit | Purpose |
 |---|---|---:|---|
+| `POST /vps/preview/provision` with `testSnapshotId` | snapshot-operator bearer | 4 KiB | Provision one exact disposable preview through the real registration path while customer selection remains disabled |
 | `POST /system-bundles/snapshot-builds` with production `testMode: false` | platform/release bearer | 8 KiB | Idempotently enqueue an eligible immutable published bundle |
 | `POST /system-bundles/snapshot-builds` with operator-only `testMode: true` | snapshot-operator bearer | 8 KiB | Enqueue a bounded disposable spike candidate without granting test-mode authority to release automation |
 | `GET /system-bundles/snapshot-builds/:buildId` | snapshot-operator bearer | none | Read coarse build phase/status |
@@ -168,7 +171,7 @@ Production selection must remain disabled until all gates pass:
 2. A separately authorized disposable Hetzner project runs the spike in the spec quickstart.
 3. The spike records creation Action behavior, image readiness timing, clone compatibility across intended architecture/location/server types, cloud-init rerun behavior, and deletion convergence.
 4. A validation clone proves the full sanitation and exact activation contract.
-5. Builds run safely with selection still off; retention and cleanup remain bounded below quota.
+5. Builds run safely with selection still off; one exact test-mode snapshot completes operator-only preview provisioning, real registration, service health, timing capture, and cleanup; retention remains bounded below quota.
 6. Selection starts at a small deterministic percentage for both new-customer provisioning and recovery; clean-image fallback metrics remain healthy for both flows.
 7. Expand the shared rollout percentage only after provisioning and recovery are both proven at the smaller cohort. V1 has no independent recovery selection switch.
 

--- a/docs/dev/preview-environments.md
+++ b/docs/dev/preview-environments.md
@@ -83,6 +83,12 @@ Rerunning the workflow resumes that exact machine; an absent or failed preview i
 retried through the same idempotent route. The platform persists the machine and a
 durable provisioning job atomically before provider dispatch.
 
+Golden-snapshot rollout validation may additionally supply one exact
+`testSnapshotId`. That optional field is accepted only with the separate snapshot
+operator bearer, only for a ready test-mode image, and fails closed rather than
+falling back to a clean image. Normal preview automation continues to use the
+platform bearer and cannot opt into this path.
+
 To walk the full onboarding/billing flow against branch platform code — a
 four-slice split (staging slot for the shell, an IAM-proxied `preview-platform`
 revision for the journey/reliability API, a local `dev:platform` + Stripe CLI

--- a/packages/platform/src/customer-vps-routes.ts
+++ b/packages/platform/src/customer-vps-routes.ts
@@ -43,6 +43,7 @@ export function meetsMessagingResourceFloor(
 export interface CustomerVpsRoutesDeps {
   service: CustomerVpsService;
   platformSecret: string;
+  goldenSnapshotOperatorSecret?: string;
   assertPrimaryStorageReady?: (options?: { force?: boolean }) => Promise<void>;
   probeMachineHealth?: (machine: { machineId: string; handle: string; publicIPv4: string | null }) => Promise<boolean>;
   probeMachineRuntime?: (machine: { machineId: string; handle: string; publicIPv4: string | null }) => Promise<{
@@ -129,6 +130,16 @@ export function createCustomerVpsRoutes(deps: CustomerVpsRoutesDeps): Hono {
     return null;
   }
 
+  function previewAuthKind(c: import('hono').Context): 'platform' | 'snapshot_operator' | null {
+    const authorization = c.req.header('authorization');
+    if (bearerTokenMatches(authorization, deps.platformSecret)) return 'platform';
+    if (deps.goldenSnapshotOperatorSecret
+      && bearerTokenMatches(authorization, deps.goldenSnapshotOperatorSecret)) {
+      return 'snapshot_operator';
+    }
+    return null;
+  }
+
   app.post('/storage-check', bodyLimit({ maxSize: VPS_BODY_LIMIT }), async (c) => {
     const authError = requirePlatformAuth(c);
     if (authError) return authError;
@@ -188,8 +199,8 @@ export function createCustomerVpsRoutes(deps: CustomerVpsRoutesDeps): Hono {
   });
 
   app.post('/preview/provision', bodyLimit({ maxSize: VPS_BODY_LIMIT }), async (c) => {
-    const authError = requirePlatformAuth(c);
-    if (authError) return authError;
+    const authKind = previewAuthKind(c);
+    if (!authKind) return c.json({ error: 'Unauthorized' }, 401);
     let parsed: ReturnType<typeof PreviewProvisionRequestSchema.safeParse>;
     try {
       parsed = PreviewProvisionRequestSchema.safeParse(await readJson(c));
@@ -199,6 +210,8 @@ export function createCustomerVpsRoutes(deps: CustomerVpsRoutesDeps): Hono {
     if (!parsed.success) {
       return c.json({ error: 'Invalid request' }, 400);
     }
+    const requiredAuthKind = parsed.data.testSnapshotId ? 'snapshot_operator' : 'platform';
+    if (authKind !== requiredAuthKind) return c.json({ error: 'Unauthorized' }, 401);
     const { clerkUserId, handle, runtimeSlot, developerTools } = parsed.data;
     emitTelemetry(MATRIX_TELEMETRY_EVENTS.VPS_PROVISION_REQUESTED, {
       distinctId: clerkUserId,

--- a/packages/platform/src/customer-vps-schema.ts
+++ b/packages/platform/src/customer-vps-schema.ts
@@ -46,6 +46,7 @@ export const PreviewProvisionRequestSchema = z.object({
   runtimeSlot: PreviewRuntimeSlotSchema,
   accessClerkUserIds: z.array(ClerkUserIdSchema).max(8).default([]),
   developerTools: DeveloperToolsSchema.optional(),
+  testSnapshotId: z.uuid().optional(),
 }).strict()
   .refine((request) => request.handle === request.runtimeSlot, {
     message: 'Preview handle and runtime slot must match',

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -91,7 +91,6 @@ import {
   chooseProvisioningImage,
   chooseRecoveryImage,
   fallbackProvisioningImage,
-  resolveGoldenSnapshotRollout,
   type ProvisioningImageDecision,
 } from './golden-snapshot-activation.js';
 import {
@@ -102,6 +101,12 @@ import {
   releaseGoldenSnapshotLease,
   releaseGoldenSnapshotLeaseInTransaction,
 } from './golden-snapshot-repository.js';
+import {
+  bindTestSnapshotToPreviewProvisionInTransaction,
+  createPreviewTestSnapshotCreateIntent,
+  isPreviewTestSnapshotDecision,
+  resolvePersistedProvisioningImage,
+} from './golden-snapshot-preview-test.js';
 
 export interface ProvisionResponse {
   machineId: string;
@@ -1195,47 +1200,17 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       let transitionedToFallback = false;
       let effectiveProviderCreateActionId = job.providerCreateActionId;
       if (job.imageSource === 'snapshot' && job.snapshotId && job.snapshotLeaseId) {
-        const rollout = await resolveGoldenSnapshotRollout(
-          deps.db,
-          deps.config.goldenSnapshots,
-          row.machineId,
-          claimedAt.toISOString(),
-        );
-        const persistedSnapshot = await getGoldenSnapshot(deps.db, job.snapshotId);
-        const freshnessCutoff = new Date(
-          claimedAt.getTime() - deps.config.goldenSnapshots.freshnessMaxAgeMs,
-        ).toISOString();
-        if (!rollout.included || !persistedSnapshot?.providerImageId || persistedSnapshot.state !== 'ready'
-          || !persistedSnapshot.readyAt || persistedSnapshot.readyAt <= freshnessCutoff) {
-          await fallbackProvisioningImage(deps.db, {
-            jobId: job.jobId,
-            reason: !rollout.included
-              ? 'snapshot_rollout_disabled'
-              : persistedSnapshot?.state === 'ready' ? 'snapshot_stale' : 'snapshot_unavailable',
-            now: claimedAt.toISOString(),
-          });
-          transitionedToFallback = true;
-          effectiveProviderCreateActionId = null;
-          imageDecision = {
-            imageSource: 'clean_image',
-            targetBundleVersion: imageVersion,
-            targetBundleSha256: job.targetBundleSha256 ?? '0'.repeat(64),
-          };
-        } else {
-          imageDecision = {
-            imageSource: 'snapshot',
-            targetBundleVersion: imageVersion,
-            targetBundleSha256: job.targetBundleSha256 ?? persistedSnapshot.bundleSha256,
-            snapshotId: persistedSnapshot.snapshotId,
-            snapshotLeaseId: job.snapshotLeaseId,
-            providerImageId: persistedSnapshot.providerImageId,
-            sourceBundleVersion: persistedSnapshot.bundleVersion,
-            sourceBaseGeneration: persistedSnapshot.compatibility.baseGeneration,
-            rolloutGeneration: rollout.generation,
-            exact: persistedSnapshot.bundleSha256 === job.targetBundleSha256,
-            requiresExactUpdate: persistedSnapshot.bundleSha256 !== job.targetBundleSha256,
-          };
-        }
+        const resolved = await resolvePersistedProvisioningImage({
+          db: deps.db,
+          config: deps.config.goldenSnapshots,
+          machine: row,
+          job,
+          imageVersion,
+          claimedAt,
+        });
+        imageDecision = resolved.imageDecision;
+        transitionedToFallback = resolved.transitionedToFallback;
+        effectiveProviderCreateActionId = resolved.effectiveProviderCreateActionId;
       } else if (job.imageSource === 'clean_image') {
         imageDecision = {
           imageSource: 'clean_image',
@@ -1336,12 +1311,19 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
               || selectableSnapshot.providerImageId !== imageDecision.providerImageId) {
               throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
             }
-            const intent = await createGoldenSnapshotCreateIntent(deps.db, {
-              intentId: randomUUID(), snapshotId: imageDecision.snapshotId,
-              leaseId: imageDecision.snapshotLeaseId, machineId: row.machineId,
-              purpose: 'provision', rolloutGeneration: imageDecision.rolloutGeneration,
-              now: now().toISOString(),
-            });
+            const intent = isPreviewTestSnapshotDecision(imageDecision)
+              ? await createPreviewTestSnapshotCreateIntent(deps.db, {
+                  intentId: randomUUID(), snapshotId: imageDecision.snapshotId,
+                  leaseId: imageDecision.snapshotLeaseId, machineId: row.machineId,
+                  providerImageId: imageDecision.providerImageId,
+                  now: now().toISOString(),
+                })
+              : await createGoldenSnapshotCreateIntent(deps.db, {
+                  intentId: randomUUID(), snapshotId: imageDecision.snapshotId,
+                  leaseId: imageDecision.snapshotLeaseId, machineId: row.machineId,
+                  purpose: 'provision', rolloutGeneration: imageDecision.rolloutGeneration,
+                  now: now().toISOString(),
+                });
             if (!intent || intent.state === 'denied') {
               throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
             }
@@ -1371,6 +1353,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           if (!(createErr instanceof CustomerVpsError)
             || createErr.code !== 'snapshot_clone_rejected'
             || imageDecision.imageSource !== 'snapshot') throw createErr;
+          if (isPreviewTestSnapshotDecision(imageDecision)) throw createErr;
           await fallbackProvisioningImage(deps.db, {
             jobId: job.jobId,
             reason: 'clone_rejected',
@@ -1466,6 +1449,20 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         if (createResult === 'error') {
           if (imageDecision.imageSource !== 'snapshot') {
             throw new Error('Provider create action failed');
+          }
+          if (isPreviewTestSnapshotDecision(imageDecision)) {
+            try {
+              await deps.hetzner.deleteServer(server.id);
+              if (await deps.hetzner.getServer(server.id)) return 'pending';
+              serverIdForCompensation = null;
+            } catch (cleanupErr: unknown) {
+              logCustomerVpsError('rejected preview-test snapshot clone cleanup failed', cleanupErr);
+              await queueProviderDeletion({
+                providerServerId: server.id, reason: 'rejected_snapshot_clone',
+                machineId: row.machineId, handle: row.handle, err: cleanupErr,
+              });
+            }
+            throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
           }
           await fallbackProvisioningImage(deps.db, {
             jobId: job.jobId, reason: 'clone_rejected', now: now().toISOString(),
@@ -1605,6 +1602,9 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     provisioningClass: UserMachineProvisioningClass,
     dispatch: NonNullable<ProvisionOptions['dispatch']>,
   ): Promise<ProvisionResponse> {
+    const testSnapshotId = provisioningClass === 'preview' && 'testSnapshotId' in input
+      ? input.testSnapshotId
+      : undefined;
     const request = {
       ...input,
       runtimeSlot: input.runtimeSlot ?? 'primary',
@@ -1618,6 +1618,14 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       machine: UserMachineRecord,
     ): Promise<UserMachineRecord> => {
       if (provisioningClass !== 'preview') return machine;
+      if (testSnapshotId) {
+        const existingJob = await getProvisioningJobByMachineId(db, machine.machineId);
+        const matchesRequestedSnapshot = machine.provisioningClass === 'preview'
+          && (machine.sourceSnapshotId === testSnapshotId || existingJob?.snapshotId === testSnapshotId);
+        if (!matchesRequestedSnapshot) {
+          throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+        }
+      }
       await updateUserMachine(db, machine.machineId, {
         accessClerkUserIds: request.accessClerkUserIds,
       });
@@ -1687,6 +1695,9 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       let attempt = 1;
       if (existing) {
         if (existing.status !== 'failed') {
+          if (testSnapshotId) {
+            await reconcilePreviewAccess(trx, existing);
+          }
           if (provisioningClass === 'preview' && existing.runtimeSlot !== request.runtimeSlot) {
             const failedExact = await getActiveUserMachineByClerkId(
               trx,
@@ -1749,6 +1760,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           throw billingUpgradeRequired();
         }
       }
+      const serverType = transactionBillingContext?.serverType ?? deps.config.serverType;
       await insertUserMachine(trx, {
         machineId,
         clerkUserId: request.clerkUserId,
@@ -1758,7 +1770,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         accessClerkUserIds: request.accessClerkUserIds,
         status: 'provisioning',
         imageVersion: bundleRef.imageVersion,
-        serverType: transactionBillingContext?.serverType ?? deps.config.serverType,
+        serverType,
         location: ('location' in request ? request.location : undefined) ?? deps.config.location,
         developerTools: request.developerTools,
         registrationTokenHash: registration.hash,
@@ -1773,7 +1785,20 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         availableAt: currentTime.toISOString(),
         createdAt: currentTime.toISOString(),
       });
-        return { existing: null };
+      if (testSnapshotId) {
+        const bound = await bindTestSnapshotToPreviewProvisionInTransaction(trx, {
+          snapshotId: testSnapshotId,
+          targetBundleVersion: bundleRef.imageVersion,
+          serverType,
+          machineId,
+          provisioningJobId: jobId,
+          now: currentTime.toISOString(),
+        }, deps.config.goldenSnapshots);
+        if (!bound) {
+          throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+        }
+      }
+      return { existing: null };
       });
     } catch (err: unknown) {
       const errorCode = err instanceof Error

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -1285,7 +1285,30 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       if (existingServers.length > 0 && matchingServers.length === 0) {
         throw new Error('Existing provider server image provenance is ambiguous');
       }
-      const existingServer = matchingServers[0];
+      let existingServer = matchingServers[0];
+      if (!existingServer && isPreviewTestSnapshotDecision(imageDecision)
+        && effectiveProviderCreateActionId !== null) {
+        const persistedServer = row.hetznerServerId === null
+          ? null
+          : await deps.hetzner.getServer(row.hetznerServerId);
+        if (persistedServer) {
+          if (persistedServer.labels?.machine_id !== row.machineId
+            || persistedServer.labels?.snapshot_id !== imageDecision.snapshotId) {
+            throw new Error('Persisted preview-test server provenance is ambiguous');
+          }
+          existingServer = persistedServer;
+        } else {
+          const priorCreateResult = await waitForProvisioningCreateAction(
+            effectiveProviderCreateActionId,
+          );
+          if (priorCreateResult === 'pending') return 'pending';
+          throw new CustomerVpsError(
+            409,
+            'snapshot_clone_rejected',
+            'Provisioning image unavailable',
+          );
+        }
+      }
       const createInput = {
           name: buildServerName(row.handle),
           serverType: row.serverType ?? deps.config.serverType,

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -1476,14 +1476,26 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           if (isPreviewTestSnapshotDecision(imageDecision)) {
             try {
               await deps.hetzner.deleteServer(server.id);
-              if (await deps.hetzner.getServer(server.id)) return 'pending';
+              if (await deps.hetzner.getServer(server.id)) {
+                await enqueueProviderDeletionTx(deps.db, {
+                  providerServerId: server.id,
+                  reason: 'rejected_snapshot_clone',
+                  machineId: row.machineId,
+                  handle: row.handle,
+                  detail: 'rejected preview-test snapshot clone deletion pending',
+                });
+              }
               serverIdForCompensation = null;
             } catch (cleanupErr: unknown) {
               logCustomerVpsError('rejected preview-test snapshot clone cleanup failed', cleanupErr);
-              await queueProviderDeletion({
-                providerServerId: server.id, reason: 'rejected_snapshot_clone',
-                machineId: row.machineId, handle: row.handle, err: cleanupErr,
+              await enqueueProviderDeletionTx(deps.db, {
+                providerServerId: server.id,
+                reason: 'rejected_snapshot_clone',
+                machineId: row.machineId,
+                handle: row.handle,
+                detail: 'rejected preview-test snapshot clone cleanup failed',
               });
+              serverIdForCompensation = null;
             }
             throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
           }

--- a/packages/platform/src/golden-snapshot-activation.ts
+++ b/packages/platform/src/golden-snapshot-activation.ts
@@ -17,6 +17,12 @@ const ServerProfiles: Record<string, { architecture: 'x86' | 'arm'; diskGb: numb
   cax41: { architecture: 'arm', diskGb: 320 },
 };
 
+export function getGoldenSnapshotServerProfile(
+  serverType: string,
+): { architecture: 'x86' | 'arm'; diskGb: number } | undefined {
+  return ServerProfiles[serverType];
+}
+
 const SelectionInputSchema = z.object({
   jobId: z.string().uuid(),
   machineId: z.string().uuid(),
@@ -49,6 +55,7 @@ export type ProvisioningImageDecision =
       sourceBundleVersion: string;
       sourceBaseGeneration: string;
       rolloutGeneration: number;
+      previewTest?: true;
       exact: boolean;
       requiresExactUpdate: boolean;
     };

--- a/packages/platform/src/golden-snapshot-preview-test.ts
+++ b/packages/platform/src/golden-snapshot-preview-test.ts
@@ -1,0 +1,306 @@
+import { randomUUID } from 'node:crypto';
+import { sql } from 'kysely';
+import { z } from 'zod/v4';
+import type { PlatformDB, UserMachineRecord } from './db.js';
+import type { ProvisioningJobRecord } from './customer-vps-provisioning-jobs.js';
+import { CustomerVpsError } from './customer-vps-errors.js';
+import {
+  fallbackProvisioningImage,
+  getGoldenSnapshotServerProfile,
+  resolveGoldenSnapshotRollout,
+  type ProvisioningImageDecision,
+} from './golden-snapshot-activation.js';
+import { getGoldenSnapshot } from './golden-snapshot-repository.js';
+import {
+  compatibilityKey,
+  GoldenSnapshotBundleVersionSchema,
+  GoldenSnapshotRuntimeConfigSchema,
+  type GoldenSnapshotRuntimeConfig,
+} from './golden-snapshot-schema.js';
+
+const UuidSchema = z.uuid();
+const IsoDateSchema = z.string().datetime({ offset: true })
+  .transform((value) => new Date(value).toISOString());
+const CreateIntentStateSchema = z.enum(['pending', 'accepted', 'denied', 'activated', 'cleaned']);
+
+const BindInputSchema = z.object({
+  snapshotId: UuidSchema,
+  targetBundleVersion: GoldenSnapshotBundleVersionSchema,
+  serverType: z.string().min(1).max(64),
+  machineId: UuidSchema,
+  provisioningJobId: UuidSchema,
+  now: IsoDateSchema,
+}).strict();
+
+export function isPreviewTestSnapshotDecision(
+  decision: ProvisioningImageDecision,
+): decision is Extract<ProvisioningImageDecision, { imageSource: 'snapshot' }> & { previewTest: true } {
+  return decision.imageSource === 'snapshot' && decision.previewTest === true;
+}
+
+export async function resolvePersistedProvisioningImage(input: {
+  db: PlatformDB;
+  config: GoldenSnapshotRuntimeConfig;
+  machine: UserMachineRecord;
+  job: ProvisioningJobRecord;
+  imageVersion: string;
+  claimedAt: Date;
+}): Promise<{
+  imageDecision: ProvisioningImageDecision;
+  transitionedToFallback: boolean;
+  effectiveProviderCreateActionId: number | null;
+}> {
+  const config = GoldenSnapshotRuntimeConfigSchema.parse(input.config);
+  const { db, machine, job, imageVersion, claimedAt } = input;
+  if (job.imageSource !== 'snapshot' || !job.snapshotId || !job.snapshotLeaseId) {
+    throw new Error('Persisted snapshot decision is incomplete');
+  }
+  const persistedSnapshot = await getGoldenSnapshot(db, job.snapshotId);
+  const isPreviewTestSnapshot = machine.provisioningClass === 'preview'
+    && persistedSnapshot?.testMode === true;
+  const rollout = isPreviewTestSnapshot
+    ? { included: false, generation: 0 }
+    : await resolveGoldenSnapshotRollout(db, config, machine.machineId, claimedAt.toISOString());
+  const freshnessMaxAgeMs = isPreviewTestSnapshot
+    ? Math.min(config.freshnessMaxAgeMs, config.testModeTtlMs)
+    : config.freshnessMaxAgeMs;
+  const freshnessCutoff = new Date(claimedAt.getTime() - freshnessMaxAgeMs).toISOString();
+  const unavailable = !persistedSnapshot?.providerImageId
+    || persistedSnapshot.providerImageStatus !== 'available'
+    || persistedSnapshot.state !== 'ready'
+    || !persistedSnapshot.readyAt
+    || persistedSnapshot.readyAt <= freshnessCutoff
+    || (isPreviewTestSnapshot && (
+      persistedSnapshot.bundleVersion !== imageVersion
+      || persistedSnapshot.bundleSha256 !== job.targetBundleSha256
+    ));
+  if ((!rollout.included && !isPreviewTestSnapshot) || unavailable) {
+    if (isPreviewTestSnapshot) {
+      throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+    }
+    await fallbackProvisioningImage(db, {
+      jobId: job.jobId,
+      reason: !rollout.included
+        ? 'snapshot_rollout_disabled'
+        : persistedSnapshot?.state === 'ready' ? 'snapshot_stale' : 'snapshot_unavailable',
+      now: claimedAt.toISOString(),
+    });
+    return {
+      imageDecision: {
+        imageSource: 'clean_image',
+        targetBundleVersion: imageVersion,
+        targetBundleSha256: job.targetBundleSha256 ?? '0'.repeat(64),
+      },
+      transitionedToFallback: true,
+      effectiveProviderCreateActionId: null,
+    };
+  }
+  const providerImageId = persistedSnapshot.providerImageId;
+  if (providerImageId === null) {
+    throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+  }
+  return {
+    imageDecision: {
+      imageSource: 'snapshot',
+      targetBundleVersion: imageVersion,
+      targetBundleSha256: job.targetBundleSha256 ?? persistedSnapshot.bundleSha256,
+      snapshotId: persistedSnapshot.snapshotId,
+      snapshotLeaseId: job.snapshotLeaseId,
+      providerImageId,
+      sourceBundleVersion: persistedSnapshot.bundleVersion,
+      sourceBaseGeneration: persistedSnapshot.compatibility.baseGeneration,
+      rolloutGeneration: isPreviewTestSnapshot ? 0 : rollout.generation,
+      ...(isPreviewTestSnapshot ? { previewTest: true as const } : {}),
+      exact: persistedSnapshot.bundleSha256 === job.targetBundleSha256,
+      requiresExactUpdate: persistedSnapshot.bundleSha256 !== job.targetBundleSha256,
+    },
+    transitionedToFallback: false,
+    effectiveProviderCreateActionId: job.providerCreateActionId,
+  };
+}
+
+/**
+ * Bind one operator-requested test image to one preview job. This is called
+ * inside the machine+job creation transaction, and repeats the preview-class
+ * check in SQL so ordinary customer jobs cannot gain this capability.
+ */
+export async function bindTestSnapshotToPreviewProvisionInTransaction(
+  trx: PlatformDB,
+  rawInput: z.input<typeof BindInputSchema>,
+  rawConfig: GoldenSnapshotRuntimeConfig,
+): Promise<boolean> {
+  const input = BindInputSchema.parse(rawInput);
+  const config = GoldenSnapshotRuntimeConfigSchema.parse(rawConfig);
+  const profile = getGoldenSnapshotServerProfile(input.serverType);
+  if (!profile || profile.architecture !== config.compatibility.architecture) return false;
+  const now = input.now;
+  const expiresAt = new Date(Date.parse(now) + config.provisioningLeaseMs).toISOString();
+  const identity = await trx.executor.selectFrom('golden_snapshots')
+    .select(['base_generation', 'compatibility_key'])
+    .where('snapshot_id', '=', input.snapshotId).executeTakeFirst();
+  if (!identity) return false;
+  await sql`SELECT pg_advisory_xact_lock(hashtext(${identity.base_generation}))`.execute(trx.executor);
+  await sql`SELECT pg_advisory_xact_lock(hashtext(${identity.compatibility_key}))`.execute(trx.executor);
+  const previewJob = await trx.executor.selectFrom('provisioning_jobs')
+    .innerJoin('user_machines', 'user_machines.machine_id', 'provisioning_jobs.machine_id')
+    .select('provisioning_jobs.job_id')
+    .where('provisioning_jobs.job_id', '=', input.provisioningJobId)
+    .where('provisioning_jobs.machine_id', '=', input.machineId)
+    .where('provisioning_jobs.status', '=', 'queued')
+    .where('user_machines.provisioning_class', '=', 'preview')
+    .where('user_machines.deleted_at', 'is', null)
+    .executeTakeFirst();
+  if (!previewJob) return false;
+  const snapshot = await trx.executor.selectFrom('golden_snapshots').select([
+    'snapshot_id', 'bundle_version', 'bundle_sha256', 'compatibility_key', 'architecture',
+    'activation_abi', 'minimum_disk_gb', 'image_disk_gb', 'test_mode', 'state',
+    'provider_image_id', 'provider_image_status', 'ready_at', 'base_generation',
+  ]).where('snapshot_id', '=', input.snapshotId).forUpdate().executeTakeFirst();
+  if (!snapshot) return false;
+  const release = await trx.executor.selectFrom('host_bundle_releases').select('sha256')
+    .where('version', '=', input.targetBundleVersion).executeTakeFirst();
+  const revoked = await trx.executor.selectFrom('golden_snapshot_revoked_base_generations')
+    .select('base_generation').where('base_generation', '=', snapshot.base_generation).executeTakeFirst();
+  const freshnessCutoff = new Date(
+    Date.parse(now) - Math.min(config.freshnessMaxAgeMs, config.testModeTtlMs),
+  ).toISOString();
+  const selectable = snapshot.test_mode
+    && snapshot.state === 'ready'
+    && snapshot.provider_image_id !== null
+    && snapshot.provider_image_status === 'available'
+    && snapshot.ready_at !== null
+    && snapshot.ready_at > freshnessCutoff
+    && snapshot.compatibility_key === compatibilityKey(config.compatibility)
+    && snapshot.architecture === config.compatibility.architecture
+    && snapshot.activation_abi === config.compatibility.activationAbi
+    && snapshot.minimum_disk_gb <= profile.diskGb
+    && (snapshot.image_disk_gb === null || snapshot.image_disk_gb <= profile.diskGb)
+    && snapshot.bundle_version === input.targetBundleVersion
+    && release?.sha256.toLowerCase() === snapshot.bundle_sha256
+    && revoked === undefined;
+  if (!selectable) return false;
+  const leaseId = randomUUID();
+  const lease = await trx.executor.insertInto('golden_snapshot_leases').values({
+    lease_id: leaseId,
+    snapshot_id: snapshot.snapshot_id,
+    machine_id: input.machineId,
+    purpose: 'provision',
+    target_bundle_version: input.targetBundleVersion,
+    created_at: now,
+    expires_at: expiresAt,
+    released_at: null,
+  }).onConflict((oc) => oc.column('machine_id').where('released_at', 'is', null).doNothing())
+    .returning('lease_id').executeTakeFirst();
+  if (!lease) return false;
+  const linked = await trx.executor.updateTable('provisioning_jobs').set({
+    target_bundle_version: input.targetBundleVersion,
+    target_bundle_sha256: snapshot.bundle_sha256,
+    image_source: 'snapshot',
+    snapshot_id: snapshot.snapshot_id,
+    snapshot_lease_id: leaseId,
+    activation_step: 'creating',
+    fallback_reason: null,
+    updated_at: now,
+  }).where('job_id', '=', input.provisioningJobId)
+    .where('machine_id', '=', input.machineId)
+    .where('status', '=', 'queued')
+    .returning('job_id').executeTakeFirst();
+  if (!linked) throw new Error('Preview provisioning job lost before test snapshot lease commit');
+  await trx.executor.insertInto('golden_snapshot_audit_events').values({
+    event_id: randomUUID(),
+    snapshot_id: snapshot.snapshot_id,
+    build_id: null,
+    cleanup_id: null,
+    event_type: 'snapshot_test_provision_leased',
+    actor_type: 'operator',
+    actor_id_hash: null,
+    from_state: null,
+    to_state: null,
+    reason: null,
+    created_at: now,
+  }).execute();
+  return true;
+}
+
+const CreateIntentInputSchema = z.object({
+  intentId: UuidSchema,
+  snapshotId: UuidSchema,
+  leaseId: UuidSchema,
+  machineId: UuidSchema,
+  providerImageId: z.number().int().positive(),
+  now: IsoDateSchema,
+}).strict();
+
+export async function createPreviewTestSnapshotCreateIntent(
+  db: PlatformDB,
+  rawInput: z.input<typeof CreateIntentInputSchema>,
+): Promise<{ state: z.infer<typeof CreateIntentStateSchema> } | undefined> {
+  const input = CreateIntentInputSchema.parse(rawInput);
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const identity = await trx.executor.selectFrom('golden_snapshots')
+      .select(['base_generation', 'compatibility_key'])
+      .where('snapshot_id', '=', input.snapshotId).executeTakeFirst();
+    if (!identity) return undefined;
+    await sql`SELECT pg_advisory_xact_lock(hashtext(${identity.base_generation}))`.execute(trx.executor);
+    await sql`SELECT pg_advisory_xact_lock(hashtext(${identity.compatibility_key}))`.execute(trx.executor);
+    const snapshot = await trx.executor.selectFrom('golden_snapshots').select([
+      'snapshot_id', 'bundle_version', 'bundle_sha256', 'test_mode', 'state',
+      'provider_image_id', 'provider_image_status', 'base_generation',
+    ]).where('snapshot_id', '=', input.snapshotId).forUpdate().executeTakeFirst();
+    if (!snapshot || !snapshot.test_mode || snapshot.state !== 'ready'
+      || snapshot.provider_image_id !== input.providerImageId
+      || snapshot.provider_image_status !== 'available') return undefined;
+    const revoked = await trx.executor.selectFrom('golden_snapshot_revoked_base_generations')
+      .select('base_generation').where('base_generation', '=', snapshot.base_generation).executeTakeFirst();
+    if (revoked) return undefined;
+    const previewJob = await trx.executor.selectFrom('provisioning_jobs')
+      .innerJoin('user_machines', 'user_machines.machine_id', 'provisioning_jobs.machine_id')
+      .select(['provisioning_jobs.target_bundle_version', 'provisioning_jobs.target_bundle_sha256'])
+      .where('provisioning_jobs.machine_id', '=', input.machineId)
+      .where('provisioning_jobs.snapshot_id', '=', input.snapshotId)
+      .where('provisioning_jobs.snapshot_lease_id', '=', input.leaseId)
+      .where('provisioning_jobs.image_source', '=', 'snapshot')
+      .where('provisioning_jobs.status', '=', 'running')
+      .where('user_machines.provisioning_class', '=', 'preview')
+      .where('user_machines.deleted_at', 'is', null)
+      .executeTakeFirst();
+    if (!previewJob || previewJob.target_bundle_version !== snapshot.bundle_version
+      || previewJob.target_bundle_sha256 !== snapshot.bundle_sha256) return undefined;
+    const lease = await trx.executor.selectFrom('golden_snapshot_leases').selectAll()
+      .where('lease_id', '=', input.leaseId).forUpdate().executeTakeFirst();
+    if (!lease || lease.released_at !== null || lease.snapshot_id !== input.snapshotId
+      || lease.machine_id !== input.machineId || lease.purpose !== 'provision'
+      || lease.target_bundle_version !== snapshot.bundle_version) return undefined;
+    await trx.executor.insertInto('golden_snapshot_create_intents').values({
+      intent_id: input.intentId,
+      snapshot_id: input.snapshotId,
+      lease_id: input.leaseId,
+      machine_id: input.machineId,
+      purpose: 'provision',
+      rollout_generation: 0,
+      state: 'pending',
+      provider_create_action_id: null,
+      created_at: input.now,
+      updated_at: input.now,
+      completed_at: null,
+    }).onConflict((oc) => oc.column('lease_id').doNothing()).execute();
+    const intent = await trx.executor.selectFrom('golden_snapshot_create_intents')
+      .select(['intent_id', 'snapshot_id', 'machine_id', 'state', 'rollout_generation'])
+      .where('lease_id', '=', input.leaseId).executeTakeFirstOrThrow();
+    if (intent.snapshot_id !== input.snapshotId || intent.machine_id !== input.machineId
+      || Number(intent.rollout_generation) !== 0) {
+      throw new Error('Preview-test snapshot create intent provenance conflict');
+    }
+    const linked = await trx.executor.updateTable('provisioning_jobs').set({
+      snapshot_create_intent_id: intent.intent_id,
+      updated_at: input.now,
+    }).where('snapshot_lease_id', '=', input.leaseId)
+      .where((eb) => eb.or([
+        eb('snapshot_create_intent_id', 'is', null),
+        eb('snapshot_create_intent_id', '=', intent.intent_id),
+      ])).returning('job_id').executeTakeFirst();
+    if (!linked) throw new Error('Preview-test snapshot intent linkage failed');
+    return { state: CreateIntentStateSchema.parse(intent.state) };
+  });
+}

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -744,6 +744,7 @@ export function createApp(deps: {
     app.route('/vps', createCustomerVpsRoutes({
       service: deps.customerVpsService,
       platformSecret,
+      goldenSnapshotOperatorSecret,
       probeMachineHealth,
       probeMachineRuntime,
       recordRuntimeMetrics: platformMetricsRoutes.recordRuntimeMetrics,

--- a/tests/platform/customer-vps-routes.test.ts
+++ b/tests/platform/customer-vps-routes.test.ts
@@ -11,6 +11,7 @@ import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-
 describe('platform/customer-vps-routes', () => {
   let db: PlatformDB;
   const platformSecret = 'platform-secret';
+  const snapshotOperatorSecret = 'snapshot-operator-secret';
 
   beforeEach(async () => {
     ({ db } = await createTestPlatformDb());
@@ -44,7 +45,11 @@ describe('platform/customer-vps-routes', () => {
       now: () => new Date('2026-04-26T12:00:00.000Z'),
     });
     const app = new Hono();
-    app.route('/vps', createCustomerVpsRoutes({ service, platformSecret }));
+    app.route('/vps', createCustomerVpsRoutes({
+      service,
+      platformSecret,
+      goldenSnapshotOperatorSecret: snapshotOperatorSecret,
+    }));
     return app;
   }
 
@@ -104,7 +109,11 @@ describe('platform/customer-vps-routes', () => {
       provisionPreview,
     } as unknown as Parameters<typeof createCustomerVpsRoutes>[0]['service'];
     const app = new Hono();
-    app.route('/vps', createCustomerVpsRoutes({ service, platformSecret }));
+    app.route('/vps', createCustomerVpsRoutes({
+      service,
+      platformSecret,
+      goldenSnapshotOperatorSecret: snapshotOperatorSecret,
+    }));
 
     const unauthorized = await app.request('/vps/preview/provision', {
       method: 'POST',
@@ -127,7 +136,7 @@ describe('platform/customer-vps-routes', () => {
       expect(await invalid.json()).toEqual({ error: 'Invalid request' });
     }
 
-    const accepted = await app.request('/vps/preview/provision', {
+    const releaseCredentialRejected = await app.request('/vps/preview/provision', {
       method: 'POST',
       headers: { authorization: `Bearer ${platformSecret}`, 'content-type': 'application/json' },
       body: JSON.stringify({
@@ -135,6 +144,20 @@ describe('platform/customer-vps-routes', () => {
         handle: 'pr-897',
         runtimeSlot: 'pr-897',
         accessClerkUserIds: ['user_456'],
+        testSnapshotId: '10000000-0000-4000-8000-000000000001',
+      }),
+    });
+    expect(releaseCredentialRejected.status).toBe(401);
+
+    const accepted = await app.request('/vps/preview/provision', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${snapshotOperatorSecret}`, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        clerkUserId: 'user_123',
+        handle: 'pr-897',
+        runtimeSlot: 'pr-897',
+        accessClerkUserIds: ['user_456'],
+        testSnapshotId: '10000000-0000-4000-8000-000000000001',
       }),
     });
 
@@ -145,6 +168,7 @@ describe('platform/customer-vps-routes', () => {
       handle: 'pr-897',
       runtimeSlot: 'pr-897',
       accessClerkUserIds: ['user_456'],
+      testSnapshotId: '10000000-0000-4000-8000-000000000001',
     });
     expect(provision).not.toHaveBeenCalled();
 
@@ -156,6 +180,45 @@ describe('platform/customer-vps-routes', () => {
     });
     expect(failed.status).toBe(500);
     expect(await failed.json()).toEqual({ error: 'Provisioning failed' });
+  });
+
+  it('does not grant exact-snapshot authority to the ordinary customer provision route', async () => {
+    const provision = vi.fn().mockResolvedValue({
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff113',
+      status: 'provisioning',
+      etaSeconds: 90,
+    });
+    const service = { provision } as unknown as Parameters<typeof createCustomerVpsRoutes>[0]['service'];
+    const app = new Hono();
+    app.route('/vps', createCustomerVpsRoutes({
+      service,
+      platformSecret,
+      goldenSnapshotOperatorSecret: snapshotOperatorSecret,
+    }));
+    const body = {
+      clerkUserId: 'user_customer',
+      handle: 'customer-test',
+      testSnapshotId: '10000000-0000-4000-8000-000000000001',
+    };
+
+    const operatorAttempt = await app.request('/vps/provision', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${snapshotOperatorSecret}`, 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(operatorAttempt.status).toBe(401);
+
+    const customerAttempt = await app.request('/vps/provision', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${platformSecret}`, 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(customerAttempt.status).toBe(202);
+    expect(provision).toHaveBeenCalledWith({
+      clerkUserId: 'user_customer',
+      handle: 'customer-test',
+      runtimeSlot: 'primary',
+    });
   });
 
   it('rejects duplicate, owner, and oversized preview collaborator lists', async () => {

--- a/tests/platform/golden-snapshot-provisioning.test.ts
+++ b/tests/platform/golden-snapshot-provisioning.test.ts
@@ -75,12 +75,13 @@ describe('golden snapshot provisioning activation', () => {
     await destroyTestPlatformDb(db);
   });
 
-  async function readySnapshot(version: 'v1' | 'v2', imageId: number) {
+  async function readySnapshot(version: 'v1' | 'v2', imageId: number, testMode = false) {
     const suffix = version === 'v1' ? '1' : '2';
     const enqueued = await enqueueGoldenSnapshotBuild(db, {
       bundleVersion: version, compatibility,
       snapshotId: `10000000-0000-4000-8000-00000000000${suffix}`,
       buildId: `20000000-0000-4000-8000-00000000000${suffix}`,
+      testMode,
       now: `2026-07-0${suffix}T01:00:00.000Z`,
     });
     const claimed = await claimGoldenSnapshotBuild(
@@ -106,6 +107,167 @@ describe('golden snapshot provisioning activation', () => {
     });
     return enqueued.snapshot.snapshotId;
   }
+
+  it('provisions and registers an operator preview from one exact test snapshot while rollout stays disabled', async () => {
+    const snapshotId = await readySnapshot('v2', 302, true);
+    const createServer = vi.fn().mockResolvedValue({
+      id: 903,
+      status: 'running',
+      serverType: 'cpx22',
+      publicIPv4: '203.0.113.93',
+      publicIPv6: '2001:db8::93/64',
+    });
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET: 'platform-secret',
+        CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+        MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+        S3_ACCESS_KEY_ID: 'access-key',
+        S3_SECRET_ACCESS_KEY: 'secret-key',
+        S3_ENDPOINT: 'https://r2.example',
+        HETZNER_SERVER_TYPE: 'cpx22',
+        GOLDEN_SNAPSHOTS_ENABLED: 'false',
+        GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '0',
+      }),
+      hetzner: createMockHetznerClient({ createServer }),
+      systemStore: createMockCustomerVpsSystemStore(),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000009',
+      provisioningJobIdFactory: () => '50000000-0000-4000-8000-000000000009',
+      tokenFactory: () => ({
+        token: 'preview-registration-token',
+        hash: hashRegistrationToken('preview-registration-token'),
+        expiresAt: '2026-07-03T01:00:00.000Z',
+      }),
+      now: () => new Date('2026-07-03T00:01:00.000Z'),
+    });
+
+    await expect(service.provisionPreview({
+      clerkUserId: 'user_preview_test',
+      handle: 'pr-1273',
+      runtimeSlot: 'pr-1273',
+      testSnapshotId: snapshotId,
+    })).resolves.toMatchObject({
+      machineId: '30000000-0000-4000-8000-000000000009',
+      status: 'provisioning',
+    });
+
+    expect(createServer).toHaveBeenCalledWith(expect.objectContaining({
+      image: 302,
+      labels: expect.objectContaining({
+        image_source: 'snapshot',
+        snapshot_id: snapshotId,
+      }),
+    }));
+    await expect(db.executor.selectFrom('golden_snapshot_rollout_controls')
+      .selectAll().execute()).resolves.toEqual([]);
+    await expect(getProvisioningJob(db, '50000000-0000-4000-8000-000000000009'))
+      .resolves.toMatchObject({
+        imageSource: 'snapshot',
+        snapshotId,
+        targetBundleVersion: 'v2',
+        targetBundleSha256: '2'.repeat(64),
+      });
+    await expect(db.executor.selectFrom('golden_snapshot_create_intents')
+      .select(['snapshot_id', 'machine_id', 'rollout_generation', 'state'])
+      .where('machine_id', '=', '30000000-0000-4000-8000-000000000009')
+      .executeTakeFirstOrThrow()).resolves.toEqual({
+      snapshot_id: snapshotId,
+      machine_id: '30000000-0000-4000-8000-000000000009',
+      rollout_generation: 0,
+      state: 'accepted',
+    });
+
+    await expect(service.register('preview-registration-token', {
+      machineId: '30000000-0000-4000-8000-000000000009',
+      hetznerServerId: 903,
+      publicIPv4: '203.0.113.93',
+      publicIPv6: '2001:db8::93',
+      imageVersion: 'v2',
+      bundleSha256: '2'.repeat(64),
+      healthy: true,
+    })).resolves.toEqual({ registered: true, status: 'running' });
+    await expect(getUserMachine(db, '30000000-0000-4000-8000-000000000009'))
+      .resolves.toMatchObject({
+        status: 'running',
+        sourceSnapshotId: snapshotId,
+        sourceBaseGeneration: compatibility.baseGeneration,
+      });
+  });
+
+  it('rejects a non-test snapshot on the operator preview override before provider creation', async () => {
+    const snapshotId = await readySnapshot('v2', 302);
+    const createServer = vi.fn();
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET: 'platform-secret',
+        CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+        MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+        S3_ACCESS_KEY_ID: 'access-key',
+        S3_SECRET_ACCESS_KEY: 'secret-key',
+        S3_ENDPOINT: 'https://r2.example',
+        HETZNER_SERVER_TYPE: 'cpx22',
+      }),
+      hetzner: createMockHetznerClient({ createServer }),
+      systemStore: createMockCustomerVpsSystemStore(),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000010',
+      provisioningJobIdFactory: () => '50000000-0000-4000-8000-000000000010',
+      now: () => new Date('2026-07-03T00:01:00.000Z'),
+    });
+
+    await expect(service.provisionPreview({
+      clerkUserId: 'user_preview_test',
+      handle: 'pr-1274',
+      runtimeSlot: 'pr-1274',
+      testSnapshotId: snapshotId,
+    })).rejects.toMatchObject({ code: 'snapshot_clone_rejected' });
+    expect(createServer).not.toHaveBeenCalled();
+    await expect(getUserMachine(db, '30000000-0000-4000-8000-000000000010'))
+      .resolves.toBeUndefined();
+  });
+
+  it('fails an exact preview test closed when the provider rejects the snapshot clone', async () => {
+    const snapshotId = await readySnapshot('v2', 302, true);
+    const createServer = vi.fn().mockRejectedValue(
+      new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable'),
+    );
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET: 'platform-secret',
+        CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+        MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+        S3_ACCESS_KEY_ID: 'access-key',
+        S3_SECRET_ACCESS_KEY: 'secret-key',
+        S3_ENDPOINT: 'https://r2.example',
+        HETZNER_SERVER_TYPE: 'cpx22',
+        GOLDEN_SNAPSHOTS_ENABLED: 'false',
+        GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '0',
+      }),
+      hetzner: createMockHetznerClient({ createServer }),
+      systemStore: createMockCustomerVpsSystemStore(),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000011',
+      provisioningJobIdFactory: () => '50000000-0000-4000-8000-000000000011',
+      now: () => new Date('2026-07-03T00:01:00.000Z'),
+    });
+
+    await expect(service.provisionPreview({
+      clerkUserId: 'user_preview_test',
+      handle: 'pr-1275',
+      runtimeSlot: 'pr-1275',
+      testSnapshotId: snapshotId,
+    })).rejects.toMatchObject({ code: 'snapshot_clone_rejected' });
+    expect(createServer).toHaveBeenCalledTimes(1);
+    expect(createServer).toHaveBeenCalledWith(expect.objectContaining({ image: 302 }));
+    await expect(getUserMachine(db, '30000000-0000-4000-8000-000000000011'))
+      .resolves.toMatchObject({ status: 'failed', failureCode: 'snapshot_clone_rejected' });
+    await expect(db.executor.selectFrom('golden_snapshot_leases').select('released_at')
+      .where('machine_id', '=', '30000000-0000-4000-8000-000000000011')
+      .executeTakeFirstOrThrow()).resolves.toMatchObject({
+      released_at: '2026-07-03T00:01:00.000Z',
+    });
+  });
 
   it('atomically selects an exact snapshot, leases it, and persists durable activation provenance', async () => {
     const snapshotId = await readySnapshot('v2', 302);

--- a/tests/platform/golden-snapshot-provisioning.test.ts
+++ b/tests/platform/golden-snapshot-provisioning.test.ts
@@ -285,9 +285,7 @@ describe('golden snapshot provisioning activation', () => {
         ...firstServer, id: 905, publicIPv4: '203.0.113.95', createActionId: 1805,
       });
     const deleteServer = vi.fn().mockResolvedValue(undefined);
-    const getServer = vi.fn()
-      .mockResolvedValueOnce(firstServer)
-      .mockResolvedValueOnce(null);
+    const getServer = vi.fn().mockResolvedValue(firstServer);
     const service = createCustomerVpsService({
       db,
       config: loadCustomerVpsConfig({
@@ -321,12 +319,20 @@ describe('golden snapshot provisioning activation', () => {
       handle: 'pr-1273',
       runtimeSlot: 'pr-1273',
       testSnapshotId: snapshotId,
-    })).resolves.toMatchObject({ status: 'provisioning' });
+    })).rejects.toMatchObject({ code: 'snapshot_clone_rejected' });
     expect(createServer).toHaveBeenCalledTimes(1);
     expect(deleteServer).toHaveBeenCalledWith(904);
+    await expect(db.executor.selectFrom('provider_deletion_queue')
+      .select(['provider_server_id', 'reason', 'completed_at'])
+      .where('provider_server_id', '=', 904)
+      .executeTakeFirstOrThrow()).resolves.toEqual({
+      provider_server_id: 904,
+      reason: 'rejected_snapshot_clone',
+      completed_at: null,
+    });
 
     currentNow = new Date('2026-07-03T00:07:00.000Z');
-    await expect(service.dispatchProvisioningJobs()).resolves.toMatchObject({ failed: 1 });
+    await expect(service.dispatchProvisioningJobs()).resolves.toMatchObject({ checked: 0 });
     expect(createServer).toHaveBeenCalledTimes(1);
     await expect(getProvisioningJob(db, '50000000-0000-4000-8000-000000000014'))
       .resolves.toMatchObject({

--- a/tests/platform/golden-snapshot-provisioning.test.ts
+++ b/tests/platform/golden-snapshot-provisioning.test.ts
@@ -269,6 +269,74 @@ describe('golden snapshot provisioning activation', () => {
     });
   });
 
+  it('never creates a second exact-test server after a persisted provider action is rejected', async () => {
+    const snapshotId = await readySnapshot('v2', 302, true);
+    let currentNow = new Date('2026-07-03T00:01:00.000Z');
+    const firstServer = {
+      id: 904, status: 'initializing' as const, publicIPv4: '203.0.113.94', createActionId: 1804,
+      labels: {
+        machine_id: '30000000-0000-4000-8000-000000000014',
+        snapshot_id: snapshotId,
+      },
+    };
+    const createServer = vi.fn()
+      .mockResolvedValueOnce(firstServer)
+      .mockResolvedValueOnce({
+        ...firstServer, id: 905, publicIPv4: '203.0.113.95', createActionId: 1805,
+      });
+    const deleteServer = vi.fn().mockResolvedValue(undefined);
+    const getServer = vi.fn()
+      .mockResolvedValueOnce(firstServer)
+      .mockResolvedValueOnce(null);
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET: 'platform-secret',
+        CUSTOMER_VPS_IMAGE_VERSION: 'v2',
+        MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+        S3_ACCESS_KEY_ID: 'access-key',
+        S3_SECRET_ACCESS_KEY: 'secret-key',
+        S3_ENDPOINT: 'https://r2.example',
+        HETZNER_SERVER_TYPE: 'cpx22',
+        GOLDEN_SNAPSHOTS_ENABLED: 'false',
+        GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '0',
+      }),
+      hetzner: createMockHetznerClient({
+        createServer,
+        deleteServer,
+        getServer,
+        getAction: vi.fn().mockResolvedValue({
+          id: 1804, status: 'error', command: 'create_server',
+        }),
+        listServersByLabel: vi.fn().mockResolvedValue([]),
+      }),
+      systemStore: createMockCustomerVpsSystemStore(),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000014',
+      provisioningJobIdFactory: () => '50000000-0000-4000-8000-000000000014',
+      now: () => currentNow,
+    });
+
+    await expect(service.provisionPreview({
+      clerkUserId: 'user_preview_action_retry',
+      handle: 'pr-1273',
+      runtimeSlot: 'pr-1273',
+      testSnapshotId: snapshotId,
+    })).resolves.toMatchObject({ status: 'provisioning' });
+    expect(createServer).toHaveBeenCalledTimes(1);
+    expect(deleteServer).toHaveBeenCalledWith(904);
+
+    currentNow = new Date('2026-07-03T00:07:00.000Z');
+    await expect(service.dispatchProvisioningJobs()).resolves.toMatchObject({ failed: 1 });
+    expect(createServer).toHaveBeenCalledTimes(1);
+    await expect(getProvisioningJob(db, '50000000-0000-4000-8000-000000000014'))
+      .resolves.toMatchObject({
+        status: 'failed',
+        providerCreateActionId: 1804,
+      });
+    await expect(getUserMachine(db, '30000000-0000-4000-8000-000000000014'))
+      .resolves.toMatchObject({ status: 'failed', failureCode: 'snapshot_clone_rejected' });
+  });
+
   it('atomically selects an exact snapshot, leases it, and persists durable activation provenance', async () => {
     const snapshotId = await readySnapshot('v2', 302);
     const selected = await chooseProvisioningImage(db, config, {


### PR DESCRIPTION
## Summary

- add an operator-only `testSnapshotId` override to real preview provisioning
- require the separate snapshot-operator credential and reject release/platform credentials for the override
- bind only a fresh, ready, provider-available, exact-bundle test-mode snapshot to a preview machine and durable job in one transaction
- fail the exact test closed instead of silently falling back to a clean image
- preserve the normal preview/customer paths and leave customer snapshot rollout disabled

## Tests

- `pnpm exec vitest run tests/platform/customer-vps-routes.test.ts tests/platform/golden-snapshot-provisioning.test.ts --reporter=dot` (51 passed)
- `pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json`
- `bun run check:patterns` (0 violations; existing scanner warnings only)
- `git diff --check`
- memory-safe serial repository suite is still running; no failures so far

## Review / monitoring

- waiting for trusted Greptile review on the exact head before adding `ready-for-ci`
- after merge: monitor the exact `main` CI and deployment, then build one disposable test snapshot and run real provider creation, registration, service health, provenance, reuse, and timing verification

## Invariants

- **Source of truth:** the persisted provisioning job, snapshot record, host-bundle release digest, lease, and create intent determine image provenance; request data alone never does.
- **Lock / transaction scope:** machine + job creation, preview-class verification, snapshot compatibility/freshness checks, and lease binding commit atomically under owner, base-generation, compatibility, and snapshot locks.
- **Acceptable orphan states:** ambiguous provider outcomes remain pending for exact-label reconciliation; definite exact-test rejection fails the machine and uses existing durable cleanup instead of creating a clean fallback server.
- **Auth source of truth:** ordinary preview automation uses `PLATFORM_SECRET`; a request containing `testSnapshotId` requires `GOLDEN_SNAPSHOT_OPERATOR_SECRET`. The ordinary customer route cannot consume this field.
- **Deferred scope:** this PR does not enable or change the customer rollout percentage. Selection remains off until the disposable registered-onboarding proof passes.

## File-size note

The exact-test decision/lease/intent logic lives in a focused 306-line module instead of adding another responsibility to the existing large customer provisioning service; that file retains orchestration only.
