### PR TITLE
fix(chat): stream Hermes responses before completion

### DIFF
--- a/packages/gateway/src/chat/hermes-provider-adapter.ts
+++ b/packages/gateway/src/chat/hermes-provider-adapter.ts
@@ -1,6 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
 import { z } from "zod/v4";
 import { buildAgentRuntimeEnvironment } from "../agent-launcher.js";
 import {
@@ -10,18 +8,42 @@ import {
   type CanonicalProviderRunEvent,
   type CanonicalProviderRunInput,
 } from "./provider-adapter.js";
+import { createCanonicalCliEventQueue } from "./cli-process.js";
 import {
-  createCanonicalCliEventQueue,
-  runCanonicalCli,
-  type CanonicalCliSpawn,
-} from "./cli-process.js";
+  createHermesStdioClient,
+  type HermesGatewayEvent,
+  type HermesGatewaySpawn,
+} from "./hermes-stdio-client.js";
 
-const HermesChatStateSchema = z.object({
-  sessionId: z.string().min(1).max(512).regex(/^[A-Za-z0-9][A-Za-z0-9_-]{0,511}$/),
-}).strict();
-const HermesUsageSchema = z.object({
-  session_id: HermesChatStateSchema.shape.sessionId,
+const SafeSessionIdSchema = z.string().min(1).max(512).regex(/^[A-Za-z0-9][A-Za-z0-9_-]{0,511}$/);
+const HermesChatStateSchema = z.object({ sessionId: SafeSessionIdSchema }).strict();
+const HermesSessionSchema = z.object({
+  session_id: SafeSessionIdSchema,
+  stored_session_id: SafeSessionIdSchema.optional(),
+  session_key: SafeSessionIdSchema.optional(),
 }).passthrough();
+const HermesDeltaSchema = z.object({ text: z.string().max(96 * 1024) }).passthrough();
+const HermesInterimSchema = z.object({
+  text: z.string().min(1).max(96 * 1024),
+  already_streamed: z.boolean().default(false),
+}).passthrough();
+const HermesCompletionSchema = z.object({
+  text: z.string().max(96 * 1024),
+  status: z.enum(["complete", "completed", "interrupted", "error"]).default("complete"),
+  response_previewed: z.boolean().default(false),
+}).passthrough();
+const HermesPromptResponseSchema = z.object({ status: z.literal("streaming") }).passthrough();
+const HermesModelConfigResponseSchema = z.object({ confirm_required: z.boolean().optional() }).passthrough();
+const HermesYoloResponseSchema = z.object({
+  key: z.literal("yolo"),
+  value: z.literal("1"),
+  scope: z.literal("session"),
+}).passthrough();
+const HermesCwdResponseSchema = z.object({ cwd: z.string().min(1).max(4_096) }).passthrough();
+type HermesCompletion = z.infer<typeof HermesCompletionSchema>;
+type HermesCompletionResult =
+  | { ok: true; value: HermesCompletion }
+  | { ok: false; error: Error };
 
 export type HermesChatState = z.infer<typeof HermesChatStateSchema>;
 const DEFAULT_TIMEOUT_MS = 30 * 60_000;
@@ -37,19 +59,6 @@ function selection(value: string): { provider: string; model: string } {
   return { provider, model };
 }
 
-async function createUsageFile() {
-  const directory = await mkdtemp(join(tmpdir(), "matrix-hermes-run-"));
-  return { directory, path: join(directory, "usage.json") };
-}
-
-async function readUsageFile(path: string): Promise<unknown> {
-  return JSON.parse(await readFile(path, "utf8"));
-}
-
-async function cleanupUsageFile(directory: string): Promise<void> {
-  await rm(directory, { recursive: true, force: true });
-}
-
 function outputChunks(text: string): string[] {
   const chunks: string[] = [];
   for (let index = 0; index < text.length; index += 4_000) {
@@ -59,13 +68,29 @@ function outputChunks(text: string): string[] {
   return chunks;
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolveValue) => {
+    resolve = resolveValue;
+  });
+  return { promise, resolve };
+}
+
+function emitDelta(
+  queue: ReturnType<typeof createCanonicalCliEventQueue<CanonicalProviderRunEvent>>,
+  text: string,
+): void {
+  for (const delta of outputChunks(text)) {
+    queue.push(CanonicalProviderRunEventSchema.parse({ type: "assistant.delta", delta }));
+  }
+}
+
 export function createHermesChatProviderAdapter(options: {
   homePath: string;
-  spawnFn?: CanonicalCliSpawn;
+  spawnFn?: HermesGatewaySpawn;
   timeoutMs?: number;
-  createUsageFile?: () => Promise<{ directory: string; path: string }>;
-  readUsageFile?: (path: string) => Promise<unknown>;
-  cleanupUsageFile?: (directory: string) => Promise<void>;
+  readyTimeoutMs?: number;
+  requestTimeoutMs?: number;
 }): CanonicalChatProviderAdapter<HermesChatState> {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
@@ -74,59 +99,178 @@ export function createHermesChatProviderAdapter(options: {
     resumeState?: HermesChatState,
   ): AsyncGenerator<CanonicalProviderRunEvent> {
     const input = parseCanonicalProviderRunInput(inputValue);
-    if (input.permissionMode !== "full_access") {
-      throw new Error("Unsupported Hermes permission mode");
-    }
-    if (input.interactionMode !== "default") {
-      throw new Error("Unsupported Hermes interaction mode");
-    }
+    if (input.permissionMode !== "full_access") throw new Error("Unsupported Hermes permission mode");
+    if (input.interactionMode !== "default") throw new Error("Unsupported Hermes interaction mode");
     const selected = selection(input.selection.model);
-    const usage = await (options.createUsageFile ?? createUsageFile)();
-    const cleanup = options.cleanupUsageFile ?? cleanupUsageFile;
     const queue = createCanonicalCliEventQueue<CanonicalProviderRunEvent>();
-    let output = "";
-    const args = [
-      "-z", input.prompt,
-      "--provider", selected.provider,
-      "--model", selected.model,
-      "--usage-file", usage.path,
-      "--yolo",
-      ...(resumeState ? ["--resume", resumeState.sessionId] : []),
-    ];
+    const completion = deferred<HermesCompletionResult>();
+    let liveSessionId: string | undefined;
+    let durableSessionId: string | undefined;
+    let currentSegment = "";
+    let lastSealedSegment = "";
+    let emittedOutputBytes = 0;
+    let separatorPending = false;
+    let completionSettled = false;
+
+    const emitVisibleText = (text: string) => {
+      if (!text) return;
+      const separator = separatorPending && emittedOutputBytes > 0 ? "\n\n" : "";
+      const addedBytes = Buffer.byteLength(separator + text, "utf8");
+      if (emittedOutputBytes + addedBytes > MAX_OUTPUT_BYTES) {
+        throw new Error("Hermes output exceeded limit");
+      }
+      emitDelta(queue, separator);
+      emitDelta(queue, text);
+      emittedOutputBytes += addedBytes;
+      separatorPending = false;
+    };
+
+    const handleEvent = (event: HermesGatewayEvent) => {
+      if (completionSettled || !liveSessionId || event.session_id !== liveSessionId) return;
+      if (event.type === "message.delta") {
+        const { text } = HermesDeltaSchema.parse(event.payload);
+        if (!text) return;
+        emitVisibleText(text);
+        currentSegment += text;
+      } else if (event.type === "message.interim") {
+        const interim = HermesInterimSchema.parse(event.payload);
+        if (interim.already_streamed) {
+          if (interim.text !== currentSegment) {
+            throw new Error("Hermes interim response did not match streamed output");
+          }
+        } else {
+          if (currentSegment) separatorPending = true;
+          emitVisibleText(interim.text);
+        }
+        lastSealedSegment = interim.text;
+        currentSegment = "";
+        separatorPending = emittedOutputBytes > 0;
+      } else if (event.type === "message.complete") {
+        const parsed = HermesCompletionSchema.parse(event.payload);
+        completionSettled = true;
+        completion.resolve({ ok: true, value: parsed });
+      } else if (event.type === "error") {
+        completionSettled = true;
+        completion.resolve({ ok: false, error: new Error("Hermes Run failed") });
+      }
+    };
+
+    const hermesRoot = join(options.homePath, ".hermes", "hermes-agent");
+    const existingPythonPath = process.env.PYTHONPATH?.trim();
+    const client = createHermesStdioClient({
+      command: join(hermesRoot, "venv", "bin", "python"),
+      args: ["-u", "-m", "tui_gateway.entry"],
+      cwd: input.executionRoot ?? options.homePath,
+      env: {
+        ...buildAgentRuntimeEnvironment(options.homePath),
+        HERMES_PYTHON_SRC_ROOT: hermesRoot,
+        PYTHONPATH: existingPythonPath ? `${hermesRoot}${delimiter}${existingPythonPath}` : hermesRoot,
+        PYTHONUNBUFFERED: "1",
+      },
+      spawnFn: options.spawnFn,
+      readyTimeoutMs: options.readyTimeoutMs,
+      requestTimeoutMs: options.requestTimeoutMs,
+      onEvent: handleEvent,
+      onFailure(error) {
+        if (!completionSettled) {
+          completionSettled = true;
+          completion.resolve({ ok: false, error });
+        }
+      },
+    });
 
     void (async () => {
+      let totalTimer: NodeJS.Timeout | undefined;
+      let abortRun: (() => void) | undefined;
       try {
-        await runCanonicalCli({
-          command: "hermes",
-          args,
-          cwd: input.executionRoot ?? options.homePath,
-          env: buildAgentRuntimeEnvironment(options.homePath),
-          signal: input.signal,
-          timeoutMs,
-          maxStdoutBytes: MAX_OUTPUT_BYTES,
-          spawnFn: options.spawnFn,
-          onStdout(chunk) {
-            output += chunk.toString("utf8");
-          },
+        const stopped = new Promise<never>((_resolve, reject) => {
+          abortRun = () => reject(new Error("Hermes Run aborted"));
+          if (input.signal.aborted) return abortRun();
+          input.signal.addEventListener("abort", abortRun, { once: true });
+          totalTimer = setTimeout(() => reject(new Error("Hermes Run timed out")), timeoutMs);
+          totalTimer.unref?.();
         });
-        for (const delta of outputChunks(output)) {
-          queue.push(CanonicalProviderRunEventSchema.parse({ type: "assistant.delta", delta }));
-        }
-        try {
-          const usageReport = HermesUsageSchema.parse(
-            await (options.readUsageFile ?? readUsageFile)(usage.path),
-          );
-          if (usageReport.session_id !== resumeState?.sessionId) {
-            queue.push(CanonicalProviderRunEventSchema.parse({
-              type: "state.updated",
-              state: { sessionId: usageReport.session_id },
+        const withinRun = <T>(operation: Promise<T>) => Promise.race([operation, stopped]);
+        await withinRun(client.ready());
+        const rawSession = resumeState
+          ? await withinRun(client.request("session.resume", {
+              session_id: resumeState.sessionId,
+              cols: 120,
+              source: "matrix-os-desktop",
+              cwd: input.executionRoot ?? options.homePath,
+              omit_messages: true,
+            }))
+          : await withinRun(client.request("session.create", {
+              cols: 120,
+              source: "matrix-os-desktop",
+              cwd: input.executionRoot ?? options.homePath,
+              provider: selected.provider,
+              model: selected.model,
             }));
+        const session = HermesSessionSchema.parse(rawSession);
+        liveSessionId = session.session_id;
+        durableSessionId = session.stored_session_id ?? session.session_key ?? resumeState?.sessionId;
+        if (!durableSessionId) throw new Error("Hermes did not return a durable session");
+        if (resumeState) {
+          const modelConfig = HermesModelConfigResponseSchema.parse(await withinRun(client.request("config.set", {
+            session_id: liveSessionId,
+            key: "model",
+            value: `${selected.model} --provider ${selected.provider} --session`,
+            confirm_expensive_model: true,
+          })));
+          if (modelConfig.confirm_required) throw new Error("Hermes model selection requires confirmation");
+        }
+        const expectedCwd = input.executionRoot ?? options.homePath;
+        const cwdResponse = HermesCwdResponseSchema.parse(await withinRun(client.request("session.cwd.set", {
+          session_id: liveSessionId,
+          cwd: expectedCwd,
+        })));
+        if (cwdResponse.cwd !== expectedCwd) throw new Error("Hermes execution root did not match");
+        HermesYoloResponseSchema.parse(await withinRun(client.request("config.set", {
+          session_id: liveSessionId,
+          key: "yolo",
+          value: "1",
+          scope: "session",
+        })));
+        HermesPromptResponseSchema.parse(await withinRun(client.request("prompt.submit", {
+          session_id: liveSessionId,
+          text: input.prompt,
+          surface: "desktop",
+        })));
+        const completionResult = await withinRun(completion.promise);
+        if (!completionResult.ok) throw completionResult.error;
+        const final = completionResult.value;
+        if (final.status === "error") throw new Error("Hermes Run failed");
+        if (final.status === "interrupted" && !input.signal.aborted) {
+          throw new Error("Hermes Run was interrupted");
+        }
+        if (Buffer.byteLength(final.text, "utf8") > MAX_OUTPUT_BYTES) {
+          throw new Error("Hermes output exceeded limit");
+        }
+        const previewAlreadySealed = final.response_previewed
+          && !currentSegment
+          && final.text === lastSealedSegment;
+        if (!previewAlreadySealed) {
+          if (!final.text.startsWith(currentSegment)) {
+            throw new Error("Hermes final response did not match streamed output");
           }
-        } catch (error: unknown) {
-          console.warn("[chat/hermes] Usage report unavailable:", error instanceof Error ? error.name : "UnknownError");
+          emitVisibleText(final.text.slice(currentSegment.length));
+        }
+        if (durableSessionId && durableSessionId !== resumeState?.sessionId) {
+          queue.push(CanonicalProviderRunEventSchema.parse({
+            type: "state.updated",
+            state: { sessionId: durableSessionId },
+          }));
         }
         queue.push(CanonicalProviderRunEventSchema.parse({ type: "run.completed", outcome: "completed" }));
       } catch (error: unknown) {
+        if (input.signal.aborted && liveSessionId) {
+          try {
+            await client.request("session.interrupt", { session_id: liveSessionId }, 1_000);
+          } catch (interruptError: unknown) {
+            console.warn("[chat/hermes] Interrupt acknowledgement unavailable:", interruptError instanceof Error ? interruptError.name : "UnknownError");
+          }
+        }
         console.warn("[chat/hermes] Provider Run failed:", error instanceof Error ? error.name : "UnknownError");
         queue.push(CanonicalProviderRunEventSchema.parse({
           type: "run.completed",
@@ -134,18 +278,16 @@ export function createHermesChatProviderAdapter(options: {
           ...(input.signal.aborted ? {} : {
             error: {
               code: "run_failed",
-              safeMessage: "Hermes could not complete this Run. Check its provider connection and retry.",
+              safeMessage: "The selected provider could not complete this Run. Check its connection and retry.",
               retryable: true,
               recoveryActions: ["retry"],
             },
           }),
         }));
       } finally {
-        try {
-          await cleanup(usage.directory);
-        } catch (error: unknown) {
-          console.warn("[chat/hermes] Temporary usage cleanup failed:", error instanceof Error ? error.name : "UnknownError");
-        }
+        if (totalTimer) clearTimeout(totalTimer);
+        if (abortRun) input.signal.removeEventListener("abort", abortRun);
+        await client.close();
         queue.finish();
       }
     })();

--- a/packages/gateway/src/chat/hermes-provider-adapter.ts
+++ b/packages/gateway/src/chat/hermes-provider-adapter.ts
@@ -48,6 +48,10 @@ type HermesCompletionResult =
 export type HermesChatState = z.infer<typeof HermesChatStateSchema>;
 const DEFAULT_TIMEOUT_MS = 30 * 60_000;
 const MAX_OUTPUT_BYTES = 96 * 1024;
+const DELTA_FLUSH_BYTES = 256;
+const DELTA_FLUSH_INTERVAL_MS = 50;
+// Reserve room in the 500-event canonical queue for a bounded final flush and terminal events.
+const MAX_LIVE_DELTA_EVENTS = 350;
 
 function selection(value: string): { provider: string; model: string } {
   const separator = value.indexOf(":");
@@ -76,15 +80,6 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
-function emitDelta(
-  queue: ReturnType<typeof createCanonicalCliEventQueue<CanonicalProviderRunEvent>>,
-  text: string,
-): void {
-  for (const delta of outputChunks(text)) {
-    queue.push(CanonicalProviderRunEventSchema.parse({ type: "assistant.delta", delta }));
-  }
-}
-
 export function createHermesChatProviderAdapter(options: {
   homePath: string;
   spawnFn?: HermesGatewaySpawn;
@@ -109,8 +104,34 @@ export function createHermesChatProviderAdapter(options: {
     let currentSegment = "";
     let lastSealedSegment = "";
     let emittedOutputBytes = 0;
+    let emittedDeltaEvents = 0;
+    let pendingVisibleText = "";
+    let deltaFlushTimer: NodeJS.Timeout | undefined;
     let separatorPending = false;
     let completionSettled = false;
+
+    const flushVisibleText = (force = false) => {
+      if (!pendingVisibleText || (!force && emittedDeltaEvents >= MAX_LIVE_DELTA_EVENTS)) return;
+      if (deltaFlushTimer) {
+        clearTimeout(deltaFlushTimer);
+        deltaFlushTimer = undefined;
+      }
+      const text = pendingVisibleText;
+      pendingVisibleText = "";
+      for (const delta of outputChunks(text)) {
+        queue.push(CanonicalProviderRunEventSchema.parse({ type: "assistant.delta", delta }));
+        emittedDeltaEvents += 1;
+      }
+    };
+
+    const scheduleVisibleTextFlush = () => {
+      if (deltaFlushTimer || emittedDeltaEvents >= MAX_LIVE_DELTA_EVENTS) return;
+      deltaFlushTimer = setTimeout(() => {
+        deltaFlushTimer = undefined;
+        flushVisibleText();
+      }, DELTA_FLUSH_INTERVAL_MS);
+      deltaFlushTimer.unref?.();
+    };
 
     const emitVisibleText = (text: string) => {
       if (!text) return;
@@ -119,10 +140,17 @@ export function createHermesChatProviderAdapter(options: {
       if (emittedOutputBytes + addedBytes > MAX_OUTPUT_BYTES) {
         throw new Error("Hermes output exceeded limit");
       }
-      emitDelta(queue, separator);
-      emitDelta(queue, text);
+      pendingVisibleText += separator + text;
       emittedOutputBytes += addedBytes;
       separatorPending = false;
+      if (emittedDeltaEvents === 0) {
+        flushVisibleText();
+      } else if (emittedDeltaEvents < MAX_LIVE_DELTA_EVENTS
+        && Buffer.byteLength(pendingVisibleText, "utf8") >= DELTA_FLUSH_BYTES) {
+        flushVisibleText();
+      } else if (emittedDeltaEvents < MAX_LIVE_DELTA_EVENTS) {
+        scheduleVisibleTextFlush();
+      }
     };
 
     const handleEvent = (event: HermesGatewayEvent) => {
@@ -256,6 +284,7 @@ export function createHermesChatProviderAdapter(options: {
           }
           emitVisibleText(final.text.slice(currentSegment.length));
         }
+        flushVisibleText(true);
         if (durableSessionId && durableSessionId !== resumeState?.sessionId) {
           queue.push(CanonicalProviderRunEventSchema.parse({
             type: "state.updated",
@@ -264,6 +293,7 @@ export function createHermesChatProviderAdapter(options: {
         }
         queue.push(CanonicalProviderRunEventSchema.parse({ type: "run.completed", outcome: "completed" }));
       } catch (error: unknown) {
+        flushVisibleText(true);
         if (input.signal.aborted && liveSessionId) {
           try {
             await client.request("session.interrupt", { session_id: liveSessionId }, 1_000);
@@ -285,6 +315,7 @@ export function createHermesChatProviderAdapter(options: {
           }),
         }));
       } finally {
+        if (deltaFlushTimer) clearTimeout(deltaFlushTimer);
         if (totalTimer) clearTimeout(totalTimer);
         if (abortRun) input.signal.removeEventListener("abort", abortRun);
         await client.close();

--- a/packages/gateway/src/chat/hermes-stdio-client.ts
+++ b/packages/gateway/src/chat/hermes-stdio-client.ts
@@ -1,0 +1,266 @@
+import { spawn } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
+import { z } from "zod/v4";
+
+const JsonRpcIdSchema = z.union([z.string().max(128), z.number().int().safe()]);
+const JsonRpcResponseSchema = z.object({
+  jsonrpc: z.literal("2.0"),
+  id: JsonRpcIdSchema,
+  result: z.unknown().optional(),
+  error: z.object({
+    code: z.number().int(),
+    message: z.string(),
+    data: z.unknown().optional(),
+  }).strict().optional(),
+}).strict().refine((value) => (value.result !== undefined) !== (value.error !== undefined));
+const HermesGatewayEventSchema = z.object({
+  jsonrpc: z.literal("2.0"),
+  method: z.literal("event"),
+  params: z.object({
+    type: z.string().min(1).max(128),
+    session_id: z.string().min(1).max(512).optional(),
+    payload: z.unknown().optional(),
+  }).passthrough(),
+}).strict();
+
+export type HermesGatewayEvent = z.infer<typeof HermesGatewayEventSchema>["params"];
+
+interface HermesGatewayWritable {
+  write(chunk: string): boolean;
+  end(): void;
+}
+
+interface HermesGatewayReadable {
+  on(event: "data", listener: (chunk: Buffer) => void): void;
+}
+
+export interface HermesGatewayProcess {
+  stdin: HermesGatewayWritable;
+  stdout: HermesGatewayReadable;
+  stderr: HermesGatewayReadable;
+  once(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): void;
+  once(event: "error", listener: (error: Error) => void): void;
+  kill(signal: NodeJS.Signals): void;
+}
+
+export type HermesGatewaySpawn = (
+  command: string,
+  args: string[],
+  options: { cwd: string; env: Record<string, string>; stdio: ["pipe", "pipe", "pipe"] },
+) => HermesGatewayProcess;
+
+interface PendingRequest {
+  resolve(value: unknown): void;
+  reject(error: Error): void;
+  timer: NodeJS.Timeout;
+}
+
+export interface HermesStdioClient {
+  ready(): Promise<void>;
+  request(method: string, params: Record<string, unknown>, timeoutMs?: number): Promise<unknown>;
+  close(): Promise<void>;
+}
+
+const defaultSpawn: HermesGatewaySpawn = (command, args, options) => spawn(command, args, options);
+const MAX_FRAME_BYTES = 256 * 1024;
+const MAX_PENDING_REQUESTS = 16;
+const DEFAULT_READY_TIMEOUT_MS = 15_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const TERMINATION_GRACE_MS = 1_000;
+const FORCE_SETTLE_MS = 250;
+
+function safeError(message: string, cause?: unknown): Error {
+  return new Error(message, cause === undefined ? undefined : { cause });
+}
+
+export function createHermesStdioClient(options: {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: Record<string, string>;
+  spawnFn?: HermesGatewaySpawn;
+  readyTimeoutMs?: number;
+  requestTimeoutMs?: number;
+  onEvent(event: HermesGatewayEvent): void;
+  onFailure(error: Error): void;
+}): HermesStdioClient {
+  const pending = new Map<string | number, PendingRequest>();
+  const decoder = new StringDecoder("utf8");
+  let inputBuffer = "";
+  let requestId = 0;
+  let failed: Error | undefined;
+  let closing = false;
+  let exited = false;
+  let readySettled = false;
+  let resolveReady!: () => void;
+  let rejectReady!: (error: Error) => void;
+  let resolveExit!: () => void;
+  const readyPromise = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+  const exitPromise = new Promise<void>((resolve) => {
+    resolveExit = resolve;
+  });
+  const child = (options.spawnFn ?? defaultSpawn)(options.command, options.args, {
+    cwd: options.cwd,
+    env: { ...process.env, ...options.env } as Record<string, string>,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  const readyTimer = setTimeout(() => {
+    fail(safeError("Hermes gateway did not become ready"));
+  }, options.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS);
+  readyTimer.unref?.();
+
+  function settleReady(error?: Error): void {
+    if (readySettled) return;
+    readySettled = true;
+    clearTimeout(readyTimer);
+    if (error) rejectReady(error);
+    else resolveReady();
+  }
+
+  function rejectPending(error: Error): void {
+    for (const request of pending.values()) {
+      clearTimeout(request.timer);
+      request.reject(error);
+    }
+    pending.clear();
+  }
+
+  function fail(error: Error): void {
+    if (failed || closing) return;
+    failed = error;
+    settleReady(error);
+    rejectPending(error);
+    options.onFailure(error);
+    child.kill("SIGTERM");
+  }
+
+  function handleFrame(line: string): void {
+    if (Buffer.byteLength(line, "utf8") > MAX_FRAME_BYTES) {
+      fail(safeError("Hermes gateway frame exceeded limit"));
+      return;
+    }
+    let value: unknown;
+    try {
+      value = JSON.parse(line);
+    } catch (error: unknown) {
+      fail(safeError("Hermes gateway returned invalid data", error));
+      return;
+    }
+    const event = HermesGatewayEventSchema.safeParse(value);
+    if (event.success) {
+      if (event.data.params.type === "gateway.ready") settleReady();
+      try {
+        options.onEvent(event.data.params);
+      } catch (error: unknown) {
+        fail(safeError("Hermes gateway event was invalid", error));
+      }
+      return;
+    }
+    const response = JsonRpcResponseSchema.safeParse(value);
+    if (!response.success) {
+      fail(safeError("Hermes gateway returned an unsupported frame"));
+      return;
+    }
+    const request = pending.get(response.data.id);
+    if (!request) return;
+    pending.delete(response.data.id);
+    clearTimeout(request.timer);
+    if (response.data.error) request.reject(safeError("Hermes gateway request failed"));
+    else request.resolve(response.data.result);
+  }
+
+  child.stdout.on("data", (chunk) => {
+    if (failed || closing) return;
+    inputBuffer += decoder.write(chunk);
+    if (Buffer.byteLength(inputBuffer, "utf8") > MAX_FRAME_BYTES && !inputBuffer.includes("\n")) {
+      fail(safeError("Hermes gateway frame exceeded limit"));
+      return;
+    }
+    while (!failed) {
+      const newline = inputBuffer.indexOf("\n");
+      if (newline < 0) break;
+      const line = inputBuffer.slice(0, newline).trim();
+      inputBuffer = inputBuffer.slice(newline + 1);
+      if (line) handleFrame(line);
+    }
+    if (!failed && Buffer.byteLength(inputBuffer, "utf8") > MAX_FRAME_BYTES) {
+      fail(safeError("Hermes gateway frame exceeded limit"));
+    }
+  });
+  let stderrBytes = 0;
+  child.stderr.on("data", (chunk) => {
+    stderrBytes = Math.min(8_192, stderrBytes + chunk.byteLength);
+  });
+  child.once("error", (error) => fail(safeError("Hermes gateway could not start", error)));
+  child.once("exit", (code, signal) => {
+    exited = true;
+    resolveExit();
+    if (closing) return;
+    fail(safeError(code === 0 && signal === null
+      ? "Hermes gateway exited before the Run completed"
+      : "Hermes gateway exited unsuccessfully"));
+  });
+
+  return {
+    ready: () => readyPromise,
+    request(method, params, timeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS) {
+      if (failed) return Promise.reject(failed);
+      if (closing) return Promise.reject(safeError("Hermes gateway is closing"));
+      if (pending.size >= MAX_PENDING_REQUESTS) {
+        return Promise.reject(safeError("Hermes gateway request limit exceeded"));
+      }
+      const id = ++requestId;
+      const frame = `${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`;
+      if (Buffer.byteLength(frame, "utf8") > MAX_FRAME_BYTES) {
+        return Promise.reject(safeError("Hermes gateway request exceeded limit"));
+      }
+      return new Promise<unknown>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pending.delete(id);
+          reject(safeError("Hermes gateway request timed out"));
+        }, timeoutMs);
+        timer.unref?.();
+        pending.set(id, { resolve, reject, timer });
+        try {
+          child.stdin.write(frame);
+        } catch (error: unknown) {
+          clearTimeout(timer);
+          pending.delete(id);
+          reject(safeError("Hermes gateway request could not be sent", error));
+        }
+      });
+    },
+    async close() {
+      if (closing) return exitPromise;
+      closing = true;
+      clearTimeout(readyTimer);
+      settleReady(safeError("Hermes gateway closed"));
+      rejectPending(safeError("Hermes gateway closed"));
+      if (exited) return;
+      child.stdin.end();
+      let forceKillTimer: NodeJS.Timeout | undefined;
+      let forceSettleTimer: NodeJS.Timeout | undefined;
+      await Promise.race([
+        exitPromise,
+        new Promise<void>((resolve) => {
+          forceKillTimer = setTimeout(() => {
+            if (exited) return resolve();
+            child.kill("SIGTERM");
+            forceSettleTimer = setTimeout(() => {
+              if (!exited) child.kill("SIGKILL");
+              resolve();
+            }, FORCE_SETTLE_MS);
+            forceSettleTimer.unref?.();
+          }, TERMINATION_GRACE_MS);
+          forceKillTimer.unref?.();
+        }),
+      ]);
+      if (forceKillTimer) clearTimeout(forceKillTimer);
+      if (forceSettleTimer) clearTimeout(forceSettleTimer);
+    },
+  };
+}

--- a/packages/gateway/src/chat/hermes-stdio-client.ts
+++ b/packages/gateway/src/chat/hermes-stdio-client.ts
@@ -18,7 +18,7 @@ const HermesGatewayEventSchema = z.object({
   method: z.literal("event"),
   params: z.object({
     type: z.string().min(1).max(128),
-    session_id: z.string().min(1).max(512).optional(),
+    session_id: z.union([z.literal(""), z.string().min(1).max(512)]).optional(),
     payload: z.unknown().optional(),
   }).passthrough(),
 }).strict();

--- a/tests/gateway/chat-hermes-provider.test.ts
+++ b/tests/gateway/chat-hermes-provider.test.ts
@@ -1,25 +1,84 @@
 import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import { createHermesChatProviderAdapter } from "../../packages/gateway/src/chat/hermes-provider-adapter.js";
+import type {
+  HermesGatewayProcess,
+  HermesGatewaySpawn,
+} from "../../packages/gateway/src/chat/hermes-stdio-client.js";
+
+interface RpcRequest {
+  jsonrpc: "2.0";
+  id: number;
+  method: string;
+  params: Record<string, unknown>;
+}
 
 class FakeStream extends EventEmitter {}
 
-function child(stdoutText: string, exitCode = 0) {
+function fakeGateway(options: { emitReady?: boolean; ignoreMethods?: readonly string[] } = {}) {
   const stdout = new FakeStream();
   const stderr = new FakeStream();
-  const process = new EventEmitter() as EventEmitter & {
-    stdout: FakeStream;
-    stderr: FakeStream;
-    kill: ReturnType<typeof vi.fn>;
+  const emitter = new EventEmitter();
+  const requests: RpcRequest[] = [];
+  const send = (frame: unknown) => stdout.emit("data", Buffer.from(`${JSON.stringify(frame)}\n`));
+  const respond = (request: RpcRequest, result: unknown) => send({ jsonrpc: "2.0", id: request.id, result });
+  const stdin = {
+    write: vi.fn((chunk: string) => {
+      for (const line of chunk.trim().split("\n")) {
+        const request = JSON.parse(line) as RpcRequest;
+        requests.push(request);
+        if (options.ignoreMethods?.includes(request.method)) continue;
+        queueMicrotask(() => {
+          if (request.method === "session.create") {
+            respond(request, { session_id: "live_session", stored_session_id: "durable_session" });
+          } else if (request.method === "session.resume") {
+            respond(request, { session_id: "live_session", session_key: request.params.session_id });
+          } else if (request.method === "prompt.submit") {
+            respond(request, { status: "streaming" });
+          } else if (request.method === "session.interrupt") {
+            respond(request, { status: "interrupted" });
+          } else if (request.method === "config.set" && request.params.key === "yolo") {
+            respond(request, { key: "yolo", value: "1", scope: "session" });
+          } else if (request.method === "config.set" && request.params.key === "model") {
+            respond(request, { key: "model", value: request.params.value, confirm_required: false });
+          } else if (request.method === "session.cwd.set") {
+            respond(request, { cwd: request.params.cwd });
+          } else {
+            respond(request, {});
+          }
+        });
+      }
+      return true;
+    }),
+    end: vi.fn(() => queueMicrotask(() => emitter.emit("exit", 0, null))),
   };
-  process.stdout = stdout;
-  process.stderr = stderr;
-  process.kill = vi.fn();
-  queueMicrotask(() => {
-    stdout.emit("data", Buffer.from(stdoutText));
-    process.emit("exit", exitCode, null);
+  const kill = vi.fn((signal: NodeJS.Signals) => queueMicrotask(() => emitter.emit("exit", null, signal)));
+  const process = Object.assign(emitter, { stdin, stdout, stderr, kill }) as unknown as HermesGatewayProcess;
+  const spawnFn = vi.fn<HermesGatewaySpawn>(() => {
+    if (options.emitReady !== false) {
+      queueMicrotask(() => send({
+        jsonrpc: "2.0",
+        method: "event",
+        params: { type: "gateway.ready", payload: { change_events: true } },
+      }));
+    }
+    return process;
   });
-  return process;
+  return {
+    process,
+    requests,
+    spawnFn,
+    sendRaw(value: string) {
+      stdout.emit("data", Buffer.from(value));
+    },
+    event(type: string, payload: unknown, sessionId = "live_session") {
+      send({
+        jsonrpc: "2.0",
+        method: "event",
+        params: { type, session_id: sessionId, payload },
+      });
+    },
+  };
 }
 
 const baseInput = {
@@ -36,63 +95,272 @@ const baseInput = {
   signal: new AbortController().signal,
 };
 
+async function collect(iterable: AsyncIterable<unknown>): Promise<unknown[]> {
+  const events = [];
+  for await (const event of iterable) events.push(event);
+  return events;
+}
+
 describe("Hermes canonical Chat Provider adapter", () => {
-  it("runs the actual configured Hermes provider/model instead of Matrix kernel", async () => {
-    const spawnFn = vi.fn(() => child("hello from hermes"));
-    const readUsageFile = vi.fn(async () => ({ session_id: "hermes_session" }));
-    const cleanupUsageFile = vi.fn(async () => undefined);
+  it("yields assistant text before the Hermes process completes", async () => {
+    const gateway = fakeGateway();
     const adapter = createHermesChatProviderAdapter({
       homePath: "/home/matrix/home",
-      spawnFn,
-      createUsageFile: vi.fn(async () => ({ directory: "/tmp/hermes-run", path: "/tmp/hermes-run/usage.json" })),
-      readUsageFile,
-      cleanupUsageFile,
+      spawnFn: gateway.spawnFn,
     });
+    const iterator = adapter.start(baseInput)[Symbol.asyncIterator]();
+    const firstEvent = iterator.next();
+    await vi.waitFor(() => expect(gateway.requests.some(({ method }) => method === "prompt.submit")).toBe(true));
 
-    const events = [];
-    for await (const event of adapter.start(baseInput)) events.push(event);
+    gateway.event("message.delta", { text: "first live fragment" });
+    const observed = await Promise.race([
+      firstEvent,
+      new Promise<"not-streamed">((resolve) => setTimeout(() => resolve("not-streamed"), 50)),
+    ]);
 
-    const [command, args, options] = spawnFn.mock.calls[0]!;
-    expect(command).toBe("hermes");
-    expect(args).toEqual(expect.arrayContaining([
-      "-z", "hello",
-      "--provider", "openai-codex",
-      "--model", "gpt-5.6-luna",
-      "--usage-file", "/tmp/hermes-run/usage.json",
-      "--yolo",
-    ]));
-    expect(args).not.toContain("--source");
-    expect(options).toMatchObject({ cwd: "/safe/project" });
-    expect(events).toEqual([
-      { type: "assistant.delta", delta: "hello from hermes" },
-      { type: "state.updated", state: { sessionId: "hermes_session" } },
+    expect(observed).toEqual({
+      done: false,
+      value: { type: "assistant.delta", delta: "first live fragment" },
+    });
+    expect(gateway.process.kill).not.toHaveBeenCalled();
+    gateway.event("message.complete", { text: "first live fragment", status: "complete" });
+    const remaining = [];
+    while (true) {
+      const next = await iterator.next();
+      if (next.done) break;
+      remaining.push(next.value);
+    }
+    expect(remaining).toEqual([
+      { type: "state.updated", state: { sessionId: "durable_session" } },
       { type: "run.completed", outcome: "completed" },
     ]);
-    expect(cleanupUsageFile).toHaveBeenCalledWith("/tmp/hermes-run");
   });
 
-  it("resumes only the persisted Hermes session", async () => {
-    const spawnFn = vi.fn(() => child("continued"));
+  it("starts the official Hermes stdio gateway with the selected provider, model, and root", async () => {
+    const gateway = fakeGateway();
     const adapter = createHermesChatProviderAdapter({
       homePath: "/home/matrix/home",
-      spawnFn,
-      createUsageFile: vi.fn(async () => ({ directory: "/tmp/hermes-run", path: "/tmp/hermes-run/usage.json" })),
-      readUsageFile: vi.fn(async () => ({ session_id: "hermes_session" })),
-      cleanupUsageFile: vi.fn(async () => undefined),
+      spawnFn: gateway.spawnFn,
     });
-    const events = [];
-    for await (const event of adapter.resume!({
-      ...baseInput,
-      resumeState: { sessionId: "hermes_session" },
-    })) events.push(event);
+    const eventsPromise = collect(adapter.start(baseInput));
+    await vi.waitFor(() => expect(gateway.requests.some(({ method }) => method === "prompt.submit")).toBe(true));
+    gateway.event("message.delta", { text: "hello " });
+    gateway.event("message.delta", { text: "from hermes" });
+    gateway.event("message.complete", { text: "hello from hermes", status: "complete" });
 
-    expect(spawnFn.mock.calls[0]![1]).toEqual(expect.arrayContaining(["--resume", "hermes_session"]));
-    expect(events.at(-1)).toEqual({ type: "run.completed", outcome: "completed" });
+    expect(await eventsPromise).toEqual([
+      { type: "assistant.delta", delta: "hello " },
+      { type: "assistant.delta", delta: "from hermes" },
+      { type: "state.updated", state: { sessionId: "durable_session" } },
+      { type: "run.completed", outcome: "completed" },
+    ]);
+    const [command, args, options] = gateway.spawnFn.mock.calls[0]!;
+    expect(command).toBe("/home/matrix/home/.hermes/hermes-agent/venv/bin/python");
+    expect(args).toEqual(["-u", "-m", "tui_gateway.entry"]);
+    expect(options).toMatchObject({
+      cwd: "/safe/project",
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        HOME: "/home/matrix/home",
+        MATRIX_HOME: "/home/matrix/home",
+        HERMES_PYTHON_SRC_ROOT: "/home/matrix/home/.hermes/hermes-agent",
+        PYTHONPATH: "/home/matrix/home/.hermes/hermes-agent",
+        PYTHONUNBUFFERED: "1",
+      },
+    });
+    expect(gateway.requests).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        method: "session.create",
+        params: expect.objectContaining({
+          cwd: "/safe/project",
+          provider: "openai-codex",
+          model: "gpt-5.6-luna",
+          source: "matrix-os-desktop",
+        }),
+      }),
+      expect.objectContaining({
+        method: "session.cwd.set",
+        params: { session_id: "live_session", cwd: "/safe/project" },
+      }),
+      expect.objectContaining({
+        method: "config.set",
+        params: { session_id: "live_session", key: "yolo", value: "1", scope: "session" },
+      }),
+      expect.objectContaining({
+        method: "prompt.submit",
+        params: { session_id: "live_session", text: "hello", surface: "desktop" },
+      }),
+    ]));
+  });
+
+  it("resumes only the persisted Hermes session in a fresh gateway process", async () => {
+    const gateway = fakeGateway();
+    const adapter = createHermesChatProviderAdapter({
+      homePath: "/home/matrix/home",
+      spawnFn: gateway.spawnFn,
+    });
+    const eventsPromise = collect(adapter.resume!({
+      ...baseInput,
+      resumeState: { sessionId: "durable_session" },
+    }));
+    await vi.waitFor(() => expect(gateway.requests.some(({ method }) => method === "prompt.submit")).toBe(true));
+    gateway.event("message.delta", { text: "continued" });
+    gateway.event("message.complete", { text: "continued", status: "complete" });
+
+    expect(await eventsPromise).toEqual([
+      { type: "assistant.delta", delta: "continued" },
+      { type: "run.completed", outcome: "completed" },
+    ]);
+    expect(gateway.requests.find(({ method }) => method === "session.resume")?.params).toMatchObject({
+      session_id: "durable_session",
+      cwd: "/safe/project",
+      omit_messages: true,
+    });
+    expect(gateway.requests).toContainEqual(expect.objectContaining({
+      method: "config.set",
+      params: {
+        session_id: "live_session",
+        key: "model",
+        value: "gpt-5.6-luna --provider openai-codex --session",
+        confirm_expensive_model: true,
+      },
+    }));
+    expect(gateway.requests.some(({ method }) => method === "session.create")).toBe(false);
+  });
+
+  it("reconciles an authoritative completion tail without duplicating streamed text", async () => {
+    const gateway = fakeGateway();
+    const adapter = createHermesChatProviderAdapter({ homePath: "/home/matrix/home", spawnFn: gateway.spawnFn });
+    const eventsPromise = collect(adapter.start(baseInput));
+    await vi.waitFor(() => expect(gateway.requests.some(({ method }) => method === "prompt.submit")).toBe(true));
+    gateway.event("message.delta", { text: "streamed" });
+    gateway.event("message.complete", { text: "streamed tail", status: "complete" });
+
+    expect(await eventsPromise).toEqual([
+      { type: "assistant.delta", delta: "streamed" },
+      { type: "assistant.delta", delta: " tail" },
+      { type: "state.updated", state: { sessionId: "durable_session" } },
+      { type: "run.completed", outcome: "completed" },
+    ]);
+  });
+
+  it("preserves an interim Hermes segment before streaming the final segment", async () => {
+    const gateway = fakeGateway();
+    const adapter = createHermesChatProviderAdapter({ homePath: "/home/matrix/home", spawnFn: gateway.spawnFn });
+    const eventsPromise = collect(adapter.start(baseInput));
+    await vi.waitFor(() => expect(gateway.requests.some(({ method }) => method === "prompt.submit")).toBe(true));
+    gateway.event("message.delta", { text: "interim answer" });
+    gateway.event("message.interim", { text: "interim answer", already_streamed: true });
+    gateway.event("message.delta", { text: "final answer" });
+    gateway.event("message.complete", { text: "final answer", status: "complete" });
+
+    expect(await eventsPromise).toEqual([
+      { type: "assistant.delta", delta: "interim answer" },
+      { type: "assistant.delta", delta: "\n\n" },
+      { type: "assistant.delta", delta: "final answer" },
+      { type: "state.updated", state: { sessionId: "durable_session" } },
+      { type: "run.completed", outcome: "completed" },
+    ]);
+  });
+
+  it("interrupts the live Hermes session before closing an aborted Run", async () => {
+    const gateway = fakeGateway();
+    const abortController = new AbortController();
+    const adapter = createHermesChatProviderAdapter({ homePath: "/home/matrix/home", spawnFn: gateway.spawnFn });
+    const eventsPromise = collect(adapter.start({ ...baseInput, signal: abortController.signal }));
+    await vi.waitFor(() => expect(gateway.requests.some(({ method }) => method === "prompt.submit")).toBe(true));
+
+    abortController.abort();
+
+    expect(await eventsPromise).toEqual([{ type: "run.completed", outcome: "aborted" }]);
+    expect(gateway.requests).toContainEqual(expect.objectContaining({
+      method: "session.interrupt",
+      params: { session_id: "live_session" },
+    }));
+    expect(gateway.process.stdin.end).toHaveBeenCalledOnce();
+  });
+
+  it("fails safely when Hermes returns malformed protocol data", async () => {
+    const gateway = fakeGateway();
+    const adapter = createHermesChatProviderAdapter({ homePath: "/home/matrix/home", spawnFn: gateway.spawnFn });
+    const eventsPromise = collect(adapter.start(baseInput));
+    await vi.waitFor(() => expect(gateway.requests.some(({ method }) => method === "prompt.submit")).toBe(true));
+
+    gateway.sendRaw("not-json\n");
+
+    expect(await eventsPromise).toEqual([{
+      type: "run.completed",
+      outcome: "failed",
+      error: {
+        code: "run_failed",
+        safeMessage: "The selected provider could not complete this Run. Check its connection and retry.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      },
+    }]);
+    expect(gateway.process.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("fails closed when the final response diverges from already streamed text", async () => {
+    const gateway = fakeGateway();
+    const adapter = createHermesChatProviderAdapter({ homePath: "/home/matrix/home", spawnFn: gateway.spawnFn });
+    const eventsPromise = collect(adapter.start(baseInput));
+    await vi.waitFor(() => expect(gateway.requests.some(({ method }) => method === "prompt.submit")).toBe(true));
+    gateway.event("message.delta", { text: "visible partial" });
+    gateway.event("message.complete", { text: "different final", status: "complete" });
+
+    expect(await eventsPromise).toEqual([
+      { type: "assistant.delta", delta: "visible partial" },
+      expect.objectContaining({ type: "run.completed", outcome: "failed" }),
+    ]);
+  });
+
+  it("caps streamed Hermes output before it can grow adapter memory without bound", async () => {
+    const gateway = fakeGateway();
+    const adapter = createHermesChatProviderAdapter({ homePath: "/home/matrix/home", spawnFn: gateway.spawnFn });
+    const eventsPromise = collect(adapter.start(baseInput));
+    await vi.waitFor(() => expect(gateway.requests.some(({ method }) => method === "prompt.submit")).toBe(true));
+    gateway.event("message.delta", { text: "x".repeat(96 * 1024 + 1) });
+
+    expect(await eventsPromise).toEqual([
+      expect.objectContaining({ type: "run.completed", outcome: "failed" }),
+    ]);
+    expect(gateway.process.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("bounds gateway startup instead of waiting forever for a ready frame", async () => {
+    const gateway = fakeGateway({ emitReady: false });
+    const adapter = createHermesChatProviderAdapter({
+      homePath: "/home/matrix/home",
+      spawnFn: gateway.spawnFn,
+      readyTimeoutMs: 5,
+    });
+
+    expect(await collect(adapter.start(baseInput))).toEqual([
+      expect.objectContaining({ type: "run.completed", outcome: "failed" }),
+    ]);
+    expect(gateway.process.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(gateway.requests).toEqual([]);
+  });
+
+  it("bounds JSON-RPC requests instead of waiting forever for a response", async () => {
+    const gateway = fakeGateway({ ignoreMethods: ["session.create"] });
+    const adapter = createHermesChatProviderAdapter({
+      homePath: "/home/matrix/home",
+      spawnFn: gateway.spawnFn,
+      requestTimeoutMs: 5,
+    });
+
+    expect(await collect(adapter.start(baseInput))).toEqual([
+      expect.objectContaining({ type: "run.completed", outcome: "failed" }),
+    ]);
+    expect(gateway.requests.map(({ method }) => method)).toEqual(["session.create"]);
+    expect(gateway.process.stdin.end).toHaveBeenCalledOnce();
   });
 
   it("rejects unsupported permission and malformed provider selections before spawn", async () => {
-    const spawnFn = vi.fn(() => child("ignored"));
-    const adapter = createHermesChatProviderAdapter({ homePath: "/home/matrix/home", spawnFn });
+    const gateway = fakeGateway();
+    const adapter = createHermesChatProviderAdapter({ homePath: "/home/matrix/home", spawnFn: gateway.spawnFn });
 
     await expect(async () => {
       for await (const _event of adapter.start({ ...baseInput, permissionMode: "supervised" })) {}
@@ -103,6 +371,6 @@ describe("Hermes canonical Chat Provider adapter", () => {
         selection: { instanceId: "hermes_default", model: "missing-separator" },
       })) {}
     }).rejects.toThrow("Unsupported Hermes model selection");
-    expect(spawnFn).not.toHaveBeenCalled();
+    expect(gateway.spawnFn).not.toHaveBeenCalled();
   });
 });

--- a/tests/gateway/chat-hermes-provider.test.ts
+++ b/tests/gateway/chat-hermes-provider.test.ts
@@ -136,6 +136,30 @@ describe("Hermes canonical Chat Provider adapter", () => {
     ]);
   });
 
+  it("coalesces fine-grained Hermes deltas below the canonical activity limit", async () => {
+    const gateway = fakeGateway();
+    const adapter = createHermesChatProviderAdapter({
+      homePath: "/home/matrix/home",
+      spawnFn: gateway.spawnFn,
+    });
+    const eventsPromise = collect(adapter.start(baseInput));
+    await vi.waitFor(() => expect(gateway.requests.some(({ method }) => method === "prompt.submit")).toBe(true));
+
+    const response = "x".repeat(600);
+    for (const character of response) {
+      gateway.event("message.delta", { text: character });
+    }
+    gateway.event("message.complete", { text: response, status: "complete" });
+
+    const events = await eventsPromise;
+    const deltas = events.filter((event): event is { type: "assistant.delta"; delta: string } => (
+      typeof event === "object" && event !== null && (event as { type?: unknown }).type === "assistant.delta"
+    ));
+    expect(deltas.map(({ delta }) => delta).join("")).toBe(response);
+    expect(deltas.length).toBeLessThan(100);
+    expect(events.at(-1)).toEqual({ type: "run.completed", outcome: "completed" });
+  });
+
   it("ignores global Hermes advisory events with an empty session id", async () => {
     const gateway = fakeGateway();
     const adapter = createHermesChatProviderAdapter({
@@ -277,8 +301,7 @@ describe("Hermes canonical Chat Provider adapter", () => {
 
     expect(await eventsPromise).toEqual([
       { type: "assistant.delta", delta: "interim answer" },
-      { type: "assistant.delta", delta: "\n\n" },
-      { type: "assistant.delta", delta: "final answer" },
+      { type: "assistant.delta", delta: "\n\nfinal answer" },
       { type: "state.updated", state: { sessionId: "durable_session" } },
       { type: "run.completed", outcome: "completed" },
     ]);

--- a/tests/gateway/chat-hermes-provider.test.ts
+++ b/tests/gateway/chat-hermes-provider.test.ts
@@ -136,6 +136,27 @@ describe("Hermes canonical Chat Provider adapter", () => {
     ]);
   });
 
+  it("ignores global Hermes advisory events with an empty session id", async () => {
+    const gateway = fakeGateway();
+    const adapter = createHermesChatProviderAdapter({
+      homePath: "/home/matrix/home",
+      spawnFn: gateway.spawnFn,
+    });
+    const eventsPromise = collect(adapter.start(baseInput));
+    await vi.waitFor(() => expect(gateway.requests.some(({ method }) => method === "prompt.submit")).toBe(true));
+
+    gateway.event("sessions.changed", {}, "");
+    gateway.event("message.delta", { text: "still streaming" });
+    gateway.event("message.complete", { text: "still streaming", status: "complete" });
+
+    expect(await eventsPromise).toEqual([
+      { type: "assistant.delta", delta: "still streaming" },
+      { type: "state.updated", state: { sessionId: "durable_session" } },
+      { type: "run.completed", outcome: "completed" },
+    ]);
+    expect(gateway.process.kill).not.toHaveBeenCalled();
+  });
+
   it("starts the official Hermes stdio gateway with the selected provider, model, and root", async () => {
     const gateway = fakeGateway();
     const adapter = createHermesChatProviderAdapter({


### PR DESCRIPTION
## Summary

- replace Hermes `-z` oneshot buffering with the official stdio TUI gateway JSON-RPC transport
- emit bounded `assistant.delta` events before provider completion, preserve Hermes interim segments, and reconcile the authoritative final response without duplication
- accept Hermes global advisory events whose protocol-level `session_id` is the empty string, so `sessions.changed` cannot terminate a run before its first delta
- coalesce Hermes' fine-grained token stream with an immediate first fragment, a bounded 50 ms / 256 byte flush policy, and a hard live-event budget so long replies cannot exhaust the canonical 500-activity limit
- preserve selected provider/model, canonical execution root, durable Hermes session resume, full-access session approvals, cancellation, timeouts, and generic client-safe errors

## Root cause

There were three independent backend defects on the canonical Desktop Chat path:

1. Hermes oneshot mode explicitly disables its delta callback and returns one final content block. The previous adapter buffered that stdout until process exit and only then split the completed string into small chunks, which looked animated but could never be live.
2. The official stdio gateway emits a legal global advisory frame before assistant output: `sessions.changed` with `session_id: ""`. The first adapter revision rejected that frame as malformed and killed the child before the first `message.delta`.
3. Real Hermes output is extremely fine-grained. Persisting every upstream token as one canonical activity exhausted the existing 500-activity limit. The exact-head runtime reached 498 assistant deltas, failed on the next append, and never committed an assistant message.

The final adapter consumes Hermes' supported stdio stream, ignores non-session advisory frames, emits the first real fragment immediately, and coalesces subsequent fragments without raising the canonical database cap.

## Tests

- TDD regression: the real empty-session `sessions.changed` frame fails against the old schema and passes after the boundary fix
- TDD regression: 600 one-character Hermes deltas fail with `Provider CLI event buffer exceeded` before coalescing; after the fix they reconstruct the exact response in fewer than 100 canonical deltas
- Post-rebase focused suites — 54/54 passed at exact head `15199663d103632e33e0000a470274e4ee0cdaf7`
- `pnpm --filter @matrix-os/gateway build` — passed
- `bun run typecheck` — passed
- `bun run check:patterns` — 0 violations; 5 existing warning groups
- `bun run build:desktop` — passed
- `tests/shell/terminal-pane-scrolling.test.tsx` — 31/31 passed when independently rerunning the sole unrelated flaky failure from the duplicate automatic CI run
- Hosted exact-head CI: [33239611879](https://github.com/HamedMP/matrix-os/actions/runs/33239611879) — passed
- Hosted exact-head Docker tests: [33239611765](https://github.com/HamedMP/matrix-os/actions/runs/33239611765) — passed

## Exact-head runtime evidence

- Preview VPS workflow: [33239432639](https://github.com/HamedMP/matrix-os/actions/runs/33239432639) — passed
- Preview computer: [`pr-1383`](https://app.matrix-os.com/vm/pr-1383)
- Bundle: `v2026.08.29-pr1383-33239432639-1-94f86c2`
- Runtime commit: `94f86c2120e33f1d83588337feee8ab7cf003bc2`
- Real Hermes chat: `chat_9e7f776e96ec42f99cea821ad461d2b8`
- Real Hermes run: `run_7941eb7868bb4d1998f4309d5782fa35` — completed
- First persisted assistant delta: 9.696 seconds before run completion
- Activity budget: 138 assistant deltas / 141 total activities
- Transcript parity: 727 streamed characters = 727 committed characters
- A full Desktop renderer reload preserved the exact committed response.

## Review / Monitoring

- Linear: [OM-180](https://linear.app/matrix-os/issue/OM-180/fix-real-time-hermes-streaming-in-desktop-chat)
- Owner Human Review approved; PR is Ready for Review with `ready-for-ci` applied.
- Greptile: 5/5 on exact head `15199663d103632e33e0000a470274e4ee0cdaf7`, with no findings.
- The authenticated exact-head Desktop remains open against Preview Computer `pr-1383` with the successful Hermes conversation visible.
- Owner authorized merge on 2026-08-29.

## Invariants

### Source of truth

- Canonical Chat run activity and committed transcript in owner-scoped Postgres remain the UI source of truth.
- Hermes' durable session ID remains opaque provider state; live gateway events are reconciled against `message.complete` before a successful terminal outcome.

### Lock/transaction scope

- This change adds no database writes, locks, or transactions.
- The provider subprocess and JSON-RPC calls stay outside canonical Chat repository critical sections; the existing orchestrator persists normalized events.

### Acceptable orphan states

- A provider failure after live deltas may leave auditable partial run activity, followed by a failed terminal outcome; it does not commit a false successful response.
- Each Hermes gateway child is run-scoped, bounded by startup/request/run timeouts, and drained with stdin close plus TERM/KILL fallback.

### Auth source of truth

- Existing canonical Chat route authentication and owner principal resolution remain authoritative; no endpoint or auth fallback is added.
- Provider/model/session/event payloads are validated at the adapter boundary, and internal errors are reduced to a generic safe client message.

### Deferred scope

- No frontend code change: existing Desktop active-run polling and persisted-delta projection already satisfy the rendering seam.
- No long-lived Hermes service, provider-native transcript replacement, production rollout, or reuse of the canceled PR/Preview.
- The adjacent first-install dashboard/systemd ordering issue observed while preparing the disposable Preview is not part of this streaming fix.
- No public docs change: this restores the already-intended streaming behavior rather than adding a user-facing capability.
