### PR TITLE
feat(chat): persist exact per-turn changes

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -11,6 +11,7 @@
     "#agent-thread-contracts": "./src/agent-thread-contracts.ts",
     "#canonical-chat": "./src/canonical-chat.ts",
     "#canonical-chat-api": "./src/canonical-chat-api.ts",
+    "#canonical-chat-changes": "./src/canonical-chat-changes.ts",
     "#canonical-chat-primitives": "./src/canonical-chat-primitives.ts",
     "#canonical-chat-compatibility": "./src/canonical-chat-compatibility.ts",
     "#canonical-chat-compatibility-public": "./src/canonical-chat-compatibility-public.ts",

--- a/packages/contracts/src/canonical-chat-changes.ts
+++ b/packages/contracts/src/canonical-chat-changes.ts
@@ -1,0 +1,122 @@
+import { z } from "zod/v4";
+import { IsoTimestampSchema } from "#contract-primitives";
+import {
+  CanonicalChatExecutionRootRefSchema,
+  canonicalBoundedText,
+  canonicalEncodedByteLength,
+  canonicalReferenceId,
+} from "#canonical-chat-primitives";
+import {
+  CanonicalChatIdSchema,
+  CanonicalChatRunIdSchema,
+  CanonicalChatTurnIdSchema,
+} from "#canonical-chat";
+
+export const CanonicalChatChangePathSchema = z.string()
+  .min(1)
+  .max(4_096)
+  .regex(/^(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))[^\\\u0000\r\n]+$/);
+
+export const CanonicalChatTurnChangeFileSchema = z.object({
+  path: CanonicalChatChangePathSchema,
+  previousPath: CanonicalChatChangePathSchema.optional(),
+  status: z.enum(["added", "modified", "deleted", "renamed", "binary"]),
+  additions: z.number().int().min(0).max(1_000_000),
+  deletions: z.number().int().min(0).max(1_000_000),
+  partial: z.boolean(),
+}).strict().superRefine((file, ctx) => {
+  if ((file.status === "renamed") !== (file.previousPath !== undefined)) {
+    ctx.addIssue({ code: "custom", path: ["previousPath"], message: "Only renamed files require a previous path" });
+  }
+});
+
+export const CanonicalChatTurnChangeSetSchema = z.object({
+  chatId: CanonicalChatIdSchema,
+  turnId: CanonicalChatTurnIdSchema,
+  runId: CanonicalChatRunIdSchema,
+  projectId: canonicalReferenceId(160),
+  executionRoot: CanonicalChatExecutionRootRefSchema,
+  revision: z.string().regex(/^turnrev_[a-f0-9]{64}$/),
+  beforeRevision: z.string().regex(/^tree_[a-f0-9]{40,64}$/),
+  afterRevision: z.string().regex(/^tree_[a-f0-9]{40,64}$/),
+  source: z.enum(["provider_authoritative", "workspace_checkpoints"]),
+  label: z.enum([
+    "Exact turn changes",
+    "Workspace changes observed during this turn",
+    "Concurrent workspace changes observed during this turn",
+    "No workspace changes",
+  ]),
+  concurrent: z.boolean(),
+  partial: z.boolean(),
+  files: z.array(CanonicalChatTurnChangeFileSchema).max(200),
+  totals: z.object({
+    changedFileCount: z.number().int().min(0).max(10_000),
+    additions: z.number().int().min(0).max(1_000_000),
+    deletions: z.number().int().min(0).max(1_000_000),
+  }).strict(),
+  capturedAt: IsoTimestampSchema,
+}).strict().superRefine((changes, ctx) => {
+  if (changes.totals.changedFileCount < changes.files.length) {
+    ctx.addIssue({ code: "custom", path: ["totals", "changedFileCount"], message: "File count cannot be smaller than the projection" });
+  }
+  if (changes.source === "provider_authoritative" && changes.label !== "Exact turn changes") {
+    ctx.addIssue({ code: "custom", path: ["label"], message: "Provider-authoritative changes require the exact-turn label" });
+  }
+  if (changes.concurrent !== changes.label.startsWith("Concurrent")) {
+    ctx.addIssue({ code: "custom", path: ["concurrent"], message: "Concurrent state and label must agree" });
+  }
+  if (changes.totals.changedFileCount === 0 && changes.label !== "No workspace changes") {
+    ctx.addIssue({ code: "custom", path: ["label"], message: "Empty changes require the no-change label" });
+  }
+});
+
+export const CanonicalChatTurnChangeSummaryResponseSchema = z.object({
+  changes: CanonicalChatTurnChangeSetSchema,
+}).strict();
+
+export const CanonicalChatTurnDiffResponseSchema = z.object({
+  chatId: CanonicalChatIdSchema,
+  turnId: CanonicalChatTurnIdSchema,
+  revision: CanonicalChatTurnChangeSetSchema.shape.revision,
+  file: CanonicalChatTurnChangeFileSchema.extend({
+    hunks: z.array(z.object({
+      id: canonicalReferenceId(128),
+      oldStart: z.number().int().min(0).max(1_000_000),
+      oldLines: z.number().int().min(0).max(1_000_000),
+      newStart: z.number().int().min(0).max(1_000_000),
+      newLines: z.number().int().min(0).max(1_000_000),
+      heading: canonicalBoundedText(120, 480).optional(),
+      partial: z.boolean(),
+      lines: z.array(z.discriminatedUnion("kind", [
+        z.object({ kind: z.literal("context"), oldLine: z.number().int().min(1), newLine: z.number().int().min(1), content: z.string().max(1_000).refine((value) => canonicalEncodedByteLength(value) <= 4_000) }).strict(),
+        z.object({ kind: z.literal("add"), newLine: z.number().int().min(1), content: z.string().max(1_000).refine((value) => canonicalEncodedByteLength(value) <= 4_000) }).strict(),
+        z.object({ kind: z.literal("remove"), oldLine: z.number().int().min(1), content: z.string().max(1_000).refine((value) => canonicalEncodedByteLength(value) <= 4_000) }).strict(),
+      ])).max(120),
+    }).strict()).max(100),
+  }).strict(),
+}).strict();
+
+export const CanonicalChatTurnFileReadQuerySchema = z.object({
+  path: CanonicalChatChangePathSchema,
+  version: z.enum(["before", "after", "current"]),
+}).strict();
+
+export const CanonicalChatTurnFileReadResponseSchema = z.object({
+  chatId: CanonicalChatIdSchema,
+  turnId: CanonicalChatTurnIdSchema,
+  revision: CanonicalChatTurnChangeSetSchema.shape.revision,
+  path: CanonicalChatChangePathSchema,
+  version: z.enum(["before", "after", "current"]),
+  label: z.enum(["Before turn", "After turn", "Current file"]),
+  content: canonicalBoundedText(64_000, 256 * 1024),
+  encoding: z.literal("utf8"),
+  truncated: z.boolean(),
+  sizeBytes: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+}).strict();
+
+export type CanonicalChatTurnChangeFile = z.infer<typeof CanonicalChatTurnChangeFileSchema>;
+export type CanonicalChatTurnChangeSet = z.infer<typeof CanonicalChatTurnChangeSetSchema>;
+export type CanonicalChatTurnChangeSummaryResponse = z.infer<typeof CanonicalChatTurnChangeSummaryResponseSchema>;
+export type CanonicalChatTurnDiffResponse = z.infer<typeof CanonicalChatTurnDiffResponseSchema>;
+export type CanonicalChatTurnFileReadQuery = z.infer<typeof CanonicalChatTurnFileReadQuerySchema>;
+export type CanonicalChatTurnFileReadResponse = z.infer<typeof CanonicalChatTurnFileReadResponseSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -27,6 +27,7 @@ export * from "#agent-runtime-config";
 export * from "#agent-thread-contracts";
 export * from "#canonical-chat";
 export * from "#canonical-chat-api";
+export * from "#canonical-chat-changes";
 export {
   CanonicalChatCompatibilityProjectionSchema,
 } from "#canonical-chat-compatibility";

--- a/packages/gateway/src/chat/database.ts
+++ b/packages/gateway/src/chat/database.ts
@@ -126,6 +126,24 @@ export interface ChatRunAdapterStateTable {
   updated_at: Timestamp;
 }
 
+export interface ChatTurnChangeSetsTable {
+  run_id: string;
+  chat_id: string;
+  turn_id: string;
+  project_id: string;
+  execution_root: JsonValue;
+  execution_root_fingerprint: string;
+  before_tree: string;
+  before_head: string;
+  after_tree: string | null;
+  after_head: string | null;
+  status: "capturing" | "settled";
+  change_set: JsonValue | null;
+  byte_count: number;
+  captured_at: Timestamp;
+  updated_at: Timestamp;
+}
+
 export interface ChatOutboxTable {
   cursor: Generated<number>;
   owner_type: "personal" | "organization";
@@ -181,6 +199,7 @@ export interface ChatDatabase {
   chat_runs: ChatRunsTable;
   chat_run_events: ChatRunEventsTable;
   chat_run_adapter_state: ChatRunAdapterStateTable;
+  chat_turn_change_sets: ChatTurnChangeSetsTable;
   chat_outbox: ChatOutboxTable;
   chat_deletions: ChatDeletionsTable;
   chat_legacy_imports: ChatLegacyImportsTable;
@@ -393,6 +412,26 @@ export async function bootstrapChatDatabase(db: Kysely<ChatDatabase>): Promise<v
     )
   `.execute(db);
   await sql`
+    CREATE TABLE IF NOT EXISTS chat_turn_change_sets (
+      run_id TEXT PRIMARY KEY REFERENCES chat_runs(id) ON DELETE CASCADE,
+      chat_id TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+      turn_id TEXT NOT NULL REFERENCES chat_turns(id) ON DELETE CASCADE,
+      project_id TEXT NOT NULL,
+      execution_root JSONB NOT NULL,
+      execution_root_fingerprint TEXT NOT NULL CHECK (execution_root_fingerprint ~ '^[a-f0-9]{64}$'),
+      before_tree TEXT NOT NULL CHECK (before_tree ~ '^[a-f0-9]{40,64}$'),
+      before_head TEXT NOT NULL CHECK (before_head ~ '^[a-f0-9]{40,64}$'),
+      after_tree TEXT CHECK (after_tree ~ '^[a-f0-9]{40,64}$'),
+      after_head TEXT CHECK (after_head ~ '^[a-f0-9]{40,64}$'),
+      status TEXT NOT NULL CHECK (status IN ('capturing', 'settled')),
+      change_set JSONB,
+      byte_count INTEGER NOT NULL DEFAULT 0 CHECK (byte_count >= 0 AND byte_count <= 524288),
+      captured_at TIMESTAMPTZ NOT NULL,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      UNIQUE (turn_id, run_id)
+    )
+  `.execute(db);
+  await sql`
     CREATE TABLE IF NOT EXISTS chat_outbox (
       cursor BIGSERIAL PRIMARY KEY,
       owner_type TEXT NOT NULL CHECK (owner_type IN ('personal', 'organization')),
@@ -451,6 +490,7 @@ export async function bootstrapChatDatabase(db: Kysely<ChatDatabase>): Promise<v
   await sql`CREATE INDEX IF NOT EXISTS idx_chat_messages_page ON chat_messages(chat_id, seq)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_chat_run_events_run_occurred ON chat_run_events(run_id, occurred_at, id)`.execute(db);
   await sql`CREATE UNIQUE INDEX IF NOT EXISTS idx_chat_run_events_receive_seq ON chat_run_events(receive_seq)`.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_chat_turn_change_sets_turn ON chat_turn_change_sets(chat_id, turn_id, updated_at DESC)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_chat_messages_search ON chat_messages USING GIN (to_tsvector('simple', search_text)) WHERE state = 'committed'`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_chat_outbox_owner_cursor ON chat_outbox(owner_type, owner_id, cursor)`.execute(db);
 }

--- a/packages/gateway/src/chat/orchestrator.ts
+++ b/packages/gateway/src/chat/orchestrator.ts
@@ -16,6 +16,7 @@ import {
   type CanonicalChatRunCancellationResponse,
   type CanonicalChatSafeError,
   type CanonicalChatTurnAdmissionResponse,
+  type CanonicalChatTurnChangeSet,
   type CanonicalCreateChatTurnRequest,
   type CanonicalRetryChatTurnRequest,
 } from "@matrix-os/contracts";
@@ -45,6 +46,7 @@ import {
   type ChatRepository,
 } from "./repository.js";
 import type { ChatOwner } from "./records.js";
+import type { ChatTurnChangeCapture, ChatTurnCheckpoint } from "./turn-changes.js";
 
 const MAX_ACTIVE_RUNS_GLOBAL = 64;
 const MAX_ACTIVE_RUNS_PER_OWNER = 8;
@@ -64,7 +66,17 @@ interface ActiveRun {
   chatId: string;
   runId: string;
   instanceId: string;
+  run: CanonicalChatRun;
+  resolvedRoot?: ResolvedChatExecutionRoot;
+  turnChangeStart?: ChatTurnCheckpoint;
+  terminalChanges?: Promise<TurnChangeSettlement | undefined>;
   completion: Promise<void>;
+}
+
+interface TurnChangeSettlement {
+  changes: CanonicalChatTurnChangeSet;
+  afterTree: string;
+  afterHead: string;
 }
 
 function id(prefix: "cturn_" | "run_" | "msg_" | "activity_"): string {
@@ -173,6 +185,7 @@ export class CanonicalChatOrchestrator {
     catalog: Pick<ChatProviderCatalogService, "getCatalog">;
     adapters: CanonicalChatProviderRegistry;
     executionRoots?: ChatExecutionRootResolver;
+    turnChanges?: Pick<ChatTurnChangeCapture, "captureStart" | "captureFinal">;
     now?: () => Date;
     shutdownDrainMs?: number;
   }) {
@@ -343,6 +356,18 @@ export class CanonicalChatOrchestrator {
       createdAt: timestamp,
       updatedAt: timestamp,
     });
+    let turnChangeStart: ChatTurnCheckpoint | undefined;
+    if (resolvedRoot && this.options.turnChanges) {
+      try {
+        turnChangeStart = await this.options.turnChanges.captureStart(resolvedRoot.primaryWorkspaceRoot);
+      } catch (error: unknown) {
+        console.warn("[chat/orchestrator] Turn checkpoint capture failed:", error instanceof Error ? error.name : "UnknownError");
+        throw new CanonicalChatOrchestrationError(
+          safeError("project_unavailable", "The Project workspace is unavailable.", true, ["retry"]),
+          503,
+        );
+      }
+    }
     let admitted;
     this.reservePendingDispatch(run.id);
     try {
@@ -354,6 +379,19 @@ export class CanonicalChatOrchestrator {
         turn,
         run,
         ...(adapterState ? { adapterState } : {}),
+        ...(turnChangeStart && resolvedRoot ? {
+          turnChangeStart: {
+            chatId,
+            turnId: turn.id,
+            runId: run.id,
+            projectId: resolvedRoot.ref.projectId,
+            executionRoot: resolvedRoot.ref,
+            executionRootFingerprint: resolvedRoot.fingerprint,
+            beforeTree: turnChangeStart.tree,
+            beforeHead: turnChangeStart.head,
+            capturedAt: timestamp,
+          },
+        } : {}),
       });
     } catch (error: unknown) {
       this.pendingDispatch.delete(run.id);
@@ -363,11 +401,13 @@ export class CanonicalChatOrchestrator {
     try {
       if (!admitted.alreadyAccepted) {
         if (this.atCapacity(owner)) {
+          const turnChanges = await this.captureTerminalChanges(admitted.run, resolvedRoot, turnChangeStart, timestamp);
           await this.options.repository.finishRun(owner, {
             chatId,
             runId: admitted.run.id,
             outcome: "failed",
             completedAt: timestamp,
+            ...(turnChanges ? { turnChanges } : {}),
           });
           throw new CanonicalChatOrchestrationError(
             safeError("run_unavailable", "Chat execution is temporarily busy.", true, ["retry"]),
@@ -382,6 +422,7 @@ export class CanonicalChatOrchestrator {
           admitted.chat.chat.messageCount + 1,
           resolvedRoot,
           resumeState,
+          turnChangeStart,
         );
       }
       return CanonicalChatTurnAdmissionResponseSchema.parse({
@@ -494,6 +535,18 @@ export class CanonicalChatOrchestrator {
       createdAt: timestamp,
       updatedAt: timestamp,
     });
+    let turnChangeStart: ChatTurnCheckpoint | undefined;
+    if (resolvedRoot && this.options.turnChanges) {
+      try {
+        turnChangeStart = await this.options.turnChanges.captureStart(resolvedRoot.primaryWorkspaceRoot);
+      } catch (error: unknown) {
+        console.warn("[chat/orchestrator] Retry checkpoint capture failed:", error instanceof Error ? error.name : "UnknownError");
+        throw new CanonicalChatOrchestrationError(
+          safeError("project_unavailable", "The Project workspace is unavailable.", true, ["retry"]),
+          503,
+        );
+      }
+    }
     let admitted;
     this.reservePendingDispatch(run.id);
     try {
@@ -505,6 +558,19 @@ export class CanonicalChatOrchestrator {
         baseRevision: input.baseRevision,
         run,
         ...(adapterState ? { adapterState } : {}),
+        ...(turnChangeStart && resolvedRoot ? {
+          turnChangeStart: {
+            chatId,
+            turnId,
+            runId: run.id,
+            projectId: resolvedRoot.ref.projectId,
+            executionRoot: resolvedRoot.ref,
+            executionRootFingerprint: resolvedRoot.fingerprint,
+            beforeTree: turnChangeStart.tree,
+            beforeHead: turnChangeStart.head,
+            capturedAt: timestamp,
+          },
+        } : {}),
       });
     } catch (error: unknown) {
       this.pendingDispatch.delete(run.id);
@@ -513,11 +579,13 @@ export class CanonicalChatOrchestrator {
     try {
       if (!admitted.alreadyAccepted) {
         if (this.atCapacity(owner)) {
+          const turnChanges = await this.captureTerminalChanges(admitted.run, resolvedRoot, turnChangeStart, timestamp);
           await this.options.repository.finishRun(owner, {
             chatId,
             runId: admitted.run.id,
             outcome: "failed",
             completedAt: timestamp,
+            ...(turnChanges ? { turnChanges } : {}),
           });
           throw new CanonicalChatOrchestrationError(
             safeError("run_unavailable", "Chat execution is temporarily busy.", true, ["retry"]),
@@ -532,6 +600,7 @@ export class CanonicalChatOrchestrator {
           admitted.chat.chat.messageCount + 1,
           resolvedRoot,
           resumeState,
+          turnChangeStart,
         );
       }
       return CanonicalChatRunAdmissionResponseSchema.parse({
@@ -553,9 +622,10 @@ export class CanonicalChatOrchestrator {
     outputSeq: number,
     resolvedRoot?: ResolvedChatExecutionRoot,
     resumeState?: unknown,
+    turnChangeStart?: ChatTurnCheckpoint,
   ): void {
     const controller = new AbortController();
-    const completion = this.dispatch(owner, message, run, adapter, outputSeq, controller, resolvedRoot, resumeState)
+    const completion = this.dispatch(owner, message, run, adapter, outputSeq, controller, resolvedRoot, resumeState, turnChangeStart)
       .catch((error: unknown) => {
         console.error("[chat/orchestrator] Run dispatch failed:", error instanceof Error ? error.name : "UnknownError");
       })
@@ -567,6 +637,9 @@ export class CanonicalChatOrchestrator {
       chatId: run.chatId,
       runId: run.id,
       instanceId: run.instanceId,
+      run,
+      ...(resolvedRoot ? { resolvedRoot } : {}),
+      ...(turnChangeStart ? { turnChangeStart } : {}),
       completion,
     });
   }
@@ -580,6 +653,7 @@ export class CanonicalChatOrchestrator {
     controller: AbortController,
     resolvedRoot?: ResolvedChatExecutionRoot,
     resumeState?: unknown,
+    turnChangeStart?: ChatTurnCheckpoint,
   ): Promise<void> {
     const startedAt = (this.options.now ?? (() => new Date()))().toISOString();
     try {
@@ -673,12 +747,14 @@ export class CanonicalChatOrchestrator {
         parts: [{ type: "text", text }],
         createdAt: completedAt,
       }) : undefined;
+      const turnChanges = await this.captureTerminalChanges(run, resolvedRoot, turnChangeStart, completedAt);
       await this.options.repository.finishRun(owner, {
         chatId: run.chatId,
         runId: run.id,
         outcome: terminal.outcome,
         completedAt,
         ...(output ? { output } : {}),
+        ...(turnChanges ? { turnChanges } : {}),
       });
     } catch (error: unknown) {
       if (error instanceof ChatRunNotActiveError) return;
@@ -699,15 +775,61 @@ export class CanonicalChatOrchestrator {
             activityError instanceof Error ? activityError.name : "UnknownError",
           );
         }
+        const turnChanges = await this.captureTerminalChanges(run, resolvedRoot, turnChangeStart, completedAt);
         await this.options.repository.finishRun(owner, {
           chatId: run.chatId,
           runId: run.id,
           outcome,
           completedAt,
+          ...(turnChanges ? { turnChanges } : {}),
         });
       } catch (finishError: unknown) {
         if (!(finishError instanceof ChatRunNotActiveError)) throw finishError;
       }
+    }
+  }
+
+  private async captureTerminalChanges(
+    run: CanonicalChatRun,
+    resolvedRoot: ResolvedChatExecutionRoot | undefined,
+    start: ChatTurnCheckpoint | undefined,
+    capturedAt: string,
+  ): Promise<TurnChangeSettlement | undefined> {
+    const active = this.active.get(run.id);
+    if (active?.terminalChanges) return active.terminalChanges;
+    const capture = this.captureTerminalChangesOnce(run, resolvedRoot, start, capturedAt);
+    if (active) active.terminalChanges = capture;
+    return capture;
+  }
+
+  private async captureTerminalChangesOnce(
+    run: CanonicalChatRun,
+    resolvedRoot: ResolvedChatExecutionRoot | undefined,
+    start: ChatTurnCheckpoint | undefined,
+    capturedAt: string,
+  ): Promise<TurnChangeSettlement | undefined> {
+    if (!this.options.turnChanges || !resolvedRoot || !start || !run.executionRoot) return undefined;
+    try {
+      const captured = await this.options.turnChanges.captureFinal({
+        root: resolvedRoot.primaryWorkspaceRoot,
+        start,
+        identity: {
+          chatId: run.chatId,
+          turnId: run.turnId,
+          runId: run.id,
+          projectId: resolvedRoot.ref.projectId,
+          executionRoot: run.executionRoot,
+        },
+        capturedAt,
+      });
+      return {
+        changes: captured.changes,
+        afterTree: captured.end.tree,
+        afterHead: captured.end.head,
+      };
+    } catch (error: unknown) {
+      console.warn("[chat/orchestrator] Terminal turn-change capture failed:", error instanceof Error ? error.name : "UnknownError");
+      return undefined;
     }
   }
 
@@ -754,11 +876,22 @@ export class CanonicalChatOrchestrator {
       });
     }
     try {
+      const completedAt = (this.options.now ?? (() => new Date()))().toISOString();
+      const turnChanges = active && active.chatId === chatId && active.owner.type === owner.type
+        && active.owner.ownerId === owner.ownerId
+        ? await this.captureTerminalChanges(
+          active.run,
+          active.resolvedRoot,
+          active.turnChangeStart,
+          completedAt,
+        )
+        : undefined;
       const finished = await this.options.repository.finishRun(owner, {
         chatId,
         runId,
         outcome: "aborted",
-        completedAt: (this.options.now ?? (() => new Date()))().toISOString(),
+        completedAt,
+        ...(turnChanges ? { turnChanges } : {}),
       });
       if (providerCancellation) {
         let timeout: ReturnType<typeof setTimeout> | undefined;

--- a/packages/gateway/src/chat/repository.ts
+++ b/packages/gateway/src/chat/repository.ts
@@ -43,6 +43,12 @@ import {
   type ChatRecord,
 } from "./records.js";
 import { ChatRunLifecycleRepository } from "./run-lifecycle-repository.js";
+import {
+  ChatTurnChangeRepository,
+  recordTurnChangeStartInTransaction,
+  type ChatTurnChangeRecord,
+  type ChatTurnChangeStartInput,
+} from "./turn-change-repository.js";
 
 export {
   ChatBusyError,
@@ -81,6 +87,7 @@ export interface AdmitTurnInput {
   turn: CanonicalChatTurn;
   run: CanonicalChatRun;
   adapterState?: { schemaVersion: number; state: unknown };
+  turnChangeStart?: ChatTurnChangeStartInput;
 }
 
 export interface AdmittedTurn {
@@ -98,6 +105,7 @@ export interface AdmitRetryInput {
   baseRevision: number;
   run: CanonicalChatRun;
   adapterState?: { schemaVersion: number; state: unknown };
+  turnChangeStart?: ChatTurnChangeStartInput;
 }
 
 export interface AdmittedRun {
@@ -218,6 +226,7 @@ export class ChatRepository {
   private readonly transactionScoped: boolean;
   private readonly detail: ChatDetailRepository;
   private readonly runLifecycle: ChatRunLifecycleRepository;
+  private readonly turnChanges: ChatTurnChangeRepository;
 
   constructor(dialectOrKysely: Dialect | Kysely<ChatDatabase>, transactionScoped = false) {
     this.kysely = dialectOrKysely instanceof Kysely
@@ -226,6 +235,7 @@ export class ChatRepository {
     this.transactionScoped = transactionScoped;
     this.detail = new ChatDetailRepository(this.kysely, hydrateRecord.bind(null, this.kysely));
     this.runLifecycle = new ChatRunLifecycleRepository(this.kysely, (fn) => this.transact(fn));
+    this.turnChanges = new ChatTurnChangeRepository(this.kysely, (fn) => this.transact(fn));
   }
 
   async bootstrap(): Promise<void> {
@@ -527,6 +537,9 @@ export class ChatRepository {
           byte_count: stateBytes,
         }).execute();
       }
+      if (input.turnChangeStart) {
+        await recordTurnChangeStartInTransaction(trx, owner, input.turnChangeStart);
+      }
 
       const revision = input.baseRevision + 1;
       const updated = await trx.updateTable("chats").set({
@@ -643,6 +656,9 @@ export class ChatRepository {
           byte_count: stateBytes,
         }).execute();
       }
+      if (input.turnChangeStart) {
+        await recordTurnChangeStartInTransaction(trx, owner, input.turnChangeStart);
+      }
       await trx.updateTable("chat_turns").set({ status: "accepted", updated_at: run.updatedAt })
         .where("id", "=", turnId).execute();
       const revision = input.baseRevision + 1;
@@ -715,6 +731,18 @@ export class ChatRepository {
       turn: toTurn(turnRow),
       latestRun: toRun(runRow),
     };
+  }
+
+  async recordTurnChangeStart(ownerInput: ChatOwner, input: ChatTurnChangeStartInput): Promise<void> {
+    return this.turnChanges.recordStart(ownerInput, input);
+  }
+
+  async getTurnChanges(
+    ownerInput: ChatOwner,
+    chatId: string,
+    turnId: string,
+  ): Promise<ChatTurnChangeRecord | null> {
+    return this.turnChanges.get(ownerInput, chatId, turnId);
   }
 
   async listActiveRunContexts(
@@ -797,6 +825,11 @@ export class ChatRepository {
     outcome: "completed" | "failed" | "aborted";
     completedAt: string;
     output?: CanonicalChatMessage;
+    turnChanges?: {
+      changes: import("@matrix-os/contracts").CanonicalChatTurnChangeSet;
+      afterTree: string;
+      afterHead: string;
+    };
   }): Promise<{ run: CanonicalChatRun; transitioned: boolean }> {
     return this.runLifecycle.finishRun(ownerInput, input);
   }

--- a/packages/gateway/src/chat/routes.ts
+++ b/packages/gateway/src/chat/routes.ts
@@ -9,6 +9,10 @@ import {
   CanonicalChatRunAdmissionResponseSchema,
   CanonicalChatRunIdSchema,
   CanonicalChatTurnIdSchema,
+  CanonicalChatTurnChangeSummaryResponseSchema,
+  CanonicalChatTurnDiffResponseSchema,
+  CanonicalChatTurnFileReadQuerySchema,
+  CanonicalChatTurnFileReadResponseSchema,
   CanonicalChatTurnAdmissionResponseSchema,
   CanonicalChatSafeErrorSchema,
   CanonicalCreateChatRequestSchema,
@@ -21,6 +25,10 @@ import {
   type CanonicalChatRunCancellationResponse,
   type CanonicalChatRunAdmissionResponse,
   type CanonicalChatTurnAdmissionResponse,
+  type CanonicalChatTurnChangeSummaryResponse,
+  type CanonicalChatTurnDiffResponse,
+  type CanonicalChatTurnFileReadQuery,
+  type CanonicalChatTurnFileReadResponse,
   type CanonicalCancelChatRunRequest,
   type CanonicalCreateChatRequest,
   type CanonicalCreateChatTurnRequest,
@@ -90,6 +98,23 @@ export interface CanonicalChatRouteService {
     limit: number;
     cursor?: string;
   }): Promise<CanonicalChatDetailResponse | null>;
+  getTurnChanges(
+    owner: ChatOwner,
+    chatId: string,
+    turnId: string,
+  ): Promise<CanonicalChatTurnChangeSummaryResponse | null>;
+  getTurnDiff(
+    owner: ChatOwner,
+    chatId: string,
+    turnId: string,
+    path: string,
+  ): Promise<CanonicalChatTurnDiffResponse | null>;
+  readTurnFile(
+    owner: ChatOwner,
+    chatId: string,
+    turnId: string,
+    input: CanonicalChatTurnFileReadQuery,
+  ): Promise<CanonicalChatTurnFileReadResponse | null>;
   admitTurn(
     principal: RequestPrincipal,
     owner: ChatOwner,
@@ -290,6 +315,63 @@ export function createCanonicalChatRoutes(options: {
       );
       if (!result) return notFound(context);
       return context.json(CanonicalChatDetailResponseSchema.parse(result));
+    } catch (error: unknown) {
+      return handleError(context, error);
+    }
+  });
+
+  routes.get("/api/chats/:chatId/turns/:turnId/changes", async (context) => {
+    try {
+      const chatId = CanonicalChatIdSchema.parse(context.req.param("chatId"));
+      const turnId = CanonicalChatTurnIdSchema.parse(context.req.param("turnId"));
+      const result = await options.service.getTurnChanges(
+        ownerFromPrincipal(options.getPrincipal(context)),
+        chatId,
+        turnId,
+      );
+      if (!result) return notFound(context);
+      return context.json(CanonicalChatTurnChangeSummaryResponseSchema.parse(result));
+    } catch (error: unknown) {
+      return handleError(context, error);
+    }
+  });
+
+  routes.get("/api/chats/:chatId/turns/:turnId/changes/diff", async (context) => {
+    try {
+      const chatId = CanonicalChatIdSchema.parse(context.req.param("chatId"));
+      const turnId = CanonicalChatTurnIdSchema.parse(context.req.param("turnId"));
+      const parsedPath = CanonicalChatTurnFileReadQuerySchema.shape.path.safeParse(context.req.query("path"));
+      if (!parsedPath.success) return validationError(context);
+      const result = await options.service.getTurnDiff(
+        ownerFromPrincipal(options.getPrincipal(context)),
+        chatId,
+        turnId,
+        parsedPath.data,
+      );
+      if (!result) return notFound(context);
+      return context.json(CanonicalChatTurnDiffResponseSchema.parse(result));
+    } catch (error: unknown) {
+      return handleError(context, error);
+    }
+  });
+
+  routes.get("/api/chats/:chatId/turns/:turnId/files", async (context) => {
+    try {
+      const chatId = CanonicalChatIdSchema.parse(context.req.param("chatId"));
+      const turnId = CanonicalChatTurnIdSchema.parse(context.req.param("turnId"));
+      const parsed = CanonicalChatTurnFileReadQuerySchema.safeParse({
+        path: context.req.query("path"),
+        version: context.req.query("version"),
+      });
+      if (!parsed.success) return validationError(context);
+      const result = await options.service.readTurnFile(
+        ownerFromPrincipal(options.getPrincipal(context)),
+        chatId,
+        turnId,
+        parsed.data,
+      );
+      if (!result) return notFound(context);
+      return context.json(CanonicalChatTurnFileReadResponseSchema.parse(result));
     } catch (error: unknown) {
       return handleError(context, error);
     }

--- a/packages/gateway/src/chat/run-lifecycle-repository.ts
+++ b/packages/gateway/src/chat/run-lifecycle-repository.ts
@@ -6,6 +6,7 @@ import {
   type CanonicalChatMessage,
   type CanonicalChatRun,
   type CanonicalChatRunActivity,
+  type CanonicalChatTurnChangeSet,
 } from "@matrix-os/contracts";
 import { sql, type Kysely, type Selectable, type Transaction } from "kysely";
 import { z } from "zod/v4";
@@ -25,6 +26,7 @@ import {
   type ChatOutboxEventType,
   type ChatOwner,
 } from "./records.js";
+import { settleTurnChangesInTransaction } from "./turn-change-repository.js";
 
 type Executor = Kysely<ChatDatabase> | Transaction<ChatDatabase>;
 type Transact = <T>(fn: (trx: Executor) => Promise<T>) => Promise<T>;
@@ -302,6 +304,7 @@ export class ChatRunLifecycleRepository {
     outcome: "completed" | "failed" | "aborted";
     completedAt: string;
     output?: CanonicalChatMessage;
+    turnChanges?: { changes: CanonicalChatTurnChangeSet; afterTree: string; afterHead: string };
   }): Promise<{ run: CanonicalChatRun; transitioned: boolean }> {
     const owner = validateOwner(ownerInput);
     const completedAt = new Date(input.completedAt).toISOString();
@@ -314,6 +317,13 @@ export class ChatRunLifecycleRepository {
       if (!current) throw new ChatNotFoundError(input.chatId);
       if (!ACTIVE_RUNS.includes(current.status as typeof ACTIVE_RUNS[number])) {
         return { run: toRun(current), transitioned: false };
+      }
+      if (input.turnChanges) {
+        await settleTurnChangesInTransaction(trx, owner, {
+          chatId: input.chatId,
+          runId: input.runId,
+          ...input.turnChanges,
+        });
       }
       if (output !== undefined) {
         const expectedState = input.outcome === "completed" ? "committed" : "failed";

--- a/packages/gateway/src/chat/service.ts
+++ b/packages/gateway/src/chat/service.ts
@@ -9,6 +9,11 @@ import {
   CanonicalChatRunAdmissionResponseSchema,
   CanonicalChatSafeErrorSchema,
   CanonicalChatTurnAdmissionResponseSchema,
+  CanonicalChatTurnIdSchema,
+  CanonicalChatTurnChangeSummaryResponseSchema,
+  CanonicalChatTurnDiffResponseSchema,
+  CanonicalChatTurnFileReadQuerySchema,
+  CanonicalChatTurnFileReadResponseSchema,
   CanonicalCreateChatTurnRequestSchema,
   CanonicalRetryChatTurnRequestSchema,
   CanonicalUpdateChatProjectRequestSchema,
@@ -19,6 +24,10 @@ import {
   type CanonicalChatRunCancellationResponse,
   type CanonicalChatRunAdmissionResponse,
   type CanonicalChatTurnAdmissionResponse,
+  type CanonicalChatTurnChangeSummaryResponse,
+  type CanonicalChatTurnDiffResponse,
+  type CanonicalChatTurnFileReadQuery,
+  type CanonicalChatTurnFileReadResponse,
   type CanonicalCancelChatRunRequest,
   type CanonicalCreateChatRequest,
   type CanonicalCreateChatTurnRequest,
@@ -32,6 +41,10 @@ import type { CanonicalChatRouteService } from "./routes.js";
 import type { RequestPrincipal } from "../request-principal.js";
 import { ChatExecutionRootError, type ChatExecutionRootResolver } from "./execution-root.js";
 import { CanonicalChatOrchestrationError, type CanonicalChatOrchestrator } from "./orchestrator.js";
+import {
+  ChatTurnChangeCaptureError,
+  type ChatTurnChangeCapture,
+} from "./turn-changes.js";
 
 const CursorEnvelopeSchema = z.discriminatedUnion("kind", [
   z.object({
@@ -49,7 +62,21 @@ const CursorEnvelopeSchema = z.discriminatedUnion("kind", [
 ]);
 
 type CursorEnvelope = z.infer<typeof CursorEnvelopeSchema>;
-type ChatServiceRepository = Pick<ChatRepository, "create" | "update" | "hardDelete" | "list" | "search" | "getDetailPage">;
+type ChatServiceRepository = Pick<ChatRepository, "create" | "update" | "hardDelete" | "list" | "search" | "getDetailPage" | "getTurnChanges">;
+
+function turnChangeUnavailable(error: unknown): never {
+  if (error instanceof ChatExecutionRootError || error instanceof ChatTurnChangeCaptureError) {
+    const retryable = error instanceof ChatExecutionRootError && error.code === "validation_unavailable"
+      || error instanceof ChatTurnChangeCaptureError && error.code === "capture_unavailable";
+    throw new CanonicalChatOrchestrationError(CanonicalChatSafeErrorSchema.parse({
+      code: "resource_unavailable",
+      safeMessage: "The requested Chat change is unavailable.",
+      retryable,
+      ...(retryable ? { recoveryActions: ["retry"] as const } : {}),
+    }), retryable ? 503 : 404);
+  }
+  throw error;
+}
 
 function encodeCursor(value: CursorEnvelope): string {
   return CanonicalChatApiCursorSchema.parse(
@@ -90,9 +117,36 @@ export function createCanonicalChatService(
   repository: ChatServiceRepository,
   options: {
     orchestrator?: Pick<CanonicalChatOrchestrator, "admitTurn" | "cancelRun" | "retryTurn">;
-    executionRoots?: Pick<ChatExecutionRootResolver, "resolve">;
+    executionRoots?: Pick<ChatExecutionRootResolver, "resolve" | "revalidate">;
+    turnChanges?: Pick<ChatTurnChangeCapture, "readDiff" | "readFile">;
   } = {},
 ): CanonicalChatRouteService {
+  const resolveStoredChanges = async (owner: ChatOwner, chatId: string, turnId: string) => {
+    const stored = await repository.getTurnChanges(
+      owner,
+      CanonicalChatIdSchema.parse(chatId),
+      CanonicalChatTurnIdSchema.parse(turnId),
+    );
+    if (!stored) return null;
+    if (!options.executionRoots || !options.turnChanges) {
+      return turnChangeUnavailable(new ChatTurnChangeCaptureError("capture_unavailable"));
+    }
+    try {
+      const resolved = await options.executionRoots.revalidate(owner, {
+        ref: stored.changes.executionRoot,
+        fingerprint: stored.executionRootFingerprint,
+      });
+      return {
+        stored,
+        root: resolved.primaryWorkspaceRoot,
+        start: { tree: stored.beforeTree, head: stored.beforeHead },
+        end: { tree: stored.afterTree, head: stored.afterHead },
+      };
+    } catch (error: unknown) {
+      return turnChangeUnavailable(error);
+    }
+  };
+
   return {
     async create(owner: ChatOwner, input: CanonicalCreateChatRequest): Promise<CanonicalChatRecord> {
       const request = CanonicalCreateChatRequestSchema.parse(input);
@@ -208,6 +262,78 @@ export function createCanonicalChatService(
       });
     },
 
+    async getTurnChanges(
+      owner: ChatOwner,
+      chatId: string,
+      turnId: string,
+    ): Promise<CanonicalChatTurnChangeSummaryResponse | null> {
+      const stored = await repository.getTurnChanges(
+        owner,
+        CanonicalChatIdSchema.parse(chatId),
+        CanonicalChatTurnIdSchema.parse(turnId),
+      );
+      return stored ? CanonicalChatTurnChangeSummaryResponseSchema.parse({ changes: stored.changes }) : null;
+    },
+
+    async getTurnDiff(
+      owner: ChatOwner,
+      chatId: string,
+      turnId: string,
+      path: string,
+    ): Promise<CanonicalChatTurnDiffResponse | null> {
+      const resolved = await resolveStoredChanges(owner, chatId, turnId);
+      if (!resolved) return null;
+      const parsedPath = CanonicalChatTurnFileReadQuerySchema.shape.path.parse(path);
+      const file = resolved.stored.changes.files.find((entry) => entry.path === parsedPath);
+      if (!file) return null;
+      try {
+        return CanonicalChatTurnDiffResponseSchema.parse({
+          chatId: resolved.stored.changes.chatId,
+          turnId: resolved.stored.changes.turnId,
+          revision: resolved.stored.changes.revision,
+          file: await options.turnChanges!.readDiff({
+            root: resolved.root,
+            path: parsedPath,
+            start: resolved.start,
+            end: resolved.end,
+            file,
+          }),
+        });
+      } catch (error: unknown) {
+        return turnChangeUnavailable(error);
+      }
+    },
+
+    async readTurnFile(
+      owner: ChatOwner,
+      chatId: string,
+      turnId: string,
+      input: CanonicalChatTurnFileReadQuery,
+    ): Promise<CanonicalChatTurnFileReadResponse | null> {
+      const resolved = await resolveStoredChanges(owner, chatId, turnId);
+      if (!resolved) return null;
+      const request = CanonicalChatTurnFileReadQuerySchema.parse(input);
+      if (!resolved.stored.changes.files.some((entry) => entry.path === request.path || entry.previousPath === request.path)) {
+        return null;
+      }
+      try {
+        return CanonicalChatTurnFileReadResponseSchema.parse({
+          chatId: resolved.stored.changes.chatId,
+          turnId: resolved.stored.changes.turnId,
+          revision: resolved.stored.changes.revision,
+          ...await options.turnChanges!.readFile({
+            root: resolved.root,
+            path: request.path,
+            version: request.version,
+            start: resolved.start,
+            end: resolved.end,
+          }),
+        });
+      } catch (error: unknown) {
+        return turnChangeUnavailable(error);
+      }
+    },
+
     async admitTurn(
       principal: RequestPrincipal,
       owner: ChatOwner,
@@ -267,6 +393,9 @@ export function createUnavailableCanonicalChatService(): CanonicalChatRouteServi
     list: unavailable,
     search: unavailable,
     getDetail: unavailable,
+    getTurnChanges: unavailable,
+    getTurnDiff: unavailable,
+    readTurnFile: unavailable,
     admitTurn: unavailable,
     cancelRun: unavailable,
     retryTurn: unavailable,

--- a/packages/gateway/src/chat/turn-change-repository.ts
+++ b/packages/gateway/src/chat/turn-change-repository.ts
@@ -1,0 +1,191 @@
+import {
+  CanonicalChatExecutionRootRefSchema,
+  CanonicalChatIdSchema,
+  CanonicalChatRunIdSchema,
+  CanonicalChatTurnChangeSetSchema,
+  CanonicalChatTurnIdSchema,
+  CanonicalOwnerScopeSchema,
+  type CanonicalChatExecutionRootRef,
+  type CanonicalChatTurnChangeSet,
+} from "@matrix-os/contracts";
+import { type Kysely, type Selectable, type Transaction } from "kysely";
+import { z } from "zod/v4";
+import type { ChatDatabase, ChatTurnChangeSetsTable } from "./database.js";
+import { ChatConflictError, ChatNotFoundError } from "./errors.js";
+import { jsonb, parseJson, type ChatOwner } from "./records.js";
+
+type Executor = Kysely<ChatDatabase> | Transaction<ChatDatabase>;
+type Transact = <T>(fn: (trx: Executor) => Promise<T>) => Promise<T>;
+const GitObjectIdSchema = z.string().regex(/^[a-f0-9]{40,64}$/);
+const FingerprintSchema = z.string().regex(/^[a-f0-9]{64}$/);
+
+export interface ChatTurnChangeStartInput {
+  chatId: string;
+  turnId: string;
+  runId: string;
+  projectId: string;
+  executionRoot: CanonicalChatExecutionRootRef;
+  executionRootFingerprint: string;
+  beforeTree: string;
+  beforeHead: string;
+  capturedAt: string;
+}
+
+export interface ChatTurnChangeRecord {
+  changes: CanonicalChatTurnChangeSet;
+  executionRootFingerprint: string;
+  beforeTree: string;
+  beforeHead: string;
+  afterTree: string;
+  afterHead: string;
+}
+
+export async function recordTurnChangeStartInTransaction(
+  trx: Executor,
+  ownerInput: ChatOwner,
+  input: ChatTurnChangeStartInput,
+): Promise<void> {
+  const owner = CanonicalOwnerScopeSchema.parse(ownerInput);
+  const parsed = {
+    chatId: CanonicalChatIdSchema.parse(input.chatId),
+    turnId: CanonicalChatTurnIdSchema.parse(input.turnId),
+    runId: CanonicalChatRunIdSchema.parse(input.runId),
+    projectId: z.string().min(1).max(160).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/).parse(input.projectId),
+    executionRoot: CanonicalChatExecutionRootRefSchema.parse(input.executionRoot),
+    executionRootFingerprint: FingerprintSchema.parse(input.executionRootFingerprint),
+    beforeTree: GitObjectIdSchema.parse(input.beforeTree),
+    beforeHead: GitObjectIdSchema.parse(input.beforeHead),
+    capturedAt: new Date(input.capturedAt).toISOString(),
+  };
+  const run = await trx.selectFrom("chat_runs")
+    .innerJoin("chats", "chats.id", "chat_runs.chat_id")
+    .select([
+      "chat_runs.id", "chat_runs.turn_id", "chat_runs.execution_root",
+      "chat_runs.execution_root_fingerprint", "chats.project_id",
+    ])
+    .where("chat_runs.id", "=", parsed.runId)
+    .where("chat_runs.chat_id", "=", parsed.chatId)
+    .where("chats.owner_type", "=", owner.type)
+    .where("chats.owner_id", "=", owner.ownerId)
+    .forUpdate()
+    .executeTakeFirst();
+  if (!run) throw new ChatNotFoundError(parsed.chatId);
+  if (run.turn_id !== parsed.turnId || run.project_id !== parsed.projectId
+    || run.execution_root_fingerprint !== parsed.executionRootFingerprint
+    || !sameJson(parseJson(run.execution_root), parsed.executionRoot)) {
+    throw new ChatConflictError(parsed.chatId, 0);
+  }
+  await trx.insertInto("chat_turn_change_sets").values({
+    run_id: parsed.runId,
+    chat_id: parsed.chatId,
+    turn_id: parsed.turnId,
+    project_id: parsed.projectId,
+    execution_root: jsonb(parsed.executionRoot),
+    execution_root_fingerprint: parsed.executionRootFingerprint,
+    before_tree: parsed.beforeTree,
+    before_head: parsed.beforeHead,
+    after_tree: null,
+    after_head: null,
+    status: "capturing",
+    change_set: null,
+    byte_count: 0,
+    captured_at: parsed.capturedAt,
+    updated_at: parsed.capturedAt,
+  }).onConflict((conflict) => conflict.column("run_id").doNothing()).execute();
+  const stored = await trx.selectFrom("chat_turn_change_sets").selectAll()
+    .where("run_id", "=", parsed.runId).executeTakeFirstOrThrow();
+  if (stored.chat_id !== parsed.chatId || stored.turn_id !== parsed.turnId || stored.project_id !== parsed.projectId
+    || stored.before_tree !== parsed.beforeTree || stored.before_head !== parsed.beforeHead
+    || stored.execution_root_fingerprint !== parsed.executionRootFingerprint
+    || !sameJson(parseJson(stored.execution_root), parsed.executionRoot)) {
+    throw new ChatConflictError(parsed.chatId, 0);
+  }
+}
+
+function sameJson(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function parseSettled(row: Selectable<ChatTurnChangeSetsTable>): ChatTurnChangeRecord | null {
+  if (row.status !== "settled" || row.change_set === null || row.after_tree === null || row.after_head === null) return null;
+  return {
+    changes: CanonicalChatTurnChangeSetSchema.parse(parseJson(row.change_set)),
+    executionRootFingerprint: row.execution_root_fingerprint,
+    beforeTree: row.before_tree,
+    beforeHead: row.before_head,
+    afterTree: row.after_tree,
+    afterHead: row.after_head,
+  };
+}
+
+export async function settleTurnChangesInTransaction(
+  trx: Executor,
+  ownerInput: ChatOwner,
+  input: {
+    chatId: string;
+    runId: string;
+    changes: CanonicalChatTurnChangeSet;
+    afterTree: string;
+    afterHead: string;
+  },
+): Promise<void> {
+  const owner = CanonicalOwnerScopeSchema.parse(ownerInput);
+  const changes = CanonicalChatTurnChangeSetSchema.parse(input.changes);
+  const afterTree = GitObjectIdSchema.parse(input.afterTree);
+  const afterHead = GitObjectIdSchema.parse(input.afterHead);
+  const row = await trx.selectFrom("chat_turn_change_sets")
+    .innerJoin("chats", "chats.id", "chat_turn_change_sets.chat_id")
+    .selectAll("chat_turn_change_sets")
+    .where("chat_turn_change_sets.run_id", "=", CanonicalChatRunIdSchema.parse(input.runId))
+    .where("chat_turn_change_sets.chat_id", "=", CanonicalChatIdSchema.parse(input.chatId))
+    .where("chats.owner_type", "=", owner.type)
+    .where("chats.owner_id", "=", owner.ownerId)
+    .forUpdate()
+    .executeTakeFirst();
+  if (!row) throw new ChatNotFoundError(input.chatId);
+  if (changes.chatId !== row.chat_id || changes.turnId !== row.turn_id || changes.runId !== row.run_id
+    || changes.projectId !== row.project_id || changes.beforeRevision !== `tree_${row.before_tree}`
+    || changes.afterRevision !== `tree_${afterTree}` || !sameJson(changes.executionRoot, parseJson(row.execution_root))) {
+    throw new ChatConflictError(input.chatId, 0);
+  }
+  const byteCount = Buffer.byteLength(JSON.stringify(changes), "utf8");
+  if (byteCount > 512 * 1024) throw new ChatConflictError(input.chatId, 0);
+  if (row.status === "settled") {
+    const existing = parseSettled(row);
+    if (!existing || !sameJson(existing.changes, changes) || existing.afterTree !== afterTree || existing.afterHead !== afterHead) {
+      throw new ChatConflictError(input.chatId, 0);
+    }
+    return;
+  }
+  await trx.updateTable("chat_turn_change_sets").set({
+    after_tree: afterTree,
+    after_head: afterHead,
+    status: "settled",
+    change_set: jsonb(changes),
+    byte_count: byteCount,
+    updated_at: changes.capturedAt,
+  }).where("run_id", "=", row.run_id).where("status", "=", "capturing").executeTakeFirstOrThrow();
+}
+
+export class ChatTurnChangeRepository {
+  constructor(private readonly kysely: Kysely<ChatDatabase>, private readonly transact: Transact) {}
+
+  async recordStart(ownerInput: ChatOwner, input: ChatTurnChangeStartInput): Promise<void> {
+    await this.transact((trx) => recordTurnChangeStartInTransaction(trx, ownerInput, input));
+  }
+
+  async get(ownerInput: ChatOwner, chatId: string, turnId: string): Promise<ChatTurnChangeRecord | null> {
+    const owner = CanonicalOwnerScopeSchema.parse(ownerInput);
+    const row = await this.kysely.selectFrom("chat_turn_change_sets")
+      .innerJoin("chats", "chats.id", "chat_turn_change_sets.chat_id")
+      .innerJoin("chat_runs", "chat_runs.id", "chat_turn_change_sets.run_id")
+      .selectAll("chat_turn_change_sets")
+      .where("chat_turn_change_sets.chat_id", "=", CanonicalChatIdSchema.parse(chatId))
+      .where("chat_turn_change_sets.turn_id", "=", CanonicalChatTurnIdSchema.parse(turnId))
+      .where("chats.owner_type", "=", owner.type)
+      .where("chats.owner_id", "=", owner.ownerId)
+      .orderBy("chat_runs.attempt", "desc")
+      .executeTakeFirst();
+    return row ? parseSettled(row) : null;
+  }
+}

--- a/packages/gateway/src/chat/turn-changes.ts
+++ b/packages/gateway/src/chat/turn-changes.ts
@@ -108,7 +108,11 @@ function parseNameStatus(output: string): NameStatus[] {
   return files;
 }
 
-function parseNumstat(output: string): Map<string, { additions: number; deletions: number; binary: boolean }> {
+export function parseBoundedNumstat(
+  output: string,
+  retainedPaths: readonly string[],
+): Map<string, { additions: number; deletions: number; binary: boolean }> {
+  const retained = new Set(retainedPaths.slice(0, MAX_CHANGE_FILES));
   const values = output.split("\0");
   const result = new Map<string, { additions: number; deletions: number; binary: boolean }>();
   for (let index = 0; index < values.length;) {
@@ -125,6 +129,7 @@ function parseNumstat(output: string): Map<string, { additions: number; deletion
       path = values[index++] ?? "";
     }
     if (!path) continue;
+    if (!retained.has(path) || result.size >= MAX_CHANGE_FILES) continue;
     const binary = additionsText === "-" || deletionsText === "-";
     result.set(path, {
       additions: binary ? 0 : Number.parseInt(additionsText, 10) || 0,
@@ -282,7 +287,10 @@ export function createChatTurnChangeCapture(options: {
         git(input.root, ["diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--numstat", "-z", input.start.tree, end.tree, "--", "."], { maxBuffer: outputLimitBytes }),
       ]);
       const nameStatus = parseNameStatus(names);
-      const stats = parseNumstat(numstat);
+      const stats = parseBoundedNumstat(
+        numstat,
+        nameStatus.slice(0, MAX_CHANGE_FILES).map((file) => file.path),
+      );
       const changedFileCount = nameStatus.length;
       const projected = nameStatus.slice(0, MAX_CHANGE_FILES).map((file) => {
         const counts = stats.get(file.path) ?? { additions: 0, deletions: 0, binary: file.status === "binary" };

--- a/packages/gateway/src/chat/turn-changes.ts
+++ b/packages/gateway/src/chat/turn-changes.ts
@@ -1,0 +1,433 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { constants as fsConstants } from "node:fs";
+import { lstat, mkdtemp, open, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { promisify } from "node:util";
+import {
+  CanonicalChatTurnChangeSetSchema,
+  CanonicalChatTurnDiffResponseSchema,
+  CanonicalChatTurnFileReadQuerySchema,
+  type CanonicalChatTurnChangeSet,
+} from "@matrix-os/contracts";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_GIT_OUTPUT_BYTES = 512 * 1024;
+const DEFAULT_READ_LIMIT_BYTES = 256 * 1024;
+const MAX_CHANGE_FILES = 200;
+const GIT_OBJECT_ID = /^[a-f0-9]{40,64}$/;
+
+export interface ChatTurnCheckpoint {
+  tree: string;
+  head: string;
+}
+
+export interface ChatTurnChangeEnd extends ChatTurnCheckpoint {}
+
+export type ChatTurnGitRunner = (
+  root: string,
+  args: readonly string[],
+  options?: { env?: NodeJS.ProcessEnv; maxBuffer?: number; timeout?: number },
+) => Promise<string>;
+
+export class ChatTurnChangeCaptureError extends Error {
+  constructor(readonly code: "capture_unavailable" | "file_not_found" | "file_unavailable" | "binary_file") {
+    super(code);
+    this.name = "ChatTurnChangeCaptureError";
+  }
+}
+
+function safeGitError(error: unknown): ChatTurnChangeCaptureError {
+  console.warn("[chat/turn-changes] Git checkpoint unavailable:", error instanceof Error ? error.name : "UnknownError");
+  return new ChatTurnChangeCaptureError("capture_unavailable");
+}
+
+const defaultRunGit: ChatTurnGitRunner = async (root, args, options) => {
+  const { stdout } = await execFileAsync("git", ["-C", root, ...args], {
+    encoding: "utf8",
+    env: options?.env,
+    maxBuffer: options?.maxBuffer ?? DEFAULT_GIT_OUTPUT_BYTES,
+    timeout: options?.timeout ?? DEFAULT_TIMEOUT_MS,
+    killSignal: "SIGKILL",
+  });
+  return stdout;
+};
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolvePromise, rejectPromise) => {
+    const timer = setTimeout(() => rejectPromise(new ChatTurnChangeCaptureError("capture_unavailable")), timeoutMs);
+    timer.unref?.();
+    promise.then(resolvePromise, rejectPromise).finally(() => clearTimeout(timer));
+  });
+}
+
+function fsCode(error: unknown): string {
+  return typeof error === "object" && error !== null && "code" in error ? String(error.code) : "";
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return rel === "" || (rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
+}
+
+function checkpointRevision(tree: string): string {
+  if (!GIT_OBJECT_ID.test(tree)) throw new ChatTurnChangeCaptureError("capture_unavailable");
+  return `tree_${tree}`;
+}
+
+interface NameStatus {
+  path: string;
+  previousPath?: string;
+  status: CanonicalChatTurnChangeSet["files"][number]["status"];
+}
+
+function parseNameStatus(output: string): NameStatus[] {
+  const values = output.split("\0");
+  const files: NameStatus[] = [];
+  for (let index = 0; index < values.length;) {
+    const status = values[index++];
+    if (!status) continue;
+    if (status.startsWith("R")) {
+      const previousPath = values[index++];
+      const path = values[index++];
+      if (previousPath && path) files.push({ path, previousPath, status: "renamed" });
+      continue;
+    }
+    const path = values[index++];
+    if (!path) continue;
+    files.push({
+      path,
+      status: status.startsWith("A") ? "added"
+        : status.startsWith("D") ? "deleted"
+          : status.startsWith("T") ? "binary"
+            : "modified",
+    });
+  }
+  return files;
+}
+
+function parseNumstat(output: string): Map<string, { additions: number; deletions: number; binary: boolean }> {
+  const values = output.split("\0");
+  const result = new Map<string, { additions: number; deletions: number; binary: boolean }>();
+  for (let index = 0; index < values.length;) {
+    const record = values[index++];
+    if (!record) continue;
+    const firstTab = record.indexOf("\t");
+    const secondTab = record.indexOf("\t", firstTab + 1);
+    if (firstTab < 0 || secondTab < 0) continue;
+    const additionsText = record.slice(0, firstTab);
+    const deletionsText = record.slice(firstTab + 1, secondTab);
+    let path = record.slice(secondTab + 1);
+    if (!path) {
+      index += 1;
+      path = values[index++] ?? "";
+    }
+    if (!path) continue;
+    const binary = additionsText === "-" || deletionsText === "-";
+    result.set(path, {
+      additions: binary ? 0 : Number.parseInt(additionsText, 10) || 0,
+      deletions: binary ? 0 : Number.parseInt(deletionsText, 10) || 0,
+      binary,
+    });
+  }
+  return result;
+}
+
+function labelFor(fileCount: number, concurrent: boolean): CanonicalChatTurnChangeSet["label"] {
+  if (fileCount === 0) return "No workspace changes";
+  return concurrent
+    ? "Concurrent workspace changes observed during this turn"
+    : "Workspace changes observed during this turn";
+}
+
+function parseDiffHunks(output: string, path: string) {
+  const hunks: Array<{
+    id: string;
+    oldStart: number;
+    oldLines: number;
+    newStart: number;
+    newLines: number;
+    heading?: string;
+    partial: boolean;
+    lines: Array<Record<string, unknown>>;
+  }> = [];
+  let current: typeof hunks[number] | undefined;
+  let oldLine = 0;
+  let newLine = 0;
+  let resultPartial = false;
+  for (const line of output.split("\n")) {
+    const header = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/.exec(line);
+    if (header) {
+      if (hunks.length >= 100) {
+        resultPartial = true;
+        current = undefined;
+        continue;
+      }
+      oldLine = Number.parseInt(header[1] ?? "0", 10);
+      newLine = Number.parseInt(header[3] ?? "0", 10);
+      const heading = (header[5] ?? "").trim().slice(0, 120);
+      current = {
+        id: `hunk_${createHash("sha256").update(`${path}\0${hunks.length}`).digest("hex").slice(0, 24)}`,
+        oldStart: oldLine,
+        oldLines: Number.parseInt(header[2] ?? "1", 10),
+        newStart: newLine,
+        newLines: Number.parseInt(header[4] ?? "1", 10),
+        ...(heading ? { heading } : {}),
+        partial: false,
+        lines: [],
+      };
+      hunks.push(current);
+      continue;
+    }
+    if (!current || line.startsWith("\\ No newline")) continue;
+    if (![" ", "+", "-"].includes(line[0] ?? "")) continue;
+    if (current.lines.length >= 120) {
+      current.partial = true;
+      resultPartial = true;
+      continue;
+    }
+    const rawContent = line.slice(1);
+    const content = rawContent.slice(0, 1_000);
+    if (content.length < rawContent.length) {
+      current.partial = true;
+      resultPartial = true;
+    }
+    if (line.startsWith(" ")) {
+      current.lines.push({ kind: "context", oldLine, newLine, content });
+      oldLine += 1;
+      newLine += 1;
+    } else if (line.startsWith("+")) {
+      current.lines.push({ kind: "add", newLine, content });
+      newLine += 1;
+    } else {
+      current.lines.push({ kind: "remove", oldLine, content });
+      oldLine += 1;
+    }
+  }
+  return { hunks, partial: resultPartial };
+}
+
+export function createChatTurnChangeCapture(options: {
+  runGit?: ChatTurnGitRunner;
+  timeoutMs?: number;
+  outputLimitBytes?: number;
+  readLimitBytes?: number;
+} = {}) {
+  const runGit = options.runGit ?? defaultRunGit;
+  const timeoutMs = Math.max(1, Math.min(options.timeoutMs ?? DEFAULT_TIMEOUT_MS, 30_000));
+  const outputLimitBytes = Math.max(1_024, Math.min(options.outputLimitBytes ?? DEFAULT_GIT_OUTPUT_BYTES, DEFAULT_GIT_OUTPUT_BYTES));
+  const readLimitBytes = Math.max(1, Math.min(options.readLimitBytes ?? DEFAULT_READ_LIMIT_BYTES, DEFAULT_READ_LIMIT_BYTES));
+
+  const git = async (root: string, args: readonly string[], commandOptions?: { env?: NodeJS.ProcessEnv; maxBuffer?: number }) => {
+    try {
+      return await withTimeout(runGit(root, args, { ...commandOptions, timeout: timeoutMs }), timeoutMs);
+    } catch (error: unknown) {
+      if (error instanceof ChatTurnChangeCaptureError) throw error;
+      throw safeGitError(error);
+    }
+  };
+
+  const snapshot = async (rootInput: string): Promise<ChatTurnCheckpoint> => {
+    const root = resolve(rootInput);
+    let temp = "";
+    try {
+      const stats = await lstat(root);
+      if (!stats.isDirectory() || stats.isSymbolicLink()) throw new ChatTurnChangeCaptureError("capture_unavailable");
+      temp = await mkdtemp(join(tmpdir(), "matrix-chat-turn-checkpoint-"));
+      const indexPath = join(temp, "index");
+      const env = { ...process.env, GIT_INDEX_FILE: indexPath, GIT_OPTIONAL_LOCKS: "0" };
+      await git(root, ["read-tree", "HEAD"], { env, maxBuffer: 64 * 1024 });
+      await git(root, ["add", "-A", "--", "."], { env, maxBuffer: outputLimitBytes });
+      const [tree, head] = await Promise.all([
+        git(root, ["write-tree"], { env, maxBuffer: 64 * 1024 }),
+        git(root, ["rev-parse", "HEAD"], { maxBuffer: 64 * 1024 }),
+      ]);
+      const parsed = { tree: tree.trim(), head: head.trim() };
+      if (!GIT_OBJECT_ID.test(parsed.tree) || !GIT_OBJECT_ID.test(parsed.head)) {
+        throw new ChatTurnChangeCaptureError("capture_unavailable");
+      }
+      return parsed;
+    } catch (error: unknown) {
+      if (error instanceof ChatTurnChangeCaptureError) throw error;
+      throw safeGitError(error);
+    } finally {
+      if (temp) {
+        await rm(temp, { recursive: true, force: true }).catch((error: unknown) => {
+          console.warn("[chat/turn-changes] Checkpoint temp cleanup failed:", error instanceof Error ? error.name : "UnknownError");
+        });
+      }
+    }
+  };
+
+  return {
+    captureStart: snapshot,
+
+    async captureFinal(input: {
+      root: string;
+      start: ChatTurnCheckpoint;
+      identity: {
+        chatId: string;
+        turnId: string;
+        runId: string;
+        projectId: string;
+        executionRoot: CanonicalChatTurnChangeSet["executionRoot"];
+      };
+      capturedAt: string;
+    }): Promise<{ changes: CanonicalChatTurnChangeSet; end: ChatTurnChangeEnd }> {
+      const end = await snapshot(input.root);
+      const [names, numstat] = await Promise.all([
+        git(input.root, ["diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--name-status", "-z", input.start.tree, end.tree, "--", "."], { maxBuffer: outputLimitBytes }),
+        git(input.root, ["diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--numstat", "-z", input.start.tree, end.tree, "--", "."], { maxBuffer: outputLimitBytes }),
+      ]);
+      const nameStatus = parseNameStatus(names);
+      const stats = parseNumstat(numstat);
+      const changedFileCount = nameStatus.length;
+      const projected = nameStatus.slice(0, MAX_CHANGE_FILES).map((file) => {
+        const counts = stats.get(file.path) ?? { additions: 0, deletions: 0, binary: file.status === "binary" };
+        return {
+          ...file,
+          status: counts.binary ? "binary" as const : file.status,
+          additions: counts.additions,
+          deletions: counts.deletions,
+          partial: counts.binary,
+        };
+      });
+      const additions = projected.reduce((total, file) => total + file.additions, 0);
+      const deletions = projected.reduce((total, file) => total + file.deletions, 0);
+      const concurrent = input.start.head !== end.head;
+      const partial = nameStatus.length > MAX_CHANGE_FILES || projected.some((file) => file.partial);
+      const revision = createHash("sha256")
+        .update(JSON.stringify({ version: 1, ...input.identity, before: input.start.tree, after: end.tree }))
+        .digest("hex");
+      return {
+        end,
+        changes: CanonicalChatTurnChangeSetSchema.parse({
+          ...input.identity,
+          revision: `turnrev_${revision}`,
+          beforeRevision: checkpointRevision(input.start.tree),
+          afterRevision: checkpointRevision(end.tree),
+          source: "workspace_checkpoints",
+          label: labelFor(changedFileCount, concurrent),
+          concurrent,
+          partial,
+          files: projected,
+          totals: { changedFileCount, additions, deletions },
+          capturedAt: input.capturedAt,
+        }),
+      };
+    },
+
+    async readFile(input: {
+      root: string;
+      path: string;
+      version: "before" | "after" | "current";
+      start: ChatTurnCheckpoint;
+      end: ChatTurnChangeEnd;
+    }): Promise<{
+      path: string;
+      version: "before" | "after" | "current";
+      label: "Before turn" | "After turn" | "Current file";
+      content: string;
+      encoding: "utf8";
+      truncated: boolean;
+      sizeBytes: number;
+    }> {
+      const parsedRequest = CanonicalChatTurnFileReadQuerySchema.safeParse({ path: input.path, version: input.version });
+      if (!parsedRequest.success) throw new ChatTurnChangeCaptureError("file_not_found");
+      const request = parsedRequest.data;
+      const root = await realpath(resolve(input.root)).catch((error: unknown) => {
+        console.warn("[chat/turn-changes] Workspace root unavailable:", error instanceof Error ? error.name : "UnknownError");
+        throw new ChatTurnChangeCaptureError("file_unavailable");
+      });
+      let content: Buffer;
+      let sizeBytes: number;
+      if (request.version === "current") {
+        const target = resolve(root, request.path);
+        if (!isWithin(root, target)) throw new ChatTurnChangeCaptureError("file_not_found");
+        let stats: Awaited<ReturnType<typeof lstat>>;
+        let targetReal: string;
+        try {
+          stats = await lstat(target);
+          if (stats.isSymbolicLink() || !stats.isFile()) throw new ChatTurnChangeCaptureError("file_not_found");
+          targetReal = await realpath(target);
+        } catch (error: unknown) {
+          if (error instanceof ChatTurnChangeCaptureError) throw error;
+          if (["ENOENT", "ENOTDIR", "EACCES"].includes(fsCode(error))) throw new ChatTurnChangeCaptureError("file_not_found");
+          throw new ChatTurnChangeCaptureError("file_unavailable");
+        }
+        if (!isWithin(root, targetReal)) throw new ChatTurnChangeCaptureError("file_not_found");
+        const handle = await open(targetReal, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW).catch((error: unknown) => {
+          if (["ELOOP", "ENOENT", "ENOTDIR", "EACCES"].includes(fsCode(error))) {
+            throw new ChatTurnChangeCaptureError("file_not_found");
+          }
+          throw new ChatTurnChangeCaptureError("file_unavailable");
+        });
+        try {
+          const opened = await handle.stat();
+          if (!opened.isFile() || opened.dev !== stats.dev || opened.ino !== stats.ino) {
+            throw new ChatTurnChangeCaptureError("file_not_found");
+          }
+          sizeBytes = Number(opened.size);
+          const buffer = Buffer.alloc(readLimitBytes + 1);
+          const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+          content = buffer.subarray(0, Number(bytesRead));
+        } finally {
+          await handle.close();
+        }
+      } else {
+        const tree = request.version === "before" ? input.start.tree : input.end.tree;
+        const listing = await git(root, ["ls-tree", "-z", tree, "--", request.path], { maxBuffer: 16 * 1024 });
+        const match = listing.match(/^([0-9]{6}) blob ([a-f0-9]{40,64})\t([^\0]+)\0$/);
+        if (!match || match[3] !== request.path || match[1] === "120000") {
+          throw new ChatTurnChangeCaptureError("file_not_found");
+        }
+        const objectId = match[2]!;
+        sizeBytes = Number.parseInt((await git(root, ["cat-file", "-s", objectId], { maxBuffer: 64 * 1024 })).trim(), 10);
+        const text = await git(root, ["cat-file", "blob", objectId], { maxBuffer: readLimitBytes + 1 });
+        content = Buffer.from(text, "utf8");
+      }
+      if (content.includes(0)) throw new ChatTurnChangeCaptureError("binary_file");
+      const truncated = sizeBytes > readLimitBytes || content.byteLength > readLimitBytes;
+      const bounded = content.subarray(0, readLimitBytes);
+      return {
+        path: request.path,
+        version: request.version,
+        label: request.version === "before" ? "Before turn" : request.version === "after" ? "After turn" : "Current file",
+        content: bounded.toString("utf8"),
+        encoding: "utf8",
+        truncated,
+        sizeBytes,
+      };
+    },
+
+    async readDiff(input: {
+      root: string;
+      path: string;
+      start: ChatTurnCheckpoint;
+      end: ChatTurnChangeEnd;
+      file: CanonicalChatTurnChangeSet["files"][number];
+    }) {
+      const parsedPath = CanonicalChatTurnFileReadQuerySchema.safeParse({ path: input.path, version: "after" });
+      if (!parsedPath.success || input.file.path !== parsedPath.data.path) {
+        throw new ChatTurnChangeCaptureError("file_not_found");
+      }
+      if (input.file.status === "binary") {
+        return CanonicalChatTurnDiffResponseSchema.shape.file.parse({ ...input.file, hunks: [] });
+      }
+      const output = await git(resolve(input.root), [
+        "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--unified=3",
+        input.start.tree, input.end.tree, "--", input.file.path,
+      ], { maxBuffer: outputLimitBytes });
+      const parsed = parseDiffHunks(output, input.file.path);
+      return CanonicalChatTurnDiffResponseSchema.shape.file.parse({
+        ...input.file,
+        partial: input.file.partial || parsed.partial,
+        hunks: parsed.hunks,
+      });
+    },
+  };
+}
+
+export type ChatTurnChangeCapture = ReturnType<typeof createChatTurnChangeCapture>;

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -152,6 +152,7 @@ import {
   createCanonicalChatService,
   createUnavailableCanonicalChatService,
 } from "./chat/service.js";
+import { createChatTurnChangeCapture, type ChatTurnChangeCapture } from "./chat/turn-changes.js";
 import { createCodingAgentFileStore } from "./coding-agents/file-read.js";
 import { createCodingAgentSourceControlStore } from "./coding-agents/source-control.js";
 import { registerCodingAgentAttentionNotifications } from "./coding-agents/attention-notifications.js";
@@ -861,6 +862,7 @@ export async function createGateway(config: GatewayConfig) {
   let chatRepository: ChatRepository | null = null;
   let canonicalChatOrchestrator: CanonicalChatOrchestrator | null = null;
   let canonicalChatExecutionRoots: ChatExecutionRootResolver | null = null;
+  let canonicalChatTurnChanges: ChatTurnChangeCapture | null = null;
   let messagingRepository: MessagingKyselyRepository | null = null;
 
   if (databaseUrl) {
@@ -4168,6 +4170,7 @@ export async function createGateway(config: GatewayConfig) {
       projects: codingAgentProjectManager,
       worktrees: codingAgentWorktreeManager,
     });
+    canonicalChatTurnChanges = createChatTurnChangeCapture();
     const canonicalAdapters: CanonicalChatProviderAdapter[] = [
       createHermesChatProviderAdapter({ homePath }),
     ];
@@ -4187,6 +4190,7 @@ export async function createGateway(config: GatewayConfig) {
       catalog: canonicalChatProviderCatalog,
       adapters: new CanonicalChatProviderRegistry(canonicalAdapters),
       executionRoots: canonicalChatExecutionRoots,
+      turnChanges: canonicalChatTurnChanges,
     });
     for (const ownerId of new Set(codingAgentOwnerIds)) {
       await canonicalChatOrchestrator.reconcileActiveRuns({ type: "personal", ownerId });
@@ -4197,6 +4201,7 @@ export async function createGateway(config: GatewayConfig) {
         ? createCanonicalChatService(chatRepository, {
           ...(canonicalChatOrchestrator ? { orchestrator: canonicalChatOrchestrator } : {}),
           ...(canonicalChatExecutionRoots ? { executionRoots: canonicalChatExecutionRoots } : {}),
+          ...(canonicalChatTurnChanges ? { turnChanges: canonicalChatTurnChanges } : {}),
         })
       : createUnavailableCanonicalChatService(),
     getPrincipal: (c) => requireRequestPrincipal(c),

--- a/tests/contracts/canonical-chat-changes.test.ts
+++ b/tests/contracts/canonical-chat-changes.test.ts
@@ -1,0 +1,70 @@
+import {
+  CanonicalChatTurnChangeSetSchema,
+  CanonicalChatTurnFileReadQuerySchema,
+} from "@matrix-os/contracts";
+import { describe, expect, it } from "vitest";
+
+const base = {
+  chatId: "chat_changes",
+  turnId: "cturn_changes",
+  runId: "run_changes",
+  projectId: "project_matrix",
+  executionRoot: { kind: "worktree", projectId: "project_matrix", worktreeId: "wt_abc123def456" },
+  revision: `turnrev_${"a".repeat(64)}`,
+  beforeRevision: `tree_${"b".repeat(40)}`,
+  afterRevision: `tree_${"c".repeat(40)}`,
+  source: "workspace_checkpoints",
+  label: "Workspace changes observed during this turn",
+  concurrent: false,
+  partial: false,
+  files: [{ path: "src/app.ts", status: "modified", additions: 2, deletions: 1, partial: false }],
+  totals: { changedFileCount: 1, additions: 2, deletions: 1 },
+  capturedAt: "2026-08-27T04:00:00.000Z",
+} as const;
+
+describe("canonical Chat turn-change contracts", () => {
+  it("accepts bounded checkpoint changes and preserves rename, binary, partial and concurrent truth", () => {
+    expect(CanonicalChatTurnChangeSetSchema.parse(base).files[0]?.path).toBe("src/app.ts");
+    expect(CanonicalChatTurnChangeSetSchema.parse({
+      ...base,
+      label: "Concurrent workspace changes observed during this turn",
+      concurrent: true,
+      partial: true,
+      files: [
+        { path: "src/new.ts", previousPath: "src/old.ts", status: "renamed", additions: 0, deletions: 0, partial: false },
+        { path: "logo.png", status: "binary", additions: 0, deletions: 0, partial: true },
+      ],
+      totals: { changedFileCount: 2, additions: 0, deletions: 0 },
+    }).files).toHaveLength(2);
+  });
+
+  it("rejects traversal, absolute paths, inconsistent rename metadata and dishonest labels", () => {
+    for (const path of ["../secret", "/home/matrix/secret", "src/../../secret", "src\\secret"]) {
+      expect(CanonicalChatTurnFileReadQuerySchema.safeParse({ path, version: "current" }).success).toBe(false);
+    }
+    expect(CanonicalChatTurnChangeSetSchema.safeParse({
+      ...base,
+      files: [{ ...base.files[0], status: "renamed" }],
+    }).success).toBe(false);
+    expect(CanonicalChatTurnChangeSetSchema.safeParse({
+      ...base,
+      source: "provider_authoritative",
+    }).success).toBe(false);
+  });
+
+  it("requires honest no-change and Current file labels through strict enums", () => {
+    expect(CanonicalChatTurnChangeSetSchema.parse({
+      ...base,
+      label: "No workspace changes",
+      files: [],
+      totals: { changedFileCount: 0, additions: 0, deletions: 0 },
+    }).label).toBe("No workspace changes");
+    expect(CanonicalChatTurnFileReadQuerySchema.parse({ path: "README.md", version: "current" }))
+      .toEqual({ path: "README.md", version: "current" });
+    expect(CanonicalChatTurnFileReadQuerySchema.safeParse({
+      path: "README.md",
+      version: "current",
+      ownerId: "other",
+    }).success).toBe(false);
+  });
+});

--- a/tests/gateway/chat-orchestrator.test.ts
+++ b/tests/gateway/chat-orchestrator.test.ts
@@ -172,6 +172,77 @@ describe("CanonicalChatOrchestrator", () => {
     ]);
   });
 
+  it("captures the workspace before dispatch and settles changes atomically with the terminal Run", async () => {
+    await repository.create(owner, {
+      id: "chat_turn_changes",
+      clientRequestId: "req_create_turn_changes",
+      title: "Turn changes",
+      projectId: "project_matrix",
+    });
+    const captureStart = vi.fn(async () => ({ tree: "1".repeat(40), head: "2".repeat(40) }));
+    const captureFinal = vi.fn(async (input: { identity: { chatId: string; turnId: string; runId: string }; start: { tree: string } }) => ({
+      end: { tree: "3".repeat(40), head: "2".repeat(40) },
+      changes: {
+        ...input.identity,
+        projectId: "project_matrix",
+        executionRoot: { kind: "project" as const, projectId: "project_matrix" },
+        revision: `turnrev_${"4".repeat(64)}`,
+        beforeRevision: `tree_${input.start.tree}`,
+        afterRevision: `tree_${"3".repeat(40)}`,
+        source: "workspace_checkpoints" as const,
+        label: "Workspace changes observed during this turn" as const,
+        concurrent: false,
+        partial: false,
+        files: [{ path: "src/app.ts", status: "modified" as const, additions: 1, deletions: 0, partial: false }],
+        totals: { changedFileCount: 1, additions: 1, deletions: 0 },
+        capturedAt: "2026-08-26T00:00:00.000Z",
+      },
+    }));
+    const provider = adapter(async function* () {
+      expect(captureStart).toHaveBeenCalledTimes(1);
+      yield { type: "run.completed", outcome: "completed" };
+    });
+    const roots: ChatExecutionRootResolver = {
+      resolve: async (_owner, ref) => ({
+        ref,
+        fingerprint: "f".repeat(64),
+        primaryWorkspaceRoot: "/safe/project",
+        projectSlug: "matrix-os",
+      }),
+      revalidate: async (_owner, provenance) => ({
+        ...provenance,
+        primaryWorkspaceRoot: "/safe/project",
+        projectSlug: "matrix-os",
+      }),
+    };
+    const orchestrator = new CanonicalChatOrchestrator({
+      repository,
+      catalog: { getCatalog: async () => catalog() },
+      adapters: new CanonicalChatProviderRegistry([provider]),
+      executionRoots: roots,
+      turnChanges: { captureStart, captureFinal },
+      now: () => new Date("2026-08-26T00:00:00.000Z"),
+    });
+
+    const admitted = await orchestrator.admitTurn(principal, owner, "chat_turn_changes", {
+      clientRequestId: "req_turn_changes",
+      baseRevision: 0,
+      parts: [{ type: "text", text: "edit it" }],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+    });
+    await orchestrator.drain();
+
+    expect(captureFinal).toHaveBeenCalledWith(expect.objectContaining({
+      root: "/safe/project",
+      start: { tree: "1".repeat(40), head: "2".repeat(40) },
+      identity: expect.objectContaining({ chatId: "chat_turn_changes", runId: admitted.run.id }),
+    }));
+    await expect(repository.getTurnChanges(owner, "chat_turn_changes", admitted.turn.id))
+      .resolves.toMatchObject({ changes: { files: [expect.objectContaining({ path: "src/app.ts" })] } });
+  });
+
   it("persists and replays typed Provider activity in first-received order", async () => {
     await repository.create(owner, {
       id: "chat_typed_activity",
@@ -533,6 +604,72 @@ describe("CanonicalChatOrchestrator", () => {
     expect(snapshot?.activities.some((activity) =>
       activity.type === "assistant.delta" && activity.delta === "late output"
     )).toBe(false);
+  });
+
+  it("atomically settles the active Run checkpoint when cancellation wins the Provider race", async () => {
+    await repository.create(owner, {
+      id: "chat_cancelled_changes",
+      clientRequestId: "req_create_cancelled_changes",
+      title: "Cancelled changes",
+      projectId: "project_matrix",
+    });
+    const provider = adapter(async function* (input) {
+      await new Promise<void>((resolve) => input.signal.addEventListener("abort", () => resolve(), { once: true }));
+      yield { type: "run.completed", outcome: "aborted" };
+    });
+    const roots = {
+      resolve: vi.fn(async () => ({
+        ref: { kind: "project" as const, projectId: "project_matrix" },
+        fingerprint: "a".repeat(64),
+        primaryWorkspaceRoot: "/safe/project",
+        projectSlug: "matrix-os",
+      })),
+      revalidate: vi.fn(async (_owner, provenance) => ({
+        ...provenance,
+        primaryWorkspaceRoot: "/safe/project",
+        projectSlug: "matrix-os",
+      })),
+    };
+    const captureStart = vi.fn(async () => ({ tree: "b".repeat(40), head: "d".repeat(40) }));
+    const captureFinal = vi.fn(async (input) => ({
+      end: { tree: "c".repeat(40), head: "d".repeat(40) },
+      changes: {
+        ...input.identity,
+        revision: `turnrev_${"e".repeat(64)}`,
+        beforeRevision: `tree_${input.start.tree}`,
+        afterRevision: `tree_${"c".repeat(40)}`,
+        source: "workspace_checkpoints" as const,
+        label: "Workspace changes observed during this turn" as const,
+        concurrent: false,
+        partial: false,
+        files: [{ path: "src/app.ts", status: "modified" as const, additions: 1, deletions: 0, partial: false }],
+        totals: { changedFileCount: 1, additions: 1, deletions: 0 },
+        capturedAt: input.capturedAt,
+      },
+    }));
+    const orchestrator = new CanonicalChatOrchestrator({
+      repository,
+      catalog: { getCatalog: async () => catalog() },
+      adapters: new CanonicalChatProviderRegistry([provider]),
+      executionRoots: roots,
+      turnChanges: { captureStart, captureFinal },
+      now: () => new Date("2026-08-26T00:00:00.000Z"),
+    });
+    const admitted = await orchestrator.admitTurn(principal, owner, "chat_cancelled_changes", {
+      clientRequestId: "req_cancelled_changes_turn",
+      baseRevision: 0,
+      parts: [{ type: "text", text: "wait" }],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+    });
+
+    await orchestrator.cancelRun(owner, "chat_cancelled_changes", admitted.run.id);
+    await orchestrator.drain();
+
+    expect(captureFinal).toHaveBeenCalledTimes(1);
+    expect((await repository.getTurnChanges(owner, "chat_cancelled_changes", admitted.turn.id))?.changes)
+      .toMatchObject({ runId: admitted.run.id, label: "Workspace changes observed during this turn" });
   });
 
   it("resumes later Turns only through the same adapter state schema and Instance", async () => {

--- a/tests/gateway/chat-repository.test.ts
+++ b/tests/gateway/chat-repository.test.ts
@@ -127,6 +127,7 @@ describe("ChatRepository", () => {
       "chat_run_adapter_state",
       "chat_run_events",
       "chat_runs",
+      "chat_turn_change_sets",
       "chat_turns",
       "chat_user_state",
       "chats",

--- a/tests/gateway/chat-routes.test.ts
+++ b/tests/gateway/chat-routes.test.ts
@@ -5,6 +5,7 @@ import {
   CanonicalChatDetailResponseSchema,
   CanonicalChatListResponseSchema,
   CanonicalChatRecordSchema,
+  CanonicalChatTurnChangeSetSchema,
   type CanonicalChatDetailResponse,
   type CanonicalChatListResponse,
   type CanonicalChatRecord,
@@ -59,6 +60,9 @@ function routeService(overrides: Partial<CanonicalChatRouteService> = {}): Canon
     retryTurn: vi.fn(async () => {
       throw new Error("not configured");
     }),
+    getTurnChanges: vi.fn(async () => null),
+    getTurnDiff: vi.fn(async () => null),
+    readTurnFile: vi.fn(async () => null),
     ...overrides,
   };
 }
@@ -71,6 +75,71 @@ function appFor(service: CanonicalChatRouteService) {
 }
 
 describe("canonical Chat routes", () => {
+  it("serves owner-derived turn changes, structured diff and honestly labeled file reads", async () => {
+    const changes = CanonicalChatTurnChangeSetSchema.parse({
+      chatId: "chat_route_test",
+      turnId: "cturn_route",
+      runId: "run_route",
+      projectId: "project_matrix",
+      executionRoot: { kind: "project", projectId: "project_matrix" },
+      revision: `turnrev_${"a".repeat(64)}`,
+      beforeRevision: `tree_${"b".repeat(40)}`,
+      afterRevision: `tree_${"c".repeat(40)}`,
+      source: "workspace_checkpoints",
+      label: "Workspace changes observed during this turn",
+      concurrent: false,
+      partial: false,
+      files: [{ path: "src/app.ts", status: "modified", additions: 1, deletions: 0, partial: false }],
+      totals: { changedFileCount: 1, additions: 1, deletions: 0 },
+      capturedAt: "2026-08-27T04:00:00.000Z",
+    });
+    const getTurnChanges = vi.fn(async () => ({ changes }));
+    const getTurnDiff = vi.fn(async () => ({
+      chatId: changes.chatId,
+      turnId: changes.turnId,
+      revision: changes.revision,
+      file: { ...changes.files[0]!, hunks: [] },
+    }));
+    const readTurnFile = vi.fn(async () => ({
+      chatId: changes.chatId,
+      turnId: changes.turnId,
+      revision: changes.revision,
+      path: "src/app.ts",
+      version: "current" as const,
+      label: "Current file" as const,
+      content: "export const app = true;\n",
+      encoding: "utf8" as const,
+      truncated: false,
+      sizeBytes: 25,
+    }));
+    const app = appFor(routeService({ getTurnChanges, getTurnDiff, readTurnFile }));
+
+    expect((await app.request("/api/chats/chat_route_test/turns/cturn_route/changes")).status).toBe(200);
+    expect((await app.request("/api/chats/chat_route_test/turns/cturn_route/changes/diff?path=src%2Fapp.ts")).status).toBe(200);
+    const fileResponse = await app.request("/api/chats/chat_route_test/turns/cturn_route/files?path=src%2Fapp.ts&version=current");
+    expect(fileResponse.status).toBe(200);
+    expect(await fileResponse.json()).toMatchObject({ label: "Current file", version: "current" });
+    expect(getTurnChanges).toHaveBeenCalledWith({ type: "personal", ownerId: "owner_1" }, "chat_route_test", "cturn_route");
+    expect(getTurnDiff).toHaveBeenCalledWith({ type: "personal", ownerId: "owner_1" }, "chat_route_test", "cturn_route", "src/app.ts");
+    expect(readTurnFile).toHaveBeenCalledWith(
+      { type: "personal", ownerId: "owner_1" },
+      "chat_route_test",
+      "cturn_route",
+      { path: "src/app.ts", version: "current" },
+    );
+  });
+
+  it("rejects unsafe turn-change paths before the service boundary", async () => {
+    const getTurnDiff = vi.fn(async () => null);
+    const readTurnFile = vi.fn(async () => null);
+    const app = appFor(routeService({ getTurnDiff, readTurnFile }));
+    expect((await app.request("/api/chats/chat_route_test/turns/cturn_route/changes/diff?path=..%2Fsecret")).status).toBe(400);
+    expect((await app.request("/api/chats/chat_route_test/turns/cturn_route/files?path=%2Fetc%2Fpasswd&version=current")).status).toBe(400);
+    expect((await app.request("/api/chats/chat_route_test/turns/cturn_route/files?path=src%2Fapp.ts&version=unknown")).status).toBe(400);
+    expect(getTurnDiff).not.toHaveBeenCalled();
+    expect(readTurnFile).not.toHaveBeenCalled();
+  });
+
   it("derives personal ownership and creates a Chat through the shared service", async () => {
     const create = vi.fn(async (_owner: ChatOwner, _input: CanonicalCreateChatRequest) => record);
     const service = routeService({ create });

--- a/tests/gateway/chat-service.test.ts
+++ b/tests/gateway/chat-service.test.ts
@@ -1,4 +1,4 @@
-import type { CanonicalChatRecord } from "@matrix-os/contracts";
+import { CanonicalChatTurnChangeSetSchema, type CanonicalChatRecord } from "@matrix-os/contracts";
 import { describe, expect, it, vi } from "vitest";
 import { createCanonicalChatService } from "../../packages/gateway/src/chat/service.js";
 import { ChatExecutionRootError } from "../../packages/gateway/src/chat/execution-root.js";
@@ -26,7 +26,7 @@ function record(id = "chat_service_test"): CanonicalChatRecord {
   };
 }
 
-function repository(overrides: Partial<Pick<ChatRepository, "create" | "list" | "search" | "getDetailPage" | "update" | "hardDelete">> = {}) {
+function repository(overrides: Partial<Pick<ChatRepository, "create" | "list" | "search" | "getDetailPage" | "update" | "hardDelete" | "getTurnChanges">> = {}) {
   return {
     create: vi.fn(async () => record()),
     list: vi.fn(async () => ({ items: [record()] } satisfies ChatListPage)),
@@ -40,11 +40,76 @@ function repository(overrides: Partial<Pick<ChatRepository, "create" | "list" | 
     } satisfies ChatDetailPage)),
     update: vi.fn(async () => ({ ...record(), projectId: "project_1" })),
     hardDelete: vi.fn(async () => ({ chatId: "chat_service_test", deletedAt: "2026-08-26T12:00:00.000Z" })),
+    getTurnChanges: vi.fn(async () => null),
     ...overrides,
-  } as Pick<ChatRepository, "create" | "list" | "search" | "getDetailPage" | "update" | "hardDelete">;
+  } as Pick<ChatRepository, "create" | "list" | "search" | "getDetailPage" | "update" | "hardDelete" | "getTurnChanges">;
 }
 
 describe("canonical Chat service", () => {
+  it("revalidates persisted root provenance before structured diff and current file reads", async () => {
+    const changes = CanonicalChatTurnChangeSetSchema.parse({
+      chatId: "chat_service_test",
+      turnId: "cturn_service",
+      runId: "run_service",
+      projectId: "project_1",
+      executionRoot: { kind: "project", projectId: "project_1" },
+      revision: `turnrev_${"a".repeat(64)}`,
+      beforeRevision: `tree_${"b".repeat(40)}`,
+      afterRevision: `tree_${"c".repeat(40)}`,
+      source: "workspace_checkpoints",
+      label: "Workspace changes observed during this turn",
+      concurrent: false,
+      partial: false,
+      files: [{ path: "src/app.ts", status: "modified", additions: 1, deletions: 0, partial: false }],
+      totals: { changedFileCount: 1, additions: 1, deletions: 0 },
+      capturedAt: "2026-08-27T04:00:00.000Z",
+    });
+    const stored = {
+      changes,
+      executionRootFingerprint: "d".repeat(64),
+      beforeTree: "b".repeat(40),
+      beforeHead: "e".repeat(40),
+      afterTree: "c".repeat(40),
+      afterHead: "e".repeat(40),
+    };
+    const getTurnChanges = vi.fn(async () => stored);
+    const revalidate = vi.fn(async () => ({
+      ref: changes.executionRoot,
+      primaryWorkspaceRoot: "/private/project",
+      projectSlug: "project-1",
+      fingerprint: stored.executionRootFingerprint,
+    }));
+    const readDiff = vi.fn(async ({ file }) => ({ ...file, hunks: [] }));
+    const readFile = vi.fn(async () => ({
+      path: "src/app.ts",
+      version: "current" as const,
+      label: "Current file" as const,
+      content: "export const app = true;\n",
+      encoding: "utf8" as const,
+      truncated: false,
+      sizeBytes: 25,
+    }));
+    const service = createCanonicalChatService(repository({ getTurnChanges }), {
+      executionRoots: { resolve: vi.fn(), revalidate },
+      turnChanges: { readDiff, readFile },
+    });
+
+    expect(await service.getTurnChanges(owner, changes.chatId, changes.turnId)).toEqual({ changes });
+    expect(await service.getTurnDiff(owner, changes.chatId, changes.turnId, "src/app.ts"))
+      .toMatchObject({ revision: changes.revision, file: { path: "src/app.ts", hunks: [] } });
+    expect(await service.readTurnFile(owner, changes.chatId, changes.turnId, { path: "src/app.ts", version: "current" }))
+      .toMatchObject({ revision: changes.revision, label: "Current file" });
+    expect(revalidate).toHaveBeenCalledWith(owner, {
+      ref: changes.executionRoot,
+      fingerprint: stored.executionRootFingerprint,
+    });
+    expect(readDiff).toHaveBeenCalledWith(expect.objectContaining({
+      root: "/private/project",
+      start: { tree: stored.beforeTree, head: stored.beforeHead },
+      end: { tree: stored.afterTree, head: stored.afterHead },
+    }));
+  });
+
   it("generates server-owned Chat ids and a bounded default title", async () => {
     const create = vi.fn(async (_owner, input) => record(input.id));
     const repo = repository({ create });

--- a/tests/gateway/chat-turn-change-repository.test.ts
+++ b/tests/gateway/chat-turn-change-repository.test.ts
@@ -1,0 +1,143 @@
+import { KyselyPGlite } from "kysely-pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CanonicalChatMessage, CanonicalChatRun, CanonicalChatTurn } from "@matrix-os/contracts";
+import { ChatRepository } from "../../packages/gateway/src/chat/repository.js";
+
+const owner = { type: "personal" as const, ownerId: "owner_changes" };
+const other = { type: "personal" as const, ownerId: "owner_other" };
+const at = "2026-08-27T04:00:00.000Z";
+
+function records(chatId: string) {
+  const message: CanonicalChatMessage = {
+    id: "msg_changes",
+    chatId,
+    seq: 1,
+    role: "user",
+    state: "committed",
+    turnId: "cturn_changes",
+    parts: [{ type: "text", text: "change it" }],
+    createdAt: at,
+  };
+  const turn: CanonicalChatTurn = {
+    id: "cturn_changes",
+    chatId,
+    clientRequestId: "req_changes",
+    baseMessageSeq: 0,
+    inputMessageId: message.id,
+    status: "accepted",
+    createdAt: at,
+    updatedAt: at,
+  };
+  const run: CanonicalChatRun = {
+    id: "run_changes",
+    chatId,
+    turnId: turn.id,
+    attempt: 1,
+    driverKind: "codex",
+    instanceId: "codex_default",
+    selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+    interactionMode: "default",
+    permissionMode: "supervised",
+    executionRoot: { kind: "project", projectId: "project_matrix" },
+    executionRootFingerprint: "f".repeat(64),
+    status: "accepted",
+    historyBoundarySeq: 0,
+    capabilitySnapshot: {
+      revision: "catalog_changes",
+      rootChat: true,
+      attachments: [],
+      resources: ["file", "folder", "project"],
+      tools: [],
+      approvals: true,
+      userInput: true,
+      resume: true,
+      cancellation: true,
+      worktrees: "optional",
+      interactionModes: ["default"],
+      permissionModes: ["supervised"],
+    },
+    createdAt: at,
+    updatedAt: at,
+  };
+  return { message, turn, run };
+}
+
+describe("ChatRepository turn changes", () => {
+  let pglite: InstanceType<typeof KyselyPGlite>;
+  let repository: ChatRepository;
+
+  beforeEach(async () => {
+    pglite = await KyselyPGlite.create();
+    repository = new ChatRepository(pglite.dialect);
+    await repository.bootstrap();
+    await repository.create(owner, {
+      id: "chat_changes",
+      clientRequestId: "req_create_changes",
+      title: "Changes",
+      projectId: "project_matrix",
+    });
+    const { message, turn, run } = records("chat_changes");
+    await repository.admitTurn(owner, { chatId: "chat_changes", baseRevision: 0, message, turn, run });
+  });
+
+  afterEach(async () => repository.kysely.destroy());
+
+  it("persists an owner-scoped start checkpoint and settles the change set atomically with the Run", async () => {
+    await repository.recordTurnChangeStart(owner, {
+      chatId: "chat_changes",
+      turnId: "cturn_changes",
+      runId: "run_changes",
+      projectId: "project_matrix",
+      executionRoot: { kind: "project", projectId: "project_matrix" },
+      executionRootFingerprint: "f".repeat(64),
+      beforeTree: "a".repeat(40),
+      beforeHead: "b".repeat(40),
+      capturedAt: at,
+    });
+    const changes = {
+      chatId: "chat_changes",
+      turnId: "cturn_changes",
+      runId: "run_changes",
+      projectId: "project_matrix",
+      executionRoot: { kind: "project" as const, projectId: "project_matrix" },
+      revision: `turnrev_${"c".repeat(64)}`,
+      beforeRevision: `tree_${"a".repeat(40)}`,
+      afterRevision: `tree_${"d".repeat(40)}`,
+      source: "workspace_checkpoints" as const,
+      label: "Workspace changes observed during this turn" as const,
+      concurrent: false,
+      partial: false,
+      files: [{ path: "README.md", status: "modified" as const, additions: 1, deletions: 1, partial: false }],
+      totals: { changedFileCount: 1, additions: 1, deletions: 1 },
+      capturedAt: at,
+    };
+    await repository.finishRun(owner, {
+      chatId: "chat_changes",
+      runId: "run_changes",
+      outcome: "completed",
+      completedAt: at,
+      turnChanges: { changes, afterTree: "d".repeat(40), afterHead: "b".repeat(40) },
+    });
+
+    await expect(repository.getTurnChanges(owner, "chat_changes", "cturn_changes"))
+      .resolves.toMatchObject({ changes, beforeTree: "a".repeat(40), afterTree: "d".repeat(40) });
+    await expect(repository.getTurnChanges(other, "chat_changes", "cturn_changes")).resolves.toBeNull();
+  });
+
+  it("rejects mismatched root provenance without settling the Run", async () => {
+    await expect(repository.recordTurnChangeStart(owner, {
+      chatId: "chat_changes",
+      turnId: "cturn_changes",
+      runId: "run_changes",
+      projectId: "project_other",
+      executionRoot: { kind: "project", projectId: "project_other" },
+      executionRootFingerprint: "e".repeat(64),
+      beforeTree: "a".repeat(40),
+      beforeHead: "b".repeat(40),
+      capturedAt: at,
+    })).rejects.toBeDefined();
+
+    expect((await repository.getTurnRunContext(owner, "chat_changes", "cturn_changes"))?.latestRun.status)
+      .toBe("accepted");
+  });
+});

--- a/tests/gateway/chat-turn-changes.test.ts
+++ b/tests/gateway/chat-turn-changes.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ChatTurnChangeCaptureError,
   createChatTurnChangeCapture,
+  parseBoundedNumstat,
 } from "../../packages/gateway/src/chat/turn-changes.js";
 
 const execFileAsync = promisify(execFile);
@@ -35,6 +36,53 @@ afterEach(async () => {
 });
 
 describe("Chat turn checkpoint capture", () => {
+  it("caps retained numstat entries even when Git reports more paths than the projection limit", () => {
+    const paths = Array.from({ length: 250 }, (_, index) => `src/file-${index}.ts`);
+    const output = paths.map((path) => `1\t0\t${path}\0`).join("");
+
+    const stats = parseBoundedNumstat(output, paths);
+
+    expect(stats.size).toBe(200);
+    expect(stats.get("src/file-199.ts")).toEqual({ additions: 1, deletions: 0, binary: false });
+    expect(stats.has("src/file-200.ts")).toBe(false);
+  });
+
+  it("reports an honest partial projection when Git returns more than 200 changed paths", async () => {
+    const root = await mkdtemp(join(tmpdir(), "matrix-chat-turn-overflow-"));
+    created.push(root);
+    const paths = Array.from({ length: 201 }, (_, index) => `src/file-${index}.ts`);
+    let writeTreeCalls = 0;
+    const runGit = vi.fn(async (_root: string, args: readonly string[]) => {
+      if (args[0] === "write-tree") return `${(writeTreeCalls++ === 0 ? "b" : "c").repeat(40)}\n`;
+      if (args[0] === "rev-parse") return `${"d".repeat(40)}\n`;
+      if (args.includes("--name-status")) return paths.map((path) => `M\0${path}\0`).join("");
+      if (args.includes("--numstat")) return paths.map((path) => `1\t0\t${path}\0`).join("");
+      return "";
+    });
+    const capture = createChatTurnChangeCapture({ runGit });
+    const start = await capture.captureStart(root);
+
+    const result = await capture.captureFinal({
+      root,
+      start,
+      identity: {
+        chatId: "chat_overflow",
+        turnId: "cturn_overflow",
+        runId: "run_overflow",
+        projectId: "project_matrix",
+        executionRoot: { kind: "project", projectId: "project_matrix" },
+      },
+      capturedAt: "2026-08-27T04:00:00.000Z",
+    });
+
+    expect(result.changes).toMatchObject({
+      partial: true,
+      totals: { changedFileCount: 201, additions: 200, deletions: 0 },
+    });
+    expect(result.changes.files).toHaveLength(200);
+    expect(result.changes.files.at(-1)?.path).toBe("src/file-199.ts");
+  });
+
   it("isolates changes between checkpoints including rename and binary files", async () => {
     const root = await repository();
     await writeFile(join(root, "README.md"), "pre-existing\n", "utf8");

--- a/tests/gateway/chat-turn-changes.test.ts
+++ b/tests/gateway/chat-turn-changes.test.ts
@@ -1,0 +1,161 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rename, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ChatTurnChangeCaptureError,
+  createChatTurnChangeCapture,
+} from "../../packages/gateway/src/chat/turn-changes.js";
+
+const execFileAsync = promisify(execFile);
+const created: string[] = [];
+
+async function git(cwd: string, ...args: string[]) {
+  await execFileAsync("git", ["-C", cwd, ...args]);
+}
+
+async function repository() {
+  const root = await mkdtemp(join(tmpdir(), "matrix-chat-turn-changes-"));
+  created.push(root);
+  await git(root, "init", "-q");
+  await git(root, "config", "user.email", "test@example.com");
+  await git(root, "config", "user.name", "Matrix Test");
+  await writeFile(join(root, "README.md"), "before\n", "utf8");
+  await writeFile(join(root, "old.ts"), "export const old = true;\n", "utf8");
+  await git(root, "add", ".");
+  await git(root, "commit", "-qm", "initial");
+  return root;
+}
+
+afterEach(async () => {
+  const { rm } = await import("node:fs/promises");
+  await Promise.all(created.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe("Chat turn checkpoint capture", () => {
+  it("isolates changes between checkpoints including rename and binary files", async () => {
+    const root = await repository();
+    await writeFile(join(root, "README.md"), "pre-existing\n", "utf8");
+    const capture = createChatTurnChangeCapture();
+    const start = await capture.captureStart(root);
+
+    await writeFile(join(root, "README.md"), "during turn\nsecond line\n", "utf8");
+    await rename(join(root, "old.ts"), join(root, "new.ts"));
+    await writeFile(join(root, "logo.bin"), Buffer.from([0, 1, 2, 3]));
+    const result = await capture.captureFinal({
+      root,
+      start,
+      identity: {
+        chatId: "chat_changes",
+        turnId: "cturn_changes",
+        runId: "run_changes",
+        projectId: "project_matrix",
+        executionRoot: { kind: "project", projectId: "project_matrix" },
+      },
+      capturedAt: "2026-08-27T04:00:00.000Z",
+    });
+
+    expect(result.changes.source).toBe("workspace_checkpoints");
+    expect(result.changes.label).toBe("Workspace changes observed during this turn");
+    expect(result.changes.files).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: "README.md", status: "modified", additions: 2, deletions: 1 }),
+      expect.objectContaining({ path: "new.ts", previousPath: "old.ts", status: "renamed" }),
+      expect.objectContaining({ path: "logo.bin", status: "binary", partial: true }),
+    ]));
+    expect(result.changes.files).not.toContainEqual(expect.objectContaining({ path: "README.md", deletions: 0 }));
+    await expect(capture.readDiff({
+      root,
+      path: "README.md",
+      start,
+      end: result.end,
+      file: result.changes.files.find((file) => file.path === "README.md")!,
+    })).resolves.toMatchObject({
+      path: "README.md",
+      hunks: [expect.objectContaining({
+        lines: expect.arrayContaining([
+          expect.objectContaining({ kind: "remove", content: "pre-existing" }),
+          expect.objectContaining({ kind: "add", content: "during turn" }),
+        ]),
+      })],
+    });
+  });
+
+  it("returns an honest no-change set and marks HEAD movement concurrent", async () => {
+    const root = await repository();
+    const capture = createChatTurnChangeCapture();
+    const start = await capture.captureStart(root);
+    const noChange = await capture.captureFinal({
+      root,
+      start,
+      identity: {
+        chatId: "chat_no_change",
+        turnId: "cturn_no_change",
+        runId: "run_no_change",
+        projectId: "project_matrix",
+        executionRoot: { kind: "project", projectId: "project_matrix" },
+      },
+      capturedAt: "2026-08-27T04:00:00.000Z",
+    });
+    expect(noChange.changes.label).toBe("No workspace changes");
+
+    await writeFile(join(root, "README.md"), "committed elsewhere\n", "utf8");
+    await git(root, "add", ".");
+    await git(root, "commit", "-qm", "external");
+    const concurrent = await capture.captureFinal({
+      root,
+      start,
+      identity: {
+        chatId: "chat_concurrent",
+        turnId: "cturn_concurrent",
+        runId: "run_concurrent",
+        projectId: "project_matrix",
+        executionRoot: { kind: "project", projectId: "project_matrix" },
+      },
+      capturedAt: "2026-08-27T04:01:00.000Z",
+    });
+    expect(concurrent.changes.concurrent).toBe(true);
+    expect(concurrent.changes.label).toBe("Concurrent workspace changes observed during this turn");
+  });
+
+  it("reads bounded checkpoint/current text and denies traversal, symlinks and binary content", async () => {
+    const root = await repository();
+    const capture = createChatTurnChangeCapture({ readLimitBytes: 8 });
+    const start = await capture.captureStart(root);
+    await writeFile(join(root, "README.md"), "after content longer\n", "utf8");
+    const final = await capture.captureFinal({
+      root,
+      start,
+      identity: {
+        chatId: "chat_read",
+        turnId: "cturn_read",
+        runId: "run_read",
+        projectId: "project_matrix",
+        executionRoot: { kind: "project", projectId: "project_matrix" },
+      },
+      capturedAt: "2026-08-27T04:00:00.000Z",
+    });
+    expect(await capture.readFile({ root, path: "README.md", version: "before", start, end: final.end }))
+      .toMatchObject({ content: "before\n", label: "Before turn", truncated: false });
+    expect(await capture.readFile({ root, path: "README.md", version: "current", start, end: final.end }))
+      .toMatchObject({ content: "after co", label: "Current file", truncated: true });
+
+    await symlink("README.md", join(root, "link.md"));
+    await mkdir(join(root, "nested"));
+    await writeFile(join(root, "binary.bin"), Buffer.from([0, 1, 2]));
+    for (const path of ["../secret", "link.md", "binary.bin"]) {
+      await expect(capture.readFile({ root, path, version: "current", start, end: final.end }))
+        .rejects.toBeInstanceOf(ChatTurnChangeCaptureError);
+    }
+  });
+
+  it("bounds Git commands by timeout and converts internal failures to safe errors", async () => {
+    const root = await mkdtemp(join(tmpdir(), "matrix-chat-turn-timeout-"));
+    created.push(root);
+    const runGit = vi.fn(async () => await new Promise<string>(() => {}));
+    const capture = createChatTurnChangeCapture({ runGit, timeoutMs: 5 });
+    await expect(capture.captureStart(root)).rejects.toMatchObject({ code: "capture_unavailable" });
+    expect(runGit).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Capture a bounded Git workspace checkpoint before canonical Chat dispatch and persist it atomically with Turn/Run admission.
- Settle owner-scoped per-Turn change metadata in the same transaction as the terminal Run/Turn/Chat/outbox transition, including completion, failure, cancellation, retries, and capacity failure.
- Expose strict change summary, structured diff, and safe file-read routes for MAT-481.
- Label fallback evidence honestly as Workspace changes observed during this turn, Concurrent workspace changes observed during this turn, or No workspace changes; no authorship inference.

## Invariants
- **Source of truth:** owner-controlled Postgres stores the canonical change-set metadata/provenance. Git trees/blobs in the owner Project/worktree are the file bytes. No renderer artifact store or frontend persistence is introduced.
- **Atomicity:** the start checkpoint is inserted inside the Turn/Run admission transaction. Final change settlement is inside the same transaction as the terminal Run, Turn, Chat, and outbox transition. Git commands/file reads run outside DB transactions.
- **Authorization:** request principal derives owner scope; repository reads join through the owned Chat; file/diff reads revalidate the persisted execution-root ref and fingerprint before touching the filesystem.
- **Boundaries:** strict Zod IDs/paths, traversal denial, symlink denial including no-follow and inode verification, binary denial for file preview, bounded files/hunks/lines/content, Git max buffers, and command timeouts. Git uses execFile, --no-ext-diff, and --no-textconv.
- **Failure semantics:** capturing rows are never exposed as settled results; raw provider/Git/filesystem errors and absolute paths are never returned to clients. Unsupported or failed capture remains safely unavailable rather than being mislabeled exact.
- **Evidence honesty:** current implementation uses guarded workspace checkpoints because no trusted provider-authoritative diff seam exists yet. Exact turn changes remains reserved for provider-authoritative evidence.

## Tests
- Focused MAT-478 contract/Gateway suite: 86 passed.
- bun run typecheck passed across the workspace.
- bun run check:patterns passed with 0 violations.
- git diff --check passed.

## Deferred / excluded
- Inspector layout and UI composition: MAT-475 and MAT-481.
- Renderer artifact store or persistence.
- Review workflow, commit/PR actions, and authorship inference.
- Provider-authoritative diff capture until a trusted provider seam exists.
- Public docs/site changes.

Linear: MAT-478