### PR TITLE
fix(billing): align checkout summary with configurator

### DIFF
--- a/shell/src/components/settings/sections/BillingPanel.tsx
+++ b/shell/src/components/settings/sections/BillingPanel.tsx
@@ -1296,29 +1296,32 @@ function BillingPanelInner({
   }
 
   return (
-    <div className="space-y-4">
-      <div>
-        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-forest/55">
-          {mode === "provisioning"
-            ? "Provisioning"
-            : mode === "add-computer"
-            ? "New computer"
-            : "Billing"}
-        </p>
-        <h3 className="mt-1.5 text-xl font-semibold tracking-tight text-deep sm:text-2xl">
-          {mode === "device-setup"
-            ? "Finish billing to approve CLI login"
-            : mode === "provisioning" || mode === "add-computer"
-            ? "Pick the cloud computer Matrix boots on"
-            : "Manage your hosted Matrix computer"}
-        </h3>
-        <p className="mt-1.5 max-w-xl text-sm leading-6 text-forest/65">
-          Choose the plan for your hosted runtime. Billing starts in Stripe before Matrix
-          attaches a dedicated VPS.
-        </p>
-      </div>
+    <div
+      className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-start"
+      data-testid="billing-configurator-layout"
+    >
+      <div className="space-y-4" data-testid="billing-configurator-main">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-forest/55">
+            {mode === "provisioning"
+              ? "Provisioning"
+              : mode === "add-computer"
+              ? "New computer"
+              : "Billing"}
+          </p>
+          <h3 className="mt-1.5 text-xl font-semibold tracking-tight text-deep sm:text-2xl">
+            {mode === "device-setup"
+              ? "Finish billing to approve CLI login"
+              : mode === "provisioning" || mode === "add-computer"
+              ? "Pick the cloud computer Matrix boots on"
+              : "Manage your hosted Matrix computer"}
+          </h3>
+          <p className="mt-1.5 max-w-xl text-sm leading-6 text-forest/65">
+            Choose the plan for your hosted runtime. Billing starts in Stripe before Matrix
+            attaches a dedicated VPS.
+          </p>
+        </div>
 
-      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-start">
         <div className="rounded-3xl border border-forest/12 bg-white p-4 sm:p-5">
           <SelectionTriggerCards
             profiles={allowedProfiles}
@@ -1345,21 +1348,21 @@ function BillingPanelInner({
             ))}
           </ul>
         </div>
-        <CheckoutPanel
-          mode={mode}
-          onCheckoutIntent={onCheckoutIntent}
-          onCheckoutNavigate={onCheckoutNavigate}
-          checkoutReturnPath={checkoutReturnPath}
-          checkoutRuntimeSlot={checkoutRuntimeSlot}
-          checkoutBypassed={checkoutBypassed}
-          telemetryProperties={telemetryProperties}
-          selectedProfile={selectedProfile}
-          selectedRegion={selectedRegion}
-          billingInterval={billingInterval}
-          onBillingIntervalChange={handleBillingIntervalChange}
-          trialDurationDays={trialDurationDays}
-        />
       </div>
+      <CheckoutPanel
+        mode={mode}
+        onCheckoutIntent={onCheckoutIntent}
+        onCheckoutNavigate={onCheckoutNavigate}
+        checkoutReturnPath={checkoutReturnPath}
+        checkoutRuntimeSlot={checkoutRuntimeSlot}
+        checkoutBypassed={checkoutBypassed}
+        telemetryProperties={telemetryProperties}
+        selectedProfile={selectedProfile}
+        selectedRegion={selectedRegion}
+        billingInterval={billingInterval}
+        onBillingIntervalChange={handleBillingIntervalChange}
+        trialDurationDays={trialDurationDays}
+      />
     </div>
   );
 }

--- a/tests/shell/billing-section.test.tsx
+++ b/tests/shell/billing-section.test.tsx
@@ -503,6 +503,8 @@ describe("BillingSection", () => {
     expect(layout.children).toHaveLength(2);
     expect(layout.children[0]).toBe(mainColumn);
     expect(layout.children[1]).toBe(summary);
+    expect(layout.className).toContain("lg:grid-cols-[minmax(0,1fr)_360px]");
+    expect(layout.className).toContain("lg:items-start");
     expect(mainColumn.contains(heading)).toBe(true);
   });
 

--- a/tests/shell/billing-section.test.tsx
+++ b/tests/shell/billing-section.test.tsx
@@ -484,6 +484,28 @@ describe("BillingSection", () => {
     expect(screen.queryByTestId("pricing-table")).toBeNull();
   });
 
+  it("aligns the provisioning intro and checkout summary in the same layout row", async () => {
+    clerkState.isLoaded = true;
+    clerkState.activePlan = null;
+
+    const { BillingSection } = await loadBillingSection();
+
+    render(<BillingSection mode="provisioning" />);
+
+    await waitFor(() => expect(screen.getByText("Not active")).toBeTruthy());
+    const layout = screen.getByTestId("billing-configurator-layout");
+    const mainColumn = screen.getByTestId("billing-configurator-main");
+    const heading = screen.getByRole("heading", {
+      name: "Pick the cloud computer Matrix boots on",
+    });
+    const summary = screen.getByRole("complementary");
+
+    expect(layout.children).toHaveLength(2);
+    expect(layout.children[0]).toBe(mainColumn);
+    expect(layout.children[1]).toBe(summary);
+    expect(mainColumn.contains(heading)).toBe(true);
+  });
+
   it("uses device setup copy when billing is opened from CLI login", async () => {
     clerkState.isLoaded = true;
     clerkState.activePlan = null;


### PR DESCRIPTION
## Summary

- Align the checkout summary with the provisioning intro at desktop widths.
- Preserve the existing mobile stacking order: intro, selectors, then summary.
- Add a structural regression test for the two-column billing configurator.

## Invariants

- Source of truth: the existing React render tree; no state or persistence behavior changes.
- Lock/transaction scope: not applicable (UI-only change).
- Acceptable orphan states: not applicable.
- Auth source of truth: unchanged.
- Deferred scope: none.

## Tests

- `bun run test tests/shell/billing-section.test.tsx --run` (23 passed)
- `bun run typecheck` (passed)
- `bun run check:patterns` (0 violations)
- `bun run test` (stopped after unrelated latest-main failures in default apps, gateway review snapshots, and host-script suites)

## Review/Monitoring

- Latest trusted Greptile result: **5/5** on `2f651f44d`, with zero new comments.
- `ready-for-ci` applied.
- Label-triggered CI: **18 passed, 12 intentionally skipped, 0 failed, 0 pending**.
- This workflow did not merge the PR.