### PR TITLE
fix(onboarding): require VPS readiness before checkout

### DIFF
--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -58,6 +58,11 @@ jobs:
       GOLDEN_SNAPSHOT_BUILDS_ENABLED: ${{ vars.GOLDEN_SNAPSHOT_BUILDS_ENABLED || 'false' }}
       MATRIX_CARD_TRIALS_ENABLED: ${{ vars.MATRIX_CARD_TRIALS_ENABLED || 'true' }}
       MATRIX_CARD_TRIAL_DAYS: ${{ vars.MATRIX_CARD_TRIAL_DAYS || '3' }}
+      MATRIX_PREBILLING_PROVISIONING_ENABLED: 'true'
+      MATRIX_PREBILLING_PROVISIONING_ROLLOUT_PERCENT: '100'
+      MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE: ${{ vars.MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE || '1' }}
+      MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS: ${{ vars.MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS || '254000' }}
+      MATRIX_PREBILLING_PROVISIONING_COSTS: ${{ vars.MATRIX_PREBILLING_PROVISIONING_COSTS || 'cpx22:92900;cpx32:169900;cpx52:254000' }}
       POSTHOG_PUBLIC_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.posthog.com' }}
       POSTHOG_PUBLIC_API_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_API_HOST || '/relay' }}
       DEPLOY_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'production' }}
@@ -108,6 +113,18 @@ jobs:
           esac
           if ! [[ "$MATRIX_CARD_TRIAL_DAYS" =~ ^(0*[1-9]|0*[12][0-9]|0*30)$ ]]; then
             echo "MATRIX_CARD_TRIAL_DAYS must be an integer from 1 to 30." >&2
+            exit 1
+          fi
+          if ! [[ "$MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE" =~ ^[1-9][0-9]*$ ]]; then
+            echo "MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE must be a positive integer." >&2
+            exit 1
+          fi
+          if ! [[ "$MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS" =~ ^[1-9][0-9]*$ ]]; then
+            echo "MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS must be a positive integer." >&2
+            exit 1
+          fi
+          if ! [[ "$MATRIX_PREBILLING_PROVISIONING_COSTS" =~ ^cpx22:[1-9][0-9]*\;cpx32:[1-9][0-9]*\;cpx52:[1-9][0-9]*$ ]]; then
+            echo "MATRIX_PREBILLING_PROVISIONING_COSTS must define cpx22, cpx32, and cpx52." >&2
             exit 1
           fi
 
@@ -524,7 +541,7 @@ jobs:
             --ingress all \
             --allow-unauthenticated \
             "${traffic_flags[@]}" \
-            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_BACKGROUND_WORKERS_ENABLED=false,PLATFORM_PORT=8080,PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL},MATRIX_API_ORIGIN=${MATRIX_API_ORIGIN},CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_TLS_VERIFY=false,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_APP_DOMAIN_HOSTS=${MATRIX_APP_DOMAIN_HOSTS},MATRIX_CODE_DOMAIN_HOSTS=${MATRIX_CODE_DOMAIN_HOSTS},NEXT_PUBLIC_MATRIX_APP_URL=${MATRIX_APP_URL},MATRIX_BILLING_PROVIDER=stripe,MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED},MATRIX_CARD_TRIAL_DAYS=${MATRIX_CARD_TRIAL_DAYS},POSTHOG_HOST=https://eu.i.posthog.com,POSTHOG_API_HOST=https://eu.i.posthog.com,NEXT_PUBLIC_POSTHOG_HOST=${POSTHOG_PUBLIC_HOST},NEXT_PUBLIC_POSTHOG_API_HOST=${POSTHOG_PUBLIC_API_HOST},R2_PREFIX_ROOT=matrixos-sync,GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED},GOLDEN_SNAPSHOTS_ENABLED=false,GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0${ats_env_bindings}" \
+            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_BACKGROUND_WORKERS_ENABLED=false,PLATFORM_PORT=8080,PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL},MATRIX_API_ORIGIN=${MATRIX_API_ORIGIN},CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_TLS_VERIFY=false,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_APP_DOMAIN_HOSTS=${MATRIX_APP_DOMAIN_HOSTS},MATRIX_CODE_DOMAIN_HOSTS=${MATRIX_CODE_DOMAIN_HOSTS},NEXT_PUBLIC_MATRIX_APP_URL=${MATRIX_APP_URL},MATRIX_BILLING_PROVIDER=stripe,MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED},MATRIX_CARD_TRIAL_DAYS=${MATRIX_CARD_TRIAL_DAYS},MATRIX_PREBILLING_PROVISIONING_ENABLED=${MATRIX_PREBILLING_PROVISIONING_ENABLED},MATRIX_PREBILLING_PROVISIONING_ROLLOUT_PERCENT=${MATRIX_PREBILLING_PROVISIONING_ROLLOUT_PERCENT},MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE=${MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE},MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS=${MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS},MATRIX_PREBILLING_PROVISIONING_COSTS=${MATRIX_PREBILLING_PROVISIONING_COSTS},POSTHOG_HOST=https://eu.i.posthog.com,POSTHOG_API_HOST=https://eu.i.posthog.com,NEXT_PUBLIC_POSTHOG_HOST=${POSTHOG_PUBLIC_HOST},NEXT_PUBLIC_POSTHOG_API_HOST=${POSTHOG_PUBLIC_API_HOST},R2_PREFIX_ROOT=matrixos-sync,GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED},GOLDEN_SNAPSHOTS_ENABLED=false,GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0${ats_env_bindings}" \
             --set-secrets "PLATFORM_DATABASE_URL=platform-database-url:latest,PLATFORM_SECRET=platform-secret:latest,GOLDEN_SNAPSHOT_OPERATOR_SECRET=golden-snapshot-operator-secret:latest,PLATFORM_JWT_SECRET=platform-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,STRIPE_SECRET_KEY=stripe-secret-key:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual:latest,PIPEDREAM_CLIENT_ID=pipedream-client-id:latest,PIPEDREAM_CLIENT_SECRET=pipedream-client-secret:latest,PIPEDREAM_PROJECT_ID=pipedream-project-id:latest,PIPEDREAM_ENVIRONMENT=pipedream-environment:latest,R2_ACCOUNT_ID=r2-account-id:latest,R2_BUCKET=r2-bucket:latest,R2_ENDPOINT=r2-endpoint:latest,R2_ACCESS_KEY_ID=r2-access-key-id:latest,R2_SECRET_ACCESS_KEY=r2-secret-access-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,HETZNER_API_TOKEN=hetzner-api-token:latest,POSTHOG_TOKEN=posthog-token:latest,POSTHOG_PROJECT_TOKEN=posthog-project-token:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,NEXT_PUBLIC_POSTHOG_KEY=next-public-posthog-key:latest,NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=next-public-posthog-project-token:latest${ats_secret_bindings}" \
             --format=json); then
             exit 1
@@ -546,6 +563,30 @@ jobs:
           echo "Resolved candidate revision $candidate_revision at $candidate_url"
           echo "CANDIDATE_URL=$candidate_url" >> "$GITHUB_ENV"
           echo "CANDIDATE_REVISION=$candidate_revision" >> "$GITHUB_ENV"
+
+      - name: Verify deployed prebilling contract
+        run: |
+          set -euo pipefail
+          revision_json="$(gcloud run revisions describe "$CANDIDATE_REVISION" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_REGION" \
+            --format=json)"
+          required_prebilling_env=(
+            MATRIX_PREBILLING_PROVISIONING_ENABLED
+            MATRIX_PREBILLING_PROVISIONING_ROLLOUT_PERCENT
+            MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE
+            MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS
+            MATRIX_PREBILLING_PROVISIONING_COSTS
+          )
+          for name in "${required_prebilling_env[@]}"; do
+            expected="${!name}"
+            actual="$(printf '%s\n' "$revision_json" | jq -r --arg name "$name" \
+              '.spec.containers[0].env[]? | select(.name == $name) | .value // empty')"
+            if [ "$actual" != "$expected" ]; then
+              echo "prebilling deployment contract is missing or incorrect for $name" >&2
+              exit 1
+            fi
+          done
 
       - name: Smoke candidate revision
         run: |
@@ -694,7 +735,7 @@ jobs:
             --no-traffic \
             --min-instances "$min_instances" \
             --no-cpu-throttling \
-            --update-env-vars "PLATFORM_BACKGROUND_WORKERS_ENABLED=true,MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED},MATRIX_CARD_TRIAL_DAYS=${MATRIX_CARD_TRIAL_DAYS},GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED},GOLDEN_SNAPSHOTS_ENABLED=false,GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0" \
+            --update-env-vars "PLATFORM_BACKGROUND_WORKERS_ENABLED=true,MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED},MATRIX_CARD_TRIAL_DAYS=${MATRIX_CARD_TRIAL_DAYS},MATRIX_PREBILLING_PROVISIONING_ENABLED=${MATRIX_PREBILLING_PROVISIONING_ENABLED},MATRIX_PREBILLING_PROVISIONING_ROLLOUT_PERCENT=${MATRIX_PREBILLING_PROVISIONING_ROLLOUT_PERCENT},MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE=${MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE},MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS=${MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS},MATRIX_PREBILLING_PROVISIONING_COSTS=${MATRIX_PREBILLING_PROVISIONING_COSTS},GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED},GOLDEN_SNAPSHOTS_ENABLED=false,GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=0" \
             --format=json)"
           production_revision="$(printf '%s\n' "$deploy_json" | jq -r '.status.traffic[]? | select(.tag == "production-candidate") | .revisionName // empty' | head -1)"
           if [ -z "$production_revision" ]; then

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -5,6 +5,7 @@ import { MATRIX_TELEMETRY_EVENTS } from '@matrix-os/observability';
 import { z } from 'zod/v4';
 import { appOrigin, resolveReturnPath } from './origins.js';
 import {
+  abandonCreatingCheckoutAttempt,
   claimCardTrialCheckoutAttempt,
   claimCheckoutAttempt,
   cancelOutstandingBillingRuntimeActions,
@@ -115,6 +116,10 @@ const BillingStatusQuerySchema = z.object({
   runtimeSlot: RuntimeSlotSchema.optional(),
 }).strict();
 
+const CheckoutPreparationStatusQuerySchema = z.object({
+  attemptId: z.uuid(),
+}).strict();
+
 export interface StripeCheckoutSessionInput {
   idempotencyKey: string;
   clerkUserId: string;
@@ -184,13 +189,15 @@ export interface PrebillingCheckoutCoordinator {
     intentId: string;
     stripeSessionId: string;
     stripeSessionExpiresAt: string;
-  }): Promise<void>;
+  }): Promise<boolean>;
+  getPreparationStatus(input: {
+    checkoutAttemptId: string;
+    clerkUserId: string;
+  }): Promise<'preparing' | 'ready' | 'failed'>;
   authorizeSubscription(
     db: PlatformDB,
     input: { intentId: string; clerkUserId: string; runtimeSlot: string; now: string },
-  ): Promise<{ authorized: boolean; machineId: string | null; needsFallback: boolean }>;
-  ensureFallback(input: { intentId: string }): Promise<void>;
-  reconcileFallbacks?(): Promise<{ checked: number; completed: number; failed: number }>;
+  ): Promise<{ authorized: boolean; machineId: string | null }>;
   expireCheckout(
     db: PlatformDB,
     input: { stripeSessionId: string; intentId?: string; clerkUserId?: string; now: string },
@@ -218,6 +225,8 @@ export function createBillingRoutes(options: {
   const app = new Hono();
   const env = options.env ?? process.env;
   const cardTrialDays = resolveCardTrialDays(env);
+  const primaryPrebillingRequired = env.CUSTOMER_VPS_ENABLED === 'true'
+    && env.MATRIX_BILLING_PROVIDER === 'stripe';
   const now = options.now ?? (() => new Date());
   const persistEntitlement = options.upsertEntitlement ?? upsertBillingEntitlement;
 
@@ -241,6 +250,33 @@ export function createBillingRoutes(options: {
       console.warn(`[billing] ${route} auth resolution failed:`, err instanceof Error ? err.name : typeof err);
       return null;
     }
+  }
+
+  async function preparedCheckoutResponse(
+    c: Context,
+    clerkUserId: string,
+    attempt: NonNullable<Awaited<ReturnType<typeof getActiveCheckoutAttempt>>>,
+  ) {
+    if (attempt.runtimeSlot !== 'primary') {
+      if (!attempt.checkoutUrl) throw new Error('checkout_url_missing');
+      return c.json({ url: attempt.checkoutUrl }, 200);
+    }
+    if (!options.prebilling) {
+      if (primaryPrebillingRequired) return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
+      if (!attempt.checkoutUrl) throw new Error('checkout_url_missing');
+      return c.json({ url: attempt.checkoutUrl }, 200);
+    }
+    const status = await options.prebilling.getPreparationStatus({
+      checkoutAttemptId: attempt.id,
+      clerkUserId,
+    });
+    if (status === 'preparing') {
+      return c.json({ status: 'preparing', attemptId: attempt.id }, 202);
+    }
+    if (status !== 'ready' || !attempt.checkoutUrl) {
+      return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
+    }
+    return c.json({ url: attempt.checkoutUrl }, 200);
   }
 
   app.post('/checkout', bodyLimit({ maxSize: BILLING_BODY_LIMIT }), async (c) => {
@@ -332,6 +368,9 @@ export function createBillingRoutes(options: {
       if (parsed.data.serverType && parsed.data.serverType !== serverType) {
         return c.json({ error: 'Invalid request' }, 400);
       }
+      if (primaryPrebillingRequired && parsed.data.runtimeSlot === 'primary' && !options.prebilling) {
+        return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
+      }
       const checkoutClaim = {
         clerkUserId,
         createdAt: currentTime.toISOString(),
@@ -399,6 +438,9 @@ export function createBillingRoutes(options: {
               && recoveredPlan.interval === parsed.data.interval
               && recoveredRegion.data === parsed.data.regionSlug
             ) {
+              if (parsed.data.runtimeSlot === 'primary' && options.prebilling) {
+                return preparedCheckoutResponse(c, clerkUserId, attempt.attempt);
+              }
               return c.json({ url: session.url }, 200);
             }
             return c.json({
@@ -415,7 +457,7 @@ export function createBillingRoutes(options: {
       }
       if (!attempt.claimed) {
         if (attempt.selectionMatches && attempt.attempt.status === 'open' && attempt.attempt.checkoutUrl) {
-          return c.json({ url: attempt.attempt.checkoutUrl }, 200);
+          return preparedCheckoutResponse(c, clerkUserId, attempt.attempt);
         }
         if (
           !attempt.selectionMatches
@@ -458,6 +500,10 @@ export function createBillingRoutes(options: {
           console.warn('[billing] prebilling intent unavailable:', err instanceof Error ? err.name : typeof err);
         }
       }
+      if (options.prebilling && parsed.data.runtimeSlot === 'primary' && !preparation) {
+        await abandonCreatingCheckoutAttempt(options.db, attempt.attempt.id, currentTime.toISOString());
+        return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
+      }
       const session = await options.stripe.createCheckoutSession({
         idempotencyKey: attempt.attempt.id,
         clerkUserId,
@@ -482,20 +528,27 @@ export function createBillingRoutes(options: {
       }
       if (preparation) {
         try {
-          await options.prebilling?.startPreparation({
+          const started = await options.prebilling?.startPreparation({
             intentId: preparation.intentId,
             stripeSessionId: session.id,
             stripeSessionExpiresAt: session.expiresAt ?? preparation.expiresAt,
           });
+          if (!started) return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
         } catch (err: unknown) {
           console.warn('[billing] prebilling preparation unavailable:', err instanceof Error ? err.name : typeof err);
+          return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
         }
       }
       emitTelemetry(BILLING_CHECKOUT_CREATED_EVENT, {
         distinctId: clerkUserId,
         properties: checkoutProperties,
       });
-      return c.json({ url: session.url }, 200);
+      return preparedCheckoutResponse(c, clerkUserId, {
+        ...attempt.attempt,
+        stripeSessionId: session.id,
+        checkoutUrl: session.url,
+        status: 'open',
+      });
     } catch (err: unknown) {
       console.error('[billing] checkout creation failed:', err instanceof Error ? err.message : String(err));
       emitTelemetry(BILLING_CHECKOUT_FAILED_EVENT, {
@@ -506,6 +559,23 @@ export function createBillingRoutes(options: {
           http_status: 503,
         },
       });
+      return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
+    }
+  });
+
+  app.get('/checkout/status', async (c) => {
+    const clerkUserId = await resolveRouteClerkUserId(c, 'checkout status');
+    if (!clerkUserId) return c.json({ error: 'Unauthorized' }, 401);
+    const parsed = CheckoutPreparationStatusQuerySchema.safeParse(c.req.query());
+    if (!parsed.success) return c.json({ error: 'Invalid request' }, 400);
+    try {
+      const attempt = await getActiveCheckoutAttempt(options.db, clerkUserId, 'primary');
+      if (!attempt || attempt.id !== parsed.data.attemptId) {
+        return c.json({ error: 'Checkout unavailable' }, 404);
+      }
+      return preparedCheckoutResponse(c, clerkUserId, attempt);
+    } catch (err: unknown) {
+      console.error('[billing] checkout status failed:', err instanceof Error ? err.name : typeof err);
       return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
     }
   });
@@ -625,7 +695,6 @@ export function createBillingRoutes(options: {
 
     try {
       const webhookProcessedAt = now();
-      let fallbackIntentId: string | undefined;
       const result = await runBillingWebhookTransaction(options.db, async (trx) => {
         const inserted = await insertBillingWebhookEvent(trx, {
           stripeEventId: event.id,
@@ -830,13 +899,13 @@ export function createBillingRoutes(options: {
           && projection.prebillingIntentId
           && getRuntimeAccessDecision(summary, webhookProcessedAt).runtimeProxyAllowed
         ) {
-          const authorization = await options.prebilling?.authorizeSubscription(trx, {
+          if (!options.prebilling) throw new Error('prebilling_authorization_unavailable');
+          await options.prebilling.authorizeSubscription(trx, {
             intentId: projection.prebillingIntentId,
             clerkUserId: projection.clerkUserId,
             runtimeSlot: projection.runtimeSlot,
             now: webhookProcessedAt.toISOString(),
           });
-          if (authorization?.needsFallback) fallbackIntentId = projection.prebillingIntentId;
         }
         emitTelemetry(BILLING_SUBSCRIPTION_UPDATED_EVENT, {
           distinctId: entitlement.clerkUserId,
@@ -876,15 +945,6 @@ export function createBillingRoutes(options: {
         }
         return { received: true, processed: true };
       });
-      if (!fallbackIntentId && 'duplicate' in result && result.duplicate && isSubscriptionEvent(event.type)) {
-        const subscription = event.data.object && typeof event.data.object === 'object'
-          ? event.data.object as { status?: unknown; metadata?: unknown }
-          : undefined;
-        if (['active', 'trialing', 'past_due'].includes(String(subscription?.status))) {
-          fallbackIntentId = readPrebillingIntentIdFromStripeMetadata(subscription?.metadata) ?? undefined;
-        }
-      }
-      if (fallbackIntentId) await options.prebilling?.ensureFallback({ intentId: fallbackIntentId });
       return c.json(result, 200);
     } catch (err: unknown) {
       console.error('[billing] Stripe webhook processing failed:', err instanceof Error ? err.message : String(err));

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -194,6 +194,10 @@ export interface PrebillingCheckoutCoordinator {
     checkoutAttemptId: string;
     clerkUserId: string;
   }): Promise<'preparing' | 'ready' | 'failed'>;
+  retryPreparation(input: {
+    checkoutAttemptId: string;
+    clerkUserId: string;
+  }): Promise<boolean>;
   authorizeSubscription(
     db: PlatformDB,
     input: { intentId: string; clerkUserId: string; runtimeSlot: string; now: string },
@@ -256,6 +260,7 @@ export function createBillingRoutes(options: {
     c: Context,
     clerkUserId: string,
     attempt: NonNullable<Awaited<ReturnType<typeof getActiveCheckoutAttempt>>>,
+    retryFailed = false,
   ) {
     if (attempt.runtimeSlot !== 'primary') {
       if (!attempt.checkoutUrl) throw new Error('checkout_url_missing');
@@ -266,10 +271,22 @@ export function createBillingRoutes(options: {
       if (!attempt.checkoutUrl) throw new Error('checkout_url_missing');
       return c.json({ url: attempt.checkoutUrl }, 200);
     }
-    const status = await options.prebilling.getPreparationStatus({
+    let status = await options.prebilling.getPreparationStatus({
       checkoutAttemptId: attempt.id,
       clerkUserId,
     });
+    if (status === 'failed' && retryFailed) {
+      const restarted = await options.prebilling.retryPreparation({
+        checkoutAttemptId: attempt.id,
+        clerkUserId,
+      });
+      if (restarted) {
+        status = await options.prebilling.getPreparationStatus({
+          checkoutAttemptId: attempt.id,
+          clerkUserId,
+        });
+      }
+    }
     if (status === 'preparing') {
       return c.json({ status: 'preparing', attemptId: attempt.id }, 202);
     }
@@ -439,7 +456,7 @@ export function createBillingRoutes(options: {
               && recoveredRegion.data === parsed.data.regionSlug
             ) {
               if (parsed.data.runtimeSlot === 'primary' && options.prebilling) {
-                return preparedCheckoutResponse(c, clerkUserId, attempt.attempt);
+                return preparedCheckoutResponse(c, clerkUserId, attempt.attempt, true);
               }
               return c.json({ url: session.url }, 200);
             }
@@ -457,7 +474,7 @@ export function createBillingRoutes(options: {
       }
       if (!attempt.claimed) {
         if (attempt.selectionMatches && attempt.attempt.status === 'open' && attempt.attempt.checkoutUrl) {
-          return preparedCheckoutResponse(c, clerkUserId, attempt.attempt);
+          return preparedCheckoutResponse(c, clerkUserId, attempt.attempt, true);
         }
         if (
           !attempt.selectionMatches

--- a/packages/platform/src/customer-vps-provisioning-jobs.ts
+++ b/packages/platform/src/customer-vps-provisioning-jobs.ts
@@ -1,4 +1,5 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+import { sql } from 'kysely';
 import { z } from 'zod/v4';
 import type { PlatformDB } from './db.js';
 
@@ -348,19 +349,30 @@ export async function failProvisioningJob(
   errorCode: string,
 ): Promise<boolean> {
   await db.ready;
-  const row = await db.executor
-    .updateTable('provisioning_jobs')
-    .set({
-      status: 'failed',
-      encrypted_payload: null,
-      lease_expires_at: null,
-      updated_at: now,
-      completed_at: now,
-      last_error_code: errorCode.slice(0, 64),
-    })
-    .where('job_id', '=', jobId)
-    .where('status', '=', 'running')
-    .returning('job_id')
-    .executeTakeFirst();
-  return Boolean(row);
+  const boundedErrorCode = errorCode.slice(0, 64);
+  const result = await sql<{ failed: boolean }>`
+    WITH failed_job AS (
+      UPDATE provisioning_jobs
+      SET status = 'failed',
+          encrypted_payload = NULL,
+          lease_expires_at = NULL,
+          updated_at = ${now},
+          completed_at = ${now},
+          last_error_code = ${boundedErrorCode}
+      WHERE job_id = ${jobId} AND status = 'running'
+      RETURNING prebilling_intent_id
+    ), failed_intent AS (
+      UPDATE prebilling_provisioning_intents
+      SET state = 'preparation_failed',
+          reserved_hourly_cost_micros = 0,
+          last_error_code = ${boundedErrorCode},
+          revision = revision + 1,
+          updated_at = ${now}
+      WHERE id = (SELECT prebilling_intent_id FROM failed_job)
+        AND state = 'preparing'
+      RETURNING id
+    )
+    SELECT EXISTS(SELECT 1 FROM failed_job) AS failed
+  `.execute(db.executor);
+  return result.rows[0]?.failed ?? false;
 }

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -92,7 +92,11 @@ import {
   type NewProvisioningJob,
   type ProvisioningPayload,
 } from './customer-vps-provisioning-jobs.js';
-import { bindPrebillingIntentMachine, validatePrebillingProvisioningIntent } from './prebilling-provisioning-store.js';
+import {
+  bindPrebillingIntentMachine,
+  markPrebillingIntentReady,
+  validatePrebillingProvisioningIntent,
+} from './prebilling-provisioning-store.js';
 import { isProvisioningJobAuthorized, persistProvisioningClaimMutation } from './customer-vps-prebilling.js';
 import {
   chooseProvisioningImage,
@@ -2279,6 +2283,18 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           },
         );
         if (!registered) throw new CustomerVpsError(409, 'invalid_state', 'Machine cannot register');
+        if (row.prebillingIntentId) {
+          const markedReady = await markPrebillingIntentReady(trx, {
+            intentId: row.prebillingIntentId,
+            machineId: row.machineId,
+            clerkUserId: row.clerkUserId,
+            runtimeSlot: row.runtimeSlot,
+            now: lastSeenAt,
+          });
+          if (!markedReady) {
+            throw new CustomerVpsError(409, 'registration_rejected', 'Registration rejected');
+          }
+        }
         if (row.recoveryOldServerId !== null) {
           await enqueueProviderDeletionTx(trx, {
             providerServerId: row.recoveryOldServerId,

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -4392,6 +4392,31 @@ export async function finalizeCheckoutAttempt(
     && existing.checkout_url === checkoutUrl;
 }
 
+export async function abandonCreatingCheckoutAttempt(
+  db: PlatformDB,
+  id: string,
+  resolvedAt: string,
+): Promise<boolean> {
+  await db.ready;
+  return db.transaction(async (trx) => {
+    const abandoned = await trx.executor
+      .updateTable('billing_checkout_attempts')
+      .set({ status: 'abandoned', resolved_at: resolvedAt })
+      .where('id', '=', id)
+      .where('status', '=', 'creating')
+      .where('stripe_session_id', 'is', null)
+      .returning('id')
+      .executeTakeFirst();
+    if (!abandoned) return false;
+    await trx.executor
+      .updateTable('billing_trial_accounts')
+      .set({ trial_checkout_attempt_id: null, updated_at: resolvedAt })
+      .where('trial_checkout_attempt_id', '=', id)
+      .execute();
+    return true;
+  });
+}
+
 export async function getLatestCheckoutAttempt(
   db: PlatformDB,
   clerkUserId: string,

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -553,9 +553,6 @@ export function createApp(deps: {
         }),
       })
     : undefined;
-  deps.customerVpsService?.setPrebillingFallbackReconciler?.(
-    prebilling ? async () => { await prebilling.reconcileFallbacks?.(); } : undefined,
-  );
   app.route('/billing', createBillingRoutes({
     db,
     stripe: appEnv.STRIPE_SECRET_KEY

--- a/packages/platform/src/prebilling-provisioning-config.ts
+++ b/packages/platform/src/prebilling-provisioning-config.ts
@@ -38,6 +38,24 @@ function parseCosts(value: string | undefined): ReadonlyMap<string, number> {
   }
 }
 
+function parseCompactCosts(value: string | undefined): ReadonlyMap<string, number> {
+  if (!value) return new Map();
+  try {
+    const entries = value.split(';').filter(Boolean).map((entry) => {
+      const separator = entry.indexOf(':');
+      if (separator <= 0) throw new Error('invalid_prebilling_cost_entry');
+      return [entry.slice(0, separator), Number(entry.slice(separator + 1))] as const;
+    });
+    if (entries.length > MAX_COST_ENTRIES) return new Map();
+    return new Map(Object.entries(CostMapSchema.parse(Object.fromEntries(entries))));
+  } catch (err: unknown) {
+    if (err instanceof z.ZodError || (err instanceof Error && err.message === 'invalid_prebilling_cost_entry')) {
+      return new Map();
+    }
+    throw err;
+  }
+}
+
 export function loadPrebillingProvisioningConfig(env: NodeJS.ProcessEnv): PrebillingProvisioningConfig {
   const enabled = env.MATRIX_PREBILLING_PROVISIONING_ENABLED === 'true';
   return {
@@ -57,7 +75,9 @@ export function loadPrebillingProvisioningConfig(env: NodeJS.ProcessEnv): Prebil
     // otherwise valid checkout is not rejected after spending a few seconds
     // in transit.
     leaseMs: 31 * 60 * 1_000,
-    serverHourlyCostMicros: parseCosts(env.MATRIX_PREBILLING_PROVISIONING_COSTS_JSON),
+    serverHourlyCostMicros: env.MATRIX_PREBILLING_PROVISIONING_COSTS
+      ? parseCompactCosts(env.MATRIX_PREBILLING_PROVISIONING_COSTS)
+      : parseCosts(env.MATRIX_PREBILLING_PROVISIONING_COSTS_JSON),
   };
 }
 

--- a/packages/platform/src/prebilling-provisioning-store.ts
+++ b/packages/platform/src/prebilling-provisioning-store.ts
@@ -402,6 +402,26 @@ export async function markPrebillingPreparationFailed(
   return Boolean(updated);
 }
 
+export async function resetPrebillingPreparationForRetry(
+  db: PlatformDB,
+  input: { intentId: string; clerkUserId: string; now: string },
+): Promise<boolean> {
+  await db.ready;
+  const updated = await db.executor.updateTable('prebilling_provisioning_intents').set((eb) => ({
+    state: 'awaiting_checkout',
+    reserved_hourly_cost_micros: 0,
+    last_error_code: null,
+    revision: eb('revision', '+', 1),
+    updated_at: input.now,
+  })).where('id', '=', input.intentId)
+    .where('clerk_user_id', '=', input.clerkUserId)
+    .where('state', 'in', ['preparation_failed', 'preparation_deferred'])
+    .where('stripe_session_id', 'is not', null)
+    .where('stripe_session_expires_at', '>', input.now)
+    .returning('id').executeTakeFirst();
+  return Boolean(updated);
+}
+
 /** Must be called inside the signed billing projection transaction. */
 export async function authorizePrebillingIntent(
   db: PlatformDB,

--- a/packages/platform/src/prebilling-provisioning-store.ts
+++ b/packages/platform/src/prebilling-provisioning-store.ts
@@ -329,34 +329,110 @@ export async function bindPrebillingIntentMachine(
   return Boolean(row);
 }
 
+/** Marks an exact fenced machine ready only after its registration transaction
+ * has made the machine running. The intent and machine transition together, so
+ * checkout can never observe readiness ahead of durable runtime registration. */
+export async function markPrebillingIntentReady(
+  db: PlatformDB,
+  input: {
+    intentId: string;
+    machineId: string;
+    clerkUserId: string;
+    runtimeSlot: string;
+    now: string;
+  },
+): Promise<boolean> {
+  await db.ready;
+  const updated = await sql<{ ready: boolean }>`
+    WITH marked AS (
+      UPDATE prebilling_provisioning_intents AS intent
+      SET state = 'ready_waiting_for_billing',
+          ready_at = ${input.now},
+          revision = intent.revision + 1,
+          updated_at = ${input.now}
+      WHERE intent.id = ${input.intentId}
+        AND intent.machine_id = ${input.machineId}
+        AND intent.clerk_user_id = ${input.clerkUserId}
+        AND intent.runtime_slot = ${input.runtimeSlot}
+        AND intent.state = 'preparing'
+        AND EXISTS (
+          SELECT 1
+          FROM user_machines AS machine
+          WHERE machine.machine_id = ${input.machineId}
+            AND machine.prebilling_intent_id = intent.id
+            AND machine.clerk_user_id = intent.clerk_user_id
+            AND machine.runtime_slot = intent.runtime_slot
+            AND machine.status = 'running'
+            AND machine.activation_state = 'awaiting_billing'
+            AND machine.deleted_at IS NULL
+        )
+      RETURNING intent.id
+    )
+    SELECT EXISTS(SELECT 1 FROM marked) OR EXISTS(
+      SELECT 1
+      FROM prebilling_provisioning_intents AS intent
+      JOIN user_machines AS machine ON machine.machine_id = intent.machine_id
+      WHERE intent.id = ${input.intentId}
+        AND intent.machine_id = ${input.machineId}
+        AND intent.clerk_user_id = ${input.clerkUserId}
+        AND intent.runtime_slot = ${input.runtimeSlot}
+        AND intent.state = 'authorized'
+        AND machine.status = 'running'
+        AND machine.activation_state = 'authorized'
+        AND machine.deleted_at IS NULL
+    ) AS ready
+  `.execute(db.executor);
+  return updated.rows[0]?.ready ?? false;
+}
+
+export async function markPrebillingPreparationFailed(
+  db: PlatformDB,
+  input: { intentId: string; now: string; errorCode: string },
+): Promise<boolean> {
+  await db.ready;
+  const updated = await db.executor.updateTable('prebilling_provisioning_intents').set((eb) => ({
+    state: 'preparation_failed',
+    reserved_hourly_cost_micros: 0,
+    last_error_code: input.errorCode.slice(0, 64),
+    revision: eb('revision', '+', 1),
+    updated_at: input.now,
+  })).where('id', '=', input.intentId)
+    .where('state', '=', 'preparing')
+    .returning('id').executeTakeFirst();
+  return Boolean(updated);
+}
+
 /** Must be called inside the signed billing projection transaction. */
 export async function authorizePrebillingIntent(
   db: PlatformDB,
   input: { intentId: string; clerkUserId: string; runtimeSlot: string; now: string },
-): Promise<{ authorized: boolean; machineId: string | null; needsFallback: boolean }> {
+): Promise<{ authorized: boolean; machineId: string | null }> {
   await db.ready;
   const current = await db.executor.selectFrom('prebilling_provisioning_intents').selectAll()
     .where('id', '=', input.intentId)
     .where('clerk_user_id', '=', input.clerkUserId)
     .where('runtime_slot', '=', input.runtimeSlot)
     .forUpdate().executeTakeFirst();
-  if (!current) return { authorized: false, machineId: null, needsFallback: false };
+  if (!current) throw new Error('prebilling_intent_not_found');
   const intent = mapIntent(current);
   if (intent.state === 'authorized') {
-    return { authorized: true, machineId: intent.machineId, needsFallback: intent.machineId === null };
+    if (!intent.machineId) throw new Error('prebilling_machine_not_ready');
+    return { authorized: true, machineId: intent.machineId };
   }
-  if (intent.machineId) {
-    const activated = await db.executor.updateTable('user_machines').set({
-      activation_state: 'authorized',
-      activation_authorized_at: input.now,
-    }).where('machine_id', '=', intent.machineId)
-      .where('prebilling_intent_id', '=', intent.id)
-      .where('clerk_user_id', '=', input.clerkUserId)
-      .where('runtime_slot', '=', input.runtimeSlot)
-      .where('activation_state', '=', 'awaiting_billing')
-      .returning('machine_id').executeTakeFirst();
-    if (!activated) throw new Error('prebilling_machine_activation_mismatch');
+  if (intent.state !== 'ready_waiting_for_billing' || !intent.machineId) {
+    throw new Error('prebilling_machine_not_ready');
   }
+  const activated = await db.executor.updateTable('user_machines').set({
+    activation_state: 'authorized',
+    activation_authorized_at: input.now,
+  }).where('machine_id', '=', intent.machineId)
+    .where('prebilling_intent_id', '=', intent.id)
+    .where('clerk_user_id', '=', input.clerkUserId)
+    .where('runtime_slot', '=', input.runtimeSlot)
+    .where('status', '=', 'running')
+    .where('activation_state', '=', 'awaiting_billing')
+    .returning('machine_id').executeTakeFirst();
+  if (!activated) throw new Error('prebilling_machine_activation_mismatch');
   const authorized = await db.executor.updateTable('prebilling_provisioning_intents').set({
     state: 'authorized',
     authorized_at: input.now,
@@ -367,7 +443,7 @@ export async function authorizePrebillingIntent(
   }).where('id', '=', intent.id).where('revision', '=', intent.revision)
     .returning('id').executeTakeFirst();
   if (!authorized) throw new Error('prebilling_authorization_conflict');
-  return { authorized: true, machineId: intent.machineId, needsFallback: intent.machineId === null };
+  return { authorized: true, machineId: intent.machineId };
 }
 
 /** Must be called inside the verified Stripe webhook transaction. */

--- a/packages/platform/src/prebilling-provisioning.ts
+++ b/packages/platform/src/prebilling-provisioning.ts
@@ -11,16 +11,12 @@ import {
 import {
   admitPrebillingIntent,
   authorizePrebillingIntent,
-  bindAuthorizedPrebillingFallbackMachine,
-  claimAuthorizedPrebillingFallbackIntent,
   cleanupExpiredPrebillingCheckout,
   createPrebillingIntent,
   getPrebillingIntent,
-  listAuthorizedPrebillingFallbackIntents,
-  releaseAuthorizedPrebillingFallbackClaim,
+  getPrebillingIntentByCheckoutAttempt,
+  markPrebillingPreparationFailed,
 } from './prebilling-provisioning-store.js';
-
-const FALLBACK_CLAIM_LEASE_MS = 5 * 60 * 1000;
 
 export function createPrebillingProvisioningCoordinator(options: {
   db: PlatformDB;
@@ -43,33 +39,6 @@ export function createPrebillingProvisioningCoordinator(options: {
 }): PrebillingCheckoutCoordinator {
   const intentIdFactory = options.intentIdFactory ?? randomUUID;
   const now = options.now ?? (() => new Date());
-  const ensureFallback = async (intentId: string) => {
-    const claimedAt = now();
-    const leaseExpiresAt = new Date(claimedAt.getTime() + FALLBACK_CLAIM_LEASE_MS).toISOString();
-    const current = await claimAuthorizedPrebillingFallbackIntent(options.db, {
-      intentId, now: claimedAt.toISOString(), leaseExpiresAt,
-    });
-    if (!current) return false;
-    try {
-      const identity = await options.resolveIdentity(current.clerkUserId);
-      if (!identity) throw new Error('prebilling_identity_unavailable');
-      const provisioned = await options.customerVpsService.provision({
-        clerkUserId: current.clerkUserId, handle: identity.handle, runtimeSlot: 'primary', serverType: current.serverType,
-        location: z.enum(['fsn1', 'nbg1', 'ash', 'hil']).parse(current.regionSlug.replace(/^region_/, '')),
-        developerTools: current.developerTools,
-      }, { dispatch: 'detached' });
-      if (!await bindAuthorizedPrebillingFallbackMachine(options.db, {
-        intentId, clerkUserId: current.clerkUserId, runtimeSlot: current.runtimeSlot,
-        machineId: provisioned.machineId, leaseExpiresAt, now: now().toISOString(),
-      })) throw new Error('prebilling_fallback_binding_conflict');
-      await options.onProvisioned?.({ clerkUserId: current.clerkUserId, handle: identity.handle,
-        displayName: identity.displayName, email: identity.email, machineId: provisioned.machineId });
-      return true;
-    } catch (err: unknown) {
-      await releaseAuthorizedPrebillingFallbackClaim(options.db, { intentId, leaseExpiresAt, now: now().toISOString() });
-      throw err;
-    }
-  };
   return {
     async createIntent(input) {
       if (!prebillingRolloutIncludesUser(options.config, input.clerkUserId)) return undefined;
@@ -91,9 +60,9 @@ export function createPrebillingProvisioningCoordinator(options: {
 
     async startPreparation(input) {
       const current = await getPrebillingIntent(options.db, input.intentId);
-      if (!current) return;
+      if (!current) return false;
       const cost = prebillingHourlyCostMicros(options.config, current.serverType);
-      if (cost === null) return;
+      if (cost === null) return false;
       const admission = await admitPrebillingIntent(options.db, {
         ...input,
         reservedHourlyCostMicros: cost,
@@ -101,47 +70,48 @@ export function createPrebillingProvisioningCoordinator(options: {
         maxHourlyCostMicros: options.config.maxHourlyCostMicros,
         now: now().toISOString(),
       });
-      if (!admission.admitted) return;
-      const identity = await options.resolveIdentity(current.clerkUserId);
-      if (!identity) throw new Error('prebilling_identity_unavailable');
-      const provisioned = await options.customerVpsService.provisionForCheckout({
-        clerkUserId: current.clerkUserId,
-        handle: identity.handle,
-        runtimeSlot: 'primary',
-        serverType: current.serverType,
-        location: z.enum(['fsn1', 'nbg1', 'ash', 'hil']).parse(
-          current.regionSlug.replace(/^region_/, ''),
-        ),
-        developerTools: current.developerTools,
-      }, current.id, { dispatch: 'detached' });
-      await options.onProvisioned?.({
-        clerkUserId: current.clerkUserId,
-        handle: identity.handle,
-        displayName: identity.displayName,
-        email: identity.email,
-        machineId: provisioned.machineId,
-      });
+      if (!admission.admitted) return false;
+      try {
+        const identity = await options.resolveIdentity(current.clerkUserId);
+        if (!identity) throw new Error('prebilling_identity_unavailable');
+        const provisioned = await options.customerVpsService.provisionForCheckout({
+          clerkUserId: current.clerkUserId,
+          handle: identity.handle,
+          runtimeSlot: 'primary',
+          serverType: current.serverType,
+          location: z.enum(['fsn1', 'nbg1', 'ash', 'hil']).parse(
+            current.regionSlug.replace(/^region_/, ''),
+          ),
+          developerTools: current.developerTools,
+        }, current.id, { dispatch: 'detached' });
+        await options.onProvisioned?.({
+          clerkUserId: current.clerkUserId,
+          handle: identity.handle,
+          displayName: identity.displayName,
+          email: identity.email,
+          machineId: provisioned.machineId,
+        });
+        return true;
+      } catch (err: unknown) {
+        await markPrebillingPreparationFailed(options.db, {
+          intentId: current.id,
+          now: now().toISOString(),
+          errorCode: err instanceof Error ? err.name : 'preparation_failed',
+        });
+        throw err;
+      }
+    },
+
+    async getPreparationStatus(input) {
+      const intent = await getPrebillingIntentByCheckoutAttempt(options.db, input.checkoutAttemptId);
+      if (!intent || intent.clerkUserId !== input.clerkUserId) return 'failed';
+      if (intent.state === 'ready_waiting_for_billing') return 'ready';
+      if (intent.state === 'awaiting_checkout' || intent.state === 'preparing') return 'preparing';
+      return 'failed';
     },
 
     authorizeSubscription(db, input) {
       return authorizePrebillingIntent(db, input);
-    },
-
-    async ensureFallback(input) {
-      await ensureFallback(input.intentId);
-    },
-
-    async reconcileFallbacks() {
-      const intents = await listAuthorizedPrebillingFallbackIntents(options.db, now().toISOString());
-      let completed = 0; let failed = 0;
-      for (const intent of intents) {
-        try { if (await ensureFallback(intent.id)) completed += 1; }
-        catch (err: unknown) {
-          failed += 1;
-          console.error('[prebilling] fallback reconciliation failed:', err instanceof Error ? err.name : typeof err);
-        }
-      }
-      return { checked: intents.length, completed, failed };
     },
 
     expireCheckout(db, input) {

--- a/packages/platform/src/prebilling-provisioning.ts
+++ b/packages/platform/src/prebilling-provisioning.ts
@@ -16,6 +16,7 @@ import {
   getPrebillingIntent,
   getPrebillingIntentByCheckoutAttempt,
   markPrebillingPreparationFailed,
+  resetPrebillingPreparationForRetry,
 } from './prebilling-provisioning-store.js';
 
 export function createPrebillingProvisioningCoordinator(options: {
@@ -39,6 +40,58 @@ export function createPrebillingProvisioningCoordinator(options: {
 }): PrebillingCheckoutCoordinator {
   const intentIdFactory = options.intentIdFactory ?? randomUUID;
   const now = options.now ?? (() => new Date());
+  const startPreparation: PrebillingCheckoutCoordinator['startPreparation'] = async (input) => {
+    const current = await getPrebillingIntent(options.db, input.intentId);
+    if (!current) return false;
+    const cost = prebillingHourlyCostMicros(options.config, current.serverType);
+    if (cost === null) {
+      if (current.stripeSessionId) {
+        await markPrebillingPreparationFailed(options.db, {
+          intentId: current.id,
+          now: now().toISOString(),
+          errorCode: 'prebilling_cost_unavailable',
+        });
+      }
+      return false;
+    }
+    const admission = await admitPrebillingIntent(options.db, {
+      ...input,
+      reservedHourlyCostMicros: cost,
+      maxActive: options.config.maxActive,
+      maxHourlyCostMicros: options.config.maxHourlyCostMicros,
+      now: now().toISOString(),
+    });
+    if (!admission.admitted) return false;
+    try {
+      const identity = await options.resolveIdentity(current.clerkUserId);
+      if (!identity) throw new Error('prebilling_identity_unavailable');
+      const provisioned = await options.customerVpsService.provisionForCheckout({
+        clerkUserId: current.clerkUserId,
+        handle: identity.handle,
+        runtimeSlot: 'primary',
+        serverType: current.serverType,
+        location: z.enum(['fsn1', 'nbg1', 'ash', 'hil']).parse(
+          current.regionSlug.replace(/^region_/, ''),
+        ),
+        developerTools: current.developerTools,
+      }, current.id, { dispatch: 'detached' });
+      await options.onProvisioned?.({
+        clerkUserId: current.clerkUserId,
+        handle: identity.handle,
+        displayName: identity.displayName,
+        email: identity.email,
+        machineId: provisioned.machineId,
+      });
+      return true;
+    } catch (err: unknown) {
+      await markPrebillingPreparationFailed(options.db, {
+        intentId: current.id,
+        now: now().toISOString(),
+        errorCode: err instanceof Error ? err.name : 'preparation_failed',
+      });
+      throw err;
+    }
+  };
   return {
     async createIntent(input) {
       if (!prebillingRolloutIncludesUser(options.config, input.clerkUserId)) return undefined;
@@ -58,49 +111,7 @@ export function createPrebillingProvisioningCoordinator(options: {
       };
     },
 
-    async startPreparation(input) {
-      const current = await getPrebillingIntent(options.db, input.intentId);
-      if (!current) return false;
-      const cost = prebillingHourlyCostMicros(options.config, current.serverType);
-      if (cost === null) return false;
-      const admission = await admitPrebillingIntent(options.db, {
-        ...input,
-        reservedHourlyCostMicros: cost,
-        maxActive: options.config.maxActive,
-        maxHourlyCostMicros: options.config.maxHourlyCostMicros,
-        now: now().toISOString(),
-      });
-      if (!admission.admitted) return false;
-      try {
-        const identity = await options.resolveIdentity(current.clerkUserId);
-        if (!identity) throw new Error('prebilling_identity_unavailable');
-        const provisioned = await options.customerVpsService.provisionForCheckout({
-          clerkUserId: current.clerkUserId,
-          handle: identity.handle,
-          runtimeSlot: 'primary',
-          serverType: current.serverType,
-          location: z.enum(['fsn1', 'nbg1', 'ash', 'hil']).parse(
-            current.regionSlug.replace(/^region_/, ''),
-          ),
-          developerTools: current.developerTools,
-        }, current.id, { dispatch: 'detached' });
-        await options.onProvisioned?.({
-          clerkUserId: current.clerkUserId,
-          handle: identity.handle,
-          displayName: identity.displayName,
-          email: identity.email,
-          machineId: provisioned.machineId,
-        });
-        return true;
-      } catch (err: unknown) {
-        await markPrebillingPreparationFailed(options.db, {
-          intentId: current.id,
-          now: now().toISOString(),
-          errorCode: err instanceof Error ? err.name : 'preparation_failed',
-        });
-        throw err;
-      }
-    },
+    startPreparation,
 
     async getPreparationStatus(input) {
       const intent = await getPrebillingIntentByCheckoutAttempt(options.db, input.checkoutAttemptId);
@@ -108,6 +119,28 @@ export function createPrebillingProvisioningCoordinator(options: {
       if (intent.state === 'ready_waiting_for_billing') return 'ready';
       if (intent.state === 'awaiting_checkout' || intent.state === 'preparing') return 'preparing';
       return 'failed';
+    },
+
+    async retryPreparation(input) {
+      const intent = await getPrebillingIntentByCheckoutAttempt(options.db, input.checkoutAttemptId);
+      if (!intent || intent.clerkUserId !== input.clerkUserId) return false;
+      if (intent.state === 'preparing' || intent.state === 'ready_waiting_for_billing') return true;
+      if (!intent.stripeSessionId || !intent.stripeSessionExpiresAt) return false;
+      const reset = await resetPrebillingPreparationForRetry(options.db, {
+        intentId: intent.id,
+        clerkUserId: input.clerkUserId,
+        now: now().toISOString(),
+      });
+      if (!reset) {
+        const latest = await getPrebillingIntent(options.db, intent.id);
+        return latest?.clerkUserId === input.clerkUserId
+          && ['awaiting_checkout', 'preparing', 'ready_waiting_for_billing'].includes(latest.state);
+      }
+      return startPreparation({
+        intentId: intent.id,
+        stripeSessionId: intent.stripeSessionId,
+        stripeSessionExpiresAt: intent.stripeSessionExpiresAt,
+      });
     },
 
     authorizeSubscription(db, input) {

--- a/shell/src/components/settings/sections/BillingPanel.tsx
+++ b/shell/src/components/settings/sections/BillingPanel.tsx
@@ -34,6 +34,7 @@ import type {
 } from "@/hooks/useMatrixBillingAccess";
 import { capturePostHogEvent, capturePostHogLog } from "@/lib/posthog-client";
 import { isSelfHostedDocument } from "@/lib/self-host-mode";
+import { waitForPreparedCheckout } from "@/lib/billing-checkout-preparation";
 import { DeveloperToolsSelector } from "@/components/onboarding/DefaultInstallsStep";
 import {
   defaultDeveloperTools,
@@ -70,11 +71,12 @@ const regionGroupLabels: Record<string, string> = {
   "ap-southeast": "Asia Pacific",
 };
 const includedHighlights = [
-  "Dedicated VPS attached right after checkout",
+  "Dedicated VPS prepared before checkout",
   "Your files and data persist across restarts",
   "Change tier or cancel anytime in the billing portal",
 ] as const;
 const BILLING_CHECKOUT_TIMEOUT_MS = 10_000;
+const BILLING_PREPARATION_TIMEOUT_MS = 370_000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const acceptedPaymentMarks = ["Visa", "Mastercard"] as const;
 const billingPlanNames: Record<string, string> = {
@@ -210,7 +212,7 @@ function CheckoutPanel({
     setCheckoutError(null);
     captureBillingTelemetry("checkout_intent", telemetryPropertiesRef.current);
     const controller = new AbortController();
-    const timeoutId = window.setTimeout(() => controller.abort(), BILLING_CHECKOUT_TIMEOUT_MS);
+    const timeoutId = window.setTimeout(() => controller.abort(), BILLING_PREPARATION_TIMEOUT_MS);
     // react-doctor-disable-next-line react-hooks-js/todo -- React Compiler bailout on the try/finally needed to clear the abort timeout and reset `checkoutLoading` on every path; the code is correct and the finalizer must run whether the request resolves, rejects, or throws.
     try {
       const response = await fetch("/billing/checkout", {
@@ -237,7 +239,19 @@ function CheckoutPanel({
           error_kind: err instanceof Error ? err.name : typeof err,
         });
         return null;
-      })) as { code?: unknown; selection?: unknown; url?: unknown } | null;
+      })) as { attemptId?: unknown; code?: unknown; selection?: unknown; status?: unknown; url?: unknown } | null;
+      if (response.status === 202 && body?.status === "preparing") {
+        if (typeof body.attemptId !== "string" || body.attemptId.length === 0) {
+          reportCheckoutError("invalid_preparation_response");
+          return;
+        }
+        const prepared = await waitForPreparedCheckout({
+          attemptId: body.attemptId,
+          signal: controller.signal,
+        });
+        (onCheckoutNavigate ?? ((target: string) => window.location.assign(target)))(prepared.url);
+        return;
+      }
       if (!response.ok) {
         if (response.status === 409 && body?.code === "checkout_selection_conflict") {
           const message = checkoutSelectionConflictMessage(body.selection);
@@ -297,7 +311,7 @@ function CheckoutPanel({
               ? "Add your card in Stripe Checkout. You will not be charged today."
               : mode === "device-setup"
               ? "Review your plan and region here. Stripe opens only after you choose Continue to pay."
-              : "Secure checkout opens before Matrix provisions this computer."}
+              : "Matrix prepares this computer before secure checkout opens."}
           </p>
         </div>
       )}
@@ -389,7 +403,7 @@ function CheckoutPanel({
           <CreditCardIcon className="size-4" aria-hidden="true" />
         )}
         {checkoutLoading
-          ? "Opening checkout"
+          ? "Preparing computer"
           : checkoutBypassed
           ? "Continue setup"
           : trialDurationDays !== null

--- a/shell/src/lib/billing-checkout-preparation.ts
+++ b/shell/src/lib/billing-checkout-preparation.ts
@@ -1,0 +1,53 @@
+const PREPARATION_POLL_INTERVAL_MS = 1_500;
+const MAX_PREPARATION_POLLS = 240;
+
+type CheckoutPreparationBody = {
+  status?: unknown;
+  url?: unknown;
+};
+
+function waitForDelay(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const onAbort = () => {
+      window.clearTimeout(timer);
+      reject(signal.reason);
+    };
+    const timer = window.setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+export async function waitForPreparedCheckout(options: {
+  attemptId: string;
+  signal: AbortSignal;
+  fetcher?: typeof fetch;
+  wait?: (ms: number, signal: AbortSignal) => Promise<void>;
+}): Promise<{ url: string }> {
+  const fetcher = options.fetcher ?? fetch;
+  const wait = options.wait ?? waitForDelay;
+  const statusUrl = `/billing/checkout/status?attemptId=${encodeURIComponent(options.attemptId)}`;
+  for (let poll = 0; poll < MAX_PREPARATION_POLLS; poll += 1) {
+    await wait(PREPARATION_POLL_INTERVAL_MS, options.signal);
+    const response = await fetcher(statusUrl, {
+      method: 'GET',
+      credentials: 'include',
+      headers: { accept: 'application/json' },
+      signal: options.signal,
+    });
+    const body = await response.json().catch(() => null) as CheckoutPreparationBody | null;
+    if (response.ok && typeof body?.url === 'string' && body.url.length > 0) {
+      return { url: body.url };
+    }
+    if (response.status !== 202 || body?.status !== 'preparing') {
+      throw new Error('checkout_preparation_failed');
+    }
+  }
+  throw new Error('checkout_preparation_timeout');
+}

--- a/shell/src/lib/billing-checkout-preparation.ts
+++ b/shell/src/lib/billing-checkout-preparation.ts
@@ -41,7 +41,16 @@ export async function waitForPreparedCheckout(options: {
       headers: { accept: 'application/json' },
       signal: options.signal,
     });
-    const body = await response.json().catch(() => null) as CheckoutPreparationBody | null;
+    let body: CheckoutPreparationBody | null;
+    try {
+      body = await response.json() as CheckoutPreparationBody;
+    } catch (err: unknown) {
+      console.warn(
+        '[billing] checkout preparation response parse failed',
+        err instanceof Error ? err.name : typeof err,
+      );
+      throw new Error('checkout_preparation_invalid_response');
+    }
     if (response.ok && typeof body?.url === 'string' && body.url.length > 0) {
       return { url: body.url };
     }

--- a/tests/platform/billing-routes.test.ts
+++ b/tests/platform/billing-routes.test.ts
@@ -120,6 +120,7 @@ describe('platform billing routes', () => {
         order.push('preparation');
         return true;
       }),
+      retryPreparation: vi.fn(),
       getPreparationStatus: vi.fn().mockResolvedValue('preparing' as const),
       authorizeSubscription: vi.fn(),
       expireCheckout: vi.fn(),
@@ -181,6 +182,7 @@ describe('platform billing routes', () => {
     const prebilling = {
       createIntent: vi.fn().mockResolvedValue(undefined),
       startPreparation: vi.fn(),
+      retryPreparation: vi.fn(),
       getPreparationStatus: vi.fn(),
       authorizeSubscription: vi.fn(),
       expireCheckout: vi.fn(),
@@ -219,7 +221,10 @@ describe('platform billing routes', () => {
         expiresAt: '2026-05-30T00:31:00.000Z',
       }),
       startPreparation: vi.fn().mockResolvedValue(false),
-      getPreparationStatus: vi.fn(),
+      retryPreparation: vi.fn().mockResolvedValue(true),
+      getPreparationStatus: vi.fn()
+        .mockResolvedValueOnce('failed' as const)
+        .mockResolvedValue('preparing' as const),
       authorizeSubscription: vi.fn(),
       expireCheckout: vi.fn(),
     };
@@ -246,12 +251,31 @@ describe('platform billing routes', () => {
     expect(response.status).toBe(503);
     expect(await response.json()).toEqual({ error: 'Billing unavailable', code: 'billing_unavailable' });
     expect(stripe.createCheckoutSession).toHaveBeenCalledOnce();
+
+    const retry = await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        planSlug: 'matrix_builder',
+        interval: 'monthly',
+        regionSlug: 'region_fsn1',
+        runtimeSlot: 'primary',
+      }),
+    });
+    expect(retry.status).toBe(202);
+    expect(await retry.json()).toEqual({ status: 'preparing', attemptId: expect.any(String) });
+    expect(prebilling.retryPreparation).toHaveBeenCalledWith({
+      checkoutAttemptId: expect.any(String),
+      clerkUserId: 'user_123',
+    });
+    expect(stripe.createCheckoutSession).toHaveBeenCalledOnce();
   });
 
   it('returns a prepared checkout URL only after owner-bound readiness', async () => {
     const prebilling = {
       createIntent: vi.fn(),
       startPreparation: vi.fn(),
+      retryPreparation: vi.fn(),
       getPreparationStatus: vi.fn()
         .mockResolvedValueOnce('preparing' as const)
         .mockResolvedValueOnce('ready' as const),
@@ -1367,6 +1391,7 @@ describe('platform billing routes', () => {
       prebilling: {
         createIntent: vi.fn(),
         startPreparation: vi.fn(),
+        retryPreparation: vi.fn(),
         getPreparationStatus: vi.fn(),
         authorizeSubscription,
         expireCheckout: vi.fn(),
@@ -1512,6 +1537,7 @@ describe('platform billing routes', () => {
       prebilling: {
         createIntent: vi.fn(),
         startPreparation: vi.fn(),
+        retryPreparation: vi.fn(),
         getPreparationStatus: vi.fn(),
         authorizeSubscription: vi.fn(),
         expireCheckout,

--- a/tests/platform/billing-routes.test.ts
+++ b/tests/platform/billing-routes.test.ts
@@ -2,12 +2,14 @@ import { Hono } from 'hono';
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import {
   claimBillingRuntimeAction,
+  claimCheckoutAttempt,
   completeBillingRuntimeAction,
   enqueueBillingRuntimeAction,
   getBillingEntitlement,
   getBillingSubscription,
   getBillingCustomerByClerkUserId,
   getLatestCheckoutAttempt,
+  finalizeCheckoutAttempt,
   insertUserMachine,
   listBillingRuntimeActions,
   insertCheckoutAttempt,
@@ -107,7 +109,7 @@ describe('platform billing routes', () => {
     );
   });
 
-  it('starts admitted preparation after Stripe opens and before checkout returns', async () => {
+  it('withholds Stripe checkout until the exact primary computer is ready', async () => {
     const order: string[] = [];
     const prebilling = {
       createIntent: vi.fn(async () => {
@@ -116,9 +118,10 @@ describe('platform billing routes', () => {
       }),
       startPreparation: vi.fn(async () => {
         order.push('preparation');
+        return true;
       }),
+      getPreparationStatus: vi.fn().mockResolvedValue('preparing' as const),
       authorizeSubscription: vi.fn(),
-      ensureFallback: vi.fn(),
       expireCheckout: vi.fn(),
     };
     vi.mocked(stripe.createCheckoutSession).mockImplementation(async () => {
@@ -151,7 +154,11 @@ describe('platform billing routes', () => {
       }),
     });
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({
+      status: 'preparing',
+      attemptId: expect.any(String),
+    });
     expect(order).toEqual(['intent', 'stripe', 'preparation']);
     expect(prebilling.createIntent).toHaveBeenCalledWith(expect.objectContaining({
       checkoutAttemptId: expect.any(String),
@@ -167,6 +174,130 @@ describe('platform billing routes', () => {
       intentId: 'intent_123',
       stripeSessionId: 'cs_test_session',
       stripeSessionExpiresAt: '2026-05-30T00:30:00.000Z',
+    });
+  });
+
+  it('fails primary checkout closed when prebilling is unavailable', async () => {
+    const prebilling = {
+      createIntent: vi.fn().mockResolvedValue(undefined),
+      startPreparation: vi.fn(),
+      getPreparationStatus: vi.fn(),
+      authorizeSubscription: vi.fn(),
+      expireCheckout: vi.fn(),
+    };
+    const app = new Hono();
+    app.route('/billing', createBillingRoutes({
+      db,
+      stripe,
+      env,
+      resolveClerkUserId: () => Promise.resolve('user_123'),
+      now: () => new Date('2026-05-30T00:00:00.000Z'),
+      prebilling,
+    }));
+
+    const response = await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        planSlug: 'matrix_builder',
+        interval: 'monthly',
+        regionSlug: 'region_fsn1',
+        runtimeSlot: 'primary',
+      }),
+    });
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: 'Billing unavailable', code: 'billing_unavailable' });
+    expect(stripe.createCheckoutSession).not.toHaveBeenCalled();
+    expect(prebilling.startPreparation).not.toHaveBeenCalled();
+  });
+
+  it('never returns a Stripe URL when unpaid preparation capacity is full', async () => {
+    const prebilling = {
+      createIntent: vi.fn().mockResolvedValue({
+        intentId: 'intent_123',
+        expiresAt: '2026-05-30T00:31:00.000Z',
+      }),
+      startPreparation: vi.fn().mockResolvedValue(false),
+      getPreparationStatus: vi.fn(),
+      authorizeSubscription: vi.fn(),
+      expireCheckout: vi.fn(),
+    };
+    const app = new Hono();
+    app.route('/billing', createBillingRoutes({
+      db,
+      stripe,
+      env,
+      resolveClerkUserId: () => Promise.resolve('user_123'),
+      prebilling,
+    }));
+
+    const response = await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        planSlug: 'matrix_builder',
+        interval: 'monthly',
+        regionSlug: 'region_fsn1',
+        runtimeSlot: 'primary',
+      }),
+    });
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: 'Billing unavailable', code: 'billing_unavailable' });
+    expect(stripe.createCheckoutSession).toHaveBeenCalledOnce();
+  });
+
+  it('returns a prepared checkout URL only after owner-bound readiness', async () => {
+    const prebilling = {
+      createIntent: vi.fn(),
+      startPreparation: vi.fn(),
+      getPreparationStatus: vi.fn()
+        .mockResolvedValueOnce('preparing' as const)
+        .mockResolvedValueOnce('ready' as const),
+      authorizeSubscription: vi.fn(),
+      expireCheckout: vi.fn(),
+    };
+    const app = new Hono();
+    app.route('/billing', createBillingRoutes({
+      db,
+      stripe,
+      env,
+      resolveClerkUserId: () => Promise.resolve('user_123'),
+      prebilling,
+    }));
+    const checkout = await claimCheckoutAttempt(db, {
+      id: '76edda9c-1431-4777-bd55-ebfa73fa938d',
+      clerkUserId: 'user_123',
+      runtimeSlot: 'primary',
+      planSlug: 'matrix_builder',
+      billingInterval: 'monthly',
+      regionSlug: 'region_fsn1',
+      serverType: 'cpx32',
+      createdAt: '2026-05-30T00:00:00.000Z',
+    });
+    expect(checkout.claimed).toBe(true);
+    expect(await finalizeCheckoutAttempt(
+      db,
+      checkout.attempt.id,
+      'cs_test_session',
+      'https://checkout.stripe.test/session',
+    )).toBe(true);
+
+    const preparing = await app.request(
+      `/billing/checkout/status?attemptId=${checkout.attempt.id}`,
+    );
+    const ready = await app.request(
+      `/billing/checkout/status?attemptId=${checkout.attempt.id}`,
+    );
+
+    expect(preparing.status).toBe(202);
+    expect(await preparing.json()).toEqual({ status: 'preparing', attemptId: checkout.attempt.id });
+    expect(ready.status).toBe(200);
+    expect(await ready.json()).toEqual({ url: 'https://checkout.stripe.test/session' });
+    expect(prebilling.getPreparationStatus).toHaveBeenNthCalledWith(1, {
+      checkoutAttemptId: checkout.attempt.id,
+      clerkUserId: 'user_123',
     });
   });
 
@@ -1218,19 +1349,14 @@ describe('platform billing routes', () => {
     });
   });
 
-  it('authorizes the exact preparation and retries durable fallback after a signed active projection', async () => {
+  it('fails a signed active projection closed when the prepared machine is not ready', async () => {
     vi.mocked(stripe.constructWebhookEvent).mockReturnValue(subscriptionEvent('evt_prebilling', {
       runtimeSlot: 'primary',
       prebillingIntentId: 'intent_123',
     }));
-    const authorizeSubscription = vi.fn().mockResolvedValue({
-      authorized: true,
-      machineId: null,
-      needsFallback: true,
-    });
-    const ensureFallback = vi.fn()
-      .mockRejectedValueOnce(new Error('fallback enqueue unavailable'))
-      .mockResolvedValueOnce(undefined);
+    const authorizeSubscription = vi.fn().mockRejectedValue(
+      new Error('prebilling_machine_not_ready'),
+    );
     const app = new Hono();
     app.route('/billing', createBillingRoutes({
       db,
@@ -1241,8 +1367,8 @@ describe('platform billing routes', () => {
       prebilling: {
         createIntent: vi.fn(),
         startPreparation: vi.fn(),
+        getPreparationStatus: vi.fn(),
         authorizeSubscription,
-        ensureFallback,
         expireCheckout: vi.fn(),
       },
     }));
@@ -1260,13 +1386,11 @@ describe('platform billing routes', () => {
       runtimeSlot: 'primary',
       now: '2026-05-30T00:00:00.000Z',
     });
-    expect(ensureFallback).toHaveBeenCalledWith({ intentId: 'intent_123' });
-
     const retry = await app.request('/billing/webhooks/stripe', {
       method: 'POST', headers: { 'stripe-signature': 'valid' }, body: '{}',
     });
-    expect(retry.status).toBe(200);
-    expect(ensureFallback).toHaveBeenCalledTimes(2);
+    expect(retry.status).toBe(500);
+    expect(authorizeSubscription).toHaveBeenCalledTimes(2);
   });
 
   it('keeps subscriptions independent when one additional computer is canceled', async () => {
@@ -1388,8 +1512,8 @@ describe('platform billing routes', () => {
       prebilling: {
         createIntent: vi.fn(),
         startPreparation: vi.fn(),
+        getPreparationStatus: vi.fn(),
         authorizeSubscription: vi.fn(),
-        ensureFallback: vi.fn(),
         expireCheckout,
       },
     }));

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -482,6 +482,28 @@ describe('CI workflows', () => {
     }
   });
 
+  it('durably deploys fail-closed prebilling for every new primary signup', () => {
+    const root = process.cwd();
+    const production = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
+
+    expect(production).toContain("MATRIX_PREBILLING_PROVISIONING_ENABLED: 'true'");
+    expect(production).toContain("MATRIX_PREBILLING_PROVISIONING_ROLLOUT_PERCENT: '100'");
+    expect(production).toContain("MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE: ${{ vars.MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE || '1' }}");
+    expect(production).toContain("MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS: ${{ vars.MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS || '254000' }}");
+    expect(production).toContain("MATRIX_PREBILLING_PROVISIONING_COSTS: ${{ vars.MATRIX_PREBILLING_PROVISIONING_COSTS || 'cpx22:92900;cpx32:169900;cpx52:254000' }}");
+    for (const name of [
+      'MATRIX_PREBILLING_PROVISIONING_ENABLED',
+      'MATRIX_PREBILLING_PROVISIONING_ROLLOUT_PERCENT',
+      'MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE',
+      'MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS',
+      'MATRIX_PREBILLING_PROVISIONING_COSTS',
+    ]) {
+      expect(production).toContain(`${name}=\${${name}}`);
+    }
+    expect(production).toContain('Verify deployed prebilling contract');
+    expect(production).toContain('prebilling deployment contract is missing');
+  });
+
   it('preflights and binds distinct golden snapshot operator secrets for platform revisions', () => {
     const root = process.cwd();
     const production = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');

--- a/tests/platform/prebilling-provisioning.test.ts
+++ b/tests/platform/prebilling-provisioning.test.ts
@@ -19,6 +19,7 @@ import {
   createPrebillingIntent,
   cleanupExpiredPrebillingCheckout,
   getPrebillingIntentByCheckoutAttempt,
+  markPrebillingIntentReady,
 } from '../../packages/platform/src/prebilling-provisioning-store.js';
 import { createCustomerVpsService } from '../../packages/platform/src/customer-vps.js';
 import { createPrebillingProvisioningCoordinator } from '../../packages/platform/src/prebilling-provisioning.js';
@@ -62,6 +63,14 @@ describe('platform prebilling provisioning foundation', () => {
     });
     expect(enabled.serverHourlyCostMicros.get('cpx22')).toBe(50_000);
     expect(prebillingRolloutIncludesUser(enabled, 'user_123')).toBe(true);
+    expect(loadPrebillingProvisioningConfig({
+      MATRIX_PREBILLING_PROVISIONING_ENABLED: 'true',
+      MATRIX_PREBILLING_PROVISIONING_COSTS: 'cpx22:92900;cpx32:169900;cpx52:254000',
+    }).serverHourlyCostMicros).toEqual(new Map([
+      ['cpx22', 92_900],
+      ['cpx32', 169_900],
+      ['cpx52', 254_000],
+    ]));
   });
 
   it('creates one immutable intent for a checkout and canonical selection', async () => {
@@ -220,6 +229,16 @@ describe('platform prebilling provisioning foundation', () => {
     await expect(getPrebillingIntentByCheckoutAttempt(db, 'checkout-1')).resolves.toMatchObject({
       machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
     });
+    await expect(service.register('registration-token', {
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'dev',
+    })).resolves.toMatchObject({ registered: true, status: 'running' });
+    await expect(getPrebillingIntentByCheckoutAttempt(db, 'checkout-1')).resolves.toMatchObject({
+      state: 'ready_waiting_for_billing',
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+    });
     const reconcileFallbacks = vi.fn().mockResolvedValue(undefined);
     service.setPrebillingFallbackReconciler?.(reconcileFallbacks);
     await service.reconcileProvisioning();
@@ -292,15 +311,6 @@ describe('platform prebilling provisioning foundation', () => {
       status: 'provisioning',
       etaSeconds: 90,
     });
-    const provision = vi.fn().mockImplementation(async () => {
-      await insertUserMachine(db, {
-        machineId: 'fallback-machine', clerkUserId: 'user_123', handle: 'alice', runtimeSlot: 'primary',
-        provisioningClass: 'customer', accessClerkUserIds: [], status: 'provisioning', imageVersion: 'dev',
-        developerTools: ['codex', 'claude-code'], registrationTokenHash: null,
-        registrationTokenExpiresAt: null, provisionedAt: CREATED_AT,
-      });
-      return { machineId: 'fallback-machine', status: 'provisioning' };
-    });
     const coordinator = createPrebillingProvisioningCoordinator({
       db,
       config: loadPrebillingProvisioningConfig({
@@ -310,7 +320,7 @@ describe('platform prebilling provisioning foundation', () => {
         MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS: '50000',
         MATRIX_PREBILLING_PROVISIONING_COSTS_JSON: '{"cpx32":50000}',
       }),
-      customerVpsService: { provisionForCheckout, provision } as never,
+      customerVpsService: { provisionForCheckout } as never,
       resolveIdentity: vi.fn().mockResolvedValue({ handle: 'alice' }),
       intentIdFactory: () => 'intent-1',
       now: () => new Date(CREATED_AT),
@@ -328,11 +338,11 @@ describe('platform prebilling provisioning foundation', () => {
       now: CREATED_AT,
     });
     expect(preparation).toEqual({ intentId: 'intent-1', expiresAt: EXPIRES_AT });
-    await coordinator.startPreparation({
+    await expect(coordinator.startPreparation({
       intentId: 'intent-1',
       stripeSessionId: 'cs_1',
       stripeSessionExpiresAt: EXPIRES_AT,
-    });
+    })).resolves.toBe(true);
 
     expect(provisionForCheckout).toHaveBeenCalledWith({
       clerkUserId: 'user_123',
@@ -342,23 +352,20 @@ describe('platform prebilling provisioning foundation', () => {
       location: 'fsn1',
       developerTools: ['codex', 'claude-code'],
     }, 'intent-1', { dispatch: 'detached' });
-    await db.transaction((trx) => coordinator.authorizeSubscription(trx, {
-      intentId: 'intent-1', clerkUserId: 'user_123', runtimeSlot: 'primary', now: CREATED_AT,
-    }));
-    await expect(coordinator.reconcileFallbacks()).resolves.toEqual({ checked: 1, completed: 1, failed: 0 });
-    await expect(getPrebillingIntentByCheckoutAttempt(db, 'checkout-1')).resolves.toMatchObject({ machineId: 'fallback-machine' });
-    await expect(coordinator.reconcileFallbacks()).resolves.toEqual({ checked: 0, completed: 0, failed: 0 });
-    expect(provision).toHaveBeenCalledWith(expect.objectContaining({
-      clerkUserId: 'user_123', serverType: 'cpx32', developerTools: ['codex', 'claude-code'],
-    }), { dispatch: 'detached' });
+    await expect(coordinator.getPreparationStatus({
+      checkoutAttemptId: 'checkout-1', clerkUserId: 'user_123',
+    })).resolves.toBe('preparing');
   });
 
   it('leases fallback provisioning to one platform process', async () => {
     await seedCheckout('checkout-1', 'user_123');
     await createIntent('intent-1', 'checkout-1', 'user_123');
-    await db.transaction((trx) => authorizePrebillingIntent(trx, {
-      intentId: 'intent-1', clerkUserId: 'user_123', runtimeSlot: 'primary', now: CREATED_AT,
-    }));
+    // Legacy rows from before fail-closed authorization can still be claimed
+    // safely while they age out; new authorization can no longer create one.
+    await db.executor.updateTable('prebilling_provisioning_intents').set({
+      state: 'authorized',
+      authorized_at: CREATED_AT,
+    }).where('id', '=', 'intent-1').execute();
     const claims = await Promise.all([1, 2].map(() => claimAuthorizedPrebillingFallbackIntent(db, {
       intentId: 'intent-1', now: CREATED_AT, leaseExpiresAt: EXPIRES_AT,
     })));
@@ -407,10 +414,19 @@ describe('platform prebilling provisioning foundation', () => {
 
     await expect(db.transaction((trx) => authorizePrebillingIntent(trx, {
       intentId: 'intent-1', clerkUserId: 'user_123', runtimeSlot: 'primary', now: CREATED_AT,
+    }))).rejects.toThrow('prebilling_machine_not_ready');
+    await expect(db.transaction((trx) => markPrebillingIntentReady(trx, {
+      intentId: 'intent-1',
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      clerkUserId: 'user_123',
+      runtimeSlot: 'primary',
+      now: CREATED_AT,
+    }))).resolves.toBe(true);
+    await expect(db.transaction((trx) => authorizePrebillingIntent(trx, {
+      intentId: 'intent-1', clerkUserId: 'user_123', runtimeSlot: 'primary', now: CREATED_AT,
     }))).resolves.toEqual({
       authorized: true,
       machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
-      needsFallback: false,
     });
     await expect(getActiveUserMachineByClerkId(db, 'user_123', 'primary')).resolves.toMatchObject({
       activationState: 'authorized',

--- a/tests/platform/prebilling-provisioning.test.ts
+++ b/tests/platform/prebilling-provisioning.test.ts
@@ -20,6 +20,7 @@ import {
   cleanupExpiredPrebillingCheckout,
   getPrebillingIntentByCheckoutAttempt,
   markPrebillingIntentReady,
+  resetPrebillingPreparationForRetry,
 } from '../../packages/platform/src/prebilling-provisioning-store.js';
 import { createCustomerVpsService } from '../../packages/platform/src/customer-vps.js';
 import { createPrebillingProvisioningCoordinator } from '../../packages/platform/src/prebilling-provisioning.js';
@@ -140,6 +141,15 @@ describe('platform prebilling provisioning foundation', () => {
     expect(admitted.intent).toMatchObject({ state: 'preparing', reservedHourlyCostMicros: 50_000 });
     expect(deferred).toMatchObject({ admitted: false, reason: 'capacity' });
     expect(deferred.intent).toMatchObject({ state: 'preparation_deferred', reservedHourlyCostMicros: 0 });
+    await expect(resetPrebillingPreparationForRetry(db, {
+      intentId: 'intent-2',
+      clerkUserId: 'user_456',
+      now: CREATED_AT,
+    })).resolves.toBe(true);
+    await expect(getPrebillingIntentByCheckoutAttempt(db, 'checkout-2')).resolves.toMatchObject({
+      state: 'awaiting_checkout',
+      lastErrorCode: null,
+    });
   });
 
   it('keeps existing machines authorized by default during the additive migration', async () => {

--- a/tests/shell/billing-checkout-preparation.test.ts
+++ b/tests/shell/billing-checkout-preparation.test.ts
@@ -30,4 +30,14 @@ describe('billing checkout preparation', () => {
       wait: vi.fn().mockResolvedValue(undefined),
     })).rejects.toThrow('checkout_preparation_failed');
   });
+
+  it('preserves a typed error when the status response is not JSON', async () => {
+    const fetcher = vi.fn().mockResolvedValue(new Response('not-json', { status: 200 }));
+    await expect(waitForPreparedCheckout({
+      attemptId: '76edda9c-1431-4777-bd55-ebfa73fa938d',
+      signal: new AbortController().signal,
+      fetcher,
+      wait: vi.fn().mockResolvedValue(undefined),
+    })).rejects.toThrow('checkout_preparation_invalid_response');
+  });
 });

--- a/tests/shell/billing-checkout-preparation.test.ts
+++ b/tests/shell/billing-checkout-preparation.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { waitForPreparedCheckout } from '../../shell/src/lib/billing-checkout-preparation.js';
+
+describe('billing checkout preparation', () => {
+  it('polls an owner-bound attempt and returns only the ready checkout URL', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(Response.json({ status: 'preparing' }, { status: 202 }))
+      .mockResolvedValueOnce(Response.json({ url: 'https://checkout.stripe.test/ready' }));
+
+    await expect(waitForPreparedCheckout({
+      attemptId: '76edda9c-1431-4777-bd55-ebfa73fa938d',
+      signal: new AbortController().signal,
+      fetcher,
+      wait: vi.fn().mockResolvedValue(undefined),
+    })).resolves.toEqual({ url: 'https://checkout.stripe.test/ready' });
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher).toHaveBeenCalledWith(
+      '/billing/checkout/status?attemptId=76edda9c-1431-4777-bd55-ebfa73fa938d',
+      expect.objectContaining({ credentials: 'include', signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('fails safely when preparation does not become ready', async () => {
+    const fetcher = vi.fn().mockResolvedValue(Response.json({ code: 'billing_unavailable' }, { status: 503 }));
+    await expect(waitForPreparedCheckout({
+      attemptId: '76edda9c-1431-4777-bd55-ebfa73fa938d',
+      signal: new AbortController().signal,
+      fetcher,
+      wait: vi.fn().mockResolvedValue(undefined),
+    })).rejects.toThrow('checkout_preparation_failed');
+  });
+});


### PR DESCRIPTION
## Summary

- withhold the Stripe Checkout URL until the exact fenced primary VPS has registered and reached `ready_waiting_for_billing`
- fail checkout closed when prebilling configuration, capacity, or preparation is unavailable; signed billing authorization can no longer create a post-payment fallback machine
- poll preparation from the billing UI while preserving the selected compute, region, and developer tools
- persist the 100% prebilling rollout in the Cloud Run workflow and verify the deployed revision contains the exact contract before promotion

## Safety contract

New primary signup is now:

`compute + region + agents -> fenced VPS ready -> Stripe Checkout -> signed webhook authorization -> Matrix`

The default unpaid capacity remains deliberately bounded at `MAX_ACTIVE=1`. When that slot is occupied, another signup is blocked before payment instead of falling back to post-payment provisioning. The GitHub environment variables can raise the reviewed capacity and cost ceiling without changing the fail-closed behavior.

## Validation

- `pnpm --filter @matrix-os/platform build`
- `pnpm exec vitest run tests/platform/billing-routes.test.ts` (81 tests; full suite green before final focused assertion, final changed-path cases rerun green)
- `pnpm exec vitest run tests/platform/prebilling-provisioning.test.ts tests/platform/ci-workflows.test.ts tests/shell/billing-checkout-preparation.test.ts` (50 tests)
- `pnpm exec vitest run tests/platform/customer-vps-provisioning-durability.test.ts tests/platform/customer-vps-reliability.test.ts tests/platform/customer-vps.test.ts` (106 tests)
- `pnpm --dir shell exec next build --webpack`

## Deployment

No production deployment or traffic change is included in this PR.