### PR TITLE
feat(ci): add coverage-aware main queue

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,6 +28,21 @@ logs and artifacts.
 Docs-only changes still run targeted docs contract tests through `Docs Contract Tests`.
 Expensive jobs remain path-aware.
 
+### Main CI queue and coverage frontier
+
+Main pushes enter GitHub's FIFO concurrency queue in `ci.yml` (up to the
+platform's 100-run `queue: max` limit). A non-doc push also starts
+`ci-supersede.yml`, whose only write permission is cancelling older active CI
+runs whose heads are ancestors of the new commit. Docs-only successors
+queue behind broader runs instead of cancelling them.
+
+When a queued run is admitted, `scripts/ci/main-ci-coverage.mjs` finds the latest
+successful `CI coverage-v1` ancestor and treats it as the coverage frontier. The
+run plans against the complete frontier-to-head diff, not only the newest commit.
+Consequently, a failed or cancelled predecessor is automatically absorbed into
+the successor's source, docs-contract, pattern-scan, and React Doctor scope. If
+no trusted frontier exists, the run bootstraps from Git's empty tree.
+
 ## Release Artifacts
 
 Matrix OS does not publish customer runtime Docker images. The customer runtime
@@ -58,6 +73,7 @@ OTA payloads.
 | Workflow | Owner | When it runs | Required? |
 | --- | --- | --- | --- |
 | `ci.yml` | Core code validation | `ready-for-ci`, ready PRs, merge queue, `main`, manual | Yes, via `CI Results` |
+| `ci-supersede.yml` | Safe main-CI supersession | Non-doc pushes to `main` | No; optimization only, queueing remains safe if it fails |
 | `docker-test.yml` | Legacy/local Docker scenario validation | Docker/local-runtime changes on `ready-for-ci`, ready PRs, and `main`; every merge queue, nightly, and manual run | Required when Docker/local-runtime paths are touched |
 | `host-bundle-release.yml` | VPS-native customer runtime release | `main`, `v*` tags, manual | Required for host bundle publishing |
 | `platform-cloud-run.yml` | Platform/app-shell Cloud Run deployment | `main` when platform/auth-shell inputs change, manual | Required for app.matrix-os.com platform changes |

--- a/.github/workflows/ci-supersede.yml
+++ b/.github/workflows/ci-supersede.yml
@@ -1,0 +1,32 @@
+name: Supersede Main CI
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'specs/**'
+      - '**/*.md'
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  supersede:
+    name: Supersede covered main CI runs
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Cancel covered ancestor runs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/ci/supersede-main-ci.mjs

--- a/.github/workflows/ci-supersede.yml
+++ b/.github/workflows/ci-supersede.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+run-name: CI coverage-v1 · ${{ github.sha }}
 
 on:
   workflow_dispatch:
@@ -11,7 +12,11 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name != 'ready-for-ci' && github.run_id || 'shared' }}
-  cancel-in-progress: true
+  queue: max
+
+permissions:
+  actions: read
+  contents: read
 
 jobs:
   changes:
@@ -19,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     outputs:
+      base_sha: ${{ steps.changed.outputs.base_sha }}
+      bootstrap: ${{ steps.changed.outputs.bootstrap }}
       should_run: ${{ steps.changed.outputs.should_run }}
       docs_contract_tests: ${{ steps.changed.outputs.docs_contract_tests }}
     steps:
@@ -40,7 +47,7 @@ jobs:
             echo "Checkout fetch attempt $attempt/$CHECKOUT_MAX_ATTEMPTS"
             if timeout --foreground --kill-after=5s "${CHECKOUT_TIMEOUT_SECONDS}s" \
               git -c http.extraheader="AUTHORIZATION: basic $auth_header" \
-                fetch --no-tags --prune --no-recurse-submodules --depth=1 \
+                fetch --no-tags --prune --no-recurse-submodules \
                 origin "$GITHUB_SHA" \
               && git checkout --force --detach "$GITHUB_SHA"; then
               echo "Checkout fetch succeeded on attempt $attempt/$CHECKOUT_MAX_ATTEMPTS"
@@ -63,9 +70,17 @@ jobs:
         env:
           PR_ACTION: ${{ github.event.action || '' }}
           PR_LABEL_NAME: ${{ github.event.label.name || '' }}
-          GITHUB_EVENT_BEFORE: ${{ github.event.before || '' }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+
+          # Main runs are admitted through the queue. Plan from the last
+          # successful coverage-aware ancestor so failed or cancelled work is
+          # automatically absorbed by the next run.
+          if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            node scripts/ci/main-ci-coverage.mjs >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           # Manual and merge-queue runs must execute CI regardless of changed paths.
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] || [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then
@@ -90,17 +105,8 @@ jobs:
             exit 0
           fi
 
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
-            changed_files="$(git diff --name-only "origin/$GITHUB_BASE_REF" "$GITHUB_SHA")"
-          else
-            zero_sha="0000000000000000000000000000000000000000"
-            if [ -n "${GITHUB_EVENT_BEFORE:-}" ] && [ "$GITHUB_EVENT_BEFORE" != "$zero_sha" ] && git cat-file -e "${GITHUB_EVENT_BEFORE}^{commit}" 2>/dev/null; then
-              changed_files="$(git diff --name-only "$GITHUB_EVENT_BEFORE" "$GITHUB_SHA")"
-            else
-              changed_files="$(git show --pretty= --name-only "$GITHUB_SHA")"
-            fi
-          fi
+          git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
+          changed_files="$(git diff --name-only "origin/$GITHUB_BASE_REF" "$GITHUB_SHA")"
 
           should_run=false
           docs_contract_tests=false
@@ -108,7 +114,7 @@ jobs:
             [ -z "$file" ] && continue
             case "$file" in
               docs/*|specs/*|*.md) docs_contract_tests=true ;;
-              *) should_run=true; docs_contract_tests=false; break ;;
+              *) should_run=true ;;
             esac
           done <<EOF
           $changed_files
@@ -216,9 +222,23 @@ jobs:
 
       - name: Run CLAUDE.md pattern scanner on changed files
         if: needs.changes.outputs.should_run == 'true'
+        env:
+          COVERAGE_BASE_SHA: ${{ needs.changes.outputs.base_sha }}
+          COVERAGE_BOOTSTRAP: ${{ needs.changes.outputs.bootstrap }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             ./scripts/review/check-patterns.sh --diff origin/${{ github.base_ref }}
+          elif [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            BEFORE="$COVERAGE_BASE_SHA"
+            if [ -z "$BEFORE" ]; then
+              echo "Main CI coverage base is missing" >&2
+              exit 1
+            fi
+            if [ "$COVERAGE_BOOTSTRAP" = "true" ]; then
+              ./scripts/review/check-patterns.sh
+            else
+              ./scripts/review/check-patterns.sh --diff "$BEFORE"
+            fi
           else
             # On push: only scan files changed in this push range.
             # github.event.before is the pre-push tip; on force-push or first
@@ -259,6 +279,7 @@ jobs:
       - name: Audit React code (project dirs with changed .tsx/.jsx)
         if: needs.changes.outputs.should_run == 'true'
         env:
+          COVERAGE_BASE_SHA: ${{ needs.changes.outputs.base_sha }}
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
           HEAD_SHA: ${{ github.sha }}
@@ -267,6 +288,13 @@ jobs:
           if [ "$EVENT_NAME" = "pull_request" ]; then
             git fetch --no-tags --depth=1 origin "$BASE_REF"
             base="origin/$BASE_REF"
+          elif [ "$EVENT_NAME" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            BEFORE="$COVERAGE_BASE_SHA"
+            if [ -z "$BEFORE" ]; then
+              echo "Main CI coverage base is missing" >&2
+              exit 1
+            fi
+            base="$BEFORE"
           else
             base="HEAD^"
             git rev-parse --verify "$base" >/dev/null 2>&1 || base="HEAD"

--- a/scripts/ci/git-coverage.mjs
+++ b/scripts/ci/git-coverage.mjs
@@ -1,0 +1,52 @@
+import { spawnSync } from "node:child_process";
+
+export const EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+export const GIT_TIMEOUT_MS = 30_000;
+export const GIT_MAX_BUFFER_BYTES = 4 * 1024 * 1024;
+export const MAX_CHANGED_PATHS = 10_000;
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+export function assertCommitSha(sha) {
+  if (typeof sha !== "string" || !SHA_PATTERN.test(sha)) {
+    throw new Error("Commit SHA is invalid");
+  }
+}
+
+export function isGitAncestor(candidateSha, targetSha, { spawnGit = spawnSync } = {}) {
+  assertCommitSha(candidateSha);
+  assertCommitSha(targetSha);
+  const result = spawnGit("git", ["merge-base", "--is-ancestor", candidateSha, targetSha], gitOptions());
+  if (result.error) throw new Error("Git ancestry check failed");
+  if (result.status === 0) return true;
+  if (result.status === 1) return false;
+  throw new Error("Git ancestry check failed");
+}
+
+export function readGitChangedPaths(baseSha, targetSha, { spawnGit = spawnSync } = {}) {
+  assertCommitSha(baseSha);
+  assertCommitSha(targetSha);
+  const result = spawnGit(
+    "git",
+    ["diff", "--name-only", "--no-renames", "-z", `${baseSha}..${targetSha}`, "--"],
+    gitOptions(),
+  );
+  if (result.error || result.status !== 0) {
+    throw new Error("Git coverage diff failed");
+  }
+  const stdout = typeof result.stdout === "string" ? result.stdout : "";
+  const paths = stdout.split("\0").filter(Boolean);
+  if (paths.length > MAX_CHANGED_PATHS) {
+    throw new Error("Git coverage diff exceeds the changed-path limit");
+  }
+  return paths;
+}
+
+function gitOptions() {
+  return {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: GIT_TIMEOUT_MS,
+    maxBuffer: GIT_MAX_BUFFER_BYTES,
+  };
+}

--- a/scripts/ci/github-actions-api.mjs
+++ b/scripts/ci/github-actions-api.mjs
@@ -1,0 +1,74 @@
+export const GITHUB_REQUEST_TIMEOUT_MS = 10_000;
+export const MAX_GITHUB_RESPONSE_BYTES = 4 * 1024 * 1024;
+
+const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/;
+
+export function assertGitHubConfig(repository, token) {
+  if (
+    !REPOSITORY_PATTERN.test(repository) ||
+    typeof token !== "string" ||
+    token.length === 0 ||
+    token.length > 8192 ||
+    /[\0\r\n]/.test(token)
+  ) {
+    throw new Error("GitHub Actions configuration is invalid");
+  }
+}
+
+export async function requestGitHubJson(endpoint, options) {
+  const response = await requestGitHub(endpoint, options);
+  return readBoundedJson(response);
+}
+
+export async function requestGitHub(endpoint, {
+  token,
+  fetchImpl = fetch,
+  method = "GET",
+  acceptedStatuses = [200],
+}) {
+  let response;
+  try {
+    response = await fetchImpl(endpoint, {
+      method,
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "x-github-api-version": "2022-11-28",
+      },
+      redirect: "error",
+      signal: AbortSignal.timeout(GITHUB_REQUEST_TIMEOUT_MS),
+    });
+  } catch {
+    throw new Error("GitHub Actions API is unavailable");
+  }
+  if (!acceptedStatuses.includes(response.status)) {
+    throw new Error("GitHub Actions API request failed");
+  }
+  return response;
+}
+
+async function readBoundedJson(response) {
+  if (!response.body) throw new Error("GitHub Actions API response is invalid");
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_GITHUB_RESPONSE_BYTES) {
+        throw new Error("GitHub Actions API response is too large");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch (error) {
+    if (error instanceof SyntaxError) throw new Error("GitHub Actions API response is invalid");
+    throw error;
+  }
+}

--- a/scripts/ci/github-actions-api.mjs
+++ b/scripts/ci/github-actions-api.mjs
@@ -38,7 +38,12 @@ export async function requestGitHub(endpoint, {
       redirect: "error",
       signal: AbortSignal.timeout(GITHUB_REQUEST_TIMEOUT_MS),
     });
-  } catch {
+  } catch (error) {
+    const rawMessage = error instanceof Error
+      ? error.message
+      : "Unknown GitHub Actions API error";
+    const diagnostic = rawMessage.replace(/[\0\r\n]/g, " ").slice(0, 500);
+    console.error(`GitHub Actions API request failed: ${diagnostic}`);
     throw new Error("GitHub Actions API is unavailable");
   }
   if (!acceptedStatuses.includes(response.status)) {

--- a/scripts/ci/main-ci-coverage.mjs
+++ b/scripts/ci/main-ci-coverage.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from "node:url";
+import {
+  assertGitHubConfig,
+  GITHUB_REQUEST_TIMEOUT_MS,
+  MAX_GITHUB_RESPONSE_BYTES,
+  requestGitHubJson,
+} from "./github-actions-api.mjs";
+import {
+  assertCommitSha,
+  EMPTY_TREE_SHA,
+  isGitAncestor,
+  MAX_CHANGED_PATHS,
+  readGitChangedPaths,
+} from "./git-coverage.mjs";
+
+export { GITHUB_REQUEST_TIMEOUT_MS, MAX_GITHUB_RESPONSE_BYTES };
+export const COVERAGE_RUN_PREFIX = "CI coverage-v1 · ";
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+export function classifyMainCiChanges(changedPaths) {
+  if (!Array.isArray(changedPaths)) {
+    throw new Error("Changed paths must be an array");
+  }
+  if (changedPaths.length > MAX_CHANGED_PATHS) {
+    throw new Error("Changed path count exceeds the limit");
+  }
+  let shouldRun = false;
+  let docsContractTests = false;
+
+  for (const path of changedPaths) {
+    if (typeof path !== "string" || path.length > 4096 || /[\0\r\n]/.test(path)) {
+      throw new Error("Changed path is invalid");
+    }
+    if (path.startsWith("docs/") || path.startsWith("specs/") || path.endsWith(".md")) {
+      docsContractTests = true;
+    } else {
+      shouldRun = true;
+    }
+  }
+
+  return { shouldRun, docsContractTests };
+}
+
+export async function selectCoverageFrontier(runs, targetSha, { isAncestor }) {
+  for (const run of runs) {
+    if (
+      typeof run?.headSha !== "string" ||
+      run.headSha === targetSha ||
+      typeof run?.displayTitle !== "string" ||
+      !run.displayTitle.startsWith(COVERAGE_RUN_PREFIX)
+    ) {
+      continue;
+    }
+    if (await isAncestor(run.headSha, targetSha)) {
+      return run.headSha;
+    }
+  }
+  return null;
+}
+
+export async function buildMainCiCoveragePlan(
+  { targetSha, successfulRuns },
+  { isAncestor, getEmptyTreeSha, getChangedPaths },
+) {
+  const frontier = await selectCoverageFrontier(successfulRuns, targetSha, { isAncestor });
+  const baseSha = frontier ?? await getEmptyTreeSha();
+  const changedPaths = await getChangedPaths(baseSha, targetSha);
+  const decision = classifyMainCiChanges(changedPaths);
+
+  return {
+    baseSha,
+    bootstrap: frontier === null,
+    ...decision,
+  };
+}
+
+export async function listSuccessfulCoverageRuns({ repository, token, fetchImpl = fetch }) {
+  assertGitHubConfig(repository, token);
+
+  const endpoint = `https://api.github.com/repos/${repository}/actions/workflows/ci.yml/runs?branch=main&event=push&status=success&per_page=100`;
+  const body = await requestGitHubJson(endpoint, { token, fetchImpl });
+  if (!Array.isArray(body?.workflow_runs)) {
+    throw new Error("Main CI coverage history is invalid");
+  }
+  if (body.workflow_runs.length > 100) {
+    throw new Error("Main CI coverage history exceeds the run limit");
+  }
+  return body.workflow_runs.flatMap((run) => {
+    if (
+      !Number.isSafeInteger(run?.id) ||
+      typeof run?.head_sha !== "string" ||
+      !SHA_PATTERN.test(run.head_sha) ||
+      typeof run?.display_title !== "string"
+    ) {
+      return [];
+    }
+    return [{ id: run.id, headSha: run.head_sha, displayTitle: run.display_title }];
+  });
+}
+
+export async function runMainCiCoverage({ repository, targetSha, token, fetchImpl = fetch }) {
+  assertCommitSha(targetSha);
+  const successfulRuns = await listSuccessfulCoverageRuns({ repository, token, fetchImpl });
+  return buildMainCiCoveragePlan(
+    { targetSha, successfulRuns },
+    {
+      isAncestor: async (candidate, target) => isGitAncestor(candidate, target),
+      getEmptyTreeSha: async () => EMPTY_TREE_SHA,
+      getChangedPaths: async (base, target) => readGitChangedPaths(base, target),
+    },
+  );
+}
+
+async function main() {
+  const plan = await runMainCiCoverage({
+    repository: process.env.GITHUB_REPOSITORY ?? "",
+    targetSha: process.env.GITHUB_SHA ?? "",
+    token: process.env.GITHUB_TOKEN ?? "",
+  });
+  process.stderr.write(
+    `main-ci-coverage: base=${plan.baseSha} bootstrap=${plan.bootstrap} source=${plan.shouldRun} docs=${plan.docsContractTests}\n`,
+  );
+  process.stdout.write([
+    `base_sha=${plan.baseSha}`,
+    `bootstrap=${plan.bootstrap}`,
+    `should_run=${plan.shouldRun}`,
+    `docs_contract_tests=${plan.docsContractTests}`,
+    "",
+  ].join("\n"));
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : "Unknown main CI coverage failure";
+    process.stderr.write(`main-ci-coverage: ${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ci/supersede-main-ci.mjs
+++ b/scripts/ci/supersede-main-ci.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from "node:url";
+import {
+  assertGitHubConfig,
+  requestGitHub,
+  requestGitHubJson,
+} from "./github-actions-api.mjs";
+import { assertCommitSha, isGitAncestor } from "./git-coverage.mjs";
+
+const ACTIVE_RUN_STATUSES = new Set([
+  "in_progress",
+  "pending",
+  "queued",
+  "requested",
+  "waiting",
+]);
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+export async function findSupersededMainCiRuns(runs, targetSha, { isAncestor }) {
+  const superseded = [];
+
+  for (const run of runs) {
+    if (
+      run?.event !== "push" ||
+      !ACTIVE_RUN_STATUSES.has(run?.status) ||
+      typeof run?.headSha !== "string" ||
+      run.headSha === targetSha ||
+      !Number.isSafeInteger(run?.id)
+    ) {
+      continue;
+    }
+    if (await isAncestor(run.headSha, targetSha)) {
+      superseded.push({ id: run.id, headSha: run.headSha });
+    }
+  }
+
+  return superseded;
+}
+
+export async function cancelSupersededMainCiRuns(runs, { cancelRun }) {
+  let cancelled = 0;
+  let alreadyCompleted = 0;
+
+  for (const run of runs) {
+    const outcome = await cancelRun(run.id);
+    if (outcome === "cancelled") cancelled += 1;
+    else if (outcome === "already_completed") alreadyCompleted += 1;
+    else throw new Error("Main CI cancellation returned an invalid outcome");
+  }
+
+  return { cancelled, alreadyCompleted };
+}
+
+export async function supersedeMainCi(
+  config,
+  { listRuns, isAncestor, cancelRun },
+) {
+  const runs = await listRuns(config);
+  const superseded = await findSupersededMainCiRuns(runs, config.targetSha, { isAncestor });
+  const result = await cancelSupersededMainCiRuns(superseded, { cancelRun });
+  return { selected: superseded.length, ...result };
+}
+
+export async function listActiveMainCiRuns({ repository, token, fetchImpl = fetch }) {
+  assertGitHubConfig(repository, token);
+  const endpoint = `https://api.github.com/repos/${repository}/actions/workflows/ci.yml/runs?branch=main&event=push&per_page=100`;
+  const body = await requestGitHubJson(endpoint, { token, fetchImpl });
+  if (!Array.isArray(body?.workflow_runs)) {
+    throw new Error("Main CI queue response is invalid");
+  }
+  if (body.workflow_runs.length > 100) {
+    throw new Error("Main CI queue response exceeds the run limit");
+  }
+  return body.workflow_runs.flatMap((run) => {
+    if (
+      !Number.isSafeInteger(run?.id) ||
+      typeof run?.head_sha !== "string" ||
+      !SHA_PATTERN.test(run.head_sha) ||
+      typeof run?.event !== "string" ||
+      typeof run?.status !== "string"
+    ) {
+      return [];
+    }
+    return [{
+      id: run.id,
+      headSha: run.head_sha,
+      event: run.event,
+      status: run.status,
+    }];
+  });
+}
+
+export async function cancelMainCiRun(
+  runId,
+  { repository, token, fetchImpl = fetch },
+) {
+  assertGitHubConfig(repository, token);
+  if (!Number.isSafeInteger(runId) || runId <= 0) {
+    throw new Error("Main CI run ID is invalid");
+  }
+  const endpoint = `https://api.github.com/repos/${repository}/actions/runs/${runId}/cancel`;
+  const response = await requestGitHub(endpoint, {
+    token,
+    fetchImpl,
+    method: "POST",
+    acceptedStatuses: [202, 409],
+  });
+  return response.status === 202 ? "cancelled" : "already_completed";
+}
+
+export async function runMainCiSupersession({ repository, targetSha, token, fetchImpl = fetch }) {
+  assertCommitSha(targetSha);
+  const config = { repository, targetSha, token, fetchImpl };
+  return supersedeMainCi(config, {
+    listRuns: () => listActiveMainCiRuns(config),
+    isAncestor: async (candidate, target) => isGitAncestor(candidate, target),
+    cancelRun: (runId) => cancelMainCiRun(runId, config),
+  });
+}
+
+async function main() {
+  const result = await runMainCiSupersession({
+    repository: process.env.GITHUB_REPOSITORY ?? "",
+    targetSha: process.env.GITHUB_SHA ?? "",
+    token: process.env.GITHUB_TOKEN ?? "",
+  });
+  process.stdout.write(
+    `Main CI supersession selected=${result.selected} cancelled=${result.cancelled} already_completed=${result.alreadyCompleted}\n`,
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : "Unknown main CI supersession failure";
+    process.stderr.write(`main-ci-supersede: ${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -134,6 +134,12 @@ describe('CI workflows', () => {
     expect(superseder).toContain("- 'docs/**'");
     expect(superseder).toContain("- 'specs/**'");
     expect(superseder).toContain("- '**/*.md'");
+    expect(superseder).toContain(
+      'uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6',
+    );
+    expect(superseder).toContain(
+      'uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6',
+    );
     expect(superseder).toContain('node scripts/ci/supersede-main-ci.mjs');
   });
 

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -57,6 +57,10 @@ if [[ " $* " == *" fetch "* ]]; then
     echo "fetch did not request the event commit" >&2
     exit 64
   fi
+  if [[ " $* " == *" --depth=1 "* ]]; then
+    echo "event commit fetch must retain full history" >&2
+    exit 65
+  fi
   attempt=0
   if [ -f "$FAKE_GIT_FETCH_ATTEMPTS" ]; then
     attempt="$(cat "$FAKE_GIT_FETCH_ATTEMPTS")"
@@ -117,6 +121,22 @@ describe('CI workflows', () => {
     ['STRIPE_PRICE_MATRIX_MAX_ANNUAL', 'stripe-price-matrix-max-annual'],
   ] as const;
 
+  it('queues main CI runs and delegates only full-plan supersession to a narrow workflow', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/ci.yml'), 'utf8');
+    const superseder = readFileSync(join(root, '.github/workflows/ci-supersede.yml'), 'utf8');
+
+    expect(workflow).toContain('run-name: CI coverage-v1');
+    expect(workflow).toContain('queue: max');
+    expect(workflow).not.toContain('cancel-in-progress:');
+    expect(superseder).toContain('actions: write');
+    expect(superseder).toContain('paths-ignore:');
+    expect(superseder).toContain("- 'docs/**'");
+    expect(superseder).toContain("- 'specs/**'");
+    expect(superseder).toContain("- '**/*.md'");
+    expect(superseder).toContain('node scripts/ci/supersede-main-ci.mjs');
+  });
+
   it('exposes a stable aggregate CI result job for branch protection', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/ci.yml'), 'utf8');
@@ -138,7 +158,7 @@ describe('CI workflows', () => {
     expect(workflow).toContain('Branch protection should require this aggregate job');
   });
 
-  it('keeps CI change detection within its bounded checkout budget', () => {
+  it('plans main coverage from the last trusted frontier and wires its range into diff checks', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/ci.yml'), 'utf8');
     const changesJob = workflow.slice(
@@ -157,6 +177,12 @@ describe('CI workflows', () => {
     expect(changesJob).toContain('git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"');
     expect(changesJob).not.toContain('uses: actions/checkout@v6');
     expect(changesJob).not.toContain('fetch-depth: 0');
+    expect(changesJob).toContain('node scripts/ci/main-ci-coverage.mjs >> "$GITHUB_OUTPUT"');
+    expect(workflow).toContain('base_sha: ${{ steps.changed.outputs.base_sha }}');
+    expect(workflow).toContain('COVERAGE_BASE_SHA: ${{ needs.changes.outputs.base_sha }}');
+    expect(workflow).toContain('COVERAGE_BOOTSTRAP: ${{ needs.changes.outputs.bootstrap }}');
+    expect(workflow).toContain('if [ "$COVERAGE_BOOTSTRAP" = "true" ]; then');
+    expect(workflow).toContain('BEFORE="$COVERAGE_BASE_SHA"');
   });
 
   it('recovers when the first change-detection checkout fetch fails transiently', () => {
@@ -226,6 +252,9 @@ describe('CI workflows', () => {
     expect(readme).toContain('host bundle release tests are blocking');
     expect(readme).toContain('React Doctor');
     expect(readme).toContain('Docs Contract Tests');
+    expect(readme).toContain('coverage frontier');
+    expect(readme).toContain('ci-supersede.yml');
+    expect(readme).toMatch(/Docs-only successors\s+queue behind broader runs/);
     expect(readme).toContain('Screenshot workflow removed');
   });
 

--- a/tests/scripts/ci-git-coverage.test.ts
+++ b/tests/scripts/ci-git-coverage.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  GIT_MAX_BUFFER_BYTES,
+  GIT_TIMEOUT_MS,
+  isGitAncestor,
+  readGitChangedPaths,
+} from "../../scripts/ci/git-coverage.mjs";
+
+describe("CI git coverage helpers", () => {
+  it("distinguishes a non-ancestor from an invalid git comparison", () => {
+    const spawnGit = vi.fn()
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 128, stdout: "", stderr: "bad revision" });
+
+    expect(isGitAncestor("a".repeat(40), "b".repeat(40), { spawnGit })).toBe(false);
+    expect(() => isGitAncestor("a".repeat(40), "b".repeat(40), { spawnGit }))
+      .toThrow("Git ancestry check failed");
+  });
+
+  it("reads a bounded NUL-delimited cumulative diff", () => {
+    const spawnGit = vi.fn(() => ({
+      status: 0,
+      stdout: "docs/a.md\0packages/gateway/src/server.ts\0",
+      stderr: "",
+    }));
+
+    expect(
+      readGitChangedPaths("a".repeat(40), "b".repeat(40), { spawnGit }),
+    ).toEqual(["docs/a.md", "packages/gateway/src/server.ts"]);
+    expect(spawnGit).toHaveBeenCalledWith(
+      "git",
+      [
+        "diff",
+        "--name-only",
+        "--no-renames",
+        "-z",
+        `${"a".repeat(40)}..${"b".repeat(40)}`,
+        "--",
+      ],
+      expect.objectContaining({
+        timeout: GIT_TIMEOUT_MS,
+        maxBuffer: GIT_MAX_BUFFER_BYTES,
+      }),
+    );
+  });
+});

--- a/tests/scripts/github-actions-api.test.ts
+++ b/tests/scripts/github-actions-api.test.ts
@@ -32,4 +32,23 @@ describe("CI GitHub Actions API client", () => {
     expect(failure).toMatchObject({ message: "GitHub Actions API request failed" });
     expect(String(failure)).not.toContain("provider secret");
   });
+
+  it("logs fetch diagnostics while preserving a generic caller error", async () => {
+    const diagnostic = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      await expect(
+        requestGitHub("https://api.github.com/fixed", {
+          token: "token",
+          fetchImpl: vi.fn(async () => {
+            throw new Error("DNS lookup timed out");
+          }),
+        }),
+      ).rejects.toThrow("GitHub Actions API is unavailable");
+      expect(diagnostic).toHaveBeenCalledWith(
+        "GitHub Actions API request failed: DNS lookup timed out",
+      );
+    } finally {
+      diagnostic.mockRestore();
+    }
+  });
 });

--- a/tests/scripts/github-actions-api.test.ts
+++ b/tests/scripts/github-actions-api.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  assertGitHubConfig,
+  MAX_GITHUB_RESPONSE_BYTES,
+  requestGitHub,
+  requestGitHubJson,
+} from "../../scripts/ci/github-actions-api.mjs";
+
+describe("CI GitHub Actions API client", () => {
+  it("rejects oversized or malformed credentials before constructing a request", () => {
+    expect(() => assertGitHubConfig("HamedMP/matrix-os", "x".repeat(8193)))
+      .toThrow("GitHub Actions configuration is invalid");
+    expect(() => assertGitHubConfig("HamedMP/matrix-os/extra", "token"))
+      .toThrow("GitHub Actions configuration is invalid");
+  });
+
+  it("bounds response bodies and keeps upstream details out of failures", async () => {
+    await expect(
+      requestGitHubJson("https://api.github.com/fixed", {
+        token: "token",
+        fetchImpl: vi.fn(async () => new Response(
+          JSON.stringify({ data: "x".repeat(MAX_GITHUB_RESPONSE_BYTES) }),
+          { status: 200 },
+        )),
+      }),
+    ).rejects.toThrow("GitHub Actions API response is too large");
+
+    const failure = await requestGitHub("https://api.github.com/fixed", {
+      token: "token",
+      fetchImpl: vi.fn(async () => new Response("provider secret", { status: 503 })),
+    }).catch((error: unknown) => error);
+    expect(failure).toMatchObject({ message: "GitHub Actions API request failed" });
+    expect(String(failure)).not.toContain("provider secret");
+  });
+});

--- a/tests/scripts/main-ci-coverage.test.ts
+++ b/tests/scripts/main-ci-coverage.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildMainCiCoveragePlan,
+  classifyMainCiChanges,
+  listSuccessfulCoverageRuns,
+  selectCoverageFrontier,
+} from "../../scripts/ci/main-ci-coverage.mjs";
+import { EMPTY_TREE_SHA, MAX_CHANGED_PATHS } from "../../scripts/ci/git-coverage.mjs";
+
+describe("main CI coverage planning", () => {
+  it("keeps both source and docs obligations for a mixed change set", () => {
+    expect(
+      classifyMainCiChanges([
+        "packages/gateway/src/server.ts",
+        "docs/dev/onboarding.md",
+      ]),
+    ).toEqual({
+      shouldRun: true,
+      docsContractTests: true,
+    });
+  });
+
+  it.each([
+    [["docs/dev/onboarding.md"], { shouldRun: false, docsContractTests: true }],
+    [["specs/123-queue/spec.md"], { shouldRun: false, docsContractTests: true }],
+    [["README.md"], { shouldRun: false, docsContractTests: true }],
+    [["packages/gateway/src/server.ts"], { shouldRun: true, docsContractTests: false }],
+    [[], { shouldRun: false, docsContractTests: false }],
+  ])("classifies %j without dropping independent obligations", (paths, expected) => {
+    expect(classifyMainCiChanges(paths)).toEqual(expected);
+  });
+
+  it("rejects an unbounded changed-path set", () => {
+    expect(() => classifyMainCiChanges(Array(MAX_CHANGED_PATHS + 1).fill("README.md")))
+      .toThrow("Changed path count exceeds the limit");
+  });
+
+  it("selects the newest successful coverage-aware ancestor as the frontier", async () => {
+    const runs = [
+      { headSha: "newer", displayTitle: "CI coverage-v1 · newer" },
+      { headSha: "untrusted", displayTitle: "CI" },
+      { headSha: "older", displayTitle: "CI coverage-v1 · older" },
+    ];
+
+    await expect(
+      selectCoverageFrontier(runs, "target", {
+        isAncestor: async (candidate, target) =>
+          target === "target" && candidate !== "newer",
+      }),
+    ).resolves.toBe("older");
+  });
+
+  it("promotes a queued docs commit when broader predecessor coverage did not succeed", async () => {
+    const changedRanges: Array<[string, string]> = [];
+
+    await expect(
+      buildMainCiCoveragePlan(
+        {
+          targetSha: "docs-head",
+          successfulRuns: [
+            { headSha: "last-green", displayTitle: "CI coverage-v1 · last-green" },
+          ],
+        },
+        {
+          isAncestor: async () => true,
+          getEmptyTreeSha: async () => "empty-tree",
+          getChangedPaths: async (base, head) => {
+            changedRanges.push([base, head]);
+            return ["packages/gateway/src/server.ts", "docs/dev/onboarding.md"];
+          },
+        },
+      ),
+    ).resolves.toEqual({
+      baseSha: "last-green",
+      bootstrap: false,
+      shouldRun: true,
+      docsContractTests: true,
+    });
+    expect(changedRanges).toEqual([["last-green", "docs-head"]]);
+  });
+
+  it("bootstraps from the empty tree when no trusted coverage run exists", async () => {
+    const getChangedPaths = vi.fn(async () => ["scripts/ci/main-ci-coverage.mjs"]);
+
+    await expect(
+      buildMainCiCoveragePlan(
+        { targetSha: "first-head", successfulRuns: [] },
+        {
+          isAncestor: async () => false,
+          getEmptyTreeSha: async () => EMPTY_TREE_SHA,
+          getChangedPaths,
+        },
+      ),
+    ).resolves.toEqual({
+      baseSha: EMPTY_TREE_SHA,
+      bootstrap: true,
+      shouldRun: true,
+      docsContractTests: false,
+    });
+    expect(getChangedPaths).toHaveBeenCalledWith(EMPTY_TREE_SHA, "first-head");
+  });
+
+  it("keeps a docs successor lightweight after its broader predecessor succeeds", async () => {
+    await expect(
+      buildMainCiCoveragePlan(
+        {
+          targetSha: "docs-head",
+          successfulRuns: [
+            { headSha: "full-green", displayTitle: "CI coverage-v1 · full-green" },
+          ],
+        },
+        {
+          isAncestor: async () => true,
+          getEmptyTreeSha: async () => EMPTY_TREE_SHA,
+          getChangedPaths: async () => ["docs/dev/releases.md"],
+        },
+      ),
+    ).resolves.toEqual({
+      baseSha: "full-green",
+      bootstrap: false,
+      shouldRun: false,
+      docsContractTests: true,
+    });
+  });
+
+  it("loads only bounded successful main-push history from the fixed GitHub API", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      workflow_runs: [
+        {
+          id: 42,
+          head_sha: "a".repeat(40),
+          display_title: "CI coverage-v1 · candidate",
+        },
+      ],
+    }), { status: 200 }));
+
+    await expect(
+      listSuccessfulCoverageRuns({
+        repository: "HamedMP/matrix-os",
+        token: "test-token",
+        fetchImpl,
+      }),
+    ).resolves.toEqual([
+      {
+        id: 42,
+        headSha: "a".repeat(40),
+        displayTitle: "CI coverage-v1 · candidate",
+      },
+    ]);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.github.com/repos/HamedMP/matrix-os/actions/workflows/ci.yml/runs?branch=main&event=push&status=success&per_page=100",
+      expect.objectContaining({
+        redirect: "error",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+});

--- a/tests/scripts/supersede-main-ci.test.ts
+++ b/tests/scripts/supersede-main-ci.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  cancelMainCiRun,
+  cancelSupersededMainCiRuns,
+  findSupersededMainCiRuns,
+  listActiveMainCiRuns,
+  supersedeMainCi,
+} from "../../scripts/ci/supersede-main-ci.mjs";
+
+describe("main CI supersession", () => {
+  it("cancels only active older main-push runs that are ancestors of the full successor", async () => {
+    const runs = [
+      { id: 1, headSha: "running-ancestor", event: "push", status: "in_progress" },
+      { id: 2, headSha: "queued-ancestor", event: "push", status: "queued" },
+      { id: 3, headSha: "same-head", event: "push", status: "queued" },
+      { id: 4, headSha: "newer-head", event: "push", status: "queued" },
+      { id: 5, headSha: "completed", event: "push", status: "completed" },
+      { id: 6, headSha: "pr-head", event: "pull_request", status: "in_progress" },
+    ];
+
+    await expect(
+      findSupersededMainCiRuns(runs, "same-head", {
+        isAncestor: async (candidate) => candidate.endsWith("ancestor"),
+      }),
+    ).resolves.toEqual([
+      { id: 1, headSha: "running-ancestor" },
+      { id: 2, headSha: "queued-ancestor" },
+    ]);
+  });
+
+  it("treats a completion race as safe while canceling every selected run", async () => {
+    const cancelRun = vi.fn()
+      .mockResolvedValueOnce("cancelled")
+      .mockResolvedValueOnce("already_completed");
+
+    await expect(
+      cancelSupersededMainCiRuns(
+        [
+          { id: 10, headSha: "first" },
+          { id: 11, headSha: "second" },
+        ],
+        { cancelRun },
+      ),
+    ).resolves.toEqual({ cancelled: 1, alreadyCompleted: 1 });
+    expect(cancelRun).toHaveBeenNthCalledWith(1, 10);
+    expect(cancelRun).toHaveBeenNthCalledWith(2, 11);
+  });
+
+  it("fails closed unless the full successor can load, compare, and cancel the queue", async () => {
+    const cancelRun = vi.fn(async () => "cancelled" as const);
+
+    await expect(
+      supersedeMainCi(
+        { repository: "HamedMP/matrix-os", targetSha: "target", token: "token" },
+        {
+          listRuns: async () => [
+            { id: 7, headSha: "ancestor", event: "push", status: "in_progress" },
+          ],
+          isAncestor: async () => true,
+          cancelRun,
+        },
+      ),
+    ).resolves.toEqual({ selected: 1, cancelled: 1, alreadyCompleted: 0 });
+    expect(cancelRun).toHaveBeenCalledWith(7);
+  });
+
+  it("uses bounded GitHub requests and accepts completion races from the cancel endpoint", async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        workflow_runs: [
+          {
+            id: 99,
+            head_sha: "a".repeat(40),
+            event: "push",
+            status: "queued",
+          },
+        ],
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 409 }));
+    const config = {
+      repository: "HamedMP/matrix-os",
+      token: "test-token",
+      fetchImpl,
+    };
+
+    await expect(listActiveMainCiRuns(config)).resolves.toEqual([
+      { id: 99, headSha: "a".repeat(40), event: "push", status: "queued" },
+    ]);
+    await expect(cancelMainCiRun(99, config)).resolves.toBe("already_completed");
+    expect(fetchImpl.mock.calls[0]?.[0]).toContain("actions/workflows/ci.yml/runs");
+    expect(fetchImpl.mock.calls[0]?.[1]).toEqual(expect.objectContaining({
+      redirect: "error",
+      signal: expect.any(AbortSignal),
+    }));
+    expect(fetchImpl.mock.calls[1]?.[1]).toEqual(expect.objectContaining({ method: "POST" }));
+  });
+});


### PR DESCRIPTION
## Summary

- replace latest-wins cancellation on `main` with GitHub's bounded FIFO `queue: max`
- compute each admitted run from the latest successful coverage-aware ancestor, so failed or cancelled commits are absorbed into the next cumulative test plan
- cancel older active ancestor runs only when a non-doc successor necessarily selects the full CI plan; docs-only successors remain queued
- keep supersession as a narrow, fail-safe optimization with focused coverage, API, git, and workflow contract tests

## Tests

- `pnpm exec vitest run tests/scripts/main-ci-coverage.test.ts tests/scripts/supersede-main-ci.test.ts tests/scripts/ci-git-coverage.test.ts tests/scripts/github-actions-api.test.ts tests/platform/ci-workflows.test.ts` (58 passed)
- `bun run typecheck`
- rebased onto `fix(ci): retry change-detection checkout fetches (#1354)` and preserved its bounded retry while retaining full git history for ancestry planning
- `./scripts/review/check-patterns.sh --diff origin/main`
- `node --check scripts/ci/github-actions-api.mjs scripts/ci/git-coverage.mjs scripts/ci/main-ci-coverage.mjs scripts/ci/supersede-main-ci.mjs`
- parsed both changed workflow files with the repository `yaml` dependency
- live read-only planner probe against current GitHub Actions history
- `bun run test` was stopped after 49 minutes in unrelated platform tests without a failure summary; the focused suite and PR CI remain the relevant gates

## Review / Monitoring

- Greptile round 1 findings fixed: bounded fetch diagnostics and immutable action pins in the privileged workflow
- current-head Greptile review: 5/5 on `d7e9869abc`, with zero unresolved threads
- exact-head `CI Results` green on `d7e9869abc` after rebasing onto current `main`; all required checks pass

## Invariants

- **Source of truth:** the newest successful `CI coverage-v1` run whose head is an ancestor of the admitted `main` SHA, plus the cumulative git diff from that frontier to the current head
- **Lock / transaction scope:** `ci.yml` serializes the branch through GitHub's concurrency queue; the separate superseder may cancel only active older `push` runs whose heads are ancestors of a non-doc successor
- **Acceptable orphan states:** if history lookup, ancestry validation, or cancellation fails, no predecessor is cancelled and queued runs remain safe; a cancellation/completion race is accepted only as GitHub HTTP 409
- **Auth source of truth:** the workflow-scoped GitHub token; normal CI has `actions: read`, while only the trusted `main` superseder receives `actions: write`
- **Deferred scope:** finer-grained per-package test-set supersets and queue compaction for docs-only successors are deferred; source changes deliberately use the existing full CI plan
