### PR TITLE
feat(desktop): add running apps preview drawer

### DIFF
--- a/desktop/src/renderer/src/design/layering.ts
+++ b/desktop/src/renderer/src/design/layering.ts
@@ -5,6 +5,8 @@ export const DESKTOP_Z_INDEX = {
   nativeDesktopTabStrip: 4,
   nativeDesktopWindowStart: 10,
   nativeDesktopWindowMax: 40,
+  nativeDesktopDrawerBackdrop: 41,
+  nativeDesktopDrawer: 42,
   nativeDesktopLaunchpad: 44,
   nativeDesktopTaskbar: 45,
   dialog: 50,

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopAppDrawer.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopAppDrawer.tsx
@@ -59,6 +59,7 @@ function PreviewTile({
           event.stopPropagation();
           onClose();
         }}
+        onKeyDown={(event) => event.stopPropagation()}
       >
         <X size={14} strokeWidth={1.7} aria-hidden="true" />
       </button>
@@ -97,6 +98,7 @@ export default function DesktopAppDrawer({
       className={`absolute inset-0 ${open ? "pointer-events-auto" : "pointer-events-none"}`}
       data-state={open ? "open" : "closed"}
       data-testid="desktop-app-drawer-layer"
+      inert={!open}
     >
       <div
         aria-hidden="true"

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopAppDrawer.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopAppDrawer.tsx
@@ -67,12 +67,14 @@ function PreviewTile({
 }
 
 export default function DesktopAppDrawer({
+  open,
   tabs,
   surfaces,
   onClose,
   onActivate,
   onCloseTab,
 }: {
+  open: boolean;
   tabs: Tab[];
   surfaces: Record<string, DesktopSurface>;
   onClose: () => void;
@@ -82,28 +84,42 @@ export default function DesktopAppDrawer({
   const openTabs = tabs.filter((tab) => surfaces[tab.id]?.mode !== "closed" && surfaces[tab.id] !== undefined);
 
   useEffect(() => {
+    if (!open) return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") onClose();
     };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [onClose]);
+  }, [onClose, open]);
 
   return (
-    <div className="absolute inset-0" data-testid="desktop-app-drawer-layer">
+    <div
+      className={`absolute inset-0 ${open ? "pointer-events-auto" : "pointer-events-none"}`}
+      data-state={open ? "open" : "closed"}
+      data-testid="desktop-app-drawer-layer"
+    >
       <div
         aria-hidden="true"
         data-testid="desktop-app-drawer-backdrop"
-        className="absolute inset-0 bg-black/10 backdrop-blur-[1px]"
-        style={{ zIndex: DESKTOP_Z_INDEX.nativeDesktopDrawerBackdrop }}
+        className={`absolute inset-0 bg-black/10 backdrop-blur-[1px] ${open ? "opacity-100" : "opacity-0"}`}
+        style={{
+          zIndex: DESKTOP_Z_INDEX.nativeDesktopDrawerBackdrop,
+          transition: "opacity 180ms ease-out",
+        }}
         onPointerDown={onClose}
       />
       <aside
         role="dialog"
         aria-label="All open apps"
         aria-modal="true"
-        className="absolute inset-y-0 left-0 flex w-[240px] flex-col border-r border-[var(--border-default)] bg-[color-mix(in_srgb,var(--bg-app)_63%,transparent)] shadow-lg backdrop-blur-md motion-safe:animate-in motion-safe:slide-in-from-left"
-        style={{ zIndex: DESKTOP_Z_INDEX.nativeDesktopDrawer }}
+        aria-hidden={!open}
+        className="absolute inset-y-0 left-0 flex w-[240px] flex-col border-r border-[var(--border-default)] bg-[color-mix(in_srgb,var(--bg-app)_63%,transparent)] shadow-lg backdrop-blur-md"
+        style={{
+          zIndex: DESKTOP_Z_INDEX.nativeDesktopDrawer,
+          opacity: open ? 1 : 0,
+          transform: open ? "translateX(0)" : "translateX(-100%)",
+          transition: "transform 220ms cubic-bezier(0.22, 1, 0.36, 1), opacity 180ms ease-out",
+        }}
       >
         <header className="flex items-center justify-between px-3 py-3">
           <h2 className="text-xs font-medium text-[var(--text-secondary)]">All open apps</h2>

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopAppDrawer.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopAppDrawer.tsx
@@ -1,0 +1,127 @@
+import { useEffect, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { X } from "lucide-react";
+import { DESKTOP_Z_INDEX } from "../../design/layering";
+import type { DesktopSurface } from "../../stores/desktop-surfaces";
+import type { Tab } from "../../stores/tabs";
+import DesktopAppIcon from "./DesktopAppIcon";
+import { desktopAppAppearance } from "./desktop-apps";
+import SurfaceIcon from "./SurfaceIcon";
+
+function activateFromKeyboard(event: ReactKeyboardEvent<HTMLDivElement>, onActivate: () => void) {
+  if (event.key === "Enter" || event.key === " ") {
+    event.preventDefault();
+    onActivate();
+  }
+}
+
+function PreviewTile({
+  tab,
+  onActivate,
+  onClose,
+}: {
+  tab: Tab;
+  onActivate: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label={`Preview ${tab.title}`}
+      className="group relative h-[171px] w-[219px] shrink-0 overflow-hidden rounded-[6px] border border-[var(--border-default)] bg-[var(--bg-app)] shadow-[0_1px_2px_rgba(0,0,0,0.04)] outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+      onClick={onActivate}
+      onKeyDown={(event) => activateFromKeyboard(event, onActivate)}
+    >
+      <div data-testid="desktop-preview-icon-tile" className="flex size-full items-center justify-center bg-[var(--bg-app)] p-4">
+        <DesktopAppIcon
+          name={tab.title}
+          icon={<SurfaceIcon tab={tab} size={36} />}
+          {...desktopAppAppearance(tab.kind)}
+          className="relative size-18 rounded-[24px] border border-[var(--border-subtle)] shadow-[var(--shadow-2)]"
+        />
+      </div>
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-center gap-1 bg-gradient-to-t from-[color-mix(in_srgb,var(--bg-app)_96%,transparent)] to-transparent px-2 pb-2 pt-8">
+        <SurfaceIcon tab={tab} size={12} />
+        <span className="min-w-0 truncate text-xs text-[var(--text-primary)]">{tab.title}</span>
+      </div>
+      <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/32 text-xs font-medium text-[var(--text-inverse,#FAF9F7)] opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+        Go to app
+      </div>
+      <button
+        type="button"
+        aria-label={`Close ${tab.title} preview`}
+        className="absolute right-1 top-1 flex size-5 items-center justify-center rounded-[4.8px] text-[var(--text-primary)] opacity-0 transition-colors group-hover:opacity-100 hover:bg-[var(--bg-hover)] focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-[var(--accent)]"
+        style={{
+          background: "var(--surface-primary, #FFFEFC)",
+          border: "0.8px solid var(--border-default, #F3F2F2)",
+        }}
+        onClick={(event) => {
+          event.stopPropagation();
+          onClose();
+        }}
+      >
+        <X size={14} strokeWidth={1.7} aria-hidden="true" />
+      </button>
+    </div>
+  );
+}
+
+export default function DesktopAppDrawer({
+  tabs,
+  surfaces,
+  onClose,
+  onActivate,
+  onCloseTab,
+}: {
+  tabs: Tab[];
+  surfaces: Record<string, DesktopSurface>;
+  onClose: () => void;
+  onActivate: (tabId: string) => void;
+  onCloseTab: (tab: Tab) => void;
+}) {
+  const openTabs = tabs.filter((tab) => surfaces[tab.id]?.mode !== "closed" && surfaces[tab.id] !== undefined);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  return (
+    <div className="absolute inset-0" data-testid="desktop-app-drawer-layer">
+      <div
+        aria-hidden="true"
+        data-testid="desktop-app-drawer-backdrop"
+        className="absolute inset-0 bg-black/10 backdrop-blur-[1px]"
+        style={{ zIndex: DESKTOP_Z_INDEX.nativeDesktopDrawerBackdrop }}
+        onPointerDown={onClose}
+      />
+      <aside
+        role="dialog"
+        aria-label="All open apps"
+        aria-modal="true"
+        className="absolute inset-y-0 left-0 flex w-[240px] flex-col border-r border-[var(--border-default)] bg-[color-mix(in_srgb,var(--bg-app)_63%,transparent)] shadow-lg backdrop-blur-md motion-safe:animate-in motion-safe:slide-in-from-left"
+        style={{ zIndex: DESKTOP_Z_INDEX.nativeDesktopDrawer }}
+      >
+        <header className="flex items-center justify-between px-3 py-3">
+          <h2 className="text-xs font-medium text-[var(--text-secondary)]">All open apps</h2>
+          <button type="button" aria-label="Close all open apps" className="flex size-6 items-center justify-center rounded hover:bg-[var(--bg-hover)]" onClick={onClose}>
+            <X size={16} aria-hidden="true" />
+          </button>
+        </header>
+        <div className="flex min-h-0 flex-1 flex-col items-center gap-1 overflow-y-auto px-2 pb-3">
+          {openTabs.map((tab) => (
+            <PreviewTile
+              key={tab.id}
+              tab={tab}
+              onActivate={() => onActivate(tab.id)}
+              onClose={() => onCloseTab(tab)}
+            />
+          ))}
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopHeaderTabs.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopHeaderTabs.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { useDesktopSurfaces } from "../../stores/desktop-surfaces";
 import { useTabs, type Tab } from "../../stores/tabs";
 import { useUi } from "../../stores/ui";
+import { useDesktopAppDrawer } from "../../stores/desktop-app-drawer";
 import DesktopTabStrip from "./DesktopTabStrip";
 
 export default function DesktopHeaderTabs() {
@@ -17,6 +18,8 @@ export default function DesktopHeaderTabs() {
   const workspaceView = useDesktopSurfaces((state) => state.workspaceView);
   const showDesktop = useDesktopSurfaces((state) => state.showDesktop);
   const requestBackgroundRefresh = useUi((state) => state.requestDesktopBackgroundRefresh);
+  const drawerOpen = useDesktopAppDrawer((state) => state.open);
+  const toggleDrawer = useDesktopAppDrawer((state) => state.toggle);
 
   const showDesktopWithRefresh = useCallback(() => {
     showDesktop();
@@ -76,6 +79,8 @@ export default function DesktopHeaderTabs() {
       onClose={close}
       workspaceView={workspaceView}
       onShowDesktop={showDesktopWithRefresh}
+      onToggleSidebar={toggleDrawer}
+      sidebarOpen={drawerOpen}
     />
   );
 }

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopTabStrip.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopTabStrip.tsx
@@ -15,6 +15,8 @@ export default function DesktopTabStrip({
   onClose,
   workspaceView,
   onShowDesktop,
+  onToggleSidebar,
+  sidebarOpen,
 }: {
   tabs: Tab[];
   surfaces: Record<string, DesktopSurface>;
@@ -25,6 +27,8 @@ export default function DesktopTabStrip({
   onClose: (tab: Tab) => void;
   workspaceView: "desktop" | "tabs";
   onShowDesktop: () => void;
+  onToggleSidebar: () => void;
+  sidebarOpen: boolean;
 }) {
   const tabbed = tabs.filter((tab) => surfaces[tab.id]?.mode === "tab");
   return (
@@ -33,7 +37,8 @@ export default function DesktopTabStrip({
         mode="iconOnly"
         label="Sidebar"
         icon={<PanelLeft />}
-        onClick={() => {}}
+        selected={sidebarOpen}
+        onClick={onToggleSidebar}
       />
       <DesktopTab
         mode="iconOnly"

--- a/desktop/src/renderer/src/features/desktop-shell/NativeDesktopShell.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/NativeDesktopShell.tsx
@@ -214,15 +214,14 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
       style={{ top: "var(--titlebar-height)", background: "inherit" }}
     >
       <DesktopBackground />
-      {drawerOpen ? (
-        <DesktopAppDrawer
-          tabs={tabs}
-          surfaces={surfaces}
-          onClose={() => setDrawerOpen(false)}
-          onActivate={activateFromDrawer}
-          onCloseTab={closeFromDrawer}
-        />
-      ) : null}
+      <DesktopAppDrawer
+        open={drawerOpen}
+        tabs={tabs}
+        surfaces={surfaces}
+        onClose={() => setDrawerOpen(false)}
+        onActivate={activateFromDrawer}
+        onCloseTab={closeFromDrawer}
+      />
       {desktopModeHydrated ? (
         <>
       {desktopMode === "desktop" && !tabWorkspaceActive ? (

--- a/desktop/src/renderer/src/features/desktop-shell/NativeDesktopShell.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/NativeDesktopShell.tsx
@@ -17,6 +17,8 @@ import { useUi } from "../../stores/ui";
 import { useNativeDesktopMode } from "../../stores/native-desktop-mode";
 import DesktopWorkspacePlane from "./DesktopWorkspacePlane";
 import DesktopBackgroundMenu from "./DesktopBackgroundMenu";
+import DesktopAppDrawer from "./DesktopAppDrawer";
+import { useDesktopAppDrawer } from "../../stores/desktop-app-drawer";
 
 function currentViewport(): DesktopViewport {
   if (typeof window === "undefined") return { width: 1280, height: 720 };
@@ -55,6 +57,8 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
   const canvasPanX = useNativeDesktopMode((state) => state.panX);
   const canvasPanY = useNativeDesktopMode((state) => state.panY);
   const setDesktopMode = useNativeDesktopMode((state) => state.setMode);
+  const drawerOpen = useDesktopAppDrawer((state) => state.open);
+  const setDrawerOpen = useDesktopAppDrawer((state) => state.setOpen);
   // Mount on first use, then retain the image nodes so reopening can reuse the
   // browser's decoded icon resources instead of issuing another request set.
   const [launcherMounted, setLauncherMounted] = useState(launcherOpen);
@@ -190,6 +194,15 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
     if (tab.kind === "home") requestBackgroundRefresh();
   }, [closeSurface, closeTab, focusFallback, requestBackgroundRefresh]);
 
+  const activateFromDrawer = useCallback((tabId: string) => {
+    activate(tabId);
+    setDrawerOpen(false);
+  }, [activate, setDrawerOpen]);
+
+  const closeFromDrawer = useCallback((tab: Tab) => {
+    close(tab);
+  }, [close]);
+
   const tabWorkspaceActive = desktopMode === "desktop"
     && workspaceView === "tabs"
     && activeSurface?.mode === "tab";
@@ -201,6 +214,15 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
       style={{ top: "var(--titlebar-height)", background: "inherit" }}
     >
       <DesktopBackground />
+      {drawerOpen ? (
+        <DesktopAppDrawer
+          tabs={tabs}
+          surfaces={surfaces}
+          onClose={() => setDrawerOpen(false)}
+          onActivate={activateFromDrawer}
+          onCloseTab={closeFromDrawer}
+        />
+      ) : null}
       {desktopModeHydrated ? (
         <>
       {desktopMode === "desktop" && !tabWorkspaceActive ? (

--- a/desktop/src/renderer/src/stores/desktop-app-drawer.ts
+++ b/desktop/src/renderer/src/stores/desktop-app-drawer.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+interface DesktopAppDrawerState {
+  open: boolean;
+  setOpen(open: boolean): void;
+  toggle(): void;
+}
+
+// This is deliberately renderer-local UI state. Tabs and desktop surfaces remain
+// the durable source for which apps exist and how they are presented.
+export const useDesktopAppDrawer = create<DesktopAppDrawerState>()((set) => ({
+  open: false,
+  setOpen: (open) => set({ open }),
+  toggle: () => set((state) => ({ open: !state.open })),
+}));

--- a/tests/desktop/native-desktop-shell.test.tsx
+++ b/tests/desktop/native-desktop-shell.test.tsx
@@ -402,25 +402,25 @@ describe("native desktop shell", () => {
     expect(useTabs.getState().tabs.some((tab) => tab.kind === "app")).toBe(false);
   });
 
-  it("opens the all-open-apps drawer from Sidebar and dismisses it by close, Escape, and backdrop", () => {
+  it("opens the all-open-apps drawer from Sidebar and dismisses it by close, Escape, and backdrop", async () => {
     render(<><NavigationHeader nativeDesktop /><NativeDesktopShell overlayOpen={false} /></>);
 
     fireEvent.click(screen.getByRole("tab", { name: "Sidebar" }));
     expect(screen.getByRole("dialog", { name: "All open apps" })).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Close all open apps" }));
-    expect(screen.queryByRole("dialog", { name: "All open apps" })).toBeNull();
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "All open apps" })).toBeNull());
 
     fireEvent.click(screen.getByRole("tab", { name: "Sidebar" }));
     fireEvent.keyDown(document, { key: "Escape" });
-    expect(screen.queryByRole("dialog", { name: "All open apps" })).toBeNull();
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "All open apps" })).toBeNull());
 
     fireEvent.click(screen.getByRole("tab", { name: "Sidebar" }));
     fireEvent.pointerDown(screen.getByTestId("desktop-app-drawer-backdrop"));
-    expect(screen.queryByRole("dialog", { name: "All open apps" })).toBeNull();
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "All open apps" })).toBeNull());
   });
 
-  it("routes preview tiles to minimized, tabbed, and windowed apps without activating a close action", () => {
+  it("routes preview tiles to minimized, tabbed, and windowed apps without activating a close action", async () => {
     render(<><NavigationHeader nativeDesktop /><NativeDesktopShell overlayOpen={false} /></>);
     fireEvent.doubleClick(screen.getByRole("button", { name: "Settings" }));
     const settingsId = useTabs.getState().activeTabId!;
@@ -433,6 +433,7 @@ describe("native desktop shell", () => {
     fireEvent.click(screen.getByRole("button", { name: "Preview Settings" }));
     expect(useDesktopSurfaces.getState().surfaces[settingsId]?.mode).toBe("window");
     expect(useTabs.getState().activeTabId).toBe(settingsId);
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "All open apps" })).toBeNull());
 
     fireEvent.click(screen.getByRole("tab", { name: "Sidebar" }));
     fireEvent.click(screen.getByRole("button", { name: "Preview Terminal" }));

--- a/tests/desktop/native-desktop-shell.test.tsx
+++ b/tests/desktop/native-desktop-shell.test.tsx
@@ -405,11 +405,14 @@ describe("native desktop shell", () => {
   it("opens the all-open-apps drawer from Sidebar and dismisses it by close, Escape, and backdrop", async () => {
     render(<><NavigationHeader nativeDesktop /><NativeDesktopShell overlayOpen={false} /></>);
 
+    expect(screen.getByTestId("desktop-app-drawer-layer").hasAttribute("inert")).toBe(true);
     fireEvent.click(screen.getByRole("tab", { name: "Sidebar" }));
     expect(screen.getByRole("dialog", { name: "All open apps" })).toBeTruthy();
+    expect(screen.getByTestId("desktop-app-drawer-layer").hasAttribute("inert")).toBe(false);
 
     fireEvent.click(screen.getByRole("button", { name: "Close all open apps" }));
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "All open apps" })).toBeNull());
+    expect(screen.getByTestId("desktop-app-drawer-layer").hasAttribute("inert")).toBe(true);
 
     fireEvent.click(screen.getByRole("tab", { name: "Sidebar" }));
     fireEvent.keyDown(document, { key: "Escape" });
@@ -418,6 +421,25 @@ describe("native desktop shell", () => {
     fireEvent.click(screen.getByRole("tab", { name: "Sidebar" }));
     fireEvent.pointerDown(screen.getByTestId("desktop-app-drawer-backdrop"));
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "All open apps" })).toBeNull());
+  });
+
+  it("does not activate a preview when its close control receives a keyboard event", () => {
+    render(<><NavigationHeader nativeDesktop /><NativeDesktopShell overlayOpen={false} /></>);
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Settings" }));
+    const settingsId = useTabs.getState().activeTabId!;
+    fireEvent.click(within(screen.getByRole("dialog", { name: "Settings window" })).getByRole("button", { name: "Minimize" }));
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Terminal" }));
+    const terminalId = useTabs.getState().activeTabId!;
+    fireEvent.click(screen.getByRole("tab", { name: "Sidebar" }));
+
+    const closeSettings = screen.getByRole("button", { name: "Close Settings preview" });
+    fireEvent.keyDown(closeSettings, { key: "Enter" });
+
+    expect(useTabs.getState().activeTabId).toBe(terminalId);
+    expect(screen.getByRole("dialog", { name: "All open apps" })).toBeTruthy();
+
+    fireEvent.click(closeSettings);
+    expect(useTabs.getState().tabs.some((tab) => tab.id === settingsId)).toBe(false);
   });
 
   it("routes preview tiles to minimized, tabbed, and windowed apps without activating a close action", async () => {

--- a/tests/desktop/native-desktop-shell.test.tsx
+++ b/tests/desktop/native-desktop-shell.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import NativeDesktopShell from "@desktop/renderer/src/features/desktop-shell/NativeDesktopShell";
 import NavigationHeader from "@desktop/renderer/src/features/mission-control/NavigationHeader";
@@ -12,6 +12,7 @@ import { useApps } from "@desktop/renderer/src/stores/apps";
 import { useTabs } from "@desktop/renderer/src/stores/tabs";
 import { useUi } from "@desktop/renderer/src/stores/ui";
 import { useNativeDesktopMode } from "@desktop/renderer/src/stores/native-desktop-mode";
+import { useDesktopAppDrawer } from "@desktop/renderer/src/stores/desktop-app-drawer";
 
 const createObjectURLDescriptor = Object.getOwnPropertyDescriptor(URL, "createObjectURL");
 const revokeObjectURLDescriptor = Object.getOwnPropertyDescriptor(URL, "revokeObjectURL");
@@ -54,6 +55,7 @@ beforeEach(() => {
   useApps.setState(useApps.getInitialState(), true);
   useUi.setState(useUi.getInitialState(), true);
   useNativeDesktopMode.setState(useNativeDesktopMode.getInitialState(), true);
+  useDesktopAppDrawer.setState(useDesktopAppDrawer.getInitialState(), true);
   useNativeDesktopMode.setState({ hydrated: true });
   window.operator = {
     invoke: vi.fn(async (channel: string) => channel === "state:get"
@@ -398,6 +400,75 @@ describe("native desktop shell", () => {
     expect(screen.getByRole("tab", { name: "Terminal" })).toBeTruthy();
     expect(screen.queryByRole("dialog", { name: "App launcher" })).toBeNull();
     expect(useTabs.getState().tabs.some((tab) => tab.kind === "app")).toBe(false);
+  });
+
+  it("opens the all-open-apps drawer from Sidebar and dismisses it by close, Escape, and backdrop", () => {
+    render(<><NavigationHeader nativeDesktop /><NativeDesktopShell overlayOpen={false} /></>);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Sidebar" }));
+    expect(screen.getByRole("dialog", { name: "All open apps" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close all open apps" }));
+    expect(screen.queryByRole("dialog", { name: "All open apps" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Sidebar" }));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: "All open apps" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Sidebar" }));
+    fireEvent.pointerDown(screen.getByTestId("desktop-app-drawer-backdrop"));
+    expect(screen.queryByRole("dialog", { name: "All open apps" })).toBeNull();
+  });
+
+  it("routes preview tiles to minimized, tabbed, and windowed apps without activating a close action", () => {
+    render(<><NavigationHeader nativeDesktop /><NativeDesktopShell overlayOpen={false} /></>);
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Settings" }));
+    const settingsId = useTabs.getState().activeTabId!;
+    fireEvent.click(within(screen.getByRole("dialog", { name: "Settings window" })).getByRole("button", { name: "Minimize" }));
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Terminal" }));
+    const terminalId = useTabs.getState().activeTabId!;
+    fireEvent.click(within(screen.getByRole("dialog", { name: "Terminal window" })).getByRole("button", { name: "Maximize" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Sidebar" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview Settings" }));
+    expect(useDesktopSurfaces.getState().surfaces[settingsId]?.mode).toBe("window");
+    expect(useTabs.getState().activeTabId).toBe(settingsId);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Sidebar" }));
+    fireEvent.click(screen.getByRole("button", { name: "Preview Terminal" }));
+    expect(useDesktopSurfaces.getState().surfaces[terminalId]?.mode).toBe("tab");
+    expect(useDesktopSurfaces.getState().workspaceView).toBe("tabs");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Sidebar" }));
+    fireEvent.click(screen.getByRole("button", { name: "Close Settings preview" }));
+    expect(useTabs.getState().tabs.some((tab) => tab.id === settingsId)).toBe(false);
+    expect(useTabs.getState().activeTabId).toBe(terminalId);
+    expect(screen.getByRole("dialog", { name: "All open apps" })).toBeTruthy();
+    const terminalPreviewClose = screen.getByRole("button", { name: "Close Terminal preview" });
+    expect(terminalPreviewClose.classList.contains("size-5")).toBe(true);
+    expect(terminalPreviewClose.classList.contains("rounded-[4.8px]")).toBe(true);
+    expect(terminalPreviewClose.style.border).toContain("var(--border-default");
+  });
+
+  it("uses the same icon-and-name tile treatment for first-party and user apps", () => {
+    useConnection.setState({ platformHost: "https://runtime.example.com" });
+    useApps.setState({
+      apps: [{ slug: "notes", name: "Notes" }],
+      loaded: true,
+      loading: false,
+      error: null,
+    });
+    render(<><NavigationHeader nativeDesktop /><NativeDesktopShell overlayOpen={false} /></>);
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Terminal" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "Open App Launcher" }).at(-1)!);
+    fireEvent.click(screen.getByRole("button", { name: "Notes" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Sidebar" }));
+
+    expect(screen.getAllByTestId("desktop-preview-icon-tile").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByRole("button", { name: "Preview Terminal" }).textContent).toContain("Terminal");
+    expect(screen.getByRole("button", { name: "Preview Notes" }).textContent).toContain("Notes");
+    expect(within(screen.getByRole("button", { name: "Preview Terminal" })).getByLabelText("Terminal")
+      .classList.contains("rounded-[24px]")).toBe(true);
   });
 
   it("opens launcher apps as windows after returning from retained tabs to the Desktop", () => {


### PR DESCRIPTION
## Summary

- Add an All open apps preview drawer controlled from the native desktop Sidebar.
- Show every running app as a consistent app-icon tile with app-name label and
  square close action.
- Restore/focus selected apps and keep the preview drawer open when a tile is
  closed.
- Animate the drawer and backdrop directly from its persistent open state.

## Tests

- `pnpm exec vitest run tests/desktop/native-desktop-shell.test.tsx -t 'opens the all-open-apps|routes preview tiles|same icon-and-name' --reporter=dot`
- `pnpm --filter desktop run typecheck`
- `pnpm run check:patterns` (passed with existing warnings)
- `pnpm run typecheck` (blocked: `bun` is unavailable in this environment)
