### PR TITLE
fix(vps): keep cloud-init compatible with older bundles

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -675,10 +675,10 @@ runcmd:
       chown root:matrix /opt/matrix/release.json
       chmod 0644 /opt/matrix/release.json
     fi
-    for required_bin in matrixctl matrix-db-backup.sh matrix-restore.sh matrix-owner-env matrix-gateway matrix-shell matrix-code matrix-sync-agent matrix-integrations matrix-integrations-mcp matrix-register-integrations-mcp matrix-symphony matrix-symphony-control matrix-install-hermes; do
+    for required_bin in matrixctl matrix-db-backup.sh matrix-restore.sh matrix-owner-env matrix-gateway matrix-shell matrix-code matrix-sync-agent matrix-symphony matrix-symphony-control matrix-install-hermes; do
       chmod 0750 "/opt/matrix/bin/${required_bin}"
     done
-    for optional_bin in matrix-hermes-dashboard matrix-install-openclaw matrix-openclaw-gateway matrix-agent-runtime-control matrix-install-linux-tools matrix-install-developer-tools matrix-messaging-health matrix-messaging-backup matrix-messaging-restore; do
+    for optional_bin in matrix-integrations matrix-integrations-mcp matrix-register-integrations-mcp matrix-hermes-dashboard matrix-install-openclaw matrix-openclaw-gateway matrix-agent-runtime-control matrix-install-linux-tools matrix-install-developer-tools matrix-messaging-health matrix-messaging-backup matrix-messaging-restore; do
       if [ -e "/opt/matrix/bin/${optional_bin}" ]; then
         chmod 0750 "/opt/matrix/bin/${optional_bin}"
       fi
@@ -720,7 +720,9 @@ runcmd:
     runuser -u matrix -- env HOME=/home/matrix/home XDG_RUNTIME_DIR="/run/user/${matrix_uid}" DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/${matrix_uid}/bus" systemctl --user daemon-reload
     systemctl disable matrix-openclaw-gateway.service || true
     systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer nginx
-    systemctl enable matrix-integrations-agents.service
+    if [ -f /etc/systemd/system/matrix-integrations-agents.service ] && [ -x /opt/matrix/bin/matrix-register-integrations-mcp ]; then
+      systemctl enable matrix-integrations-agents.service
+    fi
     systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-sync-agent.service matrix-symphony.service
     log_bootstrap_phase core_services_started
     systemctl start --no-block matrix-code-server.service || echo "matrix-host: code-server runtime install will retry via systemd" >&2
@@ -729,7 +731,9 @@ runcmd:
     systemctl start --no-block matrix-hermes-dashboard.service || echo "matrix-host: optional Hermes dashboard will retry via systemd" >&2
     systemctl start --no-block matrix-linux-tools.service || echo "matrix-host: optional Linux tools install will retry via systemd" >&2
     systemctl start --no-block matrix-developer-tools.service || echo "matrix-host: optional developer tools install will retry via systemd" >&2
-    systemctl start --no-block matrix-integrations-agents.service || echo "matrix-host: agent integration registration will retry via systemd" >&2
+    if [ -f /etc/systemd/system/matrix-integrations-agents.service ] && [ -x /opt/matrix/bin/matrix-register-integrations-mcp ]; then
+      systemctl start --no-block matrix-integrations-agents.service || echo "matrix-host: agent integration registration will retry via systemd" >&2
+    fi
     if [ -x /opt/matrix/messaging/bin/synapse ] && [ -x /opt/matrix/messaging/bin/mautrix-telegram ] && [ -x /opt/matrix/messaging/bin/mautrix-whatsapp ]; then
       systemctl enable matrix-homeserver.service matrix-bridge-telegram.service matrix-bridge-whatsapp.service
       systemctl start --no-block matrix-homeserver.service matrix-bridge-telegram.service matrix-bridge-whatsapp.service || echo "matrix-host: optional messaging services will retry via systemd" >&2

--- a/tests/deploy/customer-vps/integrations-mcp-registration.test.ts
+++ b/tests/deploy/customer-vps/integrations-mcp-registration.test.ts
@@ -72,6 +72,23 @@ describe("customer VPS integrations MCP wiring", () => {
     expect(updater).toContain("sudo systemctl restart --no-block matrix-integrations-agents.service");
   });
 
+  it("keeps certified snapshots from before integrations MCP bootable", async () => {
+    const cloudInit = await readFile("distro/customer-vps/cloud-init.yaml", "utf8");
+    const integrationBins = [
+      "matrix-integrations",
+      "matrix-integrations-mcp",
+      "matrix-register-integrations-mcp",
+    ];
+    const requiredBins = cloudInit.match(/for required_bin in ([^;]+); do/)?.[1]?.split(" ") ?? [];
+    const optionalBins = cloudInit.match(/for optional_bin in ([^;]+); do/)?.[1]?.split(" ") ?? [];
+
+    expect(requiredBins).not.toEqual(expect.arrayContaining(integrationBins));
+    expect(optionalBins).toEqual(expect.arrayContaining(integrationBins));
+    expect(cloudInit).toContain(
+      'if [ -f /etc/systemd/system/matrix-integrations-agents.service ] && [ -x /opt/matrix/bin/matrix-register-integrations-mcp ]; then',
+    );
+  });
+
   it("applies one-time Matrix skill defaults after installing Hermes", async () => {
     const hermes = await readFile("distro/customer-vps/host-bin/matrix-install-hermes", "utf8");
     const build = await readFile("scripts/build-host-bundle.sh", "utf8");

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -405,7 +405,7 @@ exit 99
     expect(cloudInit).toContain('if [ -x /opt/matrix/messaging/bin/synapse ] && [ -x /opt/matrix/messaging/bin/mautrix-telegram ] && [ -x /opt/matrix/messaging/bin/mautrix-whatsapp ]; then');
     expect(cloudInit).toContain('systemctl enable matrix-homeserver.service matrix-bridge-telegram.service matrix-bridge-whatsapp.service');
     expect(cloudInit).toContain('messaging runtimes not installed; units installed but not enabled');
-    expect(cloudInit).toContain('for optional_bin in matrix-hermes-dashboard matrix-install-openclaw matrix-openclaw-gateway matrix-agent-runtime-control matrix-install-linux-tools matrix-install-developer-tools matrix-messaging-health matrix-messaging-backup matrix-messaging-restore; do');
+    expect(cloudInit).toContain('for optional_bin in matrix-integrations matrix-integrations-mcp matrix-register-integrations-mcp matrix-hermes-dashboard matrix-install-openclaw matrix-openclaw-gateway matrix-agent-runtime-control matrix-install-linux-tools matrix-install-developer-tools matrix-messaging-health matrix-messaging-backup matrix-messaging-restore; do');
     expect(cloudInit).toContain('MATRIX_HOST_BUNDLE_URL={{hostBundleUrl}}');
     expect(cloudInit).toContain('MATRIX_IMAGE_VERSION={{imageVersion}}');
     expect(cloudInit).toContain('MATRIX_UPDATE_CHANNEL={{updateChannel}}');


### PR DESCRIPTION
## Summary

- keep core first-boot binaries mandatory while treating integrations MCP assets as optional for older certified snapshots
- conditionally enable and start the integrations agent service only when both its unit and runner exist
- add a regression test for pre-integrations snapshot compatibility

## Root cause

Platform cloud-init containing the integrations MCP bootstrap can run against the pinned stable snapshot `v2026.08.22-1012` at commit `7b377d87`. That immutable snapshot predates the three integrations MCP binaries. The template unconditionally ran `chmod` on those absent paths under `set -e`, aborting first boot before restore, gateway, sync, and platform registration.

## Tests

- RED: the new certified-snapshot compatibility test failed before the implementation (`1 failed, 8 passed`)
- GREEN: focused cloud-init regression suite (`9/9`)
- related cloud-init, host-bundle, and integrations suites (`118/118`)
- `bun run typecheck`
- `bun run check:patterns` (`0` violations; `5` existing warnings)
- `git diff --check`
- isolated reruns of unrelated full-suite timeout/fixture failures passed: golden snapshot repository (`1/1`), terminals tab (`1/1`), session registry (`51/51`)

`bun run test` was attempted but is not presented as a clean acceptance signal: the shared host had two unrelated nine-day-old Vitest workers consuming most CPU, and a stale shared `/tmp/test-home` fixture contaminated the session registry suite. The affected tests passed in isolation; GitHub's sharded CI remains the authoritative broad gate.

## Review and monitoring

- do not merge until the latest trusted Greptile review reports `5/5`
- add `ready-for-ci` only after Greptile reaches `5/5`
- require all checks triggered by that label to pass
- after deployment, verify a disposable VPS reaches restore, runtime service startup, and platform registration from the pinned snapshot

## Invariants

- **Source of truth:** the pinned host bundle/snapshot owns which binaries are available; current platform cloud-init must not assume that an older immutable bundle contains later optional feature assets.
- **Lock/transaction scope:** none; this changes shell bootstrap compatibility only.
- **Acceptable orphan states:** on older bundles the integrations agent service may remain absent, while core restore, runtime startup, sync, and registration must continue.
- **Auth source of truth:** unchanged.
- **Deferred scope:** this does not backport integrations assets into an immutable snapshot; newer bundles retain the integrations service path.
