### PR TITLE
fix(deploy): restore Preview and staging status

### DIFF
--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
     paths:
-      - ".github/workflows/platform-cloud-run.yml"
       - "packages/platform/**"
       - "packages/observability/**"
       - "packages/clerk-sync/**"
@@ -67,6 +66,10 @@ jobs:
       - name: Validate deployment configuration
         run: |
           set -euo pipefail
+          if [ "$DEPLOY_ENVIRONMENT" != "production" ]; then
+            echo "Platform Cloud Run only accepts the production environment." >&2
+            exit 1
+          fi
           missing=()
           for name in \
             GCP_PROJECT_ID \

--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -18,10 +18,9 @@ on:
       environment:
         description: GitHub environment to deploy
         required: true
-        default: staging
+        default: production
         type: choice
         options:
-          - staging
           - production
       promote:
         description: Promote the deployed revision to 100% traffic

--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -111,6 +111,16 @@ jobs:
             echo "CLOUD_RUN_PREVIEW_SERVICE_ACCOUNT must be set in the selected isolated environment; refusing to fall back to another SA." >&2
             exit 1
           fi
+          if [ -z "${PREVIEW_PUBLIC_URL:-}" ]; then
+            echo "Preview/staging PLATFORM_PUBLIC_URL must be explicitly configured." >&2
+            exit 1
+          fi
+          case "$PREVIEW_PUBLIC_URL" in
+            https://app.matrix-os.com*|https://api.matrix-os.com*)
+              echo "Preview/staging must not reuse a production public origin." >&2
+              exit 1
+              ;;
+          esac
           if [ "$DEPLOYMENT_ENVIRONMENT" = "staging" ]; then
             if [ "$CLOUD_RUN_PREVIEW_SERVICE" != "matrix-platform-staging" ]; then
               echo "staging must deploy only to the dedicated matrix-platform-staging service." >&2
@@ -120,16 +130,6 @@ jobs:
               echo "staging must use the preview runtime service account." >&2
               exit 1
             fi
-            if [ -z "${PREVIEW_PUBLIC_URL:-}" ]; then
-              echo "staging PLATFORM_PUBLIC_URL must be explicitly configured." >&2
-              exit 1
-            fi
-            case "$PREVIEW_PUBLIC_URL" in
-              https://app.matrix-os.com*|https://api.matrix-os.com*)
-                echo "staging must not reuse a production public origin." >&2
-                exit 1
-                ;;
-            esac
             echo "REVISION_TAG=staging-${PR_NUMBER}" >> "$GITHUB_ENV"
           else
             if [ "$CLOUD_RUN_PREVIEW_SERVICE" != "matrix-platform-preview" ]; then

--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -295,10 +295,11 @@ jobs:
         if: steps.config.outputs.configured == 'true'
         run: |
           set -euo pipefail
-          revisions="$(gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
-            --project "$GCP_PROJECT_ID" --region "$GCP_REGION" --format json |
-            jq -r --arg tag "pr-${PR_NUMBER}" \
-              '[(.status.traffic // [])[] | select(.tag == $tag) | .revisionName] | unique | .[]')"
+          service="$(gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
+            --project "$GCP_PROJECT_ID" --region "$GCP_REGION" --format json)"
+          revisions="$(jq -r --arg tag "pr-${PR_NUMBER}" \
+            '[(.status.traffic // [])[] | select(.tag == $tag) | .revisionName] | unique | .[]' \
+            <<< "$service")"
           if [ -z "$revisions" ]; then
             echo "No revisions tagged pr-${PR_NUMBER}; nothing to tear down."
             exit 0
@@ -307,7 +308,14 @@ jobs:
             --project "$GCP_PROJECT_ID" --region "$GCP_REGION" \
             --remove-tags "pr-${PR_NUMBER}" --quiet
           for rev in $revisions; do
-            gcloud run revisions delete "$rev" \
-              --project "$GCP_PROJECT_ID" --region "$GCP_REGION" --quiet
-            echo "Deleted revision $rev"
+            if delete_output="$(gcloud run revisions delete "$rev" \
+              --project "$GCP_PROJECT_ID" --region "$GCP_REGION" --quiet 2>&1)"; then
+              echo "Deleted revision $rev"
+            elif grep -Fq "FAILED_PRECONDITION: The latest created Revision" <<< "$delete_output" \
+              && grep -Fq "cannot be directly deleted" <<< "$delete_output"; then
+              echo "::notice::Retained latest-created revision $rev after removing its PR tag."
+            else
+              printf '%s\n' "$delete_output" >&2
+              exit 1
+            fi
           done

--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -172,7 +172,8 @@ jobs:
         run: |
           set -euo pipefail
           head_sha="${{ github.event.pull_request.head.sha || github.sha }}"
-          image="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REPOSITORY}/matrix-platform:pr-${PR_NUMBER}-${head_sha::12}"
+          deployment_slug="${DEPLOYMENT_ENVIRONMENT,,}"
+          image="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REPOSITORY}/matrix-platform:${deployment_slug}-pr-${PR_NUMBER}-${head_sha::12}"
           gcloud builds submit . \
             --project "$GCP_PROJECT_ID" \
             --config cloudbuild.platform.yaml \

--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -206,13 +206,18 @@ jobs:
           PREVIEW_DOMAIN="${PREVIEW_DOMAIN%%/*}"
           deploy_preview() {
             local api_origin="$1"
+            local traffic_flags=()
+            if gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
+              --project "$GCP_PROJECT_ID" --region "$GCP_REGION" >/dev/null 2>&1; then
+              traffic_flags+=(--no-traffic)
+            fi
             gcloud run deploy "$CLOUD_RUN_PREVIEW_SERVICE" \
               --project "$GCP_PROJECT_ID" \
               --region "$GCP_REGION" \
               --image "$IMAGE" \
               --service-account "$CLOUD_RUN_SERVICE_ACCOUNT" \
               --tag "${REVISION_TAG}" \
-              --no-traffic \
+              "${traffic_flags[@]}" \
               --allow-unauthenticated \
               --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PREVIEW=true,CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_IMAGE_VERSION=dev,CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,MATRIX_STRIPE_BILLING_ENABLED=true,MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED},MATRIX_CARD_TRIAL_DAYS=${MATRIX_CARD_TRIAL_DAYS},PLATFORM_PUBLIC_URL=${PREVIEW_PUBLIC_URL},MATRIX_API_ORIGIN=${api_origin},MATRIX_APP_URL=${PREVIEW_PUBLIC_URL},MATRIX_APP_DOMAIN_HOSTS=${PREVIEW_DOMAIN}" \
               --set-secrets "PLATFORM_DATABASE_URL=platform-database-url-staging:latest,PLATFORM_SECRET=platform-preview-secret:latest,GOLDEN_SNAPSHOT_OPERATOR_SECRET=golden-snapshot-operator-secret-preview:latest,PLATFORM_JWT_SECRET=platform-preview-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-preview-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,STRIPE_SECRET_KEY=stripe-secret-key-test:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret-test:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly-test:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual-test:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly-test:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual-test:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly-test:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual-test:latest" \

--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -41,6 +41,14 @@ on:
         description: "PR number to deploy a platform preview for"
         required: true
         type: string
+      deployment_environment:
+        description: "Isolated GitHub environment to deploy"
+        required: true
+        default: Preview
+        type: choice
+        options:
+          - Preview
+          - staging
 
 permissions:
   contents: read
@@ -48,7 +56,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: preview-platform-${{ github.event.pull_request.number || inputs.pr }}
+  group: preview-platform-${{ github.event_name == 'workflow_dispatch' && inputs.deployment_environment || 'Preview' }}-${{ github.event.pull_request.number || inputs.pr }}
   cancel-in-progress: true
 
 jobs:
@@ -62,15 +70,17 @@ jobs:
          (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'preview-platform')))))
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: Preview
+    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.deployment_environment || 'Preview' }}
     env:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_REGION: ${{ vars.GCP_REGION }}
       ARTIFACT_REPOSITORY: ${{ vars.ARTIFACT_REPOSITORY }}
       CLOUD_RUN_PREVIEW_SERVICE: ${{ vars.CLOUD_RUN_PREVIEW_SERVICE }}
       CLOUD_RUN_SERVICE_ACCOUNT: ${{ vars.CLOUD_RUN_PREVIEW_SERVICE_ACCOUNT }}
+      PREVIEW_PUBLIC_URL: ${{ vars.PLATFORM_PUBLIC_URL }}
       MATRIX_CARD_TRIALS_ENABLED: ${{ vars.MATRIX_CARD_TRIALS_ENABLED || 'false' }}
       MATRIX_CARD_TRIAL_DAYS: ${{ vars.MATRIX_CARD_TRIAL_DAYS || '7' }}
+      DEPLOYMENT_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.deployment_environment || 'Preview' }}
       PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
     steps:
       - name: Check preview configuration
@@ -78,13 +88,40 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${CLOUD_RUN_PREVIEW_SERVICE:-}" ]; then
+            if [ "$DEPLOYMENT_ENVIRONMENT" = "staging" ]; then
+              echo "staging configuration is required; refusing a no-op deployment." >&2
+              exit 1
+            fi
             echo "configured=false" >> "$GITHUB_OUTPUT"
             echo "::notice::CLOUD_RUN_PREVIEW_SERVICE is not configured; platform previews are disabled. See specs/093-preview-environments/."
             exit 0
           fi
           if [ -z "${CLOUD_RUN_SERVICE_ACCOUNT:-}" ]; then
-            echo "CLOUD_RUN_PREVIEW_SERVICE_ACCOUNT must be set in the Preview environment; refusing to fall back to another SA." >&2
+            echo "CLOUD_RUN_PREVIEW_SERVICE_ACCOUNT must be set in the selected isolated environment; refusing to fall back to another SA." >&2
             exit 1
+          fi
+          if [ "$DEPLOYMENT_ENVIRONMENT" = "staging" ]; then
+            if [ "$CLOUD_RUN_PREVIEW_SERVICE" != "matrix-platform-staging" ]; then
+              echo "staging must deploy only to the dedicated matrix-platform-staging service." >&2
+              exit 1
+            fi
+            if [ "$CLOUD_RUN_SERVICE_ACCOUNT" != "matrix-platform-preview-runner@matrix-os-1144.iam.gserviceaccount.com" ]; then
+              echo "staging must use the preview runtime service account." >&2
+              exit 1
+            fi
+            if [ -z "${PREVIEW_PUBLIC_URL:-}" ]; then
+              echo "staging PLATFORM_PUBLIC_URL must be explicitly configured." >&2
+              exit 1
+            fi
+            case "$PREVIEW_PUBLIC_URL" in
+              https://app.matrix-os.com*|https://api.matrix-os.com*)
+                echo "staging must not reuse a production public origin." >&2
+                exit 1
+                ;;
+            esac
+            echo "REVISION_TAG=staging-${PR_NUMBER}" >> "$GITHUB_ENV"
+          else
+            echo "REVISION_TAG=pr-${PR_NUMBER}" >> "$GITHUB_ENV"
           fi
           case "$MATRIX_CARD_TRIALS_ENABLED" in
             true|false) ;;
@@ -174,7 +211,7 @@ jobs:
               --region "$GCP_REGION" \
               --image "$IMAGE" \
               --service-account "$CLOUD_RUN_SERVICE_ACCOUNT" \
-              --tag "pr-${PR_NUMBER}" \
+              --tag "${REVISION_TAG}" \
               --no-traffic \
               --allow-unauthenticated \
               --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PREVIEW=true,CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_IMAGE_VERSION=dev,CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,MATRIX_STRIPE_BILLING_ENABLED=true,MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED},MATRIX_CARD_TRIAL_DAYS=${MATRIX_CARD_TRIAL_DAYS},PLATFORM_PUBLIC_URL=${PREVIEW_PUBLIC_URL},MATRIX_API_ORIGIN=${api_origin},MATRIX_APP_URL=${PREVIEW_PUBLIC_URL},MATRIX_APP_DOMAIN_HOSTS=${PREVIEW_DOMAIN}" \
@@ -197,16 +234,16 @@ jobs:
             echo "Preview service URL is unavailable; refusing a shared control-plane fallback." >&2
             exit 1
           fi
-          PREVIEW_API_ORIGIN="https://pr-${PR_NUMBER}---${service_base_url#https://}"
+          PREVIEW_API_ORIGIN="https://${REVISION_TAG}---${service_base_url#https://}"
           deploy_preview "$PREVIEW_API_ORIGIN"
           url=""
           revision=""
           for _attempt in {1..10}; do
             desc="$(gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
               --project "$GCP_PROJECT_ID" --region "$GCP_REGION" --format json)"
-            url="$(jq -r --arg tag "pr-${PR_NUMBER}" \
+            url="$(jq -r --arg tag "$REVISION_TAG" \
               '[(.status.traffic // [])[] | select(.tag == $tag) | .url] | first // ""' <<< "$desc")"
-            revision="$(jq -r --arg tag "pr-${PR_NUMBER}" \
+            revision="$(jq -r --arg tag "$REVISION_TAG" \
               '[(.status.traffic // [])[] | select(.tag == $tag) | .revisionName] | first // ""' <<< "$desc")"
             if [ -n "$url" ] && [ -n "$revision" ]; then
               break
@@ -245,10 +282,10 @@ jobs:
           set -euo pipefail
           body="**Platform preview revision deployed**
 
-          - Browser-reachable host: ${PREVIEW_PUBLIC_URL} (route this PR's tag to it: \`gcloud run services update-traffic ${CLOUD_RUN_PREVIEW_SERVICE} --region ${GCP_REGION} --to-tags pr-${PR_NUMBER}=100\`, then reset when done)
+          - Browser-reachable host: ${PREVIEW_PUBLIC_URL} (route this revision's tag to it: \`gcloud run services update-traffic ${CLOUD_RUN_PREVIEW_SERVICE} --region ${GCP_REGION} --to-tags ${REVISION_TAG}=100\`, then reset when done)
           - Desktop control-plane origin: ${PREVIEW_API_ORIGIN}
           - Revision URL: ${PREVIEW_URL}
-          - Service: \`${CLOUD_RUN_PREVIEW_SERVICE}\` (deployed zero-traffic, tag \`pr-${PR_NUMBER}\`)
+          - Service: \`${CLOUD_RUN_PREVIEW_SERVICE}\` (deployed zero-traffic, tag \`${REVISION_TAG}\`)
 
           Runs as the preview runtime SA against the staging database with Stripe TEST-mode keys; production service, SA, database, and live Stripe keys are untouched."
           existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \

--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -173,7 +173,7 @@ jobs:
           set -euo pipefail
           head_sha="${{ github.event.pull_request.head.sha || github.sha }}"
           deployment_slug="${DEPLOYMENT_ENVIRONMENT,,}"
-          image="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REPOSITORY}/matrix-platform:${deployment_slug}-pr-${PR_NUMBER}-${head_sha::12}"
+          image="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REPOSITORY}/matrix-platform:${deployment_slug}-pr-${PR_NUMBER}-${head_sha::12}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           gcloud builds submit . \
             --project "$GCP_PROJECT_ID" \
             --config cloudbuild.platform.yaml \

--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -192,7 +192,7 @@ jobs:
             exit 1
           fi
 
-      - name: Deploy zero-traffic tagged revision to preview service
+      - name: Deploy isolated tagged revision
         if: steps.config.outputs.configured == 'true'
         run: |
           set -euo pipefail
@@ -207,8 +207,7 @@ jobs:
           deploy_preview() {
             local api_origin="$1"
             local traffic_flags=()
-            if gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
-              --project "$GCP_PROJECT_ID" --region "$GCP_REGION" >/dev/null 2>&1; then
+            if [ "$service_exists" = true ]; then
               traffic_flags+=(--no-traffic)
             fi
             gcloud run deploy "$CLOUD_RUN_PREVIEW_SERVICE" \
@@ -225,12 +224,25 @@ jobs:
               --quiet
           }
 
-          service_base_url="$(gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
+          service_lookup_error="$(mktemp)"
+          trap 'rm -f "$service_lookup_error"' EXIT
+          service_base_url=""
+          service_exists=false
+          if service_base_url="$(gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
             --project "$GCP_PROJECT_ID" --region "$GCP_REGION" \
-            --format='value(status.url)' 2>/dev/null || true)"
-          BOOTSTRAP_API_ORIGIN="https://preview-bootstrap.invalid"
-          if [ -z "$service_base_url" ]; then
+            --format='value(status.url)' 2>"$service_lookup_error")"; then
+            service_exists=true
+          elif grep -Fq "could not be found" "$service_lookup_error" \
+            || grep -Fq "NOT_FOUND" "$service_lookup_error"; then
+            service_exists=false
+          else
+            cat "$service_lookup_error" >&2
+            exit 1
+          fi
+          BOOTSTRAP_API_ORIGIN="$PREVIEW_PUBLIC_URL"
+          if [ "$service_exists" = false ]; then
             deploy_preview "$BOOTSTRAP_API_ORIGIN"
+            service_exists=true
             service_base_url="$(gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
               --project "$GCP_PROJECT_ID" --region "$GCP_REGION" \
               --format='value(status.url)')"
@@ -275,6 +287,20 @@ jobs:
           fi
           curl --fail --silent --show-error --retry 5 --retry-all-errors \
             --connect-timeout 5 --max-time 10 "${PREVIEW_API_ORIGIN}/health" > /dev/null
+          if [ "$DEPLOYMENT_ENVIRONMENT" = "staging" ]; then
+            gcloud run services update-traffic "$CLOUD_RUN_PREVIEW_SERVICE" \
+              --project "$GCP_PROJECT_ID" --region "$GCP_REGION" \
+              --to-revisions "${revision}=100" --quiet
+            promoted_revision="$(gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
+              --project "$GCP_PROJECT_ID" --region "$GCP_REGION" --format json \
+              | jq -r '[(.status.traffic // [])[] | select((.percent // 0) == 100) | .revisionName] | first // ""')"
+            if [ "$promoted_revision" != "$revision" ]; then
+              echo "Staging default traffic does not point to the verified revision." >&2
+              exit 1
+            fi
+            curl --fail --silent --show-error --retry 5 --retry-all-errors \
+              --connect-timeout 5 --max-time 10 "${PREVIEW_PUBLIC_URL}/health" > /dev/null
+          fi
           echo "PREVIEW_URL=$url" >> "$GITHUB_ENV"
           echo "PREVIEW_PUBLIC_URL=$PREVIEW_PUBLIC_URL" >> "$GITHUB_ENV"
           echo "PREVIEW_API_ORIGIN=$PREVIEW_API_ORIGIN" >> "$GITHUB_ENV"

--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -70,7 +70,11 @@ jobs:
          (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'preview-platform')))))
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.deployment_environment || 'Preview' }}
+    environment: >-
+      ${{ github.event_name != 'workflow_dispatch' && 'Preview' ||
+          inputs.deployment_environment == 'Preview' && 'Preview' ||
+          inputs.deployment_environment == 'staging' && 'staging' ||
+          'invalid-preview-environment' }}
     env:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_REGION: ${{ vars.GCP_REGION }}
@@ -87,6 +91,13 @@ jobs:
         id: config
         run: |
           set -euo pipefail
+          case "$DEPLOYMENT_ENVIRONMENT" in
+            Preview|staging) ;;
+            *)
+              echo "Unsupported preview deployment environment: ${DEPLOYMENT_ENVIRONMENT}" >&2
+              exit 1
+              ;;
+          esac
           if [ -z "${CLOUD_RUN_PREVIEW_SERVICE:-}" ]; then
             if [ "$DEPLOYMENT_ENVIRONMENT" = "staging" ]; then
               echo "staging configuration is required; refusing a no-op deployment." >&2
@@ -121,6 +132,14 @@ jobs:
             esac
             echo "REVISION_TAG=staging-${PR_NUMBER}" >> "$GITHUB_ENV"
           else
+            if [ "$CLOUD_RUN_PREVIEW_SERVICE" != "matrix-platform-preview" ]; then
+              echo "Preview must deploy only to the dedicated matrix-platform-preview service." >&2
+              exit 1
+            fi
+            if [ "$CLOUD_RUN_SERVICE_ACCOUNT" != "matrix-platform-preview-runner@matrix-os-1144.iam.gserviceaccount.com" ]; then
+              echo "Preview must use the preview runtime service account." >&2
+              exit 1
+            fi
             echo "REVISION_TAG=pr-${PR_NUMBER}" >> "$GITHUB_ENV"
           fi
           case "$MATRIX_CARD_TRIALS_ENABLED" in

--- a/docs/dev/preview-environments.md
+++ b/docs/dev/preview-environments.md
@@ -146,6 +146,19 @@ Hetzner token on preview); enabling it is a deliberate follow-up (a
 preview-scoped Hetzner token + VPS reaping). For that slice today, use the
 feature-VPS path in [Staging Platform and Feature VPS Runbook](staging-platform-vps.md).
 
+For a durable GitHub `staging` deployment, manually dispatch the same isolated
+lane with `deployment_environment=staging`. That target is hard-gated to the
+dedicated `matrix-platform-staging` Cloud Run service, the preview runtime
+service account, the staging database, and Stripe test-mode secrets. It deploys
+and smokes an exact-image, zero-traffic tagged revision; it never aliases the
+production service or its runtime identity:
+
+```bash
+gh workflow run preview-platform.yml --ref <branch-or-sha> \
+  -f pr=<pr-number> \
+  -f deployment_environment=staging
+```
+
 ### One-time infrastructure setup
 
 The label workflow assumes this is already provisioned in GCP/Cloudflare/Stripe

--- a/docs/dev/preview-environments.md
+++ b/docs/dev/preview-environments.md
@@ -150,8 +150,9 @@ For a durable GitHub `staging` deployment, manually dispatch the same isolated
 lane with `deployment_environment=staging`. That target is hard-gated to the
 dedicated `matrix-platform-staging` Cloud Run service, the preview runtime
 service account, the staging database, and Stripe test-mode secrets. It deploys
-and smokes an exact-image, zero-traffic tagged revision; it never aliases the
-production service or its runtime identity:
+and smokes an exact-image tagged revision, then promotes that verified revision
+to 100% of the dedicated staging service traffic. It never aliases the
+production service, traffic, or runtime identity:
 
 ```bash
 gh workflow run preview-platform.yml --ref <branch-or-sha> \

--- a/docs/dev/staging-platform-vps.md
+++ b/docs/dev/staging-platform-vps.md
@@ -32,13 +32,15 @@ cover one slice:
 > Known gap: combining all four into one browser-reachable environment is not
 > wired yet. The GitHub `staging` deployment lane is now isolated on the
 > dedicated `matrix-platform-staging` Cloud Run service with the staging
-> database, preview runtime identity, and Stripe test-mode secrets, but it is a
-> zero-traffic control-plane smoke target rather than a public end-to-end host.
+> database, preview runtime identity, and Stripe test-mode secrets. After the
+> exact tagged revision passes image and health checks, that revision receives
+> 100% of the dedicated staging service traffic. It is still not a complete
+> public end-to-end host because the disposable-VPS hand-off is separate.
 > `preview-vps` still provisions against the **production** platform. Until a
 > reviewed staging route and disposable-VPS hand-off exist, use the split below.
 
-To deploy and smoke the isolated staging control plane from an exact branch or
-SHA without promoting traffic:
+To deploy, smoke, and promote the isolated staging control plane from an exact
+branch or SHA (traffic changes only inside `matrix-platform-staging`):
 
 ```bash
 gh workflow run preview-platform.yml --ref <branch-or-sha> \

--- a/docs/dev/staging-platform-vps.md
+++ b/docs/dev/staging-platform-vps.md
@@ -30,12 +30,21 @@ cover one slice:
 | Provisioned shell on a real host | Disposable feature VPS | Confirms the boot -> first-run -> ready hand-off on a real customer VPS. |
 
 > Known gap: combining all four into one browser-reachable environment is not
-> wired yet (`preview-platform` is IAM-only and has no Stripe secrets;
-> `preview-vps` provisions against the **production** platform; the GitHub
-> `staging` environment is a no-traffic revision of the production service).
-> Closing it durably means either adding Stripe test secrets to
-> `matrix-platform-preview` and fronting it with auth, or standing up a
-> dedicated isolated staging platform. Until then, use the split below.
+> wired yet. The GitHub `staging` deployment lane is now isolated on the
+> dedicated `matrix-platform-staging` Cloud Run service with the staging
+> database, preview runtime identity, and Stripe test-mode secrets, but it is a
+> zero-traffic control-plane smoke target rather than a public end-to-end host.
+> `preview-vps` still provisions against the **production** platform. Until a
+> reviewed staging route and disposable-VPS hand-off exist, use the split below.
+
+To deploy and smoke the isolated staging control plane from an exact branch or
+SHA without promoting traffic:
+
+```bash
+gh workflow run preview-platform.yml --ref <branch-or-sha> \
+  -f pr=<pr-number> \
+  -f deployment_environment=staging
+```
 
 ## Slice 1 — Shell (boot sequence, auth door, origins)
 

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -376,6 +376,9 @@ describe('CI workflows', () => {
     expect(isolated).toContain('matrix-platform-preview-runner@matrix-os-1144.iam.gserviceaccount.com');
     expect(isolated).toContain('PLATFORM_DATABASE_URL=platform-database-url-staging:latest');
     expect(isolated).toContain('STRIPE_SECRET_KEY=stripe-secret-key-test:latest');
+    expect(isolated).toContain('traffic_flags=()');
+    expect(isolated).toContain('traffic_flags+=(--no-traffic)');
+    expect(isolated).toContain('"${traffic_flags[@]}"');
     expect(isolated).toContain('--no-traffic');
     expect(isolated).toContain('${REVISION_TAG}');
   });

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -376,7 +376,7 @@ describe('CI workflows', () => {
     expect(isolated).toContain('Preview|staging) ;;');
     expect(isolated).toContain('Unsupported preview deployment environment:');
     expect(isolated).toContain('deployment_slug="${DEPLOYMENT_ENVIRONMENT,,}"');
-    expect(isolated).toContain('matrix-platform:${deployment_slug}-pr-${PR_NUMBER}-${head_sha::12}');
+    expect(isolated).toContain('matrix-platform:${deployment_slug}-pr-${PR_NUMBER}-${head_sha::12}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}');
     expect(isolated).toContain("DEPLOYMENT_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.deployment_environment || 'Preview' }}");
     expect(isolated).not.toContain("environment: ${{ github.event_name == 'workflow_dispatch' && inputs.deployment_environment || 'Preview' }}");
     expect(isolated).toContain('if [ "$DEPLOYMENT_ENVIRONMENT" = "staging" ]; then');

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -365,6 +365,9 @@ describe('CI workflows', () => {
 
     expect(production).toMatch(/options:\s*\n\s*- production/);
     expect(production).not.toMatch(/options:\s*\n(?:\s*- [^\n]+\n)*\s*- staging/);
+    expect(production).toContain('if [ "$DEPLOY_ENVIRONMENT" != "production" ]; then');
+    expect(production).toContain('Platform Cloud Run only accepts the production environment.');
+    expect(production).not.toContain('- ".github/workflows/platform-cloud-run.yml"');
 
     expect(isolated).toContain('deployment_environment:');
     expect(isolated).toMatch(/deployment_environment:[\s\S]*?options:[\s\S]*?- Preview[\s\S]*?- staging/);
@@ -523,11 +526,12 @@ describe('CI workflows', () => {
     expect(platformWorkflow).toContain('_NEXT_PUBLIC_POSTHOG_API_HOST=$POSTHOG_PUBLIC_API_HOST');
   });
 
-  it('redeploys the platform when the Cloud Run workflow itself changes', () => {
+  it('requires explicit dispatch after platform workflow-only changes', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
 
-    expect(workflow).toContain('- ".github/workflows/platform-cloud-run.yml"');
+    expect(workflow).not.toContain('- ".github/workflows/platform-cloud-run.yml"');
+    expect(workflow).toContain('workflow_dispatch:');
   });
 
   it('verifies platform Cloud Run promotion sends all traffic to the production-role revision', () => {

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -358,6 +358,28 @@ describe('CI workflows', () => {
     expect(preview).toContain('roles/secretmanager.secretAccessor');
   });
 
+  it('deploys staging through the isolated preview control-plane lane', () => {
+    const root = process.cwd();
+    const production = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
+    const isolated = readFileSync(join(root, '.github/workflows/preview-platform.yml'), 'utf8');
+
+    expect(production).toMatch(/options:\s*\n\s*- production/);
+    expect(production).not.toMatch(/options:\s*\n(?:\s*- [^\n]+\n)*\s*- staging/);
+
+    expect(isolated).toContain('deployment_environment:');
+    expect(isolated).toMatch(/deployment_environment:[\s\S]*?options:[\s\S]*?- Preview[\s\S]*?- staging/);
+    expect(isolated).toContain("DEPLOYMENT_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.deployment_environment || 'Preview' }}");
+    expect(isolated).toContain("environment: ${{ github.event_name == 'workflow_dispatch' && inputs.deployment_environment || 'Preview' }}");
+    expect(isolated).toContain('if [ "$DEPLOYMENT_ENVIRONMENT" = "staging" ]; then');
+    expect(isolated).toContain('staging configuration is required; refusing a no-op deployment.');
+    expect(isolated).toContain('matrix-platform-staging');
+    expect(isolated).toContain('matrix-platform-preview-runner@matrix-os-1144.iam.gserviceaccount.com');
+    expect(isolated).toContain('PLATFORM_DATABASE_URL=platform-database-url-staging:latest');
+    expect(isolated).toContain('STRIPE_SECRET_KEY=stripe-secret-key-test:latest');
+    expect(isolated).toContain('--no-traffic');
+    expect(isolated).toContain('${REVISION_TAG}');
+  });
+
   it('does not require add-on prices or focused portal configurations for platform deployment', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
@@ -429,12 +451,11 @@ describe('CI workflows', () => {
     expect(workflow).toContain('starting_after');
   });
 
-  it('keeps production platform Cloud Run warm while allowing staging to scale to zero', () => {
+  it('keeps production platform Cloud Run warm', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
 
     expect(workflow).toContain('DEPLOY_ENVIRONMENT: ${{ github.event_name == \'workflow_dispatch\' && inputs.environment || \'production\' }}');
-    expect(workflow).toContain('min_instances=0');
     expect(workflow).toContain('if [ "$DEPLOY_ENVIRONMENT" = "production" ]; then');
     expect(workflow).toContain('min_instances=1');
     expect(workflow).toContain('--min-instances "$min_instances"');

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -380,6 +380,7 @@ describe('CI workflows', () => {
     expect(isolated).toContain('traffic_flags+=(--no-traffic)');
     expect(isolated).toContain('"${traffic_flags[@]}"');
     expect(isolated).toContain('--no-traffic');
+    expect(isolated).toContain('--to-revisions "${revision}=100"');
     expect(isolated).toContain('${REVISION_TAG}');
   });
 

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -384,6 +384,8 @@ describe('CI workflows', () => {
     expect(isolated).toContain('matrix-platform-staging');
     expect(isolated).toContain('matrix-platform-preview');
     expect(isolated).toContain('Preview must deploy only to the dedicated matrix-platform-preview service.');
+    expect(isolated).toContain('Preview/staging PLATFORM_PUBLIC_URL must be explicitly configured.');
+    expect(isolated).toContain('Preview/staging must not reuse a production public origin.');
     expect(isolated).toContain('matrix-platform-preview-runner@matrix-os-1144.iam.gserviceaccount.com');
     expect(isolated).toContain('PLATFORM_DATABASE_URL=platform-database-url-staging:latest');
     expect(isolated).toContain('STRIPE_SECRET_KEY=stripe-secret-key-test:latest');

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -371,11 +371,17 @@ describe('CI workflows', () => {
 
     expect(isolated).toContain('deployment_environment:');
     expect(isolated).toMatch(/deployment_environment:[\s\S]*?options:[\s\S]*?- Preview[\s\S]*?- staging/);
+    expect(isolated).toContain("'invalid-preview-environment'");
+    expect(isolated).toContain('case "$DEPLOYMENT_ENVIRONMENT" in');
+    expect(isolated).toContain('Preview|staging) ;;');
+    expect(isolated).toContain('Unsupported preview deployment environment:');
     expect(isolated).toContain("DEPLOYMENT_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.deployment_environment || 'Preview' }}");
-    expect(isolated).toContain("environment: ${{ github.event_name == 'workflow_dispatch' && inputs.deployment_environment || 'Preview' }}");
+    expect(isolated).not.toContain("environment: ${{ github.event_name == 'workflow_dispatch' && inputs.deployment_environment || 'Preview' }}");
     expect(isolated).toContain('if [ "$DEPLOYMENT_ENVIRONMENT" = "staging" ]; then');
     expect(isolated).toContain('staging configuration is required; refusing a no-op deployment.');
     expect(isolated).toContain('matrix-platform-staging');
+    expect(isolated).toContain('matrix-platform-preview');
+    expect(isolated).toContain('Preview must deploy only to the dedicated matrix-platform-preview service.');
     expect(isolated).toContain('matrix-platform-preview-runner@matrix-os-1144.iam.gserviceaccount.com');
     expect(isolated).toContain('PLATFORM_DATABASE_URL=platform-database-url-staging:latest');
     expect(isolated).toContain('STRIPE_SECRET_KEY=stripe-secret-key-test:latest');

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -375,6 +375,8 @@ describe('CI workflows', () => {
     expect(isolated).toContain('case "$DEPLOYMENT_ENVIRONMENT" in');
     expect(isolated).toContain('Preview|staging) ;;');
     expect(isolated).toContain('Unsupported preview deployment environment:');
+    expect(isolated).toContain('deployment_slug="${DEPLOYMENT_ENVIRONMENT,,}"');
+    expect(isolated).toContain('matrix-platform:${deployment_slug}-pr-${PR_NUMBER}-${head_sha::12}');
     expect(isolated).toContain("DEPLOYMENT_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.deployment_environment || 'Preview' }}");
     expect(isolated).not.toContain("environment: ${{ github.event_name == 'workflow_dispatch' && inputs.deployment_environment || 'Preview' }}");
     expect(isolated).toContain('if [ "$DEPLOYMENT_ENVIRONMENT" = "staging" ]; then');

--- a/tests/platform/preview-platform-workflow.test.ts
+++ b/tests/platform/preview-platform-workflow.test.ts
@@ -1,9 +1,94 @@
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
 
 const root = process.cwd();
+
+function runTeardownWithService(
+  service: unknown,
+  deleteFailure =
+    "ERROR: (gcloud.run.revisions.delete) FAILED_PRECONDITION: The latest created Revision 'revision-latest' cannot be directly deleted.",
+) {
+  const workflow = parse(
+    readFileSync(join(root, ".github/workflows/preview-platform.yml"), "utf8"),
+  ) as {
+    jobs: { teardown: { steps: Array<{ name?: string; run?: string }> } };
+  };
+  const script = workflow.jobs.teardown.steps.find(
+    (step) => step.name === "Remove tag and delete tagged revisions",
+  )?.run;
+  if (!script) {
+    throw new Error("Preview teardown script is missing");
+  }
+
+  const tempDir = mkdtempSync(join(tmpdir(), "matrix-preview-teardown-"));
+  const logPath = join(tempDir, "gcloud.log");
+  const gcloudPath = join(tempDir, "gcloud");
+  writeFileSync(
+    gcloudPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$MOCK_GCLOUD_LOG"
+case "$*" in
+  "run services describe "*)
+    if [[ "$*" == *"--format json"* ]]; then
+      printf '%s\\n' "$MOCK_SERVICE_JSON"
+    else
+      printf '%s\\n' "$MOCK_LATEST_REVISION"
+    fi
+    ;;
+  "run services update-traffic "*)
+    ;;
+  "run revisions delete "*)
+    if [[ "$*" == *"run revisions delete $MOCK_UNDELETABLE_REVISION "* ]]; then
+      printf '%s\n' "$MOCK_DELETE_FAILURE" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+`,
+  );
+  chmodSync(gcloudPath, 0o755);
+
+  try {
+    const result = spawnSync("bash", ["-c", script], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${tempDir}:${process.env.PATH ?? ""}`,
+        CLOUD_RUN_PREVIEW_SERVICE: "matrix-platform-preview",
+        GCP_PROJECT_ID: "matrix-test",
+        GCP_REGION: "europe-west3",
+        PR_NUMBER: "42",
+        MOCK_GCLOUD_LOG: logPath,
+        MOCK_SERVICE_JSON: JSON.stringify(service),
+        MOCK_LATEST_REVISION: "revision-latest",
+        MOCK_UNDELETABLE_REVISION: "revision-latest",
+        MOCK_DELETE_FAILURE: deleteFailure,
+      },
+    });
+    return {
+      ...result,
+      log: readFileSync(logPath, "utf8"),
+    };
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
 
 describe("preview platform workflow", () => {
   it("sources the deployed control-plane origin from the selected environment", () => {
@@ -39,5 +124,85 @@ describe("preview platform workflow", () => {
     expect(bootstrap).toBeGreaterThan(-1);
     expect(deriveOrigin).toBeGreaterThan(bootstrap);
     expect(finalDeploy).toBeGreaterThan(deriveOrigin);
+  });
+
+  it("removes closed PR tags while tolerating Cloud Run's latest-created revision guard", () => {
+    const workflow = readFileSync(
+      join(root, ".github/workflows/preview-platform.yml"),
+      "utf8",
+    );
+
+    expect(workflow).toContain('--remove-tags "pr-${PR_NUMBER}"');
+    expect(workflow).toContain('if delete_output="$(gcloud run revisions delete "$rev"');
+    expect(workflow).toContain(
+      'grep -Fq "FAILED_PRECONDITION: The latest created Revision"',
+    );
+    expect(workflow).toContain('grep -Fq "cannot be directly deleted"');
+    expect(workflow).toContain("Retained latest-created revision $rev after removing its PR tag.");
+
+    const removeTag = workflow.indexOf('--remove-tags "pr-${PR_NUMBER}"');
+    const deleteRevision = workflow.indexOf(
+      'if delete_output="$(gcloud run revisions delete "$rev"',
+    );
+    const tolerateLatest = workflow.indexOf(
+      'grep -Fq "FAILED_PRECONDITION: The latest created Revision"',
+    );
+    expect(removeTag).toBeGreaterThan(-1);
+    expect(deleteRevision).toBeGreaterThan(removeTag);
+    expect(tolerateLatest).toBeGreaterThan(deleteRevision);
+  });
+
+  it("removes the PR tag, tolerates the protected latest revision, and deletes older tagged revisions", () => {
+    const result = runTeardownWithService({
+      status: {
+        latestCreatedRevisionName: "revision-stale-snapshot",
+        traffic: [
+          { tag: "pr-42", revisionName: "revision-latest" },
+          { tag: "pr-42", revisionName: "revision-older" },
+        ],
+      },
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain(
+      "Retained latest-created revision revision-latest after removing its PR tag.",
+    );
+    expect(result.stdout).toContain("Deleted revision revision-older");
+    expect(result.log).toContain("run services update-traffic matrix-platform-preview");
+    expect(result.log).toContain("--remove-tags pr-42");
+    expect(result.log).toContain(
+      "run revisions delete revision-latest --project matrix-test --region europe-west3 --quiet",
+    );
+    expect(result.log).toContain("run revisions delete revision-older");
+  });
+
+  it("fails teardown when revision deletion returns an unrelated error", () => {
+    const result = runTeardownWithService(
+      {
+        status: {
+          traffic: [{ tag: "pr-42", revisionName: "revision-latest" }],
+        },
+      },
+      "ERROR: permission denied",
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("ERROR: permission denied");
+    expect(result.log).toContain("run revisions delete revision-latest");
+  });
+
+  it("treats an already removed preview tag as a successful no-op", () => {
+    const result = runTeardownWithService({
+      status: {
+        latestCreatedRevisionName: "revision-latest",
+        traffic: [],
+      },
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("No revisions tagged pr-42; nothing to tear down.");
+    expect(result.log).toContain("run services describe matrix-platform-preview");
+    expect(result.log).not.toContain("run services update-traffic");
+    expect(result.log).not.toContain("run revisions delete");
   });
 });

--- a/tests/platform/preview-platform-workflow.test.ts
+++ b/tests/platform/preview-platform-workflow.test.ts
@@ -90,6 +90,71 @@ esac
   }
 }
 
+function runDeployWithServiceLookupFailure(lookupFailure: string) {
+  const workflow = parse(
+    readFileSync(join(root, ".github/workflows/preview-platform.yml"), "utf8"),
+  ) as {
+    jobs: { preview: { steps: Array<{ name?: string; run?: string }> } };
+  };
+  const script = workflow.jobs.preview.steps.find(
+    (step) => step.name === "Deploy isolated tagged revision",
+  )?.run;
+  if (!script) {
+    throw new Error("Preview deployment script is missing");
+  }
+
+  const tempDir = mkdtempSync(join(tmpdir(), "matrix-preview-deploy-"));
+  const logPath = join(tempDir, "gcloud.log");
+  const gcloudPath = join(tempDir, "gcloud");
+  const githubEnvPath = join(tempDir, "github.env");
+  writeFileSync(githubEnvPath, "");
+  writeFileSync(
+    gcloudPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$MOCK_GCLOUD_LOG"
+if [[ "$*" == "run services describe "* ]]; then
+  printf '%s\\n' "$MOCK_LOOKUP_FAILURE" >&2
+  exit 1
+fi
+exit 64
+`,
+  );
+  chmodSync(gcloudPath, 0o755);
+
+  try {
+    const result = spawnSync("bash", ["-c", script], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${tempDir}:${process.env.PATH ?? ""}`,
+        CLOUD_RUN_PREVIEW_SERVICE: "matrix-platform-staging",
+        CLOUD_RUN_SERVICE_ACCOUNT:
+          "matrix-platform-preview-runner@matrix-os-1144.iam.gserviceaccount.com",
+        DEPLOYMENT_ENVIRONMENT: "staging",
+        GCP_PROJECT_ID: "matrix-test",
+        GCP_REGION: "europe-west3",
+        GITHUB_ENV: githubEnvPath,
+        IMAGE: "europe-west3-docker.pkg.dev/matrix-test/containers/platform:test",
+        MATRIX_CARD_TRIAL_DAYS: "7",
+        MATRIX_CARD_TRIALS_ENABLED: "false",
+        MOCK_GCLOUD_LOG: logPath,
+        MOCK_LOOKUP_FAILURE: lookupFailure,
+        PREVIEW_PUBLIC_URL: "https://staging.example.test",
+        PR_NUMBER: "42",
+        REVISION_TAG: "staging-42",
+      },
+    });
+    return {
+      ...result,
+      log: readFileSync(logPath, "utf8"),
+    };
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
 describe("preview platform workflow", () => {
   it("sources the deployed control-plane origin from the selected environment", () => {
     const workflow = readFileSync(
@@ -110,20 +175,51 @@ describe("preview platform workflow", () => {
       "utf8",
     );
 
-    expect(workflow).toContain("2>/dev/null || true");
-    expect(workflow).toContain('BOOTSTRAP_API_ORIGIN="https://preview-bootstrap.invalid"');
+    expect(workflow).not.toContain("2>/dev/null || true");
+    expect(workflow).toContain('service_lookup_error="$(mktemp)"');
+    expect(workflow).toContain('grep -Fq "could not be found" "$service_lookup_error"');
+    expect(workflow).toContain('BOOTSTRAP_API_ORIGIN="$PREVIEW_PUBLIC_URL"');
     expect(workflow).toContain('if [ -z "$service_base_url" ]; then');
     expect(workflow).toContain('deploy_preview "$BOOTSTRAP_API_ORIGIN"');
     expect(workflow).toContain('deploy_preview "$PREVIEW_API_ORIGIN"');
 
     const bootstrap = workflow.indexOf('deploy_preview "$BOOTSTRAP_API_ORIGIN"');
     const deriveOrigin = workflow.indexOf(
-      'PREVIEW_API_ORIGIN="https://pr-${PR_NUMBER}---${service_base_url#https://}"',
+      'PREVIEW_API_ORIGIN="https://${REVISION_TAG}---${service_base_url#https://}"',
     );
     const finalDeploy = workflow.indexOf('deploy_preview "$PREVIEW_API_ORIGIN"');
     expect(bootstrap).toBeGreaterThan(-1);
     expect(deriveOrigin).toBeGreaterThan(bootstrap);
     expect(finalDeploy).toBeGreaterThan(deriveOrigin);
+  });
+
+  it("fails closed when Cloud Run service lookup fails for a reason other than not found", () => {
+    const result = runDeployWithServiceLookupFailure(
+      "ERROR: (gcloud.run.services.describe) PERMISSION_DENIED: denied",
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("PERMISSION_DENIED: denied");
+    expect(result.log).toContain("run services describe matrix-platform-staging");
+    expect(result.log).not.toContain("run deploy");
+  });
+
+  it("promotes only the health-checked staging revision to default traffic", () => {
+    const workflow = readFileSync(
+      join(root, ".github/workflows/preview-platform.yml"),
+      "utf8",
+    );
+
+    expect(workflow).toContain('if [ "$DEPLOYMENT_ENVIRONMENT" = "staging" ]; then');
+    expect(workflow).toContain('--to-revisions "${revision}=100"');
+    expect(workflow).toContain("Staging default traffic does not point to the verified revision.");
+
+    const healthCheck = workflow.indexOf(
+      '"${PREVIEW_API_ORIGIN}/health" > /dev/null',
+    );
+    const promotion = workflow.indexOf('--to-revisions "${revision}=100"');
+    expect(healthCheck).toBeGreaterThan(-1);
+    expect(promotion).toBeGreaterThan(healthCheck);
   });
 
   it("removes closed PR tags while tolerating Cloud Run's latest-created revision guard", () => {


### PR DESCRIPTION
## What changed

- Restored Preview and staging as real, independently deployable Cloud Run lanes; no failed deployment is hidden by marking it inactive.
- Routes manual `staging` dispatches through the isolated Preview workflow and hard-gates the selected GitHub environment, Cloud Run service, runtime service account, public origin, staging database, and Stripe test-mode secrets.
- Uses environment-, PR-, commit-, run-, and attempt-scoped immutable image tags, then verifies the deployed revision resolves to the exact built image digest.
- Keeps Preview revisions tagged at 0% default traffic; promotes only the verified staging revision to 100% of the dedicated staging service, followed by a stable-URL health check.
- Makes closed-PR teardown idempotent: removes the Preview tag, deletes eligible revisions, and tolerates only Cloud Run protected-latest-revision behavior.
- Restricts the production workflow to `production` and prevents workflow-only changes from automatically promoting production.
- Adds fail-closed public-origin validation for both Preview and staging. The Preview environment now explicitly uses `https://preview.matrix-os.com` instead of inheriting the production API origin.

## Final verification

Exact head: `1e7e48e9f8659535cc25238fed8119833654df0f`

- Focused workflow tests: 43/43 passed.
- Full workspace typecheck: passed.
- Changed-file pattern scan: 0 violations.
- `git diff --check`: passed.
- [Preview run 33151424645](https://github.com/HamedMP/matrix-os/actions/runs/33151424645): success; `matrix-platform-preview-00100-mep`, tag `pr-1347`, 0% default traffic, exact image `preview-pr-1347-1e7e48e9f865-33151424645-1`, tagged health check passed, `PLATFORM_PUBLIC_URL=https://preview.matrix-os.com`.
- [Staging run 33151429605](https://github.com/HamedMP/matrix-os/actions/runs/33151429605): success; `matrix-platform-staging-00006-few`, tag `staging-1347`, exact image `staging-pr-1347-1e7e48e9f865-33151429605-1`, tagged health check passed, promoted to 100%, stable staging health check passed.
- Latest GitHub deployment statuses: Preview `success`, staging `success`, production remains `success`.
- Greptile: 5/5 on the exact head.
- Two independent exact-head reviews: no actionable findings.

## Safety and scope

Preview and staging use dedicated services and the preview runtime service account with the staging database and Stripe test-mode secrets. No production Cloud Run deployment, production database, live Stripe credential, customer VPS, or fleet traffic was changed.

The `preview-platform` label remains so closing the PR exercises the tested teardown path; the PR stays in Human Review and is not merged by this change.