### PR TITLE
fix(platform): pin exact preview snapshot bundle

### DIFF
--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -105,6 +105,7 @@ import {
   bindTestSnapshotToPreviewProvisionInTransaction,
   createPreviewTestSnapshotCreateIntent,
   isPreviewTestSnapshotDecision,
+  resolvePreviewTestSnapshotBundle,
   resolvePersistedProvisioningImage,
 } from './golden-snapshot-preview-test.js';
 
@@ -385,7 +386,22 @@ function hostBundleUrlForImageVersion(config: CustomerVpsConfig, imageVersion: s
   return url.toString();
 }
 
-async function resolveHostBundleRef(db: PlatformDB, config: CustomerVpsConfig): Promise<HostBundleRef> {
+async function resolveHostBundleRef(
+  db: PlatformDB,
+  config: CustomerVpsConfig,
+  previewTestSnapshotId?: string,
+): Promise<HostBundleRef> {
+  if (previewTestSnapshotId) {
+    const snapshotBundle = await resolvePreviewTestSnapshotBundle(db, previewTestSnapshotId);
+    if (!snapshotBundle) {
+      throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+    }
+    return {
+      imageVersion: snapshotBundle.bundleVersion,
+      hostBundleUrl: hostBundleUrlForImageVersion(config, snapshotBundle.bundleVersion),
+      sha256: snapshotBundle.bundleSha256,
+    };
+  }
   if (config.hostBundleUrlOverride || !HOST_BUNDLE_CHANNELS.has(config.imageVersion)) {
     const release = await getHostBundleRelease(db, config.imageVersion);
     return {
@@ -1701,7 +1717,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       return activeProvisionResponse(reconciled, deps.config.provisionEtaSeconds);
     }
 
-    const bundleRef = await resolveHostBundleRef(deps.db, deps.config);
+    const bundleRef = await resolveHostBundleRef(deps.db, deps.config, testSnapshotId);
 
     let provisionRow: { existing: UserMachineRecord | null };
     try {

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -378,9 +378,11 @@ function tryPinHostBundleUrlForImageVersion(
   imageVersion: string,
 ): string | undefined {
   const currentSegment = `/system-bundles/${encodeURIComponent(config.imageVersion)}/`;
-  if (!config.hostBundleUrl.includes(currentSegment)) return undefined;
+  const url = new URL(config.hostBundleUrl);
+  if (!url.pathname.includes(currentSegment)) return undefined;
   const pinnedSegment = `/system-bundles/${encodeURIComponent(imageVersion)}/`;
-  return config.hostBundleUrl.replaceAll(currentSegment, pinnedSegment);
+  url.pathname = url.pathname.replaceAll(currentSegment, pinnedSegment);
+  return url.toString();
 }
 
 function hostBundleUrlForImageVersion(config: CustomerVpsConfig, imageVersion: string): string {

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -373,12 +373,19 @@ interface HostBundleRef {
   sha256?: string | null;
 }
 
-function hostBundleUrlForImageVersion(config: CustomerVpsConfig, imageVersion: string): string {
+function tryPinHostBundleUrlForImageVersion(
+  config: CustomerVpsConfig,
+  imageVersion: string,
+): string | undefined {
   const currentSegment = `/system-bundles/${encodeURIComponent(config.imageVersion)}/`;
+  if (!config.hostBundleUrl.includes(currentSegment)) return undefined;
   const pinnedSegment = `/system-bundles/${encodeURIComponent(imageVersion)}/`;
-  if (config.hostBundleUrl.includes(currentSegment)) {
-    return config.hostBundleUrl.replaceAll(currentSegment, pinnedSegment);
-  }
+  return config.hostBundleUrl.replaceAll(currentSegment, pinnedSegment);
+}
+
+function hostBundleUrlForImageVersion(config: CustomerVpsConfig, imageVersion: string): string {
+  const pinnedUrl = tryPinHostBundleUrlForImageVersion(config, imageVersion);
+  if (pinnedUrl) return pinnedUrl;
   // Defensive fallback for future URL-template changes. The current generated
   // URL always contains the encoded image-version segment above.
   const url = new URL(config.hostBundleUrl);
@@ -396,9 +403,13 @@ async function resolveHostBundleRef(
     if (!snapshotBundle) {
       throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
     }
+    const pinnedUrl = tryPinHostBundleUrlForImageVersion(config, snapshotBundle.bundleVersion);
+    if (!pinnedUrl) {
+      throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+    }
     return {
       imageVersion: snapshotBundle.bundleVersion,
-      hostBundleUrl: hostBundleUrlForImageVersion(config, snapshotBundle.bundleVersion),
+      hostBundleUrl: pinnedUrl,
       sha256: snapshotBundle.bundleSha256,
     };
   }

--- a/packages/platform/src/golden-snapshot-preview-test.ts
+++ b/packages/platform/src/golden-snapshot-preview-test.ts
@@ -32,6 +32,27 @@ const BindInputSchema = z.object({
   now: IsoDateSchema,
 }).strict();
 
+export async function resolvePreviewTestSnapshotBundle(
+  db: PlatformDB,
+  rawSnapshotId: string,
+): Promise<{ bundleVersion: string; bundleSha256: string } | undefined> {
+  // This read only chooses the immutable bundle for cloud-init. The binding
+  // transaction below repeats every snapshot, release, and compatibility
+  // check before it commits the machine, job, and lease together.
+  const snapshotId = UuidSchema.parse(rawSnapshotId);
+  const snapshot = await getGoldenSnapshot(db, snapshotId);
+  if (!snapshot?.testMode) return undefined;
+  const release = await db.executor.selectFrom('host_bundle_releases')
+    .select('sha256')
+    .where('version', '=', snapshot.bundleVersion)
+    .executeTakeFirst();
+  if (release?.sha256.toLowerCase() !== snapshot.bundleSha256) return undefined;
+  return {
+    bundleVersion: snapshot.bundleVersion,
+    bundleSha256: snapshot.bundleSha256,
+  };
+}
+
 export function isPreviewTestSnapshotDecision(
   decision: ProvisioningImageDecision,
 ): decision is Extract<ProvisioningImageDecision, { imageSource: 'snapshot' }> & { previewTest: true } {

--- a/tests/platform/golden-snapshot-provisioning.test.ts
+++ b/tests/platform/golden-snapshot-provisioning.test.ts
@@ -203,7 +203,11 @@ describe('golden snapshot provisioning activation', () => {
       });
   });
 
-  it('rejects an exact test snapshot when a custom bundle URL cannot be safely version-pinned', async () => {
+  it.each([
+    ['nonstandard path', 'https://bundles.example/custom/latest.tar.gz'],
+    ['query-only version segment', 'https://bundles.example/custom/latest.tar.gz?source=/system-bundles/stable/'],
+    ['fragment-only version segment', 'https://bundles.example/custom/latest.tar.gz#/system-bundles/stable/'],
+  ])('rejects an exact test snapshot for a custom bundle URL with a %s', async (_case, hostBundleUrl) => {
     await promoteHostBundleChannel(db, 'stable', 'v1', '2026-07-03T00:00:00.000Z');
     const snapshotId = await readySnapshot('v2', 302, true);
     const createServer = vi.fn();
@@ -212,7 +216,7 @@ describe('golden snapshot provisioning activation', () => {
       config: loadCustomerVpsConfig({
         PLATFORM_SECRET: 'platform-secret',
         CUSTOMER_VPS_IMAGE_VERSION: 'stable',
-        MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/custom/latest.tar.gz',
+        MATRIX_HOST_BUNDLE_URL: hostBundleUrl,
         S3_ACCESS_KEY_ID: 'access-key',
         S3_SECRET_ACCESS_KEY: 'secret-key',
         S3_ENDPOINT: 'https://r2.example',

--- a/tests/platform/golden-snapshot-provisioning.test.ts
+++ b/tests/platform/golden-snapshot-provisioning.test.ts
@@ -203,6 +203,35 @@ describe('golden snapshot provisioning activation', () => {
       });
   });
 
+  it('rejects an exact test snapshot when a custom bundle URL cannot be safely version-pinned', async () => {
+    await promoteHostBundleChannel(db, 'stable', 'v1', '2026-07-03T00:00:00.000Z');
+    const snapshotId = await readySnapshot('v2', 302, true);
+    const createServer = vi.fn();
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET: 'platform-secret',
+        CUSTOMER_VPS_IMAGE_VERSION: 'stable',
+        MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/custom/latest.tar.gz',
+        S3_ACCESS_KEY_ID: 'access-key',
+        S3_SECRET_ACCESS_KEY: 'secret-key',
+        S3_ENDPOINT: 'https://r2.example',
+        HETZNER_SERVER_TYPE: 'cpx22',
+      }),
+      hetzner: createMockHetznerClient({ createServer }),
+      systemStore: createMockCustomerVpsSystemStore(),
+      now: () => new Date('2026-07-03T00:01:00.000Z'),
+    });
+
+    await expect(service.provisionPreview({
+      clerkUserId: 'user_preview_custom_bundle',
+      handle: 'pr-12741',
+      runtimeSlot: 'pr-12741',
+      testSnapshotId: snapshotId,
+    })).rejects.toMatchObject({ code: 'snapshot_clone_rejected' });
+    expect(createServer).not.toHaveBeenCalled();
+  });
+
   it('rejects a non-test snapshot on the operator preview override before provider creation', async () => {
     const snapshotId = await readySnapshot('v2', 302);
     const createServer = vi.fn();

--- a/tests/platform/golden-snapshot-provisioning.test.ts
+++ b/tests/platform/golden-snapshot-provisioning.test.ts
@@ -5,6 +5,7 @@ import {
   getUserMachine,
   insertUserMachine,
   parseNullableProviderActionId,
+  promoteHostBundleChannel,
   updateUserMachine,
   upsertHostBundleRelease,
   type PlatformDB,
@@ -108,7 +109,8 @@ describe('golden snapshot provisioning activation', () => {
     return enqueued.snapshot.snapshotId;
   }
 
-  it('provisions and registers an operator preview from one exact test snapshot while rollout stays disabled', async () => {
+  it('pins an exact test snapshot bundle when stable points to an older release', async () => {
+    await promoteHostBundleChannel(db, 'stable', 'v1', '2026-07-03T00:00:00.000Z');
     const snapshotId = await readySnapshot('v2', 302, true);
     const createServer = vi.fn().mockResolvedValue({
       id: 903,
@@ -121,8 +123,8 @@ describe('golden snapshot provisioning activation', () => {
       db,
       config: loadCustomerVpsConfig({
         PLATFORM_SECRET: 'platform-secret',
-        CUSTOMER_VPS_IMAGE_VERSION: 'v2',
-        MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+        CUSTOMER_VPS_IMAGE_VERSION: 'stable',
+        MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/stable/matrix-host-bundle.tar.gz',
         S3_ACCESS_KEY_ID: 'access-key',
         S3_SECRET_ACCESS_KEY: 'secret-key',
         S3_ENDPOINT: 'https://r2.example',
@@ -159,6 +161,12 @@ describe('golden snapshot provisioning activation', () => {
         snapshot_id: snapshotId,
       }),
     }));
+    const createInput = createServer.mock.calls[0]?.[0];
+    expect(createInput?.userData).toContain(
+      'MATRIX_HOST_BUNDLE_URL=https://bundles.example/system-bundles/v2/matrix-host-bundle.tar.gz',
+    );
+    expect(createInput?.userData).toContain('MATRIX_IMAGE_VERSION=v2');
+    expect(createInput?.userData).toContain('MATRIX_UPDATE_CHANNEL=stable');
     await expect(db.executor.selectFrom('golden_snapshot_rollout_controls')
       .selectAll().execute()).resolves.toEqual([]);
     await expect(getProvisioningJob(db, '50000000-0000-4000-8000-000000000009'))


### PR DESCRIPTION
## Summary

- pin operator preview snapshot tests to the snapshot's exact immutable host bundle, even when the configured update channel points to an older release
- keep the configured update channel unchanged so the disposable VPS still follows normal post-onboarding updates
- fail closed unless the requested test snapshot and registered bundle digest match, while retaining the authoritative transactional snapshot binding checks

## Tests

- `pnpm exec vitest run tests/platform/golden-snapshot-provisioning.test.ts` (35/35)
- `pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json`
- `bun run typecheck`
- `./scripts/review/check-patterns.sh --diff origin/main`

## Invariants

### Source of truth

- `golden_snapshots` is the source of truth for the exact test snapshot bundle version and digest.
- `host_bundle_releases` is the source of truth that the immutable bundle version exists with the same digest.
- `host_bundle_channels` remains the source of truth for the VPS update channel after onboarding; this fix does not move any channel pointer.

### Lock/transaction scope

- The pre-read only selects the exact immutable bundle used to render cloud-init.
- The existing provisioning transaction rechecks test-mode eligibility, readiness, freshness, release digest, compatibility, machine/job binding, create intent, and snapshot lease before atomically committing the preview machine and provisioning job.
- No provider or bundle-network call is added inside the transaction.

### Acceptable orphan states

- A failed pre-read creates no machine, job, lease, or provider server.
- If authoritative transactional binding fails, the transaction rolls back all preview machine/job/lease state.
- Existing provider failure cleanup and delayed-deletion behavior is unchanged.

### Auth source of truth

- The existing operator secret remains required for `testSnapshotId`; this PR does not add or weaken an auth path.
- Invalid, non-test, missing, or digest-mismatched snapshots fail closed with the existing generic snapshot rejection.

### Deferred scope

- Customer snapshot rollout remains disabled and untouched.
- This is an operator-only bug fix with no user-facing documentation change.
- Snapshot build duration is separate from onboarding duration and is not changed here.

## Live validation plan

After merge and exact-main deployment, build a fresh disposable test snapshot and run the real preview provisioning path to verify exact snapshot provenance, bundle reuse, service health, cleanup, and measured create-to-running onboarding time.
