### PR TITLE
test(desktop): avoid metadata in Hermes redaction check

### DIFF
--- a/tests/desktop/hermes-chat.test.ts
+++ b/tests/desktop/hermes-chat.test.ts
@@ -862,7 +862,10 @@ describe("useHermesChat", () => {
         content: "The agent could not complete this turn. Try again.",
       }),
     ]);
-    expect(JSON.stringify(useHermesChat.getState().messages)).not.toContain("API key");
-    expect(JSON.stringify(useHermesChat.getState().messages)).not.toContain("401");
+    const messageContent = useHermesChat.getState().messages
+      .map((message) => message.content)
+      .join("\n");
+    expect(messageContent).not.toContain("API key");
+    expect(messageContent).not.toContain("401");
   });
 });


### PR DESCRIPTION
## Summary

- Assert the Hermes redaction expectation against message content, not serialized message metadata.
- Audit all six test files added or modified by `096848da3946503c49d108120658f82157f57780`; none use this broad serialized-message assertion pattern.

## Tests

- `pnpm exec vitest run tests/desktop/hermes-chat.test.ts`
- `pnpm run check:patterns`
- Full `pnpm exec vitest run` was started and the focused Hermes suite passed, but the complete suite has unrelated existing failures in cloud-init, app-runtime, heartbeat, Codex app-server, sync mirror, and CLI shell tests.
- Direct type-check is blocked by existing `packages/integrations-mcp` Zod/MCP type errors in this checkout; the main CI type-check passed for the base commit.