### PR TITLE
fix(platform): expose snapshot guard diagnostics

### DIFF
--- a/packages/platform/src/customer-vps-errors.ts
+++ b/packages/platform/src/customer-vps-errors.ts
@@ -27,6 +27,38 @@ export class CustomerVpsError extends Error {
   }
 }
 
+export type PreviewSnapshotUnavailableReason =
+  | 'bundle_resolution_failed'
+  | 'bundle_url_unpinnable'
+  | 'existing_machine_snapshot_mismatch'
+  | 'snapshot_binding_failed'
+  | 'persisted_snapshot_missing'
+  | 'persisted_provider_image_missing'
+  | 'persisted_provider_image_unavailable'
+  | 'persisted_snapshot_not_ready'
+  | 'persisted_snapshot_ready_at_missing'
+  | 'persisted_snapshot_stale'
+  | 'persisted_bundle_version_mismatch'
+  | 'persisted_bundle_digest_mismatch'
+  | 'pre_create_snapshot_changed'
+  | 'create_intent_unavailable'
+  | 'create_intent_denied'
+  | 'provider_create_action_rejected';
+
+/**
+ * Carries a bounded, non-secret diagnostic for server-side logging while the
+ * public error contract stays deliberately generic.
+ */
+export class PreviewSnapshotUnavailableError extends CustomerVpsError {
+  readonly internalReason: PreviewSnapshotUnavailableReason;
+
+  constructor(internalReason: PreviewSnapshotUnavailableReason) {
+    super(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+    this.name = 'PreviewSnapshotUnavailableError';
+    this.internalReason = internalReason;
+  }
+}
+
 /**
  * The provider returned a bounded HTTP rejection, proving that create did not
  * have an ambiguous transport outcome. Callers may retry or fail without an
@@ -53,5 +85,8 @@ export function genericProviderError(err: unknown): CustomerVpsError {
 
 export function logCustomerVpsError(context: string, err: unknown): void {
   const message = err instanceof Error ? err.message : String(err);
-  console.error(`[customer-vps] ${context}: ${message}`);
+  const internalReason = err instanceof PreviewSnapshotUnavailableError
+    ? ` internalReason=${err.internalReason}`
+    : '';
+  console.error(`[customer-vps] ${context}: ${message}${internalReason}`);
 }

--- a/packages/platform/src/customer-vps-routes.ts
+++ b/packages/platform/src/customer-vps-routes.ts
@@ -1,7 +1,12 @@
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { MATRIX_TELEMETRY_EVENTS } from '@matrix-os/observability';
-import { CustomerVpsError, logCustomerVpsError, type CustomerVpsFailureCode } from './customer-vps-errors.js';
+import {
+  CustomerVpsError,
+  PreviewSnapshotUnavailableError,
+  logCustomerVpsError,
+  type CustomerVpsFailureCode,
+} from './customer-vps-errors.js';
 import { bearerTokenMatches } from './customer-vps-auth.js';
 import {
   MachineIdParamSchema,
@@ -84,6 +89,9 @@ function customerVpsFailureStatus(err: unknown): number {
 
 function jsonError(c: import('hono').Context, err: unknown, fallback: string) {
   if (err instanceof CustomerVpsError) {
+    if (err instanceof PreviewSnapshotUnavailableError) {
+      logCustomerVpsError(fallback, err);
+    }
     return c.json({ error: err.publicMessage }, err.status as never);
   }
   logCustomerVpsError(fallback, err);

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -42,6 +42,7 @@ import { buildPlatformVerificationToken } from './platform-token.js';
 import type { HetznerClient } from './customer-vps-hetzner.js';
 import {
   CustomerVpsError,
+  PreviewSnapshotUnavailableError,
   genericProviderError,
   logCustomerVpsError,
   type CustomerVpsFailureCode,
@@ -403,11 +404,11 @@ async function resolveHostBundleRef(
   if (previewTestSnapshotId) {
     const snapshotBundle = await resolvePreviewTestSnapshotBundle(db, previewTestSnapshotId);
     if (!snapshotBundle) {
-      throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+      throw new PreviewSnapshotUnavailableError('bundle_resolution_failed');
     }
     const pinnedUrl = tryPinHostBundleUrlForImageVersion(config, snapshotBundle.bundleVersion);
     if (!pinnedUrl) {
-      throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+      throw new PreviewSnapshotUnavailableError('bundle_url_unpinnable');
     }
     return {
       imageVersion: snapshotBundle.bundleVersion,
@@ -1331,11 +1332,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
             effectiveProviderCreateActionId,
           );
           if (priorCreateResult === 'pending') return 'pending';
-          throw new CustomerVpsError(
-            409,
-            'snapshot_clone_rejected',
-            'Provisioning image unavailable',
-          );
+          throw new PreviewSnapshotUnavailableError('provider_create_action_rejected');
         }
       }
       const createInput = {
@@ -1361,6 +1358,9 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
             const selectableSnapshot = await getGoldenSnapshot(deps.db, imageDecision.snapshotId);
             if (selectableSnapshot?.state !== 'ready'
               || selectableSnapshot.providerImageId !== imageDecision.providerImageId) {
+              if (isPreviewTestSnapshotDecision(imageDecision)) {
+                throw new PreviewSnapshotUnavailableError('pre_create_snapshot_changed');
+              }
               throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
             }
             const intent = isPreviewTestSnapshotDecision(imageDecision)
@@ -1377,6 +1377,11 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
                   now: now().toISOString(),
                 });
             if (!intent || intent.state === 'denied') {
+              if (isPreviewTestSnapshotDecision(imageDecision)) {
+                throw new PreviewSnapshotUnavailableError(
+                  intent?.state === 'denied' ? 'create_intent_denied' : 'create_intent_unavailable',
+                );
+              }
               throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
             }
           }
@@ -1393,6 +1398,11 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
                   providerServerId: server.id, reason: 'denied_snapshot_create',
                   machineId: row.machineId, handle: row.handle, err: cleanupErr,
                 });
+              }
+              if (isPreviewTestSnapshotDecision(imageDecision)) {
+                throw new PreviewSnapshotUnavailableError(
+                  accepted?.state === 'denied' ? 'create_intent_denied' : 'create_intent_unavailable',
+                );
               }
               throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
             }
@@ -1526,7 +1536,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
               });
               serverIdForCompensation = null;
             }
-            throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+            throw new PreviewSnapshotUnavailableError('provider_create_action_rejected');
           }
           await fallbackProvisioningImage(deps.db, {
             jobId: job.jobId, reason: 'clone_rejected', now: now().toISOString(),
@@ -1687,7 +1697,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         const matchesRequestedSnapshot = machine.provisioningClass === 'preview'
           && (machine.sourceSnapshotId === testSnapshotId || existingJob?.snapshotId === testSnapshotId);
         if (!matchesRequestedSnapshot) {
-          throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+          throw new PreviewSnapshotUnavailableError('existing_machine_snapshot_mismatch');
         }
       }
       await updateUserMachine(db, machine.machineId, {
@@ -1859,7 +1869,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           now: currentTime.toISOString(),
         }, deps.config.goldenSnapshots);
         if (!bound) {
-          throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+          throw new PreviewSnapshotUnavailableError('snapshot_binding_failed');
         }
       }
       return { existing: null };

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -106,7 +106,7 @@ import {
   bindTestSnapshotToPreviewProvisionInTransaction,
   createPreviewTestSnapshotCreateIntent,
   isPreviewTestSnapshotDecision,
-  resolvePreviewTestSnapshotBundle,
+  resolvePinnedPreviewTestSnapshotBundle,
   resolvePersistedProvisioningImage,
 } from './golden-snapshot-preview-test.js';
 
@@ -402,19 +402,12 @@ async function resolveHostBundleRef(
   previewTestSnapshotId?: string,
 ): Promise<HostBundleRef> {
   if (previewTestSnapshotId) {
-    const snapshotBundle = await resolvePreviewTestSnapshotBundle(db, previewTestSnapshotId);
-    if (!snapshotBundle) {
-      throw new PreviewSnapshotUnavailableError('bundle_resolution_failed');
-    }
-    const pinnedUrl = tryPinHostBundleUrlForImageVersion(config, snapshotBundle.bundleVersion);
-    if (!pinnedUrl) {
-      throw new PreviewSnapshotUnavailableError('bundle_url_unpinnable');
-    }
-    return {
-      imageVersion: snapshotBundle.bundleVersion,
-      hostBundleUrl: pinnedUrl,
-      sha256: snapshotBundle.bundleSha256,
-    };
+    return resolvePinnedPreviewTestSnapshotBundle({
+      db,
+      snapshotId: previewTestSnapshotId,
+      currentBundleVersion: config.imageVersion,
+      currentBundleUrl: config.hostBundleUrl,
+    });
   }
   if (config.hostBundleUrlOverride || !HOST_BUNDLE_CHANNELS.has(config.imageVersion)) {
     const release = await getHostBundleRelease(db, config.imageVersion);

--- a/packages/platform/src/golden-snapshot-preview-test.ts
+++ b/packages/platform/src/golden-snapshot-preview-test.ts
@@ -3,14 +3,21 @@ import { sql } from 'kysely';
 import { z } from 'zod/v4';
 import type { PlatformDB, UserMachineRecord } from './db.js';
 import type { ProvisioningJobRecord } from './customer-vps-provisioning-jobs.js';
-import { CustomerVpsError } from './customer-vps-errors.js';
+import {
+  CustomerVpsError,
+  PreviewSnapshotUnavailableError,
+  type PreviewSnapshotUnavailableReason,
+} from './customer-vps-errors.js';
 import {
   fallbackProvisioningImage,
   getGoldenSnapshotServerProfile,
   resolveGoldenSnapshotRollout,
   type ProvisioningImageDecision,
 } from './golden-snapshot-activation.js';
-import { getGoldenSnapshot } from './golden-snapshot-repository.js';
+import {
+  getGoldenSnapshot,
+  type GoldenSnapshotRecord,
+} from './golden-snapshot-repository.js';
 import {
   compatibilityKey,
   GoldenSnapshotBundleVersionSchema,
@@ -31,6 +38,29 @@ const BindInputSchema = z.object({
   provisioningJobId: UuidSchema,
   now: IsoDateSchema,
 }).strict();
+
+function persistedSnapshotUnavailableReason(input: {
+  snapshot: GoldenSnapshotRecord | undefined;
+  isPreviewTestSnapshot: boolean;
+  imageVersion: string;
+  targetBundleSha256: string | null;
+  freshnessCutoff: string;
+}): PreviewSnapshotUnavailableReason | undefined {
+  const { snapshot } = input;
+  if (!snapshot) return 'persisted_snapshot_missing';
+  if (snapshot.providerImageId === null) return 'persisted_provider_image_missing';
+  if (snapshot.providerImageStatus !== 'available') return 'persisted_provider_image_unavailable';
+  if (snapshot.state !== 'ready') return 'persisted_snapshot_not_ready';
+  if (!snapshot.readyAt) return 'persisted_snapshot_ready_at_missing';
+  if (snapshot.readyAt <= input.freshnessCutoff) return 'persisted_snapshot_stale';
+  if (input.isPreviewTestSnapshot && snapshot.bundleVersion !== input.imageVersion) {
+    return 'persisted_bundle_version_mismatch';
+  }
+  if (input.isPreviewTestSnapshot && snapshot.bundleSha256 !== input.targetBundleSha256) {
+    return 'persisted_bundle_digest_mismatch';
+  }
+  return undefined;
+}
 
 export async function resolvePreviewTestSnapshotBundle(
   db: PlatformDB,
@@ -86,18 +116,17 @@ export async function resolvePersistedProvisioningImage(input: {
     ? Math.min(config.freshnessMaxAgeMs, config.testModeTtlMs)
     : config.freshnessMaxAgeMs;
   const freshnessCutoff = new Date(claimedAt.getTime() - freshnessMaxAgeMs).toISOString();
-  const unavailable = !persistedSnapshot?.providerImageId
-    || persistedSnapshot.providerImageStatus !== 'available'
-    || persistedSnapshot.state !== 'ready'
-    || !persistedSnapshot.readyAt
-    || persistedSnapshot.readyAt <= freshnessCutoff
-    || (isPreviewTestSnapshot && (
-      persistedSnapshot.bundleVersion !== imageVersion
-      || persistedSnapshot.bundleSha256 !== job.targetBundleSha256
-    ));
+  const unavailableReason = persistedSnapshotUnavailableReason({
+    snapshot: persistedSnapshot,
+    isPreviewTestSnapshot,
+    imageVersion,
+    targetBundleSha256: job.targetBundleSha256,
+    freshnessCutoff,
+  });
+  const unavailable = unavailableReason !== undefined;
   if ((!rollout.included && !isPreviewTestSnapshot) || unavailable) {
     if (isPreviewTestSnapshot) {
-      throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+      throw new PreviewSnapshotUnavailableError(unavailableReason ?? 'persisted_snapshot_not_ready');
     }
     await fallbackProvisioningImage(db, {
       jobId: job.jobId,
@@ -116,9 +145,12 @@ export async function resolvePersistedProvisioningImage(input: {
       effectiveProviderCreateActionId: null,
     };
   }
+  if (!persistedSnapshot) {
+    throw new Error('Persisted snapshot resolution invariant failed');
+  }
   const providerImageId = persistedSnapshot.providerImageId;
   if (providerImageId === null) {
-    throw new CustomerVpsError(409, 'snapshot_clone_rejected', 'Provisioning image unavailable');
+    throw new PreviewSnapshotUnavailableError('persisted_provider_image_missing');
   }
   return {
     imageDecision: {

--- a/packages/platform/src/golden-snapshot-preview-test.ts
+++ b/packages/platform/src/golden-snapshot-preview-test.ts
@@ -83,6 +83,30 @@ export async function resolvePreviewTestSnapshotBundle(
   };
 }
 
+export async function resolvePinnedPreviewTestSnapshotBundle(input: {
+  db: PlatformDB;
+  snapshotId: string;
+  currentBundleVersion: string;
+  currentBundleUrl: string;
+}): Promise<{ imageVersion: string; hostBundleUrl: string; sha256: string }> {
+  const snapshotBundle = await resolvePreviewTestSnapshotBundle(input.db, input.snapshotId);
+  if (!snapshotBundle) {
+    throw new PreviewSnapshotUnavailableError('bundle_resolution_failed');
+  }
+  const currentSegment = `/system-bundles/${encodeURIComponent(input.currentBundleVersion)}/`;
+  const url = new URL(input.currentBundleUrl);
+  if (!url.pathname.includes(currentSegment)) {
+    throw new PreviewSnapshotUnavailableError('bundle_url_unpinnable');
+  }
+  const pinnedSegment = `/system-bundles/${encodeURIComponent(snapshotBundle.bundleVersion)}/`;
+  url.pathname = url.pathname.replaceAll(currentSegment, pinnedSegment);
+  return {
+    imageVersion: snapshotBundle.bundleVersion,
+    hostBundleUrl: url.toString(),
+    sha256: snapshotBundle.bundleSha256,
+  };
+}
+
 export function isPreviewTestSnapshotDecision(
   decision: ProvisioningImageDecision,
 ): decision is Extract<ProvisioningImageDecision, { imageSource: 'snapshot' }> & { previewTest: true } {

--- a/tests/platform/customer-vps-errors.test.ts
+++ b/tests/platform/customer-vps-errors.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  PreviewSnapshotUnavailableError,
+  logCustomerVpsError,
+} from '../../packages/platform/src/customer-vps-errors.js';
+
+describe('customer VPS error logging', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('keeps preview snapshot diagnostics server-only while logging the bounded reason', () => {
+    const error = new PreviewSnapshotUnavailableError('persisted_bundle_digest_mismatch');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    expect(error.publicMessage).toBe('Provisioning image unavailable');
+    expect(error.message).toBe('Provisioning image unavailable');
+
+    logCustomerVpsError('provisioning job failed machineId=test-machine', error);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      '[customer-vps] provisioning job failed machineId=test-machine: '
+      + 'Provisioning image unavailable internalReason=persisted_bundle_digest_mismatch',
+    );
+  });
+});

--- a/tests/platform/customer-vps-routes.test.ts
+++ b/tests/platform/customer-vps-routes.test.ts
@@ -5,6 +5,7 @@ import { createCustomerVpsService } from '../../packages/platform/src/customer-v
 import { loadCustomerVpsConfig } from '../../packages/platform/src/customer-vps-config.js';
 import { hashRegistrationToken } from '../../packages/platform/src/customer-vps-auth.js';
 import { createCustomerVpsRoutes } from '../../packages/platform/src/customer-vps-routes.js';
+import { PreviewSnapshotUnavailableError } from '../../packages/platform/src/customer-vps-errors.js';
 import { createMockCustomerVpsSystemStore, createMockHetznerClient } from './customer-vps-fixtures.js';
 import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
 
@@ -18,6 +19,7 @@ describe('platform/customer-vps-routes', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await destroyTestPlatformDb(db);
   });
 
@@ -180,6 +182,43 @@ describe('platform/customer-vps-routes', () => {
     });
     expect(failed.status).toBe(500);
     expect(await failed.json()).toEqual({ error: 'Provisioning failed' });
+  });
+
+  it('logs bounded preview snapshot diagnostics while keeping route errors generic', async () => {
+    const provisionPreview = vi.fn().mockRejectedValue(
+      new PreviewSnapshotUnavailableError('snapshot_binding_failed'),
+    );
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const service = { provisionPreview } as unknown as Parameters<
+      typeof createCustomerVpsRoutes
+    >[0]['service'];
+    const app = new Hono();
+    app.route('/vps', createCustomerVpsRoutes({
+      service,
+      platformSecret,
+      goldenSnapshotOperatorSecret: snapshotOperatorSecret,
+    }));
+
+    const response = await app.request('/vps/preview/provision', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${snapshotOperatorSecret}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        clerkUserId: 'user_123',
+        handle: 'pr-899',
+        runtimeSlot: 'pr-899',
+        testSnapshotId: '10000000-0000-4000-8000-000000000001',
+      }),
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: 'Provisioning image unavailable' });
+    expect(consoleError).toHaveBeenCalledWith(
+      '[customer-vps] /vps/preview/provision: Provisioning image unavailable '
+      + 'internalReason=snapshot_binding_failed',
+    );
   });
 
   it('does not grant exact-snapshot authority to the ordinary customer provision route', async () => {

--- a/tests/platform/golden-snapshot-provisioning.test.ts
+++ b/tests/platform/golden-snapshot-provisioning.test.ts
@@ -73,6 +73,7 @@ describe('golden snapshot provisioning activation', () => {
   });
   afterEach(async () => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
     await destroyTestPlatformDb(db);
   });
 
@@ -201,6 +202,56 @@ describe('golden snapshot provisioning activation', () => {
         sourceSnapshotId: snapshotId,
         sourceBaseGeneration: compatibility.baseGeneration,
       });
+  });
+
+  it('logs a bounded server-only reason when a leased preview snapshot becomes stale before dispatch', async () => {
+    await promoteHostBundleChannel(db, 'stable', 'v1', '2026-07-03T00:00:00.000Z');
+    const snapshotId = await readySnapshot('v2', 302, true);
+    const createServer = vi.fn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    let nowCalls = 0;
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET: 'platform-secret',
+        CUSTOMER_VPS_IMAGE_VERSION: 'stable',
+        MATRIX_HOST_BUNDLE_URL: 'https://bundles.example/system-bundles/stable/matrix-host-bundle.tar.gz',
+        S3_ACCESS_KEY_ID: 'access-key',
+        S3_SECRET_ACCESS_KEY: 'secret-key',
+        S3_ENDPOINT: 'https://r2.example',
+        HETZNER_SERVER_TYPE: 'cpx22',
+        GOLDEN_SNAPSHOTS_ENABLED: 'false',
+        GOLDEN_SNAPSHOT_ROLLOUT_PERCENT: '0',
+        GOLDEN_SNAPSHOT_FRESHNESS_MAX_AGE_MS: '60000',
+      }),
+      hetzner: createMockHetznerClient({ createServer }),
+      systemStore: createMockCustomerVpsSystemStore(),
+      machineIdFactory: () => '30000000-0000-4000-8000-000000000019',
+      provisioningJobIdFactory: () => '50000000-0000-4000-8000-000000000019',
+      tokenFactory: () => ({
+        token: 'preview-registration-token',
+        hash: hashRegistrationToken('preview-registration-token'),
+        expiresAt: '2026-07-03T01:00:00.000Z',
+      }),
+      now: () => new Date(nowCalls++ === 0
+        ? '2026-07-03T00:01:00.000Z'
+        : '2026-07-03T00:02:00.000Z'),
+    });
+
+    await expect(service.provisionPreview({
+      clerkUserId: 'user_preview_diagnostic',
+      handle: 'pr-12751',
+      runtimeSlot: 'pr-12751',
+      testSnapshotId: snapshotId,
+    })).rejects.toMatchObject({
+      code: 'snapshot_clone_rejected',
+      publicMessage: 'Provisioning image unavailable',
+    });
+
+    expect(createServer).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining(
+      'internalReason=persisted_snapshot_stale',
+    ));
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- keep preview snapshot failures generic to API clients
- attach bounded, non-secret reason codes to server-side provisioning logs
- cover the production-shaped stale lease path before any provider create call
- log synchronous pre-dispatch guard failures and keep exact bundle pinning in the focused preview module

This is targeted instrumentation for the disposable v987 onboarding failure. The failed job was rejected before a durable provider create intent existed, but every guard returned the same public 409. These bounded reasons identify the exact guard without exposing database, provider, bundle URL, or filesystem details.

## Tests

- `pnpm exec vitest run tests/platform/customer-vps-errors.test.ts tests/platform/golden-snapshot-provisioning.test.ts`
- `pnpm exec vitest run tests/platform/customer-vps-routes.test.ts -t "logs bounded preview snapshot diagnostics" --maxWorkers=1`
- `pnpm exec vitest run tests/platform/golden-snapshot-provisioning.test.ts -t "logs a bounded|rejects an exact test snapshot" --maxWorkers=1`
- `bun run typecheck`
- `bun run check:patterns:diff`
- `bun run check:patterns`
- `bun run test` (full repository suite started locally; exact snapshot provisioning and repository files passed while the remaining suite continued)

## Review / Monitoring

- Review range: `0042c6c4198cf2be28b4f177e498670d7d84d3c6..0067341dc1`
- After merge, monitor the exact `main` head through CI and platform deployment.
- Re-run one disposable exact-snapshot preview provision and inspect only the bounded `internalReason` log field.
- Keep customer snapshot rollout disabled and clean all disposable provider resources after the test.

## Invariants

### Source of truth

- Platform Postgres remains the source of truth for snapshot, lease, provisioning job, and create-intent state.
- Provider image state is still reconciled through the existing snapshot lifecycle; this PR changes diagnostics only.

### Lock/transaction scope

- Existing snapshot lease, job binding, and create-intent transactions are unchanged.
- No network call or transaction boundary is added or moved.

### Acceptable orphan states

- Existing compensation and cleanup behavior is unchanged.
- A diagnostic failure creates no new durable state and never triggers a provider request by itself.

### Auth source of truth

- Existing platform operator/test-mode authorization remains unchanged.
- Public errors remain the same generic 409 contract; bounded reason codes are written only to server logs.

### Deferred scope

- This PR does not change snapshot eligibility or fix the production guard that rejects the disposable clone.
- The exact guard identified after deployment will be fixed in a separate reviewed PR, followed by another disposable onboarding test.
