### PR TITLE
feat(terminal): coordinate live renderer ownership

### DIFF
--- a/apps/mobile/__tests__/terminal-client.test.ts
+++ b/apps/mobile/__tests__/terminal-client.test.ts
@@ -118,6 +118,7 @@ describe("mobile terminal client", () => {
   });
 
   it("sends resize, input, and detach frames (no attach frame; name is in the query)", () => {
+    jest.useFakeTimers();
     const ws = new MockWebSocket() as unknown as WebSocket;
     const messages: unknown[] = [];
     const statuses: string[] = [];
@@ -131,6 +132,16 @@ describe("mobile terminal client", () => {
 
     connection.attach();
     (ws as unknown as MockWebSocket).onopen?.();
+    (ws as unknown as MockWebSocket).onmessage?.({
+      data: JSON.stringify({
+        type: "attached",
+        session: SHELL_NAME,
+        state: "running",
+        canonicalSize: { cols: 220, rows: 70 },
+        lease: { epoch: 7 },
+      }),
+    });
+    jest.advanceTimersByTime(10_000);
     connection.sendInput("pwd\r");
     connection.resize(999, 999);
     (ws as unknown as MockWebSocket).onmessage?.({ data: JSON.stringify({ type: "output", data: "ok" }) });
@@ -138,13 +149,72 @@ describe("mobile terminal client", () => {
 
     expect(statuses).toEqual(["connecting", "open"]);
     expect((ws as unknown as MockWebSocket).sent.map((frame) => JSON.parse(frame))).toEqual([
-      { type: "resize", cols: 220, rows: 70 },
+      { type: "ping" },
       { type: "input", data: "pwd\r" },
       { type: "resize", cols: 500, rows: 200 },
       { type: "detach" },
     ]);
-    expect(messages).toEqual([{ type: "output", data: "ok" }]);
+    expect(messages).toEqual([
+      {
+        type: "attached",
+        sessionId: SHELL_NAME,
+        state: "running",
+        canonicalSize: { cols: 220, rows: 70 },
+        leaseEpoch: 7,
+      },
+      { type: "output", data: "ok" },
+    ]);
     expect((ws as unknown as MockWebSocket).closed).toBe(true);
+    jest.useRealTimers();
+  });
+
+  it("parses canonical presentation frames and stops renewing when displaced", () => {
+    jest.useFakeTimers();
+    const ws = new MockWebSocket() as unknown as WebSocket;
+    const messages: unknown[] = [];
+    const connection = new MobileTerminalConnection(ws, {
+      sessionId: SHELL_NAME,
+      cols: 100,
+      rows: 30,
+      onMessage: (frame) => messages.push(frame),
+    });
+
+    connection.attach();
+    (ws as unknown as MockWebSocket).onopen?.();
+    (ws as unknown as MockWebSocket).onmessage?.({
+      data: JSON.stringify({
+        type: "attached",
+        session: SHELL_NAME,
+        state: "running",
+        canonicalSize: { cols: 100, rows: 30 },
+        lease: { epoch: 12 },
+      }),
+    });
+    (ws as unknown as MockWebSocket).onmessage?.({
+      data: JSON.stringify({ type: "canonical-size", cols: 96, rows: 28 }),
+    });
+    (ws as unknown as MockWebSocket).onmessage?.({
+      data: JSON.stringify({ type: "presentation-reset" }),
+    });
+    (ws as unknown as MockWebSocket).onmessage?.({
+      data: JSON.stringify({ type: "lease-revoked", epoch: 12 }),
+    });
+    jest.advanceTimersByTime(30_000);
+
+    expect(messages).toEqual([
+      {
+        type: "attached",
+        sessionId: SHELL_NAME,
+        state: "running",
+        canonicalSize: { cols: 100, rows: 30 },
+        leaseEpoch: 12,
+      },
+      { type: "canonical-size", cols: 96, rows: 28 },
+      { type: "presentation-reset" },
+      { type: "lease-revoked" },
+    ]);
+    expect((ws as unknown as MockWebSocket).sent).toEqual([]);
+    jest.useRealTimers();
   });
 
   it("opens terminal sockets with browser-compatible query auth and native bearer headers", async () => {
@@ -156,12 +226,14 @@ describe("mobile terminal client", () => {
     const terminalClient = new MobileTerminalClient(gateway);
     const connection = await terminalClient.connect({
       sessionId: SHELL_NAME,
+      cols: 120,
+      rows: 40,
       onMessage: jest.fn(),
     });
 
     expect(connection).toBeTruthy();
     expect(webSocketMock).toHaveBeenCalledWith(
-      `wss://app.matrix-os.test/ws/terminal/session?session=${SHELL_NAME}&token=ws-token`,
+      `wss://app.matrix-os.test/ws/terminal/session?session=${SHELL_NAME}&client=hard&cols=120&rows=40&lease=exclusive&token=ws-token`,
       [],
       { headers: { Authorization: "Bearer clerk-token" } },
     );
@@ -176,12 +248,14 @@ describe("mobile terminal client", () => {
     const terminalClient = new MobileTerminalClient(gateway);
     const connection = await terminalClient.connect({
       sessionId: SHELL_NAME,
+      cols: 120,
+      rows: 40,
       onMessage: jest.fn(),
     });
 
     expect(connection).toBeTruthy();
     expect(webSocketMock).toHaveBeenCalledWith(
-      `wss://app.matrix-os.test/ws/terminal/session?session=${SHELL_NAME}`,
+      `wss://app.matrix-os.test/ws/terminal/session?session=${SHELL_NAME}&client=hard&cols=120&rows=40&lease=exclusive`,
       [],
       { headers: { Authorization: "Bearer clerk-token" } },
     );

--- a/apps/mobile/__tests__/terminal-screen.test.tsx
+++ b/apps/mobile/__tests__/terminal-screen.test.tsx
@@ -13,6 +13,14 @@ import {
 } from "../__mocks__/react-native-webview";
 
 const SESSION_ID = "matrix-abc1234";
+const EXCLUSIVE_HARD_PRESENTATION = {
+  client: "hard",
+  cols: 80,
+  rows: 24,
+  lease: "exclusive",
+};
+let mockFocusCallback: (() => void | (() => void)) | null = null;
+let mockFocusCleanup: (() => void) | null = null;
 
 // Auto-confirm the End-session / Detach confirmation dialogs in tests.
 function autoConfirmAlerts() {
@@ -43,7 +51,16 @@ jest.mock("expo-router", () => ({
   useRouter: () => ({ back: jest.fn() }),
   useFocusEffect: (callback: () => void | (() => void)) => {
     const React = require("react");
-    React.useEffect(callback, [callback]);
+    React.useEffect(() => {
+      mockFocusCallback = callback;
+      const cleanup = callback();
+      mockFocusCleanup = typeof cleanup === "function" ? cleanup : null;
+      return () => {
+        mockFocusCleanup?.();
+        mockFocusCleanup = null;
+        mockFocusCallback = null;
+      };
+    }, [callback]);
   },
 }));
 
@@ -83,6 +100,8 @@ describe("TerminalScreen", () => {
     global.WebSocket = OriginalWebSocket;
     jest.clearAllMocks();
     resetWebViewMock();
+    mockFocusCallback = null;
+    mockFocusCleanup = null;
   });
 
   it("opens a mobile terminal session with visible path, output, and command input", async () => {
@@ -121,7 +140,12 @@ describe("TerminalScreen", () => {
 
     // The terminal lands on a running session automatically (last-session-first).
     await waitFor(() =>
-      expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledWith("ws-token", SESSION_ID, undefined),
+      expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledWith(
+        "ws-token",
+        SESSION_ID,
+        undefined,
+        EXCLUSIVE_HARD_PRESENTATION,
+      ),
     );
     await act(async () => {
       socket.onopen?.();
@@ -257,7 +281,12 @@ describe("TerminalScreen", () => {
 
     // Remembered session auto-attaches by name on open (no create, no attach frame).
     await waitFor(() =>
-      expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledWith("ws-token", SESSION_ID, undefined),
+      expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledWith(
+        "ws-token",
+        SESSION_ID,
+        undefined,
+        EXCLUSIVE_HARD_PRESENTATION,
+      ),
     );
     expect(gatewayClient.createTerminalSession).not.toHaveBeenCalled();
     await act(async () => {
@@ -361,7 +390,12 @@ describe("TerminalScreen", () => {
 
     // The terminal auto-attaches to the last running session on open.
     await waitFor(() =>
-      expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledWith("ws-token", SESSION_ID, undefined),
+      expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledWith(
+        "ws-token",
+        SESSION_ID,
+        undefined,
+        EXCLUSIVE_HARD_PRESENTATION,
+      ),
     );
 
     await act(async () => {
@@ -424,9 +458,136 @@ describe("TerminalScreen", () => {
 
     // The persisted session is gone, so it auto-attaches to the available one.
     await waitFor(() =>
-      expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledWith("ws-token", AVAILABLE, undefined),
+      expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledWith(
+        "ws-token",
+        AVAILABLE,
+        undefined,
+        EXCLUSIVE_HARD_PRESENTATION,
+      ),
     );
     expect(gatewayClient.createTerminalSession).not.toHaveBeenCalled();
+  });
+
+  it("applies canonical presentation frames and offers explicit resume after displacement", async () => {
+    global.WebSocket = { OPEN: 1, CLOSED: 3 } as typeof WebSocket;
+    const firstSocket = new MockTerminalSocket();
+    const resumedSocket = new MockTerminalSocket();
+    jest.mocked(AsyncStorage.getItem).mockResolvedValue(null);
+    jest.mocked(AsyncStorage.setItem).mockResolvedValue();
+    const gatewayClient = {
+      getTerminalSessions: jest.fn().mockResolvedValue([
+        { sessionId: SESSION_ID, cwd: "/home/matrix/home", state: "running" },
+      ]),
+      createTerminalSession: jest.fn().mockResolvedValue(SESSION_ID),
+      getWsToken: jest.fn().mockResolvedValue("ws-token"),
+      setWebSocketToken: jest.fn(),
+      openTerminalWebSocket: jest.fn()
+        .mockReturnValueOnce(firstSocket as unknown as WebSocket)
+        .mockReturnValueOnce(resumedSocket as unknown as WebSocket),
+      deleteTerminalSession: jest.fn().mockResolvedValue(true),
+    };
+    jest.mocked(useGateway).mockReturnValue({
+      client: gatewayClient as unknown as GatewayClient,
+      connectionState: "connected",
+      gateway: null,
+      setGateway: jest.fn(),
+      unreadCount: 0,
+      incrementUnread: jest.fn(),
+      clearUnread: jest.fn(),
+    });
+
+    render(<TerminalScreen />);
+    await waitFor(() => expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      firstSocket.onopen?.();
+      firstSocket.onmessage?.({
+        data: JSON.stringify({
+          type: "attached",
+          session: SESSION_ID,
+          state: "running",
+          canonicalSize: { cols: 92, rows: 31 },
+          lease: { epoch: 5 },
+        }),
+      });
+      firstSocket.onmessage?.({ data: JSON.stringify({ type: "presentation-reset" }) });
+      firstSocket.onmessage?.({ data: JSON.stringify({ type: "canonical-size", cols: 90, rows: 30 }) });
+      firstSocket.onmessage?.({ data: JSON.stringify({ type: "lease-revoked", epoch: 5 }) });
+      await Promise.resolve();
+    });
+
+    expect(webViewInjections.some((js) => js.includes("window.__term.resize(92,31)"))).toBe(true);
+    expect(webViewInjections.some((js) => js.includes("window.__term.reset()"))).toBe(true);
+    expect(webViewInjections.some((js) => js.includes("window.__term.resize(90,30)"))).toBe(true);
+    expect(await screen.findByText("Live on another device.")).toBeTruthy();
+    expect(firstSocket.closed).toBe(true);
+
+    fireEvent.press(screen.getByText("Resume here"));
+    await waitFor(() => expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledTimes(2));
+    expect(gatewayClient.openTerminalWebSocket).toHaveBeenLastCalledWith(
+      "ws-token",
+      SESSION_ID,
+      undefined,
+      EXCLUSIVE_HARD_PRESENTATION,
+    );
+  });
+
+  it("releases ownership when unfocused and reacquires it on return", async () => {
+    global.WebSocket = { OPEN: 1, CLOSED: 3 } as typeof WebSocket;
+    const firstSocket = new MockTerminalSocket();
+    const returnedSocket = new MockTerminalSocket();
+    jest.mocked(AsyncStorage.getItem).mockResolvedValue(null);
+    jest.mocked(AsyncStorage.setItem).mockResolvedValue();
+    const gatewayClient = {
+      getTerminalSessions: jest.fn().mockResolvedValue([
+        { sessionId: SESSION_ID, cwd: "/home/matrix/home", state: "running" },
+      ]),
+      createTerminalSession: jest.fn().mockResolvedValue(SESSION_ID),
+      getWsToken: jest.fn().mockResolvedValue("ws-token"),
+      setWebSocketToken: jest.fn(),
+      openTerminalWebSocket: jest.fn()
+        .mockReturnValueOnce(firstSocket as unknown as WebSocket)
+        .mockReturnValueOnce(returnedSocket as unknown as WebSocket),
+      deleteTerminalSession: jest.fn().mockResolvedValue(true),
+    };
+    jest.mocked(useGateway).mockReturnValue({
+      client: gatewayClient as unknown as GatewayClient,
+      connectionState: "connected",
+      gateway: null,
+      setGateway: jest.fn(),
+      unreadCount: 0,
+      incrementUnread: jest.fn(),
+      clearUnread: jest.fn(),
+    });
+
+    render(<TerminalScreen />);
+    await waitFor(() => expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      firstSocket.onopen?.();
+      firstSocket.onmessage?.({
+        data: JSON.stringify({
+          type: "attached",
+          session: SESSION_ID,
+          state: "running",
+          canonicalSize: { cols: 80, rows: 24 },
+          lease: { epoch: 9 },
+        }),
+      });
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      mockFocusCleanup?.();
+      await Promise.resolve();
+    });
+    expect(firstSocket.sent.map((frame) => JSON.parse(frame))).toContainEqual({ type: "detach" });
+    expect(firstSocket.closed).toBe(true);
+
+    await act(async () => {
+      const cleanup = mockFocusCallback?.();
+      mockFocusCleanup = typeof cleanup === "function" ? cleanup : null;
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledTimes(2));
   });
 
   it("does not fall back to another running session when an explicit terminal handoff is stale", async () => {

--- a/apps/mobile/app/(tabs)/terminal.tsx
+++ b/apps/mobile/app/(tabs)/terminal.tsx
@@ -3,9 +3,11 @@ import {
   ActivityIndicator,
   Alert,
   Animated,
+  AppState,
   Easing,
   Keyboard,
   Linking,
+  Pressable,
   Text,
   useWindowDimensions,
   View,
@@ -65,6 +67,12 @@ export default function TerminalScreen() {
   const [sessionsLoaded, setSessionsLoaded] = useState(false);
   const [maximized, setMaximized] = useState(false);
   const [chromeExpanded, setChromeExpanded] = useState(false);
+  const [leaseRevoked, setLeaseRevoked] = useState(false);
+  // React Native may report null briefly while the bridge initializes. Treat
+  // that startup window as active; subsequent AppState events are authoritative.
+  const [appState, setAppState] = useState(AppState.currentState ?? "active");
+  const [focusKnown, setFocusKnown] = useState(false);
+  const [statusBarFocused, setStatusBarFocused] = useState(false);
   const terminalClient = useMemo(() => (client ? new MobileTerminalClient(client) : null), [client]);
   const connectionRef = useRef<MobileTerminalConnection | null>(null);
   const connectAttemptRef = useRef(0);
@@ -73,6 +81,9 @@ export default function TerminalScreen() {
   // The session whose live output is currently streaming, so output frames land
   // in the right scrollback cache bucket (state.activeSessionId lags in closures).
   const attachedSessionIdRef = useRef<string | null>(null);
+  // The requested session is retained across a focus/background cutover even
+  // if the socket was cancelled before its attached frame arrived.
+  const targetSessionIdRef = useRef<string | null>(null);
   const keyboardLift = useRef(new Animated.Value(0)).current;
   // Cursor-aware keyboard lift: the emulator reports the cursor's bottom edge
   // (surface-local px); combined with the surface's window offset we lift only
@@ -81,6 +92,14 @@ export default function TerminalScreen() {
   const surfaceWindowTopRef = useRef(0);
   const surfaceWrapRef = useRef<View | null>(null);
   const keyboardFrameRef = useRef<{ keyboardTopY: number; maxLift: number } | null>(null);
+
+  useFocusEffect(
+    useCallback(() => {
+      setFocusKnown(true);
+      setStatusBarFocused(true);
+      return () => setStatusBarFocused(false);
+    }, []),
+  );
 
   // Detected-URL banner state. Refs hold the rolling scan window + recent list;
   // only the surfaced URL drives a render.
@@ -150,6 +169,11 @@ export default function TerminalScreen() {
   }, [loadSessions]);
 
   useEffect(() => {
+    const subscription = AppState.addEventListener("change", setAppState);
+    return () => subscription.remove();
+  }, []);
+
+  useEffect(() => {
     loadMobileShellState()
       .then((saved) => {
         setLastTerminalSessionId(saved.lastActiveTerminalSessionId);
@@ -182,11 +206,16 @@ export default function TerminalScreen() {
 
   const handleFrame = useCallback((frame: TerminalServerFrame) => {
     if (frame.type === "attached") {
+      setLeaseRevoked(false);
       surfaceRef.current?.clear();
+      if (frame.canonicalSize) {
+        surfaceRef.current?.resize(frame.canonicalSize.cols, frame.canonicalSize.rows);
+      }
       if (frame.replay) surfaceRef.current?.write(frame.replay);
       // The gateway replay is authoritative and just repainted the cleared
       // surface, so any cached preview is now superseded — reset the cache to it.
       attachedSessionIdRef.current = frame.sessionId;
+      targetSessionIdRef.current = frame.sessionId;
       resetScrollback(frame.sessionId, frame.replay ?? "");
       if (frame.replay) scanForUrls(frame.replay);
       dispatch({
@@ -211,6 +240,25 @@ export default function TerminalScreen() {
       loadSessions();
       return;
     }
+    if (frame.type === "canonical-size") {
+      surfaceRef.current?.resize(frame.cols, frame.rows);
+      return;
+    }
+    if (frame.type === "presentation-reset") {
+      surfaceRef.current?.reset();
+      if (attachedSessionIdRef.current) resetScrollback(attachedSessionIdRef.current, "");
+      resetUrlDetection();
+      dispatch({ type: "reset.output" });
+      return;
+    }
+    if (frame.type === "lease-revoked") {
+      setLeaseRevoked(true);
+      connectingRef.current = false;
+      connectionRef.current?.close();
+      connectionRef.current = null;
+      dispatch({ type: "connection.changed", status: "detached" });
+      return;
+    }
     if (frame.type === "output") {
       surfaceRef.current?.write(frame.data);
       if (attachedSessionIdRef.current) appendScrollback(attachedSessionIdRef.current, frame.data);
@@ -221,6 +269,7 @@ export default function TerminalScreen() {
     if (frame.type === "exit") {
       if (attachedSessionIdRef.current) clearScrollback(attachedSessionIdRef.current);
       attachedSessionIdRef.current = null;
+      targetSessionIdRef.current = null;
       dispatch({ type: "terminal.ended", exitCode: frame.exitCode });
       setLastTerminalSessionId(null);
       loadSessions();
@@ -229,7 +278,7 @@ export default function TerminalScreen() {
     if (frame.type === "error") {
       dispatch({ type: "terminal.error", message: frame.message ?? "Terminal unavailable" });
     }
-  }, [loadSessions, scanForUrls]);
+  }, [loadSessions, resetUrlDetection, scanForUrls]);
 
   const clearTerminalHandoff = useCallback(() => {
     setTerminalHandoffSessionId(null);
@@ -254,6 +303,7 @@ export default function TerminalScreen() {
     const attemptId = connectAttemptRef.current + 1;
     connectAttemptRef.current = attemptId;
     connectingRef.current = true;
+    if (sessionId) targetSessionIdRef.current = sessionId;
     connectionRef.current?.detach();
     connectionRef.current = null;
     dispatch({ type: "connection.changed", status: "connecting" });
@@ -273,6 +323,7 @@ export default function TerminalScreen() {
         }
       }
       if (connectAttemptRef.current !== attemptId) return;
+      targetSessionIdRef.current = targetName;
       // New session view: drop the previous session's detected-URL banner; the
       // attach replay below re-scans this session's history.
       resetUrlDetection();
@@ -320,10 +371,10 @@ export default function TerminalScreen() {
   }, [handleFrame, resetUrlDetection, terminalClient]);
 
   const sendData = useCallback((data: string) => {
-    if (!data) return;
+    if (!data || leaseRevoked) return;
     const sent = connectionRef.current?.sendInput(data) ?? false;
     if (!sent) dispatch({ type: "terminal.error", message: "Terminal unavailable" });
-  }, []);
+  }, [leaseRevoked]);
 
   const animateKeyboardLift = useCallback((event: KeyboardEvent | null, lift: number) => {
     Animated.timing(keyboardLift, {
@@ -397,6 +448,7 @@ export default function TerminalScreen() {
       clearScrollback(sessionId);
     }
     attachedSessionIdRef.current = null;
+    targetSessionIdRef.current = null;
     resetUrlDetection();
     connectAttemptRef.current += 1;
     connectingRef.current = false;
@@ -445,8 +497,10 @@ export default function TerminalScreen() {
   // running session, attach to it automatically (once). Picking a session from
   // the Sessions screen updates the persisted last session, so it lands here.
   const autoConnectedRef = useRef(false);
+  const appIsActive = appState !== "background" && appState !== "inactive";
   useEffect(() => {
     if (autoConnectedRef.current) return;
+    if (!focusKnown || !statusBarFocused || !appIsActive) return;
     if (!terminalResumeLoaded || !sessionsLoaded) return;
     if (state.status !== "idle") return;
     if (terminalHandoffSessionId && !handoffRunningSession) {
@@ -460,11 +514,14 @@ export default function TerminalScreen() {
     connectSession(autoAttachSession.sessionId);
   }, [
     autoAttachSession,
+    appIsActive,
     clearTerminalHandoff,
     connectSession,
+    focusKnown,
     handoffRunningSession,
     sessionsLoaded,
     state.status,
+    statusBarFocused,
     terminalHandoffSessionId,
     terminalResumeLoaded,
   ]);
@@ -474,13 +531,38 @@ export default function TerminalScreen() {
   // unconditioned <StatusBar> here would leak light style onto every other
   // tab; declarative mount/unmount hands control back to the root's dark bar
   // (imperative setStatusBarStyle gets overridden by later component updates).
-  const [statusBarFocused, setStatusBarFocused] = useState(false);
-  useFocusEffect(
-    useCallback(() => {
-      setStatusBarFocused(true);
-      return () => setStatusBarFocused(false);
-    }, []),
-  );
+  const presentationActive = focusKnown && statusBarFocused && appIsActive;
+
+  useEffect(() => {
+    if (!focusKnown) return;
+    if (!presentationActive) {
+      if (connectionRef.current || connectingRef.current) {
+        connectAttemptRef.current += 1;
+        connectingRef.current = false;
+        connectionRef.current?.detach();
+        connectionRef.current = null;
+        dispatch({ type: "connection.changed", status: "detached" });
+      }
+      return;
+    }
+    const resumableSessionId = state.activeSessionId ?? targetSessionIdRef.current;
+    if (
+      leaseRevoked
+      || connectionRef.current
+      || connectingRef.current
+      || !resumableSessionId
+      || state.status !== "detached"
+    ) {
+      return;
+    }
+    void connectSession(resumableSessionId);
+  }, [connectSession, focusKnown, leaseRevoked, presentationActive, state.activeSessionId, state.status]);
+
+  const resumeHere = useCallback(() => {
+    if (!state.activeSessionId || !presentationActive) return;
+    setLeaseRevoked(false);
+    void connectSession(state.activeSessionId);
+  }, [connectSession, presentationActive, state.activeSessionId]);
 
   return (
     <View style={styles.screen}>
@@ -519,6 +601,18 @@ export default function TerminalScreen() {
             onResize={handleResize}
             onCursor={handleCursor}
           />
+          {leaseRevoked ? (
+            <View style={styles.leaseOverlay}>
+              <Text style={styles.leaseTitle}>Live on another device.</Text>
+              <Pressable
+                accessibilityRole="button"
+                onPress={resumeHere}
+                style={styles.resumeButton}
+              >
+                <Text style={styles.resumeButtonText}>Resume here</Text>
+              </Pressable>
+            </View>
+          ) : null}
           {state.status === "idle" ? (
             <View style={styles.emptyOverlay} pointerEvents="none">
               <Text style={styles.emptyTitle}>No terminal session</Text>
@@ -647,6 +741,31 @@ const styles = StyleSheet.create((theme) => ({
     color: theme.terminal.fgDim,
     fontSize: 13,
     lineHeight: 18,
+  },
+  leaseOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 2,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 12,
+    paddingHorizontal: 28,
+    backgroundColor: "rgba(15, 23, 42, 0.82)",
+  },
+  leaseTitle: {
+    fontFamily: theme.fonts.sansMedium,
+    color: theme.terminal.fg,
+    fontSize: 14,
+  },
+  resumeButton: {
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 9,
+    backgroundColor: theme.colors.primary,
+  },
+  resumeButtonText: {
+    fontFamily: theme.fonts.sansBold,
+    color: theme.colors.primaryForeground,
+    fontSize: 13,
   },
   errorBar: {
     marginHorizontal: 14,

--- a/apps/mobile/components/TerminalSurface.tsx
+++ b/apps/mobile/components/TerminalSurface.tsx
@@ -18,6 +18,8 @@ import { FIT_ADDON_JS, XTERM_CSS, XTERM_JS } from "@/components/terminal/xterm-b
 export interface TerminalSurfaceHandle {
   write: (data: string) => void;
   clear: () => void;
+  reset: () => void;
+  resize: (cols: number, rows: number) => void;
   focus: () => void;
   blur: () => void;
   scrollLines: (lines: number) => void;
@@ -245,6 +247,15 @@ export const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurface
         clear: () => {
           pendingRef.current = [];
           inject("window.__term && window.__term.clear()");
+        },
+        reset: () => {
+          pendingRef.current = [];
+          inject("window.__term && window.__term.reset()");
+        },
+        resize: (cols: number, rows: number) => {
+          if (!Number.isInteger(cols) || !Number.isInteger(rows)) return;
+          if (cols < 1 || cols > 500 || rows < 1 || rows > 200) return;
+          inject(`window.__term && window.__term.resize(${cols},${rows})`);
         },
         focus: () => inject("window.__matrixTerminal && window.__matrixTerminal.focus()"),
         blur: () => inject("window.__matrixTerminal && window.__matrixTerminal.blur()"),

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -637,13 +637,29 @@ export class GatewayClient {
     };
   }
 
-  openTerminalWebSocket(token?: string | null, sessionName?: string, fromSeq?: number): WebSocket {
+  openTerminalWebSocket(
+    token?: string | null,
+    sessionName?: string,
+    fromSeq?: number,
+    presentation?: {
+      client: "hard" | "soft";
+      cols: number;
+      rows: number;
+      lease?: "exclusive";
+    },
+  ): WebSocket {
     if (token || this.token) {
       assertSecureTokenTransport(this.baseUrl);
     }
     const params = new URLSearchParams();
     if (sessionName) params.set("session", sessionName);
     if (typeof fromSeq === "number" && Number.isFinite(fromSeq)) params.set("fromSeq", String(fromSeq));
+    if (presentation) {
+      params.set("client", presentation.client);
+      params.set("cols", String(presentation.cols));
+      params.set("rows", String(presentation.rows));
+      if (presentation.lease) params.set("lease", presentation.lease);
+    }
     if (token) params.set("token", token);
     const query = params.toString();
     const wsUrl = query ? appendQuery(this.terminalWsUrl, query) : this.terminalWsUrl;

--- a/apps/mobile/lib/terminal-client.ts
+++ b/apps/mobile/lib/terminal-client.ts
@@ -4,16 +4,34 @@ export { isSafeSessionId, parseTerminalSessions } from "@/lib/terminal-state";
 
 const WS_CONNECTING = 0;
 const WS_OPEN = 1;
+const LEASE_HEARTBEAT_INTERVAL_MS = 10_000;
 
 export type TerminalClientFrame =
   | { type: "attach"; sessionId?: string; cwd?: string; fromSeq?: number }
   | { type: "input"; data: string }
   | { type: "resize"; cols: number; rows: number }
+  | { type: "ping" }
   | { type: "detach" }
   | { type: "destroy" };
 
+export interface TerminalCanonicalSize {
+  cols: number;
+  rows: number;
+}
+
 export type TerminalServerFrame =
-  | { type: "attached"; sessionId: string; cwd?: string; replay?: string }
+  | {
+      type: "attached";
+      sessionId: string;
+      state: "running" | "exited";
+      cwd?: string;
+      replay?: string;
+      canonicalSize: TerminalCanonicalSize | null;
+      leaseEpoch: number | null;
+    }
+  | { type: "canonical-size"; cols: number; rows: number }
+  | { type: "lease-revoked" }
+  | { type: "presentation-reset" }
   | { type: "output"; data: string }
   | { type: "replay-start"; fromSeq?: number; toSeq?: number }
   | { type: "replay-end"; nextSeq?: number }
@@ -53,7 +71,14 @@ export class MobileTerminalClient {
     if (!options.sessionId) return null;
     const token = await this.gateway.getWsToken();
     this.gateway.setWebSocketToken(token);
-    const ws = this.gateway.openTerminalWebSocket(token, options.sessionId, options.fromSeq);
+    const cols = clampInteger(options.cols ?? 80, 1, 500);
+    const rows = clampInteger(options.rows ?? 24, 1, 200);
+    const ws = this.gateway.openTerminalWebSocket(token, options.sessionId, options.fromSeq, {
+      client: "hard",
+      cols,
+      rows,
+      lease: "exclusive",
+    });
     const connection = new MobileTerminalConnection(ws, options);
     connection.attach();
     return connection;
@@ -62,6 +87,8 @@ export class MobileTerminalClient {
 
 export class MobileTerminalConnection {
   private attached = false;
+  private leaseEpoch: number | null = null;
+  private leaseHeartbeatTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
     private readonly ws: WebSocket,
@@ -71,19 +98,24 @@ export class MobileTerminalConnection {
   attach(): void {
     this.options.onStatus?.("connecting");
 
-    // The session name is supplied in the WS query, so no attach frame is sent;
-    // we just announce our viewport size once the socket opens.
+    // The session name, initial hard-grid dimensions, and exclusive lease are
+    // supplied in the WS query, so no attach or startup resize frame is needed.
     this.ws.onopen = () => {
       this.attached = true;
       this.options.onStatus?.("open");
-      if (this.options.cols && this.options.rows) {
-        this.resize(this.options.cols, this.options.rows);
-      }
     };
 
     this.ws.onmessage = (event) => {
       const frame = parseTerminalServerFrame(event.data);
-      if (frame) this.options.onMessage(frame);
+      if (!frame) return;
+      if (frame.type === "attached") {
+        this.leaseEpoch = frame.leaseEpoch;
+        this.scheduleLeaseHeartbeat();
+      } else if (frame.type === "lease-revoked") {
+        this.leaseEpoch = null;
+        this.clearLeaseHeartbeat();
+      }
+      this.options.onMessage(frame);
     };
 
     this.ws.onerror = () => {
@@ -91,6 +123,9 @@ export class MobileTerminalConnection {
     };
 
     this.ws.onclose = () => {
+      this.attached = false;
+      this.leaseEpoch = null;
+      this.clearLeaseHeartbeat();
       this.options.onStatus?.("closed");
     };
   }
@@ -122,6 +157,8 @@ export class MobileTerminalConnection {
   }
 
   close(): void {
+    this.clearLeaseHeartbeat();
+    this.leaseEpoch = null;
     if (this.ws.readyState !== WS_CONNECTING && this.ws.readyState !== WS_OPEN) return;
     this.attached = false;
     this.ws.close();
@@ -132,6 +169,23 @@ export class MobileTerminalConnection {
     this.ws.send(JSON.stringify(frame));
     return true;
   }
+
+  private scheduleLeaseHeartbeat(): void {
+    this.clearLeaseHeartbeat();
+    if (this.leaseEpoch === null || !this.attached) return;
+    this.leaseHeartbeatTimer = setTimeout(() => {
+      this.leaseHeartbeatTimer = null;
+      if (this.leaseEpoch === null || !this.attached) return;
+      this.sendFrame({ type: "ping" });
+      this.scheduleLeaseHeartbeat();
+    }, LEASE_HEARTBEAT_INTERVAL_MS);
+  }
+
+  private clearLeaseHeartbeat(): void {
+    if (this.leaseHeartbeatTimer === null) return;
+    clearTimeout(this.leaseHeartbeatTimer);
+    this.leaseHeartbeatTimer = null;
+  }
 }
 
 export function buildTerminalWebSocketUrl(baseUrl: string, token?: string | null): string {
@@ -140,19 +194,89 @@ export function buildTerminalWebSocketUrl(baseUrl: string, token?: string | null
   return `${url}?token=${encodeURIComponent(token)}`;
 }
 
-function parseTerminalServerFrame(data: unknown): TerminalServerFrame | null {
+export function parseTerminalServerFrame(data: unknown): TerminalServerFrame | null {
   if (typeof data !== "string") return null;
   try {
-    const frame = JSON.parse(data) as TerminalServerFrame;
+    const frame = JSON.parse(data) as Record<string, unknown>;
     if (!frame || typeof frame !== "object" || typeof frame.type !== "string") return null;
-    if (frame.type === "attached" && typeof frame.sessionId === "string") return frame;
-    if (frame.type === "output" && typeof frame.data === "string") return frame;
-    if (frame.type === "replay-start" || frame.type === "replay-end" || frame.type === "exit") return frame;
+    if (frame.type === "attached") {
+      const sessionId = typeof frame.session === "string"
+        ? frame.session
+        : typeof frame.sessionId === "string"
+          ? frame.sessionId
+          : null;
+      if (!sessionId || (frame.state !== undefined && frame.state !== "running" && frame.state !== "exited")) {
+        return null;
+      }
+      const lease = frame.lease && typeof frame.lease === "object"
+        ? frame.lease as Record<string, unknown>
+        : null;
+      return {
+        type: "attached",
+        sessionId,
+        state: frame.state === "exited" ? "exited" : "running",
+        ...(typeof frame.cwd === "string" ? { cwd: frame.cwd } : {}),
+        ...(typeof frame.replay === "string" ? { replay: frame.replay } : {}),
+        canonicalSize: parseCanonicalSize(frame.canonicalSize),
+        leaseEpoch: Number.isSafeInteger(lease?.epoch) && (lease?.epoch as number) > 0
+          ? lease?.epoch as number
+          : null,
+      };
+    }
+    if (frame.type === "canonical-size") {
+      const size = parseCanonicalSize(frame);
+      return size ? { type: "canonical-size", ...size } : null;
+    }
+    if (frame.type === "lease-revoked") return { type: "lease-revoked" };
+    if (frame.type === "presentation-reset") return { type: "presentation-reset" };
+    if (frame.type === "output" && typeof frame.data === "string") {
+      return { type: "output", data: frame.data };
+    }
+    if (frame.type === "replay-start") {
+      return {
+        type: "replay-start",
+        ...(Number.isSafeInteger(frame.fromSeq) ? { fromSeq: frame.fromSeq as number } : {}),
+        ...(Number.isSafeInteger(frame.toSeq) ? { toSeq: frame.toSeq as number } : {}),
+      };
+    }
+    if (frame.type === "replay-end") {
+      return {
+        type: "replay-end",
+        ...(Number.isSafeInteger(frame.nextSeq) ? { nextSeq: frame.nextSeq as number } : {}),
+      };
+    }
+    if (frame.type === "exit") {
+      const rawExitCode = frame.code ?? frame.exitCode;
+      return {
+        type: "exit",
+        exitCode: typeof rawExitCode === "number" && Number.isFinite(rawExitCode)
+          ? rawExitCode
+          : rawExitCode === null
+            ? null
+            : undefined,
+      };
+    }
     if (frame.type === "error") return { type: "error", message: typeof frame.message === "string" ? frame.message : undefined };
     return null;
   } catch {
     return null;
   }
+}
+
+function parseCanonicalSize(value: unknown): TerminalCanonicalSize | null {
+  if (!value || typeof value !== "object") return null;
+  const size = value as Record<string, unknown>;
+  if (
+    !Number.isInteger(size.cols)
+    || (size.cols as number) < 1
+    || (size.cols as number) > 500
+    || !Number.isInteger(size.rows)
+    || (size.rows as number) < 1
+    || (size.rows as number) > 200
+  ) {
+    return null;
+  }
+  return { cols: size.cols as number, rows: size.rows as number };
 }
 
 function clampInteger(value: number, min: number, max: number): number {

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -35,6 +35,15 @@ import {
 const GAP_MARKER = "\r\n\x1b[2m── output gap ──\x1b[0m\r\n";
 const RECENT_ACTIVITY_THROTTLE_MS = 30_000;
 
+function proposedTerminalDimensions(fit: FitAddon | null, terminal: Terminal): { cols: number; rows: number } {
+  // The production add-on exposes proposeDimensions(). Keep a safe fallback
+  // for a temporarily unmeasurable host (and lightweight renderer test mocks).
+  if (fit && typeof fit.proposeDimensions === "function") {
+    return fit.proposeDimensions() ?? { cols: terminal.cols, rows: terminal.rows };
+  }
+  return { cols: terminal.cols, rows: terminal.rows };
+}
+
 function applyTerminalSurfaceTheme(element: HTMLElement | undefined, background: string): void {
   if (!element) return;
   element.style.width = "100%";
@@ -72,6 +81,8 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
   const hoveredLinkRef = useRef<TerminalLinkEntry | null>(null);
   const [socketState, setSocketState] = useState<ShellSocketState>("connecting");
   const [exitCode, setExitCode] = useState<number | null>(null);
+  const [leaseRevoked, setLeaseRevoked] = useState(false);
+  const [leaseAttempt, setLeaseAttempt] = useState(0);
   const [terminalContextMenu, setTerminalContextMenu] = useState<DesktopTerminalMenuState | null>(null);
   const closeTerminalContextMenu = useCallback(() => setTerminalContextMenu(null), []);
   const [pasteError, setPasteError] = useState<string | null>(null);
@@ -81,6 +92,7 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
     endedRef.current = false;
     setSocketState("connecting");
     setExitCode(null);
+    setLeaseRevoked(false);
   }
 
   // xterm lifecycle — mount once, dispose only on real unmount (tab close).
@@ -194,8 +206,8 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
       if (rafId !== null) cancelAnimationFrame(rafId);
       rafId = window.requestAnimationFrame(() => {
         rafId = null;
-        fit.fit();
-        attachmentRef.current?.resize(terminal.cols, terminal.rows);
+        const proposed = proposedTerminalDimensions(fit, terminal);
+        attachmentRef.current?.resize(proposed.cols, proposed.rows);
       });
     });
     observer.observe(host);
@@ -241,6 +253,16 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
     const attachment = manager.attach(sessionName, {
       onState: (state) => setSocketState(state),
       onOutput: (data) => terminal.write(data),
+      onCanonicalSize: (size) => {
+        if (terminal.cols !== size.cols || terminal.rows !== size.rows) {
+          terminal.resize(size.cols, size.rows);
+        }
+      },
+      onLeaseRevoked: () => {
+        endedRef.current = true;
+        setLeaseRevoked(true);
+        setSocketState("ended");
+      },
       onGap: () => {
         terminal.clear();
         terminal.write(GAP_MARKER);
@@ -250,7 +272,7 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
         setExitCode(code);
         setSocketState("ended");
       },
-    });
+    }, { cols: terminal.cols, rows: terminal.rows });
     attachmentRef.current = attachment;
     let lastRecentActivityAt = 0;
     const dataDisposable = terminal.onData((data) => {
@@ -261,8 +283,8 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
       }
       attachment.write(data);
     });
-    fit?.fit();
-    attachment.resize(terminal.cols, terminal.rows);
+    const proposed = proposedTerminalDimensions(fit, terminal);
+    attachment.resize(proposed.cols, proposed.rows);
     terminal.focus();
 
     return () => {
@@ -270,7 +292,7 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
       attachmentRef.current = null;
       if (manager.activeSessionName === sessionName) manager.detachActive();
     };
-  }, [sessionName, active, closeTerminalContextMenu]);
+  }, [sessionName, active, closeTerminalContextMenu, leaseAttempt]);
 
   useEffect(() => {
     const host = hostRef.current;
@@ -356,6 +378,17 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
   }, [active, api, sessionName]);
 
   const banner = (() => {
+    if (leaseRevoked) {
+      return {
+        text: "Live on another device.",
+        action: <Button variant="primary" onClick={() => {
+          endedRef.current = false;
+          setLeaseRevoked(false);
+          setSocketState("connecting");
+          setLeaseAttempt((attempt) => attempt + 1);
+        }}>Resume here</Button>,
+      };
+    }
     if (socketState === "fatal") {
       return { text: "This session has ended on your computer.", action: onRecreate ? <Button variant="primary" onClick={onRecreate}>Start new session</Button> : null };
     }

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -263,6 +263,9 @@ export default function TerminalView({ sessionName, active = true, onRecreate }:
         setLeaseRevoked(true);
         setSocketState("ended");
       },
+      onPresentationReset: () => {
+        terminal.reset();
+      },
       onGap: () => {
         terminal.clear();
         terminal.write(GAP_MARKER);

--- a/desktop/src/renderer/src/features/terminal/attach-manager.ts
+++ b/desktop/src/renderer/src/features/terminal/attach-manager.ts
@@ -15,6 +15,11 @@ export interface SocketControl {
   dispose(): void;
 }
 
+export interface TerminalDimensions {
+  cols: number;
+  rows: number;
+}
+
 export interface AttachManagerOptions {
   createSocket: (sessionName: string, events: ShellSocketEvents) => SocketControl;
   bufferCacheCap?: number;
@@ -53,7 +58,7 @@ export class AttachManager {
     return this.active?.sessionName ?? null;
   }
 
-  attach(sessionName: string, events: ShellSocketEvents): ActiveAttachment {
+  attach(sessionName: string, events: ShellSocketEvents, initialSize?: TerminalDimensions): ActiveAttachment {
     if (this.disposed) {
       throw new Error("AttachManager is disposed");
     }
@@ -67,6 +72,12 @@ export class AttachManager {
       onOutput: (data: string, seq: number) => {
         if (this.isLive(generation)) events.onOutput(data, seq);
       },
+      onCanonicalSize: (size) => {
+        if (this.isLive(generation)) events.onCanonicalSize?.(size);
+      },
+      onLeaseRevoked: () => {
+        if (this.isLive(generation)) events.onLeaseRevoked?.();
+      },
       onGap: () => {
         if (this.isLive(generation)) events.onGap();
       },
@@ -76,6 +87,7 @@ export class AttachManager {
     };
     const socket = this.createSocket(sessionName, guarded);
     this.active = { sessionName, socket, generation };
+    if (initialSize) socket.resize(initialSize.cols, initialSize.rows);
     socket.connect();
     return {
       sessionName,

--- a/desktop/src/renderer/src/features/terminal/attach-manager.ts
+++ b/desktop/src/renderer/src/features/terminal/attach-manager.ts
@@ -78,6 +78,9 @@ export class AttachManager {
       onLeaseRevoked: () => {
         if (this.isLive(generation)) events.onLeaseRevoked?.();
       },
+      onPresentationReset: () => {
+        if (this.isLive(generation)) events.onPresentationReset?.();
+      },
       onGap: () => {
         if (this.isLive(generation)) events.onGap();
       },

--- a/desktop/src/renderer/src/features/terminal/terminal-runtime.ts
+++ b/desktop/src/renderer/src/features/terminal/terminal-runtime.ts
@@ -16,6 +16,7 @@ export function getAttachManager(): AttachManager {
           baseUrl: platformHost,
           sessionName,
           runtimeSlot,
+          clientClass: "hard",
           events,
         });
       },

--- a/desktop/src/renderer/src/lib/shell-socket.ts
+++ b/desktop/src/renderer/src/lib/shell-socket.ts
@@ -57,6 +57,7 @@ const RESIZE_DEBOUNCE_STARTUP_MS = 220;
 const RESIZE_DEBOUNCE_STEADY_MS = 90;
 const STARTUP_SETTLE_AFTER_ATTACH_MS = 300;
 const RESIZE_FALLBACK_AFTER_ATTACH_MS = 900;
+const LEASE_HEARTBEAT_INTERVAL_MS = 10_000;
 const MIN_COLS = 1;
 const MAX_COLS = 500;
 const MIN_ROWS = 1;
@@ -126,6 +127,8 @@ export class ShellSocket {
   private settleTimer: TimerHandle | null = null;
   private fallbackTimer: TimerHandle | null = null;
   private handshakeTimer: TimerHandle | null = null;
+  private leaseHeartbeatTimer: TimerHandle | null = null;
+  private leaseEpoch: number | null = null;
 
   constructor(options: ShellSocketOptions) {
     const hasSession = typeof options.sessionName === "string" && options.sessionName.length > 0;
@@ -223,6 +226,7 @@ export class ShellSocket {
     this.lastSentDims = null;
     this.resizeSentSinceAttach = false;
     this.inStartupWindow = true;
+    this.leaseEpoch = null;
 
     const url = this.buildUrl(isReconnect);
     let socket: WebSocketLike;
@@ -389,6 +393,14 @@ export class ShellSocket {
       return;
     }
     this.failedAttempts = 0;
+    const lease = frame.lease;
+    const leaseEpoch = lease && typeof lease === "object"
+      ? (lease as Record<string, unknown>).epoch
+      : null;
+    this.leaseEpoch = typeof leaseEpoch === "number" && Number.isInteger(leaseEpoch) && leaseEpoch > 0
+      ? leaseEpoch
+      : null;
+    this.scheduleLeaseHeartbeat();
     this.handleCanonicalSize(frame.canonicalSize && typeof frame.canonicalSize === "object"
       ? frame.canonicalSize as Record<string, unknown>
       : {});
@@ -457,6 +469,18 @@ export class ShellSocket {
         this.flushResize();
       }
     }, RESIZE_FALLBACK_AFTER_ATTACH_MS);
+  }
+
+  private scheduleLeaseHeartbeat(): void {
+    if (this.leaseHeartbeatTimer !== null) this.clearT(this.leaseHeartbeatTimer);
+    this.leaseHeartbeatTimer = null;
+    if (this.leaseEpoch === null || this.currentState === "ended" || this.currentState === "fatal") return;
+    this.leaseHeartbeatTimer = this.setT(() => {
+      this.leaseHeartbeatTimer = null;
+      if (this.leaseEpoch === null || this.currentState !== "attached" || this.socket === null) return;
+      this.sendFrame({ type: "ping" });
+      this.scheduleLeaseHeartbeat();
+    }, LEASE_HEARTBEAT_INTERVAL_MS);
   }
 
   private flushResize(): void {
@@ -533,6 +557,7 @@ export class ShellSocket {
       "settleTimer",
       "fallbackTimer",
       "handshakeTimer",
+      "leaseHeartbeatTimer",
     ] as const) {
       const handle = this[key];
       if (handle !== null) {
@@ -540,6 +565,7 @@ export class ShellSocket {
         this[key] = null;
       }
     }
+    this.leaseEpoch = null;
   }
 
   private setState(state: ShellSocketState, detail?: { code?: string }): void {

--- a/desktop/src/renderer/src/lib/shell-socket.ts
+++ b/desktop/src/renderer/src/lib/shell-socket.ts
@@ -25,6 +25,8 @@ export interface WebSocketLike {
 export interface ShellSocketEvents {
   onState(state: ShellSocketState, detail?: { code?: string }): void;
   onOutput(data: string, seq: number): void;
+  onCanonicalSize?(size: { cols: number; rows: number }): void;
+  onLeaseRevoked?(): void;
   onGap(): void;
   onExit(code: number): void;
 }
@@ -34,6 +36,7 @@ export interface ShellSocketOptions {
   sessionName?: string;
   cwd?: string;
   runtimeSlot: string;
+  clientClass?: "hard" | "soft";
   events: ShellSocketEvents;
   createWebSocket?: (url: string) => WebSocketLike;
   setTimeoutFn?: typeof setTimeout;
@@ -274,7 +277,11 @@ export class ShellSocket {
       : (this.opts.sessionName ?? null);
     if (sessionName !== null && sessionName.length > 0) {
       const fromSeq = isReconnect && this.receivedOutput ? this.lastSeqValue + 1 : LIVE_TAIL_FROM_SEQ;
-      return `${base}/ws/terminal/session?session=${encodeURIComponent(sessionName)}&fromSeq=${fromSeq}${runtimeSuffix}`;
+      const size = this.lastKnownDims;
+      const sizingSuffix = this.opts.clientClass && size
+        ? `&client=${this.opts.clientClass}&cols=${size.cols}&rows=${size.rows}&lease=exclusive`
+        : "";
+      return `${base}/ws/terminal/session?session=${encodeURIComponent(sessionName)}&fromSeq=${fromSeq}${runtimeSuffix}${sizingSuffix}`;
     }
     return `${base}/ws/terminal?cwd=${encodeURIComponent(this.opts.cwd ?? "")}${runtimeSuffix}`;
   }
@@ -340,6 +347,15 @@ export class ShellSocket {
         if (this.currentState !== "attached") return;
         this.handleOutput(frame);
         return;
+      case "canonical-size":
+        this.handleCanonicalSize(frame);
+        return;
+      case "lease-revoked":
+        this.teardownSocket();
+        this.clearAllTimers();
+        this.opts.events.onLeaseRevoked?.();
+        this.setState("ended");
+        return;
       case "exit":
         if (this.currentState !== "attached") return;
         this.handleExit(frame);
@@ -369,9 +385,21 @@ export class ShellSocket {
       return;
     }
     this.failedAttempts = 0;
+    this.handleCanonicalSize(frame.canonicalSize && typeof frame.canonicalSize === "object"
+      ? frame.canonicalSize as Record<string, unknown>
+      : {});
     this.flushPendingInput();
     this.scheduleAttachTimers();
     this.setState("attached");
+  }
+
+  private handleCanonicalSize(frame: Record<string, unknown>): void {
+    const cols = frame.cols;
+    const rows = frame.rows;
+    if (typeof cols !== "number" || typeof rows !== "number" || !Number.isInteger(cols) || !Number.isInteger(rows) || cols < MIN_COLS || cols > MAX_COLS || rows < MIN_ROWS || rows > MAX_ROWS) {
+      return;
+    }
+    this.opts.events.onCanonicalSize?.({ cols, rows });
   }
 
   private handleOutput(frame: Record<string, unknown>): void {

--- a/desktop/src/renderer/src/lib/shell-socket.ts
+++ b/desktop/src/renderer/src/lib/shell-socket.ts
@@ -27,6 +27,7 @@ export interface ShellSocketEvents {
   onOutput(data: string, seq: number): void;
   onCanonicalSize?(size: { cols: number; rows: number }): void;
   onLeaseRevoked?(): void;
+  onPresentationReset?(): void;
   onGap(): void;
   onExit(code: number): void;
 }
@@ -355,6 +356,9 @@ export class ShellSocket {
         this.clearAllTimers();
         this.opts.events.onLeaseRevoked?.();
         this.setState("ended");
+        return;
+      case "presentation-reset":
+        this.opts.events.onPresentationReset?.();
         return;
       case "exit":
         if (this.currentState !== "attached") return;

--- a/docs/dev/coding-agent-shells.md
+++ b/docs/dev/coding-agent-shells.md
@@ -130,6 +130,11 @@ When adding a provider:
 
 Coding-agent threads may point at a canonical terminal session using bounded terminal identifiers. The binding rules are:
 
+Cross-surface input, presentation, and canonical-size ownership follow
+[Terminal session ownership](./terminal-session-ownership.md). In particular,
+local command-line handoff uses `mos shell attach <session>`; raw
+`zellij attach` is not a coordinated Matrix client.
+
 - Workspace orchestration owns `/api/sessions`; canonical named terminal sessions use `/api/terminal/sessions`. The assembled gateway mounts the legacy terminal compatibility routes after workspace routes so task-session requests cannot be parsed as legacy terminal creates.
 
 - Thread snapshots can expose attachable terminal references, not raw PTY output.

--- a/docs/dev/mobile-shell.md
+++ b/docs/dev/mobile-shell.md
@@ -9,6 +9,9 @@ The 075 mobile shell work makes the phone experience launcher-first while keepin
 - Apps open full screen through `MobileAppSurface` in the browser shell and native runtime routes in Expo.
 - Canvas is reachable through an explicit launcher action, not as the default phone home.
 - Terminal uses Matrix-authenticated gateway sessions and WebSockets; users do not need SSH keys.
+- The focused native Terminal participates in gateway-coordinated presentation
+  ownership: it owns one canonical grid while visible, releases on blur or app
+  background, and offers **Resume here** after another renderer takes over.
 
 ## Local Dev Build
 

--- a/docs/dev/terminal-session-ownership.md
+++ b/docs/dev/terminal-session-ownership.md
@@ -1,0 +1,95 @@
+# Terminal session ownership
+
+Matrix customers do not need SSH access to use their computer. Normal terminal
+access happens through a Matrix surface, and the gateway attaches that surface
+to the named Zellij session on the customer's VPS.
+
+This document defines which attachment paths participate in coordinated live
+presentation ownership and records the deployment assumption behind the
+in-memory lease coordinator.
+
+## Supported attachment paths
+
+The following clients participate in gateway-coordinated ownership:
+
+- the focused browser Terminal in Canvas or Desktop mode, including the mobile
+  web shell;
+- the native desktop app's Terminal tab; and
+- the Matrix CLI using `mos shell attach <session>`.
+
+For example, attach the local CLI to the same `main` session shown by Matrix:
+
+```bash
+mos shell attach main
+```
+
+These clients authenticate to `/ws/terminal/session`, request an exclusive
+lease when focused, renew the lease while idle, and honor revocation. A named
+session has one live presentation owner at a time. The owner controls input and
+the canonical rows and columns; another renderer must explicitly resume the
+session to transfer ownership. Lease expiry fails closed and does not make a
+background observer writable.
+
+The separate native-mobile terminal client is gateway-routed but does not yet
+implement the lease, canonical-size, revocation, and resume contract. Treat it
+as a non-owner for a session that has entered coordinated ownership. Interactive
+native-mobile takeover requires extending that client with the same protocol;
+it must not introduce a second ownership model.
+
+## Direct Zellij attachment
+
+`zellij attach <session>` talks directly to the Zellij server and bypasses the
+Matrix gateway. It therefore cannot participate in gateway lease acquisition,
+heartbeat renewal, epoch fencing, canonical-size coordination, or renderer
+revocation.
+
+Direct Zellij attachment is an operator/developer diagnostic path, not a normal
+customer workflow. Do not use it when validating cross-surface handoff, and do
+not recommend it in customer support instructions. Use the coordinated CLI
+command instead:
+
+```bash
+mos shell attach <session>
+```
+
+Because the VPS owner controls their machine, Matrix cannot make the raw
+Zellij binary cryptographically inaccessible. An operator who deliberately
+bypasses the gateway accepts that the direct client may disturb presentation
+state or dimensions.
+
+## Gateway topology and distributed leases
+
+The current production topology has one authoritative gateway process per
+customer VPS. Terminal leases are consequently bounded, ephemeral, in-memory
+state in that process. Zellij remains the durable source of truth for the
+session and running programs; losing gateway lease state does not terminate the
+Zellij session.
+
+Do not run multiple gateway processes against the same customer's Zellij
+runtime with the current coordinator. Separate gateway processes would have
+independent lease maps and could each believe a different renderer owns the
+same session.
+
+Before introducing multiple gateway replicas for one runtime, replace the
+process-local coordinator with a shared authority that provides all of the
+following:
+
+- atomic acquisition with one monotonically increasing fencing epoch;
+- holder-and-epoch-conditional renewal, resize, and release;
+- bounded expiry that remains fail closed;
+- revocation delivery to sockets connected through every gateway replica; and
+- one shared canonical terminal size and serialized presentation cutover.
+
+Postgres, Redis, or another shared coordinator may implement that authority,
+but the correctness contract above matters more than the storage choice. A
+multi-gateway rollout is blocked until integration tests prove that connections
+split across replicas still select exactly one writer and one presentation
+size.
+
+## Intentional presentation constraint
+
+One Zellij session cannot provide independently reflowed live grids at two
+different sizes. Matrix therefore transfers presentation ownership instead of
+trying to render two simultaneously writable layouts. Background renderers are
+read-only and offer an explicit resume action; resuming recreates the gateway's
+Zellij attach bridge at the new owner's dimensions.

--- a/docs/dev/terminal-session-ownership.md
+++ b/docs/dev/terminal-session-ownership.md
@@ -14,7 +14,8 @@ The following clients participate in gateway-coordinated ownership:
 
 - the focused browser Terminal in Canvas or Desktop mode, including the mobile
   web shell;
-- the native desktop app's Terminal tab; and
+- the native desktop app's Terminal tab;
+- the focused native mobile Terminal tab; and
 - the Matrix CLI using `mos shell attach <session>`.
 
 For example, attach the local CLI to the same `main` session shown by Matrix:
@@ -30,11 +31,11 @@ the canonical rows and columns; another renderer must explicitly resume the
 session to transfer ownership. Lease expiry fails closed and does not make a
 background observer writable.
 
-The separate native-mobile terminal client is gateway-routed but does not yet
-implement the lease, canonical-size, revocation, and resume contract. Treat it
-as a non-owner for a session that has entered coordinated ownership. Interactive
-native-mobile takeover requires extending that client with the same protocol;
-it must not introduce a second ownership model.
+The native mobile client declares its measured xterm grid as a hard renderer,
+releases ownership when its Terminal tab loses focus or the app backgrounds,
+and reacquires ownership when the user returns. If another renderer takes over
+while mobile is visible, mobile closes the displaced socket and requires an
+explicit **Resume here** action before it requests a new exclusive lease.
 
 ## Direct Zellij attachment
 

--- a/docs/dev/user-systemd-terminal-activation.md
+++ b/docs/dev/user-systemd-terminal-activation.md
@@ -6,6 +6,11 @@ units. The release remains controlled by the normal immutable host-bundle
 channel and exact-version deployment paths; merging code does not promote a
 stable channel or deploy a customer VPS.
 
+This process-ownership layer is distinct from live renderer ownership. See
+[Terminal session ownership](./terminal-session-ownership.md) for supported
+gateway attachment paths, the raw `zellij attach` boundary, and the
+single-gateway topology requirement.
+
 ## Activation source of truth
 
 The installed app payload is authoritative:

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -2318,6 +2318,7 @@ export async function createGateway(config: GatewayConfig) {
       const namedSession = c.req.query("session");
       const fromSeqParam = c.req.query("fromSeq");
       const sizingParams = parseTerminalSizingParams((name) => c.req.query(name));
+      const exclusiveLease = c.req.query("lease") === "exclusive";
       let namedHandle: { onMessage(raw: string): void; onClose(): void } | null = null;
       let namedSocketClosed = false;
       const pendingInput = createPendingTerminalInputQueue();
@@ -2343,6 +2344,7 @@ export async function createGateway(config: GatewayConfig) {
             fromSeq,
             clientClass: sizingParams.clientClass,
             declaredSize: sizingParams.declaredSize,
+            exclusiveLease,
           }).then((session) => {
             if (namedSocketClosed) {
               session.onClose();
@@ -2515,6 +2517,7 @@ export async function createGateway(config: GatewayConfig) {
       const namedSession = c.req.query("session");
       const fromSeqParam = c.req.query("fromSeq");
       const sizingParams = parseTerminalSizingParams((name) => c.req.query(name));
+      const exclusiveLease = c.req.query("lease") === "exclusive";
       let handle: SessionHandle | null = null;
       let namedHandle: { onMessage(raw: string): void; onClose(): void } | null = null;
       let namedSocketClosed = false;
@@ -2569,6 +2572,7 @@ export async function createGateway(config: GatewayConfig) {
               fromSeq,
               clientClass: sizingParams.clientClass,
               declaredSize: sizingParams.declaredSize,
+              exclusiveLease,
             }).then((session) => {
               if (namedSocketClosed) {
                 session.onClose();

--- a/packages/gateway/src/shell/terminal-lease.ts
+++ b/packages/gateway/src/shell/terminal-lease.ts
@@ -85,7 +85,12 @@ export function createTerminalLeaseCoordinator(options: TerminalLeaseCoordinator
     if (!lease || lease.holderId !== holderId || lease.epoch !== epoch) {
       return false;
     }
-    lease.lastTouchedAt = now();
+    const at = now();
+    if (expired(lease, at)) {
+      leases.delete(terminalId);
+      return false;
+    }
+    lease.lastTouchedAt = at;
     return true;
   }
 

--- a/packages/gateway/src/shell/terminal-lease.ts
+++ b/packages/gateway/src/shell/terminal-lease.ts
@@ -1,0 +1,111 @@
+import { clampTerminalSize, type TerminalSize } from "./sizing.js";
+
+export interface TerminalLease {
+  holderId: string;
+  epoch: number;
+  size: TerminalSize;
+}
+
+export interface LeaseGrant extends TerminalLease {
+  /** Present only when a still-live renderer was displaced. */
+  revoked?: Pick<TerminalLease, "holderId" | "epoch">;
+}
+
+export interface TerminalLeaseCoordinatorOptions {
+  now?: () => number;
+  ttlMs?: number;
+  maxLeases?: number;
+}
+
+interface LiveLease extends TerminalLease {
+  lastTouchedAt: number;
+}
+
+const DEFAULT_LEASE_TTL_MS = 30_000;
+const DEFAULT_MAX_LEASES = 256;
+
+/**
+ * Authority-owned, ephemeral live-renderer leases. A terminal's Zellij
+ * runtime outlives a lease; on a gateway restart all leases simply vanish and
+ * the next focused renderer establishes a fresh bridge.
+ */
+export function createTerminalLeaseCoordinator(options: TerminalLeaseCoordinatorOptions = {}) {
+  const now = options.now ?? Date.now;
+  const ttlMs = Math.max(1, Math.floor(options.ttlMs ?? DEFAULT_LEASE_TTL_MS));
+  const maxLeases = Math.max(1, Math.floor(options.maxLeases ?? DEFAULT_MAX_LEASES));
+  const leases = new Map<string, LiveLease>();
+  let nextEpoch = 0;
+
+  function expired(lease: LiveLease, at: number): boolean {
+    return at - lease.lastTouchedAt > ttlMs;
+  }
+
+  function removeExpired(at: number): void {
+    for (const [terminalId, lease] of leases) {
+      if (expired(lease, at)) leases.delete(terminalId);
+    }
+  }
+
+  function current(terminalId: string): TerminalLease | null {
+    const lease = leases.get(terminalId);
+    if (!lease) return null;
+    if (expired(lease, now())) {
+      leases.delete(terminalId);
+      return null;
+    }
+    return { holderId: lease.holderId, epoch: lease.epoch, size: lease.size };
+  }
+
+  function acquire(terminalId: string, holderId: string, size: TerminalSize): LeaseGrant {
+    const at = now();
+    removeExpired(at);
+    const prior = leases.get(terminalId);
+    if (!prior && leases.size >= maxLeases) {
+      throw new Error("terminal_lease_capacity");
+    }
+    const lease: LiveLease = {
+      holderId,
+      epoch: ++nextEpoch,
+      size: clampTerminalSize(size),
+      lastTouchedAt: at,
+    };
+    leases.set(terminalId, lease);
+    return prior
+      ? { holderId, epoch: lease.epoch, size: lease.size, revoked: { holderId: prior.holderId, epoch: prior.epoch } }
+      : { holderId, epoch: lease.epoch, size: lease.size };
+  }
+
+  function holds(terminalId: string, holderId: string, epoch: number): boolean {
+    const lease = current(terminalId);
+    return lease !== null && lease.holderId === holderId && lease.epoch === epoch;
+  }
+
+  function touch(terminalId: string, holderId: string, epoch: number): boolean {
+    const lease = leases.get(terminalId);
+    if (!lease || lease.holderId !== holderId || lease.epoch !== epoch) {
+      return false;
+    }
+    lease.lastTouchedAt = now();
+    return true;
+  }
+
+  function resize(terminalId: string, holderId: string, epoch: number, size: TerminalSize): TerminalLease | null {
+    if (!touch(terminalId, holderId, epoch)) return null;
+    const lease = leases.get(terminalId);
+    if (!lease) return null;
+    lease.size = clampTerminalSize(size);
+    return { holderId: lease.holderId, epoch: lease.epoch, size: lease.size };
+  }
+
+  function release(terminalId: string, holderId: string, epoch: number): boolean {
+    if (!holds(terminalId, holderId, epoch)) return false;
+    leases.delete(terminalId);
+    return true;
+  }
+
+  function dispose(): void {
+    leases.clear();
+  }
+
+  return { acquire, current, dispose, holds, release, resize, touch };
+}

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -158,6 +158,7 @@ interface SessionRuntime {
   idleCloseTimer: NodeJS.Timeout | null;
   disposed: boolean;
   sizing: SessionSizing | null;
+  cutoverTail: Promise<void>;
 }
 
 export function createShellWsHandler(options: ShellWsHandlerOptions) {
@@ -226,6 +227,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       idleCloseTimer: null,
       disposed: false,
       sizing: null,
+      cutoverTail: Promise.resolve(),
     };
     runtimes.set(name, runtime);
     return runtime;
@@ -311,17 +313,21 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
     });
   }
 
-  async function closeSharedAttach(
-    runtime: SessionRuntime,
-    warnContext = "final scrollback flush failed",
-    recreateQueue = true,
-  ): Promise<void> {
+  function stopSharedAttach(runtime: SessionRuntime): void {
     const child = runtime.child;
     if (runtime.outputCompat) {
       emitOutput(runtime, runtime.outputCompat.flush());
     }
     clearSharedAttach(runtime);
     child?.kill();
+  }
+
+  async function closeSharedAttach(
+    runtime: SessionRuntime,
+    warnContext = "final scrollback flush failed",
+    recreateQueue = true,
+  ): Promise<void> {
+    stopSharedAttach(runtime);
     await flushAndRotateQueue(runtime, warnContext, recreateQueue);
   }
 
@@ -352,6 +358,9 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
         continue;
       }
       conn.closed = true;
+      if (conn.leaseEpoch !== null) {
+        leaseCoordinator.release(runtime.name, conn.id, conn.leaseEpoch);
+      }
       sendJson(conn.ws, { type: "exit", code: event.exitCode });
     }
     runtime.conns.clear();
@@ -583,6 +592,20 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
     return false;
   }
 
+  async function withCutoverLock<T>(runtime: SessionRuntime, operation: () => Promise<T>): Promise<T> {
+    const prior = runtime.cutoverTail;
+    let release!: () => void;
+    runtime.cutoverTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await prior;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
   async function open({ ws, session, fromSeq = 0, clientClass: openOptionsClass, declaredSize, exclusiveLease = false }: ShellWsOpenOptions): Promise<ShellWsSession> {
     const safeName = validateSessionName(session);
     const sessions = await options.registry.list();
@@ -603,10 +626,6 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       ws.close?.();
       return { onMessage: () => undefined, onClose: () => undefined };
     }
-    if (!evictStaleOrReject(runtime, ws)) {
-      return { onMessage: () => undefined, onClose: () => undefined };
-    }
-
     const replayBuffer = runtime.buffer;
     if (!runtime.sizing) {
       runtime.sizing = createSessionSizing({
@@ -625,49 +644,18 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
     const sizing = runtime.sizing;
     await replayBuffer.ensureSeeded();
 
-    // Re-check capacity: awaits since the first check (seeding, registry
-    // list) allow concurrent opens to race the same last slot.
-    if (runtime.conns.size >= maxAttachedClients && !evictStaleOrReject(runtime, ws)) {
-      return { onMessage: () => undefined, onClose: () => undefined };
-    }
-
     // A hard declaration without a size cannot participate in negotiation;
     // treat it as legacy so it does not disable legacy resize-follow while
     // contributing nothing (review finding on spec 107 FR-007).
     const clientClass: ShellClientClass =
       openOptionsClass === "hard" && !declaredSize ? "legacy" : (openOptionsClass ?? "legacy");
     const connId = `conn-${++connCounter}`;
-    // Register before the shared attach so the first client's pty spawns at
-    // its own declared size instead of the fallback corrected after the
-    // debounce.
-    sizing.attach(connId, clientClass, declaredSize ?? null);
-
-    if (!(await ensureSharedAttach(runtime, safeName, replayBuffer))) {
-      sizing.detach(connId);
-      sendJson(ws, {
-        type: "error",
-        code: "attach_failed",
-        message: "Shell attach failed",
-      });
-      ws.close?.();
-      return { onMessage: () => undefined, onClose: () => undefined };
-    }
-
-    // One or more concurrent opens may have filled the final client slot while
-    // this call awaited the shared attach startup.
-    if (runtime.conns.size >= maxAttachedClients && !evictStaleOrReject(runtime, ws)) {
-      sizing.detach(connId);
-      return { onMessage: () => undefined, onClose: () => undefined };
-    }
-
-    const lease = exclusiveLease
-      ? leaseCoordinator.acquire(safeName, connId, declaredSize ?? sizing.spawnSize())
-      : null;
-
+    let lease: ReturnType<typeof leaseCoordinator.acquire> | null = null;
+    let sizingRegistered = false;
     const conn: ConnState = {
       id: connId,
-      exclusiveLease: lease !== null,
-      leaseEpoch: lease?.epoch ?? null,
+      exclusiveLease: exclusiveLease,
+      leaseEpoch: null,
       ws,
       openedAt: Date.now(),
       lastActivityAt: Date.now(),
@@ -678,56 +666,14 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
         });
       },
     };
-    runtime.conns.add(conn);
-    if (lease) {
-      const priorLeases = [...runtime.conns].filter((candidate) => candidate !== conn);
-      for (const prior of priorLeases) {
-        sendJson(prior.ws, { type: "lease-revoked", epoch: prior.leaseEpoch });
-        prior.close();
-      }
-      // A takeover is a resize barrier, not an ordinary debounced layout
-      // hint. Pin the sole Zellij render bridge before acknowledging the new
-      // renderer so no old-grid output can race the attached frame.
-      runtime.child?.resize(lease.size.cols, lease.size.rows);
-      options.persistCanonicalSize?.(safeName, lease.size);
-    }
-    cancelIdleClose(runtime);
-
-    const effectiveFromSeq = fromSeq === SHELL_ATTACH_LIVE_TAIL_FROM_SEQ
-      ? (await replayBuffer.latestSeq() ?? -1) + 1
-      : fromSeq;
-
-    sendJson(ws, {
-      type: "attached",
-      session: safeName,
-      state: info.status === "exited" ? "exited" : "running",
-      fromSeq: effectiveFromSeq,
-      canonicalSize: sizing.current() ?? sizing.spawnSize(),
-      ...(lease ? { lease: { epoch: lease.epoch } } : {}),
-    });
-
-    const replayOutputCompat = createTerminalOutputCompatStream({ sessionName: safeName });
-    for (const event of await replayBuffer.replayFromSeq(effectiveFromSeq)) {
-      if (event.type === "replay-evicted") {
-        continue;
-      }
-      if (event.type === "output") {
-        const data = replayOutputCompat.write(event.data);
-        if (data.length > 0) {
-          sendJson(ws, { ...event, data });
-        }
-        // A replay chunk can contain only the start of an escape sequence. The
-        // compat stream buffers it and emits bytes with the later completing
-        // chunk, matching the live-output path even when delivered seqs skip.
-        continue;
-      }
-      sendJson(ws, event);
-    }
 
     const detachConn = () => {
       runtime.conns.delete(conn);
       if (lease) leaseCoordinator.release(safeName, connId, lease.epoch);
-      sizing.detach(connId);
+      if (sizingRegistered) {
+        sizing.detach(connId);
+        sizingRegistered = false;
+      }
       if (runtime.conns.size === 0) {
         scheduleIdleClose(runtime);
       }
@@ -747,12 +693,112 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
           }
         }
         runtime.conns.delete(conn);
-        sizing.detach(connId);
+        if (sizingRegistered) {
+          sizing.detach(connId);
+          sizingRegistered = false;
+        }
         if (lease) leaseCoordinator.release(safeName, connId, lease.epoch);
         await closeSharedAttach(runtime);
         return;
       }
       detachConn();
+    };
+
+    const sendAttachedAndReplay = async (effectiveFromSeq: number): Promise<void> => {
+      sendJson(ws, {
+        type: "attached",
+        session: safeName,
+        state: info.status === "exited" ? "exited" : "running",
+        fromSeq: effectiveFromSeq,
+        canonicalSize: sizing.current() ?? sizing.spawnSize(),
+        ...(lease ? { lease: { epoch: lease.epoch } } : {}),
+      });
+
+      const replayOutputCompat = createTerminalOutputCompatStream({ sessionName: safeName });
+      for (const event of await replayBuffer.replayFromSeq(effectiveFromSeq)) {
+        if (event.type === "replay-evicted") continue;
+        if (event.type === "output") {
+          const data = replayOutputCompat.write(event.data);
+          if (data.length > 0) sendJson(ws, { ...event, data });
+          continue;
+        }
+        sendJson(ws, event);
+      }
+    };
+
+    const attached = await withCutoverLock(runtime, async () => {
+      if (!canUseRuntime(runtime)) return false;
+      cancelIdleClose(runtime);
+
+      if (!exclusiveLease && !evictStaleOrReject(runtime, ws)) return false;
+
+      if (exclusiveLease) {
+        lease = leaseCoordinator.acquire(safeName, connId, declaredSize ?? sizing.spawnSize());
+        conn.leaseEpoch = lease.epoch;
+        sizing.attach(connId, clientClass, declaredSize ?? lease.size);
+        sizingRegistered = true;
+        runtime.conns.add(conn);
+
+        for (const prior of [...runtime.conns]) {
+          if (prior === conn) continue;
+          sendJson(prior.ws, { type: "lease-revoked", epoch: prior.leaseEpoch });
+          prior.close();
+        }
+
+        // The Zellij client owns presentation modes (alternate screen, mouse
+        // reporting, cursor state). Rotate it with the lease so the incoming
+        // renderer receives a complete fresh bootstrap instead of inheriting
+        // an opaque byte-stream tail from the previous renderer.
+        stopSharedAttach(runtime);
+        options.persistCanonicalSize?.(safeName, lease.size);
+        const effectiveFromSeq = (await replayBuffer.latestSeq() ?? -1) + 1;
+        await sendAttachedAndReplay(effectiveFromSeq);
+        sendJson(ws, { type: "presentation-reset" });
+        if (!(await ensureSharedAttach(runtime, safeName, replayBuffer))) {
+          detachConn();
+          sendJson(ws, { type: "error", code: "attach_failed", message: "Shell attach failed" });
+          ws.close?.();
+          return false;
+        }
+        return true;
+      }
+
+      // A read-only observer that arrives while a lease exists must not alter
+      // canonical sizing merely by declaring itself as a hard client.
+      const sizingClass = leaseCoordinator.current(safeName) ? "soft" : clientClass;
+      sizing.attach(connId, sizingClass, declaredSize ?? null);
+      sizingRegistered = true;
+      if (!(await ensureSharedAttach(runtime, safeName, replayBuffer))) {
+        sizing.detach(connId);
+        sizingRegistered = false;
+        sendJson(ws, { type: "error", code: "attach_failed", message: "Shell attach failed" });
+        ws.close?.();
+        return false;
+      }
+      if (runtime.conns.size >= maxAttachedClients && !evictStaleOrReject(runtime, ws)) {
+        sizing.detach(connId);
+        sizingRegistered = false;
+        return false;
+      }
+      runtime.conns.add(conn);
+      const effectiveFromSeq = fromSeq === SHELL_ATTACH_LIVE_TAIL_FROM_SEQ
+        ? (await replayBuffer.latestSeq() ?? -1) + 1
+        : fromSeq;
+      await sendAttachedAndReplay(effectiveFromSeq);
+      return true;
+    });
+
+    if (!attached) {
+      return { onMessage: () => undefined, onClose: () => undefined };
+    }
+
+    const mayMutate = (resize?: TerminalSize): boolean => {
+      const currentLease = leaseCoordinator.current(safeName);
+      if (!currentLease) return !conn.exclusiveLease;
+      if (currentLease.holderId !== conn.id || currentLease.epoch !== conn.leaseEpoch) return false;
+      return resize
+        ? leaseCoordinator.resize(safeName, conn.id, currentLease.epoch, resize) !== null
+        : leaseCoordinator.touch(safeName, conn.id, currentLease.epoch);
     };
 
     return {
@@ -789,13 +835,13 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
           return;
         }
         if (msg.type === "input") {
-          if (lease && !leaseCoordinator.touch(safeName, connId, lease.epoch)) return;
+          if (!mayMutate()) return;
           runtime.child?.write(msg.data);
           return;
         }
         if (msg.type === "resize") {
           const requested = { cols: msg.cols, rows: msg.rows };
-          if (lease && !leaseCoordinator.resize(safeName, connId, lease.epoch, requested)) return;
+          if (!mayMutate(requested)) return;
           if (clientClass === "hard") {
             // A desktop-web or CLI hard client changed size: update its
             // declaration and let the arbiter re-pin the shared attach pty

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -141,7 +141,7 @@ interface ConnState {
   openedAt: number;
   lastActivityAt: number;
   closed: boolean;
-  close: () => void;
+  close: () => Promise<void>;
 }
 
 interface SessionRuntime {
@@ -243,7 +243,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       }
     }
     for (const conn of dead) {
-      conn.close();
+      void conn.close();
     }
   }
 
@@ -586,7 +586,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       // Free the slot synchronously so a concurrent open cannot observe the
       // evicted conn still occupying capacity while its close settles.
       runtime.conns.delete(stalest);
-      stalest.close();
+      void stalest.close();
       return true;
     }
     sendJson(ws, { type: "error", code: "attach_limit", message: "Too many clients attached" });
@@ -662,11 +662,10 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       openedAt: Date.now(),
       lastActivityAt: Date.now(),
       closed: false,
-      close: () => {
-        void closeSession().finally(() => {
+      close: () =>
+        closeSession().finally(() => {
           ws.close?.();
-        });
-      },
+        }),
     };
 
     const detachConn = () => {
@@ -745,7 +744,10 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
         for (const prior of [...runtime.conns]) {
           if (prior === conn) continue;
           sendJson(prior.ws, { type: "lease-revoked", epoch: prior.leaseEpoch });
-          prior.close();
+          // Remove every prior sizing registration before computing the
+          // replacement bridge size. Awaiting this makes the cutover ordering
+          // explicit instead of relying on closeSession's synchronous prefix.
+          await prior.close();
         }
 
         // The Zellij client owns presentation modes (alternate screen, mouse
@@ -799,7 +801,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       for (const candidate of [...runtime.conns]) {
         if (!candidate.exclusiveLease || candidate.leaseEpoch === null || candidate.closed) continue;
         sendJson(candidate.ws, { type: "lease-revoked", epoch: candidate.leaseEpoch });
-        candidate.close();
+        void candidate.close();
       }
     };
 

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -159,6 +159,7 @@ interface SessionRuntime {
   disposed: boolean;
   sizing: SessionSizing | null;
   cutoverTail: Promise<void>;
+  coordinatedOwnership: boolean;
 }
 
 export function createShellWsHandler(options: ShellWsHandlerOptions) {
@@ -228,6 +229,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       disposed: false,
       sizing: null,
       cutoverTail: Promise.resolve(),
+      coordinatedOwnership: false,
     };
     runtimes.set(name, runtime);
     return runtime;
@@ -734,6 +736,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
 
       if (exclusiveLease) {
         lease = leaseCoordinator.acquire(safeName, connId, declaredSize ?? sizing.spawnSize());
+        runtime.coordinatedOwnership = true;
         conn.leaseEpoch = lease.epoch;
         sizing.attach(connId, clientClass, declaredSize ?? lease.size);
         sizingRegistered = true;
@@ -792,13 +795,29 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       return { onMessage: () => undefined, onClose: () => undefined };
     }
 
-    const mayMutate = (resize?: TerminalSize): boolean => {
+    const revokeExpiredHolders = (): void => {
+      for (const candidate of [...runtime.conns]) {
+        if (!candidate.exclusiveLease || candidate.leaseEpoch === null || candidate.closed) continue;
+        sendJson(candidate.ws, { type: "lease-revoked", epoch: candidate.leaseEpoch });
+        candidate.close();
+      }
+    };
+
+    const currentLeaseOrRevokeExpired = () => {
       const currentLease = leaseCoordinator.current(safeName);
-      if (!currentLease) return !conn.exclusiveLease;
+      if (!currentLease && runtime.coordinatedOwnership) revokeExpiredHolders();
+      return currentLease;
+    };
+
+    const mayMutate = (resize?: TerminalSize): boolean => {
+      const currentLease = currentLeaseOrRevokeExpired();
+      if (!currentLease) return !runtime.coordinatedOwnership && !conn.exclusiveLease;
       if (currentLease.holderId !== conn.id || currentLease.epoch !== conn.leaseEpoch) return false;
-      return resize
+      const renewed = resize
         ? leaseCoordinator.resize(safeName, conn.id, currentLease.epoch, resize) !== null
         : leaseCoordinator.touch(safeName, conn.id, currentLease.epoch);
+      if (!renewed) revokeExpiredHolders();
+      return renewed;
     };
 
     return {
@@ -824,7 +843,8 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
 
         const msg = result.data;
         if (msg.type === "ping") {
-          if (lease) leaseCoordinator.touch(safeName, connId, lease.epoch);
+          if (conn.exclusiveLease && !mayMutate()) return;
+          if (!conn.exclusiveLease) currentLeaseOrRevokeExpired();
           sendJson(ws, { type: "pong" });
           return;
         }

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -727,6 +727,16 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       }
     };
 
+    const revokeExpiredHolders = async (): Promise<void> => {
+      const closes: Promise<void>[] = [];
+      for (const candidate of [...runtime.conns]) {
+        if (!candidate.exclusiveLease || candidate.leaseEpoch === null || candidate.closed) continue;
+        sendJson(candidate.ws, { type: "lease-revoked", epoch: candidate.leaseEpoch });
+        closes.push(candidate.close());
+      }
+      await Promise.all(closes);
+    };
+
     const attached = await withCutoverLock(runtime, async () => {
       if (!canUseRuntime(runtime)) return false;
       cancelIdleClose(runtime);
@@ -768,9 +778,17 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
         return true;
       }
 
-      // A read-only observer that arrives while a lease exists must not alter
-      // canonical sizing merely by declaring itself as a hard client.
-      const sizingClass = leaseCoordinator.current(safeName) ? "soft" : clientClass;
+      const currentLease = leaseCoordinator.current(safeName);
+      if (!currentLease && runtime.coordinatedOwnership) {
+        // Expiry removes the coordinator record before the connected holder's
+        // socket necessarily observes revocation. Remove that holder's sizing
+        // registration before admitting any later observer.
+        await revokeExpiredHolders();
+      }
+      // Once a session has entered coordinated ownership, non-exclusive
+      // connections are observers even during a lease gap. They must never
+      // re-enter hard-size negotiation merely because the lease expired.
+      const sizingClass = currentLease || runtime.coordinatedOwnership ? "soft" : clientClass;
       sizing.attach(connId, sizingClass, declaredSize ?? null);
       sizingRegistered = true;
       if (!(await ensureSharedAttach(runtime, safeName, replayBuffer))) {
@@ -797,17 +815,9 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       return { onMessage: () => undefined, onClose: () => undefined };
     }
 
-    const revokeExpiredHolders = (): void => {
-      for (const candidate of [...runtime.conns]) {
-        if (!candidate.exclusiveLease || candidate.leaseEpoch === null || candidate.closed) continue;
-        sendJson(candidate.ws, { type: "lease-revoked", epoch: candidate.leaseEpoch });
-        void candidate.close();
-      }
-    };
-
     const currentLeaseOrRevokeExpired = () => {
       const currentLease = leaseCoordinator.current(safeName);
-      if (!currentLease && runtime.coordinatedOwnership) revokeExpiredHolders();
+      if (!currentLease && runtime.coordinatedOwnership) void revokeExpiredHolders();
       return currentLease;
     };
 
@@ -818,7 +828,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       const renewed = resize
         ? leaseCoordinator.resize(safeName, conn.id, currentLease.epoch, resize) !== null
         : leaseCoordinator.touch(safeName, conn.id, currentLease.epoch);
-      if (!renewed) revokeExpiredHolders();
+      if (!renewed) void revokeExpiredHolders();
       return renewed;
     };
 

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -5,6 +5,7 @@ import { PendingPersistQueue } from "./output-pipeline.js";
 import type { ScrollbackStore } from "./scrollback-store.js";
 import { validateSessionName } from "./names.js";
 import { createSessionSizing, type SessionSizing, type ShellClientClass, type TerminalSize } from "./sizing.js";
+import { createTerminalLeaseCoordinator } from "./terminal-lease.js";
 import type { ShellAttachProcess } from "./zellij.js";
 import {
   createTerminalOutputCompatStream,
@@ -86,6 +87,8 @@ export interface ShellWsHandlerOptions {
   sizingDebounceMs?: number;
   defaultCanonicalSize?: TerminalSize;
   persistCanonicalSize?: (name: string, size: TerminalSize) => void;
+  /** Enables exclusive live-renderer takeovers for upgraded clients. */
+  leaseCoordinator?: ReturnType<typeof createTerminalLeaseCoordinator>;
 }
 
 export interface ShellWsOpenOptions {
@@ -95,6 +98,7 @@ export interface ShellWsOpenOptions {
   /** Sizing class (spec 107 FR-007): absent = legacy (pre-upgrade client). */
   clientClass?: Exclude<ShellClientClass, "legacy">;
   declaredSize?: TerminalSize;
+  exclusiveLease?: boolean;
 }
 
 export interface ShellWsSession {
@@ -130,6 +134,9 @@ function socketBufferedAmount(ws: ShellWsSocket): number {
 }
 
 interface ConnState {
+  id: string;
+  exclusiveLease: boolean;
+  leaseEpoch: number | null;
   ws: ShellWsSocket;
   openedAt: number;
   lastActivityAt: number;
@@ -154,6 +161,7 @@ interface SessionRuntime {
 }
 
 export function createShellWsHandler(options: ShellWsHandlerOptions) {
+  const leaseCoordinator = options.leaseCoordinator ?? createTerminalLeaseCoordinator();
   const maxBuffers = options.maxBuffers ?? 20;
   const maxAttachedClients = options.maxAttachedClients ?? 8;
   const staleAttachTtlMs = options.staleAttachTtlMs ?? 60_000;
@@ -575,7 +583,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
     return false;
   }
 
-  async function open({ ws, session, fromSeq = 0, clientClass: openOptionsClass, declaredSize }: ShellWsOpenOptions): Promise<ShellWsSession> {
+  async function open({ ws, session, fromSeq = 0, clientClass: openOptionsClass, declaredSize, exclusiveLease = false }: ShellWsOpenOptions): Promise<ShellWsSession> {
     const safeName = validateSessionName(session);
     const sessions = await options.registry.list();
     const info = sessions.find((candidate) => candidate.name === safeName);
@@ -652,7 +660,14 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       return { onMessage: () => undefined, onClose: () => undefined };
     }
 
+    const lease = exclusiveLease
+      ? leaseCoordinator.acquire(safeName, connId, declaredSize ?? sizing.spawnSize())
+      : null;
+
     const conn: ConnState = {
+      id: connId,
+      exclusiveLease: lease !== null,
+      leaseEpoch: lease?.epoch ?? null,
       ws,
       openedAt: Date.now(),
       lastActivityAt: Date.now(),
@@ -664,6 +679,18 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       },
     };
     runtime.conns.add(conn);
+    if (lease) {
+      const priorLeases = [...runtime.conns].filter((candidate) => candidate !== conn);
+      for (const prior of priorLeases) {
+        sendJson(prior.ws, { type: "lease-revoked", epoch: prior.leaseEpoch });
+        prior.close();
+      }
+      // A takeover is a resize barrier, not an ordinary debounced layout
+      // hint. Pin the sole Zellij render bridge before acknowledging the new
+      // renderer so no old-grid output can race the attached frame.
+      runtime.child?.resize(lease.size.cols, lease.size.rows);
+      options.persistCanonicalSize?.(safeName, lease.size);
+    }
     cancelIdleClose(runtime);
 
     const effectiveFromSeq = fromSeq === SHELL_ATTACH_LIVE_TAIL_FROM_SEQ
@@ -676,6 +703,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       state: info.status === "exited" ? "exited" : "running",
       fromSeq: effectiveFromSeq,
       canonicalSize: sizing.current() ?? sizing.spawnSize(),
+      ...(lease ? { lease: { epoch: lease.epoch } } : {}),
     });
 
     const replayOutputCompat = createTerminalOutputCompatStream({ sessionName: safeName });
@@ -698,6 +726,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
 
     const detachConn = () => {
       runtime.conns.delete(conn);
+      if (lease) leaseCoordinator.release(safeName, connId, lease.epoch);
       sizing.detach(connId);
       if (runtime.conns.size === 0) {
         scheduleIdleClose(runtime);
@@ -719,6 +748,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
         }
         runtime.conns.delete(conn);
         sizing.detach(connId);
+        if (lease) leaseCoordinator.release(safeName, connId, lease.epoch);
         await closeSharedAttach(runtime);
         return;
       }
@@ -748,6 +778,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
 
         const msg = result.data;
         if (msg.type === "ping") {
+          if (lease) leaseCoordinator.touch(safeName, connId, lease.epoch);
           sendJson(ws, { type: "pong" });
           return;
         }
@@ -758,11 +789,13 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
           return;
         }
         if (msg.type === "input") {
+          if (lease && !leaseCoordinator.touch(safeName, connId, lease.epoch)) return;
           runtime.child?.write(msg.data);
           return;
         }
         if (msg.type === "resize") {
           const requested = { cols: msg.cols, rows: msg.rows };
+          if (lease && !leaseCoordinator.resize(safeName, connId, lease.epoch, requested)) return;
           if (clientClass === "hard") {
             // A desktop-web or CLI hard client changed size: update its
             // declaration and let the arbiter re-pin the shared attach pty
@@ -803,6 +836,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
     }
     await Promise.all(drains);
     runtimes.clear();
+    leaseCoordinator.dispose();
   }
 
   return { open, dispose, pendingPersistBytes };

--- a/packages/sync-client/README.md
+++ b/packages/sync-client/README.md
@@ -47,6 +47,12 @@ matrix logout             # clear local credentials
 
 All three bin entries are installed: `matrix`, `matrixos`, `mos`.
 
+Use `mos shell attach <session>` rather than running `zellij attach` directly
+when handing a live session between Matrix surfaces. The CLI command
+participates in gateway ownership, size coordination, and renderer revocation.
+See [Terminal session ownership](../../docs/dev/terminal-session-ownership.md)
+for supported clients and the single-gateway deployment constraint.
+
 ## Requirements
 
 - Node.js 20 or newer for npm package runners and global npm installs

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -496,6 +496,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
       url.searchParams.set("client", "hard");
       url.searchParams.set("cols", String(attachOptions.size.cols));
       url.searchParams.set("rows", String(attachOptions.size.rows));
+      url.searchParams.set("lease", "exclusive");
     }
     if (typeof attachOptions.fromSeq === "number") {
       url.searchParams.set("fromSeq", String(attachOptions.fromSeq));
@@ -1332,6 +1333,10 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             }
           } else if (msg.type === "pong") {
             noteRemoteActivity();
+          } else if (msg.type === "lease-revoked") {
+            // Another focused renderer took control. Do not reconnect and
+            // immediately steal the lease back; leave the local TTY cleanly.
+            settle(() => resolve({ detached: true }));
           } else if (msg.type === "error") {
             const code = typeof msg.code === "string" && SAFE_SHELL_SERVER_ERROR_CODES.has(msg.code)
               ? msg.code

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -389,7 +389,9 @@ export function TerminalPane({
   );
   const [linkContextMenu, setLinkContextMenu] = useState<TerminalLinkMenuState | null>(null);
   const [pasteError, setPasteError] = useState<string | null>(null);
-  const [connectionNotice, setConnectionNotice] = useState<"reconnecting" | "disconnected" | null>(null);
+  const [connectionNotice, setConnectionNotice] = useState<"reconnecting" | "disconnected" | "elsewhere" | null>(null);
+  const resumeLeaseRef = useRef<() => void>(() => undefined);
+  const wasFocusedRef = useRef(isFocused);
   const outputBufferRef = useRef("");
   const commandBlockBufferRef = useRef("");
   const activeCommandBlockRef = useRef(false);
@@ -726,6 +728,7 @@ export function TerminalPane({
   // react-doctor-disable-next-line react-doctor/effect-needs-cleanup, react-doctor/exhaustive-deps -- cleanup is returned via init()'s awaited promise (see outer return), and reading the live heartbeatRef.current in cleanup is required to stop the most recent heartbeat instance.
   useEffect(() => {
     let disposed = false;
+    let leaseWasRevoked = false;
 
     async function init() {
       const log = (event: string, details: Record<string, unknown> = {}) => {
@@ -1447,6 +1450,7 @@ export function TerminalPane({
             isClosing: isClosingRef.current,
           });
           if (disposed || isClosingRef.current) return;
+          if (leaseWasRevoked) return;
 
           // Attempt reconnection with exponential backoff
           const attempt = reconnectAttemptRef.current;
@@ -1536,6 +1540,12 @@ export function TerminalPane({
 
             case "canonical-size":
               applyCanonicalGridSize(msg);
+              break;
+
+            case "lease-revoked":
+              leaseWasRevoked = true;
+              setConnectionNotice("elsewhere");
+              ws.close();
               break;
 
             case "output":
@@ -1684,6 +1694,7 @@ export function TerminalPane({
               session: currentSessionId,
               fromSeq: String(replayRequest?.requestedSeq ?? 0),
               client: suppressNativeKeyboard ? "soft" : "hard",
+              ...(isFocusedRef.current ? { lease: "exclusive" } : {}),
               ...(declaredSize
                 ? { cols: String(declaredSize.cols), rows: String(declaredSize.rows) }
                 : {}),
@@ -1747,6 +1758,24 @@ export function TerminalPane({
             bindWs(ws, true, { generation, replayRequest });
           });
       }
+
+      resumeLeaseRef.current = () => {
+        if (disposed || isClosingRef.current) return;
+        const existing = wsRef.current;
+        if (existing && existing.readyState !== WebSocket.CLOSED) {
+          existing.onopen = null;
+          existing.onclose = null;
+          existing.onerror = null;
+          existing.onmessage = null;
+          existing.close();
+          wsRef.current = null;
+          heartbeatRef.current?.stop();
+        }
+        leaseWasRevoked = false;
+        reconnectAttemptRef.current = 0;
+        setConnectionNotice(null);
+        connectWs();
+      };
 
       if (cached && canReuseCachedSocket) {
         bindWs(cached.ws, cached.ws.readyState === WebSocket.CONNECTING, {
@@ -2070,6 +2099,12 @@ export function TerminalPane({
 
   useTerminalFocusRequest(termRef, focusRequestId, isFocused, suppressNativeKeyboard);
 
+  useEffect(() => {
+    const becameFocused = isFocused && !wasFocusedRef.current;
+    wasFocusedRef.current = isFocused;
+    if (becameFocused) resumeLeaseRef.current();
+  }, [isFocused]);
+
   // Re-fit the terminal whenever the visual viewport changes (soft keyboard
   // open/close, URL-bar collapse, orientation). The document viewport is
   // resized by `interactiveWidget: "resizes-content"`; the terminal host does
@@ -2185,7 +2220,11 @@ export function TerminalPane({
               : "rgba(63, 63, 70, 0.95)",
           }}
         >
-          {connectionNotice === "reconnecting" ? "Reconnecting terminal..." : "Terminal disconnected"}
+          {connectionNotice === "reconnecting"
+            ? "Reconnecting terminal..."
+            : connectionNotice === "elsewhere"
+              ? <><span>Live on another device.</span><button type="button" onClick={() => resumeLeaseRef.current()}>Resume here</button></>
+              : "Terminal disconnected"}
         </div>
       )}
       <TerminalLinksTray

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -1401,7 +1401,7 @@ export function TerminalPane({
           // Start heartbeat
           if (heartbeatRef.current) heartbeatRef.current.stop();
           heartbeatRef.current = createSocketHealth({
-            pingIntervalMs: 30_000,
+            pingIntervalMs: 10_000,
             pongTimeoutMs: 5_000,
             send: (data) => {
               if (isCurrentWs() && ws.readyState === WebSocket.OPEN) ws.send(data);

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -1548,6 +1548,13 @@ export function TerminalPane({
               ws.close();
               break;
 
+            case "presentation-reset":
+              term.reset();
+              outputBufferRef.current = "";
+              commandBlockBufferRef.current = "";
+              activeCommandBlockRef.current = false;
+              break;
+
             case "output":
               term.write(transformTerminalOutputForCompat(
                 msg.data,

--- a/shell/src/components/terminal/terminal-server-message.ts
+++ b/shell/src/components/terminal/terminal-server-message.ts
@@ -8,6 +8,7 @@ export type TerminalServerMessage =
       canonicalSize: TerminalCanonicalSize | null;
     }
   | { type: "canonical-size"; cols: number; rows: number }
+  | { type: "lease-revoked" }
   | { type: "output"; data: string; seq: number | null }
   | { type: "block-mark"; seq: number | null; mark: { code: "A" | "B" | "C" | "D"; exitCode?: number } }
   | { type: "replay-start" }
@@ -76,6 +77,8 @@ export function parseTerminalServerMessage(raw: string): TerminalServerMessage |
       const canonicalSize = toCanonicalSize(msg);
       return canonicalSize ? { type: "canonical-size", ...canonicalSize } : null;
     }
+    case "lease-revoked":
+      return { type: "lease-revoked" };
     case "output":
       if (typeof msg.data !== "string") {
         return null;

--- a/shell/src/components/terminal/terminal-server-message.ts
+++ b/shell/src/components/terminal/terminal-server-message.ts
@@ -9,6 +9,7 @@ export type TerminalServerMessage =
     }
   | { type: "canonical-size"; cols: number; rows: number }
   | { type: "lease-revoked" }
+  | { type: "presentation-reset" }
   | { type: "output"; data: string; seq: number | null }
   | { type: "block-mark"; seq: number | null; mark: { code: "A" | "B" | "C" | "D"; exitCode?: number } }
   | { type: "replay-start" }
@@ -79,6 +80,8 @@ export function parseTerminalServerMessage(raw: string): TerminalServerMessage |
     }
     case "lease-revoked":
       return { type: "lease-revoked" };
+    case "presentation-reset":
+      return { type: "presentation-reset" };
     case "output":
       if (typeof msg.data !== "string") {
         return null;

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -207,6 +207,14 @@ describe("shell REST client", () => {
     );
   });
 
+  it("requests an exclusive live lease when attaching from a sized TTY", () => {
+    const client = createShellClient({ gatewayUrl: "https://gateway.example", token: "tok" });
+
+    expect(client.createAttachUrl("main", { size: { cols: 120, rows: 40 } })).toBe(
+      "wss://gateway.example/ws/terminal/session?session=main&client=hard&cols=120&rows=40&lease=exclusive",
+    );
+  });
+
   it("sends one-shot input over HTTP without opening a websocket attach", async () => {
     const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ ok: true })));
     const client = createShellClient({

--- a/tests/desktop/shell-socket.test.ts
+++ b/tests/desktop/shell-socket.test.ts
@@ -105,6 +105,7 @@ interface RecordedEvents {
   outputs: Array<{ data: string; seq: number }>;
   canonicalSizes: Array<{ cols: number; rows: number }>;
   revocations: number;
+  presentationResets: number;
   gaps: number;
   exits: number[];
 }
@@ -121,7 +122,7 @@ interface Harness {
 function createHarness(overrides: Partial<ShellSocketOptions> = {}): Harness {
   const sockets: FakeWebSocket[] = [];
   const timers = new FakeTimers();
-  const events: RecordedEvents = { states: [], outputs: [], canonicalSizes: [], revocations: 0, gaps: 0, exits: [] };
+  const events: RecordedEvents = { states: [], outputs: [], canonicalSizes: [], revocations: 0, presentationResets: 0, gaps: 0, exits: [] };
   const socket = new ShellSocket({
     baseUrl: "https://app.matrix-os.com",
     sessionName: "main",
@@ -138,6 +139,9 @@ function createHarness(overrides: Partial<ShellSocketOptions> = {}): Harness {
       },
       onLeaseRevoked: () => {
         events.revocations += 1;
+      },
+      onPresentationReset: () => {
+        events.presentationResets += 1;
       },
       onGap: () => {
         events.gaps += 1;
@@ -227,6 +231,18 @@ describe("ShellSocket URL building", () => {
     expect(h.events.revocations).toBe(1);
     expect(h.stateNames().at(-1)).toBe("ended");
     expect(h.sockets).toHaveLength(1);
+  });
+
+  it("resets presentation state before accepting a fresh Zellij bootstrap", () => {
+    const h = createHarness({ clientClass: "hard" });
+    h.socket.resize(120, 40);
+    connectAndAttach(h);
+
+    h.latest().frame({ type: "presentation-reset" });
+    h.latest().frame({ type: "output", seq: 7, data: "\u001b[?1000hless redraw" });
+
+    expect(h.events.presentationResets).toBe(1);
+    expect(h.events.outputs).toEqual([{ data: "\u001b[?1000hless redraw", seq: 7 }]);
   });
 
   it("converts http base urls to ws and strips trailing slashes", () => {

--- a/tests/desktop/shell-socket.test.ts
+++ b/tests/desktop/shell-socket.test.ts
@@ -233,6 +233,32 @@ describe("ShellSocket URL building", () => {
     expect(h.sockets).toHaveLength(1);
   });
 
+  it("renews an idle exclusive lease with periodic heartbeat pings", () => {
+    const h = createHarness({ clientClass: "hard" });
+    h.socket.resize(120, 40);
+    h.socket.connect();
+    h.latest().open();
+    h.latest().frame({
+      type: "attached",
+      session: "main",
+      state: "running",
+      fromSeq: 0,
+      lease: { epoch: 1 },
+    });
+
+    h.timers.advance(10_000);
+    expect(h.latest().sentFrames()).toContainEqual({ type: "ping" });
+
+    h.latest().frame({ type: "pong" });
+    h.timers.advance(10_000);
+    expect(h.latest().sentFrames().filter((frame) => frame.type === "ping")).toHaveLength(2);
+
+    h.socket.dispose();
+    const pingCount = h.latest().sentFrames().filter((frame) => frame.type === "ping").length;
+    h.timers.advance(30_000);
+    expect(h.latest().sentFrames().filter((frame) => frame.type === "ping")).toHaveLength(pingCount);
+  });
+
   it("resets presentation state before accepting a fresh Zellij bootstrap", () => {
     const h = createHarness({ clientClass: "hard" });
     h.socket.resize(120, 40);

--- a/tests/desktop/shell-socket.test.ts
+++ b/tests/desktop/shell-socket.test.ts
@@ -103,6 +103,8 @@ class FakeTimers {
 interface RecordedEvents {
   states: Array<{ state: ShellSocketState; detail?: { code?: string } }>;
   outputs: Array<{ data: string; seq: number }>;
+  canonicalSizes: Array<{ cols: number; rows: number }>;
+  revocations: number;
   gaps: number;
   exits: number[];
 }
@@ -119,7 +121,7 @@ interface Harness {
 function createHarness(overrides: Partial<ShellSocketOptions> = {}): Harness {
   const sockets: FakeWebSocket[] = [];
   const timers = new FakeTimers();
-  const events: RecordedEvents = { states: [], outputs: [], gaps: 0, exits: [] };
+  const events: RecordedEvents = { states: [], outputs: [], canonicalSizes: [], revocations: 0, gaps: 0, exits: [] };
   const socket = new ShellSocket({
     baseUrl: "https://app.matrix-os.com",
     sessionName: "main",
@@ -130,6 +132,12 @@ function createHarness(overrides: Partial<ShellSocketOptions> = {}): Harness {
       },
       onOutput: (data, seq) => {
         events.outputs.push({ data, seq });
+      },
+      onCanonicalSize: (size) => {
+        events.canonicalSizes.push(size);
+      },
+      onLeaseRevoked: () => {
+        events.revocations += 1;
       },
       onGap: () => {
         events.gaps += 1;
@@ -186,6 +194,39 @@ describe("ShellSocket URL building", () => {
       `wss://app.matrix-os.com/ws/terminal/session?session=main&fromSeq=${LIVE_TAIL_FROM_SEQ}`,
     );
     expect(LIVE_TAIL_FROM_SEQ).toBe(9_007_199_254_740_991);
+  });
+
+  it("declares a hard client size and applies authority-confirmed grid changes", () => {
+    const h = createHarness({ clientClass: "hard" });
+    h.socket.resize(132, 36);
+    h.socket.connect();
+
+    expect(h.latest().url).toContain("client=hard&cols=132&rows=36");
+    h.latest().open();
+    h.latest().frame({
+      type: "attached",
+      session: "main",
+      state: "running",
+      fromSeq: 0,
+      canonicalSize: { cols: 132, rows: 36 },
+    });
+    h.latest().frame({ type: "canonical-size", cols: 120, rows: 30 });
+
+    expect(h.events.canonicalSizes).toEqual([{ cols: 132, rows: 36 }, { cols: 120, rows: 30 }]);
+  });
+
+  it("stops reconnecting after another renderer takes the live lease", () => {
+    const h = createHarness({ clientClass: "hard" });
+    h.socket.resize(120, 40);
+    connectAndAttach(h);
+
+    h.latest().frame({ type: "lease-revoked", epoch: 1 });
+    h.latest().serverClose();
+    h.timers.advance(30_000);
+
+    expect(h.events.revocations).toBe(1);
+    expect(h.stateNames().at(-1)).toBe("ended");
+    expect(h.sockets).toHaveLength(1);
   });
 
   it("converts http base urls to ws and strips trailing slashes", () => {

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -215,7 +215,7 @@ describe("TerminalView session switching", () => {
     expect(scrollable.style.backgroundColor).toBe(colorProbe.style.backgroundColor);
   });
 
-  it("refits the existing viewport and forwards its dimensions after a host resize", () => {
+  it("proposes a new grid to the authority without locally refitting after a host resize", () => {
     vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
       callback(0);
       return 1;
@@ -230,12 +230,12 @@ describe("TerminalView session switching", () => {
       resizeObserverCallbacks.at(-1)?.([], {} as ResizeObserver);
     });
 
-    expect(fit.fitCalls).toBe(fitCallsBeforeResize + 1);
+    expect(fit.fitCalls).toBe(fitCallsBeforeResize);
     expect(attachmentResize).toHaveBeenCalledOnce();
     expect(attachmentResize).toHaveBeenCalledWith(80, 24);
   });
 
-  it("keeps xterm mounted and refits it when the terminal becomes active again", () => {
+  it("keeps xterm mounted and asks the authority for its grid when it becomes active again", () => {
     const { rerender } = render(<TerminalView sessionName="alpha" active />);
     const terminal = createdTerminals.at(-1)!;
     const fit = createdFitAddons.at(-1)!;
@@ -245,7 +245,7 @@ describe("TerminalView session switching", () => {
     rerender(<TerminalView sessionName="alpha" active />);
 
     expect(createdTerminals).toHaveLength(1);
-    expect(fit.fitCalls).toBe(fitCallsBeforeNavigation + 1);
+    expect(fit.fitCalls).toBe(fitCallsBeforeNavigation);
     expect(terminal.focus).toHaveBeenCalledTimes(2);
     expect(attachMock).toHaveBeenCalledTimes(2);
     expect(attachmentResize).toHaveBeenCalledTimes(2);
@@ -332,6 +332,17 @@ describe("TerminalView session switching", () => {
 
     act(() => events.onState("fatal"));
     expect(screen.getByRole("status").textContent).toContain("This session has ended on your computer.");
+  });
+
+  it("freezes after a lease takeover and explicitly reacquires on Resume here", () => {
+    render(<TerminalView sessionName="alpha" />);
+    const events = attachMock.mock.calls[0]?.[1] as ShellSocketEvents;
+
+    act(() => events.onLeaseRevoked?.());
+    expect(screen.getByRole("status").textContent).toContain("Live on another device.");
+
+    fireEvent.click(screen.getByRole("button", { name: "Resume here" }));
+    expect(attachMock).toHaveBeenCalledTimes(2);
   });
 
   it("re-themes live terminals only when the theme actually changes", () => {

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -34,6 +34,7 @@ const { createdFitAddons, createdTerminals, resizeObserverCallbacks } = vi.hoist
     selection: string;
     customKeyEventHandler?: (event: KeyboardEvent) => boolean;
     selectAll: ReturnType<typeof vi.fn>;
+    reset: ReturnType<typeof vi.fn>;
   }>,
   resizeObserverCallbacks: [] as ResizeObserverCallback[],
 }));
@@ -65,6 +66,7 @@ vi.mock("@xterm/xterm", () => ({
     selection = "";
     customKeyEventHandler?: (event: KeyboardEvent) => boolean;
     selectAll = vi.fn();
+    reset = vi.fn();
 
     constructor(options: FakeTerminal["initialOptions"]) {
       this.initialOptions = options;
@@ -343,6 +345,16 @@ describe("TerminalView session switching", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Resume here" }));
     expect(attachMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("resets xterm before rendering a replacement Zellij presentation", () => {
+    render(<TerminalView sessionName="alpha" />);
+    const terminal = createdTerminals.at(-1)!;
+    const events = attachMock.mock.calls[0]?.[1] as ShellSocketEvents;
+
+    act(() => events.onPresentationReset?.());
+
+    expect(terminal.reset).toHaveBeenCalledOnce();
   });
 
   it("re-themes live terminals only when the theme actually changes", () => {

--- a/tests/gateway/terminal-lease.test.ts
+++ b/tests/gateway/terminal-lease.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { createTerminalLeaseCoordinator } from "../../packages/gateway/src/shell/terminal-lease.js";
+
+describe("terminal live lease coordinator", () => {
+  it("transfers the sole live lease and invalidates the former holder", () => {
+    const leases = createTerminalLeaseCoordinator({ now: () => 1_000 });
+
+    const desktop = leases.acquire("main", "desktop", { cols: 180, rows: 50 });
+    const vps = leases.acquire("main", "vps-cli", { cols: 80, rows: 24 });
+
+    expect(desktop.epoch).toBe(1);
+    expect(vps.epoch).toBe(2);
+    expect(vps.revoked).toEqual({ holderId: "desktop", epoch: 1 });
+    expect(leases.holds("main", "desktop", desktop.epoch)).toBe(false);
+    expect(leases.holds("main", "vps-cli", vps.epoch)).toBe(true);
+    expect(leases.current("main")).toEqual({
+      holderId: "vps-cli",
+      epoch: 2,
+      size: { cols: 80, rows: 24 },
+    });
+  });
+
+  it("does not let a stale holder release or resize a newer lease", () => {
+    const leases = createTerminalLeaseCoordinator({ now: () => 1_000 });
+    const desktop = leases.acquire("main", "desktop", { cols: 180, rows: 50 });
+    const vps = leases.acquire("main", "vps-cli", { cols: 80, rows: 24 });
+
+    expect(leases.resize("main", "desktop", desktop.epoch, { cols: 200, rows: 60 })).toBeNull();
+    expect(leases.release("main", "desktop", desktop.epoch)).toBe(false);
+    expect(leases.resize("main", "vps-cli", vps.epoch, { cols: 90, rows: 30 })).toEqual({
+      holderId: "vps-cli",
+      epoch: 2,
+      size: { cols: 90, rows: 30 },
+    });
+  });
+
+  it("expires an abandoned lease before granting the next holder", () => {
+    let now = 1_000;
+    const leases = createTerminalLeaseCoordinator({ now: () => now, ttlMs: 100 });
+    const desktop = leases.acquire("main", "desktop", { cols: 180, rows: 50 });
+    now += 101;
+
+    const vps = leases.acquire("main", "vps-cli", { cols: 80, rows: 24 });
+
+    expect(vps.revoked).toBeUndefined();
+    expect(leases.holds("main", "desktop", desktop.epoch)).toBe(false);
+    expect(vps.epoch).toBe(2);
+  });
+
+  it("renews the current holder after an idle period when no takeover occurred", () => {
+    let now = 1_000;
+    const leases = createTerminalLeaseCoordinator({ now: () => now, ttlMs: 100 });
+    const desktop = leases.acquire("main", "desktop", { cols: 180, rows: 50 });
+    now += 101;
+
+    expect(leases.touch("main", "desktop", desktop.epoch)).toBe(true);
+    expect(leases.holds("main", "desktop", desktop.epoch)).toBe(true);
+  });
+});

--- a/tests/gateway/terminal-lease.test.ts
+++ b/tests/gateway/terminal-lease.test.ts
@@ -47,13 +47,24 @@ describe("terminal live lease coordinator", () => {
     expect(vps.epoch).toBe(2);
   });
 
-  it("renews the current holder after an idle period when no takeover occurred", () => {
+  it("does not revive a holder after its lease already expired", () => {
     let now = 1_000;
     const leases = createTerminalLeaseCoordinator({ now: () => now, ttlMs: 100 });
     const desktop = leases.acquire("main", "desktop", { cols: 180, rows: 50 });
     now += 101;
 
+    expect(leases.touch("main", "desktop", desktop.epoch)).toBe(false);
+    expect(leases.holds("main", "desktop", desktop.epoch)).toBe(false);
+  });
+
+  it("renews a live holder before its lease expires", () => {
+    let now = 1_000;
+    const leases = createTerminalLeaseCoordinator({ now: () => now, ttlMs: 100 });
+    const desktop = leases.acquire("main", "desktop", { cols: 180, rows: 50 });
+    now += 75;
+
     expect(leases.touch("main", "desktop", desktop.epoch)).toBe(true);
+    now += 75;
     expect(leases.holds("main", "desktop", desktop.epoch)).toBe(true);
   });
 });

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -1461,6 +1461,48 @@ describe("zellij terminal WebSocket", () => {
     await handler.dispose();
   });
 
+  it("removes an earlier non-exclusive hard client from sizing before exclusive takeover", async () => {
+    const observerPty = new FakePty();
+    const holderPty = new FakePty();
+    const observerWs = socket();
+    const holderWs = socket();
+    const attachSession = vi.fn()
+      .mockReturnValueOnce(observerPty)
+      .mockReturnValueOnce(holderPty);
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: { attachSession },
+      sizingDebounceMs: 0,
+    });
+
+    await handler.open({
+      ws: observerWs,
+      session: "main",
+      clientClass: "hard",
+      declaredSize: { cols: 80, rows: 24 },
+    });
+    await handler.open({
+      ws: holderWs,
+      session: "main",
+      clientClass: "hard",
+      declaredSize: { cols: 160, rows: 50 },
+      exclusiveLease: true,
+    });
+
+    expect(observerWs.sent).toContainEqual({ type: "lease-revoked", epoch: null });
+    expect(observerWs.closed).toBe(true);
+    expect(attachSession).toHaveBeenLastCalledWith("main", expect.objectContaining({
+      size: { cols: 160, rows: 50 },
+    }));
+    expect(holderWs.sent).toContainEqual(expect.objectContaining({
+      type: "attached",
+      canonicalSize: { cols: 160, rows: 50 },
+      lease: { epoch: 1 },
+    }));
+    expect(holderPty.resizes.at(-1)).toEqual({ cols: 160, rows: 50 });
+    await handler.dispose();
+  });
+
   it("fences non-exclusive input and resize while an exclusive lease is active", async () => {
     const initialPty = new FakePty();
     const leasedPty = new FakePty();

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -1401,4 +1401,41 @@ describe("zellij terminal WebSocket", () => {
     expect(next).toHaveBeenCalledTimes(2);
     expect(rejected).toEqual({ body: { error: "Unauthorized" }, status: 401 });
   });
+
+  it("moves the exclusive live lease to the newest focused renderer", async () => {
+    const pty = new FakePty();
+    const desktopWs = socket();
+    const vpsWs = socket();
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: { attachSession: vi.fn(() => pty) },
+      sizingDebounceMs: 0,
+    });
+
+    const desktop = await handler.open({
+      ws: desktopWs,
+      session: "main",
+      clientClass: "hard",
+      declaredSize: { cols: 180, rows: 50 },
+      exclusiveLease: true,
+    });
+    await handler.open({
+      ws: vpsWs,
+      session: "main",
+      clientClass: "hard",
+      declaredSize: { cols: 90, rows: 30 },
+      exclusiveLease: true,
+    });
+
+    expect(desktopWs.sent).toContainEqual({ type: "lease-revoked", epoch: 1 });
+    expect(desktopWs.closed).toBe(true);
+    expect(vpsWs.sent).toContainEqual(expect.objectContaining({
+      type: "attached",
+      lease: { epoch: 2 },
+    }));
+    expect(pty.resizes).toContainEqual({ cols: 90, rows: 30 });
+    desktop.onMessage(JSON.stringify({ type: "input", data: "stale" }));
+    expect(pty.writes).not.toContain("stale");
+    await handler.dispose();
+  });
 });

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -1602,6 +1602,46 @@ describe("zellij terminal WebSocket", () => {
     await handler.dispose();
   });
 
+  it("revokes an expired holder before classifying a later hard observer", async () => {
+    let now = 1_000;
+    const pty = new FakePty();
+    const holderWs = socket();
+    const observerWs = socket();
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: { attachSession: vi.fn(() => pty) },
+      leaseCoordinator: createTerminalLeaseCoordinator({ now: () => now, ttlMs: 100 }),
+      sizingDebounceMs: 0,
+    });
+
+    await handler.open({
+      ws: holderWs,
+      session: "main",
+      clientClass: "hard",
+      declaredSize: { cols: 140, rows: 40 },
+      exclusiveLease: true,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    now += 101;
+
+    await handler.open({
+      ws: observerWs,
+      session: "main",
+      clientClass: "hard",
+      declaredSize: { cols: 70, rows: 20 },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(holderWs.sent).toContainEqual({ type: "lease-revoked", epoch: 1 });
+    expect(holderWs.closed).toBe(true);
+    expect(observerWs.sent).toContainEqual(expect.objectContaining({
+      type: "attached",
+      canonicalSize: { cols: 140, rows: 40 },
+    }));
+    expect(pty.resizes.at(-1)).toEqual({ cols: 140, rows: 40 });
+    await handler.dispose();
+  });
+
   it("serializes simultaneous exclusive takeovers so the newest bridge wins", async () => {
     const firstPty = new FakePty();
     const secondPty = new FakePty();

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -6,6 +6,7 @@ import {
   shellWsMessageDataToString,
   type ShellWsSocket,
 } from "../../packages/gateway/src/shell/ws.js";
+import { createTerminalLeaseCoordinator } from "../../packages/gateway/src/shell/terminal-lease.js";
 
 class FakePty {
   writes: string[] = [];
@@ -1495,6 +1496,67 @@ describe("zellij terminal WebSocket", () => {
 
     expect(activePtyBeforeMutation.writes).not.toContain("blocked");
     expect(activePtyBeforeMutation.resizes).toHaveLength(resizeCount);
+    await handler.dispose();
+  });
+
+  it("fails closed after an exclusive lease expires while its socket remains connected", async () => {
+    let now = 1_000;
+    const pty = new FakePty();
+    const replacementPty = new FakePty();
+    const holderWs = socket();
+    const observerWs = socket();
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: {
+        attachSession: vi.fn()
+          .mockReturnValueOnce(pty)
+          .mockReturnValueOnce(replacementPty),
+      },
+      leaseCoordinator: createTerminalLeaseCoordinator({ now: () => now, ttlMs: 100 }),
+      sizingDebounceMs: 0,
+    });
+
+    const holder = await handler.open({
+      ws: holderWs,
+      session: "main",
+      clientClass: "hard",
+      declaredSize: { cols: 120, rows: 40 },
+      exclusiveLease: true,
+    });
+    const observer = await handler.open({
+      ws: observerWs,
+      session: "main",
+      clientClass: "hard",
+      declaredSize: { cols: 80, rows: 24 },
+    });
+    const activePty = [pty, replacementPty].findLast((candidate) => !candidate.killed) ?? replacementPty;
+    const resizeCount = activePty.resizes.length;
+    now += 101;
+
+    observer.onMessage(JSON.stringify({ type: "input", data: "must-stay-blocked" }));
+    observer.onMessage(JSON.stringify({ type: "resize", cols: 70, rows: 20 }));
+    holder.onMessage(JSON.stringify({ type: "input", data: "expired-holder" }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(activePty.writes).not.toContain("must-stay-blocked");
+    expect(activePty.writes).not.toContain("expired-holder");
+    expect(activePty.resizes).toHaveLength(resizeCount);
+    expect(holderWs.sent).toContainEqual({ type: "lease-revoked", epoch: 1 });
+    expect(holderWs.closed).toBe(true);
+    expect(observerWs.closed).toBe(false);
+
+    const resumedWs = socket();
+    const resumed = await handler.open({
+      ws: resumedWs,
+      session: "main",
+      clientClass: "hard",
+      declaredSize: { cols: 90, rows: 30 },
+      exclusiveLease: true,
+    });
+    resumed.onMessage(JSON.stringify({ type: "input", data: "resumed-owner" }));
+
+    expect(resumedWs.sent).toContainEqual(expect.objectContaining({ lease: { epoch: 2 } }));
+    expect(replacementPty.writes).toContain("resumed-owner");
     await handler.dispose();
   });
 

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -1403,12 +1403,16 @@ describe("zellij terminal WebSocket", () => {
   });
 
   it("moves the exclusive live lease to the newest focused renderer", async () => {
-    const pty = new FakePty();
+    const desktopPty = new FakePty();
+    const vpsPty = new FakePty();
     const desktopWs = socket();
     const vpsWs = socket();
+    const attachSession = vi.fn()
+      .mockReturnValueOnce(desktopPty)
+      .mockReturnValueOnce(vpsPty);
     const handler = createShellWsHandler({
       registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
-      adapter: { attachSession: vi.fn(() => pty) },
+      adapter: { attachSession },
       sizingDebounceMs: 0,
     });
 
@@ -1433,9 +1437,103 @@ describe("zellij terminal WebSocket", () => {
       type: "attached",
       lease: { epoch: 2 },
     }));
-    expect(pty.resizes).toContainEqual({ cols: 90, rows: 30 });
+    expect(desktopPty.killed).toBe(true);
+    expect(attachSession).toHaveBeenLastCalledWith("main", expect.objectContaining({
+      size: { cols: 90, rows: 30 },
+    }));
+    expect(vpsWs.sent).toContainEqual({ type: "presentation-reset" });
+    vpsPty.emitData("\x1b[?1000hless redraw");
+    expect(vpsWs.sent).toContainEqual(expect.objectContaining({
+      type: "output",
+      data: "\x1b[?1000hless redraw",
+    }));
+    const attachedIndex = vpsWs.sent.findIndex((frame) => (frame as { type?: unknown }).type === "attached");
+    const resetIndex = vpsWs.sent.findIndex((frame) => (frame as { type?: unknown }).type === "presentation-reset");
+    const bootstrapIndex = vpsWs.sent.findIndex((frame) => (
+      (frame as { type?: unknown; data?: unknown }).type === "output"
+      && (frame as { data?: unknown }).data === "\x1b[?1000hless redraw"
+    ));
+    expect(attachedIndex).toBeLessThan(resetIndex);
+    expect(resetIndex).toBeLessThan(bootstrapIndex);
     desktop.onMessage(JSON.stringify({ type: "input", data: "stale" }));
-    expect(pty.writes).not.toContain("stale");
+    expect(vpsPty.writes).not.toContain("stale");
+    await handler.dispose();
+  });
+
+  it("fences non-exclusive input and resize while an exclusive lease is active", async () => {
+    const initialPty = new FakePty();
+    const leasedPty = new FakePty();
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: {
+        attachSession: vi.fn()
+          .mockReturnValueOnce(initialPty)
+          .mockReturnValueOnce(leasedPty),
+      },
+      sizingDebounceMs: 0,
+    });
+
+    await handler.open({
+      ws: socket(),
+      session: "main",
+      clientClass: "hard",
+      declaredSize: { cols: 120, rows: 40 },
+      exclusiveLease: true,
+    });
+    const observer = await handler.open({
+      ws: socket(),
+      session: "main",
+      clientClass: "hard",
+      declaredSize: { cols: 80, rows: 24 },
+    });
+    const activePtyBeforeMutation = [initialPty, leasedPty]
+      .findLast((pty) => !pty.killed) ?? leasedPty;
+    const resizeCount = activePtyBeforeMutation.resizes.length;
+
+    observer.onMessage(JSON.stringify({ type: "input", data: "blocked" }));
+    observer.onMessage(JSON.stringify({ type: "resize", cols: 70, rows: 20 }));
+
+    expect(activePtyBeforeMutation.writes).not.toContain("blocked");
+    expect(activePtyBeforeMutation.resizes).toHaveLength(resizeCount);
+    await handler.dispose();
+  });
+
+  it("serializes simultaneous exclusive takeovers so the newest bridge wins", async () => {
+    const firstPty = new FakePty();
+    const secondPty = new FakePty();
+    const firstWs = socket();
+    const secondWs = socket();
+    const attachSession = vi.fn()
+      .mockReturnValueOnce(firstPty)
+      .mockReturnValueOnce(secondPty);
+    const handler = createShellWsHandler({
+      registry: { list: vi.fn(async () => [{ name: "main", status: "active" }]) },
+      adapter: { attachSession },
+      attachStartupGraceMs: 10,
+      sizingDebounceMs: 0,
+    });
+
+    const firstOpen = handler.open({
+      ws: firstWs,
+      session: "main",
+      clientClass: "hard",
+      declaredSize: { cols: 160, rows: 45 },
+      exclusiveLease: true,
+    });
+    const secondOpen = handler.open({
+      ws: secondWs,
+      session: "main",
+      clientClass: "hard",
+      declaredSize: { cols: 100, rows: 30 },
+      exclusiveLease: true,
+    });
+    await Promise.all([firstOpen, secondOpen]);
+
+    expect(attachSession).toHaveBeenCalledTimes(2);
+    expect(firstPty.killed).toBe(true);
+    expect(secondPty.killed).toBe(false);
+    expect(firstWs.sent).toContainEqual({ type: "lease-revoked", epoch: 1 });
+    expect(secondWs.sent).toContainEqual(expect.objectContaining({ lease: { epoch: 2 } }));
     await handler.dispose();
   });
 });

--- a/tests/shell/terminal-pane-scrolling.test.tsx
+++ b/tests/shell/terminal-pane-scrolling.test.tsx
@@ -480,6 +480,34 @@ describe("TerminalPane scrolling", () => {
     expect(createdTerminals[0].resize).not.toHaveBeenCalled();
   });
 
+  it("resets the web xterm before a replacement Zellij presentation", async () => {
+    render(
+      <TerminalPane
+        paneId="pane-presentation-reset"
+        cwd=""
+        theme={theme}
+        isFocused
+        sessionId="main"
+        isClosing={false}
+        shouldCacheOnUnmount={() => false}
+        shouldDestroyOnUnmount={() => false}
+        onFocus={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(WebSocketMock.instances).toHaveLength(1));
+    const socket = WebSocketMock.instances[0]!;
+    const terminal = createdTerminals[0]!;
+    await act(async () => {
+      socket.onmessage?.({
+        data: JSON.stringify({ type: "attached", session: "main", state: "running", fromSeq: 0 }),
+      });
+      socket.onmessage?.({ data: JSON.stringify({ type: "presentation-reset" }) });
+    });
+
+    expect(terminal.reset).toHaveBeenCalledOnce();
+  });
+
   it("waits for a measurable hard pane instead of attaching with a destructive fallback", async () => {
     Object.defineProperty(HTMLElement.prototype, "clientWidth", {
       configurable: true,

--- a/tests/shell/terminal-pane-scrolling.test.tsx
+++ b/tests/shell/terminal-pane-scrolling.test.tsx
@@ -90,6 +90,8 @@ const restorePlan = vi.hoisted(() => ({
   },
 }));
 
+const socketHealthConfigs = vi.hoisted(() => [] as Array<{ pingIntervalMs: number }>);
+
 const useActualRestorePlan = vi.hoisted(() => ({ current: false }));
 
 vi.mock("@xterm/xterm", () => ({
@@ -269,12 +271,15 @@ vi.mock("@/lib/websocket-auth", () => ({
 }));
 
 vi.mock("@/lib/socket-health", () => ({
-  createSocketHealth: vi.fn(() => ({
+  createSocketHealth: vi.fn((config: { pingIntervalMs: number }) => {
+    socketHealthConfigs.push(config);
+    return {
     start: vi.fn(),
     stop: vi.fn(),
     pingNow: vi.fn(),
     receivedPong: vi.fn(),
-  })),
+    };
+  }),
 }));
 
 vi.mock("@/lib/posthog-client", () => ({
@@ -446,6 +451,7 @@ describe("TerminalPane scrolling", () => {
     WebSocketMock.instances.length = 0;
     ResizeObserverMock.instances.length = 0;
     buildAuthenticatedWebSocketUrl.mockClear();
+    socketHealthConfigs.length = 0;
     Reflect.deleteProperty(window, "visualViewport");
   });
 
@@ -478,6 +484,27 @@ describe("TerminalPane scrolling", () => {
     expect(createdFitAddons[0].proposeDimensions).toHaveBeenCalled();
     expect(createdFitAddons[0].fit).not.toHaveBeenCalled();
     expect(createdTerminals[0].resize).not.toHaveBeenCalled();
+  });
+
+  it("renews the focused web terminal lease well before gateway expiry", async () => {
+    render(
+      <TerminalPane
+        paneId="pane-heartbeat"
+        cwd=""
+        theme={theme}
+        isFocused
+        sessionId="main"
+        isClosing={false}
+        shouldCacheOnUnmount={() => false}
+        shouldDestroyOnUnmount={() => false}
+        onFocus={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(WebSocketMock.instances).toHaveLength(1));
+    WebSocketMock.instances[0]!.onopen?.();
+
+    expect(socketHealthConfigs.at(-1)?.pingIntervalMs).toBe(10_000);
   });
 
   it("resets the web xterm before a replacement Zellij presentation", async () => {

--- a/tests/shell/terminal-pane-scrolling.test.tsx
+++ b/tests/shell/terminal-pane-scrolling.test.tsx
@@ -470,6 +470,7 @@ describe("TerminalPane scrolling", () => {
       expect.objectContaining({
         session: "main",
         client: "hard",
+        lease: "exclusive",
         cols: "120",
         rows: "42",
       }),

--- a/tests/shell/terminal-soft-grid.test.ts
+++ b/tests/shell/terminal-soft-grid.test.ts
@@ -105,4 +105,10 @@ describe("terminal soft-client canonical grid", () => {
       rows: 40,
     }))).toBeNull();
   });
+
+  it("accepts live-lease revocation frames", () => {
+    expect(parseTerminalServerMessage(JSON.stringify({ type: "lease-revoked", epoch: 7 }))).toEqual({
+      type: "lease-revoked",
+    });
+  });
 });

--- a/tests/shell/terminal-soft-grid.test.ts
+++ b/tests/shell/terminal-soft-grid.test.ts
@@ -110,5 +110,8 @@ describe("terminal soft-client canonical grid", () => {
     expect(parseTerminalServerMessage(JSON.stringify({ type: "lease-revoked", epoch: 7 }))).toEqual({
       type: "lease-revoked",
     });
+    expect(parseTerminalServerMessage(JSON.stringify({ type: "presentation-reset" }))).toEqual({
+      type: "presentation-reset",
+    });
   });
 });


### PR DESCRIPTION
## Summary

- add a bounded, ephemeral gateway lease coordinator for named Zellij sessions
- transfer input, presentation, and canonical terminal-size ownership to the most recently focused web, native desktop, native mobile, or `mos shell attach` renderer
- revoke and freeze displaced renderers with an explicit Resume-here path instead of allowing competing resize and scroll behavior
- rotate the gateway's Zellij attach bridge on every exclusive takeover so the new renderer receives a fresh alternate-screen, mouse-mode, cursor, and grid bootstrap at its own dimensions
- reset browser, desktop, and mobile terminal presentation state immediately before that fresh Zellij redraw
- fence all input and resize frames by holder ID and epoch, including frames from legacy/non-exclusive connections that did not request a lease
- latch sessions into fail-closed coordinated ownership so lease expiry can never restore mutation rights to a background observer
- renew idle holders every ten seconds, reject renewal after expiry, and explicitly revoke an expired connected holder
- make mobile release its lease when its terminal tab blurs or the app backgrounds, reacquire on return, and expose explicit Resume here after displacement
- serialize simultaneous takeovers and cover lease transfer, stale-holder rejection, canonical sizing, renderer revocation, CLI detach, presentation rebuilding, and mobile lifecycle handoff
- document supported attachment paths, the raw-Zellij boundary, and requirements for any future multi-gateway topology

## Tests

- repository typecheck commands equivalent to `bun run typecheck` passed (`bun` is unavailable in the local agent shell)
- `pnpm run check:patterns` passed with 0 violations and existing advisory warnings
- 166 focused gateway, browser terminal, and native desktop terminal tests passed, including expiry fencing, heartbeat renewal, and resume after expiry
- 46 CLI shell attachment tests passed
- `pnpm --filter matrix-os-mobile exec jest --runInBand` passed: 56 suites, 626 tests
- gateway and native desktop TypeScript checks passed
- `git diff --check` passed
- new relative documentation links resolve to the canonical terminal ownership guide
- `pnpm run test` was attempted but is not green on this macOS host; unrelated environment/baseline failures include GNU shell assumptions, sync timing, app-runtime process startup, and CLI timeout cases. The terminal-specific and complete mobile suites above pass.

## Invariants

### Source of truth

- Zellij remains the source of truth for the persistent terminal process, scrollback, and application state.
- The gateway coordinator is authoritative for the current live renderer, fencing epoch, and canonical terminal dimensions. Lease state is intentionally ephemeral.
- The single gateway-owned Zellij attach process is the active presentation bridge; it is recreated when ownership transfers.
- Renderers do not infer ownership locally; they act on gateway attachment, canonical-size, presentation-reset, and revocation frames.

### Lock/transaction scope

- Per-session cutovers are serialized from lease acquisition through prior-renderer revocation, bridge shutdown, presentation reset, and fresh bridge attachment.
- Holder/epoch acquisition, renewal, resize validation, and release are synchronous in-memory coordinator operations.
- Zellij process attachment occurs inside the per-session cutover critical section; no database transaction or external network call is involved.
- Every input and resize operation checks the current holder ID and epoch before reaching the shared Zellij runtime.
- Once a runtime accepts an exclusive lease, absence or expiry of that lease is a fail-closed state; only a new serialized exclusive acquisition can restore mutation authority.

### Acceptable orphan states

- A gateway restart drops all ephemeral leases and its attach bridge while leaving the named Zellij session intact; the next focused renderer establishes a fresh lease and bridge.
- A disconnected renderer may leave a lease until release or bounded TTL eviction, but it cannot create persisted orphan data.
- An expired connected holder is revoked and closed on the next terminal protocol frame; all observers remain read-only until an explicit Resume-here acquisition succeeds.
- Failed revocation delivery is safe because the old holder and epoch are fenced before further input or resize can mutate the presentation.
- A failed fresh attach closes the incoming renderer and releases its lease; a later resume can retry against the intact Zellij session.

### Auth source of truth

- Existing authenticated terminal WebSocket routing and session ownership checks remain authoritative.
- Lease requests, holder IDs, and epochs grant no authentication or authorization capability and do not bypass gateway auth.

### Deferred scope

- Raw `zellij attach` processes started directly on the VPS bypass the gateway coordinator; coordinated command-line access uses `mos shell attach` as described in [Terminal session ownership](docs/dev/terminal-session-ownership.md).
- Distributed leases across multiple gateway processes are deferred because each customer VPS currently has one authoritative gateway process; the shared-authority requirements are recorded in [Terminal session ownership](docs/dev/terminal-session-ownership.md).
- Simultaneous independently sized live presentations are intentionally out of scope; one renderer owns presentation and input at a time.
