### PR TITLE
fix(terminal): renew ownership during pending attach

### DIFF
--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -1734,7 +1734,9 @@ export function TerminalPane({
             return url.toString();
           })
           .then((wsUrl) => {
-            webSocketConnectPending = false;
+            if (generation === wsGenerationRef.current) {
+              webSocketConnectPending = false;
+            }
             if (generation !== wsGenerationRef.current || disposed || isClosingRef.current) {
               const reason = generation !== wsGenerationRef.current
                 ? "stale"
@@ -1768,6 +1770,14 @@ export function TerminalPane({
 
       resumeLeaseRef.current = () => {
         if (disposed || isClosingRef.current) return;
+        if (webSocketConnectPending) {
+          // The pending URL was built with the focus state captured when the
+          // request started. Invalidate it before reconnecting so a pane that
+          // becomes active mid-request cannot finish as a non-exclusive
+          // observer and retain the session's stale canonical grid.
+          wsGenerationRef.current += 1;
+          webSocketConnectPending = false;
+        }
         const existing = wsRef.current;
         if (existing && existing.readyState !== WebSocket.CLOSED) {
           existing.onopen = null;

--- a/tests/gateway/agent-runtime-controller.test.ts
+++ b/tests/gateway/agent-runtime-controller.test.ts
@@ -737,12 +737,17 @@ describe("agent runtime controller", () => {
   it("aborts and waits for an in-flight transition before closing adapters", async () => {
     const homePath = await createHome();
     let prepareSignal: AbortSignal | undefined;
+    let resolvePrepareListening: () => void = () => {};
+    const prepareListening = new Promise<void>((resolve) => {
+      resolvePrepareListening = resolve;
+    });
     const openclaw = fakeAdapter("openclaw", {
       prepare: vi.fn(async (signal) => new Promise<void>((_resolve, reject) => {
         prepareSignal = signal;
         signal.addEventListener("abort", () => reject(signal.reason), {
           once: true,
         });
+        resolvePrepareListening();
       })),
     });
     const hermes = fakeAdapter("hermes");
@@ -753,6 +758,7 @@ describe("agent runtime controller", () => {
     });
     const transition = controller.update({ runtime: "openclaw", revision: 0 });
     await vi.waitFor(() => expect(openclaw.prepare).toHaveBeenCalledOnce());
+    await prepareListening;
 
     await controller.close();
 

--- a/tests/gateway/session-registry.test.ts
+++ b/tests/gateway/session-registry.test.ts
@@ -83,6 +83,7 @@ describe("SessionRegistry", () => {
     });
 
     it("rejects shell not in allowlist and falls back to default", () => {
+      vi.stubEnv("SHELL", "");
       const mockSpawn = createMockSpawn();
       const registry = createRegistry({}, mockSpawn);
       registry.create("/home", "/usr/bin/python3");

--- a/tests/shell/terminal-pane-scrolling.test.tsx
+++ b/tests/shell/terminal-pane-scrolling.test.tsx
@@ -450,7 +450,16 @@ describe("TerminalPane scrolling", () => {
     mockedCapturePostHogEvent.mockClear();
     WebSocketMock.instances.length = 0;
     ResizeObserverMock.instances.length = 0;
-    buildAuthenticatedWebSocketUrl.mockClear();
+    buildAuthenticatedWebSocketUrl.mockReset();
+    buildAuthenticatedWebSocketUrl.mockImplementation((path, query) => {
+      const url = new URL(`ws://localhost${path}`);
+      for (const [key, value] of Object.entries(query ?? {})) {
+        if (value) {
+          url.searchParams.set(key, value);
+        }
+      }
+      return Promise.resolve(url.toString());
+    });
     socketHealthConfigs.length = 0;
     Reflect.deleteProperty(window, "visualViewport");
   });
@@ -484,6 +493,51 @@ describe("TerminalPane scrolling", () => {
     expect(createdFitAddons[0].proposeDimensions).toHaveBeenCalled();
     expect(createdFitAddons[0].fit).not.toHaveBeenCalled();
     expect(createdTerminals[0].resize).not.toHaveBeenCalled();
+  });
+
+  it("restarts a pending observer connection with an exclusive lease when the pane becomes focused", async () => {
+    let resolveObserverUrl: (() => void) | null = null;
+    buildAuthenticatedWebSocketUrl
+      .mockImplementationOnce((path, query) => new Promise<string>((resolve) => {
+        const url = new URL(`ws://localhost${path}`);
+        for (const [key, value] of Object.entries(query ?? {})) {
+          if (value) url.searchParams.set(key, value);
+        }
+        resolveObserverUrl = () => resolve(url.toString());
+      }));
+
+    const props = {
+      paneId: "pane-pending-focus-takeover",
+      cwd: "",
+      theme,
+      sessionId: "main",
+      isClosing: false,
+      shouldCacheOnUnmount: () => false,
+      shouldDestroyOnUnmount: () => false,
+      onFocus: () => {},
+    } satisfies Omit<Parameters<typeof TerminalPane>[0], "isFocused">;
+    const view = render(<TerminalPane {...props} isFocused={false} />);
+
+    await waitFor(() => expect(buildAuthenticatedWebSocketUrl).toHaveBeenCalledTimes(1));
+    expect(buildAuthenticatedWebSocketUrl.mock.calls[0]?.[1]).not.toHaveProperty("lease");
+
+    view.rerender(<TerminalPane {...props} isFocused />);
+
+    await waitFor(() => expect(buildAuthenticatedWebSocketUrl).toHaveBeenCalledTimes(2));
+    expect(buildAuthenticatedWebSocketUrl.mock.calls[1]?.[1]).toEqual(expect.objectContaining({
+      session: "main",
+      client: "hard",
+      lease: "exclusive",
+      cols: "120",
+      rows: "42",
+    }));
+
+    await act(async () => {
+      resolveObserverUrl?.();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(WebSocketMock.instances).toHaveLength(1));
+    expect(new URL(WebSocketMock.instances[0]!.url).searchParams.get("lease")).toBe("exclusive");
   });
 
   it("renews the focused web terminal lease well before gateway expiry", async () => {


### PR DESCRIPTION
Summary:
- invalidate an in-flight observer URL request when a pane gains focus
- reconnect with an exclusive lease and current hard-grid dimensions
- cover the focus-during-attach race with a regression test
- stabilize the runtime-controller close/abort test that timed out in label-gated CI
- stabilize the session-registry shell fallback test against CI runner SHELL differences

Rationale:
- a pending non-exclusive request could survive focus takeover and leave the Desktop renderer observing a stale canonical terminal height
- generation-scoped pending state prevents the stale request from clearing or replacing the new owner connection
- the first CI timeout came from the test waiting for the mock call record before the mock had registered its abort listener; the test now waits for the intended in-flight state explicitly
- the later CI shard 4 failure was an environment-dependent assertion: invalid-shell fallback should test the Matrix default with SHELL controlled, not inherit the runner image's shell

Tests:
- bun run test -- tests/shell/terminal-pane-scrolling.test.tsx
- bun run test -- tests/shell/terminal-pane-scrolling.test.tsx tests/shell/terminal-soft-grid.test.ts tests/gateway/terminal-zellij-ws.test.ts
- bun run test -- tests/shell/terminal-pane-scrolling.test.tsx tests/shell/terminal-app-component.test.tsx tests/shell/terminal.test.ts tests/shell/terminal-store.test.ts tests/shell/terminal-soft-grid.test.ts
- corepack pnpm install --frozen-lockfile
- corepack pnpm --filter @matrix-os/observability build
- corepack pnpm --filter @matrix-os/kernel build
- corepack pnpm --filter @matrix-os/integrations-mcp build
- node_modules/.bin/vitest run tests/shell/terminal-pane-scrolling.test.tsx tests/shell/terminal-app-component.test.tsx tests/shell/terminal.test.ts tests/shell/terminal-store.test.ts tests/shell/terminal-soft-grid.test.ts
- node_modules/.bin/vitest run tests/gateway/agent-runtime-controller.test.ts
- node_modules/.bin/vitest run tests/gateway/session-registry.test.ts

Review/Monitoring:
- latest pushed head: 2b5a0908e8dacdf45d3aa47c6a619657f0646177
- previous Greptile result was 5/5 on 89dd77660c5bb5e4e8ec986087c06c80de1a204b and was dismissed after the follow-up push
- ready-for-ci was added after the prior 5/5, then removed when Unit Tests (4/4) exposed the session-registry shell fallback assertion
- waiting for Greptile to review the latest head before re-adding ready-for-ci

Invariants:
- Terminal ownership source of truth remains the active pane/focus state plus generation-scoped pending WebSocket URL state.
- No database writes, durable owner data writes, auth rules, or runtime service behavior are changed by this PR.
- The gateway test changes only synchronize test doubles/environment with the states those tests already assert.
- No deferred correctness or security scope.
