### PR TITLE
fix(gateway): sanitize integration proxy responses

### DIFF
--- a/packages/gateway/src/integrations/proxy-response.ts
+++ b/packages/gateway/src/integrations/proxy-response.ts
@@ -1,0 +1,32 @@
+const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "trailers",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+const DECODED_FETCH_RESPONSE_HEADERS = new Set([
+  "content-encoding",
+  "content-length",
+]);
+
+export function createIntegrationProxyResponse(upstream: Response): Response {
+  const headers = new Headers(upstream.headers);
+  for (const header of HOP_BY_HOP_RESPONSE_HEADERS) {
+    headers.delete(header);
+  }
+  for (const header of DECODED_FETCH_RESPONSE_HEADERS) {
+    headers.delete(header);
+  }
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers,
+  });
+}

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -190,6 +190,7 @@ import {
   IntegrationActionNotImplementedError,
 } from "./integrations/routes.js";
 import { discoverComponentKeys, getService, getAction } from "./integrations/registry.js";
+import { createIntegrationProxyResponse } from "./integrations/proxy-response.js";
 import { z } from "zod/v4";
 import {
   createPluginRegistry,
@@ -1184,10 +1185,7 @@ export async function createGateway(config: GatewayConfig) {
       body: ["GET", "HEAD"].includes(c.req.method) ? undefined : await c.req.blob(),
     });
 
-    return new Response(upstream.body, {
-      status: upstream.status,
-      headers: upstream.headers,
-    });
+    return createIntegrationProxyResponse(upstream);
   }
 
   // Platform DB + Integrations (Pipedream Connect)

--- a/tests/gateway/integrations-proxy-response.test.ts
+++ b/tests/gateway/integrations-proxy-response.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { createIntegrationProxyResponse } from "../../packages/gateway/src/integrations/proxy-response.js";
+
+describe("integration proxy response", () => {
+  it("removes decoded representation and hop-by-hop headers", async () => {
+    const upstream = new Response(JSON.stringify([{ service: "gmail" }]), {
+      status: 200,
+      headers: {
+        "cache-control": "private, no-store",
+        connection: "keep-alive",
+        "content-encoding": "gzip",
+        "content-length": "999",
+        "content-type": "application/json",
+        "keep-alive": "timeout=5",
+        "proxy-authenticate": "Basic",
+        "proxy-authorization": "Basic secret",
+        te: "trailers",
+        trailer: "x-checksum",
+        trailers: "x-checksum",
+        "transfer-encoding": "chunked",
+        upgrade: "websocket",
+      },
+    });
+
+    const response = createIntegrationProxyResponse(upstream);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    for (const name of [
+      "connection",
+      "content-encoding",
+      "content-length",
+      "keep-alive",
+      "proxy-authenticate",
+      "proxy-authorization",
+      "te",
+      "trailer",
+      "trailers",
+      "transfer-encoding",
+      "upgrade",
+    ]) {
+      expect(response.headers.get(name), name).toBeNull();
+    }
+    await expect(response.json()).resolves.toEqual([{ service: "gmail" }]);
+  });
+});


### PR DESCRIPTION
## Summary

- sanitize platform integration responses before returning them from the VPS gateway
- remove stale `content-encoding` and `content-length` values after Node fetch decodes the upstream body
- remove hop-by-hop framing headers such as `transfer-encoding` and `connection`
- add regression coverage for the compressed/chunked response that caused `matrix-integrations inventory` to fail with `terminated`

## Tests

- `pnpm exec vitest run tests/gateway/integrations-proxy-response.test.ts`
- `pnpm --filter @matrix-os/gateway exec tsc --noEmit`
- `pnpm run check:patterns` — 0 violations

## Invariants

- **Source of truth:** platform-owned integration records remain authoritative; this change only corrects VPS response framing.
- **Lock/transaction scope:** no database writes, locks, or transaction boundaries are changed.
- **Acceptable orphan states:** none introduced; upstream failures continue to use the existing gateway error path.
- **Auth source of truth:** existing platform verification tokens and Matrix gateway authentication remain unchanged.
- **Deferred scope:** no platform or desktop changes are required; deployment is limited to the VPS host bundle.

## Manual verification

Deploy the PR host bundle to a preview VPS, then run `matrix-integrations inventory`. Repeat the authenticated request with `curl --compressed`; both should return the connected integrations as valid JSON without a terminated or chunked-stream error.
