### PR TITLE
fix(desktop): stabilize Project Chat titles and inspector resizing

### DIFF
--- a/desktop/src/renderer/src/features/chat/CanonicalChatRoute.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatRoute.tsx
@@ -175,6 +175,7 @@ export function CanonicalChatRoute({
           projectSlug: projectId,
           title: projectLabel ?? projectId,
           ...(chatId ? { chatId } : {}),
+          ...(chatId ? { chatTitle: title, chatView: "conversation" as const } : { chatView: "draft" as const }),
         });
       }}
       onProjectChanged={(chatId, targetProjectId, title) => {

--- a/desktop/src/renderer/src/features/work/WorkTab.tsx
+++ b/desktop/src/renderer/src/features/work/WorkTab.tsx
@@ -222,6 +222,7 @@ export default function WorkTab({
   const inspectorRegionRef = useRef<HTMLDivElement>(null);
   const measuredWidthRef = useRef(false);
   const pendingFocusRef = useRef<RefObject<HTMLButtonElement | null> | null>(null);
+  const resizeCleanupRef = useRef<(() => void) | null>(null);
   const surfaceChromeHost = useSurfaceChromeHost();
   const hostedChrome = surfaceChromeHost !== null;
   const [responsive, setResponsive] = useState<WorkResponsiveState>({
@@ -308,6 +309,8 @@ export default function WorkTab({
     return () => observer.disconnect();
   }, [hasInspector, initialChatId, routeKey]);
 
+  useEffect(() => () => resizeCleanupRef.current?.(), []);
+
   useLayoutEffect(() => {
     const target = pendingFocusRef.current;
     if (!target) return;
@@ -342,10 +345,11 @@ export default function WorkTab({
   }, []);
 
   const startResize = (side: "left" | "right") => (event: React.PointerEvent<HTMLDivElement>) => {
-    if (layout === "narrow") return;
+    if (layout === "narrow" || event.button !== 0) return;
     event.preventDefault();
     const bounds = workRef.current?.getBoundingClientRect();
     if (!bounds) return;
+    resizeCleanupRef.current?.();
     const move = (moveEvent: PointerEvent) => {
       if (side === "left") {
         const requested = moveEvent.clientX - bounds.left;
@@ -366,12 +370,30 @@ export default function WorkTab({
       const maxInspector = Math.max(MIN_INSPECTOR_WIDTH, Math.min(MAX_INSPECTOR_WIDTH, bounds.width - navigationSpace - MIN_CHAT_WIDTH));
       setInspectorWidth(Math.max(MIN_INSPECTOR_WIDTH, Math.min(maxInspector, requested)));
     };
+    const captureTarget = event.currentTarget;
+    const pointerId = event.pointerId;
+    let finished = false;
     const stop = () => {
+      if (finished) return;
+      finished = true;
       window.removeEventListener("pointermove", move);
       window.removeEventListener("pointerup", stop);
+      window.removeEventListener("pointercancel", stop);
+      window.removeEventListener("blur", stop);
+      captureTarget.removeEventListener("lostpointercapture", stop);
+      if (resizeCleanupRef.current === stop) resizeCleanupRef.current = null;
+      if (typeof captureTarget.hasPointerCapture === "function"
+        && captureTarget.hasPointerCapture(pointerId)) {
+        captureTarget.releasePointerCapture(pointerId);
+      }
     };
+    resizeCleanupRef.current = stop;
+    captureTarget.setPointerCapture?.(pointerId);
     window.addEventListener("pointermove", move);
-    window.addEventListener("pointerup", stop, { once: true });
+    window.addEventListener("pointerup", stop);
+    window.addEventListener("pointercancel", stop);
+    window.addEventListener("blur", stop);
+    captureTarget.addEventListener("lostpointercapture", stop);
   };
   const resizeWithKeyboard = (side: "left" | "right") => (delta: number) => {
     const width = workRef.current?.getBoundingClientRect().width ?? 0;

--- a/tests/desktop/canonical-chat-top-level-tabs.test.tsx
+++ b/tests/desktop/canonical-chat-top-level-tabs.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const workspace = vi.hoisted(() => ({
   props: null as null | {
     onActiveChatChanged?: (chatId: string | null, title?: string) => void;
+    onProjectChanged?: (chatId: string, projectId: string | null, title: string) => void;
   },
 }));
 
@@ -88,5 +89,43 @@ describe("CanonicalChatRoute top-level tab ownership", () => {
       closable: true,
     });
     expect(useTabs.getState().activeTabId).toBe(draftId);
+  });
+
+  it("keeps the selected Project Chat title when canonical detail loading reports the active Chat", async () => {
+    const workTabId = useTabs.getState().openTab({
+      kind: "work",
+      title: "Chat",
+      workRoute: "project",
+      projectSlug: "alpha",
+      chatId: "chat-old",
+      chatTitle: "Old project chat",
+      chatView: "conversation",
+      closable: false,
+    });
+
+    render(
+      <CanonicalChatRoute
+        api={routeApi()}
+        projectId="alpha"
+        projectLabel="Alpha"
+        initialChatId="chat-new"
+        initialView="conversation"
+        active
+        fallback={<div>legacy chat</div>}
+      />,
+    );
+
+    expect(await screen.findByText("canonical workspace")).toBeTruthy();
+    act(() => workspace.props?.onActiveChatChanged?.("chat-new", "New project chat"));
+
+    expect(useTabs.getState().tabs).toHaveLength(1);
+    expect(useTabs.getState().tabs.find((tab) => tab.id === workTabId)).toMatchObject({
+      kind: "work",
+      workRoute: "project",
+      projectSlug: "alpha",
+      chatId: "chat-new",
+      chatTitle: "New project chat",
+      chatView: "conversation",
+    });
   });
 });

--- a/tests/desktop/work-tab.test.tsx
+++ b/tests/desktop/work-tab.test.tsx
@@ -414,6 +414,21 @@ describe("WorkTab rail integration", () => {
     expect(screen.getByRole("separator", { name: "Resize Chat inspector" }).getAttribute("aria-valuenow")).toBe("656");
   });
 
+  it("stops resizing the Chat inspector when an extreme pointer drag is cancelled", async () => {
+    render(<WorkTab route="chat" active initialChatId="chat_global" initialChatView="conversation" />);
+    await screen.findByRole("button", { name: "Global chat" });
+
+    const inspectorSeparator = screen.getByRole("separator", { name: "Resize Chat inspector" });
+    fireEvent.pointerDown(inspectorSeparator, { button: 0, clientX: 760, pointerId: 17 });
+    fireEvent.pointerMove(window, { clientX: 700, pointerId: 17 });
+    expect(screen.getByRole("separator", { name: "Resize Chat inspector" }).getAttribute("aria-valuenow")).toBe("700");
+
+    fireEvent.pointerCancel(window, { pointerId: 17 });
+    fireEvent.pointerMove(window, { clientX: -1_000, pointerId: 17 });
+
+    expect(screen.getByRole("separator", { name: "Resize Chat inspector" }).getAttribute("aria-valuenow")).toBe("700");
+  });
+
   it("collapses both sidebars when their dividers move past the minimum", async () => {
     render(<WorkTab route="chat" active initialChatId="chat_global" initialChatView="conversation" />);
     await screen.findByRole("button", { name: "Global chat" });


### PR DESCRIPTION
## summary

- preserve the selected Project Chat title and conversation view when canonical detail loading reports the active Chat
- make inspector resizing own its pointer gesture and clean up on pointer cancel, blur, lost capture, and unmount
- add public regression coverage for both failures

## issues

- OM-181
- OM-182

## verification

- `bun run test tests/desktop/canonical-chat-top-level-tabs.test.tsx tests/desktop/work-tab.test.tsx tests/desktop/tab-content.test.tsx` — 41 tests passed
- `pnpm --filter desktop run typecheck` — passed
- `bun run typecheck` — passed
- `bun run build:desktop` — passed
- `bun run check:patterns` — 0 violations; 5 existing warning groups outside the changed files
- real Desktop source validation from exact commit `668dfefb756ebf66a6024e8090378824a3e32944` — switching Chats within one Project retained the selected title; repeated extreme inspector drags stayed clamped at 820 px and loaded; a blur-cancelled drag stopped changing width; no `Chat couldn't open`, page errors, or console errors

## human review

- Human Review passed on the prepared Desktop environment.
- After approval, the branch was rebased onto latest `main` (`53cd01a66fb338df330ef89bede0190a82723e3a`) and the focused tests, typechecks, pattern check, Desktop build, and real Desktop flow were rerun successfully on exact head `668dfefb756ebf66a6024e8090378824a3e32944`.

## manual test flow

### OM-181 — same-Project Chat title

1. In the prepared Chat window, select the first named Chat under the expanded Project and wait for its messages to load.
2. Confirm the top title exactly matches that selected Chat and is not the generic `Chat` fallback.
3. Select the second named Chat in the same Project.
4. Confirm the messages change and the top title immediately changes to the second Chat's name.
5. Switch back to the first Chat and confirm its title returns correctly.

### OM-182 — extreme inspector resize

1. Keep either Project Chat fully loaded, then open the inspector with the top-right panel button.
2. Drag the inspector divider left as far as possible and release it.
3. Confirm the inspector stops at a safe maximum, the Chat/messages/composer remain mounted, and `Chat couldn't open` never appears.
4. Repeat the extreme drag three times, including one drag released after moving the pointer outside the Chat window.
5. Close and reopen the inspector, switch to the other Chat, and repeat one extreme drag.
6. Confirm the selected Chat title and content remain correct throughout and the tab never enters the fatal fallback.

## broad-suite baseline

`bun run test` completed with 12,369 passing, 21 skipped, and 18 failing tests across 6 unrelated files. The failures are outside this four-file Desktop UI diff and are dominated by macOS/Linux host-script incompatibilities and terminal/tool timeout behavior:

- `tests/platform/ci-workflows.test.ts`
- `tests/platform/customer-vps-cloud-init.test.ts`
- `tests/platform/golden-snapshot-host-scripts.test.ts`
- `tests/gateway/onboarding-tool-packs.test.ts`
- `tests/gateway/shell-zellij.test.ts`
- `tests/shell/terminal-agent-options.test.ts`

## risk

- UI-only; no backend, persistence, schema, or deployment changes
- pointer capture is released defensively because browsers may already have released it on cancellation
