### PR TITLE
fix(ci): retry change-detection checkout fetches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,13 @@ jobs:
             if timeout --foreground --kill-after=5s "${CHECKOUT_TIMEOUT_SECONDS}s" \
               git -c http.extraheader="AUTHORIZATION: basic $auth_header" \
                 fetch --no-tags --prune --no-recurse-submodules --depth=1 \
-                origin "+${GITHUB_REF}:refs/remotes/origin/ci" \
+                origin "$GITHUB_SHA" \
               && git checkout --force --detach "$GITHUB_SHA"; then
               echo "Checkout fetch succeeded on attempt $attempt/$CHECKOUT_MAX_ATTEMPTS"
               exit 0
             fi
 
-            rm -f .git/index.lock .git/shallow.lock .git/refs/remotes/origin/ci.lock
+            rm -f .git/index.lock .git/shallow.lock
             if [ "$attempt" -eq "$CHECKOUT_MAX_ATTEMPTS" ]; then
               echo "::error::Checkout fetch failed after $CHECKOUT_MAX_ATTEMPTS attempts"
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,46 @@ jobs:
   changes:
     name: Detect CI-relevant changes
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 3
     outputs:
       should_run: ${{ steps.changed.outputs.should_run }}
       docs_contract_tests: ${{ steps.changed.outputs.docs_contract_tests }}
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
+      - name: Checkout with bounded retry
+        env:
+          CHECKOUT_BACKOFF_SECONDS: "5"
+          CHECKOUT_MAX_ATTEMPTS: "3"
+          CHECKOUT_TIMEOUT_SECONDS: "30"
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          git init .
+          git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
+          git config --local gc.auto 0
+          auth_header="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+
+          for attempt in $(seq 1 "$CHECKOUT_MAX_ATTEMPTS"); do
+            echo "Checkout fetch attempt $attempt/$CHECKOUT_MAX_ATTEMPTS"
+            if timeout --foreground --kill-after=5s "${CHECKOUT_TIMEOUT_SECONDS}s" \
+              git -c http.extraheader="AUTHORIZATION: basic $auth_header" \
+                fetch --no-tags --prune --no-recurse-submodules --depth=1 \
+                origin "+${GITHUB_REF}:refs/remotes/origin/ci" \
+              && git checkout --force --detach "$GITHUB_SHA"; then
+              echo "Checkout fetch succeeded on attempt $attempt/$CHECKOUT_MAX_ATTEMPTS"
+              exit 0
+            fi
+
+            rm -f .git/index.lock .git/shallow.lock .git/refs/remotes/origin/ci.lock
+            if [ "$attempt" -eq "$CHECKOUT_MAX_ATTEMPTS" ]; then
+              echo "::error::Checkout fetch failed after $CHECKOUT_MAX_ATTEMPTS attempts"
+              exit 1
+            fi
+
+            backoff_seconds=$((CHECKOUT_BACKOFF_SECONDS * attempt))
+            echo "Checkout fetch attempt $attempt failed; retrying in ${backoff_seconds}s"
+            sleep "$backoff_seconds"
+          done
 
       - name: Detect source changes
         id: changed

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -1,6 +1,107 @@
 import { describe, expect, it } from 'vitest';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { parse } from 'yaml';
+
+function readChangeDetectionCheckoutRun(root: string): string | undefined {
+  const workflow = parse(
+    readFileSync(join(root, '.github/workflows/ci.yml'), 'utf8'),
+  ) as {
+    jobs?: {
+      changes?: {
+        steps?: Array<{
+          name?: string;
+          run?: string;
+        }>;
+      };
+    };
+  };
+
+  return workflow.jobs?.changes?.steps?.find(
+    (step) => step.name === 'Checkout with bounded retry',
+  )?.run;
+}
+
+function runChangeDetectionCheckout(
+  checkoutRun: string,
+  failuresBeforeSuccess: number,
+): {
+  attempts: string;
+  checkoutCompleted: boolean;
+  status: number | null;
+  stderr: string;
+  stdout: string;
+} {
+  const tempDir = mkdtempSync(join(tmpdir(), 'matrix-ci-checkout-retry-'));
+  const fakeBin = join(tempDir, 'bin');
+  const fetchAttempts = join(tempDir, 'fetch-attempts');
+  const checkoutMarker = join(tempDir, 'checkout-complete');
+  mkdirSync(fakeBin);
+  writeFileSync(
+    join(fakeBin, 'git'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ " $* " == *" fetch "* ]]; then
+  attempt=0
+  if [ -f "$FAKE_GIT_FETCH_ATTEMPTS" ]; then
+    attempt="$(cat "$FAKE_GIT_FETCH_ATTEMPTS")"
+  fi
+  attempt=$((attempt + 1))
+  printf '%s' "$attempt" > "$FAKE_GIT_FETCH_ATTEMPTS"
+  if [ "$FAKE_GIT_FAILURES_BEFORE_SUCCESS" -lt 0 ] || [ "$attempt" -le "$FAKE_GIT_FAILURES_BEFORE_SUCCESS" ]; then
+    exit 1
+  fi
+fi
+if [[ " $* " == *" checkout --force --detach "* ]]; then
+  touch "$FAKE_GIT_CHECKOUT_MARKER"
+fi
+`,
+  );
+  chmodSync(join(fakeBin, 'git'), 0o755);
+
+  try {
+    const result = spawnSync('bash', ['-c', checkoutRun], {
+      cwd: tempDir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+        CHECKOUT_BACKOFF_SECONDS: '0',
+        CHECKOUT_MAX_ATTEMPTS: '3',
+        CHECKOUT_TIMEOUT_SECONDS: '1',
+        FAKE_GIT_CHECKOUT_MARKER: checkoutMarker,
+        FAKE_GIT_FAILURES_BEFORE_SUCCESS: String(failuresBeforeSuccess),
+        FAKE_GIT_FETCH_ATTEMPTS: fetchAttempts,
+        GH_TOKEN: 'test-token',
+        GITHUB_REF: 'refs/heads/main',
+        GITHUB_REPOSITORY: 'HamedMP/matrix-os',
+        GITHUB_SERVER_URL: 'https://github.com',
+        GITHUB_SHA: '0123456789012345678901234567890123456789',
+      },
+    });
+
+    return {
+      attempts: readFileSync(fetchAttempts, 'utf8'),
+      checkoutCompleted: existsSync(checkoutMarker),
+      status: result.status,
+      stderr: result.stderr,
+      stdout: result.stdout,
+    };
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
 
 describe('CI workflows', () => {
   const stripePriceSecrets = [
@@ -41,10 +142,45 @@ describe('CI workflows', () => {
       workflow.indexOf('  # ── Gate 1: Mechanical checks'),
     );
 
-    expect(changesJob).toContain('timeout-minutes: 2');
-    expect(changesJob).toContain('fetch-depth: 1');
+    expect(changesJob).toContain('timeout-minutes: 3');
+    expect(changesJob).toContain('name: Checkout with bounded retry');
+    expect(changesJob).toContain('CHECKOUT_MAX_ATTEMPTS: "3"');
+    expect(changesJob).toContain('CHECKOUT_TIMEOUT_SECONDS: "30"');
+    expect(changesJob).toContain('CHECKOUT_BACKOFF_SECONDS: "5"');
+    expect(changesJob).toContain('timeout --foreground --kill-after=5s');
+    expect(changesJob).toContain('for attempt in $(seq 1 "$CHECKOUT_MAX_ATTEMPTS")');
+    expect(changesJob).toContain('Checkout fetch failed after $CHECKOUT_MAX_ATTEMPTS attempts');
     expect(changesJob).toContain('git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"');
+    expect(changesJob).not.toContain('uses: actions/checkout@v6');
     expect(changesJob).not.toContain('fetch-depth: 0');
+  });
+
+  it('recovers when the first change-detection checkout fetch fails transiently', () => {
+    const root = process.cwd();
+    const checkoutRun = readChangeDetectionCheckoutRun(root);
+    expect(checkoutRun).toBeTypeOf('string');
+
+    const result = runChangeDetectionCheckout(checkoutRun ?? 'exit 1', 1);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.attempts).toBe('2');
+    expect(result.checkoutCompleted).toBe(true);
+    expect(result.stdout).toContain('Checkout fetch attempt 1/3');
+    expect(result.stdout).toContain('Checkout fetch attempt 2/3');
+  });
+
+  it('fails change detection after the bounded checkout attempts are exhausted', () => {
+    const root = process.cwd();
+    const checkoutRun = readChangeDetectionCheckoutRun(root);
+    expect(checkoutRun).toBeTypeOf('string');
+
+    const result = runChangeDetectionCheckout(checkoutRun ?? 'exit 1', -1);
+
+    expect(result.status).toBe(1);
+    expect(result.attempts).toBe('3');
+    expect(result.checkoutCompleted).toBe(false);
+    expect(result.stdout).toContain('Checkout fetch attempt 3/3');
+    expect(result.stdout).toContain('Checkout fetch failed after 3 attempts');
   });
 
   it('runs lightweight docs contract tests for docs-only CI changes', () => {

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -53,6 +53,10 @@ function runChangeDetectionCheckout(
     `#!/usr/bin/env bash
 set -euo pipefail
 if [[ " $* " == *" fetch "* ]]; then
+  if [[ " $* " != *" $GITHUB_SHA "* ]]; then
+    echo "fetch did not request the event commit" >&2
+    exit 64
+  fi
   attempt=0
   if [ -f "$FAKE_GIT_FETCH_ATTEMPTS" ]; then
     attempt="$(cat "$FAKE_GIT_FETCH_ATTEMPTS")"


### PR DESCRIPTION
## Summary

- replace the one-shot change-detection checkout with three shallow fetch attempts
- cap each fetch at 30 seconds, apply 5s/10s bounded backoff, and preserve a three-minute job timeout
- clear only known Git lock files after failed attempts and log every attempt/final failure
- execute the workflow checkout script in contract tests to prove transient recovery and bounded permanent failure

Closes #1254

## Tests

- `pnpm exec vitest run tests/platform/ci-workflows.test.ts` (36/36 passed)
- `bun run typecheck` (passed)
- `bun run check:patterns` (0 violations; existing warnings only)
- `bun run test` (broad run stopped after five unrelated timeouts in `tests/platform/proxy-routing.test.ts`; changed-area suite was rerun and passed afterward)

## Review/Monitoring

- Greptile current-head review: 5/5 on `c2f47df6808ca72088e70677bd064e8a3f31900a`
- Claude review: passed
- label-gated CI: changed checkout job, typecheck, pattern scan, shell production build, sync client, and three unit shards passed
- residual CI failure: `tests/gateway/session-registry.test.ts` expects `/bin/zsh` when the runner's default shell is `/bin/bash`; reproduced locally and unrelated to this PR's workflow/test files
- `ready-for-ci` removed while the aggregate CI gate remains red

## Invariants

- **Source of truth:** `.github/workflows/ci.yml` remains the sole CI change-detection and downstream fan-out definition.
- **Lock/transaction scope:** no database or application-state writes; retry cleanup is limited to known Git lock files in the ephemeral runner checkout.
- **Acceptable orphan states:** a failed attempt may leave shallow-fetch locks, which are removed before retry; downstream test and release jobs cannot start until change detection succeeds.
- **Auth source of truth:** `${{ github.token }}` is passed only to the fetch command through an HTTP authorization header and is not written to repository config.
- **Deferred scope:** other workflow checkout steps keep their existing behavior; this PR targets the main CI change-detection failure from #1254.
