### PR TITLE
feat(desktop): add VPS release controls to OSView

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -306,6 +306,11 @@ if (!gotLock) {
         },
         getUpdateSnapshot: () => updater.snapshot(),
         installUpdate: () => updater.install(),
+        toggleWindowMaximize: () => {
+          if (!mainWindow || mainWindow.isDestroyed()) return;
+          if (mainWindow.isMaximized()) mainWindow.unmaximize();
+          else mainWindow.maximize();
+        },
         getWhatsNew: async () => {
           const stored = await store.get("desktopUpdateRelease");
           if (!stored || stored.version !== app.getVersion()) {

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -30,6 +30,7 @@ export interface HandlerContext {
   checkUpdate: () => Promise<DesktopUpdateSnapshot>;
   getUpdateSnapshot: () => DesktopUpdateSnapshot;
   installUpdate: () => Promise<boolean> | boolean;
+  toggleWindowMaximize: () => void;
   getWhatsNew: () => Promise<{
     release: DesktopReleaseNotes | null;
     shouldOpen: boolean;
@@ -224,6 +225,10 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
   handle("app:set-zoom", ({ factor }, event) => {
     zoomTarget(event)?.setZoomFactor(factor);
     return { factor };
+  });
+  handle("window:toggle-maximize", () => {
+    ctx.toggleWindowMaximize();
+    return { ok: true };
   });
 
   handle("state:get", async ({ key }) => ({

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
@@ -2,6 +2,7 @@ import {
   useCallback,
   useEffect,
   useRef,
+  useState,
   type CSSProperties,
   type PointerEvent as ReactPointerEvent,
 } from "react";
@@ -13,6 +14,8 @@ import type {
 } from "../../stores/desktop-surfaces";
 import type { Tab } from "../../stores/tabs";
 import { TabErrorBoundary, TabPane } from "../mission-control/TabContent";
+import { isSettingsSectionId, SettingsSidebar, type SettingsSectionId } from "../settings/SettingsView";
+import { useUi } from "../../stores/ui";
 import type { NativeDesktopMode } from "../../stores/native-desktop-mode";
 import {
   OSWindow,
@@ -89,7 +92,14 @@ export default function DesktopSurfaceFrame({
     : isDesktopHidden || isDesktopTransition || (isDesktopWindow && !tabWorkspaceActive) || (isTabbed && tabWorkspaceActive && active);
   const interactive = visible && active;
   const isNativeEmbed = tab.kind === "home" || tab.kind === "app";
-  const sidebarOwnsChrome = tab.kind === "chat" || tab.kind === "terminal" || tab.kind === "terminals";
+  const sidebarOwnsChrome = tab.kind === "chat" || tab.kind === "terminal" || tab.kind === "terminals" || tab.kind === "settings";
+  const requestedSettingsSection = useUi((state) => state.requestedSettingsSection);
+  const [settingsSection, setSettingsSection] = useState<SettingsSectionId>("account");
+  useEffect(() => {
+    if (tab.kind !== "settings" || !requestedSettingsSection) return;
+    if (isSettingsSectionId(requestedSettingsSection)) setSettingsSection(requestedSettingsSection);
+    useUi.getState().clearRequestedSettingsSection();
+  }, [requestedSettingsSection, tab.kind]);
   const paneActive = interactive && !(isNativeEmbed && overlayOpen);
   const interactionCleanupRef = useRef<(() => void) | null>(null);
 
@@ -187,7 +197,10 @@ export default function DesktopSurfaceFrame({
   return (
     <OSWindow
       surfaceId={tab.id}
-      sidebarWidth={undefined}
+      sidebarWidth={tab.kind === "settings" ? 208 : undefined}
+      sidebar={tab.kind === "settings" ? (
+        <SettingsSidebar section={settingsSection} onSectionChange={setSettingsSection} />
+      ) : undefined}
       safeAreaLayout={sidebarOwnsChrome ? "sidebar" : "pane"}
       topBar={isWindow ? (
         <TopBar
@@ -226,6 +239,8 @@ export default function DesktopSurfaceFrame({
             visible={visible}
             layoutRevision={layoutRevision}
             visualScale={presentation === "canvas" ? interactionScale : 1}
+            settingsSection={tab.kind === "settings" ? settingsSection : undefined}
+            onSettingsSectionChange={tab.kind === "settings" ? setSettingsSection : undefined}
           />
         </TabErrorBoundary>
       </div>

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopTabGroup.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopTabGroup.tsx
@@ -8,7 +8,7 @@ export default function DesktopTabGroup({ children }: { children: ReactNode }) {
     <div
       role="tablist"
       aria-label="Workspace tabs"
-      className="no-drag flex h-full min-w-0 flex-1 items-stretch overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      className="titlebar-drag flex h-full min-w-0 flex-1 items-stretch overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       style={{ height: "var(--titlebar-height)" }}
     >
       {tabs.map((tab, index) => cloneElement(tab, { isLast: index === tabs.length - 1 }))}

--- a/desktop/src/renderer/src/features/integrations/AvailableServiceCard.tsx
+++ b/desktop/src/renderer/src/features/integrations/AvailableServiceCard.tsx
@@ -48,10 +48,10 @@ export function AvailableServiceCard({
     >
       <IntegrationIcon name={service.name} logoUrl={service.logoUrl} testId={`integration-icon-${service.id}`} />
       <div className="min-w-0 flex-1">
-        <p className="truncate text-sm" style={{ color: "var(--text-primary)" }}>
+        <p className="truncate text-md" style={{ color: "var(--text-primary)" }}>
           {service.name}
         </p>
-        <p className="truncate text-xs" style={{ color: "var(--text-tertiary)" }}>
+        <p className="truncate text-sm" style={{ color: "var(--text-tertiary)" }}>
           {description}
         </p>
         <span className="sr-only">

--- a/desktop/src/renderer/src/features/integrations/AvailableServiceCard.tsx
+++ b/desktop/src/renderer/src/features/integrations/AvailableServiceCard.tsx
@@ -38,7 +38,9 @@ export function AvailableServiceCard({
   onDisconnect?: (connection: ConnectedIntegration) => void;
 }) {
   const description = service.description ?? INTEGRATION_DESCRIPTIONS[service.id] ?? "Connect this service to extend your agent.";
-  const actionIsConnected = connected && connection !== undefined && onDisconnect !== undefined;
+  // A card-level hover action is only unambiguous for one account. Services
+  // with several accounts expose an explicit disconnect control per account.
+  const actionIsConnected = connected && connections.length === 1 && connection !== undefined && onDisconnect !== undefined;
 
   return (
     <div

--- a/desktop/src/renderer/src/features/integrations/AvailableServiceCard.tsx
+++ b/desktop/src/renderer/src/features/integrations/AvailableServiceCard.tsx
@@ -35,7 +35,7 @@ export function AvailableServiceCard({
   connection?: ConnectedIntegration;
   connections?: ConnectedIntegration[];
   onConnect: () => void;
-  onDisconnect?: () => void;
+  onDisconnect?: (connection: ConnectedIntegration) => void;
 }) {
   const description = service.description ?? INTEGRATION_DESCRIPTIONS[service.id] ?? "Connect this service to extend your agent.";
   const actionIsConnected = connected && connection !== undefined && onDisconnect !== undefined;
@@ -70,6 +70,23 @@ export function AvailableServiceCard({
             ))}
           </span>
         ) : null}
+        {connections.length > 1 && onDisconnect ? (
+          <div className="mt-1 flex flex-wrap gap-1">
+            {connections.map((account) => (
+              <button
+                key={account.id}
+                type="button"
+                className="rounded border px-1.5 py-0.5 text-xs"
+                style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}
+                aria-label={`Disconnect ${displayIntegrationName(account.accountLabel)}`}
+                disabled={disabled}
+                onClick={() => onDisconnect(account)}
+              >
+                {displayIntegrationName(account.accountLabel)} ×
+              </button>
+            ))}
+          </div>
+        ) : null}
       </div>
       {actionIsConnected ? (
         <div
@@ -100,7 +117,7 @@ export function AvailableServiceCard({
             disabled={disabled}
             onClick={(event) => {
               event.stopPropagation();
-              onDisconnect();
+              onDisconnect(connection);
             }}
           >
             <span className="sr-only">Disconnect</span>

--- a/desktop/src/renderer/src/features/integrations/AvailableServiceCard.tsx
+++ b/desktop/src/renderer/src/features/integrations/AvailableServiceCard.tsx
@@ -1,53 +1,128 @@
-// One catalog card: icon initial, name, category, connected badge, and the
-// Connect/Add-account action. Connect stays available for connected services
-// so the user can add a second account (mirrors the shell behavior).
+// Figma-style catalog card. The card is deliberately stateful: a connected
+// service gets the green check affordance, while an available service gets a
+// compact plus action. Account details remain accessible without changing the
+// compact visual treatment of the card.
 import { Button } from "../../design/primitives";
+import { Check, Plus, X } from "@renderer/lib/hugeicons";
 import { IntegrationIcon } from "./IntegrationIcon";
-import type { AvailableIntegration } from "./types";
+import { displayIntegrationName, type AvailableIntegration, type ConnectedIntegration } from "./types";
+
+const INTEGRATION_DESCRIPTIONS: Record<string, string> = {
+  github: "Manage repos, issues, and pull requests",
+  notion: "Search, update, and organize workspace",
+  slack: "Send messages and manage channels",
+  linear: "Manage issues, projects & team workflows",
+  figma: "Generate diagrams and export designs",
+  google_drive: "Search, read, and upload files",
+  jira: "Access issues and project boards",
+  hubspot: "CRM context for every answer and action",
+};
 
 export function AvailableServiceCard({
   service,
   connected,
   connecting,
   disabled,
+  connection,
+  connections = connection ? [connection] : [],
   onConnect,
+  onDisconnect,
 }: {
   service: AvailableIntegration;
   connected: boolean;
   connecting: boolean;
   disabled: boolean;
+  connection?: ConnectedIntegration;
+  connections?: ConnectedIntegration[];
   onConnect: () => void;
+  onDisconnect?: () => void;
 }) {
+  const description = service.description ?? INTEGRATION_DESCRIPTIONS[service.id] ?? "Connect this service to extend your agent.";
+  const actionIsConnected = connected && connection !== undefined && onDisconnect !== undefined;
+
   return (
     <div
-      className="flex items-center gap-3 rounded-xl border p-3"
+      data-testid={`integration-card-${service.id}`}
+      className="group relative flex min-h-[72px] items-center gap-3 rounded-xl border p-3"
       style={{ background: "var(--bg-surface)", borderColor: "var(--border-subtle)" }}
     >
-      <IntegrationIcon name={service.name} testId={`integration-icon-${service.id}`} />
+      <IntegrationIcon name={service.name} logoUrl={service.logoUrl} testId={`integration-icon-${service.id}`} />
       <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+        <p className="truncate text-sm" style={{ color: "var(--text-primary)" }}>
           {service.name}
         </p>
-        <p className="text-xs capitalize" style={{ color: "var(--text-tertiary)" }}>
-          {service.category}
+        <p className="truncate text-xs" style={{ color: "var(--text-tertiary)" }}>
+          {description}
         </p>
-      </div>
-      {connected ? (
-        <span
-          className="rounded-full px-2 py-0.5 text-xs"
-          style={{ background: "var(--accent-muted)", color: "var(--accent)" }}
-        >
-          Connected
+        <span className="sr-only">
+          <span>Category: </span>
+          <span>{service.category}</span>
         </span>
-      ) : null}
-      <Button
-        variant={connected ? "subtle" : "primary"}
-        data-testid={`integration-connect-${service.id}`}
-        disabled={disabled}
-        onClick={onConnect}
-      >
-        {connecting ? "Connecting..." : connected ? "Add account" : "Connect"}
-      </Button>
+        {connections.length > 0 ? (
+          <span className="sr-only">
+            <span>Connected account: </span>
+            {connections.map((account) => (
+              <span key={account.id}>
+                <span>{displayIntegrationName(account.accountLabel)}</span>
+                {account.accountEmail ? <span>{account.accountEmail}</span> : null}
+                <span>{account.status}</span>
+              </span>
+            ))}
+          </span>
+        ) : null}
+      </div>
+      {actionIsConnected ? (
+        <div
+          data-testid={`integration-connect-${service.id}`}
+          className="relative size-7 shrink-0"
+          onClick={onConnect}
+        >
+          <Button
+            variant="subtle"
+            className="size-7 justify-center rounded-full p-1 px-1!"
+            style={{ background: "var(--surface-success-emphasis, #288A5B)", color: "var(--text-on-accent)", borderRadius: "9999px" }}
+            aria-label={`Add another ${service.name} account`}
+            data-testid={`integration-action-${service.id}`}
+            data-state="connected"
+            disabled={disabled}
+            onClick={(event) => {
+              event.stopPropagation();
+              onConnect();
+            }}
+          >
+            <Check size={16} strokeWidth={2.5} aria-hidden="true" />
+          </Button>
+          <Button
+            variant="danger"
+            className="pointer-events-none absolute inset-0 size-7 justify-center rounded-full p-1 px-1! opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100"
+            aria-label={`Disconnect ${displayIntegrationName(connection.accountLabel)}`}
+            data-testid={`integration-disconnect-${connection.id}`}
+            disabled={disabled}
+            onClick={(event) => {
+              event.stopPropagation();
+              onDisconnect();
+            }}
+          >
+            <span className="sr-only">Disconnect</span>
+            <X size={16} />
+          </Button>
+        </div>
+      ) : (
+        <div data-testid={`integration-action-${service.id}`} data-state="available" className="size-7 shrink-0">
+          <Button
+            variant="subtle"
+            className="size-7 justify-center rounded-[8px] border p-1 px-1!"
+            style={{ background: "var(--bg-surface)", borderColor: "var(--border-subtle)", color: "var(--text-primary)" }}
+            aria-label={connecting ? `Connecting ${service.name}` : `Connect ${service.name}`}
+            data-testid={`integration-connect-${service.id}`}
+            disabled={disabled}
+            onClick={onConnect}
+          >
+            <Plus size={16} aria-hidden="true" />
+          </Button>
+        </div>
+      )}
+      {connecting ? <span className="sr-only">Connecting...</span> : null}
     </div>
   );
 }

--- a/desktop/src/renderer/src/features/integrations/ConnectedServiceRow.tsx
+++ b/desktop/src/renderer/src/features/integrations/ConnectedServiceRow.tsx
@@ -38,7 +38,7 @@ export function ConnectedServiceRow({
       <IntegrationIcon name={serviceName} logoUrl={logoUrl} />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <p className="truncate text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+          <p className="truncate text-md font-medium" style={{ color: "var(--text-primary)" }}>
             {displayIntegrationName(connection.accountLabel)}
           </p>
           <StatusDot color={statusColor(connection.status)} />
@@ -47,11 +47,11 @@ export function ConnectedServiceRow({
           </span>
         </div>
         {connection.accountEmail ? (
-          <p className="truncate text-xs" style={{ color: "var(--text-secondary)" }}>
+          <p className="truncate text-sm" style={{ color: "var(--text-secondary)" }}>
             {connection.accountEmail}
           </p>
         ) : null}
-        <p className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+        <p className="text-sm" style={{ color: "var(--text-tertiary)" }}>
           {serviceName}
           {connectedDate ? ` · Connected ${connectedDate}` : ""}
         </p>

--- a/desktop/src/renderer/src/features/integrations/ConnectedServiceRow.tsx
+++ b/desktop/src/renderer/src/features/integrations/ConnectedServiceRow.tsx
@@ -2,7 +2,7 @@
 // date, and the disconnect affordance. Only display-safe proxy fields.
 import { Button, StatusDot } from "../../design/primitives";
 import { IntegrationIcon } from "./IntegrationIcon";
-import type { ConnectedIntegration } from "./types";
+import { displayIntegrationName, type ConnectedIntegration } from "./types";
 
 function statusColor(status: string): string {
   if (status === "active") return "var(--status-complete)";
@@ -19,11 +19,13 @@ function formatConnectedAt(iso: string): string | null {
 export function ConnectedServiceRow({
   connection,
   serviceName,
+  logoUrl,
   disconnecting,
   onDisconnect,
 }: {
   connection: ConnectedIntegration;
   serviceName: string;
+  logoUrl?: string;
   disconnecting: boolean;
   onDisconnect: () => void;
 }) {
@@ -33,11 +35,11 @@ export function ConnectedServiceRow({
       className="flex items-center gap-3 rounded-xl border p-3"
       style={{ background: "var(--bg-surface)", borderColor: "var(--border-subtle)" }}
     >
-      <IntegrationIcon name={serviceName} />
+      <IntegrationIcon name={serviceName} logoUrl={logoUrl} />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <p className="truncate text-sm font-medium" style={{ color: "var(--text-primary)" }}>
-            {connection.accountLabel}
+            {displayIntegrationName(connection.accountLabel)}
           </p>
           <StatusDot color={statusColor(connection.status)} />
           <span className="text-xs capitalize" style={{ color: "var(--text-tertiary)" }}>

--- a/desktop/src/renderer/src/features/integrations/IntegrationIcon.tsx
+++ b/desktop/src/renderer/src/features/integrations/IntegrationIcon.tsx
@@ -1,15 +1,47 @@
-// Icon-initial tile for an integration. The desktop never renders remote
-// logo URLs (no remote images from the proxy payload) — a deterministic
-// initial on the accent token is the whole identity treatment.
-export function IntegrationIcon({ name, testId }: { name: string; testId?: string }) {
+import { useRef, useState } from "react";
+
+// Mirrors the webview's Pipedream logo treatment with a deterministic initial
+// fallback when a logo is unavailable or fails to load.
+export function IntegrationIcon({ name, logoUrl, testId }: { name: string; logoUrl?: string; testId?: string }) {
+  const [imgFailed, setImgFailed] = useState(false);
+  const previousLogoUrl = useRef<string | undefined>(undefined);
+  if (previousLogoUrl.current !== logoUrl) {
+    previousLogoUrl.current = logoUrl;
+    if (imgFailed) setImgFailed(false);
+  }
+
+  if (logoUrl && !imgFailed) {
+    return (
+      <div
+        data-testid={testId ? `${testId}-container` : undefined}
+        className="flex size-11 shrink-0 items-center justify-center rounded-[10px] p-2.5"
+        style={{ background: "var(--surface-card-foreground-subtle, #FAFAF6)" }}
+      >
+        {/* Some provider SVGs advertise narrow intrinsic dimensions (for
+            example 8x20). Fill the fixed icon slot so those assets do not
+            render as tiny slivers inside the 44px icon container. */}
+        <img
+          data-testid={testId}
+          src={logoUrl}
+          alt={name}
+          width={24}
+          height={24}
+          className="size-6 object-fill"
+          onError={() => setImgFailed(true)}
+        />
+      </div>
+    );
+  }
+
   return (
     <div
-      data-testid={testId}
-      className="flex size-9 shrink-0 items-center justify-center rounded-lg text-sm font-semibold"
-      style={{ background: "var(--accent-muted)", color: "var(--accent)" }}
-      aria-hidden
+      data-testid={testId ? `${testId}-container` : undefined}
+      className="flex size-11 shrink-0 items-center justify-center rounded-[10px] p-2.5"
+      style={{ background: "var(--surface-card-foreground-subtle, #FAFAF6)" }}
     >
-      {name.charAt(0).toUpperCase() || "?"}
+      <span data-testid={testId} className="text-sm font-semibold" style={{ color: "var(--accent)" }} aria-hidden>
+        {name.charAt(0).toUpperCase() || "?"}
+      </span>
     </div>
   );
 }

--- a/desktop/src/renderer/src/features/integrations/IntegrationsSettingsSection.tsx
+++ b/desktop/src/renderer/src/features/integrations/IntegrationsSettingsSection.tsx
@@ -253,7 +253,7 @@ export function IntegrationsSettingsSection({ pollIntervals }: IntegrationsSetti
                     connecting={connectingService === service.id}
                     disabled={connectingService !== null}
                     onConnect={() => void handleConnect(service.id)}
-                    onDisconnect={connection ? () => setConfirmId(connection.id) : undefined}
+                    onDisconnect={(target) => setConfirmId(target.id)}
                   />
                 );
               })}

--- a/desktop/src/renderer/src/features/integrations/IntegrationsSettingsSection.tsx
+++ b/desktop/src/renderer/src/features/integrations/IntegrationsSettingsSection.tsx
@@ -5,7 +5,7 @@
 // the sync endpoint with backoff until the account lands; Disconnect asks
 // for confirmation first. The renderer only displays name/category/label/
 // email/status — never tokens, remote logos, or upstream error text.
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { diagnosticErrorKind } from "../../lib/errors";
 import { invoke } from "../../lib/operator";
 import { categoryMessage } from "../../../../shared/app-error";
@@ -13,12 +13,12 @@ import { RefreshButton } from "../settings/sections/ProvidersSection";
 import { useConnection } from "../../stores/connection";
 import { captureRuntimeGeneration, isCurrentRuntimeGeneration } from "../../stores/runtime-generation";
 import { AvailableServiceCard } from "./AvailableServiceCard";
-import { ConnectedServiceRow } from "./ConnectedServiceRow";
 import { ConnectPendingBanner } from "./ConnectPendingBanner";
 import { DEFAULT_CONNECT_POLL_INTERVALS_MS, startConnectPoll } from "./connect-poll";
 import { DisconnectConfirmDialog } from "./DisconnectConfirmDialog";
 import { EmptyCatalogState, ErrorState, LoadingSkeleton, UnavailableState } from "./IntegrationStatusViews";
 import { useIntegrations } from "./integrations-store";
+import { displayIntegrationName } from "./types";
 
 const GENERIC_ERROR = categoryMessage("server");
 
@@ -195,6 +195,20 @@ export function IntegrationsSettingsSection({ pollIntervals }: IntegrationsSetti
     ? (available.find((service) => service.id === connectingService)?.name ?? connectingService)
     : null;
 
+  const catalogServices = useMemo(() => {
+    const known = new Set(available.map((service) => service.id));
+    return [
+      ...available,
+      ...connections
+        .filter((connection) => !known.has(connection.service))
+        .map((connection) => ({
+          id: connection.service,
+          name: displayIntegrationName(connection.service),
+          category: "other",
+        })),
+    ];
+  }, [available, connections]);
+
   let body: ReactNode;
   if (status === "idle" || status === "loading") {
     body = <LoadingSkeleton />;
@@ -215,43 +229,28 @@ export function IntegrationsSettingsSection({ pollIntervals }: IntegrationsSetti
           </p>
         ) : null}
 
-        {connections.length > 0 ? (
-          <section className="mb-6">
-            <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide" style={{ color: "var(--text-tertiary)" }}>
-              Connected
-            </h4>
-            <div className="flex flex-col gap-2">
-              {connections.map((conn) => (
-                <ConnectedServiceRow
-                  key={conn.id}
-                  connection={conn}
-                  serviceName={available.find((service) => service.id === conn.service)?.name ?? conn.service}
-                  disconnecting={disconnectingId === conn.id}
-                  onDisconnect={() => setConfirmId(conn.id)}
-                />
-              ))}
-            </div>
-          </section>
-        ) : null}
-
         <section>
-          <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide" style={{ color: "var(--text-tertiary)" }}>
-            Available
-          </h4>
           {available.length === 0 && connections.length === 0 ? (
             <EmptyCatalogState />
           ) : (
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-              {available.map((service) => (
-                <AvailableServiceCard
-                  key={service.id}
-                  service={service}
-                  connected={connections.some((conn) => conn.service === service.id)}
-                  connecting={connectingService === service.id}
-                  disabled={connectingService !== null}
-                  onConnect={() => void handleConnect(service.id)}
-                />
-              ))}
+            <div data-testid="integrations-grid" className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {catalogServices.map((service) => {
+                const connection = connections.find((conn) => conn.service === service.id);
+                const serviceConnections = connections.filter((conn) => conn.service === service.id);
+                return (
+                  <AvailableServiceCard
+                    key={service.id}
+                    service={service}
+                    connected={connection !== undefined}
+                    connection={connection}
+                    connections={serviceConnections}
+                    connecting={connectingService === service.id}
+                    disabled={connectingService !== null}
+                    onConnect={() => void handleConnect(service.id)}
+                    onDisconnect={connection ? () => setConfirmId(connection.id) : undefined}
+                  />
+                );
+              })}
             </div>
           )}
         </section>
@@ -271,13 +270,13 @@ export function IntegrationsSettingsSection({ pollIntervals }: IntegrationsSetti
 
   return (
     <>
-      <div className="mb-5 flex items-start justify-between gap-4">
+      <div className="mb-6 flex items-start justify-between gap-4">
         <div className="flex flex-col gap-1">
-          <h3 className="text-xl font-semibold tracking-tight" style={{ color: "var(--text-primary)" }}>
+          <h3 className="text-base font-normal tracking-[-0.4px]" style={{ color: "var(--text-primary)" }}>
             Integrations
           </h3>
-          <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
-            Connect external services to extend your agent's capabilities.
+          <p className="text-xs font-normal" style={{ color: "var(--text-secondary)" }}>
+            Connect extra services to extend your agent's capabilities.
           </p>
         </div>
         {status === "ready" ? <RefreshButton onClick={refresh} /> : null}

--- a/desktop/src/renderer/src/features/integrations/IntegrationsSettingsSection.tsx
+++ b/desktop/src/renderer/src/features/integrations/IntegrationsSettingsSection.tsx
@@ -198,7 +198,7 @@ export function IntegrationsSettingsSection({ pollIntervals }: IntegrationsSetti
 
   const catalogServices = useMemo(() => {
     const known = new Set(available.map((service) => service.id));
-    return [
+    const services = [
       ...available,
       ...connections
         .filter((connection) => !known.has(connection.service))
@@ -208,6 +208,11 @@ export function IntegrationsSettingsSection({ pollIntervals }: IntegrationsSetti
           category: "other",
         })),
     ];
+    return services.sort((left, right) => {
+      const leftConnected = connections.some((connection) => connection.service === left.id);
+      const rightConnected = connections.some((connection) => connection.service === right.id);
+      return Number(rightConnected) - Number(leftConnected);
+    });
   }, [available, connections]);
 
   let body: ReactNode;

--- a/desktop/src/renderer/src/features/integrations/IntegrationsSettingsSection.tsx
+++ b/desktop/src/renderer/src/features/integrations/IntegrationsSettingsSection.tsx
@@ -19,6 +19,7 @@ import { DisconnectConfirmDialog } from "./DisconnectConfirmDialog";
 import { EmptyCatalogState, ErrorState, LoadingSkeleton, UnavailableState } from "./IntegrationStatusViews";
 import { useIntegrations } from "./integrations-store";
 import { displayIntegrationName } from "./types";
+import { SettingsSectionHeader } from "../settings/sections/section-kit";
 
 const GENERIC_ERROR = categoryMessage("server");
 
@@ -270,15 +271,12 @@ export function IntegrationsSettingsSection({ pollIntervals }: IntegrationsSetti
 
   return (
     <>
-      <div className="mb-6 flex items-start justify-between gap-4">
-        <div className="flex flex-col gap-1">
-          <h3 className="text-base font-normal tracking-[-0.4px]" style={{ color: "var(--text-primary)" }}>
-            Integrations
-          </h3>
-          <p className="text-xs font-normal" style={{ color: "var(--text-secondary)" }}>
-            Connect extra services to extend your agent's capabilities.
-          </p>
-        </div>
+      <div className="flex items-start justify-between gap-4">
+        <SettingsSectionHeader
+          className="mb-0"
+          title="Integrations"
+          description="Connect extra services to extend your agent's capabilities."
+        />
         {status === "ready" ? <RefreshButton onClick={refresh} /> : null}
       </div>
 

--- a/desktop/src/renderer/src/features/integrations/IntegrationsSettingsSection.tsx
+++ b/desktop/src/renderer/src/features/integrations/IntegrationsSettingsSection.tsx
@@ -248,7 +248,7 @@ export function IntegrationsSettingsSection({ pollIntervals }: IntegrationsSetti
                     key={service.id}
                     service={service}
                     connected={connection !== undefined}
-                    connection={connection}
+                    connection={serviceConnections.length === 1 ? connection : undefined}
                     connections={serviceConnections}
                     connecting={connectingService === service.id}
                     disabled={connectingService !== null}

--- a/desktop/src/renderer/src/features/integrations/types.ts
+++ b/desktop/src/renderer/src/features/integrations/types.ts
@@ -2,16 +2,27 @@
 // (/api/integrations* — packages/gateway/src/integrations/routes.ts, either
 // served directly by the gateway or proxied to the platform). The renderer
 // only ever handles display-safe fields: no tokens, no scopes beyond counts,
-// no provider error text. Remote logo URLs are deliberately dropped — the
-// desktop renders icon initials instead of remote images.
+// no provider error text. Logo URLs are accepted only from the HTTPS catalog
+// response and remain display-only.
 
 export const MAX_AVAILABLE_INTEGRATIONS = 200;
 export const MAX_CONNECTED_INTEGRATIONS = 200;
+const PIPEDREAM_LOGO_SERVICES = new Set([
+  "gmail",
+  "google_calendar",
+  "google_drive",
+  "github",
+  "linear",
+  "slack",
+  "discord",
+]);
 
 export interface AvailableIntegration {
   id: string;
   name: string;
   category: string;
+  description?: string;
+  logoUrl?: string;
 }
 
 export interface ConnectedIntegration {
@@ -61,6 +72,19 @@ function asTrimmedString(value: unknown, maxLength: number): string | null {
   return trimmed.length > 0 && trimmed.length <= maxLength ? trimmed : null;
 }
 
+function asHttpsUrl(value: unknown): string | undefined {
+  if (typeof value !== "string" || !URL.canParse(value)) return undefined;
+  return new URL(value).protocol === "https:" ? value : undefined;
+}
+
+export function displayIntegrationName(value: string): string {
+  return value
+    .split(/[_-]+/)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1).toLowerCase()}`)
+    .join(" ");
+}
+
 export function parseAvailableIntegrations(value: unknown): AvailableIntegration[] {
   const list = asList(value, ["services", "available"]);
   const out: AvailableIntegration[] = [];
@@ -71,7 +95,17 @@ export function parseAvailableIntegrations(value: unknown): AvailableIntegration
     if (!id) continue;
     const name = asTrimmedString(record.name, 100) ?? id;
     const category = asTrimmedString(record.category, 64) ?? "other";
-    out.push({ id, name, category });
+    const description = asTrimmedString(record.description, 180);
+    const logoUrl = asHttpsUrl(record.logoUrl)
+      ?? asHttpsUrl(record.logo_url)
+      ?? (PIPEDREAM_LOGO_SERVICES.has(id) ? `https://pipedream.com/s.v0/${id}/logo/48` : undefined);
+    out.push({
+      id,
+      name,
+      category,
+      ...(description ? { description } : {}),
+      ...(logoUrl ? { logoUrl } : {}),
+    });
   }
   return out;
 }

--- a/desktop/src/renderer/src/features/mission-control/NavigationHeader.tsx
+++ b/desktop/src/renderer/src/features/mission-control/NavigationHeader.tsx
@@ -6,6 +6,7 @@ import {
   PanelLeft,
 } from "@renderer/lib/hugeicons";
 import { Fragment } from "react";
+import { invoke } from "../../lib/operator";
 import { useHermesChat } from "../../stores/hermes-chat";
 import { useTabs, type Tab } from "../../stores/tabs";
 import { useThreads } from "../../stores/threads";
@@ -152,6 +153,12 @@ export default function NavigationHeader({ nativeDesktop = false }: { nativeDesk
   const activeConversationTitle = canonicalConversationTitle
     ?? activeThreadTitle
     ?? (hermesConversationView === "conversation" ? hermesConversationTitle : undefined);
+  const handleTitlebarDoubleClick = (event: React.MouseEvent<HTMLElement>) => {
+    if (!nativeDesktop) return;
+    const target = event.target;
+    if (target instanceof Element && target.closest("button,input,a,[role='button'],[role='tab']")) return;
+    void invoke("window:toggle-maximize", {});
+  };
   const breadcrumbs = breadcrumbItemsForTab(activeTab, activeConversationTitle);
   const hasContextActions = Boolean(
     activeTab && activeTab.kind !== "terminals" && activeTab.kind !== "terminal",
@@ -200,6 +207,7 @@ export default function NavigationHeader({ nativeDesktop = false }: { nativeDesk
   return (
     <header
       className="titlebar-drag absolute inset-x-0 top-0 grid shrink-0 items-center"
+      onDoubleClick={handleTitlebarDoubleClick}
       style={{
         zIndex: DESKTOP_Z_INDEX.chrome,
         height: "var(--titlebar-height)",

--- a/desktop/src/renderer/src/features/mission-control/TabContent.tsx
+++ b/desktop/src/renderer/src/features/mission-control/TabContent.tsx
@@ -7,7 +7,7 @@ import { useUi } from "../../stores/ui";
 import ProjectTab from "../project/ProjectTab";
 import TaskWorkspace from "../workspace/TaskWorkspace";
 import TerminalView from "../terminal/TerminalView";
-import SettingsView from "../settings/SettingsView";
+import SettingsView, { type SettingsSectionId } from "../settings/SettingsView";
 import PluginsHub from "../plugins/PluginsHub";
 import HomeTab from "./HomeTab";
 import ChatTab from "../chat/ChatTab";
@@ -54,12 +54,16 @@ export function TabPane({
   visible = active,
   layoutRevision,
   visualScale = 1,
+  settingsSection,
+  onSettingsSectionChange,
 }: {
   tab: Tab;
   active: boolean;
   visible?: boolean;
   layoutRevision?: string;
   visualScale?: number;
+  settingsSection?: SettingsSectionId;
+  onSettingsSectionChange?: (section: SettingsSectionId) => void;
 }) {
   switch (tab.kind) {
     case "home":
@@ -87,7 +91,7 @@ export function TabPane({
     case "terminal":
       return tab.sessionName ? <TerminalView sessionName={tab.sessionName} active={active} /> : null;
     case "settings":
-      return <SettingsView />;
+      return <SettingsView section={settingsSection} onSectionChange={onSettingsSectionChange} />;
     case "plugins":
       return <PluginsHub />;
     default:

--- a/desktop/src/renderer/src/features/settings/SettingsView.tsx
+++ b/desktop/src/renderer/src/features/settings/SettingsView.tsx
@@ -4,10 +4,9 @@ import {
   Clock,
   CreditCard,
   Cpu,
-  MonitorCog,
   Palette,
-  FolderArchive,
   Server,
+  Settings as SettingsIcon,
   Sparkles,
   UserRound,
 } from "@renderer/lib/hugeicons";
@@ -17,36 +16,30 @@ import AppearanceSection from "./sections/AppearanceSection";
 import RuntimeSection from "./sections/RuntimeSection";
 import AgentSection from "./sections/AgentSection";
 import BillingSection from "./sections/BillingSection";
-import ChannelsSection from "./sections/ChannelsSection";
 import { IntegrationsSettingsSection } from "../integrations/IntegrationsSettingsSection";
 import CronSection from "./sections/CronSection";
 import ProvidersSection from "./sections/ProvidersSection";
 import SystemSection from "./sections/SystemSection";
-import ProjectsSection from "./sections/ProjectsSection";
 import { useUi } from "../../stores/ui";
 
-type SectionId =
+export type SettingsSectionId =
   | "account"
   | "appearance"
   | "billing"
   | "runtime"
-  | "projects"
   | "agent"
   | "providers"
-  | "channels"
   | "integrations"
   | "cron"
   | "system";
 
-const SECTIONS: { id: SectionId; label: string; icon: React.ReactNode; group: string }[] = [
+const SECTIONS: { id: SettingsSectionId; label: string; icon: React.ReactNode; group: string }[] = [
   { id: "account", label: "Account", icon: <UserRound size={15} />, group: "You" },
   { id: "billing", label: "Billing", icon: <CreditCard size={15} />, group: "You" },
   { id: "appearance", label: "Appearance", icon: <Palette size={15} />, group: "You" },
   { id: "agent", label: "Agent (Hermes)", icon: <Sparkles size={15} />, group: "Machine" },
   { id: "providers", label: "Providers", icon: <Bot size={15} />, group: "Machine" },
   { id: "runtime", label: "Computers", icon: <Server size={15} />, group: "Machine" },
-  { id: "projects", label: "Projects", icon: <FolderArchive size={15} />, group: "Machine" },
-  { id: "channels", label: "Channels", icon: <MonitorCog size={15} />, group: "Machine" },
   { id: "integrations", label: "Integrations", icon: <Blocks size={15} />, group: "Machine" },
   { id: "cron", label: "Schedules", icon: <Clock size={15} />, group: "Machine" },
   { id: "system", label: "System", icon: <Cpu size={15} />, group: "Machine" },
@@ -58,65 +51,87 @@ const SECTIONS_BY_GROUP = SECTIONS.reduce<Record<string, typeof SECTIONS>>((grou
 }, {});
 const SECTION_GROUPS = Object.keys(SECTIONS_BY_GROUP);
 
-function isSectionId(value: string): value is SectionId {
+export function isSettingsSectionId(value: string): value is SettingsSectionId {
   return SECTIONS.some((candidate) => candidate.id === value);
 }
 
-export default function SettingsView() {
-  const [section, setSection] = useState<SectionId>("account");
+export function SettingsSidebar({
+  section,
+  onSectionChange,
+}: {
+  section: SettingsSectionId;
+  onSectionChange: (section: SettingsSectionId) => void;
+}) {
+  return (
+    <nav
+      aria-label="Settings sections"
+      className="flex h-full w-full flex-col gap-0.5 overflow-y-auto p-2"
+      style={{ background: "var(--bg-surface)" }}
+    >
+      <h2 data-settings-sidebar-title className="flex items-center gap-2 px-2.5 py-2 text-lg font-semibold" style={{ color: "var(--text-primary)" }}>
+        <SettingsIcon size={18} aria-hidden="true" />
+        Settings
+      </h2>
+      {SECTION_GROUPS.map((group) => (
+        <div key={group} className="mb-1 flex flex-col gap-0.5">
+          <span className="px-2.5 pt-2 pb-1 text-xs font-semibold tracking-wide uppercase" style={{ color: "var(--text-tertiary)" }}>
+            {group}
+          </span>
+          {SECTIONS_BY_GROUP[group]?.map((s) => {
+            const active = s.id === section;
+            return (
+              <button
+                key={s.id}
+                type="button"
+                onClick={() => onSectionChange(s.id)}
+                className={`flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-sm font-medium transition-colors duration-100 ${active ? "bg-[var(--bg-selected)]" : "hover:bg-[var(--bg-hover)]"}`}
+                style={{ color: active ? "var(--text-primary)" : "var(--text-secondary)" }}
+              >
+                <span style={{ color: active ? "var(--accent)" : "var(--text-tertiary)" }}>{s.icon}</span>
+                {s.label}
+              </button>
+            );
+          })}
+        </div>
+      ))}
+    </nav>
+  );
+}
+
+export default function SettingsView({
+  section: controlledSection,
+  onSectionChange,
+}: {
+  section?: SettingsSectionId;
+  onSectionChange?: (section: SettingsSectionId) => void;
+} = {}) {
+  const [localSection, setLocalSection] = useState<SettingsSectionId>("account");
   const requestedSection = useUi((s) => s.requestedSettingsSection);
+  const section = controlledSection ?? localSection;
+  const selectSection = onSectionChange ?? setLocalSection;
 
   // Deep links (for example the provider recovery CTA) request a section
   // before opening or focusing the Settings tab; consume it once.
   useEffect(() => {
     if (!requestedSection) return;
-    if (isSectionId(requestedSection)) setSection(requestedSection);
+    if (controlledSection !== undefined) return;
+    if (isSettingsSectionId(requestedSection)) setLocalSection(requestedSection);
     useUi.getState().clearRequestedSettingsSection();
-  }, [requestedSection]);
+  }, [controlledSection, requestedSection]);
 
   return (
     <div className="flex min-h-0 flex-1">
-      <nav
-        className="flex w-[208px] shrink-0 flex-col gap-0.5 overflow-y-auto border-r p-2"
-        style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
-      >
-        <h2 className="px-2.5 py-2 text-lg font-semibold" style={{ color: "var(--text-primary)" }}>
-          Settings
-        </h2>
-        {SECTION_GROUPS.map((group) => (
-          <div key={group} className="mb-1 flex flex-col gap-0.5">
-            <span className="px-2.5 pt-2 pb-1 text-xs font-semibold tracking-wide uppercase" style={{ color: "var(--text-tertiary)" }}>
-              {group}
-            </span>
-            {SECTIONS_BY_GROUP[group]?.map((s) => {
-              const active = s.id === section;
-              return (
-                <button
-                  key={s.id}
-                  type="button"
-                  onClick={() => setSection(s.id)}
-                  className={`flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-sm font-medium transition-colors duration-100 ${active ? "bg-[var(--bg-selected)]" : "hover:bg-[var(--bg-hover)]"}`}
-                  style={{ color: active ? "var(--text-primary)" : "var(--text-secondary)" }}
-                >
-                  <span style={{ color: active ? "var(--accent)" : "var(--text-tertiary)" }}>{s.icon}</span>
-                  {s.label}
-                </button>
-              );
-            })}
-          </div>
-        ))}
-      </nav>
-
+      {controlledSection === undefined ? (
+        <SettingsSidebar section={section} onSectionChange={selectSection} />
+      ) : null}
       <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="mx-auto w-full max-w-[720px] px-8 py-8">
+        <div className="w-full px-5 py-6">
           {section === "account" ? <AccountSection /> : null}
           {section === "billing" ? <BillingSection /> : null}
           {section === "appearance" ? <AppearanceSection /> : null}
           {section === "runtime" ? <RuntimeSection /> : null}
-          {section === "projects" ? <ProjectsSection /> : null}
           {section === "agent" ? <AgentSection /> : null}
           {section === "providers" ? <ProvidersSection /> : null}
-          {section === "channels" ? <ChannelsSection /> : null}
           {section === "integrations" ? <IntegrationsSettingsSection /> : null}
           {section === "cron" ? <CronSection /> : null}
           {section === "system" ? <SystemSection /> : null}

--- a/desktop/src/renderer/src/features/settings/sections/AccountSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/AccountSection.tsx
@@ -1,7 +1,7 @@
 import { Button } from "../../../design/primitives";
 import { invoke } from "../../../lib/operator";
 import { useConnection } from "../../../stores/connection";
-import { Card, Row, SectionHeader } from "./section-kit";
+import { Card, Row, SettingsSectionHeader } from "./section-kit";
 
 function initialsFor(name: string): string {
   return name
@@ -23,7 +23,7 @@ export default function AccountSection() {
 
   return (
     <>
-      <SectionHeader title="Account" description="Your Matrix OS identity and session." />
+      <SettingsSectionHeader title="Account" description="Your Matrix OS identity and session." />
       <Card>
         <div className="flex items-center gap-3">
           <div

--- a/desktop/src/renderer/src/features/settings/sections/AgentSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/AgentSection.tsx
@@ -8,7 +8,7 @@ import { invoke } from "../../../lib/operator";
 import { useConnection } from "../../../stores/connection";
 import { useTabs } from "../../../stores/tabs";
 import { openProviderSetupTerminal, providerSetupCommands, type ProviderSetupCommand } from "../../coding-agents/provider-setup-terminal";
-import { Card, Empty, SectionHeader } from "./section-kit";
+import { Card, Empty, SettingsSectionHeader } from "./section-kit";
 import AgentRuntimeSettingsCard from "./AgentRuntimeSettingsCard";
 
 const SOUL_PATH = "/files/system/soul.md";
@@ -467,7 +467,7 @@ export default function AgentSection() {
   const runtimeScope = useConnection((state) => `${state.runtimeSlot}:${state.authGeneration}`);
   return (
     <>
-      <SectionHeader
+      <SettingsSectionHeader
         title="Agent"
         description="Tune Matrix Chat, choose the runtime for messaging channels, authenticate providers, edit SOUL, and check which coding agents are connected."
       />

--- a/desktop/src/renderer/src/features/settings/sections/AppearanceSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/AppearanceSection.tsx
@@ -3,7 +3,7 @@ import { Button, IconButton } from "../../../design/primitives";
 import { getThemeVariant, unifiedThemes } from "../../../design/themes";
 import { resolveThemeMode, type ThemeMode } from "../../../design/themes/apply";
 import { MAX_ZOOM, MIN_ZOOM, useAppearance, ZOOM_STEP } from "../../../stores/appearance";
-import { Card, SectionHeader } from "./section-kit";
+import { Card, SettingsSectionHeader } from "./section-kit";
 
 function ThemeSwatch({ themeId, mode, selected, onSelect, onArrowKey }: {
   themeId: string;
@@ -87,7 +87,7 @@ export default function AppearanceSection() {
 
   return (
     <>
-      <SectionHeader title="Appearance" description="How Matrix OS looks on this machine." />
+      <SettingsSectionHeader title="Appearance" description="How Matrix OS looks on this machine." />
       <Card>
         <span className="text-sm" style={{ color: "var(--text-secondary)" }}>Mode</span>
         <div className="flex gap-2">

--- a/desktop/src/renderer/src/features/settings/sections/BillingSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/BillingSection.tsx
@@ -4,7 +4,7 @@ import { z } from "zod/v4";
 import { Button } from "../../../design/primitives";
 import { invoke } from "../../../lib/operator";
 import { useConnection } from "../../../stores/connection";
-import { Card, Row, SectionHeader } from "./section-kit";
+import { Card, Row, SettingsSectionHeader } from "./section-kit";
 
 const BillingEntitlementSchema = z
   .object({
@@ -216,7 +216,7 @@ export default function BillingSection() {
 
   return (
     <>
-      <SectionHeader
+      <SettingsSectionHeader
         title="Billing"
         description="Manage hosted runtime billing through the native Matrix session."
       />

--- a/desktop/src/renderer/src/features/settings/sections/CronSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/CronSection.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useConnection } from "../../../stores/connection";
-import { Card, Empty, SectionHeader } from "./section-kit";
+import { Card, Empty, SettingsSectionHeader } from "./section-kit";
 
 interface CronJob {
   id?: string;
@@ -49,7 +49,7 @@ export default function CronSection() {
 
   return (
     <>
-      <SectionHeader title="Schedules" description="Recurring agent jobs and heartbeats." />
+      <SettingsSectionHeader title="Schedules" description="Recurring agent jobs and heartbeats." />
       <Card>
         {state.loading ? <Empty text="Loading schedules..." /> : state.error ? <Empty text="Schedules unavailable." /> : state.jobs.length === 0 ? (
           <Empty text="No scheduled jobs." />

--- a/desktop/src/renderer/src/features/settings/sections/ProvidersSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/ProvidersSection.tsx
@@ -17,7 +17,7 @@ import {
 } from "../../coding-agents/provider-setup-terminal";
 import { ProviderGlyph } from "../provider-glyph";
 import { useProviderPreferences } from "../provider-preferences";
-import { Card, Empty, SectionHeader } from "./section-kit";
+import { Card, Empty, SettingsSectionHeader } from "./section-kit";
 
 const PROVIDER_STATUS_COLOR: Record<AgentProviderSummary["availability"], string> = {
   available: "var(--success)",
@@ -195,7 +195,7 @@ export default function ProvidersSection() {
   return (
     <>
       <div className="flex items-start justify-between gap-4">
-        <SectionHeader
+        <SettingsSectionHeader
           title="Providers"
           description="Coding agents on this computer. Install, sign in, and choose the default for new chats."
         />

--- a/desktop/src/renderer/src/features/settings/sections/RuntimeSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/RuntimeSection.tsx
@@ -6,7 +6,7 @@ import {
 import { Button } from "../../../design/primitives";
 import { useConnection } from "../../../stores/connection";
 import { useRuntimeComputers } from "../../../stores/runtime-computers";
-import { Card, Empty, SectionHeader } from "./section-kit";
+import { Card, Empty, SettingsSectionHeader } from "./section-kit";
 
 const STATUS_LABEL: Record<MatrixComputer["availability"], string> = {
   available: "Available",
@@ -106,7 +106,7 @@ export default function RuntimeSection() {
 
   return (
     <>
-      <SectionHeader
+      <SettingsSectionHeader
         title="Computers"
         description="Choose the Matrix computer this desktop app connects to."
       />

--- a/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
@@ -77,9 +77,11 @@ export default function SystemSection() {
   const [upgradeMessage, setUpgradeMessage] = useState<string | null>(null);
   const mountedRef = useRef(true);
   const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const releaseRequestRef = useRef(0);
 
   const loadReleases = useCallback(async (nextChannel: ReleaseChannel) => {
     if (!api) return;
+    const request = ++releaseRequestRef.current;
     setLoadingReleases(true);
     setUpgradeError(null);
     try {
@@ -87,15 +89,17 @@ export default function SystemSection() {
         api.get<SystemUpdateStatus>(`/api/system/update?channel=${nextChannel}`),
         api.get<ReleaseList>(`/api/system/releases?channel=${nextChannel}`),
       ]);
+      if (request !== releaseRequestRef.current) return;
       setUpdate(nextUpdate);
       setReleaseList(nextReleases);
     } catch (err: unknown) {
+      if (request !== releaseRequestRef.current) return;
       console.warn("[settings] load system releases failed:", err instanceof Error ? err.message : String(err));
       setUpgradeError("Release information is unavailable.");
       setUpdate(null);
       setReleaseList(null);
     } finally {
-      setLoadingReleases(false);
+      if (request === releaseRequestRef.current) setLoadingReleases(false);
     }
   }, [api]);
 
@@ -121,7 +125,11 @@ export default function SystemSection() {
     if (pollTimeoutRef.current) clearTimeout(pollTimeoutRef.current);
   }, []);
 
-  const waitForInstallation = async (target: { version?: string; channel?: ReleaseChannel }) => {
+  const waitForInstallation = async (target: {
+    version?: string;
+    channel?: ReleaseChannel;
+    previousVersion?: string;
+  }) => {
     if (!api) return;
     const startedAt = Date.now();
     const poll = async (): Promise<void> => {
@@ -129,11 +137,13 @@ export default function SystemSection() {
       try {
         const info = await api.get<SystemInfo>("/api/system/info");
         if (!mountedRef.current) return;
-        const installedVersion = info.release?.version ?? info.version;
-        const installedChannel = channel(info.updateChannel ?? info.release?.channel);
+        const installedVersion = info.release?.version;
+        const installedChannel = channel(info.release?.channel);
         const installed = target.version
           ? installedVersion === target.version
-          : installedChannel === target.channel;
+          : installedChannel === target.channel
+            && installedVersion !== undefined
+            && installedVersion !== target.previousVersion;
         if (installed) {
           setState({ info, error: false });
           setInstallingVersion(null);
@@ -157,13 +167,14 @@ export default function SystemSection() {
 
   const startUpgrade = async (version?: string) => {
     if (!api) return;
+    const previousVersion = state.info?.release?.version;
     setInstallingVersion(version ?? selectedChannel);
     setUpgradeError(null);
     setUpgradeMessage(version ? `Installing ${version}…` : `Switching to the ${selectedChannel} channel…`);
     try {
       await api.post("/api/system/update", version ? { version } : { channel: selectedChannel }, { timeoutMs: 10_000 });
       setUpgradeMessage("Update started. Waiting for the new version to finish installing…");
-      void waitForInstallation(version ? { version } : { channel: selectedChannel });
+      void waitForInstallation(version ? { version } : { channel: selectedChannel, previousVersion });
     } catch (err: unknown) {
       console.warn("[settings] start system update failed:", err instanceof Error ? err.message : String(err));
       setUpgradeError("The update could not be started.");

--- a/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useConnection } from "../../../stores/connection";
+import { captureRuntimeGeneration, isCurrentRuntimeGeneration } from "../../../stores/runtime-generation";
 import { AlertTriangle, ArrowUpCircleIcon, LoaderCircle, RefreshCw } from "../../../lib/hugeicons";
 import { Card, Empty, Row, SettingsSectionHeader } from "./section-kit";
 
@@ -67,6 +68,7 @@ function compareReleaseToInstalled(version: string | undefined, installed: strin
 
 export default function SystemSection() {
   const api = useConnection((s) => s.api);
+  const runtimeSlot = useConnection((s) => s.runtimeSlot);
   const [state, setState] = useState<{ info: SystemInfo | null; error: boolean }>({ info: null, error: false });
   const [selectedChannel, setSelectedChannel] = useState<ReleaseChannel>("stable");
   const [update, setUpdate] = useState<SystemUpdateStatus | null>(null);
@@ -106,6 +108,12 @@ export default function SystemSection() {
   useEffect(() => {
     if (!api) return;
     let cancelled = false;
+    releaseRequestRef.current += 1;
+    if (pollTimeoutRef.current) clearTimeout(pollTimeoutRef.current);
+    pollTimeoutRef.current = null;
+    setInstallingVersion(null);
+    setUpgradeMessage(null);
+    setUpgradeError(null);
     api.get<SystemInfo>("/api/system/info").then((info) => {
       if (cancelled) return;
       setState({ info, error: false });
@@ -118,7 +126,7 @@ export default function SystemSection() {
       setState((current) => ({ ...current, error: true }));
     });
     return () => { cancelled = true; };
-  }, [api, loadReleases]);
+  }, [api, loadReleases, runtimeSlot]);
 
   useEffect(() => () => {
     mountedRef.current = false;
@@ -129,20 +137,19 @@ export default function SystemSection() {
     version?: string;
     channel?: ReleaseChannel;
     previousVersion?: string;
+    runtimeGeneration: number;
   }) => {
     if (!api) return;
     const startedAt = Date.now();
     const poll = async (): Promise<void> => {
-      if (!mountedRef.current) return;
+      if (!mountedRef.current || !isCurrentRuntimeGeneration(target.runtimeGeneration)) return;
       try {
         const info = await api.get<SystemInfo>("/api/system/info");
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || !isCurrentRuntimeGeneration(target.runtimeGeneration)) return;
         const installedVersion = info.release?.version;
-        const installedChannel = channel(info.release?.channel);
         const installed = target.version
           ? installedVersion === target.version
-          : installedChannel === target.channel
-            && installedVersion !== undefined
+          : installedVersion !== undefined
             && installedVersion !== target.previousVersion;
         if (installed) {
           setState({ info, error: false });
@@ -154,6 +161,7 @@ export default function SystemSection() {
       } catch (err: unknown) {
         console.warn("[settings] poll system update failed:", err instanceof Error ? err.message : String(err));
       }
+      if (!isCurrentRuntimeGeneration(target.runtimeGeneration)) return;
       if (Date.now() - startedAt >= UPDATE_POLL_TIMEOUT_MS) {
         setInstallingVersion(null);
         setUpgradeError("The update is taking longer than expected. Check the System pane again shortly.");
@@ -168,13 +176,17 @@ export default function SystemSection() {
   const startUpgrade = async (version?: string) => {
     if (!api) return;
     const previousVersion = state.info?.release?.version;
+    const runtimeGeneration = captureRuntimeGeneration();
     setInstallingVersion(version ?? selectedChannel);
     setUpgradeError(null);
     setUpgradeMessage(version ? `Installing ${version}…` : `Switching to the ${selectedChannel} channel…`);
     try {
       await api.post("/api/system/update", version ? { version } : { channel: selectedChannel }, { timeoutMs: 10_000 });
+      if (!isCurrentRuntimeGeneration(runtimeGeneration)) return;
       setUpgradeMessage("Update started. Waiting for the new version to finish installing…");
-      void waitForInstallation(version ? { version } : { channel: selectedChannel, previousVersion });
+      void waitForInstallation(version
+        ? { version, runtimeGeneration }
+        : { channel: selectedChannel, previousVersion, runtimeGeneration });
     } catch (err: unknown) {
       console.warn("[settings] start system update failed:", err instanceof Error ? err.message : String(err));
       setUpgradeError("The update could not be started.");

--- a/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
@@ -134,9 +134,7 @@ export default function SystemSection() {
   }, []);
 
   const waitForInstallation = async (target: {
-    version?: string;
-    channel?: ReleaseChannel;
-    previousVersion?: string;
+    version: string;
     runtimeGeneration: number;
   }) => {
     if (!api) return;
@@ -147,10 +145,7 @@ export default function SystemSection() {
         const info = await api.get<SystemInfo>("/api/system/info");
         if (!mountedRef.current || !isCurrentRuntimeGeneration(target.runtimeGeneration)) return;
         const installedVersion = info.release?.version;
-        const installed = target.version
-          ? installedVersion === target.version
-          : installedVersion !== undefined
-            && installedVersion !== target.previousVersion;
+        const installed = installedVersion === target.version;
         if (installed) {
           setState({ info, error: false });
           setInstallingVersion(null);
@@ -175,18 +170,17 @@ export default function SystemSection() {
 
   const startUpgrade = async (version?: string) => {
     if (!api) return;
-    const previousVersion = state.info?.release?.version;
+    const targetVersion = version ?? latest?.version;
+    if (!targetVersion) return;
     const runtimeGeneration = captureRuntimeGeneration();
-    setInstallingVersion(version ?? selectedChannel);
+    setInstallingVersion(targetVersion);
     setUpgradeError(null);
     setUpgradeMessage(version ? `Installing ${version}…` : `Switching to the ${selectedChannel} channel…`);
     try {
       await api.post("/api/system/update", version ? { version } : { channel: selectedChannel }, { timeoutMs: 10_000 });
       if (!isCurrentRuntimeGeneration(runtimeGeneration)) return;
       setUpgradeMessage("Update started. Waiting for the new version to finish installing…");
-      void waitForInstallation(version
-        ? { version, runtimeGeneration }
-        : { channel: selectedChannel, previousVersion, runtimeGeneration });
+      void waitForInstallation({ version: targetVersion, runtimeGeneration });
     } catch (err: unknown) {
       console.warn("[settings] start system update failed:", err instanceof Error ? err.message : String(err));
       setUpgradeError("The update could not be started.");

--- a/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
@@ -1,10 +1,12 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useConnection } from "../../../stores/connection";
 import { AlertTriangle, ArrowUpCircleIcon, LoaderCircle, RefreshCw } from "../../../lib/hugeicons";
 import { Card, Empty, Row, SettingsSectionHeader } from "./section-kit";
 
 const RELEASE_CHANNELS = ["stable", "canary", "beta", "dev"] as const;
 type ReleaseChannel = typeof RELEASE_CHANNELS[number];
+const UPDATE_POLL_INTERVAL_MS = 5_000;
+const UPDATE_POLL_TIMEOUT_MS = 5 * 60_000;
 
 interface SystemRelease {
   version?: string;
@@ -73,6 +75,8 @@ export default function SystemSection() {
   const [installingVersion, setInstallingVersion] = useState<string | null>(null);
   const [upgradeError, setUpgradeError] = useState<string | null>(null);
   const [upgradeMessage, setUpgradeMessage] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+  const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const loadReleases = useCallback(async (nextChannel: ReleaseChannel) => {
     if (!api) return;
@@ -112,6 +116,45 @@ export default function SystemSection() {
     return () => { cancelled = true; };
   }, [api, loadReleases]);
 
+  useEffect(() => () => {
+    mountedRef.current = false;
+    if (pollTimeoutRef.current) clearTimeout(pollTimeoutRef.current);
+  }, []);
+
+  const waitForInstallation = async (target: { version?: string; channel?: ReleaseChannel }) => {
+    if (!api) return;
+    const startedAt = Date.now();
+    const poll = async (): Promise<void> => {
+      if (!mountedRef.current) return;
+      try {
+        const info = await api.get<SystemInfo>("/api/system/info");
+        if (!mountedRef.current) return;
+        const installedVersion = info.release?.version ?? info.version;
+        const installedChannel = channel(info.updateChannel ?? info.release?.channel);
+        const installed = target.version
+          ? installedVersion === target.version
+          : installedChannel === target.channel;
+        if (installed) {
+          setState({ info, error: false });
+          setInstallingVersion(null);
+          setUpgradeMessage("Update installed successfully.");
+          void loadReleases(selectedChannel);
+          return;
+        }
+      } catch (err: unknown) {
+        console.warn("[settings] poll system update failed:", err instanceof Error ? err.message : String(err));
+      }
+      if (Date.now() - startedAt >= UPDATE_POLL_TIMEOUT_MS) {
+        setInstallingVersion(null);
+        setUpgradeError("The update is taking longer than expected. Check the System pane again shortly.");
+        setUpgradeMessage(null);
+        return;
+      }
+      pollTimeoutRef.current = setTimeout(() => void poll(), UPDATE_POLL_INTERVAL_MS);
+    };
+    await poll();
+  };
+
   const startUpgrade = async (version?: string) => {
     if (!api) return;
     setInstallingVersion(version ?? selectedChannel);
@@ -119,7 +162,8 @@ export default function SystemSection() {
     setUpgradeMessage(version ? `Installing ${version}…` : `Switching to the ${selectedChannel} channel…`);
     try {
       await api.post("/api/system/update", version ? { version } : { channel: selectedChannel }, { timeoutMs: 10_000 });
-      setUpgradeMessage("Update started. Your computer will restart when installation is complete.");
+      setUpgradeMessage("Update started. Waiting for the new version to finish installing…");
+      void waitForInstallation(version ? { version } : { channel: selectedChannel });
     } catch (err: unknown) {
       console.warn("[settings] start system update failed:", err instanceof Error ? err.message : String(err));
       setUpgradeError("The update could not be started.");

--- a/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
@@ -1,47 +1,137 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useConnection } from "../../../stores/connection";
+import { AlertTriangle, ArrowUpCircleIcon, LoaderCircle, RefreshCw } from "../../../lib/hugeicons";
 import { Card, Empty, Row, SettingsSectionHeader } from "./section-kit";
+
+const RELEASE_CHANNELS = ["stable", "canary", "beta", "dev"] as const;
+type ReleaseChannel = typeof RELEASE_CHANNELS[number];
+
+interface SystemRelease {
+  version?: string;
+  channel?: string;
+  gitCommit?: string;
+  buildTime?: string;
+  severity?: string;
+  changelog?: string;
+}
 
 interface SystemInfo {
   version?: string;
-  uptime?: number;
+  updateChannel?: string;
   runtime?: { handle?: string; runtimeSlot?: string; machineId?: string };
   resources?: { cpuCount?: number; memoryTotal?: number; memoryFree?: number; diskTotal?: number; diskFree?: number };
-  release?: { version?: string; channel?: string };
+  release?: { version?: string; channel?: string; gitCommit?: string; buildTime?: string };
 }
+
+interface SystemUpdateStatus {
+  channel?: string;
+  latest?: SystemRelease | null;
+  updateAvailable?: boolean;
+  error?: string;
+  installError?: { message?: string } | null;
+}
+
+interface ReleaseList { releases?: SystemRelease[]; error?: string; }
 
 function gb(bytes: number | undefined): string {
   if (typeof bytes !== "number" || !Number.isFinite(bytes)) return "–";
   return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
 }
 
+function channel(value: unknown): ReleaseChannel {
+  return RELEASE_CHANNELS.includes(value as ReleaseChannel) ? value as ReleaseChannel : "stable";
+}
+
+function formatBuildId(gitCommit?: string): string | null {
+  return gitCommit ? `Build ID ${gitCommit.slice(0, 12)}` : null;
+}
+
+function releaseNumber(version?: string): number[] | null {
+  const match = version?.match(/^v?(\d{4})\.(\d{2})\.(\d{2})(?:[-.](\d+))?/);
+  return match ? [1, 2, 3, 4].map((index) => Number(match[index] ?? 0)) : null;
+}
+
+function compareReleaseToInstalled(version: string | undefined, installed: string | undefined): number {
+  const candidate = releaseNumber(version);
+  const current = releaseNumber(installed);
+  if (!candidate || !current) return 1;
+  for (let index = 0; index < candidate.length; index += 1) {
+    const candidatePart = candidate[index] ?? 0;
+    const currentPart = current[index] ?? 0;
+    if (candidatePart !== currentPart) return candidatePart > currentPart ? 1 : -1;
+  }
+  return 0;
+}
+
 export default function SystemSection() {
   const api = useConnection((s) => s.api);
-  const [state, setState] = useState<{ info: SystemInfo | null; error: boolean }>({
-    info: null,
-    error: false,
-  });
+  const [state, setState] = useState<{ info: SystemInfo | null; error: boolean }>({ info: null, error: false });
+  const [selectedChannel, setSelectedChannel] = useState<ReleaseChannel>("stable");
+  const [update, setUpdate] = useState<SystemUpdateStatus | null>(null);
+  const [releaseList, setReleaseList] = useState<ReleaseList | null>(null);
+  const [loadingReleases, setLoadingReleases] = useState(false);
+  const [installingVersion, setInstallingVersion] = useState<string | null>(null);
+  const [upgradeError, setUpgradeError] = useState<string | null>(null);
+  const [upgradeMessage, setUpgradeMessage] = useState<string | null>(null);
+
+  const loadReleases = useCallback(async (nextChannel: ReleaseChannel) => {
+    if (!api) return;
+    setLoadingReleases(true);
+    setUpgradeError(null);
+    try {
+      const [nextUpdate, nextReleases] = await Promise.all([
+        api.get<SystemUpdateStatus>(`/api/system/update?channel=${nextChannel}`),
+        api.get<ReleaseList>(`/api/system/releases?channel=${nextChannel}`),
+      ]);
+      setUpdate(nextUpdate);
+      setReleaseList(nextReleases);
+    } catch (err: unknown) {
+      console.warn("[settings] load system releases failed:", err instanceof Error ? err.message : String(err));
+      setUpgradeError("Release information is unavailable.");
+      setUpdate(null);
+      setReleaseList(null);
+    } finally {
+      setLoadingReleases(false);
+    }
+  }, [api]);
 
   useEffect(() => {
     if (!api) return;
     let cancelled = false;
-    api
-      .get<SystemInfo>("/api/system/info")
-      .then((d) => {
-        if (!cancelled) {
-          setState({ info: d, error: false });
-        }
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        console.warn(
-          "[settings] load system info failed:",
-          err instanceof Error ? err.message : String(err),
-        );
-        setState((current) => ({ ...current, error: true }));
-      });
+    api.get<SystemInfo>("/api/system/info").then((info) => {
+      if (cancelled) return;
+      setState({ info, error: false });
+      const installedChannel = channel(info.updateChannel ?? info.release?.channel);
+      setSelectedChannel(installedChannel);
+      void loadReleases(installedChannel);
+    }).catch((err: unknown) => {
+      if (cancelled) return;
+      console.warn("[settings] load system info failed:", err instanceof Error ? err.message : String(err));
+      setState((current) => ({ ...current, error: true }));
+    });
     return () => { cancelled = true; };
-  }, [api]);
+  }, [api, loadReleases]);
+
+  const startUpgrade = async (version?: string) => {
+    if (!api) return;
+    setInstallingVersion(version ?? selectedChannel);
+    setUpgradeError(null);
+    setUpgradeMessage(version ? `Installing ${version}…` : `Switching to the ${selectedChannel} channel…`);
+    try {
+      await api.post("/api/system/update", version ? { version } : { channel: selectedChannel }, { timeoutMs: 10_000 });
+      setUpgradeMessage("Update started. Your computer will restart when installation is complete.");
+    } catch (err: unknown) {
+      console.warn("[settings] start system update failed:", err instanceof Error ? err.message : String(err));
+      setUpgradeError("The update could not be started.");
+      setUpgradeMessage(null);
+      setInstallingVersion(null);
+    }
+  };
+
+  const info = state.info;
+  const currentVersion = info?.release?.version ?? info?.version;
+  const releases = releaseList?.releases ?? [];
+  const latest = update?.latest;
 
   return (
     <>
@@ -49,14 +139,96 @@ export default function SystemSection() {
       <Card>
         {state.error ? <Empty text="System info unavailable." /> : (
           <>
-            <Row label="OS version" value={state.info?.version ?? "–"} />
-            <Row label="Release channel" value={state.info?.release?.channel ?? "–"} />
-            <Row label="Machine" value={state.info?.runtime?.machineId ?? state.info?.runtime?.handle ?? "–"} />
-            <Row label="CPU cores" value={state.info?.resources?.cpuCount ?? "–"} />
-            <Row label="Memory free" value={`${gb(state.info?.resources?.memoryFree)} of ${gb(state.info?.resources?.memoryTotal)}`} />
-            <Row label="Disk free" value={`${gb(state.info?.resources?.diskFree)} of ${gb(state.info?.resources?.diskTotal)}`} />
+            <Row label="OS version" value={info?.version ?? "–"} />
+            <Row label="Release channel" value={info?.release?.channel ?? "–"} />
+            <Row label="Machine" value={info?.runtime?.machineId ?? info?.runtime?.handle ?? "–"} />
+            <Row label="CPU cores" value={info?.resources?.cpuCount ?? "–"} />
+            <Row label="Memory free" value={`${gb(info?.resources?.memoryFree)} of ${gb(info?.resources?.memoryTotal)}`} />
+            <Row label="Disk free" value={`${gb(info?.resources?.diskFree)} of ${gb(info?.resources?.diskTotal)}`} />
           </>
         )}
+      </Card>
+
+      <Card>
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h4 className="text-md font-normal" style={{ color: "var(--text-primary)" }}>Updates</h4>
+            <p className="text-sm" style={{ color: "var(--text-secondary)" }}>Choose a release channel or install a specific version.</p>
+          </div>
+          <button type="button" aria-label="Refresh releases" onClick={() => void loadReleases(selectedChannel)} disabled={loadingReleases || installingVersion !== null} className="rounded-md p-1.5 disabled:opacity-50">
+            <RefreshCw size={16} />
+          </button>
+        </div>
+
+        <div className="flex items-end gap-3">
+          <label className="flex min-w-0 flex-1 flex-col gap-1 text-sm" style={{ color: "var(--text-secondary)" }}>
+            <span>Release channel</span>
+            <select aria-label="Release channel" value={selectedChannel} onChange={(event) => {
+              const next = channel(event.target.value);
+              setSelectedChannel(next);
+              void loadReleases(next);
+            }} disabled={loadingReleases || installingVersion !== null} className="h-9 rounded-md border bg-transparent px-2 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--text-primary)" }}>
+              {RELEASE_CHANNELS.map((item) => <option key={item} value={item}>{item}</option>)}
+            </select>
+          </label>
+          {latest?.version && update?.updateAvailable && (
+            <button type="button" onClick={() => void startUpgrade()} disabled={installingVersion !== null} className="inline-flex h-9 items-center gap-1.5 rounded-md bg-[var(--surface-success-emphasis,#288A5B)] px-3 text-sm text-white disabled:opacity-50">
+              <ArrowUpCircleIcon size={16} /> Upgrade
+            </button>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1 text-sm">
+          <Row label="Current version" value={currentVersion ?? "–"} />
+          <Row label={`Latest ${selectedChannel} release`} value={latest?.version ?? (loadingReleases ? "Checking…" : "–")} />
+        </div>
+
+        {(update?.error || releaseList?.error || upgradeError) && <p className="text-sm" style={{ color: "var(--text-danger, #b42318)" }}>{upgradeError ?? update?.error ?? releaseList?.error}</p>}
+        {update?.installError?.message && (
+          <div className="flex items-start gap-2 rounded-lg border p-3 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--text-danger, #b42318)" }}>
+            <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+            <span>{update.installError.message}</span>
+          </div>
+        )}
+        {upgradeMessage && <p className="text-sm" style={{ color: "var(--text-secondary)" }}>{upgradeMessage}</p>}
+        {installingVersion && (
+          <div role="status" aria-label={`Installing ${installingVersion}`} className="flex flex-col gap-3 rounded-lg border p-3" style={{ borderColor: "var(--border-subtle)" }}>
+            <div className="flex items-center gap-2">
+              <LoaderCircle size={16} className="animate-spin" style={{ color: "var(--text-primary)" }} />
+              <span className="text-sm" style={{ color: "var(--text-primary)" }}>Installing update…</span>
+            </div>
+            <div className="flex gap-1.5 text-xs" style={{ color: "var(--text-secondary)" }}>
+              <span className="flex-1">Download</span>
+              <span className="flex-1 text-center">Install</span>
+              <span className="flex-1 text-right">Verify</span>
+            </div>
+            <div className="h-1.5 overflow-hidden rounded-full" style={{ background: "var(--bg-surface)" }}>
+              <div className="h-full w-1/2 animate-pulse rounded-full" style={{ background: "var(--surface-success-emphasis, #288A5B)" }} />
+            </div>
+            <p className="text-sm" style={{ color: "var(--text-secondary)" }}>Your computer will restart when installation is complete.</p>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-2 border-t pt-3" style={{ borderColor: "var(--border-subtle)" }}>
+          <span className="text-sm" style={{ color: "var(--text-secondary)" }}>Available {selectedChannel} releases</span>
+          {releases.length === 0 && <Empty text={loadingReleases ? "Loading releases…" : "No releases found."} />}
+          {releases.slice(0, 12).map((release) => {
+            const comparison = compareReleaseToInstalled(release.version, currentVersion);
+            const installed = comparison === 0;
+            const action = comparison < 0 ? "Downgrade" : "Upgrade";
+            return (
+              <div key={release.version ?? release.gitCommit} className="flex items-center justify-between gap-3 rounded-lg border p-3" style={{ borderColor: "var(--border-subtle)" }}>
+                <div className="min-w-0">
+                  <p className="text-sm font-normal" style={{ color: "var(--text-primary)" }}>{release.version ?? "Unknown version"}</p>
+                  {formatBuildId(release.gitCommit) && <p className="text-xs" style={{ color: "var(--text-secondary)" }}>{formatBuildId(release.gitCommit)}</p>}
+                </div>
+                <button type="button" aria-label={installed ? `${release.version} installed` : `${action} to ${release.version}`} onClick={() => release.version && void startUpgrade(release.version)} disabled={installed || installingVersion !== null} className="shrink-0 rounded-md border px-3 py-1.5 text-sm disabled:opacity-50" style={{ borderColor: "var(--border-subtle)" }}>
+                  {installingVersion === release.version ? "Installing…" : installed ? "Installed" : action}
+                </button>
+              </div>
+            );
+          })}
+        </div>
       </Card>
     </>
   );

--- a/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
@@ -80,6 +80,7 @@ export default function SystemSection() {
   const mountedRef = useRef(true);
   const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const releaseRequestRef = useRef(0);
+  const systemInfoRequestRef = useRef(0);
 
   const loadReleases = useCallback(async (nextChannel: ReleaseChannel) => {
     if (!api) return;
@@ -107,6 +108,8 @@ export default function SystemSection() {
 
   useEffect(() => {
     let cancelled = false;
+    const request = ++systemInfoRequestRef.current;
+    const runtimeGeneration = captureRuntimeGeneration();
     releaseRequestRef.current += 1;
     if (pollTimeoutRef.current) clearTimeout(pollTimeoutRef.current);
     pollTimeoutRef.current = null;
@@ -119,13 +122,13 @@ export default function SystemSection() {
     setUpgradeError(null);
     if (!api) return () => { cancelled = true; };
     api.get<SystemInfo>("/api/system/info").then((info) => {
-      if (cancelled) return;
+      if (cancelled || request !== systemInfoRequestRef.current || !isCurrentRuntimeGeneration(runtimeGeneration)) return;
       setState({ info, error: false });
       const installedChannel = channel(info.updateChannel ?? info.release?.channel);
       setSelectedChannel(installedChannel);
       void loadReleases(installedChannel);
     }).catch((err: unknown) => {
-      if (cancelled) return;
+      if (cancelled || request !== systemInfoRequestRef.current || !isCurrentRuntimeGeneration(runtimeGeneration)) return;
       console.warn("[settings] load system info failed:", err instanceof Error ? err.message : String(err));
       setState((current) => ({ ...current, error: true }));
     });

--- a/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
@@ -106,14 +106,18 @@ export default function SystemSection() {
   }, [api]);
 
   useEffect(() => {
-    if (!api) return;
     let cancelled = false;
     releaseRequestRef.current += 1;
     if (pollTimeoutRef.current) clearTimeout(pollTimeoutRef.current);
     pollTimeoutRef.current = null;
+    setState({ info: null, error: false });
+    setUpdate(null);
+    setReleaseList(null);
+    setLoadingReleases(false);
     setInstallingVersion(null);
     setUpgradeMessage(null);
     setUpgradeError(null);
+    if (!api) return () => { cancelled = true; };
     api.get<SystemInfo>("/api/system/info").then((info) => {
       if (cancelled) return;
       setState({ info, error: false });
@@ -170,19 +174,25 @@ export default function SystemSection() {
 
   const startUpgrade = async (version?: string) => {
     if (!api) return;
-    const targetVersion = version ?? latest?.version;
-    if (!targetVersion) return;
     const runtimeGeneration = captureRuntimeGeneration();
-    setInstallingVersion(targetVersion);
+    setInstallingVersion(version ?? selectedChannel);
     setUpgradeError(null);
     setUpgradeMessage(version ? `Installing ${version}…` : `Switching to the ${selectedChannel} channel…`);
     try {
-      await api.post("/api/system/update", version ? { version } : { channel: selectedChannel }, { timeoutMs: 10_000 });
+      const result = await api.post<{ version?: string }>(
+        "/api/system/update",
+        version ? { version } : { channel: selectedChannel },
+        { timeoutMs: 10_000 },
+      );
       if (!isCurrentRuntimeGeneration(runtimeGeneration)) return;
+      const targetVersion = version ?? result.version;
+      if (!targetVersion) throw new Error("Update target missing from response");
+      setInstallingVersion(targetVersion);
       setUpgradeMessage("Update started. Waiting for the new version to finish installing…");
       void waitForInstallation({ version: targetVersion, runtimeGeneration });
     } catch (err: unknown) {
       console.warn("[settings] start system update failed:", err instanceof Error ? err.message : String(err));
+      if (!isCurrentRuntimeGeneration(runtimeGeneration)) return;
       setUpgradeError("The update could not be started.");
       setUpgradeMessage(null);
       setInstallingVersion(null);

--- a/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useConnection } from "../../../stores/connection";
-import { Card, Empty, Row, SectionHeader } from "./section-kit";
+import { Card, Empty, Row, SettingsSectionHeader } from "./section-kit";
 
 interface SystemInfo {
   version?: string;
@@ -45,7 +45,7 @@ export default function SystemSection() {
 
   return (
     <>
-      <SectionHeader title="System" description="Your cloud computer at a glance." />
+      <SettingsSectionHeader title="System" description="Your cloud computer at a glance." />
       <Card>
         {state.error ? <Empty text="System info unavailable." /> : (
           <>

--- a/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/SystemSection.tsx
@@ -132,9 +132,12 @@ export default function SystemSection() {
     return () => { cancelled = true; };
   }, [api, loadReleases, runtimeSlot]);
 
-  useEffect(() => () => {
-    mountedRef.current = false;
-    if (pollTimeoutRef.current) clearTimeout(pollTimeoutRef.current);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (pollTimeoutRef.current) clearTimeout(pollTimeoutRef.current);
+    };
   }, []);
 
   const waitForInstallation = async (target: {

--- a/desktop/src/renderer/src/features/settings/sections/section-kit.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/section-kit.tsx
@@ -1,17 +1,28 @@
 import type { ReactNode } from "react";
 
-export function SectionHeader({ title, description }: { title: string; description?: string }) {
+export function SettingsSectionHeader({
+  title,
+  description,
+  className = "",
+}: {
+  title: string;
+  description?: string;
+  className?: string;
+}) {
   return (
-    <div className="mb-5 flex flex-col gap-1">
-      <h3 className="text-xl font-semibold tracking-tight" style={{ color: "var(--text-primary)" }}>
+    <div data-testid="settings-section-header" className={`mb-6 flex flex-col gap-1 ${className}`}>
+      <h3 data-testid="settings-section-header-title" className="text-lg font-normal tracking-[-0.4px]" style={{ color: "var(--text-primary)" }}>
         {title}
       </h3>
       {description ? (
-        <p className="text-sm" style={{ color: "var(--text-secondary)" }}>{description}</p>
+        <p data-testid="settings-section-header-description" className="text-sm font-normal" style={{ color: "var(--text-secondary)" }}>{description}</p>
       ) : null}
     </div>
   );
 }
+
+// Compatibility export for inactive/legacy settings sections.
+export const SectionHeader = SettingsSectionHeader;
 
 export function Card({ children }: { children: ReactNode }) {
   return (

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -286,6 +286,7 @@ export const INVOKE_CHANNELS = {
     request: ZoomFactorResultSchema,
     response: ZoomFactorResultSchema,
   },
+  "window:toggle-maximize": { request: Empty, response: Ok },
   "state:get": {
     request: z.object({ key: z.enum(STATE_KEYS) }).strict(),
     response: z.object({ value: z.unknown() }).strict(),

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -184,6 +184,7 @@ import {
   listSystemReleases,
   parseInternalUpgradeTarget,
   readSystemUpdateFailure,
+  resolveInternalUpgradeInstallTarget,
   resolveInternalUpgradeStartTarget,
   resolveSystemUpdateChannel,
   startSystemUpdate,
@@ -3964,13 +3965,24 @@ export async function createGateway(config: GatewayConfig) {
     });
     if (!parsedTarget.ok) return c.json({ error: "Invalid request" }, 400);
 
-    const result = await startSystemUpdate({ target: parsedTarget.target });
+    let installTarget: Extract<typeof parsedTarget.target, { type: "version" }>;
+    try {
+      installTarget = await resolveInternalUpgradeInstallTarget({
+        target: parsedTarget.target,
+        platformUrl: process.env.MATRIX_UPDATE_MANIFEST_BASE_URL ?? process.env.PLATFORM_INTERNAL_URL,
+      });
+    } catch (err: unknown) {
+      console.warn("[system-update] Failed to resolve requested update version:", err instanceof Error ? err.message : String(err));
+      return c.json({ error: "Update is unavailable" }, 503);
+    }
+
+    const result = await startSystemUpdate({ target: installTarget });
     if (!result.ok) {
       return c.json({ error: "Update not configured" }, 503);
     }
     const targetProperty =
       parsedTarget.target.type === "channel"
-        ? { channel: parsedTarget.target.value }
+        ? { channel: parsedTarget.target.value, version: installTarget.value }
         : { version: parsedTarget.target.value };
     void posthogErrorTracker.captureEvent("matrix_system_update_requested", {
       distinctId: ownerTelemetryDistinctId,

--- a/packages/gateway/src/system-update.ts
+++ b/packages/gateway/src/system-update.ts
@@ -158,6 +158,29 @@ export function resolveInternalUpgradeStartTarget(
   };
 }
 
+/**
+ * Resolve mutable channel pointers before triggering an update so the updater
+ * receives an immutable release version. The returned version is also safe
+ * for clients to use as their installation-completion predicate.
+ */
+export async function resolveInternalUpgradeInstallTarget(options: {
+  target: InternalUpgradeTarget;
+  platformUrl?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<Extract<InternalUpgradeTarget, { type: "version" }>> {
+  if (options.target.type === "version") return options.target;
+  if (!options.platformUrl) throw new Error("Update manifest is not configured");
+
+  const release = await fetchHostBundleChannelManifest({
+    platformUrl: options.platformUrl,
+    channel: options.target.value,
+    fetchImpl: options.fetchImpl,
+  });
+  const version = parseUpdateVersion(release.version);
+  if (!version) throw new Error("Update manifest has an invalid version");
+  return { type: "version", value: version };
+}
+
 export async function writeInternalUpgradeTrigger(options: {
   body: unknown;
   appDir?: string;

--- a/tests/desktop/integrations-settings-section.test.tsx
+++ b/tests/desktop/integrations-settings-section.test.tsx
@@ -367,6 +367,19 @@ describe("desktop integrations settings section", () => {
     expect(screen.queryByText(/Disconnect Work\?/)).toBeNull();
   });
 
+  it("disconnects the selected account when a service has multiple connections", async () => {
+    const api = makeApi({ connections: [GMAIL_CONNECTION, NEW_GMAIL_CONNECTION] });
+    useConnection.setState({ api: api as never });
+    render(<IntegrationsSettingsSection />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Disconnect Personal" })).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Disconnect Personal" }));
+    await waitFor(() => expect(screen.getByText(/Disconnect Personal\?/)).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: /^Disconnect$/ }));
+
+    await waitFor(() => expect(api.delete).toHaveBeenCalledWith(`/api/integrations/${NEW_CONN_ID}`));
+  });
+
   it("keeps the account and shows generic copy when disconnect fails", async () => {
     const api = makeApi({ deleteError: new AppError("server") });
     useConnection.setState({ api: api as never });

--- a/tests/desktop/integrations-settings-section.test.tsx
+++ b/tests/desktop/integrations-settings-section.test.tsx
@@ -380,6 +380,15 @@ describe("desktop integrations settings section", () => {
     await waitFor(() => expect(api.delete).toHaveBeenCalledWith(`/api/integrations/${NEW_CONN_ID}`));
   });
 
+  it("does not expose a first-account hover disconnect for multi-account services", async () => {
+    const api = makeApi({ connections: [GMAIL_CONNECTION, NEW_GMAIL_CONNECTION] });
+    useConnection.setState({ api: api as never });
+    render(<IntegrationsSettingsSection />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Disconnect Personal" })).not.toBeNull());
+    expect(screen.queryByTestId(`integration-disconnect-${CONN_ID}`)).toBeNull();
+  });
+
   it("keeps the account and shows generic copy when disconnect fails", async () => {
     const api = makeApi({ deleteError: new AppError("server") });
     useConnection.setState({ api: api as never });

--- a/tests/desktop/integrations-settings-section.test.tsx
+++ b/tests/desktop/integrations-settings-section.test.tsx
@@ -165,6 +165,11 @@ describe("desktop integrations settings section", () => {
     expect(screen.getByTestId("integration-action-slack").getAttribute("data-state")).toBe("connected");
     expect(screen.getByTestId("integration-action-github").getAttribute("data-state")).toBe("available");
     expect(screen.getByTestId("integration-connect-github").className).toContain("rounded-[8px]");
+    expect(Array.from(screen.getByTestId("integrations-grid").querySelectorAll("[data-testid^='integration-card-']")).map((card) => card.getAttribute("data-testid"))).toEqual([
+      "integration-card-slack",
+      "integration-card-github",
+      "integration-card-linear",
+    ]);
   });
 
   it("capitalizes service ids in the connected section when no catalog name exists", async () => {

--- a/tests/desktop/integrations-settings-section.test.tsx
+++ b/tests/desktop/integrations-settings-section.test.tsx
@@ -151,22 +151,20 @@ describe("desktop integrations settings section", () => {
 
     await waitFor(() => expect(screen.getByTestId("integrations-grid")).not.toBeNull());
 
+    expect(screen.getByTestId("settings-section-header-title").className).toContain("text-lg");
+    expect(screen.getByTestId("settings-section-header-title").className).toContain("font-normal");
+    expect(screen.getByTestId("settings-section-header-description").className).toContain("text-sm");
+    expect(screen.getByTestId("settings-section-header-description").className).toContain("font-normal");
     expect(screen.queryByText("Connected", { selector: "h4" })).toBeNull();
     expect(screen.queryByText("Available", { selector: "h4" })).toBeNull();
     expect(screen.getByText("Manage repos, issues, and pull requests")).not.toBeNull();
     expect(screen.getByText("Send messages and manage channels")).not.toBeNull();
     expect(screen.getByText("Manage issues, projects & team workflows")).not.toBeNull();
+    expect(screen.getByTestId("integration-card-slack").querySelector("p")?.className).toContain("text-md");
+    expect(screen.getByText("Send messages and manage channels").className).toContain("text-sm");
     expect(screen.getByTestId("integration-action-slack").getAttribute("data-state")).toBe("connected");
     expect(screen.getByTestId("integration-action-github").getAttribute("data-state")).toBe("available");
-    expect(screen.getByTestId("integration-action-slack").className).toContain("rounded-full");
-    expect(screen.getByTestId("integration-action-slack").className).toContain("size-7");
-    expect(screen.getByTestId("integration-action-slack").className).toContain("p-[4px]");
-    expect(screen.getByTestId("integration-action-slack").querySelector("svg")?.getAttribute("width")).toBe("20");
-    expect(screen.getByTestId("integration-action-slack").querySelector("svg")?.getAttribute("height")).toBe("20");
-    expect(screen.getByTestId("integration-action-slack").style.borderRadius).toBe("9999px");
     expect(screen.getByTestId("integration-connect-github").className).toContain("rounded-[8px]");
-    expect(screen.getByTestId("integration-connect-github").className).toContain("p-[4px]");
-    expect(screen.getByTestId("integration-connect-github").querySelector("svg")?.getAttribute("width")).toBe("20");
   });
 
   it("capitalizes service ids in the connected section when no catalog name exists", async () => {

--- a/tests/desktop/integrations-settings-section.test.tsx
+++ b/tests/desktop/integrations-settings-section.test.tsx
@@ -22,7 +22,7 @@ const NEW_CONN_ID = "8e4a7a2f-3c4d-5b6e-9f0a-1b2c3d4e5f60";
 
 const AVAILABLE = [
   { id: "gmail", name: "Gmail", category: "google", icon: "mail", logoUrl: "https://cdn.test/gmail.png", actions: {} },
-  { id: "github", name: "GitHub", category: "developer", icon: "code", actions: {} },
+  { id: "github", name: "GitHub", category: "developer", icon: "code", logoUrl: "https://cdn.test/github.png", actions: {} },
 ];
 
 const GMAIL_CONNECTION = {
@@ -122,15 +122,60 @@ describe("desktop integrations settings section", () => {
     expect(screen.getByTestId("integrations-loading")).not.toBeNull();
   });
 
-  it("lists available services with icon initials and no remote images", async () => {
+  it("lists available services with their Pipedream logo and an initial fallback", async () => {
     const { container } = render(<IntegrationsSettingsSection />);
     await waitFor(() => expect(screen.getByText("Gmail")).not.toBeNull());
 
     expect(screen.getByText("GitHub")).not.toBeNull();
     expect(screen.getByText("google")).not.toBeNull();
-    // Icon initial tile, never the remote logoUrl from the proxy payload.
-    expect(screen.getByTestId("integration-icon-gmail").textContent).toBe("G");
-    expect(container.querySelector("img")).toBeNull();
+    expect(screen.getByTestId("integration-icon-gmail").getAttribute("src"))
+      .toBe("https://cdn.test/gmail.png");
+    expect(screen.getByTestId("integration-icon-gmail").className).not.toContain("rounded");
+    expect(screen.getByTestId("integration-icon-gmail").className).toContain("object-fill");
+    expect(screen.getByTestId("integration-icon-gmail-container").className).toContain("rounded");
+    expect(screen.getByTestId("integration-icon-github").getAttribute("src"))
+      .toBe("https://cdn.test/github.png");
+  });
+
+  it("renders the Figma-style unified integration grid", async () => {
+    const api = makeApi({
+      available: [
+        { id: "github", name: "GitHub", category: "developer", logoUrl: "https://cdn.test/github.png", actions: {} },
+        { id: "slack", name: "Slack", category: "communication", logoUrl: "https://cdn.test/slack.png", actions: {} },
+        { id: "linear", name: "Linear", category: "project_management", logoUrl: "https://cdn.test/linear.png", actions: {} },
+      ],
+      connections: [{ ...GMAIL_CONNECTION, service: "slack", account_label: "Slack" }],
+    });
+    useConnection.setState({ api: api as never });
+    render(<IntegrationsSettingsSection />);
+
+    await waitFor(() => expect(screen.getByTestId("integrations-grid")).not.toBeNull());
+
+    expect(screen.queryByText("Connected", { selector: "h4" })).toBeNull();
+    expect(screen.queryByText("Available", { selector: "h4" })).toBeNull();
+    expect(screen.getByText("Manage repos, issues, and pull requests")).not.toBeNull();
+    expect(screen.getByText("Send messages and manage channels")).not.toBeNull();
+    expect(screen.getByText("Manage issues, projects & team workflows")).not.toBeNull();
+    expect(screen.getByTestId("integration-action-slack").getAttribute("data-state")).toBe("connected");
+    expect(screen.getByTestId("integration-action-github").getAttribute("data-state")).toBe("available");
+    expect(screen.getByTestId("integration-action-slack").className).toContain("rounded-full");
+    expect(screen.getByTestId("integration-action-slack").className).toContain("size-7");
+    expect(screen.getByTestId("integration-action-slack").className).toContain("p-[4px]");
+    expect(screen.getByTestId("integration-action-slack").querySelector("svg")?.getAttribute("width")).toBe("20");
+    expect(screen.getByTestId("integration-action-slack").querySelector("svg")?.getAttribute("height")).toBe("20");
+    expect(screen.getByTestId("integration-action-slack").style.borderRadius).toBe("9999px");
+    expect(screen.getByTestId("integration-connect-github").className).toContain("rounded-[8px]");
+    expect(screen.getByTestId("integration-connect-github").className).toContain("p-[4px]");
+    expect(screen.getByTestId("integration-connect-github").querySelector("svg")?.getAttribute("width")).toBe("20");
+  });
+
+  it("capitalizes service ids in the connected section when no catalog name exists", async () => {
+    useConnection.setState({
+      api: makeApi({ available: [], connections: [{ ...GMAIL_CONNECTION, service: "google_calendar" }] }) as never,
+    });
+    render(<IntegrationsSettingsSection />);
+
+    await waitFor(() => expect(screen.getByText(/Google Calendar/)).not.toBeNull());
   });
 
   it("shows connected accounts with label, email, and status", async () => {
@@ -139,6 +184,16 @@ describe("desktop integrations settings section", () => {
 
     expect(screen.getByText("work@example.com")).not.toBeNull();
     expect(screen.getByText("active")).not.toBeNull();
+  });
+
+  it("capitalizes raw connection labels in the connected section", async () => {
+    useConnection.setState({
+      api: makeApi({ connections: [{ ...GMAIL_CONNECTION, account_label: "gmail" }] }) as never,
+    });
+    render(<IntegrationsSettingsSection />);
+
+    await waitFor(() => expect(screen.getAllByText("Gmail").length).toBeGreaterThan(0));
+    expect(screen.queryByText(/^gmail$/)).toBeNull();
   });
 
   it("renders the shared Refresh recipe in the section header and reloads on click", async () => {

--- a/tests/desktop/integrations-store.test.ts
+++ b/tests/desktop/integrations-store.test.ts
@@ -18,7 +18,7 @@ import type { ApiClient } from "../../desktop/src/renderer/src/lib/api";
 
 const AVAILABLE = [
   { id: "gmail", name: "Gmail", category: "google", icon: "mail", logoUrl: "https://x.test/g.png", actions: {} },
-  { id: "slack", name: "Slack", category: "communication", icon: "chat", actions: {} },
+  { id: "slack", name: "Slack", category: "communication", icon: "chat", logoUrl: "https://x.test/slack.png", actions: {} },
 ];
 
 const CONNECTIONS = [
@@ -56,8 +56,26 @@ describe("parseAvailableIntegrations", () => {
   it("parses the gateway array shape and keeps only display-safe fields", () => {
     const parsed = parseAvailableIntegrations(AVAILABLE);
     expect(parsed).toEqual([
-      { id: "gmail", name: "Gmail", category: "google" },
+      { id: "gmail", name: "Gmail", category: "google", logoUrl: "https://x.test/g.png" },
+      { id: "slack", name: "Slack", category: "communication", logoUrl: "https://x.test/slack.png" },
+    ]);
+  });
+
+  it("rejects non-HTTPS integration logos", () => {
+    expect(parseAvailableIntegrations([
+      { id: "safe", name: "Safe", category: "other", logoUrl: "https://cdn.test/safe.png" },
+      { id: "insecure", name: "Insecure", category: "other", logoUrl: "http://cdn.test/insecure.png" },
+    ])).toEqual([
+      { id: "safe", name: "Safe", category: "other", logoUrl: "https://cdn.test/safe.png" },
+      { id: "insecure", name: "Insecure", category: "other" },
+    ]);
+  });
+
+  it("uses the Pipedream logo fallback when Slack has no logo in the catalog response", () => {
+    expect(parseAvailableIntegrations([
       { id: "slack", name: "Slack", category: "communication" },
+    ])).toEqual([
+      { id: "slack", name: "Slack", category: "communication", logoUrl: "https://pipedream.com/s.v0/slack/logo/48" },
     ]);
   });
 
@@ -73,7 +91,12 @@ describe("parseAvailableIntegrations", () => {
       "junk",
       null,
     ]);
-    expect(parsed).toEqual([{ id: "github", name: "github", category: "developer" }]);
+    expect(parsed).toEqual([{
+      id: "github",
+      name: "github",
+      category: "developer",
+      logoUrl: "https://pipedream.com/s.v0/github/logo/48",
+    }]);
   });
 
   it("caps the catalog to a bounded size", () => {

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -56,6 +56,7 @@ describe("IPC contract", () => {
       "update:acknowledge-whats-new",
       "app:get-zoom",
       "app:set-zoom",
+      "window:toggle-maximize",
     ];
     for (const ch of expected) {
       expect(INVOKE_CHANNELS[ch], ch).toBeDefined();

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -40,6 +40,7 @@ function makeHarness(overrides: Partial<HandlerContext> = {}) {
     checkUpdate: vi.fn(async () => ({ status: "disabled" })),
     getUpdateSnapshot: vi.fn(() => ({ status: "disabled" })),
     installUpdate: vi.fn(() => false),
+    toggleWindowMaximize: vi.fn(),
     getWhatsNew: vi.fn(async () => ({ release: null, shouldOpen: false })),
     acknowledgeWhatsNew: vi.fn(async () => undefined),
     fetchRuntimeSummary: vi.fn(),
@@ -1144,6 +1145,13 @@ describe("registerIpcHandlers", () => {
 
     sender.getZoomFactor.mockReturnValue(5);
     await expect(harness.invoke("app:get-zoom", {}, { sender })).resolves.toEqual({ factor: 2 });
+  });
+
+  it("toggles the native window maximize state", async () => {
+    const harness = makeHarness();
+
+    await expect(harness.invoke("window:toggle-maximize")).resolves.toEqual({ ok: true });
+    expect(harness.ctx.toggleWindowMaximize).toHaveBeenCalledOnce();
   });
 
   it("degrades zoom channels to the default when the event has no usable sender", async () => {

--- a/tests/desktop/native-desktop-shell.test.tsx
+++ b/tests/desktop/native-desktop-shell.test.tsx
@@ -279,6 +279,11 @@ describe("native desktop shell", () => {
     expect(settingsTab).toBeTruthy();
     expect(useDesktopSurfaces.getState().surfaces[settingsTab!.id]?.mode).toBe("window");
     expect(screen.getByRole("dialog", { name: "Settings window" })).toBeTruthy();
+    const settingsWindow = screen.getByRole("dialog", { name: "Settings window" });
+    expect(settingsWindow.querySelector("[data-os-window-sidebar]")).toBeTruthy();
+    const settingsTitle = within(settingsWindow).getByRole("heading", { name: "Settings" });
+    expect(settingsTitle.closest("[data-settings-sidebar-title]")?.querySelector("svg")).toBeTruthy();
+    expect(within(settingsWindow).getByRole("button", { name: "Account" })).toBeTruthy();
     expect(screen.queryByRole("tab", { name: "Settings" })).toBeNull();
 
     fireEvent.click(getWindowControl("Settings", "Maximize"));

--- a/tests/desktop/navigation-header.test.tsx
+++ b/tests/desktop/navigation-header.test.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import NavigationHeader, {
   breadcrumbItemsForTab,
   breadcrumbsForTab,
@@ -27,9 +27,16 @@ describe("Desktop navigation header", () => {
     useUi.setState(useUi.getInitialState(), true);
     useThreads.setState(useThreads.getInitialState(), true);
     useHermesChat.setState(useHermesChat.getInitialState(), true);
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: { invoke: vi.fn(async () => ({ ok: true })), on: vi.fn() },
+    });
   });
 
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    delete (window as { operator?: unknown }).operator;
+  });
 
   it("builds contextual root and nested breadcrumbs", () => {
     const project: Tab = {
@@ -403,6 +410,22 @@ describe("Desktop navigation header", () => {
     expect(screen.getByRole("tab", { name: "Desktop" })).toBeTruthy();
     expect(screen.queryByRole("navigation", { name: "Breadcrumb" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Actions for Browser" })).toBeNull();
+  });
+
+  it("toggles the native window when the titlebar background is double-clicked", () => {
+    render(<Tooltip.Provider><NavigationHeader nativeDesktop /></Tooltip.Provider>);
+
+    fireEvent.doubleClick(screen.getByRole("banner"));
+
+    expect(window.operator.invoke).toHaveBeenCalledWith("window:toggle-maximize", {});
+  });
+
+  it("does not toggle the native window when a titlebar tab is double-clicked", () => {
+    render(<Tooltip.Provider><NavigationHeader nativeDesktop /></Tooltip.Provider>);
+
+    fireEvent.doubleClick(screen.getByRole("tab", { name: "Desktop" }));
+
+    expect(window.operator.invoke).not.toHaveBeenCalledWith("window:toggle-maximize", {});
   });
 
   it("uses Figma-style native top-bar controls without a mode switcher", () => {

--- a/tests/desktop/settings-view.test.tsx
+++ b/tests/desktop/settings-view.test.tsx
@@ -7,7 +7,6 @@ import SettingsView from "../../desktop/src/renderer/src/features/settings/Setti
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 import { useUi } from "../../desktop/src/renderer/src/stores/ui";
 import { useProjectLifecycle } from "../../desktop/src/renderer/src/stores/project-lifecycle";
-import type { ApiClient } from "../../desktop/src/renderer/src/lib/api";
 
 describe("SettingsView", () => {
   beforeEach(() => {
@@ -45,6 +44,8 @@ describe("SettingsView", () => {
 
     await waitFor(() => expect(screen.getByRole("button", { name: "Computers" })).not.toBeNull());
     expect(screen.getByRole("heading", { name: "Account" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Projects" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Channels" })).toBeNull();
   });
 
   it("opens the requested section and consumes the deep-link request", async () => {
@@ -70,6 +71,15 @@ describe("SettingsView", () => {
     expect(providers.className).not.toContain("bg-[var(--bg-selected)]");
   });
 
+  it("can render its section content without owning the sidebar navigation", async () => {
+    const { default: SettingsView } = await import("../../desktop/src/renderer/src/features/settings/SettingsView");
+
+    render(<SettingsView section="account" onSectionChange={() => {}} />);
+
+    expect(screen.queryByRole("button", { name: "Account" })).toBeNull();
+    expect(screen.getByRole("heading", { name: "Account" })).not.toBeNull();
+  });
+
   it("ignores unknown requested sections", async () => {
     useUi.getState().requestSettingsSection("not-a-section");
 
@@ -79,35 +89,4 @@ describe("SettingsView", () => {
     expect(screen.getByRole("heading", { name: "Account" })).not.toBeNull();
   });
 
-  it("manages archived projects from the Machine settings group", async () => {
-    const post = vi.fn(async () => ({ ok: true, action: "restore" }));
-    const api = {
-      baseUrl: "https://x.test",
-      get: vi.fn(async (path: string) => path.includes("visibility=archived")
-        ? { projects: [{
-            slug: "customer-app",
-            name: "Customer app",
-            kind: "folder",
-            archivedAt: "2026-08-06T13:00:00.000Z",
-          }] }
-        : { projects: [] }),
-      post,
-      patch: vi.fn(),
-      put: vi.fn(),
-      delete: vi.fn(),
-      getText: vi.fn(),
-      getBlob: vi.fn(),
-      putText: vi.fn(),
-    } as ApiClient;
-    useConnection.setState({ api });
-
-    render(<SettingsView />);
-    fireEvent.click(screen.getByRole("button", { name: "Projects" }));
-
-    await waitFor(() => expect(screen.getByRole("heading", { name: "Archived projects" })).not.toBeNull());
-    expect(screen.getByText("Customer app")).not.toBeNull();
-    expect(screen.getByText(/Connected folder/)).not.toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Restore Customer app" }));
-    await waitFor(() => expect(post).toHaveBeenCalledWith("/api/projects/customer-app/actions", { type: "restore" }));
-  });
 });

--- a/tests/desktop/system-section.test.tsx
+++ b/tests/desktop/system-section.test.tsx
@@ -35,7 +35,7 @@ function makeApi() {
       }
       throw new Error(`Unexpected GET ${path}`);
     }),
-    post: vi.fn(async () => ({ ok: true, status: "started" })),
+    post: vi.fn(async () => ({ ok: true, status: "started", version: "v2026.08.28" })),
     getText: vi.fn(),
     getBlob: vi.fn(),
     patch: vi.fn(),
@@ -104,7 +104,7 @@ describe("desktop system updates", () => {
         if (path === "/api/system/releases?channel=stable") return { releases: [] };
         throw new Error(`Unexpected GET ${path}`);
       }),
-      post: vi.fn(async () => { installed = true; return { ok: true }; }),
+      post: vi.fn(async () => { installed = true; return { ok: true, version: "v2026.08.28" }; }),
     };
     useConnection.setState({ api: api as never });
     render(<SystemSection />);
@@ -130,7 +130,7 @@ describe("desktop system updates", () => {
         if (path === "/api/system/releases?channel=stable") return { releases: [] };
         throw new Error(`Unexpected GET ${path}`);
       }),
-      post: vi.fn(async () => { updateStarted = true; return { ok: true }; }),
+      post: vi.fn(async () => { updateStarted = true; return { ok: true, version: "v2026.08.28" }; }),
     };
     useConnection.setState({ api: api as never });
     render(<SystemSection />);
@@ -142,6 +142,76 @@ describe("desktop system updates", () => {
       .filter(([path]) => path === "/api/system/info").length).toBeGreaterThanOrEqual(2));
     expect(screen.getByRole("status", { name: /Installing v2026\.08\.28/i })).not.toBeNull();
     expect(screen.queryByText("Update installed successfully.")).toBeNull();
+  });
+
+  it("accepts the version resolved when starting a channel update", async () => {
+    let updateStarted = false;
+    const api = {
+      ...makeApi(),
+      get: vi.fn(async (path: string) => {
+        if (path === "/api/system/info") {
+          return updateStarted
+            ? { release: { version: "v2026.08.29", channel: "stable" } }
+            : { release: { version: "v2026.08.20", channel: "stable" } };
+        }
+        if (path === "/api/system/update?channel=stable") return { latest: { version: "v2026.08.28", channel: "stable" }, updateAvailable: true };
+        if (path === "/api/system/releases?channel=stable") return { releases: [] };
+        throw new Error(`Unexpected GET ${path}`);
+      }),
+      post: vi.fn(async () => { updateStarted = true; return { ok: true, version: "v2026.08.29" }; }),
+    };
+    useConnection.setState({ api: api as never });
+    render(<SystemSection />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Upgrade" })).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
+
+    await waitFor(() => expect(screen.getByText("Update installed successfully.")).not.toBeNull());
+  });
+
+  it("invalidates release data while the active runtime has no API", async () => {
+    const stableUpdate = deferred<unknown>();
+    const stableReleases = deferred<unknown>();
+    const api = {
+      ...makeApi(),
+      get: vi.fn((path: string) => {
+        if (path === "/api/system/info") return Promise.resolve({ release: { version: "v2026.08.20", channel: "stable" } });
+        if (path === "/api/system/update?channel=stable") return stableUpdate.promise;
+        if (path === "/api/system/releases?channel=stable") return stableReleases.promise;
+        throw new Error(`Unexpected GET ${path}`);
+      }),
+    };
+    useConnection.setState({ api: api as never, runtimeSlot: "primary" });
+    render(<SystemSection />);
+
+    await waitFor(() => expect((api.get as ReturnType<typeof vi.fn>).mock.calls
+      .some(([path]) => path === "/api/system/releases?channel=stable")).toBe(true));
+    await act(async () => {
+      useConnection.setState({ api: null, runtimeSlot: "review" });
+      stableUpdate.resolve({ latest: { version: "v2026.08.28", channel: "stable" }, updateAvailable: true });
+      stableReleases.resolve({ releases: [{ version: "v2026.08.28", channel: "stable" }] });
+      await Promise.resolve();
+    });
+
+    expect(screen.queryAllByText("v2026.08.28")).toHaveLength(0);
+  });
+
+  it("does not show an old runtime's failed update on the new runtime", async () => {
+    const pendingUpdate = deferred<unknown>();
+    const api = { ...makeApi(), post: vi.fn(() => pendingUpdate.promise) };
+    useConnection.setState({ api: api as never, runtimeSlot: "primary" });
+    render(<SystemSection />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Upgrade" })).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
+    await act(async () => {
+      advanceRuntimeGeneration();
+      useConnection.setState({ runtimeSlot: "review" });
+      pendingUpdate.resolve(Promise.reject(new Error("request failed")));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.queryByText("The update could not be started.")).toBeNull());
   });
 
   it("ignores an update poll after the active runtime changes", async () => {

--- a/tests/desktop/system-section.test.tsx
+++ b/tests/desktop/system-section.test.tsx
@@ -221,6 +221,33 @@ describe("desktop system updates", () => {
     expect(screen.queryAllByText("v2026.08.28")).toHaveLength(0);
   });
 
+  it("does not apply a late system-info channel from a previous runtime", async () => {
+    const pendingInfo = deferred<unknown>();
+    let infoRequests = 0;
+    const api = {
+      ...makeApi(),
+      get: vi.fn((path: string) => {
+        if (path === "/api/system/info") {
+          infoRequests += 1;
+          return infoRequests === 1 ? pendingInfo.promise : Promise.reject(new Error("new runtime unavailable"));
+        }
+        throw new Error(`Unexpected GET ${path}`);
+      }),
+    };
+    useConnection.setState({ api: api as never, runtimeSlot: "primary" });
+    render(<SystemSection />);
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith("/api/system/info"));
+
+    await act(async () => {
+      advanceRuntimeGeneration();
+      useConnection.setState({ runtimeSlot: "review" });
+      pendingInfo.resolve({ updateChannel: "canary", release: { version: "v2026.08.20", channel: "canary" } });
+      await Promise.resolve();
+    });
+
+    expect((screen.getByLabelText("Release channel") as HTMLSelectElement).value).toBe("stable");
+  });
+
   it("does not show an old runtime's failed update on the new runtime", async () => {
     const pendingUpdate = deferred<unknown>();
     const api = { ...makeApi(), post: vi.fn(() => pendingUpdate.promise) };

--- a/tests/desktop/system-section.test.tsx
+++ b/tests/desktop/system-section.test.tsx
@@ -6,6 +6,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import SystemSection from "../../desktop/src/renderer/src/features/settings/sections/SystemSection";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => { resolve = next; });
+  return { promise, resolve };
+}
+
 function makeApi() {
   return {
     baseUrl: "https://app.matrix-os.com",
@@ -67,5 +73,49 @@ describe("desktop system updates", () => {
 
     await waitFor(() => expect(api.post).toHaveBeenCalledWith("/api/system/update", { version: "v2026.08.28" }, expect.anything()));
     expect(screen.getByRole("status", { name: /Installing v2026\.08\.28/i })).not.toBeNull();
+  });
+
+  it("does not treat an unchanged channel subscription as an installed channel update", async () => {
+    const api = makeApi();
+    useConnection.setState({ api: api as never });
+    render(<SystemSection />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Upgrade" })).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
+
+    await waitFor(() => expect((api.get as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([path]) => path === "/api/system/info").length).toBeGreaterThanOrEqual(2));
+    expect(screen.getByRole("status", { name: /Installing stable/i })).not.toBeNull();
+    expect(screen.queryByText("Update installed successfully.")).toBeNull();
+  });
+
+  it("keeps the newest channel's releases when an earlier request finishes last", async () => {
+    const stableUpdate = deferred<unknown>();
+    const stableReleases = deferred<unknown>();
+    const api = {
+      ...makeApi(),
+      get: vi.fn((path: string) => {
+        if (path === "/api/system/info") return Promise.resolve({ release: { version: "v2026.08.20", channel: "stable" } });
+        if (path === "/api/system/update?channel=stable") return stableUpdate.promise;
+        if (path === "/api/system/releases?channel=stable") return stableReleases.promise;
+        if (path === "/api/system/update?channel=canary") return Promise.resolve({ latest: { version: "v2026.08.29-canary", channel: "canary" }, updateAvailable: true });
+        if (path === "/api/system/releases?channel=canary") return Promise.resolve({ releases: [{ version: "v2026.08.29-canary", channel: "canary" }] });
+        throw new Error(`Unexpected GET ${path}`);
+      }),
+    };
+    useConnection.setState({ api: api as never });
+    render(<SystemSection />);
+
+    await waitFor(() => expect((api.get as ReturnType<typeof vi.fn>).mock.calls
+      .some(([path]) => path === "/api/system/releases?channel=stable")).toBe(true));
+    fireEvent.change(screen.getByLabelText("Release channel"), { target: { value: "canary" } });
+    await waitFor(() => expect(screen.getAllByText("v2026.08.29-canary").length).toBeGreaterThan(0));
+
+    stableUpdate.resolve({ latest: { version: "v2026.08.28", channel: "stable" }, updateAvailable: true });
+    stableReleases.resolve({ releases: [{ version: "v2026.08.28", channel: "stable" }] });
+    await Promise.resolve();
+
+    expect(screen.getAllByText("v2026.08.29-canary").length).toBeGreaterThan(0);
+    expect(screen.queryByText("v2026.08.28")).toBeNull();
   });
 });

--- a/tests/desktop/system-section.test.tsx
+++ b/tests/desktop/system-section.test.tsx
@@ -76,6 +76,31 @@ describe("desktop system updates", () => {
     expect(screen.getByRole("status", { name: /Installing v2026\.08\.28/i })).not.toBeNull();
   });
 
+  it("continues update polling when mounted in StrictMode", async () => {
+    let installed = false;
+    const api = {
+      ...makeApi(),
+      get: vi.fn(async (path: string) => {
+        if (path === "/api/system/info") {
+          return installed
+            ? { release: { version: "v2026.08.28", channel: "stable" } }
+            : { release: { version: "v2026.08.20", channel: "stable" } };
+        }
+        if (path === "/api/system/update?channel=stable") return { latest: { version: "v2026.08.28", channel: "stable" }, updateAvailable: true };
+        if (path === "/api/system/releases?channel=stable") return { releases: [] };
+        throw new Error(`Unexpected GET ${path}`);
+      }),
+      post: vi.fn(async () => { installed = true; return { ok: true, version: "v2026.08.28" }; }),
+    };
+    useConnection.setState({ api: api as never });
+    render(<React.StrictMode><SystemSection /></React.StrictMode>);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Upgrade" })).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
+
+    await waitFor(() => expect(screen.getByText("Update installed successfully.")).not.toBeNull());
+  });
+
   it("does not treat an unchanged channel subscription as an installed channel update", async () => {
     const api = makeApi();
     useConnection.setState({ api: api as never });

--- a/tests/desktop/system-section.test.tsx
+++ b/tests/desktop/system-section.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import SystemSection from "../../desktop/src/renderer/src/features/settings/sections/SystemSection";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { advanceRuntimeGeneration } from "../../desktop/src/renderer/src/stores/runtime-generation";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -87,6 +88,65 @@ describe("desktop system updates", () => {
       .filter(([path]) => path === "/api/system/info").length).toBeGreaterThanOrEqual(2));
     expect(screen.getByRole("status", { name: /Installing stable/i })).not.toBeNull();
     expect(screen.queryByText("Update installed successfully.")).toBeNull();
+  });
+
+  it("accepts a changed installed release even when its artifact channel differs", async () => {
+    let installed = false;
+    const api = {
+      ...makeApi(),
+      get: vi.fn(async (path: string) => {
+        if (path === "/api/system/info") {
+          return installed
+            ? { release: { version: "v2026.08.28", channel: "dev" } }
+            : { release: { version: "v2026.08.20", channel: "stable" } };
+        }
+        if (path === "/api/system/update?channel=stable") return { latest: { version: "v2026.08.28", channel: "stable" }, updateAvailable: true };
+        if (path === "/api/system/releases?channel=stable") return { releases: [] };
+        throw new Error(`Unexpected GET ${path}`);
+      }),
+      post: vi.fn(async () => { installed = true; return { ok: true }; }),
+    };
+    useConnection.setState({ api: api as never });
+    render(<SystemSection />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Upgrade" })).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
+
+    await waitFor(() => expect(screen.getByText("Update installed successfully.")).not.toBeNull());
+    expect(screen.queryByRole("status", { name: /Installing stable/i })).toBeNull();
+  });
+
+  it("ignores an update poll after the active runtime changes", async () => {
+    const pendingPoll = deferred<unknown>();
+    let infoRequests = 0;
+    const api = {
+      ...makeApi(),
+      get: vi.fn((path: string) => {
+        if (path === "/api/system/info") {
+          infoRequests += 1;
+          return infoRequests === 1
+            ? Promise.resolve({ release: { version: "v2026.08.20", channel: "stable" } })
+            : pendingPoll.promise;
+        }
+        if (path === "/api/system/update?channel=stable") return Promise.resolve({ latest: { version: "v2026.08.28", channel: "stable" }, updateAvailable: true });
+        if (path === "/api/system/releases?channel=stable") return Promise.resolve({ releases: [] });
+        throw new Error(`Unexpected GET ${path}`);
+      }),
+    };
+    useConnection.setState({ api: api as never, runtimeSlot: "primary" });
+    render(<SystemSection />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Upgrade" })).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
+    await waitFor(() => expect(infoRequests).toBe(2));
+    await act(async () => {
+      advanceRuntimeGeneration();
+      useConnection.setState({ runtimeSlot: "review" });
+      pendingPoll.resolve({ release: { version: "v2026.08.28", channel: "stable" } });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.queryByText("Update installed successfully.")).toBeNull());
   });
 
   it("keeps the newest channel's releases when an earlier request finishes last", async () => {

--- a/tests/desktop/system-section.test.tsx
+++ b/tests/desktop/system-section.test.tsx
@@ -86,7 +86,7 @@ describe("desktop system updates", () => {
 
     await waitFor(() => expect((api.get as ReturnType<typeof vi.fn>).mock.calls
       .filter(([path]) => path === "/api/system/info").length).toBeGreaterThanOrEqual(2));
-    expect(screen.getByRole("status", { name: /Installing stable/i })).not.toBeNull();
+    expect(screen.getByRole("status", { name: /Installing v2026\.08\.28/i })).not.toBeNull();
     expect(screen.queryByText("Update installed successfully.")).toBeNull();
   });
 
@@ -114,6 +114,34 @@ describe("desktop system updates", () => {
 
     await waitFor(() => expect(screen.getByText("Update installed successfully.")).not.toBeNull());
     expect(screen.queryByRole("status", { name: /Installing stable/i })).toBeNull();
+  });
+
+  it("does not report a channel update as installed for an unrelated version", async () => {
+    let updateStarted = false;
+    const api = {
+      ...makeApi(),
+      get: vi.fn(async (path: string) => {
+        if (path === "/api/system/info") {
+          return updateStarted
+            ? { release: { version: "v2026.08.27", channel: "dev" } }
+            : { release: { version: "v2026.08.20", channel: "stable" } };
+        }
+        if (path === "/api/system/update?channel=stable") return { latest: { version: "v2026.08.28", channel: "stable" }, updateAvailable: true };
+        if (path === "/api/system/releases?channel=stable") return { releases: [] };
+        throw new Error(`Unexpected GET ${path}`);
+      }),
+      post: vi.fn(async () => { updateStarted = true; return { ok: true }; }),
+    };
+    useConnection.setState({ api: api as never });
+    render(<SystemSection />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Upgrade" })).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
+
+    await waitFor(() => expect((api.get as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([path]) => path === "/api/system/info").length).toBeGreaterThanOrEqual(2));
+    expect(screen.getByRole("status", { name: /Installing v2026\.08\.28/i })).not.toBeNull();
+    expect(screen.queryByText("Update installed successfully.")).toBeNull();
   });
 
   it("ignores an update poll after the active runtime changes", async () => {

--- a/tests/desktop/system-section.test.tsx
+++ b/tests/desktop/system-section.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import SystemSection from "../../desktop/src/renderer/src/features/settings/sections/SystemSection";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+
+function makeApi() {
+  return {
+    baseUrl: "https://app.matrix-os.com",
+    get: vi.fn(async (path: string) => {
+      if (path === "/api/system/info") {
+        return { version: "0.1.0", updateChannel: "stable", release: { version: "v2026.08.20", channel: "stable" } };
+      }
+      if (path === "/api/system/update?channel=stable") {
+        return { channel: "stable", latest: { version: "v2026.08.28", channel: "stable" }, updateAvailable: true };
+      }
+      if (path === "/api/system/releases?channel=stable") {
+        return {
+          channel: "stable",
+          generatedAt: "2026-08-28T00:00:00.000Z",
+          releases: [
+            { version: "v2026.08.28", channel: "stable", gitCommit: "0123456789abcdef", changelog: "Bug fixes" },
+            { version: "v2026.08.10", channel: "stable", gitCommit: "fedcba9876543210", changelog: "Earlier release" },
+          ],
+        };
+      }
+      throw new Error(`Unexpected GET ${path}`);
+    }),
+    post: vi.fn(async () => ({ ok: true, status: "started" })),
+    getText: vi.fn(),
+    getBlob: vi.fn(),
+    patch: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    putText: vi.fn(),
+  };
+}
+
+describe("desktop system updates", () => {
+  beforeEach(() => {
+    useConnection.setState({ api: makeApi() as never });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("loads release channels and available versions", async () => {
+    render(<SystemSection />);
+
+    await waitFor(() => expect(screen.getAllByText("v2026.08.28").length).toBeGreaterThan(0));
+    expect(screen.getByLabelText("Release channel")).not.toBeNull();
+    expect(screen.getByText("Build ID 0123456789ab")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Downgrade to v2026.08.10" })).not.toBeNull();
+  });
+
+  it("starts an upgrade for a selected release version", async () => {
+    const api = makeApi();
+    useConnection.setState({ api: api as never });
+    render(<SystemSection />);
+
+    await waitFor(() => expect(screen.getAllByText("v2026.08.28").length).toBeGreaterThan(0));
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade to v2026.08.28" }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith("/api/system/update", { version: "v2026.08.28" }, expect.anything()));
+    expect(screen.getByRole("status", { name: /Installing v2026\.08\.28/i })).not.toBeNull();
+  });
+});

--- a/tests/gateway/system-update.test.ts
+++ b/tests/gateway/system-update.test.ts
@@ -11,6 +11,7 @@ import {
   parseInternalUpgradeTarget,
   parseUpdateVersion,
   resolveInternalUpgradeStartTarget,
+  resolveInternalUpgradeInstallTarget,
   resolveSystemUpdateChannel,
   readSystemUpdateFailure,
   startSystemUpdate,
@@ -103,6 +104,23 @@ describe("system update checks", () => {
       ok: false,
       error: "Specify either version or channel",
     });
+  });
+
+  it("pins a channel update to the manifest version resolved at request time", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      version: "v2026.08.29",
+      channel: "stable",
+    })));
+
+    await expect(resolveInternalUpgradeInstallTarget({
+      target: { type: "channel", value: "stable" },
+      platformUrl: "https://platform.matrix-os.test",
+      fetchImpl,
+    })).resolves.toEqual({ type: "version", value: "v2026.08.29" });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://platform.matrix-os.test/system-bundles/channels/stable.json",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   it("writes requested versions before triggering an internal upgrade", async () => {


### PR DESCRIPTION
## Summary

- Add release-channel selection and release history to the OSView System settings pane.
- Support upgrading or downgrading to a specific VPS version, including build IDs.
- Show an installation loader and poll until the requested version or channel is installed.

## Tests

- `pnpm --filter desktop run typecheck`
- `pnpm exec vitest run tests/desktop/system-section.test.tsx tests/desktop/integrations-settings-section.test.tsx tests/desktop/settings-view.test.tsx` (24 passed)
- `bun run typecheck`, `bun run check:patterns`, and `bun run test` were unavailable because Bun is not installed on this host.