### PR TITLE
feat(gateway): add Provider Instance catalog and Chat binding

### DIFF
--- a/packages/contracts/src/canonical-chat-provider.ts
+++ b/packages/contracts/src/canonical-chat-provider.ts
@@ -7,6 +7,7 @@ import {
 } from "#canonical-chat";
 import {
   CanonicalProviderDriverKindSchema,
+  canonicalBoundedText,
   canonicalReferenceId,
   canonicalSafeLabel,
 } from "#canonical-chat-primitives";
@@ -99,6 +100,22 @@ const CanonicalSlashDescriptorSchema = z.object({
 
 export const CanonicalChatSkillDescriptorSchema = CanonicalSlashDescriptorSchema;
 export const CanonicalChatCommandDescriptorSchema = CanonicalSlashDescriptorSchema;
+export const CanonicalProviderSetupActionSchema = z.discriminatedUnion("kind", [
+  z.object({
+    id: canonicalReferenceId(80),
+    kind: z.literal("open_settings"),
+    label: canonicalSafeLabel(120, 480),
+  }).strict(),
+  z.object({
+    id: canonicalReferenceId(80),
+    kind: z.literal("foreground_terminal"),
+    label: canonicalSafeLabel(120, 480),
+    command: canonicalBoundedText(280, 720).refine(
+      (value) => !/[\u0000\r\n]/.test(value),
+      { message: "Setup command must be one line" },
+    ),
+  }).strict(),
+]);
 export const CanonicalProviderSupportSchema = z.object({
   rootChat: z.boolean(),
   resume: z.boolean(),
@@ -130,6 +147,7 @@ export const CanonicalProviderInstanceDescriptorSchema = z.object({
   options: z.array(CanonicalProviderOptionDescriptorSchema).max(32),
   skills: z.array(CanonicalChatSkillDescriptorSchema).max(64),
   commands: z.array(CanonicalChatCommandDescriptorSchema).max(64),
+  setupActions: z.array(CanonicalProviderSetupActionSchema).max(6),
   supports: CanonicalProviderSupportSchema,
   defaultSelection: CanonicalChatModelSelectionSchema.optional(),
 }).strict().superRefine((instance, ctx) => {
@@ -203,6 +221,7 @@ export type { CanonicalProviderDriverKind } from "#canonical-chat-primitives";
 export type CanonicalProviderDriverDescriptor = z.infer<typeof CanonicalProviderDriverDescriptorSchema>;
 export type CanonicalModelDescriptor = z.infer<typeof CanonicalModelDescriptorSchema>;
 export type CanonicalProviderOptionDescriptor = z.infer<typeof CanonicalProviderOptionDescriptorSchema>;
+export type CanonicalProviderSetupAction = z.infer<typeof CanonicalProviderSetupActionSchema>;
 export type CanonicalProviderSupport = z.infer<typeof CanonicalProviderSupportSchema>;
 export type CanonicalProviderInstanceDescriptor = z.infer<typeof CanonicalProviderInstanceDescriptorSchema>;
 export type CanonicalProviderCatalog = z.infer<typeof CanonicalProviderCatalogSchema>;

--- a/packages/contracts/src/canonical-chat.ts
+++ b/packages/contracts/src/canonical-chat.ts
@@ -474,6 +474,8 @@ export const CanonicalChatRunActivitySchema = z.discriminatedUnion("type", [
 
 export type CanonicalOwnerScope = z.infer<typeof CanonicalOwnerScopeSchema>;
 export type CanonicalChatModelSelection = z.infer<typeof CanonicalChatModelSelectionSchema>;
+export type CanonicalChatAttachmentKind = z.infer<typeof CanonicalChatAttachmentKindSchema>;
+export type CanonicalChatResourceKind = z.infer<typeof CanonicalChatResourceKindSchema>;
 export type CanonicalChatInvocation = z.infer<typeof CanonicalChatInvocationSchema>;
 export type CanonicalChatResourceReference = z.infer<typeof CanonicalChatResourceReferenceSchema>;
 export type CanonicalChatCollaboration = z.infer<typeof CanonicalChatCollaborationSchema>;

--- a/packages/gateway/src/chat/provider-catalog.ts
+++ b/packages/gateway/src/chat/provider-catalog.ts
@@ -34,7 +34,7 @@ export interface ChatProviderCatalogService {
 }
 
 export class ProviderCatalogUnavailableError extends Error {
-  constructor() {
+  constructor(readonly retryable: boolean) {
     super("Provider catalog unavailable");
     this.name = "ProviderCatalogUnavailableError";
   }
@@ -283,7 +283,7 @@ export function createChatProviderCatalogService(options: {
         if (instance === null) continue;
         if (seenCodingDrivers.includes(instance.driverKind)
           || seenCodingDrivers.length === MAX_CODING_DRIVERS) {
-          throw new ProviderCatalogUnavailableError();
+          throw new ProviderCatalogUnavailableError(false);
         }
         seenCodingDrivers.push(instance.driverKind);
         codingInstances.push(instance);
@@ -315,7 +315,7 @@ export function createChatProviderCatalogService(options: {
       });
       if (!parsed.success) {
         console.warn("[chat-providers] Canonical Provider projection failed validation");
-        throw new ProviderCatalogUnavailableError();
+        throw new ProviderCatalogUnavailableError(false);
       }
       return parsed.data;
     },

--- a/packages/gateway/src/chat/provider-catalog.ts
+++ b/packages/gateway/src/chat/provider-catalog.ts
@@ -1,0 +1,403 @@
+import {
+  CanonicalChatModelSelectionSchema,
+  CanonicalChatSafeErrorSchema,
+  CanonicalProviderCatalogSchema,
+  type AgentProviderDescriptor,
+  type AgentProviderSummary,
+  type AgentRuntimeDescriptor,
+  type CanonicalChatAttachmentKind,
+  type CanonicalChatModelSelection,
+  type CanonicalChatResourceKind,
+  type CanonicalChatSafeError,
+  type CanonicalModelDescriptor,
+  type CanonicalProviderCatalog,
+  type CanonicalProviderDriverKind,
+  type CanonicalProviderInstanceDescriptor,
+  type CanonicalProviderOptionDescriptor,
+  type CanonicalProviderSetupAction,
+  type CanonicalProviderSupport,
+} from "@matrix-os/contracts";
+import { createHash } from "node:crypto";
+import { readRuntimeSnapshot, type AgentRuntimeSource } from "../agent-config/service.js";
+import type { CodingAgentProviderRegistry } from "../coding-agents/provider-registry.js";
+import type { RequestPrincipal } from "../request-principal.js";
+
+const ADAPTER_VERSION = "1.0.0";
+const SYSTEM_DRIVERS = ["hermes", "openclaw"] as const;
+
+type InstanceDraft = Omit<CanonicalProviderInstanceDescriptor, "catalogRevision">;
+
+export interface ChatProviderCatalogService {
+  getCatalog(principal: RequestPrincipal): Promise<CanonicalProviderCatalog>;
+}
+
+export class ProviderCatalogUnavailableError extends Error {
+  constructor() {
+    super("Provider catalog unavailable");
+    this.name = "ProviderCatalogUnavailableError";
+  }
+}
+
+function driverDisplayName(kind: CanonicalProviderDriverKind): string {
+  if (kind === "claude_code") return "Claude Code";
+  if (kind === "openclaw") return "OpenClaw";
+  if (kind === "opencode") return "OpenCode";
+  if (kind === "pi") return "Pi";
+  return kind.charAt(0).toUpperCase() + kind.slice(1);
+}
+
+function codingDriverKind(provider: AgentProviderSummary): CanonicalProviderDriverKind | null {
+  if (provider.kind === "claude" || provider.id === "claude") return "claude_code";
+  if (provider.kind === "codex" || provider.id === "codex") return "codex";
+  if (provider.kind === "opencode" || provider.id === "opencode") return "opencode";
+  if (provider.kind === "pi" || provider.id === "pi") return "pi";
+  return null;
+}
+
+function canonicalAvailability(
+  availability: AgentProviderSummary["availability"],
+): CanonicalProviderInstanceDescriptor["availability"] {
+  if (availability === "available") return "available";
+  if (availability === "setup_required" || availability === "installing") return "setup_required";
+  if (availability === "auth_required") return "auth_required";
+  return "unavailable";
+}
+
+function codingSupports(provider: AgentProviderSummary): CanonicalProviderSupport {
+  const isCodex = codingDriverKind(provider) === "codex";
+  return {
+    rootChat: true,
+    resume: true,
+    cancellation: true,
+    attachments: ["file", "image", "structured_ref"],
+    tools: [],
+    approvals: isCodex,
+    userInput: isCodex,
+    worktrees: "optional",
+    resources: ["file", "folder", "project", "task", "app", "terminal_session"],
+    interactionModes: provider.supportedModes,
+    permissionModes: ["supervised", "auto_accept_edits", "auto", "full_access"],
+  };
+}
+
+function codingModels(provider: AgentProviderSummary): CanonicalModelDescriptor[] {
+  const parsedModel = provider.defaultModel === undefined
+    ? null
+    : CanonicalChatModelSelectionSchema.shape.model.safeParse(provider.defaultModel);
+  const id = parsedModel?.success === true ? parsedModel.data : "provider-default";
+  const availability = provider.availability === "available"
+    ? "available" as const
+    : provider.availability === "auth_required"
+      ? "auth_required" as const
+      : "unavailable" as const;
+  return [{
+    id,
+    displayName: parsedModel?.success === true ? parsedModel.data : "Provider default",
+    availability,
+    capabilities: ["reasoning", "tools"],
+    supportsVision: false,
+    supportsToolUse: true,
+  }];
+}
+
+function codingInstance(provider: AgentProviderSummary): InstanceDraft | null {
+  const driverKind = codingDriverKind(provider);
+  if (driverKind === null) return null;
+  const id = `${driverKind}_default`;
+  const availability = canonicalAvailability(provider.availability);
+  const models = codingModels(provider);
+  return {
+    id,
+    driverKind,
+    displayName: provider.displayName,
+    availability,
+    workspaceRequirement: "project_optional",
+    models,
+    options: [],
+    skills: [],
+    commands: [],
+    setupActions: provider.setupActions,
+    supports: codingSupports(provider),
+    ...(availability === "available" ? {
+      defaultSelection: { instanceId: id, model: models[0]!.id },
+    } : {}),
+  };
+}
+
+function systemSupports(): CanonicalProviderSupport {
+  return {
+    rootChat: true,
+    resume: true,
+    cancellation: true,
+    attachments: ["file", "image", "structured_ref"],
+    tools: [],
+    approvals: false,
+    userInput: false,
+    worktrees: "none",
+    resources: ["file", "folder", "project", "task", "app", "terminal_session"],
+    interactionModes: ["default"],
+    permissionModes: ["supervised"],
+  };
+}
+
+function systemModels(
+  runtime: CanonicalProviderDriverKind,
+  providers: AgentProviderDescriptor[],
+): CanonicalModelDescriptor[] {
+  return providers
+    .filter((provider) => provider.runtime === runtime)
+    .flatMap((provider) => provider.models.map((model) => ({
+      id: `${provider.id}:${model.id}`,
+      displayName: model.displayName,
+      ...(model.description ? { description: model.description } : {}),
+      availability: model.available
+        ? provider.authStatus.state === "ready" ? "available" as const : "auth_required" as const
+        : "unavailable" as const,
+      capabilities: model.capabilities,
+      supportsVision: model.capabilities.includes("vision"),
+      supportsToolUse: model.capabilities.includes("tools"),
+    })))
+    .slice(0, 64);
+}
+
+function systemOptions(
+  runtime: CanonicalProviderDriverKind,
+  providers: AgentProviderDescriptor[],
+): CanonicalProviderOptionDescriptor[] {
+  const efforts = [...new Set(providers
+    .filter((provider) => provider.runtime === runtime)
+    .flatMap((provider) => provider.models.flatMap((model) => model.efforts)))];
+  return efforts.length === 0 ? [] : [{
+    id: "effort",
+    label: "Reasoning",
+    kind: "enum",
+    values: efforts.map((effort) => ({
+      value: effort,
+      label: effort.charAt(0).toUpperCase() + effort.slice(1),
+    })),
+    placement: "composer",
+  }];
+}
+
+function systemSetupActions(runtime: AgentRuntimeDescriptor | undefined): CanonicalProviderSetupAction[] {
+  if (runtime?.selectionState === "active" && runtime.setupAction === undefined) return [];
+  return [{
+    id: `${runtime?.id ?? "runtime"}_settings`,
+    kind: "open_settings",
+    label: `Configure ${runtime?.displayName ?? "runtime"}`,
+  }];
+}
+
+function systemAvailability(
+  runtime: AgentRuntimeDescriptor | undefined,
+  models: CanonicalModelDescriptor[],
+): CanonicalProviderInstanceDescriptor["availability"] {
+  if (runtime === undefined) return "unavailable";
+  if (runtime.installState === "missing" || runtime.installState === "installing") return "setup_required";
+  if (runtime.selectionState !== "active") return "unavailable";
+  if (models.some((model) => model.availability === "available")) return "available";
+  if (!runtime.configured || models.some((model) => model.availability === "auth_required")) {
+    return "auth_required";
+  }
+  return "unavailable";
+}
+
+function systemInstance(input: {
+  kind: typeof SYSTEM_DRIVERS[number];
+  runtime?: AgentRuntimeDescriptor;
+  providers: AgentProviderDescriptor[];
+  selectedProvider: string | null;
+  selectedModel: string | null;
+}): InstanceDraft {
+  const id = `${input.kind}_default`;
+  const models = systemModels(input.kind, input.providers);
+  const availability = systemAvailability(input.runtime, models);
+  const selectedModel = input.selectedProvider && input.selectedModel
+    ? `${input.selectedProvider}:${input.selectedModel}`
+    : null;
+  const hasSelectedModel = selectedModel !== null
+    && models.some((model) => model.id === selectedModel && model.availability === "available");
+  return {
+    id,
+    driverKind: input.kind,
+    displayName: input.runtime?.displayName ?? driverDisplayName(input.kind),
+    availability,
+    workspaceRequirement: "none",
+    models,
+    options: systemOptions(input.kind, input.providers),
+    skills: [],
+    commands: [],
+    setupActions: systemSetupActions(input.runtime),
+    supports: systemSupports(),
+    ...(availability === "available" && hasSelectedModel ? {
+      defaultSelection: { instanceId: id, model: selectedModel! },
+    } : {}),
+  };
+}
+
+function catalogRevision(drivers: unknown, instances: unknown): string {
+  const digest = createHash("sha256")
+    .update(JSON.stringify({ drivers, instances }))
+    .digest("hex")
+    .slice(0, 24);
+  return `catalog_${digest}`;
+}
+
+export function createChatProviderCatalogService(options: {
+  codingProviders: Pick<CodingAgentProviderRegistry, "listProviders">;
+  agentRuntimeSource: AgentRuntimeSource;
+  runtimeTimeoutMs?: number;
+}): ChatProviderCatalogService {
+  return {
+    async getCatalog(principal) {
+      const [codingResult, runtimeResult] = await Promise.allSettled([
+        options.codingProviders.listProviders(principal),
+        readRuntimeSnapshot(options.agentRuntimeSource, options.runtimeTimeoutMs),
+      ]);
+      if (codingResult.status === "rejected") {
+        console.warn("[chat-providers] Coding Provider inventory unavailable");
+      }
+      if (runtimeResult.status === "rejected") {
+        console.warn("[chat-providers] System Provider inventory unavailable");
+      }
+
+      const coding = codingResult.status === "fulfilled" ? codingResult.value : [];
+      const seenCodingDrivers = new Set<CanonicalProviderDriverKind>();
+      const codingInstances: InstanceDraft[] = [];
+      for (const provider of coding) {
+        const instance = codingInstance(provider);
+        if (instance === null) continue;
+        if (seenCodingDrivers.has(instance.driverKind)) {
+          throw new ProviderCatalogUnavailableError();
+        }
+        seenCodingDrivers.add(instance.driverKind);
+        codingInstances.push(instance);
+      }
+
+      const snapshot = runtimeResult.status === "fulfilled" ? runtimeResult.value : undefined;
+      const systemInstances = SYSTEM_DRIVERS.map((kind) => systemInstance({
+        kind,
+        runtime: snapshot?.runtime.options.find((runtime) => runtime.id === kind),
+        providers: snapshot?.providers ?? [],
+        selectedProvider: snapshot?.messaging.runtime === kind ? snapshot.messaging.provider : null,
+        selectedModel: snapshot?.messaging.runtime === kind ? snapshot.messaging.model : null,
+      }));
+      const instances = [...systemInstances, ...codingInstances];
+      const driverKinds = [...SYSTEM_DRIVERS, ...seenCodingDrivers];
+      const drivers = driverKinds.map((kind) => ({
+        kind,
+        displayName: driverDisplayName(kind),
+        adapterVersion: ADAPTER_VERSION,
+        capabilityClass: SYSTEM_DRIVERS.includes(kind as typeof SYSTEM_DRIVERS[number])
+          ? "system_agent" as const
+          : "coding_agent" as const,
+      }));
+      const revision = catalogRevision(drivers, instances);
+      const parsed = CanonicalProviderCatalogSchema.safeParse({
+        revision,
+        drivers,
+        instances: instances.map((instance) => ({ ...instance, catalogRevision: revision })),
+      });
+      if (!parsed.success) {
+        console.warn("[chat-providers] Canonical Provider projection failed validation");
+        throw new ProviderCatalogUnavailableError();
+      }
+      return parsed.data;
+    },
+  };
+}
+
+interface ProviderSelectionRequirements {
+  attachments?: CanonicalChatAttachmentKind[];
+  resources?: CanonicalChatResourceKind[];
+  interactionMode?: string;
+  permissionMode?: string;
+  approvals?: boolean;
+  userInput?: boolean;
+  worktree?: boolean;
+}
+
+type ProviderSelectionValidation =
+  | { ok: true; instance: CanonicalProviderInstanceDescriptor; selection: CanonicalChatModelSelection }
+  | { ok: false; error: CanonicalChatSafeError };
+
+function selectionError(
+  code: CanonicalChatSafeError["code"],
+  safeMessage: string,
+  recoveryActions?: CanonicalChatSafeError["recoveryActions"],
+): ProviderSelectionValidation {
+  return {
+    ok: false,
+    error: CanonicalChatSafeErrorSchema.parse({
+      code,
+      safeMessage,
+      retryable: false,
+      ...(recoveryActions ? { recoveryActions } : {}),
+    }),
+  };
+}
+
+function optionsMatch(
+  selection: CanonicalChatModelSelection,
+  instance: CanonicalProviderInstanceDescriptor,
+): boolean {
+  return (selection.options ?? []).every((selected) => {
+    const option = instance.options.find((candidate) => candidate.id === selected.id);
+    if (option === undefined) return false;
+    if (option.kind === "boolean") return typeof selected.value === "boolean";
+    return typeof selected.value === "string"
+      && option.values?.some((candidate) => candidate.value === selected.value) === true;
+  });
+}
+
+function supportsRequirements(
+  supports: CanonicalProviderSupport,
+  requirements: ProviderSelectionRequirements,
+): boolean {
+  return (requirements.attachments ?? []).every((value) => supports.attachments.includes(value))
+    && (requirements.resources ?? []).every((value) => supports.resources.includes(value))
+    && (!requirements.interactionMode || supports.interactionModes.includes(requirements.interactionMode))
+    && (!requirements.permissionMode || supports.permissionModes.includes(requirements.permissionMode))
+    && (!requirements.approvals || supports.approvals)
+    && (!requirements.userInput || supports.userInput)
+    && (!requirements.worktree || supports.worktrees !== "none");
+}
+
+export function validateChatProviderSelection(input: {
+  catalog: CanonicalProviderCatalog;
+  selection: CanonicalChatModelSelection;
+  boundInstanceId?: string;
+  requirements?: ProviderSelectionRequirements;
+}): ProviderSelectionValidation {
+  const selection = CanonicalChatModelSelectionSchema.safeParse(input.selection);
+  if (!selection.success) {
+    return selectionError("capability_mismatch", "The selected Provider options are not supported.");
+  }
+  if (input.boundInstanceId !== undefined
+    && input.boundInstanceId !== selection.data.instanceId) {
+    return selectionError(
+      "provider_instance_locked",
+      "This Chat is already bound to another Provider instance.",
+      ["fork_chat", "start_new_chat"],
+    );
+  }
+  const instance = input.catalog.instances.find((candidate) =>
+    candidate.id === selection.data.instanceId
+  );
+  if (instance?.availability !== "available") {
+    return selectionError(
+      "provider_unavailable",
+      "The selected Provider is not available.",
+      ["select_provider", "open_setup_terminal"],
+    );
+  }
+  const model = instance.models.find((candidate) => candidate.id === selection.data.model);
+  if (model?.availability !== "available") {
+    return selectionError("model_unavailable", "The selected model is not available.", ["select_provider"]);
+  }
+  if (!optionsMatch(selection.data, instance)
+    || !supportsRequirements(instance.supports, input.requirements ?? {})) {
+    return selectionError("capability_mismatch", "The selected Provider does not support this request.");
+  }
+  return { ok: true, instance, selection: selection.data };
+}

--- a/packages/gateway/src/chat/provider-catalog.ts
+++ b/packages/gateway/src/chat/provider-catalog.ts
@@ -24,6 +24,8 @@ import type { RequestPrincipal } from "../request-principal.js";
 
 const ADAPTER_VERSION = "1.0.0";
 const SYSTEM_DRIVERS = ["hermes", "openclaw"] as const;
+const MAX_CODING_DRIVERS = 4;
+const MAX_EFFORTS = 4;
 
 type InstanceDraft = Omit<CanonicalProviderInstanceDescriptor, "catalogRevision">;
 
@@ -64,12 +66,15 @@ function canonicalAvailability(
 }
 
 function codingSupports(provider: AgentProviderSummary): CanonicalProviderSupport {
-  const isCodex = codingDriverKind(provider) === "codex";
+  const driverKind = codingDriverKind(provider);
+  const isCodex = driverKind === "codex";
   return {
     rootChat: true,
     resume: true,
     cancellation: true,
-    attachments: ["file", "image", "structured_ref"],
+    attachments: driverKind === "pi"
+      ? ["structured_ref"]
+      : ["file", "image", "structured_ref"],
     tools: [],
     approvals: isCodex,
     userInput: isCodex,
@@ -164,9 +169,18 @@ function systemOptions(
   runtime: CanonicalProviderDriverKind,
   providers: AgentProviderDescriptor[],
 ): CanonicalProviderOptionDescriptor[] {
-  const efforts = [...new Set(providers
-    .filter((provider) => provider.runtime === runtime)
-    .flatMap((provider) => provider.models.flatMap((model) => model.efforts)))];
+  const efforts: string[] = [];
+  for (const provider of providers) {
+    if (provider.runtime !== runtime) continue;
+    for (const model of provider.models) {
+      for (const effort of model.efforts) {
+        if (!efforts.includes(effort)) efforts.push(effort);
+        if (efforts.length === MAX_EFFORTS) break;
+      }
+      if (efforts.length === MAX_EFFORTS) break;
+    }
+    if (efforts.length === MAX_EFFORTS) break;
+  }
   return efforts.length === 0 ? [] : [{
     id: "effort",
     label: "Reasoning",
@@ -262,15 +276,16 @@ export function createChatProviderCatalogService(options: {
       }
 
       const coding = codingResult.status === "fulfilled" ? codingResult.value : [];
-      const seenCodingDrivers = new Set<CanonicalProviderDriverKind>();
+      const seenCodingDrivers: CanonicalProviderDriverKind[] = [];
       const codingInstances: InstanceDraft[] = [];
       for (const provider of coding) {
         const instance = codingInstance(provider);
         if (instance === null) continue;
-        if (seenCodingDrivers.has(instance.driverKind)) {
+        if (seenCodingDrivers.includes(instance.driverKind)
+          || seenCodingDrivers.length === MAX_CODING_DRIVERS) {
           throw new ProviderCatalogUnavailableError();
         }
-        seenCodingDrivers.add(instance.driverKind);
+        seenCodingDrivers.push(instance.driverKind);
         codingInstances.push(instance);
       }
 

--- a/packages/gateway/src/chat/provider-routes.ts
+++ b/packages/gateway/src/chat/provider-routes.ts
@@ -1,7 +1,10 @@
 import { CanonicalChatSafeErrorSchema } from "@matrix-os/contracts";
 import { Hono, type Context } from "hono";
 import type { RequestPrincipal } from "../request-principal.js";
-import type { ChatProviderCatalogService } from "./provider-catalog.js";
+import {
+  ProviderCatalogUnavailableError,
+  type ChatProviderCatalogService,
+} from "./provider-catalog.js";
 
 export function createChatProviderRoutes(options: {
   catalog: Pick<ChatProviderCatalogService, "getCatalog">;
@@ -12,14 +15,18 @@ export function createChatProviderRoutes(options: {
     const principal = options.getPrincipal(context);
     try {
       return context.json(await options.catalog.getCatalog(principal));
-    } catch {
-      console.warn("[chat-providers] Provider catalog request failed");
+    } catch (error: unknown) {
+      const retryable = error instanceof ProviderCatalogUnavailableError;
+      console.warn(
+        "[chat-providers] Provider catalog request failed:",
+        error instanceof Error ? error.name : "UnknownError",
+      );
       return context.json({
         error: CanonicalChatSafeErrorSchema.parse({
           code: "service_unavailable",
           safeMessage: "Provider catalog is temporarily unavailable.",
-          retryable: true,
-          recoveryActions: ["retry"],
+          retryable,
+          ...(retryable ? { recoveryActions: ["retry"] } : {}),
         }),
       }, 503);
     }

--- a/packages/gateway/src/chat/provider-routes.ts
+++ b/packages/gateway/src/chat/provider-routes.ts
@@ -1,0 +1,28 @@
+import { CanonicalChatSafeErrorSchema } from "@matrix-os/contracts";
+import { Hono, type Context } from "hono";
+import type { RequestPrincipal } from "../request-principal.js";
+import type { ChatProviderCatalogService } from "./provider-catalog.js";
+
+export function createChatProviderRoutes(options: {
+  catalog: Pick<ChatProviderCatalogService, "getCatalog">;
+  getPrincipal: (context: Context) => RequestPrincipal;
+}): Hono {
+  const routes = new Hono();
+  routes.get("/api/chat-providers", async (context) => {
+    const principal = options.getPrincipal(context);
+    try {
+      return context.json(await options.catalog.getCatalog(principal));
+    } catch {
+      console.warn("[chat-providers] Provider catalog request failed");
+      return context.json({
+        error: CanonicalChatSafeErrorSchema.parse({
+          code: "service_unavailable",
+          safeMessage: "Provider catalog is temporarily unavailable.",
+          retryable: true,
+          recoveryActions: ["retry"],
+        }),
+      }, 503);
+    }
+  });
+  return routes;
+}

--- a/packages/gateway/src/chat/provider-routes.ts
+++ b/packages/gateway/src/chat/provider-routes.ts
@@ -16,7 +16,7 @@ export function createChatProviderRoutes(options: {
     try {
       return context.json(await options.catalog.getCatalog(principal));
     } catch (error: unknown) {
-      const retryable = error instanceof ProviderCatalogUnavailableError;
+      const retryable = error instanceof ProviderCatalogUnavailableError && error.retryable;
       console.warn(
         "[chat-providers] Provider catalog request failed:",
         error instanceof Error ? error.name : "UnknownError",

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -130,6 +130,8 @@ import { createOwnerCodingAgentProjectSummaryStore } from "./coding-agents/proje
 import { createOwnerCodingAgentProjectWorkspaceStore } from "./coding-agents/project-workspace.js";
 import { createCodingAgentThreadRelationValidator } from "./coding-agents/thread-relations.js";
 import { createCodingAgentProviderRegistry } from "./coding-agents/provider-registry.js";
+import { createChatProviderCatalogService } from "./chat/provider-catalog.js";
+import { createChatProviderRoutes } from "./chat/provider-routes.js";
 import { createCodingAgentFileStore } from "./coding-agents/file-read.js";
 import { createCodingAgentSourceControlStore } from "./coding-agents/source-control.js";
 import { registerCodingAgentAttentionNotifications } from "./coding-agents/attention-notifications.js";
@@ -4123,6 +4125,13 @@ export async function createGateway(config: GatewayConfig) {
     client: hermesClient,
   });
   await agentRuntimeServices.controller.reconcile();
+  app.route("/", createChatProviderRoutes({
+    catalog: createChatProviderCatalogService({
+      codingProviders: codingAgentProviderRegistry,
+      agentRuntimeSource: agentRuntimeServices.source,
+    }),
+    getPrincipal: (c) => requireRequestPrincipal(c),
+  }));
 
   // T978-T979: Settings API routes
   const settingsRoutes = createSettingsRoutes({

--- a/tests/contracts/canonical-chat.test.ts
+++ b/tests/contracts/canonical-chat.test.ts
@@ -268,6 +268,12 @@ describe("canonical Chat contracts", () => {
         invocation: "/review",
       }],
       commands: [],
+      setupActions: [{
+        id: "codex_connect",
+        kind: "foreground_terminal",
+        label: "Connect Codex",
+        command: "codex login --device-auth",
+      }],
       supports: {
         rootChat: true,
         resume: true,
@@ -289,6 +295,7 @@ describe("canonical Chat contracts", () => {
     });
 
     expect(instance.supports.interactionModes).toEqual(["default", "plan"]);
+    expect(instance.setupActions[0]?.kind).toBe("foreground_terminal");
     expect(CanonicalProviderInstanceDescriptorSchema.safeParse({
       ...instance,
       defaultSelection: { ...instance.defaultSelection, instanceId: "claude_primary" },
@@ -331,6 +338,15 @@ describe("canonical Chat contracts", () => {
     expect(CanonicalProviderInstanceDescriptorSchema.safeParse({
       ...instance,
       credentials: { token: "secret" },
+    }).success).toBe(false);
+    expect(CanonicalProviderInstanceDescriptorSchema.safeParse({
+      ...instance,
+      setupActions: [{
+        id: "oversized",
+        kind: "foreground_terminal",
+        label: "Run setup",
+        command: "界".repeat(280),
+      }],
     }).success).toBe(false);
 
     const slashDescriptor = (index: number) => ({

--- a/tests/contracts/fixtures/canonical-chat.ts
+++ b/tests/contracts/fixtures/canonical-chat.ts
@@ -99,6 +99,7 @@ export function createCanonicalProviderCatalogFixture(
       options: [],
       skills: [],
       commands: [],
+      setupActions: [],
       supports: {
         rootChat: true,
         resume: true,

--- a/tests/gateway/chat-provider-catalog.test.ts
+++ b/tests/gateway/chat-provider-catalog.test.ts
@@ -185,6 +185,30 @@ describe("canonical Chat Provider catalog", () => {
       .toMatchObject([{ id: "provider-default", displayName: "Provider default" }]);
   });
 
+  it("advertises only attachment kinds the Pi adapter forwards", async () => {
+    const service = createChatProviderCatalogService({
+      codingProviders: codingRegistry([codingProvider({
+        id: "pi",
+        displayName: "Pi",
+        kind: "pi",
+        supportedModes: ["default"],
+        defaultModel: undefined,
+        setupActions: [],
+      })]),
+      agentRuntimeSource: runtimeSource(),
+    });
+
+    const catalog = await service.getCatalog(principal);
+    const pi = catalog.instances.find((instance) => instance.id === "pi_default")!;
+
+    expect(pi.supports.attachments).toEqual(["structured_ref"]);
+    expect(validateChatProviderSelection({
+      catalog,
+      selection: pi.defaultSelection!,
+      requirements: { attachments: ["image"] },
+    })).toMatchObject({ ok: false, error: { code: "capability_mismatch" } });
+  });
+
   it("rejects duplicate Driver projections instead of choosing one silently", async () => {
     const service = createChatProviderCatalogService({
       codingProviders: codingRegistry([
@@ -327,6 +351,7 @@ describe("GET /api/chat-providers", () => {
   });
 
   it("returns a generic service error when catalog projection fails", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
     const app = new Hono().route("/", createChatProviderRoutes({
       catalog: { getCatalog: async () => {
         throw new Error("postgres://secret-provider-catalog");
@@ -341,9 +366,29 @@ describe("GET /api/chat-providers", () => {
       error: {
         code: "service_unavailable",
         safeMessage: "Provider catalog is temporarily unavailable.",
-        retryable: true,
-        recoveryActions: ["retry"],
+        retryable: false,
       },
+    });
+    expect(warning).toHaveBeenCalledWith(
+      "[chat-providers] Provider catalog request failed:",
+      "Error",
+    );
+    warning.mockRestore();
+  });
+
+  it("marks a known inventory failure as retryable", async () => {
+    const app = new Hono().route("/", createChatProviderRoutes({
+      catalog: { getCatalog: async () => {
+        throw new ProviderCatalogUnavailableError();
+      } },
+      getPrincipal: () => principal,
+    }));
+
+    const response = await app.request("/api/chat-providers");
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      error: { code: "service_unavailable", retryable: true },
     });
   });
 });

--- a/tests/gateway/chat-provider-catalog.test.ts
+++ b/tests/gateway/chat-provider-catalog.test.ts
@@ -1,0 +1,349 @@
+import {
+  CanonicalProviderCatalogSchema,
+  type AgentProviderSummary,
+  type CanonicalProviderCatalog,
+} from "@matrix-os/contracts";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRuntimeSource } from "../../packages/gateway/src/agent-config/service.js";
+import {
+  ProviderCatalogUnavailableError,
+  createChatProviderCatalogService,
+  validateChatProviderSelection,
+} from "../../packages/gateway/src/chat/provider-catalog.js";
+import { createChatProviderRoutes } from "../../packages/gateway/src/chat/provider-routes.js";
+import type { CodingAgentProviderRegistry } from "../../packages/gateway/src/coding-agents/provider-registry.js";
+import type { RequestPrincipal } from "../../packages/gateway/src/request-principal.js";
+
+const principal: RequestPrincipal = { userId: "owner_1", source: "jwt" };
+
+function codingProvider(
+  overrides: Partial<AgentProviderSummary> = {},
+): AgentProviderSummary {
+  return {
+    id: "codex",
+    displayName: "Codex",
+    kind: "codex",
+    availability: "available",
+    installStatus: "installed",
+    authStatus: "authenticated",
+    supportedModes: ["default", "review"],
+    defaultMode: "default",
+    defaultModel: "gpt-5.4",
+    setupActions: [{
+      id: "codex_connect",
+      kind: "foreground_terminal",
+      label: "Connect Codex",
+      command: "codex login --device-auth",
+    }],
+    ...overrides,
+  };
+}
+
+function runtimeSource(): AgentRuntimeSource {
+  return async () => ({
+    runtime: {
+      selected: "hermes",
+      options: [{
+        id: "hermes",
+        displayName: "Hermes",
+        installState: "installed",
+        health: "healthy",
+        selectionState: "active",
+        configured: true,
+        capabilities: ["provider_catalog", "model_selection", "authentication"],
+      }, {
+        id: "openclaw",
+        displayName: "OpenClaw",
+        installState: "installed",
+        health: "stopped",
+        selectionState: "available",
+        configured: false,
+        capabilities: ["provider_catalog", "model_selection", "authentication"],
+      }],
+      transition: null,
+    },
+    providers: [{
+      id: "anthropic",
+      displayName: "Anthropic",
+      runtime: "hermes",
+      scopes: ["messaging"],
+      authKind: "api_key",
+      supportedAuthKinds: ["api_key"],
+      models: [{
+        id: "claude-opus-4-6",
+        displayName: "Claude Opus 4.6",
+        capabilities: ["tools", "vision", "reasoning"],
+        efforts: ["low", "high"],
+        available: true,
+      }],
+      authStatus: { state: "ready", authenticated: true, action: "none" },
+    }],
+    messaging: {
+      runtime: "hermes",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      configured: true,
+    },
+  });
+}
+
+function codingRegistry(
+  providers: AgentProviderSummary[] = [codingProvider()],
+): CodingAgentProviderRegistry {
+  return {
+    listProviders: vi.fn(async () => providers),
+    invalidate: vi.fn(),
+  };
+}
+
+describe("canonical Chat Provider catalog", () => {
+  it("projects system and coding runtimes through one bounded catalog", async () => {
+    const service = createChatProviderCatalogService({
+      codingProviders: codingRegistry(),
+      agentRuntimeSource: runtimeSource(),
+    });
+
+    const catalog = await service.getCatalog(principal);
+
+    expect(CanonicalProviderCatalogSchema.parse(catalog)).toEqual(catalog);
+    expect(catalog.drivers.map((driver) => [driver.kind, driver.capabilityClass]))
+      .toEqual([
+        ["hermes", "system_agent"],
+        ["openclaw", "system_agent"],
+        ["codex", "coding_agent"],
+      ]);
+    expect(catalog.instances.find((instance) => instance.id === "hermes_default"))
+      .toMatchObject({
+        driverKind: "hermes",
+        availability: "available",
+        defaultSelection: {
+          instanceId: "hermes_default",
+          model: "anthropic:claude-opus-4-6",
+        },
+      });
+    expect(catalog.instances.find((instance) => instance.id === "codex_default"))
+      .toMatchObject({
+        driverKind: "codex",
+        availability: "available",
+        models: [{ id: "gpt-5.4" }],
+        setupActions: [{ id: "codex_connect" }],
+      });
+    expect(catalog.instances.find((instance) => instance.id === "openclaw_default"))
+      .toMatchObject({ availability: "unavailable", models: [] });
+    expect(new Set(catalog.instances.map((instance) => instance.catalogRevision)))
+      .toEqual(new Set([catalog.revision]));
+  });
+
+  it("fails closed per readiness source without hiding the healthy domain", async () => {
+    const failingRuntime: AgentRuntimeSource = async () => {
+      throw new Error("secret runtime endpoint failed");
+    };
+    const service = createChatProviderCatalogService({
+      codingProviders: codingRegistry(),
+      agentRuntimeSource: failingRuntime,
+    });
+
+    const catalog = await service.getCatalog(principal);
+
+    expect(catalog.instances.find((instance) => instance.id === "codex_default")?.availability)
+      .toBe("available");
+    expect(catalog.instances.filter((instance) =>
+      instance.driverKind === "hermes" || instance.driverKind === "openclaw"
+    ).every((instance) => instance.availability === "unavailable")).toBe(true);
+    expect(JSON.stringify(catalog)).not.toContain("secret runtime endpoint");
+  });
+
+  it("keeps the active system runtime when coding inventory fails", async () => {
+    const service = createChatProviderCatalogService({
+      codingProviders: {
+        listProviders: async () => {
+          throw new Error("secret coding inventory failure");
+        },
+      },
+      agentRuntimeSource: runtimeSource(),
+    });
+
+    const catalog = await service.getCatalog(principal);
+
+    expect(catalog.instances.find((instance) => instance.id === "hermes_default")?.availability)
+      .toBe("available");
+    expect(catalog.drivers.some((driver) => driver.capabilityClass === "coding_agent"))
+      .toBe(false);
+    expect(JSON.stringify(catalog)).not.toContain("secret coding inventory failure");
+  });
+
+  it("falls back to the Provider default when a legacy summary has no safe model id", async () => {
+    const service = createChatProviderCatalogService({
+      codingProviders: codingRegistry([codingProvider({ defaultModel: "GPT 5 default" })]),
+      agentRuntimeSource: runtimeSource(),
+    });
+
+    const catalog = await service.getCatalog(principal);
+
+    expect(catalog.instances.find((instance) => instance.id === "codex_default")?.models)
+      .toMatchObject([{ id: "provider-default", displayName: "Provider default" }]);
+  });
+
+  it("rejects duplicate Driver projections instead of choosing one silently", async () => {
+    const service = createChatProviderCatalogService({
+      codingProviders: codingRegistry([
+        codingProvider(),
+        codingProvider({ displayName: "Second Codex" }),
+      ]),
+      agentRuntimeSource: runtimeSource(),
+    });
+
+    await expect(service.getCatalog(principal)).rejects
+      .toBeInstanceOf(ProviderCatalogUnavailableError);
+  });
+});
+
+function selectionCatalog(): CanonicalProviderCatalog {
+  return CanonicalProviderCatalogSchema.parse({
+    revision: "catalog_test",
+    drivers: [{
+      kind: "codex",
+      displayName: "Codex",
+      adapterVersion: "1.0.0",
+      capabilityClass: "coding_agent",
+    }],
+    instances: [{
+      id: "codex_default",
+      driverKind: "codex",
+      displayName: "Codex",
+      availability: "available",
+      workspaceRequirement: "project_optional",
+      catalogRevision: "catalog_test",
+      models: ["gpt-5.4", "gpt-5.6-sol"].map((id) => ({
+        id,
+        displayName: id,
+        availability: "available",
+        capabilities: ["reasoning", "tools"],
+        supportsVision: false,
+        supportsToolUse: true,
+      })),
+      options: [{
+        id: "effort",
+        label: "Reasoning",
+        kind: "enum",
+        values: [{ value: "low", label: "Low" }, { value: "high", label: "High" }],
+        defaultValue: "low",
+        placement: "composer",
+      }],
+      skills: [],
+      commands: [],
+      setupActions: [],
+      supports: {
+        rootChat: true,
+        resume: true,
+        cancellation: true,
+        attachments: ["file"],
+        tools: [],
+        approvals: true,
+        userInput: true,
+        worktrees: "optional",
+        resources: ["file", "folder", "project"],
+        interactionModes: ["default", "review"],
+        permissionModes: ["supervised", "full_access"],
+      },
+    }],
+  });
+}
+
+describe("canonical Provider selection policy", () => {
+  it("allows model and option changes inside the bound Instance", () => {
+    const result = validateChatProviderSelection({
+      catalog: selectionCatalog(),
+      boundInstanceId: "codex_default",
+      selection: {
+        instanceId: "codex_default",
+        model: "gpt-5.6-sol",
+        options: [{ id: "effort", value: "high" }],
+      },
+      requirements: {
+        attachments: ["file"],
+        interactionMode: "review",
+        permissionMode: "supervised",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns the canonical locked error for a cross-Instance change", () => {
+    const result = validateChatProviderSelection({
+      catalog: selectionCatalog(),
+      boundInstanceId: "another_instance",
+      selection: { instanceId: "codex_default", model: "gpt-5.4" },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "provider_instance_locked",
+        safeMessage: "This Chat is already bound to another Provider instance.",
+        retryable: false,
+        recoveryActions: ["fork_chat", "start_new_chat"],
+      },
+    });
+  });
+
+  it("rejects unknown models, option values, and unsupported capabilities", () => {
+    expect(validateChatProviderSelection({
+      catalog: selectionCatalog(),
+      selection: { instanceId: "codex_default", model: "unknown" },
+    })).toMatchObject({ ok: false, error: { code: "model_unavailable" } });
+    expect(validateChatProviderSelection({
+      catalog: selectionCatalog(),
+      selection: {
+        instanceId: "codex_default",
+        model: "gpt-5.4",
+        options: [{ id: "effort", value: "ultra" }],
+      },
+    })).toMatchObject({ ok: false, error: { code: "capability_mismatch" } });
+    expect(validateChatProviderSelection({
+      catalog: selectionCatalog(),
+      selection: { instanceId: "codex_default", model: "gpt-5.4" },
+      requirements: { attachments: ["image"] },
+    })).toMatchObject({ ok: false, error: { code: "capability_mismatch" } });
+  });
+});
+
+describe("GET /api/chat-providers", () => {
+  it("returns the safe catalog for the verified principal", async () => {
+    const catalog = selectionCatalog();
+    const getCatalog = vi.fn(async () => catalog);
+    const app = new Hono().route("/", createChatProviderRoutes({
+      catalog: { getCatalog },
+      getPrincipal: () => principal,
+    }));
+
+    const response = await app.request("/api/chat-providers");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(catalog);
+    expect(getCatalog).toHaveBeenCalledWith(principal);
+  });
+
+  it("returns a generic service error when catalog projection fails", async () => {
+    const app = new Hono().route("/", createChatProviderRoutes({
+      catalog: { getCatalog: async () => {
+        throw new Error("postgres://secret-provider-catalog");
+      } },
+      getPrincipal: () => principal,
+    }));
+
+    const response = await app.request("/api/chat-providers");
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "service_unavailable",
+        safeMessage: "Provider catalog is temporarily unavailable.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      },
+    });
+  });
+});

--- a/tests/gateway/chat-provider-catalog.test.ts
+++ b/tests/gateway/chat-provider-catalog.test.ts
@@ -376,10 +376,10 @@ describe("GET /api/chat-providers", () => {
     warning.mockRestore();
   });
 
-  it("marks a known inventory failure as retryable", async () => {
+  it("marks an explicitly transient catalog failure as retryable", async () => {
     const app = new Hono().route("/", createChatProviderRoutes({
       catalog: { getCatalog: async () => {
-        throw new ProviderCatalogUnavailableError();
+        throw new ProviderCatalogUnavailableError(true);
       } },
       getPrincipal: () => principal,
     }));
@@ -390,5 +390,27 @@ describe("GET /api/chat-providers", () => {
     expect(await response.json()).toMatchObject({
       error: { code: "service_unavailable", retryable: true },
     });
+  });
+
+  it("does not recommend retrying a deterministic projection failure", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const app = new Hono().route("/", createChatProviderRoutes({
+      catalog: { getCatalog: async () => {
+        throw new ProviderCatalogUnavailableError(false);
+      } },
+      getPrincipal: () => principal,
+    }));
+
+    const response = await app.request("/api/chat-providers");
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "service_unavailable",
+        safeMessage: "Provider catalog is temporarily unavailable.",
+        retryable: false,
+      },
+    });
+    warning.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

- add the canonical `GET /api/chat-providers` projection for Hermes, OpenClaw, Codex, Claude Code, OpenCode, and Pi
- reuse the existing system-runtime source and coding-agent Provider registry for readiness and safe setup actions
- add stable V1 Provider Instance IDs, capability-derived models/options/modes/permissions, and deterministic catalog revisions
- add a shared selection validator for same-Instance model/options changes, capability mismatches, and `provider_instance_locked`

## Architecture boundary

This PR does not create another readiness registry or another Chat store. MAT-472 owns the atomic first-accepted-Turn binding write; this PR supplies the catalog and validation policy that MAT-477 will compose with that repository boundary.

## Test plan

- `bun run test -- tests/contracts/canonical-chat.test.ts tests/contracts/canonical-chat-compatibility.test.ts tests/contracts/canonical-chat-fixtures.test.ts tests/gateway/chat-provider-catalog.test.ts tests/gateway/coding-agents-provider-registry.test.ts tests/gateway/agent-runtime-services.test.ts tests/gateway/hermes-runtime-adapter.test.ts tests/gateway/openclaw-runtime-adapter.test.ts` — 88/88
- `bun run typecheck` — pass
- `bun run check:patterns:diff` — 0 violations
- Existing interactive Bash cancellation test times out in this non-interactive worktree; it has no changed-file overlap and is recorded separately from the focused MAT-473 gates.

Linear: MAT-473