### PR TITLE
feat(desktop): add native show desktop animation

### DIFF
--- a/desktop/src/renderer/src/design/index.css
+++ b/desktop/src/renderer/src/design/index.css
@@ -6,6 +6,16 @@
 @import "@fontsource/jetbrains-mono/400.css";
 @import "@fontsource/jetbrains-mono/500.css";
 @import "./tokens.css";
+
+@keyframes native-desktop-window-hide {
+  from { opacity: 1; transform: translate3d(0, 0, 0); }
+  to { opacity: 1; transform: translate3d(var(--desktop-exit-x), var(--desktop-exit-y), 0); }
+}
+
+@keyframes native-desktop-window-show {
+  from { opacity: 1; transform: translate3d(var(--desktop-exit-x), var(--desktop-exit-y), 0); }
+  to { opacity: 1; transform: translate3d(0, 0, 0); }
+}
 @import "./chat.css";
 
 /* Map tokens into Tailwind v4 theme so utilities like bg-surface work. */

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopHeaderTabs.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopHeaderTabs.tsx
@@ -17,6 +17,7 @@ export default function DesktopHeaderTabs() {
   const closeSurface = useDesktopSurfaces((state) => state.closeSurface);
   const workspaceView = useDesktopSurfaces((state) => state.workspaceView);
   const showDesktop = useDesktopSurfaces((state) => state.showDesktop);
+  const setWorkspaceView = useDesktopSurfaces((state) => state.setWorkspaceView);
   const requestBackgroundRefresh = useUi((state) => state.requestDesktopBackgroundRefresh);
   const drawerOpen = useDesktopAppDrawer((state) => state.open);
   const toggleDrawer = useDesktopAppDrawer((state) => state.toggle);
@@ -74,7 +75,8 @@ export default function DesktopHeaderTabs() {
       onRestore={restore}
       onMinimize={(tabId) => {
         minimizeSurface(tabId);
-        showDesktopWithRefresh();
+        setWorkspaceView("desktop");
+        requestBackgroundRefresh();
       }}
       onClose={close}
       workspaceView={workspaceView}

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopHeaderTabs.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopHeaderTabs.tsx
@@ -27,6 +27,15 @@ export default function DesktopHeaderTabs() {
     requestBackgroundRefresh();
   }, [requestBackgroundRefresh, showDesktop]);
 
+  const focusDesktopOrShowDesktop = useCallback(() => {
+    if (workspaceView === "desktop") {
+      showDesktopWithRefresh();
+      return;
+    }
+    setWorkspaceView("desktop");
+    requestBackgroundRefresh();
+  }, [requestBackgroundRefresh, setWorkspaceView, showDesktopWithRefresh, workspaceView]);
+
   const activate = useCallback((tabId: string) => {
     focusTab(tabId);
     activateSurface(tabId);
@@ -80,7 +89,7 @@ export default function DesktopHeaderTabs() {
       }}
       onClose={close}
       workspaceView={workspaceView}
-      onShowDesktop={showDesktopWithRefresh}
+      onShowDesktop={focusDesktopOrShowDesktop}
       onToggleSidebar={toggleDrawer}
       sidebarOpen={drawerOpen}
     />

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
@@ -30,10 +30,10 @@ function desktopWindowMotion(tabId: string, bounds: DesktopSurfaceBounds): CSSPr
     : null;
   const viewportWidth = shell?.clientWidth || (typeof window !== "undefined" ? window.innerWidth : 1280);
   const edge = direction === 0
-    ? { x: `${variation}px`, y: `${24 - bounds.y - bounds.height}px` }
+    ? { x: `${variation}px`, y: `${12 - bounds.y - bounds.height}px` }
     : direction === 1
-      ? { x: `${24 - bounds.x - bounds.width}px`, y: `${variation}px` }
-      : { x: `${viewportWidth - 24 - bounds.x}px`, y: `${variation}px` };
+      ? { x: `${12 - bounds.x - bounds.width}px`, y: `${variation}px` }
+      : { x: `${viewportWidth - 12 - bounds.x}px`, y: `${variation}px` };
   return {
     "--desktop-exit-x": edge.x,
     "--desktop-exit-y": edge.y,

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
@@ -9,6 +9,7 @@ import { DESKTOP_Z_INDEX, NATIVE_DESKTOP_LAYOUT } from "../../design/layering";
 import type {
   DesktopSurface,
   DesktopSurfaceBounds,
+  DesktopTransition,
 } from "../../stores/desktop-surfaces";
 import type { Tab } from "../../stores/tabs";
 import { TabErrorBoundary, TabPane } from "../mission-control/TabContent";
@@ -19,6 +20,26 @@ import {
   TopBar,
 } from "./OSWindow";
 
+function desktopWindowMotion(tabId: string, bounds: DesktopSurfaceBounds): CSSProperties {
+  let hash = 0;
+  for (const character of tabId) hash = (hash * 31 + character.charCodeAt(0)) | 0;
+  const direction = Math.abs(hash) % 3;
+  const variation = (Math.abs(hash >> 3) % 37) - 18;
+  const shell = typeof document !== "undefined"
+    ? document.querySelector<HTMLElement>("[data-native-desktop-shell]")
+    : null;
+  const viewportWidth = shell?.clientWidth || (typeof window !== "undefined" ? window.innerWidth : 1280);
+  const edge = direction === 0
+    ? { x: `${variation}px`, y: `${24 - bounds.y - bounds.height}px` }
+    : direction === 1
+      ? { x: `${24 - bounds.x - bounds.width}px`, y: `${variation}px` }
+      : { x: `${viewportWidth - 24 - bounds.x}px`, y: `${variation}px` };
+  return {
+    "--desktop-exit-x": edge.x,
+    "--desktop-exit-y": edge.y,
+  } as CSSProperties;
+}
+
 export default function DesktopSurfaceFrame({
   tab,
   surface,
@@ -28,6 +49,8 @@ export default function DesktopSurfaceFrame({
   presentation,
   interactionScale = 1,
   workspaceRevision = "",
+  desktopTransition = null,
+  desktopHiddenSurfaceIds = [],
   onFocus,
   onClose,
   onMinimize,
@@ -42,6 +65,8 @@ export default function DesktopSurfaceFrame({
   presentation: NativeDesktopMode;
   interactionScale?: number;
   workspaceRevision?: string;
+  desktopTransition?: DesktopTransition | null;
+  desktopHiddenSurfaceIds?: readonly string[];
   onFocus: () => void;
   onClose: () => void;
   onMinimize: () => void;
@@ -51,11 +76,17 @@ export default function DesktopSurfaceFrame({
   const isCanvas = presentation === "canvas";
   const isDesktopWindow = surface.mode === "window";
   const isTabbed = !isCanvas && surface.mode === "tab";
+  const isDesktopTransition = !isCanvas
+    && desktopTransition?.surfaceIds.includes(surface.tabId) === true;
+  const isDesktopHidden = !isCanvas
+    && desktopHiddenSurfaceIds?.includes(surface.tabId) === true;
   const isWindow = isDesktopWindow
+    || isDesktopHidden
+    || isDesktopTransition
     || (isCanvas && surface.mode !== "closed" && surface.mode !== "minimized");
   const visible = isCanvas
     ? isWindow
-    : (isDesktopWindow && !tabWorkspaceActive) || (isTabbed && tabWorkspaceActive && active);
+    : isDesktopHidden || isDesktopTransition || (isDesktopWindow && !tabWorkspaceActive) || (isTabbed && tabWorkspaceActive && active);
   const interactive = visible && active;
   const isNativeEmbed = tab.kind === "home" || tab.kind === "app";
   const sidebarOwnsChrome = tab.kind === "chat" || tab.kind === "terminal" || tab.kind === "terminals";
@@ -130,6 +161,17 @@ export default function DesktopSurfaceFrame({
     height: `${surface.bounds.height}px`,
     zIndex: surface.zIndex,
     display: visible ? "flex" : "none",
+    ...(isDesktopTransition ? {
+      ...desktopWindowMotion(surface.tabId, surface.bounds),
+      animation: desktopTransition?.phase === "hiding"
+        ? "native-desktop-window-hide 280ms cubic-bezier(0.22, 1, 0.36, 1) both"
+        : "native-desktop-window-show 280ms cubic-bezier(0.22, 1, 0.36, 1) both",
+      pointerEvents: "none",
+    } : isDesktopHidden ? {
+      ...desktopWindowMotion(surface.tabId, surface.bounds),
+      transform: "translate3d(var(--desktop-exit-x), var(--desktop-exit-y), 0)",
+      pointerEvents: "none",
+    } : {}),
     borderRadius: "var(--radius-lg)",
     border: `1px solid ${active ? "var(--border-default)" : "var(--border-subtle)"}`,
     boxShadow: active ? "var(--shadow-3)" : "var(--shadow-2)",

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopWorkspacePlane.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopWorkspacePlane.tsx
@@ -17,11 +17,13 @@ function isInsideCanvasSurface(target: EventTarget | null): boolean {
 type DesktopWorkspacePlaneProps = {
   mode: NativeDesktopMode;
   children: ReactNode;
+  onBackgroundClick?: () => void;
 } & Omit<ComponentPropsWithoutRef<"div">, "children">;
 
 const DesktopWorkspacePlane = forwardRef<HTMLDivElement, DesktopWorkspacePlaneProps>(function DesktopWorkspacePlane({
   mode,
   children,
+  onBackgroundClick,
   ...triggerProps
 }, ref) {
   const panX = useNativeDesktopMode((state) => state.panX);
@@ -79,6 +81,12 @@ const DesktopWorkspacePlane = forwardRef<HTMLDivElement, DesktopWorkspacePlanePr
   };
 
   const canvas = mode === "canvas";
+  const onClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (mode !== "desktop") return;
+    const target = event.target;
+    if (target instanceof Element && target.closest("[data-desktop-surface],button,input,a")) return;
+    onBackgroundClick?.();
+  };
   return (
     <div
       {...triggerProps}
@@ -93,6 +101,7 @@ const DesktopWorkspacePlane = forwardRef<HTMLDivElement, DesktopWorkspacePlanePr
       } : undefined}
       onPointerDown={startPan}
       onWheel={zoomCanvas}
+      onClick={onClick}
     >
       <div
         data-testid="native-desktop-workspace-plane"

--- a/desktop/src/renderer/src/features/desktop-shell/NativeDesktopShell.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/NativeDesktopShell.tsx
@@ -48,6 +48,9 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
   const closeSurface = useDesktopSurfaces((state) => state.closeSurface);
   const setSurfaceBounds = useDesktopSurfaces((state) => state.setSurfaceBounds);
   const workspaceView = useDesktopSurfaces((state) => state.workspaceView);
+  const desktopTransition = useDesktopSurfaces((state) => state.desktopTransition);
+  const desktopHiddenSurfaceIds = useDesktopSurfaces((state) => state.desktopHiddenSurfaceIds);
+  const finishDesktopTransition = useDesktopSurfaces((state) => state.finishDesktopTransition);
   const launcherOpen = useUi((state) => state.appLauncherOpen);
   const setLauncherOpen = useUi((state) => state.setAppLauncherOpen);
   const requestBackgroundRefresh = useUi((state) => state.requestDesktopBackgroundRefresh);
@@ -80,6 +83,12 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
     reconcileTabs(tabIds, viewport, desktopMode !== "canvas");
   }, [desktopMode, desktopModeHydrated, reconcileTabs, tabIds, viewport]);
 
+  useEffect(() => {
+    if (!desktopTransition) return;
+    const timer = window.setTimeout(() => finishDesktopTransition(), 280);
+    return () => window.clearTimeout(timer);
+  }, [desktopTransition, finishDesktopTransition]);
+
   const activeSurface = activeTabId ? surfaces[activeTabId] : undefined;
   const activeSurfaceAvailable = activeSurface !== undefined && activeSurface.mode !== "closed";
   useEffect(() => {
@@ -109,6 +118,10 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
   }, [reconcileAndActivateCurrent]);
 
   const closeApps = useCallback(() => setLauncherOpen(false), [setLauncherOpen]);
+  const showDesktopWithRefresh = useCallback(() => {
+    useDesktopSurfaces.getState().showDesktop();
+    requestBackgroundRefresh();
+  }, [requestBackgroundRefresh]);
   const toggleApps = useCallback(
     () => setLauncherOpen(!useUi.getState().appLauncherOpen),
     [setLauncherOpen],
@@ -218,7 +231,7 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
         <DesktopIconGrid destinations={destinations} />
       ) : null}
       <DesktopBackgroundMenu>
-        <DesktopWorkspacePlane mode={desktopMode}>
+        <DesktopWorkspacePlane mode={desktopMode} onBackgroundClick={showDesktopWithRefresh}>
           {desktopMode === "canvas" ? <DesktopIconGrid destinations={destinations} /> : null}
           {tabs.map((tab) => {
           const surface = surfaces[tab.id];
@@ -234,6 +247,8 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
               presentation={desktopMode}
               interactionScale={desktopMode === "canvas" ? canvasZoom : 1}
               workspaceRevision={desktopMode === "canvas" ? `${canvasPanX}:${canvasPanY}:${canvasZoom}` : "desktop"}
+              desktopTransition={desktopTransition}
+              desktopHiddenSurfaceIds={desktopHiddenSurfaceIds}
               onFocus={() => activate(tab.id)}
               onClose={() => close(tab)}
               onMinimize={() => minimize(tab.id)}

--- a/desktop/src/renderer/src/stores/desktop-surfaces.ts
+++ b/desktop/src/renderer/src/stores/desktop-surfaces.ts
@@ -141,6 +141,26 @@ function nextFocusedState(
   };
 }
 
+function syncDesktopHiddenState(
+  state: Pick<DesktopSurfacesState, "desktopHiddenSurfaceIds" | "desktopTransition">,
+  surfaces: Record<string, DesktopSurface>,
+  hiddenSurfaceIds = state.desktopHiddenSurfaceIds,
+  transitionSurfaceIds = state.desktopTransition?.surfaceIds,
+): Pick<DesktopSurfacesState, "desktopHiddenSurfaceIds" | "desktopTransition"> {
+  const desktopHiddenSurfaceIds = hiddenSurfaceIds.filter((tabId) => surfaces[tabId]?.mode === "window");
+  const surfaceIds = transitionSurfaceIds?.filter((tabId) => surfaces[tabId]?.mode === "window") ?? [];
+  return {
+    desktopHiddenSurfaceIds,
+    desktopTransition: surfaceIds.length > 0
+      ? { ...state.desktopTransition!, surfaceIds }
+      : null,
+  };
+}
+
+function sameStringArray(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
 export const useDesktopSurfaces = create<DesktopSurfacesState>()((set) => ({
   surfaces: {},
   nextZIndex: DESKTOP_Z_INDEX.nativeDesktopWindowStart,
@@ -190,9 +210,18 @@ export const useDesktopSurfaces = create<DesktopSurfacesState>()((set) => ({
       && Object.values(surfaces).some((surface) => surface.mode === "tab")
       ? "tabs"
       : "desktop";
-    return unchanged && workspaceView === state.workspaceView
+    const syncedHiddenState = syncDesktopHiddenState(state, surfaces);
+    const hiddenStateUnchanged = sameStringArray(
+      syncedHiddenState.desktopHiddenSurfaceIds,
+      state.desktopHiddenSurfaceIds,
+    ) && syncedHiddenState.desktopTransition?.phase === state.desktopTransition?.phase
+      && sameStringArray(
+        syncedHiddenState.desktopTransition?.surfaceIds ?? [],
+        state.desktopTransition?.surfaceIds ?? [],
+      );
+    return unchanged && workspaceView === state.workspaceView && hiddenStateUnchanged
       ? state
-      : { surfaces, nextZIndex, workspaceView };
+      : { surfaces, nextZIndex, workspaceView, ...syncedHiddenState };
   }),
 
   showDesktop: () => set((state) => {
@@ -231,7 +260,16 @@ export const useDesktopSurfaces = create<DesktopSurfacesState>()((set) => ({
       mode,
       restoreMode: mode === "tab" ? "tab" : "window",
     });
-    return { ...focused, workspaceView: mode === "tab" ? "tabs" : "desktop" };
+    return {
+      ...focused,
+      ...syncDesktopHiddenState(
+        state,
+        focused.surfaces,
+        state.desktopHiddenSurfaceIds.filter((id) => id !== tabId),
+        state.desktopTransition?.surfaceIds.filter((id) => id !== tabId),
+      ),
+      workspaceView: mode === "tab" ? "tabs" : "desktop",
+    };
   }),
 
   focusSurface: (tabId) => set((state) => nextFocusedState(state, tabId)),
@@ -289,6 +327,7 @@ export const useDesktopSurfaces = create<DesktopSurfacesState>()((set) => ({
     };
     return {
       surfaces,
+      ...syncDesktopHiddenState(state, surfaces),
       workspaceView: Object.values(surfaces).some((candidate) => candidate.mode === "tab")
         ? state.workspaceView
         : "desktop",

--- a/desktop/src/renderer/src/stores/desktop-surfaces.ts
+++ b/desktop/src/renderer/src/stores/desktop-surfaces.ts
@@ -24,6 +24,11 @@ export interface DesktopSurface {
   zIndex: number;
 }
 
+export interface DesktopTransition {
+  phase: "hiding" | "restoring";
+  surfaceIds: string[];
+}
+
 const DESKTOP_GAP = 12;
 const MIN_WINDOW_WIDTH = 440;
 const MIN_WINDOW_HEIGHT = 300;
@@ -77,8 +82,12 @@ interface DesktopSurfacesState {
   surfaces: Record<string, DesktopSurface>;
   nextZIndex: number;
   workspaceView: "desktop" | "tabs";
+  desktopHiddenSurfaceIds: string[];
+  desktopTransition: DesktopTransition | null;
   reconcileTabs(tabIds: readonly string[], viewport: DesktopViewport, constrainToViewport?: boolean): void;
   showDesktop(): void;
+  finishDesktopTransition(): void;
+  setWorkspaceView(view: "desktop" | "tabs"): void;
   activateSurface(tabId: string): void;
   focusSurface(tabId: string): void;
   minimizeSurface(tabId: string): void;
@@ -136,6 +145,8 @@ export const useDesktopSurfaces = create<DesktopSurfacesState>()((set) => ({
   surfaces: {},
   nextZIndex: DESKTOP_Z_INDEX.nativeDesktopWindowStart,
   workspaceView: "desktop",
+  desktopHiddenSurfaceIds: [],
+  desktopTransition: null,
 
   reconcileTabs: (tabIds, viewport, constrainToViewport = true) => set((state) => {
     const retained = new Set(tabIds);
@@ -184,7 +195,29 @@ export const useDesktopSurfaces = create<DesktopSurfacesState>()((set) => ({
       : { surfaces, nextZIndex, workspaceView };
   }),
 
-  showDesktop: () => set({ workspaceView: "desktop" }),
+  showDesktop: () => set((state) => {
+    if (state.desktopHiddenSurfaceIds.length > 0) {
+      return {
+        desktopHiddenSurfaceIds: [],
+        desktopTransition: { phase: "restoring", surfaceIds: state.desktopHiddenSurfaceIds },
+        workspaceView: "desktop",
+      };
+    }
+
+    const visibleSurfaceIds = Object.values(state.surfaces)
+      .filter((surface) => surface.mode === "window" || surface.mode === "tab")
+      .map((surface) => surface.tabId);
+    if (visibleSurfaceIds.length === 0) return { workspaceView: "desktop", desktopTransition: null };
+    return {
+      desktopHiddenSurfaceIds: visibleSurfaceIds,
+      desktopTransition: { phase: "hiding", surfaceIds: visibleSurfaceIds },
+      workspaceView: "desktop",
+    };
+  }),
+
+  finishDesktopTransition: () => set({ desktopTransition: null }),
+
+  setWorkspaceView: (view) => set({ workspaceView: view }),
 
   activateSurface: (tabId) => set((state) => {
     const surface = state.surfaces[tabId];

--- a/desktop/src/renderer/src/stores/desktop-surfaces.ts
+++ b/desktop/src/renderer/src/stores/desktop-surfaces.ts
@@ -205,7 +205,7 @@ export const useDesktopSurfaces = create<DesktopSurfacesState>()((set) => ({
     }
 
     const visibleSurfaceIds = Object.values(state.surfaces)
-      .filter((surface) => surface.mode === "window" || surface.mode === "tab")
+      .filter((surface) => surface.mode === "window")
       .map((surface) => surface.tabId);
     if (visibleSurfaceIds.length === 0) return { workspaceView: "desktop", desktopTransition: null };
     return {

--- a/tests/desktop/desktop-surfaces-store.test.ts
+++ b/tests/desktop/desktop-surfaces-store.test.ts
@@ -152,6 +152,31 @@ describe("desktop surfaces store", () => {
     expect(useDesktopSurfaces.getState().surfaces.chat?.mode).toBe("tab");
   });
 
+  it("removes an activated window from the hidden desktop snapshot", () => {
+    useDesktopSurfaces.getState().reconcileTabs(["home", "chat"], { width: 1200, height: 760 });
+    useDesktopSurfaces.getState().showDesktop();
+
+    useDesktopSurfaces.getState().activateSurface("home");
+
+    expect(useDesktopSurfaces.getState().desktopHiddenSurfaceIds).toEqual(["chat"]);
+    expect(useDesktopSurfaces.getState().desktopTransition?.surfaceIds).toEqual(["chat"]);
+  });
+
+  it("removes closed and deleted windows from the hidden desktop snapshot", () => {
+    useDesktopSurfaces.getState().reconcileTabs(["home", "chat"], { width: 1200, height: 760 });
+    useDesktopSurfaces.getState().showDesktop();
+
+    useDesktopSurfaces.getState().closeSurface("home");
+    expect(useDesktopSurfaces.getState().desktopHiddenSurfaceIds).toEqual(["chat"]);
+
+    useDesktopSurfaces.getState().reconcileTabs(["chat"], { width: 1200, height: 760 });
+    expect(useDesktopSurfaces.getState().desktopHiddenSurfaceIds).toEqual(["chat"]);
+
+    useDesktopSurfaces.getState().reconcileTabs(["notes"], { width: 1200, height: 760 });
+    expect(useDesktopSurfaces.getState().desktopHiddenSurfaceIds).toEqual([]);
+    expect(useDesktopSurfaces.getState().desktopTransition).toBeNull();
+  });
+
   it("returns to the desktop when a window is activated or the last tab surface disappears", () => {
     useDesktopSurfaces.getState().reconcileTabs(["terminal", "files"], { width: 1200, height: 760 });
     useDesktopSurfaces.getState().maximizeToTab("terminal");

--- a/tests/desktop/desktop-surfaces-store.test.ts
+++ b/tests/desktop/desktop-surfaces-store.test.ts
@@ -135,12 +135,12 @@ describe("desktop surfaces store", () => {
     expect(useDesktopSurfaces.getState().workspaceView).toBe("tabs");
   });
 
-  it("toggles show desktop while preserving each surface's presentation", () => {
+  it("animates only floating windows while preserving full-screen tabs", () => {
     useDesktopSurfaces.getState().reconcileTabs(["home", "chat"], { width: 1200, height: 760 });
     useDesktopSurfaces.getState().maximizeToTab("chat");
 
     useDesktopSurfaces.getState().showDesktop();
-    expect(useDesktopSurfaces.getState().desktopHiddenSurfaceIds).toEqual(["home", "chat"]);
+    expect(useDesktopSurfaces.getState().desktopHiddenSurfaceIds).toEqual(["home"]);
     expect(useDesktopSurfaces.getState().desktopTransition?.phase).toBe("hiding");
     expect(useDesktopSurfaces.getState().surfaces.home?.mode).toBe("window");
     expect(useDesktopSurfaces.getState().surfaces.chat?.mode).toBe("tab");

--- a/tests/desktop/desktop-surfaces-store.test.ts
+++ b/tests/desktop/desktop-surfaces-store.test.ts
@@ -127,12 +127,29 @@ describe("desktop surfaces store", () => {
     useDesktopSurfaces.getState().maximizeToTab("terminal");
     expect(useDesktopSurfaces.getState().workspaceView).toBe("tabs");
 
-    useDesktopSurfaces.getState().showDesktop();
+    useDesktopSurfaces.getState().setWorkspaceView("desktop");
     expect(useDesktopSurfaces.getState().workspaceView).toBe("desktop");
     expect(useDesktopSurfaces.getState().surfaces.terminal?.mode).toBe("tab");
 
     useDesktopSurfaces.getState().activateSurface("terminal");
     expect(useDesktopSurfaces.getState().workspaceView).toBe("tabs");
+  });
+
+  it("toggles show desktop while preserving each surface's presentation", () => {
+    useDesktopSurfaces.getState().reconcileTabs(["home", "chat"], { width: 1200, height: 760 });
+    useDesktopSurfaces.getState().maximizeToTab("chat");
+
+    useDesktopSurfaces.getState().showDesktop();
+    expect(useDesktopSurfaces.getState().desktopHiddenSurfaceIds).toEqual(["home", "chat"]);
+    expect(useDesktopSurfaces.getState().desktopTransition?.phase).toBe("hiding");
+    expect(useDesktopSurfaces.getState().surfaces.home?.mode).toBe("window");
+    expect(useDesktopSurfaces.getState().surfaces.chat?.mode).toBe("tab");
+
+    useDesktopSurfaces.getState().showDesktop();
+    expect(useDesktopSurfaces.getState().desktopHiddenSurfaceIds).toEqual([]);
+    expect(useDesktopSurfaces.getState().desktopTransition?.phase).toBe("restoring");
+    expect(useDesktopSurfaces.getState().surfaces.home?.mode).toBe("window");
+    expect(useDesktopSurfaces.getState().surfaces.chat?.mode).toBe("tab");
   });
 
   it("returns to the desktop when a window is activated or the last tab surface disappears", () => {

--- a/tests/desktop/native-desktop-shell.test.tsx
+++ b/tests/desktop/native-desktop-shell.test.tsx
@@ -312,7 +312,7 @@ describe("native desktop shell", () => {
     fireEvent.click(screen.getByRole("tab", { name: "Desktop" }));
     expect(screen.getByRole("tab", { name: "Desktop" }).getAttribute("aria-selected")).toBe("true");
     expect(screen.getByRole("button", { name: "Browser" })).toBeTruthy();
-    expect(useDesktopSurfaces.getState().desktopHiddenSurfaceIds).toContain(terminalTab!.id);
+    expect(useDesktopSurfaces.getState().desktopHiddenSurfaceIds).not.toContain(terminalTab!.id);
 
     fireEvent.click(screen.getByRole("tab", { name: "Desktop" }));
     expect(useDesktopSurfaces.getState().surfaces[terminalTab!.id]?.mode).toBe("tab");

--- a/tests/desktop/native-desktop-shell.test.tsx
+++ b/tests/desktop/native-desktop-shell.test.tsx
@@ -312,9 +312,10 @@ describe("native desktop shell", () => {
     fireEvent.click(screen.getByRole("tab", { name: "Desktop" }));
     expect(screen.getByRole("tab", { name: "Desktop" }).getAttribute("aria-selected")).toBe("true");
     expect(screen.getByRole("button", { name: "Browser" })).toBeTruthy();
-    expect(useDesktopSurfaces.getState().desktopHiddenSurfaceIds).not.toContain(terminalTab!.id);
+    expect(useDesktopSurfaces.getState().desktopHiddenSurfaceIds).toEqual([]);
 
     fireEvent.click(screen.getByRole("tab", { name: "Desktop" }));
+    expect(useDesktopSurfaces.getState().desktopHiddenSurfaceIds).not.toContain(terminalTab!.id);
     expect(useDesktopSurfaces.getState().surfaces[terminalTab!.id]?.mode).toBe("tab");
 
     fireEvent.click(screen.getByRole("tab", { name: "Terminal" }));

--- a/tests/desktop/native-desktop-shell.test.tsx
+++ b/tests/desktop/native-desktop-shell.test.tsx
@@ -147,6 +147,19 @@ describe("native desktop shell", () => {
     expect(await screen.findByText("Change background…")).toBeTruthy();
   });
 
+  it("toggles show desktop when the empty desktop surface is clicked", () => {
+    render(<><NavigationHeader nativeDesktop /><NativeDesktopShell overlayOpen={false} /></>);
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Terminal" }));
+
+    const terminalTab = useTabs.getState().tabs.find((candidate) => candidate.kind === "terminals");
+    expect(terminalTab).toBeTruthy();
+    fireEvent.click(screen.getByTestId("native-desktop-workspace"));
+    expect(useDesktopSurfaces.getState().desktopHiddenSurfaceIds).toContain(terminalTab!.id);
+
+    fireEvent.click(screen.getByTestId("native-desktop-workspace"));
+    expect(useDesktopSurfaces.getState().surfaces[terminalTab!.id]?.mode).toBe("window");
+  });
+
   it("loads the configured wallpaper through the authenticated API and revokes it on runtime change", async () => {
     mockLoadedWallpaperImage();
     const createObjectURL = vi.fn(() => "blob:desktop-wallpaper");
@@ -299,6 +312,9 @@ describe("native desktop shell", () => {
     fireEvent.click(screen.getByRole("tab", { name: "Desktop" }));
     expect(screen.getByRole("tab", { name: "Desktop" }).getAttribute("aria-selected")).toBe("true");
     expect(screen.getByRole("button", { name: "Browser" })).toBeTruthy();
+    expect(useDesktopSurfaces.getState().desktopHiddenSurfaceIds).toContain(terminalTab!.id);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Desktop" }));
     expect(useDesktopSurfaces.getState().surfaces[terminalTab!.id]?.mode).toBe("tab");
 
     fireEvent.click(screen.getByRole("tab", { name: "Terminal" }));


### PR DESCRIPTION
## Summary

- Add native Electron Show Desktop behavior to the Desktop title-bar tab and empty desktop surface.
- Keep floating OS windows mounted while animating each to a stable random top, left, or right edge, leaving 12px visible.
- Exclude full-screen tab surfaces from Show Desktop and keep them visible.
- Restore each window to its original window/tab presentation on the next toggle.

## Tests

- `pnpm exec vitest run tests/desktop/desktop-surfaces-store.test.ts tests/desktop/native-desktop-shell.test.tsx` — 49 passed
- `pnpm exec tsc --noEmit -p desktop/tsconfig.json`
- `pnpm run check:patterns` — passed with existing baseline warnings
- `pnpm run typecheck` — could not start because `bun` is unavailable in this environment
- `pnpm run test` — package builds passed, but the full Vitest run produced no results after several minutes and was interrupted

## Invariants

### Source of truth
- Native renderer desktop surface store is the source of truth for the show-desktop transition and hidden surface IDs.
- No new persistence or second data store was introduced.

### Lock/transaction scope
- Not applicable; this is renderer-only state and animation.

### Acceptable orphan states
- None; OS windows remain mounted during and after the animation and restore from their original modes.

### Auth source of truth
- Unchanged; no auth paths were modified.

### Deferred scope
- Web shell and Canvas mode are intentionally unchanged; this PR is native Electron Desktop mode only.

Closes MAT-496
