### PR TITLE
fix(test): isolate session registry shell defaults

### DIFF
--- a/tests/gateway/session-registry.test.ts
+++ b/tests/gateway/session-registry.test.ts
@@ -37,6 +37,7 @@ function createRegistry(
     maxSessions: opts.maxSessions ?? 10,
     bufferSize: opts.bufferSize ?? 1024,
     persistPath: opts.persistPath ?? "/tmp/test-home/system/terminal-sessions.json",
+    autoRestore: opts.autoRestore ?? false,
     ...opts,
   }, spawnFn ?? createMockSpawn());
 }
@@ -83,6 +84,7 @@ describe("SessionRegistry", () => {
     });
 
     it("rejects shell not in allowlist and falls back to default", () => {
+      vi.stubEnv("SHELL", "/bin/zsh");
       const mockSpawn = createMockSpawn();
       const registry = createRegistry({}, mockSpawn);
       registry.create("/home", "/usr/bin/python3");


### PR DESCRIPTION
## Summary

- make the invalid-shell fallback test declare its intended zsh environment instead of inheriting the runner shell
- disable auto-restore in the shared SessionRegistry unit-test factory so prior temp state cannot insert unexpected spawn calls
- repair Unit Tests shard 4 on main run 33089301601 without changing production behavior

## Tests

- SHELL=/bin/bash pnpm exec vitest run tests/gateway/session-registry.test.ts (52 passed)
- bun run typecheck (passed)
- bun run check:patterns (passed; existing warnings only)
- SHELL=/bin/bash bun run test -- --shard=4/4 confirmed SessionRegistry 52/52; the loaded local host later hit unrelated 80-second timeouts in golden-snapshot/proxy-routing tests that passed on the original main CI run, so the label-gated GitHub run remains the authoritative broad result

## Review/Monitoring

- following the worktree-pr-monitor loop
- awaiting latest trusted Greptile 5/5 before applying ready-for-ci
- will monitor label-triggered CI and remove the label before any corrective push if a required check fails

## Invariants

- source of truth: production shell selection still prefers an allowed process SHELL and otherwise falls back to zsh
- lock/transaction scope: not applicable; test-only change
- acceptable orphan states: none introduced
- auth source of truth: unchanged
- deferred scope: unrelated locally resource-bound test timeouts are delegated to fresh GitHub runners for confirmation