### PR TITLE
feat(gateway): orchestrate canonical Chat runs

### DIFF
--- a/desktop/src/renderer/src/lib/canonical-chat-client.ts
+++ b/desktop/src/renderer/src/lib/canonical-chat-client.ts
@@ -1,14 +1,28 @@
 import {
+  CanonicalCancelChatRunRequestSchema,
   CanonicalChatApiCursorSchema,
   CanonicalChatDetailResponseSchema,
   CanonicalChatIdSchema,
   CanonicalChatListResponseSchema,
   CanonicalChatRecordSchema,
+  CanonicalChatRunCancellationResponseSchema,
+  CanonicalChatRunAdmissionResponseSchema,
+  CanonicalChatRunIdSchema,
+  CanonicalChatTurnAdmissionResponseSchema,
+  CanonicalChatTurnIdSchema,
   CanonicalCreateChatRequestSchema,
+  CanonicalCreateChatTurnRequestSchema,
+  CanonicalRetryChatTurnRequestSchema,
   type CanonicalChatDetailResponse,
   type CanonicalChatListResponse,
   type CanonicalChatRecord,
+  type CanonicalChatRunCancellationResponse,
+  type CanonicalChatRunAdmissionResponse,
+  type CanonicalChatTurnAdmissionResponse,
+  type CanonicalCancelChatRunRequest,
   type CanonicalCreateChatRequest,
+  type CanonicalCreateChatTurnRequest,
+  type CanonicalRetryChatTurnRequest,
 } from "@matrix-os/contracts";
 import { z } from "zod/v4";
 import type { ApiClient } from "./api";
@@ -32,6 +46,17 @@ export interface CanonicalChatClient {
     chatId: string,
     input?: z.input<typeof CanonicalChatDetailInputSchema>,
   ): Promise<CanonicalChatDetailResponse>;
+  admitTurn(chatId: string, input: CanonicalCreateChatTurnRequest): Promise<CanonicalChatTurnAdmissionResponse>;
+  cancelRun(
+    chatId: string,
+    runId: string,
+    input: CanonicalCancelChatRunRequest,
+  ): Promise<CanonicalChatRunCancellationResponse>;
+  retryTurn(
+    chatId: string,
+    turnId: string,
+    input: CanonicalRetryChatTurnRequest,
+  ): Promise<CanonicalChatRunAdmissionResponse>;
 }
 
 function withQuery(path: string, values: Record<string, string | number | undefined>): string {
@@ -69,6 +94,35 @@ export function createCanonicalChatClient(api: ApiClient): CanonicalChatClient {
         cursor: parsed.cursor,
       }));
       return CanonicalChatDetailResponseSchema.parse(response);
+    },
+
+    async admitTurn(chatId, input) {
+      const parsedChatId = CanonicalChatIdSchema.parse(chatId);
+      const request = CanonicalCreateChatTurnRequestSchema.parse(input);
+      return CanonicalChatTurnAdmissionResponseSchema.parse(await api.post(
+        `/api/chats/${encodeURIComponent(parsedChatId)}/turns`,
+        request,
+      ));
+    },
+
+    async cancelRun(chatId, runId, input) {
+      const parsedChatId = CanonicalChatIdSchema.parse(chatId);
+      const parsedRunId = CanonicalChatRunIdSchema.parse(runId);
+      const request = CanonicalCancelChatRunRequestSchema.parse(input);
+      return CanonicalChatRunCancellationResponseSchema.parse(await api.post(
+        `/api/chats/${encodeURIComponent(parsedChatId)}/runs/${encodeURIComponent(parsedRunId)}/cancel`,
+        request,
+      ));
+    },
+
+    async retryTurn(chatId, turnId, input) {
+      const parsedChatId = CanonicalChatIdSchema.parse(chatId);
+      const parsedTurnId = CanonicalChatTurnIdSchema.parse(turnId);
+      const request = CanonicalRetryChatTurnRequestSchema.parse(input);
+      return CanonicalChatRunAdmissionResponseSchema.parse(await api.post(
+        `/api/chats/${encodeURIComponent(parsedChatId)}/turns/${encodeURIComponent(parsedTurnId)}/runs`,
+        request,
+      ));
     },
   };
 }

--- a/desktop/src/renderer/src/lib/canonical-chat-client.ts
+++ b/desktop/src/renderer/src/lib/canonical-chat-client.ts
@@ -1,0 +1,74 @@
+import {
+  CanonicalChatApiCursorSchema,
+  CanonicalChatDetailResponseSchema,
+  CanonicalChatIdSchema,
+  CanonicalChatListResponseSchema,
+  CanonicalChatRecordSchema,
+  CanonicalCreateChatRequestSchema,
+  type CanonicalChatDetailResponse,
+  type CanonicalChatListResponse,
+  type CanonicalChatRecord,
+  type CanonicalCreateChatRequest,
+} from "@matrix-os/contracts";
+import { z } from "zod/v4";
+import type { ApiClient } from "./api";
+
+const CanonicalChatListInputSchema = z.object({
+  limit: z.number().int().min(1).max(100).optional(),
+  lifecycle: z.enum(["active", "archived"]).optional(),
+  projectId: CanonicalCreateChatRequestSchema.shape.projectId.optional(),
+  cursor: CanonicalChatApiCursorSchema.optional(),
+}).strict();
+
+const CanonicalChatDetailInputSchema = z.object({
+  limit: z.number().int().min(1).max(200).optional(),
+  cursor: CanonicalChatApiCursorSchema.optional(),
+}).strict();
+
+export interface CanonicalChatClient {
+  list(input?: z.input<typeof CanonicalChatListInputSchema>): Promise<CanonicalChatListResponse>;
+  create(input: CanonicalCreateChatRequest): Promise<CanonicalChatRecord>;
+  getDetail(
+    chatId: string,
+    input?: z.input<typeof CanonicalChatDetailInputSchema>,
+  ): Promise<CanonicalChatDetailResponse>;
+}
+
+function withQuery(path: string, values: Record<string, string | number | undefined>): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== undefined) params.set(key, String(value));
+  }
+  const query = params.toString();
+  return query ? `${path}?${query}` : path;
+}
+
+export function createCanonicalChatClient(api: ApiClient): CanonicalChatClient {
+  return {
+    async list(input = {}) {
+      const parsed = CanonicalChatListInputSchema.parse(input);
+      const response = await api.get(withQuery("/api/chats", {
+        limit: parsed.limit,
+        lifecycle: parsed.lifecycle,
+        projectId: parsed.projectId,
+        cursor: parsed.cursor,
+      }));
+      return CanonicalChatListResponseSchema.parse(response);
+    },
+
+    async create(input) {
+      const parsed = CanonicalCreateChatRequestSchema.parse(input);
+      return CanonicalChatRecordSchema.parse(await api.post("/api/chats", parsed));
+    },
+
+    async getDetail(chatId, input = {}) {
+      const parsedChatId = CanonicalChatIdSchema.parse(chatId);
+      const parsed = CanonicalChatDetailInputSchema.parse(input);
+      const response = await api.get(withQuery(`/api/chats/${encodeURIComponent(parsedChatId)}`, {
+        limit: parsed.limit,
+        cursor: parsed.cursor,
+      }));
+      return CanonicalChatDetailResponseSchema.parse(response);
+    },
+  };
+}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -10,6 +10,7 @@
     "#agent-runtime-config": "./src/agent-runtime-config.ts",
     "#agent-thread-contracts": "./src/agent-thread-contracts.ts",
     "#canonical-chat": "./src/canonical-chat.ts",
+    "#canonical-chat-api": "./src/canonical-chat-api.ts",
     "#canonical-chat-primitives": "./src/canonical-chat-primitives.ts",
     "#canonical-chat-compatibility": "./src/canonical-chat-compatibility.ts",
     "#canonical-chat-compatibility-public": "./src/canonical-chat-compatibility-public.ts",

--- a/packages/contracts/src/canonical-chat-api.ts
+++ b/packages/contracts/src/canonical-chat-api.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import {
+  CanonicalChatMessagePartSchema,
   CanonicalChatMessageSchema,
   CanonicalChatModelSelectionSchema,
   CanonicalChatRequestIdSchema,
@@ -8,7 +9,10 @@ import {
   CanonicalChatSchema,
   CanonicalChatTurnSchema,
 } from "#canonical-chat";
-import { canonicalReferenceId } from "#canonical-chat-primitives";
+import {
+  CanonicalChatExecutionRootRefSchema,
+  canonicalReferenceId,
+} from "#canonical-chat-primitives";
 import {
   CanonicalChatActiveRunProjectionSchema,
   CanonicalChatProviderBindingSchema,
@@ -24,6 +28,37 @@ export const CanonicalCreateChatRequestSchema = z.object({
   title: CanonicalChatSchema.shape.title.optional(),
   projectId: canonicalReferenceId(160).optional(),
   currentSelection: CanonicalChatModelSelectionSchema.optional(),
+}).strict();
+
+const USER_INPUT_PART_TYPES = new Set([
+  "text",
+  "attachment_reference",
+  "invocation_reference",
+  "resource_reference",
+]);
+
+export const CanonicalChatUserInputPartSchema = CanonicalChatMessagePartSchema
+  .refine((part) => USER_INPUT_PART_TYPES.has(part.type), {
+    message: "Part is not accepted as user input",
+  });
+
+export const CanonicalCreateChatTurnRequestSchema = z.object({
+  clientRequestId: CanonicalChatRequestIdSchema,
+  baseRevision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  parts: z.array(CanonicalChatUserInputPartSchema).min(1).max(64),
+  selection: CanonicalChatModelSelectionSchema,
+  interactionMode: canonicalReferenceId(80),
+  permissionMode: canonicalReferenceId(80),
+  executionRoot: CanonicalChatExecutionRootRefSchema.optional(),
+}).strict();
+
+export const CanonicalCancelChatRunRequestSchema = z.object({
+  clientRequestId: CanonicalChatRequestIdSchema,
+}).strict();
+
+export const CanonicalRetryChatTurnRequestSchema = z.object({
+  clientRequestId: CanonicalChatRequestIdSchema,
+  baseRevision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
 }).strict();
 
 export const CanonicalChatRecordSchema = z.object({
@@ -70,7 +105,51 @@ export const CanonicalChatDetailResponseSchema = z.object({
   }
 });
 
+export const CanonicalChatTurnAdmissionResponseSchema = z.object({
+  record: CanonicalChatRecordSchema,
+  message: CanonicalChatMessageSchema,
+  turn: CanonicalChatTurnSchema,
+  run: CanonicalChatRunSchema,
+  admission: z.enum(["accepted", "already_accepted"]),
+}).strict().superRefine((response, ctx) => {
+  const chatId = response.record.chat.id;
+  if (response.message.chatId !== chatId
+    || response.turn.chatId !== chatId
+    || response.run.chatId !== chatId) {
+    ctx.addIssue({ code: "custom", message: "Admission Chat mismatch" });
+  }
+  if (response.message.turnId !== response.turn.id
+    || response.turn.inputMessageId !== response.message.id
+    || response.run.turnId !== response.turn.id) {
+    ctx.addIssue({ code: "custom", message: "Admission relationship mismatch" });
+  }
+});
+
+export const CanonicalChatRunCancellationResponseSchema = z.object({
+  run: CanonicalChatRunSchema,
+  cancellation: z.enum(["aborted", "already_terminal"]),
+}).strict();
+
+export const CanonicalChatRunAdmissionResponseSchema = z.object({
+  record: CanonicalChatRecordSchema,
+  turn: CanonicalChatTurnSchema,
+  run: CanonicalChatRunSchema,
+  admission: z.enum(["accepted", "already_accepted"]),
+}).strict().superRefine((response, ctx) => {
+  const chatId = response.record.chat.id;
+  if (response.turn.chatId !== chatId || response.run.chatId !== chatId
+    || response.run.turnId !== response.turn.id) {
+    ctx.addIssue({ code: "custom", message: "Run admission relationship mismatch" });
+  }
+});
+
 export type CanonicalCreateChatRequest = z.infer<typeof CanonicalCreateChatRequestSchema>;
+export type CanonicalCreateChatTurnRequest = z.infer<typeof CanonicalCreateChatTurnRequestSchema>;
+export type CanonicalCancelChatRunRequest = z.infer<typeof CanonicalCancelChatRunRequestSchema>;
+export type CanonicalRetryChatTurnRequest = z.infer<typeof CanonicalRetryChatTurnRequestSchema>;
 export type CanonicalChatRecord = z.infer<typeof CanonicalChatRecordSchema>;
 export type CanonicalChatListResponse = z.infer<typeof CanonicalChatListResponseSchema>;
 export type CanonicalChatDetailResponse = z.infer<typeof CanonicalChatDetailResponseSchema>;
+export type CanonicalChatTurnAdmissionResponse = z.infer<typeof CanonicalChatTurnAdmissionResponseSchema>;
+export type CanonicalChatRunCancellationResponse = z.infer<typeof CanonicalChatRunCancellationResponseSchema>;
+export type CanonicalChatRunAdmissionResponse = z.infer<typeof CanonicalChatRunAdmissionResponseSchema>;

--- a/packages/contracts/src/canonical-chat-api.ts
+++ b/packages/contracts/src/canonical-chat-api.ts
@@ -1,0 +1,76 @@
+import { z } from "zod/v4";
+import {
+  CanonicalChatMessageSchema,
+  CanonicalChatModelSelectionSchema,
+  CanonicalChatRequestIdSchema,
+  CanonicalChatRunActivitySchema,
+  CanonicalChatRunSchema,
+  CanonicalChatSchema,
+  CanonicalChatTurnSchema,
+} from "#canonical-chat";
+import { canonicalReferenceId } from "#canonical-chat-primitives";
+import {
+  CanonicalChatActiveRunProjectionSchema,
+  CanonicalChatProviderBindingSchema,
+} from "#canonical-chat-surface";
+
+export const CanonicalChatApiCursorSchema = z.string()
+  .min(9)
+  .max(512)
+  .regex(/^chatcur_[A-Za-z0-9_-]+$/);
+
+export const CanonicalCreateChatRequestSchema = z.object({
+  clientRequestId: CanonicalChatRequestIdSchema,
+  title: CanonicalChatSchema.shape.title.optional(),
+  projectId: canonicalReferenceId(160).optional(),
+  currentSelection: CanonicalChatModelSelectionSchema.optional(),
+}).strict();
+
+export const CanonicalChatRecordSchema = z.object({
+  chat: CanonicalChatSchema,
+  projectId: canonicalReferenceId(160).optional(),
+  providerBinding: CanonicalChatProviderBindingSchema.optional(),
+  activeRun: CanonicalChatActiveRunProjectionSchema.optional(),
+}).strict().superRefine((record, ctx) => {
+  if (record.providerBinding !== undefined
+    && record.chat.currentSelection?.instanceId !== record.providerBinding.instanceId) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["chat", "currentSelection", "instanceId"],
+      message: "Bound Chat selection must use its immutable Provider Instance",
+    });
+  }
+});
+
+export const CanonicalChatListResponseSchema = z.object({
+  items: z.array(CanonicalChatRecordSchema).max(100),
+  nextCursor: CanonicalChatApiCursorSchema.optional(),
+}).strict();
+
+export const CanonicalChatDetailResponseSchema = z.object({
+  record: CanonicalChatRecordSchema,
+  messages: z.array(CanonicalChatMessageSchema).max(200),
+  turns: z.array(CanonicalChatTurnSchema).max(100),
+  runs: z.array(CanonicalChatRunSchema).max(100),
+  activities: z.array(CanonicalChatRunActivitySchema).max(500),
+  nextCursor: CanonicalChatApiCursorSchema.optional(),
+}).strict().superRefine((detail, ctx) => {
+  const chatId = detail.record.chat.id;
+  for (const [key, values] of [
+    ["messages", detail.messages],
+    ["turns", detail.turns],
+    ["runs", detail.runs],
+    ["activities", detail.activities],
+  ] as const) {
+    values.forEach((value, index) => {
+      if (value.chatId !== chatId) {
+        ctx.addIssue({ code: "custom", path: [key, index, "chatId"], message: "Chat mismatch" });
+      }
+    });
+  }
+});
+
+export type CanonicalCreateChatRequest = z.infer<typeof CanonicalCreateChatRequestSchema>;
+export type CanonicalChatRecord = z.infer<typeof CanonicalChatRecordSchema>;
+export type CanonicalChatListResponse = z.infer<typeof CanonicalChatListResponseSchema>;
+export type CanonicalChatDetailResponse = z.infer<typeof CanonicalChatDetailResponseSchema>;

--- a/packages/contracts/src/canonical-chat.ts
+++ b/packages/contracts/src/canonical-chat.ts
@@ -154,6 +154,7 @@ export const CanonicalChatRunSchema = z.object({
   interactionMode: canonicalReferenceId(80),
   permissionMode: canonicalReferenceId(80),
   executionRoot: CanonicalChatExecutionRootRefSchema.optional(),
+  executionRootFingerprint: z.string().length(64).regex(/^[a-f0-9]{64}$/).optional(),
   status: z.enum([
     "accepted",
     "running",
@@ -186,6 +187,13 @@ export const CanonicalChatRunSchema = z.object({
 }).strict().superRefine((run, ctx) => {
   if (run.instanceId !== run.selection.instanceId) {
     ctx.addIssue({ code: "custom", path: ["selection", "instanceId"], message: "Run Instance mismatch" });
+  }
+  if ((run.executionRoot === undefined) !== (run.executionRootFingerprint === undefined)) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["executionRootFingerprint"],
+      message: "Execution root and fingerprint must be stored together",
+    });
   }
   if (new Set(run.capabilitySnapshot.attachments).size !== run.capabilitySnapshot.attachments.length) {
     ctx.addIssue({ code: "custom", path: ["capabilitySnapshot", "attachments"], message: "Duplicate attachment capability" });

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -26,6 +26,7 @@ export const CODEX_VERIFIED_NPM_PACKAGE = `@openai/codex@${CODEX_VERIFIED_VERSIO
 export * from "#agent-runtime-config";
 export * from "#agent-thread-contracts";
 export * from "#canonical-chat";
+export * from "#canonical-chat-api";
 export {
   CanonicalChatCompatibilityProjectionSchema,
 } from "#canonical-chat-compatibility";

--- a/packages/gateway/src/chat/coding-provider-adapter.ts
+++ b/packages/gateway/src/chat/coding-provider-adapter.ts
@@ -1,0 +1,320 @@
+import { createHash } from "node:crypto";
+import {
+  AgentModeSchema,
+  CanonicalChatSafeErrorSchema,
+  type AgentThreadEvent,
+  type AgentThreadSnapshot,
+  type CreateAgentThreadRequest,
+} from "@matrix-os/contracts";
+import type {
+  CodingAgentThreadStore,
+  CodingAgentTurnStore,
+} from "../coding-agents/thread-store.js";
+import { CodingAgentProviderResumeStateSchema } from "../coding-agents/provider-adapter.js";
+import {
+  CanonicalProviderRunEventSchema,
+  parseCanonicalProviderRunInput,
+  type CanonicalChatProviderAdapter,
+  type CanonicalProviderRunEvent,
+  type CanonicalProviderRunInput,
+} from "./provider-adapter.js";
+
+const MAX_BUFFERED_EVENTS = 500;
+
+type CodingThreads = Pick<
+  CodingAgentThreadStore & CodingAgentTurnStore,
+  "createThread" | "acceptTurn" | "getThread" | "abortThread" | "registerEventSink"
+>;
+
+type CodingState = { conversationId: string; providerThreadId?: string };
+
+function driverKind(providerId: string): "codex" | "claude_code" {
+  if (providerId === "codex") return "codex";
+  if (providerId === "claude") return "claude_code";
+  throw new Error("Unsupported canonical coding Provider");
+}
+
+function legacyRequestId(runId: string): string {
+  return `req_${runId.slice("run_".length)}`;
+}
+
+function principal(ownerId: string) {
+  return { userId: ownerId, source: "configured-container" as const };
+}
+
+function permissions(permissionMode: string): Pick<CreateAgentThreadRequest, "approvalPolicy" | "sandboxMode"> {
+  if (permissionMode === "full_access") return { approvalPolicy: "never", sandboxMode: "full_access" };
+  if (permissionMode === "auto" || permissionMode === "auto_accept_edits") {
+    return { approvalPolicy: "on_failure", sandboxMode: "workspace_write" };
+  }
+  if (permissionMode === "supervised") return { approvalPolicy: "on_request", sandboxMode: "workspace_write" };
+  throw new Error("Unsupported canonical coding Provider permission mode");
+}
+
+function safeResourceId(path: string): string {
+  return `file_${createHash("sha256").update(path).digest("hex").slice(0, 32)}`;
+}
+
+function normalizeEvent(event: AgentThreadEvent): CanonicalProviderRunEvent[] {
+  if (event.type === "assistant.text.delta") {
+    return [CanonicalProviderRunEventSchema.parse({ type: "assistant.delta", delta: event.delta })];
+  }
+  if (event.type === "tool.started") {
+    return [CanonicalProviderRunEventSchema.parse({
+      type: "tool.progress", toolCallId: event.toolCallId, label: event.displayName, status: "running",
+    })];
+  }
+  if (event.type === "tool.output") {
+    const candidate = CanonicalProviderRunEventSchema.safeParse({
+      type: "tool.output", toolCallId: event.toolCallId, text: event.text, truncated: event.truncated ?? false,
+    });
+    return [candidate.success ? candidate.data : CanonicalProviderRunEventSchema.parse({
+      type: "tool.output",
+      toolCallId: event.toolCallId,
+      text: "Provider tool output is available in the bound terminal.",
+      truncated: true,
+    })];
+  }
+  if (event.type === "tool.completed") {
+    return [CanonicalProviderRunEventSchema.parse({
+      type: "tool.progress",
+      toolCallId: event.toolCallId,
+      label: "Tool",
+      status: event.outcome === "success" ? "completed" : event.outcome,
+    })];
+  }
+  if (event.type === "terminal.bound") {
+    return [CanonicalProviderRunEventSchema.parse({
+      type: "terminal.bound", terminalSessionId: event.terminalSessionId,
+    })];
+  }
+  if (event.type === "review.ready") {
+    return [CanonicalProviderRunEventSchema.parse({
+      type: "review.ready", reviewId: event.reviewId, summary: event.summary,
+    })];
+  }
+  if (event.type === "file.changed") {
+    return [CanonicalProviderRunEventSchema.parse({
+      type: "resource.changed",
+      resourceId: safeResourceId(event.path),
+      resourceKind: "file",
+      changeKind: event.changeKind,
+    })];
+  }
+  if (event.type === "approval.requested") {
+    return [CanonicalProviderRunEventSchema.parse({
+      type: "approval.requested",
+      approvalId: event.approval.approvalId,
+      title: event.approval.title,
+      risk: event.approval.risk,
+    })];
+  }
+  if (event.type === "user_input.requested") {
+    return [CanonicalProviderRunEventSchema.parse({
+      type: "input.requested", requestId: event.request.requestId, title: event.request.title,
+    })];
+  }
+  if (event.type === "thread.error") {
+    return [CanonicalProviderRunEventSchema.parse({
+      type: "run.completed",
+      outcome: "failed",
+      error: CanonicalChatSafeErrorSchema.parse({
+        code: "run_failed",
+        safeMessage: "The coding Provider Run failed.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      }),
+    })];
+  }
+  if (event.type === "thread.completed") {
+    return [CanonicalProviderRunEventSchema.parse({ type: "run.completed", outcome: event.outcome })];
+  }
+  return [];
+}
+
+function attachments(input: CanonicalProviderRunInput) {
+  return input.parts.flatMap((part) => {
+    if (part.type === "attachment_reference") {
+      return [{
+        id: part.attachmentId,
+        kind: part.kind,
+        label: part.label,
+        ...(part.mimeType ? { mimeType: part.mimeType } : {}),
+        ...(part.sizeBytes === undefined ? {} : { sizeBytes: part.sizeBytes }),
+      }];
+    }
+    if (part.type === "resource_reference") {
+      return [{ id: part.resource.id, kind: "structured_ref" as const, label: part.resource.label }];
+    }
+    return [];
+  });
+}
+
+class ThreadEventInbox {
+  private readonly queued: AgentThreadEvent[] = [];
+  private failure: Error | undefined;
+  private wake: (() => void) | undefined;
+
+  constructor(private readonly signal: AbortSignal) {}
+
+  push(events: AgentThreadEvent[]): void {
+    if (this.signal.aborted || this.failure) return;
+    if (this.queued.length + events.length > MAX_BUFFERED_EVENTS) {
+      this.fail(new Error("Canonical coding Provider event buffer exceeded"));
+      return;
+    }
+    this.queued.push(...events);
+    this.wake?.();
+    this.wake = undefined;
+  }
+
+  fail(error: Error): void {
+    if (this.failure) return;
+    this.failure = error;
+    this.wake?.();
+    this.wake = undefined;
+  }
+
+  async next(): Promise<AgentThreadEvent[] | null> {
+    if (this.queued.length > 0) return this.queued.splice(0);
+    if (this.failure) throw this.failure;
+    if (this.signal.aborted) return null;
+    await new Promise<void>((resolve) => {
+      const onAbort = () => {
+        this.wake = undefined;
+        resolve();
+      };
+      this.signal.addEventListener("abort", onAbort, { once: true });
+      this.wake = () => {
+        this.signal.removeEventListener("abort", onAbort);
+        resolve();
+      };
+    });
+    if (this.queued.length > 0) return this.queued.splice(0);
+    if (this.failure) throw this.failure;
+    return null;
+  }
+}
+
+async function* normalizedEvents(
+  initial: AgentThreadEvent[],
+  inbox: ThreadEventInbox,
+): AsyncGenerator<CanonicalProviderRunEvent> {
+  const seen = new Set<string>();
+  let batch: AgentThreadEvent[] | null = initial;
+  while (batch !== null) {
+    for (const event of batch) {
+      if (seen.has(event.eventId)) continue;
+      if (seen.size >= MAX_BUFFERED_EVENTS * 2) {
+        throw new Error("Canonical coding Provider event history exceeded");
+      }
+      seen.add(event.eventId);
+      for (const normalized of normalizeEvent(event)) {
+        yield normalized;
+        if (normalized.type === "run.completed") return;
+      }
+    }
+    batch = await inbox.next();
+  }
+}
+
+function eventsForAcceptedRun(snapshot: AgentThreadSnapshot, requestId: string): AgentThreadEvent[] {
+  const index = snapshot.events.items.findIndex((event) =>
+    event.type === "turn.accepted" && event.clientRequestId === requestId
+  );
+  if (index < 0) throw new Error("Canonical coding Provider Turn was not persisted");
+  return snapshot.events.items.slice(index);
+}
+
+export function createCanonicalCodingChatProviderAdapter(options: {
+  providerId: "codex" | "claude";
+  threads: CodingThreads;
+}): CanonicalChatProviderAdapter<CodingState> {
+  const kind = driverKind(options.providerId);
+
+  function validate(inputValue: CanonicalProviderRunInput<CodingState>) {
+    const input = parseCanonicalProviderRunInput(inputValue);
+    const mode = AgentModeSchema.safeParse(input.interactionMode);
+    if (!mode.success) throw new Error("Unsupported canonical coding Provider mode");
+    return { input, mode: mode.data };
+  }
+
+  return {
+    driverKind: kind,
+    stateSchemaVersion: 1,
+    parseState: (value) => CodingAgentProviderResumeStateSchema.parse(value),
+    serializeState: (value) => CodingAgentProviderResumeStateSchema.parse(value),
+    async *start(inputValue) {
+      const { input, mode } = validate(inputValue);
+      const inbox = new ThreadEventInbox(input.signal);
+      const buffered: Array<{ threadId: string; events: AgentThreadEvent[] }> = [];
+      let bufferedEventCount = 0;
+      let targetThreadId: string | undefined;
+      const sink = options.threads.registerEventSink((published) => {
+        if (published.ownerId !== input.owner.ownerId) return;
+        if (targetThreadId === undefined) {
+          if (bufferedEventCount + published.events.length > MAX_BUFFERED_EVENTS) {
+            inbox.fail(new Error("Canonical coding Provider event buffer exceeded"));
+            return;
+          }
+          bufferedEventCount += published.events.length;
+          buffered.push({ threadId: published.threadId, events: published.events });
+        } else if (published.threadId === targetThreadId) {
+          inbox.push(published.events);
+        }
+      });
+      try {
+        const created = await options.threads.createThread(principal(input.owner.ownerId), {
+          providerId: options.providerId,
+          prompt: input.prompt,
+          ...(input.projectSlug ? { projectId: input.projectSlug } : {}),
+          ...(input.worktreeId ? { worktreeId: input.worktreeId } : {}),
+          mode,
+          ...permissions(input.permissionMode),
+          attachments: attachments(input),
+          clientRequestId: legacyRequestId(input.runId),
+        });
+        targetThreadId = created.snapshot.thread.id;
+        for (const published of buffered) {
+          if (published.threadId === targetThreadId) inbox.push(published.events);
+        }
+        yield { type: "state.updated", state: { conversationId: targetThreadId } };
+        yield* normalizedEvents(created.snapshot.events.items, inbox);
+      } finally {
+        sink.dispose();
+      }
+    },
+    async *resume(inputValue) {
+      const { input } = validate(inputValue);
+      const state = CodingAgentProviderResumeStateSchema.parse(input.resumeState);
+      const targetThreadId = state.conversationId;
+      const inbox = new ThreadEventInbox(input.signal);
+      const sink = options.threads.registerEventSink((published) => {
+        if (published.ownerId === input.owner.ownerId && published.threadId === targetThreadId) {
+          inbox.push(published.events);
+        }
+      });
+      try {
+        const requestId = legacyRequestId(input.runId);
+        await options.threads.acceptTurn(principal(input.owner.ownerId), targetThreadId, {
+          message: input.prompt,
+          attachments: attachments(input),
+          clientRequestId: requestId,
+        });
+        const current = await options.threads.getThread(principal(input.owner.ownerId), targetThreadId);
+        yield* normalizedEvents(eventsForAcceptedRun(current, requestId), inbox);
+      } finally {
+        sink.dispose();
+      }
+    },
+    async cancel(input) {
+      if (!input.state) return;
+      const state = CodingAgentProviderResumeStateSchema.parse(input.state);
+      await options.threads.abortThread(
+        principal(input.owner.ownerId),
+        state.conversationId,
+        legacyRequestId(input.runId),
+      );
+    },
+  };
+}

--- a/packages/gateway/src/chat/coding-provider-adapter.ts
+++ b/packages/gateway/src/chat/coding-provider-adapter.ts
@@ -222,7 +222,9 @@ function eventsForAcceptedRun(snapshot: AgentThreadSnapshot, requestId: string):
   const index = snapshot.events.items.findIndex((event) =>
     event.type === "turn.accepted" && event.clientRequestId === requestId
   );
-  if (index < 0) throw new Error("Canonical coding Provider Turn was not persisted");
+  // The live sink is registered before admission and remains authoritative when
+  // the bounded snapshot has already evicted this Turn's accepted marker.
+  if (index < 0) return [];
   return snapshot.events.items.slice(index);
 }
 

--- a/packages/gateway/src/chat/database.ts
+++ b/packages/gateway/src/chat/database.ts
@@ -313,7 +313,7 @@ export async function bootstrapChatDatabase(db: Kysely<ChatDatabase>): Promise<v
   `.execute(db);
   await sql`
     UPDATE chat_runs AS runs
-    SET client_request_id = turns.client_request_id
+    SET client_request_id = 'req_migrated_' || md5(runs.id)
     FROM chat_turns AS turns
     WHERE runs.turn_id = turns.id AND runs.client_request_id IS NULL
   `.execute(db);
@@ -407,6 +407,7 @@ export async function bootstrapChatDatabase(db: Kysely<ChatDatabase>): Promise<v
   await sql`CREATE INDEX IF NOT EXISTS idx_chats_owner_updated ON chats(owner_type, owner_id, lifecycle, updated_at DESC, id)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_chats_owner_project ON chats(owner_type, owner_id, project_id)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_chat_messages_page ON chat_messages(chat_id, seq)`.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_chat_run_events_run_occurred ON chat_run_events(run_id, occurred_at, id)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_chat_messages_search ON chat_messages USING GIN (to_tsvector('simple', search_text)) WHERE state = 'committed'`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_chat_outbox_owner_cursor ON chat_outbox(owner_type, owner_id, cursor)`.execute(db);
 }

--- a/packages/gateway/src/chat/database.ts
+++ b/packages/gateway/src/chat/database.ts
@@ -88,6 +88,7 @@ export interface ChatRunsTable {
   id: string;
   chat_id: string;
   turn_id: string;
+  client_request_id: string;
   attempt: number;
   driver_kind: string;
   instance_id: string;
@@ -95,6 +96,7 @@ export interface ChatRunsTable {
   interaction_mode: string;
   permission_mode: string;
   execution_root: JsonValue | null;
+  execution_root_fingerprint: string | null;
   status: "accepted" | "running" | "waiting_for_approval" | "waiting_for_input" | "completed" | "failed" | "aborted";
   outcome: "completed" | "failed" | "aborted" | null;
   started_at: NullableTimestamp;
@@ -281,6 +283,7 @@ export async function bootstrapChatDatabase(db: Kysely<ChatDatabase>): Promise<v
       id TEXT PRIMARY KEY,
       chat_id TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
       turn_id TEXT NOT NULL REFERENCES chat_turns(id) ON DELETE CASCADE,
+      client_request_id TEXT NOT NULL,
       attempt INTEGER NOT NULL CHECK (attempt BETWEEN 1 AND 100),
       driver_kind TEXT NOT NULL,
       instance_id TEXT NOT NULL,
@@ -288,6 +291,7 @@ export async function bootstrapChatDatabase(db: Kysely<ChatDatabase>): Promise<v
       interaction_mode TEXT NOT NULL,
       permission_mode TEXT NOT NULL,
       execution_root JSONB,
+      execution_root_fingerprint TEXT,
       status TEXT NOT NULL CHECK (status IN ('accepted', 'running', 'waiting_for_approval', 'waiting_for_input', 'completed', 'failed', 'aborted')),
       outcome TEXT CHECK (outcome IN ('completed', 'failed', 'aborted')),
       started_at TIMESTAMPTZ,
@@ -298,6 +302,28 @@ export async function bootstrapChatDatabase(db: Kysely<ChatDatabase>): Promise<v
       updated_at TIMESTAMPTZ NOT NULL,
       UNIQUE (turn_id, attempt)
     )
+  `.execute(db);
+  await sql`
+    ALTER TABLE chat_runs
+    ADD COLUMN IF NOT EXISTS execution_root_fingerprint TEXT
+  `.execute(db);
+  await sql`
+    ALTER TABLE chat_runs
+    ADD COLUMN IF NOT EXISTS client_request_id TEXT
+  `.execute(db);
+  await sql`
+    UPDATE chat_runs AS runs
+    SET client_request_id = turns.client_request_id
+    FROM chat_turns AS turns
+    WHERE runs.turn_id = turns.id AND runs.client_request_id IS NULL
+  `.execute(db);
+  await sql`
+    ALTER TABLE chat_runs
+    ALTER COLUMN client_request_id SET NOT NULL
+  `.execute(db);
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_chat_runs_retry_request
+    ON chat_runs(turn_id, client_request_id)
   `.execute(db);
   await sql`
     CREATE UNIQUE INDEX IF NOT EXISTS idx_chat_runs_one_active

--- a/packages/gateway/src/chat/detail-repository.ts
+++ b/packages/gateway/src/chat/detail-repository.ts
@@ -1,0 +1,96 @@
+import {
+  CanonicalChatIdSchema,
+  CanonicalOwnerScopeSchema,
+  type CanonicalChatMessage,
+  type CanonicalChatRun,
+  type CanonicalChatRunActivity,
+  type CanonicalChatTurn,
+} from "@matrix-os/contracts";
+import type { Kysely } from "kysely";
+import type { ChatDatabase } from "./database.js";
+import {
+  toActivity,
+  toMessage,
+  toRun,
+  toTurn,
+  type ChatOwner,
+  type ChatRecord,
+} from "./records.js";
+
+export interface ChatDetailPage {
+  record: ChatRecord;
+  messages: CanonicalChatMessage[];
+  turns: CanonicalChatTurn[];
+  runs: CanonicalChatRun[];
+  activities: CanonicalChatRunActivity[];
+  nextBeforeSeq?: number;
+}
+
+export class ChatDetailRepository {
+  constructor(
+    private readonly kysely: Kysely<ChatDatabase>,
+    private readonly getRecord: (owner: ChatOwner, chatId: string) => Promise<ChatRecord | null>,
+  ) {}
+
+  async getDetailPage(ownerInput: ChatOwner, chatId: string, input: {
+    beforeSeq?: number;
+    limit: number;
+  }): Promise<ChatDetailPage | null> {
+    const owner = CanonicalOwnerScopeSchema.parse(ownerInput);
+    const parsedChatId = CanonicalChatIdSchema.parse(chatId);
+    const record = await this.getRecord(owner, parsedChatId);
+    if (!record) return null;
+    const limit = Math.max(1, Math.min(200, Math.trunc(input.limit)));
+    const beforeSeq = input.beforeSeq === undefined
+      ? Number.MAX_SAFE_INTEGER
+      : Math.max(1, Math.trunc(input.beforeSeq));
+    const messageRows = await this.kysely.selectFrom("chat_messages").selectAll()
+      .where("chat_id", "=", parsedChatId)
+      .where("seq", "<", beforeSeq)
+      .orderBy("seq", "desc")
+      .limit(limit + 1)
+      .execute();
+    const hasOlder = messageRows.length > limit;
+    const selectedMessageRows = messageRows.slice(0, limit).reverse();
+    const turnIds = [...new Set(selectedMessageRows.flatMap((row) => row.turn_id ? [row.turn_id] : []))];
+    const turnRows = turnIds.length === 0 ? [] : await this.kysely.selectFrom("chat_turns").selectAll()
+      .where("chat_id", "=", parsedChatId)
+      .where("id", "in", turnIds)
+      .orderBy("created_at", "desc")
+      .limit(100)
+      .execute();
+    turnRows.reverse();
+    const selectedRunIds = selectedMessageRows.flatMap((row) => row.run_id ? [row.run_id] : []);
+    const runTurnIds = turnRows.map((row) => row.id);
+    const runRows = runTurnIds.length === 0 && selectedRunIds.length === 0 ? [] : await this.kysely
+      .selectFrom("chat_runs")
+      .selectAll()
+      .where("chat_id", "=", parsedChatId)
+      .where(({ eb, or }) => or([
+        ...(runTurnIds.length > 0 ? [eb("turn_id", "in", runTurnIds)] : []),
+        ...(selectedRunIds.length > 0 ? [eb("id", "in", selectedRunIds)] : []),
+      ]))
+      .orderBy("created_at", "desc")
+      .limit(100)
+      .execute();
+    runRows.reverse();
+    const runIds = runRows.map((row) => row.id);
+    const activityRows = runIds.length === 0 ? [] : await this.kysely.selectFrom("chat_run_events").selectAll()
+      .where("chat_id", "=", parsedChatId)
+      .where("run_id", "in", runIds)
+      .orderBy("occurred_at", "desc")
+      .limit(500)
+      .execute();
+    activityRows.reverse();
+    return {
+      record,
+      messages: selectedMessageRows.map(toMessage),
+      turns: turnRows.map(toTurn),
+      runs: runRows.map(toRun),
+      activities: activityRows.map(toActivity),
+      ...(hasOlder && selectedMessageRows[0]
+        ? { nextBeforeSeq: Number(selectedMessageRows[0].seq) }
+        : {}),
+    };
+  }
+}

--- a/packages/gateway/src/chat/errors.ts
+++ b/packages/gateway/src/chat/errors.ts
@@ -1,0 +1,34 @@
+export class ChatNotFoundError extends Error {
+  constructor(readonly chatId: string) {
+    super("Chat not found");
+    this.name = "ChatNotFoundError";
+  }
+}
+
+export class ChatConflictError extends Error {
+  constructor(readonly chatId: string, readonly latestRevision: number) {
+    super("Chat conflict");
+    this.name = "ChatConflictError";
+  }
+}
+
+export class ChatBusyError extends Error {
+  constructor(readonly chatId: string) {
+    super("Chat is busy");
+    this.name = "ChatBusyError";
+  }
+}
+
+export class ChatProviderInstanceLockedError extends Error {
+  constructor(readonly chatId: string) {
+    super("Provider Instance is locked");
+    this.name = "ChatProviderInstanceLockedError";
+  }
+}
+
+export class ChatRunNotActiveError extends Error {
+  constructor(readonly chatId: string, readonly runId: string) {
+    super("Chat Run is not active");
+    this.name = "ChatRunNotActiveError";
+  }
+}

--- a/packages/gateway/src/chat/execution-root.ts
+++ b/packages/gateway/src/chat/execution-root.ts
@@ -54,6 +54,8 @@ export interface ChatExecutionRootProvenance {
 export interface ResolvedChatExecutionRoot extends ChatExecutionRootProvenance {
   /** Gateway-only derived value. Never persist or project this path to a client. */
   primaryWorkspaceRoot: string;
+  /** Gateway-only legacy workspace Provider key derived from ProjectConfig. */
+  projectSlug: string;
 }
 
 export interface ChatExecutionRootResolver {
@@ -295,6 +297,7 @@ export function createChatExecutionRootResolver<
       return {
         ref,
         primaryWorkspaceRoot: projectRoot,
+        projectSlug: currentProject.slug,
         fingerprint: fingerprint({ owner, ref, project: currentProject, projectRoot }),
       };
     }
@@ -330,6 +333,7 @@ export function createChatExecutionRootResolver<
     return {
       ref,
       primaryWorkspaceRoot: worktreeRoot,
+      projectSlug: finalProject.slug,
       fingerprint: fingerprint({
         owner,
         ref,

--- a/packages/gateway/src/chat/hermes-provider-adapter.ts
+++ b/packages/gateway/src/chat/hermes-provider-adapter.ts
@@ -27,7 +27,7 @@ interface AsyncEventQueue {
   values(): AsyncGenerator<CanonicalProviderRunEvent>;
 }
 
-function createAsyncEventQueue(): AsyncEventQueue {
+function createAsyncEventQueue(onOverflow: () => void): AsyncEventQueue {
   const values: CanonicalProviderRunEvent[] = [];
   let done = false;
   let failure: Error | undefined;
@@ -38,6 +38,7 @@ function createAsyncEventQueue(): AsyncEventQueue {
       if (values.length >= MAX_BUFFERED_EVENTS) {
         done = true;
         failure = new Error("Canonical Hermes Provider event buffer exceeded");
+        onOverflow();
         wake?.();
         wake = undefined;
         return;
@@ -109,8 +110,8 @@ export function createHermesChatProviderAdapter(options: {
     if (input.interactionMode !== "default" || input.permissionMode !== "supervised") {
       throw new Error("Unsupported Matrix kernel mode");
     }
-    const queue = createAsyncEventQueue();
     const controller = new AbortController();
+    const queue = createAsyncEventQueue(() => controller.abort());
     const abort = () => controller.abort();
     input.signal.addEventListener("abort", abort, { once: true });
     const timeout = setTimeout(abort, timeoutMs);

--- a/packages/gateway/src/chat/hermes-provider-adapter.ts
+++ b/packages/gateway/src/chat/hermes-provider-adapter.ts
@@ -1,0 +1,198 @@
+import { z } from "zod/v4";
+import type { KernelEvent } from "@matrix-os/kernel";
+import type { Dispatcher } from "../dispatcher.js";
+import {
+  KERNEL_DEFAULTS,
+  KernelEffortSchema,
+  KernelModelSchema,
+} from "../kernel-settings.js";
+import {
+  CanonicalProviderRunEventSchema,
+  parseCanonicalProviderRunInput,
+  type CanonicalChatProviderAdapter,
+  type CanonicalProviderRunEvent,
+  type CanonicalProviderRunInput,
+} from "./provider-adapter.js";
+
+const HermesChatStateSchema = z.object({
+  sessionId: z.string().min(1).max(512).regex(/^[A-Za-z0-9][A-Za-z0-9_-]{0,511}$/),
+}).strict();
+const MAX_BUFFERED_EVENTS = 500;
+
+export type HermesChatState = z.infer<typeof HermesChatStateSchema>;
+
+interface AsyncEventQueue {
+  push(event: CanonicalProviderRunEvent): void;
+  finish(error?: Error): void;
+  values(): AsyncGenerator<CanonicalProviderRunEvent>;
+}
+
+function createAsyncEventQueue(): AsyncEventQueue {
+  const values: CanonicalProviderRunEvent[] = [];
+  let done = false;
+  let failure: Error | undefined;
+  let wake: (() => void) | undefined;
+  return {
+    push(event) {
+      if (done) return;
+      if (values.length >= MAX_BUFFERED_EVENTS) {
+        done = true;
+        failure = new Error("Canonical Hermes Provider event buffer exceeded");
+        wake?.();
+        wake = undefined;
+        return;
+      }
+      values.push(CanonicalProviderRunEventSchema.parse(event));
+      wake?.();
+      wake = undefined;
+    },
+    finish(error) {
+      if (done) {
+        if (error && !failure) failure = error;
+        return;
+      }
+      done = true;
+      failure = error;
+      wake?.();
+      wake = undefined;
+    },
+    async *values() {
+      while (!done || values.length > 0) {
+        const next = values.shift();
+        if (next) {
+          yield next;
+          continue;
+        }
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+        });
+      }
+      if (failure) throw failure;
+    },
+  };
+}
+
+function kernelSelection(input: CanonicalProviderRunInput) {
+  const [provider, modelId, extra] = input.selection.model.split(":");
+  if (provider !== "anthropic" || !modelId || extra !== undefined) {
+    throw new Error("Unsupported Matrix kernel selection");
+  }
+  const model = KernelModelSchema.safeParse(modelId);
+  if (!model.success) throw new Error("Unsupported Matrix kernel selection");
+  const selectedEffort = input.selection.options?.find((option) => option.id === "effort")?.value
+    ?? KERNEL_DEFAULTS.effort;
+  const effort = KernelEffortSchema.safeParse(selectedEffort);
+  if (!effort.success) throw new Error("Unsupported Matrix kernel selection");
+  return { model: model.data, effort: effort.data };
+}
+
+function safeToolLabel(value: string): string {
+  const normalized = value.replace(/[\u0000-\u001f\u007f]/g, " ").trim().slice(0, 240);
+  return normalized || "Tool";
+}
+
+export function createHermesChatProviderAdapter(options: {
+  dispatcher: Pick<Dispatcher, "dispatch">;
+  timeoutMs?: number;
+}): CanonicalChatProviderAdapter<HermesChatState> {
+  const timeoutMs = options.timeoutMs ?? 30 * 60 * 1_000;
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 1_000 || timeoutMs > 60 * 60 * 1_000) {
+    throw new RangeError("Invalid Matrix kernel Run timeout");
+  }
+
+  function execute(
+    inputValue: CanonicalProviderRunInput<HermesChatState>,
+    sessionId?: string,
+  ): AsyncIterable<CanonicalProviderRunEvent> {
+    const input = parseCanonicalProviderRunInput(inputValue);
+    const selection = kernelSelection(input);
+    if (input.interactionMode !== "default" || input.permissionMode !== "supervised") {
+      throw new Error("Unsupported Matrix kernel mode");
+    }
+    const queue = createAsyncEventQueue();
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    input.signal.addEventListener("abort", abort, { once: true });
+    const timeout = setTimeout(abort, timeoutMs);
+    let toolIndex = 0;
+    let activeTool: { id: string; label: string } | undefined;
+    let terminal = false;
+
+    const onEvent = (event: KernelEvent) => {
+      if (terminal) return;
+      if (event.type === "init") {
+        queue.push({ type: "state.updated", state: { sessionId: event.sessionId } });
+      } else if (event.type === "text" && event.text) {
+        queue.push({ type: "assistant.delta", delta: event.text });
+      } else if (event.type === "tool_start") {
+        toolIndex += 1;
+        activeTool = { id: `kernel_tool_${toolIndex}`, label: safeToolLabel(event.tool) };
+        queue.push({
+          type: "tool.progress",
+          toolCallId: activeTool.id,
+          label: activeTool.label,
+          status: "running",
+        });
+      } else if (event.type === "tool_end" && activeTool) {
+        queue.push({
+          type: "tool.progress",
+          toolCallId: activeTool.id,
+          label: activeTool.label,
+          status: "completed",
+        });
+        activeTool = undefined;
+      } else if (event.type === "aborted") {
+        terminal = true;
+        queue.push({ type: "run.completed", outcome: "aborted" });
+      } else if (event.type === "result") {
+        terminal = true;
+        queue.push(event.data.errors && event.data.errors.length > 0
+          ? {
+              type: "run.completed",
+              outcome: "failed",
+              error: {
+                code: "run_failed",
+                safeMessage: "The Matrix agent Run failed.",
+                retryable: true,
+                recoveryActions: ["retry"],
+              },
+            }
+          : { type: "run.completed", outcome: "completed" });
+      }
+    };
+
+    void options.dispatcher.dispatch(
+      input.prompt,
+      sessionId,
+      onEvent,
+      { chatId: input.chatId },
+      controller,
+      {
+        ...selection,
+        ...(input.executionRoot ? { workingDirectory: input.executionRoot } : {}),
+      },
+    ).then(() => {
+      if (!terminal) queue.push({ type: "run.completed", outcome: controller.signal.aborted ? "aborted" : "completed" });
+      queue.finish();
+    }).catch((error: unknown) => {
+      queue.finish(new Error(
+        controller.signal.aborted ? "Matrix kernel Run aborted" : "Matrix kernel dispatch failed",
+        { cause: error },
+      ));
+    }).finally(() => {
+      clearTimeout(timeout);
+      input.signal.removeEventListener("abort", abort);
+    });
+
+    return { [Symbol.asyncIterator]: () => queue.values() };
+  }
+
+  return {
+    driverKind: "hermes",
+    stateSchemaVersion: 1,
+    parseState: (value) => HermesChatStateSchema.parse(value),
+    serializeState: (value) => HermesChatStateSchema.parse(value),
+    start: (input) => execute(input),
+    resume: (input) => execute(input, HermesChatStateSchema.parse(input.resumeState).sessionId),
+  };
+}

--- a/packages/gateway/src/chat/orchestrator.ts
+++ b/packages/gateway/src/chat/orchestrator.ts
@@ -140,6 +140,7 @@ function mapRepositoryError(error: unknown): never {
 
 export class CanonicalChatOrchestrator {
   private readonly active = new Map<string, ActiveRun>();
+  private readonly pendingDispatch = new Set<string>();
   private readonly reconciliation = new Map<string, Promise<number>>();
   private readonly shutdownDrainMs: number;
   private closing = false;
@@ -190,6 +191,16 @@ export class CanonicalChatOrchestrator {
         503,
       );
     }
+  }
+
+  private reservePendingDispatch(runId: string): void {
+    if (!this.pendingDispatch.has(runId) && this.pendingDispatch.size >= MAX_ACTIVE_RUNS_GLOBAL) {
+      throw new CanonicalChatOrchestrationError(
+        safeError("run_unavailable", "Chat execution is temporarily busy.", true, ["retry"]),
+        503,
+      );
+    }
+    this.pendingDispatch.add(runId);
   }
 
   async admitTurn(
@@ -322,6 +333,7 @@ export class CanonicalChatOrchestrator {
       updatedAt: timestamp,
     });
     let admitted;
+    this.reservePendingDispatch(run.id);
     try {
       this.assertOpen();
       admitted = await this.options.repository.admitTurn(owner, {
@@ -333,39 +345,44 @@ export class CanonicalChatOrchestrator {
         ...(adapterState ? { adapterState } : {}),
       });
     } catch (error: unknown) {
+      this.pendingDispatch.delete(run.id);
       return mapRepositoryError(error);
     }
 
-    if (!admitted.alreadyAccepted) {
-      if (this.atCapacity(owner)) {
-        await this.options.repository.finishRun(owner, {
-          chatId,
-          runId: admitted.run.id,
-          outcome: "failed",
-          completedAt: timestamp,
-        });
-        throw new CanonicalChatOrchestrationError(
-          safeError("run_unavailable", "Chat execution is temporarily busy.", true, ["retry"]),
-          503,
+    try {
+      if (!admitted.alreadyAccepted) {
+        if (this.atCapacity(owner)) {
+          await this.options.repository.finishRun(owner, {
+            chatId,
+            runId: admitted.run.id,
+            outcome: "failed",
+            completedAt: timestamp,
+          });
+          throw new CanonicalChatOrchestrationError(
+            safeError("run_unavailable", "Chat execution is temporarily busy.", true, ["retry"]),
+            503,
+          );
+        }
+        this.startDispatch(
+          owner,
+          admitted.message,
+          admitted.run,
+          adapter,
+          admitted.chat.chat.messageCount + 1,
+          resolvedRoot,
+          resumeState,
         );
       }
-      this.startDispatch(
-        owner,
-        admitted.message,
-        admitted.run,
-        adapter,
-        admitted.chat.chat.messageCount + 1,
-        resolvedRoot,
-        resumeState,
-      );
+      return CanonicalChatTurnAdmissionResponseSchema.parse({
+        record: admitted.chat,
+        message: admitted.message,
+        turn: admitted.turn,
+        run: admitted.run,
+        admission: admitted.alreadyAccepted ? "already_accepted" : "accepted",
+      });
+    } finally {
+      this.pendingDispatch.delete(run.id);
     }
-    return CanonicalChatTurnAdmissionResponseSchema.parse({
-      record: admitted.chat,
-      message: admitted.message,
-      turn: admitted.turn,
-      run: admitted.run,
-      admission: admitted.alreadyAccepted ? "already_accepted" : "accepted",
-    });
   }
 
   async retryTurn(
@@ -467,6 +484,7 @@ export class CanonicalChatOrchestrator {
       updatedAt: timestamp,
     });
     let admitted;
+    this.reservePendingDispatch(run.id);
     try {
       this.assertOpen();
       admitted = await this.options.repository.admitRetry(owner, {
@@ -478,37 +496,42 @@ export class CanonicalChatOrchestrator {
         ...(adapterState ? { adapterState } : {}),
       });
     } catch (error: unknown) {
+      this.pendingDispatch.delete(run.id);
       return mapRepositoryError(error);
     }
-    if (!admitted.alreadyAccepted) {
-      if (this.atCapacity(owner)) {
-        await this.options.repository.finishRun(owner, {
-          chatId,
-          runId: admitted.run.id,
-          outcome: "failed",
-          completedAt: timestamp,
-        });
-        throw new CanonicalChatOrchestrationError(
-          safeError("run_unavailable", "Chat execution is temporarily busy.", true, ["retry"]),
-          503,
+    try {
+      if (!admitted.alreadyAccepted) {
+        if (this.atCapacity(owner)) {
+          await this.options.repository.finishRun(owner, {
+            chatId,
+            runId: admitted.run.id,
+            outcome: "failed",
+            completedAt: timestamp,
+          });
+          throw new CanonicalChatOrchestrationError(
+            safeError("run_unavailable", "Chat execution is temporarily busy.", true, ["retry"]),
+            503,
+          );
+        }
+        this.startDispatch(
+          owner,
+          context.message,
+          admitted.run,
+          adapter,
+          admitted.chat.chat.messageCount + 1,
+          resolvedRoot,
+          resumeState,
         );
       }
-      this.startDispatch(
-        owner,
-        context.message,
-        admitted.run,
-        adapter,
-        admitted.chat.chat.messageCount + 1,
-        resolvedRoot,
-        resumeState,
-      );
+      return CanonicalChatRunAdmissionResponseSchema.parse({
+        record: admitted.chat,
+        turn: admitted.turn,
+        run: admitted.run,
+        admission: admitted.alreadyAccepted ? "already_accepted" : "accepted",
+      });
+    } finally {
+      this.pendingDispatch.delete(run.id);
     }
-    return CanonicalChatRunAdmissionResponseSchema.parse({
-      record: admitted.chat,
-      turn: admitted.turn,
-      run: admitted.run,
-      admission: admitted.alreadyAccepted ? "already_accepted" : "accepted",
-    });
   }
 
   private startDispatch(
@@ -760,7 +783,7 @@ export class CanonicalChatOrchestrator {
     const contexts = await this.options.repository.listActiveRunContexts(owner, MAX_ACTIVE_RUNS_GLOBAL);
     let reconciled = 0;
     for (const context of contexts) {
-      if (this.active.has(context.latestRun.id)) continue;
+      if (this.active.has(context.latestRun.id) || this.pendingDispatch.has(context.latestRun.id)) continue;
       const completedAt = (this.options.now ?? (() => new Date()))().toISOString();
       const error = safeError(
         "run_unavailable",

--- a/packages/gateway/src/chat/orchestrator.ts
+++ b/packages/gateway/src/chat/orchestrator.ts
@@ -638,10 +638,19 @@ export class CanonicalChatOrchestrator {
       }
       if (!terminal) throw new Error("Provider completed without a terminal event");
       const completedAt = (this.options.now ?? (() => new Date()))().toISOString();
-      if (terminal.error) {
-        await this.persistActivities(owner, run, [{ type: "run.error", error: terminal.error }], completedAt);
+      const terminalActivities: Array<Record<string, unknown>> = [
+        ...(terminal.error ? [{ type: "run.error", error: terminal.error }] : []),
+        { type: "run.status", status: terminal.outcome },
+      ];
+      try {
+        await this.persistActivities(owner, run, terminalActivities, completedAt);
+      } catch (activityError: unknown) {
+        if (!(activityError instanceof ChatConflictError)) throw activityError;
+        console.warn(
+          "[chat/orchestrator] Terminal Run activity exceeded the persisted limit; committing the terminal outcome:",
+          activityError.name,
+        );
       }
-      await this.persistActivities(owner, run, [{ type: "run.status", status: terminal.outcome }], completedAt);
       const output = text ? CanonicalChatMessageSchema.parse({
         id: `msg_${run.id.slice("run_".length)}_assistant`,
         chatId: run.chatId,

--- a/packages/gateway/src/chat/orchestrator.ts
+++ b/packages/gateway/src/chat/orchestrator.ts
@@ -1,0 +1,764 @@
+import { randomUUID } from "node:crypto";
+import {
+  CanonicalChatMessageSchema,
+  CanonicalChatRunActivitySchema,
+  CanonicalChatRunAdmissionResponseSchema,
+  CanonicalChatRunSchema,
+  CanonicalChatSafeErrorSchema,
+  CanonicalChatTurnAdmissionResponseSchema,
+  CanonicalChatTurnSchema,
+  CanonicalCreateChatTurnRequestSchema,
+  CanonicalRetryChatTurnRequestSchema,
+  type CanonicalChatMessage,
+  type CanonicalChatRun,
+  type CanonicalChatRunActivity,
+  type CanonicalChatRunAdmissionResponse,
+  type CanonicalChatRunCancellationResponse,
+  type CanonicalChatSafeError,
+  type CanonicalChatTurnAdmissionResponse,
+  type CanonicalCreateChatTurnRequest,
+  type CanonicalRetryChatTurnRequest,
+} from "@matrix-os/contracts";
+import type { RequestPrincipal } from "../request-principal.js";
+import type {
+  ChatExecutionRootProvenance,
+  ChatExecutionRootResolver,
+  ResolvedChatExecutionRoot,
+} from "./execution-root.js";
+import {
+  validateChatProviderSelection,
+  type ChatProviderCatalogService,
+} from "./provider-catalog.js";
+import {
+  CanonicalProviderRunEventSchema,
+  type CanonicalChatProviderAdapter,
+  type CanonicalProviderRunEvent,
+  type CanonicalProviderRunInput,
+  CanonicalChatProviderRegistry,
+} from "./provider-adapter.js";
+import {
+  ChatBusyError,
+  ChatConflictError,
+  ChatNotFoundError,
+  ChatProviderInstanceLockedError,
+  ChatRunNotActiveError,
+  type ChatRepository,
+} from "./repository.js";
+import type { ChatOwner } from "./records.js";
+
+const MAX_ACTIVE_RUNS_GLOBAL = 64;
+const MAX_ACTIVE_RUNS_PER_OWNER = 8;
+const MAX_ASSISTANT_TEXT = 96 * 1024;
+
+export class CanonicalChatOrchestrationError extends Error {
+  constructor(readonly safeError: CanonicalChatSafeError, readonly status: 400 | 404 | 409 | 503) {
+    super(safeError.safeMessage);
+    this.name = "CanonicalChatOrchestrationError";
+  }
+}
+
+interface ActiveRun {
+  controller: AbortController;
+  adapter: CanonicalChatProviderAdapter;
+  owner: ChatOwner;
+  chatId: string;
+  runId: string;
+  instanceId: string;
+  completion: Promise<void>;
+}
+
+function id(prefix: "cturn_" | "run_" | "msg_" | "activity_"): string {
+  return `${prefix}${randomUUID().replaceAll("-", "")}`;
+}
+
+function safeError(
+  code: CanonicalChatSafeError["code"],
+  safeMessage: string,
+  retryable = false,
+  recoveryActions?: CanonicalChatSafeError["recoveryActions"],
+): CanonicalChatSafeError {
+  return CanonicalChatSafeErrorSchema.parse({
+    code,
+    safeMessage,
+    retryable,
+    ...(recoveryActions ? { recoveryActions } : {}),
+  });
+}
+
+function promptFor(parts: CanonicalCreateChatTurnRequest["parts"]): string {
+  const lines = parts.flatMap((part) => {
+    if (part.type === "text") return [part.text];
+    if (part.type === "invocation_reference") {
+      return [`${part.invocation.invocation}${part.invocation.arguments ? ` ${part.invocation.arguments}` : ""}`];
+    }
+    if (part.type === "resource_reference") return [`@${part.resource.label}`];
+    if (part.type === "attachment_reference") return [`@${part.label}`];
+    return [];
+  });
+  const prompt = lines.join("\n").trim();
+  if (!prompt) throw new CanonicalChatOrchestrationError(
+    safeError("capability_mismatch", "The message does not contain supported input."),
+    400,
+  );
+  return prompt;
+}
+
+function requirementsFor(input: CanonicalCreateChatTurnRequest) {
+  return {
+    attachments: input.parts.flatMap((part) =>
+      part.type === "attachment_reference" ? [part.kind] : []
+    ),
+    resources: input.parts.flatMap((part) =>
+      part.type === "resource_reference" ? [part.resource.kind] : []
+    ),
+    interactionMode: input.interactionMode,
+    permissionMode: input.permissionMode,
+    worktree: input.executionRoot?.kind === "worktree",
+  };
+}
+
+function mapRepositoryError(error: unknown): never {
+  if (error instanceof ChatNotFoundError) {
+    throw new CanonicalChatOrchestrationError(safeError("chat_not_found", "Chat not found."), 404);
+  }
+  if (error instanceof ChatBusyError) {
+    throw new CanonicalChatOrchestrationError(safeError("chat_busy", "This Chat already has an active Run."), 409);
+  }
+  if (error instanceof ChatProviderInstanceLockedError) {
+    throw new CanonicalChatOrchestrationError(safeError(
+      "provider_instance_locked",
+      "This Chat is already bound to another Provider instance.",
+      false,
+      ["fork_chat", "start_new_chat"],
+    ), 409);
+  }
+  if (error instanceof ChatConflictError) {
+    throw new CanonicalChatOrchestrationError(safeError("chat_conflict", "Chat changed. Refresh and try again.", true, ["retry"]), 409);
+  }
+  throw error;
+}
+
+export class CanonicalChatOrchestrator {
+  private readonly active = new Map<string, ActiveRun>();
+  private readonly reconciliation = new Map<string, Promise<number>>();
+  private readonly shutdownDrainMs: number;
+
+  constructor(private readonly options: {
+    repository: Pick<ChatRepository,
+      | "get"
+      | "admitTurn"
+      | "markRunRunning"
+      | "appendRunActivities"
+      | "updateAdapterState"
+      | "finishRun"
+      | "getAdapterState"
+      | "getLatestAdapterStateForChat"
+      | "getTurnRunContext"
+      | "admitRetry"
+      | "listActiveRunContexts"
+    >;
+    catalog: Pick<ChatProviderCatalogService, "getCatalog">;
+    adapters: CanonicalChatProviderRegistry;
+    executionRoots?: ChatExecutionRootResolver;
+    now?: () => Date;
+    shutdownDrainMs?: number;
+  }) {
+    this.shutdownDrainMs = options.shutdownDrainMs ?? 10_000;
+    if (!Number.isInteger(this.shutdownDrainMs) || this.shutdownDrainMs < 1 || this.shutdownDrainMs > 60_000) {
+      throw new RangeError("Invalid canonical Chat shutdown drain timeout");
+    }
+  }
+
+  get activeCount(): number {
+    return this.active.size;
+  }
+
+  private atCapacity(owner: ChatOwner): boolean {
+    if (this.active.size >= MAX_ACTIVE_RUNS_GLOBAL) return true;
+    let ownerActive = 0;
+    for (const entry of this.active.values()) {
+      if (entry.owner.type === owner.type && entry.owner.ownerId === owner.ownerId) ownerActive += 1;
+    }
+    return ownerActive >= MAX_ACTIVE_RUNS_PER_OWNER;
+  }
+
+  async admitTurn(
+    principal: RequestPrincipal,
+    owner: ChatOwner,
+    chatId: string,
+    inputValue: CanonicalCreateChatTurnRequest,
+  ): Promise<CanonicalChatTurnAdmissionResponse> {
+    await this.reconcileActiveRuns(owner);
+    const input = CanonicalCreateChatTurnRequestSchema.parse(inputValue);
+    const record = await this.options.repository.get(owner, chatId);
+    if (!record) return mapRepositoryError(new ChatNotFoundError(chatId));
+    const catalog = await this.options.catalog.getCatalog(principal);
+    const validated = validateChatProviderSelection({
+      catalog,
+      selection: input.selection,
+      ...(record.providerBinding ? { boundInstanceId: record.providerBinding.instanceId } : {}),
+      requirements: requirementsFor(input),
+    });
+    if (!validated.ok) {
+      throw new CanonicalChatOrchestrationError(validated.error, validated.error.code === "provider_instance_locked" ? 409 : 400);
+    }
+    const adapter = this.options.adapters.get(validated.instance.driverKind);
+    if (!adapter) {
+      throw new CanonicalChatOrchestrationError(
+        safeError("provider_unavailable", "The selected Provider cannot run yet.", false, ["select_provider"]),
+        503,
+      );
+    }
+    const previousState = await this.options.repository.getLatestAdapterStateForChat(owner, {
+      chatId,
+      driverKind: validated.instance.driverKind,
+      instanceId: validated.instance.id,
+    });
+    const resumeState = previousState?.schemaVersion === adapter.stateSchemaVersion
+      ? adapter.parseState(previousState.state)
+      : undefined;
+    const rootRef = input.executionRoot
+      ?? (record.projectId ? { kind: "project" as const, projectId: record.projectId } : undefined);
+    if (validated.instance.workspaceRequirement === "project_required" && rootRef === undefined) {
+      throw new CanonicalChatOrchestrationError(
+        safeError("project_required", "This Provider requires a Project.", false, ["return_to_project"]),
+        400,
+      );
+    }
+    let resolvedRoot: Awaited<ReturnType<ChatExecutionRootResolver["resolve"]>> | undefined;
+    if (rootRef !== undefined) {
+      if (!this.options.executionRoots) {
+        throw new CanonicalChatOrchestrationError(
+          safeError("project_unavailable", "The Project workspace is unavailable.", true, ["retry"]),
+          503,
+        );
+      }
+      try {
+        resolvedRoot = await this.options.executionRoots.resolve(owner, rootRef);
+      } catch (error: unknown) {
+        console.warn("[chat/orchestrator] Execution root resolution failed:", error instanceof Error ? error.name : "UnknownError");
+        throw new CanonicalChatOrchestrationError(
+          safeError("project_unavailable", "The Project workspace is unavailable.", true, ["retry"]),
+          503,
+        );
+      }
+    }
+
+    const timestamp = (this.options.now ?? (() => new Date()))().toISOString();
+    const turnId = id("cturn_");
+    const message = CanonicalChatMessageSchema.parse({
+      id: id("msg_"),
+      chatId,
+      seq: record.chat.messageCount + 1,
+      role: "user",
+      state: "committed",
+      turnId,
+      parts: input.parts,
+      createdAt: timestamp,
+    });
+    const turn = CanonicalChatTurnSchema.parse({
+      id: turnId,
+      chatId,
+      clientRequestId: input.clientRequestId,
+      baseMessageSeq: record.chat.messageCount,
+      inputMessageId: message.id,
+      status: "accepted",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    const run = CanonicalChatRunSchema.parse({
+      id: id("run_"),
+      chatId,
+      turnId,
+      attempt: 1,
+      driverKind: validated.instance.driverKind,
+      instanceId: validated.instance.id,
+      selection: validated.selection,
+      interactionMode: input.interactionMode,
+      permissionMode: input.permissionMode,
+      ...(resolvedRoot ? {
+        executionRoot: resolvedRoot.ref,
+        executionRootFingerprint: resolvedRoot.fingerprint,
+      } : {}),
+      status: "accepted",
+      historyBoundarySeq: turn.baseMessageSeq,
+      capabilitySnapshot: {
+        revision: validated.instance.catalogRevision,
+        rootChat: validated.instance.supports.rootChat,
+        attachments: validated.instance.supports.attachments,
+        resources: validated.instance.supports.resources,
+        tools: validated.instance.supports.tools,
+        approvals: validated.instance.supports.approvals,
+        userInput: validated.instance.supports.userInput,
+        resume: validated.instance.supports.resume,
+        cancellation: validated.instance.supports.cancellation,
+        worktrees: validated.instance.supports.worktrees,
+        interactionModes: validated.instance.supports.interactionModes,
+        permissionModes: validated.instance.supports.permissionModes,
+      },
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    let admitted;
+    try {
+      admitted = await this.options.repository.admitTurn(owner, {
+        chatId,
+        baseRevision: input.baseRevision,
+        message,
+        turn,
+        run,
+      });
+    } catch (error: unknown) {
+      return mapRepositoryError(error);
+    }
+
+    if (!admitted.alreadyAccepted) {
+      if (this.atCapacity(owner)) {
+        await this.options.repository.finishRun(owner, {
+          chatId,
+          runId: admitted.run.id,
+          outcome: "failed",
+          completedAt: timestamp,
+        });
+        throw new CanonicalChatOrchestrationError(
+          safeError("run_unavailable", "Chat execution is temporarily busy.", true, ["retry"]),
+          503,
+        );
+      }
+      if (resumeState !== undefined) {
+        await this.options.repository.updateAdapterState(owner, {
+          chatId,
+          runId: admitted.run.id,
+          driverKind: admitted.run.driverKind,
+          instanceId: admitted.run.instanceId,
+          schemaVersion: adapter.stateSchemaVersion,
+          state: adapter.serializeState(resumeState),
+        });
+      }
+      this.startDispatch(
+        owner,
+        admitted.message,
+        admitted.run,
+        adapter,
+        admitted.chat.chat.messageCount + 1,
+        resolvedRoot,
+        resumeState,
+      );
+    }
+    return CanonicalChatTurnAdmissionResponseSchema.parse({
+      record: admitted.chat,
+      message: admitted.message,
+      turn: admitted.turn,
+      run: admitted.run,
+      admission: admitted.alreadyAccepted ? "already_accepted" : "accepted",
+    });
+  }
+
+  async retryTurn(
+    principal: RequestPrincipal,
+    owner: ChatOwner,
+    chatId: string,
+    turnId: string,
+    inputValue: CanonicalRetryChatTurnRequest,
+  ): Promise<CanonicalChatRunAdmissionResponse> {
+    await this.reconcileActiveRuns(owner);
+    const input = CanonicalRetryChatTurnRequestSchema.parse(inputValue);
+    const context = await this.options.repository.getTurnRunContext(owner, chatId, turnId);
+    if (!context) {
+      throw new CanonicalChatOrchestrationError(safeError("run_not_found", "Run not found."), 404);
+    }
+    const catalog = await this.options.catalog.getCatalog(principal);
+    const validated = validateChatProviderSelection({
+      catalog,
+      selection: context.latestRun.selection,
+      boundInstanceId: context.latestRun.instanceId,
+      requirements: {
+        interactionMode: context.latestRun.interactionMode,
+        permissionMode: context.latestRun.permissionMode,
+        worktree: context.latestRun.executionRoot?.kind === "worktree",
+      },
+    });
+    if (!validated.ok) throw new CanonicalChatOrchestrationError(validated.error, 400);
+    const adapter = this.options.adapters.get(context.latestRun.driverKind);
+    if (!adapter) {
+      throw new CanonicalChatOrchestrationError(
+        safeError("provider_unavailable", "The selected Provider cannot run yet.", false, ["select_provider"]),
+        503,
+      );
+    }
+    let resolvedRoot: ResolvedChatExecutionRoot | undefined;
+    if (context.latestRun.executionRoot) {
+      if (!this.options.executionRoots) {
+        throw new CanonicalChatOrchestrationError(
+          safeError("project_unavailable", "The Project workspace is unavailable.", true, ["retry"]),
+          503,
+        );
+      }
+      try {
+        resolvedRoot = await this.options.executionRoots.resolve(owner, context.latestRun.executionRoot);
+      } catch (error: unknown) {
+        console.warn("[chat/orchestrator] Retry root resolution failed:", error instanceof Error ? error.name : "UnknownError");
+        throw new CanonicalChatOrchestrationError(
+          safeError("project_unavailable", "The Project workspace is unavailable.", true, ["retry"]),
+          503,
+        );
+      }
+    }
+    const previousState = await this.options.repository.getLatestAdapterStateForChat(owner, {
+      chatId,
+      driverKind: context.latestRun.driverKind,
+      instanceId: context.latestRun.instanceId,
+    });
+    const resumeState = previousState?.schemaVersion === adapter.stateSchemaVersion
+      ? adapter.parseState(previousState.state)
+      : undefined;
+    const timestamp = (this.options.now ?? (() => new Date()))().toISOString();
+    const run = CanonicalChatRunSchema.parse({
+      id: id("run_"),
+      chatId,
+      turnId,
+      attempt: context.latestRun.attempt + 1,
+      driverKind: validated.instance.driverKind,
+      instanceId: validated.instance.id,
+      selection: validated.selection,
+      interactionMode: context.latestRun.interactionMode,
+      permissionMode: context.latestRun.permissionMode,
+      ...(resolvedRoot ? {
+        executionRoot: resolvedRoot.ref,
+        executionRootFingerprint: resolvedRoot.fingerprint,
+      } : {}),
+      status: "accepted",
+      historyBoundarySeq: context.turn.baseMessageSeq,
+      capabilitySnapshot: {
+        revision: validated.instance.catalogRevision,
+        rootChat: validated.instance.supports.rootChat,
+        attachments: validated.instance.supports.attachments,
+        resources: validated.instance.supports.resources,
+        tools: validated.instance.supports.tools,
+        approvals: validated.instance.supports.approvals,
+        userInput: validated.instance.supports.userInput,
+        resume: validated.instance.supports.resume,
+        cancellation: validated.instance.supports.cancellation,
+        worktrees: validated.instance.supports.worktrees,
+        interactionModes: validated.instance.supports.interactionModes,
+        permissionModes: validated.instance.supports.permissionModes,
+      },
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    let admitted;
+    try {
+      admitted = await this.options.repository.admitRetry(owner, {
+        chatId,
+        turnId,
+        clientRequestId: input.clientRequestId,
+        baseRevision: input.baseRevision,
+        run,
+      });
+    } catch (error: unknown) {
+      return mapRepositoryError(error);
+    }
+    if (!admitted.alreadyAccepted) {
+      if (this.atCapacity(owner)) {
+        await this.options.repository.finishRun(owner, {
+          chatId,
+          runId: admitted.run.id,
+          outcome: "failed",
+          completedAt: timestamp,
+        });
+        throw new CanonicalChatOrchestrationError(
+          safeError("run_unavailable", "Chat execution is temporarily busy.", true, ["retry"]),
+          503,
+        );
+      }
+      this.startDispatch(
+        owner,
+        context.message,
+        admitted.run,
+        adapter,
+        admitted.chat.chat.messageCount + 1,
+        resolvedRoot,
+        resumeState,
+      );
+    }
+    return CanonicalChatRunAdmissionResponseSchema.parse({
+      record: admitted.chat,
+      turn: admitted.turn,
+      run: admitted.run,
+      admission: admitted.alreadyAccepted ? "already_accepted" : "accepted",
+    });
+  }
+
+  private startDispatch(
+    owner: ChatOwner,
+    message: CanonicalChatMessage,
+    run: CanonicalChatRun,
+    adapter: CanonicalChatProviderAdapter,
+    outputSeq: number,
+    resolvedRoot?: ResolvedChatExecutionRoot,
+    resumeState?: unknown,
+  ): void {
+    const controller = new AbortController();
+    const completion = this.dispatch(owner, message, run, adapter, outputSeq, controller, resolvedRoot, resumeState)
+      .catch((error: unknown) => {
+        console.error("[chat/orchestrator] Run dispatch failed:", error instanceof Error ? error.name : "UnknownError");
+      })
+      .finally(() => this.active.delete(run.id));
+    this.active.set(run.id, {
+      controller,
+      adapter,
+      owner,
+      chatId: run.chatId,
+      runId: run.id,
+      instanceId: run.instanceId,
+      completion,
+    });
+  }
+
+  private async dispatch(
+    owner: ChatOwner,
+    message: CanonicalChatMessage,
+    run: CanonicalChatRun,
+    adapter: CanonicalChatProviderAdapter,
+    outputSeq: number,
+    controller: AbortController,
+    resolvedRoot?: ResolvedChatExecutionRoot,
+    resumeState?: unknown,
+  ): Promise<void> {
+    const startedAt = (this.options.now ?? (() => new Date()))().toISOString();
+    try {
+      if (resolvedRoot && this.options.executionRoots) {
+        const provenance: ChatExecutionRootProvenance = {
+          ref: resolvedRoot.ref!,
+          fingerprint: resolvedRoot.fingerprint,
+        };
+        resolvedRoot = await this.options.executionRoots.revalidate(owner, provenance);
+      }
+      await this.options.repository.markRunRunning(owner, { chatId: run.chatId, runId: run.id, startedAt });
+      await this.persistActivities(owner, run, [{ type: "run.status", status: "running" }, {
+        type: "turn.status",
+        turnId: run.turnId,
+        status: "running",
+      }], startedAt);
+
+      const input: CanonicalProviderRunInput = {
+        owner,
+        chatId: run.chatId,
+        turnId: run.turnId,
+        runId: run.id,
+        prompt: promptFor(message.parts),
+        parts: message.parts,
+        selection: run.selection,
+        interactionMode: run.interactionMode,
+        permissionMode: run.permissionMode,
+        ...(resolvedRoot ? { executionRoot: resolvedRoot.primaryWorkspaceRoot } : {}),
+        ...(resolvedRoot ? { projectSlug: resolvedRoot.projectSlug } : {}),
+        ...(resolvedRoot?.ref.kind === "worktree" ? { worktreeId: resolvedRoot.ref.worktreeId } : {}),
+        ...(resumeState === undefined ? {} : { resumeState }),
+        signal: controller.signal,
+      };
+      let text = "";
+      let terminal: Extract<CanonicalProviderRunEvent, { type: "run.completed" }> | undefined;
+      const events = resumeState !== undefined && adapter.resume
+        ? adapter.resume({ ...input, resumeState })
+        : adapter.start(input);
+      for await (const rawEvent of events) {
+        const event = CanonicalProviderRunEventSchema.parse(rawEvent);
+        if (terminal) throw new Error("Provider emitted an event after completion");
+        if (event.type === "state.updated") {
+          const state = adapter.serializeState(adapter.parseState(event.state));
+          await this.options.repository.updateAdapterState(owner, {
+            chatId: run.chatId,
+            runId: run.id,
+            driverKind: run.driverKind,
+            instanceId: run.instanceId,
+            schemaVersion: adapter.stateSchemaVersion,
+            state,
+          });
+        } else if (event.type === "assistant.delta") {
+          if (Buffer.byteLength(text + event.delta, "utf8") > MAX_ASSISTANT_TEXT) {
+            throw new Error("Provider assistant output exceeded the canonical limit");
+          }
+          text += event.delta;
+          await this.persistActivities(owner, run, [{
+            type: "assistant.delta",
+            messageId: `msg_${run.id.slice("run_".length)}_assistant`,
+            delta: event.delta,
+          }]);
+        } else if (event.type === "run.completed") {
+          terminal = event;
+        } else {
+          await this.persistActivities(owner, run, [event]);
+        }
+      }
+      if (!terminal) throw new Error("Provider completed without a terminal event");
+      const completedAt = (this.options.now ?? (() => new Date()))().toISOString();
+      if (terminal.error) {
+        await this.persistActivities(owner, run, [{ type: "run.error", error: terminal.error }], completedAt);
+      }
+      await this.persistActivities(owner, run, [{ type: "run.status", status: terminal.outcome }], completedAt);
+      const output = text ? CanonicalChatMessageSchema.parse({
+        id: `msg_${run.id.slice("run_".length)}_assistant`,
+        chatId: run.chatId,
+        seq: outputSeq,
+        role: "assistant",
+        state: terminal.outcome === "completed" ? "committed" : "failed",
+        turnId: run.turnId,
+        runId: run.id,
+        parts: [{ type: "text", text }],
+        createdAt: completedAt,
+      }) : undefined;
+      await this.options.repository.finishRun(owner, {
+        chatId: run.chatId,
+        runId: run.id,
+        outcome: terminal.outcome,
+        completedAt,
+        ...(output ? { output } : {}),
+      });
+    } catch (error: unknown) {
+      if (error instanceof ChatRunNotActiveError) return;
+      const outcome = controller.signal.aborted ? "aborted" as const : "failed" as const;
+      const completedAt = (this.options.now ?? (() => new Date()))().toISOString();
+      const canonicalError = safeError(
+        outcome === "aborted" ? "run_unavailable" : "run_failed",
+        outcome === "aborted" ? "The Run was cancelled." : "The Run failed.",
+        outcome !== "aborted",
+        outcome === "aborted" ? undefined : ["retry"],
+      );
+      try {
+        await this.persistActivities(owner, run, [{ type: "run.error", error: canonicalError }], completedAt);
+        await this.options.repository.finishRun(owner, {
+          chatId: run.chatId,
+          runId: run.id,
+          outcome,
+          completedAt,
+        });
+      } catch (finishError: unknown) {
+        if (!(finishError instanceof ChatRunNotActiveError)) throw finishError;
+      }
+    }
+  }
+
+  private async persistActivities(
+    owner: ChatOwner,
+    run: CanonicalChatRun,
+    events: Array<Record<string, unknown>>,
+    occurredAt = (this.options.now ?? (() => new Date()))().toISOString(),
+  ): Promise<void> {
+    const activities = events.map((event) => CanonicalChatRunActivitySchema.parse({
+      ...event,
+      id: id("activity_"),
+      chatId: run.chatId,
+      runId: run.id,
+      occurredAt,
+    })) as CanonicalChatRunActivity[];
+    await this.options.repository.appendRunActivities(owner, run.chatId, run.id, activities);
+  }
+
+  async cancelRun(
+    owner: ChatOwner,
+    chatId: string,
+    runId: string,
+  ): Promise<CanonicalChatRunCancellationResponse> {
+    const active = this.active.get(runId);
+    if (active && active.chatId === chatId && active.owner.type === owner.type
+      && active.owner.ownerId === owner.ownerId) {
+      active.controller.abort();
+      try {
+        const state = await this.options.repository.getAdapterState(owner, {
+          runId,
+          driverKind: active.adapter.driverKind,
+          instanceId: active.instanceId,
+        });
+        await active.adapter.cancel?.({
+          owner,
+          chatId,
+          runId,
+          ...(state ? { state: active.adapter.parseState(state.state) } : {}),
+        });
+      } catch (error: unknown) {
+        console.warn("[chat/orchestrator] Provider cancel callback failed:", error instanceof Error ? error.name : "UnknownError");
+      }
+    }
+    try {
+      const finished = await this.options.repository.finishRun(owner, {
+        chatId,
+        runId,
+        outcome: "aborted",
+        completedAt: (this.options.now ?? (() => new Date()))().toISOString(),
+      });
+      return {
+        run: finished.run,
+        cancellation: finished.transitioned ? "aborted" : "already_terminal",
+      };
+    } catch (error: unknown) {
+      return mapRepositoryError(error);
+    }
+  }
+
+  async reconcileActiveRuns(owner: ChatOwner): Promise<number> {
+    const key = `${owner.type}:${owner.ownerId}`;
+    const existing = this.reconciliation.get(key);
+    if (existing) return existing;
+    if (this.reconciliation.size >= 64) {
+      const oldest = this.reconciliation.keys().next().value;
+      if (oldest) this.reconciliation.delete(oldest);
+    }
+    const reconciliation = this.reconcileOwnerActiveRuns(owner).catch((error: unknown) => {
+      this.reconciliation.delete(key);
+      throw error;
+    });
+    this.reconciliation.set(key, reconciliation);
+    return reconciliation;
+  }
+
+  private async reconcileOwnerActiveRuns(owner: ChatOwner): Promise<number> {
+    const contexts = await this.options.repository.listActiveRunContexts(owner, MAX_ACTIVE_RUNS_GLOBAL);
+    let reconciled = 0;
+    for (const context of contexts) {
+      if (this.active.has(context.latestRun.id)) continue;
+      const completedAt = (this.options.now ?? (() => new Date()))().toISOString();
+      const error = safeError(
+        "run_unavailable",
+        "The Run was interrupted when Matrix restarted.",
+        true,
+        ["retry"],
+      );
+      try {
+        await this.persistActivities(owner, context.latestRun, [{ type: "run.error", error }], completedAt);
+        const finished = await this.options.repository.finishRun(owner, {
+          chatId: context.latestRun.chatId,
+          runId: context.latestRun.id,
+          outcome: "failed",
+          completedAt,
+        });
+        if (finished.transitioned) reconciled += 1;
+      } catch (reconcileError: unknown) {
+        if (!(reconcileError instanceof ChatRunNotActiveError)) throw reconcileError;
+      }
+    }
+    return reconciled;
+  }
+
+  async drain(): Promise<void> {
+    await Promise.allSettled([...this.active.values()].map((entry) => entry.completion));
+  }
+
+  async close(): Promise<void> {
+    const active = [...this.active.values()];
+    await Promise.allSettled(active.map((entry) => this.cancelRun(entry.owner, entry.chatId, entry.runId)));
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        this.drain(),
+        new Promise<void>((resolve) => {
+          timeout = setTimeout(resolve, this.shutdownDrainMs);
+          timeout.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+      this.active.clear();
+    }
+  }
+}

--- a/packages/gateway/src/chat/orchestrator.ts
+++ b/packages/gateway/src/chat/orchestrator.ts
@@ -142,6 +142,7 @@ export class CanonicalChatOrchestrator {
   private readonly active = new Map<string, ActiveRun>();
   private readonly reconciliation = new Map<string, Promise<number>>();
   private readonly shutdownDrainMs: number;
+  private closing = false;
 
   constructor(private readonly options: {
     repository: Pick<ChatRepository,
@@ -182,12 +183,22 @@ export class CanonicalChatOrchestrator {
     return ownerActive >= MAX_ACTIVE_RUNS_PER_OWNER;
   }
 
+  private assertOpen(): void {
+    if (this.closing) {
+      throw new CanonicalChatOrchestrationError(
+        safeError("run_unavailable", "Chat execution is shutting down.", true, ["retry"]),
+        503,
+      );
+    }
+  }
+
   async admitTurn(
     principal: RequestPrincipal,
     owner: ChatOwner,
     chatId: string,
     inputValue: CanonicalCreateChatTurnRequest,
   ): Promise<CanonicalChatTurnAdmissionResponse> {
+    this.assertOpen();
     await this.reconcileActiveRuns(owner);
     const input = CanonicalCreateChatTurnRequestSchema.parse(inputValue);
     const record = await this.options.repository.get(owner, chatId);
@@ -214,11 +225,14 @@ export class CanonicalChatOrchestrator {
       driverKind: validated.instance.driverKind,
       instanceId: validated.instance.id,
     });
-    const resumeState = previousState?.schemaVersion === adapter.stateSchemaVersion
-      ? adapter.parseState(previousState.state)
-      : undefined;
     const rootRef = input.executionRoot
       ?? (record.projectId ? { kind: "project" as const, projectId: record.projectId } : undefined);
+    if (input.executionRoot && record.projectId && input.executionRoot.projectId !== record.projectId) {
+      throw new CanonicalChatOrchestrationError(
+        safeError("project_unavailable", "The selected workspace does not belong to this Chat's Project."),
+        400,
+      );
+    }
     if (validated.instance.workspaceRequirement === "project_required" && rootRef === undefined) {
       throw new CanonicalChatOrchestrationError(
         safeError("project_required", "This Provider requires a Project.", false, ["return_to_project"]),
@@ -243,6 +257,14 @@ export class CanonicalChatOrchestrator {
         );
       }
     }
+    const resumeState = previousState?.schemaVersion === adapter.stateSchemaVersion
+      && (previousState.executionRootFingerprint ?? null) === (resolvedRoot?.fingerprint ?? null)
+      ? adapter.parseState(previousState.state)
+      : undefined;
+    const adapterState = resumeState === undefined ? undefined : {
+      schemaVersion: adapter.stateSchemaVersion,
+      state: adapter.serializeState(resumeState),
+    };
 
     const timestamp = (this.options.now ?? (() => new Date()))().toISOString();
     const turnId = id("cturn_");
@@ -301,12 +323,14 @@ export class CanonicalChatOrchestrator {
     });
     let admitted;
     try {
+      this.assertOpen();
       admitted = await this.options.repository.admitTurn(owner, {
         chatId,
         baseRevision: input.baseRevision,
         message,
         turn,
         run,
+        ...(adapterState ? { adapterState } : {}),
       });
     } catch (error: unknown) {
       return mapRepositoryError(error);
@@ -324,16 +348,6 @@ export class CanonicalChatOrchestrator {
           safeError("run_unavailable", "Chat execution is temporarily busy.", true, ["retry"]),
           503,
         );
-      }
-      if (resumeState !== undefined) {
-        await this.options.repository.updateAdapterState(owner, {
-          chatId,
-          runId: admitted.run.id,
-          driverKind: admitted.run.driverKind,
-          instanceId: admitted.run.instanceId,
-          schemaVersion: adapter.stateSchemaVersion,
-          state: adapter.serializeState(resumeState),
-        });
       }
       this.startDispatch(
         owner,
@@ -361,6 +375,7 @@ export class CanonicalChatOrchestrator {
     turnId: string,
     inputValue: CanonicalRetryChatTurnRequest,
   ): Promise<CanonicalChatRunAdmissionResponse> {
+    this.assertOpen();
     await this.reconcileActiveRuns(owner);
     const input = CanonicalRetryChatTurnRequestSchema.parse(inputValue);
     const context = await this.options.repository.getTurnRunContext(owner, chatId, turnId);
@@ -410,8 +425,13 @@ export class CanonicalChatOrchestrator {
       instanceId: context.latestRun.instanceId,
     });
     const resumeState = previousState?.schemaVersion === adapter.stateSchemaVersion
+      && (previousState.executionRootFingerprint ?? null) === (resolvedRoot?.fingerprint ?? null)
       ? adapter.parseState(previousState.state)
       : undefined;
+    const adapterState = resumeState === undefined ? undefined : {
+      schemaVersion: adapter.stateSchemaVersion,
+      state: adapter.serializeState(resumeState),
+    };
     const timestamp = (this.options.now ?? (() => new Date()))().toISOString();
     const run = CanonicalChatRunSchema.parse({
       id: id("run_"),
@@ -448,12 +468,14 @@ export class CanonicalChatOrchestrator {
     });
     let admitted;
     try {
+      this.assertOpen();
       admitted = await this.options.repository.admitRetry(owner, {
         chatId,
         turnId,
         clientRequestId: input.clientRequestId,
         baseRevision: input.baseRevision,
         run,
+        ...(adapterState ? { adapterState } : {}),
       });
     } catch (error: unknown) {
       return mapRepositoryError(error);
@@ -626,7 +648,14 @@ export class CanonicalChatOrchestrator {
         outcome === "aborted" ? undefined : ["retry"],
       );
       try {
-        await this.persistActivities(owner, run, [{ type: "run.error", error: canonicalError }], completedAt);
+        try {
+          await this.persistActivities(owner, run, [{ type: "run.error", error: canonicalError }], completedAt);
+        } catch (activityError: unknown) {
+          console.warn(
+            "[chat/orchestrator] Terminal Run activity could not be persisted:",
+            activityError instanceof Error ? activityError.name : "UnknownError",
+          );
+        }
         await this.options.repository.finishRun(owner, {
           chatId: run.chatId,
           runId: run.id,
@@ -661,10 +690,11 @@ export class CanonicalChatOrchestrator {
     runId: string,
   ): Promise<CanonicalChatRunCancellationResponse> {
     const active = this.active.get(runId);
+    let providerCancellation: Promise<void> | undefined;
     if (active && active.chatId === chatId && active.owner.type === owner.type
       && active.owner.ownerId === owner.ownerId) {
       active.controller.abort();
-      try {
+      providerCancellation = (async () => {
         const state = await this.options.repository.getAdapterState(owner, {
           runId,
           driverKind: active.adapter.driverKind,
@@ -676,9 +706,9 @@ export class CanonicalChatOrchestrator {
           runId,
           ...(state ? { state: active.adapter.parseState(state.state) } : {}),
         });
-      } catch (error: unknown) {
+      })().catch((error: unknown) => {
         console.warn("[chat/orchestrator] Provider cancel callback failed:", error instanceof Error ? error.name : "UnknownError");
-      }
+      });
     }
     try {
       const finished = await this.options.repository.finishRun(owner, {
@@ -687,6 +717,20 @@ export class CanonicalChatOrchestrator {
         outcome: "aborted",
         completedAt: (this.options.now ?? (() => new Date()))().toISOString(),
       });
+      if (providerCancellation) {
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+        try {
+          await Promise.race([
+            providerCancellation,
+            new Promise<void>((resolve) => {
+              timeout = setTimeout(resolve, this.shutdownDrainMs);
+              timeout.unref?.();
+            }),
+          ]);
+        } finally {
+          if (timeout) clearTimeout(timeout);
+        }
+      }
       return {
         run: finished.run,
         cancellation: finished.transitioned ? "aborted" : "already_terminal",
@@ -745,12 +789,13 @@ export class CanonicalChatOrchestrator {
   }
 
   async close(): Promise<void> {
+    this.closing = true;
     const active = [...this.active.values()];
-    await Promise.allSettled(active.map((entry) => this.cancelRun(entry.owner, entry.chatId, entry.runId)));
     let timeout: ReturnType<typeof setTimeout> | undefined;
     try {
       await Promise.race([
-        this.drain(),
+        Promise.allSettled(active.map((entry) => this.cancelRun(entry.owner, entry.chatId, entry.runId)))
+          .then(() => this.drain()),
         new Promise<void>((resolve) => {
           timeout = setTimeout(resolve, this.shutdownDrainMs);
           timeout.unref?.();

--- a/packages/gateway/src/chat/orchestrator.ts
+++ b/packages/gateway/src/chat/orchestrator.ts
@@ -769,7 +769,14 @@ export class CanonicalChatOrchestrator {
         ["retry"],
       );
       try {
-        await this.persistActivities(owner, context.latestRun, [{ type: "run.error", error }], completedAt);
+        try {
+          await this.persistActivities(owner, context.latestRun, [{ type: "run.error", error }], completedAt);
+        } catch (activityError: unknown) {
+          console.warn(
+            "[chat/orchestrator] Reconciliation activity could not be persisted:",
+            activityError instanceof Error ? activityError.name : "UnknownError",
+          );
+        }
         const finished = await this.options.repository.finishRun(owner, {
           chatId: context.latestRun.chatId,
           runId: context.latestRun.id,

--- a/packages/gateway/src/chat/provider-adapter.ts
+++ b/packages/gateway/src/chat/provider-adapter.ts
@@ -1,0 +1,125 @@
+import {
+  CanonicalChatMessagePartSchema,
+  CanonicalChatModelSelectionSchema,
+  CanonicalChatSafeErrorSchema,
+  CanonicalOwnerScopeSchema,
+  type CanonicalChatMessagePart,
+  type CanonicalChatModelSelection,
+  type CanonicalChatSafeError,
+  type CanonicalOwnerScope,
+  type CanonicalProviderDriverKind,
+} from "@matrix-os/contracts";
+import { z } from "zod/v4";
+
+const SafeProviderRefSchema = z.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/);
+
+export const CanonicalProviderRunEventSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("assistant.delta"), delta: z.string().min(1).max(4_000) }).strict(),
+  z.object({
+    type: z.literal("tool.progress"),
+    toolCallId: SafeProviderRefSchema,
+    label: z.string().trim().min(1).max(240),
+    status: z.enum(["queued", "running", "completed", "failed", "cancelled"]),
+  }).strict(),
+  z.object({
+    type: z.literal("tool.output"),
+    toolCallId: SafeProviderRefSchema,
+    text: z.string().max(4_000),
+    truncated: z.boolean(),
+  }).strict(),
+  z.object({ type: z.literal("terminal.bound"), terminalSessionId: SafeProviderRefSchema }).strict(),
+  z.object({
+    type: z.literal("review.ready"),
+    reviewId: SafeProviderRefSchema,
+    summary: z.object({
+      changedFileCount: z.number().int().min(0).max(10_000),
+      additions: z.number().int().min(0).max(1_000_000),
+      deletions: z.number().int().min(0).max(1_000_000),
+      partial: z.boolean(),
+    }).strict(),
+  }).strict(),
+  z.object({
+    type: z.literal("resource.changed"),
+    resourceId: SafeProviderRefSchema,
+    resourceKind: z.enum(["file", "folder", "project", "task", "app", "terminal_session"]),
+    changeKind: z.enum(["created", "updated", "deleted", "renamed"]),
+  }).strict(),
+  z.object({
+    type: z.literal("approval.requested"),
+    approvalId: SafeProviderRefSchema,
+    title: z.string().trim().min(1).max(160),
+    risk: z.enum(["low", "medium", "high"]),
+  }).strict(),
+  z.object({
+    type: z.literal("input.requested"),
+    requestId: SafeProviderRefSchema,
+    title: z.string().trim().min(1).max(160),
+  }).strict(),
+  z.object({ type: z.literal("state.updated"), state: z.unknown() }).strict(),
+  z.object({
+    type: z.literal("run.completed"),
+    outcome: z.enum(["completed", "failed", "aborted"]),
+    error: CanonicalChatSafeErrorSchema.optional(),
+  }).strict(),
+]);
+
+export type CanonicalProviderRunEvent = z.infer<typeof CanonicalProviderRunEventSchema>;
+
+export interface CanonicalProviderRunInput<State = unknown> {
+  owner: CanonicalOwnerScope;
+  chatId: string;
+  turnId: string;
+  runId: string;
+  prompt: string;
+  parts: CanonicalChatMessagePart[];
+  selection: CanonicalChatModelSelection;
+  interactionMode: string;
+  permissionMode: string;
+  executionRoot?: string;
+  projectSlug?: string;
+  worktreeId?: string;
+  resumeState?: State;
+  signal: AbortSignal;
+}
+
+export interface CanonicalChatProviderAdapter<State = unknown> {
+  readonly driverKind: CanonicalProviderDriverKind;
+  readonly stateSchemaVersion: number;
+  parseState(value: unknown): State;
+  serializeState(value: State): unknown;
+  start(input: CanonicalProviderRunInput<State>): AsyncIterable<CanonicalProviderRunEvent>;
+  resume?(input: CanonicalProviderRunInput<State> & { resumeState: State }): AsyncIterable<CanonicalProviderRunEvent>;
+  cancel?(input: { owner: CanonicalOwnerScope; chatId: string; runId: string; state?: State }): Promise<void>;
+}
+
+export function parseCanonicalProviderRunInput<State>(
+  input: CanonicalProviderRunInput<State>,
+): CanonicalProviderRunInput<State> {
+  CanonicalOwnerScopeSchema.parse(input.owner);
+  CanonicalChatModelSelectionSchema.parse(input.selection);
+  z.array(CanonicalChatMessagePartSchema).min(1).max(64).parse(input.parts);
+  z.string().min(1).max(96 * 1024).parse(input.prompt);
+  return input;
+}
+
+export class CanonicalChatProviderRegistry {
+  private readonly adapters = new Map<CanonicalProviderDriverKind, CanonicalChatProviderAdapter>();
+
+  constructor(adapters: readonly CanonicalChatProviderAdapter[]) {
+    if (adapters.length > 20) throw new RangeError("Too many canonical Chat Provider adapters");
+    for (const adapter of adapters) {
+      if (this.adapters.has(adapter.driverKind)) {
+        throw new Error("Duplicate canonical Chat Provider adapter");
+      }
+      this.adapters.set(adapter.driverKind, adapter);
+    }
+  }
+
+  get(driverKind: CanonicalProviderDriverKind): CanonicalChatProviderAdapter | undefined {
+    return this.adapters.get(driverKind);
+  }
+}
+
+export function providerFailure(error: CanonicalChatSafeError): CanonicalProviderRunEvent {
+  return CanonicalProviderRunEventSchema.parse({ type: "run.completed", outcome: "failed", error });
+}

--- a/packages/gateway/src/chat/provider-catalog.ts
+++ b/packages/gateway/src/chat/provider-catalog.ts
@@ -320,7 +320,7 @@ function systemInstance(input: {
       ? model
       : { ...model, availability: "auth_required" as const }
   ));
-  const availability = systemAvailability(input.kind, input.runtime, models);
+  const availability = systemAvailability(input.kind, input.runtime, models, harnessConfigured);
   const selectedModel = input.kind === "hermes"
     ? `anthropic:${KERNEL_DEFAULTS.model}`
     : input.selectedProvider && input.selectedModel

--- a/packages/gateway/src/chat/provider-catalog.ts
+++ b/packages/gateway/src/chat/provider-catalog.ts
@@ -22,6 +22,7 @@ import { createHash } from "node:crypto";
 import { readRuntimeSnapshot, type AgentRuntimeSource } from "../agent-config/service.js";
 import type { CodingAgentProviderRegistry } from "../coding-agents/provider-registry.js";
 import type { RequestPrincipal } from "../request-principal.js";
+import { KERNEL_DEFAULTS, KERNEL_EFFORTS, KERNEL_MODELS } from "../kernel-settings.js";
 
 const ADAPTER_VERSION = "1.0.0";
 const SYSTEM_DRIVERS = ["hermes", "openclaw"] as const;
@@ -208,6 +209,17 @@ function systemModels(
   runtime: CanonicalProviderDriverKind,
   providers: AgentProviderDescriptor[],
 ): CanonicalModelDescriptor[] {
+  if (runtime === "hermes") {
+    return KERNEL_MODELS.map((model) => ({
+      id: `anthropic:${model.id}`,
+      displayName: model.label,
+      description: model.tier,
+      availability: "available" as const,
+      capabilities: ["tools", "vision", "reasoning"],
+      supportsVision: true,
+      supportsToolUse: true,
+    }));
+  }
   return providers
     .filter((provider) => provider.runtime === runtime)
     .flatMap((provider) => provider.models.map((model) => ({
@@ -228,6 +240,18 @@ function systemOptions(
   runtime: CanonicalProviderDriverKind,
   providers: AgentProviderDescriptor[],
 ): CanonicalProviderOptionDescriptor[] {
+  if (runtime === "hermes") {
+    return [{
+      id: "effort",
+      label: "Reasoning",
+      kind: "enum",
+      values: KERNEL_EFFORTS.map((effort) => ({
+        value: effort,
+        label: effort.charAt(0).toUpperCase() + effort.slice(1),
+      })),
+      placement: "composer",
+    }];
+  }
   const efforts: string[] = [];
   for (const provider of providers) {
     if (provider.runtime !== runtime) continue;
@@ -261,10 +285,12 @@ function systemSetupActions(runtime: AgentRuntimeDescriptor | undefined): Canoni
 }
 
 function systemAvailability(
+  kind: typeof SYSTEM_DRIVERS[number],
   runtime: AgentRuntimeDescriptor | undefined,
   models: CanonicalModelDescriptor[],
   messagingConfigured: boolean,
 ): CanonicalProviderInstanceDescriptor["availability"] {
+  if (kind === "hermes") return "available";
   if (runtime === undefined) return "unavailable";
   if (runtime.installState === "missing" || runtime.installState === "installing") return "setup_required";
   if (runtime.selectionState !== "active") return "unavailable";
@@ -290,12 +316,14 @@ function systemInstance(input: {
     && input.selectedProvider !== null
     && input.selectedModel !== null;
   const models = systemModels(input.kind, input.providers).map((model) => (
-    harnessConfigured || model.availability === "unavailable"
+    input.kind === "hermes" || harnessConfigured || model.availability === "unavailable"
       ? model
       : { ...model, availability: "auth_required" as const }
   ));
-  const availability = systemAvailability(input.runtime, models, harnessConfigured);
-  const selectedModel = input.selectedProvider && input.selectedModel
+  const availability = systemAvailability(input.kind, input.runtime, models);
+  const selectedModel = input.kind === "hermes"
+    ? `anthropic:${KERNEL_DEFAULTS.model}`
+    : input.selectedProvider && input.selectedModel
     ? `${input.selectedProvider}:${input.selectedModel}`
     : null;
   const hasSelectedModel = selectedModel !== null
@@ -310,7 +338,7 @@ function systemInstance(input: {
     options: systemOptions(input.kind, input.providers),
     skills: input.skills,
     commands: [],
-    setupActions: systemSetupActions(input.runtime),
+    setupActions: input.kind === "hermes" ? [] : systemSetupActions(input.runtime),
     supports: systemSupports(),
     ...(availability === "available" && hasSelectedModel ? {
       defaultSelection: { instanceId: id, model: selectedModel! },

--- a/packages/gateway/src/chat/records.ts
+++ b/packages/gateway/src/chat/records.ts
@@ -199,6 +199,9 @@ export function toRun(row: Selectable<ChatRunsTable>): CanonicalChatRun {
     interactionMode: row.interaction_mode,
     permissionMode: row.permission_mode,
     ...(row.execution_root === null ? {} : { executionRoot: parseJson(row.execution_root) }),
+    ...(row.execution_root_fingerprint === null
+      ? {}
+      : { executionRootFingerprint: row.execution_root_fingerprint }),
     status: row.status,
     ...(row.outcome === null ? {} : { outcome: row.outcome }),
     ...(row.started_at === null ? {} : { startedAt: asIso(row.started_at) }),

--- a/packages/gateway/src/chat/repository.ts
+++ b/packages/gateway/src/chat/repository.ts
@@ -84,6 +84,15 @@ export interface ChatListPage {
   nextCursor?: ChatListCursor;
 }
 
+export interface ChatDetailPage {
+  record: ChatRecord;
+  messages: CanonicalChatMessage[];
+  turns: CanonicalChatTurn[];
+  runs: CanonicalChatRun[];
+  activities: CanonicalChatRunActivity[];
+  nextBeforeSeq?: number;
+}
+
 export class ChatNotFoundError extends Error {
   constructor(readonly chatId: string) {
     super("Chat not found");
@@ -542,6 +551,68 @@ export class ChatRepository {
       .where("chat_id", "=", chatId).where("seq", ">", Math.max(0, Math.trunc(input.afterSeq)))
       .orderBy("seq").limit(limit).execute();
     return rows.map(toMessage);
+  }
+
+  async getDetailPage(ownerInput: ChatOwner, chatId: string, input: {
+    beforeSeq?: number;
+    limit: number;
+  }): Promise<ChatDetailPage | null> {
+    const owner = validateOwner(ownerInput);
+    const parsedChatId = CanonicalChatIdSchema.parse(chatId);
+    const record = await hydrateRecord(this.kysely, owner, parsedChatId);
+    if (!record) return null;
+    const limit = Math.max(1, Math.min(200, Math.trunc(input.limit)));
+    const beforeSeq = input.beforeSeq === undefined
+      ? Number.MAX_SAFE_INTEGER
+      : Math.max(1, Math.trunc(input.beforeSeq));
+    const messageRows = await this.kysely.selectFrom("chat_messages").selectAll()
+      .where("chat_id", "=", parsedChatId)
+      .where("seq", "<", beforeSeq)
+      .orderBy("seq", "desc")
+      .limit(limit + 1)
+      .execute();
+    const hasOlder = messageRows.length > limit;
+    const selectedMessageRows = messageRows.slice(0, limit).reverse();
+    const turnIds = [...new Set(selectedMessageRows.flatMap((row) => row.turn_id ? [row.turn_id] : []))];
+    const turnRows = turnIds.length === 0 ? [] : await this.kysely.selectFrom("chat_turns").selectAll()
+      .where("chat_id", "=", parsedChatId)
+      .where("id", "in", turnIds)
+      .orderBy("created_at", "desc")
+      .limit(100)
+      .execute();
+    turnRows.reverse();
+    const selectedRunIds = selectedMessageRows.flatMap((row) => row.run_id ? [row.run_id] : []);
+    const runTurnIds = turnRows.map((row) => row.id);
+    const runRows = runTurnIds.length === 0 && selectedRunIds.length === 0 ? [] : await this.kysely
+      .selectFrom("chat_runs")
+      .selectAll()
+      .where("chat_id", "=", parsedChatId)
+      .where(({ eb, or }) => or([
+        ...(runTurnIds.length > 0 ? [eb("turn_id", "in", runTurnIds)] : []),
+        ...(selectedRunIds.length > 0 ? [eb("id", "in", selectedRunIds)] : []),
+      ]))
+      .orderBy("created_at", "desc")
+      .limit(100)
+      .execute();
+    runRows.reverse();
+    const runIds = runRows.map((row) => row.id);
+    const activityRows = runIds.length === 0 ? [] : await this.kysely.selectFrom("chat_run_events").selectAll()
+      .where("chat_id", "=", parsedChatId)
+      .where("run_id", "in", runIds)
+      .orderBy("occurred_at", "desc")
+      .limit(500)
+      .execute();
+    activityRows.reverse();
+    return {
+      record,
+      messages: selectedMessageRows.map(toMessage),
+      turns: turnRows.map(toTurn),
+      runs: runRows.map(toRun),
+      activities: activityRows.map(toActivity),
+      ...(hasOlder && selectedMessageRows[0]
+        ? { nextBeforeSeq: Number(selectedMessageRows[0].seq) }
+        : {}),
+    };
   }
 
   async getAdapterState(ownerInput: ChatOwner, input: {

--- a/packages/gateway/src/chat/repository.ts
+++ b/packages/gateway/src/chat/repository.ts
@@ -97,6 +97,7 @@ export interface AdmitRetryInput {
   clientRequestId: string;
   baseRevision: number;
   run: CanonicalChatRun;
+  adapterState?: { schemaVersion: number; state: unknown };
 }
 
 export interface AdmittedRun {
@@ -439,6 +440,9 @@ export class ChatRepository {
         .where("client_request_id", "=", turn.clientRequestId)
         .executeTakeFirst();
       if (duplicate) return hydrateAdmission(trx, owner, toTurn(duplicate));
+      if (current.lifecycle !== "active") {
+        throw new ChatConflictError(input.chatId, Number(current.revision));
+      }
       if (Number(current.revision) !== input.baseRevision) {
         throw new ChatConflictError(input.chatId, Number(current.revision));
       }
@@ -561,7 +565,12 @@ export class ChatRepository {
     const turnId = requireSafeRef(input.turnId);
     const clientRequestId = CanonicalChatRequestIdSchema.parse(input.clientRequestId);
     const run = CanonicalChatRunSchema.parse(input.run);
+    const stateBytes = input.adapterState ? encoded.encode(JSON.stringify(input.adapterState.state)).byteLength : 0;
     if (run.chatId !== chatId || run.turnId !== turnId || run.status !== "accepted" || run.attempt < 2) {
+      throw new ChatConflictError(chatId, input.baseRevision);
+    }
+    if (input.adapterState && (!Number.isInteger(input.adapterState.schemaVersion)
+      || input.adapterState.schemaVersion < 1 || stateBytes > 64 * 1024)) {
       throw new ChatConflictError(chatId, input.baseRevision);
     }
     return this.transact(async (trx) => {
@@ -581,6 +590,9 @@ export class ChatRepository {
           run: toRun(existing),
           alreadyAccepted: true,
         };
+      }
+      if (current.lifecycle !== "active") {
+        throw new ChatConflictError(chatId, Number(current.revision));
       }
       if (Number(current.revision) !== input.baseRevision) {
         throw new ChatConflictError(chatId, Number(current.revision));
@@ -621,6 +633,16 @@ export class ChatRepository {
         created_at: run.createdAt,
         updated_at: run.updatedAt,
       }).execute();
+      if (input.adapterState) {
+        await trx.insertInto("chat_run_adapter_state").values({
+          run_id: run.id,
+          driver_kind: run.driverKind,
+          instance_id: run.instanceId,
+          schema_version: input.adapterState.schemaVersion,
+          state: jsonb(input.adapterState.state),
+          byte_count: stateBytes,
+        }).execute();
+      }
       await trx.updateTable("chat_turns").set({ status: "accepted", updated_at: run.updatedAt })
         .where("id", "=", turnId).execute();
       const revision = input.baseRevision + 1;
@@ -737,7 +759,7 @@ export class ChatRepository {
     chatId: string;
     driverKind: string;
     instanceId: string;
-  }): Promise<{ schemaVersion: number; state: unknown } | null> {
+  }): Promise<{ schemaVersion: number; state: unknown; executionRootFingerprint?: string } | null> {
     return this.runLifecycle.getLatestAdapterStateForChat(ownerInput, input);
   }
 

--- a/packages/gateway/src/chat/repository.ts
+++ b/packages/gateway/src/chat/repository.ts
@@ -3,7 +3,6 @@ import {
   CanonicalChatMessageSchema,
   CanonicalChatModelSelectionSchema,
   CanonicalChatRequestIdSchema,
-  CanonicalChatRunActivitySchema,
   CanonicalChatRunSchema,
   CanonicalChatTurnSchema,
   CanonicalOwnerScopeSchema,
@@ -16,6 +15,13 @@ import {
 import { Kysely, sql, type Dialect, type Selectable, type Transaction } from "kysely";
 import { z } from "zod/v4";
 import { bootstrapChatDatabase, type ChatDatabase, type ChatRunsTable, type ChatsTable } from "./database.js";
+import { ChatDetailRepository, type ChatDetailPage } from "./detail-repository.js";
+import {
+  ChatBusyError,
+  ChatConflictError,
+  ChatNotFoundError,
+  ChatProviderInstanceLockedError,
+} from "./errors.js";
 import {
   asIso,
   jsonb,
@@ -36,6 +42,16 @@ import {
   type ChatOwner,
   type ChatRecord,
 } from "./records.js";
+import { ChatRunLifecycleRepository } from "./run-lifecycle-repository.js";
+
+export {
+  ChatBusyError,
+  ChatConflictError,
+  ChatNotFoundError,
+  ChatProviderInstanceLockedError,
+  ChatRunNotActiveError,
+} from "./errors.js";
+export type { ChatDetailPage } from "./detail-repository.js";
 
 type Executor = Kysely<ChatDatabase> | Transaction<ChatDatabase>;
 const ACTIVE_RUNS = ["accepted", "running", "waiting_for_approval", "waiting_for_input"] as const;
@@ -72,6 +88,29 @@ export interface AdmittedTurn {
   message: CanonicalChatMessage;
   turn: CanonicalChatTurn;
   run: CanonicalChatRun;
+  alreadyAccepted: boolean;
+}
+
+export interface AdmitRetryInput {
+  chatId: string;
+  turnId: string;
+  clientRequestId: string;
+  baseRevision: number;
+  run: CanonicalChatRun;
+}
+
+export interface AdmittedRun {
+  chat: ChatRecord;
+  turn: CanonicalChatTurn;
+  run: CanonicalChatRun;
+  alreadyAccepted: boolean;
+}
+
+export interface ChatTurnRunContext {
+  chat: ChatRecord;
+  message: CanonicalChatMessage;
+  turn: CanonicalChatTurn;
+  latestRun: CanonicalChatRun;
 }
 
 export interface ChatListCursor {
@@ -82,43 +121,6 @@ export interface ChatListCursor {
 export interface ChatListPage {
   items: ChatRecord[];
   nextCursor?: ChatListCursor;
-}
-
-export interface ChatDetailPage {
-  record: ChatRecord;
-  messages: CanonicalChatMessage[];
-  turns: CanonicalChatTurn[];
-  runs: CanonicalChatRun[];
-  activities: CanonicalChatRunActivity[];
-  nextBeforeSeq?: number;
-}
-
-export class ChatNotFoundError extends Error {
-  constructor(readonly chatId: string) {
-    super("Chat not found");
-    this.name = "ChatNotFoundError";
-  }
-}
-
-export class ChatConflictError extends Error {
-  constructor(readonly chatId: string, readonly latestRevision: number) {
-    super("Chat conflict");
-    this.name = "ChatConflictError";
-  }
-}
-
-export class ChatBusyError extends Error {
-  constructor(readonly chatId: string) {
-    super("Chat is busy");
-    this.name = "ChatBusyError";
-  }
-}
-
-export class ChatProviderInstanceLockedError extends Error {
-  constructor(readonly chatId: string) {
-    super("Provider Instance is locked");
-    this.name = "ChatProviderInstanceLockedError";
-  }
 }
 
 function validateOwner(owner: ChatOwner): ChatOwner {
@@ -201,18 +203,28 @@ async function hydrateAdmission(
     executor.selectFrom("chat_runs").selectAll().where("turn_id", "=", existingTurn.id).orderBy("attempt", "desc").executeTakeFirst(),
   ]);
   if (!chat || !messageRow || !runRow) throw new ChatNotFoundError(existingTurn.chatId);
-  return { chat, message: toMessage(messageRow), turn: existingTurn, run: toRun(runRow) };
+  return {
+    chat,
+    message: toMessage(messageRow),
+    turn: existingTurn,
+    run: toRun(runRow),
+    alreadyAccepted: true,
+  };
 }
 
 export class ChatRepository {
   readonly kysely: Kysely<ChatDatabase>;
   private readonly transactionScoped: boolean;
+  private readonly detail: ChatDetailRepository;
+  private readonly runLifecycle: ChatRunLifecycleRepository;
 
   constructor(dialectOrKysely: Dialect | Kysely<ChatDatabase>, transactionScoped = false) {
     this.kysely = dialectOrKysely instanceof Kysely
       ? dialectOrKysely
       : new Kysely<ChatDatabase>({ dialect: dialectOrKysely });
     this.transactionScoped = transactionScoped;
+    this.detail = new ChatDetailRepository(this.kysely, hydrateRecord.bind(null, this.kysely));
+    this.runLifecycle = new ChatRunLifecycleRepository(this.kysely, (fn) => this.transact(fn));
   }
 
   async bootstrap(): Promise<void> {
@@ -483,6 +495,7 @@ export class ChatRepository {
         id: run.id,
         chat_id: input.chatId,
         turn_id: run.turnId,
+        client_request_id: turn.clientRequestId,
         attempt: run.attempt,
         driver_kind: run.driverKind,
         instance_id: run.instanceId,
@@ -490,6 +503,7 @@ export class ChatRepository {
         interaction_mode: run.interactionMode,
         permission_mode: run.permissionMode,
         execution_root: run.executionRoot ? jsonb(run.executionRoot) : null,
+        execution_root_fingerprint: run.executionRootFingerprint ?? null,
         status: run.status,
         outcome: run.outcome ?? null,
         started_at: run.startedAt ?? null,
@@ -529,6 +543,7 @@ export class ChatRepository {
         message,
         turn,
         run,
+        alreadyAccepted: false,
       };
     }).catch((error: unknown) => {
       if (error instanceof ChatNotFoundError || error instanceof ChatConflictError
@@ -536,6 +551,104 @@ export class ChatRepository {
       const constraint = postgresUniqueConstraint(error);
       if (constraint === "idx_chat_runs_one_active") throw new ChatBusyError(input.chatId);
       if (constraint !== null) throw new ChatConflictError(input.chatId, input.baseRevision);
+      throw error;
+    });
+  }
+
+  async admitRetry(ownerInput: ChatOwner, input: AdmitRetryInput): Promise<AdmittedRun> {
+    const owner = validateOwner(ownerInput);
+    const chatId = CanonicalChatIdSchema.parse(input.chatId);
+    const turnId = requireSafeRef(input.turnId);
+    const clientRequestId = CanonicalChatRequestIdSchema.parse(input.clientRequestId);
+    const run = CanonicalChatRunSchema.parse(input.run);
+    if (run.chatId !== chatId || run.turnId !== turnId || run.status !== "accepted" || run.attempt < 2) {
+      throw new ChatConflictError(chatId, input.baseRevision);
+    }
+    return this.transact(async (trx) => {
+      const current = await selectOwnedChat(trx, owner, chatId, true);
+      if (!current) throw new ChatNotFoundError(chatId);
+      const existing = await trx.selectFrom("chat_runs").selectAll()
+        .where("turn_id", "=", turnId)
+        .where("client_request_id", "=", clientRequestId)
+        .executeTakeFirst();
+      if (existing) {
+        const turnRow = await trx.selectFrom("chat_turns").selectAll()
+          .where("id", "=", turnId).where("chat_id", "=", chatId).executeTakeFirst();
+        if (!turnRow) throw new ChatNotFoundError(chatId);
+        return {
+          chat: toChatRecord(current, await activeRunQuery(trx, chatId)),
+          turn: toTurn(turnRow),
+          run: toRun(existing),
+          alreadyAccepted: true,
+        };
+      }
+      if (Number(current.revision) !== input.baseRevision) {
+        throw new ChatConflictError(chatId, Number(current.revision));
+      }
+      if (await activeRunQuery(trx, chatId)) throw new ChatBusyError(chatId);
+      const turnRow = await trx.selectFrom("chat_turns").selectAll()
+        .where("id", "=", turnId).where("chat_id", "=", chatId).forUpdate().executeTakeFirst();
+      if (!turnRow) throw new ChatNotFoundError(chatId);
+      const latest = await trx.selectFrom("chat_runs").selectAll()
+        .where("turn_id", "=", turnId).orderBy("attempt", "desc").forUpdate().executeTakeFirst();
+      if (!latest || ACTIVE_RUNS.includes(latest.status as typeof ACTIVE_RUNS[number])
+        || run.attempt !== latest.attempt + 1 || latest.attempt >= 100
+        || run.driverKind !== latest.driver_kind || run.instanceId !== latest.instance_id) {
+        throw new ChatConflictError(chatId, Number(current.revision));
+      }
+      if (current.bound_driver_kind !== run.driverKind || current.bound_instance_id !== run.instanceId) {
+        throw new ChatProviderInstanceLockedError(chatId);
+      }
+      await trx.insertInto("chat_runs").values({
+        id: run.id,
+        chat_id: chatId,
+        turn_id: turnId,
+        client_request_id: clientRequestId,
+        attempt: run.attempt,
+        driver_kind: run.driverKind,
+        instance_id: run.instanceId,
+        selection: jsonb(run.selection),
+        interaction_mode: run.interactionMode,
+        permission_mode: run.permissionMode,
+        execution_root: run.executionRoot ? jsonb(run.executionRoot) : null,
+        execution_root_fingerprint: run.executionRootFingerprint ?? null,
+        status: "accepted",
+        outcome: null,
+        started_at: null,
+        completed_at: null,
+        history_boundary_seq: run.historyBoundarySeq,
+        capability_snapshot: jsonb(run.capabilitySnapshot),
+        created_at: run.createdAt,
+        updated_at: run.updatedAt,
+      }).execute();
+      await trx.updateTable("chat_turns").set({ status: "accepted", updated_at: run.updatedAt })
+        .where("id", "=", turnId).execute();
+      const revision = input.baseRevision + 1;
+      const updated = await trx.updateTable("chats").set({
+        revision,
+        current_selection: jsonb(run.selection),
+        attention: "none",
+        updated_at: run.updatedAt,
+      }).where("id", "=", chatId).where("revision", "=", input.baseRevision)
+        .returningAll().executeTakeFirst();
+      if (!updated) throw new ChatConflictError(chatId, Number(current.revision));
+      await insertOutbox(trx, owner, chatId, revision, "turn.accepted", {
+        runId: run.id,
+        turnId,
+        attempt: run.attempt,
+      });
+      return {
+        chat: toChatRecord(updated, await activeRunQuery(trx, chatId)),
+        turn: toTurn({ ...turnRow, status: "accepted", updated_at: run.updatedAt }),
+        run,
+        alreadyAccepted: false,
+      };
+    }).catch((error: unknown) => {
+      if (error instanceof ChatNotFoundError || error instanceof ChatConflictError
+        || error instanceof ChatBusyError || error instanceof ChatProviderInstanceLockedError) throw error;
+      const constraint = postgresUniqueConstraint(error);
+      if (constraint === "idx_chat_runs_one_active") throw new ChatBusyError(chatId);
+      if (constraint !== null) throw new ChatConflictError(chatId, input.baseRevision);
       throw error;
     });
   }
@@ -553,66 +666,63 @@ export class ChatRepository {
     return rows.map(toMessage);
   }
 
+  async getTurnRunContext(
+    ownerInput: ChatOwner,
+    chatId: string,
+    turnId: string,
+  ): Promise<ChatTurnRunContext | null> {
+    const owner = validateOwner(ownerInput);
+    const parsedChatId = CanonicalChatIdSchema.parse(chatId);
+    const parsedTurnId = requireSafeRef(turnId);
+    const chat = await hydrateRecord(this.kysely, owner, parsedChatId);
+    if (!chat) return null;
+    const turnRow = await this.kysely.selectFrom("chat_turns").selectAll()
+      .where("id", "=", parsedTurnId).where("chat_id", "=", parsedChatId).executeTakeFirst();
+    if (!turnRow) return null;
+    const [messageRow, runRow] = await Promise.all([
+      this.kysely.selectFrom("chat_messages").selectAll()
+        .where("id", "=", turnRow.input_message_id).where("chat_id", "=", parsedChatId).executeTakeFirst(),
+      this.kysely.selectFrom("chat_runs").selectAll()
+        .where("turn_id", "=", parsedTurnId).where("chat_id", "=", parsedChatId)
+        .orderBy("attempt", "desc").executeTakeFirst(),
+    ]);
+    if (!messageRow || !runRow) return null;
+    return {
+      chat,
+      message: toMessage(messageRow),
+      turn: toTurn(turnRow),
+      latestRun: toRun(runRow),
+    };
+  }
+
+  async listActiveRunContexts(
+    ownerInput: ChatOwner,
+    limit = 64,
+  ): Promise<ChatTurnRunContext[]> {
+    const owner = validateOwner(ownerInput);
+    const boundedLimit = Math.max(1, Math.min(64, Math.trunc(limit)));
+    const rows = await this.kysely.selectFrom("chat_runs")
+      .innerJoin("chats", "chats.id", "chat_runs.chat_id")
+      .select(["chat_runs.chat_id", "chat_runs.turn_id", "chat_runs.id"])
+      .where("chats.owner_type", "=", owner.type)
+      .where("chats.owner_id", "=", owner.ownerId)
+      .where("chat_runs.status", "in", [...ACTIVE_RUNS])
+      .orderBy("chat_runs.created_at")
+      .limit(boundedLimit)
+      .execute();
+    const contexts: ChatTurnRunContext[] = [];
+    for (const row of rows) {
+      const context = await this.getTurnRunContext(owner, row.chat_id, row.turn_id);
+      if (context?.latestRun.id === row.id) contexts.push(context);
+    }
+    return contexts;
+  }
+
   async getDetailPage(ownerInput: ChatOwner, chatId: string, input: {
     beforeSeq?: number;
     limit: number;
   }): Promise<ChatDetailPage | null> {
-    const owner = validateOwner(ownerInput);
-    const parsedChatId = CanonicalChatIdSchema.parse(chatId);
-    const record = await hydrateRecord(this.kysely, owner, parsedChatId);
-    if (!record) return null;
-    const limit = Math.max(1, Math.min(200, Math.trunc(input.limit)));
-    const beforeSeq = input.beforeSeq === undefined
-      ? Number.MAX_SAFE_INTEGER
-      : Math.max(1, Math.trunc(input.beforeSeq));
-    const messageRows = await this.kysely.selectFrom("chat_messages").selectAll()
-      .where("chat_id", "=", parsedChatId)
-      .where("seq", "<", beforeSeq)
-      .orderBy("seq", "desc")
-      .limit(limit + 1)
-      .execute();
-    const hasOlder = messageRows.length > limit;
-    const selectedMessageRows = messageRows.slice(0, limit).reverse();
-    const turnIds = [...new Set(selectedMessageRows.flatMap((row) => row.turn_id ? [row.turn_id] : []))];
-    const turnRows = turnIds.length === 0 ? [] : await this.kysely.selectFrom("chat_turns").selectAll()
-      .where("chat_id", "=", parsedChatId)
-      .where("id", "in", turnIds)
-      .orderBy("created_at", "desc")
-      .limit(100)
-      .execute();
-    turnRows.reverse();
-    const selectedRunIds = selectedMessageRows.flatMap((row) => row.run_id ? [row.run_id] : []);
-    const runTurnIds = turnRows.map((row) => row.id);
-    const runRows = runTurnIds.length === 0 && selectedRunIds.length === 0 ? [] : await this.kysely
-      .selectFrom("chat_runs")
-      .selectAll()
-      .where("chat_id", "=", parsedChatId)
-      .where(({ eb, or }) => or([
-        ...(runTurnIds.length > 0 ? [eb("turn_id", "in", runTurnIds)] : []),
-        ...(selectedRunIds.length > 0 ? [eb("id", "in", selectedRunIds)] : []),
-      ]))
-      .orderBy("created_at", "desc")
-      .limit(100)
-      .execute();
-    runRows.reverse();
-    const runIds = runRows.map((row) => row.id);
-    const activityRows = runIds.length === 0 ? [] : await this.kysely.selectFrom("chat_run_events").selectAll()
-      .where("chat_id", "=", parsedChatId)
-      .where("run_id", "in", runIds)
-      .orderBy("occurred_at", "desc")
-      .limit(500)
-      .execute();
-    activityRows.reverse();
-    return {
-      record,
-      messages: selectedMessageRows.map(toMessage),
-      turns: turnRows.map(toTurn),
-      runs: runRows.map(toRun),
-      activities: activityRows.map(toActivity),
-      ...(hasOlder && selectedMessageRows[0]
-        ? { nextBeforeSeq: Number(selectedMessageRows[0].seq) }
-        : {}),
-    };
+    return this.detail.getDetailPage(ownerInput, chatId, input);
   }
 
   async getAdapterState(ownerInput: ChatOwner, input: {
@@ -620,23 +730,34 @@ export class ChatRepository {
     driverKind: string;
     instanceId: string;
   }): Promise<{ schemaVersion: number; state: unknown } | null> {
-    const owner = validateOwner(ownerInput);
-    [input.runId, input.driverKind, input.instanceId].forEach(requireSafeRef);
-    const row = await this.kysely.selectFrom("chat_run_adapter_state")
-      .innerJoin("chat_runs", "chat_runs.id", "chat_run_adapter_state.run_id")
-      .innerJoin("chats", "chats.id", "chat_runs.chat_id")
-      .select(["chat_run_adapter_state.schema_version", "chat_run_adapter_state.state"])
-      .where("chats.owner_type", "=", owner.type)
-      .where("chats.owner_id", "=", owner.ownerId)
-      .where("chat_run_adapter_state.run_id", "=", input.runId)
-      .where("chat_run_adapter_state.driver_kind", "=", input.driverKind)
-      .where("chat_run_adapter_state.instance_id", "=", input.instanceId)
-      .executeTakeFirst();
-    if (!row) return null;
-    return {
-      schemaVersion: row.schema_version,
-      state: typeof row.state === "string" ? JSON.parse(row.state) : row.state,
-    };
+    return this.runLifecycle.getAdapterState(ownerInput, input);
+  }
+
+  async getLatestAdapterStateForChat(ownerInput: ChatOwner, input: {
+    chatId: string;
+    driverKind: string;
+    instanceId: string;
+  }): Promise<{ schemaVersion: number; state: unknown } | null> {
+    return this.runLifecycle.getLatestAdapterStateForChat(ownerInput, input);
+  }
+
+  async markRunRunning(ownerInput: ChatOwner, input: {
+    chatId: string;
+    runId: string;
+    startedAt: string;
+  }): Promise<CanonicalChatRun> {
+    return this.runLifecycle.markRunRunning(ownerInput, input);
+  }
+
+  async updateAdapterState(ownerInput: ChatOwner, input: {
+    chatId: string;
+    runId: string;
+    driverKind: string;
+    instanceId: string;
+    schemaVersion: number;
+    state: unknown;
+  }): Promise<void> {
+    return this.runLifecycle.updateAdapterState(ownerInput, input);
   }
 
   async appendRunActivities(
@@ -645,47 +766,7 @@ export class ChatRepository {
     runId: string,
     input: CanonicalChatRunActivity[],
   ): Promise<number> {
-    const owner = validateOwner(ownerInput);
-    if (input.length > 100) throw new ChatConflictError(chatId, 0);
-    const activities = input.map((activity) => CanonicalChatRunActivitySchema.parse(activity));
-    if (activities.some((activity) => activity.chatId !== chatId || activity.runId !== runId)) {
-      throw new ChatConflictError(chatId, 0);
-    }
-    if (activities.length === 0) return 0;
-    return this.transact(async (trx) => {
-      const current = await selectOwnedChat(trx, owner, CanonicalChatIdSchema.parse(chatId), true);
-      if (!current) throw new ChatNotFoundError(chatId);
-      const run = await trx.selectFrom("chat_runs").select("id")
-        .where("id", "=", runId).where("chat_id", "=", chatId).executeTakeFirst();
-      if (!run) throw new ChatNotFoundError(chatId);
-      const count = await trx.selectFrom("chat_run_events").select(({ fn }) => fn.countAll().as("count"))
-        .where("run_id", "=", runId).executeTakeFirstOrThrow();
-      const activityIds = [...new Set(activities.map((activity) => activity.id))];
-      const existing = await trx.selectFrom("chat_run_events").select(["id", "chat_id", "run_id"])
-        .where("id", "in", activityIds).execute();
-      if (existing.some((row) => row.chat_id !== chatId || row.run_id !== runId)) {
-        throw new ChatConflictError(chatId, Number(current.revision));
-      }
-      const unseenCount = activityIds.length - existing.length;
-      if (Number(count.count) + unseenCount > 500) throw new ChatConflictError(chatId, Number(current.revision));
-      let inserted = 0;
-      for (const activity of activities) {
-        const row = await trx.insertInto("chat_run_events").values({
-          id: activity.id,
-          chat_id: chatId,
-          run_id: runId,
-          event: jsonb(activity),
-          occurred_at: activity.occurredAt,
-        }).onConflict((oc) => oc.column("id").doNothing()).returning("id").executeTakeFirst();
-        if (row) inserted += 1;
-      }
-      if (inserted > 0) {
-        const revision = Number(current.revision) + 1;
-        await trx.updateTable("chats").set({ revision, updated_at: sql`now()` }).where("id", "=", chatId).execute();
-        await insertOutbox(trx, owner, chatId, revision, "run.activity", { runId });
-      }
-      return inserted;
-    });
+    return this.runLifecycle.appendRunActivities(ownerInput, chatId, runId, input);
   }
 
   async finishRun(ownerInput: ChatOwner, input: {
@@ -693,38 +774,9 @@ export class ChatRepository {
     runId: string;
     outcome: "completed" | "failed" | "aborted";
     completedAt: string;
-  }): Promise<CanonicalChatRun> {
-    const owner = validateOwner(ownerInput);
-    const completedAt = new Date(input.completedAt).toISOString();
-    return this.transact(async (trx) => {
-      const chat = await selectOwnedChat(trx, owner, CanonicalChatIdSchema.parse(input.chatId), true);
-      if (!chat) throw new ChatNotFoundError(input.chatId);
-      const current = await trx.selectFrom("chat_runs").selectAll()
-        .where("id", "=", input.runId).where("chat_id", "=", input.chatId).forUpdate().executeTakeFirst();
-      if (!current) throw new ChatNotFoundError(input.chatId);
-      if (!ACTIVE_RUNS.includes(current.status as typeof ACTIVE_RUNS[number])) {
-        return toRun(current);
-      }
-      const updated = await trx.updateTable("chat_runs").set({
-        status: input.outcome,
-        outcome: input.outcome,
-        started_at: current.started_at ?? completedAt,
-        completed_at: completedAt,
-        updated_at: completedAt,
-      }).where("id", "=", input.runId).where("status", "in", [...ACTIVE_RUNS])
-        .returningAll().executeTakeFirst();
-      if (!updated) throw new ChatBusyError(input.chatId);
-      await trx.updateTable("chat_turns").set({ status: input.outcome, updated_at: completedAt })
-        .where("id", "=", updated.turn_id).execute();
-      const revision = Number(chat.revision) + 1;
-      await trx.updateTable("chats").set({
-        revision,
-        attention: input.outcome === "failed" ? "failed" : "none",
-        updated_at: completedAt,
-      }).where("id", "=", input.chatId).execute();
-      await insertOutbox(trx, owner, input.chatId, revision, `run.${input.outcome}` as ChatOutboxEventType, { runId: input.runId });
-      return toRun(updated);
-    });
+    output?: CanonicalChatMessage;
+  }): Promise<{ run: CanonicalChatRun; transitioned: boolean }> {
+    return this.runLifecycle.finishRun(ownerInput, input);
   }
 
   async replayOutbox(ownerInput: ChatOwner, input: {

--- a/packages/gateway/src/chat/routes.ts
+++ b/packages/gateway/src/chat/routes.ts
@@ -1,0 +1,161 @@
+import {
+  CanonicalChatApiCursorSchema,
+  CanonicalChatDetailResponseSchema,
+  CanonicalChatIdSchema,
+  CanonicalChatListResponseSchema,
+  CanonicalChatRecordSchema,
+  CanonicalChatSafeErrorSchema,
+  CanonicalCreateChatRequestSchema,
+  type CanonicalChatDetailResponse,
+  type CanonicalChatListResponse,
+  type CanonicalChatRecord,
+  type CanonicalCreateChatRequest,
+} from "@matrix-os/contracts";
+import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { z } from "zod/v4";
+import {
+  isRequestPrincipalError,
+  mapRequestPrincipalError,
+  type RequestPrincipal,
+} from "../request-principal.js";
+import type { ChatOwner } from "./records.js";
+
+const CHAT_CREATE_BODY_LIMIT = 96 * 1024;
+
+const ChatListQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  lifecycle: z.enum(["active", "archived"]).optional(),
+  projectId: CanonicalCreateChatRequestSchema.shape.projectId.optional(),
+  cursor: CanonicalChatApiCursorSchema.optional(),
+}).strict();
+
+const ChatDetailQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(200).default(200),
+  cursor: CanonicalChatApiCursorSchema.optional(),
+}).strict();
+
+export interface CanonicalChatRouteService {
+  create(owner: ChatOwner, input: CanonicalCreateChatRequest): Promise<CanonicalChatRecord>;
+  list(owner: ChatOwner, input: {
+    limit: number;
+    lifecycle?: "active" | "archived";
+    projectId?: string;
+    cursor?: string;
+  }): Promise<CanonicalChatListResponse>;
+  getDetail(owner: ChatOwner, chatId: string, input: {
+    limit: number;
+    cursor?: string;
+  }): Promise<CanonicalChatDetailResponse | null>;
+}
+
+function ownerFromPrincipal(principal: RequestPrincipal): ChatOwner {
+  return { type: "personal", ownerId: principal.userId };
+}
+
+function bodyTooLarge(c: Context) {
+  return c.json({ error: "Request body too large" }, 413);
+}
+
+function validationError(c: Context) {
+  return c.json({ error: "Invalid request" }, 400);
+}
+
+function notFound(c: Context) {
+  return c.json({
+    error: CanonicalChatSafeErrorSchema.parse({
+      code: "chat_not_found",
+      safeMessage: "Chat not found.",
+      retryable: false,
+    }),
+  }, 404);
+}
+
+function handleError(c: Context, error: unknown) {
+  if (error instanceof Error && error.name === "BodyLimitError") {
+    return bodyTooLarge(c);
+  }
+  if (isRequestPrincipalError(error)) {
+    const mapped = mapRequestPrincipalError(error, "Chat request failed");
+    if (mapped.log) console.error("[chat/routes] Request principal misconfigured:", error.name);
+    return c.json(mapped.body, mapped.status);
+  }
+  if (typeof error === "object" && error !== null && "issues" in error) {
+    return validationError(c);
+  }
+  console.error(
+    "[chat/routes] Canonical Chat request failed:",
+    error instanceof Error ? error.name : "UnknownError",
+  );
+  return c.json({
+    error: CanonicalChatSafeErrorSchema.parse({
+      code: "service_unavailable",
+      safeMessage: "Chat is temporarily unavailable.",
+      retryable: true,
+      recoveryActions: ["retry"],
+    }),
+  }, 503);
+}
+
+export function createCanonicalChatRoutes(options: {
+  service: CanonicalChatRouteService;
+  getPrincipal: (context: Context) => RequestPrincipal;
+}): Hono {
+  const routes = new Hono();
+  const createBodyLimit = bodyLimit({ maxSize: CHAT_CREATE_BODY_LIMIT, onError: bodyTooLarge });
+
+  routes.post("/api/chats", createBodyLimit, async (context) => {
+    try {
+      const parsed = CanonicalCreateChatRequestSchema.safeParse(await context.req.json());
+      if (!parsed.success) return validationError(context);
+      const result = await options.service.create(
+        ownerFromPrincipal(options.getPrincipal(context)),
+        parsed.data,
+      );
+      return context.json(CanonicalChatRecordSchema.parse(result), 201);
+    } catch (error: unknown) {
+      return handleError(context, error);
+    }
+  });
+
+  routes.get("/api/chats", async (context) => {
+    try {
+      const parsed = ChatListQuerySchema.safeParse({
+        limit: context.req.query("limit"),
+        lifecycle: context.req.query("lifecycle"),
+        projectId: context.req.query("projectId"),
+        cursor: context.req.query("cursor"),
+      });
+      if (!parsed.success) return validationError(context);
+      const result = await options.service.list(
+        ownerFromPrincipal(options.getPrincipal(context)),
+        parsed.data,
+      );
+      return context.json(CanonicalChatListResponseSchema.parse(result));
+    } catch (error: unknown) {
+      return handleError(context, error);
+    }
+  });
+
+  routes.get("/api/chats/:chatId", async (context) => {
+    try {
+      const chatId = CanonicalChatIdSchema.parse(context.req.param("chatId"));
+      const parsed = ChatDetailQuerySchema.safeParse({
+        limit: context.req.query("limit"),
+        cursor: context.req.query("cursor"),
+      });
+      if (!parsed.success) return validationError(context);
+      const result = await options.service.getDetail(
+        ownerFromPrincipal(options.getPrincipal(context)),
+        chatId,
+        parsed.data,
+      );
+      if (!result) return notFound(context);
+      return context.json(CanonicalChatDetailResponseSchema.parse(result));
+    } catch (error: unknown) {
+      return handleError(context, error);
+    }
+  });
+
+  return routes;
+}

--- a/packages/gateway/src/chat/routes.ts
+++ b/packages/gateway/src/chat/routes.ts
@@ -1,15 +1,29 @@
 import {
+  CanonicalCancelChatRunRequestSchema,
   CanonicalChatApiCursorSchema,
   CanonicalChatDetailResponseSchema,
   CanonicalChatIdSchema,
   CanonicalChatListResponseSchema,
   CanonicalChatRecordSchema,
+  CanonicalChatRunCancellationResponseSchema,
+  CanonicalChatRunAdmissionResponseSchema,
+  CanonicalChatRunIdSchema,
+  CanonicalChatTurnIdSchema,
+  CanonicalChatTurnAdmissionResponseSchema,
   CanonicalChatSafeErrorSchema,
   CanonicalCreateChatRequestSchema,
+  CanonicalCreateChatTurnRequestSchema,
+  CanonicalRetryChatTurnRequestSchema,
   type CanonicalChatDetailResponse,
   type CanonicalChatListResponse,
   type CanonicalChatRecord,
+  type CanonicalChatRunCancellationResponse,
+  type CanonicalChatRunAdmissionResponse,
+  type CanonicalChatTurnAdmissionResponse,
+  type CanonicalCancelChatRunRequest,
   type CanonicalCreateChatRequest,
+  type CanonicalCreateChatTurnRequest,
+  type CanonicalRetryChatTurnRequest,
 } from "@matrix-os/contracts";
 import { Hono, type Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
@@ -20,8 +34,11 @@ import {
   type RequestPrincipal,
 } from "../request-principal.js";
 import type { ChatOwner } from "./records.js";
+import { CanonicalChatOrchestrationError } from "./orchestrator.js";
 
 const CHAT_CREATE_BODY_LIMIT = 96 * 1024;
+const CHAT_TURN_BODY_LIMIT = 128 * 1024;
+const CHAT_CANCEL_BODY_LIMIT = 4 * 1024;
 
 const ChatListQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(50),
@@ -47,6 +64,25 @@ export interface CanonicalChatRouteService {
     limit: number;
     cursor?: string;
   }): Promise<CanonicalChatDetailResponse | null>;
+  admitTurn(
+    principal: RequestPrincipal,
+    owner: ChatOwner,
+    chatId: string,
+    input: CanonicalCreateChatTurnRequest,
+  ): Promise<CanonicalChatTurnAdmissionResponse>;
+  cancelRun(
+    owner: ChatOwner,
+    chatId: string,
+    runId: string,
+    input: CanonicalCancelChatRunRequest,
+  ): Promise<CanonicalChatRunCancellationResponse>;
+  retryTurn(
+    principal: RequestPrincipal,
+    owner: ChatOwner,
+    chatId: string,
+    turnId: string,
+    input: CanonicalRetryChatTurnRequest,
+  ): Promise<CanonicalChatRunAdmissionResponse>;
 }
 
 function ownerFromPrincipal(principal: RequestPrincipal): ChatOwner {
@@ -80,6 +116,9 @@ function handleError(c: Context, error: unknown) {
     if (mapped.log) console.error("[chat/routes] Request principal misconfigured:", error.name);
     return c.json(mapped.body, mapped.status);
   }
+  if (error instanceof CanonicalChatOrchestrationError) {
+    return c.json({ error: error.safeError }, error.status);
+  }
   if (typeof error === "object" && error !== null && "issues" in error) {
     return validationError(c);
   }
@@ -103,6 +142,8 @@ export function createCanonicalChatRoutes(options: {
 }): Hono {
   const routes = new Hono();
   const createBodyLimit = bodyLimit({ maxSize: CHAT_CREATE_BODY_LIMIT, onError: bodyTooLarge });
+  const turnBodyLimit = bodyLimit({ maxSize: CHAT_TURN_BODY_LIMIT, onError: bodyTooLarge });
+  const cancelBodyLimit = bodyLimit({ maxSize: CHAT_CANCEL_BODY_LIMIT, onError: bodyTooLarge });
 
   routes.post("/api/chats", createBodyLimit, async (context) => {
     try {
@@ -152,6 +193,63 @@ export function createCanonicalChatRoutes(options: {
       );
       if (!result) return notFound(context);
       return context.json(CanonicalChatDetailResponseSchema.parse(result));
+    } catch (error: unknown) {
+      return handleError(context, error);
+    }
+  });
+
+  routes.post("/api/chats/:chatId/turns", turnBodyLimit, async (context) => {
+    try {
+      const chatId = CanonicalChatIdSchema.parse(context.req.param("chatId"));
+      const parsed = CanonicalCreateChatTurnRequestSchema.safeParse(await context.req.json());
+      if (!parsed.success) return validationError(context);
+      const principal = options.getPrincipal(context);
+      const result = await options.service.admitTurn(
+        principal,
+        ownerFromPrincipal(principal),
+        chatId,
+        parsed.data,
+      );
+      return context.json(CanonicalChatTurnAdmissionResponseSchema.parse(result), 202);
+    } catch (error: unknown) {
+      return handleError(context, error);
+    }
+  });
+
+  routes.post("/api/chats/:chatId/runs/:runId/cancel", cancelBodyLimit, async (context) => {
+    try {
+      const chatId = CanonicalChatIdSchema.parse(context.req.param("chatId"));
+      const runId = CanonicalChatRunIdSchema.parse(context.req.param("runId"));
+      const parsed = CanonicalCancelChatRunRequestSchema.safeParse(await context.req.json());
+      if (!parsed.success) return validationError(context);
+      const principal = options.getPrincipal(context);
+      const result = await options.service.cancelRun(
+        ownerFromPrincipal(principal),
+        chatId,
+        runId,
+        parsed.data,
+      );
+      return context.json(CanonicalChatRunCancellationResponseSchema.parse(result));
+    } catch (error: unknown) {
+      return handleError(context, error);
+    }
+  });
+
+  routes.post("/api/chats/:chatId/turns/:turnId/runs", cancelBodyLimit, async (context) => {
+    try {
+      const chatId = CanonicalChatIdSchema.parse(context.req.param("chatId"));
+      const turnId = CanonicalChatTurnIdSchema.parse(context.req.param("turnId"));
+      const parsed = CanonicalRetryChatTurnRequestSchema.safeParse(await context.req.json());
+      if (!parsed.success) return validationError(context);
+      const principal = options.getPrincipal(context);
+      const result = await options.service.retryTurn(
+        principal,
+        ownerFromPrincipal(principal),
+        chatId,
+        turnId,
+        parsed.data,
+      );
+      return context.json(CanonicalChatRunAdmissionResponseSchema.parse(result), 202);
     } catch (error: unknown) {
       return handleError(context, error);
     }

--- a/packages/gateway/src/chat/run-lifecycle-repository.ts
+++ b/packages/gateway/src/chat/run-lifecycle-repository.ts
@@ -1,0 +1,343 @@
+import {
+  CanonicalChatIdSchema,
+  CanonicalChatMessageSchema,
+  CanonicalChatRunActivitySchema,
+  CanonicalOwnerScopeSchema,
+  type CanonicalChatMessage,
+  type CanonicalChatRun,
+  type CanonicalChatRunActivity,
+} from "@matrix-os/contracts";
+import { sql, type Kysely, type Selectable, type Transaction } from "kysely";
+import { z } from "zod/v4";
+import type { ChatDatabase, ChatsTable } from "./database.js";
+import {
+  ChatBusyError,
+  ChatConflictError,
+  ChatNotFoundError,
+  ChatProviderInstanceLockedError,
+  ChatRunNotActiveError,
+} from "./errors.js";
+import {
+  jsonb,
+  messageSearchText,
+  toActivity,
+  toRun,
+  type ChatOutboxEventType,
+  type ChatOwner,
+} from "./records.js";
+
+type Executor = Kysely<ChatDatabase> | Transaction<ChatDatabase>;
+type Transact = <T>(fn: (trx: Executor) => Promise<T>) => Promise<T>;
+const ACTIVE_RUNS = ["accepted", "running", "waiting_for_approval", "waiting_for_input"] as const;
+const SAFE_INTERNAL_REF = z.string().min(1).max(200).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/);
+const encoded = new TextEncoder();
+
+function validateOwner(owner: ChatOwner): ChatOwner {
+  return CanonicalOwnerScopeSchema.parse(owner);
+}
+
+function requireSafeRef(value: string): string {
+  return SAFE_INTERNAL_REF.parse(value);
+}
+
+function preview(message: CanonicalChatMessage): string | null {
+  const text = message.parts.find((part) => part.type === "text");
+  return text?.type === "text" ? text.text.slice(0, 280) : null;
+}
+
+async function selectOwnedChat(
+  executor: Executor,
+  owner: ChatOwner,
+  chatId: string,
+  lock = false,
+): Promise<Selectable<ChatsTable> | undefined> {
+  let query = executor.selectFrom("chats").selectAll()
+    .where("id", "=", chatId)
+    .where("owner_type", "=", owner.type)
+    .where("owner_id", "=", owner.ownerId);
+  if (lock) query = query.forUpdate();
+  return query.executeTakeFirst();
+}
+
+async function insertOutbox(
+  executor: Executor,
+  owner: ChatOwner,
+  chatId: string,
+  revision: number,
+  eventType: ChatOutboxEventType,
+  payload: Record<string, unknown> = {},
+): Promise<void> {
+  await executor.insertInto("chat_outbox").values({
+    owner_type: owner.type,
+    owner_id: owner.ownerId,
+    chat_id: chatId,
+    revision,
+    event_type: eventType,
+    payload: jsonb(payload),
+  }).execute();
+}
+
+export class ChatRunLifecycleRepository {
+  constructor(
+    private readonly kysely: Kysely<ChatDatabase>,
+    private readonly transact: Transact,
+  ) {}
+
+  async getAdapterState(ownerInput: ChatOwner, input: {
+    runId: string;
+    driverKind: string;
+    instanceId: string;
+  }): Promise<{ schemaVersion: number; state: unknown } | null> {
+    const owner = validateOwner(ownerInput);
+    [input.runId, input.driverKind, input.instanceId].forEach(requireSafeRef);
+    const row = await this.kysely.selectFrom("chat_run_adapter_state")
+      .innerJoin("chat_runs", "chat_runs.id", "chat_run_adapter_state.run_id")
+      .innerJoin("chats", "chats.id", "chat_runs.chat_id")
+      .select(["chat_run_adapter_state.schema_version", "chat_run_adapter_state.state"])
+      .where("chats.owner_type", "=", owner.type)
+      .where("chats.owner_id", "=", owner.ownerId)
+      .where("chat_run_adapter_state.run_id", "=", input.runId)
+      .where("chat_run_adapter_state.driver_kind", "=", input.driverKind)
+      .where("chat_run_adapter_state.instance_id", "=", input.instanceId)
+      .executeTakeFirst();
+    if (!row) return null;
+    return {
+      schemaVersion: row.schema_version,
+      state: typeof row.state === "string" ? JSON.parse(row.state) : row.state,
+    };
+  }
+
+  async getLatestAdapterStateForChat(ownerInput: ChatOwner, input: {
+    chatId: string;
+    driverKind: string;
+    instanceId: string;
+  }): Promise<{ schemaVersion: number; state: unknown } | null> {
+    const owner = validateOwner(ownerInput);
+    [input.driverKind, input.instanceId].forEach(requireSafeRef);
+    if (!await selectOwnedChat(this.kysely, owner, CanonicalChatIdSchema.parse(input.chatId))) return null;
+    const row = await this.kysely.selectFrom("chat_run_adapter_state")
+      .innerJoin("chat_runs", "chat_runs.id", "chat_run_adapter_state.run_id")
+      .select(["chat_run_adapter_state.schema_version", "chat_run_adapter_state.state"])
+      .where("chat_runs.chat_id", "=", input.chatId)
+      .where("chat_runs.driver_kind", "=", input.driverKind)
+      .where("chat_runs.instance_id", "=", input.instanceId)
+      .where("chat_runs.status", "=", "completed")
+      .where("chat_run_adapter_state.driver_kind", "=", input.driverKind)
+      .where("chat_run_adapter_state.instance_id", "=", input.instanceId)
+      .orderBy("chat_runs.completed_at", "desc")
+      .executeTakeFirst();
+    if (!row) return null;
+    return {
+      schemaVersion: row.schema_version,
+      state: typeof row.state === "string" ? JSON.parse(row.state) : row.state,
+    };
+  }
+
+  async markRunRunning(ownerInput: ChatOwner, input: {
+    chatId: string;
+    runId: string;
+    startedAt: string;
+  }): Promise<CanonicalChatRun> {
+    const owner = validateOwner(ownerInput);
+    const startedAt = new Date(input.startedAt).toISOString();
+    return this.transact(async (trx) => {
+      const chat = await selectOwnedChat(trx, owner, CanonicalChatIdSchema.parse(input.chatId), true);
+      if (!chat) throw new ChatNotFoundError(input.chatId);
+      const current = await trx.selectFrom("chat_runs").selectAll()
+        .where("id", "=", requireSafeRef(input.runId))
+        .where("chat_id", "=", input.chatId)
+        .forUpdate()
+        .executeTakeFirst();
+      if (!current) throw new ChatNotFoundError(input.chatId);
+      if (current.status !== "accepted") {
+        if (ACTIVE_RUNS.includes(current.status as typeof ACTIVE_RUNS[number])) return toRun(current);
+        throw new ChatRunNotActiveError(input.chatId, input.runId);
+      }
+      const updated = await trx.updateTable("chat_runs").set({
+        status: "running",
+        started_at: startedAt,
+        updated_at: startedAt,
+      }).where("id", "=", input.runId)
+        .where("status", "=", "accepted")
+        .returningAll()
+        .executeTakeFirst();
+      if (!updated) throw new ChatRunNotActiveError(input.chatId, input.runId);
+      await trx.updateTable("chat_turns").set({ status: "running", updated_at: startedAt })
+        .where("id", "=", updated.turn_id)
+        .where("status", "=", "accepted")
+        .execute();
+      return toRun(updated);
+    });
+  }
+
+  async updateAdapterState(ownerInput: ChatOwner, input: {
+    chatId: string;
+    runId: string;
+    driverKind: string;
+    instanceId: string;
+    schemaVersion: number;
+    state: unknown;
+  }): Promise<void> {
+    const owner = validateOwner(ownerInput);
+    [input.runId, input.driverKind, input.instanceId].forEach(requireSafeRef);
+    const stateBytes = encoded.encode(JSON.stringify(input.state)).byteLength;
+    if (!Number.isInteger(input.schemaVersion) || input.schemaVersion < 1 || stateBytes > 64 * 1024) {
+      throw new ChatConflictError(input.chatId, 0);
+    }
+    await this.transact(async (trx) => {
+      const chat = await selectOwnedChat(trx, owner, CanonicalChatIdSchema.parse(input.chatId), true);
+      if (!chat) throw new ChatNotFoundError(input.chatId);
+      const run = await trx.selectFrom("chat_runs").select(["status", "driver_kind", "instance_id"])
+        .where("id", "=", input.runId)
+        .where("chat_id", "=", input.chatId)
+        .forUpdate()
+        .executeTakeFirst();
+      if (!run) throw new ChatNotFoundError(input.chatId);
+      if (!ACTIVE_RUNS.includes(run.status as typeof ACTIVE_RUNS[number])) {
+        throw new ChatRunNotActiveError(input.chatId, input.runId);
+      }
+      if (run.driver_kind !== input.driverKind || run.instance_id !== input.instanceId) {
+        throw new ChatProviderInstanceLockedError(input.chatId);
+      }
+      await trx.insertInto("chat_run_adapter_state").values({
+        run_id: input.runId,
+        driver_kind: input.driverKind,
+        instance_id: input.instanceId,
+        schema_version: input.schemaVersion,
+        state: jsonb(input.state),
+        byte_count: stateBytes,
+      }).onConflict((conflict) => conflict.column("run_id").doUpdateSet({
+        schema_version: input.schemaVersion,
+        state: jsonb(input.state),
+        byte_count: stateBytes,
+        updated_at: sql`now()`,
+      })).execute();
+    });
+  }
+
+  async appendRunActivities(
+    ownerInput: ChatOwner,
+    chatId: string,
+    runId: string,
+    input: CanonicalChatRunActivity[],
+  ): Promise<number> {
+    const owner = validateOwner(ownerInput);
+    if (input.length > 100) throw new ChatConflictError(chatId, 0);
+    const activities = input.map((activity) => CanonicalChatRunActivitySchema.parse(activity));
+    if (activities.some((activity) => activity.chatId !== chatId || activity.runId !== runId)) {
+      throw new ChatConflictError(chatId, 0);
+    }
+    if (activities.length === 0) return 0;
+    return this.transact(async (trx) => {
+      const current = await selectOwnedChat(trx, owner, CanonicalChatIdSchema.parse(chatId), true);
+      if (!current) throw new ChatNotFoundError(chatId);
+      const run = await trx.selectFrom("chat_runs").select("id")
+        .where("id", "=", runId).where("chat_id", "=", chatId)
+        .where("status", "in", [...ACTIVE_RUNS]).executeTakeFirst();
+      const existingRun = run ?? await trx.selectFrom("chat_runs").select("id")
+        .where("id", "=", runId).where("chat_id", "=", chatId).executeTakeFirst();
+      if (existingRun && !run) throw new ChatRunNotActiveError(chatId, runId);
+      if (!run) throw new ChatNotFoundError(chatId);
+      const count = await trx.selectFrom("chat_run_events").select(({ fn }) => fn.countAll().as("count"))
+        .where("run_id", "=", runId).executeTakeFirstOrThrow();
+      const activityIds = [...new Set(activities.map((activity) => activity.id))];
+      const existing = await trx.selectFrom("chat_run_events").select(["id", "chat_id", "run_id"])
+        .where("id", "in", activityIds).execute();
+      if (existing.some((row) => row.chat_id !== chatId || row.run_id !== runId)) {
+        throw new ChatConflictError(chatId, Number(current.revision));
+      }
+      const unseenCount = activityIds.length - existing.length;
+      if (Number(count.count) + unseenCount > 500) throw new ChatConflictError(chatId, Number(current.revision));
+      let inserted = 0;
+      for (const activity of activities) {
+        const row = await trx.insertInto("chat_run_events").values({
+          id: activity.id,
+          chat_id: chatId,
+          run_id: runId,
+          event: jsonb(activity),
+          occurred_at: activity.occurredAt,
+        }).onConflict((oc) => oc.column("id").doNothing()).returning("id").executeTakeFirst();
+        if (row) inserted += 1;
+      }
+      if (inserted > 0) {
+        const revision = Number(current.revision) + 1;
+        await trx.updateTable("chats").set({ revision, updated_at: sql`now()` }).where("id", "=", chatId).execute();
+        await insertOutbox(trx, owner, chatId, revision, "run.activity", { runId });
+      }
+      return inserted;
+    });
+  }
+
+  async finishRun(ownerInput: ChatOwner, input: {
+    chatId: string;
+    runId: string;
+    outcome: "completed" | "failed" | "aborted";
+    completedAt: string;
+    output?: CanonicalChatMessage;
+  }): Promise<{ run: CanonicalChatRun; transitioned: boolean }> {
+    const owner = validateOwner(ownerInput);
+    const completedAt = new Date(input.completedAt).toISOString();
+    const output = input.output === undefined ? undefined : CanonicalChatMessageSchema.parse(input.output);
+    return this.transact(async (trx) => {
+      const chat = await selectOwnedChat(trx, owner, CanonicalChatIdSchema.parse(input.chatId), true);
+      if (!chat) throw new ChatNotFoundError(input.chatId);
+      const current = await trx.selectFrom("chat_runs").selectAll()
+        .where("id", "=", input.runId).where("chat_id", "=", input.chatId).forUpdate().executeTakeFirst();
+      if (!current) throw new ChatNotFoundError(input.chatId);
+      if (!ACTIVE_RUNS.includes(current.status as typeof ACTIVE_RUNS[number])) {
+        return { run: toRun(current), transitioned: false };
+      }
+      if (output !== undefined) {
+        const expectedState = input.outcome === "completed" ? "committed" : "failed";
+        if (output.chatId !== input.chatId || output.runId !== input.runId
+          || output.turnId !== current.turn_id || output.role !== "assistant"
+          || output.state !== expectedState) {
+          throw new ChatConflictError(input.chatId, Number(chat.revision));
+        }
+        const latest = await trx.selectFrom("chat_messages")
+          .select(({ fn }) => fn.max("seq").as("seq"))
+          .where("chat_id", "=", input.chatId)
+          .executeTakeFirst();
+        if (output.seq !== Number(latest?.seq ?? 0) + 1) {
+          throw new ChatConflictError(input.chatId, Number(chat.revision));
+        }
+        await trx.insertInto("chat_messages").values({
+          id: output.id,
+          chat_id: output.chatId,
+          seq: output.seq,
+          role: output.role,
+          state: output.state,
+          turn_id: output.turnId ?? null,
+          run_id: output.runId ?? null,
+          parts: jsonb(output.parts),
+          byte_count: encoded.encode(JSON.stringify(output)).byteLength,
+          search_text: messageSearchText(output),
+          created_at: output.createdAt,
+        }).execute();
+      }
+      const updated = await trx.updateTable("chat_runs").set({
+        status: input.outcome,
+        outcome: input.outcome,
+        started_at: current.started_at ?? completedAt,
+        completed_at: completedAt,
+        updated_at: completedAt,
+      }).where("id", "=", input.runId).where("status", "in", [...ACTIVE_RUNS])
+        .returningAll().executeTakeFirst();
+      if (!updated) throw new ChatBusyError(input.chatId);
+      await trx.updateTable("chat_turns").set({ status: input.outcome, updated_at: completedAt })
+        .where("id", "=", updated.turn_id).execute();
+      const revision = Number(chat.revision) + 1;
+      await trx.updateTable("chats").set({
+        revision,
+        ...(output === undefined ? {} : {
+          message_count: sql<number>`message_count + 1`,
+          last_message_preview: preview(output),
+        }),
+        attention: input.outcome === "failed" ? "failed" : "none",
+        updated_at: completedAt,
+      }).where("id", "=", input.chatId).execute();
+      await insertOutbox(trx, owner, input.chatId, revision, `run.${input.outcome}` as ChatOutboxEventType, { runId: input.runId });
+      return { run: toRun(updated), transitioned: true };
+    });
+  }
+}

--- a/packages/gateway/src/chat/run-lifecycle-repository.ts
+++ b/packages/gateway/src/chat/run-lifecycle-repository.ts
@@ -111,13 +111,17 @@ export class ChatRunLifecycleRepository {
     chatId: string;
     driverKind: string;
     instanceId: string;
-  }): Promise<{ schemaVersion: number; state: unknown } | null> {
+  }): Promise<{ schemaVersion: number; state: unknown; executionRootFingerprint?: string } | null> {
     const owner = validateOwner(ownerInput);
     [input.driverKind, input.instanceId].forEach(requireSafeRef);
     if (!await selectOwnedChat(this.kysely, owner, CanonicalChatIdSchema.parse(input.chatId))) return null;
     const row = await this.kysely.selectFrom("chat_run_adapter_state")
       .innerJoin("chat_runs", "chat_runs.id", "chat_run_adapter_state.run_id")
-      .select(["chat_run_adapter_state.schema_version", "chat_run_adapter_state.state"])
+      .select([
+        "chat_run_adapter_state.schema_version",
+        "chat_run_adapter_state.state",
+        "chat_runs.execution_root_fingerprint",
+      ])
       .where("chat_runs.chat_id", "=", input.chatId)
       .where("chat_runs.driver_kind", "=", input.driverKind)
       .where("chat_runs.instance_id", "=", input.instanceId)
@@ -130,6 +134,9 @@ export class ChatRunLifecycleRepository {
     return {
       schemaVersion: row.schema_version,
       state: typeof row.state === "string" ? JSON.parse(row.state) : row.state,
+      ...(row.execution_root_fingerprint === null ? {} : {
+        executionRootFingerprint: row.execution_root_fingerprint,
+      }),
     };
   }
 

--- a/packages/gateway/src/chat/service.ts
+++ b/packages/gateway/src/chat/service.ts
@@ -5,16 +5,29 @@ import {
   CanonicalChatIdSchema,
   CanonicalChatListResponseSchema,
   CanonicalChatRecordSchema,
+  CanonicalChatRunCancellationResponseSchema,
+  CanonicalChatRunAdmissionResponseSchema,
+  CanonicalChatTurnAdmissionResponseSchema,
+  CanonicalCreateChatTurnRequestSchema,
+  CanonicalRetryChatTurnRequestSchema,
   CanonicalCreateChatRequestSchema,
   type CanonicalChatDetailResponse,
   type CanonicalChatListResponse,
   type CanonicalChatRecord,
+  type CanonicalChatRunCancellationResponse,
+  type CanonicalChatRunAdmissionResponse,
+  type CanonicalChatTurnAdmissionResponse,
+  type CanonicalCancelChatRunRequest,
   type CanonicalCreateChatRequest,
+  type CanonicalCreateChatTurnRequest,
+  type CanonicalRetryChatTurnRequest,
 } from "@matrix-os/contracts";
 import { z } from "zod/v4";
 import type { ChatOwner } from "./records.js";
 import type { ChatRepository } from "./repository.js";
 import type { CanonicalChatRouteService } from "./routes.js";
+import type { RequestPrincipal } from "../request-principal.js";
+import type { CanonicalChatOrchestrator } from "./orchestrator.js";
 
 const CursorEnvelopeSchema = z.discriminatedUnion("kind", [
   z.object({
@@ -62,7 +75,10 @@ function decodeMessageCursor(value: string, chatId: string): number {
   return cursor.beforeSeq;
 }
 
-export function createCanonicalChatService(repository: ChatServiceRepository): CanonicalChatRouteService {
+export function createCanonicalChatService(
+  repository: ChatServiceRepository,
+  options: { orchestrator?: Pick<CanonicalChatOrchestrator, "admitTurn" | "cancelRun" | "retryTurn"> } = {},
+): CanonicalChatRouteService {
   return {
     async create(owner: ChatOwner, input: CanonicalCreateChatRequest): Promise<CanonicalChatRecord> {
       const request = CanonicalCreateChatRequestSchema.parse(input);
@@ -121,6 +137,50 @@ export function createCanonicalChatService(repository: ChatServiceRepository): C
         }),
       });
     },
+
+    async admitTurn(
+      principal: RequestPrincipal,
+      owner: ChatOwner,
+      chatId: string,
+      input: CanonicalCreateChatTurnRequest,
+    ): Promise<CanonicalChatTurnAdmissionResponse> {
+      if (!options.orchestrator) throw new Error("Canonical Chat orchestration unavailable");
+      return CanonicalChatTurnAdmissionResponseSchema.parse(await options.orchestrator.admitTurn(
+        principal,
+        owner,
+        CanonicalChatIdSchema.parse(chatId),
+        CanonicalCreateChatTurnRequestSchema.parse(input),
+      ));
+    },
+
+    async cancelRun(
+      owner: ChatOwner,
+      chatId: string,
+      runId: string,
+      _input: CanonicalCancelChatRunRequest,
+    ): Promise<CanonicalChatRunCancellationResponse> {
+      if (!options.orchestrator) throw new Error("Canonical Chat orchestration unavailable");
+      return CanonicalChatRunCancellationResponseSchema.parse(
+        await options.orchestrator.cancelRun(owner, CanonicalChatIdSchema.parse(chatId), runId),
+      );
+    },
+
+    async retryTurn(
+      principal: RequestPrincipal,
+      owner: ChatOwner,
+      chatId: string,
+      turnId: string,
+      input: CanonicalRetryChatTurnRequest,
+    ): Promise<CanonicalChatRunAdmissionResponse> {
+      if (!options.orchestrator) throw new Error("Canonical Chat orchestration unavailable");
+      return CanonicalChatRunAdmissionResponseSchema.parse(await options.orchestrator.retryTurn(
+        principal,
+        owner,
+        CanonicalChatIdSchema.parse(chatId),
+        turnId,
+        CanonicalRetryChatTurnRequestSchema.parse(input),
+      ));
+    },
   };
 }
 
@@ -134,5 +194,8 @@ export function createUnavailableCanonicalChatService(): CanonicalChatRouteServi
     create: unavailable,
     list: unavailable,
     getDetail: unavailable,
+    admitTurn: unavailable,
+    cancelRun: unavailable,
+    retryTurn: unavailable,
   };
 }

--- a/packages/gateway/src/chat/service.ts
+++ b/packages/gateway/src/chat/service.ts
@@ -1,0 +1,138 @@
+import { randomUUID } from "node:crypto";
+import {
+  CanonicalChatApiCursorSchema,
+  CanonicalChatDetailResponseSchema,
+  CanonicalChatIdSchema,
+  CanonicalChatListResponseSchema,
+  CanonicalChatRecordSchema,
+  CanonicalCreateChatRequestSchema,
+  type CanonicalChatDetailResponse,
+  type CanonicalChatListResponse,
+  type CanonicalChatRecord,
+  type CanonicalCreateChatRequest,
+} from "@matrix-os/contracts";
+import { z } from "zod/v4";
+import type { ChatOwner } from "./records.js";
+import type { ChatRepository } from "./repository.js";
+import type { CanonicalChatRouteService } from "./routes.js";
+
+const CursorEnvelopeSchema = z.discriminatedUnion("kind", [
+  z.object({
+    version: z.literal(1),
+    kind: z.literal("list"),
+    updatedAt: z.iso.datetime({ offset: true }),
+    chatId: CanonicalChatIdSchema,
+  }).strict(),
+  z.object({
+    version: z.literal(1),
+    kind: z.literal("messages"),
+    chatId: CanonicalChatIdSchema,
+    beforeSeq: z.number().int().min(1).max(Number.MAX_SAFE_INTEGER),
+  }).strict(),
+]);
+
+type CursorEnvelope = z.infer<typeof CursorEnvelopeSchema>;
+type ChatServiceRepository = Pick<ChatRepository, "create" | "list" | "getDetailPage">;
+
+function encodeCursor(value: CursorEnvelope): string {
+  return CanonicalChatApiCursorSchema.parse(
+    `chatcur_${Buffer.from(JSON.stringify(value), "utf8").toString("base64url")}`,
+  );
+}
+
+function decodeCursor(value: string): CursorEnvelope {
+  const parsed = CanonicalChatApiCursorSchema.parse(value);
+  return CursorEnvelopeSchema.parse(
+    JSON.parse(Buffer.from(parsed.slice("chatcur_".length), "base64url").toString("utf8")),
+  );
+}
+
+function decodeListCursor(value: string) {
+  const cursor = decodeCursor(value);
+  z.literal("list").parse(cursor.kind);
+  if (cursor.kind !== "list") throw new Error("Invalid Chat list cursor");
+  return { updatedAt: cursor.updatedAt, chatId: cursor.chatId };
+}
+
+function decodeMessageCursor(value: string, chatId: string): number {
+  const cursor = decodeCursor(value);
+  z.literal("messages").parse(cursor.kind);
+  if (cursor.kind !== "messages") throw new Error("Invalid Chat message cursor");
+  z.literal(chatId).parse(cursor.chatId);
+  return cursor.beforeSeq;
+}
+
+export function createCanonicalChatService(repository: ChatServiceRepository): CanonicalChatRouteService {
+  return {
+    async create(owner: ChatOwner, input: CanonicalCreateChatRequest): Promise<CanonicalChatRecord> {
+      const request = CanonicalCreateChatRequestSchema.parse(input);
+      const created = await repository.create(owner, {
+        id: CanonicalChatIdSchema.parse(`chat_${randomUUID().replaceAll("-", "")}`),
+        clientRequestId: request.clientRequestId,
+        title: request.title ?? "New chat",
+        ...(request.projectId === undefined ? {} : { projectId: request.projectId }),
+        ...(request.currentSelection === undefined ? {} : { currentSelection: request.currentSelection }),
+      });
+      return CanonicalChatRecordSchema.parse(created);
+    },
+
+    async list(owner, input): Promise<CanonicalChatListResponse> {
+      const page = await repository.list(owner, {
+        limit: input.limit,
+        ...(input.lifecycle === undefined ? {} : { lifecycle: input.lifecycle }),
+        ...(input.projectId === undefined ? {} : { projectId: input.projectId }),
+        ...(input.cursor === undefined ? {} : { cursor: decodeListCursor(input.cursor) }),
+      });
+      return CanonicalChatListResponseSchema.parse({
+        items: page.items,
+        ...(page.nextCursor === undefined ? {} : {
+          nextCursor: encodeCursor({
+            version: 1,
+            kind: "list",
+            updatedAt: page.nextCursor.updatedAt,
+            chatId: page.nextCursor.chatId,
+          }),
+        }),
+      });
+    },
+
+    async getDetail(owner, chatId, input): Promise<CanonicalChatDetailResponse | null> {
+      const parsedChatId = CanonicalChatIdSchema.parse(chatId);
+      const page = await repository.getDetailPage(owner, parsedChatId, {
+        limit: input.limit,
+        ...(input.cursor === undefined ? {} : {
+          beforeSeq: decodeMessageCursor(input.cursor, parsedChatId),
+        }),
+      });
+      if (!page) return null;
+      return CanonicalChatDetailResponseSchema.parse({
+        record: page.record,
+        messages: page.messages,
+        turns: page.turns,
+        runs: page.runs,
+        activities: page.activities,
+        ...(page.nextBeforeSeq === undefined ? {} : {
+          nextCursor: encodeCursor({
+            version: 1,
+            kind: "messages",
+            chatId: parsedChatId,
+            beforeSeq: page.nextBeforeSeq,
+          }),
+        }),
+      });
+    },
+  };
+}
+
+export function createUnavailableCanonicalChatService(): CanonicalChatRouteService {
+  const unavailable = async (): Promise<never> => {
+    const error = new Error("Canonical Chat repository unavailable");
+    error.name = "CanonicalChatServiceUnavailableError";
+    throw error;
+  };
+  return {
+    create: unavailable,
+    list: unavailable,
+    getDetail: unavailable,
+  };
+}

--- a/packages/gateway/src/chat/service.ts
+++ b/packages/gateway/src/chat/service.ts
@@ -55,8 +55,15 @@ function encodeCursor(value: CursorEnvelope): string {
 
 function decodeCursor(value: string): CursorEnvelope {
   const parsed = CanonicalChatApiCursorSchema.parse(value);
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(Buffer.from(parsed.slice("chatcur_".length), "base64url").toString("utf8"));
+  } catch (error: unknown) {
+    if (!(error instanceof SyntaxError)) throw error;
+    decoded = undefined;
+  }
   return CursorEnvelopeSchema.parse(
-    JSON.parse(Buffer.from(parsed.slice("chatcur_".length), "base64url").toString("utf8")),
+    decoded,
   );
 }
 

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -224,6 +224,8 @@ export interface CodingAgentTurnStore {
   shutdownTurns(): Promise<void>;
 }
 
+const MAX_THREAD_EVENT_SINKS = 72;
+
 export class CodingAgentThreadError extends Error {
   constructor(
     readonly code: "provider_unavailable" | "thread_not_found" | "thread_store_unavailable",
@@ -1777,7 +1779,7 @@ export function createCodingAgentThreadStore(
       return result.snapshots;
     },
     registerEventSink(sink) {
-      if (eventSinks.length >= 8) {
+      if (eventSinks.length >= MAX_THREAD_EVENT_SINKS) {
         throw new CodingAgentThreadError("thread_store_unavailable", "Too many thread event sinks");
       }
       eventSinks.push(sink);

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -134,6 +134,11 @@ import { createCodingAgentProviderRegistry } from "./coding-agents/provider-regi
 import { createChatProviderCatalogService } from "./chat/provider-catalog.js";
 import { createCodexModelCatalogSource } from "./chat/codex-model-catalog.js";
 import { createChatProviderRoutes } from "./chat/provider-routes.js";
+import { createCanonicalChatRoutes } from "./chat/routes.js";
+import {
+  createCanonicalChatService,
+  createUnavailableCanonicalChatService,
+} from "./chat/service.js";
 import { createCodingAgentFileStore } from "./coding-agents/file-read.js";
 import { createCodingAgentSourceControlStore } from "./coding-agents/source-control.js";
 import { registerCodingAgentAttentionNotifications } from "./coding-agents/attention-notifications.js";
@@ -4131,6 +4136,12 @@ export async function createGateway(config: GatewayConfig) {
     client: hermesClient,
   });
   await agentRuntimeServices.controller.reconcile();
+  app.route("/", createCanonicalChatRoutes({
+    service: chatRepository
+      ? createCanonicalChatService(chatRepository)
+      : createUnavailableCanonicalChatService(),
+    getPrincipal: (c) => requireRequestPrincipal(c),
+  }));
   app.route("/", createChatProviderRoutes({
     catalog: createChatProviderCatalogService({
       codingProviders: codingAgentProviderRegistry,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -135,6 +135,14 @@ import { createChatProviderCatalogService } from "./chat/provider-catalog.js";
 import { createCodexModelCatalogSource } from "./chat/codex-model-catalog.js";
 import { createChatProviderRoutes } from "./chat/provider-routes.js";
 import { createCanonicalChatRoutes } from "./chat/routes.js";
+import { createChatExecutionRootResolver } from "./chat/execution-root.js";
+import { createHermesChatProviderAdapter } from "./chat/hermes-provider-adapter.js";
+import { createCanonicalCodingChatProviderAdapter } from "./chat/coding-provider-adapter.js";
+import {
+  CanonicalChatProviderRegistry,
+  type CanonicalChatProviderAdapter,
+} from "./chat/provider-adapter.js";
+import { CanonicalChatOrchestrator } from "./chat/orchestrator.js";
 import {
   createCanonicalChatService,
   createUnavailableCanonicalChatService,
@@ -857,6 +865,7 @@ export async function createGateway(config: GatewayConfig) {
   let canvasSubscriptionHub: CanvasSubscriptionHub | null = null;
   let canvasCleanupTimer: ReturnType<typeof setInterval> | null = null;
   let chatRepository: ChatRepository | null = null;
+  let canonicalChatOrchestrator: CanonicalChatOrchestrator | null = null;
   let messagingRepository: MessagingKyselyRepository | null = null;
 
   if (databaseUrl) {
@@ -4136,24 +4145,59 @@ export async function createGateway(config: GatewayConfig) {
     client: hermesClient,
   });
   await agentRuntimeServices.controller.reconcile();
+  const canonicalChatProviderCatalog = createChatProviderCatalogService({
+    codingProviders: codingAgentProviderRegistry,
+    agentRuntimeSource: agentRuntimeServices.source,
+    skillsSource: () => loadSkills(homePath),
+    ...(codexExecutable ? {
+      codingModelCatalogSource: createCodexModelCatalogSource({
+        executable: codexExecutable,
+        cwd: homePath,
+      }),
+    } : {}),
+  });
+  if (chatRepository) {
+    const canonicalAdapters: CanonicalChatProviderAdapter[] = [
+      createHermesChatProviderAdapter({ dispatcher }),
+    ];
+    if (codingAgentThreadStore) {
+      if (codingAgentProviders.some((provider) => provider.providerId === "codex")) {
+        canonicalAdapters.push(createCanonicalCodingChatProviderAdapter({
+          providerId: "codex",
+          threads: codingAgentThreadStore,
+        }));
+      }
+      if (codingAgentProviders.some((provider) => provider.providerId === "claude")) {
+        canonicalAdapters.push(createCanonicalCodingChatProviderAdapter({
+          providerId: "claude",
+          threads: codingAgentThreadStore,
+        }));
+      }
+    }
+    canonicalChatOrchestrator = new CanonicalChatOrchestrator({
+      repository: chatRepository,
+      catalog: canonicalChatProviderCatalog,
+      adapters: new CanonicalChatProviderRegistry(canonicalAdapters),
+      executionRoots: createChatExecutionRootResolver({
+        homePath,
+        projects: codingAgentProjectManager,
+        worktrees: codingAgentWorktreeManager,
+      }),
+    });
+    for (const ownerId of new Set(codingAgentOwnerIds)) {
+      await canonicalChatOrchestrator.reconcileActiveRuns({ type: "personal", ownerId });
+    }
+  }
   app.route("/", createCanonicalChatRoutes({
     service: chatRepository
-      ? createCanonicalChatService(chatRepository)
+      ? createCanonicalChatService(chatRepository, {
+          ...(canonicalChatOrchestrator ? { orchestrator: canonicalChatOrchestrator } : {}),
+        })
       : createUnavailableCanonicalChatService(),
     getPrincipal: (c) => requireRequestPrincipal(c),
   }));
   app.route("/", createChatProviderRoutes({
-    catalog: createChatProviderCatalogService({
-      codingProviders: codingAgentProviderRegistry,
-      agentRuntimeSource: agentRuntimeServices.source,
-      skillsSource: () => loadSkills(homePath),
-      ...(codexExecutable ? {
-        codingModelCatalogSource: createCodexModelCatalogSource({
-          executable: codexExecutable,
-          cwd: homePath,
-        }),
-      } : {}),
-    }),
+    catalog: canonicalChatProviderCatalog,
     getPrincipal: (c) => requireRequestPrincipal(c),
   }));
 
@@ -4450,6 +4494,8 @@ export async function createGateway(config: GatewayConfig) {
       watchdog.stop();
       proactiveHeartbeat.stop();
       cronService.stop();
+      await canonicalChatOrchestrator?.close();
+      canonicalChatOrchestrator = null;
       await agentRuntimeServices.controller.close();
       await codingAgentTurnLifecycle.shutdown();
       await codexEventBridge?.shutdown();

--- a/specs/113-provider-neutral-chat-architecture/mat-477-implementation-plan.md
+++ b/specs/113-provider-neutral-chat-architecture/mat-477-implementation-plan.md
@@ -1,0 +1,59 @@
+# MAT-477 implementation plan
+
+MAT-477 adds the canonical Turn/Run execution seam on top of the PostgreSQL
+Chat repository. It remains stacked on MAT-347 so every Provider call uses the
+same owner-authorized execution-root provenance.
+
+## Vertical slices
+
+1. Add strict Turn admission, same-Turn retry, and Run-cancel contracts. The
+   verified request principal remains the owner source of truth; clients never
+   submit owners, paths, credentials, or Provider-native resume state.
+2. Admit the user message, Turn, first Run attempt, Provider binding, adapter
+   envelope, and outbox event in one repository transaction. Provider work
+   begins only after that transaction commits.
+3. Execute through a bounded canonical adapter registry. Revalidate the
+   MAT-347 root fingerprint immediately before invoking a Provider, normalize
+   every event before persistence, and commit the assistant message together
+   with the terminal Run/Turn transition.
+4. Add cancellation, same-Instance resume state, late-event rejection, and
+   restart reconciliation. Keep active controllers capped and drain them on
+   Gateway shutdown.
+5. Wire the existing Matrix kernel (`hermes` system-agent Driver), Codex, and
+   Claude Code through this one contract, then validate HTTP replay and real
+   runtime behavior before Human Review.
+
+## Security and resource limits
+
+| Route | Auth | Boundary |
+|---|---|---|
+| `POST /api/chats/:chatId/turns` | existing verified Gateway principal | strict Zod body, 128 KiB body limit, owner-derived scope |
+| `POST /api/chats/:chatId/turns/:turnId/runs` | existing verified Gateway principal | strict Zod body, 4 KiB body limit, same bound Instance and immutable Turn input |
+| `POST /api/chats/:chatId/runs/:runId/cancel` | existing verified Gateway principal | strict Zod body, 4 KiB body limit, owner/run match |
+
+Provider calls have bounded abort signals and run outside database locks.
+Adapter state is capped at 64 KiB, normalized activities remain capped by the
+repository, raw Provider errors are logged only by name, and clients receive a
+canonical safe error. Provider event queues are capped at 500 events, the
+active-Run registry is capped at 8 per owner and 64 globally, and Gateway gives
+Provider cancellation a 10-second total shutdown drain budget.
+
+## Explicit exclusions
+
+- Legacy JSON cutover/import and renderer-store deletion remain outside this
+  issue.
+- Desktop composition, message polish, and inspector UI remain MAT-476/MAT-480
+  integration work.
+- OpenCode/OpenClaw do not receive a special execution path. Pi is added only
+  after it satisfies the same canonical adapter contract.
+- Provider-native state never becomes a Chat ID or crosses a Driver/Instance
+  boundary.
+- Codex and Claude Code temporarily reuse the existing Gateway coding-thread
+  execution seam as adapter-internal state. Canonical PostgreSQL Chat records
+  remain authoritative; MAT-479 owns deletion of the legacy projection after
+  parity and migration evidence.
+
+## Documentation deliverable
+
+After runtime behavior is accepted, publish a separate public documentation PR
+in `FinnaAI/matrix-os-site`; do not create a local `www/` replacement.

--- a/specs/113-provider-neutral-chat-architecture/spec.md
+++ b/specs/113-provider-neutral-chat-architecture/spec.md
@@ -647,6 +647,7 @@ All schemas are strict and bounded. Every mutating HTTP endpoint uses Hono
 | `PATCH /api/chats/:chatId` | Verified principal | Owner/editor | Title, compatible selection, Project binding, lifecycle with base revision; Driver/Instance mutation rejected after binding |
 | `DELETE /api/chats/:chatId` | Verified principal | Owner/org admin | Reject active Run unless an explicit cancel-and-delete flow completed |
 | `POST /api/chats/:chatId/turns` | Verified principal | Owner/editor | Transactional Turn/Run admission; idempotent request ID |
+| `POST /api/chats/:chatId/turns/:turnId/runs` | Verified principal | Owner/editor | Idempotent same-Turn retry; immutable input and bound Instance |
 | `POST /api/chats/:chatId/runs/:runId/cancel` | Verified principal | Owner/editor | Same-Instance cancellation only |
 | `POST /api/chats/:chatId/forks` | Verified principal | Owner/editor | Explicit committed message boundary and optional draft selection |
 | `POST /api/chats/:chatId/exports` | Verified principal | Owner/org admin | Bounded temp export with cleanup policy |

--- a/tests/contracts/canonical-chat-api.test.ts
+++ b/tests/contracts/canonical-chat-api.test.ts
@@ -1,0 +1,77 @@
+import {
+  CanonicalChatDetailResponseSchema,
+  CanonicalChatListResponseSchema,
+  CanonicalChatRecordSchema,
+  CanonicalCreateChatRequestSchema,
+} from "@matrix-os/contracts";
+import { describe, expect, it } from "vitest";
+
+const chat = {
+  id: "chat_api_test",
+  ownerScope: { type: "personal", ownerId: "owner_1" },
+  title: "API test",
+  lifecycle: "active",
+  attention: "none",
+  revision: 0,
+  messageCount: 0,
+  createdAt: "2026-08-25T12:00:00.000Z",
+  updatedAt: "2026-08-25T12:00:00.000Z",
+} as const;
+
+describe("canonical Chat API contracts", () => {
+  it("accepts bounded create requests without client-controlled ownership or Chat ids", () => {
+    expect(CanonicalCreateChatRequestSchema.parse({
+      clientRequestId: "req_create_api_test",
+      title: "API test",
+      projectId: "project_1",
+      currentSelection: {
+        instanceId: "codex_default",
+        model: "gpt-5.6-sol",
+      },
+    })).toMatchObject({ projectId: "project_1" });
+
+    expect(CanonicalCreateChatRequestSchema.safeParse({
+      clientRequestId: "req_create_api_test",
+      title: "API test",
+      ownerScope: { type: "personal", ownerId: "other_owner" },
+    }).success).toBe(false);
+    expect(CanonicalCreateChatRequestSchema.safeParse({
+      clientRequestId: "req_create_api_test",
+      title: "API test",
+      id: "chat_client_chosen",
+    }).success).toBe(false);
+  });
+
+  it("bounds list and detail projections for shared clients", () => {
+    const record = CanonicalChatRecordSchema.parse({ chat, projectId: "project_1" });
+    expect(CanonicalChatListResponseSchema.parse({
+      items: [record],
+      nextCursor: "chatcur_opaque",
+    }).items).toHaveLength(1);
+    expect(CanonicalChatListResponseSchema.safeParse({
+      items: Array.from({ length: 101 }, () => record),
+    }).success).toBe(false);
+    expect(CanonicalChatDetailResponseSchema.parse({
+      record,
+      messages: [],
+      turns: [],
+      runs: [],
+      activities: [],
+    }).record.chat.id).toBe("chat_api_test");
+    expect(CanonicalChatDetailResponseSchema.safeParse({
+      record,
+      messages: Array.from({ length: 201 }, (_, index) => ({
+        id: `msg_${index}`,
+        chatId: chat.id,
+        seq: index + 1,
+        role: "assistant",
+        state: "committed",
+        parts: [{ type: "text", text: `message ${index}` }],
+        createdAt: "2026-08-25T12:00:00.000Z",
+      })),
+      turns: [],
+      runs: [],
+      activities: [],
+    }).success).toBe(false);
+  });
+});

--- a/tests/contracts/canonical-chat-api.test.ts
+++ b/tests/contracts/canonical-chat-api.test.ts
@@ -1,4 +1,9 @@
 import {
+  CanonicalCancelChatRunRequestSchema,
+  CanonicalChatTurnAdmissionResponseSchema,
+  CanonicalChatRunAdmissionResponseSchema,
+  CanonicalCreateChatTurnRequestSchema,
+  CanonicalRetryChatTurnRequestSchema,
   CanonicalChatDetailResponseSchema,
   CanonicalChatListResponseSchema,
   CanonicalChatRecordSchema,
@@ -16,6 +21,57 @@ const chat = {
   messageCount: 0,
   createdAt: "2026-08-25T12:00:00.000Z",
   updatedAt: "2026-08-25T12:00:00.000Z",
+} as const;
+
+const chatRecord = CanonicalChatRecordSchema.parse({ chat });
+const userMessage = {
+  id: "msg_turn_contract",
+  chatId: chat.id,
+  seq: 1,
+  role: "user",
+  state: "committed",
+  turnId: "cturn_contract",
+  parts: [{ type: "text", text: "implement it" }],
+  createdAt: "2026-08-25T12:01:00.000Z",
+} as const;
+const turn = {
+  id: "cturn_contract",
+  chatId: chat.id,
+  clientRequestId: "req_turn_contract",
+  baseMessageSeq: 0,
+  inputMessageId: userMessage.id,
+  status: "accepted",
+  createdAt: "2026-08-25T12:01:00.000Z",
+  updatedAt: "2026-08-25T12:01:00.000Z",
+} as const;
+const run = {
+  id: "run_contract",
+  chatId: chat.id,
+  turnId: turn.id,
+  attempt: 1,
+  driverKind: "codex",
+  instanceId: "codex_default",
+  selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+  interactionMode: "default",
+  permissionMode: "supervised",
+  status: "accepted",
+  historyBoundarySeq: 0,
+  capabilitySnapshot: {
+    revision: "catalog_contract",
+    rootChat: true,
+    attachments: ["file"],
+    resources: ["file", "folder", "project"],
+    tools: [],
+    approvals: true,
+    userInput: true,
+    resume: true,
+    cancellation: true,
+    worktrees: "optional",
+    interactionModes: ["default"],
+    permissionModes: ["supervised"],
+  },
+  createdAt: "2026-08-25T12:01:00.000Z",
+  updatedAt: "2026-08-25T12:01:00.000Z",
 } as const;
 
 describe("canonical Chat API contracts", () => {
@@ -73,5 +129,62 @@ describe("canonical Chat API contracts", () => {
       runs: [],
       activities: [],
     }).success).toBe(false);
+  });
+
+  it("accepts only bounded user Turn input and keeps ownership and paths server-owned", () => {
+    const request = {
+      clientRequestId: "req_turn_contract",
+      baseRevision: 2,
+      parts: [
+        { type: "text", text: "implement the canonical turn" },
+        { type: "resource_reference", resource: { kind: "file", id: "file_readme", label: "README.md" } },
+      ],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+      executionRoot: { kind: "project", projectId: "project_matrix" },
+    };
+
+    expect(CanonicalCreateChatTurnRequestSchema.parse(request)).toEqual(request);
+    expect(CanonicalCreateChatTurnRequestSchema.safeParse({
+      ...request,
+      ownerScope: { type: "personal", ownerId: "other" },
+    }).success).toBe(false);
+    expect(CanonicalCreateChatTurnRequestSchema.safeParse({
+      ...request,
+      executionRoot: { kind: "project", projectId: "/home/matrix/private" },
+    }).success).toBe(false);
+    expect(CanonicalCreateChatTurnRequestSchema.safeParse({
+      ...request,
+      parts: [{ type: "tool_result", toolCallId: "tool_1", outcome: "success", truncated: false }],
+    }).success).toBe(false);
+  });
+
+  it("defines strict admission and idempotent cancel envelopes", () => {
+    const response = {
+      record: chatRecord,
+      message: userMessage,
+      turn,
+      run,
+      admission: "accepted",
+    };
+    expect(CanonicalChatTurnAdmissionResponseSchema.parse(response)).toEqual(response);
+    expect(CanonicalCancelChatRunRequestSchema.parse({ clientRequestId: "req_cancel_contract" }))
+      .toEqual({ clientRequestId: "req_cancel_contract" });
+    expect(CanonicalCancelChatRunRequestSchema.safeParse({
+      clientRequestId: "req_cancel_contract",
+      providerSessionId: "secret",
+    }).success).toBe(false);
+
+    expect(CanonicalRetryChatTurnRequestSchema.parse({
+      clientRequestId: "req_retry_contract",
+      baseRevision: 4,
+    })).toEqual({ clientRequestId: "req_retry_contract", baseRevision: 4 });
+    expect(CanonicalChatRunAdmissionResponseSchema.parse({
+      record: chatRecord,
+      turn,
+      run: { ...run, attempt: 2 },
+      admission: "accepted",
+    })).toMatchObject({ run: { attempt: 2 } });
   });
 });

--- a/tests/contracts/canonical-chat.test.ts
+++ b/tests/contracts/canonical-chat.test.ts
@@ -57,6 +57,7 @@ describe("canonical Chat contracts", () => {
       interactionMode: "default",
       permissionMode: "supervised",
       executionRoot: { kind: "project", projectId: "matrix-os" },
+      executionRootFingerprint: "a".repeat(64),
       status: "completed",
       outcome: "completed",
       startedAt: now,
@@ -106,6 +107,14 @@ describe("canonical Chat contracts", () => {
     expect(CanonicalChatRunSchema.safeParse({
       ...run,
       completedAt: undefined,
+    }).success).toBe(false);
+    expect(CanonicalChatRunSchema.safeParse({
+      ...run,
+      executionRootFingerprint: undefined,
+    }).success).toBe(false);
+    expect(CanonicalChatRunSchema.safeParse({
+      ...run,
+      executionRoot: undefined,
     }).success).toBe(false);
   });
 

--- a/tests/contracts/fixtures/canonical-chat.ts
+++ b/tests/contracts/fixtures/canonical-chat.ts
@@ -225,6 +225,7 @@ export function createCanonicalChatFixture(state: CanonicalChatFixtureState): Ca
     interactionMode: "default",
     permissionMode: "supervised",
     executionRoot: { kind: "project", projectId: project.projectId },
+    executionRootFingerprint: "a".repeat(64),
     status,
     ...(status === "completed" || status === "failed" || status === "aborted" ? { outcome: status } : {}),
     ...(status === "accepted" ? {} : { startedAt: now }),

--- a/tests/desktop/canonical-chat-client.test.ts
+++ b/tests/desktop/canonical-chat-client.test.ts
@@ -98,4 +98,136 @@ describe("canonical Chat client", () => {
     }));
     await expect(malformed.getDetail("chat_client_test")).rejects.toThrow();
   });
+
+  it("sends strict Turn and cancel commands through the shared Gateway client", async () => {
+    const turnInput = {
+      clientRequestId: "req_client_turn",
+      baseRevision: 0,
+      parts: [{ type: "text" as const, text: "ship it" }],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+    };
+    const post = vi.fn(async (path: string) => {
+      if (path.endsWith("/cancel")) {
+        return {
+          run: {
+            id: "run_client",
+            chatId: record.chat.id,
+            turnId: "cturn_client",
+            attempt: 1,
+            driverKind: "codex",
+            instanceId: "codex_default",
+            selection: turnInput.selection,
+            interactionMode: "default",
+            permissionMode: "supervised",
+            status: "aborted",
+            outcome: "aborted",
+            startedAt: "2026-08-26T00:00:00.000Z",
+            completedAt: "2026-08-26T00:01:00.000Z",
+            historyBoundarySeq: 0,
+            capabilitySnapshot,
+            createdAt: "2026-08-26T00:00:00.000Z",
+            updatedAt: "2026-08-26T00:01:00.000Z",
+          },
+          cancellation: "aborted",
+        };
+      }
+      if (path.endsWith("/turns/cturn_client/runs")) {
+        const admitted = admissionResponse(turnInput);
+        return {
+          record: admitted.record,
+          turn: admitted.turn,
+          run: { ...admitted.run, id: "run_client_retry", attempt: 2 },
+          admission: "accepted",
+        };
+      }
+      return admissionResponse(turnInput);
+    });
+    const client = createCanonicalChatClient(api({ post }));
+
+    await client.admitTurn(record.chat.id, turnInput);
+    await client.cancelRun(record.chat.id, "run_client", { clientRequestId: "req_client_cancel" });
+    await client.retryTurn(record.chat.id, "cturn_client", {
+      clientRequestId: "req_client_retry",
+      baseRevision: 2,
+    });
+
+    expect(post).toHaveBeenNthCalledWith(1, "/api/chats/chat_client_test/turns", turnInput);
+    expect(post).toHaveBeenNthCalledWith(2, "/api/chats/chat_client_test/runs/run_client/cancel", {
+      clientRequestId: "req_client_cancel",
+    });
+    expect(post).toHaveBeenNthCalledWith(3, "/api/chats/chat_client_test/turns/cturn_client/runs", {
+      clientRequestId: "req_client_retry",
+      baseRevision: 2,
+    });
+  });
 });
+
+const capabilitySnapshot = {
+  revision: "catalog_client",
+  rootChat: true,
+  attachments: ["file" as const],
+  resources: ["file" as const, "folder" as const, "project" as const],
+  tools: [],
+  approvals: true,
+  userInput: true,
+  resume: true,
+  cancellation: true,
+  worktrees: "optional" as const,
+  interactionModes: ["default"],
+  permissionModes: ["supervised"],
+};
+
+function admissionResponse(input: {
+  clientRequestId: string;
+  selection: { instanceId: string; model: string };
+}) {
+  const currentRecord = {
+    chat: { ...record.chat, revision: 1, messageCount: 1, currentSelection: input.selection },
+    providerBinding: { driverKind: "codex", instanceId: "codex_default", lockedAtTurnId: "cturn_client" },
+    activeRun: { runId: "run_client", turnId: "cturn_client", status: "accepted" },
+  };
+  const message = {
+    id: "msg_client",
+    chatId: record.chat.id,
+    seq: 1,
+    role: "user",
+    state: "committed",
+    turnId: "cturn_client",
+    parts: [{ type: "text", text: "ship it" }],
+    createdAt: "2026-08-26T00:00:00.000Z",
+  };
+  const turn = {
+    id: "cturn_client",
+    chatId: record.chat.id,
+    clientRequestId: input.clientRequestId,
+    baseMessageSeq: 0,
+    inputMessageId: message.id,
+    status: "accepted",
+    createdAt: "2026-08-26T00:00:00.000Z",
+    updatedAt: "2026-08-26T00:00:00.000Z",
+  };
+  return {
+    record: currentRecord,
+    message,
+    turn,
+    run: {
+      id: "run_client",
+      chatId: record.chat.id,
+      turnId: turn.id,
+      attempt: 1,
+      driverKind: "codex",
+      instanceId: "codex_default",
+      selection: input.selection,
+      interactionMode: "default",
+      permissionMode: "supervised",
+      status: "accepted",
+      historyBoundarySeq: 0,
+      capabilitySnapshot,
+      createdAt: "2026-08-26T00:00:00.000Z",
+      updatedAt: "2026-08-26T00:00:00.000Z",
+    },
+    admission: "accepted",
+  };
+}

--- a/tests/desktop/canonical-chat-client.test.ts
+++ b/tests/desktop/canonical-chat-client.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createCanonicalChatClient,
+} from "@desktop/renderer/src/lib/canonical-chat-client";
+import type { ApiClient } from "@desktop/renderer/src/lib/api";
+
+const record = {
+  chat: {
+    id: "chat_client_test",
+    ownerScope: { type: "personal" as const, ownerId: "owner_1" },
+    title: "Client test",
+    lifecycle: "active" as const,
+    attention: "none" as const,
+    revision: 0,
+    messageCount: 0,
+    createdAt: "2026-08-25T12:00:00.000Z",
+    updatedAt: "2026-08-25T12:00:00.000Z",
+  },
+};
+
+function api(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    baseUrl: "https://matrix.test",
+    get: vi.fn(async () => ({ items: [record] })),
+    post: vi.fn(async () => record),
+    getText: vi.fn(),
+    getBlob: vi.fn(),
+    postBytes: vi.fn(),
+    patch: vi.fn(),
+    put: vi.fn(),
+    putBytes: vi.fn(),
+    delete: vi.fn(),
+    putText: vi.fn(),
+    ...overrides,
+  } as ApiClient;
+}
+
+describe("canonical Chat client", () => {
+  it("lists Chats through one filtered Gateway endpoint", async () => {
+    const get = vi.fn(async () => ({ items: [record], nextCursor: "chatcur_next" }));
+    const client = createCanonicalChatClient(api({ get }));
+
+    const page = await client.list({
+      limit: 25,
+      lifecycle: "active",
+      projectId: "project_1",
+      cursor: "chatcur_prev",
+    });
+
+    expect(get).toHaveBeenCalledWith(
+      "/api/chats?limit=25&lifecycle=active&projectId=project_1&cursor=chatcur_prev",
+    );
+    expect(page.items[0]?.chat.id).toBe("chat_client_test");
+  });
+
+  it("creates a Chat without accepting client-owned identity fields", async () => {
+    const post = vi.fn(async () => record);
+    const client = createCanonicalChatClient(api({ post }));
+
+    await client.create({
+      clientRequestId: "req_client_create",
+      title: "Client test",
+    });
+
+    expect(post).toHaveBeenCalledWith("/api/chats", {
+      clientRequestId: "req_client_create",
+      title: "Client test",
+    });
+    await expect(client.create({
+      clientRequestId: "req_client_create",
+      title: "Client test",
+      ownerScope: { type: "personal", ownerId: "other" },
+    } as never)).rejects.toThrow();
+  });
+
+  it("loads a bounded message page and rejects malformed Gateway projections", async () => {
+    const get = vi.fn(async () => ({
+      record,
+      messages: [],
+      turns: [],
+      runs: [],
+      activities: [],
+      nextCursor: "chatcur_older",
+    }));
+    const client = createCanonicalChatClient(api({ get }));
+
+    const detail = await client.getDetail("chat_client_test", {
+      limit: 100,
+      cursor: "chatcur_current",
+    });
+    expect(get).toHaveBeenCalledWith(
+      "/api/chats/chat_client_test?limit=100&cursor=chatcur_current",
+    );
+    expect(detail.nextCursor).toBe("chatcur_older");
+
+    const malformed = createCanonicalChatClient(api({
+      get: vi.fn(async () => ({ record: { chat: { id: "leaked" } } })),
+    }));
+    await expect(malformed.getDetail("chat_client_test")).rejects.toThrow();
+  });
+});

--- a/tests/gateway/chat-coding-provider.test.ts
+++ b/tests/gateway/chat-coding-provider.test.ts
@@ -1,0 +1,205 @@
+import {
+  AgentThreadEventSchema,
+  AgentThreadSnapshotSchema,
+  type AgentThreadEvent,
+  type AgentThreadSnapshot,
+} from "@matrix-os/contracts";
+import { describe, expect, it, vi } from "vitest";
+import { createCanonicalCodingChatProviderAdapter } from "../../packages/gateway/src/chat/coding-provider-adapter.js";
+import type {
+  CodingAgentThreadStore,
+  CodingAgentTurnStore,
+} from "../../packages/gateway/src/coding-agents/thread-store.js";
+
+const owner = { type: "personal" as const, ownerId: "owner_coding" };
+const occurredAt = "2026-08-26T00:00:00.000Z";
+
+function input(overrides: Record<string, unknown> = {}) {
+  return {
+    owner,
+    chatId: "chat_coding",
+    turnId: "cturn_coding",
+    runId: "run_coding",
+    prompt: "ship it",
+    parts: [{ type: "text" as const, text: "ship it" }],
+    selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+    interactionMode: "default",
+    permissionMode: "supervised",
+    projectSlug: "matrix-os",
+    worktreeId: "wt_feature",
+    signal: new AbortController().signal,
+    ...overrides,
+  };
+}
+
+function event(value: Omit<AgentThreadEvent, "eventId" | "threadId" | "occurredAt"> & {
+  eventId: string;
+  threadId?: string;
+}): AgentThreadEvent {
+  return AgentThreadEventSchema.parse({
+    ...value,
+    threadId: value.threadId ?? "thread_native",
+    occurredAt,
+  });
+}
+
+function snapshot(events: AgentThreadEvent[]): AgentThreadSnapshot {
+  return AgentThreadSnapshotSchema.parse({
+    thread: {
+      id: "thread_native",
+      providerId: "codex",
+      title: "Canonical Chat",
+      status: events.some((candidate) => candidate.type === "thread.completed") ? "completed" : "running",
+      attention: "none",
+      projectId: "matrix-os",
+      createdAt: occurredAt,
+      updatedAt: occurredAt,
+    },
+    events: { items: events, hasMore: false, limit: 200 },
+  });
+}
+
+type Sink = Parameters<CodingAgentThreadStore["registerEventSink"]>[0];
+
+function fakeStore(initialEvents: AgentThreadEvent[]) {
+  let sink: Sink | undefined;
+  const createThread = vi.fn(async (_principal, request) => {
+    expect(request).toMatchObject({
+      providerId: "codex",
+      projectId: "matrix-os",
+      worktreeId: "wt_feature",
+      mode: "default",
+      approvalPolicy: "on_request",
+      sandboxMode: "workspace_write",
+    });
+    return { snapshot: snapshot(initialEvents), existing: false };
+  });
+  const acceptTurn = vi.fn(async () => ({
+    threadId: "thread_native",
+    turnId: "turn_native",
+    status: "accepted" as const,
+    acceptedAt: occurredAt,
+  }));
+  const getThread = vi.fn(async () => snapshot(initialEvents));
+  const abortThread = vi.fn(async () => snapshot([]));
+  const registerEventSink = vi.fn((candidate: Sink) => {
+    sink = candidate;
+    return { dispose: vi.fn() };
+  });
+  const store = {
+    createThread,
+    acceptTurn,
+    getThread,
+    abortThread,
+    registerEventSink,
+  } as unknown as CodingAgentThreadStore & CodingAgentTurnStore;
+  return {
+    store,
+    createThread,
+    acceptTurn,
+    getThread,
+    abortThread,
+    publish(events: AgentThreadEvent[]) {
+      sink?.({ ownerId: owner.ownerId, threadId: "thread_native", events });
+    },
+  };
+}
+
+describe("canonical coding Chat Provider adapter", () => {
+  it("streams normalized Codex events from the shared Gateway thread seam", async () => {
+    const started = event({ type: "terminal.bound", eventId: "evt_terminal", terminalSessionId: "terminal_native" });
+    const fake = fakeStore([started]);
+    const adapter = createCanonicalCodingChatProviderAdapter({ providerId: "codex", threads: fake.store });
+
+    queueMicrotask(() => fake.publish([
+      event({ type: "assistant.text.delta", eventId: "evt_delta", messageId: "msg_native", delta: "done" }),
+      event({ type: "file.changed", eventId: "evt_file", path: "src/index.ts", changeKind: "updated" }),
+      event({ type: "thread.completed", eventId: "evt_complete", outcome: "completed" }),
+    ]));
+
+    const events = [];
+    for await (const candidate of adapter.start(input())) events.push(candidate);
+
+    expect(events).toEqual([
+      { type: "state.updated", state: { conversationId: "thread_native" } },
+      { type: "terminal.bound", terminalSessionId: "terminal_native" },
+      { type: "assistant.delta", delta: "done" },
+      expect.objectContaining({ type: "resource.changed", resourceKind: "file", changeKind: "updated" }),
+      { type: "run.completed", outcome: "completed" },
+    ]);
+    expect(fake.createThread).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumes and cancels only the same persisted coding thread", async () => {
+    const accepted = event({
+      type: "turn.accepted",
+      eventId: "evt_accepted",
+      turnId: "turn_native",
+      clientRequestId: "req_coding",
+      acceptedAt: occurredAt,
+    });
+    const completed = event({ type: "thread.completed", eventId: "evt_complete", outcome: "completed" });
+    const fake = fakeStore([accepted, completed]);
+    const adapter = createCanonicalCodingChatProviderAdapter({ providerId: "codex", threads: fake.store });
+
+    const events = [];
+    for await (const candidate of adapter.resume!({
+      ...input(),
+      resumeState: { conversationId: "thread_native" },
+    })) events.push(candidate);
+    expect(events).toEqual([{ type: "run.completed", outcome: "completed" }]);
+    expect(fake.acceptTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: owner.ownerId }),
+      "thread_native",
+      expect.objectContaining({ message: "ship it" }),
+    );
+
+    await adapter.cancel!({
+      owner,
+      chatId: "chat_coding",
+      runId: "run_coding",
+      state: { conversationId: "thread_native" },
+    });
+    expect(fake.abortThread).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: owner.ownerId }),
+      "thread_native",
+      "req_coding",
+    );
+  });
+
+  it("surfaces event overflow even when the shared thread store isolates sink failures", async () => {
+    let sink: Sink | undefined;
+    const overflow = Array.from({ length: 501 }, (_, index) => event({
+      type: "assistant.text.delta",
+      eventId: `evt_overflow_${index}`,
+      messageId: "msg_native",
+      delta: "x",
+    }));
+    const store = {
+      createThread: vi.fn(async () => {
+        setTimeout(() => {
+          try {
+            sink?.({ ownerId: owner.ownerId, threadId: "thread_native", events: overflow });
+          } catch {
+            // The production store isolates sink failures from other subscribers.
+          }
+        }, 0);
+        return { snapshot: snapshot([]), existing: false };
+      }),
+      acceptTurn: vi.fn(),
+      getThread: vi.fn(),
+      abortThread: vi.fn(),
+      registerEventSink: vi.fn((candidate: Sink) => {
+        sink = candidate;
+        return { dispose: vi.fn() };
+      }),
+    } as unknown as CodingAgentThreadStore & CodingAgentTurnStore;
+    const adapter = createCanonicalCodingChatProviderAdapter({ providerId: "codex", threads: store });
+
+    await expect(async () => {
+      for await (const _event of adapter.start(input({ signal: AbortSignal.timeout(100) }))) {
+        // consume
+      }
+    }).rejects.toThrow("event buffer exceeded");
+  });
+});

--- a/tests/gateway/chat-coding-provider.test.ts
+++ b/tests/gateway/chat-coding-provider.test.ts
@@ -167,6 +167,51 @@ describe("canonical coding Chat Provider adapter", () => {
     );
   });
 
+  it("uses live sink events when the bounded snapshot no longer contains the accepted marker", async () => {
+    let sink: Sink | undefined;
+    const accepted = event({
+      type: "turn.accepted",
+      eventId: "evt_live_accepted",
+      turnId: "turn_native",
+      clientRequestId: "req_coding",
+      acceptedAt: occurredAt,
+    });
+    const completed = event({ type: "thread.completed", eventId: "evt_live_complete", outcome: "completed" });
+    const stale = event({
+      type: "assistant.text.delta",
+      eventId: "evt_stale_delta",
+      messageId: "msg_stale",
+      delta: "stale",
+    });
+    const store = {
+      createThread: vi.fn(),
+      acceptTurn: vi.fn(async () => {
+        sink?.({ ownerId: owner.ownerId, threadId: "thread_native", events: [accepted, completed] });
+        return {
+          threadId: "thread_native",
+          turnId: "turn_native",
+          status: "accepted" as const,
+          acceptedAt: occurredAt,
+        };
+      }),
+      getThread: vi.fn(async () => snapshot([stale])),
+      abortThread: vi.fn(),
+      registerEventSink: vi.fn((candidate: Sink) => {
+        sink = candidate;
+        return { dispose: vi.fn() };
+      }),
+    } as unknown as CodingAgentThreadStore & CodingAgentTurnStore;
+    const adapter = createCanonicalCodingChatProviderAdapter({ providerId: "codex", threads: store });
+
+    const events = [];
+    for await (const candidate of adapter.resume!({
+      ...input(),
+      resumeState: { conversationId: "thread_native" },
+    })) events.push(candidate);
+
+    expect(events).toEqual([{ type: "run.completed", outcome: "completed" }]);
+  });
+
   it("surfaces event overflow even when the shared thread store isolates sink failures", async () => {
     let sink: Sink | undefined;
     const overflow = Array.from({ length: 501 }, (_, index) => event({
@@ -178,11 +223,7 @@ describe("canonical coding Chat Provider adapter", () => {
     const store = {
       createThread: vi.fn(async () => {
         setTimeout(() => {
-          try {
-            sink?.({ ownerId: owner.ownerId, threadId: "thread_native", events: overflow });
-          } catch {
-            // The production store isolates sink failures from other subscribers.
-          }
+          sink?.({ ownerId: owner.ownerId, threadId: "thread_native", events: overflow });
         }, 0);
         return { snapshot: snapshot([]), existing: false };
       }),

--- a/tests/gateway/chat-execution-root.test.ts
+++ b/tests/gateway/chat-execution-root.test.ts
@@ -68,6 +68,7 @@ describe("canonical Chat execution-root resolver", () => {
     expect(resolved).toEqual({
       ref: { kind: "project", projectId: projectRecord.id },
       primaryWorkspaceRoot: await realpath(externalFolder),
+      projectSlug: "matrix-os-renamed",
       fingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
     });
     expect(JSON.stringify(resolved)).not.toContain("user_owner");
@@ -76,7 +77,7 @@ describe("canonical Chat execution-root resolver", () => {
     await expect(resolver.revalidate(owner, {
       ref: resolved.ref,
       fingerprint: resolved.fingerprint,
-    })).resolves.toEqual(resolved);
+    })).resolves.toEqual({ ...resolved, projectSlug: "renamed-again" });
   });
 
   it("fails closed when project authority is revoked during revalidation", async () => {

--- a/tests/gateway/chat-hermes-provider.test.ts
+++ b/tests/gateway/chat-hermes-provider.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHermesChatProviderAdapter } from "../../packages/gateway/src/chat/hermes-provider-adapter.js";
+import type { Dispatcher } from "../../packages/gateway/src/dispatcher.js";
+
+const owner = { type: "personal" as const, ownerId: "owner_hermes" };
+
+function input(overrides: Record<string, unknown> = {}) {
+  return {
+    owner,
+    chatId: "chat_hermes",
+    turnId: "cturn_hermes",
+    runId: "run_hermes",
+    prompt: "hello",
+    parts: [{ type: "text" as const, text: "hello" }],
+    selection: {
+      instanceId: "hermes_default",
+      model: "anthropic:claude-opus-4-6",
+      options: [{ id: "effort", value: "high" }],
+    },
+    interactionMode: "default",
+    permissionMode: "supervised",
+    executionRoot: "/safe/project",
+    signal: new AbortController().signal,
+    ...overrides,
+  };
+}
+
+describe("Hermes canonical Chat Provider adapter", () => {
+  it("normalizes Matrix kernel events and persists only opaque resume state", async () => {
+    const dispatch = vi.fn<Dispatcher["dispatch"]>(async (_message, _sessionId, onEvent, context, _abort, overrides) => {
+      expect(context).toEqual({ chatId: "chat_hermes" });
+      expect(overrides).toEqual({
+        model: "claude-opus-4-6",
+        effort: "high",
+        workingDirectory: "/safe/project",
+      });
+      await onEvent({ type: "init", sessionId: "native_session" });
+      await onEvent({ type: "text", text: "hello" });
+      await onEvent({ type: "tool_start", tool: "Read" });
+      await onEvent({ type: "tool_end" });
+      await onEvent({
+        type: "result",
+        data: { sessionId: "native_session", result: "hello", cost: 0, turns: 1, tokensIn: 1, tokensOut: 1 },
+      });
+    });
+    const adapter = createHermesChatProviderAdapter({ dispatcher: { dispatch } as Pick<Dispatcher, "dispatch"> });
+
+    const events = [];
+    for await (const event of adapter.start(input())) events.push(event);
+
+    expect(events).toEqual([
+      { type: "state.updated", state: { sessionId: "native_session" } },
+      { type: "assistant.delta", delta: "hello" },
+      { type: "tool.progress", toolCallId: "kernel_tool_1", label: "Read", status: "running" },
+      { type: "tool.progress", toolCallId: "kernel_tool_1", label: "Read", status: "completed" },
+      { type: "run.completed", outcome: "completed" },
+    ]);
+    expect(adapter.parseState(adapter.serializeState({ sessionId: "native_session" })))
+      .toEqual({ sessionId: "native_session" });
+  });
+
+  it("resumes only the same bounded session and rejects non-kernel model selections", async () => {
+    const dispatch = vi.fn<Dispatcher["dispatch"]>(async (_message, sessionId, onEvent) => {
+      expect(sessionId).toBe("native_resume");
+      await onEvent({ type: "aborted" });
+    });
+    const adapter = createHermesChatProviderAdapter({ dispatcher: { dispatch } as Pick<Dispatcher, "dispatch"> });
+
+    const events = [];
+    for await (const event of adapter.resume!({
+      ...input(),
+      resumeState: { sessionId: "native_resume" },
+    })) events.push(event);
+    expect(events).toEqual([{ type: "run.completed", outcome: "aborted" }]);
+
+    await expect(async () => {
+      for await (const _event of adapter.start(input({
+        selection: { instanceId: "hermes_default", model: "openai:gpt-5" },
+      }))) {
+        // consume
+      }
+    }).rejects.toThrow("Unsupported Matrix kernel selection");
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails safely when the Matrix kernel outpaces the bounded event buffer", async () => {
+    const dispatch = vi.fn<Dispatcher["dispatch"]>(async (_message, _sessionId, onEvent) => {
+      for (let index = 0; index < 501; index += 1) {
+        void onEvent({ type: "text", text: "x" });
+      }
+    });
+    const adapter = createHermesChatProviderAdapter({ dispatcher: { dispatch } as Pick<Dispatcher, "dispatch"> });
+
+    await expect(async () => {
+      for await (const _event of adapter.start(input())) {
+        // consume
+      }
+    }).rejects.toThrow("event buffer exceeded");
+  });
+});

--- a/tests/gateway/chat-hermes-provider.test.ts
+++ b/tests/gateway/chat-hermes-provider.test.ts
@@ -84,7 +84,9 @@ describe("Hermes canonical Chat Provider adapter", () => {
   });
 
   it("fails safely when the Matrix kernel outpaces the bounded event buffer", async () => {
-    const dispatch = vi.fn<Dispatcher["dispatch"]>(async (_message, _sessionId, onEvent) => {
+    let providerSignal: AbortSignal | undefined;
+    const dispatch = vi.fn<Dispatcher["dispatch"]>(async (_message, _sessionId, onEvent, _context, abort) => {
+      providerSignal = abort.signal;
       for (let index = 0; index < 501; index += 1) {
         void onEvent({ type: "text", text: "x" });
       }
@@ -96,5 +98,6 @@ describe("Hermes canonical Chat Provider adapter", () => {
         // consume
       }
     }).rejects.toThrow("event buffer exceeded");
+    expect(providerSignal?.aborted).toBe(true);
   });
 });

--- a/tests/gateway/chat-orchestrator.test.ts
+++ b/tests/gateway/chat-orchestrator.test.ts
@@ -171,6 +171,68 @@ describe("CanonicalChatOrchestrator", () => {
     ]);
   });
 
+  it("does not reconcile a committed Run while its dispatch registration is pending", async () => {
+    await repository.create(owner, {
+      id: "chat_pending_dispatch",
+      clientRequestId: "req_create_pending_dispatch",
+      title: "Pending dispatch",
+    });
+    let releaseAdmission!: () => void;
+    let admissionCommitted!: () => void;
+    const release = new Promise<void>((resolve) => {
+      releaseAdmission = resolve;
+    });
+    const committed = new Promise<void>((resolve) => {
+      admissionCommitted = resolve;
+    });
+    const delayedRepository = new Proxy(repository, {
+      get(target, property, receiver) {
+        if (property === "admitTurn") {
+          return async (...args: Parameters<ChatRepository["admitTurn"]>) => {
+            const admitted = await target.admitTurn(...args);
+            admissionCommitted();
+            await release;
+            return admitted;
+          };
+        }
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    const start = vi.fn(async function* () {
+      yield { type: "run.completed" as const, outcome: "completed" as const };
+    });
+    const orchestrator = new CanonicalChatOrchestrator({
+      repository: delayedRepository,
+      catalog: { getCatalog: async () => catalog() },
+      adapters: new CanonicalChatProviderRegistry([adapter(start)]),
+    });
+
+    await orchestrator.reconcileActiveRuns(owner);
+    for (let index = 1; index < 64; index += 1) {
+      await orchestrator.reconcileActiveRuns({ type: "personal", ownerId: `owner_cache_${index}` });
+    }
+
+    const admission = orchestrator.admitTurn(principal, owner, "chat_pending_dispatch", {
+      clientRequestId: "req_pending_dispatch_turn",
+      baseRevision: 0,
+      parts: [{ type: "text", text: "run safely" }],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+    });
+    await committed;
+    await orchestrator.reconcileActiveRuns({ type: "personal", ownerId: "owner_cache_64" });
+    expect(await orchestrator.reconcileActiveRuns(owner)).toBe(0);
+    releaseAdmission();
+    await admission;
+    await orchestrator.drain();
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect((await repository.exportChat(owner, "chat_pending_dispatch"))?.runs[0])
+      .toMatchObject({ status: "completed", outcome: "completed" });
+  });
+
   it("rejects an execution root from another Project before resolution", async () => {
     await repository.create(owner, {
       id: "chat_wrong_project_root",

--- a/tests/gateway/chat-orchestrator.test.ts
+++ b/tests/gateway/chat-orchestrator.test.ts
@@ -483,6 +483,82 @@ describe("CanonicalChatOrchestrator", () => {
     ]);
   });
 
+  it("terminalizes an orphaned Run when its activity history is already full", async () => {
+    await repository.create(owner, {
+      id: "chat_reconcile_overflow",
+      clientRequestId: "req_create_reconcile_overflow",
+      title: "Reconcile overflow",
+    });
+    const inputMessage = {
+      id: "msg_reconcile_overflow",
+      chatId: "chat_reconcile_overflow",
+      seq: 1,
+      role: "user" as const,
+      state: "committed" as const,
+      turnId: "cturn_reconcile_overflow",
+      parts: [{ type: "text" as const, text: "continue after restart" }],
+      createdAt: "2026-08-26T00:00:00.000Z",
+    };
+    const inputTurn = {
+      id: "cturn_reconcile_overflow",
+      chatId: "chat_reconcile_overflow",
+      clientRequestId: "req_reconcile_overflow_turn",
+      baseMessageSeq: 0,
+      inputMessageId: inputMessage.id,
+      status: "accepted" as const,
+      createdAt: "2026-08-26T00:00:00.000Z",
+      updatedAt: "2026-08-26T00:00:00.000Z",
+    };
+    const admitted = await repository.admitTurn(owner, {
+      chatId: "chat_reconcile_overflow",
+      baseRevision: 0,
+      message: inputMessage,
+      turn: inputTurn,
+      run: {
+        id: "run_reconcile_overflow",
+        chatId: "chat_reconcile_overflow",
+        turnId: inputTurn.id,
+        attempt: 1,
+        driverKind: "codex",
+        instanceId: "codex_default",
+        selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+        interactionMode: "default",
+        permissionMode: "supervised",
+        status: "accepted",
+        historyBoundarySeq: 0,
+        capabilitySnapshot: catalog().instances[0]!.supports && {
+          revision: "catalog_orchestrator",
+          ...catalog().instances[0]!.supports,
+        },
+        createdAt: "2026-08-26T00:00:00.000Z",
+        updatedAt: "2026-08-26T00:00:00.000Z",
+      },
+    });
+    for (let offset = 0; offset < 500; offset += 100) {
+      await repository.appendRunActivities(owner, admitted.chat.chat.id, admitted.run.id,
+        Array.from({ length: 100 }, (_, index) => ({
+          id: `activity_reconcile_overflow_${offset + index}`,
+          chatId: admitted.chat.chat.id,
+          runId: admitted.run.id,
+          occurredAt: "2026-08-26T00:01:00.000Z",
+          type: "run.status" as const,
+          status: "running" as const,
+        })),
+      );
+    }
+    const restarted = new CanonicalChatOrchestrator({
+      repository,
+      catalog: { getCatalog: async () => catalog() },
+      adapters: new CanonicalChatProviderRegistry([]),
+      now: () => new Date("2026-08-26T00:02:00.000Z"),
+    });
+
+    expect(await restarted.reconcileActiveRuns(owner)).toBe(1);
+    const snapshot = await repository.exportChat(owner, "chat_reconcile_overflow");
+    expect(snapshot?.runs[0]).toMatchObject({ status: "failed", outcome: "failed" });
+    expect(snapshot?.activities).toHaveLength(500);
+  });
+
   it("limits one owner to eight concurrent Runs without consuming the global registry", async () => {
     const provider = adapter(async function* (input) {
       await new Promise<void>((resolve) => input.signal.addEventListener("abort", () => resolve(), { once: true }));

--- a/tests/gateway/chat-orchestrator.test.ts
+++ b/tests/gateway/chat-orchestrator.test.ts
@@ -171,6 +171,99 @@ describe("CanonicalChatOrchestrator", () => {
     ]);
   });
 
+  it("rejects an execution root from another Project before resolution", async () => {
+    await repository.create(owner, {
+      id: "chat_wrong_project_root",
+      clientRequestId: "req_create_wrong_project_root",
+      title: "Wrong Project root",
+      projectId: "project_matrix",
+    });
+    const resolve = vi.fn(async () => {
+      throw new Error("wrong Project root must not resolve");
+    });
+    const orchestrator = new CanonicalChatOrchestrator({
+      repository,
+      catalog: { getCatalog: async () => catalog() },
+      adapters: new CanonicalChatProviderRegistry([adapter(async function* () {
+        yield { type: "run.completed", outcome: "completed" };
+      })]),
+      executionRoots: { resolve, revalidate: vi.fn() },
+    });
+
+    await expect(orchestrator.admitTurn(principal, owner, "chat_wrong_project_root", {
+      clientRequestId: "req_wrong_project_root_turn",
+      baseRevision: 0,
+      parts: [{ type: "text", text: "wrong root" }],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+      executionRoot: { kind: "project", projectId: "project_other" },
+    })).rejects.toMatchObject({ safeError: { code: "project_unavailable" }, status: 400 });
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it("starts a fresh Provider session when execution-root provenance changes", async () => {
+    await repository.create(owner, {
+      id: "chat_changed_root",
+      clientRequestId: "req_create_changed_root",
+      title: "Changed root",
+      projectId: "project_matrix",
+    });
+    let fingerprint = "a".repeat(64);
+    const roots: ChatExecutionRootResolver = {
+      resolve: async (_owner, ref) => ({
+        ref,
+        fingerprint,
+        primaryWorkspaceRoot: "/safe/project",
+        projectSlug: "matrix-os",
+      }),
+      revalidate: async (_owner, provenance) => ({
+        ref: provenance.ref,
+        fingerprint: provenance.fingerprint,
+        primaryWorkspaceRoot: "/safe/project",
+        projectSlug: "matrix-os",
+      }),
+    };
+    const start = vi.fn(async function* () {
+      yield { type: "state.updated" as const, state: { sessionId: "native_root" } };
+      yield { type: "run.completed" as const, outcome: "completed" as const };
+    });
+    const resume = vi.fn(async function* () {
+      yield { type: "run.completed" as const, outcome: "completed" as const };
+    });
+    const orchestrator = new CanonicalChatOrchestrator({
+      repository,
+      catalog: { getCatalog: async () => catalog() },
+      adapters: new CanonicalChatProviderRegistry([{ ...adapter(start), resume }]),
+      executionRoots: roots,
+    });
+
+    await orchestrator.admitTurn(principal, owner, "chat_changed_root", {
+      clientRequestId: "req_changed_root_first",
+      baseRevision: 0,
+      parts: [{ type: "text", text: "first" }],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+    });
+    await orchestrator.drain();
+    const first = await repository.get(owner, "chat_changed_root");
+    expect(first).not.toBeNull();
+    fingerprint = "b".repeat(64);
+    await orchestrator.admitTurn(principal, owner, "chat_changed_root", {
+      clientRequestId: "req_changed_root_second",
+      baseRevision: first!.chat.revision,
+      parts: [{ type: "text", text: "second" }],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+    });
+    await orchestrator.drain();
+
+    expect(start).toHaveBeenCalledTimes(2);
+    expect(resume).not.toHaveBeenCalled();
+  });
+
   it("aborts an active Run idempotently and does not persist late Provider output", async () => {
     await repository.create(owner, {
       id: "chat_cancelled",
@@ -435,16 +528,53 @@ describe("CanonicalChatOrchestrator", () => {
     expect(rejected?.runs[0]).toMatchObject({ status: "failed", outcome: "failed" });
   });
 
+  it("terminalizes a Run when normalized activity exceeds the persisted limit", async () => {
+    await repository.create(owner, {
+      id: "chat_activity_overflow",
+      clientRequestId: "req_create_activity_overflow",
+      title: "Activity overflow",
+    });
+    const provider = adapter(async function* () {
+      for (let index = 0; index < 501; index += 1) {
+        yield { type: "assistant.delta", delta: "x" };
+      }
+      yield { type: "run.completed", outcome: "completed" };
+    });
+    const orchestrator = new CanonicalChatOrchestrator({
+      repository,
+      catalog: { getCatalog: async () => catalog() },
+      adapters: new CanonicalChatProviderRegistry([provider]),
+      now: () => new Date("2026-08-26T00:00:00.000Z"),
+    });
+
+    await orchestrator.admitTurn(principal, owner, "chat_activity_overflow", {
+      clientRequestId: "req_activity_overflow_turn",
+      baseRevision: 0,
+      parts: [{ type: "text", text: "overflow" }],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+    });
+    await orchestrator.drain();
+
+    const snapshot = await repository.exportChat(owner, "chat_activity_overflow");
+    expect(snapshot?.runs[0]).toMatchObject({ status: "failed", outcome: "failed" });
+    expect(orchestrator.activeCount).toBe(0);
+  });
+
   it("bounds shutdown even when a Provider ignores cancellation", async () => {
     await repository.create(owner, {
       id: "chat_shutdown",
       clientRequestId: "req_create_shutdown",
       title: "Shutdown",
     });
-    const provider = adapter(async function* () {
-      await new Promise<void>(() => undefined);
-      yield { type: "run.completed", outcome: "completed" };
-    });
+    const provider = {
+      ...adapter(async function* () {
+        await new Promise<void>(() => undefined);
+        yield { type: "run.completed", outcome: "completed" };
+      }),
+      cancel: vi.fn(async () => new Promise<void>(() => undefined)),
+    };
     const orchestrator = new CanonicalChatOrchestrator({
       repository,
       catalog: { getCatalog: async () => catalog() },
@@ -462,7 +592,11 @@ describe("CanonicalChatOrchestrator", () => {
     });
 
     const startedAt = Date.now();
-    await orchestrator.close();
+    const closed = await Promise.race([
+      orchestrator.close().then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 100)),
+    ]);
+    expect(closed).toBe(true);
     expect(Date.now() - startedAt).toBeLessThan(500);
     const snapshot = await repository.exportChat(owner, "chat_shutdown");
     expect(snapshot?.runs[0]).toMatchObject({ status: "aborted", outcome: "aborted" });

--- a/tests/gateway/chat-orchestrator.test.ts
+++ b/tests/gateway/chat-orchestrator.test.ts
@@ -1,0 +1,470 @@
+import {
+  CanonicalProviderCatalogSchema,
+  type CanonicalProviderCatalog,
+} from "@matrix-os/contracts";
+import { KyselyPGlite } from "kysely-pglite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatExecutionRootResolver } from "../../packages/gateway/src/chat/execution-root.js";
+import { CanonicalChatOrchestrator } from "../../packages/gateway/src/chat/orchestrator.js";
+import {
+  CanonicalChatProviderRegistry,
+  type CanonicalChatProviderAdapter,
+} from "../../packages/gateway/src/chat/provider-adapter.js";
+import { ChatRepository } from "../../packages/gateway/src/chat/repository.js";
+
+const owner = { type: "personal" as const, ownerId: "owner_orchestrator" };
+const principal = { userId: owner.ownerId, source: "jwt" as const };
+
+function catalog(): CanonicalProviderCatalog {
+  return CanonicalProviderCatalogSchema.parse({
+    revision: "catalog_orchestrator",
+    drivers: [{
+      kind: "codex",
+      displayName: "Codex",
+      adapterVersion: "1.0.0",
+      capabilityClass: "coding_agent",
+    }],
+    instances: [{
+      id: "codex_default",
+      driverKind: "codex",
+      displayName: "Codex",
+      availability: "available",
+      workspaceRequirement: "project_optional",
+      catalogRevision: "catalog_orchestrator",
+      models: [{
+        id: "gpt-5.6-sol",
+        displayName: "GPT-5.6-Sol",
+        availability: "available",
+        capabilities: ["reasoning", "tools"],
+        supportsVision: false,
+        supportsToolUse: true,
+      }],
+      options: [],
+      skills: [],
+      commands: [],
+      setupActions: [],
+      supports: {
+        rootChat: true,
+        resume: true,
+        cancellation: true,
+        attachments: ["file", "image", "structured_ref"],
+        tools: [],
+        approvals: true,
+        userInput: true,
+        worktrees: "optional",
+        resources: ["file", "folder", "project", "task", "app", "terminal_session"],
+        interactionModes: ["default"],
+        permissionModes: ["supervised"],
+      },
+    }],
+  });
+}
+
+function adapter(
+  start: CanonicalChatProviderAdapter<{ sessionId: string }>["start"],
+): CanonicalChatProviderAdapter<{ sessionId: string }> {
+  return {
+    driverKind: "codex",
+    stateSchemaVersion: 1,
+    parseState(value) {
+      if (!value || typeof value !== "object" || typeof (value as { sessionId?: unknown }).sessionId !== "string") {
+        throw new Error("invalid state");
+      }
+      return value as { sessionId: string };
+    },
+    serializeState: (value) => value,
+    start,
+  };
+}
+
+describe("CanonicalChatOrchestrator", () => {
+  let pglite: InstanceType<typeof KyselyPGlite>;
+  let repository: ChatRepository;
+
+  beforeEach(async () => {
+    pglite = await KyselyPGlite.create();
+    repository = new ChatRepository(pglite.dialect);
+    await repository.bootstrap();
+  });
+
+  afterEach(async () => {
+    await repository.kysely.destroy();
+  });
+
+  it("commits admission before Provider work, revalidates the root, and replays normalized output", async () => {
+    await repository.create(owner, {
+      id: "chat_orchestrated",
+      clientRequestId: "req_create_orchestrated",
+      title: "Orchestrated",
+      projectId: "project_matrix",
+    });
+    const resolve = vi.fn(async () => ({
+      ref: { kind: "project" as const, projectId: "project_matrix" },
+      fingerprint: "a".repeat(64),
+      primaryWorkspaceRoot: "/safe/project",
+      projectSlug: "matrix-os",
+    }));
+    const revalidate = vi.fn(async (_owner, provenance) => ({
+      ...provenance,
+      primaryWorkspaceRoot: "/safe/project",
+      projectSlug: "matrix-os",
+    }));
+    const roots: ChatExecutionRootResolver = { resolve, revalidate };
+    const sawCommittedAdmission = vi.fn();
+    const provider = adapter(async function* (input) {
+      const snapshot = await repository.exportChat(owner, input.chatId);
+      sawCommittedAdmission(snapshot?.runs[0]?.status, snapshot?.messages[0]?.role);
+      expect(input.executionRoot).toBe("/safe/project");
+      yield { type: "state.updated", state: { sessionId: "native_session" } };
+      yield { type: "assistant.delta", delta: "hello" };
+      yield { type: "assistant.delta", delta: " world" };
+      yield { type: "run.completed", outcome: "completed" };
+    });
+    const orchestrator = new CanonicalChatOrchestrator({
+      repository,
+      catalog: { getCatalog: async () => catalog() },
+      adapters: new CanonicalChatProviderRegistry([provider]),
+      executionRoots: roots,
+      now: () => new Date("2026-08-26T00:00:00.000Z"),
+    });
+
+    const admitted = await orchestrator.admitTurn(principal, owner, "chat_orchestrated", {
+      clientRequestId: "req_orchestrated_turn",
+      baseRevision: 0,
+      parts: [{ type: "text", text: "hello" }],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+      executionRoot: { kind: "project", projectId: "project_matrix" },
+    });
+    expect(admitted).toMatchObject({ admission: "accepted", run: { status: "accepted" } });
+    await orchestrator.drain();
+
+    expect(sawCommittedAdmission).toHaveBeenCalledWith("running", "user");
+    expect(resolve).toHaveBeenCalledWith(owner, { kind: "project", projectId: "project_matrix" });
+    expect(revalidate).toHaveBeenCalledWith(owner, {
+      ref: { kind: "project", projectId: "project_matrix" },
+      fingerprint: "a".repeat(64),
+    });
+    const snapshot = await repository.exportChat(owner, "chat_orchestrated");
+    expect(snapshot?.messages.map((message) => [message.role, message.state, message.parts]))
+      .toEqual([
+        ["user", "committed", [{ type: "text", text: "hello" }]],
+        ["assistant", "committed", [{ type: "text", text: "hello world" }]],
+      ]);
+    expect(snapshot?.runs[0]).toMatchObject({
+      status: "completed",
+      outcome: "completed",
+      executionRootFingerprint: "a".repeat(64),
+    });
+    expect(await repository.getAdapterState(owner, {
+      runId: admitted.run.id,
+      driverKind: "codex",
+      instanceId: "codex_default",
+    })).toEqual({ schemaVersion: 1, state: { sessionId: "native_session" } });
+    expect(snapshot?.activities.map((activity) => activity.type)).toEqual([
+      "run.status",
+      "turn.status",
+      "assistant.delta",
+      "assistant.delta",
+      "run.status",
+    ]);
+  });
+
+  it("aborts an active Run idempotently and does not persist late Provider output", async () => {
+    await repository.create(owner, {
+      id: "chat_cancelled",
+      clientRequestId: "req_create_cancelled",
+      title: "Cancelled",
+    });
+    const provider = adapter(async function* (input) {
+      await new Promise<void>((resolve) => input.signal.addEventListener("abort", () => resolve(), { once: true }));
+      yield { type: "assistant.delta", delta: "late output" };
+      yield { type: "run.completed", outcome: "aborted" };
+    });
+    const orchestrator = new CanonicalChatOrchestrator({
+      repository,
+      catalog: { getCatalog: async () => catalog() },
+      adapters: new CanonicalChatProviderRegistry([provider]),
+      now: () => new Date("2026-08-26T00:00:00.000Z"),
+    });
+    const admitted = await orchestrator.admitTurn(principal, owner, "chat_cancelled", {
+      clientRequestId: "req_cancelled_turn",
+      baseRevision: 0,
+      parts: [{ type: "text", text: "wait" }],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+    });
+
+    const cancelled = await orchestrator.cancelRun(owner, "chat_cancelled", admitted.run.id);
+    expect(cancelled).toMatchObject({ cancellation: "aborted", run: { status: "aborted" } });
+    const repeated = await orchestrator.cancelRun(owner, "chat_cancelled", admitted.run.id);
+    expect(repeated).toMatchObject({ cancellation: "already_terminal", run: { status: "aborted" } });
+    await orchestrator.drain();
+
+    const snapshot = await repository.exportChat(owner, "chat_cancelled");
+    expect(snapshot?.messages).toHaveLength(1);
+    expect(snapshot?.runs[0]).toMatchObject({ status: "aborted", outcome: "aborted" });
+    expect(snapshot?.activities.some((activity) =>
+      activity.type === "assistant.delta" && activity.delta === "late output"
+    )).toBe(false);
+  });
+
+  it("resumes later Turns only through the same adapter state schema and Instance", async () => {
+    await repository.create(owner, {
+      id: "chat_resumed",
+      clientRequestId: "req_create_resumed",
+      title: "Resumed",
+    });
+    const start = vi.fn(async function* () {
+      yield { type: "state.updated" as const, state: { sessionId: "native_resume" } };
+      yield { type: "assistant.delta" as const, delta: "first" };
+      yield { type: "run.completed" as const, outcome: "completed" as const };
+    });
+    const resume = vi.fn(async function* (input) {
+      expect(input.resumeState).toEqual({ sessionId: "native_resume" });
+      yield { type: "assistant.delta" as const, delta: "second" };
+      yield { type: "run.completed" as const, outcome: "completed" as const };
+    });
+    const provider = { ...adapter(start), resume };
+    const orchestrator = new CanonicalChatOrchestrator({
+      repository,
+      catalog: { getCatalog: async () => catalog() },
+      adapters: new CanonicalChatProviderRegistry([provider]),
+      now: () => new Date("2026-08-26T00:00:00.000Z"),
+    });
+
+    await orchestrator.admitTurn(principal, owner, "chat_resumed", {
+      clientRequestId: "req_resumed_first",
+      baseRevision: 0,
+      parts: [{ type: "text", text: "first" }],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+    });
+    await orchestrator.drain();
+    const afterFirst = await repository.get(owner, "chat_resumed");
+    expect(afterFirst).not.toBeNull();
+
+    await orchestrator.admitTurn(principal, owner, "chat_resumed", {
+      clientRequestId: "req_resumed_second",
+      baseRevision: afterFirst!.chat.revision,
+      parts: [{ type: "text", text: "second" }],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+    });
+    await orchestrator.drain();
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(resume).toHaveBeenCalledTimes(1);
+    const snapshot = await repository.exportChat(owner, "chat_resumed");
+    expect(snapshot?.messages.flatMap((message) =>
+      message.parts.flatMap((part) => part.type === "text" ? [part.text] : [])
+    )).toEqual(["first", "first", "second", "second"]);
+    expect(snapshot?.runs).toHaveLength(2);
+    expect(new Set(snapshot?.runs.map((run) => run.instanceId))).toEqual(new Set(["codex_default"]));
+  });
+
+  it("retries the same Turn as a new auditable Run without reusing failed output as input", async () => {
+    await repository.create(owner, {
+      id: "chat_retried",
+      clientRequestId: "req_create_retried",
+      title: "Retried",
+    });
+    let attempt = 0;
+    const provider = adapter(async function* () {
+      attempt += 1;
+      yield { type: "assistant.delta", delta: attempt === 1 ? "partial" : "recovered" };
+      yield { type: "run.completed", outcome: attempt === 1 ? "failed" : "completed" };
+    });
+    const orchestrator = new CanonicalChatOrchestrator({
+      repository,
+      catalog: { getCatalog: async () => catalog() },
+      adapters: new CanonicalChatProviderRegistry([provider]),
+      now: () => new Date("2026-08-26T00:00:00.000Z"),
+    });
+
+    const first = await orchestrator.admitTurn(principal, owner, "chat_retried", {
+      clientRequestId: "req_retried_turn",
+      baseRevision: 0,
+      parts: [{ type: "text", text: "try once" }],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+    });
+    await orchestrator.drain();
+    const failed = await repository.get(owner, "chat_retried");
+    expect(failed).not.toBeNull();
+
+    const retried = await orchestrator.retryTurn(
+      principal,
+      owner,
+      "chat_retried",
+      first.turn.id,
+      { clientRequestId: "req_retried_attempt_2", baseRevision: failed!.chat.revision },
+    );
+    expect(retried).toMatchObject({ admission: "accepted", run: { attempt: 2, status: "accepted" } });
+    await orchestrator.drain();
+
+    const snapshot = await repository.exportChat(owner, "chat_retried");
+    expect(snapshot?.turns).toHaveLength(1);
+    expect(snapshot?.runs.map((run) => [run.attempt, run.status])).toEqual([
+      [1, "failed"],
+      [2, "completed"],
+    ]);
+    expect(snapshot?.messages.map((message) => [message.seq, message.role, message.state])).toEqual([
+      [1, "user", "committed"],
+      [2, "assistant", "failed"],
+      [3, "assistant", "committed"],
+    ]);
+  });
+
+  it("reconciles accepted Runs after Gateway restart instead of guessing that a Provider is live", async () => {
+    await repository.create(owner, {
+      id: "chat_restarted",
+      clientRequestId: "req_create_restarted",
+      title: "Restarted",
+    });
+    const inputMessage = {
+      id: "msg_restarted",
+      chatId: "chat_restarted",
+      seq: 1,
+      role: "user" as const,
+      state: "committed" as const,
+      turnId: "cturn_restarted",
+      parts: [{ type: "text" as const, text: "continue after restart" }],
+      createdAt: "2026-08-26T00:00:00.000Z",
+    };
+    const inputTurn = {
+      id: "cturn_restarted",
+      chatId: "chat_restarted",
+      clientRequestId: "req_restarted_turn",
+      baseMessageSeq: 0,
+      inputMessageId: inputMessage.id,
+      status: "accepted" as const,
+      createdAt: "2026-08-26T00:00:00.000Z",
+      updatedAt: "2026-08-26T00:00:00.000Z",
+    };
+    await repository.admitTurn(owner, {
+      chatId: "chat_restarted",
+      baseRevision: 0,
+      message: inputMessage,
+      turn: inputTurn,
+      run: {
+        id: "run_restarted",
+        chatId: "chat_restarted",
+        turnId: inputTurn.id,
+        attempt: 1,
+        driverKind: "codex",
+        instanceId: "codex_default",
+        selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+        interactionMode: "default",
+        permissionMode: "supervised",
+        status: "accepted",
+        historyBoundarySeq: 0,
+        capabilitySnapshot: catalog().instances[0]!.supports && {
+          revision: "catalog_orchestrator",
+          ...catalog().instances[0]!.supports,
+        },
+        createdAt: "2026-08-26T00:00:00.000Z",
+        updatedAt: "2026-08-26T00:00:00.000Z",
+      },
+    });
+    const restarted = new CanonicalChatOrchestrator({
+      repository,
+      catalog: { getCatalog: async () => catalog() },
+      adapters: new CanonicalChatProviderRegistry([]),
+      now: () => new Date("2026-08-26T00:02:00.000Z"),
+    });
+
+    expect(await restarted.reconcileActiveRuns(owner)).toBe(1);
+    const snapshot = await repository.exportChat(owner, "chat_restarted");
+    expect(snapshot?.runs[0]).toMatchObject({ status: "failed", outcome: "failed" });
+    expect(snapshot?.activities).toEqual([
+      expect.objectContaining({
+        type: "run.error",
+        error: expect.objectContaining({ retryable: true, recoveryActions: ["retry"] }),
+      }),
+    ]);
+  });
+
+  it("limits one owner to eight concurrent Runs without consuming the global registry", async () => {
+    const provider = adapter(async function* (input) {
+      await new Promise<void>((resolve) => input.signal.addEventListener("abort", () => resolve(), { once: true }));
+      yield { type: "run.completed", outcome: "aborted" };
+    });
+    const orchestrator = new CanonicalChatOrchestrator({
+      repository,
+      catalog: { getCatalog: async () => catalog() },
+      adapters: new CanonicalChatProviderRegistry([provider]),
+      now: () => new Date("2026-08-26T00:00:00.000Z"),
+    });
+    for (let index = 0; index < 9; index += 1) {
+      await repository.create(owner, {
+        id: `chat_concurrent_${index}`,
+        clientRequestId: `req_create_concurrent_${index}`,
+        title: `Concurrent ${index}`,
+      });
+    }
+    for (let index = 0; index < 8; index += 1) {
+      await orchestrator.admitTurn(principal, owner, `chat_concurrent_${index}`, {
+        clientRequestId: `req_concurrent_turn_${index}`,
+        baseRevision: 0,
+        parts: [{ type: "text", text: `run ${index}` }],
+        selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+        interactionMode: "default",
+        permissionMode: "supervised",
+      });
+    }
+
+    try {
+      await expect(orchestrator.admitTurn(principal, owner, "chat_concurrent_8", {
+        clientRequestId: "req_concurrent_turn_8",
+        baseRevision: 0,
+        parts: [{ type: "text", text: "run 8" }],
+        selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+        interactionMode: "default",
+        permissionMode: "supervised",
+      })).rejects.toMatchObject({ safeError: { code: "run_unavailable" }, status: 503 });
+    } finally {
+      await orchestrator.close();
+    }
+    const rejected = await repository.exportChat(owner, "chat_concurrent_8");
+    expect(rejected?.runs[0]).toMatchObject({ status: "failed", outcome: "failed" });
+  });
+
+  it("bounds shutdown even when a Provider ignores cancellation", async () => {
+    await repository.create(owner, {
+      id: "chat_shutdown",
+      clientRequestId: "req_create_shutdown",
+      title: "Shutdown",
+    });
+    const provider = adapter(async function* () {
+      await new Promise<void>(() => undefined);
+      yield { type: "run.completed", outcome: "completed" };
+    });
+    const orchestrator = new CanonicalChatOrchestrator({
+      repository,
+      catalog: { getCatalog: async () => catalog() },
+      adapters: new CanonicalChatProviderRegistry([provider]),
+      shutdownDrainMs: 20,
+      now: () => new Date("2026-08-26T00:00:00.000Z"),
+    });
+    await orchestrator.admitTurn(principal, owner, "chat_shutdown", {
+      clientRequestId: "req_shutdown_turn",
+      baseRevision: 0,
+      parts: [{ type: "text", text: "hang" }],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+    });
+
+    const startedAt = Date.now();
+    await orchestrator.close();
+    expect(Date.now() - startedAt).toBeLessThan(500);
+    const snapshot = await repository.exportChat(owner, "chat_shutdown");
+    expect(snapshot?.runs[0]).toMatchObject({ status: "aborted", outcome: "aborted" });
+  });
+});

--- a/tests/gateway/chat-orchestrator.test.ts
+++ b/tests/gateway/chat-orchestrator.test.ts
@@ -666,6 +666,43 @@ describe("CanonicalChatOrchestrator", () => {
     expect(rejected?.runs[0]).toMatchObject({ status: "failed", outcome: "failed" });
   });
 
+  it("commits successful output when terminal activity exceeds the persisted limit", async () => {
+    await repository.create(owner, {
+      id: "chat_terminal_activity_overflow",
+      clientRequestId: "req_create_terminal_activity_overflow",
+      title: "Terminal activity overflow",
+    });
+    const provider = adapter(async function* () {
+      for (let index = 0; index < 498; index += 1) {
+        yield { type: "assistant.delta", delta: "x" };
+      }
+      yield { type: "run.completed", outcome: "completed" };
+    });
+    const orchestrator = new CanonicalChatOrchestrator({
+      repository,
+      catalog: { getCatalog: async () => catalog() },
+      adapters: new CanonicalChatProviderRegistry([provider]),
+      now: () => new Date("2026-08-26T00:00:00.000Z"),
+    });
+
+    await orchestrator.admitTurn(principal, owner, "chat_terminal_activity_overflow", {
+      clientRequestId: "req_terminal_activity_overflow_turn",
+      baseRevision: 0,
+      parts: [{ type: "text", text: "finish at the activity boundary" }],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+    });
+    await orchestrator.drain();
+
+    const snapshot = await repository.exportChat(owner, "chat_terminal_activity_overflow");
+    expect(snapshot?.runs[0]).toMatchObject({ status: "completed", outcome: "completed" });
+    expect(snapshot?.messages).toEqual(expect.arrayContaining([
+      expect.objectContaining({ role: "assistant", state: "committed", parts: [{ type: "text", text: "x".repeat(498) }] }),
+    ]));
+    expect(snapshot?.activities).toHaveLength(500);
+  });
+
   it("terminalizes a Run when normalized activity exceeds the persisted limit", async () => {
     await repository.create(owner, {
       id: "chat_activity_overflow",

--- a/tests/gateway/chat-provider-catalog.test.ts
+++ b/tests/gateway/chat-provider-catalog.test.ts
@@ -121,11 +121,7 @@ describe("canonical Chat Provider catalog", () => {
       .toMatchObject({
         driverKind: "hermes",
         availability: "available",
-        setupActions: [{
-          id: "hermes_settings",
-          kind: "open_settings",
-          label: "Configure Hermes",
-        }],
+        setupActions: [],
         defaultSelection: {
           instanceId: "hermes_default",
           model: "anthropic:claude-opus-4-6",
@@ -172,7 +168,7 @@ describe("canonical Chat Provider catalog", () => {
       .toEqual(new Set([catalog.revision]));
   });
 
-  it("fails a system harness closed until its own messaging authentication is configured", async () => {
+  it("keeps Matrix Chat kernel readiness independent from messaging authentication", async () => {
     const source: AgentRuntimeSource = async () => {
       const snapshot = await runtimeSource()();
       return {
@@ -191,10 +187,10 @@ describe("canonical Chat Provider catalog", () => {
     const hermes = (await service.getCatalog(principal)).instances
       .find((instance) => instance.id === "hermes_default")!;
 
-    expect(hermes.availability).toBe("auth_required");
-    expect(hermes.defaultSelection).toBeUndefined();
+    expect(hermes.availability).toBe("available");
+    expect(hermes.defaultSelection?.model).toBe("anthropic:claude-opus-4-6");
     expect(hermes.models).toEqual(expect.arrayContaining([
-      expect.objectContaining({ availability: "auth_required" }),
+      expect.objectContaining({ availability: "available" }),
     ]));
   });
 
@@ -251,10 +247,55 @@ describe("canonical Chat Provider catalog", () => {
 
     expect(catalog.instances.find((instance) => instance.id === "codex_default")?.availability)
       .toBe("available");
-    expect(catalog.instances.filter((instance) =>
-      instance.driverKind === "hermes" || instance.driverKind === "openclaw"
-    ).every((instance) => instance.availability === "unavailable")).toBe(true);
+    expect(catalog.instances.find((instance) => instance.driverKind === "hermes"))
+      .toMatchObject({
+        availability: "available",
+        models: expect.arrayContaining([expect.objectContaining({ id: "anthropic:claude-opus-4-6" })]),
+      });
+    expect(catalog.instances.find((instance) => instance.driverKind === "openclaw")?.availability)
+      .toBe("unavailable");
     expect(JSON.stringify(catalog)).not.toContain("secret runtime endpoint");
+  });
+
+  it("keeps the Matrix Chat kernel catalog separate from external Hermes messaging models", async () => {
+    const messagingOnly: AgentRuntimeSource = async () => {
+      const snapshot = await runtimeSource()(AbortSignal.timeout(1_000));
+      return {
+        ...snapshot,
+        providers: [{
+          id: "openai",
+          displayName: "OpenAI",
+          runtime: "hermes",
+          scopes: ["messaging"],
+          authKind: "api_key",
+          supportedAuthKinds: ["api_key"],
+          models: [{
+            id: "gpt-5",
+            displayName: "GPT-5",
+            capabilities: ["tools", "reasoning"],
+            efforts: ["high"],
+            available: true,
+          }],
+          authStatus: { state: "ready", authenticated: true, action: "none" },
+        }],
+        messaging: { runtime: "hermes", provider: "openai", model: "gpt-5", configured: true },
+      };
+    };
+    const service = createChatProviderCatalogService({
+      codingProviders: codingRegistry([]),
+      agentRuntimeSource: messagingOnly,
+    });
+
+    const hermes = (await service.getCatalog(principal)).instances
+      .find((instance) => instance.id === "hermes_default")!;
+
+    expect(hermes.models.map((model) => model.id)).toEqual([
+      "anthropic:claude-opus-4-6",
+      "anthropic:claude-sonnet-4-5",
+      "anthropic:claude-haiku-4-5",
+    ]);
+    expect(hermes.defaultSelection?.model).toBe("anthropic:claude-opus-4-6");
+    expect(JSON.stringify(hermes)).not.toContain("gpt-5");
   });
 
   it("keeps the active system runtime when coding inventory fails", async () => {

--- a/tests/gateway/chat-repository.test.ts
+++ b/tests/gateway/chat-repository.test.ts
@@ -131,6 +131,11 @@ describe("ChatRepository", () => {
       "chat_user_state",
       "chats",
     ]);
+    const activityIndex = await sql<{ indexname: string }>`
+      SELECT indexname FROM pg_indexes
+      WHERE schemaname = 'public' AND indexname = 'idx_chat_run_events_run_occurred'
+    `.execute(repository.kysely);
+    expect(activityIndex.rows).toEqual([{ indexname: "idx_chat_run_events_run_occurred" }]);
   });
 
   it("creates idempotently, isolates owners, and commits the outbox atomically", async () => {
@@ -312,6 +317,7 @@ describe("ChatRepository", () => {
       clientRequestId: "req_retry_attempt_2",
       baseRevision: beforeRetry!.chat.revision,
       run: retryRun,
+      adapterState: { schemaVersion: 1, state: { sessionId: "native_retry" } },
     });
     expect(admitted).toMatchObject({
       alreadyAccepted: false,
@@ -332,6 +338,59 @@ describe("ChatRepository", () => {
       run: { id: retryRun.id, attempt: 2 },
     });
     expect((await repository.exportChat(owner, chatId))?.messages).toHaveLength(1);
+    expect(await repository.getAdapterState(owner, {
+      runId: retryRun.id,
+      driverKind: retryRun.driverKind,
+      instanceId: retryRun.instanceId,
+    })).toEqual({ schemaVersion: 1, state: { sessionId: "native_retry" } });
+  });
+
+  it("rejects new Turn and retry admissions after a Chat is archived", async () => {
+    const chatId = "chat_archived_admission";
+    await repository.create(owner, {
+      id: chatId,
+      clientRequestId: "req_create_archived_admission",
+      title: "Archived admission",
+    });
+    const inputMessage = message(chatId);
+    const inputTurn = turn(chatId, inputMessage, "req_archived_seed");
+    const firstRun = run(chatId, inputTurn);
+    await repository.admitTurn(owner, {
+      chatId,
+      baseRevision: 0,
+      message: inputMessage,
+      turn: inputTurn,
+      run: firstRun,
+    });
+    await repository.finishRun(owner, {
+      chatId,
+      runId: firstRun.id,
+      outcome: "failed",
+      completedAt: now,
+    });
+    const beforeArchive = await repository.get(owner, chatId);
+    expect(beforeArchive).not.toBeNull();
+    const archived = await repository.update(owner, chatId, {
+      baseRevision: beforeArchive!.chat.revision,
+      lifecycle: "archived",
+    });
+
+    const nextMessage = message(chatId, 2);
+    const nextTurn = turn(chatId, nextMessage, "req_archived_new_turn");
+    await expect(repository.admitTurn(owner, {
+      chatId,
+      baseRevision: archived.chat.revision,
+      message: nextMessage,
+      turn: nextTurn,
+      run: run(chatId, nextTurn, 1),
+    })).rejects.toBeInstanceOf(ChatConflictError);
+    await expect(repository.admitRetry(owner, {
+      chatId,
+      turnId: inputTurn.id,
+      clientRequestId: "req_archived_retry",
+      baseRevision: archived.chat.revision,
+      run: run(chatId, inputTurn, 2),
+    })).rejects.toBeInstanceOf(ChatConflictError);
   });
 
   it("rejects a Turn whose input message does not belong to that Turn", async () => {

--- a/tests/gateway/chat-repository.test.ts
+++ b/tests/gateway/chat-repository.test.ts
@@ -551,6 +551,41 @@ describe("ChatRepository", () => {
     await expect(repository.search(otherOwner, "message", 200)).resolves.toEqual([]);
   });
 
+  it("returns the latest bounded detail page with an owner-isolated older-message cursor", async () => {
+    const created = await repository.create(owner, {
+      id: "chat_detail_page",
+      clientRequestId: "req_create_detail_page",
+      title: "Detail page",
+    });
+    await repository.kysely.insertInto("chat_messages").values(
+      [1, 2, 3].map((seq) => ({
+        id: `msg_detail_${seq}`,
+        chat_id: created.chat.id,
+        seq,
+        role: "assistant" as const,
+        state: "committed" as const,
+        turn_id: null,
+        run_id: null,
+        parts: sql`${JSON.stringify([{ type: "text", text: `detail ${seq}` }])}::jsonb`,
+        byte_count: 32,
+        search_text: `detail ${seq}`,
+        created_at: now,
+      })),
+    ).execute();
+
+    const latest = await repository.getDetailPage(owner, created.chat.id, { limit: 2 });
+    expect(latest?.messages.map((entry) => entry.seq)).toEqual([2, 3]);
+    expect(latest?.nextBeforeSeq).toBe(2);
+    const older = await repository.getDetailPage(owner, created.chat.id, {
+      limit: 2,
+      beforeSeq: latest?.nextBeforeSeq,
+    });
+    expect(older?.messages.map((entry) => entry.seq)).toEqual([1]);
+    expect(older?.nextBeforeSeq).toBeUndefined();
+    await expect(repository.getDetailPage(otherOwner, created.chat.id, { limit: 2 }))
+      .resolves.toBeNull();
+  });
+
   it("hard-deletes all content once and preserves only a content-free tombstone", async () => {
     const created = await repository.create(owner, {
       id: "chat_delete",

--- a/tests/gateway/chat-repository.test.ts
+++ b/tests/gateway/chat-repository.test.ts
@@ -254,7 +254,8 @@ describe("ChatRepository", () => {
       adapterState: { schemaVersion: 1, state: { session: "opaque" } },
     });
 
-    expect(repeated).toEqual(first);
+    expect(first.alreadyAccepted).toBe(false);
+    expect(repeated).toEqual({ ...first, alreadyAccepted: true });
     expect((await repository.get(owner, created.chat.id))?.chat).toMatchObject({ revision: 1, messageCount: 1 });
     expect((await repository.get(owner, created.chat.id))?.activeRun).toEqual({
       runId: acceptedRun.id,
@@ -276,6 +277,61 @@ describe("ChatRepository", () => {
       turn: secondTurn,
       run: run(created.chat.id, secondTurn, 2),
     })).rejects.toBeInstanceOf(ChatBusyError);
+  });
+
+  it("admits an idempotent retry as a new Run attempt without duplicating the Turn input", async () => {
+    const chatId = "chat_retry_attempt";
+    await repository.create(owner, {
+      id: chatId,
+      clientRequestId: "req_create_retry_attempt",
+      title: "Retry attempt",
+    });
+    const inputMessage = message(chatId);
+    const inputTurn = turn(chatId, inputMessage, "req_retry_turn");
+    const firstRun = run(chatId, inputTurn);
+    await repository.admitTurn(owner, {
+      chatId,
+      baseRevision: 0,
+      message: inputMessage,
+      turn: inputTurn,
+      run: firstRun,
+    });
+    await repository.finishRun(owner, {
+      chatId,
+      runId: firstRun.id,
+      outcome: "failed",
+      completedAt: now,
+    });
+    const beforeRetry = await repository.get(owner, chatId);
+    expect(beforeRetry).not.toBeNull();
+
+    const retryRun = run(chatId, inputTurn, 2);
+    const admitted = await repository.admitRetry(owner, {
+      chatId,
+      turnId: inputTurn.id,
+      clientRequestId: "req_retry_attempt_2",
+      baseRevision: beforeRetry!.chat.revision,
+      run: retryRun,
+    });
+    expect(admitted).toMatchObject({
+      alreadyAccepted: false,
+      run: { id: retryRun.id, attempt: 2, status: "accepted" },
+      turn: { id: inputTurn.id, status: "accepted" },
+      chat: { chat: { messageCount: 1 } },
+    });
+
+    const duplicate = await repository.admitRetry(owner, {
+      chatId,
+      turnId: inputTurn.id,
+      clientRequestId: "req_retry_attempt_2",
+      baseRevision: beforeRetry!.chat.revision,
+      run: { ...retryRun, id: "run_retry_duplicate" },
+    });
+    expect(duplicate).toMatchObject({
+      alreadyAccepted: true,
+      run: { id: retryRun.id, attempt: 2 },
+    });
+    expect((await repository.exportChat(owner, chatId))?.messages).toHaveLength(1);
   });
 
   it("rejects a Turn whose input message does not belong to that Turn", async () => {
@@ -413,6 +469,72 @@ describe("ChatRepository", () => {
     expect((await repository.replayOutbox(owner, { afterCursor: 0, limit: 10 })).at(-1)).toMatchObject({
       eventType: "run.completed",
     });
+  });
+
+  it("commits assistant output with the terminal transition and rejects late Provider events", async () => {
+    const created = await repository.create(owner, {
+      id: "chat_terminal_output",
+      clientRequestId: "req_create_terminal_output",
+      title: "Terminal output",
+    });
+    const input = message(created.chat.id);
+    const acceptedTurn = turn(created.chat.id, input);
+    const acceptedRun = run(created.chat.id, acceptedTurn);
+    await repository.admitTurn(owner, {
+      chatId: created.chat.id,
+      baseRevision: 0,
+      message: input,
+      turn: acceptedTurn,
+      run: acceptedRun,
+      adapterState: { schemaVersion: 1, state: { sessionId: "native_1" } },
+    });
+
+    await repository.markRunRunning(owner, {
+      chatId: created.chat.id,
+      runId: acceptedRun.id,
+      startedAt: "2026-08-25T00:00:30.000Z",
+    });
+    await repository.updateAdapterState(owner, {
+      chatId: created.chat.id,
+      runId: acceptedRun.id,
+      driverKind: "codex",
+      instanceId: "codex_default",
+      schemaVersion: 1,
+      state: { sessionId: "native_2" },
+    });
+    const assistant: CanonicalChatMessage = {
+      id: "msg_terminal_output_assistant",
+      chatId: created.chat.id,
+      seq: 2,
+      role: "assistant",
+      state: "committed",
+      turnId: acceptedTurn.id,
+      runId: acceptedRun.id,
+      parts: [{ type: "text", text: "done" }],
+      createdAt: "2026-08-25T00:01:00.000Z",
+    };
+    await repository.finishRun(owner, {
+      chatId: created.chat.id,
+      runId: acceptedRun.id,
+      outcome: "completed",
+      completedAt: assistant.createdAt,
+      output: assistant,
+    });
+
+    const snapshot = await repository.exportChat(owner, created.chat.id);
+    expect(snapshot?.messages).toEqual([input, assistant]);
+    expect(snapshot?.turns[0]).toMatchObject({ status: "completed" });
+    expect(snapshot?.runs[0]).toMatchObject({ status: "completed", outcome: "completed" });
+    expect(snapshot?.chat.chat).toMatchObject({ messageCount: 2, lastMessagePreview: "done" });
+    expect(await repository.getAdapterState(owner, {
+      runId: acceptedRun.id,
+      driverKind: "codex",
+      instanceId: "codex_default",
+    })).toEqual({ schemaVersion: 1, state: { sessionId: "native_2" } });
+
+    await expect(repository.appendRunActivities(owner, created.chat.id, acceptedRun.id, [
+      activity(created.chat.id, acceptedRun.id, 99),
+    ])).rejects.toMatchObject({ name: "ChatRunNotActiveError" });
   });
 
   it("charges the Run event limit only for unseen activity IDs", async () => {

--- a/tests/gateway/chat-routes.test.ts
+++ b/tests/gateway/chat-routes.test.ts
@@ -1,4 +1,7 @@
 import {
+  CanonicalChatRunCancellationResponseSchema,
+  CanonicalChatRunAdmissionResponseSchema,
+  CanonicalChatTurnAdmissionResponseSchema,
   CanonicalChatDetailResponseSchema,
   CanonicalChatListResponseSchema,
   CanonicalChatRecordSchema,
@@ -43,6 +46,15 @@ function routeService(overrides: Partial<CanonicalChatRouteService> = {}): Canon
       runs: [],
       activities: [],
     })),
+    admitTurn: vi.fn(async () => {
+      throw new Error("not configured");
+    }),
+    cancelRun: vi.fn(async () => {
+      throw new Error("not configured");
+    }),
+    retryTurn: vi.fn(async () => {
+      throw new Error("not configured");
+    }),
     ...overrides,
   };
 }
@@ -188,5 +200,146 @@ describe("canonical Chat routes", () => {
     } finally {
       await repository.kysely.destroy();
     }
+  });
+
+  it("admits and cancels a Run through strict owner-derived routes", async () => {
+    const admission = CanonicalChatTurnAdmissionResponseSchema.parse({
+      record: {
+        ...record,
+        chat: {
+          ...record.chat,
+          revision: 1,
+          messageCount: 1,
+          currentSelection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+        },
+        providerBinding: {
+          driverKind: "codex",
+          instanceId: "codex_default",
+          lockedAtTurnId: "cturn_route",
+        },
+        activeRun: { runId: "run_route", turnId: "cturn_route", status: "accepted" },
+      },
+      message: {
+        id: "msg_route",
+        chatId: record.chat.id,
+        seq: 1,
+        role: "user",
+        state: "committed",
+        turnId: "cturn_route",
+        parts: [{ type: "text", text: "ship it" }],
+        createdAt: "2026-08-26T00:00:00.000Z",
+      },
+      turn: {
+        id: "cturn_route",
+        chatId: record.chat.id,
+        clientRequestId: "req_route_turn",
+        baseMessageSeq: 0,
+        inputMessageId: "msg_route",
+        status: "accepted",
+        createdAt: "2026-08-26T00:00:00.000Z",
+        updatedAt: "2026-08-26T00:00:00.000Z",
+      },
+      run: {
+        id: "run_route",
+        chatId: record.chat.id,
+        turnId: "cturn_route",
+        attempt: 1,
+        driverKind: "codex",
+        instanceId: "codex_default",
+        selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+        interactionMode: "default",
+        permissionMode: "supervised",
+        status: "accepted",
+        historyBoundarySeq: 0,
+        capabilitySnapshot: {
+          revision: "catalog_route",
+          rootChat: true,
+          attachments: ["file"],
+          resources: ["file", "folder", "project"],
+          tools: [],
+          approvals: true,
+          userInput: true,
+          resume: true,
+          cancellation: true,
+          worktrees: "optional",
+          interactionModes: ["default"],
+          permissionModes: ["supervised"],
+        },
+        createdAt: "2026-08-26T00:00:00.000Z",
+        updatedAt: "2026-08-26T00:00:00.000Z",
+      },
+      admission: "accepted",
+    });
+    const cancellation = CanonicalChatRunCancellationResponseSchema.parse({
+      run: {
+        ...admission.run,
+        status: "aborted",
+        outcome: "aborted",
+        startedAt: "2026-08-26T00:00:00.000Z",
+        completedAt: "2026-08-26T00:01:00.000Z",
+        updatedAt: "2026-08-26T00:01:00.000Z",
+      },
+      cancellation: "aborted",
+    });
+    const admitTurn = vi.fn(async () => admission);
+    const cancelRun = vi.fn(async () => cancellation);
+    const retryAdmission = CanonicalChatRunAdmissionResponseSchema.parse({
+      record: admission.record,
+      turn: admission.turn,
+      run: { ...admission.run, id: "run_route_retry", attempt: 2 },
+      admission: "accepted",
+    });
+    const retryTurn = vi.fn(async () => retryAdmission);
+    const app = appFor(routeService({ admitTurn, cancelRun, retryTurn }));
+
+    const accepted = await app.request("/api/chats/chat_route_test/turns", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        clientRequestId: "req_route_turn",
+        baseRevision: 0,
+        parts: [{ type: "text", text: "ship it" }],
+        selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+        interactionMode: "default",
+        permissionMode: "supervised",
+      }),
+    });
+    expect(accepted.status).toBe(202);
+    expect(await accepted.json()).toEqual(admission);
+    expect(admitTurn).toHaveBeenCalledWith(
+      { userId: "owner_1", source: "jwt" },
+      { type: "personal", ownerId: "owner_1" },
+      "chat_route_test",
+      expect.objectContaining({ clientRequestId: "req_route_turn" }),
+    );
+
+    const cancelled = await app.request("/api/chats/chat_route_test/runs/run_route/cancel", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ clientRequestId: "req_route_cancel" }),
+    });
+    expect(cancelled.status).toBe(200);
+    expect(await cancelled.json()).toEqual(cancellation);
+    expect(cancelRun).toHaveBeenCalledWith(
+      { type: "personal", ownerId: "owner_1" },
+      "chat_route_test",
+      "run_route",
+      { clientRequestId: "req_route_cancel" },
+    );
+
+    const retried = await app.request("/api/chats/chat_route_test/turns/cturn_route/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ clientRequestId: "req_route_retry", baseRevision: 2 }),
+    });
+    expect(retried.status).toBe(202);
+    expect(await retried.json()).toEqual(retryAdmission);
+    expect(retryTurn).toHaveBeenCalledWith(
+      { userId: "owner_1", source: "jwt" },
+      { type: "personal", ownerId: "owner_1" },
+      "chat_route_test",
+      "cturn_route",
+      { clientRequestId: "req_route_retry", baseRevision: 2 },
+    );
   });
 });

--- a/tests/gateway/chat-routes.test.ts
+++ b/tests/gateway/chat-routes.test.ts
@@ -1,0 +1,143 @@
+import type {
+  CanonicalChatDetailResponse,
+  CanonicalChatListResponse,
+  CanonicalChatRecord,
+  CanonicalCreateChatRequest,
+} from "@matrix-os/contracts";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createCanonicalChatRoutes,
+  type CanonicalChatRouteService,
+} from "../../packages/gateway/src/chat/routes.js";
+import type { ChatOwner } from "../../packages/gateway/src/chat/records.js";
+
+const record: CanonicalChatRecord = {
+  chat: {
+    id: "chat_route_test",
+    ownerScope: { type: "personal", ownerId: "owner_1" },
+    title: "Route test",
+    lifecycle: "active",
+    attention: "none",
+    revision: 0,
+    messageCount: 0,
+    createdAt: "2026-08-25T12:00:00.000Z",
+    updatedAt: "2026-08-25T12:00:00.000Z",
+  },
+};
+
+function routeService(overrides: Partial<CanonicalChatRouteService> = {}): CanonicalChatRouteService {
+  return {
+    create: vi.fn(async () => record),
+    list: vi.fn(async () => ({ items: [record] })),
+    getDetail: vi.fn(async () => ({
+      record,
+      messages: [],
+      turns: [],
+      runs: [],
+      activities: [],
+    })),
+    ...overrides,
+  };
+}
+
+function appFor(service: CanonicalChatRouteService) {
+  return new Hono().route("/", createCanonicalChatRoutes({
+    service,
+    getPrincipal: () => ({ userId: "owner_1", source: "jwt" }),
+  }));
+}
+
+describe("canonical Chat routes", () => {
+  it("derives personal ownership and creates a Chat through the shared service", async () => {
+    const create = vi.fn(async (_owner: ChatOwner, _input: CanonicalCreateChatRequest) => record);
+    const service = routeService({ create });
+
+    const response = await appFor(service).request("/api/chats", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        clientRequestId: "req_route_test",
+        title: "Route test",
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toEqual(record);
+    expect(create).toHaveBeenCalledWith(
+      { type: "personal", ownerId: "owner_1" },
+      { clientRequestId: "req_route_test", title: "Route test" },
+    );
+  });
+
+  it("rejects client-controlled ownership and oversized create bodies", async () => {
+    const app = appFor(routeService());
+    const invalid = await app.request("/api/chats", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        clientRequestId: "req_route_test",
+        title: "Route test",
+        ownerScope: { type: "personal", ownerId: "other_owner" },
+      }),
+    });
+    expect(invalid.status).toBe(400);
+
+    const oversized = await app.request("/api/chats", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        clientRequestId: "req_route_test",
+        title: "x".repeat(97 * 1024),
+      }),
+    });
+    expect(oversized.status).toBe(413);
+  });
+
+  it("passes bounded filters to list and returns an opaque cursor page", async () => {
+    const page: CanonicalChatListResponse = { items: [record], nextCursor: "chatcur_next" };
+    const list = vi.fn(async () => page);
+    const response = await appFor(routeService({ list })).request(
+      "/api/chats?limit=25&lifecycle=active&projectId=project_1&cursor=chatcur_prev",
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(page);
+    expect(list).toHaveBeenCalledWith(
+      { type: "personal", ownerId: "owner_1" },
+      { limit: 25, lifecycle: "active", projectId: "project_1", cursor: "chatcur_prev" },
+    );
+  });
+
+  it("returns bounded detail and hides other-owner Chats as not found", async () => {
+    const detail: CanonicalChatDetailResponse = {
+      record,
+      messages: [],
+      turns: [],
+      runs: [],
+      activities: [],
+    };
+    const getDetail = vi.fn(async () => detail);
+    const response = await appFor(routeService({ getDetail })).request(
+      "/api/chats/chat_route_test?limit=100",
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(detail);
+    expect(getDetail).toHaveBeenCalledWith(
+      { type: "personal", ownerId: "owner_1" },
+      "chat_route_test",
+      { limit: 100 },
+    );
+
+    const missing = await appFor(routeService({ getDetail: vi.fn(async () => null) }))
+      .request("/api/chats/chat_route_test");
+    expect(missing.status).toBe(404);
+    expect(await missing.json()).toEqual({
+      error: {
+        code: "chat_not_found",
+        safeMessage: "Chat not found.",
+        retryable: false,
+      },
+    });
+  });
+});

--- a/tests/gateway/chat-routes.test.ts
+++ b/tests/gateway/chat-routes.test.ts
@@ -1,16 +1,22 @@
-import type {
-  CanonicalChatDetailResponse,
-  CanonicalChatListResponse,
-  CanonicalChatRecord,
-  CanonicalCreateChatRequest,
+import {
+  CanonicalChatDetailResponseSchema,
+  CanonicalChatListResponseSchema,
+  CanonicalChatRecordSchema,
+  type CanonicalChatDetailResponse,
+  type CanonicalChatListResponse,
+  type CanonicalChatRecord,
+  type CanonicalCreateChatRequest,
 } from "@matrix-os/contracts";
 import { Hono } from "hono";
+import { KyselyPGlite } from "kysely-pglite";
 import { describe, expect, it, vi } from "vitest";
+import { ChatRepository } from "../../packages/gateway/src/chat/repository.js";
 import {
   createCanonicalChatRoutes,
   type CanonicalChatRouteService,
 } from "../../packages/gateway/src/chat/routes.js";
 import type { ChatOwner } from "../../packages/gateway/src/chat/records.js";
+import { createCanonicalChatService } from "../../packages/gateway/src/chat/service.js";
 
 const record: CanonicalChatRecord = {
   chat: {
@@ -139,5 +145,48 @@ describe("canonical Chat routes", () => {
         retryable: false,
       },
     });
+  });
+
+  it("runs create, list, and detail through the real repository while isolating owners", async () => {
+    const pglite = await KyselyPGlite.create();
+    const repository = new ChatRepository(pglite.dialect);
+    await repository.bootstrap();
+
+    const service = createCanonicalChatService(repository);
+    const ownerApp = new Hono().route("/", createCanonicalChatRoutes({
+      service,
+      getPrincipal: () => ({ userId: "owner_integration", source: "jwt" }),
+    }));
+    const otherOwnerApp = new Hono().route("/", createCanonicalChatRoutes({
+      service,
+      getPrincipal: () => ({ userId: "other_owner", source: "jwt" }),
+    }));
+
+    try {
+      const createdResponse = await ownerApp.request("/api/chats", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          clientRequestId: "req_gateway_integration",
+          title: "Gateway integration",
+        }),
+      });
+      expect(createdResponse.status).toBe(201);
+      const created = CanonicalChatRecordSchema.parse(await createdResponse.json());
+      expect(created.chat.id).toMatch(/^chat_[a-f0-9]{32}$/);
+      expect(created.chat.ownerScope).toEqual({ type: "personal", ownerId: "owner_integration" });
+
+      const listResponse = await ownerApp.request("/api/chats");
+      expect(listResponse.status).toBe(200);
+      expect(CanonicalChatListResponseSchema.parse(await listResponse.json()).items).toEqual([created]);
+
+      const detailResponse = await ownerApp.request(`/api/chats/${created.chat.id}`);
+      expect(detailResponse.status).toBe(200);
+      expect(CanonicalChatDetailResponseSchema.parse(await detailResponse.json()).record).toEqual(created);
+
+      expect((await otherOwnerApp.request(`/api/chats/${created.chat.id}`)).status).toBe(404);
+    } finally {
+      await repository.kysely.destroy();
+    }
   });
 });

--- a/tests/gateway/chat-service.test.ts
+++ b/tests/gateway/chat-service.test.ts
@@ -81,6 +81,19 @@ describe("canonical Chat service", () => {
     });
   });
 
+  it("normalizes malformed opaque cursor payloads as validation errors", async () => {
+    const repository = {
+      create: vi.fn(),
+      list: vi.fn(),
+      getDetailPage: vi.fn(),
+    };
+    const service = createCanonicalChatService(repository as never);
+
+    await expect(service.list(owner, { limit: 25, cursor: "chatcur_ew" }))
+      .rejects.toMatchObject({ issues: expect.any(Array) });
+    expect(repository.list).not.toHaveBeenCalled();
+  });
+
   it("binds older-message cursors to the requested Chat", async () => {
     const getDetailPage = vi.fn()
       .mockResolvedValueOnce({

--- a/tests/gateway/chat-service.test.ts
+++ b/tests/gateway/chat-service.test.ts
@@ -1,0 +1,118 @@
+import type { CanonicalChatRecord } from "@matrix-os/contracts";
+import { describe, expect, it, vi } from "vitest";
+import { createCanonicalChatService } from "../../packages/gateway/src/chat/service.js";
+import type {
+  ChatDetailPage,
+  ChatListPage,
+  ChatRepository,
+} from "../../packages/gateway/src/chat/repository.js";
+
+const owner = { type: "personal" as const, ownerId: "owner_1" };
+
+function record(id = "chat_service_test"): CanonicalChatRecord {
+  return {
+    chat: {
+      id,
+      ownerScope: owner,
+      title: "Service test",
+      lifecycle: "active",
+      attention: "none",
+      revision: 0,
+      messageCount: 0,
+      createdAt: "2026-08-25T12:00:00.000Z",
+      updatedAt: "2026-08-25T12:00:00.000Z",
+    },
+  };
+}
+
+function repository(overrides: Partial<Pick<ChatRepository, "create" | "list" | "getDetailPage">> = {}) {
+  return {
+    create: vi.fn(async () => record()),
+    list: vi.fn(async () => ({ items: [record()] } satisfies ChatListPage)),
+    getDetailPage: vi.fn(async () => ({
+      record: record(),
+      messages: [],
+      turns: [],
+      runs: [],
+      activities: [],
+    } satisfies ChatDetailPage)),
+    ...overrides,
+  } as Pick<ChatRepository, "create" | "list" | "getDetailPage">;
+}
+
+describe("canonical Chat service", () => {
+  it("generates server-owned Chat ids and a bounded default title", async () => {
+    const create = vi.fn(async (_owner, input) => record(input.id));
+    const repo = repository({ create });
+    const service = createCanonicalChatService(repo);
+
+    const created = await service.create(owner, { clientRequestId: "req_service_create" });
+
+    expect(created.chat.id).toMatch(/^chat_[A-Za-z0-9_-]+$/);
+    expect(create).toHaveBeenCalledWith(owner, expect.objectContaining({
+      id: created.chat.id,
+      clientRequestId: "req_service_create",
+      title: "New chat",
+    }));
+  });
+
+  it("round-trips opaque list cursors without exposing repository cursor fields", async () => {
+    const list = vi.fn()
+      .mockResolvedValueOnce({
+        items: [record()],
+        nextCursor: {
+          updatedAt: "2026-08-25T12:00:00.123456Z",
+          chatId: "chat_service_test",
+        },
+      } satisfies ChatListPage)
+      .mockResolvedValueOnce({ items: [] } satisfies ChatListPage);
+    const service = createCanonicalChatService(repository({ list }));
+
+    const first = await service.list(owner, { limit: 25 });
+    expect(first.nextCursor).toMatch(/^chatcur_[A-Za-z0-9_-]+$/);
+    expect(first.nextCursor).not.toContain("updatedAt");
+    await service.list(owner, { limit: 25, cursor: first.nextCursor });
+    expect(list).toHaveBeenLastCalledWith(owner, {
+      limit: 25,
+      cursor: {
+        updatedAt: "2026-08-25T12:00:00.123456Z",
+        chatId: "chat_service_test",
+      },
+    });
+  });
+
+  it("binds older-message cursors to the requested Chat", async () => {
+    const getDetailPage = vi.fn()
+      .mockResolvedValueOnce({
+        record: record(),
+        messages: [],
+        turns: [],
+        runs: [],
+        activities: [],
+        nextBeforeSeq: 41,
+      } satisfies ChatDetailPage)
+      .mockResolvedValueOnce({
+        record: record(),
+        messages: [],
+        turns: [],
+        runs: [],
+        activities: [],
+      } satisfies ChatDetailPage);
+    const service = createCanonicalChatService(repository({ getDetailPage }));
+
+    const first = await service.getDetail(owner, "chat_service_test", { limit: 100 });
+    expect(first?.nextCursor).toMatch(/^chatcur_[A-Za-z0-9_-]+$/);
+    await service.getDetail(owner, "chat_service_test", {
+      limit: 100,
+      cursor: first?.nextCursor,
+    });
+    expect(getDetailPage).toHaveBeenLastCalledWith(owner, "chat_service_test", {
+      limit: 100,
+      beforeSeq: 41,
+    });
+    await expect(service.getDetail(owner, "chat_other", {
+      limit: 100,
+      cursor: first?.nextCursor,
+    })).rejects.toThrow();
+  });
+});

--- a/tests/gateway/coding-agents-thread-stream.test.ts
+++ b/tests/gateway/coding-agents-thread-stream.test.ts
@@ -287,7 +287,7 @@ describe("coding agent thread stream", () => {
   it("rejects extra stream sink registrations instead of detaching existing streams silently", async () => {
     const { threads } = await createHarness();
 
-    for (let index = 0; index < 7; index += 1) {
+    for (let index = 0; index < 71; index += 1) {
       createCodingAgentThreadStream({ threads });
     }
 

--- a/tests/gateway/coding-agents-threads.test.ts
+++ b/tests/gateway/coding-agents-threads.test.ts
@@ -81,6 +81,14 @@ function workspaceSessionIdForThread(threadId: string): string {
 }
 
 describe("coding agent thread lifecycle", () => {
+  it("reserves enough bounded event sinks for canonical Chat Runs", async () => {
+    const { threads } = await createHarness();
+    const subscriptions = Array.from({ length: 72 }, () => threads.registerEventSink(() => undefined));
+
+    expect(() => threads.registerEventSink(() => undefined)).toThrow("Too many thread event sinks");
+    for (const subscription of subscriptions) subscription.dispose();
+  });
+
   it("blocks project cleanup on active threads and deletes only the owner's terminal project history", async () => {
     const { threads } = await createHarness();
     const owner = await threads.createThread(ownerPrincipal, createBody);


### PR DESCRIPTION
## Summary

- add canonical Turn admission, Run retry/cancellation, restart reconciliation, and typed Desktop client operations
- execute Hermes, Codex, and Claude behind one provider-neutral orchestration boundary with immutable Driver and Instance binding
- harden resume, overflow, cancellation, shutdown, archived-Chat, execution-root, and activity-limit invariants through Greptile review

## Invariants

- **source of truth:** owner-local Postgres/Kysely canonical Chat, Turn, Run, activity, adapter-state, and outbox records; the legacy coding thread is only a temporary adapter-internal execution seam
- **lock/transaction scope:** admission and retry serialize on the Chat row and atomically insert the user message, Turn, Run, binding, resume envelope, and outbox event; terminal writes serialize on the same Chat row; external Provider execution happens outside database locks
- **acceptable orphan states:** accepted/running Runs are reconciled to safe failed/interrupted semantics after Gateway restart; pending dispatch reservations protect newly committed Runs until local registration; activity saturation cannot block a successful terminal Run write; retry creates a new auditable Run for the same Turn; late callbacks are rejected and cancellation is idempotent
- **auth source of truth:** a verified `RequestPrincipal` derives the owner; clients cannot submit owner identity, filesystem paths, resume state, credentials, or runtime identity
- **execution-root provenance:** Project Chats cannot execute against another Project, explicit roots are revalidated immediately before Provider work, and native Provider state resumes only when its schema and execution-root fingerprint match
- **bounds:** at most 8 active Runs per owner and 64 per Gateway, 500 buffered Provider events, 72 shared coding event sinks, 96 KiB assistant output, and one bounded 10-second shutdown deadline across cancellation and drain
- **mainline integration:** this PR is directly based on current `main`, including the merged MAT-347 persistence and MAT-476 shared Chat surface foundations

## Provider adapters

- Hermes reuses the Matrix kernel `Dispatcher`, exposes the kernel model/effort options, and aborts the underlying dispatch on bounded-queue overflow
- Codex and Claude reuse the existing Gateway coding runtime and event seam; bounded replay can fall back to the already-registered live sink when `turn.accepted` has aged out
- the canonical catalog validates the requested model before dispatch; the legacy coding seam currently launches the Provider's configured default because its create request has no model field

## Deferred scope

- MAT-480 Global Chat and Project Chat domain integration
- MAT-479 legacy coding-thread migration and removal
- OpenCode/Pi adapters, organization scope, and the private public-docs site update after acceptance

## Verification

- exact head: `b93371bd583b0ca9c8a79df9e28fc7ab4d4e1f57`
- Human Review approved by the feature owner
- Greptile exact-head check: **37 files reviewed, 0 comments added**; GitHub review threads: **0 unresolved (9 total)**
- the exact-head P1 activity-limit regression was reproduced with a boundary test and fixed so successful output still commits when persisted activity reaches the 500-event cap
- 15 focused canonical Chat and adjacent stream files: **143/143 passed**
- full typecheck, pattern gate (0 violations), and `git diff --check` passed
- exact-head Claude review and Codex provider contract checks passed
- exact-head Preview bundle and deploy passed: https://github.com/HamedMP/matrix-os/actions/runs/32921672274
- Preview: https://app.matrix-os.com/vm/pr-1327

## Expedited merge note

The feature owner explicitly approved merging without waiting for an additional Nima review because of the launch timeline. Human Review, exact-head Greptile, resolved review threads, CI contracts, and Preview VPS verification still completed before merge.

Linear: MAT-477
