### PR TITLE
feat(gateway): add canonical ai provider snapshot

### DIFF
--- a/desktop/src/renderer/src/features/chat/ProviderModelPicker.tsx
+++ b/desktop/src/renderer/src/features/chat/ProviderModelPicker.tsx
@@ -16,6 +16,7 @@ import {
 import { ProviderDriverGlyph } from "./ProviderDriverGlyph";
 
 const DRIVER_LABEL: Record<CanonicalProviderDriverKind, string> = {
+  kernel: "Matrix Agent",
   hermes: "Hermes",
   openclaw: "OpenClaw",
   codex: "Codex",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -8,6 +8,7 @@
   },
   "imports": {
     "#billing-catalog": "./src/billing-catalog.ts",
+    "#ai-provider": "./src/ai-provider.ts",
     "#agent-runtime-config": "./src/agent-runtime-config.ts",
     "#agent-thread-contracts": "./src/agent-thread-contracts.ts",
     "#canonical-chat": "./src/canonical-chat.ts",

--- a/packages/contracts/src/agent-runtime-config.ts
+++ b/packages/contracts/src/agent-runtime-config.ts
@@ -252,7 +252,7 @@ export const AgentMessagingSelectionSchema = z.object({
 });
 
 export const AgentCurrentSelectionSchema = z.object({
-  chat: AgentChatSelectionSchema,
+  chat: AgentChatSelectionSchema.nullable(),
   messaging: AgentMessagingSelectionSchema,
 }).strict();
 
@@ -280,9 +280,10 @@ const LegacyCompatibleAgentSettingsViewSchema = LegacyAgentSettingsViewSchema
   });
 
 function chatSelectionsMatch(
-  left: z.infer<typeof AgentChatSelectionSchema>,
-  right: z.infer<typeof AgentChatSelectionSchema>,
+  left: z.infer<typeof AgentChatSelectionSchema> | null,
+  right: z.infer<typeof AgentChatSelectionSchema> | null,
 ): boolean {
+  if (left === null || right === null) return left === right;
   return left.provider === right.provider
     && left.model === right.model
     && left.effort === right.effort
@@ -293,7 +294,7 @@ function chatSelectionsMatch(
 export const AgentSettingsViewSchema = LegacyAgentSettingsViewSchema.extend({
   contractVersion: z.literal(2),
   revision: z.number().int().min(0),
-  chat: AgentChatSelectionSchema,
+  chat: AgentChatSelectionSchema.nullable(),
   runtime: AgentRuntimeSelectionSchema,
   providers: AgentProviderCatalogSchema,
   currentSelection: AgentCurrentSelectionSchema,
@@ -308,40 +309,42 @@ export const AgentSettingsViewSchema = LegacyAgentSettingsViewSchema.extend({
       message: "Messaging runtime must be selected",
     });
   }
-  const effectiveLegacyModel = view.kernel.model ?? view.defaults.model;
-  const effectiveLegacyEffort = view.kernel.effort ?? view.defaults.effort;
-  if (effectiveLegacyModel !== view.chat.model
-    || effectiveLegacyEffort !== view.chat.effort) {
-    ctx.addIssue({
-      code: "custom",
-      path: ["chat"],
-      message: "Chat selection must match effective legacy settings",
-    });
-  }
-  const expectedSource = view.kernel.model === null ? "default" : "saved";
-  if (view.chat.source !== expectedSource) {
-    ctx.addIssue({
-      code: "custom",
-      path: ["chat", "source"],
-      message: "Chat source must match legacy model selection",
-    });
-  }
-  const chatProvider = view.providers.find((provider) =>
-    provider.runtime === null
-    && provider.id === view.chat.provider
-    && provider.scopes.includes("chat")
-  );
-  const chatModel = chatProvider?.models.find((model) => model.id === view.chat.model);
-  if (!chatModel) {
-    ctx.addIssue({ code: "custom", path: ["chat", "model"], message: "Chat model is not cataloged" });
-  } else if (!chatModel.efforts.includes(view.chat.effort)) {
-    ctx.addIssue({ code: "custom", path: ["chat", "effort"], message: "Chat effort is not supported" });
-  }
-  if (!view.availableModels.some((model) => model.id === view.chat.model)) {
-    ctx.addIssue({ code: "custom", path: ["availableModels"], message: "Legacy model catalog is incomplete" });
-  }
-  if (!view.availableEfforts.includes(view.chat.effort)) {
-    ctx.addIssue({ code: "custom", path: ["availableEfforts"], message: "Legacy effort catalog is incomplete" });
+  const chat = view.chat;
+  if (chat !== null) {
+    const effectiveLegacyEffort = view.kernel.effort ?? view.defaults.effort;
+    if ((view.kernel.model !== null && view.kernel.model !== chat.model)
+      || effectiveLegacyEffort !== chat.effort) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["chat"],
+        message: "Saved Chat settings must match the active selection",
+      });
+    }
+    const expectedSource = view.kernel.model === null ? "default" : "saved";
+    if (chat.source !== expectedSource) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["chat", "source"],
+        message: "Chat source must match legacy model selection",
+      });
+    }
+    const chatProvider = view.providers.find((provider) =>
+      provider.runtime === null
+      && provider.id === chat.provider
+      && provider.scopes.includes("chat")
+    );
+    const chatModel = chatProvider?.models.find((model) => model.id === chat.model);
+    if (!chatModel) {
+      ctx.addIssue({ code: "custom", path: ["chat", "model"], message: "Chat model is not cataloged" });
+    } else if (!chatModel.efforts.includes(chat.effort)) {
+      ctx.addIssue({ code: "custom", path: ["chat", "effort"], message: "Chat effort is not supported" });
+    }
+    if (!view.availableModels.some((model) => model.id === chat.model)) {
+      ctx.addIssue({ code: "custom", path: ["availableModels"], message: "Legacy model catalog is incomplete" });
+    }
+    if (!view.availableEfforts.includes(chat.effort)) {
+      ctx.addIssue({ code: "custom", path: ["availableEfforts"], message: "Legacy effort catalog is incomplete" });
+    }
   }
   const messaging = view.currentSelection.messaging;
   if (messaging.configured) {

--- a/packages/contracts/src/ai-provider.ts
+++ b/packages/contracts/src/ai-provider.ts
@@ -1,0 +1,301 @@
+import { z } from "zod/v4";
+import { canonicalReferenceId, canonicalSafeLabel } from "#canonical-chat-primitives";
+import { IsoTimestampSchema, ProviderModelReferenceSchema } from "#contract-primitives";
+
+function unique(values: readonly string[]): boolean {
+  return new Set(values).size === values.length;
+}
+
+const AiProviderIdSchema = canonicalReferenceId(128);
+const AiPolicyVersionSchema = canonicalReferenceId(160);
+const NullableTimestampSchema = IsoTimestampSchema.nullable();
+
+export const AiProviderVendorSchema = z.enum([
+  "anthropic",
+  "openrouter",
+  "openai",
+  "baseten",
+]);
+
+export const AiProviderReadinessStateSchema = z.enum([
+  "ready",
+  "setup_required",
+  "auth_required",
+  "invalid",
+  "expired",
+  "unavailable",
+  "disabled",
+  "stale",
+  "unknown",
+]);
+
+export const AiProviderActionSchema = z.enum([
+  "none",
+  "connect",
+  "enter_api_key",
+  "open_terminal",
+  "retry",
+  "contact_owner",
+]);
+
+export const AiProviderSafeReasonSchema = z.enum([
+  "auth",
+  "timeout",
+  "rate_limited",
+  "provider_unavailable",
+  "policy",
+  "unknown",
+]);
+
+export const AiProviderReadinessSchema = z.object({
+  state: AiProviderReadinessStateSchema,
+  checkedAt: NullableTimestampSchema,
+  staleAfter: NullableTimestampSchema,
+  action: AiProviderActionSchema,
+  safeReason: AiProviderSafeReasonSchema.nullable(),
+}).strict().superRefine((readiness, ctx) => {
+  if (readiness.state === "ready" && readiness.action !== "none") {
+    ctx.addIssue({ code: "custom", path: ["action"], message: "Ready providers cannot require setup" });
+  }
+  if (readiness.state !== "ready" && readiness.action === "none") {
+    ctx.addIssue({ code: "custom", path: ["action"], message: "Unavailable providers require an action" });
+  }
+  if (readiness.checkedAt === null && readiness.staleAfter !== null) {
+    ctx.addIssue({ code: "custom", path: ["staleAfter"], message: "Staleness requires a checked time" });
+  }
+});
+
+export const AiAccessSourceViewSchema = AiProviderReadinessSchema.extend({
+  id: AiProviderIdSchema,
+  displayName: canonicalSafeLabel(120, 480),
+  fundingKind: z.enum(["matrix_included", "owner_account", "owner_api_key", "matrix_addon"]),
+  vendor: AiProviderVendorSchema,
+  accountLabel: canonicalSafeLabel(120, 480).nullable(),
+  eligibleModelIds: z.array(ProviderModelReferenceSchema).max(64),
+  policyVersion: AiPolicyVersionSchema,
+}).strict().superRefine((source, ctx) => {
+  if (!unique(source.eligibleModelIds)) {
+    ctx.addIssue({ code: "custom", path: ["eligibleModelIds"], message: "Duplicate eligible model" });
+  }
+  if (source.fundingKind === "matrix_included" && source.accountLabel === null) {
+    ctx.addIssue({ code: "custom", path: ["accountLabel"], message: "Included access requires a label" });
+  }
+});
+
+export const AiProviderAccountViewSchema = AiProviderReadinessSchema.extend({
+  id: AiProviderIdSchema,
+  vendor: AiProviderVendorSchema,
+  authMethod: z.enum(["provider_profile", "api_key", "oauth_pkce"]).nullable(),
+  accountLabel: canonicalSafeLabel(120, 480).nullable(),
+}).strict().superRefine((account, ctx) => {
+  if (account.state === "setup_required" && account.authMethod !== null) {
+    ctx.addIssue({ code: "custom", path: ["authMethod"], message: "Unconfigured accounts cannot claim authentication" });
+  }
+  if (account.state === "ready" && account.authMethod === null) {
+    ctx.addIssue({ code: "custom", path: ["authMethod"], message: "Ready accounts require an authentication method" });
+  }
+});
+
+export const AiProviderDriverCapabilitySchema = z.enum([
+  "tools",
+  "resume",
+  "subagents",
+  "vision",
+  "audio",
+  "reasoning",
+  "cancellation",
+  "project_context",
+]);
+
+export const AiProviderDriverViewSchema = z.object({
+  id: AiProviderIdSchema,
+  displayName: canonicalSafeLabel(120, 480),
+  kind: z.enum(["agent_sdk", "cli", "acp", "openai_compatible"]),
+  installState: z.enum(["installed", "missing", "installing", "failed", "unknown"]),
+  health: z.enum(["ready", "degraded", "stopped", "unavailable", "unknown"]),
+  capabilities: z.array(AiProviderDriverCapabilitySchema).max(16),
+  setupActions: z.array(z.enum([
+    "install",
+    "connect_account",
+    "enter_api_key",
+    "open_terminal",
+    "retry",
+  ])).max(8),
+}).strict().superRefine((driver, ctx) => {
+  if (!unique(driver.capabilities)) {
+    ctx.addIssue({ code: "custom", path: ["capabilities"], message: "Duplicate driver capability" });
+  }
+  if (!unique(driver.setupActions)) {
+    ctx.addIssue({ code: "custom", path: ["setupActions"], message: "Duplicate setup action" });
+  }
+});
+
+export const AiModelDescriptorViewSchema = z.object({
+  id: ProviderModelReferenceSchema,
+  vendor: AiProviderVendorSchema,
+  displayName: canonicalSafeLabel(120, 480),
+  status: z.enum(["current", "legacy", "preview", "retired", "unavailable"]),
+  capabilities: z.array(z.enum([
+    "tools",
+    "vision",
+    "audio",
+    "reasoning",
+    "long_context",
+  ])).max(16),
+  effortControls: z.array(z.enum(["low", "medium", "high", "xhigh", "max"])).max(5),
+  eligibleAccessSourceIds: z.array(AiProviderIdSchema).max(16),
+  dataPolicies: z.array(z.object({
+    accessSourceId: AiProviderIdSchema,
+    route: z.enum(["matrix_relay", "owner_direct", "provider_router"]),
+    disclosureKey: canonicalReferenceId(120),
+  }).strict()).max(16),
+  aliases: z.array(ProviderModelReferenceSchema).max(16),
+  catalogVersion: AiPolicyVersionSchema,
+}).strict().superRefine((model, ctx) => {
+  for (const key of ["capabilities", "effortControls", "eligibleAccessSourceIds", "aliases"] as const) {
+    if (!unique(model[key])) {
+      ctx.addIssue({ code: "custom", path: [key], message: `Duplicate ${key} value` });
+    }
+  }
+  if (model.aliases.includes(model.id)) {
+    ctx.addIssue({ code: "custom", path: ["aliases"], message: "A model cannot alias itself" });
+  }
+  const policySourceIds = model.dataPolicies.map((policy) => policy.accessSourceId);
+  if (!unique(policySourceIds)) {
+    ctx.addIssue({ code: "custom", path: ["dataPolicies"], message: "Duplicate access source policy" });
+  }
+  if (policySourceIds.length !== model.eligibleAccessSourceIds.length
+    || policySourceIds.some((sourceId) => !model.eligibleAccessSourceIds.includes(sourceId))) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["dataPolicies"],
+      message: "Every eligible access source requires one data policy",
+    });
+  }
+});
+
+export const AiProviderInstanceViewSchema = z.object({
+  id: AiProviderIdSchema,
+  driverId: AiProviderIdSchema,
+  vendor: AiProviderVendorSchema,
+  accountId: AiProviderIdSchema.nullable(),
+  accessSourceId: AiProviderIdSchema,
+  label: canonicalSafeLabel(160, 640),
+  readiness: AiProviderReadinessSchema,
+  capabilitySnapshot: z.array(AiProviderDriverCapabilitySchema).max(16),
+  modelIds: z.array(ProviderModelReferenceSchema).max(64),
+  defaultModelId: ProviderModelReferenceSchema.nullable(),
+  catalogVersion: AiPolicyVersionSchema,
+}).strict().superRefine((instance, ctx) => {
+  if (!unique(instance.capabilitySnapshot)) {
+    ctx.addIssue({ code: "custom", path: ["capabilitySnapshot"], message: "Duplicate instance capability" });
+  }
+  if (!unique(instance.modelIds)) {
+    ctx.addIssue({ code: "custom", path: ["modelIds"], message: "Duplicate instance model" });
+  }
+  if (instance.defaultModelId !== null && !instance.modelIds.includes(instance.defaultModelId)) {
+    ctx.addIssue({ code: "custom", path: ["defaultModelId"], message: "Default model is not available on the instance" });
+  }
+  if (instance.readiness.state !== "ready" && instance.defaultModelId !== null) {
+    ctx.addIssue({ code: "custom", path: ["defaultModelId"], message: "Unavailable instances cannot have a default model" });
+  }
+});
+
+export const AiProviderSnapshotV3Schema = z.object({
+  contractVersion: z.literal(3),
+  revision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  refreshedAt: IsoTimestampSchema,
+  accessSources: z.array(AiAccessSourceViewSchema).max(16),
+  accounts: z.array(AiProviderAccountViewSchema).max(16),
+  drivers: z.array(AiProviderDriverViewSchema).max(20),
+  instances: z.array(AiProviderInstanceViewSchema).max(64),
+  models: z.array(AiModelDescriptorViewSchema).max(128),
+  active: z.object({
+    providerInstanceId: AiProviderIdSchema.nullable(),
+    accessSourceId: AiProviderIdSchema.nullable(),
+    modelId: ProviderModelReferenceSchema.nullable(),
+  }).strict(),
+}).strict().superRefine((snapshot, ctx) => {
+  const collections = [
+    ["accessSources", snapshot.accessSources.map((value) => value.id)],
+    ["accounts", snapshot.accounts.map((value) => value.id)],
+    ["drivers", snapshot.drivers.map((value) => value.id)],
+    ["instances", snapshot.instances.map((value) => value.id)],
+    ["models", snapshot.models.map((value) => value.id)],
+  ] as const;
+  for (const [key, ids] of collections) {
+    if (!unique(ids)) {
+      ctx.addIssue({ code: "custom", path: [key], message: `Duplicate ${key} id` });
+    }
+  }
+
+  const sources = new Map(snapshot.accessSources.map((value) => [value.id, value]));
+  const accounts = new Map(snapshot.accounts.map((value) => [value.id, value]));
+  const drivers = new Map(snapshot.drivers.map((value) => [value.id, value]));
+  const models = new Map(snapshot.models.map((value) => [value.id, value]));
+  const instances = new Map(snapshot.instances.map((value) => [value.id, value]));
+
+  snapshot.models.forEach((model, index) => {
+    model.eligibleAccessSourceIds.forEach((sourceId, sourceIndex) => {
+      if (!sources.has(sourceId)) {
+        ctx.addIssue({ code: "custom", path: ["models", index, "eligibleAccessSourceIds", sourceIndex], message: "Unknown access source" });
+      }
+    });
+    model.dataPolicies.forEach((policy, policyIndex) => {
+      if (!sources.has(policy.accessSourceId)) {
+        ctx.addIssue({ code: "custom", path: ["models", index, "dataPolicies", policyIndex, "accessSourceId"], message: "Unknown access source" });
+      }
+    });
+  });
+
+  snapshot.instances.forEach((instance, index) => {
+    const source = sources.get(instance.accessSourceId);
+    if (!drivers.has(instance.driverId)) {
+      ctx.addIssue({ code: "custom", path: ["instances", index, "driverId"], message: "Unknown provider driver" });
+    }
+    if (source === undefined || source.vendor !== instance.vendor) {
+      ctx.addIssue({ code: "custom", path: ["instances", index, "accessSourceId"], message: "Unknown or incompatible access source" });
+    }
+    if (instance.accountId !== null) {
+      const account = accounts.get(instance.accountId);
+      if (account === undefined || account.vendor !== instance.vendor) {
+        ctx.addIssue({ code: "custom", path: ["instances", index, "accountId"], message: "Unknown or incompatible provider account" });
+      }
+    }
+    instance.modelIds.forEach((modelId, modelIndex) => {
+      const model = models.get(modelId);
+      if (model === undefined
+        || model.vendor !== instance.vendor
+        || !source?.eligibleModelIds.includes(modelId)
+        || !model.eligibleAccessSourceIds.includes(instance.accessSourceId)) {
+        ctx.addIssue({ code: "custom", path: ["instances", index, "modelIds", modelIndex], message: "Model is not eligible for this instance" });
+      }
+    });
+  });
+
+  const activeValues = Object.values(snapshot.active);
+  const hasActive = activeValues.some((value) => value !== null);
+  if (hasActive && activeValues.some((value) => value === null)) {
+    ctx.addIssue({ code: "custom", path: ["active"], message: "Active selection must be complete" });
+    return;
+  }
+  if (!hasActive) return;
+  const instance = instances.get(snapshot.active.providerInstanceId!);
+  if (instance === undefined
+    || instance.readiness.state !== "ready"
+    || instance.accessSourceId !== snapshot.active.accessSourceId
+    || !instance.modelIds.includes(snapshot.active.modelId!)) {
+    ctx.addIssue({ code: "custom", path: ["active"], message: "Active selection is not runnable" });
+  }
+});
+
+export type AiProviderVendor = z.infer<typeof AiProviderVendorSchema>;
+export type AiProviderReadinessState = z.infer<typeof AiProviderReadinessStateSchema>;
+export type AiProviderReadiness = z.infer<typeof AiProviderReadinessSchema>;
+export type AiAccessSourceView = z.infer<typeof AiAccessSourceViewSchema>;
+export type AiProviderAccountView = z.infer<typeof AiProviderAccountViewSchema>;
+export type AiProviderDriverCapability = z.infer<typeof AiProviderDriverCapabilitySchema>;
+export type AiProviderDriverView = z.infer<typeof AiProviderDriverViewSchema>;
+export type AiProviderInstanceView = z.infer<typeof AiProviderInstanceViewSchema>;
+export type AiModelDescriptorView = z.infer<typeof AiModelDescriptorViewSchema>;
+export type AiProviderSnapshotV3 = z.infer<typeof AiProviderSnapshotV3Schema>;

--- a/packages/contracts/src/canonical-chat-primitives.ts
+++ b/packages/contracts/src/canonical-chat-primitives.ts
@@ -56,6 +56,7 @@ export function canonicalEncodedByteLength(value: unknown): number {
 }
 
 export const CanonicalProviderDriverKindSchema = z.enum([
+  "kernel",
   "hermes",
   "openclaw",
   "codex",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -24,6 +24,7 @@ import {
 export const CODEX_VERIFIED_VERSION = "0.151.0";
 export const CODEX_VERIFIED_NPM_PACKAGE = `@openai/codex@${CODEX_VERIFIED_VERSION}`;
 export * from "#billing-catalog";
+export * from "#ai-provider";
 export * from "#agent-runtime-config";
 export * from "#agent-thread-contracts";
 export * from "#canonical-chat";

--- a/packages/gateway/src/agent-config/service.ts
+++ b/packages/gateway/src/agent-config/service.ts
@@ -95,7 +95,8 @@ export function buildAgentSettingsView(
   const canonicalOwnerAccount = input.providerSnapshot?.accounts.find(
     (account) => account.id === "owner_anthropic",
   );
-  const canonicalSourceId = input.providerSnapshot?.active.accessSourceId
+  const canonicalActive = input.providerSnapshot?.active;
+  const canonicalSourceId = canonicalActive?.accessSourceId
     ?? (canonicalOwnerAccount?.authMethod === "api_key"
       ? "owner_anthropic_key"
       : canonicalOwnerAccount?.authMethod === "provider_profile"
@@ -116,15 +117,19 @@ export function buildAgentSettingsView(
   const chatProviderId = input.providerSnapshot && canonicalSourceId === "matrix_included"
     ? "matrix_ai"
     : "anthropic";
-  const model = savedModel ?? KERNEL_DEFAULTS.model;
+  const model = input.providerSnapshot
+    ? canonicalActive?.modelId ?? null
+    : savedModel ?? KERNEL_DEFAULTS.model;
   const effort = savedEffort ?? KERNEL_DEFAULTS.effort;
-  const chat = {
-    provider: chatProviderId,
-    model,
-    effort,
-    source: savedModel === null ? "default" as const : "saved" as const,
-    authKind,
-  };
+  const chat = model === null
+    ? null
+    : {
+        provider: chatProviderId,
+        model,
+        effort,
+        source: savedModel === model ? "saved" as const : "default" as const,
+        authKind,
+      };
   const canonicalAuthStatus = canonicalSource?.state === "ready"
     ? { state: "ready" as const, authenticated: true, action: "none" as const }
     : canonicalSource?.state === "unavailable"
@@ -155,6 +160,12 @@ export function buildAgentSettingsView(
     && !KERNEL_MODELS.some((entry) => entry.id === savedModel)
     ? [...KERNEL_MODELS, resolveKernelModelOption(savedModel)]
     : KERNEL_MODELS;
+  const canonicalInstance = input.providerSnapshot?.instances.find(
+    (instance) => instance.accessSourceId === canonicalSourceId,
+  );
+  const providerModels = input.providerSnapshot
+    ? availableModels.filter((entry) => canonicalInstance?.modelIds.includes(entry.id) === true)
+    : availableModels;
 
   return AgentSettingsViewSchema.parse({
     identity: input.identity,
@@ -202,7 +213,7 @@ export function buildAgentSettingsView(
       scopes: ["chat"],
       authKind,
       supportedAuthKinds: ["platform", "api_key", "oauth_login"],
-      models: availableModels.map((entry) => ({
+      models: providerModels.map((entry) => ({
         id: entry.id,
         displayName: entry.label,
         description: entry.tier,

--- a/packages/gateway/src/agent-config/service.ts
+++ b/packages/gateway/src/agent-config/service.ts
@@ -4,6 +4,7 @@ import {
   type AgentProviderDescriptor,
   type AgentRuntimeSelection,
   type AgentSettingsView,
+  type AiProviderSnapshotV3,
 } from "@matrix-os/contracts";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -23,6 +24,7 @@ interface BuildAgentSettingsViewInput {
   claudeLoginAvailable: boolean;
   platformCredentialAvailable: boolean;
   runtimeSnapshot?: AgentRuntimeSettingsSnapshot;
+  providerSnapshot?: AiProviderSnapshotV3;
 }
 
 export interface AgentRuntimeSettingsSnapshot {
@@ -90,21 +92,47 @@ export function buildAgentSettingsView(
   const savedEffort = normalizeKernelEffort(kernelConfig.effort);
   const hasByokCredential = typeof kernelConfig.anthropicApiKey === "string"
     && kernelConfig.anthropicApiKey.trim().length > 0;
-  const authKind = hasByokCredential
+  const canonicalOwnerAccount = input.providerSnapshot?.accounts.find(
+    (account) => account.id === "owner_anthropic",
+  );
+  const canonicalSourceId = input.providerSnapshot?.active.accessSourceId
+    ?? (canonicalOwnerAccount?.authMethod === "api_key"
+      ? "owner_anthropic_key"
+      : canonicalOwnerAccount?.authMethod === "provider_profile"
+        ? "owner_anthropic_profile"
+        : "matrix_included");
+  const canonicalSource = input.providerSnapshot?.accessSources.find(
+    (source) => source.id === canonicalSourceId,
+  );
+  const authKind = canonicalSourceId === "owner_anthropic_key"
+    ? "api_key" as const
+    : canonicalSourceId === "owner_anthropic_profile"
+      ? "oauth_login" as const
+      : hasByokCredential
     ? "api_key" as const
     : input.claudeLoginAvailable
       ? "oauth_login" as const
       : "platform" as const;
+  const chatProviderId = input.providerSnapshot && canonicalSourceId === "matrix_included"
+    ? "matrix_ai"
+    : "anthropic";
   const model = savedModel ?? KERNEL_DEFAULTS.model;
   const effort = savedEffort ?? KERNEL_DEFAULTS.effort;
   const chat = {
-    provider: "anthropic",
+    provider: chatProviderId,
     model,
     effort,
     source: savedModel === null ? "default" as const : "saved" as const,
     authKind,
   };
-  const authStatus = hasByokCredential
+  const canonicalAuthStatus = canonicalSource?.state === "ready"
+    ? { state: "ready" as const, authenticated: true, action: "none" as const }
+    : canonicalSource?.state === "unavailable"
+      ? { state: "unavailable" as const, authenticated: false, action: "none" as const }
+      : canonicalSource
+        ? { state: "unknown" as const, authenticated: false, action: "none" as const }
+        : null;
+  const authStatus = canonicalAuthStatus ?? (hasByokCredential
     || input.claudeLoginAvailable
     || input.platformCredentialAvailable
     ? { state: "ready" as const, authenticated: true, action: "none" as const }
@@ -112,7 +140,7 @@ export function buildAgentSettingsView(
         state: "action_required" as const,
         authenticated: false,
         action: "contact_owner" as const,
-      };
+      });
   const agentConfig = typeof input.config.agent === "object"
     && input.config.agent !== null
     && !Array.isArray(input.config.agent)
@@ -168,8 +196,8 @@ export function buildAgentSettingsView(
       transition: null,
     },
     providers: [{
-      id: "anthropic",
-      displayName: "Anthropic",
+      id: chatProviderId,
+      displayName: chatProviderId === "matrix_ai" ? "Matrix AI" : "Anthropic",
       runtime: null,
       scopes: ["chat"],
       authKind,

--- a/packages/gateway/src/ai-providers/DOMAIN.md
+++ b/packages/gateway/src/ai-providers/DOMAIN.md
@@ -1,0 +1,11 @@
+# AI Provider State Domain
+
+This directory owns the secret-free provider snapshot consumed by Chat and Settings. It keeps execution drivers, owner accounts, funding/access sources, provider instances, readiness, and model policy separate.
+
+- `ProviderCredentialStore` adapts owner-controlled runtime files and the inherited Matrix credential without returning secret material. File presence is `unknown` until a bounded health probe verifies it.
+- `AiProviderService` is the sole snapshot composer. Explicit owner selection never silently falls back to Matrix-funded access.
+- `ProviderHealthCache` has a fixed cap, TTL/LRU eviction, a recurring sweep, and an explicit shutdown drain owned by the gateway.
+- `model-catalog.ts` is a bounded bundled policy. Remote catalogs, executable driver definitions, arbitrary URLs, and owner mutations are not accepted here.
+- `GET /api/ai/providers` is read-only and runs behind the gateway's authenticated API boundary. Route failures expose only a generic message.
+
+Provider connect/disconnect mutations, funded-relay activation, remote catalog refresh, metering, and add-on purchases are intentionally deferred to later delivery phases.

--- a/packages/gateway/src/ai-providers/credential-store.ts
+++ b/packages/gateway/src/ai-providers/credential-store.ts
@@ -1,0 +1,49 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod/v4";
+import {
+  resolveKernelCredentialSources,
+  type KernelCredentialSources,
+} from "../kernel-credentials.js";
+import { normalizeKernelModel, type KernelModel } from "../kernel-settings.js";
+
+const SavedKernelConfigSchema = z.object({
+  kernel: z.object({
+    model: z.unknown().optional(),
+  }).passthrough().optional(),
+}).passthrough();
+
+export interface AiProviderCredentialSnapshot {
+  credentials: KernelCredentialSources;
+  savedModel: KernelModel | null;
+}
+
+export class ProviderCredentialStore {
+  readonly #homePath: string;
+  readonly #env: NodeJS.ProcessEnv;
+
+  constructor(options: { homePath: string; env?: NodeJS.ProcessEnv }) {
+    if (!options.homePath) throw new Error("AI provider home path is required");
+    this.#homePath = options.homePath;
+    this.#env = options.env ?? process.env;
+  }
+
+  async read(): Promise<AiProviderCredentialSnapshot> {
+    const credentials = await resolveKernelCredentialSources(this.#homePath, this.#env);
+    let savedModel: KernelModel | null = null;
+    try {
+      const parsed = SavedKernelConfigSchema.safeParse(JSON.parse(
+        await readFile(join(this.#homePath, "system/config.json"), "utf-8"),
+      ));
+      if (parsed.success) savedModel = normalizeKernelModel(parsed.data.kernel?.model);
+    } catch (err) {
+      if (!(err instanceof Error) || (err as NodeJS.ErrnoException).code !== "ENOENT") {
+        console.warn(
+          "[ai-providers] Failed to read saved model:",
+          err instanceof Error ? err.name : "UnknownError",
+        );
+      }
+    }
+    return { credentials, savedModel };
+  }
+}

--- a/packages/gateway/src/ai-providers/health.ts
+++ b/packages/gateway/src/ai-providers/health.ts
@@ -1,0 +1,81 @@
+export interface ProviderHealthCacheOptions {
+  maxEntries?: number;
+  ttlMs?: number;
+  sweepIntervalMs?: number;
+  now?: () => number;
+}
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+  lastTouched: number;
+}
+
+export class ProviderHealthCache<T> {
+  readonly #entries = new Map<string, CacheEntry<T>>();
+  readonly #maxEntries: number;
+  readonly #ttlMs: number;
+  readonly #now: () => number;
+  readonly #timer: ReturnType<typeof setInterval>;
+  #closed = false;
+
+  constructor(options: ProviderHealthCacheOptions = {}) {
+    this.#maxEntries = Math.max(1, Math.min(options.maxEntries ?? 32, 128));
+    this.#ttlMs = Math.max(1_000, Math.min(options.ttlMs ?? 30_000, 300_000));
+    this.#now = options.now ?? Date.now;
+    const sweepIntervalMs = Math.max(
+      1_000,
+      Math.min(options.sweepIntervalMs ?? this.#ttlMs, 300_000),
+    );
+    this.#timer = setInterval(() => this.sweep(), sweepIntervalMs);
+    this.#timer.unref?.();
+  }
+
+  get(key: string): T | undefined {
+    const entry = this.#entries.get(key);
+    if (!entry) return undefined;
+    const now = this.#now();
+    if (entry.expiresAt <= now) {
+      this.#entries.delete(key);
+      return undefined;
+    }
+    entry.lastTouched = now;
+    return entry.value;
+  }
+
+  set(key: string, value: T): void {
+    if (this.#closed) return;
+    const now = this.#now();
+    this.#entries.set(key, { value, expiresAt: now + this.#ttlMs, lastTouched: now });
+    while (this.#entries.size > this.#maxEntries) {
+      let oldestKey: string | undefined;
+      let oldestTouched = Number.POSITIVE_INFINITY;
+      for (const [candidateKey, entry] of this.#entries) {
+        if (entry.lastTouched < oldestTouched) {
+          oldestKey = candidateKey;
+          oldestTouched = entry.lastTouched;
+        }
+      }
+      if (oldestKey === undefined) break;
+      this.#entries.delete(oldestKey);
+    }
+  }
+
+  delete(key: string): void {
+    this.#entries.delete(key);
+  }
+
+  sweep(): void {
+    const now = this.#now();
+    for (const [key, entry] of this.#entries) {
+      if (entry.expiresAt <= now) this.#entries.delete(key);
+    }
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    clearInterval(this.#timer);
+    this.#entries.clear();
+  }
+}

--- a/packages/gateway/src/ai-providers/model-catalog.ts
+++ b/packages/gateway/src/ai-providers/model-catalog.ts
@@ -6,9 +6,10 @@ import {
   resolveKernelModelOption,
 } from "../kernel-settings.js";
 
-export const AI_PROVIDER_CATALOG_VERSION = "bundled_2026_08_29";
+export const AI_PROVIDER_CATALOG_VERSION = "bundled_2026_08_30";
 export const MATRIX_INCLUDED_MODEL_IDS = ["claude-sonnet-5"] as const;
 export const OWNER_ANTHROPIC_MODEL_IDS = [
+  "claude-fable-5",
   "claude-opus-5",
   "claude-sonnet-5",
   "claude-haiku-4-5",

--- a/packages/gateway/src/ai-providers/model-catalog.ts
+++ b/packages/gateway/src/ai-providers/model-catalog.ts
@@ -1,0 +1,68 @@
+import type { AiModelDescriptorView } from "@matrix-os/contracts";
+import {
+  KERNEL_EFFORTS,
+  KERNEL_MODELS,
+  LEGACY_KERNEL_MODEL_IDS,
+  resolveKernelModelOption,
+} from "../kernel-settings.js";
+
+export const AI_PROVIDER_CATALOG_VERSION = "bundled_2026_08_29";
+export const MATRIX_INCLUDED_MODEL_IDS = ["claude-sonnet-5"] as const;
+export const OWNER_ANTHROPIC_MODEL_IDS = [
+  "claude-opus-5",
+  "claude-sonnet-5",
+  "claude-haiku-4-5",
+  ...LEGACY_KERNEL_MODEL_IDS,
+] as const;
+
+const CURRENT_STATUS = new Map<string, "current">(
+  KERNEL_MODELS.map((model) => [model.id, "current"]),
+);
+
+export function buildBundledModelCatalog(): AiModelDescriptorView[] {
+  const modelIds = [
+    ...new Set([
+      ...KERNEL_MODELS.map((model) => model.id),
+      ...LEGACY_KERNEL_MODEL_IDS,
+    ]),
+  ];
+
+  return modelIds.map((id) => {
+    const option = resolveKernelModelOption(id);
+    const eligibleAccessSourceIds = [
+      ...(MATRIX_INCLUDED_MODEL_IDS.includes(id as (typeof MATRIX_INCLUDED_MODEL_IDS)[number])
+        ? ["matrix_included"]
+        : []),
+      ...(OWNER_ANTHROPIC_MODEL_IDS.includes(id as (typeof OWNER_ANTHROPIC_MODEL_IDS)[number])
+        ? ["owner_anthropic_key", "owner_anthropic_profile"]
+        : []),
+    ];
+    return {
+      id,
+      vendor: "anthropic" as const,
+      displayName: option.label,
+      status: CURRENT_STATUS.get(id) ?? "legacy" as const,
+      capabilities: ["tools", "vision", "reasoning", "long_context"] as const,
+      effortControls: [...KERNEL_EFFORTS],
+      eligibleAccessSourceIds,
+      dataPolicies: eligibleAccessSourceIds.map((accessSourceId) => ({
+        accessSourceId,
+        route: accessSourceId === "matrix_included"
+          ? "matrix_relay" as const
+          : "owner_direct" as const,
+        disclosureKey: accessSourceId === "matrix_included"
+          ? "matrix-cloudflare-anthropic"
+          : "owner-direct-anthropic",
+      })),
+      aliases: [],
+      catalogVersion: AI_PROVIDER_CATALOG_VERSION,
+    };
+  });
+}
+
+export function eligibleModelsForSource(
+  sourceId: string,
+  catalog: readonly AiModelDescriptorView[],
+): AiModelDescriptorView[] {
+  return catalog.filter((model) => model.eligibleAccessSourceIds.includes(sourceId));
+}

--- a/packages/gateway/src/ai-providers/routes.ts
+++ b/packages/gateway/src/ai-providers/routes.ts
@@ -1,0 +1,34 @@
+import { Hono, type Context } from "hono";
+import { z } from "zod/v4";
+import type { AiProviderSnapshotReader } from "./service.js";
+
+const ProviderQuerySchema = z.object({
+  refresh: z.enum(["true", "false"]).optional(),
+}).strict();
+
+export function createAiProviderRoutes(options: {
+  service: AiProviderSnapshotReader;
+  getPrincipal: (context: Context) => unknown;
+}) {
+  if (!options.service) throw new Error("AI provider service is required");
+  if (!options.getPrincipal) throw new Error("AI provider principal resolver is required");
+
+  const app = new Hono();
+  app.get("/providers", async (context) => {
+    options.getPrincipal(context);
+    const query = ProviderQuerySchema.safeParse(context.req.query());
+    if (!query.success) return context.json({ error: "Invalid provider status query" }, 400);
+    try {
+      return context.json(await options.service.getSnapshot({
+        refresh: query.data.refresh === "true",
+      }));
+    } catch (err) {
+      console.warn(
+        "[ai-providers] Failed to build provider status:",
+        err instanceof Error ? err.name : "UnknownError",
+      );
+      return context.json({ error: "AI provider status is unavailable" }, 503);
+    }
+  });
+  return app;
+}

--- a/packages/gateway/src/ai-providers/service.ts
+++ b/packages/gateway/src/ai-providers/service.ts
@@ -1,0 +1,332 @@
+import {
+  AiProviderReadinessSchema,
+  AiProviderSnapshotV3Schema,
+  type AiAccessSourceView,
+  type AiProviderAccountView,
+  type AiProviderReadiness,
+  type AiProviderSnapshotV3,
+} from "@matrix-os/contracts";
+import type { KernelCredentialObservationState } from "../kernel-credentials.js";
+import { KERNEL_DEFAULTS } from "../kernel-settings.js";
+import { ProviderCredentialStore } from "./credential-store.js";
+import { ProviderHealthCache } from "./health.js";
+import {
+  AI_PROVIDER_CATALOG_VERSION,
+  buildBundledModelCatalog,
+  eligibleModelsForSource,
+} from "./model-catalog.js";
+
+const HEALTH_TIMEOUT_MS = 2_000;
+const KERNEL_CAPABILITIES = [
+  "tools",
+  "resume",
+  "subagents",
+  "vision",
+  "reasoning",
+  "cancellation",
+] as const;
+
+export interface AiProviderHealthProbe {
+  (sourceId: string, signal: AbortSignal): Promise<AiProviderReadiness | null>;
+}
+
+export interface AiProviderSnapshotReader {
+  getSnapshot(options?: { refresh?: boolean }): Promise<AiProviderSnapshotV3>;
+}
+
+interface AiProviderServiceOptions {
+  homePath: string;
+  env?: NodeJS.ProcessEnv;
+  now?: () => Date;
+  healthProbe?: AiProviderHealthProbe;
+  healthCache?: ProviderHealthCache<AiProviderReadiness>;
+  healthTimeoutMs?: number;
+}
+
+function readinessForObservation(
+  state: KernelCredentialObservationState,
+  kind: "matrix" | "api_key" | "profile",
+  now: string,
+): AiProviderReadiness {
+  if (state === "ready") {
+    return { state: "ready", checkedAt: now, staleAfter: null, action: "none", safeReason: null };
+  }
+  if (state === "setup_required") {
+    return {
+      state: "setup_required",
+      checkedAt: null,
+      staleAfter: null,
+      action: kind === "api_key" ? "enter_api_key" : "connect",
+      safeReason: null,
+    };
+  }
+  if (state === "unverified") {
+    return { state: "unknown", checkedAt: null, staleAfter: null, action: "retry", safeReason: "unknown" };
+  }
+  if (state === "invalid") {
+    return {
+      state: "invalid",
+      checkedAt: null,
+      staleAfter: null,
+      action: kind === "api_key" ? "enter_api_key" : "connect",
+      safeReason: "auth",
+    };
+  }
+  if (state === "unavailable") {
+    return { state: "unavailable", checkedAt: null, staleAfter: null, action: "retry", safeReason: "unknown" };
+  }
+  return {
+    state: "disabled",
+    checkedAt: now,
+    staleAfter: null,
+    action: kind === "matrix" ? "contact_owner" : "connect",
+    safeReason: "policy",
+  };
+}
+
+function sourceFromReadiness(
+  input: Omit<AiAccessSourceView, keyof AiProviderReadiness>,
+  readiness: AiProviderReadiness,
+): AiAccessSourceView {
+  return { ...input, ...readiness };
+}
+
+function accountReadinessFromSource(
+  readiness: AiProviderReadiness,
+  authMethod: AiProviderAccountView["authMethod"],
+): AiProviderAccountView {
+  return {
+    id: "owner_anthropic",
+    vendor: "anthropic",
+    authMethod,
+    accountLabel: null,
+    ...readiness,
+  };
+}
+
+export class AiProviderService implements AiProviderSnapshotReader {
+  readonly #credentials: ProviderCredentialStore;
+  readonly #now: () => Date;
+  readonly #healthProbe?: AiProviderHealthProbe;
+  readonly #healthCache: ProviderHealthCache<AiProviderReadiness>;
+  readonly #ownsHealthCache: boolean;
+  readonly #healthTimeoutMs: number;
+
+  constructor(options: AiProviderServiceOptions) {
+    if (!options.homePath) throw new Error("AI provider home path is required");
+    this.#credentials = new ProviderCredentialStore({
+      homePath: options.homePath,
+      env: options.env,
+    });
+    this.#now = options.now ?? (() => new Date());
+    this.#healthProbe = options.healthProbe;
+    this.#healthCache = options.healthCache ?? new ProviderHealthCache<AiProviderReadiness>();
+    this.#ownsHealthCache = options.healthCache === undefined;
+    this.#healthTimeoutMs = Math.max(
+      1,
+      Math.min(options.healthTimeoutMs ?? HEALTH_TIMEOUT_MS, HEALTH_TIMEOUT_MS),
+    );
+  }
+
+  async #resolveOwnerReadiness(
+    sourceId: "owner_anthropic_key" | "owner_anthropic_profile",
+    observation: KernelCredentialObservationState,
+    kind: "api_key" | "profile",
+    now: string,
+    refresh: boolean,
+  ): Promise<AiProviderReadiness> {
+    const fallback = readinessForObservation(observation, kind, now);
+    if (observation !== "unverified" || !this.#healthProbe) return fallback;
+    if (refresh) this.#healthCache.delete(sourceId);
+    const cached = this.#healthCache.get(sourceId);
+    if (cached) return cached;
+
+    const controller = new AbortController();
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_resolve, reject) => {
+      timeout = setTimeout(() => {
+        controller.abort();
+        reject(new Error("Provider readiness deadline exceeded"));
+      }, this.#healthTimeoutMs);
+    });
+    try {
+      const result = await Promise.race([
+        this.#healthProbe(sourceId, controller.signal),
+        deadline,
+      ]);
+      const readiness = result === null ? fallback : AiProviderReadinessSchema.parse(result);
+      this.#healthCache.set(sourceId, readiness);
+      return readiness;
+    } catch (err) {
+      console.warn(
+        "[ai-providers] Provider readiness probe failed:",
+        err instanceof Error ? err.name : "UnknownError",
+      );
+      const unavailable: AiProviderReadiness = {
+        state: "unavailable",
+        checkedAt: now,
+        staleAfter: null,
+        action: "retry",
+        safeReason: controller.signal.aborted ? "timeout" : "unknown",
+      };
+      this.#healthCache.set(sourceId, unavailable);
+      return unavailable;
+    } finally {
+      if (timeout !== undefined) clearTimeout(timeout);
+    }
+  }
+
+  async getSnapshot(options: { refresh?: boolean } = {}): Promise<AiProviderSnapshotV3> {
+    const now = this.#now().toISOString();
+    const { credentials, savedModel } = await this.#credentials.read();
+    const matrixReadiness = readinessForObservation(
+      credentials.matrixIncluded.state,
+      "matrix",
+      now,
+    );
+    const apiKeyReadiness = await this.#resolveOwnerReadiness(
+      "owner_anthropic_key",
+      credentials.ownerApiKey.state,
+      "api_key",
+      now,
+      options.refresh === true,
+    );
+    const profileReadiness = await this.#resolveOwnerReadiness(
+      "owner_anthropic_profile",
+      credentials.ownerProfile.state,
+      "profile",
+      now,
+      options.refresh === true,
+    );
+    const catalog = buildBundledModelCatalog();
+
+    const accessSources: AiAccessSourceView[] = [
+      sourceFromReadiness({
+        id: "matrix_included",
+        displayName: "Matrix AI",
+        fundingKind: "matrix_included",
+        vendor: "anthropic",
+        accountLabel: "Included",
+        eligibleModelIds: eligibleModelsForSource("matrix_included", catalog).map((model) => model.id),
+        policyVersion: AI_PROVIDER_CATALOG_VERSION,
+      }, matrixReadiness),
+      sourceFromReadiness({
+        id: "owner_anthropic_key",
+        displayName: "Anthropic API key",
+        fundingKind: "owner_api_key",
+        vendor: "anthropic",
+        accountLabel: null,
+        eligibleModelIds: eligibleModelsForSource("owner_anthropic_key", catalog).map((model) => model.id),
+        policyVersion: AI_PROVIDER_CATALOG_VERSION,
+      }, apiKeyReadiness),
+      sourceFromReadiness({
+        id: "owner_anthropic_profile",
+        displayName: "Anthropic account",
+        fundingKind: "owner_account",
+        vendor: "anthropic",
+        accountLabel: null,
+        eligibleModelIds: eligibleModelsForSource("owner_anthropic_profile", catalog).map((model) => model.id),
+        policyVersion: AI_PROVIDER_CATALOG_VERSION,
+      }, profileReadiness),
+      sourceFromReadiness({
+        id: "owner_openrouter",
+        displayName: "OpenRouter account",
+        fundingKind: "owner_account",
+        vendor: "openrouter",
+        accountLabel: null,
+        eligibleModelIds: [],
+        policyVersion: AI_PROVIDER_CATALOG_VERSION,
+      }, readinessForObservation("setup_required", "profile", now)),
+    ];
+
+    const selectedOwnerReadiness = credentials.selectedMode === "api_key"
+      ? apiKeyReadiness
+      : credentials.selectedMode === "claude_login"
+        ? profileReadiness
+        : readinessForObservation("setup_required", "profile", now);
+    const accounts: AiProviderAccountView[] = [
+      accountReadinessFromSource(
+        selectedOwnerReadiness,
+        credentials.selectedMode === "api_key"
+          ? "api_key"
+          : credentials.selectedMode === "claude_login"
+            ? "provider_profile"
+            : null,
+      ),
+      {
+        id: "owner_openrouter",
+        vendor: "openrouter",
+        authMethod: null,
+        accountLabel: null,
+        ...readinessForObservation("setup_required", "profile", now),
+      },
+    ];
+
+    const instances = accessSources
+      .filter((source) => source.vendor === "anthropic")
+      .map((source) => {
+        const sourceModels = eligibleModelsForSource(source.id, catalog);
+        const configuredModel = savedModel !== null
+          && sourceModels.some((model) => model.id === savedModel)
+          ? savedModel
+          : sourceModels.some((model) => model.id === KERNEL_DEFAULTS.model)
+            ? KERNEL_DEFAULTS.model
+            : sourceModels[0]?.id ?? null;
+        return {
+          id: `kernel_${source.id}`,
+          driverId: "kernel",
+          vendor: "anthropic" as const,
+          accountId: source.id === "matrix_included" ? null : "owner_anthropic",
+          accessSourceId: source.id,
+          label: source.displayName,
+          readiness: {
+            state: source.state,
+            checkedAt: source.checkedAt,
+            staleAfter: source.staleAfter,
+            action: source.action,
+            safeReason: source.safeReason,
+          },
+          capabilitySnapshot: [...KERNEL_CAPABILITIES],
+          modelIds: sourceModels.map((model) => model.id),
+          defaultModelId: source.state === "ready" ? configuredModel : null,
+          catalogVersion: AI_PROVIDER_CATALOG_VERSION,
+        };
+      });
+
+    const selectedInstance = instances.find(
+      (instance) => instance.accessSourceId === credentials.selectedAccessSourceId,
+    );
+    const active = selectedInstance?.readiness.state === "ready"
+      && selectedInstance.defaultModelId !== null
+      ? {
+          providerInstanceId: selectedInstance.id,
+          accessSourceId: selectedInstance.accessSourceId,
+          modelId: selectedInstance.defaultModelId,
+        }
+      : { providerInstanceId: null, accessSourceId: null, modelId: null };
+
+    return AiProviderSnapshotV3Schema.parse({
+      contractVersion: 3,
+      revision: 0,
+      refreshedAt: now,
+      accessSources,
+      accounts,
+      drivers: [{
+        id: "kernel",
+        displayName: "Matrix Agent",
+        kind: "agent_sdk",
+        installState: "installed",
+        health: "ready",
+        capabilities: [...KERNEL_CAPABILITIES],
+        setupActions: [],
+      }],
+      instances,
+      models: catalog,
+      active,
+    });
+  }
+
+  close(): void {
+    if (this.#ownsHealthCache) this.#healthCache.close();
+  }
+}

--- a/packages/gateway/src/ai-providers/service.ts
+++ b/packages/gateway/src/ai-providers/service.ts
@@ -266,12 +266,16 @@ export class AiProviderService implements AiProviderSnapshotReader {
       .filter((source) => source.vendor === "anthropic")
       .map((source) => {
         const sourceModels = eligibleModelsForSource(source.id, catalog);
+        // A persisted selection is an explicit route request. If the selected
+        // access source cannot serve it, fail closed instead of silently
+        // replacing it with a cheaper or differently governed model.
         const configuredModel = savedModel !== null
-          && sourceModels.some((model) => model.id === savedModel)
-          ? savedModel
+          ? sourceModels.some((model) => model.id === savedModel)
+            ? savedModel
+            : null
           : sourceModels.some((model) => model.id === KERNEL_DEFAULTS.model)
-            ? KERNEL_DEFAULTS.model
-            : sourceModels[0]?.id ?? null;
+              ? KERNEL_DEFAULTS.model
+              : sourceModels[0]?.id ?? null;
         return {
           id: `kernel_${source.id}`,
           driverId: "kernel",

--- a/packages/gateway/src/kernel-credentials.ts
+++ b/packages/gateway/src/kernel-credentials.ts
@@ -2,10 +2,30 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 export type KernelCredentialMode = "platform" | "api_key" | "claude_login";
+export type KernelCredentialAccessSourceId =
+  | "matrix_included"
+  | "owner_anthropic_key"
+  | "owner_anthropic_profile";
+export type KernelCredentialObservationState =
+  | "ready"
+  | "setup_required"
+  | "unverified"
+  | "invalid"
+  | "unavailable"
+  | "disabled";
+
+export interface KernelCredentialSources {
+  selectedMode: KernelCredentialMode;
+  selectedAccessSourceId: KernelCredentialAccessSourceId;
+  matrixIncluded: { state: KernelCredentialObservationState };
+  ownerApiKey: { state: KernelCredentialObservationState };
+  ownerProfile: { state: KernelCredentialObservationState };
+}
 
 interface KernelCredentialResolution {
   mode: KernelCredentialMode;
   env?: Record<string, string | undefined>;
+  sources: KernelCredentialSources;
 }
 
 function hasClaudeOauthConfig(value: unknown): boolean {
@@ -16,7 +36,15 @@ function hasClaudeOauthConfig(value: unknown): boolean {
 }
 
 function logCredentialReadFailure(label: string, err: unknown): void {
-  console.warn(label, err instanceof Error ? err.message : String(err));
+  console.warn(label, err instanceof Error ? err.name : "UnknownError");
+}
+
+function isNotFound(err: unknown): boolean {
+  return err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function observationForReadFailure(err: unknown): KernelCredentialObservationState {
+  return err instanceof SyntaxError ? "invalid" : "unavailable";
 }
 
 async function resolveKernelCredentials(
@@ -24,16 +52,26 @@ async function resolveKernelCredentials(
   baseEnv: NodeJS.ProcessEnv = process.env,
 ): Promise<KernelCredentialResolution> {
   const env = { ...baseEnv };
+  const matrixState = typeof baseEnv.ANTHROPIC_API_KEY === "string"
+    && baseEnv.ANTHROPIC_API_KEY.trim().length > 0
+    ? "ready" as const
+    : "disabled" as const;
+  let apiKeyState: KernelCredentialObservationState = "setup_required";
+  let profileState: KernelCredentialObservationState = "setup_required";
+  let ownerApiKey: string | undefined;
+  let hasOwnerProfile = false;
+
   try {
     const raw = await readFile(join(homePath, "system/config.json"), "utf-8");
     const userConfig = JSON.parse(raw);
     const byokKey = userConfig?.kernel?.anthropicApiKey;
-    if (byokKey && typeof byokKey === "string") {
-      env.ANTHROPIC_API_KEY = byokKey;
-      return { mode: "api_key", env };
+    if (typeof byokKey === "string" && byokKey.trim().length > 0) {
+      ownerApiKey = byokKey;
+      apiKeyState = "unverified";
     }
   } catch (err) {
-    if (!(err instanceof Error) || (err as NodeJS.ErrnoException).code !== "ENOENT") {
+    if (!isNotFound(err)) {
+      apiKeyState = observationForReadFailure(err);
       logCredentialReadFailure("[kernel-credentials] failed to read user API key config:", err);
     }
   }
@@ -41,18 +79,45 @@ async function resolveKernelCredentials(
   try {
     const raw = await readFile(join(homePath, ".claude.json"), "utf-8");
     if (hasClaudeOauthConfig(JSON.parse(raw))) {
-      env.HOME = homePath;
-      delete env.ANTHROPIC_API_KEY;
-      delete env.ANTHROPIC_BASE_URL;
-      return { mode: "claude_login", env };
+      hasOwnerProfile = true;
+      profileState = "unverified";
     }
   } catch (err) {
-    if (!(err instanceof Error) || (err as NodeJS.ErrnoException).code !== "ENOENT") {
+    if (!isNotFound(err)) {
+      profileState = observationForReadFailure(err);
       logCredentialReadFailure("[kernel-credentials] failed to read Claude OAuth config:", err);
     }
   }
 
-  return { mode: "platform" };
+  const selectedMode: KernelCredentialMode = ownerApiKey !== undefined
+    ? "api_key"
+    : hasOwnerProfile
+      ? "claude_login"
+      : "platform";
+  const selectedAccessSourceId: KernelCredentialAccessSourceId = selectedMode === "api_key"
+    ? "owner_anthropic_key"
+    : selectedMode === "claude_login"
+      ? "owner_anthropic_profile"
+      : "matrix_included";
+  const sources: KernelCredentialSources = {
+    selectedMode,
+    selectedAccessSourceId,
+    matrixIncluded: { state: matrixState },
+    ownerApiKey: { state: apiKeyState },
+    ownerProfile: { state: profileState },
+  };
+
+  if (ownerApiKey !== undefined) {
+    env.ANTHROPIC_API_KEY = ownerApiKey;
+    return { mode: selectedMode, env, sources };
+  }
+  if (hasOwnerProfile) {
+    env.HOME = homePath;
+    delete env.ANTHROPIC_API_KEY;
+    delete env.ANTHROPIC_BASE_URL;
+    return { mode: selectedMode, env, sources };
+  }
+  return { mode: selectedMode, sources };
 }
 
 export async function buildKernelEnv(
@@ -64,4 +129,11 @@ export async function buildKernelEnv(
 
 export async function resolveKernelCredentialMode(homePath: string): Promise<KernelCredentialMode> {
   return (await resolveKernelCredentials(homePath)).mode;
+}
+
+export async function resolveKernelCredentialSources(
+  homePath: string,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): Promise<KernelCredentialSources> {
+  return (await resolveKernelCredentials(homePath, baseEnv)).sources;
 }

--- a/packages/gateway/src/kernel-credentials.ts
+++ b/packages/gateway/src/kernel-credentials.ts
@@ -47,12 +47,18 @@ function observationForReadFailure(err: unknown): KernelCredentialObservationSta
   return err instanceof SyntaxError ? "invalid" : "unavailable";
 }
 
+function isFundedAccessEnabled(env: NodeJS.ProcessEnv): boolean {
+  const value = env.MATRIX_FUNDED_AI_ENABLED?.trim().toLowerCase();
+  return value === "1" || value === "true";
+}
+
 async function resolveKernelCredentials(
   homePath: string,
   baseEnv: NodeJS.ProcessEnv = process.env,
 ): Promise<KernelCredentialResolution> {
   const env = { ...baseEnv };
-  const matrixState = typeof baseEnv.ANTHROPIC_API_KEY === "string"
+  const matrixState = isFundedAccessEnabled(baseEnv)
+    && typeof baseEnv.ANTHROPIC_API_KEY === "string"
     && baseEnv.ANTHROPIC_API_KEY.trim().length > 0
     ? "ready" as const
     : "disabled" as const;

--- a/packages/gateway/src/routes/settings.ts
+++ b/packages/gateway/src/routes/settings.ts
@@ -34,6 +34,7 @@ import {
   type AgentConfigErrorKind,
 } from "../agent-config/errors.js";
 import type { AgentRuntimeController } from "../agent-config/runtime-controller.js";
+import type { AiProviderSnapshotReader } from "../ai-providers/service.js";
 
 const DESKTOP_DEFAULTS = {
   background: { type: "wallpaper", name: "matrix-dusk.webp" },
@@ -243,12 +244,14 @@ export function createSettingsRoutes(opts: {
   channelManager: ChannelManager;
   agentRuntimeSource?: AgentRuntimeSource;
   agentRuntimeController?: AgentRuntimeController;
+  aiProviderService?: AiProviderSnapshotReader;
 }) {
   const {
     homePath,
     channelManager,
     agentRuntimeSource,
     agentRuntimeController,
+    aiProviderService,
   } = opts;
   const app = new Hono();
   const configPath = join(homePath, "system/config.json");
@@ -266,12 +269,23 @@ export function createSettingsRoutes(opts: {
       "handle",
     );
     let runtimeSnapshot;
+    let providerSnapshot;
     if (agentRuntimeSource) {
       try {
         runtimeSnapshot = await readRuntimeSnapshot(agentRuntimeSource);
       } catch (err) {
         console.warn(
           "[settings] Failed to read agent runtime settings:",
+          err instanceof Error ? err.name : "UnknownError",
+        );
+      }
+    }
+    if (aiProviderService) {
+      try {
+        providerSnapshot = await aiProviderService.getSnapshot({ refresh: false });
+      } catch (err) {
+        console.warn(
+          "[settings] Failed to read AI provider settings:",
           err instanceof Error ? err.name : "UnknownError",
         );
       }
@@ -283,6 +297,7 @@ export function createSettingsRoutes(opts: {
       platformCredentialAvailable: typeof process.env.ANTHROPIC_API_KEY === "string"
         && process.env.ANTHROPIC_API_KEY.length > 0,
       runtimeSnapshot,
+      providerSnapshot,
     });
   }
 

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -232,6 +232,8 @@ import {
   type LoadedPlugin,
 } from "./plugins/index.js";
 import { createSettingsRoutes } from "./routes/settings.js";
+import { AiProviderService } from "./ai-providers/service.js";
+import { createAiProviderRoutes } from "./ai-providers/routes.js";
 import { createHermesRoutes } from "./routes/hermes.js";
 import {
   createHermesDashboardClient,
@@ -4148,6 +4150,7 @@ export async function createGateway(config: GatewayConfig) {
     client: hermesClient,
   });
   await agentRuntimeServices.controller.reconcile();
+  const aiProviderService = new AiProviderService({ homePath });
   const canonicalExecutableDriverKinds = [
     "hermes" as const,
     ...(codingAgentProviders.some((provider) => provider.providerId === "claude")
@@ -4221,6 +4224,10 @@ export async function createGateway(config: GatewayConfig) {
     catalog: canonicalChatProviderCatalog,
     getPrincipal: (c) => requireRequestPrincipal(c),
   }));
+  app.route("/api/ai", createAiProviderRoutes({
+    service: aiProviderService,
+    getPrincipal: (c) => requireRequestPrincipal(c),
+  }));
 
   // T978-T979: Settings API routes
   const settingsRoutes = createSettingsRoutes({
@@ -4228,6 +4235,7 @@ export async function createGateway(config: GatewayConfig) {
     channelManager,
     agentRuntimeSource: agentRuntimeServices.source,
     agentRuntimeController: agentRuntimeServices.controller,
+    aiProviderService,
   });
   app.route("/api/settings", settingsRoutes);
   if (osViewStateRepository) {
@@ -4529,6 +4537,7 @@ export async function createGateway(config: GatewayConfig) {
       await codingAgentWorkspaceRuntime?.close();
       codingAgentWorkspaceRuntime = null;
       await agentRuntimeServices.controller.close();
+      aiProviderService.close();
       await codingAgentTurnLifecycle.shutdown();
       await codexEventBridge?.shutdown();
       codingAgentThreadStream?.shutdown();

--- a/shell/src/components/settings/sections/AgentRuntimePanel.tsx
+++ b/shell/src/components/settings/sections/AgentRuntimePanel.tsx
@@ -186,14 +186,22 @@ function ChatCard({
   const chatModels = availableModels(provider);
   const [modelOverride, setModelOverride] = useState("");
   const [effortOverride, setEffortOverride] = useState<AgentEffort | "">("");
-  const preferredModel = modelOverride || view.chat.model;
+  const preferredModel = modelOverride
+    || view.chat?.model
+    || view.kernel.model
+    || view.defaults.model
+    || "";
   const selectedModel = chatModels.some((entry) => entry.id === preferredModel)
     ? preferredModel
     : chatModels[0]?.id ?? "";
   const effortOptions = provider?.models.find((entry) => entry.id === selectedModel)?.efforts
     ?? view.availableEfforts;
-  const preferredEffort = effortOverride || view.chat.effort;
-  const selectedEffort = effortOptions.includes(preferredEffort)
+  const preferredEffort = effortOverride
+    || view.chat?.effort
+    || view.kernel.effort
+    || view.defaults.effort
+    || "";
+  const selectedEffort = preferredEffort !== "" && effortOptions.includes(preferredEffort)
     ? preferredEffort
     : effortOptions[0] ?? "";
   const [showKey, setShowKey] = useState(false);
@@ -608,7 +616,7 @@ export function AgentRuntimePanel({ onOpenTerminal }: AgentRuntimePanelProps) {
     <div className="space-y-4">
       {error && <div role="alert" className="rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2 text-xs text-destructive">{error}</div>}
       <ChatCard
-        key={`${view.chat.model}:${view.chat.effort}:${view.chat.authKind}:${editResetVersion}`}
+        key={`${view.chat?.model ?? "inactive"}:${view.chat?.effort ?? "none"}:${view.chat?.authKind ?? "none"}:${editResetVersion}`}
         view={view}
         busy={busy}
         onOpenTerminal={onOpenTerminal}

--- a/specs/118-ai-gateway-provider-auth/data-model.md
+++ b/specs/118-ai-gateway-provider-auth/data-model.md
@@ -95,7 +95,7 @@ Matrix-funded access is an access source, not an Anthropic login. This distincti
 | `capabilities` | bounded set | Context/output limits, tools, vision, reasoning, etc. |
 | `effortControls` | bounded set | Only controls accepted by this model/transport |
 | `accessEligibility` | bounded set | Which access-source classes may use it |
-| `dataPolicy` | object | Retention/ZDR disclosure key, not arbitrary copy |
+| `dataPolicies` | bounded object array | One route/disclosure key per eligible access source, so Matrix-relay and owner-direct paths remain distinct |
 | `aliases` | bounded array | Compatibility only; never ambiguous |
 | `catalogVersion` | bounded string | Required |
 

--- a/specs/118-ai-gateway-provider-auth/tasks.md
+++ b/specs/118-ai-gateway-provider-auth/tasks.md
@@ -1,0 +1,148 @@
+# Tasks: Phase 2 — Canonical Provider and Account Truth
+
+**Input**: Design documents from `specs/118-ai-gateway-provider-auth/`
+**Scope**: Delivery Plan Phase 2 only. Runtime spikes, funded relay transport, and the Agent SDK/model upgrade are already merged. Provider login mutations, funded relay activation, metering/add-ons, and broader harnesses remain deferred.
+**Tests**: Required by the Matrix OS constitution; every behavior task starts with a failing focused test.
+
+## Phase 1: Setup and Baseline
+
+**Purpose**: Bind this worktree to spec 118 and establish the current behavior before changing public contracts.
+
+- [X] T001 Record the Phase 2 scope, merged prerequisites, and Graphite split in `specs/118-ai-gateway-provider-auth/tasks.md`
+- [X] T002 Verify existing ignore rules cover Node, build, coverage, environment, Docker, editor, and temporary artifacts in `.gitignore`, `.dockerignore`, `eslint.config.mjs`, and `.prettierignore`
+- [X] T003 Run the focused provider/settings baseline suites in `tests/contracts/`, `tests/gateway/agent-config-service.test.ts`, `tests/gateway/chat-provider-catalog.test.ts`, and `tests/shell/agent-config.test.ts`
+
+---
+
+## Phase 2: Foundational Canonical Contracts
+
+**Purpose**: Define the bounded V3 provider/account/access-source projection shared by every shell.
+
+**⚠️ CRITICAL**: The gateway service and UI adapters depend on this contract.
+
+- [X] T004 [P] Add failing schema tests for access sources, accounts, drivers, instances, models, active selection, deterministic caps, and secret/error rejection in `tests/contracts/ai-provider.test.ts`
+- [X] T005 [P] Add failing compatibility tests for the `kernel` provider driver kind in `tests/contracts/canonical-chat-provider.test.ts`
+- [X] T006 Implement `AiProviderSnapshotV3Schema` and its bounded view schemas in `packages/contracts/src/ai-provider.ts`
+- [X] T007 Extend the canonical driver vocabulary with `kernel` and export the V3 provider types from `packages/contracts/src/canonical-chat-primitives.ts` and `packages/contracts/src/index.ts`
+- [X] T008 Run the contract tests and mark the canonical contract checkpoint green
+
+**Checkpoint**: A strict, secret-free V3 snapshot can represent Matrix-funded readiness independently from owner Anthropic/OpenRouter account state.
+
+---
+
+## Phase 3: User Story 3 — Truthful Gateway Provider State (Priority: P1) 🎯 MVP
+
+**Goal**: Produce one gateway-owned snapshot in which Matrix AI can be ready while owner Anthropic and OpenRouter remain explicitly not connected.
+
+**Independent Test**: With platform-funded access available and no owner credential, `GET /api/ai/providers` reports `matrix_included` ready, both owner accounts setup-required, the kernel driver installed/ready, and only eligible models on the Matrix-funded instance.
+
+### Tests for User Story 3
+
+- [X] T009 [P] [US3] Add failing credential-source tests for explicit Matrix, owner API-key, owner profile, missing, malformed, and unreadable states in `tests/gateway/kernel-credentials.test.ts`
+- [X] T010 [P] [US3] Add failing service fixtures for Matrix-included, owner-key, owner-profile-unverified, disabled, stale, legacy-model, and unavailable intersections in `tests/gateway/ai-provider-service.test.ts`
+- [X] T011 [P] [US3] Add failing route tests for authenticated canonical reads, refresh behavior, bounded responses, and safe failures in `tests/gateway/ai-provider-routes.test.ts`
+- [X] T012 [P] [US3] Add failing legacy settings-adapter assertions proving platform fallback never marks the owner Anthropic account connected in `tests/gateway/agent-config-service.test.ts` and `tests/gateway/settings-agent-summary.test.ts`
+
+### Implementation for User Story 3
+
+- [X] T013 [US3] Expose an explicit, secret-free kernel credential/access-source resolution from `packages/gateway/src/kernel-credentials.ts`
+- [X] T014 [US3] Implement bundled bounded model policy and capability intersection in `packages/gateway/src/ai-providers/model-catalog.ts`
+- [X] T015 [US3] Implement owner credential/account projections without treating file presence as verified readiness in `packages/gateway/src/ai-providers/credential-store.ts`
+- [X] T016 [US3] Implement a capped TTL/LRU readiness cache with recurring cleanup and shutdown drain in `packages/gateway/src/ai-providers/health.ts`
+- [X] T017 [US3] Implement deterministic `AiProviderService` snapshot composition and refresh in `packages/gateway/src/ai-providers/service.ts`
+- [X] T018 [US3] Register the authenticated read-only provider endpoint and validate dependencies at registration in `packages/gateway/src/ai-providers/routes.ts` and `packages/gateway/src/server.ts`
+- [X] T019 [US3] Adapt `GET /api/settings/agent` from the canonical snapshot while preserving the V2 compatibility response in `packages/gateway/src/agent-config/service.ts` and `packages/gateway/src/routes/settings.ts`
+- [X] T020 [US3] Document the gateway domain source of truth, cache ownership, shutdown, auth, and deferred mutations in `packages/gateway/src/ai-providers/DOMAIN.md`
+- [X] T021 [US3] Run gateway/contract tests and the gateway TypeScript project check for the service checkpoint
+
+**Checkpoint**: The gateway has one canonical provider/account truth and the legacy Settings route is only an adapter.
+
+---
+
+## Phase 4: User Story 3 — Chat and Settings Parity (Priority: P1)
+
+**Goal**: Make Chat and Settings consume the same access-source, account, harness, and model snapshot without silently switching funding.
+
+**Independent Test**: The decisive fixture renders Matrix AI as ready/included, Anthropic and OpenRouter as not connected, the Agent SDK kernel as ready, and Claude Sonnet 5 as selectable only through the Matrix-funded instance in both Chat and Settings.
+
+### Tests for User Story 3
+
+- [ ] T022 [P] [US3] Add failing canonical Chat catalog tests for the kernel Matrix-funded and owner-funded instances in `tests/gateway/chat-provider-catalog.test.ts`
+- [ ] T023 [P] [US3] Add failing bounded client normalization and safe-error tests for `/api/ai/providers` in `tests/shell/ai-provider-client.test.ts`
+- [ ] T024 [P] [US3] Add failing Settings rendering tests for separate funding, account, harness, readiness, and model labels in `tests/shell/agent-runtime-panel.test.tsx`
+- [ ] T025 [P] [US3] Add failing Chat setup/model-picker tests proving unavailable models cannot be selected and drafts remain local in `tests/shell/chat-app-provider-state.test.tsx`
+
+### Implementation for User Story 3
+
+- [ ] T026 [US3] Inject the canonical provider snapshot into Chat catalog generation and add the `kernel` instances in `packages/gateway/src/chat/provider-catalog.ts` and `packages/gateway/src/chat/provider-routes.ts`
+- [ ] T027 [US3] Implement the bounded shell provider client and serializable stable derivation helpers in `shell/src/lib/ai-providers.ts`
+- [ ] T028 [US3] Render truthful access-source and owner-account cards from the canonical snapshot in `shell/src/components/settings/sections/AgentRuntimePanel.tsx`
+- [ ] T029 [US3] Replace the hard-coded Chat model list with the canonical ready-instance/model projection while preserving the active draft in `shell/src/components/ChatApp.tsx` and `shell/src/components/chat-app-hermes.ts`
+- [ ] T030 [US3] Reuse the canonical provider client for desktop Chat catalog normalization in `desktop/src/renderer/src/features/chat/chat-provider-catalog.ts`
+- [ ] T031 [US3] Run Chat/Settings parity tests, React Doctor on changed shell files, and the shell production build
+
+**Checkpoint**: Chat and Settings display identical provider truth; existing chats remain readable and unavailable selections cannot be submitted.
+
+---
+
+## Phase 5: Polish and Review Gates
+
+**Purpose**: Validate failure modes, keep the PR layers reviewable, and freeze the phase for review.
+
+- [ ] T032 [P] Run `bun run typecheck` and `bun run check:patterns:diff` from the repository root
+- [ ] T033 [P] Run `bun run test` and record any unrelated platform-specific baseline failures in the PR body
+- [ ] T034 Run the spec quickstart provider-snapshot fixture and verify client/log output contains no secrets, raw provider errors, or filesystem paths
+- [ ] T035 Mark every completed task `[X]` in `specs/118-ai-gateway-provider-auth/tasks.md` and update Phase 2 implementation notes in `specs/118-ai-gateway-provider-auth/quickstart.md`
+- [ ] T036 Publish the Graphite stack, resolve review feedback to Greptile 5/5, add `ready-for-ci`, and monitor label-triggered CI to green
+
+---
+
+## Dependencies and Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Starts from merged `main` at `53cd01a66fb338df330ef89bede0190a82723e3a`.
+- **Foundational contracts (Phase 2)**: Depends on Setup and blocks all provider projection work.
+- **Gateway truth (Phase 3)**: Depends on the V3 schemas and is independently testable through `GET /api/ai/providers`.
+- **Chat/Settings parity (Phase 4)**: Depends on the gateway truth and remains independently reviewable as an upstack PR.
+- **Polish (Phase 5)**: Depends on both Graphite layers.
+
+### User Story Dependencies
+
+- **User Story 3** is the sole Phase 2 product story and can be validated at both the gateway and renderer checkpoints.
+- User Story 1 funded activation depends on this phase but remains Phase 3 of the delivery plan.
+- User Story 2 provider login mutations remain Phase 4 of the delivery plan.
+
+### Parallel Opportunities
+
+- T004 and T005 can be authored independently before T006/T007.
+- T009–T012 cover different boundaries and can be authored independently before service implementation.
+- T022–T025 cover gateway, client, Settings, and Chat surfaces in separate files.
+- T032 and T033 may run concurrently after implementation freezes.
+
+---
+
+## Graphite Stack Plan
+
+- **Stack 1/2 — `feat(gateway): add canonical ai provider snapshot`**: T001–T021. Contracts, explicit credential source, bounded gateway service, authenticated read route, and V2 Settings compatibility adapter.
+- **Stack 2/2 — `feat(chat): unify provider account and model state`**: T022–T036. Canonical kernel instances, Chat/Settings parity, shell client/UI, validation, and monitoring.
+
+Each layer stays below the Matrix OS review limits, carries the backend invariants section, reaches Greptile 5/5 on its exact head, and runs label-gated CI. The layers are not flattened.
+
+---
+
+## Implementation Strategy
+
+1. Land the strict V3 contract before service behavior.
+2. Make the decisive Matrix-included/owner-disconnected fixture green at the gateway.
+3. Treat existing V2 settings and Chat catalog shapes as compatibility projections only.
+4. Move renderers to the V3 snapshot without changing provider-login mutations or funded relay activation.
+5. Freeze and review each Graphite layer independently.
+
+## Deferred Scope
+
+- Anthropic/OpenRouter connect, probe, save, callback, and disconnect mutations.
+- Production funded relay credentials, eligibility/cohort refresh, and VPS provisioning.
+- Per-user allowances, usage persistence, metering, purchases, refunds, and add-ons.
+- Remote signed catalogs, Baseten, generic ACP, Cursor, and Grok.
+- Public docs publication and production rollout, which remain required before general availability.

--- a/tests/contracts/agent-runtime-config.test.ts
+++ b/tests/contracts/agent-runtime-config.test.ts
@@ -201,6 +201,29 @@ describe("agent runtime configuration contracts", () => {
     expect(AgentSettingsViewSchema.parse(makeView()).contractVersion).toBe(2);
   });
 
+  it("represents no active Chat route without weakening messaging validation", () => {
+    const inactive = makeView({
+      chat: null,
+      currentSelection: {
+        chat: null,
+        messaging: makeView().currentSelection.messaging,
+      },
+    });
+    expect(AgentSettingsViewSchema.safeParse(inactive).success).toBe(true);
+    expect(AgentSettingsViewSchema.safeParse({
+      ...inactive,
+      currentSelection: {
+        chat: null,
+        messaging: {
+          runtime: "hermes",
+          provider: "missing-provider",
+          model: "missing-model",
+          configured: true,
+        },
+      },
+    }).success).toBe(false);
+  });
+
   it("aligns the additive Chat selection with legacy effective defaults", () => {
     const defaultSelection = { ...chatSelection, source: "default" as const };
     const view = makeView({

--- a/tests/contracts/ai-provider.test.ts
+++ b/tests/contracts/ai-provider.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import {
+  AiProviderSnapshotV3Schema,
+  type AiProviderSnapshotV3,
+} from "@matrix-os/contracts";
+
+const now = "2026-08-29T20:30:00.000Z";
+
+function snapshotFixture(): AiProviderSnapshotV3 {
+  return {
+    contractVersion: 3,
+    revision: 7,
+    refreshedAt: now,
+    accessSources: [{
+      id: "matrix_included",
+      displayName: "Matrix AI",
+      fundingKind: "matrix_included",
+      vendor: "anthropic",
+      state: "ready",
+      accountLabel: "Included",
+      checkedAt: now,
+      staleAfter: null,
+      action: "none",
+      safeReason: null,
+      eligibleModelIds: ["claude-sonnet-5"],
+      policyVersion: "bundled_2026_08_29",
+    }],
+    accounts: [{
+      id: "owner_anthropic",
+      vendor: "anthropic",
+      authMethod: null,
+      state: "setup_required",
+      accountLabel: null,
+      checkedAt: null,
+      staleAfter: null,
+      action: "connect",
+      safeReason: null,
+    }, {
+      id: "owner_openrouter",
+      vendor: "openrouter",
+      authMethod: null,
+      state: "setup_required",
+      accountLabel: null,
+      checkedAt: null,
+      staleAfter: null,
+      action: "connect",
+      safeReason: null,
+    }],
+    drivers: [{
+      id: "kernel",
+      displayName: "Matrix Agent",
+      kind: "agent_sdk",
+      installState: "installed",
+      health: "ready",
+      capabilities: ["tools", "resume", "subagents", "vision", "reasoning", "cancellation"],
+      setupActions: [],
+    }],
+    instances: [{
+      id: "kernel_matrix_included",
+      driverId: "kernel",
+      vendor: "anthropic",
+      accountId: null,
+      accessSourceId: "matrix_included",
+      label: "Matrix AI",
+      readiness: {
+        state: "ready",
+        checkedAt: now,
+        staleAfter: null,
+        action: "none",
+        safeReason: null,
+      },
+      capabilitySnapshot: ["tools", "resume", "subagents", "vision", "reasoning", "cancellation"],
+      modelIds: ["claude-sonnet-5"],
+      defaultModelId: "claude-sonnet-5",
+      catalogVersion: "bundled_2026_08_29",
+    }],
+    models: [{
+      id: "claude-sonnet-5",
+      vendor: "anthropic",
+      displayName: "Claude Sonnet 5",
+      status: "current",
+      capabilities: ["tools", "vision", "reasoning", "long_context"],
+      effortControls: ["low", "medium", "high", "max"],
+      eligibleAccessSourceIds: ["matrix_included"],
+      dataPolicies: [{
+        accessSourceId: "matrix_included",
+        route: "matrix_relay",
+        disclosureKey: "matrix-cloudflare-anthropic",
+      }],
+      aliases: [],
+      catalogVersion: "bundled_2026_08_29",
+    }],
+    active: {
+      providerInstanceId: "kernel_matrix_included",
+      accessSourceId: "matrix_included",
+      modelId: "claude-sonnet-5",
+    },
+  };
+}
+
+describe("AI provider snapshot V3", () => {
+  it("keeps Matrix-funded readiness separate from owner account connection state", () => {
+    const parsed = AiProviderSnapshotV3Schema.parse(snapshotFixture());
+
+    expect(parsed.contractVersion).toBe(3);
+    expect(parsed.accessSources[0]).toMatchObject({
+      id: "matrix_included",
+      state: "ready",
+      accountLabel: "Included",
+    });
+    expect(parsed.accounts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "owner_anthropic", state: "setup_required" }),
+      expect.objectContaining({ id: "owner_openrouter", state: "setup_required" }),
+    ]));
+  });
+
+  it("rejects duplicate identifiers and active references outside the snapshot", () => {
+    const fixture = snapshotFixture();
+    expect(AiProviderSnapshotV3Schema.safeParse({
+      ...fixture,
+      accounts: [fixture.accounts[0], fixture.accounts[0]],
+    }).success).toBe(false);
+    expect(AiProviderSnapshotV3Schema.safeParse({
+      ...fixture,
+      active: { ...fixture.active, modelId: "claude-unknown" },
+    }).success).toBe(false);
+  });
+
+  it("requires instance models to be allowed by both the source and model policy", () => {
+    const fixture = snapshotFixture();
+    expect(AiProviderSnapshotV3Schema.safeParse({
+      ...fixture,
+      accessSources: [{ ...fixture.accessSources[0], eligibleModelIds: [] }],
+    }).success).toBe(false);
+    expect(AiProviderSnapshotV3Schema.safeParse({
+      ...fixture,
+      models: [{ ...fixture.models[0], eligibleAccessSourceIds: [] }],
+    }).success).toBe(false);
+    expect(AiProviderSnapshotV3Schema.safeParse({
+      ...fixture,
+      models: [{ ...fixture.models[0], dataPolicies: [] }],
+    }).success).toBe(false);
+  });
+
+  it("requires one truthful route disclosure for every eligible access source", () => {
+    const fixture = snapshotFixture();
+    fixture.accessSources.push({
+      ...fixture.accessSources[0],
+      id: "owner_anthropic_key",
+      displayName: "Anthropic API key",
+      fundingKind: "owner_api_key",
+      accountLabel: null,
+      state: "setup_required",
+      checkedAt: null,
+      action: "enter_api_key",
+    });
+    const dualSourceModel = {
+      ...fixture.models[0],
+      eligibleAccessSourceIds: ["matrix_included", "owner_anthropic_key"],
+      dataPolicies: [
+        ...fixture.models[0].dataPolicies,
+        {
+          accessSourceId: "owner_anthropic_key",
+          route: "owner_direct" as const,
+          disclosureKey: "owner-direct-anthropic",
+        },
+      ],
+    };
+
+    expect(AiProviderSnapshotV3Schema.safeParse({
+      ...fixture,
+      models: [dualSourceModel],
+    }).success).toBe(true);
+    expect(AiProviderSnapshotV3Schema.safeParse({
+      ...fixture,
+      models: [{ ...dualSourceModel, dataPolicies: dualSourceModel.dataPolicies.slice(0, 1) }],
+    }).success).toBe(false);
+  });
+
+  it("rejects credential-shaped fields and unsafe client labels", () => {
+    const fixture = snapshotFixture();
+    expect(AiProviderSnapshotV3Schema.safeParse({
+      ...fixture,
+      accounts: [{ ...fixture.accounts[0], secretRef: "owner-secret" }],
+    }).success).toBe(false);
+    expect(AiProviderSnapshotV3Schema.safeParse({
+      ...fixture,
+      accessSources: [{ ...fixture.accessSources[0], accountLabel: "api_key=sk-secret" }],
+    }).success).toBe(false);
+  });
+
+  it("caps every externally rendered collection", () => {
+    const fixture = snapshotFixture();
+    expect(AiProviderSnapshotV3Schema.safeParse({
+      ...fixture,
+      accessSources: Array.from({ length: 17 }, (_, index) => ({
+        ...fixture.accessSources[0],
+        id: `matrix_included_${index}`,
+      })),
+    }).success).toBe(false);
+  });
+});

--- a/tests/contracts/canonical-chat-provider.test.ts
+++ b/tests/contracts/canonical-chat-provider.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { CanonicalProviderDriverKindSchema } from "@matrix-os/contracts";
+
+describe("canonical Chat provider drivers", () => {
+  it("recognizes the Matrix Agent SDK kernel as an execution driver", () => {
+    expect(CanonicalProviderDriverKindSchema.parse("kernel")).toBe("kernel");
+  });
+});

--- a/tests/gateway/ai-provider-routes.test.ts
+++ b/tests/gateway/ai-provider-routes.test.ts
@@ -1,0 +1,72 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { AiProviderSnapshotV3Schema, type AiProviderSnapshotV3 } from "@matrix-os/contracts";
+import { createAiProviderRoutes } from "../../packages/gateway/src/ai-providers/routes.js";
+
+const emptySnapshot: AiProviderSnapshotV3 = {
+  contractVersion: 3,
+  revision: 0,
+  refreshedAt: "2026-08-29T21:00:00.000Z",
+  accessSources: [],
+  accounts: [],
+  drivers: [],
+  instances: [],
+  models: [],
+  active: { providerInstanceId: null, accessSourceId: null, modelId: null },
+};
+
+describe("AI provider routes", () => {
+  it("authenticates and returns the bounded canonical provider snapshot", async () => {
+    const getSnapshot = vi.fn(async () => emptySnapshot);
+    const getPrincipal = vi.fn(() => ({ userId: "owner_123" }));
+    const app = new Hono();
+    app.route("/api/ai", createAiProviderRoutes({
+      service: { getSnapshot },
+      getPrincipal,
+    }));
+
+    const response = await app.request("/api/ai/providers");
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(AiProviderSnapshotV3Schema.parse(body)).toEqual(emptySnapshot);
+    expect(getPrincipal).toHaveBeenCalledOnce();
+    expect(getSnapshot).toHaveBeenCalledWith({ refresh: false });
+  });
+
+  it("supports an explicit bounded refresh and rejects unknown query values", async () => {
+    const getSnapshot = vi.fn(async () => emptySnapshot);
+    const app = new Hono();
+    app.route("/api/ai", createAiProviderRoutes({
+      service: { getSnapshot },
+      getPrincipal: () => ({ userId: "owner_123" }),
+    }));
+
+    expect((await app.request("/api/ai/providers?refresh=true")).status).toBe(200);
+    expect(getSnapshot).toHaveBeenLastCalledWith({ refresh: true });
+    expect((await app.request("/api/ai/providers?refresh=yes")).status).toBe(400);
+  });
+
+  it("maps service failures to a provider-neutral response", async () => {
+    const app = new Hono();
+    app.route("/api/ai", createAiProviderRoutes({
+      service: { getSnapshot: async () => { throw new Error("Anthropic sk-secret /opt/private"); } },
+      getPrincipal: () => ({ userId: "owner_123" }),
+    }));
+
+    const response = await app.request("/api/ai/providers");
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toEqual({ error: "AI provider status is unavailable" });
+    expect(JSON.stringify(body)).not.toContain("Anthropic");
+    expect(JSON.stringify(body)).not.toContain("/opt/private");
+  });
+
+  it("fails registration when a required dependency is absent", () => {
+    expect(() => createAiProviderRoutes({
+      service: undefined as never,
+      getPrincipal: () => ({ userId: "owner_123" }),
+    })).toThrow("AI provider service is required");
+  });
+});

--- a/tests/gateway/ai-provider-service.test.ts
+++ b/tests/gateway/ai-provider-service.test.ts
@@ -24,12 +24,16 @@ describe("AiProviderService", () => {
 
   function createService(options: {
     platformKey?: string;
+    fundedEnabled?: boolean;
     healthProbe?: AiProviderHealthProbe;
     healthTimeoutMs?: number;
   } = {}) {
     return new AiProviderService({
       homePath,
-      env: options.platformKey ? { ANTHROPIC_API_KEY: options.platformKey } : {},
+      env: options.platformKey ? {
+        ANTHROPIC_API_KEY: options.platformKey,
+        MATRIX_FUNDED_AI_ENABLED: options.fundedEnabled === false ? "0" : "1",
+      } : {},
       now: () => NOW,
       healthProbe: options.healthProbe,
       healthTimeoutMs: options.healthTimeoutMs,
@@ -62,6 +66,25 @@ describe("AiProviderService", () => {
       modelId: "claude-sonnet-5",
     });
     expect(JSON.stringify(snapshot)).not.toContain("platform-secret");
+  });
+
+  it("does not label a legacy platform key as Matrix-funded access", async () => {
+    const snapshot = await createService({
+      platformKey: "legacy-platform-secret",
+      fundedEnabled: false,
+    }).getSnapshot();
+
+    expect(snapshot.accessSources).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "matrix_included", state: "disabled" }),
+    ]));
+    expect(snapshot.instances).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "kernel_matrix_included", readiness: { state: "ready" } }),
+    ]));
+    expect(snapshot.active).toEqual({
+      providerInstanceId: null,
+      accessSourceId: null,
+      modelId: null,
+    });
   });
 
   it("does not silently fall back to Matrix funding when an owner source is explicitly selected", async () => {

--- a/tests/gateway/ai-provider-service.test.ts
+++ b/tests/gateway/ai-provider-service.test.ts
@@ -157,6 +157,63 @@ describe("AiProviderService", () => {
       ]));
   });
 
+  it("makes Fable selectable through verified owner Anthropic access", async () => {
+    await writeFile(
+      join(homePath, "system/config.json"),
+      JSON.stringify({ kernel: { anthropicApiKey: "owner-secret", model: "claude-fable-5" } }),
+    );
+    const healthProbe: AiProviderHealthProbe = async (sourceId) => sourceId === "owner_anthropic_key"
+      ? {
+          state: "ready",
+          checkedAt: NOW.toISOString(),
+          staleAfter: "2026-08-29T21:05:00.000Z",
+          action: "none",
+          safeReason: null,
+        }
+      : null;
+
+    const snapshot = await createService({ healthProbe }).getSnapshot({ refresh: true });
+
+    expect(snapshot.accessSources.find((source) => source.id === "owner_anthropic_key")?.eligibleModelIds)
+      .toContain("claude-fable-5");
+    expect(snapshot.models.find((model) => model.id === "claude-fable-5")).toMatchObject({
+      eligibleAccessSourceIds: ["owner_anthropic_key", "owner_anthropic_profile"],
+      dataPolicies: [{
+        accessSourceId: "owner_anthropic_key",
+        route: "owner_direct",
+        disclosureKey: "owner-direct-anthropic",
+      }, {
+        accessSourceId: "owner_anthropic_profile",
+        route: "owner_direct",
+        disclosureKey: "owner-direct-anthropic",
+      }],
+    });
+    expect(snapshot.active).toEqual({
+      providerInstanceId: "kernel_owner_anthropic_key",
+      accessSourceId: "owner_anthropic_key",
+      modelId: "claude-fable-5",
+    });
+  });
+
+  it("does not silently replace a saved Fable route when Matrix policy excludes it", async () => {
+    await writeFile(
+      join(homePath, "system/config.json"),
+      JSON.stringify({ kernel: { model: "claude-fable-5" } }),
+    );
+
+    const snapshot = await createService({ platformKey: "platform-secret" }).getSnapshot();
+    const matrixInstance = snapshot.instances.find((instance) => instance.id === "kernel_matrix_included");
+
+    expect(snapshot.accessSources.find((source) => source.id === "matrix_included")?.eligibleModelIds)
+      .not.toContain("claude-fable-5");
+    expect(matrixInstance?.defaultModelId).toBeNull();
+    expect(snapshot.active).toEqual({
+      providerInstanceId: null,
+      accessSourceId: null,
+      modelId: null,
+    });
+  });
+
   it("enforces the readiness deadline when a probe ignores its abort signal", async () => {
     await writeFile(
       join(homePath, "system/config.json"),

--- a/tests/gateway/ai-provider-service.test.ts
+++ b/tests/gateway/ai-provider-service.test.ts
@@ -1,0 +1,202 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AiProviderSnapshotV3Schema } from "@matrix-os/contracts";
+import {
+  AiProviderService,
+  type AiProviderHealthProbe,
+} from "../../packages/gateway/src/ai-providers/service.js";
+
+const NOW = new Date("2026-08-29T21:00:00.000Z");
+
+describe("AiProviderService", () => {
+  let homePath: string;
+
+  beforeEach(async () => {
+    homePath = await mkdtemp(join(tmpdir(), "ai-provider-service-"));
+    await mkdir(join(homePath, "system"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(homePath, { recursive: true, force: true });
+  });
+
+  function createService(options: {
+    platformKey?: string;
+    healthProbe?: AiProviderHealthProbe;
+    healthTimeoutMs?: number;
+  } = {}) {
+    return new AiProviderService({
+      homePath,
+      env: options.platformKey ? { ANTHROPIC_API_KEY: options.platformKey } : {},
+      now: () => NOW,
+      healthProbe: options.healthProbe,
+      healthTimeoutMs: options.healthTimeoutMs,
+    });
+  }
+
+  it("projects Matrix-funded readiness independently from disconnected owner accounts", async () => {
+    const service = createService({ platformKey: "platform-secret" });
+    const snapshot = await service.getSnapshot();
+
+    expect(AiProviderSnapshotV3Schema.safeParse(snapshot).success).toBe(true);
+    expect(snapshot.accessSources).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: "matrix_included",
+        fundingKind: "matrix_included",
+        state: "ready",
+        eligibleModelIds: ["claude-sonnet-5"],
+      }),
+    ]));
+    expect(snapshot.accounts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "owner_anthropic", state: "setup_required", authMethod: null }),
+      expect.objectContaining({ id: "owner_openrouter", state: "setup_required", authMethod: null }),
+    ]));
+    expect(snapshot.drivers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "kernel", kind: "agent_sdk", health: "ready" }),
+    ]));
+    expect(snapshot.active).toEqual({
+      providerInstanceId: "kernel_matrix_included",
+      accessSourceId: "matrix_included",
+      modelId: "claude-sonnet-5",
+    });
+    expect(JSON.stringify(snapshot)).not.toContain("platform-secret");
+  });
+
+  it("does not silently fall back to Matrix funding when an owner source is explicitly selected", async () => {
+    await writeFile(
+      join(homePath, "system/config.json"),
+      JSON.stringify({ kernel: { anthropicApiKey: "owner-secret" } }),
+    );
+    const snapshot = await createService({ platformKey: "platform-secret" }).getSnapshot();
+
+    expect(snapshot.accessSources).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "owner_anthropic_key", state: "unknown" }),
+      expect.objectContaining({ id: "matrix_included", state: "ready" }),
+    ]));
+    expect(snapshot.accounts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "owner_anthropic", authMethod: "api_key", state: "unknown" }),
+    ]));
+    expect(snapshot.active).toEqual({
+      providerInstanceId: null,
+      accessSourceId: null,
+      modelId: null,
+    });
+    expect(JSON.stringify(snapshot)).not.toContain("owner-secret");
+  });
+
+  it("uses a verified owner source and retains an explicitly saved legacy model", async () => {
+    await writeFile(
+      join(homePath, "system/config.json"),
+      JSON.stringify({ kernel: { anthropicApiKey: "owner-secret", model: "claude-sonnet-4-5" } }),
+    );
+    const healthProbe: AiProviderHealthProbe = async (sourceId) => sourceId === "owner_anthropic_key"
+      ? {
+          state: "ready",
+          checkedAt: NOW.toISOString(),
+          staleAfter: "2026-08-29T21:05:00.000Z",
+          action: "none",
+          safeReason: null,
+        }
+      : null;
+
+    const snapshot = await createService({ platformKey: "platform-secret", healthProbe }).getSnapshot({ refresh: true });
+    const ownerInstance = snapshot.instances.find((instance) => instance.id === "kernel_owner_anthropic_key");
+
+    expect(ownerInstance).toMatchObject({
+      readiness: { state: "ready" },
+      defaultModelId: "claude-sonnet-4-5",
+    });
+    expect(ownerInstance?.modelIds).toEqual(expect.arrayContaining([
+      "claude-opus-5",
+      "claude-sonnet-5",
+      "claude-haiku-4-5",
+      "claude-sonnet-4-5",
+    ]));
+    expect(snapshot.active).toEqual({
+      providerInstanceId: "kernel_owner_anthropic_key",
+      accessSourceId: "owner_anthropic_key",
+      modelId: "claude-sonnet-4-5",
+    });
+    expect(snapshot.models.find((model) => model.id === "claude-sonnet-5")?.dataPolicies)
+      .toEqual(expect.arrayContaining([
+        {
+          accessSourceId: "matrix_included",
+          route: "matrix_relay",
+          disclosureKey: "matrix-cloudflare-anthropic",
+        },
+        {
+          accessSourceId: "owner_anthropic_key",
+          route: "owner_direct",
+          disclosureKey: "owner-direct-anthropic",
+        },
+      ]));
+  });
+
+  it("enforces the readiness deadline when a probe ignores its abort signal", async () => {
+    await writeFile(
+      join(homePath, "system/config.json"),
+      JSON.stringify({ kernel: { anthropicApiKey: "owner-secret" } }),
+    );
+    let probeSignal: AbortSignal | null = null;
+    const service = createService({
+      healthTimeoutMs: 5,
+      healthProbe: async (sourceId, signal) => {
+        if (sourceId !== "owner_anthropic_key") return null;
+        probeSignal = signal;
+        return await new Promise(() => {});
+      },
+    });
+
+    const pending = service.getSnapshot({ refresh: true });
+    const snapshot = await pending;
+
+    expect(probeSignal?.aborted).toBe(true);
+    expect(snapshot.accessSources).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: "owner_anthropic_key",
+        state: "unavailable",
+        safeReason: "timeout",
+      }),
+    ]));
+    service.close();
+  });
+
+  it("projects disabled Matrix access and unavailable owner credential reads safely", async () => {
+    await mkdir(join(homePath, "system/config.json"));
+    const snapshot = await createService().getSnapshot();
+
+    expect(snapshot.accessSources).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "matrix_included", state: "disabled" }),
+      expect.objectContaining({ id: "owner_anthropic_key", state: "unavailable" }),
+    ]));
+    expect(snapshot.active.modelId).toBeNull();
+  });
+
+  it("reuses bounded health results until refresh is requested", async () => {
+    await writeFile(
+      join(homePath, "system/config.json"),
+      JSON.stringify({ kernel: { anthropicApiKey: "owner-secret" } }),
+    );
+    let calls = 0;
+    const healthProbe: AiProviderHealthProbe = async () => {
+      calls += 1;
+      return {
+        state: "stale",
+        checkedAt: NOW.toISOString(),
+        staleAfter: NOW.toISOString(),
+        action: "retry",
+        safeReason: "timeout",
+      };
+    };
+    const service = createService({ healthProbe });
+
+    expect((await service.getSnapshot()).instances.find((value) => value.id === "kernel_owner_anthropic_key")?.readiness.state).toBe("stale");
+    await service.getSnapshot();
+    expect(calls).toBe(1);
+    await service.getSnapshot({ refresh: true });
+    expect(calls).toBe(2);
+    service.close();
+  });
+});

--- a/tests/gateway/kernel-credentials.test.ts
+++ b/tests/gateway/kernel-credentials.test.ts
@@ -65,6 +65,7 @@ describe("kernel credential resolution", () => {
 
     const sources = await resolveKernelCredentialSources(homePath, {
       ANTHROPIC_API_KEY: "platform-key",
+      MATRIX_FUNDED_AI_ENABLED: "1",
     });
 
     expect(sources).toEqual({
@@ -76,6 +77,16 @@ describe("kernel credential resolution", () => {
     });
     expect(JSON.stringify(sources)).not.toContain("owner-key");
     expect(JSON.stringify(sources)).not.toContain("platform-key");
+  });
+
+  it("does not infer Matrix-funded readiness from a legacy platform key", async () => {
+    await expect(resolveKernelCredentialSources(homePath, {
+      ANTHROPIC_API_KEY: "legacy-platform-key",
+      MATRIX_FUNDED_AI_ENABLED: "0",
+    })).resolves.toMatchObject({
+      selectedMode: "platform",
+      matrixIncluded: { state: "disabled" },
+    });
   });
 
   it("keeps a discovered owner profile unverified until a bounded probe succeeds", async () => {

--- a/tests/gateway/kernel-credentials.test.ts
+++ b/tests/gateway/kernel-credentials.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   buildKernelEnv,
   resolveKernelCredentialMode,
+  resolveKernelCredentialSources,
 } from "../../packages/gateway/src/kernel-credentials.js";
 
 describe("kernel credential resolution", () => {
@@ -54,5 +55,54 @@ describe("kernel credential resolution", () => {
   it("uses platform mode when owner credentials are absent", async () => {
     expect(await resolveKernelCredentialMode(homePath)).toBe("platform");
     await expect(buildKernelEnv(homePath, { ANTHROPIC_API_KEY: "platform-key" })).resolves.toBeUndefined();
+  });
+
+  it("reports Matrix and owner credential sources independently without secrets", async () => {
+    writeFileSync(
+      join(homePath, "system/config.json"),
+      JSON.stringify({ kernel: { anthropicApiKey: "sk-ant-owner-key" } }),
+    );
+
+    const sources = await resolveKernelCredentialSources(homePath, {
+      ANTHROPIC_API_KEY: "platform-key",
+    });
+
+    expect(sources).toEqual({
+      selectedMode: "api_key",
+      selectedAccessSourceId: "owner_anthropic_key",
+      matrixIncluded: { state: "ready" },
+      ownerApiKey: { state: "unverified" },
+      ownerProfile: { state: "setup_required" },
+    });
+    expect(JSON.stringify(sources)).not.toContain("owner-key");
+    expect(JSON.stringify(sources)).not.toContain("platform-key");
+  });
+
+  it("keeps a discovered owner profile unverified until a bounded probe succeeds", async () => {
+    writeFileSync(
+      join(homePath, ".claude.json"),
+      JSON.stringify({ oauthAccount: { accountUuid: "oauth-account" } }),
+    );
+
+    await expect(resolveKernelCredentialSources(homePath, {})).resolves.toEqual({
+      selectedMode: "claude_login",
+      selectedAccessSourceId: "owner_anthropic_profile",
+      matrixIncluded: { state: "disabled" },
+      ownerApiKey: { state: "setup_required" },
+      ownerProfile: { state: "unverified" },
+    });
+  });
+
+  it("distinguishes malformed and unreadable owner credential files", async () => {
+    writeFileSync(join(homePath, "system/config.json"), "{not-json");
+    mkdirSync(join(homePath, ".claude.json"));
+
+    await expect(resolveKernelCredentialSources(homePath, {})).resolves.toEqual({
+      selectedMode: "platform",
+      selectedAccessSourceId: "matrix_included",
+      matrixIncluded: { state: "disabled" },
+      ownerApiKey: { state: "invalid" },
+      ownerProfile: { state: "unavailable" },
+    });
   });
 });

--- a/tests/gateway/settings-agent-summary.test.ts
+++ b/tests/gateway/settings-agent-summary.test.ts
@@ -304,4 +304,93 @@ describe("current and legacy Anthropic models", () => {
       rmSync(providerHome, { recursive: true, force: true });
     }
   });
+
+  it("represents a saved model with no canonical runnable route as inactive", async () => {
+    const providerHome = resolve(mkdtempSync(join(tmpdir(), "settings-provider-inactive-")));
+    mkdirSync(join(providerHome, "system"), { recursive: true });
+    writeFileSync(
+      join(providerHome, "system/config.json"),
+      JSON.stringify({ kernel: { model: "claude-fable-5" } }),
+    );
+    const providerService = new AiProviderService({
+      homePath: providerHome,
+      env: {
+        ANTHROPIC_API_KEY: "platform-secret",
+        MATRIX_FUNDED_AI_ENABLED: "1",
+      },
+    });
+    try {
+      const providerSnapshot = await providerService.getSnapshot();
+      expect(providerSnapshot.active).toEqual({
+        providerInstanceId: null,
+        accessSourceId: null,
+        modelId: null,
+      });
+
+      const view = buildAgentSettingsView({
+        identity: { name: "Matrix Owner" },
+        config: { kernel: { model: "claude-fable-5" } },
+        claudeLoginAvailable: false,
+        platformCredentialAvailable: true,
+        providerSnapshot,
+      });
+
+      expect(view.kernel.model).toBe("claude-fable-5");
+      expect(view.chat).toBeNull();
+      expect(view.currentSelection.chat).toBeNull();
+      expect(view.providers.find((provider) => provider.runtime === null)).toMatchObject({
+        id: "matrix_ai",
+        models: [expect.objectContaining({ id: "claude-sonnet-5", available: true })],
+      });
+      expect(view.providers.find((provider) => provider.runtime === null)?.models)
+        .not.toEqual(expect.arrayContaining([
+          expect.objectContaining({ id: "claude-fable-5", available: true }),
+        ]));
+    } finally {
+      providerService.close();
+      rmSync(providerHome, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves a saved model when the canonical owner route is runnable", async () => {
+    const providerHome = resolve(mkdtempSync(join(tmpdir(), "settings-provider-owner-")));
+    mkdirSync(join(providerHome, "system"), { recursive: true });
+    writeFileSync(
+      join(providerHome, "system/config.json"),
+      JSON.stringify({ kernel: { anthropicApiKey: "owner-secret", model: "claude-fable-5" } }),
+    );
+    const providerService = new AiProviderService({
+      homePath: providerHome,
+      healthProbe: async (sourceId) => sourceId === "owner_anthropic_key"
+        ? {
+            state: "ready",
+            checkedAt: "2026-08-31T09:00:00.000Z",
+            staleAfter: "2026-08-31T09:05:00.000Z",
+            action: "none",
+            safeReason: null,
+          }
+        : null,
+    });
+    try {
+      const providerSnapshot = await providerService.getSnapshot({ refresh: true });
+      const view = buildAgentSettingsView({
+        identity: { name: "Matrix Owner" },
+        config: { kernel: { anthropicApiKey: "owner-secret", model: "claude-fable-5" } },
+        claudeLoginAvailable: false,
+        platformCredentialAvailable: false,
+        providerSnapshot,
+      });
+
+      expect(view.chat).toMatchObject({
+        provider: "anthropic",
+        model: "claude-fable-5",
+        source: "saved",
+        authKind: "api_key",
+      });
+      expect(view.currentSelection.chat).toEqual(view.chat);
+    } finally {
+      providerService.close();
+      rmSync(providerHome, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/gateway/settings-agent-summary.test.ts
+++ b/tests/gateway/settings-agent-summary.test.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path";
 import { Hono } from "hono";
 import { createSettingsRoutes } from "../../packages/gateway/src/routes/settings.js";
 import { buildAgentSettingsView } from "../../packages/gateway/src/agent-config/service.js";
+import { AiProviderService } from "../../packages/gateway/src/ai-providers/service.js";
 
 function stubChannelManager() {
   return {
@@ -266,5 +267,38 @@ describe("current and legacy Anthropic models", () => {
       expect.objectContaining({ id: "claude-haiku-4-5" }),
       expect.objectContaining({ id: "claude-sonnet-4-5", tier: "Legacy" }),
     ]));
+  });
+
+  it("adapts Matrix-funded access without presenting the owner Anthropic account as connected", async () => {
+    const providerHome = resolve(mkdtempSync(join(tmpdir(), "settings-provider-adapter-")));
+    mkdirSync(join(providerHome, "system"), { recursive: true });
+    writeFileSync(join(providerHome, "system/config.json"), "{}");
+    const providerService = new AiProviderService({
+      homePath: providerHome,
+      env: { ANTHROPIC_API_KEY: "platform-secret" },
+    });
+    try {
+      const providerSnapshot = await providerService.getSnapshot();
+      const view = buildAgentSettingsView({
+        identity: { name: "Matrix Owner" },
+        config: {},
+        claudeLoginAvailable: false,
+        platformCredentialAvailable: true,
+        providerSnapshot,
+      });
+
+      expect(view.chat).toMatchObject({ provider: "matrix_ai", authKind: "platform" });
+      expect(view.providers.find((provider) => provider.runtime === null)).toMatchObject({
+        id: "matrix_ai",
+        displayName: "Matrix AI",
+        authKind: "platform",
+        authStatus: { state: "ready", authenticated: true },
+      });
+      expect(providerSnapshot.accounts.find((account) => account.id === "owner_anthropic"))
+        .toMatchObject({ state: "setup_required", authMethod: null });
+    } finally {
+      providerService.close();
+      rmSync(providerHome, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/gateway/settings-agent-summary.test.ts
+++ b/tests/gateway/settings-agent-summary.test.ts
@@ -275,7 +275,10 @@ describe("current and legacy Anthropic models", () => {
     writeFileSync(join(providerHome, "system/config.json"), "{}");
     const providerService = new AiProviderService({
       homePath: providerHome,
-      env: { ANTHROPIC_API_KEY: "platform-secret" },
+      env: {
+        ANTHROPIC_API_KEY: "platform-secret",
+        MATRIX_FUNDED_AI_ENABLED: "1",
+      },
     });
     try {
       const providerSnapshot = await providerService.getSnapshot();


### PR DESCRIPTION
## Summary

- Add strict V3 contracts for access sources, owner accounts, drivers,
  provider instances, readiness, and per-source model data policy.
- Compose a bounded gateway snapshot with an authenticated read route and a
  truthful legacy Settings adapter.
- Distinguish discovered owner credentials from verified readiness, enforce
  hard probe deadlines, and drain the capped health cache on shutdown.

## Why

Matrix-funded availability must never imply that an owner Anthropic account is
connected or that owner-direct traffic uses the Matrix relay. The gateway needs
one secret-free source of truth before Chat, Settings, provider login, or future
metering can make reliable decisions.

## Tests

- 31 focused provider contract, credential, route, Settings, and service tests.
- `bun run typecheck`.
- `bun run check:patterns:diff` (0 violations).

## Review and monitoring

- Draft until Greptile reports 5/5 on this exact head.
- `ready-for-ci` is added only after that review gate passes.
- Label-triggered CI must be green before merge.

## Invariants

- **Source of truth:** `AiProviderService` owns the V3 projection from explicit
  credential observations plus the bundled model policy. Legacy Settings is a
  compatibility adapter only.
- **Lock / transaction scope:** this layer is read-only and adds no database or
  persistent file writes. The readiness cache is capped, TTL/LRU-evicted, and
  drained on gateway shutdown.
- **Acceptable orphan states:** none are created. Unreadable, malformed, stale,
  or unverified sources remain unavailable/unknown without hiding healthy
  sources.
- **Auth source of truth:** the existing gateway authentication boundary and
  request principal protect `GET /api/ai/providers`; client-controlled identity
  or forwarded headers are not used.
- **Deferred scope:** provider connect/disconnect mutations, funded relay
  activation, eligibility, metering, purchases/add-ons, Baseten, and broader
  harness support.

