### PR TITLE
fix(platform): cover clean Preview VPS bootstrap

### DIFF
--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -244,9 +244,17 @@ jobs:
       HANDLE: ${{ needs.gate.outputs.handle }}
       VERSION: ${{ needs.gate.outputs.action == 'deploy_existing' && needs.gate.outputs.requested_version || needs.build.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout preview source
+        if: needs.gate.outputs.action == 'deploy'
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.gate.outputs.head_sha }}
+
+      - name: Checkout trusted workflow helpers
+        if: needs.gate.outputs.action == 'deploy_existing'
+        uses: actions/checkout@v6
+        with:
+          ref: main
 
       - name: Download bundle artifact
         if: needs.gate.outputs.action == 'deploy'

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -228,7 +228,7 @@ jobs:
     needs: [gate, build]
     if: always() && ((needs.gate.outputs.action == 'deploy' && needs.build.result == 'success') || needs.gate.outputs.action == 'deploy_existing')
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
     env:
       R2_ACCOUNT_ID: ${{ secrets.R2_BUNDLES_ACCOUNT_ID || secrets.R2_ACCOUNT_ID }}
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_BUNDLES_ACCESS_KEY_ID || secrets.R2_ACCESS_KEY_ID }}
@@ -239,6 +239,7 @@ jobs:
       PLATFORM_SECRET: ${{ secrets.PLATFORM_SECRET }}
       PREVIEW_CLERK_USER_ID: ${{ secrets.PREVIEW_CLERK_USER_ID }}
       PREVIEW_CLERK_ACCESS_USER_IDS: ${{ secrets.PREVIEW_CLERK_ACCESS_USER_IDS }}
+      PREVIEW_PROVISION_TIMEOUT_SECONDS: 3900
       HANDLE: ${{ needs.gate.outputs.handle }}
       VERSION: ${{ needs.gate.outputs.action == 'deploy_existing' && needs.gate.outputs.requested_version || needs.build.outputs.version }}
     steps:
@@ -355,17 +356,22 @@ jobs:
 
           if [ "$status" = "provisioning" ]; then
             echo "Waiting for the VPS to come up..."
-            deadline=$((SECONDS + 600))
+            deadline=$((SECONDS + PREVIEW_PROVISION_TIMEOUT_SECONDS))
             while true; do
               sleep 15
-              status="$(curl -fsS --max-time 30 \
+              machine="$(curl -fsS --max-time 30 \
                 -H "authorization: Bearer ${PLATFORM_SECRET}" \
                 "${PLATFORM_PUBLIC_URL}/vps/fleet" |
-                jq -r --arg h "$HANDLE" --arg id "$accepted_machine_id" \
-                  '[.machines[] | select(.handle == $h and .machineId == $id and .deletedAt == null)] | .[0].status // "absent"')"
+                jq -c --arg h "$HANDLE" --arg id "$accepted_machine_id" \
+                  '[.machines[] | select(.handle == $h and .machineId == $id and .deletedAt == null)] | (.[0] // {status: "absent", failureCode: null})')"
+              status="$(jq -r '.status' <<< "$machine")"
               [ "$status" = "running" ] && break
               if [ "$status" = "failed" ]; then
-                echo "Provisioning failed for ${HANDLE}" >&2
+                failure_code="$(jq -r '.failureCode // "unknown"' <<< "$machine")"
+                if ! printf '%s' "$failure_code" | grep -Eq '^[a-z][a-z0-9_]{0,63}$'; then
+                  failure_code=unknown
+                fi
+                echo "Provisioning failed for ${HANDLE} (code: ${failure_code})" >&2
                 exit 1
               fi
               if [ "$SECONDS" -ge "$deadline" ]; then

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -228,7 +228,7 @@ jobs:
     needs: [gate, build]
     if: always() && ((needs.gate.outputs.action == 'deploy' && needs.build.result == 'success') || needs.gate.outputs.action == 'deploy_existing')
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 105
     env:
       R2_ACCOUNT_ID: ${{ secrets.R2_BUNDLES_ACCOUNT_ID || secrets.R2_ACCOUNT_ID }}
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_BUNDLES_ACCESS_KEY_ID || secrets.R2_ACCESS_KEY_ID }}
@@ -240,11 +240,11 @@ jobs:
       PREVIEW_CLERK_USER_ID: ${{ secrets.PREVIEW_CLERK_USER_ID }}
       PREVIEW_CLERK_ACCESS_USER_IDS: ${{ secrets.PREVIEW_CLERK_ACCESS_USER_IDS }}
       PREVIEW_PROVISION_TIMEOUT_SECONDS: 3900
+      PREVIEW_INSTALL_TIMEOUT_SECONDS: 600
       HANDLE: ${{ needs.gate.outputs.handle }}
       VERSION: ${{ needs.gate.outputs.action == 'deploy_existing' && needs.gate.outputs.requested_version || needs.build.outputs.version }}
     steps:
       - uses: actions/checkout@v6
-        if: needs.gate.outputs.action == 'deploy'
         with:
           ref: ${{ needs.gate.outputs.head_sha }}
 
@@ -356,30 +356,7 @@ jobs:
 
           if [ "$status" = "provisioning" ]; then
             echo "Waiting for the VPS to come up..."
-            deadline=$((SECONDS + PREVIEW_PROVISION_TIMEOUT_SECONDS))
-            while true; do
-              sleep 15
-              machine="$(curl -fsS --max-time 30 \
-                -H "authorization: Bearer ${PLATFORM_SECRET}" \
-                "${PLATFORM_PUBLIC_URL}/vps/fleet" |
-                jq -c --arg h "$HANDLE" --arg id "$accepted_machine_id" \
-                  '[.machines[] | select(.handle == $h and .machineId == $id and .deletedAt == null)] | (.[0] // {status: "absent", failureCode: null})')"
-              status="$(jq -r '.status' <<< "$machine")"
-              [ "$status" = "running" ] && break
-              if [ "$status" = "failed" ]; then
-                failure_code="$(jq -r '.failureCode // "unknown"' <<< "$machine")"
-                if ! printf '%s' "$failure_code" | grep -Eq '^[a-z][a-z0-9_]{0,63}$'; then
-                  failure_code=unknown
-                fi
-                echo "Provisioning failed for ${HANDLE} (code: ${failure_code})" >&2
-                exit 1
-              fi
-              if [ "$SECONDS" -ge "$deadline" ]; then
-                echo "Timed out waiting for ${HANDLE} to reach running (last: ${status})" >&2
-                exit 1
-              fi
-              sleep 15
-            done
+            PREVIEW_MACHINE_ID="$accepted_machine_id" ./scripts/wait-preview-provisioning.sh
           fi
 
       - name: Deploy preview bundle to preview VPS
@@ -452,7 +429,7 @@ jobs:
           jq . /tmp/deploy.json
 
           echo "Waiting for ${HANDLE} to install ${VERSION}"
-          deadline=$((SECONDS + 600))
+          deadline=$((SECONDS + PREVIEW_INSTALL_TIMEOUT_SECONDS))
           transition_repair_attempted=false
           while true; do
             runtime="$(curl -fsS --max-time 30 \
@@ -502,7 +479,7 @@ jobs:
                     echo "Exact-version transition repair deploy failed with HTTP ${code}." >&2
                     exit 1
                   fi
-                  deadline=$((SECONDS + 600))
+                  deadline=$((SECONDS + PREVIEW_INSTALL_TIMEOUT_SECONDS))
                   sleep 15
                   continue
                 fi

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -125,6 +125,10 @@ jobs:
             exit 1
           fi
           if [ "$action" = "deploy_existing" ]; then
+            if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+              echo "Pinned Preview deployments must run from the trusted main workflow." >&2
+              exit 1
+            fi
             if ! printf '%s' "$REQUESTED_VERSION" |
               grep -Eq "^v[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}-pr${PR_NUMBER}(-[0-9]+-[0-9]+)?-[0-9a-f]{7}$" ||
               [ "${REQUESTED_VERSION##*-}" != "${head_sha:0:7}" ]; then

--- a/packages/platform/src/customer-vps-config.ts
+++ b/packages/platform/src/customer-vps-config.ts
@@ -103,7 +103,7 @@ export function loadCustomerVpsConfig(env: NodeJS.ProcessEnv = process.env): Cus
     // Clean-image bootstrap allows 15 minutes for the host bundle download
     // and 30 minutes for prerequisite preparation before Gateway can register.
     // Keep a bounded buffer for the remaining host setup and reconciliation.
-    registrationTokenTtlMs: numberFromEnv(env.CUSTOMER_VPS_REGISTRATION_TOKEN_TTL_MS, 60 * 60 * 1000),
+    registrationTokenTtlMs: 60 * 60 * 1000,
     reconciliationBatchSize: numberFromEnv(env.CUSTOMER_VPS_RECONCILIATION_BATCH_SIZE, 50),
     reconciliationStaleAfterMs: numberFromEnv(env.CUSTOMER_VPS_RECONCILIATION_STALE_AFTER_MS, 10 * 60 * 1000),
     maxProvisionAttempts: numberFromEnv(env.CUSTOMER_VPS_MAX_PROVISION_ATTEMPTS, 3),

--- a/packages/platform/src/customer-vps-config.ts
+++ b/packages/platform/src/customer-vps-config.ts
@@ -100,7 +100,10 @@ export function loadCustomerVpsConfig(env: NodeJS.ProcessEnv = process.env): Cus
     posthogPublicHost: env.NEXT_PUBLIC_POSTHOG_HOST ?? DEFAULT_POSTHOG_PUBLIC_HOST,
     posthogApiHost: env.NEXT_PUBLIC_POSTHOG_API_HOST ?? '',
     provisionEtaSeconds: numberFromEnv(env.CUSTOMER_VPS_PROVISION_ETA_SECONDS, 90),
-    registrationTokenTtlMs: numberFromEnv(env.CUSTOMER_VPS_REGISTRATION_TOKEN_TTL_MS, 15 * 60 * 1000),
+    // Clean-image bootstrap allows 15 minutes for the host bundle download
+    // and 30 minutes for prerequisite preparation before Gateway can register.
+    // Keep a bounded buffer for the remaining host setup and reconciliation.
+    registrationTokenTtlMs: numberFromEnv(env.CUSTOMER_VPS_REGISTRATION_TOKEN_TTL_MS, 60 * 60 * 1000),
     reconciliationBatchSize: numberFromEnv(env.CUSTOMER_VPS_RECONCILIATION_BATCH_SIZE, 50),
     reconciliationStaleAfterMs: numberFromEnv(env.CUSTOMER_VPS_RECONCILIATION_STALE_AFTER_MS, 10 * 60 * 1000),
     maxProvisionAttempts: numberFromEnv(env.CUSTOMER_VPS_MAX_PROVISION_ATTEMPTS, 3),

--- a/scripts/wait-preview-provisioning.sh
+++ b/scripts/wait-preview-provisioning.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${PLATFORM_PUBLIC_URL:?PLATFORM_PUBLIC_URL is required}"
+: "${PLATFORM_SECRET:?PLATFORM_SECRET is required}"
+: "${HANDLE:?HANDLE is required}"
+: "${PREVIEW_MACHINE_ID:?PREVIEW_MACHINE_ID is required}"
+: "${PREVIEW_PROVISION_TIMEOUT_SECONDS:?PREVIEW_PROVISION_TIMEOUT_SECONDS is required}"
+
+poll_seconds="${PREVIEW_PROVISION_POLL_SECONDS:-15}"
+if ! [[ "$HANDLE" =~ ^pr-[1-9][0-9]{0,9}$ ]]; then
+  echo "Preview handle is invalid." >&2
+  exit 64
+fi
+if ! [[ "$PREVIEW_MACHINE_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]; then
+  echo "Preview machine ID is invalid." >&2
+  exit 64
+fi
+if ! [[ "$PREVIEW_PROVISION_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || [ "$PREVIEW_PROVISION_TIMEOUT_SECONDS" -gt 7200 ]; then
+  echo "Preview provisioning timeout is invalid." >&2
+  exit 64
+fi
+if ! [[ "$poll_seconds" =~ ^[0-9]+$ ]] || [ "$poll_seconds" -gt 60 ]; then
+  echo "Preview provisioning poll interval is invalid." >&2
+  exit 64
+fi
+
+deadline=$((SECONDS + PREVIEW_PROVISION_TIMEOUT_SECONDS))
+while true; do
+  machine="$(curl -fsS --max-time 30 -H "authorization: Bearer ${PLATFORM_SECRET}" "${PLATFORM_PUBLIC_URL}/vps/fleet" |
+    jq -c --arg h "$HANDLE" --arg id "$PREVIEW_MACHINE_ID" '[.machines[] | select(.handle == $h and .machineId == $id and .deletedAt == null)] | (.[0] // {status: "absent", failureCode: null})')"
+  status="$(jq -r '.status' <<< "$machine")"
+  case "$status" in
+    running)
+      exit 0
+      ;;
+    failed)
+      failure_code="$(jq -r '.failureCode // "unknown"' <<< "$machine")"
+      if ! printf '%s' "$failure_code" | grep -Eq '^[a-z][a-z0-9_]{0,63}$'; then
+        failure_code=unknown
+      fi
+      echo "Provisioning failed for ${HANDLE} (code: ${failure_code})" >&2
+      exit 1
+      ;;
+    provisioning|absent)
+      ;;
+    *)
+      echo "Preview ${HANDLE} entered an unsupported provisioning state." >&2
+      exit 1
+      ;;
+  esac
+
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    echo "Timed out waiting for ${HANDLE} to reach running (last: ${status})" >&2
+    exit 1
+  fi
+  sleep "$poll_seconds"
+done

--- a/specs/092-threat-model/data-flows.md
+++ b/specs/092-threat-model/data-flows.md
@@ -48,7 +48,7 @@ VPS ─▶ R2 (presign prefix-scoped ✓, but shared standing full-bucket key, F
 | Postgres tenant password | Platform (HMAC) | VPS env + `credentials.json` | env `0640`; **`credentials.json` `0644`** | per-user | **F7** |
 | R2 access key / secret | Platform | every VPS | env `0640` | **full bucket, shared** | **F4** |
 | Platform verification token | Platform (HMAC handle) | VPS env | env `0640` | per-user | ok |
-| Registration token | Platform | VPS (ephemeral) | env `0640` | per-VPS, ~15 min TTL | F11 ↓ |
+| Registration token | Platform | VPS (ephemeral) | env `0640` | per-VPS, one-time, machine-bound, ≤60 min bootstrap TTL | F11 ↓ |
 | Stripe secret / webhook secret | Platform | Platform only | GCP Secret Mgr | platform | ok |
 | Clerk secret | Platform | Platform only | GCP Secret Mgr | platform | ok |
 | Platform secret (admin bearer) | Platform | Platform + shell proxy | env / GCP | platform | gates social/store (N1) |

--- a/tests/platform/customer-vps-config.test.ts
+++ b/tests/platform/customer-vps-config.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { loadCustomerVpsConfig } from '../../packages/platform/src/customer-vps-config.js';
+
+describe('customer VPS bootstrap configuration', () => {
+  it('keeps registration tokens at the bounded clean-bootstrap lifetime', () => {
+    expect(loadCustomerVpsConfig({}).registrationTokenTtlMs).toBe(60 * 60 * 1000);
+    expect(loadCustomerVpsConfig({
+      CUSTOMER_VPS_REGISTRATION_TOKEN_TTL_MS: '1800000',
+    }).registrationTokenTtlMs).toBe(60 * 60 * 1000);
+    expect(loadCustomerVpsConfig({
+      CUSTOMER_VPS_REGISTRATION_TOKEN_TTL_MS: '7200000',
+    }).registrationTokenTtlMs).toBe(60 * 60 * 1000);
+  });
+});

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -914,19 +914,7 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     );
     expect(workflow).toContain('if [ "$status" != "provisioning" ] && [ "$status" != "running" ]; then');
     expect(workflow.indexOf('Immediate fleet visibility for ${HANDLE}: ${status}'))
-      .toBeLessThan(workflow.indexOf('deadline=$((SECONDS + PREVIEW_PROVISION_TIMEOUT_SECONDS))'));
-  });
-
-  it('preview VPS workflow waits through registration expiry and reports the terminal failure code', () => {
-    const root = process.cwd();
-    const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
-    const deployJob = workflow.slice(workflow.indexOf('  deploy:'), workflow.indexOf('  cleanup:'));
-
-    expect(deployJob).toContain('timeout-minutes: 90');
-    expect(deployJob).toContain('PREVIEW_PROVISION_TIMEOUT_SECONDS: 3900');
-    expect(deployJob).toContain('deadline=$((SECONDS + PREVIEW_PROVISION_TIMEOUT_SECONDS))');
-    expect(deployJob).toContain(`failure_code="$(jq -r '.failureCode // "unknown"' <<< "$machine")"`);
-    expect(deployJob).toContain('Provisioning failed for ${HANDLE} (code: ${failure_code})');
+      .toBeLessThan(workflow.indexOf('PREVIEW_MACHINE_ID="$accepted_machine_id" ./scripts/wait-preview-provisioning.sh'));
   });
 
   it('preview VPS workflow safely resumes an existing active preview', () => {
@@ -956,13 +944,14 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
   it('preview VPS workflow excludes soft-retired rows from every fleet lookup', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
+    const provisioningWait = readFileSync(join(root, 'scripts/wait-preview-provisioning.sh'), 'utf8');
 
     expect(workflow.match(/select\(\.handle == \$h and \.status != "deleted" and \.deletedAt == null\)/g))
       .toHaveLength(2);
     expect(workflow).toContain(
       'select(.handle == $h and .machineId == $id and .runtimeSlot == $h and .deletedAt == null)',
     );
-    expect(workflow).toContain('select(.handle == $h and .machineId == $id and .deletedAt == null)');
+    expect(provisioningWait).toContain('select(.handle == $h and .machineId == $id and .deletedAt == null)');
     expect(workflow).toContain(
       'select(.handle == $h and .runtimeSlot == $h and .status != "deleted" and .deletedAt == null)',
     );

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -914,7 +914,19 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     );
     expect(workflow).toContain('if [ "$status" != "provisioning" ] && [ "$status" != "running" ]; then');
     expect(workflow.indexOf('Immediate fleet visibility for ${HANDLE}: ${status}'))
-      .toBeLessThan(workflow.indexOf('deadline=$((SECONDS + 600))'));
+      .toBeLessThan(workflow.indexOf('deadline=$((SECONDS + PREVIEW_PROVISION_TIMEOUT_SECONDS))'));
+  });
+
+  it('preview VPS workflow waits through registration expiry and reports the terminal failure code', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
+    const deployJob = workflow.slice(workflow.indexOf('  deploy:'), workflow.indexOf('  cleanup:'));
+
+    expect(deployJob).toContain('timeout-minutes: 90');
+    expect(deployJob).toContain('PREVIEW_PROVISION_TIMEOUT_SECONDS: 3900');
+    expect(deployJob).toContain('deadline=$((SECONDS + PREVIEW_PROVISION_TIMEOUT_SECONDS))');
+    expect(deployJob).toContain(`failure_code="$(jq -r '.failureCode // "unknown"' <<< "$machine")"`);
+    expect(deployJob).toContain('Provisioning failed for ${HANDLE} (code: ${failure_code})');
   });
 
   it('preview VPS workflow safely resumes an existing active preview', () => {

--- a/tests/platform/customer-vps-reliability.test.ts
+++ b/tests/platform/customer-vps-reliability.test.ts
@@ -110,8 +110,8 @@ describe('platform/customer-vps reliability', () => {
     const { service, hetzner, setClock } = createHarness();
     await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
 
-    // Advance past the 15-minute registration token TTL and the 10-minute stale window.
-    setClock('2026-04-26T12:16:00.000Z');
+    // Advance past the 60-minute registration token TTL and the 10-minute stale window.
+    setClock('2026-04-26T13:01:00.000Z');
     const result = await service.reconcileProvisioning();
 
     expect(result.failed).toBe(1);
@@ -126,8 +126,8 @@ describe('platform/customer-vps reliability', () => {
     const { service, setClock } = createHarness();
     await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
 
-    // 12 minutes: stale (>10m) but token still valid (<15m).
-    setClock('2026-04-26T12:12:00.000Z');
+    // 30 minutes: stale (>10m) but token still valid (<60m).
+    setClock('2026-04-26T12:30:00.000Z');
     const result = await service.reconcileProvisioning();
 
     expect(result.failed).toBe(0);
@@ -285,7 +285,7 @@ describe('platform/customer-vps reliability', () => {
     const { service, setClock } = createHarness();
     const first = await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
 
-    setClock('2026-04-26T12:16:00.000Z'); // past 15-minute TTL
+    setClock('2026-04-26T13:01:00.000Z'); // past 60-minute TTL
     await expect(
       service.register('reg-token', {
         machineId: first.machineId,

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -117,6 +117,15 @@ describe('platform/customer-vps', () => {
     expect(config.hostBundleUrl).toBe('https://app.matrix-os.com/system-bundles/stable/matrix-host-bundle.tar.gz');
   });
 
+  it('keeps the one-time registration token valid through the bounded clean bootstrap window', () => {
+    const config = loadCustomerVpsConfig({});
+
+    expect(config.registrationTokenTtlMs).toBe(60 * 60 * 1000);
+    expect(loadCustomerVpsConfig({
+      CUSTOMER_VPS_REGISTRATION_TOKEN_TTL_MS: '1800000',
+    }).registrationTokenTtlMs).toBe(30 * 60 * 1000);
+  });
+
   it('does not use the private PostHog ingest host as the public browser host', () => {
     const config = loadCustomerVpsConfig({
       POSTHOG_HOST: 'https://eu.i.posthog.com',

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -117,15 +117,6 @@ describe('platform/customer-vps', () => {
     expect(config.hostBundleUrl).toBe('https://app.matrix-os.com/system-bundles/stable/matrix-host-bundle.tar.gz');
   });
 
-  it('keeps the one-time registration token valid through the bounded clean bootstrap window', () => {
-    const config = loadCustomerVpsConfig({});
-
-    expect(config.registrationTokenTtlMs).toBe(60 * 60 * 1000);
-    expect(loadCustomerVpsConfig({
-      CUSTOMER_VPS_REGISTRATION_TOKEN_TTL_MS: '1800000',
-    }).registrationTokenTtlMs).toBe(30 * 60 * 1000);
-  });
-
   it('does not use the private PostHog ingest host as the public browser host', () => {
     const config = loadCustomerVpsConfig({
       POSTHOG_HOST: 'https://eu.i.posthog.com',

--- a/tests/platform/preview-vps-workflow.test.ts
+++ b/tests/platform/preview-vps-workflow.test.ts
@@ -44,13 +44,23 @@ describe('Preview VPS provisioning workflow', () => {
   it('budgets the job for provisioning, bounded repair, and workflow overhead', () => {
     const workflow = YAML.parse(readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8'));
     const deploy = workflow.jobs.deploy;
+    const checkoutSteps = deploy.steps.filter((step: { uses?: string }) => step.uses === 'actions/checkout@v6');
     const provisionSeconds = Number(deploy.env.PREVIEW_PROVISION_TIMEOUT_SECONDS);
     const installSeconds = Number(deploy.env.PREVIEW_INSTALL_TIMEOUT_SECONDS);
     const workflowOverheadSeconds = 15 * 60;
 
     expect(deploy['timeout-minutes'] * 60)
       .toBeGreaterThanOrEqual(provisionSeconds + (2 * installSeconds) + workflowOverheadSeconds);
-    expect(deploy.steps.find((step: { uses?: string }) => step.uses === 'actions/checkout@v6').if).toBeUndefined();
+    expect(checkoutSteps).toEqual([
+      expect.objectContaining({
+        if: "needs.gate.outputs.action == 'deploy'",
+        with: { ref: '${{ needs.gate.outputs.head_sha }}' },
+      }),
+      expect.objectContaining({
+        if: "needs.gate.outputs.action == 'deploy_existing'",
+        with: { ref: 'main' },
+      }),
+    ]);
     expect(deploy.steps.find((step: { name?: string }) => step.name === 'Provision or resume preview VPS').run)
       .toContain('PREVIEW_MACHINE_ID="$accepted_machine_id" ./scripts/wait-preview-provisioning.sh');
   });

--- a/tests/platform/preview-vps-workflow.test.ts
+++ b/tests/platform/preview-vps-workflow.test.ts
@@ -1,0 +1,105 @@
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { afterEach, describe, expect, it } from 'vitest';
+import YAML from 'yaml';
+
+const root = process.cwd();
+const waitScript = join(root, 'scripts/wait-preview-provisioning.sh');
+const tempDirectories: string[] = [];
+const machineId = '30000000-0000-4000-8000-000000000001';
+
+async function runWaitScript(machine: Record<string, unknown>, overrides: NodeJS.ProcessEnv = {}) {
+  const directory = await mkdtemp(join(tmpdir(), 'matrix-preview-wait-'));
+  tempDirectories.push(directory);
+  const curlPath = join(directory, 'curl');
+  await writeFile(curlPath, '#!/usr/bin/env bash\nprintf \'%s\\n\' "$FAKE_FLEET_RESPONSE"\n');
+  await chmod(curlPath, 0o755);
+
+  return spawnSync('bash', [waitScript], {
+    cwd: root,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${directory}:${process.env.PATH ?? ''}`,
+      PLATFORM_PUBLIC_URL: 'https://platform.example',
+      PLATFORM_SECRET: 'platform-secret',
+      HANDLE: 'pr-1340',
+      PREVIEW_MACHINE_ID: machineId,
+      PREVIEW_PROVISION_TIMEOUT_SECONDS: '5',
+      PREVIEW_PROVISION_POLL_SECONDS: '0',
+      FAKE_FLEET_RESPONSE: JSON.stringify({ machines: [machine] }),
+      ...overrides,
+    },
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+describe('Preview VPS provisioning workflow', () => {
+  it('budgets the job for provisioning, bounded repair, and workflow overhead', () => {
+    const workflow = YAML.parse(readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8'));
+    const deploy = workflow.jobs.deploy;
+    const provisionSeconds = Number(deploy.env.PREVIEW_PROVISION_TIMEOUT_SECONDS);
+    const installSeconds = Number(deploy.env.PREVIEW_INSTALL_TIMEOUT_SECONDS);
+    const workflowOverheadSeconds = 15 * 60;
+
+    expect(deploy['timeout-minutes'] * 60)
+      .toBeGreaterThanOrEqual(provisionSeconds + (2 * installSeconds) + workflowOverheadSeconds);
+    expect(deploy.steps.find((step: { uses?: string }) => step.uses === 'actions/checkout@v6').if).toBeUndefined();
+    expect(deploy.steps.find((step: { name?: string }) => step.name === 'Provision or resume preview VPS').run)
+      .toContain('PREVIEW_MACHINE_ID="$accepted_machine_id" ./scripts/wait-preview-provisioning.sh');
+  });
+
+  it('returns successfully when the accepted machine is running', async () => {
+    const result = await runWaitScript({
+      handle: 'pr-1340',
+      machineId,
+      status: 'running',
+      failureCode: null,
+      deletedAt: null,
+    });
+
+    expect(result.status).toBe(0);
+  });
+
+  it('reports a coarse terminal failure code', async () => {
+    const result = await runWaitScript({
+      handle: 'pr-1340',
+      machineId,
+      status: 'failed',
+      failureCode: 'registration_timeout',
+      deletedAt: null,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('code: registration_timeout');
+  });
+
+  it('replaces malformed failure codes and bounds the wait', async () => {
+    const malformed = await runWaitScript({
+      handle: 'pr-1340',
+      machineId,
+      status: 'failed',
+      failureCode: 'provider secret: do not print',
+      deletedAt: null,
+    });
+    const timedOut = await runWaitScript({
+      handle: 'pr-1340',
+      machineId,
+      status: 'provisioning',
+      failureCode: null,
+      deletedAt: null,
+    }, { PREVIEW_PROVISION_TIMEOUT_SECONDS: '0' });
+
+    expect(malformed.status).toBe(1);
+    expect(malformed.stderr).toContain('code: unknown');
+    expect(malformed.stderr).not.toContain('provider secret');
+    expect(timedOut.status).toBe(1);
+    expect(timedOut.stderr).toContain('Timed out waiting for pr-1340');
+  });
+});

--- a/tests/platform/preview-vps-workflow.test.ts
+++ b/tests/platform/preview-vps-workflow.test.ts
@@ -61,6 +61,8 @@ describe('Preview VPS provisioning workflow', () => {
         with: { ref: 'main' },
       }),
     ]);
+    expect(workflow.jobs.gate.steps.find((step: { name?: string }) => step.name === 'Decide action').run)
+      .toContain('[ "$GITHUB_REF" != "refs/heads/main" ]');
     expect(deploy.steps.find((step: { name?: string }) => step.name === 'Provision or resume preview VPS').run)
       .toContain('PREVIEW_MACHINE_ID="$accepted_machine_id" ./scripts/wait-preview-provisioning.sh');
   });


### PR DESCRIPTION
## Summary

- keep fresh Preview VPS registration tokens valid through the bounded clean-image bootstrap window while preserving one-time, machine-bound registration
- align Preview provisioning, install, and job deadlines with the actual clean bootstrap budget
- extract provisioning polling into a bounded executable script with coarse allowlisted failure codes
- add focused workflow/config/runtime tests and update the threat-model contract

## Tests

- `flox activate -- bun run typecheck` — passed
- `flox activate -- bun run check:patterns` — 0 violations; 5 existing repository warnings
- focused MAT-508 suite — 81/81 passed
- `flox activate -- pnpm --filter @matrix-os/platform build` — passed
- Preview workflow YAML parse, `bash -n`, and `git diff --check` — passed
- `flox activate -- bun run test` — 11,888 passed, 22 failed in 8 unrelated baseline/environment-sensitive files (macOS executing Linux host scripts, Unix socket path length, date timezone, and existing Terminal test timeouts); no MAT-508 focused test failed

## Invariants

### Source of truth

- Platform Postgres remains authoritative for the Preview machine, provisioning job, and hashed one-time registration token.
- The workflow polls the exact accepted `handle` and `machineId`; it never infers readiness from a different Preview slot.

### Lock/transaction scope

- No database transaction or locking behavior changes in this PR.
- External polling remains outside Platform database critical sections and is bounded by explicit curl and workflow deadlines.

### Acceptable orphan states

- A workflow-side timeout may leave a Preview machine in `provisioning`; Platform registration expiry/reconciliation marks it failed and existing retry/delete cleanup owns retirement.
- Provider errors remain server-side; the workflow receives only a bounded coarse failure code.

### Auth source of truth

- `PLATFORM_SECRET` bearer authentication remains authoritative for Preview provisioning and fleet reads.
- VPS registration still uses a hashed, one-time, machine-bound token; the longer TTL is fixed at 60 minutes and is not configurable.

### Deferred scope

- Golden-snapshot rollout and clean-bootstrap performance optimization are not enabled here.
- MAT-499 Hermes behavior is unchanged; its real Preview Desktop validation resumes after this Platform fix deploys.

Closes [MAT-508](https://linear.app/matrix-os/issue/MAT-508/fix-fresh-preview-vps-registration-timeout-during-clean-bootstrap)
