### PR TITLE
fix(chat): support namespaced provider model ids

### DIFF
--- a/packages/contracts/src/agent-runtime-config.ts
+++ b/packages/contracts/src/agent-runtime-config.ts
@@ -1,9 +1,9 @@
 import { z } from "zod/v4";
-import { IsoTimestampSchema, SAFE_SLUG } from "#contract-primitives";
+import { IsoTimestampSchema, ProviderModelReferenceSchema, SAFE_SLUG } from "#contract-primitives";
 
 const SafeSlugSchema = z.string().min(1).max(80).regex(SAFE_SLUG);
 const SafeLabelSchema = z.string().trim().min(1).max(120);
-const ModelReferenceSchema = z.string().trim().min(1).max(160);
+const ModelReferenceSchema = ProviderModelReferenceSchema;
 
 export const AgentRuntimeIdSchema = z.enum(["hermes", "openclaw"]);
 export const AgentEffortSchema = z.enum(["low", "medium", "high", "max"]);

--- a/packages/contracts/src/canonical-chat-provider.ts
+++ b/packages/contracts/src/canonical-chat-provider.ts
@@ -1,6 +1,7 @@
 import { z } from "zod/v4";
 import {
   CanonicalChatAttachmentKindSchema,
+  CanonicalChatModelReferenceSchema,
   CanonicalChatModelSelectionSchema,
   CanonicalChatResourceKindSchema,
   CanonicalProviderInstanceIdSchema,
@@ -34,7 +35,7 @@ export const CanonicalModelCapabilitySchema = z.enum([
 ]);
 
 export const CanonicalModelDescriptorSchema = z.object({
-  id: canonicalReferenceId(160),
+  id: CanonicalChatModelReferenceSchema,
   displayName: canonicalSafeLabel(120, 480),
   description: canonicalSafeLabel(280, 1_120).optional(),
   availability: z.enum(["available", "auth_required", "unavailable"]),

--- a/packages/contracts/src/canonical-chat-surface.ts
+++ b/packages/contracts/src/canonical-chat-surface.ts
@@ -1,6 +1,7 @@
 import { z } from "zod/v4";
 import {
   CanonicalChatMessageSchema,
+  CanonicalChatModelReferenceSchema,
   CanonicalChatInvocationSchema,
   CanonicalChatResourceKindSchema,
   CanonicalChatResourceReferenceSchema,
@@ -49,7 +50,7 @@ const CanonicalChatInspectorRunSchema = z.object({
   ]),
   driverKind: CanonicalProviderDriverKindSchema,
   instanceId: CanonicalProviderInstanceIdSchema,
-  model: canonicalReferenceId(160),
+  model: CanonicalChatModelReferenceSchema,
   startedAt: IsoTimestampSchema.optional(),
   completedAt: IsoTimestampSchema.optional(),
 }).strict();

--- a/packages/contracts/src/canonical-chat.ts
+++ b/packages/contracts/src/canonical-chat.ts
@@ -30,6 +30,16 @@ export const CanonicalChatMessageIdSchema = prefixedId("msg_");
 export const CanonicalChatRequestIdSchema = prefixedId("req_");
 export const CanonicalProviderInstanceIdSchema = canonicalReferenceId(128);
 export const CanonicalChatAttachmentKindSchema = z.enum(["file", "image", "diff", "structured_ref"]);
+export const CanonicalChatModelReferenceSchema = z.string()
+  .min(1)
+  .max(160)
+  .regex(
+    /^[A-Za-z0-9][A-Za-z0-9_.:-]*(?:\/[A-Za-z0-9][A-Za-z0-9_.:-]*)*$/,
+    "Invalid model reference",
+  )
+  .refine((value) => !value.includes(".."), {
+    message: "Model reference cannot contain traversal",
+  });
 const CanonicalChatRelativePathSchema = z.string()
   .min(1)
   .max(4096)
@@ -55,7 +65,7 @@ export const CanonicalChatAttentionSchema = z.enum([
 
 export const CanonicalChatModelSelectionSchema = z.object({
   instanceId: CanonicalProviderInstanceIdSchema,
-  model: canonicalReferenceId(160),
+  model: CanonicalChatModelReferenceSchema,
   options: z.array(z.object({
     id: canonicalReferenceId(80),
     value: z.union([canonicalReferenceId(160), z.boolean()]),

--- a/packages/contracts/src/canonical-chat.ts
+++ b/packages/contracts/src/canonical-chat.ts
@@ -1,5 +1,5 @@
 import { z } from "zod/v4";
-import { IsoTimestampSchema } from "#contract-primitives";
+import { IsoTimestampSchema, ProviderModelReferenceSchema } from "#contract-primitives";
 import {
   CanonicalChatExecutionRootRefSchema,
   CanonicalProviderDriverKindSchema,
@@ -30,16 +30,7 @@ export const CanonicalChatMessageIdSchema = prefixedId("msg_");
 export const CanonicalChatRequestIdSchema = prefixedId("req_");
 export const CanonicalProviderInstanceIdSchema = canonicalReferenceId(128);
 export const CanonicalChatAttachmentKindSchema = z.enum(["file", "image", "diff", "structured_ref"]);
-export const CanonicalChatModelReferenceSchema = z.string()
-  .min(1)
-  .max(160)
-  .regex(
-    /^[A-Za-z0-9][A-Za-z0-9_.:-]*(?:\/[A-Za-z0-9][A-Za-z0-9_.:-]*)*$/,
-    "Invalid model reference",
-  )
-  .refine((value) => !value.includes(".."), {
-    message: "Model reference cannot contain traversal",
-  });
+export const CanonicalChatModelReferenceSchema = ProviderModelReferenceSchema;
 const CanonicalChatRelativePathSchema = z.string()
   .min(1)
   .max(4096)

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,5 +1,5 @@
 import { z } from "zod/v4";
-import { IsoTimestampSchema, SAFE_SLUG } from "#contract-primitives";
+import { IsoTimestampSchema, ProviderModelReferenceSchema, SAFE_SLUG } from "#contract-primitives";
 import {
   AgentAttachmentSchema,
   AgentAttentionSchema,
@@ -41,7 +41,7 @@ export * from "#kernel-result";
 export * from "#kernel-conversations";
 export * from "#safe-client-error";
 export * from "#terminal-links";
-export { IsoTimestampSchema } from "#contract-primitives";
+export { IsoTimestampSchema, ProviderModelReferenceSchema } from "#contract-primitives";
 
 const UNSAFE_ASSISTANT_PREVIEW_TEXT =
   /(postgres(?:ql)?:\/\/|mysql:\/\/|sqlite:|pipedream|twilio|openai|anthropic|constraint|stack trace|zod|issues|\/home\/|\/tmp\/|\/var\/|\/opt\/|\/etc\/|\/root\/|\/Users\/|[A-Za-z]:[\\/]|\.ssh\/|id_rsa|bearer\s+[A-Za-z0-9._-]+|sk-[A-Za-z0-9_-]+|password\s*[=:]|eyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}|ghp_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|glpat-[A-Za-z0-9_-]{12,}|xox[baprs]-[A-Za-z0-9-]{10,}|sk_(?:live|test)_[A-Za-z0-9]{12,}|AKIA[0-9A-Z]{16}|token|secret|private key|db\.internal|localhost|127\.0\.0\.1)/i;
@@ -377,7 +377,7 @@ export const CreateAgentThreadRequestSchema = z.object({
   mode: AgentModeSchema.optional(),
   approvalPolicy: ApprovalPolicySchema.optional(),
   sandboxMode: SandboxModeSchema.optional(),
-  model: referenceId(160).optional(),
+  model: ProviderModelReferenceSchema.optional(),
   modelOptions: z.array(AgentModelOptionSchema).max(32).optional(),
   attachments: z.array(AgentAttachmentSchema).max(8).optional(),
   clientRequestId: RequestIdSchema,
@@ -396,7 +396,7 @@ export type AdoptAgentThreadRequest = z.infer<typeof AdoptAgentThreadRequestSche
 export const CreateAgentTurnRequestSchema = z.object({
   message: boundedText(24_000, 96 * 1024),
   attachments: z.array(AgentAttachmentSchema).max(8).optional(),
-  model: referenceId(160).optional(),
+  model: ProviderModelReferenceSchema.optional(),
   modelOptions: z.array(AgentModelOptionSchema).max(32).optional(),
   clientRequestId: RequestIdSchema,
 }).strict();

--- a/packages/contracts/src/primitives.ts
+++ b/packages/contracts/src/primitives.ts
@@ -2,6 +2,17 @@ import { z } from "zod/v4";
 
 export const SAFE_SLUG = /^[a-z0-9][a-z0-9_-]{0,79}$/;
 
+export const ProviderModelReferenceSchema = z.string()
+  .min(1)
+  .max(160)
+  .regex(
+    /^[A-Za-z0-9][A-Za-z0-9_.:-]*(?:\/[A-Za-z0-9][A-Za-z0-9_.:-]*)*$/,
+    "Invalid model reference",
+  )
+  .refine((value) => !value.includes(".."), {
+    message: "Model reference cannot contain traversal",
+  });
+
 const ISO_DATETIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
 
 export const IsoTimestampSchema = z.string().regex(

--- a/packages/gateway/src/agent-launcher.ts
+++ b/packages/gateway/src/agent-launcher.ts
@@ -3,7 +3,12 @@ import { isAbsolute } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { z } from "zod/v4";
-import { AgentModelOptionSchema, CODEX_VERIFIED_VERSION, type AgentModelOption } from "@matrix-os/contracts";
+import {
+  AgentModelOptionSchema,
+  CODEX_VERIFIED_VERSION,
+  ProviderModelReferenceSchema,
+  type AgentModelOption,
+} from "@matrix-os/contracts";
 import { CodexExecutableSchema } from "./coding-agents/codex-executable.js";
 import { codexExecContractStatus } from "./coding-agents/codex-version.js";
 
@@ -81,7 +86,7 @@ const CodexAppServerConfigSchema = z.object({
   approvalPolicy: z.enum(["untrusted", "on-request", "never"]),
   sandbox: z.enum(["read-only", "workspace-write", "danger-full-access"]),
   writableRoots: z.array(z.string().min(1).max(4096).refine(isAbsolute)).max(20),
-  model: z.string().min(1).max(160).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]{0,159}$/).optional(),
+  model: ProviderModelReferenceSchema.optional(),
   effort: z.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]).optional(),
   serviceTier: z.string().min(1).max(160).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]{0,159}$/).optional(),
 }).strict();

--- a/packages/gateway/src/agent-session-manager.ts
+++ b/packages/gateway/src/agent-session-manager.ts
@@ -6,6 +6,7 @@ import { z } from "zod/v4";
 import {
   AgentAttachmentSchema,
   AgentModelOptionSchema,
+  ProviderModelReferenceSchema,
   type AgentAttachment,
 } from "@matrix-os/contracts";
 import {
@@ -106,7 +107,7 @@ const StartSessionSchema = z.object({
   agent: SupportedAgentSchema.optional(),
   prompt: PromptContentSchema.optional(),
   attachments: z.array(AgentAttachmentSchema).max(8).optional(),
-  model: z.string().trim().min(1).max(160).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]{0,159}$/).optional(),
+  model: ProviderModelReferenceSchema.optional(),
   modelOptions: z.array(AgentModelOptionSchema).max(32).optional(),
   mode: z.enum(["default", "plan", "review", "full_access"]).optional(),
   approvalPolicy: z.enum(["untrusted", "on_request", "on_failure", "never"]).optional(),

--- a/packages/gateway/src/chat/hermes-provider-adapter.ts
+++ b/packages/gateway/src/chat/hermes-provider-adapter.ts
@@ -1,5 +1,6 @@
 import { delimiter, join } from "node:path";
 import { z } from "zod/v4";
+import { CanonicalChatModelReferenceSchema } from "@matrix-os/contracts";
 import { buildAgentRuntimeEnvironment } from "../agent-launcher.js";
 import {
   CanonicalProviderRunEventSchema,
@@ -59,7 +60,7 @@ function selection(value: string): { provider: string; model: string } {
     throw new Error("Unsupported Hermes model selection");
   }
   const provider = z.string().regex(/^[A-Za-z0-9][A-Za-z0-9_-]{0,79}$/).parse(value.slice(0, separator));
-  const model = z.string().regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]{0,159}$/).parse(value.slice(separator + 1));
+  const model = CanonicalChatModelReferenceSchema.parse(value.slice(separator + 1));
   return { provider, model };
 }
 

--- a/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
+++ b/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
@@ -65,12 +65,19 @@ const NativeApprovalDecisionListSchema = z.array(z.unknown()).max(16).transform(
     const parsed = NativeApprovalDecisionSchema.safeParse(decision);
     return parsed.success ? [parsed.data] : [];
   }));
+// This runner is executed directly by plain Node, so keep this boundary schema
+// aligned with ProviderModelReferenceSchema from @matrix-os/contracts.
+const ProviderModelReferenceSchema = z.string()
+  .min(1)
+  .max(160)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*(?:\/[A-Za-z0-9][A-Za-z0-9_.:-]*)*$/)
+  .refine((value) => !value.includes(".."));
 const RunnerConfigSchema = z.object({
   prompt: z.string().trim().min(1).max(64 * 1024),
   approvalPolicy: z.enum(["untrusted", "on-request", "never"]),
   sandbox: z.enum(["read-only", "workspace-write", "danger-full-access"]),
   writableRoots: z.array(z.string().min(1).max(4096).refine(isAbsolute)).max(20),
-  model: z.string().min(1).max(160).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]{0,159}$/).optional(),
+  model: ProviderModelReferenceSchema.optional(),
   effort: z.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]).optional(),
   serviceTier: z.string().min(1).max(160).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]{0,159}$/).optional(),
 }).strict();

--- a/packages/gateway/src/coding-agents/codex-control-client.ts
+++ b/packages/gateway/src/coding-agents/codex-control-client.ts
@@ -6,6 +6,7 @@ import {
   AgentModelOptionSchema,
   ApprovalDecisionRequestSchema,
   ApprovalIdSchema,
+  ProviderModelReferenceSchema,
   RequestIdSchema,
   UserInputAnswerRequestSchema,
 } from "@matrix-os/contracts";
@@ -37,7 +38,7 @@ const TurnFrameSchema = z.object({
   type: z.literal("turn"),
   prompt: z.string().trim().min(1).max(64 * 1024)
     .refine((value) => Buffer.byteLength(value, "utf8") <= 64 * 1024),
-  model: z.string().trim().min(1).max(160).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]{0,159}$/).optional(),
+  model: ProviderModelReferenceSchema.optional(),
   modelOptions: z.array(AgentModelOptionSchema).max(32),
   clientRequestId: RequestIdSchema,
 }).strict();

--- a/tests/contracts/canonical-chat.test.ts
+++ b/tests/contracts/canonical-chat.test.ts
@@ -19,6 +19,21 @@ import {
 const now = "2026-08-25T00:00:00.000Z";
 
 describe("canonical Chat contracts", () => {
+  it("accepts namespaced Provider model references without accepting traversal", () => {
+    expect(CanonicalChatModelSelectionSchema.parse({
+      instanceId: "hermes_default",
+      model: "nous:anthropic/claude-opus-5",
+    })).toMatchObject({ model: "nous:anthropic/claude-opus-5" });
+    expect(CanonicalChatModelSelectionSchema.safeParse({
+      instanceId: "hermes_default",
+      model: "nous:../private-model",
+    }).success).toBe(false);
+    expect(CanonicalChatModelSelectionSchema.safeParse({
+      instanceId: "hermes_default",
+      model: "nous:anthropic\\claude-opus-5",
+    }).success).toBe(false);
+  });
+
   it("parses one complete Chat, Turn, Run, and message without exposing runtime internals", () => {
     const chat = CanonicalChatSchema.parse({
       id: "chat_demo",

--- a/tests/contracts/coding-agent-project-conversations.test.ts
+++ b/tests/contracts/coding-agent-project-conversations.test.ts
@@ -175,6 +175,7 @@ describe("coding agent project conversation contracts", () => {
     expect(AgentTurnIdSchema.parse("turn_auth_fix_1")).toBe("turn_auth_fix_1");
     expect(CreateAgentTurnRequestSchema.parse({
       message: "Continue with the gateway fix.",
+      model: "openai/gpt-5.6-sol",
       attachments: [{
         id: "review:auth:12",
         kind: "structured_ref",
@@ -182,7 +183,10 @@ describe("coding agent project conversation contracts", () => {
         path: "packages/gateway/src/auth.ts",
       }],
       clientRequestId: "req_turn_auth_1",
-    }).message).toBe("Continue with the gateway fix.");
+    })).toMatchObject({
+      message: "Continue with the gateway fix.",
+      model: "openai/gpt-5.6-sol",
+    });
 
     for (const invalid of [
       { message: "", clientRequestId: "req_turn_auth_1" },

--- a/tests/contracts/coding-agents.test.ts
+++ b/tests/contracts/coding-agents.test.ts
@@ -200,7 +200,11 @@ describe("coding agent contracts", () => {
       mode: "default",
       approvalPolicy: "on_request",
       sandboxMode: "workspace_write",
-    }).providerId).toBe("codex");
+      model: "openai/gpt-5.6-sol",
+    })).toMatchObject({
+      providerId: "codex",
+      model: "openai/gpt-5.6-sol",
+    });
     expect(() =>
       CreateAgentThreadRequestSchema.parse({
         providerId: "codex",

--- a/tests/gateway/agent-session-manager.test.ts
+++ b/tests/gateway/agent-session-manager.test.ts
@@ -158,6 +158,7 @@ describe("agent-session-manager", () => {
       worktreeId,
       pr: 42,
       prompt: "fix tests; rm -rf /",
+      model: "openai/gpt-5.6-sol",
       mode: "review",
       sandbox: { enabled: true },
     });
@@ -186,6 +187,7 @@ describe("agent-session-manager", () => {
     expect(agentLauncher.buildLaunch).toHaveBeenCalledWith(expect.objectContaining({
       agent: "codex",
       prompt: "fix tests; rm -rf /",
+      model: "openai/gpt-5.6-sol",
       mode: "review",
       cwd: join(homePath, "projects", "repo", "worktrees", worktreeId),
     }));

--- a/tests/gateway/chat-hermes-provider.test.ts
+++ b/tests/gateway/chat-hermes-provider.test.ts
@@ -102,6 +102,30 @@ async function collect(iterable: AsyncIterable<unknown>): Promise<unknown[]> {
 }
 
 describe("Hermes canonical Chat Provider adapter", () => {
+  it("forwards namespaced model ids to Hermes without rewriting them", async () => {
+    const gateway = fakeGateway();
+    const adapter = createHermesChatProviderAdapter({
+      homePath: "/home/matrix/home",
+      spawnFn: gateway.spawnFn,
+    });
+    const eventsPromise = collect(adapter.start({
+      ...baseInput,
+      selection: {
+        instanceId: "hermes_default",
+        model: "nous:anthropic/claude-opus-5",
+      },
+    }));
+
+    await vi.waitFor(() => expect(gateway.requests.some(({ method }) => method === "prompt.submit")).toBe(true));
+    expect(gateway.requests.find(({ method }) => method === "session.create")?.params)
+      .toMatchObject({ provider: "nous", model: "anthropic/claude-opus-5" });
+
+    gateway.event("message.complete", { text: "", status: "complete" });
+    await expect(eventsPromise).resolves.toEqual(expect.arrayContaining([
+      { type: "run.completed", outcome: "completed" },
+    ]));
+  });
+
   it("yields assistant text before the Hermes process completes", async () => {
     const gateway = fakeGateway();
     const adapter = createHermesChatProviderAdapter({

--- a/tests/gateway/chat-provider-catalog.test.ts
+++ b/tests/gateway/chat-provider-catalog.test.ts
@@ -98,6 +98,52 @@ function codingRegistry(
 }
 
 describe("canonical Chat Provider catalog", () => {
+  it("preserves namespaced system model ids in the canonical catalog", async () => {
+    const source: AgentRuntimeSource = async () => {
+      const snapshot = await runtimeSource()();
+      return {
+        ...snapshot,
+        providers: [...snapshot.providers, {
+          id: "nous",
+          displayName: "Nous Portal",
+          runtime: "hermes",
+          scopes: ["messaging"],
+          authKind: "oauth_login",
+          supportedAuthKinds: ["oauth_login"],
+          models: [{
+            id: "anthropic/claude-opus-5",
+            displayName: "Claude Opus 5",
+            capabilities: ["tools", "reasoning"],
+            efforts: ["high"],
+            available: true,
+          }],
+          authStatus: { state: "ready", authenticated: true, action: "none" },
+        }],
+        messaging: {
+          runtime: "hermes",
+          provider: "nous",
+          model: "anthropic/claude-opus-5",
+          configured: true,
+        },
+      };
+    };
+    const service = createChatProviderCatalogService({
+      codingProviders: codingRegistry(),
+      agentRuntimeSource: source,
+    });
+
+    const hermes = (await service.getCatalog(principal)).instances
+      .find((instance) => instance.id === "hermes_default")!;
+
+    expect(hermes.models).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "nous:anthropic/claude-opus-5" }),
+    ]));
+    expect(hermes.defaultSelection).toEqual({
+      instanceId: "hermes_default",
+      model: "nous:anthropic/claude-opus-5",
+    });
+  });
+
   it("projects system and coding runtimes through one bounded catalog", async () => {
     const service = createChatProviderCatalogService({
       codingProviders: codingRegistry(),

--- a/tests/gateway/coding-agents-codex-app-server-runtime.test.ts
+++ b/tests/gateway/coding-agents-codex-app-server-runtime.test.ts
@@ -414,7 +414,7 @@ describe("Codex app-server control runtime", () => {
       approvalPolicy: "on-request",
       sandbox: "workspace-write",
       writableRoots: [homePath],
-      model: "gpt-5.6-sol",
+      model: "openai/gpt-5.6-sol",
       effort: "low",
       serviceTier: "fast",
     }), "utf8").toString("base64");
@@ -428,7 +428,7 @@ describe("Codex app-server control runtime", () => {
     ], { cwd: homePath, stdio: ["pipe", "pipe", "pipe"] });
     const secondTurn = Buffer.from(JSON.stringify({
       prompt: "Second turn.",
-      model: "gpt-5.6-terra",
+      model: "openai/gpt-5.6-terra",
       modelOptions: [
         { id: "effort", value: "high" },
         { id: "service_tier", value: "standard" },
@@ -444,14 +444,14 @@ describe("Codex app-server control runtime", () => {
       expect(requests[0]).toMatchObject({
         threadId: "native-thread-turns",
         input: [{ type: "text", text: "First turn.", text_elements: [] }],
-        model: "gpt-5.6-sol",
+        model: "openai/gpt-5.6-sol",
         effort: "low",
         serviceTier: "fast",
       });
       expect(requests[1]).toMatchObject({
         threadId: "native-thread-turns",
         input: [{ type: "text", text: "Second turn.", text_elements: [] }],
-        model: "gpt-5.6-terra",
+        model: "openai/gpt-5.6-terra",
         effort: "high",
         serviceTier: "standard",
       });

--- a/tests/gateway/coding-agents-codex-control-client.test.ts
+++ b/tests/gateway/coding-agents-codex-control-client.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../packages/gateway/src/coding-agents/codex-control-client.js";
 
 const cleanup: Array<() => Promise<void>> = [];
+const socketTempRoot = process.platform === "darwin" ? "/tmp" : tmpdir();
 
 afterEach(async () => {
   await Promise.allSettled(cleanup.splice(0).map((remove) => remove()));
@@ -47,7 +48,7 @@ async function listen(homePath: string, sessionId: string, reply?: string) {
 
 describe("Codex control client", () => {
   it("submits bounded Turn, approval, and structured input frames", async () => {
-    const homePath = await mkdtemp(join(tmpdir(), "mx-control-"));
+    const homePath = await mkdtemp(join(socketTempRoot, "mx-control-"));
     const sessionId = "sess_thread_control_1";
     const frames = await listen(homePath, sessionId, '{"ok":true}\n');
     const client = createCodexControlClient({ homePath, timeoutMs: 1_000 });
@@ -56,7 +57,7 @@ describe("Codex control client", () => {
       sessionId,
       turnId: "turn_control_1",
       prompt: "Continue with the focused tests.",
-      model: "gpt-5.6-sol",
+      model: "openai/gpt-5.6-sol",
       modelOptions: [{ id: "effort", value: "high" }],
     });
     await client.submitApproval({
@@ -78,7 +79,7 @@ describe("Codex control client", () => {
       {
         type: "turn",
         prompt: "Continue with the focused tests.",
-        model: "gpt-5.6-sol",
+        model: "openai/gpt-5.6-sol",
         modelOptions: [{ id: "effort", value: "high" }],
         clientRequestId: "req_control_1",
       },
@@ -100,7 +101,7 @@ describe("Codex control client", () => {
   });
 
   it("fails closed for absent sockets, malformed replies, and stalled peers", async () => {
-    const absentHome = await mkdtemp(join(tmpdir(), "mx-control-absent-"));
+    const absentHome = await mkdtemp(join(socketTempRoot, "mx-control-absent-"));
     cleanup.push(() => rm(absentHome, { recursive: true, force: true }));
     const absent = createCodexControlClient({ homePath: absentHome, timeoutMs: 100 });
     await expect(absent.submitApproval({
@@ -110,7 +111,7 @@ describe("Codex control client", () => {
       clientRequestId: "req_absent_1",
     })).rejects.toThrow("Codex control request failed");
 
-    const malformedHome = await mkdtemp(join(tmpdir(), "mx-control-malformed-"));
+    const malformedHome = await mkdtemp(join(socketTempRoot, "mx-control-malformed-"));
     await listen(malformedHome, "sess_malformed", '{"providerError":"/private/path"}\n');
     const malformed = createCodexControlClient({ homePath: malformedHome, timeoutMs: 100 });
     await expect(malformed.submitApproval({
@@ -120,7 +121,7 @@ describe("Codex control client", () => {
       clientRequestId: "req_malformed_1",
     })).rejects.toThrow("Codex control request failed");
 
-    const stalledHome = await mkdtemp(join(tmpdir(), "mx-control-stalled-"));
+    const stalledHome = await mkdtemp(join(socketTempRoot, "mx-control-stalled-"));
     await listen(stalledHome, "sess_stalled");
     const stalled = createCodexControlClient({ homePath: stalledHome, timeoutMs: 25 });
     await expect(stalled.submitApproval({

--- a/tests/gateway/coding-agents-codex-runtime.test.ts
+++ b/tests/gateway/coding-agents-codex-runtime.test.ts
@@ -46,6 +46,7 @@ describe("Codex structured event runtime", () => {
       agent: "codex",
       cwd: "/home/matrix/home/projects/repo",
       prompt: "Fix the failing route.",
+      model: "openai/gpt-5.6-sol",
       approvalPolicy: "never",
       sandbox: {
         enabled: true,
@@ -65,6 +66,7 @@ describe("Codex structured event runtime", () => {
     const config = JSON.parse(Buffer.from(launch.args[4]!, "base64").toString("utf8"));
     expect(config).toEqual({
       prompt: "Fix the failing route.",
+      model: "openai/gpt-5.6-sol",
       approvalPolicy: "never",
       sandbox: "workspace-write",
       writableRoots: ["/home/matrix/home/projects/repo"],
@@ -613,9 +615,11 @@ describe("Codex structured event runtime", () => {
       runVersionCommand: vi.fn(async () => ({ stdout: "codex-cli 0.144.3\n", stderr: "" })),
     });
     let sessionId: string | undefined;
+    let runtimeModel: string | undefined;
     const runtime = {
-      startSession: vi.fn(async ({ request }: { request: { sessionId: string } }) => {
+      startSession: vi.fn(async ({ request }: { request: { sessionId: string; model?: string } }) => {
         sessionId = request.sessionId;
+        runtimeModel = request.model;
         return {
           ok: true as const,
           status: 201,
@@ -648,7 +652,7 @@ describe("Codex structured event runtime", () => {
         runId: "run_canonical_bridge",
         prompt: "Inspect the calculator.",
         parts: [{ type: "text", text: "Inspect the calculator." }],
-        selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+        selection: { instanceId: "codex_default", model: "openai/gpt-5.6-sol" },
         interactionMode: "default",
         permissionMode: "supervised",
         signal: AbortSignal.timeout(5_000),
@@ -659,6 +663,7 @@ describe("Codex structured event runtime", () => {
 
     try {
       await vi.waitFor(() => expect(sessionId).toBeDefined());
+      expect(runtimeModel).toBe("openai/gpt-5.6-sol");
       const eventPath = codexProviderEventPath(homePath, sessionId!);
       const delta = (index: number) => ({
         type: "matrix.codex.assistant.delta",


### PR DESCRIPTION
## Summary

- accept slash-delimited provider-native model identifiers in canonical Chat contracts
- preserve namespaced Hermes model IDs from provider catalog projection through session creation
- keep traversal, backslash, empty-segment, and unsafe-character inputs rejected

## Tests

- `flox activate -- bun run test -- tests/contracts/canonical-chat.test.ts tests/gateway/chat-provider-catalog.test.ts tests/gateway/chat-hermes-provider.test.ts` (45 passed)
- `flox activate -- bun run typecheck` (passed)
- `flox activate -- bun run check:patterns` (passed: 0 violations, 5 existing warnings)
- `git diff --check` (passed)
- `flox activate -- bun run test` (12,268 passed, 1 skipped; 13 macOS/environment baseline failures reproduced on untouched `main` in four unrelated files)

## Review / monitoring

- Monitor Greptile and review threads until the latest commit reaches 5/5 with no unresolved blocking findings.
- Apply `ready-for-ci` only after that review gate, then monitor required CI to completion.
- Do not merge as part of this PR workflow.

## Invariants

- **Source of truth:** the canonical model-reference schema owns validation of provider-native model identifiers; the runtime provider catalog remains authoritative for the available model inventory.
- **Lock / transaction scope:** none; this change performs no persistence writes and changes no transaction boundaries.
- **Acceptable orphan states:** none introduced; provider catalog parsing remains fail-closed, and existing stored selections are unchanged.
- **Auth source of truth:** unchanged; gateway request principals and provider credential readiness remain authoritative.
- **Deferred scope:** this does not broaden generic canonical reference IDs, alter provider discovery, or deploy a production runtime.
