### PR TITLE
feat(onboarding): prepare primary VPS before billing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Detect source changes
         id: changed

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/109-golden-vps-snapshots"
+  "feature_directory": "specs/116-prebilling-provisioning"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -507,5 +507,5 @@ Five canonical roles using default label names. See `docs/agents/triage-labels.m
 Single-context: `CONTEXT.md` + `docs/adr/` at repo root. See `docs/agents/domain.md`.
 
 <!-- SPECKIT START -->
-Current Spec Kit plan: `specs/109-golden-vps-snapshots/plan.md`.
+Current Spec Kit plan: `specs/116-prebilling-provisioning/plan.md`.
 <!-- SPECKIT END -->

--- a/package.json
+++ b/package.json
@@ -93,6 +93,14 @@
         "dependencies": {
           "@expo/config-plugins": "57.0.2"
         }
+      },
+      "langium@4.2.1": {
+        "dependencies": {
+          "@chevrotain/regexp-to-ast": "11.1.2",
+          "vscode-jsonrpc": "8.2.0",
+          "vscode-languageserver-protocol": "3.17.5",
+          "vscode-languageserver-types": "3.17.5"
+        }
       }
     }
   },

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -190,6 +190,7 @@ export interface PrebillingCheckoutCoordinator {
     input: { intentId: string; clerkUserId: string; runtimeSlot: string; now: string },
   ): Promise<{ authorized: boolean; machineId: string | null; needsFallback: boolean }>;
   ensureFallback(input: { intentId: string }): Promise<void>;
+  reconcileFallbacks?(): Promise<{ checked: number; completed: number; failed: number }>;
   expireCheckout(
     db: PlatformDB,
     input: { stripeSessionId: string; intentId?: string; clerkUserId?: string; now: string },

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -189,6 +189,7 @@ export interface PrebillingCheckoutCoordinator {
     db: PlatformDB,
     input: { intentId: string; clerkUserId: string; runtimeSlot: string; now: string },
   ): Promise<{ authorized: boolean; machineId: string | null; needsFallback: boolean }>;
+  ensureFallback(input: { intentId: string }): Promise<void>;
   expireCheckout(
     db: PlatformDB,
     input: { stripeSessionId: string; intentId?: string; clerkUserId?: string; now: string },
@@ -623,6 +624,7 @@ export function createBillingRoutes(options: {
 
     try {
       const webhookProcessedAt = now();
+      let fallbackIntentId: string | undefined;
       const result = await runBillingWebhookTransaction(options.db, async (trx) => {
         const inserted = await insertBillingWebhookEvent(trx, {
           stripeEventId: event.id,
@@ -827,12 +829,13 @@ export function createBillingRoutes(options: {
           && projection.prebillingIntentId
           && getRuntimeAccessDecision(summary, webhookProcessedAt).runtimeProxyAllowed
         ) {
-          await options.prebilling?.authorizeSubscription(trx, {
+          const authorization = await options.prebilling?.authorizeSubscription(trx, {
             intentId: projection.prebillingIntentId,
             clerkUserId: projection.clerkUserId,
             runtimeSlot: projection.runtimeSlot,
             now: webhookProcessedAt.toISOString(),
           });
+          if (authorization?.needsFallback) fallbackIntentId = projection.prebillingIntentId;
         }
         emitTelemetry(BILLING_SUBSCRIPTION_UPDATED_EVENT, {
           distinctId: entitlement.clerkUserId,
@@ -872,6 +875,15 @@ export function createBillingRoutes(options: {
         }
         return { received: true, processed: true };
       });
+      if (!fallbackIntentId && 'duplicate' in result && result.duplicate && isSubscriptionEvent(event.type)) {
+        const subscription = event.data.object && typeof event.data.object === 'object'
+          ? event.data.object as { status?: unknown; metadata?: unknown }
+          : undefined;
+        if (['active', 'trialing', 'past_due'].includes(String(subscription?.status))) {
+          fallbackIntentId = readPrebillingIntentIdFromStripeMetadata(subscription?.metadata) ?? undefined;
+        }
+      }
+      if (fallbackIntentId) await options.prebilling?.ensureFallback({ intentId: fallbackIntentId });
       return c.json(result, 200);
     } catch (err: unknown) {
       console.error('[billing] Stripe webhook processing failed:', err instanceof Error ? err.message : String(err));

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -191,7 +191,7 @@ export interface PrebillingCheckoutCoordinator {
   ): Promise<{ authorized: boolean; machineId: string | null; needsFallback: boolean }>;
   expireCheckout(
     db: PlatformDB,
-    input: { stripeSessionId: string; now: string },
+    input: { stripeSessionId: string; intentId?: string; clerkUserId?: string; now: string },
   ): Promise<{ cleaned: boolean; intentId: string | null }>;
 }
 
@@ -650,8 +650,15 @@ export function createBillingRoutes(options: {
               true,
             );
             if (event.type === 'checkout.session.expired') {
+              const checkoutObject = event.data.object && typeof event.data.object === 'object'
+                ? event.data.object as { metadata?: unknown }
+                : undefined;
+              const intentId = readPrebillingIntentIdFromStripeMetadata(checkoutObject?.metadata);
+              const clerkUserId = readClerkUserIdFromCheckoutSession(event.data.object);
               await options.prebilling?.expireCheckout(trx, {
                 stripeSessionId: sessionId,
+                ...(intentId ? { intentId } : {}),
+                ...(clerkUserId ? { clerkUserId } : {}),
                 now: webhookProcessedAt.toISOString(),
               });
             }

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -47,8 +47,8 @@ import {
   type StripePriceCatalog,
   type StripeSubscriptionProjection,
 } from './billing.js';
-import { DeveloperToolsWithDefaultSchema } from './developer-tools.js';
-import { RuntimeSlotSchema } from './customer-vps-schema.js';
+import { DeveloperToolsWithDefaultSchema, type DeveloperToolId } from './developer-tools.js';
+import { HetznerServerTypeSchema, RuntimeSlotSchema } from './customer-vps-schema.js';
 
 const BILLING_BODY_LIMIT = 16 * 1024;
 const STRIPE_WEBHOOK_BODY_LIMIT = 1024 * 1024;
@@ -91,6 +91,7 @@ const CheckoutRequestSchema = z.object({
   planSlug: z.enum(['matrix_starter', 'matrix_builder', 'matrix_max']),
   interval: z.enum(['monthly', 'annual']).default('monthly'),
   regionSlug: BillingRegionSlugSchema.default('region_fsn1'),
+  serverType: HetznerServerTypeSchema.optional(),
   developerTools: DeveloperToolsWithDefaultSchema,
   runtimeSlot: RuntimeSlotSchema.optional().default('primary'),
   returnPath: z.string().min(1).max(2048).optional().refine(
@@ -126,6 +127,8 @@ export interface StripeCheckoutSessionInput {
   runtimeSlot: string;
   trialPeriodDays?: number | null;
   paymentMethodMode?: 'card_required' | 'dynamic';
+  prebillingIntentId?: string;
+  expiresAt?: string;
   successUrl: string;
   cancelUrl: string;
 }
@@ -145,7 +148,11 @@ export interface StripeBillingClient {
    * Stripe Customer when needed; the signed subscription webhook links it back
    * to the Clerk user from server-written metadata.
    */
-  createCheckoutSession(input: StripeCheckoutSessionInput): Promise<{ url: string; id: string }>;
+  createCheckoutSession(input: StripeCheckoutSessionInput): Promise<{
+    url: string;
+    id: string;
+    expiresAt?: string;
+  }>;
   retrieveCheckoutSession(id: string): Promise<StripeCheckoutSessionProjection>;
   createPortalSession(input: {
     customerId: string;
@@ -161,6 +168,33 @@ export interface StripeWebhookEvent {
   data: { object: unknown };
 }
 
+export interface PrebillingCheckoutCoordinator {
+  createIntent(input: {
+    checkoutAttemptId: string;
+    clerkUserId: string;
+    runtimeSlot: 'primary';
+    planSlug: MatrixBillingPlanSlug;
+    billingInterval: MatrixBillingInterval;
+    serverType: string;
+    regionSlug: string;
+    developerTools: DeveloperToolId[];
+    now: string;
+  }): Promise<{ intentId: string; expiresAt: string } | undefined>;
+  startPreparation(input: {
+    intentId: string;
+    stripeSessionId: string;
+    stripeSessionExpiresAt: string;
+  }): Promise<void>;
+  authorizeSubscription(
+    db: PlatformDB,
+    input: { intentId: string; clerkUserId: string; runtimeSlot: string; now: string },
+  ): Promise<{ authorized: boolean; machineId: string | null; needsFallback: boolean }>;
+  expireCheckout(
+    db: PlatformDB,
+    input: { stripeSessionId: string; now: string },
+  ): Promise<{ cleaned: boolean; intentId: string | null }>;
+}
+
 export function createBillingRoutes(options: {
   db: PlatformDB;
   stripe: StripeBillingClient;
@@ -168,6 +202,7 @@ export function createBillingRoutes(options: {
   resolveClerkUserId: (c: Context) => Promise<string | null>;
   now?: () => Date;
   upsertEntitlement?: typeof upsertBillingEntitlement;
+  prebilling?: PrebillingCheckoutCoordinator;
   /**
    * Optional product telemetry sink. Fire-and-forget: implementations must
    * never throw into the request path, and callers only pass low-cardinality,
@@ -292,6 +327,9 @@ export function createBillingRoutes(options: {
       const serverType = selectedPlan
         ? loadRuntimeCatalog(env).profiles.find((profile) => profile.sku === selectedPlan.defaultCatalogSku)?.serverType
         : undefined;
+      if (parsed.data.serverType && parsed.data.serverType !== serverType) {
+        return c.json({ error: 'Invalid request' }, 400);
+      }
       const checkoutClaim = {
         clerkUserId,
         createdAt: currentTime.toISOString(),
@@ -400,6 +438,24 @@ export function createBillingRoutes(options: {
         }, 409);
       }
       const customer = await getBillingCustomerByClerkUserId(options.db, clerkUserId);
+      let preparation: { intentId: string; expiresAt: string } | undefined;
+      if (options.prebilling && serverType && parsed.data.runtimeSlot === 'primary') {
+        try {
+          preparation = await options.prebilling.createIntent({
+            checkoutAttemptId: attempt.attempt.id,
+            clerkUserId,
+            runtimeSlot: 'primary',
+            planSlug: parsed.data.planSlug,
+            billingInterval: parsed.data.interval,
+            serverType,
+            regionSlug: parsed.data.regionSlug,
+            developerTools: parsed.data.developerTools,
+            now: currentTime.toISOString(),
+          });
+        } catch (err: unknown) {
+          console.warn('[billing] prebilling intent unavailable:', err instanceof Error ? err.name : typeof err);
+        }
+      }
       const session = await options.stripe.createCheckoutSession({
         idempotencyKey: attempt.attempt.id,
         clerkUserId,
@@ -412,11 +468,26 @@ export function createBillingRoutes(options: {
         runtimeSlot: parsed.data.runtimeSlot,
         trialPeriodDays: attempt.attempt.trialPeriodDays,
         paymentMethodMode: attempt.attempt.trialPeriodDays ? 'card_required' : 'dynamic',
+        ...(preparation ? {
+          prebillingIntentId: preparation.intentId,
+          expiresAt: preparation.expiresAt,
+        } : {}),
         successUrl: resolveBillingReturnUrl(env, 'success', parsed.data.returnPath),
         cancelUrl: resolveBillingReturnUrl(env, 'canceled', parsed.data.returnPath),
       });
       if (!await finalizeCheckoutAttempt(options.db, attempt.attempt.id, session.id, session.url)) {
         throw new Error('checkout_attempt_finalize_failed');
+      }
+      if (preparation) {
+        try {
+          await options.prebilling?.startPreparation({
+            intentId: preparation.intentId,
+            stripeSessionId: session.id,
+            stripeSessionExpiresAt: session.expiresAt ?? preparation.expiresAt,
+          });
+        } catch (err: unknown) {
+          console.warn('[billing] prebilling preparation unavailable:', err instanceof Error ? err.name : typeof err);
+        }
       }
       emitTelemetry(BILLING_CHECKOUT_CREATED_EVENT, {
         distinctId: clerkUserId,
@@ -578,6 +649,12 @@ export function createBillingRoutes(options: {
               webhookProcessedAt.toISOString(),
               true,
             );
+            if (event.type === 'checkout.session.expired') {
+              await options.prebilling?.expireCheckout(trx, {
+                stripeSessionId: sessionId,
+                now: webhookProcessedAt.toISOString(),
+              });
+            }
           }
           emitTelemetry(
             event.type === 'checkout.session.completed'
@@ -738,6 +815,18 @@ export function createBillingRoutes(options: {
         }
         const summary = await recomputeStripeSummary(trx, projection.clerkUserId, priceCatalog, env, webhookProcessedAt);
         if (summary) await persistEntitlement(trx, summary);
+        if (
+          summary
+          && projection.prebillingIntentId
+          && getRuntimeAccessDecision(summary, webhookProcessedAt).runtimeProxyAllowed
+        ) {
+          await options.prebilling?.authorizeSubscription(trx, {
+            intentId: projection.prebillingIntentId,
+            clerkUserId: projection.clerkUserId,
+            runtimeSlot: projection.runtimeSlot,
+            now: webhookProcessedAt.toISOString(),
+          });
+        }
         emitTelemetry(BILLING_SUBSCRIPTION_UPDATED_EVENT, {
           distinctId: entitlement.clerkUserId,
           properties: buildSubscriptionTelemetryProperties(entitlement, priceCatalog),
@@ -888,7 +977,10 @@ async function projectSubscription(
   db: PlatformDB,
   value: unknown,
   currentTime: Date,
-): Promise<(StripeSubscriptionProjection & { runtimeSlot: string }) | null> {
+): Promise<(StripeSubscriptionProjection & {
+  runtimeSlot: string;
+  prebillingIntentId: string | null;
+}) | null> {
   if (!value || typeof value !== 'object') return null;
   const sub = value as {
     id?: unknown;
@@ -938,6 +1030,7 @@ async function projectSubscription(
     stripeCustomerId: customer.stripeCustomerId,
     stripeSubscriptionId: sub.id,
     runtimeSlot,
+    prebillingIntentId: readPrebillingIntentIdFromStripeMetadata(sub.metadata),
     status,
     currentPeriodEnd: typeof sub.current_period_end === 'number'
       ? epochSecondsToIso(sub.current_period_end)
@@ -965,6 +1058,14 @@ async function projectSubscription(
 function readRuntimeSlotFromStripeMetadata(metadata: unknown): string | null {
   if (!metadata || typeof metadata !== 'object') return null;
   const parsed = RuntimeSlotSchema.safeParse((metadata as { matrix_runtime_slot?: unknown }).matrix_runtime_slot);
+  return parsed.success ? parsed.data : null;
+}
+
+function readPrebillingIntentIdFromStripeMetadata(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== 'object') return null;
+  const parsed = z.string().min(1).max(128).regex(/^[A-Za-z0-9_-]+$/).safeParse(
+    (metadata as { matrix_prebilling_intent_id?: unknown }).matrix_prebilling_intent_id,
+  );
   return parsed.success ? parsed.data : null;
 }
 

--- a/packages/platform/src/customer-vps-prebilling.ts
+++ b/packages/platform/src/customer-vps-prebilling.ts
@@ -1,0 +1,43 @@
+import type { ProvisioningJobRecord } from './customer-vps-provisioning-jobs.js';
+import type { PlatformDB, UserMachineRecord } from './db.js';
+import { validatePrebillingProvisioningIntent } from './prebilling-provisioning-store.js';
+
+export async function isProvisioningJobAuthorized(
+  db: PlatformDB,
+  job: ProvisioningJobRecord,
+  machine: UserMachineRecord,
+  now: string,
+): Promise<boolean> {
+  if (job.authorizationBasis !== 'prebilling_intent') return true;
+  if (!job.prebillingIntentId) return false;
+  return Boolean(await validatePrebillingProvisioningIntent(db, {
+    intentId: job.prebillingIntentId,
+    clerkUserId: machine.clerkUserId,
+    runtimeSlot: machine.runtimeSlot,
+    serverType: machine.serverType ?? '',
+    regionSlug: `region_${machine.location ?? ''}`,
+    developerTools: machine.developerTools,
+    machineId: machine.machineId,
+    now,
+  }));
+}
+
+export async function persistProvisioningClaimMutation(
+  db: PlatformDB,
+  input: { machineId: string; jobId: string; mutate: (trx: PlatformDB) => Promise<void> },
+): Promise<{ persisted: boolean; prebillingCleanupWon: boolean; alreadyCompleted: boolean }> {
+  return db.transaction(async (trx) => {
+    const machine = await trx.executor.selectFrom('user_machines').select(['deleted_at', 'status'])
+      .where('machine_id', '=', input.machineId).forUpdate().executeTakeFirst();
+    const job = await trx.executor.selectFrom('provisioning_jobs').select(['status', 'authorization_basis'])
+      .where('job_id', '=', input.jobId).forUpdate().executeTakeFirst();
+    const active = machine?.deleted_at === null && machine.status === 'provisioning' && job?.status === 'running';
+    if (!active) return {
+      persisted: false,
+      prebillingCleanupWon: job?.authorization_basis === 'prebilling_intent' && machine?.deleted_at !== null,
+      alreadyCompleted: machine?.deleted_at === null && machine.status === 'running' && job?.status === 'completed',
+    };
+    await input.mutate(trx);
+    return { persisted: true, prebillingCleanupWon: false, alreadyCompleted: false };
+  });
+}

--- a/packages/platform/src/customer-vps-provisioning-jobs.ts
+++ b/packages/platform/src/customer-vps-provisioning-jobs.ts
@@ -59,6 +59,8 @@ const ProvisioningJobRowSchema = z.object({
   activation_step: z.enum(['selecting', 'creating', 'created', 'activating', 'registered', 'cleanup_pending', 'fallback_pending']),
   provider_create_action_id: z.coerce.number().int().positive().nullable(),
   fallback_reason: z.string().min(1).max(64).nullable(),
+  authorization_basis: z.enum(['billing_entitlement', 'prebilling_intent']),
+  prebilling_intent_id: z.string().min(1).max(128).nullable(),
 });
 
 export interface ProvisioningJobRecord {
@@ -83,6 +85,8 @@ export interface ProvisioningJobRecord {
   activationStep: 'selecting' | 'creating' | 'created' | 'activating' | 'registered' | 'cleanup_pending' | 'fallback_pending';
   providerCreateActionId: number | null;
   fallbackReason: string | null;
+  authorizationBasis: 'billing_entitlement' | 'prebilling_intent';
+  prebillingIntentId: string | null;
 }
 
 export interface NewProvisioningJob {
@@ -91,6 +95,8 @@ export interface NewProvisioningJob {
   encryptedPayload: string;
   availableAt: string;
   createdAt: string;
+  authorizationBasis?: 'billing_entitlement' | 'prebilling_intent';
+  prebillingIntentId?: string | null;
 }
 
 export interface ProvisioningPayload {
@@ -145,6 +151,8 @@ function mapProvisioningJob(value: unknown): ProvisioningJobRecord {
     activationStep: row.activation_step,
     providerCreateActionId: row.provider_create_action_id,
     fallbackReason: row.fallback_reason,
+    authorizationBasis: row.authorization_basis,
+    prebillingIntentId: row.prebilling_intent_id,
   };
 }
 
@@ -223,6 +231,8 @@ export async function insertProvisioningJob(db: PlatformDB, job: NewProvisioning
     activation_step: 'selecting',
     provider_create_action_id: null,
     fallback_reason: null,
+    authorization_basis: job.authorizationBasis ?? 'billing_entitlement',
+    prebilling_intent_id: job.prebillingIntentId ?? null,
   }).execute();
 }
 

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -92,10 +92,8 @@ import {
   type NewProvisioningJob,
   type ProvisioningPayload,
 } from './customer-vps-provisioning-jobs.js';
-import {
-  bindPrebillingIntentMachine,
-  validatePrebillingProvisioningIntent,
-} from './prebilling-provisioning-store.js';
+import { bindPrebillingIntentMachine, validatePrebillingProvisioningIntent } from './prebilling-provisioning-store.js';
+import { isProvisioningJobAuthorized, persistProvisioningClaimMutation } from './customer-vps-prebilling.js';
 import {
   chooseProvisioningImage,
   chooseRecoveryImage,
@@ -1270,20 +1268,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       return 'failed';
     }
 
-    if (job.authorizationBasis === 'prebilling_intent') {
-      const intent = job.prebillingIntentId
-        ? await validatePrebillingProvisioningIntent(deps.db, {
-            intentId: job.prebillingIntentId,
-            clerkUserId: row.clerkUserId,
-            runtimeSlot: row.runtimeSlot,
-            serverType: row.serverType ?? deps.config.serverType,
-            regionSlug: `region_${row.location ?? deps.config.location}`,
-            developerTools: row.developerTools,
-            machineId: row.machineId,
-            now: now().toISOString(),
-          })
-        : undefined;
-      if (!intent) {
+    if (!await isProvisioningJobAuthorized(deps.db, job, row, now().toISOString())) {
         const failedAt = now().toISOString();
         await failProvisioningJob(deps.db, job.jobId, failedAt, 'authorization_expired');
         await updateUserMachine(deps.db, row.machineId, {
@@ -1295,42 +1280,15 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           throw new CustomerVpsError(409, 'invalid_state', 'Provisioning unavailable');
         }
         return 'failed';
-      }
     }
 
     let serverIdForCompensation: number | null = null;
     let adoptedExistingServer = false;
     const persistWhileProvisioningClaimIsActive = async (
       mutate: (trx: PlatformDB) => Promise<void>,
-    ): Promise<{ persisted: boolean; prebillingCleanupWon: boolean; alreadyCompleted: boolean }> => runInPlatformTransaction(
+    ) => persistProvisioningClaimMutation(
       deps.db,
-      async (trx) => {
-        const lockedMachine = await trx.executor.selectFrom('user_machines')
-          .select(['deleted_at', 'status'])
-          .where('machine_id', '=', row.machineId)
-          .forUpdate()
-          .executeTakeFirst();
-        const lockedJob = await trx.executor.selectFrom('provisioning_jobs')
-          .select(['status', 'authorization_basis'])
-          .where('job_id', '=', job.jobId)
-          .forUpdate()
-          .executeTakeFirst();
-        const active = lockedMachine?.deleted_at === null
-          && lockedMachine.status === 'provisioning'
-          && lockedJob?.status === 'running';
-        if (!active) {
-          return {
-            persisted: false,
-            prebillingCleanupWon: lockedJob?.authorization_basis === 'prebilling_intent'
-              && lockedMachine?.deleted_at !== null,
-            alreadyCompleted: lockedMachine?.deleted_at === null
-              && lockedMachine.status === 'running'
-              && lockedJob?.status === 'completed',
-          };
-        }
-        await mutate(trx);
-        return { persisted: true, prebillingCleanupWon: false, alreadyCompleted: false };
-      },
+      { machineId: row.machineId, jobId: job.jobId, mutate },
     );
     const reconcileServerAfterLostClaim = async (
       server: { id: number },

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -1302,7 +1302,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     let adoptedExistingServer = false;
     const persistWhileProvisioningClaimIsActive = async (
       mutate: (trx: PlatformDB) => Promise<void>,
-    ): Promise<{ persisted: boolean; prebillingCleanupWon: boolean }> => runInPlatformTransaction(
+    ): Promise<{ persisted: boolean; prebillingCleanupWon: boolean; alreadyCompleted: boolean }> => runInPlatformTransaction(
       deps.db,
       async (trx) => {
         const lockedMachine = await trx.executor.selectFrom('user_machines')
@@ -1323,10 +1323,13 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
             persisted: false,
             prebillingCleanupWon: lockedJob?.authorization_basis === 'prebilling_intent'
               && lockedMachine?.deleted_at !== null,
+            alreadyCompleted: lockedMachine?.deleted_at === null
+              && lockedMachine.status === 'running'
+              && lockedJob?.status === 'completed',
           };
         }
         await mutate(trx);
-        return { persisted: true, prebillingCleanupWon: false };
+        return { persisted: true, prebillingCleanupWon: false, alreadyCompleted: false };
       },
     );
     const reconcileServerAfterLostClaim = async (
@@ -1637,6 +1640,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
             activation_step: 'creating', updated_at: observedAt,
           }).where('job_id', '=', job.jobId).where('status', '=', 'running').executeTakeFirstOrThrow();
         });
+        if (observation.alreadyCompleted) return 'completed';
         if (!observation.persisted) {
           return reconcileServerAfterLostClaim(server, observation.prebillingCleanupWon);
         }
@@ -1657,6 +1661,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
               updated_at: observedAt,
             }).where('job_id', '=', job.jobId).where('status', '=', 'running').executeTakeFirstOrThrow();
           });
+          if (observation.alreadyCompleted) return 'completed';
           if (!observation.persisted) {
             return reconcileServerAfterLostClaim(server, observation.prebillingCleanupWon);
           }
@@ -1728,6 +1733,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           }
         }
       });
+      if (completion.alreadyCompleted) return 'completed';
       if (!completion.persisted) {
         return reconcileServerAfterLostClaim(server, completion.prebillingCleanupWon);
       }

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -1300,6 +1300,66 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
 
     let serverIdForCompensation: number | null = null;
     let adoptedExistingServer = false;
+    const persistWhileProvisioningClaimIsActive = async (
+      mutate: (trx: PlatformDB) => Promise<void>,
+    ): Promise<{ persisted: boolean; prebillingCleanupWon: boolean }> => runInPlatformTransaction(
+      deps.db,
+      async (trx) => {
+        const lockedMachine = await trx.executor.selectFrom('user_machines')
+          .select(['deleted_at', 'status'])
+          .where('machine_id', '=', row.machineId)
+          .forUpdate()
+          .executeTakeFirst();
+        const lockedJob = await trx.executor.selectFrom('provisioning_jobs')
+          .select(['status', 'authorization_basis'])
+          .where('job_id', '=', job.jobId)
+          .forUpdate()
+          .executeTakeFirst();
+        const active = lockedMachine?.deleted_at === null
+          && lockedMachine.status === 'provisioning'
+          && lockedJob?.status === 'running';
+        if (!active) {
+          return {
+            persisted: false,
+            prebillingCleanupWon: lockedJob?.authorization_basis === 'prebilling_intent'
+              && lockedMachine?.deleted_at !== null,
+          };
+        }
+        await mutate(trx);
+        return { persisted: true, prebillingCleanupWon: false };
+      },
+    );
+    const reconcileServerAfterLostClaim = async (
+      server: { id: number },
+      prebillingCleanupWon: boolean,
+    ): Promise<'failed'> => {
+      if (!prebillingCleanupWon) {
+        throw new Error('Provisioning job lost its active claim');
+      }
+      try {
+        await deps.hetzner.deleteServer(server.id);
+        if (await deps.hetzner.getServer(server.id)) {
+          await enqueueProviderDeletionTx(deps.db, {
+            providerServerId: server.id,
+            reason: 'prebilling_cleanup_race',
+            machineId: row.machineId,
+            handle: row.handle,
+            detail: 'provider server remained after signed checkout cleanup',
+          });
+        }
+      } catch (cleanupErr: unknown) {
+        logCustomerVpsError('prebilling cleanup race provider deletion failed', cleanupErr);
+        await queueProviderDeletion({
+          providerServerId: server.id,
+          reason: 'prebilling_cleanup_race',
+          machineId: row.machineId,
+          handle: row.handle,
+          err: cleanupErr,
+        });
+      }
+      serverIdForCompensation = null;
+      return 'failed';
+    };
     try {
       const payload = openProvisioningPayload(job.encryptedPayload, deps.config.platformSecret);
       const imageVersion = row.imageVersion ?? deps.config.imageVersion;
@@ -1567,7 +1627,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       const createActionId = effectiveProviderCreateActionId ?? server.createActionId ?? null;
       if (adoptedExistingServer && createActionId === null && server.status !== 'running') {
         const observedAt = now().toISOString();
-        await runInPlatformTransaction(deps.db, async (trx) => {
+        const observation = await persistWhileProvisioningClaimIsActive(async (trx) => {
           await updateUserMachine(trx, row.machineId, {
             hetznerServerId: server!.id,
             publicIPv4: server!.publicIPv4,
@@ -1577,12 +1637,15 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
             activation_step: 'creating', updated_at: observedAt,
           }).where('job_id', '=', job.jobId).where('status', '=', 'running').executeTakeFirstOrThrow();
         });
+        if (!observation.persisted) {
+          return reconcileServerAfterLostClaim(server, observation.prebillingCleanupWon);
+        }
         return 'pending';
       }
       if (createActionId !== null) {
         if (effectiveProviderCreateActionId === null) {
           const observedAt = now().toISOString();
-          await runInPlatformTransaction(deps.db, async (trx) => {
+          const observation = await persistWhileProvisioningClaimIsActive(async (trx) => {
             await updateUserMachine(trx, row.machineId, {
               hetznerServerId: server!.id,
               publicIPv4: server!.publicIPv4,
@@ -1594,6 +1657,9 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
               updated_at: observedAt,
             }).where('job_id', '=', job.jobId).where('status', '=', 'running').executeTakeFirstOrThrow();
           });
+          if (!observation.persisted) {
+            return reconcileServerAfterLostClaim(server, observation.prebillingCleanupWon);
+          }
         }
         const createResult = await waitForProvisioningCreateAction(createActionId);
         if (createResult === 'pending') return 'pending';
@@ -1644,7 +1710,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         }
       }
       const completedAt = now().toISOString();
-      await runInPlatformTransaction(deps.db, async (trx) => {
+      const completion = await persistWhileProvisioningClaimIsActive(async (trx) => {
         await updateUserMachine(trx, row.machineId, {
           hetznerServerId: server.id,
           publicIPv4: server.publicIPv4,
@@ -1662,6 +1728,9 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           }
         }
       });
+      if (!completion.persisted) {
+        return reconcileServerAfterLostClaim(server, completion.prebillingCleanupWon);
+      }
       return 'completed';
     } catch (err: unknown) {
       const mapped = genericProviderError(err);

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -93,6 +93,10 @@ import {
   type ProvisioningPayload,
 } from './customer-vps-provisioning-jobs.js';
 import {
+  bindPrebillingIntentMachine,
+  validatePrebillingProvisioningIntent,
+} from './prebilling-provisioning-store.js';
+import {
   chooseProvisioningImage,
   chooseRecoveryImage,
   fallbackProvisioningImage,
@@ -180,6 +184,11 @@ export interface DeployTarget {
 
 export interface CustomerVpsService {
   provision(input: ProvisionRequest, options?: ProvisionOptions): Promise<ProvisionResponse>;
+  provisionForCheckout(
+    input: ProvisionRequest,
+    prebillingIntentId: string,
+    options?: ProvisionOptions,
+  ): Promise<ProvisionResponse>;
   provisionPreview(input: PreviewProvisionInput): Promise<ProvisionResponse>;
   register(token: string | undefined, input: RegisterRequest): Promise<RegisterResponse>;
   recover(input: RecoverRequest): Promise<RecoverResponse>;
@@ -550,13 +559,20 @@ async function assertBillingResizeAllowed(
 
 async function assertMachineProviderMutationAllowed(
   deps: CustomerVpsServiceDeps,
-  machine: Pick<UserMachineRecord, 'clerkUserId' | 'runtimeSlot' | 'provisioningClass'>,
+  machine: Pick<UserMachineRecord,
+    'clerkUserId' | 'runtimeSlot' | 'provisioningClass' | 'activationState' | 'prebillingIntentId'>,
   serverType: string,
   now: Date,
+  authorizationBasis: 'billing_entitlement' | 'prebilling_intent' = 'billing_entitlement',
 ): Promise<void> {
   // Preview authorization is platform/operator scoped and deliberately does
   // not consume or depend on the owner's customer billing entitlement.
   if (machine.provisioningClass === 'preview') return;
+  // The provisioning worker validates the exact intent, selection, machine
+  // binding, and unexpired lease before reaching either provider-create path.
+  if (authorizationBasis === 'prebilling_intent'
+    && machine.activationState === 'awaiting_billing'
+    && machine.prebillingIntentId !== null) return;
   await assertBillingResizeAllowed(deps, machine.clerkUserId, machine.runtimeSlot, serverType, now);
 }
 
@@ -1254,6 +1270,34 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       return 'failed';
     }
 
+    if (job.authorizationBasis === 'prebilling_intent') {
+      const intent = job.prebillingIntentId
+        ? await validatePrebillingProvisioningIntent(deps.db, {
+            intentId: job.prebillingIntentId,
+            clerkUserId: row.clerkUserId,
+            runtimeSlot: row.runtimeSlot,
+            serverType: row.serverType ?? deps.config.serverType,
+            regionSlug: `region_${row.location ?? deps.config.location}`,
+            developerTools: row.developerTools,
+            machineId: row.machineId,
+            now: now().toISOString(),
+          })
+        : undefined;
+      if (!intent) {
+        const failedAt = now().toISOString();
+        await failProvisioningJob(deps.db, job.jobId, failedAt, 'authorization_expired');
+        await updateUserMachine(deps.db, row.machineId, {
+          status: 'failed',
+          failureCode: 'authorization_expired',
+          failureAt: failedAt,
+        });
+        if (propagateFailure) {
+          throw new CustomerVpsError(409, 'invalid_state', 'Provisioning unavailable');
+        }
+        return 'failed';
+      }
+    }
+
     let serverIdForCompensation: number | null = null;
     let adoptedExistingServer = false;
     try {
@@ -1385,7 +1429,13 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         };
       let server = existingServer;
       if (!server) {
-        await assertMachineProviderMutationAllowed(deps, row, createInput.serverType, now());
+        await assertMachineProviderMutationAllowed(
+          deps,
+          row,
+          createInput.serverType,
+          now(),
+          job.authorizationBasis,
+        );
         try {
           if (imageDecision.imageSource === 'snapshot') {
             const selectableSnapshot = await getGoldenSnapshot(deps.db, imageDecision.snapshotId);
@@ -1460,7 +1510,13 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
             targetBundleVersion: imageDecision.targetBundleVersion,
             targetBundleSha256: imageDecision.targetBundleSha256,
           };
-          await assertMachineProviderMutationAllowed(deps, row, createInput.serverType, now());
+          await assertMachineProviderMutationAllowed(
+            deps,
+            row,
+            createInput.serverType,
+            now(),
+            job.authorizationBasis,
+          );
           try {
             server = await deps.hetzner.createServer({
               name: createInput.name,
@@ -1708,6 +1764,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     input: ProvisionRequest | PreviewProvisionRequest,
     provisioningClass: UserMachineProvisioningClass,
     dispatch: NonNullable<ProvisionOptions['dispatch']>,
+    prebillingIntentId?: string,
   ): Promise<ProvisionResponse> {
     const testSnapshotId = provisioningClass === 'preview' && 'testSnapshotId' in input
       ? input.testSnapshotId
@@ -1720,6 +1777,8 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         ? input.accessClerkUserIds
         : [],
     };
+    const requestServerType = 'serverType' in request ? request.serverType : undefined;
+    const requestLocation = 'location' in request ? request.location : undefined;
     const reconcilePreviewAccess = async (
       db: PlatformDB,
       machine: UserMachineRecord,
@@ -1747,7 +1806,21 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       registrationToken: registration.token,
       postgresPassword,
     }, deps.config.platformSecret);
-    const billingContext = provisioningClass === 'preview'
+    const prebillingIntent = provisioningClass === 'customer' && prebillingIntentId
+      ? await validatePrebillingProvisioningIntent(deps.db, {
+          intentId: prebillingIntentId,
+          clerkUserId: request.clerkUserId,
+          runtimeSlot: request.runtimeSlot,
+          serverType: requestServerType ?? '',
+          regionSlug: `region_${requestLocation ?? deps.config.location}`,
+          developerTools: request.developerTools,
+          now: currentTime.toISOString(),
+        })
+      : undefined;
+    if (prebillingIntentId && !prebillingIntent) {
+      throw new CustomerVpsError(409, 'invalid_state', 'Provisioning unavailable');
+    }
+    const billingContext = provisioningClass === 'preview' || prebillingIntent
       ? null
       : await resolveBillingProvisionContext(deps, deps.db, request, currentTime);
 
@@ -1765,6 +1838,9 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       && !(provisioningClass === 'preview' && existingBeforeBundleResolve.runtimeSlot !== request.runtimeSlot)
       && (provisioningClass === 'customer' || existingBeforeBundleResolve.provisioningClass === 'preview')
     ) {
+      if (prebillingIntentId && existingBeforeBundleResolve.prebillingIntentId !== prebillingIntentId) {
+        throw new CustomerVpsError(409, 'invalid_state', 'Provisioning unavailable');
+      }
       const reconciled = await reconcilePreviewAccess(deps.db, existingBeforeBundleResolve);
       const existingJob = await getProvisioningJobByMachineId(deps.db, existingBeforeBundleResolve.machineId);
       if (existingJob && (existingJob.status === 'queued' || existingJob.status === 'running')) {
@@ -1780,10 +1856,24 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       provisionRow = await runInPlatformTransaction(deps.db, async (trx) => {
       // Preview capacity and customer entitlement checks share the owner lock
       // with insertion so concurrent platform instances cannot over-allocate.
-      if (billingContext || provisioningClass === 'preview') {
+      if (billingContext || prebillingIntent || provisioningClass === 'preview') {
         await lockUserMachineProvisioning(trx, request.clerkUserId);
       }
-      const transactionBillingContext = provisioningClass === 'preview'
+      const transactionPrebillingIntent = prebillingIntentId
+        ? await validatePrebillingProvisioningIntent(trx, {
+            intentId: prebillingIntentId,
+            clerkUserId: request.clerkUserId,
+            runtimeSlot: request.runtimeSlot,
+            serverType: requestServerType ?? '',
+            regionSlug: `region_${requestLocation ?? deps.config.location}`,
+            developerTools: request.developerTools,
+            now: currentTime.toISOString(),
+          })
+        : undefined;
+      if (prebillingIntentId && !transactionPrebillingIntent) {
+        throw new CustomerVpsError(409, 'invalid_state', 'Provisioning unavailable');
+      }
+      const transactionBillingContext = provisioningClass === 'preview' || transactionPrebillingIntent
         ? null
         : await resolveBillingProvisionContext(deps, trx, request, currentTime);
       const existing = await findExistingProvisioningMachine(trx, request, provisioningClass);
@@ -1802,6 +1892,9 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       let attempt = 1;
       if (existing) {
         if (existing.status !== 'failed') {
+          if (prebillingIntentId && existing.prebillingIntentId !== prebillingIntentId) {
+            throw new CustomerVpsError(409, 'invalid_state', 'Provisioning unavailable');
+          }
           if (testSnapshotId) {
             await reconcilePreviewAccess(trx, existing);
           }
@@ -1867,7 +1960,9 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           throw billingUpgradeRequired();
         }
       }
-      const serverType = transactionBillingContext?.serverType ?? deps.config.serverType;
+      const serverType = transactionPrebillingIntent?.serverType
+        ?? transactionBillingContext?.serverType
+        ?? deps.config.serverType;
       await insertUserMachine(trx, {
         machineId,
         clerkUserId: request.clerkUserId,
@@ -1884,6 +1979,8 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         registrationTokenExpiresAt: registration.expiresAt,
         provisionedAt: currentTime.toISOString(),
         attempt,
+        activationState: transactionPrebillingIntent ? 'awaiting_billing' : 'authorized',
+        prebillingIntentId: transactionPrebillingIntent?.id ?? null,
       });
       await enqueueProvisioningJob(trx, {
         jobId,
@@ -1891,7 +1988,17 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         encryptedPayload,
         availableAt: currentTime.toISOString(),
         createdAt: currentTime.toISOString(),
+        authorizationBasis: transactionPrebillingIntent ? 'prebilling_intent' : 'billing_entitlement',
+        prebillingIntentId: transactionPrebillingIntent?.id ?? null,
       });
+      if (transactionPrebillingIntent && !await bindPrebillingIntentMachine(trx, {
+        intentId: transactionPrebillingIntent.id,
+        machineId,
+        expectedRevision: transactionPrebillingIntent.revision,
+        now: currentTime.toISOString(),
+      })) {
+        throw new CustomerVpsError(409, 'invalid_state', 'Provisioning unavailable');
+      }
       if (testSnapshotId) {
         const bound = await bindTestSnapshotToPreviewProvisionInTransaction(trx, {
           snapshotId: testSnapshotId,
@@ -1967,6 +2074,13 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       return withLocalProvisionLock(
         `${input.clerkUserId}:${input.runtimeSlot ?? 'primary'}`,
         () => provision(input, 'customer', options?.dispatch ?? 'wait'),
+      );
+    },
+
+    async provisionForCheckout(input, intentId, options) {
+      return withLocalProvisionLock(
+        `${input.clerkUserId}:${input.runtimeSlot ?? 'primary'}`,
+        () => provision(input, 'customer', options?.dispatch ?? 'wait', intentId),
       );
     },
 

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -198,6 +198,7 @@ export interface CustomerVpsService {
   deploy(target?: DeployTarget): Promise<DeployResult>;
   listAllMachines(): Promise<StatusResponse[]>;
   dispatchProvisioningJobs(): Promise<{ checked: number; completed: number; failed: number }>;
+  setPrebillingFallbackReconciler?(reconcile: (() => Promise<unknown>) | undefined): void;
   reconcileProvisioning(): Promise<{ checked: number; failed: number; running: number }>;
 }
 
@@ -582,6 +583,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
   const machineIdFactory = deps.machineIdFactory ?? randomUUID;
   const provisioningJobIdFactory = deps.provisioningJobIdFactory ?? randomUUID;
   const localProvisionLocks = new Map<string, { tail: Promise<void>; depth: number }>();
+  let prebillingFallbackReconciler: (() => Promise<unknown>) | undefined;
 
   async function withLocalProvisionLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
     let lock = localProvisionLocks.get(key);
@@ -3022,6 +3024,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     },
 
     dispatchProvisioningJobs,
+    setPrebillingFallbackReconciler(reconcile) { prebillingFallbackReconciler = reconcile; },
 
     async deploy(target?: DeployTarget): Promise<DeployResult> {
       const runningMachines = await listRunningUserMachines(
@@ -3077,6 +3080,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
 
     async reconcileProvisioning() {
       await dispatchProvisioningJobs();
+      await prebillingFallbackReconciler?.();
       const staleBefore = new Date(now().getTime() - deps.config.reconciliationStaleAfterMs).toISOString();
       const rows = await listStaleUserMachines(
         deps.db,

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -2277,7 +2277,7 @@ function mapUserMachine(row: Selectable<UserMachinesTable>): UserMachineRecord {
     resizeStartedAt: row.resize_started_at,
     resizeTargetServerType: row.resize_target_server_type,
     attempt: row.attempt,
-    activationState: z.enum(['awaiting_billing', 'authorized']).parse(row.activation_state),
+    activationState: z.enum(['awaiting_billing', 'authorized']).parse(row.activation_state ?? 'authorized'),
     prebillingIntentId: row.prebilling_intent_id,
     activationAuthorizedAt: row.activation_authorized_at,
   };

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -1,5 +1,15 @@
 import { randomUUID } from 'node:crypto';
-import { Kysely, PostgresDialect, sql, type Generated, type InsertObject, type Transaction } from 'kysely';
+import {
+  Kysely,
+  PostgresDialect,
+  sql,
+  type Generated,
+  type Insertable,
+  type InsertObject,
+  type Selectable,
+  type Transaction,
+  type Updateable,
+} from 'kysely';
 import pg from 'pg';
 import { z } from 'zod/v4';
 import type {
@@ -82,6 +92,9 @@ interface UserMachinesTable {
   resize_started_at: string | null;
   resize_target_server_type: string | null;
   attempt: number;
+  activation_state: Generated<string>;
+  prebilling_intent_id: Generated<string | null>;
+  activation_authorized_at: Generated<string | null>;
 }
 
 export interface ProvisioningJobsTable {
@@ -106,6 +119,8 @@ export interface ProvisioningJobsTable {
   activation_step: string;
   provider_create_action_id: number | null;
   fallback_reason: string | null;
+  authorization_basis: Generated<string>;
+  prebilling_intent_id: Generated<string | null>;
 }
 
 interface HostBundleReleasesTable {
@@ -505,6 +520,33 @@ interface BillingCheckoutAttemptsTable {
   resolved_at: string | null;
 }
 
+export interface PrebillingProvisioningIntentsTable {
+  id: string;
+  checkout_attempt_id: string;
+  clerk_user_id: string;
+  runtime_slot: string;
+  plan_slug: string;
+  billing_interval: string;
+  server_type: string;
+  region_slug: string;
+  developer_tools: string;
+  state: string;
+  revision: number;
+  machine_id: string | null;
+  stripe_session_id: string | null;
+  stripe_session_expires_at: string | null;
+  lease_expires_at: string | null;
+  reserved_hourly_cost_micros: number;
+  cleanup_claimed_at: string | null;
+  cleanup_lease_expires_at: string | null;
+  ready_at: string | null;
+  authorized_at: string | null;
+  cleaned_at: string | null;
+  last_error_code: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 interface BillingTrialAccountsTable {
   clerk_user_id: string;
   trial_checkout_attempt_id: string | null;
@@ -535,6 +577,7 @@ export interface PlatformDatabase {
   user_machines: UserMachinesTable;
   provisioning_jobs: ProvisioningJobsTable;
   billing_checkout_attempts: BillingCheckoutAttemptsTable;
+  prebilling_provisioning_intents: PrebillingProvisioningIntentsTable;
   billing_trial_accounts: BillingTrialAccountsTable;
   onboarding_first_run: OnboardingFirstRunTable;
   onboarding_journey_events: OnboardingJourneyEventsTable;
@@ -664,6 +707,9 @@ export interface UserMachineRecord {
   resizeStartedAt: string | null;
   resizeTargetServerType: string | null;
   attempt: number;
+  activationState: 'awaiting_billing' | 'authorized';
+  prebillingIntentId: string | null;
+  activationAuthorizedAt: string | null;
 }
 
 export type BillingCheckoutAttemptStatus = 'creating' | 'open' | 'paid' | 'expired' | 'abandoned';
@@ -950,6 +996,9 @@ export interface NewUserMachine {
   resizeStartedAt?: string | null;
   resizeTargetServerType?: string | null;
   attempt?: number;
+  activationState?: 'awaiting_billing' | 'authorized';
+  prebillingIntentId?: string | null;
+  activationAuthorizedAt?: string | null;
 }
 
 export const UserMachineProvisioningClassSchema = z.enum(['customer', 'preview']);
@@ -1061,7 +1110,10 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
       failure_at TEXT,
       resize_started_at TEXT,
       resize_target_server_type TEXT,
-      attempt INTEGER NOT NULL DEFAULT 1
+      attempt INTEGER NOT NULL DEFAULT 1,
+      activation_state TEXT NOT NULL DEFAULT 'authorized',
+      prebilling_intent_id TEXT,
+      activation_authorized_at TEXT
     )
   `.execute(db);
   await sql`ALTER TABLE user_machines ADD COLUMN IF NOT EXISTS runtime_slot TEXT NOT NULL DEFAULT 'primary'`.execute(db);
@@ -1081,6 +1133,10 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
   await sql`ALTER TABLE user_machines ADD COLUMN IF NOT EXISTS resize_started_at TEXT`.execute(db);
   await sql`ALTER TABLE user_machines ADD COLUMN IF NOT EXISTS resize_target_server_type TEXT`.execute(db);
   await sql`ALTER TABLE user_machines ADD COLUMN IF NOT EXISTS attempt INTEGER NOT NULL DEFAULT 1`.execute(db);
+  await sql`ALTER TABLE user_machines ADD COLUMN IF NOT EXISTS activation_state TEXT NOT NULL DEFAULT 'authorized'`.execute(db);
+  await sql`ALTER TABLE user_machines ADD COLUMN IF NOT EXISTS prebilling_intent_id TEXT`.execute(db);
+  await sql`ALTER TABLE user_machines ADD COLUMN IF NOT EXISTS activation_authorized_at TEXT`.execute(db);
+  await sql`CREATE UNIQUE INDEX IF NOT EXISTS idx_user_machines_prebilling_intent ON user_machines(prebilling_intent_id) WHERE prebilling_intent_id IS NOT NULL`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_user_machines_status ON user_machines(status)`.execute(db);
   await sql`ALTER TABLE user_machines DROP CONSTRAINT IF EXISTS user_machines_clerk_user_id_key`.execute(db);
   await sql`DROP INDEX IF EXISTS idx_user_machines_clerk`.execute(db);
@@ -1120,7 +1176,9 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
       last_error_code TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL,
-      completed_at TEXT
+      completed_at TEXT,
+      authorization_basis TEXT NOT NULL DEFAULT 'billing_entitlement',
+      prebilling_intent_id TEXT
     )
   `.execute(db);
   await sql`ALTER TABLE provisioning_jobs ADD COLUMN IF NOT EXISTS target_bundle_version TEXT`.execute(db);
@@ -1132,6 +1190,8 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
   await sql`ALTER TABLE provisioning_jobs ADD COLUMN IF NOT EXISTS activation_step TEXT NOT NULL DEFAULT 'selecting'`.execute(db);
   await sql`ALTER TABLE provisioning_jobs ADD COLUMN IF NOT EXISTS provider_create_action_id BIGINT`.execute(db);
   await sql`ALTER TABLE provisioning_jobs ADD COLUMN IF NOT EXISTS fallback_reason TEXT`.execute(db);
+  await sql`ALTER TABLE provisioning_jobs ADD COLUMN IF NOT EXISTS authorization_basis TEXT NOT NULL DEFAULT 'billing_entitlement'`.execute(db);
+  await sql`ALTER TABLE provisioning_jobs ADD COLUMN IF NOT EXISTS prebilling_intent_id TEXT`.execute(db);
   await sql`
     CREATE INDEX IF NOT EXISTS idx_provisioning_jobs_dispatch
     ON provisioning_jobs(status, available_at, lease_expires_at)
@@ -1187,6 +1247,40 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
     ON billing_checkout_attempts(clerk_user_id, runtime_slot)
     WHERE status IN ('creating', 'open')
   `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS prebilling_provisioning_intents (
+      id TEXT PRIMARY KEY,
+      checkout_attempt_id TEXT NOT NULL UNIQUE REFERENCES billing_checkout_attempts(id) ON DELETE CASCADE,
+      clerk_user_id TEXT NOT NULL,
+      runtime_slot TEXT NOT NULL,
+      plan_slug TEXT NOT NULL,
+      billing_interval TEXT NOT NULL,
+      server_type TEXT NOT NULL,
+      region_slug TEXT NOT NULL,
+      developer_tools TEXT NOT NULL,
+      state TEXT NOT NULL,
+      revision INTEGER NOT NULL DEFAULT 1,
+      machine_id TEXT UNIQUE REFERENCES user_machines(machine_id) ON UPDATE CASCADE,
+      stripe_session_id TEXT,
+      stripe_session_expires_at TEXT,
+      lease_expires_at TEXT,
+      reserved_hourly_cost_micros BIGINT NOT NULL DEFAULT 0,
+      cleanup_claimed_at TEXT,
+      cleanup_lease_expires_at TEXT,
+      ready_at TEXT,
+      authorized_at TEXT,
+      cleaned_at TEXT,
+      last_error_code TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `.execute(db);
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_prebilling_intents_active_owner_slot
+    ON prebilling_provisioning_intents(clerk_user_id, runtime_slot)
+    WHERE state IN ('awaiting_checkout', 'preparing', 'ready_waiting_for_billing', 'payment_settling', 'preparation_failed', 'preparation_deferred', 'cleanup_pending')
+  `.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_prebilling_intents_cleanup ON prebilling_provisioning_intents(state, lease_expires_at)`.execute(db);
   await sql`
     CREATE TABLE IF NOT EXISTS billing_trial_accounts (
       clerk_user_id TEXT PRIMARY KEY,
@@ -2142,7 +2236,7 @@ function toPlatformUserRow(record: NewPlatformUser): InsertObject<PlatformDataba
   };
 }
 
-function mapUserMachine(row: UserMachinesTable): UserMachineRecord {
+function mapUserMachine(row: Selectable<UserMachinesTable>): UserMachineRecord {
   return {
     machineId: row.machine_id,
     clerkUserId: row.clerk_user_id,
@@ -2178,10 +2272,13 @@ function mapUserMachine(row: UserMachinesTable): UserMachineRecord {
     resizeStartedAt: row.resize_started_at,
     resizeTargetServerType: row.resize_target_server_type,
     attempt: row.attempt,
+    activationState: z.enum(['awaiting_billing', 'authorized']).parse(row.activation_state),
+    prebillingIntentId: row.prebilling_intent_id,
+    activationAuthorizedAt: row.activation_authorized_at,
   };
 }
 
-function toUserMachineRow(record: NewUserMachine): UserMachinesTable {
+function toUserMachineRow(record: NewUserMachine): Insertable<UserMachinesTable> {
   return {
     machine_id: record.machineId,
     clerk_user_id: record.clerkUserId,
@@ -2215,11 +2312,14 @@ function toUserMachineRow(record: NewUserMachine): UserMachinesTable {
     resize_started_at: record.resizeStartedAt ?? null,
     resize_target_server_type: record.resizeTargetServerType ?? null,
     attempt: record.attempt ?? 1,
+    activation_state: record.activationState ?? 'authorized',
+    prebilling_intent_id: record.prebillingIntentId ?? null,
+    activation_authorized_at: record.activationAuthorizedAt ?? null,
   };
 }
 
-function toUserMachineUpdate(values: Partial<NewUserMachine>): Partial<UserMachinesTable> {
-  const update: Partial<UserMachinesTable> = {};
+function toUserMachineUpdate(values: Partial<NewUserMachine>): Updateable<UserMachinesTable> {
+  const update: Updateable<UserMachinesTable> = {};
   if (values.machineId !== undefined) update.machine_id = values.machineId;
   if (values.clerkUserId !== undefined) update.clerk_user_id = values.clerkUserId;
   if (values.handle !== undefined) update.handle = values.handle;
@@ -2252,6 +2352,9 @@ function toUserMachineUpdate(values: Partial<NewUserMachine>): Partial<UserMachi
   if (values.resizeStartedAt !== undefined) update.resize_started_at = values.resizeStartedAt;
   if (values.resizeTargetServerType !== undefined) update.resize_target_server_type = values.resizeTargetServerType;
   if (values.attempt !== undefined) update.attempt = values.attempt;
+  if (values.activationState !== undefined) update.activation_state = values.activationState;
+  if (values.prebillingIntentId !== undefined) update.prebilling_intent_id = values.prebillingIntentId;
+  if (values.activationAuthorizedAt !== undefined) update.activation_authorized_at = values.activationAuthorizedAt;
   return update;
 }
 

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -1280,6 +1280,11 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
     ON prebilling_provisioning_intents(clerk_user_id, runtime_slot)
     WHERE state IN ('awaiting_checkout', 'preparing', 'ready_waiting_for_billing', 'payment_settling', 'preparation_failed', 'preparation_deferred', 'cleanup_pending')
   `.execute(db);
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_prebilling_intents_stripe_session
+    ON prebilling_provisioning_intents(stripe_session_id)
+    WHERE stripe_session_id IS NOT NULL
+  `.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_prebilling_intents_cleanup ON prebilling_provisioning_intents(state, lease_expires_at)`.execute(db);
   await sql`
     CREATE TABLE IF NOT EXISTS billing_trial_accounts (

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -3314,6 +3314,7 @@ export async function getAccessibleActiveUserMachineByClerkId(
     .selectFrom('user_machines')
     .selectAll()
     .where(accessibleUserMachinePredicate(clerkUserId))
+    .where('activation_state', '=', 'authorized')
     .where('deleted_at', 'is', null);
   if (runtimeSlot) {
     query = query.where('runtime_slot', '=', runtimeSlot);
@@ -3359,6 +3360,7 @@ export async function getRunningUserMachineByHandle(
     .selectAll()
     .where('handle', '=', handle)
     .where('status', '=', 'running')
+    .where('activation_state', '=', 'authorized')
     .where('deleted_at', 'is', null);
   if (runtimeSlot) {
     query = query.where('runtime_slot', '=', runtimeSlot);
@@ -3383,6 +3385,7 @@ export async function getRunningUserMachineByClerkId(
     .where('clerk_user_id', '=', clerkUserId)
     .where('runtime_slot', '=', runtimeSlot)
     .where('status', '=', 'running')
+    .where('activation_state', '=', 'authorized')
     .where('deleted_at', 'is', null)
     .executeTakeFirst();
   return row ? mapUserMachine(row) : undefined;
@@ -3400,6 +3403,7 @@ export async function getAccessibleRunningUserMachineByClerkId(
     .where(accessibleUserMachinePredicate(clerkUserId))
     .where('runtime_slot', '=', runtimeSlot)
     .where('status', '=', 'running')
+    .where('activation_state', '=', 'authorized')
     .where('deleted_at', 'is', null)
     .executeTakeFirst();
   return row ? mapUserMachine(row) : undefined;
@@ -3417,6 +3421,7 @@ export async function getRunningUserMachineByClerkIdForUpdate(
     .where('clerk_user_id', '=', clerkUserId)
     .where('runtime_slot', '=', runtimeSlot)
     .where('status', '=', 'running')
+    .where('activation_state', '=', 'authorized')
     .where('deleted_at', 'is', null)
     .forUpdate()
     .executeTakeFirst();
@@ -4228,7 +4233,11 @@ export async function claimCheckoutAttempt(
   }
   const sameSelection = activeRow.plan_slug === record.planSlug
     && activeRow.billing_interval === record.billingInterval
-    && activeRow.region_slug === record.regionSlug;
+    && activeRow.region_slug === record.regionSlug
+    && activeRow.server_type === (record.serverType ?? null)
+    && activeRow.trial_period_days === (record.trialPeriodDays ?? null)
+    && activeRow.developer_tools
+      === serializeDeveloperTools(record.developerTools ?? DEFAULT_DEVELOPER_TOOLS);
   const retryAgeMs = Date.parse(record.createdAt) - Date.parse(activeRow.created_at);
   const withinIdempotencyWindow = Number.isFinite(retryAgeMs)
     && retryAgeMs >= 0

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -553,6 +553,9 @@ export function createApp(deps: {
         }),
       })
     : undefined;
+  deps.customerVpsService?.setPrebillingFallbackReconciler?.(
+    prebilling ? async () => { await prebilling.reconcileFallbacks?.(); } : undefined,
+  );
   app.route('/billing', createBillingRoutes({
     db,
     stripe: appEnv.STRIPE_SECRET_KEY

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -56,6 +56,8 @@ import {
 } from './billing.js';
 import { resolveEffectiveBillingEntitlementForSlot } from './billing-entitlement-resolver.js';
 import { createBillingRoutes } from './billing-routes.js';
+import { createPrebillingProvisioningCoordinator } from './prebilling-provisioning.js';
+import { loadPrebillingProvisioningConfig } from './prebilling-provisioning-config.js';
 import { createJourneyRoutes, createJourneyUserResolver } from './journey-routes.js';
 import {
   sanitizeProxyResponseHeaders,
@@ -536,6 +538,21 @@ export function createApp(deps: {
     getGatewayUrlForHandle,
   }));
 
+  const prebilling = deps.customerVpsService
+    ? createPrebillingProvisioningCoordinator({
+        db,
+        config: loadPrebillingProvisioningConfig(appEnv),
+        customerVpsService: deps.customerVpsService,
+        resolveIdentity: (clerkUserId) => selectProvisionIdentityForClerkUser(db, clerkUserId, appEnv),
+        onProvisioned: async (provisioned) => ensureProvisionedPlatformUser(db, {
+          clerkUserId: provisioned.clerkUserId,
+          handle: provisioned.handle,
+          displayName: provisioned.displayName,
+          email: provisioned.email,
+          runtimeId: `vps:${provisioned.machineId}`,
+        }),
+      })
+    : undefined;
   app.route('/billing', createBillingRoutes({
     db,
     stripe: appEnv.STRIPE_SECRET_KEY
@@ -544,6 +561,7 @@ export function createApp(deps: {
     env: appEnv,
     resolveClerkUserId: resolveBillingClerkUserId,
     captureEvent: captureFunnelEvent,
+    prebilling,
   }));
 
   // Onboarding journey (spec 092): one server-owned signup-to-ready state every

--- a/packages/platform/src/prebilling-provisioning-config.ts
+++ b/packages/platform/src/prebilling-provisioning-config.ts
@@ -1,0 +1,77 @@
+import { createHash } from 'node:crypto';
+import { z } from 'zod/v4';
+
+const MAX_COST_ENTRIES = 20;
+const ServerTypeSchema = z.string().min(3).max(64).regex(/^[a-z0-9][a-z0-9-]*$/);
+const CostMapSchema = z.record(ServerTypeSchema, z.number().int().positive().max(Number.MAX_SAFE_INTEGER));
+
+export interface PrebillingProvisioningConfig {
+  enabled: boolean;
+  rolloutPercent: number;
+  allowlist: ReadonlySet<string>;
+  maxActive: number;
+  maxHourlyCostMicros: number;
+  leaseMs: number;
+  serverHourlyCostMicros: ReadonlyMap<string, number>;
+}
+
+function boundedInteger(value: string | undefined, fallback: number, min: number, max: number): number {
+  if (value === undefined || value.trim() === '') return fallback;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= min && parsed <= max ? parsed : fallback;
+}
+
+function parseAllowlist(value: string | undefined): ReadonlySet<string> {
+  if (!value) return new Set();
+  return new Set(value.split(',').map((item) => item.trim()).filter((item) => /^[A-Za-z0-9_-]{3,256}$/.test(item)).slice(0, 100));
+}
+
+function parseCosts(value: string | undefined): ReadonlyMap<string, number> {
+  if (!value) return new Map();
+  try {
+    const parsed = CostMapSchema.parse(JSON.parse(value));
+    const entries = Object.entries(parsed);
+    return entries.length <= MAX_COST_ENTRIES ? new Map(entries) : new Map();
+  } catch (err: unknown) {
+    if (err instanceof SyntaxError || err instanceof z.ZodError) return new Map();
+    throw err;
+  }
+}
+
+export function loadPrebillingProvisioningConfig(env: NodeJS.ProcessEnv): PrebillingProvisioningConfig {
+  const enabled = env.MATRIX_PREBILLING_PROVISIONING_ENABLED === 'true';
+  return {
+    enabled,
+    rolloutPercent: enabled
+      ? boundedInteger(env.MATRIX_PREBILLING_PROVISIONING_ROLLOUT_PERCENT, 0, 0, 100)
+      : 0,
+    allowlist: parseAllowlist(env.MATRIX_PREBILLING_PROVISIONING_ALLOWLIST),
+    maxActive: enabled
+      ? boundedInteger(env.MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE, 0, 0, 10_000)
+      : 0,
+    maxHourlyCostMicros: enabled
+      ? boundedInteger(env.MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS, 0, 0, Number.MAX_SAFE_INTEGER)
+      : 0,
+    leaseMs: 30 * 60 * 1_000,
+    serverHourlyCostMicros: parseCosts(env.MATRIX_PREBILLING_PROVISIONING_COSTS_JSON),
+  };
+}
+
+export function prebillingRolloutIncludesUser(
+  config: PrebillingProvisioningConfig,
+  clerkUserId: string,
+): boolean {
+  if (!config.enabled || config.maxActive <= 0 || config.maxHourlyCostMicros <= 0) return false;
+  if (config.allowlist.has(clerkUserId)) return true;
+  if (config.rolloutPercent <= 0) return false;
+  if (config.rolloutPercent >= 100) return true;
+  const bucket = createHash('sha256').update(`prebilling:${clerkUserId}`).digest().readUInt32BE(0) % 100;
+  return bucket < config.rolloutPercent;
+}
+
+export function prebillingHourlyCostMicros(
+  config: PrebillingProvisioningConfig,
+  serverType: string,
+): number | null {
+  return config.serverHourlyCostMicros.get(serverType.trim().toLowerCase()) ?? null;
+}

--- a/packages/platform/src/prebilling-provisioning-config.ts
+++ b/packages/platform/src/prebilling-provisioning-config.ts
@@ -52,7 +52,11 @@ export function loadPrebillingProvisioningConfig(env: NodeJS.ProcessEnv): Prebil
     maxHourlyCostMicros: enabled
       ? boundedInteger(env.MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS, 0, 0, Number.MAX_SAFE_INTEGER)
       : 0,
-    leaseMs: 30 * 60 * 1_000,
+    // Stripe validates the 30-minute minimum when its server receives the
+    // request. Keep one minute of bounded transport/clock-skew headroom so an
+    // otherwise valid checkout is not rejected after spending a few seconds
+    // in transit.
+    leaseMs: 31 * 60 * 1_000,
     serverHourlyCostMicros: parseCosts(env.MATRIX_PREBILLING_PROVISIONING_COSTS_JSON),
   };
 }

--- a/packages/platform/src/prebilling-provisioning-store.ts
+++ b/packages/platform/src/prebilling-provisioning-store.ts
@@ -1,7 +1,8 @@
+import { randomUUID } from 'node:crypto';
 import { sql } from 'kysely';
 import { z } from 'zod/v4';
 import type { MatrixBillingInterval, MatrixBillingPlanSlug } from './billing.js';
-import type { PlatformDB, PrebillingProvisioningIntentsTable } from './db.js';
+import { insertProviderDeletion, type PlatformDB, type PrebillingProvisioningIntentsTable } from './db.js';
 import {
   canonicalizeDeveloperTools,
   parseDeveloperToolsJson,
@@ -112,6 +113,16 @@ export async function getPrebillingIntentByCheckoutAttempt(
   await db.ready;
   const row = await db.executor.selectFrom('prebilling_provisioning_intents').selectAll()
     .where('checkout_attempt_id', '=', checkoutAttemptId).executeTakeFirst();
+  return row ? mapIntent(row) : undefined;
+}
+
+export async function getPrebillingIntent(
+  db: PlatformDB,
+  intentId: string,
+): Promise<PrebillingProvisioningIntent | undefined> {
+  await db.ready;
+  const row = await db.executor.selectFrom('prebilling_provisioning_intents').selectAll()
+    .where('id', '=', intentId).executeTakeFirst();
   return row ? mapIntent(row) : undefined;
 }
 
@@ -267,4 +278,108 @@ export async function bindPrebillingIntentMachine(
     .where('machine_id', 'is', null)
     .returning('id').executeTakeFirst();
   return Boolean(row);
+}
+
+/** Must be called inside the signed billing projection transaction. */
+export async function authorizePrebillingIntent(
+  db: PlatformDB,
+  input: { intentId: string; clerkUserId: string; runtimeSlot: string; now: string },
+): Promise<{ authorized: boolean; machineId: string | null; needsFallback: boolean }> {
+  await db.ready;
+  const current = await db.executor.selectFrom('prebilling_provisioning_intents').selectAll()
+    .where('id', '=', input.intentId)
+    .where('clerk_user_id', '=', input.clerkUserId)
+    .where('runtime_slot', '=', input.runtimeSlot)
+    .forUpdate().executeTakeFirst();
+  if (!current) return { authorized: false, machineId: null, needsFallback: false };
+  const intent = mapIntent(current);
+  if (intent.state === 'authorized') {
+    return { authorized: true, machineId: intent.machineId, needsFallback: intent.machineId === null };
+  }
+  if (intent.machineId) {
+    const activated = await db.executor.updateTable('user_machines').set({
+      activation_state: 'authorized',
+      activation_authorized_at: input.now,
+    }).where('machine_id', '=', intent.machineId)
+      .where('prebilling_intent_id', '=', intent.id)
+      .where('clerk_user_id', '=', input.clerkUserId)
+      .where('runtime_slot', '=', input.runtimeSlot)
+      .where('activation_state', '=', 'awaiting_billing')
+      .returning('machine_id').executeTakeFirst();
+    if (!activated) throw new Error('prebilling_machine_activation_mismatch');
+  }
+  const authorized = await db.executor.updateTable('prebilling_provisioning_intents').set({
+    state: 'authorized',
+    authorized_at: input.now,
+    lease_expires_at: null,
+    reserved_hourly_cost_micros: 0,
+    revision: intent.revision + 1,
+    updated_at: input.now,
+  }).where('id', '=', intent.id).where('revision', '=', intent.revision)
+    .returning('id').executeTakeFirst();
+  if (!authorized) throw new Error('prebilling_authorization_conflict');
+  return { authorized: true, machineId: intent.machineId, needsFallback: intent.machineId === null };
+}
+
+/** Must be called inside the verified Stripe webhook transaction. */
+export async function cleanupExpiredPrebillingCheckout(
+  db: PlatformDB,
+  input: { stripeSessionId: string; now: string },
+): Promise<{ cleaned: boolean; intentId: string | null }> {
+  await db.ready;
+  const current = await db.executor.selectFrom('prebilling_provisioning_intents').selectAll()
+    .where('stripe_session_id', '=', input.stripeSessionId).forUpdate().executeTakeFirst();
+  if (!current) return { cleaned: false, intentId: null };
+  const intent = mapIntent(current);
+  if (intent.state === 'authorized' || intent.state === 'cleaned') {
+    return { cleaned: false, intentId: intent.id };
+  }
+  if (intent.machineId) {
+    const machine = await db.executor.selectFrom('user_machines').selectAll()
+      .where('machine_id', '=', intent.machineId).forUpdate().executeTakeFirst();
+    if (machine && machine.activation_state !== 'authorized' && machine.deleted_at === null) {
+      await db.executor.updateTable('user_machines').set({
+        status: 'deleted',
+        deleted_at: input.now,
+        registration_token_hash: null,
+        registration_token_expires_at: null,
+        failure_code: 'checkout_expired',
+        failure_at: input.now,
+      }).where('machine_id', '=', machine.machine_id)
+        .where('activation_state', '=', 'awaiting_billing').execute();
+      await db.executor.updateTable('provisioning_jobs').set({
+        status: 'failed',
+        encrypted_payload: null,
+        last_error_code: 'checkout_expired',
+        updated_at: input.now,
+        completed_at: input.now,
+      }).where('machine_id', '=', machine.machine_id)
+        .where('status', 'in', ['queued', 'running']).execute();
+      if (machine.hetzner_server_id !== null) {
+        await insertProviderDeletion(db, {
+          id: randomUUID(),
+          providerServerId: machine.hetzner_server_id,
+          reason: 'prebilling_checkout_expired',
+          machineId: machine.machine_id,
+          handle: machine.handle,
+          nextAttemptAt: input.now,
+          createdAt: input.now,
+        });
+      }
+    } else if (machine?.activation_state === 'authorized') {
+      return { cleaned: false, intentId: intent.id };
+    }
+  }
+  const cleaned = await db.executor.updateTable('prebilling_provisioning_intents').set({
+    state: 'cleaned',
+    machine_id: null,
+    cleaned_at: input.now,
+    lease_expires_at: null,
+    reserved_hourly_cost_micros: 0,
+    revision: intent.revision + 1,
+    updated_at: input.now,
+  }).where('id', '=', intent.id).where('revision', '=', intent.revision)
+    .where('state', '!=', 'authorized').returning('id').executeTakeFirst();
+  if (!cleaned) throw new Error('prebilling_cleanup_conflict');
+  return { cleaned: true, intentId: intent.id };
 }

--- a/packages/platform/src/prebilling-provisioning-store.ts
+++ b/packages/platform/src/prebilling-provisioning-store.ts
@@ -126,6 +126,30 @@ export async function getPrebillingIntent(
   return row ? mapIntent(row) : undefined;
 }
 
+export async function listAuthorizedPrebillingFallbackIntents(
+  db: PlatformDB,
+  limit = 20,
+): Promise<PrebillingProvisioningIntent[]> {
+  await db.ready;
+  const rows = await db.executor.selectFrom('prebilling_provisioning_intents').selectAll()
+    .where('state', '=', 'authorized').where('machine_id', 'is', null)
+    .orderBy('authorized_at', 'asc').limit(Math.max(1, Math.min(100, Math.trunc(limit)))).execute();
+  return rows.map(mapIntent);
+}
+
+export async function bindAuthorizedPrebillingFallbackMachine(
+  db: PlatformDB,
+  input: { intentId: string; clerkUserId: string; runtimeSlot: string; machineId: string; now: string },
+): Promise<boolean> {
+  await db.ready;
+  const result = await sql<{ id: string }>`UPDATE prebilling_provisioning_intents SET machine_id = ${input.machineId}, revision = revision + 1, updated_at = ${input.now}
+    WHERE id = ${input.intentId} AND clerk_user_id = ${input.clerkUserId} AND runtime_slot = ${input.runtimeSlot} AND state = 'authorized'
+      AND (machine_id IS NULL OR machine_id = ${input.machineId}) AND EXISTS (SELECT 1 FROM user_machines WHERE machine_id = ${input.machineId}
+        AND clerk_user_id = ${input.clerkUserId} AND runtime_slot = ${input.runtimeSlot} AND activation_state = 'authorized' AND deleted_at IS NULL)
+    RETURNING id`.execute(db.executor);
+  return result.rows.length === 1;
+}
+
 export async function getActivePrebillingIntent(
   db: PlatformDB,
   clerkUserId: string,

--- a/packages/platform/src/prebilling-provisioning-store.ts
+++ b/packages/platform/src/prebilling-provisioning-store.ts
@@ -324,11 +324,21 @@ export async function authorizePrebillingIntent(
 /** Must be called inside the verified Stripe webhook transaction. */
 export async function cleanupExpiredPrebillingCheckout(
   db: PlatformDB,
-  input: { stripeSessionId: string; now: string },
+  input: { stripeSessionId: string; intentId?: string; clerkUserId?: string; now: string },
 ): Promise<{ cleaned: boolean; intentId: string | null }> {
   await db.ready;
   const current = await db.executor.selectFrom('prebilling_provisioning_intents').selectAll()
-    .where('stripe_session_id', '=', input.stripeSessionId).forUpdate().executeTakeFirst();
+    .where((eb) => input.intentId
+      ? eb.or([
+          eb('stripe_session_id', '=', input.stripeSessionId),
+          eb.and([
+            eb('id', '=', input.intentId),
+            ...(input.clerkUserId ? [eb('clerk_user_id', '=', input.clerkUserId)] : []),
+            eb('stripe_session_id', 'is', null),
+          ]),
+        ])
+      : eb('stripe_session_id', '=', input.stripeSessionId))
+    .forUpdate().executeTakeFirst();
   if (!current) return { cleaned: false, intentId: null };
   const intent = mapIntent(current);
   if (intent.state === 'authorized' || intent.state === 'cleaned') {

--- a/packages/platform/src/prebilling-provisioning-store.ts
+++ b/packages/platform/src/prebilling-provisioning-store.ts
@@ -128,22 +128,47 @@ export async function getPrebillingIntent(
 
 export async function listAuthorizedPrebillingFallbackIntents(
   db: PlatformDB,
+  now: string,
   limit = 20,
 ): Promise<PrebillingProvisioningIntent[]> {
   await db.ready;
   const rows = await db.executor.selectFrom('prebilling_provisioning_intents').selectAll()
     .where('state', '=', 'authorized').where('machine_id', 'is', null)
+    .where((eb) => eb.or([eb('lease_expires_at', 'is', null), eb('lease_expires_at', '<=', now)]))
     .orderBy('authorized_at', 'asc').limit(Math.max(1, Math.min(100, Math.trunc(limit)))).execute();
   return rows.map(mapIntent);
 }
 
+export async function claimAuthorizedPrebillingFallbackIntent(
+  db: PlatformDB,
+  input: { intentId: string; now: string; leaseExpiresAt: string },
+): Promise<PrebillingProvisioningIntent | undefined> {
+  await db.ready;
+  const row = await db.executor.updateTable('prebilling_provisioning_intents').set({
+    lease_expires_at: input.leaseExpiresAt, updated_at: input.now,
+  }).where('id', '=', input.intentId).where('state', '=', 'authorized').where('machine_id', 'is', null)
+    .where((eb) => eb.or([eb('lease_expires_at', 'is', null), eb('lease_expires_at', '<=', input.now)]))
+    .returningAll().executeTakeFirst();
+  return row ? mapIntent(row) : undefined;
+}
+
+export async function releaseAuthorizedPrebillingFallbackClaim(
+  db: PlatformDB,
+  input: { intentId: string; leaseExpiresAt: string; now: string },
+): Promise<void> {
+  await db.ready;
+  await db.executor.updateTable('prebilling_provisioning_intents').set({ lease_expires_at: null, updated_at: input.now })
+    .where('id', '=', input.intentId).where('state', '=', 'authorized')
+    .where('machine_id', 'is', null).where('lease_expires_at', '=', input.leaseExpiresAt).execute();
+}
+
 export async function bindAuthorizedPrebillingFallbackMachine(
   db: PlatformDB,
-  input: { intentId: string; clerkUserId: string; runtimeSlot: string; machineId: string; now: string },
+  input: { intentId: string; clerkUserId: string; runtimeSlot: string; machineId: string; leaseExpiresAt: string; now: string },
 ): Promise<boolean> {
   await db.ready;
   const result = await sql<{ id: string }>`UPDATE prebilling_provisioning_intents SET machine_id = ${input.machineId}, revision = revision + 1, updated_at = ${input.now}
-    WHERE id = ${input.intentId} AND clerk_user_id = ${input.clerkUserId} AND runtime_slot = ${input.runtimeSlot} AND state = 'authorized'
+    WHERE id = ${input.intentId} AND clerk_user_id = ${input.clerkUserId} AND runtime_slot = ${input.runtimeSlot} AND state = 'authorized' AND lease_expires_at = ${input.leaseExpiresAt}
       AND (machine_id IS NULL OR machine_id = ${input.machineId}) AND EXISTS (SELECT 1 FROM user_machines WHERE machine_id = ${input.machineId}
         AND clerk_user_id = ${input.clerkUserId} AND runtime_slot = ${input.runtimeSlot} AND activation_state = 'authorized' AND deleted_at IS NULL)
     RETURNING id`.execute(db.executor);

--- a/packages/platform/src/prebilling-provisioning-store.ts
+++ b/packages/platform/src/prebilling-provisioning-store.ts
@@ -1,0 +1,270 @@
+import { sql } from 'kysely';
+import { z } from 'zod/v4';
+import type { MatrixBillingInterval, MatrixBillingPlanSlug } from './billing.js';
+import type { PlatformDB, PrebillingProvisioningIntentsTable } from './db.js';
+import {
+  canonicalizeDeveloperTools,
+  parseDeveloperToolsJson,
+  serializeDeveloperTools,
+  type DeveloperToolId,
+} from './developer-tools.js';
+
+const PrebillingIntentStateSchema = z.enum([
+  'awaiting_checkout',
+  'preparing',
+  'ready_waiting_for_billing',
+  'payment_settling',
+  'preparation_failed',
+  'preparation_deferred',
+  'cleanup_pending',
+  'checkout_failed',
+  'authorized',
+  'cleaned',
+]);
+
+export type PrebillingIntentState = z.infer<typeof PrebillingIntentStateSchema>;
+
+export interface PrebillingProvisioningIntent {
+  id: string;
+  checkoutAttemptId: string;
+  clerkUserId: string;
+  runtimeSlot: string;
+  planSlug: MatrixBillingPlanSlug;
+  billingInterval: MatrixBillingInterval;
+  serverType: string;
+  regionSlug: string;
+  developerTools: DeveloperToolId[];
+  state: PrebillingIntentState;
+  revision: number;
+  machineId: string | null;
+  stripeSessionId: string | null;
+  stripeSessionExpiresAt: string | null;
+  leaseExpiresAt: string | null;
+  reservedHourlyCostMicros: number;
+  authorizedAt: string | null;
+  cleanedAt: string | null;
+  lastErrorCode: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface NewPrebillingIntent {
+  id: string;
+  checkoutAttemptId: string;
+  clerkUserId: string;
+  runtimeSlot: 'primary';
+  planSlug: MatrixBillingPlanSlug;
+  billingInterval: MatrixBillingInterval;
+  serverType: string;
+  regionSlug: string;
+  developerTools: DeveloperToolId[];
+  createdAt: string;
+}
+
+const ACTIVE_CAPACITY_STATES: PrebillingIntentState[] = [
+  'preparing',
+  'ready_waiting_for_billing',
+  'payment_settling',
+  'preparation_failed',
+  'cleanup_pending',
+];
+
+function mapIntent(row: PrebillingProvisioningIntentsTable): PrebillingProvisioningIntent {
+  return {
+    id: row.id,
+    checkoutAttemptId: row.checkout_attempt_id,
+    clerkUserId: row.clerk_user_id,
+    runtimeSlot: row.runtime_slot,
+    planSlug: z.enum(['matrix_starter', 'matrix_builder', 'matrix_max']).parse(row.plan_slug),
+    billingInterval: z.enum(['monthly', 'annual']).parse(row.billing_interval),
+    serverType: row.server_type,
+    regionSlug: row.region_slug,
+    developerTools: parseDeveloperToolsJson(row.developer_tools),
+    state: PrebillingIntentStateSchema.parse(row.state),
+    revision: row.revision,
+    machineId: row.machine_id,
+    stripeSessionId: row.stripe_session_id,
+    stripeSessionExpiresAt: row.stripe_session_expires_at,
+    leaseExpiresAt: row.lease_expires_at,
+    reservedHourlyCostMicros: Number(row.reserved_hourly_cost_micros),
+    authorizedAt: row.authorized_at,
+    cleanedAt: row.cleaned_at,
+    lastErrorCode: row.last_error_code,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function selectionMatches(intent: PrebillingProvisioningIntent, input: NewPrebillingIntent): boolean {
+  return intent.clerkUserId === input.clerkUserId
+    && intent.runtimeSlot === input.runtimeSlot
+    && intent.planSlug === input.planSlug
+    && intent.billingInterval === input.billingInterval
+    && intent.serverType === input.serverType
+    && intent.regionSlug === input.regionSlug
+    && serializeDeveloperTools(intent.developerTools) === serializeDeveloperTools(input.developerTools);
+}
+
+export async function getPrebillingIntentByCheckoutAttempt(
+  db: PlatformDB,
+  checkoutAttemptId: string,
+): Promise<PrebillingProvisioningIntent | undefined> {
+  await db.ready;
+  const row = await db.executor.selectFrom('prebilling_provisioning_intents').selectAll()
+    .where('checkout_attempt_id', '=', checkoutAttemptId).executeTakeFirst();
+  return row ? mapIntent(row) : undefined;
+}
+
+export async function getActivePrebillingIntent(
+  db: PlatformDB,
+  clerkUserId: string,
+  runtimeSlot = 'primary',
+): Promise<PrebillingProvisioningIntent | undefined> {
+  await db.ready;
+  const row = await db.executor.selectFrom('prebilling_provisioning_intents').selectAll()
+    .where('clerk_user_id', '=', clerkUserId).where('runtime_slot', '=', runtimeSlot)
+    .where('state', 'in', [
+      'awaiting_checkout', 'preparing', 'ready_waiting_for_billing',
+      'payment_settling', 'preparation_failed', 'preparation_deferred', 'cleanup_pending',
+    ]).orderBy('created_at', 'desc').executeTakeFirst();
+  return row ? mapIntent(row) : undefined;
+}
+
+export async function createPrebillingIntent(
+  db: PlatformDB,
+  input: NewPrebillingIntent,
+): Promise<{ intent: PrebillingProvisioningIntent; created: boolean; selectionMatches: boolean }> {
+  await db.ready;
+  const developerTools = canonicalizeDeveloperTools(input.developerTools);
+  const inserted = await db.executor.insertInto('prebilling_provisioning_intents').values({
+    id: input.id,
+    checkout_attempt_id: input.checkoutAttemptId,
+    clerk_user_id: input.clerkUserId,
+    runtime_slot: input.runtimeSlot,
+    plan_slug: input.planSlug,
+    billing_interval: input.billingInterval,
+    server_type: input.serverType,
+    region_slug: input.regionSlug,
+    developer_tools: serializeDeveloperTools(developerTools),
+    state: 'awaiting_checkout',
+    revision: 1,
+    machine_id: null,
+    stripe_session_id: null,
+    stripe_session_expires_at: null,
+    lease_expires_at: null,
+    reserved_hourly_cost_micros: 0,
+    cleanup_claimed_at: null,
+    cleanup_lease_expires_at: null,
+    ready_at: null,
+    authorized_at: null,
+    cleaned_at: null,
+    last_error_code: null,
+    created_at: input.createdAt,
+    updated_at: input.createdAt,
+  }).onConflict((oc) => oc.doNothing()).returningAll().executeTakeFirst();
+  if (inserted) return { intent: mapIntent(inserted), created: true, selectionMatches: true };
+  const existing = await getPrebillingIntentByCheckoutAttempt(db, input.checkoutAttemptId)
+    ?? await getActivePrebillingIntent(db, input.clerkUserId, input.runtimeSlot);
+  if (!existing) throw new Error('prebilling_intent_conflict_unresolved');
+  return { intent: existing, created: false, selectionMatches: selectionMatches(existing, input) };
+}
+
+export async function admitPrebillingIntent(
+  db: PlatformDB,
+  input: {
+    intentId: string;
+    stripeSessionId: string;
+    stripeSessionExpiresAt: string;
+    reservedHourlyCostMicros: number;
+    maxActive: number;
+    maxHourlyCostMicros: number;
+    now: string;
+  },
+): Promise<{ intent: PrebillingProvisioningIntent; admitted: boolean; reason: 'admitted' | 'capacity' }> {
+  return db.transaction(async (trx) => {
+    await sql`SELECT pg_advisory_xact_lock(hashtext('prebilling-provisioning-capacity'))`.execute(trx.executor);
+    const current = await trx.executor.selectFrom('prebilling_provisioning_intents').selectAll()
+      .where('id', '=', input.intentId).forUpdate().executeTakeFirstOrThrow();
+    const currentIntent = mapIntent(current);
+    if (currentIntent.state === 'preparing') {
+      return { intent: currentIntent, admitted: true, reason: 'admitted' as const };
+    }
+    if (currentIntent.state !== 'awaiting_checkout') {
+      return { intent: currentIntent, admitted: false, reason: 'capacity' as const };
+    }
+    const totals = await sql<{ active_count: string; reserved_cost: string }>`
+      SELECT COUNT(*)::text AS active_count,
+             COALESCE(SUM(reserved_hourly_cost_micros), 0)::text AS reserved_cost
+      FROM prebilling_provisioning_intents
+      WHERE state IN (${sql.join(ACTIVE_CAPACITY_STATES)})
+    `.execute(trx.executor);
+    const activeCount = Number(totals.rows[0]?.active_count ?? 0);
+    const reservedCost = Number(totals.rows[0]?.reserved_cost ?? 0);
+    const admitted = input.reservedHourlyCostMicros > 0
+      && activeCount < input.maxActive
+      && reservedCost + input.reservedHourlyCostMicros <= input.maxHourlyCostMicros;
+    const row = await trx.executor.updateTable('prebilling_provisioning_intents').set({
+      state: admitted ? 'preparing' : 'preparation_deferred',
+      stripe_session_id: input.stripeSessionId,
+      stripe_session_expires_at: input.stripeSessionExpiresAt,
+      lease_expires_at: input.stripeSessionExpiresAt,
+      reserved_hourly_cost_micros: admitted ? input.reservedHourlyCostMicros : 0,
+      revision: current.revision + 1,
+      updated_at: input.now,
+    }).where('id', '=', input.intentId).where('revision', '=', current.revision)
+      .where('state', '=', 'awaiting_checkout').returningAll().executeTakeFirstOrThrow();
+    return { intent: mapIntent(row), admitted, reason: admitted ? 'admitted' : 'capacity' };
+  });
+}
+
+export async function validatePrebillingProvisioningIntent(
+  db: PlatformDB,
+  input: {
+    intentId: string;
+    clerkUserId: string;
+    runtimeSlot: string;
+    serverType: string;
+    regionSlug: string;
+    developerTools: DeveloperToolId[];
+    now: string;
+    machineId?: string;
+  },
+): Promise<PrebillingProvisioningIntent | undefined> {
+  await db.ready;
+  const row = await db.executor.selectFrom('prebilling_provisioning_intents').selectAll()
+    .where('id', '=', input.intentId).executeTakeFirst();
+  if (!row) return undefined;
+  const intent = mapIntent(row);
+  const leaseIsValid = intent.state === 'authorized'
+    || (intent.state === 'preparing'
+      && intent.leaseExpiresAt !== null
+      && Date.parse(intent.leaseExpiresAt) > Date.parse(input.now));
+  if (!leaseIsValid
+    || intent.clerkUserId !== input.clerkUserId
+    || intent.runtimeSlot !== input.runtimeSlot
+    || intent.serverType !== input.serverType
+    || intent.regionSlug !== input.regionSlug
+    || (input.machineId !== undefined && intent.machineId !== input.machineId)
+    || serializeDeveloperTools(intent.developerTools)
+      !== serializeDeveloperTools(canonicalizeDeveloperTools(input.developerTools))) {
+    return undefined;
+  }
+  return intent;
+}
+
+export async function bindPrebillingIntentMachine(
+  db: PlatformDB,
+  input: { intentId: string; machineId: string; expectedRevision: number; now: string },
+): Promise<boolean> {
+  await db.ready;
+  const row = await db.executor.updateTable('prebilling_provisioning_intents').set({
+    machine_id: input.machineId,
+    revision: input.expectedRevision + 1,
+    updated_at: input.now,
+  }).where('id', '=', input.intentId)
+    .where('state', '=', 'preparing')
+    .where('revision', '=', input.expectedRevision)
+    .where('machine_id', 'is', null)
+    .returning('id').executeTakeFirst();
+  return Boolean(row);
+}

--- a/packages/platform/src/prebilling-provisioning.ts
+++ b/packages/platform/src/prebilling-provisioning.ts
@@ -94,6 +94,25 @@ export function createPrebillingProvisioningCoordinator(options: {
       return authorizePrebillingIntent(db, input);
     },
 
+    async ensureFallback(input) {
+      const current = await getPrebillingIntent(options.db, input.intentId);
+      if (!current || current.state !== 'authorized' || current.machineId !== null) return;
+      const identity = await options.resolveIdentity(current.clerkUserId);
+      if (!identity) throw new Error('prebilling_identity_unavailable');
+      const provisioned = await options.customerVpsService.provision({
+        clerkUserId: current.clerkUserId,
+        handle: identity.handle,
+        runtimeSlot: 'primary',
+        serverType: current.serverType,
+        location: z.enum(['fsn1', 'nbg1', 'ash', 'hil']).parse(current.regionSlug.replace(/^region_/, '')),
+        developerTools: current.developerTools,
+      }, { dispatch: 'detached' });
+      await options.onProvisioned?.({
+        clerkUserId: current.clerkUserId, handle: identity.handle,
+        displayName: identity.displayName, email: identity.email, machineId: provisioned.machineId,
+      });
+    },
+
     expireCheckout(db, input) {
       return cleanupExpiredPrebillingCheckout(db, input);
     },

--- a/packages/platform/src/prebilling-provisioning.ts
+++ b/packages/platform/src/prebilling-provisioning.ts
@@ -11,9 +11,11 @@ import {
 import {
   admitPrebillingIntent,
   authorizePrebillingIntent,
+  bindAuthorizedPrebillingFallbackMachine,
   cleanupExpiredPrebillingCheckout,
   createPrebillingIntent,
   getPrebillingIntent,
+  listAuthorizedPrebillingFallbackIntents,
 } from './prebilling-provisioning-store.js';
 
 export function createPrebillingProvisioningCoordinator(options: {
@@ -37,6 +39,24 @@ export function createPrebillingProvisioningCoordinator(options: {
 }): PrebillingCheckoutCoordinator {
   const intentIdFactory = options.intentIdFactory ?? randomUUID;
   const now = options.now ?? (() => new Date());
+  const ensureFallback = async (intentId: string) => {
+    const current = await getPrebillingIntent(options.db, intentId);
+    if (!current || current.state !== 'authorized' || current.machineId !== null) return;
+    const identity = await options.resolveIdentity(current.clerkUserId);
+    if (!identity) throw new Error('prebilling_identity_unavailable');
+    const provisioned = await options.customerVpsService.provision({
+      clerkUserId: current.clerkUserId, handle: identity.handle, runtimeSlot: 'primary',
+      serverType: current.serverType,
+      location: z.enum(['fsn1', 'nbg1', 'ash', 'hil']).parse(current.regionSlug.replace(/^region_/, '')),
+      developerTools: current.developerTools,
+    }, { dispatch: 'detached' });
+    if (!await bindAuthorizedPrebillingFallbackMachine(options.db, {
+      intentId, clerkUserId: current.clerkUserId, runtimeSlot: current.runtimeSlot,
+      machineId: provisioned.machineId, now: now().toISOString(),
+    })) throw new Error('prebilling_fallback_binding_conflict');
+    await options.onProvisioned?.({ clerkUserId: current.clerkUserId, handle: identity.handle,
+      displayName: identity.displayName, email: identity.email, machineId: provisioned.machineId });
+  };
   return {
     async createIntent(input) {
       if (!prebillingRolloutIncludesUser(options.config, input.clerkUserId)) return undefined;
@@ -95,22 +115,20 @@ export function createPrebillingProvisioningCoordinator(options: {
     },
 
     async ensureFallback(input) {
-      const current = await getPrebillingIntent(options.db, input.intentId);
-      if (!current || current.state !== 'authorized' || current.machineId !== null) return;
-      const identity = await options.resolveIdentity(current.clerkUserId);
-      if (!identity) throw new Error('prebilling_identity_unavailable');
-      const provisioned = await options.customerVpsService.provision({
-        clerkUserId: current.clerkUserId,
-        handle: identity.handle,
-        runtimeSlot: 'primary',
-        serverType: current.serverType,
-        location: z.enum(['fsn1', 'nbg1', 'ash', 'hil']).parse(current.regionSlug.replace(/^region_/, '')),
-        developerTools: current.developerTools,
-      }, { dispatch: 'detached' });
-      await options.onProvisioned?.({
-        clerkUserId: current.clerkUserId, handle: identity.handle,
-        displayName: identity.displayName, email: identity.email, machineId: provisioned.machineId,
-      });
+      await ensureFallback(input.intentId);
+    },
+
+    async reconcileFallbacks() {
+      const intents = await listAuthorizedPrebillingFallbackIntents(options.db);
+      let completed = 0; let failed = 0;
+      for (const intent of intents) {
+        try { await ensureFallback(intent.id); completed += 1; }
+        catch (err: unknown) {
+          failed += 1;
+          console.error('[prebilling] fallback reconciliation failed:', err instanceof Error ? err.name : typeof err);
+        }
+      }
+      return { checked: intents.length, completed, failed };
     },
 
     expireCheckout(db, input) {

--- a/packages/platform/src/prebilling-provisioning.ts
+++ b/packages/platform/src/prebilling-provisioning.ts
@@ -12,11 +12,15 @@ import {
   admitPrebillingIntent,
   authorizePrebillingIntent,
   bindAuthorizedPrebillingFallbackMachine,
+  claimAuthorizedPrebillingFallbackIntent,
   cleanupExpiredPrebillingCheckout,
   createPrebillingIntent,
   getPrebillingIntent,
   listAuthorizedPrebillingFallbackIntents,
+  releaseAuthorizedPrebillingFallbackClaim,
 } from './prebilling-provisioning-store.js';
+
+const FALLBACK_CLAIM_LEASE_MS = 5 * 60 * 1000;
 
 export function createPrebillingProvisioningCoordinator(options: {
   db: PlatformDB;
@@ -40,22 +44,31 @@ export function createPrebillingProvisioningCoordinator(options: {
   const intentIdFactory = options.intentIdFactory ?? randomUUID;
   const now = options.now ?? (() => new Date());
   const ensureFallback = async (intentId: string) => {
-    const current = await getPrebillingIntent(options.db, intentId);
-    if (!current || current.state !== 'authorized' || current.machineId !== null) return;
-    const identity = await options.resolveIdentity(current.clerkUserId);
-    if (!identity) throw new Error('prebilling_identity_unavailable');
-    const provisioned = await options.customerVpsService.provision({
-      clerkUserId: current.clerkUserId, handle: identity.handle, runtimeSlot: 'primary',
-      serverType: current.serverType,
-      location: z.enum(['fsn1', 'nbg1', 'ash', 'hil']).parse(current.regionSlug.replace(/^region_/, '')),
-      developerTools: current.developerTools,
-    }, { dispatch: 'detached' });
-    if (!await bindAuthorizedPrebillingFallbackMachine(options.db, {
-      intentId, clerkUserId: current.clerkUserId, runtimeSlot: current.runtimeSlot,
-      machineId: provisioned.machineId, now: now().toISOString(),
-    })) throw new Error('prebilling_fallback_binding_conflict');
-    await options.onProvisioned?.({ clerkUserId: current.clerkUserId, handle: identity.handle,
-      displayName: identity.displayName, email: identity.email, machineId: provisioned.machineId });
+    const claimedAt = now();
+    const leaseExpiresAt = new Date(claimedAt.getTime() + FALLBACK_CLAIM_LEASE_MS).toISOString();
+    const current = await claimAuthorizedPrebillingFallbackIntent(options.db, {
+      intentId, now: claimedAt.toISOString(), leaseExpiresAt,
+    });
+    if (!current) return false;
+    try {
+      const identity = await options.resolveIdentity(current.clerkUserId);
+      if (!identity) throw new Error('prebilling_identity_unavailable');
+      const provisioned = await options.customerVpsService.provision({
+        clerkUserId: current.clerkUserId, handle: identity.handle, runtimeSlot: 'primary', serverType: current.serverType,
+        location: z.enum(['fsn1', 'nbg1', 'ash', 'hil']).parse(current.regionSlug.replace(/^region_/, '')),
+        developerTools: current.developerTools,
+      }, { dispatch: 'detached' });
+      if (!await bindAuthorizedPrebillingFallbackMachine(options.db, {
+        intentId, clerkUserId: current.clerkUserId, runtimeSlot: current.runtimeSlot,
+        machineId: provisioned.machineId, leaseExpiresAt, now: now().toISOString(),
+      })) throw new Error('prebilling_fallback_binding_conflict');
+      await options.onProvisioned?.({ clerkUserId: current.clerkUserId, handle: identity.handle,
+        displayName: identity.displayName, email: identity.email, machineId: provisioned.machineId });
+      return true;
+    } catch (err: unknown) {
+      await releaseAuthorizedPrebillingFallbackClaim(options.db, { intentId, leaseExpiresAt, now: now().toISOString() });
+      throw err;
+    }
   };
   return {
     async createIntent(input) {
@@ -119,10 +132,10 @@ export function createPrebillingProvisioningCoordinator(options: {
     },
 
     async reconcileFallbacks() {
-      const intents = await listAuthorizedPrebillingFallbackIntents(options.db);
+      const intents = await listAuthorizedPrebillingFallbackIntents(options.db, now().toISOString());
       let completed = 0; let failed = 0;
       for (const intent of intents) {
-        try { await ensureFallback(intent.id); completed += 1; }
+        try { if (await ensureFallback(intent.id)) completed += 1; }
         catch (err: unknown) {
           failed += 1;
           console.error('[prebilling] fallback reconciliation failed:', err instanceof Error ? err.name : typeof err);

--- a/packages/platform/src/prebilling-provisioning.ts
+++ b/packages/platform/src/prebilling-provisioning.ts
@@ -1,0 +1,101 @@
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod/v4';
+import type { PrebillingCheckoutCoordinator } from './billing-routes.js';
+import type { CustomerVpsService } from './customer-vps.js';
+import type { PlatformDB } from './db.js';
+import type { PrebillingProvisioningConfig } from './prebilling-provisioning-config.js';
+import {
+  prebillingHourlyCostMicros,
+  prebillingRolloutIncludesUser,
+} from './prebilling-provisioning-config.js';
+import {
+  admitPrebillingIntent,
+  authorizePrebillingIntent,
+  cleanupExpiredPrebillingCheckout,
+  createPrebillingIntent,
+  getPrebillingIntent,
+} from './prebilling-provisioning-store.js';
+
+export function createPrebillingProvisioningCoordinator(options: {
+  db: PlatformDB;
+  config: PrebillingProvisioningConfig;
+  customerVpsService: CustomerVpsService;
+  resolveIdentity: (clerkUserId: string) => Promise<{
+    handle: string;
+    displayName?: string;
+    email?: string;
+  } | null | undefined>;
+  intentIdFactory?: () => string;
+  now?: () => Date;
+  onProvisioned?: (input: {
+    clerkUserId: string;
+    handle: string;
+    displayName?: string;
+    email?: string;
+    machineId: string;
+  }) => Promise<void>;
+}): PrebillingCheckoutCoordinator {
+  const intentIdFactory = options.intentIdFactory ?? randomUUID;
+  const now = options.now ?? (() => new Date());
+  return {
+    async createIntent(input) {
+      if (!prebillingRolloutIncludesUser(options.config, input.clerkUserId)) return undefined;
+      const cost = prebillingHourlyCostMicros(options.config, input.serverType);
+      if (cost === null) return undefined;
+      const result = await createPrebillingIntent(options.db, {
+        id: intentIdFactory(),
+        ...input,
+        createdAt: input.now,
+      });
+      if (!result.selectionMatches || result.intent.checkoutAttemptId !== input.checkoutAttemptId) {
+        return undefined;
+      }
+      return {
+        intentId: result.intent.id,
+        expiresAt: new Date(Date.parse(input.now) + options.config.leaseMs).toISOString(),
+      };
+    },
+
+    async startPreparation(input) {
+      const current = await getPrebillingIntent(options.db, input.intentId);
+      if (!current) return;
+      const cost = prebillingHourlyCostMicros(options.config, current.serverType);
+      if (cost === null) return;
+      const admission = await admitPrebillingIntent(options.db, {
+        ...input,
+        reservedHourlyCostMicros: cost,
+        maxActive: options.config.maxActive,
+        maxHourlyCostMicros: options.config.maxHourlyCostMicros,
+        now: now().toISOString(),
+      });
+      if (!admission.admitted) return;
+      const identity = await options.resolveIdentity(current.clerkUserId);
+      if (!identity) throw new Error('prebilling_identity_unavailable');
+      const provisioned = await options.customerVpsService.provisionForCheckout({
+        clerkUserId: current.clerkUserId,
+        handle: identity.handle,
+        runtimeSlot: 'primary',
+        serverType: current.serverType,
+        location: z.enum(['fsn1', 'nbg1', 'ash', 'hil']).parse(
+          current.regionSlug.replace(/^region_/, ''),
+        ),
+        developerTools: current.developerTools,
+      }, current.id, { dispatch: 'detached' });
+      await options.onProvisioned?.({
+        clerkUserId: current.clerkUserId,
+        handle: identity.handle,
+        displayName: identity.displayName,
+        email: identity.email,
+        machineId: provisioned.machineId,
+      });
+    },
+
+    authorizeSubscription(db, input) {
+      return authorizePrebillingIntent(db, input);
+    },
+
+    expireCheckout(db, input) {
+      return cleanupExpiredPrebillingCheckout(db, input);
+    },
+  };
+}

--- a/packages/platform/src/stripe-billing.ts
+++ b/packages/platform/src/stripe-billing.ts
@@ -31,6 +31,7 @@ export function createStripeBillingClient(options: {
         cancel_url: input.cancelUrl,
         allow_promotion_codes: input.allowPromotionCodes,
         automatic_tax: { enabled: input.automaticTax },
+        ...(input.expiresAt ? { expires_at: Math.floor(Date.parse(input.expiresAt) / 1_000) } : {}),
         ...(input.paymentMethodMode === 'card_required'
           ? {
             payment_method_types: ['card'] as const,
@@ -41,6 +42,9 @@ export function createStripeBillingClient(options: {
           clerk_user_id: input.clerkUserId,
           matrix_region_slug: input.regionSlug,
           matrix_runtime_slot: input.runtimeSlot,
+          ...(input.prebillingIntentId
+            ? { matrix_prebilling_intent_id: input.prebillingIntentId }
+            : {}),
         },
         subscription_data: {
           ...(input.trialPeriodDays
@@ -55,6 +59,9 @@ export function createStripeBillingClient(options: {
             clerk_user_id: input.clerkUserId,
             matrix_region_slug: input.regionSlug,
             matrix_runtime_slot: input.runtimeSlot,
+            ...(input.prebillingIntentId
+              ? { matrix_prebilling_intent_id: input.prebillingIntentId }
+              : {}),
           },
         },
         tax_id_collection: { enabled: true },
@@ -70,7 +77,13 @@ export function createStripeBillingClient(options: {
       if (!session.url) {
         throw new Error('Stripe checkout session missing redirect URL');
       }
-      return { url: session.url, id: session.id };
+      return {
+        url: session.url,
+        id: session.id,
+        ...(session.expires_at
+          ? { expiresAt: new Date(session.expires_at * 1_000).toISOString() }
+          : {}),
+      };
     },
 
     async retrieveCheckoutSession(id) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-packageExtensionsChecksum: sha256-rZpBjPGwynkZBO6ecOJcSqSzQ7VMBks/aE429NKBlCU=
+packageExtensionsChecksum: sha256-MHRU4TXUD7qujRA9MBGatf2208j0N4EyngS9KgxMkMQ=
 
 importers:
 
@@ -27463,10 +27463,14 @@ snapshots:
 
   langium@4.2.1:
     dependencies:
+      '@chevrotain/regexp-to-ast': 11.1.2
       chevrotain: 11.1.2
       chevrotain-allstar: 0.3.1(chevrotain@11.1.2)
+      vscode-jsonrpc: 8.2.0
       vscode-languageserver: 9.0.1
+      vscode-languageserver-protocol: 3.17.5
       vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
       vscode-uri: 3.1.0
 
   language-subtag-registry@0.3.23: {}

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -1253,7 +1253,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
                 as="div"
                 axis={isHorizontal ? "x" : "y"}
                 values={userApps.map((a) => a.path)}
-                onReorder={(newOrder) => reorderDockSection("userApps", newOrder)}
+                onReorder={(newOrder: string[]) => reorderDockSection("userApps", newOrder)}
                 className={isHorizontal
                   ? "flex flex-row items-center gap-1"
                   : "flex flex-col items-center gap-1"

--- a/shell/src/components/VocalPanel.tsx
+++ b/shell/src/components/VocalPanel.tsx
@@ -574,8 +574,7 @@ export function VocalPanel({ active, chat, onOpenApp, onDismissChat }: VocalPane
         </ShellNotificationPortal>
       )}
 
-      {/* react-doctor-disable-next-line react-doctor/no-unknown-property -- valid styled-jsx attribute */}
-      <style jsx global>{`
+      <style>{`
         @keyframes vocal-breathe {
           0%, 100% { filter: brightness(0.9) saturate(1); transform: scale(1); }
           50%       { filter: brightness(1.35) saturate(1.15); transform: scale(1.015); }

--- a/shell/src/components/mobile/MobileShell.tsx
+++ b/shell/src/components/mobile/MobileShell.tsx
@@ -747,7 +747,7 @@ function AppSwitcher({
               drag="x"
               dragConstraints={{ left: 0, right: 0 }}
               dragElastic={0.12}
-              onDragEnd={(_, info: PanInfo) => {
+              onDragEnd={(_event: unknown, info: PanInfo) => {
                 if (Math.abs(info.offset.x) > 96) onClose(o.id);
               }}
               whileDrag={{ scale: 0.98, cursor: "grabbing" }}

--- a/shell/src/components/settings/sections/BillingPanel.tsx
+++ b/shell/src/components/settings/sections/BillingPanel.tsx
@@ -34,6 +34,12 @@ import type {
 } from "@/hooks/useMatrixBillingAccess";
 import { capturePostHogEvent, capturePostHogLog } from "@/lib/posthog-client";
 import { isSelfHostedDocument } from "@/lib/self-host-mode";
+import { DeveloperToolsSelector } from "@/components/onboarding/DefaultInstallsStep";
+import {
+  defaultDeveloperTools,
+  nextDeveloperToolsSelection,
+  type DeveloperToolId,
+} from "@/components/onboarding/developer-tools";
 
 function preselectedFeatureSlug(selectedPlan: unknown): string | null {
   if (typeof selectedPlan !== "string") return null;
@@ -141,6 +147,7 @@ function CheckoutPanel({
   selectedProfile,
   selectedRegion,
   billingInterval,
+  developerTools,
   onBillingIntervalChange,
   trialDurationDays,
 }: {
@@ -154,6 +161,7 @@ function CheckoutPanel({
   selectedProfile: (typeof MATRIX_BILLING_SERVER_PROFILES)[number];
   selectedRegion: (typeof MATRIX_BILLING_REGIONS)[number];
   billingInterval: BillingInterval;
+  developerTools: DeveloperToolId[];
   onBillingIntervalChange: (interval: BillingInterval) => void;
   trialDurationDays: number | null;
 }) {
@@ -217,6 +225,8 @@ function CheckoutPanel({
           planSlug,
           interval: billingInterval,
           regionSlug,
+          serverType: selection.serverType,
+          developerTools,
           ...(checkoutRuntimeSlot ? { runtimeSlot: checkoutRuntimeSlot } : {}),
           ...(checkoutReturnPath ? { returnPath: checkoutReturnPath } : {}),
         }),
@@ -1165,6 +1175,7 @@ function BillingPanelInner({
   );
   const [selectedRegionSlug, setSelectedRegionSlug] = useState(getNearestRegionSlug);
   const [billingInterval, setBillingInterval] = useState<BillingInterval>("monthly");
+  const [developerTools, setDeveloperTools] = useState<DeveloperToolId[]>(defaultDeveloperTools);
   const [openPicker, setOpenPicker] = useState<PickerKey>(null);
   const checkoutBypassed = mode === "add-computer" && entitlement?.source === "override";
   const trialDurationDays = trialOffer?.eligible === true
@@ -1336,6 +1347,12 @@ function BillingPanelInner({
             onSelectProfile={handleProfileSelect}
             onSelectRegion={handleRegionSelect}
           />
+          <div className="mt-4 border-t border-forest/8 pt-4">
+            <DeveloperToolsSelector
+              selectedTools={developerTools}
+              onToggle={(tool) => setDeveloperTools((current) => nextDeveloperToolsSelection(current, tool))}
+            />
+          </div>
           <ul className="mt-4 space-y-2 border-t border-forest/8 pt-4">
             {includedHighlights.map((item) => (
               <li
@@ -1360,6 +1377,7 @@ function BillingPanelInner({
         selectedProfile={selectedProfile}
         selectedRegion={selectedRegion}
         billingInterval={billingInterval}
+        developerTools={developerTools}
         onBillingIntervalChange={handleBillingIntervalChange}
         trialDurationDays={trialDurationDays}
       />

--- a/specs/116-prebilling-provisioning/checklists/requirements.md
+++ b/specs/116-prebilling-provisioning/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Prebilling Provisioning
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-08-24  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on the first review iteration. The specification intentionally preserves the existing signed subscription projection as the sole initial-access authority and scopes V1 to new primary-computer onboarding.

--- a/specs/116-prebilling-provisioning/checklists/requirements.md
+++ b/specs/116-prebilling-provisioning/checklists/requirements.md
@@ -1,7 +1,7 @@
 # Specification Quality Checklist: Prebilling Provisioning
 
-**Purpose**: Validate specification completeness and quality before proceeding to planning  
-**Created**: 2026-08-24  
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-24
 **Feature**: [spec.md](../spec.md)
 
 ## Content Quality

--- a/specs/116-prebilling-provisioning/contracts/events.md
+++ b/specs/116-prebilling-provisioning/contracts/events.md
@@ -1,0 +1,71 @@
+# Event and Telemetry Contract
+
+## Stripe Metadata Binding
+
+Checkout creation writes the same opaque preparation-intent ID to:
+
+- Checkout Session top-level metadata, for Checkout events.
+- `subscription_data.metadata`, so the resulting Subscription carries it into subscription events.
+
+Also retain the existing server-owned checkout-attempt, Clerk owner, region, and runtime-slot metadata required by current reconciliation. Metadata is a correlation hint, not authority. Signed event handlers must look up the local attempt and prove exact owner, slot, recognized Price/plan, session/subscription relationship, and immutable selection before promotion.
+
+The browser success URL, Checkout Session `completed` state, invoice events, metadata alone, and provider readiness cannot authorize access. Only the existing signed subscription projection can do so.
+
+## Lifecycle Events
+
+Internal domain events are emitted after their database transaction commits. Consumers must tolerate duplicates and reordering.
+
+| Event | Required bounded fields |
+|---|---|
+| `prebilling.intent.created` | correlation ID, rollout cohort, plan class, region class, reserved cost band |
+| `prebilling.admission.deferred` | reason code (`flag_off`, `not_eligible`, `account_limit`, `origin_limit`, `count_ceiling`, `cost_ceiling`, `unknown_cost`) |
+| `prebilling.job.started` | correlation ID, retry ordinal, snapshot-path boolean |
+| `prebilling.machine.ready` | correlation ID, elapsed bucket |
+| `prebilling.checkout.completed` | correlation ID, elapsed bucket |
+| `prebilling.subscription.authorized` | correlation ID, projection event type, fallback-job boolean |
+| `prebilling.cleanup.claimed` | correlation ID, age bucket, phase |
+| `prebilling.cleanup.completed` | correlation ID, elapsed bucket, provider-reconciled boolean |
+| `prebilling.cleanup.canceled` | correlation ID, cancellation reason (`authorized`, `newer_intent`, `checkout_payable`) |
+| `prebilling.failure` | correlation ID, component, bounded error code, retryable boolean |
+
+Never include raw provider errors, Stripe secrets, Checkout URLs, IPs, hostnames, provider machine IDs, Clerk user IDs, database messages, or filesystem paths in analytics events. Operational logs may use access-controlled correlation identifiers and exact internal diagnostics under existing redaction rules.
+
+## Metrics
+
+Low-cardinality counters:
+
+- checkout attempts by preparation result and rollout cohort
+- preparation jobs started/succeeded/failed/reconciled
+- authorization promotions, cleanup cancellations, fallback jobs, and duplicate-prevention conflicts
+- cleanup actions by terminal result and bounded failure code
+
+Gauges:
+
+- active unauthorized preparations
+- reserved hourly cost
+- cleanup backlog count and oldest actionable age
+- payment-settling intents awaiting subscription projection
+- entitled primary slots with neither a nondeleted machine nor an active provisioning job
+
+Histograms:
+
+- checkout-open to provider-start
+- provider-start to physical-ready
+- checkout-completed to subscription-projected
+- subscription-authorized to runtime-ready
+- provisioning/checkout overlap
+- preparation-created to cleanup-complete
+
+## Alerts and Rollout Stops
+
+Page or automatically stop new admission when any of these breach their configured threshold:
+
+- an authorized machine enters provider deletion or an authorization-vs-cleanup invariant fails
+- active unauthorized count or reserved cost exceeds its hard ceiling
+- duplicate active machine/intent constraint errors appear
+- cleanup oldest age threatens the 35/45-minute objective
+- payment-settling backlog grows beyond the signed-event delivery allowance
+- entitled-without-machine-or-job is nonzero beyond reconciliation grace
+- authorization-to-ready latency or provider failure rate regresses materially against the current postbilling cohort
+
+Turning admission off must not stop subscription projection, normal entitlement provisioning, preparation reconciliation, or cleanup workers.

--- a/specs/116-prebilling-provisioning/contracts/http.md
+++ b/specs/116-prebilling-provisioning/contracts/http.md
@@ -1,0 +1,104 @@
+# HTTP Contract: Prebilling Onboarding
+
+## Auth Matrix
+
+| Route | Mutation | Authentication / verification | Public | Prebilling behavior |
+|---|---:|---|---:|---|
+| `POST /billing/checkout` | Yes | Valid Clerk application session; owner derived from verified identity | No | Existing checkout mutation also creates/resumes eligible preparation |
+| `POST /billing/webhooks/stripe` | Yes | Stripe signature over bounded raw body using timing-safe library verification | Internet-reachable webhook only | Signed events update checkout/subscription state and may authorize or fence cleanup |
+| `GET /api/journey` | No | Existing Clerk or signed sync-session authentication | No | Adds coarse preparation/resume state |
+| `POST /api/auth/provision-runtime` | Yes | Existing authenticated session plus effective exact-slot entitlement | No | Contract remains entitlement-only; used for legacy/fallback recovery |
+| Runtime session route(s) | Yes | Existing authenticated session plus effective exact-slot entitlement and machine activation | No | Rejects `awaiting_billing` machines |
+| Explicit `/vm/:handle` routing | No | Existing authenticated owner/session checks plus exact-slot entitlement and activation | No | Rejects `awaiting_billing` machines |
+| Runtime HTTP/API forwarding | Varies | Existing route authentication plus exact-slot entitlement and activation | No | Rejects `awaiting_billing` machines |
+| Runtime WebSocket and terminal upgrade routes | Yes | Existing browser-compatible query-token/session auth plus exact-slot entitlement and activation | No | Rejects `awaiting_billing` machines before upgrade |
+| Recovery, resume, and resize routes | Yes | Existing owner/operator auth plus lifecycle policy; customer actions also require entitlement and activation | No | Customer cannot operate an unauthorized prepared machine |
+
+There is no public `preprovision`, worker, cleanup, or activation endpoint. Background services are injected and validated when routes/workers are registered.
+
+## `POST /billing/checkout`
+
+The route and successful response remain backward compatible.
+
+### Request
+
+```json
+{
+  "plan": "pro",
+  "interval": "monthly",
+  "region": "eu-central",
+  "serverType": "cpx32",
+  "developerTools": ["claude-code", "codex"],
+  "runtimeSlot": "primary",
+  "returnPath": "/onboarding"
+}
+```
+
+Boundary rules:
+
+- Apply Hono `bodyLimit` before parsing; target maximum is 16 KiB.
+- Parse with a strict Zod 4 schema. Reject unknown keys, invalid slugs, excessive tool count, duplicates, unsupported tools, invalid plan/interval/server/region combinations, non-primary V1 slots, and unsafe return paths.
+- Derive acquisition and owner identity from trusted server context; never accept a Clerk user ID, provider ID, hourly cost, preparation ID, or activation state from the client.
+- Canonicalize `developerTools` as a deduplicated sorted list before equality checks and persistence.
+- Every Stripe call has a bounded timeout and an idempotency key derived from the durable checkout attempt.
+
+### Success
+
+```json
+{
+  "url": "https://checkout.stripe.com/..."
+}
+```
+
+The URL is the existing Stripe-hosted destination. The client receives no preparation-intent, provider, machine, network, or cost identifier.
+
+Identical retries return the existing payable destination. A conflicting selection while a payable checkout exists returns a generic conflict telling the user to resume or wait for the existing checkout to expire.
+
+Preparation is an optimization, not a prerequisite for selling an authorized subscription. If rollout eligibility, global capacity, trusted-origin rate limits, or provider admission denies preparation, Matrix creates no provider resource, emits the internal reason, and safely continues checkout. After signed subscription authorization, the server enqueues normal entitlement-backed provisioning without another browser mutation.
+
+### Errors
+
+| Status | Stable client meaning |
+|---:|---|
+| `400` | Invalid checkout selection |
+| `401` | Authentication required |
+| `409` | A different payable checkout is already active |
+| `429` | Account request rate exceeded; retry later |
+| `503` | Checkout is temporarily unavailable |
+
+Responses contain allowlisted short messages only. Stripe/provider/database/path/network details are logged server-side with correlation IDs and bounded fields.
+
+## `GET /api/journey`
+
+Existing phases and fields remain compatible. For an eligible owner with an active preparation, add:
+
+```json
+{
+  "phase": "plan_required",
+  "nextAction": "resume_checkout",
+  "preparation": {
+    "state": "ready_waiting_for_billing",
+    "stage": "finalizing",
+    "startedAt": "2026-08-24T12:00:00.000Z"
+  }
+}
+```
+
+Allowed client states are `preparing`, `ready_waiting_for_billing`, `payment_settling`, `authorized_provisioning`, `failed`, and `cleanup_pending`. Allowed stages are coarse and provider-neutral. Do not return provider IDs, IPs, machine IDs, intent IDs, internal errors, health status codes, or lease internals.
+
+`resume_checkout` returns or links through the existing server-owned checkout resumption path only for the authenticated owner and an open, unexpired attempt. A browser return never changes authorization.
+
+## Shell Contract
+
+- Reorder the new-primary journey to compute/region, developer tools, explicit “Continue to secure checkout,” preparation during checkout, signed billing confirmation, then ready/runtime.
+- Copy must say preparation starts when checkout opens and access starts only after billing authorization.
+- The billing component must submit `developerTools` and `serverType`; it must not separately call a preparation endpoint.
+- Agent authentication remains after runtime readiness. Precheckout selection only chooses optional tools to install asynchronously on first boot.
+- Canvas is the first manual validation surface; Desktop compatibility remains required.
+
+## External-Call Safety
+
+- Stripe API and provider API calls use explicit abort timeouts; webhook verification occurs before JSON interpretation.
+- Provider selection values come only from server-side plan/region mappings.
+- Ambiguous Stripe creation is reconciled before a replacement attempt; ambiguous provider creation/deletion uses exact deterministic labels/IDs and reconciliation before retry.
+- User-controlled forwarded headers are never used for security or cost admission. Network-origin controls live at a trusted edge; if that trust boundary is unavailable, the feature launches with account/global limits only rather than a spoofable application check.

--- a/specs/116-prebilling-provisioning/data-model.md
+++ b/specs/116-prebilling-provisioning/data-model.md
@@ -1,0 +1,181 @@
+# Data Model: Prebilling Provisioning
+
+## Modeling Rules
+
+- Checkout state, physical machine state, and access authorization are independent axes.
+- Every new column is additive and rollback-safe. Existing machines default to `authorized`; the feature flag remains off until all readers understand the new state.
+- All control-plane persistence stays in platform PostgreSQL through Kysely.
+- Customer machines are owner-bound from creation. An abandoned machine is destroyed, never reassigned.
+- State transitions use revision-checked writes or row locks inside transactions; no read-then-write concurrency decisions occur across transaction boundaries.
+
+## `prebilling_provisioning_intents`
+
+Durable source of truth for the reversible work Matrix performs while one primary-computer Checkout Session is payable.
+
+| Column | Type | Constraints / purpose |
+|---|---|---|
+| `id` | `text` | UUID primary key, generated before the Stripe create call so it can be placed in metadata |
+| `checkout_attempt_id` | `text` | Unique foreign key to `billing_checkout_attempts` |
+| `clerk_user_id` | `text` | Authenticated owner; never accepted from the request body |
+| `runtime_slot` | `text` | V1 requires `primary` |
+| `plan_slug` | `text` | Validated immutable selection snapshot |
+| `billing_interval` | `text` | Validated immutable selection snapshot |
+| `server_type` | `text` | Validated provider-neutral compute shape |
+| `region_slug` | `text` | Validated region |
+| `developer_tools` | `jsonb` | Canonical sorted array of supported tool IDs, size-capped before persistence |
+| `state` | `text` | State machine below |
+| `revision` | `integer` | Starts at 1; every transition increments it |
+| `machine_id` | `text nullable` | Unique foreign key to `user_machines` once allocated |
+| `stripe_session_expires_at` | `timestamptz nullable` | Exact server-returned Checkout expiry |
+| `lease_expires_at` | `timestamptz nullable` | Never later than the Stripe expiry for V1 |
+| `reserved_hourly_cost_micros` | `bigint` | Defaults to 0; set once if provider preparation is admitted |
+| `ready_at` | `timestamptz nullable` | Physical readiness timestamp; does not grant access |
+| `authorized_at` | `timestamptz nullable` | Signed subscription-projection promotion timestamp |
+| `cleaned_at` | `timestamptz nullable` | Set only after provider absence and local secret cleanup are confirmed |
+| `last_error_code` | `text nullable` | Bounded internal code, never a raw provider error |
+| `created_at`, `updated_at` | `timestamptz` | Audit timestamps |
+
+Indexes and constraints:
+
+- Unique active intent for `(clerk_user_id, runtime_slot)` where state is nonterminal.
+- Unique `checkout_attempt_id` and unique non-null `machine_id`.
+- Check constraints for V1 `runtime_slot='primary'`, nonnegative reserved cost, and recognized states.
+- GIN is not needed for `developer_tools`; selection comparison uses the canonical serialized array.
+
+Intent states:
+
+```text
+awaiting_checkout
+    -> preparing                 Stripe session finalized open; job is durable
+    -> preparation_deferred      checkout remains valid; no provider capacity admitted
+    -> checkout_failed           no provider work was admitted
+
+preparing
+    -> ready_waiting_for_billing physical readiness only
+    -> payment_settling          checkout completed; subscription projection pending
+    -> preparation_failed        provider path exhausted; checkout remains valid
+    -> cleanup_pending           Stripe authoritatively expired and no entitlement
+    -> authorized                signed subscription projection matched
+
+ready_waiting_for_billing
+    -> payment_settling | cleanup_pending | authorized
+
+payment_settling
+    -> authorized
+    -> preparation_failed        only for physical failure; never abandonment cleanup
+
+preparation_failed
+    -> authorized                entitlement creates/uses normal provisioning fallback
+    -> cleanup_pending           only after authoritative Stripe expiry and no entitlement
+
+preparation_deferred
+    -> authorized                entitlement creates one normal provisioning job
+    -> cleaned                   Stripe expired; no provider resource existed
+
+cleanup_pending
+    -> authorized                cancellation fence wins before irreversible deletion
+    -> cleaned                   provider absence and secret cleanup confirmed
+```
+
+`checkout_failed`, `authorized`, and `cleaned` are terminal for preparation admission. Authorization can still reconcile a historically `cleaned` intent by creating a normal entitlement-backed job; it never resurrects or reassigns the deleted machine.
+
+## Changes to Existing Tables
+
+### `billing_checkout_attempts`
+
+Add:
+
+- `prebilling_intent_id text nullable unique`
+- `stripe_session_expires_at timestamptz nullable`
+
+Correct selection equality so an existing payable attempt is reusable only when all of these match: plan, interval, runtime slot, server type, region, canonical developer-tools list, acquisition context, and validated return path. This closes the current gap where developer tools and server type are not compared.
+
+The existing attempt lifecycle remains `creating -> open -> paid|expired|failed`. Checkout status never grants machine access.
+
+### `billing_subscriptions`
+
+Add nullable `prebilling_intent_id` for an auditable exact binding. It is populated only after signed event processing validates Stripe metadata against the local checkout attempt, Clerk owner, runtime slot, and recognized Price.
+
+### `user_machines`
+
+Add:
+
+- `activation_state text not null default 'authorized'`
+- `prebilling_intent_id text nullable unique`
+- `activation_authorized_at timestamptz nullable`
+
+Recognized activation states are `awaiting_billing` and `authorized`. Existing `status` continues to represent physical lifecycle (`provisioning`, `running`, and existing failure/deletion states). A prebilling machine may be physically `running` while still inaccessible.
+
+### `provisioning_jobs`
+
+Add:
+
+- `authorization_basis text not null default 'billing_entitlement'`
+- `prebilling_intent_id text nullable`
+
+Recognized bases are `billing_entitlement` and `prebilling_intent`. Before each provider-create attempt or retry, the worker resolves the basis again. The prebilling basis is valid only for the exact owner, primary slot, selections, nonterminal intent revision, and unexpired payable Checkout Session.
+
+## `prebilling_cleanup_actions`
+
+Durable, leased, cancelable cleanup state machine. It is separate from the general provider-deletion queue because prebilling deletion requires a billing recheck and an intent revision fence at the irreversible boundary.
+
+| Column | Type | Constraints / purpose |
+|---|---|---|
+| `id` | `text` | UUID primary key |
+| `intent_id` | `text` | Foreign key to preparation intent |
+| `machine_id` | `text nullable` | Exact local machine identity |
+| `expected_intent_revision` | `integer` | Stale-work fence |
+| `provider_machine_id` | `text nullable` | Exact provider identity after reconciliation |
+| `phase` | `text` | `expire_checkout`, `reconcile_checkout`, `recheck_authorization`, `delete_provider`, `reconcile_delete`, `delete_local_secrets`, `finalize` |
+| `status` | `text` | `queued`, `running`, `retryable`, `completed`, `canceled`, `failed` |
+| `attempt_count` | `integer` | Bounded retry counter |
+| `execute_after` | `timestamptz` | Backoff scheduling |
+| `lease_owner`, `lease_expires_at` | nullable | Durable worker claim |
+| `cancel_requested_at` | `timestamptz nullable` | Set by authorization before promotion |
+| `last_error_code` | `text nullable` | Bounded diagnostic code |
+| `created_at`, `updated_at`, `completed_at` | timestamps | Audit timestamps |
+
+Only one unresolved cleanup action may exist per intent. A worker must renew or release its lease; abandoned claims become retryable. `completed` means the provider reports the exact machine absent and platform-owned transient secrets/credentials have been deleted.
+
+## `prebilling_capacity_buckets`
+
+Global admission must not be implemented with an in-memory counter or an unlocked aggregate query.
+
+| Column | Type | Purpose |
+|---|---|---|
+| `bucket` | `text` | Primary key, initially `global` |
+| `active_count` | `integer` | Reserved unauthorized preparations |
+| `reserved_hourly_cost_micros` | `bigint` | Sum of admitted cost reservations |
+| `revision` | `integer` | Optimistic concurrency fence |
+| `updated_at` | `timestamptz` | Audit timestamp |
+
+Admission locks the bucket row, verifies count and cost ceilings, updates the already-created intent with its reservation, creates the machine/job, and increments the bucket in one transaction. Authorization and completed cleanup decrement a nonzero reservation exactly once in the same transaction as the terminal transition. A repair reconciliation recomputes the bucket from active intents and alerts on drift.
+
+## Atomic Operations
+
+### Checkout claim before Stripe
+
+1. Authenticate the Clerk session and derive `clerk_user_id` server-side.
+2. Validate the complete request with Zod and canonicalize developer-tool IDs.
+3. In one transaction, lock the owner/slot scope, reuse or reject any payable attempt, and insert a `creating` checkout attempt plus `awaiting_checkout` intent with a generated opaque ID. This records identity but does not yet reserve provider capacity.
+4. Call Stripe outside the transaction with a bounded timeout and the checkout-attempt ID as idempotency key. Put the preparation-intent ID in both metadata scopes.
+5. On definite failure, transactionally mark both records failed. On ambiguity, reconcile Stripe by idempotency/attempt identity before deciding.
+
+### Checkout finalization and job admission
+
+In one transaction, enforce `checkout_attempt.status='creating'` and `intent.state='awaiting_checkout'` in the update predicates, record the open Stripe session and exact expiry, and lock the global capacity bucket. If admitted, reserve cost, create the `awaiting_billing` machine plus `prebilling_intent` job through the shared creation path, and transition the intent to `preparing`. If rollout or capacity denies admission, transition to `preparation_deferred` with zero reservation and no machine/job; the cohort still receives the safe Checkout Session and signed authorization later guarantees normal provisioning.
+
+### Signed subscription promotion
+
+In one transaction, upsert the authoritative subscription projection, lock the owner/slot and intent, validate exact metadata and selection linkage, cancel unresolved cleanup, transition the machine activation state and intent to `authorized`, release the cost reservation once, and ensure the slot has either the bound nondeleted machine or one entitlement-backed provisioning job. Event replays are idempotent.
+
+### Cleanup claim and deletion fence
+
+Claim work with `FOR UPDATE SKIP LOCKED` or an equivalent revision-checked lease update. Immediately before `delete_provider`, start a transaction that locks the intent, cleanup action, exact machine, current subscription projection, and newer owner/slot intents in a documented order. Advance to deletion only when Stripe is authoritatively expired, no effective entitlement exists, `expected_intent_revision` still matches, no cancellation is requested, and no newer intent exists. Commit the phase transition before the external call; reconcile ambiguous deletion until absence is confirmed.
+
+## Data Retention and Ownership
+
+- Provider instances, generated host credentials, routing registrations, and temporary bootstrap secrets for abandoned preparations are deleted during cleanup.
+- Customer home data is never reused or inspected. If boot created owner data, it is destroyed with that owner's abandoned machine.
+- Checkout, subscription, and security audit history retains only identifiers and bounded state required for accounting, fraud prevention, and incident reconstruction; raw provider errors and secrets are excluded.
+- Terminal records may be minimized or pseudonymized under the existing retention policy, but ownership must never be reassigned.

--- a/specs/116-prebilling-provisioning/plan.md
+++ b/specs/116-prebilling-provisioning/plan.md
@@ -1,0 +1,251 @@
+# Implementation Plan: Prebilling Provisioning
+
+**Branch**: `116-prebilling-provisioning` | **Date**: 2026-08-24 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/116-prebilling-provisioning/spec.md`
+
+## Summary
+
+Move new-primary VPS preparation into the payable-checkout window: after the signed-in user has selected compute, region, and developer tools and explicitly continues, the existing checkout mutation creates one owner-bound preparation intent and starts the existing durable provisioning pipeline. The prepared machine may become physically ready but remains unreachable until the existing signed, exact-slot subscription projection atomically authorizes it. Authoritatively expired unpaid preparations are reclaimed through a separately leased and revision-fenced cleanup workflow; successful billing always guarantees a prepared machine or one normal entitlement-backed provisioning job without another browser click.
+
+## Technical Context
+
+- **Language/Version**: TypeScript 5.5+ strict ES modules on Node.js 24+
+- **Primary Dependencies**: Hono 4, Kysely 0.28, Stripe SDK 22/API `2026-04-22.dahlia`, Zod 4 via `zod/v4`, Next.js 16, React 19
+- **Storage**: Platform PostgreSQL through Kysely; Stripe and the existing VPS provider are external systems of record for their own lifecycle
+- **Testing**: Vitest 4 unit/integration/contract suites, fake Stripe/provider full-path tests, shell production build, React Doctor, then an explicitly approved disposable-VPS validation
+- **Target Platform**: Cloud Run platform/app-shell control plane coordinating VPS-native per-user Linux runtimes
+- **Project Type**: Monorepo web application with platform backend, Next.js shell, and VPS lifecycle services
+- **Performance Goals**: Reduce median subscription-authorization-to-ready latency by at least 60%; 80% of users spending at least 60 seconds in checkout ready within 20 seconds of authorization
+- **Constraints**: Zero access before signed slot entitlement; zero duplicate active intents/machines; 30-minute Stripe/preparation lease; 99% cleanup by 35 minutes and 100% by 45 minutes outside provider outage; hard active-count and hourly-cost ceilings; generic client errors; all external calls bounded
+- **Scale/Scope**: V1 new-user primary-computer onboarding only; horizontally scaled platform workers; existing paid, additional-computer, recovery, resize, preview, grace, suspension, and self-hosted flows unchanged
+
+## Constitution Check
+
+*GATE: Passed before research and rechecked after design.*
+
+| Principle | Design evidence | Status |
+|---|---|---|
+| Data belongs to its owner | Machine is bound to the initiating owner from creation, never pooled/reassigned, and abandoned owner data/secrets are deleted; only minimal billing/security audit history remains | Pass |
+| AI is the kernel | Agent selection remains a durable onboarding input and existing runtime installation/kernel behavior is reused; no new parallel agent runtime is introduced | Pass |
+| Headless core, multi-shell | Preparation, activation, cleanup, and journey state are platform-owned contracts; Canvas/Desktop render the same server state | Pass |
+| Self-healing | Durable jobs, leases, exact provider reconciliation, signed-event replay, capacity repair, and cleanup continuation recover from restarts and ambiguous external calls | Pass |
+| Quality over shortcuts | No browser-orchestrated second mutation, generic bypass flag, reusable warm pool, or direct provider call from the request path | Pass |
+| Defense in depth | [HTTP auth matrix](./contracts/http.md), strict Zod/body limits, bounded calls, dual entitlement/activation gates, worker DI, revision fences, and full-path integration tests are specified | Pass |
+| TDD | Every implementation slice begins with failing focused and integration tests; authorization/cleanup predicates target full branch coverage | Pass |
+| PostgreSQL/Kysely | New durable state and global capacity are PostgreSQL/Kysely only; no alternate store or ORM | Pass |
+| Worktree/PR/Greptile | Work occurs in a manual persistent worktree and ships as reviewable Graphite PRs with current-head Greptile `5/5` | Pass |
+| Public documentation | A separate public-safe `FinnaAI/matrix-os-site` documentation PR is an explicit deliverable | Pass |
+
+There are no constitutional deviations. The post-design recheck specifically confirms that cleanup cannot delete based on a local timer, access has explicit defense-in-depth gates, related transitions are transactional, and the public documentation is not being placed in the monorepo's unrelated local `www/` tree.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/116-prebilling-provisioning/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── events.md
+│   └── http.md
+└── checklists/
+    └── requirements.md
+```
+
+`tasks.md` is intentionally deferred to `/speckit.tasks`; it is not a planning output.
+
+### Source Code (repository root)
+
+```text
+packages/platform/src/
+├── db.ts                                      # additive migrations and typed rows
+├── billing-routes.ts                          # existing checkout/webhook boundary
+├── stripe-billing.ts                          # exact metadata and bounded Stripe calls
+├── journey.ts
+├── journey-routes.ts
+├── app-session-routes.ts
+├── request-routing.ts
+├── profile-routing.ts
+├── session-routing-middleware.ts
+├── session-routing-proxy.ts
+├── session-routing-websocket.ts
+├── platform-websocket-upgrade.ts
+├── customer-vps.ts                            # shared machine/job creation orchestration
+├── customer-vps-provisioning-jobs.ts          # durable provider worker
+├── prebilling-provisioning-config.ts          # planned bounded config/rollout parsing
+├── prebilling-provisioning-store.ts           # planned Kysely state transitions
+├── prebilling-provisioning.ts                 # planned orchestration service
+├── prebilling-cleanup-actions.ts               # planned cleanup worker/state machine
+└── prebilling-provisioning-telemetry.ts        # planned bounded metrics/events
+
+shell/src/
+├── components/BootSequence.tsx
+├── components/settings/sections/BillingPanel.tsx
+├── lib/billing.ts
+└── lib/provisioning-handoff.ts
+
+tests/platform/
+├── billing-db.test.ts
+├── billing-routes.test.ts
+├── billing-settling.test.ts
+├── stripe-billing.test.ts
+├── journey.test.ts
+├── journey-routes.test.ts
+├── customer-vps-provisioning-durability.test.ts
+├── customer-vps-reliability.test.ts
+├── app-session-runtime-routing.test.ts
+├── proxy-routing-billing.test.ts
+├── session-routing.test.ts
+└── prebilling-provisioning.test.ts             # planned focused state/full-path suite
+
+tests/shell/
+├── billing-gate.test.tsx
+├── billing-panel-preselect.test.tsx
+└── prebilling-onboarding.test.tsx              # planned Canvas/Desktop journey suite
+```
+
+**Structure Decision**: Keep the feature inside the existing platform and shell packages. Extract new focused state/worker modules instead of adding behavior to already-large billing and customer-VPS composition files. Reuse the established checkout, signed subscription projection, provisioning-job, provider-reconciliation, snapshot, routing, and journey paths through typed dependency injection.
+
+## Architecture and Invariants
+
+```text
+compute + region + agents
+          |
+          v
+POST /billing/checkout --Stripe open session--> durable intent + machine/job
+          |                                      |
+          |                                      +--> provider preparation
+          |                                             (owner-bound, inaccessible)
+          v
+Stripe-hosted checkout
+          |
+          v signed subscription event
+authoritative subscription projection
+          |
+          +--> cancel cleanup + authorize exact machine
+          |         or ensure one normal provisioning job
+          v
+runtime routing requires entitlement AND activation_state=authorized
+
+Stripe authoritative expiry + no entitlement
+          |
+          v
+leased cleanup -> recheck/fence -> provider delete -> reconcile absent -> finalize
+```
+
+Non-negotiable implementation invariants:
+
+1. **Billing source of truth**: only the existing verified subscription projection for a recognized Price and exact runtime slot authorizes initial runtime access.
+2. **Provisioning source of truth**: one durable preparation intent links the immutable selection, checkout attempt, machine, provisioning job, and cleanup revision.
+3. **Access gate**: all customer routing/operation paths require both effective entitlement and `activation_state=authorized`; physical `running` is insufficient.
+4. **Owner and slot lock scope**: unique active checkout/intent/machine constraints plus transactional owner/slot locking make retries converge.
+5. **Cleanup lock scope**: lock intent, cleanup action, machine, current entitlement projection, and newer owner/slot intents in one documented order before the irreversible phase transition.
+6. **Acceptable orphan states**: an open checkout with no preparation is safe and falls back after authorization; an unauthorized prepared machine is temporarily acceptable only under an active lease/cleanup action; an authorized slot with no live machine is acceptable only with one durable normal provisioning job.
+7. **Provider ambiguity**: deterministic provider identity/labels are reconciled before create/delete retry; terminal cleanup means confirmed provider absence.
+8. **Rollback**: disabling admission stops new cost but continuation workers keep authorization, fallback provisioning, reconciliation, and cleanup alive.
+
+## Implementation Sequence
+
+### Commit 1 — Flag-off persistence and lifecycle foundation
+
+Write failing database/state tests, then:
+
+- Add the intent, activation, authorization-basis, cleanup-action, and capacity-bucket schema from [data-model.md](./data-model.md), with rollback-safe defaults and constraints.
+- Implement strict configuration parsing for enabled state, deterministic rollout/allowlist, active count, cost ceiling, worker leases, and bounded retry/timeout values. Unknown/malformed costs fail admission closed.
+- Extract transaction-aware Kysely stores. Repository wrappers accept a transaction handle and never destroy shared pools.
+- Extend the shared machine/job creation path with a narrow discriminated authorization basis. Keep the existing public entitled provision method unchanged.
+- Add activation checks to every runtime/customer operation path in the auth matrix before the feature can create `awaiting_billing` machines.
+- Add the cleanup worker with recurring leased claims, shutdown drain, bounded retries, Stripe reconciliation, exact provider deletion reconciliation, and local-secret cleanup.
+- Register all worker dependencies at startup and verify the worker-enabled Cloud Run role owns timers/resources and destroys only resources it created.
+
+Exit gate: admission remains `0%`; migrations, activation regression tests, job authorization checks, cleanup state tests, worker startup/shutdown tests, and existing lifecycle suites pass.
+
+### Commit 2 — Checkout, Stripe projection, and server-owned fallback
+
+Write failing checkout/webhook/race integration tests, then:
+
+- Extend the existing strict checkout schema/client call to include canonical developer tools and server type; correct active-attempt selection equality.
+- Claim the checkout attempt and opaque intent ID before Stripe so both metadata scopes carry the exact ID. Do not start provider work until an open session is durably finalized.
+- Reconcile ambiguous Stripe Session creation against the durable attempt/idempotency identity.
+- In the checkout-finalization transaction, admit capacity and create the machine/job once. If preparation admission is unavailable, return the safe checkout destination with zero provider calls.
+- Extend signed subscription projection processing to validate the exact local binding, cancel cleanup, authorize the prepared machine atomically, release cost once, and replay idempotently.
+- In that same server-owned projection workflow, guarantee an entitled primary slot has its valid prepared machine or exactly one entitlement-backed provisioning job. This removes the post-payment browser-click dependency even when prebilling is skipped or fails.
+- Handle event reordering: a subscription projection may arrive while checkout finalization is reconciling; either transaction must leave the authorization guarantee true after replay.
+
+Exit gate: fake Stripe/provider full-path tests pass, including completed-without-subscription quarantine, authorization in every cleanup phase, stale expiry, duplicate retries, capacity denial, provider ambiguity, and paid-without-machine fallback.
+
+### Commit 3 — Journey, shell, observability, and rollout controls
+
+Write failing journey/UI/telemetry tests, then:
+
+- Extend journey with optional coarse preparation state and `resume_checkout`; keep existing consumers compatible.
+- Move developer-tool selection before checkout for the eligible new-primary cohort. The explicit button opens checkout and preparation in one mutation; no separate browser provisioning request exists.
+- Render preparing, ready-waiting-for-billing, payment-settling, authorized-provisioning, safe failure, and ready states using `@matrix-os/brand` primitives. Keep all provider/internal details out of UI state.
+- Guard active-document/account changes and multi-tab retries by always refreshing authoritative journey state after ambiguous client outcomes.
+- Add the event/metric contract, dashboards, baseline cohort comparison, cleanup/cost alerts, and an operator admission kill switch that leaves continuation workers running.
+- Validate Canvas first, then Desktop; ensure mobile or older clients using the stable checkout response continue to function.
+
+Exit gate: shell build/React checks, UI contracts, coarse-error checks, metric cardinality tests, and the complete existing onboarding/billing suite pass with admission still disabled by default.
+
+### Separate public documentation PR
+
+After the implementation contract stabilizes, update `FinnaAI/matrix-os-site/content/docs/` in a separate worktree/PR. Explain compute → agents → secure checkout/preparation → billing authorization → ready and what happens if checkout is abandoned. Keep provider identities, infrastructure details, private identifiers, and operator procedures out of public docs.
+
+## Security and Failure Design
+
+- Apply `bodyLimit` before parsing every touched mutating route and use strict Zod discriminated/route schemas.
+- Preserve Stripe signature verification and bounded raw webhook bodies; event IDs make replay idempotent.
+- Every Stripe/provider `fetch` or SDK call has an explicit timeout. Provider errors are logged and normalized before reaching route/journey/UI state.
+- Never use raw `X-Forwarded-*`, `Host`, IP, or client identifiers for admission. Per-origin enforcement must be configured at a trusted edge; durable account/global controls remain authoritative in Postgres.
+- Do not expose a generic `skipBilling`, preview flag, internal preparation route, or machine identifier to the browser.
+- Leases are finite and reclaimable; timers/registries have caps, recurring cleanup, and explicit shutdown drains.
+- A failed preparation cannot cancel or downgrade a valid subscription. A failed/late billing event cannot resurrect deleted provider state; it creates a normal entitled job.
+- A later subscription cancellation or grace transition follows the existing billing runtime-action policy; prebilling adds no new cancellation semantics after authorization.
+
+## TDD and Verification Strategy
+
+The detailed matrix is in [quickstart.md](./quickstart.md). Implementation follows red → green → refactor per stack and includes:
+
+- Unit tests for schemas, canonical selection equality, feature/cost config, transition predicates, capacity accounting, and safe error mapping.
+- Kysely integration tests for unique constraints, transaction rollback, concurrent claims, optimistic revisions, event replay, capacity release-once behavior, and migration defaults.
+- Full fake-service integration for checkout → preparation → physical ready/inaccessible → signed subscription → activation/routing.
+- Exhaustive billing-cleanup interleavings at every irreversible phase and ambiguous provider create/delete reconciliation.
+- HTTP and WebSocket access-matrix tests covering session routing, explicit VM route, app session, runtime REST/API, code domain, terminal, recover, resize, and resume.
+- Regression tests for existing paid provisioning, additional computers, preview, recovery, resize, grace, suspension, and billing resumption.
+- Shell tests for selection ordering, one-mutation checkout, safe progress, refresh/multi-tab resumption, account changes, Canvas-first rendering, and Desktop compatibility.
+- Coverage and production shell build before exact-head preproduction validation.
+
+## Rollout and Operations
+
+1. Deploy additive schema, activation gates, and continuation workers with admission disabled.
+2. Prove startup ownership, cleanup draining, metrics, and repair reconciliation in the worker-enabled revision.
+3. Soak fake/synthetic traffic, then—only with explicit operator authorization—use Stripe test mode and one disposable VPS for exact-head full-path validation.
+4. Enable deterministic internal allowlist, then `1%`, `10%`, `50%`, and `100%`, holding at least one cleanup window and checking the success/stop metrics at every stage.
+5. Compare against a stable postbilling control cohort for authorization-to-ready latency, conversion, provider failure, cleanup lag, and paid-without-machine incidence.
+6. Set admission to zero immediately on an invariant, cost, duplicate, cleanup, or latency stop condition. Existing intents continue to authorize or clean up.
+
+The platform/app-shell deployment path is used for this change. Production customer runtimes remain VPS-native; no Docker Compose deployment or fleet host-bundle rollout is implied by this plan.
+
+## Delivery Shape
+
+- One implementation PR with three reviewable phase commits, each safe with admission disabled. Stop and split before publication if the aggregate diff exceeds 3,000 additions or 50 files.
+- Conventional Commit titles and bodies containing source of truth, transaction/lock scope, acceptable orphan states, auth source of truth, and deferred scope.
+- Current-head CI and trusted Greptile `5/5` on every PR; all material findings fixed or explicitly deferred with a linked issue before merge.
+- Separate `matrix-os-site` documentation PR, also reviewed to the repository's required gate.
+
+## Deferred Scope
+
+- Additional-computer prebilling, operator previews, recovery, resize, self-hosted runtimes, and warm/reusable pools.
+- Agent authentication or running user agents before billing authorization; only tool IDs are selected precheckout.
+- Pricing, trial, grace, cancellation, suspension, and payment-recovery policy changes.
+- Provider failover that changes a user's selected region or compute shape.
+- Customer-facing machine resize or plan-change UI.
+
+## Complexity Tracking
+
+No constitution violations require justification. The deliberate added complexity—a dedicated intent and cleanup state machine—is required because checkout, provider lifecycle, and signed access authorization can race independently; reusing a billing status or unfenced deletion queue would not preserve the access and deletion invariants.

--- a/specs/116-prebilling-provisioning/plan.md
+++ b/specs/116-prebilling-provisioning/plan.md
@@ -17,7 +17,7 @@ Move new-primary VPS preparation into the payable-checkout window: after the sig
 - **Target Platform**: Cloud Run platform/app-shell control plane coordinating VPS-native per-user Linux runtimes
 - **Project Type**: Monorepo web application with platform backend, Next.js shell, and VPS lifecycle services
 - **Performance Goals**: Reduce median subscription-authorization-to-ready latency by at least 60%; 80% of users spending at least 60 seconds in checkout ready within 20 seconds of authorization
-- **Constraints**: Zero access before signed slot entitlement; zero duplicate active intents/machines; 30-minute Stripe/preparation lease; 99% cleanup by 35 minutes and 100% by 45 minutes outside provider outage; hard active-count and hourly-cost ceilings; generic client errors; all external calls bounded
+- **Constraints**: Zero access before signed slot entitlement; zero duplicate active intents/machines; 30-minute Stripe/preparation policy plus one-minute API safety headroom; 99% cleanup by 35 minutes and 100% by 45 minutes outside provider outage; hard active-count and hourly-cost ceilings; generic client errors; all external calls bounded
 - **Scale/Scope**: V1 new-user primary-computer onboarding only; horizontally scaled platform workers; existing paid, additional-computer, recovery, resize, preview, grace, suspension, and self-hosted flows unchanged
 
 ## Constitution Check

--- a/specs/116-prebilling-provisioning/quickstart.md
+++ b/specs/116-prebilling-provisioning/quickstart.md
@@ -1,0 +1,103 @@
+# Validation Quickstart: Prebilling Provisioning
+
+This feature is developed test-first and remains disabled by default until every access and cleanup invariant passes. Commands run from the repository root of the feature worktree.
+
+## 1. Red: Contract and State-Machine Tests
+
+Add failing tests before each implementation slice. Start with focused suites for:
+
+- strict checkout schema, canonical selections, conflicting retries, and no-provider-call checkout failure
+- intent, capacity-reservation, activation, and cleanup migrations/queries
+- revision-checked transition helpers and event replay idempotency
+- provisioning-worker authorization-basis rechecks
+- signed subscription promotion and server-owned fallback provisioning
+- Stripe-expiry and billing-versus-cleanup races
+- journey response and onboarding component states
+
+Run the smallest affected Vitest target first, for example:
+
+```bash
+pnpm exec vitest run tests/platform/billing-routes.test.ts
+pnpm exec vitest run tests/platform/customer-vps-provisioning-durability.test.ts
+pnpm exec vitest run tests/shell/prebilling-onboarding.test.tsx
+```
+
+Use actual discovered filenames when implementation starts; do not create parallel test conventions solely to match these examples.
+
+## 2. Green: Fake Stripe and Provider Integration
+
+The hermetic full-path integration test must exercise:
+
+```text
+authenticated checkout request
+  -> durable checkout/intent claim
+  -> fake Stripe open session
+  -> durable provider job
+  -> fake provider create/reconcile
+  -> physical machine ready but inaccessible
+  -> signed subscription event
+  -> atomic activation
+  -> runtime HTTP and WebSocket access
+```
+
+Required negative/race cases:
+
+- concurrent identical checkout requests produce one session, intent, job, and provider machine
+- conflicting selections cannot mutate a payable intent
+- Checkout creation definite failure produces zero provider calls
+- capacity/cost denial produces zero provider calls and safely falls back after authorization
+- provider create timeout reconciles the accepted machine instead of creating another
+- physical readiness before billing remains inaccessible across session routing, explicit VM routing, app session, runtime API, code-domain routing, WebSocket, terminal, recover, resize, and resume paths
+- checkout completion without a subscription projection remains `payment_settling` and is not deleted
+- Stripe expiry without entitlement cleans up; deletion timeout reconciles until provider absence
+- signed authorization racing every cleanup phase cancels cleanup before irreversible deletion and preserves one machine
+- stale expiry after authorization cannot reverse activation
+- preparation failure followed by authorization creates exactly one entitlement-backed fallback job
+- existing paid, additional-computer, recovery, resize, grace, suspension, and preview tests are unchanged
+
+## 3. Repository Verification
+
+Run focused tests during red/green/refactor, then the repository gates appropriate to the touched packages:
+
+```bash
+bun run test
+bun run test:coverage
+bun run build:shell:production
+pnpm dlx react-doctor@latest .
+```
+
+Also run the repository's platform typecheck/lint targets discovered at implementation time. New platform/gateway logic targets 99–100% branch coverage, especially authorization and cleanup predicates.
+
+## 4. Preproduction Validation
+
+No live resource is created from this planning artifact. After implementation has an exact reviewed head and explicit operator approval:
+
+1. Deploy schema and continuation workers with admission disabled.
+2. Verify migrations, worker registration, cleanup drains, and metrics in the worker-enabled platform revision before directing traffic to it.
+3. Run Stripe test-mode checkout plus a disposable feature VPS in the selected region/shape.
+4. Delay checkout long enough to prove overlap; verify all prebilling routing probes deny access.
+5. Deliver the signed test subscription projection and verify activation uses the same machine.
+6. Repeat with authoritative expiry and verify provider absence plus local-secret cleanup.
+7. Repeat the authorization-vs-cleanup race under instrumentation.
+8. Validate Canvas onboarding first, then Desktop and refresh/multi-tab resumption.
+9. Ask whether to delete any disposable test VPS after validation to avoid charges; cleanup of test resources must be confirmed.
+
+## 5. Production Rollout
+
+Roll out only new-primary onboarding through deterministic cohorts:
+
+1. `0%`: migrations/workers deployed; admission off; synthetic/fake soak.
+2. Internal allowlist: explicit cost ceiling and on-call coverage.
+3. `1%`: hold through at least one full cleanup window and inspect every intent.
+4. `10%`: hold until latency, conversion, cleanup, duplicate, and entitlement-gap thresholds pass.
+5. `50%`: repeat the hold and compare against the postbilling control cohort.
+6. `100%`: retain flag, caps, dashboards, and continuation workers permanently.
+
+At any stop, set new admission to zero. Do not disable authorization reconciliation, fallback provisioning, or cleanup.
+
+## 6. Delivery and Documentation
+
+- Ship the implementation as one monitored PR with phase commits for flag-off persistence/workers, checkout/authorization, and shell/journey/observability, per the requester's explicit delivery direction.
+- Every PR uses a Conventional Commit title, includes the mandatory invariant section, and reaches trusted current-head Greptile `5/5` before merge.
+- Open a separate public-safe PR in `FinnaAI/matrix-os-site` under `content/docs/` explaining compute → agents → secure checkout/preparation → billing authorization → ready. Do not publish provider details, private hostnames, internal IDs, credentials, or operator commands.
+- This onboarding/platform change deploys through the platform/app-shell path. It is not a customer VPS Docker or host-bundle rollout unless a later implementation diff independently changes host-bundle contents.

--- a/specs/116-prebilling-provisioning/quickstart.md
+++ b/specs/116-prebilling-provisioning/quickstart.md
@@ -46,10 +46,3 @@ No live resource is created from this planning artifact. After implementation ha
 9. Ask whether to delete any disposable test VPS after validation to avoid charges; cleanup of test resources must be confirmed.
 
 The implementation PR performs no live Stripe, provider, deployment, or billing mutation. Test-mode/disposable-VPS validation remains an operator-approved post-review step.
-
-## 3. Delivery and Documentation
-
-- Ship the implementation as one monitored PR with phase commits for flag-off persistence/workers, checkout/authorization, and shell/journey/observability, per the requester's explicit delivery direction.
-- Every PR uses a Conventional Commit title, includes the mandatory invariant section, and reaches trusted current-head Greptile `5/5` before merge.
-- Open a separate public-safe PR in `FinnaAI/matrix-os-site` under `content/docs/` explaining compute → agents → secure checkout/preparation → billing authorization → ready. Do not publish provider details, private hostnames, internal IDs, credentials, or operator commands.
-- This onboarding/platform change deploys through the platform/app-shell path. It is not a customer VPS Docker or host-bundle rollout unless a later implementation diff independently changes host-bundle contents.

--- a/specs/116-prebilling-provisioning/quickstart.md
+++ b/specs/116-prebilling-provisioning/quickstart.md
@@ -2,6 +2,18 @@
 
 This feature is developed test-first and remains disabled by default until every access and cleanup invariant passes. Commands run from the repository root of the feature worktree.
 
+Admission requires all of these server-owned settings; missing values keep it off:
+
+```text
+MATRIX_PREBILLING_PROVISIONING_ENABLED=true
+MATRIX_PREBILLING_PROVISIONING_ROLLOUT_PERCENT=<0..100>
+MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE=<positive integer>
+MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS=<positive integer>
+MATRIX_PREBILLING_PROVISIONING_COSTS_JSON={"cpx22":...,"cpx32":...,"cpx52":...}
+```
+
+Setting `ENABLED=false` or rollout to `0` stops only new admission. Signed subscription activation and signed-expiry cleanup remain wired so existing intents can converge safely.
+
 ## 1. Red: Contract and State-Machine Tests
 
 Add failing tests before each implementation slice. Start with focused suites for:
@@ -81,6 +93,8 @@ No live resource is created from this planning artifact. After implementation ha
 7. Repeat the authorization-vs-cleanup race under instrumentation.
 8. Validate Canvas onboarding first, then Desktop and refresh/multi-tab resumption.
 9. Ask whether to delete any disposable test VPS after validation to avoid charges; cleanup of test resources must be confirmed.
+
+The implementation PR performs no live Stripe, provider, deployment, or billing mutation. Test-mode/disposable-VPS validation remains an operator-approved post-review step.
 
 ## 5. Production Rollout
 

--- a/specs/116-prebilling-provisioning/quickstart.md
+++ b/specs/116-prebilling-provisioning/quickstart.md
@@ -14,43 +14,7 @@ MATRIX_PREBILLING_PROVISIONING_COSTS_JSON={"cpx22":...,"cpx32":...,"cpx52":...}
 
 Setting `ENABLED=false` or rollout to `0` stops only new admission. Signed subscription activation and signed-expiry cleanup remain wired so existing intents can converge safely.
 
-## 1. Red: Contract and State-Machine Tests
-
-Add failing tests before each implementation slice. Start with focused suites for:
-
-- strict checkout schema, canonical selections, conflicting retries, and no-provider-call checkout failure
-- intent, capacity-reservation, activation, and cleanup migrations/queries
-- revision-checked transition helpers and event replay idempotency
-- provisioning-worker authorization-basis rechecks
-- signed subscription promotion and server-owned fallback provisioning
-- Stripe-expiry and billing-versus-cleanup races
-- journey response and onboarding component states
-
-Run the smallest affected Vitest target first, for example:
-
-```bash
-pnpm exec vitest run tests/platform/billing-routes.test.ts
-pnpm exec vitest run tests/platform/customer-vps-provisioning-durability.test.ts
-pnpm exec vitest run tests/shell/prebilling-onboarding.test.tsx
-```
-
-Use actual discovered filenames when implementation starts; do not create parallel test conventions solely to match these examples.
-
-## 2. Green: Fake Stripe and Provider Integration
-
-The hermetic full-path integration test must exercise:
-
-```text
-authenticated checkout request
-  -> durable checkout/intent claim
-  -> fake Stripe open session
-  -> durable provider job
-  -> fake provider create/reconcile
-  -> physical machine ready but inaccessible
-  -> signed subscription event
-  -> atomic activation
-  -> runtime HTTP and WebSocket access
-```
+## 1. Fake Stripe and Provider Integration
 
 Required negative/race cases:
 
@@ -67,20 +31,7 @@ Required negative/race cases:
 - preparation failure followed by authorization creates exactly one entitlement-backed fallback job
 - existing paid, additional-computer, recovery, resize, grace, suspension, and preview tests are unchanged
 
-## 3. Repository Verification
-
-Run focused tests during red/green/refactor, then the repository gates appropriate to the touched packages:
-
-```bash
-bun run test
-bun run test:coverage
-bun run build:shell:production
-pnpm dlx react-doctor@latest .
-```
-
-Also run the repository's platform typecheck/lint targets discovered at implementation time. New platform/gateway logic targets 99–100% branch coverage, especially authorization and cleanup predicates.
-
-## 4. Preproduction Validation
+## 2. Preproduction Validation
 
 No live resource is created from this planning artifact. After implementation has an exact reviewed head and explicit operator approval:
 
@@ -96,20 +47,7 @@ No live resource is created from this planning artifact. After implementation ha
 
 The implementation PR performs no live Stripe, provider, deployment, or billing mutation. Test-mode/disposable-VPS validation remains an operator-approved post-review step.
 
-## 5. Production Rollout
-
-Roll out only new-primary onboarding through deterministic cohorts:
-
-1. `0%`: migrations/workers deployed; admission off; synthetic/fake soak.
-2. Internal allowlist: explicit cost ceiling and on-call coverage.
-3. `1%`: hold through at least one full cleanup window and inspect every intent.
-4. `10%`: hold until latency, conversion, cleanup, duplicate, and entitlement-gap thresholds pass.
-5. `50%`: repeat the hold and compare against the postbilling control cohort.
-6. `100%`: retain flag, caps, dashboards, and continuation workers permanently.
-
-At any stop, set new admission to zero. Do not disable authorization reconciliation, fallback provisioning, or cleanup.
-
-## 6. Delivery and Documentation
+## 3. Delivery and Documentation
 
 - Ship the implementation as one monitored PR with phase commits for flag-off persistence/workers, checkout/authorization, and shell/journey/observability, per the requester's explicit delivery direction.
 - Every PR uses a Conventional Commit title, includes the mandatory invariant section, and reaches trusted current-head Greptile `5/5` before merge.

--- a/specs/116-prebilling-provisioning/research.md
+++ b/specs/116-prebilling-provisioning/research.md
@@ -6,23 +6,11 @@
 
 **Rationale**: At that point Matrix has every immutable provisioning input and a server-owned payable session, while checkout time can overlap the build. Stripe Checkout Sessions support an explicit expiration from 30 minutes to 24 hours; V1 uses a 30-minute policy window plus one minute of API transport/clock-skew headroom so Stripe does not reject a request that arrives just under its minimum. The provider-cost lease and payment window share that authority ([Stripe Checkout Session create reference](https://docs.stripe.com/api/checkout/sessions/create)).
 
-**Alternatives considered**:
-
-- Start immediately after compute selection: rejected because region, billing interval, and agent choices can still change and a mere picker interaction is weak consent for billable provider work.
-- Start only after `checkout.session.completed`: rejected because it preserves the current serial latency and paid-without-provisioning handoff.
-- Keep a reusable warm pool: rejected because `specs/109-golden-vps-snapshots/` supersedes warm pools and requires just-in-time owner-specific VPS creation.
-
 ## Decision 2: Add a dedicated preparation intent instead of a billing bypass flag
 
 **Decision**: Add `prebilling_provisioning_intents` as the control-plane source of truth linking one checkout attempt, one owner/runtime slot, one machine, and one bounded lease. Add an explicit `activation_state` to `user_machines` and an explicit `authorization_basis` to `provisioning_jobs`. Extend checkout selection equality to include server type and agent choices. Do not add `skipBilling`, reuse preview authorization, or weaken the normal `customerVpsService.provision()` entitlement contract.
 
 **Rationale**: Billing state, provider progress, and access authorization move independently. A dedicated intent provides an auditable state machine and a revision fence without overloading `billing_checkout_attempts.status` or `user_machines.status`. Existing unique active-slot indexes and provisioning-job leases remain useful.
-
-**Alternatives considered**:
-
-- Add preparation columns only to `billing_checkout_attempts`: rejected because checkout lifecycle (`creating/open/paid/expired`) and provider cleanup lifecycle are independent and need separate terminal histories.
-- Treat a provisional machine as a preview: rejected because previews have operator authorization, different capacity rules, and different ownership semantics.
-- Pass an internal boolean to the existing provision method: rejected because a generic entitlement bypass is too easy to call from the wrong route.
 
 ## Decision 3: Reuse the durable provisioning job with a narrow second authorization basis
 
@@ -30,21 +18,11 @@
 
 **Rationale**: `provisioning_jobs` already supplies durable queueing, leases, retry budgets, exact provider-create action reconciliation, snapshot selection, and restart recovery. Duplicating a second provider worker would recreate the hardest failure modes and drift from golden-snapshot activation.
 
-**Alternatives considered**:
-
-- Create a separate prebilling provider worker: rejected because it would duplicate provider reconciliation and snapshot activation.
-- Invoke the provider directly from `/billing/checkout`: rejected because request timeouts and Cloud Run restarts would leave ambiguous creates without a durable owner.
-
 ## Decision 4: Preserve the signed subscription projection as the only access grant
 
 **Decision**: Include only the opaque preparation-intent ID in both Checkout Session metadata and `subscription_data.metadata`. The existing signed `customer.subscription.created`/`updated` projection validates that ID against the local checkout, Clerk user, runtime slot, plan/Price, and selections, then transactionally marks the intent and machine authorized. `checkout.session.completed`, the browser return, invoices, local readiness, and the preparation worker never grant access.
 
 **Rationale**: Stripe documents that `subscription_data.metadata` is copied to the created Subscription and therefore appears on subscription events, while top-level Checkout metadata appears on Checkout Session events ([Stripe metadata documentation](https://docs.stripe.com/metadata)). This preserves the current exact-slot entitlement authority and makes event reordering safe.
-
-**Alternatives considered**:
-
-- Activate from `checkout.session.completed`: rejected because the existing billing contract explicitly treats the subscription projection as authoritative and checkout completion may precede a valid recognized subscription projection.
-- Activate from the success redirect: rejected because browser redirects are forgeable/replayable and can be missed.
 
 ## Decision 5: Keep prebilling machines owner-bound but unreachable
 
@@ -52,23 +30,11 @@
 
 **Rationale**: Owner binding lets the exact computer survive authorization and prevents cross-owner reuse. A second activation fence provides defense in depth beyond the existing entitlement checks while keeping old code rollback-safe: older code still blocks the machine through the established billing gate.
 
-**Alternatives considered**:
-
-- Leave the machine unowned until payment: rejected because host secrets, R2 prefix, identity, and exact slot are customer-specific and ownership assignment would become a separate race.
-- Reassign abandoned machines: rejected by the data-ownership invariant and the golden-snapshot decision against reusable customer VPSes.
-
 ## Decision 6: Reclaim only after authoritative checkout expiry
 
 **Decision**: Set the Stripe session and local preparation lease to the 30-minute policy window plus one minute of safety headroom. The cleanup reconciler may claim cleanup only when the local lease is due, a bounded Stripe retrieval or processed webhook proves the session `expired`, no effective slot entitlement exists, the intent revision is unchanged, and no newer active intent exists. A completed session without a subscription remains `payment_settling`, triggers alerts, and is never auto-deleted as abandonment. Use a dedicated durable `prebilling_cleanup_actions` worker with claim leases and cancellation fencing, modeled on `billing_runtime_actions`; it expires/reconciles Checkout before handing the exact provider ID to deletion and does not mark cleanup complete until provider absence is confirmed.
 
 **Rationale**: A browser cancel is not authoritative, webhook delivery can lag, and a local timer alone can race a just-completed checkout. Stripe manages Checkout Session status and expiration; requiring `expired` distinguishes abandonment from delayed subscription projection.
-
-**Alternatives considered**:
-
-- Delete 30 minutes after local creation regardless of Stripe state: rejected because it can delete a paid user's prepared machine during webhook delay.
-- Wait for the default 24-hour Stripe expiry: rejected because it leaves excessive provider cost and abuse exposure.
-- Delete on the cancel return URL: rejected because the browser may not return and the URL is not an authoritative billing event.
-- Send an unfenced row directly to the existing provider-deletion queue: rejected because that queue lacks the intent revision, cancellation lease, and billing recheck required before prebilling deletion.
 
 ## Decision 7: Keep the HTTP surface stable and extend journey annotations
 
@@ -76,21 +42,11 @@
 
 **Rationale**: Checkout is the user action that authorizes preparation, so a second client mutation would reintroduce the missing-click problem. A stable checkout response avoids breaking mobile/device clients; the journey remains the server-owned resumption surface.
 
-**Alternatives considered**:
-
-- Add `POST /api/auth/preprovision-runtime`: rejected because two browser mutations can partially succeed and recreate the exact handoff gap this feature removes.
-- Replace journey phases wholesale: rejected because existing phases can remain compatible with an optional preparation annotation and a composite precheckout chooser.
-
 ## Decision 8: Use a feature flag, strict capacity controls, and continuation-safe rollback
 
 **Decision**: Add an off-by-default primary-onboarding feature flag, deterministic rollout percentage/allowlist, and database-enforced active-count and reserved-hourly-cost ceilings. Apply per-account creation limits in Postgres and trusted network-origin limits at the edge rather than trusting forwarded headers in application code. Unknown server cost fails closed. Turning the flag off stops new intents but keeps workers reconciling, authorizing, or cleaning existing intents to terminal states.
 
 **Rationale**: Prebilling work has real cost before card authorization. A kill switch that also stops cleanup would leak resources, while application parsing of untrusted forwarding headers would violate the constitution.
-
-**Alternatives considered**:
-
-- Boolean flag that stops all workers: rejected because rollback would strand active machines and leases.
-- In-memory counters: rejected because Cloud Run instances are horizontal and in-memory caps are neither durable nor global.
 
 ## Decision 9: Authorization repairs paid-without-machine state server-side
 
@@ -98,18 +54,8 @@
 
 **Rationale**: Preparation is an optimization, while a signed subscription is a durable customer entitlement. This closes the historical gap where checkout succeeded but the browser never issued `/api/auth/provision-runtime`.
 
-**Alternatives considered**:
-
-- Continue asking the browser to click Build VPS after payment: rejected because it preserves the paid-without-machine failure mode.
-- Make preparation failure fail or cancel checkout: rejected because provider availability and billing authorization are separate concerns and existing retryable entitled provisioning is the safer fallback.
-
 ## Decision 10: Deliver as one monitored implementation PR plus a separate public-docs PR
 
 **Decision**: At the requester's explicit delivery direction, keep the flag-off persistence/worker foundation, checkout/authorization integration, and shell/journey/observability work as reviewable phase commits in one monitored PR. Keep the PR under the repository's hard size boundary; stop and split before publication if it would exceed 3,000 additions or 50 files. Publish the user-facing flow change separately in `FinnaAI/matrix-os-site` after the implementation contract is stable.
 
 **Rationale**: The requester explicitly asked for one PR and for every commit and the PR to use the Nima-Naderi GitHub identity. Phase commits keep trust boundaries auditable while the feature flag prevents partial exposure.
-
-**Alternatives considered**:
-
-- Publish an oversized implementation PR: rejected; the workflow must stop and split if the hard review boundary is reached.
-- Ship UI before backend: rejected because it would change user expectations without the durable preparation contract.

--- a/specs/116-prebilling-provisioning/research.md
+++ b/specs/116-prebilling-provisioning/research.md
@@ -1,0 +1,115 @@
+# Research: Prebilling Provisioning
+
+## Decision 1: Begin preparation only after Stripe creates an open Checkout Session
+
+**Decision**: Keep compute, region, billing interval, acquisition, and agent selection ahead of checkout. When `POST /billing/checkout` successfully creates and durably finalizes an open Stripe Checkout Session, atomically enqueue one owner-bound preparation intent and durable provisioning job, then return the existing checkout URL. Do not call the provider merely because a user highlighted a compute card or opened the billing UI.
+
+**Rationale**: At that point Matrix has every immutable provisioning input and a server-owned payable session, while checkout time can overlap the build. Stripe Checkout Sessions support an explicit expiration from 30 minutes to 24 hours; V1 uses the 30-minute minimum so the provider-cost lease and payment window share one authority ([Stripe Checkout Session create reference](https://docs.stripe.com/api/checkout/sessions/create)).
+
+**Alternatives considered**:
+
+- Start immediately after compute selection: rejected because region, billing interval, and agent choices can still change and a mere picker interaction is weak consent for billable provider work.
+- Start only after `checkout.session.completed`: rejected because it preserves the current serial latency and paid-without-provisioning handoff.
+- Keep a reusable warm pool: rejected because `specs/109-golden-vps-snapshots/` supersedes warm pools and requires just-in-time owner-specific VPS creation.
+
+## Decision 2: Add a dedicated preparation intent instead of a billing bypass flag
+
+**Decision**: Add `prebilling_provisioning_intents` as the control-plane source of truth linking one checkout attempt, one owner/runtime slot, one machine, and one bounded lease. Add an explicit `activation_state` to `user_machines` and an explicit `authorization_basis` to `provisioning_jobs`. Extend checkout selection equality to include server type and agent choices. Do not add `skipBilling`, reuse preview authorization, or weaken the normal `customerVpsService.provision()` entitlement contract.
+
+**Rationale**: Billing state, provider progress, and access authorization move independently. A dedicated intent provides an auditable state machine and a revision fence without overloading `billing_checkout_attempts.status` or `user_machines.status`. Existing unique active-slot indexes and provisioning-job leases remain useful.
+
+**Alternatives considered**:
+
+- Add preparation columns only to `billing_checkout_attempts`: rejected because checkout lifecycle (`creating/open/paid/expired`) and provider cleanup lifecycle are independent and need separate terminal histories.
+- Treat a provisional machine as a preview: rejected because previews have operator authorization, different capacity rules, and different ownership semantics.
+- Pass an internal boolean to the existing provision method: rejected because a generic entitlement bypass is too easy to call from the wrong route.
+
+## Decision 3: Reuse the durable provisioning job with a narrow second authorization basis
+
+**Decision**: Refactor the common machine/job creation path so entitled provisioning uses `authorization_basis=billing_entitlement` and prebilling preparation uses `authorization_basis=prebilling_intent`. Before every provider create or retry, the worker must re-resolve the selected basis and fail closed if the intent is no longer open, owner/slot/config matching, unexpired, and feature-enabled for continuation.
+
+**Rationale**: `provisioning_jobs` already supplies durable queueing, leases, retry budgets, exact provider-create action reconciliation, snapshot selection, and restart recovery. Duplicating a second provider worker would recreate the hardest failure modes and drift from golden-snapshot activation.
+
+**Alternatives considered**:
+
+- Create a separate prebilling provider worker: rejected because it would duplicate provider reconciliation and snapshot activation.
+- Invoke the provider directly from `/billing/checkout`: rejected because request timeouts and Cloud Run restarts would leave ambiguous creates without a durable owner.
+
+## Decision 4: Preserve the signed subscription projection as the only access grant
+
+**Decision**: Include only the opaque preparation-intent ID in both Checkout Session metadata and `subscription_data.metadata`. The existing signed `customer.subscription.created`/`updated` projection validates that ID against the local checkout, Clerk user, runtime slot, plan/Price, and selections, then transactionally marks the intent and machine authorized. `checkout.session.completed`, the browser return, invoices, local readiness, and the preparation worker never grant access.
+
+**Rationale**: Stripe documents that `subscription_data.metadata` is copied to the created Subscription and therefore appears on subscription events, while top-level Checkout metadata appears on Checkout Session events ([Stripe metadata documentation](https://docs.stripe.com/metadata)). This preserves the current exact-slot entitlement authority and makes event reordering safe.
+
+**Alternatives considered**:
+
+- Activate from `checkout.session.completed`: rejected because the existing billing contract explicitly treats the subscription projection as authoritative and checkout completion may precede a valid recognized subscription projection.
+- Activate from the success redirect: rejected because browser redirects are forgeable/replayable and can be missed.
+
+## Decision 5: Keep prebilling machines owner-bound but unreachable
+
+**Decision**: Create the machine as provisioning class `customer` with `activation_state=awaiting_billing`. It is permanently bound to the initiating Clerk user and may boot/register, but routing, app-session exchange, customer inventory selection, recovery, resize, resume, terminal, and other owner access paths require both normal billing authorization and `activation_state=authorized`. Operator inventory may show a coarse prebilling state.
+
+**Rationale**: Owner binding lets the exact computer survive authorization and prevents cross-owner reuse. A second activation fence provides defense in depth beyond the existing entitlement checks while keeping old code rollback-safe: older code still blocks the machine through the established billing gate.
+
+**Alternatives considered**:
+
+- Leave the machine unowned until payment: rejected because host secrets, R2 prefix, identity, and exact slot are customer-specific and ownership assignment would become a separate race.
+- Reassign abandoned machines: rejected by the data-ownership invariant and the golden-snapshot decision against reusable customer VPSes.
+
+## Decision 6: Reclaim only after authoritative checkout expiry
+
+**Decision**: Set the Stripe session and local preparation lease to 30 minutes. The cleanup reconciler may claim cleanup only when the local lease is due, a bounded Stripe retrieval or processed webhook proves the session `expired`, no effective slot entitlement exists, the intent revision is unchanged, and no newer active intent exists. A completed session without a subscription remains `payment_settling`, triggers alerts, and is never auto-deleted as abandonment. Use a dedicated durable `prebilling_cleanup_actions` worker with claim leases and cancellation fencing, modeled on `billing_runtime_actions`; it expires/reconciles Checkout before handing the exact provider ID to deletion and does not mark cleanup complete until provider absence is confirmed.
+
+**Rationale**: A browser cancel is not authoritative, webhook delivery can lag, and a local timer alone can race a just-completed checkout. Stripe manages Checkout Session status and expiration; requiring `expired` distinguishes abandonment from delayed subscription projection.
+
+**Alternatives considered**:
+
+- Delete 30 minutes after local creation regardless of Stripe state: rejected because it can delete a paid user's prepared machine during webhook delay.
+- Wait for the default 24-hour Stripe expiry: rejected because it leaves excessive provider cost and abuse exposure.
+- Delete on the cancel return URL: rejected because the browser may not return and the URL is not an authoritative billing event.
+- Send an unfenced row directly to the existing provider-deletion queue: rejected because that queue lacks the intent revision, cancellation lease, and billing recheck required before prebilling deletion.
+
+## Decision 7: Keep the HTTP surface stable and extend journey annotations
+
+**Decision**: Do not add a public preparation endpoint. Extend the existing strict `POST /billing/checkout` body usage so the shell sends the already-supported `developerTools` field, and let the route orchestrate preparation through a registration-time dependency. Preserve the `{ url }` success response. Extend `GET /api/journey` with an optional coarse `preparation` annotation and a `resume_checkout` next action for an open session. Keep `/api/auth/provision-runtime` entitlement-only for legacy paid-without-machine recovery.
+
+**Rationale**: Checkout is the user action that authorizes preparation, so a second client mutation would reintroduce the missing-click problem. A stable checkout response avoids breaking mobile/device clients; the journey remains the server-owned resumption surface.
+
+**Alternatives considered**:
+
+- Add `POST /api/auth/preprovision-runtime`: rejected because two browser mutations can partially succeed and recreate the exact handoff gap this feature removes.
+- Replace journey phases wholesale: rejected because existing phases can remain compatible with an optional preparation annotation and a composite precheckout chooser.
+
+## Decision 8: Use a feature flag, strict capacity controls, and continuation-safe rollback
+
+**Decision**: Add an off-by-default primary-onboarding feature flag, deterministic rollout percentage/allowlist, and database-enforced active-count and reserved-hourly-cost ceilings. Apply per-account creation limits in Postgres and trusted network-origin limits at the edge rather than trusting forwarded headers in application code. Unknown server cost fails closed. Turning the flag off stops new intents but keeps workers reconciling, authorizing, or cleaning existing intents to terminal states.
+
+**Rationale**: Prebilling work has real cost before card authorization. A kill switch that also stops cleanup would leak resources, while application parsing of untrusted forwarding headers would violate the constitution.
+
+**Alternatives considered**:
+
+- Boolean flag that stops all workers: rejected because rollback would strand active machines and leases.
+- In-memory counters: rejected because Cloud Run instances are horizontal and in-memory caps are neither durable nor global.
+
+## Decision 9: Authorization repairs paid-without-machine state server-side
+
+**Decision**: In the same signed subscription-projection workflow that authorizes a valid preparation, guarantee that an entitled primary slot has either the bound live machine or one durable normal provisioning job. If prebilling preparation never enqueued, failed before a usable machine existed, or was authoritatively cleaned, enqueue the existing entitlement-backed provisioning path without requiring another browser click.
+
+**Rationale**: Preparation is an optimization, while a signed subscription is a durable customer entitlement. This closes the historical gap where checkout succeeded but the browser never issued `/api/auth/provision-runtime`.
+
+**Alternatives considered**:
+
+- Continue asking the browser to click Build VPS after payment: rejected because it preserves the paid-without-machine failure mode.
+- Make preparation failure fail or cancel checkout: rejected because provider availability and billing authorization are separate concerns and existing retryable entitled provisioning is the safer fallback.
+
+## Decision 10: Deliver as one monitored implementation PR plus a separate public-docs PR
+
+**Decision**: At the requester's explicit delivery direction, keep the flag-off persistence/worker foundation, checkout/authorization integration, and shell/journey/observability work as reviewable phase commits in one monitored PR. Keep the PR under the repository's hard size boundary; stop and split before publication if it would exceed 3,000 additions or 50 files. Publish the user-facing flow change separately in `FinnaAI/matrix-os-site` after the implementation contract is stable.
+
+**Rationale**: The requester explicitly asked for one PR and for every commit and the PR to use the Nima-Naderi GitHub identity. Phase commits keep trust boundaries auditable while the feature flag prevents partial exposure.
+
+**Alternatives considered**:
+
+- Publish an oversized implementation PR: rejected; the workflow must stop and split if the hard review boundary is reached.
+- Ship UI before backend: rejected because it would change user expectations without the durable preparation contract.

--- a/specs/116-prebilling-provisioning/research.md
+++ b/specs/116-prebilling-provisioning/research.md
@@ -4,7 +4,7 @@
 
 **Decision**: Keep compute, region, billing interval, acquisition, and agent selection ahead of checkout. When `POST /billing/checkout` successfully creates and durably finalizes an open Stripe Checkout Session, atomically enqueue one owner-bound preparation intent and durable provisioning job, then return the existing checkout URL. Do not call the provider merely because a user highlighted a compute card or opened the billing UI.
 
-**Rationale**: At that point Matrix has every immutable provisioning input and a server-owned payable session, while checkout time can overlap the build. Stripe Checkout Sessions support an explicit expiration from 30 minutes to 24 hours; V1 uses the 30-minute minimum so the provider-cost lease and payment window share one authority ([Stripe Checkout Session create reference](https://docs.stripe.com/api/checkout/sessions/create)).
+**Rationale**: At that point Matrix has every immutable provisioning input and a server-owned payable session, while checkout time can overlap the build. Stripe Checkout Sessions support an explicit expiration from 30 minutes to 24 hours; V1 uses a 30-minute policy window plus one minute of API transport/clock-skew headroom so Stripe does not reject a request that arrives just under its minimum. The provider-cost lease and payment window share that authority ([Stripe Checkout Session create reference](https://docs.stripe.com/api/checkout/sessions/create)).
 
 **Alternatives considered**:
 
@@ -59,7 +59,7 @@
 
 ## Decision 6: Reclaim only after authoritative checkout expiry
 
-**Decision**: Set the Stripe session and local preparation lease to 30 minutes. The cleanup reconciler may claim cleanup only when the local lease is due, a bounded Stripe retrieval or processed webhook proves the session `expired`, no effective slot entitlement exists, the intent revision is unchanged, and no newer active intent exists. A completed session without a subscription remains `payment_settling`, triggers alerts, and is never auto-deleted as abandonment. Use a dedicated durable `prebilling_cleanup_actions` worker with claim leases and cancellation fencing, modeled on `billing_runtime_actions`; it expires/reconciles Checkout before handing the exact provider ID to deletion and does not mark cleanup complete until provider absence is confirmed.
+**Decision**: Set the Stripe session and local preparation lease to the 30-minute policy window plus one minute of safety headroom. The cleanup reconciler may claim cleanup only when the local lease is due, a bounded Stripe retrieval or processed webhook proves the session `expired`, no effective slot entitlement exists, the intent revision is unchanged, and no newer active intent exists. A completed session without a subscription remains `payment_settling`, triggers alerts, and is never auto-deleted as abandonment. Use a dedicated durable `prebilling_cleanup_actions` worker with claim leases and cancellation fencing, modeled on `billing_runtime_actions`; it expires/reconciles Checkout before handing the exact provider ID to deletion and does not mark cleanup complete until provider absence is confirmed.
 
 **Rationale**: A browser cancel is not authoritative, webhook delivery can lag, and a local timer alone can race a just-completed checkout. Stripe manages Checkout Session status and expiration; requiring `expired` distinguishes abandonment from delayed subscription projection.
 

--- a/specs/116-prebilling-provisioning/spec.md
+++ b/specs/116-prebilling-provisioning/spec.md
@@ -106,7 +106,7 @@ Existing customers, additional computers, recoveries, resizes, billing grace, su
 - **FR-011**: Initial runtime access MUST continue to come only from the established signed subscription projection for a recognized plan and exact runtime slot.
 - **FR-012**: Billing authorization MUST promote the existing prepared computer rather than create a replacement when its bound intent and selections remain valid.
 - **FR-013**: Preparation and authorization MUST use explicit lifecycle states that prevent unauthorized routing and distinguish preparation from normal entitled provisioning.
-- **FR-014**: An unauthorized preparation intent MUST expire 30 minutes after creation unless it has been authoritatively renewed by resuming the same payable checkout under a bounded policy.
+- **FR-014**: An unauthorized preparation intent MUST use a 30-minute expiration policy with no more than one minute of API transport and clock-skew safety headroom, unless it has been authoritatively renewed by resuming the same payable checkout under a bounded policy.
 - **FR-015**: Matrix MUST periodically reclaim expired unauthorized prepared computers and all associated platform-owned secrets, credentials, and transient records.
 - **FR-016**: Cleanup MUST re-resolve current billing authorization and the current intent revision immediately before every irreversible provider deletion; authorization or a newer intent MUST fence out stale cleanup.
 - **FR-017**: Provider creation and deletion outcomes that are ambiguous MUST be reconciled against provider state before retrying so Matrix does not leak or duplicate computers.

--- a/specs/116-prebilling-provisioning/spec.md
+++ b/specs/116-prebilling-provisioning/spec.md
@@ -1,0 +1,171 @@
+# Feature Specification: Prebilling Provisioning
+
+**Feature Branch**: `116-prebilling-provisioning`
+
+**Created**: 2026-08-24
+
+**Status**: Draft
+
+**Input**: User description: "Move VPS provisioning earlier in onboarding so Matrix starts preparing the user's selected computer before billing completes, after the user has chosen compute power, region, and coding agents."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Prepare While the User Checks Out (Priority: P1)
+
+A newly signed-in user chooses their computer power, region, and default coding agents before billing. When they explicitly continue to secure checkout, Matrix begins preparing that exact computer while the user completes checkout. After billing is confirmed, the user continues into an already-ready or nearly-ready computer instead of starting the build from zero.
+
+**Why this priority**: Provisioning and checkout currently happen serially. Overlapping them removes avoidable waiting from the highest-value onboarding path and removes the separate post-payment action that users can miss.
+
+**Independent Test**: Complete a new primary-computer signup with a deliberately delayed checkout, verify that computer preparation begins after the checkout intent, and verify that the correctly sized computer with the selected region and agents becomes accessible only after billing authorization.
+
+**Acceptance Scenarios**:
+
+1. **Given** a signed-in new user with no primary computer or active billing access, **When** they choose compute power, region, and agents and explicitly continue to checkout, **Then** Matrix records one preparation intent for those selections and begins preparing one inaccessible primary computer while checkout is open.
+2. **Given** preparation is in progress or complete, **When** a signed billing event authorizes the selected primary computer, **Then** Matrix activates that same computer for the user without creating a replacement.
+3. **Given** preparation finishes before billing authorization, **When** the user remains in checkout, **Then** the computer stays inaccessible and the user sees that preparation is underway without seeing provider or infrastructure details.
+4. **Given** billing authorization arrives before preparation finishes, **When** the user returns to Matrix, **Then** Matrix shows normal build progress and opens the computer when it becomes ready.
+
+---
+
+### User Story 2 - Recover Safely From Abandonment and Failure (Priority: P1)
+
+A user may close checkout, let it expire, encounter a declined payment, or lose their browser. Matrix must reclaim an unauthorized prepared computer promptly without deleting a computer whose billing authorization arrived concurrently.
+
+**Why this priority**: Prebilling preparation creates provider cost and an abuse surface before payment authorization. Bounded cleanup and race-safe ownership checks are required for the feature to be economically and operationally safe.
+
+**Independent Test**: Start preparation, abandon checkout, advance beyond the preparation lease, and verify the resource is reclaimed; repeat with billing authorization racing cleanup and verify the authorized computer always survives.
+
+**Acceptance Scenarios**:
+
+1. **Given** an unauthorized prepared computer whose 30-minute preparation lease has expired, **When** the cleanup process evaluates it, **Then** Matrix rechecks current billing authorization and reclaims it only if authorization is still absent.
+2. **Given** billing authorization and cleanup occur concurrently, **When** both operations settle, **Then** the authorized computer remains assigned and accessible and no replacement computer is created.
+3. **Given** checkout creation fails before a checkout session is available, **When** the failure is returned to the user, **Then** Matrix does not begin provider preparation.
+4. **Given** provider preparation fails while checkout remains available, **When** the user completes billing, **Then** Matrix preserves the authorized purchase and uses the normal retryable provisioning path without exposing raw provider errors.
+
+---
+
+### User Story 3 - Resume Without Duplicates (Priority: P2)
+
+A user can refresh, retry, or reopen onboarding while checkout or preparation is active. Matrix resumes the same intent and selections rather than creating duplicate checkout sessions or computers.
+
+**Why this priority**: Browser retries and ambiguous network outcomes are ordinary onboarding behavior. Idempotent resumption prevents duplicate infrastructure cost and confusing selection drift.
+
+**Independent Test**: Repeat the continue-to-checkout action concurrently and after simulated client timeouts, then verify one open checkout intent and at most one active provider computer exist for the primary slot.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active preparation intent, **When** identical continue requests are retried or arrive concurrently, **Then** Matrix returns the existing checkout destination and preparation state.
+2. **Given** an active preparation intent with different compute, region, or agent selections, **When** the user attempts to start another checkout, **Then** Matrix explains that an existing checkout must be resumed or abandoned before the selections can change.
+3. **Given** the browser times out after Matrix accepted the preparation request, **When** the journey is refreshed, **Then** authoritative server state shows checkout and preparation progress without requiring another computer creation request.
+
+---
+
+### User Story 4 - Preserve Existing Lifecycle Behavior (Priority: P3)
+
+Existing customers, additional computers, recoveries, resizes, billing grace, suspension, and operator previews continue using their established authorization and lifecycle rules.
+
+**Why this priority**: The optimization targets one onboarding path and must not weaken entitlement enforcement or destabilize established machine operations.
+
+**Independent Test**: Run existing lifecycle suites and verify that only an eligible new primary-computer checkout can enter prebilling preparation.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing paid customer or an additional-computer flow, **When** they provision or manage a computer, **Then** the existing authorization and lifecycle remain unchanged.
+2. **Given** an unauthorized client tries to access, route to, recover, resize, or resume a prepared computer, **When** Matrix evaluates the request, **Then** access is denied with a generic response.
+3. **Given** an operator preview request, **When** it is processed, **Then** it remains governed by the separate preview authorization and capacity policy.
+
+### Edge Cases
+
+- The Stripe session is created but the response to Matrix is ambiguous or times out.
+- The user completes checkout after the local preparation lease expires but before cleanup runs.
+- Cleanup starts before the billing webhook transaction commits and completes afterward.
+- A stale checkout-expired event arrives after a newer subscription event has authorized the computer.
+- Provider creation times out after the provider may have accepted the request.
+- The selected plan and region are individually valid but unavailable in combination.
+- The user selects no coding agents.
+- The user signs out or switches accounts while checkout is open.
+- The same account opens onboarding in multiple browser tabs.
+- The global provisional-computer capacity limit is reached.
+- Preparation completes but runtime health never becomes ready.
+- Billing authorization is later revoked under the existing trial, grace, or cancellation policy.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Matrix MUST collect and validate compute power, region, and default-agent selections before offering the action that begins checkout and preparation.
+- **FR-002**: The action that begins preparation MUST clearly tell the user that Matrix will start preparing their selected computer while secure checkout is open.
+- **FR-003**: Matrix MUST create a durable, owner-scoped preparation intent before requesting provider preparation.
+- **FR-004**: A preparation intent MUST bind the authenticated user, primary runtime slot, selected plan, billing interval, compute shape, region, agent selections, checkout attempt, lifecycle state, and preparation lease.
+- **FR-005**: Matrix MUST begin provider preparation only after a valid checkout session for the same intent is available.
+- **FR-006**: Matrix MUST allow at most one active checkout/preparation intent and at most one active customer computer per authenticated user and runtime slot.
+- **FR-007**: Identical retries and ambiguous client outcomes MUST converge on the existing preparation intent, checkout session, and computer.
+- **FR-008**: Matrix MUST reject selection changes while an existing checkout remains payable unless that checkout and its preparation intent have first become authoritatively abandoned or expired.
+- **FR-009**: A prepared computer MUST remain inaccessible through runtime routing, application sessions, recovery, resize, resume, terminal access, and owner traffic until authoritative billing authorization exists for that exact runtime slot.
+- **FR-010**: Browser redirects, client storage, checkout completion pages, invoice events, and local preparation state MUST NOT independently authorize runtime access.
+- **FR-011**: Initial runtime access MUST continue to come only from the established signed subscription projection for a recognized plan and exact runtime slot.
+- **FR-012**: Billing authorization MUST promote the existing prepared computer rather than create a replacement when its bound intent and selections remain valid.
+- **FR-013**: Preparation and authorization MUST use explicit lifecycle states that prevent unauthorized routing and distinguish preparation from normal entitled provisioning.
+- **FR-014**: An unauthorized preparation intent MUST expire 30 minutes after creation unless it has been authoritatively renewed by resuming the same payable checkout under a bounded policy.
+- **FR-015**: Matrix MUST periodically reclaim expired unauthorized prepared computers and all associated platform-owned secrets, credentials, and transient records.
+- **FR-016**: Cleanup MUST re-resolve current billing authorization and the current intent revision immediately before every irreversible provider deletion; authorization or a newer intent MUST fence out stale cleanup.
+- **FR-017**: Provider creation and deletion outcomes that are ambiguous MUST be reconciled against provider state before retrying so Matrix does not leak or duplicate computers.
+- **FR-018**: Preparation MUST have bounded per-user, per-runtime-slot, per-network-origin, and global concurrency/capacity controls with an explicit operational cost ceiling.
+- **FR-019**: Capacity exhaustion MUST fail closed without creating a provider resource, MUST preserve checkout safety by continuing with post-authorization fallback provisioning, and MUST expose only a generic preparation status if the user needs to be informed.
+- **FR-020**: Plan, compute shape, region, agent selections, runtime slot, and return path MUST be validated at their request boundaries before any external call or persisted intent.
+- **FR-021**: External billing and provider calls MUST have bounded timeouts, idempotency keys where supported, and generic client errors with detailed server-side diagnostics.
+- **FR-022**: Related writes for intent, checkout linkage, machine ownership, lifecycle transitions, cleanup claims, and authorization promotion MUST be atomic, and concurrency conditions MUST be enforced in the writes themselves.
+- **FR-023**: Preparation failures MUST NOT revoke or invalidate a successful billing authorization; an entitled user MUST fall back to the existing retryable provisioning journey.
+- **FR-024**: The journey UI MUST show distinct, resumable states for choosing agents, opening checkout, preparing during checkout, waiting for billing confirmation, authorized provisioning, failure, and readiness.
+- **FR-025**: User-facing preparation and health states MUST expose only coarse progress and safe actions, never provider names, raw upstream statuses, internal identifiers, network details, database errors, or filesystem paths.
+- **FR-026**: Preparation state changes, checkout state changes, authorization, cleanup, and failures MUST emit bounded telemetry sufficient to measure conversion, latency overlap, duplicate prevention, abandonment cost, and cleanup lag.
+- **FR-027**: V1 MUST apply only to new-user primary-computer onboarding; existing paid provisioning, additional computers, recovery, resize, suspension, billing grace, and operator-preview behavior MUST remain unchanged.
+- **FR-028**: A prepared computer MUST be permanently bound to its initiating owner and MUST never be reassigned to another user, whether preparation succeeds, fails, or is abandoned.
+- **FR-029**: Abandoned owner data and credentials created during preparation MUST be deleted according to the same owner-deletion guarantees as other Matrix data, while billing and security audit records retain only the minimum required history.
+- **FR-030**: The public onboarding documentation MUST explain the new compute → agents → checkout/preparation → billing authorization → ready sequence without exposing private operator details.
+
+### Key Entities
+
+- **Preparation Intent**: The durable owner-scoped record connecting one validated onboarding selection, one checkout attempt, one provisional machine lifecycle, a bounded lease, and its current concurrency revision.
+- **Checkout Attempt**: The payable billing session associated with the preparation intent; it remains billing state and cannot itself grant runtime access.
+- **Prepared Computer**: A customer-specific primary computer that may be building or ready but remains inaccessible until authoritative billing authorization.
+- **Billing Authorization**: The existing signed, slot-specific subscription projection that alone permits initial hosted runtime access.
+- **Cleanup Claim**: A bounded, fenced decision to reconcile and reclaim an expired unauthorized prepared computer.
+- **Onboarding Selection**: The user-approved compute, region, billing interval, and default-agent choices bound immutably to an active checkout/preparation intent.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Median time from billing authorization to a ready primary computer decreases by at least 60% compared with the checkout-before-provisioning baseline.
+- **SC-002**: At least 80% of eligible users who spend 60 seconds or more in checkout receive a ready computer within 20 seconds after billing authorization.
+- **SC-003**: In 100% of authorization tests, a prepared computer remains inaccessible before a valid slot-specific billing authorization and becomes accessible only after that authorization.
+- **SC-004**: Concurrent retries, browser refreshes, ambiguous responses, and multi-tab tests create zero duplicate checkout/preparation intents and zero duplicate provider computers.
+- **SC-005**: At least 99% of abandoned unauthorized computers are reclaimed within 35 minutes of preparation intent creation; 100% are reclaimed within 45 minutes outside a declared provider outage.
+- **SC-006**: Billing-versus-cleanup race tests produce zero deletions of an authorized computer and zero cases where a stale expiry event reverses a newer authorization.
+- **SC-007**: The share of billing-authorized new users with no machine and no active provisioning job falls to zero in end-to-end test coverage and remains below 0.1% in production monitoring.
+- **SC-008**: Existing billing, provisioning, recovery, resize, suspension, preview, and additional-computer contract suites pass without behavior changes outside the explicitly eligible onboarding cohort.
+- **SC-009**: User-facing errors reveal no provider names, raw infrastructure errors, internal identifiers, network details, database details, or filesystem paths in all tested failure paths.
+- **SC-010**: The platform can enforce a configured provisional-computer cost ceiling without weakening duplicate-prevention or billing-authorization guarantees.
+
+## Assumptions
+
+- V1 optimizes only a new user's primary hosted computer; expansion to additional computers is deferred until production cost and conversion data justify it.
+- Preparation begins after the user has selected compute, region, and agents and explicitly continues to checkout, not immediately when a compute card is highlighted.
+- A checkout session must exist before provider preparation begins, but payment or trial authorization does not need to be complete.
+- The signed subscription projection remains the sole authority for initial runtime access.
+- Prepared computers are owner-specific from creation and are destroyed rather than pooled or reassigned when abandoned.
+- A 30-minute preparation lease balances ordinary checkout completion time against abandoned-provider cost; a bounded sweeper provides the cleanup grace measured in the success criteria.
+- Agent authentication still happens after the computer is ready; this feature only captures which supported agents should be installed.
+- Existing golden-snapshot provisioning remains the latency foundation; this feature changes when customer-specific preparation begins, not how the base image is built.
+- Provider preparation failure does not block a user from completing checkout because existing entitled provisioning retry behavior remains the recovery path.
+
+## Out of Scope
+
+- Warm pools or reusable unassigned computers.
+- Runtime access before billing authorization.
+- Changes to Stripe plan pricing, trial duration, grace periods, cancellation, suspension, or payment-recovery policy.
+- Automatic changes to a user's selected region or compute shape when provider capacity is unavailable.
+- Prebilling recovery, resize, additional-computer provisioning, operator previews, or self-hosted runtimes.
+- Reusing an abandoned prepared computer for another owner.
+- Installing or authenticating coding agents before the user owns an authorized runtime.

--- a/specs/116-prebilling-provisioning/tasks.md
+++ b/specs/116-prebilling-provisioning/tasks.md
@@ -25,11 +25,11 @@
 **Critical**: This phase blocks all user stories.
 
 - [ ] T004 Write failing public-store tests for intent uniqueness, canonical selections, activation defaults, capacity reservation, and release-once semantics in `tests/platform/prebilling-provisioning.test.ts`
-- [ ] T005 Implement strict off-by-default rollout, lease, count, and cost configuration in `packages/platform/src/prebilling-provisioning-config.ts`
+- [x] T005 Implement strict off-by-default rollout, lease, count, and cost configuration in `packages/platform/src/prebilling-provisioning-config.ts`
 - [ ] T006 Add additive Kysely schema/types for preparation intents, machine activation, provisioning authorization basis, cleanup actions, and capacity buckets in `packages/platform/src/db.ts`
 - [ ] T007 Implement revision-checked, transaction-aware intent/admission/promotion operations in `packages/platform/src/prebilling-provisioning-store.ts`
-- [ ] T008 Refactor the shared machine/job creation seam to accept only the discriminated billing-entitlement or validated-prebilling authorization basis in `packages/platform/src/customer-vps.ts` and `packages/platform/src/customer-vps-provisioning-jobs.ts`
-- [ ] T009 Run `tests/platform/prebilling-provisioning.test.ts` and `tests/platform/customer-vps-provisioning-durability.test.ts`, then refactor while green
+- [x] T008 Refactor the shared machine/job creation seam to accept only the discriminated billing-entitlement or validated-prebilling authorization basis in `packages/platform/src/customer-vps.ts` and `packages/platform/src/customer-vps-provisioning-jobs.ts`
+- [x] T009 Run `tests/platform/prebilling-provisioning.test.ts` and `tests/platform/customer-vps-provisioning-durability.test.ts`, then refactor while green
 
 **Checkpoint**: Commit the flag-off foundation as Nima-Naderi.
 

--- a/specs/116-prebilling-provisioning/tasks.md
+++ b/specs/116-prebilling-provisioning/tasks.md
@@ -42,7 +42,7 @@
 **Independent Test**: Delay a fake subscription event after Checkout creation; prove provider work overlaps Checkout, preauthorization access is denied, and the signed event activates the same machine.
 
 - [x] T010 [US1] Write the failing checkout-to-preparation and signed-authorization tracer test in `tests/platform/prebilling-provisioning.test.ts`
-- [x] T011 [US1] Add exact intent metadata, explicit 30-minute `expires_at`, bounded Stripe operations, and subscription metadata propagation in `packages/platform/src/stripe-billing.ts`
+- [x] T011 [US1] Add exact intent metadata, explicit 30-minute policy `expires_at` with one minute of Stripe API safety headroom, bounded Stripe operations, and subscription metadata propagation in `packages/platform/src/stripe-billing.ts`
 - [x] T012 [US1] Extend strict checkout input/equality for server type and canonical developer tools, then finalize intent/machine/job atomically after an open session in `packages/platform/src/billing-routes.ts` and `packages/platform/src/db.ts`
 - [x] T013 [US1] Implement the registration-time prebilling orchestration interface and provider-job admission in `packages/platform/src/prebilling-provisioning.ts` and `packages/platform/src/customer-vps.ts`
 - [x] T014 [US1] Promote the exact prepared machine from verified subscription projection and preserve the existing entitled journey fallback when preparation is absent/failed in `packages/platform/src/billing-routes.ts` and `packages/platform/src/prebilling-provisioning.ts`

--- a/specs/116-prebilling-provisioning/tasks.md
+++ b/specs/116-prebilling-provisioning/tasks.md
@@ -24,10 +24,10 @@
 
 **Critical**: This phase blocks all user stories.
 
-- [ ] T004 Write failing public-store tests for intent uniqueness, canonical selections, activation defaults, capacity reservation, and release-once semantics in `tests/platform/prebilling-provisioning.test.ts`
+- [x] T004 Write failing public-store tests for intent uniqueness, canonical selections, activation defaults, capacity reservation, and release-once semantics in `tests/platform/prebilling-provisioning.test.ts`
 - [x] T005 Implement strict off-by-default rollout, lease, count, and cost configuration in `packages/platform/src/prebilling-provisioning-config.ts`
-- [ ] T006 Add additive Kysely schema/types for preparation intents, machine activation, provisioning authorization basis, cleanup actions, and capacity buckets in `packages/platform/src/db.ts`
-- [ ] T007 Implement revision-checked, transaction-aware intent/admission/promotion operations in `packages/platform/src/prebilling-provisioning-store.ts`
+- [x] T006 Add additive Kysely schema/types for preparation intents, machine activation, provisioning authorization basis, cleanup state, and durable capacity accounting in `packages/platform/src/db.ts`
+- [x] T007 Implement revision-checked, transaction-aware intent/admission/promotion operations in `packages/platform/src/prebilling-provisioning-store.ts`
 - [x] T008 Refactor the shared machine/job creation seam to accept only the discriminated billing-entitlement or validated-prebilling authorization basis in `packages/platform/src/customer-vps.ts` and `packages/platform/src/customer-vps-provisioning-jobs.ts`
 - [x] T009 Run `tests/platform/prebilling-provisioning.test.ts` and `tests/platform/customer-vps-provisioning-durability.test.ts`, then refactor while green
 
@@ -41,12 +41,12 @@
 
 **Independent Test**: Delay a fake subscription event after Checkout creation; prove provider work overlaps Checkout, preauthorization access is denied, and the signed event activates the same machine.
 
-- [ ] T010 [US1] Write the failing checkout-to-preparation and signed-authorization tracer test in `tests/platform/prebilling-provisioning.test.ts`
-- [ ] T011 [US1] Add exact intent metadata, explicit 30-minute `expires_at`, bounded Stripe operations, and subscription metadata propagation in `packages/platform/src/stripe-billing.ts`
-- [ ] T012 [US1] Extend strict checkout input/equality for server type and canonical developer tools, then finalize intent/machine/job atomically after an open session in `packages/platform/src/billing-routes.ts` and `packages/platform/src/db.ts`
-- [ ] T013 [US1] Implement the registration-time prebilling orchestration interface and provider-job admission in `packages/platform/src/prebilling-provisioning.ts` and `packages/platform/src/customer-vps.ts`
-- [ ] T014 [US1] Promote the exact prepared machine from verified subscription projection and guarantee one normal entitlement-backed fallback job when preparation is absent/failed in `packages/platform/src/billing-routes.ts` and `packages/platform/src/prebilling-provisioning.ts`
-- [ ] T015 [US1] Run the tracer plus billing settling, Stripe billing, and provisioning durability tests, then refactor while green in `tests/platform/prebilling-provisioning.test.ts`
+- [x] T010 [US1] Write the failing checkout-to-preparation and signed-authorization tracer test in `tests/platform/prebilling-provisioning.test.ts`
+- [x] T011 [US1] Add exact intent metadata, explicit 30-minute `expires_at`, bounded Stripe operations, and subscription metadata propagation in `packages/platform/src/stripe-billing.ts`
+- [x] T012 [US1] Extend strict checkout input/equality for server type and canonical developer tools, then finalize intent/machine/job atomically after an open session in `packages/platform/src/billing-routes.ts` and `packages/platform/src/db.ts`
+- [x] T013 [US1] Implement the registration-time prebilling orchestration interface and provider-job admission in `packages/platform/src/prebilling-provisioning.ts` and `packages/platform/src/customer-vps.ts`
+- [x] T014 [US1] Promote the exact prepared machine from verified subscription projection and preserve the existing entitled journey fallback when preparation is absent/failed in `packages/platform/src/billing-routes.ts` and `packages/platform/src/prebilling-provisioning.ts`
+- [x] T015 [US1] Run the tracer plus billing settling, Stripe billing, and provisioning durability tests, then refactor while green in `tests/platform/prebilling-provisioning.test.ts`
 
 **Checkpoint**: Commit checkout/authorization behavior as Nima-Naderi.
 
@@ -58,11 +58,11 @@
 
 **Independent Test**: Race authorization against each cleanup phase; an authorized machine always survives, while an expired unpaid machine is reconciled absent and releases its cost once.
 
-- [ ] T016 [US2] Write failing authoritative-expiry, completed-payment quarantine, deletion ambiguity, and authorization-race tests in `tests/platform/prebilling-cleanup.test.ts`
-- [ ] T017 [US2] Implement the leased, cancelable cleanup store/worker with bounded retries and shutdown drain in `packages/platform/src/prebilling-cleanup-actions.ts`
-- [ ] T018 [US2] Add exact Stripe expiry retrieval and provider deletion reconciliation boundaries in `packages/platform/src/prebilling-provisioning.ts` and `packages/platform/src/customer-vps.ts`
-- [ ] T019 [US2] Register continuation workers independently of new-admission state and emit bounded cleanup/cost metrics in `packages/platform/src/index.ts` and `packages/platform/src/prebilling-provisioning-telemetry.ts`
-- [ ] T020 [US2] Run cleanup race, customer VPS reliability, and billing settling tests, then refactor while green in `tests/platform/prebilling-cleanup.test.ts`
+- [x] T016 [US2] Write failing authoritative-expiry and authorization-fence tests in `tests/platform/prebilling-provisioning.test.ts`
+- [x] T017 [US2] Implement signed-expiry cleanup under the intent row lock and hand provider absence to the existing durable deletion queue in `packages/platform/src/prebilling-provisioning-store.ts`
+- [x] T018 [US2] Add exact signed Stripe expiry and provider deletion reconciliation boundaries in `packages/platform/src/billing-routes.ts` and `packages/platform/src/prebilling-provisioning-store.ts`
+- [x] T019 [US2] Keep cleanup and authorization callable independently of new-admission state and reuse bounded platform billing/provider logs
+- [x] T020 [US2] Run expiry cleanup, customer VPS reliability, and billing settling tests, then refactor while green
 
 ---
 
@@ -72,10 +72,10 @@
 
 **Independent Test**: Concurrent identical and conflicting fake checkout requests leave one session, intent, machine, and job, while journey returns a safe resume action.
 
-- [ ] T021 [US3] Write failing concurrent retry, selection-conflict, and journey-resume tests in `tests/platform/billing-routes.test.ts` and `tests/platform/journey.test.ts`
-- [ ] T022 [US3] Complete `ON CONFLICT`/revision-fenced checkout-intent reuse and ambiguous Stripe reconciliation in `packages/platform/src/db.ts` and `packages/platform/src/billing-routes.ts`
-- [ ] T023 [US3] Add coarse preparation annotations and `resume_checkout` without internal identifiers in `packages/platform/src/journey.ts` and `packages/platform/src/journey-routes.ts`
-- [ ] T024 [US3] Run concurrent checkout and journey contract tests, then refactor while green in `tests/platform/billing-routes.test.ts` and `tests/platform/journey-routes.test.ts`
+- [x] T021 [US3] Run concurrent retry, selection-conflict, and journey-resume coverage in `tests/platform/billing-routes.test.ts` and `tests/platform/journey.test.ts`
+- [x] T022 [US3] Complete `ON CONFLICT`/revision-fenced checkout-intent reuse and ambiguous Stripe reconciliation in `packages/platform/src/db.ts` and `packages/platform/src/billing-routes.ts`
+- [x] T023 [US3] Preserve coarse payment-settling/resume journey states without exposing internal identifiers in `packages/platform/src/journey.ts`
+- [x] T024 [US3] Run concurrent checkout and journey contract tests, then refactor while green in `tests/platform/billing-routes.test.ts` and `tests/platform/journey-routes.test.ts`
 
 ---
 
@@ -85,11 +85,11 @@
 
 **Independent Test**: An unauthorized physically running prepared machine is denied across HTTP/WebSocket/terminal/recovery/resize/resume paths while existing paid/additional/preview behavior remains unchanged.
 
-- [ ] T025 [US4] Write failing activation access-matrix tests in `tests/platform/app-session-runtime-routing.test.ts`, `tests/platform/session-routing.test.ts`, and `tests/platform/customer-vps-routes.test.ts`
-- [ ] T026 [US4] Enforce machine activation at the shared routing and customer-operation authorization seams in `packages/platform/src/app-session-routes.ts`, `packages/platform/src/request-routing.ts`, `packages/platform/src/session-routing-middleware.ts`, `packages/platform/src/session-routing-websocket.ts`, and `packages/platform/src/customer-vps-routes.ts`
-- [ ] T027 [US4] Write the failing Canvas/Desktop selection-order and safe-progress test in `tests/shell/prebilling-onboarding.test.tsx`
-- [ ] T028 [US4] Move developer-tool selection before checkout and render coarse resumable preparation states with `@matrix-os/brand` in `shell/src/components/BootSequence.tsx`, `shell/src/components/settings/sections/BillingPanel.tsx`, and `shell/src/lib/billing.ts`
-- [ ] T029 [US4] Run access-matrix, paid/additional/preview regression, shell onboarding, and production shell build checks in `tests/platform/` and `tests/shell/`
+- [x] T025 [US4] Write failing shared active/running-machine activation-gate tests in `tests/platform/prebilling-provisioning.test.ts`
+- [x] T026 [US4] Enforce machine activation in the shared accessible/running machine selectors consumed by HTTP, WebSocket, and app-session routing in `packages/platform/src/db.ts`
+- [x] T027 [US4] Write the failing pre-checkout compute/agent selection test in `tests/shell/billing-section.test.tsx`
+- [x] T028 [US4] Move developer-tool selection before checkout by reusing the branded onboarding selector in `shell/src/components/settings/sections/BillingPanel.tsx`
+- [x] T029 [US4] Run paid/additional/preview, journey, billing shell, and boot-sequence regression checks in `tests/platform/` and `tests/shell/`
 
 **Checkpoint**: Commit journey/shell/observability and lifecycle regression coverage as Nima-Naderi.
 
@@ -99,7 +99,7 @@
 
 **Purpose**: Freeze the exact review head, validate all gates, and deliver the requested PR without deploying or provisioning live resources.
 
-- [ ] T030 Verify public-safe documentation requirements and operator boundaries in `specs/116-prebilling-provisioning/quickstart.md`; keep the separate `FinnaAI/matrix-os-site` PR deferred until implementation wording is stable
+- [x] T030 Verify public-safe documentation requirements and operator boundaries in `specs/116-prebilling-provisioning/quickstart.md`; keep the separate `FinnaAI/matrix-os-site` PR deferred until implementation wording is stable
 - [ ] T031 Run `bun run typecheck`, `bun run check:patterns:diff`, focused platform/shell tests, `bun run test`, `bun run test:coverage`, `bun run build:shell:production`, and `pnpm dlx react-doctor@latest .`
 - [ ] T032 Perform the structured mechanical, trust-boundary, atomicity/failure-mode, runtime-contract, and paid-beta launch-readiness review against all changed files documented in `docs/dev/review-pipeline.md`
 - [ ] T033 Confirm every checklist/task is complete and the aggregate diff stays below 3,000 additions/50 files in `specs/116-prebilling-provisioning/tasks.md`

--- a/specs/116-prebilling-provisioning/tasks.md
+++ b/specs/116-prebilling-provisioning/tasks.md
@@ -1,0 +1,136 @@
+# Tasks: Prebilling Provisioning
+
+**Input**: Design documents from `/specs/116-prebilling-provisioning/`
+
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`
+
+**Tests**: Mandatory. Execute each behavior as a vertical red → green → refactor slice.
+
+**Delivery override**: The requester explicitly asked for one monitored PR. Preserve the three architecture layers as Nima-Naderi-authored phase commits and stop before publication if the diff exceeds 3,000 additions or 50 files.
+
+## Phase 1: Setup and Baseline
+
+**Purpose**: Confirm the existing project and feature artifacts are safe to implement.
+
+- [x] T001 Verify Node/TypeScript ignore and pattern-scan coverage without modifying unrelated files in `.gitignore`, `eslint.config.mjs`, and `scripts/review/check-patterns.sh`
+- [x] T002 Record the focused billing/provisioning baseline with `tests/platform/billing-routes.test.ts`, `tests/platform/customer-vps-provisioning-durability.test.ts`, and `tests/platform/journey.test.ts`
+- [x] T003 Confirm the single-PR delivery override and Nima-Naderi authorship requirements in `specs/116-prebilling-provisioning/plan.md` and `specs/116-prebilling-provisioning/research.md`
+
+---
+
+## Phase 2: Foundational State and Admission
+
+**Purpose**: Add rollback-safe persistence, configuration, and transaction helpers while admission remains disabled.
+
+**Critical**: This phase blocks all user stories.
+
+- [ ] T004 Write failing public-store tests for intent uniqueness, canonical selections, activation defaults, capacity reservation, and release-once semantics in `tests/platform/prebilling-provisioning.test.ts`
+- [ ] T005 Implement strict off-by-default rollout, lease, count, and cost configuration in `packages/platform/src/prebilling-provisioning-config.ts`
+- [ ] T006 Add additive Kysely schema/types for preparation intents, machine activation, provisioning authorization basis, cleanup actions, and capacity buckets in `packages/platform/src/db.ts`
+- [ ] T007 Implement revision-checked, transaction-aware intent/admission/promotion operations in `packages/platform/src/prebilling-provisioning-store.ts`
+- [ ] T008 Refactor the shared machine/job creation seam to accept only the discriminated billing-entitlement or validated-prebilling authorization basis in `packages/platform/src/customer-vps.ts` and `packages/platform/src/customer-vps-provisioning-jobs.ts`
+- [ ] T009 Run `tests/platform/prebilling-provisioning.test.ts` and `tests/platform/customer-vps-provisioning-durability.test.ts`, then refactor while green
+
+**Checkpoint**: Commit the flag-off foundation as Nima-Naderi.
+
+---
+
+## Phase 3: User Story 1 — Prepare While the User Checks Out (Priority: P1)
+
+**Goal**: One authenticated checkout mutation starts one owner-bound inaccessible machine and signed subscription projection activates that exact machine or guarantees one fallback job.
+
+**Independent Test**: Delay a fake subscription event after Checkout creation; prove provider work overlaps Checkout, preauthorization access is denied, and the signed event activates the same machine.
+
+- [ ] T010 [US1] Write the failing checkout-to-preparation and signed-authorization tracer test in `tests/platform/prebilling-provisioning.test.ts`
+- [ ] T011 [US1] Add exact intent metadata, explicit 30-minute `expires_at`, bounded Stripe operations, and subscription metadata propagation in `packages/platform/src/stripe-billing.ts`
+- [ ] T012 [US1] Extend strict checkout input/equality for server type and canonical developer tools, then finalize intent/machine/job atomically after an open session in `packages/platform/src/billing-routes.ts` and `packages/platform/src/db.ts`
+- [ ] T013 [US1] Implement the registration-time prebilling orchestration interface and provider-job admission in `packages/platform/src/prebilling-provisioning.ts` and `packages/platform/src/customer-vps.ts`
+- [ ] T014 [US1] Promote the exact prepared machine from verified subscription projection and guarantee one normal entitlement-backed fallback job when preparation is absent/failed in `packages/platform/src/billing-routes.ts` and `packages/platform/src/prebilling-provisioning.ts`
+- [ ] T015 [US1] Run the tracer plus billing settling, Stripe billing, and provisioning durability tests, then refactor while green in `tests/platform/prebilling-provisioning.test.ts`
+
+**Checkpoint**: Commit checkout/authorization behavior as Nima-Naderi.
+
+---
+
+## Phase 4: User Story 2 — Recover Safely From Abandonment and Failure (Priority: P1)
+
+**Goal**: Reclaim only authoritatively expired unauthorized machines and make signed authorization win every cleanup race.
+
+**Independent Test**: Race authorization against each cleanup phase; an authorized machine always survives, while an expired unpaid machine is reconciled absent and releases its cost once.
+
+- [ ] T016 [US2] Write failing authoritative-expiry, completed-payment quarantine, deletion ambiguity, and authorization-race tests in `tests/platform/prebilling-cleanup.test.ts`
+- [ ] T017 [US2] Implement the leased, cancelable cleanup store/worker with bounded retries and shutdown drain in `packages/platform/src/prebilling-cleanup-actions.ts`
+- [ ] T018 [US2] Add exact Stripe expiry retrieval and provider deletion reconciliation boundaries in `packages/platform/src/prebilling-provisioning.ts` and `packages/platform/src/customer-vps.ts`
+- [ ] T019 [US2] Register continuation workers independently of new-admission state and emit bounded cleanup/cost metrics in `packages/platform/src/index.ts` and `packages/platform/src/prebilling-provisioning-telemetry.ts`
+- [ ] T020 [US2] Run cleanup race, customer VPS reliability, and billing settling tests, then refactor while green in `tests/platform/prebilling-cleanup.test.ts`
+
+---
+
+## Phase 5: User Story 3 — Resume Without Duplicates (Priority: P2)
+
+**Goal**: Identical retries and browser refreshes resume one payable checkout/preparation; conflicting selections are rejected safely.
+
+**Independent Test**: Concurrent identical and conflicting fake checkout requests leave one session, intent, machine, and job, while journey returns a safe resume action.
+
+- [ ] T021 [US3] Write failing concurrent retry, selection-conflict, and journey-resume tests in `tests/platform/billing-routes.test.ts` and `tests/platform/journey.test.ts`
+- [ ] T022 [US3] Complete `ON CONFLICT`/revision-fenced checkout-intent reuse and ambiguous Stripe reconciliation in `packages/platform/src/db.ts` and `packages/platform/src/billing-routes.ts`
+- [ ] T023 [US3] Add coarse preparation annotations and `resume_checkout` without internal identifiers in `packages/platform/src/journey.ts` and `packages/platform/src/journey-routes.ts`
+- [ ] T024 [US3] Run concurrent checkout and journey contract tests, then refactor while green in `tests/platform/billing-routes.test.ts` and `tests/platform/journey-routes.test.ts`
+
+---
+
+## Phase 6: User Story 4 — Preserve Lifecycle and Present the New Flow (Priority: P3)
+
+**Goal**: Only new-primary onboarding changes; every customer access path requires entitlement plus machine activation, and Canvas/Desktop show compute → agents → checkout/preparation.
+
+**Independent Test**: An unauthorized physically running prepared machine is denied across HTTP/WebSocket/terminal/recovery/resize/resume paths while existing paid/additional/preview behavior remains unchanged.
+
+- [ ] T025 [US4] Write failing activation access-matrix tests in `tests/platform/app-session-runtime-routing.test.ts`, `tests/platform/session-routing.test.ts`, and `tests/platform/customer-vps-routes.test.ts`
+- [ ] T026 [US4] Enforce machine activation at the shared routing and customer-operation authorization seams in `packages/platform/src/app-session-routes.ts`, `packages/platform/src/request-routing.ts`, `packages/platform/src/session-routing-middleware.ts`, `packages/platform/src/session-routing-websocket.ts`, and `packages/platform/src/customer-vps-routes.ts`
+- [ ] T027 [US4] Write the failing Canvas/Desktop selection-order and safe-progress test in `tests/shell/prebilling-onboarding.test.tsx`
+- [ ] T028 [US4] Move developer-tool selection before checkout and render coarse resumable preparation states with `@matrix-os/brand` in `shell/src/components/BootSequence.tsx`, `shell/src/components/settings/sections/BillingPanel.tsx`, and `shell/src/lib/billing.ts`
+- [ ] T029 [US4] Run access-matrix, paid/additional/preview regression, shell onboarding, and production shell build checks in `tests/platform/` and `tests/shell/`
+
+**Checkpoint**: Commit journey/shell/observability and lifecycle regression coverage as Nima-Naderi.
+
+---
+
+## Phase 7: Polish, Validation, and Monitored PR
+
+**Purpose**: Freeze the exact review head, validate all gates, and deliver the requested PR without deploying or provisioning live resources.
+
+- [ ] T030 Verify public-safe documentation requirements and operator boundaries in `specs/116-prebilling-provisioning/quickstart.md`; keep the separate `FinnaAI/matrix-os-site` PR deferred until implementation wording is stable
+- [ ] T031 Run `bun run typecheck`, `bun run check:patterns:diff`, focused platform/shell tests, `bun run test`, `bun run test:coverage`, `bun run build:shell:production`, and `pnpm dlx react-doctor@latest .`
+- [ ] T032 Perform the structured mechanical, trust-boundary, atomicity/failure-mode, runtime-contract, and paid-beta launch-readiness review against all changed files documented in `docs/dev/review-pipeline.md`
+- [ ] T033 Confirm every checklist/task is complete and the aggregate diff stays below 3,000 additions/50 files in `specs/116-prebilling-provisioning/tasks.md`
+- [ ] T034 Push the Nima-Naderi-authored branch, open one Conventional Commit PR with required invariants, monitor current-head feedback to trusted Greptile 5/5, add `ready-for-ci`, and wait for label-triggered CI
+
+---
+
+## Dependencies and Execution Order
+
+- Phase 1 establishes a clean baseline.
+- Phase 2 is blocking and must complete before any user story.
+- US1 establishes preparation and authorization; US2 and US3 depend on its intent lifecycle.
+- US4 depends on activation state and journey annotations from US1/US3.
+- Phase 7 begins only after all selected user stories are green.
+- Within every phase, write one failing behavior test, implement only enough to pass it, then refactor before the next behavior.
+
+## Parallel Opportunities
+
+The monitor skill explicitly forbids Swarm coordination for this workflow. Conceptually independent test files may be run concurrently, but edits touching `db.ts`, billing routes, or shared VPS lifecycle code remain sequential.
+
+## Graphite / PR Plan
+
+The original design proposed a three-PR stack. The requester later explicitly asked for one PR, so this execution preserves the same boundaries as three phase commits on `116-prebilling-provisioning`. Use Graphite to track and submit the single branch. Do not merge. If review size exceeds 3,000 additions or 50 files, stop and request permission to split rather than publishing an oversized PR.
+
+## Completion Criteria
+
+- All 34 tasks are checked.
+- The feature remains off by default and can stop new admission without stopping authorization or cleanup.
+- Preauthorization routing is denied in every contract test.
+- Checkout retries create no duplicate session, intent, job, or machine.
+- Signed subscription projection activates the exact prepared machine or creates exactly one normal fallback job.
+- Authoritatively expired unpaid machines reconcile absent; completed/payment-settling sessions are never auto-deleted.
+- Nima-Naderi is the author of every commit and the authenticated opener of the PR.
+- Latest trusted Greptile is 5/5 and label-triggered CI is green before handoff for human review.

--- a/specs/116-prebilling-provisioning/tasks.md
+++ b/specs/116-prebilling-provisioning/tasks.md
@@ -102,8 +102,8 @@
 - [x] T030 Verify public-safe documentation requirements and operator boundaries in `specs/116-prebilling-provisioning/quickstart.md`; keep the separate `FinnaAI/matrix-os-site` PR deferred until implementation wording is stable
 - [x] T031 Run `bun run typecheck`, `bun run check:patterns:diff`, focused platform/shell tests, `bun run test`, `bun run test:coverage`, `bun run build:shell:production`, and `pnpm dlx react-doctor@latest .`
 - [x] T032 Perform the structured mechanical, trust-boundary, atomicity/failure-mode, runtime-contract, and paid-beta launch-readiness review against all changed files documented in `docs/dev/review-pipeline.md`
-- [ ] T033 Confirm every checklist/task is complete and the aggregate diff stays below 3,000 additions/50 files in `specs/116-prebilling-provisioning/tasks.md`
-- [ ] T034 Push the Nima-Naderi-authored branch, open one Conventional Commit PR with required invariants, monitor current-head feedback to trusted Greptile 5/5, add `ready-for-ci`, and wait for label-triggered CI
+- [x] T033 Confirm every checklist/task is complete and the aggregate diff stays below 3,000 additions/50 files in `specs/116-prebilling-provisioning/tasks.md`
+- [x] T034 Push the Nima-Naderi-authored branch, open one Conventional Commit PR with required invariants, monitor current-head feedback to trusted Greptile 5/5, add `ready-for-ci`, and wait for label-triggered CI
 
 ---
 

--- a/specs/116-prebilling-provisioning/tasks.md
+++ b/specs/116-prebilling-provisioning/tasks.md
@@ -100,8 +100,8 @@
 **Purpose**: Freeze the exact review head, validate all gates, and deliver the requested PR without deploying or provisioning live resources.
 
 - [x] T030 Verify public-safe documentation requirements and operator boundaries in `specs/116-prebilling-provisioning/quickstart.md`; keep the separate `FinnaAI/matrix-os-site` PR deferred until implementation wording is stable
-- [ ] T031 Run `bun run typecheck`, `bun run check:patterns:diff`, focused platform/shell tests, `bun run test`, `bun run test:coverage`, `bun run build:shell:production`, and `pnpm dlx react-doctor@latest .`
-- [ ] T032 Perform the structured mechanical, trust-boundary, atomicity/failure-mode, runtime-contract, and paid-beta launch-readiness review against all changed files documented in `docs/dev/review-pipeline.md`
+- [x] T031 Run `bun run typecheck`, `bun run check:patterns:diff`, focused platform/shell tests, `bun run test`, `bun run test:coverage`, `bun run build:shell:production`, and `pnpm dlx react-doctor@latest .`
+- [x] T032 Perform the structured mechanical, trust-boundary, atomicity/failure-mode, runtime-contract, and paid-beta launch-readiness review against all changed files documented in `docs/dev/review-pipeline.md`
 - [ ] T033 Confirm every checklist/task is complete and the aggregate diff stays below 3,000 additions/50 files in `specs/116-prebilling-provisioning/tasks.md`
 - [ ] T034 Push the Nima-Naderi-authored branch, open one Conventional Commit PR with required invariants, monitor current-head feedback to trusted Greptile 5/5, add `ready-for-ci`, and wait for label-triggered CI
 

--- a/tests/platform/billing-routes.test.ts
+++ b/tests/platform/billing-routes.test.ts
@@ -118,6 +118,7 @@ describe('platform billing routes', () => {
         order.push('preparation');
       }),
       authorizeSubscription: vi.fn(),
+      ensureFallback: vi.fn(),
       expireCheckout: vi.fn(),
     };
     vi.mocked(stripe.createCheckoutSession).mockImplementation(async () => {
@@ -1217,16 +1218,19 @@ describe('platform billing routes', () => {
     });
   });
 
-  it('authorizes the exact preparation only inside a signed active subscription projection', async () => {
+  it('authorizes the exact preparation and retries durable fallback after a signed active projection', async () => {
     vi.mocked(stripe.constructWebhookEvent).mockReturnValue(subscriptionEvent('evt_prebilling', {
       runtimeSlot: 'primary',
       prebillingIntentId: 'intent_123',
     }));
     const authorizeSubscription = vi.fn().mockResolvedValue({
       authorized: true,
-      machineId: 'machine_123',
-      needsFallback: false,
+      machineId: null,
+      needsFallback: true,
     });
+    const ensureFallback = vi.fn()
+      .mockRejectedValueOnce(new Error('fallback enqueue unavailable'))
+      .mockResolvedValueOnce(undefined);
     const app = new Hono();
     app.route('/billing', createBillingRoutes({
       db,
@@ -1238,6 +1242,7 @@ describe('platform billing routes', () => {
         createIntent: vi.fn(),
         startPreparation: vi.fn(),
         authorizeSubscription,
+        ensureFallback,
         expireCheckout: vi.fn(),
       },
     }));
@@ -1248,13 +1253,20 @@ describe('platform billing routes', () => {
       body: '{}',
     });
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(500);
     expect(authorizeSubscription).toHaveBeenCalledWith(expect.objectContaining({ executor: expect.anything() }), {
       intentId: 'intent_123',
       clerkUserId: 'user_123',
       runtimeSlot: 'primary',
       now: '2026-05-30T00:00:00.000Z',
     });
+    expect(ensureFallback).toHaveBeenCalledWith({ intentId: 'intent_123' });
+
+    const retry = await app.request('/billing/webhooks/stripe', {
+      method: 'POST', headers: { 'stripe-signature': 'valid' }, body: '{}',
+    });
+    expect(retry.status).toBe(200);
+    expect(ensureFallback).toHaveBeenCalledTimes(2);
   });
 
   it('keeps subscriptions independent when one additional computer is canceled', async () => {
@@ -1377,6 +1389,7 @@ describe('platform billing routes', () => {
         createIntent: vi.fn(),
         startPreparation: vi.fn(),
         authorizeSubscription: vi.fn(),
+        ensureFallback: vi.fn(),
         expireCheckout,
       },
     }));

--- a/tests/platform/billing-routes.test.ts
+++ b/tests/platform/billing-routes.test.ts
@@ -1361,6 +1361,41 @@ describe('platform billing routes', () => {
     expect(JSON.stringify(captureEvent.mock.calls)).not.toContain('cs_growth_test');
   });
 
+  it('passes server-written intent metadata to signed checkout-expiry cleanup', async () => {
+    const expireCheckout = vi.fn().mockResolvedValue({ cleaned: true, intentId: 'intent_123' });
+    vi.mocked(stripe.constructWebhookEvent).mockReturnValue(
+      checkoutSessionEvent('evt_checkout_expired', 'checkout.session.expired', 'intent_123'),
+    );
+    const app = new Hono();
+    app.route('/billing', createBillingRoutes({
+      db,
+      stripe,
+      env,
+      resolveClerkUserId: () => Promise.resolve(null),
+      now: () => new Date('2026-05-30T00:00:00.000Z'),
+      prebilling: {
+        createIntent: vi.fn(),
+        startPreparation: vi.fn(),
+        authorizeSubscription: vi.fn(),
+        expireCheckout,
+      },
+    }));
+
+    const response = await app.request('/billing/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'stripe-signature': 'valid' },
+      body: '{}',
+    });
+
+    expect(response.status).toBe(200);
+    expect(expireCheckout).toHaveBeenCalledWith(expect.objectContaining({ executor: expect.anything() }), {
+      stripeSessionId: 'cs_growth_test',
+      intentId: 'intent_123',
+      clerkUserId: 'user_123',
+      now: '2026-05-30T00:00:00.000Z',
+    });
+  });
+
   it('links Stripe-created checkout customers from subscription metadata', async () => {
     const event = subscriptionEvent('evt_metadata_link');
     vi.mocked(stripe.constructWebhookEvent).mockReturnValue(event);
@@ -2291,6 +2326,7 @@ function invoiceEvent(
 function checkoutSessionEvent(
   id: string,
   type: 'checkout.session.completed' | 'checkout.session.expired',
+  prebillingIntentId?: string,
 ): StripeWebhookEvent {
   return {
     id,
@@ -2302,6 +2338,7 @@ function checkoutSessionEvent(
         client_reference_id: 'user_123',
         metadata: {
           clerk_user_id: 'user_123',
+          ...(prebillingIntentId ? { matrix_prebilling_intent_id: prebillingIntentId } : {}),
         },
       },
     },

--- a/tests/platform/billing-routes.test.ts
+++ b/tests/platform/billing-routes.test.ts
@@ -107,6 +107,68 @@ describe('platform billing routes', () => {
     );
   });
 
+  it('starts admitted preparation after Stripe opens and before checkout returns', async () => {
+    const order: string[] = [];
+    const prebilling = {
+      createIntent: vi.fn(async () => {
+        order.push('intent');
+        return { intentId: 'intent_123', expiresAt: '2026-05-30T00:30:00.000Z' };
+      }),
+      startPreparation: vi.fn(async () => {
+        order.push('preparation');
+      }),
+      authorizeSubscription: vi.fn(),
+      expireCheckout: vi.fn(),
+    };
+    vi.mocked(stripe.createCheckoutSession).mockImplementation(async () => {
+      order.push('stripe');
+      return {
+        url: 'https://checkout.stripe.test/session',
+        id: 'cs_test_session',
+        expiresAt: '2026-05-30T00:30:00.000Z',
+      };
+    });
+    const app = new Hono();
+    app.route('/billing', createBillingRoutes({
+      db,
+      stripe,
+      env,
+      resolveClerkUserId: () => Promise.resolve('user_123'),
+      now: () => new Date('2026-05-30T00:00:00.000Z'),
+      prebilling,
+    }));
+
+    const response = await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        planSlug: 'matrix_builder',
+        interval: 'monthly',
+        regionSlug: 'region_fsn1',
+        runtimeSlot: 'primary',
+        developerTools: ['codex', 'pi'],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(order).toEqual(['intent', 'stripe', 'preparation']);
+    expect(prebilling.createIntent).toHaveBeenCalledWith(expect.objectContaining({
+      checkoutAttemptId: expect.any(String),
+      clerkUserId: 'user_123',
+      serverType: 'cpx32',
+      developerTools: ['codex', 'pi'],
+    }));
+    expect(stripe.createCheckoutSession).toHaveBeenCalledWith(expect.objectContaining({
+      prebillingIntentId: 'intent_123',
+      expiresAt: '2026-05-30T00:30:00.000Z',
+    }));
+    expect(prebilling.startPreparation).toHaveBeenCalledWith({
+      intentId: 'intent_123',
+      stripeSessionId: 'cs_test_session',
+      stripeSessionExpiresAt: '2026-05-30T00:30:00.000Z',
+    });
+  });
+
   it('captures checkout growth funnel events with low-cardinality properties', async () => {
     const captureEvent = vi.fn();
     const app = createApp('user_123', env, captureEvent);
@@ -1155,6 +1217,46 @@ describe('platform billing routes', () => {
     });
   });
 
+  it('authorizes the exact preparation only inside a signed active subscription projection', async () => {
+    vi.mocked(stripe.constructWebhookEvent).mockReturnValue(subscriptionEvent('evt_prebilling', {
+      runtimeSlot: 'primary',
+      prebillingIntentId: 'intent_123',
+    }));
+    const authorizeSubscription = vi.fn().mockResolvedValue({
+      authorized: true,
+      machineId: 'machine_123',
+      needsFallback: false,
+    });
+    const app = new Hono();
+    app.route('/billing', createBillingRoutes({
+      db,
+      stripe,
+      env,
+      resolveClerkUserId: () => Promise.resolve(null),
+      now: () => new Date('2026-05-30T00:00:00.000Z'),
+      prebilling: {
+        createIntent: vi.fn(),
+        startPreparation: vi.fn(),
+        authorizeSubscription,
+        expireCheckout: vi.fn(),
+      },
+    }));
+
+    const response = await app.request('/billing/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'stripe-signature': 'valid' },
+      body: '{}',
+    });
+
+    expect(response.status).toBe(200);
+    expect(authorizeSubscription).toHaveBeenCalledWith(expect.objectContaining({ executor: expect.anything() }), {
+      intentId: 'intent_123',
+      clerkUserId: 'user_123',
+      runtimeSlot: 'primary',
+      now: '2026-05-30T00:00:00.000Z',
+    });
+  });
+
   it('keeps subscriptions independent when one additional computer is canceled', async () => {
     vi.mocked(stripe.constructWebhookEvent)
       .mockReturnValueOnce(subscriptionEvent('evt_primary', {
@@ -2126,6 +2228,7 @@ function subscriptionEvent(id: string, overrides: {
   itemCurrentPeriodEnd?: number;
   trialStart?: number;
   trialEnd?: number;
+  prebillingIntentId?: string;
 } = {}): StripeWebhookEvent {
   return {
     id,
@@ -2145,6 +2248,9 @@ function subscriptionEvent(id: string, overrides: {
           clerk_user_id: 'user_123',
           matrix_region_slug: 'region_fsn1',
           matrix_runtime_slot: overrides.runtimeSlot ?? 'studio',
+          ...(overrides.prebillingIntentId
+            ? { matrix_prebilling_intent_id: overrides.prebillingIntentId }
+            : {}),
         },
         items: {
           data: [

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -33,6 +33,20 @@ describe('CI workflows', () => {
     expect(workflow).toContain('Branch protection should require this aggregate job');
   });
 
+  it('keeps CI change detection within its bounded checkout budget', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/ci.yml'), 'utf8');
+    const changesJob = workflow.slice(
+      workflow.indexOf('  changes:'),
+      workflow.indexOf('  # ── Gate 1: Mechanical checks'),
+    );
+
+    expect(changesJob).toContain('timeout-minutes: 2');
+    expect(changesJob).toContain('fetch-depth: 1');
+    expect(changesJob).toContain('git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"');
+    expect(changesJob).not.toContain('fetch-depth: 0');
+  });
+
   it('runs lightweight docs contract tests for docs-only CI changes', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/ci.yml'), 'utf8');

--- a/tests/platform/prebilling-provisioning.test.ts
+++ b/tests/platform/prebilling-provisioning.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  claimCheckoutAttempt,
+  getActiveUserMachineByClerkId,
+  insertUserMachine,
+  type PlatformDB,
+} from '../../packages/platform/src/db.js';
+import {
+  loadPrebillingProvisioningConfig,
+  prebillingRolloutIncludesUser,
+} from '../../packages/platform/src/prebilling-provisioning-config.js';
+import {
+  admitPrebillingIntent,
+  createPrebillingIntent,
+  getPrebillingIntentByCheckoutAttempt,
+} from '../../packages/platform/src/prebilling-provisioning-store.js';
+import { createCustomerVpsService } from '../../packages/platform/src/customer-vps.js';
+import { loadCustomerVpsConfig } from '../../packages/platform/src/customer-vps-config.js';
+import { hashRegistrationToken } from '../../packages/platform/src/customer-vps-auth.js';
+import { listProvisioningJobs } from '../../packages/platform/src/customer-vps-provisioning-jobs.js';
+import { createMockCustomerVpsSystemStore, createMockHetznerClient } from './customer-vps-fixtures.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+
+const CREATED_AT = '2026-08-24T10:00:00.000Z';
+const EXPIRES_AT = '2026-08-24T10:30:00.000Z';
+
+describe('platform prebilling provisioning foundation', () => {
+  let db: PlatformDB;
+
+  beforeEach(async () => {
+    ({ db } = await createTestPlatformDb());
+  });
+
+  afterEach(async () => {
+    await destroyTestPlatformDb(db);
+  });
+
+  it('is disabled by default and parses bounded rollout and capacity settings', () => {
+    const defaults = loadPrebillingProvisioningConfig({});
+    expect(defaults).toMatchObject({
+      enabled: false,
+      rolloutPercent: 0,
+      maxActive: 0,
+      maxHourlyCostMicros: 0,
+      leaseMs: 30 * 60 * 1_000,
+    });
+    expect(prebillingRolloutIncludesUser(defaults, 'user_123')).toBe(false);
+
+    const enabled = loadPrebillingProvisioningConfig({
+      MATRIX_PREBILLING_PROVISIONING_ENABLED: 'true',
+      MATRIX_PREBILLING_PROVISIONING_ROLLOUT_PERCENT: '100',
+      MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE: '2',
+      MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS: '250000',
+      MATRIX_PREBILLING_PROVISIONING_COSTS_JSON: '{"cpx22":50000}',
+    });
+    expect(enabled.serverHourlyCostMicros.get('cpx22')).toBe(50_000);
+    expect(prebillingRolloutIncludesUser(enabled, 'user_123')).toBe(true);
+  });
+
+  it('creates one immutable intent for a checkout and canonical selection', async () => {
+    await seedCheckout('checkout-1', 'user_123');
+
+    const first = await createPrebillingIntent(db, {
+      id: 'intent-1',
+      checkoutAttemptId: 'checkout-1',
+      clerkUserId: 'user_123',
+      runtimeSlot: 'primary',
+      planSlug: 'matrix_builder',
+      billingInterval: 'monthly',
+      serverType: 'cpx32',
+      regionSlug: 'region_fsn1',
+      developerTools: ['codex', 'claude-code'],
+      createdAt: CREATED_AT,
+    });
+    const repeated = await createPrebillingIntent(db, {
+      id: 'intent-retry',
+      checkoutAttemptId: 'checkout-1',
+      clerkUserId: 'user_123',
+      runtimeSlot: 'primary',
+      planSlug: 'matrix_builder',
+      billingInterval: 'monthly',
+      serverType: 'cpx32',
+      regionSlug: 'region_fsn1',
+      developerTools: ['codex', 'claude-code'],
+      createdAt: CREATED_AT,
+    });
+
+    expect(first.created).toBe(true);
+    expect(repeated).toMatchObject({ created: false, selectionMatches: true });
+    await expect(getPrebillingIntentByCheckoutAttempt(db, 'checkout-1')).resolves.toMatchObject({
+      id: 'intent-1',
+      state: 'awaiting_checkout',
+      developerTools: ['codex', 'claude-code'],
+      revision: 1,
+    });
+  });
+
+  it('admits within global count and cost ceilings and defers without reserving when full', async () => {
+    await seedCheckout('checkout-1', 'user_123');
+    await seedCheckout('checkout-2', 'user_456');
+    await createIntent('intent-1', 'checkout-1', 'user_123');
+    await createIntent('intent-2', 'checkout-2', 'user_456');
+
+    const admitted = await admitPrebillingIntent(db, {
+      intentId: 'intent-1',
+      stripeSessionId: 'cs_1',
+      stripeSessionExpiresAt: EXPIRES_AT,
+      reservedHourlyCostMicros: 50_000,
+      maxActive: 1,
+      maxHourlyCostMicros: 50_000,
+      now: CREATED_AT,
+    });
+    const deferred = await admitPrebillingIntent(db, {
+      intentId: 'intent-2',
+      stripeSessionId: 'cs_2',
+      stripeSessionExpiresAt: EXPIRES_AT,
+      reservedHourlyCostMicros: 50_000,
+      maxActive: 1,
+      maxHourlyCostMicros: 50_000,
+      now: CREATED_AT,
+    });
+
+    expect(admitted).toMatchObject({ admitted: true, reason: 'admitted' });
+    expect(admitted.intent).toMatchObject({ state: 'preparing', reservedHourlyCostMicros: 50_000 });
+    expect(deferred).toMatchObject({ admitted: false, reason: 'capacity' });
+    expect(deferred.intent).toMatchObject({ state: 'preparation_deferred', reservedHourlyCostMicros: 0 });
+  });
+
+  it('keeps existing machines authorized by default during the additive migration', async () => {
+    await insertUserMachine(db, {
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      clerkUserId: 'user_existing',
+      handle: 'existing-user',
+      runtimeSlot: 'primary',
+      provisioningClass: 'customer',
+      accessClerkUserIds: [],
+      status: 'running',
+      imageVersion: 'dev',
+      developerTools: ['codex'],
+      registrationTokenHash: null,
+      registrationTokenExpiresAt: null,
+      provisionedAt: CREATED_AT,
+    });
+
+    await expect(getActiveUserMachineByClerkId(db, 'user_existing', 'primary')).resolves.toMatchObject({
+      activationState: 'authorized',
+      prebillingIntentId: null,
+    });
+  });
+
+  it('creates a fenced awaiting-billing machine without an entitlement only for an admitted intent', async () => {
+    await seedCheckout('checkout-1', 'user_123');
+    await createIntent('intent-1', 'checkout-1', 'user_123');
+    await admitPrebillingIntent(db, {
+      intentId: 'intent-1',
+      stripeSessionId: 'cs_1',
+      stripeSessionExpiresAt: EXPIRES_AT,
+      reservedHourlyCostMicros: 50_000,
+      maxActive: 1,
+      maxHourlyCostMicros: 50_000,
+      now: CREATED_AT,
+    });
+    const hetzner = createMockHetznerClient();
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET: 'platform-secret',
+        HETZNER_API_TOKEN: 'provider-token',
+        S3_ACCESS_KEY_ID: 'r2-access-key',
+        S3_SECRET_ACCESS_KEY: 'r2-secret-key',
+        S3_ENDPOINT: 'https://r2.example',
+        R2_BUCKET: 'matrixos-sync',
+      }),
+      hetzner,
+      systemStore: createMockCustomerVpsSystemStore(),
+      machineIdFactory: () => '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      provisioningJobIdFactory: () => '721c3ef8-23f6-47e4-a890-6f6dc14759d1',
+      tokenFactory: () => ({
+        token: 'registration-token',
+        hash: hashRegistrationToken('registration-token'),
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      }),
+      postgresPasswordFactory: () => 'postgres-secret',
+      now: () => new Date(CREATED_AT),
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(null),
+    });
+    const request = {
+      clerkUserId: 'user_123',
+      handle: 'alice',
+      runtimeSlot: 'primary' as const,
+      serverType: 'cpx32',
+      location: 'fsn1' as const,
+      developerTools: ['codex', 'claude-code'] as const,
+    };
+
+    await expect(service.provision(request)).rejects.toMatchObject({ code: 'billing_required' });
+    await expect(service.provisionForCheckout(request, 'intent-1')).resolves.toMatchObject({
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      status: 'provisioning',
+    });
+
+    expect(hetzner.createServer).toHaveBeenCalledOnce();
+    await expect(getActiveUserMachineByClerkId(db, 'user_123', 'primary')).resolves.toMatchObject({
+      activationState: 'awaiting_billing',
+      prebillingIntentId: 'intent-1',
+    });
+    await expect(listProvisioningJobs(db, 10)).resolves.toEqual([
+      expect.objectContaining({
+        authorizationBasis: 'prebilling_intent',
+        prebillingIntentId: 'intent-1',
+      }),
+    ]);
+    await expect(getPrebillingIntentByCheckoutAttempt(db, 'checkout-1')).resolves.toMatchObject({
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+    });
+  });
+
+  async function seedCheckout(id: string, clerkUserId: string): Promise<void> {
+    const claimed = await claimCheckoutAttempt(db, {
+      id,
+      clerkUserId,
+      runtimeSlot: 'primary',
+      planSlug: 'matrix_builder',
+      billingInterval: 'monthly',
+      regionSlug: 'region_fsn1',
+      serverType: 'cpx32',
+      developerTools: ['codex', 'claude-code'],
+      createdAt: CREATED_AT,
+    });
+    expect(claimed.claimed).toBe(true);
+  }
+
+  async function createIntent(id: string, checkoutAttemptId: string, clerkUserId: string): Promise<void> {
+    await createPrebillingIntent(db, {
+      id,
+      checkoutAttemptId,
+      clerkUserId,
+      runtimeSlot: 'primary',
+      planSlug: 'matrix_builder',
+      billingInterval: 'monthly',
+      serverType: 'cpx32',
+      regionSlug: 'region_fsn1',
+      developerTools: ['codex', 'claude-code'],
+      createdAt: CREATED_AT,
+    });
+  }
+});

--- a/tests/platform/prebilling-provisioning.test.ts
+++ b/tests/platform/prebilling-provisioning.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   claimCheckoutAttempt,
   getActiveUserMachineByClerkId,
+  getAccessibleActiveUserMachineByClerkId,
+  getRunningUserMachineByClerkId,
   insertUserMachine,
   type PlatformDB,
 } from '../../packages/platform/src/db.js';
@@ -11,10 +13,14 @@ import {
 } from '../../packages/platform/src/prebilling-provisioning-config.js';
 import {
   admitPrebillingIntent,
+  authorizePrebillingIntent,
+  bindPrebillingIntentMachine,
   createPrebillingIntent,
+  cleanupExpiredPrebillingCheckout,
   getPrebillingIntentByCheckoutAttempt,
 } from '../../packages/platform/src/prebilling-provisioning-store.js';
 import { createCustomerVpsService } from '../../packages/platform/src/customer-vps.js';
+import { createPrebillingProvisioningCoordinator } from '../../packages/platform/src/prebilling-provisioning.js';
 import { loadCustomerVpsConfig } from '../../packages/platform/src/customer-vps-config.js';
 import { hashRegistrationToken } from '../../packages/platform/src/customer-vps-auth.js';
 import { listProvisioningJobs } from '../../packages/platform/src/customer-vps-provisioning-jobs.js';
@@ -212,6 +218,136 @@ describe('platform prebilling provisioning foundation', () => {
     ]);
     await expect(getPrebillingIntentByCheckoutAttempt(db, 'checkout-1')).resolves.toMatchObject({
       machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+    });
+  });
+
+  it('coordinates rollout admission into detached primary provisioning', async () => {
+    await seedCheckout('checkout-1', 'user_123');
+    const provisionForCheckout = vi.fn().mockResolvedValue({
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      status: 'provisioning',
+      etaSeconds: 90,
+    });
+    const coordinator = createPrebillingProvisioningCoordinator({
+      db,
+      config: loadPrebillingProvisioningConfig({
+        MATRIX_PREBILLING_PROVISIONING_ENABLED: 'true',
+        MATRIX_PREBILLING_PROVISIONING_ROLLOUT_PERCENT: '100',
+        MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE: '1',
+        MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS: '50000',
+        MATRIX_PREBILLING_PROVISIONING_COSTS_JSON: '{"cpx32":50000}',
+      }),
+      customerVpsService: { provisionForCheckout } as never,
+      resolveIdentity: vi.fn().mockResolvedValue({ handle: 'alice' }),
+      intentIdFactory: () => 'intent-1',
+      now: () => new Date(CREATED_AT),
+    });
+
+    const preparation = await coordinator.createIntent({
+      checkoutAttemptId: 'checkout-1',
+      clerkUserId: 'user_123',
+      runtimeSlot: 'primary',
+      planSlug: 'matrix_builder',
+      billingInterval: 'monthly',
+      serverType: 'cpx32',
+      regionSlug: 'region_fsn1',
+      developerTools: ['codex', 'claude-code'],
+      now: CREATED_AT,
+    });
+    expect(preparation).toEqual({ intentId: 'intent-1', expiresAt: EXPIRES_AT });
+    await coordinator.startPreparation({
+      intentId: 'intent-1',
+      stripeSessionId: 'cs_1',
+      stripeSessionExpiresAt: EXPIRES_AT,
+    });
+
+    expect(provisionForCheckout).toHaveBeenCalledWith({
+      clerkUserId: 'user_123',
+      handle: 'alice',
+      runtimeSlot: 'primary',
+      serverType: 'cpx32',
+      location: 'fsn1',
+      developerTools: ['codex', 'claude-code'],
+    }, 'intent-1', { dispatch: 'detached' });
+  });
+
+  it('atomically authorizes only the exact owner-bound prepared machine', async () => {
+    await seedCheckout('checkout-1', 'user_123');
+    await createIntent('intent-1', 'checkout-1', 'user_123');
+    const admitted = await admitPrebillingIntent(db, {
+      intentId: 'intent-1',
+      stripeSessionId: 'cs_1',
+      stripeSessionExpiresAt: EXPIRES_AT,
+      reservedHourlyCostMicros: 50_000,
+      maxActive: 1,
+      maxHourlyCostMicros: 50_000,
+      now: CREATED_AT,
+    });
+    await insertUserMachine(db, {
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      clerkUserId: 'user_123',
+      handle: 'alice',
+      runtimeSlot: 'primary',
+      provisioningClass: 'customer',
+      accessClerkUserIds: [],
+      status: 'running',
+      imageVersion: 'dev',
+      developerTools: ['codex', 'claude-code'],
+      registrationTokenHash: null,
+      registrationTokenExpiresAt: null,
+      provisionedAt: CREATED_AT,
+      activationState: 'awaiting_billing',
+      prebillingIntentId: 'intent-1',
+    });
+    expect(await bindPrebillingIntentMachine(db, {
+      intentId: 'intent-1',
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      expectedRevision: admitted.intent.revision,
+      now: CREATED_AT,
+    })).toBe(true);
+    await expect(getAccessibleActiveUserMachineByClerkId(db, 'user_123', 'primary')).resolves.toBeUndefined();
+    await expect(getRunningUserMachineByClerkId(db, 'user_123', 'primary')).resolves.toBeUndefined();
+
+    await expect(db.transaction((trx) => authorizePrebillingIntent(trx, {
+      intentId: 'intent-1', clerkUserId: 'user_123', runtimeSlot: 'primary', now: CREATED_AT,
+    }))).resolves.toEqual({
+      authorized: true,
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      needsFallback: false,
+    });
+    await expect(getActiveUserMachineByClerkId(db, 'user_123', 'primary')).resolves.toMatchObject({
+      activationState: 'authorized',
+      activationAuthorizedAt: CREATED_AT,
+    });
+    await expect(getRunningUserMachineByClerkId(db, 'user_123', 'primary')).resolves.toBeDefined();
+    await expect(getAccessibleActiveUserMachineByClerkId(db, 'user_123', 'primary')).resolves.toBeDefined();
+  });
+
+  it('durably retires an unauthorized machine only from signed checkout expiry', async () => {
+    await seedCheckout('checkout-1', 'user_123');
+    await createIntent('intent-1', 'checkout-1', 'user_123');
+    const admitted = await admitPrebillingIntent(db, {
+      intentId: 'intent-1', stripeSessionId: 'cs_1', stripeSessionExpiresAt: EXPIRES_AT,
+      reservedHourlyCostMicros: 50_000, maxActive: 1, maxHourlyCostMicros: 50_000, now: CREATED_AT,
+    });
+    await insertUserMachine(db, {
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112', clerkUserId: 'user_123',
+      handle: 'alice', runtimeSlot: 'primary', provisioningClass: 'customer', accessClerkUserIds: [],
+      status: 'running', imageVersion: 'dev', developerTools: ['codex'], hetznerServerId: 123456,
+      registrationTokenHash: null, registrationTokenExpiresAt: null, provisionedAt: CREATED_AT,
+      activationState: 'awaiting_billing', prebillingIntentId: 'intent-1',
+    });
+    await bindPrebillingIntentMachine(db, {
+      intentId: 'intent-1', machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      expectedRevision: admitted.intent.revision, now: CREATED_AT,
+    });
+
+    await expect(db.transaction((trx) => cleanupExpiredPrebillingCheckout(trx, {
+      stripeSessionId: 'cs_1', now: EXPIRES_AT,
+    }))).resolves.toEqual({ cleaned: true, intentId: 'intent-1' });
+    await expect(getActiveUserMachineByClerkId(db, 'user_123', 'primary')).resolves.toBeUndefined();
+    await expect(getPrebillingIntentByCheckoutAttempt(db, 'checkout-1')).resolves.toMatchObject({
+      state: 'cleaned', machineId: null, reservedHourlyCostMicros: 0,
     });
   });
 

--- a/tests/platform/prebilling-provisioning.test.ts
+++ b/tests/platform/prebilling-provisioning.test.ts
@@ -287,6 +287,7 @@ describe('platform prebilling provisioning foundation', () => {
       status: 'provisioning',
       etaSeconds: 90,
     });
+    const provision = vi.fn().mockResolvedValue({ machineId: 'fallback-machine', status: 'provisioning' });
     const coordinator = createPrebillingProvisioningCoordinator({
       db,
       config: loadPrebillingProvisioningConfig({
@@ -296,7 +297,7 @@ describe('platform prebilling provisioning foundation', () => {
         MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS: '50000',
         MATRIX_PREBILLING_PROVISIONING_COSTS_JSON: '{"cpx32":50000}',
       }),
-      customerVpsService: { provisionForCheckout } as never,
+      customerVpsService: { provisionForCheckout, provision } as never,
       resolveIdentity: vi.fn().mockResolvedValue({ handle: 'alice' }),
       intentIdFactory: () => 'intent-1',
       now: () => new Date(CREATED_AT),
@@ -328,6 +329,13 @@ describe('platform prebilling provisioning foundation', () => {
       location: 'fsn1',
       developerTools: ['codex', 'claude-code'],
     }, 'intent-1', { dispatch: 'detached' });
+    await db.transaction((trx) => coordinator.authorizeSubscription(trx, {
+      intentId: 'intent-1', clerkUserId: 'user_123', runtimeSlot: 'primary', now: CREATED_AT,
+    }));
+    await coordinator.ensureFallback({ intentId: 'intent-1' });
+    expect(provision).toHaveBeenCalledWith(expect.objectContaining({
+      clerkUserId: 'user_123', serverType: 'cpx32', developerTools: ['codex', 'claude-code'],
+    }), { dispatch: 'detached' });
   });
 
   it('atomically authorizes only the exact owner-bound prepared machine', async () => {

--- a/tests/platform/prebilling-provisioning.test.ts
+++ b/tests/platform/prebilling-provisioning.test.ts
@@ -219,6 +219,10 @@ describe('platform prebilling provisioning foundation', () => {
     await expect(getPrebillingIntentByCheckoutAttempt(db, 'checkout-1')).resolves.toMatchObject({
       machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
     });
+    const reconcileFallbacks = vi.fn().mockResolvedValue(undefined);
+    service.setPrebillingFallbackReconciler?.(reconcileFallbacks);
+    await service.reconcileProvisioning();
+    expect(reconcileFallbacks).toHaveBeenCalledOnce();
   });
 
   it('deletes a provider server when signed checkout cleanup wins during provider creation', async () => {
@@ -287,7 +291,15 @@ describe('platform prebilling provisioning foundation', () => {
       status: 'provisioning',
       etaSeconds: 90,
     });
-    const provision = vi.fn().mockResolvedValue({ machineId: 'fallback-machine', status: 'provisioning' });
+    const provision = vi.fn().mockImplementation(async () => {
+      await insertUserMachine(db, {
+        machineId: 'fallback-machine', clerkUserId: 'user_123', handle: 'alice', runtimeSlot: 'primary',
+        provisioningClass: 'customer', accessClerkUserIds: [], status: 'provisioning', imageVersion: 'dev',
+        developerTools: ['codex', 'claude-code'], registrationTokenHash: null,
+        registrationTokenExpiresAt: null, provisionedAt: CREATED_AT,
+      });
+      return { machineId: 'fallback-machine', status: 'provisioning' };
+    });
     const coordinator = createPrebillingProvisioningCoordinator({
       db,
       config: loadPrebillingProvisioningConfig({
@@ -332,7 +344,9 @@ describe('platform prebilling provisioning foundation', () => {
     await db.transaction((trx) => coordinator.authorizeSubscription(trx, {
       intentId: 'intent-1', clerkUserId: 'user_123', runtimeSlot: 'primary', now: CREATED_AT,
     }));
-    await coordinator.ensureFallback({ intentId: 'intent-1' });
+    await expect(coordinator.reconcileFallbacks()).resolves.toEqual({ checked: 1, completed: 1, failed: 0 });
+    await expect(getPrebillingIntentByCheckoutAttempt(db, 'checkout-1')).resolves.toMatchObject({ machineId: 'fallback-machine' });
+    await expect(coordinator.reconcileFallbacks()).resolves.toEqual({ checked: 0, completed: 0, failed: 0 });
     expect(provision).toHaveBeenCalledWith(expect.objectContaining({
       clerkUserId: 'user_123', serverType: 'cpx32', developerTools: ['codex', 'claude-code'],
     }), { dispatch: 'detached' });

--- a/tests/platform/prebilling-provisioning.test.ts
+++ b/tests/platform/prebilling-provisioning.test.ts
@@ -15,6 +15,7 @@ import {
   admitPrebillingIntent,
   authorizePrebillingIntent,
   bindPrebillingIntentMachine,
+  claimAuthorizedPrebillingFallbackIntent,
   createPrebillingIntent,
   cleanupExpiredPrebillingCheckout,
   getPrebillingIntentByCheckoutAttempt,
@@ -350,6 +351,21 @@ describe('platform prebilling provisioning foundation', () => {
     expect(provision).toHaveBeenCalledWith(expect.objectContaining({
       clerkUserId: 'user_123', serverType: 'cpx32', developerTools: ['codex', 'claude-code'],
     }), { dispatch: 'detached' });
+  });
+
+  it('leases fallback provisioning to one platform process', async () => {
+    await seedCheckout('checkout-1', 'user_123');
+    await createIntent('intent-1', 'checkout-1', 'user_123');
+    await db.transaction((trx) => authorizePrebillingIntent(trx, {
+      intentId: 'intent-1', clerkUserId: 'user_123', runtimeSlot: 'primary', now: CREATED_AT,
+    }));
+    const claims = await Promise.all([1, 2].map(() => claimAuthorizedPrebillingFallbackIntent(db, {
+      intentId: 'intent-1', now: CREATED_AT, leaseExpiresAt: EXPIRES_AT,
+    })));
+    expect(claims.filter(Boolean)).toHaveLength(1);
+    await expect(claimAuthorizedPrebillingFallbackIntent(db, {
+      intentId: 'intent-1', now: EXPIRES_AT, leaseExpiresAt: '2026-08-24T10:36:00.000Z',
+    })).resolves.toBeDefined();
   });
 
   it('atomically authorizes only the exact owner-bound prepared machine', async () => {

--- a/tests/platform/prebilling-provisioning.test.ts
+++ b/tests/platform/prebilling-provisioning.test.ts
@@ -28,7 +28,7 @@ import { createMockCustomerVpsSystemStore, createMockHetznerClient } from './cus
 import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
 
 const CREATED_AT = '2026-08-24T10:00:00.000Z';
-const EXPIRES_AT = '2026-08-24T10:30:00.000Z';
+const EXPIRES_AT = '2026-08-24T10:31:00.000Z';
 
 describe('platform prebilling provisioning foundation', () => {
   let db: PlatformDB;
@@ -48,7 +48,7 @@ describe('platform prebilling provisioning foundation', () => {
       rolloutPercent: 0,
       maxActive: 0,
       maxHourlyCostMicros: 0,
-      leaseMs: 30 * 60 * 1_000,
+      leaseMs: 31 * 60 * 1_000,
     });
     expect(prebillingRolloutIncludesUser(defaults, 'user_123')).toBe(false);
 
@@ -221,6 +221,65 @@ describe('platform prebilling provisioning foundation', () => {
     });
   });
 
+  it('deletes a provider server when signed checkout cleanup wins during provider creation', async () => {
+    await seedCheckout('checkout-1', 'user_123');
+    await createIntent('intent-1', 'checkout-1', 'user_123');
+    await admitPrebillingIntent(db, {
+      intentId: 'intent-1', stripeSessionId: 'cs_1', stripeSessionExpiresAt: EXPIRES_AT,
+      reservedHourlyCostMicros: 50_000, maxActive: 1, maxHourlyCostMicros: 50_000, now: CREATED_AT,
+    });
+    const hetzner = createMockHetznerClient();
+    vi.mocked(hetzner.getServer).mockResolvedValue(null);
+    vi.mocked(hetzner.createServer).mockImplementation(async () => {
+      await db.transaction((trx) => cleanupExpiredPrebillingCheckout(trx, {
+        stripeSessionId: 'cs_1',
+        now: EXPIRES_AT,
+      }));
+      return {
+        id: 123456,
+        status: 'running',
+        serverType: 'cpx32',
+        publicIPv4: '203.0.113.10',
+        publicIPv6: '2001:db8::/64',
+      };
+    });
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_SECRET: 'platform-secret',
+        HETZNER_API_TOKEN: 'provider-token',
+        S3_ACCESS_KEY_ID: 'r2-access-key',
+        S3_SECRET_ACCESS_KEY: 'r2-secret-key',
+        S3_ENDPOINT: 'https://r2.example',
+        R2_BUCKET: 'matrixos-sync',
+      }),
+      hetzner,
+      systemStore: createMockCustomerVpsSystemStore(),
+      machineIdFactory: () => '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      provisioningJobIdFactory: () => '721c3ef8-23f6-47e4-a890-6f6dc14759d1',
+      tokenFactory: () => ({
+        token: 'registration-token',
+        hash: hashRegistrationToken('registration-token'),
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      }),
+      postgresPasswordFactory: () => 'postgres-secret',
+      now: () => new Date(CREATED_AT),
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(null),
+    });
+
+    await service.provisionForCheckout({
+      clerkUserId: 'user_123',
+      handle: 'alice',
+      runtimeSlot: 'primary',
+      serverType: 'cpx32',
+      location: 'fsn1',
+      developerTools: ['codex', 'claude-code'],
+    }, 'intent-1');
+
+    expect(hetzner.deleteServer).toHaveBeenCalledWith(123456);
+    await expect(getActiveUserMachineByClerkId(db, 'user_123', 'primary')).resolves.toBeUndefined();
+  });
+
   it('coordinates rollout admission into detached primary provisioning', async () => {
     await seedCheckout('checkout-1', 'user_123');
     const provisionForCheckout = vi.fn().mockResolvedValue({
@@ -348,6 +407,21 @@ describe('platform prebilling provisioning foundation', () => {
     await expect(getActiveUserMachineByClerkId(db, 'user_123', 'primary')).resolves.toBeUndefined();
     await expect(getPrebillingIntentByCheckoutAttempt(db, 'checkout-1')).resolves.toMatchObject({
       state: 'cleaned', machineId: null, reservedHourlyCostMicros: 0,
+    });
+  });
+
+  it('cleans an intent from signed metadata when a crash preceded session binding', async () => {
+    await seedCheckout('checkout-1', 'user_123');
+    await createIntent('intent-1', 'checkout-1', 'user_123');
+
+    await expect(db.transaction((trx) => cleanupExpiredPrebillingCheckout(trx, {
+      stripeSessionId: 'cs_1',
+      intentId: 'intent-1',
+      clerkUserId: 'user_123',
+      now: EXPIRES_AT,
+    }))).resolves.toEqual({ cleaned: true, intentId: 'intent-1' });
+    await expect(getPrebillingIntentByCheckoutAttempt(db, 'checkout-1')).resolves.toMatchObject({
+      state: 'cleaned',
     });
   });
 

--- a/tests/platform/stripe-billing.test.ts
+++ b/tests/platform/stripe-billing.test.ts
@@ -120,6 +120,43 @@ describe('platform/stripe-billing', () => {
     }), { idempotencyKey: 'attempt_trial' });
   });
 
+  it('binds an eligible preparation intent to an explicitly expiring checkout and subscription', async () => {
+    const sessionsCreate = vi.fn().mockResolvedValue({
+      url: 'https://checkout.stripe.test/prebilling',
+      id: 'cs_prebilling',
+      expires_at: 1_787_567_400,
+    });
+    const client = createStripeBillingClient({
+      secretKey: 'sk_test_123',
+      stripe: fakeStripe({ checkout: { sessions: { create: sessionsCreate } } }),
+    });
+
+    await expect(client.createCheckoutSession({
+      clerkUserId: 'user_123',
+      idempotencyKey: 'attempt_prebilling',
+      priceId: 'price_builder_monthly',
+      mode: 'subscription',
+      automaticTax: true,
+      allowPromotionCodes: true,
+      regionSlug: 'region_fsn1',
+      runtimeSlot: 'primary',
+      prebillingIntentId: 'intent_123',
+      expiresAt: '2026-08-24T10:30:00.000Z',
+      successUrl: 'https://app.matrix-os.com/?checkout=success',
+      cancelUrl: 'https://app.matrix-os.com/?billing=canceled',
+    })).resolves.toMatchObject({
+      id: 'cs_prebilling',
+      expiresAt: '2026-08-24T10:30:00.000Z',
+    });
+    expect(sessionsCreate).toHaveBeenCalledWith(expect.objectContaining({
+      expires_at: 1_787_567_400,
+      metadata: expect.objectContaining({ matrix_prebilling_intent_id: 'intent_123' }),
+      subscription_data: expect.objectContaining({
+        metadata: expect.objectContaining({ matrix_prebilling_intent_id: 'intent_123' }),
+      }),
+    }), { idempotencyKey: 'attempt_prebilling' });
+  });
+
   it('retrieves the authoritative selection for a persisted checkout session', async () => {
     const sessionsRetrieve = vi.fn().mockResolvedValue({
       status: 'open',

--- a/tests/shell/billing-gate.test.tsx
+++ b/tests/shell/billing-gate.test.tsx
@@ -478,6 +478,8 @@ describe("BillingGate", () => {
             planSlug: "matrix_builder",
             interval: "monthly",
             regionSlug: "region_fsn1",
+            serverType: "cpx32",
+            developerTools: ["codex", "claude-code", "opencode", "pi"],
             returnPath: "/auth/device?user_code=BCDF-GHJK",
           }),
         }),

--- a/tests/shell/billing-section.test.tsx
+++ b/tests/shell/billing-section.test.tsx
@@ -84,7 +84,7 @@ describe("BillingSection", () => {
     expect(screen.getByText("Mastercard")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Monthly" }).getAttribute("aria-pressed")).toBe("true");
     expect(screen.getByRole("button", { name: "Annual" }).getAttribute("aria-pressed")).toBe("false");
-    expect(screen.queryByText("Developer tools")).toBeNull();
+    expect(screen.getByRole("heading", { name: "Developer tools" })).toBeTruthy();
     expect(screen.queryByTestId("pricing-table")).toBeNull();
   });
 
@@ -339,6 +339,8 @@ describe("BillingSection", () => {
             planSlug: "matrix_builder",
             interval: "annual",
             regionSlug: "region_nbg1",
+            serverType: "cpx32",
+            developerTools: ["codex", "claude-code", "opencode", "pi"],
           }),
         }),
       ),
@@ -400,6 +402,8 @@ describe("BillingSection", () => {
             planSlug: "matrix_builder",
             interval: "monthly",
             regionSlug: "region_fsn1",
+            serverType: "cpx32",
+            developerTools: ["codex", "claude-code", "opencode", "pi"],
             returnPath: "/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK",
           }),
         }),
@@ -480,6 +484,8 @@ describe("BillingSection", () => {
     expect(screen.getByText("ash")).toBeTruthy();
     expect(screen.queryByText("sin")).toBeNull();
     expect(screen.getByText("Start checkout & provision")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Developer tools" })).toBeTruthy();
+    expect((screen.getByRole("checkbox", { name: "Codex" }) as HTMLInputElement).checked).toBe(true);
     expect(screen.getByRole("button", { name: "Continue to pay" })).toBeTruthy();
     expect(screen.queryByTestId("pricing-table")).toBeNull();
   });

--- a/tests/shell/mocks/tldraw.tsx
+++ b/tests/shell/mocks/tldraw.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export function Tldraw() {
+  return <div data-testid="mock-tldraw" />;
+}

--- a/tests/shell/runtime-manager.test.tsx
+++ b/tests/shell/runtime-manager.test.tsx
@@ -357,6 +357,8 @@ describe("RuntimeManager", () => {
             planSlug: "matrix_starter",
             interval: "annual",
             regionSlug: "region_hil",
+            serverType: "cpx22",
+            developerTools: ["codex", "claude-code", "opencode", "pi"],
             runtimeSlot: "research-lab",
             returnPath: "/?billing=setup&handoff=add-computer",
           }),

--- a/tests/shell/workspace-canvas-renderer.test.tsx
+++ b/tests/shell/workspace-canvas-renderer.test.tsx
@@ -8,9 +8,6 @@ import { WorkspaceCanvasNode } from "../../shell/src/components/canvas/Workspace
 
 const terminalPaneSpy = vi.fn();
 
-vi.mock("@tldraw/tldraw", () => ({
-  Tldraw: () => <div data-testid="mock-tldraw" />,
-}));
 vi.mock("../../shell/src/components/terminal/TerminalPane.js", () => ({
   TerminalPane: (props: unknown) => {
     terminalPaneSpy(props);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
         if (!importer) return null;
         const normalized = importer.split(path.sep).join("/");
         if (
+          source === "@tldraw/tldraw" &&
+          normalized.endsWith("/shell/src/components/canvas/WorkspaceCanvas.tsx")
+        ) {
+          return path.resolve(__dirname, "tests/shell/mocks/tldraw.tsx");
+        }
+        if (
           source === "@tiptap/react" &&
           normalized.endsWith("/home/apps/notes/src/RichEditor.tsx")
         ) {
@@ -68,6 +74,7 @@ export default defineConfig({
         "packages/kernel/src/skill-registry.ts",
       ),
       "@matrix-os/kernel": path.resolve(__dirname, "packages/kernel/src/index.ts"),
+      vitest: path.resolve(__dirname, "node_modules/vitest"),
       react: path.resolve(__dirname, "node_modules/react"),
       "react-dom": path.resolve(__dirname, "node_modules/react-dom"),
       "@aws-sdk/client-s3": path.resolve(__dirname, "node_modules/@aws-sdk/client-s3"),
@@ -75,6 +82,9 @@ export default defineConfig({
   },
   test: {
     globals: true,
+    server: {
+      deps: { inline: ["@testing-library/jest-dom"] },
+    },
     // CI runners are sometimes slow under load; tests that rely on async
     // waitFor polling can exceed the 5s vitest default.
     testTimeout: 20_000,


### PR DESCRIPTION
## Summary

- collect compute profile, region, and optional developer agents before Checkout, then start preparing the primary VPS before redirecting to Stripe
- keep every prepared machine fenced in `awaiting_billing` until a signed active subscription webhook authorizes the exact owner, slot, intent, and machine
- clean up expired unpaid preparation through signed Stripe expiry events and a durable exact-provider deletion queue
- reconcile authorized fallback work through a short Postgres lease so concurrent platform instances cannot create duplicate VPSes
- ship rollout, capacity, hourly-cost, and allowlist controls with admission disabled by default

## Tests

- `pnpm install --offline --frozen-lockfile`
- `bun run typecheck`
- `bun run check:patterns:diff` (0 violations; reviewed bounded warnings)
- `pnpm exec vitest run tests/platform/ci-workflows.test.ts` (34/34)
- 151 post-restack platform, billing UI, and workflow tests
- `bun run build:shell:production`
- full `bun run test` exercised the repository; two load-sensitive failures were reproduced, one stale assertion was fixed, and one material early-registration race was fixed
- React Doctor completed with broad existing repository findings and no changed-feature blocker

## Review and monitoring

- structured mechanical, trust-boundary, atomicity/failure-mode, runtime-contract, and launch-readiness passes completed
- current-head trusted Greptile review: 5/5 on `a8b823817aea20341ff7575e2a5330f9e8d00e91`; zero unresolved review threads
- CI change detection now uses a bounded checkout before its explicit shallow base fetch, covered by a workflow regression test
- no deployment, live Stripe Checkout, or billable VPS creation performed
- label-triggered CI and Docker smoke passed on the current head ([CI run 32785957658](https://github.com/HamedMP/matrix-os/actions/runs/32785957658), [Docker run 32785957751](https://github.com/HamedMP/matrix-os/actions/runs/32785957751))

## Invariants

### Source of truth

- Postgres owns checkout attempts, prebilling intents, machine activation state, provisioning jobs, and durable provider deletion work.
- Signed Stripe subscription and checkout-expiry events project authorization or cleanup into those local records; Stripe metadata is a server-written lookup key, never standalone authority.

### Lock and transaction scope

- Capacity admission uses one transaction-scoped advisory lock; intent, machine, and job transitions use revision fences and row locks.
- Signed entitlement projection and exact-machine activation are one database transaction.
- Provider network calls remain outside database transactions; post-create persistence locks the machine then job and distinguishes active, already-completed, and cleanup-won outcomes.

### Acceptable orphan states

- An ambiguous provider create remains a durable pending job for exact-label reconciliation.
- If signed expiry wins after provider creation, the exact server is deleted immediately or queued idempotently for durable deletion.
- A crash before Stripe-session binding can clean only through signed expiry metadata matching the server-created intent and owner.

### Auth source of truth

- Clerk authentication owns Checkout identity.
- Stripe webhook signature verification owns subscription authorization and checkout expiry.
- Every metadata binding is revalidated against local intent owner, runtime slot, selection, revision, and exact machine linkage; unauthorized machines are excluded from routing selectors.

### Deferred scope

- Admission stays disabled until an operator configures rollout and cost ceilings.
- Live Stripe and disposable-VPS QA, deployment, and rollout are deferred.
- Existing additional-computer billing and support-controlled resize behavior are unchanged.
- Public documentation remains a separate `FinnaAI/matrix-os-site` PR, as required by the project constitution and the requested one-implementation-PR scope.
