### PR TITLE
feat(client-data): add TanStack Query foundation

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -43,6 +43,7 @@
     "@tiptap/markdown": "3.22.4",
     "@tiptap/react": "3.22.4",
     "@tiptap/starter-kit": "3.22.4",
+    "@tanstack/react-query": "^5.101.4",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-serialize": "^0.14.0",

--- a/desktop/src/renderer/src/features/settings/cron.api.ts
+++ b/desktop/src/renderer/src/features/settings/cron.api.ts
@@ -1,0 +1,34 @@
+import { queryOptions } from "@tanstack/react-query";
+import type { ApiClient } from "../../lib/api";
+import { desktopQueryScope, type DesktopQueryScope } from "../../lib/query-client";
+
+export interface CronJob {
+  id?: string;
+  name?: string;
+  schedule?: string;
+  prompt?: string;
+  enabled?: boolean;
+}
+
+export const cronKeys = {
+  all: (scope: DesktopQueryScope) => ["cron", ...desktopQueryScope(scope)] as const,
+  list: (scope: DesktopQueryScope) => ["cron", ...desktopQueryScope(scope), "list"] as const,
+};
+
+export function cronQueryOptions(api: ApiClient, scope: DesktopQueryScope) {
+  return queryOptions({
+    queryKey: cronKeys.list(scope),
+    queryFn: async ({ signal }) => parseCronJobs(await api.get<unknown>("/api/cron", { signal })),
+  });
+}
+
+export function parseCronJobs(value: unknown): CronJob[] {
+  const list = Array.isArray(value)
+    ? value
+    : value && typeof value === "object" && Array.isArray((value as { jobs?: unknown }).jobs)
+      ? (value as { jobs: unknown[] }).jobs
+      : value && typeof value === "object" && Array.isArray((value as { cron?: unknown }).cron)
+        ? (value as { cron: unknown[] }).cron
+        : [];
+  return list.slice(0, 100).filter((record): record is CronJob => Boolean(record) && typeof record === "object");
+}

--- a/desktop/src/renderer/src/features/settings/sections/CronSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/CronSection.tsx
@@ -1,60 +1,28 @@
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useConnection } from "../../../stores/connection";
 import { Card, Empty, SettingsSectionHeader } from "./section-kit";
-
-interface CronJob {
-  id?: string;
-  name?: string;
-  schedule?: string;
-  prompt?: string;
-  enabled?: boolean;
-}
-
-function parse(value: unknown): CronJob[] {
-  const list = Array.isArray(value)
-    ? value
-    : value && typeof value === "object" && Array.isArray((value as { jobs?: unknown }).jobs)
-      ? (value as { jobs: unknown[] }).jobs
-      : value && typeof value === "object" && Array.isArray((value as { cron?: unknown }).cron)
-        ? (value as { cron: unknown[] }).cron
-        : [];
-  return list.slice(0, 100).filter((r): r is CronJob => Boolean(r) && typeof r === "object");
-}
+import { cronQueryOptions } from "../cron.api";
 
 export default function CronSection() {
   const api = useConnection((s) => s.api);
-  const [state, setState] = useState<{ jobs: CronJob[]; error: boolean; loading: boolean }>({
-    jobs: [],
-    error: false,
-    loading: Boolean(api),
+  const platformHost = useConnection((s) => s.platformHost);
+  const authGeneration = useConnection((s) => s.authGeneration);
+  const runtimeSlot = useConnection((s) => s.runtimeSlot);
+  const scope = useMemo(() => ({ platformHost, authGeneration, runtimeSlot }), [platformHost, authGeneration, runtimeSlot]);
+  const { data: jobs = [], isError, isPending } = useQuery({
+    ...cronQueryOptions(api ?? { get: async () => [] } as never, scope),
+    enabled: api !== null,
   });
-
-  useEffect(() => {
-    if (!api) {
-      setState((current) => ({ ...current, loading: false }));
-      return;
-    }
-    let cancelled = false;
-    setState((current) => ({ ...current, error: false, loading: true }));
-    api.get<unknown>("/api/cron").then((res) => {
-      if (!cancelled) {
-        setState({ jobs: parse(res), error: false, loading: false });
-      }
-    }).catch((err: unknown) => {
-      console.warn("[settings] cron load failed:", err instanceof Error ? err.message : String(err));
-      if (!cancelled) setState((current) => ({ ...current, error: true, loading: false }));
-    });
-    return () => { cancelled = true; };
-  }, [api]);
 
   return (
     <>
       <SettingsSectionHeader title="Schedules" description="Recurring agent jobs and heartbeats." />
       <Card>
-        {state.loading ? <Empty text="Loading schedules..." /> : state.error ? <Empty text="Schedules unavailable." /> : state.jobs.length === 0 ? (
+        {api !== null && isPending ? <Empty text="Loading schedules..." /> : isError ? <Empty text="Schedules unavailable." /> : jobs.length === 0 ? (
           <Empty text="No scheduled jobs." />
         ) : (
-          state.jobs.map((j, i) => (
+          jobs.map((j, i) => (
             <div key={j.id ?? i} className="flex flex-col gap-0.5 border-b pb-2 last:border-0 last:pb-0" style={{ borderColor: "var(--border-subtle)" }}>
               <div className="flex items-center justify-between">
                 <span className="text-sm" style={{ color: "var(--text-primary)" }}>{j.name ?? j.prompt ?? j.id ?? "Job"}</span>

--- a/desktop/src/renderer/src/lib/api.ts
+++ b/desktop/src/renderer/src/lib/api.ts
@@ -28,24 +28,28 @@ export interface BoundedReadOptions {
   // file can be stale by the time the body is fetched, so the cap must apply
   // to the transfer itself; exceeding it rejects with "file_too_large".
   maxBytes?: number;
+  signal?: AbortSignal;
+  timeoutMs?: number;
 }
 
 export interface RequestTimeoutOptions {
   /** Internal operation-specific timeout. Every request remains bounded. */
   timeoutMs?: number;
+  /** Cancellation propagated from the owning UI lifecycle. */
+  signal?: AbortSignal;
 }
 
 export interface ApiClient {
-  get<T>(path: string): Promise<T>;
+  get<T>(path: string, options?: RequestTimeoutOptions): Promise<T>;
   getText(path: string, options?: BoundedReadOptions): Promise<string>;
   getBlob(path: string, options?: BoundedReadOptions): Promise<Blob>;
   post<T>(path: string, body: unknown, options?: RequestTimeoutOptions): Promise<T>;
   postBytes<T>(path: string, body: Blob, headers: Record<string, string>, options?: RequestTimeoutOptions): Promise<T>;
-  patch<T>(path: string, body: unknown): Promise<T>;
+  patch<T>(path: string, body: unknown, options?: RequestTimeoutOptions): Promise<T>;
   put<T>(path: string, body: unknown, options?: RequestTimeoutOptions): Promise<T>;
   putBytes<T>(path: string, body: Blob, headers: Record<string, string>, options?: RequestTimeoutOptions): Promise<T>;
-  delete<T>(path: string): Promise<T>;
-  putText<T>(path: string, body: string): Promise<T>;
+  delete<T>(path: string, options?: RequestTimeoutOptions): Promise<T>;
+  putText<T>(path: string, body: string, options?: RequestTimeoutOptions): Promise<T>;
   /** Returns a client whose requests remain bound to one runtime slot. */
   forRuntime(runtimeSlot: string): ApiClient;
   baseUrl: string;
@@ -54,13 +58,22 @@ export interface ApiClient {
 export function createApiClient(options: ApiClientOptions): ApiClient {
   const fetchFn: FetchFn = options.fetchFn ?? ((input, init) => fetch(input, init));
 
-  async function send(path: string, init: RequestInit, timeoutMs = API_TIMEOUT_MS): Promise<Response> {
+  function signalWithTimeout(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
+    const timeout = AbortSignal.timeout(timeoutMs);
+    return signal ? AbortSignal.any([signal, timeout]) : timeout;
+  }
+
+  async function send(
+    path: string,
+    init: RequestInit,
+    requestOptions?: RequestTimeoutOptions,
+  ): Promise<Response> {
     const url = buildGatewayUrl(options.baseUrl, path, options.getRuntimeSlot());
     let response: Response;
     try {
       response = await fetchFn(url, {
         ...init,
-        signal: AbortSignal.timeout(timeoutMs),
+        signal: signalWithTimeout(requestOptions?.signal, requestOptions?.timeoutMs ?? API_TIMEOUT_MS),
       });
     } catch (err: unknown) {
       throw new AppError(classifyTransportError(err), { cause: err });
@@ -83,7 +96,7 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
   }
 
   async function request<T>(path: string, init: RequestInit, options?: RequestTimeoutOptions): Promise<T> {
-    const response = await send(path, init, options?.timeoutMs);
+    const response = await send(path, init, options);
     try {
       return (await response.json()) as T;
     } catch (err: unknown) {
@@ -120,7 +133,7 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
   }
 
   async function requestText(path: string, init: RequestInit, bounds?: BoundedReadOptions): Promise<string> {
-    const response = await send(path, init);
+    const response = await send(path, init, bounds);
     try {
       if (bounds?.maxBytes !== undefined) {
         const chunks = await readBoundedBytes(response, bounds.maxBytes);
@@ -135,7 +148,7 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
   }
 
   async function requestBlob(path: string, init: RequestInit, bounds?: BoundedReadOptions): Promise<Blob> {
-    const response = await send(path, init);
+    const response = await send(path, init, bounds);
     try {
       if (bounds?.maxBytes !== undefined) {
         const chunks = await readBoundedBytes(response, bounds.maxBytes);
@@ -155,7 +168,7 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
       ...options,
       getRuntimeSlot: () => runtimeSlot,
     }),
-    get: (path) => request(path, { method: "GET" }),
+    get: (path, requestOptions) => request(path, { method: "GET" }, requestOptions),
     getText: (path, boundedOptions) => requestText(path, { method: "GET" }, boundedOptions),
     getBlob: (path, boundedOptions) => requestBlob(path, { method: "GET" }, boundedOptions),
     post: (path, body, requestOptions) =>
@@ -166,12 +179,12 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
       }, requestOptions),
     postBytes: (path, body, headers, requestOptions) =>
       request(path, { method: "POST", headers, body }, requestOptions),
-    patch: (path, body) =>
+    patch: (path, body, requestOptions) =>
       request(path, {
         method: "PATCH",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(body),
-      }),
+      }, requestOptions),
     put: (path, body, requestOptions) =>
       request(path, {
         method: "PUT",
@@ -182,17 +195,17 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
       request(path, { method: "PUT", headers, body }, requestOptions),
     // The gateway task DELETE route parses the JSON body unconditionally, so a
     // body-less DELETE 400s; always send an empty JSON object.
-    delete: (path) =>
+    delete: (path, requestOptions) =>
       request(path, {
         method: "DELETE",
         headers: { "content-type": "application/json" },
         body: "{}",
-      }),
-    putText: (path, body) =>
+      }, requestOptions),
+    putText: (path, body, requestOptions) =>
       request(path, {
         method: "PUT",
         headers: { "content-type": "text/plain" },
         body,
-      }),
+      }, requestOptions),
   };
 }

--- a/desktop/src/renderer/src/lib/query-client.ts
+++ b/desktop/src/renderer/src/lib/query-client.ts
@@ -1,0 +1,32 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export interface DesktopQueryScope {
+  platformHost: string;
+  authGeneration: number;
+  runtimeSlot: string;
+}
+
+export function desktopQueryScope({ platformHost, authGeneration, runtimeSlot }: DesktopQueryScope): readonly [string, number, string] {
+  return [platformHost, authGeneration, runtimeSlot];
+}
+
+export function createDesktopQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 10_000,
+        gcTime: 5 * 60_000,
+        retry: 1,
+        refetchOnWindowFocus: false,
+      },
+      mutations: { retry: false },
+    },
+  });
+}
+
+export const desktopQueryClient = createDesktopQueryClient();
+
+export function clearDesktopQueryCache(): void {
+  void desktopQueryClient.cancelQueries(undefined, { silent: true });
+  desktopQueryClient.clear();
+}

--- a/desktop/src/renderer/src/main.tsx
+++ b/desktop/src/renderer/src/main.tsx
@@ -1,10 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
+import { desktopQueryClient } from "./lib/query-client";
 import "./design/index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={desktopQueryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/desktop/src/renderer/src/stores/connection.ts
+++ b/desktop/src/renderer/src/stores/connection.ts
@@ -8,6 +8,7 @@ import { advanceRuntimeGeneration } from "./runtime-generation";
 import { reconcileDesktopRuntimeChange } from "./runtime-transition";
 import { resetAppsRuntime } from "./apps";
 import { flushActiveNotesBeforeIdentityChange } from "../features/notes/notes-controller";
+import { clearDesktopQueryCache } from "../lib/query-client";
 
 export type ConnectionStatus = "loading" | "signed-out" | "signed-in";
 
@@ -56,6 +57,7 @@ export const useConnection = create<ConnectionState>()((set, get) => ({
       // Advance BEFORE publishing the new identity so a response settling in
       // between is already considered stale.
       if (identityChanged) {
+        clearDesktopQueryCache();
         advanceRuntimeGeneration();
         clearDraftChats();
         resetAppsRuntime();
@@ -85,6 +87,7 @@ export const useConnection = create<ConnectionState>()((set, get) => ({
       console.warn("[connection] failed to refresh auth status:", err instanceof Error ? err.message : String(err));
       // Dropping to signed-out is an identity change too.
       if (get().status !== "signed-out") {
+        clearDesktopQueryCache();
         advanceRuntimeGeneration();
         clearDraftChats();
         resetAppsRuntime();
@@ -109,6 +112,7 @@ export const useConnection = create<ConnectionState>()((set, get) => ({
       await invoke("runtime:select", { slot });
       // Clear previous-computer state only after the trusted core confirms the
       // switch, and before the new slot becomes observable to the UI.
+      clearDesktopQueryCache();
       reconcileDesktopRuntimeChange();
       // Publish the slot only after invalidating the previous ApiClient. The
       // trusted auth snapshot below may settle on a later turn; keeping the old
@@ -135,6 +139,7 @@ export const useConnection = create<ConnectionState>()((set, get) => ({
     // computers. Advance the shared generation and synchronously remove every
     // previous-owner cache before publishing signed-out state, so an in-flight
     // request cannot repopulate the next account's desktop.
+    clearDesktopQueryCache();
     reconcileDesktopRuntimeChange();
     set({ status: "signed-out", handle: null, displayName: null, imageUrl: null, api: null });
   },

--- a/docs/dev/client-data-access.md
+++ b/docs/dev/client-data-access.md
@@ -1,0 +1,51 @@
+# Client Data Access
+
+Browser and Electron renderer HTTP calls follow one layered convention:
+
+```text
+UI call site -> useQuery/useMutation -> feature-domain fetcher -> renderer transport
+```
+
+Use TanStack Query for cacheable gateway state. Keep Zustand for UI state,
+runtime orchestration, and streaming transports. Do not force WebSockets,
+streaming chat or terminal traffic, progress-sensitive transfers, redirects,
+service-worker traffic, server-side calls, or Electron IPC through Query.
+
+## Transports
+
+- Desktop renderer HTTP uses `desktop/src/renderer/src/lib/api.ts`. It owns
+  trusted-core authentication, runtime-slot routing, safe error mapping,
+  bounded bodies, timeouts, and caller cancellation composition.
+- Web shell HTTP uses `shell/src/api/http.ts`. It resolves the gateway URL at
+  request time and provides the same timeout, cancellation, and safe-error
+  guarantees.
+
+Every Query fetcher passes its supplied `signal` to the transport. The
+transport combines that signal with a mandatory timeout; cancellation must
+never remove the timeout bound.
+
+## Domain modules
+
+Place fetchers, response parsing, and key factories in the owning domain.
+Examples include `shell/src/api/plugins.ts` and
+`desktop/src/renderer/src/features/settings/cron.api.ts`.
+
+- Fetchers accept explicit inputs and optional request options; they do not
+  read global component or Zustand state to infer cache identity.
+- Keys must include all owner/runtime selectors. Desktop keys include platform
+  host, authentication generation, and runtime slot.
+- Mutations explicitly update or invalidate only affected keys after success.
+  Optimistic writes require a rollback test.
+
+## Runtime transitions
+
+The desktop QueryClient is memory-only. It is cancelled and cleared before an
+identity or runtime transition publishes the replacement scope. Query keys
+still carry the same scope so a future ordering regression cannot display a
+previous runtime's data.
+
+## Tests
+
+Write a focused failing test before adding a transport or domain operation.
+Cover successful parsing, safe failures, cancellation propagation, key scope,
+and mutation follow-up. Run the focused test suite plus renderer typechecks.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/react-query':
+        specifier: ^5.101.4
+        version: 5.102.2(react@19.2.6)
       '@tiptap/extension-list':
         specifier: 3.22.4
         version: 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)
@@ -1027,6 +1030,9 @@ importers:
       '@streamdown/mermaid':
         specifier: ^1.0.2
         version: 1.0.2(react@19.2.6)
+      '@tanstack/react-query':
+        specifier: ^5.101.4
+        version: 5.102.2(react@19.2.6)
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
@@ -6184,8 +6190,16 @@ packages:
   '@tanstack/query-core@5.100.11':
     resolution: {integrity: sha512-lmE0994apShXPj8CUxgx4ch5yUJhE9k/+tVwihBvPOyerACWdBocfFg24t8+0RhtlTd7tEgchDkhlCxNssvDxw==}
 
+  '@tanstack/query-core@5.102.2':
+    resolution: {integrity: sha512-zQ5794PXBlV5Wl7N23SR1/Ss+wPE/h2Ye4XlKpm3omN8i8b/Fd4DAdqpLS2AXj5M/RMObt3k5qy3E7kzt/AvBA==}
+
   '@tanstack/query-core@5.87.4':
     resolution: {integrity: sha512-uNsg6zMxraEPDVO2Bn+F3/ctHi+Zsk+MMpcN8h6P7ozqD088F6mFY5TfGM7zuyIrL7HKpDyu6QHfLWiDxh3cuw==}
+
+  '@tanstack/react-query@5.102.2':
+    resolution: {integrity: sha512-KxU8ZyOEuJ81eTSgXa8GQbk/jO/rz0elYtNKt3VMtM2pRjeO8ADIu7sqqmEjFKJKqco9h2N1ojIDuHs6VfDItQ==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -21482,7 +21496,14 @@ snapshots:
 
   '@tanstack/query-core@5.100.11': {}
 
+  '@tanstack/query-core@5.102.2': {}
+
   '@tanstack/query-core@5.87.4': {}
+
+  '@tanstack/react-query@5.102.2(react@19.2.6)':
+    dependencies:
+      '@tanstack/query-core': 5.102.2
+      react: 19.2.6
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/shell/package.json
+++ b/shell/package.json
@@ -36,6 +36,7 @@
     "@streamdown/code": "^1.0.2",
     "@streamdown/math": "^1.0.2",
     "@streamdown/mermaid": "^1.0.2",
+    "@tanstack/react-query": "^5.101.4",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-image": "^0.9.0",
     "@xterm/addon-search": "^0.16.0",

--- a/shell/src/api/http.ts
+++ b/shell/src/api/http.ts
@@ -1,0 +1,114 @@
+import { getGatewayUrl } from "@/lib/gateway";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export type ClientApiErrorCategory = "unauthorized" | "offline" | "timeout" | "notFound" | "server";
+
+export class ClientApiError extends Error {
+  readonly category: ClientApiErrorCategory;
+  readonly detail?: string;
+
+  constructor(category: ClientApiErrorCategory, options?: { cause?: unknown; detail?: string }) {
+    super(clientErrorMessage(category), options);
+    this.name = "ClientApiError";
+    this.category = category;
+    this.detail = options?.detail;
+  }
+}
+
+export interface RequestOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+export interface ShellApiClientOptions {
+  getGatewayUrl?: () => string;
+  fetchFn?: (input: string, init?: RequestInit) => Promise<Response>;
+}
+
+export interface ShellApiClient {
+  get<T>(path: string, options?: RequestOptions): Promise<T>;
+  post<T>(path: string, body: unknown, options?: RequestOptions): Promise<T>;
+  put<T>(path: string, body: unknown, options?: RequestOptions): Promise<T>;
+  patch<T>(path: string, body: unknown, options?: RequestOptions): Promise<T>;
+  delete<T>(path: string, options?: RequestOptions): Promise<T>;
+}
+
+export function createShellApiClient(options: ShellApiClientOptions = {}): ShellApiClient {
+  const resolveGatewayUrl = options.getGatewayUrl ?? getGatewayUrl;
+  const fetchFn = options.fetchFn ?? ((input: string, init?: RequestInit) => fetch(input, init));
+
+  async function request<T>(path: string, init: RequestInit, requestOptions?: RequestOptions): Promise<T> {
+    const timeout = AbortSignal.timeout(requestOptions?.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    const signal = requestOptions?.signal ? AbortSignal.any([requestOptions.signal, timeout]) : timeout;
+    let response: Response;
+    try {
+      response = await fetchFn(`${resolveGatewayUrl().replace(/\/$/, "")}${path}`, { ...init, signal });
+    } catch (error: unknown) {
+      throw new ClientApiError(classifyTransportError(error), { cause: error });
+    }
+
+    if (!response.ok) {
+      throw new ClientApiError(classifyHttpStatus(response.status), {
+        detail: await safeErrorDetail(response),
+      });
+    }
+
+    try {
+      return await response.json() as T;
+    } catch (error: unknown) {
+      throw new ClientApiError("server", { cause: error });
+    }
+  }
+
+  const json = <T>(method: "POST" | "PUT" | "PATCH", path: string, body: unknown, requestOptions?: RequestOptions): Promise<T> =>
+    request(path, {
+      method,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }, requestOptions);
+
+  return {
+    get: <T>(path: string, requestOptions?: RequestOptions) => request<T>(path, { method: "GET" }, requestOptions),
+    post: <T>(path: string, body: unknown, requestOptions?: RequestOptions) => json<T>("POST", path, body, requestOptions),
+    put: <T>(path: string, body: unknown, requestOptions?: RequestOptions) => json<T>("PUT", path, body, requestOptions),
+    patch: <T>(path: string, body: unknown, requestOptions?: RequestOptions) => json<T>("PATCH", path, body, requestOptions),
+    delete: <T>(path: string, requestOptions?: RequestOptions) => request<T>(path, { method: "DELETE" }, requestOptions),
+  };
+}
+
+export const shellApi = createShellApiClient();
+
+function clientErrorMessage(category: ClientApiErrorCategory): string {
+  return {
+    unauthorized: "Your session has expired. Please sign in again.",
+    offline: "Can't reach Matrix OS. Check your connection.",
+    timeout: "The request timed out. Please try again.",
+    notFound: "That item could not be found.",
+    server: "Something went wrong. Please try again.",
+  }[category];
+}
+
+function classifyHttpStatus(status: number): ClientApiErrorCategory {
+  if (status === 401 || status === 403) return "unauthorized";
+  if (status === 404) return "notFound";
+  return "server";
+}
+
+function classifyTransportError(error: unknown): ClientApiErrorCategory {
+  if (error instanceof DOMException && (error.name === "TimeoutError" || error.name === "AbortError")) return "timeout";
+  return error instanceof TypeError ? "offline" : "server";
+}
+
+async function safeErrorDetail(response: Response): Promise<string | undefined> {
+  try {
+    const body = await response.clone().json() as { error?: unknown };
+    const value = typeof body.error === "object" && body.error
+      ? (body.error as { code?: unknown }).code
+      : body.error;
+    return typeof value === "string" && /^[a-z][a-z0-9_]{2,48}$/.test(value) ? value : undefined;
+  } catch (error: unknown) {
+    console.warn("[client-api] gateway error response could not be parsed", error instanceof Error ? error.name : "unknown");
+    return undefined;
+  }
+}

--- a/shell/src/api/plugins.ts
+++ b/shell/src/api/plugins.ts
@@ -1,0 +1,77 @@
+import { queryOptions } from "@tanstack/react-query";
+import { shellApi, type RequestOptions } from "./http";
+
+export interface PluginInfo {
+  id: string;
+  name: string;
+  version: string;
+  description?: string;
+  origin: string;
+  status: string;
+  contributions: {
+    tools: number;
+    hooks: number;
+    channels: number;
+    routes: number;
+    services: number;
+    skills: number;
+  };
+}
+
+type PluginLoader = (options?: RequestOptions) => Promise<PluginInfo[]>;
+
+export const pluginKeys = {
+  all: () => ["plugins"] as const,
+  list: () => ["plugins", "list"] as const,
+};
+
+export async function listPlugins(options?: RequestOptions): Promise<PluginInfo[]> {
+  return parsePlugins(await shellApi.get<unknown>("/api/plugins", options));
+}
+
+export function pluginsQueryOptions(loader: PluginLoader = listPlugins) {
+  return queryOptions({
+    queryKey: pluginKeys.list(),
+    queryFn: ({ signal }) => loader({ signal }),
+  });
+}
+
+function parsePlugins(value: unknown): PluginInfo[] {
+  if (!Array.isArray(value)) return [];
+  const plugins: PluginInfo[] = [];
+  for (const raw of value.slice(0, 500)) {
+    if (!raw || typeof raw !== "object") continue;
+    const plugin = raw as Record<string, unknown>;
+    if (
+      typeof plugin.id !== "string"
+      || typeof plugin.name !== "string"
+      || typeof plugin.version !== "string"
+      || typeof plugin.origin !== "string"
+      || typeof plugin.status !== "string"
+    ) continue;
+    const contributions = plugin.contributions && typeof plugin.contributions === "object"
+      ? plugin.contributions as Record<string, unknown>
+      : {};
+    plugins.push({
+      id: plugin.id,
+      name: plugin.name,
+      version: plugin.version,
+      description: typeof plugin.description === "string" ? plugin.description : undefined,
+      origin: plugin.origin,
+      status: plugin.status,
+      contributions: {
+        tools: count(contributions.tools),
+        hooks: count(contributions.hooks),
+        channels: count(contributions.channels),
+        routes: count(contributions.routes),
+        services: count(contributions.services),
+        skills: count(contributions.skills),
+      },
+    });
+  }
+  return plugins;
+}
+
+function count(value: unknown): number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 10_000 ? value : 0;
+}

--- a/shell/src/api/query-client.ts
+++ b/shell/src/api/query-client.ts
@@ -1,0 +1,15 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export function createShellQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 10_000,
+        gcTime: 5 * 60_000,
+        retry: 1,
+        refetchOnWindowFocus: false,
+      },
+      mutations: { retry: false },
+    },
+  });
+}

--- a/shell/src/app/layout.tsx
+++ b/shell/src/app/layout.tsx
@@ -25,6 +25,7 @@ import { PwaRegister } from "@/components/pwa/PwaRegister";
 import { InstallPrompt } from "@/components/pwa/InstallPrompt";
 import { PostHogIdentify } from "@/components/PostHogIdentify";
 import { Toaster } from "@/components/ui/sonner";
+import { AppProviders } from "./providers";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -135,7 +136,7 @@ export default async function RootLayout({
       data-posthog-disable-replay={process.env.POSTHOG_DISABLE_REPLAY ? "1" : undefined}
     >
       <body className={`${inter.variable} ${instrumentSans.variable} ${instrumentSerif.variable} ${jetbrainsMono.variable} ${cormorant.variable} ${orbitron.variable} ${geistSans.variable} ${geistMono.variable} ${bricolage.variable}`}>
-        {children}
+        <AppProviders>{children}</AppProviders>
         {includePostHogIdentify ? <PostHogIdentify /> : null}
         <PwaRegister />
         <InstallPrompt />

--- a/shell/src/app/providers.tsx
+++ b/shell/src/app/providers.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { QueryClientProvider } from "@tanstack/react-query";
+import { useState, type ReactNode } from "react";
+import { createShellQueryClient } from "@/api/query-client";
+
+export function AppProviders({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(createShellQueryClient);
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/shell/src/components/settings/sections/PluginsSection.tsx
+++ b/shell/src/components/settings/sections/PluginsSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -11,28 +12,8 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
-import { getGatewayUrl } from "@/lib/gateway";
 import { PuzzleIcon, PlusIcon } from "@/lib/hugeicons";
-
-const GATEWAY = getGatewayUrl();
-const PLUGINS_FETCH_TIMEOUT_MS = 10_000;
-
-interface PluginInfo {
-  id: string;
-  name: string;
-  version: string;
-  description?: string;
-  origin: string;
-  status: string;
-  contributions: {
-    tools: number;
-    hooks: number;
-    channels: number;
-    routes: number;
-    services: number;
-    skills: number;
-  };
-}
+import { pluginsQueryOptions } from "@/api/plugins";
 
 const ORIGIN_STYLES: Record<string, string> = {
   bundled: "bg-blue-500/10 text-blue-600",
@@ -49,33 +30,8 @@ const CONFIG_EXAMPLE = `{
 }`;
 
 export function PluginsSection() {
-  const [plugins, setPlugins] = useState<PluginInfo[]>([]);
-  const [error, setError] = useState(false);
+  const { data: plugins = [], isError, isPending } = useQuery(pluginsQueryOptions());
   const [dialogOpen, setDialogOpen] = useState(false);
-
-  // react-doctor-disable-next-line react-doctor/no-fetch-in-effect -- guarded run-once mount load (empty deps): the request carries AbortSignal.timeout, the `cancelled` flag gates every setState, and the controller aborts in cleanup, so this is the correct fetch-on-mount pattern; a data-fetching library would add no safety here.
-  useEffect(() => {
-    let cancelled = false;
-
-    fetch(`${GATEWAY}/api/plugins`, {
-      signal: AbortSignal.timeout(PLUGINS_FETCH_TIMEOUT_MS),
-    })
-      .then((r) => {
-        if (!r.ok) throw new Error();
-        return r.json();
-      })
-      .then((data) => { if (!cancelled) setPlugins(data); })
-      .catch((error: unknown) => {
-        if (!cancelled) {
-          console.warn("Failed to load plugins", error);
-          setError(true);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-6">
@@ -87,7 +43,15 @@ export function PluginsSection() {
         </Button>
       </div>
 
-      {error && (
+      {isPending && (
+        <Card>
+          <CardContent className="py-8 text-center">
+            <p className="text-sm text-muted-foreground">Loading plugins...</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {isError && (
         <Card>
           <CardContent className="py-8 text-center">
             <PuzzleIcon className="size-8 text-muted-foreground/40 mx-auto mb-3" />
@@ -98,7 +62,7 @@ export function PluginsSection() {
         </Card>
       )}
 
-      {!error && plugins.length === 0 && (
+      {!isPending && !isError && plugins.length === 0 && (
         <Card>
           <CardContent className="flex flex-col items-center justify-center py-12 text-center">
             <PuzzleIcon className="size-8 text-muted-foreground/40 mb-3" />
@@ -110,7 +74,7 @@ export function PluginsSection() {
         </Card>
       )}
 
-      {plugins.length > 0 && (
+      {!isPending && !isError && plugins.length > 0 && (
         <div className="space-y-3">
           {plugins.map((plugin) => {
             const c = plugin.contributions;

--- a/tests/desktop/api-client.test.ts
+++ b/tests/desktop/api-client.test.ts
@@ -67,6 +67,23 @@ describe("createApiClient", () => {
     expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
   });
 
+  it("composes a caller cancellation signal with the mandatory timeout", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(200, { ok: true }));
+    const caller = new AbortController();
+    const client = createApiClient({
+      baseUrl: "https://app.matrix-os.com",
+      getRuntimeSlot: () => "primary",
+      fetchFn,
+    });
+
+    await client.get("/api/apps", { signal: caller.signal });
+
+    const [, init] = fetchFn.mock.calls[0]!;
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+    caller.abort();
+    expect((init as RequestInit).signal!.aborted).toBe(true);
+  });
+
   it("maps 401 to unauthorized AppError", async () => {
     const fetchFn = vi.fn().mockResolvedValue(jsonResponse(401, {}));
     const client = createApiClient({

--- a/tests/desktop/cron-api.test.ts
+++ b/tests/desktop/cron-api.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from "vitest";
+import { cronKeys, cronQueryOptions } from "@desktop/renderer/src/features/settings/cron.api";
+
+describe("cronQueryOptions", () => {
+  it("scopes a cron query and forwards Query cancellation to the desktop transport", async () => {
+    const api = { get: vi.fn().mockResolvedValue({ jobs: [] }) };
+    const scope = { platformHost: "https://app.matrix-os.com", authGeneration: 3, runtimeSlot: "work" };
+    const options = cronQueryOptions(api as never, scope);
+    const controller = new AbortController();
+
+    await options.queryFn!({
+      client: {} as never,
+      queryKey: options.queryKey,
+      signal: controller.signal,
+      meta: undefined,
+    });
+
+    expect(options.queryKey).toEqual(cronKeys.list(scope));
+    expect(api.get).toHaveBeenCalledWith("/api/cron", { signal: controller.signal });
+  });
+});

--- a/tests/desktop/query-client.test.ts
+++ b/tests/desktop/query-client.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { createDesktopQueryClient, desktopQueryScope } from "@desktop/renderer/src/lib/query-client";
+
+describe("desktop query client", () => {
+  it("keeps cache identity scoped to the authenticated runtime", () => {
+    expect(desktopQueryScope({ platformHost: "https://app.matrix-os.com", authGeneration: 7, runtimeSlot: "work" })).toEqual([
+      "https://app.matrix-os.com",
+      7,
+      "work",
+    ]);
+  });
+
+  it("does not retry mutations and does not refetch queries on window focus", () => {
+    const client = createDesktopQueryClient();
+    expect(client.getDefaultOptions().mutations?.retry).toBe(false);
+    expect(client.getDefaultOptions().queries?.refetchOnWindowFocus).toBe(false);
+  });
+});

--- a/tests/shell/client-http.test.ts
+++ b/tests/shell/client-http.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import { ClientApiError, createShellApiClient } from "@/api/http";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("createShellApiClient", () => {
+  it("resolves the gateway URL at request time and composes caller cancellation with its timeout", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(200, { apps: [] }));
+    const controller = new AbortController();
+    let gatewayUrl = "https://first.test";
+    const api = createShellApiClient({ getGatewayUrl: () => gatewayUrl, fetchFn });
+
+    gatewayUrl = "https://second.test";
+    await api.get("/api/apps", { signal: controller.signal });
+
+    const [url, init] = fetchFn.mock.calls[0]!;
+    expect(url).toBe("https://second.test/api/apps");
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+    controller.abort();
+    expect((init as RequestInit).signal!.aborted).toBe(true);
+  });
+
+  it("maps unsafe gateway failures to generic client errors", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(500, { error: "/private/secret" }));
+    const api = createShellApiClient({ getGatewayUrl: () => "https://gateway.test", fetchFn });
+
+    await expect(api.get("/api/apps")).rejects.toEqual(
+      expect.objectContaining<ClientApiError>({ category: "server", detail: undefined }),
+    );
+  });
+});

--- a/tests/shell/plugins-api.test.ts
+++ b/tests/shell/plugins-api.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { pluginKeys, pluginsQueryOptions } from "@/api/plugins";
+
+describe("pluginsQueryOptions", () => {
+  it("uses the domain-owned key and forwards Query cancellation to its fetcher", async () => {
+    const listPlugins = vi.fn().mockResolvedValue([]);
+    const options = pluginsQueryOptions(listPlugins);
+    const controller = new AbortController();
+
+    await options.queryFn!({
+      client: {} as never,
+      queryKey: options.queryKey,
+      signal: controller.signal,
+      meta: undefined,
+    });
+
+    expect(options.queryKey).toEqual(pluginKeys.list());
+    expect(listPlugins).toHaveBeenCalledWith({ signal: controller.signal });
+  });
+});

--- a/tests/shell/query-client.test.ts
+++ b/tests/shell/query-client.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { createShellQueryClient } from "@/api/query-client";
+
+describe("shell query client", () => {
+  it("uses non-persistent, conservative retry defaults", () => {
+    const client = createShellQueryClient();
+    expect(client.getDefaultOptions().queries?.retry).toBe(1);
+    expect(client.getDefaultOptions().mutations?.retry).toBe(false);
+    expect(client.getDefaultOptions().queries?.refetchOnWindowFocus).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add TanStack Query to the desktop renderer and web shell with non-persistent QueryClient defaults
- centralize bounded client transport behavior and migrate the Plugins and Schedules settings calls to domain fetchers and Query options
- clear desktop cached data whenever the authenticated runtime identity changes, and document the client data-access convention

## Tests
- Focused Vitest transport, QueryClient, and domain tests: 27 passed
- Shell TypeScript check: pnpm --filter shell exec tsc --noEmit
- Desktop renderer TypeScript check: pnpm --filter desktop exec tsc --noEmit -p tsconfig.json
- Shell lint remains blocked by the local eslint-config-next dependency failing to resolve the bundled Next ESLint parser
- Full desktop typecheck remains blocked by existing main-process tsconfig errors for crypto and WebSocket; the renderer-only typecheck passes

## Invariants
- Server gateway responses remain the source of truth; Query cache is memory-only
- Desktop requests continue through the authenticated core transport, while the shell keeps its existing gateway/session boundary
- Desktop query cache is cleared before runtime transition reconciliation so data cannot cross authenticated runtime identities

## Follow-up
This is the foundation and representative migration layer for [MAT-495](https://linear.app/matrix-os/issue/MAT-495/featclient-data-centralize-client-api-access-with-tanstack-query). Remaining domain migrations and the public contributor-doc update stay tracked in that ticket.

## Review / Monitoring
Please review the transport boundary, query-key scoping, cancellation behavior, and the two migrated call sites. I will address review feedback and wait for the repository automated review and CI gates before handoff.