### PR TITLE
fix(desktop): smoke test on native mac runners

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -33,12 +33,16 @@ permissions:
 jobs:
   mac:
     name: macOS ${{ matrix.arch }}
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        arch: [arm64, x64]
+        include:
+          - arch: arm64
+            runner: macos-latest
+          - arch: x64
+            runner: macos-15-intel
     env:
       MATRIX_DESKTOP_UPDATE_CHANNEL: ${{ inputs.channel }}
       APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -263,10 +267,6 @@ jobs:
             "$copy_dir/Matrix OS.app/Contents/MacOS/Matrix OS" --disable-gpu >"$app_log" 2>&1 &
           app_pid=$!
           launch_attempts=20
-          if [ "${{ matrix.arch }}" = "x64" ]; then
-            # GitHub's macOS runner is arm64, so the x64 app starts through Rosetta.
-            launch_attempts=60
-          fi
           for ((attempt = 1; attempt <= launch_attempts; attempt += 1)); do
             if ! kill -0 "$app_pid" 2>/dev/null; then
               wait "$app_pid" || true

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -28,9 +28,14 @@ describe("desktop release workflows", () => {
     expect(workflow).toContain("Smoke test macOS DMG mount");
     expect(workflow).toContain("desktop-update-fixture-server.mjs");
     expect(workflow).toContain('OPERATOR_UPDATE_FEED="http://127.0.0.1:${update_port}/"');
+    expect(workflow).toContain("runs-on: ${{ matrix.runner }}");
     expect(workflow).toMatch(
-      /launch_attempts=20\n\s+if \[ "\$\{\{ matrix\.arch \}\}" = "x64" \]; then\n\s+# GitHub's macOS runner is arm64, so the x64 app starts through Rosetta\.\n\s+launch_attempts=60\n\s+fi\n\s+for \(\(attempt = 1; attempt <= launch_attempts; attempt \+= 1\)\); do/,
+      /include:\n\s+- arch: arm64\n\s+runner: macos-latest\n\s+- arch: x64\n\s+runner: macos-15-intel/,
     );
+    expect(workflow).toMatch(
+      /launch_attempts=20\n\s+for \(\(attempt = 1; attempt <= launch_attempts; attempt \+= 1\)\); do/,
+    );
+    expect(workflow).not.toContain("starts through Rosetta");
     expect(workflow).toContain('grep -Fq "[updates] update check completed: up to date" "$app_log"');
     expect(workflow).toContain('grep -Fq "[updates] check failed:" "$app_log"');
     expect(workflow).toContain('hdiutil attach "$dmg_path" -mountpoint "$mount_dir" -nobrowse -readonly');


### PR DESCRIPTION
## Summary

- run arm64 Desktop packaging and updater smoke on the ARM macOS runner
- run x64 Desktop packaging and updater smoke on the Intel macOS runner
- keep the deterministic packaged updater probe as a release-blocking gate

## Why

Canary run 32379371658 confirmed that the signed x64 app remained alive but never entered Electron main while translated through Rosetta on the ARM runner. Extending the wait budget did not help. Running each artifact on a matching native runner exercises the actual packaged boundary without cross-architecture startup behavior.

## Validation

- flox activate -- pnpm exec vitest run tests/desktop/desktop-release-workflows.test.ts
- flox activate -- pnpm run check:patterns
- git diff --check