### PR TITLE
feat(desktop): ship signed Windows releases

### DIFF
--- a/.github/actions/prune-desktop-channel-assets/action.yml
+++ b/.github/actions/prune-desktop-channel-assets/action.yml
@@ -1,5 +1,5 @@
 name: Prune Desktop channel assets
-description: Keep a mutable Desktop channel release limited to its two update manifests.
+description: Keep a mutable Desktop channel release limited to its three update manifests.
 
 inputs:
   tag_name:
@@ -23,10 +23,12 @@ runs:
           stable)
             ALLOWED_MAC="latest-mac.yml"
             ALLOWED_LINUX="latest-linux.yml"
+            ALLOWED_WINDOWS="latest.yml"
             ;;
           beta|canary|dev)
             ALLOWED_MAC="${CHANNEL}-mac.yml"
             ALLOWED_LINUX="${CHANNEL}-linux.yml"
+            ALLOWED_WINDOWS="${CHANNEL}.yml"
             ;;
           *)
             echo "Unsupported Desktop update channel: $CHANNEL" >&2
@@ -37,7 +39,7 @@ runs:
         gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" \
           --json assets --jq '.assets[].name' \
           | while IFS= read -r asset; do
-              if [ "$asset" = "$ALLOWED_MAC" ] || [ "$asset" = "$ALLOWED_LINUX" ]; then
+              if [ "$asset" = "$ALLOWED_MAC" ] || [ "$asset" = "$ALLOWED_LINUX" ] || [ "$asset" = "$ALLOWED_WINDOWS" ]; then
                 continue
               fi
               gh release delete-asset "$TAG_NAME" "$asset" \

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -375,6 +375,7 @@ jobs:
           update_port_file="$copy_dir/update-fixture.port"
           update_server_log="$copy_dir/update-fixture.log"
           node scripts/release/desktop-update-fixture-server.mjs \
+            --platform mac \
             --channel "$CHANNEL" \
             --version "$PACKAGE_VERSION" \
             --port-file "$update_port_file" >"$update_server_log" 2>&1 &
@@ -544,5 +545,254 @@ jobs:
             desktop/dist/*.AppImage
             desktop/dist/*.blockmap
             desktop/dist/*-linux.yml
+          if-no-files-found: error
+          retention-days: ${{ inputs.retention_days }}
+
+  windows:
+    name: Windows x64
+    runs-on: windows-latest
+    environment: desktop-release
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      MATRIX_DESKTOP_UPDATE_CHANNEL: ${{ inputs.channel }}
+      VITE_POSTHOG_PROJECT_TOKEN: ${{ vars.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN || vars.NEXT_PUBLIC_POSTHOG_KEY }}
+      VITE_POSTHOG_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.posthog.com' }}
+      MATRIX_DESKTOP_WINDOWS_SIGNING_MODE: ${{ vars.MATRIX_DESKTOP_WINDOWS_SIGNING_MODE }}
+      MATRIX_DESKTOP_WINDOWS_PUBLISHER_NAME: ${{ vars.MATRIX_DESKTOP_WINDOWS_PUBLISHER_NAME }}
+      MATRIX_DESKTOP_WINDOWS_SIGNING_ENDPOINT: ${{ vars.MATRIX_DESKTOP_WINDOWS_SIGNING_ENDPOINT }}
+      MATRIX_DESKTOP_WINDOWS_SIGNING_ACCOUNT: ${{ vars.MATRIX_DESKTOP_WINDOWS_SIGNING_ACCOUNT }}
+      MATRIX_DESKTOP_WINDOWS_CERTIFICATE_PROFILE: ${{ vars.MATRIX_DESKTOP_WINDOWS_CERTIFICATE_PROFILE }}
+      WIN_CSC_LINK: ${{ secrets.MATRIX_DESKTOP_WINDOWS_CERTIFICATE || secrets.WIN_CSC_LINK }}
+      WIN_CSC_KEY_PASSWORD: ${{ secrets.MATRIX_DESKTOP_WINDOWS_CERTIFICATE_PASSWORD || secrets.WIN_CSC_KEY_PASSWORD }}
+    steps:
+      - name: Validate PostHog support configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          normalized_posthog_token="$(printf '%s' "${VITE_POSTHOG_PROJECT_TOKEN:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+          if [ -z "$normalized_posthog_token" ]; then
+            echo "Missing required public PostHog project token for Desktop Support" >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate Windows signing configuration
+        shell: pwsh
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.MATRIX_DESKTOP_WINDOWS_AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.MATRIX_DESKTOP_WINDOWS_AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.MATRIX_DESKTOP_WINDOWS_AZURE_SUBSCRIPTION_ID }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          node --input-type=module -e "import { resolveWindowsSigningConfig } from './scripts/release/windows-signing-config.mjs'; resolveWindowsSigningConfig(process.env);"
+          if ($env:MATRIX_DESKTOP_WINDOWS_SIGNING_MODE -eq "azure") {
+            foreach ($name in @("AZURE_CLIENT_ID", "AZURE_TENANT_ID", "AZURE_SUBSCRIPTION_ID")) {
+              if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
+                throw "Missing required Azure OIDC configuration: $name"
+              }
+            }
+          }
+
+      - name: Authenticate to Azure for Artifact Signing
+        if: ${{ env.MATRIX_DESKTOP_WINDOWS_SIGNING_MODE == 'azure' }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.MATRIX_DESKTOP_WINDOWS_AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.MATRIX_DESKTOP_WINDOWS_AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.MATRIX_DESKTOP_WINDOWS_AZURE_SUBSCRIPTION_ID }}
+
+      - name: Apply desktop release version
+        if: ${{ inputs.version != '' || inputs.version_suffix != '' }}
+        shell: pwsh
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          VERSION_SUFFIX: ${{ inputs.version_suffix }}
+        run: |
+          node --input-type=module -e "import { readFile, writeFile } from 'node:fs/promises'; const p='desktop/package.json'; const j=JSON.parse(await readFile(p,'utf8')); const exact=process.env.RELEASE_VERSION || ''; const suffix=process.env.VERSION_SUFFIX || ''; j.version = exact || (j.version.replace(/-.*/, '') + '-' + suffix); await writeFile(p, JSON.stringify(j, null, 2) + '\n');"
+
+      - name: Build desktop app
+        shell: pwsh
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
+        run: pnpm --filter desktop build
+
+      - name: Package signed Windows app
+        working-directory: desktop
+        shell: pwsh
+        run: pnpm exec electron-builder --config electron-builder.windows.mjs --win nsis --x64 --publish never
+
+      - name: Resolve Windows artifact metadata
+        id: windows_artifact
+        shell: pwsh
+        run: |
+          $packageVersion = node -p "require('./desktop/package.json').version"
+          "package_version=$packageVersion" >> $env:GITHUB_OUTPUT
+          "artifact_base=Matrix-OS-${packageVersion}-win-x64" >> $env:GITHUB_OUTPUT
+
+      - name: Verify Windows artifacts and Authenticode signatures
+        shell: pwsh
+        env:
+          ARTIFACT_BASE: ${{ steps.windows_artifact.outputs.artifact_base }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $installerPath = Join-Path $PWD "desktop/dist/$env:ARTIFACT_BASE.exe"
+          $blockmapPath = "$installerPath.blockmap"
+          $manifestPath = Join-Path $PWD "desktop/dist/latest.yml"
+          $appPath = Join-Path $PWD "desktop/dist/win-unpacked/Matrix OS.exe"
+          $appUpdatePath = Join-Path $PWD "desktop/dist/win-unpacked/resources/app-update.yml"
+          foreach ($path in @($installerPath, $blockmapPath, $manifestPath, $appPath, $appUpdatePath)) {
+            if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+              throw "Missing expected Windows release artifact: $path"
+            }
+          }
+          $unexpected = Get-ChildItem desktop/dist -File -Filter "Matrix-OS-*-win-*.exe" |
+            Where-Object { $_.FullName -ne $installerPath }
+          if ($unexpected) {
+            throw "Windows build produced unexpected installer: $($unexpected[0].Name)"
+          }
+          foreach ($signedPath in @($appPath, $installerPath)) {
+            $signature = Get-AuthenticodeSignature -LiteralPath $signedPath
+            if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
+              throw "Invalid Authenticode signature on $signedPath (status: $($signature.Status))"
+            }
+            if ($signature.SignerCertificate.Subject -ne $env:MATRIX_DESKTOP_WINDOWS_PUBLISHER_NAME) {
+              throw "Unexpected Authenticode publisher on $signedPath"
+            }
+          }
+          $asarEntries = pnpm exec asar list "desktop/dist/win-unpacked/resources/app.asar"
+          if ($asarEntries -match "node_modules/@matrix-os/contracts") {
+            throw "Packaged app contains raw @matrix-os/contracts sources"
+          }
+
+      - name: Create Windows channel update manifest
+        if: ${{ inputs.channel != 'stable' }}
+        shell: pwsh
+        env:
+          CHANNEL: ${{ inputs.channel }}
+        run: Copy-Item desktop/dist/latest.yml "desktop/dist/$env:CHANNEL.yml"
+
+      - name: Smoke test Windows installer, protocols, app, updater, and uninstaller
+        shell: pwsh
+        env:
+          ARTIFACT_BASE: ${{ steps.windows_artifact.outputs.artifact_base }}
+          CHANNEL: ${{ inputs.channel }}
+          PACKAGE_VERSION: ${{ steps.windows_artifact.outputs.package_version }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $installerPath = Join-Path $PWD "desktop/dist/$env:ARTIFACT_BASE.exe"
+          $installDirectory = Join-Path $env:LOCALAPPDATA "Programs/Matrix OS"
+          $installedAppPath = Join-Path $installDirectory "Matrix OS.exe"
+          $uninstallerPath = Join-Path $installDirectory "Uninstall Matrix OS.exe"
+          $smokeDirectory = Join-Path $env:RUNNER_TEMP "matrix-os-windows-smoke"
+          New-Item -ItemType Directory -Force -Path $smokeDirectory | Out-Null
+          $serverProcess = $null
+          $appProcess = $null
+          try {
+            Start-Process -FilePath $installerPath -ArgumentList "/S" -Wait
+            foreach ($path in @($installedAppPath, $uninstallerPath)) {
+              if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+                throw "Silent NSIS install did not create $path"
+              }
+            }
+            foreach ($scheme in @("matrixos", "matrix-os")) {
+              $protocolKey = "Registry::HKEY_CURRENT_USER\Software\Classes\$scheme"
+              if (-not (Test-Path -LiteralPath $protocolKey)) {
+                throw "NSIS install did not register protocol $scheme"
+              }
+            }
+
+            $portFile = Join-Path $smokeDirectory "update-fixture.port"
+            $serverLog = Join-Path $smokeDirectory "update-fixture.log"
+            $serverErrorLog = Join-Path $smokeDirectory "update-fixture-error.log"
+            $serverProcess = Start-Process -FilePath "node" -ArgumentList @(
+              "scripts/release/desktop-update-fixture-server.mjs",
+              "--platform", "windows",
+              "--channel", $env:CHANNEL,
+              "--version", $env:PACKAGE_VERSION,
+              "--port-file", $portFile
+            ) -PassThru -RedirectStandardOutput $serverLog -RedirectStandardError $serverErrorLog
+            for ($attempt = 1; $attempt -le 40 -and -not (Test-Path $portFile); $attempt++) {
+              if ($serverProcess.HasExited) {
+                throw "Desktop update fixture server exited before becoming ready"
+              }
+              Start-Sleep -Milliseconds 250
+            }
+            if (-not (Test-Path $portFile)) {
+              throw "Desktop update fixture server did not become ready"
+            }
+            $updatePort = (Get-Content -Raw $portFile).Trim()
+            if ($updatePort -notmatch "^[0-9]+$") {
+              throw "Desktop update fixture server returned an invalid port"
+            }
+
+            $env:OPERATOR_USER_DATA_DIR = Join-Path $smokeDirectory "user-data"
+            $env:OPERATOR_UPDATE_CHANNEL = $env:CHANNEL
+            $env:OPERATOR_UPDATE_FEED = "http://127.0.0.1:$updatePort/"
+            $appLog = Join-Path $smokeDirectory "matrix-os-launch.log"
+            $appErrorLog = Join-Path $smokeDirectory "matrix-os-launch-error.log"
+            $appProcess = Start-Process -FilePath $installedAppPath -ArgumentList "--disable-gpu" `
+              -PassThru -RedirectStandardOutput $appLog -RedirectStandardError $appErrorLog
+            $updateSucceeded = $false
+            for ($attempt = 1; $attempt -le 30; $attempt++) {
+              if ($appProcess.HasExited) {
+                throw "Installed Windows app exited during launch smoke test"
+              }
+              $combinedLog = ((Get-Content $appLog, $appErrorLog -Raw -ErrorAction SilentlyContinue) -join "`n")
+              if ($combinedLog.Contains("[updates] check failed:")) {
+                throw "Installed Windows updater failed its fixture feed check"
+              }
+              if ($combinedLog.Contains("[updates] update check completed: up to date")) {
+                $updateSucceeded = $true
+                break
+              }
+              Start-Sleep -Seconds 1
+            }
+            if (-not $updateSucceeded) {
+              throw "Installed Windows updater did not complete its fixture feed check"
+            }
+            if ($combinedLog.Contains("ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING")) {
+              throw "Installed Windows app attempted to load raw TypeScript"
+            }
+          } finally {
+            if ($appProcess -and -not $appProcess.HasExited) {
+              Stop-Process -Id $appProcess.Id -Force -ErrorAction SilentlyContinue
+              $appProcess.WaitForExit()
+            }
+            if ($serverProcess -and -not $serverProcess.HasExited) {
+              Stop-Process -Id $serverProcess.Id -Force -ErrorAction SilentlyContinue
+              $serverProcess.WaitForExit()
+            }
+            if (Test-Path -LiteralPath $uninstallerPath -PathType Leaf) {
+              Start-Process -FilePath $uninstallerPath -ArgumentList "/S" -Wait
+            }
+          }
+          if (Test-Path -LiteralPath $installedAppPath) {
+            throw "Silent NSIS uninstall left the installed app behind"
+          }
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ inputs.artifact_prefix }}-windows-x64
+          path: |
+            desktop/dist/*.exe
+            desktop/dist/*.blockmap
+            desktop/dist/*.yml
           if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -578,16 +578,16 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: pnpm
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -611,7 +611,7 @@ jobs:
 
       - name: Authenticate to Azure for Artifact Signing
         if: ${{ env.MATRIX_DESKTOP_WINDOWS_SIGNING_MODE == 'azure' }}
-        uses: azure/login@v2
+        uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2
         with:
           client-id: ${{ secrets.MATRIX_DESKTOP_WINDOWS_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.MATRIX_DESKTOP_WINDOWS_AZURE_TENANT_ID }}
@@ -787,7 +787,7 @@ jobs:
           }
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ${{ inputs.artifact_prefix }}-windows-x64
           path: |

--- a/.github/workflows/desktop-release-canary.yml
+++ b/.github/workflows/desktop-release-canary.yml
@@ -43,6 +43,9 @@ jobs:
 
   build:
     needs: prepare
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/desktop-build.yml
     with:
       channel: canary

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -107,6 +107,9 @@ jobs:
 
   build:
     needs: prepare
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/desktop-build.yml
     with:
       channel: ${{ needs.prepare.outputs.channel }}

--- a/desktop/electron-builder.windows.mjs
+++ b/desktop/electron-builder.windows.mjs
@@ -1,0 +1,6 @@
+import { resolveWindowsSigningConfig } from "../scripts/release/windows-signing-config.mjs";
+
+export default {
+  extends: "./electron-builder.yml",
+  ...resolveWindowsSigningConfig(process.env),
+};

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -41,6 +41,21 @@ dmg:
       y: 322
       type: link
       path: /Applications
+win:
+  icon: build/icon.png
+  requestedExecutionLevel: asInvoker
+  verifyUpdateCodeSignature: true
+  target:
+    - target: nsis
+      arch: [x64]
+nsis:
+  oneClick: true
+  perMachine: false
+  allowElevation: true
+  createDesktopShortcut: always
+  createStartMenuShortcut: true
+  shortcutName: Matrix OS
+  uninstallDisplayName: Matrix OS
 linux:
   category: Utility
   target:

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -41,6 +41,7 @@ import {
   type FittedWindowBounds,
   type WindowBounds,
 } from "./platform/window-bounds";
+import { windowChromeOptions } from "./platform/window-chrome";
 import { createUpdater } from "./updates";
 import { createUpdateAwareBeforeQuit } from "./update-quit";
 import { safeExternalHttpUrl } from "./external-url";
@@ -102,10 +103,7 @@ async function openExternalHttpUrl(url: string): Promise<void> {
 function createWindow(bounds: FittedWindowBounds): BrowserWindow {
   const win = new BrowserWindow({
     ...bounds,
-    // Let the renderer's active surface continue beneath the macOS controls
-    // instead of retaining an opaque native title-bar material.
-    titleBarStyle: "hidden",
-    trafficLightPosition: { x: 14, y: 13 },
+    ...windowChromeOptions(process.platform),
     backgroundColor: "#0e0e13",
     show: false,
     webPreferences: {

--- a/desktop/src/main/platform/menu-template.ts
+++ b/desktop/src/main/platform/menu-template.ts
@@ -6,6 +6,7 @@ type MenuEventSender = (channel: string, payload: unknown) => void;
 interface AppMenuTemplateOptions {
   appName: string;
   isPackaged: boolean;
+  platform?: NodeJS.Platform;
   openExternal(url: string): void;
   send: MenuEventSender;
   adjustZoom(action: ZoomAction): void;
@@ -16,26 +17,29 @@ interface AppMenuTemplateOptions {
 export function createAppMenuTemplate({
   appName,
   isPackaged,
+  platform = process.platform,
   openExternal,
   send,
   adjustZoom,
   checkForUpdates,
   quitApp,
 }: AppMenuTemplateOptions): MenuItemConstructorOptions[] {
+  const isMac = platform === "darwin";
+  const primary = (keys: string) => `${isMac ? "Cmd" : "CmdOrCtrl"}+${keys}`;
   const viewSubmenu: MenuItemConstructorOptions[] = [
     {
       label: "Command Palette",
-      accelerator: "Cmd+K",
+      accelerator: primary("K"),
       click: () => send("menu:action", { action: "palette" }),
     },
     {
       label: "Go to File",
-      accelerator: "Cmd+P",
+      accelerator: primary("P"),
       click: () => send("menu:action", { action: "quick-open" }),
     },
     {
       label: "Terminal",
-      accelerator: "Cmd+Alt+T",
+      accelerator: primary("Alt+T"),
       click: () => send("menu:navigate", { kind: "terminals" }),
     },
     {
@@ -43,13 +47,7 @@ export function createAppMenuTemplate({
       accelerator: "CmdOrCtrl+R",
       click: () => send("menu:action", { action: "refresh-home" }),
     },
-  ];
-
-  viewSubmenu.push(
     { type: "separator" },
-    // Custom click handlers instead of the zoomin/zoomout/resetzoom roles so
-    // the factor round-trips through the shared zoom step path and the
-    // renderer store hears about it via app:zoom-changed.
     {
       label: "Zoom In",
       accelerator: "CmdOrCtrl+=",
@@ -70,75 +68,93 @@ export function createAppMenuTemplate({
     ...(isPackaged
       ? []
       : ([{ type: "separator" }, { role: "toggleDevTools" }] as MenuItemConstructorOptions[])),
-  );
+  ];
+
+  const updateItem: MenuItemConstructorOptions = {
+    label: "Check for Updates…",
+    click: () => {
+      send("update:manual-check-requested", {});
+      checkForUpdates();
+    },
+  };
+  const settingsItem: MenuItemConstructorOptions = {
+    label: "Settings…",
+    accelerator: primary(","),
+    click: () => send("menu:navigate", { kind: "settings" }),
+  };
+  const newItems: MenuItemConstructorOptions[] = [
+    {
+      label: "New",
+      accelerator: primary("N"),
+      click: () => send("menu:action", { action: "new-context" }),
+    },
+    {
+      label: "New Agent Thread",
+      accelerator: primary("J"),
+      click: () => send("menu:action", { action: "new-thread" }),
+    },
+    { type: "separator" },
+    {
+      label: "New Tab",
+      accelerator: primary("T"),
+      click: () => send("menu:action", { action: "new-tab" }),
+    },
+    {
+      label: "Close Tab",
+      accelerator: primary("W"),
+      click: () => send("menu:action", { action: "close-tab" }),
+    },
+  ];
+
+  const platformMenus: MenuItemConstructorOptions[] = isMac
+    ? [
+        {
+          label: appName,
+          submenu: [
+            { role: "about" },
+            updateItem,
+            { type: "separator" },
+            settingsItem,
+            { type: "separator" },
+            { role: "services" },
+            { type: "separator" },
+            { role: "hide" },
+            { role: "hideOthers" },
+            { role: "unhide" },
+            { type: "separator" },
+            {
+              label: "Close Selected App",
+              accelerator: primary("Q"),
+              click: () => send("menu:action", { action: "close-app" }),
+            },
+            { label: `Quit ${appName}`, click: quitApp },
+          ],
+        },
+        { label: "File", submenu: newItems },
+      ]
+    : [
+        {
+          label: "File",
+          submenu: [
+            ...newItems,
+            { type: "separator" },
+            settingsItem,
+            updateItem,
+            { type: "separator" },
+            {
+              label: "Close Selected App",
+              accelerator: primary("Q"),
+              click: () => send("menu:action", { action: "close-app" }),
+            },
+            { label: "Exit", click: quitApp },
+          ],
+        },
+      ];
 
   return [
-    {
-      label: appName,
-      submenu: [
-        { role: "about" },
-        {
-          label: "Check for Updates…",
-          click: () => {
-            send("update:manual-check-requested", {});
-            checkForUpdates();
-          },
-        },
-        { type: "separator" },
-        {
-          label: "Settings…",
-          accelerator: "Cmd+,",
-          click: () => send("menu:navigate", { kind: "settings" }),
-        },
-        { type: "separator" },
-        { role: "services" },
-        { type: "separator" },
-        { role: "hide" },
-        { role: "hideOthers" },
-        { role: "unhide" },
-        { type: "separator" },
-        {
-          label: "Close Selected App",
-          accelerator: "Cmd+Q",
-          click: () => send("menu:action", { action: "close-app" }),
-        },
-        {
-          label: `Quit ${appName}`,
-          click: quitApp,
-        },
-      ],
-    },
-    {
-      label: "File",
-      submenu: [
-        {
-          label: "New",
-          accelerator: "Cmd+N",
-          click: () => send("menu:action", { action: "new-context" }),
-        },
-        {
-          label: "New Agent Thread",
-          accelerator: "Cmd+J",
-          click: () => send("menu:action", { action: "new-thread" }),
-        },
-        { type: "separator" },
-        {
-          label: "New Tab",
-          accelerator: "Cmd+T",
-          click: () => send("menu:action", { action: "new-tab" }),
-        },
-        {
-          label: "Close Tab",
-          accelerator: "Cmd+W",
-          click: () => send("menu:action", { action: "close-tab" }),
-        },
-      ],
-    },
+    ...platformMenus,
     { role: "editMenu" },
-    {
-      label: "View",
-      submenu: viewSubmenu,
-    },
+    { label: "View", submenu: viewSubmenu },
     { role: "windowMenu" },
     {
       role: "help",

--- a/desktop/src/main/platform/menu.ts
+++ b/desktop/src/main/platform/menu.ts
@@ -25,6 +25,7 @@ export function installAppMenu(
   const template = createAppMenuTemplate({
     appName: app.name,
     isPackaged: app.isPackaged,
+    platform: process.platform,
     openExternal: (url) => {
       void shell.openExternal(url);
     },

--- a/desktop/src/main/platform/window-chrome.ts
+++ b/desktop/src/main/platform/window-chrome.ts
@@ -1,0 +1,28 @@
+import type { BrowserWindowConstructorOptions } from "electron";
+
+type WindowChromeOptions = Pick<
+  BrowserWindowConstructorOptions,
+  "titleBarOverlay" | "titleBarStyle" | "trafficLightPosition"
+>;
+
+export function windowChromeOptions(platform: NodeJS.Platform): WindowChromeOptions {
+  if (platform === "darwin") {
+    return {
+      titleBarStyle: "hidden",
+      trafficLightPosition: { x: 14, y: 13 },
+    };
+  }
+
+  if (platform === "win32") {
+    return {
+      titleBarStyle: "hidden",
+      titleBarOverlay: {
+        color: "#0e0e13",
+        symbolColor: "#f9f7f1",
+        height: 38,
+      },
+    };
+  }
+
+  return { titleBarStyle: "default" };
+}

--- a/desktop/src/renderer/src/design/index.css
+++ b/desktop/src/renderer/src/design/index.css
@@ -75,7 +75,13 @@ textarea,
   user-select: text;
 }
 
-/* ── Titlebar drag region (frameless hiddenInset window) ──────── */
+/* ── Titlebar drag region ─────────────────────────────────────── */
+.native-titlebar {
+  left: env(titlebar-area-x, 0px);
+  right: auto;
+  top: env(titlebar-area-y, 0px);
+  width: env(titlebar-area-width, 100%);
+}
 .titlebar-drag {
   -webkit-app-region: drag;
 }

--- a/desktop/src/renderer/src/features/board/CreateTaskDialog.tsx
+++ b/desktop/src/renderer/src/features/board/CreateTaskDialog.tsx
@@ -6,6 +6,7 @@ import {
   type CSSProperties,
   type MutableRefObject,
 } from "react";
+import { desktopShortcutLabel } from "@renderer/lib/platform-labels";
 import { Button, Dialog } from "../../design/primitives";
 import { useBoard, BOARD_COLUMNS, type CardPriority, type CardStatus } from "../../stores/board";
 import { useConnection } from "../../stores/connection";
@@ -190,7 +191,7 @@ function CreateTaskForm({
           variant="subtle"
           disabled={!canSubmit}
           onClick={() => void submit(true).catch(logSubmitFailure)}
-          title="Create and open (Cmd+Shift+Enter)"
+          title={`Create and open (${desktopShortcutLabel("Shift+Enter")})`}
         >
           Create + open
         </Button>
@@ -198,7 +199,7 @@ function CreateTaskForm({
           variant="primary"
           disabled={!canSubmit}
           onClick={() => void submit(false).catch(logSubmitFailure)}
-          title="Create (Cmd+Enter)"
+          title={`Create (${desktopShortcutLabel("Enter")})`}
         >
           {submitting ? "Creating…" : "Create"}
         </Button>

--- a/desktop/src/renderer/src/features/editor/EditorPanel.tsx
+++ b/desktop/src/renderer/src/features/editor/EditorPanel.tsx
@@ -1,4 +1,5 @@
 import { Code2, Eye, FileCode2, X } from "@renderer/lib/hugeicons";
+import { desktopShortcutLabel } from "@renderer/lib/platform-labels";
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { Button, EmptyState } from "../../design/primitives";
 import { useConnection } from "../../stores/connection";
@@ -29,7 +30,7 @@ export default function EditorPanel({ taskId }: { taskId: string }) {
       <EmptyState
         icon={<FileCode2 size={24} />}
         headline="No file open"
-        description="Open a file from the file browser or press ⌘P to quick-open."
+        description={`Open a file from the file browser or press ${desktopShortcutLabel("P")} to quick-open.`}
       />
     );
   }

--- a/desktop/src/renderer/src/features/mission-control/NavigationHeader.tsx
+++ b/desktop/src/renderer/src/features/mission-control/NavigationHeader.tsx
@@ -227,7 +227,7 @@ export default function NavigationHeader({ nativeDesktop = false }: { nativeDesk
 
   return (
     <header
-      className="titlebar-drag absolute inset-x-0 top-0 grid shrink-0 items-center"
+      className="native-titlebar titlebar-drag absolute inset-x-0 top-0 grid shrink-0 items-center"
       onDoubleClick={handleTitlebarDoubleClick}
       style={{
         zIndex: DESKTOP_Z_INDEX.chrome,

--- a/desktop/src/renderer/src/features/palette/CommandPalette.tsx
+++ b/desktop/src/renderer/src/features/palette/CommandPalette.tsx
@@ -1,4 +1,5 @@
 import { Command } from "cmdk";
+import { desktopShortcutLabel } from "@renderer/lib/platform-labels";
 import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import type { AgentThreadSummary, ReviewSummary, TerminalSessionSummary } from "@matrix-os/contracts";
 import { ClipboardCheck, GitBranch, Globe2, Kanban, LayoutGrid, MessageSquarePlus, PanelsTopLeft, Plus, Settings, Sparkles, SquareTerminal } from "@renderer/lib/hugeicons";
@@ -238,7 +239,7 @@ export default function CommandPalette() {
             <PaletteItem
               icon={<MessageSquarePlus size={14} />}
               label="New agent run"
-              shortcut="⌘J"
+              shortcut={desktopShortcutLabel("J")}
               onSelect={() =>
                 run(() => {
                   handleNewAgentRunShortcut(

--- a/desktop/src/renderer/src/features/settings/sections/AppearanceSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/AppearanceSection.tsx
@@ -1,4 +1,5 @@
 import { Check, Minus, Plus } from "@renderer/lib/hugeicons";
+import { desktopShortcutLabel } from "@renderer/lib/platform-labels";
 import { Button, IconButton } from "../../../design/primitives";
 import { getThemeVariant, unifiedThemes } from "../../../design/themes";
 import { resolveThemeMode, type ThemeMode } from "../../../design/themes/apply";
@@ -102,7 +103,7 @@ export default function AppearanceSection() {
         <span className="text-sm" style={{ color: "var(--text-secondary)" }}>Zoom</span>
         <div className="flex items-center gap-2">
           <IconButton
-            label="Zoom out (⌘-)"
+            label={`Zoom out (${desktopShortcutLabel("-")})`}
             disabled={zoom <= MIN_ZOOM}
             onClick={() => setZoom(zoom - ZOOM_STEP)}
           >
@@ -115,7 +116,7 @@ export default function AppearanceSection() {
             {Math.round(zoom * 100)}%
           </span>
           <IconButton
-            label="Zoom in (⌘=)"
+            label={`Zoom in (${desktopShortcutLabel("=")})`}
             disabled={zoom >= MAX_ZOOM}
             onClick={() => setZoom(zoom + ZOOM_STEP)}
           >
@@ -126,7 +127,7 @@ export default function AppearanceSection() {
           </Button>
         </div>
         <p className="text-xs" style={{ color: "var(--text-tertiary)" }}>
-          Zooms the entire interface. ⌘=, ⌘-, and ⌘0 work anywhere in the app.
+          Zooms the entire interface. {desktopShortcutLabel("=")}, {desktopShortcutLabel("-")}, and {desktopShortcutLabel("0")} work anywhere in the app.
         </p>
       </Card>
       <Card>

--- a/desktop/src/renderer/src/features/signin/SignIn.tsx
+++ b/desktop/src/renderer/src/features/signin/SignIn.tsx
@@ -64,7 +64,7 @@ export default function SignIn() {
 
   return (
     <div className="flex h-full flex-col" style={{ background: "var(--bg-app)" }}>
-      <header className="titlebar-drag absolute inset-x-0 top-0 z-10" style={{ height: "var(--titlebar-height)" }} />
+      <header className="native-titlebar titlebar-drag absolute inset-x-0 top-0 z-10" style={{ height: "var(--titlebar-height)" }} />
       <div className="grid flex-1 grid-cols-1 md:grid-cols-[minmax(0,1fr)_minmax(0,1.05fr)]">
         <BrandPanel
           title={<>Code on your<br />cloud computer</>}

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -12,6 +12,7 @@ import {
   Trash2,
   X,
 } from "@renderer/lib/hugeicons";
+import { systemTerminalLabel } from "@renderer/lib/platform-labels";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button, Dialog, EmptyState, IconButton } from "../../design/primitives";
 import RetainedPane from "../../design/RetainedPane";
@@ -563,7 +564,7 @@ function ShellListEmpty() {
     <div className="flex flex-col items-center justify-center gap-2 rounded-md border border-dashed px-4 py-8 text-center" style={{ borderColor: "var(--border-subtle)" }}>
       <SquareTerminal size={22} style={{ color: "var(--text-tertiary)" }} />
       <p className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>No shell sessions yet</p>
-      <p className="text-xs" style={{ color: "var(--text-secondary)" }}>Start a shell to attach from the Mac Terminal.</p>
+      <p className="text-xs" style={{ color: "var(--text-secondary)" }}>Start a shell to attach from the {systemTerminalLabel()}.</p>
     </div>
   );
 }

--- a/desktop/src/renderer/src/features/threads/Composer.tsx
+++ b/desktop/src/renderer/src/features/threads/Composer.tsx
@@ -1,4 +1,5 @@
 import { CornerDownLeft } from "@renderer/lib/hugeicons";
+import { desktopShortcutLabel } from "@renderer/lib/platform-labels";
 import { useMemo, useState } from "react";
 import { Dialog } from "../../design/primitives";
 import { sendKernelMessage } from "../../lib/kernel-wiring";
@@ -84,7 +85,7 @@ function ComposerForm({ onClose }: { onClose: () => void }) {
         >
           Start
           <span className="flex items-center gap-0.5 text-xs opacity-80">
-            ⌘<CornerDownLeft size={11} />
+            {desktopShortcutLabel("")}<CornerDownLeft size={11} />
           </span>
         </button>
       </div>

--- a/desktop/src/renderer/src/features/workspace/PanelStrip.tsx
+++ b/desktop/src/renderer/src/features/workspace/PanelStrip.tsx
@@ -1,4 +1,5 @@
 import { Component, useMemo, type ErrorInfo, type ReactNode } from "react";
+import { desktopShortcutLabel } from "@renderer/lib/platform-labels";
 import { Group, Panel, Separator, type Layout as GroupLayout } from "react-resizable-panels";
 import {
   useWorkspace,
@@ -101,7 +102,7 @@ export default function PanelStrip({ taskId, renderPanel }: PanelStripProps) {
     return (
       <div className="flex flex-1 items-center justify-center">
         <span className="text-sm" style={{ color: "var(--text-tertiary)" }}>
-          All panels hidden. Toggle one from the toolbar (⌘1–⌘7).
+          All panels hidden. Toggle one from the toolbar ({desktopShortcutLabel("1")}–{desktopShortcutLabel("7")}).
         </span>
       </div>
     );

--- a/desktop/src/renderer/src/features/workspace/TaskWorkspace.tsx
+++ b/desktop/src/renderer/src/features/workspace/TaskWorkspace.tsx
@@ -9,6 +9,7 @@ import {
   Sparkles,
   SquareTerminal,
 } from "@renderer/lib/hugeicons";
+import { desktopShortcutLabel } from "@renderer/lib/platform-labels";
 import { useEffect, useMemo, useState } from "react";
 import { EmptyState, IconButton, StatusDot } from "../../design/primitives";
 import { useBoard } from "../../stores/board";
@@ -325,7 +326,7 @@ export default function TaskWorkspace({
           {PANEL_SHORTCUT_ORDER.map((panel, i) => (
             <IconButton
               key={panel}
-              label={`${PANEL_TITLES[panel]} (⌘${i + 1})`}
+              label={`${PANEL_TITLES[panel]} (${desktopShortcutLabel(String(i + 1))})`}
               active={Boolean(layout.visible[panel])}
               onClick={() => togglePanel(taskId, panel)}
             >

--- a/desktop/src/renderer/src/lib/platform-labels.ts
+++ b/desktop/src/renderer/src/lib/platform-labels.ts
@@ -1,0 +1,17 @@
+function currentPlatform(): string {
+  return typeof navigator === "undefined" ? "" : navigator.platform;
+}
+
+function isMacPlatform(platform: string): boolean {
+  return /^(Mac|iPhone|iPad|iPod)/i.test(platform);
+}
+
+export function desktopShortcutLabel(keys: string, platform = currentPlatform()): string {
+  return `${isMacPlatform(platform) ? "⌘" : "Ctrl+"}${keys}`;
+}
+
+export function systemTerminalLabel(platform = currentPlatform()): string {
+  if (isMacPlatform(platform)) return "Mac Terminal";
+  if (/^Win/i.test(platform)) return "Windows Terminal";
+  return "system terminal";
+}

--- a/docs/dev/desktop-release.md
+++ b/docs/dev/desktop-release.md
@@ -15,7 +15,9 @@ This pipeline borrows the useful parts of two working desktop release systems:
 - SlayZone: release manifest with SHA-256 sums, explicit channel metadata, and
   dry-run release bundles before publish.
 
-## Required Secrets
+## Required signing configuration
+
+### macOS
 
 The macOS jobs expect an Apple Developer ID Application certificate readable by
 electron-builder:
@@ -31,11 +33,98 @@ secure URL supported by electron-builder. macOS release jobs fail before the
 build if any certificate, certificate-password, or notarization secret is
 missing; unsigned artifacts must never reach a release.
 
+### Windows (recommended: Azure Artifact Signing)
+
+Windows releases are x64 NSIS installers. The release workflow runs on a
+Windows GitHub runner, signs through Azure Artifact Signing (formerly Trusted
+Signing), and fails closed if signing is missing or invalid. It verifies the
+Authenticode signature on both `Matrix OS.exe` and the NSIS installer before an
+artifact can be uploaded. This is app packaging; Electron's [Windows build
+instructions](https://www.electronjs.org/docs/latest/development/build-instructions-windows)
+are for compiling Electron itself and are not required.
+
+Provision the signer once:
+
+1. In the Azure portal, create an **Artifact Signing** account in the chosen
+   region. Complete organization identity validation, then create a
+   **Public Trust** certificate profile. Record the account name, profile name,
+   regional endpoint, and the certificate profile's complete subject DN. North
+   Europe uses `https://neu.codesigning.azure.net`; use the endpoint shown by
+   the account rather than guessing.
+2. Create a Microsoft Entra application and service principal dedicated to
+   Matrix OS Desktop releases. Do not create a client secret.
+3. Add a federated credential to that application with:
+   - issuer: `https://token.actions.githubusercontent.com`
+   - subject: `repo:HamedMP/matrix-os:environment:desktop-release`
+   - audience: `api://AzureADTokenExchange`
+4. At the certificate-profile resource scope, assign the service principal the
+   least-privilege **Artifact Signing Certificate Profile Signer** role. The
+   scope has this form:
+
+   ```text
+   /subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.CodeSigning/codeSigningAccounts/<account>/certificateProfiles/<profile>
+   ```
+
+5. In GitHub, create an environment named `desktop-release`. Restrict its
+   deployment branches/tags to reviewed release refs. The Windows job uses this
+   environment so every OIDC token has one stable, narrow subject.
+6. Add these repository Actions secrets:
+   - `MATRIX_DESKTOP_WINDOWS_AZURE_CLIENT_ID`: Entra application (client) ID
+   - `MATRIX_DESKTOP_WINDOWS_AZURE_TENANT_ID`: Entra directory (tenant) ID
+   - `MATRIX_DESKTOP_WINDOWS_AZURE_SUBSCRIPTION_ID`: Azure subscription ID
+7. Add these repository Actions variables:
+   - `MATRIX_DESKTOP_WINDOWS_SIGNING_MODE=azure`
+   - `MATRIX_DESKTOP_WINDOWS_PUBLISHER_NAME=<complete certificate subject DN>`
+   - `MATRIX_DESKTOP_WINDOWS_SIGNING_ENDPOINT=<regional HTTPS endpoint>`
+   - `MATRIX_DESKTOP_WINDOWS_SIGNING_ACCOUNT=<Artifact Signing account>`
+   - `MATRIX_DESKTOP_WINDOWS_CERTIFICATE_PROFILE=<certificate profile>`
+
+The publisher value must match the issued certificate subject exactly,
+including the `CN=`, organization, locality/state when present, and country.
+The updater embeds this subject and rejects an update whose signer does not
+match it. The workflow authenticates with `azure/login` and short-lived GitHub
+OIDC credentials; no Azure client secret or signing private key is stored in
+GitHub.
+
+Useful one-time Entra/RBAC commands after creating the Artifact Signing account
+and certificate profile in the portal:
+
+```bash
+APP_CLIENT_ID="$(az ad app create --display-name matrix-os-desktop-release --query appId -o tsv)"
+APP_OBJECT_ID="$(az ad app show --id "$APP_CLIENT_ID" --query id -o tsv)"
+SP_OBJECT_ID="$(az ad sp create --id "$APP_CLIENT_ID" --query id -o tsv)"
+
+# Create credential.json with the issuer, subject, and audience listed above.
+az ad app federated-credential create --id "$APP_OBJECT_ID" --parameters credential.json
+
+az role assignment create \
+  --assignee-object-id "$SP_OBJECT_ID" \
+  --assignee-principal-type ServicePrincipal \
+  --role "Artifact Signing Certificate Profile Signer" \
+  --scope "/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.CodeSigning/codeSigningAccounts/<account>/certificateProfiles/<profile>"
+```
+
+### Windows certificate-file fallback
+
+If Azure Artifact Signing is unavailable, an exportable OV `.pfx` can be used.
+Set `MATRIX_DESKTOP_WINDOWS_SIGNING_MODE=certificate`, retain the exact
+`MATRIX_DESKTOP_WINDOWS_PUBLISHER_NAME`, and add:
+
+- `MATRIX_DESKTOP_WINDOWS_CERTIFICATE`: base64-encoded `.pfx` (or a secure URL
+  accepted by electron-builder)
+- `MATRIX_DESKTOP_WINDOWS_CERTIFICATE_PASSWORD`: the `.pfx` password
+
+The fallback maps those secrets to electron-builder's `WIN_CSC_LINK` and
+`WIN_CSC_KEY_PASSWORD` only inside the Windows job. Never commit a certificate,
+password, Azure token, or generated signing metadata. Prefer Artifact Signing:
+it avoids an exportable private key and gives the workflow short-lived access.
+
 ## Channels
 
 - Stable: tag `desktop-vX.Y.Z` or run `Desktop Release` with `channel=stable`
   and `mode=publish`. The immutable version release holds the signed artifacts;
-  `desktop-stable` points to its `latest-mac.yml` and `latest-linux.yml` manifests.
+  `desktop-stable` points to `latest-mac.yml`, `latest-linux.yml`, and the
+  Windows `latest.yml` manifest.
 - Beta: run `Desktop Release` with `channel=beta`. The immutable GitHub release
   is marked prerelease and `desktop-beta` points to its channel manifests.
 - Canary: `Desktop Canary Release` runs every 12 hours and can be triggered
@@ -84,7 +173,8 @@ git push origin desktop-v0.1.0
 ```
 
 The release workflow builds macOS arm64/x64 DMG+ZIP artifacts, Linux x64
-AppImage artifacts, merges the channel manifests, generates checksums, and
+AppImage artifacts, and a Windows x64 NSIS `.exe`; prepares all three platform
+manifests; generates checksums; and
 creates the immutable GitHub release with generated changelog notes. It then
 advances the selected `desktop-<channel>` pointer release. Before upload, each macOS
 build verifies its Developer ID signature, stapled notarization ticket, and
@@ -97,6 +187,14 @@ complete a real `electron-updater` check against a deterministic local Generic
 feed; module loading, provider configuration, manifest-selection, or branded
 DMG background errors fail the build.
 
+The Windows job also checks exact installer/blockmap names, validates both
+Authenticode signer subjects, installs silently into the current user's
+profile, checks the `matrixos://` and legacy `matrix-os://` protocol
+registrations, launches the installed application against the same local
+updater fixture, and silently uninstalls it. Any missing artifact, invalid
+signature, protocol-registration failure, launch failure, updater failure, or
+incomplete uninstall blocks the release.
+
 ## Updates
 
 Packaged desktop builds use a channel-scoped Generic feed backed by GitHub
@@ -105,6 +203,8 @@ release downloads:
 - `desktop-stable` serves `latest-mac.yml` and `latest-linux.yml`.
 - `desktop-beta`, `desktop-canary`, and `desktop-dev` serve their matching
   `<channel>-mac.yml` and `<channel>-linux.yml` manifests.
+- Windows uses `latest.yml` on stable and `<channel>.yml` on prerelease
+  channels from the same channel pointer releases.
 
 The app checks on launch and then hourly; **Matrix OS > Check for Updates…** is
 present in installed and development menus. It starts the same check manually
@@ -147,6 +247,21 @@ the approved #1255 green branded installer background appears, **Matrix OS** and
 Applications succeeds. Launch the installed app and confirm Gatekeeper opens it
 without an unidentified-developer warning. This manual visual check complements
 the automated Finder-background gate; it does not replace it.
+
+On a clean Windows 11 x64 user, download the exact `.exe` and verify its
+Properties > Digital Signatures subject matches
+`MATRIX_DESKTOP_WINDOWS_PUBLISHER_NAME`. Install it, confirm the Start Menu and
+desktop shortcuts, open a `matrixos://auth?status=approved` link, check for
+updates from the File menu, and uninstall it from Windows Settings. This manual
+SmartScreen/UI check complements the automated Authenticode and silent-install
+gate.
+
+## References
+
+- [electron-builder Windows code signing](https://www.electron.build/docs/features/code-signing/code-signing-win/)
+- [Azure Artifact Signing roles](https://learn.microsoft.com/en-us/azure/artifact-signing/concept-resources-roles)
+- [Azure Artifact Signing regional endpoints](https://learn.microsoft.com/en-us/azure/artifact-signing/how-to-signing-integrations)
+- [Azure Artifact Signing GitHub OIDC setup](https://github.com/Azure/artifact-signing-action/blob/main/docs/OIDC.md)
 
 For a canary A-to-B acceptance test, install signed Canary A, publish signed
 Canary B, and verify `desktop-canary` serves a manifest whose artifact URLs

--- a/scripts/release/desktop-update-fixture-server.mjs
+++ b/scripts/release/desktop-update-fixture-server.mjs
@@ -4,10 +4,8 @@ import { createServer } from "node:http";
 import { writeFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 
-const PLATFORMS = new Set(["mac", "windows", "linux"]);
-
 export function resolveFixtureManifestName(platform, channel) {
-  if (!PLATFORMS.has(platform)) {
+  if (!["mac", "windows", "linux"].includes(platform)) {
     throw new Error("--platform must be one of mac, windows, or linux");
   }
   if (!channel || !["stable", "beta", "canary", "dev"].includes(channel)) {

--- a/scripts/release/desktop-update-fixture-server.mjs
+++ b/scripts/release/desktop-update-fixture-server.mjs
@@ -2,69 +2,91 @@
 
 import { createServer } from "node:http";
 import { writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
 
-const args = process.argv.slice(2);
+const PLATFORMS = new Set(["mac", "windows", "linux"]);
 
-function option(name) {
-  const index = args.indexOf(name);
-  if (index === -1) return undefined;
-  return args[index + 1];
+export function resolveFixtureManifestName(platform, channel) {
+  if (!PLATFORMS.has(platform)) {
+    throw new Error("--platform must be one of mac, windows, or linux");
+  }
+  if (!channel || !["stable", "beta", "canary", "dev"].includes(channel)) {
+    throw new Error("--channel must be one of stable, beta, canary, or dev");
+  }
+  const base = channel === "stable" ? "latest" : channel;
+  if (platform === "windows") return `${base}.yml`;
+  return `${base}-${platform}.yml`;
 }
 
-const channel = option("--channel");
-const version = option("--version");
-const portFile = option("--port-file");
-const printOnly = args.includes("--print");
+async function main() {
+  const args = process.argv.slice(2);
 
-if (!channel || !["stable", "beta", "canary", "dev"].includes(channel)) {
-  throw new Error("--channel must be one of stable, beta, canary, or dev");
-}
-if (!version || !/^[0-9A-Za-z][0-9A-Za-z.+-]*$/.test(version)) {
-  throw new Error("--version must be a safe semantic version");
-}
-if (!printOnly && !portFile) {
-  throw new Error("--port-file is required when starting the fixture server");
-}
+  function option(name) {
+    const index = args.indexOf(name);
+    if (index === -1) return undefined;
+    return args[index + 1];
+  }
 
-const sha512 = Buffer.alloc(64).toString("base64");
-const manifest = [
-  `version: ${version}`,
-  "files:",
-  "  - url: fixture.zip",
-  `    sha512: ${sha512}`,
-  "    size: 1",
-  "path: fixture.zip",
-  `sha512: ${sha512}`,
-  "releaseDate: '2026-01-01T00:00:00.000Z'",
-  "releaseNotes: |-",
-  "  Packaged updater fixture probe.",
-  "",
-].join("\n");
+  const channel = option("--channel");
+  const platform = option("--platform") ?? "mac";
+  const version = option("--version");
+  const portFile = option("--port-file");
+  const printOnly = args.includes("--print");
 
-if (printOnly) {
-  process.stdout.write(manifest);
-} else {
-  const manifestName = `${channel === "stable" ? "latest" : channel}-mac.yml`;
-  const server = createServer((request, response) => {
-    if (request.method !== "GET" || new URL(request.url ?? "/", "http://localhost").pathname !== `/${manifestName}`) {
-      response.writeHead(404).end("Not found");
-      return;
-    }
-    response.writeHead(200, {
-      "Cache-Control": "no-store",
-      "Content-Length": Buffer.byteLength(manifest),
-      "Content-Type": "text/yaml; charset=utf-8",
+  const manifestName = resolveFixtureManifestName(platform, channel);
+  if (!version || !/^[0-9A-Za-z][0-9A-Za-z.+-]*$/.test(version)) {
+    throw new Error("--version must be a safe semantic version");
+  }
+  if (!printOnly && !portFile) {
+    throw new Error("--port-file is required when starting the fixture server");
+  }
+
+  const sha512 = Buffer.alloc(64).toString("base64");
+  const manifest = [
+    `version: ${version}`,
+    "files:",
+    "  - url: fixture.zip",
+    `    sha512: ${sha512}`,
+    "    size: 1",
+    "path: fixture.zip",
+    `sha512: ${sha512}`,
+    "releaseDate: '2026-01-01T00:00:00.000Z'",
+    "releaseNotes: |-",
+    "  Packaged updater fixture probe.",
+    "",
+  ].join("\n");
+
+  if (printOnly) {
+    process.stdout.write(manifest);
+  } else {
+    const server = createServer((request, response) => {
+      if (
+        request.method !== "GET"
+        || new URL(request.url ?? "/", "http://localhost").pathname !== `/${manifestName}`
+      ) {
+        response.writeHead(404).end("Not found");
+        return;
+      }
+      response.writeHead(200, {
+        "Cache-Control": "no-store",
+        "Content-Length": Buffer.byteLength(manifest),
+        "Content-Type": "text/yaml; charset=utf-8",
+      });
+      response.end(manifest);
+      console.info(`[fixture] served ${manifestName}`);
     });
-    response.end(manifest);
-    console.info(`[fixture] served ${manifestName}`);
-  });
-  server.requestTimeout = 5_000;
-  server.listen(0, "127.0.0.1", async () => {
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("Fixture server did not bind to a TCP port");
-    }
-    await writeFile(portFile, `${address.port}\n`, { encoding: "utf8" });
-    console.info(`[fixture] listening on 127.0.0.1:${address.port}`);
-  });
+    server.requestTimeout = 5_000;
+    server.listen(0, "127.0.0.1", async () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Fixture server did not bind to a TCP port");
+      }
+      await writeFile(portFile, `${address.port}\n`, { encoding: "utf8" });
+      console.info(`[fixture] listening on 127.0.0.1:${address.port}`);
+    });
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
 }

--- a/scripts/release/prepare-desktop-channel-manifests.mjs
+++ b/scripts/release/prepare-desktop-channel-manifests.mjs
@@ -38,6 +38,7 @@ if (!CHANNELS.has(channel)) {
 const platformManifestNames = [
   channel === "stable" ? "latest-mac.yml" : `${channel}-mac.yml`,
   channel === "stable" ? "latest-linux.yml" : `${channel}-linux.yml`,
+  channel === "stable" ? "latest.yml" : `${channel}.yml`,
 ];
 const releaseNotes = (await readFile(notesPath, "utf8")).trim().slice(0, MAX_RELEASE_NOTES_LENGTH);
 if (!releaseNotes) {

--- a/scripts/release/windows-signing-config.mjs
+++ b/scripts/release/windows-signing-config.mjs
@@ -1,0 +1,100 @@
+const AZURE_SIGNING_HOST = /(^|\.)codesigning\.azure\.net$/i;
+const SAFE_RESOURCE_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+function required(environment, name) {
+  const value = environment[name]?.trim();
+  if (!value) throw new Error(`${name} is required for Windows release signing`);
+  return value;
+}
+
+function publisherName(environment) {
+  const value = required(environment, "MATRIX_DESKTOP_WINDOWS_PUBLISHER_NAME");
+  if (!value.startsWith("CN=") || value.length > 512 || /[\r\n]/.test(value)) {
+    throw new Error("Windows signing publisher must be the full certificate subject beginning with CN=");
+  }
+  return value;
+}
+
+function safeResourceName(environment, name) {
+  const value = required(environment, name);
+  if (!SAFE_RESOURCE_NAME.test(value)) {
+    throw new Error(`${name} contains unsupported characters`);
+  }
+  return value;
+}
+
+function azureEndpoint(environment) {
+  const raw = required(environment, "MATRIX_DESKTOP_WINDOWS_SIGNING_ENDPOINT");
+  let endpoint;
+  try {
+    endpoint = new URL(raw);
+  } catch {
+    throw new Error("Windows signing endpoint must be a valid Azure Artifact Signing URL");
+  }
+  if (
+    endpoint.protocol !== "https:" ||
+    !AZURE_SIGNING_HOST.test(endpoint.hostname) ||
+    endpoint.username ||
+    endpoint.password ||
+    endpoint.port ||
+    (endpoint.pathname !== "/" && endpoint.pathname !== "") ||
+    endpoint.search ||
+    endpoint.hash
+  ) {
+    throw new Error("Windows signing endpoint must be an HTTPS *.codesigning.azure.net origin");
+  }
+  return endpoint.origin;
+}
+
+export function resolveWindowsSigningConfig(environment = process.env) {
+  const mode = required(environment, "MATRIX_DESKTOP_WINDOWS_SIGNING_MODE");
+  const publisher = publisherName(environment);
+
+  if (mode === "azure") {
+    return {
+      forceCodeSigning: true,
+      win: {
+        azureSignOptions: {
+          publisherName: publisher,
+          endpoint: azureEndpoint(environment),
+          codeSigningAccountName: safeResourceName(
+            environment,
+            "MATRIX_DESKTOP_WINDOWS_SIGNING_ACCOUNT",
+          ),
+          certificateProfileName: safeResourceName(
+            environment,
+            "MATRIX_DESKTOP_WINDOWS_CERTIFICATE_PROFILE",
+          ),
+          ExcludeEnvironmentCredential: "true",
+          ExcludeWorkloadIdentityCredential: "true",
+          ExcludeManagedIdentityCredential: "true",
+          ExcludeSharedTokenCacheCredential: "true",
+          ExcludeVisualStudioCredential: "true",
+          ExcludeVisualStudioCodeCredential: "true",
+          ExcludeAzureCliCredential: "false",
+          ExcludeAzurePowerShellCredential: "true",
+          ExcludeAzureDeveloperCliCredential: "true",
+          ExcludeInteractiveBrowserCredential: "true",
+        },
+      },
+    };
+  }
+
+  if (mode === "certificate") {
+    required(environment, "WIN_CSC_LINK");
+    required(environment, "WIN_CSC_KEY_PASSWORD");
+    return {
+      forceCodeSigning: true,
+      win: {
+        signtoolOptions: {
+          publisherName: publisher,
+          signingHashAlgorithms: ["sha256"],
+        },
+      },
+    };
+  }
+
+  throw new Error(
+    "MATRIX_DESKTOP_WINDOWS_SIGNING_MODE must be either azure or certificate",
+  );
+}

--- a/specs/118-electron-windows-release/spec.md
+++ b/specs/118-electron-windows-release/spec.md
@@ -1,0 +1,57 @@
+# Electron Windows Release
+
+## Goal
+
+Ship the existing Matrix OS Electron desktop as a signed Windows 11 x64 NSIS
+installer through the same immutable release and OTA channel system used by
+macOS and Linux.
+
+## Decisions
+
+- Package `win32-x64` as a per-user, one-click NSIS installer. It requests
+  `asInvoker`, registers `matrixos://` plus the narrowed legacy `matrix-os://`
+  scheme, and does not require administrator access for a normal install.
+- Use Azure Artifact Signing with GitHub OIDC as the primary signer. Scope the
+  service principal to `Artifact Signing Certificate Profile Signer` on one
+  certificate profile. Keep an explicit exportable-PFX fallback for outages.
+- Keep local `electron-builder.yml` usable without signing. The release-only
+  `electron-builder.windows.mjs` config requires a valid signing mode and sets
+  `forceCodeSigning`, so release CI cannot emit unsigned Windows artifacts.
+- Publish stable Windows metadata as `latest.yml` and prerelease metadata as
+  `<channel>.yml`. Mutable channel releases hold only the macOS, Linux, and
+  Windows manifests; all installer bytes remain on immutable version releases.
+- Use Windows window-controls overlay and Windows menu/accelerator conventions.
+  Linux keeps its native title bar; macOS retains traffic lights.
+
+## Security and failure boundaries
+
+No application endpoint changes are introduced, so the endpoint auth matrix is
+not applicable. Signing input is the relevant trust boundary:
+
+- Signing mode, publisher subject, Azure endpoint, account, and profile are
+  validated before packaging.
+- Azure endpoints must be credential-free HTTPS origins under
+  `*.codesigning.azure.net`; resource names are bounded safe identifiers.
+- Certificate bytes, passwords, and OIDC tokens never enter generated config,
+  logs, artifacts, or source control.
+- Release packaging fails closed if configuration is absent or if either the
+  installed executable or installer lacks a valid signature from the configured
+  publisher.
+- GitHub OIDC access is bound to the protected `desktop-release` environment;
+  Azure RBAC is scoped to one certificate profile.
+
+## Wiring verification
+
+The reusable desktop workflow must build on `windows-latest`, authenticate,
+package, verify exact artifacts, verify Authenticode, silently install, verify
+both protocol registrations, launch the installed app against a bounded local
+updater fixture, then uninstall. Unit/contract tests cover signing config,
+builder config, manifest names, channel pruning, menu conventions, and window
+chrome. Desktop typecheck/build and YAML parsing run before review.
+
+## Delivery
+
+- Matrix OS implementation PR with tests, workflow, runbook, and this spec.
+- Separate PR in private `FinnaAI/matrix-os-site` updating the public desktop
+  installation/release documentation with Windows availability and signed
+  installer expectations.

--- a/tests/desktop/appearance-section.test.tsx
+++ b/tests/desktop/appearance-section.test.tsx
@@ -7,6 +7,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AppearanceSection from "../../desktop/src/renderer/src/features/settings/sections/AppearanceSection";
 import { DEFAULT_THEME_ID, unifiedThemes } from "../../desktop/src/renderer/src/design/themes";
 import { useAppearance } from "../../desktop/src/renderer/src/stores/appearance";
+import { desktopShortcutLabel } from "../../desktop/src/renderer/src/lib/platform-labels";
+
+const ZOOM_IN_LABEL = `Zoom in (${desktopShortcutLabel("=")})`;
+const ZOOM_OUT_LABEL = `Zoom out (${desktopShortcutLabel("-")})`;
 
 // IconButton uses Radix tooltips; App.tsx provides the Tooltip.Provider in
 // production, so tests wrap the section the same way.
@@ -112,15 +116,15 @@ describe("AppearanceSection", () => {
   it("steps zoom through the store and applies it via IPC", () => {
     renderSection();
 
-    fireEvent.click(screen.getByRole("button", { name: "Zoom in (⌘=)" }));
+    fireEvent.click(screen.getByRole("button", { name: ZOOM_IN_LABEL }));
 
     expect(useAppearance.getState().zoom).toBe(1.1);
     expect(screen.getByText("110%")).not.toBeNull();
     expect(invoke).toHaveBeenCalledWith("app:set-zoom", { factor: 1.1 });
     expect(screen.getByRole("button", { name: "Reset" })).toHaveProperty("disabled", false);
 
-    fireEvent.click(screen.getByRole("button", { name: "Zoom out (⌘-)" }));
-    fireEvent.click(screen.getByRole("button", { name: "Zoom out (⌘-)" }));
+    fireEvent.click(screen.getByRole("button", { name: ZOOM_OUT_LABEL }));
+    fireEvent.click(screen.getByRole("button", { name: ZOOM_OUT_LABEL }));
 
     expect(useAppearance.getState().zoom).toBe(0.9);
     expect(screen.getByText("90%")).not.toBeNull();
@@ -143,7 +147,7 @@ describe("AppearanceSection", () => {
     useAppearance.getState().setZoom(2);
     renderSection();
 
-    expect(screen.getByRole("button", { name: "Zoom in (⌘=)" })).toHaveProperty("disabled", true);
-    expect(screen.getByRole("button", { name: "Zoom out (⌘-)" })).toHaveProperty("disabled", false);
+    expect(screen.getByRole("button", { name: ZOOM_IN_LABEL })).toHaveProperty("disabled", true);
+    expect(screen.getByRole("button", { name: ZOOM_OUT_LABEL })).toHaveProperty("disabled", false);
   });
 });

--- a/tests/desktop/desktop-channel-manifest.test.ts
+++ b/tests/desktop/desktop-channel-manifest.test.ts
@@ -22,6 +22,10 @@ describe("Desktop channel manifests", () => {
       join(source, "canary-linux.yml"),
       "version: 1.2.3-canary.2\nfiles:\n  - url: app.AppImage\n    sha512: linux\npath: app.AppImage\nsha512: linux\n",
     );
+    writeFileSync(
+      join(source, "canary.yml"),
+      "version: 1.2.3-canary.2\nfiles:\n  - url: installer.exe\n    sha512: windows\npath: installer.exe\nsha512: windows\n",
+    );
     writeFileSync(notes, "## Improved\n\n- Faster startup\n");
 
     try {
@@ -38,6 +42,7 @@ describe("Desktop channel manifests", () => {
 
       const mac = readFileSync(join(output, "canary-mac.yml"), "utf8");
       const linux = readFileSync(join(output, "canary-linux.yml"), "utf8");
+      const windows = readFileSync(join(output, "canary.yml"), "utf8");
       expect(mac).toContain(
         "url: https://github.com/HamedMP/matrix-os/releases/download/desktop-v1.2.3-canary.2/arm64.zip",
       );
@@ -47,8 +52,12 @@ describe("Desktop channel manifests", () => {
       expect(linux).toContain(
         "url: https://github.com/HamedMP/matrix-os/releases/download/desktop-v1.2.3-canary.2/app.AppImage",
       );
+      expect(windows).toContain(
+        "url: https://github.com/HamedMP/matrix-os/releases/download/desktop-v1.2.3-canary.2/installer.exe",
+      );
       expect(mac).toContain("releaseNotes: |-\n  ## Improved\n  \n  - Faster startup\n");
       expect(linux).toContain("releaseNotes: |-\n  ## Improved\n  \n  - Faster startup\n");
+      expect(windows).toContain("releaseNotes: |-\n  ## Improved\n  \n  - Faster startup\n");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -121,8 +121,8 @@ describe("desktop release workflows", () => {
   it("injects the public PostHog support configuration into every packaged Desktop build", () => {
     const workflow = readFileSync(join(root, ".github/workflows/desktop-build.yml"), "utf8");
 
-    expect(workflow.match(/^\s+VITE_POSTHOG_PROJECT_TOKEN: \$\{\{/gm)).toHaveLength(2);
-    expect(workflow.match(/^\s+VITE_POSTHOG_HOST: \$\{\{/gm)).toHaveLength(2);
+    expect(workflow.match(/^\s+VITE_POSTHOG_PROJECT_TOKEN: \$\{\{/gm)).toHaveLength(3);
+    expect(workflow.match(/^\s+VITE_POSTHOG_HOST: \$\{\{/gm)).toHaveLength(3);
     expect(workflow).toContain("vars.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN || vars.NEXT_PUBLIC_POSTHOG_KEY");
     expect(workflow).toContain("vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.posthog.com'");
   });
@@ -134,15 +134,57 @@ describe("desktop release workflows", () => {
     const missingTokenCheck = 'if [ -z "$normalized_posthog_token" ]; then';
     const missingTokenError = "Missing required public PostHog project token for Desktop Support";
 
-    expect(workflow.match(new RegExp(validationName, "g"))).toHaveLength(2);
-    expect(workflow.split(normalizeToken)).toHaveLength(3);
-    expect(workflow.split(missingTokenCheck)).toHaveLength(3);
-    expect(workflow.match(new RegExp(missingTokenError, "g"))).toHaveLength(2);
+    expect(workflow.match(new RegExp(validationName, "g"))).toHaveLength(3);
+    expect(workflow.split(normalizeToken)).toHaveLength(4);
+    expect(workflow.split(missingTokenCheck)).toHaveLength(4);
+    expect(workflow.match(new RegExp(missingTokenError, "g"))).toHaveLength(3);
 
     const macJob = workflow.slice(workflow.indexOf("  mac:"), workflow.indexOf("  linux:"));
-    const linuxJob = workflow.slice(workflow.indexOf("  linux:"));
+    const linuxJob = workflow.slice(workflow.indexOf("  linux:"), workflow.indexOf("  windows:"));
+    const windowsJob = workflow.slice(workflow.indexOf("  windows:"));
     expect(macJob.indexOf(validationName)).toBeLessThan(macJob.indexOf("uses: actions/checkout@v6"));
     expect(linuxJob.indexOf(validationName)).toBeLessThan(linuxJob.indexOf("uses: actions/checkout@v6"));
+    expect(windowsJob.indexOf(validationName)).toBeLessThan(
+      windowsJob.indexOf("uses: actions/checkout@v6"),
+    );
+  });
+
+  it("builds, signs, installs, launches, and uninstalls an exact Windows NSIS release", () => {
+    const workflow = readFileSync(join(root, ".github/workflows/desktop-build.yml"), "utf8");
+    const release = readFileSync(join(root, ".github/workflows/desktop-release.yml"), "utf8");
+    const canary = readFileSync(
+      join(root, ".github/workflows/desktop-release-canary.yml"),
+      "utf8",
+    );
+    const windowsJob = workflow.slice(workflow.indexOf("  windows:"));
+
+    expect(windowsJob).toContain("name: Windows x64");
+    expect(windowsJob).toContain("runs-on: windows-latest");
+    expect(windowsJob).toContain("id-token: write");
+    expect(windowsJob).toContain("name: Validate Windows signing configuration");
+    expect(windowsJob).toContain("MATRIX_DESKTOP_WINDOWS_SIGNING_MODE");
+    expect(windowsJob).toContain("uses: azure/login@v2");
+    expect(windowsJob).toContain("secrets.MATRIX_DESKTOP_WINDOWS_AZURE_CLIENT_ID");
+    expect(windowsJob).toContain("secrets.MATRIX_DESKTOP_WINDOWS_AZURE_TENANT_ID");
+    expect(windowsJob).toContain("secrets.MATRIX_DESKTOP_WINDOWS_AZURE_SUBSCRIPTION_ID");
+    expect(windowsJob).toContain("electron-builder.windows.mjs --win nsis --x64");
+    expect(windowsJob).toContain("artifact_base=Matrix-OS-${packageVersion}-win-x64");
+    expect(windowsJob).toContain('"desktop/dist/$env:ARTIFACT_BASE.exe"');
+    expect(windowsJob).toContain('$blockmapPath = "$installerPath.blockmap"');
+    expect(windowsJob).toContain("Get-AuthenticodeSignature");
+    expect(windowsJob).toContain("Status -ne [System.Management.Automation.SignatureStatus]::Valid");
+    expect(windowsJob).toContain('Start-Process -FilePath $installerPath -ArgumentList "/S" -Wait');
+    expect(windowsJob).toContain('foreach ($scheme in @("matrixos", "matrix-os"))');
+    expect(windowsJob).toContain("Registry::HKEY_CURRENT_USER\\Software\\Classes\\$scheme");
+    expect(windowsJob).toContain("desktop-update-fixture-server.mjs");
+    expect(windowsJob).toContain('"--platform", "windows"');
+    expect(windowsJob).toContain("[updates] update check completed: up to date");
+    expect(windowsJob).toContain('Start-Process -FilePath $uninstallerPath -ArgumentList "/S" -Wait');
+    expect(windowsJob).toContain("desktop/dist/*.exe");
+    expect(windowsJob).toContain("desktop/dist/*.yml");
+
+    expect(release).toContain("id-token: write");
+    expect(canary).toContain("id-token: write");
   });
 
   it("keeps raw workspace TypeScript out of the packaged app archive", () => {
@@ -287,7 +329,7 @@ describe("desktop release workflows", () => {
     expect(action).toContain('REMOTE_TAG_SHA" != "$EXPECTED_SHA"');
   });
 
-  it("keeps only the two platform manifests on a Desktop channel pointer release", () => {
+  it("keeps only the three platform manifests on a Desktop channel pointer release", () => {
     const action = readFileSync(
       join(root, ".github/actions/prune-desktop-channel-assets/action.yml"),
       "utf8",
@@ -295,8 +337,10 @@ describe("desktop release workflows", () => {
 
     expect(action).toContain('ALLOWED_MAC="latest-mac.yml"');
     expect(action).toContain('ALLOWED_LINUX="latest-linux.yml"');
+    expect(action).toContain('ALLOWED_WINDOWS="latest.yml"');
     expect(action).toContain('ALLOWED_MAC="${CHANNEL}-mac.yml"');
     expect(action).toContain('ALLOWED_LINUX="${CHANNEL}-linux.yml"');
+    expect(action).toContain('ALLOWED_WINDOWS="${CHANNEL}.yml"');
     expect(action).toContain('gh release delete-asset "$TAG_NAME" "$asset"');
     expect(action).toContain("--yes");
   });

--- a/tests/desktop/desktop-release-workflows.test.ts
+++ b/tests/desktop/desktop-release-workflows.test.ts
@@ -145,7 +145,7 @@ describe("desktop release workflows", () => {
     expect(macJob.indexOf(validationName)).toBeLessThan(macJob.indexOf("uses: actions/checkout@v6"));
     expect(linuxJob.indexOf(validationName)).toBeLessThan(linuxJob.indexOf("uses: actions/checkout@v6"));
     expect(windowsJob.indexOf(validationName)).toBeLessThan(
-      windowsJob.indexOf("uses: actions/checkout@v6"),
+      windowsJob.indexOf("uses: actions/checkout@"),
     );
   });
 
@@ -163,7 +163,17 @@ describe("desktop release workflows", () => {
     expect(windowsJob).toContain("id-token: write");
     expect(windowsJob).toContain("name: Validate Windows signing configuration");
     expect(windowsJob).toContain("MATRIX_DESKTOP_WINDOWS_SIGNING_MODE");
-    expect(windowsJob).toContain("uses: azure/login@v2");
+    for (const pinnedAction of [
+      "actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803",
+      "pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86",
+      "actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38",
+      "oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6",
+      "azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6",
+      "actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f",
+    ]) {
+      expect(windowsJob).toContain(`uses: ${pinnedAction}`);
+    }
+    expect(windowsJob).not.toMatch(/^\s+-?\s*uses:\s+[^\s]+@v\d+\s*$/m);
     expect(windowsJob).toContain("secrets.MATRIX_DESKTOP_WINDOWS_AZURE_CLIENT_ID");
     expect(windowsJob).toContain("secrets.MATRIX_DESKTOP_WINDOWS_AZURE_TENANT_ID");
     expect(windowsJob).toContain("secrets.MATRIX_DESKTOP_WINDOWS_AZURE_SUBSCRIPTION_ID");

--- a/tests/desktop/desktop-update-fixture-server.test.ts
+++ b/tests/desktop/desktop-update-fixture-server.test.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { resolveFixtureManifestName } from "../../scripts/release/desktop-update-fixture-server.mjs";
 
 const root = process.cwd();
 
@@ -24,5 +25,14 @@ describe("desktop update fixture server", () => {
     expect(manifest).toContain("url: fixture.zip");
     expect(manifest).toContain("sha512:");
     expect(manifest).toContain("releaseNotes: |-");
+  });
+
+  it.each([
+    ["mac", "latest-mac.yml", "beta-mac.yml"],
+    ["windows", "latest.yml", "beta.yml"],
+    ["linux", "latest-linux.yml", "beta-linux.yml"],
+  ])("resolves stable and prerelease manifest names for %s", (platform, stable, beta) => {
+    expect(resolveFixtureManifestName(platform, "stable")).toBe(stable);
+    expect(resolveFixtureManifestName(platform, "beta")).toBe(beta);
   });
 });

--- a/tests/desktop/desktop-update-fixture-server.test.ts
+++ b/tests/desktop/desktop-update-fixture-server.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveFixtureManifestName } from "../../scripts/release/desktop-update-fixture-server.mjs";
@@ -34,5 +35,15 @@ describe("desktop update fixture server", () => {
   ])("resolves stable and prerelease manifest names for %s", (platform, stable, beta) => {
     expect(resolveFixtureManifestName(platform, "stable")).toBe(stable);
     expect(resolveFixtureManifestName(platform, "beta")).toBe(beta);
+  });
+
+  it("uses a fixed literal allowlist without introducing an unbounded collection", () => {
+    const source = readFileSync(
+      join(root, "scripts/release/desktop-update-fixture-server.mjs"),
+      "utf8",
+    );
+
+    expect(source).not.toContain("new Set(");
+    expect(source).toContain('["mac", "windows", "linux"].includes(platform)');
   });
 });

--- a/tests/desktop/menu-template.test.ts
+++ b/tests/desktop/menu-template.test.ts
@@ -9,6 +9,7 @@ describe("createAppMenuTemplate", () => {
       const template = createAppMenuTemplate({
         appName: "Matrix OS",
         isPackaged,
+        platform: "darwin",
         openExternal: vi.fn(),
         send,
         adjustZoom: vi.fn(),
@@ -36,6 +37,7 @@ describe("createAppMenuTemplate", () => {
       const template = createAppMenuTemplate({
         appName: "Matrix OS",
         isPackaged,
+        platform: "darwin",
         openExternal: vi.fn(),
         send,
         adjustZoom: vi.fn(),
@@ -63,6 +65,7 @@ describe("createAppMenuTemplate", () => {
     const template = createAppMenuTemplate({
       appName: "Matrix OS",
       isPackaged: true,
+      platform: "darwin",
       openExternal: vi.fn(),
       send,
       adjustZoom: vi.fn(),
@@ -91,6 +94,7 @@ describe("createAppMenuTemplate", () => {
     const template = createAppMenuTemplate({
       appName: "Matrix OS",
       isPackaged: true,
+      platform: "darwin",
       openExternal: vi.fn(),
       send,
       adjustZoom: vi.fn(),
@@ -118,6 +122,7 @@ describe("createAppMenuTemplate", () => {
     const template = createAppMenuTemplate({
       appName: "Matrix OS",
       isPackaged: true,
+      platform: "darwin",
       openExternal: vi.fn(),
       send: vi.fn(),
       adjustZoom,
@@ -155,6 +160,7 @@ describe("createAppMenuTemplate", () => {
     const template = createAppMenuTemplate({
       appName: "Matrix OS",
       isPackaged: true,
+      platform: "darwin",
       openExternal: vi.fn(),
       send: vi.fn(),
       adjustZoom: vi.fn(),
@@ -176,6 +182,7 @@ describe("createAppMenuTemplate", () => {
     const template = createAppMenuTemplate({
       appName: "Matrix OS",
       isPackaged: true,
+      platform: "darwin",
       openExternal: vi.fn(),
       send,
       adjustZoom: vi.fn(),

--- a/tests/desktop/menu-template.test.ts
+++ b/tests/desktop/menu-template.test.ts
@@ -213,4 +213,59 @@ describe("createAppMenuTemplate", () => {
     quitItem.click({} as never, {} as never, {} as never);
     expect(quitApp).toHaveBeenCalledOnce();
   });
+
+  it("uses Windows conventions without macOS-only application roles", () => {
+    const send = vi.fn();
+    const quitApp = vi.fn();
+    const template = createAppMenuTemplate({
+      appName: "Matrix OS",
+      isPackaged: true,
+      platform: "win32",
+      openExternal: vi.fn(),
+      send,
+      adjustZoom: vi.fn(),
+      checkForUpdates: vi.fn(),
+      quitApp,
+    });
+
+    expect(template[0]?.label).toBe("File");
+    expect(template.some((item) => item.label === "Matrix OS")).toBe(false);
+    const serialized = JSON.stringify(template);
+    expect(serialized).not.toContain('"role":"services"');
+    expect(serialized).not.toContain('"role":"hide"');
+    expect(serialized).not.toContain('"role":"hideOthers"');
+    expect(serialized).not.toContain('"role":"unhide"');
+
+    const fileMenu = template.find((item) => item.label === "File");
+    const fileItems = Array.isArray(fileMenu?.submenu) ? fileMenu.submenu : [];
+    const expectations = [
+      ["New", "CmdOrCtrl+N"],
+      ["New Agent Thread", "CmdOrCtrl+J"],
+      ["New Tab", "CmdOrCtrl+T"],
+      ["Close Tab", "CmdOrCtrl+W"],
+      ["Settings…", "CmdOrCtrl+,"],
+      ["Check for Updates…", undefined],
+      ["Exit", undefined],
+    ] as const;
+
+    for (const [label, accelerator] of expectations) {
+      const item = fileItems.find((candidate) => "label" in candidate && candidate.label === label);
+      expect(item, label).toBeTruthy();
+      expect(item && "accelerator" in item ? item.accelerator : undefined).toBe(accelerator);
+    }
+
+    const viewMenu = template.find((item) => item.label === "View");
+    const viewItems = Array.isArray(viewMenu?.submenu) ? viewMenu.submenu : [];
+    const terminal = viewItems.find((item) => "label" in item && item.label === "Terminal");
+    expect(terminal && "accelerator" in terminal ? terminal.accelerator : null).toBe(
+      "CmdOrCtrl+Alt+T",
+    );
+
+    const exit = fileItems.find((item) => "label" in item && item.label === "Exit");
+    if (!exit || !("click" in exit) || typeof exit.click !== "function") {
+      throw new Error("Exit is not clickable");
+    }
+    exit.click({} as never, {} as never, {} as never);
+    expect(quitApp).toHaveBeenCalledOnce();
+  });
 });

--- a/tests/desktop/packaging.test.ts
+++ b/tests/desktop/packaging.test.ts
@@ -36,6 +36,43 @@ describe("desktop packaging", () => {
     expect(schemes).toContain("matrix-os");
   });
 
+  it("builds a signed per-user NSIS installer with verified updates on Windows", () => {
+    const root = process.cwd();
+    const raw = readFileSync(join(root, "desktop/electron-builder.yml"), "utf8");
+    const config = parse(raw) as {
+      win?: {
+        icon?: string;
+        requestedExecutionLevel?: string;
+        target?: Array<{ target?: string; arch?: string[] }>;
+        verifyUpdateCodeSignature?: boolean;
+      };
+      nsis?: Record<string, unknown>;
+    };
+
+    expect(config.win).toEqual({
+      icon: "build/icon.png",
+      requestedExecutionLevel: "asInvoker",
+      verifyUpdateCodeSignature: true,
+      target: [{ target: "nsis", arch: ["x64"] }],
+    });
+    expect(config.nsis).toMatchObject({
+      oneClick: true,
+      perMachine: false,
+      allowElevation: true,
+      createDesktopShortcut: "always",
+      createStartMenuShortcut: true,
+      shortcutName: "Matrix OS",
+      uninstallDisplayName: "Matrix OS",
+    });
+
+    const releaseConfig = readFileSync(
+      join(root, "desktop/electron-builder.windows.mjs"),
+      "utf8",
+    );
+    expect(releaseConfig).toContain('extends: "./electron-builder.yml"');
+    expect(releaseConfig).toContain("resolveWindowsSigningConfig(process.env)");
+  });
+
   it("uses the canonical Matrix brand assets for a Retina DMG installer", () => {
     const root = process.cwd();
     const raw = readFileSync(join(root, "desktop/electron-builder.yml"), "utf8");

--- a/tests/desktop/platform-labels.test.ts
+++ b/tests/desktop/platform-labels.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  desktopShortcutLabel,
+  systemTerminalLabel,
+} from "../../desktop/src/renderer/src/lib/platform-labels";
+
+describe("desktop platform labels", () => {
+  it.each([
+    ["MacIntel", "K", "⌘K"],
+    ["Win32", "K", "Ctrl+K"],
+    ["Linux x86_64", "K", "Ctrl+K"],
+  ])("formats %s shortcuts", (platform, keys, expected) => {
+    expect(desktopShortcutLabel(keys, platform)).toBe(expected);
+  });
+
+  it.each([
+    ["MacIntel", "Mac Terminal"],
+    ["Win32", "Windows Terminal"],
+    ["Linux x86_64", "system terminal"],
+  ])("names the %s terminal", (platform, expected) => {
+    expect(systemTerminalLabel(platform)).toBe(expected);
+  });
+});

--- a/tests/desktop/window-chrome.test.ts
+++ b/tests/desktop/window-chrome.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { windowChromeOptions } from "../../desktop/src/main/platform/window-chrome";
+
+describe("windowChromeOptions", () => {
+  it("keeps native macOS traffic lights over the renderer title bar", () => {
+    expect(windowChromeOptions("darwin")).toEqual({
+      titleBarStyle: "hidden",
+      trafficLightPosition: { x: 14, y: 13 },
+    });
+  });
+
+  it("uses Windows window controls overlay without macOS-only options", () => {
+    expect(windowChromeOptions("win32")).toEqual({
+      titleBarStyle: "hidden",
+      titleBarOverlay: {
+        color: "#0e0e13",
+        symbolColor: "#f9f7f1",
+        height: 38,
+      },
+    });
+  });
+
+  it("keeps Linux native window controls", () => {
+    expect(windowChromeOptions("linux")).toEqual({ titleBarStyle: "default" });
+  });
+});

--- a/tests/desktop/windows-signing-config.test.ts
+++ b/tests/desktop/windows-signing-config.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { resolveWindowsSigningConfig } from "../../scripts/release/windows-signing-config.mjs";
+
+const azureEnvironment = {
+  MATRIX_DESKTOP_WINDOWS_SIGNING_MODE: "azure",
+  MATRIX_DESKTOP_WINDOWS_PUBLISHER_NAME: "CN=Matrix OS AB, O=Matrix OS AB, C=SE",
+  MATRIX_DESKTOP_WINDOWS_SIGNING_ENDPOINT: "https://neu.codesigning.azure.net",
+  MATRIX_DESKTOP_WINDOWS_SIGNING_ACCOUNT: "matrix-os",
+  MATRIX_DESKTOP_WINDOWS_CERTIFICATE_PROFILE: "public-trust",
+};
+
+describe("resolveWindowsSigningConfig", () => {
+  it("configures Azure Artifact Signing through the already-authenticated Azure CLI", () => {
+    const config = resolveWindowsSigningConfig(azureEnvironment);
+
+    expect(config).toEqual({
+      forceCodeSigning: true,
+      win: {
+        azureSignOptions: {
+          publisherName: "CN=Matrix OS AB, O=Matrix OS AB, C=SE",
+          endpoint: "https://neu.codesigning.azure.net",
+          codeSigningAccountName: "matrix-os",
+          certificateProfileName: "public-trust",
+          ExcludeEnvironmentCredential: "true",
+          ExcludeWorkloadIdentityCredential: "true",
+          ExcludeManagedIdentityCredential: "true",
+          ExcludeSharedTokenCacheCredential: "true",
+          ExcludeVisualStudioCredential: "true",
+          ExcludeVisualStudioCodeCredential: "true",
+          ExcludeAzureCliCredential: "false",
+          ExcludeAzurePowerShellCredential: "true",
+          ExcludeAzureDeveloperCliCredential: "true",
+          ExcludeInteractiveBrowserCredential: "true",
+        },
+      },
+    });
+  });
+
+  it("supports a conventional certificate as an explicit fallback", () => {
+    const config = resolveWindowsSigningConfig({
+      MATRIX_DESKTOP_WINDOWS_SIGNING_MODE: "certificate",
+      MATRIX_DESKTOP_WINDOWS_PUBLISHER_NAME: "CN=Matrix OS AB, O=Matrix OS AB, C=SE",
+      WIN_CSC_LINK: "base64:private-certificate-material",
+      WIN_CSC_KEY_PASSWORD: "private-password",
+    });
+
+    expect(config).toEqual({
+      forceCodeSigning: true,
+      win: {
+        signtoolOptions: {
+          publisherName: "CN=Matrix OS AB, O=Matrix OS AB, C=SE",
+          signingHashAlgorithms: ["sha256"],
+        },
+      },
+    });
+    expect(JSON.stringify(config)).not.toContain("private-certificate-material");
+    expect(JSON.stringify(config)).not.toContain("private-password");
+  });
+
+  it.each([
+    [{}, "MATRIX_DESKTOP_WINDOWS_SIGNING_MODE"],
+    [
+      {
+        ...azureEnvironment,
+        MATRIX_DESKTOP_WINDOWS_PUBLISHER_NAME: "Matrix OS AB",
+      },
+      "publisher",
+    ],
+    [
+      {
+        ...azureEnvironment,
+        MATRIX_DESKTOP_WINDOWS_SIGNING_ENDPOINT: "https://example.com",
+      },
+      "endpoint",
+    ],
+    [
+      {
+        MATRIX_DESKTOP_WINDOWS_SIGNING_MODE: "certificate",
+        MATRIX_DESKTOP_WINDOWS_PUBLISHER_NAME: "CN=Matrix OS AB",
+        WIN_CSC_LINK: "base64:certificate",
+      },
+      "WIN_CSC_KEY_PASSWORD",
+    ],
+  ])("fails closed for incomplete or unsafe signing input", (environment, expectedMessage) => {
+    expect(() => resolveWindowsSigningConfig(environment)).toThrow(expectedMessage);
+  });
+});


### PR DESCRIPTION
## Summary

- ship a Windows 11 x64 per-user NSIS installer with native window chrome, Windows menus, and platform-correct labels
- sign release builds through Azure Artifact Signing with GitHub OIDC, with an explicit PFX fallback and fail-closed validation
- publish Windows OTA manifests and verify exact artifacts, Authenticode, silent install, protocol registration, launch/update behavior, and uninstall on windows-latest
- document complete signer provisioning and release verification in the operator runbook and feature spec

## Tests

- Red phase: 12 expected Windows contract/module failures before implementation
- `vitest run tests/desktop`: 235 files, 2487 tests passed
- focused Windows desktop suite: 9 files, 69 tests passed
- Greptile hardening tests: 2 files, 30 tests passed after an expected two-test red phase
- desktop renderer and main TypeScript checks passed
- production Electron Vite build passed
- electron-builder 26 config resolution and schema validation passed with synthetic Azure settings
- workflow/action/builder YAML parsing and `git diff --check` passed

## Invariants

- **Source of truth:** `desktop/electron-builder.yml` owns platform packaging; `desktop/electron-builder.windows.mjs` owns release-only signing enforcement; `.github/workflows/desktop-build.yml` owns release verification; the selected Azure certificate profile owns the publisher identity.
- **Lock/transaction scope:** no database or shared runtime mutation is introduced. Immutable version artifacts are built and verified before existing channel-pointer publication runs.
- **Acceptable orphan states:** a failed build may leave a bounded GitHub Actions artifact or runner-local install, both covered by retention/cleanup. It must not publish an unsigned installer or advance a channel pointer.
- **Auth source of truth:** GitHub Actions OIDC from the protected `desktop-release` environment authenticates to Entra; Azure RBAC is scoped to the certificate profile. The fallback reads the PFX and password only from Actions secrets.
- **Deferred scope:** Windows arm64, MSIX/Microsoft Store distribution, and production SmartScreen reputation validation remain outside this PR. Real Windows 11 native-chrome screenshots and interaction proof are tracked in [#1399](https://github.com/HamedMP/matrix-os/issues/1399) because they require the first signed installer and Windows acceptance host; the issue defines exact evidence and privacy requirements.

## Documentation

Public docs and the four-platform direct-download contract are in [FinnaAI/matrix-os-site#53](https://github.com/FinnaAI/matrix-os-site/pull/53). Merge or deploy that PR with the first complete Windows release.