### PR TITLE
feat(gateway): resolve canonical Chat execution roots

### DIFF
--- a/packages/gateway/src/chat/execution-root.ts
+++ b/packages/gateway/src/chat/execution-root.ts
@@ -1,0 +1,237 @@
+import { createHash } from "node:crypto";
+import { lstat, realpath } from "node:fs/promises";
+import {
+  CanonicalChatExecutionRootRefSchema,
+  CanonicalOwnerScopeSchema,
+  type CanonicalChatExecutionRootRef,
+  type CanonicalOwnerScope,
+} from "@matrix-os/contracts";
+import type { OwnerScope } from "../state-ops.js";
+
+export interface ChatExecutionRootProject {
+  id: string;
+  slug: string;
+  localPath: string;
+}
+
+export interface ChatExecutionRootWorktree {
+  id: string;
+  projectSlug: string;
+  path: string;
+  createdAt: string;
+}
+
+export interface ChatExecutionRootProjectSource<Project extends ChatExecutionRootProject> {
+  getProjectById(
+    ownerScope: OwnerScope,
+    projectId: string,
+  ): Promise<
+    | { ok: true; project: Project }
+    | { ok: false; status: number; error: unknown }
+  >;
+  resolveProjectWorkingDirectory(project: Project): Promise<string | null>;
+}
+
+export interface ChatExecutionRootWorktreeSource<Worktree extends ChatExecutionRootWorktree> {
+  getWorktree(
+    projectSlug: string,
+    worktreeId: string,
+    ownerScope: OwnerScope,
+  ): Promise<
+    | { ok: true; worktree: Worktree }
+    | { ok: false; status: number; error: unknown }
+  >;
+}
+
+export interface ChatExecutionRootProvenance {
+  ref: CanonicalChatExecutionRootRef;
+  fingerprint: string;
+}
+
+export interface ResolvedChatExecutionRoot extends ChatExecutionRootProvenance {
+  /** Gateway-only derived value. Never persist or project this path to a client. */
+  primaryWorkspaceRoot: string;
+}
+
+export interface ChatExecutionRootResolver {
+  resolve(
+    ownerScope: CanonicalOwnerScope,
+    ref: CanonicalChatExecutionRootRef,
+  ): Promise<ResolvedChatExecutionRoot>;
+  revalidate(
+    ownerScope: CanonicalOwnerScope,
+    provenance: ChatExecutionRootProvenance,
+  ): Promise<ResolvedChatExecutionRoot>;
+}
+
+export class ChatExecutionRootError extends Error {
+  constructor(readonly code: "invalid_root" | "root_changed" | "validation_unavailable") {
+    super(code);
+    this.name = "ChatExecutionRootError";
+  }
+}
+
+function projectOwnerScope(ownerInput: CanonicalOwnerScope): OwnerScope {
+  const owner = CanonicalOwnerScopeSchema.parse(ownerInput);
+  return {
+    type: owner.type === "organization" ? "org" : "user",
+    id: owner.ownerId,
+  };
+}
+
+function dependencyError(status: number): ChatExecutionRootError {
+  return new ChatExecutionRootError(status >= 500 ? "validation_unavailable" : "invalid_root");
+}
+
+async function canonicalDirectory(candidatePath: string): Promise<string> {
+  try {
+    const stats = await lstat(candidatePath);
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      throw new ChatExecutionRootError("invalid_root");
+    }
+    return await realpath(candidatePath);
+  } catch (error: unknown) {
+    if (error instanceof ChatExecutionRootError) throw error;
+    if (error instanceof Error && "code" in error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ENOENT" || code === "ENOTDIR" || code === "EACCES") {
+        throw new ChatExecutionRootError("invalid_root");
+      }
+    }
+    throw new ChatExecutionRootError("validation_unavailable");
+  }
+}
+
+function fingerprint(value: {
+  owner: CanonicalOwnerScope;
+  ref: CanonicalChatExecutionRootRef;
+  project: ChatExecutionRootProject;
+  projectRoot: string;
+  worktree?: ChatExecutionRootWorktree & { root: string };
+}): string {
+  const payload = value.worktree
+    ? {
+        version: 1,
+        owner: value.owner,
+        ref: value.ref,
+        project: {
+          id: value.project.id,
+          root: value.projectRoot,
+        },
+        worktree: {
+          id: value.worktree.id,
+          projectSlug: value.worktree.projectSlug,
+          root: value.worktree.root,
+          createdAt: value.worktree.createdAt,
+        },
+      }
+    : {
+        version: 1,
+        owner: value.owner,
+        ref: value.ref,
+        project: {
+          id: value.project.id,
+          root: value.projectRoot,
+        },
+      };
+  return createHash("sha256").update(JSON.stringify(payload)).digest("hex");
+}
+
+export function createChatExecutionRootResolver<
+  Project extends ChatExecutionRootProject,
+  Worktree extends ChatExecutionRootWorktree,
+>(options: {
+  projects: ChatExecutionRootProjectSource<Project>;
+  worktrees?: ChatExecutionRootWorktreeSource<Worktree>;
+}): ChatExecutionRootResolver {
+  if (!options.projects || !options.worktrees) {
+    throw new Error("Chat execution-root dependencies are unavailable");
+  }
+  const worktrees = options.worktrees;
+
+  async function resolve(
+    ownerInput: CanonicalOwnerScope,
+    refInput: CanonicalChatExecutionRootRef,
+  ): Promise<ResolvedChatExecutionRoot> {
+    let owner: CanonicalOwnerScope;
+    let ref: CanonicalChatExecutionRootRef;
+    try {
+      owner = CanonicalOwnerScopeSchema.parse(ownerInput);
+      ref = CanonicalChatExecutionRootRefSchema.parse(refInput);
+    } catch {
+      throw new ChatExecutionRootError("invalid_root");
+    }
+    const ownerScope = projectOwnerScope(owner);
+    let projectResult: Awaited<ReturnType<typeof options.projects.getProjectById>>;
+    try {
+      projectResult = await options.projects.getProjectById(ownerScope, ref.projectId);
+    } catch {
+      throw new ChatExecutionRootError("validation_unavailable");
+    }
+    if (!projectResult.ok) throw dependencyError(projectResult.status);
+    const project = projectResult.project;
+    if (project.id !== ref.projectId) throw new ChatExecutionRootError("invalid_root");
+
+    let resolvedProjectRoot: string | null;
+    try {
+      resolvedProjectRoot = await options.projects.resolveProjectWorkingDirectory(project);
+    } catch {
+      throw new ChatExecutionRootError("validation_unavailable");
+    }
+    if (!resolvedProjectRoot) throw new ChatExecutionRootError("invalid_root");
+    const projectRoot = await canonicalDirectory(resolvedProjectRoot);
+    if (projectRoot !== await canonicalDirectory(project.localPath)) {
+      throw new ChatExecutionRootError("invalid_root");
+    }
+
+    if (ref.kind === "project") {
+      return {
+        ref,
+        primaryWorkspaceRoot: projectRoot,
+        fingerprint: fingerprint({ owner, ref, project, projectRoot }),
+      };
+    }
+
+    let worktreeResult: Awaited<ReturnType<typeof worktrees.getWorktree>>;
+    try {
+      worktreeResult = await worktrees.getWorktree(project.slug, ref.worktreeId, ownerScope);
+    } catch {
+      throw new ChatExecutionRootError("validation_unavailable");
+    }
+    if (!worktreeResult.ok) throw dependencyError(worktreeResult.status);
+    const worktree = worktreeResult.worktree;
+    if (
+      worktree.id !== ref.worktreeId
+      || worktree.projectSlug !== project.slug
+      || !Number.isFinite(Date.parse(worktree.createdAt))
+    ) {
+      throw new ChatExecutionRootError("invalid_root");
+    }
+    const worktreeRoot = await canonicalDirectory(worktree.path);
+    return {
+      ref,
+      primaryWorkspaceRoot: worktreeRoot,
+      fingerprint: fingerprint({
+        owner,
+        ref,
+        project,
+        projectRoot,
+        worktree: { ...worktree, root: worktreeRoot },
+      }),
+    };
+  }
+
+  return {
+    resolve,
+    async revalidate(ownerScope, provenance) {
+      if (!/^[a-f0-9]{64}$/.test(provenance.fingerprint)) {
+        throw new ChatExecutionRootError("invalid_root");
+      }
+      const resolved = await resolve(ownerScope, provenance.ref);
+      if (resolved.fingerprint !== provenance.fingerprint) {
+        throw new ChatExecutionRootError("root_changed");
+      }
+      return resolved;
+    },
+  };
+}

--- a/packages/gateway/src/chat/execution-root.ts
+++ b/packages/gateway/src/chat/execution-root.ts
@@ -4,9 +4,11 @@ import { isAbsolute, join, relative, resolve as resolvePath, sep } from "node:pa
 import {
   CanonicalChatExecutionRootRefSchema,
   CanonicalOwnerScopeSchema,
+  WorktreeIdSchema,
   type CanonicalChatExecutionRootRef,
   type CanonicalOwnerScope,
 } from "@matrix-os/contracts";
+import { PROJECT_SLUG_REGEX } from "../project-registry.js";
 import type { OwnerScope } from "../state-ops.js";
 
 export interface ChatExecutionRootProject {
@@ -295,6 +297,10 @@ export function createChatExecutionRootResolver<
         primaryWorkspaceRoot: projectRoot,
         fingerprint: fingerprint({ owner, ref, project: currentProject, projectRoot }),
       };
+    }
+
+    if (!PROJECT_SLUG_REGEX.test(project.slug) || !WorktreeIdSchema.safeParse(ref.worktreeId).success) {
+      throw new ChatExecutionRootError("invalid_root");
     }
 
     const worktree = await loadWorktree(ownerScope, project.slug, ref.worktreeId);

--- a/packages/gateway/src/chat/execution-root.ts
+++ b/packages/gateway/src/chat/execution-root.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { lstat, realpath } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve as resolvePath, sep } from "node:path";
 import {
   CanonicalChatExecutionRootRefSchema,
   CanonicalOwnerScopeSchema,
@@ -102,6 +103,62 @@ async function canonicalDirectory(candidatePath: string): Promise<string> {
   }
 }
 
+function isWithin(basePath: string, candidatePath: string): boolean {
+  const rel = relative(basePath, candidatePath);
+  return rel !== ""
+    && rel !== ".."
+    && !rel.startsWith(`..${sep}`)
+    && !isAbsolute(rel);
+}
+
+async function canonicalManagedWorktreeDirectory(input: {
+  homePath: string;
+  projectSlug: string;
+  worktreeId: string;
+  candidatePath: string;
+}): Promise<string> {
+  const candidate = resolvePath(input.candidatePath);
+  const variants = [
+    ["worktrees", input.projectSlug, input.worktreeId],
+    ["projects", input.projectSlug, "worktrees", input.worktreeId],
+  ];
+  const segments = variants.find((variant) => join(input.homePath, ...variant) === candidate);
+  if (!segments) throw new ChatExecutionRootError("invalid_root");
+
+  const validateChain = async () => {
+    let current = input.homePath;
+    for (const segment of segments) {
+      current = join(current, segment);
+      const stats = await lstat(current);
+      if (!stats.isDirectory() || stats.isSymbolicLink()) {
+        throw new ChatExecutionRootError("invalid_root");
+      }
+    }
+  };
+
+  try {
+    await validateChain();
+    const [canonicalHome, canonicalWorktree] = await Promise.all([
+      canonicalDirectory(input.homePath),
+      realpath(candidate),
+    ]);
+    await validateChain();
+    if (!isWithin(canonicalHome, canonicalWorktree)) {
+      throw new ChatExecutionRootError("invalid_root");
+    }
+    return canonicalWorktree;
+  } catch (error: unknown) {
+    if (error instanceof ChatExecutionRootError) throw error;
+    if (error instanceof Error && "code" in error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ENOENT" || code === "ENOTDIR" || code === "EACCES") {
+        throw new ChatExecutionRootError("invalid_root");
+      }
+    }
+    throw new ChatExecutionRootError("validation_unavailable");
+  }
+}
+
 function fingerprint(value: {
   owner: CanonicalOwnerScope;
   ref: CanonicalChatExecutionRootRef;
@@ -109,31 +166,23 @@ function fingerprint(value: {
   projectRoot: string;
   worktree?: ChatExecutionRootWorktree & { root: string };
 }): string {
-  const payload = value.worktree
-    ? {
-        version: 1,
-        owner: value.owner,
-        ref: value.ref,
-        project: {
-          id: value.project.id,
-          root: value.projectRoot,
-        },
-        worktree: {
-          id: value.worktree.id,
-          projectSlug: value.worktree.projectSlug,
-          root: value.worktree.root,
-          createdAt: value.worktree.createdAt,
-        },
-      }
-    : {
-        version: 1,
-        owner: value.owner,
-        ref: value.ref,
-        project: {
-          id: value.project.id,
-          root: value.projectRoot,
-        },
-      };
+  const payload = {
+    version: 1,
+    owner: value.owner,
+    ref: value.ref,
+    project: {
+      id: value.project.id,
+      root: value.projectRoot,
+    },
+    ...(value.worktree ? {
+      worktree: {
+        id: value.worktree.id,
+        projectSlug: value.worktree.projectSlug,
+        root: value.worktree.root,
+        createdAt: value.worktree.createdAt,
+      },
+    } : {}),
+  };
   return createHash("sha256").update(JSON.stringify(payload)).digest("hex");
 }
 
@@ -141,6 +190,7 @@ export function createChatExecutionRootResolver<
   Project extends ChatExecutionRootProject,
   Worktree extends ChatExecutionRootWorktree,
 >(options: {
+  homePath: string;
   projects: ChatExecutionRootProjectSource<Project>;
   worktrees?: ChatExecutionRootWorktreeSource<Worktree>;
 }): ChatExecutionRootResolver {
@@ -148,8 +198,9 @@ export function createChatExecutionRootResolver<
     throw new Error("Chat execution-root dependencies are unavailable");
   }
   const worktrees = options.worktrees;
+  const homePath = resolvePath(options.homePath);
 
-  async function resolve(
+  async function resolveRoot(
     ownerInput: CanonicalOwnerScope,
     refInput: CanonicalChatExecutionRootRef,
   ): Promise<ResolvedChatExecutionRoot> {
@@ -207,7 +258,12 @@ export function createChatExecutionRootResolver<
     ) {
       throw new ChatExecutionRootError("invalid_root");
     }
-    const worktreeRoot = await canonicalDirectory(worktree.path);
+    const worktreeRoot = await canonicalManagedWorktreeDirectory({
+      homePath,
+      projectSlug: project.slug,
+      worktreeId: worktree.id,
+      candidatePath: worktree.path,
+    });
     return {
       ref,
       primaryWorkspaceRoot: worktreeRoot,
@@ -222,12 +278,12 @@ export function createChatExecutionRootResolver<
   }
 
   return {
-    resolve,
+    resolve: resolveRoot,
     async revalidate(ownerScope, provenance) {
       if (!/^[a-f0-9]{64}$/.test(provenance.fingerprint)) {
         throw new ChatExecutionRootError("invalid_root");
       }
-      const resolved = await resolve(ownerScope, provenance.ref);
+      const resolved = await resolveRoot(ownerScope, provenance.ref);
       if (resolved.fingerprint !== provenance.fingerprint) {
         throw new ChatExecutionRootError("root_changed");
       }

--- a/packages/gateway/src/chat/execution-root.ts
+++ b/packages/gateway/src/chat/execution-root.ts
@@ -84,6 +84,25 @@ function dependencyError(status: number): ChatExecutionRootError {
   return new ChatExecutionRootError(status >= 500 ? "validation_unavailable" : "invalid_root");
 }
 
+function sameProjectAuthority(
+  left: ChatExecutionRootProject,
+  right: ChatExecutionRootProject,
+): boolean {
+  return left.id === right.id
+    && left.slug === right.slug
+    && left.localPath === right.localPath;
+}
+
+function sameWorktreeAuthority(
+  left: ChatExecutionRootWorktree,
+  right: ChatExecutionRootWorktree,
+): boolean {
+  return left.id === right.id
+    && left.projectSlug === right.projectSlug
+    && left.path === right.path
+    && left.createdAt === right.createdAt;
+}
+
 async function canonicalDirectory(candidatePath: string): Promise<string> {
   try {
     const stats = await lstat(candidatePath);
@@ -200,6 +219,45 @@ export function createChatExecutionRootResolver<
   const worktrees = options.worktrees;
   const homePath = resolvePath(options.homePath);
 
+  async function loadProject(ownerScope: OwnerScope, projectId: string): Promise<Project> {
+    let projectResult: Awaited<ReturnType<typeof options.projects.getProjectById>>;
+    try {
+      projectResult = await options.projects.getProjectById(ownerScope, projectId);
+    } catch (error: unknown) {
+      if (error instanceof ChatExecutionRootError) throw error;
+      throw new ChatExecutionRootError("validation_unavailable");
+    }
+    if (!projectResult.ok) throw dependencyError(projectResult.status);
+    if (projectResult.project.id !== projectId) {
+      throw new ChatExecutionRootError("invalid_root");
+    }
+    return projectResult.project;
+  }
+
+  async function loadWorktree(
+    ownerScope: OwnerScope,
+    projectSlug: string,
+    worktreeId: string,
+  ): Promise<Worktree> {
+    let worktreeResult: Awaited<ReturnType<typeof worktrees.getWorktree>>;
+    try {
+      worktreeResult = await worktrees.getWorktree(projectSlug, worktreeId, ownerScope);
+    } catch (error: unknown) {
+      if (error instanceof ChatExecutionRootError) throw error;
+      throw new ChatExecutionRootError("validation_unavailable");
+    }
+    if (!worktreeResult.ok) throw dependencyError(worktreeResult.status);
+    const worktree = worktreeResult.worktree;
+    if (
+      worktree.id !== worktreeId
+      || worktree.projectSlug !== projectSlug
+      || !Number.isFinite(Date.parse(worktree.createdAt))
+    ) {
+      throw new ChatExecutionRootError("invalid_root");
+    }
+    return worktree;
+  }
+
   async function resolveRoot(
     ownerInput: CanonicalOwnerScope,
     refInput: CanonicalChatExecutionRootRef,
@@ -212,16 +270,7 @@ export function createChatExecutionRootResolver<
     const owner = parsedOwner.data;
     const ref = parsedRef.data;
     const ownerScope = projectOwnerScope(owner);
-    let projectResult: Awaited<ReturnType<typeof options.projects.getProjectById>>;
-    try {
-      projectResult = await options.projects.getProjectById(ownerScope, ref.projectId);
-    } catch (error: unknown) {
-      if (error instanceof ChatExecutionRootError) throw error;
-      throw new ChatExecutionRootError("validation_unavailable");
-    }
-    if (!projectResult.ok) throw dependencyError(projectResult.status);
-    const project = projectResult.project;
-    if (project.id !== ref.projectId) throw new ChatExecutionRootError("invalid_root");
+    const project = await loadProject(ownerScope, ref.projectId);
 
     let resolvedProjectRoot: string | null;
     try {
@@ -237,44 +286,45 @@ export function createChatExecutionRootResolver<
     }
 
     if (ref.kind === "project") {
+      const currentProject = await loadProject(ownerScope, ref.projectId);
+      if (!sameProjectAuthority(project, currentProject)) {
+        throw new ChatExecutionRootError("invalid_root");
+      }
       return {
         ref,
         primaryWorkspaceRoot: projectRoot,
-        fingerprint: fingerprint({ owner, ref, project, projectRoot }),
+        fingerprint: fingerprint({ owner, ref, project: currentProject, projectRoot }),
       };
     }
 
-    let worktreeResult: Awaited<ReturnType<typeof worktrees.getWorktree>>;
-    try {
-      worktreeResult = await worktrees.getWorktree(project.slug, ref.worktreeId, ownerScope);
-    } catch (error: unknown) {
-      if (error instanceof ChatExecutionRootError) throw error;
-      throw new ChatExecutionRootError("validation_unavailable");
-    }
-    if (!worktreeResult.ok) throw dependencyError(worktreeResult.status);
-    const worktree = worktreeResult.worktree;
-    if (
-      worktree.id !== ref.worktreeId
-      || worktree.projectSlug !== project.slug
-      || !Number.isFinite(Date.parse(worktree.createdAt))
-    ) {
-      throw new ChatExecutionRootError("invalid_root");
-    }
+    const worktree = await loadWorktree(ownerScope, project.slug, ref.worktreeId);
     const worktreeRoot = await canonicalManagedWorktreeDirectory({
       homePath,
       projectSlug: project.slug,
       worktreeId: worktree.id,
       candidatePath: worktree.path,
     });
+    const currentProject = await loadProject(ownerScope, ref.projectId);
+    if (!sameProjectAuthority(project, currentProject)) {
+      throw new ChatExecutionRootError("invalid_root");
+    }
+    const currentWorktree = await loadWorktree(
+      ownerScope,
+      currentProject.slug,
+      ref.worktreeId,
+    );
+    if (!sameWorktreeAuthority(worktree, currentWorktree)) {
+      throw new ChatExecutionRootError("invalid_root");
+    }
     return {
       ref,
       primaryWorkspaceRoot: worktreeRoot,
       fingerprint: fingerprint({
         owner,
         ref,
-        project,
+        project: currentProject,
         projectRoot,
-        worktree: { ...worktree, root: worktreeRoot },
+        worktree: { ...currentWorktree, root: worktreeRoot },
       }),
     };
   }

--- a/packages/gateway/src/chat/execution-root.ts
+++ b/packages/gateway/src/chat/execution-root.ts
@@ -103,6 +103,12 @@ function sameWorktreeAuthority(
     && left.createdAt === right.createdAt;
 }
 
+function isInvalidDirectoryError(error: unknown): boolean {
+  if (!(error instanceof Error) || !("code" in error)) return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "ENOENT" || code === "ENOTDIR" || code === "EACCES";
+}
+
 async function canonicalDirectory(candidatePath: string): Promise<string> {
   try {
     const stats = await lstat(candidatePath);
@@ -112,11 +118,8 @@ async function canonicalDirectory(candidatePath: string): Promise<string> {
     return await realpath(candidatePath);
   } catch (error: unknown) {
     if (error instanceof ChatExecutionRootError) throw error;
-    if (error instanceof Error && "code" in error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code === "ENOENT" || code === "ENOTDIR" || code === "EACCES") {
-        throw new ChatExecutionRootError("invalid_root");
-      }
+    if (isInvalidDirectoryError(error)) {
+      throw new ChatExecutionRootError("invalid_root");
     }
     throw new ChatExecutionRootError("validation_unavailable");
   }
@@ -168,11 +171,8 @@ async function canonicalManagedWorktreeDirectory(input: {
     return canonicalWorktree;
   } catch (error: unknown) {
     if (error instanceof ChatExecutionRootError) throw error;
-    if (error instanceof Error && "code" in error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code === "ENOENT" || code === "ENOTDIR" || code === "EACCES") {
-        throw new ChatExecutionRootError("invalid_root");
-      }
+    if (isInvalidDirectoryError(error)) {
+      throw new ChatExecutionRootError("invalid_root");
     }
     throw new ChatExecutionRootError("validation_unavailable");
   }
@@ -308,6 +308,7 @@ export function createChatExecutionRootResolver<
     if (!sameProjectAuthority(project, currentProject)) {
       throw new ChatExecutionRootError("invalid_root");
     }
+    // Worktree lookup is slug-addressed, so bracket it with immutable Project authority reads.
     const currentWorktree = await loadWorktree(
       ownerScope,
       currentProject.slug,
@@ -316,13 +317,17 @@ export function createChatExecutionRootResolver<
     if (!sameWorktreeAuthority(worktree, currentWorktree)) {
       throw new ChatExecutionRootError("invalid_root");
     }
+    const finalProject = await loadProject(ownerScope, ref.projectId);
+    if (!sameProjectAuthority(currentProject, finalProject)) {
+      throw new ChatExecutionRootError("invalid_root");
+    }
     return {
       ref,
       primaryWorkspaceRoot: worktreeRoot,
       fingerprint: fingerprint({
         owner,
         ref,
-        project: currentProject,
+        project: finalProject,
         projectRoot,
         worktree: { ...currentWorktree, root: worktreeRoot },
       }),

--- a/packages/gateway/src/chat/execution-root.ts
+++ b/packages/gateway/src/chat/execution-root.ts
@@ -204,19 +204,19 @@ export function createChatExecutionRootResolver<
     ownerInput: CanonicalOwnerScope,
     refInput: CanonicalChatExecutionRootRef,
   ): Promise<ResolvedChatExecutionRoot> {
-    let owner: CanonicalOwnerScope;
-    let ref: CanonicalChatExecutionRootRef;
-    try {
-      owner = CanonicalOwnerScopeSchema.parse(ownerInput);
-      ref = CanonicalChatExecutionRootRefSchema.parse(refInput);
-    } catch {
+    const parsedOwner = CanonicalOwnerScopeSchema.safeParse(ownerInput);
+    const parsedRef = CanonicalChatExecutionRootRefSchema.safeParse(refInput);
+    if (!parsedOwner.success || !parsedRef.success) {
       throw new ChatExecutionRootError("invalid_root");
     }
+    const owner = parsedOwner.data;
+    const ref = parsedRef.data;
     const ownerScope = projectOwnerScope(owner);
     let projectResult: Awaited<ReturnType<typeof options.projects.getProjectById>>;
     try {
       projectResult = await options.projects.getProjectById(ownerScope, ref.projectId);
-    } catch {
+    } catch (error: unknown) {
+      if (error instanceof ChatExecutionRootError) throw error;
       throw new ChatExecutionRootError("validation_unavailable");
     }
     if (!projectResult.ok) throw dependencyError(projectResult.status);
@@ -226,7 +226,8 @@ export function createChatExecutionRootResolver<
     let resolvedProjectRoot: string | null;
     try {
       resolvedProjectRoot = await options.projects.resolveProjectWorkingDirectory(project);
-    } catch {
+    } catch (error: unknown) {
+      if (error instanceof ChatExecutionRootError) throw error;
       throw new ChatExecutionRootError("validation_unavailable");
     }
     if (!resolvedProjectRoot) throw new ChatExecutionRootError("invalid_root");
@@ -246,7 +247,8 @@ export function createChatExecutionRootResolver<
     let worktreeResult: Awaited<ReturnType<typeof worktrees.getWorktree>>;
     try {
       worktreeResult = await worktrees.getWorktree(project.slug, ref.worktreeId, ownerScope);
-    } catch {
+    } catch (error: unknown) {
+      if (error instanceof ChatExecutionRootError) throw error;
       throw new ChatExecutionRootError("validation_unavailable");
     }
     if (!worktreeResult.ok) throw dependencyError(worktreeResult.status);

--- a/packages/gateway/src/project-identity-index.ts
+++ b/packages/gateway/src/project-identity-index.ts
@@ -1,0 +1,47 @@
+import type { OwnerScope } from "./state-ops.js";
+
+export interface ProjectIdentityRecord {
+  id: string;
+  ownerScope: OwnerScope;
+  archivedAt?: string;
+  deletingAt?: string;
+}
+
+export type ProjectIdentityLookup<Project extends ProjectIdentityRecord> =
+  | { kind: "found"; project: Project }
+  | { kind: "missing" }
+  | { kind: "conflict" }
+  | { kind: "capacity" };
+
+function sameOwner(left: OwnerScope, right: OwnerScope): boolean {
+  return left.type === right.type && left.id === right.id;
+}
+
+/**
+ * Rebuilds a request-scoped ID index from authoritative owner files. Rebuilding
+ * keeps external file repairs visible without a stale long-lived cache.
+ */
+export async function reconcileProjectIdentityIndex<Project extends ProjectIdentityRecord>(options: {
+  ownerScope: OwnerScope;
+  projectId: string;
+  maxEntries: number;
+  listSlugs(): Promise<string[]>;
+  readProject(slug: string): Promise<Project | null>;
+}): Promise<ProjectIdentityLookup<Project>> {
+  const slugs = await options.listSlugs();
+  if (slugs.length > options.maxEntries) return { kind: "capacity" };
+
+  const index: Record<string, Project | null> = Object.create(null) as Record<string, Project | null>;
+  for (const slug of slugs) {
+    const project = await options.readProject(slug);
+    if (!project || !sameOwner(project.ownerScope, options.ownerScope)) continue;
+    if (Object.hasOwn(index, project.id)) index[project.id] = null;
+    else index[project.id] = project;
+  }
+
+  if (!Object.hasOwn(index, options.projectId)) return { kind: "missing" };
+  const project = index[options.projectId];
+  if (!project) return { kind: "conflict" };
+  if (project.archivedAt || project.deletingAt) return { kind: "missing" };
+  return { kind: "found", project };
+}

--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -99,6 +99,7 @@ const CLONE_TIMEOUT_MS = 5 * 60_000;
 
 const GitHubUrlSchema = z.string().trim().min(1).max(512);
 const SlugSchema = z.string().trim().regex(PROJECT_SLUG_REGEX);
+const ProjectIdSchema = z.string().regex(/^proj_[A-Za-z0-9_-]{1,128}$/);
 const ProjectNameSchema = z.string().trim().min(1).max(128);
 const ProjectDescriptionSchema = z.string().trim().max(1_000).optional();
 const CreateRequestIdSchema = z.string().min(5).max(132).regex(/^req_[A-Za-z0-9_-]+$/);
@@ -698,6 +699,40 @@ export function createProjectManager(options: {
       }
       projects.sort((a, b) => a.deletingAt!.localeCompare(b.deletingAt!));
       return { projects, nextCursor: null };
+    },
+
+    async getProjectById(
+      ownerScope: OwnerScope,
+      projectId: string,
+    ): Promise<Result<{ project: ProjectConfig }> | Failure> {
+      if (!ProjectIdSchema.safeParse(projectId).success) {
+        return genericError(400, "invalid_project_id", "Project reference is invalid");
+      }
+      // ponytail: reconcile the bounded file registry on each lookup; add a
+      // cache only if real project counts make this scan measurable.
+      const matches: ProjectConfig[] = [];
+      for (const slug of await registry.listSlugs()) {
+        const project = await readProjectConfig(homePath, slug);
+        if (
+          project?.id !== projectId
+          || !ownerScopeMatches(project.ownerScope, ownerScope)
+          || project.archivedAt
+          || project.deletingAt
+        ) {
+          continue;
+        }
+        matches.push(project);
+        if (matches.length > 1) {
+          return genericError(
+            409,
+            "project_identity_conflict",
+            "Project identity requires repair",
+          );
+        }
+      }
+      return matches[0]
+        ? { ok: true, project: matches[0] }
+        : genericError(404, "not_found", "Project was not found");
     },
 
     async getProject(

--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -318,24 +318,9 @@ async function resolveEligibleProjectWorkingDirectory(
         : null;
     }
 
-    const registryEntry = join(projectsRoot, project.slug);
-    if (
-      realLocalPath === registryEntry
-      || realLocalPath.startsWith(`${registryEntry}${sep}`)
-      || registryEntry.startsWith(`${realLocalPath}${sep}`)
-    ) {
-      return null;
-    }
-    const relativeToRegistry = relative(projectsRoot, realLocalPath);
-    if (
-      relativeToRegistry !== ""
-      && !relativeToRegistry.startsWith("..")
-      && !isAbsolute(relativeToRegistry)
-    ) {
-      const segments = relativeToRegistry.split(sep);
-      if (segments.length === 1 || segments[1] !== "repo") return null;
-    }
-    return realLocalPath;
+    return await isManagedProjectContainer(realHomePath, realLocalPath)
+      ? null
+      : realLocalPath;
   } catch (error: unknown) {
     if (error instanceof Error && "code" in error) {
       const code = (error as NodeJS.ErrnoException).code;

--- a/packages/gateway/src/project-manager.ts
+++ b/packages/gateway/src/project-manager.ts
@@ -11,6 +11,7 @@ import { isMatrixManagedProjectSource } from "./project-registry-layout.js";
 import { createProjectRegistry, PROJECT_SLUG_REGEX } from "./project-registry.js";
 import { removeValidatedLegacyProjectState } from "./legacy-project-state.js";
 import { projectStateRecoveryDir } from "./bounded-json-file.js";
+import { reconcileProjectIdentityIndex } from "./project-identity-index.js";
 
 export { PROJECT_SLUG_REGEX } from "./project-registry.js";
 
@@ -96,6 +97,7 @@ type CreateProjectMode = ProjectKind;
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const CLONE_TIMEOUT_MS = 5 * 60_000;
+const MAX_PROJECT_ID_INDEX_ENTRIES = 10_000;
 
 const GitHubUrlSchema = z.string().trim().min(1).max(512);
 const SlugSchema = z.string().trim().regex(PROJECT_SLUG_REGEX);
@@ -708,31 +710,21 @@ export function createProjectManager(options: {
       if (!ProjectIdSchema.safeParse(projectId).success) {
         return genericError(400, "invalid_project_id", "Project reference is invalid");
       }
-      // ponytail: reconcile the bounded file registry on each lookup; add a
-      // cache only if real project counts make this scan measurable.
-      const matches: ProjectConfig[] = [];
-      for (const slug of await registry.listSlugs()) {
-        const project = await readProjectConfig(homePath, slug);
-        if (
-          project?.id !== projectId
-          || !ownerScopeMatches(project.ownerScope, ownerScope)
-          || project.archivedAt
-          || project.deletingAt
-        ) {
-          continue;
-        }
-        matches.push(project);
-        if (matches.length > 1) {
-          return genericError(
-            409,
-            "project_identity_conflict",
-            "Project identity requires repair",
-          );
-        }
+      const result = await reconcileProjectIdentityIndex({
+        ownerScope,
+        projectId,
+        maxEntries: MAX_PROJECT_ID_INDEX_ENTRIES,
+        listSlugs: () => registry.listSlugs(),
+        readProject: (slug) => readProjectConfig(homePath, slug),
+      });
+      if (result.kind === "found") return { ok: true, project: result.project };
+      if (result.kind === "conflict") {
+        return genericError(409, "project_identity_conflict", "Project identity requires repair");
       }
-      return matches[0]
-        ? { ok: true, project: matches[0] }
-        : genericError(404, "not_found", "Project was not found");
+      if (result.kind === "capacity") {
+        return genericError(503, "project_index_unavailable", "Project lookup is unavailable");
+      }
+      return genericError(404, "not_found", "Project was not found");
     },
 
     async getProject(

--- a/packages/gateway/src/worktree-manager.ts
+++ b/packages/gateway/src/worktree-manager.ts
@@ -352,8 +352,12 @@ export function createWorktreeManager(options: {
         return failure(400, "invalid_ref", "Worktree reference is invalid");
       }
       const project = await readProject(homePath, projectSlug);
-      const worktree = project && !project.archivedAt && !project.deletingAt && (!ownerScope
-        || (project.ownerScope.type === ownerScope.type && project.ownerScope.id === ownerScope.id))
+      const worktree = project && (!ownerScope || (
+        !project.archivedAt
+        && !project.deletingAt
+        && project.ownerScope.type === ownerScope.type
+        && project.ownerScope.id === ownerScope.id
+      ))
         ? await readWorktree(homePath, projectSlug, id)
         : null;
       return worktree

--- a/packages/gateway/src/worktree-manager.ts
+++ b/packages/gateway/src/worktree-manager.ts
@@ -343,12 +343,19 @@ export function createWorktreeManager(options: {
   const runCommand = options.runCommand ?? defaultRunCommand;
 
   return {
-    async getWorktree(projectSlug: string, id: string): Promise<{ ok: true; worktree: WorktreeRecord } | Failure> {
+    async getWorktree(
+      projectSlug: string,
+      id: string,
+      ownerScope?: OwnerScope,
+    ): Promise<{ ok: true; worktree: WorktreeRecord } | Failure> {
       if (!SlugSchema.safeParse(projectSlug).success || !WorktreeIdSchema.safeParse(id).success) {
         return failure(400, "invalid_ref", "Worktree reference is invalid");
       }
       const project = await readProject(homePath, projectSlug);
-      const worktree = project ? await readWorktree(homePath, projectSlug, id) : null;
+      const worktree = project && !project.archivedAt && !project.deletingAt && (!ownerScope
+        || (project.ownerScope.type === ownerScope.type && project.ownerScope.id === ownerScope.id))
+        ? await readWorktree(homePath, projectSlug, id)
+        : null;
       return worktree
         ? { ok: true, worktree }
         : failure(404, "not_found", "Worktree was not found");

--- a/tests/gateway/chat-execution-root.test.ts
+++ b/tests/gateway/chat-execution-root.test.ts
@@ -129,6 +129,34 @@ describe("canonical Chat execution-root resolver", () => {
     expect(projectRoot.fingerprint).not.toBe(worktreeRoot.fingerprint);
   });
 
+  it("resolves a folder project connected directly under projects", async () => {
+    const homePath = await temporaryDirectory("matrix-execution-root-home-");
+    const checkout = join(homePath, "projects", "matrix-os");
+    await mkdir(checkout, { recursive: true });
+    const projectManager = createProjectManager({ homePath, runCommand: vi.fn() });
+    const createdProject = await projectManager.createProject({
+      mode: "folder",
+      name: "Matrix OS",
+      slug: "matrix-os",
+      path: "projects/matrix-os",
+      ownerScope: { type: "user", id: owner.ownerId },
+    });
+    expect(createdProject.ok).toBe(true);
+    if (!createdProject.ok) return;
+    const resolver = createChatExecutionRootResolver({
+      homePath,
+      projects: projectManager,
+      worktrees: createWorktreeManager({ homePath, runCommand: vi.fn() }),
+    });
+
+    const resolved = await resolver.resolve(owner, {
+      kind: "project",
+      projectId: createdProject.project.id,
+    });
+
+    expect(resolved.primaryWorkspaceRoot).toBe(await realpath(checkout));
+  });
+
   it("binds worktree fingerprints to exact project and WorktreeRecord provenance", async () => {
     const homePath = await temporaryDirectory("matrix-execution-root-home-");
     const projectPath = await temporaryDirectory("matrix-project-root-");

--- a/tests/gateway/chat-execution-root.test.ts
+++ b/tests/gateway/chat-execution-root.test.ts
@@ -271,6 +271,47 @@ describe("canonical Chat execution-root resolver", () => {
     );
   });
 
+  it("fails closed when project authority is revoked during the final worktree reload", async () => {
+    const homePath = await temporaryDirectory("matrix-execution-root-home-");
+    const projectPath = await temporaryDirectory("matrix-project-root-");
+    const projectRecord = project({ localPath: projectPath });
+    const worktreePath = join(homePath, "worktrees", projectRecord.slug, "wt_abc123def456");
+    await mkdir(worktreePath, { recursive: true });
+    const worktreeRecord = worktree({ path: worktreePath });
+    let projectActive = true;
+    let revokeDuringFinalWorktreeReload = false;
+    let worktreeReloads = 0;
+    const resolver = createChatExecutionRootResolver({
+      homePath,
+      projects: {
+        getProjectById: vi.fn(async () => projectActive
+          ? { ok: true as const, project: projectRecord }
+          : { ok: false as const, status: 404, error: { code: "not_found" } }),
+        resolveProjectWorkingDirectory: vi.fn(async () => projectPath),
+      },
+      worktrees: {
+        getWorktree: vi.fn(async () => {
+          worktreeReloads += 1;
+          if (revokeDuringFinalWorktreeReload && worktreeReloads === 2) {
+            projectActive = false;
+          }
+          return { ok: true as const, worktree: worktreeRecord };
+        }),
+      },
+    });
+    const first = await resolver.resolve(owner, {
+      kind: "worktree",
+      projectId: projectRecord.id,
+      worktreeId: worktreeRecord.id,
+    });
+
+    revokeDuringFinalWorktreeReload = true;
+    worktreeReloads = 0;
+    await expect(resolver.revalidate(owner, first)).rejects.toEqual(
+      new ChatExecutionRootError("invalid_root"),
+    );
+  });
+
   it("rejects mismatched metadata, direct or ancestor symlinks, and unavailable authority", async () => {
     const homePath = await temporaryDirectory("matrix-execution-root-home-");
     const projectPath = await temporaryDirectory("matrix-project-root-");

--- a/tests/gateway/chat-execution-root.test.ts
+++ b/tests/gateway/chat-execution-root.test.ts
@@ -79,6 +79,36 @@ describe("canonical Chat execution-root resolver", () => {
     })).resolves.toEqual(resolved);
   });
 
+  it("fails closed when project authority is revoked during revalidation", async () => {
+    const homePath = await temporaryDirectory("matrix-execution-root-home-");
+    const externalFolder = await temporaryDirectory("matrix-owner-folder-");
+    const projectRecord = project({ localPath: externalFolder });
+    let active = true;
+    let revokeDuringPathValidation = false;
+    const resolver = createChatExecutionRootResolver({
+      homePath,
+      projects: {
+        getProjectById: vi.fn(async () => active
+          ? { ok: true as const, project: projectRecord }
+          : { ok: false as const, status: 404, error: { code: "not_found" } }),
+        resolveProjectWorkingDirectory: vi.fn(async () => {
+          if (revokeDuringPathValidation) active = false;
+          return externalFolder;
+        }),
+      },
+      worktrees: { getWorktree: vi.fn() },
+    });
+    const first = await resolver.resolve(owner, {
+      kind: "project",
+      projectId: projectRecord.id,
+    });
+
+    revokeDuringPathValidation = true;
+    await expect(resolver.revalidate(owner, first)).rejects.toEqual(
+      new ChatExecutionRootError("invalid_root"),
+    );
+  });
+
   it("wires the production ProjectManager and WorktreeManager through the same seam", async () => {
     const homePath = await temporaryDirectory("matrix-execution-root-home-");
     const projectManager = createProjectManager({ homePath, runCommand: vi.fn() });
@@ -198,6 +228,47 @@ describe("canonical Chat execution-root resolver", () => {
       ref,
       fingerprint: first.fingerprint,
     })).rejects.toEqual(new ChatExecutionRootError("root_changed"));
+  });
+
+  it("fails closed when worktree authority is revoked during revalidation", async () => {
+    const homePath = await temporaryDirectory("matrix-execution-root-home-");
+    const projectPath = await temporaryDirectory("matrix-project-root-");
+    const projectRecord = project({ localPath: projectPath });
+    const worktreePath = join(homePath, "worktrees", projectRecord.slug, "wt_abc123def456");
+    await mkdir(worktreePath, { recursive: true });
+    let active = true;
+    let revokeWhenPathIsRead = false;
+    const worktreeRecord: ChatExecutionRootWorktree = {
+      id: "wt_abc123def456",
+      projectSlug: projectRecord.slug,
+      get path() {
+        if (revokeWhenPathIsRead) active = false;
+        return worktreePath;
+      },
+      createdAt: "2026-08-25T09:00:00.000Z",
+    };
+    const resolver = createChatExecutionRootResolver({
+      homePath,
+      projects: {
+        getProjectById: vi.fn(async () => ({ ok: true as const, project: projectRecord })),
+        resolveProjectWorkingDirectory: vi.fn(async () => projectPath),
+      },
+      worktrees: {
+        getWorktree: vi.fn(async () => active
+          ? { ok: true as const, worktree: worktreeRecord }
+          : { ok: false as const, status: 404, error: { code: "not_found" } }),
+      },
+    });
+    const first = await resolver.resolve(owner, {
+      kind: "worktree",
+      projectId: projectRecord.id,
+      worktreeId: worktreeRecord.id,
+    });
+
+    revokeWhenPathIsRead = true;
+    await expect(resolver.revalidate(owner, first)).rejects.toEqual(
+      new ChatExecutionRootError("invalid_root"),
+    );
   });
 
   it("rejects mismatched metadata, direct or ancestor symlinks, and unavailable authority", async () => {

--- a/tests/gateway/chat-execution-root.test.ts
+++ b/tests/gateway/chat-execution-root.test.ts
@@ -1,0 +1,212 @@
+import { mkdir, mkdtemp, realpath, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ChatExecutionRootError,
+  createChatExecutionRootResolver,
+  type ChatExecutionRootProject,
+  type ChatExecutionRootWorktree,
+} from "../../packages/gateway/src/chat/execution-root.js";
+import { createProjectManager } from "../../packages/gateway/src/project-manager.js";
+import { createWorktreeManager } from "../../packages/gateway/src/worktree-manager.js";
+
+const owner = { type: "personal" as const, ownerId: "user_owner" };
+const roots: string[] = [];
+
+async function temporaryDirectory(prefix: string): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(path);
+  return path;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(roots.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+function project(input: Partial<ChatExecutionRootProject> & Pick<ChatExecutionRootProject, "localPath">): ChatExecutionRootProject {
+  return {
+    id: "proj_immutable",
+    slug: "matrix-os-renamed",
+    localPath: input.localPath,
+    ...input,
+  };
+}
+
+function worktree(input: Partial<ChatExecutionRootWorktree> & Pick<ChatExecutionRootWorktree, "path">): ChatExecutionRootWorktree {
+  return {
+    id: "wt_abc123def456",
+    projectSlug: "matrix-os-renamed",
+    path: input.path,
+    createdAt: "2026-08-25T09:00:00.000Z",
+    ...input,
+  };
+}
+
+describe("canonical Chat execution-root resolver", () => {
+  it("resolves a project by immutable ID and supports an approved folder root", async () => {
+    const externalFolder = await temporaryDirectory("matrix-owner-folder-");
+    let projectRecord = project({ localPath: externalFolder });
+    const getProjectById = vi.fn(async () => ({ ok: true as const, project: projectRecord }));
+    const resolver = createChatExecutionRootResolver({
+      projects: {
+        getProjectById,
+        resolveProjectWorkingDirectory: vi.fn(async () => externalFolder),
+      },
+      worktrees: { getWorktree: vi.fn() },
+    });
+
+    const resolved = await resolver.resolve(owner, { kind: "project", projectId: projectRecord.id });
+
+    expect(getProjectById).toHaveBeenCalledWith(
+      { type: "user", id: owner.ownerId },
+      projectRecord.id,
+    );
+    expect(resolved).toEqual({
+      ref: { kind: "project", projectId: projectRecord.id },
+      primaryWorkspaceRoot: await realpath(externalFolder),
+      fingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+    expect(JSON.stringify(resolved)).not.toContain("user_owner");
+
+    projectRecord = { ...projectRecord, slug: "renamed-again" };
+    await expect(resolver.revalidate(owner, {
+      ref: resolved.ref,
+      fingerprint: resolved.fingerprint,
+    })).resolves.toEqual(resolved);
+  });
+
+  it("wires the production ProjectManager and WorktreeManager through the same seam", async () => {
+    const homePath = await temporaryDirectory("matrix-execution-root-home-");
+    const projectManager = createProjectManager({ homePath, runCommand: vi.fn() });
+    const createdProject = await projectManager.createProject({
+      mode: "scratch",
+      name: "Canonical Chat",
+      slug: "canonical-chat",
+      ownerScope: { type: "user", id: owner.ownerId },
+    });
+    expect(createdProject.ok).toBe(true);
+    if (!createdProject.ok) return;
+    const worktreeManager = createWorktreeManager({
+      homePath,
+      runCommand: vi.fn(async (_command: string, args: string[]) => {
+        if (args[0] === "worktree" && args[1] === "add") {
+          const separator = args.indexOf("--");
+          const path = separator >= 0 ? args[separator + 1] : undefined;
+          if (path) await mkdir(path, { recursive: true });
+        }
+        return { stdout: "", stderr: "" };
+      }),
+    });
+    const createdWorktree = await worktreeManager.createWorktree({
+      projectSlug: createdProject.project.slug,
+      branch: "feature/chat-root",
+      ownerScope: { type: "user", id: owner.ownerId },
+    });
+    expect(createdWorktree.ok).toBe(true);
+    if (!createdWorktree.ok) return;
+    const resolver = createChatExecutionRootResolver({
+      projects: projectManager,
+      worktrees: worktreeManager,
+    });
+
+    const projectRoot = await resolver.resolve(owner, {
+      kind: "project",
+      projectId: createdProject.project.id,
+    });
+    const worktreeRoot = await resolver.resolve(owner, {
+      kind: "worktree",
+      projectId: createdProject.project.id,
+      worktreeId: createdWorktree.worktree.id,
+    });
+
+    expect(projectRoot.primaryWorkspaceRoot).toBe(await realpath(createdProject.project.localPath));
+    expect(worktreeRoot.primaryWorkspaceRoot).toBe(await realpath(createdWorktree.worktree.path));
+    expect(projectRoot.fingerprint).not.toBe(worktreeRoot.fingerprint);
+  });
+
+  it("binds worktree fingerprints to exact project and WorktreeRecord provenance", async () => {
+    const projectPath = await temporaryDirectory("matrix-project-root-");
+    const firstWorktreePath = await temporaryDirectory("matrix-worktree-root-");
+    const secondWorktreePath = await temporaryDirectory("matrix-worktree-moved-");
+    const projectRecord = project({ localPath: projectPath });
+    let worktreeRecord = worktree({ path: firstWorktreePath });
+    const getWorktree = vi.fn(async () => ({ ok: true as const, worktree: worktreeRecord }));
+    const resolver = createChatExecutionRootResolver({
+      projects: {
+        getProjectById: vi.fn(async () => ({ ok: true as const, project: projectRecord })),
+        resolveProjectWorkingDirectory: vi.fn(async () => projectPath),
+      },
+      worktrees: { getWorktree },
+    });
+    const ref = {
+      kind: "worktree" as const,
+      projectId: projectRecord.id,
+      worktreeId: worktreeRecord.id,
+    };
+
+    const first = await resolver.resolve(owner, ref);
+    expect(getWorktree).toHaveBeenCalledWith(
+      projectRecord.slug,
+      worktreeRecord.id,
+      { type: "user", id: owner.ownerId },
+    );
+    await expect(resolver.revalidate(owner, {
+      ref,
+      fingerprint: first.fingerprint,
+    })).resolves.toEqual(first);
+
+    worktreeRecord = worktree({
+      path: secondWorktreePath,
+      createdAt: "2026-08-25T10:00:00.000Z",
+    });
+    await expect(resolver.revalidate(owner, {
+      ref,
+      fingerprint: first.fingerprint,
+    })).rejects.toEqual(new ChatExecutionRootError("root_changed"));
+  });
+
+  it("rejects mismatched metadata, symlink roots, and unavailable authority with safe errors", async () => {
+    const projectPath = await temporaryDirectory("matrix-project-root-");
+    const targetPath = await temporaryDirectory("matrix-worktree-target-");
+    const symlinkRoot = join(await temporaryDirectory("matrix-worktree-parent-"), "linked");
+    await symlink(targetPath, symlinkRoot);
+    const projectRecord = project({ localPath: projectPath });
+    let response:
+      | { ok: true; worktree: ChatExecutionRootWorktree }
+      | { ok: false; status: number; error: unknown } = {
+        ok: true,
+        worktree: worktree({ path: symlinkRoot, projectSlug: "wrong-project" }),
+      };
+    const resolver = createChatExecutionRootResolver({
+      projects: {
+        getProjectById: vi.fn(async () => ({ ok: true as const, project: projectRecord })),
+        resolveProjectWorkingDirectory: vi.fn(async () => projectPath),
+      },
+      worktrees: { getWorktree: vi.fn(async () => response) },
+    });
+    const ref = { kind: "worktree" as const, projectId: projectRecord.id, worktreeId: "wt_abc123def456" };
+
+    await expect(resolver.resolve(owner, ref)).rejects.toEqual(new ChatExecutionRootError("invalid_root"));
+    response = {
+      ok: true,
+      worktree: worktree({ path: symlinkRoot }),
+    };
+    await expect(resolver.resolve(owner, ref)).rejects.toEqual(new ChatExecutionRootError("invalid_root"));
+    response = { ok: false, status: 503, error: new Error("secret upstream detail") };
+    await expect(resolver.resolve(owner, ref)).rejects.toEqual(
+      new ChatExecutionRootError("validation_unavailable"),
+    );
+    await expect(resolver.revalidate(owner, {
+      ref,
+      fingerprint: "not-a-fingerprint",
+    })).rejects.toEqual(new ChatExecutionRootError("invalid_root"));
+    expect(() => createChatExecutionRootResolver({
+      projects: {
+        getProjectById: vi.fn(),
+        resolveProjectWorkingDirectory: vi.fn(),
+      },
+    })).toThrow("Chat execution-root dependencies are unavailable");
+  });
+});

--- a/tests/gateway/chat-execution-root.test.ts
+++ b/tests/gateway/chat-execution-root.test.ts
@@ -46,10 +46,12 @@ function worktree(input: Partial<ChatExecutionRootWorktree> & Pick<ChatExecution
 
 describe("canonical Chat execution-root resolver", () => {
   it("resolves a project by immutable ID and supports an approved folder root", async () => {
+    const homePath = await temporaryDirectory("matrix-execution-root-home-");
     const externalFolder = await temporaryDirectory("matrix-owner-folder-");
     let projectRecord = project({ localPath: externalFolder });
     const getProjectById = vi.fn(async () => ({ ok: true as const, project: projectRecord }));
     const resolver = createChatExecutionRootResolver({
+      homePath,
       projects: {
         getProjectById,
         resolveProjectWorkingDirectory: vi.fn(async () => externalFolder),
@@ -107,6 +109,7 @@ describe("canonical Chat execution-root resolver", () => {
     expect(createdWorktree.ok).toBe(true);
     if (!createdWorktree.ok) return;
     const resolver = createChatExecutionRootResolver({
+      homePath,
       projects: projectManager,
       worktrees: worktreeManager,
     });
@@ -127,13 +130,15 @@ describe("canonical Chat execution-root resolver", () => {
   });
 
   it("binds worktree fingerprints to exact project and WorktreeRecord provenance", async () => {
+    const homePath = await temporaryDirectory("matrix-execution-root-home-");
     const projectPath = await temporaryDirectory("matrix-project-root-");
-    const firstWorktreePath = await temporaryDirectory("matrix-worktree-root-");
-    const secondWorktreePath = await temporaryDirectory("matrix-worktree-moved-");
     const projectRecord = project({ localPath: projectPath });
+    const firstWorktreePath = join(homePath, "worktrees", projectRecord.slug, "wt_abc123def456");
+    await mkdir(firstWorktreePath, { recursive: true });
     let worktreeRecord = worktree({ path: firstWorktreePath });
     const getWorktree = vi.fn(async () => ({ ok: true as const, worktree: worktreeRecord }));
     const resolver = createChatExecutionRootResolver({
+      homePath,
       projects: {
         getProjectById: vi.fn(async () => ({ ok: true as const, project: projectRecord })),
         resolveProjectWorkingDirectory: vi.fn(async () => projectPath),
@@ -158,7 +163,7 @@ describe("canonical Chat execution-root resolver", () => {
     })).resolves.toEqual(first);
 
     worktreeRecord = worktree({
-      path: secondWorktreePath,
+      path: firstWorktreePath,
       createdAt: "2026-08-25T10:00:00.000Z",
     });
     await expect(resolver.revalidate(owner, {
@@ -167,12 +172,17 @@ describe("canonical Chat execution-root resolver", () => {
     })).rejects.toEqual(new ChatExecutionRootError("root_changed"));
   });
 
-  it("rejects mismatched metadata, symlink roots, and unavailable authority with safe errors", async () => {
+  it("rejects mismatched metadata, direct or ancestor symlinks, and unavailable authority", async () => {
+    const homePath = await temporaryDirectory("matrix-execution-root-home-");
     const projectPath = await temporaryDirectory("matrix-project-root-");
     const targetPath = await temporaryDirectory("matrix-worktree-target-");
-    const symlinkRoot = join(await temporaryDirectory("matrix-worktree-parent-"), "linked");
-    await symlink(targetPath, symlinkRoot);
+    const insideTargetPath = join(homePath, "system", "redirected-worktree");
+    await mkdir(join(insideTargetPath, "wt_abc123def456"), { recursive: true });
     const projectRecord = project({ localPath: projectPath });
+    const managedParent = join(homePath, "worktrees", projectRecord.slug);
+    const symlinkRoot = join(managedParent, "wt_abc123def456");
+    await mkdir(managedParent, { recursive: true });
+    await symlink(targetPath, symlinkRoot);
     let response:
       | { ok: true; worktree: ChatExecutionRootWorktree }
       | { ok: false; status: number; error: unknown } = {
@@ -180,6 +190,7 @@ describe("canonical Chat execution-root resolver", () => {
         worktree: worktree({ path: symlinkRoot, projectSlug: "wrong-project" }),
       };
     const resolver = createChatExecutionRootResolver({
+      homePath,
       projects: {
         getProjectById: vi.fn(async () => ({ ok: true as const, project: projectRecord })),
         resolveProjectWorkingDirectory: vi.fn(async () => projectPath),
@@ -194,6 +205,18 @@ describe("canonical Chat execution-root resolver", () => {
       worktree: worktree({ path: symlinkRoot }),
     };
     await expect(resolver.resolve(owner, ref)).rejects.toEqual(new ChatExecutionRootError("invalid_root"));
+    await rm(symlinkRoot);
+    await rm(managedParent, { recursive: true });
+    await mkdir(join(targetPath, "wt_abc123def456"));
+    await symlink(targetPath, managedParent);
+    response = {
+      ok: true,
+      worktree: worktree({ path: symlinkRoot }),
+    };
+    await expect(resolver.resolve(owner, ref)).rejects.toEqual(new ChatExecutionRootError("invalid_root"));
+    await rm(managedParent);
+    await symlink(insideTargetPath, managedParent);
+    await expect(resolver.resolve(owner, ref)).rejects.toEqual(new ChatExecutionRootError("invalid_root"));
     response = { ok: false, status: 503, error: new Error("secret upstream detail") };
     await expect(resolver.resolve(owner, ref)).rejects.toEqual(
       new ChatExecutionRootError("validation_unavailable"),
@@ -203,6 +226,7 @@ describe("canonical Chat execution-root resolver", () => {
       fingerprint: "not-a-fingerprint",
     })).rejects.toEqual(new ChatExecutionRootError("invalid_root"));
     expect(() => createChatExecutionRootResolver({
+      homePath,
       projects: {
         getProjectById: vi.fn(),
         resolveProjectWorkingDirectory: vi.fn(),

--- a/tests/gateway/chat-execution-root.test.ts
+++ b/tests/gateway/chat-execution-root.test.ts
@@ -312,6 +312,44 @@ describe("canonical Chat execution-root resolver", () => {
     );
   });
 
+  it.each([
+    ["project slug", "..", "wt_abc123def456"],
+    ["worktree id", "matrix-os-renamed", "worktree"],
+  ])("rejects an invalid %s returned by alternate authority sources", async (
+    _label,
+    projectSlug,
+    worktreeId,
+  ) => {
+    const homePath = await temporaryDirectory("matrix-execution-root-home-");
+    const projectPath = await temporaryDirectory("matrix-project-root-");
+    const projectRecord = project({ localPath: projectPath, slug: projectSlug });
+    const worktreesRoot = join(homePath, "worktrees");
+    const worktreePath = join(worktreesRoot, projectSlug, worktreeId);
+    await mkdir(worktreesRoot, { recursive: true });
+    await mkdir(worktreePath, { recursive: true });
+    const worktreeRecord = worktree({
+      id: worktreeId,
+      projectSlug,
+      path: worktreePath,
+    });
+    const resolver = createChatExecutionRootResolver({
+      homePath,
+      projects: {
+        getProjectById: vi.fn(async () => ({ ok: true as const, project: projectRecord })),
+        resolveProjectWorkingDirectory: vi.fn(async () => projectPath),
+      },
+      worktrees: {
+        getWorktree: vi.fn(async () => ({ ok: true as const, worktree: worktreeRecord })),
+      },
+    });
+
+    await expect(resolver.resolve(owner, {
+      kind: "worktree",
+      projectId: projectRecord.id,
+      worktreeId,
+    })).rejects.toEqual(new ChatExecutionRootError("invalid_root"));
+  });
+
   it("rejects mismatched metadata, direct or ancestor symlinks, and unavailable authority", async () => {
     const homePath = await temporaryDirectory("matrix-execution-root-home-");
     const projectPath = await temporaryDirectory("matrix-project-root-");

--- a/tests/gateway/project-manager-identity.test.ts
+++ b/tests/gateway/project-manager-identity.test.ts
@@ -63,6 +63,16 @@ describe("project-manager immutable identity", () => {
       status: 409,
       error: { code: "project_identity_conflict" },
     });
+
+    await atomicWriteJson(secondConfigPath, {
+      ...secondConfig,
+      id: second.project.id,
+      archivedAt: "2026-08-25T15:00:00.000Z",
+    });
+    await expect(manager.getProjectById(ownerScope, first.project.id)).resolves.toMatchObject({
+      ok: true,
+      project: { id: first.project.id, slug: first.project.slug },
+    });
   });
 
   it("bounds index reconciliation before reading excess project configs", async () => {

--- a/tests/gateway/project-manager-identity.test.ts
+++ b/tests/gateway/project-manager-identity.test.ts
@@ -1,0 +1,79 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createProjectManager } from "../../packages/gateway/src/project-manager.js";
+import { reconcileProjectIdentityIndex } from "../../packages/gateway/src/project-identity-index.js";
+import { atomicWriteJson } from "../../packages/gateway/src/state-ops.js";
+
+describe("project-manager immutable identity", () => {
+  let homePath: string;
+
+  beforeEach(async () => {
+    homePath = await mkdtemp(join(tmpdir(), "matrix-project-identity-"));
+  });
+
+  afterEach(() => {
+    rmSync(homePath, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("resolves active owner projects by immutable ID instead of mutable slug", async () => {
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+    const created = await manager.createProject({
+      mode: "scratch",
+      name: "Immutable workspace",
+      slug: "mutable-slug",
+      ownerScope: { type: "user", id: "user_123" },
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    await expect(manager.getProjectById(
+      { type: "user", id: "user_123" },
+      created.project.id,
+    )).resolves.toMatchObject({
+      ok: true,
+      project: { id: created.project.id, slug: "mutable-slug" },
+    });
+    await expect(manager.getProjectById(
+      { type: "user", id: "another_owner" },
+      created.project.id,
+    )).resolves.toMatchObject({ ok: false, status: 404, error: { code: "not_found" } });
+  });
+
+  it("fails closed when active or archived ProjectConfigs reuse an owner ID", async () => {
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+    const ownerScope = { type: "user" as const, id: "user_123" };
+    const first = await manager.createProject({ mode: "scratch", name: "First", slug: "first", ownerScope });
+    const second = await manager.createProject({ mode: "scratch", name: "Second", slug: "second", ownerScope });
+    expect(first.ok && second.ok).toBe(true);
+    if (!first.ok || !second.ok) return;
+    const secondConfigPath = join(homePath, "system", "projects", "second", "config.json");
+    const secondConfig = JSON.parse(await readFile(secondConfigPath, "utf-8"));
+    await atomicWriteJson(secondConfigPath, {
+      ...secondConfig,
+      id: first.project.id,
+      archivedAt: "2026-08-25T15:00:00.000Z",
+    });
+
+    await expect(manager.getProjectById(ownerScope, first.project.id)).resolves.toMatchObject({
+      ok: false,
+      status: 409,
+      error: { code: "project_identity_conflict" },
+    });
+  });
+
+  it("bounds index reconciliation before reading excess project configs", async () => {
+    const readProject = vi.fn();
+    await expect(reconcileProjectIdentityIndex({
+      ownerScope: { type: "user", id: "user_123" },
+      projectId: "proj_target",
+      maxEntries: 2,
+      listSlugs: async () => ["one", "two", "three"],
+      readProject,
+    })).resolves.toEqual({ kind: "capacity" });
+    expect(readProject).not.toHaveBeenCalled();
+  });
+});

--- a/tests/gateway/project-manager.test.ts
+++ b/tests/gateway/project-manager.test.ts
@@ -97,6 +97,48 @@ describe("project-manager", () => {
     expect(config.localPath).toBe(join(homePath, "projects", "empty-workspace", "repo"));
   });
 
+  it("resolves active owner projects by immutable ID instead of mutable slug", async () => {
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+    const created = await manager.createProject({
+      mode: "scratch",
+      name: "Immutable workspace",
+      slug: "mutable-slug",
+      ownerScope: { type: "user", id: "user_123" },
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    await expect(manager.getProjectById(
+      { type: "user", id: "user_123" },
+      created.project.id,
+    )).resolves.toMatchObject({
+      ok: true,
+      project: { id: created.project.id, slug: "mutable-slug" },
+    });
+    await expect(manager.getProjectById(
+      { type: "user", id: "another_owner" },
+      created.project.id,
+    )).resolves.toMatchObject({ ok: false, status: 404, error: { code: "not_found" } });
+  });
+
+  it("fails closed when duplicate active ProjectConfig IDs require repair", async () => {
+    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
+    const ownerScope = { type: "user" as const, id: "user_123" };
+    const first = await manager.createProject({ mode: "scratch", name: "First", slug: "first", ownerScope });
+    const second = await manager.createProject({ mode: "scratch", name: "Second", slug: "second", ownerScope });
+    expect(first.ok && second.ok).toBe(true);
+    if (!first.ok || !second.ok) return;
+    const secondConfigPath = join(homePath, "system", "projects", "second", "config.json");
+    const secondConfig = JSON.parse(await readFile(secondConfigPath, "utf-8"));
+    await atomicWriteJson(secondConfigPath, { ...secondConfig, id: first.project.id });
+
+    await expect(manager.getProjectById(ownerScope, first.project.id)).resolves.toMatchObject({
+      ok: false,
+      status: 409,
+      error: { code: "project_identity_conflict" },
+    });
+  });
+
   it("rejects an oversized project description at the manager boundary", async () => {
     const manager = createProjectManager({ homePath, runCommand: vi.fn() });
 

--- a/tests/gateway/project-manager.test.ts
+++ b/tests/gateway/project-manager.test.ts
@@ -97,48 +97,6 @@ describe("project-manager", () => {
     expect(config.localPath).toBe(join(homePath, "projects", "empty-workspace", "repo"));
   });
 
-  it("resolves active owner projects by immutable ID instead of mutable slug", async () => {
-    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
-    const created = await manager.createProject({
-      mode: "scratch",
-      name: "Immutable workspace",
-      slug: "mutable-slug",
-      ownerScope: { type: "user", id: "user_123" },
-    });
-    expect(created.ok).toBe(true);
-    if (!created.ok) return;
-
-    await expect(manager.getProjectById(
-      { type: "user", id: "user_123" },
-      created.project.id,
-    )).resolves.toMatchObject({
-      ok: true,
-      project: { id: created.project.id, slug: "mutable-slug" },
-    });
-    await expect(manager.getProjectById(
-      { type: "user", id: "another_owner" },
-      created.project.id,
-    )).resolves.toMatchObject({ ok: false, status: 404, error: { code: "not_found" } });
-  });
-
-  it("fails closed when duplicate active ProjectConfig IDs require repair", async () => {
-    const manager = createProjectManager({ homePath, runCommand: vi.fn() });
-    const ownerScope = { type: "user" as const, id: "user_123" };
-    const first = await manager.createProject({ mode: "scratch", name: "First", slug: "first", ownerScope });
-    const second = await manager.createProject({ mode: "scratch", name: "Second", slug: "second", ownerScope });
-    expect(first.ok && second.ok).toBe(true);
-    if (!first.ok || !second.ok) return;
-    const secondConfigPath = join(homePath, "system", "projects", "second", "config.json");
-    const secondConfig = JSON.parse(await readFile(secondConfigPath, "utf-8"));
-    await atomicWriteJson(secondConfigPath, { ...secondConfig, id: first.project.id });
-
-    await expect(manager.getProjectById(ownerScope, first.project.id)).resolves.toMatchObject({
-      ok: false,
-      status: 409,
-      error: { code: "project_identity_conflict" },
-    });
-  });
-
   it("rejects an oversized project description at the manager boundary", async () => {
     const manager = createProjectManager({ homePath, runCommand: vi.fn() });
 

--- a/tests/gateway/worktree-manager.test.ts
+++ b/tests/gateway/worktree-manager.test.ts
@@ -70,6 +70,24 @@ describe("worktree-manager", () => {
       .rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("resolves an exact worktree only inside the owning project scope", async () => {
+    const manager = createWorktreeManager({ homePath, runCommand: successfulRunCommand() });
+    const created = await manager.createWorktree({ projectSlug: "repo", branch: "feature/root" });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    await expect(manager.getWorktree(
+      "repo",
+      created.worktree.id,
+      { type: "user", id: "local" },
+    )).resolves.toMatchObject({ ok: true, worktree: { id: created.worktree.id } });
+    await expect(manager.getWorktree(
+      "repo",
+      created.worktree.id,
+      { type: "user", id: "another-owner" },
+    )).resolves.toMatchObject({ ok: false, status: 404 });
+  });
+
   it("fetches GitHub PR refs before creating a PR worktree", async () => {
     const runCommand = successfulRunCommand();
     const manager = createWorktreeManager({ homePath, runCommand });


### PR DESCRIPTION
## Summary

- add the canonical Gateway `ChatExecutionRootResolver` consumed by MAT-477 Run orchestration
- resolve active Projects by immutable owner-scoped `ProjectConfig.id`, never by mutable slug
- reconcile a bounded request-scoped Project identity index and fail closed on duplicate IDs
- resolve worktrees through the exact owner-scoped `WorktreeRecord` for the resolved Project
- accept valid owner-connected folder projects directly under `~/projects/<slug>`
- distinguish those folder projects from legacy managed project containers through authoritative registry metadata
- require exact managed worktree paths and reject direct or ancestor symlink redirects
- derive a transient Gateway-only `primaryWorkspaceRoot` plus persistable non-secret fingerprint
- revalidate current Project and Worktree provenance before provider start or resume
- map validation and dependency failures to typed safe errors without bare catches

## Tests

- focused MAT-347 suites: 72 passed across execution-root, project identity, project manager, and worktree manager
- adjacent workspace and canonical Chat repository regression suites: 44 passed
- full TypeScript typecheck: passed
- full pattern gate: passed with zero violations
- TDD stale-authority regressions: Project and Worktree revocation during revalidation, including Project replacement during the final slug-addressed Worktree reload, reproduced red before the resolver re-read fix and now pass
- duplicate-ID repair: the same ProjectManager instance fails closed on conflict and resolves the surviving Project after repair
- resolver-boundary segment validation: alternate authority sources cannot supply a traversal-shaped Project slug or a non-canonical Worktree ID to the managed-path join
- full repository suite: 11,534 passed, 20 skipped, and 25 failed across 10 unrelated platform snapshot/device-route, terminal/provider timing, socket-path, and default-app date test files
- live old-bundle reproduction: `v2026.08.25-pr1328-32870837724-1-0726606` returned typed `invalid_root` for the valid Desktop folder project at `~/projects/matrix-os`
- exact-head Preview VPS: `v2026.08.25-pr1328-32881709825-1-bbf7fe0` independently read back with release commit `bbf7fe06c4fe1fb431bc37a49991f75142edc667` and ref `codex/mat-347-execution-root-provenance`; the VPS reported `running`, `healthy=true`, and the same active app version after deployment
- live resolver probe on the user-approved predecessor head: a valid Desktop folder Project resolved to `~/projects/matrix-os`, emitted a 64-character fingerprint, and passed immediate provenance revalidation; subsequent exact-head changes are backend-only authority re-reads and resolver-boundary validation covered by the 116 focused and adjacent tests above

## Invariants

### Source of truth

- owner `ProjectConfig` and `WorktreeRecord` files remain authoritative
- PostgreSQL does not copy project paths or worktree records
- canonical Run state persists only `ChatExecutionRootRef` plus the non-secret fingerprint; the raw path is transient and Gateway-only

### Lock/transaction scope

- MAT-477 resolves before Turn admission, stores the ref and fingerprint in the transaction, then revalidates immediately before the provider call
- no filesystem I/O is held across a database transaction

### Acceptable orphan states

- no new filesystem or database objects are created by resolution
- moved, deleted, archived, owner-mismatched, symlinked, duplicate-ID, over-capacity, or dependency-unavailable roots fail closed with typed safe errors

### Auth source of truth

- the authenticated canonical owner scope selects the Project and Worktree registries
- `projectId` is immutable `ProjectConfig.id`; slug is used only after resolving that Project and only to address its worktree registry

### Deferred scope

- this PR does not touch `threads.json`, legacy conversations, Desktop stores, or renderer persistence
- Desktop Chat UI, inspector, Files and Changes, Terminal, Preview, worktree-management UI, provider adapters, and Turn and Run orchestration remain in MAT-476, MAT-475, MAT-478, MAT-481, and MAT-477
- `project-manager.ts` remains above the repository's 1,000-line threshold; [MAT-486](https://linear.app/matrix-os/issue/MAT-486/refactor-gateway-projectmanager-below-the-large-file-threshold) owns the behavior-preserving extraction into focused creation, lookup, and lifecycle/path modules while keeping `createProjectManager()` as a thin composition boundary

## Review state

Ready for Review. Desktop Human Review, exact-head Preview, CI, Docker Smoke, and Greptile 5/5 passed on `bbf7fe06`, with zero unresolved actionable threads.

Closes MAT-347
