### PR TITLE
fix(desktop): raise release build heap limit

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -121,6 +121,8 @@ jobs:
           node --input-type=module -e "import { readFile, writeFile } from 'node:fs/promises'; const p='desktop/package.json'; const j=JSON.parse(await readFile(p,'utf8')); const exact=process.env.RELEASE_VERSION || ''; const suffix=process.env.VERSION_SUFFIX || ''; j.version = exact || (j.version.replace(/-.*/, '') + '-' + suffix); await writeFile(p, JSON.stringify(j, null, 2) + '\n');"
 
       - name: Build desktop app
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
         run: pnpm --filter desktop build
 
       - name: Package desktop app
@@ -378,6 +380,8 @@ jobs:
           node --input-type=module -e "import { readFile, writeFile } from 'node:fs/promises'; const p='desktop/package.json'; const j=JSON.parse(await readFile(p,'utf8')); const exact=process.env.RELEASE_VERSION || ''; const suffix=process.env.VERSION_SUFFIX || ''; j.version = exact || (j.version.replace(/-.*/, '') + '-' + suffix); await writeFile(p, JSON.stringify(j, null, 2) + '\n');"
 
       - name: Build desktop app
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
         run: pnpm --filter desktop build
 
       - name: Package desktop app

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -101,6 +101,16 @@ describe("desktop release workflows", () => {
     expect(linuxJob.indexOf(validationName)).toBeLessThan(linuxJob.indexOf("uses: actions/checkout@v6"));
   });
 
+  it("gives release renderer builds enough Node heap on every runner", () => {
+    const workflow = readFileSync(join(root, ".github/workflows/desktop-build.yml"), "utf8");
+
+    expect(
+      workflow.match(
+        /- name: Build desktop app\n\s+env:\n\s+NODE_OPTIONS: "--max-old-space-size=4096"\n\s+run: pnpm --filter desktop build/g,
+      ),
+    ).toHaveLength(2);
+  });
+
   it("keeps raw workspace TypeScript out of the packaged app archive", () => {
     const builder = readFileSync(join(root, "desktop/electron-builder.yml"), "utf8");
 


### PR DESCRIPTION
## Summary

- give Desktop renderer builds a 4 GiB Node heap in both macOS and Linux release jobs
- add a workflow contract test covering every release runner
- keep packaging, signing, and runtime behavior unchanged

## Evidence

Desktop Canary run 33238891489 failed in the Build desktop app step on both macOS arm64 and macOS x64 with V8 heap exhaustion, while Linux x64 passed.

- TDD red: the new heap contract failed before the workflow change
- Focused test: 23/23 passed
- git diff --check: passed

## Invariants

- **Source of truth:** desktop-build.yml remains the single release-build workflow contract.
- **Lock / transaction scope:** none; this changes CI process memory only.
- **Acceptable orphan states:** none; a renderer build either completes or fails before packaging.
- **Auth source of truth:** unchanged; release configuration remains in GitHub Actions secrets/variables.
- **Deferred scope:** packaged Canary publication and real signed Desktop validation remain post-merge release gates.

## Release validation

After merge, rerun Desktop Canary Release and require both macOS architectures to complete build, package, sign, smoke-test, and upload before publishing.