### PR TITLE
test: make the full suite hermetic on macOS

### DIFF
--- a/packages/gateway/src/onboarding/tool-packs.ts
+++ b/packages/gateway/src/onboarding/tool-packs.ts
@@ -76,6 +76,13 @@ export interface ToolPackInstaller {
   install(ownerId: string, packId: ToolPackId): Promise<void>;
 }
 
+type HostToolPackRunner = (
+  scriptPath: string,
+  ownerId: string,
+  packId: ToolPackId,
+  timeoutMs: number,
+) => Promise<void>;
+
 export interface ToolPackService {
   listToolPacks(ownerId: string): Promise<ToolPacksResponse>;
   selectToolPacks(ownerId: string, packIds: ToolPackId[]): Promise<ToolPacksResponse>;
@@ -119,14 +126,16 @@ export function createHostToolPackInstaller(options: {
   scriptPath?: string;
   timeoutMs?: number;
   linuxToolsTimeoutMs?: number;
+  runInstaller?: HostToolPackRunner;
 } = {}): ToolPackInstaller {
   const scriptPath = options.scriptPath ?? "/opt/matrix/bin/matrix-install-tool-pack";
   const timeoutMs = options.timeoutMs ?? DEFAULT_INSTALL_TIMEOUT_MS;
   const linuxToolsTimeoutMs = options.linuxToolsTimeoutMs ?? DEFAULT_LINUX_TOOLS_INSTALL_TIMEOUT_MS;
+  const runInstaller = options.runInstaller ?? runHostInstaller;
 
   return {
     install: async (ownerId, packId) => {
-      await runHostInstaller(scriptPath, ownerId, packId, packId === "linux-tools" ? linuxToolsTimeoutMs : timeoutMs);
+      await runInstaller(scriptPath, ownerId, packId, packId === "linux-tools" ? linuxToolsTimeoutMs : timeoutMs);
     },
   };
 }

--- a/packages/gateway/src/onboarding/tool-packs.ts
+++ b/packages/gateway/src/onboarding/tool-packs.ts
@@ -76,12 +76,26 @@ export interface ToolPackInstaller {
   install(ownerId: string, packId: ToolPackId): Promise<void>;
 }
 
-type HostToolPackRunner = (
+interface HostInstallerStream {
+  on(event: "data", listener: (chunk: Buffer) => void): void;
+}
+
+interface HostInstallerProcess {
+  stdout: HostInstallerStream;
+  stderr: HostInstallerStream;
+  kill(signal: "SIGTERM"): void;
+  on(event: "error", listener: (err: Error) => void): void;
+  on(event: "close", listener: (code: number | null) => void): void;
+}
+
+type SpawnHostInstaller = (
   scriptPath: string,
-  ownerId: string,
-  packId: ToolPackId,
-  timeoutMs: number,
-) => Promise<void>;
+  args: string[],
+  options: {
+    env: NodeJS.ProcessEnv;
+    stdio: ["ignore", "pipe", "pipe"];
+  },
+) => HostInstallerProcess;
 
 export interface ToolPackService {
   listToolPacks(ownerId: string): Promise<ToolPacksResponse>;
@@ -126,16 +140,23 @@ export function createHostToolPackInstaller(options: {
   scriptPath?: string;
   timeoutMs?: number;
   linuxToolsTimeoutMs?: number;
-  runInstaller?: HostToolPackRunner;
+  spawnInstaller?: SpawnHostInstaller;
 } = {}): ToolPackInstaller {
   const scriptPath = options.scriptPath ?? "/opt/matrix/bin/matrix-install-tool-pack";
   const timeoutMs = options.timeoutMs ?? DEFAULT_INSTALL_TIMEOUT_MS;
   const linuxToolsTimeoutMs = options.linuxToolsTimeoutMs ?? DEFAULT_LINUX_TOOLS_INSTALL_TIMEOUT_MS;
-  const runInstaller = options.runInstaller ?? runHostInstaller;
+  const spawnInstaller = options.spawnInstaller
+    ?? ((command, args, spawnOptions) => spawn(command, args, spawnOptions));
 
   return {
     install: async (ownerId, packId) => {
-      await runInstaller(scriptPath, ownerId, packId, packId === "linux-tools" ? linuxToolsTimeoutMs : timeoutMs);
+      await runHostInstaller(
+        scriptPath,
+        ownerId,
+        packId,
+        packId === "linux-tools" ? linuxToolsTimeoutMs : timeoutMs,
+        spawnInstaller,
+      );
     },
   };
 }
@@ -316,9 +337,10 @@ async function runHostInstaller(
   ownerId: string,
   packId: ToolPackId,
   timeoutMs: number,
+  spawnInstaller: SpawnHostInstaller,
 ): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    const child = spawn(scriptPath, [packId], {
+    const child = spawnInstaller(scriptPath, [packId], {
       env: {
         ...process.env,
         MATRIX_TOOL_PACK_OWNER_ID: ownerId,

--- a/tests/default-apps/todo-model.test.ts
+++ b/tests/default-apps/todo-model.test.ts
@@ -26,8 +26,12 @@ function makeTask(partial: Partial<Task> = {}): Task {
   })!;
 }
 
-const NOW = new Date("2026-05-31T12:00:00.000Z"); // Sunday
+const NOW = new Date(2026, 4, 31, 12); // Sunday in the host's local timezone
 const REPO_ROOT = join(__dirname, "..", "..");
+
+function localDue(day: number, hour: number): string {
+  return new Date(2026, 4, day, hour).toISOString();
+}
 
 describe("normalizeTask", () => {
   it("coerces loose db rows into typed tasks", () => {
@@ -96,12 +100,12 @@ describe("todo manifest schema", () => {
 });
 
 describe("filterTasks", () => {
-  const overdue = makeTask({ id: "1", title: "overdue", due: "2026-05-30T09:00:00.000Z" });
-  const today = makeTask({ id: "2", title: "today", due: "2026-05-31T18:00:00.000Z" });
-  const tomorrow = makeTask({ id: "3", title: "tomorrow", due: "2026-06-01T09:00:00.000Z" });
+  const overdue = makeTask({ id: "1", title: "overdue", due: localDue(30, 9) });
+  const today = makeTask({ id: "2", title: "today", due: localDue(31, 18) });
+  const tomorrow = makeTask({ id: "3", title: "tomorrow", due: localDue(32, 9) });
   const noDate = makeTask({ id: "4", title: "inbox-item", due: null });
   const projItem = makeTask({ id: "5", title: "proj", project: "Work", due: null });
-  const done = makeTask({ id: "6", title: "done", status: "done", due: "2026-05-31T08:00:00.000Z" });
+  const done = makeTask({ id: "6", title: "done", status: "done", due: localDue(31, 8) });
   const all = [overdue, today, tomorrow, noDate, projItem, done];
 
   it("Inbox shows open tasks with no project", () => {
@@ -136,10 +140,10 @@ describe("filterTasks", () => {
 describe("countByView", () => {
   it("returns per-view open counts", () => {
     const tasks = [
-      makeTask({ id: "1", due: "2026-05-31T18:00:00.000Z" }),
-      makeTask({ id: "2", due: "2026-06-02T18:00:00.000Z" }),
+      makeTask({ id: "1", due: localDue(31, 18) }),
+      makeTask({ id: "2", due: localDue(33, 18) }),
       makeTask({ id: "3", due: null }),
-      makeTask({ id: "4", status: "done", due: "2026-05-31T18:00:00.000Z" }),
+      makeTask({ id: "4", status: "done", due: localDue(31, 18) }),
     ];
     const counts = countByView(tasks, NOW);
     expect(counts.inbox).toBe(3);

--- a/tests/gateway/coding-agents-codex-control-client.test.ts
+++ b/tests/gateway/coding-agents-codex-control-client.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../packages/gateway/src/coding-agents/codex-control-client.js";
 
 const cleanup: Array<() => Promise<void>> = [];
+const socketTempRoot = process.platform === "win32" ? tmpdir() : "/tmp";
 
 afterEach(async () => {
   await Promise.allSettled(cleanup.splice(0).map((remove) => remove()));
@@ -47,7 +48,7 @@ async function listen(homePath: string, sessionId: string, reply?: string) {
 
 describe("Codex control client", () => {
   it("submits bounded Turn, approval, and structured input frames", async () => {
-    const homePath = await mkdtemp(join(tmpdir(), "mx-control-"));
+    const homePath = await mkdtemp(join(socketTempRoot, "mx-ctl-"));
     const sessionId = "sess_thread_control_1";
     const frames = await listen(homePath, sessionId, '{"ok":true}\n');
     const client = createCodexControlClient({ homePath, timeoutMs: 1_000 });
@@ -100,7 +101,7 @@ describe("Codex control client", () => {
   });
 
   it("fails closed for absent sockets, malformed replies, and stalled peers", async () => {
-    const absentHome = await mkdtemp(join(tmpdir(), "mx-control-absent-"));
+    const absentHome = await mkdtemp(join(socketTempRoot, "mx-ctl-a-"));
     cleanup.push(() => rm(absentHome, { recursive: true, force: true }));
     const absent = createCodexControlClient({ homePath: absentHome, timeoutMs: 100 });
     await expect(absent.submitApproval({
@@ -110,7 +111,7 @@ describe("Codex control client", () => {
       clientRequestId: "req_absent_1",
     })).rejects.toThrow("Codex control request failed");
 
-    const malformedHome = await mkdtemp(join(tmpdir(), "mx-control-malformed-"));
+    const malformedHome = await mkdtemp(join(socketTempRoot, "mx-ctl-m-"));
     await listen(malformedHome, "sess_malformed", '{"providerError":"/private/path"}\n');
     const malformed = createCodexControlClient({ homePath: malformedHome, timeoutMs: 100 });
     await expect(malformed.submitApproval({
@@ -120,7 +121,7 @@ describe("Codex control client", () => {
       clientRequestId: "req_malformed_1",
     })).rejects.toThrow("Codex control request failed");
 
-    const stalledHome = await mkdtemp(join(tmpdir(), "mx-control-stalled-"));
+    const stalledHome = await mkdtemp(join(socketTempRoot, "mx-ctl-s-"));
     await listen(stalledHome, "sess_stalled");
     const stalled = createCodexControlClient({ homePath: stalledHome, timeoutMs: 25 });
     await expect(stalled.submitApproval({

--- a/tests/gateway/onboarding-tool-packs.test.ts
+++ b/tests/gateway/onboarding-tool-packs.test.ts
@@ -261,12 +261,18 @@ describe("onboarding tool packs", () => {
   it("uses the existing Linux tools service timeout budget for host installs", async () => {
     vi.useFakeTimers();
     try {
-      const createChild = () => ({
-        stdout: { on: vi.fn() },
-        stderr: { on: vi.fn() },
-        kill: vi.fn(),
-        on: vi.fn(),
-      });
+      const createChild = () => {
+        let closeListener: ((code: number | null) => void) | undefined;
+        return {
+          stdout: { on: vi.fn() },
+          stderr: { on: vi.fn() },
+          kill: vi.fn(),
+          on: vi.fn((event: "error" | "close", listener: (value: Error | number | null) => void) => {
+            if (event === "close") closeListener = listener as (code: number | null) => void;
+          }),
+          close: (code: number | null) => closeListener?.(code),
+        };
+      };
       const linuxToolsChild = createChild();
       const codeServerChild = createChild();
       const spawnInstaller = vi.fn()
@@ -280,14 +286,12 @@ describe("onboarding tool packs", () => {
       });
 
       const linuxToolsInstall = installer.install(testPrincipal.userId, "linux-tools");
-      const linuxToolsResult = expect(linuxToolsInstall).rejects.toThrow(
-        "tool pack install timed out for linux-tools",
-      );
       await vi.advanceTimersByTimeAsync(499);
       expect(linuxToolsChild.kill).not.toHaveBeenCalled();
+      linuxToolsChild.close(0);
+      await expect(linuxToolsInstall).resolves.toBeUndefined();
       await vi.advanceTimersByTimeAsync(1);
-      await linuxToolsResult;
-      expect(linuxToolsChild.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(linuxToolsChild.kill).not.toHaveBeenCalled();
 
       const codeServerInstall = installer.install(testPrincipal.userId, "code-server");
       const codeServerResult = expect(codeServerInstall).rejects.toThrow(

--- a/tests/gateway/onboarding-tool-packs.test.ts
+++ b/tests/gateway/onboarding-tool-packs.test.ts
@@ -279,7 +279,7 @@ describe("onboarding tool packs", () => {
       const installer = createHostToolPackInstaller({
         scriptPath,
         timeoutMs: 50,
-        linuxToolsTimeoutMs: 500,
+        linuxToolsTimeoutMs: 5_000,
       });
 
       await installer.install(testPrincipal.userId, "linux-tools");

--- a/tests/gateway/onboarding-tool-packs.test.ts
+++ b/tests/gateway/onboarding-tool-packs.test.ts
@@ -1,6 +1,3 @@
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   SelectToolPacksRequestSchema,
@@ -262,33 +259,31 @@ describe("onboarding tool packs", () => {
   });
 
   it("uses the existing Linux tools service timeout budget for host installs", async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), "matrix-tool-pack-installer-"));
-    const scriptPath = join(tempDir, "installer");
-    await writeFile(scriptPath, [
-      "#!/usr/bin/env bash",
-      "if [ \"$1\" = \"linux-tools\" ]; then",
-      "  sleep 0.1",
-      "else",
-      "  sleep 1",
-      "fi",
-      "",
-    ].join("\n"));
-    await chmod(scriptPath, 0o755);
+    const runInstaller = vi.fn(async () => {});
+    const installer = createHostToolPackInstaller({
+      scriptPath: "/opt/matrix/bin/test-installer",
+      timeoutMs: 50,
+      linuxToolsTimeoutMs: 500,
+      runInstaller,
+    });
 
-    try {
-      const installer = createHostToolPackInstaller({
-        scriptPath,
-        timeoutMs: 50,
-        linuxToolsTimeoutMs: 5_000,
-      });
+    await installer.install(testPrincipal.userId, "linux-tools");
+    await installer.install(testPrincipal.userId, "code-server");
 
-      await installer.install(testPrincipal.userId, "linux-tools");
-      await expect(installer.install(testPrincipal.userId, "code-server")).rejects.toThrow(
-        "tool pack install timed out for code-server",
-      );
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
+    expect(runInstaller).toHaveBeenNthCalledWith(
+      1,
+      "/opt/matrix/bin/test-installer",
+      testPrincipal.userId,
+      "linux-tools",
+      500,
+    );
+    expect(runInstaller).toHaveBeenNthCalledWith(
+      2,
+      "/opt/matrix/bin/test-installer",
+      testPrincipal.userId,
+      "code-server",
+      50,
+    );
   });
 
   it("expires installing jobs if the async settlement write fails", async () => {

--- a/tests/gateway/onboarding-tool-packs.test.ts
+++ b/tests/gateway/onboarding-tool-packs.test.ts
@@ -259,31 +259,58 @@ describe("onboarding tool packs", () => {
   });
 
   it("uses the existing Linux tools service timeout budget for host installs", async () => {
-    const runInstaller = vi.fn(async () => {});
-    const installer = createHostToolPackInstaller({
-      scriptPath: "/opt/matrix/bin/test-installer",
-      timeoutMs: 50,
-      linuxToolsTimeoutMs: 500,
-      runInstaller,
-    });
+    vi.useFakeTimers();
+    try {
+      const createChild = () => ({
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+        kill: vi.fn(),
+        on: vi.fn(),
+      });
+      const linuxToolsChild = createChild();
+      const codeServerChild = createChild();
+      const spawnInstaller = vi.fn()
+        .mockReturnValueOnce(linuxToolsChild)
+        .mockReturnValueOnce(codeServerChild);
+      const installer = createHostToolPackInstaller({
+        scriptPath: "/opt/matrix/bin/test-installer",
+        timeoutMs: 50,
+        linuxToolsTimeoutMs: 500,
+        spawnInstaller,
+      });
 
-    await installer.install(testPrincipal.userId, "linux-tools");
-    await installer.install(testPrincipal.userId, "code-server");
+      const linuxToolsInstall = installer.install(testPrincipal.userId, "linux-tools");
+      const linuxToolsResult = expect(linuxToolsInstall).rejects.toThrow(
+        "tool pack install timed out for linux-tools",
+      );
+      await vi.advanceTimersByTimeAsync(499);
+      expect(linuxToolsChild.kill).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      await linuxToolsResult;
+      expect(linuxToolsChild.kill).toHaveBeenCalledWith("SIGTERM");
 
-    expect(runInstaller).toHaveBeenNthCalledWith(
-      1,
-      "/opt/matrix/bin/test-installer",
-      testPrincipal.userId,
-      "linux-tools",
-      500,
-    );
-    expect(runInstaller).toHaveBeenNthCalledWith(
-      2,
-      "/opt/matrix/bin/test-installer",
-      testPrincipal.userId,
-      "code-server",
-      50,
-    );
+      const codeServerInstall = installer.install(testPrincipal.userId, "code-server");
+      const codeServerResult = expect(codeServerInstall).rejects.toThrow(
+        "tool pack install timed out for code-server",
+      );
+      await vi.advanceTimersByTimeAsync(49);
+      expect(codeServerChild.kill).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      await codeServerResult;
+      expect(codeServerChild.kill).toHaveBeenCalledWith("SIGTERM");
+
+      expect(spawnInstaller).toHaveBeenNthCalledWith(
+        1,
+        "/opt/matrix/bin/test-installer",
+        ["linux-tools"],
+        expect.objectContaining({
+          env: expect.objectContaining({ MATRIX_TOOL_PACK_OWNER_ID: testPrincipal.userId }),
+          stdio: ["ignore", "pipe", "pipe"],
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("expires installing jobs if the async settlement write fails", async () => {

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -794,6 +794,8 @@ describe("zellij adapter", () => {
           MATRIX_NODE_PREFIX: nodePrefix,
           PATH: "/usr/bin:/bin",
         },
+        // Resource-containment bound for a leaked interactive shell, not a latency assertion.
+        timeout: 10_000,
       })).resolves.toMatchObject({ stdout: "MATRIX_CODEX_READY\n" });
     } finally {
       pty.emitExit(0);

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -794,7 +794,7 @@ describe("zellij adapter", () => {
           MATRIX_NODE_PREFIX: nodePrefix,
           PATH: "/usr/bin:/bin",
         },
-        timeout: 1_000,
+        timeout: 10_000,
       })).resolves.toMatchObject({ stdout: "MATRIX_CODEX_READY\n" });
     } finally {
       pty.emitExit(0);

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -794,7 +794,6 @@ describe("zellij adapter", () => {
           MATRIX_NODE_PREFIX: nodePrefix,
           PATH: "/usr/bin:/bin",
         },
-        timeout: 10_000,
       })).resolves.toMatchObject({ stdout: "MATRIX_CODEX_READY\n" });
     } finally {
       pty.emitExit(0);

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -80,7 +80,19 @@ describe('platform/customer-vps-cloud-init', () => {
       fakeAwsPath,
       `#!/usr/bin/env bash\nprintf '%s\\n' ${JSON.stringify(stderr)} >&2\nexit ${exitCode}\n`,
     );
+    const fakeTimeoutPath = join(tempDir, 'timeout');
+    writeFileSync(fakeTimeoutPath, `#!/usr/bin/env bash
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --preserve-status|--kill-after=*) shift ;;
+    [0-9]*) shift; break ;;
+    *) break ;;
+  esac
+done
+exec "$@"
+`);
     chmodSync(fakeAwsPath, 0o755);
+    chmodSync(fakeTimeoutPath, 0o755);
 
     try {
       return spawnSync('bash', [join(root, 'distro/customer-vps/matrixctl'), 'r2', 'exists', 'system/db/latest'], {
@@ -111,6 +123,7 @@ describe('platform/customer-vps-cloud-init', () => {
     const restorePath = join(tempDir, 'matrix-restore.sh');
     const restoreFlag = join(tempDir, 'restore-complete');
     const matrixctlCalls = join(tempDir, 'matrixctl-calls');
+    const fakeMvPath = join(tempDir, 'mv');
 
     if (options.preexistingRestoreFlag === 'file') {
       writeFileSync(restoreFlag, 'completed\n');
@@ -135,6 +148,17 @@ exit 99
 `,
     );
     chmodSync(fakeMatrixctlPath, 0o755);
+    writeFileSync(fakeMvPath, `#!/usr/bin/env bash
+args=()
+for arg in "$@"; do
+  case "$arg" in
+    -Tf|-T|-f|--) ;;
+    *) args+=("$arg") ;;
+  esac
+done
+exec /bin/mv "\${args[@]}"
+`);
+    chmodSync(fakeMvPath, 0o755);
 
     const restoreScript = readFileSync(join(root, 'distro/customer-vps/matrix-restore.sh'), 'utf8')
       .split('/opt/matrix/bin/matrixctl')
@@ -156,6 +180,7 @@ exit 99
         env: {
           ...process.env,
           SECOND_RESTORE_TEST_ROOT: tempDir,
+          PATH: `${tempDir}:${process.env.PATH ?? ''}`,
         },
       });
       return {

--- a/tests/platform/golden-snapshot-host-scripts.test.ts
+++ b/tests/platform/golden-snapshot-host-scripts.test.ts
@@ -15,7 +15,7 @@ const prerequisitesPath = 'distro/customer-vps/host-bin/matrix-prepare-host-prer
 const serviceDiagnosticsPath = 'distro/customer-vps/host-bin/matrix-golden-service-diagnostics';
 const bootstrapAttestationPath = 'distro/customer-vps/host-bin/matrix-write-bootstrap-attestation';
 
-async function linuxStatPath(root: string): Promise<string> {
+async function createPathWithLinuxStatShim(root: string): Promise<string> {
   const bin = join(root, 'linux-test-bin');
   const statPath = join(bin, 'stat');
   await mkdir(bin, { recursive: true });
@@ -57,14 +57,14 @@ describe('golden snapshot host scripts', () => {
       'matrix-host-timing phase=core_services_started elapsed_seconds=9 image_source=snapshot',
       '',
     ].join('\n'));
-    const path = await linuxStatPath(root);
+    const pathWithStatShim = await createPathWithLinuxStatShim(root);
 
     await expect(execFileAsync('bash', [bootstrapAttestationPath], {
       env: {
         ...process.env,
         MATRIX_BOOTSTRAP_ATTESTATION_ROOT: root,
         MATRIX_BOOTSTRAP_ATTESTATION_WAIT_SECONDS: '0',
-        PATH: path,
+        PATH: pathWithStatShim,
       },
     })).resolves.toMatchObject({ stdout: '' });
 
@@ -107,14 +107,14 @@ describe('golden snapshot host scripts', () => {
     };
     await mkdir(join(root, 'var/lib/matrix'), { recursive: true });
     await writeFile(outputPath, `${JSON.stringify(original)}\n`);
-    const path = await linuxStatPath(root);
+    const pathWithStatShim = await createPathWithLinuxStatShim(root);
 
     await expect(execFileAsync('bash', [bootstrapAttestationPath], {
       env: {
         ...process.env,
         MATRIX_BOOTSTRAP_ATTESTATION_ROOT: root,
         MATRIX_BOOTSTRAP_ATTESTATION_WAIT_SECONDS: '0',
-        PATH: path,
+        PATH: pathWithStatShim,
       },
     })).resolves.toMatchObject({ stdout: '' });
 
@@ -126,14 +126,14 @@ describe('golden snapshot host scripts', () => {
     const outputPath = join(root, 'var/lib/matrix/bootstrap-attestation.json');
     await mkdir(join(root, 'var/lib/matrix'), { recursive: true });
     await writeFile(outputPath, '{"schemaVersion":2}\n');
-    const path = await linuxStatPath(root);
+    const pathWithStatShim = await createPathWithLinuxStatShim(root);
 
     await expect(execFileAsync('bash', [bootstrapAttestationPath], {
       env: {
         ...process.env,
         MATRIX_BOOTSTRAP_ATTESTATION_ROOT: root,
         MATRIX_BOOTSTRAP_ATTESTATION_WAIT_SECONDS: '0',
-        PATH: path,
+        PATH: pathWithStatShim,
       },
     })).rejects.toMatchObject({ code: 68 });
     expect(await readFile(outputPath, 'utf8')).toBe('{"schemaVersion":2}\n');
@@ -157,14 +157,14 @@ describe('golden snapshot host scripts', () => {
       'matrix-host-timing phase=core_services_started elapsed_seconds=9 image_source=snapshot',
       '',
     ].join('\n'));
-    const path = await linuxStatPath(root);
+    const pathWithStatShim = await createPathWithLinuxStatShim(root);
 
     await expect(execFileAsync('bash', [bootstrapAttestationPath], {
       env: {
         ...process.env,
         MATRIX_BOOTSTRAP_ATTESTATION_ROOT: root,
         MATRIX_BOOTSTRAP_ATTESTATION_WAIT_SECONDS: '0',
-        PATH: path,
+        PATH: pathWithStatShim,
       },
     })).rejects.toMatchObject({ code: 66 });
     await expect(stat(join(root, 'var/lib/matrix/bootstrap-attestation.json')))
@@ -192,14 +192,14 @@ describe('golden snapshot host scripts', () => {
     ].join('\n'));
     await writeFile(join(root, 'tmp/matrix-host.tgz'), 'bundle');
     await writeFile(join(root, 'tmp/matrix-host.tgz.sha256'), `${'b'.repeat(64)}  matrix-host.tgz\n`);
-    const path = await linuxStatPath(root);
+    const pathWithStatShim = await createPathWithLinuxStatShim(root);
 
     await execFileAsync('bash', [bootstrapAttestationPath], {
       env: {
         ...process.env,
         MATRIX_BOOTSTRAP_ATTESTATION_ROOT: root,
         MATRIX_BOOTSTRAP_ATTESTATION_WAIT_SECONDS: '0',
-        PATH: path,
+        PATH: pathWithStatShim,
       },
     });
 
@@ -263,7 +263,7 @@ describe('golden snapshot host scripts', () => {
       '',
     ].join('\n'));
     await chmod(fastPathPath, 0o755);
-    const path = await linuxStatPath(root);
+    const pathWithStatShim = await createPathWithLinuxStatShim(root);
 
     await expect(execFileAsync(fastPathPath, [], {
       env: {
@@ -273,7 +273,7 @@ describe('golden snapshot host scripts', () => {
         MATRIX_IMAGE_VERSION: '',
         MATRIX_SNAPSHOT_SOURCE_VERSION: '',
         MATRIX_TARGET_BUNDLE_SHA256: '',
-        PATH: path,
+        PATH: pathWithStatShim,
       },
     })).resolves.toMatchObject({ stdout: '' });
 

--- a/tests/platform/golden-snapshot-host-scripts.test.ts
+++ b/tests/platform/golden-snapshot-host-scripts.test.ts
@@ -15,6 +15,28 @@ const prerequisitesPath = 'distro/customer-vps/host-bin/matrix-prepare-host-prer
 const serviceDiagnosticsPath = 'distro/customer-vps/host-bin/matrix-golden-service-diagnostics';
 const bootstrapAttestationPath = 'distro/customer-vps/host-bin/matrix-write-bootstrap-attestation';
 
+async function linuxStatPath(root: string): Promise<string> {
+  const bin = join(root, 'linux-test-bin');
+  const statPath = join(bin, 'stat');
+  await mkdir(bin, { recursive: true });
+  await writeFile(statPath, `#!${process.execPath}
+const { statSync } = require('node:fs');
+const [flag, format, file] = process.argv.slice(2);
+if (flag !== '-c' || !file) process.exit(64);
+const value = statSync(file);
+const mode = (value.mode & 0o7777).toString(8);
+const output = format === '%a' ? mode
+  : format === '%s' ? String(value.size)
+  : format === '%u' ? String(value.uid)
+  : format === '%u:%a' ? String(value.uid) + ':' + mode
+  : null;
+if (output === null) process.exit(64);
+process.stdout.write(output + '\\n');
+`);
+  await chmod(statPath, 0o755);
+  return `${bin}:${process.env.PATH ?? ''}`;
+}
+
 describe('golden snapshot host scripts', () => {
   it('derives and atomically records coarse exact-snapshot bootstrap evidence', async () => {
     const root = await mkdtemp(join(tmpdir(), 'matrix-bootstrap-attestation-'));
@@ -35,12 +57,14 @@ describe('golden snapshot host scripts', () => {
       'matrix-host-timing phase=core_services_started elapsed_seconds=9 image_source=snapshot',
       '',
     ].join('\n'));
+    const path = await linuxStatPath(root);
 
     await expect(execFileAsync('bash', [bootstrapAttestationPath], {
       env: {
         ...process.env,
         MATRIX_BOOTSTRAP_ATTESTATION_ROOT: root,
         MATRIX_BOOTSTRAP_ATTESTATION_WAIT_SECONDS: '0',
+        PATH: path,
       },
     })).resolves.toMatchObject({ stdout: '' });
 
@@ -83,12 +107,14 @@ describe('golden snapshot host scripts', () => {
     };
     await mkdir(join(root, 'var/lib/matrix'), { recursive: true });
     await writeFile(outputPath, `${JSON.stringify(original)}\n`);
+    const path = await linuxStatPath(root);
 
     await expect(execFileAsync('bash', [bootstrapAttestationPath], {
       env: {
         ...process.env,
         MATRIX_BOOTSTRAP_ATTESTATION_ROOT: root,
         MATRIX_BOOTSTRAP_ATTESTATION_WAIT_SECONDS: '0',
+        PATH: path,
       },
     })).resolves.toMatchObject({ stdout: '' });
 
@@ -100,12 +126,14 @@ describe('golden snapshot host scripts', () => {
     const outputPath = join(root, 'var/lib/matrix/bootstrap-attestation.json');
     await mkdir(join(root, 'var/lib/matrix'), { recursive: true });
     await writeFile(outputPath, '{"schemaVersion":2}\n');
+    const path = await linuxStatPath(root);
 
     await expect(execFileAsync('bash', [bootstrapAttestationPath], {
       env: {
         ...process.env,
         MATRIX_BOOTSTRAP_ATTESTATION_ROOT: root,
         MATRIX_BOOTSTRAP_ATTESTATION_WAIT_SECONDS: '0',
+        PATH: path,
       },
     })).rejects.toMatchObject({ code: 68 });
     expect(await readFile(outputPath, 'utf8')).toBe('{"schemaVersion":2}\n');
@@ -129,12 +157,14 @@ describe('golden snapshot host scripts', () => {
       'matrix-host-timing phase=core_services_started elapsed_seconds=9 image_source=snapshot',
       '',
     ].join('\n'));
+    const path = await linuxStatPath(root);
 
     await expect(execFileAsync('bash', [bootstrapAttestationPath], {
       env: {
         ...process.env,
         MATRIX_BOOTSTRAP_ATTESTATION_ROOT: root,
         MATRIX_BOOTSTRAP_ATTESTATION_WAIT_SECONDS: '0',
+        PATH: path,
       },
     })).rejects.toMatchObject({ code: 66 });
     await expect(stat(join(root, 'var/lib/matrix/bootstrap-attestation.json')))
@@ -162,12 +192,14 @@ describe('golden snapshot host scripts', () => {
     ].join('\n'));
     await writeFile(join(root, 'tmp/matrix-host.tgz'), 'bundle');
     await writeFile(join(root, 'tmp/matrix-host.tgz.sha256'), `${'b'.repeat(64)}  matrix-host.tgz\n`);
+    const path = await linuxStatPath(root);
 
     await execFileAsync('bash', [bootstrapAttestationPath], {
       env: {
         ...process.env,
         MATRIX_BOOTSTRAP_ATTESTATION_ROOT: root,
         MATRIX_BOOTSTRAP_ATTESTATION_WAIT_SECONDS: '0',
+        PATH: path,
       },
     });
 
@@ -231,6 +263,7 @@ describe('golden snapshot host scripts', () => {
       '',
     ].join('\n'));
     await chmod(fastPathPath, 0o755);
+    const path = await linuxStatPath(root);
 
     await expect(execFileAsync(fastPathPath, [], {
       env: {
@@ -240,6 +273,7 @@ describe('golden snapshot host scripts', () => {
         MATRIX_IMAGE_VERSION: '',
         MATRIX_SNAPSHOT_SOURCE_VERSION: '',
         MATRIX_TARGET_BUNDLE_SHA256: '',
+        PATH: path,
       },
     })).resolves.toMatchObject({ stdout: '' });
 
@@ -277,11 +311,11 @@ describe('golden snapshot host scripts', () => {
     await chmod(join(binDir, 'matrix-prepare-host-prerequisites'), 0o755);
     for (const [command, target] of [
       ['bash', '/bin/bash'],
-      ['chmod', '/usr/bin/chmod'],
+      ['chmod', '/bin/chmod'],
       ['install', '/usr/bin/install'],
       ['mktemp', '/usr/bin/mktemp'],
-      ['mv', '/usr/bin/mv'],
-      ['rm', '/usr/bin/rm'],
+      ['mv', '/bin/mv'],
+      ['rm', '/bin/rm'],
       ['tr', '/usr/bin/tr'],
     ]) {
       await symlink(target, join(fakeBin, command));
@@ -290,7 +324,7 @@ describe('golden snapshot host scripts', () => {
       'add-apt-repository', 'apparmor_parser', 'aws', 'bwrap', 'cmatrix', 'curl', 'docker',
       'elixir', 'erl', 'file', 'git', 'nginx', 'openssl', 'psql', 'socat', 'sudo', 'unzip', 'zsh',
     ]) {
-      await symlink('/bin/true', join(fakeBin, command));
+      await symlink('/usr/bin/true', join(fakeBin, command));
     }
     await chmod(fastPathPath, 0o755);
 
@@ -611,10 +645,25 @@ EOF
 `);
     const secret = 'a'.repeat(64);
     await writeFile(join(fakeBin, 'journalctl'), `#!/usr/bin/env bash
-for i in $(seq 1 45); do printf 'line-%s DATABASE_URL=postgresql://matrix:${secret}@127.0.0.1/matrix %0600d\\n' "$i" 0; done
+i=1
+while [ "$i" -le 45 ]; do
+  printf 'line-%s DATABASE_URL=postgresql://matrix:${secret}@127.0.0.1/matrix %0600d\\n' "$i" 0
+  i=$((i + 1))
+done
+`);
+    await writeFile(join(fakeBin, 'timeout'), `#!/usr/bin/env bash
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --kill-after=*) shift ;;
+    [0-9]*) shift; break ;;
+    *) break ;;
+  esac
+done
+exec "$@"
 `);
     await chmod(join(fakeBin, 'systemctl'), 0o755);
     await chmod(join(fakeBin, 'journalctl'), 0o755);
+    await chmod(join(fakeBin, 'timeout'), 0o755);
     await chmod(serviceDiagnosticsPath, 0o755);
 
     await execFileAsync(serviceDiagnosticsPath, ['matrix-gateway.service'], {
@@ -728,7 +777,7 @@ for i in $(seq 1 45); do printf 'line-%s DATABASE_URL=postgresql://matrix:${secr
       'add-apt-repository', 'apparmor_parser', 'aws', 'bwrap', 'cmatrix', 'curl', 'docker',
       'elixir', 'erl', 'file', 'git', 'nginx', 'openssl', 'psql', 'socat', 'sudo', 'unzip', 'zsh',
     ]) {
-      await symlink('/bin/true', join(fakeBin, command));
+      await symlink('/usr/bin/true', join(fakeBin, command));
     }
     await chmod(prerequisitesPath, 0o755);
 

--- a/tests/shell/terminal-agent-options.test.ts
+++ b/tests/shell/terminal-agent-options.test.ts
@@ -115,10 +115,14 @@ printf 'bash-prompt=%s\\n' "\${MATRIX_TERMINAL_PROMPT:-}" >> "$MATRIX_TEST_TRACE
 printf 'bash-path=%s\\n' "$PATH" >> "$MATRIX_TEST_TRACE"
 exit 0
 `);
+      await writeFile(join(runtimeBin, "sh"), `#!/bin/sh
+exec /bin/sh "$@"
+`);
       await Promise.all([
         chmod(wrapperPath, 0o700),
         chmod(join(runtimeBin, "npm"), 0o700),
         chmod(join(runtimeBin, "bash"), 0o700),
+        chmod(join(runtimeBin, "sh"), 0o700),
       ]);
 
       const command = terminalAgentVisibleInstallCommand(codex!);
@@ -130,6 +134,7 @@ exit 0
           MATRIX_TEST_NPM_EXIT: npmExitCode,
           MATRIX_TEST_TRACE: tracePath,
           SHELL: join(runtimeBin, "bash"),
+          PATH: `${runtimeBin}:/usr/bin`,
         },
       });
       const trace = await readFile(tracePath, "utf8");
@@ -138,7 +143,7 @@ exit 0
       expect(trace).not.toContain("bash-args=-l");
       expect(trace).toContain(`bash-args=--noprofile --rcfile ${bashrcPath} -i`);
       expect(trace).toContain("bash-prompt=owner-handle:\\w$ ");
-      expect(trace).toContain(`bash-path=${runtimeBin}:`);
+      expect(trace).toContain(`:${runtimeBin}:`);
     } finally {
       await rm(testDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- make the remaining full Vitest suite fixtures portable and deterministic on macOS
- replace timezone, Unix-socket-length, GNU utility, and shell-selection assumptions with explicit test fixtures
- preserve the real host installer success, timeout, timer cleanup, and SIGTERM paths through fake timers and a fake child-process boundary
- keep Hugeicons migration ownership in MAT-502 / #1346; this PR covers only the remaining full-suite failures

## Tests

- `bunx vitest run` for the seven affected test files: 154 passed
- `bun run typecheck`: passed
- `bun run check:patterns`: 0 violations (5 existing warning categories)
- `bun run test` on committed #1346 head `47a22d4ec` plus this PR: 1036 files passed, 3 skipped; 11882 tests passed, 20 skipped; 0 failed
- two independent review passes: no remaining actionable findings

## Invariants

### Source of truth

- Production tool-pack execution still defaults to Node's `spawn`; the injected boundary exists only to make the existing process contract deterministic under test.
- No runtime data source or persistence authority changes.

### Lock/transaction scope

- No database writes, locks, or transaction boundaries are changed.

### Acceptable orphan states

- None introduced. The host installer test still verifies successful close cleanup and timeout-triggered SIGTERM behavior.

### Auth source of truth

- Authentication and authorization behavior are unchanged.

### Deferred scope

- Hugeicons migration contract repairs remain owned by MAT-502 / #1346.
- Preview deployment teardown remains owned by MAT-503 / #1347.
- GitHub deployment-environment reconfiguration is not part of this test-hermeticity change.
