### PR TITLE
feat(desktop): adapt Chat to OS View

### DIFF
--- a/desktop/src/renderer/src/features/chat/CanonicalChatIndex.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatIndex.tsx
@@ -26,6 +26,7 @@ export function CanonicalChatIndex({
   onSelect,
   onDelete,
   onNewChat,
+  layout = "wide",
 }: {
   items: CanonicalChatRecord[];
   activeChatId: string | null;
@@ -37,14 +38,21 @@ export function CanonicalChatIndex({
   onSelect: (chatId: string) => void;
   onDelete: (record: CanonicalChatRecord) => void;
   onNewChat: () => void;
+  layout?: "wide" | "narrow";
 }) {
   const [searchOpen, setSearchOpen] = useState(query.length > 0);
 
   return (
-    <OSWindowSafeView area="sidebar" className="h-full min-h-0 w-[280px] min-w-[200px] max-w-[280px] shrink-0">
+    <OSWindowSafeView
+      area="sidebar"
+      data-layout={layout}
+      className={layout === "narrow"
+        ? "h-[168px] min-h-[120px] w-full max-w-none shrink-0"
+        : "h-full min-h-0 w-[280px] min-w-[200px] max-w-[280px] shrink-0"}
+    >
       <aside
         aria-label="Global chats"
-        className="flex h-full min-h-0 w-full flex-col border-r"
+        className={`flex h-full min-h-0 w-full flex-col ${layout === "narrow" ? "border-b" : "border-r"}`}
         style={{ borderColor: "var(--border-default, #F3F2F2)" }}
       >
         <header className="flex shrink-0 items-center justify-between border-b px-4 py-2" style={{ borderColor: "var(--border-default, #F3F2F2)" }}>

--- a/desktop/src/renderer/src/features/chat/CanonicalChatIndex.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatIndex.tsx
@@ -17,6 +17,7 @@ function activityLabel(timestamp: string): string {
 
 export function CanonicalChatIndex({
   items,
+  activeChatId,
   query,
   status,
   error,
@@ -27,6 +28,7 @@ export function CanonicalChatIndex({
   onNewChat,
 }: {
   items: CanonicalChatRecord[];
+  activeChatId: string | null;
   query: string;
   status: "idle" | "loading" | "ready" | "error";
   error: string | null;
@@ -117,7 +119,9 @@ export function CanonicalChatIndex({
                 <button
                   type="button"
                   aria-label={record.chat.title}
+                  aria-current={record.chat.id === activeChatId || undefined}
                   className="flex min-h-14 w-full min-w-0 items-center px-4 py-3 pr-24 text-left hover:bg-[var(--bg-hover)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[var(--accent)]"
+                  style={{ background: record.chat.id === activeChatId ? "var(--bg-selected)" : "transparent" }}
                   onClick={() => onSelect(record.chat.id)}
                 >
                   <span className="min-w-0 flex-1 truncate text-sm" style={{ color: "var(--text-primary)" }}>{record.chat.title}</span>

--- a/desktop/src/renderer/src/features/chat/CanonicalChatIndex.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatIndex.tsx
@@ -1,6 +1,8 @@
 import type { CanonicalChatRecord } from "@matrix-os/contracts";
-import { MessageSquare, Search, Trash2, X } from "lucide-react";
+import { MessageSquare, Plus, Search, Trash2, X } from "lucide-react";
 import { useState } from "react";
+
+import { OSWindowSafeView } from "../desktop-shell/OSWindow";
 
 function activityLabel(timestamp: string): string {
   const elapsedSeconds = Math.max(0, Math.floor((Date.now() - new Date(timestamp).getTime()) / 1_000));
@@ -35,77 +37,107 @@ export function CanonicalChatIndex({
   onNewChat: () => void;
 }) {
   const [searchOpen, setSearchOpen] = useState(query.length > 0);
-  return (
-    <section className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 py-4 sm:px-8" aria-labelledby="canonical-chat-index-title">
-      <div data-chat-index-content className="mx-auto flex w-full max-w-[1020px] flex-col">
-        <div className="mb-6 flex min-h-[47px] min-w-0 items-center justify-between gap-4">
-          <h1 id="canonical-chat-index-title" className="text-[36px] font-medium leading-none tracking-[-0.02em]" style={{ color: "var(--text-primary)", fontFamily: '"Instrument Serif", Georgia, serif' }}>
-            Chats
-          </h1>
-          <div className="flex min-w-0 flex-1 items-center justify-end gap-2">
-            {searchOpen ? (
-              <form
-                className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-lg border px-2.5 sm:max-w-64"
-                style={{ background: "var(--bg-surface)", borderColor: "var(--border-default)" }}
-                onSubmit={(event) => { event.preventDefault(); onSearch(query); }}
-              >
-                <Search size={14} aria-hidden style={{ color: "var(--text-tertiary)" }} />
-                <input
-                  type="text"
-                  role="searchbox"
-                  aria-label="Search chats"
-                  autoFocus
-                  value={query}
-                  onChange={(event) => onQueryChange(event.currentTarget.value)}
-                  className="min-w-0 flex-1 bg-transparent text-sm outline-none"
-                  style={{ color: "var(--text-primary)" }}
-                  placeholder="Search chats"
-                />
-                <button type="button" aria-label="Close search" className="inline-flex h-6 w-6 items-center justify-center rounded-md hover:bg-[var(--bg-hover)]" onClick={() => { setSearchOpen(false); onQueryChange(""); onSearch(""); }}>
-                  <X size={13} aria-hidden />
-                </button>
-              </form>
-            ) : (
-              <button type="button" aria-label="Search chats" className="inline-flex h-8 w-8 items-center justify-center rounded-lg border hover:bg-[var(--bg-hover)]" style={{ background: "var(--bg-raised)", borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }} onClick={() => setSearchOpen(true)}>
-                <Search size={15} aria-hidden />
-              </button>
-            )}
-            <button type="button" className="inline-flex h-8 items-center rounded-lg px-3 text-sm font-medium" style={{ background: "var(--accent)", color: "var(--text-on-accent)" }} onClick={onNewChat}>New chat</button>
-          </div>
-        </div>
 
-        {error ? <div role="alert" className="mb-3 rounded-lg border px-3 py-2 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>{error}</div> : null}
+  return (
+    <OSWindowSafeView area="sidebar" className="h-full min-h-0 w-[280px] min-w-[200px] max-w-[280px] shrink-0">
+      <aside
+        aria-label="Global chats"
+        className="flex h-full min-h-0 w-full flex-col border-r"
+        style={{ borderColor: "var(--border-default, #F3F2F2)" }}
+      >
+        <header className="flex shrink-0 items-center justify-between border-b px-4 py-2" style={{ borderColor: "var(--border-default, #F3F2F2)" }}>
+          <div className="flex min-w-0 items-center gap-1">
+            <MessageSquare size={16} aria-hidden="true" />
+            <h1 aria-label="Chats" className="truncate text-base font-medium tracking-[-0.4px]" style={{ color: "var(--text-primary)" }}>Chat</h1>
+          </div>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              aria-label="Search chats"
+              className="flex size-6 items-center justify-center rounded-md hover:bg-[var(--bg-hover)]"
+              style={{ color: "var(--text-secondary)" }}
+              onClick={() => setSearchOpen((open) => !open)}
+            >
+              <Search size={15} aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              aria-label="New chat"
+              className="flex size-6 items-center justify-center rounded-md text-white"
+              style={{ background: "var(--surface-overlay, #242323)" }}
+              onClick={onNewChat}
+            >
+              <Plus size={16} aria-hidden="true" />
+            </button>
+          </div>
+        </header>
+
+        {searchOpen ? (
+          <form
+            className="mx-3 my-2 flex h-8 shrink-0 items-center gap-2 rounded-lg border px-2"
+            style={{ borderColor: "var(--border-default)", background: "var(--bg-surface)" }}
+            onSubmit={(event) => { event.preventDefault(); onSearch(query); }}
+          >
+            <Search size={14} aria-hidden="true" style={{ color: "var(--text-tertiary)" }} />
+            <input
+              type="text"
+              role="searchbox"
+              aria-label="Search chats"
+              autoFocus
+              value={query}
+              className="min-w-0 flex-1 bg-transparent text-sm outline-none"
+              style={{ color: "var(--text-primary)" }}
+              placeholder="Search chats"
+              onChange={(event) => onQueryChange(event.currentTarget.value)}
+            />
+            <button
+              type="button"
+              aria-label="Close search"
+              className="flex size-5 items-center justify-center rounded hover:bg-[var(--bg-hover)]"
+              onClick={() => { setSearchOpen(false); onQueryChange(""); onSearch(""); }}
+            >
+              <X size={13} aria-hidden="true" />
+            </button>
+          </form>
+        ) : null}
+
+        {error ? <div role="alert" className="mx-3 mt-2 rounded-lg px-2 py-2 text-xs" style={{ color: "var(--text-secondary)", background: "var(--bg-sunken)" }}>{error}</div> : null}
         {status === "loading" && items.length === 0 ? (
-          <div role="status" aria-label="Loading chats" className="py-8 text-center text-sm" style={{ color: "var(--text-tertiary)" }}>
+          <div role="status" aria-label="Loading chats" className="px-4 py-3 text-xs" style={{ color: "var(--text-tertiary)" }}>
             Loading chats…
           </div>
         ) : null}
         {status !== "loading" && items.length === 0 ? (
-          <div className="flex min-h-[280px] flex-col items-center justify-center rounded-xl border px-6 text-center" style={{ background: "var(--bg-surface)", borderColor: "var(--border-subtle)" }}>
-            <span className="flex h-10 w-10 items-center justify-center rounded-xl" style={{ background: "var(--bg-sunken)", color: "var(--text-tertiary)" }}><MessageSquare size={18} aria-hidden /></span>
-            <h2 className="mt-4 text-base font-semibold" style={{ color: "var(--text-primary)" }}>No chats yet</h2>
-            <p className="mt-1 text-sm" style={{ color: "var(--text-secondary)" }}>Start a chat, then return to it from here.</p>
-          </div>
+          <p className="px-4 py-3 text-xs" style={{ color: "var(--text-tertiary)" }}>No chats yet.</p>
         ) : null}
         {items.length > 0 ? (
-          <div data-chat-index-list className="pb-4">
+          <ul aria-label="Chat history" className="min-h-0 flex-1 overflow-y-auto pb-4">
             {items.map((record) => (
-              <div key={record.chat.id} className="group flex h-16 w-full items-center border-b last:border-b-0 hover:bg-[var(--bg-hover)]" style={{ borderColor: "var(--border-subtle)" }}>
-                <button type="button" aria-label={record.chat.title} className="flex min-w-0 flex-1 items-center gap-6 self-stretch px-4 text-left last:border-b-0" onClick={() => onSelect(record.chat.id)}>
-                  <span className="min-w-0 flex-1 truncate text-base font-medium" style={{ color: "var(--text-primary)" }}>{record.chat.title}</span>
-                  <span className="flex shrink-0 items-center gap-4">
-                    <span className="rounded-full border px-2 py-1 text-xs font-medium capitalize" style={{ borderColor: "var(--border-default)", color: "var(--text-tertiary)" }}>{record.providerBinding?.driverKind?.replace("_", " ") ?? "Chat"}</span>
-                    <time className="w-[110px] shrink-0 text-right text-[13px]" style={{ color: "var(--text-tertiary)" }} dateTime={record.chat.updatedAt}>{activityLabel(record.chat.updatedAt)}</time>
-                  </span>
+              <li key={record.chat.id} className="group/chat relative shrink-0 border-b" style={{ borderColor: "var(--border-default, #F3F2F2)" }}>
+                <button
+                  type="button"
+                  aria-label={record.chat.title}
+                  className="flex min-h-14 w-full min-w-0 items-center px-4 py-3 pr-24 text-left hover:bg-[var(--bg-hover)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[var(--accent)]"
+                  onClick={() => onSelect(record.chat.id)}
+                >
+                  <span className="min-w-0 flex-1 truncate text-sm" style={{ color: "var(--text-primary)" }}>{record.chat.title}</span>
                 </button>
-                <button type="button" aria-label={`Delete ${record.chat.title}`} className="mr-2 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg opacity-0 focus-visible:opacity-100 group-hover:opacity-100 hover:bg-[var(--danger-muted)]" style={{ color: "var(--danger)" }} onClick={() => onDelete(record)}>
-                  <Trash2 size={15} aria-hidden />
+                <time className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-xs transition-opacity group-hover/chat:opacity-0" style={{ color: "var(--text-tertiary)" }} dateTime={record.chat.updatedAt}>
+                  {activityLabel(record.chat.updatedAt)}
+                </time>
+                <button
+                  type="button"
+                  aria-label={`Delete ${record.chat.title}`}
+                  className="absolute right-3 top-1/2 z-10 flex size-6 -translate-y-1/2 items-center justify-center rounded-md bg-[var(--surface-base-background,#FFFFFD)] text-[var(--text-tertiary)] opacity-0 transition-opacity hover:bg-[var(--bg-hover)] hover:text-[var(--danger)] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)] group-hover/chat:opacity-100"
+                  onClick={() => onDelete(record)}
+                >
+                  <Trash2 size={14} aria-hidden="true" />
                 </button>
-              </div>
+              </li>
             ))}
-          </div>
+          </ul>
         ) : null}
-      </div>
-    </section>
+      </aside>
+    </OSWindowSafeView>
   );
 }

--- a/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
@@ -385,9 +385,9 @@ export function CanonicalChatWorkspace({
     </>
   );
 
-  if (projectId === null && globalView === "index") {
-    return (
-      <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden" data-slot="canonical-chat-workspace">
+  return (
+    <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden" data-slot="canonical-chat-workspace">
+      {projectId === null ? (
         <CanonicalChatIndex
           items={controller.items}
           query={query}
@@ -402,36 +402,7 @@ export function CanonicalChatWorkspace({
           }}
           onNewChat={startNewChat}
         />
-        <DeleteConversationDialog
-          conversation={deleteTarget}
-          deleting={deleting}
-          error={deleteError}
-          onCancel={() => {
-            if (deleting) return;
-            setDeleteTarget(null);
-            setDeleteError(null);
-          }}
-          onConfirm={() => {
-            if (!deleteTarget || deleting) return;
-            setDeleting(true);
-            void controller.deleteChat(deleteTarget.id).then((deleted) => {
-              if (deleted) {
-                onChatDeleted?.(deleteTarget.id);
-                setDeleteTarget(null);
-                setDeleteError(null);
-              } else {
-                setDeleteError("The Chat could not be deleted. Try again.");
-              }
-            }).finally(() => setDeleting(false));
-          }}
-        />
-      </div>
-    );
-  }
-
-  return (
-    <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden" data-slot="canonical-chat-workspace">
-      {projectId ? <aside
+      ) : <aside
         aria-label="Project chats"
         className="flex w-[260px] shrink-0 flex-col border-r p-3"
         style={{ borderColor: "var(--border-subtle)", background: "var(--bg-sunken)" }}
@@ -497,7 +468,7 @@ export function CanonicalChatWorkspace({
             <p className="px-2 py-3 text-xs" style={{ color: "var(--text-tertiary)" }}>No chats yet.</p>
           ) : null}
         </div>
-      </aside> : null}
+      </aside>}
       <SharedChatSurface
         ariaLabel={projectId ? "Project Chat" : "Global Chat"}
         project={projectId ? { projectId, label: projectLabel ?? projectId } : undefined}
@@ -531,12 +502,37 @@ export function CanonicalChatWorkspace({
                 What should we build today?
               </h1>
             </div>
-            <ChatStarterCards onSelect={setDraft} />
+            <ChatStarterCards layout="two-by-two" onSelect={setDraft} />
             {composer}
           </div>
         )}
       </SharedChatSurface>
       {inspector}
+      {projectId === null ? (
+        <DeleteConversationDialog
+          conversation={deleteTarget}
+          deleting={deleting}
+          error={deleteError}
+          onCancel={() => {
+            if (deleting) return;
+            setDeleteTarget(null);
+            setDeleteError(null);
+          }}
+          onConfirm={() => {
+            if (!deleteTarget || deleting) return;
+            setDeleting(true);
+            void controller.deleteChat(deleteTarget.id).then((deleted) => {
+              if (deleted) {
+                onChatDeleted?.(deleteTarget.id);
+                setDeleteTarget(null);
+                setDeleteError(null);
+              } else {
+                setDeleteError("The Chat could not be deleted. Try again.");
+              }
+            }).finally(() => setDeleting(false));
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
@@ -145,6 +145,20 @@ export function CanonicalChatWorkspace({
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; title: string } | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const workspaceRef = useRef<HTMLDivElement>(null);
+  const [workspaceLayout, setWorkspaceLayout] = useState<"wide" | "narrow">("wide");
+
+  useLayoutEffect(() => {
+    const workspace = workspaceRef.current;
+    if (!workspace || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width;
+      if (typeof width !== "number") return;
+      setWorkspaceLayout(width < 720 ? "narrow" : "wide");
+    });
+    observer.observe(workspace);
+    return () => observer.disconnect();
+  }, []);
 
   useEffect(() => {
     if (!api || runtimeStatus !== "idle") return;
@@ -381,12 +395,18 @@ export function CanonicalChatWorkspace({
             }}
           />
         )}
+        layout={workspaceLayout === "narrow" ? "narrow" : "default"}
       />
     </>
   );
 
   return (
-    <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden" data-slot="canonical-chat-workspace">
+    <div
+      ref={workspaceRef}
+      className={`relative flex min-h-0 min-w-0 flex-1 overflow-hidden ${workspaceLayout === "narrow" ? "flex-col" : "flex-row"}`}
+      data-slot="canonical-chat-workspace"
+      data-layout={workspaceLayout}
+    >
       {projectId === null ? (
         <CanonicalChatIndex
           items={controller.items}
@@ -402,10 +422,12 @@ export function CanonicalChatWorkspace({
             setDeleteTarget({ id: record.chat.id, title: record.chat.title });
           }}
           onNewChat={startNewChat}
+          layout={workspaceLayout}
         />
       ) : <aside
         aria-label="Project chats"
-        className="flex w-[260px] shrink-0 flex-col border-r p-3"
+        data-layout={workspaceLayout}
+        className={`flex shrink-0 flex-col p-3 ${workspaceLayout === "narrow" ? "h-[168px] min-h-[120px] w-full border-b" : "w-[260px] border-r"}`}
         style={{ borderColor: "var(--border-subtle)", background: "var(--bg-sunken)" }}
       >
         <div className="flex items-center justify-between gap-2 px-1 pb-3">
@@ -496,25 +518,36 @@ export function CanonicalChatWorkspace({
             Loading chat…
           </div>
         ) : projectId === null ? (
-          <div className="flex min-h-0 flex-1 flex-col">
-            <div className="flex min-h-0 flex-1 items-center justify-center px-5 py-8">
+          <div
+            data-slot="chat-new-chat-content"
+            className={`flex min-h-0 flex-1 flex-col ${workspaceLayout === "narrow" ? "overflow-y-auto" : ""}`}
+          >
+            <div className={`flex min-h-0 flex-1 items-center justify-center ${workspaceLayout === "narrow" ? "px-3 py-3" : "px-5 py-8"}`}>
               <div className="w-full max-w-[480px]">
-                <ChatStarterCards layout="two-by-two" onSelect={setDraft} />
+                <ChatStarterCards
+                  layout="two-by-two"
+                  density={workspaceLayout === "narrow" ? "compact" : "regular"}
+                  onSelect={setDraft}
+                />
               </div>
             </div>
-            <div className="mx-auto w-full max-w-[868px] shrink-0 px-5 pb-5">
+            <div className={`mx-auto w-full max-w-[868px] shrink-0 ${workspaceLayout === "narrow" ? "px-3 pb-3" : "px-5 pb-5"}`}>
               {composer}
             </div>
           </div>
         ) : (
-          <div className="mx-auto flex min-h-0 w-full max-w-[868px] flex-1 flex-col justify-center gap-[26px] px-5 py-8">
+          <div className={`mx-auto flex min-h-0 w-full max-w-[868px] flex-1 flex-col justify-center ${workspaceLayout === "narrow" ? "gap-3 overflow-y-auto px-3 py-3" : "gap-[26px] px-5 py-8"}`}>
             <div className="flex flex-col items-center gap-3 text-center">
               <MessageSquare size={28} aria-hidden style={{ color: "var(--text-tertiary)" }} />
               <h1 className="text-[32px] font-semibold leading-tight tracking-[-0.02em]" style={{ color: "var(--text-primary)" }}>
                 What should we build today?
               </h1>
             </div>
-            <ChatStarterCards layout="two-by-two" onSelect={setDraft} />
+            <ChatStarterCards
+              layout="two-by-two"
+              density={workspaceLayout === "narrow" ? "compact" : "regular"}
+              onSelect={setDraft}
+            />
             {composer}
           </div>
         )}

--- a/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
@@ -390,6 +390,7 @@ export function CanonicalChatWorkspace({
       {projectId === null ? (
         <CanonicalChatIndex
           items={controller.items}
+          activeChatId={controller.activeChatId}
           query={query}
           status={controller.status}
           error={controller.error}
@@ -493,6 +494,17 @@ export function CanonicalChatWorkspace({
             style={{ color: "var(--text-tertiary)" }}
           >
             Loading chat…
+          </div>
+        ) : projectId === null ? (
+          <div className="flex min-h-0 flex-1 flex-col">
+            <div className="flex min-h-0 flex-1 items-center justify-center px-5 py-8">
+              <div className="w-full max-w-[480px]">
+                <ChatStarterCards layout="two-by-two" onSelect={setDraft} />
+              </div>
+            </div>
+            <div className="mx-auto w-full max-w-[868px] shrink-0 px-5 pb-5">
+              {composer}
+            </div>
           </div>
         ) : (
           <div className="mx-auto flex min-h-0 w-full max-w-[868px] flex-1 flex-col justify-center gap-[26px] px-5 py-8">

--- a/desktop/src/renderer/src/features/chat/ChatStarterCards.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatStarterCards.tsx
@@ -9,9 +9,11 @@ const STARTERS = [
 
 export function ChatStarterCards({
   layout = "responsive",
+  density = "regular",
   onSelect,
 }: {
   layout?: "responsive" | "two-by-two";
+  density?: "regular" | "compact";
   onSelect: (prompt: string) => void;
 }) {
   return (
@@ -22,7 +24,7 @@ export function ChatStarterCards({
           type="button"
           aria-label={label}
           onClick={() => onSelect(label)}
-          className="flex min-h-32 flex-col items-start justify-between rounded-xl border p-4 text-left outline-none transition-colors hover:bg-[var(--bg-hover)] focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          className={`flex flex-col items-start justify-between rounded-xl border text-left outline-none transition-colors hover:bg-[var(--bg-hover)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] ${density === "compact" ? "min-h-24 p-3" : "min-h-32 p-4"}`}
           style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
         >
           <span className="flex size-8 items-center justify-center rounded-lg" style={{ background: "var(--bg-sunken)", color: tone }}>

--- a/desktop/src/renderer/src/features/chat/ChatStarterCards.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatStarterCards.tsx
@@ -7,9 +7,15 @@ const STARTERS = [
   { label: "Fix issues and failures", Icon: Bug, tone: "var(--warning)" },
 ] as const;
 
-export function ChatStarterCards({ onSelect }: { onSelect: (prompt: string) => void }) {
+export function ChatStarterCards({
+  layout = "responsive",
+  onSelect,
+}: {
+  layout?: "responsive" | "two-by-two";
+  onSelect: (prompt: string) => void;
+}) {
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4" data-slot="chat-starter-cards">
+    <div className={`grid grid-cols-2 gap-3 ${layout === "responsive" ? "sm:grid-cols-4" : ""}`} data-slot="chat-starter-cards">
       {STARTERS.map(({ label, Icon, tone }) => (
         <button
           key={label}

--- a/desktop/src/renderer/src/features/chat/SharedChatComposer.tsx
+++ b/desktop/src/renderer/src/features/chat/SharedChatComposer.tsx
@@ -218,6 +218,7 @@ export function SharedChatComposer({
   maxLength,
   unavailableProviderLabel,
   menuSide = "top",
+  layout = "default",
 }: {
   value: string;
   onChange: (value: string) => void;
@@ -250,6 +251,7 @@ export function SharedChatComposer({
   maxLength?: number;
   unavailableProviderLabel?: string;
   menuSide?: "top" | "bottom";
+  layout?: "default" | "narrow";
 }) {
   const [attachmentMenuOpen, setAttachmentMenuOpen] = useState(false);
   const [dismissedSuggestionKey, setDismissedSuggestionKey] = useState<string | null>(null);
@@ -482,6 +484,7 @@ export function SharedChatComposer({
         canSubmit={canSubmit ?? (!disabled && (value.trim().length > 0 || referenceTokens.length > 0))}
         autoFocus={autoFocus}
         focusRequestId={focusRequestId}
+        layout={layout}
         maxLength={maxLength}
         placeholder={placeholder}
         ariaLabel={ariaLabel}

--- a/desktop/src/renderer/src/features/chat/elements/prompt-input.tsx
+++ b/desktop/src/renderer/src/features/chat/elements/prompt-input.tsx
@@ -23,6 +23,7 @@ export function PromptInput({
   canSubmit,
   focusRequestId,
   onTextareaKeyDown,
+  layout = "default",
 }: {
   value: string;
   onChange: (v: string) => void;
@@ -46,6 +47,7 @@ export function PromptInput({
   // Bumping this id focuses the textarea (type-to-start, ⌘J, chip seeds).
   focusRequestId?: number;
   onTextareaKeyDown?: (event: KeyboardEvent<HTMLTextAreaElement>) => boolean | void;
+  layout?: "default" | "narrow";
 }) {
   const ref = useRef<HTMLTextAreaElement>(null);
   const submissionReady = canSubmit ?? value.trim().length > 0;
@@ -68,6 +70,7 @@ export function PromptInput({
   return (
     <div
       className="prompt-card flex flex-col rounded-[var(--radius-xl)] border"
+      data-layout={layout}
       style={{ background: "var(--bg-surface)" }}
     >
       {attachments}
@@ -99,11 +102,11 @@ export function PromptInput({
           />
         </div>
       )}
-      <div className="flex items-center justify-between gap-2 px-2.5 pb-2.5">
-        <div className="flex min-w-0 flex-1 items-center gap-1">
+      <div className={`flex gap-2 px-2.5 pb-2.5 ${layout === "narrow" ? "flex-col items-stretch" : "items-center justify-between"}`}>
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1">
           {controls}
         </div>
-        <div className="flex shrink-0 items-center gap-1.5">
+        <div className={`flex shrink-0 flex-wrap items-center gap-1.5 ${layout === "narrow" ? "justify-end" : ""}`}>
           {trailingControls}
           {busy && onAbort ? (
             <button

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
@@ -58,7 +58,7 @@ export default function DesktopSurfaceFrame({
     : (isDesktopWindow && !tabWorkspaceActive) || (isTabbed && tabWorkspaceActive && active);
   const interactive = visible && active;
   const isNativeEmbed = tab.kind === "home" || tab.kind === "app";
-  const terminalOwnsChrome = tab.kind === "terminal" || tab.kind === "terminals";
+  const sidebarOwnsChrome = tab.kind === "chat" || tab.kind === "terminal" || tab.kind === "terminals";
   const paneActive = interactive && !(isNativeEmbed && overlayOpen);
   const interactionCleanupRef = useRef<(() => void) | null>(null);
 
@@ -146,11 +146,11 @@ export default function DesktopSurfaceFrame({
     <OSWindow
       surfaceId={tab.id}
       sidebarWidth={undefined}
-      safeAreaLayout={terminalOwnsChrome ? "sidebar" : "pane"}
+      safeAreaLayout={sidebarOwnsChrome ? "sidebar" : "pane"}
       topBar={isWindow ? (
         <TopBar
-          chromePlacement={terminalOwnsChrome ? "sidebar" : "full-width"}
-          sidebarWidth={terminalOwnsChrome ? OS_WINDOW_SIDEBAR_WIDTH : undefined}
+          chromePlacement={sidebarOwnsChrome ? "sidebar" : "full-width"}
+          sidebarWidth={sidebarOwnsChrome ? OS_WINDOW_SIDEBAR_WIDTH : undefined}
           onClose={onClose}
           onMinimize={onMinimize}
           onMaximize={onMaximize}

--- a/tests/desktop/canonical-chat-route.test.tsx
+++ b/tests/desktop/canonical-chat-route.test.tsx
@@ -92,6 +92,7 @@ describe("CanonicalChatRoute", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "New chat" }));
     expect(await screen.findByRole("textbox", { name: "Start a chat" })).toBeTruthy();
+    expect(screen.getByRole("complementary", { name: "Global chats" })).toBeTruthy();
 
     rerender(
       <CanonicalChatRoute
@@ -111,7 +112,7 @@ describe("CanonicalChatRoute", () => {
     );
 
     expect(await screen.findByRole("textbox", { name: "Start a chat" })).toBeTruthy();
-    expect(screen.queryByRole("heading", { name: "Chats" })).toBeNull();
+    expect(screen.getByRole("complementary", { name: "Global chats" })).toBeTruthy();
 
     rerender(
       <CanonicalChatRoute
@@ -122,7 +123,7 @@ describe("CanonicalChatRoute", () => {
       />,
     );
     expect(await screen.findByRole("textbox", { name: "Start a chat" })).toBeTruthy();
-    expect(screen.queryByRole("heading", { name: "Chats" })).toBeNull();
+    expect(screen.getByRole("complementary", { name: "Global chats" })).toBeTruthy();
   });
 
   it("keeps the legacy route on an older Gateway instead of showing a broken surface", async () => {

--- a/tests/desktop/canonical-chat-workspace.test.tsx
+++ b/tests/desktop/canonical-chat-workspace.test.tsx
@@ -87,8 +87,8 @@ describe("CanonicalChatWorkspace", () => {
     expect(surface.querySelector('[data-slot="shared-chat-composer"]')).toBeTruthy();
   });
 
-  it("keeps the global Figma list full-width and exposes the MAT-476 attachment control", async () => {
-    const { container } = render(
+  it("renders Global Chat history beside the new-chat pane before a Chat is selected", async () => {
+    render(
       <CanonicalChatWorkspace
         client={client()}
         projectId={null}
@@ -97,15 +97,29 @@ describe("CanonicalChatWorkspace", () => {
       />,
     );
 
-    expect(await screen.findByRole("heading", { name: "Chats" })).toBeTruthy();
-    expect(container.querySelector('aside[aria-label="Global chats"]')).toBeNull();
+    expect(await screen.findByRole("complementary", { name: "Global chats" })).toBeTruthy();
+    expect(screen.getByRole("region", { name: "Global Chat" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "What should we build today?" })).toBeTruthy();
     expect(screen.getByRole("button", { name: snapshot.chat.title })).toBeTruthy();
-    expect(container.querySelector("[data-chat-index-content]")?.className).toContain("max-w-[1020px]");
-    expect(container.querySelector("[data-chat-index-list]")?.className).toContain("pb-4");
-    expect(screen.getByRole("button", { name: snapshot.chat.title }).className).toContain("last:border-b-0");
+  });
 
-    fireEvent.click(screen.getByRole("button", { name: "New chat" }));
-    expect(await screen.findByRole("button", { name: "Add files and more" })).toBeTruthy();
+  it("keeps Global Chat history visible while starting a draft and reopening an existing Chat", async () => {
+    render(
+      <CanonicalChatWorkspace
+        client={client()}
+        projectId={null}
+        active
+        catalog={providerCatalog}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "New chat" }));
+    expect(screen.getByRole("complementary", { name: "Global chats" })).toBeTruthy();
+    expect(screen.getByRole("textbox", { name: "Start a chat" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: snapshot.chat.title }));
+    expect(screen.getByRole("complementary", { name: "Global chats" })).toBeTruthy();
+    expect(await screen.findByRole("textbox", { name: "Reply to chat" })).toBeTruthy();
   });
 
   it("reveals a delete action on Chat row hover and removes the confirmed Chat", async () => {

--- a/tests/desktop/canonical-chat-workspace.test.tsx
+++ b/tests/desktop/canonical-chat-workspace.test.tsx
@@ -99,7 +99,11 @@ describe("CanonicalChatWorkspace", () => {
 
     expect(await screen.findByRole("complementary", { name: "Global chats" })).toBeTruthy();
     expect(screen.getByRole("region", { name: "Global Chat" })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "What should we build today?" })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "What should we build today?" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Explore and understand code" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Build a new feature, app, or tool" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Review code and suggest changes" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Fix issues and failures" })).toBeTruthy();
     expect(screen.getByRole("button", { name: snapshot.chat.title })).toBeTruthy();
   });
 
@@ -117,9 +121,12 @@ describe("CanonicalChatWorkspace", () => {
     expect(screen.getByRole("complementary", { name: "Global chats" })).toBeTruthy();
     expect(screen.getByRole("textbox", { name: "Start a chat" })).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: snapshot.chat.title }));
+    const existingChat = screen.getByRole("button", { name: snapshot.chat.title });
+    fireEvent.click(existingChat);
     expect(screen.getByRole("complementary", { name: "Global chats" })).toBeTruthy();
     expect(await screen.findByRole("textbox", { name: "Reply to chat" })).toBeTruthy();
+    expect(existingChat.getAttribute("aria-current")).toBe("true");
+    expect(existingChat.style.background).toBe("var(--bg-selected)");
   });
 
   it("reveals a delete action on Chat row hover and removes the confirmed Chat", async () => {

--- a/tests/desktop/canonical-chat-workspace.test.tsx
+++ b/tests/desktop/canonical-chat-workspace.test.tsx
@@ -12,6 +12,31 @@ import { setSharedComposerText } from "./shared-chat-composer-test-utils";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { snapshot, providerCatalog } = createCanonicalChatFixture("completed");
+const resizeObserverCallbacks: ResizeObserverCallback[] = [];
+
+class WorkspaceResizeObserver implements ResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    resizeObserverCallbacks.push(callback);
+  }
+
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() { return []; }
+}
+
+function resizeChatWorkspace(width: number) {
+  const workspace = document.querySelector<HTMLElement>('[data-slot="canonical-chat-workspace"]');
+  if (!workspace) throw new Error("Canonical Chat workspace did not render");
+  const entry = {
+    target: workspace,
+    contentRect: { width },
+  } as unknown as ResizeObserverEntry;
+  for (const callback of resizeObserverCallbacks) {
+    callback([entry], {} as ResizeObserver);
+  }
+}
+
 const record = {
   chat: {
     id: snapshot.chat.id,
@@ -52,14 +77,11 @@ function client(): CanonicalChatClient {
 
 describe("CanonicalChatWorkspace", () => {
   beforeAll(() => {
-    globalThis.ResizeObserver = class {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    } as typeof ResizeObserver;
+    globalThis.ResizeObserver = WorkspaceResizeObserver;
   });
 
   beforeEach(() => {
+    resizeObserverCallbacks.length = 0;
     useBoard.setState(useBoard.getInitialState(), true);
     useConnection.setState(useConnection.getInitialState(), true);
   });
@@ -105,6 +127,58 @@ describe("CanonicalChatWorkspace", () => {
     expect(screen.getByRole("button", { name: "Review code and suggest changes" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Fix issues and failures" })).toBeTruthy();
     expect(screen.getByRole("button", { name: snapshot.chat.title })).toBeTruthy();
+  });
+
+  it("uses a single-column New Chat layout at the OS View minimum width", async () => {
+    render(
+      <CanonicalChatWorkspace
+        client={client()}
+        projectId={null}
+        active
+        catalog={providerCatalog}
+      />,
+    );
+
+    await screen.findByRole("button", { name: "Explore and understand code" });
+    act(() => resizeChatWorkspace(440));
+
+    const workspace = document.querySelector<HTMLElement>('[data-slot="canonical-chat-workspace"]');
+    const index = screen.getByRole("complementary", { name: "Global chats" }).parentElement;
+    const starters = document.querySelector<HTMLElement>('[data-slot="chat-starter-cards"]');
+    const composer = document.querySelector<HTMLElement>('[data-slot="shared-chat-composer"] .prompt-card');
+    const newChatContent = document.querySelector<HTMLElement>('[data-slot="chat-new-chat-content"]');
+    expect(workspace?.getAttribute("data-layout")).toBe("narrow");
+    expect(workspace?.className).toContain("flex-col");
+    expect(index?.getAttribute("data-layout")).toBe("narrow");
+    expect(starters?.className).toContain("grid-cols-2");
+    expect(screen.getByRole("button", { name: "Explore and understand code" }).className).toContain("min-h-24");
+    expect(newChatContent?.className).toContain("overflow-y-auto");
+    expect(composer?.getAttribute("data-layout")).toBe("narrow");
+  });
+
+  it("keeps an existing conversation usable at the OS View minimum width", async () => {
+    render(
+      <CanonicalChatWorkspace
+        client={client()}
+        projectId={null}
+        initialChatId={snapshot.chat.id}
+        initialView="conversation"
+        active
+        catalog={providerCatalog}
+      />,
+    );
+
+    await screen.findByRole("textbox", { name: "Reply to chat" });
+    act(() => resizeChatWorkspace(440));
+
+    const workspace = document.querySelector<HTMLElement>('[data-slot="canonical-chat-workspace"]');
+    const index = screen.getByRole("complementary", { name: "Global chats" }).parentElement;
+    const composer = document.querySelector<HTMLElement>('[data-slot="shared-chat-composer"] .prompt-card');
+    expect(workspace?.getAttribute("data-layout")).toBe("narrow");
+    expect(workspace?.className).toContain("flex-col");
+    expect(index?.getAttribute("data-layout")).toBe("narrow");
+    expect(screen.getByRole("region", { name: "Messages" })).toBeTruthy();
+    expect(composer?.getAttribute("data-layout")).toBe("narrow");
   });
 
   it("keeps Global Chat history visible while starting a draft and reopening an existing Chat", async () => {

--- a/tests/desktop/native-desktop-shell.test.tsx
+++ b/tests/desktop/native-desktop-shell.test.tsx
@@ -616,6 +616,13 @@ describe("native desktop shell", () => {
     fireEvent.doubleClick(screen.getByRole("button", { name: "Chat" }));
     fireEvent.doubleClick(screen.getByRole("button", { name: "Terminal" }));
 
+    const chatWindow = screen.getByRole("dialog", { name: "Chat window" });
+    const terminalWindow = screen.getByRole("dialog", { name: "Terminal window" });
+    const chatChrome = chatWindow.querySelector<HTMLElement>('[data-os-window-chrome-placement="sidebar"]');
+    const terminalChrome = terminalWindow.querySelector<HTMLElement>('[data-os-window-chrome-placement="sidebar"]');
+    expect(chatChrome).toBeTruthy();
+    expect(chatChrome?.style.width).toBe("280px");
+    expect(terminalChrome?.style.width).toBe("280px");
     expect(screen.getByText("Chat content")).toBeTruthy();
     expect(screen.getByText("Terminal content")).toBeTruthy();
     expect(screen.getByTestId("desktop-surface-content-chat").hasAttribute("inert")).toBe(true);


### PR DESCRIPTION
## Summary

- adapt the canonical Global Chat surface from PR #1329 to the Desktop OS View
- keep a persistent 280px history sidebar beside new and existing conversations
- switch minimum-width Chat windows to a usable stacked layout below 720px
- compact New Chat starter cards and split narrow composer controls so content remains usable
- give Chat the same sidebar-owned window chrome pattern as Terminal
- preserve provider/model, reload, Project move, and canonical route behavior

## Figma

- [Global Chat window](https://www.figma.com/design/USFVlYYFZ3WKJBAzFZSceC/Desktop-app?node-id=740-13254&m=dev)
- [Independent Chat and Terminal windows](https://www.figma.com/design/USFVlYYFZ3WKJBAzFZSceC/Desktop-app?node-id=740-13429&m=dev)

## Tests

- 17/17 focused minimum-width Chat tests passed
- 140/140 related canonical Chat, ChatTab, Shared Chat, OS window, and Terminal regressions passed
- Desktop typecheck and production Electron build passed
- local `bun run typecheck` passed
- local `bun run check:patterns` passed with 0 violations
- exact-head GitHub Type Check, Pattern Scan, React Doctor, Docs Contract Tests, Sync Client Package, and Shell Production Build passed

## Invariants

- **Source of truth:** canonical Gateway Chat APIs and existing persisted Desktop window state remain authoritative; this PR changes renderer layout only.
- **Lock / transaction scope:** none; no persistence, backend writes, locks, or transaction boundaries are changed.
- **Acceptable orphan states:** none introduced; environments without ResizeObserver keep the existing wide layout fallback.
- **Auth source of truth:** unchanged Desktop and Gateway authentication paths.
- **Deferred scope:** MAT-458, MAT-474, MAT-475, and MAT-481 message/inspector work; provider/backend architecture changes; public documentation changes because this is an existing-surface responsive adaptation.

## Review gate

Human Review approved at exact head `764578012f6b752e1cebd7a76d44d5f456086f31`. Exact-head Desktop screenshots are attached to MAT-489.

Greptile reviewed the same exact head at 5/5 with no findings. Remaining GitHub unit-test shards must pass before squash merge.

Linear: MAT-489