### PR TITLE
feat(desktop): polish canonical Chat messages

### DIFF
--- a/desktop/src/renderer/src/components/conversation/presentation.ts
+++ b/desktop/src/renderer/src/components/conversation/presentation.ts
@@ -3,7 +3,7 @@ export type ConversationMessageRole = "user" | "assistant";
 export interface ConversationAttachmentPresentation {
   id: string;
   label: string;
-  kind: "file";
+  kind: "file" | "resource" | "invocation";
 }
 
 export interface ConversationMessagePresentation {
@@ -14,8 +14,15 @@ export interface ConversationMessagePresentation {
   markdown: string;
   copyText: string;
   timestamp: number;
+  /** @deprecated Use references for new provider-neutral projections. */
   attachments?: ConversationAttachmentPresentation[];
+  references?: ConversationAttachmentPresentation[];
 }
+
+export type ConversationActionPresentation =
+  | { kind: "retry"; turnId: string; label: string }
+  | { kind: "approval"; requestId: string; decision: "approve" | "approve_for_session" | "decline" | "cancel"; label: string }
+  | { kind: "input"; requestId: string; label: string };
 
 export type ConversationActivityKind =
   | "phase"
@@ -55,10 +62,25 @@ export interface ConversationNoticePresentation {
   kind: "notice";
   id: string;
   phase: "commentary" | "final";
-  tone: "neutral" | "stopped" | "failed";
+  tone: "neutral" | "info" | "success" | "warning" | "stopped" | "failed";
   label: string;
   markdown: string;
   timestamp: number;
+  actions?: ConversationActionPresentation[];
+}
+
+export interface ConversationRequestPresentation {
+  kind: "request";
+  id: string;
+  phase: "commentary" | "final";
+  requestKind: "approval" | "input";
+  requestId: string;
+  state: "waiting" | "resolved";
+  label: string;
+  detail?: string;
+  risk?: "low" | "medium" | "high";
+  timestamp: number;
+  actions?: ConversationActionPresentation[];
 }
 
 /**
@@ -70,6 +92,7 @@ export interface ConversationWorkPresentationMap {
   message: ConversationMessagePresentation;
   "activity-group": ConversationActivityGroupPresentation;
   notice: ConversationNoticePresentation;
+  request: ConversationRequestPresentation;
 }
 
 export type ConversationWorkPresentation =
@@ -82,9 +105,11 @@ export interface ConversationTurnPresentation {
   active: boolean;
   user?: ConversationMessagePresentation;
   work: ConversationWorkPresentation[];
-  final?: ConversationMessagePresentation | ConversationNoticePresentation;
+  final?: ConversationMessagePresentation | ConversationNoticePresentation | ConversationRequestPresentation;
 }
 
 export interface ConversationPresentationCallbacks {
   copyText: (text: string) => Promise<void>;
+  performAction?: (action: ConversationActionPresentation, input?: string) => Promise<void>;
+  canPerformAction?: (action: ConversationActionPresentation) => boolean;
 }

--- a/desktop/src/renderer/src/components/conversation/transcript.tsx
+++ b/desktop/src/renderer/src/components/conversation/transcript.tsx
@@ -1,4 +1,13 @@
-import { ChevronRight, CircleAlert, FileText } from "lucide-react";
+import {
+  CheckCircle2,
+  ChevronRight,
+  CircleAlert,
+  Command,
+  FileText,
+  Link2,
+  MessageCircleQuestion,
+  ShieldAlert,
+} from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import {
   Conversation,
@@ -13,6 +22,7 @@ import type {
   ConversationMessagePresentation,
   ConversationNoticePresentation,
   ConversationPresentationCallbacks,
+  ConversationRequestPresentation,
   ConversationTurnPresentation,
   ConversationWorkPresentation,
 } from "./presentation";
@@ -81,26 +91,50 @@ function UserMessage({
   message: ConversationMessagePresentation;
   callbacks: ConversationPresentationCallbacks;
 }) {
+  const lines = message.markdown.split("\n");
+  const collapsible = message.markdown.length > 700 || lines.length > 12;
+  const [expanded, setExpanded] = useState(false);
+  const references = message.references ?? message.attachments ?? [];
+  const visibleMarkdown = collapsible && !expanded
+    ? `${lines.slice(0, 10).join("\n").slice(0, 700)}…`
+    : message.markdown;
   return (
     <ConversationItem messageId={`user:${message.id}`} scrollAnchor>
       <Message align="end">
         <MessageContent>
           <Bubble variant="secondary" align="end">
             <BubbleContent className="max-w-[580px] whitespace-pre-wrap" data-selectable>
-              {message.markdown}
-              {message.attachments?.length ? (
+              {visibleMarkdown}
+              {references.length > 0 ? (
                 <span className="mt-2 flex flex-wrap justify-end gap-1.5">
-                  {message.attachments.map((attachment) => (
+                  {references.map((reference) => {
+                    const Icon = reference.kind === "file"
+                      ? FileText
+                      : reference.kind === "invocation" ? Command : Link2;
+                    return (
                     <span
-                      key={attachment.id}
+                      key={`${reference.kind}:${reference.id}`}
                       className="inline-flex max-w-full items-center gap-1.5 rounded-md border px-2 py-1 text-xs"
                       style={{ borderColor: "var(--border-default)", color: "var(--text-secondary)" }}
                     >
-                      <FileText size={12} aria-hidden className="shrink-0" />
-                      <span className="truncate">{attachment.label}</span>
+                      <Icon size={12} aria-hidden className="shrink-0" />
+                      <span className="truncate">{reference.label}</span>
                     </span>
-                  ))}
+                    );
+                  })}
                 </span>
+              ) : null}
+              {collapsible ? (
+                <button
+                  type="button"
+                  aria-label={expanded ? "Show less" : "Show full message"}
+                  aria-expanded={expanded}
+                  className="mt-2 block rounded-md text-xs font-medium underline underline-offset-2 focus-visible:outline-2 focus-visible:outline-[var(--accent)]"
+                  style={{ color: "var(--text-secondary)" }}
+                  onClick={() => setExpanded((value) => !value)}
+                >
+                  {expanded ? "Show less" : "Show more"}
+                </button>
               ) : null}
             </BubbleContent>
           </Bubble>
@@ -190,18 +224,39 @@ function Notice({
   callbacks: ConversationPresentationCallbacks;
 }) {
   const failed = notice.tone === "failed";
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const [actionFailed, setActionFailed] = useState(false);
+  const availableActions = (notice.actions ?? []).filter((action) => (
+    callbacks.performAction && (!callbacks.canPerformAction || callbacks.canPerformAction(action))
+  ));
+  const perform = async (action: typeof availableActions[number]) => {
+    if (!callbacks.performAction || pendingAction) return;
+    setPendingAction(action.kind);
+    setActionFailed(false);
+    try {
+      await callbacks.performAction(action, undefined);
+    } catch (error) {
+      console.warn("[conversation] action failed:", error instanceof Error ? error.name : "UnknownError");
+      setActionFailed(true);
+    } finally {
+      setPendingAction(null);
+    }
+  };
   return (
     <ConversationItem messageId={`notice:${notice.id}`}>
       <Message>
         <MessageContent>
           <Bubble variant="ghost">
             <BubbleContent
-              {...(failed ? { role: "status", "aria-label": notice.label } : {})}
+              role="status"
+              aria-label={notice.label}
               className={`max-w-[620px] rounded-xl px-3.5 py-3 text-sm ${failed ? "flex items-start gap-2.5" : ""}`}
               style={{
                 background: failed
                   ? "color-mix(in srgb, var(--danger) 8%, transparent)"
-                  : "var(--bg-sunken)",
+                  : notice.tone === "success"
+                    ? "color-mix(in srgb, var(--success) 8%, transparent)"
+                    : "var(--bg-sunken)",
                 color: "var(--text-primary)",
               }}
             >
@@ -218,12 +273,129 @@ function Notice({
                 <div className="mt-0.5 leading-5" style={{ color: "var(--text-secondary)" }}>
                   <MessageResponse copyText={callbacks.copyText}>{notice.markdown}</MessageResponse>
                 </div>
+                {availableActions.length > 0 ? (
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {availableActions.map((action) => (
+                      <button
+                        key={`${action.kind}:${action.label}`}
+                        type="button"
+                        aria-label={`${action.label} ${notice.label}`}
+                        disabled={pendingAction !== null}
+                        className="rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-[var(--bg-hover)] focus-visible:outline-2 focus-visible:outline-[var(--accent)] disabled:opacity-50"
+                        style={{ borderColor: "var(--border-default)" }}
+                        onClick={() => void perform(action)}
+                      >
+                        {action.label}
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+                {actionFailed ? <p role="alert" className="mt-1 text-xs">The action failed. Try again.</p> : null}
               </div>
             </BubbleContent>
           </Bubble>
         </MessageContent>
       </Message>
     </ConversationItem>
+  );
+}
+
+function Request({
+  request,
+  callbacks,
+}: {
+  request: ConversationRequestPresentation;
+  callbacks: ConversationPresentationCallbacks;
+}) {
+  const [answer, setAnswer] = useState("");
+  const [pending, setPending] = useState(false);
+  const [actionFailed, setActionFailed] = useState(false);
+  const availableActions = (request.actions ?? []).filter((action) => (
+    callbacks.performAction && (!callbacks.canPerformAction || callbacks.canPerformAction(action))
+  ));
+  const inputAction = availableActions.find((action) => action.kind === "input");
+  const label = `${request.requestKind === "approval" ? "Approval" : "Input"} ${request.state === "waiting" ? "required" : "resolved"}: ${request.label}`;
+  const perform = async (action: typeof availableActions[number], input?: string) => {
+    if (!callbacks.performAction || pending) return;
+    setPending(true);
+    setActionFailed(false);
+    try {
+      await callbacks.performAction(action, input);
+    } catch (error) {
+      console.warn("[conversation] request action failed:", error instanceof Error ? error.name : "UnknownError");
+      setActionFailed(true);
+    } finally {
+      setPending(false);
+    }
+  };
+  const Icon = request.requestKind === "approval" ? ShieldAlert : MessageCircleQuestion;
+  return (
+    <div
+      role="group"
+      aria-label={label}
+      className="max-w-[620px] rounded-xl border p-3"
+      style={{ borderColor: "var(--border-default)", background: "var(--bg-sunken)" }}
+    >
+      <div className="flex min-w-0 items-start gap-2.5">
+        {request.state === "resolved"
+          ? <CheckCircle2 aria-hidden className="mt-0.5 size-4 shrink-0" style={{ color: "var(--success)" }} />
+          : <Icon aria-hidden className="mt-0.5 size-4 shrink-0" style={{ color: "var(--text-secondary)" }} />}
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="font-medium">{request.label}</p>
+            {request.risk ? (
+              <span className="rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wide" style={{ borderColor: "var(--border-default)", color: "var(--text-tertiary)" }}>
+                {request.risk} risk
+              </span>
+            ) : null}
+          </div>
+          {request.detail ? <p className="mt-1 text-sm" style={{ color: "var(--text-secondary)" }}>{request.detail}</p> : null}
+          {request.state === "waiting" && inputAction ? (
+            <form
+              className="mt-2 flex min-w-0 gap-2"
+              onSubmit={(event) => {
+                event.preventDefault();
+                if (answer.trim()) void perform(inputAction, answer.trim());
+              }}
+            >
+              <input
+                aria-label={`Answer ${request.label}`}
+                value={answer}
+                disabled={pending}
+                className="h-8 min-w-0 flex-1 rounded-md border bg-transparent px-2 text-sm outline-none focus:border-[var(--accent)]"
+                style={{ borderColor: "var(--border-default)" }}
+                onChange={(event) => setAnswer(event.currentTarget.value)}
+              />
+              <button
+                type="submit"
+                disabled={pending || answer.trim().length === 0}
+                className="rounded-md bg-[var(--accent)] px-2.5 text-xs font-medium text-[var(--text-on-accent)] disabled:opacity-50"
+              >
+                {inputAction.label}
+              </button>
+            </form>
+          ) : null}
+          {request.state === "waiting" && request.requestKind === "approval" && availableActions.length > 0 ? (
+            <div className="mt-2 flex flex-wrap gap-2">
+              {availableActions.map((action) => (
+                <button
+                  key={action.kind === "approval" ? action.decision : action.label}
+                  type="button"
+                  aria-label={`${action.label} ${request.label}`}
+                  disabled={pending}
+                  className="rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-[var(--bg-hover)] focus-visible:outline-2 focus-visible:outline-[var(--accent)] disabled:opacity-50"
+                  style={{ borderColor: "var(--border-default)" }}
+                  onClick={() => void perform(action, undefined)}
+                >
+                  {action.label}
+                </button>
+              ))}
+            </div>
+          ) : null}
+          {actionFailed ? <p role="alert" className="mt-1 text-xs">The action failed. Try again.</p> : null}
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -247,6 +419,7 @@ function PresentationItem({
       </ConversationItem>
     );
   }
+  if (item.kind === "request") return <Request request={item} callbacks={callbacks} />;
   if (item.kind === "notice") return <Notice notice={item} callbacks={callbacks} />;
   return (
     <ResponseMessage
@@ -307,7 +480,7 @@ export function ConversationTranscript({
   turns: ConversationTurnPresentation[];
   callbacks: ConversationPresentationCallbacks;
 }) {
-  const initialFinalIds = useRef(new Set(
+  const [initialFinalIds] = useState(() => new Set(
     turns.flatMap((turn) => turn.final ? [turn.final.id] : []),
   ));
   return (
@@ -318,7 +491,7 @@ export function ConversationTranscript({
             key={turn.id}
             turn={turn}
             callbacks={callbacks}
-            initialFinalIds={initialFinalIds.current}
+            initialFinalIds={initialFinalIds}
           />
         ))}
       </ConversationContent>

--- a/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
@@ -511,7 +511,16 @@ export function CanonicalChatWorkspace({
         ) : null}
         {controller.detail ? (
           <>
-            <ConversationTranscript turns={transcript} callbacks={{ copyText }} />
+            <ConversationTranscript
+              turns={transcript}
+              callbacks={{
+                copyText,
+                canPerformAction: (action) => action.kind === "retry",
+                performAction: async (action) => {
+                  if (action.kind === "retry") await controller.retryTurn(action.turnId);
+                },
+              }}
+            />
             <div className="mx-auto w-full max-w-[868px] shrink-0 px-5 pb-5">{composer}</div>
           </>
         ) : globalView === "conversation" && (controller.activeChatId || initialChatId) ? (

--- a/desktop/src/renderer/src/features/chat/canonical-chat-presentation.ts
+++ b/desktop/src/renderer/src/features/chat/canonical-chat-presentation.ts
@@ -5,9 +5,11 @@ import type {
   CanonicalChatTurn,
 } from "@matrix-os/contracts";
 import type {
+  ConversationAttachmentPresentation,
   ConversationActivityPresentation,
   ConversationMessagePresentation,
   ConversationNoticePresentation,
+  ConversationRequestPresentation,
   ConversationTurnPresentation,
   ConversationWorkPresentation,
 } from "../../components/conversation/presentation";
@@ -15,8 +17,6 @@ import type {
 function messageText(message: CanonicalChatMessage): string {
   return message.parts.flatMap((part) => {
     if (part.type === "text" || part.type === "summary") return [part.text];
-    if (part.type === "status") return [part.detail ? `${part.label}\n\n${part.detail}` : part.label];
-    if (part.type === "tool_result" && part.text) return [part.text];
     return [];
   }).join("\n\n");
 }
@@ -26,9 +26,20 @@ function messagePresentation(
   phase: "commentary" | "final",
 ): ConversationMessagePresentation {
   const markdown = messageText(message);
-  const attachments = message.parts.flatMap((part) => part.type === "attachment_reference"
-    ? [{ id: part.attachmentId, kind: "file" as const, label: part.label }]
-    : []);
+  const references: ConversationAttachmentPresentation[] = [];
+  for (const part of message.parts) {
+    if (part.type === "attachment_reference") {
+      references.push({ id: part.attachmentId, kind: "file", label: part.label });
+    } else if (part.type === "resource_reference") {
+      references.push({ id: part.resource.id, kind: "resource", label: part.resource.label });
+    } else if (part.type === "invocation_reference") {
+      references.push({
+        id: part.invocation.descriptorId,
+        kind: "invocation",
+        label: part.invocation.invocation,
+      });
+    }
+  }
   return {
     kind: "message",
     id: message.id,
@@ -37,8 +48,97 @@ function messagePresentation(
     markdown,
     copyText: markdown,
     timestamp: Date.parse(message.createdAt),
-    ...(attachments.length > 0 ? { attachments } : {}),
+    ...(references.length > 0 ? { references } : {}),
   };
+}
+
+function messageWork(
+  message: CanonicalChatMessage,
+): ConversationWorkPresentation[] {
+  const toolRequests = new Map<string, Extract<CanonicalChatMessage["parts"][number], { type: "tool_request" }>>();
+  const toolResults = new Map<string, Extract<CanonicalChatMessage["parts"][number], { type: "tool_result" }>>();
+  const toolOrder: string[] = [];
+  const approvals = new Map<string, Extract<CanonicalChatMessage["parts"][number], { type: "approval_request" }>>();
+  const approvalResults = new Map<string, Extract<CanonicalChatMessage["parts"][number], { type: "approval_result" }>>();
+  const approvalOrder: string[] = [];
+  const notices: ConversationNoticePresentation[] = [];
+  const timestamp = Date.parse(message.createdAt);
+
+  for (const part of message.parts) {
+    if (part.type === "tool_request") {
+      if (!toolRequests.has(part.toolCallId)) toolOrder.push(part.toolCallId);
+      toolRequests.set(part.toolCallId, part);
+    } else if (part.type === "tool_result") {
+      if (!toolRequests.has(part.toolCallId) && !toolResults.has(part.toolCallId)) toolOrder.push(part.toolCallId);
+      toolResults.set(part.toolCallId, part);
+    } else if (part.type === "approval_request") {
+      if (!approvals.has(part.approvalId)) approvalOrder.push(part.approvalId);
+      approvals.set(part.approvalId, part);
+    } else if (part.type === "approval_result") {
+      approvalResults.set(part.approvalId, part);
+    } else if (part.type === "status") {
+      notices.push({
+        kind: "notice",
+        id: `${message.id}:status:${notices.length}`,
+        phase: "commentary",
+        tone: part.tone === "error" ? "failed" : part.tone,
+        label: part.label,
+        markdown: part.detail ?? "",
+        timestamp,
+      });
+    }
+  }
+
+  const tools: ConversationWorkPresentation[] = toolOrder.length > 0
+    ? [{
+        kind: "activity-group",
+        id: `${message.id}:tools`,
+        activities: toolOrder.map((toolCallId) => {
+          const request = toolRequests.get(toolCallId);
+          const result = toolResults.get(toolCallId);
+          const state = result?.outcome === "failed"
+            ? "failed" as const
+            : result?.outcome === "cancelled"
+              ? "stopped" as const
+              : result ? "completed" as const : "running" as const;
+          const detail = [request?.inputPreview, result?.text].filter(Boolean).join("\n\n");
+          return {
+            id: `${message.id}:${toolCallId}`,
+            kind: "tool" as const,
+            state,
+            label: request?.label ?? "Tool result",
+            ...(detail ? { detail, preview: request?.inputPreview ?? result?.text, previewKind: "text" as const } : {}),
+          };
+        }),
+      }]
+    : [];
+  const requests: ConversationRequestPresentation[] = approvalOrder.map((approvalId) => {
+    const request = approvals.get(approvalId)!;
+    const resolved = approvalResults.get(approvalId);
+    return {
+      kind: "request",
+      id: `${message.id}:approval:${approvalId}`,
+      phase: "commentary",
+      requestKind: "approval",
+      requestId: approvalId,
+      state: resolved ? "resolved" : "waiting",
+      label: request.title,
+      detail: request.description,
+      risk: request.risk,
+      timestamp,
+      ...(resolved ? {} : {
+        actions: request.allowedDecisions.map((decision) => ({
+          kind: "approval" as const,
+          requestId: approvalId,
+          decision,
+          label: decision === "approve_for_session"
+            ? "Approve for session"
+            : decision === "approve" ? "Approve" : decision === "decline" ? "Decline" : "Cancel",
+        })),
+      }),
+    };
+  });
+  return [...tools, ...requests, ...notices];
 }
 
 function isActiveRun(run: CanonicalChatRun | undefined): boolean {
@@ -66,19 +166,26 @@ function runPresentation(
   run: CanonicalChatRun | undefined,
   activities: CanonicalChatRunActivity[],
   hasCommittedAssistantMessage: boolean,
+  turnId: string,
 ): {
   work: ConversationWorkPresentation[];
   streamingFinal?: ConversationMessagePresentation;
   failure?: ConversationNoticePresentation;
 } {
   if (!run) return { work: [] };
-  const runActivities = activities.filter((activity) => activity.runId === run.id);
+  const uniqueRunActivities = new Map<string, CanonicalChatRunActivity>();
+  for (const activity of activities) {
+    if (activity.runId === run.id) uniqueRunActivities.set(activity.id, activity);
+  }
+  const runActivities = [...uniqueRunActivities.values()];
   const toolProgress = new Map<string, Extract<CanonicalChatRunActivity, { type: "tool.progress" }>>();
   const agentActivities = new Map<string, Extract<CanonicalChatRunActivity, { type: "agent.activity" }>>();
   const activityOrder: Array<{ type: "tool" | "agent"; id: string }> = [];
   const toolOutput = new Map<string, string[]>();
   const streamed = new Map<string, { text: string; occurredAt: string }>();
   let runError: Extract<CanonicalChatRunActivity, { type: "run.error" }> | undefined;
+  const requests = new Map<string, ConversationRequestPresentation>();
+  const requestOrder: string[] = [];
 
   for (const activity of runActivities) {
     if (activity.type === "tool.progress") {
@@ -105,6 +212,42 @@ function runPresentation(
       });
     } else if (activity.type === "run.error") {
       runError = activity;
+    } else if (activity.type === "approval.requested") {
+      const key = `approval:${activity.approvalId}`;
+      if (!requests.has(key)) requestOrder.push(key);
+      requests.set(key, {
+        kind: "request",
+        id: activity.id,
+        phase: "commentary",
+        requestKind: "approval",
+        requestId: activity.approvalId,
+        state: "waiting",
+        label: activity.title,
+        risk: activity.risk,
+        timestamp: Date.parse(activity.occurredAt),
+      });
+    } else if (activity.type === "approval.resolved") {
+      const key = `approval:${activity.approvalId}`;
+      const current = requests.get(key);
+      if (current) requests.set(key, { ...current, state: "resolved" });
+    } else if (activity.type === "input.requested") {
+      const key = `input:${activity.requestId}`;
+      if (!requests.has(key)) requestOrder.push(key);
+      requests.set(key, {
+        kind: "request",
+        id: activity.id,
+        phase: "commentary",
+        requestKind: "input",
+        requestId: activity.requestId,
+        state: "waiting",
+        label: activity.title,
+        timestamp: Date.parse(activity.occurredAt),
+        actions: [{ kind: "input", requestId: activity.requestId, label: "Submit" }],
+      });
+    } else if (activity.type === "input.resolved") {
+      const key = `input:${activity.requestId}`;
+      const current = requests.get(key);
+      if (current) requests.set(key, { ...current, state: "resolved", actions: undefined });
     }
   }
 
@@ -136,9 +279,15 @@ function runPresentation(
       ...(detail ? { detail, preview: detail, previewKind: "text" as const } : {}),
     });
   }
-  const work: ConversationWorkPresentation[] = activityRows.length > 0
-    ? [{ kind: "activity-group", id: `${run.id}:activities`, activities: activityRows }]
-    : [];
+  const work: ConversationWorkPresentation[] = [
+    ...(activityRows.length > 0
+      ? [{ kind: "activity-group" as const, id: `${run.id}:activities`, activities: activityRows }]
+      : []),
+    ...requestOrder.flatMap((key) => {
+      const request = requests.get(key);
+      return request ? [request] : [];
+    }),
+  ];
   const streamedMessage = [...streamed.entries()].at(-1);
   const streamingFinal = !hasCommittedAssistantMessage && streamedMessage
     ? {
@@ -160,6 +309,9 @@ function runPresentation(
         label: "Agent work failed",
         markdown: runError.error.safeMessage,
         timestamp: Date.parse(runError.occurredAt),
+        ...(runError.error.retryable && runError.error.recoveryActions?.includes("retry")
+          ? { actions: [{ kind: "retry" as const, turnId, label: "Retry" }] }
+          : {}),
       }
     : undefined;
   return { work, ...(streamingFinal ? { streamingFinal } : {}), ...(failure ? { failure } : {}) };
@@ -180,9 +332,13 @@ export function canonicalChatPresentation(input: {
       message.turnId === turn.id && message.role === "assistant"
     ));
     const finalMessage = assistantMessages.at(-1);
-    const live = runPresentation(run, input.activities, Boolean(finalMessage));
+    const live = runPresentation(run, input.activities, Boolean(finalMessage), turn.id);
     const work = [
-      ...assistantMessages.slice(0, -1).map((message) => messagePresentation(message, "commentary")),
+      ...assistantMessages.slice(0, -1).flatMap((message) => [
+        ...messageWork(message),
+        ...(messageText(message) ? [messagePresentation(message, "commentary")] : []),
+      ]),
+      ...(finalMessage ? messageWork(finalMessage) : []),
       ...live.work,
     ];
     const startedAt = Date.parse(run?.startedAt ?? run?.createdAt ?? turn.createdAt);
@@ -194,7 +350,7 @@ export function canonicalChatPresentation(input: {
       active: isActiveRun(run),
       ...(userMessage ? { user: messagePresentation(userMessage, "commentary") } : {}),
       work,
-      ...(finalMessage
+      ...(finalMessage && messageText(finalMessage)
         ? { final: messagePresentation(finalMessage, "final") }
         : live.streamingFinal
           ? { final: live.streamingFinal }

--- a/desktop/src/renderer/src/features/chat/use-canonical-chat-route-controller.ts
+++ b/desktop/src/renderer/src/features/chat/use-canonical-chat-route-controller.ts
@@ -234,6 +234,25 @@ export function useCanonicalChatRouteController({
     }
   }, [client, detail, loadDetail]);
 
+  const retryTurn = useCallback(async (turnId: string) => {
+    if (!detail || detail.record.activeRun) return;
+    const routeScope = routeScopeRef.current;
+    const isCurrentScope = () => Boolean(routeScope?.active && routeScopeRef.current === routeScope);
+    try {
+      await client.retryTurn(detail.record.chat.id, turnId, {
+        clientRequestId: canonicalChatRequestId(),
+        baseRevision: detail.record.chat.revision,
+      });
+      if (!isCurrentScope()) return;
+      await loadDetail(detail.record.chat.id);
+      setError(null);
+    } catch (error: unknown) {
+      console.warn("[canonical-chat] retry failed:", diagnosticErrorKind(error));
+      if (!isCurrentScope()) return;
+      setError("The Run could not be retried. Refresh and try again.");
+    }
+  }, [client, detail, loadDetail]);
+
   const deleteChat = useCallback(async (chatId: string) => {
     const routeScope = routeScopeRef.current;
     const isCurrentScope = () => Boolean(routeScope?.active && routeScopeRef.current === routeScope);
@@ -264,6 +283,7 @@ export function useCanonicalChatRouteController({
     moveProject,
     submitTurn,
     cancelActiveRun,
+    retryTurn,
     deleteChat,
     startNewChat: () => selectChat(null),
   };

--- a/tests/desktop/canonical-chat-presentation.test.ts
+++ b/tests/desktop/canonical-chat-presentation.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { CanonicalChatRunActivitySchema } from "@matrix-os/contracts";
-import { createCanonicalChatFixture } from "../contracts/fixtures/canonical-chat";
+import {
+  createCanonicalChatFixture,
+  createCanonicalMessagePartsFixture,
+} from "../contracts/fixtures/canonical-chat";
 import { canonicalChatPresentation } from "@desktop/renderer/src/features/chat/canonical-chat-presentation";
 
 describe("canonical Chat presentation adapter", () => {
@@ -30,6 +33,67 @@ describe("canonical Chat presentation adapter", () => {
       active: false,
       user: { role: "user" },
       final: { role: "assistant" },
+    });
+  });
+
+  it("projects every canonical message part without provider-owned rendering", () => {
+    const { snapshot } = createCanonicalChatFixture("completed");
+    const run = snapshot.runs[0]!;
+    const turn = snapshot.turns[0]!;
+
+    const [projected] = canonicalChatPresentation({
+      messages: [
+        ...snapshot.messages,
+        {
+          id: "msg_fixture_structured",
+          chatId: snapshot.chat.id,
+          seq: 2,
+          role: "assistant",
+          state: "committed",
+          turnId: turn.id,
+          runId: run.id,
+          parts: createCanonicalMessagePartsFixture(),
+          createdAt: run.updatedAt,
+        },
+      ],
+      turns: snapshot.turns,
+      runs: snapshot.runs,
+      activities: snapshot.activities,
+    });
+
+    expect(projected?.work).toEqual([
+      {
+        kind: "activity-group",
+        id: "msg_fixture_structured:tools",
+        activities: [expect.objectContaining({
+          id: "msg_fixture_structured:tool_fixture",
+          kind: "tool",
+          state: "completed",
+          label: "Read the contract",
+          detail: "Contract loaded.",
+        })],
+      },
+      expect.objectContaining({
+        kind: "request",
+        requestKind: "approval",
+        state: "resolved",
+        label: "Apply changes",
+        detail: "Allow the contract edit.",
+      }),
+      expect.objectContaining({
+        kind: "notice",
+        tone: "success",
+        label: "Contract updated",
+      }),
+    ]);
+    expect(projected?.final).toMatchObject({
+      kind: "message",
+      markdown: "Build the canonical Chat contract.\n\nCanonical schemas are ready.",
+      references: [
+        { id: "attachment_fixture", kind: "file", label: "spec.md" },
+        { id: "review", kind: "invocation", label: "/review" },
+        { id: "src.gateway.routes", kind: "resource", label: "packages/gateway/src/routes.ts" },
+      ],
     });
   });
 
@@ -89,6 +153,59 @@ describe("canonical Chat presentation adapter", () => {
         copyText: "I found the issue.",
       },
     });
+  });
+
+  it("keeps live, reloaded, and reconnected activity projections identical", () => {
+    const { snapshot } = createCanonicalChatFixture("accepted");
+    const run = snapshot.runs[0]!;
+    const occurredAt = run.startedAt ?? run.createdAt;
+    const activities = [
+      {
+        id: "activity_plan_stable",
+        chatId: snapshot.chat.id,
+        runId: run.id,
+        type: "agent.activity" as const,
+        activityId: "plan_stable",
+        kind: "plan" as const,
+        label: "Plan implementation",
+        status: "running" as const,
+        occurredAt,
+      },
+      {
+        id: "activity_delta_stable_one",
+        chatId: snapshot.chat.id,
+        runId: run.id,
+        type: "assistant.delta" as const,
+        messageId: "msg_fixture_stable",
+        delta: "Stable ",
+        occurredAt,
+      },
+      {
+        id: "activity_delta_stable_two",
+        chatId: snapshot.chat.id,
+        runId: run.id,
+        type: "assistant.delta" as const,
+        messageId: "msg_fixture_stable",
+        delta: "after reconnect.",
+        occurredAt,
+      },
+    ];
+    const input = {
+      messages: snapshot.messages,
+      turns: snapshot.turns,
+      runs: snapshot.runs,
+      activities,
+    };
+
+    const live = canonicalChatPresentation(input);
+    const reloaded = canonicalChatPresentation(structuredClone(input));
+    const reconnected = canonicalChatPresentation({
+      ...structuredClone(input),
+      activities: [...activities, ...structuredClone(activities)],
+    });
+
+    expect(reloaded).toEqual(live);
+    expect(reconnected).toEqual(live);
   });
 
   it("keeps typed activity in first-received order while projecting terminal states", () => {
@@ -212,5 +329,93 @@ describe("canonical Chat presentation adapter", () => {
         }),
       ],
     }]);
+  });
+
+  it("projects safe attention and retry rows from canonical Run activity", () => {
+    const { snapshot } = createCanonicalChatFixture("failed");
+    const run = snapshot.runs[0]!;
+    const turn = snapshot.turns[0]!;
+    const occurredAt = run.completedAt ?? run.updatedAt;
+
+    const [projected] = canonicalChatPresentation({
+      messages: snapshot.messages,
+      turns: snapshot.turns,
+      runs: snapshot.runs,
+      activities: [
+        {
+          id: "activity_reasoning",
+          chatId: snapshot.chat.id,
+          runId: run.id,
+          type: "agent.activity",
+          activityId: "reasoning_safe",
+          kind: "reasoning",
+          label: "Reasoning",
+          status: "completed",
+          summary: "Compared the two public contracts.",
+          occurredAt,
+        },
+        {
+          id: "activity_approval",
+          chatId: snapshot.chat.id,
+          runId: run.id,
+          type: "approval.requested",
+          approvalId: "approval_safe",
+          title: "Apply changes",
+          risk: "medium",
+          occurredAt,
+        },
+        {
+          id: "activity_input",
+          chatId: snapshot.chat.id,
+          runId: run.id,
+          type: "input.requested",
+          requestId: "input_safe",
+          title: "Choose a target",
+          occurredAt,
+        },
+        {
+          id: "activity_failure",
+          chatId: snapshot.chat.id,
+          runId: run.id,
+          type: "run.error",
+          error: {
+            code: "run_failed",
+            safeMessage: "The Run stopped safely.",
+            retryable: true,
+            recoveryActions: ["retry"],
+          },
+          occurredAt,
+        },
+      ],
+    });
+
+    expect(projected?.work).toEqual([
+      {
+        kind: "activity-group",
+        id: `${run.id}:activities`,
+        activities: [expect.objectContaining({
+          kind: "reasoning",
+          detail: "Compared the two public contracts.",
+        })],
+      },
+      expect.objectContaining({
+        kind: "request",
+        requestKind: "approval",
+        state: "waiting",
+        requestId: "approval_safe",
+      }),
+      expect.objectContaining({
+        kind: "request",
+        requestKind: "input",
+        state: "waiting",
+        requestId: "input_safe",
+      }),
+    ]);
+    expect(projected?.final).toMatchObject({
+      kind: "notice",
+      tone: "failed",
+      markdown: "The Run stopped safely.",
+      actions: [{ kind: "retry", turnId: turn.id, label: "Retry" }],
+    });
   });
 });

--- a/tests/desktop/canonical-chat-route-controller.test.tsx
+++ b/tests/desktop/canonical-chat-route-controller.test.tsx
@@ -640,4 +640,30 @@ describe("canonical Chat route controller", () => {
     expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("provider secret detail"));
     warn.mockRestore();
   });
+
+  it("retries a failed canonical Turn with the confirmed Chat revision", async () => {
+    const retryTurn = vi.fn(async () => ({
+      record: { ...globalRecord, chat: { ...globalRecord.chat, revision: 1 } },
+      turn: { id: "cturn_retry" },
+      run: { id: "run_retry" },
+      admission: "accepted" as const,
+    }));
+    const sharedClient = client({ retryTurn });
+    const { result } = renderHook(() => useCanonicalChatRouteController({
+      client: sharedClient,
+      projectId: null,
+      active: true,
+    }));
+    await waitFor(() => expect(result.current.detail?.record.chat.id).toBe("chat_global"));
+
+    await act(async () => {
+      await result.current.retryTurn("cturn_retry");
+    });
+
+    expect(retryTurn).toHaveBeenCalledWith("chat_global", "cturn_retry", {
+      clientRequestId: expect.stringMatching(/^req_/),
+      baseRevision: 0,
+    });
+    expect(sharedClient.getDetail).toHaveBeenCalledTimes(2);
+  });
 });

--- a/tests/desktop/canonical-chat-workspace.test.tsx
+++ b/tests/desktop/canonical-chat-workspace.test.tsx
@@ -333,6 +333,74 @@ describe("CanonicalChatWorkspace", () => {
     expect(screen.getByRole("complementary", { name: "Conversation tools" })).toBeTruthy();
   });
 
+  it("wires the canonical failed-Run retry action without a provider store", async () => {
+    const failed = createCanonicalChatFixture("failed").snapshot;
+    const failedRun = failed.runs[0]!;
+    const failedTurn = failed.turns[0]!;
+    const failedRecord = {
+      chat: {
+        id: failed.chat.id,
+        ownerScope: failed.chat.ownerScope,
+        title: failed.chat.title,
+        lifecycle: failed.chat.lifecycle,
+        attention: failed.chat.attention,
+        revision: failed.chat.revision,
+        messageCount: failed.chat.messageCount,
+        lastMessagePreview: failed.chat.lastMessagePreview,
+        currentSelection: failed.chat.currentSelection,
+        createdAt: failed.chat.createdAt,
+        updatedAt: failed.chat.updatedAt,
+      },
+      projectId: "matrix-os",
+      providerBinding: failed.chat.providerBinding,
+    };
+    const failedClient = client();
+    vi.mocked(failedClient.list).mockResolvedValue({ items: [failedRecord] });
+    vi.mocked(failedClient.getDetail).mockResolvedValue({
+      record: failedRecord,
+      messages: failed.messages,
+      turns: failed.turns,
+      runs: failed.runs,
+      activities: [{
+        id: "activity_failed_retry",
+        chatId: failed.chat.id,
+        runId: failedRun.id,
+        type: "run.error",
+        error: {
+          code: "run_failed",
+          safeMessage: "The Run stopped safely.",
+          retryable: true,
+          recoveryActions: ["retry"],
+        },
+        occurredAt: failedRun.completedAt ?? failedRun.updatedAt,
+      }],
+    });
+    vi.mocked(failedClient.retryTurn).mockResolvedValue({
+      record: failedRecord,
+      turn: failedTurn,
+      run: failedRun,
+      admission: "accepted",
+    });
+
+    render(
+      <CanonicalChatWorkspace
+        client={failedClient}
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        active
+        catalog={providerCatalog}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: failed.chat.title }));
+    fireEvent.click(await screen.findByRole("button", { name: "Retry Agent work failed" }));
+    await waitFor(() => expect(failedClient.retryTurn).toHaveBeenCalledWith(
+      failed.chat.id,
+      failedTurn.id,
+      { clientRequestId: expect.stringMatching(/^req_/), baseRevision: failed.chat.revision },
+    ));
+  });
+
   it("shows a conversation loading state instead of flashing the New Chat hero", async () => {
     let resolveDetail!: (value: Awaited<ReturnType<CanonicalChatClient["getDetail"]>>) => void;
     const delayedClient = client();

--- a/tests/desktop/conversation-transcript-neutral.test.tsx
+++ b/tests/desktop/conversation-transcript-neutral.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConversationTranscript } from "../../desktop/src/renderer/src/components/conversation/transcript";
 import type { ConversationTurnPresentation } from "../../desktop/src/renderer/src/components/conversation/presentation";
@@ -160,5 +160,152 @@ describe("provider-neutral conversation transcript", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("renders structured references and keeps long user content keyboard-expandable", () => {
+    const longUserText = Array.from({ length: 18 }, (_, index) => `line ${index}`).join("\n");
+    const turns: ConversationTurnPresentation[] = [{
+      id: "turn-structured",
+      startedAt: 1_000,
+      endedAt: 2_000,
+      active: false,
+      user: {
+        kind: "message",
+        id: "message-user-long",
+        role: "user",
+        phase: "commentary",
+        markdown: longUserText,
+        copyText: longUserText,
+        timestamp: 1_000,
+        references: [
+          { id: "file-1", kind: "file", label: "spec.md" },
+          { id: "resource-1", kind: "resource", label: "packages/gateway" },
+          { id: "skill-1", kind: "invocation", label: "/review" },
+        ],
+      },
+      work: [],
+    }];
+
+    render(<ConversationTranscript turns={turns} callbacks={{ copyText: vi.fn() }} />);
+
+    expect(screen.getByText("spec.md")).toBeTruthy();
+    expect(screen.getByText("packages/gateway")).toBeTruthy();
+    expect(screen.getByText("/review")).toBeTruthy();
+    const expand = screen.getByRole("button", { name: "Show full message" });
+    fireEvent.keyDown(expand, { key: "Enter" });
+    fireEvent.click(expand);
+    expect(screen.getByRole("button", { name: "Show less" })).toBeTruthy();
+    expect(screen.getByText(/line 17/)).toBeTruthy();
+  });
+
+  it("exposes provider-neutral approval, requested-input, and retry actions", async () => {
+    const performAction = vi.fn(async () => undefined);
+    const turns: ConversationTurnPresentation[] = [{
+      id: "turn-actions",
+      startedAt: 1_000,
+      endedAt: 1_000,
+      active: true,
+      work: [
+        {
+          kind: "request",
+          id: "request-approval",
+          phase: "commentary",
+          requestKind: "approval",
+          requestId: "approval-1",
+          state: "waiting",
+          label: "Apply changes",
+          detail: "Allow the safe edit.",
+          risk: "medium",
+          timestamp: 1_000,
+          actions: [
+            { kind: "approval", requestId: "approval-1", decision: "approve", label: "Approve" },
+            { kind: "approval", requestId: "approval-1", decision: "decline", label: "Decline" },
+          ],
+        },
+        {
+          kind: "request",
+          id: "request-input",
+          phase: "commentary",
+          requestKind: "input",
+          requestId: "input-1",
+          state: "waiting",
+          label: "Choose a target",
+          timestamp: 1_000,
+          actions: [{ kind: "input", requestId: "input-1", label: "Submit" }],
+        },
+      ],
+      final: {
+        kind: "notice",
+        id: "notice-failed",
+        phase: "final",
+        tone: "failed",
+        label: "Agent work failed",
+        markdown: "The Run stopped safely.",
+        timestamp: 1_000,
+        actions: [{ kind: "retry", turnId: "turn-actions", label: "Retry" }],
+      },
+    }];
+
+    render(
+      <ConversationTranscript
+        turns={turns}
+        callbacks={{ copyText: vi.fn(), performAction, canPerformAction: () => true }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve Apply changes" }));
+    expect(await screen.findByText("Allow the safe edit.")).toBeTruthy();
+    const answer = screen.getByRole("textbox", { name: "Answer Choose a target" });
+    fireEvent.change(answer, { target: { value: "Desktop" } });
+    fireEvent.submit(answer.closest("form")!);
+    fireEvent.click(screen.getByRole("button", { name: "Retry Agent work failed" }));
+
+    await waitFor(() => expect(performAction).toHaveBeenCalledTimes(3));
+    expect(performAction).toHaveBeenNthCalledWith(1, {
+      kind: "approval",
+      requestId: "approval-1",
+      decision: "approve",
+      label: "Approve",
+    }, undefined);
+    expect(performAction).toHaveBeenNthCalledWith(2, {
+      kind: "input",
+      requestId: "input-1",
+      label: "Submit",
+    }, "Desktop");
+    expect(performAction).toHaveBeenNthCalledWith(3, {
+      kind: "retry",
+      turnId: "turn-actions",
+      label: "Retry",
+    }, undefined);
+  });
+
+  it("does not expose unsupported request actions", () => {
+    const turns: ConversationTurnPresentation[] = [{
+      id: "turn-readonly-request",
+      startedAt: 1_000,
+      endedAt: 1_000,
+      active: true,
+      work: [{
+        kind: "request",
+        id: "request-readonly",
+        phase: "commentary",
+        requestKind: "approval",
+        requestId: "approval-readonly",
+        state: "waiting",
+        label: "Apply changes",
+        timestamp: 1_000,
+        actions: [{ kind: "approval", requestId: "approval-readonly", decision: "approve", label: "Approve" }],
+      }],
+    }];
+
+    render(
+      <ConversationTranscript
+        turns={turns}
+        callbacks={{ copyText: vi.fn(), performAction: vi.fn(), canPerformAction: () => false }}
+      />,
+    );
+
+    expect(screen.getByRole("group", { name: "Approval required: Apply changes" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Approve Apply changes" })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- render every canonical Chat message part through the shared ConversationTimeline, including references, tools, status, safe reasoning summaries, approvals, and requested input
- preserve typed Run activity, streaming, retryable failures, timestamps/actions, long-content expansion, and accessible keyboard controls
- keep the Desktop route provider-neutral and wire retry through the canonical Chat client
- deduplicate replayed activity IDs so live, reload, and reconnect projections stay identical

## Tests
- `bun run test -- tests/desktop/canonical-chat-presentation.test.ts tests/desktop/conversation-transcript-neutral.test.tsx tests/desktop/canonical-chat-route-controller.test.tsx tests/desktop/canonical-chat-workspace.test.tsx tests/desktop/conversation-neutral-boundary.test.ts tests/desktop/chat-tab-render.test.tsx` (86 passed)
- `pnpm --filter desktop run typecheck`
- `bun run build:desktop`
- `bun run check:patterns:diff` (0 violations; inherited warnings only)
- React Doctor changed-scope review completed; one async heuristic is a false positive because request rows are keyed by request identity

## Stack and boundaries
- stacked on MAT-458 / PR #1337 at `1345098dd72f71875e29ca6ad164315b262645c7`
- no direct Hermes, thread, or workspace store imports
- no provider orchestration, exact changed-files claims, or renderer persistence
- canonical approval/input dispatch remains hidden until canonical endpoints expose those commands; pure presentation actions are covered

## Current stage
Implementation Green. Keep this PR draft and MAT-474 In Progress until coordinated exact-head Desktop evidence and human test steps are ready.