### PR TITLE
fix(desktop): repair main CI regressions

### DIFF
--- a/desktop/src/renderer/src/design/tokens.css
+++ b/desktop/src/renderer/src/design/tokens.css
@@ -20,6 +20,7 @@
   --surface-overlay: #242323;
   --surface-tertiary: #e1e0e0;
   --surface-success: #eef7f2;
+  --surface-card-foreground-subtle: #fafaf6;
 
   /* ── Desktop wallpaper mesh (kept in sync with the web shell) ─ */
   --gradient-deep: #323d2e;
@@ -57,6 +58,7 @@
   --text-disabled: #b5b1a3;
   --text-on-accent: #fafaf5;
   --text-inverse: #fafaf5;
+  --text-danger: #b42318;
 
   /* ── Brand & semantic ───────────────────────────────────────── */
   --accent: #434e3f;
@@ -157,6 +159,7 @@
   --surface-overlay: #242323;
   --surface-tertiary: #2a302c;
   --surface-success: #173827;
+  --surface-card-foreground-subtle: #242923;
 
   --forest: #1a1e1a;
   --forest-deep: #101210;
@@ -183,6 +186,7 @@
   --text-disabled: #55605a;
   --text-on-accent: #141614;
   --text-inverse: #fafaf5;
+  --text-danger: #f28b82;
 
   --accent: #8cc7be;
   --accent-hover: #9dd3cb;

--- a/tests/desktop/design-tokens.test.ts
+++ b/tests/desktop/design-tokens.test.ts
@@ -131,6 +131,17 @@ describe("Figma semantic surface tokens", () => {
       }
     }
   });
+
+  it("defines the integration icon surface and danger text tokens in both modes", () => {
+    expect(tokenValue(themeBlock(tokensCss, ":root"), "--surface-card-foreground-subtle")).toBe(
+      "#fafaf6",
+    );
+    expect(tokenValue(themeBlock(tokensCss, ":root"), "--text-danger")).toBe("#b42318");
+    expect(tokenValue(themeBlock(tokensCss, '[data-theme="dark"]'), "--surface-card-foreground-subtle")).toBe(
+      "#242923",
+    );
+    expect(tokenValue(themeBlock(tokensCss, '[data-theme="dark"]'), "--text-danger")).toBe("#f28b82");
+  });
 });
 
 describe("composer focus presentation", () => {

--- a/tests/desktop/settings-sections-error.test.tsx
+++ b/tests/desktop/settings-sections-error.test.tsx
@@ -82,7 +82,7 @@ describe("settings data sections", () => {
 
     await waitFor(() => {
       expect(screen.queryByText(unavailable)).toBeNull();
-      expect(screen.queryByText(visible)).not.toBeNull();
+      expect(screen.getAllByText(visible).length).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- Add explicit light-mode defaults and sensible dark-mode values for the
  integration card surface and danger text design tokens.
- Update the system-section retry regression test to handle the current
  version being rendered in both the OS and update rows.

## Tests

- `pnpm exec vitest run tests/desktop/design-tokens.test.ts tests/desktop/settings-sections-error.test.tsx`
- `pnpm --filter desktop run typecheck`
- `./scripts/review/check-patterns.sh` — 0 violations; existing warnings only
- `pnpm exec vitest run` — stopped after unrelated baseline failures in
  platform, sync-client, and host-script suites

## Review/Monitoring

- Manual worktree: `/private/tmp/matrix-os-fix-ci`
- Branch: `codex/fix-main-ci`
- Broad CI should be monitored after review approval.

## Invariants

- No backend, persistence, auth, or external-call behavior changed.
- Light-mode fallback colors are preserved as explicit tokens.
- Dark-mode tokens remain scoped to the desktop renderer theme.
