### PR TITLE
fix(desktop): keep update dialogs above hosted shell

### DIFF
--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -165,6 +165,15 @@ export class EmbedManager {
     return true;
   }
 
+  suspendAll(): boolean {
+    for (const record of this.records.values()) {
+      if (!record.live) continue;
+      record.view.detach();
+      record.live = false;
+    }
+    return true;
+  }
+
   focus(embedId: string): boolean {
     const record = this.records.get(embedId);
     if (!record) return false;

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -104,6 +104,16 @@ export class EmbedService {
     return this.manager.setActive(embedId, active) || pending;
   }
 
+  suspendAll(): boolean {
+    for (const embedId of this.pendingHostedShells.keys()) {
+      this.pendingActive.set(embedId, false);
+    }
+    for (const embedId of this.pendingApps.keys()) {
+      this.pendingActive.set(embedId, false);
+    }
+    return this.manager.suspendAll();
+  }
+
   async reload(embedId: string): Promise<boolean> {
     if (this.hostedShellIds.has(embedId)) {
       const generation = this.hostedShellGeneration;

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -291,6 +291,7 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
   handle("embed:set-active", ({ embedId, active }) => ({
     ok: ctx.embeds.setActive(embedId, active),
   }));
+  handle("embed:suspend-all", () => ({ ok: ctx.embeds.suspendAll() }));
   handle("embed:reload", async ({ embedId }) => ({ ok: await ctx.embeds.reload(embedId) }));
   handle("embed:close", ({ embedId }) => ({ ok: ctx.embeds.close(embedId) }));
   handle("embed:retry-auth", async ({ embedId }) => {

--- a/desktop/src/renderer/src/features/updates/DesktopUpdateExperience.tsx
+++ b/desktop/src/renderer/src/features/updates/DesktopUpdateExperience.tsx
@@ -1,10 +1,24 @@
 import { useEffect } from "react";
 import { useDesktopUpdate } from "../../stores/desktop-update";
+import { useUi } from "../../stores/ui";
 import ManualUpdateDialog from "./ManualUpdateDialog";
 import WhatsNewDialog from "./WhatsNewDialog";
 
 export default function DesktopUpdateExperience() {
+  const manualDialogOpen = useDesktopUpdate((state) => state.manualDialogOpen);
+  const whatsNewOpen = useDesktopUpdate((state) => state.whatsNewOpen);
+  const acquireRendererOverlay = useUi((state) => state.acquireRendererOverlay);
+  const releaseRendererOverlay = useUi((state) => state.releaseRendererOverlay);
+  const updateOverlayOpen = manualDialogOpen || whatsNewOpen;
+
   useEffect(() => useDesktopUpdate.getState().initialize(), []);
+
+  useEffect(() => {
+    if (!updateOverlayOpen) return;
+    acquireRendererOverlay();
+    return releaseRendererOverlay;
+  }, [acquireRendererOverlay, releaseRendererOverlay, updateOverlayOpen]);
+
   return (
     <>
       <ManualUpdateDialog />

--- a/desktop/src/renderer/src/features/updates/DesktopUpdateExperience.tsx
+++ b/desktop/src/renderer/src/features/updates/DesktopUpdateExperience.tsx
@@ -21,13 +21,18 @@ export default function DesktopUpdateExperience() {
     if (!updateOverlayOpen) return;
     let active = true;
     acquireRendererOverlay();
+    const recoverFromSuspensionFailure = () => {
+      if (!active) return;
+      console.warn("[desktop-update] failed to suspend native embeds");
+      useDesktopUpdate.setState({ manualDialogOpen: false, whatsNewOpen: false });
+    };
     void invoke("embed:suspend-all", {})
       .then(({ ok }) => {
-        if (active && ok) setNativeEmbedsSuspended(true);
+        if (!active) return;
+        if (ok) setNativeEmbedsSuspended(true);
+        else recoverFromSuspensionFailure();
       })
-      .catch(() => {
-        console.warn("[desktop-update] failed to suspend native embeds");
-      });
+      .catch(recoverFromSuspensionFailure);
     return () => {
       active = false;
       setNativeEmbedsSuspended(false);

--- a/desktop/src/renderer/src/features/updates/DesktopUpdateExperience.tsx
+++ b/desktop/src/renderer/src/features/updates/DesktopUpdateExperience.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
+import { invoke } from "../../lib/operator";
 import { useDesktopUpdate } from "../../stores/desktop-update";
 import { useUi } from "../../stores/ui";
 import ManualUpdateDialog from "./ManualUpdateDialog";
@@ -10,14 +11,31 @@ export default function DesktopUpdateExperience() {
   const acquireRendererOverlay = useUi((state) => state.acquireRendererOverlay);
   const releaseRendererOverlay = useUi((state) => state.releaseRendererOverlay);
   const updateOverlayOpen = manualDialogOpen || whatsNewOpen;
+  const [nativeEmbedsSuspended, setNativeEmbedsSuspended] = useState(false);
 
   useEffect(() => useDesktopUpdate.getState().initialize(), []);
 
-  useEffect(() => {
+  // Hold renderer-driven embeds inactive immediately, then wait for the trusted
+  // core to confirm that every native view is detached before painting a dialog.
+  useLayoutEffect(() => {
     if (!updateOverlayOpen) return;
+    let active = true;
     acquireRendererOverlay();
-    return releaseRendererOverlay;
+    void invoke("embed:suspend-all", {})
+      .then(({ ok }) => {
+        if (active && ok) setNativeEmbedsSuspended(true);
+      })
+      .catch(() => {
+        console.warn("[desktop-update] failed to suspend native embeds");
+      });
+    return () => {
+      active = false;
+      setNativeEmbedsSuspended(false);
+      releaseRendererOverlay();
+    };
   }, [acquireRendererOverlay, releaseRendererOverlay, updateOverlayOpen]);
+
+  if (updateOverlayOpen && !nativeEmbedsSuspended) return null;
 
   return (
     <>

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -321,6 +321,10 @@ export const INVOKE_CHANNELS = {
     request: z.object({ embedId: z.string().min(1).max(64), active: z.boolean() }).strict(),
     response: Ok,
   },
+  "embed:suspend-all": {
+    request: Empty,
+    response: Ok,
+  },
   "embed:reload": {
     request: z.object({ embedId: z.string().min(1).max(64) }).strict(),
     response: Ok,

--- a/tests/desktop/app-update-experience.test.tsx
+++ b/tests/desktop/app-update-experience.test.tsx
@@ -28,6 +28,7 @@ describe("App desktop update experience", () => {
       invoke: vi.fn(async (channel: string) => {
         if (channel === "update:get-state") return { status: "disabled" };
         if (channel === "update:get-whats-new") return { release: null, shouldOpen: false };
+        if (channel === "embed:suspend-all") return { ok: true };
         return { signedIn: false, platformHost: "", runtimeSlot: "primary", authGeneration: 0 };
       }),
       on: vi.fn((channel: string, listener: (payload: unknown) => void) => {
@@ -56,7 +57,7 @@ describe("App desktop update experience", () => {
     act(() => {
       listeners.get("update:manual-check-requested")?.({});
     });
-    expect(screen.getByRole("dialog", { name: "Software Update" })).toBeTruthy();
+    expect(await screen.findByRole("dialog", { name: "Software Update" })).toBeTruthy();
     expect(screen.getByText("Signed out")).toBeTruthy();
   });
 });

--- a/tests/desktop/desktop-update-ui.test.tsx
+++ b/tests/desktop/desktop-update-ui.test.tsx
@@ -64,6 +64,37 @@ describe("desktop update experience", () => {
     });
   });
 
+  it("restores the hosted shell when native embed suspension fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const invoke = vi.fn((channel: string) => {
+      if (channel === "embed:suspend-all") {
+        return Promise.reject(new Error("private IPC failure"));
+      }
+      if (channel === "update:get-state") return Promise.resolve({ status: "disabled" });
+      if (channel === "update:get-whats-new") {
+        return Promise.resolve({ release: null, shouldOpen: false });
+      }
+      return Promise.resolve({ ok: true });
+    });
+    vi.stubGlobal("operator", { invoke, on: vi.fn(() => vi.fn()) });
+    useDesktopUpdate.setState({ manualDialogOpen: true, whatsNewOpen: true });
+
+    render(
+      <Tooltip.Provider>
+        <DesktopUpdateExperience />
+      </Tooltip.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(useDesktopUpdate.getState().manualDialogOpen).toBe(false);
+      expect(useDesktopUpdate.getState().whatsNewOpen).toBe(false);
+      expect(useUi.getState().rendererOverlayCount).toBe(0);
+    });
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(warn).toHaveBeenCalledWith("[desktop-update] failed to suspend native embeds");
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("private IPC failure"));
+  });
+
   it("subscribes to background update state without acknowledging before dismissal", async () => {
     let updateListener: ((payload: unknown) => void) | null = null;
     const invoke = vi.fn(async (channel: string) => {

--- a/tests/desktop/desktop-update-ui.test.tsx
+++ b/tests/desktop/desktop-update-ui.test.tsx
@@ -9,6 +9,7 @@ import DesktopUpdateExperience from "../../desktop/src/renderer/src/features/upd
 import ManualUpdateDialog from "../../desktop/src/renderer/src/features/updates/ManualUpdateDialog";
 import WhatsNewDialog from "../../desktop/src/renderer/src/features/updates/WhatsNewDialog";
 import { useDesktopUpdate } from "../../desktop/src/renderer/src/stores/desktop-update";
+import { useUi } from "../../desktop/src/renderer/src/stores/ui";
 
 describe("desktop update experience", () => {
   beforeEach(() => {
@@ -19,6 +20,7 @@ describe("desktop update experience", () => {
       manualDialogOpen: false,
       installing: false,
     });
+    useUi.setState({ rendererOverlayCount: 0 });
   });
 
   afterEach(() => {
@@ -107,6 +109,7 @@ describe("desktop update experience", () => {
     });
     expect(screen.getByRole("dialog", { name: "Software Update" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Checking for updates…" })).toBeTruthy();
+    await waitFor(() => expect(useUi.getState().rendererOverlayCount).toBe(1));
 
     act(() => {
       listeners.get("update:state-changed")?.({
@@ -145,6 +148,7 @@ describe("desktop update experience", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Later" }));
     expect(screen.queryByRole("dialog", { name: "Software Update" })).toBeNull();
+    await waitFor(() => expect(useUi.getState().rendererOverlayCount).toBe(0));
   });
 
   it("lets a failed manual check retry through the trusted updater IPC", async () => {
@@ -263,6 +267,7 @@ describe("desktop update experience", () => {
     await waitFor(() => {
       expect(screen.getByRole("dialog", { name: "What's New" })).toBeTruthy();
       expect(listeners.has("update:manual-check-requested")).toBe(true);
+      expect(useUi.getState().rendererOverlayCount).toBe(1);
     });
 
     act(() => {
@@ -273,6 +278,10 @@ describe("desktop update experience", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Later" }));
     expect(screen.getByRole("dialog", { name: "What's New" })).toBeTruthy();
+    expect(useUi.getState().rendererOverlayCount).toBe(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close What's New" }));
+    await waitFor(() => expect(useUi.getState().rendererOverlayCount).toBe(0));
   });
 
   it("shows a blue Update control only when the download is ready and installs immediately", async () => {

--- a/tests/desktop/desktop-update-ui.test.tsx
+++ b/tests/desktop/desktop-update-ui.test.tsx
@@ -29,6 +29,41 @@ describe("desktop update experience", () => {
     vi.unstubAllGlobals();
   });
 
+  it("waits for native embeds to suspend before painting an update dialog", async () => {
+    let resolveSuspend!: (value: { ok: boolean }) => void;
+    const suspend = new Promise<{ ok: boolean }>((resolve) => {
+      resolveSuspend = resolve;
+    });
+    const invoke = vi.fn((channel: string) => {
+      if (channel === "embed:suspend-all") return suspend;
+      if (channel === "update:get-state") return Promise.resolve({ status: "disabled" });
+      if (channel === "update:get-whats-new") {
+        return Promise.resolve({ release: null, shouldOpen: false });
+      }
+      return Promise.resolve({ ok: true });
+    });
+    vi.stubGlobal("operator", { invoke, on: vi.fn(() => vi.fn()) });
+    useDesktopUpdate.setState({ manualDialogOpen: true });
+
+    render(
+      <Tooltip.Provider>
+        <DesktopUpdateExperience />
+      </Tooltip.Provider>,
+    );
+
+    expect(useUi.getState().rendererOverlayCount).toBe(1);
+    expect(invoke).toHaveBeenCalledWith("embed:suspend-all", {});
+    expect(screen.queryByRole("dialog", { name: "Software Update" })).toBeNull();
+
+    await act(async () => {
+      resolveSuspend({ ok: true });
+      await suspend;
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Software Update" })).toBeTruthy();
+    });
+  });
+
   it("subscribes to background update state without acknowledging before dismissal", async () => {
     let updateListener: ((payload: unknown) => void) | null = null;
     const invoke = vi.fn(async (channel: string) => {
@@ -107,7 +142,7 @@ describe("desktop update experience", () => {
     act(() => {
       listeners.get("update:manual-check-requested")?.({});
     });
-    expect(screen.getByRole("dialog", { name: "Software Update" })).toBeTruthy();
+    expect(await screen.findByRole("dialog", { name: "Software Update" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Checking for updates…" })).toBeTruthy();
     await waitFor(() => expect(useUi.getState().rendererOverlayCount).toBe(1));
 

--- a/tests/desktop/embed-manager.test.ts
+++ b/tests/desktop/embed-manager.test.ts
@@ -427,6 +427,22 @@ describe("EmbedManager", () => {
     expect(manager.setActive("nope", false)).toBe(false);
   });
 
+  it("suspends every live embed while keeping each record reattachable", () => {
+    const { manager, views } = makeManager(3);
+    const first = manager.open("app", "a", BOUNDS, "https://gw.test/a");
+    const second = manager.open("app", "b", BOUNDS, "https://gw.test/b");
+
+    expect(manager.suspendAll()).toBe(true);
+    expect(manager.liveCount).toBe(0);
+    expect(manager.has(first)).toBe(true);
+    expect(manager.has(second)).toBe(true);
+    expect(views[0]?.view.events).toContain("detach");
+    expect(views[1]?.view.events).toContain("detach");
+
+    expect(manager.setActive(first, true)).toBe(true);
+    expect(manager.liveCount).toBe(1);
+  });
+
   it("closeAll destroys every embed including suspended ones", () => {
     const { manager, views } = makeManager(1);
     manager.open("app", "a", BOUNDS, "https://gw.test/a");

--- a/tests/desktop/embed-service.test.ts
+++ b/tests/desktop/embed-service.test.ts
@@ -240,6 +240,31 @@ describe("EmbedService", () => {
     expect(emitState).toHaveBeenCalledWith("embed-shell", "loading");
   });
 
+  it("suspends live and pending embeds through the trusted core", () => {
+    const service = new EmbedService({
+      getWindow: () => null,
+      getGatewayOrigin: () => "https://gateway.test",
+      getToken: () => "token",
+      emitState: vi.fn(),
+    });
+    const internals = service as unknown as {
+      pendingHostedShells: Map<string, Bounds>;
+      pendingApps: Map<string, { slug: string; bounds: Bounds }>;
+      pendingActive: Map<string, boolean>;
+      manager: { suspendAll: () => boolean };
+    };
+    const suspendAll = vi.spyOn(internals.manager, "suspendAll").mockReturnValue(true);
+    internals.pendingHostedShells.set("embed-shell", BOUNDS);
+    internals.pendingApps.set("embed-app", { slug: "notes", bounds: BOUNDS });
+    internals.pendingActive.set("embed-shell", true);
+    internals.pendingActive.set("embed-app", true);
+
+    expect(service.suspendAll()).toBe(true);
+    expect(suspendAll).toHaveBeenCalledOnce();
+    expect(internals.pendingActive.get("embed-shell")).toBe(false);
+    expect(internals.pendingActive.get("embed-app")).toBe(false);
+  });
+
   it("schedules hosted-shell session refresh from the app-session cookie expiry", async () => {
     vi.useFakeTimers();
     const service = new EmbedService({

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -42,6 +42,7 @@ describe("IPC contract", () => {
       "state:set",
       "embed:open",
       "embed:set-bounds",
+      "embed:suspend-all",
       "embed:reload",
       "embed:close",
       "embed:retry-auth",

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -28,6 +28,7 @@ function makeHarness(overrides: Partial<HandlerContext> = {}) {
       open: vi.fn(),
       setBounds: vi.fn(),
       setActive: vi.fn(),
+      suspendAll: vi.fn(),
       reload: vi.fn(),
       close: vi.fn(),
       retryAuth: vi.fn(),
@@ -183,6 +184,14 @@ describe("registerIpcHandlers", () => {
       ok: false,
     });
     expect(console.warn).toHaveBeenCalledWith("[ipc] embed:retry-auth failed:", "handoff unavailable");
+  });
+
+  it("waits for the trusted core to suspend native embeds", async () => {
+    const harness = makeHarness();
+    vi.mocked(harness.ctx.embeds.suspendAll).mockReturnValue(true);
+
+    await expect(harness.invoke("embed:suspend-all")).resolves.toEqual({ ok: true });
+    expect(harness.ctx.embeds.suspendAll).toHaveBeenCalledOnce();
   });
 
   it("reloads an existing embed through the trusted core", async () => {

--- a/tests/desktop/tab-content.test.tsx
+++ b/tests/desktop/tab-content.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import TabContent, { TabErrorBoundary } from "@desktop/renderer/src/features/mission-control/TabContent";
 import { useConnection } from "@desktop/renderer/src/stores/connection";
 import { useTabs } from "@desktop/renderer/src/stores/tabs";
+import { useUi } from "@desktop/renderer/src/stores/ui";
 
 const taskWorkspaceMock = vi.hoisted(() =>
   vi.fn(({ taskId, projectSlug }: { taskId: string; projectSlug?: string }) => (
@@ -35,7 +36,9 @@ vi.mock("@desktop/renderer/src/features/terminal/TerminalsTab", () => ({
   default: terminalsTabMock,
 }));
 vi.mock("@desktop/renderer/src/features/mission-control/HomeTab", () => ({
-  default: () => <button type="button">Home workspace</button>,
+  default: ({ active }: { active: boolean }) => (
+    <button type="button" data-active={String(active)}>Home workspace</button>
+  ),
 }));
 vi.mock("@desktop/renderer/src/features/chat/ChatTab", () => ({
   default: () => <button type="button">Chat workspace</button>,
@@ -57,6 +60,7 @@ describe("TabContent", () => {
       api: null,
     });
     useTabs.setState({ tabs: [], activeTabId: null });
+    useUi.setState({ rendererOverlayCount: 0 });
   });
 
   afterEach(() => {
@@ -150,6 +154,20 @@ describe("TabContent", () => {
 
     act(() => useTabs.getState().focusTab(workspaceId));
     expect(workspace.getAttribute("data-active")).toBe("true");
+  });
+
+  it("detaches the active Home native view while a renderer overlay lease is held", () => {
+    useTabs.getState().openTab({ kind: "home", title: "Home", closable: false });
+    render(<TabContent />);
+
+    const home = screen.getByRole("button", { name: "Home workspace" });
+    expect(home.getAttribute("data-active")).toBe("true");
+
+    act(() => useUi.getState().acquireRendererOverlay());
+    expect(home.getAttribute("data-active")).toBe("false");
+
+    act(() => useUi.getState().releaseRendererOverlay());
+    expect(home.getAttribute("data-active")).toBe("true");
   });
 
   it("renders the apps tab through the tracked AppLauncher module", () => {

--- a/tests/e2e/desktop/update-experience.e2e.test.ts
+++ b/tests/e2e/desktop/update-experience.e2e.test.ts
@@ -18,6 +18,13 @@ suite("desktop update experience", () => {
   let page: Page;
   let userDataDir: string;
 
+  function attachedNativeViewCount(): Promise<number> {
+    return app.evaluate(({ BrowserWindow }) => {
+      const window = BrowserWindow.getAllWindows()[0];
+      return window?.contentView.children.length ?? 0;
+    });
+  }
+
   function seedRelease(version: string): void {
     const statePath = join(userDataDir, "state.json");
     const state = existsSync(statePath)
@@ -91,8 +98,10 @@ suite("desktop update experience", () => {
     await page.getByRole("heading", {
       name: "Updates are unavailable in this preview",
     }).waitFor();
+    await expect.poll(attachedNativeViewCount).toBe(0);
     await page.screenshot({ path: join(SCREENSHOT_DIR, "mat-441-manual-update-dialog.png") });
     await page.getByRole("button", { name: "Close" }).click();
+    await expect.poll(attachedNativeViewCount).toBe(0);
   });
 
   it("shows What's New after launch and places Update at the right edge of the account row", async () => {
@@ -111,6 +120,7 @@ suite("desktop update experience", () => {
     await page.setViewportSize({ width: 1280, height: 800 });
 
     await page.getByRole("button", { name: "Close What's New" }).click();
+    await expect.poll(attachedNativeViewCount).toBe(1);
     await app.evaluate(({ BrowserWindow }) => {
       BrowserWindow.getAllWindows()[0]?.webContents.send("update:state-changed", {
         status: "ready",


### PR DESCRIPTION
## Summary

- keep the manual update dialog and What's New above the Home hosted shell
- acquire the existing renderer-overlay lease while either update surface is open
- synchronously suspend every live and pending native embed through typed IPC
- wait for the trusted main process to confirm detachment before painting the first dialog frame
- restore the hosted shell when the final update surface closes or native suspension fails
- add focused renderer, IPC, embed-manager, and packaged Electron regression coverage

## Root cause

Home is rendered by a native `WebContentsView`. Native child views are composited above renderer DOM, so increasing the dialog z-index cannot bring a React modal above the hosted shell.

The original overlay lease correctly detached Home after the renderer reacted, but Greptile identified a valid first-frame race: a passive renderer effect could paint the modal before the cross-process detach completed. The update experience now acquires the lease before paint, calls a typed `embed:suspend-all` trusted-main boundary, and does not mount the dialog until main confirms that all live and pending native views are suspended.

## Validation

- focused Desktop update + hosted-view boundary: `152/152` tests passed
- full Desktop suite: `176/176` files and `1815/1815` tests passed
- Desktop typecheck passed
- repository typecheck passed
- production Desktop build and unsigned macOS arm64 package passed
- packaged Home validation:
  - manual update: native view `1 → 0` before the dialog becomes visible, then `0 → 1` after close
  - What's New: native view `1 → 0` before the dialog becomes visible, then `0 → 1` after close
- React Doctor changed-scope scan: no issues found
- `git diff --check` passed

The earlier repository-wide `bun run test` gate completed with `10988` passed, `20` skipped, and `29` failures outside the changed Desktop files. The red cases are concentrated in host-specific shell scripts, Codex Unix-socket/terminal handoff tests, long-running app builds, date-sensitive Todo expectations, and workspace dependency resolution. Focused and full Desktop coverage remain green.

## Final packaged Home regression evidence

### Manual update dialog

[Open the final packaged Home update-dialog screenshot in Linear](https://uploads.linear.app/9d7c8ca2-ff8b-42ea-8321-35892cc887d8/89c44571-2cec-457f-8b62-c3dbd2df39b5/ccfbf085-279d-4894-b4ee-1b109d5df029)

### What's New

[Open the final packaged Home What's New screenshot in Linear](https://uploads.linear.app/9d7c8ca2-ff8b-42ea-8321-35892cc887d8/ef98695c-a57c-4e1d-86fe-ea901ff58853/94c727fb-b65b-4293-9076-5a0e08060f33)

## Signed Canary A → B acceptance evidence

These screenshots are from the completed signed OTA acceptance run, not a new release produced by this regression-fix branch.

### Checking

[Open the Canary B Checking screenshot in Linear](https://uploads.linear.app/9d7c8ca2-ff8b-42ea-8321-35892cc887d8/bb449bab-cb52-454c-ac6e-f56a025fac2a/a4c4ab2f-abcb-4898-ae90-62689d64561e)

### Ready

[Open the Canary B Ready screenshot in Linear](https://uploads.linear.app/9d7c8ca2-ff8b-42ea-8321-35892cc887d8/ed0751ac-39c6-43bf-a7df-645efb7f73b4/aa5a66f8-22a4-48e0-8404-6491794e8ead)

### What's New after restart

[Open the Canary B What's New screenshot in Linear](https://uploads.linear.app/9d7c8ca2-ff8b-42ea-8321-35892cc887d8/f725c07e-3d91-476f-984f-b45cd434ed32/2fa8ca9e-c2ba-457d-8e9b-3a530b2bf939)

## Invariants

- **Source of truth:** update state remains in the canonical Desktop update store; native-view visibility remains owned by the existing renderer-overlay lease manager plus the trusted embed service.
- **Transaction / lock scope:** no database writes or cross-process lock semantics are changed.
- **Acceptable orphan states:** the overlay lease is released by React layout-effect cleanup on close or unmount, so a dialog cannot permanently detach the hosted shell.
- **Authorization source of truth:** authentication, update-channel selection, signing, and feed authorization are unchanged.
- **Deferred scope:** this PR does not merge, publish, promote, sign, or otherwise modify Desktop release artifacts or channels.

## Tracking

- Linear: [MAT-441](https://linear.app/matrix-os/issue/MAT-441/fix-packaged-desktop-updater-module-interop)
- Base sync: `origin/main` at `3a8046776ad495642a1918c22e005fcd77e89d61` (already an ancestor; no conflicts)
- First-frame fix: `9118bb291`n- Suspension-failure recovery: `be3cbc997`

@Nima-Naderi ready for review.