### PR TITLE
feat(desktop): align Chat and Files home lists

### DIFF
--- a/desktop/src/renderer/src/features/chat/HermesConversationIndex.tsx
+++ b/desktop/src/renderer/src/features/chat/HermesConversationIndex.tsx
@@ -156,9 +156,9 @@ function HermesConversationIndexContent({ api }: { api: ApiClient | null }) {
   };
 
   return (
-    <section className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 py-6 sm:px-8" aria-labelledby="conversation-index-title">
-      <div className="mx-auto flex w-full max-w-[1020px] flex-col">
-        <div className="mb-6 flex min-h-10 min-w-0 items-center justify-between gap-4">
+    <section className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 py-4 sm:px-8" aria-labelledby="conversation-index-title">
+      <div data-chat-index-content className="mx-auto flex w-full max-w-[1020px] flex-col">
+        <div data-chat-index-header className="mb-2 flex min-h-[47px] min-w-0 items-center justify-between gap-4">
           <h1 id="conversation-index-title" className="text-[36px] font-medium leading-none tracking-[-0.02em]" style={{ color: "var(--text-primary)", fontFamily: '"Instrument Serif", Georgia, serif' }}>
             Chats
           </h1>
@@ -197,15 +197,15 @@ function HermesConversationIndexContent({ api }: { api: ApiClient | null }) {
               <button
                 type="button"
                 aria-label="Search chats"
-                className="inline-flex h-8 w-8 items-center justify-center rounded-lg transition-colors hover:bg-[var(--bg-hover)] focus-visible:outline-2 focus-visible:outline-[var(--accent)]"
-                style={{ color: "var(--text-secondary)" }}
+                className="inline-flex h-8 w-8 items-center justify-center rounded-lg border transition-colors hover:bg-[var(--bg-hover)] focus-visible:outline-2 focus-visible:outline-[var(--accent)]"
+                style={{ background: "var(--bg-raised)", borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}
                 onClick={() => setSearchOpen(true)}
               >
                 <Search size={15} aria-hidden />
               </button>
             )}
             <Button
-              variant="subtle"
+              variant="primary"
               className="h-8"
               disabled={!api}
               onClick={() => void startConversation()}
@@ -273,7 +273,7 @@ function HermesConversationIndexContent({ api }: { api: ApiClient | null }) {
         ) : null}
 
         {filteredConversations.length > 0 ? (
-          <div className="overflow-hidden rounded-xl border" style={{ background: "var(--bg-surface)", borderColor: "var(--border-subtle)" }}>
+          <div data-chat-index-list>
             {filteredConversations.map((conversation) => (
               <ConversationRow
                 key={conversation.id}

--- a/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
+++ b/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
@@ -493,7 +493,7 @@ export default function ComputerFileBrowser({
         searchQuery={searchQuery}
         onSearchOpen={() => setSearchOpen(true)}
         onSearchClose={() => {
-          restoreFocusRef.current = sortedEntries.length > 0;
+          restoreFocusRef.current = viewEntries.length > 0;
           setSearchOpen(false);
           setSearchQuery("");
         }}

--- a/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
+++ b/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
@@ -296,7 +296,7 @@ export default function ComputerFileBrowser({
     if (viewStatus !== "ready" || !restoreFocusRef.current) return;
     restoreFocusRef.current = false;
     entryRefs.current[0]?.focus();
-  }, [viewStatus, sortedEntries, view]);
+  }, [viewStatus, sortedEntries, view, searchOpen]);
 
   const focusEntry = useCallback((index: number) => {
     const clamped = Math.max(0, Math.min(index, sortedEntries.length - 1));
@@ -493,6 +493,7 @@ export default function ComputerFileBrowser({
         searchQuery={searchQuery}
         onSearchOpen={() => setSearchOpen(true)}
         onSearchClose={() => {
+          restoreFocusRef.current = sortedEntries.length > 0;
           setSearchOpen(false);
           setSearchQuery("");
         }}

--- a/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
+++ b/desktop/src/renderer/src/features/files/ComputerFileBrowser.tsx
@@ -109,6 +109,8 @@ export default function ComputerFileBrowser({
   const [error, setError] = useState<string | null>(null);
   const [sortKey, setSortKey] = useState<BrowserSortKey>("name");
   const [sortDirection, setSortDirection] = useState<BrowserSortDirection>("asc");
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const requestGeneration = useRef(0);
   const directoryPreviewTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const entryRefs = useRef<Array<HTMLButtonElement | null>>([]);
@@ -154,9 +156,14 @@ export default function ComputerFileBrowser({
     [scoped, mode, entries],
   );
 
+  const visibleEntries = useMemo(() => {
+    const normalizedQuery = searchQuery.trim().toLocaleLowerCase();
+    if (!normalizedQuery) return viewEntries;
+    return viewEntries.filter((entry) => entry.name.toLocaleLowerCase().includes(normalizedQuery));
+  }, [searchQuery, viewEntries]);
   const sortedEntries = useMemo(
-    () => sortBrowserEntries(viewEntries, sortKey, sortDirection),
-    [viewEntries, sortKey, sortDirection],
+    () => sortBrowserEntries(visibleEntries, sortKey, sortDirection),
+    [visibleEntries, sortKey, sortDirection],
   );
 
   const load = useCallback(async (path: string) => {
@@ -210,6 +217,8 @@ export default function ComputerFileBrowser({
     resetHistory();
     setCandidatePath("");
     setSelectedPath(null);
+    setSearchOpen(false);
+    setSearchQuery("");
     void load("");
     return () => {
       cancelPendingDirectoryPreview();
@@ -222,6 +231,8 @@ export default function ComputerFileBrowser({
     markFocusForRestore();
     setCandidatePath(path);
     setSelectedPath(null);
+    setSearchOpen(false);
+    setSearchQuery("");
     onSelectionChange?.({
       path,
       entry: entry ?? {
@@ -361,7 +372,7 @@ export default function ComputerFileBrowser({
   // Name flexes (minmax(0,1fr) + truncate); Size/Modified are fixed-width
   // right-aligned columns sized to the format.ts outputs, so long names only
   // truncate once the pane is genuinely out of room.
-  const listColumns = compact ? "minmax(0,1fr) 56px 80px" : "minmax(0,1fr) 72px 104px";
+  const listColumns = compact ? "minmax(0,1fr) 56px 80px" : "minmax(0,1fr) 110px 110px";
 
   let content: ReactNode;
   if (viewStatus === "loading") {
@@ -379,7 +390,7 @@ export default function ComputerFileBrowser({
     content = (
       <div className="flex h-full flex-col items-center justify-center gap-2 text-sm" style={{ color: "var(--text-tertiary)" }}>
         <FolderOpen size={22} aria-hidden />
-        <span>{mode === "folder-picker" ? "No subfolders here." : "This folder is empty."}</span>
+        <span>{searchQuery.trim() ? "No files match this search." : mode === "folder-picker" ? "No subfolders here." : "This folder is empty."}</span>
       </div>
     );
   } else {
@@ -418,7 +429,8 @@ export default function ComputerFileBrowser({
       ) : (
         <div>
           <div
-            className={`sticky top-0 z-10 grid items-center ${compact ? "gap-1" : "gap-2"} border-b px-2 pb-1 text-[11px] font-medium`}
+            data-files-list-header
+            className={`sticky top-0 z-10 grid items-center border-b px-2 font-medium ${compact ? "gap-1 pb-1 text-[11px]" : "h-9 gap-4 text-sm"}`}
             style={{
               gridTemplateColumns: listColumns,
               borderColor: "var(--border-subtle)",
@@ -441,7 +453,7 @@ export default function ComputerFileBrowser({
               onClick={() => toggleSort("size")}
             />
             <SortHeader
-              label="Modified"
+              label={compact ? "Modified" : "Date modified"}
               sortLabel="Sort by modified"
               active={sortKey === "modified"}
               direction={sortDirection}
@@ -449,7 +461,7 @@ export default function ComputerFileBrowser({
               onClick={() => toggleSort("modified")}
             />
           </div>
-          <div className="grid grid-cols-1 gap-0.5 pt-0.5">{buttons}</div>
+          <div className={`grid grid-cols-1 ${compact ? "gap-0.5 pt-0.5" : "gap-0"}`}>{buttons}</div>
         </div>
       );
   }
@@ -477,6 +489,14 @@ export default function ComputerFileBrowser({
         onNavigate={navigate}
         onRefresh={() => void load(viewCurrentPath)}
         onUpload={mode === "browse" && !viewReadOnly ? () => fileInputRef.current?.click() : undefined}
+        searchOpen={searchOpen}
+        searchQuery={searchQuery}
+        onSearchOpen={() => setSearchOpen(true)}
+        onSearchClose={() => {
+          setSearchOpen(false);
+          setSearchQuery("");
+        }}
+        onSearchQueryChange={setSearchQuery}
       />
 
       {mode === "browse" ? (
@@ -495,7 +515,7 @@ export default function ComputerFileBrowser({
       <div
         data-files-listing
         className={`${compact ? "h-52" : "min-h-0 flex-1"} relative overflow-y-auto ${
-          compact && view === "list" ? "px-1.5 pb-1.5" : "p-1.5"
+          compact && view === "list" ? "px-1.5 pb-1.5" : compact || view === "grid" ? "p-1.5" : "pb-4"
         }`}
         onDragEnter={mode === "browse" && !viewReadOnly ? (event) => {
           if (!hasRegularDroppedFiles(event.dataTransfer)) return;

--- a/desktop/src/renderer/src/features/files/FilesWorkspace.tsx
+++ b/desktop/src/renderer/src/features/files/FilesWorkspace.tsx
@@ -47,7 +47,14 @@ export default function FilesWorkspace() {
           : "grid-rows-1"}`}
         style={{ background: "var(--bg-surface)" }}
       >
-        <ComputerFileBrowser onSelectionChange={handleSelectionChange} framed={false} />
+        <div
+          data-testid="files-home-content"
+          className={activeSelection
+            ? "contents"
+            : "mx-auto flex min-h-0 w-full max-w-[1052px] flex-col px-4 pt-4"}
+        >
+          <ComputerFileBrowser onSelectionChange={handleSelectionChange} framed={false} />
+        </div>
         {activeSelection ? (
           <Suspense fallback={<div className="flex flex-1 items-center justify-center text-xs" style={{ color: "var(--text-tertiary)" }}>Loading preview…</div>}>
             <PreviewPane selection={activeSelection} />

--- a/desktop/src/renderer/src/features/files/browser-views.tsx
+++ b/desktop/src/renderer/src/features/files/browser-views.tsx
@@ -13,7 +13,9 @@ import {
   LayoutGrid,
   List,
   RefreshCw,
+  Search,
   Upload,
+  X,
 } from "lucide-react";
 import type { DragEvent, KeyboardEvent } from "react";
 import { Button, IconButton } from "../../design/primitives";
@@ -80,8 +82,8 @@ export function ViewSwitcher({
     <div
       role="group"
       aria-label="View options"
-      className="flex shrink-0 items-center gap-0.5 rounded-md p-0.5"
-      style={{ background: "var(--bg-hover)" }}
+      className="flex h-8 shrink-0 items-center gap-0.5 rounded-lg border p-0.5"
+      style={{ background: "var(--bg-hover)", borderColor: "var(--border-subtle)" }}
     >
       {VIEW_OPTIONS.map(({ mode, label, icon: Icon }) => {
         const active = view === mode;
@@ -92,13 +94,13 @@ export function ViewSwitcher({
             aria-label={label}
             aria-pressed={active}
             onClick={() => onChange(mode)}
-            className="flex h-6 w-6 items-center justify-center rounded outline-none transition-colors focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
+            className="flex h-[26px] w-[26px] items-center justify-center rounded-md outline-none transition-colors focus-visible:ring-1 focus-visible:ring-[var(--accent)]"
             style={{
               background: active ? "var(--bg-selected)" : "transparent",
               color: active ? "var(--text-primary)" : "var(--text-tertiary)",
             }}
           >
-            <Icon size={13} aria-hidden />
+            <Icon size={16} aria-hidden />
           </button>
         );
       })}
@@ -226,10 +228,14 @@ export function EntryButton({
       type="button"
       aria-label={`Open ${entry.name}`}
       aria-pressed={pressed}
-      className={`grid h-9 w-full items-center ${compact ? "gap-1" : "gap-2"} rounded-md px-2 text-left text-sm outline-none hover:bg-[var(--bg-hover)] focus-visible:ring-1 focus-visible:ring-[var(--accent)]`}
+      data-files-list-row
+      className={`grid w-full items-center outline-none hover:bg-[var(--bg-hover)] focus-visible:ring-1 focus-visible:ring-[var(--accent)] ${compact
+        ? "h-9 gap-1 rounded-md px-2 text-left text-sm"
+        : "h-[54px] gap-4 rounded-none border-b px-4 text-left text-base font-medium last:border-b-0"}`}
       style={{
         gridTemplateColumns: listColumns,
         background: selected ? "var(--bg-selected)" : "transparent",
+        borderColor: compact ? undefined : "var(--border-subtle)",
         color: "var(--text-primary)",
       }}
       onClick={onSelect}
@@ -246,16 +252,16 @@ export function EntryButton({
         onDropFiles(regularDroppedFiles(event.dataTransfer));
       }}
     >
-      <span className="flex min-w-0 items-center gap-2">
+      <span className={`flex min-w-0 items-center ${compact ? "gap-2" : "gap-4"}`}>
         <span className="shrink-0" style={{ color: glyphColor }}>
-          <FileGlyph kind={kind} size={16} />
+          <FileGlyph kind={kind} size={compact ? 16 : 20} />
         </span>
         <span className="min-w-0 flex-1 truncate">{entry.name}</span>
       </span>
-      <span className="truncate text-right text-xs" style={{ color: "var(--text-tertiary)" }}>
+      <span className="truncate text-right text-[13px] font-normal" style={{ color: "var(--text-tertiary)" }}>
         {managed ? "Managed" : formatEntrySize(entry)}
       </span>
-      <span className="truncate text-right text-xs" style={{ color: "var(--text-tertiary)" }}>
+      <span className="truncate text-right text-[13px] font-normal" style={{ color: "var(--text-tertiary)" }}>
         {formatModified(entry.modifiedAt)}
       </span>
     </button>
@@ -277,6 +283,11 @@ export function BrowserToolbar({
   onNavigate,
   onRefresh,
   onUpload,
+  searchOpen,
+  searchQuery,
+  onSearchOpen,
+  onSearchClose,
+  onSearchQueryChange,
 }: {
   compact: boolean;
   currentPath: string;
@@ -292,33 +303,36 @@ export function BrowserToolbar({
   onNavigate: (path: string) => void;
   onRefresh: () => void;
   onUpload?: () => void;
+  searchOpen: boolean;
+  searchQuery: string;
+  onSearchOpen: () => void;
+  onSearchClose: () => void;
+  onSearchQueryChange: (query: string) => void;
 }) {
   return (
-    <div className="flex h-10 shrink-0 items-center gap-1 border-b px-2" style={{ borderColor: "var(--border-subtle)" }}>
-      <IconButton label="Back" className="shrink-0 disabled:opacity-40" disabled={!canGoBack} onClick={onBack}>
-        <ArrowLeft size={13} />
+    <div data-files-toolbar className="flex h-[37px] shrink-0 items-center gap-1 border-b" style={{ borderColor: "var(--border-subtle)" }}>
+      <IconButton label="Back" className="h-8 w-8 shrink-0 disabled:opacity-40" disabled={!canGoBack} onClick={onBack}>
+        <ArrowLeft size={16} />
       </IconButton>
-      <IconButton label="Forward" className="shrink-0 disabled:opacity-40" disabled={!canGoForward} onClick={onForward}>
-        <ArrowRight size={13} />
+      <IconButton label="Forward" className="h-8 w-8 shrink-0 disabled:opacity-40" disabled={!canGoForward} onClick={onForward}>
+        <ArrowRight size={16} />
       </IconButton>
-      <IconButton
-        label="Up one level"
-        className="shrink-0 disabled:opacity-40"
-        disabled={!currentPath}
-        onClick={onUp}
-      >
-        <ArrowUp size={13} />
-      </IconButton>
+      {currentPath ? (
+        <IconButton label="Up one level" className="h-8 w-8 shrink-0" onClick={onUp}>
+          <ArrowUp size={16} />
+        </IconButton>
+      ) : null}
       <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
         <button
           type="button"
           aria-label="Matrix home"
-          className="flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium hover:bg-[var(--bg-hover)]"
+          className="flex h-8 shrink-0 items-center gap-1.5 rounded-lg px-2 text-sm font-medium hover:bg-[var(--bg-hover)]"
           style={{ color: currentPath ? "var(--text-secondary)" : "var(--text-primary)" }}
           onClick={() => onNavigate("")}
         >
-          <Home size={13} />
+          <Home size={16} />
           {!compact ? "Matrix home" : "Home"}
+          {!compact ? <ChevronDown size={16} aria-hidden /> : null}
         </button>
         {crumbs.map((crumb) => (
           <span key={crumb.path} className="flex min-w-0 items-center gap-1">
@@ -339,15 +353,43 @@ export function BrowserToolbar({
           Read only
         </span>
       ) : null}
-      <ViewSwitcher view={view} onChange={onViewChange} />
-      {onUpload ? (
-        <IconButton label="Upload files" className="shrink-0" onClick={onUpload}>
-          <Upload size={13} />
+      {currentPath ? (
+        <IconButton label="Refresh folder" className="h-8 w-8 shrink-0" onClick={onRefresh}>
+          <RefreshCw size={16} />
         </IconButton>
       ) : null}
-      <IconButton label="Refresh folder" className="shrink-0" onClick={onRefresh}>
-        <RefreshCw size={13} />
-      </IconButton>
+      <ViewSwitcher view={view} onChange={onViewChange} />
+      {searchOpen ? (
+        <div className="flex h-8 min-w-0 flex-1 items-center gap-1.5 rounded-lg border px-2 sm:max-w-48" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }}>
+          <Search size={16} aria-hidden style={{ color: "var(--text-tertiary)" }} />
+          <input
+            type="text"
+            role="searchbox"
+            aria-label="Search files"
+            autoFocus
+            value={searchQuery}
+            onChange={(event) => onSearchQueryChange(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") onSearchClose();
+            }}
+            className="min-w-0 flex-1 bg-transparent text-sm outline-none"
+            style={{ color: "var(--text-primary)" }}
+            placeholder="Search files"
+          />
+          <button type="button" aria-label="Close file search" className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md hover:bg-[var(--bg-hover)]" onClick={onSearchClose}>
+            <X size={14} aria-hidden />
+          </button>
+        </div>
+      ) : (
+        <IconButton label="Search files" className="h-8 w-8 shrink-0 border" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }} onClick={onSearchOpen}>
+          <Search size={16} />
+        </IconButton>
+      )}
+      {onUpload ? (
+        <IconButton label="Upload files" className="h-8 w-8 shrink-0 border" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }} onClick={onUpload}>
+          <Upload size={16} />
+        </IconButton>
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/renderer/src/features/files/browser-views.tsx
+++ b/desktop/src/renderer/src/features/files/browser-views.tsx
@@ -17,6 +17,7 @@ import {
   Upload,
   X,
 } from "lucide-react";
+import { useEffect, useRef } from "react";
 import type { DragEvent, KeyboardEvent } from "react";
 import { Button, IconButton } from "../../design/primitives";
 import type { BrowserEntry, BrowserSortDirection } from "./browser-entries";
@@ -309,8 +310,18 @@ export function BrowserToolbar({
   onSearchClose: () => void;
   onSearchQueryChange: (query: string) => void;
 }) {
+  const toolbarRef = useRef<HTMLDivElement | null>(null);
+  const previousSearchOpenRef = useRef(searchOpen);
+
+  useEffect(() => {
+    if (previousSearchOpenRef.current && !searchOpen) {
+      toolbarRef.current?.querySelector<HTMLButtonElement>("[data-files-search-trigger]")?.focus();
+    }
+    previousSearchOpenRef.current = searchOpen;
+  }, [searchOpen]);
+
   return (
-    <div data-files-toolbar className="flex h-[37px] shrink-0 items-center gap-1 border-b" style={{ borderColor: "var(--border-subtle)" }}>
+    <div ref={toolbarRef} data-files-toolbar className="flex h-[37px] shrink-0 items-center gap-1 border-b" style={{ borderColor: "var(--border-subtle)" }}>
       <IconButton label="Back" className="h-8 w-8 shrink-0 disabled:opacity-40" disabled={!canGoBack} onClick={onBack}>
         <ArrowLeft size={16} />
       </IconButton>
@@ -381,7 +392,7 @@ export function BrowserToolbar({
           </button>
         </div>
       ) : (
-        <IconButton label="Search files" className="h-8 w-8 shrink-0 border" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }} onClick={onSearchOpen}>
+        <IconButton data-files-search-trigger label="Search files" className="h-8 w-8 shrink-0 border" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-raised)" }} onClick={onSearchOpen}>
           <Search size={16} />
         </IconButton>
       )}

--- a/tests/desktop/chat-tab-render.test.tsx
+++ b/tests/desktop/chat-tab-render.test.tsx
@@ -380,6 +380,37 @@ describe("ChatTab", () => {
     expect(screen.queryByText("hello")).toBeNull();
   });
 
+  it("renders the Chat home with the approved handoff hierarchy", () => {
+    useHermesChat.setState({
+      view: "index",
+      indexStatus: "ready",
+      indexError: null,
+      conversations: [{
+        id: "conversation-one",
+        title: "Plan the launch",
+        preview: "Review the final launch checklist",
+        messageCount: 4,
+        createdAt: 20,
+        updatedAt: 30,
+      }],
+    });
+
+    const { container } = render(<ChatTab />);
+
+    const content = container.querySelector<HTMLElement>("[data-chat-index-content]");
+    const header = container.querySelector<HTMLElement>("[data-chat-index-header]");
+    const list = container.querySelector<HTMLElement>("[data-chat-index-list]");
+    const row = container.querySelector<HTMLElement>("[data-conversation-row]");
+    expect(content?.className).toContain("max-w-[1020px]");
+    expect(header?.className).toContain("min-h-[47px]");
+    expect(header?.className).toContain("mb-2");
+    expect(list?.className).not.toContain("rounded");
+    expect(list?.className).not.toContain("border");
+    expect(row?.className).toContain("h-16");
+    expect(screen.getByRole("button", { name: "Search chats" }).className).toContain("border");
+    expect(screen.getByRole("button", { name: "New chat" }).style.background).toBe("var(--accent)");
+  });
+
   it("reconciles stale Hermes Recents without removing coding-agent chats", async () => {
     useTabs.getState().recordRecentHermesConversation("conversation-live", "Live chat");
     useTabs.getState().recordRecentHermesConversation("conversation-deleted", "Deleted chat");

--- a/tests/desktop/files-browser-views.test.tsx
+++ b/tests/desktop/files-browser-views.test.tsx
@@ -204,6 +204,22 @@ describe("ComputerFileBrowser view options", () => {
     });
   });
 
+  it("returns keyboard focus to the listing after closing search", async () => {
+    renderBrowser();
+    await screen.findByRole("button", { name: "Open README.md" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Search files" }));
+    const searchbox = screen.getByRole("searchbox", { name: "Search files" });
+    expect(document.activeElement).toBe(searchbox);
+
+    fireEvent.keyDown(searchbox, { key: "Escape" });
+
+    expect(screen.queryByRole("searchbox", { name: "Search files" })).toBeNull();
+    await waitFor(() => {
+      expect(document.activeElement?.getAttribute("aria-label")).toMatch(/^Open /);
+    });
+  });
+
   it("switches between list and grid from the segmented control", async () => {
     renderBrowser();
     expect(await screen.findByRole("button", { name: "Open README.md" })).toBeTruthy();

--- a/tests/desktop/files-browser-views.test.tsx
+++ b/tests/desktop/files-browser-views.test.tsx
@@ -243,6 +243,31 @@ describe("ComputerFileBrowser view options", () => {
     expect(screen.getByText("3 items")).toBeTruthy();
   });
 
+  it("matches the Files list handoff geometry and filters from the toolbar search", async () => {
+    const { container } = renderBrowser();
+    const readme = await screen.findByRole("button", { name: "Open README.md" });
+
+    const toolbar = container.querySelector<HTMLElement>("[data-files-toolbar]");
+    const header = container.querySelector<HTMLElement>("[data-files-list-header]");
+    expect(toolbar?.className).toContain("h-[37px]");
+    expect(header?.className).toContain("h-9");
+    expect(header?.textContent).toContain("Date modified");
+    expect(readme.getAttribute("data-files-list-row")).toBe("true");
+    expect(readme.className).toContain("h-[54px]");
+    expect(readme.className).toContain("rounded-none");
+    expect(readme.className).toContain("px-4");
+    expect(readme.getAttribute("style")).toContain("minmax(0,1fr) 110px 110px");
+    expect(screen.queryByRole("button", { name: "Up one level" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Refresh folder" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Search files" }));
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search files" }), {
+      target: { value: "readme" },
+    });
+    expect(screen.getByRole("button", { name: "Open README.md" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Open hero.png" })).toBeNull();
+  });
+
   it("gives the name column the flexible track with fixed right-aligned meta columns", async () => {
     renderBrowser();
     const row = await screen.findByRole("button", { name: "Open README.md" });
@@ -250,7 +275,7 @@ describe("ComputerFileBrowser view options", () => {
     // Name owns the flexible minmax track; Size/Modified are fixed-width
     // columns sized to the format.ts outputs so names only truncate when the
     // pane is genuinely out of room.
-    expect(row.getAttribute("style")).toContain("minmax(0,1fr) 72px 104px");
+    expect(row.getAttribute("style")).toContain("minmax(0,1fr) 110px 110px");
     expect(screen.getByText("2 KB").className).toContain("text-right");
     const modifiedHeader = screen.getByRole("button", { name: "Sort by modified" });
     expect(modifiedHeader.className).toContain("justify-end");
@@ -408,8 +433,8 @@ describe("ComputerFileBrowser view options", () => {
 
   it("goes up one level from the toolbar button", async () => {
     renderBrowser();
-    const up = await screen.findByRole("button", { name: "Up one level" });
-    expect(up.hasAttribute("disabled")).toBe(true);
+    await screen.findByRole("button", { name: "Open workspaces" });
+    expect(screen.queryByRole("button", { name: "Up one level" })).toBeNull();
 
     fireEvent.doubleClick(screen.getByRole("button", { name: "Open workspaces" }));
     await screen.findByRole("button", { name: "Open app.ts" });

--- a/tests/desktop/files-browser-views.test.tsx
+++ b/tests/desktop/files-browser-views.test.tsx
@@ -220,6 +220,22 @@ describe("ComputerFileBrowser view options", () => {
     });
   });
 
+  it("returns keyboard focus after closing a search with no results", async () => {
+    renderBrowser();
+    await screen.findByRole("button", { name: "Open README.md" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Search files" }));
+    const searchbox = screen.getByRole("searchbox", { name: "Search files" });
+    fireEvent.change(searchbox, { target: { value: "no-match" } });
+    expect(screen.queryByRole("button", { name: /^Open / })).toBeNull();
+
+    fireEvent.keyDown(searchbox, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(document.activeElement?.getAttribute("aria-label")).toMatch(/^Open /);
+    });
+  });
+
   it("switches between list and grid from the segmented control", async () => {
     renderBrowser();
     expect(await screen.findByRole("button", { name: "Open README.md" })).toBeTruthy();

--- a/tests/desktop/files-browser-views.test.tsx
+++ b/tests/desktop/files-browser-views.test.tsx
@@ -236,6 +236,22 @@ describe("ComputerFileBrowser view options", () => {
     });
   });
 
+  it("returns keyboard focus to the search control in an empty listing", async () => {
+    api.get.mockResolvedValue({ entries: [] });
+    renderBrowser();
+    await screen.findByText("This folder is empty.");
+
+    fireEvent.click(screen.getByRole("button", { name: "Search files" }));
+    const searchbox = screen.getByRole("searchbox", { name: "Search files" });
+    expect(document.activeElement).toBe(searchbox);
+
+    fireEvent.keyDown(searchbox, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByRole("button", { name: "Search files" }));
+    });
+  });
+
   it("switches between list and grid from the segmented control", async () => {
     renderBrowser();
     expect(await screen.findByRole("button", { name: "Open README.md" })).toBeTruthy();

--- a/tests/desktop/files-workspace.test.tsx
+++ b/tests/desktop/files-workspace.test.tsx
@@ -111,13 +111,16 @@ describe("Files workspace", () => {
     ]);
   });
 
-  it("starts with the full-width overview and opens a split preview after selection", async () => {
+  it("starts with the Figma-width overview and opens a split preview after selection", async () => {
     render(<Tooltip.Provider><FilesWorkspace /></Tooltip.Provider>);
     await screen.findByRole("button", { name: "Open README.md" });
 
     const panes = screen.getByTestId("files-workspace-panes");
     expect(panes.getAttribute("data-layout")).toBe("overview");
-    expect(within(panes).getByRole("button", { name: "Refresh folder" })).toBeTruthy();
+    const homeContent = within(panes).getByTestId("files-home-content");
+    expect(homeContent.className).toContain("max-w-[1052px]");
+    expect(homeContent.className).toContain("px-4");
+    expect(homeContent.className).toContain("pt-4");
     expect(within(panes).queryByRole("region", { name: "File preview" })).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Open workspaces" }));

--- a/tests/e2e/desktop/hermes-conversations-responsive.e2e.test.ts
+++ b/tests/e2e/desktop/hermes-conversations-responsive.e2e.test.ts
@@ -11,8 +11,25 @@ const desktopRequire = createRequire(resolve(__dirname, "../../../desktop/packag
 const ELECTRON_EXECUTABLE = desktopRequire("electron") as string;
 const SCREENSHOT_DIR = resolve(__dirname, "../../../output/playwright/mat-299-responsive");
 const MAT_322_SCREENSHOT_DIR = resolve(__dirname, "../../../output/playwright/mat-322");
+const WIDE_VIEWPORT = { width: 1280, height: 800 } as const;
 const MINIMUM_VIEWPORT = { width: 880, height: 560 } as const;
 const suite = existsSync(DESKTOP_MAIN) ? describe : describe.skip;
+
+async function resizeDesktopWindow(
+  app: ElectronApplication,
+  page: Page,
+  size: { width: number; height: number },
+) {
+  await app.evaluate(({ BrowserWindow }, nextSize) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    if (!window) throw new Error("Desktop window is unavailable");
+    window.setContentSize(nextSize.width, nextSize.height);
+  }, size);
+  await page.waitForFunction(
+    (nextSize) => innerWidth === nextSize.width && innerHeight === nextSize.height,
+    size,
+  );
+}
 
 async function measureOverflow(root: Locator) {
   return root.evaluate((element) => {
@@ -68,7 +85,7 @@ suite("responsive Hermes Desktop conversations", () => {
       },
     });
     page = await app.firstWindow();
-    await page.setViewportSize(MINIMUM_VIEWPORT);
+    await resizeDesktopWindow(app, page, MINIMUM_VIEWPORT);
     await page.evaluate(() => window.operator.invoke("auth:start-device-flow", {}));
     await page.locator("aside button", { hasText: "Chat" }).first().waitFor({ timeout: 15_000 });
   }, 60_000);
@@ -79,8 +96,8 @@ suite("responsive Hermes Desktop conversations", () => {
     if (userDataDir) rmSync(userDataDir, { recursive: true, force: true });
   });
 
-  it("keeps Chat and Files toolbar actions visible at the Figma handoff viewport", async () => {
-    await page.setViewportSize({ width: 1512, height: 982 });
+  it("keeps Chat and Files toolbar actions visible after a native window resize", async () => {
+    await resizeDesktopWindow(app, page, WIDE_VIEWPORT);
     await page.locator("aside button", { hasText: "Chat" }).first().click();
     await page.getByRole("heading", { name: "Chats" }).waitFor({ timeout: 10_000 });
     expectNoHorizontalOverflow(await measureOverflow(page.locator("[data-chat-index-header]")));
@@ -89,7 +106,7 @@ suite("responsive Hermes Desktop conversations", () => {
     await page.getByRole("heading", { name: "Files" }).waitFor({ timeout: 10_000 });
     expectNoHorizontalOverflow(await measureOverflow(page.getByTestId("files-home-content")));
 
-    await page.setViewportSize(MINIMUM_VIEWPORT);
+    await resizeDesktopWindow(app, page, MINIMUM_VIEWPORT);
   }, 30_000);
 
   it("keeps Chats lifecycle surfaces inside the minimum Desktop viewport", async () => {

--- a/tests/e2e/desktop/hermes-conversations-responsive.e2e.test.ts
+++ b/tests/e2e/desktop/hermes-conversations-responsive.e2e.test.ts
@@ -69,6 +69,8 @@ suite("responsive Hermes Desktop conversations", () => {
     });
     page = await app.firstWindow();
     await page.setViewportSize(MINIMUM_VIEWPORT);
+    await page.evaluate(() => window.operator.invoke("auth:start-device-flow", {}));
+    await page.locator("aside button", { hasText: "Chat" }).first().waitFor({ timeout: 15_000 });
   }, 60_000);
 
   afterAll(async () => {
@@ -77,9 +79,20 @@ suite("responsive Hermes Desktop conversations", () => {
     if (userDataDir) rmSync(userDataDir, { recursive: true, force: true });
   });
 
+  it("keeps Chat and Files toolbar actions visible at the Figma handoff viewport", async () => {
+    await page.setViewportSize({ width: 1512, height: 982 });
+    await page.locator("aside button", { hasText: "Chat" }).first().click();
+    await page.getByRole("heading", { name: "Chats" }).waitFor({ timeout: 10_000 });
+    expectNoHorizontalOverflow(await measureOverflow(page.locator("[data-chat-index-header]")));
+
+    await page.locator("aside button", { hasText: "Files" }).first().click();
+    await page.getByRole("heading", { name: "Files" }).waitFor({ timeout: 10_000 });
+    expectNoHorizontalOverflow(await measureOverflow(page.getByTestId("files-home-content")));
+
+    await page.setViewportSize(MINIMUM_VIEWPORT);
+  }, 30_000);
+
   it("keeps Chats lifecycle surfaces inside the minimum Desktop viewport", async () => {
-    await page.getByRole("button", { name: /continue in browser/i }).click();
-    await page.locator("aside button", { hasText: "Chat" }).first().waitFor({ timeout: 15_000 });
     await page.locator("aside button", { hasText: "Chat" }).first().click();
 
     const chats = page.locator('section[aria-labelledby="conversation-index-title"]');
@@ -122,5 +135,20 @@ suite("responsive Hermes Desktop conversations", () => {
     expectNoHorizontalOverflow(conversationOverflow);
     expectNoHorizontalOverflow(resourcesOverflow);
     expectNoHorizontalOverflow(dialogOverflow);
+    await page.keyboard.press("Escape");
+  }, 30_000);
+
+  it("keeps every Files home toolbar control inside the minimum Desktop viewport", async () => {
+    await page.locator("aside button", { hasText: "Files" }).first().click();
+    await page.getByRole("heading", { name: "Files" }).waitFor({ timeout: 10_000 });
+
+    const files = page.getByTestId("files-home-content");
+    const filesOverflow = await measureOverflow(files);
+
+    expectNoHorizontalOverflow(filesOverflow);
+    expect(await page.getByRole("button", { name: "Grid view" }).count()).toBe(1);
+    expect(await page.getByRole("button", { name: "List view" }).count()).toBe(1);
+    expect(await page.getByRole("button", { name: "Search files" }).count()).toBe(1);
+    expect(await page.getByRole("button", { name: "Upload files" }).count()).toBe(1);
   }, 30_000);
 });


### PR DESCRIPTION
## Summary

- align the Desktop Chat conversation index with the Figma hierarchy, spacing, toolbar, and unboxed row treatment
- align the Desktop Files root list with the Figma toolbar, columns, row geometry, view switcher, search, and upload controls
- preserve Gateway-backed state, Files navigation, grid mode, selection, and preview behavior
- restore keyboard focus after Files search closes for populated, zero-result, and empty listings
- cover Chat and Files action visibility at both the Figma and minimum Desktop viewports without opening an external activation page

## Figma

- Chat: https://www.figma.com/design/USFVlYYFZ3WKJBAzFZSceC/Desktop-app?node-id=67-4472&m=dev
- Files: https://www.figma.com/design/USFVlYYFZ3WKJBAzFZSceC/Desktop-app?node-id=67-5663&m=dev

## Invariants

- Source of truth: the existing Gateway-backed Chat and Files stores; Figma only changes presentation.
- Lock/transaction boundary: none; this is renderer-only and introduces no persistent writes.
- Acceptable orphan states: none; Files search is bounded local UI state and resets when the runtime or directory changes.
- Auth source of truth: the existing Desktop auth, connection, and API client paths.
- Deferred scope: chat detail/composer, Files preview/grid styling, sidebar, Terminal, and authentication browser behavior.

## Verification

- Exact head: `88213eadb1fdd7e92278f03395f900a0d8240a04`
- Greptile: 5/5; all three review threads resolved
- Five focused Desktop suites: 108/108 passed when run by suite
- Native Electron responsive E2E: 3/3 passed at 1280×800 and 880×560
- Full typecheck: passed
- Pattern scan: 0 violations
- Desktop build and unsigned macOS packaging: passed
- Fresh packaged macOS validation at 1120×760: Chat and Files actions remain inside the adaptive workspace
- Evidence attached to [MAT-455](https://linear.app/matrix-os/issue/MAT-455/align-desktop-chat-and-files-home-lists-with-figma)

One combined parallel focused run briefly produced 107/108 because the markdown-preview heading missed its wait window. The affected Files workspace suite then passed 28/28 independently and in the serial gate; no product or test changes were required.

The broad repository test command was stopped after unrelated failures in untouched Platform/Gateway suites, including customer VPS cloud-init, host scripts, zellij, coding-agent runtime, and onboarding tool-pack tests. Focused Desktop coverage and all static/build gates above pass on this head.

Linear: https://linear.app/matrix-os/issue/MAT-455/align-desktop-chat-and-files-home-lists-with-figma
