### PR TITLE
fix(desktop): route terminal launches through terminal app

### DIFF
--- a/desktop/src/renderer/src/features/coding-agents/AgentThreadLists.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentThreadLists.tsx
@@ -13,6 +13,7 @@ export function ThreadList({
   onOpenThread?: (thread: AgentThreadSummary) => void;
 }) {
   const openTab = useTabs((s) => s.openTab);
+  const requestTerminalSession = useTabs((s) => s.requestTerminalSession);
   const activeThreadId = useCodingAgentWorkspace((s) => s.activeThreadId);
   const loadThreadSnapshot = useCodingAgentWorkspace((s) => s.loadThreadSnapshot);
   const findAttachableSessionName = (sessionId: string): string | null =>
@@ -56,7 +57,11 @@ export function ThreadList({
                     variant="ghost"
                     aria-label={`Open terminal for ${thread.title}`}
                     title={`Open terminal for ${thread.title}`}
-                    onClick={() => openTab({ kind: "terminal", sessionName: thread.terminalSessionId, title: terminalSessionName })}
+                    onClick={() => {
+                      if (!thread.terminalSessionId) return;
+                      openTab({ kind: "terminals", title: "Terminal" });
+                      requestTerminalSession(terminalSessionName);
+                    }}
                   >
                     <SquareTerminal size={14} />
                   </Button>

--- a/desktop/src/renderer/src/features/coding-agents/provider-setup-terminal.ts
+++ b/desktop/src/renderer/src/features/coding-agents/provider-setup-terminal.ts
@@ -5,7 +5,7 @@ import type {
   SafeSetupAction,
 } from "@matrix-os/contracts";
 import type { ApiClient } from "../../lib/api";
-import type { useTabs } from "../../stores/tabs";
+import { useTabs } from "../../stores/tabs";
 import { providerSupportsSetupAction } from "./provider-readiness";
 
 const MAX_PROVIDER_SETUP_ACTIONS = 10;
@@ -99,7 +99,8 @@ export async function openProviderSetupTerminal(
     const sessionName = typeof response.name === "string" && SESSION_NAME_PATTERN.test(response.name)
       ? response.name
       : requestedSessionName;
-    openTab({ kind: "terminal", sessionName, title: setup.label });
+    openTab({ kind: "terminals", title: "Terminal" });
+    useTabs.getState().requestTerminalSession(sessionName);
     return true;
   } catch (err: unknown) {
     console.error(`[${logPrefix}] Failed to open provider setup terminal:`, err instanceof Error ? err.name : typeof err);

--- a/desktop/src/renderer/src/features/coding-agents/provider-setup-terminal.ts
+++ b/desktop/src/renderer/src/features/coding-agents/provider-setup-terminal.ts
@@ -7,6 +7,7 @@ import type {
 import type { ApiClient } from "../../lib/api";
 import { useTabs } from "../../stores/tabs";
 import { useShellSessions } from "../../stores/shell-sessions";
+import { captureRuntimeGeneration, isCurrentRuntimeGeneration } from "../../stores/runtime-generation";
 import { providerSupportsSetupAction } from "./provider-readiness";
 
 const MAX_PROVIDER_SETUP_ACTIONS = 10;
@@ -91,12 +92,14 @@ export async function openProviderSetupTerminal(
   logPrefix = "provider-setup",
 ): Promise<boolean> {
   try {
+    const runtimeGeneration = captureRuntimeGeneration();
     const requestedSessionName = freshSetupSessionName(setup);
     const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", {
       name: requestedSessionName,
       cwd: "projects",
       cmd: setup.command,
     });
+    if (!isCurrentRuntimeGeneration(runtimeGeneration)) return true;
     const sessionName = typeof response.name === "string" && SESSION_NAME_PATTERN.test(response.name)
       ? response.name
       : requestedSessionName;

--- a/desktop/src/renderer/src/features/coding-agents/provider-setup-terminal.ts
+++ b/desktop/src/renderer/src/features/coding-agents/provider-setup-terminal.ts
@@ -6,6 +6,7 @@ import type {
 } from "@matrix-os/contracts";
 import type { ApiClient } from "../../lib/api";
 import { useTabs } from "../../stores/tabs";
+import { useShellSessions } from "../../stores/shell-sessions";
 import { providerSupportsSetupAction } from "./provider-readiness";
 
 const MAX_PROVIDER_SETUP_ACTIONS = 10;
@@ -99,6 +100,7 @@ export async function openProviderSetupTerminal(
     const sessionName = typeof response.name === "string" && SESSION_NAME_PATTERN.test(response.name)
       ? response.name
       : requestedSessionName;
+    useShellSessions.getState().adoptCreatedSession(sessionName);
     openTab({ kind: "terminals", title: "Terminal" });
     useTabs.getState().requestTerminalSession(sessionName);
     return true;

--- a/desktop/src/renderer/src/features/coding-agents/provider-setup-terminal.ts
+++ b/desktop/src/renderer/src/features/coding-agents/provider-setup-terminal.ts
@@ -91,8 +91,8 @@ export async function openProviderSetupTerminal(
   openTab: ReturnType<typeof useTabs.getState>["openTab"],
   logPrefix = "provider-setup",
 ): Promise<boolean> {
+  const runtimeGeneration = captureRuntimeGeneration();
   try {
-    const runtimeGeneration = captureRuntimeGeneration();
     const requestedSessionName = freshSetupSessionName(setup);
     const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", {
       name: requestedSessionName,
@@ -108,6 +108,7 @@ export async function openProviderSetupTerminal(
     useTabs.getState().requestTerminalSession(sessionName);
     return true;
   } catch (err: unknown) {
+    if (!isCurrentRuntimeGeneration(runtimeGeneration)) return true;
     console.error(`[${logPrefix}] Failed to open provider setup terminal:`, err instanceof Error ? err.name : typeof err);
     return false;
   }

--- a/desktop/src/renderer/src/features/plugins/McpServersSection.tsx
+++ b/desktop/src/renderer/src/features/plugins/McpServersSection.tsx
@@ -2,43 +2,14 @@
 // gateway route lists MCP servers today (the kernel wires mcpServers
 // internally per agent run in packages/kernel/src/options.ts), so there is
 // nothing real to render. The section says where MCP servers live and hands
-// off to the canonical terminal session for managing them.
+// off to the canonical Terminal app for managing them.
 import { Server } from "@renderer/lib/hugeicons";
-import { useState } from "react";
-import { categoryMessage } from "../../../../shared/app-error";
 import { Button } from "../../design/primitives";
-import { useConnection } from "../../stores/connection";
 import { useTabs } from "../../stores/tabs";
 import { openPluginsTerminal } from "./open-plugins-terminal";
 
-const MCP_TERMINAL_SESSION = "plugins-mcp";
-
 export function McpServersSection() {
-  const api = useConnection((s) => s.api);
   const openTab = useTabs((s) => s.openTab);
-  const [busy, setBusy] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
-  const handleOpenTerminal = async (): Promise<void> => {
-    if (busy) return;
-    if (!api) {
-      setErrorMessage(categoryMessage("misconfigured"));
-      return;
-    }
-    setBusy(true);
-    setErrorMessage(null);
-    try {
-      const opened = await openPluginsTerminal(api, openTab, {
-        sessionName: MCP_TERMINAL_SESSION,
-        title: "MCP servers",
-      });
-      // "runtime-changed" is not a failure: the session was created on the
-      // computer the user just left, so there is nothing to apologise for.
-      if (opened === "failed") setErrorMessage(categoryMessage("server"));
-    } finally {
-      setBusy(false);
-    }
-  };
 
   return (
     <>
@@ -64,13 +35,10 @@ export function McpServersSection() {
           edit MCP servers in your agent configuration.
         </p>
         <div className="mt-2">
-          <Button variant="primary" disabled={busy} onClick={() => void handleOpenTerminal()}>
-            {busy ? "Opening…" : "Open terminal"}
+          <Button variant="primary" onClick={() => openPluginsTerminal(openTab)}>
+            Open terminal
           </Button>
         </div>
-        {errorMessage ? (
-          <p className="text-xs" style={{ color: "var(--danger)" }}>{errorMessage}</p>
-        ) : null}
       </div>
     </>
   );

--- a/desktop/src/renderer/src/features/plugins/SkillsSection.tsx
+++ b/desktop/src/renderer/src/features/plugins/SkillsSection.tsx
@@ -1,7 +1,7 @@
 // Skills section of the Plugins hub. REAL data path: GET /api/settings/skills
 // (see plugins-store.ts) — the list below is the actual installed skill pack
 // on the connected computer, rendered read-only. The empty state is honest:
-// no skills installed, with the canonical terminal path to manage them.
+// no skills installed, with the canonical Terminal app path to manage them.
 import { Search, Sparkles, X } from "@renderer/lib/hugeicons";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { categoryMessage } from "../../../../shared/app-error";
@@ -11,8 +11,6 @@ import { useConnection } from "../../stores/connection";
 import { useTabs } from "../../stores/tabs";
 import { openPluginsTerminal } from "./open-plugins-terminal";
 import { usePlugins } from "./plugins-store";
-
-const SKILLS_TERMINAL_SESSION = "plugins-skills";
 
 function SkillsLoadingSkeleton() {
   return (
@@ -30,8 +28,6 @@ export function SkillsSection() {
   const skills = usePlugins((s) => s.skills);
   const status = usePlugins((s) => s.skillsStatus);
   const errorMessage = usePlugins((s) => s.skillsError);
-  const [terminalBusy, setTerminalBusy] = useState(false);
-  const [terminalError, setTerminalError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
 
   const normalizedQuery = query.trim().toLocaleLowerCase();
@@ -52,26 +48,6 @@ export function SkillsSection() {
     void usePlugins.getState().refreshSkills(api);
   };
 
-  const handleOpenTerminal = async (): Promise<void> => {
-    if (terminalBusy) return;
-    if (!api) {
-      setTerminalError(categoryMessage("misconfigured"));
-      return;
-    }
-    setTerminalBusy(true);
-    setTerminalError(null);
-    try {
-      const opened = await openPluginsTerminal(api, openTab, {
-        sessionName: SKILLS_TERMINAL_SESSION,
-        title: "Skills",
-      });
-      // "runtime-changed" is not a failure: the session was created on the
-      // computer the user just left, so there is nothing to apologise for.
-      if (opened === "failed") setTerminalError(categoryMessage("server"));
-    } finally {
-      setTerminalBusy(false);
-    }
-  };
 
   let body: ReactNode;
   if (status === "idle" || status === "loading") {
@@ -119,13 +95,10 @@ export function SkillsSection() {
           Ask Hermes to create one, or manage them in a terminal.
         </p>
         <div className="mt-2">
-          <Button variant="primary" disabled={terminalBusy} onClick={() => void handleOpenTerminal()}>
-            {terminalBusy ? "Opening…" : "Open terminal"}
+          <Button variant="primary" onClick={() => openPluginsTerminal(openTab)}>
+            Open terminal
           </Button>
         </div>
-        {terminalError ? (
-          <p className="text-xs" style={{ color: "var(--danger)" }}>{terminalError}</p>
-        ) : null}
       </div>
     );
   } else if (filteredSkills.length === 0) {

--- a/desktop/src/renderer/src/features/plugins/index.ts
+++ b/desktop/src/renderer/src/features/plugins/index.ts
@@ -7,5 +7,5 @@ export { SkillsSection } from "./SkillsSection";
 export { McpServersSection } from "./McpServersSection";
 export { CliSection, CLI_BREW_INSTALL_COMMAND, CLI_NPM_INSTALL_COMMAND } from "./CliSection";
 export { usePlugins, pluginsStore, type SkillsStatus } from "./plugins-store";
-export { openPluginsTerminal, PLUGINS_TERMINAL_CWD } from "./open-plugins-terminal";
+export { openPluginsTerminal } from "./open-plugins-terminal";
 export { MAX_SKILLS, parseSkills, type SkillInfo } from "./types";

--- a/desktop/src/renderer/src/features/plugins/open-plugins-terminal.ts
+++ b/desktop/src/renderer/src/features/plugins/open-plugins-terminal.ts
@@ -1,54 +1,11 @@
-// Opens a canonical terminal session for Plugins hub management tasks (MCP
-// server config, skill files). Same flow as provider setup terminals
-// (features/coding-agents/provider-setup-terminal.ts): create the session
-// through the gateway, then focus it as a terminal tab. Session names are
-// deterministic per topic, so a second click re-attaches to the same session
-// (the gateway registry adopts existing sessions).
-import type { ApiClient } from "../../lib/api";
-import { useConnection } from "../../stores/connection";
+// Opens the shared Terminal app for Plugins hub management tasks (MCP server
+// config, skill files). Plugins must not create a hidden or topic-specific
+// terminal session; the Terminal app owns session creation and attachment.
 import type { useTabs } from "../../stores/tabs";
 
-const SESSION_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]{0,29}[a-z0-9])?$/;
-
-export const PLUGINS_TERMINAL_CWD = "projects";
-
 export async function openPluginsTerminal(
-  api: ApiClient,
   openTab: ReturnType<typeof useTabs.getState>["openTab"],
-  options: { sessionName: string; title: string },
-): Promise<"opened" | "failed" | "runtime-changed"> {
-  // The request URL is resolved against the runtime selected right now.
-  const { runtimeSlot, authGeneration } = useConnection.getState();
-  try {
-    const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", {
-      name: options.sessionName,
-      cwd: PLUGINS_TERMINAL_CWD,
-    });
-    // Switching computers mid-request clears the tab strip and repoints the
-    // terminal transport. The session created above lives on the previous
-    // computer, so opening a tab for it would attach to the wrong runtime.
-    const current = useConnection.getState();
-    if (current.runtimeSlot !== runtimeSlot || current.authGeneration !== authGeneration) {
-      // The POST succeeded, so a real session now exists on the previous
-      // computer. Reporting this as a failure would show "something went wrong
-      // on the server" for an operation that worked.
-      console.warn(
-        "[plugins] abandoned a terminal session created on the previous computer:",
-        options.sessionName,
-      );
-      return "runtime-changed";
-    }
-    const sessionName =
-      typeof response.name === "string" && SESSION_NAME_PATTERN.test(response.name)
-        ? response.name
-        : options.sessionName;
-    openTab({ kind: "terminal", sessionName, title: options.title });
-    return "opened";
-  } catch (err: unknown) {
-    console.error(
-      "[plugins] Failed to open terminal session:",
-      err instanceof Error ? err.name : "Unknown error",
-    );
-    return "failed";
-  }
+): Promise<"opened"> {
+  openTab({ kind: "terminals", title: "Terminal" });
+  return "opened";
 }

--- a/desktop/src/renderer/src/stores/shell-sessions.ts
+++ b/desktop/src/renderer/src/stores/shell-sessions.ts
@@ -43,6 +43,7 @@ interface ShellSessionsState {
   authoritativeRevision: number;
   load(api: ApiClient): Promise<ShellSessionSummary[] | null>;
   create(api: ApiClient): Promise<ShellSessionSummary | null>;
+  adoptCreatedSession(name: string): void;
   deleteSession(api: ApiClient, name: string): Promise<boolean>;
   rename(api: ApiClient, name: string, nextName: string): Promise<boolean>;
   reorder(api: ApiClient, fromName: string, toName: string): Promise<boolean>;
@@ -268,7 +269,10 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
     for (let attempt = 0; attempt < SHELL_SESSION_CREATE_ATTEMPTS; attempt += 1) {
       const name = nextShellName();
       try {
-        const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", { name, cwd: DEFAULT_CWD });
+        const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", {
+          name,
+          cwd: DEFAULT_CWD,
+        });
         if (!isCurrentRuntimeGeneration(generation)) return null;
         const createdName = typeof response.name === "string" && isValidShellSessionName(response.name) ? response.name : name;
         let created: ShellSessionSummary = {
@@ -319,6 +323,23 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
     }
     set({ creating: false, error: "server" });
     return null;
+  },
+
+  adoptCreatedSession: (name) => {
+    if (!isValidShellSessionName(name)) return;
+    set((state) => (
+      state.sessions.some((session) => session.name === name)
+        ? state
+        : {
+            sessions: [{
+              name,
+              status: "active",
+              placement: "active",
+              attachCommand: shellConnectCommand(name),
+            }, ...state.sessions],
+            authoritativeRevision: state.authoritativeRevision + 1,
+          }
+    ));
   },
 
   deleteSession: async (api, name) => {

--- a/desktop/src/renderer/src/stores/shell-sessions.ts
+++ b/desktop/src/renderer/src/stores/shell-sessions.ts
@@ -337,6 +337,10 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
               placement: "active",
               attachCommand: shellConnectCommand(name),
             }, ...state.sessions],
+            // A session-list fetch that started before this confirmed create
+            // can return a stale snapshot without the new session. Advance
+            // the sequence so it cannot overwrite this optimistic entry.
+            loadSequence: state.loadSequence + 1,
             authoritativeRevision: state.authoritativeRevision + 1,
           }
     ));

--- a/tests/desktop/command-palette.test.tsx
+++ b/tests/desktop/command-palette.test.tsx
@@ -555,10 +555,10 @@ describe("CommandPalette", () => {
       });
     });
     expect(openTab).toHaveBeenCalledWith({
-      kind: "terminal",
-      sessionName: "matrix-setup-codex-a1b2c3",
-      title: "Install Codex",
+      kind: "terminals",
+      title: "Terminal",
     });
+    expect(useTabs.getState().terminalSessionRequest?.sessionName).toBe("matrix-setup-codex-a1b2c3");
   });
 
   it("uses distinct setup session names for similar provider setup actions", async () => {

--- a/tests/desktop/plugins-mcp.test.tsx
+++ b/tests/desktop/plugins-mcp.test.tsx
@@ -4,8 +4,7 @@
 // route lists MCP servers today (kernel wires mcpServers internally in
 // packages/kernel/src/options.ts), so the section is an HONEST empty state:
 // it explains that MCP servers are configured on the Matrix computer and
-// offers the canonical terminal path (POST /api/terminal/sessions + terminal
-// tab, the same flow as provider setup terminals).
+// offers the canonical Terminal app path (the shared terminal overview tab).
 import React from "react";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -62,46 +61,38 @@ describe("desktop plugins MCP servers section", () => {
     expect(screen.getByRole("button", { name: /Open terminal/i })).not.toBeNull();
   });
 
-  it("opens a terminal session so the user can manage MCP servers", async () => {
+  it("opens the new Terminal app without creating a separate session", async () => {
     const api = makeApi();
     useConnection.setState({ api: api as never });
     render(<McpServersSection />);
 
     fireEvent.click(screen.getByRole("button", { name: /Open terminal/i }));
 
-    await waitFor(() =>
-      expect(api.post).toHaveBeenCalledWith("/api/terminal/sessions", {
-        name: "plugins-mcp",
-        cwd: "projects",
-      }),
-    );
+    await waitFor(() => expect(useTabs.getState().tabs).toHaveLength(1));
+    expect(api.post).not.toHaveBeenCalled();
     const tabs = useTabs.getState().tabs;
-    expect(tabs.some((tab) => tab.kind === "terminal" && tab.sessionName === "plugins-mcp")).toBe(true);
+    expect(tabs.some((tab) => tab.kind === "terminals" && tab.title === "Terminal")).toBe(true);
   });
 
-  it("shows generic copy and does not open a tab when the session cannot be created", async () => {
+  it("opens the Terminal app even when no API session can be created", async () => {
     const api = makeApi({ postError: new AppError("server") });
     useConnection.setState({ api: api as never });
     render(<McpServersSection />);
 
     fireEvent.click(screen.getByRole("button", { name: /Open terminal/i }));
 
-    await waitFor(() =>
-      expect(screen.getByText("Something went wrong. Please try again.")).not.toBeNull(),
-    );
-    expect(useTabs.getState().tabs).toHaveLength(0);
+    await waitFor(() => expect(useTabs.getState().tabs).toHaveLength(1));
+    expect(api.post).not.toHaveBeenCalled();
+    expect(useTabs.getState().tabs[0]).toMatchObject({ kind: "terminals", title: "Terminal" });
   });
 
-  it("shows the misconfigured copy when no computer is connected", async () => {
+  it("opens the Terminal app when no computer is connected", async () => {
     useConnection.setState({ api: null as never });
     render(<McpServersSection />);
 
     fireEvent.click(screen.getByRole("button", { name: /Open terminal/i }));
 
-    await waitFor(() =>
-      expect(
-        screen.getByText("No computer is connected. Select a runtime to continue."),
-      ).not.toBeNull(),
-    );
+    await waitFor(() => expect(useTabs.getState().tabs).toHaveLength(1));
+    expect(useTabs.getState().tabs[0]).toMatchObject({ kind: "terminals", title: "Terminal" });
   });
 });

--- a/tests/desktop/plugins-runtime-switch.test.ts
+++ b/tests/desktop/plugins-runtime-switch.test.ts
@@ -12,11 +12,11 @@ import {
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 import type { ApiClient } from "../../desktop/src/renderer/src/lib/api";
 
-function makeApi(get: (path: string) => Promise<unknown>, post?: (path: string, body?: unknown) => Promise<unknown>) {
+function makeApi(get: (path: string) => Promise<unknown>) {
   return {
     baseUrl: "https://gateway.test",
     get: vi.fn(get),
-    post: vi.fn(post ?? (async () => ({ name: "plugins-mcp" }))),
+    post: vi.fn(),
     delete: vi.fn(),
     patch: vi.fn(),
     put: vi.fn(),
@@ -54,21 +54,13 @@ describe("plugins hub across runtime switches", () => {
     expect(usePlugins.getState().skills.map((skill) => skill.name)).toEqual(["current-skill"]);
   });
 
-  it("does not open a terminal tab for a session created on the previous computer", async () => {
-    let releaseSession!: (value: { name: string }) => void;
-    const api = makeApi(
-      async () => [],
-      () => new Promise<{ name: string }>((resolve) => { releaseSession = resolve; }),
-    );
+  it("opens the Terminal app without creating a session on a runtime", async () => {
+    const api = makeApi(async () => []);
     const openTab = vi.fn();
 
-    const opening = openPluginsTerminal(api, openTab, { sessionName: "plugins-mcp", title: "MCP servers" });
-    // The user switches computers while the session POST is in flight.
-    useConnection.setState({ runtimeSlot: "secondary", authGeneration: 2 });
-    releaseSession({ name: "plugins-mcp" });
-
-    await expect(opening).resolves.toBe("runtime-changed");
-    expect(openTab).not.toHaveBeenCalled();
+    await expect(openPluginsTerminal(openTab)).resolves.toBe("opened");
+    expect(api.post).not.toHaveBeenCalled();
+    expect(openTab).toHaveBeenCalledWith({ kind: "terminals", title: "Terminal" });
   });
 
   it("drops an in-flight skills response and cached owner data on sign-out", async () => {
@@ -95,12 +87,11 @@ describe("plugins hub across runtime switches", () => {
   });
 
   it("still opens the tab when the runtime is unchanged", async () => {
-    const api = makeApi(async () => [], async () => ({ name: "plugins-mcp" }));
     const openTab = vi.fn();
 
     await expect(
-      openPluginsTerminal(api, openTab, { sessionName: "plugins-mcp", title: "MCP servers" }),
+      openPluginsTerminal(openTab),
     ).resolves.toBe("opened");
-    expect(openTab).toHaveBeenCalledWith({ kind: "terminal", sessionName: "plugins-mcp", title: "MCP servers" });
+    expect(openTab).toHaveBeenCalledWith({ kind: "terminals", title: "Terminal" });
   });
 });

--- a/tests/desktop/plugins-skills.test.tsx
+++ b/tests/desktop/plugins-skills.test.tsx
@@ -235,32 +235,22 @@ describe("desktop plugins skills section", () => {
     await waitFor(() => expect(screen.getByText("No skills installed yet.")).not.toBeNull());
 
     fireEvent.click(screen.getByRole("button", { name: /Open terminal/i }));
-    await waitFor(() =>
-      expect(api.post).toHaveBeenCalledWith("/api/terminal/sessions", {
-        name: "plugins-skills",
-        cwd: "projects",
-      }),
-    );
+    await waitFor(() => expect(useTabs.getState().tabs).toHaveLength(1));
+    expect(api.post).not.toHaveBeenCalled();
     const tabs = useTabs.getState().tabs;
-    expect(tabs.some((tab) => tab.kind === "terminal" && tab.sessionName === "plugins-skills")).toBe(true);
+    expect(tabs.some((tab) => tab.kind === "terminals" && tab.title === "Terminal")).toBe(true);
   });
 
-  it("shows generic copy when the terminal cannot be opened", async () => {
-    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  it("opens the Terminal app without requiring a session request", async () => {
     const api = makeApi({ skills: [] });
-    api.post = vi.fn(async () => {
-      throw new Error("secret-token-leak");
-    });
     useConnection.setState({ api: api as never });
     render(<SkillsSection />);
 
     await waitFor(() => expect(screen.getByText("No skills installed yet.")).not.toBeNull());
     fireEvent.click(screen.getByRole("button", { name: /Open terminal/i }));
 
-    await waitFor(() =>
-      expect(screen.getByText("Something went wrong. Please try again.")).not.toBeNull(),
-    );
-    expect(useTabs.getState().tabs).toHaveLength(0);
-    expect(error.mock.calls.flat().join(" ")).not.toContain("secret-token-leak");
+    await waitFor(() => expect(useTabs.getState().tabs).toHaveLength(1));
+    expect(api.post).not.toHaveBeenCalled();
+    expect(useTabs.getState().tabs[0]).toMatchObject({ kind: "terminals", title: "Terminal" });
   });
 });

--- a/tests/desktop/provider-readiness-notice.test.tsx
+++ b/tests/desktop/provider-readiness-notice.test.tsx
@@ -164,8 +164,9 @@ describe("ProviderReadinessNotice", () => {
       expect.objectContaining({ cmd: installAction.command, cwd: "projects" }),
     ));
     expect(useTabs.getState().tabs).toEqual([
-      expect.objectContaining({ kind: "terminal", title: "Install Codex" }),
+      expect.objectContaining({ kind: "terminals", title: "Terminal" }),
     ]);
+    expect(useTabs.getState().terminalSessionRequest?.sessionName).toBe("matrix-setup-codex");
   });
 
   it("refuses a renderer-supplied Claude action when the Gateway omits setup actions", async () => {

--- a/tests/desktop/provider-setup-routing.test.tsx
+++ b/tests/desktop/provider-setup-routing.test.tsx
@@ -108,6 +108,7 @@ describe("system harness setup routing", () => {
       cwd: "projects",
       cmd: "sh -lc 'opencode'",
     })));
-    expect(useTabs.getState().tabs.some((tab) => tab.kind === "terminal")).toBe(true);
+    expect(useTabs.getState().tabs.some((tab) => tab.kind === "terminals")).toBe(true);
+    expect(useTabs.getState().terminalSessionRequest?.sessionName).toBe("matrix-setup-opencode");
   });
 });

--- a/tests/desktop/provider-setup-routing.test.tsx
+++ b/tests/desktop/provider-setup-routing.test.tsx
@@ -12,6 +12,7 @@ import type { ApiClient } from "../../desktop/src/renderer/src/lib/api";
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 import { useUi } from "../../desktop/src/renderer/src/stores/ui";
 import { useShellSessions } from "../../desktop/src/renderer/src/stores/shell-sessions";
+import { advanceRuntimeGeneration } from "../../desktop/src/renderer/src/stores/runtime-generation";
 
 function instance(driverKind: CanonicalProviderDriverKind): CanonicalProviderInstanceDescriptor {
   return {
@@ -113,5 +114,23 @@ describe("system harness setup routing", () => {
     expect(useTabs.getState().tabs.some((tab) => tab.kind === "terminals")).toBe(true);
     expect(useTabs.getState().terminalSessionRequest?.sessionName).toBe("matrix-setup-opencode");
     expect(useShellSessions.getState().sessions.map((session) => session.name)).toEqual(["matrix-setup-opencode"]);
+  });
+
+  it("does not adopt a setup session after switching runtimes", async () => {
+    let resolvePost: ((value: { name: string }) => void) | undefined;
+    const post = vi.fn(() => new Promise<{ name: string }>((resolve) => {
+      resolvePost = resolve;
+    }));
+    render(<TerminalHarness api={{ post } as unknown as ApiClient} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+    await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
+
+    advanceRuntimeGeneration();
+    resolvePost?.({ name: "matrix-setup-opencode" });
+
+    await waitFor(() => expect(useTabs.getState().tabs.some((tab) => tab.kind === "terminals")).toBe(false));
+    expect(useTabs.getState().terminalSessionRequest).toBeNull();
+    expect(useShellSessions.getState().sessions).toEqual([]);
   });
 });

--- a/tests/desktop/provider-setup-routing.test.tsx
+++ b/tests/desktop/provider-setup-routing.test.tsx
@@ -8,6 +8,7 @@ import type {
   CanonicalProviderInstanceDescriptor,
 } from "@matrix-os/contracts";
 import { useProviderSetup } from "../../desktop/src/renderer/src/features/chat/use-provider-setup";
+import { openProviderSetupTerminal } from "../../desktop/src/renderer/src/features/coding-agents/provider-setup-terminal";
 import type { ApiClient } from "../../desktop/src/renderer/src/lib/api";
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 import { useUi } from "../../desktop/src/renderer/src/stores/ui";
@@ -132,5 +133,31 @@ describe("system harness setup routing", () => {
     await waitFor(() => expect(useTabs.getState().tabs.some((tab) => tab.kind === "terminals")).toBe(false));
     expect(useTabs.getState().terminalSessionRequest).toBeNull();
     expect(useShellSessions.getState().sessions).toEqual([]);
+  });
+
+  it("ignores a setup-session rejection after switching runtimes", async () => {
+    let rejectPost: ((reason: Error) => void) | undefined;
+    const post = vi.fn(() => new Promise<{ name: string }>((_resolve, reject) => {
+      rejectPost = reject;
+    }));
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const opened = openProviderSetupTerminal(
+      { post } as unknown as ApiClient,
+      {
+        key: "opencode:connect",
+        label: "Connect OpenCode",
+        command: "sh -lc 'opencode'",
+        sessionName: "matrix-setup-opencode",
+      },
+      useTabs.getState().openTab,
+    );
+    await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
+
+    advanceRuntimeGeneration();
+    rejectPost?.(new Error("offline"));
+
+    await expect(opened).resolves.toBe(true);
+    expect(error).not.toHaveBeenCalled();
   });
 });

--- a/tests/desktop/provider-setup-routing.test.tsx
+++ b/tests/desktop/provider-setup-routing.test.tsx
@@ -11,6 +11,7 @@ import { useProviderSetup } from "../../desktop/src/renderer/src/features/chat/u
 import type { ApiClient } from "../../desktop/src/renderer/src/lib/api";
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 import { useUi } from "../../desktop/src/renderer/src/stores/ui";
+import { useShellSessions } from "../../desktop/src/renderer/src/stores/shell-sessions";
 
 function instance(driverKind: CanonicalProviderDriverKind): CanonicalProviderInstanceDescriptor {
   return {
@@ -81,6 +82,7 @@ function TerminalHarness({ api }: { api: ApiClient }) {
 describe("system harness setup routing", () => {
   beforeEach(() => {
     useTabs.setState(useTabs.getInitialState(), true);
+    useShellSessions.setState(useShellSessions.getInitialState(), true);
     useUi.setState({ requestedSettingsSection: null });
   });
 
@@ -110,5 +112,6 @@ describe("system harness setup routing", () => {
     })));
     expect(useTabs.getState().tabs.some((tab) => tab.kind === "terminals")).toBe(true);
     expect(useTabs.getState().terminalSessionRequest?.sessionName).toBe("matrix-setup-opencode");
+    expect(useShellSessions.getState().sessions.map((session) => session.name)).toEqual(["matrix-setup-opencode"]);
   });
 });

--- a/tests/desktop/shell-sessions-store.test.ts
+++ b/tests/desktop/shell-sessions-store.test.ts
@@ -185,6 +185,19 @@ describe("useShellSessions", () => {
     expect(useShellSessions.getState().sessions.map((session) => session.name)).toEqual(["matrix-current"]);
   });
 
+  it("keeps an adopted provider session when an older load settles afterwards", async () => {
+    const staleResponse = deferred<{ sessions: Array<{ name: string }> }>();
+    const pending = useShellSessions.getState().load(makeApi({
+      get: vi.fn().mockReturnValue(staleResponse.promise),
+    }));
+
+    useShellSessions.getState().adoptCreatedSession("matrix-setup-codex");
+    staleResponse.resolve({ sessions: [] });
+
+    expect(await pending).toBeNull();
+    expect(useShellSessions.getState().sessions.map((session) => session.name)).toEqual(["matrix-setup-codex"]);
+  });
+
   it("creates shell sessions with two-word names, projects cwd, and retries one 409 conflict", async () => {
     const post = vi
       .fn()


### PR DESCRIPTION
## Summary
- Route Plugins MCP and Skills actions, provider setup flows, Command Palette,
  and agent-thread actions through the native Desktop Terminal app.
- Preserve and select created provider setup sessions, including against
  concurrent session-list refreshes.
- Ignore late provider setup resolutions and failures after a computer/runtime
  switch so an old runtime cannot open a terminal or display an error in the
  newly selected runtime.

## Tests
- `pnpm exec vitest run tests/desktop/provider-setup-routing.test.tsx tests/desktop/shell-sessions-store.test.ts tests/desktop/provider-readiness-notice.test.tsx tests/desktop/command-palette.test.tsx tests/desktop/plugins-hub.test.tsx tests/desktop/plugins-skills.test.tsx tests/desktop/plugins-mcp.test.tsx tests/desktop/plugins-runtime-switch.test.ts` (77 passed)
- `pnpm --filter desktop run typecheck`
- `pnpm run check:patterns:diff` (previous validated push)

## Notes
- Recent Views is a legacy sidebar path and is not used by the native Desktop
  OS view.
- Native Desktop terminals use the shared `kind: "terminals"` tab surface;
  the web/Canvas `__terminal__` built-in route is not a Desktop tab route.
- No backend or persistence changes.
