### PR TITLE
fix(ui): repair Hugeicons migration test contracts

### DIFF
--- a/desktop/src/renderer/src/design/tokens.css
+++ b/desktop/src/renderer/src/design/tokens.css
@@ -56,6 +56,7 @@
   --text-subtle: #96968f;
   --text-disabled: #b5b1a3;
   --text-on-accent: #fafaf5;
+  --text-inverse: #fafaf5;
 
   /* ── Brand & semantic ───────────────────────────────────────── */
   --accent: #434e3f;
@@ -181,6 +182,7 @@
   --text-subtle: #96968f;
   --text-disabled: #55605a;
   --text-on-accent: #141614;
+  --text-inverse: #fafaf5;
 
   --accent: #8cc7be;
   --accent-hover: #9dd3cb;

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopAppDrawer.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopAppDrawer.tsx
@@ -44,7 +44,7 @@ function PreviewTile({
         <SurfaceIcon tab={tab} size={12} />
         <span className="min-w-0 truncate text-xs text-[var(--text-primary)]">{tab.title}</span>
       </div>
-      <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/32 text-xs font-medium text-[var(--text-inverse,#FAF9F7)] opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+      <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/32 text-xs font-medium text-[var(--text-inverse)] opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
         Go to app
       </div>
       <button

--- a/desktop/src/renderer/src/features/settings/provider-glyph.tsx
+++ b/desktop/src/renderer/src/features/settings/provider-glyph.tsx
@@ -1,5 +1,5 @@
-// Static glyph per coding-agent provider kind. Uses bundled lucide icons only
-// — provider logos are never fetched from remote URLs.
+// Static glyph per coding-agent provider kind. Uses bundled icons only —
+// provider logos are never fetched from remote URLs.
 import type { AgentProviderSummary } from "@matrix-os/contracts";
 import { Code2, Cpu, MousePointer2, Pi, Sparkles, SquareTerminal } from "@renderer/lib/hugeicons";
 

--- a/tests/desktop/design-tokens.test.ts
+++ b/tests/desktop/design-tokens.test.ts
@@ -126,7 +126,7 @@ describe("Figma semantic surface tokens", () => {
   it("defines the OS window surfaces and success badge tokens in both modes", () => {
     for (const selector of [":root", '[data-theme="dark"]']) {
       const block = themeBlock(tokensCss, selector);
-      for (const name of ["--surface-base-background", "--surface-primary", "--surface-overlay", "--surface-tertiary", "--surface-success", "--border-success"]) {
+      for (const name of ["--surface-base-background", "--surface-primary", "--surface-overlay", "--surface-tertiary", "--surface-success", "--border-success", "--text-inverse"]) {
         expect(tokenValue(block, name)).toMatch(/^#/);
       }
     }

--- a/tests/desktop/navigation-header.test.tsx
+++ b/tests/desktop/navigation-header.test.tsx
@@ -365,9 +365,7 @@ describe("Desktop navigation header", () => {
       expect(icon?.style.width).toBe("14px");
       expect(icon?.style.height).toBe("14px");
     }
-    expect(actions[2]?.querySelector(".lucide-panel-left")).toBeTruthy();
-    expect(actions[2]?.querySelector(".lucide-panel-left-close")).toBeNull();
-    expect(actions[2]?.querySelector(".lucide-panel-left-open")).toBeNull();
+    expect(actions[2]?.querySelector("[data-header-icon] svg")).toBeTruthy();
   });
 
   it("places Home actions behind the Figma breadcrumb ellipsis", async () => {
@@ -375,7 +373,7 @@ describe("Desktop navigation header", () => {
     render(<Tooltip.Provider><NavigationHeader /></Tooltip.Provider>);
 
     const breadcrumb = screen.getByRole("navigation", { name: "Breadcrumb" });
-    expect(breadcrumb.querySelector(".lucide-chevron-right")).toBeTruthy();
+    expect(breadcrumb.querySelectorAll("svg")).toHaveLength(1);
     const actions = screen.getByRole("button", { name: "Actions for Home" });
     expect(breadcrumb.nextElementSibling).toContain(actions);
 
@@ -418,7 +416,7 @@ describe("Desktop navigation header", () => {
 
     const breadcrumb = screen.getByRole("navigation", { name: "Breadcrumb" });
     expect(breadcrumb.textContent).toBe("Terminalclever-comet");
-    expect(breadcrumb.querySelectorAll(".lucide-chevron-right")).toHaveLength(1);
+    expect(breadcrumb.querySelectorAll("svg")).toHaveLength(1);
     expect(screen.queryByRole("button", { name: "Actions for clever-comet" })).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Terminal" }));
@@ -435,7 +433,7 @@ describe("Desktop navigation header", () => {
 
     const breadcrumb = screen.getByRole("navigation", { name: "Breadcrumb" });
     expect(breadcrumb.textContent).toBe("Terminalfocused-shell");
-    expect(breadcrumb.querySelectorAll(".lucide-chevron-right")).toHaveLength(1);
+    expect(breadcrumb.querySelectorAll("svg")).toHaveLength(1);
     expect(screen.queryByRole("button", { name: "Actions for Friendly terminal title" })).toBeNull();
   });
 

--- a/tests/desktop/navigation-header.test.tsx
+++ b/tests/desktop/navigation-header.test.tsx
@@ -13,6 +13,12 @@ import { useTabs, type Tab } from "../../desktop/src/renderer/src/stores/tabs";
 import { useHermesChat } from "../../desktop/src/renderer/src/stores/hermes-chat";
 import { useThreads } from "../../desktop/src/renderer/src/stores/threads";
 import { useUi } from "../../desktop/src/renderer/src/stores/ui";
+import {
+  ChevronLeft,
+  ChevronRight,
+  PanelLeft,
+} from "../../desktop/src/renderer/src/lib/hugeicons";
+import { expectRenderedIcon } from "../helpers/rendered-icon";
 
 describe("Desktop navigation header", () => {
   beforeEach(() => {
@@ -365,7 +371,9 @@ describe("Desktop navigation header", () => {
       expect(icon?.style.width).toBe("14px");
       expect(icon?.style.height).toBe("14px");
     }
-    expect(actions[2]?.querySelector("[data-header-icon] svg")).toBeTruthy();
+    expectRenderedIcon(actions[0]?.querySelector("[data-header-icon] svg"), ChevronLeft);
+    expectRenderedIcon(actions[1]?.querySelector("[data-header-icon] svg"), ChevronRight);
+    expectRenderedIcon(actions[2]?.querySelector("[data-header-icon] svg"), PanelLeft);
   });
 
   it("places Home actions behind the Figma breadcrumb ellipsis", async () => {
@@ -374,6 +382,7 @@ describe("Desktop navigation header", () => {
 
     const breadcrumb = screen.getByRole("navigation", { name: "Breadcrumb" });
     expect(breadcrumb.querySelectorAll("svg")).toHaveLength(1);
+    expectRenderedIcon(breadcrumb.querySelector("svg"), ChevronRight);
     const actions = screen.getByRole("button", { name: "Actions for Home" });
     expect(breadcrumb.nextElementSibling).toContain(actions);
 
@@ -417,6 +426,7 @@ describe("Desktop navigation header", () => {
     const breadcrumb = screen.getByRole("navigation", { name: "Breadcrumb" });
     expect(breadcrumb.textContent).toBe("Terminalclever-comet");
     expect(breadcrumb.querySelectorAll("svg")).toHaveLength(1);
+    expectRenderedIcon(breadcrumb.querySelector("svg"), ChevronRight);
     expect(screen.queryByRole("button", { name: "Actions for clever-comet" })).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Terminal" }));
@@ -434,6 +444,7 @@ describe("Desktop navigation header", () => {
     const breadcrumb = screen.getByRole("navigation", { name: "Breadcrumb" });
     expect(breadcrumb.textContent).toBe("Terminalfocused-shell");
     expect(breadcrumb.querySelectorAll("svg")).toHaveLength(1);
+    expectRenderedIcon(breadcrumb.querySelector("svg"), ChevronRight);
     expect(screen.queryByRole("button", { name: "Actions for Friendly terminal title" })).toBeNull();
   });
 

--- a/tests/desktop/provider-glyph-pi.test.tsx
+++ b/tests/desktop/provider-glyph-pi.test.tsx
@@ -10,18 +10,24 @@ describe("ProviderGlyph", () => {
     cleanup();
   });
 
-  it.each([
-    ["claude", "lucide-sparkles"],
-    ["codex", "lucide-square-terminal"],
-    ["opencode", "lucide-code-xml"],
-    ["cursor", "lucide-mouse-pointer2"],
-    ["pi", "lucide-pi"],
-    ["custom", "lucide-cpu"],
-  ] as const)("renders the %s glyph", (kind, iconClass) => {
+  const kinds = ["claude", "codex", "opencode", "cursor", "pi", "custom"] as const;
+
+  it.each(kinds)("renders the %s glyph", (kind) => {
     const { container } = render(<ProviderGlyph kind={kind} />);
     const svg = container.querySelector("svg");
     expect(svg).not.toBeNull();
-    expect(svg?.classList.contains(iconClass)).toBe(true);
+    expect(container.firstElementChild?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("keeps a distinct bundled glyph for each provider kind", () => {
+    const glyphs = kinds.map((kind) => {
+      const { container, unmount } = render(<ProviderGlyph kind={kind} />);
+      const markup = container.querySelector("svg")?.innerHTML;
+      unmount();
+      return markup;
+    });
+
+    expect(new Set(glyphs).size).toBe(kinds.length);
   });
 
   it("renders pi with the shared accent chrome", () => {

--- a/tests/desktop/sidebar-navigation-shell.test.tsx
+++ b/tests/desktop/sidebar-navigation-shell.test.tsx
@@ -12,6 +12,17 @@ import { useHermesChat } from "../../desktop/src/renderer/src/stores/hermes-chat
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 import { useThreads } from "../../desktop/src/renderer/src/stores/threads";
 import { useUi } from "../../desktop/src/renderer/src/stores/ui";
+import {
+  File,
+  FolderKanban,
+  FolderOpen,
+  House,
+  LayoutGrid,
+  MessageCircle,
+  SquareTerminal,
+  Terminal,
+} from "../../desktop/src/renderer/src/lib/hugeicons";
+import { expectRenderedIcon } from "../helpers/rendered-icon";
 
 vi.mock("../../desktop/src/renderer/src/features/runtime/RuntimeComputerMenu", () => ({
   default: () => <button type="button">Main computer</button>,
@@ -89,9 +100,18 @@ describe("Desktop sidebar navigation shell", () => {
     expect(screen.getByText("Fix navigation")).toBeTruthy();
     expect(screen.getByText("dev")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Open recent Matrix OS" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Open recent Fix navigation" }).querySelector("[data-sidebar-icon] svg")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Open recent dev" }).querySelector("[data-sidebar-icon] svg")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Open recent Matrix OS" }).querySelector("[data-sidebar-icon] svg")).toBeTruthy();
+    expectRenderedIcon(
+      screen.getByRole("button", { name: "Open recent Fix navigation" }).querySelector("[data-sidebar-icon] svg"),
+      MessageCircle,
+    );
+    expectRenderedIcon(
+      screen.getByRole("button", { name: "Open recent dev" }).querySelector("[data-sidebar-icon] svg"),
+      SquareTerminal,
+    );
+    expectRenderedIcon(
+      screen.getByRole("button", { name: "Open recent Matrix OS" }).querySelector("[data-sidebar-icon] svg"),
+      FolderKanban,
+    );
 
     fireEvent.pointerDown(screen.getByRole("button", { name: "Filter recents" }), { button: 0, ctrlKey: false });
     fireEvent.click(await screen.findByRole("menuitemradio", { name: "Terminals" }));
@@ -235,8 +255,19 @@ describe("Desktop sidebar navigation shell", () => {
     expect(terminal.style.borderWidth).toBe("");
     expect(terminal.style.fontWeight).toBe("500");
 
-    for (const label of ["Home", "Chat", "Terminal", "Files", "Apps", "Projects"]) {
-      expect(screen.getByRole("button", { name: label }).querySelector("[data-sidebar-icon] svg")).toBeTruthy();
+    const figmaGlyphs = {
+      Home: House,
+      Chat: MessageCircle,
+      Terminal,
+      Files: File,
+      Apps: LayoutGrid,
+      Projects: FolderOpen,
+    } as const;
+    for (const [label, ExpectedIcon] of Object.entries(figmaGlyphs)) {
+      expectRenderedIcon(
+        screen.getByRole("button", { name: label }).querySelector("[data-sidebar-icon] svg"),
+        ExpectedIcon,
+      );
     }
     const pluginsGlyph = screen.getByRole("button", { name: "Plugins" })
       .querySelector<HTMLElement>('[data-figma-icon="phosphor-plugs"]');

--- a/tests/desktop/sidebar-navigation-shell.test.tsx
+++ b/tests/desktop/sidebar-navigation-shell.test.tsx
@@ -89,9 +89,9 @@ describe("Desktop sidebar navigation shell", () => {
     expect(screen.getByText("Fix navigation")).toBeTruthy();
     expect(screen.getByText("dev")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Open recent Matrix OS" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Open recent Fix navigation" }).querySelector(".lucide-message-circle")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Open recent dev" }).querySelector(".lucide-square-terminal")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Open recent Matrix OS" }).querySelector(".lucide-folder-kanban")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open recent Fix navigation" }).querySelector("[data-sidebar-icon] svg")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open recent dev" }).querySelector("[data-sidebar-icon] svg")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open recent Matrix OS" }).querySelector("[data-sidebar-icon] svg")).toBeTruthy();
 
     fireEvent.pointerDown(screen.getByRole("button", { name: "Filter recents" }), { button: 0, ctrlKey: false });
     fireEvent.click(await screen.findByRole("menuitemradio", { name: "Terminals" }));
@@ -235,16 +235,8 @@ describe("Desktop sidebar navigation shell", () => {
     expect(terminal.style.borderWidth).toBe("");
     expect(terminal.style.fontWeight).toBe("500");
 
-    const figmaGlyphs = {
-      Home: ".lucide-house",
-      Chat: ".lucide-message-circle",
-      Terminal: ".lucide-terminal",
-      Files: ".lucide-file",
-      Apps: ".lucide-layout-grid",
-      Projects: ".lucide-folder-open",
-    } as const;
-    for (const [label, selector] of Object.entries(figmaGlyphs)) {
-      expect(screen.getByRole("button", { name: label }).querySelector(selector)).toBeTruthy();
+    for (const label of ["Home", "Chat", "Terminal", "Files", "Apps", "Projects"]) {
+      expect(screen.getByRole("button", { name: label }).querySelector("[data-sidebar-icon] svg")).toBeTruthy();
     }
     const pluginsGlyph = screen.getByRole("button", { name: "Plugins" })
       .querySelector<HTMLElement>('[data-figma-icon="phosphor-plugs"]');

--- a/tests/helpers/rendered-icon.tsx
+++ b/tests/helpers/rendered-icon.tsx
@@ -1,0 +1,33 @@
+import { createElement, type ComponentType, type SVGProps } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { expect } from "vitest";
+
+type IconComponent = ComponentType<SVGProps<SVGSVGElement> & {
+  size?: number | string;
+  strokeWidth?: number;
+}>;
+
+function normalizedGeometry(svg: Element): string {
+  const clone = svg.cloneNode(true) as Element;
+  for (const element of [clone, ...clone.querySelectorAll("*")]) {
+    element.removeAttribute("stroke-width");
+  }
+  return clone.innerHTML;
+}
+
+function renderedIconGeometry(Icon: IconComponent): string {
+  const host = document.createElement("div");
+  host.innerHTML = renderToStaticMarkup(createElement(Icon, { size: 24 }));
+  const svg = host.querySelector("svg");
+  if (!svg) throw new Error("Expected icon component to render an SVG");
+  return normalizedGeometry(svg);
+}
+
+export function expectRenderedIcon(
+  actual: Element | null | undefined,
+  ExpectedIcon: IconComponent,
+): void {
+  expect(actual, "Expected an SVG icon").toBeTruthy();
+  expect(actual?.tagName.toLowerCase()).toBe("svg");
+  expect(actual ? normalizedGeometry(actual) : null).toBe(renderedIconGeometry(ExpectedIcon));
+}

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -2991,7 +2991,7 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
-    expect(screen.getByTestId("terminal-drawer-collapse-icon").querySelector('path[d="m11 17-5-5 5-5"]')).toBeTruthy();
+    expect(screen.getByTestId("terminal-drawer-collapse-icon").tagName.toLowerCase()).toBe("svg");
     expect(screen.getByTestId("terminal-sidebar-shell").style.transition).toContain("transform");
 
     fireEvent.click(screen.getByRole("button", { name: "Hide sessions drawer" }));
@@ -3004,7 +3004,7 @@ describe("TerminalApp", () => {
     expect(rail.style.width).toBe("76px");
     expect(rail.className).not.toContain("absolute");
     expect(screen.getByRole("button", { name: "Expand sessions drawer" })).toBeTruthy();
-    expect(screen.getByTestId("terminal-drawer-expand-icon").querySelector('path[d="m6 17 5-5-5-5"]')).toBeTruthy();
+    expect(screen.getByTestId("terminal-drawer-expand-icon").tagName.toLowerCase()).toBe("svg");
     expect(screen.getByRole("button", { name: "New session" })).toBeTruthy();
     const matrixRailButton = screen.getByRole("button", { name: "Open matrix-main" });
     expect(matrixRailButton.textContent).toBe("mma");

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -69,6 +69,8 @@ import {
 } from "../../shell/src/components/terminal/TerminalSidebarItems.js";
 import type { ShellSessionSummary } from "../../shell/src/components/terminal/terminal-session-state.js";
 import { getTerminalThemePreset } from "../../shell/src/components/terminal/terminal-themes.js";
+import { ChevronsLeftIcon, ChevronsRightIcon } from "../../shell/src/lib/hugeicons.js";
+import { expectRenderedIcon } from "../helpers/rendered-icon";
 
 function normalizeCssColor(color: string) {
   const element = document.createElement("div");
@@ -2991,7 +2993,7 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
-    expect(screen.getByTestId("terminal-drawer-collapse-icon").tagName.toLowerCase()).toBe("svg");
+    expectRenderedIcon(screen.getByTestId("terminal-drawer-collapse-icon"), ChevronsLeftIcon);
     expect(screen.getByTestId("terminal-sidebar-shell").style.transition).toContain("transform");
 
     fireEvent.click(screen.getByRole("button", { name: "Hide sessions drawer" }));
@@ -3004,7 +3006,7 @@ describe("TerminalApp", () => {
     expect(rail.style.width).toBe("76px");
     expect(rail.className).not.toContain("absolute");
     expect(screen.getByRole("button", { name: "Expand sessions drawer" })).toBeTruthy();
-    expect(screen.getByTestId("terminal-drawer-expand-icon").tagName.toLowerCase()).toBe("svg");
+    expectRenderedIcon(screen.getByTestId("terminal-drawer-expand-icon"), ChevronsRightIcon);
     expect(screen.getByRole("button", { name: "New session" })).toBeTruthy();
     const matrixRailButton = screen.getByRole("button", { name: "Open matrix-main" });
     expect(matrixRailButton.textContent).toBe("mma");

--- a/tests/shell/user-button-hydration.test.tsx
+++ b/tests/shell/user-button-hydration.test.tsx
@@ -30,7 +30,8 @@ describe("UserButton hydration shell", () => {
     const { UserButton } = await import("../../shell/src/components/UserButton.js");
     const html = renderToString(<UserButton />);
 
-    expect(html).toContain("lucide-user");
+    expect(html).toContain("<svg");
+    expect(html).toContain("size-4");
     expect(html).not.toContain("data-clerk-component");
   });
 });

--- a/tests/shell/user-button-hydration.test.tsx
+++ b/tests/shell/user-button-hydration.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { renderToString } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
+import { UserIcon } from "../../shell/src/lib/hugeicons.js";
 
 vi.mock("@clerk/nextjs", () => ({
   useAuth: () => ({ isLoaded: true, isSignedIn: true }),
@@ -30,8 +31,7 @@ describe("UserButton hydration shell", () => {
     const { UserButton } = await import("../../shell/src/components/UserButton.js");
     const html = renderToString(<UserButton />);
 
-    expect(html).toContain("<svg");
-    expect(html).toContain("size-4");
+    expect(html).toContain(renderToString(<UserIcon className="size-4" />));
     expect(html).not.toContain("data-clerk-component");
   });
 });


### PR DESCRIPTION
## Summary

- repair the post-merge MAT-502 CI regression by replacing Lucide-specific
  DOM assertions with Hugeicons-compatible rendered behavior
- preserve semantic icon identity by comparing rendered glyph geometry against
  the expected Hugeicons wrapper for navigation, recents, breadcrumbs, Terminal
  drawer directions, provider kinds, and the SSR account placeholder
- define `--text-inverse` in both Desktop themes and remove the app-drawer
  fallback without changing the rendered color

## Validation

- focused regression suite: 154 tests passed across the original six failing
  files
- semantic reviewer-fix suite: 138/138 tests passed across four affected files
- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing warnings only)
- `bun run build:desktop`
- local full suite was run until it reproduced 10 unrelated host/bootstrap
  baseline failures in `customer-vps-cloud-init` and
  `golden-snapshot-host-scripts`; the affected Desktop/Shell suites stayed green
- GitHub CI remains the authority for the full Linux shard result on this head

## Invariants

- icon source of truth remains the Desktop and shell Hugeicons adapters; no
  Lucide dependency or compatibility class is restored
- semantic tests compare glyph geometry while ignoring presentation-only stroke
  width so size and weight changes do not masquerade as icon swaps
- theme source of truth remains `desktop/src/renderer/src/design/tokens.css`
- no auth, persistence, database, transaction, API, or VPS runtime behavior is
  changed
- no records, resources, or background work can be orphaned by this patch

## Human Review

1. Open the OS View and confirm the sidebar, Back/Forward, and sidebar-collapse
   icons render in Chat, Projects, and Terminal.
2. In Terminal, hide and expand the sessions drawer and confirm both controls
   keep their correct directional icons.
3. Open Settings > Providers and confirm provider glyphs render distinctly.
4. Open the running-apps drawer in light and dark mode; hover a preview and
   confirm `Go to app` remains readable.

Linear: [MAT-502](https://linear.app/matrix-os/issue/MAT-502/migrate-desktop-and-shell-icons-from-lucide-to-hugeicons)
