### PR TITLE
fix(desktop): keep collapsed sidebar divider below titlebar

### DIFF
--- a/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
+++ b/desktop/src/renderer/src/features/mission-control/Sidebar.tsx
@@ -61,11 +61,13 @@ export default function Sidebar() {
     <aside
       aria-label="Matrix OS navigation"
       data-sidebar-state={collapsed ? "collapsed" : "expanded"}
-      className="flex shrink-0 flex-col"
+      className="relative flex shrink-0 flex-col"
       style={{
         width: collapsed ? "var(--sidebar-collapsed-width)" : "var(--sidebar-expanded-width)",
         background: "var(--bg-sunken)",
-        borderRight: "1px solid var(--border-subtle)",
+        borderRight: collapsed
+          ? "0px solid transparent"
+          : "1px solid var(--border-subtle)",
         transition: "width 140ms var(--ease-out)",
       }}
     >
@@ -82,6 +84,18 @@ export default function Sidebar() {
           </div>
         )}
       </div>
+
+      {collapsed ? (
+        <div
+          aria-hidden="true"
+          data-testid="collapsed-sidebar-divider"
+          className="pointer-events-none absolute right-0 bottom-0"
+          style={{
+            top: "var(--titlebar-height)",
+            borderRight: "1px solid var(--border-subtle)",
+          }}
+        />
+      ) : null}
 
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-2 pb-2">
         <nav aria-label="Primary" className="flex flex-col gap-0.5">

--- a/tests/desktop/sidebar-navigation-shell.test.tsx
+++ b/tests/desktop/sidebar-navigation-shell.test.tsx
@@ -196,6 +196,8 @@ describe("Desktop sidebar navigation shell", () => {
     const sidebar = screen.getByRole("complementary", { name: "Matrix OS navigation" });
     expect(sidebar.getAttribute("data-sidebar-state")).toBe("expanded");
     expect(sidebar.style.width).toBe("var(--sidebar-expanded-width)");
+    expect(sidebar.style.borderRight).toBe("1px solid var(--border-subtle)");
+    expect(screen.queryByTestId("collapsed-sidebar-divider")).toBeNull();
     expect(screen.getByTestId("matrix-sidebar-logo")).toBeTruthy();
 
     expect(screen.getByRole("button", { name: "Terminal" }).getAttribute("aria-current")).toBe("page");
@@ -218,6 +220,9 @@ describe("Desktop sidebar navigation shell", () => {
     const sidebar = screen.getByRole("complementary", { name: "Matrix OS navigation" });
     expect(sidebar.getAttribute("data-sidebar-state")).toBe("collapsed");
     expect(sidebar.style.width).toBe("var(--sidebar-collapsed-width)");
+    expect(sidebar.style.borderRightWidth).toBe("0px");
+    expect(screen.getByTestId("collapsed-sidebar-divider").style.top)
+      .toBe("var(--titlebar-height)");
     expect(screen.queryByTestId("matrix-sidebar-logo")).toBeNull();
     expect(screen.queryByText("Recents")).toBeNull();
     expect(screen.queryByText("Projects")).toBeNull();

--- a/tests/e2e/desktop/sidebar-titlebar-safe-area.e2e.test.ts
+++ b/tests/e2e/desktop/sidebar-titlebar-safe-area.e2e.test.ts
@@ -52,7 +52,7 @@ suite("Desktop sidebar macOS titlebar safe area", () => {
     await page.setViewportSize(viewport);
     await expect.poll(async () => (await page.locator("aside").boundingBox())?.width).toBe(240);
     await page.screenshot({
-      path: join(SCREENSHOT_DIR, `mat-325-sidebar-expanded-${viewportName}.png`),
+      path: join(SCREENSHOT_DIR, `mat-449-sidebar-expanded-${viewportName}.png`),
     });
 
     const collapse = page.getByRole("button", { name: "Collapse sidebar" });
@@ -61,14 +61,23 @@ suite("Desktop sidebar macOS titlebar safe area", () => {
 
     await expect.poll(async () => (await page.locator("aside").boundingBox())?.width).toBe(56);
     const sidebarBox = await page.locator("aside").boundingBox();
+    const titlebarBox = await page.locator("aside > .titlebar-drag").boundingBox();
+    const dividerBox = await page.getByTestId("collapsed-sidebar-divider").boundingBox();
     const expand = page.getByRole("button", { name: "Expand sidebar" });
     const expandBox = await expand.boundingBox();
     await page.screenshot({
-      path: join(SCREENSHOT_DIR, `mat-325-sidebar-collapsed-${viewportName}.png`),
+      path: join(SCREENSHOT_DIR, `mat-449-sidebar-collapsed-${viewportName}.png`),
     });
 
     expect(sidebarBox).not.toBeNull();
     expect(sidebarBox?.width).toBe(56);
+    expect(await page.locator("aside").evaluate((element) =>
+      window.getComputedStyle(element).borderRightWidth)).toBe("0px");
+    expect(titlebarBox).not.toBeNull();
+    expect(dividerBox).not.toBeNull();
+    expect(dividerBox?.y ?? 0).toBeGreaterThanOrEqual(
+      (titlebarBox?.y ?? 0) + (titlebarBox?.height ?? 0),
+    );
     expect(expandBox).not.toBeNull();
     expect(expandBox?.x ?? 0).toBeGreaterThanOrEqual(MACOS_TITLEBAR_SAFE_X);
     expect(await expand.isVisible()).toBe(true);
@@ -79,7 +88,7 @@ suite("Desktop sidebar macOS titlebar safe area", () => {
     await expect.poll(async () => (await page.locator("aside").boundingBox())?.width).toBe(240);
   }
 
-  it("keeps the 56px collapsed rail and expand control outside native traffic lights", async () => {
+  it("keeps collapsed sidebar chrome outside native traffic lights", async () => {
     await expectSidebarLayoutsClearOfTrafficLights(
       { width: 1280, height: 820 },
       "normal",


### PR DESCRIPTION
## Summary

- remove the collapsed sidebar's full-height border so it no longer crosses the native macOS traffic-light region
- add a collapsed-only divider that begins at the existing titlebar boundary
- preserve the expanded sidebar divider, 56px collapsed rail, navigation, and controls

Linear: [MAT-449](https://linear.app/matrix-os/issue/MAT-449/remove-the-collapsed-desktop-sidebar-divider-from-the-macos-traffic)

## Validation

- `pnpm exec vitest run tests/desktop/sidebar-navigation-shell.test.tsx` — 12/12 passed
- `pnpm exec vitest run --config vitest.e2e.config.ts tests/e2e/desktop/sidebar-titlebar-safe-area.e2e.test.ts` — 1/1 passed at 1280x820 and 880x560
- `bun run typecheck` — passed
- `bun run build:desktop` — passed
- unsigned macOS package build — passed
- `bun run check:patterns:diff` — 0 violations
- packaged macOS app inspected with native traffic lights; collapsed divider starts below the titlebar

The full repository suite completed with 10,944 passing and 28 failing tests across 19 files. The failures are outside this Desktop sidebar diff and include existing UI Vitest resolution, Codex control/runtime sockets, Terminal install handoff, Todo date-boundary, and platform host-script cases. Both MAT-449 focused suites pass.

## Invariants

### Source of truth
- Existing `sidebarCollapsed` UI state and shared shell CSS tokens remain authoritative.

### Lock/transaction scope
- Not applicable; this is renderer-only presentation logic.

### Acceptable orphan states
- Not applicable; no persistence or external side effects are introduced.

### Auth source of truth
- Unchanged.

### Deferred scope
- Full Figma side-navigation alignment remains in MAT-450 and is intentionally excluded until MAT-449 merges.

## Review scope

Review commit: `5f1f40219`

Closes MAT-449
