### PR TITLE
fix(onboarding): restore Clerk device signup styles

### DIFF
--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -183,9 +183,7 @@ function applyNoFrameHeaders(
   const captchaDirectives = options.allowClerkCaptcha
     ? " worker-src 'self' blob:; frame-src https://challenges.cloudflare.com;"
     : '';
-  const styleSrc = scriptNonce
-    ? `'self' 'nonce-${scriptNonce}' https://fonts.googleapis.com`
-    : `'self' 'unsafe-inline' https://fonts.googleapis.com`;
+  const styleSrc = `'self' 'unsafe-inline' https://fonts.googleapis.com`;
   c.header(
     'Content-Security-Policy',
     `frame-ancestors 'none'; script-src ${scriptSrc}${captchaSrc};${captchaDirectives} style-src ${styleSrc}; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'none'`,

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -900,10 +900,14 @@ describe("device routes", () => {
       expect(res.headers.get("content-security-policy")).toContain("https://challenges.cloudflare.com");
       expect(res.headers.get("content-security-policy")).toContain("worker-src 'self' blob:");
       expect(res.headers.get("content-security-policy")).toContain("frame-src https://challenges.cloudflare.com");
-      expect(res.headers.get("content-security-policy")).toContain("style-src 'self' 'nonce-");
+      expect(res.headers.get("content-security-policy")).toContain(
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+      );
       expect(res.headers.get("content-security-policy")).toContain("https://fonts.googleapis.com");
       expect(res.headers.get("content-security-policy")).toContain("font-src 'self' https://fonts.gstatic.com");
-      expect(res.headers.get("content-security-policy")).not.toContain("'unsafe-inline'");
+      expect(res.headers.get("content-security-policy")).not.toMatch(
+        /script-src[^;]*'unsafe-inline'/,
+      );
       const cookie = res.headers.get("set-cookie") ?? "";
       expect(cookie).toMatch(/device_csrf=[A-Fa-f0-9]+/);
       expect(cookie).toMatch(/HttpOnly/);


### PR DESCRIPTION
## Summary
- restore Clerk's runtime CSS-in-JS on the device authorization signup screen
- preserve nonce-only script execution while allowing inline styles only in `style-src`
- add regression coverage for both CSP boundaries

## Tests
- `tests/platform/device-routes.test.ts`: 37 passed
- platform TypeScript check: passed
- `bun run check:patterns`: 0 violations
- `git diff --check`: passed
- full repository wrappers were attempted but are blocked in this fresh worktree by the local Node 22 environment, mixed Vite 6/7 dependency links, and unresolved root `vitest`; the affected platform package and route suite pass independently

## Invariants
- Source of truth: Clerk remains the identity and session source of truth; this changes response styling policy only.
- Lock/transaction scope: no database reads, writes, locks, or transactions change.
- Acceptable orphan states: device-code expiry and pending approval behavior are unchanged.
- Auth source of truth: script execution remains limited by the existing per-request nonce and Clerk host allowlist; only `style-src` permits inline runtime CSS as required by Clerk.
- Deferred scope: no broader CSP redesign or Clerk component replacement is included.

## Post-Deploy Monitoring & Validation
- Validate one signed-out `/auth/device` signup flow immediately after deployment.
- Confirm the Clerk form is fully styled and the browser console contains no `Refused to apply inline style` CSP violations.
- Watch platform device-auth 4xx/5xx rates and browser reports containing `Could not load signup` during the first 30 minutes.
- Healthy signal: the username/terms step renders at normal component dimensions and continues into device approval.
- Failure trigger: any unstyled Clerk form or new device-auth CSP violation; roll back this commit and restore the prior response header while investigating.
- Owner: release operator performing the deployment validation.
