### PR TITLE
fix(desktop): require support token in release builds

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -51,6 +51,15 @@ jobs:
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD || secrets.APPLE_APP_PASSWORD }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
     steps:
+      - name: Validate PostHog support configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${VITE_POSTHOG_PROJECT_TOKEN:-}" ]; then
+            echo "Missing required public PostHog project token for Desktop Support" >&2
+            exit 1
+          fi
+
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
@@ -335,6 +344,15 @@ jobs:
       VITE_POSTHOG_PROJECT_TOKEN: ${{ vars.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN || vars.NEXT_PUBLIC_POSTHOG_KEY }}
       VITE_POSTHOG_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.posthog.com' }}
     steps:
+      - name: Validate PostHog support configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${VITE_POSTHOG_PROJECT_TOKEN:-}" ]; then
+            echo "Missing required public PostHog project token for Desktop Support" >&2
+            exit 1
+          fi
+
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -55,7 +55,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "${VITE_POSTHOG_PROJECT_TOKEN:-}" ]; then
+          normalized_posthog_token="$(printf '%s' "${VITE_POSTHOG_PROJECT_TOKEN:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+          if [ -z "$normalized_posthog_token" ]; then
             echo "Missing required public PostHog project token for Desktop Support" >&2
             exit 1
           fi
@@ -348,7 +349,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "${VITE_POSTHOG_PROJECT_TOKEN:-}" ]; then
+          normalized_posthog_token="$(printf '%s' "${VITE_POSTHOG_PROJECT_TOKEN:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+          if [ -z "$normalized_posthog_token" ]; then
             echo "Missing required public PostHog project token for Desktop Support" >&2
             exit 1
           fi

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -77,10 +77,26 @@ describe("desktop release workflows", () => {
   it("injects the public PostHog support configuration into every packaged Desktop build", () => {
     const workflow = readFileSync(join(root, ".github/workflows/desktop-build.yml"), "utf8");
 
-    expect(workflow.match(/VITE_POSTHOG_PROJECT_TOKEN:/g)).toHaveLength(2);
-    expect(workflow.match(/VITE_POSTHOG_HOST:/g)).toHaveLength(2);
+    expect(workflow.match(/^\s+VITE_POSTHOG_PROJECT_TOKEN: \$\{\{/gm)).toHaveLength(2);
+    expect(workflow.match(/^\s+VITE_POSTHOG_HOST: \$\{\{/gm)).toHaveLength(2);
     expect(workflow).toContain("vars.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN || vars.NEXT_PUBLIC_POSTHOG_KEY");
     expect(workflow).toContain("vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.posthog.com'");
+  });
+
+  it("fails packaged Desktop builds before bundling when PostHog support is unconfigured", () => {
+    const workflow = readFileSync(join(root, ".github/workflows/desktop-build.yml"), "utf8");
+    const validationName = "name: Validate PostHog support configuration";
+    const missingTokenCheck = 'if [ -z "${VITE_POSTHOG_PROJECT_TOKEN:-}" ]; then';
+    const missingTokenError = "Missing required public PostHog project token for Desktop Support";
+
+    expect(workflow.match(new RegExp(validationName, "g"))).toHaveLength(2);
+    expect(workflow.split(missingTokenCheck)).toHaveLength(3);
+    expect(workflow.match(new RegExp(missingTokenError, "g"))).toHaveLength(2);
+
+    const macJob = workflow.slice(workflow.indexOf("  mac:"), workflow.indexOf("  linux:"));
+    const linuxJob = workflow.slice(workflow.indexOf("  linux:"));
+    expect(macJob.indexOf(validationName)).toBeLessThan(macJob.indexOf("name: Build desktop app"));
+    expect(linuxJob.indexOf(validationName)).toBeLessThan(linuxJob.indexOf("name: Build desktop app"));
   });
 
   it("keeps raw workspace TypeScript out of the packaged app archive", () => {

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -86,17 +86,19 @@ describe("desktop release workflows", () => {
   it("fails packaged Desktop builds before bundling when PostHog support is unconfigured", () => {
     const workflow = readFileSync(join(root, ".github/workflows/desktop-build.yml"), "utf8");
     const validationName = "name: Validate PostHog support configuration";
-    const missingTokenCheck = 'if [ -z "${VITE_POSTHOG_PROJECT_TOKEN:-}" ]; then';
+    const normalizeToken = "normalized_posthog_token=\"$(printf '%s' \"${VITE_POSTHOG_PROJECT_TOKEN:-}\" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')\"";
+    const missingTokenCheck = 'if [ -z "$normalized_posthog_token" ]; then';
     const missingTokenError = "Missing required public PostHog project token for Desktop Support";
 
     expect(workflow.match(new RegExp(validationName, "g"))).toHaveLength(2);
+    expect(workflow.split(normalizeToken)).toHaveLength(3);
     expect(workflow.split(missingTokenCheck)).toHaveLength(3);
     expect(workflow.match(new RegExp(missingTokenError, "g"))).toHaveLength(2);
 
     const macJob = workflow.slice(workflow.indexOf("  mac:"), workflow.indexOf("  linux:"));
     const linuxJob = workflow.slice(workflow.indexOf("  linux:"));
-    expect(macJob.indexOf(validationName)).toBeLessThan(macJob.indexOf("name: Build desktop app"));
-    expect(linuxJob.indexOf(validationName)).toBeLessThan(linuxJob.indexOf("name: Build desktop app"));
+    expect(macJob.indexOf(validationName)).toBeLessThan(macJob.indexOf("uses: actions/checkout@v6"));
+    expect(linuxJob.indexOf(validationName)).toBeLessThan(linuxJob.indexOf("uses: actions/checkout@v6"));
   });
 
   it("keeps raw workspace TypeScript out of the packaged app archive", () => {


### PR DESCRIPTION
## Summary

- fail macOS and Linux packaged Desktop builds before setup when the public PostHog project token is missing
- add a release workflow contract test covering both jobs and validation ordering
- configure the verified Matrix OS PostHog project token as the `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` repository variable

Linear: [MAT-511](https://linear.app/matrix-os/issue/MAT-511/featdesktop-add-posthog-support-widget)

## Tests

- `flox activate -- bun run test tests/desktop/desktop-release-workflows.test.ts` — 22/22 passed
- `flox activate -- bun run typecheck` — passed
- `flox activate -- bun run check:patterns` — 0 violations, 5 existing warning groups
- `git diff --check` — passed
- local `actionlint` unavailable; GitHub Actions is the workflow parser gate

## Review/Monitoring

- require trusted Greptile 5/5 on the exact PR head
- add `ready-for-ci` only after Greptile 5/5, then require triggered CI success
- after merge, dispatch Desktop Canary Release and verify the packaged Desktop exposes Support

## Invariants

- **Source of truth:** Matrix OS PostHog project `127225`; GitHub repository variable `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` supplies the public build-time token
- **Lock/transaction scope:** none; workflow-only validation plus a repository variable
- **Acceptable orphan states:** none; a missing token fails the build before checkout instead of producing a degraded package
- **Auth source of truth:** unchanged; PostHog widget authentication and the existing first-party relay remain authoritative
- **Deferred scope:** no Support UI or relay behavior changes; this PR only prevents misconfigured packaged releases
