### PR TITLE
feat(desktop): complete first-class app parity

### DIFF
--- a/desktop/electron.vite.config.ts
+++ b/desktop/electron.vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { resolve } from "node:path";
+import { DESKTOP_DEV_RENDERER_HOST } from "./src/main/renderer-url";
 
 const desktopUpdateChannel =
   process.env.MATRIX_DESKTOP_UPDATE_CHANNEL || process.env.OPERATOR_UPDATE_CHANNEL || "";
@@ -51,6 +52,7 @@ export default defineConfig({
       host: "127.0.0.1",
       port: 5173,
       strictPort: true,
+      allowedHosts: [DESKTOP_DEV_RENDERER_HOST],
     },
     resolve: {
       alias: {

--- a/desktop/electron.vite.config.ts
+++ b/desktop/electron.vite.config.ts
@@ -44,6 +44,9 @@ export default defineConfig({
   },
   renderer: {
     plugins: [react(), tailwindcss()],
+    // Reuse the web terminal's canonical agent logos so Desktop and web never
+    // drift to different provider artwork.
+    publicDir: resolve(__dirname, "../shell/public"),
     server: {
       host: "127.0.0.1",
       port: 5173,

--- a/desktop/src/main/auth/header-injection.ts
+++ b/desktop/src/main/auth/header-injection.ts
@@ -4,6 +4,8 @@
 // partitions never get this hook (lesson L1: remote content can never ride the
 // native principal).
 
+import { DESKTOP_DEV_RENDERER_HOST } from "../renderer-url";
+
 interface WebRequestLike {
   onBeforeSendHeaders(
     listener: (
@@ -85,7 +87,12 @@ function isLocalDevRendererOrigin(origin: string): boolean {
   if (!normalized) return false;
   const url = new URL(normalized);
   return (
-    (url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]") &&
+    (
+      url.hostname === "localhost" ||
+      url.hostname === "127.0.0.1" ||
+      url.hostname === "[::1]" ||
+      url.hostname === DESKTOP_DEV_RENDERER_HOST
+    ) &&
     url.port.length > 0
   );
 }

--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -36,6 +36,7 @@ export type EmbedManagerOptions = {
     routeSlug: string | null;
     allowedOrigins: string[];
     resolveNavigation?: (url: string) => RuntimeBrowserNavigationDecision;
+    allowPublicNavigation?: boolean;
     onState: (state: "loading" | "ready" | "failed") => void;
   }) => EmbedViewLike;
   maxLive?: number;
@@ -102,6 +103,7 @@ export class EmbedManager {
       routeSlug?: string;
       allowedOrigins?: string[];
       resolveNavigation?: (url: string) => RuntimeBrowserNavigationDecision;
+      allowPublicNavigation?: boolean;
       onState?: (state: "loading" | "ready" | "failed") => void;
       onDispose?: () => void;
     },
@@ -144,6 +146,7 @@ export class EmbedManager {
       routeSlug: kind === "app" ? options?.routeSlug ?? slug : null,
       allowedOrigins,
       resolveNavigation: options?.resolveNavigation,
+      allowPublicNavigation: options?.allowPublicNavigation,
       onState: emitState,
     });
     record = {

--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -120,7 +120,7 @@ export class EmbedManager {
         : kind === "code-editor"
           ? "persist:code-editor"
         : kind === "browser"
-          ? `runtime-browser-${id}`
+          ? "persist:browser"
           : this.appPartition(options?.routeSlug ?? slug);
 
     const active = options?.active ?? true;

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -101,6 +101,7 @@ export class EmbedService {
         routeSlug,
         allowedOrigins,
         resolveNavigation,
+        allowPublicNavigation,
         onState,
       }) => {
         const window = this.deps.getWindow();
@@ -120,8 +121,9 @@ export class EmbedService {
           partition,
           allowedOrigins,
           resolveNavigation,
+          allowPublicNavigation,
           onState,
-          denyPermissions: kind === "code-editor",
+          denyPermissions: kind === "code-editor" || kind === "browser",
           ...(bridge ? { appBridge: bridge } : {}),
         });
       },
@@ -137,7 +139,7 @@ export class EmbedService {
       return this.openCodeEditor(gatewayOrigin, request.bounds, request.active ?? true);
     }
     if (request.kind === "browser") {
-      return this.openRuntimeBrowser(
+      return this.openBrowser(
         gatewayOrigin,
         request.url ?? "",
         request.bounds,
@@ -393,6 +395,38 @@ export class EmbedService {
       return { embedId, state: "failed" };
     }
     return { embedId, state: "loading" };
+  }
+
+  private async openBrowser(
+    gatewayOrigin: string,
+    rawUrl: string,
+    bounds: Bounds,
+    active: boolean,
+  ): Promise<OpenResult> {
+    const resolved = resolveBrowserAddress(rawUrl);
+    if (!resolved) return { embedId: randomUUID(), state: "failed" };
+    if (resolved.disposition === "runtime") {
+      return this.openRuntimeBrowser(gatewayOrigin, resolved.url, bounds, active);
+    }
+
+    const embedId = randomUUID();
+    const origin = new URL(resolved.url).origin;
+    try {
+      this.manager.open("browser", null, bounds, resolved.url, {
+        id: embedId,
+        active,
+        allowedOrigins: [origin],
+        allowPublicNavigation: true,
+        onState: (state) => this.deps.emitState(embedId, state),
+      });
+      return { embedId, state: "loading" };
+    } catch (err: unknown) {
+      console.warn(
+        "[embed-service] public browser open failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+      return { embedId, state: "failed" };
+    }
   }
 
   private disposeBrowserForward(embedId: string, forward: PortForwardHandle): void {

--- a/desktop/src/main/embeds/web-contents-view.ts
+++ b/desktop/src/main/embeds/web-contents-view.ts
@@ -7,12 +7,16 @@ import { isNavigationAllowed } from "./origin-policy";
 import type { Bounds, EmbedViewLike } from "./embed-manager";
 import { safeExternalHttpUrl } from "../external-url";
 import type { RuntimeBrowserNavigationDecision } from "../../shared/runtime-browser-url";
+import { resolveBrowserAddress } from "../../shared/runtime-browser-url";
+
+const MAX_PUBLIC_BROWSER_ORIGINS = 64;
 
 export function createWebContentsView(options: {
   window: BaseWindow;
   partition: string;
   allowedOrigins: string[];
   resolveNavigation?: (url: string) => RuntimeBrowserNavigationDecision;
+  allowPublicNavigation?: boolean;
   onState: (state: "loading" | "ready" | "failed") => void;
   denyPermissions?: boolean;
   appBridge?: {
@@ -37,6 +41,31 @@ export function createWebContentsView(options: {
   });
 
   const contents = view.webContents;
+  const publicOrigins = new Map<string, true>();
+  for (const origin of options.allowedOrigins) publicOrigins.set(origin, true);
+  const rememberPublicOrigin = (origin: string) => {
+    publicOrigins.delete(origin);
+    publicOrigins.set(origin, true);
+    while (publicOrigins.size > MAX_PUBLIC_BROWSER_ORIGINS) {
+      const oldest = publicOrigins.keys().next().value as string | undefined;
+      if (!oldest) break;
+      publicOrigins.delete(oldest);
+    }
+  };
+  const publicNavigationUrl = (rawUrl: string): string | null => {
+    if (!options.allowPublicNavigation) return null;
+    const resolved = resolveBrowserAddress(rawUrl);
+    return resolved?.disposition === "public" ? resolved.url : null;
+  };
+  const isAllowedNavigation = (url: string): boolean => {
+    if (isNavigationAllowed(url, options.allowedOrigins)) return true;
+    if (!options.allowPublicNavigation) return false;
+    try {
+      return publicOrigins.has(new URL(url).origin);
+    } catch {
+      return false;
+    }
+  };
   if (options.appBridge || options.denyPermissions) {
     // App views receive only the explicit typed bridge. Browser capabilities
     // that could escape that permission model are denied by default.
@@ -74,10 +103,16 @@ export function createWebContentsView(options: {
         ? (event as { preventDefault?: unknown }).preventDefault
         : null;
     if (!url || typeof preventDefault !== "function") return;
-    if (!isNavigationAllowed(url, options.allowedOrigins)) {
+    if (!isAllowedNavigation(url)) {
       preventDefault.call(event);
       const decision = options.resolveNavigation?.(url);
       if (decision && loadResolvedNavigation(decision)) return;
+      const publicUrl = publicNavigationUrl(url);
+      if (publicUrl) {
+        rememberPublicOrigin(new URL(publicUrl).origin);
+        void contents.loadURL(publicUrl).catch(() => options.onState("failed"));
+        return;
+      }
       const externalUrl = safeExternalHttpUrl(url);
       if (externalUrl) void shell.openExternal(externalUrl);
     }
@@ -85,12 +120,18 @@ export function createWebContentsView(options: {
   contents.on("will-navigate", blockExternalNavigation);
   contents.on("will-redirect", blockExternalNavigation);
   contents.setWindowOpenHandler(({ url }) => {
-    if (options.resolveNavigation && isNavigationAllowed(url, options.allowedOrigins)) {
+    if (isAllowedNavigation(url)) {
       void contents.loadURL(url).catch(() => options.onState("failed"));
       return { action: "deny" };
     }
     const decision = options.resolveNavigation?.(url);
     if (decision && loadResolvedNavigation(decision)) return { action: "deny" };
+    const publicUrl = publicNavigationUrl(url);
+    if (publicUrl) {
+      rememberPublicOrigin(new URL(publicUrl).origin);
+      void contents.loadURL(publicUrl).catch(() => options.onState("failed"));
+      return { action: "deny" };
+    }
     const externalUrl = safeExternalHttpUrl(url);
     if (externalUrl) void shell.openExternal(externalUrl);
     return { action: "deny" };

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -44,12 +44,17 @@ import {
 import { createUpdater } from "./updates";
 import { createUpdateAwareBeforeQuit } from "./update-quit";
 import { safeExternalHttpUrl } from "./external-url";
+import { desktopDevHostResolverRules, resolveDesktopRendererUrl } from "./renderer-url";
 import { EVENT_CHANNELS, type EventChannel, type EventPayload } from "../shared/ipc-contract";
 
 const DEFAULT_PLATFORM_HOST = "https://app.matrix-os.com";
 const DESKTOP_APP_NAME = "Matrix OS";
+const desktopRendererUrl = resolveDesktopRendererUrl(process.env.ELECTRON_RENDERER_URL);
 
 app.setName(DESKTOP_APP_NAME);
+if (desktopRendererUrl && desktopRendererUrl !== process.env.ELECTRON_RENDERER_URL) {
+  app.commandLine.appendSwitch("host-resolver-rules", desktopDevHostResolverRules());
+}
 
 // Test isolation: e2e runs point userData at a temp dir so they never touch
 // the real profile or credential.
@@ -129,8 +134,8 @@ function createWindow(bounds: FittedWindowBounds): BrowserWindow {
   win.on("focus", () => sendEvent("window:focus-changed", { focused: true }));
   win.on("blur", () => sendEvent("window:focus-changed", { focused: false }));
 
-  if (process.env.ELECTRON_RENDERER_URL) {
-    void win.loadURL(process.env.ELECTRON_RENDERER_URL).catch((err: unknown) => {
+  if (desktopRendererUrl) {
+    void win.loadURL(desktopRendererUrl).catch((err: unknown) => {
       logMainError("failed to load renderer URL", err);
     });
   } else {
@@ -206,8 +211,8 @@ if (!gotLock) {
       });
       await auth.init();
 
-      const rendererOrigin = process.env.ELECTRON_RENDERER_URL
-        ? new URL(process.env.ELECTRON_RENDERER_URL).origin
+      const rendererOrigin = desktopRendererUrl
+        ? new URL(desktopRendererUrl).origin
         : "null";
       // Renderer session gets origin-scoped bearer injection; embed partitions
       // (separate sessions) never do (lesson L1).

--- a/desktop/src/main/renderer-url.ts
+++ b/desktop/src/main/renderer-url.ts
@@ -1,0 +1,22 @@
+export const DESKTOP_DEV_RENDERER_HOST = "desktop.local.matrix-os.com";
+
+const LOCAL_RENDERER_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]"]);
+
+export function resolveDesktopRendererUrl(rendererUrl: string | undefined): string | undefined {
+  if (!rendererUrl) return rendererUrl;
+  try {
+    const parsed = new URL(rendererUrl);
+    if (parsed.protocol !== "http:" || !LOCAL_RENDERER_HOSTS.has(parsed.hostname)) {
+      return rendererUrl;
+    }
+    parsed.hostname = DESKTOP_DEV_RENDERER_HOST;
+    return parsed.toString();
+  } catch {
+    return rendererUrl;
+  }
+}
+
+export function desktopDevHostResolverRules(): string {
+  return `MAP ${DESKTOP_DEV_RENDERER_HOST} 127.0.0.1`;
+}
+

--- a/desktop/src/renderer/src/design/index.css
+++ b/desktop/src/renderer/src/design/index.css
@@ -93,6 +93,19 @@ textarea,
   border-radius: var(--radius-sm);
 }
 
+/* Command rows select instantly, then linger briefly as the pointer leaves. */
+[data-instant-list-hover] {
+  transition-delay: 75ms;
+  transition-duration: 180ms;
+  transition-property: background-color, color;
+  transition-timing-function: ease-out;
+}
+
+[data-instant-list-hover][data-selected="true"] {
+  transition-delay: 0ms;
+  transition-duration: 0ms;
+}
+
 /* ── Markdown code highlighting (rehype-highlight) ────────────────
    Brand-variable token colors so highlighting works in light + dark
    without shipping a fixed highlight.js theme. The <pre> owns the bg. */

--- a/desktop/src/renderer/src/features/browser/BrowserTab.tsx
+++ b/desktop/src/renderer/src/features/browser/BrowserTab.tsx
@@ -1,6 +1,8 @@
 import { ExternalLink, Globe2, Plus, SlidersHorizontalIcon, X } from "@renderer/lib/hugeicons";
-import { type FormEvent, type KeyboardEvent, useEffect, useMemo, useState } from "react";
+import { type FormEvent, type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
 import { resolveBrowserAddress } from "../../../../shared/runtime-browser-url";
+import { invoke } from "../../lib/operator";
+import { useBrowserNavigation } from "../../stores/browser-navigation";
 import EmbedHost from "../embeds/EmbedHost";
 
 const BROWSER_SESSION_KEY = "matrix.desktop.browser.session.v1";
@@ -97,6 +99,9 @@ export default function BrowserTab({
   const [restorePreviousTabs, setRestorePreviousTabs] = useState(restorePreviousTabsEnabled);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
+  const pendingNavigation = useBrowserNavigation((state) => state.pending);
+  const consumeNavigation = useBrowserNavigation((state) => state.consume);
+  const handledNavigationId = useRef<number | null>(null);
   const activeTab = useMemo(
     () => session.tabs.find((tab) => tab.id === session.activeId) ?? session.tabs[0]!,
     [session],
@@ -107,6 +112,35 @@ export default function BrowserTab({
     if (restorePreviousTabs) window.localStorage.setItem(BROWSER_SESSION_KEY, JSON.stringify(session));
     else window.localStorage.removeItem(BROWSER_SESSION_KEY);
   }, [restorePreviousTabs, session]);
+
+  useEffect(() => {
+    if (!pendingNavigation || handledNavigationId.current === pendingNavigation.id) return;
+    handledNavigationId.current = pendingNavigation.id;
+    consumeNavigation(pendingNavigation.id);
+    setSettingsOpen(false);
+    setMessage(null);
+    setSession((current) => {
+      const activePage = current.tabs.find((tab) => tab.id === current.activeId);
+      const target = activePage && activePage.url === null && activePage.address === ""
+        ? activePage
+        : current.tabs.length < MAX_BROWSER_TABS
+          ? createBrowserPage()
+          : activePage ?? current.tabs[0]!;
+      const nextPage: BrowserPage = {
+        ...target,
+        address: pendingNavigation.url,
+        url: pendingNavigation.url,
+        navigationRevision: target.navigationRevision + 1,
+      };
+      const replacing = current.tabs.some((tab) => tab.id === target.id);
+      return {
+        tabs: replacing
+          ? current.tabs.map((tab) => tab.id === target.id ? nextPage : tab)
+          : [...current.tabs, nextPage],
+        activeId: target.id,
+      };
+    });
+  }, [consumeNavigation, pendingNavigation]);
 
   const updateActiveTab = (update: (tab: BrowserPage) => BrowserPage) => {
     setSession((current) => ({
@@ -162,6 +196,8 @@ export default function BrowserTab({
     setSettingsOpen(false);
     setSession((current) => ({ ...current, activeId: tabId }));
   };
+
+  const activeResolution = activeTab.url ? resolveBrowserAddress(activeTab.url) : null;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col" style={{ background: "var(--bg-app)" }}>
@@ -243,6 +279,31 @@ export default function BrowserTab({
           <ExternalLink size={13} aria-hidden="true" />
           Go
         </button>
+        {activeResolution?.disposition === "public" ? (
+          <button
+            type="button"
+            aria-label="Open current page in external browser"
+            title="Open in external browser"
+            className="inline-flex size-8 items-center justify-center rounded-lg hover:bg-[var(--bg-hover)]"
+            style={{ color: "var(--text-secondary)" }}
+            onClick={() => {
+              const url = activeTab.url;
+              if (!url) return;
+              void (async () => {
+                try {
+                  await invoke("shell:open-external", { url });
+                } catch (error: unknown) {
+                  console.warn(
+                    "[browser] Failed to open the current page externally:",
+                    error instanceof Error ? error.name : typeof error,
+                  );
+                }
+              })();
+            }}
+          >
+            <ExternalLink size={15} aria-hidden="true" />
+          </button>
+        ) : null}
         <button
           type="button"
           aria-label="Browser settings"

--- a/desktop/src/renderer/src/features/browser/BrowserTab.tsx
+++ b/desktop/src/renderer/src/features/browser/BrowserTab.tsx
@@ -1,7 +1,6 @@
 import { ExternalLink, Globe2 } from "@renderer/lib/hugeicons";
 import { type FormEvent, useState } from "react";
 import { resolveBrowserAddress } from "../../../../shared/runtime-browser-url";
-import { invoke } from "../../lib/operator";
 import EmbedHost from "../embeds/EmbedHost";
 
 export default function BrowserTab({
@@ -14,8 +13,8 @@ export default function BrowserTab({
   visualScale?: number;
 }) {
   const [address, setAddress] = useState("");
-  const [runtimeUrl, setRuntimeUrl] = useState<string | null>(null);
-  const [runtimeNavigationRevision, setRuntimeNavigationRevision] = useState(0);
+  const [browserUrl, setBrowserUrl] = useState<string | null>(null);
+  const [navigationRevision, setNavigationRevision] = useState(0);
   const [message, setMessage] = useState<string | null>(null);
 
   const navigate = (event: FormEvent) => {
@@ -26,16 +25,9 @@ export default function BrowserTab({
       return;
     }
     setMessage(null);
-    if (resolved.disposition === "runtime") {
-      setAddress(resolved.url);
-      setRuntimeUrl(resolved.url);
-      setRuntimeNavigationRevision((revision) => revision + 1);
-      return;
-    }
-    setRuntimeUrl(null);
-    void invoke("shell:open-external", { url: resolved.url })
-      .then(() => setMessage("Opened in your local browser."))
-      .catch(() => setMessage("Could not open the local browser."));
+    setAddress(resolved.url);
+    setBrowserUrl(resolved.url);
+    setNavigationRevision((revision) => revision + 1);
   };
 
   return (
@@ -67,11 +59,11 @@ export default function BrowserTab({
           Go
         </button>
       </form>
-      {runtimeUrl ? (
+      {browserUrl ? (
         <EmbedHost
-          key={`${runtimeUrl}:${runtimeNavigationRevision}`}
+          key={`${browserUrl}:${navigationRevision}`}
           kind="browser"
-          url={runtimeUrl}
+          url={browserUrl}
           active={active}
           layoutRevision={layoutRevision}
           visualScale={visualScale}
@@ -87,7 +79,7 @@ export default function BrowserTab({
           <div>
             <h2 className="text-base font-semibold" style={{ color: "var(--text-primary)" }}>Browser</h2>
             <p className="mt-1 max-w-md text-sm" style={{ color: "var(--text-secondary)" }}>
-              Runtime localhost ports stay inside Matrix. Public sites and searches open in your local browser.
+              Browse public websites normally. Runtime localhost ports stay inside Matrix through the selected computer.
             </p>
           </div>
           {message ? <p role="status" className="text-xs" style={{ color: "var(--text-tertiary)" }}>{message}</p> : null}

--- a/desktop/src/renderer/src/features/browser/BrowserTab.tsx
+++ b/desktop/src/renderer/src/features/browser/BrowserTab.tsx
@@ -1,7 +1,88 @@
-import { ExternalLink, Globe2 } from "@renderer/lib/hugeicons";
-import { type FormEvent, useState } from "react";
+import { ExternalLink, Globe2, Plus, SlidersHorizontalIcon, X } from "@renderer/lib/hugeicons";
+import { type FormEvent, type KeyboardEvent, useEffect, useMemo, useState } from "react";
 import { resolveBrowserAddress } from "../../../../shared/runtime-browser-url";
 import EmbedHost from "../embeds/EmbedHost";
+
+const BROWSER_SESSION_KEY = "matrix.desktop.browser.session.v1";
+const BROWSER_SETTINGS_KEY = "matrix.desktop.browser.settings.v1";
+const MAX_BROWSER_TABS = 8;
+
+interface BrowserPage {
+  id: string;
+  address: string;
+  url: string | null;
+  navigationRevision: number;
+}
+
+interface BrowserSession {
+  tabs: BrowserPage[];
+  activeId: string;
+}
+
+let nextBrowserTab = 0;
+
+function createBrowserPage(): BrowserPage {
+  nextBrowserTab += 1;
+  return {
+    id: `browser-tab-${Date.now().toString(36)}-${nextBrowserTab}`,
+    address: "",
+    url: null,
+    navigationRevision: 0,
+  };
+}
+
+function restorePreviousTabsEnabled(): boolean {
+  try {
+    const stored = window.localStorage.getItem(BROWSER_SETTINGS_KEY);
+    if (!stored) return true;
+    return JSON.parse(stored)?.restorePreviousTabs !== false;
+  } catch {
+    return true;
+  }
+}
+
+function readBrowserSession(): BrowserSession {
+  const fallback = createBrowserPage();
+  if (!restorePreviousTabsEnabled()) return { tabs: [fallback], activeId: fallback.id };
+  try {
+    const stored = window.localStorage.getItem(BROWSER_SESSION_KEY);
+    if (!stored) return { tabs: [fallback], activeId: fallback.id };
+    const parsed = JSON.parse(stored) as Partial<BrowserSession>;
+    if (!Array.isArray(parsed.tabs)) return { tabs: [fallback], activeId: fallback.id };
+    const tabs = parsed.tabs.slice(0, MAX_BROWSER_TABS).flatMap<BrowserPage>((candidate): BrowserPage[] => {
+      if (!candidate || typeof candidate !== "object") return [];
+      const page = candidate as Partial<BrowserPage>;
+      if (typeof page.id !== "string" || page.id.length > 100) return [];
+      if (page.url === null && (page.address === "" || page.address === undefined)) {
+        return [{ id: page.id, address: "", url: null, navigationRevision: 0 }];
+      }
+      if (typeof page.url !== "string") return [];
+      const resolved = resolveBrowserAddress(page.url);
+      if (!resolved || resolved.url !== page.url) return [];
+      return [{
+        id: page.id,
+        address: typeof page.address === "string" ? page.address.slice(0, 4096) : page.url,
+        url: page.url,
+        navigationRevision: 0,
+      }];
+    });
+    if (tabs.length === 0) return { tabs: [fallback], activeId: fallback.id };
+    const activeId = tabs.some((tab) => tab.id === parsed.activeId) ? parsed.activeId! : tabs[0]!.id;
+    return { tabs, activeId };
+  } catch {
+    return { tabs: [fallback], activeId: fallback.id };
+  }
+}
+
+function browserTabTitle(tab: BrowserPage): string {
+  if (!tab.url) return "New tab";
+  try {
+    const url = new URL(tab.url);
+    return url.hostname || "Browser";
+  } catch {
+    return "Browser";
+  }
+}
 
 export default function BrowserTab({
   active,
@@ -12,26 +93,130 @@ export default function BrowserTab({
   layoutRevision?: string;
   visualScale?: number;
 }) {
-  const [address, setAddress] = useState("");
-  const [browserUrl, setBrowserUrl] = useState<string | null>(null);
-  const [navigationRevision, setNavigationRevision] = useState(0);
+  const [session, setSession] = useState<BrowserSession>(readBrowserSession);
+  const [restorePreviousTabs, setRestorePreviousTabs] = useState(restorePreviousTabsEnabled);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
+  const activeTab = useMemo(
+    () => session.tabs.find((tab) => tab.id === session.activeId) ?? session.tabs[0]!,
+    [session],
+  );
+
+  useEffect(() => {
+    window.localStorage.setItem(BROWSER_SETTINGS_KEY, JSON.stringify({ restorePreviousTabs }));
+    if (restorePreviousTabs) window.localStorage.setItem(BROWSER_SESSION_KEY, JSON.stringify(session));
+    else window.localStorage.removeItem(BROWSER_SESSION_KEY);
+  }, [restorePreviousTabs, session]);
+
+  const updateActiveTab = (update: (tab: BrowserPage) => BrowserPage) => {
+    setSession((current) => ({
+      ...current,
+      tabs: current.tabs.map((tab) => tab.id === current.activeId ? update(tab) : tab),
+    }));
+  };
 
   const navigate = (event: FormEvent) => {
     event.preventDefault();
-    const resolved = resolveBrowserAddress(address);
+    const resolved = resolveBrowserAddress(activeTab.address);
     if (!resolved) {
       setMessage("Enter a web address or a runtime port such as 127.0.0.1:3000.");
       return;
     }
     setMessage(null);
-    setAddress(resolved.url);
-    setBrowserUrl(resolved.url);
-    setNavigationRevision((revision) => revision + 1);
+    updateActiveTab((tab) => ({
+      ...tab,
+      address: resolved.url,
+      url: resolved.url,
+      navigationRevision: tab.navigationRevision + 1,
+    }));
+  };
+
+  const addTab = () => {
+    if (session.tabs.length >= MAX_BROWSER_TABS) {
+      setMessage(`Browser tabs are limited to ${MAX_BROWSER_TABS}.`);
+      return;
+    }
+    const tab = createBrowserPage();
+    setMessage(null);
+    setSettingsOpen(false);
+    setSession((current) => ({ tabs: [...current.tabs, tab], activeId: tab.id }));
+  };
+
+  const closeTab = (tabId: string) => {
+    setSession((current) => {
+      const closingIndex = current.tabs.findIndex((tab) => tab.id === tabId);
+      const remaining = current.tabs.filter((tab) => tab.id !== tabId);
+      if (remaining.length === 0) {
+        const replacement = createBrowserPage();
+        return { tabs: [replacement], activeId: replacement.id };
+      }
+      if (current.activeId !== tabId) return { ...current, tabs: remaining };
+      const replacement = remaining[Math.min(Math.max(closingIndex, 0), remaining.length - 1)]!;
+      return { tabs: remaining, activeId: replacement.id };
+    });
+  };
+
+  const selectTabWithKeyboard = (event: KeyboardEvent<HTMLDivElement>, tabId: string) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    setSettingsOpen(false);
+    setSession((current) => ({ ...current, activeId: tabId }));
   };
 
   return (
     <div className="flex min-h-0 flex-1 flex-col" style={{ background: "var(--bg-app)" }}>
+      <div
+        role="tablist"
+        aria-label="Browser tabs"
+        className="flex h-10 shrink-0 items-end gap-1 overflow-x-auto border-b px-2 pt-1"
+        style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+      >
+        {session.tabs.map((tab, index) => {
+          const selected = !settingsOpen && tab.id === session.activeId;
+          return (
+            <div
+              key={tab.id}
+              role="tab"
+              aria-selected={selected}
+              tabIndex={selected ? 0 : -1}
+              className="group flex h-8 min-w-28 max-w-48 cursor-default items-center gap-2 rounded-t-lg border px-2 text-xs"
+              style={{
+                color: "var(--text-primary)",
+                borderColor: selected ? "var(--border-default)" : "transparent",
+                background: selected ? "var(--bg-app)" : "transparent",
+              }}
+              onClick={() => {
+                setSettingsOpen(false);
+                setSession((current) => ({ ...current, activeId: tab.id }));
+              }}
+              onKeyDown={(event) => selectTabWithKeyboard(event, tab.id)}
+            >
+              <Globe2 size={13} aria-hidden="true" className="shrink-0" />
+              <span className="min-w-0 flex-1 truncate">{browserTabTitle(tab)}</span>
+              <button
+                type="button"
+                aria-label={`Close browser tab ${index + 1}`}
+                className="inline-flex size-5 shrink-0 items-center justify-center rounded hover:bg-[var(--bg-hover)]"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  closeTab(tab.id);
+                }}
+              >
+                <X size={11} aria-hidden="true" />
+              </button>
+            </div>
+          );
+        })}
+        <button
+          type="button"
+          aria-label="New browser tab"
+          className="mb-1 inline-flex size-7 shrink-0 items-center justify-center rounded-md hover:bg-[var(--bg-hover)]"
+          onClick={addTab}
+        >
+          <Plus size={14} aria-hidden="true" />
+        </button>
+      </div>
+
       <form
         className="flex shrink-0 items-center gap-2 border-b px-3 py-2"
         style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
@@ -40,8 +225,8 @@ export default function BrowserTab({
         <Globe2 size={15} aria-hidden="true" style={{ color: "var(--text-tertiary)" }} />
         <input
           aria-label="Browser address"
-          value={address}
-          onChange={(event) => setAddress(event.target.value)}
+          value={activeTab.address}
+          onChange={(event) => updateActiveTab((tab) => ({ ...tab, address: event.target.value }))}
           placeholder="Search or enter 127.0.0.1:3000"
           className="h-8 min-w-0 flex-1 rounded-lg border px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
           style={{
@@ -58,12 +243,57 @@ export default function BrowserTab({
           <ExternalLink size={13} aria-hidden="true" />
           Go
         </button>
+        <button
+          type="button"
+          aria-label="Browser settings"
+          aria-pressed={settingsOpen}
+          className="inline-flex size-8 items-center justify-center rounded-lg hover:bg-[var(--bg-hover)]"
+          style={{ color: "var(--text-secondary)" }}
+          onClick={() => setSettingsOpen((shown) => !shown)}
+        >
+          <SlidersHorizontalIcon size={15} aria-hidden="true" />
+        </button>
       </form>
-      {browserUrl ? (
+
+      {settingsOpen ? (
+        <section
+          role="region"
+          aria-label="Browser settings"
+          className="min-h-0 flex-1 overflow-y-auto px-6 py-5"
+          style={{ color: "var(--text-primary)" }}
+        >
+          <h2 className="text-base font-semibold">Browser settings</h2>
+          <div className="mt-5 max-w-xl space-y-4 text-sm">
+            <label className="flex items-center justify-between gap-4 rounded-xl border p-4" style={{ borderColor: "var(--border-default)" }}>
+              <span>
+                <span className="block font-medium">Restore previous tabs</span>
+                <span className="mt-1 block text-xs" style={{ color: "var(--text-secondary)" }}>Reopen your tab URLs after restarting Desktop.</span>
+              </span>
+              <input
+                type="checkbox"
+                aria-label="Restore previous tabs"
+                checked={restorePreviousTabs}
+                onChange={(event) => setRestorePreviousTabs(event.target.checked)}
+              />
+            </label>
+            <div className="rounded-xl border p-4" style={{ borderColor: "var(--border-default)" }}>
+              <p className="font-medium">Site data</p>
+              <p className="mt-1 text-xs" style={{ color: "var(--text-secondary)" }}>Cookies and sign-ins persist in the browser profile.</p>
+            </div>
+            <label className="flex items-start justify-between gap-4 rounded-xl border p-4 opacity-75" style={{ borderColor: "var(--border-default)" }}>
+              <span>
+                <span className="block font-medium">Save passwords</span>
+                <span className="mt-1 block text-xs" style={{ color: "var(--text-secondary)" }}>Password saving requires an OS-encrypted browser vault and is not enabled yet. Matrix will never store passwords in local storage.</span>
+              </span>
+              <input type="checkbox" aria-label="Save passwords" disabled />
+            </label>
+          </div>
+        </section>
+      ) : activeTab.url ? (
         <EmbedHost
-          key={`${browserUrl}:${navigationRevision}`}
+          key={`${activeTab.id}:${activeTab.url}:${activeTab.navigationRevision}`}
           kind="browser"
-          url={browserUrl}
+          url={activeTab.url}
           active={active}
           layoutRevision={layoutRevision}
           visualScale={visualScale}

--- a/desktop/src/renderer/src/features/browser/help-navigation.ts
+++ b/desktop/src/renderer/src/features/browser/help-navigation.ts
@@ -1,0 +1,11 @@
+import type { Tab } from "../../stores/tabs";
+import { useBrowserNavigation } from "../../stores/browser-navigation";
+
+export const MATRIX_HELP_URL = "https://matrix-os.com/docs";
+
+type OpenTab = (spec: Omit<Tab, "id" | "closable"> & { closable?: boolean }) => string;
+
+export function openHelpInMatrixBrowser(openTab: OpenTab): void {
+  useBrowserNavigation.getState().request(MATRIX_HELP_URL);
+  openTab({ kind: "browser", title: "Browser" });
+}

--- a/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
@@ -40,6 +40,7 @@ import {
 import { SharedChatSurface } from "./SharedChatSurface";
 import { useCanonicalChatRouteController } from "./use-canonical-chat-route-controller";
 import { useProviderSetup } from "./use-provider-setup";
+import { useCreateAppRequest } from "../../stores/create-app-request";
 
 const EMPTY_PROVIDER_SUMMARIES: AgentProviderSummary[] = [];
 
@@ -155,6 +156,16 @@ export function CanonicalChatWorkspace({
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const workspaceRef = useRef<HTMLDivElement>(null);
   const [workspaceLayout, setWorkspaceLayout] = useState<"wide" | "narrow">("wide");
+  const createAppRequest = useCreateAppRequest((state) => state.request);
+  const clearCreateAppRequest = useCreateAppRequest((state) => state.clear);
+
+  useEffect(() => {
+    if (!active || !createAppRequest) return;
+    setDraft(createAppRequest.prompt);
+    setDraftProjectId(projectId);
+    setGlobalView("draft");
+    clearCreateAppRequest(createAppRequest.id);
+  }, [active, clearCreateAppRequest, createAppRequest, projectId]);
 
   useLayoutEffect(() => {
     const workspace = workspaceRef.current;

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopBackground.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopBackground.tsx
@@ -3,7 +3,11 @@ import { DESKTOP_Z_INDEX } from "../../design/layering";
 import type { ApiClient } from "../../lib/api";
 import { useConnection } from "../../stores/connection";
 import { useUi } from "../../stores/ui";
-import { defaultDesktopIcons, useDesktopIcons } from "../../stores/desktop-icons";
+import {
+  captureDesktopIconsHydrationRevision,
+  defaultDesktopIcons,
+  useDesktopIcons,
+} from "../../stores/desktop-icons";
 import { FIXED_DESKTOP_APPS } from "./desktop-apps";
 
 type DesktopBackgroundConfig =
@@ -144,8 +148,11 @@ export default function DesktopBackground() {
 
     if (api) {
       void (async () => {
+        const iconHydrationRevision = captureDesktopIconsHydrationRevision();
         const config = await api.get<{ background?: unknown; desktopIcons?: unknown }>("/api/settings/desktop");
-        if (!cancelled) useDesktopIcons.getState().hydrate(config.desktopIcons, DEFAULT_DESKTOP_ICONS);
+        if (!cancelled) {
+          useDesktopIcons.getState().hydrate(config.desktopIcons, DEFAULT_DESKTOP_ICONS, iconHydrationRevision);
+        }
         const background = backgroundConfig(config?.background);
         if (!background) return;
         if (background.type !== "wallpaper") {

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopBackground.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopBackground.tsx
@@ -3,6 +3,8 @@ import { DESKTOP_Z_INDEX } from "../../design/layering";
 import type { ApiClient } from "../../lib/api";
 import { useConnection } from "../../stores/connection";
 import { useUi } from "../../stores/ui";
+import { defaultDesktopIcons, useDesktopIcons } from "../../stores/desktop-icons";
+import { FIXED_DESKTOP_APPS } from "./desktop-apps";
 
 type DesktopBackgroundConfig =
   | { type: "pattern" }
@@ -13,6 +15,7 @@ type DesktopBackgroundConfig =
 
 const FALLBACK_STYLE: CSSProperties = { background: "var(--bg-app)" };
 const WALLPAPER_MAX_BYTES = 10 * 1024 * 1024;
+const DEFAULT_DESKTOP_ICONS = defaultDesktopIcons(FIXED_DESKTOP_APPS.map((app) => app.path));
 
 function meshGradient(): string {
   return [
@@ -141,7 +144,8 @@ export default function DesktopBackground() {
 
     if (api) {
       void (async () => {
-        const config = await api.get<{ background?: unknown }>("/api/settings/desktop");
+        const config = await api.get<{ background?: unknown; desktopIcons?: unknown }>("/api/settings/desktop");
+        if (!cancelled) useDesktopIcons.getState().hydrate(config.desktopIcons, DEFAULT_DESKTOP_ICONS);
         const background = backgroundConfig(config?.background);
         if (!background) return;
         if (background.type !== "wallpaper") {

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopIconGrid.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopIconGrid.tsx
@@ -40,7 +40,7 @@ export default function DesktopIconGrid({
     <nav
       ref={layerRef}
       aria-label="Desktop apps"
-      className="absolute inset-0"
+      className="pointer-events-none absolute inset-0"
       style={{ zIndex: DESKTOP_Z_INDEX.nativeDesktopIcons }}
     >
       {placements.map((placement) => {
@@ -53,7 +53,7 @@ export default function DesktopIconGrid({
             type="button"
             aria-label={destination.name}
             data-selected={selected || undefined}
-            className="group absolute flex w-[76px] touch-none flex-col items-center gap-1.5 rounded-xl px-1 py-1.5 outline-none transition-colors hover:bg-[var(--bg-hover)] focus-visible:bg-[var(--bg-hover)] data-[selected]:bg-[var(--bg-selected)]"
+            className="pointer-events-auto group absolute flex w-[76px] touch-none flex-col items-center gap-1.5 rounded-xl px-1 py-1.5 outline-none transition-colors hover:bg-[var(--bg-hover)] focus-visible:bg-[var(--bg-hover)] data-[selected]:bg-[var(--bg-selected)]"
             style={{ left: placement.x, top: placement.y }}
             onClick={() => setSelectedId(destination.id)}
             onDoubleClick={destination.open}
@@ -120,7 +120,7 @@ export default function DesktopIconGrid({
         <div
           role="menu"
           data-launchpad-interactive
-          className="fixed min-w-48 rounded-xl border p-1 shadow-[var(--shadow-3)]"
+          className="pointer-events-auto fixed min-w-48 rounded-xl border p-1 shadow-[var(--shadow-3)]"
           style={{ left: menu.x, top: menu.y, zIndex: DESKTOP_Z_INDEX.nativeDesktopLaunchpad, background: "var(--bg-surface)" }}
         >
           <button

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopIconGrid.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopIconGrid.tsx
@@ -2,13 +2,27 @@ import { useEffect, useRef, useState } from "react";
 import DesktopAppIcon from "./DesktopAppIcon";
 import type { DesktopAppConfig } from "./desktop-apps";
 import { DESKTOP_Z_INDEX } from "../../design/layering";
+import type { DesktopIconPlacement } from "../../stores/desktop-icons";
 
-export interface DesktopDestination extends DesktopAppConfig {
+export interface DesktopDestination extends Omit<DesktopAppConfig, "id"> {
+  id: string;
+  iconUrl?: string;
   open: () => void;
 }
 
-export default function DesktopIconGrid({ destinations }: { destinations: DesktopDestination[] }) {
+export default function DesktopIconGrid({
+  destinations,
+  placements,
+  onMove,
+  onRemove,
+}: {
+  destinations: DesktopDestination[];
+  placements: DesktopIconPlacement[];
+  onMove: (path: string, x: number, y: number) => void;
+  onRemove: (path: string) => void;
+}) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [menu, setMenu] = useState<{ path: string; name: string; x: number; y: number } | null>(null);
   const layerRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
@@ -16,6 +30,7 @@ export default function DesktopIconGrid({ destinations }: { destinations: Deskto
       const target = event.target;
       if (!(target instanceof Node) || layerRef.current?.contains(target)) return;
       setSelectedId(null);
+      setMenu(null);
     };
     document.addEventListener("pointerdown", clearSelection);
     return () => document.removeEventListener("pointerdown", clearSelection);
@@ -25,10 +40,12 @@ export default function DesktopIconGrid({ destinations }: { destinations: Deskto
     <nav
       ref={layerRef}
       aria-label="Desktop apps"
-      className="absolute left-5 top-5 grid grid-cols-2 gap-x-3 gap-y-4"
+      className="absolute inset-0"
       style={{ zIndex: DESKTOP_Z_INDEX.nativeDesktopIcons }}
     >
-      {destinations.map((destination) => {
+      {placements.map((placement) => {
+        const destination = destinations.find((candidate) => candidate.path === placement.path);
+        if (!destination) return null;
         const selected = selectedId === destination.id;
         return (
           <button
@@ -36,9 +53,37 @@ export default function DesktopIconGrid({ destinations }: { destinations: Deskto
             type="button"
             aria-label={destination.name}
             data-selected={selected || undefined}
-            className="group flex w-[76px] flex-col items-center gap-1.5 rounded-xl px-1 py-1.5 outline-none transition-colors hover:bg-[var(--bg-hover)] focus-visible:bg-[var(--bg-hover)] data-[selected]:bg-[var(--bg-selected)]"
+            className="group absolute flex w-[76px] touch-none flex-col items-center gap-1.5 rounded-xl px-1 py-1.5 outline-none transition-colors hover:bg-[var(--bg-hover)] focus-visible:bg-[var(--bg-hover)] data-[selected]:bg-[var(--bg-selected)]"
+            style={{ left: placement.x, top: placement.y }}
             onClick={() => setSelectedId(destination.id)}
             onDoubleClick={destination.open}
+            onContextMenu={(event) => {
+              event.preventDefault();
+              setMenu({ path: placement.path, name: destination.name, x: event.clientX, y: event.clientY });
+            }}
+            onPointerDown={(event) => {
+              if (event.button !== 0) return;
+              const startX = event.clientX;
+              const startY = event.clientY;
+              const pointerId = event.pointerId;
+              event.currentTarget.setPointerCapture?.(pointerId);
+              const target = event.currentTarget;
+              const move = (moveEvent: PointerEvent) => {
+                target.style.left = `${Math.max(0, placement.x + moveEvent.clientX - startX)}px`;
+                target.style.top = `${Math.max(0, placement.y + moveEvent.clientY - startY)}px`;
+              };
+              const up = (upEvent: PointerEvent) => {
+                target.removeEventListener("pointermove", move);
+                target.removeEventListener("pointerup", up);
+                const dx = upEvent.clientX - startX;
+                const dy = upEvent.clientY - startY;
+                if (Math.abs(dx) + Math.abs(dy) > 3) {
+                  onMove(placement.path, Math.max(0, placement.x + dx), Math.max(0, placement.y + dy));
+                }
+              };
+              target.addEventListener("pointermove", move);
+              target.addEventListener("pointerup", up);
+            }}
             onKeyDown={(event) => {
               if (event.key === "Enter") {
                 event.preventDefault();
@@ -50,7 +95,9 @@ export default function DesktopIconGrid({ destinations }: { destinations: Deskto
           >
             <DesktopAppIcon
               name={destination.name}
-              icon={<destination.icon size={24} aria-hidden="true" />}
+              icon={destination.iconUrl
+                ? <img src={destination.iconUrl} alt="" className="size-full object-cover" draggable={false} />
+                : <destination.icon size={24} aria-hidden="true" />}
               color={destination.color ?? "var(--bg-surface)"}
               iconColor={destination.iconColor ?? "var(--accent)"}
               className="relative size-12 rounded-[14px] border shadow-[var(--shadow-2)] transition-transform duration-150 group-hover:-translate-y-0.5"
@@ -69,6 +116,26 @@ export default function DesktopIconGrid({ destinations }: { destinations: Deskto
           </button>
         );
       })}
+      {menu ? (
+        <div
+          role="menu"
+          data-launchpad-interactive
+          className="fixed min-w-48 rounded-xl border p-1 shadow-[var(--shadow-3)]"
+          style={{ left: menu.x, top: menu.y, zIndex: DESKTOP_Z_INDEX.nativeDesktopLaunchpad, background: "var(--bg-surface)" }}
+        >
+          <button
+            type="button"
+            role="menuitem"
+            className="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-[var(--bg-hover)]"
+            onClick={() => {
+              onRemove(menu.path);
+              setMenu(null);
+            }}
+          >
+            Remove {menu.name} from Desktop
+          </button>
+        </div>
+      ) : null}
     </nav>
   );
 }

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopLaunchpad.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopLaunchpad.tsx
@@ -1,15 +1,22 @@
 import { useEffect, useEffectEvent } from "react";
 import { DESKTOP_Z_INDEX } from "../../design/layering";
 import AppLauncher from "../embeds/AppLauncher";
+import type { DesktopAppConfig } from "./desktop-apps";
 
 export default function DesktopLaunchpad({
   open,
   onClose,
   onLaunchTab,
+  onCreateApp,
+  onOpenDesktopApp,
+  onAddToDesktop,
 }: {
   open: boolean;
   onClose: () => void;
   onLaunchTab?: (tabId: string) => void;
+  onCreateApp?: () => void;
+  onOpenDesktopApp?: (app: DesktopAppConfig) => void;
+  onAddToDesktop?: (path: string) => void;
 }) {
   const closeLauncher = useEffectEvent(onClose);
 
@@ -43,6 +50,9 @@ export default function DesktopLaunchpad({
       <AppLauncher
         presentation="launchpad"
         launcherActive={open}
+        onCreateApp={onCreateApp}
+        onOpenDesktopApp={onOpenDesktopApp}
+        onAddToDesktop={onAddToDesktop}
         onLaunch={(tabId) => {
           onLaunchTab?.(tabId);
           onClose();

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopModeControls.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopModeControls.tsx
@@ -18,10 +18,10 @@ export default function DesktopModeControls() {
       >
         <Search aria-hidden="true" size={16} />
       </button>
+      <DesktopSupportButton />
       <div className="relative w-[156px]">
         <RuntimeComputerMenu collapsed={false} />
       </div>
-      <DesktopSupportButton />
       <AccountMenu collapsed compact />
     </div>
   );

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopModeControls.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopModeControls.tsx
@@ -1,10 +1,23 @@
 import AccountMenu from "../mission-control/AccountMenu";
 import RuntimeComputerMenu from "../runtime/RuntimeComputerMenu";
 import DesktopSupportButton from "../support/DesktopSupportButton";
+import { Search } from "../../lib/hugeicons";
+import { useUi } from "../../stores/ui";
 
 export default function DesktopModeControls() {
+  const setPaletteOpen = useUi((state) => state.setPaletteOpen);
   return (
     <div className="no-drag ml-auto flex h-full shrink-0 items-center gap-2 border-l pl-3" style={{ borderColor: "var(--border-subtle)" }}>
+      <button
+        type="button"
+        aria-label="Search"
+        title="Search (Cmd+K)"
+        className="flex size-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-[var(--bg-hover)] focus-visible:bg-[var(--bg-hover)]"
+        style={{ color: "var(--text-secondary)" }}
+        onClick={() => setPaletteOpen(true)}
+      >
+        <Search aria-hidden="true" size={16} />
+      </button>
       <div className="relative w-[156px]">
         <RuntimeComputerMenu collapsed={false} />
       </div>

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
@@ -25,6 +25,21 @@ import {
 } from "./OSWindow";
 import { SurfaceChromeContext, type SurfaceChromeSpec } from "./SurfaceChrome";
 
+export function shouldActivateDesktopPane(input: {
+  active: boolean;
+  visible: boolean;
+  overlayOpen: boolean;
+  isNativeEmbed: boolean;
+  isDesktopHidden: boolean;
+  isDesktopTransition: boolean;
+}): boolean {
+  if (!input.active || !input.visible) return false;
+  if (input.isNativeEmbed && (input.overlayOpen || input.isDesktopHidden || input.isDesktopTransition)) {
+    return false;
+  }
+  return true;
+}
+
 function desktopWindowMotion(tabId: string, bounds: DesktopSurfaceBounds): CSSProperties {
   let hash = 0;
   for (const character of tabId) hash = (hash * 31 + character.charCodeAt(0)) | 0;
@@ -102,7 +117,14 @@ export default function DesktopSurfaceFrame({
     if (isSettingsSectionId(requestedSettingsSection)) setSettingsSection(requestedSettingsSection);
     useUi.getState().clearRequestedSettingsSection();
   }, [requestedSettingsSection, tab.kind]);
-  const paneActive = interactive && !(isNativeEmbed && overlayOpen);
+  const paneActive = shouldActivateDesktopPane({
+    active,
+    visible,
+    overlayOpen,
+    isNativeEmbed,
+    isDesktopHidden,
+    isDesktopTransition,
+  });
   const interactionCleanupRef = useRef<(() => void) | null>(null);
   const [surfaceChrome, setSurfaceChrome] = useState<SurfaceChromeSpec | null>(null);
   const surfaceChromeHost = useMemo(() => ({ setChrome: setSurfaceChrome }), []);

--- a/desktop/src/renderer/src/features/desktop-shell/NativeDesktopShell.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/NativeDesktopShell.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
 import {
   topmostVisibleDesktopSurfaceId,
   useDesktopSurfaces,
@@ -75,6 +75,7 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
   const runtimeSlot = useConnection((state) => state.runtimeSlot);
   const installedApps = useApps((state) => state.apps);
   const desktopIcons = useDesktopIcons((state) => state.icons);
+  const primeDesktopIcons = useDesktopIcons((state) => state.prime);
   const moveDesktopIcon = useDesktopIcons((state) => state.move);
   const removeDesktopIcon = useDesktopIcons((state) => state.remove);
   const addDesktopIcon = useDesktopIcons((state) => state.add);
@@ -87,6 +88,10 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
     () => defaultDesktopIcons(FIXED_DESKTOP_APPS.map((app) => app.path)),
     [],
   );
+
+  useLayoutEffect(() => {
+    primeDesktopIcons(defaultIconLayout);
+  }, [defaultIconLayout, primeDesktopIcons]);
 
   const effectiveDesktopIcons = desktopIcons.length > 0 || useDesktopIcons.getState().loaded
     ? desktopIcons

--- a/desktop/src/renderer/src/features/desktop-shell/NativeDesktopShell.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/NativeDesktopShell.tsx
@@ -20,6 +20,12 @@ import DesktopWorkspacePlane from "./DesktopWorkspacePlane";
 import DesktopBackgroundMenu from "./DesktopBackgroundMenu";
 import DesktopAppDrawer from "./DesktopAppDrawer";
 import { useDesktopAppDrawer } from "../../stores/desktop-app-drawer";
+import { useConnection } from "../../stores/connection";
+import { defaultDesktopIcons, useDesktopIcons } from "../../stores/desktop-icons";
+import { trackDesktopEvent } from "../../lib/desktop-analytics";
+import { appIconUrl, useApps } from "../../stores/apps";
+import { LayoutGrid } from "@renderer/lib/hugeicons";
+import { useCreateAppRequest } from "../../stores/create-app-request";
 
 function currentViewport(): DesktopViewport {
   if (typeof window === "undefined") return { width: 1280, height: 720 };
@@ -64,11 +70,27 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
   const setDesktopMode = useNativeDesktopMode((state) => state.setMode);
   const drawerOpen = useDesktopAppDrawer((state) => state.open);
   const setDrawerOpen = useDesktopAppDrawer((state) => state.setOpen);
+  const api = useConnection((state) => state.api);
+  const platformHost = useConnection((state) => state.platformHost);
+  const runtimeSlot = useConnection((state) => state.runtimeSlot);
+  const installedApps = useApps((state) => state.apps);
+  const desktopIcons = useDesktopIcons((state) => state.icons);
+  const moveDesktopIcon = useDesktopIcons((state) => state.move);
+  const removeDesktopIcon = useDesktopIcons((state) => state.remove);
+  const addDesktopIcon = useDesktopIcons((state) => state.add);
   // Mount on first use, then retain the image nodes so reopening can reuse the
   // browser's decoded icon resources instead of issuing another request set.
   const [launcherMounted, setLauncherMounted] = useState(launcherOpen);
   const [viewport, setViewport] = useState(currentViewport);
   const tabIds = useMemo(() => tabs.map((tab) => tab.id), [tabs]);
+  const defaultIconLayout = useMemo(
+    () => defaultDesktopIcons(FIXED_DESKTOP_APPS.map((app) => app.path)),
+    [],
+  );
+
+  const effectiveDesktopIcons = desktopIcons.length > 0 || useDesktopIcons.getState().loaded
+    ? desktopIcons
+    : defaultIconLayout;
 
   useEffect(() => {
     const resize = () => setViewport(currentViewport());
@@ -107,6 +129,8 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
   const activate = useCallback((tabId: string) => {
     focusTab(tabId);
     activateSurface(tabId);
+    const tab = useTabs.getState().tabs.find((candidate) => candidate.id === tabId);
+    trackDesktopEvent({ name: "desktop_app_focused", appKind: tab?.kind });
   }, [activateSurface, focusTab]);
 
   const reconcileAndActivateCurrent = useCallback(() => {
@@ -127,9 +151,14 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
   const showDesktopWithRefresh = useCallback(() => {
     useDesktopSurfaces.getState().showDesktop();
     requestBackgroundRefresh();
+    trackDesktopEvent({ name: "desktop_shown" });
   }, [requestBackgroundRefresh]);
   const toggleApps = useCallback(
-    () => setLauncherOpen(!useUi.getState().appLauncherOpen),
+    () => {
+      const open = !useUi.getState().appLauncherOpen;
+      setLauncherOpen(open);
+      trackDesktopEvent({ name: "desktop_launcher_toggled", open });
+    },
     [setLauncherOpen],
   );
   const launchApp = useCallback((tabId: string) => {
@@ -161,7 +190,12 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
       terminal: () => openRoot(openTerminalIndex),
       files: () => openRoot(() => openTab(FILES_WORKSPACE_TAB_SPEC)),
       editor: () => openRoot(() => openTab(EDITOR_WORKSPACE_TAB_SPEC)),
-      vscode: () => openRoot(() => openTab({ kind: "vscode", title: "VS Code", closable: false })),
+      vscode: () => openRoot(() => openTab({
+        kind: "vscode",
+        title: "VS Code",
+        closable: false,
+        icon: FIXED_DESKTOP_APPS.find((app) => app.id === "vscode")?.iconUrl,
+      })),
       settings: () => openRoot(() => {
         useUi.getState().requestSettingsSection("account");
         openTab({ kind: "settings", title: "Settings" });
@@ -174,8 +208,61 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
       notes: () => openRoot(() => openTab({ kind: "notes", title: "Notes" })),
       whiteboard: () => openRoot(() => openTab({ kind: "app", slug: "whiteboard", title: "Whiteboard" })),
     };
-    return FIXED_DESKTOP_APPS.map((app) => ({ ...app, open: openers[app.id] }));
-  }, [openRoot, openTab]);
+    const fixed = FIXED_DESKTOP_APPS.map((app) => ({
+      ...app,
+      open: () => {
+        trackDesktopEvent({ name: "desktop_app_opened", appKind: app.id });
+        openers[app.id]();
+      },
+    }));
+    const fixedPaths = new Set(fixed.map((app) => app.path));
+    const generated: DesktopDestination[] = installedApps.flatMap((app) => {
+      if (!app.path || fixedPaths.has(app.path)) return [];
+      return [{
+        id: `installed:${app.slug}`,
+        path: app.path,
+        kind: "app",
+        icon: LayoutGrid,
+        iconUrl: appIconUrl(platformHost, app.slug, runtimeSlot) ?? undefined,
+        name: app.name,
+        color: "var(--bg-surface)",
+        open: () => {
+          trackDesktopEvent({ name: "desktop_app_opened", appKind: "app" });
+          openRoot(() => openTab({ kind: "app", slug: app.slug, title: app.name, ...(app.appIdentity ? { appIdentity: app.appIdentity } : {}) }));
+        },
+      }];
+    });
+    return [...fixed, ...generated];
+  }, [installedApps, openRoot, openTab, platformHost, runtimeSlot]);
+
+  const openDesktopApp = useCallback((app: (typeof FIXED_DESKTOP_APPS)[number]) => {
+    destinations.find((destination) => destination.id === app.id)?.open();
+    setLauncherOpen(false);
+  }, [destinations, setLauncherOpen]);
+
+  const createApp = useCallback(() => {
+    useCreateAppRequest.getState().requestDraft();
+    destinations.find((destination) => destination.id === "work")?.open();
+    setLauncherOpen(false);
+  }, [destinations, setLauncherOpen]);
+
+  const moveIcon = useCallback((path: string, x: number, y: number) => {
+    if (api) {
+      void moveDesktopIcon(path, x, y, api);
+      trackDesktopEvent({ name: "desktop_icon_moved" });
+    }
+  }, [api, moveDesktopIcon]);
+
+  const removeIcon = useCallback((path: string) => {
+    if (api) {
+      void removeDesktopIcon(path, api);
+      trackDesktopEvent({ name: "desktop_icon_removed" });
+    }
+  }, [api, removeDesktopIcon]);
+
+  const addIcon = useCallback((path: string) => {
+    if (api) void addDesktopIcon(path, api);
+  }, [addDesktopIcon, api]);
 
   const focusFallback = useCallback((excludedTabId: string) => {
     const tabIds = useTabs.getState().tabs.map((tab) => tab.id);
@@ -194,6 +281,7 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
     if (minimizedTab?.kind === "home" || minimizedTab?.kind === "browser") {
       requestBackgroundRefresh();
     }
+    trackDesktopEvent({ name: "desktop_app_minimized", appKind: minimizedTab?.kind });
   }, [focusFallback, minimizeSurface, requestBackgroundRefresh]);
 
   const close = useCallback((tab: Tab) => {
@@ -202,6 +290,7 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
     else closeSurface(tab.id);
     if (wasActive) focusFallback(tab.id);
     if (tab.kind === "home" || tab.kind === "browser") requestBackgroundRefresh();
+    trackDesktopEvent({ name: "desktop_app_closed", appKind: tab.kind });
   }, [closeSurface, closeTab, focusFallback, requestBackgroundRefresh]);
 
   const activateFromDrawer = useCallback((tabId: string) => {
@@ -235,11 +324,11 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
       {desktopModeHydrated ? (
         <>
       {desktopMode === "desktop" && !tabWorkspaceActive ? (
-        <DesktopIconGrid destinations={destinations} />
+        <DesktopIconGrid destinations={destinations} placements={effectiveDesktopIcons} onMove={moveIcon} onRemove={removeIcon} />
       ) : null}
       <DesktopBackgroundMenu>
         <DesktopWorkspacePlane mode={desktopMode} onBackgroundClick={showDesktopWithRefresh}>
-          {desktopMode === "canvas" ? <DesktopIconGrid destinations={destinations} /> : null}
+          {desktopMode === "canvas" ? <DesktopIconGrid destinations={destinations} placements={effectiveDesktopIcons} onMove={moveIcon} onRemove={removeIcon} /> : null}
           {tabs.map((tab) => {
           const surface = surfaces[tab.id];
           if (!surface) return null;
@@ -271,7 +360,14 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
         </DesktopWorkspacePlane>
       </DesktopBackgroundMenu>
       {launcherMounted ? (
-        <DesktopLaunchpad open={launcherOpen} onClose={closeApps} onLaunchTab={launchApp} />
+        <DesktopLaunchpad
+          open={launcherOpen}
+          onClose={closeApps}
+          onLaunchTab={launchApp}
+          onCreateApp={createApp}
+          onOpenDesktopApp={openDesktopApp}
+          onAddToDesktop={addIcon}
+        />
       ) : null}
       {!tabWorkspaceActive ? (
         <DesktopTaskbar

--- a/desktop/src/renderer/src/features/desktop-shell/SurfaceIcon.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/SurfaceIcon.tsx
@@ -42,7 +42,7 @@ export default function SurfaceIcon({
   size?: number;
 }) {
   const Icon = SURFACE_ICON[tab.kind];
-  const iconUrl = tab.icon && /^https?:\/\//.test(tab.icon) ? tab.icon : null;
+  const iconUrl = tab.icon && /^(?:https?:\/\/|\/|data:image\/)/.test(tab.icon) ? tab.icon : null;
   if (iconUrl) return <RemoteSurfaceIcon key={iconUrl} iconUrl={iconUrl} size={size} fallback={Icon} />;
   return <Icon size={size} aria-hidden="true" />;
 }

--- a/desktop/src/renderer/src/features/desktop-shell/desktop-apps.ts
+++ b/desktop/src/renderer/src/features/desktop-shell/desktop-apps.ts
@@ -12,6 +12,7 @@ import {
   type LucideIcon,
 } from "@renderer/lib/hugeicons";
 import type { TabKind } from "../../stores/tabs";
+import vscodeIconUrl from "../../../../../../shell/public/vscode.png";
 
 export type DesktopAppId =
   | "work"
@@ -27,11 +28,13 @@ export type DesktopAppId =
 
 export interface DesktopAppConfig {
   id: DesktopAppId;
+  path: string;
   kind: TabKind;
   icon: LucideIcon;
   name: string;
   color?: string;
   iconColor?: string;
+  iconUrl?: string;
   settingsSection?: "services";
   slug?: "whiteboard";
 }
@@ -39,6 +42,7 @@ export interface DesktopAppConfig {
 export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
   {
     id: "work",
+    path: "__chat__",
     kind: "work",
     icon: MessageSquare,
     name: "Chat",
@@ -47,6 +51,7 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
   },
   {
     id: "terminal",
+    path: "__terminal__",
     kind: "terminals",
     icon: SquareTerminal,
     name: "Terminal",
@@ -55,6 +60,7 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
   },
   {
     id: "files",
+    path: "__file-browser__",
     kind: "files",
     icon: FolderTree,
     name: "Files",
@@ -63,6 +69,7 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
   },
   {
     id: "editor",
+    path: "__editor__",
     kind: "editor",
     icon: FilePenLine,
     name: "Editor",
@@ -71,14 +78,17 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
   },
   {
     id: "vscode",
+    path: "__vscode__",
     kind: "vscode",
     icon: Code2,
+    iconUrl: vscodeIconUrl,
     name: "VS Code",
     color: "#007ACC",
     iconColor: "white",
   },
   {
     id: "settings",
+    path: "__settings__",
     kind: "settings",
     icon: Settings,
     name: "Settings",
@@ -87,6 +97,7 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
   },
   {
     id: "plugins",
+    path: "__plugins__",
     kind: "settings",
     icon: Blocks,
     name: "Plugins",
@@ -96,6 +107,7 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
   },
   {
     id: "browser",
+    path: "__browser__",
     kind: "browser",
     icon: Globe2,
     name: "Browser",
@@ -104,6 +116,7 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
   },
   {
     id: "notes",
+    path: "__notes__",
     kind: "notes",
     icon: Notebook,
     name: "Notes",
@@ -112,6 +125,7 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
   },
   {
     id: "whiteboard",
+    path: "apps/whiteboard/index.html",
     kind: "app",
     icon: BrushIcon,
     name: "Whiteboard",

--- a/desktop/src/renderer/src/features/desktop-shell/desktop-apps.ts
+++ b/desktop/src/renderer/src/features/desktop-shell/desktop-apps.ts
@@ -83,8 +83,8 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
     icon: Code2,
     iconUrl: vscodeIconUrl,
     name: "VS Code",
-    color: "#007ACC",
-    iconColor: "white",
+    color: "#FFFEFC",
+    iconColor: "#007ACC",
   },
   {
     id: "settings",

--- a/desktop/src/renderer/src/features/editor/DesktopEditorWorkspace.tsx
+++ b/desktop/src/renderer/src/features/editor/DesktopEditorWorkspace.tsx
@@ -86,7 +86,7 @@ export default function DesktopEditorWorkspace() {
           ) : paths.map((path) => {
             const active = path === activePath;
             return (
-              <RetainedPane key={path} active={active} visible={active}>
+              <RetainedPane key={path} active={active} visible={active} className="absolute inset-0 min-h-0 min-w-0">
                 <MonacoEditorHost
                   path={path}
                   active={active}

--- a/desktop/src/renderer/src/features/editor/MonacoEditorHost.tsx
+++ b/desktop/src/renderer/src/features/editor/MonacoEditorHost.tsx
@@ -76,6 +76,7 @@ export default function MonacoEditorHost({
   const [saving, setSaving] = useState(false);
   const [documentRevision, setDocumentRevision] = useState(0);
   const [fallbackContent, setFallbackContent] = useState("");
+  const [monacoState, setMonacoState] = useState<"pending" | "ready" | "failed">("pending");
   const supportsMonaco = typeof Worker === "function"
     && typeof navigator !== "undefined"
     && !navigator.userAgent.includes("jsdom");
@@ -89,6 +90,7 @@ export default function MonacoEditorHost({
     setLoadError(null);
     setSaveError(null);
     setConflict(false);
+    setMonacoState("pending");
     fileRef.current = null;
     filesRef.current = files;
     contentRef.current = "";
@@ -119,6 +121,7 @@ export default function MonacoEditorHost({
     if (!host || !supportsMonaco || loadState !== "ready") return;
     let current = true;
     let model: MonacoEditor.ITextModel | null = null;
+    setMonacoState("pending");
     void import("monaco-editor").then((monaco) => {
       if (!current) return;
       model = monaco.editor.createModel(contentRef.current, languageForPath(path));
@@ -144,6 +147,16 @@ export default function MonacoEditorHost({
         dirtyChangeRef.current(contentRef.current !== fileRef.current?.content);
       });
       editorRef.current = editor;
+      setMonacoState("ready");
+    }).catch((error: unknown) => {
+      model?.dispose();
+      model = null;
+      if (!current) return;
+      console.warn(
+        "[desktop-editor] Monaco initialization failed:",
+        error instanceof Error ? error.name : typeof error,
+      );
+      setMonacoState("failed");
     });
     return () => {
       current = false;
@@ -247,22 +260,31 @@ export default function MonacoEditorHost({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {supportsMonaco ? (
-        <div ref={hostRef} className="min-h-0 flex-1" data-monaco-editor data-path={path} />
-      ) : (
+      <div className="relative min-h-0 flex-1 overflow-hidden">
+        {supportsMonaco ? (
+          <div
+            ref={hostRef}
+            className="absolute inset-0 min-h-0"
+            data-monaco-editor
+            data-monaco-state={monacoState}
+            data-path={path}
+            style={monacoState === "ready" ? undefined : { opacity: 0, pointerEvents: "none" }}
+          />
+        ) : null}
         <textarea
           aria-label={`Edit ${path}`}
           value={fallbackContent}
+          hidden={supportsMonaco && monacoState === "ready"}
           onChange={(event) => {
             const content = event.target.value;
             contentRef.current = content;
             setFallbackContent(content);
             dirtyChangeRef.current(content !== fileRef.current?.content);
           }}
-          className="min-h-0 flex-1 resize-none border-0 p-4 font-mono text-[13px] leading-5 outline-none"
+          className="absolute inset-0 size-full resize-none border-0 p-4 font-mono text-[13px] leading-5 outline-none"
           style={{ background: "var(--bg-sunken)", color: "var(--text-primary)" }}
         />
-      )}
+      </div>
       {saveError ? (
         <div role="alert" className="flex items-center justify-between gap-3 border-t px-3 py-2 text-xs" style={{ borderColor: "var(--border-subtle)", color: "var(--danger)" }}>
           <span>{saveError}</span><Button variant="ghost" onClick={() => setSaveError(null)}>Dismiss</Button>

--- a/desktop/src/renderer/src/features/editor/editor-save.ts
+++ b/desktop/src/renderer/src/features/editor/editor-save.ts
@@ -7,8 +7,10 @@
 //     type: "file"|"directory", size?, modified: ISO string, created: ISO
 //     string, mime? }; 404 when missing. mtime field is `modified` (ISO),
 //     normalized here to epoch ms.
-//   GET /files/{path}            -> raw text body
-//   PUT /files/{path}            -> raw text body in, { ok: true, modified? } out
+//   GET /api/files/blob?path=... -> raw text body
+//   PUT /api/files/blob?path=... -> raw text body in, { ok: true, modified? } out
+// The authenticated `/api` route is required behind the platform runtime
+// router; raw `/files/*` is app-content delivery and can resolve to the shell.
 import { z } from "zod/v4";
 import { AppError } from "../../../../shared/app-error";
 import type { ApiClient } from "../../lib/api";
@@ -32,11 +34,8 @@ const WireWriteSchema = z.looseObject({
   modified: z.union([z.string(), z.number()]).optional(),
 });
 
-function encodeFilesPath(path: string): string {
-  return path
-    .split("/")
-    .map((segment) => encodeURIComponent(segment))
-    .join("/");
+function fileBlobPath(path: string, force = false): string {
+  return `/api/files/blob?path=${encodeURIComponent(path)}${force ? "&force=true" : ""}`;
 }
 
 function normalizeMtime(value: string | number | undefined): number | null {
@@ -64,13 +63,13 @@ export function createFilesApi(api: ApiClient, maxReadBytes?: number): FilesApi 
       return { mtime: normalizeMtime(parsed.data.modified) };
     },
     read: (path) => {
-      const encodedPath = `/files/${encodeFilesPath(path)}`;
+      const encodedPath = fileBlobPath(path);
       return maxReadBytes === undefined
         ? api.getText(encodedPath)
         : api.getText(encodedPath, { maxBytes: maxReadBytes });
     },
     write: async (path, content) => {
-      const raw = await api.putText<unknown>(`/files/${encodeFilesPath(path)}`, content);
+      const raw = await api.putText<unknown>(fileBlobPath(path, true), content);
       const parsed = WireWriteSchema.safeParse(raw);
       if (!parsed.success) return { mtime: null };
       return { mtime: normalizeMtime(parsed.data.modified) };

--- a/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
+++ b/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
@@ -1,9 +1,15 @@
-import { LayoutGrid, Search } from "@renderer/lib/hugeicons";
+import { LayoutGrid, Plus, Search } from "@renderer/lib/hugeicons";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Button, EmptyState } from "../../design/primitives";
 import { appIconUrl, useApps, type MatrixApp } from "../../stores/apps";
 import { useConnection } from "../../stores/connection";
 import { useTabs } from "../../stores/tabs";
+import { FIXED_DESKTOP_APPS, type DesktopAppConfig } from "../desktop-shell/desktop-apps";
+
+type LauncherEntry =
+  | { type: "create"; key: "__create-app__"; name: "Create app" }
+  | { type: "fixed"; key: string; name: string; app: DesktopAppConfig }
+  | { type: "installed"; key: string; name: string; app: MatrixApp };
 
 function AppIcon({ url, name, large = false }: { url: string | null; name: string; large?: boolean }) {
   const [failed, setFailed] = useState(false);
@@ -37,10 +43,16 @@ export default function AppLauncher({
   presentation = "surface",
   launcherActive = true,
   onLaunch,
+  onCreateApp,
+  onOpenDesktopApp,
+  onAddToDesktop,
 }: {
   presentation?: "surface" | "launchpad";
   launcherActive?: boolean;
   onLaunch?: (tabId: string) => void;
+  onCreateApp?: () => void;
+  onOpenDesktopApp?: (app: DesktopAppConfig) => void;
+  onAddToDesktop?: (path: string) => void;
 } = {}) {
   const api = useConnection((s) => s.api);
   const platformHost = useConnection((s) => s.platformHost);
@@ -53,6 +65,7 @@ export default function AppLauncher({
   const load = useApps((s) => s.load);
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
+  const [contextEntry, setContextEntry] = useState<LauncherEntry | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -64,15 +77,40 @@ export default function AppLauncher({
     if (launcherActive) inputRef.current?.focus();
   }, [launcherActive]);
 
+  const entries = useMemo<LauncherEntry[]>(() => {
+    if (presentation !== "launchpad") {
+      return apps.map((app) => ({ type: "installed", key: `installed:${app.slug}`, name: app.name, app }));
+    }
+    const fixedNames = new Set(FIXED_DESKTOP_APPS.map((app) => app.name.toLowerCase()));
+    return [
+      { type: "create", key: "__create-app__", name: "Create app" },
+      ...FIXED_DESKTOP_APPS.map((app) => {
+        const installed = apps.find((candidate) => candidate.name.toLowerCase() === app.name.toLowerCase());
+        return {
+          type: "fixed" as const,
+          key: app.path,
+          name: app.name,
+          app: installed
+            ? { ...app, iconUrl: appIconUrl(platformHost, installed.slug, runtimeSlot) ?? app.iconUrl }
+            : app,
+        };
+      }),
+      ...apps
+        .filter((app) => !fixedNames.has(app.name.toLowerCase()))
+        .map((app) => ({ type: "installed" as const, key: `installed:${app.slug}`, name: app.name, app })),
+    ];
+  }, [apps, platformHost, presentation, runtimeSlot]);
+
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
-    if (!q) return apps;
-    return apps.filter((a) => a.name.toLowerCase().includes(q) || a.slug.toLowerCase().includes(q));
-  }, [apps, query]);
+    if (!q) return entries;
+    return entries.filter((entry) => entry.name.toLowerCase().includes(q)
+      || (entry.type === "installed" && entry.app.slug.toLowerCase().includes(q)));
+  }, [entries, query]);
 
   const activeIndex = filtered.length === 0 ? 0 : Math.min(active, filtered.length - 1);
 
-  const open = (app: MatrixApp) => {
+  const openInstalled = (app: MatrixApp) => {
     const tabId = openTab({
       kind: "app",
       slug: app.slug,
@@ -81,6 +119,18 @@ export default function AppLauncher({
       ...(appIconUrl(platformHost, app.slug, runtimeSlot) ? { icon: appIconUrl(platformHost, app.slug, runtimeSlot)! } : {}),
     });
     onLaunch?.(tabId);
+  };
+
+  const open = (entry: LauncherEntry) => {
+    if (entry.type === "create") {
+      onCreateApp?.();
+      return;
+    }
+    if (entry.type === "fixed") {
+      onOpenDesktopApp?.(entry.app);
+      return;
+    }
+    openInstalled(entry.app);
   };
 
   const onKeyDown = (e: React.KeyboardEvent) => {
@@ -93,8 +143,8 @@ export default function AppLauncher({
       setActive((i) => (i - 1 + filtered.length) % filtered.length);
     } else if (e.key === "Enter") {
       e.preventDefault();
-      const app = filtered[activeIndex];
-      if (app) open(app);
+      const entry = filtered[activeIndex];
+      if (entry) open(entry);
     }
   };
 
@@ -170,13 +220,14 @@ export default function AppLauncher({
         {filtered.length === 0 ? (
           <p className="px-1 text-sm" style={{ color: "var(--text-tertiary)" }}>No apps match “{query}”.</p>
         ) : (
-          <div className={`grid ${presentation === "launchpad" ? "grid-cols-[repeat(auto-fill,minmax(112px,1fr))] gap-x-5 gap-y-6" : "grid-cols-[repeat(auto-fill,minmax(124px,1fr))] gap-3"}`}>
-            {filtered.map((app, i) => {
+          <div data-testid="desktop-launcher-grid" className={`grid ${presentation === "launchpad" ? "grid-cols-[repeat(auto-fill,minmax(112px,1fr))] gap-x-5 gap-y-6" : "grid-cols-[repeat(auto-fill,minmax(124px,1fr))] gap-3"}`}>
+            {filtered.map((entry, i) => {
               const highlighted = i === activeIndex;
               return (
                 <button
-                  key={app.slug}
+                  key={entry.key}
                   type="button"
+                  aria-label={entry.name}
                   data-launchpad-interactive={presentation === "launchpad" || undefined}
                   className={`flex flex-col items-center gap-2 rounded-xl transition-colors duration-100 ${presentation === "launchpad" ? "border border-transparent p-3" : "border p-4"}`}
                   style={{
@@ -186,20 +237,54 @@ export default function AppLauncher({
                     borderColor: highlighted ? "var(--accent)" : presentation === "launchpad" ? "transparent" : "var(--border-subtle)",
                   }}
                   onMouseEnter={() => setActive(i)}
-                onClick={() => open(app)}
+                  onContextMenu={(event) => {
+                    if (entry.type === "create") return;
+                    event.preventDefault();
+                    setContextEntry(entry);
+                  }}
+                  onClick={() => open(entry)}
                 >
-                  <AppIcon url={appIconUrl(platformHost, app.slug, runtimeSlot)} name={app.name} large={presentation === "launchpad"} />
+                  {entry.type === "create" ? (
+                    <span className="flex size-16 items-center justify-center rounded-[18px] bg-[var(--accent)] text-white shadow-[var(--shadow-1)]">
+                      <Plus size={40} aria-hidden="true" />
+                    </span>
+                  ) : entry.type === "fixed" ? (
+                    <span className="flex size-16 items-center justify-center rounded-[18px] shadow-[var(--shadow-1)]" style={{ background: entry.app.color, color: entry.app.iconColor }}>
+                      {entry.app.iconUrl
+                        ? <img src={entry.app.iconUrl} alt="" className="size-full rounded-[18px] object-cover" draggable={false} />
+                        : <entry.app.icon size={32} aria-hidden="true" />}
+                    </span>
+                  ) : (
+                    <AppIcon url={appIconUrl(platformHost, entry.app.slug, runtimeSlot)} name={entry.name} large={presentation === "launchpad"} />
+                  )}
                   <span
                     className="w-full truncate text-center text-sm font-medium"
                     style={{ color: "var(--text-primary)", textShadow: presentation === "launchpad" ? "0 1px 2px var(--bg-app)" : undefined }}
                   >
-                    {app.name}
+                    {entry.name}
                   </span>
                 </button>
               );
             })}
           </div>
         )}
+        {contextEntry && onAddToDesktop ? (
+          <div role="menu" data-launchpad-interactive className="fixed left-1/2 top-1/2 z-50 min-w-48 -translate-x-1/2 rounded-xl border bg-[var(--bg-surface)] p-1 shadow-[var(--shadow-3)]">
+            <button
+              type="button"
+              role="menuitem"
+              className="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-[var(--bg-hover)]"
+              onClick={() => {
+                if (contextEntry.type === "create") return;
+                const path = contextEntry.app.path;
+                if (path) onAddToDesktop(path);
+                setContextEntry(null);
+              }}
+            >
+              Add {contextEntry.name} to Desktop
+            </button>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/desktop/src/renderer/src/features/integrations/AvailableServiceCard.tsx
+++ b/desktop/src/renderer/src/features/integrations/AvailableServiceCard.tsx
@@ -3,7 +3,7 @@
 // compact plus action. Account details remain accessible without changing the
 // compact visual treatment of the card.
 import { Button } from "../../design/primitives";
-import { Check, Plus, X } from "@renderer/lib/hugeicons";
+import { Check, Plus } from "@renderer/lib/hugeicons";
 import { IntegrationIcon } from "./IntegrationIcon";
 import { displayIntegrationName, type AvailableIntegration, type ConnectedIntegration } from "./types";
 
@@ -38,10 +38,6 @@ export function AvailableServiceCard({
   onDisconnect?: (connection: ConnectedIntegration) => void;
 }) {
   const description = service.description ?? INTEGRATION_DESCRIPTIONS[service.id] ?? "Connect this service to extend your agent.";
-  // A card-level hover action is only unambiguous for one account. Services
-  // with several accounts expose an explicit disconnect control per account.
-  const actionIsConnected = connected && connections.length === 1 && connection !== undefined && onDisconnect !== undefined;
-
   return (
     <div
       data-testid={`integration-card-${service.id}`}
@@ -67,16 +63,17 @@ export function AvailableServiceCard({
                 <span className="font-medium">{displayIntegrationName(account.accountLabel)}</span>
                 {account.accountEmail ? <span className="truncate">{account.accountEmail}</span> : null}
                 <span className="capitalize" style={{ color: "var(--surface-success-emphasis, #288A5B)" }}>{account.status}</span>
-                {connections.length > 1 && onDisconnect ? (
+                {onDisconnect ? (
                   <button
                     type="button"
-                    className="ml-auto rounded border px-1.5 py-0.5"
+                    data-testid={`integration-disconnect-${account.id}`}
+                    className="ml-auto shrink-0 rounded border px-1.5 py-0.5"
                     style={{ borderColor: "var(--border-subtle)" }}
                     aria-label={`Disconnect ${displayIntegrationName(account.accountLabel)}`}
                     disabled={disabled}
                     onClick={() => onDisconnect(account)}
                   >
-                    Remove
+                    Disconnect
                   </button>
                 ) : null}
               </div>
@@ -84,40 +81,30 @@ export function AvailableServiceCard({
           </div>
         ) : null}
       </div>
-      {actionIsConnected ? (
+      {connected ? (
         <div
-          data-testid={`integration-connect-${service.id}`}
-          className="relative size-7 shrink-0"
-          onClick={onConnect}
+          data-testid={`integration-action-${service.id}`}
+          data-state="connected"
+          className="flex shrink-0 items-center gap-2 self-start"
         >
-          <Button
-            variant="subtle"
-            className="size-7 justify-center rounded-full p-1 px-1!"
+          <span
+            data-testid={`integration-status-${service.id}`}
+            aria-label={`${service.name} connected`}
+            className="flex size-7 items-center justify-center rounded-full"
             style={{ background: "var(--surface-success-emphasis, #288A5B)", color: "var(--text-on-accent)", borderRadius: "9999px" }}
-            aria-label={`Add another ${service.name} account`}
-            data-testid={`integration-action-${service.id}`}
-            data-state="connected"
-            disabled={disabled}
-            onClick={(event) => {
-              event.stopPropagation();
-              onConnect();
-            }}
           >
             <Check size={16} strokeWidth={2.5} aria-hidden="true" />
-          </Button>
+          </span>
           <Button
-            variant="danger"
-            className="pointer-events-none absolute inset-0 size-7 justify-center rounded-full p-1 px-1! opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100"
-            aria-label={`Disconnect ${displayIntegrationName(connection.accountLabel)}`}
-            data-testid={`integration-disconnect-${connection.id}`}
+            variant="subtle"
+            className="size-7 justify-center rounded-[8px] border p-1 px-1!"
+            style={{ background: "var(--bg-surface)", borderColor: "var(--border-subtle)", color: "var(--text-primary)" }}
+            aria-label={`Add another ${service.name} account`}
+            data-testid={`integration-connect-${service.id}`}
             disabled={disabled}
-            onClick={(event) => {
-              event.stopPropagation();
-              onDisconnect(connection);
-            }}
+            onClick={onConnect}
           >
-            <span className="sr-only">Disconnect</span>
-            <X size={16} />
+            <Plus size={16} aria-hidden="true" />
           </Button>
         </div>
       ) : (

--- a/desktop/src/renderer/src/features/integrations/AvailableServiceCard.tsx
+++ b/desktop/src/renderer/src/features/integrations/AvailableServiceCard.tsx
@@ -61,31 +61,25 @@ export function AvailableServiceCard({
           <span>{service.category}</span>
         </span>
         {connections.length > 0 ? (
-          <span className="sr-only">
-            <span>Connected account: </span>
+          <div className="mt-1 flex flex-col gap-1" aria-label={`${service.name} connected accounts`}>
             {connections.map((account) => (
-              <span key={account.id}>
-                <span>{displayIntegrationName(account.accountLabel)}</span>
-                {account.accountEmail ? <span>{account.accountEmail}</span> : null}
-                <span>{account.status}</span>
-              </span>
-            ))}
-          </span>
-        ) : null}
-        {connections.length > 1 && onDisconnect ? (
-          <div className="mt-1 flex flex-wrap gap-1">
-            {connections.map((account) => (
-              <button
-                key={account.id}
-                type="button"
-                className="rounded border px-1.5 py-0.5 text-xs"
-                style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}
-                aria-label={`Disconnect ${displayIntegrationName(account.accountLabel)}`}
-                disabled={disabled}
-                onClick={() => onDisconnect(account)}
-              >
-                {displayIntegrationName(account.accountLabel)} ×
-              </button>
+              <div key={account.id} className="flex min-w-0 items-center gap-1.5 text-xs" style={{ color: "var(--text-secondary)" }}>
+                <span className="font-medium">{displayIntegrationName(account.accountLabel)}</span>
+                {account.accountEmail ? <span className="truncate">{account.accountEmail}</span> : null}
+                <span className="capitalize" style={{ color: "var(--surface-success-emphasis, #288A5B)" }}>{account.status}</span>
+                {connections.length > 1 && onDisconnect ? (
+                  <button
+                    type="button"
+                    className="ml-auto rounded border px-1.5 py-0.5"
+                    style={{ borderColor: "var(--border-subtle)" }}
+                    aria-label={`Disconnect ${displayIntegrationName(account.accountLabel)}`}
+                    disabled={disabled}
+                    onClick={() => onDisconnect(account)}
+                  >
+                    Remove
+                  </button>
+                ) : null}
+              </div>
             ))}
           </div>
         ) : null}

--- a/desktop/src/renderer/src/features/mission-control/AccountMenu.tsx
+++ b/desktop/src/renderer/src/features/mission-control/AccountMenu.tsx
@@ -8,10 +8,10 @@ import {
 } from "@renderer/lib/hugeicons";
 import { useEffect, useState, type ReactNode } from "react";
 import { DESKTOP_Z_INDEX } from "../../design/layering";
-import { invoke } from "../../lib/operator";
 import { useConnection } from "../../stores/connection";
 import { useTabs } from "../../stores/tabs";
 import { useUi } from "../../stores/ui";
+import { openHelpInMatrixBrowser } from "../browser/help-navigation";
 
 function AccountAvatar({
   imageUrl,
@@ -164,7 +164,7 @@ export default function AccountMenu({
               trailing
               onSelect={() => {
                 setOpen(false);
-                void invoke("shell:open-external", { url: "https://matrix-os.com/docs" });
+                openHelpInMatrixBrowser(openTab);
               }}
             />
             <DropdownMenu.Separator className="my-1 h-px" style={{ background: "var(--border-subtle)" }} />

--- a/desktop/src/renderer/src/features/mission-control/TabBar.tsx
+++ b/desktop/src/renderer/src/features/mission-control/TabBar.tsx
@@ -38,7 +38,7 @@ const TAB_ICON: Record<TabKind, LucideIcon> = {
 
 function TabIcon({ tab, active }: { tab: Tab; active: boolean }) {
   const Icon = TAB_ICON[tab.kind];
-  const iconUrl = tab.icon && /^https?:\/\//.test(tab.icon) ? tab.icon : null;
+  const iconUrl = tab.icon && /^(?:https?:\/\/|\/|data:image\/)/.test(tab.icon) ? tab.icon : null;
   const [failed, setFailed] = useState(false);
   const prev = useRef<string | null>(null);
   if (prev.current !== iconUrl) {

--- a/desktop/src/renderer/src/features/palette/CommandPalette.tsx
+++ b/desktop/src/renderer/src/features/palette/CommandPalette.tsx
@@ -2,7 +2,7 @@ import { Command } from "cmdk";
 import { Notebook } from "@renderer/lib/hugeicons";
 import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import type { AgentThreadSummary, ReviewSummary, TerminalSessionSummary } from "@matrix-os/contracts";
-import { ClipboardCheck, GitBranch, Globe2, Kanban, LayoutGrid, MessageSquarePlus, PanelsTopLeft, Plus, Settings, Sparkles, SquareTerminal } from "@renderer/lib/hugeicons";
+import { ClipboardCheck, GitBranch, Globe2, Kanban, LayoutGrid, MessageSquarePlus, PanelsTopLeft, Plus, Search, Settings, Sparkles, SquareTerminal } from "@renderer/lib/hugeicons";
 import { appIconUrl, useApps } from "../../stores/apps";
 import { useBoard } from "../../stores/board";
 import { useCodingAgentWorkspace } from "../../stores/coding-agent-workspace";
@@ -26,6 +26,13 @@ const TERMINAL_REVIEW_STATUSES: ReviewSummary["status"][] = ["approved", "conver
 const SESSION_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]{0,29}[a-z0-9])?$/;
 const SETUP_DISCONNECTED_ERROR = "Connect to your Matrix computer before opening setup.";
 const SETUP_TERMINAL_ERROR = "Could not open setup terminal. Try again from Terminal.";
+type PaletteCategory = "all" | "projects" | "actions" | "settings";
+const PALETTE_CATEGORIES: Array<{ id: PaletteCategory; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "projects", label: "Projects" },
+  { id: "actions", label: "Actions" },
+  { id: "settings", label: "Settings" },
+];
 
 function isTerminalReviewStatus(status: ReviewSummary["status"]): boolean {
   return TERMINAL_REVIEW_STATUSES.includes(status);
@@ -89,6 +96,8 @@ export default function CommandPalette() {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [category, setCategory] = useState<PaletteCategory>("all");
+  const [query, setQuery] = useState("");
   const open = useUi((s) => s.paletteOpen);
   const setOpen = useUi((s) => s.setPaletteOpen);
   const openTab = useTabs((s) => s.openTab);
@@ -122,7 +131,11 @@ export default function CommandPalette() {
   }, [open, api, loadShellSessions]);
 
   useEffect(() => {
-    if (open) setActionError(null);
+    if (open) {
+      setActionError(null);
+      setCategory("all");
+      setQuery("");
+    }
   }, [open]);
 
   useEffect(() => {
@@ -148,6 +161,9 @@ export default function CommandPalette() {
   const threadCommands = CODING_AGENTS_DESKTOP_WORKSPACE ? paletteThreadCommands(summary) : [];
   const terminalCommands = CODING_AGENTS_DESKTOP_WORKSPACE ? paletteTerminalCommands(summary, shellSessions) : [];
   const setupCommands = CODING_AGENTS_DESKTOP_WORKSPACE ? providerSetupCommands(summary?.providers ?? []) : [];
+  const showActions = category === "all" || category === "actions";
+  const showProjects = category === "all" || category === "projects";
+  const showSettings = category === "all" || category === "settings";
 
   const run = (fn: () => void) => {
     setActionError(null);
@@ -173,7 +189,7 @@ export default function CommandPalette() {
     <dialog
       ref={dialogRef}
       aria-label="Command palette"
-      className="fixed inset-0 z-50 m-0 flex h-screen max-h-none w-screen max-w-none items-start justify-center border-0 bg-transparent p-0 pt-[16vh]"
+      className="fixed inset-0 z-50 m-0 flex h-screen max-h-none w-screen max-w-none items-start justify-center border-0 bg-transparent p-0 pt-[8vh]"
       onCancel={(e) => {
         e.preventDefault();
         setOpen(false);
@@ -189,7 +205,7 @@ export default function CommandPalette() {
       />
       <Command
         label="Search commands"
-        className="fade-in relative z-10 w-[560px] overflow-hidden rounded-xl border"
+        className="fade-in relative z-10 w-[min(760px,calc(100vw-32px))] overflow-hidden rounded-2xl border"
         style={{
           background: "var(--bg-overlay)",
           borderColor: "var(--border-default)",
@@ -199,19 +215,45 @@ export default function CommandPalette() {
           if (e.key === "Escape") setOpen(false);
         }}
       >
-        <Command.Input
-          ref={inputRef}
-          autoFocus
-          placeholder="Search tasks, sessions, actions…"
-          className="w-full border-b bg-transparent px-4 py-3 text-md outline-none"
-          style={{ borderColor: "var(--border-subtle)", color: "var(--text-primary)" }}
-        />
+        <div className="flex h-16 items-center gap-3 border-b px-5" style={{ borderColor: "var(--border-subtle)" }}>
+          <Search size={24} aria-hidden="true" style={{ color: "var(--text-tertiary)" }} />
+          <Command.Input
+            ref={inputRef}
+            autoFocus
+            value={query}
+            onValueChange={setQuery}
+            placeholder="Type a command or search…"
+            className="min-w-0 flex-1 rounded-none bg-transparent text-lg outline-none focus-visible:shadow-none"
+            style={{ color: "var(--text-primary)" }}
+          />
+          <kbd className="rounded-full border px-2.5 py-1 text-xs" style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>⌘K</kbd>
+        </div>
+        <div role="tablist" aria-label="Command categories" className="flex h-11 items-stretch gap-1 border-b px-4" style={{ borderColor: "var(--border-subtle)" }}>
+          {PALETTE_CATEGORIES.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              role="tab"
+              aria-selected={category === item.id}
+              className="relative px-3 text-sm font-medium"
+              style={{ color: category === item.id ? "var(--text-primary)" : "var(--text-secondary)" }}
+              onClick={() => {
+                setCategory(item.id);
+                setQuery("");
+                window.requestAnimationFrame(() => inputRef.current?.focus());
+              }}
+            >
+              {item.label}
+              {category === item.id ? <span className="absolute inset-x-2 bottom-0 h-0.5 rounded-full" style={{ background: "var(--accent)" }} /> : null}
+            </button>
+          ))}
+        </div>
         {actionError ? (
           <div className="border-b px-4 py-2 text-sm" style={{ borderColor: "var(--border-subtle)", color: "var(--danger)" }}>
             {actionError}
           </div>
         ) : null}
-        <Command.List className="max-h-[320px] overflow-y-auto p-1.5">
+        <Command.List className="max-h-[min(560px,68vh)] overflow-y-auto p-3">
           <Command.Empty
             className="px-3 py-6 text-center text-sm"
             style={{ color: "var(--text-tertiary)" }}
@@ -219,7 +261,7 @@ export default function CommandPalette() {
             No results.
           </Command.Empty>
 
-          <Command.Group
+          {showActions ? <Command.Group
             heading="Actions"
             className="[&_[cmdk-group-heading]]:px-2.5 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide"
             style={{ color: "var(--text-tertiary)" }}
@@ -276,11 +318,22 @@ export default function CommandPalette() {
                 else openTab({ kind: "apps", title: "Apps" });
               })}
             />
-            <PaletteItem icon={<Settings size={14} />} label="Open settings" onSelect={() => run(() => openTab({ kind: "settings", title: "Settings" }))} />
-          </Command.Group>
+          </Command.Group> : null}
 
-          {projects.length > 0 ? (
-            <Command.Group heading="Projects" style={{ color: "var(--text-tertiary)" }}>
+          {showSettings ? (
+            <Command.Group heading="Settings" style={{ color: "var(--text-tertiary)" }}>
+              <PaletteItem
+                icon={<Settings size={14} />}
+                label="Open settings"
+                shortcut="⌘,"
+                keywords={["preferences", "services", "integrations", "account", "runtime"]}
+                onSelect={() => run(() => openTab({ kind: "settings", title: "Settings" }))}
+              />
+            </Command.Group>
+          ) : null}
+
+          {showProjects && projects.length > 0 ? (
+            <Command.Group heading="Recent projects" style={{ color: "var(--text-tertiary)" }}>
               {projects.slice(0, 20).map((p) => (
                 <PaletteItem
                   key={p.slug}
@@ -292,7 +345,7 @@ export default function CommandPalette() {
             </Command.Group>
           ) : null}
 
-          {cards.length > 0 ? (
+          {showProjects && cards.length > 0 ? (
             <Command.Group heading="Tasks" style={{ color: "var(--text-tertiary)" }}>
               {cards.slice(0, 30).map((card) => (
                 <PaletteItem
@@ -305,7 +358,7 @@ export default function CommandPalette() {
             </Command.Group>
           ) : null}
 
-          {reviewCommands.length > 0 ? (
+          {showProjects && reviewCommands.length > 0 ? (
             <Command.Group heading="Reviews" style={{ color: "var(--text-tertiary)" }}>
               {reviewCommands.map((review) => (
                 <PaletteItem
@@ -326,7 +379,7 @@ export default function CommandPalette() {
             </Command.Group>
           ) : null}
 
-          {threadCommands.length > 0 ? (
+          {showProjects && threadCommands.length > 0 ? (
             <Command.Group heading="Threads" style={{ color: "var(--text-tertiary)" }}>
               {threadCommands.map((thread) => (
                 <PaletteItem
@@ -341,7 +394,7 @@ export default function CommandPalette() {
             </Command.Group>
           ) : null}
 
-          {terminalCommands.length > 0 ? (
+          {showActions && terminalCommands.length > 0 ? (
             <Command.Group heading="Agent terminals" style={{ color: "var(--text-tertiary)" }}>
               {terminalCommands.map((session) => (
                 <PaletteItem
@@ -356,7 +409,7 @@ export default function CommandPalette() {
             </Command.Group>
           ) : null}
 
-          {shellSessions.length > 0 ? (
+          {showActions && shellSessions.length > 0 ? (
             <Command.Group heading="Sessions" style={{ color: "var(--text-tertiary)" }}>
               {shellSessions.slice(0, 20).map((session) => {
                 const label = session.name;
@@ -374,7 +427,7 @@ export default function CommandPalette() {
             </Command.Group>
           ) : null}
 
-          {apps.length > 0 ? (
+          {showActions && apps.length > 0 ? (
             <Command.Group heading="Apps" style={{ color: "var(--text-tertiary)" }}>
               {apps.slice(0, 30).map((app) => (
                 <PaletteItem
@@ -387,7 +440,7 @@ export default function CommandPalette() {
             </Command.Group>
           ) : null}
 
-          {otherTabs.length > 0 ? (
+          {showActions && otherTabs.length > 0 ? (
             <Command.Group heading="Open tabs" style={{ color: "var(--text-tertiary)" }}>
               {otherTabs.map((tab) => (
                 <PaletteItem
@@ -420,6 +473,7 @@ function PaletteItem({
 }) {
   return (
     <Command.Item
+      data-instant-list-hover
       onSelect={onSelect}
       keywords={keywords}
       className="flex cursor-default items-center gap-2.5 rounded-md px-2.5 py-2 text-sm data-[selected=true]:bg-[var(--bg-selected)]"

--- a/desktop/src/renderer/src/features/palette/CommandPalette.tsx
+++ b/desktop/src/renderer/src/features/palette/CommandPalette.tsx
@@ -87,6 +87,7 @@ function paletteTerminalCommands(
 
 export default function CommandPalette() {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const open = useUi((s) => s.paletteOpen);
   const setOpen = useUi((s) => s.setPaletteOpen);
@@ -130,7 +131,10 @@ export default function CommandPalette() {
     if (!dialog) return;
     if (typeof dialog.showModal === "function") dialog.showModal();
     else dialog.setAttribute("open", "");
+    inputRef.current?.focus();
+    const focusFrame = window.requestAnimationFrame(() => inputRef.current?.focus());
     return () => {
+      window.cancelAnimationFrame(focusFrame);
       if (typeof dialog.close === "function") dialog.close();
       else dialog.removeAttribute("open");
     };
@@ -196,6 +200,7 @@ export default function CommandPalette() {
         }}
       >
         <Command.Input
+          ref={inputRef}
           autoFocus
           placeholder="Search tasks, sessions, actions…"
           className="w-full border-b bg-transparent px-4 py-3 text-md outline-none"

--- a/desktop/src/renderer/src/features/palette/CommandPalette.tsx
+++ b/desktop/src/renderer/src/features/palette/CommandPalette.tsx
@@ -1,13 +1,13 @@
 import { Command } from "cmdk";
 import { Notebook } from "@renderer/lib/hugeicons";
 import { useEffect, useRef, useState, type KeyboardEvent } from "react";
-import type { AgentThreadSummary, ReviewSummary, TerminalSessionSummary } from "@matrix-os/contracts";
+import type { AgentThreadSummary, ReviewSummary, RuntimeSummary, TerminalSessionSummary } from "@matrix-os/contracts";
 import { ClipboardCheck, GitBranch, Globe2, Kanban, LayoutGrid, MessageSquarePlus, PanelsTopLeft, Plus, Search, Settings, Sparkles, SquareTerminal } from "@renderer/lib/hugeicons";
 import { appIconUrl, useApps } from "../../stores/apps";
 import { useBoard } from "../../stores/board";
 import { useCodingAgentWorkspace } from "../../stores/coding-agent-workspace";
 import { useConnection } from "../../stores/connection";
-import { useShellSessions } from "../../stores/shell-sessions";
+import { useShellSessions, type ShellSessionSummary } from "../../stores/shell-sessions";
 import { useTabs } from "../../stores/tabs";
 import { useThreads } from "../../stores/threads";
 import { useUi } from "../../stores/ui";
@@ -22,6 +22,7 @@ const EMPTY_REVIEWS: ReviewSummary[] = [];
 const MAX_PALETTE_REVIEWS = 10;
 const MAX_PALETTE_THREADS = 20;
 const MAX_PALETTE_TERMINALS = 20;
+const GENERIC_THREAD_TITLE = "Coding agent run";
 const TERMINAL_REVIEW_STATUSES: ReviewSummary["status"][] = ["approved", "converged", "stopped"];
 const SESSION_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]{0,29}[a-z0-9])?$/;
 const SETUP_DISCONNECTED_ERROR = "Connect to your Matrix computer before opening setup.";
@@ -57,14 +58,49 @@ function paletteReviewCommands(reviews: ReviewSummary[]): ReviewSummary[] {
     .slice(0, MAX_PALETTE_REVIEWS);
 }
 
-function paletteThreadCommands(summary: { activeThreads: { items: AgentThreadSummary[] }; attentionThreads: { items: AgentThreadSummary[] } } | null): AgentThreadSummary[] {
+interface PaletteThreadCommand {
+  thread: AgentThreadSummary;
+  title: string;
+}
+
+function contextualAgentRunTitle(thread: AgentThreadSummary): string {
+  const context = thread.projectId?.trim() || thread.taskId?.trim() || thread.providerId;
+  return `${context} agent run`;
+}
+
+function linkedThreadTitle(
+  thread: AgentThreadSummary,
+  summary: RuntimeSummary,
+  shellSessions: ShellSessionSummary[],
+): string {
+  const persistedTitle = thread.title.trim();
+  if (persistedTitle.toLocaleLowerCase() !== GENERIC_THREAD_TITLE.toLocaleLowerCase()) {
+    return persistedTitle;
+  }
+  if (!thread.terminalSessionId) return contextualAgentRunTitle(thread);
+  const terminalSession = summary.terminalSessions.items.find((session) => (
+    session.id === thread.terminalSessionId
+  ));
+  if (!terminalSession) return contextualAgentRunTitle(thread);
+  const shellSession = shellSessions.find((session) => session.name === terminalSession.name);
+  const agentTitle = shellSession?.subtitle?.trim();
+  if (agentTitle && agentTitle.toLocaleLowerCase() !== GENERIC_THREAD_TITLE.toLocaleLowerCase()) {
+    return agentTitle;
+  }
+  return terminalSession.name;
+}
+
+function paletteThreadCommands(
+  summary: RuntimeSummary | null,
+  shellSessions: ShellSessionSummary[],
+): PaletteThreadCommand[] {
   if (!summary) return [];
-  const commands: AgentThreadSummary[] = [];
+  const commands: PaletteThreadCommand[] = [];
   const seen = new Set<string>();
   for (const thread of [...summary.attentionThreads.items, ...summary.activeThreads.items]) {
     if (seen.has(thread.id)) continue;
     seen.add(thread.id);
-    commands.push(thread);
+    commands.push({ thread, title: linkedThreadTitle(thread, summary, shellSessions) });
     if (commands.length >= MAX_PALETTE_THREADS) break;
   }
   return commands;
@@ -158,7 +194,7 @@ export default function CommandPalette() {
   const cards = activeSlug ? (cardsByProject[activeSlug] ?? []) : [];
   const otherTabs = tabs.filter((t) => t.id !== activeTabId);
   const reviewCommands = CODING_AGENTS_DESKTOP_WORKSPACE ? paletteReviewCommands(reviews?.items ?? EMPTY_REVIEWS) : EMPTY_REVIEWS;
-  const threadCommands = CODING_AGENTS_DESKTOP_WORKSPACE ? paletteThreadCommands(summary) : [];
+  const threadCommands = CODING_AGENTS_DESKTOP_WORKSPACE ? paletteThreadCommands(summary, shellSessions) : [];
   const terminalCommands = CODING_AGENTS_DESKTOP_WORKSPACE ? paletteTerminalCommands(summary, shellSessions) : [];
   const setupCommands = CODING_AGENTS_DESKTOP_WORKSPACE ? providerSetupCommands(summary?.providers ?? []) : [];
   const showActions = category === "all" || category === "actions";
@@ -381,11 +417,12 @@ export default function CommandPalette() {
 
           {showProjects && threadCommands.length > 0 ? (
             <Command.Group heading="Threads" style={{ color: "var(--text-tertiary)" }}>
-              {threadCommands.map((thread) => (
+              {threadCommands.map(({ thread, title }) => (
                 <PaletteItem
                   key={thread.id}
                   icon={<GitBranch size={14} />}
-                  label={`Open thread ${thread.title}`}
+                  label={`Open thread ${title}`}
+                  keywords={[thread.title, thread.providerId, title]}
                   onSelect={() =>
                     run(() => void openCodingAgentThread(thread.id))
                   }

--- a/desktop/src/renderer/src/features/support/DesktopSupportButton.tsx
+++ b/desktop/src/renderer/src/features/support/DesktopSupportButton.tsx
@@ -1,12 +1,9 @@
 import { MessageCircle } from "../../lib/hugeicons";
 import {
-  isDesktopSupportConfigured,
   openDesktopSupport,
 } from "./DesktopSupportWidget";
 
 export default function DesktopSupportButton() {
-  if (!isDesktopSupportConfigured()) return null;
-
   return (
     <button
       type="button"
@@ -14,7 +11,9 @@ export default function DesktopSupportButton() {
       title="Support"
       className="flex size-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-[var(--bg-hover)] focus-visible:bg-[var(--bg-hover)]"
       style={{ color: "var(--text-secondary)" }}
-      onClick={() => void openDesktopSupport()}
+      onClick={() => {
+        void openDesktopSupport();
+      }}
     >
       <MessageCircle aria-hidden="true" size={16} />
     </button>

--- a/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
+++ b/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
@@ -29,7 +29,7 @@ function configuredToken(): string | null {
   return token || null;
 }
 
-export function isDesktopSupportConfigured(): boolean {
+function isDesktopSupportConfigured(): boolean {
   return configuredToken() !== null;
 }
 
@@ -158,6 +158,7 @@ async function openSupportPanel(generation: number): Promise<boolean> {
 }
 
 export function openDesktopSupport(): Promise<boolean> {
+  if (!isDesktopSupportConfigured()) return Promise.resolve(false);
   if (!openSupportPromise) {
     const generation = supportLifecycleGeneration;
     const promise = openSupportPanel(generation)

--- a/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
+++ b/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
@@ -1,5 +1,6 @@
 import "posthog-js/dist/conversations";
 import posthog from "posthog-js/dist/module.no-external";
+import { DESKTOP_ANALYTICS_EVENT, isDesktopAnalyticsName, type DesktopAnalyticsDetail } from "../../lib/desktop-analytics";
 import { useEffect } from "react";
 import { useConnection } from "../../stores/connection";
 
@@ -271,6 +272,20 @@ export default function DesktopSupportWidget() {
       console.warn("[desktop-support] PostHog identification failed:", errorKind(error));
     }
   }, [authGeneration, displayName, handle, platformHost, status]);
+
+  useEffect(() => {
+    const capture = (event: Event) => {
+      const detail = (event as CustomEvent<DesktopAnalyticsDetail>).detail;
+      if (!initialized || activeIdentity === null || !isDesktopAnalyticsName(detail?.name)) return;
+      posthog.capture(detail.name, {
+        ...(detail.appKind ? { app_kind: detail.appKind } : {}),
+        ...(typeof detail.open === "boolean" ? { open: detail.open } : {}),
+        matrix_client: "desktop",
+      });
+    };
+    window.addEventListener(DESKTOP_ANALYTICS_EVENT, capture);
+    return () => window.removeEventListener(DESKTOP_ANALYTICS_EVENT, capture);
+  }, []);
 
   useEffect(() => () => {
     invalidatePendingSupportOpen();

--- a/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
+++ b/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
@@ -3,6 +3,7 @@ import posthog from "posthog-js/dist/module.no-external";
 import { DESKTOP_ANALYTICS_EVENT, isDesktopAnalyticsName, type DesktopAnalyticsDetail } from "../../lib/desktop-analytics";
 import { useEffect } from "react";
 import { useConnection } from "../../stores/connection";
+import { useUi } from "../../stores/ui";
 
 type PostHogInitOptions = Parameters<typeof posthog.init>[1];
 
@@ -14,6 +15,7 @@ let launcherObserver: MutationObserver | null = null;
 let openSupportPromise: Promise<boolean> | null = null;
 let supportLifecycleGeneration = 0;
 let cancelPendingElementWait: (() => void) | null = null;
+let supportOverlayHeld = false;
 
 const POSTHOG_WIDGET_ID = "ph-conversations-widget-container";
 const POSTHOG_LAUNCHER_SELECTOR = 'button[aria-label^="Open chat"]';
@@ -56,16 +58,29 @@ function hidePostHogWidget(): void {
   }
 }
 
+function acquireSupportOverlay(): void {
+  if (supportOverlayHeld) return;
+  supportOverlayHeld = true;
+  useUi.getState().acquireRendererOverlay();
+}
+
+function releaseSupportOverlay(): void {
+  if (!supportOverlayHeld) return;
+  supportOverlayHeld = false;
+  useUi.getState().releaseRendererOverlay();
+}
+
 function suppressDefaultLauncher(): void {
   const widget = document.getElementById(POSTHOG_WIDGET_ID);
   const launcher = widget?.querySelector(POSTHOG_LAUNCHER_SELECTOR);
   const panel = widget?.querySelector(POSTHOG_CLOSE_SELECTOR);
-  if (!launcher && !panel) return;
 
   if (allowPostHogWidget) {
     if (openSupportPromise || panel) return;
     allowPostHogWidget = false;
+    releaseSupportOverlay();
   }
+  if (!launcher && !panel) return;
   hidePostHogWidget();
 }
 
@@ -160,11 +175,16 @@ async function openSupportPanel(generation: number): Promise<boolean> {
 export function openDesktopSupport(): Promise<boolean> {
   if (!isDesktopSupportConfigured()) return Promise.resolve(false);
   if (!openSupportPromise) {
+    acquireSupportOverlay();
     const generation = supportLifecycleGeneration;
     const promise = openSupportPanel(generation)
       .catch((error: unknown) => {
         console.warn("[desktop-support] Support chat unavailable:", errorKind(error));
         return false;
+      })
+      .then((opened) => {
+        if (!opened) releaseSupportOverlay();
+        return opened;
       })
       .finally(() => {
         if (openSupportPromise === promise) openSupportPromise = null;
@@ -177,6 +197,7 @@ export function openDesktopSupport(): Promise<boolean> {
 function hideAndResetSupport(): void {
   invalidatePendingSupportOpen();
   allowPostHogWidget = false;
+  releaseSupportOverlay();
   if (!initialized) return;
   hidePostHogWidget();
   if (activeIdentity === null) return;
@@ -291,6 +312,7 @@ export default function DesktopSupportWidget() {
   useEffect(() => () => {
     invalidatePendingSupportOpen();
     allowPostHogWidget = false;
+    releaseSupportOverlay();
     stopLauncherObserver();
   }, []);
 

--- a/desktop/src/renderer/src/features/terminal/DesktopNewSessionControl.tsx
+++ b/desktop/src/renderer/src/features/terminal/DesktopNewSessionControl.tsx
@@ -10,6 +10,7 @@ import {
   type TerminalAgentMenuAction,
   type TerminalAgentOption,
 } from "./terminal-agent-options";
+import { DesktopTerminalAgentLogo } from "./DesktopTerminalAgentLogo";
 
 export function DesktopNewSessionControl({
   disabled,
@@ -81,7 +82,7 @@ export function DesktopNewSessionControl({
                 <SessionMenuItem
                   key={option.id}
                   label={option.label}
-                  badge={option.shortLabel.slice(0, 2)}
+                  icon={<DesktopTerminalAgentLogo agent={option.id} />}
                   status={status}
                   disabled={action === null}
                   onSelect={() => action && onCreateAgent(option, action)}
@@ -98,14 +99,12 @@ export function DesktopNewSessionControl({
 function SessionMenuItem({
   label,
   icon,
-  badge,
   status,
   disabled = false,
   onSelect,
 }: {
   label: string;
   icon?: React.ReactNode;
-  badge?: string;
   status?: string | null;
   disabled?: boolean;
   onSelect: () => void;
@@ -116,9 +115,9 @@ function SessionMenuItem({
       onSelect={onSelect}
       className="flex cursor-default items-center gap-2 rounded-md px-2.5 py-2 text-sm outline-none data-[disabled]:opacity-50 data-[highlighted]:bg-[var(--bg-hover)]"
     >
-      <span className="flex size-5 shrink-0 items-center justify-center rounded text-[9px] font-bold" style={{ background: "var(--bg-selected)", color: "var(--text-secondary)" }}>
-        {icon ?? badge}
-      </span>
+      {icon ? icon : (
+        <span className="flex size-5 shrink-0 items-center justify-center rounded text-[9px] font-bold" style={{ background: "var(--bg-selected)", color: "var(--text-secondary)" }} />
+      )}
       <span className="min-w-0 flex-1">{label}</span>
       {status ? <span className="text-[10px]" style={{ color: "var(--text-tertiary)" }}>{status}</span> : null}
     </DropdownMenu.Item>

--- a/desktop/src/renderer/src/features/terminal/DesktopTerminalAgentLogo.tsx
+++ b/desktop/src/renderer/src/features/terminal/DesktopTerminalAgentLogo.tsx
@@ -1,0 +1,43 @@
+import {
+  TERMINAL_AGENT_OPTIONS,
+  type TerminalAgentId,
+} from "./terminal-agent-options";
+
+export function DesktopTerminalAgentLogo({
+  agent,
+  compact = false,
+  testIdPrefix = "desktop-terminal-agent-logo",
+}: {
+  agent: TerminalAgentId;
+  compact?: boolean;
+  testIdPrefix?: string;
+}) {
+  const option = TERMINAL_AGENT_OPTIONS.find((candidate) => candidate.id === agent);
+  if (!option) return null;
+  const containerSize = compact ? 18 : 22;
+  const imageSize = compact ? 12 : 15;
+  return (
+    <span
+      aria-hidden="true"
+      data-testid={`${testIdPrefix}-${agent}`}
+      className="inline-flex shrink-0 items-center justify-center overflow-hidden"
+      style={{
+        width: containerSize,
+        height: containerSize,
+        borderRadius: compact ? 5 : 7,
+        background: option.color,
+      }}
+    >
+      <img
+        alt=""
+        draggable={false}
+        width={imageSize}
+        height={imageSize}
+        src={option.logoSrc}
+        data-testid={`${testIdPrefix}-image-${agent}`}
+        className="block object-contain"
+        style={{ width: imageSize, height: imageSize }}
+      />
+    </span>
+  );
+}

--- a/desktop/src/renderer/src/features/terminal/TerminalSessionSidebar.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalSessionSidebar.tsx
@@ -1,5 +1,6 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { Check, Clipboard, Edit3, MoreHorizontal, SquareTerminal, Trash2, X } from "@renderer/lib/hugeicons";
+import { Check, Clipboard, Edit3, Folder, MoreHorizontal, PinIcon, PinOffIcon, SquareTerminal, Trash2, X } from "@renderer/lib/hugeicons";
+import { useState } from "react";
 
 import { DESKTOP_Z_INDEX } from "../../design/layering";
 import type { ShellSessionSummary } from "../../stores/shell-sessions";
@@ -14,16 +15,21 @@ import {
   type TerminalAgentMenuAction,
   type TerminalAgentOption,
 } from "./terminal-agent-options";
-
-function isActive(shell: ShellSessionSummary): boolean {
-  return shell.status === "active" || shell.visualStatus === "running";
-}
+import { DesktopTerminalAgentLogo } from "./DesktopTerminalAgentLogo";
 
 function agentMetadata(shell: ShellSessionSummary): string | null {
   if (!shell.agent) return null;
-  return [terminalAgentLabel(shell.agent), shell.model, shell.strength, shell.lastAction ?? shell.subtitle]
+  return [terminalAgentLabel(shell.agent), shell.model, shell.strength]
     .filter(Boolean)
     .join(" · ");
+}
+
+function displayCwd(cwd: string): string {
+  return cwd === "~" ? cwd : `~/${cwd}`;
+}
+
+function sessionTitle(shell: ShellSessionSummary): string {
+  return shell.subtitle?.trim() || shell.name;
 }
 
 export function TerminalSessionSidebar({
@@ -45,6 +51,7 @@ export function TerminalSessionSidebar({
   onCommitRename,
   onCancelRename,
   onCopyConnectCommand,
+  onPin,
   onDelete,
 }: {
   sessions: ShellSessionSummary[];
@@ -65,8 +72,10 @@ export function TerminalSessionSidebar({
   onCommitRename: () => void;
   onCancelRename: () => void;
   onCopyConnectCommand: (session: ShellSessionSummary) => void;
+  onPin: (session: ShellSessionSummary, pinned: boolean) => void;
   onDelete: (session: ShellSessionSummary) => void;
 }) {
+  const [actionsName, setActionsName] = useState<string | null>(null);
   return (
     <OSWindowSafeView area="sidebar" data-terminal-session-sidebar className="flex h-full min-h-0 w-full flex-col">
       <aside className="flex h-full min-h-0 w-full flex-col">
@@ -86,9 +95,10 @@ export function TerminalSessionSidebar({
           />
         </div>
         <ul aria-label="Terminal sessions" className="min-h-0 flex-1 overflow-y-auto pb-4">
-          {sessions.map((session) => {
+          {[...sessions].sort((left, right) => Number(Boolean(right.pinned)) - Number(Boolean(left.pinned))).map((session) => {
             const selected = selectedName === session.name;
             const metadata = agentMetadata(session);
+            const title = sessionTitle(session);
             const renaming = renamingName === session.name;
             return (
               <li key={session.name} className="group/session relative shrink-0 border-b" style={{ borderColor: "var(--border-subtle)" }}>
@@ -123,39 +133,73 @@ export function TerminalSessionSidebar({
                       type="button"
                       aria-label={`Open ${session.name}`}
                       aria-current={selected || undefined}
-                      className="flex min-h-16 w-full min-w-0 items-start gap-2 px-4 py-3 pr-10 text-left hover:bg-[var(--bg-hover)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[var(--accent)]"
+                      className="flex min-h-16 w-full min-w-0 items-start px-4 py-3 pr-10 text-left hover:bg-[var(--bg-hover)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[var(--accent)]"
                       style={{ background: selected ? "var(--bg-hover)" : "transparent" }}
                       onClick={() => onSelect(session)}
+                      onContextMenu={(event) => {
+                        event.preventDefault();
+                        setActionsName(session.name);
+                      }}
                     >
-                      <span
-                        data-terminal-session-status={isActive(session) ? "active" : "inactive"}
-                        className="mt-1.5 size-2.5 shrink-0 rounded-full"
-                        style={{ background: isActive(session) ? "var(--success)" : "var(--text-tertiary)" }}
-                      />
                       <span className="min-w-0 flex-1">
                         <span className="flex min-w-0 items-center justify-between gap-2">
-                          <span className="truncate text-sm leading-5" style={{ color: "var(--text-primary)" }}>{session.name}</span>
-                          <span className="shrink-0 text-[10px]" style={{ color: "var(--text-tertiary)" }}>{relativeSessionActivity(session.updatedAt)}</span>
+                          <span
+                            data-testid={`terminal-session-title-${session.name}`}
+                            className="truncate text-sm leading-5"
+                            style={{ color: "var(--text-primary)" }}
+                            onDoubleClick={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                              onRename(session);
+                            }}
+                          >
+                            {title}
+                          </span>
+                          <span className="flex shrink-0 items-center gap-1 text-[10px]" style={{ color: "var(--text-tertiary)" }}>
+                            {session.pinned ? <PinIcon size={11} aria-label="Pinned" /> : null}
+                            {relativeSessionActivity(session.updatedAt)}
+                          </span>
                         </span>
-                        {metadata ? <span className="mt-0.5 block truncate text-[10px] leading-4" style={{ color: "var(--text-secondary)" }}>{metadata}</span> : null}
+                        {session.cwd || (metadata && session.agent) ? (
+                          <span
+                            data-testid={`terminal-session-agent-metadata-${session.name}`}
+                            className="mt-0.5 flex min-w-0 items-center justify-between gap-2 text-[10px] leading-4"
+                            style={{ color: "var(--text-secondary)" }}
+                          >
+                            <span
+                              data-testid={`terminal-session-path-${session.name}`}
+                              className="flex min-w-0 items-center gap-1.5"
+                            >
+                              {session.cwd ? <Folder size={13} className="shrink-0" aria-hidden="true" /> : null}
+                              {session.cwd ? <span className="min-w-0 truncate font-mono">{displayCwd(session.cwd)}</span> : null}
+                            </span>
+                            {session.agent ? (
+                              <span
+                                data-testid={`terminal-session-agent-${session.name}`}
+                                className="flex min-w-0 shrink-0 items-center gap-1.5"
+                              >
+                                <DesktopTerminalAgentLogo
+                                  agent={session.agent}
+                                  compact
+                                  testIdPrefix="desktop-terminal-session-agent-logo"
+                                />
+                                {metadata ? <span className="max-w-28 truncate">{metadata}</span> : null}
+                              </span>
+                            ) : null}
+                          </span>
+                        ) : null}
                       </span>
                     </button>
                     <SessionActions
                       session={session}
                       disabled={disabled}
+                      open={actionsName === session.name}
+                      onOpenChange={(open) => setActionsName(open ? session.name : null)}
                       onRename={() => onRename(session)}
                       onCopy={() => onCopyConnectCommand(session)}
+                      onPin={() => onPin(session, !session.pinned)}
                       onDelete={() => onDelete(session)}
                     />
-                    <button
-                      type="button"
-                      aria-label={`Delete ${session.name}`}
-                      disabled={disabled}
-                      className="absolute right-9 top-3 z-10 flex size-7 items-center justify-center rounded-md bg-[var(--bg-surface)] text-[var(--text-tertiary)] opacity-0 transition-opacity hover:bg-[var(--bg-hover)] hover:text-[var(--danger)] focus-visible:opacity-100 group-hover/session:opacity-100"
-                      onClick={() => onDelete(session)}
-                    >
-                      <Trash2 size={13} aria-hidden="true" />
-                    </button>
                   </>
                 )}
               </li>
@@ -167,15 +211,18 @@ export function TerminalSessionSidebar({
   );
 }
 
-function SessionActions({ session, disabled, onRename, onCopy, onDelete }: {
+function SessionActions({ session, disabled, open, onOpenChange, onRename, onCopy, onPin, onDelete }: {
   session: ShellSessionSummary;
   disabled: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   onRename: () => void;
   onCopy: () => void;
+  onPin: () => void;
   onDelete: () => void;
 }) {
   return (
-    <DropdownMenu.Root>
+    <DropdownMenu.Root open={open} onOpenChange={onOpenChange}>
       <DropdownMenu.Trigger asChild>
         <button
           type="button"
@@ -196,6 +243,11 @@ function SessionActions({ session, disabled, onRename, onCopy, onDelete }: {
         >
           <SessionAction icon={<Edit3 size={13} />} label="Rename" onSelect={onRename} />
           <SessionAction icon={<Clipboard size={13} />} label="Copy connect command" onSelect={onCopy} />
+          <SessionAction
+            icon={session.pinned ? <PinOffIcon size={13} /> : <PinIcon size={13} />}
+            label={session.pinned ? "Unpin" : "Pin"}
+            onSelect={onPin}
+          />
           <DropdownMenu.Separator className="my-1 h-px" style={{ background: "var(--border-subtle)" }} />
           <SessionAction icon={<Trash2 size={13} />} label="Delete" danger onSelect={onDelete} />
         </DropdownMenu.Content>

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -62,7 +62,7 @@ function shellStatusLabel(shell: ShellSessionSummary): string {
 }
 
 function shellTitle(shell: ShellSessionSummary): string {
-  return shell.subtitle?.trim() || shell.lastAction?.trim() || shell.name;
+  return shell.subtitle?.trim() || shell.name;
 }
 
 function mostRecentShell(sessions: ShellSessionSummary[]): ShellSessionSummary | null {
@@ -428,6 +428,10 @@ export default function TerminalsTab({
             setRenameError(null);
           }}
           onCopyConnectCommand={(shell) => void copyAttachCommand(shell)}
+          onPin={(shell, pinned) => {
+            if (!api) return;
+            void useShellSessions.getState().patchUiState(api, shell.name, { pinned });
+          }}
           onDelete={setDeleteTarget}
         />
       </div>

--- a/desktop/src/renderer/src/features/terminal/terminal-agent-options.ts
+++ b/desktop/src/renderer/src/features/terminal/terminal-agent-options.ts
@@ -8,6 +8,8 @@ export interface TerminalAgentOption {
   id: TerminalAgentId;
   label: string;
   shortLabel: string;
+  color: string;
+  logoSrc: string;
   launchCommand: string;
   installPackage: string;
   installFlags?: string[];
@@ -18,6 +20,8 @@ export const TERMINAL_AGENT_OPTIONS: readonly TerminalAgentOption[] = [
     id: "claude",
     label: "Claude Code",
     shortLabel: "Claude",
+    color: "#D8792C",
+    logoSrc: "/agent-logos/claude-code.png",
     launchCommand: "claude",
     installPackage: "@anthropic-ai/claude-code@latest",
   },
@@ -25,6 +29,8 @@ export const TERMINAL_AGENT_OPTIONS: readonly TerminalAgentOption[] = [
     id: "codex",
     label: "Codex",
     shortLabel: "Codex",
+    color: "#465243",
+    logoSrc: "/agent-logos/codex.png",
     launchCommand: "codex",
     installPackage: CODEX_VERIFIED_NPM_PACKAGE,
   },
@@ -32,6 +38,8 @@ export const TERMINAL_AGENT_OPTIONS: readonly TerminalAgentOption[] = [
     id: "opencode",
     label: "OpenCode",
     shortLabel: "OpenCode",
+    color: "#111111",
+    logoSrc: "/agent-logos/opencode-white.png",
     launchCommand: "opencode",
     installPackage: "opencode-ai@latest",
   },
@@ -39,6 +47,8 @@ export const TERMINAL_AGENT_OPTIONS: readonly TerminalAgentOption[] = [
     id: "pi",
     label: "Pi",
     shortLabel: "Pi",
+    color: "#1E2F5C",
+    logoSrc: "/agent-logos/pi-coding-agent.png",
     launchCommand: "pi",
     installPackage: "@earendil-works/pi-coding-agent@latest",
     installFlags: ["--ignore-scripts"],

--- a/desktop/src/renderer/src/lib/desktop-analytics.ts
+++ b/desktop/src/renderer/src/lib/desktop-analytics.ts
@@ -1,0 +1,42 @@
+export const DESKTOP_ANALYTICS_EVENT = "matrix:desktop-analytics";
+
+export type DesktopAnalyticsName =
+  | "desktop_app_opened"
+  | "desktop_app_focused"
+  | "desktop_app_minimized"
+  | "desktop_app_closed"
+  | "desktop_launcher_toggled"
+  | "desktop_shown"
+  | "desktop_icon_moved"
+  | "desktop_icon_removed";
+
+const DESKTOP_ANALYTICS_NAMES = new Set<DesktopAnalyticsName>([
+  "desktop_app_opened",
+  "desktop_app_focused",
+  "desktop_app_minimized",
+  "desktop_app_closed",
+  "desktop_launcher_toggled",
+  "desktop_shown",
+  "desktop_icon_moved",
+  "desktop_icon_removed",
+]);
+
+export function isDesktopAnalyticsName(value: unknown): value is DesktopAnalyticsName {
+  return typeof value === "string" && DESKTOP_ANALYTICS_NAMES.has(value as DesktopAnalyticsName);
+}
+
+export interface DesktopAnalyticsDetail {
+  name: DesktopAnalyticsName;
+  appKind?: string;
+  open?: boolean;
+}
+
+const SAFE_VALUE = /^[a-z0-9_-]{1,64}$/i;
+
+export function trackDesktopEvent(detail: DesktopAnalyticsDetail): void {
+  if (typeof window === "undefined") return;
+  const safeDetail: DesktopAnalyticsDetail = { name: detail.name };
+  if (detail.appKind && SAFE_VALUE.test(detail.appKind)) safeDetail.appKind = detail.appKind;
+  if (typeof detail.open === "boolean") safeDetail.open = detail.open;
+  window.dispatchEvent(new CustomEvent<DesktopAnalyticsDetail>(DESKTOP_ANALYTICS_EVENT, { detail: safeDetail }));
+}

--- a/desktop/src/renderer/src/stores/apps.ts
+++ b/desktop/src/renderer/src/stores/apps.ts
@@ -8,6 +8,7 @@ import type { ApiClient } from "../lib/api";
 export interface MatrixApp {
   slug: string;
   name: string;
+  path?: string;
   category?: string;
   appIdentity?: string;
 }
@@ -21,6 +22,12 @@ function appIdentityFromFile(value: unknown): string | undefined {
     .replace(/\/index\.html$/, "")
     .replace(/\.html$/, "");
   return identity.length <= 256 && SAFE_APP_IDENTITY.test(identity) ? identity : undefined;
+}
+
+function appPathFromFile(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length > 2048) return undefined;
+  const path = value.replace(/^\/+/, "");
+  return path.startsWith("apps/") && !path.split("/").includes("..") ? path : undefined;
 }
 
 const MAX_APP_ICON_PRELOADS = 20;
@@ -84,9 +91,11 @@ export function parseApps(value: unknown): MatrixApp[] {
     const category =
       typeof app.category === "string" && app.category.trim().length > 0 ? app.category.trim() : undefined;
     const appIdentity = appIdentityFromFile(app.file);
+    const path = appPathFromFile(app.file);
     apps.push({
       slug,
       name,
+      ...(path ? { path } : {}),
       ...(category ? { category } : {}),
       ...(appIdentity ? { appIdentity } : {}),
     });

--- a/desktop/src/renderer/src/stores/browser-navigation.ts
+++ b/desktop/src/renderer/src/stores/browser-navigation.ts
@@ -1,0 +1,32 @@
+import { resolveBrowserAddress } from "../../../shared/runtime-browser-url";
+import { create } from "zustand";
+
+const MAX_BROWSER_ADDRESS_LENGTH = 4_096;
+
+export interface BrowserNavigationRequest {
+  id: number;
+  url: string;
+}
+
+interface BrowserNavigationState {
+  pending: BrowserNavigationRequest | null;
+  sequence: number;
+  request(address: string): number | null;
+  consume(id: number): void;
+}
+
+export const useBrowserNavigation = create<BrowserNavigationState>()((set, get) => ({
+  pending: null,
+  sequence: 0,
+  request: (address) => {
+    if (address.length > MAX_BROWSER_ADDRESS_LENGTH) return null;
+    const resolved = resolveBrowserAddress(address);
+    if (!resolved) return null;
+    const id = get().sequence + 1;
+    set({ pending: { id, url: resolved.url }, sequence: id });
+    return id;
+  },
+  consume: (id) => set((state) => (
+    state.pending?.id === id ? { pending: null } : state
+  )),
+}));

--- a/desktop/src/renderer/src/stores/create-app-request.ts
+++ b/desktop/src/renderer/src/stores/create-app-request.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-const CREATE_APP_PROMPT = "Build a new Matrix app. Use the Matrix builder agent and ~/agents/knowledge/app-generation.md. Ask me what I want to create before you start building.";
+const CREATE_APP_PROMPT = "/matrix-app-builder ";
 
 interface CreateAppRequestState {
   request: { id: number; prompt: string } | null;

--- a/desktop/src/renderer/src/stores/create-app-request.ts
+++ b/desktop/src/renderer/src/stores/create-app-request.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+
+const CREATE_APP_PROMPT = "Build a new Matrix app. Use the Matrix builder agent and ~/agents/knowledge/app-generation.md. Ask me what I want to create before you start building.";
+
+interface CreateAppRequestState {
+  request: { id: number; prompt: string } | null;
+  requestDraft: () => void;
+  clear: (id: number) => void;
+}
+
+let nextRequestId = 0;
+
+export const useCreateAppRequest = create<CreateAppRequestState>((set, get) => ({
+  request: null,
+  requestDraft: () => set({ request: { id: ++nextRequestId, prompt: CREATE_APP_PROMPT } }),
+  clear: (id) => {
+    if (get().request?.id === id) set({ request: null });
+  },
+}));

--- a/desktop/src/renderer/src/stores/desktop-icons.ts
+++ b/desktop/src/renderer/src/stores/desktop-icons.ts
@@ -81,6 +81,7 @@ let hydrationRevision = 0;
 let confirmedIcons: DesktopIconPlacement[] = [];
 let hasConfirmedIcons = false;
 let unconfirmedHydrationRevision: number | null = null;
+let deferredHydrationIcons: DesktopIconPlacement[] | null = null;
 
 function copyIcons(icons: readonly DesktopIconPlacement[]): DesktopIconPlacement[] {
   return icons.map((icon) => ({ ...icon }));
@@ -94,6 +95,7 @@ export function resetDesktopIconsRuntime(): void {
   confirmedIcons = [];
   hasConfirmedIcons = false;
   unconfirmedHydrationRevision = null;
+  deferredHydrationIcons = null;
   useDesktopIcons.setState({ icons: [], loaded: false });
 }
 
@@ -138,12 +140,22 @@ async function applyOptimisticMutation(
       confirmedIcons = copyIcons(snapshot);
       hasConfirmedIcons = true;
       unconfirmedHydrationRevision = null;
+      deferredHydrationIcons = null;
     }
   } catch (error: unknown) {
     console.warn("[desktop-icons] persist failed:", error instanceof Error ? error.name : typeof error);
     if (epoch === stateEpoch && sequence === mutationSequence && isCurrentRuntimeGeneration(runtimeGeneration)) {
       if (hasConfirmedIcons) {
         set({ icons: copyIcons(confirmedIcons), loaded: true });
+      } else if (deferredHydrationIcons !== null) {
+        const icons = copyIcons(deferredHydrationIcons);
+        confirmedIcons = copyIcons(icons);
+        hasConfirmedIcons = true;
+        unconfirmedHydrationRevision = null;
+        deferredHydrationIcons = null;
+        hydrationRevision += 1;
+        set({ icons, loaded: true });
+        restoredPendingHydration = true;
       } else {
         set({ icons: rollbackIcons, loaded: false });
         if (unconfirmedHydrationRevision !== null) {
@@ -166,14 +178,20 @@ export const useDesktopIcons = create<DesktopIconsState>()((set, get) => ({
     set({ icons: copyIcons(defaults) });
   },
   hydrate: (value, defaults, expectedRevision) => {
-    if (expectedRevision !== hydrationRevision) return;
     const icons = parseDesktopIcons(value) ?? copyIcons(defaults);
+    if (expectedRevision !== hydrationRevision) {
+      if (!hasConfirmedIcons && unconfirmedHydrationRevision === expectedRevision) {
+        deferredHydrationIcons = copyIcons(icons);
+      }
+      return;
+    }
     mutationSequence += 1;
     stateEpoch += 1;
     hydrationRevision += 1;
     confirmedIcons = copyIcons(icons);
     hasConfirmedIcons = true;
     unconfirmedHydrationRevision = null;
+    deferredHydrationIcons = null;
     set({ icons, loaded: true });
   },
   load: async (api, defaults) => {
@@ -183,28 +201,40 @@ export const useDesktopIcons = create<DesktopIconsState>()((set, get) => ({
     try {
       const config = await api.get<{ desktopIcons?: unknown }>("/api/settings/desktop");
       if (sequence !== loadSequence
-        || expectedHydrationRevision !== hydrationRevision
         || !isCurrentRuntimeGeneration(runtimeGeneration)) return;
       const icons = parseDesktopIcons(config.desktopIcons) ?? copyIcons(defaults);
+      if (expectedHydrationRevision !== hydrationRevision) {
+        if (!hasConfirmedIcons && unconfirmedHydrationRevision === expectedHydrationRevision) {
+          deferredHydrationIcons = copyIcons(icons);
+        }
+        return;
+      }
       mutationSequence += 1;
       stateEpoch += 1;
       hydrationRevision += 1;
       confirmedIcons = copyIcons(icons);
       hasConfirmedIcons = true;
       unconfirmedHydrationRevision = null;
+      deferredHydrationIcons = null;
       set({ icons, loaded: true });
     } catch (error: unknown) {
       if (sequence !== loadSequence
-        || expectedHydrationRevision !== hydrationRevision
         || !isCurrentRuntimeGeneration(runtimeGeneration)) return;
       console.warn("[desktop-icons] load failed:", error instanceof Error ? error.name : typeof error);
       const icons = copyIcons(defaults);
+      if (expectedHydrationRevision !== hydrationRevision) {
+        if (!hasConfirmedIcons && unconfirmedHydrationRevision === expectedHydrationRevision) {
+          deferredHydrationIcons = copyIcons(icons);
+        }
+        return;
+      }
       mutationSequence += 1;
       stateEpoch += 1;
       hydrationRevision += 1;
       confirmedIcons = copyIcons(icons);
       hasConfirmedIcons = true;
       unconfirmedHydrationRevision = null;
+      deferredHydrationIcons = null;
       set({ icons, loaded: true });
     }
   },

--- a/desktop/src/renderer/src/stores/desktop-icons.ts
+++ b/desktop/src/renderer/src/stores/desktop-icons.ts
@@ -81,7 +81,9 @@ let hydrationRevision = 0;
 let confirmedIcons: DesktopIconPlacement[] = [];
 let hasConfirmedIcons = false;
 let unconfirmedHydrationRevision: number | null = null;
+let unconfirmedRollbackIcons: DesktopIconPlacement[] | null = null;
 let deferredHydrationIcons: DesktopIconPlacement[] | null = null;
+let replayableHydrationRange: { min: number; max: number } | null = null;
 
 function copyIcons(icons: readonly DesktopIconPlacement[]): DesktopIconPlacement[] {
   return icons.map((icon) => ({ ...icon }));
@@ -95,7 +97,9 @@ export function resetDesktopIconsRuntime(): void {
   confirmedIcons = [];
   hasConfirmedIcons = false;
   unconfirmedHydrationRevision = null;
+  unconfirmedRollbackIcons = null;
   deferredHydrationIcons = null;
+  replayableHydrationRange = null;
   useDesktopIcons.setState({ icons: [], loaded: false });
 }
 
@@ -130,6 +134,8 @@ async function applyOptimisticMutation(
   const snapshot = copyIcons(icons);
   if (!hasConfirmedIcons && unconfirmedHydrationRevision === null) {
     unconfirmedHydrationRevision = hydrationRevision;
+    unconfirmedRollbackIcons = copyIcons(previousIcons);
+    replayableHydrationRange = null;
   }
   hydrationRevision += 1;
   set({ icons: snapshot, loaded: true });
@@ -140,7 +146,9 @@ async function applyOptimisticMutation(
       confirmedIcons = copyIcons(snapshot);
       hasConfirmedIcons = true;
       unconfirmedHydrationRevision = null;
+      unconfirmedRollbackIcons = null;
       deferredHydrationIcons = null;
+      replayableHydrationRange = null;
     }
   } catch (error: unknown) {
     console.warn("[desktop-icons] persist failed:", error instanceof Error ? error.name : typeof error);
@@ -152,15 +160,22 @@ async function applyOptimisticMutation(
         confirmedIcons = copyIcons(icons);
         hasConfirmedIcons = true;
         unconfirmedHydrationRevision = null;
+        unconfirmedRollbackIcons = null;
         deferredHydrationIcons = null;
+        replayableHydrationRange = null;
         hydrationRevision += 1;
         set({ icons, loaded: true });
         restoredPendingHydration = true;
       } else {
-        set({ icons: rollbackIcons, loaded: false });
+        set({ icons: copyIcons(unconfirmedRollbackIcons ?? rollbackIcons), loaded: false });
         if (unconfirmedHydrationRevision !== null) {
+          replayableHydrationRange = {
+            min: unconfirmedHydrationRevision,
+            max: hydrationRevision,
+          };
           hydrationRevision = unconfirmedHydrationRevision;
           unconfirmedHydrationRevision = null;
+          unconfirmedRollbackIcons = null;
           restoredPendingHydration = true;
         }
       }
@@ -179,10 +194,18 @@ export const useDesktopIcons = create<DesktopIconsState>()((set, get) => ({
   },
   hydrate: (value, defaults, expectedRevision) => {
     const icons = parseDesktopIcons(value) ?? copyIcons(defaults);
-    if (expectedRevision !== hydrationRevision) {
-      if (!hasConfirmedIcons && unconfirmedHydrationRevision === expectedRevision) {
-        deferredHydrationIcons = copyIcons(icons);
-      }
+    const replayable = replayableHydrationRange !== null
+      && expectedRevision >= replayableHydrationRange.min
+      && expectedRevision <= replayableHydrationRange.max;
+    if (!replayable
+      && !hasConfirmedIcons
+      && unconfirmedHydrationRevision !== null
+      && expectedRevision >= unconfirmedHydrationRevision
+      && expectedRevision <= hydrationRevision) {
+      deferredHydrationIcons = copyIcons(icons);
+      return;
+    }
+    if (!replayable && expectedRevision !== hydrationRevision) {
       return;
     }
     mutationSequence += 1;
@@ -191,7 +214,9 @@ export const useDesktopIcons = create<DesktopIconsState>()((set, get) => ({
     confirmedIcons = copyIcons(icons);
     hasConfirmedIcons = true;
     unconfirmedHydrationRevision = null;
+    unconfirmedRollbackIcons = null;
     deferredHydrationIcons = null;
+    replayableHydrationRange = null;
     set({ icons, loaded: true });
   },
   load: async (api, defaults) => {
@@ -203,10 +228,18 @@ export const useDesktopIcons = create<DesktopIconsState>()((set, get) => ({
       if (sequence !== loadSequence
         || !isCurrentRuntimeGeneration(runtimeGeneration)) return;
       const icons = parseDesktopIcons(config.desktopIcons) ?? copyIcons(defaults);
-      if (expectedHydrationRevision !== hydrationRevision) {
-        if (!hasConfirmedIcons && unconfirmedHydrationRevision === expectedHydrationRevision) {
-          deferredHydrationIcons = copyIcons(icons);
-        }
+      const replayable = replayableHydrationRange !== null
+        && expectedHydrationRevision >= replayableHydrationRange.min
+        && expectedHydrationRevision <= replayableHydrationRange.max;
+      if (!replayable
+        && !hasConfirmedIcons
+        && unconfirmedHydrationRevision !== null
+        && expectedHydrationRevision >= unconfirmedHydrationRevision
+        && expectedHydrationRevision <= hydrationRevision) {
+        deferredHydrationIcons = copyIcons(icons);
+        return;
+      }
+      if (!replayable && expectedHydrationRevision !== hydrationRevision) {
         return;
       }
       mutationSequence += 1;
@@ -215,17 +248,27 @@ export const useDesktopIcons = create<DesktopIconsState>()((set, get) => ({
       confirmedIcons = copyIcons(icons);
       hasConfirmedIcons = true;
       unconfirmedHydrationRevision = null;
+      unconfirmedRollbackIcons = null;
       deferredHydrationIcons = null;
+      replayableHydrationRange = null;
       set({ icons, loaded: true });
     } catch (error: unknown) {
       if (sequence !== loadSequence
         || !isCurrentRuntimeGeneration(runtimeGeneration)) return;
       console.warn("[desktop-icons] load failed:", error instanceof Error ? error.name : typeof error);
       const icons = copyIcons(defaults);
-      if (expectedHydrationRevision !== hydrationRevision) {
-        if (!hasConfirmedIcons && unconfirmedHydrationRevision === expectedHydrationRevision) {
-          deferredHydrationIcons = copyIcons(icons);
-        }
+      const replayable = replayableHydrationRange !== null
+        && expectedHydrationRevision >= replayableHydrationRange.min
+        && expectedHydrationRevision <= replayableHydrationRange.max;
+      if (!replayable
+        && !hasConfirmedIcons
+        && unconfirmedHydrationRevision !== null
+        && expectedHydrationRevision >= unconfirmedHydrationRevision
+        && expectedHydrationRevision <= hydrationRevision) {
+        deferredHydrationIcons = copyIcons(icons);
+        return;
+      }
+      if (!replayable && expectedHydrationRevision !== hydrationRevision) {
         return;
       }
       mutationSequence += 1;
@@ -234,7 +277,9 @@ export const useDesktopIcons = create<DesktopIconsState>()((set, get) => ({
       confirmedIcons = copyIcons(icons);
       hasConfirmedIcons = true;
       unconfirmedHydrationRevision = null;
+      unconfirmedRollbackIcons = null;
       deferredHydrationIcons = null;
+      replayableHydrationRange = null;
       set({ icons, loaded: true });
     }
   },

--- a/desktop/src/renderer/src/stores/desktop-icons.ts
+++ b/desktop/src/renderer/src/stores/desktop-icons.ts
@@ -65,6 +65,7 @@ function nextOpenSlot(icons: readonly DesktopIconPlacement[]): Pick<DesktopIconP
 interface DesktopIconsState {
   icons: DesktopIconPlacement[];
   loaded: boolean;
+  prime(defaults: readonly DesktopIconPlacement[]): void;
   load(api: ApiClient, defaults: readonly DesktopIconPlacement[]): Promise<void>;
   hydrate(value: unknown, defaults: readonly DesktopIconPlacement[], expectedRevision: number): void;
   move(path: string, x: number, y: number, api: ApiClient): Promise<void>;
@@ -78,6 +79,8 @@ let mutationSequence = 0;
 let stateEpoch = 0;
 let hydrationRevision = 0;
 let confirmedIcons: DesktopIconPlacement[] = [];
+let hasConfirmedIcons = false;
+let unconfirmedHydrationRevision: number | null = null;
 
 function copyIcons(icons: readonly DesktopIconPlacement[]): DesktopIconPlacement[] {
   return icons.map((icon) => ({ ...icon }));
@@ -89,6 +92,8 @@ export function resetDesktopIconsRuntime(): void {
   stateEpoch += 1;
   hydrationRevision += 1;
   confirmedIcons = [];
+  hasConfirmedIcons = false;
+  unconfirmedHydrationRevision = null;
   useDesktopIcons.setState({ icons: [], loaded: false });
 }
 
@@ -112,33 +117,54 @@ function persist(api: ApiClient, icons: DesktopIconPlacement[]): Promise<void> {
 
 async function applyOptimisticMutation(
   api: ApiClient,
+  previousIcons: DesktopIconPlacement[],
   icons: DesktopIconPlacement[],
   set: (partial: Partial<DesktopIconsState>) => void,
 ): Promise<void> {
   const sequence = ++mutationSequence;
   const epoch = stateEpoch;
   const runtimeGeneration = captureRuntimeGeneration();
+  const rollbackIcons = copyIcons(previousIcons);
   const snapshot = copyIcons(icons);
+  if (!hasConfirmedIcons && unconfirmedHydrationRevision === null) {
+    unconfirmedHydrationRevision = hydrationRevision;
+  }
   hydrationRevision += 1;
   set({ icons: snapshot, loaded: true });
+  let restoredPendingHydration = false;
   try {
     await persist(api, snapshot);
     if (epoch === stateEpoch && sequence <= mutationSequence && isCurrentRuntimeGeneration(runtimeGeneration)) {
       confirmedIcons = copyIcons(snapshot);
+      hasConfirmedIcons = true;
+      unconfirmedHydrationRevision = null;
     }
   } catch (error: unknown) {
     console.warn("[desktop-icons] persist failed:", error instanceof Error ? error.name : typeof error);
     if (epoch === stateEpoch && sequence === mutationSequence && isCurrentRuntimeGeneration(runtimeGeneration)) {
-      set({ icons: copyIcons(confirmedIcons) });
+      if (hasConfirmedIcons) {
+        set({ icons: copyIcons(confirmedIcons), loaded: true });
+      } else {
+        set({ icons: rollbackIcons, loaded: false });
+        if (unconfirmedHydrationRevision !== null) {
+          hydrationRevision = unconfirmedHydrationRevision;
+          unconfirmedHydrationRevision = null;
+          restoredPendingHydration = true;
+        }
+      }
     }
   } finally {
-    if (epoch === stateEpoch) hydrationRevision += 1;
+    if (epoch === stateEpoch && !restoredPendingHydration) hydrationRevision += 1;
   }
 }
 
 export const useDesktopIcons = create<DesktopIconsState>()((set, get) => ({
   icons: [],
   loaded: false,
+  prime: (defaults) => {
+    if (get().loaded || get().icons.length > 0) return;
+    set({ icons: copyIcons(defaults) });
+  },
   hydrate: (value, defaults, expectedRevision) => {
     if (expectedRevision !== hydrationRevision) return;
     const icons = parseDesktopIcons(value) ?? copyIcons(defaults);
@@ -146,6 +172,8 @@ export const useDesktopIcons = create<DesktopIconsState>()((set, get) => ({
     stateEpoch += 1;
     hydrationRevision += 1;
     confirmedIcons = copyIcons(icons);
+    hasConfirmedIcons = true;
+    unconfirmedHydrationRevision = null;
     set({ icons, loaded: true });
   },
   load: async (api, defaults) => {
@@ -162,6 +190,8 @@ export const useDesktopIcons = create<DesktopIconsState>()((set, get) => ({
       stateEpoch += 1;
       hydrationRevision += 1;
       confirmedIcons = copyIcons(icons);
+      hasConfirmedIcons = true;
+      unconfirmedHydrationRevision = null;
       set({ icons, loaded: true });
     } catch (error: unknown) {
       if (sequence !== loadSequence
@@ -173,23 +203,27 @@ export const useDesktopIcons = create<DesktopIconsState>()((set, get) => ({
       stateEpoch += 1;
       hydrationRevision += 1;
       confirmedIcons = copyIcons(icons);
+      hasConfirmedIcons = true;
+      unconfirmedHydrationRevision = null;
       set({ icons, loaded: true });
     }
   },
   move: async (path, x, y, api) => {
-    const next = get().icons.map((icon) => icon.path === path
+    const current = get().icons;
+    const next = current.map((icon) => icon.path === path
       ? { ...icon, x: Math.max(0, Math.min(MAX_COORDINATE, Math.round(x))), y: Math.max(0, Math.min(MAX_COORDINATE, Math.round(y))) }
       : icon);
-    await applyOptimisticMutation(api, next, set);
+    await applyOptimisticMutation(api, current, next, set);
   },
   remove: async (path, api) => {
-    const next = get().icons.filter((icon) => icon.path !== path);
-    await applyOptimisticMutation(api, next, set);
+    const current = get().icons;
+    const next = current.filter((icon) => icon.path !== path);
+    await applyOptimisticMutation(api, current, next, set);
   },
   add: async (path, api) => {
     const current = get().icons;
     if (!path || path.length > 2048 || current.some((icon) => icon.path === path) || current.length >= MAX_DESKTOP_ICONS) return;
     const next = [...current, { path, ...nextOpenSlot(current) }];
-    await applyOptimisticMutation(api, next, set);
+    await applyOptimisticMutation(api, current, next, set);
   },
 }));

--- a/desktop/src/renderer/src/stores/desktop-icons.ts
+++ b/desktop/src/renderer/src/stores/desktop-icons.ts
@@ -66,7 +66,7 @@ interface DesktopIconsState {
   icons: DesktopIconPlacement[];
   loaded: boolean;
   load(api: ApiClient, defaults: readonly DesktopIconPlacement[]): Promise<void>;
-  hydrate(value: unknown, defaults: readonly DesktopIconPlacement[]): void;
+  hydrate(value: unknown, defaults: readonly DesktopIconPlacement[], expectedRevision: number): void;
   move(path: string, x: number, y: number, api: ApiClient): Promise<void>;
   remove(path: string, api: ApiClient): Promise<void>;
   add(path: string, api: ApiClient): Promise<void>;
@@ -76,6 +76,7 @@ let loadSequence = 0;
 let persistQueue: Promise<void> = Promise.resolve();
 let mutationSequence = 0;
 let stateEpoch = 0;
+let hydrationRevision = 0;
 let confirmedIcons: DesktopIconPlacement[] = [];
 
 function copyIcons(icons: readonly DesktopIconPlacement[]): DesktopIconPlacement[] {
@@ -86,8 +87,13 @@ export function resetDesktopIconsRuntime(): void {
   loadSequence += 1;
   mutationSequence += 1;
   stateEpoch += 1;
+  hydrationRevision += 1;
   confirmedIcons = [];
   useDesktopIcons.setState({ icons: [], loaded: false });
+}
+
+export function captureDesktopIconsHydrationRevision(): number {
+  return hydrationRevision;
 }
 
 function persist(api: ApiClient, icons: DesktopIconPlacement[]): Promise<void> {
@@ -113,7 +119,8 @@ async function applyOptimisticMutation(
   const epoch = stateEpoch;
   const runtimeGeneration = captureRuntimeGeneration();
   const snapshot = copyIcons(icons);
-  set({ icons: snapshot });
+  hydrationRevision += 1;
+  set({ icons: snapshot, loaded: true });
   try {
     await persist(api, snapshot);
     if (epoch === stateEpoch && sequence <= mutationSequence && isCurrentRuntimeGeneration(runtimeGeneration)) {
@@ -124,36 +131,47 @@ async function applyOptimisticMutation(
     if (epoch === stateEpoch && sequence === mutationSequence && isCurrentRuntimeGeneration(runtimeGeneration)) {
       set({ icons: copyIcons(confirmedIcons) });
     }
+  } finally {
+    if (epoch === stateEpoch) hydrationRevision += 1;
   }
 }
 
 export const useDesktopIcons = create<DesktopIconsState>()((set, get) => ({
   icons: [],
   loaded: false,
-  hydrate: (value, defaults) => {
+  hydrate: (value, defaults, expectedRevision) => {
+    if (expectedRevision !== hydrationRevision) return;
     const icons = parseDesktopIcons(value) ?? copyIcons(defaults);
     mutationSequence += 1;
     stateEpoch += 1;
+    hydrationRevision += 1;
     confirmedIcons = copyIcons(icons);
     set({ icons, loaded: true });
   },
   load: async (api, defaults) => {
     const sequence = ++loadSequence;
+    const expectedHydrationRevision = hydrationRevision;
     const runtimeGeneration = captureRuntimeGeneration();
     try {
       const config = await api.get<{ desktopIcons?: unknown }>("/api/settings/desktop");
-      if (sequence !== loadSequence || !isCurrentRuntimeGeneration(runtimeGeneration)) return;
+      if (sequence !== loadSequence
+        || expectedHydrationRevision !== hydrationRevision
+        || !isCurrentRuntimeGeneration(runtimeGeneration)) return;
       const icons = parseDesktopIcons(config.desktopIcons) ?? copyIcons(defaults);
       mutationSequence += 1;
       stateEpoch += 1;
+      hydrationRevision += 1;
       confirmedIcons = copyIcons(icons);
       set({ icons, loaded: true });
     } catch (error: unknown) {
-      if (sequence !== loadSequence || !isCurrentRuntimeGeneration(runtimeGeneration)) return;
+      if (sequence !== loadSequence
+        || expectedHydrationRevision !== hydrationRevision
+        || !isCurrentRuntimeGeneration(runtimeGeneration)) return;
       console.warn("[desktop-icons] load failed:", error instanceof Error ? error.name : typeof error);
       const icons = copyIcons(defaults);
       mutationSequence += 1;
       stateEpoch += 1;
+      hydrationRevision += 1;
       confirmedIcons = copyIcons(icons);
       set({ icons, loaded: true });
     }

--- a/desktop/src/renderer/src/stores/desktop-icons.ts
+++ b/desktop/src/renderer/src/stores/desktop-icons.ts
@@ -78,6 +78,7 @@ let persistQueue: Promise<void> = Promise.resolve();
 let mutationSequence = 0;
 let stateEpoch = 0;
 let hydrationRevision = 0;
+let pendingMutationCount = 0;
 let confirmedIcons: DesktopIconPlacement[] = [];
 let hasConfirmedIcons = false;
 let unconfirmedHydrationRevision: number | null = null;
@@ -94,6 +95,7 @@ export function resetDesktopIconsRuntime(): void {
   mutationSequence += 1;
   stateEpoch += 1;
   hydrationRevision += 1;
+  pendingMutationCount = 0;
   confirmedIcons = [];
   hasConfirmedIcons = false;
   unconfirmedHydrationRevision = null;
@@ -129,6 +131,7 @@ async function applyOptimisticMutation(
 ): Promise<void> {
   const sequence = ++mutationSequence;
   const epoch = stateEpoch;
+  pendingMutationCount += 1;
   const runtimeGeneration = captureRuntimeGeneration();
   const rollbackIcons = copyIcons(previousIcons);
   const snapshot = copyIcons(icons);
@@ -154,6 +157,7 @@ async function applyOptimisticMutation(
     console.warn("[desktop-icons] persist failed:", error instanceof Error ? error.name : typeof error);
     if (epoch === stateEpoch && sequence === mutationSequence && isCurrentRuntimeGeneration(runtimeGeneration)) {
       if (hasConfirmedIcons) {
+        deferredHydrationIcons = null;
         set({ icons: copyIcons(confirmedIcons), loaded: true });
       } else if (deferredHydrationIcons !== null) {
         const icons = copyIcons(deferredHydrationIcons);
@@ -181,7 +185,10 @@ async function applyOptimisticMutation(
       }
     }
   } finally {
-    if (epoch === stateEpoch && !restoredPendingHydration) hydrationRevision += 1;
+    if (epoch === stateEpoch) {
+      pendingMutationCount = Math.max(0, pendingMutationCount - 1);
+      if (!restoredPendingHydration) hydrationRevision += 1;
+    }
   }
 }
 
@@ -197,6 +204,10 @@ export const useDesktopIcons = create<DesktopIconsState>()((set, get) => ({
     const replayable = replayableHydrationRange !== null
       && expectedRevision >= replayableHydrationRange.min
       && expectedRevision <= replayableHydrationRange.max;
+    if (!replayable && pendingMutationCount > 0 && expectedRevision === hydrationRevision) {
+      deferredHydrationIcons = copyIcons(icons);
+      return;
+    }
     if (!replayable
       && !hasConfirmedIcons
       && unconfirmedHydrationRevision !== null
@@ -231,6 +242,10 @@ export const useDesktopIcons = create<DesktopIconsState>()((set, get) => ({
       const replayable = replayableHydrationRange !== null
         && expectedHydrationRevision >= replayableHydrationRange.min
         && expectedHydrationRevision <= replayableHydrationRange.max;
+      if (!replayable && pendingMutationCount > 0 && expectedHydrationRevision === hydrationRevision) {
+        deferredHydrationIcons = copyIcons(icons);
+        return;
+      }
       if (!replayable
         && !hasConfirmedIcons
         && unconfirmedHydrationRevision !== null
@@ -260,6 +275,10 @@ export const useDesktopIcons = create<DesktopIconsState>()((set, get) => ({
       const replayable = replayableHydrationRange !== null
         && expectedHydrationRevision >= replayableHydrationRange.min
         && expectedHydrationRevision <= replayableHydrationRange.max;
+      if (!replayable && pendingMutationCount > 0 && expectedHydrationRevision === hydrationRevision) {
+        deferredHydrationIcons = copyIcons(icons);
+        return;
+      }
       if (!replayable
         && !hasConfirmedIcons
         && unconfirmedHydrationRevision !== null

--- a/desktop/src/renderer/src/stores/desktop-icons.ts
+++ b/desktop/src/renderer/src/stores/desktop-icons.ts
@@ -1,0 +1,138 @@
+import { create } from "zustand";
+import type { ApiClient } from "../lib/api";
+import { captureRuntimeGeneration, isCurrentRuntimeGeneration } from "./runtime-generation";
+
+export interface DesktopIconPlacement {
+  path: string;
+  x: number;
+  y: number;
+}
+
+const MAX_DESKTOP_ICONS = 512;
+const MAX_COORDINATE = 16_384;
+const GRID_X = 88;
+const GRID_Y = 92;
+const GRID_COLUMNS = 2;
+const START_X = 20;
+const START_Y = 20;
+
+function validPlacement(value: unknown): value is DesktopIconPlacement {
+  if (!value || typeof value !== "object") return false;
+  const icon = value as Partial<DesktopIconPlacement>;
+  return typeof icon.path === "string"
+    && icon.path.length > 0
+    && icon.path.length <= 2048
+    && Number.isInteger(icon.x)
+    && Number.isInteger(icon.y)
+    && icon.x! >= 0
+    && icon.y! >= 0
+    && icon.x! <= MAX_COORDINATE
+    && icon.y! <= MAX_COORDINATE;
+}
+
+export function parseDesktopIcons(value: unknown): DesktopIconPlacement[] | null {
+  if (!Array.isArray(value)) return null;
+  const icons: DesktopIconPlacement[] = [];
+  const seen = new Set<string>();
+  for (const raw of value.slice(0, MAX_DESKTOP_ICONS)) {
+    if (!validPlacement(raw) || seen.has(raw.path)) continue;
+    seen.add(raw.path);
+    icons.push({ path: raw.path, x: raw.x, y: raw.y });
+  }
+  return icons;
+}
+
+export function defaultDesktopIcons(paths: readonly string[]): DesktopIconPlacement[] {
+  return paths.slice(0, MAX_DESKTOP_ICONS).map((path, index) => ({
+    path,
+    x: START_X + (index % GRID_COLUMNS) * GRID_X,
+    y: START_Y + Math.floor(index / GRID_COLUMNS) * GRID_Y,
+  }));
+}
+
+function nextOpenSlot(icons: readonly DesktopIconPlacement[]): Pick<DesktopIconPlacement, "x" | "y"> {
+  const occupied = new Set(icons.map((icon) => `${icon.x}:${icon.y}`));
+  for (let index = 0; index < MAX_DESKTOP_ICONS; index += 1) {
+    const candidate = {
+      x: START_X + (index % GRID_COLUMNS) * GRID_X,
+      y: START_Y + Math.floor(index / GRID_COLUMNS) * GRID_Y,
+    };
+    if (!occupied.has(`${candidate.x}:${candidate.y}`)) return candidate;
+  }
+  return { x: START_X, y: START_Y };
+}
+
+interface DesktopIconsState {
+  icons: DesktopIconPlacement[];
+  loaded: boolean;
+  load(api: ApiClient, defaults: readonly DesktopIconPlacement[]): Promise<void>;
+  hydrate(value: unknown, defaults: readonly DesktopIconPlacement[]): void;
+  move(path: string, x: number, y: number, api: ApiClient): Promise<void>;
+  remove(path: string, api: ApiClient): Promise<void>;
+  add(path: string, api: ApiClient): Promise<void>;
+}
+
+let loadSequence = 0;
+let persistQueue: Promise<void> = Promise.resolve();
+
+export function resetDesktopIconsRuntime(): void {
+  loadSequence += 1;
+  useDesktopIcons.setState({ icons: [], loaded: false });
+}
+
+function persist(api: ApiClient, icons: DesktopIconPlacement[]): Promise<void> {
+  const runtimeGeneration = captureRuntimeGeneration();
+  const snapshot = icons.map((icon) => ({ ...icon }));
+  const write = async () => {
+    if (!isCurrentRuntimeGeneration(runtimeGeneration)) return;
+    await api.patch("/api/settings/desktop", { desktopIcons: snapshot });
+  };
+  const pending = persistQueue.then(write, write);
+  persistQueue = pending.catch((error: unknown) => {
+    console.warn("[desktop-icons] persist queue recovered:", error instanceof Error ? error.name : typeof error);
+  });
+  return pending.catch((error: unknown) => {
+    console.warn("[desktop-icons] persist failed:", error instanceof Error ? error.name : typeof error);
+  });
+}
+
+export const useDesktopIcons = create<DesktopIconsState>()((set, get) => ({
+  icons: [],
+  loaded: false,
+  hydrate: (value, defaults) => set({
+    icons: parseDesktopIcons(value) ?? defaults.map((icon) => ({ ...icon })),
+    loaded: true,
+  }),
+  load: async (api, defaults) => {
+    const sequence = ++loadSequence;
+    const runtimeGeneration = captureRuntimeGeneration();
+    try {
+      const config = await api.get<{ desktopIcons?: unknown }>("/api/settings/desktop");
+      if (sequence !== loadSequence || !isCurrentRuntimeGeneration(runtimeGeneration)) return;
+      set({ icons: parseDesktopIcons(config.desktopIcons) ?? defaults.map((icon) => ({ ...icon })), loaded: true });
+    } catch (error: unknown) {
+      if (sequence !== loadSequence || !isCurrentRuntimeGeneration(runtimeGeneration)) return;
+      console.warn("[desktop-icons] load failed:", error instanceof Error ? error.name : typeof error);
+      set({ icons: defaults.map((icon) => ({ ...icon })), loaded: true });
+    }
+  },
+  move: async (path, x, y, api) => {
+    const next = get().icons.map((icon) => icon.path === path
+      ? { ...icon, x: Math.max(0, Math.min(MAX_COORDINATE, Math.round(x))), y: Math.max(0, Math.min(MAX_COORDINATE, Math.round(y))) }
+      : icon);
+    set({ icons: next });
+    await persist(api, next);
+  },
+  remove: async (path, api) => {
+    const next = get().icons.filter((icon) => icon.path !== path);
+    set({ icons: next });
+    await persist(api, next);
+  },
+  add: async (path, api) => {
+    const current = get().icons;
+    if (!path || path.length > 2048 || current.some((icon) => icon.path === path) || current.length >= MAX_DESKTOP_ICONS) return;
+    const next = [...current, { path, ...nextOpenSlot(current) }];
+    set({ icons: next });
+    await persist(api, next);
+  },
+}));

--- a/desktop/src/renderer/src/stores/desktop-icons.ts
+++ b/desktop/src/renderer/src/stores/desktop-icons.ts
@@ -74,9 +74,19 @@ interface DesktopIconsState {
 
 let loadSequence = 0;
 let persistQueue: Promise<void> = Promise.resolve();
+let mutationSequence = 0;
+let stateEpoch = 0;
+let confirmedIcons: DesktopIconPlacement[] = [];
+
+function copyIcons(icons: readonly DesktopIconPlacement[]): DesktopIconPlacement[] {
+  return icons.map((icon) => ({ ...icon }));
+}
 
 export function resetDesktopIconsRuntime(): void {
   loadSequence += 1;
+  mutationSequence += 1;
+  stateEpoch += 1;
+  confirmedIcons = [];
   useDesktopIcons.setState({ icons: [], loaded: false });
 }
 
@@ -91,48 +101,77 @@ function persist(api: ApiClient, icons: DesktopIconPlacement[]): Promise<void> {
   persistQueue = pending.catch((error: unknown) => {
     console.warn("[desktop-icons] persist queue recovered:", error instanceof Error ? error.name : typeof error);
   });
-  return pending.catch((error: unknown) => {
+  return pending;
+}
+
+async function applyOptimisticMutation(
+  api: ApiClient,
+  icons: DesktopIconPlacement[],
+  set: (partial: Partial<DesktopIconsState>) => void,
+): Promise<void> {
+  const sequence = ++mutationSequence;
+  const epoch = stateEpoch;
+  const runtimeGeneration = captureRuntimeGeneration();
+  const snapshot = copyIcons(icons);
+  set({ icons: snapshot });
+  try {
+    await persist(api, snapshot);
+    if (epoch === stateEpoch && sequence <= mutationSequence && isCurrentRuntimeGeneration(runtimeGeneration)) {
+      confirmedIcons = copyIcons(snapshot);
+    }
+  } catch (error: unknown) {
     console.warn("[desktop-icons] persist failed:", error instanceof Error ? error.name : typeof error);
-  });
+    if (epoch === stateEpoch && sequence === mutationSequence && isCurrentRuntimeGeneration(runtimeGeneration)) {
+      set({ icons: copyIcons(confirmedIcons) });
+    }
+  }
 }
 
 export const useDesktopIcons = create<DesktopIconsState>()((set, get) => ({
   icons: [],
   loaded: false,
-  hydrate: (value, defaults) => set({
-    icons: parseDesktopIcons(value) ?? defaults.map((icon) => ({ ...icon })),
-    loaded: true,
-  }),
+  hydrate: (value, defaults) => {
+    const icons = parseDesktopIcons(value) ?? copyIcons(defaults);
+    mutationSequence += 1;
+    stateEpoch += 1;
+    confirmedIcons = copyIcons(icons);
+    set({ icons, loaded: true });
+  },
   load: async (api, defaults) => {
     const sequence = ++loadSequence;
     const runtimeGeneration = captureRuntimeGeneration();
     try {
       const config = await api.get<{ desktopIcons?: unknown }>("/api/settings/desktop");
       if (sequence !== loadSequence || !isCurrentRuntimeGeneration(runtimeGeneration)) return;
-      set({ icons: parseDesktopIcons(config.desktopIcons) ?? defaults.map((icon) => ({ ...icon })), loaded: true });
+      const icons = parseDesktopIcons(config.desktopIcons) ?? copyIcons(defaults);
+      mutationSequence += 1;
+      stateEpoch += 1;
+      confirmedIcons = copyIcons(icons);
+      set({ icons, loaded: true });
     } catch (error: unknown) {
       if (sequence !== loadSequence || !isCurrentRuntimeGeneration(runtimeGeneration)) return;
       console.warn("[desktop-icons] load failed:", error instanceof Error ? error.name : typeof error);
-      set({ icons: defaults.map((icon) => ({ ...icon })), loaded: true });
+      const icons = copyIcons(defaults);
+      mutationSequence += 1;
+      stateEpoch += 1;
+      confirmedIcons = copyIcons(icons);
+      set({ icons, loaded: true });
     }
   },
   move: async (path, x, y, api) => {
     const next = get().icons.map((icon) => icon.path === path
       ? { ...icon, x: Math.max(0, Math.min(MAX_COORDINATE, Math.round(x))), y: Math.max(0, Math.min(MAX_COORDINATE, Math.round(y))) }
       : icon);
-    set({ icons: next });
-    await persist(api, next);
+    await applyOptimisticMutation(api, next, set);
   },
   remove: async (path, api) => {
     const next = get().icons.filter((icon) => icon.path !== path);
-    set({ icons: next });
-    await persist(api, next);
+    await applyOptimisticMutation(api, next, set);
   },
   add: async (path, api) => {
     const current = get().icons;
     if (!path || path.length > 2048 || current.some((icon) => icon.path === path) || current.length >= MAX_DESKTOP_ICONS) return;
     const next = [...current, { path, ...nextOpenSlot(current) }];
-    set({ icons: next });
-    await persist(api, next);
+    await applyOptimisticMutation(api, next, set);
   },
 }));

--- a/desktop/src/renderer/src/stores/desktop-icons.ts
+++ b/desktop/src/renderer/src/stores/desktop-icons.ts
@@ -156,10 +156,7 @@ async function applyOptimisticMutation(
   } catch (error: unknown) {
     console.warn("[desktop-icons] persist failed:", error instanceof Error ? error.name : typeof error);
     if (epoch === stateEpoch && sequence === mutationSequence && isCurrentRuntimeGeneration(runtimeGeneration)) {
-      if (hasConfirmedIcons) {
-        deferredHydrationIcons = null;
-        set({ icons: copyIcons(confirmedIcons), loaded: true });
-      } else if (deferredHydrationIcons !== null) {
+      if (deferredHydrationIcons !== null) {
         const icons = copyIcons(deferredHydrationIcons);
         confirmedIcons = copyIcons(icons);
         hasConfirmedIcons = true;
@@ -170,6 +167,8 @@ async function applyOptimisticMutation(
         hydrationRevision += 1;
         set({ icons, loaded: true });
         restoredPendingHydration = true;
+      } else if (hasConfirmedIcons) {
+        set({ icons: copyIcons(confirmedIcons), loaded: true });
       } else {
         set({ icons: copyIcons(unconfirmedRollbackIcons ?? rollbackIcons), loaded: false });
         if (unconfirmedHydrationRevision !== null) {

--- a/desktop/src/renderer/src/stores/runtime-transition.ts
+++ b/desktop/src/renderer/src/stores/runtime-transition.ts
@@ -23,6 +23,8 @@ import { resetAppsRuntime } from "./apps";
 import { NATIVE_DESKTOP_WINDOW_SHELL } from "../lib/feature-flags";
 import { HOSTED_SHELL_TAB_SPEC } from "../lib/hosted-shell";
 import { useDesktopSurfaces } from "./desktop-surfaces";
+import { resetDesktopIconsRuntime } from "./desktop-icons";
+import { useCreateAppRequest } from "./create-app-request";
 
 interface RuntimeChangeOptions {
   disposeRuntimeAttachments?: () => void;
@@ -66,6 +68,8 @@ export function reconcileDesktopRuntimeChange(options: RuntimeChangeOptions = {}
     terminalSessionRequestSequence: 0,
   });
   useDesktopSurfaces.setState(useDesktopSurfaces.getInitialState(), true);
+  resetDesktopIconsRuntime();
+  useCreateAppRequest.setState({ request: null });
   // The native window shell intentionally returns to its icon desktop. The
   // legacy renderer still needs a hosted-shell root because it has no desktop.
   if (!NATIVE_DESKTOP_WINDOW_SHELL) useTabs.getState().openTab(HOSTED_SHELL_TAB_SPEC);

--- a/desktop/src/renderer/src/stores/shell-sessions.ts
+++ b/desktop/src/renderer/src/stores/shell-sessions.ts
@@ -9,6 +9,8 @@ export type ShellVisualStatus = "running" | "waiting" | "finished" | "idle";
 
 export interface ShellSessionSummary {
   name: string;
+  cwd?: string;
+  pinned?: boolean;
   status?: "active" | "exited" | "degraded";
   placement?: ShellSessionPlacement;
   createdAt?: string;
@@ -32,7 +34,7 @@ export interface ShellSessionSummary {
   tabs?: Array<{ idx: number; name?: string; focused?: boolean }>;
 }
 
-export type ShellUiStatePatch = Partial<Pick<ShellSessionSummary, "placement" | "lastSeenSeq">>;
+export type ShellUiStatePatch = Partial<Pick<ShellSessionSummary, "placement" | "lastSeenSeq" | "pinned">>;
 export interface ShellSessionCreateOptions {
   cmd?: string;
   agent?: NonNullable<ShellSessionSummary["agent"]>;
@@ -81,11 +83,20 @@ function asArray<T>(value: unknown): T[] {
   return Array.isArray(value) ? (value as T[]) : [];
 }
 
+function isSafeDisplayCwd(value: unknown): value is string {
+  if (typeof value !== "string" || value.length === 0 || value.length > 4096 || value.includes("\0")) return false;
+  if (value === "~") return true;
+  if (value.startsWith("/") || value.startsWith("\\")) return false;
+  return !value.split(/[\\/]/).some((segment) => segment === "..");
+}
+
 function asShellSession(value: unknown): ShellSessionSummary | null {
   if (!value || typeof value !== "object") return null;
   const record = value as Record<string, unknown>;
   if (typeof record.name !== "string" || !isValidShellSessionName(record.name)) return null;
   const shell: ShellSessionSummary = { name: record.name };
+  if (isSafeDisplayCwd(record.cwd)) shell.cwd = record.cwd;
+  if (typeof record.pinned === "boolean") shell.pinned = record.pinned;
   if (record.status === "active" || record.status === "exited" || record.status === "degraded") shell.status = record.status;
   if (record.placement === "active" || record.placement === "background") shell.placement = record.placement;
   if (typeof record.createdAt === "string") shell.createdAt = record.createdAt;
@@ -340,6 +351,7 @@ export const useShellSessions = create<ShellSessionsState>()((set, get) => ({
         : {
             sessions: [{
               name,
+              cwd: DEFAULT_CWD,
               status: "active",
               placement: "active",
               attachCommand: shellConnectCommand(name),

--- a/desktop/src/shared/runtime-browser-url.ts
+++ b/desktop/src/shared/runtime-browser-url.ts
@@ -5,7 +5,7 @@ export type BrowserAddressResolution =
       remoteHost: "127.0.0.1" | "::1" | "localhost";
       remotePort: number;
     }
-  | { disposition: "external"; url: string };
+  | { disposition: "public"; url: string };
 
 export type RuntimeBrowserNavigationDecision =
   | { disposition: "rewrite"; url: string }
@@ -53,7 +53,7 @@ export function resolveBrowserAddress(value: string): BrowserAddressResolution |
 
   if (!urlInput) {
     const params = new URLSearchParams({ q: input });
-    return { disposition: "external", url: `https://www.google.com/search?${params.toString()}` };
+    return { disposition: "public", url: `https://www.google.com/search?${params.toString()}` };
   }
 
   const parsed = parseHttpUrl(urlInput);
@@ -73,7 +73,7 @@ export function resolveBrowserAddress(value: string): BrowserAddressResolution |
       remotePort,
     };
   }
-  return { disposition: "external", url: parsed.toString() };
+  return { disposition: "public", url: parsed.toString() };
 }
 
 export function resolveRuntimeBrowserNavigation(
@@ -94,7 +94,7 @@ export function resolveRuntimeBrowserNavigation(
   // to the user's browser: a DNS alias or rebinding response could otherwise
   // reach loopback/private services outside the authenticated tunnel. Public
   // URLs entered directly in BrowserTab still use resolveBrowserAddress().
-  if (resolved.disposition === "external") return { disposition: "block" };
+  if (resolved.disposition === "public") return { disposition: "block" };
   if (resolved.remotePort !== remotePort) return { disposition: "block" };
 
   local.pathname = target.pathname;

--- a/packages/gateway/src/routes/settings.ts
+++ b/packages/gateway/src/routes/settings.ts
@@ -77,6 +77,12 @@ const DesktopDockPatchSchema = z.object({
   autoHide: z.boolean().optional(),
 }).strict();
 
+const DesktopIconSchema = z.object({
+  path: z.string().min(1).max(2048),
+  x: z.number().int().min(0).max(16_384),
+  y: z.number().int().min(0).max(16_384),
+}).strict();
+
 const DesktopPatchSchema = z.object({
   background: DesktopBackgroundSchema.optional(),
   dock: DesktopDockPatchSchema.optional(),
@@ -86,6 +92,7 @@ const DesktopPatchSchema = z.object({
     userApps: z.array(z.string().min(1).max(2048)).max(512).optional(),
     systemApps: z.array(z.string().min(1).max(2048)).max(512).optional(),
   }).strict().optional(),
+  desktopIcons: z.array(DesktopIconSchema).max(512).optional(),
 }).strict().refine((patch) => Object.keys(patch).length > 0, "Patch cannot be empty");
 
 const WALLPAPER_FILE_EXTENSIONS = new Set([

--- a/packages/gateway/src/shell/focused-pane-runtime.ts
+++ b/packages/gateway/src/shell/focused-pane-runtime.ts
@@ -1,6 +1,8 @@
 export interface FocusedPaneRuntimeObservation {
   cwd: string | null;
   command: string | null;
+  /** Title emitted by the active terminal application, when available. */
+  title?: string;
   observed: boolean;
 }
 

--- a/packages/gateway/src/shell/registry.ts
+++ b/packages/gateway/src/shell/registry.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { isAbsolute, join, relative, sep } from "node:path";
 import { z } from "zod/v4";
 import { writeUtf8FileAtomic } from "./atomic-write.js";
 import {
@@ -10,6 +10,7 @@ import {
   AgentKindSchema,
   AgentSessionStateStore,
   deriveAgentVisualStatus,
+  sanitizeAgentSubtitle,
   type AgentKind,
   type AgentSessionSnapshot,
 } from "./agent-session-state.js";
@@ -33,6 +34,33 @@ const ShellSessionReferenceSchema = z.object({
 const SHELL_RUNNING_FALLBACK_WINDOW_MS = 12_000;
 const MAX_CONCURRENT_SESSION_DECORATIONS = 8;
 const VERIFIED_RUNTIME_INCARNATION = Symbol("verified-runtime-incarnation");
+
+function publicShellCwd(homePath: string, cwd: string): { cwd: string } | Record<string, never> {
+  const homeRelative = relative(homePath, cwd);
+  if (homeRelative === "") return { cwd: "~" };
+  if (isAbsolute(homeRelative) || homeRelative === ".." || homeRelative.startsWith(`..${sep}`)) return {};
+  return { cwd: homeRelative };
+}
+
+function activeAgentTitle(
+  sessionName: string,
+  agent: AgentKind | undefined,
+  paneTitle: string | undefined,
+): string | undefined {
+  if (!agent || !paneTitle) return undefined;
+  const title = sanitizeAgentSubtitle(paneTitle);
+  if (!title) return undefined;
+  const genericTitles = new Set([
+    sessionName.toLowerCase(),
+    agent,
+    "claude code",
+    "codex",
+    "opencode",
+    "pi",
+    "terminal",
+  ]);
+  return genericTitles.has(title.toLowerCase()) ? undefined : title;
+}
 
 export interface ShellRegistryAdapter {
   listSessions(): Promise<string[]>;
@@ -71,6 +99,7 @@ const ShellSessionSchema = z.object({
   visualStatusUpdatedAt: z.string().optional(),
   agent: AgentKindSchema.optional(),
   cwd: z.string().max(4096).optional(),
+  pinned: z.boolean().optional(),
 });
 
 const RegistryFileSchema = z.object({
@@ -92,6 +121,8 @@ export interface ShellSessionAlias {
   source: ShellSessionAliasSource;
 }
 export type ShellSession = Omit<PersistedShellSession, "cwd"> & {
+  /** Home-relative active pane path; absolute host paths are never exposed. */
+  cwd?: string;
   canonicalName: string;
   latestSeq: number | null;
   unread: boolean;
@@ -118,6 +149,7 @@ export type ShellSession = Omit<PersistedShellSession, "cwd"> & {
 export interface ShellSessionUiStatePatch {
   placement?: ShellPlacement;
   lastSeenSeq?: number | null;
+  pinned?: boolean;
   /** @deprecated Accepted for one compatibility release and intentionally ignored. */
   visualStatus?: ShellVisualStatus;
 }
@@ -145,6 +177,7 @@ export class ShellRegistry {
   private readonly persistPath: string;
   private readonly agentStateStore: ShellAgentStateStore;
   private readonly gitContextResolver: { resolve(input: TerminalGitContextInput): Promise<TerminalGitContext | null> };
+  private readonly resolvedHomePath: Promise<string>;
   private mutationQueue: Promise<void> = Promise.resolve();
 
   constructor(private readonly options: ShellRegistryOptions) {
@@ -152,6 +185,7 @@ export class ShellRegistry {
       options.persistPath ?? join(options.homePath, "system", "shell-sessions.json");
     this.agentStateStore = options.agentStateStore ?? new AgentSessionStateStore({ homePath: options.homePath });
     this.gitContextResolver = options.gitContextResolver ?? new TerminalGitContextResolver({ homePath: options.homePath });
+    this.resolvedHomePath = resolveShellCwd("~", options.homePath);
   }
 
   async list(): Promise<ShellSession[]> {
@@ -318,6 +352,7 @@ export class ShellRegistry {
         updatedAt: now,
         ...(patch.placement !== undefined ? { placement: patch.placement } : {}),
         ...(patch.lastSeenSeq !== undefined ? { lastSeenSeq: patch.lastSeenSeq } : {}),
+        ...(patch.pinned !== undefined ? { pinned: patch.pinned } : {}),
       };
       delete next.visualStatus;
       delete next.visualStatusUpdatedAt;
@@ -567,9 +602,10 @@ export class ShellRegistry {
     const unread = latestSeq !== null && lastSeenSeq !== null && latestSeq > lastSeenSeq;
     const references = file ? this.referencesForTarget(file, session.name) : [];
     const recoverable = session.status === "exited" && references.length > 0;
+    const activeCwd = focusedPaneRuntime.cwd ?? session.cwd;
     const gitContext = await this.readGitContext({
       sessionName: session.name,
-      cwd: focusedPaneRuntime.cwd ?? session.cwd,
+      cwd: activeCwd,
     });
     const observedAgent = focusedPaneRuntime.observed
       ? inferAgentFromCommand(focusedPaneRuntime.command ?? undefined)
@@ -590,16 +626,23 @@ export class ShellRegistry {
     const liveAgent = focusedPaneRuntime.observed
       ? observedAgent
       : compatibleSnapshot?.agent ?? launchHintAgent;
+    const paneSubtitle = activeAgentTitle(session.name, liveAgent, focusedPaneRuntime.title);
     const agentVisualStatus = liveAgent
       ? deriveAgentVisualStatus(compatibleSnapshot, unread) ?? "running"
       : null;
     const visualStatus = agentVisualStatus
       ?? this.deriveVisualStatus(session, unread, activity);
+    const displayCwd = activeCwd
+      ? publicShellCwd(await this.resolvedHomePath, activeCwd)
+      : {};
     const { cwd: _internalCwd, agent: _launchHint, ...publicSession } = session;
     return {
       ...publicSession,
+      ...displayCwd,
       ...(liveAgent ? { agent: liveAgent } : {}),
-      ...(compatibleSnapshot?.subtitle ? { subtitle: compatibleSnapshot.subtitle } : {}),
+      ...(compatibleSnapshot?.subtitle || paneSubtitle
+        ? { subtitle: compatibleSnapshot?.subtitle ?? paneSubtitle }
+        : {}),
       ...(compatibleSnapshot?.lastAction ? { lastAction: compatibleSnapshot.lastAction } : {}),
       ...(compatibleSnapshot?.agentUpdatedAt ? { agentUpdatedAt: compatibleSnapshot.agentUpdatedAt } : {}),
       ...(compatibleSnapshot?.model ? { model: compatibleSnapshot.model } : {}),

--- a/packages/gateway/src/shell/routes.ts
+++ b/packages/gateway/src/shell/routes.ts
@@ -165,6 +165,7 @@ const PasteAssetQuerySchema = z.object({
 const SessionUiStateBodySchema = z.object({
   placement: z.enum(["active", "background"]).optional(),
   lastSeenSeq: z.number().int().nonnegative().nullable().optional(),
+  pinned: z.boolean().optional(),
   visualStatus: z.enum(["running", "finished", "idle", "waiting"]).optional(),
 }).strict().refine((value) => Object.keys(value).length > 0);
 const SessionRenameBodySchema = z.object({

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -125,6 +125,7 @@ const ZellijPaneListSchema = z.array(z.object({
   tab_id: z.number().int().nonnegative(),
   pane_cwd: z.string().min(1).max(4096).nullable().optional(),
   pane_command: z.string().trim().min(1).max(4096).nullable().optional(),
+  pane_title: z.string().trim().min(1).max(4096).nullable().optional(),
 }).passthrough()).max(256);
 
 const SAFE_ATTACH_ENV_KEYS = new Set([
@@ -492,6 +493,7 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
         const value: FocusedPaneRuntimeObservation = {
           cwd: focusedPane.pane_cwd ?? null,
           command: focusedPane.pane_command,
+          ...(focusedPane.pane_title ? { title: focusedPane.pane_title } : {}),
           observed: true,
         };
         return cacheFocusedPaneRuntime(name, value);

--- a/shell/src/app/globals.css
+++ b/shell/src/app/globals.css
@@ -3,6 +3,19 @@
 @import "shadcn/tailwind.css";
 @import "@clerk/ui/themes/shadcn.css";
 
+/* Opt-in command-list motion: immediate entry, delayed fade on exit. */
+[data-instant-list-hover] {
+  transition-delay: 75ms;
+  transition-duration: 180ms;
+  transition-property: background-color, color;
+  transition-timing-function: ease-out;
+}
+
+[data-instant-list-hover][data-selected="true"] {
+  transition-delay: 0ms;
+  transition-duration: 0ms;
+}
+
 @font-face {
   font-family: "MesloLGS NF";
   src: url("/fonts/meslo/MesloLGS%20NF%20Regular.ttf") format("truetype");

--- a/shell/src/components/AppTile.tsx
+++ b/shell/src/components/AppTile.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { PinIcon, RefreshCwIcon, PencilIcon, EyeOffIcon } from "@/lib/hugeicons";
+import { PinIcon, PlusIcon, RefreshCwIcon, PencilIcon, EyeOffIcon } from "@/lib/hugeicons";
 import { useIconWithFallback } from "@/hooks/useIconWithFallback";
 import {
   ContextMenu,
@@ -19,15 +19,18 @@ interface AppTileProps {
   onRegenerateIcon?: () => void;
   onRename?: (newName: string) => void;
   onRemoveFromCanvas?: () => void;
+  createApp?: boolean;
+  onAddToDesktop?: () => void;
 }
 
-export function AppTile({ name, isOpen, onClick, pinned, onTogglePin, iconUrl, onRegenerateIcon, onRename, onRemoveFromCanvas }: AppTileProps) {
+export function AppTile({ name, isOpen, onClick, pinned, onTogglePin, iconUrl, onRegenerateIcon, onRename, onRemoveFromCanvas, createApp = false, onAddToDesktop }: AppTileProps) {
   const initial = name.charAt(0).toUpperCase();
   const { showImage, onError: onImgError } = useIconWithFallback(iconUrl);
 
   const tile = (
     <button
       type="button"
+      aria-label={name}
       onClick={onClick}
       data-app-tile
       className="relative flex flex-col items-center gap-1.5 p-1.5 rounded-xl hover:bg-accent/50 transition-colors group"
@@ -41,7 +44,9 @@ export function AppTile({ name, isOpen, onClick, pinned, onTogglePin, iconUrl, o
               : "bg-card border border-border/60 text-foreground group-hover:shadow-md"
           }`}
         >
-          {showImage ? (
+          {createApp ? (
+            <PlusIcon className="size-12" aria-hidden="true" />
+          ) : showImage ? (
             // react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- app icon served from a runtime gateway host (/icons/{slug}.png) that cannot be statically configured for next/image
             <img src={iconUrl} alt={name} className="size-full object-cover" onError={onImgError} />
           ) : (
@@ -86,7 +91,7 @@ export function AppTile({ name, isOpen, onClick, pinned, onTogglePin, iconUrl, o
     </button>
   );
 
-  const hasContextMenu = onTogglePin || onRegenerateIcon || onRename || onRemoveFromCanvas;
+  const hasContextMenu = onTogglePin || onRegenerateIcon || onRename || onRemoveFromCanvas || onAddToDesktop;
   if (!hasContextMenu) return tile;
 
   return (
@@ -95,6 +100,12 @@ export function AppTile({ name, isOpen, onClick, pinned, onTogglePin, iconUrl, o
         {tile}
       </ContextMenuTrigger>
       <ContextMenuContent>
+        {onAddToDesktop && (
+          <ContextMenuItem onSelect={onAddToDesktop}>
+            <PlusIcon className="size-3.5 mr-2" />
+            Add to Desktop
+          </ContextMenuItem>
+        )}
         {onTogglePin && (
           <ContextMenuItem onSelect={onTogglePin}>
             <PinIcon className="size-3.5 mr-2" />

--- a/shell/src/components/ChatApp.tsx
+++ b/shell/src/components/ChatApp.tsx
@@ -100,6 +100,8 @@ interface ChatAppProps {
     files?: Array<{ name: string; type: string; data: string }>,
     options?: { displayText?: string; promptText?: string },
   ) => void;
+  composerDraftRequest?: { id: number; text: string } | null;
+  onComposerDraftConsumed?: (id: number) => void;
   mobile?: boolean;
 }
 
@@ -139,6 +141,8 @@ export function ChatApp({
   onNewChat,
   onSwitchConversation,
   onSubmit,
+  composerDraftRequest,
+  onComposerDraftConsumed,
   mobile = false,
   // react-doctor-disable-next-line react-doctor/prefer-useReducer -- these useState fields (sidebarOpen, searchQuery, setupOpen, model, channels) are independent UI concerns with separate update sites and lifecycles, not one related state machine; collapsing them into a reducer would couple unrelated transitions and is not a mechanical, behavior-identical change.
 }: ChatAppProps) {
@@ -342,6 +346,8 @@ export function ChatApp({
             suggestions={suggestions}
             mobile={mobile}
             model={model}
+            composerDraftRequest={composerDraftRequest}
+            onComposerDraftConsumed={onComposerDraftConsumed}
           />
         ) : (
           <div className="flex flex-1 flex-col min-h-0">
@@ -394,7 +400,13 @@ export function ChatApp({
                   />
                 </div>
               )}
-              <ChatInput connected={connected} busy={busy} onSubmit={submitWithHermesSetup} />
+              <ChatInput
+                connected={connected}
+                busy={busy}
+                onSubmit={submitWithHermesSetup}
+                draftRequest={composerDraftRequest}
+                onDraftConsumed={onComposerDraftConsumed}
+              />
             </div>
           </div>
         )}
@@ -409,12 +421,16 @@ function EmptyState({
   suggestions,
   mobile,
   model,
+  composerDraftRequest,
+  onComposerDraftConsumed,
 }: {
   onSubmit: (text: string) => void;
   connected: boolean;
   suggestions: string[];
   mobile: boolean;
   model: string;
+  composerDraftRequest?: { id: number; text: string } | null;
+  onComposerDraftConsumed?: (id: number) => void;
 }) {
   return (
     <div className="flex flex-1 flex-col items-center justify-center px-4">
@@ -428,7 +444,14 @@ function EmptyState({
         </div>
 
         {/* Input */}
-        <ChatInput connected={connected} busy={false} onSubmit={onSubmit} autoFocus={!mobile} />
+        <ChatInput
+          connected={connected}
+          busy={false}
+          onSubmit={onSubmit}
+          autoFocus={!mobile}
+          draftRequest={composerDraftRequest}
+          onDraftConsumed={onComposerDraftConsumed}
+        />
 
         {/* Suggestions */}
         {suggestions.length > 0 && (
@@ -559,11 +582,15 @@ function ChatInput({
   busy,
   onSubmit,
   autoFocus,
+  draftRequest,
+  onDraftConsumed,
 }: {
   connected: boolean;
   busy: boolean;
   onSubmit: (text: string, files?: Array<{ name: string; type: string; data: string }>) => void;
   autoFocus?: boolean;
+  draftRequest?: { id: number; text: string } | null;
+  onDraftConsumed?: (id: number) => void;
 }) {
   const [input, setInput] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -584,6 +611,13 @@ function ChatInput({
     // react-doctor-disable-next-line react-doctor/no-event-handler -- focusing a DOM ref when the composer mounts or autoFocus turns on is a legitimate effect, not a user-event side effect that belongs in a parent handler
     if (autoFocus) textareaRef.current?.focus();
   }, [autoFocus]);
+
+  useEffect(() => {
+    if (!draftRequest) return;
+    setInput(draftRequest.text);
+    textareaRef.current?.focus();
+    onDraftConsumed?.(draftRequest.id);
+  }, [draftRequest, onDraftConsumed]);
 
   const handleSubmit = async (e?: React.FormEvent) => {
     e?.preventDefault();

--- a/shell/src/components/CommandPalette.tsx
+++ b/shell/src/components/CommandPalette.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useCommandStore, type Command } from "@/stores/commands";
 import {
   CommandDialog,
@@ -31,22 +31,37 @@ export function CommandPalette({
   const commands = useCommandStore((s) => s.commands);
 
   const listRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [category, setCategory] = useState<"all" | "apps" | "actions" | "settings">("all");
+  const [query, setQuery] = useState("");
   const handleInputChange = () => {
     requestAnimationFrame(() => {
       listRef.current?.scrollTo({ top: 0 });
     });
   };
 
-  const { apps, actions } = (() => {
+  useEffect(() => {
+    if (!open) return;
+    setCategory("all");
+    setQuery("");
+    inputRef.current?.focus();
+    const frame = window.requestAnimationFrame(() => inputRef.current?.focus());
+    return () => window.cancelAnimationFrame(frame);
+  }, [open]);
+
+  const { apps, actions, settings } = (() => {
     const apps: Command[] = [];
     const actions: Command[] = [];
-    const grouped = { apps, actions };
+    const settings: Command[] = [];
+    const grouped = { apps, actions, settings };
     for (const cmd of commands.values()) {
       if (cmd.group === "Apps") apps.push(cmd);
+      else if (cmd.id.includes("settings") || cmd.keywords?.some((keyword) => keyword === "settings" || keyword === "preferences")) settings.push(cmd);
       else actions.push(cmd);
     }
     apps.sort((a, b) => a.label.localeCompare(b.label));
     actions.sort((a, b) => a.label.localeCompare(b.label));
+    settings.sort((a, b) => a.label.localeCompare(b.label));
     return grouped;
   })();
 
@@ -55,15 +70,52 @@ export function CommandPalette({
       open={open}
       onOpenChange={onOpenChange}
       showCloseButton={false}
-      className="top-[20%] translate-y-0 z-[60] max-w-[520px]"
+      className="top-[8%] translate-y-0 z-[60] max-w-[760px] rounded-2xl"
     >
-      <CommandInput placeholder="Search commands..." onValueChange={handleInputChange} />
-      <CommandList ref={listRef}>
+      <div className="relative">
+        <CommandInput
+          ref={inputRef}
+          value={query}
+          placeholder="Type a command or search…"
+          className="h-16 rounded-none pr-16 text-lg focus-visible:border-transparent focus-visible:ring-0 focus-visible:shadow-none"
+          onValueChange={(value: string) => {
+            setQuery(value);
+            handleInputChange();
+          }}
+        />
+        <kbd className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 rounded-full border px-2.5 py-1 text-xs text-muted-foreground">⌘K</kbd>
+      </div>
+      <div role="tablist" aria-label="Command categories" className="flex h-11 items-stretch gap-1 border-b px-4">
+        {([
+          ["all", "All"],
+          ["apps", "Apps"],
+          ["actions", "Actions"],
+          ["settings", "Settings"],
+        ] as const).map(([id, label]) => (
+          <button
+            key={id}
+            type="button"
+            role="tab"
+            aria-selected={category === id}
+            className="relative px-3 text-sm font-medium text-muted-foreground aria-selected:text-foreground"
+            onClick={() => {
+              setCategory(id);
+              setQuery("");
+              window.requestAnimationFrame(() => inputRef.current?.focus());
+            }}
+          >
+            {label}
+            {category === id ? <span className="absolute inset-x-2 bottom-0 h-0.5 rounded-full bg-primary" /> : null}
+          </button>
+        ))}
+      </div>
+      <CommandList ref={listRef} className="max-h-[min(560px,68vh)] p-2">
         <CommandEmpty>No commands found.</CommandEmpty>
-        {apps.length > 0 && (
+        {(category === "all" || category === "apps") && apps.length > 0 && (
           <CommandGroup heading="Apps">
             {apps.map((cmd) => (
               <CommandItem
+                data-instant-list-hover
                 key={cmd.id}
                 value={[cmd.label, ...(cmd.keywords ?? [])].join(" ")}
                 onSelect={() => {
@@ -87,10 +139,11 @@ export function CommandPalette({
             ))}
           </CommandGroup>
         )}
-        {actions.length > 0 && (
+        {(category === "all" || category === "actions") && actions.length > 0 && (
           <CommandGroup heading="Actions">
             {actions.map((cmd) => (
               <CommandItem
+                data-instant-list-hover
                 key={cmd.id}
                 value={[cmd.label, ...(cmd.keywords ?? [])].join(" ")}
                 onSelect={() => {
@@ -102,6 +155,24 @@ export function CommandPalette({
                 {cmd.shortcut && (
                   <CommandShortcut>{formatShortcut(cmd.shortcut)}</CommandShortcut>
                 )}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+        {(category === "all" || category === "settings") && settings.length > 0 && (
+          <CommandGroup heading="Settings">
+            {settings.map((cmd) => (
+              <CommandItem
+                data-instant-list-hover
+                key={cmd.id}
+                value={[cmd.label, ...(cmd.keywords ?? [])].join(" ")}
+                onSelect={() => {
+                  cmd.execute();
+                  onOpenChange(false);
+                }}
+              >
+                <span>{cmd.label}</span>
+                {cmd.shortcut && <CommandShortcut>{formatShortcut(cmd.shortcut)}</CommandShortcut>}
               </CommandItem>
             ))}
           </CommandGroup>

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -448,6 +448,27 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
     }
   }, [focusCanvasWindow, openWindow, wmRestoreAndFocusWindow]);
 
+  // Keep every app entry point on one routing path. Some installed catalog
+  // apps (notably Browser) intentionally map to shell-owned behavior instead
+  // of AppViewer, so dock, command-palette, launcher, and deep-link launches
+  // must all resolve them before opening a window.
+  const openAppOrFocus = useCallback((path: string, name?: string) => {
+    const builtInLaunch = resolveWebDesktopBuiltInLaunch(path, name);
+    if (builtInLaunch?.kind === "external") {
+      window.open(builtInLaunch.url, "_blank", "noopener,noreferrer");
+      return;
+    }
+    if (builtInLaunch?.kind === "external-code") {
+      window.open(getCodeEditorUrl(), "_blank", "noopener,noreferrer");
+      return;
+    }
+    if (builtInLaunch?.kind === "app") {
+      focusOrOpen(builtInLaunch.name, builtInLaunch.path);
+      return;
+    }
+    focusOrOpen(name ?? apps.find((app) => app.path === path)?.name ?? "App", path);
+  }, [apps, focusOrOpen]);
+
   const openSetupTerminal = (action: TerminalLaunchAction) => {
     const windows = useWindowManager.getState().windows;
     const focusedId = useWindowManager.getState().focusedWindowId;
@@ -493,7 +514,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
     const currentApps = useWindowManager.getState().apps;
     const match = findAppByName(currentApps, query);
     if (match) {
-      focusOrOpen(match.name, match.path);
+      openAppOrFocus(match.path, match.name);
       return { success: true, resolvedName: match.name };
     }
     return { success: false };
@@ -504,8 +525,8 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
     const match = useWindowManager.getState().apps.find((app) => app.path === launchAppPath);
     if (!match) return;
     launchPathConsumedRef.current = launchAppPath;
-    focusOrOpen(match.name, match.path);
-  }, [apps, focusOrOpen, launchAppPath]);
+    openAppOrFocus(match.path, match.name);
+  }, [apps, launchAppPath, openAppOrFocus]);
 
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- identity consumed by the module-load useEffect dependency array (L~1070); a fresh function each render would re-run the layout/modules/apps fetch on every render
   const loadModules = useCallback(async (signal?: AbortSignal) => {
@@ -897,10 +918,6 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
   };
 
   const toggleMcRef = useRef(() => { setTaskBoardOpen((prev) => !prev); setSettingsOpen(false); });
-  const openWindowRef = useRef(openWindow);
-  useEffect(() => {
-    openWindowRef.current = openWindow;
-  }, [openWindow]);
 
   // react-doctor-disable-next-line react-doctor/no-cascading-set-state -- false positive: the setState calls counted here (setDesktopMode, setSettingsOpen, setTaskBoardOpen) live inside command `execute` handlers that only fire on user invocation; this effect just registers/unregisters command-palette entries and runs no setState synchronously, so there is no render cascade
   useEffect(() => {
@@ -1096,11 +1113,11 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
       group: "Apps" as const,
       icon: app.iconUrl,
       keywords: [app.path],
-      execute: () => openWindowRef.current(app.name, app.path),
+      execute: () => openAppOrFocus(app.path, app.name),
     }));
     if (appCommands.length > 0) register(appCommands);
     return () => unregister(apps.map((a) => `app:${a.path}`));
-  }, [apps, register, unregister]);
+  }, [apps, openAppOrFocus, register, unregister]);
 
   useEffect(() => {
     if (!fullscreenWindowId) return;
@@ -1117,25 +1134,6 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
       onOpenGuide={() => setManualSetupVisible(true)}
     />
   ) : null;
-
-  // Shared by the Windows taskbar (start menu, quick launch) and the XP
-  // desktop icons: open the app window or focus the existing one.
-  const openAppOrFocus = (path: string, name?: string) => {
-    const builtInLaunch = resolveWebDesktopBuiltInLaunch(path, name);
-    if (builtInLaunch?.kind === "external") {
-      window.open(builtInLaunch.url, "_blank", "noopener,noreferrer");
-      return;
-    }
-    if (builtInLaunch?.kind === "external-code") {
-      window.open(getCodeEditorUrl(), "_blank", "noopener,noreferrer");
-      return;
-    }
-    if (builtInLaunch?.kind === "app") {
-      focusOrOpen(builtInLaunch.name, builtInLaunch.path);
-      return;
-    }
-    focusOrOpen(name ?? apps.find((a) => a.path === path)?.name ?? "App", path);
-  };
 
   const launcherApps = useMemo(() => {
     const firstClass = [
@@ -1162,24 +1160,9 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
       setChatOpen(false);
       return;
     }
-    const builtInLaunch = resolveWebDesktopBuiltInLaunch(path, name);
-    if (builtInLaunch?.kind === "external") {
-      window.open(builtInLaunch.url, "_blank", "noopener,noreferrer");
-      setTaskBoardOpen(false);
-      return;
-    }
-    if (builtInLaunch?.kind === "external-code") {
-      window.open(getCodeEditorUrl(), "_blank", "noopener,noreferrer");
-      setTaskBoardOpen(false);
-      return;
-    }
-    if (builtInLaunch?.kind === "app") {
-      focusOrOpen(builtInLaunch.name, builtInLaunch.path);
-      setTaskBoardOpen(false);
-      return;
-    }
-    focusOrOpen(name, path);
-  }, [focusOrOpen]);
+    openAppOrFocus(path, name);
+    setTaskBoardOpen(false);
+  }, [openAppOrFocus]);
 
   if (firstRunStatus === "checking") {
     return (
@@ -1304,7 +1287,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
                       <DockIcon
                         name={app.name}
                         active={hasAny}
-                        onClick={() => focusOrOpen(app.name, app.path)}
+                        onClick={() => openAppOrFocus(app.path, app.name)}
                         iconSize={dock.iconSize}
                         tooltipSide={tooltipSide}
                         iconUrl={app.iconUrl}
@@ -1411,7 +1394,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
                       key={app.path}
                       name={app.name}
                       active={hasAny}
-                      onClick={() => focusOrOpen(app.name, app.path)}
+                      onClick={() => openAppOrFocus(app.path, app.name)}
                       iconSize={dock.iconSize}
                       tooltipSide={tooltipSide}
                       iconUrl={app.iconUrl}

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef, type ReactNode } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef, type ReactNode } from "react";
 import { useFileWatcher } from "@/hooks/useFileWatcher";
 import { useWindowManager, type LayoutWindow } from "@/hooks/useWindowManager";
 import { useCommandStore } from "@/stores/commands";
@@ -157,6 +157,10 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
   const togglePin = useDesktopConfigStore((s) => s.togglePin);
   const dockOrder = useDesktopConfigStore((s) => s.dockOrder);
   const reorderDockSection = useDesktopConfigStore((s) => s.reorderDockSection);
+  const desktopIcons = useDesktopConfigStore((s) => s.desktopIcons);
+  const moveDesktopIcon = useDesktopConfigStore((s) => s.moveDesktopIcon);
+  const removeDesktopIcon = useDesktopConfigStore((s) => s.removeDesktopIcon);
+  const addDesktopIcon = useDesktopConfigStore((s) => s.addDesktopIcon);
   const appLaunchTimes = useWindowManager((s) => s.appLaunchTimes);
   const isHorizontal = dock.position === "bottom";
   const tooltipSide: "left" | "right" | "top" = dock.position === "left" ? "right" : dock.position === "right" ? "left" : "top";
@@ -1114,8 +1118,59 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
 
   // Shared by the Windows taskbar (start menu, quick launch) and the XP
   // desktop icons: open the app window or focus the existing one.
-  const openAppOrFocus = (path: string, name?: string) =>
+  const openAppOrFocus = (path: string, name?: string) => {
+    if (path === "__browser__") {
+      window.open("https://www.google.com", "_blank", "noopener,noreferrer");
+      return;
+    }
+    if (path === "__vscode__") {
+      window.open(getCodeEditorUrl(), "_blank", "noopener,noreferrer");
+      return;
+    }
+    if (path === "__editor__") {
+      focusOrOpen("Files", "__file-browser__");
+      return;
+    }
     focusOrOpen(name ?? apps.find((a) => a.path === path)?.name ?? "App", path);
+  };
+
+  const launcherApps = useMemo(() => {
+    const firstClass = [
+      apps.find((app) => app.path === "__chat__") ? { ...apps.find((app) => app.path === "__chat__")!, name: "Chat" } : { name: "Chat", path: "__chat__" },
+      apps.find((app) => app.path === "__terminal__") ?? { name: "Terminal", path: "__terminal__" },
+      apps.find((app) => app.path === "__file-browser__") ?? { name: "Files", path: "__file-browser__" },
+      { name: "Editor", path: "__editor__" },
+      { name: "VS Code", path: "__vscode__", iconUrl: "/vscode.png" },
+      { name: "Settings", path: "__settings__" },
+      { name: "Plugins", path: "__plugins__" },
+      apps.find((app) => app.name.toLowerCase() === "browser") ?? { name: "Browser", path: "__browser__" },
+      apps.find((app) => app.name.toLowerCase() === "notes") ?? { name: "Notes", path: "apps/notes/index.html" },
+      apps.find((app) => app.name.toLowerCase() === "whiteboard") ?? { name: "Whiteboard", path: "apps/whiteboard/index.html" },
+    ];
+    const firstClassPaths = new Set(firstClass.map((app) => app.path));
+    return [...firstClass, ...apps.filter((app) => !firstClassPaths.has(app.path))];
+  }, [apps]);
+
+  const openLauncherDestination = useCallback((name: string, path: string) => {
+    if (path === "__settings__" || path === "__plugins__") {
+      setSettingsDefaultSection(path === "__plugins__" ? "integrations" : "appearance");
+      setSettingsOpen(true);
+      setTaskBoardOpen(false);
+      setChatOpen(false);
+      return;
+    }
+    if (path === "__vscode__") {
+      window.open(getCodeEditorUrl(), "_blank", "noopener,noreferrer");
+      setTaskBoardOpen(false);
+      return;
+    }
+    if (path === "__editor__") {
+      focusOrOpen("Files", "__file-browser__");
+      setTaskBoardOpen(false);
+      return;
+    }
+    focusOrOpen(name, path);
+  }, [focusOrOpen]);
 
   if (firstRunStatus === "checking") {
     return (
@@ -1578,6 +1633,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
               }}
               headerActions={(
                 <WebDesktopControls
+                  onOpenCommandPalette={onOpenCommandPalette ?? (() => {})}
                   onOpenSettings={(section) => {
                     setSettingsDefaultSection(section);
                     setSettingsOpen(true);
@@ -1601,6 +1657,9 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
                 }
               }}
               onToggleFullscreen={wmToggleFullscreen}
+              desktopIcons={desktopIcons}
+              onMoveDesktopIcon={moveDesktopIcon}
+              onRemoveDesktopIcon={removeDesktopIcon}
             />
           ) : null}
           {/* XP desktop icons: above the wallpaper, below app windows. The
@@ -1610,18 +1669,26 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
           <MissionControl
             open={taskBoardOpen}
             nativePresentation={desktopMode === "desktop"}
-            apps={apps}
+            apps={launcherApps}
             openWindows={windows.reduce<Set<string>>((acc, w) => {
               if (!w.minimized) acc.add(w.path);
               return acc;
             }, new Set())}
-            onOpenApp={openWindow}
+            onOpenApp={openLauncherDestination}
             onClose={() => setTaskBoardOpen(false)}
             pinnedApps={pinnedApps}
             onTogglePin={togglePin}
             onRegenerateIcon={regenerateIcon}
             onRenameApp={renameAppOnServer}
             onRemoveFromCanvas={removeFromCanvas}
+            onCreateApp={() => {
+              focusOrOpen("Chat", "__chat__");
+              chat?.submitMessage("Create a new Matrix app", undefined, {
+                displayText: "Create a new app",
+                promptText: "Use the Matrix app builder agent and app-generation guidance. Ask me what app I want to create, then help me build it.",
+              });
+            }}
+            onAddToDesktop={addDesktopIcon}
           />
 
           {!modeConfig.showWindows && modeConfig.id === "ambient" && (

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -49,7 +49,10 @@ import { nameToSlug } from "@/lib/utils";
 import { iconUrlForSlug } from "@/lib/app-launch";
 import { reconcileDesignApps, type ApiAppEntry } from "@/lib/design-apps-refresh";
 import { HERMES_CHAT_HIDDEN, VOICE_HIDDEN, getCodeEditorUrl } from "@/lib/feature-flags";
-import { resolveWebDesktopBuiltInLaunch } from "@/lib/web-desktop-app-launch";
+import {
+  buildWebDesktopLauncherApps,
+  resolveWebDesktopBuiltInLaunch,
+} from "@/lib/web-desktop-app-launch";
 import { isMainSectionApp, applyOrder } from "@/lib/dock-sections";
 import { MatrixLoadingScreen } from "./MatrixLoadingScreen";
 import {
@@ -1135,22 +1138,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
     />
   ) : null;
 
-  const launcherApps = useMemo(() => {
-    const firstClass = [
-      apps.find((app) => app.path === "__chat__") ? { ...apps.find((app) => app.path === "__chat__")!, name: "Chat" } : { name: "Chat", path: "__chat__" },
-      apps.find((app) => app.path === "__terminal__") ?? { name: "Terminal", path: "__terminal__" },
-      apps.find((app) => app.path === "__file-browser__") ?? { name: "Files", path: "__file-browser__" },
-      { name: "Editor", path: "__editor__" },
-      { name: "VS Code", path: "__vscode__", iconUrl: "/vscode.png" },
-      { name: "Settings", path: "__settings__" },
-      { name: "Plugins", path: "__plugins__" },
-      apps.find((app) => app.name.toLowerCase() === "browser") ?? { name: "Browser", path: "__browser__" },
-      apps.find((app) => app.name.toLowerCase() === "notes") ?? { name: "Notes", path: "apps/notes/index.html" },
-      apps.find((app) => app.name.toLowerCase() === "whiteboard") ?? { name: "Whiteboard", path: "apps/whiteboard/index.html" },
-    ];
-    const firstClassPaths = new Set(firstClass.map((app) => app.path));
-    return [...firstClass, ...apps.filter((app) => !firstClassPaths.has(app.path))];
-  }, [apps]);
+  const launcherApps = useMemo(() => buildWebDesktopLauncherApps(apps), [apps]);
 
   const openLauncherDestination = useCallback((name: string, path: string) => {
     if (path === "__settings__" || path === "__plugins__") {

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -1691,10 +1691,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
             onRemoveFromCanvas={removeFromCanvas}
             onCreateApp={() => {
               focusOrOpen("Chat", "__chat__");
-              chat?.submitMessage("Create a new Matrix app", undefined, {
-                displayText: "Create a new app",
-                promptText: "Use the Matrix app builder agent and app-generation guidance. Ask me what app I want to create, then help me build it.",
-              });
+              chat?.requestComposerDraft("/matrix-app-builder ");
             }}
             onAddToDesktop={addDesktopIcon}
           />

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -84,6 +84,7 @@ import {
   WebDesktopControls,
   type WebDesktopSettingsSection,
 } from "./desktop/WebDesktopControls";
+import { openShellSupport } from "@/lib/posthog-client";
 import { Reorder } from "framer-motion";
 
 const GATEWAY_URL = getGatewayUrl();
@@ -1642,6 +1643,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
               headerActions={(
                 <WebDesktopControls
                   onOpenCommandPalette={onOpenCommandPalette ?? (() => {})}
+                  onOpenSupport={() => void openShellSupport()}
                   onOpenSettings={(section) => {
                     setSettingsDefaultSection(section);
                     setSettingsOpen(true);

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -1120,7 +1120,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
   // Shared by the Windows taskbar (start menu, quick launch) and the XP
   // desktop icons: open the app window or focus the existing one.
   const openAppOrFocus = (path: string, name?: string) => {
-    const builtInLaunch = resolveWebDesktopBuiltInLaunch(path);
+    const builtInLaunch = resolveWebDesktopBuiltInLaunch(path, name);
     if (builtInLaunch?.kind === "external") {
       window.open(builtInLaunch.url, "_blank", "noopener,noreferrer");
       return;
@@ -1161,7 +1161,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
       setChatOpen(false);
       return;
     }
-    const builtInLaunch = resolveWebDesktopBuiltInLaunch(path);
+    const builtInLaunch = resolveWebDesktopBuiltInLaunch(path, name);
     if (builtInLaunch?.kind === "external") {
       window.open(builtInLaunch.url, "_blank", "noopener,noreferrer");
       setTaskBoardOpen(false);

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -453,7 +453,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
   // of AppViewer, so dock, command-palette, launcher, and deep-link launches
   // must all resolve them before opening a window.
   const openAppOrFocus = useCallback((path: string, name?: string) => {
-    const builtInLaunch = resolveWebDesktopBuiltInLaunch(path, name);
+    const builtInLaunch = resolveWebDesktopBuiltInLaunch(path);
     if (builtInLaunch?.kind === "external") {
       window.open(builtInLaunch.url, "_blank", "noopener,noreferrer");
       return;

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -49,6 +49,7 @@ import { nameToSlug } from "@/lib/utils";
 import { iconUrlForSlug } from "@/lib/app-launch";
 import { reconcileDesignApps, type ApiAppEntry } from "@/lib/design-apps-refresh";
 import { HERMES_CHAT_HIDDEN, VOICE_HIDDEN, getCodeEditorUrl } from "@/lib/feature-flags";
+import { resolveWebDesktopBuiltInLaunch } from "@/lib/web-desktop-app-launch";
 import { isMainSectionApp, applyOrder } from "@/lib/dock-sections";
 import { MatrixLoadingScreen } from "./MatrixLoadingScreen";
 import {
@@ -1119,16 +1120,17 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
   // Shared by the Windows taskbar (start menu, quick launch) and the XP
   // desktop icons: open the app window or focus the existing one.
   const openAppOrFocus = (path: string, name?: string) => {
-    if (path === "__browser__") {
-      window.open("https://www.google.com", "_blank", "noopener,noreferrer");
+    const builtInLaunch = resolveWebDesktopBuiltInLaunch(path);
+    if (builtInLaunch?.kind === "external") {
+      window.open(builtInLaunch.url, "_blank", "noopener,noreferrer");
       return;
     }
-    if (path === "__vscode__") {
+    if (builtInLaunch?.kind === "external-code") {
       window.open(getCodeEditorUrl(), "_blank", "noopener,noreferrer");
       return;
     }
-    if (path === "__editor__") {
-      focusOrOpen("Files", "__file-browser__");
+    if (builtInLaunch?.kind === "app") {
+      focusOrOpen(builtInLaunch.name, builtInLaunch.path);
       return;
     }
     focusOrOpen(name ?? apps.find((a) => a.path === path)?.name ?? "App", path);
@@ -1159,13 +1161,19 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
       setChatOpen(false);
       return;
     }
-    if (path === "__vscode__") {
+    const builtInLaunch = resolveWebDesktopBuiltInLaunch(path);
+    if (builtInLaunch?.kind === "external") {
+      window.open(builtInLaunch.url, "_blank", "noopener,noreferrer");
+      setTaskBoardOpen(false);
+      return;
+    }
+    if (builtInLaunch?.kind === "external-code") {
       window.open(getCodeEditorUrl(), "_blank", "noopener,noreferrer");
       setTaskBoardOpen(false);
       return;
     }
-    if (path === "__editor__") {
-      focusOrOpen("Files", "__file-browser__");
+    if (builtInLaunch?.kind === "app") {
+      focusOrOpen(builtInLaunch.name, builtInLaunch.path);
       setTaskBoardOpen(false);
       return;
     }

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -1594,7 +1594,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
                 <button
                   type="button"
                   key={app.path}
-                  onClick={() => openWindow(app.name, app.path)}
+                  onClick={() => openAppOrFocus(app.path, app.name)}
                   className={`flex shrink-0 h-9 items-center gap-1.5 px-3 rounded-lg border transition-all active:scale-95 ${
                     win
                       ? "bg-primary/10 border-primary/30 text-foreground"

--- a/shell/src/components/MissionControl.tsx
+++ b/shell/src/components/MissionControl.tsx
@@ -32,7 +32,11 @@ interface MissionControlProps {
   onRenameApp?: (slug: string, newName: string) => void;
   onRemoveFromCanvas?: (path: string) => void;
   nativePresentation?: boolean;
+  onCreateApp: () => void;
+  onAddToDesktop?: (path: string) => void;
 }
+
+const CREATE_APP: AppEntry = { name: "Create app", path: "__create-app__" };
 
 export function MissionControl({
   open,
@@ -46,6 +50,8 @@ export function MissionControl({
   onRenameApp,
   onRemoveFromCanvas,
   nativePresentation = false,
+  onCreateApp,
+  onAddToDesktop,
 }: MissionControlProps) {
   const { provision } = useTaskBoard();
   const themeStyle = useThemeStyle();
@@ -91,12 +97,20 @@ export function MissionControl({
 
   if (!mounted) return null;
 
+  const launcherApps = apps.some((app) => app.path === CREATE_APP.path)
+    ? apps
+    : [CREATE_APP, ...apps];
+  const openLauncherApp = (name: string, path: string) => {
+    if (path === CREATE_APP.path) onCreateApp();
+    else onOpenApp(name, path);
+  };
+
   // Native Desktop and macOS designs share the full-screen launchpad model.
   // The older dock-management panel remains available only to legacy shell
   // renderers; pinning and ordering belong to Settings, not the OS launcher.
   if (nativePresentation || themeStyle === "macos-glass") {
     return (
-      <Launchpad apps={apps} visible={visible} onOpenApp={onOpenApp} onClose={onClose} />
+      <Launchpad apps={launcherApps} visible={visible} onOpenApp={openLauncherApp} onClose={onClose} onAddToDesktop={onAddToDesktop} />
     );
   }
 
@@ -159,15 +173,16 @@ export function MissionControl({
         )}
 
         <LauncherGrid
-          apps={apps}
+          apps={launcherApps}
           openWindows={openWindows}
           pinnedApps={pinnedApps}
-          onOpenApp={onOpenApp}
+          onOpenApp={openLauncherApp}
           onClose={onClose}
           onTogglePin={onTogglePin}
           onRegenerateIcon={onRegenerateIcon}
           onRenameApp={onRenameApp}
           onRemoveFromCanvas={onRemoveFromCanvas}
+          onAddToDesktop={onAddToDesktop}
           visible={visible}
           closingRef={closingRef}
         />
@@ -193,6 +208,7 @@ function LauncherGrid({
   onRegenerateIcon,
   onRenameApp,
   onRemoveFromCanvas,
+  onAddToDesktop,
   visible,
   closingRef,
 }: {
@@ -205,6 +221,7 @@ function LauncherGrid({
   onRegenerateIcon: (slug: string) => void;
   onRenameApp?: (slug: string, newName: string) => void;
   onRemoveFromCanvas?: (path: string) => void;
+  onAddToDesktop?: (path: string) => void;
   visible: boolean;
   closingRef: React.RefObject<boolean>;
 }) {
@@ -228,6 +245,8 @@ function LauncherGrid({
       >
         <AppTile
           name={app.name}
+          createApp={app.path === CREATE_APP.path}
+          onAddToDesktop={app.path !== CREATE_APP.path && onAddToDesktop ? () => onAddToDesktop(app.path) : undefined}
           isOpen={openWindows.has(app.path)}
           onClick={() => {
             onOpenApp(app.name, app.path);

--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -530,6 +530,8 @@ export function CanvasWindow({ win, hidden = false, deferAppContent = false }: C
               onNewChat={chatState.newChat}
               onSwitchConversation={chatState.switchConversation}
               onSubmit={chatState.submitMessage}
+              composerDraftRequest={chatState.composerDraftRequest}
+              onComposerDraftConsumed={chatState.consumeComposerDraft}
               mobile={isMobile}
             />
           )}

--- a/shell/src/components/desktop/DesktopWindow.tsx
+++ b/shell/src/components/desktop/DesktopWindow.tsx
@@ -218,6 +218,8 @@ export function DesktopWindow({
                 onNewChat={chat.newChat}
                 onSwitchConversation={chat.switchConversation}
                 onSubmit={chat.submitMessage}
+                composerDraftRequest={chat.composerDraftRequest}
+                onComposerDraftConsumed={chat.consumeComposerDraft}
               />
             )}
           </div>

--- a/shell/src/components/desktop/WebDesktopControls.tsx
+++ b/shell/src/components/desktop/WebDesktopControls.tsx
@@ -1,22 +1,32 @@
 "use client";
 
 import Link from "next/link";
-import { CircleHelpIcon, ServerIcon } from "@/lib/hugeicons";
+import { CircleHelpIcon, SearchIcon, ServerIcon } from "@/lib/hugeicons";
 import { UserButton } from "../UserButton";
 
 export type WebDesktopSettingsSection = "appearance" | "billing" | "integrations";
 
 interface WebDesktopControlsProps {
   onOpenSettings: (section: WebDesktopSettingsSection) => void;
+  onOpenCommandPalette: () => void;
 }
 
 const actionClass =
   "flex size-7 items-center justify-center rounded-full border border-border/60 bg-card text-muted-foreground shadow-sm transition-colors hover:bg-muted/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 
 /** Web-safe equivalents of the native Desktop titlebar controls. */
-export function WebDesktopControls({ onOpenSettings }: WebDesktopControlsProps) {
+export function WebDesktopControls({ onOpenSettings, onOpenCommandPalette }: WebDesktopControlsProps) {
   return (
     <nav aria-label="Desktop controls" className="flex items-center gap-1.5">
+      <button
+        type="button"
+        aria-label="Search"
+        title="Search (Cmd+K)"
+        className={actionClass}
+        onClick={onOpenCommandPalette}
+      >
+        <SearchIcon className="size-3.5" aria-hidden="true" />
+      </button>
       <Link
         href="/runtime"
         aria-label="Switch computer"

--- a/shell/src/components/desktop/WebDesktopControls.tsx
+++ b/shell/src/components/desktop/WebDesktopControls.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { CircleHelpIcon, SearchIcon, ServerIcon } from "@/lib/hugeicons";
+import { MessageCircleIcon, SearchIcon, ServerIcon } from "@/lib/hugeicons";
 import { UserButton } from "../UserButton";
 
 export type WebDesktopSettingsSection = "appearance" | "billing" | "integrations";
@@ -9,13 +9,14 @@ export type WebDesktopSettingsSection = "appearance" | "billing" | "integrations
 interface WebDesktopControlsProps {
   onOpenSettings: (section: WebDesktopSettingsSection) => void;
   onOpenCommandPalette: () => void;
+  onOpenSupport: () => void;
 }
 
 const actionClass =
   "flex size-7 items-center justify-center rounded-full border border-border/60 bg-card text-muted-foreground shadow-sm transition-colors hover:bg-muted/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 
 /** Web-safe equivalents of the native Desktop titlebar controls. */
-export function WebDesktopControls({ onOpenSettings, onOpenCommandPalette }: WebDesktopControlsProps) {
+export function WebDesktopControls({ onOpenSettings, onOpenCommandPalette, onOpenSupport }: WebDesktopControlsProps) {
   return (
     <nav aria-label="Desktop controls" className="flex items-center gap-1.5">
       <button
@@ -27,6 +28,15 @@ export function WebDesktopControls({ onOpenSettings, onOpenCommandPalette }: Web
       >
         <SearchIcon className="size-3.5" aria-hidden="true" />
       </button>
+      <button
+        type="button"
+        aria-label="Support chat"
+        title="Support chat"
+        className={actionClass}
+        onClick={onOpenSupport}
+      >
+        <MessageCircleIcon className="size-3.5" aria-hidden="true" />
+      </button>
       <Link
         href="/runtime"
         aria-label="Switch computer"
@@ -35,16 +45,6 @@ export function WebDesktopControls({ onOpenSettings, onOpenCommandPalette }: Web
       >
         <ServerIcon className="size-3.5" aria-hidden="true" />
       </Link>
-      <a
-        href="https://matrix-os.com/docs"
-        target="_blank"
-        rel="noreferrer"
-        aria-label="Support"
-        title="Support"
-        className={actionClass}
-      >
-        <CircleHelpIcon className="size-3.5" aria-hidden="true" />
-      </a>
       <UserButton variant="menubar" onOpenSettings={onOpenSettings} />
     </nav>
   );

--- a/shell/src/components/desktop/WebDesktopSurface.tsx
+++ b/shell/src/components/desktop/WebDesktopSurface.tsx
@@ -4,6 +4,7 @@ import { useLayoutEffect, useMemo, useState, type CSSProperties, type ReactNode 
 import type { AppEntry, AppWindow } from "@/hooks/useWindowManager";
 import { useDesktopConfigStore, type DesktopIconPlacement } from "@/stores/desktop-config";
 import { SHELL_Z_INDEX } from "@/lib/shell-layering";
+import { buildWebDesktopLauncherApps } from "@/lib/web-desktop-app-launch";
 import {
   Blocks,
   BrushIcon,
@@ -259,28 +260,7 @@ export function WebDesktopSurface({
 }: WebDesktopSurfaceProps) {
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const primeDesktopIcons = useDesktopConfigStore((state) => state.primeDesktopIcons);
-  const desktopApps = useMemo(() => {
-    const preferred = [
-      apps.find((app) => app.path === "__chat__")
-        ? { ...apps.find((app) => app.path === "__chat__")!, name: "Chat" }
-        : undefined,
-      apps.find((app) => app.path === "__terminal__"),
-      apps.find((app) => app.path === "__file-browser__"),
-      { name: "Editor", path: "__editor__" },
-      { name: "VS Code", path: "__vscode__", iconUrl: "/vscode.png" },
-      { name: "Settings", path: "__settings__" },
-      { name: "Plugins", path: "__plugins__" },
-      apps.find((app) => app.name.toLowerCase() === "browser") ?? { name: "Browser", path: "__browser__" },
-      apps.find((app) => app.name.toLowerCase() === "notes") ?? { name: "Notes", path: "apps/notes/index.html" },
-      apps.find((app) => app.name.toLowerCase() === "whiteboard") ?? { name: "Whiteboard", path: "apps/whiteboard/index.html" },
-    ];
-    const seen = new Set<string>();
-    return preferred.filter((app): app is AppEntry => {
-      if (!app || seen.has(app.path)) return false;
-      seen.add(app.path);
-      return true;
-    });
-  }, [apps]);
+  const desktopApps = useMemo(() => buildWebDesktopLauncherApps(apps).slice(0, 10), [apps]);
   const defaultPlacements = useMemo<DesktopIconPlacement[]>(() => desktopApps.map((app, index) => ({
     path: app.path,
     x: 20 + (index % 2) * 88,

--- a/shell/src/components/desktop/WebDesktopSurface.tsx
+++ b/shell/src/components/desktop/WebDesktopSurface.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useMemo, useState, type CSSProperties, type ReactNode } from "react";
+import { useLayoutEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
 import type { AppEntry, AppWindow } from "@/hooks/useWindowManager";
-import type { DesktopIconPlacement } from "@/stores/desktop-config";
+import { useDesktopConfigStore, type DesktopIconPlacement } from "@/stores/desktop-config";
 import { SHELL_Z_INDEX } from "@/lib/shell-layering";
 import {
   Blocks,
@@ -258,6 +258,7 @@ export function WebDesktopSurface({
   onRemoveDesktopIcon,
 }: WebDesktopSurfaceProps) {
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const primeDesktopIcons = useDesktopConfigStore((state) => state.primeDesktopIcons);
   const desktopApps = useMemo(() => {
     const preferred = [
       apps.find((app) => app.path === "__chat__")
@@ -280,11 +281,15 @@ export function WebDesktopSurface({
       return true;
     });
   }, [apps]);
-  const placements = useMemo<DesktopIconPlacement[]>(() => desktopIcons ?? desktopApps.map((app, index) => ({
+  const defaultPlacements = useMemo<DesktopIconPlacement[]>(() => desktopApps.map((app, index) => ({
     path: app.path,
     x: 20 + (index % 2) * 88,
     y: 20 + Math.floor(index / 2) * 92,
-  })), [desktopApps, desktopIcons]);
+  })), [desktopApps]);
+  useLayoutEffect(() => {
+    if (desktopIcons === undefined) primeDesktopIcons(defaultPlacements);
+  }, [defaultPlacements, desktopIcons, primeDesktopIcons]);
+  const placements = desktopIcons ?? defaultPlacements;
   const placedApps = useMemo(() => placements.flatMap((placement) => {
     const app = desktopApps.find((candidate) => candidate.path === placement.path)
       ?? apps.find((candidate) => candidate.path === placement.path);

--- a/shell/src/components/desktop/WebDesktopSurface.tsx
+++ b/shell/src/components/desktop/WebDesktopSurface.tsx
@@ -2,10 +2,13 @@
 
 import { useMemo, useState, type CSSProperties, type ReactNode } from "react";
 import type { AppEntry, AppWindow } from "@/hooks/useWindowManager";
+import type { DesktopIconPlacement } from "@/stores/desktop-config";
 import { SHELL_Z_INDEX } from "@/lib/shell-layering";
 import {
   Blocks,
   BrushIcon,
+  Code2,
+  FilePenLine,
   FileText,
   FolderKanban,
   FolderTree,
@@ -33,6 +36,9 @@ interface WebDesktopSurfaceProps {
   onShowDesktop: () => void;
   onToggleFullscreen: (id: string) => void;
   children?: ReactNode;
+  desktopIcons?: DesktopIconPlacement[];
+  onMoveDesktopIcon?: (path: string, x: number, y: number) => void;
+  onRemoveDesktopIcon?: (path: string) => void;
 }
 
 interface DesktopIconAppearance {
@@ -60,6 +66,12 @@ export function desktopAppearanceForApp(app: AppEntry): DesktopIconAppearance {
   }
   if (app.path === "__file-browser__") {
     return { color: "var(--surface-brand-emphasis, #748E59)", iconColor: "white", icon: FolderTree };
+  }
+  if (app.path === "__editor__") {
+    return { color: "#4D7FA8", iconColor: "white", icon: FilePenLine };
+  }
+  if (app.path === "__vscode__") {
+    return { color: "#007ACC", iconColor: "white", icon: Code2 };
   }
   if (app.path === "__plugins__" || name === "plugins") {
     return { color: "#7C6DB4", iconColor: "white", icon: Blocks };
@@ -106,26 +118,58 @@ function DesktopDestination({
   selected,
   onSelect,
   onOpen,
+  placement,
+  onMove,
+  onRemove,
 }: {
   app: AppEntry;
   selected: boolean;
   onSelect: () => void;
   onOpen: () => void;
+  placement: DesktopIconPlacement;
+  onMove?: (path: string, x: number, y: number) => void;
+  onRemove?: (path: string) => void;
 }) {
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   return (
-    <button
-      type="button"
-      aria-label={app.name}
-      data-selected={selected || undefined}
-      className="group flex w-[76px] flex-col items-center gap-1.5 rounded-xl px-1 py-1.5 outline-none transition-colors hover:bg-white/10 focus-visible:bg-white/10 data-[selected]:bg-white/15"
-      onClick={onSelect}
-      onDoubleClick={onOpen}
-      onKeyDown={(event) => {
-        if (event.key !== "Enter") return;
-        event.preventDefault();
-        onOpen();
-      }}
-    >
+    <>
+      <button
+        type="button"
+        aria-label={app.name}
+        data-selected={selected || undefined}
+        className="group absolute flex w-[76px] touch-none flex-col items-center gap-1.5 rounded-xl px-1 py-1.5 outline-none transition-colors hover:bg-white/10 focus-visible:bg-white/10 data-[selected]:bg-white/15"
+        style={{ left: placement.x, top: placement.y + 38 }}
+        onClick={onSelect}
+        onDoubleClick={onOpen}
+        onContextMenu={(event) => {
+          event.preventDefault();
+          setMenu({ x: event.clientX, y: event.clientY });
+        }}
+        onPointerDown={(event) => {
+          if (event.button !== 0 || !onMove) return;
+          const target = event.currentTarget;
+          const startX = event.clientX;
+          const startY = event.clientY;
+          const move = (moveEvent: PointerEvent) => {
+            target.style.left = `${Math.max(0, placement.x + moveEvent.clientX - startX)}px`;
+            target.style.top = `${38 + Math.max(0, placement.y + moveEvent.clientY - startY)}px`;
+          };
+          const up = (upEvent: PointerEvent) => {
+            target.removeEventListener("pointermove", move);
+            target.removeEventListener("pointerup", up);
+            const dx = upEvent.clientX - startX;
+            const dy = upEvent.clientY - startY;
+            if (Math.abs(dx) + Math.abs(dy) > 3) onMove(app.path, Math.max(0, placement.x + dx), Math.max(0, placement.y + dy));
+          };
+          target.addEventListener("pointermove", move);
+          target.addEventListener("pointerup", up);
+        }}
+        onKeyDown={(event) => {
+          if (event.key !== "Enter") return;
+          event.preventDefault();
+          onOpen();
+        }}
+      >
       <DesktopAppIcon
         app={app}
         className="relative size-12 rounded-[14px] transition-transform duration-150 group-hover:-translate-y-0.5"
@@ -136,7 +180,23 @@ function DesktopDestination({
       >
         {app.name === "Hermes" ? "Chat" : app.name}
       </span>
-    </button>
+      </button>
+      {menu && onRemove ? (
+        <div role="menu" className="pointer-events-auto fixed min-w-48 rounded-xl border bg-popover p-1 text-popover-foreground shadow-lg" style={{ left: menu.x, top: menu.y, zIndex: SHELL_Z_INDEX.launchpad }}>
+          <button
+            type="button"
+            role="menuitem"
+            className="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-accent"
+            onClick={() => {
+              onRemove(app.path);
+              setMenu(null);
+            }}
+          >
+            Remove {app.name === "Hermes" ? "Chat" : app.name} from Desktop
+          </button>
+        </div>
+      ) : null}
+    </>
   );
 }
 
@@ -193,6 +253,9 @@ export function WebDesktopSurface({
   onShowDesktop,
   onToggleFullscreen,
   children,
+  desktopIcons,
+  onMoveDesktopIcon,
+  onRemoveDesktopIcon,
 }: WebDesktopSurfaceProps) {
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const desktopApps = useMemo(() => {
@@ -202,11 +265,13 @@ export function WebDesktopSurface({
         : undefined,
       apps.find((app) => app.path === "__terminal__"),
       apps.find((app) => app.path === "__file-browser__"),
+      { name: "Editor", path: "__editor__" },
+      { name: "VS Code", path: "__vscode__", iconUrl: "/vscode.png" },
       { name: "Settings", path: "__settings__" },
       { name: "Plugins", path: "__plugins__" },
-      apps.find((app) => app.name.toLowerCase() === "browser"),
-      apps.find((app) => app.name.toLowerCase() === "notes"),
-      apps.find((app) => app.name.toLowerCase() === "whiteboard"),
+      apps.find((app) => app.name.toLowerCase() === "browser") ?? { name: "Browser", path: "__browser__" },
+      apps.find((app) => app.name.toLowerCase() === "notes") ?? { name: "Notes", path: "apps/notes/index.html" },
+      apps.find((app) => app.name.toLowerCase() === "whiteboard") ?? { name: "Whiteboard", path: "apps/whiteboard/index.html" },
     ];
     const seen = new Set<string>();
     return preferred.filter((app): app is AppEntry => {
@@ -215,6 +280,16 @@ export function WebDesktopSurface({
       return true;
     });
   }, [apps]);
+  const placements = useMemo<DesktopIconPlacement[]>(() => desktopIcons ?? desktopApps.map((app, index) => ({
+    path: app.path,
+    x: 20 + (index % 2) * 88,
+    y: 20 + Math.floor(index / 2) * 92,
+  })), [desktopApps, desktopIcons]);
+  const placedApps = useMemo(() => placements.flatMap((placement) => {
+    const app = desktopApps.find((candidate) => candidate.path === placement.path)
+      ?? apps.find((candidate) => candidate.path === placement.path);
+    return app ? [{ app, placement }] : [];
+  }), [apps, desktopApps, placements]);
   const filesApp = apps.find((app) => app.path === "__file-browser__");
   const filesWindow = windows.find((windowRecord) => windowRecord.path === "__file-browser__");
   const otherRunningWindows = windows.filter((windowRecord) => windowRecord.path !== "__file-browser__");
@@ -255,13 +330,16 @@ export function WebDesktopSurface({
 
       <nav
         aria-label="Desktop apps"
-        className="pointer-events-auto absolute left-5 top-[58px] grid grid-cols-2 gap-x-3 gap-y-4"
+        className="pointer-events-auto absolute inset-0"
         style={{ zIndex: SHELL_Z_INDEX.desktopIcons }}
       >
-        {desktopApps.map((app) => (
+        {placedApps.map(({ app, placement }) => (
           <DesktopDestination
             key={app.path}
             app={app}
+            placement={placement}
+            onMove={onMoveDesktopIcon}
+            onRemove={onRemoveDesktopIcon}
             selected={selectedPath === app.path}
             onSelect={() => setSelectedPath(app.path)}
             onOpen={() => {

--- a/shell/src/components/desktop/WebDesktopSurface.tsx
+++ b/shell/src/components/desktop/WebDesktopSurface.tsx
@@ -71,7 +71,7 @@ export function desktopAppearanceForApp(app: AppEntry): DesktopIconAppearance {
     return { color: "#4D7FA8", iconColor: "white", icon: FilePenLine };
   }
   if (app.path === "__vscode__") {
-    return { color: "#007ACC", iconColor: "white", icon: Code2 };
+    return { color: "#FFFEFC", iconColor: "#007ACC", icon: Code2 };
   }
   if (app.path === "__plugins__" || name === "plugins") {
     return { color: "#7C6DB4", iconColor: "white", icon: Blocks };
@@ -101,7 +101,7 @@ function DesktopAppIcon({ app, className = "" }: { app: AppEntry; className?: st
       className={`flex items-center justify-center overflow-hidden border border-black/5 shadow-[0_5px_16px_rgba(0,0,0,0.16)] ${className}`}
       style={{ background: appearance.color, color: appearance.iconColor }}
     >
-      {app.iconUrl && !isCanonicalDesktopApp ? (
+      {app.iconUrl && (!isCanonicalDesktopApp || app.path === "__vscode__") ? (
         // Gateway-owned app icons can change at runtime and are already
         // versioned by ETag, so Next/Image cannot statically optimize them.
         // eslint-disable-next-line @next/next/no-img-element

--- a/shell/src/components/launchpad/Launchpad.tsx
+++ b/shell/src/components/launchpad/Launchpad.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { SearchIcon } from "@/lib/hugeicons";
+import { PlusIcon, SearchIcon } from "@/lib/hugeicons";
 import { useIconWithFallback } from "@/hooks/useIconWithFallback";
 import type { AppEntry } from "@/hooks/useWindowManager";
 import { groupLauncherApps } from "@/lib/dock-sections";
@@ -27,11 +27,13 @@ export function Launchpad({
   visible,
   onOpenApp,
   onClose,
+  onAddToDesktop,
 }: {
   apps: AppEntry[];
   visible: boolean;
   onOpenApp: (name: string, path: string) => void;
   onClose: () => void;
+  onAddToDesktop?: (path: string) => void;
 }) {
   // Keep the registry's stable order, flattened from the classic sections.
   const groups = groupLauncherApps(apps);
@@ -39,6 +41,7 @@ export function Launchpad({
 
   const [query, setQuery] = useState("");
   const [pageIndex, setPageIndex] = useState(0);
+  const [contextApp, setContextApp] = useState<AppEntry | null>(null);
   const filteredApps = filterLaunchpadApps(orderedApps, query);
 
   // Viewport-derived page size. window is only read inside this effect
@@ -141,7 +144,7 @@ export function Launchpad({
               }}
             >
               {pageApps.map((app) => (
-                <LaunchpadTile key={app.path} app={app} onLaunch={() => launch(app)} />
+                <LaunchpadTile key={app.path} app={app} onLaunch={() => launch(app)} onContextMenu={() => setContextApp(app)} />
               ))}
             </div>
           ) : (
@@ -163,17 +166,34 @@ export function Launchpad({
               />
             ))}
         </div>
+        {contextApp && contextApp.path !== "__create-app__" && onAddToDesktop ? (
+          <div role="menu" className="fixed left-1/2 top-1/2 z-50 min-w-48 -translate-x-1/2 rounded-xl border bg-popover p-1 text-popover-foreground shadow-lg">
+            <button
+              type="button"
+              role="menuitem"
+              className="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-accent"
+              onClick={() => {
+                onAddToDesktop(contextApp.path);
+                setContextApp(null);
+              }}
+            >
+              Add {contextApp.name} to Desktop
+            </button>
+          </div>
+        ) : null}
       </div>
     </div>
   );
 }
 
-function LaunchpadTile({ app, onLaunch }: { app: AppEntry; onLaunch: () => void }) {
+function LaunchpadTile({ app, onLaunch, onContextMenu }: { app: AppEntry; onLaunch: () => void; onContextMenu: () => void }) {
   const { showImage, onError } = useIconWithFallback(app.iconUrl);
   return (
-    <button type="button" data-launchpad-tile className="launchpad-tile" onClick={onLaunch}>
+    <button type="button" aria-label={app.name} data-launchpad-tile className="launchpad-tile" onClick={onLaunch} onContextMenu={(event) => { event.preventDefault(); onContextMenu(); }}>
       <span className="launchpad-icon">
-        {showImage && app.iconUrl ? (
+        {app.path === "__create-app__" ? (
+          <PlusIcon className="size-12" aria-hidden="true" />
+        ) : showImage && app.iconUrl ? (
           // react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- app icon served from a runtime gateway host (/icons/{slug}.png) that cannot be statically configured for next/image
           <img src={app.iconUrl} alt="" draggable={false} onError={onError} />
         ) : (

--- a/shell/src/components/mobile/MobileShell.tsx
+++ b/shell/src/components/mobile/MobileShell.tsx
@@ -602,6 +602,8 @@ function MobileAppFrame({
         onNewChat={() => void chat.newChat()}
         onSwitchConversation={chat.switchConversation}
         onSubmit={chat.submitMessage}
+        composerDraftRequest={chat.composerDraftRequest}
+        onComposerDraftConsumed={chat.consumeComposerDraft}
       />
     );
   }

--- a/shell/src/components/terminal/MobileTerminalControls.tsx
+++ b/shell/src/components/terminal/MobileTerminalControls.tsx
@@ -72,6 +72,7 @@ export function MobileTerminalActions({
       : terminalAgentVisibleInstallCommand(option);
     void ctx.createShellSessionTab(label, getCwd(), {
       cmd,
+      ...(action === "launch" ? { agent: option.id } : {}),
       ...(action === "launch" && option.id === "codex" ? { compatMode: "codex-tui" } : {}),
     });
   };

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -403,6 +403,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     const tab: Tab = {
       id,
       label: label ?? basename,
+      ...(claude ? { agent: "claude" as const } : startupCommand === "codex" ? { agent: "codex" as const } : {}),
       paneTree: {
         type: "pane",
         id: paneId,
@@ -423,13 +424,14 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     label: string,
     sessionId: string,
     cwd = DEFAULT_CWD,
-    options: { compatMode?: TerminalCompatMode; legacyCompat?: boolean } = {},
+    options: { agent?: CreateShellSessionTabOptions["agent"]; compatMode?: TerminalCompatMode; legacyCompat?: boolean } = {},
   ) => {
     const id = genId();
     const paneId = genId();
     const tab: Tab = {
       id,
       label,
+      ...(options.agent ? { agent: options.agent } : {}),
       paneTree: {
         type: "pane",
         id: paneId,
@@ -485,7 +487,11 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
         }
         const data = await res.json() as { name?: unknown };
         const sessionName = typeof data.name === "string" ? data.name : name;
-        addSessionTab(label, sessionName, requestedCwd, { compatMode: options.compatMode, legacyCompat: false });
+        addSessionTab(label, sessionName, requestedCwd, {
+          ...(options.agent ? { agent: options.agent } : {}),
+          ...(options.compatMode ? { compatMode: options.compatMode } : {}),
+          legacyCompat: false,
+        });
         return sessionName;
       } catch (err: unknown) {
         console.warn(

--- a/shell/src/components/terminal/TerminalAppContext.tsx
+++ b/shell/src/components/terminal/TerminalAppContext.tsx
@@ -36,7 +36,7 @@ export interface TerminalAppContextType {
   windowControls?: TerminalWindowControls;
   terminalBackground: string;
   addTab: (cwd: string, label?: string, claude?: boolean, startupCommand?: string) => string;
-  addSessionTab: (label: string, sessionId: string, cwd?: string) => string;
+  addSessionTab: (label: string, sessionId: string, cwd?: string, options?: { agent?: CreateShellSessionTabOptions["agent"]; compatMode?: TerminalCompatMode; legacyCompat?: boolean }) => string;
   createShellSessionTab: (label: string, cwd?: string, options?: CreateShellSessionTabOptions) => Promise<string | null>;
   backgroundShellSession: (sessionId: string) => void;
   removeDeletedShellSessionFromLayout: (sessionId: string) => void;

--- a/shell/src/components/terminal/TerminalDesignTabStrip.tsx
+++ b/shell/src/components/terminal/TerminalDesignTabStrip.tsx
@@ -4,6 +4,7 @@ import { useEffect, useEffectEvent, useRef, useState } from "react";
 import { ChevronDownIcon, PlusIcon, XIcon } from "@/lib/hugeicons";
 
 import { useTerminalAppContext } from "./TerminalAppContext";
+import { TerminalAgentLogo } from "./TerminalAgentLogo";
 import { DEFAULT_CWD } from "./terminal-layout";
 import type { TerminalDesignId } from "./terminal-design";
 import "./terminal-designs.css";
@@ -71,6 +72,13 @@ export function TerminalDesignTabStrip({ design, instanceId }: { design: Termina
                 className="terminal-design-tab-activate"
                 onClick={() => ctx.setActiveTab(tab.id)}
               >
+                {tab.agent ? (
+                  <TerminalAgentLogo
+                    agent={tab.agent}
+                    compact
+                    testIdPrefix="terminal-design-tab-agent-logo"
+                  />
+                ) : null}
                 <span className="terminal-design-tab-label">{tab.label}</span>
               </button>
               <button

--- a/shell/src/components/terminal/TerminalSidebar.tsx
+++ b/shell/src/components/terminal/TerminalSidebar.tsx
@@ -753,8 +753,15 @@ export function LocalTerminalSidebar({
   const renderedShells = filteredShells.length > 0
     ? filteredShells
     : shellsAuthoritative ? [] : syntheticFilteredShells;
-  const activeShells = renderedShells.filter((shell) => (shell.placement ?? (openSessionIds.has(shell.name) ? "active" : "background")) === "active");
-  const backgroundShells = renderedShells.filter((shell) => (shell.placement ?? (openSessionIds.has(shell.name) ? "active" : "background")) === "background");
+  const pinnedFirst = (left: ShellSessionSummary, right: ShellSessionSummary) => (
+    Number(Boolean(right.pinned)) - Number(Boolean(left.pinned))
+  );
+  const activeShells = renderedShells
+    .filter((shell) => (shell.placement ?? (openSessionIds.has(shell.name) ? "active" : "background")) === "active")
+    .sort(pinnedFirst);
+  const backgroundShells = renderedShells
+    .filter((shell) => (shell.placement ?? (openSessionIds.has(shell.name) ? "active" : "background")) === "background")
+    .sort(pinnedFirst);
   const activeTerminalTab = ctx.tabs.find((terminalTab) => terminalTab.id === ctx.activeTabId) ?? ctx.tabs[0];
   const selectedPaneId = activeTerminalTab
     ? ctx.focusedPaneId && hasPaneId(activeTerminalTab.paneTree, ctx.focusedPaneId)
@@ -840,7 +847,10 @@ export function LocalTerminalSidebar({
     if (existingTab) {
       ctx.setActiveTab(existingTab.id);
     } else {
-      ctx.addSessionTab(formatShellDisplayName(shell.name), shell.name);
+      ctx.addSessionTab(shell.subtitle?.trim() || formatShellDisplayName(shell.name), shell.name, DEFAULT_CWD, {
+        ...(shell.agent ? { agent: shell.agent } : {}),
+        legacyCompat: false,
+      });
     }
     if (markSeen && shell.latestSeq !== undefined && shell.latestSeq !== null && shell.lastSeenSeq !== shell.latestSeq) {
       void patchShellUiState(shell.name, { lastSeenSeq: shell.latestSeq });
@@ -1288,6 +1298,7 @@ export function LocalTerminalSidebar({
             selectedShellName={activeShellName}
             onOpen={openActiveShell}
             onToggle={moveShellToBackground}
+            onPin={(shell) => void patchShellUiState(shell.name, { pinned: !shell.pinned })}
             onRename={(shell, nextName) => renameManagedShell(shell, nextName)}
             onDelete={(shell, anchorElement, returnFocusElement) => setCloseConfirmationRequest({ shell, anchorElement, returnFocusElement })}
             draggingShellName={draggingShellName}
@@ -1310,6 +1321,7 @@ export function LocalTerminalSidebar({
             selectedShellName={activeShellName}
             onOpen={makeShellActive}
             onToggle={makeShellActive}
+            onPin={(shell) => void patchShellUiState(shell.name, { pinned: !shell.pinned })}
             onRename={(shell, nextName) => renameManagedShell(shell, nextName)}
             onDelete={(shell, anchorElement, returnFocusElement) => setCloseConfirmationRequest({ shell, anchorElement, returnFocusElement })}
             draggingShellName={draggingShellName}

--- a/shell/src/components/terminal/TerminalSidebarItems.tsx
+++ b/shell/src/components/terminal/TerminalSidebarItems.tsx
@@ -9,6 +9,8 @@ import {
   LinkIcon,
   MoreHorizontalIcon,
   PencilIcon,
+  PinIcon,
+  PinOffIcon,
   PlusIcon,
   Rows2Icon,
   Trash2Icon,
@@ -688,6 +690,7 @@ export function ShellSessionGroup({
   selectedShellName,
   onOpen,
   onToggle,
+  onPin,
   onRename,
   onDelete,
   draggingShellName,
@@ -708,6 +711,7 @@ export function ShellSessionGroup({
   selectedShellName: string | null;
   onOpen: (shell: ShellSessionSummary) => void;
   onToggle: (shell: ShellSessionSummary) => void;
+  onPin: (shell: ShellSessionSummary) => void;
   onRename: (shell: ShellSessionSummary, nextName: string) => Promise<boolean>;
   onDelete: (shell: ShellSessionSummary, anchorElement: HTMLElement, returnFocusElement: HTMLButtonElement) => void;
   draggingShellName: string | null;
@@ -780,6 +784,7 @@ export function ShellSessionGroup({
                 selected={shell.name === selectedShellName}
                 onOpen={() => onOpen(shell)}
                 onToggle={() => onToggle(shell)}
+                onPin={() => onPin(shell)}
                 onRename={(nextName) => onRename(shell, nextName)}
                 onDelete={(anchorElement, returnFocusElement) => onDelete(shell, anchorElement, returnFocusElement)}
                 dragging={shell.name === draggingShellName}
@@ -867,6 +872,7 @@ function ShellCard({
   selected,
   onOpen,
   onToggle,
+  onPin,
   onRename,
   onDelete,
   dragging,
@@ -883,6 +889,7 @@ function ShellCard({
   selected: boolean;
   onOpen: () => void;
   onToggle: () => void;
+  onPin: () => void;
   onRename: (nextName: string) => Promise<boolean>;
   onDelete: (anchorElement: HTMLElement, returnFocusElement: HTMLButtonElement) => void;
   dragging: boolean;
@@ -1422,6 +1429,15 @@ function ShellCard({
                       }}
                     >
                       <Rows2Icon size={13} strokeWidth={2} />
+                    </SessionContextMenuItem>
+                    <SessionContextMenuItem
+                      label={shell.pinned ? "Unpin" : "Pin"}
+                      onClick={() => {
+                        closeContextMenuWithFocusReturn();
+                        onPin();
+                      }}
+                    >
+                      {shell.pinned ? <PinOffIcon size={13} strokeWidth={2} /> : <PinIcon size={13} strokeWidth={2} />}
                     </SessionContextMenuItem>
                     <hr style={SESSION_CONTEXT_MENU_SEPARATOR_STYLE} />
                     <SessionContextMenuItem

--- a/shell/src/components/terminal/terminal-layout.ts
+++ b/shell/src/components/terminal/terminal-layout.ts
@@ -8,6 +8,7 @@ export const DEFAULT_CWD = "projects";
 export interface Tab {
   id: string;
   label: string;
+  agent?: "claude" | "codex" | "opencode" | "pi";
   paneTree: PaneNode;
 }
 

--- a/shell/src/components/terminal/terminal-session-state.ts
+++ b/shell/src/components/terminal/terminal-session-state.ts
@@ -1,5 +1,7 @@
 export interface ShellSessionSummary {
   name: string;
+  cwd?: string;
+  pinned?: boolean;
   status?: "active" | "exited" | "degraded";
   placement?: "active" | "background";
   updatedAt?: string;
@@ -39,7 +41,7 @@ export function shouldShowShellStatusDot(shell: ShellSessionSummary): boolean {
   return getShellVisualStatus(shell) === "waiting";
 }
 
-export type ShellUiStatePatch = Partial<Pick<ShellSessionSummary, "placement" | "lastSeenSeq">>;
+export type ShellUiStatePatch = Partial<Pick<ShellSessionSummary, "placement" | "lastSeenSeq" | "pinned">>;
 type ShellUiStatePatchKey = keyof ShellUiStatePatch;
 
 export interface ShellRefreshState {
@@ -49,7 +51,7 @@ export interface ShellRefreshState {
   error: string | null;
 }
 
-const SHELL_UI_STATE_PATCH_KEYS: ShellUiStatePatchKey[] = ["placement", "lastSeenSeq"];
+const SHELL_UI_STATE_PATCH_KEYS: ShellUiStatePatchKey[] = ["placement", "lastSeenSeq", "pinned"];
 
 export function shellSessionsEqual(left: ShellSessionSummary[], right: ShellSessionSummary[]): boolean {
   return left.length === right.length && left.every((session, index) => {
@@ -57,6 +59,8 @@ export function shellSessionsEqual(left: ShellSessionSummary[], right: ShellSess
     if (!next) return false;
     if (
       session.name !== next.name ||
+      session.cwd !== next.cwd ||
+      session.pinned !== next.pinned ||
       session.status !== next.status ||
       session.placement !== next.placement ||
       session.updatedAt !== next.updatedAt ||
@@ -122,6 +126,9 @@ function snapshotShellUiStatePatchValue(
     case "lastSeenSeq":
       previousValues.lastSeenSeq = shell.lastSeenSeq;
       return;
+    case "pinned":
+      previousValues.pinned = shell.pinned;
+      return;
     default: {
       const unhandledKey: never = key;
       throw new Error(`Unhandled shell UI state patch key: ${String(unhandledKey)}`);
@@ -151,6 +158,10 @@ function rollbackShellUiStatePatchValue(
     case "lastSeenSeq":
       return Object.is(shell.lastSeenSeq, patch.lastSeenSeq)
         ? { ...shell, lastSeenSeq: previousValues.lastSeenSeq }
+        : shell;
+    case "pinned":
+      return Object.is(shell.pinned, patch.pinned)
+        ? { ...shell, pinned: previousValues.pinned }
         : shell;
     default: {
       const unhandledKey: never = key;

--- a/shell/src/hooks/useChatState.ts
+++ b/shell/src/hooks/useChatState.ts
@@ -27,6 +27,9 @@ export interface ChatState {
   connected: boolean;
   queue: QueuedMessage[];
   conversations: ReturnType<typeof useConversation>["conversations"];
+  composerDraftRequest: { id: number; text: string } | null;
+  requestComposerDraft: (text: string) => void;
+  consumeComposerDraft: (id: number) => void;
   submitMessage: (
     text: string,
     files?: Array<{ name: string; type: string; data: string }>,
@@ -44,6 +47,8 @@ export function useChatState(): ChatState {
   const [busy, setBusy] = useState(false);
   const [currentTool, setCurrentTool] = useState<string | null>(null);
   const [queue, setQueue] = useState<QueuedMessage[]>([]);
+  const [composerDraftRequest, setComposerDraftRequest] = useState<{ id: number; text: string } | null>(null);
+  const composerDraftSequence = useRef(0);
   const { connected, connectionEpoch, subscribe, send } = useSocket();
   const { conversations, load } = useConversation();
   const sessionRef = useRef(sessionId);
@@ -214,6 +219,14 @@ export function useChatState(): ChatState {
     // show a "stopping..." pending state in the meantime if needed.
   }, [send]);
 
+  const requestComposerDraft = useCallback((text: string) => {
+    setComposerDraftRequest({ id: ++composerDraftSequence.current, text });
+  }, []);
+
+  const consumeComposerDraft = useCallback((id: number) => {
+    setComposerDraftRequest((current) => current?.id === id ? null : current);
+  }, []);
+
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- returned hook API / stable identity for effect dep
   const newChat = useCallback(async () => {
     setMessages([]);
@@ -263,6 +276,9 @@ export function useChatState(): ChatState {
     connected,
     queue,
     conversations,
+    composerDraftRequest,
+    requestComposerDraft,
+    consumeComposerDraft,
     submitMessage,
     newChat,
     switchConversation,

--- a/shell/src/hooks/useDesktopConfig.ts
+++ b/shell/src/hooks/useDesktopConfig.ts
@@ -3,7 +3,7 @@
 import { useEffect, useLayoutEffect, useState } from "react";
 import { useFileWatcher } from "./useFileWatcher";
 import { getGatewayUrl } from "@/lib/gateway";
-import { useDesktopConfigStore, type DockConfig } from "@/stores/desktop-config";
+import { useDesktopConfigStore, type DesktopIconPlacement, type DockConfig } from "@/stores/desktop-config";
 import { DEFAULT_PINNED_APPS } from "@/lib/builtin-apps";
 import {
   loadShellSnapshot,
@@ -29,6 +29,7 @@ export interface DesktopConfig {
     userApps?: string[];
     systemApps?: string[];
   };
+  desktopIcons?: DesktopIconPlacement[];
 }
 
 export type DesktopConfigPatch = Omit<Partial<DesktopConfig>, "dock"> & {
@@ -146,12 +147,14 @@ function applyDesktopConfigSnapshot(
     setDock: (dock: DockConfig) => void;
     setPinnedApps: (apps: string[]) => void;
     setDockOrder: (order: DesktopConfig["dockOrder"]) => void;
+    setDesktopIcons: (icons: DesktopConfig["desktopIcons"]) => void;
   },
 ) {
   rememberDesktopConfig(gatewayUrl, cfg);
   setters.setDock(cfg.dock);
   setters.setPinnedApps(cfg.pinnedApps);
   setters.setDockOrder(cfg.dockOrder);
+  setters.setDesktopIcons(cfg.desktopIcons);
   applyBackground(cfg.background, gatewayUrl);
 }
 
@@ -163,12 +166,13 @@ export function useDesktopConfig(options: DesktopConfigHookOptions = {}) {
   const setDock = useDesktopConfigStore((s) => s.setDock);
   const setPinnedApps = useDesktopConfigStore((s) => s.setPinnedApps);
   const setDockOrder = useDesktopConfigStore((s) => s.setDockOrder);
+  const setDesktopIcons = useDesktopConfigStore((s) => s.setDesktopIcons);
 
   useLayoutEffect(() => {
     const cachedConfig = loadShellSnapshot(cacheScope)?.desktopConfig;
     if (!cachedConfig) return;
-    applyDesktopConfigSnapshot(cachedConfig, gatewayUrl, { setDock, setPinnedApps, setDockOrder });
-  }, [cacheKey, cacheScope, gatewayUrl, setDock, setPinnedApps, setDockOrder]);
+    applyDesktopConfigSnapshot(cachedConfig, gatewayUrl, { setDock, setPinnedApps, setDockOrder, setDesktopIcons });
+  }, [cacheKey, cacheScope, gatewayUrl, setDock, setPinnedApps, setDockOrder, setDesktopIcons]);
 
   // react-doctor-disable-next-line react-doctor/no-cascading-set-state, react-doctor/no-fetch-in-effect -- the setConfig/setDock/setPinnedApps/setDockOrder calls all populate distinct stores from a single fetched desktop-config payload inside one async .then callback; they run together once the mount-only gateway load resolves (guarded by AbortController), not as a synchronous render-time cascade, and target separate Zustand slices that cannot be collapsed
   useEffect(() => {
@@ -176,12 +180,12 @@ export function useDesktopConfig(options: DesktopConfigHookOptions = {}) {
     fetchDesktopConfig(gatewayUrl, controller.signal).then((cfg) => {
       if (controller.signal.aborted) return;
       setConfig(cfg);
-      applyDesktopConfigSnapshot(cfg, gatewayUrl, { setDock, setPinnedApps, setDockOrder });
+      applyDesktopConfigSnapshot(cfg, gatewayUrl, { setDock, setPinnedApps, setDockOrder, setDesktopIcons });
       saveShellSnapshot(cacheScope, { desktopConfig: cfg });
     });
 
     return () => controller.abort();
-  }, [cacheKey, cacheScope, gatewayUrl, setDock, setPinnedApps, setDockOrder]);
+  }, [cacheKey, cacheScope, gatewayUrl, setDock, setPinnedApps, setDockOrder, setDesktopIcons]);
 
   useEffect(() => {
     rememberDesktopConfig(gatewayUrl, config);
@@ -195,6 +199,7 @@ export function useDesktopConfig(options: DesktopConfigHookOptions = {}) {
         setDock(cfg.dock);
         setPinnedApps(cfg.pinnedApps);
         setDockOrder(cfg.dockOrder);
+        setDesktopIcons(cfg.desktopIcons);
         saveShellSnapshot(cacheScope, { desktopConfig: cfg });
       });
     }

--- a/shell/src/hooks/useDesktopConfig.ts
+++ b/shell/src/hooks/useDesktopConfig.ts
@@ -3,7 +3,12 @@
 import { useEffect, useLayoutEffect, useState } from "react";
 import { useFileWatcher } from "./useFileWatcher";
 import { getGatewayUrl } from "@/lib/gateway";
-import { useDesktopConfigStore, type DesktopIconPlacement, type DockConfig } from "@/stores/desktop-config";
+import {
+  captureWebDesktopIconsHydrationRevision,
+  useDesktopConfigStore,
+  type DesktopIconPlacement,
+  type DockConfig,
+} from "@/stores/desktop-config";
 import { DEFAULT_PINNED_APPS } from "@/lib/builtin-apps";
 import {
   loadShellSnapshot,
@@ -147,14 +152,15 @@ function applyDesktopConfigSnapshot(
     setDock: (dock: DockConfig) => void;
     setPinnedApps: (apps: string[]) => void;
     setDockOrder: (order: DesktopConfig["dockOrder"]) => void;
-    setDesktopIcons: (icons: DesktopConfig["desktopIcons"]) => void;
+    setDesktopIcons: (icons: DesktopConfig["desktopIcons"], expectedHydrationRevision?: number) => void;
   },
+  desktopIconsHydrationRevision?: number,
 ) {
   rememberDesktopConfig(gatewayUrl, cfg);
   setters.setDock(cfg.dock);
   setters.setPinnedApps(cfg.pinnedApps);
   setters.setDockOrder(cfg.dockOrder);
-  setters.setDesktopIcons(cfg.desktopIcons);
+  setters.setDesktopIcons(cfg.desktopIcons, desktopIconsHydrationRevision);
   applyBackground(cfg.background, gatewayUrl);
 }
 
@@ -177,10 +183,16 @@ export function useDesktopConfig(options: DesktopConfigHookOptions = {}) {
   // react-doctor-disable-next-line react-doctor/no-cascading-set-state, react-doctor/no-fetch-in-effect -- the setConfig/setDock/setPinnedApps/setDockOrder calls all populate distinct stores from a single fetched desktop-config payload inside one async .then callback; they run together once the mount-only gateway load resolves (guarded by AbortController), not as a synchronous render-time cascade, and target separate Zustand slices that cannot be collapsed
   useEffect(() => {
     const controller = new AbortController();
+    const desktopIconsHydrationRevision = captureWebDesktopIconsHydrationRevision();
     fetchDesktopConfig(gatewayUrl, controller.signal).then((cfg) => {
       if (controller.signal.aborted) return;
       setConfig(cfg);
-      applyDesktopConfigSnapshot(cfg, gatewayUrl, { setDock, setPinnedApps, setDockOrder, setDesktopIcons });
+      applyDesktopConfigSnapshot(
+        cfg,
+        gatewayUrl,
+        { setDock, setPinnedApps, setDockOrder, setDesktopIcons },
+        desktopIconsHydrationRevision,
+      );
       saveShellSnapshot(cacheScope, { desktopConfig: cfg });
     });
 
@@ -194,12 +206,13 @@ export function useDesktopConfig(options: DesktopConfigHookOptions = {}) {
 
   useFileWatcher((path, event) => {
     if (path === "system/desktop.json" && event !== "unlink") {
+      const desktopIconsHydrationRevision = captureWebDesktopIconsHydrationRevision();
       fetchDesktopConfig(gatewayUrl).then((cfg) => {
         setConfig(cfg);
         setDock(cfg.dock);
         setPinnedApps(cfg.pinnedApps);
         setDockOrder(cfg.dockOrder);
-        setDesktopIcons(cfg.desktopIcons);
+        setDesktopIcons(cfg.desktopIcons, desktopIconsHydrationRevision);
         saveShellSnapshot(cacheScope, { desktopConfig: cfg });
       });
     }

--- a/shell/src/lib/posthog-client.ts
+++ b/shell/src/lib/posthog-client.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import "posthog-js/dist/conversations";
 import posthog from "posthog-js";
 import {
   buildPostHogCookieConsentInitOptions,
@@ -22,6 +23,7 @@ const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_API_HOST: process.env.NEXT_PUBLIC_POSTHOG_API_HOST ?? "/relay",
 });
 const CLIENT_ERROR_REPORT_TIMEOUT_MS = 10_000;
+const SUPPORT_AVAILABILITY_TIMEOUT_MS = 10_000;
 // Replay kill switch. NEXT_PUBLIC_* is inlined at build time, so the build
 // flag alone cannot stop replay during an incident. The layout additionally
 // exposes the server's runtime POSTHOG_DISABLE_REPLAY env as a data
@@ -85,6 +87,26 @@ export function capturePostHogEvent(event: string, properties: ClientProperties 
     posthog.capture(event, sanitizeProperties(properties));
   } catch (err: unknown) {
     console.warn("[posthog] Failed to capture client event:", err instanceof Error ? err.name : typeof err);
+  }
+}
+
+export async function openShellSupport(currentConfig: typeof config = config): Promise<boolean> {
+  if (!currentConfig) return false;
+  try {
+    ensurePostHogInitialized(currentConfig);
+    const deadline = Date.now() + SUPPORT_AVAILABILITY_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      if (posthog.conversations.isAvailable()) {
+        posthog.capture("shell_support_chat_opened", { matrix_client: "web" });
+        posthog.conversations.show();
+        return true;
+      }
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 100));
+    }
+    return false;
+  } catch (err: unknown) {
+    console.warn("[posthog] Failed to open support chat:", err instanceof Error ? err.name : typeof err);
+    return false;
   }
 }
 

--- a/shell/src/lib/web-desktop-app-launch.ts
+++ b/shell/src/lib/web-desktop-app-launch.ts
@@ -1,0 +1,17 @@
+export type WebDesktopBuiltInLaunch =
+  | { kind: "external"; url: string }
+  | { kind: "external-code" }
+  | { kind: "app"; name: string; path: string };
+
+export function resolveWebDesktopBuiltInLaunch(path: string): WebDesktopBuiltInLaunch | null {
+  if (path === "__browser__") {
+    return { kind: "external", url: "https://www.google.com" };
+  }
+  if (path === "__vscode__") {
+    return { kind: "external-code" };
+  }
+  if (path === "__editor__") {
+    return { kind: "app", name: "Files", path: "__file-browser__" };
+  }
+  return null;
+}

--- a/shell/src/lib/web-desktop-app-launch.ts
+++ b/shell/src/lib/web-desktop-app-launch.ts
@@ -1,3 +1,5 @@
+import type { AppEntry } from "@/hooks/useWindowManager";
+
 export type WebDesktopBuiltInLaunch =
   | { kind: "external"; url: string }
   | { kind: "external-code" }
@@ -18,4 +20,29 @@ export function resolveWebDesktopBuiltInLaunch(path: string): WebDesktopBuiltInL
     return { kind: "app", name: "Files", path: "__file-browser__" };
   }
   return null;
+}
+
+function findCanonicalApp(apps: readonly AppEntry[], paths: readonly string[]): AppEntry | undefined {
+  return apps.find((app) => paths.includes(app.path));
+}
+
+export function buildWebDesktopLauncherApps(apps: readonly AppEntry[]): AppEntry[] {
+  const chat = findCanonicalApp(apps, ["__chat__"]);
+  const firstClass: AppEntry[] = [
+    chat ? { ...chat, name: "Chat" } : { name: "Chat", path: "__chat__" },
+    findCanonicalApp(apps, ["__terminal__"]) ?? { name: "Terminal", path: "__terminal__" },
+    findCanonicalApp(apps, ["__file-browser__"]) ?? { name: "Files", path: "__file-browser__" },
+    { name: "Editor", path: "__editor__" },
+    { name: "VS Code", path: "__vscode__", iconUrl: "/vscode.png" },
+    { name: "Settings", path: "__settings__" },
+    { name: "Plugins", path: "__plugins__" },
+    findCanonicalApp(apps, ["apps/browser/index.html", "apps/browser/dist/index.html"])
+      ?? { name: "Browser", path: "__browser__" },
+    findCanonicalApp(apps, ["apps/notes/index.html", "apps/notes/dist/index.html"])
+      ?? { name: "Notes", path: "apps/notes/index.html" },
+    findCanonicalApp(apps, ["apps/whiteboard/index.html", "apps/whiteboard/dist/index.html"])
+      ?? { name: "Whiteboard", path: "apps/whiteboard/index.html" },
+  ];
+  const firstClassPaths = new Set(firstClass.map((app) => app.path));
+  return [...firstClass, ...apps.filter((app) => !firstClassPaths.has(app.path))];
 }

--- a/shell/src/lib/web-desktop-app-launch.ts
+++ b/shell/src/lib/web-desktop-app-launch.ts
@@ -3,8 +3,8 @@ export type WebDesktopBuiltInLaunch =
   | { kind: "external-code" }
   | { kind: "app"; name: string; path: string };
 
-export function resolveWebDesktopBuiltInLaunch(path: string): WebDesktopBuiltInLaunch | null {
-  if (path === "__browser__") {
+export function resolveWebDesktopBuiltInLaunch(path: string, name?: string): WebDesktopBuiltInLaunch | null {
+  if (path === "__browser__" || name?.trim().toLowerCase() === "browser") {
     return { kind: "external", url: "https://www.google.com" };
   }
   if (path === "__vscode__") {

--- a/shell/src/lib/web-desktop-app-launch.ts
+++ b/shell/src/lib/web-desktop-app-launch.ts
@@ -3,8 +3,12 @@ export type WebDesktopBuiltInLaunch =
   | { kind: "external-code" }
   | { kind: "app"; name: string; path: string };
 
-export function resolveWebDesktopBuiltInLaunch(path: string, name?: string): WebDesktopBuiltInLaunch | null {
-  if (path === "__browser__" || name?.trim().toLowerCase() === "browser") {
+export function resolveWebDesktopBuiltInLaunch(path: string): WebDesktopBuiltInLaunch | null {
+  if (
+    path === "__browser__"
+    || path === "apps/browser/index.html"
+    || path === "apps/browser/dist/index.html"
+  ) {
     return { kind: "external", url: "https://www.google.com" };
   }
   if (path === "__vscode__") {

--- a/shell/src/stores/desktop-config.ts
+++ b/shell/src/stores/desktop-config.ts
@@ -52,6 +52,7 @@ let desktopIconHydrationRevision = 0;
 let confirmedDesktopIcons: DesktopIconPlacement[] | undefined;
 let hasConfirmedDesktopIcons = false;
 let unconfirmedDesktopHydrationRevision: number | null = null;
+let deferredDesktopHydration: { icons: DesktopIconPlacement[] | undefined } | null = null;
 
 export function captureWebDesktopIconsHydrationRevision(): number {
   return desktopIconHydrationRevision;
@@ -64,6 +65,7 @@ export function resetWebDesktopIconsRuntime(): void {
   confirmedDesktopIcons = undefined;
   hasConfirmedDesktopIcons = false;
   unconfirmedDesktopHydrationRevision = null;
+  deferredDesktopHydration = null;
   useDesktopConfigStore.setState({ desktopIcons: undefined });
 }
 
@@ -112,12 +114,22 @@ function applyDesktopIconMutation(
       confirmedDesktopIcons = copyDesktopIcons(snapshot);
       hasConfirmedDesktopIcons = true;
       unconfirmedDesktopHydrationRevision = null;
+      deferredDesktopHydration = null;
     }
   }).catch((error: unknown) => {
     console.warn("[desktop-config] desktopIcons persist failed:", error instanceof Error ? error.name : typeof error);
     if (epoch === desktopIconStateEpoch && sequence === desktopIconMutationSequence) {
       if (hasConfirmedDesktopIcons) {
         set({ desktopIcons: copyDesktopIcons(confirmedDesktopIcons) });
+      } else if (deferredDesktopHydration !== null) {
+        const desktopIcons = copyDesktopIcons(deferredDesktopHydration.icons);
+        confirmedDesktopIcons = copyDesktopIcons(desktopIcons);
+        hasConfirmedDesktopIcons = true;
+        unconfirmedDesktopHydrationRevision = null;
+        deferredDesktopHydration = null;
+        desktopIconHydrationRevision += 1;
+        set({ desktopIcons });
+        restoredPendingHydration = true;
       } else {
         set({ desktopIcons: rollbackIcons });
         if (unconfirmedDesktopHydrationRevision !== null) {
@@ -146,13 +158,19 @@ export const useDesktopConfigStore = create<DesktopConfigStore>((set, get) => ({
   },
   setDesktopIcons: (desktopIcons, expectedHydrationRevision) => {
     if (expectedHydrationRevision !== undefined
-      && expectedHydrationRevision !== desktopIconHydrationRevision) return;
+      && expectedHydrationRevision !== desktopIconHydrationRevision) {
+      if (!hasConfirmedDesktopIcons && unconfirmedDesktopHydrationRevision === expectedHydrationRevision) {
+        deferredDesktopHydration = { icons: copyDesktopIcons(desktopIcons) };
+      }
+      return;
+    }
     desktopIconMutationSequence += 1;
     desktopIconStateEpoch += 1;
     desktopIconHydrationRevision += 1;
     confirmedDesktopIcons = copyDesktopIcons(desktopIcons);
     hasConfirmedDesktopIcons = true;
     unconfirmedDesktopHydrationRevision = null;
+    deferredDesktopHydration = null;
     set({ desktopIcons: copyDesktopIcons(desktopIcons) });
   },
   moveDesktopIcon: (path, x, y) => {

--- a/shell/src/stores/desktop-config.ts
+++ b/shell/src/stores/desktop-config.ts
@@ -45,6 +45,13 @@ interface DesktopConfigStore {
 }
 
 let desktopPersistQueue: Promise<void> = Promise.resolve();
+let desktopIconMutationSequence = 0;
+let desktopIconStateEpoch = 0;
+let confirmedDesktopIcons: DesktopIconPlacement[] | undefined;
+
+function copyDesktopIcons(icons: readonly DesktopIconPlacement[] | undefined): DesktopIconPlacement[] | undefined {
+  return icons?.map((icon) => ({ ...icon }));
+}
 
 function persistDesktopPatch(patch: Record<string, unknown>): Promise<void> {
   const gatewayUrl = getGatewayUrl();
@@ -67,6 +74,26 @@ function persistDesktopPatch(patch: Record<string, unknown>): Promise<void> {
   return pending;
 }
 
+function applyDesktopIconMutation(
+  icons: DesktopIconPlacement[],
+  set: (partial: Partial<DesktopConfigStore>) => void,
+): void {
+  const sequence = ++desktopIconMutationSequence;
+  const epoch = desktopIconStateEpoch;
+  const snapshot = copyDesktopIcons(icons) ?? [];
+  set({ desktopIcons: snapshot });
+  void persistDesktopPatch({ desktopIcons: snapshot }).then(() => {
+    if (epoch === desktopIconStateEpoch && sequence <= desktopIconMutationSequence) {
+      confirmedDesktopIcons = copyDesktopIcons(snapshot);
+    }
+  }).catch((error: unknown) => {
+    console.warn("[desktop-config] desktopIcons persist failed:", error instanceof Error ? error.name : typeof error);
+    if (epoch === desktopIconStateEpoch && sequence === desktopIconMutationSequence) {
+      set({ desktopIcons: copyDesktopIcons(confirmedDesktopIcons) });
+    }
+  });
+}
+
 export const useDesktopConfigStore = create<DesktopConfigStore>((set, get) => ({
   dock: { position: "left", size: 44, iconSize: 30, autoHide: false },
   pinnedApps: [...DEFAULT_PINNED_APPS],
@@ -75,7 +102,12 @@ export const useDesktopConfigStore = create<DesktopConfigStore>((set, get) => ({
   setDock: (dock) => set({ dock }),
   setPinnedApps: (pinnedApps) => set({ pinnedApps }),
   setDockOrder: (dockOrder) => set({ dockOrder }),
-  setDesktopIcons: (desktopIcons) => set({ desktopIcons }),
+  setDesktopIcons: (desktopIcons) => {
+    desktopIconMutationSequence += 1;
+    desktopIconStateEpoch += 1;
+    confirmedDesktopIcons = copyDesktopIcons(desktopIcons);
+    set({ desktopIcons: copyDesktopIcons(desktopIcons) });
+  },
   moveDesktopIcon: (path, x, y) => {
     const current = get().desktopIcons ?? [];
     const next = current.map((icon) => icon.path === path ? {
@@ -83,17 +115,11 @@ export const useDesktopConfigStore = create<DesktopConfigStore>((set, get) => ({
       x: Math.max(0, Math.min(MAX_DESKTOP_COORDINATE, Math.round(x))),
       y: Math.max(0, Math.min(MAX_DESKTOP_COORDINATE, Math.round(y))),
     } : icon);
-    set({ desktopIcons: next });
-    persistDesktopPatch({ desktopIcons: next }).catch((err) => {
-      console.warn("[desktop-config] moveDesktopIcon persist failed:", err instanceof Error ? err.message : String(err));
-    });
+    applyDesktopIconMutation(next, set);
   },
   removeDesktopIcon: (path) => {
     const next = (get().desktopIcons ?? []).filter((icon) => icon.path !== path);
-    set({ desktopIcons: next });
-    persistDesktopPatch({ desktopIcons: next }).catch((err) => {
-      console.warn("[desktop-config] removeDesktopIcon persist failed:", err instanceof Error ? err.message : String(err));
-    });
+    applyDesktopIconMutation(next, set);
   },
   addDesktopIcon: (path) => {
     const current = get().desktopIcons ?? [];
@@ -108,10 +134,7 @@ export const useDesktopConfigStore = create<DesktopConfigStore>((set, get) => ({
       }
     }
     const next = [...current, { path, ...slot }];
-    set({ desktopIcons: next });
-    persistDesktopPatch({ desktopIcons: next }).catch((err) => {
-      console.warn("[desktop-config] addDesktopIcon persist failed:", err instanceof Error ? err.message : String(err));
-    });
+    applyDesktopIconMutation(next, set);
   },
   togglePin: (path) => {
     const current = get().pinnedApps ?? [];

--- a/shell/src/stores/desktop-config.ts
+++ b/shell/src/stores/desktop-config.ts
@@ -31,7 +31,7 @@ interface DesktopConfigStore {
   setDock: (dock: DockConfig) => void;
   setPinnedApps: (apps: string[]) => void;
   setDockOrder: (order: DockOrder | undefined) => void;
-  setDesktopIcons: (icons: DesktopIconPlacement[] | undefined) => void;
+  setDesktopIcons: (icons: DesktopIconPlacement[] | undefined, expectedHydrationRevision?: number) => void;
   moveDesktopIcon: (path: string, x: number, y: number) => void;
   removeDesktopIcon: (path: string) => void;
   addDesktopIcon: (path: string) => void;
@@ -47,7 +47,12 @@ interface DesktopConfigStore {
 let desktopPersistQueue: Promise<void> = Promise.resolve();
 let desktopIconMutationSequence = 0;
 let desktopIconStateEpoch = 0;
+let desktopIconHydrationRevision = 0;
 let confirmedDesktopIcons: DesktopIconPlacement[] | undefined;
+
+export function captureWebDesktopIconsHydrationRevision(): number {
+  return desktopIconHydrationRevision;
+}
 
 function copyDesktopIcons(icons: readonly DesktopIconPlacement[] | undefined): DesktopIconPlacement[] | undefined {
   return icons?.map((icon) => ({ ...icon }));
@@ -81,6 +86,7 @@ function applyDesktopIconMutation(
   const sequence = ++desktopIconMutationSequence;
   const epoch = desktopIconStateEpoch;
   const snapshot = copyDesktopIcons(icons) ?? [];
+  desktopIconHydrationRevision += 1;
   set({ desktopIcons: snapshot });
   void persistDesktopPatch({ desktopIcons: snapshot }).then(() => {
     if (epoch === desktopIconStateEpoch && sequence <= desktopIconMutationSequence) {
@@ -91,6 +97,8 @@ function applyDesktopIconMutation(
     if (epoch === desktopIconStateEpoch && sequence === desktopIconMutationSequence) {
       set({ desktopIcons: copyDesktopIcons(confirmedDesktopIcons) });
     }
+  }).finally(() => {
+    if (epoch === desktopIconStateEpoch) desktopIconHydrationRevision += 1;
   });
 }
 
@@ -102,9 +110,12 @@ export const useDesktopConfigStore = create<DesktopConfigStore>((set, get) => ({
   setDock: (dock) => set({ dock }),
   setPinnedApps: (pinnedApps) => set({ pinnedApps }),
   setDockOrder: (dockOrder) => set({ dockOrder }),
-  setDesktopIcons: (desktopIcons) => {
+  setDesktopIcons: (desktopIcons, expectedHydrationRevision) => {
+    if (expectedHydrationRevision !== undefined
+      && expectedHydrationRevision !== desktopIconHydrationRevision) return;
     desktopIconMutationSequence += 1;
     desktopIconStateEpoch += 1;
+    desktopIconHydrationRevision += 1;
     confirmedDesktopIcons = copyDesktopIcons(desktopIcons);
     set({ desktopIcons: copyDesktopIcons(desktopIcons) });
   },

--- a/shell/src/stores/desktop-config.ts
+++ b/shell/src/stores/desktop-config.ts
@@ -52,7 +52,9 @@ let desktopIconHydrationRevision = 0;
 let confirmedDesktopIcons: DesktopIconPlacement[] | undefined;
 let hasConfirmedDesktopIcons = false;
 let unconfirmedDesktopHydrationRevision: number | null = null;
+let unconfirmedDesktopRollbackIcons: DesktopIconPlacement[] | null = null;
 let deferredDesktopHydration: { icons: DesktopIconPlacement[] | undefined } | null = null;
+let replayableDesktopHydrationRange: { min: number; max: number } | null = null;
 
 export function captureWebDesktopIconsHydrationRevision(): number {
   return desktopIconHydrationRevision;
@@ -65,7 +67,9 @@ export function resetWebDesktopIconsRuntime(): void {
   confirmedDesktopIcons = undefined;
   hasConfirmedDesktopIcons = false;
   unconfirmedDesktopHydrationRevision = null;
+  unconfirmedDesktopRollbackIcons = null;
   deferredDesktopHydration = null;
+  replayableDesktopHydrationRange = null;
   useDesktopConfigStore.setState({ desktopIcons: undefined });
 }
 
@@ -105,6 +109,8 @@ function applyDesktopIconMutation(
   const snapshot = copyDesktopIcons(icons) ?? [];
   if (!hasConfirmedDesktopIcons && unconfirmedDesktopHydrationRevision === null) {
     unconfirmedDesktopHydrationRevision = desktopIconHydrationRevision;
+    unconfirmedDesktopRollbackIcons = copyDesktopIcons(previousIcons) ?? [];
+    replayableDesktopHydrationRange = null;
   }
   desktopIconHydrationRevision += 1;
   set({ desktopIcons: snapshot });
@@ -114,7 +120,9 @@ function applyDesktopIconMutation(
       confirmedDesktopIcons = copyDesktopIcons(snapshot);
       hasConfirmedDesktopIcons = true;
       unconfirmedDesktopHydrationRevision = null;
+      unconfirmedDesktopRollbackIcons = null;
       deferredDesktopHydration = null;
+      replayableDesktopHydrationRange = null;
     }
   }).catch((error: unknown) => {
     console.warn("[desktop-config] desktopIcons persist failed:", error instanceof Error ? error.name : typeof error);
@@ -126,15 +134,22 @@ function applyDesktopIconMutation(
         confirmedDesktopIcons = copyDesktopIcons(desktopIcons);
         hasConfirmedDesktopIcons = true;
         unconfirmedDesktopHydrationRevision = null;
+        unconfirmedDesktopRollbackIcons = null;
         deferredDesktopHydration = null;
+        replayableDesktopHydrationRange = null;
         desktopIconHydrationRevision += 1;
         set({ desktopIcons });
         restoredPendingHydration = true;
       } else {
-        set({ desktopIcons: rollbackIcons });
+        set({ desktopIcons: copyDesktopIcons(unconfirmedDesktopRollbackIcons ?? rollbackIcons) });
         if (unconfirmedDesktopHydrationRevision !== null) {
+          replayableDesktopHydrationRange = {
+            min: unconfirmedDesktopHydrationRevision,
+            max: desktopIconHydrationRevision,
+          };
           desktopIconHydrationRevision = unconfirmedDesktopHydrationRevision;
           unconfirmedDesktopHydrationRevision = null;
+          unconfirmedDesktopRollbackIcons = null;
           restoredPendingHydration = true;
         }
       }
@@ -157,12 +172,19 @@ export const useDesktopConfigStore = create<DesktopConfigStore>((set, get) => ({
     set({ desktopIcons: copyDesktopIcons(icons) });
   },
   setDesktopIcons: (desktopIcons, expectedHydrationRevision) => {
-    if (expectedHydrationRevision !== undefined
-      && expectedHydrationRevision !== desktopIconHydrationRevision) {
-      if (!hasConfirmedDesktopIcons && unconfirmedDesktopHydrationRevision === expectedHydrationRevision) {
+    if (expectedHydrationRevision !== undefined) {
+      const replayable = replayableDesktopHydrationRange !== null
+        && expectedHydrationRevision >= replayableDesktopHydrationRange.min
+        && expectedHydrationRevision <= replayableDesktopHydrationRange.max;
+      if (!replayable
+        && !hasConfirmedDesktopIcons
+        && unconfirmedDesktopHydrationRevision !== null
+        && expectedHydrationRevision >= unconfirmedDesktopHydrationRevision
+        && expectedHydrationRevision <= desktopIconHydrationRevision) {
         deferredDesktopHydration = { icons: copyDesktopIcons(desktopIcons) };
+        return;
       }
-      return;
+      if (!replayable && expectedHydrationRevision !== desktopIconHydrationRevision) return;
     }
     desktopIconMutationSequence += 1;
     desktopIconStateEpoch += 1;
@@ -170,7 +192,9 @@ export const useDesktopConfigStore = create<DesktopConfigStore>((set, get) => ({
     confirmedDesktopIcons = copyDesktopIcons(desktopIcons);
     hasConfirmedDesktopIcons = true;
     unconfirmedDesktopHydrationRevision = null;
+    unconfirmedDesktopRollbackIcons = null;
     deferredDesktopHydration = null;
+    replayableDesktopHydrationRange = null;
     set({ desktopIcons: copyDesktopIcons(desktopIcons) });
   },
   moveDesktopIcon: (path, x, y) => {

--- a/shell/src/stores/desktop-config.ts
+++ b/shell/src/stores/desktop-config.ts
@@ -31,6 +31,7 @@ interface DesktopConfigStore {
   setDock: (dock: DockConfig) => void;
   setPinnedApps: (apps: string[]) => void;
   setDockOrder: (order: DockOrder | undefined) => void;
+  primeDesktopIcons: (icons: DesktopIconPlacement[]) => void;
   setDesktopIcons: (icons: DesktopIconPlacement[] | undefined, expectedHydrationRevision?: number) => void;
   moveDesktopIcon: (path: string, x: number, y: number) => void;
   removeDesktopIcon: (path: string) => void;
@@ -49,9 +50,21 @@ let desktopIconMutationSequence = 0;
 let desktopIconStateEpoch = 0;
 let desktopIconHydrationRevision = 0;
 let confirmedDesktopIcons: DesktopIconPlacement[] | undefined;
+let hasConfirmedDesktopIcons = false;
+let unconfirmedDesktopHydrationRevision: number | null = null;
 
 export function captureWebDesktopIconsHydrationRevision(): number {
   return desktopIconHydrationRevision;
+}
+
+export function resetWebDesktopIconsRuntime(): void {
+  desktopIconMutationSequence += 1;
+  desktopIconStateEpoch += 1;
+  desktopIconHydrationRevision += 1;
+  confirmedDesktopIcons = undefined;
+  hasConfirmedDesktopIcons = false;
+  unconfirmedDesktopHydrationRevision = null;
+  useDesktopConfigStore.setState({ desktopIcons: undefined });
 }
 
 function copyDesktopIcons(icons: readonly DesktopIconPlacement[] | undefined): DesktopIconPlacement[] | undefined {
@@ -80,25 +93,42 @@ function persistDesktopPatch(patch: Record<string, unknown>): Promise<void> {
 }
 
 function applyDesktopIconMutation(
+  previousIcons: DesktopIconPlacement[],
   icons: DesktopIconPlacement[],
   set: (partial: Partial<DesktopConfigStore>) => void,
 ): void {
   const sequence = ++desktopIconMutationSequence;
   const epoch = desktopIconStateEpoch;
+  const rollbackIcons = copyDesktopIcons(previousIcons) ?? [];
   const snapshot = copyDesktopIcons(icons) ?? [];
+  if (!hasConfirmedDesktopIcons && unconfirmedDesktopHydrationRevision === null) {
+    unconfirmedDesktopHydrationRevision = desktopIconHydrationRevision;
+  }
   desktopIconHydrationRevision += 1;
   set({ desktopIcons: snapshot });
+  let restoredPendingHydration = false;
   void persistDesktopPatch({ desktopIcons: snapshot }).then(() => {
     if (epoch === desktopIconStateEpoch && sequence <= desktopIconMutationSequence) {
       confirmedDesktopIcons = copyDesktopIcons(snapshot);
+      hasConfirmedDesktopIcons = true;
+      unconfirmedDesktopHydrationRevision = null;
     }
   }).catch((error: unknown) => {
     console.warn("[desktop-config] desktopIcons persist failed:", error instanceof Error ? error.name : typeof error);
     if (epoch === desktopIconStateEpoch && sequence === desktopIconMutationSequence) {
-      set({ desktopIcons: copyDesktopIcons(confirmedDesktopIcons) });
+      if (hasConfirmedDesktopIcons) {
+        set({ desktopIcons: copyDesktopIcons(confirmedDesktopIcons) });
+      } else {
+        set({ desktopIcons: rollbackIcons });
+        if (unconfirmedDesktopHydrationRevision !== null) {
+          desktopIconHydrationRevision = unconfirmedDesktopHydrationRevision;
+          unconfirmedDesktopHydrationRevision = null;
+          restoredPendingHydration = true;
+        }
+      }
     }
   }).finally(() => {
-    if (epoch === desktopIconStateEpoch) desktopIconHydrationRevision += 1;
+    if (epoch === desktopIconStateEpoch && !restoredPendingHydration) desktopIconHydrationRevision += 1;
   });
 }
 
@@ -110,6 +140,10 @@ export const useDesktopConfigStore = create<DesktopConfigStore>((set, get) => ({
   setDock: (dock) => set({ dock }),
   setPinnedApps: (pinnedApps) => set({ pinnedApps }),
   setDockOrder: (dockOrder) => set({ dockOrder }),
+  primeDesktopIcons: (icons) => {
+    if (get().desktopIcons !== undefined) return;
+    set({ desktopIcons: copyDesktopIcons(icons) });
+  },
   setDesktopIcons: (desktopIcons, expectedHydrationRevision) => {
     if (expectedHydrationRevision !== undefined
       && expectedHydrationRevision !== desktopIconHydrationRevision) return;
@@ -117,6 +151,8 @@ export const useDesktopConfigStore = create<DesktopConfigStore>((set, get) => ({
     desktopIconStateEpoch += 1;
     desktopIconHydrationRevision += 1;
     confirmedDesktopIcons = copyDesktopIcons(desktopIcons);
+    hasConfirmedDesktopIcons = true;
+    unconfirmedDesktopHydrationRevision = null;
     set({ desktopIcons: copyDesktopIcons(desktopIcons) });
   },
   moveDesktopIcon: (path, x, y) => {
@@ -126,11 +162,12 @@ export const useDesktopConfigStore = create<DesktopConfigStore>((set, get) => ({
       x: Math.max(0, Math.min(MAX_DESKTOP_COORDINATE, Math.round(x))),
       y: Math.max(0, Math.min(MAX_DESKTOP_COORDINATE, Math.round(y))),
     } : icon);
-    applyDesktopIconMutation(next, set);
+    applyDesktopIconMutation(current, next, set);
   },
   removeDesktopIcon: (path) => {
-    const next = (get().desktopIcons ?? []).filter((icon) => icon.path !== path);
-    applyDesktopIconMutation(next, set);
+    const current = get().desktopIcons ?? [];
+    const next = current.filter((icon) => icon.path !== path);
+    applyDesktopIconMutation(current, next, set);
   },
   addDesktopIcon: (path) => {
     const current = get().desktopIcons ?? [];
@@ -145,7 +182,7 @@ export const useDesktopConfigStore = create<DesktopConfigStore>((set, get) => ({
       }
     }
     const next = [...current, { path, ...slot }];
-    applyDesktopIconMutation(next, set);
+    applyDesktopIconMutation(current, next, set);
   },
   togglePin: (path) => {
     const current = get().pinnedApps ?? [];

--- a/shell/src/stores/desktop-config.ts
+++ b/shell/src/stores/desktop-config.ts
@@ -14,13 +14,27 @@ export interface DockOrder {
   systemApps?: string[];
 }
 
+export interface DesktopIconPlacement {
+  path: string;
+  x: number;
+  y: number;
+}
+
+const MAX_DESKTOP_ICONS = 512;
+const MAX_DESKTOP_COORDINATE = 16_384;
+
 interface DesktopConfigStore {
   dock: DockConfig;
   pinnedApps: string[];
   dockOrder: DockOrder | undefined;
+  desktopIcons: DesktopIconPlacement[] | undefined;
   setDock: (dock: DockConfig) => void;
   setPinnedApps: (apps: string[]) => void;
   setDockOrder: (order: DockOrder | undefined) => void;
+  setDesktopIcons: (icons: DesktopIconPlacement[] | undefined) => void;
+  moveDesktopIcon: (path: string, x: number, y: number) => void;
+  removeDesktopIcon: (path: string) => void;
+  addDesktopIcon: (path: string) => void;
   togglePin: (path: string) => void;
   /** Persist a new section ordering. Accepts a partial update so callers
       can reorder one section without touching the other. */
@@ -30,32 +44,75 @@ interface DesktopConfigStore {
   ) => void;
 }
 
-async function persistDesktopPatch(patch: Record<string, unknown>): Promise<void> {
+let desktopPersistQueue: Promise<void> = Promise.resolve();
+
+function persistDesktopPatch(patch: Record<string, unknown>): Promise<void> {
   const gatewayUrl = getGatewayUrl();
   const url = `${gatewayUrl}/api/settings/desktop`;
-  const getRes = await fetch(url, { signal: AbortSignal.timeout(5000) });
-  if (!getRes.ok) {
-    throw new Error(`GET /api/settings/desktop ${getRes.status}`);
-  }
-  const config = (await getRes.json()) as Record<string, unknown>;
-  const putRes = await fetch(url, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ ...config, ...patch }),
-    signal: AbortSignal.timeout(5000),
+  const snapshot = JSON.stringify(patch);
+  const write = async () => {
+    if (getGatewayUrl() !== gatewayUrl) return;
+    const putRes = await fetch(url, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: snapshot,
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!putRes.ok) throw new Error(`PATCH /api/settings/desktop ${putRes.status}`);
+  };
+  const pending = desktopPersistQueue.then(write, write);
+  desktopPersistQueue = pending.catch((error: unknown) => {
+    console.warn("[desktop-config] persist queue recovered:", error instanceof Error ? error.name : typeof error);
   });
-  if (!putRes.ok) {
-    throw new Error(`PUT /api/settings/desktop ${putRes.status}`);
-  }
+  return pending;
 }
 
 export const useDesktopConfigStore = create<DesktopConfigStore>((set, get) => ({
   dock: { position: "left", size: 44, iconSize: 30, autoHide: false },
   pinnedApps: [...DEFAULT_PINNED_APPS],
   dockOrder: undefined,
+  desktopIcons: undefined,
   setDock: (dock) => set({ dock }),
   setPinnedApps: (pinnedApps) => set({ pinnedApps }),
   setDockOrder: (dockOrder) => set({ dockOrder }),
+  setDesktopIcons: (desktopIcons) => set({ desktopIcons }),
+  moveDesktopIcon: (path, x, y) => {
+    const current = get().desktopIcons ?? [];
+    const next = current.map((icon) => icon.path === path ? {
+      ...icon,
+      x: Math.max(0, Math.min(MAX_DESKTOP_COORDINATE, Math.round(x))),
+      y: Math.max(0, Math.min(MAX_DESKTOP_COORDINATE, Math.round(y))),
+    } : icon);
+    set({ desktopIcons: next });
+    persistDesktopPatch({ desktopIcons: next }).catch((err) => {
+      console.warn("[desktop-config] moveDesktopIcon persist failed:", err instanceof Error ? err.message : String(err));
+    });
+  },
+  removeDesktopIcon: (path) => {
+    const next = (get().desktopIcons ?? []).filter((icon) => icon.path !== path);
+    set({ desktopIcons: next });
+    persistDesktopPatch({ desktopIcons: next }).catch((err) => {
+      console.warn("[desktop-config] removeDesktopIcon persist failed:", err instanceof Error ? err.message : String(err));
+    });
+  },
+  addDesktopIcon: (path) => {
+    const current = get().desktopIcons ?? [];
+    if (!path || path.length > 2048 || current.length >= MAX_DESKTOP_ICONS || current.some((icon) => icon.path === path)) return;
+    const occupied = new Set(current.map((icon) => `${icon.x}:${icon.y}`));
+    let slot = { x: 20, y: 20 };
+    for (let index = 0; index < MAX_DESKTOP_ICONS; index += 1) {
+      const candidate = { x: 20 + (index % 2) * 88, y: 20 + Math.floor(index / 2) * 92 };
+      if (!occupied.has(`${candidate.x}:${candidate.y}`)) {
+        slot = candidate;
+        break;
+      }
+    }
+    const next = [...current, { path, ...slot }];
+    set({ desktopIcons: next });
+    persistDesktopPatch({ desktopIcons: next }).catch((err) => {
+      console.warn("[desktop-config] addDesktopIcon persist failed:", err instanceof Error ? err.message : String(err));
+    });
+  },
   togglePin: (path) => {
     const current = get().pinnedApps ?? [];
     const next = current.includes(path)

--- a/tests/desktop/app-launcher.test.tsx
+++ b/tests/desktop/app-launcher.test.tsx
@@ -93,6 +93,41 @@ describe("AppLauncher", () => {
     });
   });
 
+  it("puts Create app first and includes every first-class Desktop app", () => {
+    const onCreateApp = vi.fn();
+    render(<AppLauncher presentation="launchpad" onCreateApp={onCreateApp} />);
+
+    const launcher = screen.getByTestId("desktop-launcher-grid");
+    const names = Array.from(launcher.querySelectorAll("button"))
+      .map((button) => button.getAttribute("aria-label"));
+    expect(names.slice(0, 11)).toEqual([
+      "Create app",
+      "Chat",
+      "Terminal",
+      "Files",
+      "Editor",
+      "VS Code",
+      "Settings",
+      "Plugins",
+      "Browser",
+      "Notes",
+      "Whiteboard",
+    ]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create app" }));
+    expect(onCreateApp).toHaveBeenCalledOnce();
+  });
+
+  it("adds a launcher app back to the Desktop from its context menu", () => {
+    const onAddToDesktop = vi.fn();
+    render(<AppLauncher presentation="launchpad" onAddToDesktop={onAddToDesktop} />);
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Notes" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Add Notes to Desktop" }));
+
+    expect(onAddToDesktop).toHaveBeenCalledWith("__notes__");
+  });
+
   it("keeps the focused launcher search field free of a nested focus ring", () => {
     render(<AppLauncher presentation="launchpad" />);
 

--- a/tests/desktop/browser-tab.test.tsx
+++ b/tests/desktop/browser-tab.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import BrowserTab from "@desktop/renderer/src/features/browser/BrowserTab";
 import { invoke } from "@desktop/renderer/src/lib/operator";
@@ -46,8 +46,7 @@ describe("BrowserTab", () => {
     expect(mocks.embedRender.mock.calls.length).toBeGreaterThan(renderCount);
   });
 
-  it("opens public URLs and searches in the local browser", async () => {
-    vi.mocked(invoke).mockResolvedValue({ ok: true });
+  it("opens public URLs and searches inside the Desktop Browser", () => {
     render(<BrowserTab active />);
 
     const address = screen.getByRole("textbox", { name: "Browser address" });
@@ -58,9 +57,9 @@ describe("BrowserTab", () => {
     fireEvent.change(address, { target: { value: "Matrix OS docs" } });
     fireEvent.click(screen.getByRole("button", { name: "Go" }));
 
-    await waitFor(() => expect(invoke).toHaveBeenCalledWith("shell:open-external", {
-      url: "https://www.google.com/search?q=Matrix+OS+docs",
-    }));
-    expect(screen.queryByTestId("embed")).toBeNull();
+    expect(screen.getByTestId("embed").textContent).toBe(
+      "browser:https://www.google.com/search?q=Matrix+OS+docs",
+    );
+    expect(invoke).not.toHaveBeenCalled();
   });
 });

--- a/tests/desktop/browser-tab.test.tsx
+++ b/tests/desktop/browser-tab.test.tsx
@@ -5,6 +5,7 @@ import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import BrowserTab from "@desktop/renderer/src/features/browser/BrowserTab";
 import { invoke } from "@desktop/renderer/src/lib/operator";
+import { useBrowserNavigation } from "@desktop/renderer/src/stores/browser-navigation";
 
 const mocks = vi.hoisted(() => ({ embedRender: vi.fn() }));
 
@@ -21,6 +22,7 @@ describe("BrowserTab", () => {
     window.localStorage.clear();
     vi.mocked(invoke).mockReset();
     mocks.embedRender.mockReset();
+    useBrowserNavigation.setState(useBrowserNavigation.getInitialState(), true);
   });
 
   it("keeps loopback navigation inside the selected runtime embed", () => {
@@ -106,5 +108,35 @@ describe("BrowserTab", () => {
     expect((within(settings).getByRole("checkbox", { name: "Restore previous tabs" }) as HTMLInputElement).checked).toBe(true);
     expect(within(settings).getByText("Cookies and sign-ins persist in the browser profile.")).toBeTruthy();
     expect(within(settings).getByText(/Password saving requires an OS-encrypted browser vault/)).toBeTruthy();
+  });
+
+  it("opens requested Help pages in Matrix Browser with an external-browser option", () => {
+    useBrowserNavigation.getState().request("https://matrix-os.com/docs");
+
+    render(<BrowserTab active />);
+
+    expect(screen.getByRole<HTMLInputElement>("textbox", { name: "Browser address" }).value)
+      .toBe("https://matrix-os.com/docs");
+    expect(screen.getByTestId("embed").textContent).toBe("browser:https://matrix-os.com/docs");
+    expect(useBrowserNavigation.getState().pending).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open current page in external browser" }));
+    expect(invoke).toHaveBeenCalledWith("shell:open-external", {
+      url: "https://matrix-os.com/docs",
+    });
+  });
+
+  it("does not offer the external-browser escape hatch for tunneled runtime pages", () => {
+    useBrowserNavigation.getState().request("http://127.0.0.1:3000");
+
+    render(<BrowserTab active />);
+
+    expect(screen.getByTestId("embed").textContent).toBe("browser:http://127.0.0.1:3000/");
+    expect(screen.queryByRole("button", { name: "Open current page in external browser" })).toBeNull();
+  });
+
+  it("rejects oversized cross-app browser navigation requests", () => {
+    expect(useBrowserNavigation.getState().request("x".repeat(4_097))).toBeNull();
+    expect(useBrowserNavigation.getState().pending).toBeNull();
   });
 });

--- a/tests/desktop/browser-tab.test.tsx
+++ b/tests/desktop/browser-tab.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import BrowserTab from "@desktop/renderer/src/features/browser/BrowserTab";
 import { invoke } from "@desktop/renderer/src/lib/operator";
@@ -18,6 +18,7 @@ vi.mock("@desktop/renderer/src/features/embeds/EmbedHost", () => ({
 
 describe("BrowserTab", () => {
   beforeEach(() => {
+    window.localStorage.clear();
     vi.mocked(invoke).mockReset();
     mocks.embedRender.mockReset();
   });
@@ -61,5 +62,49 @@ describe("BrowserTab", () => {
       "browser:https://www.google.com/search?q=Matrix+OS+docs",
     );
     expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("opens, switches, and closes multiple browser tabs", () => {
+    render(<BrowserTab active />);
+
+    const tablist = screen.getByRole("tablist", { name: "Browser tabs" });
+    expect(within(tablist).getAllByRole("tab")).toHaveLength(1);
+    fireEvent.click(screen.getByRole("button", { name: "New browser tab" }));
+    expect(within(tablist).getAllByRole("tab")).toHaveLength(2);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Browser address" }), {
+      target: { value: "https://example.com/docs" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Go" }));
+    expect(screen.getByTestId("embed").textContent).toBe("browser:https://example.com/docs");
+
+    fireEvent.click(within(tablist).getAllByRole("tab")[0]!);
+    expect(screen.queryByTestId("embed")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Close browser tab 2" }));
+    expect(within(tablist).getAllByRole("tab")).toHaveLength(1);
+  });
+
+  it("restores the previous tabs and active URL after remount", () => {
+    const first = render(<BrowserTab active />);
+    fireEvent.change(screen.getByRole("textbox", { name: "Browser address" }), {
+      target: { value: "https://example.com/previous" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Go" }));
+    first.unmount();
+
+    render(<BrowserTab active />);
+    expect(screen.getByRole<HTMLInputElement>("textbox", { name: "Browser address" }).value)
+      .toBe("https://example.com/previous");
+    expect(screen.getByTestId("embed").textContent).toBe("browser:https://example.com/previous");
+  });
+
+  it("offers browser session settings and explains password-vault safety", () => {
+    render(<BrowserTab active />);
+    fireEvent.click(screen.getByRole("button", { name: "Browser settings" }));
+
+    const settings = screen.getByRole("region", { name: "Browser settings" });
+    expect((within(settings).getByRole("checkbox", { name: "Restore previous tabs" }) as HTMLInputElement).checked).toBe(true);
+    expect(within(settings).getByText("Cookies and sign-ins persist in the browser profile.")).toBeTruthy();
+    expect(within(settings).getByText(/Password saving requires an OS-encrypted browser vault/)).toBeTruthy();
   });
 });

--- a/tests/desktop/command-palette.test.tsx
+++ b/tests/desktop/command-palette.test.tsx
@@ -90,6 +90,14 @@ describe("CommandPalette", () => {
       value: ResizeObserverStub,
     });
     window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    window.HTMLDialogElement.prototype.showModal = function showModal() {
+      this.setAttribute("open", "");
+      this.tabIndex = -1;
+      this.focus();
+    };
+    window.HTMLDialogElement.prototype.close = function close() {
+      this.removeAttribute("open");
+    };
     useUi.setState({ paletteOpen: true, createTaskOpen: false, createProjectOpen: false, composerOpen: false });
     useBoard.setState({ activeProjectSlug: null, projects: [], cardsByProject: {} });
     useSessions.setState({ sessions: [] });
@@ -129,6 +137,13 @@ describe("CommandPalette", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+  });
+
+  it("focuses the search input after the native dialog opens", async () => {
+    render(<CommandPalette />);
+
+    const input = screen.getByPlaceholderText("Search tasks, sessions, actions…");
+    await waitFor(() => expect(document.activeElement).toBe(input));
   });
 
   it("forces an app catalog retry after a previous palette load failed", async () => {

--- a/tests/desktop/command-palette.test.tsx
+++ b/tests/desktop/command-palette.test.tsx
@@ -142,8 +142,42 @@ describe("CommandPalette", () => {
   it("focuses the search input after the native dialog opens", async () => {
     render(<CommandPalette />);
 
-    const input = screen.getByPlaceholderText("Search tasks, sessions, actions…");
+    const input = screen.getByPlaceholderText("Type a command or search…");
     await waitFor(() => expect(document.activeElement).toBe(input));
+    expect(input.className).toContain("focus-visible:shadow-none");
+  });
+
+  it("provides the categorized command-center design without losing command behavior", async () => {
+    useBoard.setState({
+      activeProjectSlug: null,
+      projects: [{ slug: "matrix-os", name: "Matrix OS" }],
+      cardsByProject: {},
+    });
+
+    render(<CommandPalette />);
+
+    expect(screen.getByText("⌘K")).not.toBeNull();
+    const input = screen.getByPlaceholderText("Type a command or search…");
+    await waitFor(() => expect(document.activeElement).toBe(input));
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+      "All",
+      "Projects",
+      "Actions",
+      "Settings",
+    ]);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Projects" }));
+    expect(screen.getByText("Matrix OS")).not.toBeNull();
+    expect(screen.queryByText("Open Terminal")).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Actions" }));
+    const terminalItem = screen.getByText("Open Terminal").closest("[cmdk-item]");
+    expect(terminalItem?.hasAttribute("data-instant-list-hover")).toBe(true);
+    expect(screen.queryByText("Matrix OS")).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Settings" }));
+    expect(screen.getByText("Open settings")).not.toBeNull();
+    expect(screen.queryByText("Open Terminal")).toBeNull();
   });
 
   it("forces an app catalog retry after a previous palette load failed", async () => {

--- a/tests/desktop/command-palette.test.tsx
+++ b/tests/desktop/command-palette.test.tsx
@@ -390,6 +390,69 @@ describe("CommandPalette", () => {
     await waitFor(() => expect(loadThreadSnapshot).toHaveBeenCalledWith("thread_alpha"));
   });
 
+  it("uses linked agent-session titles instead of repeating the generic thread title", () => {
+    useShellSessions.setState({
+      sessions: [
+        {
+          name: "support-chat-fix",
+          status: "active",
+          agent: "codex",
+          subtitle: "Fix support chat",
+          cwd: "projects/matrix-os",
+        },
+        {
+          name: "browser-tabs",
+          status: "active",
+          agent: "claude",
+          subtitle: "Improve Browser tabs",
+          cwd: "projects/matrix-os",
+        },
+        {
+          name: "bright-tide",
+          status: "active",
+          agent: "pi",
+          cwd: "projects/matrix-os",
+        },
+      ],
+    });
+    useCodingAgentWorkspace.setState({
+      summary: runtimeSummaryWithThreads({
+        activeThreads: [
+          threadSummary("thread_support", {
+            title: "Coding agent run",
+            terminalSessionId: "term_support",
+          }),
+          threadSummary("thread_browser", {
+            title: "Coding agent run",
+            terminalSessionId: "term_browser",
+          }),
+          threadSummary("thread_untitled", {
+            title: "Coding agent run",
+            terminalSessionId: "term_untitled",
+          }),
+          threadSummary("thread_stale_terminal", {
+            title: "Coding agent run",
+            terminalSessionId: "term_no_longer_live",
+            projectId: "matrix-os",
+          }),
+        ],
+        terminalSessions: [
+          terminalSessionSummary("term_support", { name: "support-chat-fix" }),
+          terminalSessionSummary("term_browser", { name: "browser-tabs" }),
+          terminalSessionSummary("term_untitled", { name: "bright-tide" }),
+        ],
+      }),
+    });
+
+    render(<CommandPalette />);
+
+    expect(screen.getByText("Open thread Fix support chat")).toBeTruthy();
+    expect(screen.getByText("Open thread Improve Browser tabs")).toBeTruthy();
+    expect(screen.getByText("Open thread bright-tide")).toBeTruthy();
+    expect(screen.getByText("Open thread matrix-os agent run")).toBeTruthy();
+    expect(screen.queryByText("Open thread Coding agent run")).toBeNull();
+  });
+
   it("opens attachable coding-agent terminal sessions from the command palette", async () => {
     const openTab = vi.fn();
     useTabs.setState({ openTab });

--- a/tests/desktop/create-app-request.test.ts
+++ b/tests/desktop/create-app-request.test.ts
@@ -1,0 +1,11 @@
+import { beforeEach, expect, it } from "vitest";
+import { useCreateAppRequest } from "@desktop/renderer/src/stores/create-app-request";
+
+beforeEach(() => useCreateAppRequest.setState(useCreateAppRequest.getInitialState(), true));
+
+it("prepares a Matrix builder-agent draft for the Create App launcher", () => {
+  useCreateAppRequest.getState().requestDraft();
+
+  expect(useCreateAppRequest.getState().request?.prompt).toContain("Matrix builder agent");
+  expect(useCreateAppRequest.getState().request?.prompt).toContain("app-generation.md");
+});

--- a/tests/desktop/create-app-request.test.ts
+++ b/tests/desktop/create-app-request.test.ts
@@ -6,6 +6,5 @@ beforeEach(() => useCreateAppRequest.setState(useCreateAppRequest.getInitialStat
 it("prepares a Matrix builder-agent draft for the Create App launcher", () => {
   useCreateAppRequest.getState().requestDraft();
 
-  expect(useCreateAppRequest.getState().request?.prompt).toContain("Matrix builder agent");
-  expect(useCreateAppRequest.getState().request?.prompt).toContain("app-generation.md");
+  expect(useCreateAppRequest.getState().request?.prompt).toBe("/matrix-app-builder ");
 });

--- a/tests/desktop/desktop-default-apps.test.ts
+++ b/tests/desktop/desktop-default-apps.test.ts
@@ -29,6 +29,7 @@ describe("native desktop default apps", () => {
     expect(FIXED_DESKTOP_APPS.find((app) => app.id === "vscode")).toMatchObject({
       kind: "vscode",
       name: "VS Code",
+      color: "#FFFEFC",
     });
     expect(FIXED_DESKTOP_APPS.find((app) => app.id === "plugins")).toMatchObject({
       kind: "settings",

--- a/tests/desktop/desktop-editor-workspace.test.tsx
+++ b/tests/desktop/desktop-editor-workspace.test.tsx
@@ -33,8 +33,12 @@ describe("DesktopEditorWorkspace", () => {
     fireEvent.click(screen.getByRole("button", { name: "Browse main.ts" }));
 
     expect(await screen.findByRole("tab", { name: "main.ts" })).toBeTruthy();
-    expect(screen.getByText("Editing projects/app/src/main.ts").getAttribute("data-active"))
-      .toBe("true");
+    const editor = screen.getByText("Editing projects/app/src/main.ts");
+    expect(editor.getAttribute("data-active")).toBe("true");
+    const retainedPane = editor.closest("[data-retained-pane]");
+    expect(retainedPane?.className).toContain("absolute");
+    expect(retainedPane?.className).toContain("inset-0");
+    expect(retainedPane?.className).toContain("min-w-0");
   });
 
   it("clears open documents when the selected runtime identity changes", async () => {

--- a/tests/desktop/desktop-icon-grid.test.tsx
+++ b/tests/desktop/desktop-icon-grid.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+import { MessageSquare } from "@desktop/renderer/src/lib/hugeicons";
+import DesktopIconGrid from "@desktop/renderer/src/features/desktop-shell/DesktopIconGrid";
+
+it("removes a Desktop icon from its context menu", () => {
+  const onRemove = vi.fn();
+  render(
+    <DesktopIconGrid
+      destinations={[{
+        id: "work",
+        path: "__chat__",
+        kind: "work",
+        icon: MessageSquare,
+        name: "Chat",
+        open: vi.fn(),
+      }]}
+      placements={[{ path: "__chat__", x: 20, y: 20 }]}
+      onMove={vi.fn()}
+      onRemove={onRemove}
+    />,
+  );
+
+  fireEvent.contextMenu(screen.getByRole("button", { name: "Chat" }));
+  fireEvent.click(screen.getByRole("menuitem", { name: "Remove Chat from Desktop" }));
+
+  expect(onRemove).toHaveBeenCalledWith("__chat__");
+});

--- a/tests/desktop/desktop-icons-store.test.ts
+++ b/tests/desktop/desktop-icons-store.test.ts
@@ -207,4 +207,33 @@ describe("native Desktop icon layout", () => {
 
     expect(useDesktopIcons.getState().icons).toContainEqual({ path: "__chat__", x: 240, y: 180 });
   });
+
+  it("restores newer deferred hydration when an in-flight icon write fails", async () => {
+    let rejectPatch: ((error: Error) => void) | undefined;
+    const newerOwnerLayout = [{ path: "__file-browser__", x: 196, y: 112 }];
+    const api = {
+      get: vi.fn(async () => ({ desktopIcons: [CHAT, FILES] })),
+      patch: vi.fn(() => new Promise<never>((_resolve, reject) => {
+        rejectPatch = reject;
+      })),
+    };
+    await useDesktopIcons.getState().load(api as never, [CHAT, FILES]);
+
+    const move = useDesktopIcons.getState().move("__chat__", 240, 180, api as never);
+    await vi.waitFor(() => expect(api.patch).toHaveBeenCalledTimes(1));
+    const overlappingHydrationRevision = captureDesktopIconsHydrationRevision();
+    useDesktopIcons.getState().hydrate(
+      newerOwnerLayout,
+      [CHAT, FILES],
+      overlappingHydrationRevision,
+    );
+
+    rejectPatch?.(new Error("offline"));
+    await move;
+
+    expect(useDesktopIcons.getState()).toMatchObject({
+      icons: newerOwnerLayout,
+      loaded: true,
+    });
+  });
 });

--- a/tests/desktop/desktop-icons-store.test.ts
+++ b/tests/desktop/desktop-icons-store.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resetDesktopIconsRuntime, useDesktopIcons } from "@desktop/renderer/src/stores/desktop-icons";
+import {
+  captureDesktopIconsHydrationRevision,
+  resetDesktopIconsRuntime,
+  useDesktopIcons,
+} from "@desktop/renderer/src/stores/desktop-icons";
 
 const CHAT = { path: "__chat__", x: 20, y: 20 };
 const FILES = { path: "__file-browser__", x: 108, y: 20 };
@@ -63,5 +67,39 @@ describe("native Desktop icon layout", () => {
     await Promise.all([move, remove]);
 
     expect(useDesktopIcons.getState().icons).toEqual([{ path: "__chat__", x: 240, y: 180 }]);
+  });
+
+  it("ignores settings hydration that started before a successful icon write", async () => {
+    const api = {
+      get: vi.fn(async () => ({ desktopIcons: [CHAT, FILES] })),
+      patch: vi.fn(async () => ({ ok: true })),
+    };
+    await useDesktopIcons.getState().load(api as never, [CHAT, FILES]);
+    const staleHydrationRevision = captureDesktopIconsHydrationRevision();
+
+    await useDesktopIcons.getState().move("__chat__", 240, 180, api as never);
+    useDesktopIcons.getState().hydrate([CHAT, FILES], [CHAT, FILES], staleHydrationRevision);
+
+    expect(useDesktopIcons.getState().icons).toContainEqual({ path: "__chat__", x: 240, y: 180 });
+  });
+
+  it("ignores settings hydration that overlaps an in-flight icon write", async () => {
+    let finishPatch: (() => void) | undefined;
+    const api = {
+      get: vi.fn(async () => ({ desktopIcons: [CHAT, FILES] })),
+      patch: vi.fn(() => new Promise<{ ok: true }>((resolve) => {
+        finishPatch = () => resolve({ ok: true });
+      })),
+    };
+    await useDesktopIcons.getState().load(api as never, [CHAT, FILES]);
+
+    const move = useDesktopIcons.getState().move("__chat__", 240, 180, api as never);
+    await vi.waitFor(() => expect(api.patch).toHaveBeenCalledTimes(1));
+    const staleHydrationRevision = captureDesktopIconsHydrationRevision();
+    finishPatch?.();
+    await move;
+    useDesktopIcons.getState().hydrate([CHAT, FILES], [CHAT, FILES], staleHydrationRevision);
+
+    expect(useDesktopIcons.getState().icons).toContainEqual({ path: "__chat__", x: 240, y: 180 });
   });
 });

--- a/tests/desktop/desktop-icons-store.test.ts
+++ b/tests/desktop/desktop-icons-store.test.ts
@@ -53,6 +53,25 @@ describe("native Desktop icon layout", () => {
     expect(useDesktopIcons.getState().icons).toEqual([CHAT, FILES]);
   });
 
+  it("allows pending settings hydration after an initial icon write fails", async () => {
+    const api = {
+      patch: vi.fn(async () => { throw new Error("offline"); }),
+    };
+    const pendingHydrationRevision = captureDesktopIconsHydrationRevision();
+    useDesktopIcons.getState().prime([CHAT, FILES]);
+
+    await useDesktopIcons.getState().move("__chat__", 240, 180, api as never);
+    useDesktopIcons.getState().hydrate([FILES], [CHAT, FILES], pendingHydrationRevision);
+
+    expect(api.patch).toHaveBeenCalledWith("/api/settings/desktop", {
+      desktopIcons: [
+        { path: "__chat__", x: 240, y: 180 },
+        FILES,
+      ],
+    });
+    expect(useDesktopIcons.getState()).toMatchObject({ icons: [FILES], loaded: true });
+  });
+
   it("keeps a later successful queued layout when an earlier write fails", async () => {
     const api = {
       get: vi.fn(async () => ({ desktopIcons: [CHAT, FILES] })),

--- a/tests/desktop/desktop-icons-store.test.ts
+++ b/tests/desktop/desktop-icons-store.test.ts
@@ -184,4 +184,27 @@ describe("native Desktop icon layout", () => {
 
     expect(useDesktopIcons.getState().icons).toContainEqual({ path: "__chat__", x: 240, y: 180 });
   });
+
+  it("defers focus hydration until an in-flight icon write succeeds", async () => {
+    let finishPatch: (() => void) | undefined;
+    const api = {
+      get: vi.fn(async () => ({ desktopIcons: [CHAT, FILES] })),
+      patch: vi.fn(() => new Promise<{ ok: true }>((resolve) => {
+        finishPatch = () => resolve({ ok: true });
+      })),
+    };
+    await useDesktopIcons.getState().load(api as never, [CHAT, FILES]);
+
+    const move = useDesktopIcons.getState().move("__chat__", 240, 180, api as never);
+    await vi.waitFor(() => expect(api.patch).toHaveBeenCalledTimes(1));
+    const overlappingHydrationRevision = captureDesktopIconsHydrationRevision();
+    useDesktopIcons.getState().hydrate([CHAT, FILES], [CHAT, FILES], overlappingHydrationRevision);
+
+    expect(useDesktopIcons.getState().icons).toContainEqual({ path: "__chat__", x: 240, y: 180 });
+
+    finishPatch?.();
+    await move;
+
+    expect(useDesktopIcons.getState().icons).toContainEqual({ path: "__chat__", x: 240, y: 180 });
+  });
 });

--- a/tests/desktop/desktop-icons-store.test.ts
+++ b/tests/desktop/desktop-icons-store.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useDesktopIcons } from "@desktop/renderer/src/stores/desktop-icons";
+
+const CHAT = { path: "__chat__", x: 20, y: 20 };
+const FILES = { path: "__file-browser__", x: 108, y: 20 };
+
+describe("native Desktop icon layout", () => {
+  beforeEach(() => useDesktopIcons.setState(useDesktopIcons.getInitialState(), true));
+
+  it("loads the owner-controlled layout from desktop settings", async () => {
+    const api = { get: vi.fn(async () => ({ desktopIcons: [FILES] })) };
+
+    await useDesktopIcons.getState().load(api as never, [CHAT, FILES]);
+
+    expect(useDesktopIcons.getState().icons).toEqual([FILES]);
+  });
+
+  it("persists moving, removing, and adding icons through the bounded desktop patch", async () => {
+    const api = {
+      get: vi.fn(async () => ({ desktopIcons: [CHAT, FILES] })),
+      patch: vi.fn(async () => ({ ok: true })),
+    };
+    await useDesktopIcons.getState().load(api as never, [CHAT, FILES]);
+
+    await useDesktopIcons.getState().move("__chat__", 240, 180, api as never);
+    await useDesktopIcons.getState().remove("__file-browser__", api as never);
+    await useDesktopIcons.getState().add("apps/notes/index.html", api as never);
+
+    expect(useDesktopIcons.getState().icons).toContainEqual({ path: "__chat__", x: 240, y: 180 });
+    expect(useDesktopIcons.getState().icons.some((icon) => icon.path === "__file-browser__")).toBe(false);
+    expect(useDesktopIcons.getState().icons.some((icon) => icon.path === "apps/notes/index.html")).toBe(true);
+    expect(api.patch).toHaveBeenLastCalledWith("/api/settings/desktop", {
+      desktopIcons: useDesktopIcons.getState().icons,
+    });
+  });
+});

--- a/tests/desktop/desktop-icons-store.test.ts
+++ b/tests/desktop/desktop-icons-store.test.ts
@@ -72,6 +72,25 @@ describe("native Desktop icon layout", () => {
     expect(useDesktopIcons.getState()).toMatchObject({ icons: [FILES], loaded: true });
   });
 
+  it("replays settings hydration that resolves before an initial icon write fails", async () => {
+    let rejectPatch: ((error: Error) => void) | undefined;
+    const api = {
+      patch: vi.fn(() => new Promise<never>((_resolve, reject) => {
+        rejectPatch = reject;
+      })),
+    };
+    const pendingHydrationRevision = captureDesktopIconsHydrationRevision();
+    useDesktopIcons.getState().prime([CHAT, FILES]);
+
+    const move = useDesktopIcons.getState().move("__chat__", 240, 180, api as never);
+    await vi.waitFor(() => expect(api.patch).toHaveBeenCalledTimes(1));
+    useDesktopIcons.getState().hydrate([FILES], [CHAT, FILES], pendingHydrationRevision);
+    rejectPatch?.(new Error("offline"));
+    await move;
+
+    expect(useDesktopIcons.getState()).toMatchObject({ icons: [FILES], loaded: true });
+  });
+
   it("keeps a later successful queued layout when an earlier write fails", async () => {
     const api = {
       get: vi.fn(async () => ({ desktopIcons: [CHAT, FILES] })),

--- a/tests/desktop/desktop-icons-store.test.ts
+++ b/tests/desktop/desktop-icons-store.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useDesktopIcons } from "@desktop/renderer/src/stores/desktop-icons";
+import { resetDesktopIconsRuntime, useDesktopIcons } from "@desktop/renderer/src/stores/desktop-icons";
 
 const CHAT = { path: "__chat__", x: 20, y: 20 };
 const FILES = { path: "__file-browser__", x: 108, y: 20 };
 
 describe("native Desktop icon layout", () => {
-  beforeEach(() => useDesktopIcons.setState(useDesktopIcons.getInitialState(), true));
+  beforeEach(() => {
+    resetDesktopIconsRuntime();
+    useDesktopIcons.setState(useDesktopIcons.getInitialState(), true);
+  });
 
   it("loads the owner-controlled layout from desktop settings", async () => {
     const api = { get: vi.fn(async () => ({ desktopIcons: [FILES] })) };
@@ -32,5 +35,33 @@ describe("native Desktop icon layout", () => {
     expect(api.patch).toHaveBeenLastCalledWith("/api/settings/desktop", {
       desktopIcons: useDesktopIcons.getState().icons,
     });
+  });
+
+  it("rolls the optimistic layout back when persistence fails", async () => {
+    const api = {
+      get: vi.fn(async () => ({ desktopIcons: [CHAT, FILES] })),
+      patch: vi.fn(async () => { throw new Error("offline"); }),
+    };
+    await useDesktopIcons.getState().load(api as never, [CHAT, FILES]);
+
+    await useDesktopIcons.getState().move("__chat__", 240, 180, api as never);
+
+    expect(useDesktopIcons.getState().icons).toEqual([CHAT, FILES]);
+  });
+
+  it("keeps a later successful queued layout when an earlier write fails", async () => {
+    const api = {
+      get: vi.fn(async () => ({ desktopIcons: [CHAT, FILES] })),
+      patch: vi.fn()
+        .mockRejectedValueOnce(new Error("offline"))
+        .mockResolvedValueOnce({ ok: true }),
+    };
+    await useDesktopIcons.getState().load(api as never, [CHAT, FILES]);
+
+    const move = useDesktopIcons.getState().move("__chat__", 240, 180, api as never);
+    const remove = useDesktopIcons.getState().remove("__file-browser__", api as never);
+    await Promise.all([move, remove]);
+
+    expect(useDesktopIcons.getState().icons).toEqual([{ path: "__chat__", x: 240, y: 180 }]);
   });
 });

--- a/tests/desktop/desktop-icons-store.test.ts
+++ b/tests/desktop/desktop-icons-store.test.ts
@@ -91,6 +91,50 @@ describe("native Desktop icon layout", () => {
     expect(useDesktopIcons.getState()).toMatchObject({ icons: [FILES], loaded: true });
   });
 
+  it("replays hydration captured between two failed initial icon writes", async () => {
+    const rejectPatch: Array<(error: Error) => void> = [];
+    const api = {
+      patch: vi.fn(() => new Promise<never>((_resolve, reject) => {
+        rejectPatch.push(reject);
+      })),
+    };
+    useDesktopIcons.getState().prime([CHAT, FILES]);
+
+    const move = useDesktopIcons.getState().move("__chat__", 240, 180, api as never);
+    await vi.waitFor(() => expect(api.patch).toHaveBeenCalledTimes(1));
+    const intermediateHydrationRevision = captureDesktopIconsHydrationRevision();
+    const remove = useDesktopIcons.getState().remove("__file-browser__", api as never);
+    useDesktopIcons.getState().hydrate([FILES], [CHAT, FILES], intermediateHydrationRevision);
+    rejectPatch[0]?.(new Error("first offline"));
+    await vi.waitFor(() => expect(api.patch).toHaveBeenCalledTimes(2));
+    rejectPatch[1]?.(new Error("second offline"));
+    await Promise.all([move, remove]);
+
+    expect(useDesktopIcons.getState()).toMatchObject({ icons: [FILES], loaded: true });
+  });
+
+  it("accepts intermediate hydration after both initial icon writes already failed", async () => {
+    const rejectPatch: Array<(error: Error) => void> = [];
+    const api = {
+      patch: vi.fn(() => new Promise<never>((_resolve, reject) => {
+        rejectPatch.push(reject);
+      })),
+    };
+    useDesktopIcons.getState().prime([CHAT, FILES]);
+
+    const move = useDesktopIcons.getState().move("__chat__", 240, 180, api as never);
+    await vi.waitFor(() => expect(api.patch).toHaveBeenCalledTimes(1));
+    const intermediateHydrationRevision = captureDesktopIconsHydrationRevision();
+    const remove = useDesktopIcons.getState().remove("__file-browser__", api as never);
+    rejectPatch[0]?.(new Error("first offline"));
+    await vi.waitFor(() => expect(api.patch).toHaveBeenCalledTimes(2));
+    rejectPatch[1]?.(new Error("second offline"));
+    await Promise.all([move, remove]);
+    useDesktopIcons.getState().hydrate([FILES], [CHAT, FILES], intermediateHydrationRevision);
+
+    expect(useDesktopIcons.getState()).toMatchObject({ icons: [FILES], loaded: true });
+  });
+
   it("keeps a later successful queued layout when an earlier write fails", async () => {
     const api = {
       get: vi.fn(async () => ({ desktopIcons: [CHAT, FILES] })),

--- a/tests/desktop/desktop-renderer-url.test.ts
+++ b/tests/desktop/desktop-renderer-url.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  DESKTOP_DEV_RENDERER_HOST,
+  desktopDevHostResolverRules,
+  resolveDesktopRendererUrl,
+} from "@desktop/main/renderer-url";
+
+describe("Desktop renderer URL", () => {
+  it("maps the local Vite renderer onto an allowed Matrix development hostname", () => {
+    expect(resolveDesktopRendererUrl("http://127.0.0.1:5173/")).toBe(
+      `http://${DESKTOP_DEV_RENDERER_HOST}:5173/`,
+    );
+    expect(resolveDesktopRendererUrl("http://localhost:5173/path?mode=desktop")).toBe(
+      `http://${DESKTOP_DEV_RENDERER_HOST}:5173/path?mode=desktop`,
+    );
+    expect(desktopDevHostResolverRules()).toBe(
+      `MAP ${DESKTOP_DEV_RENDERER_HOST} 127.0.0.1`,
+    );
+  });
+
+  it("does not rewrite non-local or malformed renderer URLs", () => {
+    expect(resolveDesktopRendererUrl("https://app.matrix-os.com/desktop")).toBe(
+      "https://app.matrix-os.com/desktop",
+    );
+    expect(resolveDesktopRendererUrl("not a URL")).toBe("not a URL");
+    expect(resolveDesktopRendererUrl(undefined)).toBeUndefined();
+  });
+});

--- a/tests/desktop/desktop-support-widget.test.tsx
+++ b/tests/desktop/desktop-support-widget.test.tsx
@@ -6,6 +6,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import DesktopModeControls from "@desktop/renderer/src/features/desktop-shell/DesktopModeControls";
 import DesktopSupportWidget from "@desktop/renderer/src/features/support/DesktopSupportWidget";
 import { useConnection } from "@desktop/renderer/src/stores/connection";
+import { useBrowserNavigation } from "@desktop/renderer/src/stores/browser-navigation";
+import { useTabs } from "@desktop/renderer/src/stores/tabs";
 import { useUi } from "@desktop/renderer/src/stores/ui";
 
 const posthogClient = vi.hoisted(() => ({
@@ -79,6 +81,8 @@ describe("Desktop support widget", () => {
       platformHost: "https://app.matrix-os.com",
       authGeneration: 1,
     });
+    useBrowserNavigation.setState(useBrowserNavigation.getInitialState(), true);
+    useTabs.setState(useTabs.getInitialState(), true);
   });
 
   afterEach(() => {
@@ -103,6 +107,18 @@ describe("Desktop support widget", () => {
       "[desktop-support] PostHog initialization failed:",
       "Error",
     );
+  });
+
+  it("keeps Support visible without redirecting an unconfigured chat button to docs", async () => {
+    vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "");
+
+    render(<DesktopModeControls />);
+    expect(screen.getByRole("button", { name: "Support" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Support" }));
+
+    await act(async () => Promise.resolve());
+    expect(useTabs.getState().tabs).toEqual([]);
+    expect(useBrowserNavigation.getState().pending).toBeNull();
   });
 
   it("loads PostHog Conversations through the first-party relay without broad Desktop capture", async () => {
@@ -172,7 +188,7 @@ describe("Desktop support widget", () => {
     await waitFor(() => expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull());
 
     expect(screen.getAllByRole("button").map((button) => button.getAttribute("aria-label") ?? button.textContent))
-      .toEqual(["Search", "Main computer", "Support", "Open account menu"]);
+      .toEqual(["Search", "Support", "Main computer", "Open account menu"]);
 
     fireEvent.click(screen.getByRole("button", { name: "Search" }));
     expect(useUi.getState().paletteOpen).toBe(true);

--- a/tests/desktop/desktop-support-widget.test.tsx
+++ b/tests/desktop/desktop-support-widget.test.tsx
@@ -83,6 +83,7 @@ describe("Desktop support widget", () => {
     });
     useBrowserNavigation.setState(useBrowserNavigation.getInitialState(), true);
     useTabs.setState(useTabs.getInitialState(), true);
+    useUi.setState(useUi.getInitialState(), true);
   });
 
   afterEach(() => {
@@ -196,6 +197,7 @@ describe("Desktop support widget", () => {
     fireEvent.click(screen.getByRole("button", { name: "Support" }));
 
     await waitFor(() => expect(posthogClient.conversations.show).toHaveBeenCalledTimes(1));
+    expect(useUi.getState().rendererOverlayCount).toBe(1);
     expect(await screen.findByRole("button", { name: "Close" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull();
 
@@ -209,11 +211,13 @@ describe("Desktop support widget", () => {
     fireEvent.click(replacementClose);
 
     await waitFor(() => expect(document.getElementById("ph-conversations-widget-container")).toBeNull());
+    await waitFor(() => expect(useUi.getState().rendererOverlayCount).toBe(0));
     expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Support" }));
 
     await waitFor(() => expect(posthogClient.conversations.show).toHaveBeenCalledTimes(2));
+    expect(useUi.getState().rendererOverlayCount).toBe(1);
     expect(await screen.findByRole("button", { name: "Close" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull();
   });

--- a/tests/desktop/desktop-support-widget.test.tsx
+++ b/tests/desktop/desktop-support-widget.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import DesktopModeControls from "@desktop/renderer/src/features/desktop-shell/DesktopModeControls";
 import DesktopSupportWidget from "@desktop/renderer/src/features/support/DesktopSupportWidget";
 import { useConnection } from "@desktop/renderer/src/stores/connection";
+import { useUi } from "@desktop/renderer/src/stores/ui";
 
 const posthogClient = vi.hoisted(() => ({
   conversations: {
@@ -13,6 +14,7 @@ const posthogClient = vi.hoisted(() => ({
     isAvailable: vi.fn(() => true),
     show: vi.fn(),
   },
+  capture: vi.fn(),
   identify: vi.fn(),
   init: vi.fn(),
   reset: vi.fn(),
@@ -170,7 +172,10 @@ describe("Desktop support widget", () => {
     await waitFor(() => expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull());
 
     expect(screen.getAllByRole("button").map((button) => button.getAttribute("aria-label") ?? button.textContent))
-      .toEqual(["Main computer", "Support", "Open account menu"]);
+      .toEqual(["Search", "Main computer", "Support", "Open account menu"]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    expect(useUi.getState().paletteOpen).toBe(true);
 
     fireEvent.click(screen.getByRole("button", { name: "Support" }));
 
@@ -215,6 +220,20 @@ describe("Desktop support widget", () => {
     expect(posthogClient.reset).toHaveBeenCalledTimes(1);
     expect(posthogClient.identify).toHaveBeenLastCalledWith("neo", {
       $name: "Neo",
+      matrix_client: "desktop",
+    });
+  });
+
+  it("captures bounded Desktop lifecycle events after identifying the account", async () => {
+    render(<DesktopSupportWidget />);
+    await waitFor(() => expect(posthogClient.identify).toHaveBeenCalled());
+
+    window.dispatchEvent(new CustomEvent("matrix:desktop-analytics", {
+      detail: { name: "desktop_app_opened", appKind: "browser" },
+    }));
+
+    expect(posthogClient.capture).toHaveBeenCalledWith("desktop_app_opened", {
+      app_kind: "browser",
       matrix_client: "desktop",
     });
   });

--- a/tests/desktop/desktop-surface-pane-active.test.ts
+++ b/tests/desktop/desktop-surface-pane-active.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { shouldActivateDesktopPane } from "@desktop/renderer/src/features/desktop-shell/DesktopSurfaceFrame";
+
+describe("desktop native pane activation", () => {
+  it("detaches native embeds while Show Desktop hides or transitions their windows", () => {
+    const base = {
+      active: true,
+      visible: true,
+      overlayOpen: false,
+      isNativeEmbed: true,
+    };
+
+    expect(shouldActivateDesktopPane({
+      ...base,
+      isDesktopHidden: true,
+      isDesktopTransition: false,
+    })).toBe(false);
+    expect(shouldActivateDesktopPane({
+      ...base,
+      isDesktopHidden: false,
+      isDesktopTransition: true,
+    })).toBe(false);
+  });
+
+  it("keeps ordinary visible panes active", () => {
+    expect(shouldActivateDesktopPane({
+      active: true,
+      visible: true,
+      overlayOpen: false,
+      isNativeEmbed: true,
+      isDesktopHidden: false,
+      isDesktopTransition: false,
+    })).toBe(true);
+  });
+});

--- a/tests/desktop/editor-save.test.ts
+++ b/tests/desktop/editor-save.test.ts
@@ -80,11 +80,11 @@ describe("createFilesApi", () => {
     });
   });
 
-  it("reads raw text from /files with per-segment path encoding", async () => {
+  it("reads raw text through the authenticated file-blob route", async () => {
     const api = makeApi();
     const files = createFilesApi(api);
     await expect(files.read("projects/my notes.md")).resolves.toBe("file body");
-    expect(api.getText).toHaveBeenCalledWith("/files/projects/my%20notes.md");
+    expect(api.getText).toHaveBeenCalledWith("/api/files/blob?path=projects%2Fmy%20notes.md");
   });
 
   it("passes the configured transfer cap to bounded editor reads", async () => {
@@ -92,16 +92,19 @@ describe("createFilesApi", () => {
     const files = createFilesApi(api, 1_024);
     await expect(files.read("projects/large notes.md")).resolves.toBe("file body");
     expect(api.getText).toHaveBeenCalledWith(
-      "/files/projects/large%20notes.md",
+      "/api/files/blob?path=projects%2Flarge%20notes.md",
       { maxBytes: 1_024 },
     );
   });
 
-  it("writes raw text via PUT /files with per-segment path encoding", async () => {
+  it("writes raw text through the authenticated file-blob route", async () => {
     const api = makeApi();
     const files = createFilesApi(api);
     await expect(files.write("projects/my notes.md", "hello")).resolves.toEqual({ mtime: null });
-    expect(api.putText).toHaveBeenCalledWith("/files/projects/my%20notes.md", "hello");
+    expect(api.putText).toHaveBeenCalledWith(
+      "/api/files/blob?path=projects%2Fmy%20notes.md&force=true",
+      "hello",
+    );
   });
 
   it("returns the normalized write mtime when PUT includes modified metadata", async () => {

--- a/tests/desktop/embed-manager.test.ts
+++ b/tests/desktop/embed-manager.test.ts
@@ -425,7 +425,7 @@ describe("EmbedManager", () => {
 
     expect(created).toEqual([{
       kind: "browser",
-      partition: expect.stringMatching(/^runtime-browser-/),
+      partition: "persist:browser",
       allowedOrigins: ["http://127.0.0.1:49152"],
     }]);
   });

--- a/tests/desktop/embed-service.test.ts
+++ b/tests/desktop/embed-service.test.ts
@@ -121,6 +121,43 @@ describe("EmbedService", () => {
     service.closeAll();
   });
 
+  it("opens public websites directly without starting a runtime tunnel", async () => {
+    const startPortForward = vi.fn();
+    const service = new EmbedService({
+      getWindow: () => null,
+      getGatewayOrigin: () => "https://gateway.test",
+      getToken: () => "token",
+      emitState: vi.fn(),
+      startPortForward,
+    });
+    const internals = service as unknown as {
+      manager: { open: (...args: unknown[]) => string };
+    };
+    const open = vi.spyOn(internals.manager, "open").mockImplementation((...args) => (
+      (args[4] as { id: string }).id
+    ));
+
+    const result = await service.open({
+      kind: "browser",
+      url: "https://matrix-os.com/docs",
+      bounds: BOUNDS,
+    });
+
+    expect(result.state).toBe("loading");
+    expect(startPortForward).not.toHaveBeenCalled();
+    expect(open).toHaveBeenCalledWith(
+      "browser",
+      null,
+      BOUNDS,
+      "https://matrix-os.com/docs",
+      expect.objectContaining({
+        id: result.embedId,
+        allowedOrigins: ["https://matrix-os.com"],
+        allowPublicNavigation: true,
+      }),
+    );
+  });
+
   it("tunnels runtime loopback pages through Matrix and closes the tunnel with the embed", async () => {
     const closeForward = vi.fn(async () => {});
     const startPortForward = vi.fn(async () => ({

--- a/tests/desktop/integrations-settings-section.test.tsx
+++ b/tests/desktop/integrations-settings-section.test.tsx
@@ -172,6 +172,25 @@ describe("desktop integrations settings section", () => {
     ]);
   });
 
+  it("keeps connected status, add-account, and disconnect as separate controls", async () => {
+    const api = makeApi({
+      available: [
+        { id: "slack", name: "Slack", category: "communication", logoUrl: "https://cdn.test/slack.png", actions: {} },
+      ],
+      connections: [{ ...GMAIL_CONNECTION, service: "slack", account_label: "Slack" }],
+    });
+    useConnection.setState({ api: api as never });
+    render(<IntegrationsSettingsSection />);
+
+    const connectedStatus = await screen.findByTestId("integration-status-slack");
+    const addAccount = screen.getByRole("button", { name: "Add another Slack account" });
+    const disconnect = screen.getByRole("button", { name: "Disconnect Slack" });
+
+    expect(connectedStatus.contains(addAccount)).toBe(false);
+    expect(connectedStatus.contains(disconnect)).toBe(false);
+    expect(disconnect.className).not.toContain("absolute");
+  });
+
   it("capitalizes service ids in the connected section when no catalog name exists", async () => {
     useConnection.setState({
       api: makeApi({ available: [], connections: [{ ...GMAIL_CONNECTION, service: "google_calendar" }] }) as never,
@@ -372,6 +391,7 @@ describe("desktop integrations settings section", () => {
     useConnection.setState({ api: api as never });
     render(<IntegrationsSettingsSection />);
 
+    await waitFor(() => expect(screen.getByRole("button", { name: "Add another Gmail account" })).not.toBeNull());
     await waitFor(() => expect(screen.getByRole("button", { name: "Disconnect Personal" })).not.toBeNull());
     fireEvent.click(screen.getByRole("button", { name: "Disconnect Personal" }));
     await waitFor(() => expect(screen.getByText(/Disconnect Personal\?/)).not.toBeNull());
@@ -380,13 +400,13 @@ describe("desktop integrations settings section", () => {
     await waitFor(() => expect(api.delete).toHaveBeenCalledWith(`/api/integrations/${NEW_CONN_ID}`));
   });
 
-  it("does not expose a first-account hover disconnect for multi-account services", async () => {
+  it("uses the visible per-account disconnect instead of a hover overlay", async () => {
     const api = makeApi({ connections: [GMAIL_CONNECTION, NEW_GMAIL_CONNECTION] });
     useConnection.setState({ api: api as never });
     render(<IntegrationsSettingsSection />);
 
     await waitFor(() => expect(screen.getByRole("button", { name: "Disconnect Personal" })).not.toBeNull());
-    expect(screen.queryByTestId(`integration-disconnect-${CONN_ID}`)).toBeNull();
+    expect(screen.getByTestId(`integration-disconnect-${CONN_ID}`).textContent).toBe("Disconnect");
   });
 
   it("keeps the account and shows generic copy when disconnect fails", async () => {

--- a/tests/desktop/monaco-editor-host.test.tsx
+++ b/tests/desktop/monaco-editor-host.test.tsx
@@ -6,6 +6,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import MonacoEditorHost, { MAX_MONACO_FILE_BYTES } from "@desktop/renderer/src/features/editor/MonacoEditorHost";
 import { useConnection } from "@desktop/renderer/src/stores/connection";
 
+const monacoMocks = vi.hoisted(() => ({
+  create: vi.fn(() => {
+    throw new Error("monaco failed to initialize");
+  }),
+  createModel: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+vi.mock("monaco-editor", () => ({
+  editor: {
+    create: monacoMocks.create,
+    createModel: monacoMocks.createModel,
+  },
+}));
+
 function makeApi() {
   const get = vi.fn(async () => ({ modified: "2026-08-29T10:00:00.000Z" }));
   const getText = vi.fn(async () => "export const value = 1;\n");
@@ -65,5 +79,24 @@ describe("MonacoEditorHost", () => {
     });
 
     expect(api.putText).not.toHaveBeenCalled();
+  });
+
+  it("keeps loaded file content visible when Monaco cannot initialize", async () => {
+    const originalWorker = globalThis.Worker;
+    const originalUserAgent = navigator.userAgent;
+    Object.defineProperty(globalThis, "Worker", { configurable: true, value: class WorkerStub {} });
+    Object.defineProperty(navigator, "userAgent", { configurable: true, value: "Matrix OS Electron" });
+    try {
+      const api = makeApi();
+      useConnection.setState({ api: api as never });
+
+      render(<MonacoEditorHost path="projects/app/src/main.ts" active onDirtyChange={vi.fn()} />);
+
+      const fallback = await screen.findByRole("textbox", { name: "Edit projects/app/src/main.ts" });
+      expect((fallback as HTMLTextAreaElement).value).toBe("export const value = 1;\n");
+    } finally {
+      Object.defineProperty(globalThis, "Worker", { configurable: true, value: originalWorker });
+      Object.defineProperty(navigator, "userAgent", { configurable: true, value: originalUserAgent });
+    }
   });
 });

--- a/tests/desktop/monaco-editor-host.test.tsx
+++ b/tests/desktop/monaco-editor-host.test.tsx
@@ -43,7 +43,7 @@ describe("MonacoEditorHost", () => {
 
     const editor = await screen.findByRole("textbox", { name: "Edit projects/app/src/main.ts" });
     expect(api.getText).toHaveBeenCalledWith(
-      "/files/projects/app/src/main.ts",
+      "/api/files/blob?path=projects%2Fapp%2Fsrc%2Fmain.ts",
       { maxBytes: MAX_MONACO_FILE_BYTES },
     );
     fireEvent.change(editor, { target: { value: "export const value = 2;\n" } });
@@ -51,7 +51,7 @@ describe("MonacoEditorHost", () => {
     fireEvent.keyDown(window, { key: "s", metaKey: true });
 
     await waitFor(() => expect(api.putText).toHaveBeenCalledWith(
-      "/files/projects/app/src/main.ts",
+      "/api/files/blob?path=projects%2Fapp%2Fsrc%2Fmain.ts&force=true",
       "export const value = 2;\n",
     ));
     expect(onDirtyChange).toHaveBeenLastCalledWith(false);

--- a/tests/desktop/native-desktop-shell.test.tsx
+++ b/tests/desktop/native-desktop-shell.test.tsx
@@ -13,6 +13,7 @@ import { useTabs } from "@desktop/renderer/src/stores/tabs";
 import { useUi } from "@desktop/renderer/src/stores/ui";
 import { useNativeDesktopMode } from "@desktop/renderer/src/stores/native-desktop-mode";
 import { useDesktopAppDrawer } from "@desktop/renderer/src/stores/desktop-app-drawer";
+import { useDesktopIcons } from "@desktop/renderer/src/stores/desktop-icons";
 
 const createObjectURLDescriptor = Object.getOwnPropertyDescriptor(URL, "createObjectURL");
 const revokeObjectURLDescriptor = Object.getOwnPropertyDescriptor(URL, "revokeObjectURL");
@@ -69,6 +70,7 @@ beforeEach(() => {
   useUi.setState(useUi.getInitialState(), true);
   useNativeDesktopMode.setState(useNativeDesktopMode.getInitialState(), true);
   useDesktopAppDrawer.setState(useDesktopAppDrawer.getInitialState(), true);
+  useDesktopIcons.setState(useDesktopIcons.getInitialState(), true);
   useNativeDesktopMode.setState({ hydrated: true });
   window.operator = {
     invoke: vi.fn(async (channel: string) => channel === "state:get"
@@ -621,7 +623,7 @@ describe("native desktop shell", () => {
     fireEvent.click(within(screen.getByRole("dialog", { name: "App launcher" }))
       .getByRole("button", { name: "Notes" }));
 
-    const notesTab = useTabs.getState().tabs.find((candidate) => candidate.kind === "app")!;
+    const notesTab = useTabs.getState().tabs.find((candidate) => candidate.kind === "notes")!;
     expect(useDesktopSurfaces.getState().workspaceView).toBe("desktop");
     expect(useDesktopSurfaces.getState().surfaces[notesTab.id]?.mode).toBe("window");
   });

--- a/tests/desktop/native-desktop-shell.test.tsx
+++ b/tests/desktop/native-desktop-shell.test.tsx
@@ -152,6 +152,9 @@ describe("native desktop shell", () => {
   it("opens the background menu from an empty desktop right-click", async () => {
     render(<NativeDesktopShell overlayOpen={false} />);
 
+    const iconLayer = screen.getByRole("navigation", { name: "Desktop apps" });
+    expect(iconLayer.className).toContain("pointer-events-none");
+    expect(screen.getByRole("button", { name: "Chat" }).className).toContain("pointer-events-auto");
     fireEvent.contextMenu(screen.getByTestId("native-desktop-workspace"));
 
     expect(await screen.findByText("Change background…")).toBeTruthy();

--- a/tests/desktop/runtime-browser-url.test.ts
+++ b/tests/desktop/runtime-browser-url.test.ts
@@ -20,20 +20,20 @@ describe("desktop browser address routing", () => {
     });
   });
 
-  it("opens public web addresses in local Chromium", () => {
+  it("opens public web addresses inside the Desktop Browser", () => {
     expect(resolveBrowserAddress("docs.matrix-os.com")).toEqual({
-      disposition: "external",
+      disposition: "public",
       url: "https://docs.matrix-os.com/",
     });
     expect(resolveBrowserAddress("https://developer.mozilla.org/en-US/")).toEqual({
-      disposition: "external",
+      disposition: "public",
       url: "https://developer.mozilla.org/en-US/",
     });
   });
 
-  it("turns free text into a local-browser web search", () => {
+  it("turns free text into an in-app web search", () => {
     expect(resolveBrowserAddress("Matrix OS docs")).toEqual({
-      disposition: "external",
+      disposition: "public",
       url: "https://www.google.com/search?q=Matrix+OS+docs",
     });
   });
@@ -57,7 +57,7 @@ describe("desktop browser address routing", () => {
 
   it("blocks all runtime-controlled off-tunnel navigation before DNS resolution", () => {
     expect(resolveBrowserAddress("https://matrix-os.com/docs")).toEqual({
-      disposition: "external",
+      disposition: "public",
       url: "https://matrix-os.com/docs",
     });
     expect(resolveRuntimeBrowserNavigation(

--- a/tests/desktop/runtime-transition.test.ts
+++ b/tests/desktop/runtime-transition.test.ts
@@ -16,6 +16,8 @@ import { useThreads } from "../../desktop/src/renderer/src/stores/threads";
 import { useWorkspace } from "../../desktop/src/renderer/src/stores/workspace";
 import { useApps } from "../../desktop/src/renderer/src/stores/apps";
 import { useDesktopSurfaces } from "../../desktop/src/renderer/src/stores/desktop-surfaces";
+import { useDesktopIcons } from "../../desktop/src/renderer/src/stores/desktop-icons";
+import { useCreateAppRequest } from "../../desktop/src/renderer/src/stores/create-app-request";
 
 describe("desktop runtime transition", () => {
   beforeEach(() => {
@@ -57,6 +59,8 @@ describe("desktop runtime transition", () => {
       workspaceView: "tabs",
       nextZIndex: 41,
     });
+    useDesktopIcons.setState({ icons: [{ path: "__chat__", x: 20, y: 20 }], loaded: true });
+    useCreateAppRequest.getState().requestDraft();
     useCodingAgentWorkspace.setState({ activeThreadId: "thread_old", selectedReviewId: "review_old" });
     useProjectWorkspaces.setState({
       entries: {
@@ -93,6 +97,8 @@ describe("desktop runtime transition", () => {
     expect(useProjectWorkspaces.getState().entries).toEqual({});
     expect(useProjectView.getState().entries).toEqual({});
     expect(useDesktopSurfaces.getState()).toMatchObject({ surfaces: {}, workspaceView: "desktop" });
+    expect(useDesktopIcons.getState()).toMatchObject({ icons: [], loaded: false });
+    expect(useCreateAppRequest.getState().request).toBeNull();
   });
 
   it("clears unsent chat drafts owned by the previous identity", () => {

--- a/tests/desktop/shell-sessions-store.test.ts
+++ b/tests/desktop/shell-sessions-store.test.ts
@@ -58,6 +58,8 @@ describe("useShellSessions", () => {
           sessions: [
             {
               name: "matrix-main",
+              cwd: "projects/matrix-os",
+              pinned: true,
               status: "active",
               placement: "active",
               createdAt: "2026-06-23T11:00:00.000Z",
@@ -97,6 +99,8 @@ describe("useShellSessions", () => {
     expect(useShellSessions.getState().sessions[0]?.tabs).toEqual([{ idx: 0, name: "main", focused: true }]);
     expect(useShellSessions.getState().sessions[0]).toMatchObject({
       createdAt: "2026-06-23T11:00:00.000Z",
+      cwd: "projects/matrix-os",
+      pinned: true,
       agent: "codex",
       subtitle: "Implement agent-aware terminal sessions",
       lastAction: "Edited registry.ts",

--- a/tests/desktop/sidebar-navigation-shell.test.tsx
+++ b/tests/desktop/sidebar-navigation-shell.test.tsx
@@ -8,6 +8,7 @@ import Sidebar from "../../desktop/src/renderer/src/features/mission-control/Sid
 import { useBoard } from "../../desktop/src/renderer/src/stores/board";
 import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+import { useBrowserNavigation } from "../../desktop/src/renderer/src/stores/browser-navigation";
 import { useHermesChat } from "../../desktop/src/renderer/src/stores/hermes-chat";
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 import { useThreads } from "../../desktop/src/renderer/src/stores/threads";
@@ -69,6 +70,7 @@ describe("Desktop sidebar navigation shell", () => {
       activeThreadId: null,
     });
     useTabs.setState(useTabs.getInitialState(), true);
+    useBrowserNavigation.setState(useBrowserNavigation.getInitialState(), true);
     useTabs.getState().ensureNavigationScope("runtime-a");
     useTabs.getState().openTab({ kind: "project", projectSlug: "matrix-os", title: "Matrix OS" });
     useTabs.getState().openTab({ kind: "terminal", sessionName: "dev", title: "dev" });
@@ -404,7 +406,12 @@ describe("Desktop sidebar navigation shell", () => {
 
     fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
     fireEvent.click(await screen.findByRole("menuitem", { name: "Get help" }));
-    expect(invoke).toHaveBeenCalledWith("shell:open-external", { url: "https://matrix-os.com/docs" });
+    expect(useTabs.getState().tabs.find((tab) => tab.id === useTabs.getState().activeTabId))
+      .toMatchObject({ kind: "browser", title: "Browser" });
+    expect(useBrowserNavigation.getState().pending).toMatchObject({
+      url: "https://matrix-os.com/docs",
+    });
+    expect(invoke).not.toHaveBeenCalledWith("shell:open-external", expect.anything());
 
     fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
     fireEvent.click(await screen.findByRole("menuitem", { name: "Logout" }));

--- a/tests/desktop/terminal-session-sidebar.test.tsx
+++ b/tests/desktop/terminal-session-sidebar.test.tsx
@@ -6,14 +6,14 @@ import { describe, expect, it, vi } from "vitest";
 import { TerminalSessionSidebar } from "../../desktop/src/renderer/src/features/terminal/TerminalSessionSidebar.js";
 
 describe("TerminalSessionSidebar", () => {
-  it("opens sessions from a non-squashing, scrollable list with status dots", () => {
+  it("opens sessions from a non-squashing, scrollable list with active paths and no status dots", () => {
     const onSelect = vi.fn();
     const onCreate = vi.fn();
     const onDelete = vi.fn();
     const { container } = render(
       <TerminalSessionSidebar
         sessions={[
-          { name: "swift-willow", status: "active", updatedAt: new Date(Date.now() - 5 * 60_000).toISOString() },
+          { name: "swift-willow", status: "active", cwd: "projects/matrix-os", updatedAt: new Date(Date.now() - 5 * 60_000).toISOString() },
           { name: "quiet-pine", status: "exited" },
         ]}
         selectedName={null}
@@ -21,6 +21,7 @@ describe("TerminalSessionSidebar", () => {
         disabled={false}
         onCreate={onCreate}
         onSelect={onSelect}
+        onPin={vi.fn()}
         onDelete={onDelete}
       />,
     );
@@ -31,12 +32,12 @@ describe("TerminalSessionSidebar", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open swift-willow" }));
     expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ name: "swift-willow" }));
     expect(screen.getByText("5 minutes ago")).toBeTruthy();
-    fireEvent.mouseEnter(screen.getByRole("button", { name: "Open swift-willow" }));
-    fireEvent.click(screen.getByRole("button", { name: "Delete swift-willow" }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for swift-willow" }), { button: 0, ctrlKey: false });
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
     expect(onDelete).toHaveBeenCalledWith(expect.objectContaining({ name: "swift-willow" }));
     expect(onSelect).toHaveBeenCalledOnce();
-    expect(container.querySelector('[data-terminal-session-status="active"]')).toBeTruthy();
-    expect(container.querySelector('[data-terminal-session-status="inactive"]')).toBeTruthy();
+    expect(screen.getByText("~/projects/matrix-os")).toBeTruthy();
+    expect(container.querySelector("[data-terminal-session-status]")).toBeNull();
     expect(screen.getByRole("list", { name: "Terminal sessions" }).className).toContain("overflow-y-auto");
     expect(screen.queryByRole("button", { name: "Shell theme" })).toBeNull();
   });

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -556,15 +556,76 @@ describe("TerminalsTab", () => {
     expect(screen.queryByRole("textbox", { name: "Search terminal sessions" })).toBeNull();
   });
 
-  it("keeps the OS View sidebar delete action accessible", () => {
+  it("keeps delete and connect actions in one non-overlapping overflow menu", async () => {
     useShellSessions.setState({
       sessions: [{ name: "matrix-main", status: "active", placement: "active" }],
     });
 
     renderTab();
 
-    expect(screen.getByRole("button", { name: "Delete matrix-main" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "More actions for matrix-main" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Delete matrix-main" })).toBeNull();
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for matrix-main" }), { button: 0, ctrlKey: false });
+    expect(await screen.findByRole("menuitem", { name: "Copy connect command" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Delete" })).toBeTruthy();
+  });
+
+  it("opens the same session actions menu when a terminal row is right-clicked", async () => {
+    useShellSessions.setState({
+      sessions: [{ name: "matrix-main", status: "active", placement: "active" }],
+    });
+
+    renderTab();
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Open matrix-main" }));
+
+    expect(await screen.findByRole("menuitem", { name: "Rename" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Copy connect command" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Delete" })).toBeTruthy();
+  });
+
+  it("pins and unpins sessions from the shared overflow menu and keeps pinned sessions first", async () => {
+    const patchUiState = vi.fn().mockResolvedValue(true);
+    useShellSessions.setState({
+      sessions: [
+        { name: "matrix-later", status: "active" },
+        { name: "matrix-pinned", status: "active", pinned: true },
+      ],
+      patchUiState,
+    });
+
+    renderTab();
+
+    const rows = screen.getAllByRole("button", { name: /^Open matrix-/ });
+    expect(rows.map((row) => row.getAttribute("aria-label"))).toEqual([
+      "Open matrix-pinned",
+      "Open matrix-later",
+    ]);
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for matrix-later" }), { button: 0, ctrlKey: false });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Pin" }));
+    await waitFor(() => expect(patchUiState).toHaveBeenCalledWith(
+      useConnection.getState().api,
+      "matrix-later",
+      { pinned: true },
+    ));
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Open matrix-pinned" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Unpin" }));
+    await waitFor(() => expect(patchUiState).toHaveBeenCalledWith(
+      useConnection.getState().api,
+      "matrix-pinned",
+      { pinned: false },
+    ));
+  });
+
+  it("enters rename mode when the terminal session title is double-clicked", () => {
+    useShellSessions.setState({
+      sessions: [{ name: "matrix-main", status: "active", subtitle: "Fix terminal actions" }],
+    });
+
+    renderTab();
+    fireEvent.doubleClick(screen.getByTestId("terminal-session-title-matrix-main"));
+
+    expect(screen.getByRole<HTMLInputElement>("textbox", { name: "Terminal session name" }).value).toBe("matrix-main");
   });
 
   it("creates Claude, Codex, OpenCode, and Pi sessions from the new-terminal menu", async () => {
@@ -581,12 +642,40 @@ describe("TerminalsTab", () => {
     expect(screen.getByRole("menuitem", { name: /Codex/ })).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: /OpenCode/ })).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: /Pi/ })).toBeTruthy();
+    expect(screen.getByTestId("desktop-terminal-agent-logo-image-claude").getAttribute("src")).toContain("/agent-logos/claude-code.png");
+    expect(screen.getByTestId("desktop-terminal-agent-logo-image-codex").getAttribute("src")).toContain("/agent-logos/codex.png");
+    expect(screen.getByTestId("desktop-terminal-agent-logo-image-opencode").getAttribute("src")).toContain("/agent-logos/opencode-white.png");
+    expect(screen.getByTestId("desktop-terminal-agent-logo-image-pi").getAttribute("src")).toContain("/agent-logos/pi-coding-agent.png");
 
     fireEvent.click(screen.getByRole("menuitem", { name: /Codex/ }));
     await waitFor(() => expect(createShell).toHaveBeenCalledWith(useConnection.getState().api, {
       cmd: "codex",
       agent: "codex",
     }));
+  });
+
+  it("shows an agent session's task title and proper agent icon in its terminal tab", () => {
+    useShellSessions.setState({
+      sessions: [{
+        name: "matrix-codex-fix",
+        status: "active",
+        agent: "codex",
+        subtitle: "Fix terminal tabs",
+        model: "gpt-5.6",
+        cwd: "projects/matrix-os",
+      }],
+    });
+
+    renderTab();
+
+    expect(screen.getByText("Fix terminal tabs")).toBeTruthy();
+    const metadata = screen.getByTestId("terminal-session-agent-metadata-matrix-codex-fix");
+    expect(metadata.textContent).toContain("Codex · gpt-5.6");
+    expect(metadata.textContent).toContain("~/projects/matrix-os");
+    expect(screen.getByTestId("terminal-session-path-matrix-codex-fix").compareDocumentPosition(
+      screen.getByTestId("terminal-session-agent-matrix-codex-fix"),
+    ) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(metadata.contains(screen.getByTestId("desktop-terminal-session-agent-logo-image-codex"))).toBe(true);
   });
 
   it("keeps agents disabled when installation inventory is unresolved", async () => {
@@ -703,6 +792,7 @@ describe("TerminalsTab", () => {
         agent: "codex",
         model: "gpt-5.4",
         strength: "high",
+        subtitle: "Improve terminal session rows",
         lastAction: "Editing terminal sidebar",
       }],
     });
@@ -713,7 +803,8 @@ describe("TerminalsTab", () => {
     expect(row.textContent).toContain("Codex");
     expect(row.textContent).toContain("gpt-5.4");
     expect(row.textContent).toContain("high");
-    expect(row.textContent).toContain("Editing terminal sidebar");
+    expect(row.textContent).toContain("Improve terminal session rows");
+    expect(row.textContent).not.toContain("Editing terminal sidebar");
     expect(screen.getByRole("heading", { name: "matrix-main" })).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Editing terminal sidebar" })).toBeNull();
   });
@@ -745,7 +836,7 @@ describe("TerminalsTab", () => {
     ));
   });
 
-  it("renders canonical active, waiting, and closed lifecycle badges with relative activity", () => {
+  it("renders relative activity without lifecycle dots", () => {
     useShellSessions.setState({
       sessions: [
         { name: "matrix-active", status: "active", visualStatus: "running", updatedAt: new Date(Date.now() - 120_000).toISOString() },
@@ -758,8 +849,7 @@ describe("TerminalsTab", () => {
 
     expect(screen.getByRole("button", { name: "Open matrix-active" }).parentElement?.textContent)
       .toContain("2 minutes ago");
-    expect(document.querySelector('[data-terminal-session-status="active"]')).toBeTruthy();
-    expect(document.querySelectorAll('[data-terminal-session-status="inactive"]')).toHaveLength(2);
+    expect(document.querySelector("[data-terminal-session-status]")).toBeNull();
   });
 
   it("bounds loading and load-error states in the list surface", () => {
@@ -805,7 +895,8 @@ describe("TerminalsTab", () => {
 
     renderTab();
 
-    fireEvent.click(screen.getByRole("button", { name: "Delete matrix-main" }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for matrix-main" }), { button: 0, ctrlKey: false });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Delete" }));
     expect(deleteSession).not.toHaveBeenCalled();
     expect(screen.getByText("Delete matrix-main?")).toBeTruthy();
     const dialog = screen.getByRole("dialog");
@@ -837,7 +928,8 @@ describe("TerminalsTab", () => {
     useTabs.getState().openTab({ kind: "terminal", sessionName: "matrix-delete", title: "matrix-delete" });
 
     renderTab();
-    fireEvent.click(screen.getByRole("button", { name: "Delete matrix-delete" }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for matrix-delete" }), { button: 0, ctrlKey: false });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Delete" }));
     fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
 
     await waitFor(() => expect(deleteSession).toHaveBeenCalledOnce());

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -849,6 +849,8 @@ describe("TerminalsTab", () => {
 
     expect(screen.getByRole("button", { name: "Open matrix-active" }).parentElement?.textContent)
       .toContain("2 minutes ago");
+    expect(screen.getByRole("button", { name: "Open matrix-waiting" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open matrix-closed" })).toBeTruthy();
     expect(document.querySelector("[data-terminal-session-status]")).toBeNull();
   });
 

--- a/tests/desktop/web-contents-view.test.ts
+++ b/tests/desktop/web-contents-view.test.ts
@@ -189,6 +189,28 @@ describe("createWebContentsView", () => {
     expect(electronMock.shell.openExternal).not.toHaveBeenCalled();
   });
 
+  it("keeps safe cross-origin navigation inside a public Browser view", () => {
+    createWebContentsView({
+      window: {
+        contentView: { addChildView: vi.fn(), removeChildView: vi.fn() },
+      } as never,
+      partition: "persist:browser",
+      allowedOrigins: ["https://matrix-os.com"],
+      allowPublicNavigation: true,
+      onState: vi.fn(),
+    });
+    const preventDefault = vi.fn();
+    const navigate = electronMock.handlers.get("will-navigate");
+
+    navigate?.({ preventDefault }, "https://developer.mozilla.org/en-US/");
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(electronMock.webContents.loadURL).toHaveBeenCalledWith(
+      "https://developer.mozilla.org/en-US/",
+    );
+    expect(electronMock.shell.openExternal).not.toHaveBeenCalled();
+  });
+
   it("opens HTTPS links requested by the hosted Shell in the system browser", () => {
     createWebContentsView({
       window: {

--- a/tests/e2e/desktop/handoff-regression-matrix.ts
+++ b/tests/e2e/desktop/handoff-regression-matrix.ts
@@ -348,7 +348,7 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
     evidence: [
       testEvidence(
         "tests/desktop/terminals-tab.test.tsx",
-        "renders canonical active, waiting, and closed lifecycle badges with relative activity",
+        "renders relative activity without lifecycle dots",
       ),
       testEvidence(
         "tests/desktop/terminals-tab.test.tsx",
@@ -364,7 +364,7 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
       "completed",
       "stopped",
     ],
-    assertion: "Session list and detail cover running, waiting, idle, ended, failure, and retry states.",
+    assertion: "Session rows cover running, waiting, and ended states without redundant lifecycle dots, while loading and failures remain bounded and retryable.",
   },
   {
     id: "terminal-search-empty",
@@ -385,7 +385,7 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
     evidence: [
       testEvidence(
         "tests/desktop/terminals-tab.test.tsx",
-        "keeps the OS View sidebar delete action accessible",
+        "keeps delete and connect actions in one non-overlapping overflow menu",
       ),
       testEvidence(
         "tests/desktop/terminals-tab.test.tsx",

--- a/tests/gateway/settings-desktop.test.ts
+++ b/tests/gateway/settings-desktop.test.ts
@@ -178,6 +178,29 @@ describe("Settings: desktop + theme + wallpapers", () => {
       });
     });
 
+    it("accepts a bounded owner-controlled Desktop icon layout", async () => {
+      const desktopIcons = [
+        { path: "__chat__", x: 20, y: 20 },
+        { path: "apps/notes/index.html", x: 108, y: 20 },
+      ];
+      const response = await app.request("/api/settings/desktop", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ desktopIcons }),
+      });
+
+      expect(response.status).toBe(200);
+      const saved = JSON.parse(readFileSync(join(homePath, "system/desktop.json"), "utf-8"));
+      expect(saved.desktopIcons).toEqual(desktopIcons);
+
+      const invalid = await app.request("/api/settings/desktop", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ desktopIcons: [{ path: "__chat__", x: -1, y: 20 }] }),
+      });
+      expect(invalid.status).toBe(400);
+    });
+
     it("rejects invalid and oversized patch bodies", async () => {
       const invalid = await app.request("/api/settings/desktop", {
         method: "PATCH",

--- a/tests/gateway/shell-registry.test.ts
+++ b/tests/gateway/shell-registry.test.ts
@@ -96,7 +96,7 @@ describe("shell registry", () => {
     expect(adapter.focusedPaneRuntime).toHaveBeenCalledTimes(sessionNames.length);
   });
 
-  it("adds gateway-owned project and Git context while preserving the session cwd", async () => {
+  it("adds gateway-owned project, Git context, and a home-relative active cwd", async () => {
     const root = await tempRoot();
     const cwd = join(root, "projects", "matrix-os");
     await mkdir(cwd, { recursive: true });
@@ -122,15 +122,31 @@ describe("shell registry", () => {
     const listed = await registry.list();
     expect(listed).toMatchObject([{
       name: "calm-otter",
+      cwd: "projects/matrix-os",
       project: "Matrix OS",
       repository: "HamedMP/matrix-os",
       branch: "codex/session-context",
       pullRequest: { number: 1032, url: "https://github.com/HamedMP/matrix-os/pull/1032" },
     }]);
-    expect(listed[0]).not.toHaveProperty("cwd");
     const persisted = JSON.parse(await readFile(join(root, "system", "shell-sessions.json"), "utf8"));
     expect(persisted.sessions["calm-otter"].cwd).toBe(resolvedCwd);
     expect(gitContextResolver.resolve).toHaveBeenCalledWith({ sessionName: "calm-otter", cwd: resolvedCwd });
+  });
+
+  it("does not expose an active cwd outside the Matrix home", async () => {
+    const root = await tempRoot();
+    const outside = await tempRoot();
+    const adapter = {
+      listSessions: vi.fn(async () => ["calm-otter"]),
+      createSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+      focusedPaneRuntime: vi.fn(async () => ({ cwd: outside, command: "zsh", observed: true })),
+    };
+    const registry = new ShellRegistry({ homePath: root, adapter });
+
+    const listed = await registry.list();
+
+    expect(listed[0]).not.toHaveProperty("cwd");
   });
 
   it("persists an explicitly launched agent and omits agent metadata from plain terminals", async () => {
@@ -289,13 +305,19 @@ describe("shell registry", () => {
       listSessions: vi.fn(async () => ["main"]),
       createSession: vi.fn(async () => undefined),
       deleteSession: vi.fn(async () => undefined),
-      focusedPaneRuntime: vi.fn(async () => ({ cwd: root, command: "claude", observed: true })),
+      focusedPaneRuntime: vi.fn(async () => ({
+        cwd: root,
+        command: "claude",
+        title: "Investigate production SSH",
+        observed: true,
+      })),
     };
     const registry = new ShellRegistry({ homePath: root, adapter });
 
     await expect(registry.list()).resolves.toMatchObject([{
       name: "main",
       agent: "claude",
+      subtitle: "Investigate production SSH",
       visualStatus: "running",
     }]);
   });
@@ -774,7 +796,7 @@ describe("shell registry", () => {
       scrollbackStore: scrollbackStore as never,
     });
 
-    await registry.updateUiState("main", { placement: "background", lastSeenSeq: 4 });
+    await registry.updateUiState("main", { placement: "background", lastSeenSeq: 4, pinned: true });
     vi.setSystemTime(new Date("2026-06-18T12:00:01.000Z"));
     await registry.updateUiState("review-done", { lastSeenSeq: 3, visualStatus: "finished" });
     vi.setSystemTime(new Date("2026-06-18T12:00:02.000Z"));
@@ -782,6 +804,7 @@ describe("shell registry", () => {
     await expect(registry.list()).resolves.toMatchObject([
       {
         name: "main",
+        pinned: true,
         placement: "background",
         latestSeq: 12,
         lastSeenSeq: 4,
@@ -806,6 +829,7 @@ describe("shell registry", () => {
 
     const raw = await readFile(join(root, "system", "shell-sessions.json"), "utf-8");
     expect(JSON.parse(raw).sessions.main.placement).toBe("background");
+    expect(JSON.parse(raw).sessions.main.pinned).toBe(true);
   });
 
   it("derives status dots from OSC marks and unread output while ignoring legacy client state", async () => {

--- a/tests/gateway/shell-routes.test.ts
+++ b/tests/gateway/shell-routes.test.ts
@@ -363,11 +363,11 @@ describe("gateway shell routes", () => {
     const res = await app.request("/api/terminal/sessions/calm-otter/ui-state", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ placement: "background", visualStatus: "waiting" }),
+      body: JSON.stringify({ placement: "background", pinned: true, visualStatus: "waiting" }),
     });
 
     expect(res.status).toBe(200);
-    expect(updateUiState).toHaveBeenCalledWith("calm-otter", { placement: "background" });
+    expect(updateUiState).toHaveBeenCalledWith("calm-otter", { placement: "background", pinned: true });
   });
 
   it("rate limits rapid shell session creation without imposing a live-session cap", async () => {

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -145,6 +145,7 @@ describe("zellij adapter", () => {
           tab_id: 1,
           pane_cwd: "/home/alice/project",
           pane_command: "codex",
+          pane_title: "Fix terminal session rows",
         }]), "");
       return childProcess();
     });
@@ -153,6 +154,7 @@ describe("zellij adapter", () => {
     await expect(adapter.focusedPaneRuntime("main")).resolves.toEqual({
       cwd: "/home/alice/project",
       command: "codex",
+      title: "Fix terminal session rows",
       observed: true,
     });
     expect(execFile).toHaveBeenCalledTimes(1);

--- a/tests/shell/command-palette-design.test.tsx
+++ b/tests/shell/command-palette-design.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CommandPalette } from "../../shell/src/components/CommandPalette";
+import { useCommandStore } from "../../shell/src/stores/commands";
+
+describe("web CommandPalette design", () => {
+  beforeEach(() => {
+    class ResizeObserverStub {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    useCommandStore.setState({ commands: new Map() });
+    useCommandStore.getState().register([
+      { id: "app:notes", label: "Notes", group: "Apps", execute: vi.fn() },
+      { id: "action:new-chat", label: "New Chat", group: "Actions", shortcut: "Cmd+N", execute: vi.fn() },
+      { id: "action:open-settings", label: "Open Settings", group: "Actions", shortcut: "Cmd+,", keywords: ["preferences"], execute: vi.fn() },
+    ]);
+  });
+
+  it("focuses its large search field and filters through functional categories", async () => {
+    render(<CommandPalette open onOpenChange={vi.fn()} />);
+
+    const input = screen.getByPlaceholderText("Type a command or search…");
+    await waitFor(() => expect(document.activeElement).toBe(input));
+    expect(input.className).toContain("focus-visible:shadow-none");
+    expect(screen.getByText("⌘K")).toBeTruthy();
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+      "All",
+      "Apps",
+      "Actions",
+      "Settings",
+    ]);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Apps" }));
+    expect(screen.getByText("Notes").closest("[cmdk-item]")?.hasAttribute("data-instant-list-hover")).toBe(true);
+    expect(screen.queryByText("New Chat")).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Settings" }));
+    expect(screen.getByText("Open Settings")).toBeTruthy();
+    expect(screen.queryByText("Notes")).toBeNull();
+  });
+});

--- a/tests/shell/desktop-config.test.ts
+++ b/tests/shell/desktop-config.test.ts
@@ -39,6 +39,7 @@ describe("Desktop config", () => {
     useDesktopConfigStore.setState({
       dock: { position: "left", size: 56, iconSize: 40, autoHide: false },
       pinnedApps: [...DEFAULT_PINNED_APPS],
+      desktopIcons: undefined,
     });
     vi.restoreAllMocks();
     resetDesktopConfigRuntimeCacheForTests();
@@ -254,6 +255,27 @@ describe("Desktop config", () => {
       pinnedApps: ["apps/test.html"],
     };
     expect(config.pinnedApps).toEqual(["apps/test.html"]);
+  });
+
+  it("moves, removes, and adds Desktop icons through bounded PATCH updates", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ config: {} }) });
+    vi.stubGlobal("fetch", mockFetch);
+    useDesktopConfigStore.getState().setDesktopIcons([
+      { path: "__chat__", x: 20, y: 58 },
+      { path: "__terminal__", x: 108, y: 58 },
+    ]);
+
+    useDesktopConfigStore.getState().moveDesktopIcon("__chat__", 240, 180);
+    useDesktopConfigStore.getState().removeDesktopIcon("__terminal__");
+    useDesktopConfigStore.getState().addDesktopIcon("apps/notes/index.html");
+
+    expect(useDesktopConfigStore.getState().desktopIcons).toContainEqual({ path: "__chat__", x: 240, y: 180 });
+    expect(useDesktopConfigStore.getState().desktopIcons?.some((icon) => icon.path === "__terminal__")).toBe(false);
+    expect(useDesktopConfigStore.getState().desktopIcons?.some((icon) => icon.path === "apps/notes/index.html")).toBe(true);
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(3));
+    expect(JSON.parse(mockFetch.mock.calls.at(-1)?.[1].body)).toEqual({
+      desktopIcons: useDesktopConfigStore.getState().desktopIcons,
+    });
   });
 
   it("initializes from the scoped shell snapshot before revalidating desktop config", async () => {

--- a/tests/shell/desktop-config.test.ts
+++ b/tests/shell/desktop-config.test.ts
@@ -339,6 +339,57 @@ describe("Desktop config", () => {
     await waitFor(() => expect(useDesktopConfigStore.getState().desktopIcons).toEqual(serverIcons));
   });
 
+  it("replays web hydration captured between two failed initial icon writes", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const resolvePatch: Array<(response: { ok: false; status: number }) => void> = [];
+    vi.stubGlobal("fetch", vi.fn(() => new Promise((resolve) => {
+      resolvePatch.push(resolve);
+    })));
+    const defaults = [
+      { path: "__chat__", x: 20, y: 58 },
+      { path: "__terminal__", x: 108, y: 58 },
+    ];
+    const serverIcons = [defaults[1]];
+    useDesktopConfigStore.getState().primeDesktopIcons(defaults);
+
+    useDesktopConfigStore.getState().moveDesktopIcon("__chat__", 240, 180);
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    const intermediateHydrationRevision = captureWebDesktopIconsHydrationRevision();
+    useDesktopConfigStore.getState().removeDesktopIcon("__terminal__");
+    useDesktopConfigStore.getState().setDesktopIcons(serverIcons, intermediateHydrationRevision);
+    resolvePatch[0]?.({ ok: false, status: 503 });
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    resolvePatch[1]?.({ ok: false, status: 503 });
+
+    await waitFor(() => expect(useDesktopConfigStore.getState().desktopIcons).toEqual(serverIcons));
+  });
+
+  it("accepts intermediate web hydration after both initial icon writes already failed", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const resolvePatch: Array<(response: { ok: false; status: number }) => void> = [];
+    vi.stubGlobal("fetch", vi.fn(() => new Promise((resolve) => {
+      resolvePatch.push(resolve);
+    })));
+    const defaults = [
+      { path: "__chat__", x: 20, y: 58 },
+      { path: "__terminal__", x: 108, y: 58 },
+    ];
+    const serverIcons = [defaults[1]];
+    useDesktopConfigStore.getState().primeDesktopIcons(defaults);
+
+    useDesktopConfigStore.getState().moveDesktopIcon("__chat__", 240, 180);
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    const intermediateHydrationRevision = captureWebDesktopIconsHydrationRevision();
+    useDesktopConfigStore.getState().removeDesktopIcon("__terminal__");
+    resolvePatch[0]?.({ ok: false, status: 503 });
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    resolvePatch[1]?.({ ok: false, status: 503 });
+    await waitFor(() => expect(useDesktopConfigStore.getState().desktopIcons).toEqual(defaults));
+    useDesktopConfigStore.getState().setDesktopIcons(serverIcons, intermediateHydrationRevision);
+
+    expect(useDesktopConfigStore.getState().desktopIcons).toEqual(serverIcons);
+  });
+
   it("ignores stale web Desktop icon hydration after a successful PATCH", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
     const confirmed = [

--- a/tests/shell/desktop-config.test.ts
+++ b/tests/shell/desktop-config.test.ts
@@ -317,6 +317,28 @@ describe("Desktop config", () => {
     expect(useDesktopConfigStore.getState().desktopIcons).toEqual(serverIcons);
   });
 
+  it("replays web settings hydration that resolves before an initial icon write fails", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let resolvePatch: ((response: { ok: false; status: number }) => void) | undefined;
+    vi.stubGlobal("fetch", vi.fn(() => new Promise((resolve) => {
+      resolvePatch = resolve;
+    })));
+    const defaults = [
+      { path: "__chat__", x: 20, y: 58 },
+      { path: "__terminal__", x: 108, y: 58 },
+    ];
+    const serverIcons = [defaults[1]];
+    const pendingHydrationRevision = captureWebDesktopIconsHydrationRevision();
+    useDesktopConfigStore.getState().primeDesktopIcons(defaults);
+
+    useDesktopConfigStore.getState().moveDesktopIcon("__chat__", 240, 180);
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    useDesktopConfigStore.getState().setDesktopIcons(serverIcons, pendingHydrationRevision);
+    resolvePatch?.({ ok: false, status: 503 });
+
+    await waitFor(() => expect(useDesktopConfigStore.getState().desktopIcons).toEqual(serverIcons));
+  });
+
   it("ignores stale web Desktop icon hydration after a successful PATCH", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
     const confirmed = [

--- a/tests/shell/desktop-config.test.ts
+++ b/tests/shell/desktop-config.test.ts
@@ -2,7 +2,11 @@
 
 import { renderHook, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { useDesktopConfigStore, type DockConfig } from "../../shell/src/stores/desktop-config";
+import {
+  captureWebDesktopIconsHydrationRevision,
+  useDesktopConfigStore,
+  type DockConfig,
+} from "../../shell/src/stores/desktop-config";
 import { DEFAULT_PINNED_APPS } from "../../shell/src/lib/builtin-apps";
 import {
   buildMeshGradient,
@@ -290,6 +294,22 @@ describe("Desktop config", () => {
     useDesktopConfigStore.getState().moveDesktopIcon("__chat__", 240, 180);
 
     await waitFor(() => expect(useDesktopConfigStore.getState().desktopIcons).toEqual(confirmed));
+  });
+
+  it("ignores stale web Desktop icon hydration after a successful PATCH", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+    const confirmed = [
+      { path: "__chat__", x: 20, y: 58 },
+      { path: "__terminal__", x: 108, y: 58 },
+    ];
+    useDesktopConfigStore.getState().setDesktopIcons(confirmed);
+    const staleHydrationRevision = captureWebDesktopIconsHydrationRevision();
+
+    useDesktopConfigStore.getState().moveDesktopIcon("__chat__", 240, 180);
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    useDesktopConfigStore.getState().setDesktopIcons(confirmed, staleHydrationRevision);
+
+    expect(useDesktopConfigStore.getState().desktopIcons).toContainEqual({ path: "__chat__", x: 240, y: 180 });
   });
 
   it("initializes from the scoped shell snapshot before revalidating desktop config", async () => {

--- a/tests/shell/desktop-config.test.ts
+++ b/tests/shell/desktop-config.test.ts
@@ -4,6 +4,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   captureWebDesktopIconsHydrationRevision,
+  resetWebDesktopIconsRuntime,
   useDesktopConfigStore,
   type DockConfig,
 } from "../../shell/src/stores/desktop-config";
@@ -45,6 +46,7 @@ describe("Desktop config", () => {
       pinnedApps: [...DEFAULT_PINNED_APPS],
       desktopIcons: undefined,
     });
+    resetWebDesktopIconsRuntime();
     vi.restoreAllMocks();
     resetDesktopConfigRuntimeCacheForTests();
     window.history.replaceState({}, "", "/");
@@ -294,6 +296,25 @@ describe("Desktop config", () => {
     useDesktopConfigStore.getState().moveDesktopIcon("__chat__", 240, 180);
 
     await waitFor(() => expect(useDesktopConfigStore.getState().desktopIcons).toEqual(confirmed));
+  });
+
+  it("allows pending web settings hydration after an initial icon write fails", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+    const defaults = [
+      { path: "__chat__", x: 20, y: 58 },
+      { path: "__terminal__", x: 108, y: 58 },
+    ];
+    const serverIcons = [defaults[1]];
+    const pendingHydrationRevision = captureWebDesktopIconsHydrationRevision();
+    useDesktopConfigStore.getState().primeDesktopIcons(defaults);
+
+    useDesktopConfigStore.getState().moveDesktopIcon("__chat__", 240, 180);
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    await waitFor(() => expect(useDesktopConfigStore.getState().desktopIcons).toEqual(defaults));
+    useDesktopConfigStore.getState().setDesktopIcons(serverIcons, pendingHydrationRevision);
+
+    expect(useDesktopConfigStore.getState().desktopIcons).toEqual(serverIcons);
   });
 
   it("ignores stale web Desktop icon hydration after a successful PATCH", async () => {

--- a/tests/shell/desktop-config.test.ts
+++ b/tests/shell/desktop-config.test.ts
@@ -278,6 +278,20 @@ describe("Desktop config", () => {
     });
   });
 
+  it("restores the confirmed web Desktop icon layout after a failed PATCH", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+    const confirmed = [
+      { path: "__chat__", x: 20, y: 58 },
+      { path: "__terminal__", x: 108, y: 58 },
+    ];
+    useDesktopConfigStore.getState().setDesktopIcons(confirmed);
+
+    useDesktopConfigStore.getState().moveDesktopIcon("__chat__", 240, 180);
+
+    await waitFor(() => expect(useDesktopConfigStore.getState().desktopIcons).toEqual(confirmed));
+  });
+
   it("initializes from the scoped shell snapshot before revalidating desktop config", async () => {
     const scope = createShellSnapshotScope({ userId: "user_123", pathname: "/" });
     expect(scope).not.toBeNull();

--- a/tests/shell/desktop-launcher-mode.test.tsx
+++ b/tests/shell/desktop-launcher-mode.test.tsx
@@ -218,7 +218,7 @@ describe("Desktop launcher dock button by mode", () => {
     await waitFor(() => {
       expect(Array.from(desktopApps.querySelectorAll("button")).map(
         (button) => button.getAttribute("aria-label"),
-      ).slice(0, 4)).toEqual(["Chat", "Terminal", "Files", "Settings"]);
+      ).slice(0, 4)).toEqual(["Chat", "Terminal", "Files", "Editor"]);
     });
     expect(windowManagerStore.getState().apps.find((app) => app.path === "__chat__"))
       .toMatchObject({ name: "Hermes", path: "__chat__" });

--- a/tests/shell/desktop-launcher-mode.test.tsx
+++ b/tests/shell/desktop-launcher-mode.test.tsx
@@ -265,6 +265,44 @@ describe("Desktop launcher dock button by mode", () => {
     )).toBe(false);
   });
 
+  it("routes a mobile pinned Browser through the dedicated public browser launch", async () => {
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/settings/onboarding-status")) return jsonResponse({ complete: true });
+      if (url.includes("/api/shell/bootstrap")) {
+        return jsonResponse({
+          layout: { windows: [] },
+          apps: [{
+            name: "Browser",
+            path: "/files/apps/browser/dist/index.html",
+            icon: "browser",
+            slug: "browser",
+          }],
+          modules: [],
+        });
+      }
+      return jsonResponse({});
+    }));
+    const openExternal = vi.spyOn(window, "open").mockImplementation(() => null);
+    resetShellMode("canvas", true);
+
+    render(<DesktopComponent />);
+
+    await waitFor(() => {
+      expect(windowManagerStore.getState().apps.some(
+        (app) => app.path === "apps/browser/dist/index.html",
+      )).toBe(true);
+    });
+    act(() => desktopConfigStore.setState({ pinnedApps: ["apps/browser/dist/index.html"] }));
+    const browserButtons = await screen.findAllByRole("button", { name: "Browser" });
+    fireEvent.click(browserButtons.at(-1)!);
+
+    expect(openExternal).toHaveBeenCalledWith("https://www.google.com", "_blank", "noopener,noreferrer");
+    expect(windowManagerStore.getState().windows.some(
+      (windowRecord) => windowRecord.path === "apps/browser/dist/index.html",
+    )).toBe(false);
+  });
+
   it("registers apps from the scoped shell bootstrap snapshot before network bootstrap returns", async () => {
     const scope = createShellSnapshotScope({ userId: "user_123", pathname: "/" });
     expect(scope).not.toBeNull();

--- a/tests/shell/desktop-launcher-mode.test.tsx
+++ b/tests/shell/desktop-launcher-mode.test.tsx
@@ -228,6 +228,43 @@ describe("Desktop launcher dock button by mode", () => {
       .toMatchObject({ title: "Chat", path: "__chat__" });
   });
 
+  it("routes an installed Browser command through the dedicated public browser launch", async () => {
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/settings/onboarding-status")) return jsonResponse({ complete: true });
+      if (url.includes("/api/shell/bootstrap")) {
+        return jsonResponse({
+          layout: { windows: [] },
+          apps: [{
+            name: "Browser",
+            path: "/files/apps/browser/dist/index.html",
+            icon: "browser",
+            slug: "browser",
+          }],
+          modules: [],
+        });
+      }
+      return jsonResponse({});
+    }));
+    const openExternal = vi.spyOn(window, "open").mockImplementation(() => null);
+    const commandStore = (await import("../../shell/src/stores/commands.js")).useCommandStore;
+    resetShellMode("desktop", true);
+
+    render(<DesktopComponent />);
+
+    const browserCommand = await waitFor(() => {
+      const command = commandStore.getState().commands.get("app:apps/browser/dist/index.html");
+      expect(command).toBeDefined();
+      return command!;
+    });
+    act(() => browserCommand.execute());
+
+    expect(openExternal).toHaveBeenCalledWith("https://www.google.com", "_blank", "noopener,noreferrer");
+    expect(windowManagerStore.getState().windows.some(
+      (windowRecord) => windowRecord.path === "apps/browser/dist/index.html",
+    )).toBe(false);
+  });
+
   it("registers apps from the scoped shell bootstrap snapshot before network bootstrap returns", async () => {
     const scope = createShellSnapshotScope({ userId: "user_123", pathname: "/" });
     expect(scope).not.toBeNull();

--- a/tests/shell/launchpad.test.tsx
+++ b/tests/shell/launchpad.test.tsx
@@ -40,6 +40,8 @@ async function renderLauncher(opts: { apps?: TestApp[] } = {}) {
     onRegenerateIcon: vi.fn(),
     onRenameApp: vi.fn(),
     onRemoveFromCanvas: vi.fn(),
+    onCreateApp: vi.fn(),
+    onAddToDesktop: vi.fn(),
   };
   const props = {
     apps: opts.apps ?? defaultApps,
@@ -115,7 +117,7 @@ describe("Launchpad (macos-glass launcher)", () => {
         tile.textContent?.trim(),
       );
 
-      expect(names).toEqual(["Terminal", "Notes", "Calculator", "Chess", "2048"]);
+      expect(names).toEqual(["Create app", "Terminal", "Notes", "Calculator", "Chess", "2048"]);
     },
   );
 
@@ -144,13 +146,36 @@ describe("Launchpad (macos-glass launcher)", () => {
     expect(document.activeElement).toBe(search);
 
     expect(screen.getByRole("button", { name: "Terminal" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Create app" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Notes" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Chess" })).toBeTruthy();
     expect(
       (container.querySelector("[data-launchpad-grid]") as HTMLElement).style.gridTemplateColumns,
-    ).toContain("repeat(3,");
+    ).toContain("repeat(4,");
     // One page of apps: no page dots.
     expect(screen.queryByRole("button", { name: /go to page/i })).toBeNull();
+  });
+
+  it("launches Create app through the dedicated first tile", async () => {
+    setDesign("macos-glass");
+    const { handlers, container } = await renderLauncher();
+
+    const firstTile = container.querySelector<HTMLElement>("[data-launchpad-tile]");
+    expect(firstTile?.getAttribute("aria-label")).toBe("Create app");
+    fireEvent.click(screen.getByRole("button", { name: "Create app" }));
+
+    expect(handlers.onCreateApp).toHaveBeenCalledOnce();
+    expect(handlers.onOpenApp).not.toHaveBeenCalledWith("Create app", expect.anything());
+  });
+
+  it("adds a launcher app to the Desktop from its context menu", async () => {
+    setDesign("macos-glass");
+    const { handlers } = await renderLauncher();
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Notes" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Add Notes to Desktop" }));
+
+    expect(handlers.onAddToDesktop).toHaveBeenCalledWith("apps/notes/index.html");
   });
 
   it("reserves the grid padding and gaps so launchpad stays centered in the viewport", () => {
@@ -225,8 +250,8 @@ describe("Launchpad (macos-glass launcher)", () => {
     }));
     await renderLauncher({ apps });
 
-    expect(screen.queryByRole("button", { name: "App 8" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "App 9" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "App 7" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "App 8" })).toBeNull();
 
     const dots = screen.getAllByRole("button", { name: /go to page/i });
     expect(dots).toHaveLength(2);
@@ -235,6 +260,7 @@ describe("Launchpad (macos-glass launcher)", () => {
 
     fireEvent.click(dots[1]);
     expect(screen.queryByRole("button", { name: "App 1" })).toBeNull();
+    expect(screen.getByRole("button", { name: "App 8" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "App 9" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "App 10" })).toBeTruthy();
     expect(dots[1].getAttribute("aria-current")).toBe("page");

--- a/tests/shell/posthog-proxy.test.ts
+++ b/tests/shell/posthog-proxy.test.ts
@@ -4,6 +4,10 @@ import { describe, expect, it, vi } from "vitest";
 import nextConfig from "../../shell/next.config";
 
 const posthogMock = vi.hoisted(() => ({
+  conversations: {
+    isAvailable: vi.fn(() => true),
+    show: vi.fn(),
+  },
   init: vi.fn(),
   capture: vi.fn(),
   identify: vi.fn(),
@@ -14,6 +18,7 @@ const posthogMock = vi.hoisted(() => ({
 vi.mock("posthog-js", () => ({
   default: posthogMock,
 }));
+vi.mock("posthog-js/dist/conversations", () => ({}));
 
 type RewriteRule = { source: string; destination: string };
 
@@ -97,6 +102,21 @@ describe("shell PostHog same-origin proxy", () => {
     mock._isIdentified = () => true;
     resetPostHogIdentity(config);
     expect(posthogMock.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens PostHog Conversations from the shell navbar", async () => {
+    const { openShellSupport } = await import("../../shell/src/lib/posthog-client");
+    const opened = await openShellSupport({
+      token: "phc_test",
+      apiHost: "/relay",
+      uiHost: "https://eu.posthog.com",
+    });
+
+    expect(opened).toBe(true);
+    expect(posthogMock.conversations.show).toHaveBeenCalledOnce();
+    expect(posthogMock.capture).toHaveBeenCalledWith("shell_support_chat_opened", {
+      matrix_client: "web",
+    });
   });
 
   it("defaults the shell api host to the /relay same-origin proxy", () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -413,6 +413,7 @@ describe("TerminalApp", () => {
 
     const menu = await openSessionContextMenu("calm-otter", "calm-otter");
     expect(within(menu).getByRole("menuitem", { name: "Copy Connect Command" })).toBeTruthy();
+    expect(within(menu).getByRole("menuitem", { name: "Pin" })).toBeTruthy();
     expect(screen.queryByTestId("terminal-session-hover-card-calm-otter")).toBeNull();
 
     fireEvent.keyDown(within(menu).getByRole("menuitem", { name: "Move to Background" }), { key: "Escape" });
@@ -457,6 +458,7 @@ describe("TerminalApp", () => {
       selectedShellName: null,
       onOpen: vi.fn(),
       onToggle: vi.fn(),
+      onPin: vi.fn(),
       onRename: vi.fn(async () => true),
       onDelete: vi.fn(),
       draggingShellName: null,
@@ -600,6 +602,7 @@ describe("TerminalApp", () => {
         selectedShellName={null}
         onOpen={onOpen}
         onToggle={vi.fn()}
+        onPin={vi.fn()}
         onRename={vi.fn(async () => true)}
         onDelete={vi.fn()}
         draggingShellName={null}
@@ -2803,8 +2806,9 @@ describe("TerminalApp", () => {
     expect(menu.style.padding).toBe("5px");
     const moveItem = within(menu).getByRole("menuitem", { name: "Move to Background" });
     const copyItem = within(menu).getByRole("menuitem", { name: "Copy Connect Command" });
+    const pinItem = within(menu).getByRole("menuitem", { name: "Pin" });
     const closeItem = within(menu).getByRole("menuitem", { name: "Close" });
-    expect(within(menu).getAllByRole("menuitem")).toEqual([copyItem, moveItem, closeItem]);
+    expect(within(menu).getAllByRole("menuitem")).toEqual([copyItem, moveItem, pinItem, closeItem]);
     expect(within(menu).getByRole("separator").nextElementSibling).toBe(closeItem);
     expect(closeItem.dataset.tone).toBe("destructive");
     expect(closeItem.style.color).toBe("var(--terminal-drawer-destructive-fg)");

--- a/tests/shell/terminal-design-tab-strip.test.tsx
+++ b/tests/shell/terminal-design-tab-strip.test.tsx
@@ -184,6 +184,21 @@ describe("TerminalApp per-design interior chrome", () => {
     expect(gridProps.theme.colors.background).toBe("#1C2019");
   });
 
+  it("keeps the agent icon and agent title on web terminal tabs", async () => {
+    setThemeStyle("win11");
+    render(<TerminalApp initialSessionId="canvas-session-123" />);
+    await flushAsync();
+
+    fireEvent.keyDown(screen.getByRole("application", { name: "Terminal" }), {
+      key: "C",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(screen.getByRole("tab", { name: /Claude Code/ })).toBeTruthy();
+    expect(screen.getByTestId("terminal-design-tab-agent-logo-claude")).toBeTruthy();
+  });
+
   it("renders the minimal glass strip under macos-glass with a light translucent content surface", async () => {
     setThemeStyle("macos-glass");
     render(<TerminalApp initialSessionId="canvas-session-123" />);

--- a/tests/shell/terminal-session-state.test.ts
+++ b/tests/shell/terminal-session-state.test.ts
@@ -44,6 +44,7 @@ describe("terminal session state helpers", () => {
     const optimistic = applyShellUiStatePatch(mainShell, {
       placement: "background",
       lastSeenSeq: 8,
+      pinned: true,
     });
     const concurrentlyRefreshed = {
       ...optimistic,
@@ -55,12 +56,13 @@ describe("terminal session state helpers", () => {
 
     expect(rollbackShellUiStatePatch(
       concurrentlyRefreshed,
-      { placement: "background", lastSeenSeq: 8 },
-      { placement: "active", lastSeenSeq: 4 },
+      { placement: "background", lastSeenSeq: 8, pinned: true },
+      { placement: "active", lastSeenSeq: 4, pinned: false },
     )).toMatchObject({
       placement: "active",
       latestSeq: 12,
       lastSeenSeq: 10,
+      pinned: false,
       unread: true,
     });
   });

--- a/tests/shell/use-chat-state-refresh.test.tsx
+++ b/tests/shell/use-chat-state-refresh.test.tsx
@@ -122,6 +122,24 @@ describe("useChatState refresh recovery", () => {
     });
   });
 
+  it("stages and consumes the Matrix app-builder draft without submitting it", async () => {
+    let latestState: ReturnType<typeof useChatState> | null = null;
+    render(<Probe onState={(state) => { latestState = state; }} />);
+
+    await act(async () => {
+      latestState?.requestComposerDraft("/matrix-app-builder ");
+    });
+
+    const request = latestState?.composerDraftRequest;
+    expect(request?.text).toBe("/matrix-app-builder ");
+    expect(sendMock).not.toHaveBeenCalledWith(expect.objectContaining({ type: "message" }));
+
+    await act(async () => {
+      if (request) latestState?.consumeComposerDraft(request.id);
+    });
+    expect(latestState?.composerDraftRequest).toBeNull();
+  });
+
   it("reattaches the active conversation after a socket reconnect epoch", async () => {
     mockConversations = [];
     let latestState: ReturnType<typeof useChatState> | null = null;

--- a/tests/shell/web-desktop-app-launch.test.ts
+++ b/tests/shell/web-desktop-app-launch.test.ts
@@ -9,6 +9,13 @@ describe("web Desktop built-in app launch routing", () => {
     });
   });
 
+  it("routes the installed Browser catalog entry through the dedicated Browser launch", () => {
+    expect(resolveWebDesktopBuiltInLaunch("apps/browser/index.html", "Browser")).toEqual({
+      kind: "external",
+      url: "https://www.google.com",
+    });
+  });
+
   it("routes VS Code externally and Editor to Files", () => {
     expect(resolveWebDesktopBuiltInLaunch("__vscode__")?.kind).toBe("external-code");
     expect(resolveWebDesktopBuiltInLaunch("__editor__")).toEqual({
@@ -19,7 +26,7 @@ describe("web Desktop built-in app launch routing", () => {
   });
 
   it("leaves installed and other built-ins to normal app handling", () => {
-    expect(resolveWebDesktopBuiltInLaunch("apps/browser/index.html")).toBeNull();
+    expect(resolveWebDesktopBuiltInLaunch("apps/browser/index.html", "Another app")).toBeNull();
     expect(resolveWebDesktopBuiltInLaunch("__chat__")).toBeNull();
   });
 });

--- a/tests/shell/web-desktop-app-launch.test.ts
+++ b/tests/shell/web-desktop-app-launch.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveWebDesktopBuiltInLaunch } from "../../shell/src/lib/web-desktop-app-launch.js";
+import {
+  buildWebDesktopLauncherApps,
+  resolveWebDesktopBuiltInLaunch,
+} from "../../shell/src/lib/web-desktop-app-launch.js";
 
 describe("web Desktop built-in app launch routing", () => {
   it("routes the fallback Browser launcher to a public browser URL", () => {
@@ -22,6 +25,21 @@ describe("web Desktop built-in app launch routing", () => {
 
   it("does not hijack a user app that is merely named Browser", () => {
     expect(resolveWebDesktopBuiltInLaunch("apps/custom-browser/dist/index.html")).toBeNull();
+  });
+
+  it("keeps a dedicated Browser slot alongside a same-named custom app", () => {
+    const customBrowser = {
+      name: "Browser",
+      path: "apps/browser-clone/index.html",
+      iconUrl: "/icons/browser-clone.svg",
+    };
+
+    const launcherApps = buildWebDesktopLauncherApps([customBrowser]);
+
+    expect(launcherApps.filter((app) => app.name === "Browser")).toEqual([
+      { name: "Browser", path: "__browser__" },
+      customBrowser,
+    ]);
   });
 
   it("routes VS Code externally and Editor to Files", () => {

--- a/tests/shell/web-desktop-app-launch.test.ts
+++ b/tests/shell/web-desktop-app-launch.test.ts
@@ -10,10 +10,18 @@ describe("web Desktop built-in app launch routing", () => {
   });
 
   it("routes the installed Browser catalog entry through the dedicated Browser launch", () => {
-    expect(resolveWebDesktopBuiltInLaunch("apps/browser/index.html", "Browser")).toEqual({
+    expect(resolveWebDesktopBuiltInLaunch("apps/browser/index.html")).toEqual({
       kind: "external",
       url: "https://www.google.com",
     });
+    expect(resolveWebDesktopBuiltInLaunch("apps/browser/dist/index.html")).toEqual({
+      kind: "external",
+      url: "https://www.google.com",
+    });
+  });
+
+  it("does not hijack a user app that is merely named Browser", () => {
+    expect(resolveWebDesktopBuiltInLaunch("apps/custom-browser/dist/index.html")).toBeNull();
   });
 
   it("routes VS Code externally and Editor to Files", () => {
@@ -26,7 +34,7 @@ describe("web Desktop built-in app launch routing", () => {
   });
 
   it("leaves installed and other built-ins to normal app handling", () => {
-    expect(resolveWebDesktopBuiltInLaunch("apps/browser/index.html", "Another app")).toBeNull();
+    expect(resolveWebDesktopBuiltInLaunch("apps/browser-clone/index.html")).toBeNull();
     expect(resolveWebDesktopBuiltInLaunch("__chat__")).toBeNull();
   });
 });

--- a/tests/shell/web-desktop-app-launch.test.ts
+++ b/tests/shell/web-desktop-app-launch.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolveWebDesktopBuiltInLaunch } from "../../shell/src/lib/web-desktop-app-launch.js";
+
+describe("web Desktop built-in app launch routing", () => {
+  it("routes the fallback Browser launcher to a public browser URL", () => {
+    expect(resolveWebDesktopBuiltInLaunch("__browser__")).toEqual({
+      kind: "external",
+      url: "https://www.google.com",
+    });
+  });
+
+  it("routes VS Code externally and Editor to Files", () => {
+    expect(resolveWebDesktopBuiltInLaunch("__vscode__")?.kind).toBe("external-code");
+    expect(resolveWebDesktopBuiltInLaunch("__editor__")).toEqual({
+      kind: "app",
+      name: "Files",
+      path: "__file-browser__",
+    });
+  });
+
+  it("leaves installed and other built-ins to normal app handling", () => {
+    expect(resolveWebDesktopBuiltInLaunch("apps/browser/index.html")).toBeNull();
+    expect(resolveWebDesktopBuiltInLaunch("__chat__")).toBeNull();
+  });
+});

--- a/tests/shell/web-desktop-controls.test.tsx
+++ b/tests/shell/web-desktop-controls.test.tsx
@@ -15,19 +15,23 @@ describe("WebDesktopControls", () => {
   it("maps native Desktop right-side actions to web-safe navigation", () => {
     const onOpenSettings = vi.fn();
     const onOpenCommandPalette = vi.fn();
+    const onOpenSupport = vi.fn();
     render(
       <WebDesktopControls
         onOpenSettings={onOpenSettings}
         onOpenCommandPalette={onOpenCommandPalette}
+        onOpenSupport={onOpenSupport}
       />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Search" }));
     expect(onOpenCommandPalette).toHaveBeenCalledOnce();
     expect(screen.getByRole("link", { name: "Switch computer" }).getAttribute("href")).toBe("/runtime");
-    const support = screen.getByRole("link", { name: "Support" });
-    expect(support.getAttribute("href")).toBe("https://matrix-os.com/docs");
-    expect(support.getAttribute("target")).toBe("_blank");
+    fireEvent.click(screen.getByRole("button", { name: "Support chat" }));
+    expect(onOpenSupport).toHaveBeenCalledOnce();
+    expect(Array.from(screen.getByRole("navigation", { name: "Desktop controls" }).children)
+      .map((control) => control.getAttribute("aria-label") ?? control.textContent))
+      .toEqual(["Search", "Support chat", "Switch computer", "Account"]);
     fireEvent.click(screen.getByRole("button", { name: "Account" }));
     expect(onOpenSettings).toHaveBeenCalledWith("billing");
   });

--- a/tests/shell/web-desktop-controls.test.tsx
+++ b/tests/shell/web-desktop-controls.test.tsx
@@ -14,8 +14,16 @@ vi.mock("@/components/UserButton", () => ({
 describe("WebDesktopControls", () => {
   it("maps native Desktop right-side actions to web-safe navigation", () => {
     const onOpenSettings = vi.fn();
-    render(<WebDesktopControls onOpenSettings={onOpenSettings} />);
+    const onOpenCommandPalette = vi.fn();
+    render(
+      <WebDesktopControls
+        onOpenSettings={onOpenSettings}
+        onOpenCommandPalette={onOpenCommandPalette}
+      />,
+    );
 
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    expect(onOpenCommandPalette).toHaveBeenCalledOnce();
     expect(screen.getByRole("link", { name: "Switch computer" }).getAttribute("href")).toBe("/runtime");
     const support = screen.getByRole("link", { name: "Support" });
     expect(support.getAttribute("href")).toBe("https://matrix-os.com/docs");

--- a/tests/shell/web-desktop-surface.test.tsx
+++ b/tests/shell/web-desktop-surface.test.tsx
@@ -92,6 +92,32 @@ describe("WebDesktopSurface", () => {
     expect(onActivateWindow).toHaveBeenCalledWith("terminal-window");
   });
 
+  it("removes a configured Desktop icon from its context menu", () => {
+    const onRemoveDesktopIcon = vi.fn();
+    render(
+      <WebDesktopSurface
+        apps={apps}
+        windows={windows}
+        fullscreenWindowId={null}
+        launcherOpen={false}
+        desktopIcons={[{ path: "__chat__", x: 20, y: 58 }]}
+        onMoveDesktopIcon={vi.fn()}
+        onRemoveDesktopIcon={onRemoveDesktopIcon}
+        onOpenApp={vi.fn()}
+        onOpenLauncher={vi.fn()}
+        onOpenSettings={vi.fn()}
+        onActivateWindow={vi.fn()}
+        onCloseWindow={vi.fn()}
+        onShowDesktop={vi.fn()}
+        onToggleFullscreen={vi.fn()}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Chat" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Remove Chat from Desktop" }));
+    expect(onRemoveDesktopIcon).toHaveBeenCalledWith("__chat__");
+  });
+
   it("ships the canonical Desktop destinations in parity order and deep-links Plugins to Services", () => {
     const onOpenSettings = vi.fn();
     const onOpenApp = vi.fn();
@@ -113,7 +139,7 @@ describe("WebDesktopSurface", () => {
 
     const desktop = screen.getByRole("navigation", { name: "Desktop apps" });
     expect(Array.from(desktop.querySelectorAll("button")).map((button) => button.getAttribute("aria-label")))
-      .toEqual(["Chat", "Terminal", "Files", "Settings", "Plugins", "Browser", "Notes", "Whiteboard"]);
+      .toEqual(["Chat", "Terminal", "Files", "Editor", "VS Code", "Settings", "Plugins", "Browser", "Notes", "Whiteboard"]);
 
     fireEvent.doubleClick(screen.getByRole("button", { name: "Plugins" }));
     expect(onOpenSettings).toHaveBeenCalledWith("integrations");

--- a/tests/shell/web-desktop-surface.test.tsx
+++ b/tests/shell/web-desktop-surface.test.tsx
@@ -150,6 +150,35 @@ describe("WebDesktopSurface", () => {
     expect(onOpenApp).toHaveBeenCalledWith("apps/notes/index.html", "Notes");
   });
 
+  it("keeps the dedicated Browser desktop icon when a custom app is also named Browser", () => {
+    const onOpenApp = vi.fn();
+    const customBrowser = {
+      name: "Browser",
+      path: "apps/browser-clone/index.html",
+      iconUrl: "/icons/browser-clone.svg",
+    };
+    render(
+      <WebDesktopSurface
+        apps={[...apps.filter((app) => app.path !== "apps/browser/index.html"), customBrowser]}
+        windows={windows}
+        fullscreenWindowId={null}
+        launcherOpen={false}
+        onOpenApp={onOpenApp}
+        onOpenLauncher={vi.fn()}
+        onOpenSettings={vi.fn()}
+        onActivateWindow={vi.fn()}
+        onCloseWindow={vi.fn()}
+        onShowDesktop={vi.fn()}
+        onToggleFullscreen={vi.fn()}
+      />,
+    );
+
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Browser" }));
+
+    expect(onOpenApp).toHaveBeenCalledWith("__browser__", "Browser");
+    expect(onOpenApp).not.toHaveBeenCalledWith(customBrowser.path, customBrowser.name);
+  });
+
   it("renders account, runtime, and support controls in the header action slot", () => {
     render(
       <WebDesktopSurface

--- a/tests/shell/web-desktop-surface.test.tsx
+++ b/tests/shell/web-desktop-surface.test.tsx
@@ -140,6 +140,9 @@ describe("WebDesktopSurface", () => {
     const desktop = screen.getByRole("navigation", { name: "Desktop apps" });
     expect(Array.from(desktop.querySelectorAll("button")).map((button) => button.getAttribute("aria-label")))
       .toEqual(["Chat", "Terminal", "Files", "Editor", "VS Code", "Settings", "Plugins", "Browser", "Notes", "Whiteboard"]);
+    const vscodeIcon = screen.getByRole("button", { name: "VS Code" }).querySelector<HTMLElement>("[data-desktop-app-icon]");
+    expect(vscodeIcon?.style.background).toBe("rgb(255, 254, 252)");
+    expect(vscodeIcon?.querySelector("img")?.getAttribute("src")).toBe("/vscode.png");
 
     fireEvent.doubleClick(screen.getByRole("button", { name: "Plugins" }));
     expect(onOpenSettings).toHaveBeenCalledWith("integrations");


### PR DESCRIPTION
## Summary

- make Chat the first default app after the Create App launcher action and ship first-class Terminal, Files, Editor, VS Code, Settings, Plugins, Browser, Notes, and Whiteboard launchers across native Desktop and the web shell
- add persistent draggable/removable Desktop icons, launcher-to-Desktop actions, a focused Cmd+K palette, top-nav Search, account/runtime/support parity, multi-account service details, and identified Desktop lifecycle analytics
- make Browser tabs navigate public sites normally while routing explicit loopback ports through the selected authenticated Matrix runtime tunnel, with bounded resources, cleanup, and runtime-race protection
- fix Monaco file-content fallback, chat-to-editor file launches, native embed detachment when showing the Desktop, failed icon-write rollback, and stale settings-hydration races

## Tests

- `flox activate -- pnpm exec vitest run tests/desktop/desktop-icons-store.test.ts tests/desktop/desktop-background.test.tsx tests/desktop/desktop-icon-grid.test.tsx tests/desktop/runtime-transition.test.ts tests/shell/desktop-config.test.ts tests/shell/web-desktop-surface.test.tsx tests/shell/desktop-launcher-mode.test.tsx` (60 passed)
- focused Desktop parity suite (251 passed)
- full repository suite (12,420 passed; macOS-only local incompatibilities remain in Linux host scripts and generated interactive-shell subprocess tests)
- `flox activate -- bun run typecheck`
- `flox activate -- pnpm exec tsc --noEmit -p shell/tsconfig.json`
- `flox activate -- bun run check:patterns`
- `flox activate -- bun run build:shell:production`
- `flox activate -- bun run build:desktop`
- `git diff --check`

## Review / Monitoring

- [ ] exact-head Greptile 5/5
- [ ] `ready-for-ci` added after the exact-head rating
- [ ] required CI green

## Invariants

- Desktop icon settings remain owner-scoped through the existing settings endpoint; the new payload is schema-bounded to 512 safe positions.
- Public Browser navigation remains isolated in its Browser embed; loopback URLs require an explicit port and use the authenticated selected-runtime `/ws/forward` tunnel.
- Embed origins, pending tunnels, analytics properties, icon counts, coordinates, and editor resources are capped; tunnels and stale embeds are cleaned up on close and runtime changes.
- No database schema or persistence backend is introduced.
