### PR TITLE
fix(desktop): restore terminal session controls

### DIFF
--- a/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
@@ -94,7 +94,7 @@ export default function DesktopSurfaceFrame({
     : isDesktopHidden || isDesktopTransition || (isDesktopWindow && !tabWorkspaceActive) || (isTabbed && tabWorkspaceActive && active);
   const interactive = visible && active;
   const isNativeEmbed = tab.kind === "home" || tab.kind === "app";
-  const sidebarOwnsChrome = tab.kind === "chat" || tab.kind === "terminal" || tab.kind === "terminals" || tab.kind === "settings";
+  const sidebarOwnsChrome = tab.kind === "chat" || tab.kind === "settings";
   const requestedSettingsSection = useUi((state) => state.requestedSettingsSection);
   const [settingsSection, setSettingsSection] = useState<SettingsSectionId>("account");
   useEffect(() => {

--- a/desktop/src/renderer/src/features/terminal/DesktopNewSessionControl.tsx
+++ b/desktop/src/renderer/src/features/terminal/DesktopNewSessionControl.tsx
@@ -1,0 +1,117 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { ChevronDown, Plus, SquareTerminal } from "@renderer/lib/hugeicons";
+
+import { DESKTOP_Z_INDEX } from "../../design/layering";
+import {
+  TERMINAL_AGENT_OPTIONS,
+  terminalAgentAction,
+  type TerminalAgentId,
+  type TerminalAgentInstallState,
+  type TerminalAgentMenuAction,
+  type TerminalAgentOption,
+} from "./terminal-agent-options";
+
+export function DesktopNewSessionControl({
+  disabled,
+  creating,
+  agentStatuses,
+  checkingAgentStatuses,
+  onRefreshAgentStatuses,
+  onCreateShell,
+  onCreateAgent,
+}: {
+  disabled: boolean;
+  creating: boolean;
+  agentStatuses: Record<TerminalAgentId, TerminalAgentInstallState>;
+  checkingAgentStatuses: boolean;
+  onRefreshAgentStatuses: () => void;
+  onCreateShell: () => void;
+  onCreateAgent: (option: TerminalAgentOption, action: TerminalAgentMenuAction) => void;
+}) {
+  const controlDisabled = disabled || creating;
+  return (
+    <div className="no-drag flex h-7 shrink-0 overflow-hidden rounded-md" style={{ background: "var(--accent)", color: "var(--text-on-accent)" }}>
+      <button
+        type="button"
+        aria-label="New shell session"
+        disabled={controlDisabled}
+        className="flex w-7 items-center justify-center disabled:opacity-50"
+        onClick={onCreateShell}
+      >
+        <Plus size={15} aria-hidden="true" />
+      </button>
+      <DropdownMenu.Root onOpenChange={(open) => open && onRefreshAgentStatuses()}>
+        <DropdownMenu.Trigger asChild>
+          <button
+            type="button"
+            aria-label="Choose session type"
+            disabled={controlDisabled}
+            className="flex w-5 items-center justify-center border-l border-white/20 disabled:opacity-50"
+          >
+            <ChevronDown size={11} aria-hidden="true" />
+          </button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            aria-label="New terminal session"
+            align="end"
+            sideOffset={6}
+            className="fade-in min-w-[210px] rounded-lg border p-1"
+            style={{
+              zIndex: DESKTOP_Z_INDEX.popover,
+              background: "var(--bg-overlay)",
+              borderColor: "var(--border-default)",
+              boxShadow: "var(--shadow-2)",
+              color: "var(--text-primary)",
+            }}
+          >
+            <DropdownMenu.Label className="px-2.5 pb-1 pt-1.5 text-[10px] font-semibold uppercase tracking-[0.08em]" style={{ color: "var(--text-tertiary)" }}>
+              New tab
+            </DropdownMenu.Label>
+            <SessionMenuItem label="Shell" icon={<SquareTerminal size={14} />} onSelect={onCreateShell} />
+            {TERMINAL_AGENT_OPTIONS.map((option) => {
+              const state = agentStatuses[option.id];
+              const status = state === "missing" ? "Install" : state === "unknown" && checkingAgentStatuses ? "Checking…" : null;
+              return (
+                <SessionMenuItem
+                  key={option.id}
+                  label={option.label}
+                  badge={option.shortLabel.slice(0, 2)}
+                  status={status}
+                  onSelect={() => onCreateAgent(option, terminalAgentAction(state))}
+                />
+              );
+            })}
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+    </div>
+  );
+}
+
+function SessionMenuItem({
+  label,
+  icon,
+  badge,
+  status,
+  onSelect,
+}: {
+  label: string;
+  icon?: React.ReactNode;
+  badge?: string;
+  status?: string | null;
+  onSelect: () => void;
+}) {
+  return (
+    <DropdownMenu.Item
+      onSelect={onSelect}
+      className="flex cursor-default items-center gap-2 rounded-md px-2.5 py-2 text-sm outline-none data-[highlighted]:bg-[var(--bg-hover)]"
+    >
+      <span className="flex size-5 shrink-0 items-center justify-center rounded text-[9px] font-bold" style={{ background: "var(--bg-selected)", color: "var(--text-secondary)" }}>
+        {icon ?? badge}
+      </span>
+      <span className="min-w-0 flex-1">{label}</span>
+      {status ? <span className="text-[10px]" style={{ color: "var(--text-tertiary)" }}>{status}</span> : null}
+    </DropdownMenu.Item>
+  );
+}

--- a/desktop/src/renderer/src/features/terminal/DesktopNewSessionControl.tsx
+++ b/desktop/src/renderer/src/features/terminal/DesktopNewSessionControl.tsx
@@ -71,14 +71,20 @@ export function DesktopNewSessionControl({
             <SessionMenuItem label="Shell" icon={<SquareTerminal size={14} />} onSelect={onCreateShell} />
             {TERMINAL_AGENT_OPTIONS.map((option) => {
               const state = agentStatuses[option.id];
-              const status = state === "missing" ? "Install" : state === "unknown" && checkingAgentStatuses ? "Checking…" : null;
+              const action = terminalAgentAction(state);
+              const status = state === "missing"
+                ? "Install"
+                : state === "unknown"
+                  ? checkingAgentStatuses ? "Checking…" : "Unavailable"
+                  : null;
               return (
                 <SessionMenuItem
                   key={option.id}
                   label={option.label}
                   badge={option.shortLabel.slice(0, 2)}
                   status={status}
-                  onSelect={() => onCreateAgent(option, terminalAgentAction(state))}
+                  disabled={action === null}
+                  onSelect={() => action && onCreateAgent(option, action)}
                 />
               );
             })}
@@ -94,18 +100,21 @@ function SessionMenuItem({
   icon,
   badge,
   status,
+  disabled = false,
   onSelect,
 }: {
   label: string;
   icon?: React.ReactNode;
   badge?: string;
   status?: string | null;
+  disabled?: boolean;
   onSelect: () => void;
 }) {
   return (
     <DropdownMenu.Item
+      disabled={disabled}
       onSelect={onSelect}
-      className="flex cursor-default items-center gap-2 rounded-md px-2.5 py-2 text-sm outline-none data-[highlighted]:bg-[var(--bg-hover)]"
+      className="flex cursor-default items-center gap-2 rounded-md px-2.5 py-2 text-sm outline-none data-[disabled]:opacity-50 data-[highlighted]:bg-[var(--bg-hover)]"
     >
       <span className="flex size-5 shrink-0 items-center justify-center rounded text-[9px] font-bold" style={{ background: "var(--bg-selected)", color: "var(--text-secondary)" }}>
         {icon ?? badge}

--- a/desktop/src/renderer/src/features/terminal/DesktopTerminalThemePicker.tsx
+++ b/desktop/src/renderer/src/features/terminal/DesktopTerminalThemePicker.tsx
@@ -27,6 +27,7 @@ export function DesktopTerminalThemePicker() {
           aria-label="Shell theme"
           title="Shell theme"
           disabled={!api}
+          onPointerDown={(event) => event.stopPropagation()}
           className="inline-flex size-7 shrink-0 items-center justify-center rounded-md border outline-none transition-colors hover:bg-[var(--bg-hover)] focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50"
           style={{
             background: "var(--bg-surface)",

--- a/desktop/src/renderer/src/features/terminal/TerminalSessionSidebar.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalSessionSidebar.tsx
@@ -1,11 +1,29 @@
-import { Plus, SquareTerminal, Trash2 } from "@renderer/lib/hugeicons";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { Check, Clipboard, Edit3, MoreHorizontal, SquareTerminal, Trash2, X } from "@renderer/lib/hugeicons";
 
+import { DESKTOP_Z_INDEX } from "../../design/layering";
 import type { ShellSessionSummary } from "../../stores/shell-sessions";
 import { OSWindowSafeView } from "../desktop-shell/OSWindow";
+import { DesktopNewSessionControl } from "./DesktopNewSessionControl";
 import { relativeSessionActivity } from "./terminal-session-activity";
+import {
+  terminalAgentLabel,
+  UNKNOWN_TERMINAL_AGENT_STATUSES,
+  type TerminalAgentId,
+  type TerminalAgentInstallState,
+  type TerminalAgentMenuAction,
+  type TerminalAgentOption,
+} from "./terminal-agent-options";
 
 function isActive(shell: ShellSessionSummary): boolean {
   return shell.status === "active" || shell.visualStatus === "running";
+}
+
+function agentMetadata(shell: ShellSessionSummary): string | null {
+  if (!shell.agent) return null;
+  return [terminalAgentLabel(shell.agent), shell.model, shell.strength, shell.lastAction ?? shell.subtitle]
+    .filter(Boolean)
+    .join(" · ");
 }
 
 export function TerminalSessionSidebar({
@@ -13,79 +31,188 @@ export function TerminalSessionSidebar({
   selectedName,
   creating,
   disabled,
+  agentStatuses = UNKNOWN_TERMINAL_AGENT_STATUSES,
+  checkingAgentStatuses = false,
+  renamingName,
+  renameDraft,
+  renameError,
   onCreate,
+  onCreateAgent,
+  onRefreshAgentStatuses,
   onSelect,
+  onRename,
+  onRenameDraft,
+  onCommitRename,
+  onCancelRename,
+  onCopyConnectCommand,
   onDelete,
 }: {
   sessions: ShellSessionSummary[];
   selectedName: string | null;
   creating: boolean;
   disabled: boolean;
+  agentStatuses: Record<TerminalAgentId, TerminalAgentInstallState>;
+  checkingAgentStatuses: boolean;
+  renamingName: string | null;
+  renameDraft: string;
+  renameError: string | null;
   onCreate: () => void;
+  onCreateAgent: (option: TerminalAgentOption, action: TerminalAgentMenuAction) => void;
+  onRefreshAgentStatuses: () => void;
   onSelect: (session: ShellSessionSummary) => void;
+  onRename: (session: ShellSessionSummary) => void;
+  onRenameDraft: (value: string) => void;
+  onCommitRename: () => void;
+  onCancelRename: () => void;
+  onCopyConnectCommand: (session: ShellSessionSummary) => void;
   onDelete: (session: ShellSessionSummary) => void;
 }) {
   return (
-    <OSWindowSafeView
-      area="sidebar"
-      data-terminal-session-sidebar
-      className="flex h-full min-h-0 w-full flex-col"
-    >
+    <OSWindowSafeView area="sidebar" data-terminal-session-sidebar className="flex h-full min-h-0 w-full flex-col">
       <aside className="flex h-full min-h-0 w-full flex-col">
-      <div className="flex shrink-0 items-center justify-between border-b px-4 py-2" style={{ borderColor: "var(--border-subtle)" }}>
-        <div className="flex min-w-0 items-center gap-1">
-          <SquareTerminal size={16} aria-hidden="true" />
-          <h1 className="truncate text-base font-medium tracking-[-0.4px]" style={{ color: "var(--text-primary)" }}>Terminal</h1>
+        <div className="flex min-h-12 shrink-0 items-center justify-between border-b px-4 py-2" style={{ borderColor: "var(--border-subtle)" }}>
+          <div className="flex min-w-0 items-center gap-1.5">
+            <SquareTerminal size={16} aria-hidden="true" />
+            <h1 className="truncate text-base font-medium tracking-[-0.4px]" style={{ color: "var(--text-primary)" }}>Terminal</h1>
+          </div>
+          <DesktopNewSessionControl
+            disabled={disabled}
+            creating={creating}
+            agentStatuses={agentStatuses}
+            checkingAgentStatuses={checkingAgentStatuses}
+            onRefreshAgentStatuses={onRefreshAgentStatuses}
+            onCreateShell={onCreate}
+            onCreateAgent={onCreateAgent}
+          />
         </div>
-        <button
-          type="button"
-          aria-label="New terminal session"
-          disabled={disabled || creating}
-          className="flex size-6 shrink-0 items-center justify-center rounded-md disabled:opacity-50"
-          style={{ background: "var(--accent)", color: "var(--text-on-accent)" }}
-          onClick={onCreate}
-        >
-          <Plus size={16} aria-hidden="true" />
-        </button>
-      </div>
-      <ul aria-label="Terminal sessions" className="min-h-0 flex-1 overflow-y-auto pb-4">
-        {sessions.map((session) => {
-          const selected = selectedName === session.name;
-          return (
-            <li key={session.name} className="group/session relative shrink-0 border-b" style={{ borderColor: "var(--border-subtle)" }}>
-              <button
-                type="button"
-                aria-label={`Open ${session.name}`}
-                aria-current={selected || undefined}
-                className="flex min-h-11 w-full min-w-0 items-center gap-1.5 px-4 py-3 pr-24 text-left hover:bg-[var(--bg-hover)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[var(--accent)]"
-                style={{ background: selected ? "var(--bg-hover)" : "transparent" }}
-                onClick={() => onSelect(session)}
-              >
-                <span
-                  data-terminal-session-status={isActive(session) ? "active" : "inactive"}
-                  className="size-2.5 shrink-0 rounded-full"
-                  style={{ background: isActive(session) ? "var(--success)" : "var(--text-tertiary)" }}
-                />
-                <span className="min-w-0 flex-1 truncate text-sm leading-5" style={{ color: "var(--text-primary)" }}>
-                  {session.name}
-                </span>
-              </button>
-              <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-xs transition-opacity group-hover/session:opacity-0" style={{ color: "var(--text-tertiary)" }}>
-                {relativeSessionActivity(session.updatedAt)}
-              </span>
-              <button
-                type="button"
-                aria-label={`Delete ${session.name}`}
-                className="absolute right-3 top-1/2 z-10 flex size-6 -translate-y-1/2 items-center justify-center rounded-md bg-[var(--bg-surface)] text-[var(--text-tertiary)] opacity-0 transition-opacity hover:bg-[var(--bg-hover)] hover:text-[var(--danger)] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent)] group-hover/session:opacity-100"
-                onClick={() => onDelete(session)}
-              >
-                <Trash2 size={14} aria-hidden="true" />
-              </button>
-            </li>
-          );
-        })}
-      </ul>
+        <ul aria-label="Terminal sessions" className="min-h-0 flex-1 overflow-y-auto pb-4">
+          {sessions.map((session) => {
+            const selected = selectedName === session.name;
+            const metadata = agentMetadata(session);
+            const renaming = renamingName === session.name;
+            return (
+              <li key={session.name} className="group/session relative shrink-0 border-b" style={{ borderColor: "var(--border-subtle)" }}>
+                {renaming ? (
+                  <div className="flex min-h-16 flex-col justify-center gap-1 px-3 py-2">
+                    <div className="flex items-center gap-1">
+                      <input
+                        autoFocus
+                        aria-label="Terminal session name"
+                        value={renameDraft}
+                        disabled={disabled}
+                        className="h-7 min-w-0 flex-1 rounded-md border bg-transparent px-2 font-mono text-xs outline-none focus:ring-1 focus:ring-[var(--accent)]"
+                        style={{ borderColor: "var(--border-subtle)", color: "var(--text-primary)" }}
+                        onChange={(event) => onRenameDraft(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") onCommitRename();
+                          if (event.key === "Escape") onCancelRename();
+                        }}
+                      />
+                      <button type="button" aria-label="Save terminal session name" className="flex size-7 items-center justify-center rounded-md hover:bg-[var(--bg-hover)]" onClick={onCommitRename}>
+                        <Check size={13} />
+                      </button>
+                      <button type="button" aria-label="Cancel terminal session rename" className="flex size-7 items-center justify-center rounded-md hover:bg-[var(--bg-hover)]" onClick={onCancelRename}>
+                        <X size={13} />
+                      </button>
+                    </div>
+                    {renameError ? <span className="text-[10px]" style={{ color: "var(--danger)" }}>{renameError}</span> : null}
+                  </div>
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      aria-label={`Open ${session.name}`}
+                      aria-current={selected || undefined}
+                      className="flex min-h-16 w-full min-w-0 items-start gap-2 px-4 py-3 pr-10 text-left hover:bg-[var(--bg-hover)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[var(--accent)]"
+                      style={{ background: selected ? "var(--bg-hover)" : "transparent" }}
+                      onClick={() => onSelect(session)}
+                    >
+                      <span
+                        data-terminal-session-status={isActive(session) ? "active" : "inactive"}
+                        className="mt-1.5 size-2.5 shrink-0 rounded-full"
+                        style={{ background: isActive(session) ? "var(--success)" : "var(--text-tertiary)" }}
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="flex min-w-0 items-center justify-between gap-2">
+                          <span className="truncate text-sm leading-5" style={{ color: "var(--text-primary)" }}>{session.name}</span>
+                          <span className="shrink-0 text-[10px]" style={{ color: "var(--text-tertiary)" }}>{relativeSessionActivity(session.updatedAt)}</span>
+                        </span>
+                        {metadata ? <span className="mt-0.5 block truncate text-[10px] leading-4" style={{ color: "var(--text-secondary)" }}>{metadata}</span> : null}
+                      </span>
+                    </button>
+                    <SessionActions
+                      session={session}
+                      disabled={disabled}
+                      onRename={() => onRename(session)}
+                      onCopy={() => onCopyConnectCommand(session)}
+                      onDelete={() => onDelete(session)}
+                    />
+                    <button
+                      type="button"
+                      aria-label={`Delete ${session.name}`}
+                      disabled={disabled}
+                      className="absolute right-9 top-3 z-10 flex size-7 items-center justify-center rounded-md bg-[var(--bg-surface)] text-[var(--text-tertiary)] opacity-0 transition-opacity hover:bg-[var(--bg-hover)] hover:text-[var(--danger)] focus-visible:opacity-100 group-hover/session:opacity-100"
+                      onClick={() => onDelete(session)}
+                    >
+                      <Trash2 size={13} aria-hidden="true" />
+                    </button>
+                  </>
+                )}
+              </li>
+            );
+          })}
+        </ul>
       </aside>
     </OSWindowSafeView>
+  );
+}
+
+function SessionActions({ session, disabled, onRename, onCopy, onDelete }: {
+  session: ShellSessionSummary;
+  disabled: boolean;
+  onRename: () => void;
+  onCopy: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button
+          type="button"
+          aria-label={`More actions for ${session.name}`}
+          disabled={disabled}
+          className="absolute right-2 top-3 z-10 flex size-7 items-center justify-center rounded-md bg-[var(--bg-surface)] text-[var(--text-tertiary)] opacity-0 transition-opacity hover:bg-[var(--bg-active)] focus-visible:opacity-100 group-hover/session:opacity-100"
+        >
+          <MoreHorizontal size={14} aria-hidden="true" />
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          aria-label={`Actions for ${session.name}`}
+          align="end"
+          sideOffset={5}
+          className="fade-in min-w-[200px] rounded-lg border p-1"
+          style={{ zIndex: DESKTOP_Z_INDEX.popover, background: "var(--bg-overlay)", borderColor: "var(--border-default)", boxShadow: "var(--shadow-2)" }}
+        >
+          <SessionAction icon={<Edit3 size={13} />} label="Rename" onSelect={onRename} />
+          <SessionAction icon={<Clipboard size={13} />} label="Copy connect command" onSelect={onCopy} />
+          <DropdownMenu.Separator className="my-1 h-px" style={{ background: "var(--border-subtle)" }} />
+          <SessionAction icon={<Trash2 size={13} />} label="Delete" danger onSelect={onDelete} />
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}
+
+function SessionAction({ icon, label, danger = false, onSelect }: { icon: React.ReactNode; label: string; danger?: boolean; onSelect: () => void }) {
+  return (
+    <DropdownMenu.Item
+      onSelect={onSelect}
+      className="flex cursor-default items-center gap-2 rounded-md px-2.5 py-1.5 text-sm outline-none data-[highlighted]:bg-[var(--bg-hover)]"
+      style={{ color: danger ? "var(--danger)" : "var(--text-primary)" }}
+    >
+      {icon}
+      {label}
+    </DropdownMenu.Item>
   );
 }

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -125,14 +125,28 @@ export default function TerminalsTab({
   const [renameDraft, setRenameDraft] = useState("");
   const [renameError, setRenameError] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<ShellSessionSummary | null>(null);
-  const [agentStatuses, setAgentStatuses] = useState({ ...UNKNOWN_TERMINAL_AGENT_STATUSES });
-  const [checkingAgentStatuses, setCheckingAgentStatuses] = useState(false);
+  const [agentInventory, setAgentInventory] = useState(() => ({
+    api,
+    runtimeSlot,
+    statuses: { ...UNKNOWN_TERMINAL_AGENT_STATUSES },
+    checking: false,
+  }));
   const agentStatusRequestRef = useRef(0);
+  const agentInventoryIsCurrent = agentInventory.api === api
+    && agentInventory.runtimeSlot === runtimeSlot;
+  const agentStatuses = agentInventoryIsCurrent
+    ? agentInventory.statuses
+    : UNKNOWN_TERMINAL_AGENT_STATUSES;
+  const checkingAgentStatuses = agentInventoryIsCurrent && agentInventory.checking;
 
   useEffect(() => {
     agentStatusRequestRef.current += 1;
-    setAgentStatuses({ ...UNKNOWN_TERMINAL_AGENT_STATUSES });
-    setCheckingAgentStatuses(false);
+    setAgentInventory({
+      api,
+      runtimeSlot,
+      statuses: { ...UNKNOWN_TERMINAL_AGENT_STATUSES },
+      checking: false,
+    });
   }, [api, runtimeSlot]);
 
   useEffect(() => {
@@ -209,20 +223,38 @@ export default function TerminalsTab({
     if (!api || checkingAgentStatuses) return;
     const requestId = agentStatusRequestRef.current + 1;
     agentStatusRequestRef.current = requestId;
-    setCheckingAgentStatuses(true);
+    const requestApi = api;
+    const requestRuntimeSlot = runtimeSlot;
+    setAgentInventory((current) => ({
+      api: requestApi,
+      runtimeSlot: requestRuntimeSlot,
+      statuses: current.api === requestApi && current.runtimeSlot === requestRuntimeSlot
+        ? current.statuses
+        : { ...UNKNOWN_TERMINAL_AGENT_STATUSES },
+      checking: true,
+    }));
     try {
-      const statuses = parseTerminalAgentStatuses(await api.get("/api/agents"));
+      const statuses = parseTerminalAgentStatuses(await requestApi.get("/api/agents"));
       if (agentStatusRequestRef.current === requestId) {
-        setAgentStatuses(statuses);
+        setAgentInventory({
+          api: requestApi,
+          runtimeSlot: requestRuntimeSlot,
+          statuses,
+          checking: true,
+        });
       }
     } catch (err: unknown) {
       console.warn("[terminal] Failed to load agent status:", err instanceof Error ? err.message : String(err));
     } finally {
       if (agentStatusRequestRef.current === requestId) {
-        setCheckingAgentStatuses(false);
+        setAgentInventory((current) => (
+          current.api === requestApi && current.runtimeSlot === requestRuntimeSlot
+            ? { ...current, checking: false }
+            : current
+        ));
       }
     }
-  }, [api, checkingAgentStatuses]);
+  }, [api, checkingAgentStatuses, runtimeSlot]);
 
   const createAgentSession = async (option: TerminalAgentOption, action: TerminalAgentMenuAction) => {
     if (!api || creating) return;

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -34,6 +34,13 @@ import { TerminalSessionSidebar } from "./TerminalSessionSidebar";
 import { relativeSessionActivity } from "./terminal-session-activity";
 import { useTerminalAppearance } from "../../stores/terminal-appearance";
 import { DesktopTerminalThemePicker } from "./DesktopTerminalThemePicker";
+import {
+  parseTerminalAgentStatuses,
+  terminalAgentVisibleInstallCommand,
+  UNKNOWN_TERMINAL_AGENT_STATUSES,
+  type TerminalAgentMenuAction,
+  type TerminalAgentOption,
+} from "./terminal-agent-options";
 
 const RENAME_HELP = "Use lowercase letters, numbers, and hyphens. Start and end with a letter or number.";
 const SESSION_START_FORMATTER = new Intl.DateTimeFormat(undefined, {
@@ -76,87 +83,8 @@ function sessionStart(createdAt: string | undefined): string {
   return SESSION_START_FORMATTER.format(timestamp);
 }
 
-function placementFor(shell: ShellSessionSummary, openShellNames: Set<string>): ShellSessionPlacement {
-  return shell.placement ?? (openShellNames.has(shell.name) ? "active" : "background");
-}
-
 function normalizeBusyNames(names: string[]): string[] {
   return names.filter((name, index) => name.length > 0 && names.indexOf(name) === index);
-}
-
-function TerminalAppTabs({
-  openedSessionNames,
-  selectedName,
-  onSelectOverview,
-  onSelectSession,
-  onCloseSession,
-}: {
-  openedSessionNames: string[];
-  selectedName: string | null;
-  onSelectOverview: () => void;
-  onSelectSession: (name: string) => void;
-  onCloseSession: (name: string) => void;
-}) {
-  if (openedSessionNames.length === 0) return null;
-  return (
-    <div
-      role="tablist"
-      aria-label="Terminal app tabs"
-      className="flex h-9 shrink-0 items-end gap-1 overflow-x-auto border-b px-2 pt-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-      style={{ borderColor: "var(--border-subtle)", background: "var(--bg-sunken)" }}
-    >
-      <button
-        type="button"
-        role="tab"
-        aria-label="Terminal sessions"
-        aria-selected={selectedName === null}
-        className="flex h-7 shrink-0 items-center gap-1.5 rounded-t-md border px-2.5 text-xs"
-        style={{
-          borderColor: selectedName === null ? "var(--border-subtle)" : "transparent",
-          borderBottomColor: selectedName === null ? "var(--bg-surface)" : "transparent",
-          background: selectedName === null ? "var(--bg-surface)" : "transparent",
-          color: selectedName === null ? "var(--text-primary)" : "var(--text-secondary)",
-        }}
-        onClick={onSelectOverview}
-      >
-        <SquareTerminal size={12} aria-hidden="true" /> Sessions
-      </button>
-      {openedSessionNames.map((name) => {
-        const selected = selectedName === name;
-        return (
-          <div
-            key={name}
-            className="group flex h-7 min-w-[116px] max-w-[190px] items-center rounded-t-md border pl-2.5 pr-1"
-            style={{
-              borderColor: selected ? "var(--border-subtle)" : "transparent",
-              borderBottomColor: selected ? "var(--bg-surface)" : "transparent",
-              background: selected ? "var(--bg-surface)" : "transparent",
-              color: selected ? "var(--text-primary)" : "var(--text-secondary)",
-            }}
-          >
-            <button
-              type="button"
-              role="tab"
-              aria-label={name}
-              aria-selected={selected}
-              className="min-w-0 flex-1 truncate text-left font-mono text-[11px]"
-              onClick={() => onSelectSession(name)}
-            >
-              {name}
-            </button>
-            <button
-              type="button"
-              aria-label={`Close ${name} terminal tab`}
-              className="flex size-5 shrink-0 items-center justify-center rounded opacity-60 hover:bg-[var(--bg-hover)] hover:opacity-100"
-              onClick={() => onCloseSession(name)}
-            >
-              <X size={11} aria-hidden="true" />
-            </button>
-          </div>
-        );
-      })}
-    </div>
-  );
 }
 
 // react-doctor-disable-next-line react-doctor/no-giant-component, react-doctor/prefer-useReducer -- TerminalsTab is the cohesive shell-session workspace: network load/create, selection, rename, delete confirmation, search, and drag refs are independent UI concerns. A reducer would couple unrelated state transitions without reducing render risk; extracting subcomponents below keeps the row/empty states isolated.
@@ -178,7 +106,6 @@ export default function TerminalsTab({
   const create = useShellSessions((s) => s.create);
   const deleteSession = useShellSessions((s) => s.deleteSession);
   const rename = useShellSessions((s) => s.rename);
-  const reorder = useShellSessions((s) => s.reorder);
   const patchUiState = useShellSessions((s) => s.patchUiState);
   const tabs = useTabs((s) => s.tabs);
   const recordRecentTerminal = useTabs((s) => s.recordRecentTerminal);
@@ -192,16 +119,14 @@ export default function TerminalsTab({
   const [selectedName, setSelectedName] = useState<string | null>(() => mostRecentShell(shells)?.name ?? null);
   const [liveSessionName, setLiveSessionName] = useState<string | null>(null);
   const [openedSessionNames, setOpenedSessionNames] = useState<string[]>([]);
-  const [searchOpen, setSearchOpen] = useState(false);
-  const [query, setQuery] = useState("");
   const [busyNames, setBusyNames] = useState<string[]>([]);
   const [actionError, setActionError] = useState<string | null>(null);
   const [renamingName, setRenamingName] = useState<string | null>(null);
   const [renameDraft, setRenameDraft] = useState("");
   const [renameError, setRenameError] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<ShellSessionSummary | null>(null);
-  const draggingNameRef = useRef<string | null>(null);
-  const draggingPlacementRef = useRef<ShellSessionPlacement | null>(null);
+  const [agentStatuses, setAgentStatuses] = useState({ ...UNKNOWN_TERMINAL_AGENT_STATUSES });
+  const [checkingAgentStatuses, setCheckingAgentStatuses] = useState(false);
 
   useEffect(() => {
     void loadTerminalAppearance(api);
@@ -218,14 +143,6 @@ export default function TerminalsTab({
     setLiveSessionName((current) => current && liveNames.has(current) ? current : null);
     setSelectedName((current) => current && liveNames.has(current) ? current : null);
   }, [authoritativeRevision, error, loading, reconcileRecentTerminals, shells]);
-
-  const openShellNames = useMemo(
-    () => new Set([
-      ...tabs.flatMap((tab) => (tab.kind === "terminal" && tab.sessionName ? [tab.sessionName] : [])),
-      ...(liveSessionName ? [liveSessionName] : []),
-    ]),
-    [liveSessionName, tabs],
-  );
 
   const latestShell = useMemo(() => mostRecentShell(shells), [shells]);
   const selected = selectedName && shells.some((shell) => shell.name === selectedName)
@@ -281,6 +198,33 @@ export default function TerminalsTab({
     showShellDetail(created);
   };
 
+  const refreshAgentStatuses = useCallback(async () => {
+    if (!api || checkingAgentStatuses) return;
+    setCheckingAgentStatuses(true);
+    try {
+      setAgentStatuses(parseTerminalAgentStatuses(await api.get("/api/agents")));
+    } catch (err: unknown) {
+      console.warn("[terminal] Failed to load agent status:", err instanceof Error ? err.message : String(err));
+    } finally {
+      setCheckingAgentStatuses(false);
+    }
+  }, [api, checkingAgentStatuses]);
+
+  const createAgentSession = async (option: TerminalAgentOption, action: TerminalAgentMenuAction) => {
+    if (!api || creating) return;
+    setActionError(null);
+    const created = await create(api, {
+      cmd: action === "launch" ? option.launchCommand : terminalAgentVisibleInstallCommand(option),
+      ...(action === "launch" ? { agent: option.id } : {}),
+    });
+    if (!created) {
+      setActionError(action === "launch" ? `Could not start ${option.label}` : `Could not install ${option.label}`);
+      return;
+    }
+    recordRecentTerminal(created.name, created.name);
+    showShellDetail(created);
+  };
+
   const showShellDetail = useCallback((shell: ShellSessionSummary) => {
     setOpenedSessionNames((current) => [
       ...current.filter((name) => name !== shell.name),
@@ -329,8 +273,6 @@ export default function TerminalsTab({
     terminalSessionRequest,
   ]);
 
-  const openShellInTab = (shell: ShellSessionSummary) => showShellDetail(shell);
-
   const closeShellTab = (name: string) => {
     const remaining = openedSessionNames.filter((openedName) => openedName !== name);
     setOpenedSessionNames(remaining);
@@ -338,24 +280,6 @@ export default function TerminalsTab({
     const nextName = remaining.at(-1) ?? null;
     setSelectedName(nextName);
     setLiveSessionName(nextName);
-  };
-
-  const moveShell = async (shell: ShellSessionSummary, placement: ShellSessionPlacement) => {
-    if (!api || !markShellBusy(shell.name)) return;
-    setActionError(null);
-    const patch = placement === "active" && shell.latestSeq !== undefined && shell.latestSeq !== null
-      ? { placement, lastSeenSeq: shell.latestSeq }
-      : { placement };
-    const ok = await patchUiState(api, shell.name, patch);
-    if (!ok) setActionError("Could not update shell");
-    if (placement === "active" && ok) {
-      showShellDetail(
-        shell.latestSeq !== undefined && shell.latestSeq !== null
-          ? { ...shell, placement, lastSeenSeq: shell.latestSeq }
-          : { ...shell, placement },
-      );
-    }
-    clearShellBusy(shell.name);
   };
 
   const copyAttachCommand = async (shell: ShellSessionSummary) => {
@@ -421,26 +345,6 @@ export default function TerminalsTab({
     setLiveSessionName((current) => current === name ? null : current);
   };
 
-  const finishDrag = () => {
-    draggingNameRef.current = null;
-    draggingPlacementRef.current = null;
-  };
-
-  const dropOnShell = (target: ShellSessionSummary) => {
-    const draggingName = draggingNameRef.current;
-    const draggingPlacement = draggingPlacementRef.current;
-    if (!api || !draggingName || draggingName === target.name) {
-      finishDrag();
-      return;
-    }
-    if (draggingPlacement !== placementFor(target, openShellNames)) {
-      finishDrag();
-      return;
-    }
-    void reorder(api, draggingName, target.name);
-    finishDrag();
-  };
-
   const overviewSelected = selected === null;
 
   return (
@@ -458,8 +362,26 @@ export default function TerminalsTab({
           selectedName={selectedName}
           creating={creating}
           disabled={!api}
+          agentStatuses={agentStatuses}
+          checkingAgentStatuses={checkingAgentStatuses}
+          renamingName={renamingName}
+          renameDraft={renameDraft}
+          renameError={renameError}
           onCreate={() => void createShell()}
+          onCreateAgent={(option, action) => void createAgentSession(option, action)}
+          onRefreshAgentStatuses={() => void refreshAgentStatuses()}
           onSelect={showShellDetail}
+          onRename={startRename}
+          onRenameDraft={(value) => {
+            setRenameDraft(value);
+            setRenameError(null);
+          }}
+          onCommitRename={() => void commitRename()}
+          onCancelRename={() => {
+            setRenamingName(null);
+            setRenameError(null);
+          }}
+          onCopyConnectCommand={(shell) => void copyAttachCommand(shell)}
           onDelete={setDeleteTarget}
         />
       </div>
@@ -526,7 +448,7 @@ export default function TerminalsTab({
               style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
             >
               <div className="min-w-0 flex-1">
-                <h1 className="truncate text-xs font-medium leading-[19.5px]" style={{ color: "var(--text-primary)" }}>{shellTitle(shell)}</h1>
+                <h1 className="truncate text-xs font-medium leading-[19.5px]" style={{ color: "var(--text-primary)" }}>{shell.name}</h1>
                 <p className="mt-1 truncate text-xs leading-4 tracking-[0.12px]" style={{ color: "var(--text-tertiary)" }}>
                   Started at {sessionStart(shell.createdAt)} · {runtimeSlot === "primary" ? "main computer" : runtimeSlot}
                 </p>

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -127,6 +127,13 @@ export default function TerminalsTab({
   const [deleteTarget, setDeleteTarget] = useState<ShellSessionSummary | null>(null);
   const [agentStatuses, setAgentStatuses] = useState({ ...UNKNOWN_TERMINAL_AGENT_STATUSES });
   const [checkingAgentStatuses, setCheckingAgentStatuses] = useState(false);
+  const agentStatusRequestRef = useRef(0);
+
+  useEffect(() => {
+    agentStatusRequestRef.current += 1;
+    setAgentStatuses({ ...UNKNOWN_TERMINAL_AGENT_STATUSES });
+    setCheckingAgentStatuses(false);
+  }, [api, runtimeSlot]);
 
   useEffect(() => {
     void loadTerminalAppearance(api);
@@ -200,13 +207,20 @@ export default function TerminalsTab({
 
   const refreshAgentStatuses = useCallback(async () => {
     if (!api || checkingAgentStatuses) return;
+    const requestId = agentStatusRequestRef.current + 1;
+    agentStatusRequestRef.current = requestId;
     setCheckingAgentStatuses(true);
     try {
-      setAgentStatuses(parseTerminalAgentStatuses(await api.get("/api/agents")));
+      const statuses = parseTerminalAgentStatuses(await api.get("/api/agents"));
+      if (agentStatusRequestRef.current === requestId) {
+        setAgentStatuses(statuses);
+      }
     } catch (err: unknown) {
       console.warn("[terminal] Failed to load agent status:", err instanceof Error ? err.message : String(err));
     } finally {
-      setCheckingAgentStatuses(false);
+      if (agentStatusRequestRef.current === requestId) {
+        setCheckingAgentStatuses(false);
+      }
     }
   }, [api, checkingAgentStatuses]);
 

--- a/desktop/src/renderer/src/features/terminal/terminal-agent-options.ts
+++ b/desktop/src/renderer/src/features/terminal/terminal-agent-options.ts
@@ -1,0 +1,97 @@
+import { CODEX_VERIFIED_NPM_PACKAGE } from "@matrix-os/contracts";
+
+export type TerminalAgentId = "claude" | "codex" | "opencode" | "pi";
+export type TerminalAgentInstallState = "installed" | "missing" | "unknown";
+export type TerminalAgentMenuAction = "launch" | "install";
+
+export interface TerminalAgentOption {
+  id: TerminalAgentId;
+  label: string;
+  shortLabel: string;
+  launchCommand: string;
+  installPackage: string;
+  installFlags?: string[];
+}
+
+export const TERMINAL_AGENT_OPTIONS: readonly TerminalAgentOption[] = [
+  {
+    id: "claude",
+    label: "Claude Code",
+    shortLabel: "Claude",
+    launchCommand: "claude",
+    installPackage: "@anthropic-ai/claude-code@latest",
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    shortLabel: "Codex",
+    launchCommand: "codex",
+    installPackage: CODEX_VERIFIED_NPM_PACKAGE,
+  },
+  {
+    id: "opencode",
+    label: "OpenCode",
+    shortLabel: "OpenCode",
+    launchCommand: "opencode",
+    installPackage: "opencode-ai@latest",
+  },
+  {
+    id: "pi",
+    label: "Pi",
+    shortLabel: "Pi",
+    launchCommand: "pi",
+    installPackage: "@earendil-works/pi-coding-agent@latest",
+    installFlags: ["--ignore-scripts"],
+  },
+];
+
+export const UNKNOWN_TERMINAL_AGENT_STATUSES: Record<TerminalAgentId, TerminalAgentInstallState> = {
+  claude: "unknown",
+  codex: "unknown",
+  opencode: "unknown",
+  pi: "unknown",
+};
+
+export function parseTerminalAgentStatuses(value: unknown): Record<TerminalAgentId, TerminalAgentInstallState> {
+  const statuses = { ...UNKNOWN_TERMINAL_AGENT_STATUSES };
+  if (!value || typeof value !== "object" || !("agents" in value) || !Array.isArray(value.agents)) {
+    return statuses;
+  }
+  for (const candidate of value.agents) {
+    if (!candidate || typeof candidate !== "object") continue;
+    const record = candidate as { id?: unknown; installState?: unknown; installed?: unknown };
+    const option = TERMINAL_AGENT_OPTIONS.find(({ id }) => id === record.id);
+    if (!option) continue;
+    if (record.installState === "installed" || record.installState === "missing" || record.installState === "unknown") {
+      statuses[option.id] = record.installState;
+    } else if (record.installed === true) {
+      statuses[option.id] = "installed";
+    } else if (record.installed === false) {
+      statuses[option.id] = "missing";
+    }
+  }
+  return statuses;
+}
+
+export function terminalAgentAction(state: TerminalAgentInstallState): TerminalAgentMenuAction {
+  return state === "missing" ? "install" : "launch";
+}
+
+export function terminalAgentVisibleInstallCommand(option: TerminalAgentOption): string {
+  const flags = option.installFlags?.join(" ") ?? "";
+  const extraFlags = flags ? `${flags} ` : "";
+  const command = [
+    'export MATRIX_NODE_PREFIX="${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}"',
+    'export PATH="$MATRIX_NODE_PREFIX/bin:$PATH"',
+    `npm install -g ${extraFlags}--prefix "$MATRIX_NODE_PREFIX" ${option.installPackage}`,
+  ].join("; ");
+  return `sh -lc ${shellQuote(`printf '%s\\n' ${shellQuote(command)}; ${command}`)}`;
+}
+
+export function terminalAgentLabel(agent: TerminalAgentId): string {
+  return TERMINAL_AGENT_OPTIONS.find((option) => option.id === agent)?.shortLabel ?? agent;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/desktop/src/renderer/src/features/terminal/terminal-agent-options.ts
+++ b/desktop/src/renderer/src/features/terminal/terminal-agent-options.ts
@@ -73,7 +73,8 @@ export function parseTerminalAgentStatuses(value: unknown): Record<TerminalAgent
   return statuses;
 }
 
-export function terminalAgentAction(state: TerminalAgentInstallState): TerminalAgentMenuAction {
+export function terminalAgentAction(state: TerminalAgentInstallState): TerminalAgentMenuAction | null {
+  if (state === "unknown") return null;
   return state === "missing" ? "install" : "launch";
 }
 

--- a/desktop/src/renderer/src/stores/shell-sessions.ts
+++ b/desktop/src/renderer/src/stores/shell-sessions.ts
@@ -33,6 +33,10 @@ export interface ShellSessionSummary {
 }
 
 export type ShellUiStatePatch = Partial<Pick<ShellSessionSummary, "placement" | "lastSeenSeq">>;
+export interface ShellSessionCreateOptions {
+  cmd?: string;
+  agent?: NonNullable<ShellSessionSummary["agent"]>;
+}
 
 interface ShellSessionsState {
   sessions: ShellSessionSummary[];
@@ -42,7 +46,7 @@ interface ShellSessionsState {
   loadSequence: number;
   authoritativeRevision: number;
   load(api: ApiClient): Promise<ShellSessionSummary[] | null>;
-  create(api: ApiClient): Promise<ShellSessionSummary | null>;
+  create(api: ApiClient, options?: ShellSessionCreateOptions): Promise<ShellSessionSummary | null>;
   adoptCreatedSession(name: string): void;
   deleteSession(api: ApiClient, name: string): Promise<boolean>;
   rename(api: ApiClient, name: string, nextName: string): Promise<boolean>;
@@ -259,7 +263,7 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
     }
   },
 
-  create: async (api) => {
+  create: async (api, options = {}) => {
     if (get().creating) return null;
     // A computer switch advances the runtime generation and clears this store;
     // a create that settles afterwards belongs to the previous computer and
@@ -272,6 +276,8 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
         const response = await api.post<{ name?: unknown }>("/api/terminal/sessions", {
           name,
           cwd: DEFAULT_CWD,
+          ...(options.cmd ? { cmd: options.cmd } : {}),
+          ...(options.agent ? { agent: options.agent } : {}),
         });
         if (!isCurrentRuntimeGeneration(generation)) return null;
         const createdName = typeof response.name === "string" && isValidShellSessionName(response.name) ? response.name : name;
@@ -280,6 +286,7 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
           status: "active",
           placement: "active",
           attachCommand: shellConnectCommand(createdName),
+          ...(options.agent ? { agent: options.agent } : {}),
         };
         const refreshSequence = get().loadSequence + 1;
         set({ loadSequence: refreshSequence });

--- a/tests/desktop/native-desktop-shell.test.tsx
+++ b/tests/desktop/native-desktop-shell.test.tsx
@@ -766,9 +766,12 @@ describe("native desktop shell", () => {
     const workWindow = screen.getByRole("dialog", { name: "Chat window" });
     const terminalWindow = screen.getByRole("dialog", { name: "Terminal window" });
     const workChrome = workWindow.querySelector<HTMLElement>('[data-os-window-chrome-placement="sidebar"]');
-    const terminalChrome = terminalWindow.querySelector<HTMLElement>('[data-os-window-chrome-placement="sidebar"]');
+    const terminalChrome = terminalWindow.querySelector<HTMLElement>('[data-os-window-chrome-placement="full-width"]');
     expect(workChrome).toBeNull();
-    expect(terminalChrome?.style.width).toBe("280px");
+    expect(terminalChrome?.style.width).toBe("100%");
+    expect(terminalChrome?.textContent).toContain("Terminal");
+    expect((terminalWindow.querySelector("[data-os-window-gesture-layer]") as HTMLElement).style.width).toBe("100%");
+    expect((terminalWindow.querySelector('[data-os-window-safe-view="pane"]') as HTMLElement).style.paddingTop).toBe("48px");
     expect(screen.getByText("Chat content")).toBeTruthy();
     expect(screen.getByText("Terminal content")).toBeTruthy();
     expect(screen.getByTestId("desktop-surface-content-work").hasAttribute("inert")).toBe(true);

--- a/tests/desktop/shell-sessions-store.test.ts
+++ b/tests/desktop/shell-sessions-store.test.ts
@@ -220,6 +220,26 @@ describe("useShellSessions", () => {
     expect(useShellSessions.getState().sessions.map((session) => session.name)).toEqual(["matrix-created"]);
   });
 
+  it("creates agent sessions with the canonical command and agent metadata", async () => {
+    const post = vi.fn().mockResolvedValue({ name: "matrix-codex" });
+    const get = vi.fn().mockResolvedValue({
+      sessions: [{ name: "matrix-codex", status: "active", agent: "codex" }],
+    });
+
+    const created = await useShellSessions.getState().create(makeApi({ post, get }), {
+      cmd: "codex",
+      agent: "codex",
+    });
+
+    expect(created).toMatchObject({ name: "matrix-codex", agent: "codex" });
+    expect(post).toHaveBeenCalledWith("/api/terminal/sessions", {
+      name: expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
+      cwd: "projects",
+      cmd: "codex",
+      agent: "codex",
+    });
+  });
+
   it("uses fresh two-word shell names only after repeated collisions", async () => {
     const post = vi
       .fn()

--- a/tests/desktop/terminal-session-sidebar.test.tsx
+++ b/tests/desktop/terminal-session-sidebar.test.tsx
@@ -26,7 +26,7 @@ describe("TerminalSessionSidebar", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Terminal" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "New terminal session" }));
+    fireEvent.click(screen.getByRole("button", { name: "New shell session" }));
     expect(onCreate).toHaveBeenCalledOnce();
     fireEvent.click(screen.getByRole("button", { name: "Open swift-willow" }));
     expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ name: "swift-willow" }));

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -648,6 +648,53 @@ describe("TerminalsTab", () => {
     expect(newApi.get).toHaveBeenCalledWith("/api/agents");
   });
 
+  it("masks the previous runtime inventory before passive invalidation runs", async () => {
+    const oldApi = {
+      get: vi.fn(async (path: string) => (
+        path === "/api/agents"
+          ? installedAgents
+          : { preferences: { shellThemeId: "dark" } }
+      )),
+      put: terminalPreferencesPut,
+    };
+    const newApi = {
+      get: vi.fn(async (path: string) => (
+        path === "/api/agents"
+          ? { agents: [{ id: "codex", installState: "missing" }] }
+          : { preferences: { shellThemeId: "dark" } }
+      )),
+      put: terminalPreferencesPut,
+    };
+    let codexLabelDuringRuntimeCommit = "";
+
+    function RuntimeCommitObserver() {
+      const runtimeSlot = useConnection((state) => state.runtimeSlot);
+      React.useLayoutEffect(() => {
+        if (runtimeSlot !== "secondary") return;
+        codexLabelDuringRuntimeCommit = screen
+          .getAllByRole("menuitem")
+          .find((item) => item.textContent?.includes("Codex"))
+          ?.textContent ?? "";
+      }, [runtimeSlot]);
+      return null;
+    }
+
+    useConnection.setState({ api: oldApi as never, runtimeSlot: "primary" });
+    useShellSessions.setState({ sessions: [{ name: "matrix-main", status: "active" }] });
+    render(
+      <Tooltip.Provider>
+        <TerminalsTab />
+        <RuntimeCommitObserver />
+      </Tooltip.Provider>,
+    );
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Choose session type" }), { button: 0, ctrlKey: false });
+    await waitFor(() => expect(screen.getByRole("menuitem", { name: /Codex/ }).textContent).not.toContain("Unavailable"));
+
+    act(() => useConnection.setState({ api: newApi as never, runtimeSlot: "secondary" }));
+
+    expect(codexLabelDuringRuntimeCommit).toContain("Unavailable");
+  });
+
   it("shows the running agent and its current activity in each session row", () => {
     useShellSessions.setState({
       sessions: [{

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -13,8 +13,21 @@ import { useAppearance } from "../../desktop/src/renderer/src/stores/appearance"
 import { useTerminalAppearance } from "../../desktop/src/renderer/src/stores/terminal-appearance";
 
 const terminalMounts = vi.hoisted(() => new Map<string, number>());
-const terminalPreferencesGet = vi.fn(async () => ({ preferences: { shellThemeId: "dark" } }));
+const installedAgents = {
+  agents: ["claude", "codex", "opencode", "pi"].map((id) => ({ id, installState: "installed" })),
+};
+const terminalPreferencesGet = vi.fn(async (path: string) => (
+  path === "/api/agents" ? installedAgents : { preferences: { shellThemeId: "dark" } }
+));
 const terminalPreferencesPut = vi.fn(async () => ({ preferences: { shellThemeId: "dark" } }));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
 
 vi.mock("../../desktop/src/renderer/src/features/terminal/TerminalView", () => ({
   default: ({
@@ -56,7 +69,10 @@ function renderTab(active = true) {
 describe("TerminalsTab", () => {
   beforeEach(() => {
     terminalMounts.clear();
-    terminalPreferencesGet.mockClear();
+    terminalPreferencesGet.mockReset();
+    terminalPreferencesGet.mockImplementation(async (path: string) => (
+      path === "/api/agents" ? installedAgents : { preferences: { shellThemeId: "dark" } }
+    ));
     terminalPreferencesPut.mockClear();
     window.operator = {
       invoke: vi.fn(async () => ({ ok: true })),
@@ -571,6 +587,65 @@ describe("TerminalsTab", () => {
       cmd: "codex",
       agent: "codex",
     }));
+  });
+
+  it("keeps agents disabled when installation inventory is unresolved", async () => {
+    const createShell = vi.fn().mockResolvedValue({ name: "matrix-created", status: "active" });
+    terminalPreferencesGet.mockImplementation(async (path: string) => (
+      path === "/api/agents" ? { agents: [] } : { preferences: { shellThemeId: "dark" } }
+    ));
+    useShellSessions.setState({
+      create: createShell,
+      sessions: [{ name: "matrix-main", status: "active" }],
+    });
+
+    renderTab();
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Choose session type" }), { button: 0, ctrlKey: false });
+
+    const codex = await screen.findByRole("menuitem", { name: /Codex.*Unavailable/ });
+    expect(codex.getAttribute("aria-disabled")).toBe("true");
+    fireEvent.click(codex);
+    expect(createShell).not.toHaveBeenCalled();
+  });
+
+  it("ignores agent inventory that settles after the selected runtime changes", async () => {
+    const oldInventory = deferred<unknown>();
+    const oldApi = {
+      get: vi.fn((path: string) => (
+        path === "/api/agents"
+          ? oldInventory.promise
+          : Promise.resolve({ preferences: { shellThemeId: "dark" } })
+      )),
+      put: terminalPreferencesPut,
+    };
+    const newApi = {
+      get: vi.fn(async (path: string) => (
+        path === "/api/agents"
+          ? { agents: [{ id: "codex", installState: "missing" }] }
+          : { preferences: { shellThemeId: "dark" } }
+      )),
+      put: terminalPreferencesPut,
+    };
+    useConnection.setState({ api: oldApi as never, runtimeSlot: "primary" });
+    useShellSessions.setState({ sessions: [{ name: "matrix-main", status: "active" }] });
+
+    renderTab();
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Choose session type" }), { button: 0, ctrlKey: false });
+    await waitFor(() => expect(oldApi.get).toHaveBeenCalledWith("/api/agents"));
+
+    act(() => useConnection.setState({ api: newApi as never, runtimeSlot: "secondary" }));
+    act(() => oldInventory.resolve({ agents: [{ id: "codex", installState: "installed" }] }));
+
+    const staleCodex = await screen.findByRole("menuitem", { name: /Codex.*Unavailable/ });
+    expect(staleCodex.getAttribute("aria-disabled")).toBe("true");
+
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Choose session type" }), { button: 0, ctrlKey: false });
+
+    const currentCodex = await screen.findByRole("menuitem", { name: /Codex.*Install/ });
+    expect(currentCodex.getAttribute("aria-disabled")).toBeNull();
+    expect(newApi.get).toHaveBeenCalledWith("/api/agents");
   });
 
   it("shows the running agent and its current activity in each session row", () => {

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -534,7 +534,8 @@ describe("TerminalsTab", () => {
 
     expect(screen.getByRole("heading", { name: "Terminal" }).className).toContain("text-base");
     expect(screen.getByRole("list", { name: "Terminal sessions" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "New terminal session" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "New shell session" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Choose session type" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Select terminal sessions" })).toBeNull();
     expect(screen.queryByRole("textbox", { name: "Search terminal sessions" })).toBeNull();
   });
@@ -547,7 +548,79 @@ describe("TerminalsTab", () => {
     renderTab();
 
     expect(screen.getByRole("button", { name: "Delete matrix-main" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Rename matrix-main" })).toBeNull();
+    expect(screen.getByRole("button", { name: "More actions for matrix-main" })).toBeTruthy();
+  });
+
+  it("creates Claude, Codex, OpenCode, and Pi sessions from the new-terminal menu", async () => {
+    const createShell = vi.fn().mockResolvedValue({ name: "matrix-created", status: "active" });
+    useShellSessions.setState({
+      create: createShell,
+      sessions: [{ name: "matrix-main", status: "active" }],
+    });
+
+    renderTab();
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Choose session type" }), { button: 0, ctrlKey: false });
+
+    expect(await screen.findByRole("menuitem", { name: /Claude Code/ })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: /Codex/ })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: /OpenCode/ })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: /Pi/ })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: /Codex/ }));
+    await waitFor(() => expect(createShell).toHaveBeenCalledWith(useConnection.getState().api, {
+      cmd: "codex",
+      agent: "codex",
+    }));
+  });
+
+  it("shows the running agent and its current activity in each session row", () => {
+    useShellSessions.setState({
+      sessions: [{
+        name: "matrix-main",
+        status: "active",
+        agent: "codex",
+        model: "gpt-5.4",
+        strength: "high",
+        lastAction: "Editing terminal sidebar",
+      }],
+    });
+
+    renderTab();
+
+    const row = screen.getByRole("button", { name: "Open matrix-main" });
+    expect(row.textContent).toContain("Codex");
+    expect(row.textContent).toContain("gpt-5.4");
+    expect(row.textContent).toContain("high");
+    expect(row.textContent).toContain("Editing terminal sidebar");
+    expect(screen.getByRole("heading", { name: "matrix-main" })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Editing terminal sidebar" })).toBeNull();
+  });
+
+  it("renames a session and copies its connect command from row actions", async () => {
+    const rename = vi.fn().mockResolvedValue(true);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+    useShellSessions.setState({
+      sessions: [{ name: "matrix-main", status: "active" }],
+      rename,
+    });
+
+    renderTab();
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for matrix-main" }), { button: 0, ctrlKey: false });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Copy connect command" }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("matrix shell connect matrix-main"));
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for matrix-main" }), { button: 0, ctrlKey: false });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Rename" }));
+    const input = screen.getByRole("textbox", { name: "Terminal session name" });
+    fireEvent.change(input, { target: { value: "matrix-renamed" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => expect(rename).toHaveBeenCalledWith(
+      useConnection.getState().api,
+      "matrix-main",
+      "matrix-renamed",
+    ));
   });
 
   it("renders canonical active, waiting, and closed lifecycle badges with relative activity", () => {
@@ -594,7 +667,7 @@ describe("TerminalsTab", () => {
 
     renderTab();
 
-    fireEvent.click(screen.getByRole("button", { name: "New terminal session" }));
+    fireEvent.click(screen.getByRole("button", { name: "New shell session" }));
 
     await waitFor(() => expect(createShell).toHaveBeenCalledWith(useConnection.getState().api));
     expect(createWorkspace).not.toHaveBeenCalled();

--- a/tests/e2e/desktop/terminal-sessions.e2e.test.ts
+++ b/tests/e2e/desktop/terminal-sessions.e2e.test.ts
@@ -109,7 +109,12 @@ suite("Desktop terminal session handoff", () => {
     await page.evaluate(async () => {
       await window.operator.invoke("auth:start-device-flow", {});
     });
-    await page.locator("aside button", { hasText: "Terminal" }).first().waitFor({ timeout: 15_000 });
+    try {
+      await page.getByRole("button", { name: "Terminal", exact: true }).first().waitFor({ timeout: 15_000 });
+    } catch (error: unknown) {
+      await page.screenshot({ path: join(SCREENSHOT_DIR, "terminal-session-boot-failure.png") });
+      throw new Error(`Desktop shell did not become ready: ${await page.locator("body").innerText()}`, { cause: error });
+    }
   }, 60_000);
 
   afterAll(async () => {
@@ -135,8 +140,41 @@ suite("Desktop terminal session handoff", () => {
     }).toBe(true);
   });
 
+  it("opens the compact shell-theme picker through Electron hit testing", async () => {
+    await page.getByRole("button", { name: "Terminal", exact: true }).first().dblclick({ timeout: 5_000 });
+    const terminalWindow = page.getByRole("dialog", { name: "Terminal window" });
+    const fullWidthChrome = terminalWindow.locator('[data-os-window-chrome-placement="full-width"]');
+    await fullWidthChrome.waitFor({ timeout: 5_000 });
+    expect(await fullWidthChrome.textContent()).toContain("Terminal");
+
+    await terminalWindow.getByRole("button", { name: "Choose session type" }).click();
+    for (const agent of ["Claude Code", "Codex", "OpenCode", "Pi"]) {
+      await page.getByRole("menuitem", { name: new RegExp(agent) }).waitFor({ timeout: 5_000 });
+    }
+    await page.keyboard.press("Escape");
+
+    const session = page.getByRole("button", { name: "Open matrix-task-1" });
+    await session.waitFor({ timeout: 10_000 });
+    await session.click({ timeout: 5_000 });
+
+    const trigger = page.getByRole("button", { name: "Shell theme" });
+    await trigger.waitFor({ timeout: 5_000 });
+    expect(await trigger.isEnabled()).toBe(true);
+    const [dragBounds, triggerBounds] = await Promise.all([
+      terminalWindow.locator("[data-os-window-gesture-layer]").boundingBox(),
+      trigger.boundingBox(),
+    ]);
+    expect(dragBounds).not.toBeNull();
+    expect(triggerBounds).not.toBeNull();
+    expect(triggerBounds!.y).toBeGreaterThanOrEqual(dragBounds!.y + dragBounds!.height);
+    await trigger.click();
+
+    await page.getByRole("menu", { name: "Shell theme" }).waitFor({ timeout: 5_000 });
+    await page.getByRole("menuitemradio", { name: /P10k Rainbow/ }).waitFor({ timeout: 5_000 });
+  });
+
   it("renders the Figma-aligned list and preserves the mounted terminal buffer across list-detail navigation", async () => {
-    await page.locator("aside button", { hasText: "Terminal" }).first().click();
+    await page.getByRole("button", { name: "Terminal", exact: true }).first().dblclick();
     await page.getByRole("heading", { name: "Terminal" }).waitFor({ timeout: 10_000 });
     await page.getByText("Active", { exact: true }).waitFor();
     await page.getByText("Waiting", { exact: true }).waitFor();


### PR DESCRIPTION
## Summary

- restore the Desktop Terminal split-menu for Shell, Claude Code, Codex, OpenCode, and Pi, including visible install sessions for missing agents
- show agent/model/activity metadata in session rows and restore rename plus copy-connect-command actions
- give the floating Terminal window a full-width title bar so the title is not truncated and the compact theme picker sits below the draggable region

## Verification

- `bun run typecheck`
- `bun run check:patterns` (0 violations; 5 pre-existing warnings)
- Desktop test suite (2,463 tests passing)
- focused Terminal unit/store/layout tests (86 tests passing)
- Desktop production build
- real Electron regression: full-width title, agent menu, and opening the compact theme picker
- `bun run test` was started locally; the saturated parallel runner produced unrelated 20-second listener/timer timeouts across existing CLI, sync, heartbeat, provider, and app-runtime suites, so CI is the authoritative full-suite signal

## Invariants

- **Source of truth:** canonical shell sessions remain `/api/terminal/sessions`; installed agent inventory remains `/api/agents`; terminal shell theme remains `/api/terminal/preferences`; session agent metadata continues to come from the Gateway.
- **Lock / transaction scope:** no database writes, transactions, locks, or rate-limit behavior were added or changed. Session creation and rename use the existing canonical endpoints and their existing concurrency controls.
- **Acceptable orphan states:** a successfully created session may remain visible if the follow-up refresh fails; the store preserves the optimistic canonical session. Missing-agent installation intentionally runs in a visible terminal session and remains available for diagnosis or retry.
- **Auth source of truth:** the Desktop `ApiClient` and selected-runtime connection boundary remain authoritative for bearer credentials. No endpoint, authorization rule, or bypass was added.
- **Deferred scope:** this PR does not redesign the web Terminal, alter provider installers, change global Matrix OS theming, or add a separate persistence model.

## Documentation

- No public documentation change: this restores existing Terminal behavior in the native Desktop renderer and adds regression coverage.
