### PR TITLE
fix(desktop): stabilize native shell CI

### DIFF
--- a/desktop/src/renderer/src/design/tokens.css
+++ b/desktop/src/renderer/src/design/tokens.css
@@ -45,6 +45,7 @@
   --text-secondary: #5b5f53;
   /* WCAG AA: 4.99:1 on --bg-surface, 4.86:1 on --bg-app. */
   --text-tertiary: #73705f;
+  --text-subtle: #96968f;
   --text-disabled: #b5b1a3;
   --text-on-accent: #fafaf5;
 
@@ -62,6 +63,13 @@
   --danger-muted: rgba(200, 85, 61, 0.12);
   --info: #4a7c92;
   --info-muted: rgba(74, 124, 146, 0.12);
+  --surface-brand-emphasis: #748e59;
+  --surface-error-emphasis: #ba5236;
+  --surface-info-emphasis: #3b85ba;
+  --surface-inverse: #0d0c0c;
+  --surface-neutral-emphasis: #6b7280;
+  --surface-success-emphasis: #288a5b;
+  --surface-warning-emphasis: #e0aa52;
   --update-action: #2f9bff;
   --update-action-foreground: #ffffff;
   --update-action-muted: rgba(47, 155, 255, 0.12);
@@ -155,6 +163,7 @@
   --text-primary: #eaecea;
   --text-secondary: #aab4ac;
   --text-tertiary: #7a8a80;
+  --text-subtle: #96968f;
   --text-disabled: #55605a;
   --text-on-accent: #141614;
 
@@ -163,6 +172,13 @@
   --accent-muted: rgba(140, 199, 190, 0.16);
   --highlight: #d8853f;
   --highlight-muted: rgba(216, 133, 63, 0.18);
+  --surface-brand-emphasis: #748e59;
+  --surface-error-emphasis: #ba5236;
+  --surface-info-emphasis: #3b85ba;
+  --surface-inverse: #0d0c0c;
+  --surface-neutral-emphasis: #6b7280;
+  --surface-success-emphasis: #288a5b;
+  --surface-warning-emphasis: #e0aa52;
   --update-action: #2f9bff;
   --update-action-foreground: #ffffff;
   --update-action-muted: rgba(47, 155, 255, 0.18);

--- a/desktop/src/renderer/src/stores/native-desktop-mode.ts
+++ b/desktop/src/renderer/src/stores/native-desktop-mode.ts
@@ -25,10 +25,6 @@ interface NativeDesktopModeState {
   resetCanvasTransform: () => void;
 }
 
-function isNativeDesktopMode(value: unknown): value is NativeDesktopMode {
-  return value === "desktop" || value === "canvas";
-}
-
 function finiteOr(value: number | undefined, fallback: number): number {
   return value !== undefined && Number.isFinite(value) ? value : fallback;
 }
@@ -62,12 +58,14 @@ export const useNativeDesktopMode = create<NativeDesktopModeState>()((set, get) 
       try {
         const result = await invoke("state:get", { key: "desktopShell" });
         const persisted = result.value as { mode?: unknown } | null;
+        const migrateLegacyCanvasMode = persisted?.mode === "canvas";
         set(modeRevision === startingRevision
           ? {
-              mode: isNativeDesktopMode(persisted?.mode) ? persisted.mode : "desktop",
+              mode: "desktop",
               hydrated: true,
             }
           : { hydrated: true });
+        if (migrateLegacyCanvasMode) persistMode("desktop");
       } catch (error: unknown) {
         console.warn(
           "[native-desktop] mode load failed:",
@@ -77,11 +75,11 @@ export const useNativeDesktopMode = create<NativeDesktopModeState>()((set, get) 
       }
     },
 
-    setMode: (mode) => {
-      if (get().mode === mode) return;
+    setMode: () => {
+      if (get().mode === "desktop") return;
       modeRevision += 1;
-      set({ mode });
-      persistMode(mode);
+      set({ mode: "desktop" });
+      persistMode("desktop");
     },
 
     setCanvasTransform: (patch) => set((state) => ({

--- a/tests/desktop/native-desktop-mode.test.ts
+++ b/tests/desktop/native-desktop-mode.test.ts
@@ -15,11 +15,17 @@ describe("native desktop mode store", () => {
     };
   });
 
-  it("loads the persisted Canvas mode", async () => {
+  it("migrates persisted Canvas mode to Desktop", async () => {
     await useNativeDesktopMode.getState().load();
 
-    expect(useNativeDesktopMode.getState()).toMatchObject({ mode: "canvas", hydrated: true });
+    expect(useNativeDesktopMode.getState()).toMatchObject({ mode: "desktop", hydrated: true });
     expect(window.operator.invoke).toHaveBeenCalledWith("state:get", { key: "desktopShell" });
+    await vi.waitFor(() => {
+      expect(window.operator.invoke).toHaveBeenCalledWith("state:set", {
+        key: "desktopShell",
+        value: { mode: "desktop" },
+      });
+    });
   });
 
   it("falls back to Desktop for invalid persisted state", async () => {
@@ -30,19 +36,13 @@ describe("native desktop mode store", () => {
     expect(useNativeDesktopMode.getState()).toMatchObject({ mode: "desktop", hydrated: true });
   });
 
-  it("persists mode changes without replacing the shared canvas transform", async () => {
+  it("prevents legacy Canvas selections from replacing Desktop mode", async () => {
     useNativeDesktopMode.getState().setCanvasTransform({ panX: 42, panY: -18, zoom: 1.25 });
 
     useNativeDesktopMode.getState().setMode("canvas");
-    await vi.waitFor(() => {
-      expect(window.operator.invoke).toHaveBeenCalledWith("state:set", {
-        key: "desktopShell",
-        value: { mode: "canvas" },
-      });
-    });
 
     expect(useNativeDesktopMode.getState()).toMatchObject({
-      mode: "canvas",
+      mode: "desktop",
       panX: 42,
       panY: -18,
       zoom: 1.25,
@@ -58,7 +58,7 @@ describe("native desktop mode store", () => {
     expect(useNativeDesktopMode.getState()).toMatchObject({ panX: 0, panY: 0, zoom: 1 });
   });
 
-  it("does not overwrite a user selection when hydration finishes late", async () => {
+  it("does not restore Canvas when hydration finishes after a legacy selection", async () => {
     let resolveLoad: ((value: { value: { mode: "desktop" } }) => void) | undefined;
     window.operator.invoke = vi.fn((channel: string) => {
       if (channel === "state:get") {
@@ -74,6 +74,6 @@ describe("native desktop mode store", () => {
     resolveLoad?.({ value: { mode: "desktop" } });
     await loading;
 
-    expect(useNativeDesktopMode.getState()).toMatchObject({ mode: "canvas", hydrated: true });
+    expect(useNativeDesktopMode.getState()).toMatchObject({ mode: "desktop", hydrated: true });
   });
 });

--- a/tests/desktop/native-desktop-shell.test.tsx
+++ b/tests/desktop/native-desktop-shell.test.tsx
@@ -16,6 +16,21 @@ import { useNativeDesktopMode } from "@desktop/renderer/src/stores/native-deskto
 const createObjectURLDescriptor = Object.getOwnPropertyDescriptor(URL, "createObjectURL");
 const revokeObjectURLDescriptor = Object.getOwnPropertyDescriptor(URL, "revokeObjectURL");
 
+function mockLoadedWallpaperImage(): void {
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    queueMicrotask(() => callback(0));
+    return 0;
+  });
+  vi.stubGlobal("Image", class {
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+
+    set src(_value: string) {
+      queueMicrotask(() => this.onload?.());
+    }
+  });
+}
+
 vi.mock("@desktop/renderer/src/features/mission-control/TabContent", () => ({
   TabPane: ({ tab, layoutRevision }: { tab: { title: string }; layoutRevision?: string }) => (
     <div data-layout-revision={layoutRevision}>{tab.title} content</div>
@@ -53,6 +68,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
   if (createObjectURLDescriptor) Object.defineProperty(URL, "createObjectURL", createObjectURLDescriptor);
   else Reflect.deleteProperty(URL, "createObjectURL");
   if (revokeObjectURLDescriptor) Object.defineProperty(URL, "revokeObjectURL", revokeObjectURLDescriptor);
@@ -125,6 +141,7 @@ describe("native desktop shell", () => {
   });
 
   it("loads the configured wallpaper through the authenticated API and revokes it on runtime change", async () => {
+    mockLoadedWallpaperImage();
     const createObjectURL = vi.fn(() => "blob:desktop-wallpaper");
     const revokeObjectURL = vi.fn();
     Object.defineProperty(URL, "createObjectURL", { configurable: true, value: createObjectURL });
@@ -158,6 +175,7 @@ describe("native desktop shell", () => {
   });
 
   it("refreshes the wallpaper when the desktop regains focus", async () => {
+    mockLoadedWallpaperImage();
     const createObjectURL = vi.fn(() => "blob:first-wallpaper");
     const revokeObjectURL = vi.fn();
     Object.defineProperty(URL, "createObjectURL", { configurable: true, value: createObjectURL });
@@ -230,7 +248,7 @@ describe("native desktop shell", () => {
     expect(useDesktopSurfaces.getState().surfaces[useTabs.getState().activeTabId!]?.mode).toBe("window");
   });
 
-  it("offers Settings as a native app in Desktop and Canvas and maximizes it into tabs", () => {
+  it("offers Settings as a native app and maximizes it into tabs", () => {
     render(<><NavigationHeader nativeDesktop /><NativeDesktopShell overlayOpen={false} /></>);
 
     const settingsIcon = screen.getByRole("button", { name: "Settings" });
@@ -248,73 +266,7 @@ describe("native desktop shell", () => {
     expect(screen.getByRole("tab", { name: "Settings" }).getAttribute("aria-selected")).toBe("true");
 
     fireEvent.click(screen.getByRole("tab", { name: "Desktop" }));
-    fireEvent.click(screen.getByRole("button", { name: "Canvas mode" }));
     expect(screen.getByRole("button", { name: "Settings" })).toBeTruthy();
-  });
-
-  it("switches the same running window between Desktop and Canvas without remounting it", () => {
-    render(<><NavigationHeader nativeDesktop /><NativeDesktopShell overlayOpen={false} /></>);
-    fireEvent.doubleClick(screen.getByRole("button", { name: "Chat" }));
-    const tabId = useTabs.getState().activeTabId!;
-    const bounds = useDesktopSurfaces.getState().surfaces[tabId]!.bounds;
-    const originalSurface = document.querySelector(`[data-desktop-surface="${tabId}"]`);
-
-    fireEvent.click(screen.getByRole("button", { name: "Canvas mode" }));
-
-    expect(useNativeDesktopMode.getState().mode).toBe("canvas");
-    expect(screen.getByTestId("native-desktop-canvas")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Browser" })).toBeTruthy();
-    expect(document.querySelector(`[data-desktop-surface="${tabId}"]`)).toBe(originalSurface);
-    expect(useDesktopSurfaces.getState().surfaces[tabId]!.bounds).toEqual(bounds);
-    expect(screen.getByRole("dialog", { name: "Hermes window" })).toBeTruthy();
-
-    fireEvent.click(screen.getByRole("button", { name: "Desktop mode" }));
-
-    expect(useNativeDesktopMode.getState().mode).toBe("desktop");
-    expect(screen.queryByTestId("native-desktop-canvas")).toBeNull();
-    expect(document.querySelector(`[data-desktop-surface="${tabId}"]`)).toBe(originalSurface);
-    expect(screen.getByRole("button", { name: "Browser" })).toBeTruthy();
-  });
-
-  it("zooms, pans, resets, and fits the Canvas from the unified window bar", () => {
-    render(<><NavigationHeader nativeDesktop /><NativeDesktopShell overlayOpen={false} /></>);
-    fireEvent.doubleClick(screen.getByRole("button", { name: "Files" }));
-    fireEvent.click(screen.getByRole("button", { name: "Canvas mode" }));
-
-    fireEvent.click(screen.getByRole("button", { name: "Zoom Canvas in" }));
-    expect(useNativeDesktopMode.getState().zoom).toBeGreaterThan(1);
-
-    fireEvent.pointerDown(screen.getByTestId("native-desktop-canvas"), {
-      button: 0,
-      clientX: 500,
-      clientY: 300,
-      pointerId: 4,
-    });
-    fireEvent.pointerMove(window, { clientX: 560, clientY: 345, pointerId: 4 });
-    fireEvent.pointerUp(window, { pointerId: 4 });
-    expect(useNativeDesktopMode.getState()).toMatchObject({ panX: 60, panY: 45 });
-
-    fireEvent.click(screen.getByRole("button", { name: "Reset Canvas view" }));
-    expect(useNativeDesktopMode.getState()).toMatchObject({ panX: 0, panY: 0, zoom: 1 });
-
-    fireEvent.click(screen.getByRole("button", { name: "Fit Canvas apps" }));
-    expect(useNativeDesktopMode.getState().zoom).toBeLessThanOrEqual(1.5);
-  });
-
-  it("does not zoom the Canvas from a wheel gesture inside an app window", () => {
-    render(<><NavigationHeader nativeDesktop /><NativeDesktopShell overlayOpen={false} /></>);
-    fireEvent.doubleClick(screen.getByRole("button", { name: "Files" }));
-    fireEvent.click(screen.getByRole("button", { name: "Canvas mode" }));
-    const before = useNativeDesktopMode.getState().zoom;
-
-    fireEvent.wheel(screen.getByRole("dialog", { name: "Files window" }), {
-      ctrlKey: true,
-      deltaY: -100,
-      clientX: 500,
-      clientY: 300,
-    });
-
-    expect(useNativeDesktopMode.getState().zoom).toBe(before);
   });
 
   it("opens Terminal as its own window and only adds it to the main tab strip when maximized", () => {


### PR DESCRIPTION
## Summary

- Define the semantic tokens used by the native desktop icon and account-menu refresh.
- Make native wallpaper tests simulate image decoding and post-paint cleanup deterministically.
- Retire Canvas mode entry points and migrate existing saved Canvas preferences to Desktop mode.

## Tests

- `pnpm exec vitest run tests/desktop/native-desktop-mode.test.ts tests/desktop/native-desktop-shell.test.tsx tests/desktop/design-tokens.test.ts`
- `pnpm --filter desktop run typecheck`

## Review / Monitoring

- Follow-up for the CI failure on main after #1310.
