### PR TITLE
feat(desktop): adapt Projects to OS View

### DIFF
--- a/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
+++ b/desktop/src/renderer/src/features/board/CreateProjectDialog.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, FolderOpen, Github, X } from "lucide-react";
+import { ArrowLeft, FolderOpen, FolderPlus, Github, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button, Dialog } from "../../design/primitives";
 import { toUserMessage } from "../../lib/errors";
@@ -80,7 +80,7 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
   const authGeneration = useConnection((s) => s.authGeneration);
 
   const [step, setStep] = useState<Step>("pick");
-  const [selectedMode, setSelectedMode] = useState<"folder" | "github" | null>(null);
+  const [selectedMode, setSelectedMode] = useState<Mode | null>(null);
   const [name, setName] = useState("");
   const [nameTouched, setNameTouched] = useState(false);
   const [description, setDescription] = useState("");
@@ -332,28 +332,39 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
             style={{ borderColor: "var(--border-default)", color: "var(--text-primary)" }}
           />
         </label>
-        <div className="grid grid-cols-2 gap-2">
-        <ModeCard
-          icon={<FolderOpen size={16} />}
-          label="Folders"
-          description="Connect an existing folder or create a new one"
-          selected={selectedMode === "folder"}
-          onSelect={() => {
-            setSelectedMode("folder");
-            setStep("folder");
-          }}
-        />
-        <ModeCard
-          icon={<Github size={16} />}
-          label="Clone from GitHub"
-          description="Copy a repository to this computer"
-          selected={selectedMode === "github"}
-          onSelect={() => {
-            setSelectedMode("github");
-            setStep("github");
-          }}
-        />
-      </div>
+        <div className="grid grid-cols-3 gap-2">
+          <ModeCard
+            icon={<FolderOpen size={16} />}
+            label="Existing folder"
+            description="Connect a folder on this computer"
+            selected={selectedMode === "folder"}
+            onSelect={() => {
+              setSelectedMode("folder");
+              setStep("folder");
+            }}
+          />
+          <ModeCard
+            icon={<Github size={16} />}
+            label="Clone from GitHub"
+            description="Copy a repository to this computer"
+            selected={selectedMode === "github"}
+            onSelect={() => {
+              setSelectedMode("github");
+              setStep("github");
+            }}
+          />
+          <ModeCard
+            icon={<FolderPlus size={16} />}
+            label="New folder"
+            description="Create a local project"
+            selected={selectedMode === "scratch"}
+            onSelect={() => {
+              setSelectedMode("scratch");
+              setParentSelection(null);
+              setStep("scratch");
+            }}
+          />
+        </div>
       </div>
       <div className="flex justify-end gap-2 border-t px-4 py-3" style={{ borderColor: "var(--border-subtle)" }}>
         <Button variant="subtle" onClick={closeFromUser}>Cancel</Button>
@@ -415,33 +426,19 @@ function CreateProjectForm({ onClose }: { onClose: () => void }) {
       ) : null}
 
       {step === "folder" ? (
-        <>
-          <button
-            type="button"
-            className="flex items-center justify-between rounded-lg border px-3 py-2 text-left text-sm hover:bg-[var(--bg-hover)]"
-            style={{ borderColor: "var(--border-subtle)", color: "var(--text-primary)" }}
-            onClick={() => {
-              setParentSelection(null);
-              setStep("scratch");
-            }}
-          >
-            <span>New folder in Projects</span>
-            <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>Create a local project</span>
-          </button>
-          <ExistingFolderStepFields
-            name={name}
-            onNameChange={(value) => {
-              setName(value);
-              setNameTouched(true);
-            }}
-            folderPath={folderPath}
-            projects={projects}
-            onChooseFolder={chooseFolder}
-            onCreateFolder={startNewFolderAt}
-            onOpenProject={(slug) => void runSubmission((ctx) => openExistingProject(ctx, slug))}
-            submitting={submitting}
-          />
-        </>
+        <ExistingFolderStepFields
+          name={name}
+          onNameChange={(value) => {
+            setName(value);
+            setNameTouched(true);
+          }}
+          folderPath={folderPath}
+          projects={projects}
+          onChooseFolder={chooseFolder}
+          onCreateFolder={startNewFolderAt}
+          onOpenProject={(slug) => void runSubmission((ctx) => openExistingProject(ctx, slug))}
+          submitting={submitting}
+        />
       ) : null}
 
       {step === "scratch" ? (

--- a/desktop/src/renderer/src/features/desktop-shell/NativeDesktopShell.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/NativeDesktopShell.tsx
@@ -104,14 +104,6 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
     reconcileAndActivateCurrent();
   }, [reconcileAndActivateCurrent]);
 
-  const openRootAsTab = useCallback((open: () => void) => {
-    openRoot(open);
-    const tabId = useTabs.getState().activeTabId;
-    if (!tabId) return;
-    maximizeToTab(tabId);
-    focusTab(tabId);
-  }, [focusTab, maximizeToTab, openRoot]);
-
   const closeApps = useCallback(() => setLauncherOpen(false), [setLauncherOpen]);
   const toggleApps = useCallback(
     () => setLauncherOpen(!useUi.getState().appLauncherOpen),
@@ -148,12 +140,10 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
       files: () => openRoot(() => openTab(FILES_WORKSPACE_TAB_SPEC)),
       plugins: () => openRoot(() => openTab({ kind: "plugins", title: "Plugins" })),
       settings: () => openRoot(() => openTab({ kind: "settings", title: "Settings" })),
-      projects: () => desktopMode === "canvas"
-        ? openRoot(openProjectsIndex)
-        : openRootAsTab(openProjectsIndex),
+      projects: () => openRoot(openProjectsIndex),
     };
     return FIXED_DESKTOP_APPS.map((app) => ({ ...app, open: openers[app.id] }));
-  }, [desktopMode, openRoot, openRootAsTab, openTab]);
+  }, [openRoot, openTab]);
 
   const focusFallback = useCallback((excludedTabId: string) => {
     const surfaceState = useDesktopSurfaces.getState().surfaces;

--- a/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
@@ -71,6 +71,7 @@ export function ProjectChatDraft({
   canonicalProjectId = projectId,
   onCanonicalCreated,
   presentation = "hero",
+  heroHeadline,
 }: {
   summary: RuntimeSummary;
   projectId: string;
@@ -84,6 +85,7 @@ export function ProjectChatDraft({
   canonicalProjectId?: string;
   onCanonicalCreated?: (chatId: string, label: string) => void;
   presentation?: "hero" | "landing";
+  heroHeadline?: string;
 }) {
   const preferredProviderId = useProviderPreferences((s) => s.defaultProviderId);
   const composerSelections = useProviderPreferences((s) => s.composerSelections);
@@ -391,6 +393,7 @@ export function ProjectChatDraft({
       {presentation === "hero" ? (
         <ProjectChatHero
           projectLabel={projectLabel}
+          headline={heroHeadline}
           suggestionsVisible={canCreate && promptEmpty}
           typeToStartEnabled={typeToStartEnabled}
           onSuggestion={(prompt) => {

--- a/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
@@ -403,7 +403,7 @@ export function ProjectChatDraft({
         />
       ) : null}
       <div className={`shrink-0 ${presentation === "landing" ? "" : "px-6 pb-5"}`}>
-        <div className={`mx-auto w-full ${presentation === "landing" ? "max-w-none" : "max-w-[46rem]"}`} data-slot="draft-composer">
+        <div className={`@container/project-composer mx-auto w-full ${presentation === "landing" ? "max-w-none" : "max-w-[46rem]"}`} data-slot="draft-composer">
           {canonicalError || createError ? (
             <p className="mb-1 px-1 text-xs" style={{ color: "var(--danger)" }}>{canonicalError ?? createError}</p>
           ) : null}
@@ -470,9 +470,14 @@ export function ProjectChatDraft({
                   ariaLabel="Message new chat"
                   placeholder={presentation === "landing" ? "How can I help you today?" : "Ask the agent to do anything…"}
                   leadingControls={(
-                    <span className="flex h-8 min-w-0 items-center gap-1.5 rounded-lg px-2 text-sm" style={{ color: "var(--text-secondary)" }}>
-                      <FolderOpen size={14} aria-hidden />
-                      <span className="max-w-40 truncate">{projectLabel}</span>
+                    <span
+                      aria-label={`Project folder ${projectLabel}`}
+                      title={projectLabel}
+                      className="flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-lg px-2 text-sm"
+                      style={{ color: "var(--text-secondary)" }}
+                    >
+                      <FolderOpen size={14} aria-hidden className="shrink-0" />
+                      <span className="hidden max-w-40 truncate @min-[36rem]/project-composer:inline">{projectLabel}</span>
                     </span>
                   )}
               />

--- a/desktop/src/renderer/src/features/project/ProjectChatHero.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatHero.tsx
@@ -1,24 +1,20 @@
-// Suggestion chips seed the same new-chat draft as type-to-start; keep them
-// generic enough to be useful for any project shape.
-const SUGGESTIONS = [
-  "Fix a failing test",
-  "Review my recent changes",
-  "Explore the codebase",
-] as const;
+import { ChatStarterCards } from "../chat/ChatStarterCards";
 
 /**
- * The draft-chat hero block: centered headline, suggestion chips (only while
+ * The draft-chat hero block: centered headline, starter actions (only while
  * the draft prompt is empty), and the type-to-start hint. Presentational only —
  * the draft composer itself lives in ProjectChatDraft, anchored at the bottom
  * of the pane exactly like the thread composer.
  */
 export function ProjectChatHero({
   projectLabel,
+  headline = "What should we work on?",
   suggestionsVisible,
   typeToStartEnabled,
   onSuggestion,
 }: {
   projectLabel: string;
+  headline?: string;
   suggestionsVisible: boolean;
   typeToStartEnabled: boolean;
   onSuggestion: (prompt: string) => void;
@@ -30,30 +26,14 @@ export function ProjectChatHero({
     >
       <div className="flex flex-col items-center gap-2 text-center">
         <h2 className="text-xl font-semibold" style={{ color: "var(--text-primary)" }}>
-          What should we work on?
+          {headline}
         </h2>
         <p className="text-sm" style={{ color: "var(--text-tertiary)" }}>
           Start a new chat in {projectLabel}
         </p>
       </div>
       {suggestionsVisible ? (
-        <div className="flex flex-wrap items-center justify-center gap-2">
-          {SUGGESTIONS.map((suggestion) => (
-            <button
-              key={suggestion}
-              type="button"
-              onClick={() => onSuggestion(suggestion)}
-              className="rounded-full border px-3 py-1.5 text-xs transition-colors hover:bg-[var(--bg-hover)]"
-              style={{
-                borderColor: "var(--border-subtle)",
-                background: "var(--bg-surface)",
-                color: "var(--text-secondary)",
-              }}
-            >
-              {suggestion}
-            </button>
-          ))}
-        </div>
+        <ChatStarterCards onSelect={onSuggestion} />
       ) : null}
       {typeToStartEnabled && suggestionsVisible ? (
         <p className="text-[11px]" style={{ color: "var(--text-tertiary)" }}>

--- a/desktop/src/renderer/src/features/project/ProjectOverview.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectOverview.tsx
@@ -153,16 +153,16 @@ export default function ProjectOverview({
   const sessions = useMemo(() => (
     canonicalStatus === "ready"
       ? canonicalProjectSessions(canonicalChats)
-      : (canonicalStatus === "loading" || canonicalStatus === "error") && canonicalClient && active
+      : (canonicalStatus === "loading" || canonicalStatus === "error") && canonicalClient
         ? []
         : legacySessions
-  ), [active, canonicalChats, canonicalClient, canonicalStatus, legacySessions]);
+  ), [canonicalChats, canonicalClient, canonicalStatus, legacySessions]);
   const [nowMs, setNowMs] = useState(() => Date.now());
   const hermesRefreshScopeRef = useRef<string | null>(null);
 
   useEffect(() => {
     let current = true;
-    if (!active || !canonicalClient) {
+    if (!canonicalClient) {
       setCanonicalStatus("unavailable");
       setCanonicalChats([]);
       return () => { current = false; };
@@ -181,7 +181,7 @@ export default function ProjectOverview({
         : "error");
     });
     return () => { current = false; };
-  }, [active, canonicalClient, canonicalLoadRevision, canonicalProjectId]);
+  }, [canonicalClient, canonicalLoadRevision, canonicalProjectId]);
 
   useEffect(() => {
     if (!active) {

--- a/desktop/src/renderer/src/features/project/ProjectOverview.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectOverview.tsx
@@ -229,7 +229,12 @@ export default function ProjectOverview({
               seed={null}
               focusRequestId={composerFocusRequestId}
               typeToStartEnabled={canCreate}
-              presentation="landing"
+              presentation={sessions.length === 0
+                && workspaceEntry?.status !== "loading"
+                && workspaceEntry?.status !== "error"
+                ? "hero"
+                : "landing"}
+              heroHeadline="What should we build today?"
               canonicalClient={canonicalStatus === "ready" ? canonicalClient : null}
               canonicalProjectId={canonicalProjectId}
               onCanonicalCreated={(chatId, label) => {

--- a/desktop/src/renderer/src/features/project/ProjectsIndex.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectsIndex.tsx
@@ -164,7 +164,7 @@ function ProjectCard(props: {
     <button
       type="button"
       aria-label={`Open project ${project.name}`}
-      className="group flex min-h-[176px] flex-col rounded-xl border p-4 text-left outline-none transition-[border-color,background-color] hover:border-[var(--text-primary)] hover:bg-[var(--bg-hover)] focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+      className="group flex min-h-[176px] w-full flex-col rounded-xl border p-4 text-left outline-none transition-[border-color,background-color] hover:border-[var(--text-primary)] hover:bg-[var(--bg-hover)] focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
       style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
       onClick={onOpen}
     >
@@ -283,19 +283,20 @@ export default function ProjectsIndex() {
             action={api ? <Button variant="primary" onClick={() => void loadProjects(api)}>Retry</Button> : undefined}
           />
         ) : visibleProjects.length > 0 ? (
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <ul aria-label="Projects" className="grid list-none grid-cols-1 gap-3 p-0 sm:grid-cols-2 md:grid-cols-3">
             {pagedProjects.map((project) => {
               const summary = summaryProjects?.find((candidate) => candidate.id === project.slug);
               return (
-                <ProjectCard
-                  key={project.slug}
-                  project={project}
-                  summaryUpdatedAt={summary?.updatedAt}
-                  onOpen={() => openProjectOverview(project.slug, project.name || project.slug)}
-                />
+                <li key={project.slug} className="min-w-0">
+                  <ProjectCard
+                    project={project}
+                    summaryUpdatedAt={summary?.updatedAt}
+                    onOpen={() => openProjectOverview(project.slug, project.name || project.slug)}
+                  />
+                </li>
               );
             })}
-          </div>
+          </ul>
         ) : (
           <div className="rounded-xl border px-5 py-10 text-center" style={{ borderColor: "var(--border-subtle)", color: "var(--text-tertiary)" }}>
             {query ? "No projects match your search." : "Create your first project to get started."}

--- a/tests/desktop/add-project-dialog.test.tsx
+++ b/tests/desktop/add-project-dialog.test.tsx
@@ -32,8 +32,7 @@ describe("CreateProjectDialog add-project flows", () => {
     fireEvent.change(screen.getByLabelText("What are you working on?"), {
       target: { value: projectName },
     });
-    fireEvent.click(screen.getByRole("button", { name: /Folders/ }));
-    fireEvent.click(screen.getByRole("button", { name: /New folder in Projects/ }));
+    fireEvent.click(screen.getByRole("button", { name: /New folder/ }));
   }
 
   beforeEach(() => {
@@ -67,11 +66,12 @@ describe("CreateProjectDialog add-project flows", () => {
     vi.unstubAllGlobals();
   });
 
-  it("starts on the two Figma source cards and navigates back", async () => {
+  it("starts on the three Figma source cards and navigates back", async () => {
     render(<CreateProjectDialog open onClose={vi.fn()} />);
 
-    expect(screen.getByRole("button", { name: /Folders/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Existing folder/ })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Clone from GitHub/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /New folder/ })).toBeTruthy();
 
     selectCloneSource();
     expect(screen.getByPlaceholderText("https://github.com/owner/repo")).toBeTruthy();

--- a/tests/desktop/conversation-hero.test.tsx
+++ b/tests/desktop/conversation-hero.test.tsx
@@ -193,9 +193,9 @@ describe("ProjectChatsView hero empty state", () => {
     expect(await screen.findByText("What should we work on?")).toBeTruthy();
     // The draft composer (same floating bar threads use) sits under the hero.
     expect(screen.getByLabelText("Message new chat")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Fix a failing test" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Review my recent changes" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Explore the codebase" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Fix issues and failures" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Review code and suggest changes" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Explore and understand code" })).toBeTruthy();
     // The rail and the type-to-start affordance survive the hero swap.
     expect(screen.getByRole("navigation", { name: "Project conversations" })).toBeTruthy();
     expect(screen.getByText("Start typing to begin a new chat")).toBeTruthy();
@@ -286,10 +286,10 @@ describe("ProjectChatsView hero empty state", () => {
     render(<ProjectChatsView projectId="matrix-os" active />);
     await screen.findByText("What should we work on?");
 
-    fireEvent.click(screen.getByRole("button", { name: "Review my recent changes" }));
+    fireEvent.click(screen.getByRole("button", { name: "Review code and suggest changes" }));
 
     const prompt = await screen.findByLabelText("Message new chat");
-    await waitFor(() => expect(prompt.textContent).toBe("Review my recent changes"));
+    await waitFor(() => expect(prompt.textContent).toBe("Review code and suggest changes"));
     // The chip seeds the draft in place — never a second inspector copy.
     expect(screen.getAllByLabelText("Message new chat")).toHaveLength(1);
   });

--- a/tests/desktop/create-project-dialog.test.tsx
+++ b/tests/desktop/create-project-dialog.test.tsx
@@ -52,8 +52,9 @@ describe("CreateProjectDialog", () => {
     expect(screen.getAllByText("Create a project")).toHaveLength(2);
     expect(screen.getByLabelText("What are you working on?")).toBeTruthy();
     expect(screen.getByLabelText("What are you trying to achieve?")).toBeTruthy();
-    expect(screen.getByRole("button", { name: /Folders/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Existing folder/ })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Clone from GitHub/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /New folder/ })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Create project" }).hasAttribute("disabled")).toBe(true);
   });
 

--- a/tests/desktop/create-project-dialog.test.tsx
+++ b/tests/desktop/create-project-dialog.test.tsx
@@ -14,12 +14,12 @@ import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 describe("CreateProjectDialog", () => {
   function openFolders() {
     fireEvent.change(screen.getByLabelText("What are you working on?"), { target: { value: "Temporary" } });
-    fireEvent.click(screen.getByRole("button", { name: /Folders/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Existing folder/ }));
   }
 
   function openNewFolder() {
-    openFolders();
-    fireEvent.click(screen.getByRole("button", { name: /New folder in Projects/ }));
+    fireEvent.change(screen.getByLabelText("What are you working on?"), { target: { value: "Temporary" } });
+    fireEvent.click(screen.getByRole("button", { name: /New folder/ }));
   }
 
   beforeEach(() => {
@@ -61,7 +61,7 @@ describe("CreateProjectDialog", () => {
   it("opens the folder and GitHub source flows directly from their cards", () => {
     render(<Tooltip.Provider><CreateProjectDialog open onClose={vi.fn()} /></Tooltip.Provider>);
 
-    fireEvent.click(screen.getByRole("button", { name: /Folders/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Existing folder/ }));
     expect(screen.getByText("Connect an existing folder")).toBeTruthy();
 
     fireEvent.click(screen.getAllByRole("button", { name: "Back" })[0]!);

--- a/tests/desktop/draft-chat-replaces-selection.test.tsx
+++ b/tests/desktop/draft-chat-replaces-selection.test.tsx
@@ -337,10 +337,10 @@ describe("draft chat replaces the selected thread", () => {
     fireEvent.click(screen.getByRole("button", { name: "New chat in Matrix OS" }));
     await screen.findByText("What should we work on?");
 
-    fireEvent.click(screen.getByRole("button", { name: "Review my recent changes" }));
+    fireEvent.click(screen.getByRole("button", { name: "Review code and suggest changes" }));
 
     const composer = await screen.findByLabelText("Message new chat");
-    await waitFor(() => expect(composer.textContent).toBe("Review my recent changes"));
+    await waitFor(() => expect(composer.textContent).toBe("Review code and suggest changes"));
     // Exactly one composer exists — the draft pane never duplicates the form.
     expect(screen.getAllByLabelText("Message new chat")).toHaveLength(1);
     expect(screen.queryByLabelText("Agent run prompt")).toBeNull();

--- a/tests/desktop/native-desktop-shell.test.tsx
+++ b/tests/desktop/native-desktop-shell.test.tsx
@@ -323,18 +323,22 @@ describe("native desktop shell", () => {
     expect(screen.getByRole("tab", { name: "Desktop" }).getAttribute("aria-selected")).toBe("true");
   });
 
-  it.each([
-    ["Projects", "projects"],
-  ] as const)("opens %s directly as a tab workspace", (label, kind) => {
+  it("opens Projects as a floating window and only adds it to the tab strip when maximized", () => {
     render(<><NavigationHeader nativeDesktop /><NativeDesktopShell overlayOpen={false} /></>);
 
-    fireEvent.doubleClick(screen.getByRole("button", { name: label }));
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Projects" }));
 
-    expect(screen.getByRole("tab", { name: label }).getAttribute("aria-selected")).toBe("true");
-    const tab = useTabs.getState().tabs.find((candidate) => candidate.kind === kind);
+    const tab = useTabs.getState().tabs.find((candidate) => candidate.kind === "projects");
     expect(tab).toBeTruthy();
+    expect(useDesktopSurfaces.getState().surfaces[tab!.id]?.mode).toBe("window");
+    expect(screen.getByRole("dialog", { name: "Projects window" })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Desktop" }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.queryByRole("tab", { name: "Projects" })).toBeNull();
+
+    fireEvent.click(getWindowControl("Projects", "Maximize"));
+
     expect(useDesktopSurfaces.getState().surfaces[tab!.id]?.mode).toBe("tab");
-    expect(screen.queryByRole("dialog", { name: `${label} window` })).toBeNull();
+    expect(screen.getByRole("tab", { name: "Projects" }).getAttribute("aria-selected")).toBe("true");
   });
 
   it("opens Apps as a transient launcher instead of a desktop app surface", () => {

--- a/tests/desktop/project-chat-narrow-layout.test.tsx
+++ b/tests/desktop/project-chat-narrow-layout.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import type { CanonicalChatClient } from "@desktop/renderer/src/lib/canonical-chat-client";
+import { CanonicalChatWorkspace } from "@desktop/renderer/src/features/chat/CanonicalChatWorkspace";
+import { useBoard } from "@desktop/renderer/src/stores/board";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+import { createCanonicalChatFixture } from "../contracts/fixtures/canonical-chat";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { snapshot, providerCatalog } = createCanonicalChatFixture("completed");
+const resizeObserverCallbacks: ResizeObserverCallback[] = [];
+
+class WorkspaceResizeObserver implements ResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    resizeObserverCallbacks.push(callback);
+  }
+
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+const record = {
+  chat: {
+    id: snapshot.chat.id,
+    ownerScope: snapshot.chat.ownerScope,
+    title: snapshot.chat.title,
+    lifecycle: snapshot.chat.lifecycle,
+    attention: snapshot.chat.attention,
+    revision: snapshot.chat.revision,
+    messageCount: snapshot.chat.messageCount,
+    lastMessagePreview: snapshot.chat.lastMessagePreview,
+    currentSelection: snapshot.chat.currentSelection,
+    createdAt: snapshot.chat.createdAt,
+    updatedAt: snapshot.chat.updatedAt,
+  },
+  projectId: "matrix-os",
+  providerBinding: snapshot.chat.providerBinding,
+};
+
+function client(): CanonicalChatClient {
+  return {
+    list: vi.fn(async () => ({ items: [record] })),
+    search: vi.fn(async () => ({ items: [record] })),
+    getDetail: vi.fn(async () => ({
+      record,
+      messages: snapshot.messages,
+      turns: snapshot.turns,
+      runs: snapshot.runs,
+      activities: snapshot.activities,
+    })),
+    create: vi.fn(),
+    updateProject: vi.fn(),
+    delete: vi.fn(),
+    admitTurn: vi.fn(),
+    cancelRun: vi.fn(),
+    retryTurn: vi.fn(),
+  } as CanonicalChatClient;
+}
+
+function resizeProjectChat(width: number) {
+  const workspace = document.querySelector<HTMLElement>('[data-slot="canonical-chat-workspace"]');
+  if (!workspace) throw new Error("Canonical Project Chat workspace did not render");
+  const entry = {
+    target: workspace,
+    contentRect: { width },
+  } as unknown as ResizeObserverEntry;
+  for (const callback of resizeObserverCallbacks) {
+    callback([entry], {} as ResizeObserver);
+  }
+}
+
+describe("Project Chat narrow layout", () => {
+  beforeAll(() => {
+    globalThis.ResizeObserver = WorkspaceResizeObserver;
+  });
+
+  beforeEach(() => {
+    resizeObserverCallbacks.length = 0;
+    useBoard.setState(useBoard.getInitialState(), true);
+    useConnection.setState(useConnection.getInitialState(), true);
+  });
+
+  afterEach(cleanup);
+
+  it("stacks the Project rail above an existing conversation at the OS View minimum width", async () => {
+    render(
+      <CanonicalChatWorkspace
+        client={client()}
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        initialChatId={snapshot.chat.id}
+        active
+        catalog={providerCatalog}
+      />,
+    );
+
+    await screen.findByRole("textbox", { name: "Reply to chat" });
+    act(() => resizeProjectChat(440));
+
+    const workspace = document.querySelector<HTMLElement>('[data-slot="canonical-chat-workspace"]');
+    const rail = screen.getByRole("complementary", { name: "Project chats" });
+    const composer = document.querySelector<HTMLElement>(
+      '[data-slot="shared-chat-composer"] .prompt-card',
+    );
+
+    expect(workspace?.getAttribute("data-layout")).toBe("narrow");
+    expect(workspace?.className).toContain("flex-col");
+    expect(rail.getAttribute("data-layout")).toBe("narrow");
+    expect(rail.className).toContain("w-full");
+    expect(rail.className).toContain("border-b");
+    expect(screen.getByRole("region", { name: "Messages" })).toBeTruthy();
+    expect(composer?.getAttribute("data-layout")).toBe("narrow");
+  });
+});

--- a/tests/desktop/project-overview.test.tsx
+++ b/tests/desktop/project-overview.test.tsx
@@ -269,6 +269,80 @@ describe("ProjectOverview", () => {
       .toBe(snapshot.chat.id);
   });
 
+  it("keeps canonical Project Chats when the Project window moves behind another window", async () => {
+    const { snapshot } = createCanonicalChatFixture("completed");
+    const canonicalRecord = {
+      chat: {
+        id: snapshot.chat.id,
+        ownerScope: snapshot.chat.ownerScope,
+        title: "Canonical project investigation",
+        lifecycle: snapshot.chat.lifecycle,
+        attention: snapshot.chat.attention,
+        revision: snapshot.chat.revision,
+        messageCount: snapshot.chat.messageCount,
+        lastMessagePreview: snapshot.chat.lastMessagePreview,
+        currentSelection: snapshot.chat.currentSelection,
+        createdAt: snapshot.chat.createdAt,
+        updatedAt: snapshot.chat.updatedAt,
+      },
+      projectId: "matrix-os",
+      providerBinding: snapshot.chat.providerBinding,
+    };
+    useConnection.setState({
+      status: "signed-in",
+      api: {
+        baseUrl: "https://matrix.test",
+        get: vi.fn(async (path: string) => {
+          if (path === "/api/chats?limit=100&projectId=matrix-os") return { items: [canonicalRecord] };
+          if (path === "/api/conversations") return { conversations: [] };
+          throw new Error(`unexpected api path ${path}`);
+        }),
+      } as never,
+    });
+
+    const view = render(
+      <ProjectOverview
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        summary={summaryWithThreads([{ ...thread(1), title: "Coding agent run" }])}
+        active
+        viewSwitch={null}
+      />,
+    );
+
+    await screen.findByRole("button", { name: "Open chat Canonical project investigation" });
+    view.rerender(
+      <ProjectOverview
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        summary={summaryWithThreads([{ ...thread(1), title: "Coding agent run" }])}
+        active={false}
+        viewSwitch={null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Open chat Canonical project investigation" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Open session Coding agent run" })).toBeNull();
+    });
+  });
+
+  it("keeps the Project folder context affordance available in compact windows", () => {
+    render(
+      <div style={{ width: 320 }}>
+        <ProjectOverview
+          projectId="matrix-os"
+          projectLabel="Matrix OS"
+          summary={summaryWithProjectComposer()}
+          active={false}
+          viewSwitch={null}
+        />
+      </div>,
+    );
+
+    expect(screen.getByLabelText("Project folder Matrix OS")).toBeTruthy();
+  });
+
   it("shows a safe canonical-list error instead of silently falling back to legacy sessions", async () => {
     const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     useConnection.setState({

--- a/tests/desktop/project-overview.test.tsx
+++ b/tests/desktop/project-overview.test.tsx
@@ -94,6 +94,7 @@ describe("ProjectOverview", () => {
 
     expect(screen.getByText("Loading project workspace…")).toBeTruthy();
     expect(screen.getByText("Fetching chat and workspace capabilities from this Matrix computer.")).toBeTruthy();
+    expect(screen.queryByText("What should we build today?")).toBeNull();
   });
 
   it("shows application-owned copy instead of a raw workspace error", () => {
@@ -120,6 +121,31 @@ describe("ProjectOverview", () => {
 
     expect(screen.getByText("Project sessions are unavailable.")).toBeTruthy();
     expect(screen.queryByText(/postgres failed/)).toBeNull();
+    expect(screen.queryByText("What should we build today?")).toBeNull();
+  });
+
+  it("shows the Figma empty Project hero and four starter actions only when the workspace is ready", () => {
+    render(
+      <ProjectOverview
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        summary={summaryWithProjectComposer()}
+        active={false}
+        viewSwitch={null}
+      />,
+    );
+
+    expect(screen.getByText("What should we build today?")).toBeTruthy();
+    for (const action of [
+      "Explore and understand code",
+      "Build a new feature, app, or tool",
+      "Review code and suggest changes",
+      "Fix issues and failures",
+    ]) {
+      expect(screen.getByRole("button", { name: action })).toBeTruthy();
+    }
+    expect(screen.queryByText("Loading project workspace…")).toBeNull();
+    expect(screen.queryByText("Project sessions are unavailable.")).toBeNull();
   });
 
   it("bounds the rendered recent-session collection", () => {

--- a/tests/desktop/projects-index.test.tsx
+++ b/tests/desktop/projects-index.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ProjectsIndex from "../../desktop/src/renderer/src/features/project/ProjectsIndex";
 import { useBoard } from "../../desktop/src/renderer/src/stores/board";
@@ -45,8 +45,9 @@ describe("ProjectsIndex", () => {
   it("opens a project card in the canonical project tab", () => {
     render(<ProjectsIndex />);
 
-    expect(screen.getByText("Build my portfolio and case study")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Open project Portfolio" }));
+    const collection = screen.getByRole("list", { name: "Projects" });
+    expect(within(collection).getByText("Build my portfolio and case study")).toBeTruthy();
+    fireEvent.click(within(collection).getByRole("button", { name: "Open project Portfolio" }));
 
     expect(useTabs.getState().tabs).toEqual([
       expect.objectContaining({ kind: "project", projectSlug: "portfolio", title: "Portfolio" }),

--- a/tests/e2e/desktop/project-folder-picker-layout.e2e.test.ts
+++ b/tests/e2e/desktop/project-folder-picker-layout.e2e.test.ts
@@ -85,7 +85,7 @@ suite("Desktop Add Project compact folder picker", () => {
     await page.getByRole("button", { name: "New", exact: true }).click();
     const dialog = page.getByRole("dialog", { name: "Create a project" });
     await dialog.waitFor();
-    await dialog.getByRole("button", { name: /Folders/ }).click();
+    await dialog.getByRole("button", { name: /Existing folder/ }).click();
     await dialog.getByText("Connect an existing folder", { exact: true }).waitFor();
     await dialog.getByRole("button", { name: "List view" }).click();
 


### PR DESCRIPTION
## Summary

- adapt Projects list, detail, empty, and create states to the Desktop OS View
- open Projects as a floating OS window before maximizing into a tab
- expose Existing folder, Clone from GitHub, and New folder as direct create sources
- preserve canonical Project Chat, session loading, project context, and existing submission guards
- make Project Chat stack its chat rail above the message surface at narrow OS-window widths
- add a 440px public rendered-surface regression for the Project Chat route

## Figma

- [Projects OS View states](https://www.figma.com/design/USFVlYYFZ3WKJBAzFZSceC/Desktop-app?node-id=740-14400&m=dev)

## Tests

- focused/related Project Chat and Projects coverage: 9 files, 133 tests passed
- Desktop typecheck passed
- pattern check passed with 0 violations
- production Electron build passed
- `git diff --check` passed
- exact product source at 440px confirms no horizontal overflow in workspace, Project chat rail, or composer

## Current stage

Human Review approved. Final Greptile 5/5 and current-head CI gate at `29a2024f718cf3f8c0668d3530dbd2ce5f4a07db`.

Linear: MAT-488