### PR TITLE
fix(desktop): allow Rosetta updater smoke startup

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -262,7 +262,12 @@ jobs:
             OPERATOR_UPDATE_FEED="http://127.0.0.1:${update_port}/" \
             "$copy_dir/Matrix OS.app/Contents/MacOS/Matrix OS" --disable-gpu >"$app_log" 2>&1 &
           app_pid=$!
-          for _ in {1..20}; do
+          launch_attempts=20
+          if [ "${{ matrix.arch }}" = "x64" ]; then
+            # GitHub's macOS runner is arm64, so the x64 app starts through Rosetta.
+            launch_attempts=60
+          fi
+          for ((attempt = 1; attempt <= launch_attempts; attempt += 1)); do
             if ! kill -0 "$app_pid" 2>/dev/null; then
               wait "$app_pid" || true
               cat "$app_log"

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -28,6 +28,11 @@ describe("desktop release workflows", () => {
     expect(workflow).toContain("Smoke test macOS DMG mount");
     expect(workflow).toContain("desktop-update-fixture-server.mjs");
     expect(workflow).toContain('OPERATOR_UPDATE_FEED="http://127.0.0.1:${update_port}/"');
+    expect(workflow).toContain('if [ "${{ matrix.arch }}" = "x64" ]; then');
+    expect(workflow).toContain("launch_attempts=60");
+    expect(workflow).toContain(
+      "for ((attempt = 1; attempt <= launch_attempts; attempt += 1)); do",
+    );
     expect(workflow).toContain('grep -Fq "[updates] update check completed: up to date" "$app_log"');
     expect(workflow).toContain('grep -Fq "[updates] check failed:" "$app_log"');
     expect(workflow).toContain('hdiutil attach "$dmg_path" -mountpoint "$mount_dir" -nobrowse -readonly');

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -28,10 +28,8 @@ describe("desktop release workflows", () => {
     expect(workflow).toContain("Smoke test macOS DMG mount");
     expect(workflow).toContain("desktop-update-fixture-server.mjs");
     expect(workflow).toContain('OPERATOR_UPDATE_FEED="http://127.0.0.1:${update_port}/"');
-    expect(workflow).toContain('if [ "${{ matrix.arch }}" = "x64" ]; then');
-    expect(workflow).toContain("launch_attempts=60");
-    expect(workflow).toContain(
-      "for ((attempt = 1; attempt <= launch_attempts; attempt += 1)); do",
+    expect(workflow).toMatch(
+      /launch_attempts=20\n\s+if \[ "\$\{\{ matrix\.arch \}\}" = "x64" \]; then\n\s+# GitHub's macOS runner is arm64, so the x64 app starts through Rosetta\.\n\s+launch_attempts=60\n\s+fi\n\s+for \(\(attempt = 1; attempt <= launch_attempts; attempt \+= 1\)\); do/,
     );
     expect(workflow).toContain('grep -Fq "[updates] update check completed: up to date" "$app_log"');
     expect(workflow).toContain('grep -Fq "[updates] check failed:" "$app_log"');


### PR DESCRIPTION
## Summary

- Give the x64 packaged updater smoke a 60-second startup budget on the arm64 GitHub macOS runner.
- Keep the native arm64 startup budget at 20 seconds.
- Retain the same fail-closed updater-feed assertion and app-exit detection.

## Why

Signed Canary run [32376130867](https://github.com/HamedMP/matrix-os/actions/runs/32376130867) completed x64 signing and notarization, but the translated x64 app had not emitted the updater probe signal within the existing 20-second window. The native arm64 lane completed the same probe successfully. The release was correctly blocked before publishing or advancing the Canary pointer.

Linear: MAT-441

## Tests

- `flox activate -- bunx vitest run tests/desktop/desktop-release-workflows.test.ts` (19/19)
- `flox activate -- bun run check:patterns` (0 violations; existing warnings only)
- `git diff --check`

## Release gate

Re-run the signed Canary workflow and require both macOS architectures to pass the packaged updater probe before publishing Canary A.