### PR TITLE
fix(platform): honor snapshot creation deadline

### DIFF
--- a/packages/platform/src/golden-snapshot-repository.ts
+++ b/packages/platform/src/golden-snapshot-repository.ts
@@ -642,7 +642,10 @@ export async function claimGoldenSnapshotBuild(
       .select('build_id')
       .where('build_id', '=', buildId)
       .where('status', '=', 'running')
-      .where('attempts', '<', maxAttempts)
+      .where((eb) => eb.or([
+        eb('attempts', '<', maxAttempts),
+        eb('phase', '=', 'snapshot_wait'),
+      ]))
       .where('lease_expires_at', '<=', now)
       .where((eb) => eb.or([
         eb('phase', 'not in', ['builder_boot', 'validation_boot']),
@@ -655,9 +658,14 @@ export async function claimGoldenSnapshotBuild(
       return undefined;
     }
     const row = await trx.executor.updateTable('golden_snapshot_builds').set({
-      status: 'running', attempts: sql<number>`attempts + 1`, claimed_at: now,
+      status: 'running',
+      attempts: sql<number>`CASE WHEN phase = 'snapshot_wait' THEN attempts ELSE attempts + 1 END`,
+      claimed_at: now,
       lease_expires_at: leaseExpiresAt, updated_at: now,
-    }).where('build_id', '=', buildId).where('attempts', '<', maxAttempts)
+    }).where('build_id', '=', buildId).where((eb) => eb.or([
+      eb('attempts', '<', maxAttempts),
+      eb('phase', '=', 'snapshot_wait'),
+    ]))
       .where('phase', 'not in', ['builder_boot', 'validation_boot'])
       .where((eb) => eb.exists(
         eb.selectFrom('golden_snapshots').select('snapshot_id')
@@ -690,6 +698,7 @@ async function terminalizeExhaustedGoldenSnapshotBuild(
   const exhausted = await trx.executor.selectFrom('golden_snapshot_builds').selectAll()
     .where('build_id', '=', buildId).where('status', '=', 'running')
     .where('attempts', '>=', maxAttempts).where('lease_expires_at', '<=', now)
+    .where('phase', '!=', 'snapshot_wait')
     .where((eb) => eb.or([
       eb('phase', 'not in', ['builder_boot', 'validation_boot']),
       eb('callback_expires_at', 'is', null),
@@ -763,6 +772,7 @@ export async function claimGoldenSnapshotBuildBatch(
     const exhausted = await trx.executor.selectFrom('golden_snapshot_builds').select('build_id')
       .where('status', '=', 'running').where('attempts', '>=', maxAttempts)
       .where('lease_expires_at', '<=', now)
+      .where('phase', '!=', 'snapshot_wait')
       .where((eb) => eb.or([
         eb('phase', 'not in', ['builder_boot', 'validation_boot']),
         eb('callback_expires_at', 'is', null),
@@ -775,7 +785,10 @@ export async function claimGoldenSnapshotBuildBatch(
     }
     const reclaimable = await trx.executor.selectFrom('golden_snapshot_builds')
       .select('build_id')
-      .where('attempts', '<', maxAttempts)
+      .where((eb) => eb.or([
+        eb('attempts', '<', maxAttempts),
+        eb('phase', '=', 'snapshot_wait'),
+      ]))
       .where('phase', 'not in', ['builder_boot', 'validation_boot'])
       .where((eb) => eb.exists(
         eb.selectFrom('golden_snapshots').select('snapshot_id')
@@ -815,12 +828,15 @@ export async function claimGoldenSnapshotBuildBatch(
     for (const candidate of reclaimable) {
       const row = await trx.executor.updateTable('golden_snapshot_builds').set({
         status: 'running',
-        attempts: sql<number>`attempts + 1`,
+        attempts: sql<number>`CASE WHEN phase = 'snapshot_wait' THEN attempts ELSE attempts + 1 END`,
         claimed_at: now,
         lease_expires_at: leaseExpiresAt,
         updated_at: now,
       }).where('build_id', '=', candidate.build_id)
-        .where('attempts', '<', maxAttempts)
+        .where((eb) => eb.or([
+          eb('attempts', '<', maxAttempts),
+          eb('phase', '=', 'snapshot_wait'),
+        ]))
         .where('phase', 'not in', ['builder_boot', 'validation_boot'])
         .where('status', '=', 'running')
         .where('lease_expires_at', '<=', now)

--- a/packages/platform/src/golden-snapshot-service.ts
+++ b/packages/platform/src/golden-snapshot-service.ts
@@ -1004,7 +1004,19 @@ export function createGoldenSnapshotService(rawDeps: GoldenSnapshotServiceDeps):
         }
         return 'snapshot_wait';
       }
-      if (image.status !== 'available' || (action !== null && action.status !== 'success')) return 'snapshot_wait';
+      if (image.status !== 'available' || (action !== null && action.status !== 'success')) {
+        if (!build.callbackExpiresAt || build.callbackExpiresAt <= at) {
+          await quarantine(
+            buildId,
+            snapshot.snapshotId,
+            'snapshot_creation_timeout',
+            at,
+            build.phase,
+          );
+          throw new Error('Golden snapshot creation timed out');
+        }
+        return 'snapshot_wait';
+      }
       if (image.architecture !== snapshot.compatibility.architecture || image.deleteProtected) {
         await quarantine(buildId, snapshot.snapshotId, 'image_incompatible', at, build.phase);
         throw new Error('Golden snapshot image compatibility validation failed');

--- a/packages/platform/src/golden-snapshot-service.ts
+++ b/packages/platform/src/golden-snapshot-service.ts
@@ -947,16 +947,43 @@ export function createGoldenSnapshotService(rawDeps: GoldenSnapshotServiceDeps):
     }
 
     if (build.phase === 'snapshot_wait') {
-      let image = snapshot.providerImageId === null
+      const readProviderState = async <T>(context: string, read: () => Promise<T>): Promise<T> => {
+        try {
+          return await read();
+        } catch (err: unknown) {
+          if (!build.callbackExpiresAt || build.callbackExpiresAt <= at) {
+            await quarantine(
+              buildId,
+              snapshot.snapshotId,
+              'snapshot_creation_timeout',
+              at,
+              build.phase,
+            );
+            throw new Error('Golden snapshot creation timed out');
+          }
+          throw providerFailure(context, err);
+        }
+      };
+      const providerImageId = snapshot.providerImageId;
+      const providerSnapshotActionId = build.providerSnapshotActionId;
+      let image = providerImageId === null
         ? null
-        : await deps.hetzner.getImage(snapshot.providerImageId);
-      const action = build.providerSnapshotActionId === null
+        : await readProviderState(
+          'snapshot image confirmation',
+          () => deps.hetzner.getImage(providerImageId),
+        );
+      const action = providerSnapshotActionId === null
         ? null
-        : await deps.hetzner.getAction(build.providerSnapshotActionId);
+        : await readProviderState(
+          'snapshot action confirmation',
+          () => deps.hetzner.getAction(providerSnapshotActionId),
+        );
       if (snapshot.providerImageId === null) {
         const selector = `matrix.snapshot-build=${buildId},matrix.snapshot-id=${snapshot.snapshotId}`;
-        const candidates = (await deps.hetzner.listImagesByLabel(selector)).filter((candidate) =>
-          candidate.labels['matrix.snapshot-build'] === buildId
+        const candidates = (await readProviderState(
+          'snapshot image reconciliation',
+          () => deps.hetzner.listImagesByLabel(selector),
+        )).filter((candidate) => candidate.labels['matrix.snapshot-build'] === buildId
           && candidate.labels['matrix.snapshot-id'] === snapshot.snapshotId
           && candidate.labels['matrix.role'] === 'builder');
         if (candidates.length > 1) {

--- a/packages/platform/src/golden-snapshot-service.ts
+++ b/packages/platform/src/golden-snapshot-service.ts
@@ -954,7 +954,14 @@ export function createGoldenSnapshotService(rawDeps: GoldenSnapshotServiceDeps):
           observedAt,
         };
       };
-      const readProviderState = async <T>(context: string, read: () => Promise<T>): Promise<T> => {
+      const readProviderState = async <T>(
+        context: string,
+        read: () => Promise<T>,
+        expiredFailure: { code: string; message: string } = {
+          code: 'snapshot_creation_timeout',
+          message: 'Golden snapshot creation timed out',
+        },
+      ): Promise<T> => {
         try {
           return await read();
         } catch (err: unknown) {
@@ -963,11 +970,11 @@ export function createGoldenSnapshotService(rawDeps: GoldenSnapshotServiceDeps):
             await quarantine(
               buildId,
               snapshot.snapshotId,
-              'snapshot_creation_timeout',
+              expiredFailure.code,
               deadline.observedAt,
               build.phase,
             );
-            throw new Error('Golden snapshot creation timed out');
+            throw new Error(expiredFailure.message);
           }
           throw providerFailure(context, err);
         }
@@ -991,6 +998,10 @@ export function createGoldenSnapshotService(rawDeps: GoldenSnapshotServiceDeps):
         const candidates = (await readProviderState(
           'snapshot image reconciliation',
           () => deps.hetzner.listImagesByLabel(selector),
+          {
+            code: 'snapshot_create_unresolved',
+            message: 'Golden snapshot image recovery window expired',
+          },
         )).filter((candidate) => candidate.labels['matrix.snapshot-build'] === buildId
           && candidate.labels['matrix.snapshot-id'] === snapshot.snapshotId
           && candidate.labels['matrix.role'] === 'builder');

--- a/packages/platform/src/golden-snapshot-service.ts
+++ b/packages/platform/src/golden-snapshot-service.ts
@@ -947,16 +947,24 @@ export function createGoldenSnapshotService(rawDeps: GoldenSnapshotServiceDeps):
     }
 
     if (build.phase === 'snapshot_wait') {
+      const observeDeadline = (): { expired: boolean; observedAt: string } => {
+        const observedAt = now();
+        return {
+          expired: !build.callbackExpiresAt || build.callbackExpiresAt <= observedAt,
+          observedAt,
+        };
+      };
       const readProviderState = async <T>(context: string, read: () => Promise<T>): Promise<T> => {
         try {
           return await read();
         } catch (err: unknown) {
-          if (!build.callbackExpiresAt || build.callbackExpiresAt <= at) {
+          const deadline = observeDeadline();
+          if (deadline.expired) {
             await quarantine(
               buildId,
               snapshot.snapshotId,
               'snapshot_creation_timeout',
-              at,
+              deadline.observedAt,
               build.phase,
             );
             throw new Error('Golden snapshot creation timed out');
@@ -1009,10 +1017,18 @@ export function createGoldenSnapshotService(rawDeps: GoldenSnapshotServiceDeps):
               now: at,
             },
           )) throw new Error('Golden snapshot build lease lost during image adoption');
-        } else if (build.callbackExpiresAt && build.callbackExpiresAt <= at) {
-          await quarantine(buildId, snapshot.snapshotId, 'snapshot_create_unresolved', at, build.phase);
-          throw new Error('Golden snapshot image recovery window expired');
         } else {
+          const deadline = observeDeadline();
+          if (deadline.expired) {
+            await quarantine(
+              buildId,
+              snapshot.snapshotId,
+              'snapshot_create_unresolved',
+              deadline.observedAt,
+              build.phase,
+            );
+            throw new Error('Golden snapshot image recovery window expired');
+          }
           return 'snapshot_wait';
         }
       }
@@ -1025,19 +1041,27 @@ export function createGoldenSnapshotService(rawDeps: GoldenSnapshotServiceDeps):
         throw new Error('Golden snapshot image validation failed');
       }
       if (action === null && (build.providerSnapshotActionId !== null || image.status !== 'available')) {
-        if (build.callbackExpiresAt && build.callbackExpiresAt <= at) {
-          await quarantine(buildId, snapshot.snapshotId, 'snapshot_action_unconfirmed', at, build.phase);
+        const deadline = observeDeadline();
+        if (deadline.expired) {
+          await quarantine(
+            buildId,
+            snapshot.snapshotId,
+            'snapshot_action_unconfirmed',
+            deadline.observedAt,
+            build.phase,
+          );
           throw new Error('Golden snapshot action confirmation timed out');
         }
         return 'snapshot_wait';
       }
       if (image.status !== 'available' || (action !== null && action.status !== 'success')) {
-        if (!build.callbackExpiresAt || build.callbackExpiresAt <= at) {
+        const deadline = observeDeadline();
+        if (deadline.expired) {
           await quarantine(
             buildId,
             snapshot.snapshotId,
             'snapshot_creation_timeout',
-            at,
+            deadline.observedAt,
             build.phase,
           );
           throw new Error('Golden snapshot creation timed out');

--- a/tests/platform/golden-snapshot-repository.test.ts
+++ b/tests/platform/golden-snapshot-repository.test.ts
@@ -869,6 +869,52 @@ describe('golden snapshot repository', () => {
     ]);
   });
 
+  it('renews snapshot waits without consuming the generic retry budget', async () => {
+    const enqueued = await enqueueGoldenSnapshotBuild(db, {
+      bundleVersion: 'v1', compatibility,
+      snapshotId: '10000000-0000-4000-8000-000000000053',
+      buildId: '20000000-0000-4000-8000-000000000053',
+      now: '2026-07-03T00:00:00.000Z',
+    });
+    await db.executor.updateTable('golden_snapshots').set({
+      state: 'sanitizing', provider_image_id: 953, provider_image_status: 'creating',
+      image_architecture: 'x86', image_disk_gb: 40,
+    }).where('snapshot_id', '=', enqueued.snapshot.snapshotId).execute();
+    await db.executor.updateTable('golden_snapshot_builds').set({
+      status: 'running', phase: 'snapshot_wait', attempts: 1,
+      lease_expires_at: '2026-07-03T00:01:00.000Z',
+      callback_expires_at: '2026-07-03T00:30:00.000Z',
+      provider_snapshot_action_id: 1053,
+    }).where('build_id', '=', enqueued.build.buildId).execute();
+
+    await expect(claimGoldenSnapshotBuildBatch(
+      db, '2026-07-03T00:02:00.000Z', '2026-07-03T00:07:00.000Z', 1, 10, 2,
+    )).resolves.toEqual([
+      expect.objectContaining({
+        buildId: enqueued.build.buildId, phase: 'snapshot_wait', attempts: 1,
+        leaseExpiresAt: '2026-07-03T00:07:00.000Z',
+      }),
+    ]);
+    await expect(claimGoldenSnapshotBuildBatch(
+      db, '2026-07-03T00:08:00.000Z', '2026-07-03T00:13:00.000Z', 1, 10, 2,
+    )).resolves.toEqual([
+      expect.objectContaining({
+        buildId: enqueued.build.buildId, phase: 'snapshot_wait', attempts: 1,
+        leaseExpiresAt: '2026-07-03T00:13:00.000Z',
+      }),
+    ]);
+    await expect(claimGoldenSnapshotBuild(
+      db, enqueued.build.buildId,
+      '2026-07-03T00:14:00.000Z', '2026-07-03T00:19:00.000Z', 1,
+    )).resolves.toMatchObject({
+      buildId: enqueued.build.buildId, phase: 'snapshot_wait', attempts: 1,
+      leaseExpiresAt: '2026-07-03T00:19:00.000Z',
+    });
+    await expect(getGoldenSnapshot(db, enqueued.snapshot.snapshotId)).resolves.toMatchObject({
+      state: 'sanitizing', failureCode: null,
+    });
+  });
+
   it('finalizes exhausted expired builds before the bounded batch claims new work', async () => {
     const exhausted = await enqueueGoldenSnapshotBuild(db, {
       bundleVersion: 'v1', compatibility,

--- a/tests/platform/golden-snapshot-service.test.ts
+++ b/tests/platform/golden-snapshot-service.test.ts
@@ -589,6 +589,47 @@ describe('golden snapshot build service', () => {
     },
   );
 
+  it.each(['resolved', 'rejected'] as const)(
+    'fails an expired provider snapshot when an in-flight image read is %s after the deadline',
+    async (outcome) => {
+      let currentTime = '2026-07-03T00:01:00.000Z';
+      const pendingImage = {
+        id: 301, status: 'creating' as const, type: 'snapshot' as const,
+        architecture: 'x86' as const, diskGb: 40, labels: {}, deleteProtected: false,
+      };
+      const getImage = vi.fn().mockImplementation(async () => {
+        currentTime = '2026-07-03T00:32:00.000Z';
+        if (outcome === 'rejected') throw new Error('synthetic provider outage');
+        return pendingImage;
+      });
+      const { enqueued, service } = await setup({
+        createSnapshot: vi.fn().mockResolvedValue({
+          image: pendingImage,
+          action: { id: 401, status: 'running', command: 'create_image' },
+        }),
+        getImage,
+        getAction: vi.fn()
+          .mockResolvedValueOnce({ id: 201, status: 'success', command: 'create_server' })
+          .mockResolvedValue({ id: 401, status: 'running', command: 'create_image' }),
+      }, () => currentTime);
+      await service.runBuildStep(enqueued.build.buildId);
+      await service.consumeCallback(enqueued.build.buildId, 'phase-token-long-enough', {
+        eventId: randomUUID(), phase: 'sanitized', bundleVersion: 'v1',
+        bundleSha256: '1'.repeat(64), ...builderFingerprints,
+      });
+      await expect(service.runBuildStep(enqueued.build.buildId)).resolves.toBe('snapshot_wait');
+
+      await expect(service.runBuildStep(enqueued.build.buildId))
+        .rejects.toThrow('Golden snapshot creation timed out');
+      await expect(getGoldenSnapshotBuild(db, enqueued.build.buildId)).resolves.toMatchObject({
+        phase: 'failed', status: 'failed', lastErrorCode: 'snapshot_creation_timeout',
+      });
+      await expect(getGoldenSnapshot(db, enqueued.snapshot.snapshotId)).resolves.toMatchObject({
+        state: 'quarantined', failureCode: 'snapshot_creation_timeout',
+      });
+    },
+  );
+
   it('records builder boot evidence before accepting sanitation', async () => {
     const { enqueued, service, hetzner } = await setup();
     expect(await service.runBuildStep(enqueued.build.buildId)).toBe('builder_boot');

--- a/tests/platform/golden-snapshot-service.test.ts
+++ b/tests/platform/golden-snapshot-service.test.ts
@@ -511,6 +511,40 @@ describe('golden snapshot build service', () => {
     expect(await listPendingGoldenSnapshotCleanup(db, '2026-07-03T00:02:00.000Z', 10)).toEqual([]);
   });
 
+  it('fails a provider snapshot that remains pending past its explicit deadline', async () => {
+    let currentTime = '2026-07-03T00:01:00.000Z';
+    const pendingImage = {
+      id: 301, status: 'creating' as const, type: 'snapshot' as const,
+      architecture: 'x86' as const, diskGb: 40, labels: {}, deleteProtected: false,
+    };
+    const { enqueued, service } = await setup({
+      createSnapshot: vi.fn().mockResolvedValue({
+        image: pendingImage,
+        action: { id: 401, status: 'running', command: 'create_image' },
+      }),
+      getImage: vi.fn().mockResolvedValue(pendingImage),
+      getAction: vi.fn()
+        .mockResolvedValueOnce({ id: 201, status: 'success', command: 'create_server' })
+        .mockResolvedValue({ id: 401, status: 'running', command: 'create_image' }),
+    }, () => currentTime);
+    await service.runBuildStep(enqueued.build.buildId);
+    await service.consumeCallback(enqueued.build.buildId, 'phase-token-long-enough', {
+      eventId: randomUUID(), phase: 'sanitized', bundleVersion: 'v1',
+      bundleSha256: '1'.repeat(64), ...builderFingerprints,
+    });
+    await expect(service.runBuildStep(enqueued.build.buildId)).resolves.toBe('snapshot_wait');
+
+    currentTime = '2026-07-03T00:32:00.000Z';
+    await expect(service.runBuildStep(enqueued.build.buildId))
+      .rejects.toThrow('Golden snapshot creation timed out');
+    await expect(getGoldenSnapshotBuild(db, enqueued.build.buildId)).resolves.toMatchObject({
+      phase: 'failed', status: 'failed', lastErrorCode: 'snapshot_creation_timeout',
+    });
+    await expect(getGoldenSnapshot(db, enqueued.snapshot.snapshotId)).resolves.toMatchObject({
+      state: 'quarantined', failureCode: 'snapshot_creation_timeout',
+    });
+  });
+
   it('records builder boot evidence before accepting sanitation', async () => {
     const { enqueued, service, hetzner } = await setup();
     expect(await service.runBuildStep(enqueued.build.buildId)).toBe('builder_boot');

--- a/tests/platform/golden-snapshot-service.test.ts
+++ b/tests/platform/golden-snapshot-service.test.ts
@@ -545,6 +545,50 @@ describe('golden snapshot build service', () => {
     });
   });
 
+  it.each(['image', 'action'] as const)(
+    'fails an expired provider snapshot when the %s status read fails',
+    async (failedRead) => {
+      let currentTime = '2026-07-03T00:01:00.000Z';
+      const pendingImage = {
+        id: 301, status: 'creating' as const, type: 'snapshot' as const,
+        architecture: 'x86' as const, diskGb: 40, labels: {}, deleteProtected: false,
+      };
+      const getAction = vi.fn()
+        .mockResolvedValueOnce({ id: 201, status: 'success', command: 'create_server' });
+      if (failedRead === 'action') {
+        getAction.mockRejectedValueOnce(new Error('synthetic provider outage'));
+      } else {
+        getAction.mockResolvedValueOnce({ id: 401, status: 'running', command: 'create_image' });
+      }
+      const { enqueued, service } = await setup({
+        createSnapshot: vi.fn().mockResolvedValue({
+          image: pendingImage,
+          action: { id: 401, status: 'running', command: 'create_image' },
+        }),
+        getImage: failedRead === 'image'
+          ? vi.fn().mockRejectedValue(new Error('synthetic provider outage'))
+          : vi.fn().mockResolvedValue(pendingImage),
+        getAction,
+      }, () => currentTime);
+      await service.runBuildStep(enqueued.build.buildId);
+      await service.consumeCallback(enqueued.build.buildId, 'phase-token-long-enough', {
+        eventId: randomUUID(), phase: 'sanitized', bundleVersion: 'v1',
+        bundleSha256: '1'.repeat(64), ...builderFingerprints,
+      });
+      await expect(service.runBuildStep(enqueued.build.buildId)).resolves.toBe('snapshot_wait');
+
+      currentTime = '2026-07-03T00:32:00.000Z';
+      await expect(service.runBuildStep(enqueued.build.buildId))
+        .rejects.toThrow('Golden snapshot creation timed out');
+      await expect(getGoldenSnapshotBuild(db, enqueued.build.buildId)).resolves.toMatchObject({
+        phase: 'failed', status: 'failed', lastErrorCode: 'snapshot_creation_timeout',
+      });
+      await expect(getGoldenSnapshot(db, enqueued.snapshot.snapshotId)).resolves.toMatchObject({
+        state: 'quarantined', failureCode: 'snapshot_creation_timeout',
+      });
+    },
+  );
+
   it('records builder boot evidence before accepting sanitation', async () => {
     const { enqueued, service, hetzner } = await setup();
     expect(await service.runBuildStep(enqueued.build.buildId)).toBe('builder_boot');

--- a/tests/platform/golden-snapshot-service.test.ts
+++ b/tests/platform/golden-snapshot-service.test.ts
@@ -630,6 +630,53 @@ describe('golden snapshot build service', () => {
     },
   );
 
+  it('retains orphan reconciliation when exact-label discovery fails after the deadline', async () => {
+    let currentTime = '2026-07-03T00:01:00.000Z';
+    const lateImage = {
+      id: 909, status: 'available' as const, type: 'snapshot' as const,
+      architecture: 'x86' as const, diskGb: 40, deleteProtected: false,
+      labels: {
+        'matrix.snapshot-build': '20000000-0000-4000-8000-000000000001',
+        'matrix.snapshot-id': '10000000-0000-4000-8000-000000000001',
+        'matrix.role': 'builder',
+      },
+    };
+    const listImagesByLabel = vi.fn()
+      .mockImplementationOnce(async () => {
+        currentTime = '2026-07-03T00:32:00.000Z';
+        throw new Error('synthetic provider outage');
+      })
+      .mockResolvedValueOnce([lateImage]);
+    const { enqueued, service } = await setup({
+      createSnapshot: vi.fn().mockRejectedValueOnce(new Error('synthetic timeout')),
+      listImagesByLabel,
+    }, () => currentTime);
+    await service.runBuildStep(enqueued.build.buildId);
+    await service.consumeCallback(enqueued.build.buildId, 'phase-token-long-enough', {
+      eventId: randomUUID(), phase: 'sanitized', bundleVersion: 'v1',
+      bundleSha256: '1'.repeat(64), ...builderFingerprints,
+    });
+    await expect(service.runBuildStep(enqueued.build.buildId)).rejects.toThrow('provider operation');
+
+    await expect(service.runBuildStep(enqueued.build.buildId))
+      .rejects.toThrow('Golden snapshot image recovery window expired');
+    await expect(getGoldenSnapshotBuild(db, enqueued.build.buildId)).resolves.toMatchObject({
+      phase: 'failed', status: 'failed', lastErrorCode: 'snapshot_create_unresolved',
+      pendingOperation: `snapshot:${enqueued.snapshot.snapshotId}`,
+    });
+    await expect(getGoldenSnapshot(db, enqueued.snapshot.snapshotId)).resolves.toMatchObject({
+      state: 'quarantined', failureCode: 'snapshot_create_unresolved',
+    });
+
+    currentTime = '2026-07-03T00:33:00.000Z';
+    await expect(service.runOrphanReconciliationStep(enqueued.build.buildId)).resolves.toBe('queued');
+    await expect(listPendingGoldenSnapshotCleanup(db, currentTime, 10)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ resourceType: 'snapshot_image', providerResourceId: lateImage.id }),
+      ]),
+    );
+  });
+
   it('records builder boot evidence before accepting sanitation', async () => {
     const { enqueued, service, hetzner } = await setup();
     expect(await service.runBuildStep(enqueued.build.buildId)).toBe('builder_boot');


### PR DESCRIPTION
## Summary

- renew `snapshot_wait` worker leases without consuming the generic build retry budget
- fail a genuinely pending provider snapshot at its explicit callback deadline
- cover both batch and direct lease claims plus the provider timeout path

## Why

The exact v990 disposable snapshot build reached Hetzner image creation successfully, but Hetzner kept the image in `creating` beyond 25 minutes. The worker uses five-minute leases and the default generic retry budget is five attempts, so each normal polling lease consumed an attempt and terminally failed the build at exactly 25 minutes with `retry_budget_exhausted`, even though the snapshot phase has an explicit 60-minute deadline.

`snapshot_wait` is a long-running provider poll, not a retry failure. This change keeps renewing that phase without incrementing attempts and makes the explicit snapshot deadline the fail-closed bound.

## Tests

- `bun run test -- tests/platform/golden-snapshot-repository.test.ts tests/platform/golden-snapshot-service.test.ts` (116 passed)
- `bun run test -- tests/platform/golden-snapshot-provisioning.test.ts` (37 passed)
- `bun run typecheck`
- `pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json`
- `bun run check:patterns:diff` (0 violations)
- `git diff --check`

## Review and monitoring

- customer snapshot selection remains disabled and rollout remains 0%
- after merge, build one exact test-mode snapshot from the new release and rerun the disposable preview onboarding validation
- measure snapshot preparation separately from request-to-registration and request-to-services-ready latency

## Invariants

- **Source of truth:** PostgreSQL build phase, lease, attempts, and explicit callback deadline remain authoritative; provider status is re-read before every transition.
- **Lock / transaction scope:** existing advisory capacity lock and row-conditional claim updates remain unchanged; lease renewal is still atomic.
- **Acceptable orphan states:** a timed-out or failed snapshot is quarantined and queued for exact-label cleanup; no unlabeled or ambiguous resource is adopted or deleted.
- **Auth source of truth:** operator-only snapshot routes and existing platform worker credentials are unchanged.
- **Deferred scope:** provider snapshot creation speed is external; this PR only ensures valid long-running creation is bounded by the configured deadline instead of an unrelated retry counter.
