### PR TITLE
feat(integrations): expand managed service catalog

### DIFF
--- a/packages/gateway/src/integrations/pipedream.ts
+++ b/packages/gateway/src/integrations/pipedream.ts
@@ -46,6 +46,7 @@ export interface PipedreamConnectClient {
     accountId: string;
     url: string;
     params?: Record<string, string>;
+    headers?: Record<string, string>;
   }): Promise<unknown>;
 
   proxyPost(opts: {
@@ -53,6 +54,7 @@ export interface PipedreamConnectClient {
     accountId: string;
     url: string;
     body?: Record<string, unknown>;
+    headers?: Record<string, string>;
   }): Promise<unknown>;
 
   proxyPut(opts: {
@@ -60,6 +62,7 @@ export interface PipedreamConnectClient {
     accountId: string;
     url: string;
     body?: Record<string, unknown>;
+    headers?: Record<string, string>;
   }): Promise<unknown>;
 
   proxyPatch(opts: {
@@ -67,6 +70,7 @@ export interface PipedreamConnectClient {
     accountId: string;
     url: string;
     body?: Record<string, unknown>;
+    headers?: Record<string, string>;
   }): Promise<unknown>;
 
   proxyDelete(opts: {
@@ -74,6 +78,7 @@ export interface PipedreamConnectClient {
     accountId: string;
     url: string;
     params?: Record<string, string>;
+    headers?: Record<string, string>;
   }): Promise<unknown>;
 
   revokeAccount(accountId: string): Promise<void>;
@@ -211,6 +216,7 @@ export async function createPipedreamClient(
           externalUserId: opts.externalUserId,
           accountId: opts.accountId,
           params: opts.params,
+          headers: opts.headers,
         },
         { timeoutInSeconds: API_TIMEOUT_SECONDS },
       );
@@ -224,6 +230,7 @@ export async function createPipedreamClient(
           externalUserId: opts.externalUserId,
           accountId: opts.accountId,
           body: opts.body ?? {},
+          headers: opts.headers,
         },
         { timeoutInSeconds: API_TIMEOUT_SECONDS },
       );
@@ -237,6 +244,7 @@ export async function createPipedreamClient(
           externalUserId: opts.externalUserId,
           accountId: opts.accountId,
           body: opts.body ?? {},
+          headers: opts.headers,
         },
         { timeoutInSeconds: API_TIMEOUT_SECONDS },
       );
@@ -250,6 +258,7 @@ export async function createPipedreamClient(
           externalUserId: opts.externalUserId,
           accountId: opts.accountId,
           body: opts.body ?? {},
+          headers: opts.headers,
         },
         { timeoutInSeconds: API_TIMEOUT_SECONDS },
       );
@@ -268,6 +277,7 @@ export async function createPipedreamClient(
           externalUserId: opts.externalUserId,
           accountId: opts.accountId,
           params: opts.params,
+          headers: opts.headers,
         },
         { timeoutInSeconds: API_TIMEOUT_SECONDS },
       );

--- a/packages/gateway/src/integrations/registry-expansion.ts
+++ b/packages/gateway/src/integrations/registry-expansion.ts
@@ -1,0 +1,263 @@
+import type { IntegrationActionRisk, ServiceAction, ServiceDefinition } from "./types.js";
+
+const LOGO_BASE = "https://pipedream.com/s.v0";
+const NOTION_HEADERS = Object.freeze({ "Notion-Version": "2022-06-28" });
+
+function cappedPositiveInt(value: unknown, fallback: number, max: number): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.min(Math.floor(parsed), max);
+}
+
+type ExpansionAction = Omit<ServiceAction, "risk"> & { risk: IntegrationActionRisk };
+type ExpansionService = Omit<ServiceDefinition, "actions" | "connectorKind"> & {
+  connectorKind?: ServiceDefinition["connectorKind"];
+  actions: Record<string, ExpansionAction>;
+};
+
+export const EXPANSION_SERVICE_REGISTRY: Record<string, ExpansionService> = {
+  google_docs: {
+    id: "google_docs",
+    name: "Google Docs",
+    category: "google",
+    pipedreamApp: "google_docs",
+    icon: "file-text",
+    logoUrl: `${LOGO_BASE}/google_docs/logo/48`,
+    actions: {
+      get_document: {
+        description: "Get a Google document by ID",
+        risk: "read",
+        params: { documentId: { type: "string", required: true } },
+        directApi: {
+          method: "GET",
+          url: (p) => `https://docs.googleapis.com/v1/documents/${encodeURIComponent(String(p.documentId))}`,
+        },
+      },
+      create_document: {
+        description: "Create a Google document",
+        risk: "write",
+        params: { title: { type: "string", required: true } },
+        directApi: {
+          method: "POST",
+          url: "https://docs.googleapis.com/v1/documents",
+          mapBody: (p) => ({ title: String(p.title) }),
+        },
+      },
+      batch_update_document: {
+        description: "Apply a batch of updates to a Google document",
+        risk: "write",
+        params: {
+          documentId: { type: "string", required: true },
+          requests: { type: "array", required: true },
+        },
+        directApi: {
+          method: "POST",
+          url: (p) => `https://docs.googleapis.com/v1/documents/${encodeURIComponent(String(p.documentId))}:batchUpdate`,
+          mapBody: (p) => ({ requests: p.requests }),
+        },
+      },
+    },
+  },
+
+  notion: {
+    id: "notion",
+    name: "Notion",
+    category: "productivity",
+    pipedreamApp: "notion",
+    icon: "notebook",
+    logoUrl: `${LOGO_BASE}/notion/logo/48`,
+    actions: {
+      search: {
+        description: "Search pages and databases",
+        risk: "read",
+        params: { query: { type: "string" }, filter: { type: "object" }, pageSize: { type: "number" } },
+        directApi: {
+          method: "POST",
+          url: "https://api.notion.com/v1/search",
+          staticHeaders: NOTION_HEADERS,
+          mapBody: (p) => ({
+            ...(p.query ? { query: String(p.query) } : {}),
+            ...(p.filter && typeof p.filter === "object" ? { filter: p.filter } : {}),
+            ...(p.pageSize ? { page_size: cappedPositiveInt(p.pageSize, 20, 100) } : {}),
+          }),
+        },
+      },
+      get_page: {
+        description: "Get a Notion page",
+        risk: "read",
+        params: { pageId: { type: "string", required: true } },
+        directApi: {
+          method: "GET",
+          url: (p) => `https://api.notion.com/v1/pages/${encodeURIComponent(String(p.pageId))}`,
+          staticHeaders: NOTION_HEADERS,
+        },
+      },
+      query_database: {
+        description: "Query a Notion database",
+        risk: "read",
+        params: { databaseId: { type: "string", required: true }, filter: { type: "object" }, sorts: { type: "array" } },
+        directApi: {
+          method: "POST",
+          url: (p) => `https://api.notion.com/v1/databases/${encodeURIComponent(String(p.databaseId))}/query`,
+          staticHeaders: NOTION_HEADERS,
+          mapBody: (p) => ({
+            ...(p.filter && typeof p.filter === "object" ? { filter: p.filter } : {}),
+            ...(Array.isArray(p.sorts) ? { sorts: p.sorts } : {}),
+          }),
+        },
+      },
+      create_page: {
+        description: "Create a Notion page",
+        risk: "write",
+        params: {
+          parent: { type: "object", required: true },
+          properties: { type: "object", required: true },
+          children: { type: "array" },
+        },
+        directApi: {
+          method: "POST",
+          url: "https://api.notion.com/v1/pages",
+          staticHeaders: NOTION_HEADERS,
+          mapBody: (p) => ({ parent: p.parent, properties: p.properties, ...(p.children ? { children: p.children } : {}) }),
+        },
+      },
+      update_page: {
+        description: "Update a Notion page",
+        risk: "write",
+        params: { pageId: { type: "string", required: true }, properties: { type: "object", required: true } },
+        directApi: {
+          method: "PATCH",
+          url: (p) => `https://api.notion.com/v1/pages/${encodeURIComponent(String(p.pageId))}`,
+          staticHeaders: NOTION_HEADERS,
+          mapBody: (p) => ({ properties: p.properties }),
+        },
+      },
+      append_blocks: {
+        description: "Append content blocks to a Notion page or block",
+        risk: "write",
+        params: { blockId: { type: "string", required: true }, children: { type: "array", required: true } },
+        directApi: {
+          method: "PATCH",
+          url: (p) => `https://api.notion.com/v1/blocks/${encodeURIComponent(String(p.blockId))}/children`,
+          staticHeaders: NOTION_HEADERS,
+          mapBody: (p) => ({ children: p.children }),
+        },
+      },
+    },
+  },
+
+  figma: {
+    id: "figma",
+    name: "Figma",
+    category: "design",
+    pipedreamApp: "figma",
+    icon: "figma",
+    logoUrl: `${LOGO_BASE}/figma/logo/48`,
+    actions: {
+      get_file: {
+        description: "Get a Figma file",
+        risk: "read",
+        params: { fileKey: { type: "string", required: true }, depth: { type: "number" } },
+        directApi: {
+          method: "GET",
+          url: (p) => `https://api.figma.com/v1/files/${encodeURIComponent(String(p.fileKey))}`,
+          mapParams: (p): Record<string, string> => p.depth
+            ? { depth: String(cappedPositiveInt(p.depth, 1, 10)) }
+            : {},
+        },
+      },
+      get_nodes: {
+        description: "Get selected nodes from a Figma file",
+        risk: "read",
+        params: { fileKey: { type: "string", required: true }, ids: { type: "array", required: true } },
+        directApi: {
+          method: "GET",
+          url: (p) => `https://api.figma.com/v1/files/${encodeURIComponent(String(p.fileKey))}/nodes`,
+          mapParams: (p) => ({ ids: (p.ids as unknown[]).map(String).join(",") }),
+        },
+      },
+      list_comments: {
+        description: "List comments on a Figma file",
+        risk: "read",
+        params: { fileKey: { type: "string", required: true } },
+        directApi: {
+          method: "GET",
+          url: (p) => `https://api.figma.com/v1/files/${encodeURIComponent(String(p.fileKey))}/comments`,
+        },
+      },
+      post_comment: {
+        description: "Post a comment on a Figma file",
+        risk: "write",
+        params: { fileKey: { type: "string", required: true }, message: { type: "string", required: true }, clientMeta: { type: "object" } },
+        directApi: {
+          method: "POST",
+          url: (p) => `https://api.figma.com/v1/files/${encodeURIComponent(String(p.fileKey))}/comments`,
+          mapBody: (p) => ({ message: String(p.message), ...(p.clientMeta ? { client_meta: p.clientMeta } : {}) }),
+        },
+      },
+    },
+  },
+
+  posthog: {
+    id: "posthog",
+    name: "PostHog",
+    category: "analytics",
+    pipedreamApp: "posthog",
+    icon: "chart",
+    logoUrl: `${LOGO_BASE}/posthog/logo/48`,
+    actions: {
+      list_projects: { description: "List PostHog projects", risk: "read", params: {} },
+      list_insights: { description: "List insights in a PostHog project", risk: "read", params: { projectId: { type: "number", required: true }, limit: { type: "number" } } },
+      get_insight: { description: "Get a PostHog insight", risk: "read", params: { projectId: { type: "number", required: true }, insightId: { type: "number", required: true } } },
+      query: { description: "Run a read-only PostHog query", risk: "read", params: { projectId: { type: "number", required: true }, query: { type: "object", required: true } } },
+    },
+  },
+
+  jira: {
+    id: "jira",
+    name: "Jira",
+    category: "developer",
+    pipedreamApp: "jira",
+    icon: "check-list",
+    logoUrl: `${LOGO_BASE}/jira/logo/48`,
+    actions: {
+      list_projects: { description: "List Jira projects", risk: "read", params: { maxResults: { type: "number" } } },
+      search_issues: { description: "Search Jira issues with JQL", risk: "read", params: { jql: { type: "string", required: true }, maxResults: { type: "number" } } },
+      get_issue: { description: "Get a Jira issue", risk: "read", params: { issueKey: { type: "string", required: true } } },
+      create_issue: { description: "Create a Jira issue", risk: "write", params: { projectKey: { type: "string", required: true }, issueType: { type: "string", required: true }, summary: { type: "string", required: true }, description: { type: "object" } } },
+      update_issue: { description: "Update a Jira issue", risk: "write", params: { issueKey: { type: "string", required: true }, fields: { type: "object", required: true } } },
+      add_comment: { description: "Add a comment to a Jira issue", risk: "write", params: { issueKey: { type: "string", required: true }, body: { type: "object", required: true } } },
+    },
+  },
+
+  stripe: {
+    id: "stripe",
+    name: "Stripe",
+    category: "finance",
+    pipedreamApp: "stripe",
+    icon: "credit-card",
+    logoUrl: `${LOGO_BASE}/stripe/logo/48`,
+    actions: {
+      list_customers: { description: "List Stripe customers using a restricted read-only key", risk: "read", params: { limit: { type: "number" } }, directApi: { method: "GET", url: "https://api.stripe.com/v1/customers", mapParams: (p) => ({ limit: String(cappedPositiveInt(p.limit, 10, 100)) }) } },
+      get_customer: { description: "Get a Stripe customer", risk: "read", params: { customerId: { type: "string", required: true } }, directApi: { method: "GET", url: (p) => `https://api.stripe.com/v1/customers/${encodeURIComponent(String(p.customerId))}` } },
+      list_subscriptions: { description: "List Stripe subscriptions", risk: "read", params: { customerId: { type: "string" }, limit: { type: "number" } }, directApi: { method: "GET", url: "https://api.stripe.com/v1/subscriptions", mapParams: (p) => ({ ...(p.customerId ? { customer: String(p.customerId) } : {}), limit: String(cappedPositiveInt(p.limit, 10, 100)) }) } },
+      list_invoices: { description: "List Stripe invoices", risk: "read", params: { customerId: { type: "string" }, limit: { type: "number" } }, directApi: { method: "GET", url: "https://api.stripe.com/v1/invoices", mapParams: (p) => ({ ...(p.customerId ? { customer: String(p.customerId) } : {}), limit: String(cappedPositiveInt(p.limit, 10, 100)) }) } },
+      list_payment_intents: { description: "List Stripe payment intents", risk: "read", params: { customerId: { type: "string" }, limit: { type: "number" } }, directApi: { method: "GET", url: "https://api.stripe.com/v1/payment_intents", mapParams: (p) => ({ ...(p.customerId ? { customer: String(p.customerId) } : {}), limit: String(cappedPositiveInt(p.limit, 10, 100)) }) } },
+      get_balance: { description: "Get the Stripe account balance", risk: "read", params: {}, directApi: { method: "GET", url: "https://api.stripe.com/v1/balance" } },
+    },
+  },
+
+  granola: {
+    id: "granola",
+    name: "Granola",
+    category: "productivity",
+    connectorKind: "mcp_preset",
+    mcpPreset: { url: "https://mcp.granola.ai/mcp", authMode: "oauth" },
+    icon: "note",
+    logoUrl: "",
+    actions: {
+      list_notes: { description: "List Granola meeting notes", risk: "read", params: { query: { type: "string" }, limit: { type: "number" } } },
+      get_note: { description: "Get a Granola note, optionally including its transcript", risk: "read", params: { noteId: { type: "string", required: true }, includeTranscript: { type: "boolean" } } },
+    },
+  },
+};

--- a/packages/gateway/src/integrations/registry.ts
+++ b/packages/gateway/src/integrations/registry.ts
@@ -1,4 +1,9 @@
-import type { ServiceAction, ServiceDefinition } from "./types.js";
+import type {
+  IntegrationActionRisk,
+  ServiceAction,
+  ServiceDefinition,
+} from "./types.js";
+import { EXPANSION_SERVICE_REGISTRY } from "./registry-expansion.js";
 import type { PipedreamConnectClient } from "./pipedream.js";
 
 const LOGO_BASE = "https://pipedream.com/s.v0";
@@ -83,7 +88,46 @@ function linearGraphqlBody(query: string, variables?: Record<string, unknown>): 
   return variables ? { query, variables } : { query };
 }
 
-export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = {
+type RegistryActionInput = Omit<ServiceAction, "risk"> & { risk?: IntegrationActionRisk };
+type RegistryServiceInput = Omit<ServiceDefinition, "actions" | "connectorKind"> & {
+  connectorKind?: ServiceDefinition["connectorKind"];
+  actions: Record<string, RegistryActionInput>;
+};
+
+const WRITE_ACTIONS = new Set([
+  "gmail.send_email",
+  "google_calendar.create_event",
+  "google_calendar.update_event",
+  "google_drive.upload_file",
+  "google_drive.share_file",
+  "github.create_issue",
+  "linear.create_issue",
+  "linear.update_issue",
+  "linear.comment_issue",
+  "linear.create_workflow_state",
+  "slack.send_message",
+  "slack.react",
+  "discord.send_message",
+]);
+function defineServiceRegistry(
+  input: Record<string, RegistryServiceInput>,
+): Record<string, ServiceDefinition> {
+  return Object.fromEntries(Object.entries(input).map(([serviceId, service]) => [
+    serviceId,
+    {
+      ...service,
+      connectorKind: service.connectorKind ?? "pipedream",
+      actions: Object.fromEntries(Object.entries(service.actions).map(([actionId, action]) => {
+        const key = `${serviceId}.${actionId}`;
+        const risk = action.risk
+          ?? (WRITE_ACTIONS.has(key) ? "write" : "read");
+        return [actionId, { ...action, risk }];
+      })),
+    },
+  ])) as Record<string, ServiceDefinition>;
+}
+
+export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineServiceRegistry({
   gmail: {
     id: "gmail",
     name: "Gmail",
@@ -254,18 +298,6 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = {
             ...(p.start !== undefined ? { start: { dateTime: String(p.start) } } : {}),
             ...(p.end !== undefined ? { end: { dateTime: String(p.end) } } : {}),
           }),
-        },
-      },
-      // GCal API: events.delete. Returns 204 No Content on success.
-      delete_event: {
-        description: "Delete a calendar event",
-        params: {
-          eventId: { type: "string", required: true },
-        },
-        directApi: {
-          method: "DELETE",
-          url: (p) =>
-            `https://www.googleapis.com/calendar/v3/calendars/primary/events/${encodeURIComponent(String(p.eventId))}`,
         },
       },
     },
@@ -761,21 +793,6 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = {
           }),
         },
       },
-      graphql: {
-        description: "Run a custom Linear GraphQL operation for advanced workflows",
-        params: {
-          query: { type: "string", required: true },
-          variables: { type: "object" },
-        },
-        directApi: {
-          method: "POST",
-          url: "https://api.linear.app/graphql",
-          mapBody: (p) => ({
-            query: String(p.query),
-            ...(p.variables && typeof p.variables === "object" ? { variables: p.variables } : {}),
-          }),
-        },
-      },
     },
   },
 
@@ -956,7 +973,9 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = {
       },
     },
   },
-};
+
+  ...EXPANSION_SERVICE_REGISTRY,
+});
 
 export function getService(id: string): ServiceDefinition | undefined {
   return SERVICE_REGISTRY[id];
@@ -1001,6 +1020,7 @@ export async function discoverComponentKeys(
 
   for (const service of services) {
     try {
+      if (service.connectorKind !== "pipedream" || !service.pipedreamApp) continue;
       const actions = await pipedream.discoverActions(service.pipedreamApp);
       const keySet = new Map(actions.map((a) => [a.key, a]));
 

--- a/packages/gateway/src/integrations/registry.ts
+++ b/packages/gateway/src/integrations/registry.ts
@@ -1,8 +1,4 @@
-import type {
-  IntegrationActionRisk,
-  ServiceAction,
-  ServiceDefinition,
-} from "./types.js";
+import type { ServiceAction, ServiceDefinition } from "./types.js";
 import { EXPANSION_SERVICE_REGISTRY } from "./registry-expansion.js";
 import type { PipedreamConnectClient } from "./pipedream.js";
 
@@ -88,27 +84,11 @@ function linearGraphqlBody(query: string, variables?: Record<string, unknown>): 
   return variables ? { query, variables } : { query };
 }
 
-type RegistryActionInput = Omit<ServiceAction, "risk"> & { risk?: IntegrationActionRisk };
 type RegistryServiceInput = Omit<ServiceDefinition, "actions" | "connectorKind"> & {
   connectorKind?: ServiceDefinition["connectorKind"];
-  actions: Record<string, RegistryActionInput>;
+  actions: ServiceDefinition["actions"];
 };
 
-const WRITE_ACTIONS = new Set([
-  "gmail.send_email",
-  "google_calendar.create_event",
-  "google_calendar.update_event",
-  "google_drive.upload_file",
-  "google_drive.share_file",
-  "github.create_issue",
-  "linear.create_issue",
-  "linear.update_issue",
-  "linear.comment_issue",
-  "linear.create_workflow_state",
-  "slack.send_message",
-  "slack.react",
-  "discord.send_message",
-]);
 function defineServiceRegistry(
   input: Record<string, RegistryServiceInput>,
 ): Record<string, ServiceDefinition> {
@@ -117,12 +97,6 @@ function defineServiceRegistry(
     {
       ...service,
       connectorKind: service.connectorKind ?? "pipedream",
-      actions: Object.fromEntries(Object.entries(service.actions).map(([actionId, action]) => {
-        const key = `${serviceId}.${actionId}`;
-        const risk = action.risk
-          ?? (WRITE_ACTIONS.has(key) ? "write" : "read");
-        return [actionId, { ...action, risk }];
-      })),
     },
   ])) as Record<string, ServiceDefinition>;
 }
@@ -138,6 +112,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
     actions: {
       list_messages: {
         description: "List recent email messages",
+        risk: "read",
         params: {
           query: { type: "string" },
           maxResults: { type: "number" },
@@ -153,6 +128,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       get_message: {
         description: "Get a specific email message by ID",
+        risk: "read",
         params: {
           messageId: { type: "string", required: true },
         },
@@ -175,6 +151,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // CR/LF in the body is legitimate message content.
       send_email: {
         description: "Send an email",
+        risk: "write",
         params: {
           to: { type: "string", required: true },
           subject: { type: "string", required: true },
@@ -199,6 +176,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       search: {
         description: "Search emails by query",
+        risk: "read",
         params: {
           query: { type: "string", required: true },
           maxResults: { type: "number" },
@@ -214,6 +192,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       list_labels: {
         description: "List all email labels",
+        risk: "read",
         params: {},
         directApi: {
           method: "GET",
@@ -236,6 +215,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // and a /calendars/list call to enumerate.
       list_events: {
         description: "List calendar events",
+        risk: "read",
         params: {
           timeMin: { type: "string" },
           timeMax: { type: "string" },
@@ -259,6 +239,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // and remap to {date: ...} all-day events here.
       create_event: {
         description: "Create a new calendar event",
+        risk: "write",
         params: {
           summary: { type: "string", required: true },
           start: { type: "string", required: true },
@@ -283,6 +264,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // forwarded.
       update_event: {
         description: "Update an existing calendar event",
+        risk: "write",
         params: {
           eventId: { type: "string", required: true },
           summary: { type: "string" },
@@ -316,6 +298,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // language. If both are absent, returns the user's recent files.
       list_files: {
         description: "List files in Google Drive",
+        risk: "read",
         params: {
           query: { type: "string" },
           maxResults: { type: "number" },
@@ -341,6 +324,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // would need a separate `download_file` action we haven't shipped.
       get_file: {
         description: "Get file metadata by ID",
+        risk: "read",
         params: {
           fileId: { type: "string", required: true },
         },
@@ -366,6 +350,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // integrations skill at home/.agents/skills/matrix-integrations/SKILL.md.
       upload_file: {
         description: "Upload a file to Google Drive (requires paid Pipedream plan)",
+        risk: "write",
         params: {
           name: { type: "string", required: true },
           content: { type: "string", required: true },
@@ -379,6 +364,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // want a notification, they can paste the link manually.
       share_file: {
         description: "Share a file with another user",
+        risk: "write",
         params: {
           fileId: { type: "string", required: true },
           email: { type: "string", required: true },
@@ -417,6 +403,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // active repos surface first; matches what `gh repo list` does.
       list_repos: {
         description: "List repositories",
+        risk: "read",
         params: {
           sort: { type: "string" },
           per_page: { type: "number" },
@@ -435,6 +422,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // issues should filter on `pull_request === null` client-side.
       list_issues: {
         description: "List issues for a repository (use owner/repo format)",
+        risk: "read",
         params: {
           repo: { type: "string", required: true },
           state: { type: "string" },
@@ -452,6 +440,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // split here. Empty string -> no labels, not a single empty label.
       create_issue: {
         description: "Create a new issue (use owner/repo format)",
+        risk: "write",
         params: {
           repo: { type: "string", required: true },
           title: { type: "string", required: true },
@@ -473,6 +462,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // GitHub API: GET /repos/{owner}/{repo}/pulls.
       list_prs: {
         description: "List pull requests for a repository (use owner/repo format)",
+        risk: "read",
         params: {
           repo: { type: "string", required: true },
           state: { type: "string" },
@@ -489,6 +479,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // default is unread only.
       get_notifications: {
         description: "Get notifications",
+        risk: "read",
         params: {
           all: { type: "boolean" },
         },
@@ -513,6 +504,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
     actions: {
       viewer: {
         description: "Get the connected Linear user",
+        risk: "read",
         params: {},
         directApi: {
           method: "POST",
@@ -526,6 +518,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       list_teams: {
         description: "List Linear teams",
+        risk: "read",
         params: {
           first: { type: "number" },
         },
@@ -543,6 +536,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       list_projects: {
         description: "List Linear projects",
+        risk: "read",
         params: {
           first: { type: "number" },
           after: { type: "string" },
@@ -572,6 +566,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       list_workflow_states: {
         description: "List workflow states for a Linear team",
+        risk: "read",
         params: {
           teamId: { type: "string", required: true },
           first: { type: "number" },
@@ -593,6 +588,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       list_issues: {
         description: "List Linear issues, optionally filtered by team, project, or state name",
+        risk: "read",
         params: {
           first: { type: "number" },
           teamId: { type: "string" },
@@ -670,6 +666,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       create_issue: {
         description: "Create a Linear issue",
+        risk: "write",
         params: {
           teamId: { type: "string", required: true },
           title: { type: "string", required: true },
@@ -709,6 +706,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       update_issue: {
         description: "Update a Linear issue",
+        risk: "write",
         params: {
           issueId: { type: "string", required: true },
           title: { type: "string" },
@@ -743,6 +741,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       comment_issue: {
         description: "Add a comment to a Linear issue",
+        risk: "write",
         params: {
           issueId: { type: "string", required: true },
           body: { type: "string", required: true },
@@ -767,6 +766,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       create_workflow_state: {
         description: "Create a Linear workflow state for Symphony",
+        risk: "write",
         params: {
           teamId: { type: "string", required: true },
           name: { type: "string", required: true },
@@ -817,6 +817,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // channel name like "#general" -- Slack resolves both.
       send_message: {
         description: "Send a message to a channel",
+        risk: "write",
         params: {
           channel: { type: "string", required: true },
           text: { type: "string", required: true },
@@ -832,6 +833,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       list_channels: {
         description: "List available channels",
+        risk: "read",
         params: {
           limit: { type: "number" },
         },
@@ -847,6 +849,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       list_messages: {
         description: "List messages in a channel",
+        risk: "read",
         params: {
           channel: { type: "string", required: true },
           limit: { type: "number" },
@@ -866,6 +869,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // they need to reconnect with `search:read` user-scope.
       search: {
         description: "Search messages",
+        risk: "read",
         params: {
           query: { type: "string", required: true },
         },
@@ -881,6 +885,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // colons -- ":thumbsup:" should be passed as "thumbsup".
       react: {
         description: "Add a reaction to a message (emoji name without colons)",
+        risk: "write",
         params: {
           channel: { type: "string", required: true },
           timestamp: { type: "string", required: true },
@@ -920,6 +925,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // strictly validated before interpolation.
       send_message: {
         description: "Send a message to a channel",
+        risk: "write",
         params: {
           channelId: { type: "string", required: true },
           content: { type: "string", required: true },
@@ -936,6 +942,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // OAuth scope.
       list_servers: {
         description: "List servers the bot is in",
+        risk: "read",
         params: {},
         directApi: {
           method: "GET",
@@ -946,6 +953,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // VIEW_CHANNEL permission.
       list_channels: {
         description: "List channels in a server",
+        risk: "read",
         params: {
           serverId: { type: "string", required: true },
         },
@@ -958,6 +966,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // GET /channels/{channel.id}/messages. Returns most recent first.
       list_messages: {
         description: "List messages in a channel",
+        risk: "read",
         params: {
           channelId: { type: "string", required: true },
           limit: { type: "number" },

--- a/packages/gateway/src/integrations/routes.ts
+++ b/packages/gateway/src/integrations/routes.ts
@@ -1016,20 +1016,29 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
   // DELETE /:id -- disconnect service
   // -----------------------------------------------------------------------
 
-  app.delete("/:id", async (c) => {
+  app.delete("/:id", bodyLimit({ maxSize: 1024 }), async (c) => {
     const uid = await requireUser(c);
     if (!uid) return c.json({ error: "Unauthorized" }, 401);
 
     const id = c.req.param("id");
     if (!UUID_RE.test(id)) return c.json({ error: "Invalid ID" }, 400);
-    if (mcpPresetBroker && await mcpPresetBroker.disconnect(uid, id)) {
-      emit({ type: "integration:disconnected", service: "granola", id });
-      return c.json({ ok: true });
-    }
     const result = await requireOwnedService(c, id, uid);
     if (result === "invalid") return c.json({ error: "Invalid ID" }, 400);
-    if (result === null) return c.json({ error: "Not found" }, 404);
     if (result === "forbidden") return c.json({ error: "Forbidden" }, 403);
+
+    if (result === null) {
+      if (!mcpPresetBroker) return c.json({ error: "Not found" }, 404);
+      try {
+        if (await mcpPresetBroker.disconnect(uid, id)) {
+          emit({ type: "integration:disconnected", service: "granola", id });
+          return c.json({ ok: true });
+        }
+      } catch (err: unknown) {
+        console.error("[integrations] MCP preset disconnect error:", err);
+        return c.json({ error: "Integration service unavailable" }, 503);
+      }
+      return c.json({ error: "Not found" }, 404);
+    }
 
     try {
       await pipedream.revokeAccount(result.pipedream_account_id);

--- a/packages/gateway/src/integrations/routes.ts
+++ b/packages/gateway/src/integrations/routes.ts
@@ -136,7 +136,7 @@ export async function executeIntegrationAction(opts: {
     );
     const configuredProps: Record<string, unknown> = {
       ...safeParams,
-      [def.pipedreamApp]: { authProvisionId: connection.pipedream_account_id },
+      [def.pipedreamApp!]: { authProvisionId: connection.pipedream_account_id },
     };
     const result = await pipedream.runAction({
       externalUserId,
@@ -163,6 +163,7 @@ export async function executeIntegrationAction(opts: {
             accountId,
             url,
             params: api.mapParams ? api.mapParams(params ?? {}) : undefined,
+            ...(api.staticHeaders ? { headers: { ...api.staticHeaders } } : {}),
           }),
         };
       case "DELETE":
@@ -172,6 +173,7 @@ export async function executeIntegrationAction(opts: {
             accountId,
             url,
             params: api.mapParams ? api.mapParams(params ?? {}) : undefined,
+            ...(api.staticHeaders ? { headers: { ...api.staticHeaders } } : {}),
           }),
         };
       case "POST":
@@ -181,6 +183,7 @@ export async function executeIntegrationAction(opts: {
             accountId,
             url,
             body: api.mapBody ? api.mapBody(params ?? {}) : (params ?? {}),
+            ...(api.staticHeaders ? { headers: { ...api.staticHeaders } } : {}),
           }),
         };
       case "PUT":
@@ -190,6 +193,7 @@ export async function executeIntegrationAction(opts: {
             accountId,
             url,
             body: api.mapBody ? api.mapBody(params ?? {}) : (params ?? {}),
+            ...(api.staticHeaders ? { headers: { ...api.staticHeaders } } : {}),
           }),
         };
       case "PATCH":
@@ -199,6 +203,7 @@ export async function executeIntegrationAction(opts: {
             accountId,
             url,
             body: api.mapBody ? api.mapBody(params ?? {}) : (params ?? {}),
+            ...(api.staticHeaders ? { headers: { ...api.staticHeaders } } : {}),
           }),
         };
       default: {
@@ -358,10 +363,30 @@ export interface IntegrationRoutesOpts {
   webhookSecret: string;
   resolveUserId: (c: Context) => Promise<string | null>;
   broadcast?: IntegrationBroadcast;
+  mcpPresetBroker?: {
+    listConnections(userId: string): Promise<Array<{
+      id: string;
+      service: string;
+      account_label: string;
+      account_email: string | null;
+      scopes: string[];
+      status: string;
+      connected_at: Date | string;
+      last_used_at: Date | string | null;
+    }>>;
+    connect(userId: string, service: ServiceDefinition): Promise<{ url: string }>;
+    call(input: {
+      userId: string;
+      service: ServiceDefinition;
+      actionId: string;
+      params?: Record<string, unknown>;
+    }): Promise<unknown>;
+    disconnect(userId: string, connectionId: string): Promise<boolean>;
+  };
 }
 
 export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
-  const { db, pipedream, webhookSecret, resolveUserId, broadcast } = opts;
+  const { db, pipedream, webhookSecret, resolveUserId, broadcast, mcpPresetBroker } = opts;
   const emit = broadcast ?? (() => {});
   const app = new Hono();
 
@@ -497,8 +522,8 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
     const promise = (async () => {
       const services = listServices();
       const results = await Promise.allSettled(
-        services.map(async (s) => {
-          const info = await pipedream.getAppInfo(s.pipedreamApp);
+        services.filter((service) => service.connectorKind === "pipedream" && service.pipedreamApp).map(async (s) => {
+          const info = await pipedream.getAppInfo(s.pipedreamApp!);
           if (info?.imgSrc) {
             if (logoCache.size >= LOGO_CACHE_MAX) logoCache.delete(logoCache.keys().next().value!);
             logoCache.set(s.id, info.imgSrc);
@@ -531,10 +556,12 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
   });
 
   app.get("/available", (c) => {
-    const services = listServices().map((s) => ({
-      ...s,
-      logoUrl: logoCache.get(s.id) || s.logoUrl,
-    }));
+    const services = listServices()
+      .filter((service) => service.connectorKind !== "mcp_preset" || mcpPresetBroker)
+      .map((s) => ({
+        ...s,
+        logoUrl: logoCache.get(s.id) || s.logoUrl,
+      }));
     return c.json(services);
   });
 
@@ -545,7 +572,10 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
   app.get("/", async (c) => {
     const uid = await requireUser(c);
     if (!uid) return c.json({ error: "Unauthorized" }, 401);
-    const services = await db.listConnectedServices(uid);
+    const services = [
+      ...await db.listConnectedServices(uid),
+      ...(mcpPresetBroker ? await mcpPresetBroker.listConnections(uid) : []),
+    ];
     return c.json(services.map(({ id, service, account_label, account_email, scopes, status, connected_at, last_used_at }) => ({
       id, service, account_label, account_email, scopes, status, connected_at, last_used_at,
     })));
@@ -567,7 +597,10 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
       const existing = await db.listConnectedServices(uid);
       const existingPdIds = new Set(existing.map((s) => s.pipedream_account_id));
 
-      const newAccounts = pdAccounts.filter((acc) => !existingPdIds.has(acc.id) && getService(acc.app));
+      const newAccounts = pdAccounts.filter((acc) => {
+        const service = getService(acc.app);
+        return !existingPdIds.has(acc.id) && service?.connectorKind === "pipedream";
+      });
 
       // Resolve emails for new accounts missing them
       const resolvedEmails = await Promise.all(
@@ -620,7 +653,10 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
         }),
       );
 
-      const services = await db.listConnectedServices(uid);
+      const services = [
+        ...await db.listConnectedServices(uid),
+        ...(mcpPresetBroker ? await mcpPresetBroker.listConnections(uid) : []),
+      ];
       return c.json({ synced, services });
     } catch (err) {
       console.error("[integrations] Sync failed:", err instanceof Error ? err.message : err);
@@ -654,6 +690,18 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
     if (!def) {
       return c.json({ error: `Unknown service: ${service}` }, 400);
     }
+
+    if (def.connectorKind === "mcp_preset") {
+      if (!mcpPresetBroker) return c.json({ error: "Service connection unavailable" }, 503);
+      try {
+        const result = await mcpPresetBroker.connect(uid, def);
+        return c.json({ url: result.url, service });
+      } catch (err) {
+        console.error("[integrations] MCP preset connect failed:", err instanceof Error ? err.message : String(err));
+        return c.json({ error: "Failed to initiate connection. Please try again." }, 502);
+      }
+    }
+    if (!def.pipedreamApp) return c.json({ error: "Service connection unavailable" }, 503);
 
     const externalId = await getOrCreateExternalId(uid);
 
@@ -700,7 +748,7 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
 
     const { external_user_id, account_id, app: appName, label, email, scopes } = parsed.data;
 
-    if (!getService(appName)) {
+    if (getService(appName)?.connectorKind !== "pipedream") {
       return c.json({ error: "Unsupported app" }, 400);
     }
 
@@ -804,6 +852,22 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
         missing: paramValidation.missing.length > 0 ? paramValidation.missing : undefined,
         type_errors: paramValidation.typeErrors.length > 0 ? paramValidation.typeErrors : undefined,
       }, 400);
+    }
+
+    if (def.connectorKind === "mcp_preset") {
+      if (!mcpPresetBroker) return c.json({ error: "Integration service unavailable" }, 503);
+      try {
+        const data = await mcpPresetBroker.call({
+          userId: uid,
+          service: def,
+          actionId: action,
+          params,
+        });
+        return c.json({ data, service, action });
+      } catch (err) {
+        console.error("[integrations] MCP preset call failed:", err instanceof Error ? err.message : String(err));
+        return c.json({ error: "Integration call failed" }, 502);
+      }
     }
 
     // Find the user's active connection for this service. On cache miss
@@ -957,6 +1021,11 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
     if (!uid) return c.json({ error: "Unauthorized" }, 401);
 
     const id = c.req.param("id");
+    if (!UUID_RE.test(id)) return c.json({ error: "Invalid ID" }, 400);
+    if (mcpPresetBroker && await mcpPresetBroker.disconnect(uid, id)) {
+      emit({ type: "integration:disconnected", service: "granola", id });
+      return c.json({ ok: true });
+    }
     const result = await requireOwnedService(c, id, uid);
     if (result === "invalid") return c.json({ error: "Invalid ID" }, 400);
     if (result === null) return c.json({ error: "Not found" }, 404);

--- a/packages/gateway/src/integrations/types.ts
+++ b/packages/gateway/src/integrations/types.ts
@@ -9,11 +9,17 @@ export interface DirectApi {
   url: string | ((params: Record<string, unknown>) => string);
   mapParams?: (params: Record<string, unknown>) => Record<string, string>;
   mapBody?: (params: Record<string, unknown>) => Record<string, unknown>;
+  /** Header names and values are compile-time registry data, never caller input. */
+  staticHeaders?: Readonly<Record<string, string>>;
 }
+
+export type IntegrationActionRisk = "read" | "write" | "destructive";
+export type IntegrationConnectorKind = "pipedream" | "mcp_preset";
 
 export interface ServiceAction {
   description: string;
   params: Record<string, ActionParam>;
+  risk: IntegrationActionRisk;
   componentKey?: string;
   directApi?: DirectApi;
 }
@@ -22,7 +28,12 @@ export interface ServiceDefinition {
   id: string;
   name: string;
   category: string;
-  pipedreamApp: string;
+  connectorKind: IntegrationConnectorKind;
+  pipedreamApp?: string;
+  mcpPreset?: {
+    url: string;
+    authMode: "oauth";
+  };
   icon: string;
   logoUrl: string;
   actions: Record<string, ServiceAction>;

--- a/scripts/lib/pipedream-integration-verification.ts
+++ b/scripts/lib/pipedream-integration-verification.ts
@@ -1,0 +1,34 @@
+import type { DiscoveredAction } from "../../packages/gateway/src/integrations/pipedream.js";
+import type { ServiceAction } from "../../packages/gateway/src/integrations/types.js";
+
+interface BindDiscoveredComponentKeyInput {
+  serviceId: string;
+  actionId: string;
+  action: ServiceAction;
+  discovered: readonly DiscoveredAction[];
+  componentKey?: string;
+}
+
+/**
+ * Bind a caller-selected component key only after exact live discovery proves
+ * that it exists. Direct API actions do not need a Pipedream component.
+ */
+export function bindDiscoveredComponentKey(
+  input: BindDiscoveredComponentKeyInput,
+): ServiceAction {
+  if (input.action.directApi) return input.action;
+
+  const componentKey = input.componentKey?.trim();
+  if (!componentKey) {
+    throw new Error(
+      `${input.serviceId}/${input.actionId} componentKey is required for live verification`,
+    );
+  }
+  if (!input.discovered.some((candidate) => candidate.key === componentKey)) {
+    throw new Error(
+      `${input.serviceId}/${input.actionId} componentKey was not returned by live discovery`,
+    );
+  }
+
+  return { ...input.action, componentKey };
+}

--- a/scripts/verify-pipedream-integration-expansion.ts
+++ b/scripts/verify-pipedream-integration-expansion.ts
@@ -1,0 +1,66 @@
+/**
+ * Live development-project gate for spec 118.
+ *
+ * PIPEDREAM_VERIFICATION_CASES is a JSON object keyed by Matrix service id:
+ * {"figma":{"accountId":"apn_...","action":"list_comments","params":{"fileKey":"..."}}}
+ * The script intentionally requires real connected accounts and invokes the
+ * production execution boundary; it never fabricates component keys.
+ */
+import { createPipedreamClient } from "../packages/gateway/src/integrations/pipedream.js";
+import { executeIntegrationAction } from "../packages/gateway/src/integrations/routes.js";
+import { getAction, getService } from "../packages/gateway/src/integrations/registry.js";
+
+const REQUIRED = ["google_docs", "notion", "figma", "posthog", "jira", "stripe"] as const;
+const clientId = process.env.PIPEDREAM_CLIENT_ID;
+const clientSecret = process.env.PIPEDREAM_CLIENT_SECRET;
+const projectId = process.env.PIPEDREAM_PROJECT_ID;
+const externalUserId = process.env.PIPEDREAM_VERIFICATION_EXTERNAL_USER_ID;
+const casesRaw = process.env.PIPEDREAM_VERIFICATION_CASES;
+
+if (!clientId || !clientSecret || !projectId || !externalUserId || !casesRaw) {
+  throw new Error("Live verification requires Pipedream development credentials, an external user id, and PIPEDREAM_VERIFICATION_CASES");
+}
+if ((process.env.PIPEDREAM_ENVIRONMENT ?? "development") !== "development") {
+  throw new Error("Verification is development-environment only");
+}
+
+const cases = JSON.parse(casesRaw) as Record<string, {
+  accountId: string;
+  action: string;
+  params?: Record<string, unknown>;
+}>;
+const pipedream = await createPipedreamClient({
+  clientId,
+  clientSecret,
+  projectId,
+  environment: "development",
+});
+
+for (const serviceId of REQUIRED) {
+  const service = getService(serviceId);
+  const verification = cases[serviceId];
+  if (!service?.pipedreamApp || !verification) throw new Error(`Missing verification case for ${serviceId}`);
+  const app = await pipedream.getAppInfo(service.pipedreamApp);
+  if (!app) throw new Error(`Pipedream app slug not found: ${service.pipedreamApp}`);
+  const discovered = await pipedream.discoverActions(service.pipedreamApp);
+  const action = getAction(serviceId, verification.action);
+  if (!action || action.risk !== "read") throw new Error(`${serviceId} verification action must be read-only`);
+  const result = await executeIntegrationAction({
+    pipedream,
+    externalUserId,
+    connection: { pipedream_account_id: verification.accountId },
+    def: service,
+    actionDef: action,
+    serviceId,
+    actionId: verification.action,
+    params: verification.params,
+  });
+  process.stdout.write(`${JSON.stringify({
+    service: serviceId,
+    appSlug: service.pipedreamApp,
+    appName: app.name,
+    discoveredComponentKeys: discovered.map((item) => item.key),
+    readAction: verification.action,
+    readSucceeded: result.data !== undefined,
+  })}\n`);
+}

--- a/scripts/verify-pipedream-integration-expansion.ts
+++ b/scripts/verify-pipedream-integration-expansion.ts
@@ -2,13 +2,14 @@
  * Live development-project gate for spec 118.
  *
  * PIPEDREAM_VERIFICATION_CASES is a JSON object keyed by Matrix service id:
- * {"figma":{"accountId":"apn_...","action":"list_comments","params":{"fileKey":"..."}}}
+ * {"posthog":{"accountId":"apn_...","action":"list_projects","componentKey":"posthog-list-projects"}}
  * The script intentionally requires real connected accounts and invokes the
  * production execution boundary; it never fabricates component keys.
  */
 import { createPipedreamClient } from "../packages/gateway/src/integrations/pipedream.js";
 import { executeIntegrationAction } from "../packages/gateway/src/integrations/routes.js";
 import { getAction, getService } from "../packages/gateway/src/integrations/registry.js";
+import { bindDiscoveredComponentKey } from "./lib/pipedream-integration-verification.js";
 
 const REQUIRED = ["google_docs", "notion", "figma", "posthog", "jira", "stripe"] as const;
 const clientId = process.env.PIPEDREAM_CLIENT_ID;
@@ -27,6 +28,7 @@ if ((process.env.PIPEDREAM_ENVIRONMENT ?? "development") !== "development") {
 const cases = JSON.parse(casesRaw) as Record<string, {
   accountId: string;
   action: string;
+  componentKey?: string;
   params?: Record<string, unknown>;
 }>;
 const pipedream = await createPipedreamClient({
@@ -45,12 +47,19 @@ for (const serviceId of REQUIRED) {
   const discovered = await pipedream.discoverActions(service.pipedreamApp);
   const action = getAction(serviceId, verification.action);
   if (!action || action.risk !== "read") throw new Error(`${serviceId} verification action must be read-only`);
+  const verifiedAction = bindDiscoveredComponentKey({
+    serviceId,
+    actionId: verification.action,
+    action,
+    discovered,
+    componentKey: verification.componentKey,
+  });
   const result = await executeIntegrationAction({
     pipedream,
     externalUserId,
     connection: { pipedream_account_id: verification.accountId },
     def: service,
-    actionDef: action,
+    actionDef: verifiedAction,
     serviceId,
     actionId: verification.action,
     params: verification.params,
@@ -60,6 +69,7 @@ for (const serviceId of REQUIRED) {
     appSlug: service.pipedreamApp,
     appName: app.name,
     discoveredComponentKeys: discovered.map((item) => item.key),
+    verifiedComponentKey: verifiedAction.componentKey ?? null,
     readAction: verification.action,
     readSucceeded: result.data !== undefined,
   })}\n`);

--- a/specs/118-integration-expansion/SDK-VERIFICATION.md
+++ b/specs/118-integration-expansion/SDK-VERIFICATION.md
@@ -6,7 +6,7 @@ Date: 2026-08-29
 
 The live Pipedream development-environment spike is **blocked** in this checkout. `PIPEDREAM_CLIENT_ID`, `PIPEDREAM_CLIENT_SECRET`, `PIPEDREAM_PROJECT_ID`, a development external-user ID, and connected provider test accounts are not present. No successful provider read, granted-scope capture, or SDK component key is claimed here.
 
-Run `node --import tsx scripts/verify-pipedream-integration-expansion.ts` with `PIPEDREAM_ENVIRONMENT=development` and the documented `PIPEDREAM_VERIFICATION_CASES` input. Paste its JSONL output and the Pipedream connection metadata below before release. The script rejects production projects and invokes one real read through Matrix's action boundary for each provider.
+Run `node --import tsx scripts/verify-pipedream-integration-expansion.ts` with `PIPEDREAM_ENVIRONMENT=development` and `PIPEDREAM_VERIFICATION_CASES` containing an account, read action, parameters, and the exact live-discovered `componentKey` for each component-backed case (currently PostHog and Jira). Direct-API cases omit `componentKey`. Paste its JSONL output and the Pipedream connection metadata below before release. The script rejects production projects, confirms each supplied component key appears in `discoverActions()`, and invokes one real read through Matrix's action boundary for each provider.
 
 | Provider | Documented app slug/auth evidence | Paid-plan evidence | Live app/auth/scopes/read | Component keys |
 | --- | --- | --- | --- | --- |

--- a/specs/118-integration-expansion/SDK-VERIFICATION.md
+++ b/specs/118-integration-expansion/SDK-VERIFICATION.md
@@ -1,0 +1,33 @@
+# SDK verification — managed integration expansion
+
+Date: 2026-08-29
+
+## Gate status
+
+The live Pipedream development-environment spike is **blocked** in this checkout. `PIPEDREAM_CLIENT_ID`, `PIPEDREAM_CLIENT_SECRET`, `PIPEDREAM_PROJECT_ID`, a development external-user ID, and connected provider test accounts are not present. No successful provider read, granted-scope capture, or SDK component key is claimed here.
+
+Run `node --import tsx scripts/verify-pipedream-integration-expansion.ts` with `PIPEDREAM_ENVIRONMENT=development` and the documented `PIPEDREAM_VERIFICATION_CASES` input. Paste its JSONL output and the Pipedream connection metadata below before release. The script rejects production projects and invokes one real read through Matrix's action boundary for each provider.
+
+| Provider | Documented app slug/auth evidence | Paid-plan evidence | Live app/auth/scopes/read | Component keys |
+| --- | --- | --- | --- | --- |
+| Google Docs | `google_docs`; Pipedream's current app page exposes this slug | Not listed as Premium App | **BLOCKED** | None recorded |
+| Notion | `notion`; current Pipedream app catalog | Not listed as Premium App | **BLOCKED** | None recorded |
+| Figma | `figma`; Pipedream example shows OAuth access token and `/v1/me` read | Not listed as Premium App | **BLOCKED** | None recorded |
+| PostHog | `posthog`; Pipedream example shows API-key auth and `/api/users/@me/` read | Not listed as Premium App | **BLOCKED** | None recorded |
+| Jira | `jira`; Pipedream example shows OAuth and `https://api.atlassian.com/me` | Jira is listed as a Premium App | **BLOCKED** | None recorded |
+| Stripe | `stripe`; Pipedream example shows API-key auth | Stripe is listed as a Premium App | **BLOCKED** | None recorded |
+
+Sources consulted: Pipedream's official app catalog, app-discovery/API documentation, and Premium Apps list. Documentation confirms candidate slugs and auth shapes, but it does not replace the required connected-account spike.
+
+## Release rule
+
+- Do not hand-author or infer component keys. `discoverComponentKeys()` only accepts keys returned by the live SDK action catalog.
+- PostHog and Jira actions have no speculative component keys or direct endpoint contracts. They deliberately fail as not implemented until the live spike records compatible SDK components.
+- The remaining new providers use explicitly reviewed direct API routes, but their end-to-end release gate is still a successful development-account read.
+- Stripe must use a connected restricted read-only key (`rk_...`) scoped only to the catalog reads. Matrix billing Stripe credentials are never accepted by this flow.
+
+## Granola verification
+
+Granola's current official documentation confirms the public endpoint `https://mcp.granola.ai/mcp`, Streamable HTTP, browser OAuth with bearer tokens, and no MCP API-key/service-account mode. The upstream tools currently documented are `list_meetings`, `get_meetings`, and paid-plan-only `get_meeting_transcript`; Matrix maps these to stable `list_notes` and `get_note` actions after runtime schema discovery.
+
+The live Granola OAuth/read spike is also account-gated and remains **BLOCKED** in this checkout.

--- a/specs/118-integration-expansion/spec.md
+++ b/specs/118-integration-expansion/spec.md
@@ -1,0 +1,72 @@
+# Managed integrations and Custom MCP expansion
+
+## Outcome
+
+Matrix preserves the existing seven integrations and adds Google Docs, Notion,
+Figma, PostHog, Jira, Stripe, and Granola. The ordinary providers use
+Pipedream; Granola is a curated OAuth Streamable HTTP preset. Personal Custom
+MCP is platform brokered and available in Canvas and desktop settings.
+
+The live provider-account release gate and evidence live in
+`SDK-VERIFICATION.md`. Missing credentials in the implementation checkout are
+recorded as a blocker rather than replaced with inferred component keys.
+
+## Trust boundaries
+
+| Boundary | Secret-bearing | Enforcement |
+| --- | --- | --- |
+| Platform Postgres | AES-256-GCM credential envelopes | dedicated required key; random nonce; owner + server AAD |
+| Platform broker | decrypted credential in request memory | owner checks, revision checks, limits, OAuth rotation/revocation |
+| Customer VPS | no MCP/provider credential | atomic `~/system/mcp-servers.json` projection |
+| Kernel | no upstream credential | generic list/describe/call tools; external-content wrapper; approvals |
+| Apps | no Custom MCP access in v1 | no `window.MatrixOS.service()` or manifest bridge |
+
+Effective permission is `platform.enabled ∩ local.enabled` at an identical
+revision. Missing, stale, disabled, or mismatched state fails closed.
+
+## Lifecycle and failure behavior
+
+- Create: validate URL → create `pending` database row → atomically project →
+  activate. Pending rows expire after 24 hours.
+- Discover: initialize current Streamable HTTP, cap catalog/schema sizes, and
+  persist every discovered tool disabled with `always_ask`.
+- Enable: requires at least one selected tool and optimistic revision match.
+- Remove: disable platform row first → remove projection → revoke OAuth →
+  delete. Revocation/projection failure leaves `action_required` visible.
+- Calls: revalidate URL and DNS, pin the validated address, reject redirects,
+  apply 30-second timeout/64 KB request/1 MB response bounds, and wrap output
+  as untrusted content.
+- Session clients use capped TTL/LRU reuse; stale/failing clients are isolated,
+  and shutdown sends best-effort MCP session DELETE drains.
+
+## Authentication matrix
+
+| Mode | Stored platform-side | Notes |
+| --- | --- | --- |
+| none | nothing | HTTPS only |
+| OAuth | access/rotating refresh token and discovered metadata | discovery, PKCE S256, expiring one-time state, resource audience binding |
+| bearer | encrypted token | emits only `Authorization: Bearer` |
+| api_key | encrypted token | emits only compile-time `X-API-Key` name |
+
+Custom header names are never user controlled. Managed direct APIs may define
+compile-time static headers such as Notion's API version.
+
+## Resource limits
+
+- 20 personal servers per owner; curated presets do not consume this quota
+- 100 tools per server; 32 KB per input schema
+- 64 KB mutation and upstream request bodies; 1 MB upstream response
+- 10 seconds for OAuth/discovery; 30 seconds for tool calls
+- 60 owner mutations per minute and bounded route rate-state memory
+
+## Runtime wiring
+
+Public `/api/mcp-servers` routes are Clerk-session owned. Customer gateways
+proxy kernel calls to `/internal/containers/:handle/mcp-servers` using the
+exact customer-host credential; platform resolution binds the same handle and
+Clerk user. Projection writes go in the opposite direction to an internal VPS
+route authenticated by that exact credential and expected owner ID.
+
+The primary kernel can use enabled servers. A custom subagent call is denied
+unless its YAML `mcp` frontmatter names the server ID or name. No upstream
+server is injected into Agent SDK `mcpServers`.

--- a/tests/integrations/action-execution.test.ts
+++ b/tests/integrations/action-execution.test.ts
@@ -55,33 +55,32 @@ describe("executeIntegrationAction", () => {
     expect(pipedream.proxyPost).not.toHaveBeenCalled();
   });
 
-  it("dispatches DELETE directApi actions with proxyDelete", async () => {
-    const pipedream = mockPipedream();
-    vi.mocked(pipedream.proxyDelete).mockResolvedValue(undefined);
 
-    const service = getService("google_calendar")!;
-    const action = getAction("google_calendar", "delete_event")!;
+  it("forwards only registry-owned static headers to the provider proxy", async () => {
+    const pipedream = mockPipedream();
+    vi.mocked(pipedream.proxyPost).mockResolvedValue({ results: [] });
 
     await executeIntegrationAction({
       pipedream,
       externalUserId: "user-1",
       connection: { pipedream_account_id: "acc-1" },
-      def: service,
-      actionDef: action,
-      serviceId: "google_calendar",
-      actionId: "delete_event",
+      def: getService("notion")!,
+      actionDef: getAction("notion", "search")!,
+      serviceId: "notion",
+      actionId: "search",
       params: {
-        eventId: "evt_456",
+        query: "roadmap",
+        headers: { Authorization: "attacker-controlled" },
       },
     });
 
-    expect(pipedream.proxyDelete).toHaveBeenCalledWith({
+    expect(pipedream.proxyPost).toHaveBeenCalledWith({
       externalUserId: "user-1",
       accountId: "acc-1",
-      url: "https://www.googleapis.com/calendar/v3/calendars/primary/events/evt_456",
-      params: undefined,
+      url: "https://api.notion.com/v1/search",
+      body: { query: "roadmap" },
+      headers: { "Notion-Version": "2022-06-28" },
     });
-    expect(pipedream.proxyPost).not.toHaveBeenCalled();
   });
 
   it("throws a not-implemented error instead of calling a fabricated fallback URL", async () => {

--- a/tests/integrations/registry.test.ts
+++ b/tests/integrations/registry.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
 import {
   SERVICE_REGISTRY,
   getService,
@@ -79,6 +80,16 @@ describe("Service Registry", () => {
         expect(["read", "write", "destructive"]).toContain(action.risk);
       }
     }
+  });
+
+  it("requires explicit risk metadata at the registry definition boundary", () => {
+    const source = readFileSync(new URL(
+      "../../packages/gateway/src/integrations/registry.ts",
+      import.meta.url,
+    ), "utf8");
+
+    expect(source).not.toContain("risk?: IntegrationActionRisk");
+    expect(source).not.toContain("WRITE_ACTIONS");
   });
 
   it("contains the seven expansion services with stable action contracts", () => {

--- a/tests/integrations/registry.test.ts
+++ b/tests/integrations/registry.test.ts
@@ -10,9 +10,9 @@ import {
 import type { PipedreamConnectClient } from "../../packages/gateway/src/integrations/pipedream.js";
 
 describe("Service Registry", () => {
-  it("has 7 launch services", () => {
-    expect(listServices()).toHaveLength(7);
-    expect(Object.keys(SERVICE_REGISTRY)).toHaveLength(7);
+  it("has the 14-service managed catalog", () => {
+    expect(listServices()).toHaveLength(14);
+    expect(Object.keys(SERVICE_REGISTRY)).toHaveLength(14);
   });
 
   it("returns service by id", () => {
@@ -69,9 +69,92 @@ describe("Service Registry", () => {
       expect(service.id).toBeTruthy();
       expect(service.name).toBeTruthy();
       expect(service.category).toBeTruthy();
-      expect(service.pipedreamApp).toBeTruthy();
+      expect(["pipedream", "mcp_preset"]).toContain(service.connectorKind);
+      if (service.connectorKind === "pipedream") {
+        expect(service.pipedreamApp).toBeTruthy();
+      }
       expect(service.icon).toBeTruthy();
       expect(Object.keys(service.actions).length).toBeGreaterThan(0);
+      for (const action of Object.values(service.actions)) {
+        expect(["read", "write", "destructive"]).toContain(action.risk);
+      }
+    }
+  });
+
+  it("contains the seven expansion services with stable action contracts", () => {
+    const expected: Record<string, { read: string[]; write: string[] }> = {
+      google_docs: {
+        read: ["get_document"],
+        write: ["create_document", "batch_update_document"],
+      },
+      notion: {
+        read: ["search", "get_page", "query_database"],
+        write: ["create_page", "update_page", "append_blocks"],
+      },
+      figma: {
+        read: ["get_file", "get_nodes", "list_comments"],
+        write: ["post_comment"],
+      },
+      posthog: {
+        read: ["list_projects", "list_insights", "get_insight", "query"],
+        write: [],
+      },
+      jira: {
+        read: ["list_projects", "search_issues", "get_issue"],
+        write: ["create_issue", "update_issue", "add_comment"],
+      },
+      stripe: {
+        read: [
+          "list_customers",
+          "get_customer",
+          "list_subscriptions",
+          "list_invoices",
+          "list_payment_intents",
+          "get_balance",
+        ],
+        write: [],
+      },
+      granola: {
+        read: ["list_notes", "get_note"],
+        write: [],
+      },
+    };
+
+    for (const [serviceId, contract] of Object.entries(expected)) {
+      const service = getService(serviceId);
+      expect(service, serviceId).toBeDefined();
+      expect(Object.keys(service!.actions)).toEqual([
+        ...contract.read,
+        ...contract.write,
+      ]);
+      for (const action of contract.read) {
+        expect(service!.actions[action]!.risk).toBe("read");
+      }
+      for (const action of contract.write) {
+        expect(service!.actions[action]!.risk).toBe("write");
+      }
+    }
+
+    expect(getService("granola")).toMatchObject({
+      connectorKind: "mcp_preset",
+      mcpPreset: { url: "https://mcp.granola.ai/mcp", authMode: "oauth" },
+    });
+  });
+
+  it("keeps Stripe, PostHog, and Granola strictly read-only", () => {
+    for (const serviceId of ["stripe", "posthog", "granola"]) {
+      const actions = Object.values(getService(serviceId)!.actions);
+      expect(actions.every((action) => action.risk === "read"), serviceId).toBe(true);
+    }
+  });
+
+  it("uses only compile-time static header names", () => {
+    const notion = getService("notion")!;
+    for (const action of Object.values(notion.actions)) {
+      expect(action.directApi?.staticHeaders).toEqual({
+        "Notion-Version": "2022-06-28",
+      });
+      expect(action.params).not.toHaveProperty("headers");
     }
   });
 
@@ -86,7 +169,7 @@ describe("Service Registry", () => {
     expect(ids).toContain("discord");
   });
 
-  it("exposes Linear project, issue, workflow, comment, and GraphQL actions", () => {
+  it("exposes bounded Linear project, issue, workflow, and comment actions", () => {
     const linear = getService("linear");
     expect(linear).toBeDefined();
     expect(linear!.name).toBe("Linear");
@@ -104,17 +187,21 @@ describe("Service Registry", () => {
       "update_issue",
       "comment_issue",
       "create_workflow_state",
-      "graphql",
     ]));
 
     expect(getAction("linear", "create_issue")!.directApi).toMatchObject({
       method: "POST",
       url: "https://api.linear.app/graphql",
     });
-    expect(getAction("linear", "graphql")!.params).toMatchObject({
-      query: { type: "string", required: true },
-      variables: { type: "object" },
-    });
+    expect(getAction("linear", "graphql")).toBeUndefined();
+  });
+
+  it("does not register destructive or arbitrary-provider escape-hatch actions", () => {
+    expect(getAction("google_calendar", "delete_event")).toBeUndefined();
+    expect(getAction("linear", "graphql")).toBeUndefined();
+    for (const service of listServices()) {
+      expect(Object.values(service.actions).every((action) => action.risk !== "destructive")).toBe(true);
+    }
   });
 
   describe("validateIntegrationManifest", () => {
@@ -128,10 +215,10 @@ describe("Service Registry", () => {
 
     it("returns invalid for unknown services", () => {
       const result = validateIntegrationManifest({
-        integrations: { required: ["gmail", "notion"] },
+        integrations: { required: ["gmail", "salesforce"] },
       });
       expect(result.valid).toBe(false);
-      expect(result.missing).toEqual(["notion"]);
+      expect(result.missing).toEqual(["salesforce"]);
     });
 
     it("handles dotted service.action refs", () => {

--- a/tests/integrations/routes.test.ts
+++ b/tests/integrations/routes.test.ts
@@ -647,6 +647,95 @@ describe("Integration Routes", () => {
   // -----------------------------------------------------------------------
 
   describe("DELETE /:id", () => {
+    it("rejects oversized DELETE bodies before probing either connector", async () => {
+      const disconnect = vi.fn().mockResolvedValue(false);
+      const routes = createIntegrationRoutes({
+        db,
+        pipedream,
+        webhookSecret: WEBHOOK_SECRET,
+        resolveUserId: async () => userId,
+        mcpPresetBroker: {
+          listConnections: vi.fn().mockResolvedValue([]),
+          connect: vi.fn().mockResolvedValue({ url: "https://example.com/oauth" }),
+          call: vi.fn().mockResolvedValue({}),
+          disconnect,
+        },
+      });
+      const brokeredApp = new Hono();
+      brokeredApp.route("/api/integrations", routes);
+
+      const res = await brokeredApp.request(
+        "/api/integrations/00000000-0000-0000-0000-000000000000",
+        {
+          method: "DELETE",
+          headers: { "content-length": "2048" },
+          body: "x".repeat(2048),
+        },
+      );
+
+      expect(res.status).toBe(413);
+      expect(disconnect).not.toHaveBeenCalled();
+      expect(pipedream.revokeAccount).not.toHaveBeenCalled();
+    });
+
+    it("does not probe the MCP broker when disconnecting a Pipedream account", async () => {
+      const svc = await db.connectService({
+        userId,
+        service: "github",
+        pipedreamAccountId: "pd_acc_broker_independent",
+        accountLabel: "Broker Independent",
+        scopes: ["repo"],
+      });
+      const disconnect = vi.fn().mockRejectedValue(new Error("custom MCP database unavailable"));
+      const routes = createIntegrationRoutes({
+        db,
+        pipedream,
+        webhookSecret: WEBHOOK_SECRET,
+        resolveUserId: async () => userId,
+        mcpPresetBroker: {
+          listConnections: vi.fn().mockResolvedValue([]),
+          connect: vi.fn().mockResolvedValue({ url: "https://example.com/oauth" }),
+          call: vi.fn().mockResolvedValue({}),
+          disconnect,
+        },
+      });
+      const brokeredApp = new Hono();
+      brokeredApp.route("/api/integrations", routes);
+
+      const res = await brokeredApp.request(`/api/integrations/${svc.id}`, { method: "DELETE" });
+
+      expect(res.status).toBe(200);
+      expect(disconnect).not.toHaveBeenCalled();
+      expect(pipedream.revokeAccount).toHaveBeenCalledWith("pd_acc_broker_independent");
+    });
+
+    it("maps MCP broker disconnect failures to a generic service error", async () => {
+      const disconnect = vi.fn().mockRejectedValue(new Error("custom MCP database unavailable"));
+      const routes = createIntegrationRoutes({
+        db,
+        pipedream,
+        webhookSecret: WEBHOOK_SECRET,
+        resolveUserId: async () => userId,
+        mcpPresetBroker: {
+          listConnections: vi.fn().mockResolvedValue([]),
+          connect: vi.fn().mockResolvedValue({ url: "https://example.com/oauth" }),
+          call: vi.fn().mockResolvedValue({}),
+          disconnect,
+        },
+      });
+      const brokeredApp = new Hono();
+      brokeredApp.route("/api/integrations", routes);
+
+      const res = await brokeredApp.request(
+        "/api/integrations/00000000-0000-0000-0000-000000000000",
+        { method: "DELETE" },
+      );
+
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({ error: "Integration service unavailable" });
+      expect(disconnect).toHaveBeenCalledWith(userId, "00000000-0000-0000-0000-000000000000");
+    });
+
     it("disconnects a service and revokes Pipedream credentials", async () => {
       const svc = await db.connectService({
         userId,

--- a/tests/integrations/routes.test.ts
+++ b/tests/integrations/routes.test.ts
@@ -86,6 +86,29 @@ describe("Integration Routes", () => {
       expect(gmail).toBeDefined();
       expect(gmail.name).toBe("Gmail");
       expect(gmail.actions).toBeDefined();
+      expect(data.some((service: { id: string }) => service.id === "granola")).toBe(false);
+    });
+
+    it("advertises MCP presets only when their broker is wired", async () => {
+      const routes = createIntegrationRoutes({
+        db,
+        pipedream,
+        webhookSecret: WEBHOOK_SECRET,
+        resolveUserId: async () => userId,
+        mcpPresetBroker: {
+          listConnections: vi.fn().mockResolvedValue([]),
+          connect: vi.fn().mockResolvedValue({ url: "https://example.com/oauth" }),
+          call: vi.fn().mockResolvedValue({}),
+          disconnect: vi.fn().mockResolvedValue(false),
+        },
+      });
+      const brokeredApp = new Hono();
+      brokeredApp.route("/api/integrations", routes);
+
+      const res = await brokeredApp.request("/api/integrations/available");
+      expect(res.status).toBe(200);
+      const data = await res.json() as Array<{ id: string }>;
+      expect(data.some((service) => service.id === "granola")).toBe(true);
     });
   });
 

--- a/tests/scripts/verify-pipedream-integration-expansion.test.ts
+++ b/tests/scripts/verify-pipedream-integration-expansion.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { DiscoveredAction } from "../../packages/gateway/src/integrations/pipedream.js";
+import { getAction } from "../../packages/gateway/src/integrations/registry.js";
+import { bindDiscoveredComponentKey } from "../../scripts/lib/pipedream-integration-verification.js";
+
+describe("Pipedream integration expansion verification", () => {
+  const discovered: DiscoveredAction[] = [
+    { key: "posthog-list-projects", name: "List Projects" },
+    { key: "posthog-get-project", name: "Get Project" },
+  ];
+
+  it("binds only an exact live-discovered component key for one verification invocation", () => {
+    const registryAction = getAction("posthog", "list_projects")!;
+
+    const verifiedAction = bindDiscoveredComponentKey({
+      serviceId: "posthog",
+      actionId: "list_projects",
+      action: registryAction,
+      discovered,
+      componentKey: "posthog-list-projects",
+    });
+
+    expect(verifiedAction).toEqual({
+      ...registryAction,
+      componentKey: "posthog-list-projects",
+    });
+    expect(registryAction.componentKey).toBeUndefined();
+  });
+
+  it("rejects missing or non-discovered component keys for component-backed actions", () => {
+    const action = getAction("posthog", "list_projects")!;
+
+    expect(() => bindDiscoveredComponentKey({
+      serviceId: "posthog",
+      actionId: "list_projects",
+      action,
+      discovered,
+    })).toThrow("componentKey is required");
+
+    expect(() => bindDiscoveredComponentKey({
+      serviceId: "posthog",
+      actionId: "list_projects",
+      action,
+      discovered,
+      componentKey: "hand-authored-key",
+    })).toThrow("was not returned by live discovery");
+  });
+
+  it("leaves reviewed direct API actions unchanged", () => {
+    const action = getAction("figma", "get_file")!;
+    expect(bindDiscoveredComponentKey({
+      serviceId: "figma",
+      actionId: "get_file",
+      action,
+      discovered: [],
+    })).toBe(action);
+  });
+});


### PR DESCRIPTION
## Summary

- expand the managed registry with Google Docs, Notion, Figma, PostHog, Jira, Stripe, and the curated Granola MCP preset
- add connector-kind, action-risk, and compile-time static-header contracts while preserving the existing seven services
- document SDK verification status and gate component-backed actions whose Pipedream keys could not be verified

## Stack

1. This PR: managed catalog and action contracts
2. [PR #1411](https://github.com/HamedMP/matrix-os/pull/1411): Custom MCP broker, security, storage, and APIs
3. [PR #1412](https://github.com/HamedMP/matrix-os/pull/1412): production broker composition, kernel/runtime wiring, and web/desktop management UI

Granola is intentionally not advertised when `mcpPresetBroker` is absent in this contract layer. The production broker is composed in PR #1412 on top of PR #1411, so the full stack enables Granola while every incomplete layer fails closed.

## Invariants

- **Source of truth:** the compile-time service registry defines managed actions; Pipedream remains the credential and connection authority for Pipedream connectors.
- **Lock/transaction scope:** this layer adds no persistence or multi-write workflow; registry lookup and provider calls use the existing integration lifecycle.
- **Acceptable orphan states:** none are introduced because this layer creates no durable records.
- **Auth source of truth:** existing owner-authenticated integration routes and platform-owned Pipedream proxying remain authoritative.
- **Deferred scope:** live Pipedream development credentials were unavailable, so unverified PostHog and Jira component-backed actions remain gated; destructive provider actions are intentionally absent. Production Custom MCP composition is implemented in linked stack PR #1412.

## Validation

- registry suite: 22 tests passed
- focused integration action and managed-contract tests passed
- affected package TypeScript checks passed
- production shell build passed
- pattern scan: 0 violations
