### PR TITLE
fix(billing): make preview trial rollout configurable

### DIFF
--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -69,6 +69,7 @@ jobs:
       ARTIFACT_REPOSITORY: ${{ vars.ARTIFACT_REPOSITORY }}
       CLOUD_RUN_PREVIEW_SERVICE: ${{ vars.CLOUD_RUN_PREVIEW_SERVICE }}
       CLOUD_RUN_SERVICE_ACCOUNT: ${{ vars.CLOUD_RUN_PREVIEW_SERVICE_ACCOUNT }}
+      MATRIX_CARD_TRIALS_ENABLED: ${{ vars.MATRIX_CARD_TRIALS_ENABLED || 'false' }}
       PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
     steps:
       - name: Check preview configuration
@@ -84,6 +85,13 @@ jobs:
             echo "CLOUD_RUN_PREVIEW_SERVICE_ACCOUNT must be set in the Preview environment; refusing to fall back to another SA." >&2
             exit 1
           fi
+          case "$MATRIX_CARD_TRIALS_ENABLED" in
+            true|false) ;;
+            *)
+              echo "MATRIX_CARD_TRIALS_ENABLED must be true or false." >&2
+              exit 1
+              ;;
+          esac
           echo "configured=true" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v6
@@ -164,7 +172,7 @@ jobs:
               --tag "pr-${PR_NUMBER}" \
               --no-traffic \
               --allow-unauthenticated \
-              --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PREVIEW=true,CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_IMAGE_VERSION=dev,CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,MATRIX_STRIPE_BILLING_ENABLED=true,MATRIX_CARD_TRIALS_ENABLED=true,PLATFORM_PUBLIC_URL=${PREVIEW_PUBLIC_URL},MATRIX_API_ORIGIN=${api_origin},MATRIX_APP_URL=${PREVIEW_PUBLIC_URL},MATRIX_APP_DOMAIN_HOSTS=${PREVIEW_DOMAIN}" \
+              --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PREVIEW=true,CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_IMAGE_VERSION=dev,CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,MATRIX_STRIPE_BILLING_ENABLED=true,MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED},PLATFORM_PUBLIC_URL=${PREVIEW_PUBLIC_URL},MATRIX_API_ORIGIN=${api_origin},MATRIX_APP_URL=${PREVIEW_PUBLIC_URL},MATRIX_APP_DOMAIN_HOSTS=${PREVIEW_DOMAIN}" \
               --set-secrets "PLATFORM_DATABASE_URL=platform-database-url-staging:latest,PLATFORM_SECRET=platform-preview-secret:latest,GOLDEN_SNAPSHOT_OPERATOR_SECRET=golden-snapshot-operator-secret-preview:latest,PLATFORM_JWT_SECRET=platform-preview-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-preview-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,STRIPE_SECRET_KEY=stripe-secret-key-test:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret-test:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly-test:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual-test:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly-test:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual-test:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly-test:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual-test:latest" \
               --cpu 1 --memory 1Gi --concurrency 10 --timeout 300 --min-instances 0 --max-instances 2 \
               --quiet

--- a/docs/dev/preview-environments.md
+++ b/docs/dev/preview-environments.md
@@ -109,7 +109,10 @@ secrets, the Clerk keys, the R2 bundles credentials (required by
 `CUSTOMER_VPS_ENABLED=true` boot validation), and **Stripe TEST-mode** secrets.
 Production `CLOUD_RUN_SERVICE`, its runtime SA, its database, and live Stripe
 keys are never referenced. No Hetzner token is mounted, so a preview platform
-cannot provision real VPSes. On PR close the workflow removes the `pr-<N>` tag
+cannot provision real VPSes. Provider-disabled revisions marked
+`PLATFORM_PREVIEW=true` therefore skip the production primary-sync-storage
+startup invariant; mounting a Hetzner token immediately restores that fail-closed
+canonical EU R2 check. On PR close the workflow removes the `pr-<N>` tag
 and deletes its revisions, mirroring the VPS teardown model.
 
 **Browser-reachable onboarding/billing.** The service runs with public ingress

--- a/docs/dev/preview-environments.md
+++ b/docs/dev/preview-environments.md
@@ -163,6 +163,11 @@ The label workflow assumes this is already provisioned in GCP/Cloudflare/Stripe
    its signing secret as `stripe-webhook-secret-test`.
 4. Grant `matrix-platform-preview-runner` `secretAccessor` on the new secrets.
 
+The GitHub `Preview` environment may set `MATRIX_CARD_TRIALS_ENABLED` to
+`true` or `false`; it defaults to `false`. Keep it disabled for the immediate-
+payment regression pass, enable it only for trial scenarios, then return it to
+`false` after validation. Each change requires redeploying the preview revision.
+
 ## Centralized logs
 
 Everything funnels into the ops-VPS Loki and is queryable one way:

--- a/packages/platform/src/platform-startup-env.ts
+++ b/packages/platform/src/platform-startup-env.ts
@@ -59,6 +59,7 @@ export function checkCustomerVpsPrimaryStorageEnv(
   log: (msg: string) => void = console.error,
 ): string[] {
   if (env.NODE_ENV !== 'production' || env.CUSTOMER_VPS_ENABLED !== 'true') return [];
+  if (env.PLATFORM_PREVIEW === 'true' && !env.HETZNER_API_TOKEN?.trim()) return [];
 
   const problems: string[] = [];
   const accountId = env.R2_ACCOUNT_ID?.trim();

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -306,7 +306,9 @@ describe('CI workflows', () => {
 
     expect(production).toContain("MATRIX_CARD_TRIALS_ENABLED: ${{ vars.MATRIX_CARD_TRIALS_ENABLED || 'false' }}");
     expect(production).toContain('MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED}');
-    expect(preview).toContain('MATRIX_CARD_TRIALS_ENABLED=true');
+    expect(preview).toContain("MATRIX_CARD_TRIALS_ENABLED: ${{ vars.MATRIX_CARD_TRIALS_ENABLED || 'false' }}");
+    expect(preview).toContain('MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED}');
+    expect(preview).toContain('MATRIX_CARD_TRIALS_ENABLED must be true or false.');
     for (const eventType of [
       'customer.subscription.trial_will_end',
       'invoice.paid',

--- a/tests/platform/home-mirror-env-check.test.ts
+++ b/tests/platform/home-mirror-env-check.test.ts
@@ -46,6 +46,20 @@ describe('checkCustomerVpsPrimaryStorageEnv', () => {
       R2_ACCOUNT_ID: 'local-account',
     }, vi.fn())).toEqual([]);
   });
+
+  it('exempts only provider-disabled preview revisions from production primary storage', () => {
+    const isolatedPreview = {
+      NODE_ENV: 'production',
+      PLATFORM_PREVIEW: 'true',
+      CUSTOMER_VPS_ENABLED: 'true',
+    };
+
+    expect(checkCustomerVpsPrimaryStorageEnv(isolatedPreview, vi.fn())).toEqual([]);
+    expect(checkCustomerVpsPrimaryStorageEnv({
+      ...isolatedPreview,
+      HETZNER_API_TOKEN: 'provider-token',
+    }, vi.fn())).toContain('R2_ENDPOINT');
+  });
 });
 
 describe("checkHomeMirrorS3Env (startup assertion for silent-failure #6)", () => {


### PR DESCRIPTION
## Summary

- source the card-trial rollout flag from the isolated GitHub `Preview` environment
- default preview trials to disabled and fail closed on invalid values
- allow a provider-disabled preview revision to start without production primary-sync R2 credentials
- restore the canonical EU primary-R2 startup invariant immediately if a Hetzner provider token is mounted
- document the disabled -> enabled -> disabled staging validation sequence and preview isolation boundary

## Tests

- RED: `bun run test -- tests/platform/ci-workflows.test.ts` failed on the missing preview flag contract
- GREEN: `bun run test -- tests/platform/ci-workflows.test.ts` (33 passed)
- RED: `bun run test -- tests/platform/home-mirror-env-check.test.ts tests/platform/preview-platform-workflow.test.ts` failed because provider-disabled preview still required production primary R2
- GREEN: `bun run test -- tests/platform/home-mirror-env-check.test.ts tests/platform/preview-platform-workflow.test.ts` (24 passed)
- `bun run typecheck`
- `bun run check:patterns` (0 violations; pre-existing warnings only)
- `git diff --check`
- full `bun run test` in progress; exact-head CI remains authoritative

## Preview evidence

- Initial preview deployment reached Cloud Run but revision startup failed on the production primary-R2 invariant.
- No Hetzner token or primary sync-R2 credential is mounted in Preview, so this failure occurred before any provider action.
- Production service, production traffic, and production trial flag were not changed.

## Review/Monitoring

- Await trusted Greptile 5/5 on the exact head.
- Add `ready-for-ci` only after Greptile reaches 5/5, then require all triggered CI to pass.
- Use this PR preview only with Stripe test-mode secrets and the staging database.

## Invariants

- **Source of truth:** GitHub `Preview` environment variable `MATRIX_CARD_TRIALS_ENABLED`; absent means `false`.
- **Lock/transaction scope:** Not applicable; this changes deployment configuration and startup validation only.
- **Acceptable orphan states:** A failed deployment may leave the prior tagged preview revision intact; it must not redirect production traffic.
- **Auth source of truth:** The dedicated Preview GitHub environment, Workload Identity, and `matrix-platform-preview-runner` service account remain unchanged.
- **Isolation boundary:** A provider-disabled preview may omit primary sync-R2 credentials. Mounting a Hetzner token restores fail-closed canonical EU primary-R2 validation.
- **Deferred scope:** No production flag change, live Stripe mutation, provider credential, stable bundle promotion, or fleet deployment.
