### PR TITLE
feat(gateway): add canonical Chat repository

### DIFF
--- a/packages/gateway/src/chat/database.ts
+++ b/packages/gateway/src/chat/database.ts
@@ -1,0 +1,386 @@
+import { sql, type ColumnType, type Generated, type Kysely } from "kysely";
+
+type Timestamp = ColumnType<Date | string, Date | string | undefined, Date | string>;
+type NullableTimestamp = ColumnType<Date | string | null, Date | string | null | undefined, Date | string | null>;
+type JsonValue = ColumnType<unknown, unknown, unknown>;
+
+export interface ChatsTable {
+  id: string;
+  owner_type: "personal" | "organization";
+  owner_id: string;
+  create_request_id: string;
+  project_id: string | null;
+  title: string;
+  lifecycle: "active" | "archived";
+  attention: "none" | "approval_required" | "input_required" | "failed";
+  revision: ColumnType<number, number | undefined, number>;
+  message_count: ColumnType<number, number | undefined, number>;
+  collaboration: JsonValue | null;
+  user_state: JsonValue | null;
+  shell_state: JsonValue | null;
+  fork_provenance: JsonValue | null;
+  last_message_preview: string | null;
+  current_selection: JsonValue | null;
+  bound_driver_kind: string | null;
+  bound_instance_id: string | null;
+  bound_at_turn_id: string | null;
+  created_at: Timestamp;
+  updated_at: Timestamp;
+}
+
+export interface ChatMembersTable {
+  chat_id: string;
+  principal_type: "user" | "organization";
+  principal_id: string;
+  role: "owner" | "editor" | "viewer";
+  created_at: Timestamp;
+}
+
+export interface ChatUserStateTable {
+  chat_id: string;
+  principal_id: string;
+  read_through_seq: ColumnType<number, number | undefined, number>;
+  pinned: ColumnType<boolean, boolean | undefined, boolean>;
+  muted: ColumnType<boolean, boolean | undefined, boolean>;
+  attention_acknowledged_at: NullableTimestamp;
+  last_opened_at: NullableTimestamp;
+  updated_at: Timestamp;
+}
+
+export interface ChatMessagesTable {
+  id: string;
+  chat_id: string;
+  seq: number;
+  role: "user" | "assistant" | "tool" | "system";
+  state: "pending" | "committed" | "failed";
+  turn_id: string | null;
+  run_id: string | null;
+  parts: JsonValue;
+  byte_count: number;
+  search_text: string;
+  created_at: Timestamp;
+}
+
+export interface ChatAttachmentsTable {
+  id: string;
+  chat_id: string;
+  message_id: string;
+  kind: "file" | "image" | "diff" | "structured_ref";
+  label: string;
+  mime_type: string | null;
+  size_bytes: number | null;
+  owner_reference: string | null;
+  created_at: Timestamp;
+}
+
+export interface ChatTurnsTable {
+  id: string;
+  chat_id: string;
+  client_request_id: string;
+  base_message_seq: number;
+  input_message_id: string;
+  status: "accepted" | "running" | "completed" | "failed" | "aborted";
+  created_at: Timestamp;
+  updated_at: Timestamp;
+}
+
+export interface ChatRunsTable {
+  id: string;
+  chat_id: string;
+  turn_id: string;
+  attempt: number;
+  driver_kind: string;
+  instance_id: string;
+  selection: JsonValue;
+  interaction_mode: string;
+  permission_mode: string;
+  execution_root: JsonValue | null;
+  status: "accepted" | "running" | "waiting_for_approval" | "waiting_for_input" | "completed" | "failed" | "aborted";
+  outcome: "completed" | "failed" | "aborted" | null;
+  started_at: NullableTimestamp;
+  completed_at: NullableTimestamp;
+  history_boundary_seq: number;
+  capability_snapshot: JsonValue;
+  created_at: Timestamp;
+  updated_at: Timestamp;
+}
+
+export interface ChatRunEventsTable {
+  id: string;
+  chat_id: string;
+  run_id: string;
+  event: JsonValue;
+  occurred_at: Timestamp;
+}
+
+export interface ChatRunAdapterStateTable {
+  run_id: string;
+  driver_kind: string;
+  instance_id: string;
+  schema_version: number;
+  state: JsonValue;
+  byte_count: number;
+  updated_at: Timestamp;
+}
+
+export interface ChatOutboxTable {
+  cursor: Generated<number>;
+  owner_type: "personal" | "organization";
+  owner_id: string;
+  chat_id: string;
+  revision: number;
+  event_type: string;
+  payload: JsonValue;
+  created_at: Timestamp;
+}
+
+export interface ChatDeletionsTable {
+  owner_type: "personal" | "organization";
+  owner_id: string;
+  chat_id: string;
+  request_id: string;
+  deleted_at: Timestamp;
+}
+
+export interface ChatLegacyImportsTable {
+  owner_type: "personal" | "organization";
+  owner_id: string;
+  source_kind: string;
+  source_id: string;
+  chat_id: string;
+  source_hash: string;
+  import_version: number;
+  verification_status: "pending" | "verified" | "failed";
+  updated_at: Timestamp;
+}
+
+export interface ChatMigrationsTable {
+  owner_type: "personal" | "organization";
+  owner_id: string;
+  migration_id: string;
+  phase: string;
+  source_fingerprint: string;
+  imported_count: number;
+  error_count: number;
+  cutover_at: NullableTimestamp;
+  legacy_alias_expires_at: NullableTimestamp;
+  created_at: Timestamp;
+  updated_at: Timestamp;
+}
+
+export interface ChatDatabase {
+  chats: ChatsTable;
+  chat_members: ChatMembersTable;
+  chat_user_state: ChatUserStateTable;
+  chat_messages: ChatMessagesTable;
+  chat_attachments: ChatAttachmentsTable;
+  chat_turns: ChatTurnsTable;
+  chat_runs: ChatRunsTable;
+  chat_run_events: ChatRunEventsTable;
+  chat_run_adapter_state: ChatRunAdapterStateTable;
+  chat_outbox: ChatOutboxTable;
+  chat_deletions: ChatDeletionsTable;
+  chat_legacy_imports: ChatLegacyImportsTable;
+  chat_migrations: ChatMigrationsTable;
+}
+
+export async function bootstrapChatDatabase(db: Kysely<ChatDatabase>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS chats (
+      id TEXT PRIMARY KEY,
+      owner_type TEXT NOT NULL CHECK (owner_type IN ('personal', 'organization')),
+      owner_id TEXT NOT NULL,
+      create_request_id TEXT NOT NULL,
+      project_id TEXT,
+      title TEXT NOT NULL,
+      lifecycle TEXT NOT NULL CHECK (lifecycle IN ('active', 'archived')),
+      attention TEXT NOT NULL CHECK (attention IN ('none', 'approval_required', 'input_required', 'failed')),
+      revision BIGINT NOT NULL DEFAULT 0,
+      message_count BIGINT NOT NULL DEFAULT 0,
+      collaboration JSONB,
+      user_state JSONB,
+      shell_state JSONB,
+      fork_provenance JSONB,
+      last_message_preview TEXT,
+      current_selection JSONB,
+      bound_driver_kind TEXT,
+      bound_instance_id TEXT,
+      bound_at_turn_id TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      UNIQUE (owner_type, owner_id, create_request_id)
+    )
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS chat_members (
+      chat_id TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+      principal_type TEXT NOT NULL CHECK (principal_type IN ('user', 'organization')),
+      principal_id TEXT NOT NULL,
+      role TEXT NOT NULL CHECK (role IN ('owner', 'editor', 'viewer')),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      PRIMARY KEY (chat_id, principal_type, principal_id)
+    )
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS chat_user_state (
+      chat_id TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+      principal_id TEXT NOT NULL,
+      read_through_seq BIGINT NOT NULL DEFAULT 0,
+      pinned BOOLEAN NOT NULL DEFAULT false,
+      muted BOOLEAN NOT NULL DEFAULT false,
+      attention_acknowledged_at TIMESTAMPTZ,
+      last_opened_at TIMESTAMPTZ,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      PRIMARY KEY (chat_id, principal_id)
+    )
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS chat_messages (
+      id TEXT PRIMARY KEY,
+      chat_id TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+      seq BIGINT NOT NULL,
+      role TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'tool', 'system')),
+      state TEXT NOT NULL CHECK (state IN ('pending', 'committed', 'failed')),
+      turn_id TEXT,
+      run_id TEXT,
+      parts JSONB NOT NULL,
+      byte_count INTEGER NOT NULL CHECK (byte_count >= 0 AND byte_count <= 131072),
+      search_text TEXT NOT NULL DEFAULT '',
+      created_at TIMESTAMPTZ NOT NULL,
+      UNIQUE (chat_id, seq)
+    )
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS chat_attachments (
+      id TEXT PRIMARY KEY,
+      chat_id TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+      message_id TEXT NOT NULL REFERENCES chat_messages(id) ON DELETE CASCADE,
+      kind TEXT NOT NULL CHECK (kind IN ('file', 'image', 'diff', 'structured_ref')),
+      label TEXT NOT NULL,
+      mime_type TEXT,
+      size_bytes INTEGER,
+      owner_reference TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS chat_turns (
+      id TEXT PRIMARY KEY,
+      chat_id TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+      client_request_id TEXT NOT NULL,
+      base_message_seq BIGINT NOT NULL,
+      input_message_id TEXT NOT NULL REFERENCES chat_messages(id) ON DELETE CASCADE,
+      status TEXT NOT NULL CHECK (status IN ('accepted', 'running', 'completed', 'failed', 'aborted')),
+      created_at TIMESTAMPTZ NOT NULL,
+      updated_at TIMESTAMPTZ NOT NULL,
+      UNIQUE (chat_id, client_request_id)
+    )
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS chat_runs (
+      id TEXT PRIMARY KEY,
+      chat_id TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+      turn_id TEXT NOT NULL REFERENCES chat_turns(id) ON DELETE CASCADE,
+      attempt INTEGER NOT NULL CHECK (attempt BETWEEN 1 AND 100),
+      driver_kind TEXT NOT NULL,
+      instance_id TEXT NOT NULL,
+      selection JSONB NOT NULL,
+      interaction_mode TEXT NOT NULL,
+      permission_mode TEXT NOT NULL,
+      execution_root JSONB,
+      status TEXT NOT NULL CHECK (status IN ('accepted', 'running', 'waiting_for_approval', 'waiting_for_input', 'completed', 'failed', 'aborted')),
+      outcome TEXT CHECK (outcome IN ('completed', 'failed', 'aborted')),
+      started_at TIMESTAMPTZ,
+      completed_at TIMESTAMPTZ,
+      history_boundary_seq BIGINT NOT NULL,
+      capability_snapshot JSONB NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL,
+      updated_at TIMESTAMPTZ NOT NULL,
+      UNIQUE (turn_id, attempt)
+    )
+  `.execute(db);
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_chat_runs_one_active
+    ON chat_runs(chat_id)
+    WHERE status IN ('accepted', 'running', 'waiting_for_approval', 'waiting_for_input')
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS chat_run_events (
+      id TEXT PRIMARY KEY,
+      chat_id TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+      run_id TEXT NOT NULL REFERENCES chat_runs(id) ON DELETE CASCADE,
+      event JSONB NOT NULL,
+      occurred_at TIMESTAMPTZ NOT NULL
+    )
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS chat_run_adapter_state (
+      run_id TEXT PRIMARY KEY REFERENCES chat_runs(id) ON DELETE CASCADE,
+      driver_kind TEXT NOT NULL,
+      instance_id TEXT NOT NULL,
+      schema_version INTEGER NOT NULL CHECK (schema_version > 0),
+      state JSONB NOT NULL,
+      byte_count INTEGER NOT NULL CHECK (byte_count >= 0 AND byte_count <= 65536),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS chat_outbox (
+      cursor BIGSERIAL PRIMARY KEY,
+      owner_type TEXT NOT NULL CHECK (owner_type IN ('personal', 'organization')),
+      owner_id TEXT NOT NULL,
+      chat_id TEXT NOT NULL,
+      revision BIGINT NOT NULL,
+      event_type TEXT NOT NULL,
+      payload JSONB NOT NULL DEFAULT '{}',
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS chat_deletions (
+      owner_type TEXT NOT NULL CHECK (owner_type IN ('personal', 'organization')),
+      owner_id TEXT NOT NULL,
+      chat_id TEXT NOT NULL,
+      request_id TEXT NOT NULL,
+      deleted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      PRIMARY KEY (owner_type, owner_id, chat_id),
+      UNIQUE (owner_type, owner_id, request_id)
+    )
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS chat_legacy_imports (
+      owner_type TEXT NOT NULL CHECK (owner_type IN ('personal', 'organization')),
+      owner_id TEXT NOT NULL,
+      source_kind TEXT NOT NULL,
+      source_id TEXT NOT NULL,
+      chat_id TEXT NOT NULL,
+      source_hash TEXT NOT NULL,
+      import_version INTEGER NOT NULL CHECK (import_version > 0),
+      verification_status TEXT NOT NULL CHECK (verification_status IN ('pending', 'verified', 'failed')),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      PRIMARY KEY (owner_type, owner_id, source_kind, source_id)
+    )
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS chat_migrations (
+      owner_type TEXT NOT NULL CHECK (owner_type IN ('personal', 'organization')),
+      owner_id TEXT NOT NULL,
+      migration_id TEXT NOT NULL,
+      phase TEXT NOT NULL,
+      source_fingerprint TEXT NOT NULL,
+      imported_count INTEGER NOT NULL DEFAULT 0,
+      error_count INTEGER NOT NULL DEFAULT 0,
+      cutover_at TIMESTAMPTZ,
+      legacy_alias_expires_at TIMESTAMPTZ,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      PRIMARY KEY (owner_type, owner_id, migration_id)
+    )
+  `.execute(db);
+
+  await sql`CREATE INDEX IF NOT EXISTS idx_chats_owner_updated ON chats(owner_type, owner_id, lifecycle, updated_at DESC, id)`.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_chats_owner_project ON chats(owner_type, owner_id, project_id)`.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_chat_messages_page ON chat_messages(chat_id, seq)`.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_chat_messages_search ON chat_messages USING GIN (to_tsvector('simple', search_text)) WHERE state = 'committed'`.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_chat_outbox_owner_cursor ON chat_outbox(owner_type, owner_id, cursor)`.execute(db);
+}

--- a/packages/gateway/src/chat/records.ts
+++ b/packages/gateway/src/chat/records.ts
@@ -1,0 +1,252 @@
+import {
+  CanonicalChatActiveRunProjectionSchema,
+  CanonicalChatMessageSchema,
+  CanonicalChatRunActivitySchema,
+  CanonicalChatRunSchema,
+  CanonicalChatSchema,
+  CanonicalChatTurnSchema,
+  CanonicalChatProviderBindingSchema,
+  type CanonicalChat,
+  type CanonicalChatMessage,
+  type CanonicalChatProviderBinding,
+  type CanonicalChatRun,
+  type CanonicalChatRunActivity,
+  type CanonicalChatSummary,
+  type CanonicalChatTurn,
+  type CanonicalOwnerScope,
+} from "@matrix-os/contracts";
+import { sql, type RawBuilder, type Selectable } from "kysely";
+import type {
+  ChatLegacyImportsTable,
+  ChatMigrationsTable,
+  ChatMessagesTable,
+  ChatOutboxTable,
+  ChatRunEventsTable,
+  ChatRunsTable,
+  ChatTurnsTable,
+  ChatsTable,
+} from "./database.js";
+
+export type ChatOwner = CanonicalOwnerScope;
+
+export interface ChatRecord {
+  chat: CanonicalChat;
+  projectId?: string;
+  providerBinding?: CanonicalChatProviderBinding;
+  activeRun?: NonNullable<CanonicalChatSummary["activeRun"]>;
+}
+
+export type ChatOutboxEventType =
+  | "chat.created"
+  | "chat.updated"
+  | "turn.accepted"
+  | "run.activity"
+  | "run.completed"
+  | "run.failed"
+  | "run.aborted"
+  | "chat.deleted"
+  | "migration.completed";
+
+export interface ChatOutboxEvent {
+  cursor: number;
+  chatId: string;
+  revision: number;
+  eventType: ChatOutboxEventType;
+  payload: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface ChatLegacyImportRecord {
+  sourceKind: string;
+  sourceId: string;
+  chatId: string;
+  sourceHash: string;
+  importVersion: number;
+  verificationStatus: "pending" | "verified" | "failed";
+  updatedAt: string;
+}
+
+export interface ChatMigrationRecord {
+  migrationId: string;
+  phase: string;
+  sourceFingerprint: string;
+  importedCount: number;
+  errorCount: number;
+  cutoverAt?: string;
+  legacyAliasExpiresAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ChatExport {
+  chat: ChatRecord;
+  messages: CanonicalChatMessage[];
+  turns: CanonicalChatTurn[];
+  runs: CanonicalChatRun[];
+  activities: CanonicalChatRunActivity[];
+  attachments: Array<{
+    id: string;
+    messageId: string;
+    kind: "file" | "image" | "diff" | "structured_ref";
+    label: string;
+    mimeType?: string;
+    sizeBytes?: number;
+  }>;
+}
+
+export function asIso(value: Date | string | null | undefined): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+export function parseJson<T>(value: unknown): T {
+  return (typeof value === "string" ? JSON.parse(value) : value) as T;
+}
+
+export function jsonb(value: unknown): RawBuilder<unknown> {
+  return sql`${JSON.stringify(value)}::jsonb`;
+}
+
+export function messageSearchText(message: CanonicalChatMessage): string {
+  return message.parts
+    .flatMap((part) => {
+      if (part.type === "text" || part.type === "summary") return [part.text];
+      if (part.type === "status") return [part.label, part.detail ?? ""];
+      return [];
+    })
+    .join("\n")
+    .slice(0, 96 * 1024);
+}
+
+export function toChatRecord(
+  row: Selectable<ChatsTable>,
+  activeRun?: Selectable<ChatRunsTable>,
+): ChatRecord {
+  const chat = CanonicalChatSchema.parse({
+    id: row.id,
+    ownerScope: { type: row.owner_type, ownerId: row.owner_id },
+    title: row.title,
+    lifecycle: row.lifecycle,
+    attention: row.attention,
+    revision: Number(row.revision),
+    messageCount: Number(row.message_count),
+    ...(row.collaboration === null ? {} : { collaboration: parseJson(row.collaboration) }),
+    ...(row.user_state === null ? {} : { userState: parseJson(row.user_state) }),
+    ...(row.shell_state === null ? {} : { shellState: parseJson(row.shell_state) }),
+    ...(row.fork_provenance === null ? {} : { forkProvenance: parseJson(row.fork_provenance) }),
+    ...(row.last_message_preview === null ? {} : { lastMessagePreview: row.last_message_preview }),
+    ...(row.current_selection === null ? {} : { currentSelection: parseJson(row.current_selection) }),
+    createdAt: asIso(row.created_at),
+    updatedAt: asIso(row.updated_at),
+  });
+  const providerBinding = row.bound_driver_kind && row.bound_instance_id && row.bound_at_turn_id
+    ? CanonicalChatProviderBindingSchema.parse({
+        driverKind: row.bound_driver_kind,
+        instanceId: row.bound_instance_id,
+        lockedAtTurnId: row.bound_at_turn_id,
+      })
+    : undefined;
+  return {
+    chat,
+    ...(row.project_id === null ? {} : { projectId: row.project_id }),
+    ...(providerBinding ? { providerBinding } : {}),
+    ...(activeRun ? {
+      activeRun: CanonicalChatActiveRunProjectionSchema.parse({
+        runId: activeRun.id,
+        turnId: activeRun.turn_id,
+        status: activeRun.status,
+      }),
+    } : {}),
+  };
+}
+
+export function toMessage(row: Selectable<ChatMessagesTable>): CanonicalChatMessage {
+  return CanonicalChatMessageSchema.parse({
+    id: row.id,
+    chatId: row.chat_id,
+    seq: Number(row.seq),
+    role: row.role,
+    state: row.state,
+    ...(row.turn_id === null ? {} : { turnId: row.turn_id }),
+    ...(row.run_id === null ? {} : { runId: row.run_id }),
+    parts: parseJson(row.parts),
+    createdAt: asIso(row.created_at),
+  });
+}
+
+export function toTurn(row: Selectable<ChatTurnsTable>): CanonicalChatTurn {
+  return CanonicalChatTurnSchema.parse({
+    id: row.id,
+    chatId: row.chat_id,
+    clientRequestId: row.client_request_id,
+    baseMessageSeq: Number(row.base_message_seq),
+    inputMessageId: row.input_message_id,
+    status: row.status,
+    createdAt: asIso(row.created_at),
+    updatedAt: asIso(row.updated_at),
+  });
+}
+
+export function toRun(row: Selectable<ChatRunsTable>): CanonicalChatRun {
+  return CanonicalChatRunSchema.parse({
+    id: row.id,
+    chatId: row.chat_id,
+    turnId: row.turn_id,
+    attempt: row.attempt,
+    driverKind: row.driver_kind,
+    instanceId: row.instance_id,
+    selection: parseJson(row.selection),
+    interactionMode: row.interaction_mode,
+    permissionMode: row.permission_mode,
+    ...(row.execution_root === null ? {} : { executionRoot: parseJson(row.execution_root) }),
+    status: row.status,
+    ...(row.outcome === null ? {} : { outcome: row.outcome }),
+    ...(row.started_at === null ? {} : { startedAt: asIso(row.started_at) }),
+    ...(row.completed_at === null ? {} : { completedAt: asIso(row.completed_at) }),
+    historyBoundarySeq: Number(row.history_boundary_seq),
+    capabilitySnapshot: parseJson(row.capability_snapshot),
+    createdAt: asIso(row.created_at),
+    updatedAt: asIso(row.updated_at),
+  });
+}
+
+export function toActivity(row: Selectable<ChatRunEventsTable>): CanonicalChatRunActivity {
+  return CanonicalChatRunActivitySchema.parse(parseJson(row.event));
+}
+
+export function toOutbox(row: Selectable<ChatOutboxTable>): ChatOutboxEvent {
+  return {
+    cursor: Number(row.cursor),
+    chatId: row.chat_id,
+    revision: Number(row.revision),
+    eventType: row.event_type as ChatOutboxEventType,
+    payload: parseJson<Record<string, unknown>>(row.payload),
+    createdAt: asIso(row.created_at) ?? new Date(0).toISOString(),
+  };
+}
+
+export function toLegacyImport(row: Selectable<ChatLegacyImportsTable>): ChatLegacyImportRecord {
+  return {
+    sourceKind: row.source_kind,
+    sourceId: row.source_id,
+    chatId: row.chat_id,
+    sourceHash: row.source_hash,
+    importVersion: row.import_version,
+    verificationStatus: row.verification_status,
+    updatedAt: asIso(row.updated_at) ?? new Date(0).toISOString(),
+  };
+}
+
+export function toMigration(row: Selectable<ChatMigrationsTable>): ChatMigrationRecord {
+  return {
+    migrationId: row.migration_id,
+    phase: row.phase,
+    sourceFingerprint: row.source_fingerprint,
+    importedCount: row.imported_count,
+    errorCount: row.error_count,
+    ...(row.cutover_at === null ? {} : { cutoverAt: asIso(row.cutover_at) }),
+    ...(row.legacy_alias_expires_at === null ? {} : { legacyAliasExpiresAt: asIso(row.legacy_alias_expires_at) }),
+    createdAt: asIso(row.created_at) ?? new Date(0).toISOString(),
+    updatedAt: asIso(row.updated_at) ?? new Date(0).toISOString(),
+  };
+}

--- a/packages/gateway/src/chat/repository.ts
+++ b/packages/gateway/src/chat/repository.ts
@@ -752,7 +752,20 @@ export class ChatRepository {
         owner_id: owner.ownerId,
         chat_id: input.chatId,
         request_id: input.clientRequestId,
-      }).returningAll().executeTakeFirstOrThrow();
+      }).onConflict((oc) => oc.columns(["owner_type", "owner_id", "request_id"]).doNothing())
+        .returningAll().executeTakeFirst();
+      if (!deletion) {
+        const conflictingRequest = await trx.selectFrom("chat_deletions").selectAll()
+          .where("owner_type", "=", owner.type).where("owner_id", "=", owner.ownerId)
+          .where("request_id", "=", input.clientRequestId).executeTakeFirst();
+        if (conflictingRequest?.chat_id === input.chatId) {
+          return {
+            chatId: conflictingRequest.chat_id,
+            deletedAt: asIso(conflictingRequest.deleted_at) ?? new Date(0).toISOString(),
+          };
+        }
+        throw new ChatConflictError(input.chatId, Number(chat.revision));
+      }
       await insertOutbox(trx, owner, input.chatId, Number(chat.revision) + 1, "chat.deleted");
       await trx.deleteFrom("chats").where("id", "=", input.chatId)
         .where("owner_type", "=", owner.type).where("owner_id", "=", owner.ownerId).execute();

--- a/packages/gateway/src/chat/repository.ts
+++ b/packages/gateway/src/chat/repository.ts
@@ -74,6 +74,16 @@ export interface AdmittedTurn {
   run: CanonicalChatRun;
 }
 
+export interface ChatListCursor {
+  updatedAt: string;
+  chatId: string;
+}
+
+export interface ChatListPage {
+  items: ChatRecord[];
+  nextCursor?: ChatListCursor;
+}
+
 export class ChatNotFoundError extends Error {
   constructor(readonly chatId: string) {
     super("Chat not found");
@@ -308,11 +318,13 @@ export class ChatRepository {
     limit: number;
     lifecycle?: "active" | "archived";
     projectId?: string | null;
-    cursor?: { updatedAt: string; chatId: string };
-  }): Promise<ChatRecord[]> {
+    cursor?: ChatListCursor;
+  }): Promise<ChatListPage> {
     const owner = validateOwner(ownerInput);
     const limit = Math.max(1, Math.min(100, Math.trunc(input.limit)));
     let query = this.kysely.selectFrom("chats").selectAll()
+      .select(sql<string>`to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`
+        .as("cursor_updated_at"))
       .where("owner_type", "=", owner.type)
       .where("owner_id", "=", owner.ownerId);
     if (input.lifecycle) query = query.where("lifecycle", "=", input.lifecycle);
@@ -320,15 +332,24 @@ export class ChatRepository {
       ? query.where("project_id", "is", null)
       : query.where("project_id", "=", requireSafeRef(input.projectId));
     if (input.cursor) {
-      const cursorAt = new Date(z.iso.datetime({ offset: true }).parse(input.cursor.updatedAt));
+      const cursorTimestamp = z.iso.datetime({ offset: true }).parse(input.cursor.updatedAt);
+      const cursorAt = sql<Date>`${cursorTimestamp}::timestamptz`;
       const cursorChatId = CanonicalChatIdSchema.parse(input.cursor.chatId);
       query = query.where(({ and, eb, or }) => or([
         eb("updated_at", "<", cursorAt),
         and([eb("updated_at", "=", cursorAt), eb("id", ">", cursorChatId)]),
       ]));
     }
-    const rows = await query.orderBy("updated_at", "desc").orderBy("id").limit(limit).execute();
-    return Promise.all(rows.map(async (row) => toChatRecord(row, await activeRunQuery(this.kysely, row.id))));
+    const rows = await query.orderBy("updated_at", "desc").orderBy("id").limit(limit + 1).execute();
+    const pageRows = rows.slice(0, limit);
+    const items = await Promise.all(pageRows.map(async (row) => (
+      toChatRecord(row, await activeRunQuery(this.kysely, row.id))
+    )));
+    const last = rows.length > limit ? pageRows.at(-1) : undefined;
+    return {
+      items,
+      ...(last ? { nextCursor: { updatedAt: last.cursor_updated_at, chatId: last.id } } : {}),
+    };
   }
 
   async update(ownerInput: ChatOwner, chatId: string, input: UpdateChatInput): Promise<ChatRecord> {
@@ -713,7 +734,18 @@ export class ChatRepository {
         return { chatId: priorChat.chat_id, deletedAt: asIso(priorChat.deleted_at) ?? new Date(0).toISOString() };
       }
       const chat = await selectOwnedChat(trx, owner, input.chatId, true);
-      if (!chat) throw new ChatNotFoundError(input.chatId);
+      if (!chat) {
+        const committedDeletion = await trx.selectFrom("chat_deletions").selectAll()
+          .where("owner_type", "=", owner.type).where("owner_id", "=", owner.ownerId)
+          .where("chat_id", "=", input.chatId).executeTakeFirst();
+        if (committedDeletion) {
+          return {
+            chatId: committedDeletion.chat_id,
+            deletedAt: asIso(committedDeletion.deleted_at) ?? new Date(0).toISOString(),
+          };
+        }
+        throw new ChatNotFoundError(input.chatId);
+      }
       if (await activeRunQuery(trx, input.chatId)) throw new ChatBusyError(input.chatId);
       const deletion = await trx.insertInto("chat_deletions").values({
         owner_type: owner.type,

--- a/packages/gateway/src/chat/repository.ts
+++ b/packages/gateway/src/chat/repository.ts
@@ -1,0 +1,793 @@
+import {
+  CanonicalChatIdSchema,
+  CanonicalChatMessageSchema,
+  CanonicalChatModelSelectionSchema,
+  CanonicalChatRequestIdSchema,
+  CanonicalChatRunActivitySchema,
+  CanonicalChatRunSchema,
+  CanonicalChatTurnSchema,
+  CanonicalOwnerScopeSchema,
+  type CanonicalChatMessage,
+  type CanonicalChatModelSelection,
+  type CanonicalChatRun,
+  type CanonicalChatRunActivity,
+  type CanonicalChatTurn,
+} from "@matrix-os/contracts";
+import { Kysely, sql, type Dialect, type Selectable, type Transaction } from "kysely";
+import { z } from "zod/v4";
+import { bootstrapChatDatabase, type ChatDatabase, type ChatRunsTable, type ChatsTable } from "./database.js";
+import {
+  asIso,
+  jsonb,
+  messageSearchText,
+  toActivity,
+  toChatRecord,
+  toLegacyImport,
+  toMessage,
+  toMigration,
+  toOutbox,
+  toRun,
+  toTurn,
+  type ChatExport,
+  type ChatLegacyImportRecord,
+  type ChatMigrationRecord,
+  type ChatOutboxEvent,
+  type ChatOutboxEventType,
+  type ChatOwner,
+  type ChatRecord,
+} from "./records.js";
+
+type Executor = Kysely<ChatDatabase> | Transaction<ChatDatabase>;
+const ACTIVE_RUNS = ["accepted", "running", "waiting_for_approval", "waiting_for_input"] as const;
+const SAFE_INTERNAL_REF = z.string().min(1).max(200).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/);
+const encoded = new TextEncoder();
+
+export interface CreateChatInput {
+  id: string;
+  clientRequestId: string;
+  title: string;
+  projectId?: string;
+  currentSelection?: CanonicalChatModelSelection;
+}
+
+export interface UpdateChatInput {
+  baseRevision: number;
+  title?: string;
+  projectId?: string | null;
+  lifecycle?: "active" | "archived";
+  currentSelection?: CanonicalChatModelSelection;
+}
+
+export interface AdmitTurnInput {
+  chatId: string;
+  baseRevision: number;
+  message: CanonicalChatMessage;
+  turn: CanonicalChatTurn;
+  run: CanonicalChatRun;
+  adapterState?: { schemaVersion: number; state: unknown };
+}
+
+export interface AdmittedTurn {
+  chat: ChatRecord;
+  message: CanonicalChatMessage;
+  turn: CanonicalChatTurn;
+  run: CanonicalChatRun;
+}
+
+export class ChatNotFoundError extends Error {
+  constructor(readonly chatId: string) {
+    super("Chat not found");
+    this.name = "ChatNotFoundError";
+  }
+}
+
+export class ChatConflictError extends Error {
+  constructor(readonly chatId: string, readonly latestRevision: number) {
+    super("Chat conflict");
+    this.name = "ChatConflictError";
+  }
+}
+
+export class ChatBusyError extends Error {
+  constructor(readonly chatId: string) {
+    super("Chat is busy");
+    this.name = "ChatBusyError";
+  }
+}
+
+export class ChatProviderInstanceLockedError extends Error {
+  constructor(readonly chatId: string) {
+    super("Provider Instance is locked");
+    this.name = "ChatProviderInstanceLockedError";
+  }
+}
+
+function validateOwner(owner: ChatOwner): ChatOwner {
+  return CanonicalOwnerScopeSchema.parse(owner);
+}
+
+function requireSafeRef(value: string): string {
+  return SAFE_INTERNAL_REF.parse(value);
+}
+
+function preview(message: CanonicalChatMessage): string | null {
+  const text = message.parts.find((part) => part.type === "text");
+  return text?.type === "text" ? text.text.slice(0, 280) : null;
+}
+
+function activeRunQuery(executor: Executor, chatId: string) {
+  return executor.selectFrom("chat_runs").selectAll()
+    .where("chat_id", "=", chatId)
+    .where("status", "in", [...ACTIVE_RUNS])
+    .executeTakeFirst();
+}
+
+async function insertOutbox(
+  executor: Executor,
+  owner: ChatOwner,
+  chatId: string,
+  revision: number,
+  eventType: ChatOutboxEventType,
+  payload: Record<string, unknown> = {},
+): Promise<void> {
+  await executor.insertInto("chat_outbox").values({
+    owner_type: owner.type,
+    owner_id: owner.ownerId,
+    chat_id: chatId,
+    revision,
+    event_type: eventType,
+    payload: jsonb(payload),
+  }).execute();
+}
+
+async function selectOwnedChat(
+  executor: Executor,
+  owner: ChatOwner,
+  chatId: string,
+  lock = false,
+): Promise<Selectable<ChatsTable> | undefined> {
+  let query = executor.selectFrom("chats").selectAll()
+    .where("id", "=", chatId)
+    .where("owner_type", "=", owner.type)
+    .where("owner_id", "=", owner.ownerId);
+  if (lock) query = query.forUpdate();
+  return query.executeTakeFirst();
+}
+
+async function hydrateRecord(
+  executor: Executor,
+  owner: ChatOwner,
+  chatId: string,
+): Promise<ChatRecord | null> {
+  const row = await selectOwnedChat(executor, owner, chatId);
+  if (!row) return null;
+  return toChatRecord(row, await activeRunQuery(executor, chatId));
+}
+
+async function hydrateAdmission(
+  executor: Executor,
+  owner: ChatOwner,
+  existingTurn: CanonicalChatTurn,
+): Promise<AdmittedTurn> {
+  const [chat, messageRow, runRow] = await Promise.all([
+    hydrateRecord(executor, owner, existingTurn.chatId),
+    executor.selectFrom("chat_messages").selectAll().where("id", "=", existingTurn.inputMessageId).executeTakeFirst(),
+    executor.selectFrom("chat_runs").selectAll().where("turn_id", "=", existingTurn.id).orderBy("attempt", "desc").executeTakeFirst(),
+  ]);
+  if (!chat || !messageRow || !runRow) throw new ChatNotFoundError(existingTurn.chatId);
+  return { chat, message: toMessage(messageRow), turn: existingTurn, run: toRun(runRow) };
+}
+
+export class ChatRepository {
+  readonly kysely: Kysely<ChatDatabase>;
+  private readonly transactionScoped: boolean;
+
+  constructor(dialectOrKysely: Dialect | Kysely<ChatDatabase>, transactionScoped = false) {
+    this.kysely = dialectOrKysely instanceof Kysely
+      ? dialectOrKysely
+      : new Kysely<ChatDatabase>({ dialect: dialectOrKysely });
+    this.transactionScoped = transactionScoped;
+  }
+
+  async bootstrap(): Promise<void> {
+    await bootstrapChatDatabase(this.kysely);
+  }
+
+  async release(): Promise<void> {
+    // The Gateway owns and closes the shared Kysely instance after Chat drains.
+  }
+
+  async withTransaction<T>(fn: (repository: ChatRepository) => Promise<T>): Promise<T> {
+    return this.transact((trx) => fn(new ChatRepository(trx, true)));
+  }
+
+  private async transact<T>(fn: (trx: Executor) => Promise<T>): Promise<T> {
+    if (this.transactionScoped) return fn(this.kysely);
+    return this.kysely.transaction().execute(fn);
+  }
+
+  async create(ownerInput: ChatOwner, input: CreateChatInput): Promise<ChatRecord> {
+    const owner = validateOwner(ownerInput);
+    CanonicalChatIdSchema.parse(input.id);
+    CanonicalChatRequestIdSchema.parse(input.clientRequestId);
+    if (input.projectId !== undefined) requireSafeRef(input.projectId);
+    if (input.currentSelection !== undefined) CanonicalChatModelSelectionSchema.parse(input.currentSelection);
+    const timestamp = new Date().toISOString();
+
+    return this.transact(async (trx) => {
+      const candidate = toChatRecord({
+        id: input.id,
+        owner_type: owner.type,
+        owner_id: owner.ownerId,
+        create_request_id: input.clientRequestId,
+        project_id: input.projectId ?? null,
+        title: input.title,
+        lifecycle: "active",
+        attention: "none",
+        revision: 0,
+        message_count: 0,
+        collaboration: null,
+        user_state: null,
+        shell_state: null,
+        fork_provenance: null,
+        last_message_preview: null,
+        current_selection: input.currentSelection ?? null,
+        bound_driver_kind: null,
+        bound_instance_id: null,
+        bound_at_turn_id: null,
+        created_at: timestamp,
+        updated_at: timestamp,
+      });
+      const inserted = await trx.insertInto("chats").values({
+        id: candidate.chat.id,
+        owner_type: owner.type,
+        owner_id: owner.ownerId,
+        create_request_id: input.clientRequestId,
+        project_id: input.projectId ?? null,
+        title: candidate.chat.title,
+        lifecycle: candidate.chat.lifecycle,
+        attention: candidate.chat.attention,
+        revision: 0,
+        message_count: 0,
+        collaboration: null,
+        user_state: null,
+        shell_state: null,
+        fork_provenance: null,
+        last_message_preview: null,
+        current_selection: input.currentSelection ? jsonb(input.currentSelection) : null,
+        bound_driver_kind: null,
+        bound_instance_id: null,
+        bound_at_turn_id: null,
+      }).onConflict((oc) => oc.columns(["owner_type", "owner_id", "create_request_id"]).doNothing())
+        .returningAll().executeTakeFirst();
+
+      if (!inserted) {
+        const existing = await trx.selectFrom("chats").selectAll()
+          .where("owner_type", "=", owner.type)
+          .where("owner_id", "=", owner.ownerId)
+          .where("create_request_id", "=", input.clientRequestId)
+          .executeTakeFirst();
+        if (!existing) throw new ChatConflictError(input.id, 0);
+        return toChatRecord(existing, await activeRunQuery(trx, existing.id));
+      }
+
+      await trx.insertInto("chat_members").values({
+        chat_id: inserted.id,
+        principal_type: owner.type === "organization" ? "organization" : "user",
+        principal_id: owner.ownerId,
+        role: "owner",
+      }).execute();
+      await trx.insertInto("chat_user_state").values({
+        chat_id: inserted.id,
+        principal_id: owner.ownerId,
+        read_through_seq: 0,
+        pinned: false,
+        muted: false,
+        attention_acknowledged_at: null,
+        last_opened_at: null,
+      }).execute();
+      await insertOutbox(trx, owner, inserted.id, 0, "chat.created");
+      return toChatRecord(inserted);
+    });
+  }
+
+  async get(ownerInput: ChatOwner, chatId: string): Promise<ChatRecord | null> {
+    const owner = validateOwner(ownerInput);
+    CanonicalChatIdSchema.parse(chatId);
+    return hydrateRecord(this.kysely, owner, chatId);
+  }
+
+  async list(ownerInput: ChatOwner, input: {
+    limit: number;
+    lifecycle?: "active" | "archived";
+    projectId?: string | null;
+    beforeUpdatedAt?: string;
+  }): Promise<ChatRecord[]> {
+    const owner = validateOwner(ownerInput);
+    const limit = Math.max(1, Math.min(100, Math.trunc(input.limit)));
+    let query = this.kysely.selectFrom("chats").selectAll()
+      .where("owner_type", "=", owner.type)
+      .where("owner_id", "=", owner.ownerId);
+    if (input.lifecycle) query = query.where("lifecycle", "=", input.lifecycle);
+    if (input.projectId !== undefined) query = input.projectId === null
+      ? query.where("project_id", "is", null)
+      : query.where("project_id", "=", requireSafeRef(input.projectId));
+    if (input.beforeUpdatedAt) query = query.where("updated_at", "<", new Date(input.beforeUpdatedAt));
+    const rows = await query.orderBy("updated_at", "desc").orderBy("id").limit(limit).execute();
+    return Promise.all(rows.map(async (row) => toChatRecord(row, await activeRunQuery(this.kysely, row.id))));
+  }
+
+  async update(ownerInput: ChatOwner, chatId: string, input: UpdateChatInput): Promise<ChatRecord> {
+    const owner = validateOwner(ownerInput);
+    CanonicalChatIdSchema.parse(chatId);
+    if (input.currentSelection) CanonicalChatModelSelectionSchema.parse(input.currentSelection);
+    if (typeof input.projectId === "string") requireSafeRef(input.projectId);
+
+    return this.transact(async (trx) => {
+      const current = await selectOwnedChat(trx, owner, chatId, true);
+      if (!current) throw new ChatNotFoundError(chatId);
+      if (Number(current.revision) !== input.baseRevision) {
+        throw new ChatConflictError(chatId, Number(current.revision));
+      }
+      const contextChanges = ("projectId" in input && (input.projectId ?? null) !== current.project_id)
+        || (input.lifecycle !== undefined && input.lifecycle !== current.lifecycle);
+      if (contextChanges && await activeRunQuery(trx, chatId)) throw new ChatBusyError(chatId);
+      if (current.bound_instance_id && input.currentSelection
+        && input.currentSelection.instanceId !== current.bound_instance_id) {
+        throw new ChatProviderInstanceLockedError(chatId);
+      }
+
+      const revision = input.baseRevision + 1;
+      const updated = await trx.updateTable("chats").set({
+        ...(input.title === undefined ? {} : { title: input.title }),
+        ...("projectId" in input ? { project_id: input.projectId ?? null } : {}),
+        ...(input.lifecycle === undefined ? {} : { lifecycle: input.lifecycle }),
+        ...(input.currentSelection === undefined ? {} : { current_selection: jsonb(input.currentSelection) }),
+        revision,
+        updated_at: sql`now()`,
+      }).where("id", "=", chatId)
+        .where("owner_type", "=", owner.type)
+        .where("owner_id", "=", owner.ownerId)
+        .where("revision", "=", input.baseRevision)
+        .returningAll().executeTakeFirst();
+      if (!updated) throw new ChatConflictError(chatId, Number(current.revision));
+      const record = toChatRecord(updated, await activeRunQuery(trx, chatId));
+      await insertOutbox(trx, owner, chatId, record.chat.revision, "chat.updated");
+      return record;
+    });
+  }
+
+  async admitTurn(ownerInput: ChatOwner, input: AdmitTurnInput): Promise<AdmittedTurn> {
+    const owner = validateOwner(ownerInput);
+    CanonicalChatIdSchema.parse(input.chatId);
+    const message = CanonicalChatMessageSchema.parse(input.message);
+    const turn = CanonicalChatTurnSchema.parse(input.turn);
+    const run = CanonicalChatRunSchema.parse(input.run);
+    if (message.chatId !== input.chatId || turn.chatId !== input.chatId || run.chatId !== input.chatId
+      || turn.inputMessageId !== message.id || message.turnId !== turn.id || message.runId !== undefined
+      || message.role !== "user" || message.state !== "committed" || run.turnId !== turn.id) {
+      throw new ChatConflictError(input.chatId, input.baseRevision);
+    }
+    if (turn.status !== "accepted" || run.status !== "accepted") throw new ChatConflictError(input.chatId, input.baseRevision);
+    const stateBytes = input.adapterState ? encoded.encode(JSON.stringify(input.adapterState.state)).byteLength : 0;
+    if (input.adapterState && (!Number.isInteger(input.adapterState.schemaVersion)
+      || input.adapterState.schemaVersion < 1 || stateBytes > 64 * 1024)) {
+      throw new ChatConflictError(input.chatId, input.baseRevision);
+    }
+
+    return this.transact(async (trx) => {
+      const duplicate = await trx.selectFrom("chat_turns").selectAll()
+        .where("chat_id", "=", input.chatId)
+        .where("client_request_id", "=", turn.clientRequestId)
+        .executeTakeFirst();
+      if (duplicate) return hydrateAdmission(trx, owner, toTurn(duplicate));
+
+      const current = await selectOwnedChat(trx, owner, input.chatId, true);
+      if (!current) throw new ChatNotFoundError(input.chatId);
+      if (Number(current.revision) !== input.baseRevision) {
+        throw new ChatConflictError(input.chatId, Number(current.revision));
+      }
+      if (await activeRunQuery(trx, input.chatId)) throw new ChatBusyError(input.chatId);
+      if (current.bound_instance_id && (current.bound_instance_id !== run.instanceId
+        || current.bound_driver_kind !== run.driverKind)) {
+        throw new ChatProviderInstanceLockedError(input.chatId);
+      }
+      const latest = await trx.selectFrom("chat_messages")
+        .select(({ fn }) => fn.max("seq").as("seq"))
+        .where("chat_id", "=", input.chatId).executeTakeFirst();
+      const lastSeq = Number(latest?.seq ?? 0);
+      if (message.seq !== lastSeq + 1 || turn.baseMessageSeq !== lastSeq) {
+        throw new ChatConflictError(input.chatId, Number(current.revision));
+      }
+
+      await trx.insertInto("chat_messages").values({
+        id: message.id,
+        chat_id: input.chatId,
+        seq: message.seq,
+        role: message.role,
+        state: message.state,
+        turn_id: message.turnId ?? null,
+        run_id: message.runId ?? null,
+        parts: jsonb(message.parts),
+        byte_count: encoded.encode(JSON.stringify(message)).byteLength,
+        search_text: messageSearchText(message),
+        created_at: message.createdAt,
+      }).execute();
+      for (const part of message.parts) {
+        if (part.type !== "attachment_reference") continue;
+        await trx.insertInto("chat_attachments").values({
+          id: part.attachmentId,
+          chat_id: input.chatId,
+          message_id: message.id,
+          kind: part.kind,
+          label: part.label,
+          mime_type: part.mimeType ?? null,
+          size_bytes: part.sizeBytes ?? null,
+          owner_reference: null,
+        }).execute();
+      }
+      await trx.insertInto("chat_turns").values({
+        id: turn.id,
+        chat_id: input.chatId,
+        client_request_id: turn.clientRequestId,
+        base_message_seq: turn.baseMessageSeq,
+        input_message_id: turn.inputMessageId,
+        status: turn.status,
+        created_at: turn.createdAt,
+        updated_at: turn.updatedAt,
+      }).execute();
+      await trx.insertInto("chat_runs").values({
+        id: run.id,
+        chat_id: input.chatId,
+        turn_id: run.turnId,
+        attempt: run.attempt,
+        driver_kind: run.driverKind,
+        instance_id: run.instanceId,
+        selection: jsonb(run.selection),
+        interaction_mode: run.interactionMode,
+        permission_mode: run.permissionMode,
+        execution_root: run.executionRoot ? jsonb(run.executionRoot) : null,
+        status: run.status,
+        outcome: run.outcome ?? null,
+        started_at: run.startedAt ?? null,
+        completed_at: run.completedAt ?? null,
+        history_boundary_seq: run.historyBoundarySeq,
+        capability_snapshot: jsonb(run.capabilitySnapshot),
+        created_at: run.createdAt,
+        updated_at: run.updatedAt,
+      }).execute();
+      if (input.adapterState) {
+        await trx.insertInto("chat_run_adapter_state").values({
+          run_id: run.id,
+          driver_kind: run.driverKind,
+          instance_id: run.instanceId,
+          schema_version: input.adapterState.schemaVersion,
+          state: jsonb(input.adapterState.state),
+          byte_count: stateBytes,
+        }).execute();
+      }
+
+      const revision = input.baseRevision + 1;
+      const updated = await trx.updateTable("chats").set({
+        revision,
+        message_count: sql<number>`message_count + 1`,
+        last_message_preview: preview(message),
+        current_selection: jsonb(run.selection),
+        bound_driver_kind: current.bound_driver_kind ?? run.driverKind,
+        bound_instance_id: current.bound_instance_id ?? run.instanceId,
+        bound_at_turn_id: current.bound_at_turn_id ?? turn.id,
+        updated_at: sql`now()`,
+      }).where("id", "=", input.chatId).where("revision", "=", input.baseRevision)
+        .returningAll().executeTakeFirst();
+      if (!updated) throw new ChatConflictError(input.chatId, Number(current.revision));
+      await insertOutbox(trx, owner, input.chatId, revision, "turn.accepted", { runId: run.id, turnId: turn.id });
+      return {
+        chat: toChatRecord(updated, await activeRunQuery(trx, input.chatId)),
+        message,
+        turn,
+        run,
+      };
+    }).catch((error: unknown) => {
+      if (error instanceof ChatNotFoundError || error instanceof ChatConflictError
+        || error instanceof ChatBusyError || error instanceof ChatProviderInstanceLockedError) throw error;
+      if (typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "23505") {
+        throw new ChatBusyError(input.chatId);
+      }
+      throw error;
+    });
+  }
+
+  async getMessages(ownerInput: ChatOwner, chatId: string, input: {
+    afterSeq: number;
+    limit: number;
+  }): Promise<CanonicalChatMessage[]> {
+    const owner = validateOwner(ownerInput);
+    if (!await selectOwnedChat(this.kysely, owner, CanonicalChatIdSchema.parse(chatId))) return [];
+    const limit = Math.max(1, Math.min(200, Math.trunc(input.limit)));
+    const rows = await this.kysely.selectFrom("chat_messages").selectAll()
+      .where("chat_id", "=", chatId).where("seq", ">", Math.max(0, Math.trunc(input.afterSeq)))
+      .orderBy("seq").limit(limit).execute();
+    return rows.map(toMessage);
+  }
+
+  async getAdapterState(ownerInput: ChatOwner, input: {
+    runId: string;
+    driverKind: string;
+    instanceId: string;
+  }): Promise<{ schemaVersion: number; state: unknown } | null> {
+    const owner = validateOwner(ownerInput);
+    [input.runId, input.driverKind, input.instanceId].forEach(requireSafeRef);
+    const row = await this.kysely.selectFrom("chat_run_adapter_state")
+      .innerJoin("chat_runs", "chat_runs.id", "chat_run_adapter_state.run_id")
+      .innerJoin("chats", "chats.id", "chat_runs.chat_id")
+      .select(["chat_run_adapter_state.schema_version", "chat_run_adapter_state.state"])
+      .where("chats.owner_type", "=", owner.type)
+      .where("chats.owner_id", "=", owner.ownerId)
+      .where("chat_run_adapter_state.run_id", "=", input.runId)
+      .where("chat_run_adapter_state.driver_kind", "=", input.driverKind)
+      .where("chat_run_adapter_state.instance_id", "=", input.instanceId)
+      .executeTakeFirst();
+    if (!row) return null;
+    return {
+      schemaVersion: row.schema_version,
+      state: typeof row.state === "string" ? JSON.parse(row.state) : row.state,
+    };
+  }
+
+  async appendRunActivities(
+    ownerInput: ChatOwner,
+    chatId: string,
+    runId: string,
+    input: CanonicalChatRunActivity[],
+  ): Promise<number> {
+    const owner = validateOwner(ownerInput);
+    if (input.length > 100) throw new ChatConflictError(chatId, 0);
+    const activities = input.map((activity) => CanonicalChatRunActivitySchema.parse(activity));
+    if (activities.some((activity) => activity.chatId !== chatId || activity.runId !== runId)) {
+      throw new ChatConflictError(chatId, 0);
+    }
+    return this.transact(async (trx) => {
+      const current = await selectOwnedChat(trx, owner, CanonicalChatIdSchema.parse(chatId), true);
+      if (!current) throw new ChatNotFoundError(chatId);
+      const run = await trx.selectFrom("chat_runs").select("id")
+        .where("id", "=", runId).where("chat_id", "=", chatId).executeTakeFirst();
+      if (!run) throw new ChatNotFoundError(chatId);
+      const count = await trx.selectFrom("chat_run_events").select(({ fn }) => fn.countAll().as("count"))
+        .where("run_id", "=", runId).executeTakeFirstOrThrow();
+      if (Number(count.count) + activities.length > 500) throw new ChatConflictError(chatId, Number(current.revision));
+      let inserted = 0;
+      for (const activity of activities) {
+        const row = await trx.insertInto("chat_run_events").values({
+          id: activity.id,
+          chat_id: chatId,
+          run_id: runId,
+          event: jsonb(activity),
+          occurred_at: activity.occurredAt,
+        }).onConflict((oc) => oc.column("id").doNothing()).returning("id").executeTakeFirst();
+        if (row) inserted += 1;
+      }
+      if (inserted > 0) {
+        const revision = Number(current.revision) + 1;
+        await trx.updateTable("chats").set({ revision, updated_at: sql`now()` }).where("id", "=", chatId).execute();
+        await insertOutbox(trx, owner, chatId, revision, "run.activity", { runId });
+      }
+      return inserted;
+    });
+  }
+
+  async finishRun(ownerInput: ChatOwner, input: {
+    chatId: string;
+    runId: string;
+    outcome: "completed" | "failed" | "aborted";
+    completedAt: string;
+  }): Promise<CanonicalChatRun> {
+    const owner = validateOwner(ownerInput);
+    const completedAt = new Date(input.completedAt).toISOString();
+    return this.transact(async (trx) => {
+      const chat = await selectOwnedChat(trx, owner, CanonicalChatIdSchema.parse(input.chatId), true);
+      if (!chat) throw new ChatNotFoundError(input.chatId);
+      const current = await trx.selectFrom("chat_runs").selectAll()
+        .where("id", "=", input.runId).where("chat_id", "=", input.chatId).forUpdate().executeTakeFirst();
+      if (!current) throw new ChatNotFoundError(input.chatId);
+      if (!ACTIVE_RUNS.includes(current.status as typeof ACTIVE_RUNS[number])) {
+        return toRun(current);
+      }
+      const updated = await trx.updateTable("chat_runs").set({
+        status: input.outcome,
+        outcome: input.outcome,
+        started_at: current.started_at ?? completedAt,
+        completed_at: completedAt,
+        updated_at: completedAt,
+      }).where("id", "=", input.runId).where("status", "in", [...ACTIVE_RUNS])
+        .returningAll().executeTakeFirst();
+      if (!updated) throw new ChatBusyError(input.chatId);
+      await trx.updateTable("chat_turns").set({ status: input.outcome, updated_at: completedAt })
+        .where("id", "=", updated.turn_id).execute();
+      const revision = Number(chat.revision) + 1;
+      await trx.updateTable("chats").set({
+        revision,
+        attention: input.outcome === "failed" ? "failed" : "none",
+        updated_at: completedAt,
+      }).where("id", "=", input.chatId).execute();
+      await insertOutbox(trx, owner, input.chatId, revision, `run.${input.outcome}` as ChatOutboxEventType, { runId: input.runId });
+      return toRun(updated);
+    });
+  }
+
+  async replayOutbox(ownerInput: ChatOwner, input: {
+    afterCursor: number;
+    limit: number;
+  }): Promise<ChatOutboxEvent[]> {
+    const owner = validateOwner(ownerInput);
+    const rows = await this.kysely.selectFrom("chat_outbox").selectAll()
+      .where("owner_type", "=", owner.type).where("owner_id", "=", owner.ownerId)
+      .where("cursor", ">", Math.max(0, Math.trunc(input.afterCursor)))
+      .orderBy("cursor").limit(Math.max(1, Math.min(100, Math.trunc(input.limit)))).execute();
+    return rows.map(toOutbox);
+  }
+
+  async search(ownerInput: ChatOwner, queryInput: string, limitInput = 20): Promise<ChatRecord[]> {
+    const owner = validateOwner(ownerInput);
+    const query = queryInput.trim().slice(0, 200);
+    if (!query) return [];
+    const rows = await this.kysely.selectFrom("chats")
+      .innerJoin("chat_messages", "chat_messages.chat_id", "chats.id")
+      .selectAll("chats")
+      .distinct()
+      .where("chats.owner_type", "=", owner.type).where("chats.owner_id", "=", owner.ownerId)
+      .where("chat_messages.state", "=", "committed")
+      .where(sql<boolean>`to_tsvector('simple', chat_messages.search_text) @@ plainto_tsquery('simple', ${query})`)
+      .orderBy("chats.updated_at", "desc").limit(Math.max(1, Math.min(100, Math.trunc(limitInput)))).execute();
+    return Promise.all(rows.map(async (row) => toChatRecord(row, await activeRunQuery(this.kysely, row.id))));
+  }
+
+  async exportChat(ownerInput: ChatOwner, chatId: string): Promise<ChatExport | null> {
+    const owner = validateOwner(ownerInput);
+    const chat = await hydrateRecord(this.kysely, owner, CanonicalChatIdSchema.parse(chatId));
+    if (!chat) return null;
+    const [messages, turns, runs, activities, attachments] = await Promise.all([
+      this.kysely.selectFrom("chat_messages").selectAll().where("chat_id", "=", chatId).orderBy("seq").execute(),
+      this.kysely.selectFrom("chat_turns").selectAll().where("chat_id", "=", chatId).orderBy("created_at").execute(),
+      this.kysely.selectFrom("chat_runs").selectAll().where("chat_id", "=", chatId).orderBy("created_at").execute(),
+      this.kysely.selectFrom("chat_run_events").selectAll().where("chat_id", "=", chatId).orderBy("occurred_at").execute(),
+      this.kysely.selectFrom("chat_attachments").selectAll().where("chat_id", "=", chatId).orderBy("created_at").execute(),
+    ]);
+    return {
+      chat,
+      messages: messages.map(toMessage),
+      turns: turns.map(toTurn),
+      runs: runs.map(toRun),
+      activities: activities.map(toActivity),
+      attachments: attachments.map((row) => ({
+        id: row.id,
+        messageId: row.message_id,
+        kind: row.kind,
+        label: row.label,
+        ...(row.mime_type === null ? {} : { mimeType: row.mime_type }),
+        ...(row.size_bytes === null ? {} : { sizeBytes: row.size_bytes }),
+      })),
+    };
+  }
+
+  async hardDelete(ownerInput: ChatOwner, input: {
+    chatId: string;
+    clientRequestId: string;
+  }): Promise<{ chatId: string; deletedAt: string }> {
+    const owner = validateOwner(ownerInput);
+    CanonicalChatIdSchema.parse(input.chatId);
+    CanonicalChatRequestIdSchema.parse(input.clientRequestId);
+    return this.transact(async (trx) => {
+      const prior = await trx.selectFrom("chat_deletions").selectAll()
+        .where("owner_type", "=", owner.type).where("owner_id", "=", owner.ownerId)
+        .where("chat_id", "=", input.chatId).where("request_id", "=", input.clientRequestId)
+        .executeTakeFirst();
+      if (prior) return { chatId: prior.chat_id, deletedAt: asIso(prior.deleted_at) ?? new Date(0).toISOString() };
+      const chat = await selectOwnedChat(trx, owner, input.chatId, true);
+      if (!chat) throw new ChatNotFoundError(input.chatId);
+      if (await activeRunQuery(trx, input.chatId)) throw new ChatBusyError(input.chatId);
+      const deletion = await trx.insertInto("chat_deletions").values({
+        owner_type: owner.type,
+        owner_id: owner.ownerId,
+        chat_id: input.chatId,
+        request_id: input.clientRequestId,
+      }).returningAll().executeTakeFirstOrThrow();
+      await insertOutbox(trx, owner, input.chatId, Number(chat.revision) + 1, "chat.deleted");
+      await trx.deleteFrom("chats").where("id", "=", input.chatId)
+        .where("owner_type", "=", owner.type).where("owner_id", "=", owner.ownerId).execute();
+      return { chatId: input.chatId, deletedAt: asIso(deletion.deleted_at) ?? new Date(0).toISOString() };
+    });
+  }
+
+  async upsertLegacyImport(ownerInput: ChatOwner, input: {
+    sourceKind: string;
+    sourceId: string;
+    chatId: string;
+    sourceHash: string;
+    importVersion: number;
+    verificationStatus: "pending" | "verified" | "failed";
+  }): Promise<ChatLegacyImportRecord> {
+    const owner = validateOwner(ownerInput);
+    [input.sourceKind, input.sourceId, input.sourceHash].forEach(requireSafeRef);
+    CanonicalChatIdSchema.parse(input.chatId);
+    const row = await this.kysely.insertInto("chat_legacy_imports").values({
+      owner_type: owner.type,
+      owner_id: owner.ownerId,
+      source_kind: input.sourceKind,
+      source_id: input.sourceId,
+      chat_id: input.chatId,
+      source_hash: input.sourceHash,
+      import_version: input.importVersion,
+      verification_status: input.verificationStatus,
+    }).onConflict((oc) => oc.columns(["owner_type", "owner_id", "source_kind", "source_id"]).doUpdateSet({
+      chat_id: input.chatId,
+      source_hash: input.sourceHash,
+      import_version: input.importVersion,
+      verification_status: input.verificationStatus,
+      updated_at: sql`now()`,
+    })).returningAll().executeTakeFirstOrThrow();
+    return toLegacyImport(row);
+  }
+
+  async getLegacyImport(ownerInput: ChatOwner, sourceKind: string, sourceId: string): Promise<ChatLegacyImportRecord | null> {
+    const owner = validateOwner(ownerInput);
+    const row = await this.kysely.selectFrom("chat_legacy_imports").selectAll()
+      .where("owner_type", "=", owner.type).where("owner_id", "=", owner.ownerId)
+      .where("source_kind", "=", requireSafeRef(sourceKind)).where("source_id", "=", requireSafeRef(sourceId))
+      .executeTakeFirst();
+    return row ? toLegacyImport(row) : null;
+  }
+
+  async recordMigration(ownerInput: ChatOwner, input: {
+    migrationId: string;
+    phase: string;
+    sourceFingerprint: string;
+    importedCount: number;
+    errorCount: number;
+    cutoverAt?: string;
+    legacyAliasExpiresAt?: string;
+  }): Promise<ChatMigrationRecord> {
+    const owner = validateOwner(ownerInput);
+    [input.migrationId, input.phase, input.sourceFingerprint].forEach(requireSafeRef);
+    const row = await this.kysely.insertInto("chat_migrations").values({
+      owner_type: owner.type,
+      owner_id: owner.ownerId,
+      migration_id: input.migrationId,
+      phase: input.phase,
+      source_fingerprint: input.sourceFingerprint,
+      imported_count: input.importedCount,
+      error_count: input.errorCount,
+      cutover_at: input.cutoverAt ?? null,
+      legacy_alias_expires_at: input.legacyAliasExpiresAt ?? null,
+    }).onConflict((oc) => oc.columns(["owner_type", "owner_id", "migration_id"]).doUpdateSet({
+      phase: input.phase,
+      source_fingerprint: input.sourceFingerprint,
+      imported_count: input.importedCount,
+      error_count: input.errorCount,
+      cutover_at: input.cutoverAt ?? null,
+      legacy_alias_expires_at: input.legacyAliasExpiresAt ?? null,
+      updated_at: sql`now()`,
+    })).returningAll().executeTakeFirstOrThrow();
+    return toMigration(row);
+  }
+
+  async getMigration(ownerInput: ChatOwner, migrationId: string): Promise<ChatMigrationRecord | null> {
+    const owner = validateOwner(ownerInput);
+    const row = await this.kysely.selectFrom("chat_migrations").selectAll()
+      .where("owner_type", "=", owner.type).where("owner_id", "=", owner.ownerId)
+      .where("migration_id", "=", requireSafeRef(migrationId)).executeTakeFirst();
+    return row ? toMigration(row) : null;
+  }
+
+  async pruneOutbox(ownerInput: ChatOwner, beforeCursor: number, limitInput = 1_000): Promise<number> {
+    const owner = validateOwner(ownerInput);
+    const rows = await this.kysely.selectFrom("chat_outbox").select("cursor")
+      .where("owner_type", "=", owner.type).where("owner_id", "=", owner.ownerId)
+      .where("cursor", "<", Math.max(0, Math.trunc(beforeCursor))).orderBy("cursor")
+      .limit(Math.max(1, Math.min(1_000, Math.trunc(limitInput)))).execute();
+    if (rows.length === 0) return 0;
+    const result = await this.kysely.deleteFrom("chat_outbox").where("cursor", "in", rows.map((row) => row.cursor)).executeTakeFirst();
+    return Number(result.numDeletedRows);
+  }
+}
+
+export type { ChatDatabase, ChatExport, ChatOutboxEvent, ChatOwner, ChatRecord };

--- a/packages/gateway/src/chat/repository.ts
+++ b/packages/gateway/src/chat/repository.ts
@@ -110,6 +110,13 @@ function requireSafeRef(value: string): string {
   return SAFE_INTERNAL_REF.parse(value);
 }
 
+function postgresUniqueConstraint(error: unknown): string | null {
+  if (typeof error !== "object" || error === null || !("code" in error)
+    || (error as { code?: unknown }).code !== "23505") return null;
+  const constraint = "constraint" in error ? (error as { constraint?: unknown }).constraint : undefined;
+  return typeof constraint === "string" ? constraint : "";
+}
+
 function preview(message: CanonicalChatMessage): string | null {
   const text = message.parts.find((part) => part.type === "text");
   return text?.type === "text" ? text.text.slice(0, 280) : null;
@@ -301,7 +308,7 @@ export class ChatRepository {
     limit: number;
     lifecycle?: "active" | "archived";
     projectId?: string | null;
-    beforeUpdatedAt?: string;
+    cursor?: { updatedAt: string; chatId: string };
   }): Promise<ChatRecord[]> {
     const owner = validateOwner(ownerInput);
     const limit = Math.max(1, Math.min(100, Math.trunc(input.limit)));
@@ -312,7 +319,14 @@ export class ChatRepository {
     if (input.projectId !== undefined) query = input.projectId === null
       ? query.where("project_id", "is", null)
       : query.where("project_id", "=", requireSafeRef(input.projectId));
-    if (input.beforeUpdatedAt) query = query.where("updated_at", "<", new Date(input.beforeUpdatedAt));
+    if (input.cursor) {
+      const cursorAt = new Date(z.iso.datetime({ offset: true }).parse(input.cursor.updatedAt));
+      const cursorChatId = CanonicalChatIdSchema.parse(input.cursor.chatId);
+      query = query.where(({ and, eb, or }) => or([
+        eb("updated_at", "<", cursorAt),
+        and([eb("updated_at", "=", cursorAt), eb("id", ">", cursorChatId)]),
+      ]));
+    }
     const rows = await query.orderBy("updated_at", "desc").orderBy("id").limit(limit).execute();
     return Promise.all(rows.map(async (row) => toChatRecord(row, await activeRunQuery(this.kysely, row.id))));
   }
@@ -376,14 +390,13 @@ export class ChatRepository {
     }
 
     return this.transact(async (trx) => {
+      const current = await selectOwnedChat(trx, owner, input.chatId, true);
+      if (!current) throw new ChatNotFoundError(input.chatId);
       const duplicate = await trx.selectFrom("chat_turns").selectAll()
         .where("chat_id", "=", input.chatId)
         .where("client_request_id", "=", turn.clientRequestId)
         .executeTakeFirst();
       if (duplicate) return hydrateAdmission(trx, owner, toTurn(duplicate));
-
-      const current = await selectOwnedChat(trx, owner, input.chatId, true);
-      if (!current) throw new ChatNotFoundError(input.chatId);
       if (Number(current.revision) !== input.baseRevision) {
         throw new ChatConflictError(input.chatId, Number(current.revision));
       }
@@ -490,9 +503,9 @@ export class ChatRepository {
     }).catch((error: unknown) => {
       if (error instanceof ChatNotFoundError || error instanceof ChatConflictError
         || error instanceof ChatBusyError || error instanceof ChatProviderInstanceLockedError) throw error;
-      if (typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "23505") {
-        throw new ChatBusyError(input.chatId);
-      }
+      const constraint = postgresUniqueConstraint(error);
+      if (constraint === "idx_chat_runs_one_active") throw new ChatBusyError(input.chatId);
+      if (constraint !== null) throw new ChatConflictError(input.chatId, input.baseRevision);
       throw error;
     });
   }
@@ -546,6 +559,7 @@ export class ChatRepository {
     if (activities.some((activity) => activity.chatId !== chatId || activity.runId !== runId)) {
       throw new ChatConflictError(chatId, 0);
     }
+    if (activities.length === 0) return 0;
     return this.transact(async (trx) => {
       const current = await selectOwnedChat(trx, owner, CanonicalChatIdSchema.parse(chatId), true);
       if (!current) throw new ChatNotFoundError(chatId);
@@ -554,7 +568,14 @@ export class ChatRepository {
       if (!run) throw new ChatNotFoundError(chatId);
       const count = await trx.selectFrom("chat_run_events").select(({ fn }) => fn.countAll().as("count"))
         .where("run_id", "=", runId).executeTakeFirstOrThrow();
-      if (Number(count.count) + activities.length > 500) throw new ChatConflictError(chatId, Number(current.revision));
+      const activityIds = [...new Set(activities.map((activity) => activity.id))];
+      const existing = await trx.selectFrom("chat_run_events").select(["id", "chat_id", "run_id"])
+        .where("id", "in", activityIds).execute();
+      if (existing.some((row) => row.chat_id !== chatId || row.run_id !== runId)) {
+        throw new ChatConflictError(chatId, Number(current.revision));
+      }
+      const unseenCount = activityIds.length - existing.length;
+      if (Number(count.count) + unseenCount > 500) throw new ChatConflictError(chatId, Number(current.revision));
       let inserted = 0;
       for (const activity of activities) {
         const row = await trx.insertInto("chat_run_events").values({
@@ -677,11 +698,20 @@ export class ChatRepository {
     CanonicalChatIdSchema.parse(input.chatId);
     CanonicalChatRequestIdSchema.parse(input.clientRequestId);
     return this.transact(async (trx) => {
-      const prior = await trx.selectFrom("chat_deletions").selectAll()
+      const priorRequest = await trx.selectFrom("chat_deletions").selectAll()
         .where("owner_type", "=", owner.type).where("owner_id", "=", owner.ownerId)
-        .where("chat_id", "=", input.chatId).where("request_id", "=", input.clientRequestId)
+        .where("request_id", "=", input.clientRequestId)
         .executeTakeFirst();
-      if (prior) return { chatId: prior.chat_id, deletedAt: asIso(prior.deleted_at) ?? new Date(0).toISOString() };
+      if (priorRequest) {
+        if (priorRequest.chat_id !== input.chatId) throw new ChatConflictError(input.chatId, 0);
+        return { chatId: priorRequest.chat_id, deletedAt: asIso(priorRequest.deleted_at) ?? new Date(0).toISOString() };
+      }
+      const priorChat = await trx.selectFrom("chat_deletions").selectAll()
+        .where("owner_type", "=", owner.type).where("owner_id", "=", owner.ownerId)
+        .where("chat_id", "=", input.chatId).executeTakeFirst();
+      if (priorChat) {
+        return { chatId: priorChat.chat_id, deletedAt: asIso(priorChat.deleted_at) ?? new Date(0).toISOString() };
+      }
       const chat = await selectOwnedChat(trx, owner, input.chatId, true);
       if (!chat) throw new ChatNotFoundError(input.chatId);
       if (await activeRunQuery(trx, input.chatId)) throw new ChatBusyError(input.chatId);

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -232,6 +232,7 @@ import { createCanvasRoutes } from "./canvas/routes.js";
 import { CanvasSubscriptionHub } from "./canvas/subscriptions.js";
 import { CanvasIdSchema } from "./canvas/contracts.js";
 import { cleanupCanvasTempFiles } from "./canvas/recovery.js";
+import { ChatRepository } from "./chat/repository.js";
 import { MessagingKyselyRepository } from "./messages/repository.js";
 import { createMessagingRoutes } from "./messages/routes.js";
 import type { WSContext } from "hono/ws";
@@ -846,6 +847,7 @@ export async function createGateway(config: GatewayConfig) {
   let canvasService: CanvasService | null = null;
   let canvasSubscriptionHub: CanvasSubscriptionHub | null = null;
   let canvasCleanupTimer: ReturnType<typeof setInterval> | null = null;
+  let chatRepository: ChatRepository | null = null;
   let messagingRepository: MessagingKyselyRepository | null = null;
 
   if (databaseUrl) {
@@ -859,6 +861,8 @@ export async function createGateway(config: GatewayConfig) {
       appRegistry = createAppRegistry(appDb, kysely);
       canvasRepository = new CanvasRepository(kysely as Kysely<any>);
       await canvasRepository.bootstrap();
+      chatRepository = new ChatRepository(kysely as Kysely<any>);
+      await chatRepository.bootstrap();
       canvasService = new CanvasService(canvasRepository, { terminalRegistry: sessionRegistry, homePath });
       messagingRepository = new MessagingKyselyRepository(kysely as Kysely<any>);
       await messagingRepository.bootstrap();
@@ -4439,6 +4443,8 @@ export async function createGateway(config: GatewayConfig) {
         logBestEffortFailure("Home mirror startup failed during shutdown", err);
       });
       syncR2?.destroy();
+      await chatRepository?.release();
+      chatRepository = null;
       await canvasRepository?.destroy();
       await socialRoutes?.shutdownPostHog();
       await appDb?.destroy();

--- a/tests/gateway/chat-repository.test.ts
+++ b/tests/gateway/chat-repository.test.ts
@@ -1,0 +1,530 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sql } from "kysely";
+import { KyselyPGlite } from "kysely-pglite";
+import type {
+  CanonicalChatMessage,
+  CanonicalChatRun,
+  CanonicalChatRunActivity,
+  CanonicalChatTurn,
+} from "@matrix-os/contracts";
+import {
+  ChatBusyError,
+  ChatConflictError,
+  ChatNotFoundError,
+  ChatRepository,
+} from "../../packages/gateway/src/chat/repository.js";
+
+const owner = { type: "personal" as const, ownerId: "user_a" };
+const otherOwner = { type: "personal" as const, ownerId: "user_b" };
+const now = "2026-08-25T00:00:00.000Z";
+
+function selection(instanceId = "codex_default") {
+  return { instanceId, model: "gpt-5.6-sol" };
+}
+
+function message(chatId: string, seq = 1): CanonicalChatMessage {
+  return {
+    id: `msg_${chatId}_${seq}`,
+    chatId,
+    seq,
+    role: "user",
+    state: "committed",
+    turnId: `cturn_${chatId}_${seq}`,
+    parts: [{ type: "text", text: `message ${seq}` }],
+    createdAt: now,
+  };
+}
+
+function turn(chatId: string, input: CanonicalChatMessage, request = "req_turn_1"): CanonicalChatTurn {
+  return {
+    id: `cturn_${chatId}_${input.seq}`,
+    chatId,
+    clientRequestId: request,
+    baseMessageSeq: input.seq - 1,
+    inputMessageId: input.id,
+    status: "accepted",
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function run(chatId: string, inputTurn: CanonicalChatTurn, attempt = 1): CanonicalChatRun {
+  return {
+    id: `run_${chatId}_${attempt}`,
+    chatId,
+    turnId: inputTurn.id,
+    attempt,
+    driverKind: "codex",
+    instanceId: "codex_default",
+    selection: selection(),
+    interactionMode: "default",
+    permissionMode: "supervised",
+    status: "accepted",
+    historyBoundarySeq: inputTurn.baseMessageSeq,
+    capabilitySnapshot: {
+      revision: "catalog_1",
+      rootChat: true,
+      attachments: ["file"],
+      resources: ["file", "folder", "project"],
+      tools: ["read", "write"],
+      approvals: true,
+      userInput: true,
+      resume: true,
+      cancellation: true,
+      worktrees: "optional",
+      interactionModes: ["default"],
+      permissionModes: ["supervised"],
+    },
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+describe("ChatRepository", () => {
+  let pglite: InstanceType<typeof KyselyPGlite>;
+  let repository: ChatRepository;
+
+  beforeEach(async () => {
+    pglite = await KyselyPGlite.create();
+    repository = new ChatRepository(pglite.dialect);
+    await repository.bootstrap();
+  });
+
+  afterEach(async () => {
+    await repository.kysely.destroy();
+  });
+
+  it("bootstraps every canonical Chat table and index idempotently", async () => {
+    await repository.bootstrap();
+    const tables = await repository.kysely
+      .selectFrom("information_schema.tables")
+      .select("table_name")
+      .where("table_schema", "=", "public")
+      .where("table_name", "like", "chat%")
+      .execute();
+
+    expect(tables.map((row) => row.table_name).sort()).toEqual([
+      "chat_attachments",
+      "chat_deletions",
+      "chat_legacy_imports",
+      "chat_members",
+      "chat_messages",
+      "chat_migrations",
+      "chat_outbox",
+      "chat_run_adapter_state",
+      "chat_run_events",
+      "chat_runs",
+      "chat_turns",
+      "chat_user_state",
+      "chats",
+    ]);
+  });
+
+  it("creates idempotently, isolates owners, and commits the outbox atomically", async () => {
+    const first = await repository.create(owner, {
+      id: "chat_owner_a",
+      clientRequestId: "req_create_owner_a",
+      title: "Canonical backend",
+      projectId: "project_matrix",
+      currentSelection: selection(),
+    });
+    const repeated = await repository.create(owner, {
+      id: "chat_ignored_duplicate",
+      clientRequestId: "req_create_owner_a",
+      title: "Ignored duplicate",
+    });
+
+    expect(repeated.chat.id).toBe(first.chat.id);
+    expect(await repository.get(otherOwner, first.chat.id)).toBeNull();
+    expect(await repository.list(owner, { limit: 101 })).toHaveLength(1);
+    await expect(repository.replayOutbox(otherOwner, { afterCursor: 0, limit: 10 })).resolves.toEqual([]);
+    await expect(repository.replayOutbox(owner, { afterCursor: 0, limit: 10 })).resolves.toEqual([
+      expect.objectContaining({ chatId: first.chat.id, eventType: "chat.created", revision: 0 }),
+    ]);
+
+    await expect(repository.withTransaction(async (tx) => {
+      await tx.create(owner, {
+        id: "chat_rolled_back",
+        clientRequestId: "req_create_rolled_back",
+        title: "Rollback",
+      });
+      throw new Error("rollback");
+    })).rejects.toThrow("rollback");
+    expect(await repository.get(owner, "chat_rolled_back")).toBeNull();
+  });
+
+  it("enforces optimistic revisions and blocks Project mutation during an active Run", async () => {
+    const created = await repository.create(owner, {
+      id: "chat_revision",
+      clientRequestId: "req_create_revision",
+      title: "Revisioned",
+      projectId: "project_a",
+    });
+    const updated = await repository.update(owner, created.chat.id, {
+      baseRevision: 0,
+      title: "Revision two",
+      projectId: "project_b",
+    });
+    expect(updated.chat.revision).toBe(1);
+    expect(updated.projectId).toBe("project_b");
+    await expect(repository.update(owner, created.chat.id, {
+      baseRevision: 0,
+      title: "Stale",
+    })).rejects.toBeInstanceOf(ChatConflictError);
+
+    const input = message(created.chat.id);
+    const acceptedTurn = turn(created.chat.id, input);
+    await repository.admitTurn(owner, {
+      chatId: created.chat.id,
+      baseRevision: 1,
+      message: input,
+      turn: acceptedTurn,
+      run: run(created.chat.id, acceptedTurn),
+      adapterState: { schemaVersion: 1, state: { session: "opaque" } },
+    });
+    await expect(repository.update(owner, created.chat.id, {
+      baseRevision: 2,
+      projectId: "project_c",
+    })).rejects.toBeInstanceOf(ChatBusyError);
+  });
+
+  it("admits a Turn atomically, deduplicates requests, and permits only one active Run", async () => {
+    const created = await repository.create(owner, {
+      id: "chat_turns",
+      clientRequestId: "req_create_turns",
+      title: "Turns",
+    });
+    const input = message(created.chat.id);
+    const acceptedTurn = turn(created.chat.id, input);
+    const acceptedRun = run(created.chat.id, acceptedTurn);
+
+    const first = await repository.admitTurn(owner, {
+      chatId: created.chat.id,
+      baseRevision: 0,
+      message: input,
+      turn: acceptedTurn,
+      run: acceptedRun,
+      adapterState: { schemaVersion: 1, state: { session: "opaque" } },
+    });
+    const repeated = await repository.admitTurn(owner, {
+      chatId: created.chat.id,
+      baseRevision: 0,
+      message: input,
+      turn: acceptedTurn,
+      run: acceptedRun,
+      adapterState: { schemaVersion: 1, state: { session: "opaque" } },
+    });
+
+    expect(repeated).toEqual(first);
+    expect((await repository.get(owner, created.chat.id))?.chat).toMatchObject({ revision: 1, messageCount: 1 });
+    expect((await repository.get(owner, created.chat.id))?.activeRun).toEqual({
+      runId: acceptedRun.id,
+      turnId: acceptedTurn.id,
+      status: "accepted",
+    });
+    expect(await repository.getMessages(owner, created.chat.id, { afterSeq: 0, limit: 200 })).toEqual([input]);
+    expect(await repository.replayOutbox(owner, { afterCursor: 0, limit: 10 })).toEqual([
+      expect.objectContaining({ eventType: "chat.created" }),
+      expect.objectContaining({ eventType: "turn.accepted", revision: 1 }),
+    ]);
+
+    const secondMessage = message(created.chat.id, 2);
+    const secondTurn = turn(created.chat.id, secondMessage, "req_turn_2");
+    await expect(repository.admitTurn(owner, {
+      chatId: created.chat.id,
+      baseRevision: 1,
+      message: secondMessage,
+      turn: secondTurn,
+      run: run(created.chat.id, secondTurn, 2),
+    })).rejects.toBeInstanceOf(ChatBusyError);
+  });
+
+  it("rejects a Turn whose input message does not belong to that Turn", async () => {
+    const created = await repository.create(owner, {
+      id: "chat_invalid_turn_message",
+      clientRequestId: "req_create_invalid_turn_message",
+      title: "Invalid Turn message",
+    });
+    const input = { ...message(created.chat.id), turnId: "cturn_wrong" };
+    const acceptedTurn = turn(created.chat.id, input);
+
+    await expect(repository.admitTurn(owner, {
+      chatId: created.chat.id,
+      baseRevision: 0,
+      message: input,
+      turn: acceptedTurn,
+      run: run(created.chat.id, acceptedTurn),
+    })).rejects.toBeInstanceOf(ChatConflictError);
+    expect(await repository.getMessages(owner, created.chat.id, { afterSeq: 0, limit: 200 })).toEqual([]);
+  });
+
+  it("backs serialized Turn admission with a database-level active Run constraint", async () => {
+    const created = await repository.create(owner, {
+      id: "chat_admission_race",
+      clientRequestId: "req_create_admission_race",
+      title: "Admission race",
+    });
+    const firstMessage = message(created.chat.id, 1);
+    const firstTurn = turn(created.chat.id, firstMessage, "req_race_first");
+    const secondMessage = {
+      ...message(created.chat.id, 2),
+      id: "msg_race_second",
+      turnId: "cturn_race_second",
+    };
+    const secondTurn = { ...turn(created.chat.id, secondMessage, "req_race_second"), id: "cturn_race_second" };
+    await repository.admitTurn(owner, {
+      chatId: created.chat.id,
+      baseRevision: 0,
+      message: firstMessage,
+      turn: firstTurn,
+      run: run(created.chat.id, firstTurn, 1),
+    });
+    await expect(repository.admitTurn(owner, {
+      chatId: created.chat.id,
+      baseRevision: 1,
+      message: secondMessage,
+      turn: secondTurn,
+      run: { ...run(created.chat.id, secondTurn, 1), id: "run_race_second" },
+    })).rejects.toBeInstanceOf(ChatBusyError);
+
+    const activeRunIndex = await sql<{ indexdef: string }>`
+      SELECT indexdef
+      FROM pg_indexes
+      WHERE schemaname = 'public' AND indexname = 'idx_chat_runs_one_active'
+    `.execute(repository.kysely);
+    expect(activeRunIndex.rows).toEqual([
+      expect.objectContaining({
+        indexdef: expect.stringMatching(/UNIQUE INDEX.*chat_id.*status.*accepted.*running.*waiting_for_approval.*waiting_for_input/i),
+      }),
+    ]);
+    expect(await repository.getMessages(owner, created.chat.id, { afterSeq: 0, limit: 200 })).toHaveLength(1);
+    expect((await repository.exportChat(owner, created.chat.id))?.runs).toHaveLength(1);
+    expect(await repository.replayOutbox(owner, { afterCursor: 0, limit: 10 })).toHaveLength(2);
+  });
+
+  it("stores only bounded normalized events and transitions a Run terminal with its outbox", async () => {
+    const created = await repository.create(owner, {
+      id: "chat_events",
+      clientRequestId: "req_create_events",
+      title: "Events",
+    });
+    const input = message(created.chat.id);
+    const acceptedTurn = turn(created.chat.id, input);
+    const acceptedRun = run(created.chat.id, acceptedTurn);
+    await repository.admitTurn(owner, {
+      chatId: created.chat.id,
+      baseRevision: 0,
+      message: input,
+      turn: acceptedTurn,
+      run: acceptedRun,
+    });
+    const activity: CanonicalChatRunActivity = {
+      id: "activity_running",
+      chatId: created.chat.id,
+      runId: acceptedRun.id,
+      occurredAt: now,
+      type: "run.status",
+      status: "running",
+    };
+    await repository.appendRunActivities(owner, created.chat.id, acceptedRun.id, [activity]);
+    await repository.finishRun(owner, {
+      chatId: created.chat.id,
+      runId: acceptedRun.id,
+      outcome: "completed",
+      completedAt: "2026-08-25T00:01:00.000Z",
+    });
+
+    const snapshot = await repository.exportChat(owner, created.chat.id);
+    expect(snapshot?.activities).toEqual([activity]);
+    expect(snapshot?.runs[0]).toMatchObject({ status: "completed", outcome: "completed" });
+    expect(snapshot).not.toHaveProperty("adapterState");
+    expect((await repository.get(owner, created.chat.id))?.activeRun).toBeUndefined();
+    expect((await repository.replayOutbox(owner, { afterCursor: 0, limit: 10 })).at(-1)).toMatchObject({
+      eventType: "run.completed",
+    });
+  });
+
+  it("keeps adapter state behind the exact Driver and Instance boundary", async () => {
+    const created = await repository.create(owner, {
+      id: "chat_adapter_state",
+      clientRequestId: "req_create_adapter_state",
+      title: "Adapter state",
+    });
+    const input = message(created.chat.id);
+    const acceptedTurn = turn(created.chat.id, input);
+    const acceptedRun = run(created.chat.id, acceptedTurn);
+    await repository.admitTurn(owner, {
+      chatId: created.chat.id,
+      baseRevision: 0,
+      message: input,
+      turn: acceptedTurn,
+      run: acceptedRun,
+      adapterState: { schemaVersion: 3, state: { nativeSession: "opaque" } },
+    });
+
+    await expect(repository.getAdapterState(owner, {
+      runId: acceptedRun.id,
+      driverKind: "codex",
+      instanceId: "codex_default",
+    })).resolves.toEqual({ schemaVersion: 3, state: { nativeSession: "opaque" } });
+    await expect(repository.getAdapterState(owner, {
+      runId: acceptedRun.id,
+      driverKind: "pi",
+      instanceId: "codex_default",
+    })).resolves.toBeNull();
+    await expect(repository.getAdapterState(otherOwner, {
+      runId: acceptedRun.id,
+      driverKind: "codex",
+      instanceId: "codex_default",
+    })).resolves.toBeNull();
+  });
+
+  it("serializes delete and finalize without resurrecting Chat content", async () => {
+    const created = await repository.create(owner, {
+      id: "chat_delete_finish_race",
+      clientRequestId: "req_create_delete_finish_race",
+      title: "Delete finalize race",
+    });
+    const input = message(created.chat.id);
+    const acceptedTurn = turn(created.chat.id, input);
+    const acceptedRun = run(created.chat.id, acceptedTurn);
+    await repository.admitTurn(owner, {
+      chatId: created.chat.id,
+      baseRevision: 0,
+      message: input,
+      turn: acceptedTurn,
+      run: acceptedRun,
+    });
+
+    await expect(repository.hardDelete(owner, {
+      chatId: created.chat.id,
+      clientRequestId: "req_delete_while_active",
+    })).rejects.toBeInstanceOf(ChatBusyError);
+    await repository.finishRun(owner, {
+      chatId: created.chat.id,
+      runId: acceptedRun.id,
+      outcome: "completed",
+      completedAt: "2026-08-25T00:02:00.000Z",
+    });
+    await repository.hardDelete(owner, {
+      chatId: created.chat.id,
+      clientRequestId: "req_delete_after_finish",
+    });
+
+    expect(await repository.get(owner, created.chat.id)).toBeNull();
+    expect(await repository.exportChat(owner, created.chat.id)).toBeNull();
+    await expect(repository.finishRun(owner, {
+      chatId: created.chat.id,
+      runId: acceptedRun.id,
+      outcome: "completed",
+      completedAt: "2026-08-25T00:03:00.000Z",
+    })).rejects.toBeInstanceOf(ChatNotFoundError);
+    expect(await repository.get(owner, created.chat.id)).toBeNull();
+  });
+
+  it("searches only committed owner-local canonical message text with a bounded result", async () => {
+    const created = await repository.create(owner, {
+      id: "chat_search",
+      clientRequestId: "req_create_search",
+      title: "Search",
+    });
+    const input = message(created.chat.id);
+    const acceptedTurn = turn(created.chat.id, input);
+    await repository.admitTurn(owner, {
+      chatId: created.chat.id,
+      baseRevision: 0,
+      message: input,
+      turn: acceptedTurn,
+      run: run(created.chat.id, acceptedTurn),
+    });
+
+    await expect(repository.search(owner, "message", 200)).resolves.toEqual([
+      expect.objectContaining({ chat: expect.objectContaining({ id: created.chat.id }) }),
+    ]);
+    await expect(repository.search(otherOwner, "message", 200)).resolves.toEqual([]);
+  });
+
+  it("hard-deletes all content once and preserves only a content-free tombstone", async () => {
+    const created = await repository.create(owner, {
+      id: "chat_delete",
+      clientRequestId: "req_create_delete",
+      title: "Delete me",
+    });
+    const first = await repository.hardDelete(owner, {
+      chatId: created.chat.id,
+      clientRequestId: "req_delete_once",
+    });
+    const repeated = await repository.hardDelete(owner, {
+      chatId: created.chat.id,
+      clientRequestId: "req_delete_once",
+    });
+
+    expect(repeated).toEqual(first);
+    expect(await repository.get(owner, created.chat.id)).toBeNull();
+    expect(await repository.exportChat(owner, created.chat.id)).toBeNull();
+    await expect(repository.hardDelete(otherOwner, {
+      chatId: created.chat.id,
+      clientRequestId: "req_delete_other",
+    })).rejects.toBeInstanceOf(ChatNotFoundError);
+    const tombstones = await repository.kysely.selectFrom("chat_deletions").selectAll().execute();
+    expect(tombstones).toEqual([
+      expect.objectContaining({ chat_id: created.chat.id, owner_id: owner.ownerId, request_id: "req_delete_once" }),
+    ]);
+    expect(JSON.stringify(tombstones)).not.toContain("Delete me");
+  });
+
+  it("records legacy import and migration checkpoints idempotently", async () => {
+    await repository.upsertLegacyImport(owner, {
+      sourceKind: "hermes",
+      sourceId: "legacy_1",
+      chatId: "chat_imported",
+      sourceHash: "sha256:first",
+      importVersion: 1,
+      verificationStatus: "verified",
+    });
+    await repository.upsertLegacyImport(owner, {
+      sourceKind: "hermes",
+      sourceId: "legacy_1",
+      chatId: "chat_imported",
+      sourceHash: "sha256:second",
+      importVersion: 2,
+      verificationStatus: "verified",
+    });
+    expect(await repository.getLegacyImport(owner, "hermes", "legacy_1")).toMatchObject({
+      sourceHash: "sha256:second",
+      importVersion: 2,
+    });
+
+    await repository.recordMigration(owner, {
+      migrationId: "canonical_chat_v1",
+      phase: "verified",
+      sourceFingerprint: "sha256:sources",
+      importedCount: 1,
+      errorCount: 0,
+    });
+    expect(await repository.getMigration(owner, "canonical_chat_v1")).toMatchObject({
+      phase: "verified",
+      importedCount: 1,
+    });
+  });
+
+  it("never destroys the shared Gateway Kysely instance", async () => {
+    await repository.release();
+    await expect(repository.list(owner, { limit: 1 })).resolves.toEqual([]);
+  });
+
+  it("wires Chat bootstrap and release around the Gateway-owned Kysely lifecycle", () => {
+    const source = readFileSync(join(process.cwd(), "packages/gateway/src/server.ts"), "utf8");
+    const construct = source.indexOf("chatRepository = new ChatRepository(kysely");
+    const bootstrap = source.indexOf("await chatRepository.bootstrap()", construct);
+    const release = source.indexOf("await chatRepository?.release()");
+    const ownerDestroy = source.indexOf("await appDb?.destroy()", release);
+
+    expect(construct).toBeGreaterThan(-1);
+    expect(bootstrap).toBeGreaterThan(construct);
+    expect(release).toBeGreaterThan(bootstrap);
+    expect(ownerDestroy).toBeGreaterThan(release);
+  });
+});

--- a/tests/gateway/chat-repository.test.ts
+++ b/tests/gateway/chat-repository.test.ts
@@ -624,6 +624,22 @@ describe("ChatRepository", () => {
     expect(notFound).toBeGreaterThan(tombstoneRecheck);
   });
 
+  it("handles concurrent owner-wide deletion request conflicts at the insert boundary", () => {
+    const source = readFileSync(
+      join(process.cwd(), "packages/gateway/src/chat/repository.ts"),
+      "utf8",
+    );
+    const hardDelete = source.slice(
+      source.indexOf("  async hardDelete("),
+      source.indexOf("  async upsertLegacyImport("),
+    );
+
+    expect(hardDelete).toContain(
+      '.onConflict((oc) => oc.columns(["owner_type", "owner_id", "request_id"]).doNothing())',
+    );
+    expect(hardDelete).toMatch(/if \(!deletion\)[\s\S]*request_id[\s\S]*ChatConflictError/);
+  });
+
   it("records legacy import and migration checkpoints idempotently", async () => {
     await repository.upsertLegacyImport(owner, {
       sourceKind: "hermes",

--- a/tests/gateway/chat-repository.test.ts
+++ b/tests/gateway/chat-repository.test.ts
@@ -149,7 +149,7 @@ describe("ChatRepository", () => {
 
     expect(repeated.chat.id).toBe(first.chat.id);
     expect(await repository.get(otherOwner, first.chat.id)).toBeNull();
-    expect(await repository.list(owner, { limit: 101 })).toHaveLength(1);
+    expect((await repository.list(owner, { limit: 101 })).items).toHaveLength(1);
     await expect(repository.replayOutbox(otherOwner, { afterCursor: 0, limit: 10 })).resolves.toEqual([]);
     await expect(repository.replayOutbox(owner, { afterCursor: 0, limit: 10 })).resolves.toEqual([
       expect.objectContaining({ chatId: first.chat.id, eventType: "chat.created", revision: 0 }),
@@ -166,7 +166,7 @@ describe("ChatRepository", () => {
     expect(await repository.get(owner, "chat_rolled_back")).toBeNull();
   });
 
-  it("paginates equal updated timestamps with the Chat ID tie-breaker", async () => {
+  it("paginates equal microsecond timestamps with an opaque precision-safe cursor", async () => {
     for (const suffix of ["a", "b", "c"]) {
       await repository.create(owner, {
         id: `chat_page_${suffix}`,
@@ -174,18 +174,22 @@ describe("ChatRepository", () => {
         title: `Page ${suffix}`,
       });
     }
-    const tiedAt = "2026-08-25T00:10:00.000Z";
+    const tiedAt = "2026-08-25T00:10:00.123456Z";
     await sql`UPDATE chats SET updated_at = ${tiedAt}`.execute(repository.kysely);
 
     const firstPage = await repository.list(owner, { limit: 2 });
-    const cursorChat = firstPage.at(-1)!;
+    expect(firstPage.nextCursor).toEqual({
+      updatedAt: tiedAt,
+      chatId: "chat_page_b",
+    });
     const secondPage = await repository.list(owner, {
       limit: 2,
-      cursor: { updatedAt: cursorChat.chat.updatedAt, chatId: cursorChat.chat.id },
+      cursor: firstPage.nextCursor,
     });
 
-    expect(firstPage.map((record) => record.chat.id)).toEqual(["chat_page_a", "chat_page_b"]);
-    expect(secondPage.map((record) => record.chat.id)).toEqual(["chat_page_c"]);
+    expect(firstPage.items.map((record) => record.chat.id)).toEqual(["chat_page_a", "chat_page_b"]);
+    expect(secondPage.items.map((record) => record.chat.id)).toEqual(["chat_page_c"]);
+    expect(secondPage.nextCursor).toBeUndefined();
   });
 
   it("enforces optimistic revisions and blocks Project mutation during an active Run", async () => {
@@ -602,6 +606,24 @@ describe("ChatRepository", () => {
     expect(await repository.get(owner, second.chat.id)).not.toBeNull();
   });
 
+  it("rechecks the deletion tombstone after a concurrent delete wins the Chat row lock", () => {
+    const source = readFileSync(
+      join(process.cwd(), "packages/gateway/src/chat/repository.ts"),
+      "utf8",
+    );
+    const hardDelete = source.slice(
+      source.indexOf("  async hardDelete("),
+      source.indexOf("  async upsertLegacyImport("),
+    );
+    const lockedChat = hardDelete.indexOf("selectOwnedChat(trx, owner, input.chatId, true)");
+    const tombstoneRecheck = hardDelete.indexOf("selectFrom(\"chat_deletions\")", lockedChat);
+    const notFound = hardDelete.indexOf("throw new ChatNotFoundError", lockedChat);
+
+    expect(lockedChat).toBeGreaterThan(-1);
+    expect(tombstoneRecheck).toBeGreaterThan(lockedChat);
+    expect(notFound).toBeGreaterThan(tombstoneRecheck);
+  });
+
   it("records legacy import and migration checkpoints idempotently", async () => {
     await repository.upsertLegacyImport(owner, {
       sourceKind: "hermes",
@@ -639,7 +661,7 @@ describe("ChatRepository", () => {
 
   it("never destroys the shared Gateway Kysely instance", async () => {
     await repository.release();
-    await expect(repository.list(owner, { limit: 1 })).resolves.toEqual([]);
+    await expect(repository.list(owner, { limit: 1 })).resolves.toEqual({ items: [] });
   });
 
   it("wires Chat bootstrap and release around the Gateway-owned Kysely lifecycle", () => {

--- a/tests/gateway/chat-repository.test.ts
+++ b/tests/gateway/chat-repository.test.ts
@@ -82,6 +82,17 @@ function run(chatId: string, inputTurn: CanonicalChatTurn, attempt = 1): Canonic
   };
 }
 
+function activity(chatId: string, runId: string, index: number): CanonicalChatRunActivity {
+  return {
+    id: `activity_${index}`,
+    chatId,
+    runId,
+    occurredAt: now,
+    type: "run.status",
+    status: "running",
+  };
+}
+
 describe("ChatRepository", () => {
   let pglite: InstanceType<typeof KyselyPGlite>;
   let repository: ChatRepository;
@@ -153,6 +164,28 @@ describe("ChatRepository", () => {
       throw new Error("rollback");
     })).rejects.toThrow("rollback");
     expect(await repository.get(owner, "chat_rolled_back")).toBeNull();
+  });
+
+  it("paginates equal updated timestamps with the Chat ID tie-breaker", async () => {
+    for (const suffix of ["a", "b", "c"]) {
+      await repository.create(owner, {
+        id: `chat_page_${suffix}`,
+        clientRequestId: `req_create_page_${suffix}`,
+        title: `Page ${suffix}`,
+      });
+    }
+    const tiedAt = "2026-08-25T00:10:00.000Z";
+    await sql`UPDATE chats SET updated_at = ${tiedAt}`.execute(repository.kysely);
+
+    const firstPage = await repository.list(owner, { limit: 2 });
+    const cursorChat = firstPage.at(-1)!;
+    const secondPage = await repository.list(owner, {
+      limit: 2,
+      cursor: { updatedAt: cursorChat.chat.updatedAt, chatId: cursorChat.chat.id },
+    });
+
+    expect(firstPage.map((record) => record.chat.id)).toEqual(["chat_page_a", "chat_page_b"]);
+    expect(secondPage.map((record) => record.chat.id)).toEqual(["chat_page_c"]);
   });
 
   it("enforces optimistic revisions and blocks Project mutation during an active Run", async () => {
@@ -260,6 +293,38 @@ describe("ChatRepository", () => {
     expect(await repository.getMessages(owner, created.chat.id, { afterSeq: 0, limit: 200 })).toEqual([]);
   });
 
+  it("reports non-active-Run uniqueness failures as conflicts instead of busy", async () => {
+    const first = await repository.create(owner, {
+      id: "chat_unique_first",
+      clientRequestId: "req_create_unique_first",
+      title: "First unique Chat",
+    });
+    const firstMessage = message(first.chat.id);
+    const firstTurn = turn(first.chat.id, firstMessage);
+    await repository.admitTurn(owner, {
+      chatId: first.chat.id,
+      baseRevision: 0,
+      message: firstMessage,
+      turn: firstTurn,
+      run: run(first.chat.id, firstTurn),
+    });
+
+    const second = await repository.create(owner, {
+      id: "chat_unique_second",
+      clientRequestId: "req_create_unique_second",
+      title: "Second unique Chat",
+    });
+    const secondMessage = { ...message(second.chat.id), id: firstMessage.id };
+    const secondTurn = turn(second.chat.id, secondMessage, "req_turn_unique_second");
+    await expect(repository.admitTurn(owner, {
+      chatId: second.chat.id,
+      baseRevision: 0,
+      message: secondMessage,
+      turn: secondTurn,
+      run: run(second.chat.id, secondTurn),
+    })).rejects.toBeInstanceOf(ChatConflictError);
+  });
+
   it("backs serialized Turn admission with a database-level active Run constraint", async () => {
     const created = await repository.create(owner, {
       id: "chat_admission_race",
@@ -344,6 +409,42 @@ describe("ChatRepository", () => {
     expect((await repository.replayOutbox(owner, { afterCursor: 0, limit: 10 })).at(-1)).toMatchObject({
       eventType: "run.completed",
     });
+  });
+
+  it("charges the Run event limit only for unseen activity IDs", async () => {
+    const created = await repository.create(owner, {
+      id: "chat_activity_retry_capacity",
+      clientRequestId: "req_create_activity_retry_capacity",
+      title: "Activity retry capacity",
+    });
+    const input = message(created.chat.id);
+    const acceptedTurn = turn(created.chat.id, input);
+    const acceptedRun = run(created.chat.id, acceptedTurn);
+    await repository.admitTurn(owner, {
+      chatId: created.chat.id,
+      baseRevision: 0,
+      message: input,
+      turn: acceptedTurn,
+      run: acceptedRun,
+    });
+    const persisted = Array.from({ length: 499 }, (_, index) => activity(created.chat.id, acceptedRun.id, index));
+    await repository.kysely.insertInto("chat_run_events").values(persisted.map((event) => ({
+      id: event.id,
+      chat_id: created.chat.id,
+      run_id: acceptedRun.id,
+      event: sql`${JSON.stringify(event)}::jsonb`,
+      occurred_at: event.occurredAt,
+    }))).execute();
+
+    await expect(repository.appendRunActivities(owner, created.chat.id, acceptedRun.id, [
+      persisted[0]!,
+      activity(created.chat.id, acceptedRun.id, 499),
+    ])).resolves.toBe(1);
+    const count = await repository.kysely.selectFrom("chat_run_events")
+      .select(({ fn }) => fn.countAll().as("count"))
+      .where("run_id", "=", acceptedRun.id)
+      .executeTakeFirstOrThrow();
+    expect(Number(count.count)).toBe(500);
   });
 
   it("keeps adapter state behind the exact Driver and Instance boundary", async () => {
@@ -460,8 +561,13 @@ describe("ChatRepository", () => {
       chatId: created.chat.id,
       clientRequestId: "req_delete_once",
     });
+    const repeatedWithNewRequest = await repository.hardDelete(owner, {
+      chatId: created.chat.id,
+      clientRequestId: "req_delete_again",
+    });
 
     expect(repeated).toEqual(first);
+    expect(repeatedWithNewRequest).toEqual(first);
     expect(await repository.get(owner, created.chat.id)).toBeNull();
     expect(await repository.exportChat(owner, created.chat.id)).toBeNull();
     await expect(repository.hardDelete(otherOwner, {
@@ -473,6 +579,27 @@ describe("ChatRepository", () => {
       expect.objectContaining({ chat_id: created.chat.id, owner_id: owner.ownerId, request_id: "req_delete_once" }),
     ]);
     expect(JSON.stringify(tombstones)).not.toContain("Delete me");
+  });
+
+  it("rejects owner-wide deletion request reuse for another Chat as a typed conflict", async () => {
+    const first = await repository.create(owner, {
+      id: "chat_delete_request_first",
+      clientRequestId: "req_create_delete_request_first",
+      title: "First deletion target",
+    });
+    const second = await repository.create(owner, {
+      id: "chat_delete_request_second",
+      clientRequestId: "req_create_delete_request_second",
+      title: "Second deletion target",
+    });
+    const requestId = "req_delete_owner_wide";
+    await repository.hardDelete(owner, { chatId: first.chat.id, clientRequestId: requestId });
+
+    await expect(repository.hardDelete(owner, {
+      chatId: second.chat.id,
+      clientRequestId: requestId,
+    })).rejects.toBeInstanceOf(ChatConflictError);
+    expect(await repository.get(owner, second.chat.id)).not.toBeNull();
   });
 
   it("records legacy import and migration checkpoints idempotently", async () => {


### PR DESCRIPTION
## Summary

- add the canonical owner-local PostgreSQL/Kysely schema for Chats, messages, attachments, Turns, Runs, adapter state, outbox, deletion tombstones, and migration checkpoints
- add a repository with owner isolation, optimistic revisions, idempotent create/Turn/delete flows, immutable first-Turn Provider binding, one-active-Run enforcement, bounded replay/search/export/cleanup, and transactional outbox writes
- wire the repository into the existing Gateway-owned Kysely lifecycle without creating or destroying another pool

Linear: [MAT-472](https://linear.app/matrix-os/issue/MAT-472/add-owner-local-chat-repository-and-transactional-outbox)

## Invariants

- **Source of truth:** owner-local PostgreSQL is the canonical Chat repository introduced here. Legacy JSON remains authoritative until the explicit MAT-479 migration cutover; this PR does not dual-write or cut over reads.
- **Lock / transaction scope:** create, update, Turn admission, Run finalization, deletion, and their outbox records commit in one Kysely transaction. Context mutation, admission, finalization, and deletion lock the same Chat row; a partial unique index is the database backstop for one active Run.
- **Acceptable orphan states:** canonical Chat rows and outbox records do not commit independently. Delete retains only a content-free idempotency tombstone and deletion event. Owner-file attachment bytes are references and are not deleted by this repository.
- **Auth source of truth:** this is an internal repository seam. The caller supplies a CanonicalOwnerScope resolved by the authenticated Gateway boundary; no new route or renderer-supplied owner override is added here.
- **Deferred scope:** Provider discovery/capability validation (MAT-473), Turn/Run dispatch and routes (MAT-477), JSON import/cutover (MAT-479), event subscriptions, Desktop UI, and Global/Project composition are intentionally excluded.

## Verification

- `flox activate -- pnpm exec vitest run tests/gateway/chat-repository.test.ts` — 20/20 passed
- `flox activate -- pnpm typecheck` — passed
- `flox activate -- pnpm check:patterns:diff` — 0 violations; broad scanner warnings only
- `git diff --check` — passed
- Greptile exact head `bd5dc5da284a89b9836c79f1859305b084a41fc4` — 5/5, 0 unresolved threads

The focused suite exercises schema bootstrap, owner isolation, rollback/outbox atomicity, revision conflicts, Project mutation guards, idempotent Turn admission, canonical message/Turn linkage, the active-Run partial unique index, normalized event and adapter-state bounds, precision-safe keyset pagination, delete/finalize serialization, concurrent deletion retries and request conflicts, owner-local search, hard delete/tombstones, migration checkpoints, and shared Kysely startup/shutdown ownership.

## Human Review

Approved by the issue owner. This PR intentionally has no API or Desktop surface; authenticated owner-VPS dispatch and UI acceptance belong to MAT-477/MAT-480 after this storage seam lands.
