### PR TITLE
fix(vps): report safe preview provisioning failures

### DIFF
--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -279,6 +279,17 @@ jobs:
             exit 1
           fi
 
+          public_provision_failure_code() {
+            case "$1" in
+              quota_exceeded|snapshot_quota_exceeded|provider_unavailable|provider_timeout|snapshot_clone_rejected|user_data_too_large|r2_unavailable|invalid_state|billing_required|not_found|registration_rejected|registration_timeout|retry_exhausted|unknown)
+                printf '%s\n' "$1"
+                ;;
+              *)
+                printf 'unknown\n'
+                ;;
+            esac
+          }
+
           fleet_machine="$(curl -fsS --max-time 30 \
             -H "authorization: Bearer ${PLATFORM_SECRET}" \
             "${PLATFORM_PUBLIC_URL}/vps/fleet" |
@@ -358,14 +369,18 @@ jobs:
             deadline=$((SECONDS + 600))
             while true; do
               sleep 15
-              status="$(curl -fsS --max-time 30 \
+              machine_state="$(curl -fsS --max-time 30 \
                 -H "authorization: Bearer ${PLATFORM_SECRET}" \
                 "${PLATFORM_PUBLIC_URL}/vps/fleet" |
-                jq -r --arg h "$HANDLE" --arg id "$accepted_machine_id" \
-                  '[.machines[] | select(.handle == $h and .machineId == $id and .deletedAt == null)] | .[0].status // "absent"')"
+                jq -c --arg h "$HANDLE" --arg id "$accepted_machine_id" \
+                  '[.machines[] | select(.handle == $h and .machineId == $id and .deletedAt == null)]
+                   | (.[0] // {status: "absent", failureCode: null})')"
+              status="$(jq -r '.status' <<< "$machine_state")"
               [ "$status" = "running" ] && break
               if [ "$status" = "failed" ]; then
-                echo "Provisioning failed for ${HANDLE}" >&2
+                raw_failure_code="$(jq -r '.failureCode // "unknown"' <<< "$machine_state")"
+                failure_code="$(public_provision_failure_code "$raw_failure_code")"
+                echo "Provisioning failed for ${HANDLE} (${failure_code})" >&2
                 exit 1
               fi
               if [ "$SECONDS" -ge "$deadline" ]; then

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -917,6 +917,19 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
       .toBeLessThan(workflow.indexOf('deadline=$((SECONDS + 600))'));
   });
 
+  it('preview VPS workflow reports only a public-safe coarse provisioning failure', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
+
+    expect(workflow).toContain('public_provision_failure_code()');
+    expect(workflow).toContain(
+      'quota_exceeded|snapshot_quota_exceeded|provider_unavailable|provider_timeout|snapshot_clone_rejected|user_data_too_large|r2_unavailable|invalid_state|billing_required|not_found|registration_rejected|registration_timeout|retry_exhausted|unknown)',
+    );
+    expect(workflow).toContain("printf 'unknown\\n'");
+    expect(workflow).toContain('Provisioning failed for ${HANDLE} (${failure_code})');
+    expect(workflow).not.toContain('Provisioning failed for ${HANDLE} (${raw_failure_code})');
+  });
+
   it('preview VPS workflow safely resumes an existing active preview', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');


### PR DESCRIPTION
## Summary

- read the accepted Preview VPS status and `failureCode` in one fleet snapshot while waiting for first boot
- expose only the fixed public-safe `CustomerVpsFailureCode` allowlist, with `unknown` for unexpected values
- add a workflow-contract regression test for the sanitized failure output

The first-boot defect itself was fixed by #1322: older stable snapshots do not contain the newer integrations MCP binaries, and cloud-init must treat those assets as optional. MAT-484's retry reused the already-failed machine, so it never exercised that merged fix. A fresh disposable Preview now proves the repaired path.

Linear: [MAT-484](https://linear.app/matrix-os/issue/MAT-484/fix-preview-vps-first-boot-remaining-provisioning-then-failing)

## Invariants

- **Source of truth:** persisted Platform fleet state remains authoritative; the workflow reads the accepted machine's coarse `failureCode` and does not infer provider details.
- **Lock / transaction scope:** none added; this workflow change is read-only after the existing provision request and does not alter Platform persistence or leases.
- **Acceptable orphan states:** an unrecognized or missing failure code is reported as `unknown`; the machine stays in its Platform-owned terminal state for operator diagnosis.
- **Auth source of truth:** the existing Platform bearer secret and owner-scoped Preview route are unchanged.
- **Deferred scope:** cloud-init compatibility remains owned by merged PR #1322. MAT-476 Chat work and the inactive second QA Clerk session are intentionally out of scope.

## Verification

- TDD red: `tests/platform/customer-vps-host-bundle.test.ts` failed 1/67 before the classifier existed
- TDD green after rebase on current `origin/main`: 67/67 passed
- `tests/platform/customer-vps-preview-routes.test.ts`: 21/21 passed
- `tests/deploy/customer-vps/integrations-mcp-registration.test.ts`: 9/9 passed, including old-snapshot compatibility
- combined focused run: 138/140 passed; the two failures are unrelated macOS GNU-tool assumptions in `customer-vps-cloud-init.test.ts` (`mv -T` and missing GNU `timeout`)
- `bun run typecheck`: passed
- `bun run check:patterns`: 0 violations, 5 existing warnings
- `git diff --check`: passed

## Real Preview evidence

- teardown `32830713754`: removed the already-failed `pr-1318` VPS
- fresh pinned run `32830804744`: `absent -> provisioning -> running` within the 10-minute budget; runtime and active app both reached exact `v2026.08.25-pr1318-32826664209-1-52ace92`
- retry `32831184644`: completed in 10 seconds, reused the existing running `pr-1318`, and preserved the exact version without duplicate provisioning
- authenticated inventory `32831274499`: the first QA user verified exactly one matching owner Preview; the run then failed because the second configured QA user had no active Clerk session, not because of Preview duplication or runtime health

An exploratory broad-suite run exposed pre-existing failures outside both changed files, including macOS/GNU utility assumptions and unrelated shell/coding-agent timing tests. It was stopped after the branch rebased onto the newly advanced `origin/main`, because the in-flight run no longer represented one exact head; it is not counted as acceptance evidence.
