### PR TITLE
feat(billing): configure card trial duration

### DIFF
--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -57,6 +57,7 @@ jobs:
       ATS_BOOKING_BASE_URL: ${{ vars.ATS_BOOKING_BASE_URL }}
       GOLDEN_SNAPSHOT_BUILDS_ENABLED: ${{ vars.GOLDEN_SNAPSHOT_BUILDS_ENABLED || 'false' }}
       MATRIX_CARD_TRIALS_ENABLED: ${{ vars.MATRIX_CARD_TRIALS_ENABLED || 'false' }}
+      MATRIX_CARD_TRIAL_DAYS: ${{ vars.MATRIX_CARD_TRIAL_DAYS || '7' }}
       POSTHOG_PUBLIC_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.posthog.com' }}
       POSTHOG_PUBLIC_API_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_API_HOST || '/relay' }}
       DEPLOY_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'production' }}
@@ -105,6 +106,10 @@ jobs:
               exit 1
               ;;
           esac
+          if ! [[ "$MATRIX_CARD_TRIAL_DAYS" =~ ^(0*[1-9]|0*[12][0-9]|0*30)$ ]]; then
+            echo "MATRIX_CARD_TRIAL_DAYS must be an integer from 1 to 30." >&2
+            exit 1
+          fi
 
       - name: Authenticate to Google Cloud
         # google-github-actions v4 tags are not published yet; v3 is the latest
@@ -519,7 +524,7 @@ jobs:
             --ingress all \
             --allow-unauthenticated \
             "${traffic_flags[@]}" \
-            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_BACKGROUND_WORKERS_ENABLED=false,PLATFORM_PORT=8080,PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL},MATRIX_API_ORIGIN=${MATRIX_API_ORIGIN},CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_TLS_VERIFY=false,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_APP_DOMAIN_HOSTS=${MATRIX_APP_DOMAIN_HOSTS},MATRIX_CODE_DOMAIN_HOSTS=${MATRIX_CODE_DOMAIN_HOSTS},NEXT_PUBLIC_MATRIX_APP_URL=${MATRIX_APP_URL},MATRIX_BILLING_PROVIDER=stripe,MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED},POSTHOG_HOST=https://eu.i.posthog.com,POSTHOG_API_HOST=https://eu.i.posthog.com,NEXT_PUBLIC_POSTHOG_HOST=${POSTHOG_PUBLIC_HOST},NEXT_PUBLIC_POSTHOG_API_HOST=${POSTHOG_PUBLIC_API_HOST},R2_PREFIX_ROOT=matrixos-sync,GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED},GOLDEN_SNAPSHOTS_ENABLED=false,GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0${ats_env_bindings}" \
+            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_BACKGROUND_WORKERS_ENABLED=false,PLATFORM_PORT=8080,PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL},MATRIX_API_ORIGIN=${MATRIX_API_ORIGIN},CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_TLS_VERIFY=false,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_APP_DOMAIN_HOSTS=${MATRIX_APP_DOMAIN_HOSTS},MATRIX_CODE_DOMAIN_HOSTS=${MATRIX_CODE_DOMAIN_HOSTS},NEXT_PUBLIC_MATRIX_APP_URL=${MATRIX_APP_URL},MATRIX_BILLING_PROVIDER=stripe,MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED},MATRIX_CARD_TRIAL_DAYS=${MATRIX_CARD_TRIAL_DAYS},POSTHOG_HOST=https://eu.i.posthog.com,POSTHOG_API_HOST=https://eu.i.posthog.com,NEXT_PUBLIC_POSTHOG_HOST=${POSTHOG_PUBLIC_HOST},NEXT_PUBLIC_POSTHOG_API_HOST=${POSTHOG_PUBLIC_API_HOST},R2_PREFIX_ROOT=matrixos-sync,GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED},GOLDEN_SNAPSHOTS_ENABLED=false,GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0${ats_env_bindings}" \
             --set-secrets "PLATFORM_DATABASE_URL=platform-database-url:latest,PLATFORM_SECRET=platform-secret:latest,GOLDEN_SNAPSHOT_OPERATOR_SECRET=golden-snapshot-operator-secret:latest,PLATFORM_JWT_SECRET=platform-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,STRIPE_SECRET_KEY=stripe-secret-key:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual:latest,PIPEDREAM_CLIENT_ID=pipedream-client-id:latest,PIPEDREAM_CLIENT_SECRET=pipedream-client-secret:latest,PIPEDREAM_PROJECT_ID=pipedream-project-id:latest,PIPEDREAM_ENVIRONMENT=pipedream-environment:latest,R2_ACCOUNT_ID=r2-account-id:latest,R2_BUCKET=r2-bucket:latest,R2_ENDPOINT=r2-endpoint:latest,R2_ACCESS_KEY_ID=r2-access-key-id:latest,R2_SECRET_ACCESS_KEY=r2-secret-access-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,HETZNER_API_TOKEN=hetzner-api-token:latest,POSTHOG_TOKEN=posthog-token:latest,POSTHOG_PROJECT_TOKEN=posthog-project-token:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,NEXT_PUBLIC_POSTHOG_KEY=next-public-posthog-key:latest,NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=next-public-posthog-project-token:latest${ats_secret_bindings}" \
             --format=json); then
             exit 1
@@ -689,7 +694,7 @@ jobs:
             --no-traffic \
             --min-instances "$min_instances" \
             --no-cpu-throttling \
-            --update-env-vars "PLATFORM_BACKGROUND_WORKERS_ENABLED=true,MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED},GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED},GOLDEN_SNAPSHOTS_ENABLED=false,GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0" \
+            --update-env-vars "PLATFORM_BACKGROUND_WORKERS_ENABLED=true,MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED},MATRIX_CARD_TRIAL_DAYS=${MATRIX_CARD_TRIAL_DAYS},GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED},GOLDEN_SNAPSHOTS_ENABLED=false,GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0" \
             --format=json)"
           production_revision="$(printf '%s\n' "$deploy_json" | jq -r '.status.traffic[]? | select(.tag == "production-candidate") | .revisionName // empty' | head -1)"
           if [ -z "$production_revision" ]; then

--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -70,6 +70,7 @@ jobs:
       CLOUD_RUN_PREVIEW_SERVICE: ${{ vars.CLOUD_RUN_PREVIEW_SERVICE }}
       CLOUD_RUN_SERVICE_ACCOUNT: ${{ vars.CLOUD_RUN_PREVIEW_SERVICE_ACCOUNT }}
       MATRIX_CARD_TRIALS_ENABLED: ${{ vars.MATRIX_CARD_TRIALS_ENABLED || 'false' }}
+      MATRIX_CARD_TRIAL_DAYS: ${{ vars.MATRIX_CARD_TRIAL_DAYS || '7' }}
       PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
     steps:
       - name: Check preview configuration
@@ -92,6 +93,10 @@ jobs:
               exit 1
               ;;
           esac
+          if ! [[ "$MATRIX_CARD_TRIAL_DAYS" =~ ^(0*[1-9]|0*[12][0-9]|0*30)$ ]]; then
+            echo "MATRIX_CARD_TRIAL_DAYS must be an integer from 1 to 30." >&2
+            exit 1
+          fi
           echo "configured=true" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v6
@@ -172,7 +177,7 @@ jobs:
               --tag "pr-${PR_NUMBER}" \
               --no-traffic \
               --allow-unauthenticated \
-              --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PREVIEW=true,CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_IMAGE_VERSION=dev,CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,MATRIX_STRIPE_BILLING_ENABLED=true,MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED},PLATFORM_PUBLIC_URL=${PREVIEW_PUBLIC_URL},MATRIX_API_ORIGIN=${api_origin},MATRIX_APP_URL=${PREVIEW_PUBLIC_URL},MATRIX_APP_DOMAIN_HOSTS=${PREVIEW_DOMAIN}" \
+              --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PREVIEW=true,CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_IMAGE_VERSION=dev,CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,MATRIX_STRIPE_BILLING_ENABLED=true,MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED},MATRIX_CARD_TRIAL_DAYS=${MATRIX_CARD_TRIAL_DAYS},PLATFORM_PUBLIC_URL=${PREVIEW_PUBLIC_URL},MATRIX_API_ORIGIN=${api_origin},MATRIX_APP_URL=${PREVIEW_PUBLIC_URL},MATRIX_APP_DOMAIN_HOSTS=${PREVIEW_DOMAIN}" \
               --set-secrets "PLATFORM_DATABASE_URL=platform-database-url-staging:latest,PLATFORM_SECRET=platform-preview-secret:latest,GOLDEN_SNAPSHOT_OPERATOR_SECRET=golden-snapshot-operator-secret-preview:latest,PLATFORM_JWT_SECRET=platform-preview-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-preview-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,STRIPE_SECRET_KEY=stripe-secret-key-test:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret-test:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly-test:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual-test:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly-test:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual-test:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly-test:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual-test:latest" \
               --cpu 1 --memory 1Gi --concurrency 10 --timeout 300 --min-instances 0 --max-instances 2 \
               --quiet

--- a/docs/dev/preview-environments.md
+++ b/docs/dev/preview-environments.md
@@ -169,7 +169,11 @@ The label workflow assumes this is already provisioned in GCP/Cloudflare/Stripe
 The GitHub `Preview` environment may set `MATRIX_CARD_TRIALS_ENABLED` to
 `true` or `false`; it defaults to `false`. Keep it disabled for the immediate-
 payment regression pass, enable it only for trial scenarios, then return it to
-`false` after validation. Each change requires redeploying the preview revision.
+`false` after validation. `MATRIX_CARD_TRIAL_DAYS` controls new trial offers,
+defaults to `7`, and must be an integer from `1` through `30`. Each change
+requires redeploying the preview revision. Existing Stripe trials and reserved
+Checkout attempts retain their original duration, and billing status continues
+to display that reserved duration until the attempt settles.
 
 ## Centralized logs
 

--- a/docs/dev/staging-platform-vps.md
+++ b/docs/dev/staging-platform-vps.md
@@ -96,8 +96,11 @@ stripe listen --forward-to "localhost:${PLATFORM_PORT:-9000}/billing/webhooks/st
 bun run dev:platform
 ```
 
-Set `MATRIX_CARD_TRIALS_ENABLED=true` for this test slice. Drive a checkout for
-a first primary computer with `4242 4242 4242 4242`, and confirm:
+Set `MATRIX_CARD_TRIALS_ENABLED=true` and `MATRIX_CARD_TRIAL_DAYS=7` for the
+canonical test slice. The duration accepts integers from `1` through `30`; a
+shorter value compresses conversion testing but does not reproduce the normal
+three-day reminder transition. Drive a checkout for a first primary computer
+with `4242 4242 4242 4242`, and confirm:
 
 - Stripe collects the card, creates a `trialing` subscription with an
   authoritative seven-day `trial_end`, and charges `$0` initially;
@@ -225,7 +228,11 @@ account and production platform env:
     three-day reminder window as `customer.subscription.trial_will_end`.
 11. Set the GitHub environment variable `MATRIX_CARD_TRIALS_ENABLED=true` only
     when the offer is ready to roll out. Returning it to `false` stops new
-    offers without changing subscriptions already in trial.
+    offers without changing subscriptions already in trial. Set
+    `MATRIX_CARD_TRIAL_DAYS` to an integer from `1` through `30` (`7` is the
+    product default); duration changes affect only new offers and preserve
+    existing Stripe trials and reserved Checkout attempts. Pre-Checkout billing
+    copy must continue to use a reserved attempt's duration after a redeploy.
 12. Rebuild the host bundle after changing any `NEXT_PUBLIC_*` value; build a
     stable release from the merge commit for traceability.
 

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -18,6 +18,7 @@ import {
   getBillingSubscription,
   getBillingSubscriptionByStripeId,
   getActiveUserMachineByClerkId,
+  getActiveCheckoutAttempt,
   getSettlingCheckoutAttempt,
   insertBillingWebhookEvent,
   isCardTrialOfferEligible,
@@ -53,6 +54,10 @@ const BILLING_BODY_LIMIT = 16 * 1024;
 const STRIPE_WEBHOOK_BODY_LIMIT = 1024 * 1024;
 const MAX_STRIPE_API_TIMEOUT_MS = 10_000;
 export const MATRIX_CARD_TRIAL_DAYS = 7;
+const MatrixCardTrialDaysSchema = z.string()
+  .regex(/^[0-9]+$/)
+  .transform(Number)
+  .pipe(z.number().int().min(1).max(30));
 const CLERK_USER_ID_PATTERN = /^user_[A-Za-z0-9]{1,128}$/;
 const BILLING_UNAVAILABLE_RESPONSE = {
   error: 'Billing unavailable',
@@ -175,6 +180,7 @@ export function createBillingRoutes(options: {
 }): Hono {
   const app = new Hono();
   const env = options.env ?? process.env;
+  const cardTrialDays = resolveCardTrialDays(env);
   const now = options.now ?? (() => new Date());
   const persistEntitlement = options.upsertEntitlement ?? upsertBillingEntitlement;
 
@@ -301,7 +307,7 @@ export function createBillingRoutes(options: {
         ? claimCardTrialCheckoutAttempt(options.db, {
             id: randomUUID(),
             ...checkoutClaim,
-          }, MATRIX_CARD_TRIAL_DAYS)
+          }, cardTrialDays)
         : claimCheckoutAttempt(options.db, {
             id: randomUUID(),
             ...checkoutClaim,
@@ -472,6 +478,7 @@ export function createBillingRoutes(options: {
       const currentTime = now();
       const query = BillingStatusQuerySchema.safeParse(c.req.query());
       if (!query.success) return c.json({ error: 'Invalid request' }, 400);
+      const runtimeSlot = query.data.runtimeSlot ?? 'primary';
       const state = await getBillingEntitlementState(options.db, clerkUserId, currentTime.toISOString());
       let stripeEntitlement = parseBillingEntitlementRecord(state.entitlement);
       if (query.data.runtimeSlot) {
@@ -506,11 +513,18 @@ export function createBillingRoutes(options: {
         now: currentTime,
       });
       const access = getRuntimeAccessDecision(entitlement, currentTime);
+      const trialsEnabledForSlot = env.MATRIX_CARD_TRIALS_ENABLED === 'true'
+        && runtimeSlot === 'primary';
+      const activeAttempt = await getActiveCheckoutAttempt(options.db, clerkUserId, runtimeSlot);
+      const offerEligible = trialsEnabledForSlot
+        ? await isCardTrialOfferEligible(options.db, clerkUserId)
+        : false;
+      const reservedTrialDays = runtimeSlot === 'primary'
+        ? activeAttempt?.trialPeriodDays ?? null
+        : null;
       const trialOffer = {
-        eligible: env.MATRIX_CARD_TRIALS_ENABLED === 'true'
-          && (query.data.runtimeSlot ?? 'primary') === 'primary'
-          && await isCardTrialOfferEligible(options.db, clerkUserId),
-        durationDays: MATRIX_CARD_TRIAL_DAYS,
+        eligible: reservedTrialDays !== null || (offerEligible && !activeAttempt),
+        durationDays: reservedTrialDays ?? cardTrialDays,
       };
       return c.json({ entitlement, access, trialOffer }, 200);
     } catch (err: unknown) {
@@ -777,6 +791,16 @@ export function createBillingRoutes(options: {
   });
 
   return app;
+}
+
+function resolveCardTrialDays(env: NodeJS.ProcessEnv): number {
+  const configured = env.MATRIX_CARD_TRIAL_DAYS;
+  if (configured === undefined) return MATRIX_CARD_TRIAL_DAYS;
+  const parsed = MatrixCardTrialDaysSchema.safeParse(configured);
+  if (!parsed.success) {
+    throw new Error('MATRIX_CARD_TRIAL_DAYS must be an integer from 1 to 30');
+  }
+  return parsed.data;
 }
 
 function resolvePriceId(

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -4289,6 +4289,23 @@ export async function getLatestCheckoutAttempt(
   return row ? mapCheckoutAttempt(row) : undefined;
 }
 
+export async function getActiveCheckoutAttempt(
+  db: PlatformDB,
+  clerkUserId: string,
+  runtimeSlot: string,
+): Promise<BillingCheckoutAttemptRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .selectFrom('billing_checkout_attempts')
+    .selectAll()
+    .where('clerk_user_id', '=', clerkUserId)
+    .where('runtime_slot', '=', runtimeSlot)
+    .where('status', 'in', ['creating', 'open'])
+    .orderBy('created_at', 'desc')
+    .executeTakeFirst();
+  return row ? mapCheckoutAttempt(row) : undefined;
+}
+
 /**
  * The attempt that governs payment settling: a confirmed `paid` attempt always
  * wins over a newer still-`open` one, so a paying user who opens a second

--- a/specs/115-card-required-runtime-trial/spec.md
+++ b/specs/115-card-required-runtime-trial/spec.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-Matrix offers one Stripe-native seven-day subscription trial for an account's first primary hosted computer. Stripe Checkout collects a card before Matrix provisions the VPS, charges $0 at trial creation, and automatically attempts the selected Starter, Builder, or Max price when Stripe's authoritative `trial_end` arrives. Checkout redirects never grant access; signed Stripe subscription and invoice webhooks project the entitlement used by provisioning and routing.
+Matrix offers one Stripe-native subscription trial for an account's first primary hosted computer. The product default is seven days; operators may set `MATRIX_CARD_TRIAL_DAYS` to an integer from 1 through 30 for a controlled rollout. Stripe Checkout collects a card before Matrix provisions the VPS, charges $0 at trial creation, and automatically attempts the selected Starter, Builder, or Max price when Stripe's authoritative `trial_end` arrives. Checkout redirects never grant access; signed Stripe subscription and invoice webhooks project the entitlement used by provisioning and routing.
 
 This specification supersedes the "no trials" requirements in `specs/084-stripe-runtime-plans/spec.md`. It also narrows that specification's dynamic-payment-method rule: trial Checkout is card-only and always collects a payment method, while paid and additional-computer Checkout continues to use Stripe's configured dynamic methods.
 
@@ -38,6 +38,7 @@ This specification supersedes the "no trials" requirements in `specs/084-stripe-
 - Canceling during the trial retains access until Stripe ends the trial. An unpaid end gates access and schedules suspension.
 - Poweroff retains the machine row, provider server, disk, backups, home files, and owner Postgres data.
 - Promotion codes remain independent invoice discounts and never implement trial duration.
+- `MATRIX_CARD_TRIAL_DAYS` is the server-side offer source of truth, defaults to `7`, and fails startup/deployment validation outside `1..30`. Stripe's persisted `trial_end` remains authoritative after subscription creation.
 
 ## Eligibility And Checkout
 
@@ -48,7 +49,7 @@ Trial eligibility is serialized on a per-Clerk-account ledger row and evaluated 
 3. No historical Stripe subscription exists for the Clerk account.
 4. The account has no consumed-trial timestamp.
 
-The ledger reserves the trial against the active Checkout attempt. Duplicate or ambiguous Stripe requests reuse that attempt's persisted `trial_period_days=7`. An expired/abandoned attempt releases the reservation for a fresh Checkout because no Stripe subscription was created. A verified `checkout.session.completed` event consumes the reservation immediately, and a verified `customer.subscription.created` event with `status=trialing` idempotently confirms consumption. Disabling the rollout flag affects only new offers and does not alter existing subscriptions or actions.
+The ledger reserves the trial against the active Checkout attempt. Duplicate or ambiguous Stripe requests reuse that attempt's persisted `trial_period_days`, even if the configured duration later changes. An expired/abandoned attempt releases the reservation for a fresh Checkout because no Stripe subscription was created. A verified `checkout.session.completed` event consumes the reservation immediately, and a verified `customer.subscription.created` event with `status=trialing` idempotently confirms consumption. Disabling the rollout flag or changing the duration affects only new offers and does not alter existing subscriptions or actions.
 
 Eligible Checkout sessions use:
 
@@ -58,7 +59,7 @@ Eligible Checkout sessions use:
   payment_method_types: ['card'],
   payment_method_collection: 'always',
   subscription_data: {
-    trial_period_days: 7,
+    trial_period_days: configuredTrialDays,
     trial_settings: {
       end_behavior: { missing_payment_method: 'cancel' },
     },
@@ -123,7 +124,7 @@ Suspension requests graceful provider shutdown and falls back to forced poweroff
 
 ## Product Experience
 
-Before Checkout, eligible users see "Start your 7-day free trial", "Card required", "$0 today", the exact selected price/interval beginning after seven days, the exact first-charge date, and "Cancel before this date to avoid being charged". The CTA is "Start 7-day trial". Ineligible and additional-computer flows keep immediate-payment language.
+Before Checkout, eligible users see "Start your {duration}-day free trial", "Card required", "$0 today", the exact selected price/interval beginning after the configured duration, the exact first-charge date, and "Cancel before this date to avoid being charged". The CTA is "Start {duration}-day trial". While an open or creating Checkout attempt reserves a trial, billing status and copy use that attempt's persisted duration even if operator configuration changes. An active non-trial Checkout, ineligible account, or additional-computer flow keeps immediate-payment language.
 
 During a trial, the shared shell shows a persistent notice with days remaining, upcoming price/date, and a Customer Portal link. It becomes prominent during the final three days. Trial lifecycle telemetry is PII-free and covers started, reminder due, converted, payment failed, VPS suspended, and VPS resumed.
 
@@ -133,6 +134,6 @@ Stripe Dashboard production configuration must enable Stripe's trial-ending emai
 
 - Unit/integration tests cover eligibility serialization, Checkout parameters, retry persistence, trial projection, conversion recognition, zero-value invoice rejection, duplicate/out-of-order webhooks, immediate access gating, established grace, suspension cancellation, recovery resume, action leases/retries, provider-call idempotency, graceful-shutdown fallback, and payment/action races.
 - Shell tests cover eligible, ineligible, active, expiring, failed, recovered, and additional-computer states.
-- Stripe test mode and Test Clocks exercise successful and declined conversion through the full seven days.
+- Stripe test mode and Test Clocks exercise successful and declined conversion through the configured trial duration; the canonical product test remains seven days.
 - Run targeted billing/VPS/UI tests, full tests and coverage, production shell build, and Canvas-first browser validation.
 - Public pricing and billing documentation ships in a separate `matrix-os-site` PR (MAT-446).

--- a/tests/platform/billing-routes.test.ts
+++ b/tests/platform/billing-routes.test.ts
@@ -193,6 +193,150 @@ describe('platform billing routes', () => {
     });
   });
 
+  it('offers and persists the configured card-trial duration', async () => {
+    const trialEnv = {
+      ...env,
+      MATRIX_CARD_TRIALS_ENABLED: 'true',
+      MATRIX_CARD_TRIAL_DAYS: '1',
+    };
+    const app = createApp('user_123', trialEnv);
+
+    const status = await app.request('/billing/status?runtimeSlot=primary');
+    await expect(status.json()).resolves.toMatchObject({
+      trialOffer: { eligible: true, durationDays: 1 },
+    });
+
+    const checkout = await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        planSlug: 'matrix_builder',
+        interval: 'monthly',
+        regionSlug: 'region_fsn1',
+        runtimeSlot: 'primary',
+      }),
+    });
+
+    expect(checkout.status).toBe(200);
+    expect(stripe.createCheckoutSession).toHaveBeenCalledWith(expect.objectContaining({
+      trialPeriodDays: 1,
+      paymentMethodMode: 'card_required',
+    }));
+    await expect(getLatestCheckoutAttempt(db, 'user_123')).resolves.toMatchObject({
+      runtimeSlot: 'primary',
+      trialPeriodDays: 1,
+    });
+  });
+
+  it.each(['open', 'creating'] as const)(
+    'keeps status copy aligned with a reserved trial in %s state after the configured duration changes',
+    async (attemptStatus) => {
+      if (attemptStatus === 'creating') {
+        stripe.createCheckoutSession = vi.fn().mockRejectedValue(new Error('stripe response timeout'));
+      }
+      const sevenDayApp = createApp('user_123', {
+        ...env,
+        MATRIX_CARD_TRIALS_ENABLED: 'true',
+        MATRIX_CARD_TRIAL_DAYS: '7',
+      });
+      const checkout = await sevenDayApp.request('/billing/checkout', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          planSlug: 'matrix_builder',
+          interval: 'monthly',
+          regionSlug: 'region_fsn1',
+          runtimeSlot: 'primary',
+        }),
+      });
+      expect(checkout.status).toBe(attemptStatus === 'open' ? 200 : 503);
+      await expect(getLatestCheckoutAttempt(db, 'user_123')).resolves.toMatchObject({
+        status: attemptStatus,
+        trialPeriodDays: 7,
+      });
+
+      const oneDayApp = createApp('user_123', {
+        ...env,
+        MATRIX_CARD_TRIALS_ENABLED: 'true',
+        MATRIX_CARD_TRIAL_DAYS: '1',
+      });
+      const status = await oneDayApp.request('/billing/status?runtimeSlot=primary');
+
+      await expect(status.json()).resolves.toMatchObject({
+        trialOffer: { eligible: true, durationDays: 7 },
+      });
+    },
+  );
+
+  it('keeps status copy aligned with a reserved trial after the rollout flag is disabled', async () => {
+    const trialApp = createApp('user_123', {
+      ...env,
+      MATRIX_CARD_TRIALS_ENABLED: 'true',
+      MATRIX_CARD_TRIAL_DAYS: '7',
+    });
+    const checkout = await trialApp.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        planSlug: 'matrix_builder',
+        interval: 'monthly',
+        regionSlug: 'region_fsn1',
+        runtimeSlot: 'primary',
+      }),
+    });
+    expect(checkout.status).toBe(200);
+
+    const disabledApp = createApp('user_123', {
+      ...env,
+      MATRIX_CARD_TRIALS_ENABLED: 'false',
+      MATRIX_CARD_TRIAL_DAYS: '1',
+    });
+    const status = await disabledApp.request('/billing/status?runtimeSlot=primary');
+
+    await expect(status.json()).resolves.toMatchObject({
+      trialOffer: { eligible: true, durationDays: 7 },
+    });
+  });
+
+  it('keeps an active immediate-payment Checkout ineligible when trials are later enabled', async () => {
+    const immediateApp = createApp('user_123', {
+      ...env,
+      MATRIX_CARD_TRIALS_ENABLED: 'false',
+    });
+    const checkout = await immediateApp.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        planSlug: 'matrix_builder',
+        interval: 'monthly',
+        regionSlug: 'region_fsn1',
+        runtimeSlot: 'primary',
+      }),
+    });
+    expect(checkout.status).toBe(200);
+
+    const trialApp = createApp('user_123', {
+      ...env,
+      MATRIX_CARD_TRIALS_ENABLED: 'true',
+      MATRIX_CARD_TRIAL_DAYS: '1',
+    });
+    const status = await trialApp.request('/billing/status?runtimeSlot=primary');
+
+    await expect(status.json()).resolves.toMatchObject({
+      trialOffer: { eligible: false, durationDays: 1 },
+    });
+  });
+
+  it.each(['0', '31', '1e1', '0x0a', ' 1 ', '18446744073709551623'])(
+    'rejects invalid card-trial duration %j during route startup',
+    (trialDays) => {
+      expect(() => createApp('user_123', {
+        ...env,
+        MATRIX_CARD_TRIAL_DAYS: trialDays,
+      })).toThrow('MATRIX_CARD_TRIAL_DAYS must be an integer from 1 to 30');
+    },
+  );
+
   it('does not offer a trial for additional computers or accounts with subscription history', async () => {
     const trialEnv = { ...env, MATRIX_CARD_TRIALS_ENABLED: 'true' };
     const additionalApp = createApp('user_123', trialEnv);

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -306,8 +306,18 @@ describe('CI workflows', () => {
 
     expect(production).toContain("MATRIX_CARD_TRIALS_ENABLED: ${{ vars.MATRIX_CARD_TRIALS_ENABLED || 'false' }}");
     expect(production).toContain('MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED}');
+    expect(production).toContain("MATRIX_CARD_TRIAL_DAYS: ${{ vars.MATRIX_CARD_TRIAL_DAYS || '7' }}");
+    expect(production).toContain('MATRIX_CARD_TRIAL_DAYS=${MATRIX_CARD_TRIAL_DAYS}');
+    expect(production).toContain('MATRIX_CARD_TRIAL_DAYS must be an integer from 1 to 30.');
+    expect(production).toContain('[[ "$MATRIX_CARD_TRIAL_DAYS" =~ ^(0*[1-9]|0*[12][0-9]|0*30)$ ]]');
+    expect(production).not.toContain('10#$MATRIX_CARD_TRIAL_DAYS');
     expect(preview).toContain("MATRIX_CARD_TRIALS_ENABLED: ${{ vars.MATRIX_CARD_TRIALS_ENABLED || 'false' }}");
     expect(preview).toContain('MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED}');
+    expect(preview).toContain("MATRIX_CARD_TRIAL_DAYS: ${{ vars.MATRIX_CARD_TRIAL_DAYS || '7' }}");
+    expect(preview).toContain('MATRIX_CARD_TRIAL_DAYS=${MATRIX_CARD_TRIAL_DAYS}');
+    expect(preview).toContain('MATRIX_CARD_TRIAL_DAYS must be an integer from 1 to 30.');
+    expect(preview).toContain('[[ "$MATRIX_CARD_TRIAL_DAYS" =~ ^(0*[1-9]|0*[12][0-9]|0*30)$ ]]');
+    expect(preview).not.toContain('10#$MATRIX_CARD_TRIAL_DAYS');
     expect(preview).toContain('MATRIX_CARD_TRIALS_ENABLED must be true or false.');
     for (const eventType of [
       'customer.subscription.trial_will_end',

--- a/tests/shell/billing-section.test.tsx
+++ b/tests/shell/billing-section.test.tsx
@@ -88,8 +88,8 @@ describe("BillingSection", () => {
     expect(screen.queryByTestId("pricing-table")).toBeNull();
   });
 
-  it("explains the card-required seven-day trial before opening Checkout", async () => {
-    const trialEnd = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  it.each([1, 7])("explains the card-required %i-day trial before opening Checkout", async (durationDays) => {
+    const trialEnd = new Date(Date.now() + durationDays * 24 * 60 * 60 * 1000);
     const formattedTrialEnd = new Intl.DateTimeFormat(undefined, {
       month: "short",
       day: "numeric",
@@ -98,7 +98,7 @@ describe("BillingSection", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({
         access: { runtimeProxyAllowed: false },
-        trialOffer: { eligible: true, durationDays: 7 },
+        trialOffer: { eligible: true, durationDays },
       }), {
         status: 200,
         headers: { "content-type": "application/json" },
@@ -108,13 +108,13 @@ describe("BillingSection", () => {
 
     render(<BillingSection mode="provisioning" />);
 
-    await waitFor(() => expect(screen.getByText("Start your 7-day free trial")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(`Start your ${durationDays}-day free trial`)).toBeTruthy());
     expect(screen.getByText("Card required")).toBeTruthy();
     expect(screen.getByText("$0 today").classList.contains("text-cream")).toBe(true);
     expect(screen.getByText(`First charge ${formattedTrialEnd}`)).toBeTruthy();
     expect(screen.getByText(`Cancel before ${formattedTrialEnd} to avoid being charged.`)).toBeTruthy();
     expect(screen.getByText("$19/month after your trial")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Start 7-day trial" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: `Start ${durationDays}-day trial` })).toBeTruthy();
   });
 
   it("keeps immediate-payment language for additional computers", async () => {


### PR DESCRIPTION
## Summary

- add validated `MATRIX_CARD_TRIAL_DAYS` configuration for new card-required trial offers
- keep seven days as the safe product default while allowing controlled values from 1 through 30
- wire the value into production and preview Cloud Run revisions, including the production worker revision
- preserve each reserved Checkout attempt's original duration when configuration changes
- cover one-day and seven-day billing copy and update the trial specification/operator documentation

## Tests

- `pnpm exec vitest run tests/platform/billing-routes.test.ts tests/platform/ci-workflows.test.ts tests/shell/billing-section.test.tsx` (128 passed)
- `pnpm exec vitest run tests/shell/agent-settings.test.tsx tests/shell/hermes-configuration.test.tsx` (31 passed; dependency-link verification)
- `bun run typecheck`
- `bun run check:patterns` (0 violations; 5 existing warnings)
- `pnpm --filter '@matrix-os/brand' build`
- `pnpm --filter '@matrix-os/observability' build`
- `pnpm --dir shell exec next build --webpack`
- `git diff --check`

## Review and monitoring

- Do not add `ready-for-ci` or merge until trusted Greptile reports 5/5 on the current head.
- After merge, set the production GitHub environment variable to `MATRIX_CARD_TRIAL_DAYS=1`, deploy/promote through Platform Cloud Run, and verify both the web and worker revisions received it.
- Monitor trial-started, conversion, payment-failure, suspension/resume, and webhook-failure telemetry during the controlled production test.

## Invariants

- **Source of truth:** `MATRIX_CARD_TRIAL_DAYS` controls only newly claimed trial offers. Billing status uses an active attempt's persisted `trial_period_days`, and an active non-trial attempt keeps immediate-payment copy. After Stripe creates the subscription, signed Stripe webhook data and authoritative `trial_start`/`trial_end` control lifecycle state.
- **Lock and transaction scope:** the existing per-account trial ledger claim and Checkout-attempt transaction boundaries are unchanged. The configured duration is resolved once at route startup and passed into the existing serialized claim.
- **Acceptable orphan states:** unchanged. Ambiguous Checkout creation continues to reuse its persisted idempotency key and attempt duration; expired/abandoned attempts remain reclaimable under the existing settlement rules.
- **Auth source of truth:** unchanged. Clerk authenticates Matrix billing routes, while only verified Stripe webhook signatures project entitlements; Checkout redirects never grant access.
- **Deferred scope:** this PR does not mutate existing trials, alter suspension/recovery behavior, promote a host bundle, or merge the public documentation PR. `FinnaAI/matrix-os-site#40` still requires Greptile 5/5 before merge.
