### PR TITLE
feat(desktop): add PostHog support widget

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -45,6 +45,8 @@ jobs:
             runner: macos-15-intel
     env:
       MATRIX_DESKTOP_UPDATE_CHANNEL: ${{ inputs.channel }}
+      VITE_POSTHOG_PROJECT_TOKEN: ${{ vars.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN || vars.NEXT_PUBLIC_POSTHOG_KEY }}
+      VITE_POSTHOG_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.posthog.com' }}
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD || secrets.APPLE_APP_PASSWORD }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -330,6 +332,8 @@ jobs:
     timeout-minutes: 35
     env:
       MATRIX_DESKTOP_UPDATE_CHANNEL: ${{ inputs.channel }}
+      VITE_POSTHOG_PROJECT_TOKEN: ${{ vars.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN || vars.NEXT_PUBLIC_POSTHOG_KEY }}
+      VITE_POSTHOG_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.posthog.com' }}
     steps:
       - uses: actions/checkout@v6
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -54,6 +54,7 @@
     "electron-updater": "^6.7.3",
     "framer-motion": "^12.29.0",
     "lexical": "^0.41.0",
+    "posthog-js": "^1.376.0",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-markdown": "^10.1.0",

--- a/desktop/src/main/auth/header-injection.ts
+++ b/desktop/src/main/auth/header-injection.ts
@@ -28,6 +28,8 @@ interface SessionLike {
   webRequest: WebRequestLike;
 }
 
+const MATRIX_SUPPORT_REFERRER = "https://app.matrix-os.com/";
+
 function normalizeWsScheme(url: URL): string {
   if (url.protocol === "ws:") return "http:";
   if (url.protocol === "wss:") return "https:";
@@ -126,19 +128,14 @@ export function installHeaderInjection(
       details.requestHeaders["Authorization"] = `Bearer ${token}`;
     }
     if (rendererOrigin === "null" && shouldInjectAuth(details.url, gatewayOrigin)) {
-      try {
-        const request = new URL(details.url);
-        const gateway = gatewayOrigin ? new URL(gatewayOrigin) : null;
-        if (
-          gateway &&
-          (request.protocol === "http:" || request.protocol === "https:") &&
-          request.pathname.startsWith("/relay/api/conversations/v1/widget/")
-        ) {
-          details.requestHeaders.Referer = `${gateway.origin}/`;
-        }
-      } catch (error: unknown) {
-        if (!(error instanceof TypeError)) throw error;
-        // Invalid URLs already fail shouldInjectAuth; keep the request unchanged.
+      // shouldInjectAuth has already parsed and validated this URL against the
+      // active gateway origin, so constructing it here cannot fail.
+      const request = new URL(details.url);
+      if (
+        (request.protocol === "http:" || request.protocol === "https:") &&
+        request.pathname.startsWith("/relay/api/conversations/v1/widget/")
+      ) {
+        details.requestHeaders.Referer = MATRIX_SUPPORT_REFERRER;
       }
     }
     callback({ requestHeaders: details.requestHeaders });

--- a/desktop/src/main/auth/header-injection.ts
+++ b/desktop/src/main/auth/header-injection.ts
@@ -117,11 +117,29 @@ export function installHeaderInjection(
   rendererSession: SessionLike,
   getToken: () => string | null,
   getGatewayOrigin: () => string | null,
+  rendererOrigin: string,
 ): void {
   rendererSession.webRequest.onBeforeSendHeaders((details, callback) => {
+    const gatewayOrigin = getGatewayOrigin();
     const token = getToken();
-    if (token && shouldInjectAuth(details.url, getGatewayOrigin())) {
+    if (token && shouldInjectAuth(details.url, gatewayOrigin)) {
       details.requestHeaders["Authorization"] = `Bearer ${token}`;
+    }
+    if (rendererOrigin === "null" && shouldInjectAuth(details.url, gatewayOrigin)) {
+      try {
+        const request = new URL(details.url);
+        const gateway = gatewayOrigin ? new URL(gatewayOrigin) : null;
+        if (
+          gateway &&
+          (request.protocol === "http:" || request.protocol === "https:") &&
+          request.pathname.startsWith("/relay/api/conversations/v1/widget/")
+        ) {
+          details.requestHeaders.Referer = `${gateway.origin}/`;
+        }
+      } catch (error: unknown) {
+        if (!(error instanceof TypeError)) throw error;
+        // Invalid URLs already fail shouldInjectAuth; keep the request unchanged.
+      }
     }
     callback({ requestHeaders: details.requestHeaders });
   });
@@ -173,7 +191,7 @@ export function installGatewayCors(
       responseHeaders["Access-Control-Allow-Origin"] = [rendererOrigin];
       responseHeaders["Access-Control-Allow-Methods"] = ["GET, POST, PATCH, PUT, DELETE, OPTIONS"];
       responseHeaders["Access-Control-Allow-Headers"] = [
-        "Authorization, Content-Type, x-runtime-slot, X-Matrix-Filename",
+        "Authorization, Content-Type, x-runtime-slot, X-Matrix-Filename, X-Conversations-Token",
       ];
       responseHeaders["Access-Control-Allow-Credentials"] = ["true"];
     }

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -206,18 +206,19 @@ if (!gotLock) {
       });
       await auth.init();
 
+      const rendererOrigin = process.env.ELECTRON_RENDERER_URL
+        ? new URL(process.env.ELECTRON_RENDERER_URL).origin
+        : "null";
       // Renderer session gets origin-scoped bearer injection; embed partitions
       // (separate sessions) never do (lesson L1).
       installHeaderInjection(
         session.defaultSession,
         () => auth.getToken(),
         () => auth.getGatewayOrigin(),
+        rendererOrigin,
       );
       // The renderer is a different origin than the gateway (file:// in prod,
       // localhost in dev), so allow its cross-origin fetches to the gateway.
-      const rendererOrigin = process.env.ELECTRON_RENDERER_URL
-        ? new URL(process.env.ELECTRON_RENDERER_URL).origin
-        : "null";
       installGatewayCors(session.defaultSession, () => auth.getGatewayOrigin(), rendererOrigin);
 
       const nativeAppBridge = new NativeAppBridge({

--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import { Toaster } from "sonner";
 import SignIn from "./features/signin/SignIn";
 import MissionControl from "./features/mission-control/MissionControl";
 import DesktopUpdateExperience from "./features/updates/DesktopUpdateExperience";
+import DesktopSupportWidget from "./features/support/DesktopSupportWidget";
 import { useAppearance } from "./stores/appearance";
 import { useConnection, wireConnectionEvents } from "./stores/connection";
 
@@ -35,6 +36,7 @@ export default function App() {
           <MissionControl />
         )}
       </div>
+      <DesktopSupportWidget />
       <DesktopUpdateExperience />
       <Toaster
         position="bottom-right"

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopModeControls.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopModeControls.tsx
@@ -1,5 +1,6 @@
 import AccountMenu from "../mission-control/AccountMenu";
 import RuntimeComputerMenu from "../runtime/RuntimeComputerMenu";
+import DesktopSupportButton from "../support/DesktopSupportButton";
 
 export default function DesktopModeControls() {
   return (
@@ -7,6 +8,7 @@ export default function DesktopModeControls() {
       <div className="relative w-[156px]">
         <RuntimeComputerMenu collapsed={false} />
       </div>
+      <DesktopSupportButton />
       <AccountMenu collapsed compact />
     </div>
   );

--- a/desktop/src/renderer/src/features/support/DesktopSupportButton.tsx
+++ b/desktop/src/renderer/src/features/support/DesktopSupportButton.tsx
@@ -1,0 +1,22 @@
+import { MessageCircle } from "../../lib/hugeicons";
+import {
+  isDesktopSupportConfigured,
+  openDesktopSupport,
+} from "./DesktopSupportWidget";
+
+export default function DesktopSupportButton() {
+  if (!isDesktopSupportConfigured()) return null;
+
+  return (
+    <button
+      type="button"
+      aria-label="Support"
+      title="Support"
+      className="flex size-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-[var(--bg-hover)] focus-visible:bg-[var(--bg-hover)]"
+      style={{ color: "var(--text-secondary)" }}
+      onClick={() => void openDesktopSupport()}
+    >
+      <MessageCircle aria-hidden="true" size={16} />
+    </button>
+  );
+}

--- a/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
+++ b/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
@@ -1,0 +1,110 @@
+import "posthog-js/dist/conversations";
+import posthog from "posthog-js/dist/module.no-external";
+import { useEffect } from "react";
+import { useConnection } from "../../stores/connection";
+
+type PostHogInitOptions = Parameters<typeof posthog.init>[1];
+
+let initialized = false;
+let activeIdentity: string | null = null;
+
+function errorKind(error: unknown): string {
+  return error instanceof Error ? error.name : typeof error;
+}
+
+function configuredToken(): string | null {
+  const token = import.meta.env.VITE_POSTHOG_PROJECT_TOKEN?.trim();
+  return token || null;
+}
+
+function configuredUiHost(): string {
+  return import.meta.env.VITE_POSTHOG_HOST?.trim() || "https://eu.posthog.com";
+}
+
+function relayUrl(platformHost: string): string | null {
+  try {
+    const platformUrl = new URL(platformHost);
+    if (platformUrl.protocol !== "https:" && platformUrl.protocol !== "http:") return null;
+    return new URL("/relay", platformUrl.origin).toString().replace(/\/$/, "");
+  } catch (error: unknown) {
+    if (error instanceof TypeError) return null;
+    throw error;
+  }
+}
+
+function hideAndResetSupport(): void {
+  if (!initialized || activeIdentity === null) return;
+  try {
+    posthog.conversations.hide();
+  } catch (error: unknown) {
+    console.warn("[desktop-support] Failed to hide PostHog widget:", errorKind(error));
+  }
+  try {
+    posthog.reset();
+  } catch (error: unknown) {
+    console.warn("[desktop-support] Failed to reset PostHog identity:", errorKind(error));
+  }
+  activeIdentity = null;
+}
+
+export default function DesktopSupportWidget() {
+  const status = useConnection((state) => state.status);
+  const handle = useConnection((state) => state.handle);
+  const displayName = useConnection((state) => state.displayName);
+  const platformHost = useConnection((state) => state.platformHost);
+  const authGeneration = useConnection((state) => state.authGeneration);
+
+  useEffect(() => {
+    const token = configuredToken();
+    const apiHost = relayUrl(platformHost);
+    if (!token || status !== "signed-in" || !handle || !apiHost) {
+      hideAndResetSupport();
+      return;
+    }
+
+    if (!initialized) {
+      try {
+        posthog.init(token, {
+          api_host: apiHost,
+          ui_host: configuredUiHost(),
+          defaults: "2026-01-30",
+          autocapture: false,
+          capture_dead_clicks: false,
+          capture_exceptions: false,
+          capture_heatmaps: false,
+          capture_pageleave: false,
+          capture_pageview: false,
+          capture_performance: false,
+          disable_external_dependency_loading: true,
+          disable_session_recording: true,
+          disable_surveys: true,
+          disable_surveys_automatic_display: true,
+          disable_web_experiments: true,
+          enable_recording_console_log: false,
+          persistence: "localStorage",
+          persistence_name: "matrix_os_desktop_support",
+          person_profiles: "identified_only",
+          rageclick: false,
+        } as PostHogInitOptions);
+        initialized = true;
+      } catch (error: unknown) {
+        console.warn("[desktop-support] PostHog initialization failed:", errorKind(error));
+        return;
+      }
+    }
+
+    const identity = `${handle}:${authGeneration}`;
+    if (activeIdentity === identity) return;
+    try {
+      posthog.identify(handle, {
+        $name: displayName ?? handle,
+        matrix_client: "desktop",
+      });
+      activeIdentity = identity;
+    } catch (error: unknown) {
+      console.warn("[desktop-support] PostHog identification failed:", errorKind(error));
+    }
+  }, [authGeneration, displayName, handle, platformHost, status]);
+
+  return null;
+}

--- a/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
+++ b/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
@@ -10,7 +10,6 @@ let activeIdentity: string | null = null;
 let allowPostHogWidget = false;
 let launcherObserver: MutationObserver | null = null;
 let openSupportPromise: Promise<boolean> | null = null;
-let closeButtonWithCleanup: HTMLButtonElement | null = null;
 
 const POSTHOG_WIDGET_ID = "ph-conversations-widget-container";
 const POSTHOG_LAUNCHER_SELECTOR = 'button[aria-label^="Open chat"]';
@@ -54,7 +53,10 @@ function hidePostHogWidget(): void {
 }
 
 function suppressDefaultLauncher(): void {
-  if (allowPostHogWidget || !document.getElementById(POSTHOG_WIDGET_ID)) return;
+  if (
+    allowPostHogWidget ||
+    !document.querySelector(`#${POSTHOG_WIDGET_ID} ${POSTHOG_LAUNCHER_SELECTOR}`)
+  ) return;
   hidePostHogWidget();
 }
 
@@ -101,16 +103,6 @@ async function waitForConversations(): Promise<boolean> {
   return false;
 }
 
-function hideAfterPanelCloses(closeButton: HTMLButtonElement): void {
-  if (closeButtonWithCleanup === closeButton) return;
-  closeButtonWithCleanup = closeButton;
-  closeButton.addEventListener("click", () => {
-    closeButtonWithCleanup = null;
-    allowPostHogWidget = false;
-    queueMicrotask(hidePostHogWidget);
-  }, { once: true });
-}
-
 async function openSupportPanel(): Promise<boolean> {
   if (!initialized || activeIdentity === null || !await waitForConversations()) return false;
 
@@ -127,7 +119,10 @@ async function openSupportPanel(): Promise<boolean> {
     }
     if (!closeButton) return false;
 
-    hideAfterPanelCloses(closeButton);
+    // Once the provider panel is open, re-arm launcher suppression. This does
+    // not hide the panel itself; it only removes PostHog's default launcher if
+    // closing or re-rendering the panel brings that button back.
+    allowPostHogWidget = false;
     return true;
   } finally {
     if (!document.querySelector(POSTHOG_CLOSE_SELECTOR)) {
@@ -154,7 +149,6 @@ export function openDesktopSupport(): Promise<boolean> {
 function hideAndResetSupport(): void {
   allowPostHogWidget = false;
   stopLauncherObserver();
-  closeButtonWithCleanup = null;
   if (!initialized) return;
   hidePostHogWidget();
   if (activeIdentity === null) return;

--- a/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
+++ b/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
@@ -216,6 +216,7 @@ export default function DesktopSupportWidget() {
         matrix_client: "desktop",
       });
       activeIdentity = identity;
+      hidePostHogWidget();
       suppressDefaultLauncher();
     } catch (error: unknown) {
       console.warn("[desktop-support] PostHog identification failed:", errorKind(error));

--- a/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
+++ b/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
@@ -7,6 +7,15 @@ type PostHogInitOptions = Parameters<typeof posthog.init>[1];
 
 let initialized = false;
 let activeIdentity: string | null = null;
+let allowPostHogWidget = false;
+let launcherObserver: MutationObserver | null = null;
+let openSupportPromise: Promise<boolean> | null = null;
+let closeButtonWithCleanup: HTMLButtonElement | null = null;
+
+const POSTHOG_WIDGET_ID = "ph-conversations-widget-container";
+const POSTHOG_LAUNCHER_SELECTOR = 'button[aria-label^="Open chat"]';
+const POSTHOG_CLOSE_SELECTOR = 'button[aria-label="Close"]';
+const SUPPORT_OPEN_TIMEOUT_MS = 10_000;
 
 function errorKind(error: unknown): string {
   return error instanceof Error ? error.name : typeof error;
@@ -15,6 +24,10 @@ function errorKind(error: unknown): string {
 function configuredToken(): string | null {
   const token = import.meta.env.VITE_POSTHOG_PROJECT_TOKEN?.trim();
   return token || null;
+}
+
+export function isDesktopSupportConfigured(): boolean {
+  return configuredToken() !== null;
 }
 
 function configuredUiHost(): string {
@@ -32,13 +45,119 @@ function relayUrl(platformHost: string): string | null {
   }
 }
 
-function hideAndResetSupport(): void {
-  if (!initialized || activeIdentity === null) return;
+function hidePostHogWidget(): void {
   try {
     posthog.conversations.hide();
   } catch (error: unknown) {
     console.warn("[desktop-support] Failed to hide PostHog widget:", errorKind(error));
   }
+}
+
+function suppressDefaultLauncher(): void {
+  if (allowPostHogWidget || !document.getElementById(POSTHOG_WIDGET_ID)) return;
+  hidePostHogWidget();
+}
+
+function startLauncherObserver(): void {
+  if (launcherObserver || !document.body) return;
+  launcherObserver = new MutationObserver(suppressDefaultLauncher);
+  launcherObserver.observe(document.body, { childList: true, subtree: true });
+  suppressDefaultLauncher();
+}
+
+function stopLauncherObserver(): void {
+  launcherObserver?.disconnect();
+  launcherObserver = null;
+}
+
+function waitForElement(selector: string): Promise<HTMLButtonElement | null> {
+  const existing = document.querySelector<HTMLButtonElement>(selector);
+  if (existing) return Promise.resolve(existing);
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (element: HTMLButtonElement | null) => {
+      if (settled) return;
+      settled = true;
+      observer.disconnect();
+      window.clearTimeout(timeoutId);
+      resolve(element);
+    };
+    const observer = new MutationObserver(() => {
+      const element = document.querySelector<HTMLButtonElement>(selector);
+      if (element) finish(element);
+    });
+    const timeoutId = window.setTimeout(() => finish(null), SUPPORT_OPEN_TIMEOUT_MS);
+    observer.observe(document.body, { childList: true, subtree: true });
+  });
+}
+
+async function waitForConversations(): Promise<boolean> {
+  const deadline = Date.now() + SUPPORT_OPEN_TIMEOUT_MS;
+  while (Date.now() < deadline && activeIdentity !== null) {
+    if (posthog.conversations.isAvailable()) return true;
+    await new Promise((resolve) => window.setTimeout(resolve, 100));
+  }
+  return false;
+}
+
+function hideAfterPanelCloses(closeButton: HTMLButtonElement): void {
+  if (closeButtonWithCleanup === closeButton) return;
+  closeButtonWithCleanup = closeButton;
+  closeButton.addEventListener("click", () => {
+    closeButtonWithCleanup = null;
+    allowPostHogWidget = false;
+    queueMicrotask(hidePostHogWidget);
+  }, { once: true });
+}
+
+async function openSupportPanel(): Promise<boolean> {
+  if (!initialized || activeIdentity === null || !await waitForConversations()) return false;
+
+  allowPostHogWidget = true;
+  try {
+    posthog.conversations.show();
+
+    let closeButton = document.querySelector<HTMLButtonElement>(POSTHOG_CLOSE_SELECTOR);
+    if (!closeButton) {
+      const launcher = await waitForElement(POSTHOG_LAUNCHER_SELECTOR);
+      if (!launcher) return false;
+      launcher.click();
+      closeButton = await waitForElement(POSTHOG_CLOSE_SELECTOR);
+    }
+    if (!closeButton) return false;
+
+    hideAfterPanelCloses(closeButton);
+    return true;
+  } finally {
+    if (!document.querySelector(POSTHOG_CLOSE_SELECTOR)) {
+      allowPostHogWidget = false;
+      suppressDefaultLauncher();
+    }
+  }
+}
+
+export function openDesktopSupport(): Promise<boolean> {
+  if (!openSupportPromise) {
+    openSupportPromise = openSupportPanel()
+      .catch((error: unknown) => {
+        console.warn("[desktop-support] Support chat unavailable:", errorKind(error));
+        return false;
+      })
+      .finally(() => {
+        openSupportPromise = null;
+      });
+  }
+  return openSupportPromise;
+}
+
+function hideAndResetSupport(): void {
+  allowPostHogWidget = false;
+  stopLauncherObserver();
+  closeButtonWithCleanup = null;
+  if (!initialized) return;
+  hidePostHogWidget();
+  if (activeIdentity === null) return;
   try {
     posthog.reset();
   } catch (error: unknown) {
@@ -61,6 +180,8 @@ export default function DesktopSupportWidget() {
       hideAndResetSupport();
       return;
     }
+
+    startLauncherObserver();
 
     if (!initialized) {
       try {
@@ -101,10 +222,16 @@ export default function DesktopSupportWidget() {
         matrix_client: "desktop",
       });
       activeIdentity = identity;
+      suppressDefaultLauncher();
     } catch (error: unknown) {
       console.warn("[desktop-support] PostHog identification failed:", errorKind(error));
     }
   }, [authGeneration, displayName, handle, platformHost, status]);
+
+  useEffect(() => () => {
+    allowPostHogWidget = false;
+    stopLauncherObserver();
+  }, []);
 
   return null;
 }

--- a/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
+++ b/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
@@ -7,9 +7,12 @@ type PostHogInitOptions = Parameters<typeof posthog.init>[1];
 
 let initialized = false;
 let activeIdentity: string | null = null;
+let activeApiHost: string | null = null;
 let allowPostHogWidget = false;
 let launcherObserver: MutationObserver | null = null;
 let openSupportPromise: Promise<boolean> | null = null;
+let supportLifecycleGeneration = 0;
+let cancelPendingElementWait: (() => void) | null = null;
 
 const POSTHOG_WIDGET_ID = "ph-conversations-widget-container";
 const POSTHOG_LAUNCHER_SELECTOR = 'button[aria-label^="Open chat"]';
@@ -77,7 +80,19 @@ function stopLauncherObserver(): void {
   launcherObserver = null;
 }
 
-function waitForElement(selector: string): Promise<HTMLButtonElement | null> {
+function invalidatePendingSupportOpen(): void {
+  supportLifecycleGeneration += 1;
+  cancelPendingElementWait?.();
+  cancelPendingElementWait = null;
+  openSupportPromise = null;
+}
+
+function supportOpenIsCurrent(generation: number): boolean {
+  return generation === supportLifecycleGeneration && initialized && activeIdentity !== null;
+}
+
+function waitForElement(selector: string, generation: number): Promise<HTMLButtonElement | null> {
+  if (!supportOpenIsCurrent(generation)) return Promise.resolve(null);
   const existing = document.querySelector<HTMLButtonElement>(selector);
   if (existing) return Promise.resolve(existing);
 
@@ -88,45 +103,53 @@ function waitForElement(selector: string): Promise<HTMLButtonElement | null> {
       settled = true;
       observer.disconnect();
       window.clearTimeout(timeoutId);
+      if (cancelPendingElementWait === cancel) cancelPendingElementWait = null;
       resolve(element);
     };
+    const cancel = () => finish(null);
     const observer = new MutationObserver(() => {
+      if (!supportOpenIsCurrent(generation)) {
+        finish(null);
+        return;
+      }
       const element = document.querySelector<HTMLButtonElement>(selector);
       if (element) finish(element);
     });
     const timeoutId = window.setTimeout(() => finish(null), SUPPORT_OPEN_TIMEOUT_MS);
+    cancelPendingElementWait = cancel;
     observer.observe(document.body, { childList: true, subtree: true });
   });
 }
 
-async function waitForConversations(): Promise<boolean> {
+async function waitForConversations(generation: number): Promise<boolean> {
   const deadline = Date.now() + SUPPORT_OPEN_TIMEOUT_MS;
-  while (Date.now() < deadline && activeIdentity !== null) {
+  while (Date.now() < deadline && supportOpenIsCurrent(generation)) {
     if (posthog.conversations.isAvailable()) return true;
     await new Promise((resolve) => window.setTimeout(resolve, 100));
   }
   return false;
 }
 
-async function openSupportPanel(): Promise<boolean> {
-  if (!initialized || activeIdentity === null || !await waitForConversations()) return false;
+async function openSupportPanel(generation: number): Promise<boolean> {
+  if (!supportOpenIsCurrent(generation) || !await waitForConversations(generation)) return false;
 
   allowPostHogWidget = true;
   try {
+    if (!supportOpenIsCurrent(generation)) return false;
     posthog.conversations.show();
 
     let closeButton = document.querySelector<HTMLButtonElement>(POSTHOG_CLOSE_SELECTOR);
     if (!closeButton) {
-      const launcher = await waitForElement(POSTHOG_LAUNCHER_SELECTOR);
-      if (!launcher) return false;
+      const launcher = await waitForElement(POSTHOG_LAUNCHER_SELECTOR, generation);
+      if (!launcher || !supportOpenIsCurrent(generation)) return false;
       launcher.click();
-      closeButton = await waitForElement(POSTHOG_CLOSE_SELECTOR);
+      closeButton = await waitForElement(POSTHOG_CLOSE_SELECTOR, generation);
     }
-    if (!closeButton) return false;
+    if (!closeButton || !supportOpenIsCurrent(generation)) return false;
 
     return true;
   } finally {
-    if (!document.querySelector(POSTHOG_CLOSE_SELECTOR)) {
+    if (generation === supportLifecycleGeneration && !document.querySelector(POSTHOG_CLOSE_SELECTOR)) {
       allowPostHogWidget = false;
       suppressDefaultLauncher();
     }
@@ -135,21 +158,23 @@ async function openSupportPanel(): Promise<boolean> {
 
 export function openDesktopSupport(): Promise<boolean> {
   if (!openSupportPromise) {
-    openSupportPromise = openSupportPanel()
+    const generation = supportLifecycleGeneration;
+    const promise = openSupportPanel(generation)
       .catch((error: unknown) => {
         console.warn("[desktop-support] Support chat unavailable:", errorKind(error));
         return false;
       })
       .finally(() => {
-        openSupportPromise = null;
+        if (openSupportPromise === promise) openSupportPromise = null;
       });
+    openSupportPromise = promise;
   }
   return openSupportPromise;
 }
 
 function hideAndResetSupport(): void {
+  invalidatePendingSupportOpen();
   allowPostHogWidget = false;
-  stopLauncherObserver();
   if (!initialized) return;
   hidePostHogWidget();
   if (activeIdentity === null) return;
@@ -203,8 +228,24 @@ export default function DesktopSupportWidget() {
           rageclick: false,
         } as PostHogInitOptions);
         initialized = true;
+        activeApiHost = apiHost;
       } catch (error: unknown) {
         console.warn("[desktop-support] PostHog initialization failed:", errorKind(error));
+        return;
+      }
+    }
+
+    if (activeApiHost !== apiHost) {
+      invalidatePendingSupportOpen();
+      allowPostHogWidget = false;
+      hidePostHogWidget();
+      try {
+        if (activeIdentity !== null) posthog.reset();
+        activeIdentity = null;
+        posthog.set_config({ api_host: apiHost });
+        activeApiHost = apiHost;
+      } catch (error: unknown) {
+        console.warn("[desktop-support] PostHog relay rebind failed:", errorKind(error));
         return;
       }
     }
@@ -212,6 +253,13 @@ export default function DesktopSupportWidget() {
     const identity = `${handle}:${authGeneration}`;
     if (activeIdentity === identity) return;
     try {
+      if (activeIdentity !== null) {
+        invalidatePendingSupportOpen();
+        allowPostHogWidget = false;
+        hidePostHogWidget();
+        posthog.reset();
+        activeIdentity = null;
+      }
       posthog.identify(handle, {
         $name: displayName ?? handle,
         matrix_client: "desktop",
@@ -225,6 +273,7 @@ export default function DesktopSupportWidget() {
   }, [authGeneration, displayName, handle, platformHost, status]);
 
   useEffect(() => () => {
+    invalidatePendingSupportOpen();
     allowPostHogWidget = false;
     stopLauncherObserver();
   }, []);

--- a/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
+++ b/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
@@ -53,10 +53,15 @@ function hidePostHogWidget(): void {
 }
 
 function suppressDefaultLauncher(): void {
-  if (
-    allowPostHogWidget ||
-    !document.querySelector(`#${POSTHOG_WIDGET_ID} ${POSTHOG_LAUNCHER_SELECTOR}`)
-  ) return;
+  const widget = document.getElementById(POSTHOG_WIDGET_ID);
+  const launcher = widget?.querySelector(POSTHOG_LAUNCHER_SELECTOR);
+  const panel = widget?.querySelector(POSTHOG_CLOSE_SELECTOR);
+  if (!launcher && !panel) return;
+
+  if (allowPostHogWidget) {
+    if (openSupportPromise || panel) return;
+    allowPostHogWidget = false;
+  }
   hidePostHogWidget();
 }
 
@@ -119,10 +124,6 @@ async function openSupportPanel(): Promise<boolean> {
     }
     if (!closeButton) return false;
 
-    // Once the provider panel is open, re-arm launcher suppression. This does
-    // not hide the panel itself; it only removes PostHog's default launcher if
-    // closing or re-rendering the panel brings that button back.
-    allowPostHogWidget = false;
     return true;
   } finally {
     if (!document.querySelector(POSTHOG_CLOSE_SELECTOR)) {

--- a/desktop/src/renderer/src/vite-env.d.ts
+++ b/desktop/src/renderer/src/vite-env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+declare module "posthog-js/dist/conversations";
+
 declare module "*?worker" {
   const workerConstructor: new () => Worker;
   export default workerConstructor;

--- a/packages/platform/src/posthog-relay.ts
+++ b/packages/platform/src/posthog-relay.ts
@@ -15,6 +15,7 @@ const POSTHOG_RELAY_FORWARD_HEADERS = new Set([
   'origin',
   'referer',
   'user-agent',
+  'x-conversations-token',
 ]);
 
 export interface PostHogRelayDependencies {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,6 +408,9 @@ importers:
       lexical:
         specifier: ^0.41.0
         version: 0.41.0
+      posthog-js:
+        specifier: ^1.376.0
+        version: 1.376.0
       react:
         specifier: 19.2.6
         version: 19.2.6

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -74,6 +74,15 @@ describe("desktop release workflows", () => {
     expect(config).not.toContain("MATRIX_DESKTOP_UPDATE_CHANNEL ?? process.env.OPERATOR_UPDATE_CHANNEL");
   });
 
+  it("injects the public PostHog support configuration into every packaged Desktop build", () => {
+    const workflow = readFileSync(join(root, ".github/workflows/desktop-build.yml"), "utf8");
+
+    expect(workflow.match(/VITE_POSTHOG_PROJECT_TOKEN:/g)).toHaveLength(2);
+    expect(workflow.match(/VITE_POSTHOG_HOST:/g)).toHaveLength(2);
+    expect(workflow).toContain("vars.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN || vars.NEXT_PUBLIC_POSTHOG_KEY");
+    expect(workflow).toContain("vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.posthog.com'");
+  });
+
   it("keeps raw workspace TypeScript out of the packaged app archive", () => {
     const builder = readFileSync(join(root, "desktop/electron-builder.yml"), "utf8");
 

--- a/tests/desktop/desktop-support-widget.test.tsx
+++ b/tests/desktop/desktop-support-widget.test.tsx
@@ -49,6 +49,21 @@ function renderPostHogLauncher(): HTMLDivElement {
   return container;
 }
 
+function renderPersistedOpenPostHogPanel(): HTMLDivElement {
+  let container = document.getElementById("ph-conversations-widget-container") as HTMLDivElement | null;
+  if (!container) {
+    container = document.createElement("div");
+    container.id = "ph-conversations-widget-container";
+    document.body.appendChild(container);
+  }
+  const close = document.createElement("button");
+  close.type = "button";
+  close.setAttribute("aria-label", "Close");
+  close.addEventListener("click", renderPostHogLauncher);
+  container.replaceChildren(close);
+  return container;
+}
+
 describe("Desktop support widget", () => {
   beforeEach(() => {
     vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_desktop_test");
@@ -115,6 +130,7 @@ describe("Desktop support widget", () => {
       $name: "Neo",
       matrix_client: "desktop",
     });
+    expect(posthogClient.conversations.hide).toHaveBeenCalledTimes(1);
 
     act(() => {
       useConnection.setState({
@@ -126,7 +142,7 @@ describe("Desktop support widget", () => {
       });
     });
 
-    await waitFor(() => expect(posthogClient.conversations.hide).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(posthogClient.conversations.hide).toHaveBeenCalledTimes(2));
     expect(posthogClient.reset).toHaveBeenCalledTimes(1);
   });
 
@@ -138,6 +154,10 @@ describe("Desktop support widget", () => {
       renderPostHogLauncher();
     });
 
+    // PostHog persists its own open/closed state. A previous open session must
+    // not make support cover the Desktop immediately after the next sign-in.
+    renderPersistedOpenPostHogPanel();
+
     render(
       <>
         <DesktopSupportWidget />
@@ -146,7 +166,7 @@ describe("Desktop support widget", () => {
     );
 
     await waitFor(() => expect(posthogClient.identify).toHaveBeenCalled());
-    renderPostHogLauncher();
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Close" })).toBeNull());
     await waitFor(() => expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull());
 
     expect(screen.getAllByRole("button").map((button) => button.getAttribute("aria-label") ?? button.textContent))

--- a/tests/desktop/desktop-support-widget.test.tsx
+++ b/tests/desktop/desktop-support-widget.test.tsx
@@ -16,6 +16,7 @@ const posthogClient = vi.hoisted(() => ({
   identify: vi.fn(),
   init: vi.fn(),
   reset: vi.fn(),
+  set_config: vi.fn(),
 }));
 
 vi.mock("posthog-js/dist/conversations", () => ({}));
@@ -194,5 +195,63 @@ describe("Desktop support widget", () => {
     await waitFor(() => expect(posthogClient.conversations.show).toHaveBeenCalledTimes(2));
     expect(await screen.findByRole("button", { name: "Close" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull();
+  });
+
+  it("rebinds support to the selected runtime relay", async () => {
+    render(<DesktopSupportWidget />);
+
+    act(() => {
+      useConnection.setState({
+        platformHost: "https://preview.matrix-os.com",
+        authGeneration: 2,
+      });
+    });
+
+    await waitFor(() => {
+      expect(posthogClient.set_config).toHaveBeenCalledWith({
+        api_host: "https://preview.matrix-os.com/relay",
+      });
+    });
+    expect(posthogClient.reset).toHaveBeenCalledTimes(1);
+    expect(posthogClient.identify).toHaveBeenLastCalledWith("neo", {
+      $name: "Neo",
+      matrix_client: "desktop",
+    });
+  });
+
+  it("does not finish an old support open after sign-out", async () => {
+    posthogClient.conversations.hide.mockImplementation(() => {
+      document.getElementById("ph-conversations-widget-container")?.remove();
+    });
+    posthogClient.conversations.show.mockImplementation(() => undefined);
+
+    render(
+      <>
+        <DesktopSupportWidget />
+        <DesktopModeControls />
+      </>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Support" }));
+    await waitFor(() => expect(posthogClient.conversations.show).toHaveBeenCalledTimes(1));
+    const resetCallsBeforeSignOut = posthogClient.reset.mock.calls.length;
+
+    act(() => {
+      useConnection.setState({
+        status: "signed-out",
+        handle: null,
+        displayName: null,
+        imageUrl: null,
+        api: null,
+      });
+    });
+    await waitFor(() => {
+      expect(posthogClient.reset.mock.calls.length).toBeGreaterThan(resetCallsBeforeSignOut);
+    });
+
+    renderPostHogLauncher();
+
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull());
+    expect(screen.queryByRole("button", { name: "Close" })).toBeNull();
   });
 });

--- a/tests/desktop/desktop-support-widget.test.tsx
+++ b/tests/desktop/desktop-support-widget.test.tsx
@@ -158,9 +158,22 @@ describe("Desktop support widget", () => {
     expect(await screen.findByRole("button", { name: "Close" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    // PostHog can re-render its panel while it is open. Replacing the close
+    // control exercises the user-visible contract without relying on a
+    // listener remaining attached to one provider-owned DOM node.
+    const close = screen.getByRole("button", { name: "Close" });
+    const replacementClose = close.cloneNode(true) as HTMLButtonElement;
+    replacementClose.addEventListener("click", renderPostHogLauncher);
+    close.replaceWith(replacementClose);
+    fireEvent.click(replacementClose);
 
     await waitFor(() => expect(document.getElementById("ph-conversations-widget-container")).toBeNull());
+    expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Support" }));
+
+    await waitFor(() => expect(posthogClient.conversations.show).toHaveBeenCalledTimes(2));
+    expect(await screen.findByRole("button", { name: "Close" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull();
   });
 });

--- a/tests/desktop/desktop-support-widget.test.tsx
+++ b/tests/desktop/desktop-support-widget.test.tsx
@@ -154,10 +154,6 @@ describe("Desktop support widget", () => {
       renderPostHogLauncher();
     });
 
-    // PostHog persists its own open/closed state. A previous open session must
-    // not make support cover the Desktop immediately after the next sign-in.
-    renderPersistedOpenPostHogPanel();
-
     render(
       <>
         <DesktopSupportWidget />
@@ -166,6 +162,9 @@ describe("Desktop support widget", () => {
     );
 
     await waitFor(() => expect(posthogClient.identify).toHaveBeenCalled());
+    // PostHog restores persisted widget state asynchronously after identity
+    // setup. A previous open session must not cover the Desktop after login.
+    renderPersistedOpenPostHogPanel();
     await waitFor(() => expect(screen.queryByRole("button", { name: "Close" })).toBeNull());
     await waitFor(() => expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull());
 

--- a/tests/desktop/desktop-support-widget.test.tsx
+++ b/tests/desktop/desktop-support-widget.test.tsx
@@ -1,14 +1,17 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import DesktopModeControls from "@desktop/renderer/src/features/desktop-shell/DesktopModeControls";
 import DesktopSupportWidget from "@desktop/renderer/src/features/support/DesktopSupportWidget";
 import { useConnection } from "@desktop/renderer/src/stores/connection";
 
 const posthogClient = vi.hoisted(() => ({
   conversations: {
     hide: vi.fn(),
+    isAvailable: vi.fn(() => true),
+    show: vi.fn(),
   },
   identify: vi.fn(),
   init: vi.fn(),
@@ -17,6 +20,34 @@ const posthogClient = vi.hoisted(() => ({
 
 vi.mock("posthog-js/dist/conversations", () => ({}));
 vi.mock("posthog-js/dist/module.no-external", () => ({ default: posthogClient }));
+vi.mock("@desktop/renderer/src/features/runtime/RuntimeComputerMenu", () => ({
+  default: () => <button type="button">Main computer</button>,
+}));
+vi.mock("@desktop/renderer/src/features/mission-control/AccountMenu", () => ({
+  default: () => <button type="button" aria-label="Open account menu">Avatar</button>,
+}));
+
+function renderPostHogLauncher(): HTMLDivElement {
+  let container = document.getElementById("ph-conversations-widget-container") as HTMLDivElement | null;
+  if (!container) {
+    container = document.createElement("div");
+    container.id = "ph-conversations-widget-container";
+    document.body.appendChild(container);
+  }
+  container.replaceChildren();
+  const launcher = document.createElement("button");
+  launcher.type = "button";
+  launcher.setAttribute("aria-label", "Open chat");
+  launcher.addEventListener("click", () => {
+    const close = document.createElement("button");
+    close.type = "button";
+    close.setAttribute("aria-label", "Close");
+    close.addEventListener("click", renderPostHogLauncher);
+    container?.replaceChildren(close);
+  });
+  container.appendChild(launcher);
+  return container;
+}
 
 describe("Desktop support widget", () => {
   beforeEach(() => {
@@ -37,6 +68,7 @@ describe("Desktop support widget", () => {
     vi.unstubAllEnvs();
     vi.clearAllMocks();
     vi.restoreAllMocks();
+    document.getElementById("ph-conversations-widget-container")?.remove();
   });
 
   it("fails closed when PostHog cannot initialize", async () => {
@@ -96,5 +128,39 @@ describe("Desktop support widget", () => {
 
     await waitFor(() => expect(posthogClient.conversations.hide).toHaveBeenCalledTimes(1));
     expect(posthogClient.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens support from beside the avatar without leaving the default launcher", async () => {
+    posthogClient.conversations.hide.mockImplementation(() => {
+      document.getElementById("ph-conversations-widget-container")?.remove();
+    });
+    posthogClient.conversations.show.mockImplementation(() => {
+      renderPostHogLauncher();
+    });
+
+    render(
+      <>
+        <DesktopSupportWidget />
+        <DesktopModeControls />
+      </>,
+    );
+
+    await waitFor(() => expect(posthogClient.identify).toHaveBeenCalled());
+    renderPostHogLauncher();
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull());
+
+    expect(screen.getAllByRole("button").map((button) => button.getAttribute("aria-label") ?? button.textContent))
+      .toEqual(["Main computer", "Support", "Open account menu"]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Support" }));
+
+    await waitFor(() => expect(posthogClient.conversations.show).toHaveBeenCalledTimes(1));
+    expect(await screen.findByRole("button", { name: "Close" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    await waitFor(() => expect(document.getElementById("ph-conversations-widget-container")).toBeNull());
+    expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull();
   });
 });

--- a/tests/desktop/desktop-support-widget.test.tsx
+++ b/tests/desktop/desktop-support-widget.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import DesktopSupportWidget from "@desktop/renderer/src/features/support/DesktopSupportWidget";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+
+const posthogClient = vi.hoisted(() => ({
+  conversations: {
+    hide: vi.fn(),
+  },
+  identify: vi.fn(),
+  init: vi.fn(),
+  reset: vi.fn(),
+}));
+
+vi.mock("posthog-js/dist/conversations", () => ({}));
+vi.mock("posthog-js/dist/module.no-external", () => ({ default: posthogClient }));
+
+describe("Desktop support widget", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_desktop_test");
+    vi.stubEnv("VITE_POSTHOG_HOST", "https://eu.posthog.com");
+    useConnection.setState(useConnection.getInitialState(), true);
+    useConnection.setState({
+      status: "signed-in",
+      handle: "neo",
+      displayName: "Neo",
+      platformHost: "https://app.matrix-os.com",
+      authGeneration: 1,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it("fails closed when PostHog cannot initialize", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    posthogClient.init.mockImplementationOnce(() => {
+      throw new Error("provider details must stay private");
+    });
+
+    render(<DesktopSupportWidget />);
+
+    await waitFor(() => expect(posthogClient.init).toHaveBeenCalledTimes(1));
+    expect(posthogClient.identify).not.toHaveBeenCalled();
+    expect(warning).toHaveBeenCalledWith(
+      "[desktop-support] PostHog initialization failed:",
+      "Error",
+    );
+  });
+
+  it("loads PostHog Conversations through the first-party relay without broad Desktop capture", async () => {
+    render(<DesktopSupportWidget />);
+
+    await waitFor(() => expect(posthogClient.init).toHaveBeenCalledTimes(1));
+    expect(posthogClient.init).toHaveBeenCalledWith(
+      "phc_desktop_test",
+      expect.objectContaining({
+        api_host: "https://app.matrix-os.com/relay",
+        ui_host: "https://eu.posthog.com",
+        autocapture: false,
+        capture_dead_clicks: false,
+        capture_exceptions: false,
+        capture_heatmaps: false,
+        capture_pageleave: false,
+        capture_pageview: false,
+        capture_performance: false,
+        disable_external_dependency_loading: true,
+        disable_session_recording: true,
+        disable_surveys: true,
+        rageclick: false,
+        persistence: "localStorage",
+        persistence_name: "matrix_os_desktop_support",
+      }),
+    );
+    expect(posthogClient.identify).toHaveBeenCalledWith("neo", {
+      $name: "Neo",
+      matrix_client: "desktop",
+    });
+
+    act(() => {
+      useConnection.setState({
+        status: "signed-out",
+        handle: null,
+        displayName: null,
+        imageUrl: null,
+        api: null,
+      });
+    });
+
+    await waitFor(() => expect(posthogClient.conversations.hide).toHaveBeenCalledTimes(1));
+    expect(posthogClient.reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/desktop/header-injection.test.ts
+++ b/tests/desktop/header-injection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildRendererCsp,
   installGatewayCors,
+  installHeaderInjection,
   shouldInjectAuth,
 } from "@desktop/main/auth/header-injection";
 
@@ -54,6 +55,73 @@ function corsSession() {
   };
 }
 
+type BeforeSendHeadersListener = (
+  details: { url: string; requestHeaders: Record<string, string> },
+  callback: (response: { requestHeaders: Record<string, string> }) => void,
+) => void;
+
+function headerSession() {
+  let listener: BeforeSendHeadersListener | null = null;
+  const session = {
+    webRequest: {
+      onBeforeSendHeaders: (l: BeforeSendHeadersListener) => {
+        listener = l;
+      },
+      onHeadersReceived: () => undefined,
+    },
+  };
+  return {
+    session,
+    fire(url: string, requestHeaders: Record<string, string> = {}) {
+      const cb = vi.fn();
+      listener?.({ url, requestHeaders }, cb);
+      return cb.mock.calls[0]?.[0]?.requestHeaders ?? {};
+    },
+  };
+}
+
+describe("installHeaderInjection", () => {
+  it("sets the trusted Matrix OS referrer for packaged Support widget calls", () => {
+    const { session, fire } = headerSession();
+    installHeaderInjection(session, () => null, () => GATEWAY, "null");
+
+    const headers = fire(`${GATEWAY}/relay/api/conversations/v1/widget/message`);
+
+    expect(headers.Referer).toBe("https://app.matrix-os.com/");
+  });
+
+  it("does not add the Support referrer to analytics or unrelated requests", () => {
+    const { session, fire } = headerSession();
+    installHeaderInjection(session, () => null, () => GATEWAY, "null");
+
+    expect(fire(`${GATEWAY}/relay/i/v0/e/`).Referer).toBeUndefined();
+    expect(fire(`${GATEWAY}/api/apps`).Referer).toBeUndefined();
+    expect(fire("https://eu.i.posthog.com/api/conversations/v1/widget/message").Referer)
+      .toBeUndefined();
+  });
+
+  it("does not rewrite Support referrers for the localhost development renderer", () => {
+    const { session, fire } = headerSession();
+    installHeaderInjection(session, () => null, () => GATEWAY, "http://localhost:5173");
+
+    const headers = fire(`${GATEWAY}/relay/api/conversations/v1/widget/message`);
+
+    expect(headers.Referer).toBeUndefined();
+  });
+
+  it("preserves gateway Authorization injection alongside the packaged Support referrer", () => {
+    const { session, fire } = headerSession();
+    installHeaderInjection(session, () => "matrix-token", () => GATEWAY, "null");
+
+    const headers = fire(`${GATEWAY}/relay/api/conversations/v1/widget/messages/ticket-1`);
+
+    expect(headers).toEqual({
+      Authorization: "Bearer matrix-token",
+      Referer: "https://app.matrix-os.com/",
+    });
+  });
+});
+
 describe("installGatewayCors", () => {
   it("adds Access-Control-Allow-Origin for gateway responses", () => {
     const { session, fire } = corsSession();
@@ -63,6 +131,7 @@ describe("installGatewayCors", () => {
     expect(res.responseHeaders?.["Access-Control-Allow-Headers"]?.[0]).toContain("Authorization");
     expect(res.responseHeaders?.["Access-Control-Allow-Headers"]?.[0]).toContain("x-runtime-slot");
     expect(res.responseHeaders?.["Access-Control-Allow-Headers"]?.[0]).toContain("X-Matrix-Filename");
+    expect(res.responseHeaders?.["Access-Control-Allow-Headers"]?.[0]).toContain("X-Conversations-Token");
     expect(res.responseHeaders?.["Access-Control-Allow-Credentials"]).toEqual(["true"]);
     expect(res.responseHeaders?.["content-type"]).toEqual(["application/json"]);
   });

--- a/tests/desktop/header-injection.test.ts
+++ b/tests/desktop/header-injection.test.ts
@@ -109,6 +109,16 @@ describe("installHeaderInjection", () => {
     expect(headers.Referer).toBeUndefined();
   });
 
+  it("keeps the official Matrix OS referrer when a packaged build targets a preview gateway", () => {
+    const previewGateway = "https://pr-1366---matrix-platform-preview.example.run.app";
+    const { session, fire } = headerSession();
+    installHeaderInjection(session, () => null, () => previewGateway, "null");
+
+    const headers = fire(`${previewGateway}/relay/api/conversations/v1/widget/message`);
+
+    expect(headers.Referer).toBe("https://app.matrix-os.com/");
+  });
+
   it("preserves gateway Authorization injection alongside the packaged Support referrer", () => {
     const { session, fire } = headerSession();
     installHeaderInjection(session, () => "matrix-token", () => GATEWAY, "null");

--- a/tests/platform/posthog-relay.test.ts
+++ b/tests/platform/posthog-relay.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { proxyPostHogRelay } from '../../packages/platform/src/posthog-relay.js';
+
+describe('platform PostHog relay', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('forwards the public Conversations token without forwarding Matrix authorization', async () => {
+    const upstreamFetch = vi.fn().mockResolvedValue(new Response('{}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+    vi.stubGlobal('fetch', upstreamFetch);
+    const app = new Hono();
+    app.all('/relay/*', (c) => proxyPostHogRelay(c, { logRouteError: vi.fn() }));
+
+    const response = await app.request('/relay/api/conversations/v1/widget/message?ip=0', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer matrix-session-token',
+        'content-type': 'application/json',
+        origin: 'null',
+        referer: 'https://app.matrix-os.com/',
+        'x-conversations-token': 'public-widget-token',
+      },
+      body: JSON.stringify({ message: 'support request' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(upstreamFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = upstreamFetch.mock.calls[0] as [string, RequestInit];
+    const headers = new Headers(init.headers);
+    expect(url).toBe('https://eu.i.posthog.com/api/conversations/v1/widget/message?ip=0');
+    expect(headers.get('x-conversations-token')).toBe('public-widget-token');
+    expect(headers.get('authorization')).toBeNull();
+    expect(headers.get('referer')).toBe('https://app.matrix-os.com/');
+  });
+});


### PR DESCRIPTION
## Summary

- add a Support button to the signed-in Electron Desktop header, immediately between the runtime selector and account avatar
- open PostHog Conversations from that header button while suppressing the default bottom-right PostHog launcher, including after the panel closes
- route support traffic through the existing first-party `/relay` endpoint and bundle the Conversations extension for the packaged renderer CSP
- identify the signed-in handle, reset identity on logout, and disable replay, autocapture, page/performance/error capture, surveys, and external dependency loading
- rebind the PostHog client to the selected runtime relay and cancel stale panel-open work across runtime, credential, sign-out, and unmount boundaries
- inject the existing public PostHog build variables into macOS and Linux Desktop release jobs

## Tests

- exact-head PR regression suite: 50/50 passed across Desktop release workflow, support widget, header injection, and platform relay tests
- Desktop and repository typecheck: passed
- exact-head production Desktop build with PostHog variables: passed
- exact-head packaged Desktop read-back: one Support button immediately left of the avatar; zero default `Open chat` launchers; panel initially closed on a fresh launch
- `bun run check:patterns`: 0 violations; 5 repository warning groups
- `git diff --check origin/main...HEAD`: passed
- local full `bun run test`: 11,906 passed, 20 skipped, 22 failed in unchanged date-sensitive fixtures, macOS/Linux host-script incompatibilities, Unix socket path limits, and timeout-prone suites; the two new lifecycle regressions account for the +2 passing tests versus the prior run
- the formal GitHub `CI Results` workflow remains a required merge gate

## Review / Monitoring

- Greptile reviewed `1cad01b4295bb8e887fa251330aeedb047363a75` at 3/5 and identified two valid lifecycle races
- both findings are fixed with regression coverage at exact head `851139e9bbeb0325d4aa6fde995e39dd029a6ba1`; Greptile rereview is pending
- `ready-for-ci` remains withheld until the latest trusted Greptile result is 5/5 with zero unresolved findings
- merge remains blocked until exact-head Greptile is 5/5 and label-triggered `CI Results` succeeds
- real support submission and operator reply validation still requires a deliberate test message after the platform relay fix is deployed

## Invariants

- source of truth: PostHog Conversations remains the support conversation store; Matrix OS adds no parallel support database
- lock and transaction scope: no Matrix database writes, locks, or multi-write transaction are introduced
- acceptable orphan states: relay requests may fail independently and return the existing coarse relay response; no local support record is created
- auth source of truth: existing platform authentication protects `/relay`; only the required `X-Conversations-Token` request header is forwarded to the fixed PostHog endpoint
- runtime isolation: support identity, relay configuration, and pending UI work are invalidated before a new runtime or credential generation becomes active
- deferred scope: custom support modal/chat UI, custom support persistence, session replay, and automated operator reply handling remain out of scope

## Exclusions

- no custom Platform API or Postgres support table
- no custom support modal or chat UI
- no session replay

Linear: [MAT-511](https://linear.app/matrix-os/issue/MAT-511/featdesktop-add-posthog-support-widget)