### PR TITLE
feat(desktop): add coding provider readiness recovery

### DIFF
--- a/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
@@ -51,6 +51,11 @@ import { AttachmentPreviewRow } from "../chat/attachments/AttachmentPreviewRow";
 import { useConversationAttachments } from "../chat/attachments/use-conversation-attachments";
 import { abortAgentThread, agentThreadAbortSupported } from "./abort-thread";
 import { AgentComposerPickers } from "./composer-pickers";
+import { ProviderReadinessNotice } from "./ProviderReadinessNotice";
+import {
+  deriveProviderReadiness,
+  type ProviderReadinessPresentation,
+} from "./provider-readiness";
 import {
   projectConversationTimeline,
   type AssistantEvent,
@@ -642,6 +647,8 @@ function ConversationComposer({
   threadBusy,
   composerControls,
   attachments,
+  readiness,
+  providers,
 }: {
   threadId: string;
   threadLabel: string;
@@ -650,6 +657,8 @@ function ConversationComposer({
   // Left side of the composer bottom row (provider/mode pickers).
   composerControls?: ReactNode;
   attachments: ReturnType<typeof useConversationAttachments>;
+  readiness?: ProviderReadinessPresentation;
+  providers: RuntimeSummary["providers"];
 }) {
   const [message, setMessage] = useState("");
   const [uploadingAttachments, setUploadingAttachments] = useState(false);
@@ -663,7 +672,14 @@ function ConversationComposer({
   const abortSupported = agentThreadAbortSupported();
 
   async function submit() {
-    if ((!message.trim() && attachments.items.length === 0) || waitingForAction || threadBusy || submitting || uploadingAttachments) return;
+    if (
+      (!message.trim() && attachments.items.length === 0)
+      || readiness?.blocked
+      || waitingForAction
+      || threadBusy
+      || submitting
+      || uploadingAttachments
+    ) return;
     // Every accepted submit is a direct send. While the thread is known busy,
     // the draft remains local and editable, but Matrix does not offer a doomed
     // send or invent a renderer-owned queue.
@@ -695,6 +711,15 @@ function ConversationComposer({
       {/* Floating composer card: same centered column as the transcript; the
           rounded/shadowed surface itself lives on PromptInput's prompt-card. */}
       <div className="mx-auto w-full max-w-[46rem]" data-slot="conversation-composer">
+        {readiness ? (
+          <div className="mb-2">
+            <ProviderReadinessNotice
+              readiness={readiness}
+              providers={providers}
+              onRefresh={() => useCodingAgentWorkspace.getState().refresh()}
+            />
+          </div>
+        ) : null}
         {turnThreadId === threadId && turnError ? (
           <p className="mb-1 px-1 text-xs" style={{ color: "var(--danger)" }}>{turnError}</p>
         ) : null}
@@ -705,7 +730,14 @@ function ConversationComposer({
           onAbort={abortSupported && (submitting || threadBusy) ? () => void abortAgentThread(threadId) : undefined}
           busy={submitting || threadBusy || uploadingAttachments}
           disabled={waitingForAction || uploadingAttachments}
-          canSubmit={!waitingForAction && !threadBusy && !submitting && !uploadingAttachments && (message.trim().length > 0 || attachments.items.length > 0)}
+          canSubmit={
+            !readiness?.blocked
+            && !waitingForAction
+            && !threadBusy
+            && !submitting
+            && !uploadingAttachments
+            && (message.trim().length > 0 || attachments.items.length > 0)
+          }
           attachments={(
             <AttachmentPreviewRow
               items={attachments.items}
@@ -799,6 +831,16 @@ export function AgentConversationView({
   const streamingAssistant = lastItem?.kind === "assistant"
     && !lastItem.events.some((event) => event.type === "assistant.text.completed");
   const showWorking = running && !streamingAssistant;
+  // Project Chats always supplies the runtime summary. Keeping this optional
+  // preserves the transcript component's isolated story/test seam; every
+  // product send path derives fail-closed readiness from the stored provider.
+  const providerReadiness = summary
+    ? deriveProviderReadiness({
+        summary,
+        providerId: snapshot.thread.providerId,
+        loading: false,
+      })
+    : undefined;
 
   return (
     <section aria-label={`Conversation ${snapshot.thread.title}`} className="ph-no-capture flex min-h-[460px] min-w-0 flex-1 flex-col overflow-hidden" style={{ background: "var(--bg-app)" }} {...attachments.paneProps}>
@@ -887,6 +929,8 @@ export function AgentConversationView({
           waitingForAction={snapshot.thread.status === "waiting_for_approval" || snapshot.thread.status === "waiting_for_input"}
           threadBusy={running}
           attachments={attachments}
+          readiness={providerReadiness}
+          providers={summary?.providers ?? []}
           composerControls={
             summary ? (
               <AgentComposerPickers

--- a/desktop/src/renderer/src/features/coding-agents/ProviderReadinessNotice.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/ProviderReadinessNotice.tsx
@@ -1,0 +1,118 @@
+import type { AgentProviderSummary, SafeSetupAction } from "@matrix-os/contracts";
+import { AlertCircle } from "lucide-react";
+import { useState } from "react";
+import { Button } from "../../design/primitives";
+import { useConnection } from "../../stores/connection";
+import { useTabs } from "../../stores/tabs";
+import { useUi } from "../../stores/ui";
+import { executeProviderSetupAction } from "./provider-setup-terminal";
+import type { ProviderReadinessPresentation } from "./provider-readiness";
+
+const SETUP_ERROR = "Could not open provider setup. Open Providers settings to continue.";
+const REFRESH_ERROR = "Provider status is unavailable right now.";
+
+function sameSetupAction(left: SafeSetupAction, right: SafeSetupAction): boolean {
+  if (left.kind !== right.kind || left.id !== right.id || left.label !== right.label) return false;
+  return left.kind === "open_settings" ||
+    (right.kind === "foreground_terminal" && left.command === right.command);
+}
+
+export function ProviderReadinessNotice(props: {
+  readiness: ProviderReadinessPresentation;
+  providers: AgentProviderSummary[];
+  onRefresh: () => Promise<void>;
+}): React.JSX.Element | null {
+  const api = useConnection((state) => state.api);
+  const openTab = useTabs((state) => state.openTab);
+  const requestSettingsSection = useUi((state) => state.requestSettingsSection);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!props.readiness.blocked || props.readiness.state === "ready") return null;
+
+  const runAction = async () => {
+    const readinessAction = props.readiness.action;
+    if (!readinessAction || pending) return;
+    setPending(true);
+    setError(null);
+    try {
+      if (readinessAction.kind === "refresh") {
+        await props.onRefresh();
+        return;
+      }
+      if (readinessAction.action.kind === "open_settings") {
+        requestSettingsSection("providers");
+        openTab({ kind: "settings", title: "Settings" });
+        return;
+      }
+      const provider = props.providers.find((candidate) =>
+        candidate.setupActions.some((action) => sameSetupAction(action, readinessAction.action))
+      );
+      const opened = provider
+        ? await executeProviderSetupAction({
+            provider,
+            action: readinessAction.action,
+            api,
+            openTab,
+            requestSettingsSection,
+          })
+        : false;
+      if (!opened) setError(SETUP_ERROR);
+    } catch (err: unknown) {
+      console.error(
+        "[provider-readiness] Recovery action failed:",
+        err instanceof Error ? err.name : typeof err,
+      );
+      setError(readinessAction.kind === "refresh" ? REFRESH_ERROR : SETUP_ERROR);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const actionLabel = props.readiness.action?.kind === "setup"
+    ? props.readiness.action.action.label
+    : "Refresh status";
+  const pendingLabel = props.readiness.action?.kind === "refresh" ? "Refreshing…" : "Opening…";
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-start gap-2.5 rounded-lg border px-3 py-2.5"
+      style={{
+        borderColor: "var(--warning)",
+        background: "color-mix(in srgb, var(--warning) 8%, transparent)",
+      }}
+    >
+      <AlertCircle
+        aria-hidden="true"
+        size={15}
+        className="mt-0.5 shrink-0"
+        style={{ color: "var(--warning)" }}
+      />
+      <div className="min-w-0 flex-1">
+        <p className="text-xs font-medium" style={{ color: "var(--text-primary)" }}>
+          {props.readiness.title}
+        </p>
+        <p className="mt-0.5 text-xs" style={{ color: "var(--text-secondary)" }}>
+          {props.readiness.description}
+        </p>
+        {error ? (
+          <p className="mt-1 text-xs" style={{ color: "var(--danger)" }}>
+            {error}
+          </p>
+        ) : null}
+      </div>
+      {props.readiness.action ? (
+        <Button
+          variant="subtle"
+          disabled={pending}
+          aria-label={props.readiness.action.kind === "refresh" ? "Refresh provider status" : actionLabel}
+          onClick={() => void runAction()}
+        >
+          {pending ? pendingLabel : actionLabel}
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/coding-agents/provider-readiness.ts
+++ b/desktop/src/renderer/src/features/coding-agents/provider-readiness.ts
@@ -1,0 +1,139 @@
+import type { RuntimeSummary, SafeSetupAction } from "@matrix-os/contracts";
+
+export type ProviderReadinessAction =
+  | { kind: "setup"; action: SafeSetupAction }
+  | { kind: "refresh" }
+  | null;
+
+export interface ProviderReadinessPresentation {
+  state:
+    | "loading"
+    | "ready"
+    | "unconfigured"
+    | "missing"
+    | "auth_required"
+    | "expired"
+    | "installing"
+    | "unsupported"
+    | "unverified";
+  blocked: boolean;
+  title: string;
+  description: string;
+  action: ProviderReadinessAction;
+}
+
+const OPEN_PROVIDER_SETTINGS_ACTION: SafeSetupAction = {
+  id: "provider_settings",
+  kind: "open_settings",
+  label: "Open provider settings",
+};
+
+function unverifiedProvider(displayName?: string): ProviderReadinessPresentation {
+  return {
+    state: "unverified",
+    blocked: true,
+    title: displayName
+      ? `Matrix could not verify ${displayName}`
+      : "Matrix could not verify this provider",
+    description: "Refresh provider status before sending.",
+    action: { kind: "refresh" },
+  };
+}
+
+function setupAction(
+  setupActions: SafeSetupAction[],
+): Extract<ProviderReadinessAction, { kind: "setup" }> {
+  return {
+    kind: "setup",
+    action: setupActions[0] ?? OPEN_PROVIDER_SETTINGS_ACTION,
+  };
+}
+
+export function deriveProviderReadiness(input: {
+  summary: RuntimeSummary | null;
+  providerId?: string;
+  loading: boolean;
+}): ProviderReadinessPresentation {
+  if (input.loading) {
+    return {
+      state: "loading",
+      blocked: true,
+      title: "Checking coding agent provider",
+      description: "Matrix is verifying the selected provider.",
+      action: null,
+    };
+  }
+  if (!input.summary) return unverifiedProvider();
+  if (!input.providerId || input.summary.providers.length === 0) {
+    return {
+      state: "unconfigured",
+      blocked: true,
+      title: "No coding agent provider is configured",
+      description: "Open provider settings to choose a coding agent provider.",
+      action: { kind: "setup", action: OPEN_PROVIDER_SETTINGS_ACTION },
+    };
+  }
+
+  const provider = input.summary.providers.find((candidate) => candidate.id === input.providerId);
+  if (!provider) return unverifiedProvider();
+
+  if (
+    provider.availability === "available" &&
+    provider.installStatus === "installed" &&
+    provider.authStatus === "authenticated"
+  ) {
+    return {
+      state: "ready",
+      blocked: false,
+      title: "",
+      description: "",
+      action: null,
+    };
+  }
+  if (provider.availability === "installing" || provider.installStatus === "installing") {
+    return {
+      state: "installing",
+      blocked: true,
+      title: `Installing ${provider.displayName}`,
+      description: "Refresh provider status after installation finishes.",
+      action: { kind: "refresh" },
+    };
+  }
+  if (provider.authStatus === "expired") {
+    return {
+      state: "expired",
+      blocked: true,
+      title: `${provider.displayName} needs to be reconnected`,
+      description: `Reconnect ${provider.displayName} before sending a message.`,
+      action: setupAction(provider.setupActions),
+    };
+  }
+  if (provider.availability === "auth_required") {
+    return {
+      state: "auth_required",
+      blocked: true,
+      title: `Connect ${provider.displayName} to continue`,
+      description: `Sign in to ${provider.displayName} before sending a message.`,
+      action: setupAction(provider.setupActions),
+    };
+  }
+  if (provider.availability === "setup_required" || provider.installStatus === "missing") {
+    return {
+      state: "missing",
+      blocked: true,
+      title: `${provider.displayName} is not installed`,
+      description: `Install ${provider.displayName} before sending a message.`,
+      action: setupAction(provider.setupActions),
+    };
+  }
+  if (provider.installStatus === "failed") {
+    return {
+      state: "unsupported",
+      blocked: true,
+      title: `Update ${provider.displayName} to a supported version`,
+      description: `Open setup to install a supported ${provider.displayName} version.`,
+      action: setupAction(provider.setupActions),
+    };
+  }
+  return unverifiedProvider(provider.displayName);
+}

--- a/desktop/src/renderer/src/features/coding-agents/provider-readiness.ts
+++ b/desktop/src/renderer/src/features/coding-agents/provider-readiness.ts
@@ -49,6 +49,21 @@ function setupAction(
   };
 }
 
+function authenticationAction(
+  providerId: string,
+  setupActions: SafeSetupAction[],
+): Extract<ProviderReadinessAction, { kind: "setup" }> {
+  const trustedActionIds = new Set([
+    `${providerId}_connect`,
+    `${providerId}_reconnect`,
+  ]);
+  return {
+    kind: "setup",
+    action: setupActions.find((action) => trustedActionIds.has(action.id))
+      ?? OPEN_PROVIDER_SETTINGS_ACTION,
+  };
+}
+
 export function deriveProviderReadiness(input: {
   summary: RuntimeSummary | null;
   providerId?: string;
@@ -105,7 +120,7 @@ export function deriveProviderReadiness(input: {
       blocked: true,
       title: `${provider.displayName} needs to be reconnected`,
       description: `Reconnect ${provider.displayName} before sending a message.`,
-      action: setupAction(provider.setupActions),
+      action: authenticationAction(provider.id, provider.setupActions),
     };
   }
   if (provider.availability === "auth_required") {
@@ -114,7 +129,7 @@ export function deriveProviderReadiness(input: {
       blocked: true,
       title: `Connect ${provider.displayName} to continue`,
       description: `Sign in to ${provider.displayName} before sending a message.`,
-      action: setupAction(provider.setupActions),
+      action: authenticationAction(provider.id, provider.setupActions),
     };
   }
   if (provider.availability === "setup_required" || provider.installStatus === "missing") {

--- a/desktop/src/renderer/src/features/coding-agents/provider-setup-terminal.ts
+++ b/desktop/src/renderer/src/features/coding-agents/provider-setup-terminal.ts
@@ -80,3 +80,34 @@ export async function openProviderSetupTerminal(
     return false;
   }
 }
+
+export async function executeProviderSetupAction(input: {
+  provider: AgentProviderSummary;
+  action: SafeSetupAction;
+  api: ApiClient | null;
+  openTab: ReturnType<typeof useTabs.getState>["openTab"];
+  requestSettingsSection: (section: string) => void;
+}): Promise<boolean> {
+  if (input.action.kind === "open_settings") {
+    input.requestSettingsSection("providers");
+    input.openTab({ kind: "settings", title: "Settings" });
+    return true;
+  }
+  if (!input.api) return false;
+  const foregroundAction = input.action;
+
+  const trustedAction = input.provider.setupActions.find((candidate) =>
+    candidate.kind === "foreground_terminal" &&
+    candidate.id === foregroundAction.id &&
+    candidate.label === foregroundAction.label &&
+    candidate.command === foregroundAction.command
+  );
+  if (!trustedAction || trustedAction.kind !== "foreground_terminal") return false;
+  const setup = providerSetupCommands([input.provider]).find((candidate) =>
+    candidate.key === `${input.provider.id}:${trustedAction.id}` &&
+    candidate.label === trustedAction.label &&
+    candidate.command === trustedAction.command
+  );
+  if (!setup) return false;
+  return await openProviderSetupTerminal(input.api, setup, input.openTab, "provider-readiness");
+}

--- a/desktop/src/renderer/src/features/coding-agents/provider-setup-terminal.ts
+++ b/desktop/src/renderer/src/features/coding-agents/provider-setup-terminal.ts
@@ -3,7 +3,10 @@ import type { ApiClient } from "../../lib/api";
 import type { useTabs } from "../../stores/tabs";
 
 const MAX_PROVIDER_SETUP_ACTIONS = 10;
+const MAX_SETUP_SESSION_NAME_LENGTH = 31;
+const SETUP_RUN_SUFFIX_LENGTH = 6;
 const SESSION_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]{0,29}[a-z0-9])?$/;
+let setupRunSequence = 0;
 
 type ForegroundSetupAction = Extract<SafeSetupAction, { kind: "foreground_terminal" }>;
 
@@ -41,6 +44,22 @@ function setupSessionName(providerId: string, actionId: string): string {
   return `${prefix}${segment || "agent"}-${suffix}`;
 }
 
+function freshSetupSessionName(setup: ProviderSetupCommand): string {
+  setupRunSequence = (setupRunSequence + 1) % Number.MAX_SAFE_INTEGER;
+  const randomIdentity = typeof globalThis.crypto?.randomUUID === "function"
+    ? globalThis.crypto.randomUUID()
+    : "";
+  const suffix = setupSessionHash(
+    `${setup.key}:${setup.command}:${Date.now()}:${setupRunSequence}:${randomIdentity}`,
+  );
+  const stableName = /-[a-z0-9]{6}$/.test(setup.sessionName)
+    ? setup.sessionName.slice(0, -(SETUP_RUN_SUFFIX_LENGTH + 1))
+    : setup.sessionName;
+  const maxBaseLength = MAX_SETUP_SESSION_NAME_LENGTH - SETUP_RUN_SUFFIX_LENGTH - 1;
+  const base = stableName.slice(0, maxBaseLength).replace(/-+$/g, "") || "matrix-setup";
+  return `${base}-${suffix}`;
+}
+
 export function providerSetupCommands(providers: AgentProviderSummary[]): ProviderSetupCommand[] {
   const commands: ProviderSetupCommand[] = [];
   for (const provider of providers) {
@@ -65,14 +84,15 @@ export async function openProviderSetupTerminal(
   logPrefix = "provider-setup",
 ): Promise<boolean> {
   try {
+    const requestedSessionName = freshSetupSessionName(setup);
     const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", {
-      name: setup.sessionName,
+      name: requestedSessionName,
       cwd: "projects",
       cmd: setup.command,
     });
     const sessionName = typeof response.name === "string" && SESSION_NAME_PATTERN.test(response.name)
       ? response.name
-      : setup.sessionName;
+      : requestedSessionName;
     openTab({ kind: "terminal", sessionName, title: setup.label });
     return true;
   } catch (err: unknown) {

--- a/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
@@ -16,6 +16,8 @@ import { AttachmentPreviewRow } from "../chat/attachments/AttachmentPreviewRow";
 import { useConversationAttachments } from "../chat/attachments/use-conversation-attachments";
 import { AgentComposerPickers } from "../coding-agents/composer-pickers";
 import { capabilityEnabled } from "../coding-agents/capabilities";
+import { ProviderReadinessNotice } from "../coding-agents/ProviderReadinessNotice";
+import { deriveProviderReadiness } from "../coding-agents/provider-readiness";
 import { isTypeToStartInteractiveTarget } from "../coding-agents/type-to-start";
 import {
   clearComposerLaunchContext,
@@ -100,6 +102,8 @@ export function ProjectChatDraft({
   const createStatus = useCodingAgentWorkspace((s) => s.createStatus);
   const createError = useCodingAgentWorkspace((s) => s.createError);
   const createThread = useCodingAgentWorkspace((s) => s.createThread);
+  const workspaceStatus = useCodingAgentWorkspace((s) => s.status);
+  const refreshSummary = useCodingAgentWorkspace((s) => s.refresh);
   const resolveNewChatTarget = useProjectWorkspaces((s) => s.resolveNewChatTarget);
   const canCreate = capabilityEnabled(summary, "codingAgentsThreadCreate");
   const submitting = createStatus === "submitting";
@@ -123,6 +127,13 @@ export function ProjectChatDraft({
         mode: initialDraft.mode,
         sandboxMode: initialDraft.sandboxMode,
       };
+  const selectedProvider = summary.providers.find((provider) => provider.id === effectiveDraft.providerId)
+    ?? summary.providers[0];
+  const readiness = deriveProviderReadiness({
+    summary,
+    providerId: effectiveDraft.providerId ?? selectedProvider?.id,
+    loading: workspaceStatus === "loading",
+  });
 
   useEffect(() => {
     void useProviderPreferences.getState().hydrate();
@@ -146,7 +157,7 @@ export function ProjectChatDraft({
   }, [active, typeToStartEnabled, canCreate]);
 
   async function submit() {
-    if (submitting || submitInFlightRef.current) return;
+    if (readiness.blocked || submitting || submitInFlightRef.current) return;
     let effective = effectiveDraft;
     if (!effective.prompt.trim() && attachments.items.length === 0) return;
     submitInFlightRef.current = true;
@@ -190,8 +201,6 @@ export function ProjectChatDraft({
     }
   }
 
-  const selectedProvider = summary.providers.find((provider) => provider.id === effectiveDraft.providerId)
-    ?? summary.providers[0];
   const promptEmpty = effectiveDraft.prompt.trim().length === 0 && attachments.items.length === 0;
 
   return (
@@ -217,48 +226,57 @@ export function ProjectChatDraft({
             <p className="mb-1 px-1 text-xs" style={{ color: "var(--danger)" }}>{createError}</p>
           ) : null}
           {canCreate ? (
-            <PromptInput
-              value={effectiveDraft.prompt}
-              onChange={(prompt) => setDraft((current) => ({ ...current, prompt }))}
-              onSubmit={() => void submit()}
-              busy={busy}
-              disabled={busy}
-              canSubmit={!busy && (effectiveDraft.prompt.trim().length > 0 || attachments.items.length > 0)}
-              attachments={(
-                <AttachmentPreviewRow
-                  items={attachments.items}
-                  disabled={busy}
-                  onRemove={attachments.remove}
-                  onRetry={(localId) => void attachments.retry(localId)}
+            <>
+              <div className="mb-2">
+                <ProviderReadinessNotice
+                  readiness={readiness}
+                  providers={summary.providers}
+                  onRefresh={refreshSummary}
                 />
-              )}
-              autoFocus={active}
-              focusRequestId={active ? focusRequestId + localFocusBumps : 0}
-              maxLength={24_000}
-              ariaLabel="Message new chat"
-              placeholder="Ask the agent to do anything…"
-              controls={(
-                <AgentComposerPickers
-                  summary={summary}
-                  providerId={selectedProvider?.id}
-                  mode={effectiveDraft.mode ?? selectedProvider?.defaultMode}
-                  onProviderChange={(providerId) => {
-                    providerSelectionTouchedRef.current = true;
-                    const provider = summary.providers.find((candidate) => candidate.id === providerId);
-                    setDraft((current) => ({
-                      ...current,
-                      providerId: provider?.id,
-                      mode: provider?.defaultMode ?? current.mode,
-                      sandboxMode: defaultSandboxModeForProvider(provider),
-                    }));
-                  }}
-                  onModeChange={(mode) => {
-                    providerSelectionTouchedRef.current = true;
-                    setDraft((current) => ({ ...current, mode }));
-                  }}
-                />
-              )}
-            />
+              </div>
+              <PromptInput
+                value={effectiveDraft.prompt}
+                onChange={(prompt) => setDraft((current) => ({ ...current, prompt }))}
+                onSubmit={() => void submit()}
+                busy={busy}
+                disabled={busy}
+                canSubmit={!busy && !readiness.blocked && (effectiveDraft.prompt.trim().length > 0 || attachments.items.length > 0)}
+                attachments={(
+                  <AttachmentPreviewRow
+                    items={attachments.items}
+                    disabled={busy}
+                    onRemove={attachments.remove}
+                    onRetry={(localId) => void attachments.retry(localId)}
+                  />
+                )}
+                autoFocus={active}
+                focusRequestId={active ? focusRequestId + localFocusBumps : 0}
+                maxLength={24_000}
+                ariaLabel="Message new chat"
+                placeholder="Ask the agent to do anything…"
+                controls={(
+                  <AgentComposerPickers
+                    summary={summary}
+                    providerId={selectedProvider?.id}
+                    mode={effectiveDraft.mode ?? selectedProvider?.defaultMode}
+                    onProviderChange={(providerId) => {
+                      providerSelectionTouchedRef.current = true;
+                      const provider = summary.providers.find((candidate) => candidate.id === providerId);
+                      setDraft((current) => ({
+                        ...current,
+                        providerId: provider?.id,
+                        mode: provider?.defaultMode ?? current.mode,
+                        sandboxMode: defaultSandboxModeForProvider(provider),
+                      }));
+                    }}
+                    onModeChange={(mode) => {
+                      providerSelectionTouchedRef.current = true;
+                      setDraft((current) => ({ ...current, mode }));
+                    }}
+                  />
+                )}
+              />
+            </>
           ) : (
             <div
               className="rounded-[var(--radius-xl)] border p-4 text-sm"

--- a/desktop/src/renderer/src/features/project/ProjectChatsView.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatsView.tsx
@@ -56,7 +56,7 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
   const status = useCodingAgentWorkspace((s) => s.status);
   const summary = useCodingAgentWorkspace((s) => s.summary);
   const error = useCodingAgentWorkspace((s) => s.error);
-  const refresh = useCodingAgentWorkspace((s) => s.refresh);
+  const refreshRuntimeSummary = useCodingAgentWorkspace((s) => s.refresh);
   const loadNotificationPreferences = useCodingAgentWorkspace((s) => s.loadNotificationPreferences);
   const activeThreadId = useCodingAgentWorkspace((s) => s.activeThreadId);
   const threadSnapshotStatus = useCodingAgentWorkspace((s) => s.threadSnapshotStatus);
@@ -123,8 +123,8 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
       || draftReadinessRefreshedRef.current
     ) return;
     draftReadinessRefreshedRef.current = true;
-    void refresh();
-  }, [active, projectWorkspaceEnabled, refresh, selectedThreadId, workspaceEntry?.status]);
+    void refreshRuntimeSummary();
+  }, [active, projectWorkspaceEnabled, refreshRuntimeSummary, selectedThreadId, workspaceEntry?.status]);
 
   useEffect(() => {
     if (!projectWorkspaceEnabled) return;
@@ -327,7 +327,7 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
         icon={<Server size={28} />}
         headline={error ?? "Runtime summary unavailable"}
         description="Refresh the workspace or check your selected runtime."
-        action={<Button onClick={() => void refresh()}>Retry</Button>}
+        action={<Button onClick={() => void refreshRuntimeSummary()}>Retry</Button>}
       />
     );
   }

--- a/desktop/src/renderer/src/features/project/ProjectChatsView.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatsView.tsx
@@ -82,6 +82,7 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
   const [composerSeed, setComposerSeed] = useState<ComposerSeed | null>(null);
   const [inspectorTabOverride, setInspectorTabOverride] = useState<AgentConversationInspectorTab | null>(null);
   const newChatRequestIdRef = useRef(0);
+  const draftReadinessRefreshedRef = useRef(false);
 
   // Runtime-scope reconciliation + self-sufficiency bootstrap: the first
   // mounted view claims the scope (clearing the previous account's data),
@@ -105,6 +106,25 @@ export default function ProjectChatsView({ projectId, active }: { projectId: str
     ? capabilityEnabled(summary, "codingAgentsProjectWorkspace")
     : false;
   const capabilitiesLoaded = summary !== null;
+
+  // Terminal-based provider setup changes readiness outside React. Refresh
+  // once whenever the active project enters its New Chat surface so the
+  // composer does not wait for unrelated navigation to discover login/logout.
+  // This is transition-driven, not a polling loop; leaving the draft resets
+  // the guard so the next deliberate New Chat entry checks again.
+  useEffect(() => {
+    if (!active || selectedThreadId !== null) {
+      draftReadinessRefreshedRef.current = false;
+      return;
+    }
+    if (
+      !projectWorkspaceEnabled
+      || workspaceEntry?.status !== "ready"
+      || draftReadinessRefreshedRef.current
+    ) return;
+    draftReadinessRefreshedRef.current = true;
+    void refresh();
+  }, [active, projectWorkspaceEnabled, refresh, selectedThreadId, workspaceEntry?.status]);
 
   useEffect(() => {
     if (!projectWorkspaceEnabled) return;

--- a/desktop/src/renderer/src/features/project/ProjectTab.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectTab.tsx
@@ -65,8 +65,6 @@ export default function ProjectTab({ projectSlug, active }: { projectSlug: strin
   const summary = useCodingAgentWorkspace((s) => s.summary);
   const refresh = useCodingAgentWorkspace((s) => s.refresh);
   const refreshWorkspace = useProjectWorkspaces((s) => s.refresh);
-  const hasProjectViewEntry = useProjectView((s) => s.entries[projectSlug] !== undefined);
-  const selectedThreadId = useProjectView((s) => s.entries[projectSlug]?.selectedThreadId ?? null);
   const runtimeScope = useConnection(codingAgentRuntimeScope);
   const api = useConnection((s) => s.api);
   const createTaskOpen = useUi((s) => s.createTaskOpen);
@@ -138,8 +136,10 @@ export default function ProjectTab({ projectSlug, active }: { projectSlug: strin
               onClick={() => {
                 void (async () => {
                   await refresh();
+                  const currentViewEntry = useProjectView.getState().entries[projectSlug];
                   await refreshWorkspace(projectSlug, {
-                    preserveEmptySelection: hasProjectViewEntry && selectedThreadId === null,
+                    preserveEmptySelection:
+                      currentViewEntry !== undefined && currentViewEntry.selectedThreadId === null,
                   });
                 })();
               }}

--- a/desktop/src/renderer/src/features/project/ProjectTab.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectTab.tsx
@@ -65,6 +65,7 @@ export default function ProjectTab({ projectSlug, active }: { projectSlug: strin
   const summary = useCodingAgentWorkspace((s) => s.summary);
   const refresh = useCodingAgentWorkspace((s) => s.refresh);
   const refreshWorkspace = useProjectWorkspaces((s) => s.refresh);
+  const hasProjectViewEntry = useProjectView((s) => s.entries[projectSlug] !== undefined);
   const selectedThreadId = useProjectView((s) => s.entries[projectSlug]?.selectedThreadId ?? null);
   const runtimeScope = useConnection(codingAgentRuntimeScope);
   const api = useConnection((s) => s.api);
@@ -138,7 +139,7 @@ export default function ProjectTab({ projectSlug, active }: { projectSlug: strin
                 void (async () => {
                   await refresh();
                   await refreshWorkspace(projectSlug, {
-                    preserveEmptySelection: selectedThreadId === null,
+                    preserveEmptySelection: hasProjectViewEntry && selectedThreadId === null,
                   });
                 })();
               }}

--- a/desktop/src/renderer/src/features/project/ProjectTab.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectTab.tsx
@@ -65,6 +65,7 @@ export default function ProjectTab({ projectSlug, active }: { projectSlug: strin
   const summary = useCodingAgentWorkspace((s) => s.summary);
   const refresh = useCodingAgentWorkspace((s) => s.refresh);
   const refreshWorkspace = useProjectWorkspaces((s) => s.refresh);
+  const selectedThreadId = useProjectView((s) => s.entries[projectSlug]?.selectedThreadId ?? null);
   const runtimeScope = useConnection(codingAgentRuntimeScope);
   const api = useConnection((s) => s.api);
   const createTaskOpen = useUi((s) => s.createTaskOpen);
@@ -136,7 +137,9 @@ export default function ProjectTab({ projectSlug, active }: { projectSlug: strin
               onClick={() => {
                 void (async () => {
                   await refresh();
-                  await refreshWorkspace(projectSlug);
+                  await refreshWorkspace(projectSlug, {
+                    preserveEmptySelection: selectedThreadId === null,
+                  });
                 })();
               }}
             >

--- a/desktop/src/renderer/src/stores/project-view.ts
+++ b/desktop/src/renderer/src/stores/project-view.ts
@@ -21,12 +21,23 @@ const DEFAULT_VIEW: ProjectView = "board";
 
 interface ProjectViewState {
   entries: Record<string, ProjectViewEntry>;
+  selectionRevisions: Record<string, number>;
   runtimeScope: string | null;
   hydrate: (runtimeScope: string) => Promise<void>;
   viewFor: (projectId: string) => ProjectView;
   selectedThreadFor: (projectId: string) => string | null;
+  selectionRevisionFor: (projectId: string) => number;
   setView: (projectId: string, view: ProjectView) => void;
   setSelectedThread: (projectId: string, threadId: string | null) => void;
+}
+
+function retainSelectionRevisions(
+  revisions: Record<string, number>,
+  entries: Record<string, ProjectViewEntry>,
+): Record<string, number> {
+  return Object.fromEntries(
+    Object.entries(revisions).filter(([projectId]) => projectId in entries),
+  );
 }
 
 function persistEntries(entries: Record<string, ProjectViewEntry>, runtimeScope: string | null): void {
@@ -68,7 +79,7 @@ function upsertEntry(
 }
 
 export function clearProjectViewRuntime(): void {
-  useProjectView.setState({ entries: {}, runtimeScope: null });
+  useProjectView.setState({ entries: {}, selectionRevisions: {}, runtimeScope: null });
 }
 
 export function clearProjectView(projectId: string): void {
@@ -76,12 +87,15 @@ export function clearProjectView(projectId: string): void {
   if (!(projectId in state.entries)) return;
   const entries = { ...state.entries };
   delete entries[projectId];
-  useProjectView.setState({ entries });
+  const selectionRevisions = { ...state.selectionRevisions };
+  delete selectionRevisions[projectId];
+  useProjectView.setState({ entries, selectionRevisions });
   persistEntries(entries, state.runtimeScope);
 }
 
 export const useProjectView = create<ProjectViewState>()((set, get) => ({
   entries: {},
+  selectionRevisions: {},
   runtimeScope: null,
 
   hydrate: async (runtimeScope) => {
@@ -122,7 +136,10 @@ export const useProjectView = create<ProjectViewState>()((set, get) => ({
             .slice(0, MAX_PROJECT_VIEW_ENTRIES)
             .map((key) => [key, merged[key]!] as const),
         );
-    set({ entries: capped });
+    set({
+      entries: capped,
+      selectionRevisions: retainSelectionRevisions(get().selectionRevisions, capped),
+    });
     persistEntries(capped, runtimeScope);
   },
 
@@ -130,15 +147,32 @@ export const useProjectView = create<ProjectViewState>()((set, get) => ({
 
   selectedThreadFor: (projectId) => get().entries[projectId]?.selectedThreadId ?? null,
 
+  selectionRevisionFor: (projectId) => get().selectionRevisions[projectId] ?? 0,
+
   setView: (projectId, view) => {
     const entries = upsertEntry(get().entries, projectId, { view }, Date.now());
-    set({ entries });
+    set({
+      entries,
+      selectionRevisions: retainSelectionRevisions(get().selectionRevisions, entries),
+    });
     persistEntries(entries, get().runtimeScope);
   },
 
   setSelectedThread: (projectId, threadId) => {
-    const entries = upsertEntry(get().entries, projectId, { selectedThreadId: threadId }, Date.now());
-    set({ entries });
+    const entries = upsertEntry(
+      get().entries,
+      projectId,
+      { selectedThreadId: threadId },
+      Date.now(),
+    );
+    const selectionRevisions = retainSelectionRevisions(
+      {
+        ...get().selectionRevisions,
+        [projectId]: (get().selectionRevisions[projectId] ?? 0) + 1,
+      },
+      entries,
+    );
+    set({ entries, selectionRevisions });
     persistEntries(entries, get().runtimeScope);
   },
 }));

--- a/desktop/src/renderer/src/stores/project-workspaces.ts
+++ b/desktop/src/renderer/src/stores/project-workspaces.ts
@@ -121,7 +121,8 @@ async function performWorkspaceLoad(
 ): Promise<void> {
   const runtimeGeneration = captureRuntimeGeneration();
   const generation = nextGeneration(projectId);
-  const selectionAtLoadStart = useProjectView.getState().entries[projectId]?.selectedThreadId;
+  const viewEntryAtLoadStart = useProjectView.getState().entries[projectId];
+  const selectionAtLoadStart = viewEntryAtLoadStart?.selectedThreadId;
   useProjectWorkspaces.setState((state) => ({
     entries: {
       ...state.entries,
@@ -146,9 +147,11 @@ async function performWorkspaceLoad(
     // Reconcile the persisted chat selection against the fresh projection.
     const projectView = useProjectView.getState();
     const currentSelection = projectView.selectedThreadFor(projectId);
-    const selectedNewChatDuringLoad = selectionAtLoadStart !== undefined
-      && selectionAtLoadStart !== null
-      && currentSelection === null;
+    const selectedNewChatDuringLoad = currentSelection === null
+      && (
+        (selectionAtLoadStart !== undefined && selectionAtLoadStart !== null)
+        || (viewEntryAtLoadStart === undefined && projectView.entries[projectId] !== undefined)
+      );
     if ((options.preserveEmptySelection || selectedNewChatDuringLoad) && currentSelection === null) {
       return;
     }

--- a/desktop/src/renderer/src/stores/project-workspaces.ts
+++ b/desktop/src/renderer/src/stores/project-workspaces.ts
@@ -121,8 +121,7 @@ async function performWorkspaceLoad(
 ): Promise<void> {
   const runtimeGeneration = captureRuntimeGeneration();
   const generation = nextGeneration(projectId);
-  const viewEntryAtLoadStart = useProjectView.getState().entries[projectId];
-  const selectionAtLoadStart = viewEntryAtLoadStart?.selectedThreadId;
+  const selectionRevisionAtLoadStart = useProjectView.getState().selectionRevisionFor(projectId);
   useProjectWorkspaces.setState((state) => ({
     entries: {
       ...state.entries,
@@ -148,10 +147,7 @@ async function performWorkspaceLoad(
     const projectView = useProjectView.getState();
     const currentSelection = projectView.selectedThreadFor(projectId);
     const selectedNewChatDuringLoad = currentSelection === null
-      && (
-        (selectionAtLoadStart !== undefined && selectionAtLoadStart !== null)
-        || (viewEntryAtLoadStart === undefined && projectView.entries[projectId] !== undefined)
-      );
+      && projectView.selectionRevisionFor(projectId) !== selectionRevisionAtLoadStart;
     if ((options.preserveEmptySelection || selectedNewChatDuringLoad) && currentSelection === null) {
       return;
     }

--- a/desktop/src/renderer/src/stores/project-workspaces.ts
+++ b/desktop/src/renderer/src/stores/project-workspaces.ts
@@ -121,6 +121,7 @@ async function performWorkspaceLoad(
 ): Promise<void> {
   const runtimeGeneration = captureRuntimeGeneration();
   const generation = nextGeneration(projectId);
+  const selectionAtLoadStart = useProjectView.getState().entries[projectId]?.selectedThreadId;
   useProjectWorkspaces.setState((state) => ({
     entries: {
       ...state.entries,
@@ -145,7 +146,12 @@ async function performWorkspaceLoad(
     // Reconcile the persisted chat selection against the fresh projection.
     const projectView = useProjectView.getState();
     const currentSelection = projectView.selectedThreadFor(projectId);
-    if (options.preserveEmptySelection && currentSelection === null) return;
+    const selectedNewChatDuringLoad = selectionAtLoadStart !== undefined
+      && selectionAtLoadStart !== null
+      && currentSelection === null;
+    if ((options.preserveEmptySelection || selectedNewChatDuringLoad) && currentSelection === null) {
+      return;
+    }
     const selected = reconcileProjectChatSelection(
       workspace,
       currentSelection,

--- a/desktop/src/renderer/src/stores/project-workspaces.ts
+++ b/desktop/src/renderer/src/stores/project-workspaces.ts
@@ -26,6 +26,10 @@ export interface ProjectWorkspaceEntry {
 
 export const MAX_PROJECT_WORKSPACE_ENTRIES = 12;
 
+export interface ProjectWorkspaceRefreshOptions {
+  preserveEmptySelection?: boolean;
+}
+
 interface ProjectWorkspacesState {
   entries: Record<string, ProjectWorkspaceEntry>;
   // Identity this cache belongs to. Project ids are board slugs, so two
@@ -35,7 +39,7 @@ interface ProjectWorkspacesState {
   runtimeScope: string | null;
   ensureRuntimeScope: (scope: string) => void;
   ensure: (projectId: string) => Promise<void>;
-  refresh: (projectId: string) => Promise<void>;
+  refresh: (projectId: string, options?: ProjectWorkspaceRefreshOptions) => Promise<void>;
   resolveNewChatTarget: (
     projectId: string,
     taskId?: string,
@@ -111,7 +115,10 @@ function isStaleLoad(projectId: string, runtimeGeneration: number, generation: n
   return !isCurrentRuntimeGeneration(runtimeGeneration) || loadGenerations[projectId] !== generation;
 }
 
-async function performWorkspaceLoad(projectId: string): Promise<void> {
+async function performWorkspaceLoad(
+  projectId: string,
+  options: ProjectWorkspaceRefreshOptions = {},
+): Promise<void> {
   const runtimeGeneration = captureRuntimeGeneration();
   const generation = nextGeneration(projectId);
   useProjectWorkspaces.setState((state) => ({
@@ -137,12 +144,14 @@ async function performWorkspaceLoad(projectId: string): Promise<void> {
     }));
     // Reconcile the persisted chat selection against the fresh projection.
     const projectView = useProjectView.getState();
+    const currentSelection = projectView.selectedThreadFor(projectId);
+    if (options.preserveEmptySelection && currentSelection === null) return;
     const selected = reconcileProjectChatSelection(
       workspace,
-      projectView.selectedThreadFor(projectId),
+      currentSelection,
       summaryThreadIdsFor(projectId),
     );
-    if (selected !== projectView.selectedThreadFor(projectId)) {
+    if (selected !== currentSelection) {
       projectView.setSelectedThread(projectId, selected);
     }
   } catch (error: unknown) {
@@ -168,8 +177,11 @@ async function performWorkspaceLoad(projectId: string): Promise<void> {
   }
 }
 
-function loadWorkspace(projectId: string): Promise<void> {
-  const pending = performWorkspaceLoad(projectId).finally(() => {
+function loadWorkspace(
+  projectId: string,
+  options?: ProjectWorkspaceRefreshOptions,
+): Promise<void> {
+  const pending = performWorkspaceLoad(projectId, options).finally(() => {
     if (activeLoadPromises[projectId] === pending) {
       delete activeLoadPromises[projectId];
     }
@@ -207,8 +219,8 @@ export const useProjectWorkspaces = create<ProjectWorkspacesState>()((set, get) 
     }
   },
 
-  refresh: async (projectId) => {
-    await loadWorkspace(projectId);
+  refresh: async (projectId, options) => {
+    await loadWorkspace(projectId, options);
   },
 
   resolveNewChatTarget: async (projectId, taskId) => {

--- a/docs/dev/coding-agent-shells.md
+++ b/docs/dev/coding-agent-shells.md
@@ -118,6 +118,8 @@ Pi (`@earendil-works/pi-coding-agent`) is an executable direct-spawn adapter, no
 
 Claude and Codex workspace adapters expose only fixed server-owned foreground setup actions. Every setup action defaults `MATRIX_NODE_PREFIX` to the canonical `/opt/matrix/runtime/node` prefix and prepends `$MATRIX_NODE_PREFIX/bin` to `PATH` before invoking a provider command. Install actions run the existing npm package install in a visible terminal, connect actions launch the provider's interactive local login flow, and both leave an interactive shell open afterward. Commands are bounded by `SafeSetupActionSchema`; clients must not render command text, persist it, or accept client-supplied replacements.
 
+Desktop project-chat composers derive readiness only from the validated runtime summary. A send is allowed only when the selected new-chat provider, or the existing thread's stored provider, is explicitly `available`, `installed`, and `authenticated`. Missing, setup-required, auth-required, expired, installing, unsupported, unknown, and summary-check failure states all fail closed. The blocked composer remains editable and keeps its draft, but button and keyboard submission must not invoke a thread mutation. Recovery renders the server-owned safe setup action in a foreground terminal, or a summary refresh when no setup action is appropriate; the shell must re-read readiness before sending and must not infer success from a terminal opening.
+
 When adding a provider:
 
 1. Add a provider summary state through the provider registry.
@@ -379,30 +381,36 @@ launch tokens, or customer identifiers.
 4. If a provider requires setup, use the foreground setup action. Confirm it
    opens a canonical terminal session and does not expose setup commands,
    credentials, or provider raw errors in renderer state or screenshots.
-5. Open an existing thread, or create a disposable test thread only when a
-   provider is ready. Confirm the detail snapshot loads, event grouping is
-   bounded, stream updates do not duplicate replayed events, and unresolved
-   approval/input controls stay idempotent while a request is in flight.
-6. Use a bound terminal action from Agents or thread detail. Confirm it opens
+5. Before provider recovery, confirm both a new-chat draft and a stored-thread
+   follow-up remain editable, keep their text, show a visible recovery notice,
+   and invoke no create/turn mutation from either the Send button or Enter.
+   Complete the real provider setup, refresh readiness, and confirm the same
+   drafts remain present until explicitly sent.
+6. Open an existing thread, or create a disposable test thread only when a
+   provider is ready. Confirm one new chat and one follow-up each produce an
+   accepted gateway turn, the detail snapshot loads, event grouping is bounded,
+   stream updates do not duplicate replayed events, and unresolved approval/input
+   controls stay idempotent while a request is in flight.
+7. Use a bound terminal action from Agents or thread detail. Confirm it opens
    the existing Terminal tab/model for the canonical Matrix terminal session;
    detaching or leaving the tab must not terminate the underlying process.
-7. Open review, file, and preview surfaces. Confirm review/file content loads
+8. Open review, file, and preview surfaces. Confirm review/file content loads
    through trusted IPC, file edits remain transient until saved through the
    gateway, large/partial data shows recoverable UI, HTTPS previews open through
    safe desktop open paths, and failures remain generic.
-8. Trigger or simulate a coding-agent attention notification with a bounded
+9. Trigger or simulate a coding-agent attention notification with a bounded
    thread reference. Confirm clicking the native notification focuses the
    Agents workspace and visibly selects the matching thread. Confirm the badge
    count reflects bounded gateway-owned attention state and uses overflow
    behavior when the list is truncated.
-9. Put the runtime in an unavailable or offline state, or switch away from it,
+10. Put the runtime in an unavailable or offline state, or switch away from it,
    then return. Confirm stale thread, terminal, review, and preview references
    are dropped or shown as recoverable, and the UI rehydrates from the gateway
    instead of trusting local renderer state.
-10. Recheck Terminal Shells, Apps, Settings, Chat, hosted shell embeds, updater
+11. Recheck Terminal Shells, Apps, Settings, Chat, hosted shell embeds, updater
     entry points, deep links, native menus, shortcuts, and window restore after
     the Agents pass.
-11. Record branch, commit, desktop app build type, selected validation commands,
+12. Record branch, commit, desktop app build type, selected validation commands,
     pass/fail notes, and any deferred manual step with the automated or manual
     coverage that still applies.
 

--- a/packages/gateway/src/coding-agents/provider-registry.ts
+++ b/packages/gateway/src/coding-agents/provider-registry.ts
@@ -89,34 +89,18 @@ function kindForAgent(agent: AgentId): AgentProviderSummary["kind"] {
 }
 
 function summaryFromCredential(credential: AgentCredentialSummary): AgentProviderSummary {
-  const isAvailable = credential.status === "available";
-  const isMissing = credential.status === "missing";
-  const isExpired = credential.status === "expired" || credential.status === "revoked";
-  const failed = credential.status === "failed";
-  return AgentProviderSummarySchema.parse({
+  return AgentProviderSummarySchema.parse(applyCredentialState({
     id: credential.agent,
     displayName: displayNameForAgent(credential.agent),
     kind: kindForAgent(credential.agent),
     availability: "unavailable",
-    installStatus: isAvailable || isExpired
-      ? "installed"
-      : isMissing
-        ? "missing"
-        : failed
-          ? "failed"
-          : "unknown",
-    authStatus: isAvailable
-      ? "authenticated"
-      : isExpired
-        ? "expired"
-        : isMissing
-          ? "missing"
-          : "unknown",
+    installStatus: "unknown",
+    authStatus: "unknown",
     supportedModes: ["default", "review"],
     defaultMode: "default",
     setupActions: [],
     lastCheckedAt: credential.verifiedAt ?? undefined,
-  });
+  }, credential));
 }
 
 async function callWithTimeout<T>(
@@ -134,40 +118,61 @@ async function callWithTimeout<T>(
   });
 }
 
-function applyCredentialState(
+export function applyCredentialState(
   summary: AgentProviderSummary,
   credential: AgentCredentialSummary | undefined,
 ): AgentProviderSummary {
-  if (!credential || credential.status === "not_applicable") return summary;
-  if (credential.status === "missing") {
-    return {
-      ...summary,
-      availability: "setup_required",
-      installStatus: "missing",
-      authStatus: "missing",
-    };
+  if (!credential) return summary;
+  switch (credential.status) {
+    case "available":
+      return {
+        ...summary,
+        installStatus: "installed",
+        authStatus: "authenticated",
+      };
+    case "missing":
+      return {
+        ...summary,
+        availability: "setup_required",
+        installStatus: "missing",
+        authStatus: "missing",
+      };
+    case "auth_required":
+      return {
+        ...summary,
+        availability: "auth_required",
+        installStatus: "installed",
+        authStatus: "missing",
+      };
+    case "expired":
+    case "revoked":
+      return {
+        ...summary,
+        availability: "auth_required",
+        installStatus: "installed",
+        authStatus: "expired",
+      };
+    case "failed":
+    case "version_unsupported":
+      return {
+        ...summary,
+        availability: "unavailable",
+        installStatus: "failed",
+        authStatus: "unknown",
+      };
+    case "check_failed":
+    case "not_applicable":
+      return {
+        ...summary,
+        availability: "unavailable",
+        installStatus: "unknown",
+        authStatus: "unknown",
+      };
+    default: {
+      const unhandledStatus: never = credential.status;
+      return unhandledStatus;
+    }
   }
-  if (credential.status === "expired" || credential.status === "revoked") {
-    return {
-      ...summary,
-      availability: "auth_required",
-      installStatus: "installed",
-      authStatus: "expired",
-    };
-  }
-  if (credential.status === "failed") {
-    return {
-      ...summary,
-      availability: "unavailable",
-      installStatus: "failed",
-      authStatus: "unknown",
-    };
-  }
-  return {
-    ...summary,
-    installStatus: "installed",
-    authStatus: "authenticated",
-  };
 }
 
 function shouldCheckHealth(summary: AgentProviderSummary): boolean {

--- a/packages/gateway/src/coding-agents/runtime-summary.ts
+++ b/packages/gateway/src/coding-agents/runtime-summary.ts
@@ -18,7 +18,10 @@ import type {
 } from "../onboarding/activation-contracts.js";
 import type { AgentCredentialStatusService } from "../onboarding/agent-credential-status.js";
 import { logCodingAgentWarning } from "./diagnostics.js";
-import type { CodingAgentProviderRegistry } from "./provider-registry.js";
+import {
+  applyCredentialState,
+  type CodingAgentProviderRegistry,
+} from "./provider-registry.js";
 
 const TERMINAL_SUMMARY_LIMIT = 20;
 const PREVIEW_SUMMARY_LIMIT = 50;
@@ -166,31 +169,18 @@ function capability(input: {
 }
 
 function statusToProviderSummary(agent: AgentCredentialSummary): AgentProviderSummary {
-  const isAvailable = agent.status === "available";
-  const isMissing = agent.status === "missing";
-  const isExpired = agent.status === "expired" || agent.status === "revoked";
-  const failed = agent.status === "failed";
-
-  return {
+  return applyCredentialState({
     id: agent.agent,
     displayName: displayNameForAgent(agent.agent),
     kind: kindForAgent(agent.agent),
-    availability: isAvailable
-      ? "available"
-      : isExpired
-        ? "auth_required"
-        : isMissing
-          ? "setup_required"
-          : failed
-            ? "unavailable"
-            : "unknown",
-    installStatus: isAvailable || isExpired ? "installed" : isMissing ? "missing" : failed ? "failed" : "unknown",
-    authStatus: isAvailable ? "authenticated" : isExpired ? "expired" : isMissing ? "missing" : "unknown",
+    availability: "available",
+    installStatus: "unknown",
+    authStatus: "unknown",
     supportedModes: ["default", "review"],
     defaultMode: "default",
     setupActions: [],
     lastCheckedAt: agent.verifiedAt ?? undefined,
-  };
+  }, agent);
 }
 
 function displayNameForAgent(agent: AgentId): string {

--- a/packages/gateway/src/coding-agents/workspace-provider.ts
+++ b/packages/gateway/src/coding-agents/workspace-provider.ts
@@ -28,7 +28,7 @@ const SETUP_AGENTS: Record<SetupAgent, { installPackage: string; connectCommand:
   },
   codex: {
     installPackage: CODEX_VERIFIED_NPM_PACKAGE,
-    connectCommand: "codex login",
+    connectCommand: "codex login --device-auth",
   },
 };
 

--- a/specs/105-coding-agent-shells/current-state.md
+++ b/specs/105-coding-agent-shells/current-state.md
@@ -1,7 +1,7 @@
 # Current State: Coding Agent Shells
 
 **Branch stack**: implementation checkpoint merged to `main` through PR #869 (`056b3da668ed6d1753712120316d2d5accfafdcf`)
-**Updated**: 2026-07-13
+**Updated**: 2026-08-21
 **Scope**: Inventory for the coding-agent desktop/mobile shell work. This file records the current Matrix-native route, contract, client, and regression-test state so later slices keep gateway/runtime as source of truth and keep desktop/mobile as thin shells.
 
 For the evidence-based checkpoint audit, see [completion-audit.md](./completion-audit.md).
@@ -18,7 +18,7 @@ The landed checkpoint is not the confirmed final information architecture. Curre
 - The current desktop `AgentWorkspace` is a sectioned dashboard. It does not provide the required persistent project/task/thread navigator or a segmented Conversation/Kanban mode over one selected project.
 - Mobile now adds gateway-validated project/task/thread routes, multi-thread Conversation groups, and a capability-gated Kanban projection with phone/tablet layouts. SDK 57 device and cross-shell evidence remain outstanding.
 - Mobile now has a Cloud-authenticated computer chooser backed by a bounded platform projection. It can reconnect the same signed-in shell to main or preview `/vm/:handle` routes while persisting only the selected gateway reference; remote preview device evidence remains outstanding.
-- Desktop follow-up controls still seed a new thread with a structured reference. Mobile now uses the gateway same-thread turn route with transient drafts and exact retry idempotency; desktop and cross-shell confirmation remain outstanding. Delivering input to a running workspace session settles that turn without marking the thread complete; canonical session-stop reconciliation owns terminal thread status.
+- Desktop project chats now use the gateway same-thread turn route. New-chat and follow-up composers fail closed unless the selected or stored provider is explicitly available, installed, and authenticated; blocked drafts stay local, editable, and isolated per thread while a safe foreground setup or refresh action remains visible. Real authenticated VPS/Desktop recovery and accepted-turn evidence remains outstanding. Mobile uses the same gateway same-thread turn route with transient drafts and exact retry idempotency; cross-shell confirmation remains outstanding. Delivering input to a running workspace session settles that turn without marking the thread complete; canonical session-stop reconciliation owns terminal thread status.
 - Existing desktop Kanban task routes/statuses are canonical and reusable, but coding-thread aggregates and multi-thread task navigation are not integrated into that board.
 
 The clarified target and required evidence are defined in `SPEC.md`, `ARCHITECTURE.md`, `plan.md`, `tasks.md`, and `acceptance-tests.md`. No implementation completion claim should treat the existing dashboard/create path as proof of those requirements.

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeSummary } from "@matrix-os/contracts";
 import ProjectChatsView, {
   clearComposerLaunchContext,
   mergeComposerSeed,
@@ -37,7 +38,16 @@ function summaryFixture({
   sourceControl = false,
   threadTerminalSessionId,
   terminalSessionName = "matrix-abc1234",
-}: { threadCreate?: boolean; sameThreadTurns?: boolean; files?: boolean; sourceControl?: boolean; threadTerminalSessionId?: string; terminalSessionName?: string } = {}) {
+  providers,
+}: {
+  threadCreate?: boolean;
+  sameThreadTurns?: boolean;
+  files?: boolean;
+  sourceControl?: boolean;
+  threadTerminalSessionId?: string;
+  terminalSessionName?: string;
+  providers?: RuntimeSummary["providers"];
+} = {}) {
   return {
     runtime: {
       id: "rt_primary",
@@ -76,7 +86,7 @@ function summaryFixture({
           }]
         : []),
     ],
-    providers: [
+    providers: providers ?? [
       {
         id: "codex",
         kind: "codex",
@@ -1291,6 +1301,155 @@ describe("ProjectChatsView", () => {
       });
     });
     await waitFor(() => expect((composer as HTMLTextAreaElement).value).toBe(""));
+  });
+
+  it.each([
+    {
+      name: "missing",
+      provider: {
+        ...summaryFixture().providers[0],
+        availability: "setup_required" as const,
+        installStatus: "missing" as const,
+        authStatus: "missing" as const,
+        setupActions: [{
+          id: "codex_install",
+          kind: "foreground_terminal" as const,
+          label: "Install Codex",
+          command: "npm install -g @openai/codex",
+        }],
+      },
+      notice: "Codex is not installed",
+      action: "Install Codex",
+    },
+    {
+      name: "auth-required",
+      provider: {
+        ...summaryFixture().providers[0],
+        availability: "auth_required" as const,
+        authStatus: "missing" as const,
+        setupActions: [{
+          id: "codex_connect",
+          kind: "foreground_terminal" as const,
+          label: "Connect Codex",
+          command: "codex login",
+        }],
+      },
+      notice: "Connect Codex to continue",
+      action: "Connect Codex",
+    },
+  ])("preserves the stored-provider follow-up while $name, then sends after refresh", async ({
+    provider,
+    notice,
+    action,
+  }) => {
+    const settledSnapshot = {
+      ...threadSnapshotFixture(),
+      thread: {
+        ...threadSnapshotFixture().thread,
+        status: "completed" as const,
+        attention: "none" as const,
+      },
+    };
+    const blockedSummary = summaryFixture({ providers: [provider] });
+    useProjectView.getState().setSelectedThread("matrix-os", "thread_alpha");
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "runtime:get-summary") return Promise.resolve(blockedSummary);
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-notification-preferences") {
+        return Promise.resolve({ attentionPush: { approval: true, input: true, failed: true, completed: true } });
+      }
+      if (channel === "runtime:get-thread-snapshot") return Promise.resolve(settledSnapshot);
+      if (channel === "runtime:create-turn") {
+        return Promise.resolve({
+          ok: true,
+          response: {
+            threadId: "thread_alpha",
+            turnId: "turn_provider_recovered",
+            status: "accepted",
+            acceptedAt: "2026-07-06T00:06:00.000Z",
+          },
+        });
+      }
+      return Promise.reject(new Error(`unexpected channel ${channel}`));
+    });
+
+    render(<ProjectChatsView projectId="matrix-os" active />);
+    const composer = await screen.findByLabelText("Message conversation") as HTMLTextAreaElement;
+    const draft = `Keep this ${provider.availability} follow-up`;
+    fireEvent.change(composer, { target: { value: draft } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    fireEvent.keyDown(composer, { key: "Enter" });
+
+    expect(screen.getByText(notice)).toBeTruthy();
+    expect(screen.getByRole("button", { name: action })).toBeTruthy();
+    expect(composer.disabled).toBe(false);
+    expect(composer.value).toBe(draft);
+    expect(vi.mocked(window.operator.invoke).mock.calls.filter(([channel]) => channel === "runtime:create-turn")).toHaveLength(0);
+
+    act(() => {
+      useCodingAgentWorkspace.setState({
+        status: "ready",
+        summary: summaryFixture(),
+        summaryRevision: useCodingAgentWorkspace.getState().summaryRevision + 1,
+      });
+    });
+
+    await waitFor(() => expect(screen.queryByText(notice)).toBeNull());
+    expect(composer.value).toBe(draft);
+    fireEvent.keyDown(composer, { key: "Enter" });
+
+    await waitFor(() => expect(window.operator.invoke).toHaveBeenCalledWith(
+      "runtime:create-turn",
+      expect.objectContaining({ threadId: "thread_alpha", message: draft }),
+    ));
+    await waitFor(() => expect(composer.value).toBe(""));
+  });
+
+  it("keeps a blocked follow-up draft isolated when switching threads", async () => {
+    const blockedProvider = {
+      ...summaryFixture().providers[0],
+      availability: "auth_required" as const,
+      authStatus: "missing" as const,
+      setupActions: [],
+    };
+    const settledAlpha = {
+      ...threadSnapshotFixture(),
+      thread: {
+        ...threadSnapshotFixture().thread,
+        status: "completed" as const,
+        attention: "none" as const,
+      },
+    };
+    const settledBeta = {
+      ...betaThreadSnapshotFixture(),
+      thread: { ...betaThreadSnapshotFixture().thread, status: "completed" as const },
+    };
+    useProjectView.getState().setSelectedThread("matrix-os", "thread_alpha");
+    window.operator.invoke = vi.fn((channel: string, payload?: unknown) => {
+      if (channel === "runtime:get-summary") {
+        return Promise.resolve(summaryFixture({ providers: [blockedProvider] }));
+      }
+      if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
+      if (channel === "runtime:get-notification-preferences") {
+        return Promise.resolve({ attentionPush: { approval: true, input: true, failed: true, completed: true } });
+      }
+      if (channel === "runtime:get-thread-snapshot") {
+        return Promise.resolve((payload as { threadId?: string })?.threadId === "thread_beta" ? settledBeta : settledAlpha);
+      }
+      return Promise.reject(new Error(`unexpected channel ${channel}`));
+    });
+
+    render(<ProjectChatsView projectId="matrix-os" active />);
+    const alphaComposer = await screen.findByLabelText("Message conversation") as HTMLTextAreaElement;
+    fireEvent.change(alphaComposer, { target: { value: "Alpha-only blocked draft" } });
+    expect(screen.getByText("Connect Codex to continue")).toBeTruthy();
+
+    act(() => useProjectView.getState().setSelectedThread("matrix-os", "thread_beta"));
+
+    expect(await screen.findByRole("region", { name: "Conversation Fix billing route" })).toBeTruthy();
+    const betaComposer = screen.getByLabelText("Message conversation") as HTMLTextAreaElement;
+    expect(betaComposer.value).toBe("");
+    expect(vi.mocked(window.operator.invoke).mock.calls.filter(([channel]) => channel === "runtime:create-turn")).toHaveLength(0);
   });
 
   it("withholds the same-thread composer when the runtime does not support turns", async () => {

--- a/tests/desktop/draft-chat-send.test.tsx
+++ b/tests/desktop/draft-chat-send.test.tsx
@@ -18,7 +18,17 @@ import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 const NOW = "2026-07-12T12:00:00.000Z";
 const defaultResolveNewChatTarget = useProjectWorkspaces.getState().resolveNewChatTarget;
 
-function summaryFixture(): RuntimeSummary {
+function summaryFixture(providers: RuntimeSummary["providers"] = [{
+  id: "codex",
+  kind: "codex",
+  displayName: "Codex",
+  availability: "available",
+  installStatus: "installed",
+  authStatus: "authenticated",
+  supportedModes: ["default", "plan"],
+  defaultMode: "default",
+  setupActions: [],
+}]): RuntimeSummary {
   return {
     runtime: { id: "rt_primary", label: "Primary", status: "available" },
     capabilities: [
@@ -28,17 +38,7 @@ function summaryFixture(): RuntimeSummary {
       { id: "codingAgentsReview", enabled: true },
       { id: "codingAgentsProjectWorkspace", enabled: true },
     ],
-    providers: [{
-      id: "codex",
-      kind: "codex",
-      displayName: "Codex",
-      availability: "available",
-      installStatus: "installed",
-      authStatus: "authenticated",
-      supportedModes: ["default", "plan"],
-      defaultMode: "default",
-      setupActions: [],
-    }],
+    providers,
     projects: {
       items: [{ id: "matrix-os", label: "Matrix OS", status: "available", taskCount: 1, threadCount: 2, attentionCount: 0 }],
       hasMore: false,
@@ -93,11 +93,12 @@ function createdThreadSnapshot(prompt: string) {
   };
 }
 
-function mockOperator({ createImpl }: {
+function mockOperator({ createImpl, summary = summaryFixture() }: {
   createImpl?: (payload: unknown) => Promise<unknown>;
+  summary?: RuntimeSummary;
 } = {}) {
   const invoke = vi.fn(async (channel: string, payload: unknown) => {
-    if (channel === "runtime:get-summary") return summaryFixture();
+    if (channel === "runtime:get-summary") return summary;
     if (channel === "runtime:get-reviews") return { items: [], hasMore: false, limit: 50 };
     if (channel === "runtime:get-notification-preferences") {
       return { attentionPush: { approval: true, input: true, failed: true, completed: true } };
@@ -250,6 +251,101 @@ describe("draft chat implicit thread creation", () => {
     await waitFor(() => {
       expect(useProjectView.getState().selectedThreadFor("matrix-os")).toBe("thread_new_draft");
     });
+  });
+
+  it.each([
+    {
+      name: "no provider",
+      providers: [],
+      notice: "No coding agent provider is configured",
+      action: "Open provider settings",
+    },
+    {
+      name: "missing provider install",
+      providers: [{
+        ...summaryFixture().providers[0]!,
+        availability: "setup_required" as const,
+        installStatus: "missing" as const,
+        authStatus: "missing" as const,
+        setupActions: [{
+          id: "codex_install",
+          kind: "foreground_terminal" as const,
+          label: "Install Codex",
+          command: "npm install -g @openai/codex",
+        }],
+      }],
+      notice: "Codex is not installed",
+      action: "Install Codex",
+    },
+    {
+      name: "provider authentication required",
+      providers: [{
+        ...summaryFixture().providers[0]!,
+        availability: "auth_required" as const,
+        authStatus: "missing" as const,
+        setupActions: [{
+          id: "codex_connect",
+          kind: "foreground_terminal" as const,
+          label: "Connect Codex",
+          command: "codex login",
+        }],
+      }],
+      notice: "Connect Codex to continue",
+      action: "Connect Codex",
+    },
+    {
+      name: "expired provider authentication",
+      providers: [{
+        ...summaryFixture().providers[0]!,
+        availability: "auth_required" as const,
+        authStatus: "expired" as const,
+        setupActions: [{
+          id: "codex_reconnect",
+          kind: "foreground_terminal" as const,
+          label: "Reconnect Codex",
+          command: "codex login",
+        }],
+      }],
+      notice: "Codex needs to be reconnected",
+      action: "Reconnect Codex",
+    },
+    {
+      name: "provider install in progress",
+      providers: [{
+        ...summaryFixture().providers[0]!,
+        availability: "installing" as const,
+        installStatus: "installing" as const,
+        authStatus: "unknown" as const,
+      }],
+      notice: "Installing Codex",
+      action: "Refresh provider status",
+    },
+    {
+      name: "unverified provider",
+      providers: [{
+        ...summaryFixture().providers[0]!,
+        availability: "unknown" as const,
+        installStatus: "unknown" as const,
+        authStatus: "unknown" as const,
+      }],
+      notice: "Matrix could not verify Codex",
+      action: "Refresh provider status",
+    },
+  ])("blocks $name without losing the editable draft", async ({ providers, notice, action }) => {
+    const { invoke } = mockOperator({ summary: summaryFixture(providers) });
+    const composer = await openDraft();
+    const prompt = `Preserve this ${notice}`;
+
+    fireEvent.change(composer, { target: { value: prompt } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    fireEvent.keyDown(composer, { key: "Enter" });
+
+    expect(screen.getByText(notice)).toBeTruthy();
+    expect(screen.getByRole("button", { name: action })).toBeTruthy();
+    expect(composer.disabled).toBe(false);
+    expect(composer.value).toBe(prompt);
+    expect(useDraftChat.getState().draftFor("matrix-os")?.prompt).toBe(prompt);
+    expect(vi.mocked(invoke).mock.calls.filter(([channel]) => channel === "runtime:create-thread")).toHaveLength(0);
   });
 
   it("resolves the project relation lazily when the draft was typed without a seed", async () => {

--- a/tests/desktop/project-tab.test.tsx
+++ b/tests/desktop/project-tab.test.tsx
@@ -371,6 +371,93 @@ describe("ProjectTab", () => {
     expect(screen.getByLabelText("Message new chat")).toBeTruthy();
   });
 
+  it("keeps a new chat selected while the provider refresh is pending", async () => {
+    const invoke = window.operator.invoke as ReturnType<typeof vi.fn>;
+    const originalImplementation = invoke.getMockImplementation()!;
+    let resolveProviderRefresh!: (summary: RuntimeSummary) => void;
+    let deferNextSummary = true;
+    invoke.mockImplementation((channel: string, payload: unknown) => {
+      if (channel === "runtime:get-summary" && deferNextSummary) {
+        deferNextSummary = false;
+        return new Promise<RuntimeSummary>((resolve) => {
+          resolveProviderRefresh = resolve;
+        });
+      }
+      return originalImplementation(channel, payload);
+    });
+    useCodingAgentWorkspace.setState({ status: "ready", summary: summaryFixture() });
+
+    try {
+      render(<ProjectTab projectSlug="matrix-os" active />);
+      fireEvent.click(screen.getByRole("button", { name: "Refresh agent workspace" }));
+      await waitFor(() => expect(deferNextSummary).toBe(false));
+
+      fireEvent.click(screen.getByRole("button", { name: "Chats" }));
+      await screen.findByRole("button", { name: "Chat Plan the auth work" });
+      fireEvent.click(screen.getByRole("button", { name: "New chat in Matrix OS" }));
+      expect(await screen.findByLabelText("Message new chat")).toBeTruthy();
+
+      const workspaceCallsBeforeProviderSettles = invoke.mock.calls.filter(
+        ([channel]) => channel === "runtime:get-project-workspace",
+      ).length;
+      await act(async () => {
+        resolveProviderRefresh(summaryFixture());
+        await Promise.resolve();
+      });
+      await waitFor(() => {
+        expect(invoke.mock.calls.filter(([channel]) => channel === "runtime:get-project-workspace").length)
+          .toBe(workspaceCallsBeforeProviderSettles + 1);
+      });
+
+      expect(useProjectView.getState().selectedThreadFor("matrix-os")).toBeNull();
+      expect(screen.getByLabelText("Message new chat")).toBeTruthy();
+    } finally {
+      invoke.mockImplementation(originalImplementation);
+    }
+  });
+
+  it("keeps a new chat selected while the project workspace refresh is pending", async () => {
+    const invoke = window.operator.invoke as ReturnType<typeof vi.fn>;
+    const originalImplementation = invoke.getMockImplementation()!;
+    useCodingAgentWorkspace.setState({ status: "ready", summary: summaryFixture() });
+
+    render(<ProjectTab projectSlug="matrix-os" active />);
+    fireEvent.click(screen.getByRole("button", { name: "Chats" }));
+    await screen.findByRole("button", { name: "Chat Plan the auth work" });
+
+    let resolveWorkspaceRefresh!: (workspace: ProjectAgentWorkspace) => void;
+    let deferNextWorkspace = true;
+    invoke.mockImplementation((channel: string, payload: unknown) => {
+      if (channel === "runtime:get-project-workspace" && deferNextWorkspace) {
+        deferNextWorkspace = false;
+        return new Promise<ProjectAgentWorkspace>((resolve) => {
+          resolveWorkspaceRefresh = resolve;
+        });
+      }
+      return originalImplementation(channel, payload);
+    });
+
+    try {
+      fireEvent.click(screen.getByRole("button", { name: "Refresh agent workspace" }));
+      await waitFor(() => expect(deferNextWorkspace).toBe(false));
+
+      fireEvent.click(screen.getByRole("button", { name: "New chat in Matrix OS" }));
+      expect(await screen.findByLabelText("Message new chat")).toBeTruthy();
+      await act(async () => {
+        resolveWorkspaceRefresh(workspaceFixture());
+        await Promise.resolve();
+      });
+      await waitFor(() => {
+        expect(useProjectWorkspaces.getState().entries["matrix-os"]?.status).toBe("ready");
+      });
+
+      expect(useProjectView.getState().selectedThreadFor("matrix-os")).toBeNull();
+      expect(screen.getByLabelText("Message new chat")).toBeTruthy();
+    } finally {
+      invoke.mockImplementation(originalImplementation);
+    }
+  });
+
   it("reconciles the first chat when Board refreshes without an established project selection", async () => {
     render(<ProjectTab projectSlug="matrix-os" active />);
     await screen.findByText("Primary");

--- a/tests/desktop/project-tab.test.tsx
+++ b/tests/desktop/project-tab.test.tsx
@@ -157,6 +157,7 @@ function resetStores() {
   useProjectView.setState({ entries: {}, runtimeScope: null });
   useProjectWorkspaces.setState({ entries: {} });
   useProjectChatLauncher.setState({ composerRequest: null });
+  useUi.setState({ createTaskOpen: false });
   useCodingAgentWorkspace.setState({
     status: "idle",
     summary: null,
@@ -329,6 +330,45 @@ describe("ProjectTab", () => {
     await waitFor(() => {
       expect(useProjectView.getState().selectedThreadFor("matrix-os")).toBeNull();
     });
+  });
+
+  it("refreshes provider readiness when opening a new chat", async () => {
+    const invoke = window.operator.invoke as ReturnType<typeof vi.fn>;
+    render(<ProjectChatsView projectId="matrix-os" active />);
+    await screen.findByRole("button", { name: "Chat Plan the auth work" });
+    const summaryCallsBeforeNewChat = invoke.mock.calls.filter(
+      ([channel]) => channel === "runtime:get-summary",
+    ).length;
+
+    fireEvent.click(screen.getByRole("button", { name: "New chat in Matrix OS" }));
+
+    expect(await screen.findByLabelText("Message new chat")).toBeTruthy();
+    await waitFor(() => {
+      expect(invoke.mock.calls.filter(([channel]) => channel === "runtime:get-summary").length)
+        .toBe(summaryCallsBeforeNewChat + 1);
+    });
+  });
+
+  it("keeps the new-chat draft selected when the project workspace is refreshed", async () => {
+    const invoke = window.operator.invoke as ReturnType<typeof vi.fn>;
+    render(<ProjectTab projectSlug="matrix-os" active />);
+    fireEvent.click(screen.getByRole("button", { name: "Chats" }));
+    await screen.findByRole("button", { name: "Chat Plan the auth work" });
+    fireEvent.click(screen.getByRole("button", { name: "New chat in Matrix OS" }));
+    expect(await screen.findByLabelText("Message new chat")).toBeTruthy();
+    expect(useProjectView.getState().selectedThreadFor("matrix-os")).toBeNull();
+    const workspaceCallsBeforeRefresh = invoke.mock.calls.filter(
+      ([channel]) => channel === "runtime:get-project-workspace",
+    ).length;
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh agent workspace" }));
+
+    await waitFor(() => {
+      expect(invoke.mock.calls.filter(([channel]) => channel === "runtime:get-project-workspace").length)
+        .toBe(workspaceCallsBeforeRefresh + 1);
+    });
+    expect(useProjectView.getState().selectedThreadFor("matrix-os")).toBeNull();
+    expect(screen.getByLabelText("Message new chat")).toBeTruthy();
   });
 
   it("keeps a compose request pending until runtime capabilities finish loading", async () => {

--- a/tests/desktop/project-tab.test.tsx
+++ b/tests/desktop/project-tab.test.tsx
@@ -371,6 +371,18 @@ describe("ProjectTab", () => {
     expect(screen.getByLabelText("Message new chat")).toBeTruthy();
   });
 
+  it("reconciles the first chat when Board refreshes without an established project selection", async () => {
+    render(<ProjectTab projectSlug="matrix-os" active />);
+    await screen.findByText("Primary");
+    expect(useProjectView.getState().entries["matrix-os"]).toBeUndefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh agent workspace" }));
+
+    await waitFor(() => {
+      expect(useProjectView.getState().selectedThreadFor("matrix-os")).toBe("thread_plan");
+    });
+  });
+
   it("keeps a compose request pending until runtime capabilities finish loading", async () => {
     useCodingAgentWorkspace.setState({ status: "loading", summary: null });
     useProjectChatLauncher.getState().requestComposer("matrix-os");

--- a/tests/desktop/project-tab.test.tsx
+++ b/tests/desktop/project-tab.test.tsx
@@ -336,8 +336,12 @@ describe("ProjectTab", () => {
     const invoke = window.operator.invoke as ReturnType<typeof vi.fn>;
     render(<ProjectChatsView projectId="matrix-os" active />);
     await screen.findByRole("button", { name: "Chat Plan the auth work" });
+    const summaryRevisionBeforeNewChat = useCodingAgentWorkspace.getState().summaryRevision;
     const summaryCallsBeforeNewChat = invoke.mock.calls.filter(
       ([channel]) => channel === "runtime:get-summary",
+    ).length;
+    const workspaceCallsBeforeNewChat = invoke.mock.calls.filter(
+      ([channel]) => channel === "runtime:get-project-workspace",
     ).length;
 
     fireEvent.click(screen.getByRole("button", { name: "New chat in Matrix OS" }));
@@ -347,6 +351,15 @@ describe("ProjectTab", () => {
       expect(invoke.mock.calls.filter(([channel]) => channel === "runtime:get-summary").length)
         .toBe(summaryCallsBeforeNewChat + 1);
     });
+    await waitFor(() => {
+      expect(useCodingAgentWorkspace.getState().summaryRevision)
+        .toBe(summaryRevisionBeforeNewChat + 1);
+    });
+    expect(invoke.mock.calls.filter(
+      ([channel]) => channel === "runtime:get-project-workspace",
+    )).toHaveLength(workspaceCallsBeforeNewChat);
+    expect(useProjectView.getState().selectedThreadFor("matrix-os")).toBeNull();
+    expect(screen.getByLabelText("Message new chat")).toBeTruthy();
   });
 
   it("keeps the new-chat draft selected when the project workspace is refreshed", async () => {

--- a/tests/desktop/project-workspaces-store.test.ts
+++ b/tests/desktop/project-workspaces-store.test.ts
@@ -230,6 +230,32 @@ describe("project workspaces store", () => {
     expect(useProjectView.getState().selectedThreadFor("matrix-os")).toBeNull();
   });
 
+  it("still reconciles the first thread when only the project view changes during loading", async () => {
+    let resolveWorkspace: (value: ProjectAgentWorkspace) => void = () => undefined;
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: {
+        invoke: vi.fn((channel: string) => {
+          if (channel === "runtime:get-project-workspace") {
+            return new Promise<ProjectAgentWorkspace>((resolve) => {
+              resolveWorkspace = resolve;
+            });
+          }
+          if (channel === "state:set") return Promise.resolve({ ok: true });
+          throw new Error(`unexpected channel ${channel}`);
+        }),
+        on: vi.fn(() => () => undefined),
+      },
+    });
+
+    const load = useProjectWorkspaces.getState().ensure("matrix-os");
+    useProjectView.getState().setView("matrix-os", "chats");
+    resolveWorkspace(workspace("matrix-os", "task_auth", "thread_plan"));
+    await load;
+
+    expect(useProjectView.getState().selectedThreadFor("matrix-os")).toBe("thread_plan");
+  });
+
   it("keeps a selection that is only known through the runtime summary lists", async () => {
     mockOperator({ "matrix-os": workspace("matrix-os", "task_auth", "thread_plan") });
     useCodingAgentWorkspace.setState({

--- a/tests/desktop/project-workspaces-store.test.ts
+++ b/tests/desktop/project-workspaces-store.test.ts
@@ -205,6 +205,31 @@ describe("project workspaces store", () => {
     expect(useProjectView.getState().selectedThreadFor("matrix-os")).toBe("thread_plan");
   });
 
+  it("preserves New Chat selected during a first load without a view entry", async () => {
+    let resolveWorkspace: (value: ProjectAgentWorkspace) => void = () => undefined;
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: {
+        invoke: vi.fn((channel: string) => {
+          if (channel !== "runtime:get-project-workspace") return Promise.resolve({ ok: true });
+          return new Promise<ProjectAgentWorkspace>((resolve) => {
+            resolveWorkspace = resolve;
+          });
+        }),
+        on: vi.fn(() => () => undefined),
+      },
+    });
+
+    const pendingLoad = useProjectWorkspaces.getState().refresh("matrix-os");
+    expect(useProjectView.getState().entries["matrix-os"]).toBeUndefined();
+
+    useProjectView.getState().setSelectedThread("matrix-os", null);
+    resolveWorkspace(workspace("matrix-os", "task_auth", "thread_plan"));
+    await pendingLoad;
+
+    expect(useProjectView.getState().selectedThreadFor("matrix-os")).toBeNull();
+  });
+
   it("keeps a selection that is only known through the runtime summary lists", async () => {
     mockOperator({ "matrix-os": workspace("matrix-os", "task_auth", "thread_plan") });
     useCodingAgentWorkspace.setState({

--- a/tests/desktop/provider-readiness-notice.test.tsx
+++ b/tests/desktop/provider-readiness-notice.test.tsx
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentProviderSummary } from "@matrix-os/contracts";
+import { ProviderReadinessNotice } from "../../desktop/src/renderer/src/features/coding-agents/ProviderReadinessNotice";
+import type { ProviderReadinessPresentation } from "../../desktop/src/renderer/src/features/coding-agents/provider-readiness";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
+import { useUi } from "../../desktop/src/renderer/src/stores/ui";
+
+const installAction = {
+  id: "codex_install",
+  kind: "foreground_terminal" as const,
+  label: "Install Codex",
+  command: "npm install -g @openai/codex",
+};
+
+const provider: AgentProviderSummary = {
+  id: "codex",
+  kind: "codex",
+  displayName: "Codex",
+  availability: "setup_required",
+  installStatus: "missing",
+  authStatus: "missing",
+  supportedModes: ["default"],
+  defaultMode: "default",
+  setupActions: [installAction],
+};
+
+function readiness(
+  overrides: Partial<ProviderReadinessPresentation> = {},
+): ProviderReadinessPresentation {
+  return {
+    state: "missing",
+    blocked: true,
+    title: "Codex is not installed",
+    description: "Install Codex before sending a message.",
+    action: { kind: "setup", action: installAction },
+    ...overrides,
+  };
+}
+
+describe("ProviderReadinessNotice", () => {
+  let api: { post: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    api = { post: vi.fn().mockResolvedValue({ name: "matrix-setup-codex" }) };
+    useConnection.setState({ status: "signed-in", api: api as never });
+    useTabs.setState(useTabs.getInitialState(), true);
+    useUi.setState({ requestedSettingsSection: null });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders nothing when the selected provider is ready", () => {
+    const { container } = render(
+      <ProviderReadinessNotice
+        readiness={readiness({
+          state: "ready",
+          blocked: false,
+          title: "",
+          description: "",
+          action: null,
+        })}
+        providers={[provider]}
+        onRefresh={vi.fn()}
+      />,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it.each([
+    [
+      "missing",
+      "Codex is not installed",
+      "Install Codex before sending a message.",
+      "Install Codex",
+    ],
+    [
+      "auth_required",
+      "Connect Codex to continue",
+      "Sign in to Codex before sending a message.",
+      "Connect Codex",
+    ],
+  ] as const)("renders safe %s recovery copy", (state, title, description, label) => {
+    const action = { ...installAction, id: `codex_${state}`, label };
+    render(
+      <ProviderReadinessNotice
+        readiness={readiness({
+          state,
+          title,
+          description,
+          action: { kind: "setup", action },
+        })}
+        providers={[{ ...provider, setupActions: [action] }]}
+        onRefresh={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(title)).toBeTruthy();
+    expect(screen.getByText(description)).toBeTruthy();
+    expect(screen.getByRole("button", { name: label })).toBeTruthy();
+    expect(document.body.textContent).not.toMatch(/npm install|codex login|token|secret|\/home\//i);
+  });
+
+  it("requests Providers before opening Settings", () => {
+    const order: string[] = [];
+    const requestSettingsSection = vi.fn((section: string) => {
+      order.push(`request:${section}`);
+      useUi.setState({ requestedSettingsSection: section });
+    });
+    const openTab = vi.fn(() => {
+      order.push("open:settings");
+      return "settings";
+    });
+    useUi.setState({ requestSettingsSection });
+    useTabs.setState({ openTab: openTab as never });
+
+    render(
+      <ProviderReadinessNotice
+        readiness={readiness({
+          state: "unconfigured",
+          title: "No coding agent provider is configured",
+          description: "Open provider settings to choose a coding agent provider.",
+          action: {
+            kind: "setup",
+            action: {
+              id: "provider_settings",
+              kind: "open_settings",
+              label: "Open provider settings",
+            },
+          },
+        })}
+        providers={[]}
+        onRefresh={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open provider settings" }));
+
+    expect(order).toEqual(["request:providers", "open:settings"]);
+  });
+
+  it("opens foreground setup in the canonical visible Terminal", async () => {
+    render(
+      <ProviderReadinessNotice
+        readiness={readiness()}
+        providers={[provider]}
+        onRefresh={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Install Codex" }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith(
+      "/api/terminal/sessions",
+      expect.objectContaining({ cmd: installAction.command, cwd: "projects" }),
+    ));
+    expect(useTabs.getState().tabs).toEqual([
+      expect.objectContaining({ kind: "terminal", title: "Install Codex" }),
+    ]);
+  });
+
+  it("refreshes once and exposes pending state", async () => {
+    let finishRefresh: (() => void) | undefined;
+    const onRefresh = vi.fn(() => new Promise<void>((resolve) => {
+      finishRefresh = resolve;
+    }));
+    render(
+      <ProviderReadinessNotice
+        readiness={readiness({
+          state: "unverified",
+          title: "Matrix could not verify Codex",
+          description: "Refresh provider status before sending.",
+          action: { kind: "refresh" },
+        })}
+        providers={[provider]}
+        onRefresh={onRefresh}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh provider status" }));
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Refreshing…")).toBeTruthy();
+
+    await act(async () => finishRefresh?.());
+    expect(screen.getByText("Refresh status")).toBeTruthy();
+  });
+
+  it("fails safely without an API while keeping the recovery notice visible", async () => {
+    useConnection.setState({ api: null });
+    render(
+      <ProviderReadinessNotice
+        readiness={readiness()}
+        providers={[provider]}
+        onRefresh={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Install Codex" }));
+
+    expect(await screen.findByText("Could not open provider setup. Open Providers settings to continue.")).toBeTruthy();
+    expect(screen.getByText("Codex is not installed")).toBeTruthy();
+    expect(api.post).not.toHaveBeenCalled();
+  });
+});

--- a/tests/desktop/provider-readiness-notice.test.tsx
+++ b/tests/desktop/provider-readiness-notice.test.tsx
@@ -167,6 +167,35 @@ describe("ProviderReadinessNotice", () => {
     ]);
   });
 
+  it("executes the current command in a fresh setup session on deliberate retry", async () => {
+    render(
+      <ProviderReadinessNotice
+        readiness={readiness()}
+        providers={[provider]}
+        onRefresh={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Install Codex" }));
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole("button", { name: "Install Codex" }));
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(2));
+
+    const firstRequest = api.post.mock.calls[0]?.[1];
+    const retryRequest = api.post.mock.calls[1]?.[1];
+    expect(firstRequest).toEqual(expect.objectContaining({
+      cmd: installAction.command,
+      cwd: "projects",
+      name: expect.stringMatching(/^matrix-setup-[a-z0-9-]{1,18}$/),
+    }));
+    expect(retryRequest).toEqual(expect.objectContaining({
+      cmd: installAction.command,
+      cwd: "projects",
+      name: expect.stringMatching(/^matrix-setup-[a-z0-9-]{1,18}$/),
+    }));
+    expect(retryRequest.name).not.toBe(firstRequest.name);
+  });
+
   it("refreshes once and exposes pending state", async () => {
     let finishRefresh: (() => void) | undefined;
     const onRefresh = vi.fn(() => new Promise<void>((resolve) => {

--- a/tests/desktop/provider-readiness.test.ts
+++ b/tests/desktop/provider-readiness.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest";
+import type { AgentProviderSummary, RuntimeSummary } from "@matrix-os/contracts";
+import {
+  deriveProviderReadiness,
+  type ProviderReadinessPresentation,
+} from "../../desktop/src/renderer/src/features/coding-agents/provider-readiness.js";
+
+const installAction = {
+  id: "codex_install",
+  kind: "foreground_terminal" as const,
+  label: "Install Codex",
+  command: "npm install -g @openai/codex",
+};
+
+const connectAction = {
+  id: "codex_connect",
+  kind: "foreground_terminal" as const,
+  label: "Connect Codex",
+  command: "codex login",
+};
+
+function provider(overrides: Partial<AgentProviderSummary> = {}): AgentProviderSummary {
+  return {
+    id: "codex",
+    kind: "codex",
+    displayName: "Codex",
+    availability: "available",
+    installStatus: "installed",
+    authStatus: "authenticated",
+    supportedModes: ["default"],
+    defaultMode: "default",
+    setupActions: [],
+    ...overrides,
+  };
+}
+
+function summary(providers: AgentProviderSummary[]): RuntimeSummary {
+  return {
+    runtime: { id: "rt_primary", label: "Primary", status: "available" },
+    capabilities: [{ id: "codingAgentsRuntimeSummary", enabled: true }],
+    providers,
+    projects: { items: [], hasMore: false, limit: 20 },
+    activeThreads: { items: [], hasMore: false, limit: 20 },
+    attentionThreads: { items: [], hasMore: false, limit: 20 },
+    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    previewSessions: { items: [], hasMore: false, limit: 50 },
+    recentActivity: { items: [], hasMore: false, limit: 20 },
+    limits: {
+      maxPromptBytes: 16_384,
+      maxAttachmentCount: 8,
+      maxTerminalInputBytes: 8_192,
+      maxListItems: 20,
+    },
+    serverTime: "2026-08-21T12:00:00.000Z",
+  };
+}
+
+function visibleCopy(readiness: ProviderReadinessPresentation): string {
+  return `${readiness.title} ${readiness.description}`;
+}
+
+describe("deriveProviderReadiness", () => {
+  it("keeps summary hydration distinct from an unconfigured provider", () => {
+    expect(deriveProviderReadiness({ summary: null, loading: true })).toEqual({
+      state: "loading",
+      blocked: true,
+      title: "Checking coding agent provider",
+      description: "Matrix is verifying the selected provider.",
+      action: null,
+    });
+  });
+
+  it("fails closed when the runtime summary is unavailable", () => {
+    expect(deriveProviderReadiness({ summary: null, loading: false })).toEqual({
+      state: "unverified",
+      blocked: true,
+      title: "Matrix could not verify this provider",
+      description: "Refresh provider status before sending.",
+      action: { kind: "refresh" },
+    });
+  });
+
+  it("opens provider settings when no provider is configured", () => {
+    expect(deriveProviderReadiness({ summary: summary([]), loading: false })).toEqual({
+      state: "unconfigured",
+      blocked: true,
+      title: "No coding agent provider is configured",
+      description: "Open provider settings to choose a coding agent provider.",
+      action: {
+        kind: "setup",
+        action: {
+          id: "provider_settings",
+          kind: "open_settings",
+          label: "Open provider settings",
+        },
+      },
+    });
+  });
+
+  it("fails closed when the selected provider is missing from the summary", () => {
+    expect(deriveProviderReadiness({
+      summary: summary([provider({ id: "claude", displayName: "Claude", kind: "claude" })]),
+      providerId: "codex",
+      loading: false,
+    })).toEqual({
+      state: "unverified",
+      blocked: true,
+      title: "Matrix could not verify this provider",
+      description: "Refresh provider status before sending.",
+      action: { kind: "refresh" },
+    });
+  });
+
+  it("allows sending only for an available, installed, authenticated provider", () => {
+    expect(deriveProviderReadiness({
+      summary: summary([provider()]),
+      providerId: "codex",
+      loading: false,
+    })).toEqual({
+      state: "ready",
+      blocked: false,
+      title: "",
+      description: "",
+      action: null,
+    });
+  });
+
+  it.each([
+    {
+      name: "not installed",
+      value: provider({
+        availability: "setup_required",
+        installStatus: "missing",
+        authStatus: "missing",
+        setupActions: [installAction],
+      }),
+      expected: {
+        state: "missing",
+        blocked: true,
+        title: "Codex is not installed",
+        description: "Install Codex before sending a message.",
+        action: { kind: "setup", action: installAction },
+      },
+    },
+    {
+      name: "authentication required",
+      value: provider({
+        availability: "auth_required",
+        authStatus: "missing",
+        setupActions: [connectAction],
+      }),
+      expected: {
+        state: "auth_required",
+        blocked: true,
+        title: "Connect Codex to continue",
+        description: "Sign in to Codex before sending a message.",
+        action: { kind: "setup", action: connectAction },
+      },
+    },
+    {
+      name: "authentication expired",
+      value: provider({
+        availability: "auth_required",
+        authStatus: "expired",
+        setupActions: [connectAction],
+      }),
+      expected: {
+        state: "expired",
+        blocked: true,
+        title: "Codex needs to be reconnected",
+        description: "Reconnect Codex before sending a message.",
+        action: { kind: "setup", action: connectAction },
+      },
+    },
+    {
+      name: "installing",
+      value: provider({
+        availability: "installing",
+        installStatus: "installing",
+        authStatus: "unknown",
+      }),
+      expected: {
+        state: "installing",
+        blocked: true,
+        title: "Installing Codex",
+        description: "Refresh provider status after installation finishes.",
+        action: { kind: "refresh" },
+      },
+    },
+    {
+      name: "version unsupported",
+      value: provider({
+        availability: "unavailable",
+        installStatus: "failed",
+        authStatus: "unknown",
+      }),
+      expected: {
+        state: "unsupported",
+        blocked: true,
+        title: "Update Codex to a supported version",
+        description: "Open setup to install a supported Codex version.",
+        action: {
+          kind: "setup",
+          action: {
+            id: "provider_settings",
+            kind: "open_settings",
+            label: "Open provider settings",
+          },
+        },
+      },
+    },
+    {
+      name: "check failed",
+      value: provider({
+        availability: "unavailable",
+        installStatus: "unknown",
+        authStatus: "unknown",
+      }),
+      expected: {
+        state: "unverified",
+        blocked: true,
+        title: "Matrix could not verify Codex",
+        description: "Refresh provider status before sending.",
+        action: { kind: "refresh" },
+      },
+    },
+  ])("derives safe presentation for $name", ({ value, expected }) => {
+    const readiness = deriveProviderReadiness({
+      summary: summary([value]),
+      providerId: "codex",
+      loading: false,
+    });
+
+    expect(readiness).toEqual(expected);
+    expect(visibleCopy(readiness)).not.toMatch(/npm install|codex login|token|secret|\/home\//i);
+  });
+});

--- a/tests/desktop/provider-readiness.test.ts
+++ b/tests/desktop/provider-readiness.test.ts
@@ -125,6 +125,43 @@ describe("deriveProviderReadiness", () => {
     });
   });
 
+  it("selects the authentication action for an installed provider that needs login", () => {
+    const readiness = deriveProviderReadiness({
+      summary: summary([provider({
+        availability: "auth_required",
+        installStatus: "installed",
+        authStatus: "missing",
+        setupActions: [installAction, connectAction],
+      })]),
+      providerId: "codex",
+      loading: false,
+    });
+
+    expect(readiness.action).toEqual({ kind: "setup", action: connectAction });
+  });
+
+  it("opens provider settings when authentication recovery is unavailable", () => {
+    const readiness = deriveProviderReadiness({
+      summary: summary([provider({
+        availability: "auth_required",
+        installStatus: "installed",
+        authStatus: "missing",
+        setupActions: [installAction],
+      })]),
+      providerId: "codex",
+      loading: false,
+    });
+
+    expect(readiness.action).toEqual({
+      kind: "setup",
+      action: {
+        id: "provider_settings",
+        kind: "open_settings",
+        label: "Open provider settings",
+      },
+    });
+  });
+
   it.each([
     {
       name: "not installed",

--- a/tests/gateway/coding-agents-provider-registry.test.ts
+++ b/tests/gateway/coding-agents-provider-registry.test.ts
@@ -10,6 +10,16 @@ import type { RequestPrincipal } from "../../packages/gateway/src/request-princi
 const baseNow = new Date("2026-07-09T12:00:00.000Z");
 const owner: RequestPrincipal = { userId: "owner_user", source: "jwt" };
 
+function providerReady(summary: {
+  availability: string;
+  installStatus: string;
+  authStatus: string;
+}): boolean {
+  return summary.availability === "available" &&
+    summary.installStatus === "installed" &&
+    summary.authStatus === "authenticated";
+}
+
 function credentialService(
   status: AgentCredentialStatus,
 ): Pick<AgentCredentialStatusService, "getStatus"> {
@@ -93,13 +103,18 @@ describe("coding-agent provider registry", () => {
   });
 
   it.each([
-    ["missing", "setup_required", "missing", "missing"],
-    ["expired", "auth_required", "installed", "expired"],
-    ["revoked", "auth_required", "installed", "expired"],
-    ["failed", "unavailable", "failed", "unknown"],
+    ["available", "available", "installed", "authenticated", true],
+    ["missing", "setup_required", "missing", "missing", false],
+    ["auth_required", "auth_required", "installed", "missing", false],
+    ["expired", "auth_required", "installed", "expired", false],
+    ["revoked", "auth_required", "installed", "expired", false],
+    ["failed", "unavailable", "failed", "unknown", false],
+    ["check_failed", "unavailable", "unknown", "unknown", false],
+    ["version_unsupported", "unavailable", "failed", "unknown", false],
+    ["not_applicable", "unavailable", "unknown", "unknown", false],
   ] as const)(
     "maps %s credential state to coarse provider status",
-    async (status, availability, installStatus, authStatus) => {
+    async (status, availability, installStatus, authStatus, ready) => {
       const healthCheck = vi.fn(() => ({ ok: true }));
       const registry = createCodingAgentProviderRegistry({
         providers: [adapter({ healthCheck })],
@@ -110,7 +125,8 @@ describe("coding-agent provider registry", () => {
       const [summary] = await registry.listProviders(owner);
 
       expect(summary).toMatchObject({ availability, installStatus, authStatus });
-      expect(healthCheck).not.toHaveBeenCalled();
+      expect(providerReady(summary!)).toBe(ready);
+      expect(healthCheck).toHaveBeenCalledTimes(ready ? 1 : 0);
     },
   );
 

--- a/tests/gateway/coding-agents-summary.test.ts
+++ b/tests/gateway/coding-agents-summary.test.ts
@@ -128,6 +128,49 @@ describe("coding agent runtime summary", () => {
     expect(JSON.stringify(summary)).not.toMatch(/\/home\/matrix|\/bin\/bash|token|secret|Postgres/i);
   });
 
+  it.each([
+    ["available", "available", "installed", "authenticated"],
+    ["missing", "setup_required", "missing", "missing"],
+    ["auth_required", "auth_required", "installed", "missing"],
+    ["expired", "auth_required", "installed", "expired"],
+    ["revoked", "auth_required", "installed", "expired"],
+    ["failed", "unavailable", "failed", "unknown"],
+    ["check_failed", "unavailable", "unknown", "unknown"],
+    ["version_unsupported", "unavailable", "failed", "unknown"],
+    ["not_applicable", "unavailable", "unknown", "unknown"],
+  ] as const)(
+    "fails closed when the fallback credential summary reports %s",
+    async (status, availability, installStatus, authStatus) => {
+      const service = createCodingAgentRuntimeSummaryService({
+        homePath: "/home/matrix/home",
+        agentCredentials: {
+          getStatus: async () => ({
+            systemAgent: "hermes",
+            activeAgents: status === "available" ? ["codex", "hermes"] : ["hermes"],
+            routingExplanation: "Provider state is runtime-owned.",
+            agents: [{
+              agent: "codex",
+              status,
+              coordinationRole: "coding_specialist",
+              workflows: ["coding"],
+              degradedWorkflows: status === "available" ? [] : ["coding"],
+              verifiedAt: status === "available" ? now.toISOString() : null,
+              nextAction: null,
+            }],
+          }),
+        },
+        providerIds: ["codex"],
+        now: () => now,
+      });
+
+      const summary = RuntimeSummarySchema.parse(await service.getSummary(testPrincipal));
+
+      expect(summary.providers).toEqual([
+        expect.objectContaining({ availability, installStatus, authStatus }),
+      ]);
+    },
+  );
+
   it("only advertises providers registered for coding-agent thread starts", async () => {
     const service = createCodingAgentRuntimeSummaryService({
       homePath: "/home/matrix/home",

--- a/tests/gateway/coding-agents-workspace-provider.test.ts
+++ b/tests/gateway/coding-agents-workspace-provider.test.ts
@@ -57,6 +57,27 @@ function workspaceSession(overrides: Record<string, unknown> = {}) {
 }
 
 describe("coding agent workspace provider", () => {
+  it("uses device authentication for the remote Codex connect action", async () => {
+    const provider = createWorkspaceCodingAgentProvider({
+      providerId: "codex",
+      agent: "codex",
+      runtime: {
+        startSession: vi.fn(),
+        stopSession: vi.fn(),
+      },
+    });
+
+    const actions = await provider.buildSetupAction?.({
+      principal: ownerPrincipal,
+      now: () => baseNow,
+      signal: AbortSignal.timeout(1_000),
+    });
+
+    expect(actions?.find((action) => action.id === "codex_connect")?.command).toBe(
+      'sh -lc \'export MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"; export PATH="$MATRIX_NODE_PREFIX/bin:$PATH"; codex login --device-auth\'',
+    );
+  });
+
   it.each([
     ["claude", "@anthropic-ai/claude-code@latest", "claude"],
     ["codex", CODEX_VERIFIED_NPM_PACKAGE, "codex login"],
@@ -165,7 +186,7 @@ exit 0
       });
       const trace = await readFile(tracePath, "utf8");
 
-      expect(trace).toContain("connect-args=login");
+      expect(trace).toContain("connect-args=login --device-auth");
       expect(trace).not.toContain("bash-args=-l");
       expect(trace).toContain(`bash-args=--noprofile --rcfile ${bashrcPath} -i`);
       expect(trace).toContain("bash-prompt=owner-handle:\\w$ ");


### PR DESCRIPTION
## Summary

- make gateway provider projections fail closed for every non-ready credential state
- derive one bounded Desktop readiness model for new chats and stored-thread follow-ups
- preserve editable drafts while blocking button and Enter submission, with visible trusted recovery actions
- refresh provider readiness once on each deliberate New Chat entry
- preserve an intentional New Chat selection and its draft across manual workspace refresh

## Stack

- Linear: [MAT-459](https://linear.app/matrix-os/issue/MAT-459/pr-13-provider-readiness)
- Stacked on PR #1251 (`codex/mat-348-agent-output-composer`)
- Exact base: `b641ad546cd380008bcf37ead3a3a40414360937`
- Current head: `32860f3a343abf5a652e640f5b48bf5f4d5bf9f8`

## Invariants

- Source of truth: the authenticated gateway `RuntimeSummary.providers` projection; Desktop does not infer readiness from a terminal opening or local state.
- Authorization source of truth: existing main-process bearer injection and gateway owner checks. No bearer token or provider credential enters renderer state.
- Write/lock scope: this PR adds no database writes, transactions, locks, or renderer persistence. Accepted thread mutations remain gateway-owned and are never queued locally.
- Recoverable intermediate state: blocked drafts may remain transiently orphaned in the mounted composer while setup is incomplete; they stay editable, are isolated by thread key, and disappear only through existing navigation/unmount behavior or an accepted send.
- Setup actions: only bounded server-owned `SafeSetupAction` values can open the canonical foreground Terminal or Providers settings. Command text is not rendered or replaced by client input.
- Refresh behavior: readiness refresh is transition-driven once per New Chat entry, not a polling loop; manual refresh preserves an intentional empty thread selection.

## Tests

- focused PR 1 provider/readiness/Desktop gate — 215/215 passed
- `tests/desktop/project-workspaces-store.test.ts` — 16/16 passed
- `tests/desktop/providers-section.test.tsx` + `tests/desktop/command-palette.test.tsx` — 25/25 passed
- exact remote Codex device-auth command assertion — passed
- `bun run typecheck` — passed
- `bun run check:patterns` — 0 violations (5 repository baseline warnings)
- `pnpm --filter desktop build` — passed
- `git diff --check` — passed
- broad `bun run test` is not clean on this checkout: unrelated baseline/environment failures include generated Terminal wrappers entering host zsh instead of fake Bash, older tool-version assertions, and slow platform fixtures. The affected focused gates above are clean.

## Previous preview evidence

- Validated head: `a8dd51e1c01b7c8651b9ec03a5cdabd580b7d557`
- Bundle: `v2026.08.21-pr1294-32506060173-1-a8dd51e`
- Workflow: [Preview VPS run 32506060173](https://github.com/HamedMP/matrix-os/actions/runs/32506060173)
- `pr-1294` reported `healthy=true`, the exact runtime version, and the same active `/opt/matrix/app/BUNDLE_VERSION`.
- Fresh authenticated Desktop evidence on the exact renderer verified: New Chat stayed selected after header Refresh, the editable draft value was unchanged, the current non-ready Codex state remained fail-closed, and the visible recovery CTA remained available.
- New Chat entry refresh is covered by the new RED-to-GREEN public UI regression. Human acceptance of the refreshed setup/recovery flow remains in progress and is not claimed here.

## Current review refinement

- Exact head `32860f3a343abf5a652e640f5b48bf5f4d5bf9f8` tracks explicit thread-selection revisions and makes the runtime-summary refresh boundary explicit so view-only changes cannot be mistaken for New Chat intent.
- Fresh gates: 47/47 focused Desktop tests, repository and Desktop typechecks, Desktop production build, pattern scan with 0 violations, and diff check.
- The broad repository suite was sampled and stopped after unrelated baseline and environment failures; no full-suite green claim is made.

## Deferred / excluded

- typed activity and semantic transcript projection (PR 2)
- diff and file preview rendering (PR 3)
- MAT-349 reload/live ordering and lifecycle work
- browser auth redirects, hidden setup, polling loops, provider credentials, raw errors, and new persistence

This PR must remain Draft. MAT-459 remains in Human Review, and Human Review is user-owned.


