### PR TITLE
fix(desktop): suppress external browser in automated checks

### DIFF
--- a/.agents/skills/launch-app/SKILL.md
+++ b/.agents/skills/launch-app/SKILL.md
@@ -22,6 +22,17 @@ bun run dev:shell
 bun run dev:platform
 ```
 
+For automated or agent-driven Electron checks that exercise the stub device
+authorization flow, disable system-browser side effects explicitly:
+
+```bash
+OPERATOR_DISABLE_EXTERNAL_BROWSER=1 bun run dev:desktop
+```
+
+Keep this variable unset for manual authentication checks. Desktop E2E tests
+set it centrally through `vitest.e2e.config.ts` so clicking **Continue in
+browser** can complete stub authorization without stealing foreground focus.
+
 ## Bundled Default Apps
 
 First-party apps live under `home/apps/**` and build to `dist/`.

--- a/desktop/src/main/external-url.ts
+++ b/desktop/src/main/external-url.ts
@@ -1,5 +1,10 @@
 const MAX_EXTERNAL_URL_LENGTH = 2048;
 
+interface ExternalHttpUrlOpenerOptions {
+  disabled: boolean;
+  openExternal: (url: string) => Promise<void>;
+}
+
 export function safeExternalHttpUrl(raw: string): string | null {
   let parsed: URL;
   try {
@@ -16,4 +21,15 @@ export function safeExternalHttpUrl(raw: string): string | null {
     return null;
   }
   return parsed.toString();
+}
+
+export function createExternalHttpUrlOpener({
+  disabled,
+  openExternal,
+}: ExternalHttpUrlOpenerOptions): (url: string) => Promise<void> {
+  return async (url) => {
+    const externalUrl = safeExternalHttpUrl(url);
+    if (!externalUrl || disabled) return;
+    await openExternal(externalUrl);
+  };
 }

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -36,7 +36,7 @@ import { registerIpcHandlers } from "./ipc/handlers";
 import { createLocalStore } from "./persistence/local-store";
 import { installAppMenu } from "./platform/menu";
 import { createUpdater } from "./updates";
-import { safeExternalHttpUrl } from "./external-url";
+import { createExternalHttpUrlOpener } from "./external-url";
 import { EVENT_CHANNELS, type EventChannel, type EventPayload } from "../shared/ipc-contract";
 
 const DEFAULT_PLATFORM_HOST = "https://app.matrix-os.com";
@@ -82,11 +82,10 @@ function sendEvent<C extends EventChannel>(channel: C, payload: EventPayload<C>)
   mainWindow?.webContents.send(channel, parsed.data);
 }
 
-async function openExternalHttpUrl(url: string): Promise<void> {
-  const externalUrl = safeExternalHttpUrl(url);
-  if (!externalUrl) return;
-  await shell.openExternal(externalUrl);
-}
+const openExternalHttpUrl = createExternalHttpUrlOpener({
+  disabled: process.env.OPERATOR_DISABLE_EXTERNAL_BROWSER === "1",
+  openExternal: (url) => shell.openExternal(url),
+});
 
 function createWindow(bounds: { x?: number; y?: number; width: number; height: number }): BrowserWindow {
   const win = new BrowserWindow({

--- a/tests/desktop/external-url.test.ts
+++ b/tests/desktop/external-url.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { safeExternalHttpUrl } from "@desktop/main/external-url";
+import {
+  createExternalHttpUrlOpener,
+  safeExternalHttpUrl,
+} from "@desktop/main/external-url";
 
 describe("safeExternalHttpUrl", () => {
   it("allows normalized HTTP and HTTPS URLs", () => {
@@ -13,5 +16,33 @@ describe("safeExternalHttpUrl", () => {
     expect(safeExternalHttpUrl("javascript:alert(1)")).toBeNull();
     expect(safeExternalHttpUrl("https://user:pass@example.org/private")).toBeNull();
     expect(safeExternalHttpUrl("not a URL")).toBeNull();
+  });
+
+  it("suppresses operating-system browser launches during automated Desktop checks", async () => {
+    const opened: string[] = [];
+    const openExternalHttpUrl = createExternalHttpUrlOpener({
+      disabled: true,
+      openExternal: async (url) => {
+        opened.push(url);
+      },
+    });
+
+    await openExternalHttpUrl("https://example.test/activate");
+
+    expect(opened).toEqual([]);
+  });
+
+  it("opens safe URLs when automation suppression is disabled", async () => {
+    const opened: string[] = [];
+    const openExternalHttpUrl = createExternalHttpUrlOpener({
+      disabled: false,
+      openExternal: async (url) => {
+        opened.push(url);
+      },
+    });
+
+    await openExternalHttpUrl("https://app.matrix-os.com/auth/device");
+
+    expect(opened).toEqual(["https://app.matrix-os.com/auth/device"]);
   });
 });

--- a/tests/e2e/desktop/external-browser-suppression.e2e.test.ts
+++ b/tests/e2e/desktop/external-browser-suppression.e2e.test.ts
@@ -1,0 +1,68 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { _electron, type ElectronApplication, type Page } from "playwright";
+import { startStubGateway, type StubGateway } from "./fixtures/stub-gateway";
+
+const DESKTOP_MAIN = resolve(__dirname, "../../../desktop/out/main/index.js");
+const desktopRequire = createRequire(resolve(__dirname, "../../../desktop/package.json"));
+const ELECTRON_EXECUTABLE = desktopRequire("electron") as string;
+const EVIDENCE_DIR = resolve(__dirname, "../../../output/playwright/mat-452");
+const suite = existsSync(DESKTOP_MAIN) ? describe : describe.skip;
+
+suite("automated Desktop external-browser policy", () => {
+  let app: ElectronApplication;
+  let gateway: StubGateway;
+  let page: Page;
+  let userDataDir: string;
+
+  beforeAll(async () => {
+    mkdirSync(EVIDENCE_DIR, { recursive: true });
+    gateway = await startStubGateway();
+    userDataDir = mkdtempSync(join(tmpdir(), "matrix-os-browser-suppression-"));
+    app = await _electron.launch({
+      executablePath: ELECTRON_EXECUTABLE,
+      args: [DESKTOP_MAIN],
+      env: {
+        ...process.env,
+        OPERATOR_GATEWAY_URL: gateway.url,
+        OPERATOR_USER_DATA_DIR: userDataDir,
+      },
+    });
+    page = await app.firstWindow();
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.close();
+    await gateway?.close();
+    if (userDataDir) rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  it("completes stub authorization without invoking the operating-system browser", async () => {
+    await app.evaluate(({ shell }) => {
+      const state = globalThis as typeof globalThis & { openedExternalUrls?: string[] };
+      state.openedExternalUrls = [];
+      shell.openExternal = async (url) => {
+        state.openedExternalUrls?.push(url);
+      };
+    });
+
+    await page.getByRole("button", { name: /continue in browser/i }).click();
+    await page.locator("aside button", { hasText: "Terminal" }).first().waitFor({
+      timeout: 15_000,
+    });
+
+    const openedExternalUrls = await app.evaluate(() => {
+      const state = globalThis as typeof globalThis & { openedExternalUrls?: string[] };
+      return state.openedExternalUrls ?? [];
+    });
+    expect(openedExternalUrls).toEqual([]);
+    expect(gateway.state.tokenRequests).toBeGreaterThan(0);
+
+    await page.screenshot({
+      path: join(EVIDENCE_DIR, "stub-auth-without-external-browser.png"),
+    });
+  }, 30_000);
+});

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
     },
   },
   test: {
+    env: {
+      OPERATOR_DISABLE_EXTERNAL_BROWSER: "1",
+    },
     globals: true,
     include: ["tests/e2e/**/*.e2e.test.ts"],
     testTimeout: 30_000,


### PR DESCRIPTION
## Summary

- add an explicit automation-only external-browser suppression policy at the trusted Electron main-process boundary
- enable the policy centrally for Desktop E2E and document agent-driven launch usage
- add unit coverage and a real built-Electron regression test

## Root cause

The Desktop stub gateway returns `https://example.test/activate`. The renderer automatically sends the verification URL through `shell:open-external`, while E2E launchers inherited the real Electron `shell.openExternal` behavior. Automated checks therefore opened the user's system browser and stole foreground focus.

## Tests

- `flox activate -- bun run test -- tests/desktop/external-url.test.ts tests/desktop/ipc-handlers.test.ts tests/desktop/signin-device-auth.test.tsx` — 52 passed
- `flox activate -- bun run build:desktop` — passed
- `flox activate -- bun run test:e2e -- tests/e2e/desktop/external-browser-suppression.e2e.test.ts` — passed against the real built Electron app; zero external browser calls
- `flox activate -- bun run typecheck` — passed
- `flox activate -- bun run check:patterns` — zero violations; five pre-existing warnings
- `flox activate -- bun run test` — 10,956 passed, 28 failed across 19 files, 20 skipped. All failures are outside this diff and include environment/tooling failures in UI test setup, macOS/Linux host-script incompatibilities, Unix socket path failures, and unrelated Codex/terminal timeout suites.

## Invariants

- **Source of truth:** Electron main process remains the sole owner of external-navigation policy; the renderer cannot bypass it.
- **Lock/transaction scope:** N/A — no persistence or database changes.
- **Acceptable orphan states:** N/A — no durable resources are created.
- **Auth source of truth:** Device authorization and polling are unchanged; only the OS browser side effect is suppressed when explicitly requested.
- **Deferred scope:** Manual and production authentication keep their browser handoff. Embedded web-content navigation is outside this issue.

Closes MAT-452
