### PR TITLE
fix(desktop): restore draggable tab chrome

### DIFF
--- a/desktop/src/renderer/src/features/desktop-shell/DesktopTab.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopTab.tsx
@@ -55,7 +55,7 @@ export default function DesktopTab({
         aria-selected={selected}
         title={label}
         data-desktop-tab
-        className="flex h-full shrink-0 items-center justify-center border-l p-3 outline-none transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+        className="no-drag flex h-full shrink-0 items-center justify-center border-l p-3 outline-none transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
         style={{ ...tabBorderStyle(isLast), ...colors, height: "var(--titlebar-height)" }}
         onClick={onClick}
         onDoubleClick={onDoubleClick}
@@ -68,7 +68,7 @@ export default function DesktopTab({
   return (
     <div
       data-desktop-tab
-      className="group flex h-full min-w-[132px] max-w-[220px] shrink-0 items-center gap-2 border-l px-3 text-xs outline-none transition-colors hover:bg-[var(--bg-hover)]"
+      className="titlebar-drag group flex h-full min-w-[132px] max-w-[220px] shrink-0 items-center gap-2 border-l px-3 text-xs outline-none transition-colors hover:bg-[var(--bg-hover)]"
       style={{ ...tabBorderStyle(isLast), ...colors, height: "var(--titlebar-height)" }}
     >
       <button
@@ -76,7 +76,7 @@ export default function DesktopTab({
         role="tab"
         aria-label={label}
         aria-selected={selected}
-        className="flex min-w-0 flex-1 items-center gap-2 text-left outline-none"
+        className="no-drag flex min-w-0 flex-1 items-center gap-2 text-left outline-none"
         onClick={onClick}
         onDoubleClick={onDoubleClick}
         onKeyDown={(event) => activateFromKeyboard(event, onClick)}
@@ -89,7 +89,7 @@ export default function DesktopTab({
           type="button"
           aria-label={`Minimize ${label} tab`}
           title={`Minimize ${label}`}
-          className="flex size-5 shrink-0 items-center justify-center rounded opacity-60 hover:bg-[var(--bg-hover)] hover:opacity-100"
+          className="no-drag flex size-5 shrink-0 items-center justify-center rounded opacity-60 hover:bg-[var(--bg-hover)] hover:opacity-100"
           onClick={(event) => {
             event.stopPropagation();
             onMinimize();
@@ -103,7 +103,7 @@ export default function DesktopTab({
           type="button"
           aria-label={`Close ${label}`}
           title={`Close ${label}`}
-          className="flex size-5 shrink-0 items-center justify-center rounded opacity-60 hover:bg-[var(--bg-hover)] hover:opacity-100"
+          className="no-drag flex size-5 shrink-0 items-center justify-center rounded opacity-60 hover:bg-[var(--bg-hover)] hover:opacity-100"
           onClick={(event) => {
             event.stopPropagation();
             onClose();

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopTabGroup.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopTabGroup.tsx
@@ -8,7 +8,7 @@ export default function DesktopTabGroup({ children }: { children: ReactNode }) {
     <div
       role="tablist"
       aria-label="Workspace tabs"
-      className="no-drag flex h-full min-w-0 flex-1 items-stretch overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      className="titlebar-drag flex h-full min-w-0 flex-1 items-stretch overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       style={{ height: "var(--titlebar-height)" }}
     >
       {tabs.map((tab, index) => cloneElement(tab, { isLast: index === tabs.length - 1 }))}

--- a/tests/desktop/desktop-tab-group.test.tsx
+++ b/tests/desktop/desktop-tab-group.test.tsx
@@ -8,6 +8,45 @@ import DesktopTab from "../../desktop/src/renderer/src/features/desktop-shell/De
 import DesktopTabGroup from "../../desktop/src/renderer/src/features/desktop-shell/DesktopTabGroup";
 
 describe("DesktopTabGroup", () => {
+  it("keeps the workspace tab row available as a native window drag surface", () => {
+    render(
+      <DesktopTabGroup>
+        <DesktopTab mode="iconOnly" label="Sidebar" icon={<PanelLeft />} onClick={vi.fn()} />
+        <DesktopTab mode="iconOnly" label="Desktop" icon={<Monitor />} onClick={vi.fn()} />
+      </DesktopTabGroup>,
+    );
+
+    const tablist = screen.getByRole("tablist", { name: "Workspace tabs" });
+    expect(tablist.classList.contains("titlebar-drag")).toBe(true);
+    expect(tablist.classList.contains("no-drag")).toBe(false);
+    expect(screen.getAllByRole("tab").every((tab) => (
+      tab.tagName === "BUTTON" && tab.classList.contains("no-drag")
+    ))).toBe(true);
+  });
+
+  it("keeps the non-interactive body of a full workspace tab draggable", () => {
+    render(
+      <DesktopTab
+        mode="full"
+        label="Browser"
+        icon={<Monitor />}
+        canClose
+        onClick={vi.fn()}
+        onMinimize={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const browserTab = screen.getByRole("tab", { name: "Browser" });
+    const tabBody = browserTab.closest("[data-desktop-tab]");
+    expect(tabBody?.classList.contains("titlebar-drag")).toBe(true);
+    expect(tabBody?.classList.contains("no-drag")).toBe(false);
+    expect(browserTab.tagName).toBe("BUTTON");
+    expect(browserTab.classList.contains("no-drag")).toBe(true);
+    expect(screen.getByRole("button", { name: "Minimize Browser tab" }).classList.contains("no-drag")).toBe(true);
+    expect(screen.getByRole("button", { name: "Close Browser" }).classList.contains("no-drag")).toBe(true);
+  });
+
   it("gives every tab a left border and only the final tab a right border", () => {
     render(
       <DesktopTabGroup>


### PR DESCRIPTION
## Summary

- restore the native Desktop workspace tab row as a draggable Electron titlebar surface
- keep the non-interactive body of every full tab draggable when tabs fill the row
- explicitly exclude tab activation, minimize, and close buttons from native dragging
- add focused regression coverage for both sides of the drag/no-drag contract

## Tests

- `flox activate -- bun run test -- tests/desktop/desktop-tab-group.test.tsx tests/desktop/navigation-header.test.tsx tests/desktop/native-desktop-shell.test.tsx` — 64 passed
- `flox activate -- pnpm --filter desktop typecheck` — passed
- `flox activate -- bun run build:desktop` — passed
- `flox activate -- bun run check:patterns` — 0 violations; existing broad warnings only
- exact-worktree built Electron launched with isolated user data; runtime computed styles were `drag` for the tablist and Browser tab body, and `no-drag` for activation/minimize/close controls

## Human Review

Physical native-window dragging remains intentionally unclaimed: the system GUI driver disconnected on native titlebar drags and produced no trustworthy bounds change. Before approval, drag the exact Desktop build from empty top-row space and from the non-button area of a full tab, then confirm activation, keyboard use, minimize, close, account/runtime menus, and macOS traffic lights still work.

## Invariants

- **Source of truth:** `titlebar-drag` / `no-drag` renderer classes and the shared Electron titlebar CSS contract
- **Lock/transaction scope:** not applicable; renderer-only presentation change
- **Acceptable orphan states:** none; no persistence or resource ownership changes
- **Auth source of truth:** unchanged; no authentication or runtime-routing changes
- **Deferred scope:** browser-shell/Canvas dragging, navigation semantics, and Windows/Linux visual equivalence

## Documentation

No public documentation change is expected for this bug fix.

Linear: [MAT-509](https://linear.app/matrix-os/issue/MAT-509/fix-desktop-window-dragging-across-the-top-tab-chrome)
