### PR TITLE
fix(platform): normalize preview provider image ids

### DIFF
--- a/packages/platform/src/golden-snapshot-preview-test.ts
+++ b/packages/platform/src/golden-snapshot-preview-test.ts
@@ -308,6 +308,14 @@ const CreateIntentInputSchema = z.object({
   now: IsoDateSchema,
 }).strict();
 
+const PreviewProviderImageIdSchema = z.coerce.number().int().positive()
+  .max(Number.MAX_SAFE_INTEGER);
+
+export function normalizePreviewTestProviderImageId(value: unknown): number | undefined {
+  const parsed = PreviewProviderImageIdSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+}
+
 export async function createPreviewTestSnapshotCreateIntent(
   db: PlatformDB,
   rawInput: z.input<typeof CreateIntentInputSchema>,
@@ -326,7 +334,7 @@ export async function createPreviewTestSnapshotCreateIntent(
       'provider_image_id', 'provider_image_status', 'base_generation',
     ]).where('snapshot_id', '=', input.snapshotId).forUpdate().executeTakeFirst();
     if (!snapshot || !snapshot.test_mode || snapshot.state !== 'ready'
-      || snapshot.provider_image_id !== input.providerImageId
+      || normalizePreviewTestProviderImageId(snapshot.provider_image_id) !== input.providerImageId
       || snapshot.provider_image_status !== 'available') return undefined;
     const revoked = await trx.executor.selectFrom('golden_snapshot_revoked_base_generations')
       .select('base_generation').where('base_generation', '=', snapshot.base_generation).executeTakeFirst();

--- a/tests/platform/golden-snapshot-provisioning.test.ts
+++ b/tests/platform/golden-snapshot-provisioning.test.ts
@@ -34,6 +34,7 @@ import { loadCustomerVpsConfig } from '../../packages/platform/src/customer-vps-
 import { CustomerVpsError } from '../../packages/platform/src/customer-vps-errors.js';
 import { hashRegistrationToken } from '../../packages/platform/src/customer-vps-auth.js';
 import { createMockCustomerVpsSystemStore, createMockHetznerClient } from './customer-vps-fixtures.js';
+import { normalizePreviewTestProviderImageId } from '../../packages/platform/src/golden-snapshot-preview-test.js';
 
 const compatibility = {
   provider: 'hetzner' as const, architecture: 'x86' as const, region: 'eu-central', baseImage: 'ubuntu-24.04',
@@ -75,6 +76,10 @@ describe('golden snapshot provisioning activation', () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     await destroyTestPlatformDb(db);
+  });
+
+  it('normalizes Postgres BIGINT provider image ids before exact preview comparison', () => {
+    expect(normalizePreviewTestProviderImageId('422202690')).toBe(422202690);
   });
 
   async function readySnapshot(version: 'v1' | 'v2', imageId: number, testMode = false) {


### PR DESCRIPTION
## Summary
- normalize Postgres `BIGINT` provider image IDs before exact preview-snapshot comparison
- preserve fail-closed behavior for invalid or unsafe provider IDs
- cover the production-shaped string ID returned by node-postgres

## Why
Production returned `provider_image_id` as a string while the exact preview guard compared it strictly to a number. The identical provider image was rejected, so the create intent was never persisted and Hetzner was never called.

## Tests
- TDD red: new bigint regression failed before implementation
- `pnpm exec vitest run tests/platform/golden-snapshot-provisioning.test.ts --reporter=dot` (37/37)
- `bun run typecheck`
- `pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json`
- `bun run check:patterns:diff` (0 violations)
- `git diff --check`

## Review / monitoring
- Disposable v988 reproduction logged `internalReason=create_intent_unavailable`
- Production DB showed `provider_image_id` as `"422202690"` and no create intent
- Customer golden-snapshot rollout remains disabled at 0%

## Invariants
- **Source of truth:** the persisted provider image ID bound to the exact test snapshot
- **Lock / transaction scope:** existing snapshot, lease, and create-intent transaction is unchanged
- **Acceptable orphan states:** unchanged; no provider call occurs until the create intent is durably linked
- **Auth source of truth:** existing operator-only preview provisioning authorization is unchanged
- **Deferred scope:** customer snapshot rollout remains disabled; this PR only repairs the operator exact-snapshot test path