### PR TITLE
fix(billing): preserve renewal grace with Stripe item periods

### DIFF
--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -895,6 +895,20 @@ async function projectSubscription(
   const existing = await getBillingSubscriptionByStripeId(db, sub.id);
   const runtimeSlot = readRuntimeSlotFromStripeMetadata(sub.metadata) ?? 'primary';
   const data = Array.isArray(sub.items?.data) ? sub.items.data : [];
+  const itemPeriodBoundaries = data.flatMap((item) => {
+    if (!item || typeof item !== 'object') return [];
+    const candidate = item as {
+      current_period_start?: unknown;
+      current_period_end?: unknown;
+    };
+    const boundary = status === 'past_due' || status === 'unpaid'
+      ? candidate.current_period_start
+      : candidate.current_period_end;
+    return typeof boundary === 'number' ? [boundary] : [];
+  });
+  const itemPeriodBoundary = itemPeriodBoundaries.length > 0
+    ? Math.min(...itemPeriodBoundaries)
+    : null;
   return {
     clerkUserId: customer.clerkUserId,
     stripeCustomerId: customer.stripeCustomerId,
@@ -903,7 +917,7 @@ async function projectSubscription(
     status,
     currentPeriodEnd: typeof sub.current_period_end === 'number'
       ? epochSecondsToIso(sub.current_period_end)
-      : null,
+      : (itemPeriodBoundary === null ? null : epochSecondsToIso(itemPeriodBoundary)),
     trialStartedAt: typeof sub.trial_start === 'number'
       ? epochSecondsToIso(sub.trial_start)
       : (existing?.trialStartedAt ?? null),

--- a/tests/platform/billing-routes.test.ts
+++ b/tests/platform/billing-routes.test.ts
@@ -1413,6 +1413,54 @@ describe('platform billing routes', () => {
     ]);
   });
 
+  it('keeps three-day renewal grace when Stripe reports periods on subscription items', async () => {
+    const trialStart = Date.parse('2026-05-23T00:00:00.000Z') / 1000;
+    const trialEnd = Date.parse('2026-05-30T00:00:00.000Z') / 1000;
+    const renewalStart = Date.parse('2026-06-30T00:00:00.000Z') / 1000;
+    const renewalEnd = Date.parse('2026-07-30T00:00:00.000Z') / 1000;
+    vi.mocked(stripe.constructWebhookEvent)
+      .mockReturnValueOnce(subscriptionEvent('evt_trial_started', {
+        subscriptionId: 'sub_trial', runtimeSlot: 'primary', priceId: 'price_builder_monthly', status: 'trialing',
+        created: trialStart, trialStart, trialEnd,
+      }))
+      .mockReturnValueOnce(invoiceEvent('evt_trial_converted', 'invoice.paid', 'sub_trial'))
+      .mockReturnValueOnce(subscriptionEvent('evt_trial_active', {
+        subscriptionId: 'sub_trial', runtimeSlot: 'primary', priceId: 'price_builder_monthly', status: 'active',
+        created: trialEnd + 60, trialStart, trialEnd,
+        omitTopLevelCurrentPeriodEnd: true,
+        itemCurrentPeriodStart: trialEnd,
+        itemCurrentPeriodEnd: renewalStart,
+      }))
+      .mockReturnValueOnce(subscriptionEvent('evt_renewal_past_due', {
+        subscriptionId: 'sub_trial', runtimeSlot: 'primary', priceId: 'price_builder_monthly', status: 'past_due',
+        created: renewalStart, trialStart, trialEnd,
+        omitTopLevelCurrentPeriodEnd: true,
+        itemCurrentPeriodStart: renewalStart,
+        itemCurrentPeriodEnd: renewalEnd,
+      }));
+    const app = createApp('user_123', env, undefined, () => new Date('2026-07-01T00:00:00.000Z'));
+
+    for (let index = 0; index < 4; index += 1) {
+      const response = await app.request('/billing/webhooks/stripe', {
+        method: 'POST', headers: { 'stripe-signature': 'valid' }, body: '{}',
+      });
+      expect(response.status).toBe(200);
+    }
+
+    const status = await app.request('/billing/status?runtimeSlot=primary');
+    expect(status.status).toBe(200);
+    await expect(status.json()).resolves.toMatchObject({
+      entitlement: {
+        status: 'past_due',
+        gracePeriodEndsAt: '2026-07-03T00:00:00.000Z',
+      },
+      access: {
+        runtimeProxyAllowed: true,
+        reason: 'grace_period',
+      },
+    });
+  });
+
   it('does not let an older paid invoice convert a trial after a newer terminal subscription event', async () => {
     await insertUserMachine(db, {
       machineId: 'machine_trial', clerkUserId: 'user_123', handle: 'trial-user',
@@ -1929,6 +1977,9 @@ function subscriptionEvent(id: string, overrides: {
   status?: string;
   created?: number;
   currentPeriodEnd?: number;
+  omitTopLevelCurrentPeriodEnd?: boolean;
+  itemCurrentPeriodStart?: number;
+  itemCurrentPeriodEnd?: number;
   trialStart?: number;
   trialEnd?: number;
 } = {}): StripeWebhookEvent {
@@ -1941,7 +1992,9 @@ function subscriptionEvent(id: string, overrides: {
         id: overrides.subscriptionId ?? 'sub_123',
         customer: 'cus_123',
         status: overrides.status ?? 'active',
-        current_period_end: overrides.currentPeriodEnd ?? 1_782_432_000,
+        ...(!overrides.omitTopLevelCurrentPeriodEnd
+          ? { current_period_end: overrides.currentPeriodEnd ?? 1_782_432_000 }
+          : {}),
         trial_start: overrides.trialStart,
         trial_end: overrides.trialEnd,
         metadata: {
@@ -1951,7 +2004,12 @@ function subscriptionEvent(id: string, overrides: {
         },
         items: {
           data: [
-            { price: { id: overrides.priceId ?? 'price_max_monthly' }, quantity: 1 },
+            {
+              price: { id: overrides.priceId ?? 'price_max_monthly' },
+              quantity: 1,
+              current_period_start: overrides.itemCurrentPeriodStart,
+              current_period_end: overrides.itemCurrentPeriodEnd,
+            },
             { price: { id: 'price_extra_runtime_monthly' }, quantity: 1 },
           ],
         },


### PR DESCRIPTION
## Summary
- parse subscription item period timestamps used by Stripe API `2026-04-22.dahlia` when top-level `current_period_end` is absent
- anchor `past_due` and `unpaid` renewal grace to the unpaid item period start
- preserve active subscription renewal boundaries from the item period end
- add a route-level trial-conversion-to-renewal-failure regression

## Tests
- `pnpm exec vitest run tests/platform/billing-routes.test.ts -t "keeps three-day renewal grace when Stripe reports periods on subscription items" --reporter=verbose`
- `pnpm exec vitest run tests/platform/billing-routes.test.ts tests/platform/billing-entitlements.test.ts tests/platform/stripe-billing.test.ts --reporter=verbose` (82 passed)
- `bun run typecheck`
- `bun run check:patterns` (0 violations)
- genuine Stripe Test Clock `customer.subscription.updated` replay: `past_due` projected with an exact 72-hour grace deadline and runtime access reason `grace_period`

## Review/Monitoring
- rollout remains blocked; do not merge or activate trials until this PR has Greptile 5/5 and required CI is green
- after merge, repeat the established-renewal Test Clock scenario on the deployed staging revision

## Invariants
- **Source of truth:** verified Stripe subscription webhooks remain authoritative; redirects do not grant entitlement
- **Lock/transaction scope:** unchanged; period parsing feeds the existing single webhook transaction and monotonic subscription projection
- **Acceptable orphan states:** no new external actions or persistence objects are introduced; a delayed webhook may temporarily leave the prior entitlement until Stripe delivery succeeds
- **Auth source of truth:** Stripe signature verification remains the webhook trust boundary; Clerk identity remains the billing status boundary
- **Deferred scope:** no production flag change, stable promotion, fleet deployment, provider action, or documentation merge is included