### PR TITLE
feat(desktop): warm app icons before Apps opens

### DIFF
--- a/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
+++ b/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
@@ -36,6 +36,7 @@ function AppIcon({ url, name }: { url: string | null; name: string }) {
 export default function AppLauncher() {
   const api = useConnection((s) => s.api);
   const platformHost = useConnection((s) => s.platformHost);
+  const runtimeSlot = useConnection((s) => s.runtimeSlot);
   const openTab = useTabs((s) => s.openTab);
   const apps = useApps((s) => s.apps);
   const loaded = useApps((s) => s.loaded);
@@ -64,7 +65,7 @@ export default function AppLauncher() {
   const activeIndex = filtered.length === 0 ? 0 : Math.min(active, filtered.length - 1);
 
   const open = (slug: string, name: string) =>
-    openTab({ kind: "app", slug, title: name, ...(appIconUrl(platformHost, slug) ? { icon: appIconUrl(platformHost, slug)! } : {}) });
+    openTab({ kind: "app", slug, title: name, ...(appIconUrl(platformHost, slug, runtimeSlot) ? { icon: appIconUrl(platformHost, slug, runtimeSlot)! } : {}) });
 
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (filtered.length === 0) return;
@@ -160,7 +161,7 @@ export default function AppLauncher() {
                   onMouseEnter={() => setActive(i)}
                   onClick={() => open(app.slug, app.name)}
                 >
-                  <AppIcon url={appIconUrl(platformHost, app.slug)} name={app.name} />
+                  <AppIcon url={appIconUrl(platformHost, app.slug, runtimeSlot)} name={app.name} />
                   <span className="w-full truncate text-center text-sm" style={{ color: "var(--text-primary)" }}>
                     {app.name}
                   </span>

--- a/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
+++ b/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
@@ -19,6 +19,7 @@ import { wireKernel } from "../../lib/kernel-wiring";
 import { codingAgentRuntimeScope } from "../../../../shared/coding-agent-project-workspace";
 import DesktopUpdateExperience from "../updates/DesktopUpdateExperience";
 import { useShellSessionSync } from "../../lib/shell-session-sync";
+import { preloadAppIcons, useApps } from "../../stores/apps";
 
 export default function MissionControl() {
   const api = useConnection((s) => s.api);
@@ -27,6 +28,7 @@ export default function MissionControl() {
   const runtimeScope = useConnection(codingAgentRuntimeScope);
   const authGeneration = useConnection((s) => s.authGeneration);
   const loadProjects = useBoard((s) => s.loadProjects);
+  const loadApps = useApps((s) => s.load);
   const openTab = useTabs((s) => s.openTab);
   const tabCount = useTabs((s) => s.tabs.length);
   const createProjectOpen = useUi((s) => s.createProjectOpen);
@@ -100,6 +102,21 @@ export default function MissionControl() {
       cancelled = true;
     };
   }, [api, loadProjects, runtimeSlot]);
+
+  // Warm the catalog and icon cache as soon as this computer is connected,
+  // rather than making the first Apps-tab visit wait for both request stages.
+  useEffect(() => {
+    if (!api) return;
+    let cancelled = false;
+    void loadApps(api).then(() => {
+      if (!cancelled) {
+        preloadAppIcons(platformHost, runtimeSlot, useApps.getState().apps);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [api, loadApps, platformHost, runtimeSlot]);
 
   useEffect(() => {
     if (!api) return;

--- a/desktop/src/renderer/src/features/palette/CommandPalette.tsx
+++ b/desktop/src/renderer/src/features/palette/CommandPalette.tsx
@@ -106,6 +106,7 @@ export default function CommandPalette() {
   const selectReview = useCodingAgentWorkspace((s) => s.selectReview);
   const api = useConnection((s) => s.api);
   const platformHost = useConnection((s) => s.platformHost);
+  const runtimeSlot = useConnection((s) => s.runtimeSlot);
 
   // Make sure apps are available the first time the palette opens.
   useEffect(() => {
@@ -364,7 +365,7 @@ export default function CommandPalette() {
                   key={app.slug}
                   icon={<LayoutGrid size={14} />}
                   label={app.name}
-                  onSelect={() => run(() => openTab({ kind: "app", slug: app.slug, title: app.name, ...(appIconUrl(platformHost, app.slug) ? { icon: appIconUrl(platformHost, app.slug)! } : {}) }))}
+                  onSelect={() => run(() => openTab({ kind: "app", slug: app.slug, title: app.name, ...(appIconUrl(platformHost, app.slug, runtimeSlot) ? { icon: appIconUrl(platformHost, app.slug, runtimeSlot)! } : {}) }))}
                 />
               ))}
             </Command.Group>

--- a/desktop/src/renderer/src/stores/apps.ts
+++ b/desktop/src/renderer/src/stores/apps.ts
@@ -1,5 +1,6 @@
-// Installed Matrix OS apps (GET /api/apps). Loaded lazily and shared by the
-// Apps launcher and the command palette so both list the same set.
+// Installed Matrix OS apps (GET /api/apps). Loaded at desktop startup and
+// shared by the Apps launcher and the command palette so both list the same
+// set.
 import { create } from "zustand";
 import { AppError, type AppErrorCategory } from "../../../shared/app-error";
 import type { ApiClient } from "../lib/api";
@@ -10,12 +11,49 @@ export interface MatrixApp {
   category?: string;
 }
 
+const MAX_APP_ICON_PRELOADS = 20;
+let iconPreloadLinks: HTMLLinkElement[] = [];
+let appsLoadInFlight: Promise<void> | null = null;
+let appsLoadGeneration = 0;
+
 // Apps resolve their icon through the gateway's /icons/{slug}.png, which falls
 // back to shipped assets. Bearer auth is injected by the trusted core for the
 // gateway origin, so the renderer can load it directly.
-export function appIconUrl(platformHost: string, slug: string): string | null {
+export function appIconUrl(platformHost: string, slug: string, runtimeSlot = "primary"): string | null {
   if (!platformHost) return null;
-  return `${platformHost.replace(/\/$/, "")}/icons/${encodeURIComponent(slug)}.png`;
+  const url = `${platformHost.replace(/\/$/, "")}/icons/${encodeURIComponent(slug)}.png`;
+  return runtimeSlot === "primary" ? url : `${url}?runtime=${encodeURIComponent(runtimeSlot)}`;
+}
+
+/**
+ * Retains preload hints for the first Apps-page row set before the page mounts.
+ * The capped links make the browser request icons before the user opens Apps.
+ */
+export function preloadAppIcons(platformHost: string, runtimeSlot: string, apps: readonly MatrixApp[]): void {
+  clearPreloadedAppIcons();
+  if (typeof document === "undefined") return;
+  for (const app of apps.slice(0, MAX_APP_ICON_PRELOADS)) {
+    const url = appIconUrl(platformHost, app.slug, runtimeSlot);
+    if (!url) continue;
+    const link = document.createElement("link");
+    link.rel = "preload";
+    link.setAttribute("as", "image");
+    link.setAttribute("fetchpriority", "low");
+    link.href = url;
+    document.head.append(link);
+    iconPreloadLinks.push(link);
+  }
+}
+
+export function resetAppsRuntime(): void {
+  clearPreloadedAppIcons();
+  appsLoadGeneration += 1;
+  useApps.setState({ apps: [], loaded: false, loading: false, error: null });
+}
+
+function clearPreloadedAppIcons(): void {
+  for (const link of iconPreloadLinks) link.remove();
+  iconPreloadLinks = [];
 }
 
 export function parseApps(value: unknown): MatrixApp[] {
@@ -53,14 +91,25 @@ export const useApps = create<AppsState>()((set, get) => ({
   error: null,
 
   load: async (api, force = false) => {
-    if (get().loading) return;
+    if (get().loading) return appsLoadInFlight ?? Promise.resolve();
     if (get().loaded && !force) return;
     set({ loading: true });
+    const loadGeneration = appsLoadGeneration;
+    const request = (async () => {
+      try {
+        const res = await api.get<unknown>("/api/apps");
+        if (loadGeneration !== appsLoadGeneration) return;
+        set({ apps: parseApps(res), loaded: true, loading: false, error: null });
+      } catch (err: unknown) {
+        if (loadGeneration !== appsLoadGeneration) return;
+        set({ loading: false, loaded: true, error: err instanceof AppError ? err.category : "server" });
+      }
+    })();
+    appsLoadInFlight = request;
     try {
-      const res = await api.get<unknown>("/api/apps");
-      set({ apps: parseApps(res), loaded: true, loading: false, error: null });
-    } catch (err: unknown) {
-      set({ loading: false, loaded: true, error: err instanceof AppError ? err.category : "server" });
+      await request;
+    } finally {
+      if (appsLoadInFlight === request) appsLoadInFlight = null;
     }
   },
 }));

--- a/desktop/src/renderer/src/stores/connection.ts
+++ b/desktop/src/renderer/src/stores/connection.ts
@@ -6,6 +6,7 @@ import { createApiClient, type ApiClient } from "../lib/api";
 import { clearDraftChats } from "./draft-chat";
 import { advanceRuntimeGeneration } from "./runtime-generation";
 import { reconcileDesktopRuntimeChange } from "./runtime-transition";
+import { resetAppsRuntime } from "./apps";
 
 export type ConnectionStatus = "loading" | "signed-out" | "signed-in";
 
@@ -56,6 +57,7 @@ export const useConnection = create<ConnectionState>()((set, get) => ({
       if (identityChanged) {
         advanceRuntimeGeneration();
         clearDraftChats();
+        resetAppsRuntime();
       }
       const api = status.signedIn
         ? createApiClient({
@@ -84,6 +86,7 @@ export const useConnection = create<ConnectionState>()((set, get) => ({
       if (get().status !== "signed-out") {
         advanceRuntimeGeneration();
         clearDraftChats();
+        resetAppsRuntime();
       }
       set({ status: "signed-out", handle: null, displayName: null, imageUrl: null, api: null });
     }

--- a/desktop/src/renderer/src/stores/runtime-transition.ts
+++ b/desktop/src/renderer/src/stores/runtime-transition.ts
@@ -19,6 +19,7 @@ import { useThreads } from "./threads";
 import { useUi } from "./ui";
 import { useWorkspace } from "./workspace";
 import { advanceRuntimeGeneration } from "./runtime-generation";
+import { resetAppsRuntime } from "./apps";
 
 interface RuntimeChangeOptions {
   disposeRuntimeAttachments?: () => void;
@@ -103,6 +104,7 @@ export function reconcileDesktopRuntimeChange(options: RuntimeChangeOptions = {}
     loadingPaths: {},
   });
   useThreads.setState({ threads: [], activeThreadId: null });
+  resetAppsRuntime();
   clearCodingAgentRuntimeSelection();
   clearDraftChats();
   clearProjectWorkspaces();

--- a/tests/desktop/apps-store.test.ts
+++ b/tests/desktop/apps-store.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { appIconUrl, preloadAppIcons, resetAppsRuntime, useApps } from "../../desktop/src/renderer/src/stores/apps";
+
+describe("desktop app icon warmup", () => {
+  afterEach(() => {
+    resetAppsRuntime();
+  });
+
+  it("preloads only the first 20 selected-runtime icons", () => {
+    preloadAppIcons("https://platform.test/", "preview", Array.from({ length: 24 }, (_, index) => ({
+      slug: `app-${index}`,
+      name: `App ${index}`,
+    })));
+
+    const links = [...document.head.querySelectorAll('link[rel="preload"][as="image"]')];
+    expect(links).toHaveLength(20);
+    expect(links[0]?.getAttribute("href")).toBe("https://platform.test/icons/app-0.png?runtime=preview");
+    expect(links.at(-1)?.getAttribute("href")).toBe("https://platform.test/icons/app-19.png?runtime=preview");
+  });
+
+  it("removes preloads when the runtime changes", () => {
+    preloadAppIcons("https://platform.test", "primary", [{ slug: "notes", name: "Notes" }]);
+
+    resetAppsRuntime();
+
+    expect(document.head.querySelectorAll('link[rel="preload"][as="image"]')).toHaveLength(0);
+  });
+
+  it("waits for an already-running catalog request before a second consumer continues", async () => {
+    let resolveCatalog!: (value: unknown) => void;
+    const api = {
+      get: vi.fn(() => new Promise<unknown>((resolve) => {
+        resolveCatalog = resolve;
+      })),
+    };
+
+    const first = useApps.getState().load(api as never);
+    const second = useApps.getState().load(api as never);
+    resolveCatalog({ apps: [{ slug: "notes", name: "Notes" }] });
+
+    await Promise.all([first, second]);
+
+    expect(api.get).toHaveBeenCalledOnce();
+    expect(useApps.getState().apps).toEqual([{ slug: "notes", name: "Notes" }]);
+  });
+
+  it("preserves the primary-runtime icon URL", () => {
+    expect(appIconUrl("https://platform.test/", "notes")).toBe("https://platform.test/icons/notes.png");
+  });
+});

--- a/tests/desktop/connection-store.test.ts
+++ b/tests/desktop/connection-store.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@desktop/renderer/src/stores/connection";
 import { useBoard } from "@desktop/renderer/src/stores/board";
 import { clearDraftChats, useDraftChat } from "@desktop/renderer/src/stores/draft-chat";
+import { useApps } from "@desktop/renderer/src/stores/apps";
 
 type Listener = (payload: unknown) => void;
 
@@ -203,6 +204,24 @@ describe("connection event wiring", () => {
     expect(useConnection.getState().status).toBe("signed-out");
     expect(useConnection.getState().api).toBeNull();
     expect(warn).toHaveBeenCalledWith("[connection] failed to refresh auth status:", "ipc unavailable");
+  });
+
+  it("clears app catalog state when auth status lookup fails", async () => {
+    useConnection.setState({ status: "signed-in", handle: "old-owner" });
+    useApps.setState({
+      apps: [{ slug: "private-app", name: "Private app" }],
+      loaded: true,
+      loading: false,
+      error: null,
+    });
+    window.operator = {
+      invoke: vi.fn().mockRejectedValue(new Error("ipc unavailable")),
+      on: vi.fn(),
+    };
+
+    await useConnection.getState().refresh();
+
+    expect(useApps.getState()).toMatchObject({ apps: [], loaded: false, loading: false, error: null });
   });
 
   it("unwires auth and runtime listeners so tests can reinitialize the bridge", async () => {

--- a/tests/desktop/mission-control.test.tsx
+++ b/tests/desktop/mission-control.test.tsx
@@ -9,6 +9,7 @@ import { useConnection } from "../../desktop/src/renderer/src/stores/connection"
 import { useBoard, type Project } from "../../desktop/src/renderer/src/stores/board";
 import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
 import { useShellSessions } from "../../desktop/src/renderer/src/stores/shell-sessions";
+import { useApps } from "../../desktop/src/renderer/src/stores/apps";
 import { useUi } from "../../desktop/src/renderer/src/stores/ui";
 
 vi.mock("../../desktop/src/renderer/src/features/mission-control/Sidebar", () => ({
@@ -54,6 +55,7 @@ vi.mock("../../desktop/src/renderer/src/lib/kernel-wiring", () => ({
 describe("MissionControl", () => {
   beforeEach(() => {
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    useApps.setState(useApps.getInitialState(), true);
     useShellSessions.setState({
       ...useShellSessions.getInitialState(),
       load: vi.fn().mockResolvedValue([]),
@@ -143,6 +145,40 @@ describe("MissionControl", () => {
     render(<MissionControl />);
 
     await waitFor(() => expect(load).toHaveBeenCalledWith(api));
+  });
+
+  it("warms the app catalog before the Apps tab is opened", async () => {
+    const api = { get: vi.fn() };
+    const load = vi.fn().mockResolvedValue(undefined);
+    useApps.setState({ apps: [], loaded: false, loading: false, error: null, load });
+    useBoard.setState({ loadProjects: vi.fn(async () => undefined) });
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: api as never,
+    });
+
+    render(<MissionControl />);
+
+    await waitFor(() => expect(load).toHaveBeenCalledWith(api));
+  });
+
+  it("warms resolved catalog icons during desktop startup", async () => {
+    const api = { get: vi.fn().mockResolvedValue({ apps: [{ slug: "notes", name: "Notes" }] }) };
+    useBoard.setState({ loadProjects: vi.fn(async () => undefined) });
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      api: api as never,
+    });
+
+    render(<MissionControl />);
+
+    await waitFor(() => expect(document.head.querySelector('link[href="https://platform.test/icons/notes.png"]')).not.toBeNull());
   });
 
   it("restarts shell synchronization when the selected runtime changes", async () => {

--- a/tests/desktop/runtime-transition.test.ts
+++ b/tests/desktop/runtime-transition.test.ts
@@ -14,6 +14,7 @@ import { useShellSessions } from "../../desktop/src/renderer/src/stores/shell-se
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 import { useThreads } from "../../desktop/src/renderer/src/stores/threads";
 import { useWorkspace } from "../../desktop/src/renderer/src/stores/workspace";
+import { useApps } from "../../desktop/src/renderer/src/stores/apps";
 
 describe("desktop runtime transition", () => {
   beforeEach(() => {
@@ -36,6 +37,12 @@ describe("desktop runtime transition", () => {
     useWorkspace.setState({ entries: [{ taskId: "task_old", lastFocusedAt: 1, live: true }] });
     useEditorTabs.setState({ tabsByTask: { task_old: ["README.md"] }, activePathByTask: { task_old: "README.md" }, dirtyPathsByTask: {} });
     useThreads.setState({ threads: [], activeThreadId: "thread_old" });
+    useApps.setState({
+      apps: [{ slug: "old-app", name: "Old app" }],
+      loaded: true,
+      loading: false,
+      error: null,
+    });
     useCodingAgentWorkspace.setState({ activeThreadId: "thread_old", selectedReviewId: "review_old" });
     useProjectWorkspaces.setState({
       entries: {
@@ -67,6 +74,7 @@ describe("desktop runtime transition", () => {
     expect(useWorkspace.getState().entries).toEqual([]);
     expect(useEditorTabs.getState().tabsByTask).toEqual({});
     expect(useThreads.getState()).toMatchObject({ threads: [], activeThreadId: null });
+    expect(useApps.getState()).toMatchObject({ apps: [], loaded: false, loading: false, error: null });
     expect(useCodingAgentWorkspace.getState()).toMatchObject({ activeThreadId: null, selectedReviewId: null });
     expect(useProjectWorkspaces.getState().entries).toEqual({});
     expect(useProjectView.getState().entries).toEqual({});


### PR DESCRIPTION
Summary:
- Load the app catalog during signed-in desktop startup.
- Preload the first 20 app icons and scope them to the active runtime.
- Clear catalog and preload state on runtime, identity, and auth failures.

Rationale:
- Avoid the first Apps-page catalog and icon loading waterfall.
- Keep preloading bounded while preventing state from crossing runtimes.

Tests:
- pnpm --filter desktop typecheck
- pnpm run check:patterns
- pnpm exec vitest run focused desktop suites (51 passed)

Co-authored-by: Codex <codex@openai.com>
