### PR TITLE
test(kernel): verify current agent sdk and gateway behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, "stack/**"]
+    branches: [main, "stack/**", "codex/**"]
     types: [labeled, ready_for_review]
 
 concurrency:
@@ -362,6 +362,43 @@ jobs:
         run: pnpm --filter @finnaai/matrix exec node ./scripts/check-publish.mjs
 
   # ── Gate 2: Tests ──
+  agent-sdk-compatibility:
+    name: Agent SDK 0.3.251 Compatibility
+    needs: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Skip expensive CI for docs-only changes
+        if: needs.changes.outputs.should_run != 'true'
+        run: echo "No CI-relevant source changes detected; skipping Agent SDK compatibility."
+
+      - uses: actions/checkout@v6
+        if: needs.changes.outputs.should_run == 'true'
+
+      - uses: pnpm/action-setup@v6
+        if: needs.changes.outputs.should_run == 'true'
+
+      - uses: actions/setup-node@v6
+        if: needs.changes.outputs.should_run == 'true'
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+        if: needs.changes.outputs.should_run == 'true'
+
+      - name: Install exact Agent SDK
+        if: needs.changes.outputs.should_run == 'true'
+        run: |
+          mkdir -p "${{ runner.temp }}/matrix-agent-sdk-03251"
+          pnpm add --ignore-scripts --save-exact --dir "${{ runner.temp }}/matrix-agent-sdk-03251" @anthropic-ai/claude-agent-sdk@0.3.251
+
+      - name: Run real Agent SDK compatibility spike
+        if: needs.changes.outputs.should_run == 'true'
+        env:
+          MATRIX_AGENT_SDK_PACKAGE_DIR: ${{ runner.temp }}/matrix-agent-sdk-03251/node_modules/@anthropic-ai/claude-agent-sdk
+        run: pnpm exec vitest run tests/scripts/agent-sdk-real-runtime-spike.test.ts
+
   unit:
     name: Unit Tests (${{ matrix.shard }}/4)
     needs: [changes, patterns, sync-client]
@@ -490,7 +527,7 @@ jobs:
 
   ci-results:
     name: CI Results
-    needs: [changes, typecheck, shell-production-build, patterns, react-doctor, sync-client, unit, docs-contract, e2e]
+    needs: [changes, typecheck, shell-production-build, patterns, react-doctor, sync-client, agent-sdk-compatibility, unit, docs-contract, e2e]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -504,6 +541,7 @@ jobs:
           PATTERNS_RESULT: ${{ needs.patterns.result }}
           REACT_DOCTOR_RESULT: ${{ needs.react-doctor.result }}
           SYNC_CLIENT_RESULT: ${{ needs.sync-client.result }}
+          AGENT_SDK_COMPATIBILITY_RESULT: ${{ needs.agent-sdk-compatibility.result }}
           UNIT_RESULT: ${{ needs.unit.result }}
           DOCS_CONTRACT_RESULT: ${{ needs.docs-contract.result }}
           E2E_RESULT: ${{ needs.e2e.result }}
@@ -525,13 +563,14 @@ jobs:
             echo "| Pattern Scan | $PATTERNS_RESULT |"
             echo "| React Doctor | $REACT_DOCTOR_RESULT |"
             echo "| Sync Client Package (Node 20) | $SYNC_CLIENT_RESULT |"
+            echo "| Agent SDK 0.3.251 Compatibility | $AGENT_SDK_COMPATIBILITY_RESULT |"
             echo "| Unit Tests | $UNIT_RESULT |"
             echo "| Docs Contract Tests | $DOCS_CONTRACT_RESULT |"
             echo "| E2E Tests | $E2E_RESULT |"
           } >> "$GITHUB_STEP_SUMMARY"
 
           failed=false
-          for result in "$CHANGES_RESULT" "$TYPECHECK_RESULT" "$SHELL_PRODUCTION_BUILD_RESULT" "$PATTERNS_RESULT" "$REACT_DOCTOR_RESULT" "$SYNC_CLIENT_RESULT" "$UNIT_RESULT" "$DOCS_CONTRACT_RESULT" "$E2E_RESULT"; do
+          for result in "$CHANGES_RESULT" "$TYPECHECK_RESULT" "$SHELL_PRODUCTION_BUILD_RESULT" "$PATTERNS_RESULT" "$REACT_DOCTOR_RESULT" "$SYNC_CLIENT_RESULT" "$AGENT_SDK_COMPATIBILITY_RESULT" "$UNIT_RESULT" "$DOCS_CONTRACT_RESULT" "$E2E_RESULT"; do
             case "$result" in
               success|skipped)
                 ;;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "docker:build": "docker compose --env-file .env.docker -f docker-compose.dev.yml build --no-cache",
     "cleanup:local-artifacts": "node scripts/cleanup-local-artifacts.mjs",
     "observability:posthog-alerts": "node scripts/observability/setup-posthog-alerts.mjs",
+    "spike:agent-sdk": "node scripts/spikes/agent-sdk-gateway/run.mjs",
     "release:enqueue-golden-snapshot": "node scripts/enqueue-golden-snapshot.mjs",
     "test": "sh -c 'pnpm --filter @matrix-os/observability build && pnpm --filter @matrix-os/kernel build && pnpm --filter @matrix-os/integrations-mcp build && vitest run \"$@\"' --",
     "test:golden-snapshots": "bun run test -- --maxWorkers=1 --no-file-parallelism tests/platform/golden-snapshot-*.test.ts tests/platform/host-bundle-snapshot-workflow.test.ts tests/platform/host-bundle-route.test.ts tests/platform/r2-client.test.ts tests/platform/ci-workflows.test.ts tests/platform/customer-vps.test.ts tests/platform/customer-vps-cloud-init.test.ts tests/platform/customer-vps-hetzner.test.ts tests/platform/customer-vps-host-bundle.test.ts",

--- a/scripts/spikes/agent-sdk-gateway/fake-provider.mjs
+++ b/scripts/spikes/agent-sdk-gateway/fake-provider.mjs
@@ -1,0 +1,474 @@
+import { createRequire } from "node:module";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  buildAgentSdkTransportEnvironment,
+  inspectAgentSdkInstallation,
+} from "./verification.mjs";
+
+const MODEL = "claude-haiku-4-5-20251001";
+const MCP_TOOL_NAME = "mcp__spike__echo";
+
+function sseEvent(event, data) {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function startMessage(response, contentBlock) {
+  response.write(
+    sseEvent("message_start", {
+      type: "message_start",
+      message: {
+        id: `msg_${crypto.randomUUID()}`,
+        type: "message",
+        role: "assistant",
+        model: MODEL,
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 1,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          output_tokens: 0,
+        },
+      },
+    }),
+  );
+  response.write(
+    sseEvent("content_block_start", {
+      type: "content_block_start",
+      index: 0,
+      content_block: contentBlock,
+    }),
+  );
+}
+
+function finishMessage(response, stopReason) {
+  response.write(
+    sseEvent("content_block_stop", { type: "content_block_stop", index: 0 }),
+  );
+  response.write(
+    sseEvent("message_delta", {
+      type: "message_delta",
+      delta: { stop_reason: stopReason, stop_sequence: null },
+      usage: { output_tokens: 1 },
+    }),
+  );
+  response.end(sseEvent("message_stop", { type: "message_stop" }));
+}
+
+function sendText(response, text, stopReason = "end_turn") {
+  startMessage(response, { type: "text", text: "" });
+  response.write(
+    sseEvent("content_block_delta", {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text },
+    }),
+  );
+  finishMessage(response, stopReason);
+}
+
+function sendToolUse(response) {
+  startMessage(response, {
+    type: "tool_use",
+    id: "toolu_spike_echo",
+    name: MCP_TOOL_NAME,
+    input: {},
+  });
+  response.write(
+    sseEvent("content_block_delta", {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "input_json_delta", partial_json: '{"value":"first-turn"}' },
+    }),
+  );
+  finishMessage(response, "tool_use");
+}
+
+function sendAgentToolUse(response) {
+  startMessage(response, {
+    type: "tool_use",
+    id: "toolu_spike_agent",
+    name: "Agent",
+    input: {},
+  });
+  response.write(
+    sseEvent("content_block_delta", {
+      type: "content_block_delta",
+      index: 0,
+      delta: {
+        type: "input_json_delta",
+        partial_json: JSON.stringify({
+          description: "Run deterministic child",
+          prompt: "Subagent child verification: reply subagent-child-ok.",
+          subagent_type: "spike-agent",
+        }),
+      },
+    }),
+  );
+  finishMessage(response, "tool_use");
+}
+
+function requestHasText(body, text) {
+  return body.messages?.some((message) =>
+    Array.isArray(message.content)
+      ? message.content.some(
+          (block) =>
+            block?.type === "text" &&
+            typeof block.text === "string" &&
+            block.text.includes(text),
+        )
+      : false,
+  );
+}
+
+function requestHasToolResult(body) {
+  return body.messages?.some((message) =>
+    Array.isArray(message.content)
+      ? message.content.some((block) => block?.type === "tool_result")
+      : false,
+  );
+}
+
+function requestHasResumePrompt(body) {
+  return requestHasText(body, "Resume verification");
+}
+
+function requestHasCancellationPrompt(body) {
+  return requestHasText(body, "Cancellation verification");
+}
+
+async function withDeadline(promise, timeoutMs, label) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Fake provider did not bind a TCP port");
+  }
+  return address.port;
+}
+
+async function closeServer(server) {
+  server.closeAllConnections();
+  await new Promise((resolve) => server.close(resolve));
+}
+
+function resultMessage(messages) {
+  const result = messages.findLast((message) => message.type === "result");
+  if (!result || result.subtype !== "success" || result.is_error) {
+    throw new Error("Agent SDK fake-provider turn did not succeed");
+  }
+  return result;
+}
+
+function initMessage(messages) {
+  const init = messages.find(
+    (message) => message.type === "system" && message.subtype === "init",
+  );
+  if (!init) throw new Error("Agent SDK fake-provider turn emitted no init event");
+  return init;
+}
+
+export async function runFakeProviderVerification({ sdkPackageDirectory }) {
+  const artifactReport = await inspectAgentSdkInstallation(sdkPackageDirectory);
+  const runtime = await import(
+    pathToFileURL(path.join(sdkPackageDirectory, "sdk.mjs")).href
+  );
+  const requireFromSpike = createRequire(import.meta.url);
+  const { z } = requireFromSpike("zod/v4");
+  const workDirectory = await mkdtemp(path.join(os.tmpdir(), "matrix-agent-sdk-spike-"));
+  const configDirectory = path.join(workDirectory, "claude-config");
+  const requests = [];
+  let hookCalls = 0;
+  let mcpCalls = 0;
+  let markCancellationRequestSeen;
+  const cancellationRequestSeen = new Promise((resolve) => {
+    markCancellationRequestSeen = resolve;
+  });
+
+  await mkdir(path.join(workDirectory, ".claude", "skills", "spike-skill"), {
+    recursive: true,
+  });
+  await writeFile(
+    path.join(workDirectory, ".claude", "skills", "spike-skill", "SKILL.md"),
+    "---\nname: spike-skill\ndescription: Phase 0 SDK verification fixture\n---\nReply deterministically.\n",
+    { flag: "wx" },
+  );
+
+  const server = http.createServer(async (request, response) => {
+    if (request.method === "HEAD" && request.url === "/api/hello") {
+      response.writeHead(200).end();
+      return;
+    }
+    if (request.method !== "POST" || !request.url?.startsWith("/v1/messages")) {
+      response.writeHead(404).end();
+      return;
+    }
+
+    let rawBody = "";
+    for await (const chunk of request) rawBody += chunk;
+    const body = JSON.parse(rawBody);
+    requests.push({
+      path: request.url,
+      authorization: request.headers.authorization,
+      anthropicBeta: request.headers["anthropic-beta"],
+      body,
+    });
+
+    if (requestHasCancellationPrompt(body)) {
+      markCancellationRequestSeen();
+      return;
+    }
+
+    response.writeHead(200, {
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+      "content-type": "text/event-stream",
+    });
+    if (requestHasText(body, "Refusal verification")) {
+      sendText(response, "refused-by-spike", "refusal");
+    } else if (requestHasText(body, "Subagent child verification")) {
+      sendText(response, "subagent-child-ok");
+    } else if (requestHasText(body, "Subagent verification")) {
+      if (requestHasToolResult(body)) sendText(response, "subagent-ok");
+      else sendAgentToolUse(response);
+    } else if (requestHasResumePrompt(body)) {
+      sendText(response, "resume-ok");
+    } else if (requestHasToolResult(body)) {
+      sendText(response, "mcp-ok");
+    } else {
+      sendToolUse(response);
+    }
+  });
+
+  try {
+    const port = await listen(server);
+    const transportEnvironment = buildAgentSdkTransportEnvironment({
+      baseUrl: `http://127.0.0.1:${port}`,
+      authToken: "spike-token",
+    });
+    const environment = {
+      ...process.env,
+      ...transportEnvironment,
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+      CLAUDE_CODE_REFUSAL_FALLBACK_CATCH_ALL: "0",
+      CLAUDE_CONFIG_DIR: configDirectory,
+    };
+    const mcpServer = runtime.createSdkMcpServer({
+      name: "spike",
+      tools: [
+        runtime.tool(
+          "echo",
+          "Echo a value for deterministic Agent SDK verification",
+          { value: z.string() },
+          async ({ value }) => {
+            mcpCalls += 1;
+            return { content: [{ type: "text", text: `echo:${value}` }] };
+          },
+        ),
+      ],
+    });
+    const sharedOptions = {
+      allowedTools: [MCP_TOOL_NAME],
+      cwd: workDirectory,
+      env: environment,
+      executable: "node",
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: MCP_TOOL_NAME,
+            hooks: [
+              async () => {
+                hookCalls += 1;
+                return {
+                  hookSpecificOutput: {
+                    hookEventName: "PreToolUse",
+                    permissionDecision: "allow",
+                  },
+                };
+              },
+            ],
+          },
+        ],
+      },
+      maxTurns: 2,
+      mcpServers: { spike: mcpServer },
+      model: MODEL,
+      settingSources: ["project"],
+      skills: ["spike-skill"],
+      tools: [MCP_TOOL_NAME],
+    };
+
+    const firstMessages = [];
+    for await (const message of runtime.query({
+      prompt: "Call the echo tool with first-turn, then report its result.",
+      options: sharedOptions,
+    })) {
+      firstMessages.push(message);
+    }
+    const firstResult = resultMessage(firstMessages);
+    const firstInit = initMessage(firstMessages);
+
+    const resumeMessages = [];
+    for await (const message of runtime.query({
+      prompt: "Resume verification: reply with resume-ok.",
+      options: {
+        ...sharedOptions,
+        maxTurns: 1,
+        resume: firstResult.session_id,
+      },
+    })) {
+      resumeMessages.push(message);
+    }
+    const resumeResult = resultMessage(resumeMessages);
+    const subagentMessages = [];
+    for await (const message of runtime.query({
+      prompt: "Subagent verification: delegate to spike-agent and report subagent-ok.",
+      options: {
+        ...sharedOptions,
+        agents: {
+          "spike-agent": {
+            description: "Deterministic fake-provider verification agent",
+            prompt: "Follow the verification prompt exactly.",
+            tools: [],
+            model: MODEL,
+            maxTurns: 1,
+          },
+        },
+        allowedTools: ["Agent"],
+        maxTurns: 3,
+        skills: [],
+        tools: ["Agent"],
+      },
+    })) {
+      subagentMessages.push(message);
+    }
+    const subagentResult = resultMessage(subagentMessages);
+
+    const refusalMessages = [];
+    try {
+      for await (const message of runtime.query({
+        prompt: "Refusal verification: emit the provider refusal fixture.",
+        options: {
+          ...sharedOptions,
+          allowedTools: [],
+          maxTurns: 1,
+          skills: [],
+          tools: [],
+        },
+      })) {
+        refusalMessages.push(message);
+      }
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.includes("can't help")) {
+        throw error;
+      }
+    }
+    const refusalResult = refusalMessages.findLast(
+      (message) => message.type === "result",
+    );
+    const refusalEvent = refusalMessages.find(
+      (message) =>
+        message.type === "system" && message.subtype === "model_refusal_no_fallback",
+    );
+    if (!refusalEvent) {
+      throw new Error("Agent SDK did not emit a structured no-fallback refusal");
+    }
+
+    const abortController = new AbortController();
+    const cancellationStartedAt = Date.now();
+    const cancellationRun = (async () => {
+      try {
+        for await (const _message of runtime.query({
+          prompt: "Cancellation verification: wait for the provider.",
+          options: {
+            ...sharedOptions,
+            abortController,
+            maxTurns: 1,
+          },
+        })) {
+          // The fake provider deliberately never starts this response.
+        }
+      } catch (error) {
+        if (
+          error?.name !== "AbortError" &&
+          !(typeof runtime.AbortError === "function" && error instanceof runtime.AbortError)
+        ) {
+          throw error;
+        }
+      }
+    })();
+    await withDeadline(cancellationRequestSeen, 5_000, "cancellation request");
+    abortController.abort();
+    await withDeadline(cancellationRun, 5_000, "Agent SDK cancellation");
+    const cancellationDurationMs = Date.now() - cancellationStartedAt;
+    const firstRequest = requests[0];
+    const usage = Object.values(firstResult.modelUsage)[0];
+    if (!firstRequest || !usage) {
+      throw new Error("Agent SDK fake-provider report is incomplete");
+    }
+
+    return {
+      sdkVersion: artifactReport.version,
+      transport: {
+        authorization:
+          firstRequest.authorization === "Bearer spike-token" ? "present" : "missing",
+        baseUrl: "loopback",
+        messagesPath: firstRequest.path,
+        anthropicBeta: firstRequest.anthropicBeta ?? "",
+      },
+      firstTurn: {
+        hookCalls,
+        mcpCalls,
+        result: firstResult.result,
+        skillLoaded: firstInit.skills?.includes("spike-skill") ?? false,
+        usageModel: usage.canonicalModel,
+      },
+      resume: {
+        result: resumeResult.result,
+        reusedSession: resumeResult.session_id === firstResult.session_id,
+      },
+      subagent: {
+        result: subagentResult.result,
+        spawned: subagentResult.subagent_stats?.spawned ?? 0,
+      },
+      refusal: {
+        structuredEvent: refusalEvent.subtype,
+        stopReason: refusalResult?.stop_reason ?? "refusal",
+      },
+      cancellation: {
+        aborted: abortController.signal.aborted,
+        withinDeadline: cancellationDurationMs < 5_000,
+      },
+    };
+  } finally {
+    if (server.listening) await closeServer(server);
+    await rm(workDirectory, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 50,
+    });
+  }
+}

--- a/scripts/spikes/agent-sdk-gateway/run.mjs
+++ b/scripts/spikes/agent-sdk-gateway/run.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+import { runFakeProviderVerification } from "./fake-provider.mjs";
+import {
+  OPENROUTER_ANTHROPIC_BASE_URL,
+  TARGET_AGENT_SDK_VERSION,
+  formatVerificationFailure,
+  parseClaudeAuthStatus,
+} from "./verification.mjs";
+
+function readClaudeAuthStatus() {
+  const configuredExecutable = process.env.MATRIX_CLAUDE_BIN;
+  if (configuredExecutable && !path.isAbsolute(configuredExecutable)) {
+    throw new Error("MATRIX_CLAUDE_BIN must be an absolute path");
+  }
+  const result = spawnSync(configuredExecutable ?? "claude", ["auth", "status", "--json"], {
+    encoding: "utf8",
+    env: { ...process.env, NO_COLOR: "1" },
+    maxBuffer: 64 * 1024,
+    timeout: 10_000,
+  });
+  if (result.error?.code === "ENOENT") {
+    return { available: false, loggedIn: false };
+  }
+  if (result.error) {
+    throw new Error("Claude auth status check failed");
+  }
+  return { available: true, ...parseClaudeAuthStatus(result.stdout) };
+}
+
+async function main() {
+  const packageDirectory =
+    process.env.MATRIX_AGENT_SDK_PACKAGE_DIR ?? process.argv[2];
+  if (!packageDirectory || !path.isAbsolute(packageDirectory)) {
+    throw new Error(
+      "Set MATRIX_AGENT_SDK_PACKAGE_DIR to the absolute @anthropic-ai/claude-agent-sdk package directory",
+    );
+  }
+
+  const runtime = await runFakeProviderVerification({
+    sdkPackageDirectory: packageDirectory,
+  });
+  const report = {
+    targetVersion: TARGET_AGENT_SDK_VERSION,
+    runtime,
+    anthropicLogin: readClaudeAuthStatus(),
+    openRouter: {
+      agentSdkBaseUrl: OPENROUTER_ANTHROPIC_BASE_URL,
+      oauthPkceContract: "verified",
+      liveExchange: "credential_blocked",
+    },
+    cloudflare: {
+      anthropicStreaming: "fake_provider_verified",
+      liveUnifiedBilling: "credential_blocked",
+      payloadLoggingHeader: "cf-aig-collect-log-payload: false",
+      perRequestZdrHeader: "cf-aig-zdr: true",
+      customMetadataLimit: 5,
+    },
+  };
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${formatVerificationFailure(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/spikes/agent-sdk-gateway/verification.mjs
+++ b/scripts/spikes/agent-sdk-gateway/verification.mjs
@@ -1,0 +1,245 @@
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+import path from "node:path";
+
+export const TARGET_AGENT_SDK_VERSION = "0.3.251";
+export const OPENROUTER_ANTHROPIC_BASE_URL = "https://openrouter.ai/api";
+export const OPENROUTER_AUTHORIZE_URL = "https://openrouter.ai/auth";
+export const OPENROUTER_EXCHANGE_URL = "https://openrouter.ai/api/v1/auth/keys";
+
+const REQUIRED_RUNTIME_EXPORTS = ["createSdkMcpServer", "query", "tool"];
+const ALLOWED_CLOUDFLARE_METADATA_KEYS = new Set([
+  "access_source",
+  "matrix_user_ref",
+  "model_ref",
+  "run_ref",
+  "runtime_ref",
+  "team_ref",
+]);
+
+function isSafeCallback(url) {
+  if (url.protocol === "https:") return true;
+  return (
+    url.protocol === "http:" &&
+    (url.hostname === "localhost" || url.hostname === "127.0.0.1")
+  );
+}
+
+function requireBoundedString(value, label, { min = 1, max = 512 } = {}) {
+  if (typeof value !== "string" || value.length < min || value.length > max) {
+    throw new Error(`${label} must be a string between ${min} and ${max} characters`);
+  }
+  return value;
+}
+
+function hasDeclaration(declarationText, pattern) {
+  return pattern.test(declarationText);
+}
+
+export function verifyAgentSdkArtifacts({
+  manifest,
+  declarationText,
+  runtimeExports,
+  hookEvents,
+}) {
+  const exports = new Set(runtimeExports);
+  const events = new Set(hookEvents);
+  const checks = {
+    abortController: hasDeclaration(
+      declarationText,
+      /abortController\?:\s*AbortController\s*;/,
+    ),
+    agents: hasDeclaration(
+      declarationText,
+      /agents\?:\s*Record<string,\s*AgentDefinition>\s*;/,
+    ),
+    hooks: hasDeclaration(
+      declarationText,
+      /hooks\?:\s*Partial<Record<HookEvent,\s*HookCallbackMatcher\[\]>>\s*;/,
+    ),
+    inProcessMcp:
+      exports.has("createSdkMcpServer") &&
+      hasDeclaration(
+        declarationText,
+        /mcpServers\?:\s*Record<string,\s*McpServerConfig>\s*;/,
+      ),
+    preToolUse: exports.has("HOOK_EVENTS") && events.has("PreToolUse"),
+    query: exports.has("query"),
+    resume: hasDeclaration(declarationText, /resume\?:\s*string\s*;/),
+    skills: hasDeclaration(
+      declarationText,
+      /skills\?:\s*string\[\]\s*\|\s*['"]all['"]\s*;/,
+    ),
+    structuredOutput: hasDeclaration(
+      declarationText,
+      /structured_output\?:\s*unknown\s*;/,
+    ),
+    tool: exports.has("tool"),
+    usage: hasDeclaration(
+      declarationText,
+      /modelUsage:\s*Record<string,\s*ModelUsage>\s*;/,
+    ),
+  };
+
+  const failed = Object.entries(checks)
+    .filter(([, passed]) => !passed)
+    .map(([name]) => name);
+  if (manifest?.version !== TARGET_AGENT_SDK_VERSION) {
+    failed.unshift(
+      `version (expected ${TARGET_AGENT_SDK_VERSION}, received ${String(manifest?.version)})`,
+    );
+  }
+  if (failed.length > 0) {
+    throw new Error(`Agent SDK verification failed: ${failed.join(", ")}`);
+  }
+
+  return { version: manifest.version, checks };
+}
+
+export async function inspectAgentSdkInstallation(packageDirectory) {
+  const manifestPath = path.join(packageDirectory, "package.json");
+  const declarationPath = path.join(packageDirectory, "sdk.d.ts");
+  const runtimePath = path.join(packageDirectory, "sdk.mjs");
+  const [manifestText, declarationText, runtime] = await Promise.all([
+    readFile(manifestPath, "utf8"),
+    readFile(declarationPath, "utf8"),
+    import(pathToFileURL(runtimePath).href),
+  ]);
+  const manifest = JSON.parse(manifestText);
+
+  return verifyAgentSdkArtifacts({
+    manifest,
+    declarationText,
+    runtimeExports: Object.keys(runtime),
+    hookEvents: Array.isArray(runtime.HOOK_EVENTS) ? runtime.HOOK_EVENTS : [],
+  });
+}
+
+export function parseClaudeAuthStatus(stdout) {
+  let value;
+  try {
+    value = JSON.parse(stdout);
+  } catch (error) {
+    throw new Error("Invalid Claude auth status JSON", { cause: error });
+  }
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    typeof value.loggedIn !== "boolean" ||
+    typeof value.authMethod !== "string" ||
+    value.authMethod.length > 64 ||
+    typeof value.apiProvider !== "string" ||
+    value.apiProvider.length > 64
+  ) {
+    throw new Error("Invalid Claude auth status shape", {
+      cause: new TypeError("unexpected auth status fields"),
+    });
+  }
+  return {
+    loggedIn: value.loggedIn,
+    authMethod: value.authMethod,
+    apiProvider: value.apiProvider,
+  };
+}
+
+export function formatVerificationFailure(error) {
+  if (!(error instanceof Error)) return "Unknown failure: verification failed";
+  const safePrefixes = [
+    "Agent SDK verification failed:",
+    "Agent SDK runtime exports missing:",
+    "Invalid Claude auth status",
+    "Set MATRIX_AGENT_SDK_PACKAGE_DIR",
+    "MATRIX_CLAUDE_BIN must be an absolute path",
+    "Claude auth status check failed",
+    "Agent SDK fake-provider",
+    "Agent SDK did not emit",
+    "Fake provider did not bind",
+  ];
+  const safeMessage = safePrefixes.some((prefix) => error.message.startsWith(prefix))
+    ? error.message
+    : "verification failed";
+  return `${error.name}: ${safeMessage}`;
+}
+
+export function buildAgentSdkTransportEnvironment({ baseUrl, authToken }) {
+  const parsed = new URL(baseUrl);
+  const isLoopback =
+    parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1";
+  if (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && isLoopback)) {
+    throw new Error("Agent SDK base URL must use HTTPS (except loopback spikes)");
+  }
+  requireBoundedString(authToken, "Agent SDK auth token", { max: 4096 });
+
+  return {
+    ANTHROPIC_API_KEY: "",
+    ANTHROPIC_AUTH_TOKEN: authToken,
+    ANTHROPIC_BASE_URL: parsed.toString().replace(/\/$/, ""),
+  };
+}
+
+export function buildOpenRouterAuthorizeUrl({ callbackUrl, codeChallenge }) {
+  const callback = new URL(callbackUrl);
+  if (!isSafeCallback(callback)) {
+    throw new Error("OpenRouter callback must use HTTPS or loopback HTTP");
+  }
+  requireBoundedString(callback.searchParams.get("state"), "owner-bound state", {
+    min: 16,
+    max: 512,
+  });
+  requireBoundedString(codeChallenge, "PKCE code challenge", { min: 43, max: 128 });
+  if (!/^[A-Za-z0-9_-]+$/.test(codeChallenge)) {
+    throw new Error("PKCE code challenge must be base64url encoded");
+  }
+
+  const authorize = new URL(OPENROUTER_AUTHORIZE_URL);
+  authorize.searchParams.set("callback_url", callback.toString());
+  authorize.searchParams.set("code_challenge", codeChallenge);
+  authorize.searchParams.set("code_challenge_method", "S256");
+  return authorize.toString();
+}
+
+export function buildOpenRouterExchangeRequest({ code, codeVerifier }) {
+  requireBoundedString(code, "OpenRouter authorization code", { max: 2048 });
+  requireBoundedString(codeVerifier, "PKCE code verifier", { min: 43, max: 128 });
+  if (!/^[A-Za-z0-9._~-]+$/.test(codeVerifier)) {
+    throw new Error("PKCE code verifier contains invalid characters");
+  }
+
+  return {
+    url: OPENROUTER_EXCHANGE_URL,
+    init: {
+      method: "POST",
+      redirect: "error",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        code,
+        code_verifier: codeVerifier,
+        code_challenge_method: "S256",
+      }),
+      signal: AbortSignal.timeout(10_000),
+    },
+  };
+}
+
+export function verifyCloudflareMetadata(metadata) {
+  const entries = Object.entries(metadata);
+  if (entries.length > 5) {
+    throw new Error("Cloudflare custom metadata accepts at most five entries");
+  }
+  for (const [key, value] of entries) {
+    if (!ALLOWED_CLOUDFLARE_METADATA_KEYS.has(key)) {
+      throw new Error("Cloudflare metadata must be content-free and use allowlisted keys");
+    }
+    requireBoundedString(value, `Cloudflare metadata ${key}`, { max: 128 });
+  }
+  return Object.fromEntries(entries.sort(([left], [right]) => left.localeCompare(right)));
+}
+
+export function assertRequiredRuntimeExports(runtime) {
+  const missing = REQUIRED_RUNTIME_EXPORTS.filter(
+    (exportName) => typeof runtime[exportName] !== "function",
+  );
+  if (missing.length > 0) {
+    throw new Error(`Agent SDK runtime exports missing: ${missing.join(", ")}`);
+  }
+}

--- a/specs/118-ai-gateway-provider-auth/plan.md
+++ b/specs/118-ai-gateway-provider-auth/plan.md
@@ -211,6 +211,8 @@ Every numbered slice is an independently reviewable PR. Tests are written red fi
 
 **Checkpoint**: red/green fake-provider assertions plus bounded real low-cost tests; `bun run test` and kernel coverage; local Docker compatibility only if exercising proxy packaging; no rollout.
 
+**Verification record**: [`sdk-verification.md`](./sdk-verification.md) captures the exact SDK/runtime results, reproducible commands, and the credential-blocked live checks that remain before rollout.
+
 **PR**: `test(kernel): verify current agent sdk and gateway behavior`
 
 ### Phase 1 — Upgrade Agent SDK and current model catalog

--- a/specs/118-ai-gateway-provider-auth/sdk-verification.md
+++ b/specs/118-ai-gateway-provider-auth/sdk-verification.md
@@ -1,0 +1,82 @@
+# Agent SDK and Gateway Verification
+
+**Verified**: 2026-08-29
+
+**Target**: `@anthropic-ai/claude-agent-sdk@0.3.251`
+
+**Production version during this spike**: `0.2.79` (unchanged; the upgrade belongs to Phase 1)
+
+## Reproduce
+
+Install the target SDK outside the repository so this spike does not alter the
+production dependency or lockfile:
+
+```bash
+mkdir -p /private/tmp/matrix-agent-sdk-03251
+pnpm add --dir /private/tmp/matrix-agent-sdk-03251 @anthropic-ai/claude-agent-sdk@0.3.251
+MATRIX_AGENT_SDK_PACKAGE_DIR=/private/tmp/matrix-agent-sdk-03251/node_modules/@anthropic-ai/claude-agent-sdk \
+  bun run spike:agent-sdk
+```
+
+If `claude` is not on `PATH`, set `MATRIX_CLAUDE_BIN` to its absolute path. The
+runner binds only to loopback, uses a fake bearer token, makes no paid model
+request, removes its temporary skill/session directory, and never prints a
+credential or raw auth-status output.
+
+The normal contract tests run without an SDK download:
+
+```bash
+pnpm exec vitest run tests/scripts/agent-sdk-gateway-verification.test.ts
+```
+
+The real-runtime test is opt-in for ordinary local unit runs:
+
+```bash
+MATRIX_AGENT_SDK_PACKAGE_DIR=/absolute/path/to/node_modules/@anthropic-ai/claude-agent-sdk \
+  pnpm exec vitest run tests/scripts/agent-sdk-real-runtime-spike.test.ts
+```
+
+CI has a required `Agent SDK 0.3.251 Compatibility` job that installs the exact
+package into the runner's temporary directory and runs this test. The ordinary
+unit shards keep it skipped so they do not repeat the external install four
+times.
+
+## Results
+
+| Check | Result | Evidence / decision |
+|---|---|---|
+| Exact package and runtime surface | Pass | Exact `0.3.251`; runtime exports `query`, `createSdkMcpServer`, `tool`, and `HOOK_EVENTS`. Types retain V1 `resume`, `mcpServers`, `agents`, `hooks`, `abortController`, structured output, and `modelUsage`. |
+| Relay base URL and token | Pass | The bundled Claude runtime called the loopback Anthropic endpoint at `/v1/messages?beta=true` and sent the configured bearer token. The report only records `present`. `ANTHROPIC_API_KEY` must be explicitly empty when `ANTHROPIC_AUTH_TOKEN` is used. |
+| First-turn in-process MCP | Pass | A forced first response called `mcp__spike__echo`; the in-process tool ran once and the next model request contained its tool result. |
+| V1 `query()` + `resume` | Pass | The second `query()` reused the first result's session ID and returned `resume-ok`. Keep V1 for the Phase 1 upgrade. |
+| `PreToolUse` | Pass | The matcher ran exactly once for the MCP tool and allowed it. Defense-in-depth hooks remain available. |
+| Skills | Pass | A temporary project skill was visible in the init event with `skills: ["spike-skill"]`. `Skill` in `allowedTools` is deprecated in `0.3.251`; Matrix must migrate to the `skills` option. |
+| Agent subagents | Pass | A forced `Agent` tool call spawned the configured subagent and returned a structured result. The result reported one spawned subagent. |
+| Cancellation | Pass | Aborting `Options.abortController` terminated a request whose upstream never responded within the five-second spike deadline. |
+| Refusal and usage | Pass | A provider `stop_reason: "refusal"` produced `model_refusal_no_fallback`; the SDK then throws after emitting the structured event. Consumers must retain events before normalizing that error. Successful results expose per-model canonical provider/model and cost/token usage through `modelUsage`. |
+| Anthropic login status | Contract pass; live login blocked | The installed CLI supports `claude auth login` (`--claudeai`, `--console`, `--email`, `--sso`) and machine-readable `claude auth status --json`. This machine reported `loggedIn: false`, so an authenticated owner-profile turn was not run. Chat/Settings can launch the visible CLI login and poll the structured status; they must not infer readiness from credential files. |
+| OpenRouter Agent SDK transport | Official contract pass; live call blocked | OpenRouter documents `ANTHROPIC_BASE_URL=https://openrouter.ai/api`, `ANTHROPIC_AUTH_TOKEN=<owner key>`, and an explicitly empty `ANTHROPIC_API_KEY`. No owner key was available for a live model request. |
+| OpenRouter OAuth PKCE | Contract pass; live exchange blocked | Builders require S256, an owner-bound one-time `state` in the callback, the fixed HTTPS exchange endpoint, redirect rejection, and a ten-second timeout. No authorization code was minted or exchanged. |
+| Cloudflare Anthropic streaming | Protocol pass; live Unified Billing blocked | The fake provider proves the Agent SDK's Anthropic streaming and required beta-header behavior through the Matrix-compatible boundary. No Cloudflare gateway credential was available for an external inference call. |
+| Cloudflare privacy / metadata | Contract pass | Funded requests must send `cf-aig-collect-log-payload: false` and `cf-aig-zdr: true`; metadata is allowlisted, content-free, and capped at Cloudflare's five-entry limit. |
+| Cloudflare spend controls | Documentation verified; live enforcement blocked | Gateway rules can scope budgets by model/provider/custom metadata, including split-by-user. They are eventually consistent and are not Matrix's hard customer balance. Matrix remains authoritative for eligibility, add-on credit, and hard admission. |
+
+## Frozen provider contracts
+
+- OpenRouter Agent SDK: <https://openrouter.ai/docs/guides/community/anthropic-agent-sdk>
+- OpenRouter OAuth PKCE: <https://openrouter.ai/docs/guides/overview/auth/oauth>
+- Cloudflare Unified Billing and per-request ZDR: <https://developers.cloudflare.com/ai-gateway/features/unified-billing/>
+- Cloudflare payload-log suppression: <https://developers.cloudflare.com/ai-gateway/observability/logging/>
+- Cloudflare limits: <https://developers.cloudflare.com/ai-gateway/reference/limits/>
+
+## Phase 1 migration gates
+
+1. Remove `Skill` from `allowedTools` and configure the explicit `skills` option.
+2. Keep V1 `query()` with `resume`; do not adopt a newer session API until the
+   same MCP/resume harness passes against it.
+3. Normalize `modelUsage` rather than summing main-loop `usage`; `modelUsage`
+   includes subagents and other query-pipeline calls.
+4. Preserve structured refusal events even when the SDK subsequently throws.
+5. Run one bounded authenticated owner-profile turn and one Cloudflare Unified
+   Billing turn in a secret-bearing environment before rollout. The deterministic
+   fake-provider suite remains the required regression gate.

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -150,17 +150,18 @@ describe('CI workflows', () => {
     expect(workflow).toContain('ci-results:');
     expect(workflow).toContain('name: CI Results');
     expect(workflow).toContain('if: always()');
-    expect(workflow).toContain('needs: [changes, typecheck, shell-production-build, patterns, react-doctor, sync-client, unit, docs-contract, e2e]');
+    expect(workflow).toContain('needs: [changes, typecheck, shell-production-build, patterns, react-doctor, sync-client, agent-sdk-compatibility, unit, docs-contract, e2e]');
     expect(workflow).toContain('### CI Results');
     expect(workflow).toContain('needs.typecheck.result');
     expect(workflow).toContain('needs.shell-production-build.result');
     expect(workflow).toContain('needs.patterns.result');
     expect(workflow).toContain('needs.react-doctor.result');
     expect(workflow).toContain('needs.sync-client.result');
+    expect(workflow).toContain('needs.agent-sdk-compatibility.result');
     expect(workflow).toContain('needs.unit.result');
     expect(workflow).toContain('needs.docs-contract.result');
     expect(workflow).toContain('needs.e2e.result');
-    expect(workflow).toContain('"$PATTERNS_RESULT" "$REACT_DOCTOR_RESULT" "$SYNC_CLIENT_RESULT" "$UNIT_RESULT" "$DOCS_CONTRACT_RESULT"');
+    expect(workflow).toContain('"$PATTERNS_RESULT" "$REACT_DOCTOR_RESULT" "$SYNC_CLIENT_RESULT" "$AGENT_SDK_COMPATIBILITY_RESULT" "$UNIT_RESULT" "$DOCS_CONTRACT_RESULT"');
     expect(workflow).toContain('Branch protection should require this aggregate job');
   });
 

--- a/tests/scripts/agent-sdk-ci-workflow.test.ts
+++ b/tests/scripts/agent-sdk-ci-workflow.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+describe("Agent SDK compatibility CI gate", () => {
+  it("installs the exact external SDK and includes the real-runtime spike in CI Results", () => {
+    const workflow = parse(
+      readFileSync(join(process.cwd(), ".github/workflows/ci.yml"), "utf8"),
+    ) as {
+      jobs: Record<string, {
+        name?: string;
+        needs?: string[];
+        steps?: Array<{ name?: string; run?: string; env?: Record<string, string> }>;
+      }>;
+    };
+
+    const compatibility = workflow.jobs["agent-sdk-compatibility"];
+    expect(
+      ((workflow as unknown as { on: { pull_request: { branches: string[] } } }).on
+        .pull_request.branches),
+    ).toContain("codex/**");
+    expect(compatibility?.name).toBe("Agent SDK 0.3.251 Compatibility");
+    const installStep = compatibility?.steps?.find(
+      (step) => step.name === "Install exact Agent SDK",
+    )?.run;
+    expect(installStep).toContain(
+      'mkdir -p "${{ runner.temp }}/matrix-agent-sdk-03251"',
+    );
+    expect(installStep).toContain("@anthropic-ai/claude-agent-sdk@0.3.251");
+
+    const runtimeStep = compatibility?.steps?.find(
+      (step) => step.name === "Run real Agent SDK compatibility spike",
+    );
+    expect(runtimeStep?.env?.MATRIX_AGENT_SDK_PACKAGE_DIR).toContain(
+      "node_modules/@anthropic-ai/claude-agent-sdk",
+    );
+    expect(runtimeStep?.run).toContain(
+      "tests/scripts/agent-sdk-real-runtime-spike.test.ts",
+    );
+
+    const aggregate = workflow.jobs["ci-results"];
+    expect(aggregate?.needs).toContain("agent-sdk-compatibility");
+    expect(
+      aggregate?.steps?.find((step) => step.name === "Summarize required CI jobs")
+        ?.env?.AGENT_SDK_COMPATIBILITY_RESULT,
+    ).toBe("${{ needs.agent-sdk-compatibility.result }}");
+  });
+});

--- a/tests/scripts/agent-sdk-gateway-verification.test.ts
+++ b/tests/scripts/agent-sdk-gateway-verification.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  TARGET_AGENT_SDK_VERSION,
+  buildAgentSdkTransportEnvironment,
+  buildOpenRouterAuthorizeUrl,
+  buildOpenRouterExchangeRequest,
+  formatVerificationFailure,
+  parseClaudeAuthStatus,
+  verifyAgentSdkArtifacts,
+  verifyCloudflareMetadata,
+} from "../../scripts/spikes/agent-sdk-gateway/verification.mjs";
+
+const REQUIRED_DECLARATIONS = `
+export declare type Options = {
+  abortController?: AbortController;
+  agents?: Record<string, AgentDefinition>;
+  hooks?: Partial<Record<HookEvent, HookCallbackMatcher[]>>;
+  mcpServers?: Record<string, McpServerConfig>;
+  resume?: string;
+  skills?: string[] | 'all';
+};
+export declare type SDKResultSuccess = {
+  structured_output?: unknown;
+  modelUsage: Record<string, ModelUsage>;
+};
+`;
+
+describe("Agent SDK and gateway verification contracts", () => {
+  it("pins the Phase 0 target and verifies the required SDK surface", () => {
+    expect(TARGET_AGENT_SDK_VERSION).toBe("0.3.251");
+
+    expect(
+      verifyAgentSdkArtifacts({
+        manifest: { version: TARGET_AGENT_SDK_VERSION },
+        declarationText: REQUIRED_DECLARATIONS,
+        runtimeExports: ["HOOK_EVENTS", "createSdkMcpServer", "query", "tool"],
+        hookEvents: ["PreToolUse"],
+      }),
+    ).toEqual({
+      version: TARGET_AGENT_SDK_VERSION,
+      checks: {
+        abortController: true,
+        agents: true,
+        hooks: true,
+        inProcessMcp: true,
+        preToolUse: true,
+        query: true,
+        resume: true,
+        skills: true,
+        structuredOutput: true,
+        tool: true,
+        usage: true,
+      },
+    });
+  });
+
+  it("fails closed when the SDK version or a required capability drifts", () => {
+    expect(() =>
+      verifyAgentSdkArtifacts({
+        manifest: { version: "0.3.250" },
+        declarationText: REQUIRED_DECLARATIONS.replace("resume?: string;", ""),
+        runtimeExports: ["query"],
+        hookEvents: [],
+      }),
+    ).toThrow(/Agent SDK verification failed/);
+  });
+
+  it("normalizes Claude's machine-readable login state without retaining output", () => {
+    expect(
+      parseClaudeAuthStatus(
+        JSON.stringify({
+          loggedIn: false,
+          authMethod: "none",
+          apiProvider: "firstParty",
+          analyticsDisabled: false,
+        }),
+      ),
+    ).toEqual({
+      loggedIn: false,
+      authMethod: "none",
+      apiProvider: "firstParty",
+    });
+
+    expect(() => parseClaudeAuthStatus('{"loggedIn":"yes"}')).toThrow(
+      /Invalid Claude auth status/,
+    );
+
+    try {
+      parseClaudeAuthStatus("not-json");
+      throw new Error("expected parseClaudeAuthStatus to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error & { cause?: unknown }).cause).toBeInstanceOf(SyntaxError);
+    }
+  });
+
+  it("preserves safe diagnostics while redacting unknown failure messages", () => {
+    expect(
+      formatVerificationFailure(
+        new Error("Agent SDK verification failed: resume"),
+      ),
+    ).toBe("Error: Agent SDK verification failed: resume");
+    expect(
+      formatVerificationFailure(new Error("upstream leaked sk-secret-value")),
+    ).toBe("Error: verification failed");
+    expect(formatVerificationFailure("unexpected rejection")).toBe(
+      "Unknown failure: verification failed",
+    );
+  });
+
+  it("builds an isolated Agent SDK relay environment", () => {
+    expect(
+      buildAgentSdkTransportEnvironment({
+        baseUrl: "https://relay.matrix.example/anthropic",
+        authToken: "test-token",
+      }),
+    ).toEqual({
+      ANTHROPIC_API_KEY: "",
+      ANTHROPIC_AUTH_TOKEN: "test-token",
+      ANTHROPIC_BASE_URL: "https://relay.matrix.example/anthropic",
+    });
+
+    expect(() =>
+      buildAgentSdkTransportEnvironment({
+        baseUrl: "http://169.254.169.254/latest",
+        authToken: "test-token",
+      }),
+    ).toThrow(/HTTPS/);
+  });
+
+  it("freezes OpenRouter PKCE authorization and exchange request shapes", () => {
+    const callbackUrl =
+      "https://app.matrix-os.com/api/ai/connections/openrouter/callback?state=owner-bound-attempt";
+    const codeChallenge = "a".repeat(43);
+
+    const authorizeUrl = new URL(
+      buildOpenRouterAuthorizeUrl({ callbackUrl, codeChallenge }),
+    );
+    expect(authorizeUrl.origin + authorizeUrl.pathname).toBe(
+      "https://openrouter.ai/auth",
+    );
+    expect(authorizeUrl.searchParams.get("callback_url")).toBe(callbackUrl);
+    expect(authorizeUrl.searchParams.get("code_challenge")).toBe(codeChallenge);
+    expect(authorizeUrl.searchParams.get("code_challenge_method")).toBe("S256");
+
+    const exchange = buildOpenRouterExchangeRequest({
+      code: "one-time-code",
+      codeVerifier: "v".repeat(43),
+    });
+    expect(exchange.url).toBe("https://openrouter.ai/api/v1/auth/keys");
+    expect(exchange.init).toMatchObject({
+      method: "POST",
+      redirect: "error",
+      headers: { "content-type": "application/json" },
+    });
+    expect(JSON.parse(String(exchange.init.body))).toEqual({
+      code: "one-time-code",
+      code_verifier: "v".repeat(43),
+      code_challenge_method: "S256",
+    });
+    expect(exchange.init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("requires owner-bound PKCE state and rejects unsafe callbacks", () => {
+    expect(() =>
+      buildOpenRouterAuthorizeUrl({
+        callbackUrl: "https://app.matrix-os.com/callback",
+        codeChallenge: "a".repeat(43),
+      }),
+    ).toThrow(/state/);
+
+    expect(() =>
+      buildOpenRouterAuthorizeUrl({
+        callbackUrl: "http://example.com/callback?state=attempt",
+        codeChallenge: "a".repeat(43),
+      }),
+    ).toThrow(/callback/);
+  });
+
+  it("keeps Cloudflare custom metadata content-free and within its five-entry limit", () => {
+    expect(
+      verifyCloudflareMetadata({
+        matrix_user_ref: "usr_hash",
+        runtime_ref: "runtime_hash",
+        run_ref: "run_hash",
+        access_source: "matrix_funded",
+      }),
+    ).toEqual({
+      access_source: "matrix_funded",
+      matrix_user_ref: "usr_hash",
+      run_ref: "run_hash",
+      runtime_ref: "runtime_hash",
+    });
+
+    expect(() =>
+      verifyCloudflareMetadata({ a: "1", b: "2", c: "3", d: "4", e: "5", f: "6" }),
+    ).toThrow(/five/);
+    expect(() => verifyCloudflareMetadata({ prompt: "secret" })).toThrow(
+      /content-free/,
+    );
+  });
+});

--- a/tests/scripts/agent-sdk-real-runtime-spike.test.ts
+++ b/tests/scripts/agent-sdk-real-runtime-spike.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { runFakeProviderVerification } from "../../scripts/spikes/agent-sdk-gateway/fake-provider.mjs";
+
+const sdkPackageDirectory = process.env.MATRIX_AGENT_SDK_PACKAGE_DIR;
+
+describe.skipIf(!sdkPackageDirectory)("Agent SDK 0.3.251 real-runtime spike", () => {
+  it(
+    "proves transport auth, first-turn in-process MCP, PreToolUse, skills, resume, and usage",
+    async () => {
+      const report = await runFakeProviderVerification({
+        sdkPackageDirectory: sdkPackageDirectory!,
+      });
+
+      expect(report).toMatchObject({
+        sdkVersion: "0.3.251",
+        transport: {
+          authorization: "present",
+          baseUrl: "loopback",
+          messagesPath: "/v1/messages?beta=true",
+        },
+        firstTurn: {
+          hookCalls: 1,
+          mcpCalls: 1,
+          result: "mcp-ok",
+          skillLoaded: true,
+          usageModel: "claude-haiku-4-5",
+        },
+        resume: {
+          result: "resume-ok",
+          reusedSession: true,
+        },
+        cancellation: {
+          aborted: true,
+          withinDeadline: true,
+        },
+        subagent: {
+          result: "subagent-ok",
+          spawned: 1,
+        },
+        refusal: {
+          structuredEvent: "model_refusal_no_fallback",
+          stopReason: "refusal",
+        },
+      });
+      expect(report.transport.anthropicBeta).toContain("claude-code-20250219");
+      expect(report.transport.authorization).not.toContain("spike-token");
+    },
+    30_000,
+  );
+});


### PR DESCRIPTION
## Summary

- add a reproducible `@anthropic-ai/claude-agent-sdk@0.3.251` compatibility harness without changing the production SDK dependency or lockfile
- prove V1 `query()` + `resume`, first-turn in-process MCP, `PreToolUse`, project skills, `Agent` subagents, cancellation, structured refusals, canonical usage, and relay base URL/token behavior against a no-cost loopback Anthropic provider
- freeze OpenRouter Agent SDK/OAuth PKCE and Cloudflare privacy/metadata contracts, and record which live checks remain credential-blocked
- normalize `claude auth status --json` into a non-sensitive login state suitable for future Chat/Settings polling

## Stack

Depends on #1397, which adds the default-disabled funded Cloudflare relay boundary.

This PR is the Phase 0 verification slice. It deliberately does not upgrade the production Agent SDK; that remains the next stacked PR after these gates are reviewed.

## Verification

- `MATRIX_AGENT_SDK_PACKAGE_DIR=... pnpm exec vitest run tests/scripts/agent-sdk-gateway-verification.test.ts tests/scripts/agent-sdk-real-runtime-spike.test.ts` — 8 passed using exact SDK 0.3.251
- ordinary unit path — 8 contract assertions pass; the real-runtime test is skipped there to avoid four duplicate package installs
- required `Agent SDK 0.3.251 Compatibility` CI job — installs the exact external package in the runner temp directory and runs the real-runtime test
- `MATRIX_AGENT_SDK_PACKAGE_DIR=... MATRIX_CLAUDE_BIN=... bun run spike:agent-sdk` — end-to-end report passed; local Anthropic state is logged out
- `bun run typecheck` — passed
- `bun run check:patterns` — 0 violations
- `git diff --check` — passed

The review follow-up also preserves parse failures through `cause` and reports allowlisted diagnostics while redacting unknown upstream messages.

## Remaining credential-bearing checks

- one bounded authenticated Anthropic owner-profile turn
- one OpenRouter OAuth exchange plus Agent SDK model turn
- one Cloudflare Unified Billing streaming turn and spend-rule enforcement observation

Those checks require real owner/gateway credentials and are explicitly recorded as blocked rather than treated as passes. No rollout is included here.
