### PR TITLE
feat(integrations): add custom MCP broker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,15 @@ PIPEDREAM_PROJECT_ID=
 PIPEDREAM_ENVIRONMENT=development
 PIPEDREAM_WEBHOOK_SECRET=
 
+# Platform-owned Custom MCP broker. Keep disabled until every required value
+# is provisioned. Generate the dedicated AES-256 key with `openssl rand -base64 32`;
+# never reuse billing, Pipedream, PLATFORM_SECRET, or upgrade credentials.
+CUSTOM_MCP_ENABLED=false
+MCP_CREDENTIAL_ENCRYPTION_KEY=
+MCP_OAUTH_CLIENT_ID=
+MCP_OAUTH_CALLBACK_URL=https://app.matrix-os.com/api/mcp-servers/oauth/callback
+# Direct customer-gateway HTTPS URL; `{handle}` is replaced after owner checks.
+
 # Platform DB (can reuse DATABASE_URL or separate)
 PLATFORM_DATABASE_URL=
 

--- a/packages/gateway/src/integrations/custom-mcp/broker.ts
+++ b/packages/gateway/src/integrations/custom-mcp/broker.ts
@@ -1,0 +1,449 @@
+import { randomUUID } from "node:crypto";
+import type { PlatformDb } from "../../platform-db.js";
+import {
+  decryptCustomMcpCredential,
+  encryptCustomMcpCredential,
+} from "./crypto.js";
+import { RemoteMcpClient } from "./client.js";
+import { validateCustomMcpUrl } from "./security.js";
+import type {
+  CustomMcpApproval,
+  CustomMcpAuthMode,
+  CustomMcpServer,
+  CustomMcpServerProjection,
+  CustomMcpStatus,
+  CustomMcpTool,
+} from "./types.js";
+
+const PENDING_TTL_MS = 24 * 60 * 60 * 1000;
+
+export interface CustomMcpCredential {
+  authorization?: string;
+  oauth?: {
+    accessToken?: string;
+    refreshToken?: string;
+    expiresAt?: string;
+    state?: string;
+    stateExpiresAt?: string;
+    verifier?: string;
+    tokenEndpoint?: string;
+    authorizationEndpoint?: string;
+    resource?: string;
+    revocationEndpoint?: string;
+    clientId?: string;
+    redirectUri?: string;
+    scopes?: string[];
+  };
+}
+
+export interface CustomMcpProjectionBroker {
+  upsert(userId: string, server: CustomMcpServerProjection): Promise<void>;
+  remove(userId: string, serverId: string): Promise<void>;
+  read?(userId: string, serverId: string): Promise<CustomMcpServerProjection | null>;
+}
+
+export interface CreateCustomMcpInput {
+  name: string;
+  url: string;
+  authMode: CustomMcpAuthMode;
+  credential?: string;
+}
+
+export interface PatchCustomMcpInput {
+  revision: number;
+  name?: string;
+  enabled?: boolean;
+  tools?: Array<{
+    name: string;
+    enabled: boolean;
+    approval: CustomMcpApproval;
+  }>;
+}
+
+export class CustomMcpBrokerError extends Error {
+  constructor(
+    readonly code: "not_found" | "conflict" | "invalid" | "forbidden" | "upstream" | "action_required",
+    message = "Custom MCP operation failed",
+  ) {
+    super(message);
+    this.name = "CustomMcpBrokerError";
+  }
+}
+
+function toProjection(server: CustomMcpServer): CustomMcpServerProjection {
+  return {
+    id: server.id,
+    name: server.name,
+    url: server.url,
+    authMode: server.authMode,
+    enabled: server.enabled,
+    revision: server.revision,
+    tools: server.tools.map((tool) => ({
+      name: tool.name,
+      enabled: tool.enabled,
+      approval: tool.approval,
+    })),
+  };
+}
+
+function authorizationFor(
+  authMode: CustomMcpAuthMode,
+  credential: string | undefined,
+): CustomMcpCredential | undefined {
+  if (authMode === "none" || authMode === "oauth") return undefined;
+  if (!credential || credential.length > 8_192) {
+    throw new CustomMcpBrokerError("invalid", "Credential is required");
+  }
+  return authMode === "bearer"
+    ? { authorization: `Bearer ${credential}` }
+    : { authorization: `X-API-Key ${credential}` };
+}
+
+export class CustomMcpBroker {
+  private readonly client: RemoteMcpClient;
+
+  constructor(private readonly options: {
+    db: PlatformDb;
+    encryptionKey: Buffer;
+    projection: CustomMcpProjectionBroker;
+    client?: RemoteMcpClient;
+    now?: () => Date;
+    validateUrl?: typeof validateCustomMcpUrl;
+    revokeOAuth?: (credential: CustomMcpCredential) => Promise<void>;
+    resolveOAuthAuthorization?: (
+      userId: string,
+      row: NonNullable<Awaited<ReturnType<PlatformDb["getCustomMcpServerForBroker"]>>>,
+    ) => Promise<string | undefined>;
+  }) {
+    this.client = options.client ?? new RemoteMcpClient();
+  }
+
+  async shutdown(): Promise<void> {
+    await this.client.shutdown();
+  }
+
+  async list(userId: string): Promise<CustomMcpServer[]> {
+    return this.options.db.listCustomMcpServers(userId);
+  }
+
+  async sweepPending(): Promise<number> {
+    return this.options.db.sweepPendingCustomMcpServers(this.options.now?.() ?? new Date());
+  }
+
+  async getPreset(userId: string, presetId: string) {
+    return this.options.db.getCustomMcpPresetForBroker(presetId, userId);
+  }
+
+  async ensurePreset(input: {
+    userId: string;
+    presetId: string;
+    name: string;
+    url: string;
+  }): Promise<NonNullable<Awaited<ReturnType<PlatformDb["getCustomMcpServerForBroker"]>>>> {
+    const existing = await this.options.db.getCustomMcpPresetForBroker(input.presetId, input.userId);
+    if (existing) return existing;
+    await this.validateRemoteUrl(input.url);
+    const id = randomUUID();
+    const now = this.options.now?.() ?? new Date();
+    const pending = await this.options.db.createCustomMcpServer({
+      id,
+      userId: input.userId,
+      presetId: input.presetId,
+      name: input.name,
+      url: input.url,
+      authMode: "oauth",
+      pendingExpiresAt: new Date(now.getTime() + PENDING_TTL_MS),
+    });
+    await this.options.projection.upsert(input.userId, toProjection(pending));
+    const activated = await this.options.db.updateCustomMcpServer(id, input.userId, pending.revision, {
+      status: "auth_required",
+      pendingExpiresAt: null,
+    });
+    if (!activated) throw new CustomMcpBrokerError("conflict");
+    await this.options.projection.upsert(input.userId, toProjection(activated));
+    return await this.requirePrivate(input.userId, id);
+  }
+
+  async activatePreset(input: {
+    userId: string;
+    presetId: string;
+    allowedTools: readonly string[];
+    requiredTools?: readonly string[];
+  }): Promise<NonNullable<Awaited<ReturnType<PlatformDb["getCustomMcpServerForBroker"]>>>> {
+    let row = await this.options.db.getCustomMcpPresetForBroker(input.presetId, input.userId);
+    if (!row) throw new CustomMcpBrokerError("not_found");
+    if (row.status === "ready" && row.enabled) return row;
+    if (row.status === "auth_required") return row;
+    const discovered = await this.client.discover({
+      serverId: row.id,
+      url: row.url,
+      authorization: await this.readAuthorization(input.userId, row),
+    });
+    const allowed = new Set(input.allowedTools);
+    const tools = discovered.map((tool) => ({
+      ...tool,
+      enabled: allowed.has(tool.name),
+      approval: "allow" as const,
+    }));
+    if (!(input.requiredTools ?? input.allowedTools).every((name) =>
+      tools.some((tool) => tool.name === name))) {
+      throw new CustomMcpBrokerError("upstream", "Curated MCP tool contract is unavailable");
+    }
+    const updated = await this.options.db.updateCustomMcpServer(row.id, input.userId, row.revision, {
+      tools,
+      enabled: true,
+      status: "ready",
+    });
+    if (!updated) throw new CustomMcpBrokerError("conflict");
+    await this.options.projection.upsert(input.userId, toProjection(updated));
+    row = await this.requirePrivate(input.userId, row.id);
+    return row;
+  }
+
+  async describe(userId: string, serverId: string): Promise<CustomMcpServer> {
+    const server = await this.options.db.getCustomMcpServerForBroker(serverId, userId);
+    if (!server) throw new CustomMcpBrokerError("not_found");
+    return {
+      id: server.id,
+      name: server.name,
+      url: server.url,
+      authMode: server.auth_mode,
+      status: server.status,
+      enabled: server.enabled,
+      revision: server.revision,
+      tools: server.tools,
+    };
+  }
+
+  async create(userId: string, input: CreateCustomMcpInput): Promise<CustomMcpServer> {
+    await this.validateRemoteUrl(input.url);
+    const id = randomUUID();
+    const credential = authorizationFor(input.authMode, input.credential);
+    const encryptedCredentials = credential
+      ? encryptCustomMcpCredential(credential, this.options.encryptionKey, { userId, serverId: id })
+      : undefined;
+    const now = this.options.now?.() ?? new Date();
+    const pending = await this.options.db.createCustomMcpServer({
+      id,
+      userId,
+      name: input.name,
+      url: input.url,
+      authMode: input.authMode,
+      encryptedCredentials,
+      pendingExpiresAt: new Date(now.getTime() + PENDING_TTL_MS),
+    });
+
+    try {
+      await this.options.projection.upsert(userId, toProjection(pending));
+    } catch (error) {
+      console.error("[custom-mcp] initial projection failed:", error instanceof Error ? error.message : String(error));
+      throw new CustomMcpBrokerError("upstream");
+    }
+
+    const status: CustomMcpStatus = input.authMode === "oauth" ? "auth_required" : "disabled";
+    const activated = await this.options.db.updateCustomMcpServer(id, userId, pending.revision, {
+      status,
+      pendingExpiresAt: null,
+    });
+    if (!activated) throw new CustomMcpBrokerError("conflict");
+    await this.projectOrMarkActionRequired(userId, activated);
+    return activated;
+  }
+
+  async discover(userId: string, serverId: string): Promise<CustomMcpServer> {
+    const row = await this.requirePrivate(userId, serverId);
+    const tools = await this.client.discover({
+      serverId,
+      url: row.url,
+      authorization: await this.readAuthorization(userId, row),
+    });
+    const updated = await this.options.db.updateCustomMcpServer(serverId, userId, row.revision, {
+      tools,
+      status: "disabled",
+      enabled: false,
+      actionRequiredReason: null,
+    });
+    if (!updated) throw new CustomMcpBrokerError("conflict");
+    await this.projectOrMarkActionRequired(userId, updated);
+    return updated;
+  }
+
+  async patch(userId: string, serverId: string, input: PatchCustomMcpInput): Promise<CustomMcpServer> {
+    const row = await this.requirePrivate(userId, serverId);
+    if (row.revision !== input.revision) throw new CustomMcpBrokerError("conflict");
+    let tools: CustomMcpTool[] | undefined;
+    if (input.tools) {
+      const discovered = new Map(row.tools.map((tool) => [tool.name, tool]));
+      const names = new Set<string>();
+      tools = input.tools.map((selection) => {
+        if (names.has(selection.name)) throw new CustomMcpBrokerError("invalid");
+        names.add(selection.name);
+        const tool = discovered.get(selection.name);
+        if (!tool) throw new CustomMcpBrokerError("invalid");
+        return { ...tool, enabled: selection.enabled, approval: selection.approval };
+      });
+      for (const tool of row.tools) {
+        if (!names.has(tool.name)) tools.push({ ...tool, enabled: false, approval: "always_ask" });
+      }
+    }
+    const enabled = input.enabled ?? row.enabled;
+    if (enabled && !(tools ?? row.tools).some((tool) => tool.enabled)) {
+      throw new CustomMcpBrokerError("invalid", "Select at least one tool before enabling the server");
+    }
+    const status: CustomMcpStatus = enabled ? "ready" : "disabled";
+    const updated = await this.options.db.updateCustomMcpServer(serverId, userId, input.revision, {
+      ...(input.name !== undefined ? { name: input.name } : {}),
+      enabled,
+      status,
+      ...(tools ? { tools } : {}),
+    });
+    if (!updated) throw new CustomMcpBrokerError("conflict");
+    await this.projectOrMarkActionRequired(userId, updated);
+    return updated;
+  }
+
+  async test(userId: string, serverId: string): Promise<{ ok: true; tools: number }> {
+    const row = await this.requirePrivate(userId, serverId);
+    const tools = await this.client.discover({
+      serverId,
+      url: row.url,
+      authorization: await this.readAuthorization(userId, row),
+    });
+    return { ok: true, tools: tools.length };
+  }
+
+  async callTool(input: {
+    userId: string;
+    serverId: string;
+    toolName: string;
+    arguments?: Record<string, unknown>;
+    localProjection: CustomMcpServerProjection | null;
+    approvalGranted: boolean;
+  }): Promise<unknown> {
+    const row = await this.requirePrivate(input.userId, input.serverId);
+    if (!row.enabled || row.status !== "ready") throw new CustomMcpBrokerError("forbidden");
+    const tool = row.enforcement_projection.find((candidate) => candidate.name === input.toolName);
+    const localTool = input.localProjection?.tools.find((candidate) => candidate.name === input.toolName);
+    if (!tool?.enabled
+      || !localTool?.enabled
+      || input.localProjection?.revision !== row.revision) {
+      throw new CustomMcpBrokerError("forbidden");
+    }
+    if ((tool.approval === "always_ask" || localTool.approval === "always_ask")
+      && !input.approvalGranted) {
+      throw new CustomMcpBrokerError("forbidden", "Tool approval is required");
+    }
+    return this.client.callTool({
+      serverId: row.id,
+      url: row.url,
+      authorization: await this.readAuthorization(input.userId, row),
+      toolName: input.toolName,
+      arguments: input.arguments,
+    });
+  }
+
+  async callSelectedTool(input: {
+    userId: string;
+    serverId: string;
+    toolName: string;
+    arguments?: Record<string, unknown>;
+    approvalGranted: boolean;
+  }): Promise<unknown> {
+    const localProjection = this.options.projection.read
+      ? await this.options.projection.read(input.userId, input.serverId)
+      : null;
+    return this.callTool({ ...input, localProjection });
+  }
+
+  async remove(userId: string, serverId: string): Promise<void> {
+    const row = await this.requirePrivate(userId, serverId);
+    const disabled = await this.options.db.updateCustomMcpServer(serverId, userId, row.revision, {
+      enabled: false,
+      status: "disabled",
+    });
+    if (!disabled) throw new CustomMcpBrokerError("conflict");
+    try {
+      await this.options.projection.remove(userId, serverId);
+      if (row.auth_mode === "oauth" && this.options.revokeOAuth) {
+        const credential = this.readCredential(userId, row);
+        await this.options.revokeOAuth(credential);
+      }
+    } catch (error) {
+      console.error("[custom-mcp] removal requires action:", error instanceof Error ? error.message : String(error));
+      await this.options.db.updateCustomMcpServer(serverId, userId, disabled.revision, {
+        status: "action_required",
+        actionRequiredReason: "credential_revocation_failed",
+      });
+      throw new CustomMcpBrokerError("action_required");
+    }
+    if (!await this.options.db.deleteCustomMcpServer(serverId, userId)) {
+      throw new CustomMcpBrokerError("conflict");
+    }
+  }
+
+  private async requirePrivate(userId: string, serverId: string) {
+    const row = await this.options.db.getCustomMcpServerForBroker(serverId, userId);
+    if (!row) throw new CustomMcpBrokerError("not_found");
+    return row;
+  }
+
+  private async validateRemoteUrl(url: string): Promise<void> {
+    try {
+      await (this.options.validateUrl ?? validateCustomMcpUrl)(url);
+    } catch (validationError: unknown) {
+      console.warn(
+        "[custom-mcp] remote URL validation failed:",
+        validationError instanceof Error ? validationError.message : String(validationError),
+      );
+      throw new CustomMcpBrokerError("invalid", "Custom MCP server URL is not allowed");
+    }
+  }
+
+  private readCredential(
+    userId: string,
+    row: Awaited<ReturnType<PlatformDb["getCustomMcpServerForBroker"]>> & {},
+  ): CustomMcpCredential {
+    if (!row.encrypted_credentials) return {};
+    return decryptCustomMcpCredential<CustomMcpCredential>(
+      row.encrypted_credentials,
+      this.options.encryptionKey,
+      { userId, serverId: row.id },
+    );
+  }
+
+  private async readAuthorization(
+    userId: string,
+    row: Awaited<ReturnType<PlatformDb["getCustomMcpServerForBroker"]>> & {},
+  ): Promise<string | undefined> {
+    if (row.auth_mode === "oauth" && this.options.resolveOAuthAuthorization) {
+      return this.options.resolveOAuthAuthorization(userId, row);
+    }
+    const credential = this.readCredential(userId, row);
+    if (credential.oauth?.accessToken) return `Bearer ${credential.oauth.accessToken}`;
+    if (!credential.authorization) return undefined;
+    if (credential.authorization.startsWith("X-API-Key ")) {
+      // The HTTP client accepts a single authorization string today. Preserve
+      // the mode marker so the request layer can translate it without ever
+      // exposing the value to callers.
+      return credential.authorization;
+    }
+    return credential.authorization;
+  }
+
+  private async projectOrMarkActionRequired(
+    userId: string,
+    server: CustomMcpServer,
+  ): Promise<void> {
+    try {
+      await this.options.projection.upsert(userId, toProjection(server));
+    } catch (error) {
+      console.error("[custom-mcp] projection reconciliation failed:", error instanceof Error ? error.message : String(error));
+      await this.options.db.updateCustomMcpServer(server.id, userId, server.revision, {
+        enabled: false,
+        status: "action_required",
+        actionRequiredReason: "projection_reconciliation_failed",
+      });
+      throw new CustomMcpBrokerError("action_required");
+    }
+  }
+}

--- a/packages/gateway/src/integrations/custom-mcp/client.ts
+++ b/packages/gateway/src/integrations/custom-mcp/client.ts
@@ -1,0 +1,405 @@
+import { request as httpsRequest } from "node:https";
+import type { LookupFunction } from "node:net";
+import { createHash } from "node:crypto";
+import { validateCustomMcpUrl } from "./security.js";
+import type { CustomMcpTool } from "./types.js";
+
+const MAX_REQUEST_BYTES = 64 * 1024;
+const MAX_SCHEMA_BYTES = 32 * 1024;
+const MAX_RESPONSE_BYTES = 1024 * 1024;
+const MAX_TOOLS = 100;
+const DISCOVERY_TIMEOUT_MS = 10_000;
+const TOOL_TIMEOUT_MS = 30_000;
+const PROTOCOL_VERSION = "2025-06-18";
+
+export interface RemoteMcpRequest {
+  method?: "POST" | "DELETE";
+  url: string;
+  headers: Record<string, string>;
+  body?: unknown;
+  timeoutMs: number;
+}
+
+export interface RemoteMcpResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+export type RemoteMcpRequester = (
+  request: RemoteMcpRequest,
+) => Promise<RemoteMcpResponse>;
+
+interface JsonRpcResponse {
+  jsonrpc?: string;
+  id?: string | number | null;
+  result?: unknown;
+  error?: { code?: number; message?: string };
+}
+
+function byteLength(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+function parseSseBody(raw: string): unknown {
+  const messages = raw.split(/\r?\n\r?\n/).flatMap((event) => {
+    const data = event.split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trim())
+      .filter(Boolean)
+      .join("\n");
+    return data ? [JSON.parse(data)] : [];
+  });
+  // A response stream may contain related notifications before the actual
+  // JSON-RPC response. Return the last id-bearing message to rpc().
+  return messages.findLast((message) =>
+    Boolean(message) && typeof message === "object" && "id" in (message as object));
+}
+
+export const pinnedRemoteMcpRequester: RemoteMcpRequester = async (input) => {
+  const body = input.body === undefined ? undefined : JSON.stringify(input.body);
+  const bodyBytes = body ? Buffer.byteLength(body, "utf8") : 0;
+  if (bodyBytes > MAX_REQUEST_BYTES) {
+    throw new Error("Custom MCP request exceeds 64 KB limit");
+  }
+  const target = await validateCustomMcpUrl(input.url);
+  const lookup: LookupFunction = ((_hostname, _options, callback) => {
+    callback(null, target.address, target.family);
+  }) as LookupFunction;
+
+  return new Promise<RemoteMcpResponse>((resolve, reject) => {
+    const request = httpsRequest(target.url, {
+      method: input.method ?? "POST",
+      headers: {
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+        ...(body === undefined ? {} : { "content-length": String(bodyBytes) }),
+        ...input.headers,
+      },
+      lookup,
+      servername: target.url.hostname,
+      timeout: input.timeoutMs,
+    }, (response) => {
+      const status = response.statusCode ?? 502;
+      if (status >= 300 && status < 400) {
+        response.resume();
+        reject(new Error("Custom MCP redirects are not allowed"));
+        return;
+      }
+      const chunks: Buffer[] = [];
+      let total = 0;
+      response.on("data", (chunk: Buffer) => {
+        total += chunk.length;
+        if (total > MAX_RESPONSE_BYTES) {
+          response.destroy(new Error("Custom MCP response exceeds 1 MB limit"));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      response.on("error", reject);
+      response.on("end", () => {
+        const headers = Object.fromEntries(Object.entries(response.headers)
+          .filter((entry): entry is [string, string | string[]] => entry[1] !== undefined)
+          .map(([name, value]) => [name.toLowerCase(), Array.isArray(value) ? value.join(", ") : value]));
+        const raw = Buffer.concat(chunks).toString("utf8");
+        let parsed: unknown;
+        try {
+          const contentType = headers["content-type"] ?? "";
+          parsed = raw.length === 0
+            ? undefined
+            : contentType.includes("text/event-stream")
+              ? parseSseBody(raw)
+              : JSON.parse(raw);
+        } catch (parseError: unknown) {
+          console.warn(
+            "[custom-mcp] upstream response parse failed:",
+            parseError instanceof Error ? parseError.message : String(parseError),
+          );
+          reject(new Error("Custom MCP returned an invalid response"));
+          return;
+        }
+        resolve({ status, headers, body: parsed });
+      });
+    });
+    request.on("timeout", () => request.destroy(new Error("Custom MCP request timed out")));
+    request.on("error", reject);
+    request.end(body);
+  });
+};
+
+export interface RemoteMcpConnection {
+  serverId: string;
+  url: string;
+  authorization?: string;
+}
+
+export interface RemoteMcpCall extends RemoteMcpConnection {
+  toolName: string;
+  arguments?: Record<string, unknown>;
+}
+
+interface Session {
+  id?: string;
+  nextRequestId: number;
+  headers: Record<string, string>;
+}
+
+interface CachedSession {
+  connection: RemoteMcpConnection;
+  authorizationFingerprint: string;
+  session: Session;
+  lastUsed: number;
+}
+
+interface PendingInitialization {
+  url: string;
+  authorizationFingerprint: string;
+  promise: Promise<Session>;
+}
+
+export class RemoteMcpClient {
+  private readonly requester: RemoteMcpRequester;
+  private readonly sessions = new Map<string, CachedSession>();
+  private readonly initializations = new Map<string, PendingInitialization>();
+  private readonly maxSessions: number;
+  private readonly sessionTtlMs: number;
+  private readonly now: () => number;
+  private shuttingDown = false;
+
+  constructor(options: { requester?: RemoteMcpRequester; maxSessions?: number; sessionTtlMs?: number; now?: () => number } = {}) {
+    this.requester = options.requester ?? pinnedRemoteMcpRequester;
+    this.maxSessions = options.maxSessions ?? 50;
+    this.sessionTtlMs = options.sessionTtlMs ?? 5 * 60_000;
+    this.now = options.now ?? Date.now;
+  }
+
+  async discover(connection: RemoteMcpConnection): Promise<CustomMcpTool[]> {
+    const session = await this.getSession(connection);
+    let response;
+    try {
+      response = await this.rpc(connection, session, "tools/list", {}, DISCOVERY_TIMEOUT_MS);
+    } catch (error) {
+      await this.evict(connection.serverId);
+      throw error;
+    }
+    const result = response.result as { tools?: unknown } | undefined;
+    if (!Array.isArray(result?.tools)) throw new Error("Custom MCP returned an invalid tool catalog");
+    if (result.tools.length > MAX_TOOLS) throw new Error("Custom MCP tool limit exceeded");
+
+    return result.tools.map((rawTool) => {
+      if (!rawTool || typeof rawTool !== "object" || Array.isArray(rawTool)) {
+        throw new Error("Custom MCP returned an invalid tool definition");
+      }
+      const tool = rawTool as { name?: unknown; description?: unknown; inputSchema?: unknown };
+      if (typeof tool.name !== "string" || tool.name.length < 1 || tool.name.length > 128) {
+        throw new Error("Custom MCP returned an invalid tool name");
+      }
+      const schema = tool.inputSchema ?? { type: "object" };
+      if (byteLength(schema) > MAX_SCHEMA_BYTES) throw new Error("Custom MCP schema limit exceeded");
+      const description = typeof tool.description === "string"
+        ? tool.description.slice(0, 8_192)
+        : "";
+      return {
+        name: tool.name,
+        description,
+        inputSchema: schema,
+        approval: "always_ask" as const,
+        enabled: false,
+      };
+    });
+  }
+
+  async callTool(call: RemoteMcpCall): Promise<unknown> {
+    if (byteLength(call.arguments ?? {}) > MAX_REQUEST_BYTES) {
+      throw new Error("Custom MCP request exceeds 64 KB limit");
+    }
+    const session = await this.getSession(call);
+    let response;
+    try {
+      response = await this.rpc(call, session, "tools/call", {
+        name: call.toolName,
+        arguments: call.arguments ?? {},
+      }, TOOL_TIMEOUT_MS);
+    } catch (error) {
+      await this.evict(call.serverId);
+      throw error;
+    }
+    return response.result;
+  }
+
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true;
+    await Promise.allSettled(
+      [...this.initializations.values()].map((entry) => entry.promise),
+    );
+    const entries = [...this.sessions.values()];
+    this.sessions.clear();
+    await Promise.allSettled(entries.map((entry) => this.terminate(entry)));
+  }
+
+  private baseHeaders(connection: RemoteMcpConnection): Record<string, string> {
+    if (connection.authorization?.startsWith("X-API-Key ")) {
+      return { "x-api-key": connection.authorization.slice("X-API-Key ".length) };
+    }
+    return connection.authorization
+      ? { authorization: connection.authorization }
+      : {};
+  }
+
+  private authorizationFingerprint(connection: RemoteMcpConnection): string {
+    return createHash("sha256").update(connection.authorization ?? "").digest("base64url");
+  }
+
+  private async getSession(connection: RemoteMcpConnection): Promise<Session> {
+    if (this.shuttingDown) throw new Error("Custom MCP client is shutting down");
+    const now = this.now();
+    for (const [serverId, entry] of this.sessions) {
+      if (now - entry.lastUsed > this.sessionTtlMs) await this.evict(serverId);
+    }
+    const fingerprint = this.authorizationFingerprint(connection);
+    const existing = this.sessions.get(connection.serverId);
+    if (existing && existing.connection.url === connection.url && existing.authorizationFingerprint === fingerprint) {
+      existing.lastUsed = now;
+      this.sessions.delete(connection.serverId);
+      this.sessions.set(connection.serverId, existing);
+      return existing.session;
+    }
+    if (existing) await this.evict(connection.serverId);
+
+    const pending = this.initializations.get(connection.serverId);
+    if (pending) {
+      if (pending.url === connection.url && pending.authorizationFingerprint === fingerprint) {
+        return pending.promise;
+      }
+      try {
+        await pending.promise;
+      } catch (initializationError: unknown) {
+        console.warn(
+          "[custom-mcp] superseded initialization failed:",
+          initializationError instanceof Error ? initializationError.message : String(initializationError),
+        );
+      }
+      return this.getSession(connection);
+    }
+    if (this.initializations.size >= this.maxSessions) {
+      throw new Error("Custom MCP session capacity exceeded");
+    }
+
+    // Eviction can await an upstream DELETE. Re-check after every awaited
+    // eviction so shutdown cannot miss and then leak a late initialization.
+    if (this.shuttingDown) throw new Error("Custom MCP client is shutting down");
+    const promise = this.initializeAndCache(connection, fingerprint, now);
+    this.initializations.set(connection.serverId, {
+      url: connection.url,
+      authorizationFingerprint: fingerprint,
+      promise,
+    });
+    try {
+      return await promise;
+    } finally {
+      const current = this.initializations.get(connection.serverId);
+      if (current?.promise === promise) this.initializations.delete(connection.serverId);
+    }
+  }
+
+  private async initializeAndCache(
+    connection: RemoteMcpConnection,
+    authorizationFingerprint: string,
+    lastUsed: number,
+  ): Promise<Session> {
+    const session = await this.initialize(connection);
+    this.sessions.set(connection.serverId, {
+      connection: { ...connection },
+      authorizationFingerprint,
+      session,
+      lastUsed,
+    });
+    while (this.sessions.size > this.maxSessions) {
+      const oldest = this.sessions.keys().next().value as string | undefined;
+      if (oldest) await this.evict(oldest);
+    }
+    return session;
+  }
+
+  private async initialize(connection: RemoteMcpConnection): Promise<Session> {
+    const session: Session = {
+      nextRequestId: 1,
+      headers: this.baseHeaders(connection),
+    };
+    const response = await this.rpc(connection, session, "initialize", {
+      protocolVersion: PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: { name: "matrix-custom-mcp-broker", version: "1.0.0" },
+    }, DISCOVERY_TIMEOUT_MS);
+    const result = response.result as { protocolVersion?: unknown } | undefined;
+    if (!result || typeof result.protocolVersion !== "string") {
+      throw new Error("Custom MCP initialization failed");
+    }
+    const sessionId = response.headers["mcp-session-id"];
+    if (sessionId) {
+      if (sessionId.length > 1024 || /[\r\n]/.test(sessionId)) {
+        throw new Error("Custom MCP returned an invalid session id");
+      }
+      session.id = sessionId;
+      session.headers["mcp-session-id"] = sessionId;
+    }
+    session.headers["mcp-protocol-version"] = result.protocolVersion;
+    await this.requester({
+      url: connection.url,
+      headers: session.headers,
+      body: { jsonrpc: "2.0", method: "notifications/initialized" },
+      timeoutMs: DISCOVERY_TIMEOUT_MS,
+    });
+    return session;
+  }
+
+  private async evict(serverId: string): Promise<void> {
+    const entry = this.sessions.get(serverId);
+    if (!entry) return;
+    this.sessions.delete(serverId);
+    try {
+      await this.terminate(entry);
+    } catch (terminationError: unknown) {
+      console.warn(
+        "[custom-mcp] session termination failed during eviction:",
+        terminationError instanceof Error ? terminationError.message : String(terminationError),
+      );
+    }
+  }
+
+  private async terminate(entry: CachedSession): Promise<void> {
+    if (!entry.session.id) return;
+    await this.requester({
+      method: "DELETE",
+      url: entry.connection.url,
+      headers: entry.session.headers,
+      timeoutMs: DISCOVERY_TIMEOUT_MS,
+    });
+  }
+
+  private async rpc(
+    connection: RemoteMcpConnection,
+    session: Session,
+    method: string,
+    params: unknown,
+    timeoutMs: number,
+  ): Promise<JsonRpcResponse & { headers: Record<string, string> }> {
+    const id = session.nextRequestId++;
+    const result = await this.requester({
+      url: connection.url,
+      headers: session.headers,
+      body: { jsonrpc: "2.0", id, method, params },
+      timeoutMs,
+    });
+    if (result.status < 200 || result.status >= 300) {
+      throw new Error("Custom MCP server request failed");
+    }
+    if (!result.body || typeof result.body !== "object" || Array.isArray(result.body)) {
+      throw new Error("Custom MCP returned an invalid JSON-RPC response");
+    }
+    const response = result.body as JsonRpcResponse;
+    if (response.error) throw new Error("Custom MCP tool returned an error");
+    if (response.id !== id) throw new Error("Custom MCP response id mismatch");
+    return { ...response, headers: result.headers };
+  }
+}

--- a/packages/gateway/src/integrations/custom-mcp/crypto.ts
+++ b/packages/gateway/src/integrations/custom-mcp/crypto.ts
@@ -1,0 +1,93 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+} from "node:crypto";
+
+const NONCE_BYTES = 12;
+const TAG_BYTES = 16;
+const ENVELOPE_VERSION = 1;
+
+export interface CustomMcpCredentialBinding {
+  userId: string;
+  serverId: string;
+}
+
+function additionalData(binding: CustomMcpCredentialBinding): Buffer {
+  return Buffer.from(
+    `matrix-custom-mcp:v1:${binding.userId}:${binding.serverId}`,
+    "utf8",
+  );
+}
+
+export function parseCustomMcpEncryptionKey(
+  value: string | undefined,
+): Buffer {
+  if (!value) {
+    throw new Error("MCP_CREDENTIAL_ENCRYPTION_KEY is required");
+  }
+
+  const trimmed = value.trim();
+  let key: Buffer;
+  if (/^[0-9a-fA-F]{64}$/.test(trimmed)) {
+    key = Buffer.from(trimmed, "hex");
+  } else if (/^[A-Za-z0-9+/]+={0,2}$/.test(trimmed)) {
+    key = Buffer.from(trimmed, "base64");
+  } else {
+    key = Buffer.alloc(0);
+  }
+  if (key.length !== 32) {
+    throw new Error("MCP_CREDENTIAL_ENCRYPTION_KEY must decode to exactly 32 bytes");
+  }
+  return key;
+}
+
+export function encryptCustomMcpCredential(
+  credential: unknown,
+  key: Buffer,
+  binding: CustomMcpCredentialBinding,
+): string {
+  if (key.length !== 32) throw new Error("Custom MCP encryption key must be 32 bytes");
+  const nonce = randomBytes(NONCE_BYTES);
+  const cipher = createCipheriv("aes-256-gcm", key, nonce, {
+    authTagLength: TAG_BYTES,
+  });
+  cipher.setAAD(additionalData(binding));
+  const plaintext = Buffer.from(JSON.stringify(credential), "utf8");
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return [
+    `v${ENVELOPE_VERSION}`,
+    nonce.toString("base64url"),
+    ciphertext.toString("base64url"),
+    tag.toString("base64url"),
+  ].join(".");
+}
+
+export function decryptCustomMcpCredential<T = unknown>(
+  envelope: string,
+  key: Buffer,
+  binding: CustomMcpCredentialBinding,
+): T {
+  if (key.length !== 32) throw new Error("Custom MCP encryption key must be 32 bytes");
+  const parts = envelope.split(".");
+  if (parts.length !== 4 || parts[0] !== `v${ENVELOPE_VERSION}`) {
+    throw new Error("Unsupported Custom MCP credential envelope");
+  }
+  const nonce = Buffer.from(parts[1]!, "base64url");
+  const ciphertext = Buffer.from(parts[2]!, "base64url");
+  const tag = Buffer.from(parts[3]!, "base64url");
+  if (nonce.length !== NONCE_BYTES || tag.length !== TAG_BYTES) {
+    throw new Error("Invalid Custom MCP credential envelope");
+  }
+  const decipher = createDecipheriv("aes-256-gcm", key, nonce, {
+    authTagLength: TAG_BYTES,
+  });
+  decipher.setAAD(additionalData(binding));
+  decipher.setAuthTag(tag);
+  const plaintext = Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]).toString("utf8");
+  return JSON.parse(plaintext) as T;
+}

--- a/packages/gateway/src/integrations/custom-mcp/gateway-routes.ts
+++ b/packages/gateway/src/integrations/custom-mcp/gateway-routes.ts
@@ -1,0 +1,23 @@
+import type { Hono } from "hono";
+import { createCustomMcpProjectionRoutes } from "./projection-routes.js";
+
+export interface CustomMcpGatewayRouteOptions {
+  homePath: string;
+  clerkUserId?: string;
+  projectionToken?: string;
+}
+
+export function registerCustomMcpGatewayRoutes(
+  app: Hono,
+  options: CustomMcpGatewayRouteOptions,
+): void {
+  if (!options.clerkUserId || !options.projectionToken) return;
+  app.route(
+    "/api/internal/mcp-projection",
+    createCustomMcpProjectionRoutes({
+      homePath: options.homePath,
+      token: options.projectionToken,
+      clerkUserId: options.clerkUserId,
+    }),
+  );
+}

--- a/packages/gateway/src/integrations/custom-mcp/oauth.ts
+++ b/packages/gateway/src/integrations/custom-mcp/oauth.ts
@@ -1,0 +1,402 @@
+import {
+  createHash,
+  randomBytes,
+  timingSafeEqual,
+} from "node:crypto";
+import { request as httpsRequest } from "node:https";
+import type { LookupFunction } from "node:net";
+import type { PlatformDb, CustomMcpServerBrokerRow } from "../../platform-db.js";
+import {
+  decryptCustomMcpCredential,
+  encryptCustomMcpCredential,
+} from "./crypto.js";
+import { validateCustomMcpUrl } from "./security.js";
+import { CustomMcpBrokerError, type CustomMcpCredential } from "./broker.js";
+
+const OAUTH_TIMEOUT_MS = 10_000;
+const OAUTH_RESPONSE_LIMIT = 64 * 1024;
+const STATE_TTL_MS = 10 * 60 * 1000;
+
+interface OAuthMetadata {
+  authorization_endpoint: string;
+  token_endpoint: string;
+  revocation_endpoint?: string;
+  code_challenge_methods_supported?: string[];
+  scopes_supported?: string[];
+}
+
+interface ProtectedResourceMetadata {
+  resource: string;
+  authorization_servers: string[];
+  scopes_supported?: string[];
+}
+
+interface OAuthTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in?: number;
+  refresh_token?: string;
+  scope?: string;
+}
+
+async function pinnedRequest(input: {
+  method: "GET" | "POST";
+  url: string;
+  headers?: Record<string, string>;
+  body?: string;
+}): Promise<{ status: number; body: unknown }> {
+  const target = await validateCustomMcpUrl(input.url);
+  const lookup: LookupFunction = ((_hostname, _options, callback) => {
+    callback(null, target.address, target.family);
+  }) as LookupFunction;
+  return new Promise((resolve, reject) => {
+    const request = httpsRequest(target.url, {
+      method: input.method,
+      headers: {
+        accept: "application/json",
+        ...(input.body ? { "content-length": String(Buffer.byteLength(input.body)) } : {}),
+        ...input.headers,
+      },
+      lookup,
+      servername: target.url.hostname,
+      timeout: OAUTH_TIMEOUT_MS,
+    }, (response) => {
+      const status = response.statusCode ?? 502;
+      if (status >= 300 && status < 400) {
+        response.resume();
+        reject(new Error("OAuth redirects are not allowed during discovery or token exchange"));
+        return;
+      }
+      const chunks: Buffer[] = [];
+      let size = 0;
+      response.on("data", (chunk: Buffer) => {
+        size += chunk.length;
+        if (size > OAUTH_RESPONSE_LIMIT) {
+          response.destroy(new Error("OAuth response limit exceeded"));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      response.on("error", reject);
+      response.on("end", () => {
+        const raw = Buffer.concat(chunks).toString("utf8");
+        try {
+          resolve({ status, body: raw ? JSON.parse(raw) : undefined });
+        } catch (parseError: unknown) {
+          console.warn(
+            "[custom-mcp/oauth] response parse failed:",
+            parseError instanceof Error ? parseError.message : String(parseError),
+          );
+          reject(new Error("OAuth server returned invalid JSON"));
+        }
+      });
+    });
+    request.on("timeout", () => request.destroy(new Error("OAuth request timed out")));
+    request.on("error", reject);
+    request.end(input.body);
+  });
+}
+
+function exactStateMatch(left: string | undefined, right: string): boolean {
+  if (!left) return false;
+  const a = Buffer.from(left);
+  const b = Buffer.from(right);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+function protectedResourceMetadataUrl(endpoint: string): string {
+  const url = new URL(endpoint);
+  const suffix = url.pathname === "/" ? "" : url.pathname;
+  url.pathname = `/.well-known/oauth-protected-resource${suffix}`;
+  url.search = "";
+  return url.href;
+}
+
+function authorizationMetadataUrl(server: string): string {
+  const url = new URL(server);
+  url.pathname = "/.well-known/oauth-authorization-server";
+  url.search = "";
+  url.hash = "";
+  return url.href;
+}
+
+function assertObject(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("OAuth metadata is invalid");
+  }
+  return value as Record<string, unknown>;
+}
+
+function parseProtectedMetadata(value: unknown): ProtectedResourceMetadata {
+  const object = assertObject(value);
+  if (typeof object.resource !== "string"
+    || !Array.isArray(object.authorization_servers)
+    || !object.authorization_servers.every((entry) => typeof entry === "string")
+    || object.authorization_servers.length < 1) {
+    throw new Error("OAuth protected resource metadata is invalid");
+  }
+  return object as unknown as ProtectedResourceMetadata;
+}
+
+function parseOAuthMetadata(value: unknown): OAuthMetadata {
+  const object = assertObject(value);
+  if (typeof object.authorization_endpoint !== "string" || typeof object.token_endpoint !== "string") {
+    throw new Error("OAuth authorization server metadata is invalid");
+  }
+  if (Array.isArray(object.code_challenge_methods_supported)
+    && !object.code_challenge_methods_supported.includes("S256")) {
+    throw new Error("OAuth server does not support PKCE S256");
+  }
+  return object as unknown as OAuthMetadata;
+}
+
+export class CustomMcpOAuthManager {
+  constructor(private readonly options: {
+    db: PlatformDb;
+    encryptionKey: Buffer;
+    clientId: string;
+    redirectUri: string;
+    scopes?: string[];
+    now?: () => Date;
+    request?: typeof pinnedRequest;
+    validateUrl?: typeof validateCustomMcpUrl;
+  }) {
+    const redirect = new URL(options.redirectUri);
+    if (redirect.protocol !== "https:") throw new Error("Custom MCP OAuth redirect URI must use HTTPS");
+    if (!options.clientId) throw new Error("MCP_OAUTH_CLIENT_ID is required");
+  }
+
+  async start(userId: string, serverId: string): Promise<string> {
+    const row = await this.requireOAuthRow(userId, serverId);
+    const request = this.options.request ?? pinnedRequest;
+    const validateUrl = this.options.validateUrl ?? validateCustomMcpUrl;
+    const resourceResponse = await request({
+      method: "GET",
+      url: protectedResourceMetadataUrl(row.url),
+    });
+    if (resourceResponse.status !== 200) throw new CustomMcpBrokerError("upstream");
+    const resource = parseProtectedMetadata(resourceResponse.body);
+    await validateUrl(resource.resource);
+    const configuredEndpoint = new URL(row.url);
+    const resourceEndpoint = new URL(resource.resource);
+    if (configuredEndpoint.origin !== resourceEndpoint.origin) {
+      throw new CustomMcpBrokerError("invalid", "OAuth resource audience mismatch");
+    }
+    const authorizationServer = resource.authorization_servers[0]!;
+    await validateUrl(authorizationServer);
+    const metadataResponse = await request({
+      method: "GET",
+      url: authorizationMetadataUrl(authorizationServer),
+    });
+    if (metadataResponse.status !== 200) throw new CustomMcpBrokerError("upstream");
+    const metadata = parseOAuthMetadata(metadataResponse.body);
+    await Promise.all([
+      validateUrl(metadata.authorization_endpoint),
+      validateUrl(metadata.token_endpoint),
+      ...(metadata.revocation_endpoint ? [validateUrl(metadata.revocation_endpoint)] : []),
+    ]);
+
+    const state = randomBytes(32).toString("base64url");
+    const verifier = randomBytes(64).toString("base64url");
+    const challenge = createHash("sha256").update(verifier).digest("base64url");
+    const now = this.options.now?.() ?? new Date();
+    const scopes = this.options.scopes ?? resource.scopes_supported ?? metadata.scopes_supported ?? [];
+    const existingCredential = this.decrypt(userId, row);
+    const credential: CustomMcpCredential = {
+      oauth: {
+        ...existingCredential.oauth,
+        state,
+        stateExpiresAt: new Date(now.getTime() + STATE_TTL_MS).toISOString(),
+        verifier,
+        tokenEndpoint: metadata.token_endpoint,
+        authorizationEndpoint: metadata.authorization_endpoint,
+        resource: resource.resource,
+        revocationEndpoint: metadata.revocation_endpoint,
+        clientId: this.options.clientId,
+        redirectUri: this.options.redirectUri,
+        scopes,
+      },
+    } as CustomMcpCredential;
+    await this.persistCredential(userId, row, credential, "auth_required");
+
+    const authorizationUrl = new URL(metadata.authorization_endpoint);
+    authorizationUrl.searchParams.set("response_type", "code");
+    authorizationUrl.searchParams.set("client_id", this.options.clientId);
+    authorizationUrl.searchParams.set("redirect_uri", this.options.redirectUri);
+    authorizationUrl.searchParams.set("code_challenge", challenge);
+    authorizationUrl.searchParams.set("code_challenge_method", "S256");
+    authorizationUrl.searchParams.set("state", state);
+    authorizationUrl.searchParams.set("resource", resource.resource);
+    if (scopes.length > 0) authorizationUrl.searchParams.set("scope", scopes.join(" "));
+    return authorizationUrl.href;
+  }
+
+  async complete(userId: string, state: string, code: string): Promise<{ serverId: string }> {
+    const rows = await this.options.db.listCustomMcpServers(userId);
+    let match: { row: CustomMcpServerBrokerRow; credential: CustomMcpCredential } | undefined;
+    for (const server of rows) {
+      const row = await this.options.db.getCustomMcpServerForBroker(server.id, userId);
+      if (!row?.encrypted_credentials || row.auth_mode !== "oauth") continue;
+      const credential = this.decrypt(userId, row);
+      if (exactStateMatch(credential.oauth?.state, state)) {
+        match = { row, credential };
+        break;
+      }
+    }
+    if (!match?.credential.oauth) throw new CustomMcpBrokerError("invalid");
+    const oauth = match.credential.oauth as NonNullable<CustomMcpCredential["oauth"]> & {
+      clientId: string;
+      redirectUri: string;
+      scopes?: string[];
+    };
+    const now = this.options.now?.() ?? new Date();
+    if (!oauth.stateExpiresAt || new Date(oauth.stateExpiresAt).getTime() <= now.getTime()
+      || !oauth.verifier || !oauth.tokenEndpoint || !oauth.resource) {
+      throw new CustomMcpBrokerError("invalid");
+    }
+    // Consume state before contacting the token endpoint. The optimistic
+    // revision update makes concurrent/replayed callbacks one-time; a failed
+    // exchange requires the user to restart authorization with fresh state.
+    const claimedCredential: CustomMcpCredential = {
+      oauth: { ...oauth, state: undefined, stateExpiresAt: undefined },
+    };
+    const encryptedClaim = encryptCustomMcpCredential(
+      claimedCredential,
+      this.options.encryptionKey,
+      { userId, serverId: match.row.id },
+    );
+    const claimed = await this.options.db.updateCustomMcpServer(match.row.id, userId, match.row.revision, {
+      encryptedCredentials: encryptedClaim,
+      status: "auth_required",
+    });
+    if (!claimed) throw new CustomMcpBrokerError("invalid");
+    const claimedRow = await this.options.db.getCustomMcpServerForBroker(match.row.id, userId);
+    if (!claimedRow) throw new CustomMcpBrokerError("not_found");
+    const token = await this.exchangeToken(oauth.tokenEndpoint, {
+      grant_type: "authorization_code",
+      code,
+      client_id: oauth.clientId,
+      redirect_uri: oauth.redirectUri,
+      code_verifier: oauth.verifier,
+      resource: oauth.resource,
+    });
+    const next: CustomMcpCredential = {
+      oauth: {
+        ...oauth,
+        state: undefined,
+        stateExpiresAt: undefined,
+        verifier: undefined,
+        accessToken: token.access_token,
+        refreshToken: token.refresh_token,
+        expiresAt: token.expires_in
+          ? new Date(now.getTime() + token.expires_in * 1_000).toISOString()
+          : undefined,
+      },
+    };
+    await this.persistCredential(userId, claimedRow, next, "disabled");
+    return { serverId: match.row.id };
+  }
+
+  async resolveAuthorization(userId: string, row: CustomMcpServerBrokerRow): Promise<string | undefined> {
+    if (row.auth_mode !== "oauth") return undefined;
+    let credential = this.decrypt(userId, row);
+    const oauth = credential.oauth;
+    if (!oauth?.accessToken) return undefined;
+    const now = this.options.now?.() ?? new Date();
+    const needsRefresh = oauth.expiresAt
+      ? new Date(oauth.expiresAt).getTime() <= now.getTime() + 30_000
+      : false;
+    if (!needsRefresh) return `Bearer ${oauth.accessToken}`;
+    if (!oauth.refreshToken || !oauth.tokenEndpoint || !oauth.resource) {
+      throw new CustomMcpBrokerError("action_required");
+    }
+    const extended = oauth as typeof oauth & { clientId?: string };
+    const token = await this.exchangeToken(oauth.tokenEndpoint, {
+      grant_type: "refresh_token",
+      refresh_token: oauth.refreshToken,
+      client_id: extended.clientId ?? this.options.clientId,
+      resource: oauth.resource,
+    });
+    credential = {
+      oauth: {
+        ...oauth,
+        accessToken: token.access_token,
+        refreshToken: token.refresh_token ?? oauth.refreshToken,
+        expiresAt: token.expires_in
+          ? new Date(now.getTime() + token.expires_in * 1_000).toISOString()
+          : undefined,
+      },
+    };
+    await this.persistCredential(userId, row, credential, row.status);
+    return `Bearer ${token.access_token}`;
+  }
+
+  async revoke(credential: CustomMcpCredential): Promise<void> {
+    const oauth = credential.oauth as (NonNullable<CustomMcpCredential["oauth"]> & {
+      revocationEndpoint?: string;
+      clientId?: string;
+    }) | undefined;
+    if (!oauth?.revocationEndpoint) return;
+    const token = oauth.refreshToken ?? oauth.accessToken;
+    if (!token) return;
+    const body = new URLSearchParams({
+      token,
+      client_id: oauth.clientId ?? this.options.clientId,
+    }).toString();
+    const response = await (this.options.request ?? pinnedRequest)({
+      method: "POST",
+      url: oauth.revocationEndpoint,
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body,
+    });
+    if (response.status < 200 || response.status >= 300) throw new Error("OAuth revocation failed");
+  }
+
+  private async exchangeToken(endpoint: string, fields: Record<string, string>): Promise<OAuthTokenResponse> {
+    const body = new URLSearchParams(fields).toString();
+    const response = await (this.options.request ?? pinnedRequest)({
+      method: "POST",
+      url: endpoint,
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body,
+    });
+    if (response.status < 200 || response.status >= 300) throw new CustomMcpBrokerError("upstream");
+    const object = assertObject(response.body);
+    if (typeof object.access_token !== "string" || object.token_type !== "Bearer") {
+      throw new CustomMcpBrokerError("upstream");
+    }
+    return object as unknown as OAuthTokenResponse;
+  }
+
+  private async requireOAuthRow(userId: string, serverId: string): Promise<CustomMcpServerBrokerRow> {
+    const row = await this.options.db.getCustomMcpServerForBroker(serverId, userId);
+    if (!row) throw new CustomMcpBrokerError("not_found");
+    if (row.auth_mode !== "oauth") throw new CustomMcpBrokerError("invalid");
+    return row;
+  }
+
+  private decrypt(userId: string, row: CustomMcpServerBrokerRow): CustomMcpCredential {
+    if (!row.encrypted_credentials) return {};
+    return decryptCustomMcpCredential<CustomMcpCredential>(
+      row.encrypted_credentials,
+      this.options.encryptionKey,
+      { userId, serverId: row.id },
+    );
+  }
+
+  private async persistCredential(
+    userId: string,
+    row: CustomMcpServerBrokerRow,
+    credential: CustomMcpCredential,
+    status: CustomMcpServerBrokerRow["status"],
+  ): Promise<void> {
+    const encrypted = encryptCustomMcpCredential(
+      credential,
+      this.options.encryptionKey,
+      { userId, serverId: row.id },
+    );
+    if (!await this.options.db.updateCustomMcpCredentials(row.id, userId, row.revision, encrypted, status)) {
+      throw new CustomMcpBrokerError("conflict");
+    }
+  }
+}

--- a/packages/gateway/src/integrations/custom-mcp/oauth.ts
+++ b/packages/gateway/src/integrations/custom-mcp/oauth.ts
@@ -232,10 +232,9 @@ export class CustomMcpOAuthManager {
   }
 
   async complete(userId: string, state: string, code: string): Promise<{ serverId: string }> {
-    const rows = await this.options.db.listCustomMcpServers(userId);
+    const rows = await this.options.db.listCustomMcpOAuthServersForBroker(userId);
     let match: { row: CustomMcpServerBrokerRow; credential: CustomMcpCredential } | undefined;
-    for (const server of rows) {
-      const row = await this.options.db.getCustomMcpServerForBroker(server.id, userId);
+    for (const row of rows) {
       if (!row?.encrypted_credentials || row.auth_mode !== "oauth") continue;
       const credential = this.decrypt(userId, row);
       if (exactStateMatch(credential.oauth?.state, state)) {

--- a/packages/gateway/src/integrations/custom-mcp/projection-routes.ts
+++ b/packages/gateway/src/integrations/custom-mcp/projection-routes.ts
@@ -1,0 +1,87 @@
+import { timingSafeEqual } from "node:crypto";
+import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { z } from "zod/v4";
+import { CustomMcpProjectionStore } from "./projection-store.js";
+
+const ApprovalSchema = z.enum(["always_ask", "allow"]);
+const ProjectionSchema = z.object({
+  id: z.uuid(),
+  name: z.string().trim().min(1).max(100),
+  url: z.url().max(2_048),
+  authMode: z.enum(["none", "oauth", "bearer", "api_key"]),
+  enabled: z.boolean(),
+  revision: z.number().int().min(1),
+  tools: z.array(z.object({
+    name: z.string().min(1).max(128),
+    enabled: z.boolean(),
+    approval: ApprovalSchema,
+  }).strict()).max(100),
+}).strict();
+
+function safeEqual(left: string | undefined, right: string | undefined): boolean {
+  if (!left || !right) return false;
+  const a = Buffer.from(left);
+  const b = Buffer.from(right);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export function createCustomMcpProjectionRoutes(options: {
+  homePath: string;
+  token: string;
+  clerkUserId: string;
+}): Hono {
+  const app = new Hono();
+  const store = new CustomMcpProjectionStore(options.homePath);
+
+  function authorize(context: Context): Response | null {
+    const authorization = context.req.header("authorization");
+    const token = authorization?.startsWith("Bearer ") ? authorization.slice(7) : undefined;
+    const clerkUserId = context.req.header("x-matrix-clerk-user-id");
+    if (!safeEqual(token, options.token) || !safeEqual(clerkUserId, options.clerkUserId)) {
+      return context.json({ error: "Unauthorized" }, 401);
+    }
+    return null;
+  }
+
+  app.get("/:id", async (context) => {
+    const rejected = authorize(context);
+    if (rejected) return rejected;
+    const id = z.uuid().safeParse(context.req.param("id"));
+    if (!id.success) return context.json({ error: "Not found" }, 404);
+    const file = await store.read();
+    const server = file.servers.find((entry) => entry.id === id.data);
+    return server ? context.json(server) : context.json({ error: "Not found" }, 404);
+  });
+
+  app.post("/", bodyLimit({ maxSize: 64 * 1024 }), async (context) => {
+    const rejected = authorize(context);
+    if (rejected) return rejected;
+    let body: unknown;
+    try {
+      body = await context.req.json();
+    } catch (parseError: unknown) {
+      console.warn(
+        "[custom-mcp] projection body parse failed:",
+        parseError instanceof Error ? parseError.name : typeof parseError,
+      );
+      return context.json({ error: "Invalid request body" }, 400);
+    }
+    const parsed = ProjectionSchema.safeParse(body);
+    if (!parsed.success) return context.json({ error: "Invalid request body" }, 400);
+    await store.upsert(parsed.data);
+    return context.json({ ok: true });
+  });
+
+  app.delete("/:id", bodyLimit({ maxSize: 64 * 1024 }), async (context) => {
+    const rejected = authorize(context);
+    if (rejected) return rejected;
+    const id = z.uuid().safeParse(context.req.param("id"));
+    if (!id.success) return context.json({ error: "Not found" }, 404);
+    await store.remove(id.data);
+    return context.json({ ok: true });
+  });
+
+  return app;
+}

--- a/packages/gateway/src/integrations/custom-mcp/projection-store.ts
+++ b/packages/gateway/src/integrations/custom-mcp/projection-store.ts
@@ -1,0 +1,74 @@
+import { join } from "node:path";
+import { atomicWriteJson, readJsonFile } from "../../state-ops.js";
+import type {
+  CustomMcpProjectionFile,
+  CustomMcpServerProjection,
+} from "./types.js";
+
+const EMPTY_PROJECTION: CustomMcpProjectionFile = { version: 1, servers: [] };
+const MAX_SERVERS = 20;
+
+function isMissingFile(error: unknown): boolean {
+  return error instanceof Error
+    && "code" in error
+    && (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+export class CustomMcpProjectionStore {
+  readonly path: string;
+  private mutationQueue: Promise<void> = Promise.resolve();
+
+  constructor(homePath: string) {
+    this.path = join(homePath, "system", "mcp-servers.json");
+  }
+
+  async read(): Promise<CustomMcpProjectionFile> {
+    try {
+      const value = await readJsonFile<CustomMcpProjectionFile>(this.path);
+      if (value.version !== 1 || !Array.isArray(value.servers)) {
+        throw new Error("Unsupported Custom MCP projection version");
+      }
+      return value;
+    } catch (error) {
+      if (isMissingFile(error)) return structuredClone(EMPTY_PROJECTION);
+      throw error;
+    }
+  }
+
+  async upsert(server: CustomMcpServerProjection): Promise<void> {
+    return this.mutate(async (file) => {
+      const existingIndex = file.servers.findIndex((entry) => entry.id === server.id);
+      if (existingIndex === -1 && file.servers.length >= MAX_SERVERS) {
+        throw new Error("Custom MCP server limit reached");
+      }
+      const safeServer = structuredClone(server);
+      if (existingIndex === -1) file.servers.push(safeServer);
+      else file.servers[existingIndex] = safeServer;
+      file.servers.sort((left, right) => left.id.localeCompare(right.id));
+    });
+  }
+
+  async remove(serverId: string): Promise<void> {
+    return this.mutate(async (file) => {
+      file.servers = file.servers.filter((server) => server.id !== serverId);
+    });
+  }
+
+  private async mutate(
+    operation: (file: CustomMcpProjectionFile) => Promise<void>,
+  ): Promise<void> {
+    const previous = this.mutationQueue.catch((error: unknown) => {
+      console.warn(
+        "[custom-mcp] previous projection mutation failed:",
+        error instanceof Error ? error.message : String(error),
+      );
+    });
+    const next = previous.then(async () => {
+      const file = await this.read();
+      await operation(file);
+      await atomicWriteJson(this.path, file);
+    });
+    this.mutationQueue = next;
+    return next;
+  }
+}

--- a/packages/gateway/src/integrations/custom-mcp/routes.ts
+++ b/packages/gateway/src/integrations/custom-mcp/routes.ts
@@ -1,0 +1,280 @@
+import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { z } from "zod/v4";
+import { CustomMcpBroker, CustomMcpBrokerError } from "./broker.js";
+
+const MUTATION_BODY_LIMIT = 64 * 1024;
+const UUID = z.uuid();
+const ToolSelectionSchema = z.object({
+  name: z.string().min(1).max(128),
+  enabled: z.boolean(),
+  approval: z.enum(["always_ask", "allow"]),
+}).strict();
+const CreateSchema = z.object({
+  name: z.string().trim().min(1).max(100),
+  url: z.url().max(2_048),
+  authMode: z.enum(["none", "oauth", "bearer", "api_key"]),
+  credential: z.string().min(1).max(8_192).optional(),
+}).strict().superRefine((value, context) => {
+  const needsCredential = value.authMode === "bearer" || value.authMode === "api_key";
+  if (needsCredential !== Boolean(value.credential)) {
+    context.addIssue({
+      code: "custom",
+      path: ["credential"],
+      message: needsCredential ? "Credential is required" : "Credential is not accepted for this auth mode",
+    });
+  }
+});
+const PatchSchema = z.object({
+  revision: z.number().int().min(1),
+  name: z.string().trim().min(1).max(100).optional(),
+  enabled: z.boolean().optional(),
+  tools: z.array(ToolSelectionSchema).max(100).optional(),
+}).strict();
+const OAuthCallbackSchema = z.object({
+  state: z.string().min(32).max(512),
+  code: z.string().min(1).max(4_096),
+}).strict();
+const ToolCallSchema = z.object({
+  tool: z.string().min(1).max(128),
+  arguments: z.record(z.string(), z.unknown()).optional(),
+  approvalGranted: z.boolean(),
+}).strict();
+
+export interface CustomMcpOAuthFlow {
+  start(userId: string, serverId: string): Promise<string>;
+  complete(userId: string, state: string, code: string): Promise<{ serverId: string }>;
+}
+
+export interface CustomMcpRoutesOptions {
+  broker: CustomMcpBroker;
+  resolveUserId: (context: Context) => Promise<string | null>;
+  oauth?: CustomMcpOAuthFlow;
+  allowToolCalls?: boolean;
+  now?: () => number;
+}
+
+interface RateState { count: number; resetAt: number }
+
+export function createCustomMcpRoutes(options: CustomMcpRoutesOptions): Hono {
+  const app = new Hono();
+  const rateStates = new Map<string, RateState>();
+  const now = options.now ?? Date.now;
+
+  function checkRateLimit(userId: string): boolean {
+    const current = now();
+    const existing = rateStates.get(userId);
+    if (!existing || current >= existing.resetAt) {
+      if (!existing && rateStates.size >= 10_000) {
+        const oldest = rateStates.keys().next().value as string | undefined;
+        if (oldest) rateStates.delete(oldest);
+      }
+      rateStates.set(userId, { count: 1, resetAt: current + 60_000 });
+      return true;
+    }
+    if (existing.count >= 60) return false;
+    existing.count += 1;
+    rateStates.delete(userId);
+    rateStates.set(userId, existing);
+    return true;
+  }
+
+  async function requireUser(context: Context, mutation = false): Promise<string | Response> {
+    const userId = await options.resolveUserId(context);
+    if (!userId) return context.json({ error: "Unauthorized" }, 401);
+    if (mutation && !checkRateLimit(userId)) {
+      return context.json({ error: "Too many requests" }, 429);
+    }
+    return userId;
+  }
+
+  function brokerError(context: Context, error: unknown): Response {
+    if (error instanceof CustomMcpBrokerError) {
+      if (error.code === "not_found" || error.code === "forbidden") {
+        return context.json({ error: "Custom MCP server not found" }, 404);
+      }
+      if (error.code === "conflict") {
+        return context.json({ error: "Revision conflict" }, 409);
+      }
+      if (error.code === "invalid") {
+        return context.json({ error: "Invalid Custom MCP request" }, 400);
+      }
+      if (error.code === "action_required") {
+        return context.json({ error: "Action required" }, 409);
+      }
+    }
+    console.error("[custom-mcp] route failed:", error instanceof Error ? error.message : String(error));
+    return context.json({ error: "Custom MCP request failed" }, 502);
+  }
+
+  app.get("/", async (context) => {
+    const userId = await requireUser(context);
+    if (typeof userId !== "string") return userId;
+    try {
+      return context.json(await options.broker.list(userId));
+    } catch (error) {
+      return brokerError(context, error);
+    }
+  });
+
+  app.get("/oauth/callback", async (context) => {
+    const userId = await requireUser(context);
+    if (typeof userId !== "string") return userId;
+    const parsed = OAuthCallbackSchema.safeParse({
+      state: context.req.query("state"),
+      code: context.req.query("code"),
+    });
+    if (!parsed.success) return context.json({ error: "Invalid OAuth callback" }, 400);
+    if (!options.oauth) return context.json({ error: "Custom MCP OAuth unavailable" }, 503);
+    try {
+      const result = await options.oauth.complete(userId, parsed.data.state, parsed.data.code);
+      return context.json({ ok: true, serverId: result.serverId });
+    } catch (error) {
+      return brokerError(context, error);
+    }
+  });
+
+  app.get("/:id", async (context) => {
+    const userId = await requireUser(context);
+    if (typeof userId !== "string") return userId;
+    const parsedId = UUID.safeParse(context.req.param("id"));
+    if (!parsedId.success) return context.json({ error: "Custom MCP server not found" }, 404);
+    try {
+      return context.json(await options.broker.describe(userId, parsedId.data));
+    } catch (error) {
+      return brokerError(context, error);
+    }
+  });
+
+  app.post("/", bodyLimit({ maxSize: MUTATION_BODY_LIMIT }), async (context) => {
+    const userId = await requireUser(context, true);
+    if (typeof userId !== "string") return userId;
+    let body: unknown;
+    try {
+      body = await context.req.json();
+    } catch (parseError: unknown) {
+      console.warn(
+        "[custom-mcp] create body parse failed:",
+        parseError instanceof Error ? parseError.name : typeof parseError,
+      );
+      return context.json({ error: "Invalid request body" }, 400);
+    }
+    const parsed = CreateSchema.safeParse(body);
+    if (!parsed.success) return context.json({ error: "Invalid request body" }, 400);
+    try {
+      return context.json(await options.broker.create(userId, parsed.data), 201);
+    } catch (error) {
+      return brokerError(context, error);
+    }
+  });
+
+  app.patch("/:id", bodyLimit({ maxSize: MUTATION_BODY_LIMIT }), async (context) => {
+    const userId = await requireUser(context, true);
+    if (typeof userId !== "string") return userId;
+    const parsedId = UUID.safeParse(context.req.param("id"));
+    if (!parsedId.success) return context.json({ error: "Custom MCP server not found" }, 404);
+    let body: unknown;
+    try {
+      body = await context.req.json();
+    } catch (parseError: unknown) {
+      console.warn(
+        "[custom-mcp] patch body parse failed:",
+        parseError instanceof Error ? parseError.name : typeof parseError,
+      );
+      return context.json({ error: "Invalid request body" }, 400);
+    }
+    const parsed = PatchSchema.safeParse(body);
+    if (!parsed.success) return context.json({ error: "Invalid request body" }, 400);
+    try {
+      return context.json(await options.broker.patch(userId, parsedId.data, parsed.data));
+    } catch (error) {
+      return brokerError(context, error);
+    }
+  });
+
+  app.delete("/:id", bodyLimit({ maxSize: MUTATION_BODY_LIMIT }), async (context) => {
+    const userId = await requireUser(context, true);
+    if (typeof userId !== "string") return userId;
+    const parsedId = UUID.safeParse(context.req.param("id"));
+    if (!parsedId.success) return context.json({ error: "Custom MCP server not found" }, 404);
+    try {
+      await options.broker.remove(userId, parsedId.data);
+      return context.json({ ok: true });
+    } catch (error) {
+      return brokerError(context, error);
+    }
+  });
+
+  app.post("/:id/connect", bodyLimit({ maxSize: MUTATION_BODY_LIMIT }), async (context) => {
+    const userId = await requireUser(context, true);
+    if (typeof userId !== "string") return userId;
+    const parsedId = UUID.safeParse(context.req.param("id"));
+    if (!parsedId.success) return context.json({ error: "Custom MCP server not found" }, 404);
+    if (!options.oauth) return context.json({ error: "Custom MCP OAuth unavailable" }, 503);
+    try {
+      return context.json({ url: await options.oauth.start(userId, parsedId.data) });
+    } catch (error) {
+      return brokerError(context, error);
+    }
+  });
+
+  async function discover(context: Context): Promise<Response> {
+    const userId = await requireUser(context, true);
+    if (typeof userId !== "string") return userId;
+    const parsedId = UUID.safeParse(context.req.param("id"));
+    if (!parsedId.success) return context.json({ error: "Custom MCP server not found" }, 404);
+    try {
+      return context.json(await options.broker.discover(userId, parsedId.data));
+    } catch (error) {
+      return brokerError(context, error);
+    }
+  }
+
+  app.post("/:id/sync", bodyLimit({ maxSize: MUTATION_BODY_LIMIT }), discover);
+  app.post("/:id/discover", bodyLimit({ maxSize: MUTATION_BODY_LIMIT }), discover);
+  app.post("/:id/test", bodyLimit({ maxSize: MUTATION_BODY_LIMIT }), async (context) => {
+    const userId = await requireUser(context, true);
+    if (typeof userId !== "string") return userId;
+    const parsedId = UUID.safeParse(context.req.param("id"));
+    if (!parsedId.success) return context.json({ error: "Custom MCP server not found" }, 404);
+    try {
+      return context.json(await options.broker.test(userId, parsedId.data));
+    } catch (error) {
+      return brokerError(context, error);
+    }
+  });
+
+  if (options.allowToolCalls) {
+    app.post("/:id/call", bodyLimit({ maxSize: MUTATION_BODY_LIMIT }), async (context) => {
+      const userId = await requireUser(context, true);
+      if (typeof userId !== "string") return userId;
+      const parsedId = UUID.safeParse(context.req.param("id"));
+      if (!parsedId.success) return context.json({ error: "Custom MCP server not found" }, 404);
+      let body: unknown;
+      try {
+        body = await context.req.json();
+      } catch (parseError: unknown) {
+        console.warn(
+          "[custom-mcp] tool-call body parse failed:",
+          parseError instanceof Error ? parseError.name : typeof parseError,
+        );
+        return context.json({ error: "Invalid request body" }, 400);
+      }
+      const parsed = ToolCallSchema.safeParse(body);
+      if (!parsed.success) return context.json({ error: "Invalid request body" }, 400);
+      try {
+        return context.json(await options.broker.callSelectedTool({
+          userId,
+          serverId: parsedId.data,
+          toolName: parsed.data.tool,
+          arguments: parsed.data.arguments,
+          approvalGranted: parsed.data.approvalGranted,
+        }));
+      } catch (error) {
+        return brokerError(context, error);
+      }
+    });
+  }
+
+  return app;
+}

--- a/packages/gateway/src/integrations/custom-mcp/security.ts
+++ b/packages/gateway/src/integrations/custom-mcp/security.ts
@@ -1,0 +1,146 @@
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+export interface ResolvedCustomMcpUrl {
+  url: URL;
+  address: string;
+  family: 4 | 6;
+}
+
+export type CustomMcpResolver = (
+  hostname: string,
+) => Promise<Array<{ address: string; family: 4 | 6 }>>;
+
+export class CustomMcpUrlError extends Error {
+  constructor() {
+    super("Custom MCP server URL is not allowed");
+    this.name = "CustomMcpUrlError";
+  }
+}
+
+function ipv4Number(address: string): number | null {
+  if (isIP(address) !== 4) return null;
+  return address.split(".").reduce((result, octet) =>
+    ((result << 8) | Number(octet)) >>> 0, 0);
+}
+
+function inIpv4Range(address: string, network: string, prefix: number): boolean {
+  const ip = ipv4Number(address);
+  const base = ipv4Number(network);
+  if (ip === null || base === null) return false;
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  return (ip & mask) === (base & mask);
+}
+
+const BLOCKED_IPV4: ReadonlyArray<readonly [string, number]> = [
+  ["0.0.0.0", 8],
+  ["10.0.0.0", 8],
+  ["100.64.0.0", 10],
+  ["127.0.0.0", 8],
+  ["169.254.0.0", 16],
+  ["172.16.0.0", 12],
+  ["192.0.0.0", 24],
+  ["192.0.2.0", 24],
+  ["192.88.99.0", 24],
+  ["192.168.0.0", 16],
+  ["198.18.0.0", 15],
+  ["198.51.100.0", 24],
+  ["203.0.113.0", 24],
+  ["224.0.0.0", 4],
+  ["240.0.0.0", 4],
+];
+
+export function isForbiddenCustomMcpAddress(address: string): boolean {
+  const family = isIP(address);
+  if (family === 4) {
+    return BLOCKED_IPV4.some(([network, prefix]) =>
+      inIpv4Range(address, network, prefix));
+  }
+  if (family !== 6) return true;
+  const normalized = address.toLowerCase().replace(/^\[|\]$/g, "");
+  if (normalized === "::" || normalized === "::1") return true;
+  if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true;
+  if (/^fe[89ab]/.test(normalized)) return true;
+  if (normalized.startsWith("ff")) return true;
+  if (normalized.startsWith("2001:db8:")) return true;
+  if (normalized.startsWith("2001:2:")) return true;
+  if (normalized.startsWith("2001:10:")) return true;
+  if (normalized.startsWith("::ffff:")) {
+    const mapped = normalized.slice("::ffff:".length);
+    return mapped.includes(".") ? isForbiddenCustomMcpAddress(mapped) : true;
+  }
+  return false;
+}
+
+function forbiddenHostname(hostname: string): boolean {
+  const value = hostname.toLowerCase().replace(/\.$/, "");
+  return value === "localhost"
+    || value === "metadata"
+    || value === "metadata.google.internal"
+    || value.endsWith(".localhost")
+    || value.endsWith(".local")
+    || value.endsWith(".internal")
+    || value.endsWith(".test")
+    || value.endsWith(".invalid")
+    || value === "example.com"
+    || value.endsWith(".example.com")
+    || value === "example.net"
+    || value.endsWith(".example.net")
+    || value === "example.org"
+    || value.endsWith(".example.org");
+}
+
+const defaultResolver: CustomMcpResolver = async (hostname) => {
+  const records = await lookup(hostname, { all: true, verbatim: true });
+  return records
+    .filter((record): record is { address: string; family: 4 | 6 } =>
+      record.family === 4 || record.family === 6);
+};
+
+export async function validateCustomMcpUrl(
+  rawUrl: string,
+  resolver: CustomMcpResolver = defaultResolver,
+): Promise<ResolvedCustomMcpUrl> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch (parseError: unknown) {
+    console.warn(
+      "[custom-mcp] URL parse failed:",
+      parseError instanceof Error ? parseError.name : typeof parseError,
+    );
+    throw new CustomMcpUrlError();
+  }
+  if (url.protocol !== "https:" || url.username || url.password || url.hash) {
+    throw new CustomMcpUrlError();
+  }
+  if (forbiddenHostname(url.hostname)) throw new CustomMcpUrlError();
+
+  const normalizedHostname = url.hostname.replace(/^\[|\]$/g, "");
+  const literalFamily = isIP(normalizedHostname);
+  if (literalFamily !== 0) {
+    if (isForbiddenCustomMcpAddress(normalizedHostname)) throw new CustomMcpUrlError();
+    return {
+      url,
+      address: normalizedHostname,
+      family: literalFamily as 4 | 6,
+    };
+  }
+
+  let records: Array<{ address: string; family: 4 | 6 }>;
+  try {
+    records = await resolver(normalizedHostname);
+  } catch (resolutionError: unknown) {
+    console.warn(
+      "[custom-mcp] DNS resolution failed:",
+      resolutionError instanceof Error ? resolutionError.message : String(resolutionError),
+    );
+    throw new CustomMcpUrlError();
+  }
+  if (records.length === 0 || records.some((record) =>
+    isForbiddenCustomMcpAddress(record.address))) {
+    throw new CustomMcpUrlError();
+  }
+  const selected = records[0]!;
+  return { url, address: selected.address, family: selected.family };
+}

--- a/packages/gateway/src/integrations/custom-mcp/types.ts
+++ b/packages/gateway/src/integrations/custom-mcp/types.ts
@@ -1,0 +1,49 @@
+export type CustomMcpAuthMode = "none" | "oauth" | "bearer" | "api_key";
+export type CustomMcpStatus =
+  | "pending"
+  | "auth_required"
+  | "ready"
+  | "degraded"
+  | "disabled"
+  | "action_required";
+export type CustomMcpApproval = "always_ask" | "allow";
+
+export interface CustomMcpTool {
+  name: string;
+  description: string;
+  inputSchema: unknown;
+  approval: CustomMcpApproval;
+  enabled: boolean;
+}
+
+export interface CustomMcpServer {
+  id: string;
+  name: string;
+  url: string;
+  authMode: CustomMcpAuthMode;
+  status: CustomMcpStatus;
+  enabled: boolean;
+  revision: number;
+  tools: CustomMcpTool[];
+}
+
+export interface CustomMcpProjectionTool {
+  name: string;
+  approval: CustomMcpApproval;
+  enabled: boolean;
+}
+
+export interface CustomMcpServerProjection {
+  id: string;
+  name: string;
+  url: string;
+  authMode: CustomMcpAuthMode;
+  enabled: boolean;
+  revision: number;
+  tools: CustomMcpProjectionTool[];
+}
+
+export interface CustomMcpProjectionFile {
+  version: 1;
+  servers: CustomMcpServerProjection[];
+}

--- a/packages/gateway/src/integrations/pipedream.ts
+++ b/packages/gateway/src/integrations/pipedream.ts
@@ -46,6 +46,7 @@ export interface PipedreamConnectClient {
     accountId: string;
     url: string;
     params?: Record<string, string>;
+    headers?: Record<string, string>;
   }): Promise<unknown>;
 
   proxyPost(opts: {
@@ -53,6 +54,7 @@ export interface PipedreamConnectClient {
     accountId: string;
     url: string;
     body?: Record<string, unknown>;
+    headers?: Record<string, string>;
   }): Promise<unknown>;
 
   proxyPut(opts: {
@@ -60,6 +62,7 @@ export interface PipedreamConnectClient {
     accountId: string;
     url: string;
     body?: Record<string, unknown>;
+    headers?: Record<string, string>;
   }): Promise<unknown>;
 
   proxyPatch(opts: {
@@ -67,6 +70,7 @@ export interface PipedreamConnectClient {
     accountId: string;
     url: string;
     body?: Record<string, unknown>;
+    headers?: Record<string, string>;
   }): Promise<unknown>;
 
   proxyDelete(opts: {
@@ -74,6 +78,7 @@ export interface PipedreamConnectClient {
     accountId: string;
     url: string;
     params?: Record<string, string>;
+    headers?: Record<string, string>;
   }): Promise<unknown>;
 
   revokeAccount(accountId: string): Promise<void>;
@@ -211,6 +216,7 @@ export async function createPipedreamClient(
           externalUserId: opts.externalUserId,
           accountId: opts.accountId,
           params: opts.params,
+          headers: opts.headers,
         },
         { timeoutInSeconds: API_TIMEOUT_SECONDS },
       );
@@ -224,6 +230,7 @@ export async function createPipedreamClient(
           externalUserId: opts.externalUserId,
           accountId: opts.accountId,
           body: opts.body ?? {},
+          headers: opts.headers,
         },
         { timeoutInSeconds: API_TIMEOUT_SECONDS },
       );
@@ -237,6 +244,7 @@ export async function createPipedreamClient(
           externalUserId: opts.externalUserId,
           accountId: opts.accountId,
           body: opts.body ?? {},
+          headers: opts.headers,
         },
         { timeoutInSeconds: API_TIMEOUT_SECONDS },
       );
@@ -250,6 +258,7 @@ export async function createPipedreamClient(
           externalUserId: opts.externalUserId,
           accountId: opts.accountId,
           body: opts.body ?? {},
+          headers: opts.headers,
         },
         { timeoutInSeconds: API_TIMEOUT_SECONDS },
       );
@@ -268,6 +277,7 @@ export async function createPipedreamClient(
           externalUserId: opts.externalUserId,
           accountId: opts.accountId,
           params: opts.params,
+          headers: opts.headers,
         },
         { timeoutInSeconds: API_TIMEOUT_SECONDS },
       );

--- a/packages/gateway/src/integrations/registry-expansion.ts
+++ b/packages/gateway/src/integrations/registry-expansion.ts
@@ -1,0 +1,263 @@
+import type { IntegrationActionRisk, ServiceAction, ServiceDefinition } from "./types.js";
+
+const LOGO_BASE = "https://pipedream.com/s.v0";
+const NOTION_HEADERS = Object.freeze({ "Notion-Version": "2022-06-28" });
+
+function cappedPositiveInt(value: unknown, fallback: number, max: number): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.min(Math.floor(parsed), max);
+}
+
+type ExpansionAction = Omit<ServiceAction, "risk"> & { risk: IntegrationActionRisk };
+type ExpansionService = Omit<ServiceDefinition, "actions" | "connectorKind"> & {
+  connectorKind?: ServiceDefinition["connectorKind"];
+  actions: Record<string, ExpansionAction>;
+};
+
+export const EXPANSION_SERVICE_REGISTRY: Record<string, ExpansionService> = {
+  google_docs: {
+    id: "google_docs",
+    name: "Google Docs",
+    category: "google",
+    pipedreamApp: "google_docs",
+    icon: "file-text",
+    logoUrl: `${LOGO_BASE}/google_docs/logo/48`,
+    actions: {
+      get_document: {
+        description: "Get a Google document by ID",
+        risk: "read",
+        params: { documentId: { type: "string", required: true } },
+        directApi: {
+          method: "GET",
+          url: (p) => `https://docs.googleapis.com/v1/documents/${encodeURIComponent(String(p.documentId))}`,
+        },
+      },
+      create_document: {
+        description: "Create a Google document",
+        risk: "write",
+        params: { title: { type: "string", required: true } },
+        directApi: {
+          method: "POST",
+          url: "https://docs.googleapis.com/v1/documents",
+          mapBody: (p) => ({ title: String(p.title) }),
+        },
+      },
+      batch_update_document: {
+        description: "Apply a batch of updates to a Google document",
+        risk: "write",
+        params: {
+          documentId: { type: "string", required: true },
+          requests: { type: "array", required: true },
+        },
+        directApi: {
+          method: "POST",
+          url: (p) => `https://docs.googleapis.com/v1/documents/${encodeURIComponent(String(p.documentId))}:batchUpdate`,
+          mapBody: (p) => ({ requests: p.requests }),
+        },
+      },
+    },
+  },
+
+  notion: {
+    id: "notion",
+    name: "Notion",
+    category: "productivity",
+    pipedreamApp: "notion",
+    icon: "notebook",
+    logoUrl: `${LOGO_BASE}/notion/logo/48`,
+    actions: {
+      search: {
+        description: "Search pages and databases",
+        risk: "read",
+        params: { query: { type: "string" }, filter: { type: "object" }, pageSize: { type: "number" } },
+        directApi: {
+          method: "POST",
+          url: "https://api.notion.com/v1/search",
+          staticHeaders: NOTION_HEADERS,
+          mapBody: (p) => ({
+            ...(p.query ? { query: String(p.query) } : {}),
+            ...(p.filter && typeof p.filter === "object" ? { filter: p.filter } : {}),
+            ...(p.pageSize ? { page_size: cappedPositiveInt(p.pageSize, 20, 100) } : {}),
+          }),
+        },
+      },
+      get_page: {
+        description: "Get a Notion page",
+        risk: "read",
+        params: { pageId: { type: "string", required: true } },
+        directApi: {
+          method: "GET",
+          url: (p) => `https://api.notion.com/v1/pages/${encodeURIComponent(String(p.pageId))}`,
+          staticHeaders: NOTION_HEADERS,
+        },
+      },
+      query_database: {
+        description: "Query a Notion database",
+        risk: "read",
+        params: { databaseId: { type: "string", required: true }, filter: { type: "object" }, sorts: { type: "array" } },
+        directApi: {
+          method: "POST",
+          url: (p) => `https://api.notion.com/v1/databases/${encodeURIComponent(String(p.databaseId))}/query`,
+          staticHeaders: NOTION_HEADERS,
+          mapBody: (p) => ({
+            ...(p.filter && typeof p.filter === "object" ? { filter: p.filter } : {}),
+            ...(Array.isArray(p.sorts) ? { sorts: p.sorts } : {}),
+          }),
+        },
+      },
+      create_page: {
+        description: "Create a Notion page",
+        risk: "write",
+        params: {
+          parent: { type: "object", required: true },
+          properties: { type: "object", required: true },
+          children: { type: "array" },
+        },
+        directApi: {
+          method: "POST",
+          url: "https://api.notion.com/v1/pages",
+          staticHeaders: NOTION_HEADERS,
+          mapBody: (p) => ({ parent: p.parent, properties: p.properties, ...(p.children ? { children: p.children } : {}) }),
+        },
+      },
+      update_page: {
+        description: "Update a Notion page",
+        risk: "write",
+        params: { pageId: { type: "string", required: true }, properties: { type: "object", required: true } },
+        directApi: {
+          method: "PATCH",
+          url: (p) => `https://api.notion.com/v1/pages/${encodeURIComponent(String(p.pageId))}`,
+          staticHeaders: NOTION_HEADERS,
+          mapBody: (p) => ({ properties: p.properties }),
+        },
+      },
+      append_blocks: {
+        description: "Append content blocks to a Notion page or block",
+        risk: "write",
+        params: { blockId: { type: "string", required: true }, children: { type: "array", required: true } },
+        directApi: {
+          method: "PATCH",
+          url: (p) => `https://api.notion.com/v1/blocks/${encodeURIComponent(String(p.blockId))}/children`,
+          staticHeaders: NOTION_HEADERS,
+          mapBody: (p) => ({ children: p.children }),
+        },
+      },
+    },
+  },
+
+  figma: {
+    id: "figma",
+    name: "Figma",
+    category: "design",
+    pipedreamApp: "figma",
+    icon: "figma",
+    logoUrl: `${LOGO_BASE}/figma/logo/48`,
+    actions: {
+      get_file: {
+        description: "Get a Figma file",
+        risk: "read",
+        params: { fileKey: { type: "string", required: true }, depth: { type: "number" } },
+        directApi: {
+          method: "GET",
+          url: (p) => `https://api.figma.com/v1/files/${encodeURIComponent(String(p.fileKey))}`,
+          mapParams: (p): Record<string, string> => p.depth
+            ? { depth: String(cappedPositiveInt(p.depth, 1, 10)) }
+            : {},
+        },
+      },
+      get_nodes: {
+        description: "Get selected nodes from a Figma file",
+        risk: "read",
+        params: { fileKey: { type: "string", required: true }, ids: { type: "array", required: true } },
+        directApi: {
+          method: "GET",
+          url: (p) => `https://api.figma.com/v1/files/${encodeURIComponent(String(p.fileKey))}/nodes`,
+          mapParams: (p) => ({ ids: (p.ids as unknown[]).map(String).join(",") }),
+        },
+      },
+      list_comments: {
+        description: "List comments on a Figma file",
+        risk: "read",
+        params: { fileKey: { type: "string", required: true } },
+        directApi: {
+          method: "GET",
+          url: (p) => `https://api.figma.com/v1/files/${encodeURIComponent(String(p.fileKey))}/comments`,
+        },
+      },
+      post_comment: {
+        description: "Post a comment on a Figma file",
+        risk: "write",
+        params: { fileKey: { type: "string", required: true }, message: { type: "string", required: true }, clientMeta: { type: "object" } },
+        directApi: {
+          method: "POST",
+          url: (p) => `https://api.figma.com/v1/files/${encodeURIComponent(String(p.fileKey))}/comments`,
+          mapBody: (p) => ({ message: String(p.message), ...(p.clientMeta ? { client_meta: p.clientMeta } : {}) }),
+        },
+      },
+    },
+  },
+
+  posthog: {
+    id: "posthog",
+    name: "PostHog",
+    category: "analytics",
+    pipedreamApp: "posthog",
+    icon: "chart",
+    logoUrl: `${LOGO_BASE}/posthog/logo/48`,
+    actions: {
+      list_projects: { description: "List PostHog projects", risk: "read", params: {} },
+      list_insights: { description: "List insights in a PostHog project", risk: "read", params: { projectId: { type: "number", required: true }, limit: { type: "number" } } },
+      get_insight: { description: "Get a PostHog insight", risk: "read", params: { projectId: { type: "number", required: true }, insightId: { type: "number", required: true } } },
+      query: { description: "Run a read-only PostHog query", risk: "read", params: { projectId: { type: "number", required: true }, query: { type: "object", required: true } } },
+    },
+  },
+
+  jira: {
+    id: "jira",
+    name: "Jira",
+    category: "developer",
+    pipedreamApp: "jira",
+    icon: "check-list",
+    logoUrl: `${LOGO_BASE}/jira/logo/48`,
+    actions: {
+      list_projects: { description: "List Jira projects", risk: "read", params: { maxResults: { type: "number" } } },
+      search_issues: { description: "Search Jira issues with JQL", risk: "read", params: { jql: { type: "string", required: true }, maxResults: { type: "number" } } },
+      get_issue: { description: "Get a Jira issue", risk: "read", params: { issueKey: { type: "string", required: true } } },
+      create_issue: { description: "Create a Jira issue", risk: "write", params: { projectKey: { type: "string", required: true }, issueType: { type: "string", required: true }, summary: { type: "string", required: true }, description: { type: "object" } } },
+      update_issue: { description: "Update a Jira issue", risk: "write", params: { issueKey: { type: "string", required: true }, fields: { type: "object", required: true } } },
+      add_comment: { description: "Add a comment to a Jira issue", risk: "write", params: { issueKey: { type: "string", required: true }, body: { type: "object", required: true } } },
+    },
+  },
+
+  stripe: {
+    id: "stripe",
+    name: "Stripe",
+    category: "finance",
+    pipedreamApp: "stripe",
+    icon: "credit-card",
+    logoUrl: `${LOGO_BASE}/stripe/logo/48`,
+    actions: {
+      list_customers: { description: "List Stripe customers using a restricted read-only key", risk: "read", params: { limit: { type: "number" } }, directApi: { method: "GET", url: "https://api.stripe.com/v1/customers", mapParams: (p) => ({ limit: String(cappedPositiveInt(p.limit, 10, 100)) }) } },
+      get_customer: { description: "Get a Stripe customer", risk: "read", params: { customerId: { type: "string", required: true } }, directApi: { method: "GET", url: (p) => `https://api.stripe.com/v1/customers/${encodeURIComponent(String(p.customerId))}` } },
+      list_subscriptions: { description: "List Stripe subscriptions", risk: "read", params: { customerId: { type: "string" }, limit: { type: "number" } }, directApi: { method: "GET", url: "https://api.stripe.com/v1/subscriptions", mapParams: (p) => ({ ...(p.customerId ? { customer: String(p.customerId) } : {}), limit: String(cappedPositiveInt(p.limit, 10, 100)) }) } },
+      list_invoices: { description: "List Stripe invoices", risk: "read", params: { customerId: { type: "string" }, limit: { type: "number" } }, directApi: { method: "GET", url: "https://api.stripe.com/v1/invoices", mapParams: (p) => ({ ...(p.customerId ? { customer: String(p.customerId) } : {}), limit: String(cappedPositiveInt(p.limit, 10, 100)) }) } },
+      list_payment_intents: { description: "List Stripe payment intents", risk: "read", params: { customerId: { type: "string" }, limit: { type: "number" } }, directApi: { method: "GET", url: "https://api.stripe.com/v1/payment_intents", mapParams: (p) => ({ ...(p.customerId ? { customer: String(p.customerId) } : {}), limit: String(cappedPositiveInt(p.limit, 10, 100)) }) } },
+      get_balance: { description: "Get the Stripe account balance", risk: "read", params: {}, directApi: { method: "GET", url: "https://api.stripe.com/v1/balance" } },
+    },
+  },
+
+  granola: {
+    id: "granola",
+    name: "Granola",
+    category: "productivity",
+    connectorKind: "mcp_preset",
+    mcpPreset: { url: "https://mcp.granola.ai/mcp", authMode: "oauth" },
+    icon: "note",
+    logoUrl: "",
+    actions: {
+      list_notes: { description: "List Granola meeting notes", risk: "read", params: { query: { type: "string" }, limit: { type: "number" } } },
+      get_note: { description: "Get a Granola note, optionally including its transcript", risk: "read", params: { noteId: { type: "string", required: true }, includeTranscript: { type: "boolean" } } },
+    },
+  },
+};

--- a/packages/gateway/src/integrations/registry.ts
+++ b/packages/gateway/src/integrations/registry.ts
@@ -1,4 +1,9 @@
-import type { ServiceAction, ServiceDefinition } from "./types.js";
+import type {
+  IntegrationActionRisk,
+  ServiceAction,
+  ServiceDefinition,
+} from "./types.js";
+import { EXPANSION_SERVICE_REGISTRY } from "./registry-expansion.js";
 import type { PipedreamConnectClient } from "./pipedream.js";
 
 const LOGO_BASE = "https://pipedream.com/s.v0";
@@ -83,7 +88,46 @@ function linearGraphqlBody(query: string, variables?: Record<string, unknown>): 
   return variables ? { query, variables } : { query };
 }
 
-export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = {
+type RegistryActionInput = Omit<ServiceAction, "risk"> & { risk?: IntegrationActionRisk };
+type RegistryServiceInput = Omit<ServiceDefinition, "actions" | "connectorKind"> & {
+  connectorKind?: ServiceDefinition["connectorKind"];
+  actions: Record<string, RegistryActionInput>;
+};
+
+const WRITE_ACTIONS = new Set([
+  "gmail.send_email",
+  "google_calendar.create_event",
+  "google_calendar.update_event",
+  "google_drive.upload_file",
+  "google_drive.share_file",
+  "github.create_issue",
+  "linear.create_issue",
+  "linear.update_issue",
+  "linear.comment_issue",
+  "linear.create_workflow_state",
+  "slack.send_message",
+  "slack.react",
+  "discord.send_message",
+]);
+function defineServiceRegistry(
+  input: Record<string, RegistryServiceInput>,
+): Record<string, ServiceDefinition> {
+  return Object.fromEntries(Object.entries(input).map(([serviceId, service]) => [
+    serviceId,
+    {
+      ...service,
+      connectorKind: service.connectorKind ?? "pipedream",
+      actions: Object.fromEntries(Object.entries(service.actions).map(([actionId, action]) => {
+        const key = `${serviceId}.${actionId}`;
+        const risk = action.risk
+          ?? (WRITE_ACTIONS.has(key) ? "write" : "read");
+        return [actionId, { ...action, risk }];
+      })),
+    },
+  ])) as Record<string, ServiceDefinition>;
+}
+
+export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineServiceRegistry({
   gmail: {
     id: "gmail",
     name: "Gmail",
@@ -254,18 +298,6 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = {
             ...(p.start !== undefined ? { start: { dateTime: String(p.start) } } : {}),
             ...(p.end !== undefined ? { end: { dateTime: String(p.end) } } : {}),
           }),
-        },
-      },
-      // GCal API: events.delete. Returns 204 No Content on success.
-      delete_event: {
-        description: "Delete a calendar event",
-        params: {
-          eventId: { type: "string", required: true },
-        },
-        directApi: {
-          method: "DELETE",
-          url: (p) =>
-            `https://www.googleapis.com/calendar/v3/calendars/primary/events/${encodeURIComponent(String(p.eventId))}`,
         },
       },
     },
@@ -761,21 +793,6 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = {
           }),
         },
       },
-      graphql: {
-        description: "Run a custom Linear GraphQL operation for advanced workflows",
-        params: {
-          query: { type: "string", required: true },
-          variables: { type: "object" },
-        },
-        directApi: {
-          method: "POST",
-          url: "https://api.linear.app/graphql",
-          mapBody: (p) => ({
-            query: String(p.query),
-            ...(p.variables && typeof p.variables === "object" ? { variables: p.variables } : {}),
-          }),
-        },
-      },
     },
   },
 
@@ -956,7 +973,9 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = {
       },
     },
   },
-};
+
+  ...EXPANSION_SERVICE_REGISTRY,
+});
 
 export function getService(id: string): ServiceDefinition | undefined {
   return SERVICE_REGISTRY[id];
@@ -1001,6 +1020,7 @@ export async function discoverComponentKeys(
 
   for (const service of services) {
     try {
+      if (service.connectorKind !== "pipedream" || !service.pipedreamApp) continue;
       const actions = await pipedream.discoverActions(service.pipedreamApp);
       const keySet = new Map(actions.map((a) => [a.key, a]));
 

--- a/packages/gateway/src/integrations/registry.ts
+++ b/packages/gateway/src/integrations/registry.ts
@@ -1,8 +1,4 @@
-import type {
-  IntegrationActionRisk,
-  ServiceAction,
-  ServiceDefinition,
-} from "./types.js";
+import type { ServiceAction, ServiceDefinition } from "./types.js";
 import { EXPANSION_SERVICE_REGISTRY } from "./registry-expansion.js";
 import type { PipedreamConnectClient } from "./pipedream.js";
 
@@ -88,27 +84,11 @@ function linearGraphqlBody(query: string, variables?: Record<string, unknown>): 
   return variables ? { query, variables } : { query };
 }
 
-type RegistryActionInput = Omit<ServiceAction, "risk"> & { risk?: IntegrationActionRisk };
 type RegistryServiceInput = Omit<ServiceDefinition, "actions" | "connectorKind"> & {
   connectorKind?: ServiceDefinition["connectorKind"];
-  actions: Record<string, RegistryActionInput>;
+  actions: ServiceDefinition["actions"];
 };
 
-const WRITE_ACTIONS = new Set([
-  "gmail.send_email",
-  "google_calendar.create_event",
-  "google_calendar.update_event",
-  "google_drive.upload_file",
-  "google_drive.share_file",
-  "github.create_issue",
-  "linear.create_issue",
-  "linear.update_issue",
-  "linear.comment_issue",
-  "linear.create_workflow_state",
-  "slack.send_message",
-  "slack.react",
-  "discord.send_message",
-]);
 function defineServiceRegistry(
   input: Record<string, RegistryServiceInput>,
 ): Record<string, ServiceDefinition> {
@@ -117,12 +97,6 @@ function defineServiceRegistry(
     {
       ...service,
       connectorKind: service.connectorKind ?? "pipedream",
-      actions: Object.fromEntries(Object.entries(service.actions).map(([actionId, action]) => {
-        const key = `${serviceId}.${actionId}`;
-        const risk = action.risk
-          ?? (WRITE_ACTIONS.has(key) ? "write" : "read");
-        return [actionId, { ...action, risk }];
-      })),
     },
   ])) as Record<string, ServiceDefinition>;
 }
@@ -138,6 +112,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
     actions: {
       list_messages: {
         description: "List recent email messages",
+        risk: "read",
         params: {
           query: { type: "string" },
           maxResults: { type: "number" },
@@ -153,6 +128,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       get_message: {
         description: "Get a specific email message by ID",
+        risk: "read",
         params: {
           messageId: { type: "string", required: true },
         },
@@ -175,6 +151,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // CR/LF in the body is legitimate message content.
       send_email: {
         description: "Send an email",
+        risk: "write",
         params: {
           to: { type: "string", required: true },
           subject: { type: "string", required: true },
@@ -199,6 +176,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       search: {
         description: "Search emails by query",
+        risk: "read",
         params: {
           query: { type: "string", required: true },
           maxResults: { type: "number" },
@@ -214,6 +192,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       list_labels: {
         description: "List all email labels",
+        risk: "read",
         params: {},
         directApi: {
           method: "GET",
@@ -236,6 +215,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // and a /calendars/list call to enumerate.
       list_events: {
         description: "List calendar events",
+        risk: "read",
         params: {
           timeMin: { type: "string" },
           timeMax: { type: "string" },
@@ -259,6 +239,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // and remap to {date: ...} all-day events here.
       create_event: {
         description: "Create a new calendar event",
+        risk: "write",
         params: {
           summary: { type: "string", required: true },
           start: { type: "string", required: true },
@@ -283,6 +264,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // forwarded.
       update_event: {
         description: "Update an existing calendar event",
+        risk: "write",
         params: {
           eventId: { type: "string", required: true },
           summary: { type: "string" },
@@ -316,6 +298,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // language. If both are absent, returns the user's recent files.
       list_files: {
         description: "List files in Google Drive",
+        risk: "read",
         params: {
           query: { type: "string" },
           maxResults: { type: "number" },
@@ -341,6 +324,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // would need a separate `download_file` action we haven't shipped.
       get_file: {
         description: "Get file metadata by ID",
+        risk: "read",
         params: {
           fileId: { type: "string", required: true },
         },
@@ -366,6 +350,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // integrations skill at home/.agents/skills/matrix-integrations/SKILL.md.
       upload_file: {
         description: "Upload a file to Google Drive (requires paid Pipedream plan)",
+        risk: "write",
         params: {
           name: { type: "string", required: true },
           content: { type: "string", required: true },
@@ -379,6 +364,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // want a notification, they can paste the link manually.
       share_file: {
         description: "Share a file with another user",
+        risk: "write",
         params: {
           fileId: { type: "string", required: true },
           email: { type: "string", required: true },
@@ -417,6 +403,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // active repos surface first; matches what `gh repo list` does.
       list_repos: {
         description: "List repositories",
+        risk: "read",
         params: {
           sort: { type: "string" },
           per_page: { type: "number" },
@@ -435,6 +422,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // issues should filter on `pull_request === null` client-side.
       list_issues: {
         description: "List issues for a repository (use owner/repo format)",
+        risk: "read",
         params: {
           repo: { type: "string", required: true },
           state: { type: "string" },
@@ -452,6 +440,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // split here. Empty string -> no labels, not a single empty label.
       create_issue: {
         description: "Create a new issue (use owner/repo format)",
+        risk: "write",
         params: {
           repo: { type: "string", required: true },
           title: { type: "string", required: true },
@@ -473,6 +462,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // GitHub API: GET /repos/{owner}/{repo}/pulls.
       list_prs: {
         description: "List pull requests for a repository (use owner/repo format)",
+        risk: "read",
         params: {
           repo: { type: "string", required: true },
           state: { type: "string" },
@@ -489,6 +479,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // default is unread only.
       get_notifications: {
         description: "Get notifications",
+        risk: "read",
         params: {
           all: { type: "boolean" },
         },
@@ -513,6 +504,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
     actions: {
       viewer: {
         description: "Get the connected Linear user",
+        risk: "read",
         params: {},
         directApi: {
           method: "POST",
@@ -526,6 +518,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       list_teams: {
         description: "List Linear teams",
+        risk: "read",
         params: {
           first: { type: "number" },
         },
@@ -543,6 +536,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       list_projects: {
         description: "List Linear projects",
+        risk: "read",
         params: {
           first: { type: "number" },
           after: { type: "string" },
@@ -572,6 +566,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       list_workflow_states: {
         description: "List workflow states for a Linear team",
+        risk: "read",
         params: {
           teamId: { type: "string", required: true },
           first: { type: "number" },
@@ -593,6 +588,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       list_issues: {
         description: "List Linear issues, optionally filtered by team, project, or state name",
+        risk: "read",
         params: {
           first: { type: "number" },
           teamId: { type: "string" },
@@ -670,6 +666,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       create_issue: {
         description: "Create a Linear issue",
+        risk: "write",
         params: {
           teamId: { type: "string", required: true },
           title: { type: "string", required: true },
@@ -709,6 +706,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       update_issue: {
         description: "Update a Linear issue",
+        risk: "write",
         params: {
           issueId: { type: "string", required: true },
           title: { type: "string" },
@@ -743,6 +741,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       comment_issue: {
         description: "Add a comment to a Linear issue",
+        risk: "write",
         params: {
           issueId: { type: "string", required: true },
           body: { type: "string", required: true },
@@ -767,6 +766,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       create_workflow_state: {
         description: "Create a Linear workflow state for Symphony",
+        risk: "write",
         params: {
           teamId: { type: "string", required: true },
           name: { type: "string", required: true },
@@ -817,6 +817,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // channel name like "#general" -- Slack resolves both.
       send_message: {
         description: "Send a message to a channel",
+        risk: "write",
         params: {
           channel: { type: "string", required: true },
           text: { type: "string", required: true },
@@ -832,6 +833,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       list_channels: {
         description: "List available channels",
+        risk: "read",
         params: {
           limit: { type: "number" },
         },
@@ -847,6 +849,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       },
       list_messages: {
         description: "List messages in a channel",
+        risk: "read",
         params: {
           channel: { type: "string", required: true },
           limit: { type: "number" },
@@ -866,6 +869,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // they need to reconnect with `search:read` user-scope.
       search: {
         description: "Search messages",
+        risk: "read",
         params: {
           query: { type: "string", required: true },
         },
@@ -881,6 +885,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // colons -- ":thumbsup:" should be passed as "thumbsup".
       react: {
         description: "Add a reaction to a message (emoji name without colons)",
+        risk: "write",
         params: {
           channel: { type: "string", required: true },
           timestamp: { type: "string", required: true },
@@ -920,6 +925,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // strictly validated before interpolation.
       send_message: {
         description: "Send a message to a channel",
+        risk: "write",
         params: {
           channelId: { type: "string", required: true },
           content: { type: "string", required: true },
@@ -936,6 +942,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // OAuth scope.
       list_servers: {
         description: "List servers the bot is in",
+        risk: "read",
         params: {},
         directApi: {
           method: "GET",
@@ -946,6 +953,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // VIEW_CHANNEL permission.
       list_channels: {
         description: "List channels in a server",
+        risk: "read",
         params: {
           serverId: { type: "string", required: true },
         },
@@ -958,6 +966,7 @@ export const SERVICE_REGISTRY: Record<string, ServiceDefinition> = defineService
       // GET /channels/{channel.id}/messages. Returns most recent first.
       list_messages: {
         description: "List messages in a channel",
+        risk: "read",
         params: {
           channelId: { type: "string", required: true },
           limit: { type: "number" },

--- a/packages/gateway/src/integrations/routes.ts
+++ b/packages/gateway/src/integrations/routes.ts
@@ -1016,20 +1016,29 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
   // DELETE /:id -- disconnect service
   // -----------------------------------------------------------------------
 
-  app.delete("/:id", async (c) => {
+  app.delete("/:id", bodyLimit({ maxSize: 1024 }), async (c) => {
     const uid = await requireUser(c);
     if (!uid) return c.json({ error: "Unauthorized" }, 401);
 
     const id = c.req.param("id");
     if (!UUID_RE.test(id)) return c.json({ error: "Invalid ID" }, 400);
-    if (mcpPresetBroker && await mcpPresetBroker.disconnect(uid, id)) {
-      emit({ type: "integration:disconnected", service: "granola", id });
-      return c.json({ ok: true });
-    }
     const result = await requireOwnedService(c, id, uid);
     if (result === "invalid") return c.json({ error: "Invalid ID" }, 400);
-    if (result === null) return c.json({ error: "Not found" }, 404);
     if (result === "forbidden") return c.json({ error: "Forbidden" }, 403);
+
+    if (result === null) {
+      if (!mcpPresetBroker) return c.json({ error: "Not found" }, 404);
+      try {
+        if (await mcpPresetBroker.disconnect(uid, id)) {
+          emit({ type: "integration:disconnected", service: "granola", id });
+          return c.json({ ok: true });
+        }
+      } catch (err: unknown) {
+        console.error("[integrations] MCP preset disconnect error:", err);
+        return c.json({ error: "Integration service unavailable" }, 503);
+      }
+      return c.json({ error: "Not found" }, 404);
+    }
 
     try {
       await pipedream.revokeAccount(result.pipedream_account_id);

--- a/packages/gateway/src/integrations/routes.ts
+++ b/packages/gateway/src/integrations/routes.ts
@@ -136,7 +136,7 @@ export async function executeIntegrationAction(opts: {
     );
     const configuredProps: Record<string, unknown> = {
       ...safeParams,
-      [def.pipedreamApp]: { authProvisionId: connection.pipedream_account_id },
+      [def.pipedreamApp!]: { authProvisionId: connection.pipedream_account_id },
     };
     const result = await pipedream.runAction({
       externalUserId,
@@ -163,6 +163,7 @@ export async function executeIntegrationAction(opts: {
             accountId,
             url,
             params: api.mapParams ? api.mapParams(params ?? {}) : undefined,
+            ...(api.staticHeaders ? { headers: { ...api.staticHeaders } } : {}),
           }),
         };
       case "DELETE":
@@ -172,6 +173,7 @@ export async function executeIntegrationAction(opts: {
             accountId,
             url,
             params: api.mapParams ? api.mapParams(params ?? {}) : undefined,
+            ...(api.staticHeaders ? { headers: { ...api.staticHeaders } } : {}),
           }),
         };
       case "POST":
@@ -181,6 +183,7 @@ export async function executeIntegrationAction(opts: {
             accountId,
             url,
             body: api.mapBody ? api.mapBody(params ?? {}) : (params ?? {}),
+            ...(api.staticHeaders ? { headers: { ...api.staticHeaders } } : {}),
           }),
         };
       case "PUT":
@@ -190,6 +193,7 @@ export async function executeIntegrationAction(opts: {
             accountId,
             url,
             body: api.mapBody ? api.mapBody(params ?? {}) : (params ?? {}),
+            ...(api.staticHeaders ? { headers: { ...api.staticHeaders } } : {}),
           }),
         };
       case "PATCH":
@@ -199,6 +203,7 @@ export async function executeIntegrationAction(opts: {
             accountId,
             url,
             body: api.mapBody ? api.mapBody(params ?? {}) : (params ?? {}),
+            ...(api.staticHeaders ? { headers: { ...api.staticHeaders } } : {}),
           }),
         };
       default: {
@@ -358,10 +363,30 @@ export interface IntegrationRoutesOpts {
   webhookSecret: string;
   resolveUserId: (c: Context) => Promise<string | null>;
   broadcast?: IntegrationBroadcast;
+  mcpPresetBroker?: {
+    listConnections(userId: string): Promise<Array<{
+      id: string;
+      service: string;
+      account_label: string;
+      account_email: string | null;
+      scopes: string[];
+      status: string;
+      connected_at: Date | string;
+      last_used_at: Date | string | null;
+    }>>;
+    connect(userId: string, service: ServiceDefinition): Promise<{ url: string }>;
+    call(input: {
+      userId: string;
+      service: ServiceDefinition;
+      actionId: string;
+      params?: Record<string, unknown>;
+    }): Promise<unknown>;
+    disconnect(userId: string, connectionId: string): Promise<boolean>;
+  };
 }
 
 export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
-  const { db, pipedream, webhookSecret, resolveUserId, broadcast } = opts;
+  const { db, pipedream, webhookSecret, resolveUserId, broadcast, mcpPresetBroker } = opts;
   const emit = broadcast ?? (() => {});
   const app = new Hono();
 
@@ -497,8 +522,8 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
     const promise = (async () => {
       const services = listServices();
       const results = await Promise.allSettled(
-        services.map(async (s) => {
-          const info = await pipedream.getAppInfo(s.pipedreamApp);
+        services.filter((service) => service.connectorKind === "pipedream" && service.pipedreamApp).map(async (s) => {
+          const info = await pipedream.getAppInfo(s.pipedreamApp!);
           if (info?.imgSrc) {
             if (logoCache.size >= LOGO_CACHE_MAX) logoCache.delete(logoCache.keys().next().value!);
             logoCache.set(s.id, info.imgSrc);
@@ -531,10 +556,12 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
   });
 
   app.get("/available", (c) => {
-    const services = listServices().map((s) => ({
-      ...s,
-      logoUrl: logoCache.get(s.id) || s.logoUrl,
-    }));
+    const services = listServices()
+      .filter((service) => service.connectorKind !== "mcp_preset" || mcpPresetBroker)
+      .map((s) => ({
+        ...s,
+        logoUrl: logoCache.get(s.id) || s.logoUrl,
+      }));
     return c.json(services);
   });
 
@@ -545,7 +572,10 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
   app.get("/", async (c) => {
     const uid = await requireUser(c);
     if (!uid) return c.json({ error: "Unauthorized" }, 401);
-    const services = await db.listConnectedServices(uid);
+    const services = [
+      ...await db.listConnectedServices(uid),
+      ...(mcpPresetBroker ? await mcpPresetBroker.listConnections(uid) : []),
+    ];
     return c.json(services.map(({ id, service, account_label, account_email, scopes, status, connected_at, last_used_at }) => ({
       id, service, account_label, account_email, scopes, status, connected_at, last_used_at,
     })));
@@ -567,7 +597,10 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
       const existing = await db.listConnectedServices(uid);
       const existingPdIds = new Set(existing.map((s) => s.pipedream_account_id));
 
-      const newAccounts = pdAccounts.filter((acc) => !existingPdIds.has(acc.id) && getService(acc.app));
+      const newAccounts = pdAccounts.filter((acc) => {
+        const service = getService(acc.app);
+        return !existingPdIds.has(acc.id) && service?.connectorKind === "pipedream";
+      });
 
       // Resolve emails for new accounts missing them
       const resolvedEmails = await Promise.all(
@@ -620,7 +653,10 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
         }),
       );
 
-      const services = await db.listConnectedServices(uid);
+      const services = [
+        ...await db.listConnectedServices(uid),
+        ...(mcpPresetBroker ? await mcpPresetBroker.listConnections(uid) : []),
+      ];
       return c.json({ synced, services });
     } catch (err) {
       console.error("[integrations] Sync failed:", err instanceof Error ? err.message : err);
@@ -654,6 +690,18 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
     if (!def) {
       return c.json({ error: `Unknown service: ${service}` }, 400);
     }
+
+    if (def.connectorKind === "mcp_preset") {
+      if (!mcpPresetBroker) return c.json({ error: "Service connection unavailable" }, 503);
+      try {
+        const result = await mcpPresetBroker.connect(uid, def);
+        return c.json({ url: result.url, service });
+      } catch (err) {
+        console.error("[integrations] MCP preset connect failed:", err instanceof Error ? err.message : String(err));
+        return c.json({ error: "Failed to initiate connection. Please try again." }, 502);
+      }
+    }
+    if (!def.pipedreamApp) return c.json({ error: "Service connection unavailable" }, 503);
 
     const externalId = await getOrCreateExternalId(uid);
 
@@ -700,7 +748,7 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
 
     const { external_user_id, account_id, app: appName, label, email, scopes } = parsed.data;
 
-    if (!getService(appName)) {
+    if (getService(appName)?.connectorKind !== "pipedream") {
       return c.json({ error: "Unsupported app" }, 400);
     }
 
@@ -804,6 +852,22 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
         missing: paramValidation.missing.length > 0 ? paramValidation.missing : undefined,
         type_errors: paramValidation.typeErrors.length > 0 ? paramValidation.typeErrors : undefined,
       }, 400);
+    }
+
+    if (def.connectorKind === "mcp_preset") {
+      if (!mcpPresetBroker) return c.json({ error: "Integration service unavailable" }, 503);
+      try {
+        const data = await mcpPresetBroker.call({
+          userId: uid,
+          service: def,
+          actionId: action,
+          params,
+        });
+        return c.json({ data, service, action });
+      } catch (err) {
+        console.error("[integrations] MCP preset call failed:", err instanceof Error ? err.message : String(err));
+        return c.json({ error: "Integration call failed" }, 502);
+      }
     }
 
     // Find the user's active connection for this service. On cache miss
@@ -957,6 +1021,11 @@ export function createIntegrationRoutes(opts: IntegrationRoutesOpts): Hono {
     if (!uid) return c.json({ error: "Unauthorized" }, 401);
 
     const id = c.req.param("id");
+    if (!UUID_RE.test(id)) return c.json({ error: "Invalid ID" }, 400);
+    if (mcpPresetBroker && await mcpPresetBroker.disconnect(uid, id)) {
+      emit({ type: "integration:disconnected", service: "granola", id });
+      return c.json({ ok: true });
+    }
     const result = await requireOwnedService(c, id, uid);
     if (result === "invalid") return c.json({ error: "Invalid ID" }, 400);
     if (result === null) return c.json({ error: "Not found" }, 404);

--- a/packages/gateway/src/integrations/types.ts
+++ b/packages/gateway/src/integrations/types.ts
@@ -9,11 +9,17 @@ export interface DirectApi {
   url: string | ((params: Record<string, unknown>) => string);
   mapParams?: (params: Record<string, unknown>) => Record<string, string>;
   mapBody?: (params: Record<string, unknown>) => Record<string, unknown>;
+  /** Header names and values are compile-time registry data, never caller input. */
+  staticHeaders?: Readonly<Record<string, string>>;
 }
+
+export type IntegrationActionRisk = "read" | "write" | "destructive";
+export type IntegrationConnectorKind = "pipedream" | "mcp_preset";
 
 export interface ServiceAction {
   description: string;
   params: Record<string, ActionParam>;
+  risk: IntegrationActionRisk;
   componentKey?: string;
   directApi?: DirectApi;
 }
@@ -22,7 +28,12 @@ export interface ServiceDefinition {
   id: string;
   name: string;
   category: string;
-  pipedreamApp: string;
+  connectorKind: IntegrationConnectorKind;
+  pipedreamApp?: string;
+  mcpPreset?: {
+    url: string;
+    authMode: "oauth";
+  };
   icon: string;
   logoUrl: string;
   actions: Record<string, ServiceAction>;

--- a/packages/gateway/src/platform-db.ts
+++ b/packages/gateway/src/platform-db.ts
@@ -1,6 +1,12 @@
 import { Kysely, PostgresDialect, sql, type InsertObject } from "kysely";
 import pg from "pg";
 import { randomUUID } from "node:crypto";
+import type {
+  CustomMcpAuthMode,
+  CustomMcpServer,
+  CustomMcpStatus,
+  CustomMcpTool,
+} from "./integrations/custom-mcp/types.js";
 
 // ---------------------------------------------------------------------------
 // Kysely table types
@@ -67,12 +73,32 @@ export interface BillingTable {
   status: string;
 }
 
+export interface CustomMcpServersTable {
+  id: string;
+  user_id: string;
+  preset_id: string | null;
+  name: string;
+  url: string;
+  auth_mode: CustomMcpAuthMode;
+  status: CustomMcpStatus;
+  enabled: boolean;
+  revision: number;
+  tools: CustomMcpTool[];
+  enforcement_projection: CustomMcpTool[];
+  encrypted_credentials: string | null;
+  pending_expires_at: Date | null;
+  action_required_reason: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
 export interface PlatformDatabase {
   users: UsersTable;
   connected_services: ConnectedServicesTable;
   user_apps: UserAppsTable;
   event_subscriptions: EventSubscriptionsTable;
   billing: BillingTable;
+  custom_mcp_servers: CustomMcpServersTable;
 }
 
 // ---------------------------------------------------------------------------
@@ -113,6 +139,29 @@ export interface CreateEventSubscriptionInput {
   eventType: string;
 }
 
+export interface CreateCustomMcpServerInput {
+  id?: string;
+  userId: string;
+  name: string;
+  url: string;
+  authMode: CustomMcpAuthMode;
+  encryptedCredentials?: string;
+  pendingExpiresAt: Date;
+  presetId?: string;
+}
+
+export interface UpdateCustomMcpServerInput {
+  name?: string;
+  enabled?: boolean;
+  status?: CustomMcpStatus;
+  tools?: CustomMcpTool[];
+  encryptedCredentials?: string | null;
+  pendingExpiresAt?: Date | null;
+  actionRequiredReason?: string | null;
+}
+
+export type CustomMcpServerBrokerRow = CustomMcpServersTable;
+
 // ---------------------------------------------------------------------------
 // PlatformDb interface
 // ---------------------------------------------------------------------------
@@ -143,6 +192,26 @@ export interface PlatformDb {
   createEventSubscription(input: CreateEventSubscriptionInput): Promise<EventSubscriptionsTable>;
   listEventSubscriptions(userId: string): Promise<EventSubscriptionsTable[]>;
   deleteEventSubscription(id: string): Promise<void>;
+
+  createCustomMcpServer(input: CreateCustomMcpServerInput): Promise<CustomMcpServer>;
+  listCustomMcpServers(userId: string): Promise<CustomMcpServer[]>;
+  getCustomMcpServerForBroker(id: string, userId: string): Promise<CustomMcpServerBrokerRow | null>;
+  getCustomMcpPresetForBroker(presetId: string, userId: string): Promise<CustomMcpServerBrokerRow | null>;
+  updateCustomMcpServer(
+    id: string,
+    userId: string,
+    revision: number,
+    update: UpdateCustomMcpServerInput,
+  ): Promise<CustomMcpServer | null>;
+  updateCustomMcpCredentials(
+    id: string,
+    userId: string,
+    revision: number,
+    encryptedCredentials: string,
+    status: CustomMcpStatus,
+  ): Promise<boolean>;
+  deleteCustomMcpServer(id: string, userId: string): Promise<boolean>;
+  sweepPendingCustomMcpServers(now: Date): Promise<number>;
 
   // Escape hatch for queries that Kysely's builder doesn't express cleanly
   // (e.g. RETURNING with custom projections, system columns, or pg-specific
@@ -187,6 +256,19 @@ export function createPlatformDb(opts: string | { dialect: any }): PlatformDb {
       pipedream_external_id: input.pipedreamExternalId ?? null,
       created_at: sql`now()`,
       updated_at: sql`now()`,
+    };
+  }
+
+  function publicCustomMcpServer(row: CustomMcpServersTable): CustomMcpServer {
+    return {
+      id: row.id,
+      name: row.name,
+      url: row.url,
+      authMode: row.auth_mode,
+      status: row.status,
+      enabled: row.enabled,
+      revision: row.revision,
+      tools: row.tools,
     };
   }
 
@@ -263,12 +345,37 @@ export function createPlatformDb(opts: string | { dialect: any }): PlatformDb {
         )
       `.execute(kysely);
 
+      await sql`
+        CREATE TABLE IF NOT EXISTS custom_mcp_servers (
+          id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          user_id                  UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          preset_id                TEXT,
+          name                     TEXT NOT NULL,
+          url                      TEXT NOT NULL,
+          auth_mode                TEXT NOT NULL CHECK (auth_mode IN ('none', 'oauth', 'bearer', 'api_key')),
+          status                   TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'auth_required', 'ready', 'degraded', 'disabled', 'action_required')),
+          enabled                  BOOLEAN NOT NULL DEFAULT false,
+          revision                 INTEGER NOT NULL DEFAULT 1 CHECK (revision >= 1),
+          tools                    JSONB NOT NULL DEFAULT '[]'::jsonb,
+          enforcement_projection   JSONB NOT NULL DEFAULT '[]'::jsonb,
+          encrypted_credentials    TEXT,
+          pending_expires_at       TIMESTAMPTZ,
+          action_required_reason   TEXT,
+          created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+          updated_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+      `.execute(kysely);
+      await sql`ALTER TABLE custom_mcp_servers ADD COLUMN IF NOT EXISTS preset_id TEXT`.execute(kysely);
+
       // Indexes
       await sql`CREATE INDEX IF NOT EXISTS idx_connected_services_user ON connected_services(user_id)`.execute(kysely);
       await sql`CREATE UNIQUE INDEX IF NOT EXISTS idx_connected_services_user_account ON connected_services(user_id, pipedream_account_id)`.execute(kysely);
       await sql`CREATE INDEX IF NOT EXISTS idx_user_apps_user ON user_apps(user_id)`.execute(kysely);
       await sql`CREATE INDEX IF NOT EXISTS idx_event_subs_user ON event_subscriptions(user_id)`.execute(kysely);
       await sql`CREATE INDEX IF NOT EXISTS idx_users_pipedream_ext_id ON users(pipedream_external_id)`.execute(kysely);
+      await sql`CREATE INDEX IF NOT EXISTS idx_custom_mcp_servers_user ON custom_mcp_servers(user_id)`.execute(kysely);
+      await sql`CREATE INDEX IF NOT EXISTS idx_custom_mcp_pending_expiry ON custom_mcp_servers(pending_expires_at) WHERE status = 'pending'`.execute(kysely);
+      await sql`CREATE UNIQUE INDEX IF NOT EXISTS idx_custom_mcp_user_preset ON custom_mcp_servers(user_id, preset_id) WHERE preset_id IS NOT NULL`.execute(kysely);
     },
 
     async createUser(input: CreateUserInput): Promise<UsersTable> {
@@ -507,6 +614,151 @@ export function createPlatformDb(opts: string | { dialect: any }): PlatformDb {
         .deleteFrom("event_subscriptions")
         .where("id", "=", id)
         .execute();
+    },
+
+    async createCustomMcpServer(input: CreateCustomMcpServerInput): Promise<CustomMcpServer> {
+      const row = await kysely.transaction().execute(async (trx) => {
+        const owner = await trx
+          .selectFrom("users")
+          .select("id")
+          .where("id", "=", input.userId)
+          .forUpdate()
+          .executeTakeFirst();
+        if (!owner) throw new Error("Custom MCP owner not found");
+        const count = await trx
+          .selectFrom("custom_mcp_servers")
+          .select((eb) => eb.fn.countAll<number>().as("count"))
+          .where("user_id", "=", input.userId)
+          .where("preset_id", "is", null)
+          .executeTakeFirstOrThrow();
+        if (Number(count.count) >= 20) throw new Error("Custom MCP server limit reached");
+        return trx
+          .insertInto("custom_mcp_servers")
+          .values({
+            id: input.id ?? randomUUID(),
+            user_id: input.userId,
+            preset_id: input.presetId ?? null,
+            name: input.name,
+            url: input.url,
+            auth_mode: input.authMode,
+            status: "pending",
+            enabled: false,
+            revision: 1,
+            tools: sql`'[]'::jsonb`,
+            enforcement_projection: sql`'[]'::jsonb`,
+            encrypted_credentials: input.encryptedCredentials ?? null,
+            pending_expires_at: input.pendingExpiresAt,
+            action_required_reason: null,
+            created_at: sql`now()`,
+            updated_at: sql`now()`,
+          })
+          .returningAll()
+          .executeTakeFirstOrThrow();
+      });
+      return publicCustomMcpServer(row);
+    },
+
+    async listCustomMcpServers(userId: string): Promise<CustomMcpServer[]> {
+      const rows = await kysely
+        .selectFrom("custom_mcp_servers")
+        .selectAll()
+        .where("user_id", "=", userId)
+        .where("preset_id", "is", null)
+        .orderBy("created_at", "asc")
+        .execute();
+      return rows.map(publicCustomMcpServer);
+    },
+
+    async getCustomMcpServerForBroker(id: string, userId: string): Promise<CustomMcpServerBrokerRow | null> {
+      return await kysely
+        .selectFrom("custom_mcp_servers")
+        .selectAll()
+        .where("id", "=", id)
+        .where("user_id", "=", userId)
+        .executeTakeFirst() ?? null;
+    },
+
+    async getCustomMcpPresetForBroker(presetId: string, userId: string): Promise<CustomMcpServerBrokerRow | null> {
+      return await kysely
+        .selectFrom("custom_mcp_servers")
+        .selectAll()
+        .where("preset_id", "=", presetId)
+        .where("user_id", "=", userId)
+        .executeTakeFirst() ?? null;
+    },
+
+    async updateCustomMcpServer(
+      id: string,
+      userId: string,
+      revision: number,
+      update: UpdateCustomMcpServerInput,
+    ): Promise<CustomMcpServer | null> {
+      const values: Record<string, unknown> = {
+        revision: sql`revision + 1`,
+        updated_at: sql`now()`,
+      };
+      if (update.name !== undefined) values.name = update.name;
+      if (update.enabled !== undefined) values.enabled = update.enabled;
+      if (update.status !== undefined) values.status = update.status;
+      if (update.tools !== undefined) {
+        values.tools = sql`${JSON.stringify(update.tools)}::jsonb`;
+        values.enforcement_projection = sql`${JSON.stringify(update.tools)}::jsonb`;
+      }
+      if (update.encryptedCredentials !== undefined) values.encrypted_credentials = update.encryptedCredentials;
+      if (update.pendingExpiresAt !== undefined) values.pending_expires_at = update.pendingExpiresAt;
+      if (update.actionRequiredReason !== undefined) values.action_required_reason = update.actionRequiredReason;
+
+      const row = await kysely
+        .updateTable("custom_mcp_servers")
+        .set(values as never)
+        .where("id", "=", id)
+        .where("user_id", "=", userId)
+        .where("revision", "=", revision)
+        .returningAll()
+        .executeTakeFirst();
+      return row ? publicCustomMcpServer(row) : null;
+    },
+
+    async deleteCustomMcpServer(id: string, userId: string): Promise<boolean> {
+      const rows = await kysely
+        .deleteFrom("custom_mcp_servers")
+        .where("id", "=", id)
+        .where("user_id", "=", userId)
+        .returning("id")
+        .execute();
+      return rows.length === 1;
+    },
+
+    async updateCustomMcpCredentials(
+      id: string,
+      userId: string,
+      revision: number,
+      encryptedCredentials: string,
+      status: CustomMcpStatus,
+    ): Promise<boolean> {
+      const row = await kysely
+        .updateTable("custom_mcp_servers")
+        .set({
+          encrypted_credentials: encryptedCredentials,
+          status,
+          updated_at: sql`now()`,
+        })
+        .where("id", "=", id)
+        .where("user_id", "=", userId)
+        .where("revision", "=", revision)
+        .returning("id")
+        .executeTakeFirst();
+      return Boolean(row);
+    },
+
+    async sweepPendingCustomMcpServers(now: Date): Promise<number> {
+      const rows = await kysely
+        .deleteFrom("custom_mcp_servers")
+        .where("status", "=", "pending")
+        .where("pending_expires_at", "<", now)
+        .returning("id")
+        .execute();
+      return rows.length;
     },
 
     async raw(query: string, params: readonly unknown[]): Promise<{ rows: Record<string, unknown>[] }> {

--- a/packages/gateway/src/platform-db.ts
+++ b/packages/gateway/src/platform-db.ts
@@ -195,6 +195,7 @@ export interface PlatformDb {
 
   createCustomMcpServer(input: CreateCustomMcpServerInput): Promise<CustomMcpServer>;
   listCustomMcpServers(userId: string): Promise<CustomMcpServer[]>;
+  listCustomMcpOAuthServersForBroker(userId: string): Promise<CustomMcpServerBrokerRow[]>;
   getCustomMcpServerForBroker(id: string, userId: string): Promise<CustomMcpServerBrokerRow | null>;
   getCustomMcpPresetForBroker(presetId: string, userId: string): Promise<CustomMcpServerBrokerRow | null>;
   updateCustomMcpServer(
@@ -667,6 +668,18 @@ export function createPlatformDb(opts: string | { dialect: any }): PlatformDb {
         .orderBy("created_at", "asc")
         .execute();
       return rows.map(publicCustomMcpServer);
+    },
+
+    async listCustomMcpOAuthServersForBroker(userId: string): Promise<CustomMcpServerBrokerRow[]> {
+      // OAuth callbacks also serve managed presets. Keep this credential-bearing
+      // lookup separate from the public custom-only inventory.
+      return kysely
+        .selectFrom("custom_mcp_servers")
+        .selectAll()
+        .where("user_id", "=", userId)
+        .where("auth_mode", "=", "oauth")
+        .where("encrypted_credentials", "is not", null)
+        .execute();
     },
 
     async getCustomMcpServerForBroker(id: string, userId: string): Promise<CustomMcpServerBrokerRow | null> {

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -206,6 +206,7 @@ import { createKvStore, type KvStore } from "./app-db-kv.js";
 import { renameApp, deleteApp } from "./app-ops.js";
 import { createPlatformDb, type PlatformDb } from "./platform-db.js";
 import { createPipedreamClient, type PipedreamConnectClient } from "./integrations/pipedream.js";
+import { registerCustomMcpGatewayRoutes } from "./integrations/custom-mcp/gateway-routes.js";
 import {
   createIntegrationRoutes,
   validateActionParams,
@@ -1907,6 +1908,11 @@ export async function createGateway(config: GatewayConfig) {
       run: (input) => shellCommandRunner.run(input),
     }));
   }
+  registerCustomMcpGatewayRoutes(app, {
+    homePath,
+    clerkUserId: process.env.MATRIX_CLERK_USER_ID ?? process.env.MATRIX_USER_ID,
+    projectionToken: process.env.UPGRADE_TOKEN,
+  });
 
   // HKDF master secret for per-app session cookies. In production MATRIX_AUTH_TOKEN
   // is the source. When it is absent (local dev, .env.example default) we mint an

--- a/scripts/lib/pipedream-integration-verification.ts
+++ b/scripts/lib/pipedream-integration-verification.ts
@@ -1,0 +1,34 @@
+import type { DiscoveredAction } from "../../packages/gateway/src/integrations/pipedream.js";
+import type { ServiceAction } from "../../packages/gateway/src/integrations/types.js";
+
+interface BindDiscoveredComponentKeyInput {
+  serviceId: string;
+  actionId: string;
+  action: ServiceAction;
+  discovered: readonly DiscoveredAction[];
+  componentKey?: string;
+}
+
+/**
+ * Bind a caller-selected component key only after exact live discovery proves
+ * that it exists. Direct API actions do not need a Pipedream component.
+ */
+export function bindDiscoveredComponentKey(
+  input: BindDiscoveredComponentKeyInput,
+): ServiceAction {
+  if (input.action.directApi) return input.action;
+
+  const componentKey = input.componentKey?.trim();
+  if (!componentKey) {
+    throw new Error(
+      `${input.serviceId}/${input.actionId} componentKey is required for live verification`,
+    );
+  }
+  if (!input.discovered.some((candidate) => candidate.key === componentKey)) {
+    throw new Error(
+      `${input.serviceId}/${input.actionId} componentKey was not returned by live discovery`,
+    );
+  }
+
+  return { ...input.action, componentKey };
+}

--- a/scripts/verify-pipedream-integration-expansion.ts
+++ b/scripts/verify-pipedream-integration-expansion.ts
@@ -1,0 +1,66 @@
+/**
+ * Live development-project gate for spec 118.
+ *
+ * PIPEDREAM_VERIFICATION_CASES is a JSON object keyed by Matrix service id:
+ * {"figma":{"accountId":"apn_...","action":"list_comments","params":{"fileKey":"..."}}}
+ * The script intentionally requires real connected accounts and invokes the
+ * production execution boundary; it never fabricates component keys.
+ */
+import { createPipedreamClient } from "../packages/gateway/src/integrations/pipedream.js";
+import { executeIntegrationAction } from "../packages/gateway/src/integrations/routes.js";
+import { getAction, getService } from "../packages/gateway/src/integrations/registry.js";
+
+const REQUIRED = ["google_docs", "notion", "figma", "posthog", "jira", "stripe"] as const;
+const clientId = process.env.PIPEDREAM_CLIENT_ID;
+const clientSecret = process.env.PIPEDREAM_CLIENT_SECRET;
+const projectId = process.env.PIPEDREAM_PROJECT_ID;
+const externalUserId = process.env.PIPEDREAM_VERIFICATION_EXTERNAL_USER_ID;
+const casesRaw = process.env.PIPEDREAM_VERIFICATION_CASES;
+
+if (!clientId || !clientSecret || !projectId || !externalUserId || !casesRaw) {
+  throw new Error("Live verification requires Pipedream development credentials, an external user id, and PIPEDREAM_VERIFICATION_CASES");
+}
+if ((process.env.PIPEDREAM_ENVIRONMENT ?? "development") !== "development") {
+  throw new Error("Verification is development-environment only");
+}
+
+const cases = JSON.parse(casesRaw) as Record<string, {
+  accountId: string;
+  action: string;
+  params?: Record<string, unknown>;
+}>;
+const pipedream = await createPipedreamClient({
+  clientId,
+  clientSecret,
+  projectId,
+  environment: "development",
+});
+
+for (const serviceId of REQUIRED) {
+  const service = getService(serviceId);
+  const verification = cases[serviceId];
+  if (!service?.pipedreamApp || !verification) throw new Error(`Missing verification case for ${serviceId}`);
+  const app = await pipedream.getAppInfo(service.pipedreamApp);
+  if (!app) throw new Error(`Pipedream app slug not found: ${service.pipedreamApp}`);
+  const discovered = await pipedream.discoverActions(service.pipedreamApp);
+  const action = getAction(serviceId, verification.action);
+  if (!action || action.risk !== "read") throw new Error(`${serviceId} verification action must be read-only`);
+  const result = await executeIntegrationAction({
+    pipedream,
+    externalUserId,
+    connection: { pipedream_account_id: verification.accountId },
+    def: service,
+    actionDef: action,
+    serviceId,
+    actionId: verification.action,
+    params: verification.params,
+  });
+  process.stdout.write(`${JSON.stringify({
+    service: serviceId,
+    appSlug: service.pipedreamApp,
+    appName: app.name,
+    discoveredComponentKeys: discovered.map((item) => item.key),
+    readAction: verification.action,
+    readSucceeded: result.data !== undefined,
+  })}\n`);
+}

--- a/scripts/verify-pipedream-integration-expansion.ts
+++ b/scripts/verify-pipedream-integration-expansion.ts
@@ -2,13 +2,14 @@
  * Live development-project gate for spec 118.
  *
  * PIPEDREAM_VERIFICATION_CASES is a JSON object keyed by Matrix service id:
- * {"figma":{"accountId":"apn_...","action":"list_comments","params":{"fileKey":"..."}}}
+ * {"posthog":{"accountId":"apn_...","action":"list_projects","componentKey":"posthog-list-projects"}}
  * The script intentionally requires real connected accounts and invokes the
  * production execution boundary; it never fabricates component keys.
  */
 import { createPipedreamClient } from "../packages/gateway/src/integrations/pipedream.js";
 import { executeIntegrationAction } from "../packages/gateway/src/integrations/routes.js";
 import { getAction, getService } from "../packages/gateway/src/integrations/registry.js";
+import { bindDiscoveredComponentKey } from "./lib/pipedream-integration-verification.js";
 
 const REQUIRED = ["google_docs", "notion", "figma", "posthog", "jira", "stripe"] as const;
 const clientId = process.env.PIPEDREAM_CLIENT_ID;
@@ -27,6 +28,7 @@ if ((process.env.PIPEDREAM_ENVIRONMENT ?? "development") !== "development") {
 const cases = JSON.parse(casesRaw) as Record<string, {
   accountId: string;
   action: string;
+  componentKey?: string;
   params?: Record<string, unknown>;
 }>;
 const pipedream = await createPipedreamClient({
@@ -45,12 +47,19 @@ for (const serviceId of REQUIRED) {
   const discovered = await pipedream.discoverActions(service.pipedreamApp);
   const action = getAction(serviceId, verification.action);
   if (!action || action.risk !== "read") throw new Error(`${serviceId} verification action must be read-only`);
+  const verifiedAction = bindDiscoveredComponentKey({
+    serviceId,
+    actionId: verification.action,
+    action,
+    discovered,
+    componentKey: verification.componentKey,
+  });
   const result = await executeIntegrationAction({
     pipedream,
     externalUserId,
     connection: { pipedream_account_id: verification.accountId },
     def: service,
-    actionDef: action,
+    actionDef: verifiedAction,
     serviceId,
     actionId: verification.action,
     params: verification.params,
@@ -60,6 +69,7 @@ for (const serviceId of REQUIRED) {
     appSlug: service.pipedreamApp,
     appName: app.name,
     discoveredComponentKeys: discovered.map((item) => item.key),
+    verifiedComponentKey: verifiedAction.componentKey ?? null,
     readAction: verification.action,
     readSucceeded: result.data !== undefined,
   })}\n`);

--- a/specs/118-integration-expansion/SDK-VERIFICATION.md
+++ b/specs/118-integration-expansion/SDK-VERIFICATION.md
@@ -6,7 +6,7 @@ Date: 2026-08-29
 
 The live Pipedream development-environment spike is **blocked** in this checkout. `PIPEDREAM_CLIENT_ID`, `PIPEDREAM_CLIENT_SECRET`, `PIPEDREAM_PROJECT_ID`, a development external-user ID, and connected provider test accounts are not present. No successful provider read, granted-scope capture, or SDK component key is claimed here.
 
-Run `node --import tsx scripts/verify-pipedream-integration-expansion.ts` with `PIPEDREAM_ENVIRONMENT=development` and the documented `PIPEDREAM_VERIFICATION_CASES` input. Paste its JSONL output and the Pipedream connection metadata below before release. The script rejects production projects and invokes one real read through Matrix's action boundary for each provider.
+Run `node --import tsx scripts/verify-pipedream-integration-expansion.ts` with `PIPEDREAM_ENVIRONMENT=development` and `PIPEDREAM_VERIFICATION_CASES` containing an account, read action, parameters, and the exact live-discovered `componentKey` for each component-backed case (currently PostHog and Jira). Direct-API cases omit `componentKey`. Paste its JSONL output and the Pipedream connection metadata below before release. The script rejects production projects, confirms each supplied component key appears in `discoverActions()`, and invokes one real read through Matrix's action boundary for each provider.
 
 | Provider | Documented app slug/auth evidence | Paid-plan evidence | Live app/auth/scopes/read | Component keys |
 | --- | --- | --- | --- | --- |

--- a/specs/118-integration-expansion/SDK-VERIFICATION.md
+++ b/specs/118-integration-expansion/SDK-VERIFICATION.md
@@ -1,0 +1,33 @@
+# SDK verification — managed integration expansion
+
+Date: 2026-08-29
+
+## Gate status
+
+The live Pipedream development-environment spike is **blocked** in this checkout. `PIPEDREAM_CLIENT_ID`, `PIPEDREAM_CLIENT_SECRET`, `PIPEDREAM_PROJECT_ID`, a development external-user ID, and connected provider test accounts are not present. No successful provider read, granted-scope capture, or SDK component key is claimed here.
+
+Run `node --import tsx scripts/verify-pipedream-integration-expansion.ts` with `PIPEDREAM_ENVIRONMENT=development` and the documented `PIPEDREAM_VERIFICATION_CASES` input. Paste its JSONL output and the Pipedream connection metadata below before release. The script rejects production projects and invokes one real read through Matrix's action boundary for each provider.
+
+| Provider | Documented app slug/auth evidence | Paid-plan evidence | Live app/auth/scopes/read | Component keys |
+| --- | --- | --- | --- | --- |
+| Google Docs | `google_docs`; Pipedream's current app page exposes this slug | Not listed as Premium App | **BLOCKED** | None recorded |
+| Notion | `notion`; current Pipedream app catalog | Not listed as Premium App | **BLOCKED** | None recorded |
+| Figma | `figma`; Pipedream example shows OAuth access token and `/v1/me` read | Not listed as Premium App | **BLOCKED** | None recorded |
+| PostHog | `posthog`; Pipedream example shows API-key auth and `/api/users/@me/` read | Not listed as Premium App | **BLOCKED** | None recorded |
+| Jira | `jira`; Pipedream example shows OAuth and `https://api.atlassian.com/me` | Jira is listed as a Premium App | **BLOCKED** | None recorded |
+| Stripe | `stripe`; Pipedream example shows API-key auth | Stripe is listed as a Premium App | **BLOCKED** | None recorded |
+
+Sources consulted: Pipedream's official app catalog, app-discovery/API documentation, and Premium Apps list. Documentation confirms candidate slugs and auth shapes, but it does not replace the required connected-account spike.
+
+## Release rule
+
+- Do not hand-author or infer component keys. `discoverComponentKeys()` only accepts keys returned by the live SDK action catalog.
+- PostHog and Jira actions have no speculative component keys or direct endpoint contracts. They deliberately fail as not implemented until the live spike records compatible SDK components.
+- The remaining new providers use explicitly reviewed direct API routes, but their end-to-end release gate is still a successful development-account read.
+- Stripe must use a connected restricted read-only key (`rk_...`) scoped only to the catalog reads. Matrix billing Stripe credentials are never accepted by this flow.
+
+## Granola verification
+
+Granola's current official documentation confirms the public endpoint `https://mcp.granola.ai/mcp`, Streamable HTTP, browser OAuth with bearer tokens, and no MCP API-key/service-account mode. The upstream tools currently documented are `list_meetings`, `get_meetings`, and paid-plan-only `get_meeting_transcript`; Matrix maps these to stable `list_notes` and `get_note` actions after runtime schema discovery.
+
+The live Granola OAuth/read spike is also account-gated and remains **BLOCKED** in this checkout.

--- a/specs/118-integration-expansion/spec.md
+++ b/specs/118-integration-expansion/spec.md
@@ -1,0 +1,72 @@
+# Managed integrations and Custom MCP expansion
+
+## Outcome
+
+Matrix preserves the existing seven integrations and adds Google Docs, Notion,
+Figma, PostHog, Jira, Stripe, and Granola. The ordinary providers use
+Pipedream; Granola is a curated OAuth Streamable HTTP preset. Personal Custom
+MCP is platform brokered and available in Canvas and desktop settings.
+
+The live provider-account release gate and evidence live in
+`SDK-VERIFICATION.md`. Missing credentials in the implementation checkout are
+recorded as a blocker rather than replaced with inferred component keys.
+
+## Trust boundaries
+
+| Boundary | Secret-bearing | Enforcement |
+| --- | --- | --- |
+| Platform Postgres | AES-256-GCM credential envelopes | dedicated required key; random nonce; owner + server AAD |
+| Platform broker | decrypted credential in request memory | owner checks, revision checks, limits, OAuth rotation/revocation |
+| Customer VPS | no MCP/provider credential | atomic `~/system/mcp-servers.json` projection |
+| Kernel | no upstream credential | generic list/describe/call tools; external-content wrapper; approvals |
+| Apps | no Custom MCP access in v1 | no `window.MatrixOS.service()` or manifest bridge |
+
+Effective permission is `platform.enabled ∩ local.enabled` at an identical
+revision. Missing, stale, disabled, or mismatched state fails closed.
+
+## Lifecycle and failure behavior
+
+- Create: validate URL → create `pending` database row → atomically project →
+  activate. Pending rows expire after 24 hours.
+- Discover: initialize current Streamable HTTP, cap catalog/schema sizes, and
+  persist every discovered tool disabled with `always_ask`.
+- Enable: requires at least one selected tool and optimistic revision match.
+- Remove: disable platform row first → remove projection → revoke OAuth →
+  delete. Revocation/projection failure leaves `action_required` visible.
+- Calls: revalidate URL and DNS, pin the validated address, reject redirects,
+  apply 30-second timeout/64 KB request/1 MB response bounds, and wrap output
+  as untrusted content.
+- Session clients use capped TTL/LRU reuse; stale/failing clients are isolated,
+  and shutdown sends best-effort MCP session DELETE drains.
+
+## Authentication matrix
+
+| Mode | Stored platform-side | Notes |
+| --- | --- | --- |
+| none | nothing | HTTPS only |
+| OAuth | access/rotating refresh token and discovered metadata | discovery, PKCE S256, expiring one-time state, resource audience binding |
+| bearer | encrypted token | emits only `Authorization: Bearer` |
+| api_key | encrypted token | emits only compile-time `X-API-Key` name |
+
+Custom header names are never user controlled. Managed direct APIs may define
+compile-time static headers such as Notion's API version.
+
+## Resource limits
+
+- 20 personal servers per owner; curated presets do not consume this quota
+- 100 tools per server; 32 KB per input schema
+- 64 KB mutation and upstream request bodies; 1 MB upstream response
+- 10 seconds for OAuth/discovery; 30 seconds for tool calls
+- 60 owner mutations per minute and bounded route rate-state memory
+
+## Runtime wiring
+
+Public `/api/mcp-servers` routes are Clerk-session owned. Customer gateways
+proxy kernel calls to `/internal/containers/:handle/mcp-servers` using the
+exact customer-host credential; platform resolution binds the same handle and
+Clerk user. Projection writes go in the opposite direction to an internal VPS
+route authenticated by that exact credential and expected owner ID.
+
+The primary kernel can use enabled servers. A custom subagent call is denied
+unless its YAML `mcp` frontmatter names the server ID or name. No upstream
+server is injected into Agent SDK `mcpServers`.

--- a/tests/integrations/action-execution.test.ts
+++ b/tests/integrations/action-execution.test.ts
@@ -55,33 +55,32 @@ describe("executeIntegrationAction", () => {
     expect(pipedream.proxyPost).not.toHaveBeenCalled();
   });
 
-  it("dispatches DELETE directApi actions with proxyDelete", async () => {
-    const pipedream = mockPipedream();
-    vi.mocked(pipedream.proxyDelete).mockResolvedValue(undefined);
 
-    const service = getService("google_calendar")!;
-    const action = getAction("google_calendar", "delete_event")!;
+  it("forwards only registry-owned static headers to the provider proxy", async () => {
+    const pipedream = mockPipedream();
+    vi.mocked(pipedream.proxyPost).mockResolvedValue({ results: [] });
 
     await executeIntegrationAction({
       pipedream,
       externalUserId: "user-1",
       connection: { pipedream_account_id: "acc-1" },
-      def: service,
-      actionDef: action,
-      serviceId: "google_calendar",
-      actionId: "delete_event",
+      def: getService("notion")!,
+      actionDef: getAction("notion", "search")!,
+      serviceId: "notion",
+      actionId: "search",
       params: {
-        eventId: "evt_456",
+        query: "roadmap",
+        headers: { Authorization: "attacker-controlled" },
       },
     });
 
-    expect(pipedream.proxyDelete).toHaveBeenCalledWith({
+    expect(pipedream.proxyPost).toHaveBeenCalledWith({
       externalUserId: "user-1",
       accountId: "acc-1",
-      url: "https://www.googleapis.com/calendar/v3/calendars/primary/events/evt_456",
-      params: undefined,
+      url: "https://api.notion.com/v1/search",
+      body: { query: "roadmap" },
+      headers: { "Notion-Version": "2022-06-28" },
     });
-    expect(pipedream.proxyPost).not.toHaveBeenCalled();
   });
 
   it("throws a not-implemented error instead of calling a fabricated fallback URL", async () => {

--- a/tests/integrations/custom-mcp-client.test.ts
+++ b/tests/integrations/custom-mcp-client.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  RemoteMcpClient,
+  type RemoteMcpRequest,
+  type RemoteMcpRequester,
+} from "../../packages/gateway/src/integrations/custom-mcp/client.js";
+
+function requester(responses: Array<{ body?: unknown; headers?: Record<string, string>; status?: number }>): RemoteMcpRequester {
+  return vi.fn(async (_request: RemoteMcpRequest) => {
+    const response = responses.shift();
+    if (!response) throw new Error("Unexpected MCP request");
+    return {
+      status: response.status ?? 200,
+      headers: response.headers ?? {},
+      body: response.body,
+    };
+  });
+}
+
+describe("remote Streamable HTTP MCP client", () => {
+  it("initializes, pins a session, and discovers bounded disabled tools", async () => {
+    const request = requester([
+      {
+        headers: { "mcp-session-id": "session-1" },
+        body: { jsonrpc: "2.0", id: 1, result: { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "test", version: "1" } } },
+      },
+      { body: undefined },
+      {
+        body: {
+          jsonrpc: "2.0",
+          id: 2,
+          result: {
+            tools: [{ name: "search", description: "Search safely", inputSchema: { type: "object", properties: {} } }],
+          },
+        },
+      },
+    ]);
+    const client = new RemoteMcpClient({ requester: request });
+    const tools = await client.discover({
+      serverId: "server-1",
+      url: "https://mcp.acme.tools/mcp",
+      authorization: "Bearer hidden",
+    });
+
+    expect(tools).toEqual([{
+      name: "search",
+      description: "Search safely",
+      inputSchema: { type: "object", properties: {} },
+      approval: "always_ask",
+      enabled: false,
+    }]);
+    expect(request).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      headers: expect.objectContaining({
+        authorization: "Bearer hidden",
+        "mcp-session-id": "session-1",
+      }),
+      timeoutMs: 10_000,
+    }));
+  });
+
+  it("refuses schemas over 32 KB and catalogs over 100 tools", async () => {
+    const hugeSchema = { description: "x".repeat(33 * 1024) };
+    const request = requester([
+      { body: { jsonrpc: "2.0", id: 1, result: { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "test", version: "1" } } } },
+      { body: undefined },
+      { body: { jsonrpc: "2.0", id: 2, result: { tools: [{ name: "huge", inputSchema: hugeSchema }] } } },
+    ]);
+    await expect(new RemoteMcpClient({ requester: request }).discover({
+      serverId: "server-1",
+      url: "https://mcp.acme.tools/mcp",
+    })).rejects.toThrow(/schema limit/i);
+
+    const tooMany = Array.from({ length: 101 }, (_, index) => ({
+      name: `tool_${index}`,
+      inputSchema: { type: "object" },
+    }));
+    const manyRequest = requester([
+      { body: { jsonrpc: "2.0", id: 1, result: { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "test", version: "1" } } } },
+      { body: undefined },
+      { body: { jsonrpc: "2.0", id: 2, result: { tools: tooMany } } },
+    ]);
+    await expect(new RemoteMcpClient({ requester: manyRequest }).discover({
+      serverId: "server-1",
+      url: "https://mcp.acme.tools/mcp",
+    })).rejects.toThrow(/tool limit/i);
+  });
+
+  it("uses the 30-second timeout for tool calls", async () => {
+    const request = requester([
+      { body: { jsonrpc: "2.0", id: 1, result: { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "test", version: "1" } } } },
+      { body: undefined },
+      { body: { jsonrpc: "2.0", id: 2, result: { content: [{ type: "text", text: "ok" }] } } },
+    ]);
+    const client = new RemoteMcpClient({ requester: request });
+    await client.callTool({
+      serverId: "server-1",
+      url: "https://mcp.acme.tools/mcp",
+      toolName: "search",
+      arguments: { q: "matrix" },
+    });
+    expect(request).toHaveBeenNthCalledWith(3, expect.objectContaining({ timeoutMs: 30_000 }));
+  });
+
+  it("reuses bounded sessions and drains them on shutdown", async () => {
+    const request = requester([
+      { headers: { "mcp-session-id": "session-1" }, body: { jsonrpc: "2.0", id: 1, result: { protocolVersion: "2025-06-18" } } },
+      { body: undefined },
+      { body: { jsonrpc: "2.0", id: 2, result: { tools: [] } } },
+      { body: { jsonrpc: "2.0", id: 3, result: { tools: [] } } },
+      { body: undefined },
+    ]);
+    const client = new RemoteMcpClient({ requester: request });
+    const connection = { serverId: "server-1", url: "https://mcp.acme.tools/mcp" };
+    await client.discover(connection);
+    await client.discover(connection);
+    await client.shutdown();
+    expect(request).toHaveBeenCalledTimes(5);
+    expect(request).toHaveBeenLastCalledWith(expect.objectContaining({
+      method: "DELETE",
+      headers: expect.objectContaining({ "mcp-session-id": "session-1" }),
+    }));
+  });
+
+  it("coalesces concurrent initialization and drains the shared session once", async () => {
+    let releaseInitialize!: () => void;
+    const initializeGate = new Promise<void>((resolve) => {
+      releaseInitialize = resolve;
+    });
+    const request = vi.fn(async (input: RemoteMcpRequest) => {
+      const body = input.body as { method?: string; id?: number } | undefined;
+      if (body?.method === "initialize") {
+        await initializeGate;
+        return {
+          status: 200,
+          headers: { "mcp-session-id": "shared-session" },
+          body: {
+            jsonrpc: "2.0",
+            id: body.id,
+            result: { protocolVersion: "2025-06-18" },
+          },
+        };
+      }
+      if (body?.method === "tools/list") {
+        return {
+          status: 200,
+          headers: {},
+          body: { jsonrpc: "2.0", id: body.id, result: { tools: [] } },
+        };
+      }
+      return { status: 200, headers: {}, body: undefined };
+    });
+    const client = new RemoteMcpClient({ requester: request });
+    const connection = { serverId: "server-1", url: "https://mcp.acme.tools/mcp" };
+
+    const first = client.discover(connection);
+    const second = client.discover(connection);
+    await vi.waitFor(() => {
+      expect(request.mock.calls.filter(([input]) =>
+        (input.body as { method?: string } | undefined)?.method === "initialize"))
+        .toHaveLength(1);
+    });
+    releaseInitialize();
+    await Promise.all([first, second]);
+    await client.shutdown();
+
+    expect(request.mock.calls.filter(([input]) =>
+      (input.body as { method?: string } | undefined)?.method === "initialize"))
+      .toHaveLength(1);
+    expect(request.mock.calls.filter(([input]) => input.method === "DELETE"))
+      .toHaveLength(1);
+  });
+
+  it("does not initialize a new session after shutdown starts during eviction", async () => {
+    let now = 0;
+    let releaseEviction!: () => void;
+    const evictionGate = new Promise<void>((resolve) => {
+      releaseEviction = resolve;
+    });
+    let initializeCount = 0;
+    const request = vi.fn(async (input: RemoteMcpRequest) => {
+      const body = input.body as { method?: string; id?: number } | undefined;
+      if (input.method === "DELETE") {
+        await evictionGate;
+        return { status: 204, headers: {}, body: undefined };
+      }
+      if (body?.method === "initialize") {
+        initializeCount += 1;
+        return {
+          status: 200,
+          headers: { "mcp-session-id": `session-${initializeCount}` },
+          body: {
+            jsonrpc: "2.0",
+            id: body.id,
+            result: { protocolVersion: "2025-06-18" },
+          },
+        };
+      }
+      if (body?.method === "tools/list") {
+        return {
+          status: 200,
+          headers: {},
+          body: { jsonrpc: "2.0", id: body.id, result: { tools: [] } },
+        };
+      }
+      return { status: 200, headers: {}, body: undefined };
+    });
+    const client = new RemoteMcpClient({ requester: request, sessionTtlMs: 1, now: () => now });
+    const connection = { serverId: "server-1", url: "https://mcp.acme.tools/mcp" };
+
+    await client.discover(connection);
+    now = 2;
+    const lateDiscovery = client.discover(connection);
+    await vi.waitFor(() => expect(request.mock.calls.some(([input]) => input.method === "DELETE")).toBe(true));
+    await client.shutdown();
+    releaseEviction();
+
+    await expect(lateDiscovery).rejects.toThrow(/shutting down/i);
+    expect(initializeCount).toBe(1);
+  });
+});

--- a/tests/integrations/custom-mcp-crypto.test.ts
+++ b/tests/integrations/custom-mcp-crypto.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  decryptCustomMcpCredential,
+  encryptCustomMcpCredential,
+  parseCustomMcpEncryptionKey,
+} from "../../packages/gateway/src/integrations/custom-mcp/crypto.js";
+
+describe("Custom MCP credential encryption", () => {
+  const key = Buffer.alloc(32, 7).toString("base64");
+
+  it("round-trips AES-256-GCM credentials with owner/server-bound AAD", () => {
+    const encrypted = encryptCustomMcpCredential(
+      { authorization: "Bearer secret-token" },
+      parseCustomMcpEncryptionKey(key),
+      { userId: "user-1", serverId: "server-1" },
+    );
+
+    expect(encrypted).not.toContain("secret-token");
+    expect(decryptCustomMcpCredential(
+      encrypted,
+      parseCustomMcpEncryptionKey(key),
+      { userId: "user-1", serverId: "server-1" },
+    )).toEqual({ authorization: "Bearer secret-token" });
+  });
+
+  it("fails closed when the owner or server binding changes", () => {
+    const encrypted = encryptCustomMcpCredential(
+      { apiKey: "hidden" },
+      parseCustomMcpEncryptionKey(key),
+      { userId: "user-1", serverId: "server-1" },
+    );
+
+    expect(() => decryptCustomMcpCredential(
+      encrypted,
+      parseCustomMcpEncryptionKey(key),
+      { userId: "user-2", serverId: "server-1" },
+    )).toThrow();
+  });
+
+  it("rejects missing, short, and malformed dedicated keys", () => {
+    expect(() => parseCustomMcpEncryptionKey(undefined)).toThrow(/MCP_CREDENTIAL_ENCRYPTION_KEY/);
+    expect(() => parseCustomMcpEncryptionKey(Buffer.alloc(16).toString("base64"))).toThrow(/32 bytes/);
+    expect(() => parseCustomMcpEncryptionKey("not base64!" )).toThrow(/32 bytes/);
+  });
+});

--- a/tests/integrations/custom-mcp-db.test.ts
+++ b/tests/integrations/custom-mcp-db.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { KyselyPGlite } from "kysely-pglite";
+import {
+  createPlatformDb,
+  type PlatformDb,
+} from "../../packages/gateway/src/platform-db.js";
+
+describe("Custom MCP platform persistence", () => {
+  let db: PlatformDb;
+  let pglite: InstanceType<typeof KyselyPGlite>;
+  let userId: string;
+
+  beforeEach(async () => {
+    pglite = await KyselyPGlite.create();
+    db = createPlatformDb({ dialect: pglite.dialect });
+    await db.migrate();
+    userId = (await db.createUser({
+      clerkId: "clerk-custom-mcp",
+      handle: "custom-mcp",
+      displayName: "Custom MCP",
+      email: "mcp@example.test",
+      containerId: "container-custom-mcp",
+    })).id;
+  });
+
+  afterEach(async () => db.destroy());
+
+  it("creates pending records and never exposes encrypted credentials in public rows", async () => {
+    const row = await db.createCustomMcpServer({
+      userId,
+      name: "Research",
+      url: "https://mcp.acme.tools/mcp",
+      authMode: "bearer",
+      encryptedCredentials: "v1.nonce.ciphertext.tag",
+      pendingExpiresAt: new Date(Date.now() + 86_400_000),
+    });
+
+    expect(row.status).toBe("pending");
+    expect(row.revision).toBe(1);
+    const publicRows = await db.listCustomMcpServers(userId);
+    expect(publicRows).toHaveLength(1);
+    expect(publicRows[0]).not.toHaveProperty("encrypted_credentials");
+
+    const privateRow = await db.getCustomMcpServerForBroker(row.id, userId);
+    expect(privateRow?.encrypted_credentials).toBe("v1.nonce.ciphertext.tag");
+  });
+
+  it("enforces optimistic revisions inside the UPDATE statement", async () => {
+    const row = await db.createCustomMcpServer({
+      userId,
+      name: "Research",
+      url: "https://mcp.acme.tools/mcp",
+      authMode: "none",
+      pendingExpiresAt: new Date(Date.now() + 86_400_000),
+    });
+
+    const updated = await db.updateCustomMcpServer(row.id, userId, 1, {
+      name: "Research v2",
+      enabled: true,
+      status: "ready",
+      tools: [{
+        name: "search",
+        description: "Search",
+        inputSchema: { type: "object" },
+        approval: "always_ask",
+        enabled: true,
+      }],
+    });
+    expect(updated?.revision).toBe(2);
+    expect(updated?.name).toBe("Research v2");
+
+    expect(await db.updateCustomMcpServer(row.id, userId, 1, {
+      name: "stale write",
+    })).toBeNull();
+  });
+
+  it("sweeps only abandoned pending records older than 24 hours", async () => {
+    await db.createCustomMcpServer({
+      userId,
+      name: "Expired",
+      url: "https://mcp.acme.tools/mcp",
+      authMode: "none",
+      pendingExpiresAt: new Date(Date.now() - 1_000),
+    });
+    const active = await db.createCustomMcpServer({
+      userId,
+      name: "Active",
+      url: "https://mcp.acme.tools/active",
+      authMode: "none",
+      pendingExpiresAt: new Date(Date.now() + 86_400_000),
+    });
+    await db.updateCustomMcpServer(active.id, userId, 1, { status: "ready" });
+
+    expect(await db.sweepPendingCustomMcpServers(new Date())).toBe(1);
+    expect((await db.listCustomMcpServers(userId)).map((server) => server.name)).toEqual(["Active"]);
+  });
+});

--- a/tests/integrations/custom-mcp-gateway-wiring.test.ts
+++ b/tests/integrations/custom-mcp-gateway-wiring.test.ts
@@ -1,0 +1,38 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { registerCustomMcpGatewayRoutes } from "../../packages/gateway/src/integrations/custom-mcp/gateway-routes.js";
+
+describe("Custom MCP gateway route composition", () => {
+  it("mounts the authenticated projection endpoint", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-mcp-gateway-"));
+    const app = new Hono();
+    registerCustomMcpGatewayRoutes(app, {
+      homePath,
+      clerkUserId: "user_123",
+      projectionToken: "projection-secret",
+    });
+
+    const response = await app.request("/api/internal/mcp-projection", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer projection-secret",
+        "content-type": "application/json",
+        "x-matrix-clerk-user-id": "user_123",
+      },
+      body: JSON.stringify({
+        id: "11111111-1111-4111-8111-111111111111",
+        name: "Research",
+        url: "https://mcp.acme.tools/mcp",
+        authMode: "none",
+        enabled: false,
+        revision: 1,
+        tools: [],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/tests/integrations/custom-mcp-oauth.test.ts
+++ b/tests/integrations/custom-mcp-oauth.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { CustomMcpOAuthManager } from "../../packages/gateway/src/integrations/custom-mcp/oauth.js";
+import { decryptCustomMcpCredential } from "../../packages/gateway/src/integrations/custom-mcp/crypto.js";
+import type { PlatformDb } from "../../packages/gateway/src/platform-db.js";
+
+describe("Custom MCP OAuth", () => {
+  it("discovers metadata and creates expiring PKCE S256 state encrypted at rest", async () => {
+    const key = Buffer.alloc(32, 9);
+    let encrypted = "";
+    const row = {
+      id: "012b72f8-33e3-455f-9ee3-dc15069932bb",
+      user_id: "owner",
+      url: "https://mcp.acme.tools/mcp",
+      auth_mode: "oauth",
+      revision: 2,
+    };
+    const db = {
+      getCustomMcpServerForBroker: vi.fn(async () => row),
+      updateCustomMcpCredentials: vi.fn(async (_id, _user, _revision, value) => { encrypted = value; return true; }),
+    } as unknown as PlatformDb;
+    const request = vi.fn()
+      .mockResolvedValueOnce({ status: 200, body: { resource: row.url, authorization_servers: ["https://auth.acme.tools"] } })
+      .mockResolvedValueOnce({ status: 200, body: {
+        authorization_endpoint: "https://auth.acme.tools/authorize",
+        token_endpoint: "https://auth.acme.tools/token",
+        code_challenge_methods_supported: ["S256"],
+      } });
+    const oauth = new CustomMcpOAuthManager({
+      db,
+      encryptionKey: key,
+      clientId: "matrix-client",
+      redirectUri: "https://app.matrix-os.com/api/mcp-servers/oauth/callback",
+      now: () => new Date("2026-08-29T00:00:00.000Z"),
+      request,
+      validateUrl: vi.fn(async (url: string) => ({ url: new URL(url), address: "93.184.216.34", family: 4 as const })),
+    });
+    const authorization = new URL(await oauth.start("owner", row.id));
+    expect(authorization.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(authorization.searchParams.get("resource")).toBe(row.url);
+    expect(authorization.searchParams.get("state")).toHaveLength(43);
+    expect(encrypted).not.toContain(authorization.searchParams.get("state")!);
+    const credential = decryptCustomMcpCredential<any>(encrypted, key, { userId: "owner", serverId: row.id });
+    expect(credential.oauth.stateExpiresAt).toBe("2026-08-29T00:10:00.000Z");
+    expect(credential.oauth.verifier.length).toBeGreaterThan(43);
+  });
+});

--- a/tests/integrations/custom-mcp-preset-oauth.test.ts
+++ b/tests/integrations/custom-mcp-preset-oauth.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { KyselyPGlite } from "kysely-pglite";
+import { createPlatformDb } from "../../packages/gateway/src/platform-db.js";
+import { CustomMcpOAuthManager } from "../../packages/gateway/src/integrations/custom-mcp/oauth.js";
+
+describe("managed preset OAuth callback", () => {
+  it.each(["granola", undefined])("completes owner-scoped OAuth once for preset %s", async (presetId) => {
+    const pg = await KyselyPGlite.create();
+    const db = createPlatformDb({ dialect: pg.dialect });
+    try {
+      await db.migrate();
+      const owner = await db.createUser({ clerkId: "review-owner", handle: "review-owner", displayName: "Review", email: "review@example.test", containerId: "review-container" });
+      const server = await db.createCustomMcpServer({ userId: owner.id, presetId, name: "Research", url: "https://mcp.acme.tools/mcp", authMode: "oauth", pendingExpiresAt: new Date(Date.now() + 86400000) });
+      const request = vi.fn()
+        .mockResolvedValueOnce({ status: 200, body: { resource: "https://mcp.acme.tools/mcp", authorization_servers: ["https://auth.acme.tools"] } })
+        .mockResolvedValueOnce({ status: 200, body: { authorization_endpoint: "https://auth.acme.tools/authorize", token_endpoint: "https://auth.acme.tools/token", code_challenge_methods_supported: ["S256"] } })
+        .mockResolvedValueOnce({ status: 200, body: { access_token: "test-only", token_type: "Bearer" } });
+      const manager = new CustomMcpOAuthManager({ db, encryptionKey: Buffer.alloc(32, 1), clientId: "review", redirectUri: "https://app.matrix-os.com/api/mcp-servers/oauth/callback", request,
+        validateUrl: vi.fn(async (url: string) => ({ url: new URL(url), address: "93.184.216.34", family: 4 as const })) });
+      const url = new URL(await manager.start(owner.id, server.id));
+      const state = url.searchParams.get("state")!;
+      const stranger = await db.createUser({ clerkId: "other-owner", handle: "other-owner", displayName: "Other", email: "other@example.test", containerId: "other-container" });
+      await expect(manager.complete(stranger.id, state, "test-code")).rejects.toMatchObject({ code: "invalid" });
+      expect(request).toHaveBeenCalledTimes(2);
+      const publicRows = await db.listCustomMcpServers(owner.id);
+      expect(publicRows).toHaveLength(presetId ? 0 : 1);
+      const completions = await Promise.allSettled([
+        manager.complete(owner.id, state, "test-code"),
+        manager.complete(owner.id, state, "test-code"),
+      ]);
+      expect(completions.filter((result) => result.status === "fulfilled")).toEqual([
+        { status: "fulfilled", value: { serverId: server.id } },
+      ]);
+      expect(completions.filter((result) => result.status === "rejected")).toHaveLength(1);
+      await expect(manager.complete(owner.id, state, "test-code")).rejects.toMatchObject({ code: "invalid" });
+      expect(request).toHaveBeenCalledTimes(3);
+    } finally { await db.destroy(); }
+  });
+
+});

--- a/tests/integrations/custom-mcp-projection.test.ts
+++ b/tests/integrations/custom-mcp-projection.test.ts
@@ -1,0 +1,59 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  CustomMcpProjectionStore,
+} from "../../packages/gateway/src/integrations/custom-mcp/projection-store.js";
+
+describe("Custom MCP owner-visible projection", () => {
+  it("persists only non-secret fields atomically", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-mcp-projection-"));
+    const store = new CustomMcpProjectionStore(homePath);
+    await store.upsert({
+      id: "11111111-1111-4111-8111-111111111111",
+      name: "Research",
+      url: "https://mcp.acme.tools/mcp",
+      authMode: "bearer",
+      enabled: true,
+      revision: 2,
+      tools: [{ name: "search", enabled: true, approval: "always_ask" }],
+    });
+
+    const raw = await readFile(join(homePath, "system", "mcp-servers.json"), "utf8");
+    expect(JSON.parse(raw)).toEqual({
+      version: 1,
+      servers: [{
+        id: "11111111-1111-4111-8111-111111111111",
+        name: "Research",
+        url: "https://mcp.acme.tools/mcp",
+        authMode: "bearer",
+        enabled: true,
+        revision: 2,
+        tools: [{ name: "search", enabled: true, approval: "always_ask" }],
+      }],
+    });
+    expect(raw).not.toMatch(/token|authorization|credential|oauth/i);
+  });
+
+  it("removes one server without disturbing other projections", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-mcp-projection-"));
+    const store = new CustomMcpProjectionStore(homePath);
+    const base = {
+      name: "Server",
+      url: "https://mcp.acme.tools/mcp",
+      authMode: "none" as const,
+      enabled: false,
+      revision: 1,
+      tools: [],
+    };
+    await store.upsert({ ...base, id: "11111111-1111-4111-8111-111111111111" });
+    await store.upsert({ ...base, id: "22222222-2222-4222-8222-222222222222" });
+    await store.remove("11111111-1111-4111-8111-111111111111");
+
+    const projection = await store.read();
+    expect(projection.servers.map((server) => server.id)).toEqual([
+      "22222222-2222-4222-8222-222222222222",
+    ]);
+  });
+});

--- a/tests/integrations/custom-mcp-routes.test.ts
+++ b/tests/integrations/custom-mcp-routes.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCustomMcpRoutes } from "../../packages/gateway/src/integrations/custom-mcp/routes.js";
+import type { CustomMcpBroker } from "../../packages/gateway/src/integrations/custom-mcp/broker.js";
+
+function broker() {
+  return {
+    list: vi.fn(async () => []),
+    describe: vi.fn(), create: vi.fn(), patch: vi.fn(), remove: vi.fn(),
+    discover: vi.fn(), test: vi.fn(), callSelectedTool: vi.fn(),
+  } as unknown as CustomMcpBroker;
+}
+
+describe("Custom MCP HTTP boundary", () => {
+  it("checks owner identity before revealing whether an id exists", async () => {
+    const service = broker();
+    const app = createCustomMcpRoutes({ broker: service, resolveUserId: async () => null });
+    const response = await app.request("/5f03d43b-bbc4-47f0-97d2-a281cf15c4c3");
+    expect(response.status).toBe(401);
+    expect(service.describe).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown fields and credentials for no-auth servers", async () => {
+    const app = createCustomMcpRoutes({ broker: broker(), resolveUserId: async () => "owner" });
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Docs", url: "https://mcp.acme.tools/mcp", authMode: "none", credential: "secret" }),
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it("returns a generic client error for a broker-rejected URL", async () => {
+    const service = broker();
+    // Use the actual error class shape so no URL details escape the boundary.
+    const { CustomMcpBrokerError } = await import("../../packages/gateway/src/integrations/custom-mcp/broker.js");
+    vi.mocked(service.create).mockRejectedValueOnce(new CustomMcpBrokerError("invalid"));
+    const app = createCustomMcpRoutes({ broker: service, resolveUserId: async () => "owner" });
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Local", url: "http://127.0.0.1/mcp", authMode: "none" }),
+    });
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid Custom MCP request" });
+  });
+
+  it("does not expose the broker call route on public route sets", async () => {
+    const service = broker();
+    const app = createCustomMcpRoutes({ broker: service, resolveUserId: async () => "owner" });
+    const response = await app.request("/5f03d43b-bbc4-47f0-97d2-a281cf15c4c3/call", { method: "POST" });
+    expect(response.status).toBe(404);
+    expect(service.callSelectedTool).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integrations/custom-mcp-security.test.ts
+++ b/tests/integrations/custom-mcp-security.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CustomMcpUrlError,
+  validateCustomMcpUrl,
+} from "../../packages/gateway/src/integrations/custom-mcp/security.js";
+
+describe("Custom MCP remote URL validation", () => {
+  const resolvePublic = vi.fn(async () => [{ address: "93.184.216.34", family: 4 as const }]);
+
+  it("accepts HTTPS and returns the DNS-pinned public address", async () => {
+    const result = await validateCustomMcpUrl("https://mcp.acme.tools/tools", resolvePublic);
+    expect(result.url.href).toBe("https://mcp.acme.tools/tools");
+    expect(result.address).toBe("93.184.216.34");
+  });
+
+  it("accepts public HTTPS servers on explicit ports and IPv6 literals", async () => {
+    await expect(validateCustomMcpUrl("https://mcp.acme.tools:8443/mcp", resolvePublic)).resolves.toMatchObject({ address: "93.184.216.34" });
+    await expect(validateCustomMcpUrl("https://[2606:4700:4700::1111]/mcp", resolvePublic)).resolves.toMatchObject({ family: 6 });
+  });
+
+  it.each([
+    "http://mcp.example.com/mcp",
+    "https://user:pass@mcp.example.com/mcp",
+    "https://mcp.example.com/mcp#fragment",
+    "https://localhost/mcp",
+    "https://127.0.0.1/mcp",
+    "https://169.254.169.254/latest/meta-data",
+    "https://192.0.2.10/mcp",
+    "https://224.0.0.1/mcp",
+  ])("rejects unsafe URL %s", async (url) => {
+    await expect(validateCustomMcpUrl(url, resolvePublic)).rejects.toBeInstanceOf(CustomMcpUrlError);
+  });
+
+  it("rejects DNS rebinding targets before a request is sent", async () => {
+    await expect(validateCustomMcpUrl(
+      "https://mcp.acme.tools/mcp",
+      vi.fn(async () => [{ address: "10.0.0.9", family: 4 as const }]),
+    )).rejects.toBeInstanceOf(CustomMcpUrlError);
+  });
+});

--- a/tests/integrations/registry.test.ts
+++ b/tests/integrations/registry.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
 import {
   SERVICE_REGISTRY,
   getService,
@@ -79,6 +80,16 @@ describe("Service Registry", () => {
         expect(["read", "write", "destructive"]).toContain(action.risk);
       }
     }
+  });
+
+  it("requires explicit risk metadata at the registry definition boundary", () => {
+    const source = readFileSync(new URL(
+      "../../packages/gateway/src/integrations/registry.ts",
+      import.meta.url,
+    ), "utf8");
+
+    expect(source).not.toContain("risk?: IntegrationActionRisk");
+    expect(source).not.toContain("WRITE_ACTIONS");
   });
 
   it("contains the seven expansion services with stable action contracts", () => {

--- a/tests/integrations/registry.test.ts
+++ b/tests/integrations/registry.test.ts
@@ -10,9 +10,9 @@ import {
 import type { PipedreamConnectClient } from "../../packages/gateway/src/integrations/pipedream.js";
 
 describe("Service Registry", () => {
-  it("has 7 launch services", () => {
-    expect(listServices()).toHaveLength(7);
-    expect(Object.keys(SERVICE_REGISTRY)).toHaveLength(7);
+  it("has the 14-service managed catalog", () => {
+    expect(listServices()).toHaveLength(14);
+    expect(Object.keys(SERVICE_REGISTRY)).toHaveLength(14);
   });
 
   it("returns service by id", () => {
@@ -69,9 +69,92 @@ describe("Service Registry", () => {
       expect(service.id).toBeTruthy();
       expect(service.name).toBeTruthy();
       expect(service.category).toBeTruthy();
-      expect(service.pipedreamApp).toBeTruthy();
+      expect(["pipedream", "mcp_preset"]).toContain(service.connectorKind);
+      if (service.connectorKind === "pipedream") {
+        expect(service.pipedreamApp).toBeTruthy();
+      }
       expect(service.icon).toBeTruthy();
       expect(Object.keys(service.actions).length).toBeGreaterThan(0);
+      for (const action of Object.values(service.actions)) {
+        expect(["read", "write", "destructive"]).toContain(action.risk);
+      }
+    }
+  });
+
+  it("contains the seven expansion services with stable action contracts", () => {
+    const expected: Record<string, { read: string[]; write: string[] }> = {
+      google_docs: {
+        read: ["get_document"],
+        write: ["create_document", "batch_update_document"],
+      },
+      notion: {
+        read: ["search", "get_page", "query_database"],
+        write: ["create_page", "update_page", "append_blocks"],
+      },
+      figma: {
+        read: ["get_file", "get_nodes", "list_comments"],
+        write: ["post_comment"],
+      },
+      posthog: {
+        read: ["list_projects", "list_insights", "get_insight", "query"],
+        write: [],
+      },
+      jira: {
+        read: ["list_projects", "search_issues", "get_issue"],
+        write: ["create_issue", "update_issue", "add_comment"],
+      },
+      stripe: {
+        read: [
+          "list_customers",
+          "get_customer",
+          "list_subscriptions",
+          "list_invoices",
+          "list_payment_intents",
+          "get_balance",
+        ],
+        write: [],
+      },
+      granola: {
+        read: ["list_notes", "get_note"],
+        write: [],
+      },
+    };
+
+    for (const [serviceId, contract] of Object.entries(expected)) {
+      const service = getService(serviceId);
+      expect(service, serviceId).toBeDefined();
+      expect(Object.keys(service!.actions)).toEqual([
+        ...contract.read,
+        ...contract.write,
+      ]);
+      for (const action of contract.read) {
+        expect(service!.actions[action]!.risk).toBe("read");
+      }
+      for (const action of contract.write) {
+        expect(service!.actions[action]!.risk).toBe("write");
+      }
+    }
+
+    expect(getService("granola")).toMatchObject({
+      connectorKind: "mcp_preset",
+      mcpPreset: { url: "https://mcp.granola.ai/mcp", authMode: "oauth" },
+    });
+  });
+
+  it("keeps Stripe, PostHog, and Granola strictly read-only", () => {
+    for (const serviceId of ["stripe", "posthog", "granola"]) {
+      const actions = Object.values(getService(serviceId)!.actions);
+      expect(actions.every((action) => action.risk === "read"), serviceId).toBe(true);
+    }
+  });
+
+  it("uses only compile-time static header names", () => {
+    const notion = getService("notion")!;
+    for (const action of Object.values(notion.actions)) {
+      expect(action.directApi?.staticHeaders).toEqual({
+        "Notion-Version": "2022-06-28",
+      });
+      expect(action.params).not.toHaveProperty("headers");
     }
   });
 
@@ -86,7 +169,7 @@ describe("Service Registry", () => {
     expect(ids).toContain("discord");
   });
 
-  it("exposes Linear project, issue, workflow, comment, and GraphQL actions", () => {
+  it("exposes bounded Linear project, issue, workflow, and comment actions", () => {
     const linear = getService("linear");
     expect(linear).toBeDefined();
     expect(linear!.name).toBe("Linear");
@@ -104,17 +187,21 @@ describe("Service Registry", () => {
       "update_issue",
       "comment_issue",
       "create_workflow_state",
-      "graphql",
     ]));
 
     expect(getAction("linear", "create_issue")!.directApi).toMatchObject({
       method: "POST",
       url: "https://api.linear.app/graphql",
     });
-    expect(getAction("linear", "graphql")!.params).toMatchObject({
-      query: { type: "string", required: true },
-      variables: { type: "object" },
-    });
+    expect(getAction("linear", "graphql")).toBeUndefined();
+  });
+
+  it("does not register destructive or arbitrary-provider escape-hatch actions", () => {
+    expect(getAction("google_calendar", "delete_event")).toBeUndefined();
+    expect(getAction("linear", "graphql")).toBeUndefined();
+    for (const service of listServices()) {
+      expect(Object.values(service.actions).every((action) => action.risk !== "destructive")).toBe(true);
+    }
   });
 
   describe("validateIntegrationManifest", () => {
@@ -128,10 +215,10 @@ describe("Service Registry", () => {
 
     it("returns invalid for unknown services", () => {
       const result = validateIntegrationManifest({
-        integrations: { required: ["gmail", "notion"] },
+        integrations: { required: ["gmail", "salesforce"] },
       });
       expect(result.valid).toBe(false);
-      expect(result.missing).toEqual(["notion"]);
+      expect(result.missing).toEqual(["salesforce"]);
     });
 
     it("handles dotted service.action refs", () => {

--- a/tests/integrations/routes.test.ts
+++ b/tests/integrations/routes.test.ts
@@ -647,6 +647,95 @@ describe("Integration Routes", () => {
   // -----------------------------------------------------------------------
 
   describe("DELETE /:id", () => {
+    it("rejects oversized DELETE bodies before probing either connector", async () => {
+      const disconnect = vi.fn().mockResolvedValue(false);
+      const routes = createIntegrationRoutes({
+        db,
+        pipedream,
+        webhookSecret: WEBHOOK_SECRET,
+        resolveUserId: async () => userId,
+        mcpPresetBroker: {
+          listConnections: vi.fn().mockResolvedValue([]),
+          connect: vi.fn().mockResolvedValue({ url: "https://example.com/oauth" }),
+          call: vi.fn().mockResolvedValue({}),
+          disconnect,
+        },
+      });
+      const brokeredApp = new Hono();
+      brokeredApp.route("/api/integrations", routes);
+
+      const res = await brokeredApp.request(
+        "/api/integrations/00000000-0000-0000-0000-000000000000",
+        {
+          method: "DELETE",
+          headers: { "content-length": "2048" },
+          body: "x".repeat(2048),
+        },
+      );
+
+      expect(res.status).toBe(413);
+      expect(disconnect).not.toHaveBeenCalled();
+      expect(pipedream.revokeAccount).not.toHaveBeenCalled();
+    });
+
+    it("does not probe the MCP broker when disconnecting a Pipedream account", async () => {
+      const svc = await db.connectService({
+        userId,
+        service: "github",
+        pipedreamAccountId: "pd_acc_broker_independent",
+        accountLabel: "Broker Independent",
+        scopes: ["repo"],
+      });
+      const disconnect = vi.fn().mockRejectedValue(new Error("custom MCP database unavailable"));
+      const routes = createIntegrationRoutes({
+        db,
+        pipedream,
+        webhookSecret: WEBHOOK_SECRET,
+        resolveUserId: async () => userId,
+        mcpPresetBroker: {
+          listConnections: vi.fn().mockResolvedValue([]),
+          connect: vi.fn().mockResolvedValue({ url: "https://example.com/oauth" }),
+          call: vi.fn().mockResolvedValue({}),
+          disconnect,
+        },
+      });
+      const brokeredApp = new Hono();
+      brokeredApp.route("/api/integrations", routes);
+
+      const res = await brokeredApp.request(`/api/integrations/${svc.id}`, { method: "DELETE" });
+
+      expect(res.status).toBe(200);
+      expect(disconnect).not.toHaveBeenCalled();
+      expect(pipedream.revokeAccount).toHaveBeenCalledWith("pd_acc_broker_independent");
+    });
+
+    it("maps MCP broker disconnect failures to a generic service error", async () => {
+      const disconnect = vi.fn().mockRejectedValue(new Error("custom MCP database unavailable"));
+      const routes = createIntegrationRoutes({
+        db,
+        pipedream,
+        webhookSecret: WEBHOOK_SECRET,
+        resolveUserId: async () => userId,
+        mcpPresetBroker: {
+          listConnections: vi.fn().mockResolvedValue([]),
+          connect: vi.fn().mockResolvedValue({ url: "https://example.com/oauth" }),
+          call: vi.fn().mockResolvedValue({}),
+          disconnect,
+        },
+      });
+      const brokeredApp = new Hono();
+      brokeredApp.route("/api/integrations", routes);
+
+      const res = await brokeredApp.request(
+        "/api/integrations/00000000-0000-0000-0000-000000000000",
+        { method: "DELETE" },
+      );
+
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({ error: "Integration service unavailable" });
+      expect(disconnect).toHaveBeenCalledWith(userId, "00000000-0000-0000-0000-000000000000");
+    });
+
     it("disconnects a service and revokes Pipedream credentials", async () => {
       const svc = await db.connectService({
         userId,

--- a/tests/integrations/routes.test.ts
+++ b/tests/integrations/routes.test.ts
@@ -86,6 +86,29 @@ describe("Integration Routes", () => {
       expect(gmail).toBeDefined();
       expect(gmail.name).toBe("Gmail");
       expect(gmail.actions).toBeDefined();
+      expect(data.some((service: { id: string }) => service.id === "granola")).toBe(false);
+    });
+
+    it("advertises MCP presets only when their broker is wired", async () => {
+      const routes = createIntegrationRoutes({
+        db,
+        pipedream,
+        webhookSecret: WEBHOOK_SECRET,
+        resolveUserId: async () => userId,
+        mcpPresetBroker: {
+          listConnections: vi.fn().mockResolvedValue([]),
+          connect: vi.fn().mockResolvedValue({ url: "https://example.com/oauth" }),
+          call: vi.fn().mockResolvedValue({}),
+          disconnect: vi.fn().mockResolvedValue(false),
+        },
+      });
+      const brokeredApp = new Hono();
+      brokeredApp.route("/api/integrations", routes);
+
+      const res = await brokeredApp.request("/api/integrations/available");
+      expect(res.status).toBe(200);
+      const data = await res.json() as Array<{ id: string }>;
+      expect(data.some((service) => service.id === "granola")).toBe(true);
     });
   });
 

--- a/tests/scripts/verify-pipedream-integration-expansion.test.ts
+++ b/tests/scripts/verify-pipedream-integration-expansion.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { DiscoveredAction } from "../../packages/gateway/src/integrations/pipedream.js";
+import { getAction } from "../../packages/gateway/src/integrations/registry.js";
+import { bindDiscoveredComponentKey } from "../../scripts/lib/pipedream-integration-verification.js";
+
+describe("Pipedream integration expansion verification", () => {
+  const discovered: DiscoveredAction[] = [
+    { key: "posthog-list-projects", name: "List Projects" },
+    { key: "posthog-get-project", name: "Get Project" },
+  ];
+
+  it("binds only an exact live-discovered component key for one verification invocation", () => {
+    const registryAction = getAction("posthog", "list_projects")!;
+
+    const verifiedAction = bindDiscoveredComponentKey({
+      serviceId: "posthog",
+      actionId: "list_projects",
+      action: registryAction,
+      discovered,
+      componentKey: "posthog-list-projects",
+    });
+
+    expect(verifiedAction).toEqual({
+      ...registryAction,
+      componentKey: "posthog-list-projects",
+    });
+    expect(registryAction.componentKey).toBeUndefined();
+  });
+
+  it("rejects missing or non-discovered component keys for component-backed actions", () => {
+    const action = getAction("posthog", "list_projects")!;
+
+    expect(() => bindDiscoveredComponentKey({
+      serviceId: "posthog",
+      actionId: "list_projects",
+      action,
+      discovered,
+    })).toThrow("componentKey is required");
+
+    expect(() => bindDiscoveredComponentKey({
+      serviceId: "posthog",
+      actionId: "list_projects",
+      action,
+      discovered,
+      componentKey: "hand-authored-key",
+    })).toThrow("was not returned by live discovery");
+  });
+
+  it("leaves reviewed direct API actions unchanged", () => {
+    const action = getAction("figma", "get_file")!;
+    expect(bindDiscoveredComponentKey({
+      serviceId: "figma",
+      actionId: "get_file",
+      action,
+      discovered: [],
+    })).toBe(action);
+  });
+});


### PR DESCRIPTION
## Summary

- add the platform-owned Custom MCP broker with encrypted per-user credentials and revisioned enforcement projections
- support remote HTTPS Streamable HTTP servers with none, OAuth PKCE, bearer, or X-API-Key authentication
- add owner APIs, exact host-authenticated internal projection routes, SSRF-resistant DNS pinning, strict limits, and capped client/session lifecycle management
- implement pending-to-active creation, fail-closed reconciliation, pending-record sweeping, and action-required removal failures
- prevent late client initialization after shutdown begins, including shutdown racing asynchronous LRU eviction

## Stack

1. [PR #1410](https://github.com/HamedMP/matrix-os/pull/1410): managed catalog and action contracts
2. This PR: Custom MCP broker, security, storage, and APIs
3. [PR #1412](https://github.com/HamedMP/matrix-os/pull/1412): production broker composition, kernel/runtime wiring, and web/desktop management UI

## Invariants

- **Source of truth:** platform Postgres owns encrypted credentials and the revisioned enforcement projection; the VPS file is non-secret owner-visible configuration, and effective permissions are the intersection of both allowlists.
- **Lock/transaction scope:** related state transitions use Kysely transactions with revision predicates in writes; DNS, OAuth, MCP discovery/calls, and credential revocation remain outside database transactions.
- **Acceptable orphan states:** abandoned pending records are swept after 24 hours; removal disables platform access first, and failed upstream revocation remains visible as `action_required`.
- **Auth source of truth:** Clerk owner identity protects public APIs; internal routes require the exact customer-host credential bound to the same Clerk user and handle; OAuth state is one-time and expiring.
- **Deferred scope:** v1 supports remote HTTPS Streamable HTTP only—no stdio or legacy SSE—and custom servers remain agent-only. Production platform startup composition is intentionally in linked stack PR #1412, which owns the runtime/UI slice and cleanup wiring.

## Validation

- custom MCP core suite: 33 tests passed
- client lifecycle regression suite: 6 tests passed, including shutdown racing eviction
- affected package TypeScript checks passed
- pattern scan: 0 violations
