### PR TITLE
docs(chat): finalize canonical Chat workspace architecture

### DIFF
--- a/specs/113-provider-neutral-chat-architecture/delivery-plan.md
+++ b/specs/113-provider-neutral-chat-architecture/delivery-plan.md
@@ -76,7 +76,7 @@ These are inputs, not work to repeat.
 | MAT-319 provider-neutral architecture | Done | [#1218](https://github.com/HamedMP/matrix-os/pull/1218) merged | Amend through this design PR; do not reopen the old implementation assumptions |
 | MAT-299 Hermes conversation lifecycle | Done | [#1213](https://github.com/HamedMP/matrix-os/pull/1213) merged | Legacy Hermes source and compatibility seam for canonical import |
 | MAT-318 persistent Project context | Done | [#1252](https://github.com/HamedMP/matrix-os/pull/1252) merged | Reuse stable Project ID and guarded context behavior; generalize to canonical Chat move |
-| MAT-321 canonical Chat persistence/adapters | Todo | No PR | Replace as an umbrella; split into `NEW-B1`, `NEW-B2`, `NEW-B4`, and `NEW-B5` below |
+| MAT-321 canonical Chat persistence/adapters | Todo | No PR | Replace as an umbrella; split into `MAT-472`, `MAT-473`, `MAT-477`, and `MAT-479` below |
 | MAT-322 Chat inbox/composer/resources | Done | [#1231](https://github.com/HamedMP/matrix-os/pull/1231) merged | Reuse visual/components; remove its stale “blocked by MAT-321” relation during Linear cleanup |
 | MAT-344 T3 Project Chat | In Progress | Umbrella | Keep as UI umbrella; children supply accepted components to final integration |
 | MAT-345 Project Chat navigation/search | Done | [#1248](https://github.com/HamedMP/matrix-os/pull/1248) merged | Reuse list/search behavior against canonical summaries |
@@ -87,22 +87,23 @@ These are inputs, not work to repeat.
 | MAT-364 Desktop Chat beta-ready | In Progress | Umbrella | Final authenticated acceptance/hardening gate, not a feature bucket |
 | MAT-453 Projects workflows | Done | [#1282](https://github.com/HamedMP/matrix-os/pull/1282) merged | Reuse Project identity, creation, and re-entry behavior |
 | MAT-455 Chat/Files home lists | Done | [#1292](https://github.com/HamedMP/matrix-os/pull/1292) merged | Reuse list presentation and navigation patterns |
-| MAT-458 typed activity timeline | In Progress | No attached PR | Keep Gateway normalization/persistence under Yuhan; split presentation polish into `NEW-D1` |
+| MAT-458 typed activity timeline | In Progress | No attached PR | Keep Gateway normalization/persistence under Yuhan; split presentation polish into `MAT-474` |
 | MAT-459 provider readiness | PR In Review in Linear | [#1294](https://github.com/HamedMP/matrix-os/pull/1294) merged | **Status drift:** reconcile Linear to merged truth before new dependency links |
-| MAT-460 turn changes/file preview | In Progress, blocked | No PR | Split backend truth (`NEW-E2`) from inspector UI (`NEW-E3`); preserve MAT-347 and MAT-458 blockers |
+| MAT-460 turn changes/file preview | In Progress, blocked | No PR | Split backend truth (`MAT-478`) from inspector UI (`MAT-481`); preserve MAT-347 and MAT-458 blockers |
 | MAT-468 real Global Chat provider switching | Human Review | [#1299](https://github.com/HamedMP/matrix-os/pull/1299) open draft | Compatibility slice only; see disposition below |
 | MAT-469 readiness refresh | Done | [#1300](https://github.com/HamedMP/matrix-os/pull/1300) merged | Reuse bounded refresh and draft-preservation behavior |
 | Supporting global/project presentation | Merged | [#1293](https://github.com/HamedMP/matrix-os/pull/1293) merged | Reuse presentation composition; it is not canonical domain/persistence unification |
 
-## Proposed Linear and PR stack
+## Created Linear and proposed PR stack
 
-`NEW-*` are planning identifiers only. Create real Linear issues after team
-review, then replace these identifiers in this document. Every PR has one owner
-and one coherent responsibility.
+The implementation issues below were created on 2026-08-24 in the Matrix OS
+team, September Public Launch project, and current cycle. All are temporarily
+assigned to Yuhan; teammates may select ownership later. Every PR retains one
+owner and one coherent responsibility.
 
-### NEW-A0 — Final architecture amendment
+### MAT-470 — Final architecture amendment
 
-**Proposed owner:** Yuhan
+**Temporary assignee:** Yuhan
 **PR:** `docs(chat): finalize canonical Chat and workspace architecture`
 **Depends on:** MAT-319/#1218 and the decisions in this document
 **Blocks:** every new implementation issue
@@ -112,11 +113,11 @@ and one coherent responsibility.
   hierarchy, shared UI boundaries, migration, and PR graph.
 - Gate: team architecture review. No runtime claim or product implementation.
 
-### NEW-A1 — Shared canonical Chat contracts and fixtures
+### MAT-471 — Shared canonical Chat contracts and fixtures
 
-**Proposed owner:** Yuhan
+**Temporary assignee:** Yuhan
 **PR:** `feat(contracts): add canonical Chat and Provider contracts`
-**Depends on:** NEW-A0
+**Depends on:** MAT-470
 **Blocks:** all backend/UI lanes
 
 - Primary files: `packages/contracts/src/**`, focused contract tests, and shared
@@ -128,12 +129,12 @@ and one coherent responsibility.
   coding-agent thread projections. Do not add storage or UI.
 - Gate: schema bounds, redaction, round-trip, and fixture compatibility tests.
 
-### NEW-B1 — Owner-local Chat repository and transactional outbox
+### MAT-472 — Owner-local Chat repository and transactional outbox
 
-**Proposed owner:** Yuhan
+**Temporary assignee:** Yuhan
 **PR:** `feat(gateway): add canonical Chat repository`
-**Depends on:** NEW-A1
-**Blocks:** NEW-B4, NEW-B5, NEW-F1
+**Depends on:** MAT-471
+**Blocks:** MAT-477, MAT-479, MAT-480
 
 - Primary files: new `packages/gateway/src/chat/**`, shared owner-database
   migrations, Gateway shutdown wiring, and `tests/gateway/chat-*.test.ts`.
@@ -145,12 +146,12 @@ and one coherent responsibility.
 - Gate: row-lock races, atomic outbox, delete/finalize races, owner isolation,
   and shutdown ownership tests.
 
-### NEW-B2 — Provider Driver/Instance catalog and Chat binding
+### MAT-473 — Provider Driver/Instance catalog and Chat binding
 
-**Proposed owner:** Yuhan
+**Temporary assignee:** Yuhan
 **PR:** `feat(gateway): add Provider Instance catalog and Chat binding`
-**Depends on:** NEW-A1
-**Blocks:** NEW-B4 and NEW-C1
+**Depends on:** MAT-471
+**Blocks:** MAT-477 and MAT-476
 
 - Primary files: new canonical Provider registry in
   `packages/gateway/src/chat/**`; adapt—not duplicate—existing
@@ -165,21 +166,21 @@ and one coherent responsibility.
 
 ### MAT-347 — Canonical execution-root provenance
 
-**Proposed owner:** Yuhan
+**Temporary assignee:** Yuhan
 **PR:** retain MAT-347's focused conventional title
-**Depends on:** NEW-A1
-**Blocks:** NEW-B4 and NEW-E2
+**Depends on:** MAT-471
+**Blocks:** MAT-477 and MAT-478
 
 - Preserve the existing exact project/worktree provenance scope.
 - Change only enough to emit the canonical `ChatExecutionRootRef` contract.
 - Do not absorb file-diff, inspector, or worktree-management UI.
 
-### NEW-B4 — Canonical Turn/Run orchestration and first adapters
+### MAT-477 — Canonical Turn/Run orchestration and first adapters
 
-**Proposed owner:** Yuhan
+**Temporary assignee:** Yuhan
 **PR:** `feat(gateway): orchestrate canonical Chat runs`
-**Depends on:** NEW-B1, NEW-B2, and MAT-347
-**Blocks:** NEW-B5, NEW-E2, and NEW-F1
+**Depends on:** MAT-472, MAT-473, and MAT-347
+**Blocks:** MAT-479, MAT-478, and MAT-480
 
 - Primary files: canonical Chat routes/orchestrator under
   `packages/gateway/src/chat/**` plus adapters around current Hermes and coding
@@ -193,12 +194,12 @@ and one coherent responsibility.
 - Gate: real accepted turns per enabled adapter, retry/resume, cancellation,
   root change, late events, restart reconciliation, and cross-shell replay.
 
-### NEW-B5 — Legacy import and canonical cutover
+### MAT-479 — Legacy import and canonical cutover
 
-**Proposed owner:** Yuhan
+**Temporary assignee:** Yuhan
 **PR:** `feat(gateway): migrate legacy conversations to canonical Chat`
-**Depends on:** NEW-B1 and NEW-B4
-**Blocks:** NEW-F2
+**Depends on:** MAT-472 and MAT-477
+**Blocks:** MAT-483
 
 - Import `system/conversations/*.json` and the single existing bounded
   `system/coding-agents/threads.json` authority. Never import renderer memory.
@@ -210,22 +211,22 @@ and one coherent responsibility.
 
 ### MAT-458 — Typed Run activity contract and durable replay
 
-**Proposed owner:** Yuhan
+**Temporary assignee:** Yuhan
 **PR:** use the existing MAT-458 issue and keep it draft until human review
-**Depends on:** MAT-349 and NEW-A1
-**Blocks:** NEW-D1 integration, NEW-E2, and NEW-F2
+**Depends on:** MAT-349 and MAT-471
+**Blocks:** MAT-474 integration, MAT-478, and MAT-483
 
 - Keep Gateway normalization, redaction, ordering, persistence/replay, and
   Desktop projection adapters here.
 - Do not own final timeline spacing/visual polish or exact changed-files truth.
-- Rebase its contract onto NEW-A1 rather than creating a second activity schema.
+- Rebase its contract onto MAT-471 rather than creating a second activity schema.
 
-### NEW-C1 — Shared Chat panel, composer, and controller
+### MAT-476 — Shared Chat panel, composer, and controller
 
-**Proposed owner:** Yuhan
+**Temporary assignee:** Yuhan
 **PR:** `feat(desktop): add shared Chat surface and composer`
-**Depends on:** NEW-A1 and NEW-B2; may use fixtures before NEW-B4
-**Blocks:** NEW-F1
+**Depends on:** MAT-471 and MAT-473; may use fixtures before MAT-477
+**Blocks:** MAT-480
 
 - Primary files: a new shared Chat feature boundary in
   `desktop/src/renderer/src/features/chat/**`; migrate useful behavior from
@@ -238,29 +239,31 @@ and one coherent responsibility.
 - Gate: identical Global/Project fixture rendering, capability controls,
   first-Turn lock UX, keyboard navigation, draft preservation, and runtime reset.
 
-### NEW-D1 — Conversation message and activity presentation
+### MAT-474 — Conversation message and activity presentation
 
-**Proposed owner:** Nima
+**Temporary assignee:** Yuhan
+**Suggested later owner:** Nima
 **PR:** `feat(desktop): polish canonical Chat messages`
-**Depends on:** NEW-A1; final integration also depends on MAT-458
-**Blocks:** NEW-F2
+**Depends on:** MAT-471; final integration also depends on MAT-458
+**Blocks:** MAT-483
 
 - Primary files: `features/chat/elements/**`, a new shared
   `ConversationTimeline`, and focused Desktop tests.
 - Own user/assistant messages, markdown/code, reasoning disclosure, streaming,
   tools, approvals, requested input, errors/retry, timestamps/actions,
   accessibility, and long-content performance.
-- Develop against NEW-A1 fixtures so backend work does not block presentation.
+- Develop against MAT-471 fixtures so backend work does not block presentation.
   Do not import `threads`, `hermes-chat`, or coding workspace stores directly.
 - Gate: every canonical part type, streaming/reload parity fixtures, keyboard/
   screen-reader behavior, virtualization or bounded rendering, and narrow width.
 
-### NEW-E1 — Provider-neutral Chat inspector shell
+### MAT-475 — Provider-neutral Chat inspector shell
 
-**Proposed owner:** Shubham
+**Temporary assignee:** Yuhan
+**Suggested later owner:** Shubham
 **PR:** `refactor(desktop): add shared Chat inspector shell`
-**Depends on:** NEW-A1; may use fixtures
-**Blocks:** NEW-E3 and NEW-F2
+**Depends on:** MAT-471; may use fixtures
+**Blocks:** MAT-481 and MAT-483
 
 - Primary files: refactor `AgentConversationInspector`,
   `AgentWorkspacePanels`, `AgentReviewPanel`, and inspector layout seams into a
@@ -270,12 +273,12 @@ and one coherent responsibility.
   surfaces.
 - Do not calculate exact diffs, read arbitrary paths, or own Chat routing.
 
-### NEW-E2 — Exact per-Turn changes and safe file-read backend
+### MAT-478 — Exact per-Turn changes and safe file-read backend
 
-**Proposed owner:** Yuhan
+**Temporary assignee:** Yuhan
 **PR:** `feat(gateway): persist exact Chat turn changes`
-**Depends on:** MAT-347, MAT-458, and NEW-B4
-**Blocks:** NEW-E3
+**Depends on:** MAT-347, MAT-458, and MAT-477
+**Blocks:** MAT-481
 
 - This is the backend half of MAT-460: capture/store bounded change truth,
   authorization, safe Git/file reads, concurrency labels, and canonical
@@ -285,12 +288,13 @@ and one coherent responsibility.
 - Gate: owner/root authorization, before/after isolation, reload, binary/rename/
   partial/concurrent cases, traversal/symlink denial, timeout, and output caps.
 
-### NEW-E3 — Changes/files inspector integration
+### MAT-481 — Changes/files inspector integration
 
-**Proposed owner:** Shubham
+**Temporary assignee:** Yuhan
+**Suggested later owner:** Shubham
 **PR:** `feat(desktop): integrate Chat changes and file preview`
-**Depends on:** NEW-E1 and NEW-E2
-**Blocks:** NEW-F2
+**Depends on:** MAT-475 and MAT-478
+**Blocks:** MAT-483
 
 - This is the UI half of MAT-460: changed-files card/tree, structured diff,
   current/checkpoint labels, file preview, stale response identity, and loading/
@@ -299,12 +303,12 @@ and one coherent responsibility.
 - Gate: all backend truth variants, reload parity, stale response cancellation,
   responsive inspector, and independent Git/hash comparison in final QA.
 
-### NEW-F1 — Merge Global and Project Chat domains
+### MAT-480 — Merge Global and Project Chat domains
 
-**Proposed owner:** Yuhan
+**Temporary assignee:** Yuhan
 **PR:** `feat(desktop): unify Global and Project Chat`
-**Depends on:** NEW-B1, NEW-B4, and NEW-C1
-**Blocks:** NEW-F2
+**Depends on:** MAT-472, MAT-477, and MAT-476
+**Blocks:** MAT-483
 
 - Route Global and Project entry points into the same controller/surface and
   canonical Chat API.
@@ -315,11 +319,11 @@ and one coherent responsibility.
 - Gate: create root/project Chat, move both directions, reload/reconnect,
   conflict and stale Project recovery, same layout/actions in both routes.
 
-### NEW-F2 — Full composition, legacy-rail removal, and real QA
+### MAT-483 — Full composition, legacy-rail removal, and real QA
 
-**Proposed owner:** Yuhan for integration; Nima and Shubham verify their surfaces
+**Temporary assignee:** Yuhan; Nima and Shubham verify their accepted surfaces
 **PR:** `refactor(desktop): cut over to canonical Chat experience`
-**Depends on:** NEW-B5, MAT-458, NEW-D1, NEW-E3, and NEW-F1
+**Depends on:** MAT-479, MAT-458, MAT-474, MAT-481, and MAT-480
 **Blocks:** MAT-364 completion and public docs
 
 - Compose the accepted panel, timeline, and inspector; switch Desktop/browser
@@ -332,9 +336,9 @@ and one coherent responsibility.
 
 ### MAT-364 — Beta acceptance and hardening
 
-**Proposed owner:** Nima for product acceptance coordination; Yuhan fixes backend/
+**Current owner:** Nima for product acceptance coordination; Yuhan fixes backend/
 panel defects; Shubham fixes inspector defects
-**Depends on:** NEW-F2 and resolution of MAT-468/#1299
+**Depends on:** MAT-483 and resolution of MAT-468/#1299
 **PRs:** one narrow bug PR per discovered issue; do not reopen the integration PR
 
 - Run the launch matrix on a real authenticated disposable customer VPS and
@@ -342,9 +346,9 @@ panel defects; Shubham fixes inspector defects
 - File each unrelated bug separately with owner, evidence, expected behavior,
   and dependency. Human Review remains the user's gate.
 
-### NEW-G1 — Public Chat and Project Workspace documentation
+### MAT-482 — Public Chat and Project Workspace documentation
 
-**Proposed owner:** Yuhan
+**Temporary assignee:** Yuhan
 **Repository/PR:** `FinnaAI/matrix-os-site`,
 `docs(chat): document canonical Chat and Project workspaces`
 **Depends on:** MAT-364 acceptance
@@ -361,37 +365,37 @@ panel defects; Shubham fixes inspector defects
 ## Dependency graph
 
 ```text
-NEW-A0 architecture
-└── NEW-A1 contracts + fixtures
-    ├── NEW-B1 repository/outbox ───────────────┐
-    ├── NEW-B2 Driver/Instance catalog ───────┐ │
-    ├── MAT-347 execution-root provenance ────┼─┼── NEW-B4 orchestration
-    ├── MAT-458 typed activity (after MAT-349)│ │       ├── NEW-B5 migration
-    ├── NEW-C1 shared panel/composer ─────────┘ │       └── NEW-E2 change truth
-    ├── NEW-D1 messages UI ─────────────────────┼──────────────┐
-    └── NEW-E1 inspector shell ─────────────────┘              │
-                                        NEW-E2 + NEW-E1 ── NEW-E3 inspector UI
+MAT-470 architecture
+└── MAT-471 contracts + fixtures
+    ├── MAT-472 repository/outbox ───────────────┐
+    ├── MAT-473 Driver/Instance catalog ───────┐ │
+    ├── MAT-347 execution-root provenance ────┼─┼── MAT-477 orchestration
+    ├── MAT-458 typed activity (after MAT-349)│ │       ├── MAT-479 migration
+    ├── MAT-476 shared panel/composer ─────────┘ │       └── MAT-478 change truth
+    ├── MAT-474 messages UI ─────────────────────┼──────────────┐
+    └── MAT-475 inspector shell ─────────────────┘              │
+                                        MAT-478 + MAT-475 ── MAT-481 inspector UI
 
-NEW-B1 + NEW-B4 + NEW-C1 ── NEW-F1 Global/Project merge
-NEW-B5 + MAT-458 + NEW-D1 + NEW-E3 + NEW-F1 ── NEW-F2 cutover
-NEW-F2 + MAT-468 disposition ── MAT-364 real beta acceptance ── NEW-G1 docs
+MAT-472 + MAT-477 + MAT-476 ── MAT-480 Global/Project merge
+MAT-479 + MAT-458 + MAT-474 + MAT-481 + MAT-480 ── MAT-483 cutover
+MAT-483 + MAT-468 disposition ── MAT-364 real beta acceptance ── MAT-482 docs
 ```
 
 ## Parallel work lanes
 
-After NEW-A1 merges, four lanes can proceed without sharing implementation
+After MAT-471 merges, four lanes can proceed without sharing implementation
 files:
 
-| Lane | Owner | Work | Integration input |
+| Lane | Suggested later owner | Work | Integration input |
 |---|---|---|---|
-| Canonical backend + Chat panel | Yuhan | NEW-B1/B2, MAT-347, NEW-B4/B5, NEW-C1, NEW-E2, NEW-F1/F2 | Owns schemas after NEW-A1, Gateway, controller, and final composition |
-| Messages | Nima | NEW-D1 | Consumes frozen schemas/fixtures; hands over pure timeline components |
-| Inspector | Shubham | NEW-E1 then NEW-E3 | Consumes fixtures, then NEW-E2 API; hands over pure inspector components |
+| Canonical backend + Chat panel | Yuhan | MAT-472/MAT-473, MAT-347, MAT-477/MAT-479, MAT-476, MAT-478, MAT-480/MAT-483 | Owns schemas after MAT-471, Gateway, controller, and final composition |
+| Messages | Nima | MAT-474 | Consumes frozen schemas/fixtures; hands over pure timeline components |
+| Inspector | Shubham | MAT-475 then MAT-481 | Consumes fixtures, then MAT-478 API; hands over pure inspector components |
 | Activity contract | Yuhan, kept separate from UI | MAT-458 | Supplies normalized/reload-stable activity to messages and inspector |
 
 Efficiency rules:
 
-- Freeze NEW-A1 before parallel UI coding. Contract changes require one short
+- Freeze MAT-471 before parallel UI coding. Contract changes require one short
   review from all three owners before merge.
 - Each lane owns disjoint files. Cross-lane changes go through the owning PR,
   never by editing another person's branch.
@@ -399,7 +403,7 @@ Efficiency rules:
   or compensate with local persistence.
 - Keep PRs stacked only on reviewed exact heads. Record the base SHA in the
   issue and PR description.
-- Integrate once at NEW-F2. Do not continuously merge three active feature
+- Integrate once at MAT-483. Do not continuously merge three active feature
   branches into one shared branch.
 - Test at public seams: contract fixture -> Gateway projection -> Desktop
   controller -> pure surface. Add real authenticated evidence at integration,
@@ -411,33 +415,30 @@ Efficiency rules:
 
 Recommended answer: complete human review of #1299 as a short-term compatibility
 slice because it already fixes the truthful “selected Provider executes the
-turn” bug. If accepted, merge it before NEW-B2 and preserve its tests, then wrap
+turn” bug. If accepted, merge it before MAT-473 and preserve its tests, then wrap
 its `hermes/codex/pi` field behind the new Driver/Instance compatibility mapper.
 
-Do not make #1299 a dependency of NEW-A1/B1/B2. It lacks owner-PostgreSQL
+Do not make #1299 a dependency of MAT-471/MAT-472/MAT-473. It lacks owner-PostgreSQL
 persistence and the full Instance contract. If human review rejects it, reuse
-only its validated routing/readiness patterns in NEW-B2/B4 and close it without
-forcing an unnecessary merge. Either path converges at NEW-F2.
+only its validated routing/readiness patterns in MAT-473/MAT-477 and close it without
+forcing an unnecessary merge. Either path converges at MAT-483.
 
-## Linear cleanup after team approval
+## Remaining Linear cleanup after team review
 
-Perform these mutations only after the team approves this plan:
+The new issues, temporary Yuhan assignments, parents, and implementation
+blockers are in place. Keep these follow-ups separate from task creation:
 
-1. Create real issues for NEW-A0/A1/B1/B2/B4/B5/C1/D1/E1/E2/E3/F1/F2/G1 and
-   replace planning IDs.
-2. Make MAT-321 an umbrella and attach B1/B2/B4/B5 as children; remove its stale
-   blocker relation from completed MAT-322.
-3. Keep MAT-344 as the experience umbrella; attach C1/D1/E1/E3/F1/F2 as the
-   relevant children without duplicating backend scope.
-4. Reconcile MAT-459 from `PR In Review` to the state matching merged PR #1294.
-5. Keep MAT-458 blocked by MAT-349 only until the accepted #1250 head is recorded,
-   then link it to NEW-A1 instead of reimplementing contracts.
-6. Convert MAT-460 into an umbrella or replace its implementation scope with
-   E2 and E3 children while preserving MAT-347/MAT-458 dependencies.
-7. Link MAT-364 only to NEW-F2 and the MAT-468 disposition; use separate bug
-   issues for acceptance findings.
-8. Create NEW-G1 in the public-site delivery project and block it on accepted
-   runtime behavior rather than on an estimated implementation date.
+1. When Nima and Shubham choose work, change only the selected task assignees;
+   keep the contract and blocker graph unchanged.
+2. Remove MAT-321's stale blocker relation from completed MAT-322 after the team
+   confirms the new split.
+3. Reconcile MAT-459 from `PR In Review` to the state matching merged PR #1294.
+4. Record the accepted #1250 head for MAT-458 before implementation and consume
+   MAT-471 rather than introducing another activity contract.
+5. Treat MAT-460 as the umbrella for MAT-478 and MAT-481 while preserving
+   MAT-347/MAT-458 dependencies.
+6. Use separate narrow issues for MAT-364 acceptance findings; do not expand
+   MAT-483 or reopen its integration PR for unrelated bugs.
 
 ## Final acceptance checklist
 

--- a/specs/113-provider-neutral-chat-architecture/delivery-plan.md
+++ b/specs/113-provider-neutral-chat-architecture/delivery-plan.md
@@ -1,0 +1,462 @@
+# Desktop Chat and Project Workspace Delivery Plan
+
+> **For agentic workers:** This is the cross-PR dependency plan, not a substitute
+> for an executable issue plan. Before changing product code, write the focused
+> issue plan and use `superpowers:test-driven-development` for every public seam.
+
+**Goal:** Ship one canonical Chat system whose Global and Project entry points
+share the same panel, messages, inspector, Gateway, persistence, and Provider
+contracts.
+
+**Architecture:** `Chat -> Turn -> Run attempt` is the durable execution tree.
+A Run uses exactly one `Provider Driver -> Provider Instance -> Model Selection`.
+The first accepted Turn locks the Chat to that Instance. Projects bind owner
+resources without duplicating them, and an idle Chat can move between Projects
+without changing identity.
+
+**Tech stack:** TypeScript, Zod 4, Hono, Kysely/PostgreSQL, React 19, Zustand,
+Vitest, Electron, and owner-VPS runtime validation.
+
+**Canonical spec:** `specs/113-provider-neutral-chat-architecture/spec.md`
+
+**Snapshot:** Reconciled against Linear and GitHub on 2026-08-24 and
+`origin/main@6a86e2e1e`. Recheck status and exact heads before starting any
+implementation PR.
+
+## Locked product decisions
+
+1. `Provider Driver` means Hermes, OpenClaw, Codex, Claude Code, OpenCode, or
+   Pi. It is an execution runtime, not an LLM vendor.
+2. `Provider Instance` means one concrete install/account/endpoint/configuration.
+   The contract supports multiple Instances even if V1 exposes one per Driver.
+3. Driver, Instance, model, and provider-specific options are separate. Effort,
+   service tier, interaction mode, permission mode, skills, commands, and
+   worktrees are capability-derived options rather than universal fields.
+4. A draft Chat may change Driver/Instance. Its first accepted Turn atomically
+   locks the exact Instance. A later Driver/Instance change requires Fork or New
+   Chat. Compatible model/options may change inside the bound Instance.
+5. Hermes/OpenClaw and coding Drivers appear in one selector, grouped by
+   capability class; unavailable Drivers stay visible with truthful setup state.
+6. Global Chat and Project Chat are routes into one `ChatSurface`,
+   `ConversationTimeline`, `ChatComposer`, and `ChatInspector`.
+7. `/` selects a typed skill/command invocation. `@` selects a typed resource
+   reference; labels are never parsed back into paths or identities.
+8. Chats are owner-owned and optionally Project-bound. Idle Chats may be added
+   to, removed from, or moved between Projects without changing `chatId`.
+9. Terminal Sessions belong to the computer/VPS terminal service and are
+   workspace-scoped. Projects list them; Chats/Runs reference them.
+   `terminalSessionId` is not a renderer `terminalTabId`. Zellij mapping is a
+   later design.
+10. `primaryWorkspaceRoot` is derived and validated for each Run from the
+    Project/worktree reference. It is not stored as Chat identity and never
+    comes from a renderer path.
+11. Owner-local PostgreSQL/Kysely and Gateway are canonical. No new renderer
+    persistence, alternate database, or second provider-specific Chat API.
+
+## Current Matrix VPS Provider reality
+
+“Provisioned” and “ready” are deliberately different. Models are supplied by
+the configured account and runtime; they are not installed as Matrix assets.
+
+| Driver | Matrix VPS provisioning on current `main` | Executable Chat path today | Final-framework treatment |
+|---|---|---|---|
+| Hermes | Default-selected agent tool pack; host install/runtime controls ship | Existing Gateway conversation rail | `system_agent` Driver and first canonical import adapter |
+| OpenClaw | Host installer/runtime controls ship; not a default-ready runtime | No canonical Chat execution adapter | Visible `system_agent`; setup/unavailable until its adapter exists |
+| Codex | Optional coding-agents pack; async install and auth required | Customer host registers the Codex workspace adapter | First coding Driver in canonical orchestration |
+| Claude Code | Optional coding-agents pack; async install and auth required | Customer host registers the Claude workspace adapter | Same Driver/Instance contract as Codex |
+| Pi | Optional coding-agents pack; async install and auth required | Direct structured adapter exists, but customer default provider list omits it | Add after the canonical contract; no special Chat type |
+| OpenCode | Optional coding-agents pack; async install and auth required | No reliable canonical structured assistant/resume path | Visible but non-runnable until an adapter passes the same contract |
+
+## Existing Linear and PR truth
+
+These are inputs, not work to repeat.
+
+| Linear | Current status | GitHub PR | Dependency role / required action |
+|---|---|---|---|
+| MAT-319 provider-neutral architecture | Done | [#1218](https://github.com/HamedMP/matrix-os/pull/1218) merged | Amend through this design PR; do not reopen the old implementation assumptions |
+| MAT-299 Hermes conversation lifecycle | Done | [#1213](https://github.com/HamedMP/matrix-os/pull/1213) merged | Legacy Hermes source and compatibility seam for canonical import |
+| MAT-318 persistent Project context | Done | [#1252](https://github.com/HamedMP/matrix-os/pull/1252) merged | Reuse stable Project ID and guarded context behavior; generalize to canonical Chat move |
+| MAT-321 canonical Chat persistence/adapters | Todo | No PR | Replace as an umbrella; split into `NEW-B1`, `NEW-B2`, `NEW-B4`, and `NEW-B5` below |
+| MAT-322 Chat inbox/composer/resources | Done | [#1231](https://github.com/HamedMP/matrix-os/pull/1231) merged | Reuse visual/components; remove its stale “blocked by MAT-321” relation during Linear cleanup |
+| MAT-344 T3 Project Chat | In Progress | Umbrella | Keep as UI umbrella; children supply accepted components to final integration |
+| MAT-345 Project Chat navigation/search | Done | [#1248](https://github.com/HamedMP/matrix-os/pull/1248) merged | Reuse list/search behavior against canonical summaries |
+| MAT-346 contextual inspector | Done | [#1253](https://github.com/HamedMP/matrix-os/pull/1253) merged | Starting point for the side-panel refactor, not the final data contract |
+| MAT-347 execution-root provenance | Todo | No PR | Critical backend dependency for canonical Run execution and exact turn changes |
+| MAT-348 structured output/composer | Done | [#1251](https://github.com/HamedMP/matrix-os/pull/1251) merged | Reuse normalized activity UI and composer interactions |
+| MAT-349 stream ordering | Done | [#1250](https://github.com/HamedMP/matrix-os/pull/1250) merged | Accepted ordering seam; prerequisite of MAT-458 |
+| MAT-364 Desktop Chat beta-ready | In Progress | Umbrella | Final authenticated acceptance/hardening gate, not a feature bucket |
+| MAT-453 Projects workflows | Done | [#1282](https://github.com/HamedMP/matrix-os/pull/1282) merged | Reuse Project identity, creation, and re-entry behavior |
+| MAT-455 Chat/Files home lists | Done | [#1292](https://github.com/HamedMP/matrix-os/pull/1292) merged | Reuse list presentation and navigation patterns |
+| MAT-458 typed activity timeline | In Progress | No attached PR | Keep Gateway normalization/persistence under Yuhan; split presentation polish into `NEW-D1` |
+| MAT-459 provider readiness | PR In Review in Linear | [#1294](https://github.com/HamedMP/matrix-os/pull/1294) merged | **Status drift:** reconcile Linear to merged truth before new dependency links |
+| MAT-460 turn changes/file preview | In Progress, blocked | No PR | Split backend truth (`NEW-E2`) from inspector UI (`NEW-E3`); preserve MAT-347 and MAT-458 blockers |
+| MAT-468 real Global Chat provider switching | Human Review | [#1299](https://github.com/HamedMP/matrix-os/pull/1299) open draft | Compatibility slice only; see disposition below |
+| MAT-469 readiness refresh | Done | [#1300](https://github.com/HamedMP/matrix-os/pull/1300) merged | Reuse bounded refresh and draft-preservation behavior |
+| Supporting global/project presentation | Merged | [#1293](https://github.com/HamedMP/matrix-os/pull/1293) merged | Reuse presentation composition; it is not canonical domain/persistence unification |
+
+## Proposed Linear and PR stack
+
+`NEW-*` are planning identifiers only. Create real Linear issues after team
+review, then replace these identifiers in this document. Every PR has one owner
+and one coherent responsibility.
+
+### NEW-A0 — Final architecture amendment
+
+**Proposed owner:** Yuhan
+**PR:** `docs(chat): finalize canonical Chat and workspace architecture`
+**Depends on:** MAT-319/#1218 and the decisions in this document
+**Blocks:** every new implementation issue
+
+- Own only this spec and dependency plan.
+- Record Driver/Instance/model semantics, first-Turn lock, Project/resource
+  hierarchy, shared UI boundaries, migration, and PR graph.
+- Gate: team architecture review. No runtime claim or product implementation.
+
+### NEW-A1 — Shared canonical Chat contracts and fixtures
+
+**Proposed owner:** Yuhan
+**PR:** `feat(contracts): add canonical Chat and Provider contracts`
+**Depends on:** NEW-A0
+**Blocks:** all backend/UI lanes
+
+- Primary files: `packages/contracts/src/**`, focused contract tests, and shared
+  fixture factories under `tests/**/fixtures`.
+- Define strict Zod schemas for Chat/Turn/Run, Driver/Instance/model/options,
+  normalized messages/activity, Provider readiness, `/` invocations, `@`
+  resources, inspector projections, and safe errors.
+- Include a temporary compatibility mapper for current Hermes conversations and
+  coding-agent thread projections. Do not add storage or UI.
+- Gate: schema bounds, redaction, round-trip, and fixture compatibility tests.
+
+### NEW-B1 — Owner-local Chat repository and transactional outbox
+
+**Proposed owner:** Yuhan
+**PR:** `feat(gateway): add canonical Chat repository`
+**Depends on:** NEW-A1
+**Blocks:** NEW-B4, NEW-B5, NEW-F1
+
+- Primary files: new `packages/gateway/src/chat/**`, shared owner-database
+  migrations, Gateway shutdown wiring, and `tests/gateway/chat-*.test.ts`.
+- Implement Kysely tables/repository, owner isolation, revisions, messages,
+  Turns/Runs, one-active-Run constraint, idempotency, project mutation,
+  outbox/replay, export/delete, and bounded cleanup.
+- Reuse the Gateway-owned Kysely instance; no new pool, SQLite, ORM, or JSON
+  authority.
+- Gate: row-lock races, atomic outbox, delete/finalize races, owner isolation,
+  and shutdown ownership tests.
+
+### NEW-B2 — Provider Driver/Instance catalog and Chat binding
+
+**Proposed owner:** Yuhan
+**PR:** `feat(gateway): add Provider Instance catalog and Chat binding`
+**Depends on:** NEW-A1
+**Blocks:** NEW-B4 and NEW-C1
+
+- Primary files: new canonical Provider registry in
+  `packages/gateway/src/chat/**`; adapt—not duplicate—existing
+  `coding-agents/provider-registry.ts`, workspace provider config, and Hermes
+  readiness seams.
+- Project Drivers and Instances, model/option descriptors, capability classes,
+  setup state, and stable Instance IDs through `GET /api/chat-providers`.
+- Enforce draft freedom, atomic first-Turn Instance lock, compatible same-Instance
+  model/options, and `provider_instance_locked` for later changes.
+- Gate: duplicate IDs, readiness failure, capability mismatch, first-Turn race,
+  same-Instance model change, and cross-Instance rejection tests.
+
+### MAT-347 — Canonical execution-root provenance
+
+**Proposed owner:** Yuhan
+**PR:** retain MAT-347's focused conventional title
+**Depends on:** NEW-A1
+**Blocks:** NEW-B4 and NEW-E2
+
+- Preserve the existing exact project/worktree provenance scope.
+- Change only enough to emit the canonical `ChatExecutionRootRef` contract.
+- Do not absorb file-diff, inspector, or worktree-management UI.
+
+### NEW-B4 — Canonical Turn/Run orchestration and first adapters
+
+**Proposed owner:** Yuhan
+**PR:** `feat(gateway): orchestrate canonical Chat runs`
+**Depends on:** NEW-B1, NEW-B2, and MAT-347
+**Blocks:** NEW-B5, NEW-E2, and NEW-F1
+
+- Primary files: canonical Chat routes/orchestrator under
+  `packages/gateway/src/chat/**` plus adapters around current Hermes and coding
+  provider seams.
+- Implement `/api/chats`, transactional Turn admission, Run attempts,
+  cancellation, same-Instance resume, normalized events, root resolution, and
+  generic errors. Start with Hermes, Codex, and Claude Code; add Pi only if it
+  passes the same adapter contract.
+- Provider calls occur after commit and cannot hold DB locks. No OpenCode or
+  OpenClaw special-case path.
+- Gate: real accepted turns per enabled adapter, retry/resume, cancellation,
+  root change, late events, restart reconciliation, and cross-shell replay.
+
+### NEW-B5 — Legacy import and canonical cutover
+
+**Proposed owner:** Yuhan
+**PR:** `feat(gateway): migrate legacy conversations to canonical Chat`
+**Depends on:** NEW-B1 and NEW-B4
+**Blocks:** NEW-F2
+
+- Import `system/conversations/*.json` and the single existing bounded
+  `system/coding-agents/threads.json` authority. Never import renderer memory.
+- Implement idempotent hashes, quarantine, maintenance barrier, explicit
+  cutover marker, 90-day alias expiry, rollback guard, and no dual write.
+- Gate: repeated/crashed import, changed source, invalid/symlink source,
+  transcript parity, adapter-state isolation, exact-expiry clock, and old-writer
+  refusal.
+
+### MAT-458 — Typed Run activity contract and durable replay
+
+**Proposed owner:** Yuhan
+**PR:** use the existing MAT-458 issue and keep it draft until human review
+**Depends on:** MAT-349 and NEW-A1
+**Blocks:** NEW-D1 integration, NEW-E2, and NEW-F2
+
+- Keep Gateway normalization, redaction, ordering, persistence/replay, and
+  Desktop projection adapters here.
+- Do not own final timeline spacing/visual polish or exact changed-files truth.
+- Rebase its contract onto NEW-A1 rather than creating a second activity schema.
+
+### NEW-C1 — Shared Chat panel, composer, and controller
+
+**Proposed owner:** Yuhan
+**PR:** `feat(desktop): add shared Chat surface and composer`
+**Depends on:** NEW-A1 and NEW-B2; may use fixtures before NEW-B4
+**Blocks:** NEW-F1
+
+- Primary files: a new shared Chat feature boundary in
+  `desktop/src/renderer/src/features/chat/**`; migrate useful behavior from
+  `ChatTab`, `ProjectChatsView`, `AgentConversationView`, and composer pickers.
+- Own active-Chat controller, empty/draft states, Provider/Instance/model/options,
+  effort/mode/permissions, `/` skill/command picker, `@` resource picker,
+  attachment/reference chips, stop/send, and responsive composition.
+- Do not own message-part visual polish, inspector internals, or Gateway
+  persistence.
+- Gate: identical Global/Project fixture rendering, capability controls,
+  first-Turn lock UX, keyboard navigation, draft preservation, and runtime reset.
+
+### NEW-D1 — Conversation message and activity presentation
+
+**Proposed owner:** Nima
+**PR:** `feat(desktop): polish canonical Chat messages`
+**Depends on:** NEW-A1; final integration also depends on MAT-458
+**Blocks:** NEW-F2
+
+- Primary files: `features/chat/elements/**`, a new shared
+  `ConversationTimeline`, and focused Desktop tests.
+- Own user/assistant messages, markdown/code, reasoning disclosure, streaming,
+  tools, approvals, requested input, errors/retry, timestamps/actions,
+  accessibility, and long-content performance.
+- Develop against NEW-A1 fixtures so backend work does not block presentation.
+  Do not import `threads`, `hermes-chat`, or coding workspace stores directly.
+- Gate: every canonical part type, streaming/reload parity fixtures, keyboard/
+  screen-reader behavior, virtualization or bounded rendering, and narrow width.
+
+### NEW-E1 — Provider-neutral Chat inspector shell
+
+**Proposed owner:** Shubham
+**PR:** `refactor(desktop): add shared Chat inspector shell`
+**Depends on:** NEW-A1; may use fixtures
+**Blocks:** NEW-E3 and NEW-F2
+
+- Primary files: refactor `AgentConversationInspector`,
+  `AgentWorkspacePanels`, `AgentReviewPanel`, and inspector layout seams into a
+  shared `ChatInspector`.
+- Own panel layout, tabs, resize/collapse, responsive behavior, focus,
+  loading/empty/error states, and fixture-driven context/Run/files/changes
+  surfaces.
+- Do not calculate exact diffs, read arbitrary paths, or own Chat routing.
+
+### NEW-E2 — Exact per-Turn changes and safe file-read backend
+
+**Proposed owner:** Yuhan
+**PR:** `feat(gateway): persist exact Chat turn changes`
+**Depends on:** MAT-347, MAT-458, and NEW-B4
+**Blocks:** NEW-E3
+
+- This is the backend half of MAT-460: capture/store bounded change truth,
+  authorization, safe Git/file reads, concurrency labels, and canonical
+  inspector projections.
+- Preserve MAT-460's distinction between exact turn diff, checkpoint result,
+  and current file. Reuse the single Chat repository/transaction queue.
+- Gate: owner/root authorization, before/after isolation, reload, binary/rename/
+  partial/concurrent cases, traversal/symlink denial, timeout, and output caps.
+
+### NEW-E3 — Changes/files inspector integration
+
+**Proposed owner:** Shubham
+**PR:** `feat(desktop): integrate Chat changes and file preview`
+**Depends on:** NEW-E1 and NEW-E2
+**Blocks:** NEW-F2
+
+- This is the UI half of MAT-460: changed-files card/tree, structured diff,
+  current/checkpoint labels, file preview, stale response identity, and loading/
+  error states inside the shared inspector.
+- Do not add a renderer artifact store or infer authorship from file events.
+- Gate: all backend truth variants, reload parity, stale response cancellation,
+  responsive inspector, and independent Git/hash comparison in final QA.
+
+### NEW-F1 — Merge Global and Project Chat domains
+
+**Proposed owner:** Yuhan
+**PR:** `feat(desktop): unify Global and Project Chat`
+**Depends on:** NEW-B1, NEW-B4, and NEW-C1
+**Blocks:** NEW-F2
+
+- Route Global and Project entry points into the same controller/surface and
+  canonical Chat API.
+- Implement Add to Project, Remove from Project, Move to Project, one Recents/
+  search identity, stable breadcrumbs, and project-scoped resource search.
+- Preserve history and `chatId`; reject moves during active Runs; do not rewrite
+  recorded Run roots.
+- Gate: create root/project Chat, move both directions, reload/reconnect,
+  conflict and stale Project recovery, same layout/actions in both routes.
+
+### NEW-F2 — Full composition, legacy-rail removal, and real QA
+
+**Proposed owner:** Yuhan for integration; Nima and Shubham verify their surfaces
+**PR:** `refactor(desktop): cut over to canonical Chat experience`
+**Depends on:** NEW-B5, MAT-458, NEW-D1, NEW-E3, and NEW-F1
+**Blocks:** MAT-364 completion and public docs
+
+- Compose the accepted panel, timeline, and inspector; switch Desktop/browser
+  Shell/CLI/channel projections to `/api/chats` and outbox replay.
+- Remove renderer-owned identity and obsolete provider-specific rails only after
+  import, parity, and rollback evidence. Do not delete owner legacy files.
+- Gate: focused suites, production builds, exact-head authenticated owner-VPS
+  turns for enabled Providers, Global/Project move, reload/reconnect, restart,
+  terminal/file references, migration parity, export/delete, and screenshots.
+
+### MAT-364 — Beta acceptance and hardening
+
+**Proposed owner:** Nima for product acceptance coordination; Yuhan fixes backend/
+panel defects; Shubham fixes inspector defects
+**Depends on:** NEW-F2 and resolution of MAT-468/#1299
+**PRs:** one narrow bug PR per discovered issue; do not reopen the integration PR
+
+- Run the launch matrix on a real authenticated disposable customer VPS and
+  built Desktop, not fixture-only UI.
+- File each unrelated bug separately with owner, evidence, expected behavior,
+  and dependency. Human Review remains the user's gate.
+
+### NEW-G1 — Public Chat and Project Workspace documentation
+
+**Proposed owner:** Yuhan
+**Repository/PR:** `FinnaAI/matrix-os-site`,
+`docs(chat): document canonical Chat and Project workspaces`
+**Depends on:** MAT-364 acceptance
+**Blocks:** public launch claim
+
+- Document user-visible Provider selection and lock behavior, Fork/New Chat,
+  model/options, `/`, `@`, Project moves, resource ownership, setup/recovery,
+  export/delete, and unavailable-state behavior.
+- Keep the public repository free of customer identifiers, internal paths,
+  credentials, private runbooks, and unshipped implementation details.
+- Gate: documentation build, link check, screenshots from the accepted exact
+  Desktop head, and behavior parity with the shipped runtime.
+
+## Dependency graph
+
+```text
+NEW-A0 architecture
+└── NEW-A1 contracts + fixtures
+    ├── NEW-B1 repository/outbox ───────────────┐
+    ├── NEW-B2 Driver/Instance catalog ───────┐ │
+    ├── MAT-347 execution-root provenance ────┼─┼── NEW-B4 orchestration
+    ├── MAT-458 typed activity (after MAT-349)│ │       ├── NEW-B5 migration
+    ├── NEW-C1 shared panel/composer ─────────┘ │       └── NEW-E2 change truth
+    ├── NEW-D1 messages UI ─────────────────────┼──────────────┐
+    └── NEW-E1 inspector shell ─────────────────┘              │
+                                        NEW-E2 + NEW-E1 ── NEW-E3 inspector UI
+
+NEW-B1 + NEW-B4 + NEW-C1 ── NEW-F1 Global/Project merge
+NEW-B5 + MAT-458 + NEW-D1 + NEW-E3 + NEW-F1 ── NEW-F2 cutover
+NEW-F2 + MAT-468 disposition ── MAT-364 real beta acceptance ── NEW-G1 docs
+```
+
+## Parallel work lanes
+
+After NEW-A1 merges, four lanes can proceed without sharing implementation
+files:
+
+| Lane | Owner | Work | Integration input |
+|---|---|---|---|
+| Canonical backend + Chat panel | Yuhan | NEW-B1/B2, MAT-347, NEW-B4/B5, NEW-C1, NEW-E2, NEW-F1/F2 | Owns schemas after NEW-A1, Gateway, controller, and final composition |
+| Messages | Nima | NEW-D1 | Consumes frozen schemas/fixtures; hands over pure timeline components |
+| Inspector | Shubham | NEW-E1 then NEW-E3 | Consumes fixtures, then NEW-E2 API; hands over pure inspector components |
+| Activity contract | Yuhan, kept separate from UI | MAT-458 | Supplies normalized/reload-stable activity to messages and inspector |
+
+Efficiency rules:
+
+- Freeze NEW-A1 before parallel UI coding. Contract changes require one short
+  review from all three owners before merge.
+- Each lane owns disjoint files. Cross-lane changes go through the owning PR,
+  never by editing another person's branch.
+- UI lanes use shared fixtures first. They must not wait for the full database
+  or compensate with local persistence.
+- Keep PRs stacked only on reviewed exact heads. Record the base SHA in the
+  issue and PR description.
+- Integrate once at NEW-F2. Do not continuously merge three active feature
+  branches into one shared branch.
+- Test at public seams: contract fixture -> Gateway projection -> Desktop
+  controller -> pure surface. Add real authenticated evidence at integration,
+  not only at the end of every visual commit.
+- Keep each Linear issue in `In Progress` and PR draft until the assigned human
+  review boundary. The user controls Human Review completion.
+
+## MAT-468 / PR #1299 disposition
+
+Recommended answer: complete human review of #1299 as a short-term compatibility
+slice because it already fixes the truthful “selected Provider executes the
+turn” bug. If accepted, merge it before NEW-B2 and preserve its tests, then wrap
+its `hermes/codex/pi` field behind the new Driver/Instance compatibility mapper.
+
+Do not make #1299 a dependency of NEW-A1/B1/B2. It lacks owner-PostgreSQL
+persistence and the full Instance contract. If human review rejects it, reuse
+only its validated routing/readiness patterns in NEW-B2/B4 and close it without
+forcing an unnecessary merge. Either path converges at NEW-F2.
+
+## Linear cleanup after team approval
+
+Perform these mutations only after the team approves this plan:
+
+1. Create real issues for NEW-A0/A1/B1/B2/B4/B5/C1/D1/E1/E2/E3/F1/F2/G1 and
+   replace planning IDs.
+2. Make MAT-321 an umbrella and attach B1/B2/B4/B5 as children; remove its stale
+   blocker relation from completed MAT-322.
+3. Keep MAT-344 as the experience umbrella; attach C1/D1/E1/E3/F1/F2 as the
+   relevant children without duplicating backend scope.
+4. Reconcile MAT-459 from `PR In Review` to the state matching merged PR #1294.
+5. Keep MAT-458 blocked by MAT-349 only until the accepted #1250 head is recorded,
+   then link it to NEW-A1 instead of reimplementing contracts.
+6. Convert MAT-460 into an umbrella or replace its implementation scope with
+   E2 and E3 children while preserving MAT-347/MAT-458 dependencies.
+7. Link MAT-364 only to NEW-F2 and the MAT-468 disposition; use separate bug
+   issues for acceptance findings.
+8. Create NEW-G1 in the public-site delivery project and block it on accepted
+   runtime behavior rather than on an estimated implementation date.
+
+## Final acceptance checklist
+
+- [ ] One Chat identity and API power Global and Project entry points.
+- [ ] The first accepted Turn locks the exact Provider Instance; later changes
+  offer Fork/New Chat instead of silently switching execution state.
+- [ ] Model/options/mode/effort/permissions render only from current capabilities.
+- [ ] `/` skills/commands and `@` resources are typed and owner-authorized.
+- [ ] An idle Chat moves between Projects without history or identity loss.
+- [ ] Files, Apps, Terminal Sessions, and Tasks retain their canonical owners;
+  Chat stores safe references only.
+- [ ] Timeline and inspector render the same live, reload, and reconnect truth.
+- [ ] Owner-local PostgreSQL, migration, outbox, delete/export, and shutdown
+  invariants pass focused tests.
+- [ ] Enabled Providers complete real authenticated owner-VPS Turns; unavailable
+  Providers fail closed with safe setup actions.
+- [ ] Built Desktop evidence covers wide/narrow layouts, keyboard/accessibility,
+  Global/Project parity, and known-bug regressions.
+- [ ] The separate `FinnaAI/matrix-os-site` documentation PR matches the
+  accepted runtime and passes its own build/link checks.
+- [ ] Linear/PR states, exact heads, checks, and human-review ownership are read
+  back before any review, merge, or launch claim.

--- a/specs/113-provider-neutral-chat-architecture/spec.md
+++ b/specs/113-provider-neutral-chat-architecture/spec.md
@@ -153,6 +153,9 @@ Instance descriptor. It never infers compatibility from names.
    strictly validated and bounded before persistence or renderer projection.
 10. Raw provider, filesystem, database, credential, or path errors never reach
     clients. Detailed diagnostics stay in owner-controlled logs.
+11. A verified request principal identifies the caller, not the storage owner.
+    Organization scope requires an authoritative membership and runtime
+    resolution; it never falls back to the caller's personal scope.
 
 ## Public contracts
 
@@ -219,6 +222,21 @@ type ChatExecutionRootRef =
   | { kind: "project"; projectId: string }
   | { kind: "worktree"; projectId: string; worktreeId: string };
 ```
+
+For personal scope, `ownerId` is the verified principal's user ID. For
+organization scope, `ownerId` is the stable organization ID, and Gateway must
+first use an authoritative platform-owned resolver to verify the caller's
+active membership and role, resolve that organization to exactly one owner
+database/runtime, and bind the Project and resource namespace to the same
+organization. The resolved owner context, rather than the caller identity, is
+then used for every Chat, Project, file, app, task, and Terminal lookup.
+
+The client cannot request or override this mapping. Missing membership fails
+with a generic authorization error; a missing, malformed, or ambiguous owner
+runtime mapping fails as service misconfiguration. Neither case may retry in
+the caller's personal scope. Until this resolver and its fail-closed contract
+tests exist, organization-owned Chats remain unavailable and the cutover is
+personal-scope only.
 
 The client never sends `OwnerScope`, a filesystem path, provider resume state,
 provider credentials, repository URL, or runtime identity. Gateway derives
@@ -436,7 +454,8 @@ Before opening the transaction, Gateway resolves any execution-root reference
 through ProjectManager/WorktreeManager and records a root fingerprint without
 holding a database lock across filesystem I/O. One transaction then:
 
-1. derive owner from the verified principal and lock the Chat row `FOR UPDATE`;
+1. resolve the authorized owner context from the verified principal and lock
+   the Chat row `FOR UPDATE` in that owner's database;
 2. validate membership, lifecycle, base revision, the same project/root
    reference, and no active Run;
 3. resolve the selected Provider Instance, model, options, and canonical history

--- a/specs/113-provider-neutral-chat-architecture/spec.md
+++ b/specs/113-provider-neutral-chat-architecture/spec.md
@@ -1,26 +1,40 @@
-# Provider-Neutral Chat Architecture and Owner-Owned Persistence
+# Canonical Chat, Provider, and Project Workspace Architecture
 
 **Linear issue:** MAT-319
 **Created:** 2026-08-13
-**Status:** Proposed for architecture review
-**Scope:** Canonical contracts, persistence, migration, and implementation sequencing
-**Related delivery:** MAT-299 and MAT-318 remain independent
+**Status:** Amended for final architecture review on 2026-08-24
+**Scope:** Canonical contracts, persistence, provider execution, shared Desktop surfaces, workspace resources, migration, and implementation sequencing
+**Related delivery:** MAT-299, MAT-318, MAT-321, MAT-344, MAT-364, and MAT-468
 
 ## Purpose
 
 Matrix OS needs one durable user-facing Chat abstraction. A Chat is the task the
 user returns to, shares, searches, exports, or deletes. Hermes, OpenClaw, Codex,
-Pi, OpenCode, and future execution systems are harness adapters that run work
-inside a Chat; they are not Chat identities or Chat types. Models are selected
-through capability-aware model plugins and are not part of Chat identity.
+Claude Code, Pi, OpenCode, and future execution systems are **Provider Drivers**:
+agent runtimes that execute Turns rather than Chat types or model vendors. A
+**Provider Instance** identifies one concrete installation, account, endpoint,
+or configuration of a Driver. A **Model Selection** combines that Instance with
+a model and capability-derived provider-specific options.
+
+A draft Chat may change Provider Driver, Instance, model, and options. The first
+accepted Turn binds the Chat to the exact Provider Instance used by its accepted
+Run. V1 never switches Driver or Instance in place after that boundary. A user
+chooses Fork with another Provider or New Chat instead. Models and options may
+change for later Turns only when the bound Instance advertises compatibility.
 
 The canonical Chat record and all relational Chat state live in the owner's
 PostgreSQL database on the user's Matrix computer/VPS through Kysely. Project
-code and `ProjectConfig` stay in owner-controlled files. Chat links to a project
-only by the immutable `ProjectConfig.id`.
+code and `ProjectConfig` stay in owner-controlled files. Chat links to a Project
+only by the immutable `ProjectConfig.id`; the Chat-to-Project binding itself is
+mutable while the Chat is idle.
 
 This specification records the public seams before implementation. It does not
 authorize a broad migration in this PR.
+
+The Desktop has two entry points, Global Chat and Project Chat, but they render
+the same Chat domain through one Chat surface, one composer, one conversation
+timeline, and one contextual inspector. A Global Chat may be added to, removed
+from, or moved between Projects while idle without changing `chatId`.
 
 ## Non-goals
 
@@ -29,7 +43,8 @@ authorize a broad migration in this PR.
 - Expanding MAT-299's current Hermes lifecycle PR or MAT-318's project-context
   implementation.
 - Platform-owned storage of owner Chat content.
-- Translating provider-native session formats between harnesses.
+- Translating provider-native session formats between Provider Drivers or
+  Instances.
 - Voice, multi-repository project UX, branch switching, or worktree-management
   UI.
 - Files CRUD or any MAT-268 behavior, dependency, or issue relation.
@@ -41,7 +56,7 @@ authorize a broad migration in this PR.
 |---|---|---|---|
 | Gateway kernel conversations | `packages/gateway/src/conversations.ts` writes synchronous `system/conversations/*.json` files | Existing list/get/create/delete/search and kernel session IDs | No owner scope, Kysely repository, transaction, turn/run model, strict persisted schema, or safe cross-shell event contract |
 | Coding-agent threads | `packages/gateway/src/coding-agents/thread-store.ts` writes one bounded `system/coding-agents/threads.json` aggregate | Owner checks, turns, events, idempotent request IDs, shutdown recovery, bounded adapter events | Provider ID is part of thread identity; opaque resume state is embedded in the aggregate; whole-file serialization limits concurrency and migration |
-| Harness/provider boundary | `provider-adapter.ts` and `provider-registry.ts` validate provider output and bound health/cache state | Adapter lifecycle, normalized events, timeouts, generic client errors | Catalog lacks a provider-neutral harness capability contract and independent model plugin registry |
+| Provider boundary | `provider-adapter.ts` and `provider-registry.ts` validate provider output and bounded health/cache state | Adapter lifecycle, normalized events, timeouts, generic client errors | Catalog lacks an explicit Driver/Instance boundary, compound model selection, and capability-driven controls |
 | Desktop Chat | `useHermesChat`, `useThreads`, `useCodingAgentWorkspace`, and `unified-threads.ts` merge one Hermes transcript, renderer-memory kernel runs, and server coding-agent projections | Bounded serializable projections and runtime invalidation patterns | Renderer memory still determines local thread identity/history; one rail hides multiple incompatible durable sources |
 | Browser Shell Chat | `useConversation.ts` lists through Gateway but reads transcript JSON through `/files` and refreshes from filesystem watcher events | Existing persistent conversation discovery and switch-session flow | File-path coupling bypasses a provider-neutral headless Chat contract |
 | Owner PostgreSQL | Gateway creates one shared Kysely connection from the VPS-local `DATABASE_URL`; messaging and canvas inject it | Owner-local database lifecycle, migrations, transactions, shared shutdown | Chat has no typed repository or schema; it must reuse this Kysely owner and must not create or destroy another pool |
@@ -57,15 +72,19 @@ Both are resolved by one database admission boundary described below.
 ### Chat
 
 A Chat is a durable, owner-scoped task. Its immutable identity is `chatId`.
-Neither `harnessId`, `modelId`, provider session ID, shell, channel, project
-slug, nor filesystem path participates in Chat identity.
+Neither Provider Driver name, Provider Instance ID, model ID, provider session
+ID, shell, channel, project slug, nor filesystem path is used to derive that
+identity. The Provider binding becomes an immutable Chat attribute after the
+first accepted Turn.
 
 A Chat contains:
 
 - lifecycle and title;
 - owner scope and optional membership/collaboration state;
-- optional immutable project ID;
-- optional default harness and model preferences;
+- an optional, revisioned Project binding by immutable Project ID;
+- an optional Provider binding while the Chat is still a draft;
+- the exact bound Provider Instance after the first accepted Turn;
+- the latest compatible model/options preference for that Instance;
 - canonical messages and attachment references;
 - turns and one or more run attempts;
 - attention, read, pinned, and shell projection state; and
@@ -79,18 +98,36 @@ Only one Run may be active for a Chat at a time.
 
 ### Run
 
-A Run is one execution attempt by exactly one harness with exactly one resolved
-model selection. The Run records what was actually used, the bounded capability
-snapshot, lifecycle timestamps, and canonical-history boundary. Provider-native
-session/resume state is stored separately behind the owning harness adapter.
+A Run is one execution attempt by exactly one Provider Instance with exactly one
+resolved Model Selection. The Run records the Driver kind, Instance ID, model,
+provider-specific options, interaction mode, permission mode, execution root,
+bounded capability snapshot, lifecycle timestamps, and canonical-history
+boundary. Provider-native session/resume state is stored separately behind the
+owning Driver adapter.
 
-### Harness and model plugins
+### Provider Driver, Provider Instance, and Model Selection
 
-A harness adapter implements execution semantics for Hermes, OpenClaw, Codex,
-Pi, OpenCode, or another runtime. A model plugin describes a selectable model
-and its capabilities/credentials. A harness declares which model capabilities
-it accepts. The orchestration layer resolves the pair; it never infers
-compatibility from names.
+A Provider Driver implements execution semantics for Hermes, OpenClaw, Codex,
+Claude Code, Pi, OpenCode, or another agent runtime. A Provider Instance is one
+installed and configured account or endpoint for that Driver. Multiple
+Instances of the same Driver are allowed by contract even when V1 exposes only
+one. The term Provider in this specification means the agent runtime, not an
+LLM vendor such as OpenAI or Anthropic.
+
+Each Instance advertises a bounded model catalog, readiness, workspace
+requirements, commands, skills, resource support, interaction modes, permission
+modes, and generic option descriptors. A Model Selection is one compound value:
+
+```ts
+interface ChatModelSelection {
+  instanceId: ProviderInstanceId;
+  model: string;
+  options?: readonly ProviderOptionSelection[];
+}
+```
+
+The orchestration layer validates the full selection against the current
+Instance descriptor. It never infers compatibility from names.
 
 ## Non-negotiable invariants
 
@@ -98,18 +135,20 @@ compatibility from names.
    cutover. Platform PostgreSQL never stores owner transcript content.
 2. Gateway/headless contracts are canonical. Shell stores are bounded caches
    and never create a persistence format.
-3. `chatId` survives harness/model changes. Provider session IDs never replace,
-   alias, or determine it.
-4. A Run may resume only through the same `harnessId` and adapter-state schema
-   version that created its resume state.
-5. A harness change starts a new Run from canonical history or creates an
-   explicit fork. Cross-harness resume is forbidden.
+3. The first accepted Turn atomically binds the Chat to one exact
+   `ProviderInstanceId`. Later Turns cannot change Driver or Instance. Provider
+   session IDs never replace, alias, or determine `chatId`.
+4. A Run may resume only through the same Provider Instance and adapter-state
+   schema version that created its resume state.
+5. Cross-Driver or cross-Instance work requires Fork with another Provider or
+   New Chat. Provider-native state is never copied across that boundary.
 6. Project references use immutable `ProjectConfig.id`; slugs, paths, branches,
-   and repository URLs are derived owner-file data.
+   and repository URLs are derived owner-file data. An idle Chat may revise its
+   Project binding without changing `chatId`.
 7. Turn admission, context mutation, archive/delete, and active-run checks lock
    the same Chat row. No check-then-write race is allowed.
 8. Multiple related writes and every outbox event are committed in one Kysely
-   transaction. External harness/model calls occur outside the transaction.
+   transaction. External Provider/model calls occur outside the transaction.
 9. Provider output, capability metadata, model metadata, and adapter state are
    strictly validated and bounded before persistence or renderer projection.
 10. Raw provider, filesystem, database, credential, or path errors never reach
@@ -130,7 +169,8 @@ interface ChatSummary {
   title: string;
   lifecycle: "active" | "archived";
   project?: ChatProjectProjection;
-  defaultSelection?: ChatExecutionSelection;
+  providerBinding?: ChatProviderBinding;
+  currentSelection?: ChatModelSelection;
   activeRun?: ChatRunProjection;
   attention: "none" | "approval_required" | "input_required" | "failed";
   lastMessagePreview: string;
@@ -140,9 +180,31 @@ interface ChatSummary {
   updatedAt: string;
 }
 
-interface ChatExecutionSelection {
-  harnessId: string;
-  modelId?: string;
+type ProviderDriverKind =
+  | "hermes"
+  | "openclaw"
+  | "codex"
+  | "claude_code"
+  | "opencode"
+  | "pi";
+
+type ProviderInstanceId = string;
+
+interface ChatProviderBinding {
+  driverKind: ProviderDriverKind;
+  instanceId: ProviderInstanceId;
+  lockedAtTurnId: string;
+}
+
+interface ProviderOptionSelection {
+  id: string;
+  value: string | boolean;
+}
+
+interface ChatModelSelection {
+  instanceId: ProviderInstanceId;
+  model: string;
+  options?: readonly ProviderOptionSelection[];
 }
 
 interface ChatProjectProjection {
@@ -161,8 +223,11 @@ type ChatExecutionRootRef =
 The client never sends `OwnerScope`, a filesystem path, provider resume state,
 provider credentials, repository URL, or runtime identity. Gateway derives
 owner scope from the verified principal and resolves project/runtime state. A
-client may select an opaque existing `worktreeId` where the harness supports
-it, but only Gateway constructs and validates `ChatExecutionRootRef`.
+client may select an opaque existing `worktreeId` where the Provider Instance
+supports it, but only Gateway constructs and validates
+`ChatExecutionRootRef`. `primaryWorkspaceRoot` is therefore a derived per-Run
+execution value, not a Chat field, Project identity, or renderer-controlled
+path.
 
 ### Canonical messages
 
@@ -178,15 +243,28 @@ but is excluded from future canonical history unless the user explicitly
 promotes or quotes it. Canonical history therefore never silently treats a
 failed provider stream as trusted context.
 
-### Harness capability contract
+### Provider capability contract
 
 ```ts
-interface HarnessDescriptor {
-  id: string;
+type ProviderCapabilityClass = "system_agent" | "coding_agent";
+
+interface ProviderDriverDescriptor {
+  kind: ProviderDriverKind;
   displayName: string;
   adapterVersion: string;
+  capabilityClass: ProviderCapabilityClass;
+}
+
+interface ProviderInstanceDescriptor {
+  id: ProviderInstanceId;
+  driverKind: ProviderDriverKind;
+  displayName: string;
   availability: "available" | "setup_required" | "auth_required" | "unavailable";
   workspaceRequirement: "none" | "project_optional" | "project_required";
+  models: readonly ModelDescriptor[];
+  options: readonly ProviderOptionDescriptor[];
+  skills: readonly ChatSkillDescriptor[];
+  commands: readonly ChatCommandDescriptor[];
   supports: {
     rootChat: boolean;
     resume: boolean;
@@ -196,14 +274,15 @@ interface HarnessDescriptor {
     approvals: boolean;
     userInput: boolean;
     worktrees: "none" | "optional" | "required";
+    interactionModes: readonly string[];
+    permissionModes: readonly string[];
   };
-  acceptedModelCapabilities: readonly ModelCapability[];
-  defaultModelId?: string;
+  defaultSelection?: ChatModelSelection;
 }
 
-interface ChatHarnessAdapter<State> {
-  readonly id: string;
-  describe(input: HarnessDescribeInput): Promise<HarnessDescriptor>;
+interface ChatProviderAdapter<State> {
+  readonly driverKind: ProviderDriverKind;
+  describeInstance(input: ProviderDescribeInput): Promise<ProviderInstanceDescriptor>;
   start(input: StartRunInput): AsyncIterable<NormalizedRunEvent>;
   resume?(input: ResumeRunInput<State>): AsyncIterable<NormalizedRunEvent>;
   cancel?(input: CancelRunInput<State>): Promise<void>;
@@ -213,9 +292,17 @@ interface ChatHarnessAdapter<State> {
 }
 ```
 
-The adapter-state store exposes state only to the registered adapter whose ID
-and schema version match the Run. Adapters must not place access tokens,
-credentials, raw stderr, or unbounded transcripts in state. A provider-native
+The registry groups Instances in one selector by `capabilityClass`, but the
+selector does not imply that Hermes/OpenClaw and coding Drivers have identical
+capabilities. The descriptor determines which controls the composer renders.
+Reasoning effort, service tier, interaction mode, permission mode, worktree,
+skills, commands, and other Driver-specific choices are capability-derived;
+the shell never hardcodes them as universal fields.
+
+The adapter-state store exposes state only to the registered adapter whose
+Driver kind, Instance ID, and schema version match the Run. Adapters must not
+place access tokens, credentials, raw stderr, or unbounded transcripts in
+state. A provider-native
 absolute execution root such as Pi's `cwd` is the sole path exception: the
 exact adapter schema must declare the field, and Gateway must realpath-resolve
 it through an owner-scoped `ChatExecutionRootResolver` at import, write, and
@@ -247,7 +334,7 @@ Run; raw paths are not. Re-resolution must reproduce the same reference and
 fingerprint before start/resume. Any file-config or worktree-record change that
 alters those inputs requires a new Run instead of reusing adapter state.
 
-### Model plugin contract
+### Model and option contract
 
 ```ts
 interface ModelDescriptor {
@@ -259,12 +346,47 @@ interface ModelDescriptor {
   supportsVision: boolean;
   supportsToolUse: boolean;
 }
+
+interface ProviderOptionDescriptor {
+  id: string;
+  label: string;
+  kind: "enum" | "boolean";
+  values?: readonly { value: string; label: string }[];
+  defaultValue?: string | boolean;
+  placement: "composer" | "advanced";
+}
+
+interface ChatSkillDescriptor {
+  id: string;
+  displayName: string;
+  description: string;
+  invocation: `/${string}`;
+}
+
+interface ChatCommandDescriptor {
+  id: string;
+  displayName: string;
+  description: string;
+  invocation: `/${string}`;
+}
+
+interface ChatResourceReference {
+  kind: "file" | "folder" | "project" | "task" | "app" | "terminal_session";
+  id: string;
+  label: string;
+  revision?: string;
+}
 ```
 
-The model registry resolves a model only when both plugin availability and
-harness capability predicates pass. The Chat may store a preferred default;
-each Run stores the resolved actual IDs. Removing a model plugin does not make
-the Chat unreadable.
+The `id` in `ChatResourceReference` is an owner-authorized opaque or
+project-relative resource token. It is never an absolute filesystem path,
+credential, provider-native ID, or renderer-only tab identity.
+
+The Instance catalog resolves a model and options only when its current
+availability and capability predicates pass. The Chat may store a compatible
+preference for its bound Instance; each Run stores the exact resolved selection
+and capability snapshot. Removing a model or Instance does not make the Chat
+unreadable.
 
 ## Owner-local PostgreSQL model
 
@@ -275,15 +397,15 @@ Run orchestration have drained.
 
 | Table | Purpose and key invariants |
 |---|---|
-| `chats` | Immutable `id`; `owner_type + owner_id`; optional immutable `project_id`; lifecycle; title; default harness/model; fork provenance; `revision`; timestamps |
+| `chats` | Immutable `id`; `owner_type + owner_id`; optional revisioned `project_id`; lifecycle; title; bound Driver/Instance after first Turn; current compatible selection; fork provenance; `revision`; timestamps |
 | `chat_members` | Collaboration principals and role (`owner`, `editor`, `viewer`); unique by Chat/principal; personal Chats still have one owner row |
 | `chat_user_state` | Per-principal read cursor, pinned/muted state, attention acknowledgement, last-opened timestamp; serializable durable UI state |
 | `chat_messages` | Per-Chat monotonic `seq`; role; strict parts JSONB; state; optional Turn/Run IDs; byte count; timestamps; unique `(chat_id, seq)` |
 | `chat_attachments` | Owner-file/object references and safe metadata; never embeds arbitrary local paths or attachment bytes in renderer projections |
 | `chat_turns` | User action, `base_message_seq`, input message, idempotency key, status, timestamps; unique `(chat_id, client_request_id)` |
-| `chat_runs` | Attempt number, actual harness/model, safe execution-root reference, capability snapshot, history boundary, status/outcome, timestamps; one active Run per Chat via a partial unique index |
+| `chat_runs` | Attempt number, actual Driver/Instance/model/options, safe execution-root reference, capability snapshot, history boundary, status/outcome, timestamps; one active Run per Chat via a partial unique index |
 | `chat_run_events` | Bounded normalized replay events for streaming, approvals, tool progress, and recovery; provider raw frames are forbidden |
-| `chat_run_adapter_state` | Opaque, bounded, schema-versioned state keyed by Run and harness; repository API is adapter-only |
+| `chat_run_adapter_state` | Opaque, bounded, schema-versioned state keyed by Run, Driver, and Instance; repository API is adapter-only |
 | `chat_outbox` | Monotonic owner/Chat event cursor inserted transactionally with mutations for cross-shell replay |
 | `chat_deletions` | Content-free idempotency tombstone for hard deletes; contains only owner, Chat ID, request ID, and deletion time |
 | `chat_legacy_imports` | Unique source kind/source ID to Chat mapping, source hash, import version, and verification status |
@@ -317,12 +439,15 @@ holding a database lock across filesystem I/O. One transaction then:
 1. derive owner from the verified principal and lock the Chat row `FOR UPDATE`;
 2. validate membership, lifecycle, base revision, the same project/root
    reference, and no active Run;
-3. resolve harness/model capability selection and canonical history boundary;
-4. insert the user message, Turn, accepted Run, initial adapter-state envelope,
+3. resolve the selected Provider Instance, model, options, and canonical history
+   boundary from the current capability descriptor;
+4. if this is the first accepted Turn, atomically bind the Chat to that exact
+   Driver and Instance; otherwise require the existing Instance binding;
+5. insert the user message, Turn, accepted Run, initial adapter-state envelope,
    and outbox event; and
-5. increment Chat revision and commit.
+6. increment Chat revision and commit.
 
-Only after commit may orchestration call the external harness/model. Immediately
+Only after commit may orchestration call the external Provider/model. Immediately
 before that call it re-resolves the exact execution-root reference and compares
 the fingerprint; a changed, deleted, moved, or owner-mismatched root fails the
 Run safely. A failed call transitions the persisted Run to `failed` in a new
@@ -348,17 +473,18 @@ outbox record commit together.
 
 - `project_id IS NULL`.
 - The Chat is a Matrix OS task, not an unowned task.
-- A harness may run only when its descriptor supports `rootChat` and its
+- A Provider Instance may run only when its descriptor supports `rootChat` and its
   workspace requirement is not `project_required`.
 - The Gateway supplies a capability-filtered root execution context. It never
-  accepts a client path and never grants a coding harness implicit access to all
+  accepts a client path and never grants a coding Provider implicit access to all
   owner system data.
-- A project-required harness is displayed as unavailable with a safe action to
+- A project-required Provider is displayed as unavailable with a safe action to
   attach a project; there is no silent fallback or auto-created project.
 
 ### Project-bound Chat
 
-- `project_id` is the immutable `ProjectConfig.id`.
+- `project_id` references the Project's immutable `ProjectConfig.id`; the Chat
+  binding may still change through the guarded idle mutation below.
 - ProjectManager adds `getProjectById(ownerScope, projectId)` and builds a
   bounded, reconciled in-memory index from owner file configs. The file config
   remains authoritative; PostgreSQL never becomes a second ProjectConfig.
@@ -375,22 +501,117 @@ outbox record commit together.
 - Worktree requirements are capability metadata only in the first delivery.
   No worktree UI or implicit worktree creation is introduced.
 
-## Harness switching, retry, resume, and fork
+### Moving a Chat between Projects
 
-1. Changing the Chat's default harness/model affects future Runs only.
-2. A new Turn may use the selected harness with a bounded canonical history
-   window. The Run records the exact included message sequence boundary.
-3. Retrying the same Turn creates another Run attempt. Failed prior attempts
-   remain auditable; their partial output is not canonical input.
-4. Same-harness resume is allowed only when the adapter supports it, the stored
+- Create may omit `projectId`; Global Chat is therefore a first-class draft and
+  durable state rather than a temporary Project.
+- Add to Project, remove from Project, and move between Projects use one
+  revision-guarded context mutation. The Chat and all canonical history retain
+  the same `chatId`.
+- The mutation is allowed only with no accepted/running/waiting Run. It locks
+  the Chat row, validates the target Project by owner and immutable ID, updates
+  `project_id`, increments revision, and appends an outbox event atomically.
+- Existing Runs retain their recorded execution-root provenance. Moving the
+  Chat never rewrites past Run roots or Provider state.
+- A moved Chat's next Turn resolves a fresh root for the new Project. If the
+  bound Provider Instance requires a capability the target cannot satisfy, the
+  move fails safely before mutation. Any native session whose recorded root no
+  longer matches is non-resumable; the same Instance starts from bounded
+  canonical history instead.
+
+## Project workspace and resource ownership
+
+The user-visible hierarchy is:
+
+```text
+Computer / VPS
+├── Provider Drivers and Provider Instances
+├── Files and installed Apps
+├── Terminal Sessions
+├── Global Chats
+└── Projects
+    ├── Project bindings to Files and Apps
+    ├── Project views of Terminal Sessions
+    ├── Chats
+    │   ├── Turns
+    │   │   └── Run attempts
+    │   └── references to Files, Apps, Tasks, and Terminal Sessions
+    └── Tasks / Kanban
+```
+
+Ownership and projection are intentionally different:
+
+| Resource | Canonical owner | Project behavior | Chat/Run behavior |
+|---|---|---|---|
+| Files/folders | Computer/VPS filesystem | Project binds approved roots and repository metadata | Messages store structured references; Runs receive resolved, permission-filtered roots |
+| Apps | Computer/VPS installation catalog | Project stores app bindings/layout, not duplicate installations | Chat may reference or launch an available App through a structured resource reference |
+| Terminal Sessions | Computer/VPS terminal service, workspace-scoped | Project lists sessions whose workspace reference resolves to it | Chat/Run stores optional references; it never owns or deletes the session implicitly |
+| Tasks/Kanban | Project | Moves with the Project and may link Chats/Runs | Chat stores stable task references, not copied task state |
+| Chats | Owner; optionally bound to one Project | Project lists bound Chats | Turn belongs to Chat; Run attempt belongs to Turn |
+
+`terminalSessionId` is the durable service identity. A renderer-local
+`terminalTabId` is only presentation state and must never be persisted as the
+session identity. The later Zellij session-versus-tab design may refine the
+projection without changing this ownership boundary.
+
+## Shared Desktop Chat composition
+
+Global Chat and Project Chat are routes into one `ChatSurface` composition:
+
+```text
+ChatSurface
+├── ConversationTimeline
+├── ChatComposer
+└── ChatInspector
+```
+
+- `ChatSurface` owns route/context wiring, loading, replay, and the active Chat
+  controller. It receives optional Project context; it does not fork the Chat
+  domain into global and project implementations.
+- `ConversationTimeline` renders canonical message parts and normalized Run
+  activity. It does not read legacy Provider stores directly.
+- `ChatComposer` renders Provider/model/options/effort/mode/permission controls
+  from the selected Instance descriptor. Before the first accepted Turn it may
+  change Instance; afterward it explains the lock and offers Fork/New Chat.
+- Typing `/` searches the union of capability-filtered skills and commands.
+  Typing `@` creates typed references to allowed files, folders, Projects,
+  Tasks, Apps, and Terminal Sessions. Display text alone is never parsed back
+  into a path or identity.
+- `ChatInspector` hosts provider-neutral tabs such as context, changes, files,
+  approvals, and Run details. A tab appears only when capability and Run data
+  support it.
+- The three surfaces consume shared schemas, fixture factories, controllers,
+  and design tokens. They do not import each other's local stores or create a
+  second Gateway/persistence contract.
+
+This boundary permits message presentation and inspector work to proceed from
+contract fixtures while the canonical Gateway and Chat panel are built.
+
+## Provider binding, retry, resume, and fork
+
+1. Before the first accepted Turn, changing Driver, Instance, model, or options
+   updates draft state only.
+2. The first accepted Turn binds the exact Driver and Instance in the same
+   transaction that admits the Turn and Run.
+3. Later Turns may change model or provider-specific options only when the bound
+   Instance currently advertises those selections as compatible. If its native
+   runtime cannot switch model inside one session, the adapter starts a fresh
+   native session from bounded canonical history while retaining the same
+   Matrix Chat and Instance binding.
+4. Retrying the same Turn creates another Run attempt through the same bound
+   Instance. Failed prior attempts remain auditable; their partial output is
+   not canonical input.
+5. Same-Instance resume is allowed only when the adapter supports it, the stored
    state parses under the exact adapter schema version, owner/project context
    still matches, and the prior Run is in a resumable state.
-5. A harness change always creates a fresh Run from canonical history. The
-   orchestration layer never passes another harness's state to it.
-6. `Fork Chat` creates a new `chatId` with explicit parent Chat/message
+6. A later request for another Driver or Instance returns
+   `provider_instance_locked` with safe Fork/New Chat actions; it never creates
+   an in-place Run through that Provider.
+7. `Fork Chat` creates a new `chatId` with explicit parent Chat/message
    provenance and copies canonical history through the selected committed
-   message. It does not copy active Runs or adapter resume state.
-7. History windowing is explicit and bounded. If full history exceeds adapter
+   message. The new Chat remains a draft until its first Turn and does not copy
+   active Runs or adapter resume state.
+8. History windowing is explicit and bounded. If full history exceeds adapter
    limits, orchestration passes a recorded sequence range and persisted explicit
    summaries; it never deletes or silently rewrites owner history.
 
@@ -402,19 +623,20 @@ All schemas are strict and bounded. Every mutating HTTP endpoint uses Hono
 | Contract | Principal | Authorization | Notes |
 |---|---|---|---|
 | `GET /api/chats` | Browser/native/CLI verified principal | Owner/member read | Bounded cursor list and filters |
-| `POST /api/chats` | Verified principal | Owner create | Idempotent request ID; optional project/default selection |
+| `POST /api/chats` | Verified principal | Owner create | Idempotent request ID; optional Project and draft selection |
 | `GET /api/chats/:chatId` | Verified principal | Owner/member read | Summary plus bounded message page |
-| `PATCH /api/chats/:chatId` | Verified principal | Owner/editor | Title, default selection, context, lifecycle with base revision |
+| `PATCH /api/chats/:chatId` | Verified principal | Owner/editor | Title, compatible selection, Project binding, lifecycle with base revision; Driver/Instance mutation rejected after binding |
 | `DELETE /api/chats/:chatId` | Verified principal | Owner/org admin | Reject active Run unless an explicit cancel-and-delete flow completed |
 | `POST /api/chats/:chatId/turns` | Verified principal | Owner/editor | Transactional Turn/Run admission; idempotent request ID |
-| `POST /api/chats/:chatId/runs/:runId/cancel` | Verified principal | Owner/editor | Same-harness cancellation only |
-| `POST /api/chats/:chatId/forks` | Verified principal | Owner/editor | Explicit committed message boundary |
+| `POST /api/chats/:chatId/runs/:runId/cancel` | Verified principal | Owner/editor | Same-Instance cancellation only |
+| `POST /api/chats/:chatId/forks` | Verified principal | Owner/editor | Explicit committed message boundary and optional draft selection |
 | `POST /api/chats/:chatId/exports` | Verified principal | Owner/org admin | Bounded temp export with cleanup policy |
-| `GET /api/chat-harnesses` | Verified principal | Owner/member read | Safe capability/model projection only |
+| `GET /api/chat-providers` | Verified principal | Owner/member read | Safe Driver/Instance/model/options/skills/commands projection only |
+| `GET /api/chats/:chatId/resources` | Verified principal | Owner/member read | Capability- and Project-filtered `@` resource search; opaque IDs only |
 | Chat event WebSocket | Browser query token or native/CLI bearer path | Owner/member read | Exact query-token allowlist, bounded frame schema, replay cursor |
 | Channel adapter dispatch | Authenticated internal channel principal | Mapped owner/member action | Channel/thread binding resolved server-side; no owner override |
 
-Auth failure is fail-closed. Missing database, ProjectManager, harness registry,
+Auth failure is fail-closed. Missing database, ProjectManager, Provider registry,
 or owner principal is service misconfiguration (`503`-style), never not-found.
 
 ## Cross-shell events and convergence
@@ -453,8 +675,8 @@ Initial hard maxima; lower deployment-specific limits may be configured.
 | Provider event batch | 100 normalized events |
 | Persisted normalized events | 500 per Run before adapter aggregation/backpressure must occur |
 | Adapter state | 64 KiB JSON envelope after serialization |
-| Harness registry | 20 harnesses; duplicate IDs fail startup |
-| Model catalog | 64 models per harness projection; 128 tool capability IDs |
+| Provider registry | 20 Drivers and 64 Instances per owner; duplicate stable IDs fail startup |
+| Instance catalog | 64 models, 64 skills/commands, 32 option descriptors, and 128 tool capability IDs per projection |
 | Dispatch history window | 200 messages or 2 MiB encoded; explicit range and truncation metadata required |
 | WebSocket frame | Existing bounded Chat frame limit; schema validation after JSON parsing |
 | Event subscribers | 32 per owner and a configured global cap; TTL sweep plus explicit shutdown drain |
@@ -470,7 +692,8 @@ Clients receive allowlisted codes such as:
 
 - `chat_not_found`, `chat_conflict`, `chat_busy`, `chat_unavailable`;
 - `project_required`, `project_unavailable`;
-- `harness_unavailable`, `model_unavailable`, `capability_mismatch`;
+- `provider_unavailable`, `provider_instance_locked`, `model_unavailable`,
+  `capability_mismatch`;
 - `run_not_found`, `run_not_resumable`, `run_unavailable`;
 - `history_window_required`; and
 - `migration_in_progress`.
@@ -486,7 +709,7 @@ Gateway shutdown order:
 
 1. stop new Chat/Turn admissions and emit a safe service-closing signal;
 2. stop accepting event subscriptions;
-3. request cancellation from active harness adapters with a 10-second total
+3. request cancellation from active Provider adapters with a 10-second total
    drain budget;
 4. transactionally mark unresolved Runs `interrupted` and append outbox events;
 5. drain/clear Chat subscribers and timers;
@@ -495,9 +718,9 @@ Gateway shutdown order:
    shared Kysely pool.
 
 On startup, reconciliation finds accepted/running/waiting Runs. It may offer
-resume only through the same adapter and valid state version. Otherwise it
+resume only through the same Driver, Instance, adapter, and valid state version. Otherwise it
 marks the Run interrupted/failed with safe recovery actions. It never resumes
-through another harness or claims an external process is still live based only
+through another Provider Instance or claims an external process is still live based only
 on timestamps.
 
 ## Export and delete
@@ -541,7 +764,7 @@ refreshing it or recreating content.
 4. Map legacy conversation IDs to new Chat IDs while preserving a compatibility
    alias. Convert messages to canonical parts. Map each coding-agent thread to
    a Chat, its accepted inputs to Turns, and provider attempts/events to Runs.
-5. Preserve valid Hermes/coding provider session state only in the matching
+5. Preserve valid Hermes/coding Provider session state only in the matching
    adapter-state envelope. Pi's absolute `cwd` remains resumable only when its
    adapter schema accepts it and Gateway binds its realpath to either the exact
    current `ProjectConfig.localPath` or one exact registered WorktreeRecord for
@@ -580,27 +803,48 @@ Rollback before cutover is safe. After cutover, rollback is allowed only to a
 release that understands the marker and PostgreSQL schema; an older JSON writer
 must refuse startup. This prevents split-brain and indefinite compatibility.
 
-## Delivery slices and issue sequencing
+## Delivery boundaries
 
-### Slice A — persistence and migration
+### Boundary A — shared contracts
 
-Add contracts, typed Kysely repository/migrations, immutable ProjectConfig ID
-lookup, transactions/outbox, JSON importer, cutover/recovery, export/delete,
-and repository/Gateway tests. This is the prerequisite for the other slices.
+Add strict shared schemas, Provider Driver/Instance descriptors, compound model
+selection, normalized message/Run projections, structured `/` invocations and
+`@` references, fixture factories, and compatibility adapters. This is the
+only prerequisite shared by otherwise parallel UI and backend work.
 
-### Slice B — harness and model adapters
+### Boundary B — canonical Gateway and persistence
 
-Add harness/model registries and capability contracts, then adapt Hermes,
-OpenClaw, Codex, Pi, and OpenCode incrementally. Move valid provider state
-behind adapter-only storage. Prove same-harness resume and cross-harness
-non-resume with contract tests.
+Add the typed Kysely repository/migrations, immutable ProjectConfig ID lookup,
+transactions/outbox, Provider registry, Turn/Run orchestration, JSON importer,
+cutover/recovery, export/delete, and Gateway tests. Adapt Hermes and Codex first;
+add Claude Code, Pi, OpenCode, and OpenClaw only through the same contracts.
 
-### Slice C — shell/UI migration
+### Boundary C — shared Chat panel
 
-Move Desktop, browser Shell, CLI, and channel shells to `/api/chats` and the
-outbox event stream. Replace source/provider-typed rails with one Chat
-projection and capability labels. Remove renderer-owned thread identity only
-after parity and cutover evidence.
+Build the single `ChatSurface` and `ChatComposer`, Provider/Instance/model
+selection, capability-driven mode/effort/permission controls, `/` picker, `@`
+references, and Global/Project context mutation. It may develop against Boundary
+A fixtures, then integrates with Boundary B.
+
+### Boundary D — conversation presentation
+
+Polish `ConversationTimeline` against canonical message and normalized Run
+fixtures. It owns rendering quality, streaming states, tool/approval/input
+parts, error/retry copy, and accessibility; it does not own Provider orchestration
+or legacy store migration.
+
+### Boundary E — contextual inspector
+
+Refactor `ChatInspector` and its changes/files/context/Run-detail tabs against
+canonical projections. It owns layout, navigation, preview, and responsive
+behavior; exact turn-diff truth remains a Gateway responsibility.
+
+### Boundary F — integration and cutover
+
+Compose Boundaries B-E, move Desktop, browser Shell, CLI, and channel shells to
+`/api/chats` plus the outbox event stream, and replace source/provider-typed
+rails with one Chat projection. Remove renderer-owned thread identity only
+after parity, migration, and real-runtime evidence.
 
 MAT-299 continues to provide the current canonical Hermes lifecycle and remains
 in PR #1213. It does not absorb the PostgreSQL migration. MAT-318 remains a
@@ -616,7 +860,8 @@ A separate public documentation PR is required in the private
 
 Implementation tests are written first after these public seams are approved.
 
-- **Contracts:** strict Chat/message/Turn/Run/harness/model schemas; reserved
+- **Contracts:** strict Chat/message/Turn/Run/Driver/Instance/model/options
+  schemas; reserved
   fields; byte/count bounds; safe errors; provider-state opacity.
 - **Repository:** migrations; owner isolation; row-lock races; optimistic
   revision; partial unique active Run; transactional outbox; hard delete;
@@ -624,20 +869,22 @@ Implementation tests are written first after these public seams are approved.
 - **Migration:** repeated import, changed hashes, invalid sources, symlinks,
   crash/restart per phase, pre/post-marker rollback, no dual writes, legacy ID
   compatibility expiry, transcript and resume-state parity.
-- **Harnesses:** capability discovery; model resolution; event/state bounds;
-  same-harness resume; cross-harness resume rejection; cancel timeout; generic
-  failures; project/root requirements.
+- **Providers:** Driver/Instance discovery; capability-derived controls; model
+  resolution; first-Turn binding; event/state bounds; same-Instance resume;
+  cross-Instance mutation rejection and Fork; cancel timeout; generic failures;
+  Project/root requirements.
 - **Gateway/auth:** route/body/query validation, `bodyLimit` including DELETE,
   personal/org membership matrix, browser WebSocket query-token path, replay
   gaps, stale subscriber eviction, shutdown drain.
 - **Concurrency:** Turn admission versus context update/delete/archive; late
   provider callbacks; duplicate requests; two-shell mutation conflicts.
-- **Shells:** runtime-scope invalidation, loading/error/reconnect/replay, failed
-  mutation preservation, capability-driven labels, no provider-specific Chat
-  types, export/delete flows.
+- **Shells:** identical Global/Project Chat composition, runtime-scope
+  invalidation, loading/error/reconnect/replay, failed mutation preservation,
+  capability-driven controls, `/` and `@` structured selection, Chat moves,
+  no Provider-specific Chat types, export/delete flows.
 - **Real runtime:** owner-VPS PostgreSQL evidence, Gateway/browser/CLI/Desktop
-  convergence, same-harness resume, harness switch from canonical history,
-  project removal recovery, restart reconciliation, and exact export/delete.
+  convergence, same-Instance resume, cross-Instance Fork, Project move/removal
+  recovery, restart reconciliation, and exact export/delete.
 
 Direct Figma parity is explicitly unverified because the Matrix OS View-seat
 MCP call limit is exhausted. Existing saved screenshots/spec evidence may guide
@@ -647,18 +894,23 @@ is restored.
 ## Acceptance criteria
 
 - [x] One provider-neutral Chat contract represents durable user-facing tasks.
-- [x] Harness/model selection is capability-driven and extensible without
-  changing Chat identity.
+- [x] Provider Driver, Provider Instance, model, and options are distinct,
+  capability-driven concepts.
 - [x] Provider session/resume state is adapter-only and cannot replace Chat ID.
 - [x] Owner-local PostgreSQL/Kysely is the durable relational source of truth.
 - [x] Project files remain authoritative and are linked by immutable project ID.
 - [x] Root and project-bound execution semantics are explicit and testable.
-- [x] Harness switching, retry, resume, and explicit fork behavior are defined.
+- [x] First-Turn Provider binding, retry, resume, and cross-Provider Fork/New
+  Chat behavior are defined.
 - [x] JSON and coding-agent sources have an idempotent, recoverable, bounded
   cutover plan with no indefinite dual write.
 - [x] Auth, validation, resource limits, shutdown, export/delete, and cross-shell
   convergence are specified.
-- [x] Focused TDD layers and three independent implementation slices are
+- [x] Global and Project Chat share one composition and Chat can move between
+  Project contexts while idle.
+- [x] Files, Apps, Terminal Sessions, Tasks, Chats, Turns, and Runs have explicit
+  ownership and reference boundaries.
+- [x] Focused TDD layers and independently ownable delivery boundaries are
   defined.
 - [x] Public documentation is a separate follow-up PR.
 - [x] MAT-268 is excluded without modification, dependency, or new relation.


### PR DESCRIPTION
## Summary

- define the canonical provider-neutral Chat hierarchy: Chat -> Turn -> Run with Provider Driver and Provider Instance binding
- align Global Chat and Project Chat around one shared surface, with explicit project, workspace-root, terminal, file, app, and task ownership
- map the implementation sequence and Linear dependency graph for MAT-471 through MAT-483

Linear: MAT-470

## Tests

- `flox activate -- bun run typecheck` — passed
- `flox activate -- bun run check:patterns` — passed with 0 violations and 5 existing review warnings
- `git diff --check origin/main...HEAD` — passed
- `flox activate -- bun run test` — broad suite completed with 11,362 passed and 20 skipped; 21 tests failed across 17 files outside this docs-only diff (macOS/Linux shell incompatibilities, dependency resolution, timeouts, and date-boundary assertions)

## Invariants

- Source of truth: this PR does not change runtime persistence; it specifies owner-local Postgres/Kysely as the target canonical Chat store for follow-up implementation.
- Lock and transaction boundary: no runtime mutation is introduced; the document requires atomic first-turn binding and transactional Chat/Turn/Run writes in later tasks.
- Orphan and recovery states: no runtime state is introduced; the design defines durable Run lifecycle and outbox recovery requirements for later tasks.
- Auth source: unchanged in this PR; proposed routes derive owner scope from the authenticated request principal.
- Deferred work: contracts, repositories, provider catalog, orchestration, UI convergence, migration, and cutover remain in MAT-471 through MAT-483.
