### PR TITLE
refactor(desktop): add shared Chat inspector shell

### DIFF
--- a/desktop/src/renderer/src/features/chat/ChatInspector.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatInspector.tsx
@@ -1,0 +1,247 @@
+import type { CanonicalChatInspectorProjection } from "@matrix-os/contracts";
+import {
+  Activity,
+  FileDiff,
+  Files,
+  FolderKanban,
+  ShieldCheck,
+  type LucideIcon,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { InspectorTabShell, type InspectorTabDefinition } from "./InspectorTabShell";
+
+export type ChatInspectorTab = "context" | "run" | "approvals" | "changes" | "files";
+
+interface ChatInspectorApprovals {
+  count: number;
+  content: ReactNode;
+}
+
+interface ChatInspectorReadyProps {
+  state: "ready";
+  projection: CanonicalChatInspectorProjection;
+  approvals?: ChatInspectorApprovals;
+  defaultTab?: ChatInspectorTab;
+  selectedTab?: ChatInspectorTab;
+  onTabChange?: (tab: ChatInspectorTab) => void;
+  headerActions?: ReactNode;
+}
+
+interface ChatInspectorPendingProps {
+  state: "loading" | "empty" | "error";
+  projection?: never;
+  approvals?: never;
+  defaultTab?: never;
+  selectedTab?: never;
+  onTabChange?: never;
+  headerActions?: ReactNode;
+}
+
+export type ChatInspectorProps = ChatInspectorReadyProps | ChatInspectorPendingProps;
+
+const STATUS_COPY = {
+  loading: "Loading chat details…",
+  empty: "Select a chat to inspect its context and activity.",
+  error: "Chat details couldn't be loaded. Try again.",
+} as const;
+
+function titleCase(value: string): string {
+  return value
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function modelLabel(model: string): string {
+  const parts = model.split("-");
+  return parts.map((part, index) => {
+    if (index === 0 && part.toLowerCase() === "gpt") return "GPT";
+    return part.charAt(0).toUpperCase() + part.slice(1);
+  }).join("-");
+}
+
+function DetailCard({ title, icon: Icon, children }: { title: string; icon: LucideIcon; children: ReactNode }) {
+  return (
+    <section
+      className="rounded-lg border p-3"
+      style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+    >
+      <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide" style={{ color: "var(--text-tertiary)" }}>
+        <Icon size={14} aria-hidden="true" />
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function ValueRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="flex items-start justify-between gap-3 py-1.5 text-xs">
+      <dt style={{ color: "var(--text-tertiary)" }}>{label}</dt>
+      <dd className="min-w-0 text-right font-medium" style={{ color: "var(--text-primary)" }}>{value}</dd>
+    </div>
+  );
+}
+
+function ContextPanel({ projection }: { projection: CanonicalChatInspectorProjection }) {
+  const { project, executionRoot } = projection.context;
+  return (
+    <div className="grid gap-3">
+      <DetailCard title="Project context" icon={FolderKanban}>
+        {project ? (
+          <dl>
+            <ValueRow label="Project" value={project.name} />
+            <ValueRow label="Type" value={titleCase(project.kind)} />
+            {project.repositoryLabel ? <ValueRow label="Repository" value={project.repositoryLabel} /> : null}
+            <ValueRow label="Status" value={titleCase(project.status)} />
+          </dl>
+        ) : (
+          <p className="text-sm" style={{ color: "var(--text-secondary)" }}>This Chat is not attached to a Project.</p>
+        )}
+      </DetailCard>
+      <DetailCard title="Execution context" icon={Activity}>
+        {executionRoot ? (
+          <dl>
+            <ValueRow
+              label="Workspace"
+              value={executionRoot.kind === "worktree" ? "Project worktree" : "Project workspace"}
+            />
+            {projection.terminals.length > 0 ? (
+              <ValueRow label="Terminal sessions" value={projection.terminals.length} />
+            ) : null}
+          </dl>
+        ) : (
+          <p className="text-sm" style={{ color: "var(--text-secondary)" }}>No execution workspace is available.</p>
+        )}
+      </DetailCard>
+    </div>
+  );
+}
+
+function RunPanel({ projection }: { projection: CanonicalChatInspectorProjection }) {
+  const run = projection.run;
+  if (!run) return null;
+  return (
+    <DetailCard title="Run details" icon={Activity}>
+      <dl>
+        <ValueRow label="Status" value={titleCase(run.status)} />
+        <ValueRow label="Provider" value={titleCase(run.driverKind)} />
+        <ValueRow label="Model" value={modelLabel(run.model)} />
+        {run.startedAt ? <ValueRow label="Started" value={<time dateTime={run.startedAt}>{new Date(run.startedAt).toLocaleString()}</time>} /> : null}
+        {run.completedAt ? <ValueRow label="Completed" value={<time dateTime={run.completedAt}>{new Date(run.completedAt).toLocaleString()}</time>} /> : null}
+      </dl>
+    </DetailCard>
+  );
+}
+
+function ChangesPanel({ projection }: { projection: CanonicalChatInspectorProjection }) {
+  const changes = projection.changes;
+  if (changes.availability === "unavailable") {
+    const copy = {
+      not_supported: "This Provider does not expose canonical change details.",
+      not_ready: "Change details are not ready yet.",
+      run_incomplete: "Change details will be available after the Run settles.",
+      history_only: "This imported Chat has history without canonical change details.",
+    }[changes.reason];
+    return <p className="rounded-lg border p-3 text-sm" role="status" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>{copy}</p>;
+  }
+  return (
+    <div className="grid gap-3">
+      <DetailCard title="Turn changes" icon={FileDiff}>
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <strong style={{ color: "var(--text-primary)" }}>
+            {changes.changedFileCount} changed {changes.changedFileCount === 1 ? "file" : "files"}
+          </strong>
+          <span style={{ color: "var(--success)" }}>+{changes.additions}</span>
+          <span style={{ color: "var(--danger)" }}>-{changes.deletions}</span>
+          {changes.partial ? <span className="rounded-full border px-2 py-0.5 text-xs" style={{ borderColor: "var(--warning)", color: "var(--warning)" }}>Partial</span> : null}
+        </div>
+      </DetailCard>
+      <ul className="grid gap-2">
+        {changes.files.map((file) => (
+          <li key={file.resource.id} className="flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-sm" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}>
+            <span className="min-w-0 truncate" style={{ color: "var(--text-primary)" }}>{file.resource.label}</span>
+            <span className="shrink-0 text-xs" style={{ color: "var(--text-tertiary)" }}>{titleCase(file.changeKind)}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function FilesPanel({ projection }: { projection: CanonicalChatInspectorProjection }) {
+  return (
+    <ul className="grid gap-2">
+      {projection.files.map((file) => (
+        <li key={`${file.kind}:${file.id}`} className="rounded-md border px-3 py-2" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}>
+          <p className="truncate text-sm font-medium" style={{ color: "var(--text-primary)" }}>{file.label}</p>
+          <p className="mt-0.5 text-xs" style={{ color: "var(--text-tertiary)" }}>{titleCase(file.kind)}</p>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function pendingState(state: ChatInspectorPendingProps["state"]): ReactNode {
+  return (
+    <div className="flex min-h-48 flex-1 items-center justify-center p-6 text-center">
+      <p
+        role={state === "error" ? "alert" : state === "loading" ? "status" : undefined}
+        className="max-w-xs text-sm"
+        style={{ color: state === "error" ? "var(--danger)" : "var(--text-secondary)" }}
+      >
+        {STATUS_COPY[state]}
+      </p>
+    </div>
+  );
+}
+
+export function ChatInspector(props: ChatInspectorProps) {
+  if (props.state !== "ready") {
+    return (
+      <aside aria-label="Chat details" className="flex min-h-0 min-w-0 flex-1 flex-col" style={{ background: "var(--bg-sunken)" }}>
+        {pendingState(props.state)}
+      </aside>
+    );
+  }
+
+  const { projection } = props;
+  const tabs: Array<InspectorTabDefinition<ChatInspectorTab>> = [
+    { id: "context", label: "Context", icon: FolderKanban, content: <ContextPanel projection={projection} /> },
+    ...(projection.run ? [{ id: "run" as const, label: "Run", icon: Activity, content: <RunPanel projection={projection} /> }] : []),
+    ...(props.approvals ? [{ id: "approvals" as const, label: "Approvals", icon: ShieldCheck, count: props.approvals.count, content: props.approvals.content }] : []),
+    {
+      id: "changes",
+      label: "Changes",
+      icon: FileDiff,
+      count: projection.changes.availability === "available" ? projection.changes.changedFileCount : undefined,
+      content: <ChangesPanel projection={projection} />,
+    },
+    ...(projection.files.length > 0 ? [{ id: "files" as const, label: "Files", icon: Files, count: projection.files.length, content: <FilesPanel projection={projection} /> }] : []),
+  ];
+  const defaultTab = props.defaultTab && tabs.some((tab) => tab.id === props.defaultTab)
+    ? props.defaultTab
+    : "context";
+
+  return (
+    <aside aria-label="Chat details" className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden" style={{ background: "var(--bg-sunken)" }}>
+      <InspectorTabShell
+        ariaLabel="Chat details"
+        tabs={tabs}
+        defaultTab={defaultTab}
+        selectedTab={props.selectedTab}
+        onTabChange={props.onTabChange}
+        header={(
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0">
+              <h2 className="truncate text-sm font-semibold" style={{ color: "var(--text-primary)" }}>Chat details</h2>
+              <p className="truncate text-xs" style={{ color: "var(--text-tertiary)" }}>Context and activity for this Chat</p>
+            </div>
+            {props.headerActions}
+          </div>
+        )}
+      />
+    </aside>
+  );
+}

--- a/desktop/src/renderer/src/features/chat/InspectorTabShell.tsx
+++ b/desktop/src/renderer/src/features/chat/InspectorTabShell.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import * as RadixTooltip from "@radix-ui/react-tooltip";
 import type { LucideIcon } from "lucide-react";
+import { DESKTOP_Z_INDEX } from "../../design/layering";
 
 export interface InspectorTabDefinition<TTab extends string> {
   id: TTab;
@@ -55,7 +56,13 @@ export function InspectorTabShell<TTab extends string>({
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const tablistRef = useRef<HTMLDivElement | null>(null);
   const [labelsVisible, setLabelsVisible] = useState(false);
-  const [visitedTabs, setVisitedTabs] = useState<TTab[]>(() => [safeDefaultTab]);
+  const [visitedTabs, setVisitedTabs] = useState<TTab[]>(() => (
+    controlledTab !== undefined
+      && controlledTab !== safeDefaultTab
+      && tabIds.includes(controlledTab)
+      ? [safeDefaultTab, controlledTab]
+      : [safeDefaultTab]
+  ));
   const visitedTabSet = useMemo(() => new Set(visitedTabs), [visitedTabs]);
 
   useEffect(() => {
@@ -166,8 +173,9 @@ export function InspectorTabShell<TTab extends string>({
                 <RadixTooltip.Portal>
                   <RadixTooltip.Content
                     sideOffset={6}
-                    className="z-[100] rounded-md px-2 py-1 text-xs"
+                    className="rounded-md px-2 py-1 text-xs"
                     style={{
+                      zIndex: DESKTOP_Z_INDEX.popover,
                       background: "var(--forest-deep)",
                       color: "var(--forest-foreground)",
                       boxShadow: "var(--shadow-2)",

--- a/desktop/src/renderer/src/features/chat/InspectorTabShell.tsx
+++ b/desktop/src/renderer/src/features/chat/InspectorTabShell.tsx
@@ -1,0 +1,204 @@
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
+import * as RadixTooltip from "@radix-ui/react-tooltip";
+import type { LucideIcon } from "lucide-react";
+
+export interface InspectorTabDefinition<TTab extends string> {
+  id: TTab;
+  label: string;
+  icon: LucideIcon;
+  count?: number;
+  content: ReactNode;
+}
+
+interface InspectorTabSelectionRequest<TTab extends string> {
+  id: number;
+  consumedId: number;
+  tab: TTab;
+  onConsumed?: (requestId: number) => void;
+}
+
+interface InspectorTabShellProps<TTab extends string> {
+  ariaLabel: string;
+  tabs: readonly InspectorTabDefinition<TTab>[];
+  defaultTab: TTab;
+  selectedTab?: TTab;
+  onTabChange?: (tab: TTab) => void;
+  selectionRequest?: InspectorTabSelectionRequest<TTab>;
+  header?: ReactNode;
+}
+
+const TAB_LABEL_MIN_WIDTH_PX = 96;
+
+export function InspectorTabShell<TTab extends string>({
+  ariaLabel,
+  tabs,
+  defaultTab,
+  selectedTab: controlledTab,
+  onTabChange,
+  selectionRequest,
+  header,
+}: InspectorTabShellProps<TTab>) {
+  const tabIds = useMemo(() => tabs.map((tab) => tab.id), [tabs]);
+  const safeDefaultTab = tabIds.includes(defaultTab) ? defaultTab : tabIds[0]!;
+  const [internalTab, setInternalTab] = useState<TTab>(safeDefaultTab);
+  const requestedTab = controlledTab ?? internalTab;
+  const selectedTab = tabIds.includes(requestedTab) ? requestedTab : safeDefaultTab;
+  const instanceId = useId();
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const tablistRef = useRef<HTMLDivElement | null>(null);
+  const [labelsVisible, setLabelsVisible] = useState(false);
+  const [visitedTabs, setVisitedTabs] = useState<TTab[]>(() => [safeDefaultTab]);
+  const visitedTabSet = useMemo(() => new Set(visitedTabs), [visitedTabs]);
+
+  useEffect(() => {
+    if (controlledTab === undefined || !tabIds.includes(controlledTab)) return;
+    setVisitedTabs((current) => current.includes(controlledTab) ? current : [...current, controlledTab]);
+  }, [controlledTab, tabIds]);
+
+  useEffect(() => {
+    const node = tablistRef.current;
+    if (!node || typeof ResizeObserver !== "function") return undefined;
+    const threshold = tabs.length * TAB_LABEL_MIN_WIDTH_PX;
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width ?? node.clientWidth;
+      setLabelsVisible(width >= threshold);
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [tabs.length]);
+
+  function selectTab(tab: TTab, focusIndex?: number) {
+    setVisitedTabs((current) => current.includes(tab) ? current : [...current, tab]);
+    if (controlledTab === undefined) setInternalTab(tab);
+    onTabChange?.(tab);
+    if (focusIndex !== undefined) tabRefs.current[focusIndex]?.focus();
+  }
+
+  useEffect(() => {
+    if (!selectionRequest || selectionRequest.id <= selectionRequest.consumedId) return;
+    selectionRequest.onConsumed?.(selectionRequest.id);
+    if (tabIds.includes(selectionRequest.tab)) selectTab(selectionRequest.tab);
+    // The request is an explicit one-shot signal. Re-running on incidental
+    // callback identity changes would incorrectly steal focus.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectionRequest?.consumedId, selectionRequest?.id]);
+
+  function handleTabKeyDown(event: KeyboardEvent<HTMLButtonElement>, index: number) {
+    let nextIndex: number | undefined;
+    if (event.key === "ArrowRight") nextIndex = (index + 1) % tabs.length;
+    else if (event.key === "ArrowLeft") nextIndex = (index - 1 + tabs.length) % tabs.length;
+    else if (event.key === "Home") nextIndex = 0;
+    else if (event.key === "End") nextIndex = tabs.length - 1;
+    if (nextIndex === undefined) return;
+    event.preventDefault();
+    selectTab(tabs[nextIndex]!.id, nextIndex);
+  }
+
+  return (
+    <RadixTooltip.Provider delayDuration={400}>
+      <div className="flex min-h-0 flex-1 flex-col">
+        {header ? (
+          <div
+            className="shrink-0 border-b px-4 pb-3 pt-4"
+            style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+          >
+            {header}
+          </div>
+        ) : null}
+        <div
+          ref={tablistRef}
+          role="tablist"
+          aria-label={ariaLabel}
+          className="grid shrink-0 gap-1 border-b p-1.5"
+          style={{
+            gridTemplateColumns: `repeat(${tabs.length}, minmax(0, 1fr))`,
+            borderColor: "var(--border-subtle)",
+            background: "var(--bg-sunken)",
+          }}
+        >
+          {tabs.map((tab, index) => {
+            const selected = tab.id === selectedTab;
+            const TabIcon = tab.icon;
+            return (
+              <RadixTooltip.Root key={tab.id}>
+                <RadixTooltip.Trigger asChild>
+                  <button
+                    ref={(node) => { tabRefs.current[index] = node; }}
+                    id={`${instanceId}-${tab.id}-tab`}
+                    type="button"
+                    role="tab"
+                    aria-label={tab.count === undefined ? tab.label : `${tab.label} ${tab.count}`}
+                    aria-selected={selected}
+                    aria-controls={`${instanceId}-${tab.id}-panel`}
+                    tabIndex={selected ? 0 : -1}
+                    className="no-drag flex min-w-0 items-center justify-center gap-1.5 overflow-hidden rounded-md border px-2 py-2 text-[11px] font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                    style={{
+                      borderColor: selected ? "var(--border-default)" : "transparent",
+                      background: selected ? "var(--bg-raised)" : "transparent",
+                      color: selected ? "var(--text-primary)" : "var(--text-tertiary)",
+                    }}
+                    onClick={() => selectTab(tab.id)}
+                    onKeyDown={(event) => handleTabKeyDown(event, index)}
+                  >
+                    <TabIcon size={14} className="shrink-0" aria-hidden="true" />
+                    {labelsVisible ? <span className="whitespace-nowrap">{tab.label}</span> : null}
+                    {tab.count === undefined ? null : (
+                      <span
+                        className="min-w-3.5 shrink-0 rounded-full px-0.5 text-center text-[9px] tabular-nums"
+                        style={{
+                          background: selected ? "var(--accent-muted)" : "var(--bg-surface)",
+                          color: selected ? "var(--accent)" : "var(--text-tertiary)",
+                        }}
+                      >
+                        {tab.count}
+                      </span>
+                    )}
+                  </button>
+                </RadixTooltip.Trigger>
+                <RadixTooltip.Portal>
+                  <RadixTooltip.Content
+                    sideOffset={6}
+                    className="z-[100] rounded-md px-2 py-1 text-xs"
+                    style={{
+                      background: "var(--forest-deep)",
+                      color: "var(--forest-foreground)",
+                      boxShadow: "var(--shadow-2)",
+                    }}
+                  >
+                    {tab.label}
+                  </RadixTooltip.Content>
+                </RadixTooltip.Portal>
+              </RadixTooltip.Root>
+            );
+          })}
+        </div>
+        {tabs.map((tab) => {
+          const selected = tab.id === selectedTab;
+          return (
+            <div
+              key={tab.id}
+              id={`${instanceId}-${tab.id}-panel`}
+              role="tabpanel"
+              aria-labelledby={`${instanceId}-${tab.id}-tab`}
+              tabIndex={selected ? 0 : -1}
+              hidden={!selected}
+              className="flex min-h-0 flex-1 flex-col overflow-y-auto outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--accent)]"
+            >
+              {selected || visitedTabSet.has(tab.id) ? (
+                <div className="flex min-h-0 flex-1 flex-col p-4">{tab.content}</div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </RadixTooltip.Provider>
+  );
+}

--- a/desktop/src/renderer/src/features/coding-agents/AgentConversationInspector.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentConversationInspector.tsx
@@ -1,6 +1,9 @@
-import { useEffect, useId, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
-import * as RadixTooltip from "@radix-ui/react-tooltip";
+import type { ReactNode } from "react";
 import { Activity, FileDiff, FolderOpen, Globe, SquareTerminal, type LucideIcon } from "lucide-react";
+import {
+  InspectorTabShell,
+  type InspectorTabDefinition,
+} from "../chat/InspectorTabShell";
 
 export type AgentConversationInspectorTab = "changes" | "files" | "terminal" | "preview" | "activity";
 
@@ -15,9 +18,6 @@ interface InspectorCounts {
 interface AgentConversationInspectorProps {
   defaultTab: AgentConversationInspectorTab;
   tabs?: readonly AgentConversationInspectorTab[];
-  // Optional controlled selection. When both are provided the parent owns the
-  // active tab (e.g. to gate live resources like an embedded terminal socket
-  // on the Terminal surface being visible).
   selectedTab?: AgentConversationInspectorTab;
   onTabChange?: (tab: AgentConversationInspectorTab) => void;
   changesFocusRequestId?: number;
@@ -27,9 +27,6 @@ interface AgentConversationInspectorProps {
   toolbar: ReactNode;
   composer?: ReactNode;
   changes: ReactNode;
-  // Optional surface rendered as a tab between Changes and Terminal when
-  // provided; omitted entirely otherwise so existing four-tab layouts keep
-  // their tab order and keyboard navigation.
   files?: ReactNode;
   terminal: ReactNode;
   preview: ReactNode;
@@ -52,16 +49,10 @@ const TAB_ICONS: Record<AgentConversationInspectorTab, LucideIcon> = {
   activity: Activity,
 };
 
-// Tabs are icon-first: a tab shows its full label only when the tablist is
-// wide enough for every tab to carry icon + label + badge without truncation
-// (~96px per tab). Below that the icon and count badge stand alone and the
-// tooltip carries the name — labels never ellipsis.
-const TAB_LABEL_MIN_WIDTH_PX = 96;
-
 export function AgentConversationInspector({
   defaultTab,
   tabs: requestedTabs,
-  selectedTab: controlledTab,
+  selectedTab,
   onTabChange,
   changesFocusRequestId = 0,
   changesFocusConsumedId = 0,
@@ -78,17 +69,7 @@ export function AgentConversationInspector({
   const defaultTabs: AgentConversationInspectorTab[] = files === undefined
     ? ["changes", "terminal", "preview", "activity"]
     : ["changes", "files", "terminal", "preview", "activity"];
-  const tabs = requestedTabs && requestedTabs.length > 0 ? [...requestedTabs] : defaultTabs;
-  const safeDefaultTab = tabs.includes(defaultTab) ? defaultTab : tabs[0]!;
-  const [internalTab, setInternalTab] = useState<AgentConversationInspectorTab>(safeDefaultTab);
-  const requestedSelectedTab = controlledTab ?? internalTab;
-  const selectedTab = tabs.includes(requestedSelectedTab) ? requestedSelectedTab : safeDefaultTab;
-  const instanceId = useId();
-  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
-  const tablistRef = useRef<HTMLDivElement | null>(null);
-  // Icon-only until the tablist proves it has room for full labels.
-  const [labelsVisible, setLabelsVisible] = useState(false);
-
+  const tabIds = requestedTabs && requestedTabs.length > 0 ? [...requestedTabs] : defaultTabs;
   const content: Record<AgentConversationInspectorTab, ReactNode> = {
     changes,
     files,
@@ -96,167 +77,33 @@ export function AgentConversationInspector({
     preview,
     activity,
   };
-
-  // Lazy-mount surfaces on first visit so a never-opened tab (file listings,
-  // live previews) costs nothing; once visited a surface stays mounted across
-  // switches so local state (drafts, scrollback, selection) survives.
-  const [visitedTabs, setVisitedTabs] = useState<AgentConversationInspectorTab[]>(() =>
-    controlledTab !== undefined
-      && controlledTab !== safeDefaultTab
-      && tabs.includes(controlledTab)
-      ? [safeDefaultTab, controlledTab]
-      : [safeDefaultTab],
-  );
-  const visitedTabSet = useMemo(() => new Set(visitedTabs), [visitedTabs]);
-
-  // Labels appear only when every tab fits icon + label + badge; otherwise
-  // the tabs stay icon-first with tooltips carrying the names.
-  useEffect(() => {
-    const node = tablistRef.current;
-    if (!node || typeof ResizeObserver !== "function") return undefined;
-    const threshold = tabs.length * TAB_LABEL_MIN_WIDTH_PX;
-    const observer = new ResizeObserver((entries) => {
-      const width = entries[0]?.contentRect.width ?? node.clientWidth;
-      setLabelsVisible(width >= threshold);
-    });
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [tabs.length]);
-
-  function selectTab(tab: AgentConversationInspectorTab, focusIndex?: number) {
-    setVisitedTabs((current) => current.includes(tab) ? current : [...current, tab]);
-    if (controlledTab === undefined) setInternalTab(tab);
-    onTabChange?.(tab);
-    if (focusIndex !== undefined) tabRefs.current[focusIndex]?.focus();
-  }
-
-  // A focus request is a one-shot signal consumed exactly once, tracked by the
-  // owner via the consumed marker. That honors a request raised before this
-  // inspector mounts (the command palette selects a review, then opens the
-  // Agents tab) while an already-consumed id cannot re-force the Changes pane
-  // on later remounts, and the runtime-switch reset to zero is not a request.
-  useEffect(() => {
-    if (changesFocusRequestId <= changesFocusConsumedId) return;
-    onChangesFocusConsumed?.(changesFocusRequestId);
-    if (tabs.includes("changes")) selectTab("changes");
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [changesFocusConsumedId, changesFocusRequestId, onChangesFocusConsumed]);
-
-  function handleTabKeyDown(event: KeyboardEvent<HTMLButtonElement>, index: number) {
-    if (event.key === "ArrowRight") {
-      event.preventDefault();
-      const next = (index + 1) % tabs.length;
-      selectTab(tabs[next]!, next);
-    } else if (event.key === "ArrowLeft") {
-      event.preventDefault();
-      const next = (index - 1 + tabs.length) % tabs.length;
-      selectTab(tabs[next]!, next);
-    } else if (event.key === "Home") {
-      event.preventDefault();
-      selectTab(tabs[0]!, 0);
-    } else if (event.key === "End") {
-      event.preventDefault();
-      const last = tabs.length - 1;
-      selectTab(tabs[last]!, last);
-    }
-  }
+  const tabs: Array<InspectorTabDefinition<AgentConversationInspectorTab>> = tabIds.map((tab) => ({
+    id: tab,
+    label: TAB_LABELS[tab],
+    icon: TAB_ICONS[tab],
+    count: counts[tab],
+    content: content[tab],
+  }));
 
   return (
-    <RadixTooltip.Provider delayDuration={400}>
-      <div className="flex min-h-0 flex-1 flex-col">
-        <div
-          className="shrink-0 space-y-3 border-b px-4 pb-3 pt-4"
-          style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
-        >
+    <InspectorTabShell
+      ariaLabel="Conversation tools"
+      tabs={tabs}
+      defaultTab={defaultTab}
+      selectedTab={selectedTab}
+      onTabChange={onTabChange}
+      selectionRequest={{
+        id: changesFocusRequestId,
+        consumedId: changesFocusConsumedId,
+        tab: "changes",
+        onConsumed: onChangesFocusConsumed,
+      }}
+      header={(
+        <div className="space-y-3">
           {toolbar}
           {composer}
         </div>
-        <div
-          ref={tablistRef}
-          role="tablist"
-          aria-label="Conversation tools"
-          className="grid shrink-0 gap-1 border-b p-1.5"
-          style={{
-            gridTemplateColumns: `repeat(${tabs.length}, minmax(0, 1fr))`,
-            borderColor: "var(--border-subtle)",
-            background: "var(--bg-sunken)",
-          }}
-        >
-        {tabs.map((tabId, index) => {
-          const selected = tabId === selectedTab;
-          const label = TAB_LABELS[tabId];
-          const TabIcon = TAB_ICONS[tabId];
-          // Surfaces without a meaningful count (the file browser) render no
-          // badge rather than a permanent zero.
-          const count = counts[tabId];
-          return (
-            <RadixTooltip.Root key={tabId}>
-              <RadixTooltip.Trigger asChild>
-                <button
-                  ref={(node) => { tabRefs.current[index] = node; }}
-                  id={`${instanceId}-${tabId}-tab`}
-                  type="button"
-                  role="tab"
-                  aria-label={count === undefined ? label : `${label} ${count}`}
-                  aria-selected={selected}
-                  aria-controls={`${instanceId}-${tabId}-panel`}
-                  tabIndex={selected ? 0 : -1}
-                  className="no-drag flex min-w-0 items-center justify-center gap-1.5 overflow-hidden rounded-md border px-2 py-2 text-[11px] font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
-                  style={{
-                    borderColor: selected ? "var(--border-default)" : "transparent",
-                    background: selected ? "var(--bg-raised)" : "transparent",
-                    color: selected ? "var(--text-primary)" : "var(--text-tertiary)",
-                  }}
-                  onClick={() => selectTab(tabId)}
-                  onKeyDown={(event) => handleTabKeyDown(event, index)}
-                >
-                  <TabIcon size={14} className="shrink-0" aria-hidden="true" />
-                  {labelsVisible ? <span className="whitespace-nowrap">{label}</span> : null}
-                  {count === undefined ? null : (
-                    <span
-                      className="min-w-3.5 shrink-0 rounded-full px-0.5 text-center text-[9px] tabular-nums"
-                      style={{
-                        background: selected ? "var(--accent-muted)" : "var(--bg-surface)",
-                        color: selected ? "var(--accent)" : "var(--text-tertiary)",
-                      }}
-                    >
-                      {count}
-                    </span>
-                  )}
-                </button>
-              </RadixTooltip.Trigger>
-              <RadixTooltip.Portal>
-                <RadixTooltip.Content
-                  sideOffset={6}
-                  className="z-[100] rounded-md px-2 py-1 text-xs"
-                  style={{ background: "var(--forest-deep)", color: "var(--forest-foreground)", boxShadow: "var(--shadow-2)" }}
-                >
-                  {label}
-                </RadixTooltip.Content>
-              </RadixTooltip.Portal>
-            </RadixTooltip.Root>
-          );
-        })}
-        </div>
-        {tabs.map((tabId) => {
-          const selected = tabId === selectedTab;
-          return (
-            <div
-              key={tabId}
-              id={`${instanceId}-${tabId}-panel`}
-              role="tabpanel"
-              aria-labelledby={`${instanceId}-${tabId}-tab`}
-              tabIndex={selected ? 0 : -1}
-              hidden={!selected}
-              className="flex min-h-0 flex-1 flex-col overflow-y-auto outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--accent)]"
-            >
-              {selected || visitedTabSet.has(tabId) ? (
-                <div className="flex min-h-0 flex-1 flex-col p-4">{content[tabId]}</div>
-              ) : null}
-            </div>
-          );
-        })}
-      </div>
-    </RadixTooltip.Provider>
+      )}
+    />
   );
 }

--- a/tests/desktop/chat-inspector.test.tsx
+++ b/tests/desktop/chat-inspector.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ChatInspector } from "../../desktop/src/renderer/src/features/chat/ChatInspector";
+import { DESKTOP_Z_INDEX } from "../../desktop/src/renderer/src/design/layering";
 import {
   createCanonicalChatFixture,
   createCanonicalInspectorFixture,
@@ -85,5 +86,51 @@ describe("ChatInspector", () => {
     context.focus();
     fireEvent.keyDown(context, { key: "ArrowRight" });
     expect(document.activeElement).toBe(screen.getByRole("tab", { name: /^Changes\b/ }));
+  });
+
+  it("mounts a non-default controlled tab on the first render and retains its live surface", () => {
+    const projection = createCanonicalInspectorFixture("available");
+    const view = render(
+      <ChatInspector
+        state="ready"
+        projection={projection}
+        defaultTab="context"
+        selectedTab="files"
+      />,
+    );
+
+    const filesTab = screen.getByRole("tab", { name: /^Files\b/ });
+    const filesPanel = document.getElementById(filesTab.getAttribute("aria-controls")!);
+    expect(filesPanel).not.toBeNull();
+    expect(within(filesPanel!).getByText("packages/gateway/src/routes.ts")).toBeTruthy();
+
+    view.rerender(
+      <ChatInspector
+        state="ready"
+        projection={projection}
+        defaultTab="context"
+        selectedTab="context"
+      />,
+    );
+
+    expect(filesPanel!.hidden).toBe(true);
+    expect(within(filesPanel!).getByText("packages/gateway/src/routes.ts")).toBeTruthy();
+  });
+
+  it("keeps tab tooltips inside the centralized desktop popover layer", async () => {
+    render(
+      <ChatInspector
+        state="ready"
+        projection={createCanonicalInspectorFixture("available")}
+      />,
+    );
+
+    fireEvent.focus(screen.getByRole("tab", { name: /^Context\b/ }));
+
+    await waitFor(() => {
+      const tooltipSurface = document.querySelector<HTMLElement>("[data-side][data-align]");
+      expect(tooltipSurface).not.toBeNull();
+      expect(tooltipSurface!.style.zIndex).toBe(String(DESKTOP_Z_INDEX.popover));
+    });
   });
 });

--- a/tests/desktop/chat-inspector.test.tsx
+++ b/tests/desktop/chat-inspector.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChatInspector } from "../../desktop/src/renderer/src/features/chat/ChatInspector";
+import {
+  createCanonicalChatFixture,
+  createCanonicalInspectorFixture,
+} from "../contracts/fixtures/canonical-chat";
+
+afterEach(cleanup);
+afterEach(() => vi.unstubAllGlobals());
+
+describe("ChatInspector", () => {
+  it("renders provider-neutral context, changes, and files from the canonical projection", () => {
+    render(
+      <ChatInspector
+        state="ready"
+        projection={createCanonicalInspectorFixture("available")}
+      />,
+    );
+
+    expect(screen.getByRole("complementary", { name: "Chat details" })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /^Context\b/ }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.getByText("Matrix OS")).toBeTruthy();
+    expect(screen.getByText("HamedMP/matrix-os")).toBeTruthy();
+    expect(screen.getByText("Project workspace")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("tab", { name: /^Changes\b/ }));
+    expect(screen.getByText("1 changed file")).toBeTruthy();
+    expect(screen.getByText("+20")).toBeTruthy();
+    expect(screen.getByText("-1")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("tab", { name: /^Files\b/ }));
+    const filesTab = screen.getByRole("tab", { name: /^Files\b/ });
+    const filesPanelId = filesTab.getAttribute("aria-controls");
+    const filesPanel = filesPanelId ? document.getElementById(filesPanelId) : null;
+    expect(filesPanel).not.toBeNull();
+    expect(within(filesPanel!).getByText("packages/gateway/src/routes.ts")).toBeTruthy();
+  });
+
+  it("shows Run and Approvals only when canonical data or a canonical slot supports them", () => {
+    const fixture = createCanonicalChatFixture("running");
+    render(
+      <ChatInspector
+        state="ready"
+        projection={fixture.snapshot.inspector}
+        approvals={{ count: 1, content: <div>Approve package changes</div> }}
+      />,
+    );
+
+    expect(screen.getByRole("tab", { name: /^Run\b/ })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /^Approvals 1$/ })).toBeTruthy();
+    expect(screen.queryByRole("tab", { name: /^Files\b/ })).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: /^Run\b/ }));
+    expect(screen.getByText("GPT-5.6-Sol")).toBeTruthy();
+    expect(screen.getByText("Codex")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("tab", { name: /^Approvals 1$/ }));
+    expect(screen.getByText("Approve package changes")).toBeTruthy();
+  });
+
+  it("renders bounded loading, empty, and error states without provider details", () => {
+    const loading = render(<ChatInspector state="loading" />);
+    expect(screen.getByRole("status").textContent).toContain("Loading chat details");
+
+    loading.rerender(<ChatInspector state="empty" />);
+    expect(screen.getByText("Select a chat to inspect its context and activity.")).toBeTruthy();
+
+    loading.rerender(<ChatInspector state="error" />);
+    expect(screen.getByRole("alert").textContent).toContain("Chat details couldn't be loaded");
+  });
+
+  it("keeps canonical tabs keyboard navigable", () => {
+    render(
+      <ChatInspector
+        state="ready"
+        projection={createCanonicalInspectorFixture("available")}
+      />,
+    );
+
+    const context = screen.getByRole("tab", { name: /^Context\b/ });
+    context.focus();
+    fireEvent.keyDown(context, { key: "ArrowRight" });
+    expect(document.activeElement).toBe(screen.getByRole("tab", { name: /^Changes\b/ }));
+  });
+});


### PR DESCRIPTION
## Summary

- add a provider-neutral Chat inspector backed by canonical Chat projections
- extract the existing coding-agent inspector tabs into a reusable accessible shell
- preserve the legacy agent inspector API while enabling Context, Run, Approvals, Changes, and Files slots
- fix controlled non-default tab first-render blank state
- use the centralized Desktop popover z-index for tab tooltips

Closes MAT-475.

## Tests

- focused ChatInspector: 6/6 passed
- related Inspector regressions: 32/32 passed
- Desktop typecheck passed
- production Electron build passed
- `git diff --check` passed
- React Doctor: no errors; one intentional visited-tab history-effect warning

## Current stage

Human Review at exact head `da810448e`.

The interactive Desktop review uses a non-committed preview harness because MAT-475 explicitly delivers the fixture-driven shell; live Chat selection/data wiring remains deferred to MAT-481. Exact-component screenshots and review steps are attached to MAT-475.

Keep this PR Draft. Do not re-request Greptile or mark Ready for Review until product Human Review is approved.

## Invariants

### Source of truth

- canonical Chat inspector projections from `@matrix-os/contracts` are the source of truth
- the Desktop shell renders projections and does not derive or persist provider-specific Chat state

### Lock/transaction scope

- not applicable; this PR adds renderer-only components and performs no writes

### Acceptable orphan states

- not applicable; no durable entities or external resources are created

### Auth source of truth

- unchanged; this renderer-only slice introduces no auth boundary

### Deferred scope

- wiring the inspector to live Chat selection and data loading
- exact changed-file and file-preview integration tracked by MAT-478/MAT-481
