### PR TITLE
fix(onboarding): preserve empty developer tool selections

### DIFF
--- a/packages/platform/src/app-session-routes.ts
+++ b/packages/platform/src/app-session-routes.ts
@@ -14,7 +14,10 @@ import type { ClerkAuth } from './clerk-auth.js';
 import type { CustomerVpsService } from './customer-vps.js';
 import { CustomerVpsError } from './customer-vps-errors.js';
 import { HetznerLocationSchema, HetznerServerTypeSchema, RuntimeSlotSchema } from './customer-vps-schema.js';
-import { DeveloperToolsSchema } from './developer-tools.js';
+import {
+  DeveloperToolsSchema,
+  resolveProvisioningDeveloperTools,
+} from './developer-tools.js';
 import { getActivePrebillingIntent } from './prebilling-provisioning-store.js';
 import type { MatrixProvisioner } from './matrix-provisioning.js';
 import {
@@ -212,21 +215,25 @@ export function createAppSessionRoutes(opts: {
         opts.applyNoStoreHeaders(c);
         return c.json({ error: 'Handle unavailable', code: 'handle_unavailable' }, 409);
       }
-      const checkoutAttempt = parsed.data.developerTools
+      const checkoutAttempt = parsed.data.developerTools !== undefined
         ? null
         : await getSettlingCheckoutAttempt(opts.db, result.userId, parsed.data.runtime);
-      const developerTools = parsed.data.developerTools ?? (
+      const settlingCheckoutDeveloperTools = (
         checkoutAttempt &&
         (checkoutAttempt.status === 'paid' || checkoutAttempt.status === 'open')
           ? checkoutAttempt.developerTools
           : undefined
+      );
+      const developerTools = resolveProvisioningDeveloperTools(
+        parsed.data.developerTools,
+        settlingCheckoutDeveloperTools,
       );
       const provisioned = await opts.customerVpsService.provision(
         {
           handle: identity.handle,
           clerkUserId: result.userId,
           runtimeSlot: parsed.data.runtime,
-          ...(developerTools ? { developerTools } : {}),
+          ...(developerTools !== undefined ? { developerTools } : {}),
           ...(parsed.data.serverType ? { serverType: parsed.data.serverType } : {}),
           ...(parsed.data.location ? { location: parsed.data.location } : {}),
         },

--- a/packages/platform/src/auth-pages.ts
+++ b/packages/platform/src/auth-pages.ts
@@ -940,7 +940,7 @@ export function getAuthPage(
       buildButton.className = 'primary';
       buildButton.textContent = 'Build VPS';
       buildButton.addEventListener('click', function() {
-        startProvisioningFromClerkSession(selectedTools);
+        startProvisioningFromClerkSession(selectedTools.slice());
       });
       actions.appendChild(buildButton);
       footer.appendChild(actions);
@@ -1067,7 +1067,7 @@ export function getAuthPage(
         window.clearTimeout(billingRetryTimeoutId);
         billingRetryTimeoutId = null;
       }
-      var developerTools = Array.isArray(selectedDeveloperTools) ? selectedDeveloperTools : defaultDeveloperTools;
+      var developerTools = Array.isArray(selectedDeveloperTools) ? selectedDeveloperTools.slice() : defaultDeveloperTools.slice();
       provisionStarted = true;
       setProvisionControls(true, null);
       if (!window.Clerk.session) {

--- a/packages/platform/src/developer-tools.ts
+++ b/packages/platform/src/developer-tools.ts
@@ -22,6 +22,17 @@ export const DeveloperToolsWithDefaultSchema = z.preprocess(
   DeveloperToolsSchema,
 );
 
+export function resolveProvisioningDeveloperTools(
+  explicitSelection: readonly DeveloperToolId[] | undefined,
+  settlingCheckoutSelection: readonly DeveloperToolId[] | undefined,
+): DeveloperToolId[] {
+  return canonicalizeDeveloperTools(
+    explicitSelection !== undefined
+      ? explicitSelection
+      : settlingCheckoutSelection ?? DEFAULT_DEVELOPER_TOOLS,
+  );
+}
+
 export function serializeDeveloperTools(input: readonly DeveloperToolId[] = DEFAULT_DEVELOPER_TOOLS): string {
   return JSON.stringify(canonicalizeDeveloperTools(input));
 }

--- a/packages/platform/src/legacy-container-routes.ts
+++ b/packages/platform/src/legacy-container-routes.ts
@@ -100,7 +100,7 @@ export function createLegacyContainerRoutes(opts: {
           clerkUserId,
           runtimeSlot,
           serverType,
-          ...(developerTools ? { developerTools } : {}),
+          ...(developerTools !== undefined ? { developerTools } : {}),
         });
         await ensureProvisionedPlatformUser(db, {
           clerkUserId,

--- a/shell/src/components/onboarding/DefaultInstallsStep.tsx
+++ b/shell/src/components/onboarding/DefaultInstallsStep.tsx
@@ -275,8 +275,9 @@ export function DefaultInstallsStep({
     setSelectedTools((current) => nextDeveloperToolsSelection(current, tool));
   }, []);
 
+  // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- stable identity is required by the global keydown effect below while the closure must refresh when the selected snapshot changes.
   const buildWithSelectedTools = useCallback((): void => {
-    if (!loading) onBuild(selectedTools);
+    if (!loading) onBuild([...selectedTools]);
   }, [loading, onBuild, selectedTools]);
 
   useEffect(() => {

--- a/tests/platform/api.test.ts
+++ b/tests/platform/api.test.ts
@@ -174,7 +174,12 @@ describe('platform/api', () => {
     const res = await vpsApp.request('/containers/provision', {
       method: 'POST',
       headers: { 'content-type': 'application/json', ...adminHeaders },
-      body: JSON.stringify({ handle: 'alice', clerkUserId: 'clerk_1', displayName: 'Alice' }),
+      body: JSON.stringify({
+        handle: 'alice',
+        clerkUserId: 'clerk_1',
+        displayName: 'Alice',
+        developerTools: [],
+      }),
     });
 
     expect(res.status).toBe(202);
@@ -187,7 +192,12 @@ describe('platform/api', () => {
       status: 'provisioning',
       etaSeconds: 90,
     });
-    expect(customerVpsService.provision).toHaveBeenCalledWith({ handle: 'alice', clerkUserId: 'clerk_1', runtimeSlot: 'primary' });
+    expect(customerVpsService.provision).toHaveBeenCalledWith({
+      handle: 'alice',
+      clerkUserId: 'clerk_1',
+      runtimeSlot: 'primary',
+      developerTools: [],
+    });
     expect(provisionSpy).not.toHaveBeenCalled();
     await expect(getPlatformUserByClerkId(db, 'clerk_1')).resolves.toMatchObject({
       clerkId: 'clerk_1',

--- a/tests/platform/auth-page-empty-developer-tools.test.ts
+++ b/tests/platform/auth-page-empty-developer-tools.test.ts
@@ -1,0 +1,104 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getAuthPage } from '../../packages/platform/src/auth-pages.js';
+
+const TOOL_LABELS = ['Codex', 'Claude Code', 'OpenCode', 'Pi'] as const;
+
+async function waitForCondition(condition: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('Timed out waiting for inline auth fallback state');
+}
+
+function requestBody(init: RequestInit | undefined): Record<string, unknown> {
+  if (typeof init?.body !== 'string') throw new Error('Expected a JSON request body');
+  return JSON.parse(init.body) as Record<string, unknown>;
+}
+
+describe('inline auth fallback developer tool selection', () => {
+  const openDoms: JSDOM[] = [];
+
+  afterEach(() => {
+    for (const dom of openDoms.splice(0)) dom.window.close();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps an empty snapshot through billing delay, 202 provisioning, and app-session exchange', async () => {
+    const requests: Array<{ url: string; init: RequestInit | undefined }> = [];
+    let provisionAttempts = 0;
+    let appSessionAttempts = 0;
+    const html = getAuthPage(
+      'pk_test_matrix',
+      'sign-up',
+      'test-nonce',
+      '/?checkout=success',
+      'https://app.matrix-os.com',
+    );
+    const dom = new JSDOM(html, {
+      url: 'https://app.matrix-os.com/?checkout=success',
+      runScripts: 'dangerously',
+      beforeParse(window) {
+        window.sessionStorage.setItem('matrix.billing.checkoutAttemptAt', String(Date.now()));
+        Object.assign(window, {
+          AbortSignal,
+          Response,
+          Clerk: {
+            load: async () => undefined,
+            user: {
+              fullName: 'Test User',
+              username: 'test-user',
+              primaryEmailAddress: { emailAddress: 'test@example.com' },
+            },
+            session: { getToken: async () => 'clerk-token' },
+            signOut: async () => undefined,
+          },
+          fetch: async (input: string | URL | Request, init?: RequestInit) => {
+            const url = String(input);
+            requests.push({ url, init });
+            if (url === '/api/auth/app-session') {
+              appSessionAttempts += 1;
+              return appSessionAttempts === 1
+                ? new Response('{}', { status: 404, headers: { 'content-type': 'application/json' } })
+                : Response.json({ redirectTo: '/' });
+            }
+            if (url === '/api/auth/provision-runtime') {
+              provisionAttempts += 1;
+              return new Response('{}', {
+                status: provisionAttempts === 1 ? 402 : 202,
+                headers: { 'content-type': 'application/json' },
+              });
+            }
+            return new Response('{}', { status: 503 });
+          },
+        });
+        const nativeSetTimeout = window.setTimeout.bind(window);
+        window.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) =>
+          nativeSetTimeout(handler, timeout === 8_000 ? 0 : timeout, ...args)) as typeof window.setTimeout;
+      },
+    });
+    openDoms.push(dom);
+
+    await waitForCondition(() => Boolean(dom.window.document.querySelector('.default-installs-state')));
+    for (const label of TOOL_LABELS) {
+      const input = Array.from(dom.window.document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'))
+        .find((candidate) => candidate.getAttribute('aria-label') === label);
+      if (!input) throw new Error(`Missing ${label} checkbox`);
+      input.checked = false;
+      input.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+    }
+
+    const buildButton = Array.from(dom.window.document.querySelectorAll<HTMLButtonElement>('button'))
+      .find((button) => button.textContent === 'Build VPS');
+    if (!buildButton) throw new Error('Missing Build VPS button');
+    expect(buildButton.disabled).toBe(false);
+    buildButton.click();
+
+    await waitForCondition(() => provisionAttempts === 2 && appSessionAttempts === 2);
+    const provisionRequests = requests.filter((request) => request.url === '/api/auth/provision-runtime');
+    expect(provisionRequests).toHaveLength(2);
+    expect(provisionRequests.map((request) => requestBody(request.init).developerTools)).toEqual([[], []]);
+    expect(requests.filter((request) => request.url === '/api/auth/app-session')).toHaveLength(2);
+  });
+});

--- a/tests/platform/billing-settling.test.ts
+++ b/tests/platform/billing-settling.test.ts
@@ -60,7 +60,7 @@ describe('platform billing checkout-attempt settling (spec 092)', () => {
     });
   }
 
-  it('records an open checkout attempt with the Stripe session id', async () => {
+  it('records an open checkout attempt with an explicit empty developer tool selection', async () => {
     const app = createApp();
     const res = await app.request('/billing/checkout', {
       method: 'POST',
@@ -68,14 +68,14 @@ describe('platform billing checkout-attempt settling (spec 092)', () => {
       body: JSON.stringify({
         planSlug: 'matrix_builder',
         interval: 'monthly',
-        developerTools: ['codex', 'pi'],
+        developerTools: [],
       }),
     });
     expect(res.status).toBe(200);
     const attempt = await getLatestCheckoutAttempt(db, 'user_123');
     expect(attempt?.stripeSessionId).toBe('cs_live_1');
     expect(attempt?.status).toBe('open');
-    expect(attempt?.developerTools).toEqual(['codex', 'pi']);
+    expect(attempt?.developerTools).toEqual([]);
   });
 
   it('marks the attempt paid on checkout.session.completed', async () => {

--- a/tests/platform/customer-vps-telemetry.test.ts
+++ b/tests/platform/customer-vps-telemetry.test.ts
@@ -78,6 +78,31 @@ describe('platform/customer-vps-routes telemetry', () => {
     });
   });
 
+  it('reports zero selected developer tools without treating the field as omitted', async () => {
+    const captureEvent = vi.fn();
+    const service = {
+      provision: vi.fn().mockResolvedValue({ machineId: MACHINE_ID, status: 'provisioning' }),
+    };
+    const app = buildApp(service, captureEvent);
+
+    const res = await app.request('/vps/provision', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({ clerkUserId: 'user_123', handle: 'alice', developerTools: [] }),
+    });
+
+    expect(res.status).toBe(202);
+    expect(captureEvent).toHaveBeenCalledWith(MATRIX_TELEMETRY_EVENTS.VPS_PROVISION_REQUESTED, {
+      distinctId: 'user_123',
+      properties: {
+        handle: 'alice',
+        runtime_slot: 'primary',
+        requested_server_type: undefined,
+        developer_tools_count: 0,
+      },
+    });
+  });
+
   it('captures matrix_vps_provision_failed with the CustomerVpsError failure code', async () => {
     const captureEvent = vi.fn();
     const service = {

--- a/tests/platform/developer-tools-schema.test.ts
+++ b/tests/platform/developer-tools-schema.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_DEVELOPER_TOOLS,
   DeveloperToolsSchema,
   parseDeveloperToolsJson,
+  resolveProvisioningDeveloperTools,
   serializeDeveloperTools,
 } from '../../packages/platform/src/developer-tools.js';
 
@@ -26,6 +27,18 @@ describe('developer tool selection schema', () => {
   it('defaults omitted or malformed persisted values to all tools', () => {
     expect(parseDeveloperToolsJson(null)).toEqual(DEFAULT_DEVELOPER_TOOLS);
     expect(parseDeveloperToolsJson('not-json')).toEqual(DEFAULT_DEVELOPER_TOOLS);
+  });
+
+  it('round-trips an explicit empty selection without restoring defaults', () => {
+    expect(DeveloperToolsSchema.parse([])).toEqual([]);
+    expect(serializeDeveloperTools([])).toBe('[]');
+    expect(parseDeveloperToolsJson('[]')).toEqual([]);
+  });
+
+  it('resolves explicit, checkout, and default provisioning selections distinctly', () => {
+    expect(resolveProvisioningDeveloperTools([], ['codex'])).toEqual([]);
+    expect(resolveProvisioningDeveloperTools(undefined, ['pi'])).toEqual(['pi']);
+    expect(resolveProvisioningDeveloperTools(undefined, undefined)).toEqual(DEFAULT_DEVELOPER_TOOLS);
   });
 
   it('deduplicates and serializes selected tools in canonical order', () => {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -1929,6 +1929,7 @@ describe("platform proxy routing", () => {
       handle: "newuser",
       clerkUserId: "user_new",
       runtimeSlot: "primary",
+      developerTools: ["codex", "claude-code", "opencode", "pi"],
     }, DETACHED_PROVISION_OPTIONS);
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.clerk.com/v1/users/user_new",
@@ -1950,7 +1951,7 @@ describe("platform proxy routing", () => {
     });
   });
 
-  it("passes directly selected developer tools to hosted runtime provisioning", async () => {
+  it("passes a directly selected empty developer tool list to hosted runtime provisioning", async () => {
     process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
     await deleteContainer(db, "alice");
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
@@ -1989,7 +1990,7 @@ describe("platform proxy routing", () => {
       },
       body: JSON.stringify({
         runtime: "research-lab",
-        developerTools: ["opencode", "pi"],
+        developerTools: [],
         serverType: "cpx22",
         location: "hil",
       }),
@@ -2000,7 +2001,7 @@ describe("platform proxy routing", () => {
       handle: "newuser",
       clerkUserId: "user_new_tools",
       runtimeSlot: "research-lab",
-      developerTools: ["opencode", "pi"],
+      developerTools: [],
       serverType: "cpx22",
       location: "hil",
     }, DETACHED_PROVISION_OPTIONS);
@@ -2798,6 +2799,8 @@ describe("platform proxy routing", () => {
     expect(html).not.toContain("showCheckoutUnavailableState();");
     expect(html).not.toContain("Opening secure checkout");
     expect(html).toContain("retryProvisioningAfterBillingDelay(developerTools)");
+    expect(html).toContain("startProvisioningFromClerkSession(selectedTools.slice());");
+    expect(html).toContain("Array.isArray(selectedDeveloperTools) ? selectedDeveloperTools.slice() : defaultDeveloperTools.slice()");
     expect(html).toContain("setProvisionControls(false, null);\n      billingRetryTimeoutId = window.setTimeout");
     expect(html).toContain("provisioning_conflict");
     expect(html).toContain("if (body && body.code === 'provisioning_conflict') {\n                billingConfirmationPolls = 0;\n                continueWithClerkSession(true);");

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../../packages/platform/src/main.js";
 import { createClerkAuth } from "../../packages/platform/src/clerk-auth.js";
 import { buildBillingSetupTarget } from "../../packages/platform/src/auth-pages.js";
+import { DEFAULT_DEVELOPER_TOOLS } from "../../packages/platform/src/developer-tools.js";
 import { issueSyncJwt } from "../../packages/platform/src/sync-jwt.js";
 import * as syncJwt from "../../packages/platform/src/sync-jwt.js";
 import { shouldServePlatformRuntimeShell } from "../../packages/platform/src/session-routing-middleware.js";
@@ -1929,7 +1930,7 @@ describe("platform proxy routing", () => {
       handle: "newuser",
       clerkUserId: "user_new",
       runtimeSlot: "primary",
-      developerTools: ["codex", "claude-code", "opencode", "pi"],
+      developerTools: DEFAULT_DEVELOPER_TOOLS,
     }, DETACHED_PROVISION_OPTIONS);
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.clerk.com/v1/users/user_new",
@@ -2229,6 +2230,7 @@ describe("platform proxy routing", () => {
       handle: "newuser",
       clerkUserId: "user_new_avatar",
       runtimeSlot: "primary",
+      developerTools: DEFAULT_DEVELOPER_TOOLS,
     }, DETACHED_PROVISION_OPTIONS);
     await expect(getPlatformUserByClerkId(db, "user_new_avatar")).resolves.toMatchObject({
       clerkId: "user_new_avatar",
@@ -2290,6 +2292,7 @@ describe("platform proxy routing", () => {
       handle: "new",
       clerkUserId: "user_new",
       runtimeSlot: "primary",
+      developerTools: DEFAULT_DEVELOPER_TOOLS,
     }, DETACHED_PROVISION_OPTIONS);
     await expect(getPlatformUserByClerkId(db, "user_new")).resolves.toMatchObject({
       clerkId: "user_new",
@@ -2342,6 +2345,7 @@ describe("platform proxy routing", () => {
       handle: "newuser",
       clerkUserId: "user_new",
       runtimeSlot: "primary",
+      developerTools: DEFAULT_DEVELOPER_TOOLS,
     }, DETACHED_PROVISION_OPTIONS);
     await expect(getPlatformUserByClerkId(db, "user_new")).resolves.toMatchObject({
       handle: "newuser",
@@ -2394,6 +2398,7 @@ describe("platform proxy routing", () => {
       handle: "very-long-username-with-hyphen",
       clerkUserId: "user_new",
       runtimeSlot: "primary",
+      developerTools: DEFAULT_DEVELOPER_TOOLS,
     }, DETACHED_PROVISION_OPTIONS);
   });
 
@@ -2498,6 +2503,7 @@ describe("platform proxy routing", () => {
       handle: fallbackHandle,
       clerkUserId: "user_new",
       runtimeSlot: "primary",
+      developerTools: DEFAULT_DEVELOPER_TOOLS,
     }, DETACHED_PROVISION_OPTIONS);
   });
 
@@ -2560,6 +2566,7 @@ describe("platform proxy routing", () => {
       handle: fallbackHandle,
       clerkUserId: "user_new",
       runtimeSlot: "primary",
+      developerTools: DEFAULT_DEVELOPER_TOOLS,
     }, DETACHED_PROVISION_OPTIONS);
   });
 
@@ -2620,6 +2627,7 @@ describe("platform proxy routing", () => {
       handle: "alice",
       clerkUserId: "user_new",
       runtimeSlot: "primary",
+      developerTools: DEFAULT_DEVELOPER_TOOLS,
     }, DETACHED_PROVISION_OPTIONS);
   });
 
@@ -2681,6 +2689,7 @@ describe("platform proxy routing", () => {
       handle: "alice",
       clerkUserId: "user_new",
       runtimeSlot: "primary",
+      developerTools: DEFAULT_DEVELOPER_TOOLS,
     }, DETACHED_PROVISION_OPTIONS);
   });
 
@@ -2730,6 +2739,7 @@ describe("platform proxy routing", () => {
       handle: fallbackHandle,
       clerkUserId: "user_new",
       runtimeSlot: "primary",
+      developerTools: DEFAULT_DEVELOPER_TOOLS,
     }, DETACHED_PROVISION_OPTIONS);
   });
 

--- a/tests/shell/billing-gate.test.tsx
+++ b/tests/shell/billing-gate.test.tsx
@@ -622,15 +622,18 @@ describe("BillingGate", () => {
       expect(screen.getByRole("checkbox", { name: label })).toHaveProperty("checked", true);
     }
     expect(fetchMock.mock.calls.some(([url]) => url === "/api/auth/provision-runtime")).toBe(false);
-    fireEvent.click(screen.getByRole("checkbox", { name: "Pi" }));
+    for (const label of ["Codex", "Claude Code", "OpenCode", "Pi"]) {
+      fireEvent.click(screen.getByRole("checkbox", { name: label }));
+    }
+    expect((screen.getByRole("button", { name: "Build VPS" }) as HTMLButtonElement).disabled).toBe(false);
     timeoutSpy.mockClear();
-    fireEvent.click(screen.getByRole("button", { name: "Build VPS" }));
+    fireEvent.keyDown(window, { key: "Enter" });
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(
         "/api/auth/provision-runtime",
         expect.objectContaining({
           method: "POST",
-          body: JSON.stringify({ developerTools: ["codex", "claude-code", "opencode"] }),
+          body: JSON.stringify({ developerTools: [] }),
         }),
       ),
     );

--- a/tests/shell/boot-sequence.test.tsx
+++ b/tests/shell/boot-sequence.test.tsx
@@ -164,7 +164,10 @@ describe("BootSequence", () => {
     for (const label of ["Codex", "Claude Code", "OpenCode", "Pi"]) {
       expect(screen.getByRole("checkbox", { name: label })).toHaveProperty("checked", true);
     }
-    fireEvent.click(screen.getByRole("checkbox", { name: "OpenCode" }));
+    for (const label of ["Codex", "Claude Code", "OpenCode", "Pi"]) {
+      fireEvent.click(screen.getByRole("checkbox", { name: label }));
+    }
+    expect((screen.getByRole("button", { name: "Build VPS" }) as HTMLButtonElement).disabled).toBe(false);
     timeoutSpy.mockClear();
     fireEvent.click(screen.getByRole("button", { name: "Build VPS" }));
 
@@ -173,7 +176,7 @@ describe("BootSequence", () => {
         "/api/auth/provision-runtime",
         expect.objectContaining({
           method: "POST",
-          body: JSON.stringify({ developerTools: ["codex", "claude-code", "pi"] }),
+          body: JSON.stringify({ developerTools: [] }),
         }),
       ),
     );

--- a/tests/shell/onboarding-acquisition-source.test.tsx
+++ b/tests/shell/onboarding-acquisition-source.test.tsx
@@ -136,6 +136,26 @@ describe("onboarding acquisition source", () => {
     expect(onBuild).toHaveBeenCalledWith(["claude-code", "opencode"]);
   });
 
+  it("submits an immutable empty selection by click and Enter", () => {
+    const submittedSelections: string[][] = [];
+    const onBuild = vi.fn((tools: Array<"codex" | "claude-code" | "opencode" | "pi">) => {
+      submittedSelections.push([...tools]);
+      tools.push("codex");
+    });
+    render(<DefaultInstallsStep onBuild={onBuild} />);
+
+    for (const label of ["Codex", "Claude Code", "OpenCode", "Pi"]) {
+      fireEvent.click(screen.getByRole("checkbox", { name: label }));
+    }
+    const buildButton = screen.getByRole("button", { name: "Build VPS" }) as HTMLButtonElement;
+    expect(buildButton.disabled).toBe(false);
+
+    fireEvent.click(buildButton);
+    fireEvent.keyDown(window, { key: "Enter" });
+
+    expect(submittedSelections).toEqual([[], []]);
+  });
+
   it("does not repeat first-touch attribution in reused add-computer flows", () => {
     render(<DefaultInstallsStep onBuild={vi.fn()} />);
 

--- a/tests/shell/runtime-manager.test.tsx
+++ b/tests/shell/runtime-manager.test.tsx
@@ -449,6 +449,10 @@ describe("RuntimeManager", () => {
     fireEvent.click(screen.getByRole("button", { name: "Continue setup" }));
 
     expect(await screen.findByRole("heading", { name: "Default installs" })).toBeTruthy();
+    for (const label of ["Codex", "Claude Code", "OpenCode", "Pi"]) {
+      fireEvent.click(screen.getByRole("checkbox", { name: label }));
+    }
+    expect((screen.getByRole("button", { name: "Build VPS" }) as HTMLButtonElement).disabled).toBe(false);
     fireEvent.click(screen.getByRole("button", { name: "Build VPS" }));
 
     await waitFor(() => {
@@ -458,7 +462,7 @@ describe("RuntimeManager", () => {
           method: "POST",
           body: JSON.stringify({
             runtime: "research-lab",
-            developerTools: ["codex", "claude-code", "opencode", "pi"],
+            developerTools: [],
             serverType: "cpx32",
             location: "fsn1",
           }),


### PR DESCRIPTION
## Summary

- define explicit `developerTools: []` as “install no optional CLI agents” while preserving checkout/default fallback only for an omitted field
- preserve immutable empty selections across inline auth billing retries, app-session handoff, BootSequence, BillingGate, and add-computer onboarding
- keep downstream provisioning, empty environment rendering, core boot behavior, validation, and zero-count telemetry intact
- list the supported developer tools separately in FinnaAI/matrix-os-site#52

## Tests

- TDD regressions: resolver/schema/persistence; platform forwarding/defaults/checkout fallback; inline fallback billing retry and session exchange; BootSequence, BillingGate, add-computer, click/Enter snapshots; zero-count telemetry; invalid IDs; empty VPS environment rendering
- Focused platform: 27 passed in the four dedicated suites; 6 passed across targeted provisioning, legacy, downstream, and validation cases
- Full proxy-routing regression: 131 passed
- Focused shell: 70 passed across BootSequence, BillingGate, RuntimeManager, and onboarding selection suites
- `bun run typecheck`
- `bun run check:patterns` and `bun run check:patterns:diff` (0 violations; existing warnings only)
- `bun run build:shell:production`
- React Doctor against `origin/main`: changed file clean
- Focused ESLint: changed onboarding component clean
- Repository lint note: `bun run lint` currently fails at the Bun filtered-script entrypoint; invoking shell ESLint directly reports the existing baseline (55 errors, 107 warnings) outside this focused change

## Review / Monitoring

- Frozen review range: `d8a0d2f1df..94b0ef299e`
- Exact-head Greptile: 5/5 on `94b0ef299e`, with no unresolved review threads
- Exact-head CI: runs `33258749504` and `33259547710` green, including all unit shards, E2E, typecheck, patterns, React Doctor, sync package, and production shell build
- Exact-head Docker build/smoke: green
- Exact-head platform preview: image `pr-1392-94b0ef299e69`, healthy zero-traffic revision `matrix-platform-preview-00106-zec`
- Disposable VPS: explicit `developerTools: []` provisioning returned `202`; `pr-1392` is running and healthy on exact bundle `v2026.08.29-pr1392-33258626392-1-94b0ef2`
- Live limitation: direct on-host optional-agent inventory remains unverified because SSH reported a host-key mismatch and the supported HTTP path requires an authenticated app session; host verification was not weakened

## Invariants

### Source of truth

- An explicit request array is authoritative, including `[]`.
- When the field is omitted, the latest settling paid/open checkout-attempt selection in platform Postgres is authoritative when present; otherwise the unchanged platform defaults apply.
- The canonical developer-tool IDs and ordering remain owned by `packages/platform/src/developer-tools.ts`.

### Lock/transaction scope

- No new writes, locks, or transaction boundaries are introduced.
- Existing checkout-attempt persistence and provisioning transaction behavior remain unchanged; the resolver is pure and runs before the existing provisioning call.

### Acceptable orphan states

- No new orphan state is introduced. Existing `202 provisioning` and billing-settling recovery behavior is preserved.
- A failed client handoff retains the captured selection for retry rather than creating a different request.

### Auth source of truth

- `/api/auth/provision-runtime` continues to use the existing Clerk session verification.
- The legacy adapter retains its existing platform/admin authentication and body limits.
- No auth, endpoint, schema shape, or client-error contract changes are made.

### Deferred scope

- Installing optional tools later remains the existing Terminal `+` flow.
- No changes to default selections when `developerTools` is omitted.
- Extracting the oversized inline auth provisioning state machine is tracked concretely in #1393; this PR keeps the behavior fix minimal and covered by assembled-page JSDOM regression tests.
- No fleet-wide deployment or merge is part of this PR.
