### PR TITLE
fix(desktop): stabilize Chat workspace navigation

### DIFF
--- a/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
@@ -223,10 +223,12 @@ export function CanonicalChatWorkspace({
 
   useEffect(() => {
     const record = controller.detail?.record;
-    if (!record || reportedChatId.current === record.chat.id) return;
+    // A parent-owned draft route can arrive one effect before the previous
+    // detail is cleared. Only explicit draft actions may promote a Chat.
+    if (initialView === "draft" || !record || reportedChatId.current === record.chat.id) return;
     reportedChatId.current = record.chat.id;
     onActiveChatChanged?.(record.chat.id, record.chat.title);
-  }, [controller.detail?.record, onActiveChatChanged]);
+  }, [controller.detail?.record, initialView, onActiveChatChanged]);
 
   const context = projectContext(
     controller.detail?.record.projectId ?? draftProjectId ?? projectId ?? undefined,

--- a/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
@@ -180,6 +180,7 @@ export function CanonicalChatWorkspace({
       && previous.projectId === projectId
     ) return;
     previousRoute.current = { initialChatId, initialView, projectId };
+    if (initialView === "draft") reportedChatId.current = initialChatId ?? null;
     if (projectId !== null) return;
     setGlobalView(initialView ?? (initialChatId ? "conversation" : "index"));
   }, [initialChatId, initialView, projectId]);

--- a/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
@@ -180,7 +180,6 @@ export function CanonicalChatWorkspace({
       && previous.projectId === projectId
     ) return;
     previousRoute.current = { initialChatId, initialView, projectId };
-    reportedChatId.current = initialChatId ?? null;
     if (projectId !== null) return;
     setGlobalView(initialView ?? (initialChatId ? "conversation" : "index"));
   }, [initialChatId, initialView, projectId]);

--- a/desktop/src/renderer/src/features/panels/InspectorFilesPanel.tsx
+++ b/desktop/src/renderer/src/features/panels/InspectorFilesPanel.tsx
@@ -84,20 +84,21 @@ function ExpandableFileTree({
 }) {
   const [expandedPaths, setExpandedPaths] = useState<string[]>([]);
   const [directories, setDirectories] = useState<Record<string, InspectorTreeDirectory>>({});
-  const mounted = useRef(true);
+  const lifecycleGeneration = useRef(0);
 
-  useEffect(() => () => { mounted.current = false; }, []);
+  useEffect(() => () => { lifecycleGeneration.current += 1; }, []);
 
   const ensureDirectory = useCallback((path: string) => {
+    const generation = lifecycleGeneration.current;
     setDirectories((current) => {
       if (current[path] || Object.keys(current).length >= MAX_EXPANDED_FILE_DIRECTORIES) return current;
       return { ...current, [path]: { status: "loading", entries: [] } };
     });
     void loadDirectory(path).then((entries) => {
-      if (!mounted.current) return;
+      if (generation !== lifecycleGeneration.current) return;
       setDirectories((current) => ({ ...current, [path]: { status: "ready", entries } }));
     }).catch(() => {
-      if (!mounted.current) return;
+      if (generation !== lifecycleGeneration.current) return;
       setDirectories((current) => ({ ...current, [path]: { status: "error", entries: [] } }));
     });
   }, [loadDirectory]);

--- a/tests/desktop/canonical-chat-workspace.test.tsx
+++ b/tests/desktop/canonical-chat-workspace.test.tsx
@@ -644,6 +644,58 @@ describe("CanonicalChatWorkspace", () => {
     expect(routeClient.getDetail).toHaveBeenCalledTimes(1);
   });
 
+  it("does not report stale detail after switching between Chats in the same Project", async () => {
+    const firstChatId = snapshot.chat.id;
+    const secondChatId = "chat_same_project_second";
+    const secondRecord = {
+      ...record,
+      chat: { ...record.chat, id: secondChatId, title: "Second project chat" },
+    };
+    const routeClient = client();
+    vi.mocked(routeClient.list).mockResolvedValue({ items: [record, secondRecord] });
+    vi.mocked(routeClient.getDetail).mockImplementation(async (chatId) => ({
+      record: chatId === secondChatId ? secondRecord : record,
+      messages: snapshot.messages,
+      turns: snapshot.turns,
+      runs: snapshot.runs,
+      activities: snapshot.activities,
+    }));
+    const reportedIds: string[] = [];
+
+    function Harness() {
+      const [activeChatId, setActiveChatId] = useState(firstChatId);
+      return (
+        <>
+          <button type="button" onClick={() => setActiveChatId(secondChatId)}>Switch project chat</button>
+          <CanonicalChatWorkspace
+            client={routeClient}
+            projectId="matrix-os"
+            projectLabel="Matrix OS"
+            initialChatId={activeChatId}
+            active
+            externalNavigation
+            catalog={providerCatalog}
+            onActiveChatChanged={(chatId) => {
+              if (!chatId) return;
+              reportedIds.push(chatId);
+              setActiveChatId(chatId);
+            }}
+          />
+        </>
+      );
+    }
+
+    render(<Harness />);
+
+    expect(await screen.findByRole("textbox", { name: "Reply to chat" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Switch project chat" }));
+
+    await waitFor(() => expect(routeClient.getDetail).toHaveBeenCalledWith(secondChatId, { limit: 200 }));
+    await waitFor(() => expect(reportedIds).toContain(secondChatId));
+    expect(reportedIds).not.toContain(firstChatId);
+    expect(vi.mocked(routeClient.getDetail).mock.calls.at(-1)?.[0]).toBe(secondChatId);
+  });
+
   it("does not let stale Global Chat detail overwrite a requested New Chat draft", async () => {
     const routeClient = client();
     const reportedIds: Array<string | null> = [];

--- a/tests/desktop/canonical-chat-workspace.test.tsx
+++ b/tests/desktop/canonical-chat-workspace.test.tsx
@@ -739,6 +739,54 @@ describe("CanonicalChatWorkspace", () => {
     expect(reportedIds).toEqual([null]);
   });
 
+  it.each([
+    ["starting another Chat in the same Project", false],
+    ["deleting the last Chat in the Project", true],
+  ] as const)("keeps New Chat visible after %s", async (_scenario, emptyProject) => {
+    const routeClient = client();
+    const reportedIds: Array<string | null> = [];
+
+    function Harness() {
+      const [route, setRoute] = useState<{
+        chatId?: string;
+        view: "draft" | "conversation";
+      }>({ chatId: snapshot.chat.id, view: "conversation" });
+      return (
+        <>
+          <button type="button" onClick={() => {
+            if (emptyProject) vi.mocked(routeClient.list).mockResolvedValue({ items: [] });
+            setRoute({ view: "draft" });
+          }}>Open project draft</button>
+          <CanonicalChatWorkspace
+            client={routeClient}
+            projectId="matrix-os"
+            projectLabel="Matrix OS"
+            initialChatId={route.chatId}
+            initialView={route.view}
+            active
+            externalNavigation
+            catalog={providerCatalog}
+            onActiveChatChanged={(chatId) => {
+              reportedIds.push(chatId);
+              if (chatId) setRoute({ chatId, view: "conversation" });
+            }}
+          />
+        </>
+      );
+    }
+
+    render(<Harness />);
+
+    expect(await screen.findByRole("textbox", { name: "Reply to chat" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Open project draft" }));
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 20));
+    });
+
+    expect(screen.getByRole("button", { name: "Explore and understand code" })).toBeTruthy();
+    expect(reportedIds).toEqual([]);
+  });
+
   it("does not submit uploaded attachments after the selected runtime changes", async () => {
     let resolveUpload!: (value: { ok: true; path: string; size: number }) => void;
     const api = {

--- a/tests/desktop/canonical-chat-workspace.test.tsx
+++ b/tests/desktop/canonical-chat-workspace.test.tsx
@@ -174,7 +174,7 @@ describe("CanonicalChatWorkspace", () => {
     });
     expect(screen.getByRole("button", { name: "Explore and understand code" })).toBeTruthy();
     expect(screen.getByRole("textbox", { name: "Start a chat" })).toBeTruthy();
-    expect(onActiveChatChanged).not.toHaveBeenCalledWith(snapshot.chat.id, expect.anything());
+    expect(onActiveChatChanged).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/tests/desktop/canonical-chat-workspace.test.tsx
+++ b/tests/desktop/canonical-chat-workspace.test.tsx
@@ -169,6 +169,9 @@ describe("CanonicalChatWorkspace", () => {
     );
 
     await waitFor(() => expect(routeClient.getDetail).toHaveBeenCalledWith(snapshot.chat.id, { limit: 200 }));
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 20));
+    });
     expect(screen.getByRole("button", { name: "Explore and understand code" })).toBeTruthy();
     expect(screen.getByRole("textbox", { name: "Start a chat" })).toBeTruthy();
     expect(onActiveChatChanged).not.toHaveBeenCalledWith(snapshot.chat.id, expect.anything());

--- a/tests/desktop/inspector-files-panel.test.tsx
+++ b/tests/desktop/inspector-files-panel.test.tsx
@@ -179,6 +179,32 @@ describe("InspectorFilesPanel", () => {
     }));
   });
 
+  it("finishes loading the Project file tree under React StrictMode", async () => {
+    vi.spyOn(window.operator, "invoke").mockResolvedValue({
+      directory: { kind: "directory" },
+      entries: {
+        items: [{ path: "README.md", kind: "file", sizeBytes: 8 }],
+        hasMore: false,
+        limit: 100,
+      },
+    });
+
+    render(
+      <React.StrictMode>
+        <Tooltip.Provider>
+          <InspectorFilesPanel
+            scope={{ kind: "project", chatId: "chat_project", projectId: "matrix-os", label: "Matrix OS" }}
+            browserOnly
+            forceList
+          />
+        </Tooltip.Provider>
+      </React.StrictMode>,
+    );
+
+    expect(await screen.findByRole("button", { name: "Open file README.md" })).toBeTruthy();
+    expect(screen.queryByText("Loading files…")).toBeNull();
+  });
+
   it("expands Project folders inline without replacing the root listing", async () => {
     const onOpenFile = vi.fn();
     const invoke = vi.spyOn(window.operator, "invoke").mockImplementation(async (channel, request) => {


### PR DESCRIPTION
## Summary

- keep Project Files results alive across the React StrictMode preflight lifecycle
- prevent stale same-Project Chat detail from overwriting explicit Chat selections
- preserve externally owned draft routes for pre-created, same-Project compose, and last-Chat deletion flows
- add regression coverage for all four reported navigation and loading races

## Root cause

- the expandable file tree used a one-way mounted flag; StrictMode cleanup permanently disabled state updates, so successful IPC results were discarded and the panel stayed on `Loading files…`
- external route synchronization marked a requested conversation Chat as already reported before its detail loaded; retained detail from the previous Chat then reverted the selection
- pre-created draft Chats need their external Chat ID registered so loaded detail cannot replace the starter UI
- same-Project compose and last-Chat deletion route the retained tab to a Project draft without a Chat ID; the previous detail survived for one effect cycle and was reported back to the parent, reopening the old or deleted Chat

## Tests

- focused canonical workspace regression suite: 27 passed
- related Desktop Chat, Work, and Files suites: 87 passed
- Desktop typecheck and production build
- changed-lines React Doctor: no issues
- pattern scan: 0 violations; 5 existing warnings
- full CI: 18 successful, 0 failing, 0 pending
- CI Unit Tests: all four shards passed
- CI E2E Tests, Shell Production Build, Type Check, Sync Client Package, Docs Contract, Pattern Scan, and React Doctor passed

## Runtime verification

- launched a production-built Desktop from exact head `2059053b24cf4ace0a4ac42e3d374cb3fe59d16c` with an isolated profile
- used the latest authenticated VPS bundle without backend changes
- confirmed the `matrix-os-site` Project Files tree loaded 28 root entries
- confirmed same-Project Chat navigation remained stable across first → second selection, with the second Chat remaining active
- confirmed same-Project compose opened the Project starter directly without detouring through Global New Chat
- confirmed no Chat loading state or load error while switching
- did not create or delete user Chat data during runtime verification; last-Chat deletion is covered by its focused regression test

## Review / Monitoring

- Greptile exact-head review: 5/5 and approved for `2059053b24cf4ace0a4ac42e3d374cb3fe59d16c`
- CI: all required checks passed

## Invariants

- source of truth: canonical Chat and Gateway contracts are unchanged; the renderer reports only loaded conversation detail and preserves parent-owned draft routes
- lock/transaction scope: none; this is renderer-only
- acceptable orphan states: none introduced
- auth source: existing Desktop credential and Gateway IPC path are unchanged
- deferred scope: no Gateway, VPS bundle, terminal backend, or visual redesign changes

Linear: https://linear.app/matrix-os/issue/OM-179/fix-chat-files-loading-and-same-project-chat-switching-regressions
