### PR TITLE
feat(kernel): update agent sdk and anthropic models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Key principles:
 ## Tech Stack
 
 - **Runtime**: Node.js 24+, TypeScript 5.5+ strict, ES modules
-- **AI**: Claude Agent SDK V1 `query()` + `resume`, Opus 4.6
+- **AI**: Claude Agent SDK V1 `query()` + `resume`, Opus 5
 - **Frontend**: Next.js 16 (`proxy.ts` replaces middleware, Turbopack, React Compiler, `cacheComponents`), React 19
 - **Backend**: Hono (HTTP/WS gateway + channel adapters)
 - **Database**: PostgreSQL via Kysely for platform, kernel durable state, social, app, and user data. Do not add alternative embedded databases or ORMs for new persistence.

--- a/home/system/config.json
+++ b/home/system/config.json
@@ -1,7 +1,7 @@
 {
   "homePath": "~/matrixos",
   "kernel": {
-    "model": "claude-opus-4-6",
+    "model": "claude-opus-5",
     "effort": "high",
     "maxTurns": 80
   },

--- a/packages/contracts/src/agent-runtime-config.ts
+++ b/packages/contracts/src/agent-runtime-config.ts
@@ -6,7 +6,7 @@ const SafeLabelSchema = z.string().trim().min(1).max(120);
 const ModelReferenceSchema = ProviderModelReferenceSchema;
 
 export const AgentRuntimeIdSchema = z.enum(["hermes", "openclaw"]);
-export const AgentEffortSchema = z.enum(["low", "medium", "high", "max"]);
+export const AgentEffortSchema = z.enum(["low", "medium", "high", "xhigh", "max"]);
 export const AgentAuthKindSchema = z.enum([
   "platform",
   "api_key",
@@ -72,7 +72,7 @@ export const AgentModelDescriptorSchema = z.object({
   displayName: SafeLabelSchema,
   description: z.string().trim().min(1).max(240).optional(),
   capabilities: z.array(AgentModelCapabilitySchema).max(12),
-  efforts: z.array(AgentEffortSchema).max(4),
+  efforts: z.array(AgentEffortSchema).max(5),
   available: z.boolean(),
 }).strict().superRefine((model, ctx) => {
   if (new Set(model.capabilities).size !== model.capabilities.length) {
@@ -269,7 +269,7 @@ export const LegacyAgentSettingsViewSchema = z.object({
   identity: z.record(z.string(), z.unknown()),
   kernel: LegacyAgentKernelSchema,
   availableModels: z.array(LegacyAgentModelSchema).max(32),
-  availableEfforts: z.array(AgentEffortSchema).max(4),
+  availableEfforts: z.array(AgentEffortSchema).max(5),
   defaults: LegacyAgentKernelSchema,
 }).strict();
 const LegacyCompatibleAgentSettingsViewSchema = LegacyAgentSettingsViewSchema

--- a/packages/gateway/src/agent-config/service.ts
+++ b/packages/gateway/src/agent-config/service.ts
@@ -14,6 +14,7 @@ import {
   KERNEL_MODELS,
   normalizeKernelEffort,
   normalizeKernelModel,
+  resolveKernelModelOption,
 } from "../kernel-settings.js";
 
 interface BuildAgentSettingsViewInput {
@@ -122,11 +123,15 @@ export function buildAgentSettingsView(
     && agentConfig.revision >= 0
     ? agentConfig.revision
     : 0;
+  const availableModels = savedModel !== null
+    && !KERNEL_MODELS.some((entry) => entry.id === savedModel)
+    ? [...KERNEL_MODELS, resolveKernelModelOption(savedModel)]
+    : KERNEL_MODELS;
 
   return AgentSettingsViewSchema.parse({
     identity: input.identity,
     kernel: { model: savedModel, effort: savedEffort },
-    availableModels: KERNEL_MODELS,
+    availableModels,
     availableEfforts: KERNEL_EFFORTS,
     defaults: KERNEL_DEFAULTS,
     contractVersion: 2,
@@ -169,7 +174,7 @@ export function buildAgentSettingsView(
       scopes: ["chat"],
       authKind,
       supportedAuthKinds: ["platform", "api_key", "oauth_login"],
-      models: KERNEL_MODELS.map((entry) => ({
+      models: availableModels.map((entry) => ({
         id: entry.id,
         displayName: entry.label,
         description: entry.tier,

--- a/packages/gateway/src/kernel-settings.ts
+++ b/packages/gateway/src/kernel-settings.ts
@@ -5,26 +5,41 @@ import {
 import { z } from "zod/v4";
 
 export const KERNEL_MODEL_IDS = [
-  "claude-opus-4-6",
-  "claude-sonnet-4-5",
+  "claude-fable-5",
+  "claude-opus-5",
+  "claude-sonnet-5",
   "claude-haiku-4-5",
 ] as const;
 
-export const KernelModelSchema = z.enum(KERNEL_MODEL_IDS);
+export const LEGACY_KERNEL_MODEL_IDS = [
+  "claude-opus-4-6",
+  "claude-sonnet-4-5",
+] as const;
+
+export const KernelModelSchema = z.union([
+  z.enum(KERNEL_MODEL_IDS),
+  z.enum(LEGACY_KERNEL_MODEL_IDS),
+]);
 export type KernelModel = z.infer<typeof KernelModelSchema>;
 
 const KERNEL_MODEL_DETAILS = {
-  "claude-opus-4-6": { label: "Claude Opus 4.6", tier: "Most capable" },
-  "claude-sonnet-4-5": { label: "Claude Sonnet 4.5", tier: "Balanced" },
+  "claude-fable-5": { label: "Claude Fable 5", tier: "Highest capability" },
+  "claude-opus-5": { label: "Claude Opus 5", tier: "Advanced" },
+  "claude-sonnet-5": { label: "Claude Sonnet 5", tier: "Best balance" },
   "claude-haiku-4-5": { label: "Claude Haiku 4.5", tier: "Fastest" },
-} as const satisfies Record<KernelModel, { label: string; tier: string }>;
+} as const satisfies Record<(typeof KERNEL_MODEL_IDS)[number], { label: string; tier: string }>;
+
+const LEGACY_KERNEL_MODEL_DETAILS = {
+  "claude-opus-4-6": { label: "Claude Opus 4.6", tier: "Legacy" },
+  "claude-sonnet-4-5": { label: "Claude Sonnet 4.5", tier: "Legacy" },
+} as const satisfies Record<(typeof LEGACY_KERNEL_MODEL_IDS)[number], { label: string; tier: string }>;
 
 export const KERNEL_MODELS = KERNEL_MODEL_IDS.map((id) => ({
   id,
   ...KERNEL_MODEL_DETAILS[id],
 }));
 
-export const KERNEL_EFFORTS = ["low", "medium", "high", "max"] as const;
+export const KERNEL_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
 export const KernelEffortSchema = z.enum(KERNEL_EFFORTS);
 export type KernelEffort = z.infer<typeof KernelEffortSchema>;
 
@@ -50,7 +65,13 @@ export function normalizeKernelEffort(value: unknown): KernelEffort | null {
 }
 
 export function resolveKernelModelOption(model: string): KernelModelOption {
-  return KERNEL_MODELS.find((option) => option.id === model) ?? {
+  const current = KERNEL_MODELS.find((option) => option.id === model);
+  if (current) return current;
+  const legacy = KernelModelSchema.safeParse(model);
+  if (legacy.success && LEGACY_KERNEL_MODEL_IDS.includes(legacy.data as (typeof LEGACY_KERNEL_MODEL_IDS)[number])) {
+    return { id: legacy.data, ...LEGACY_KERNEL_MODEL_DETAILS[legacy.data as keyof typeof LEGACY_KERNEL_MODEL_DETAILS] };
+  }
+  return {
     id: model,
     label: model,
     tier: "Custom",

--- a/packages/gateway/src/server/main-ws-messages.ts
+++ b/packages/gateway/src/server/main-ws-messages.ts
@@ -44,6 +44,12 @@ export function kernelEventToServerMessage(event: KernelEvent, requestId?: strin
       return { type: "kernel:result", data: event.data, requestId };
     case "aborted":
       return { type: "kernel:aborted", requestId };
+    case "refusal":
+      return {
+        type: "kernel:error",
+        message: "The selected model could not complete this request",
+        requestId,
+      };
   }
 }
 

--- a/packages/integrations-mcp/package.json
+++ b/packages/integrations-mcp/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@matrix-os/kernel": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -48,7 +48,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.74",
+    "@anthropic-ai/claude-agent-sdk": "0.3.240",
     "@matrix-os/gateway": "workspace:*",
     "@matrix-os/mcp-browser": "workspace:*",
     "@mozilla/readability": "^0.6.0",

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -16,7 +16,20 @@ export interface KernelResult {
   turns: number;
   tokensIn: number;
   tokensOut: number;
+  model?: string;
+  provider?: string;
+  modelUsage?: KernelModelUsage[];
   errors?: string[];
+}
+
+export interface KernelModelUsage {
+  model: string;
+  provider?: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+  costUsd: number;
 }
 
 export type KernelEvent =
@@ -24,8 +37,96 @@ export type KernelEvent =
   | { type: "text"; text: string }
   | { type: "tool_start"; tool: string }
   | { type: "tool_end"; input?: Record<string, unknown> }
+  | { type: "refusal"; reason: "model_refusal_no_fallback"; stopReason: "refusal" }
   | { type: "result"; data: KernelResult }
   | { type: "aborted" };
+
+interface SdkModelUsageLike {
+  inputTokens?: unknown;
+  outputTokens?: unknown;
+  cacheReadInputTokens?: unknown;
+  cacheCreationInputTokens?: unknown;
+  costUSD?: unknown;
+  canonicalModel?: unknown;
+  provider?: unknown;
+}
+
+interface SdkResultLike {
+  session_id: string;
+  total_cost_usd: number;
+  num_turns: number;
+  usage?: { input_tokens?: number; output_tokens?: number };
+  modelUsage?: Record<string, SdkModelUsageLike>;
+}
+
+function safeCount(value: unknown): number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : 0;
+}
+
+function safeCost(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : 0;
+}
+
+function safeUsageLabel(value: unknown, fallback: string): string {
+  return typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,127}$/.test(value)
+    ? value
+    : fallback;
+}
+
+export function normalizeSdkResult(message: SdkResultLike): KernelResult {
+  const modelUsage = Object.entries(message.modelUsage ?? {}).map(([rawModel, usage]) => ({
+    model: safeUsageLabel(usage.canonicalModel, safeUsageLabel(rawModel, "unknown")),
+    ...(typeof usage.provider === "string"
+      ? { provider: safeUsageLabel(usage.provider, "unknown") }
+      : {}),
+    inputTokens: safeCount(usage.inputTokens),
+    outputTokens: safeCount(usage.outputTokens),
+    cacheReadInputTokens: safeCount(usage.cacheReadInputTokens),
+    cacheCreationInputTokens: safeCount(usage.cacheCreationInputTokens),
+    costUsd: safeCost(usage.costUSD),
+  }));
+  if (modelUsage.length === 0) {
+    return {
+      sessionId: message.session_id,
+      cost: safeCost(message.total_cost_usd),
+      turns: safeCount(message.num_turns),
+      tokensIn: safeCount(message.usage?.input_tokens),
+      tokensOut: safeCount(message.usage?.output_tokens),
+    };
+  }
+
+  const first = modelUsage[0];
+  return {
+    sessionId: message.session_id,
+    cost: Number(modelUsage.reduce((total, usage) => total + usage.costUsd, 0).toFixed(12)),
+    turns: safeCount(message.num_turns),
+    tokensIn: modelUsage.reduce(
+      (total, usage) => total
+        + usage.inputTokens
+        + usage.cacheReadInputTokens
+        + usage.cacheCreationInputTokens,
+      0,
+    ),
+    tokensOut: modelUsage.reduce((total, usage) => total + usage.outputTokens, 0),
+    ...(first ? { model: first.model, ...(first.provider ? { provider: first.provider } : {}) } : {}),
+    modelUsage,
+  };
+}
+
+export function sdkSystemEvent(message: unknown): KernelEvent | null {
+  if (typeof message !== "object" || message === null) return null;
+  const value = message as Record<string, unknown>;
+  if (value.type !== "system" || value.subtype !== "model_refusal_no_fallback") return null;
+  return {
+    type: "refusal",
+    reason: "model_refusal_no_fallback",
+    stopReason: "refusal",
+  };
+}
 
 export async function* spawnKernel(
   message: string,
@@ -40,6 +141,7 @@ export async function* spawnKernel(
 
   // If resuming fails (stale session ID after container upgrade), retry without resume
   let retried = false;
+  let refusalEmitted = false;
 
   async function* run(options: typeof opts): AsyncGenerator<KernelEvent> {
     const query = await getQuery();
@@ -60,13 +162,19 @@ export async function* spawnKernel(
     let toolInputBuf = "";
 
     for await (const msg of response) {
+      const normalizedSystemEvent = sdkSystemEvent(msg);
+      if (normalizedSystemEvent) {
+        refusalEmitted = true;
+        yield normalizedSystemEvent;
+        continue;
+      }
       if (msg.type === "system" && "subtype" in msg && msg.subtype === "init") {
         yield { type: "init", sessionId: msg.session_id };
         continue;
       }
 
       if (msg.type === "stream_event") {
-        const event = msg.event as Record<string, unknown>;
+        const event = msg.event as unknown as Record<string, unknown>;
 
         if (event.type === "content_block_start") {
           const block = (event as Record<string, Record<string, string>>)
@@ -100,14 +208,7 @@ export async function* spawnKernel(
       }
 
       if (msg.type === "result") {
-        const usage = msg.usage as { input_tokens?: number; output_tokens?: number } | undefined;
-        const base = {
-          sessionId: msg.session_id,
-          cost: msg.total_cost_usd,
-          turns: msg.num_turns,
-          tokensIn: usage?.input_tokens ?? 0,
-          tokensOut: usage?.output_tokens ?? 0,
-        };
+        const base = normalizeSdkResult(msg);
 
         if (msg.subtype === "success") {
           yield { type: "result", data: { ...base, result: msg.result } };
@@ -128,6 +229,7 @@ export async function* spawnKernel(
       yield { type: "aborted" };
       return;
     }
+    if (refusalEmitted) return;
     // If we were resuming a session and it failed, retry without resume
     if (!retried && opts.resume) {
       retried = true;

--- a/packages/kernel/src/options.ts
+++ b/packages/kernel/src/options.ts
@@ -80,12 +80,41 @@ function loadBrowserConfig(homePath: string): {
   }
 }
 
-const KERNEL_EFFORT_VALUES = ["low", "medium", "high", "max"] as const;
+const KERNEL_EFFORT_VALUES = ["low", "medium", "high", "xhigh", "max"] as const;
 const SAFE_KERNEL_MODEL = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,79}$/;
 const KERNEL_CONFIG_MAX_BYTES = 256 * 1024;
 export type KernelEffort = (typeof KERNEL_EFFORT_VALUES)[number];
-export const DEFAULT_KERNEL_MODEL = "claude-opus-4-6";
+export const DEFAULT_KERNEL_MODEL = "claude-opus-5";
 export const DEFAULT_KERNEL_EFFORT: KernelEffort = "high";
+
+const ALL_ADAPTIVE_EFFORT_MODELS = new Set([
+  "claude-fable-5",
+  "claude-opus-5",
+  "claude-sonnet-5",
+]);
+const FOUR_LEVEL_ADAPTIVE_EFFORT_MODELS = new Set([
+  "claude-opus-4-6",
+  "claude-sonnet-4-5",
+]);
+
+export function resolveKernelSdkControls(
+  model: string,
+  effort: string,
+): { effort?: KernelEffort; thinking?: { type: "adaptive" } } {
+  const normalizedEffort = KERNEL_EFFORT_VALUES.includes(effort as KernelEffort)
+    ? effort as KernelEffort
+    : DEFAULT_KERNEL_EFFORT;
+  if (ALL_ADAPTIVE_EFFORT_MODELS.has(model)) {
+    return { effort: normalizedEffort, thinking: { type: "adaptive" } };
+  }
+  if (FOUR_LEVEL_ADAPTIVE_EFFORT_MODELS.has(model)) {
+    return {
+      effort: normalizedEffort === "xhigh" ? DEFAULT_KERNEL_EFFORT : normalizedEffort,
+      thinking: { type: "adaptive" },
+    };
+  }
+  return {};
+}
 
 function parseKernelConfigFile(raw: string): { model?: string; effort?: KernelEffort } {
   const config = JSON.parse(raw);
@@ -212,8 +241,8 @@ export async function kernelOptions(config: KernelConfig) {
   // Explicit per-call config wins; otherwise fall back to the persisted
   // ~/system/config.json kernel settings, then hardcoded defaults.
   const fileKernel = resolveKernelConfigFile(homePath);
-  const effort = (config.effort ?? fileKernel.effort) as KernelEffort;
-  const resolvedEffort = KERNEL_EFFORT_VALUES.includes(effort) ? effort : DEFAULT_KERNEL_EFFORT;
+  const model = config.model ?? fileKernel.model;
+  const controls = resolveKernelSdkControls(model, config.effort ?? fileKernel.effort);
 
   const ipcServer = await createIpcServer(db, homePath);
   const coreAgents = getCoreAgents(homePath);
@@ -238,8 +267,8 @@ export async function kernelOptions(config: KernelConfig) {
   }
 
   return {
-    model: config.model ?? fileKernel.model,
-    effort: resolvedEffort,
+    model,
+    ...controls,
     systemPrompt,
     cwd: config.workingDirectory ?? homePath,
     ...(config.env ? { env: config.env } : {}),
@@ -259,12 +288,11 @@ export async function kernelOptions(config: KernelConfig) {
       "TaskOutput",
       "WebSearch",
       "WebFetch",
-      "Skill",
       ...IPC_TOOL_NAMES,
       ...browserToolNames,
     ],
+    skills: "all" as const,
     maxTurns: config.maxTurns ?? 80,
-    thinking: { type: "adaptive" as const },
     hooks: {
       PreToolUse: [
         {

--- a/packages/kernel/src/safe-mode.ts
+++ b/packages/kernel/src/safe-mode.ts
@@ -2,7 +2,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
 export const safeModeAgentDef = {
-  model: "claude-sonnet-4-5-20250929",
+  model: "claude-sonnet-5",
   maxTurns: 10,
   disallowedTools: ["agent"],
 };

--- a/packages/mcp-browser/package.json
+++ b/packages/mcp-browser/package.json
@@ -18,7 +18,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.39",
+    "@anthropic-ai/claude-agent-sdk": "0.3.240",
     "@matrix-os/kernel": "workspace:*",
     "zod": "^4.4.3"
   },

--- a/packages/proxy/src/cost.ts
+++ b/packages/proxy/src/cost.ts
@@ -1,7 +1,11 @@
 // Anthropic pricing per million tokens (USD)
 // https://platform.claude.com/docs/en/about-claude/pricing
-// Updated 2026-03-11
+// Updated 2026-08-29. Sonnet 5 uses the $2/$10 launch pricing in effect
+// through 2026-08-31; update this table when Anthropic changes the rate.
 const PRICING: Record<string, { input: number; output: number; cacheRead: number; cacheWrite: number }> = {
+  'claude-fable-5':          { input: 10,  output: 50,  cacheRead: 1.00, cacheWrite: 12.50 },
+  'claude-opus-5':           { input: 5,   output: 25,  cacheRead: 0.50, cacheWrite: 6.25 },
+  'claude-sonnet-5':         { input: 2,   output: 10,  cacheRead: 0.20, cacheWrite: 2.50 },
   'claude-opus-4-6':         { input: 5,   output: 25,  cacheRead: 0.50, cacheWrite: 6.25 },
   'claude-opus-4-5':         { input: 5,   output: 25,  cacheRead: 0.50, cacheWrite: 6.25 },
   'claude-sonnet-4-6':       { input: 3,   output: 15,  cacheRead: 0.30, cacheWrite: 3.75 },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -665,8 +665,8 @@ importers:
         specifier: workspace:*
         version: link:../kernel
       '@modelcontextprotocol/sdk':
-        specifier: ^1.27.1
-        version: 1.27.1(zod@4.4.3)
+        specifier: ^1.29.0
+        version: 1.30.0(zod@4.4.3)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -681,8 +681,8 @@ importers:
   packages/kernel:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.74
-        version: 0.2.79(zod@4.4.3)
+        specifier: 0.3.240
+        version: 0.3.240(@anthropic-ai/sdk@0.120.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3)
       '@matrix-os/gateway':
         specifier: workspace:*
         version: link:../gateway
@@ -733,8 +733,8 @@ importers:
   packages/mcp-browser:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.39
-        version: 0.2.79(zod@4.4.3)
+        specifier: 0.3.240
+        version: 0.3.240(@anthropic-ai/sdk@0.120.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3)
       '@matrix-os/kernel':
         specifier: workspace:*
         version: link:../kernel
@@ -1236,11 +1236,66 @@ packages:
     resolution: {integrity: sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==}
     hasBin: true
 
-  '@anthropic-ai/claude-agent-sdk@0.2.79':
-    resolution: {integrity: sha512-4HmjT2pzjcYSXGxe18L0D1+5GEak3bk25C2H9GlKFnOeCkYAHG4cla4U/rn+v+S2Ecv5m/hsNQ1hDbzg4Ns7rA==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.240':
+    resolution: {integrity: sha512-iCGku/IOMvvwSfdFQXnkX2Txzo6nNzz/JoJ2tvmPSnA2NvEEKbSL2P7/WCGSo8asKe1m/6S6EDhYbiagyhc5VQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.240':
+    resolution: {integrity: sha512-rA5uZtNGbpxe2+ghzBCZvB30Q4tcFduxkP1qMjI4jOFNq5M4b0O173MaQj+g8D9o0clKbAIEx3tq8pSrtEXotA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.240':
+    resolution: {integrity: sha512-EsshHPGUtkuw4SAIFnj0zUDfb3Kvp/wPPtVyF0i+rjvekY99ZiQmLZeAmNWf1qTdktYlNiQZE2D77qUW+kaOYA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.240':
+    resolution: {integrity: sha512-cvfxos8HdvVlHO9vKpt8i5cC87a5EuLFBtzjtr+ycczipp4+af+A15J3y2+PEHIvEoLWXxbGKEsX4c81rALn1w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.240':
+    resolution: {integrity: sha512-wcuLoslY5vepqOALUKhQ/7mTaMqqPD/iCqZ74BwSRjgaylMoNKIkrdKMIcJwewgrcPuiAdJOYEdYGUaWYX9a2Q==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.240':
+    resolution: {integrity: sha512-pp3VLi/AuZhYn4SY0cMXRHdJam3B7US423OhrV90qlJzNdJ389urxgfQSbuc38wh4nRpbo3xD1uz83qFD/MSag==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.240':
+    resolution: {integrity: sha512-HbXGvQFCB7DTdlTq/JRlpgQBtTjTnMirg28LdLvvXaZL492cZPAvk8CjhzgvRlwQaHv4qpUvkR33R2xlyiBGkg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.240':
+    resolution: {integrity: sha512-XSM+BTBmYi6a06h/ERReyn+oLRrF2JvkbB/BLC1H0GcRwdsiv4r3bzwy0rLcR2OXNzPL8aZ5C5hOG6mqUFiazg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.3.240':
+    resolution: {integrity: sha512-rt/n4rr/Iqem0JtDdL7DdzDnMEei652sS00wVwZ3/0btFt9ah5/iKPKZi8udJ2fjiBwJk6spz9vUQrm6LeyXsA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
       zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.120.0':
+    resolution: {integrity: sha512-ZlvmNFT/iIF6JD13rxbbMWD8nvGR0RaUp6yMQnoc+4Af0YjVVe/bIdW1XSQQsoxXAtg1NaT6Vak0LKFlJ4d37Q==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@asamuzakjp/css-color@5.0.1':
     resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
@@ -3824,8 +3879,8 @@ packages:
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
 
-  '@modelcontextprotocol/sdk@1.27.1':
-    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -10813,6 +10868,10 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -13892,6 +13951,9 @@ packages:
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -14874,19 +14936,51 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.2
 
-  '@anthropic-ai/claude-agent-sdk@0.2.79(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.240':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.240':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.240':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.240':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.240':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.240':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.240':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.240':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.3.240(@anthropic-ai/sdk@0.120.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3)':
     dependencies:
+      '@anthropic-ai/sdk': 0.120.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.240
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.240
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.240
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.240
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.240
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.240
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.240
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.240
+
+  '@anthropic-ai/sdk@0.120.0(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.3
 
   '@asamuzakjp/css-color@5.0.1':
     dependencies:
@@ -18546,7 +18640,7 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.8)
       ajv: 8.18.0
@@ -18568,7 +18662,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.8)
       ajv: 8.18.0
@@ -27490,6 +27584,11 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -30749,7 +30848,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@dotenvx/dotenvx': 1.55.1
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.30.0(zod@3.25.76)
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.1
       commander: 14.0.3
@@ -31511,6 +31610,8 @@ snapshots:
   truncate-utf8-bytes@1.0.2:
     dependencies:
       utf8-byte-length: 1.0.5
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:

--- a/specs/118-ai-gateway-provider-auth/sdk-verification.md
+++ b/specs/118-ai-gateway-provider-auth/sdk-verification.md
@@ -4,12 +4,14 @@
 
 **Target**: `@anthropic-ai/claude-agent-sdk@0.3.251`
 
-**Production version during this spike**: `0.2.79` (unchanged; the upgrade belongs to Phase 1)
+**Production version after Phase 1**: `0.3.240`, the newest release old enough
+to satisfy the workspace's seven-day `minimumReleaseAge` policy. The exact
+`0.3.251` compatibility job remains the forward-compatibility gate.
 
 ## Reproduce
 
-Install the target SDK outside the repository so this spike does not alter the
-production dependency or lockfile:
+Install the forward target SDK outside the repository so the compatibility job
+does not alter the production dependency or lockfile:
 
 ```bash
 mkdir -p /private/tmp/matrix-agent-sdk-03251
@@ -80,3 +82,17 @@ times.
 5. Run one bounded authenticated owner-profile turn and one Cloudflare Unified
    Billing turn in a secret-bearing environment before rollout. The deterministic
    fake-provider suite remains the required regression gate.
+
+## Phase 1 implementation status
+
+- Production dependencies are pinned to `0.3.240`; the lockfile resolves the
+  matching platform packages and MCP SDK peer range.
+- V1 `query()` plus `resume` remains the kernel path.
+- Skills use `skills: "all"`; the deprecated `Skill` allowlist entry is gone.
+- Claude Fable 5, Opus 5, Sonnet 5, and Haiku 4.5 are the current catalog.
+  Existing 4.x model IDs remain valid legacy choices and are never rewritten.
+- Effort and adaptive thinking are emitted only for models whose current API
+  contract supports them. Claude 5 exposes `xhigh`; Haiku and unknown/custom
+  models receive neither field.
+- Results normalize cumulative `modelUsage`, and no-fallback refusals reach the
+  shell as a safe generic terminal error.

--- a/tests/gateway/server-message-helpers.test.ts
+++ b/tests/gateway/server-message-helpers.test.ts
@@ -68,6 +68,15 @@ describe("gateway main WebSocket message helpers", () => {
       type: "kernel:aborted",
       requestId: "r1",
     });
+    expect(kernelEventToServerMessage({
+      type: "refusal",
+      reason: "model_refusal_no_fallback",
+      stopReason: "refusal",
+    }, "r1")).toEqual({
+      type: "kernel:error",
+      message: "The selected model could not complete this request",
+      requestId: "r1",
+    });
   });
 
   it("derives stable ack ids for client actions", () => {

--- a/tests/gateway/settings-agent-summary.test.ts
+++ b/tests/gateway/settings-agent-summary.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { Hono } from "hono";
 import { createSettingsRoutes } from "../../packages/gateway/src/routes/settings.js";
+import { buildAgentSettingsView } from "../../packages/gateway/src/agent-config/service.js";
 
 function stubChannelManager() {
   return {
@@ -131,8 +132,8 @@ describe("GET /api/settings/agent/summary", () => {
     expect(body.soulPreview).not.toContain("sk-ant-never-return-this");
     expect(body.soulPreview).not.toContain("/opt/matrix/private");
     expect(body.kernel).toEqual({
-      model: "claude-opus-4-6",
-      modelLabel: "Claude Opus 4.6",
+      model: "claude-opus-5",
+      modelLabel: "Claude Opus 5",
       effort: "high",
     });
     expect(JSON.stringify(body)).not.toContain("/opt/matrix/private");
@@ -241,5 +242,29 @@ describe("GET /api/settings/agent/summary", () => {
       tagline: "Stay curious, grounded, and useful.",
     });
     expect(body.soulPreview).toBe("Stay curious, grounded, and useful.");
+  });
+});
+
+describe("current and legacy Anthropic models", () => {
+  it("advertises Claude 5 while retaining an explicitly saved legacy model", () => {
+    const view = buildAgentSettingsView({
+      identity: { name: "Matrix Owner" },
+      config: { kernel: { model: "claude-sonnet-4-5", effort: "medium" } },
+      claudeLoginAvailable: false,
+      platformCredentialAvailable: true,
+    });
+
+    expect(view.chat).toMatchObject({
+      model: "claude-sonnet-4-5",
+      effort: "medium",
+      source: "saved",
+    });
+    expect(view.availableModels).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "claude-fable-5" }),
+      expect.objectContaining({ id: "claude-opus-5" }),
+      expect.objectContaining({ id: "claude-sonnet-5" }),
+      expect.objectContaining({ id: "claude-haiku-4-5" }),
+      expect.objectContaining({ id: "claude-sonnet-4-5", tier: "Legacy" }),
+    ]));
   });
 });

--- a/tests/gateway/settings-desktop.test.ts
+++ b/tests/gateway/settings-desktop.test.ts
@@ -488,8 +488,9 @@ describe("Settings: desktop + theme + wallpapers", () => {
       expect(data.kernel).toEqual({ model: null, effort: null });
       expect(data.availableModels.map((model: { id: string }) => model.id))
         .toEqual([
-          "claude-opus-4-6",
-          "claude-sonnet-4-5",
+          "claude-fable-5",
+          "claude-opus-5",
+          "claude-sonnet-5",
           "claude-haiku-4-5",
         ]);
       expect(AgentSettingsViewSchema.safeParse(data).success).toBe(true);
@@ -644,9 +645,9 @@ describe("Settings: desktop + theme + wallpapers", () => {
       expect(res.status).toBe(200);
       const data = await res.json();
       expect(data.kernel).toEqual({ model: null, effort: null });
-      expect(data.availableModels.map((m: { id: string }) => m.id)).toContain("claude-opus-4-6");
-      expect(data.availableEfforts).toEqual(["low", "medium", "high", "max"]);
-      expect(data.defaults).toEqual({ model: "claude-opus-4-6", effort: "high" });
+      expect(data.availableModels.map((m: { id: string }) => m.id)).toContain("claude-opus-5");
+      expect(data.availableEfforts).toEqual(["low", "medium", "high", "xhigh", "max"]);
+      expect(data.defaults).toEqual({ model: "claude-opus-5", effort: "high" });
     });
 
     it("reflects persisted kernel config", async () => {

--- a/tests/gateway/system-info.test.ts
+++ b/tests/gateway/system-info.test.ts
@@ -526,7 +526,7 @@ describe("T135: System info", () => {
 
     const info = getSystemInfo(homePath);
 
-    expect(info.model).toBe("claude-opus-4-6");
+    expect(info.model).toBe("claude-opus-5");
     expect(info.effort).toBe("high");
     rmSync(homePath, { recursive: true, force: true });
   });
@@ -537,7 +537,7 @@ describe("T135: System info", () => {
 
     const info = getSystemInfo(homePath);
 
-    expect(info.model).toBe("claude-opus-4-6");
+    expect(info.model).toBe("claude-opus-5");
     expect(info.effort).toBe("high");
     rmSync(homePath, { recursive: true, force: true });
   });

--- a/tests/kernel/agent-sdk-upgrade.test.ts
+++ b/tests/kernel/agent-sdk-upgrade.test.ts
@@ -1,0 +1,148 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_KERNEL_MODEL,
+  resolveKernelSdkControls,
+} from "../../packages/kernel/src/options.js";
+import {
+  normalizeSdkResult,
+  sdkSystemEvent,
+} from "../../packages/kernel/src/kernel.js";
+import {
+  KERNEL_DEFAULTS,
+  KERNEL_EFFORTS,
+  KERNEL_MODEL_IDS,
+  normalizeKernelModel,
+  resolveKernelModelOption,
+} from "../../packages/gateway/src/kernel-settings.js";
+import { calculateCost } from "../../packages/proxy/src/cost.js";
+
+describe("production Agent SDK upgrade", () => {
+  it("pins the newest package version eligible under the seven-day hold", () => {
+    const kernelPackage = JSON.parse(
+      readFileSync("packages/kernel/package.json", "utf8"),
+    ) as { dependencies: Record<string, string> };
+    const browserPackage = JSON.parse(
+      readFileSync("packages/mcp-browser/package.json", "utf8"),
+    ) as { dependencies: Record<string, string> };
+    const integrationsPackage = JSON.parse(
+      readFileSync("packages/integrations-mcp/package.json", "utf8"),
+    ) as { dependencies: Record<string, string> };
+
+    expect(kernelPackage.dependencies["@anthropic-ai/claude-agent-sdk"]).toBe("0.3.240");
+    expect(browserPackage.dependencies["@anthropic-ai/claude-agent-sdk"]).toBe("0.3.240");
+    expect(integrationsPackage.dependencies["@modelcontextprotocol/sdk"]).toBe("^1.29.0");
+  });
+
+  it("uses the current first-party Claude catalog without rewriting legacy IDs", () => {
+    expect(DEFAULT_KERNEL_MODEL).toBe("claude-opus-5");
+    expect(KERNEL_DEFAULTS.model).toBe("claude-opus-5");
+    expect(KERNEL_MODEL_IDS).toEqual([
+      "claude-fable-5",
+      "claude-opus-5",
+      "claude-sonnet-5",
+      "claude-haiku-4-5",
+    ]);
+    expect(KERNEL_EFFORTS).toEqual(["low", "medium", "high", "xhigh", "max"]);
+    expect(normalizeKernelModel("claude-sonnet-4-5")).toBe("claude-sonnet-4-5");
+    expect(resolveKernelModelOption("claude-sonnet-4-5")).toMatchObject({
+      id: "claude-sonnet-4-5",
+      label: "Claude Sonnet 4.5",
+      tier: "Legacy",
+    });
+    const homeConfig = JSON.parse(readFileSync("home/system/config.json", "utf8")) as {
+      kernel: { model: string };
+    };
+    expect(homeConfig.kernel.model).toBe("claude-opus-5");
+  });
+
+  it("calculates costs for every current Claude model", () => {
+    const oneMillion = {
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheReadTokens: 1_000_000,
+      cacheWriteTokens: 1_000_000,
+    };
+    expect(calculateCost({ model: "claude-fable-5", ...oneMillion })).toBe(73.5);
+    expect(calculateCost({ model: "claude-opus-5", ...oneMillion })).toBe(36.75);
+    expect(calculateCost({ model: "claude-sonnet-5", ...oneMillion })).toBe(14.7);
+    expect(calculateCost({ model: "claude-haiku-4-5-20251001", ...oneMillion })).toBe(7.35);
+  });
+
+  it("only sends effort and adaptive thinking to models that support them", () => {
+    expect(resolveKernelSdkControls("claude-sonnet-5", "xhigh")).toEqual({
+      effort: "xhigh",
+      thinking: { type: "adaptive" },
+    });
+    expect(resolveKernelSdkControls("claude-opus-4-6", "xhigh")).toEqual({
+      effort: "high",
+      thinking: { type: "adaptive" },
+    });
+    expect(resolveKernelSdkControls("claude-sonnet-4-5", "max")).toEqual({
+      effort: "max",
+      thinking: { type: "adaptive" },
+    });
+    expect(resolveKernelSdkControls("claude-haiku-4-5", "max")).toEqual({});
+    expect(resolveKernelSdkControls("owner-custom-model", "high")).toEqual({});
+  });
+
+  it("normalizes cumulative modelUsage across main and subagent calls", () => {
+    expect(normalizeSdkResult({
+      session_id: "session-1",
+      num_turns: 3,
+      total_cost_usd: 99,
+      usage: { input_tokens: 1, output_tokens: 2 },
+      modelUsage: {
+        "claude-sonnet-5": {
+          inputTokens: 10,
+          outputTokens: 5,
+          cacheReadInputTokens: 20,
+          cacheCreationInputTokens: 4,
+          webSearchRequests: 0,
+          costUSD: 0.2,
+          contextWindow: 1_000_000,
+          maxOutputTokens: 128_000,
+          canonicalModel: "claude-sonnet-5",
+          provider: "gateway",
+        },
+        "claude-haiku-4-5": {
+          inputTokens: 7,
+          outputTokens: 3,
+          cacheReadInputTokens: 0,
+          cacheCreationInputTokens: 0,
+          webSearchRequests: 0,
+          costUSD: 0.01,
+          contextWindow: 200_000,
+          maxOutputTokens: 64_000,
+          canonicalModel: "claude-haiku-4-5-20251001",
+          provider: "gateway",
+        },
+      },
+    })).toMatchObject({
+      sessionId: "session-1",
+      cost: 0.21,
+      turns: 3,
+      tokensIn: 41,
+      tokensOut: 8,
+      model: "claude-sonnet-5",
+      provider: "gateway",
+      modelUsage: [
+        expect.objectContaining({ model: "claude-sonnet-5", costUsd: 0.2 }),
+        expect.objectContaining({ model: "claude-haiku-4-5-20251001", costUsd: 0.01 }),
+      ],
+    });
+  });
+
+  it("maps the SDK no-fallback refusal to a safe structured kernel event", () => {
+    expect(sdkSystemEvent({
+      type: "system",
+      subtype: "model_refusal_no_fallback",
+      stop_reason: "refusal",
+    })).toEqual({
+      type: "refusal",
+      reason: "model_refusal_no_fallback",
+      stopReason: "refusal",
+    });
+  });
+});

--- a/tests/kernel/options.test.ts
+++ b/tests/kernel/options.test.ts
@@ -104,7 +104,7 @@ describe("loadKernelConfigFile", () => {
 
     writeFileSync(join(homePath, "system", "config.json"), "{not json");
     await expect(resolveKernelConfigFileAsync(homePath)).resolves.toEqual({
-      model: "claude-opus-4-6",
+      model: "claude-opus-5",
       effort: "high",
     });
   });
@@ -117,7 +117,7 @@ describe("loadKernelConfigFile", () => {
 
     expect(loadKernelConfigFile(homePath)).toEqual({});
     await expect(resolveKernelConfigFileAsync(homePath)).resolves.toEqual({
-      model: "claude-opus-4-6",
+      model: "claude-opus-5",
       effort: "high",
     });
   });


### PR DESCRIPTION
## Summary

- pin the production Claude Agent SDK to `0.3.240`, the newest release eligible under the seven-day dependency hold, while retaining the exact `0.3.251` compatibility gate from #1402
- move new homes and safe mode to Claude Opus 5 and expose Fable 5, Opus 5, Sonnet 5, Haiku 4.5, and `xhigh` effort without rewriting saved legacy or custom model IDs
- emit effort and adaptive thinking only for supported model families, migrate SDK skills to the current `skills` option, and keep V1 `query()` plus `resume`
- normalize cumulative per-model SDK usage across main and subagent calls, including cache tokens, canonical model/provider, and cost
- preserve structured no-fallback refusal events and return a safe generic shell error
- add current Claude 5 proxy pricing and executable regression coverage for the production dependency/catalog/runtime contract

## Stack

Depends on #1402, which proves the current Agent SDK, Anthropic-compatible relay, Cloudflare privacy controls, OpenRouter contracts, V1 resume, MCP, hooks, skills, subagents, cancellation, refusals, and model usage against a no-cost loopback provider.

This is the Phase 1 production SDK and model-catalog layer. Provider connection truth, funded relay provisioning, account login flows, transactional credit metering, signed catalogs, and public docs remain later Graphite layers.

## Verification

- focused changed-area suite: 47 files and 661 tests passed before the final default-model expectation update
- isolated final suite: SDK/model, system info, gateway settings, relay, server mapping, and zellij tests passed, 156 tests total outside the macOS-only interactive-shell mismatch
- strict `tsc --noEmit` for kernel, gateway, and proxy passed
- `pnpm install --frozen-lockfile` passed
- `git diff --check` passed
- full `bun run test`: 12,321 tests passed; two stale system-info expectations were fixed. Remaining failures are unchanged macOS/Linux fixture incompatibilities (`stat -c`, `mv -T`, `add-apt-repository`) and the terminal handoff test selecting macOS system zsh instead of the Linux fake Bash path. Linux CI is authoritative for those host fixtures.

## Invariants

- saved legacy and custom model IDs remain valid and visible; migration never silently rewrites owner configuration
- unsupported and custom models receive no guessed effort or thinking fields
- provider names and raw SDK errors are never exposed to clients
- V1 `query()` plus `resume` remains the kernel session mechanism
- result usage is additive and backward compatible; final hard-balance admission and reconciliation remain a later transactional Postgres layer
- production remains inside the seven-day package release hold; forward compatibility is tested separately against exact SDK `0.3.251`

## Review gate

Do not add `ready-for-ci` until the latest trusted Greptile review is 5/5 for head SHA `b53d2a98d925517391041733f325fd727c96d7a2` and every actionable thread is resolved. Do not merge as part of this workflow.