### PR TITLE
docs(releases): clarify package distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg?style=for-the-badge" alt="AGPL-3.0 License"></a>
-  <a href="https://github.com/HamedMP/matrix-os/stargazers"><img src="https://img.shields.io/github/stars/HamedMP/matrix-os?style=for-the-badge" alt="GitHub stars"></a>
   <a href="https://matrix-os.com"><img src="https://img.shields.io/badge/Live-matrix--os.com-D06F25?style=for-the-badge" alt="matrix-os.com"></a>
   <a href="https://matrix-os.com/skills.md"><img src="https://img.shields.io/badge/Agent_Setup-skills.md-434E3F?style=for-the-badge" alt="Agent setup"></a>
   <a href="https://skills.sh/HamedMP/matrix-os"><img src="https://skills.sh/b/HamedMP/matrix-os" alt="skills.sh"></a>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 <p align="center">
   <a href="https://matrix-os.com">Website</a> ·
   <a href="https://matrix-os.com/docs">Docs</a> ·
+  <a href="docs/dev/releases.md">Releases</a> ·
   <a href="https://matrix-os.com/whitepaper">Whitepaper</a> ·
   <a href="https://matrix-os.com/skills.md">Agent setup</a> ·
   <a href="https://deepwiki.com/HamedMP/matrix-os">DeepWiki</a> ·
@@ -24,6 +25,7 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg?style=for-the-badge" alt="AGPL-3.0 License"></a>
+  <a href="https://github.com/HamedMP/matrix-os/stargazers"><img src="https://img.shields.io/github/stars/HamedMP/matrix-os?style=for-the-badge" alt="GitHub stars"></a>
   <a href="https://matrix-os.com"><img src="https://img.shields.io/badge/Live-matrix--os.com-D06F25?style=for-the-badge" alt="matrix-os.com"></a>
   <a href="https://matrix-os.com/skills.md"><img src="https://img.shields.io/badge/Agent_Setup-skills.md-434E3F?style=for-the-badge" alt="Agent setup"></a>
   <a href="https://skills.sh/HamedMP/matrix-os"><img src="https://skills.sh/b/HamedMP/matrix-os" alt="skills.sh"></a>
@@ -58,6 +60,21 @@ Matrix OS is the foundation for **Web 4**: a unified environment where operating
 ---
 
 ## Install Matrix OS
+
+Matrix OS ships through product-scoped release lanes rather than one ambiguous
+repository package. Use the artifact native to the surface you are installing:
+
+| Surface | Supported distribution |
+|---------|------------------------|
+| Managed cloud | [matrix-os.com](https://matrix-os.com) provisions a VPS-native runtime |
+| Self-hosted runtime | Verified host bundle through the manual VPS installer below |
+| CLI | npm, Homebrew, install script, and versioned GitHub release binaries |
+| Desktop | Signed/notarized macOS installers, Linux AppImage, and updater metadata in GitHub Releases |
+| Mobile | No public store install link is documented yet; operator releases use TestFlight, Google Play internal testing, and compatible EAS updates |
+| Hosted platform | Immutable Google Artifact Registry image deployed to Cloud Run; not a customer runtime image |
+
+See [Release artifacts and channels](docs/dev/releases.md#release-artifact-inventory)
+for the source of truth and rollback boundary of every lane.
 
 ### Managed Matrix Cloud
 

--- a/docs/dev/releases.md
+++ b/docs/dev/releases.md
@@ -23,6 +23,26 @@ and CI validation. The platform service image is intentionally separate: Cloud
 Run requires a container image, but customer VPSes never install or update from
 that image.
 
+### GitHub Packages policy
+
+GitHub Packages is a registry, not a catalog for every downloadable Matrix OS
+artifact. A package is justified only when its registry-native format gives an
+operator or integrator a supported pull path. Publishing placeholder containers
+for installers would create a second, misleading source of truth.
+
+| Surface | GitHub Packages decision | Reason |
+| --- | --- | --- |
+| CLI | Do not duplicate today | npm is the install authority; Homebrew and versioned GitHub binaries cover the other supported install paths. A GitHub npm mirror would also require a different owner scope from `@finnaai/matrix`. |
+| Customer runtime host bundle | Keep R2 plus Platform Postgres authoritative | The updater consumes an immutable tarball, checksum, incremental manifest, and DB-backed channel metadata. An OCI mirror is useful only after it carries the same digest/provenance and has a concrete operator pull workflow. |
+| Platform | Do not mirror today | Google Artifact Registry remains the deploy authority. Reconsider a read-only GHCR mirror only after a named consumer and exact deployed-digest, provenance, retention, verification, and rollback contract exist. |
+| Desktop | Use GitHub Releases, not Packages | Signed/notarized macOS installers, the Linux AppImage, blockmaps, and updater manifests are release assets rather than registry packages. |
+| Mobile | Use native testing tracks and EAS, not Packages | No public App Store or Google Play install route is documented today. Operator releases use TestFlight, Google Play internal testing, EAS Build, and compatible EAS Update channels. |
+
+Before adding a GHCR mirror, define its consumer, immutable tag/digest mapping,
+retention policy, visibility, provenance/attestation, verification command, and
+rollback relationship to the authoritative release lane. Do not publish a
+second build of the same version merely to populate the repository sidebar.
+
 ## Engineer Summary
 
 - `main` is the source of truth. A push to `main` runs `.github/workflows/host-bundle-release.yml`.


### PR DESCRIPTION
## Summary

- expose the release catalog from the README
- tell users which supported distribution belongs to managed cloud, self-hosted runtime, CLI, Desktop, Mobile, and Platform
- make the GitHub Packages decision explicit: do not duplicate CLI, host bundle, Platform, Desktop, or Mobile artifacts today without a real registry consumer and provenance contract
- distinguish signed/notarized macOS artifacts from Linux AppImage/updater metadata and label Mobile's current TestFlight/Play-internal/EAS routes accurately

Linear: [MAT-504](https://linear.app/matrix-os/issue/MAT-504/expose-product-scoped-matrix-os-release-artifacts-on-github)

## Tests

- `flox activate -- bunx vitest run tests/platform/ci-workflows.test.ts tests/repository/site-extraction.test.ts` — 36 passed
- `flox activate -- bun run check:patterns:diff` — 0 violations; baseline warnings only
- `git diff --check origin/main...HEAD` — passed

## Scope

- Documentation and repository discovery only.
- No artifact was published, mirrored, promoted, or deployed.
- Google Artifact Registry, R2 plus Platform Postgres, npm/Homebrew, GitHub Releases, and native Mobile distribution remain authoritative for their existing lanes.
- Repository topics still require maintainer/admin permission and are not changed by this PR.
