### PR TITLE
feat(terminal-runtime): add project-scoped workspace foundation

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -170,7 +170,7 @@ export const TerminalTabSchema = z.object({
   uiState: z.object({
     placement: z.enum(["active", "background"]).default("active"),
     lastSeenSeq: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER).nullable().default(null),
-    pinned: z.boolean().default(false),
+    pinned: z.boolean().optional(),
     layoutName: SafeDisplayStringSchema.optional(),
     legacyTabs: z.array(z.object({
       name: SafeDisplayStringSchema.optional(),

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -35,6 +35,7 @@
     "@matrix-os/kernel": "workspace:*",
     "@matrix-os/observability": "workspace:*",
     "@matrix-os/scope-runtime": "workspace:*",
+    "@matrix-os/terminal-runtime": "workspace:*",
     "@pipedream/sdk": "^2.4.3",
     "@types/node-cron": "^3.0.11",
     "chokidar": "^4.0.0",

--- a/packages/terminal-runtime/src/index.ts
+++ b/packages/terminal-runtime/src/index.ts
@@ -1,2 +1,7 @@
 export * from "./workspace-store.js";
 export * from "./runtime.js";
+export * from "./migration.js";
+export * from "./zellij-adapter.js";
+export * from "./socket-client.js";
+export * from "./socket-server.js";
+export * from "./socket-protocol.js";

--- a/packages/terminal-runtime/src/limits.ts
+++ b/packages/terminal-runtime/src/limits.ts
@@ -1,0 +1,15 @@
+export const MAX_TERMINAL_SNAPSHOT_ANSI_BYTES = 5 * 1024 * 1024;
+
+// Zellij's ANSI string and its line arrays describe the same retained output.
+// JSON can expand each control character to six bytes (for example `\\u0001`),
+// so reserve that worst case for both representations plus bounded envelope
+// overhead. This remains a finite per-tab disk/read limit.
+export const MAX_TERMINAL_SNAPSHOT_BYTES =
+  (MAX_TERMINAL_SNAPSHOT_ANSI_BYTES * 6 * 2) + (4 * 1024 * 1024);
+
+// Requests contain only bounded control/input frames. Responses may contain a
+// full validated snapshot, so they get a separate finite allowance without
+// increasing the server's untrusted inbound allocation limit.
+export const MAX_TERMINAL_RUNTIME_REQUEST_FRAME_BYTES = 8 * 1024 * 1024;
+export const MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES =
+  MAX_TERMINAL_SNAPSHOT_BYTES + (1024 * 1024);

--- a/packages/terminal-runtime/src/migration.ts
+++ b/packages/terminal-runtime/src/migration.ts
@@ -1,0 +1,771 @@
+import { randomBytes } from "node:crypto";
+import { lstat, mkdir, open, readFile, readdir, rename, rm, type FileHandle } from "node:fs/promises";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { ProjectIdSchema, TerminalRefSchema, type TerminalRef } from "@matrix-os/contracts";
+import { z } from "zod/v4";
+import { MAX_TERMINAL_SNAPSHOT_ANSI_BYTES } from "./limits.js";
+import { TerminalWorkspaceStore } from "./workspace-store.js";
+
+const MAX_LEGACY_STATE_BYTES = 16 * 1024 * 1024;
+const MAX_REFERENCE_FILE_BYTES = 4 * 1024 * 1024;
+const MAX_LEGACY_SCROLLBACK_BYTES = MAX_TERMINAL_SNAPSHOT_ANSI_BYTES;
+// The legacy store retained its newest NDJSON record even when the serialized
+// JSON line exceeded the five MiB file budget. A five MiB ANSI string can grow
+// to six bytes per code unit when JSON-escaped; keep that historical record
+// readable while retaining a finite migration allocation.
+const MAX_LEGACY_SCROLLBACK_FILE_BYTES = (MAX_LEGACY_SCROLLBACK_BYTES * 6) + (64 * 1024);
+const MAX_LEGACY_SCROLLBACK_PREFIX_BYTES = 64 * 1024;
+const MAX_REFERENCE_FILES = 1_024;
+const JOURNAL_NAME = "terminal-migration-journal.json";
+const STATE_NAME = "terminal-workspaces.json";
+const STAGED_STATE_NAME = "terminal-workspaces.staged.json";
+const LegacyScrollbackRecordSchema = z.union([
+  z.object({
+    type: z.literal("output"),
+    seq: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+    data: z.string().max(MAX_LEGACY_SCROLLBACK_BYTES),
+  }).passthrough(),
+  z.object({
+    type: z.enum(["block-mark", "seq-reserve"]),
+    seq: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  }).passthrough(),
+]);
+const LegacyOversizedOutputRecordSchema = z.object({
+  type: z.literal("output"),
+  seq: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  data: z.string().max(MAX_LEGACY_SCROLLBACK_FILE_BYTES),
+}).passthrough();
+
+const LegacySessionSchema = z.object({
+  name: z.string().min(1).max(128),
+  status: z.enum(["active", "exited"]),
+  createdAt: z.string().datetime({ offset: true }).optional(),
+  cwd: z.string().max(4096).optional(),
+  projectId: ProjectIdSchema.optional(),
+  layoutName: z.string().min(1).max(120).optional(),
+  tabs: z.array(z.object({
+    idx: z.number().int().min(0),
+    name: z.string().min(1).max(120).optional(),
+    focused: z.boolean().optional(),
+    createdAt: z.string().datetime({ offset: true }).optional(),
+  }).passthrough()).max(1_000).optional(),
+  placement: z.enum(["active", "background"]).optional(),
+  lastSeenSeq: z.number().int().min(0).nullable().optional(),
+  agent: z.enum(["claude", "codex", "opencode", "pi"]).optional(),
+}).passthrough();
+const LegacyRegistrySchema = z.object({
+  sessions: z.record(z.string().regex(/^[a-z0-9][a-z0-9_-]{0,63}$/), LegacySessionSchema),
+}).passthrough();
+const JournalSchema = z.object({
+  schemaVersion: z.literal(1),
+  status: z.enum([
+    "staging",
+    "staged",
+    "stopped",
+    "activating",
+    "committed",
+    "rolling_back",
+    "rolled_back",
+    "failed",
+  ]),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true }),
+  legacySessionNames: z.array(z.string().min(1).max(128)).max(10_000),
+  generatedSessionNames: z.array(z.string().regex(/^matrix-w-[0-9a-f]{32}$/)).max(10_001).default([]),
+  terminalRefs: z.record(z.string().min(1).max(128), TerminalRefSchema),
+  backups: z.record(z.string().min(1).max(4096), z.string().max(MAX_LEGACY_SCROLLBACK_BYTES)),
+  generatedPaths: z.array(z.string().min(1).max(4096)).max(20_000),
+}).strict();
+
+type Journal = z.infer<typeof JournalSchema>;
+
+export interface LegacyZellijCutover {
+  stopLegacySessions(names: string[]): Promise<void>;
+  ensureWorkspace(sessionName: string, size: { cols: number; rows: number }): Promise<void>;
+  createShellTab(sessionName: string, input: {
+    internalName: string;
+    cwd: string;
+    command?: never;
+  }): Promise<{ tabId: number; paneId: string }>;
+  findTabByInternalName?(sessionName: string, internalName: string): Promise<{ tabId: number; paneId: string } | undefined>;
+  stopWorkspaceSessions?(sessionNames: string[]): Promise<void>;
+}
+
+export interface TerminalMigrationProject {
+  id: string;
+  cwd: string;
+}
+
+export interface TerminalMigrationResult {
+  status: "committed" | "already_committed";
+  migratedTabs: number;
+  stoppedLegacySessions: number;
+}
+
+export async function migrateTerminalWorkspaces(options: {
+  homePath: string;
+  projects: TerminalMigrationProject[];
+  cutover: LegacyZellijCutover;
+  now?: () => Date;
+}): Promise<TerminalMigrationResult> {
+  const now = options.now ?? (() => new Date());
+  const systemPath = join(options.homePath, "system");
+  const finalStatePath = join(systemPath, STATE_NAME);
+  const stagedStatePath = join(systemPath, STAGED_STATE_NAME);
+  const journalPath = join(systemPath, JOURNAL_NAME);
+  await mkdir(systemPath, { recursive: true, mode: 0o700 });
+
+  let journal = await readJournalIfPresent(journalPath);
+  if (journal?.status === "rolling_back") {
+    await completeTerminalWorkspaceRollback({
+      homePath: options.homePath,
+      cutover: options.cutover,
+      journal,
+      journalPath,
+      now,
+    });
+    journal = await readJournalIfPresent(journalPath);
+  }
+
+  const committedState = await readJsonIfPresent(finalStatePath, MAX_LEGACY_STATE_BYTES);
+  if (isSchemaV2State(committedState)) {
+    if (journal && journal.status !== "committed") {
+      journal.status = "committed";
+      journal.updatedAt = now().toISOString();
+      await writeJsonAtomic(journalPath, journal);
+    }
+    return {
+      status: "already_committed",
+      migratedTabs: Object.keys(journal?.terminalRefs ?? {}).length,
+      stoppedLegacySessions: journal?.legacySessionNames.length ?? 0,
+    };
+  }
+  if (committedState !== undefined) throw new Error("terminal_state_corrupt");
+
+  const registryPath = join(systemPath, "shell-sessions.json");
+  const legacyRaw = await readJsonIfPresent(registryPath, MAX_LEGACY_STATE_BYTES) ?? { sessions: {} };
+  const legacy = LegacyRegistrySchema.parse(legacyRaw);
+  const entries = Object.entries(legacy.sessions);
+  if (entries.length > 10_000) throw new Error("legacy_terminal_capacity");
+  if (!journal || journal.status === "rolled_back" || journal.status === "failed") {
+    const timestamp = now().toISOString();
+    journal = {
+      schemaVersion: 1,
+      status: "staging",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      legacySessionNames: entries.map(([legacyId]) => legacyId),
+      generatedSessionNames: [],
+      terminalRefs: {},
+      backups: { [relative(options.homePath, registryPath)]: JSON.stringify(legacyRaw) },
+      generatedPaths: [],
+    };
+    await writeJsonAtomic(journalPath, journal);
+  }
+
+  const projects = options.projects.map((project) => ({
+    id: ProjectIdSchema.parse(project.id),
+    cwd: canonicalRelativeCwd(options.homePath, project.cwd),
+  }));
+  if (journal.status === "committed") throw new Error("terminal_state_corrupt");
+  if (["staged", "stopped", "activating"].includes(journal.status)) {
+    const stagedState = await readJsonIfPresent(stagedStatePath, MAX_LEGACY_STATE_BYTES);
+    if (!isSchemaV2State(stagedState)) throw new Error("terminal_state_corrupt");
+  }
+  const stagedStore = new TerminalWorkspaceStore({ homePath: options.homePath, statePath: stagedStatePath, now });
+  if (journal.status === "staging") {
+    await stagedStore.ensureWorkspace();
+    for (const [legacyId, session] of entries) {
+      const projectId = classifyProject(session, projects, options.homePath);
+      const workspace = await stagedStore.ensureWorkspace(projectId ? { projectId } : {});
+      const tab = await stagedStore.createMigratedTab(workspace.id, {
+        migrationKey: legacyId,
+        name: session.name,
+        cwd: canonicalRelativeCwd(options.homePath, session.cwd ?? ""),
+        createdAt: session.createdAt,
+        ...(session.agent ? { agent: { providerId: session.agent } } : {}),
+        uiState: {
+          placement: session.placement ?? "active",
+          lastSeenSeq: session.lastSeenSeq ?? null,
+          ...(session.layoutName ? { layoutName: session.layoutName } : {}),
+          ...(session.tabs ? {
+            legacyTabs: session.tabs.map((tab) => ({
+              ...(tab.name ? { name: tab.name } : {}),
+              ...(tab.focused === undefined ? {} : { focused: tab.focused }),
+              ...(tab.createdAt ? { createdAt: tab.createdAt } : {}),
+            })),
+          } : {}),
+        },
+      });
+      journal.terminalRefs[legacyId] = { workspaceId: workspace.id, tabId: tab.id };
+      await migrateNameScopedState(
+        options.homePath,
+        legacyId,
+        journal.terminalRefs[legacyId],
+        stagedStore,
+        journal,
+        journalPath,
+        now,
+      );
+      journal.updatedAt = now().toISOString();
+      await writeJsonAtomic(journalPath, journal);
+    }
+    await persistGeneratedSessionNames(stagedStore, journal, journalPath, now);
+    await stageReferenceRewrites(options.homePath, journal, journalPath, now);
+    journal.status = "staged";
+    journal.updatedAt = now().toISOString();
+    await writeJsonAtomic(journalPath, journal);
+  }
+  if (["staged", "stopped", "activating"].includes(journal.status)) {
+    await persistGeneratedSessionNames(stagedStore, journal, journalPath, now);
+  }
+
+  if (journal.status === "staged") {
+    await options.cutover.stopLegacySessions(journal.legacySessionNames);
+    journal.status = "stopped";
+    journal.updatedAt = now().toISOString();
+    await writeJsonAtomic(journalPath, journal);
+  }
+  if (journal.status === "stopped" || journal.status === "activating") {
+    journal.status = "activating";
+    journal.updatedAt = now().toISOString();
+    await writeJsonAtomic(journalPath, journal);
+    for (const workspace of await stagedStore.listWorkspaces()) {
+      const internal = await stagedStore.getRuntimeWorkspace(workspace.id);
+      if (!internal) throw new Error("staged_workspace_missing");
+      await options.cutover.ensureWorkspace(internal.zellijSessionName, internal.canonicalSize);
+      for (const tab of Object.values(internal.tabs).sort((left, right) => left.order - right.order)) {
+        const ref = { workspaceId: internal.id, tabId: tab.id };
+        let ids = await options.cutover.findTabByInternalName?.(internal.zellijSessionName, tab.zellijTabName);
+        ids ??= tab.zellijTabId !== null && tab.zellijPaneId !== null
+          ? { tabId: tab.zellijTabId, paneId: tab.zellijPaneId }
+          : undefined;
+        ids ??= await options.cutover.createShellTab(internal.zellijSessionName, {
+          internalName: tab.zellijTabName,
+          cwd: tab.cwd,
+        });
+        await stagedStore.activateTab(ref, ids);
+      }
+    }
+    await renameDurable(stagedStatePath, finalStatePath);
+    journal.status = "committed";
+    journal.updatedAt = now().toISOString();
+    await writeJsonAtomic(journalPath, journal);
+  }
+  return {
+    status: "committed",
+    migratedTabs: Object.keys(journal.terminalRefs).length,
+    stoppedLegacySessions: journal.legacySessionNames.length,
+  };
+}
+
+export async function rollbackTerminalWorkspaceMigration(options: {
+  homePath: string;
+  cutover: LegacyZellijCutover;
+  now?: () => Date;
+}): Promise<void> {
+  const now = options.now ?? (() => new Date());
+  const systemPath = join(options.homePath, "system");
+  const journalPath = join(systemPath, JOURNAL_NAME);
+  const journal = await readJournalIfPresent(journalPath);
+  if (!journal) throw new Error("terminal_migration_backup_missing");
+  if (journal.status === "rolled_back") return;
+  if (journal.status !== "rolling_back") {
+    journal.status = "rolling_back";
+    journal.updatedAt = now().toISOString();
+    await writeJsonAtomic(journalPath, journal);
+  }
+  await completeTerminalWorkspaceRollback({
+    homePath: options.homePath,
+    cutover: options.cutover,
+    journal,
+    journalPath,
+    now,
+  });
+}
+
+async function completeTerminalWorkspaceRollback(options: {
+  homePath: string;
+  cutover: LegacyZellijCutover;
+  journal: Journal;
+  journalPath: string;
+  now: () => Date;
+}): Promise<void> {
+  const systemPath = join(options.homePath, "system");
+  const stores = [
+    new TerminalWorkspaceStore({ homePath: options.homePath }),
+    new TerminalWorkspaceStore({
+      homePath: options.homePath,
+      statePath: join(systemPath, STAGED_STATE_NAME),
+    }),
+  ];
+  const zellijNames = new Set<string>(options.journal.generatedSessionNames);
+  let unreadableStores = 0;
+  let finalStoreUnreadable = false;
+  for (const [index, store] of stores.entries()) {
+    try {
+      const workspaceIds = (await store.listWorkspaces()).map((workspace) => workspace.id);
+      const workspaces = await Promise.all(workspaceIds.map((id) => store.getRuntimeWorkspace(id)));
+      for (const workspace of workspaces) {
+        if (workspace) zellijNames.add(workspace.zellijSessionName);
+      }
+    } catch (error: unknown) {
+      unreadableStores += 1;
+      if (index === 0) finalStoreUnreadable = true;
+      // Generated v2 state is disposable during rollback. If it cannot be
+      // inventoried, continue restoring the journaled legacy source of truth
+      // and remove the unreadable state file below.
+      console.warn(
+        "[terminal-runtime] skipped unreadable generated state during rollback",
+        error instanceof Error ? error.name : "unknown_error",
+      );
+    }
+  }
+  // The committed store can contain workspaces created after cutover that do
+  // not exist in the migration journal. If that store cannot be inventoried,
+  // rollback cannot safely stop every generated session or delete its durable
+  // identity, even when the journal contains older migration-era names.
+  if (finalStoreUnreadable || (zellijNames.size === 0 && unreadableStores > 0)) {
+    throw new Error("terminal_migration_session_identity_missing");
+  }
+  const discoveredSessionNames = [...zellijNames].sort();
+  if (JSON.stringify(discoveredSessionNames) !== JSON.stringify(options.journal.generatedSessionNames)) {
+    options.journal.generatedSessionNames = discoveredSessionNames;
+    options.journal.updatedAt = options.now().toISOString();
+    await writeJsonAtomic(options.journalPath, options.journal);
+  }
+  await options.cutover.stopWorkspaceSessions?.(discoveredSessionNames);
+  for (const [relativePath, content] of Object.entries(options.journal.backups)) {
+    await writeTextAtomic(resolveWithinHome(options.homePath, relativePath), content);
+  }
+  for (const relativePath of options.journal.generatedPaths) {
+    await removeDurable(resolveWithinHome(options.homePath, relativePath));
+  }
+  await removeDurable(join(systemPath, STATE_NAME));
+  await removeDurable(join(systemPath, STAGED_STATE_NAME));
+  options.journal.status = "rolled_back";
+  options.journal.updatedAt = options.now().toISOString();
+  await writeJsonAtomic(options.journalPath, options.journal);
+}
+
+async function persistGeneratedSessionNames(
+  store: TerminalWorkspaceStore,
+  journal: Journal,
+  journalPath: string,
+  now: () => Date,
+): Promise<void> {
+  const names: string[] = [];
+  for (const workspace of await store.listWorkspaces()) {
+    const internal = await store.getRuntimeWorkspace(workspace.id);
+    if (!internal) throw new Error("staged_workspace_missing");
+    names.push(internal.zellijSessionName);
+  }
+  names.sort();
+  if (JSON.stringify(names) === JSON.stringify(journal.generatedSessionNames)) return;
+  journal.generatedSessionNames = names;
+  journal.updatedAt = now().toISOString();
+  await writeJsonAtomic(journalPath, journal);
+}
+
+function classifyProject(
+  session: z.infer<typeof LegacySessionSchema>,
+  projects: Array<{ id: string; cwd: string }>,
+  homePath: string,
+): string | undefined {
+  if (session.projectId && projects.some((project) => project.id === session.projectId)) return session.projectId;
+  const cwd = canonicalRelativeCwd(homePath, session.cwd ?? "");
+  const matches = projects.filter((project) => cwd === project.cwd || cwd.startsWith(`${project.cwd}/`));
+  return matches.length === 1 ? matches[0]!.id : undefined;
+}
+
+async function migrateNameScopedState(
+  homePath: string,
+  legacyName: string,
+  ref: TerminalRef,
+  stagedStore: TerminalWorkspaceStore,
+  journal: Journal,
+  journalPath: string,
+  now: () => Date,
+): Promise<void> {
+  const migrations = [
+    { source: join("system", "shell-preferences", `${legacyName}.json`), target: join("system", "terminal-tabs", ref.tabId, "preferences.json"), json: true },
+    { source: join("system", "agent-sessions", `${legacyName}.json`), target: join("system", "terminal-tabs", ref.tabId, "agent.json"), json: true },
+  ];
+  for (const migration of migrations) {
+    const source = join(homePath, migration.source);
+    const content = await readTextIfPresent(source, MAX_REFERENCE_FILE_BYTES);
+    if (content === undefined) continue;
+    journal.backups[migration.source] ??= content;
+    let next = content;
+    if (migration.json) {
+      next = `${JSON.stringify(rewriteTerminalRefs(JSON.parse(content), { [legacyName]: ref }), null, 2)}\n`;
+    }
+    if (!journal.generatedPaths.includes(migration.target)) journal.generatedPaths.push(migration.target);
+    journal.updatedAt = now().toISOString();
+    await writeJsonAtomic(journalPath, journal);
+    await writeTextAtomic(join(homePath, migration.target), next);
+  }
+  await migrateLegacyScrollback(homePath, legacyName, ref, stagedStore, journal, journalPath, now);
+}
+
+async function migrateLegacyScrollback(
+  homePath: string,
+  legacyName: string,
+  ref: TerminalRef,
+  stagedStore: TerminalWorkspaceStore,
+  journal: Journal,
+  journalPath: string,
+  now: () => Date,
+): Promise<void> {
+  const source = join("system", "scrollback", `${legacyName}.ndjson`);
+  const parsedScrollback = await readLegacyScrollback(join(homePath, source));
+  if (parsedScrollback === undefined) return;
+  const target = join("system", "terminal-workspaces", "scrollback", `${ref.tabId}.json`);
+  // The legacy source is read-only during migration, so rollback preserves it
+  // in place and only needs to remove this generated v2 snapshot.
+  if (!journal.generatedPaths.includes(target)) journal.generatedPaths.push(target);
+  journal.updatedAt = now().toISOString();
+  await writeJsonAtomic(journalPath, journal);
+
+  const { records, malformedRecords } = parsedScrollback;
+  if (malformedRecords > 0) {
+    console.warn("[terminal-runtime] skipped malformed legacy scrollback records", {
+      count: malformedRecords,
+    });
+  }
+  const output = records
+    .filter((record): record is z.infer<typeof LegacyScrollbackRecordSchema> & { type: "output"; data: string } => record.type === "output")
+    .sort((left, right) => left.seq - right.seq)
+    .map((record) => record.data);
+  const ansi = retainNewestUtf8Output(output, MAX_LEGACY_SCROLLBACK_BYTES);
+  const lines = ansi.split(/\r?\n/);
+  if (lines.at(-1) === "") lines.pop();
+  const scrollback = lines
+    .flatMap((line) => line.length <= 16_384
+      ? [line]
+      : Array.from({ length: Math.ceil(line.length / 16_384) }, (_, index) => (
+          line.slice(index * 16_384, (index + 1) * 16_384)
+        )))
+    .slice(-100_000);
+  await stagedStore.importSnapshot(ref, {
+    ansi,
+    viewport: [],
+    scrollback,
+    seq: records.reduce((latest, record) => Math.max(latest, record.seq), 0),
+  });
+}
+
+type LegacyScrollbackRecord = z.infer<typeof LegacyScrollbackRecordSchema>;
+
+async function readLegacyScrollback(path: string): Promise<{
+  records: LegacyScrollbackRecord[];
+  malformedRecords: number;
+} | undefined> {
+  try {
+    const entry = await lstat(path);
+    if (!entry.isFile() || entry.isSymbolicLink()) throw new Error("migration_state_invalid");
+    if (entry.size > MAX_LEGACY_SCROLLBACK_FILE_BYTES) {
+      return {
+        records: [await readOversizedLegacyOutputRecord(path, entry.size)],
+        malformedRecords: 0,
+      };
+    }
+    return parseLegacyScrollback(await readFile(path, "utf8"));
+  } catch (error) {
+    if (isMissing(error)) return undefined;
+    throw error;
+  }
+}
+
+function parseLegacyScrollback(content: string): {
+  records: LegacyScrollbackRecord[];
+  malformedRecords: number;
+} {
+  const records: LegacyScrollbackRecord[] = [];
+  let malformedRecords = 0;
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    try {
+      const decoded: unknown = JSON.parse(line);
+      const parsed = LegacyScrollbackRecordSchema.safeParse(decoded);
+      if (parsed.success) records.push(parsed.data);
+      else {
+        const oversizedOutput = LegacyOversizedOutputRecordSchema.safeParse(decoded);
+        if (oversizedOutput.success) {
+          records.push(LegacyScrollbackRecordSchema.parse({
+            ...oversizedOutput.data,
+            data: retainNewestUtf8Output([oversizedOutput.data.data], MAX_LEGACY_SCROLLBACK_BYTES),
+          }));
+        } else {
+          malformedRecords += 1;
+        }
+      }
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error;
+      malformedRecords += 1;
+    }
+  }
+  return { records, malformedRecords };
+}
+
+async function readOversizedLegacyOutputRecord(path: string, size: number): Promise<LegacyScrollbackRecord> {
+  const handle = await open(path, "r");
+  try {
+    const prefixLength = Math.min(size, MAX_LEGACY_SCROLLBACK_PREFIX_BYTES);
+    const prefixBuffer = await readFileWindow(handle, prefixLength, 0);
+    const prefix = prefixBuffer.toString("utf8");
+    const metadata = /^\{"type":"output","seq":([0-9]+),"data":"/.exec(prefix);
+    const seq = metadata ? Number(metadata[1]) : Number.NaN;
+    if (!Number.isSafeInteger(seq)) throw new Error("migration_state_invalid");
+
+    // The legacy writer's size enforcement retained only the newest line when
+    // that line alone exceeded its budget. Read a bounded suffix large enough
+    // for the worst JSON escape expansion (six bytes per retained output byte)
+    // instead of allocating the arbitrarily large source record.
+    const tailLength = Math.min(size, MAX_LEGACY_SCROLLBACK_FILE_BYTES);
+    const tailBuffer = await readFileWindow(handle, tailLength, size - tailLength);
+    let utf8Start = 0;
+    while (
+      utf8Start < tailBuffer.length
+      && (tailBuffer[utf8Start]! & 0b1100_0000) === 0b1000_0000
+    ) utf8Start += 1;
+    const tail = tailBuffer.subarray(utf8Start).toString("utf8").trimEnd();
+    const dataMarker = '"data":"';
+    const markerIndex = tail.indexOf(dataMarker);
+    const encodedStart = markerIndex === -1 ? 0 : markerIndex + dataMarker.length;
+    const atIndex = tail.lastIndexOf(',"at":');
+    const closingQuote = atIndex === -1
+      ? findLastUnescapedQuote(tail, tail.lastIndexOf("}"))
+      : atIndex - 1;
+    if (closingQuote < encodedStart || tail[closingQuote] !== '"') {
+      throw new Error("migration_state_invalid");
+    }
+    const decodedTail = decodeTruncatedJsonString(tail.slice(encodedStart, closingQuote));
+    const data = retainNewestUtf8Output([decodedTail], MAX_LEGACY_SCROLLBACK_BYTES);
+    return LegacyScrollbackRecordSchema.parse({ type: "output", seq, data });
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readFileWindow(handle: FileHandle, length: number, position: number): Promise<Buffer> {
+  const buffer = Buffer.alloc(length);
+  let offset = 0;
+  while (offset < length) {
+    const { bytesRead } = await handle.read(buffer, offset, length - offset, position + offset);
+    if (bytesRead === 0) throw new Error("migration_state_invalid");
+    offset += bytesRead;
+  }
+  return buffer;
+}
+
+function findLastUnescapedQuote(value: string, before: number): number {
+  for (let index = before - 1; index >= 0; index -= 1) {
+    if (value[index] !== '"') continue;
+    let backslashes = 0;
+    for (let cursor = index - 1; cursor >= 0 && value[cursor] === "\\"; cursor -= 1) {
+      backslashes += 1;
+    }
+    if (backslashes % 2 === 0) return index;
+  }
+  return -1;
+}
+
+function decodeTruncatedJsonString(value: string): string {
+  // A suffix can begin inside one JSON escape. At most six leading code units
+  // belong to that partial escape; they are outside the newest retained output.
+  for (let offset = 0; offset <= Math.min(6, value.length); offset += 1) {
+    try {
+      const parsed: unknown = JSON.parse(`"${value.slice(offset)}"`);
+      if (typeof parsed === "string") return parsed;
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error;
+    }
+  }
+  throw new Error("migration_state_invalid");
+}
+
+function retainNewestUtf8Output(chunks: string[], maxBytes: number): string {
+  const retained: string[] = [];
+  let remainingBytes = maxBytes;
+  for (let index = chunks.length - 1; index >= 0 && remainingBytes > 0; index -= 1) {
+    const chunk = chunks[index]!;
+    const chunkBytes = Buffer.byteLength(chunk);
+    if (chunkBytes <= remainingBytes) {
+      retained.unshift(chunk);
+      remainingBytes -= chunkBytes;
+      continue;
+    }
+    const encoded = Buffer.from(chunk);
+    let start = encoded.length - remainingBytes;
+    while (start < encoded.length && (encoded[start]! & 0b1100_0000) === 0b1000_0000) start += 1;
+    retained.unshift(encoded.subarray(start).toString("utf8"));
+    remainingBytes = 0;
+  }
+  return retained.join("");
+}
+
+async function stageReferenceRewrites(
+  homePath: string,
+  journal: Journal,
+  journalPath: string,
+  now: () => Date,
+): Promise<void> {
+  const systemPath = join(homePath, "system");
+  const candidates = [
+    join(systemPath, "terminal-layouts.json"),
+    join(systemPath, "desktop.json"),
+    join(systemPath, "canvas.json"),
+    join(systemPath, "coding-agent-threads.json"),
+    ...(await collectJsonFiles(join(systemPath, "sessions"))),
+    ...(await collectJsonFiles(join(systemPath, "agent-sessions"))),
+  ];
+  const planned: Array<{ path: string; content: string }> = [];
+  for (const path of [...new Set(candidates)].slice(0, MAX_REFERENCE_FILES)) {
+    const content = await readTextIfPresent(path, MAX_REFERENCE_FILE_BYTES);
+    if (content === undefined) continue;
+    const rewritten = rewriteTerminalRefs(JSON.parse(content), journal.terminalRefs);
+    const next = `${JSON.stringify(rewritten, null, 2)}\n`;
+    if (next === content || JSON.stringify(JSON.parse(content)) === JSON.stringify(rewritten)) continue;
+    const relativePath = relative(homePath, path);
+    journal.backups[relativePath] ??= content;
+    planned.push({ path, content: next });
+  }
+  if (planned.length > 0) {
+    journal.updatedAt = now().toISOString();
+    await writeJsonAtomic(journalPath, journal);
+  }
+  for (const rewrite of planned) {
+    await writeTextAtomic(rewrite.path, rewrite.content);
+  }
+}
+
+function rewriteTerminalRefs(value: unknown, refs: Record<string, TerminalRef>): unknown {
+  if (Array.isArray(value)) return value.map((item) => rewriteTerminalRefs(item, refs));
+  if (!value || typeof value !== "object") return value;
+  const record = value as Record<string, unknown>;
+  const next: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(record)) {
+    if (key === "terminalSessionId" && typeof child === "string" && refs[child]) {
+      next.terminalRef = refs[child];
+    } else {
+      next[key] = rewriteTerminalRefs(child, refs);
+    }
+  }
+  if (record.kind === "terminal_session" && typeof record.id === "string" && refs[record.id]) {
+    delete next.id;
+    next.kind = "terminal_tab";
+    next.terminalRef = refs[record.id];
+  }
+  return next;
+}
+
+async function collectJsonFiles(directory: string): Promise<string[]> {
+  try {
+    const files = await readdir(directory, { withFileTypes: true });
+    return files.filter((file) => file.isFile() && !file.isSymbolicLink() && file.name.endsWith(".json"))
+      .map((file) => join(directory, file.name));
+  } catch (error) {
+    if (isMissing(error)) return [];
+    throw error;
+  }
+}
+
+function canonicalRelativeCwd(homePath: string, cwd: string): string {
+  if (cwd === "" || cwd === homePath) return "";
+  const normalized = cwd.startsWith(`${homePath}${sep}`) ? relative(homePath, cwd) : cwd;
+  if (normalized.startsWith("/") || normalized.includes("\0") || normalized.includes("\\")) return "";
+  if (normalized.split("/").some((part) => part === "" || part === "." || part === "..")) return "";
+  return normalized;
+}
+
+function resolveWithinHome(homePath: string, relativePath: string): string {
+  const target = resolve(homePath, relativePath);
+  const root = `${resolve(homePath)}${sep}`;
+  if (!target.startsWith(root)) throw new Error("migration_path_invalid");
+  return target;
+}
+
+async function readJournalIfPresent(path: string): Promise<Journal | undefined> {
+  const raw = await readJsonIfPresent(path, MAX_LEGACY_STATE_BYTES);
+  return raw === undefined ? undefined : JournalSchema.parse(raw);
+}
+
+async function readJsonIfPresent(path: string, maxBytes: number): Promise<unknown | undefined> {
+  const content = await readTextIfPresent(path, maxBytes);
+  return content === undefined ? undefined : JSON.parse(content);
+}
+
+async function readTextIfPresent(path: string, maxBytes: number): Promise<string | undefined> {
+  try {
+    const entry = await lstat(path);
+    if (!entry.isFile() || entry.isSymbolicLink() || entry.size > maxBytes) throw new Error("migration_state_invalid");
+    return readFile(path, "utf8");
+  } catch (error) {
+    if (isMissing(error)) return undefined;
+    throw error;
+  }
+}
+
+async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
+  await writeTextAtomic(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function renameDurable(sourcePath: string, targetPath: string): Promise<void> {
+  await rename(sourcePath, targetPath);
+  await syncDirectory(dirname(targetPath));
+}
+
+async function removeDurable(path: string): Promise<void> {
+  await rm(path, { force: true });
+  try {
+    await syncDirectory(dirname(path));
+  } catch (error) {
+    if (!isMissing(error)) throw error;
+  }
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  const directoryHandle = await open(path, "r");
+  try {
+    await directoryHandle.sync();
+  } finally {
+    await directoryHandle.close();
+  }
+}
+
+async function writeTextAtomic(path: string, content: string): Promise<void> {
+  const directoryPath = dirname(path);
+  await mkdir(directoryPath, { recursive: true, mode: 0o700 });
+  const temporaryPath = `${path}.${randomBytes(8).toString("hex")}.tmp`;
+  const handle = await open(temporaryPath, "wx", 0o600);
+  try {
+    try {
+      await handle.writeFile(content, "utf8");
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await rename(temporaryPath, path);
+    await syncDirectory(directoryPath);
+  } catch (error) {
+    try {
+      await rm(temporaryPath, { force: true });
+    } catch (cleanupError) {
+      console.error(
+        "terminal migration temporary-file cleanup failed",
+        cleanupError instanceof Error ? cleanupError.name : "unknown_error",
+      );
+    }
+    throw error;
+  }
+}
+
+function isSchemaV2State(value: unknown): boolean {
+  return Boolean(value && typeof value === "object" && (value as { schemaVersion?: unknown }).schemaVersion === 2);
+}
+
+function isMissing(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}

--- a/packages/terminal-runtime/src/runtime.ts
+++ b/packages/terminal-runtime/src/runtime.ts
@@ -1,6 +1,8 @@
 import {
   TerminalRefSchema,
+  TerminalPaneActionSchema,
   TerminalWorkspaceIdSchema,
+  type TerminalPaneAction,
   type TerminalRef,
   type TerminalTab,
   type TerminalWorkspace,
@@ -35,6 +37,7 @@ export interface ZellijRuntimeAdapter {
   deleteSession?(sessionName: string): Promise<void>;
   resizeSession?(sessionName: string, size: { cols: number; rows: number }): Promise<void>;
   writeToPane?(sessionName: string, paneId: string, data: Uint8Array): Promise<void>;
+  paneAction?(sessionName: string, tabId: number, action: TerminalPaneAction): Promise<void>;
 }
 
 export interface ZellijAttachment {
@@ -305,6 +308,23 @@ export class TerminalRuntime {
         throw new Error("Terminal tab unavailable");
       }
       await this.zellij.writeToPane(workspace.zellijSessionName, tab.zellijPaneId, data);
+    });
+  }
+
+  async paneAction(refInput: TerminalRef, actionInput: TerminalPaneAction): Promise<void> {
+    const ref = TerminalRefSchema.parse(refInput);
+    const action = TerminalPaneActionSchema.parse(actionInput);
+    if (action.type === "close") {
+      await this.terminateTab(ref);
+      return;
+    }
+    await this.runWorkspaceMutation(async () => {
+      const workspace = await this.requireRuntimeWorkspace(ref.workspaceId);
+      const tab = workspace.tabs[ref.tabId];
+      if (!tab || tab.zellijTabId === null || !this.zellij.paneAction) {
+        throw new Error("Terminal tab unavailable");
+      }
+      await this.zellij.paneAction(workspace.zellijSessionName, tab.zellijTabId, action);
     });
   }
 

--- a/packages/terminal-runtime/src/service.ts
+++ b/packages/terminal-runtime/src/service.ts
@@ -1,0 +1,79 @@
+import { lstat, readFile, readdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { z } from "zod/v4";
+import { migrateTerminalWorkspaces, rollbackTerminalWorkspaceMigration } from "./migration.js";
+import { TerminalRuntime } from "./runtime.js";
+import { TerminalRuntimeSocketClient } from "./socket-client.js";
+import { TerminalRuntimeSocketServer } from "./socket-server.js";
+import { TerminalWorkspaceStore } from "./workspace-store.js";
+import { ZellijCliRuntimeAdapter } from "./zellij-adapter.js";
+
+const ProjectConfigSchema = z.object({
+  id: z.string().min(1).max(160),
+  localPath: z.string().min(1).max(4096),
+}).passthrough();
+const MAX_PROJECT_CONFIG_BYTES = 1024 * 1024;
+
+async function listProjects(homePath: string): Promise<Array<{ id: string; cwd: string }>> {
+  const directory = join(homePath, "projects");
+  let entries;
+  try { entries = await readdir(directory, { withFileTypes: true }); }
+  catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+    throw error;
+  }
+  const projects: Array<{ id: string; cwd: string }> = [];
+  for (const entry of entries.slice(0, 10_000)) {
+    if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
+    const path = join(directory, entry.name, "config.json");
+    try {
+      const info = await lstat(path);
+      if (!info.isFile() || info.isSymbolicLink() || info.size > MAX_PROJECT_CONFIG_BYTES) continue;
+      const project = ProjectConfigSchema.parse(JSON.parse(await readFile(path, "utf8")));
+      projects.push({ id: project.id, cwd: project.localPath });
+    } catch (error) {
+      console.error("[terminal-runtime] project metadata skipped", error);
+    }
+  }
+  return projects;
+}
+
+async function main(): Promise<void> {
+  const homePath = resolve(process.env.MATRIX_HOME ?? process.env.HOME ?? "/home/matrix/home");
+  const socketPath = process.env.MATRIX_TERMINAL_RUNTIME_SOCKET ?? "/run/matrix/terminal-runtime.sock";
+  const mode = process.argv[2];
+  if (mode === "--health-check") {
+    const client = new TerminalRuntimeSocketClient({ socketPath, timeoutMs: 5_000 });
+    await client.listWorkspaces();
+    return;
+  }
+  const zellij = new ZellijCliRuntimeAdapter({
+    homePath,
+    binaryPath: process.env.MATRIX_ZELLIJ_BIN ?? "/opt/matrix/bin/zellij",
+  });
+  if (mode === "--rollback") {
+    await rollbackTerminalWorkspaceMigration({ homePath, cutover: zellij });
+    return;
+  }
+  await migrateTerminalWorkspaces({ homePath, projects: await listProjects(homePath), cutover: zellij });
+  if (mode === "--migrate-only") return;
+
+  const runtime = new TerminalRuntime({ store: new TerminalWorkspaceStore({ homePath }), zellij });
+  await runtime.restoreAll();
+  const server = new TerminalRuntimeSocketServer({ socketPath, runtime });
+  await server.start();
+  let closing = false;
+  const close = async () => {
+    if (closing) return;
+    closing = true;
+    await server.close();
+    await runtime.shutdown();
+  };
+  process.once("SIGTERM", () => { void close().then(() => process.exit(0)); });
+  process.once("SIGINT", () => { void close().then(() => process.exit(0)); });
+}
+
+void main().catch((error: unknown) => {
+  console.error("[terminal-runtime] fatal startup failure", error);
+  process.exit(1);
+});

--- a/packages/terminal-runtime/src/socket-client.ts
+++ b/packages/terminal-runtime/src/socket-client.ts
@@ -1,0 +1,187 @@
+import { randomBytes } from "node:crypto";
+import { createConnection } from "node:net";
+import {
+  TerminalTabClientFrameSchema,
+  TerminalTabServerFrameSchema,
+  TerminalTabSchema,
+  TerminalWorkspaceSchema,
+  type TerminalPaneAction,
+  type TerminalTab,
+  type TerminalWorkspace,
+} from "@matrix-os/contracts";
+import { z } from "zod/v4";
+import { encodeSocketFrame, SocketFrameDecoder } from "./socket-framing.js";
+import { MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES } from "./limits.js";
+import {
+  TerminalRuntimeResponseSchema,
+  type TerminalRuntimeRequest,
+} from "./socket-protocol.js";
+
+export interface TerminalRuntimeSocketClientOptions {
+  socketPath: string;
+  timeoutMs?: number;
+}
+
+export interface TerminalRuntimeSocketStream {
+  send(frame: z.input<typeof TerminalTabClientFrameSchema>): void;
+  close(): void;
+}
+
+export class TerminalRuntimeSocketClient {
+  private readonly socketPath: string;
+  private readonly timeoutMs: number;
+
+  constructor(options: TerminalRuntimeSocketClientOptions) {
+    this.socketPath = options.socketPath;
+    this.timeoutMs = options.timeoutMs ?? 10_000;
+  }
+
+  async listWorkspaces(): Promise<TerminalWorkspace[]> {
+    return z.array(TerminalWorkspaceSchema).max(1_000).parse(await this.call("ListWorkspaces", {}));
+  }
+
+  async ensureWorkspace(input: { projectId?: string } = {}): Promise<TerminalWorkspace> {
+    return TerminalWorkspaceSchema.parse(await this.call("EnsureWorkspace", input));
+  }
+
+  async createTab(workspaceId: string, input: {
+    name: string;
+    cwd: string;
+    command?: string[];
+    agent?: TerminalTab["agent"];
+  }): Promise<TerminalTab> {
+    return TerminalTabSchema.parse(await this.call("CreateTab", { workspaceId, ...input }));
+  }
+
+  async getSnapshot(ref: { workspaceId: string; tabId: string }): Promise<unknown> {
+    return this.call("GetSnapshot", ref);
+  }
+
+  async renameTab(ref: { workspaceId: string; tabId: string }, input: { name: string; baseRevision: number }): Promise<TerminalTab> {
+    return TerminalTabSchema.parse(await this.call("RenameTab", { ...ref, ...input }));
+  }
+
+  async reorderTabs(workspaceId: string, input: { tabIds: string[]; baseRevision: number }): Promise<TerminalWorkspace> {
+    return TerminalWorkspaceSchema.parse(await this.call("ReorderTabs", { workspaceId, ...input }));
+  }
+
+  async terminateTab(ref: { workspaceId: string; tabId: string }): Promise<void> {
+    await this.call("TerminateTab", ref);
+  }
+
+  async paneAction(ref: { workspaceId: string; tabId: string }, action: TerminalPaneAction): Promise<void> {
+    await this.call("PaneAction", { ...ref, action });
+  }
+
+  async writeInput(ref: { workspaceId: string; tabId: string }, data: string): Promise<void> {
+    await this.call("WriteInput", { ...ref, data });
+  }
+
+  async updateTabUiState(ref: { workspaceId: string; tabId: string }, input: {
+    placement?: "active" | "background";
+    lastSeenSeq?: number | null;
+    pinned?: boolean;
+    baseRevision: number;
+  }): Promise<TerminalTab> {
+    return TerminalTabSchema.parse(await this.call("UpdateTabUiState", { ...ref, ...input }));
+  }
+
+  async resize(ref: { workspaceId: string; tabId: string }, input: {
+    mode: "hard" | "soft";
+    size: { cols: number; rows: number };
+  }): Promise<TerminalWorkspace> {
+    return TerminalWorkspaceSchema.parse(await this.call("Resize", { ...ref, ...input }));
+  }
+
+  async deletionImpact(workspaceId: string): Promise<{ runningTabs: number; tabs: TerminalTab[] }> {
+    return z.object({ runningTabs: z.number().int().min(0), tabs: z.array(TerminalTabSchema).max(10_000) }).parse(
+      await this.call("DeletionImpact", { workspaceId }),
+    );
+  }
+
+  async deleteWorkspace(workspaceId: string, input: { confirmTerminate: true }): Promise<void> {
+    await this.call("DeleteWorkspace", { workspaceId, ...input });
+  }
+
+  attach(input: {
+    ref: { workspaceId: string; tabId: string };
+    viewerId: string;
+    fromSeq?: number;
+    mode: "hard" | "soft";
+    size: { cols: number; rows: number };
+    onFrame(frame: z.infer<typeof TerminalTabServerFrameSchema>): void;
+    onClose(): void;
+    onError(error: Error): void;
+  }): TerminalRuntimeSocketStream {
+    const requestId = `req_${randomBytes(16).toString("hex")}`;
+    const socket = createConnection(this.socketPath);
+    const decoder = new SocketFrameDecoder(MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES);
+    let closed = false;
+    const close = () => {
+      if (closed) return;
+      closed = true;
+      socket.end();
+    };
+    socket.once("connect", () => socket.write(encodeSocketFrame({
+      version: 1,
+      requestId,
+      operation: "Attach",
+      input: { ...input.ref, viewerId: input.viewerId, fromSeq: input.fromSeq ?? 0, mode: input.mode, size: input.size },
+    })));
+    socket.on("data", (chunk) => {
+      try {
+        for (const raw of decoder.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))) {
+          input.onFrame(TerminalTabServerFrameSchema.parse(raw));
+        }
+      } catch (error) {
+        input.onError(error instanceof Error ? error : new Error("Invalid terminal runtime frame"));
+        socket.destroy();
+      }
+    });
+    socket.once("error", (error) => input.onError(error));
+    socket.once("close", () => { closed = true; input.onClose(); });
+    return {
+      send: (frame) => {
+        if (closed) throw new Error("Terminal runtime stream closed");
+        socket.write(encodeSocketFrame(TerminalTabClientFrameSchema.parse(frame)));
+      },
+      close,
+    };
+  }
+
+  private call(
+    operation: TerminalRuntimeRequest["operation"],
+    input: Record<string, unknown>,
+  ): Promise<unknown> {
+    const requestId = `req_${randomBytes(16).toString("hex")}`;
+    const request = { version: 1, requestId, operation, input };
+    return new Promise((resolve, reject) => {
+      const socket = createConnection(this.socketPath);
+      const decoder = new SocketFrameDecoder(MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES);
+      const timer = setTimeout(() => {
+        socket.destroy();
+        reject(new Error("Terminal runtime unavailable"));
+      }, this.timeoutMs);
+      timer.unref();
+      const finish = () => clearTimeout(timer);
+      socket.once("connect", () => socket.write(encodeSocketFrame(request)));
+      socket.on("data", (chunk) => {
+        try {
+          const [raw] = decoder.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+          if (raw === undefined) return;
+          const response = TerminalRuntimeResponseSchema.parse(raw);
+          if (!response.ok) throw new Error(response.error.message);
+          if (response.requestId !== requestId) throw new Error("Terminal runtime response mismatch");
+          finish();
+          socket.end();
+          resolve(response.result);
+        } catch (error) {
+          finish();
+          socket.destroy();
+          reject(error);
+        }
+      });
+      socket.once("error", (error) => { finish(); reject(error); });
+    });
+  }
+}

--- a/packages/terminal-runtime/src/socket-framing.ts
+++ b/packages/terminal-runtime/src/socket-framing.ts
@@ -1,0 +1,52 @@
+import {
+  MAX_TERMINAL_RUNTIME_REQUEST_FRAME_BYTES,
+  MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES,
+} from "./limits.js";
+
+function validateFrameLimit(value: number): number {
+  if (!Number.isSafeInteger(value)
+    || value < 1
+    || value > MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES) {
+    throw new Error("Terminal runtime frame limit is invalid");
+  }
+  return value;
+}
+
+export function encodeSocketFrame(
+  value: unknown,
+  maxFrameBytes = MAX_TERMINAL_RUNTIME_REQUEST_FRAME_BYTES,
+): Buffer {
+  const frameLimit = validateFrameLimit(maxFrameBytes);
+  const body = Buffer.from(JSON.stringify(value), "utf8");
+  if (body.byteLength > frameLimit) throw new Error("Terminal runtime frame is too large");
+  const frame = Buffer.allocUnsafe(4 + body.byteLength);
+  frame.writeUInt32BE(body.byteLength, 0);
+  body.copy(frame, 4);
+  return frame;
+}
+
+export class SocketFrameDecoder {
+  private pending = Buffer.alloc(0);
+  private readonly maxFrameBytes: number;
+
+  constructor(maxFrameBytes = MAX_TERMINAL_RUNTIME_REQUEST_FRAME_BYTES) {
+    this.maxFrameBytes = validateFrameLimit(maxFrameBytes);
+  }
+
+  push(chunk: Buffer): unknown[] {
+    if (this.pending.byteLength + chunk.byteLength > this.maxFrameBytes + 4) {
+      throw new Error("Terminal runtime frame is too large");
+    }
+    this.pending = Buffer.concat([this.pending, chunk]);
+    const frames: unknown[] = [];
+    while (this.pending.byteLength >= 4) {
+      const length = this.pending.readUInt32BE(0);
+      if (length > this.maxFrameBytes) throw new Error("Terminal runtime frame is too large");
+      if (this.pending.byteLength < length + 4) break;
+      const body = this.pending.subarray(4, length + 4);
+      this.pending = this.pending.subarray(length + 4);
+      frames.push(JSON.parse(body.toString("utf8")));
+    }
+    return frames;
+  }
+}

--- a/packages/terminal-runtime/src/socket-protocol.ts
+++ b/packages/terminal-runtime/src/socket-protocol.ts
@@ -1,0 +1,126 @@
+import {
+  ProjectIdSchema,
+  SafeDisplayStringSchema,
+  TerminalPaneActionSchema,
+  TerminalRefSchema,
+  TerminalWorkspaceIdSchema,
+} from "@matrix-os/contracts";
+import { z } from "zod/v4";
+
+const RequestIdSchema = z.string().regex(/^req_[0-9a-f]{32}$/);
+const RequestBase = { version: z.literal(1), requestId: RequestIdSchema };
+
+export const TerminalRuntimeRequestSchema = z.discriminatedUnion("operation", [
+  z.object({ ...RequestBase, operation: z.literal("ListWorkspaces"), input: z.object({}).strict() }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal("EnsureWorkspace"),
+    input: z.object({ projectId: ProjectIdSchema.optional() }).strict(),
+  }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal("CreateTab"),
+    input: z.object({
+      workspaceId: TerminalWorkspaceIdSchema,
+      name: SafeDisplayStringSchema,
+      cwd: z.string().max(4096),
+      command: z.array(z.string().min(1).max(4096)).min(1).max(128).optional(),
+      agent: z.object({
+        providerId: z.string().min(1).max(80).regex(/^[a-z0-9]+(?:[._-][a-z0-9]+)*$/),
+        threadId: z.string().regex(/^thread_[A-Za-z0-9_-]+$/).optional(),
+      }).strict().optional(),
+    }).strict(),
+  }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal("GetSnapshot"),
+    input: TerminalRefSchema,
+  }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal("RenameTab"),
+    input: TerminalRefSchema.extend({
+      name: SafeDisplayStringSchema,
+      baseRevision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+    }).strict(),
+  }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal("ReorderTabs"),
+    input: z.object({
+      workspaceId: TerminalWorkspaceIdSchema,
+      tabIds: z.array(z.string().regex(/^tt_[0-9a-f]{32}$/)).max(10_000),
+      baseRevision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+    }).strict(),
+  }).strict(),
+  z.object({ ...RequestBase, operation: z.literal("TerminateTab"), input: TerminalRefSchema }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal("PaneAction"),
+    input: TerminalRefSchema.extend({ action: TerminalPaneActionSchema }).strict(),
+  }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal("WriteInput"),
+    input: TerminalRefSchema.extend({ data: z.string().min(1).max(64 * 1024) }).strict(),
+  }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal("UpdateTabUiState"),
+    input: TerminalRefSchema.extend({
+      placement: z.enum(["active", "background"]).optional(),
+      lastSeenSeq: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER).nullable().optional(),
+      pinned: z.boolean().optional(),
+      baseRevision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+    }).strict(),
+  }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal("Resize"),
+    input: TerminalRefSchema.extend({
+      mode: z.enum(["hard", "soft"]),
+      size: z.object({ cols: z.number().int().min(20).max(500), rows: z.number().int().min(5).max(200) }).strict(),
+    }).strict(),
+  }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal("DeletionImpact"),
+    input: z.object({ workspaceId: TerminalWorkspaceIdSchema }).strict(),
+  }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal("DeleteWorkspace"),
+    input: z.object({ workspaceId: TerminalWorkspaceIdSchema, confirmTerminate: z.literal(true) }).strict(),
+  }).strict(),
+  z.object({
+    ...RequestBase,
+    operation: z.literal("Attach"),
+    input: TerminalRefSchema.extend({
+      viewerId: z.string().min(1).max(128).regex(/^[A-Za-z0-9_.:-]+$/),
+      fromSeq: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER).default(0),
+      mode: z.enum(["hard", "soft"]),
+      size: z.object({ cols: z.number().int().min(20).max(500), rows: z.number().int().min(5).max(200) }).strict(),
+    }).strict(),
+  }).strict(),
+]);
+
+export const TerminalRuntimeResponseSchema = z.discriminatedUnion("ok", [
+  z.object({
+    version: z.literal(1),
+    requestId: RequestIdSchema,
+    ok: z.literal(true),
+    result: z.unknown(),
+  }).strict(),
+  z.object({
+    version: z.literal(1),
+    requestId: RequestIdSchema.optional(),
+    ok: z.literal(false),
+    error: z.object({
+      code: z.enum(["invalid_request", "not_found", "conflict", "unavailable", "failed"]),
+      message: z.string().min(1).max(128),
+    }).strict(),
+  }).strict(),
+]);
+
+export type TerminalRuntimeRequest = z.infer<typeof TerminalRuntimeRequestSchema>;
+export type TerminalRuntimeResponse = z.infer<typeof TerminalRuntimeResponseSchema>;

--- a/packages/terminal-runtime/src/socket-server.ts
+++ b/packages/terminal-runtime/src/socket-server.ts
@@ -1,0 +1,342 @@
+import { chmod, lstat, mkdir, unlink } from "node:fs/promises";
+import { createServer, type Server, type Socket } from "node:net";
+import { dirname } from "node:path";
+import {
+  TerminalTabClientFrameSchema,
+  type TerminalPaneAction,
+  type TerminalRef,
+  type TerminalTabServerFrameSchema,
+  type TerminalTab,
+  type TerminalWorkspace,
+} from "@matrix-os/contracts";
+import type { z } from "zod/v4";
+import type { TerminalSnapshot } from "./workspace-store.js";
+import { encodeSocketFrame, SocketFrameDecoder } from "./socket-framing.js";
+import { MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES } from "./limits.js";
+import {
+  TerminalRuntimeRequestSchema,
+  type TerminalRuntimeRequest,
+  type TerminalRuntimeResponse,
+} from "./socket-protocol.js";
+
+export interface TerminalRuntimeControlApi {
+  listWorkspaces(): Promise<TerminalWorkspace[]>;
+  ensureWorkspace(input?: { projectId?: string }): Promise<TerminalWorkspace>;
+  createTab(workspaceId: string, input: {
+    name: string;
+    cwd: string;
+    command?: string[];
+    agent?: TerminalTab["agent"];
+  }): Promise<TerminalTab>;
+  getSnapshot(ref: { workspaceId: string; tabId: string }): Promise<TerminalSnapshot | undefined>;
+  renameTab(ref: { workspaceId: string; tabId: string }, input: { name: string; baseRevision: number }): Promise<TerminalTab>;
+  reorderTabs(workspaceId: string, input: { tabIds: string[]; baseRevision: number }): Promise<TerminalWorkspace>;
+  terminateTab(ref: { workspaceId: string; tabId: string }): Promise<void>;
+  paneAction(ref: { workspaceId: string; tabId: string }, action: TerminalPaneAction): Promise<void>;
+  writeInput(ref: { workspaceId: string; tabId: string }, data: string): Promise<void>;
+  updateTabUiState(ref: { workspaceId: string; tabId: string }, input: {
+    placement?: "active" | "background";
+    lastSeenSeq?: number | null;
+    pinned?: boolean;
+    baseRevision: number;
+  }): Promise<TerminalTab>;
+  resize(ref: { workspaceId: string; tabId: string }, input: { mode: "hard" | "soft"; size: { cols: number; rows: number } }): Promise<TerminalWorkspace>;
+  deletionImpact(workspaceId: string): Promise<{ runningTabs: number; tabs: TerminalTab[] }>;
+  deleteWorkspace(workspaceId: string, input: { confirmTerminate: boolean }): Promise<void>;
+  attach(ref: TerminalRef, input: {
+    viewerId: string;
+    send(data: Uint8Array): void | Promise<void>;
+    onExit(exitCode: number | null): void | Promise<void>;
+  }): Promise<{ write(data: string): Promise<void>; touch(): void; detach(): Promise<void> }>;
+}
+
+type TerminalServerFrame = z.infer<typeof TerminalTabServerFrameSchema>;
+
+function encodeSocketResponseFrame(value: unknown): Buffer {
+  return encodeSocketFrame(value, MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES);
+}
+
+export interface TerminalRuntimeSocketServerOptions {
+  socketPath: string;
+  runtime: TerminalRuntimeControlApi;
+  maxConnections?: number;
+  idleTimeoutMs?: number;
+}
+
+export class TerminalRuntimeSocketServer {
+  private readonly options: TerminalRuntimeSocketServerOptions;
+  private readonly connections = new Set<Socket>();
+  private server: Server | null = null;
+
+  constructor(options: TerminalRuntimeSocketServerOptions) {
+    this.options = options;
+  }
+
+  async start(): Promise<void> {
+    if (this.server) return;
+    const socketDirectory = dirname(this.options.socketPath);
+    await mkdir(socketDirectory, { recursive: true, mode: 0o700 });
+    const directoryEntry = await lstat(socketDirectory);
+    if (!directoryEntry.isDirectory() || directoryEntry.isSymbolicLink()) {
+      throw new Error("Terminal runtime socket directory is invalid");
+    }
+    await chmod(socketDirectory, 0o700);
+    await removeStaleSocket(this.options.socketPath);
+    const server = createServer((socket) => this.accept(socket));
+    this.server = server;
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      const previousUmask = process.umask(0o177);
+      try {
+        server.listen(this.options.socketPath, () => {
+          server.off("error", reject);
+          resolve();
+        });
+      } finally {
+        process.umask(previousUmask);
+      }
+    });
+    // Defense in depth in case platform-specific socket creation ignores umask.
+    await chmod(this.options.socketPath, 0o600);
+  }
+
+  async close(): Promise<void> {
+    const server = this.server;
+    if (!server) return;
+    this.server = null;
+    for (const socket of this.connections) {
+      socket.end(encodeSocketResponseFrame({
+        version: 1,
+        ok: false,
+        error: { code: "unavailable", message: "Terminal runtime is restarting" },
+      } satisfies TerminalRuntimeResponse));
+    }
+    this.connections.clear();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await unlink(this.options.socketPath).catch((error: unknown) => {
+      if (!isMissing(error)) throw error;
+    });
+  }
+
+  private accept(socket: Socket): void {
+    if (this.connections.size >= (this.options.maxConnections ?? 256)) {
+      socket.end(encodeSocketResponseFrame({
+        version: 1,
+        ok: false,
+        error: { code: "unavailable", message: "Terminal runtime is busy" },
+      } satisfies TerminalRuntimeResponse));
+      return;
+    }
+    this.connections.add(socket);
+    socket.setTimeout(this.options.idleTimeoutMs ?? 30_000, () => socket.destroy());
+    const decoder = new SocketFrameDecoder();
+    let handled = false;
+    let streamMessage: ((raw: unknown) => Promise<void>) | null = null;
+    const pendingStreamFrames: unknown[] = [];
+    socket.on("data", (chunk) => {
+      try {
+        const frames = decoder.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        for (const frame of frames) {
+          if (!handled) {
+            handled = true;
+            void this.handle(socket, frame).then((handler) => {
+              streamMessage = handler;
+              if (!handler) return;
+              for (const pending of pendingStreamFrames.splice(0)) {
+                void handler(pending).catch((error: unknown) => {
+                  console.error(
+                    "[terminal-runtime] buffered stream frame failed",
+                    error instanceof Error ? error.name : "unknown_error",
+                  );
+                  socket.destroy();
+                });
+              }
+            }).catch((error: unknown) => {
+              console.error("[terminal-runtime] attach request failed", error);
+              socket.end(encodeSocketResponseFrame({
+                version: 1,
+                ok: false,
+                error: { code: "failed", message: "Terminal operation failed" },
+              } satisfies TerminalRuntimeResponse));
+            });
+          } else if (streamMessage) {
+            void streamMessage(frame).catch((error: unknown) => {
+              console.error(
+                "[terminal-runtime] stream frame failed",
+                error instanceof Error ? error.name : "unknown_error",
+              );
+              socket.destroy();
+            });
+          } else if (pendingStreamFrames.length < 32) {
+            pendingStreamFrames.push(frame);
+          } else {
+            socket.destroy();
+          }
+        }
+      } catch (error) {
+        console.error(
+          "[terminal-runtime] invalid socket frame",
+          error instanceof Error ? error.name : "unknown_error",
+        );
+        handled = true;
+        socket.end(encodeSocketResponseFrame({
+          version: 1,
+          ok: false,
+          error: { code: "invalid_request", message: "Invalid terminal runtime request" },
+        } satisfies TerminalRuntimeResponse));
+      }
+    });
+    socket.once("close", () => this.connections.delete(socket));
+    socket.once("error", () => this.connections.delete(socket));
+  }
+
+  private async handle(socket: Socket, raw: unknown): Promise<((raw: unknown) => Promise<void>) | null> {
+    const parsed = TerminalRuntimeRequestSchema.safeParse(raw);
+    if (!parsed.success) {
+      socket.end(encodeSocketResponseFrame({
+        version: 1,
+        ok: false,
+        error: { code: "invalid_request", message: "Invalid terminal runtime request" },
+      } satisfies TerminalRuntimeResponse));
+      return null;
+    }
+    if (parsed.data.operation === "Attach") return this.handleAttach(socket, parsed.data);
+    try {
+      const result = await this.dispatch(parsed.data);
+      socket.end(encodeSocketResponseFrame({
+        version: 1,
+        requestId: parsed.data.requestId,
+        ok: true,
+        result,
+      } satisfies TerminalRuntimeResponse));
+      return null;
+    } catch (error: unknown) {
+      console.error("[terminal-runtime] control request failed", error);
+      socket.end(encodeSocketResponseFrame({
+        version: 1,
+        requestId: parsed.data.requestId,
+        ok: false,
+        error: { code: "failed", message: "Terminal operation failed" },
+      } satisfies TerminalRuntimeResponse));
+      return null;
+    }
+  }
+
+  private async handleAttach(
+    socket: Socket,
+    request: Extract<TerminalRuntimeRequest, { operation: "Attach" }>,
+  ): Promise<(raw: unknown) => Promise<void>> {
+    socket.setTimeout(0);
+    const ref = { workspaceId: request.input.workspaceId, tabId: request.input.tabId };
+    const resized = await this.options.runtime.resize(ref, request.input);
+    const tab = resized.tabs.find((candidate) => candidate.id === ref.tabId);
+    if (!tab) throw new Error("Terminal tab not found");
+    const snapshot = await this.options.runtime.getSnapshot(ref);
+    let nextSeq = Math.max(request.input.fromSeq, (snapshot?.seq ?? -1) + 1);
+    let revision = Math.max(tab.revision, snapshot?.revision ?? 0);
+    const send = (frame: TerminalServerFrame) => {
+      if (!socket.destroyed) socket.write(encodeSocketResponseFrame(frame));
+    };
+    send({
+      type: "attached",
+      terminalRef: ref,
+      canonicalSize: resized.canonicalSize,
+      revision,
+      nextSeq,
+    });
+    if (snapshot) {
+      send({ type: "replay-start", terminalRef: ref, revision, fromSeq: request.input.fromSeq });
+      if (request.input.fromSeq < snapshot.seq) {
+        send({ type: "replay-evicted", terminalRef: ref, revision, fromSeq: request.input.fromSeq, nextSeq: snapshot.seq });
+      }
+      send({
+        type: "snapshot",
+        terminalRef: ref,
+        canonicalSize: resized.canonicalSize,
+        revision,
+        presentationRevision: snapshot.presentationRevision,
+        seq: snapshot.seq,
+        ansi: snapshot.ansi,
+        viewport: { top: 0, rows: Math.min(snapshot.viewport.length || resized.canonicalSize.rows, 200) },
+      });
+      send({ type: "replay-end", terminalRef: ref, revision, nextSeq, toSeq: snapshot.seq });
+    }
+    const decoder = new TextDecoder();
+    const viewer = await this.options.runtime.attach(ref, {
+      viewerId: request.input.viewerId,
+      send: (data) => {
+        const text = decoder.decode(data, { stream: true });
+        if (!text) return;
+        send({ type: "output", terminalRef: ref, revision, seq: nextSeq++, data: text });
+      },
+      onExit: (exitCode) => {
+        revision += 1;
+        send({ type: "exit", terminalRef: ref, revision, exitCode });
+        socket.end();
+      },
+    });
+    let detached = false;
+    const detach = async () => {
+      if (detached) return;
+      detached = true;
+      await viewer.detach();
+    };
+    socket.once("close", () => { void detach(); });
+    return async (raw) => {
+      const frame = TerminalTabClientFrameSchema.parse(raw);
+      if (frame.terminalRef.workspaceId !== ref.workspaceId || frame.terminalRef.tabId !== ref.tabId) {
+        throw new Error("Terminal reference mismatch");
+      }
+      if (frame.type === "input") await viewer.write(frame.data);
+      if (frame.type === "resize") {
+        const workspace = await this.options.runtime.resize(ref, frame);
+        revision = workspace.revision;
+        send({ type: "canonical-size", terminalRef: ref, revision, canonicalSize: workspace.canonicalSize });
+      }
+      if (frame.type === "detach") {
+        await detach();
+        socket.end();
+      }
+      if (frame.type === "ping") viewer.touch();
+      if (frame.type === "ping") {
+        send({ type: "pong", terminalRef: ref, revision });
+      }
+    };
+  }
+
+  private dispatch(request: TerminalRuntimeRequest): Promise<unknown> {
+    switch (request.operation) {
+      case "ListWorkspaces": return this.options.runtime.listWorkspaces();
+      case "EnsureWorkspace": return this.options.runtime.ensureWorkspace(request.input);
+      case "CreateTab": return this.options.runtime.createTab(request.input.workspaceId, request.input);
+      case "GetSnapshot": return this.options.runtime.getSnapshot(request.input);
+      case "RenameTab": return this.options.runtime.renameTab(request.input, request.input);
+      case "ReorderTabs": return this.options.runtime.reorderTabs(request.input.workspaceId, request.input);
+      case "TerminateTab": return this.options.runtime.terminateTab(request.input).then(() => null);
+      case "PaneAction": return this.options.runtime.paneAction(
+        { workspaceId: request.input.workspaceId, tabId: request.input.tabId },
+        request.input.action,
+      ).then(() => null);
+      case "WriteInput": return this.options.runtime.writeInput(request.input, request.input.data).then(() => null);
+      case "UpdateTabUiState": return this.options.runtime.updateTabUiState(request.input, request.input);
+      case "Resize": return this.options.runtime.resize(request.input, request.input);
+      case "DeletionImpact": return this.options.runtime.deletionImpact(request.input.workspaceId);
+      case "DeleteWorkspace": return this.options.runtime.deleteWorkspace(request.input.workspaceId, request.input).then(() => null);
+      case "Attach": throw new Error("Attach must use stream dispatch");
+    }
+  }
+}
+
+async function removeStaleSocket(path: string): Promise<void> {
+  try {
+    const entry = await lstat(path);
+    if (!entry.isSocket()) throw new Error("Terminal runtime socket path is occupied");
+    await unlink(path);
+  } catch (error) {
+    if (!isMissing(error)) throw error;
+  }
+}
+
+function isMissing(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}

--- a/packages/terminal-runtime/src/workspace-store.ts
+++ b/packages/terminal-runtime/src/workspace-store.ts
@@ -15,14 +15,12 @@ import {
   type TerminalWorkspace,
 } from "@matrix-os/contracts";
 import { z } from "zod/v4";
+import {
+  MAX_TERMINAL_SNAPSHOT_ANSI_BYTES,
+  MAX_TERMINAL_SNAPSHOT_BYTES,
+} from "./limits.js";
 
 const MAX_STATE_BYTES = 16 * 1024 * 1024;
-const MAX_SNAPSHOT_ANSI_BYTES = 5 * 1024 * 1024;
-// Zellij's ANSI string and its line arrays describe the same retained output.
-// JSON can expand each control character to six bytes (for example `\\u0001`),
-// so reserve that worst case for both representations plus bounded envelope
-// overhead. This remains a finite per-tab disk/read limit.
-const MAX_SNAPSHOT_BYTES = (MAX_SNAPSHOT_ANSI_BYTES * 6 * 2) + (4 * 1024 * 1024);
 const DEFAULT_SIZE = { cols: 120, rows: 36 } as const;
 const InternalTabSchema = TerminalTabSchema.omit({}).extend({
   zellijTabName: z.string().regex(/^matrix-tab-[0-9a-f]{32}$/),
@@ -53,8 +51,9 @@ const SnapshotSchema = z.object({
   schemaVersion: z.literal(1),
   terminalRef: TerminalRefSchema,
   revision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  presentationRevision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER).default(0),
   seq: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
-  ansi: z.string().max(MAX_SNAPSHOT_ANSI_BYTES),
+  ansi: z.string().max(MAX_TERMINAL_SNAPSHOT_ANSI_BYTES),
   viewport: z.array(z.string().max(16_384)).max(200),
   scrollback: z.array(z.string().max(16_384)).max(100_000),
   updatedAt: z.string().datetime({ offset: true }),
@@ -300,6 +299,7 @@ export class TerminalWorkspaceStore {
         schemaVersion: 1,
         terminalRef: ref,
         revision: tab.revision,
+        presentationRevision: previous?.presentationRevision ?? 0,
         seq: (previous?.seq ?? -1) + 1,
         ansi: input.ansi,
         viewport: input.viewport,
@@ -342,6 +342,7 @@ export class TerminalWorkspaceStore {
         schemaVersion: 1,
         terminalRef: ref,
         revision: tab.revision,
+        presentationRevision: (previous?.presentationRevision ?? 0) + 1,
         seq,
         ansi: input.ansi,
         viewport: input.viewport,
@@ -477,7 +478,7 @@ export class TerminalWorkspaceStore {
     const path = this.snapshotPath(ref.tabId);
     try {
       const entry = await lstat(path);
-      if (!entry.isFile() || entry.isSymbolicLink() || entry.size > MAX_SNAPSHOT_BYTES) {
+      if (!entry.isFile() || entry.isSymbolicLink() || entry.size > MAX_TERMINAL_SNAPSHOT_BYTES) {
         throw new TerminalStateCorruptError();
       }
       const snapshot = SnapshotSchema.parse(JSON.parse(await readFile(path, "utf8")));
@@ -531,7 +532,7 @@ export class TerminalWorkspaceStore {
 
   private async persistSnapshot(snapshot: TerminalSnapshot): Promise<void> {
     const content = `${JSON.stringify(SnapshotSchema.parse(snapshot))}\n`;
-    if (Buffer.byteLength(content) > MAX_SNAPSHOT_BYTES) throw new Error("Terminal snapshot capacity reached");
+    if (Buffer.byteLength(content) > MAX_TERMINAL_SNAPSHOT_BYTES) throw new Error("Terminal snapshot capacity reached");
     const target = this.snapshotPath(snapshot.terminalRef.tabId);
     await writeTextAtomic(target, content);
   }

--- a/packages/terminal-runtime/src/zellij-adapter.ts
+++ b/packages/terminal-runtime/src/zellij-adapter.ts
@@ -1,0 +1,532 @@
+import { execFile as nodeExecFile, spawn as spawnProcess } from "node:child_process";
+import { chmod, mkdir, open, rename } from "node:fs/promises";
+import { join } from "node:path";
+import { spawn as spawnNodePty } from "node-pty";
+import { z } from "zod/v4";
+import { TerminalPaneActionSchema, type TerminalPaneAction } from "@matrix-os/contracts";
+import type {
+  ZellijAttachment,
+  ZellijObserver,
+  ZellijObserverEvent,
+  ZellijRuntimeAdapter,
+} from "./runtime.js";
+
+const MAX_COMMAND_OUTPUT_BYTES = 5 * 1024 * 1024;
+const MAX_SUBSCRIPTION_LINE_BYTES = 1024 * 1024;
+const STRUCTURED_READINESS_ATTEMPTS = 20;
+const SESSION_NAME = /^matrix-w-[0-9a-f]{32}$/;
+const TAB_NAME = /^matrix-tab-[0-9a-f]{32}$/;
+const PANE_ID = /^terminal_[0-9]+$/;
+const LEGACY_SESSION_NAME = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/;
+const PaneSchema = z.object({
+  id: z.number().int().min(0),
+  is_plugin: z.boolean(),
+  tab_id: z.number().int().min(0),
+  pane_title: z.string().max(128).optional(),
+}).passthrough();
+const TabSchema = z.object({
+  tab_id: z.number().int().min(0),
+  name: z.string().max(128),
+}).passthrough();
+const SubscribeEventSchema = z.discriminatedUnion("event", [
+  z.object({
+    event: z.literal("pane_update"),
+    pane_id: z.string().regex(PANE_ID),
+    viewport: z.array(z.string().max(16_384)).max(200),
+    scrollback: z.array(z.string().max(16_384)).max(100_000).nullable().optional(),
+    is_initial: z.boolean().optional(),
+  }).strict(),
+  z.object({ event: z.literal("pane_closed"), pane_id: z.string().regex(PANE_ID) }).strict(),
+]);
+
+export interface RuntimePty {
+  resize(cols: number, rows: number): void;
+  kill(): void;
+  onData(listener: (data: string) => void): { dispose(): void };
+  onExit(listener: (event: { exitCode: number; signal?: number }) => void): { dispose(): void };
+}
+
+export interface RuntimeSubscriptionProcess {
+  close(): Promise<void>;
+}
+
+export interface ZellijCliRuntimeAdapterOptions {
+  homePath: string;
+  binaryPath?: string;
+  timeoutMs?: number;
+  run?: (args: string[]) => Promise<string>;
+  spawnPty?: (args: string[], options: { cwd: string; env: Record<string, string>; cols: number; rows: number }) => RuntimePty;
+  spawnSubscription?: (
+    args: string[],
+    onLine: (line: string) => void,
+    onExit: (exitCode: number | null) => void,
+  ) => RuntimeSubscriptionProcess;
+}
+
+export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
+  private readonly homePath: string;
+  private readonly binaryPath: string;
+  private readonly runCommand: (args: string[]) => Promise<string>;
+  private readonly spawnPtyProcess: NonNullable<ZellijCliRuntimeAdapterOptions["spawnPty"]>;
+  private readonly spawnSubscriptionProcess: NonNullable<ZellijCliRuntimeAdapterOptions["spawnSubscription"]>;
+  private readonly workspaceLayoutPath: string;
+
+  constructor(options: ZellijCliRuntimeAdapterOptions) {
+    this.homePath = options.homePath;
+    this.binaryPath = options.binaryPath ?? "/opt/matrix/bin/zellij";
+    this.workspaceLayoutPath = join(options.homePath, "system", "zellij", "runtime-workspace.kdl");
+    this.runCommand = options.run ?? createCommandRunner({
+      binaryPath: this.binaryPath,
+      cwd: this.homePath,
+      env: runtimeEnv(options.homePath),
+      timeoutMs: options.timeoutMs ?? 10_000,
+    });
+    this.spawnPtyProcess = options.spawnPty ?? ((args, spawnOptions) => {
+      return spawnNodePty(this.binaryPath, args, {
+        name: "xterm-256color",
+        cwd: spawnOptions.cwd,
+        env: spawnOptions.env,
+        cols: spawnOptions.cols,
+        rows: spawnOptions.rows,
+      });
+    });
+    this.spawnSubscriptionProcess = options.spawnSubscription ?? ((args, onLine, onExit) => {
+      return spawnLineProcess(this.binaryPath, args, this.homePath, runtimeEnv(this.homePath), onLine, onExit);
+    });
+  }
+
+  async ensureSession(sessionNameInput: string, size = { cols: 120, rows: 36 }): Promise<void> {
+    const sessionName = z.string().regex(SESSION_NAME).parse(sessionNameInput);
+    if ((await this.listSessions()).includes(sessionName)) return;
+    await this.ensureLayout();
+    z.object({ cols: z.number().int().min(20).max(500), rows: z.number().int().min(5).max(200) }).parse(size);
+    await this.run([
+      "attach", "--create-background", sessionName,
+      "options", "--default-layout", this.workspaceLayoutPath,
+    ]);
+    await this.waitForSession(sessionName);
+  }
+
+  ensureWorkspace(sessionName: string, size: { cols: number; rows: number }): Promise<void> {
+    return this.ensureSession(sessionName, size);
+  }
+
+  createShellTab(sessionName: string, input: { internalName: string; cwd: string }): Promise<{ tabId: number; paneId: string }> {
+    return this.createTab(sessionName, input);
+  }
+
+  async stopLegacySessions(namesInput: string[]): Promise<void> {
+    const names = z.array(z.string().regex(LEGACY_SESSION_NAME)).max(10_000).parse(namesInput);
+    for (const name of names) {
+      try { await this.run(["delete-session", name, "--force"]); }
+      catch (error) { console.warn("[terminal-runtime] legacy session already stopped", name, error); }
+    }
+  }
+
+  async stopWorkspaceSessions(names: string[]): Promise<void> {
+    const requested = z.array(z.string().regex(SESSION_NAME)).max(10_000).parse(names);
+    const running = new Set(await this.listSessions());
+    for (const name of requested) {
+      if (!running.has(name)) continue;
+      try { await this.deleteSession(name); } catch (error) { if (!isMissingZellijSessionFailure(error)) throw error; console.warn("[terminal-runtime] workspace session already stopped", error instanceof Error ? error.name : "unknown_error"); }
+    }
+  }
+
+  async createTab(sessionNameInput: string, input: {
+    internalName: string;
+    cwd: string;
+    command?: string[];
+  }): Promise<{ tabId: number; paneId: string }> {
+    const sessionName = z.string().regex(SESSION_NAME).parse(sessionNameInput);
+    const internalName = z.string().regex(TAB_NAME).parse(input.internalName);
+    const cwd = this.resolveCwd(input.cwd);
+    const tabs = await this.readStructuredJson(
+      ["--session", sessionName, "action", "list-tabs", "--json"],
+      z.array(TabSchema).max(10_000),
+    );
+    const bootstrap = tabs.find((tab) => tab.name === "matrix-bootstrap");
+    const output = await this.run([
+      "--session", sessionName, "action", "new-tab",
+      "--name", internalName,
+      "--cwd", cwd,
+      ...(input.command ? ["--", ...input.command] : []),
+    ]);
+    const outputTabId = output.trim();
+    const tabId = /^\d+$/.test(outputTabId)
+      ? z.coerce.number().int().min(0).parse(outputTabId)
+      : await this.waitForTabId(sessionName, internalName);
+    if (bootstrap) {
+      await this.run(["--session", sessionName, "action", "close-tab", "--tab-id", String(bootstrap.tab_id)]);
+    }
+    const paneId = await this.waitForManagedPane(sessionName, tabId);
+    await this.run(["--session", sessionName, "action", "rename-pane", "--pane-id", paneId, internalName]);
+    return { tabId, paneId };
+  }
+
+  async openAttachment(sessionNameInput: string, input: {
+    paneId: string;
+    size: { cols: number; rows: number };
+    onData: (data: Uint8Array) => void;
+    onExit: (exitCode: number | null) => void;
+  }): Promise<ZellijAttachment> {
+    const sessionName = z.string().regex(SESSION_NAME).parse(sessionNameInput);
+    const paneId = z.string().regex(PANE_ID).parse(input.paneId);
+    const pty = this.spawnPtyProcess(["attach", sessionName], {
+      cwd: this.homePath,
+      env: runtimeEnv(this.homePath),
+      cols: input.size.cols,
+      rows: input.size.rows,
+    });
+    const dataDisposable = pty.onData((data) => input.onData(new TextEncoder().encode(data)));
+    const exitDisposable = pty.onExit((event) => input.onExit(event.exitCode));
+    await this.run(["--session", sessionName, "action", "focus-pane-id", paneId]);
+    let closed = false;
+    return {
+      write: async (data) => {
+        if (closed) throw new Error("Terminal attachment closed");
+        await this.run([
+          "--session", sessionName, "action", "write-chars", "--pane-id", paneId, "--",
+          new TextDecoder().decode(data),
+        ]);
+      },
+      resize: async (cols, rows) => { if (!closed) pty.resize(cols, rows); },
+      close: async () => {
+        if (closed) return;
+        closed = true;
+        dataDisposable.dispose();
+        exitDisposable.dispose();
+        pty.kill();
+      },
+    };
+  }
+
+  async writeToPane(sessionNameInput: string, paneIdInput: string, data: Uint8Array): Promise<void> {
+    const sessionName = z.string().regex(SESSION_NAME).parse(sessionNameInput);
+    const paneId = z.string().regex(PANE_ID).parse(paneIdInput);
+    await this.run([
+      "--session", sessionName, "action", "write-chars", "--pane-id", paneId, "--",
+      new TextDecoder().decode(data),
+    ]);
+  }
+
+  async paneAction(
+    sessionNameInput: string,
+    tabIdInput: number,
+    actionInput: TerminalPaneAction,
+  ): Promise<void> {
+    const sessionName = z.string().regex(SESSION_NAME).parse(sessionNameInput);
+    const tabId = z.number().int().min(0).parse(tabIdInput);
+    const action = TerminalPaneActionSchema.parse(actionInput);
+    await this.run(["--session", sessionName, "action", "go-to-tab-by-id", String(tabId)]);
+    await this.run(terminalPaneActionArgs(sessionName, action));
+  }
+
+  async findTabByInternalName(
+    sessionNameInput: string,
+    internalNameInput: string,
+  ): Promise<{ tabId: number; paneId: string } | undefined> {
+    const sessionName = z.string().regex(SESSION_NAME).parse(sessionNameInput);
+    const internalName = z.string().regex(TAB_NAME).parse(internalNameInput);
+    const tabs = await this.readStructuredJson(
+      ["--session", sessionName, "action", "list-tabs", "--json"],
+      z.array(TabSchema).max(10_000),
+    );
+    const tab = tabs.find((candidate) => candidate.name === internalName);
+    if (!tab) return undefined;
+    const panes = await this.readStructuredJson(
+      ["--session", sessionName, "action", "list-panes", "--all", "--json"],
+      z.array(PaneSchema).max(10_000),
+    );
+    const managedPanes = panes.filter((pane) => pane.tab_id === tab.tab_id && !pane.is_plugin);
+    const primaryPane = managedPanes.find((pane) => pane.pane_title === internalName)
+      ?? (managedPanes.length === 1 ? managedPanes[0] : undefined);
+    if (!primaryPane) throw new Error("Managed terminal tab primary pane is unavailable");
+    return { tabId: tab.tab_id, paneId: `terminal_${primaryPane.id}` };
+  }
+
+  async subscribeWorkspace(sessionNameInput: string, input: {
+    paneIds: string[];
+    onEvent: (event: ZellijObserverEvent) => void;
+  }): Promise<ZellijObserver> {
+    const sessionName = z.string().regex(SESSION_NAME).parse(sessionNameInput);
+    const paneIds = z.array(z.string().regex(PANE_ID)).min(1).max(10_000).parse(input.paneIds);
+    let eventChain = Promise.resolve();
+    const args = ["--session", sessionName, "subscribe", "--pane-id", ...paneIds];
+    // `--scrollback` accepts an optional variadic value, so keep it last. If it
+    // precedes pane selectors clap can consume those selectors as values.
+    args.push("--format", "json", "--ansi", "--scrollback");
+    const process = this.spawnSubscriptionProcess(args, (line) => {
+      if (Buffer.byteLength(line) > MAX_SUBSCRIPTION_LINE_BYTES) return;
+      const parsed = SubscribeEventSchema.safeParse(safeJson(line));
+      if (!parsed.success) {
+        console.error("[terminal-runtime] rejected invalid Zellij observer event", parsed.error.issues.map((issue) => issue.path.join(".")));
+        return;
+      }
+      eventChain = eventChain.then(async () => {
+        if (parsed.data.event === "pane_closed") {
+          input.onEvent({ type: "pane-closed", paneId: parsed.data.pane_id });
+          return;
+        }
+        const ansi = await this.run([
+          "--session", sessionName, "action", "dump-screen", "--pane-id", parsed.data.pane_id, "--full", "--ansi",
+        ]);
+        const fullLines = ansi.split(/\r?\n/);
+        const scrollback = parsed.data.scrollback ?? fullLines.slice(0, Math.max(0, fullLines.length - parsed.data.viewport.length));
+        input.onEvent({
+          type: "pane-update",
+          paneId: parsed.data.pane_id,
+          ansi,
+          viewport: parsed.data.viewport,
+          scrollback,
+        });
+      }).catch((error: unknown) => {
+        console.error("[terminal-runtime] Zellij observer update failed", error);
+      });
+    }, (exitCode) => {
+      if (exitCode !== 0 && exitCode !== null) {
+        console.error("[terminal-runtime] Zellij observer exited unexpectedly", exitCode);
+      }
+    });
+    return {
+      close: async () => {
+        await process.close();
+        await eventChain;
+      },
+    };
+  }
+
+  async renameTab(sessionNameInput: string, tabId: number, nameInput: string): Promise<void> {
+    const sessionName = z.string().regex(SESSION_NAME).parse(sessionNameInput);
+    const name = z.string().min(1).max(120).parse(nameInput);
+    await this.run(["--session", sessionName, "action", "rename-tab", "--tab-id", String(tabId), name]);
+  }
+
+  async closeTab(sessionNameInput: string, tabId: number): Promise<void> {
+    const sessionName = z.string().regex(SESSION_NAME).parse(sessionNameInput);
+    await this.run(["--session", sessionName, "action", "close-tab", "--tab-id", String(tabId)]);
+  }
+
+  async deleteSession(sessionNameInput: string): Promise<void> {
+    const sessionName = z.string().regex(SESSION_NAME).parse(sessionNameInput);
+    await this.run(["delete-session", sessionName, "--force"]);
+  }
+
+  async resizeSession(sessionNameInput: string, size: { cols: number; rows: number }): Promise<void> {
+    const sessionName = z.string().regex(SESSION_NAME).parse(sessionNameInput);
+    const parsed = z.object({ cols: z.number().int().min(20).max(500), rows: z.number().int().min(5).max(200) }).parse(size);
+    // Detached workspaces acquire their effective grid from hard-size
+    // attachments. The canonical size remains persisted by the runtime.
+    void parsed;
+  }
+
+  private async listSessions(): Promise<string[]> {
+    try {
+      return (await this.run(["list-sessions", "--no-formatting"]))
+        .split(/\r?\n/)
+        .filter((line) => !/\bEXITED\b/i.test(line))
+        .map((line) => line.trim().split(/\s+/)[0] ?? "")
+        .filter((name) => SESSION_NAME.test(name));
+    } catch (error) {
+      if (isMissingZellijSessionFailure(error)) return [];
+      console.warn(
+        "[terminal-runtime] failed to list Zellij sessions",
+        error instanceof Error ? error.name : "unknown_error",
+      );
+      throw error;
+    }
+  }
+
+  private async waitForSession(sessionName: string): Promise<void> {
+    const deadline = Date.now() + 10_000;
+    let loggedFailure = false;
+    while (Date.now() < deadline) {
+      try {
+        await this.run(["--session", sessionName, "action", "list-panes", "--json"]);
+        return;
+      } catch (error) {
+        if (!loggedFailure) {
+          console.warn(
+            "[terminal-runtime] waiting for Zellij workspace",
+            error instanceof Error ? error.name : "unknown_error",
+          );
+          loggedFailure = true;
+        }
+        await new Promise<void>((resolve) => setTimeout(resolve, 50));
+      }
+    }
+    throw new Error("Terminal workspace failed to start");
+  }
+
+  private async ensureLayout(): Promise<void> {
+    const content = 'layout {\n  tab name="matrix-bootstrap" focus=true {\n    pane\n  }\n}\n';
+    await mkdir(join(this.homePath, "system", "zellij"), { recursive: true, mode: 0o700 });
+    const temporaryPath = `${this.workspaceLayoutPath}.${process.pid}.tmp`;
+    const handle = await open(temporaryPath, "wx", 0o600);
+    try { await handle.writeFile(content, "utf8"); } finally { await handle.close(); }
+    await rename(temporaryPath, this.workspaceLayoutPath);
+    await chmod(this.workspaceLayoutPath, 0o600);
+  }
+
+  private resolveCwd(cwd: string): string {
+    if (cwd === "") return this.homePath;
+    const parsed = z.string().max(4096)
+      .refine((value) => !value.startsWith("/") && value.split("/").every((part) => part && part !== "." && part !== ".."))
+      .parse(cwd);
+    return join(this.homePath, parsed);
+  }
+
+  private run(args: string[]): Promise<string> {
+    return this.runCommand(args);
+  }
+
+  private async readStructuredJson<T>(args: string[], schema: z.ZodType<T>): Promise<T> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      try {
+        const output = (await this.run(args)).trim();
+        const arrayStart = output.indexOf("[");
+        const objectStart = output.indexOf("{");
+        const start = arrayStart < 0
+          ? objectStart
+          : objectStart < 0
+            ? arrayStart
+            : Math.min(arrayStart, objectStart);
+        const end = Math.max(output.lastIndexOf("]"), output.lastIndexOf("}"));
+        if (start < 0 || end < start) {
+          throw new Error("Zellij structured command returned non-JSON output");
+        }
+        return schema.parse(JSON.parse(output.slice(start, end + 1)));
+      } catch (error) {
+        lastError = error;
+        await new Promise<void>((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+      }
+    }
+    throw lastError instanceof Error ? lastError : new Error("Zellij structured command failed");
+  }
+
+  private async waitForManagedPane(sessionName: string, tabId: number): Promise<string> {
+    for (let attempt = 0; attempt < STRUCTURED_READINESS_ATTEMPTS; attempt += 1) {
+      const panes = await this.readStructuredJson(
+        ["--session", sessionName, "action", "list-panes", "--all", "--json"],
+        z.array(PaneSchema).max(10_000),
+      );
+      const tabPanes = panes.filter((pane) => pane.tab_id === tabId && !pane.is_plugin);
+      if (tabPanes.length === 1) return `terminal_${tabPanes[0]!.id}`;
+      await new Promise<void>((resolve) => setTimeout(resolve, 25 * (attempt + 1)));
+    }
+    throw new Error("Managed terminal tab must contain exactly one pane");
+  }
+
+  private async waitForTabId(sessionName: string, internalName: string): Promise<number> {
+    for (let attempt = 0; attempt < STRUCTURED_READINESS_ATTEMPTS; attempt += 1) {
+      const tabs = await this.readStructuredJson(
+        ["--session", sessionName, "action", "list-tabs", "--json"],
+        z.array(TabSchema).max(10_000),
+      );
+      const tab = tabs.find((candidate) => candidate.name === internalName);
+      if (tab) return tab.tab_id;
+      await new Promise<void>((resolve) => setTimeout(resolve, 25 * (attempt + 1)));
+    }
+    throw new Error("Managed terminal tab failed to report its identifier");
+  }
+}
+
+function terminalPaneActionArgs(sessionName: string, action: TerminalPaneAction): string[] {
+  const prefix = ["--session", sessionName, "action"];
+  switch (action.type) {
+    case "split": return [...prefix, "new-pane", "--direction", action.direction];
+    case "focus": return [...prefix, "move-focus", action.direction];
+    case "resize": return [...prefix, "resize", "increase", action.direction];
+    case "fullscreen": return [...prefix, "toggle-fullscreen"];
+    case "scroll": return [...prefix, action.edge === "top" ? "scroll-to-top" : "scroll-to-bottom"];
+    case "close": return [...prefix, "close-pane"];
+  }
+}
+
+function createCommandRunner(options: {
+  binaryPath: string;
+  cwd: string;
+  env: Record<string, string>;
+  timeoutMs: number;
+}): (args: string[]) => Promise<string> {
+  return (args) => new Promise((resolve, reject) => {
+    nodeExecFile(options.binaryPath, args, {
+      cwd: options.cwd,
+      env: options.env,
+      timeout: options.timeoutMs,
+      maxBuffer: MAX_COMMAND_OUTPUT_BYTES,
+    }, (error, stdout, stderr) => {
+      if (error) {
+        const failure = new Error("Terminal runtime command failed") as Error & { stderr?: string };
+        const diagnostic = String(stderr);
+        if (diagnostic) failure.stderr = diagnostic;
+        reject(failure);
+      } else resolve(String(stdout));
+    });
+  });
+}
+
+function isMissingZellijSessionFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const stderr = (error as Error & { stderr?: unknown }).stderr;
+  return typeof stderr === "string" && /(?:no active zellij sessions found|\bsession\b.*\b(?:not found|does not exist)\b)/i.test(stderr);
+}
+
+function spawnLineProcess(
+  binaryPath: string,
+  args: string[],
+  cwd: string,
+  env: Record<string, string>,
+  onLine: (line: string) => void,
+  onExit: (exitCode: number | null) => void,
+): RuntimeSubscriptionProcess {
+  const child = spawnProcess(binaryPath, args, { cwd, env, stdio: ["ignore", "pipe", "ignore"] });
+  let buffer = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    buffer += chunk;
+    if (Buffer.byteLength(buffer) > MAX_SUBSCRIPTION_LINE_BYTES * 2) {
+      buffer = "";
+      return;
+    }
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) if (line) onLine(line);
+  });
+  child.once("exit", onExit);
+  return {
+    close: async () => {
+      if (child.exitCode !== null) return;
+      child.kill("SIGTERM");
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(() => { child.kill("SIGKILL"); resolve(); }, 2_000);
+        timer.unref();
+        child.once("exit", () => { clearTimeout(timer); resolve(); });
+      });
+    },
+  };
+}
+
+function runtimeEnv(homePath: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (typeof value !== "string" || key === "ZELLIJ" || key === "ZELLIJ_SESSION_NAME" || key === "ZELLIJ_PANE_ID") continue;
+    env[key] = value;
+  }
+  env.HOME = homePath;
+  env.MATRIX_HOME = homePath;
+  env.ZELLIJ_CONFIG_DIR = join(homePath, "system", "zellij");
+  return env;
+}
+
+function safeJson(line: string): unknown {
+  try {
+    return JSON.parse(line);
+  } catch (error) {
+    console.warn(
+      "[terminal-runtime] rejected malformed Zellij observer JSON",
+      error instanceof Error ? error.name : "unknown_error",
+    );
+    return null;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,6 +617,9 @@ importers:
       '@matrix-os/scope-runtime':
         specifier: workspace:*
         version: link:../scope-runtime
+      '@matrix-os/terminal-runtime':
+        specifier: workspace:*
+        version: link:../terminal-runtime
       '@pipedream/sdk':
         specifier: ^2.4.3
         version: 2.4.3

--- a/tests/terminal-runtime/migration.test.ts
+++ b/tests/terminal-runtime/migration.test.ts
@@ -1,0 +1,525 @@
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  migrateTerminalWorkspaces,
+  rollbackTerminalWorkspaceMigration,
+  type LegacyZellijCutover,
+} from "../../packages/terminal-runtime/src/migration.js";
+import { TerminalWorkspaceStore } from "../../packages/terminal-runtime/src/workspace-store.js";
+
+const homes: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(homes.splice(0).map((home) => rm(home, { recursive: true, force: true })));
+});
+
+describe("terminal workspace cutover", () => {
+  it("commits a reserved main workspace on a clean install with no legacy sessions", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-migration-clean-"));
+    homes.push(homePath);
+    const ensured: string[] = [];
+    const cutover: LegacyZellijCutover = {
+      stopLegacySessions: async (names) => expect(names).toEqual([]),
+      ensureWorkspace: async (sessionName) => { ensured.push(sessionName); },
+      createShellTab: async () => ({ tabId: 1, paneId: "terminal_1" }),
+    };
+
+    await expect(migrateTerminalWorkspaces({ homePath, projects: [], cutover })).resolves.toEqual({
+      status: "committed",
+      migratedTabs: 0,
+      stoppedLegacySessions: 0,
+    });
+    const state = JSON.parse(await readFile(join(homePath, "system", "terminal-workspaces.json"), "utf8"));
+    expect(Object.values(state.workspaces)).toHaveLength(1);
+    expect(Object.values(state.workspaces)[0]).toMatchObject({ scope: "main", tabs: {} });
+    expect(ensured).toHaveLength(1);
+  });
+
+  it("fsyncs the containing directory after atomic journal and owner-state renames", async () => {
+    const source = await readFile(
+      join(process.cwd(), "packages/terminal-runtime/src/migration.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain("await renameDurable(stagedStatePath, finalStatePath)");
+    expect(source).toContain('const directoryHandle = await open(path, "r")');
+    expect(source).toContain("await directoryHandle.sync()");
+    expect(source).toContain("await directoryHandle.close()");
+  });
+
+  it("persists original reference-file backups before attempting in-place rewrites", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-migration-backup-"));
+    homes.push(homePath);
+    const systemPath = join(homePath, "system");
+    const sessionsPath = join(systemPath, "sessions");
+    await mkdir(sessionsPath, { recursive: true });
+    const original = `${JSON.stringify({ terminalSessionId: "legacy" })}\n`;
+    const referencePath = join(sessionsPath, "thread.json");
+    await writeFile(referencePath, original);
+    await writeFile(join(systemPath, "shell-sessions.json"), JSON.stringify({
+      sessions: {
+        legacy: { name: "legacy", status: "active", cwd: "" },
+      },
+    }));
+    await chmod(sessionsPath, 0o500);
+
+    const cutover: LegacyZellijCutover = {
+      stopLegacySessions: async () => undefined,
+      ensureWorkspace: async () => undefined,
+      createShellTab: async () => ({ tabId: 1, paneId: "terminal_1" }),
+    };
+
+    try {
+      await expect(migrateTerminalWorkspaces({ homePath, projects: [], cutover })).rejects.toMatchObject({
+        code: "EACCES",
+      });
+      const journal = JSON.parse(await readFile(join(systemPath, "terminal-migration-journal.json"), "utf8"));
+      expect(journal.status).toBe("staging");
+      expect(journal.backups["system/sessions/thread.json"]).toBe(original);
+      expect(await readFile(referencePath, "utf8")).toBe(original);
+    } finally {
+      await chmod(sessionsPath, 0o700);
+    }
+  });
+
+  it("journals generated name-scoped targets before attempting their writes", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-migration-generated-"));
+    homes.push(homePath);
+    const systemPath = join(homePath, "system");
+    await mkdir(join(systemPath, "shell-preferences"), { recursive: true });
+    await writeFile(join(systemPath, "shell-sessions.json"), JSON.stringify({
+      sessions: {
+        legacy: { name: "legacy", status: "active", cwd: "" },
+      },
+    }));
+    await writeFile(join(systemPath, "shell-preferences", "legacy.json"), JSON.stringify({
+      terminalSessionId: "legacy",
+    }));
+    await writeFile(join(systemPath, "terminal-tabs"), "blocks generated target directory creation");
+
+    const cutover: LegacyZellijCutover = {
+      stopLegacySessions: async () => undefined,
+      ensureWorkspace: async () => undefined,
+      createShellTab: async () => ({ tabId: 1, paneId: "terminal_1" }),
+    };
+
+    await expect(migrateTerminalWorkspaces({ homePath, projects: [], cutover })).rejects.toMatchObject({
+      code: "ENOTDIR",
+    });
+    const journal = JSON.parse(await readFile(join(systemPath, "terminal-migration-journal.json"), "utf8"));
+    expect(journal.status).toBe("staging");
+    expect(journal.generatedPaths).toEqual([
+      expect.stringMatching(/^system\/terminal-tabs\/[^/]+\/preferences\.json$/),
+    ]);
+    await rm(join(systemPath, "terminal-tabs"), { force: true });
+    await rollbackTerminalWorkspaceMigration({ homePath, cutover });
+    expect(JSON.parse(await readFile(join(systemPath, "terminal-migration-journal.json"), "utf8")).status)
+      .toBe("rolled_back");
+  });
+
+  it("journals, classifies, rewrites, stops, recreates shells, commits, and rolls back idempotently", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-migration-"));
+    homes.push(homePath);
+    const systemPath = join(homePath, "system");
+    await mkdir(systemPath, { recursive: true });
+    const legacy = {
+      sessions: {
+        explicit: { name: "build", status: "active", cwd: "projects/alpha", projectId: "alpha", createdAt: "2026-08-01T00:00:00.000Z" },
+        inferred: { name: "build", status: "active", cwd: "projects/beta/packages/app", createdAt: "2026-08-02T00:00:00.000Z" },
+        ambiguous: { name: "setup", status: "active", cwd: "downloads", createdAt: "2026-08-03T00:00:00.000Z" },
+      },
+    };
+    await writeFile(join(systemPath, "shell-sessions.json"), JSON.stringify(legacy));
+    await writeFile(join(systemPath, "terminal-layouts.json"), JSON.stringify({ panes: [
+      { terminalSessionId: "explicit" },
+      { terminalSessionId: "ambiguous" },
+    ] }));
+    await mkdir(join(systemPath, "scrollback"), { recursive: true });
+    const legacyScrollback = [
+      JSON.stringify({ type: "output", seq: 4, data: "\u001b[32mbuilding\u001b[0m\n" }),
+      "malformed legacy record",
+      JSON.stringify({ type: "seq-reserve", seq: 6 }),
+      JSON.stringify({ type: "output", seq: 5, data: "done\n" }),
+    ].join("\n") + "\n";
+    await writeFile(join(systemPath, "scrollback", "explicit.ndjson"), legacyScrollback);
+
+    const created: Array<{ sessionName: string; tabName: string; cwd: string; command?: string }> = [];
+    const stopped: string[][] = [];
+    const cutover: LegacyZellijCutover = {
+      stopLegacySessions: async (names) => {
+        const journal = JSON.parse(await readFile(join(systemPath, "terminal-migration-journal.json"), "utf8"));
+        expect(journal.status).toBe("staged");
+        stopped.push(names);
+      },
+      ensureWorkspace: async () => undefined,
+      createShellTab: async (sessionName, input) => {
+        created.push({ sessionName, tabName: input.internalName, cwd: input.cwd, command: input.command });
+        const tabId = created.length;
+        return { tabId, paneId: `terminal_${tabId}` };
+      },
+    };
+
+    const result = await migrateTerminalWorkspaces({
+      homePath,
+      projects: [
+        { id: "alpha", cwd: "projects/alpha" },
+        { id: "beta", cwd: "projects/beta" },
+      ],
+      cutover,
+    });
+
+    expect(result).toMatchObject({ migratedTabs: 3, stoppedLegacySessions: 3, status: "committed" });
+    expect(stopped).toEqual([["explicit", "inferred", "ambiguous"]]);
+    expect(created).toHaveLength(3);
+    expect(created.every((entry) => entry.command === undefined)).toBe(true);
+
+    const state = JSON.parse(await readFile(join(systemPath, "terminal-workspaces.json"), "utf8"));
+    const workspaces = Object.values(state.workspaces) as Array<{ scope: string; projectId?: string; tabs: Record<string, { name: string }> }>;
+    expect(workspaces.map((workspace) => workspace.projectId ?? workspace.scope).sort()).toEqual(["alpha", "beta", "main"]);
+    expect(workspaces.flatMap((workspace) => Object.values(workspace.tabs).map((tab) => tab.name)).sort()).toEqual(["build", "build", "setup"]);
+
+    const layout = JSON.parse(await readFile(join(systemPath, "terminal-layouts.json"), "utf8"));
+    expect(layout.panes.every((pane: Record<string, unknown>) => pane.terminalRef && !("terminalSessionId" in pane))).toBe(true);
+    const migratedRef = layout.panes[0].terminalRef;
+    await expect(new TerminalWorkspaceStore({ homePath }).readSnapshot(migratedRef)).resolves.toMatchObject({
+      terminalRef: migratedRef,
+      seq: 6,
+      ansi: "\u001b[32mbuilding\u001b[0m\ndone\n",
+      scrollback: ["\u001b[32mbuilding\u001b[0m", "done"],
+    });
+
+    const journalPath = join(systemPath, "terminal-migration-journal.json");
+    const interruptedJournal = JSON.parse(await readFile(journalPath, "utf8"));
+    interruptedJournal.status = "activating";
+    await writeFile(journalPath, JSON.stringify(interruptedJournal));
+
+    const retry = await migrateTerminalWorkspaces({ homePath, projects: [], cutover });
+    expect(retry.status).toBe("already_committed");
+    expect(created).toHaveLength(3);
+    expect(JSON.parse(await readFile(journalPath, "utf8")).status).toBe("committed");
+
+    await rollbackTerminalWorkspaceMigration({ homePath, cutover });
+    expect(JSON.parse(await readFile(join(systemPath, "shell-sessions.json"), "utf8"))).toEqual(legacy);
+    expect(JSON.parse(await readFile(join(systemPath, "terminal-layouts.json"), "utf8")).panes[0]).toEqual({ terminalSessionId: "explicit" });
+    expect(await readFile(join(systemPath, "scrollback", "explicit.ndjson"), "utf8")).toBe(legacyScrollback);
+  });
+
+  it("resumes an interrupted rollback before validating cutover state", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-migration-rollback-retry-"));
+    homes.push(homePath);
+    const systemPath = join(homePath, "system");
+    await mkdir(systemPath, { recursive: true });
+    await writeFile(join(systemPath, "shell-sessions.json"), JSON.stringify({
+      sessions: {
+        legacy: { name: "build", status: "active", cwd: "" },
+      },
+    }));
+    await writeFile(join(systemPath, "terminal-layouts.json"), JSON.stringify({
+      panes: [{ terminalSessionId: "legacy" }],
+    }));
+
+    let interruptRollback = true;
+    const cutover: LegacyZellijCutover = {
+      stopLegacySessions: async () => undefined,
+      ensureWorkspace: async () => undefined,
+      createShellTab: async () => ({ tabId: 1, paneId: "terminal_1" }),
+      stopWorkspaceSessions: async () => {
+        const journal = JSON.parse(await readFile(
+          join(systemPath, "terminal-migration-journal.json"),
+          "utf8",
+        ));
+        expect(journal.status).toBe("rolling_back");
+        if (interruptRollback) {
+          interruptRollback = false;
+          throw new Error("simulated rollback interruption");
+        }
+      },
+    };
+
+    await migrateTerminalWorkspaces({ homePath, projects: [], cutover });
+    await expect(rollbackTerminalWorkspaceMigration({ homePath, cutover }))
+      .rejects.toThrow("simulated rollback interruption");
+    expect(JSON.parse(await readFile(
+      join(systemPath, "terminal-migration-journal.json"),
+      "utf8",
+    )).status).toBe("rolling_back");
+
+    // Model a later interruption after the new state files were removed but
+    // before the rollback journal reached its terminal state.
+    await rm(join(systemPath, "terminal-workspaces.json"), { force: true });
+    await rm(join(systemPath, "terminal-workspaces.staged.json"), { force: true });
+
+    await expect(migrateTerminalWorkspaces({ homePath, projects: [], cutover })).resolves.toMatchObject({
+      status: "committed",
+      migratedTabs: 1,
+    });
+    expect(JSON.parse(await readFile(
+      join(systemPath, "terminal-migration-journal.json"),
+      "utf8",
+    )).status).toBe("committed");
+    expect(JSON.parse(await readFile(join(systemPath, "terminal-layouts.json"), "utf8")).panes[0])
+      .toHaveProperty("terminalRef");
+  });
+
+  it("stops staged workspace sessions when activation fails before commit", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-migration-staged-rollback-"));
+    homes.push(homePath);
+    const systemPath = join(homePath, "system");
+    await mkdir(systemPath, { recursive: true });
+    await writeFile(join(systemPath, "shell-sessions.json"), JSON.stringify({
+      sessions: {
+        legacy: { name: "build", status: "active", cwd: "" },
+      },
+    }));
+
+    const ensured: string[] = [];
+    const stopped: string[][] = [];
+    const cutover: LegacyZellijCutover = {
+      stopLegacySessions: async () => undefined,
+      ensureWorkspace: async (sessionName) => { ensured.push(sessionName); },
+      createShellTab: async () => {
+        throw new Error("simulated activation failure");
+      },
+      stopWorkspaceSessions: async (sessionNames) => { stopped.push(sessionNames); },
+    };
+
+    await expect(migrateTerminalWorkspaces({ homePath, projects: [], cutover }))
+      .rejects.toThrow("simulated activation failure");
+    await expect(rollbackTerminalWorkspaceMigration({ homePath, cutover })).resolves.toBeUndefined();
+
+    expect(ensured).toHaveLength(1);
+    expect(stopped).toEqual([ensured]);
+    expect(JSON.parse(await readFile(
+      join(systemPath, "terminal-migration-journal.json"),
+      "utf8",
+    )).status).toBe("rolled_back");
+  });
+
+  it("refuses rollback when unreadable committed state may contain newer workspaces", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-migration-corrupt-rollback-"));
+    homes.push(homePath);
+    const systemPath = join(homePath, "system");
+    await mkdir(systemPath, { recursive: true });
+    const legacy = {
+      sessions: {
+        legacy: { name: "build", status: "active", cwd: "" },
+      },
+    };
+    const layout = { panes: [{ terminalSessionId: "legacy" }] };
+    await writeFile(join(systemPath, "shell-sessions.json"), JSON.stringify(legacy));
+    await writeFile(join(systemPath, "terminal-layouts.json"), JSON.stringify(layout));
+    const stopped: string[][] = [];
+    const cutover: LegacyZellijCutover = {
+      stopLegacySessions: async () => undefined,
+      ensureWorkspace: async () => undefined,
+      createShellTab: async () => ({ tabId: 1, paneId: "terminal_1" }),
+      stopWorkspaceSessions: async (sessionNames) => { stopped.push(sessionNames); },
+    };
+
+    await migrateTerminalWorkspaces({ homePath, projects: [], cutover });
+    const store = new TerminalWorkspaceStore({ homePath });
+    const newerWorkspace = await store.ensureWorkspace({ projectId: "created-after-cutover" });
+    expect(await store.getRuntimeWorkspace(newerWorkspace.id)).toMatchObject({
+      projectId: "created-after-cutover",
+    });
+    await writeFile(join(systemPath, "terminal-workspaces.json"), "not-json");
+
+    await expect(rollbackTerminalWorkspaceMigration({ homePath, cutover }))
+      .rejects.toThrow("terminal_migration_session_identity_missing");
+    expect(stopped).toEqual([]);
+    expect(await readFile(join(systemPath, "terminal-workspaces.json"), "utf8")).toBe("not-json");
+    expect(JSON.parse(await readFile(
+      join(systemPath, "terminal-migration-journal.json"),
+      "utf8",
+    )).status).toBe("rolling_back");
+  });
+
+  it("does not complete rollback from an old journal when session identities are unrecoverable", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-migration-old-journal-"));
+    homes.push(homePath);
+    const systemPath = join(homePath, "system");
+    await mkdir(systemPath, { recursive: true });
+    await writeFile(join(systemPath, "shell-sessions.json"), JSON.stringify({
+      sessions: {
+        legacy: { name: "build", status: "active", cwd: "" },
+      },
+    }));
+    const stopped: string[][] = [];
+    const cutover: LegacyZellijCutover = {
+      stopLegacySessions: async () => undefined,
+      ensureWorkspace: async () => undefined,
+      createShellTab: async () => ({ tabId: 1, paneId: "terminal_1" }),
+      stopWorkspaceSessions: async (sessionNames) => { stopped.push(sessionNames); },
+    };
+
+    await migrateTerminalWorkspaces({ homePath, projects: [], cutover });
+    const journalPath = join(systemPath, "terminal-migration-journal.json");
+    const oldJournal = JSON.parse(await readFile(journalPath, "utf8"));
+    delete oldJournal.generatedSessionNames;
+    await writeFile(journalPath, JSON.stringify(oldJournal));
+    await writeFile(join(systemPath, "terminal-workspaces.json"), "not-json");
+
+    await expect(rollbackTerminalWorkspaceMigration({ homePath, cutover }))
+      .rejects.toThrow("terminal_migration_session_identity_missing");
+    expect(stopped).toEqual([]);
+    expect(JSON.parse(await readFile(journalPath, "utf8")).status).toBe("rolling_back");
+  });
+
+  it("accepts the oversized newest record retained by the legacy five MiB store", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-migration-large-scrollback-"));
+    homes.push(homePath);
+    const systemPath = join(homePath, "system");
+    await mkdir(join(systemPath, "scrollback"), { recursive: true });
+    await writeFile(join(systemPath, "shell-sessions.json"), JSON.stringify({
+      sessions: {
+        legacy: { name: "large", status: "active", cwd: "" },
+      },
+    }));
+    const retained = "x".repeat(5 * 1024 * 1024);
+    const legacyScrollback = `${JSON.stringify({ type: "output", seq: 9, data: retained })}\n`;
+    expect(Buffer.byteLength(legacyScrollback)).toBeGreaterThan(5 * 1024 * 1024);
+    await writeFile(join(systemPath, "scrollback", "legacy.ndjson"), legacyScrollback);
+    const cutover: LegacyZellijCutover = {
+      stopLegacySessions: async () => undefined,
+      ensureWorkspace: async () => undefined,
+      createShellTab: async () => ({ tabId: 1, paneId: "terminal_1" }),
+    };
+
+    await expect(migrateTerminalWorkspaces({ homePath, projects: [], cutover })).resolves.toMatchObject({
+      status: "committed",
+      migratedTabs: 1,
+    });
+    const journal = JSON.parse(await readFile(join(systemPath, "terminal-migration-journal.json"), "utf8"));
+    expect(journal.backups).not.toHaveProperty("system/scrollback/legacy.ndjson");
+    const workspace = (await new TerminalWorkspaceStore({ homePath }).listWorkspaces())[0]!;
+    await expect(new TerminalWorkspaceStore({ homePath }).readSnapshot({
+      workspaceId: workspace.id,
+      tabId: workspace.tabs[0]!.id,
+    })).resolves.toMatchObject({ ansi: retained, seq: 9 });
+  });
+
+  it("retains the newest five MiB from an intermediate-size legacy output record", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-migration-intermediate-scrollback-"));
+    homes.push(homePath);
+    const systemPath = join(homePath, "system");
+    await mkdir(join(systemPath, "scrollback"), { recursive: true });
+    const legacySession = { sessions: { legacy: { name: "intermediate", status: "active", cwd: "" } } };
+    await writeFile(join(systemPath, "shell-sessions.json"), JSON.stringify(legacySession));
+    const retained = "x".repeat((5 * 1024 * 1024) + (32 * 1024));
+    const legacyScrollback = `${JSON.stringify({ type: "output", seq: 10, data: retained })}\n`;
+    expect(Buffer.byteLength(legacyScrollback)).toBeLessThan(30 * 1024 * 1024);
+    await writeFile(join(systemPath, "scrollback", "legacy.ndjson"), legacyScrollback);
+    const cutover: LegacyZellijCutover = {
+      stopLegacySessions: async () => undefined,
+      ensureWorkspace: async () => undefined,
+      createShellTab: async () => ({ tabId: 1, paneId: "terminal_1" }),
+    };
+    await expect(migrateTerminalWorkspaces({ homePath, projects: [], cutover }))
+      .resolves.toMatchObject({ status: "committed", migratedTabs: 1 });
+    const store = new TerminalWorkspaceStore({ homePath });
+    const workspace = (await store.listWorkspaces())[0]!;
+    await expect(store.readSnapshot({ workspaceId: workspace.id, tabId: workspace.tabs[0]!.id }))
+      .resolves.toMatchObject({ ansi: "x".repeat(5 * 1024 * 1024), seq: 10 });
+  });
+
+  it("retains the newest five MiB when valid legacy output records exceed the snapshot cap", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-migration-aggregate-scrollback-"));
+    homes.push(homePath);
+    const systemPath = join(homePath, "system");
+    await mkdir(join(systemPath, "scrollback"), { recursive: true });
+    await writeFile(join(systemPath, "shell-sessions.json"), JSON.stringify({
+      sessions: {
+        legacy: { name: "aggregate", status: "active", cwd: "" },
+      },
+    }));
+    const older = "a".repeat(3 * 1024 * 1024);
+    const newer = "b".repeat(3 * 1024 * 1024);
+    await writeFile(join(systemPath, "scrollback", "legacy.ndjson"), [
+      JSON.stringify({ type: "output", seq: 1, data: older }),
+      JSON.stringify({ type: "output", seq: 2, data: newer }),
+    ].join("\n") + "\n");
+    const cutover: LegacyZellijCutover = {
+      stopLegacySessions: async () => undefined,
+      ensureWorkspace: async () => undefined,
+      createShellTab: async () => ({ tabId: 1, paneId: "terminal_1" }),
+    };
+
+    await expect(migrateTerminalWorkspaces({ homePath, projects: [], cutover })).resolves.toMatchObject({
+      status: "committed",
+      migratedTabs: 1,
+    });
+    const workspace = (await new TerminalWorkspaceStore({ homePath }).listWorkspaces())[0]!;
+    await expect(new TerminalWorkspaceStore({ homePath }).readSnapshot({
+      workspaceId: workspace.id,
+      tabId: workspace.tabs[0]!.id,
+    })).resolves.toMatchObject({
+      ansi: `${"a".repeat(2 * 1024 * 1024)}${newer}`,
+      seq: 2,
+    });
+  });
+
+  it("streams the retained tail of a valid legacy output record beyond the migration read ceiling", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-migration-huge-scrollback-"));
+    homes.push(homePath);
+    const systemPath = join(homePath, "system");
+    await mkdir(join(systemPath, "scrollback"), { recursive: true });
+    await writeFile(join(systemPath, "shell-sessions.json"), JSON.stringify({
+      sessions: {
+        legacy: { name: "huge", status: "active", cwd: "" },
+      },
+    }));
+    const retainedBytes = 5 * 1024 * 1024;
+    const oversized = `${"\0".repeat(retainedBytes + 20_000)}z`;
+    await writeFile(
+      join(systemPath, "scrollback", "legacy.ndjson"),
+      `${JSON.stringify({
+        type: "output",
+        seq: 11,
+        data: oversized,
+        at: "2026-09-07T12:00:00.000Z",
+      })}\n`,
+    );
+    const cutover: LegacyZellijCutover = {
+      stopLegacySessions: async () => undefined,
+      ensureWorkspace: async () => undefined,
+      createShellTab: async () => ({ tabId: 1, paneId: "terminal_1" }),
+    };
+
+    await expect(migrateTerminalWorkspaces({ homePath, projects: [], cutover })).resolves.toMatchObject({
+      status: "committed",
+      migratedTabs: 1,
+    });
+    const workspace = (await new TerminalWorkspaceStore({ homePath }).listWorkspaces())[0]!;
+    const snapshot = await new TerminalWorkspaceStore({ homePath }).readSnapshot({
+      workspaceId: workspace.id,
+      tabId: workspace.tabs[0]!.id,
+    });
+    expect(snapshot).toMatchObject({ seq: 11 });
+    expect(snapshot?.ansi).toBe(`${"\0".repeat(retainedBytes - 1)}z`);
+  });
+
+  it("rejects a persisted traversal session key before reading scrollback", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-migration-traversal-"));
+    homes.push(homePath);
+    const systemPath = join(homePath, "system");
+    await mkdir(join(systemPath, "scrollback"), { recursive: true });
+    await writeFile(join(systemPath, "shell-sessions.json"), JSON.stringify({
+      sessions: {
+        "../outside": { name: "outside", status: "active", cwd: "" },
+      },
+    }));
+    const outsidePath = join(systemPath, "outside.ndjson");
+    const outside = `${JSON.stringify({ type: "output", seq: 1, data: "must not be read" })}\n`;
+    await writeFile(outsidePath, outside);
+    const cutover: LegacyZellijCutover = {
+      stopLegacySessions: async () => undefined,
+      ensureWorkspace: async () => undefined,
+      createShellTab: async () => ({ tabId: 1, paneId: "terminal_1" }),
+    };
+
+    await expect(migrateTerminalWorkspaces({ homePath, projects: [], cutover })).rejects.toThrow();
+    expect(await readFile(outsidePath, "utf8")).toBe(outside);
+  });
+});

--- a/tests/terminal-runtime/runtime.test.ts
+++ b/tests/terminal-runtime/runtime.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import type { TerminalPaneAction } from "@matrix-os/contracts";
 import {
   TerminalRuntime,
   type ZellijAttachment,
@@ -28,6 +29,7 @@ class FakeZellij implements ZellijRuntimeAdapter {
   readonly deletedSessions: string[] = [];
   readonly renamedTabs: Array<{ tabId: number; name: string }> = [];
   readonly resizedSessions: Array<{ cols: number; rows: number }> = [];
+  readonly paneActions: Array<{ sessionName: string; tabId: number; action: TerminalPaneAction }> = [];
   failNextSubscription = false;
   subscriptionFailuresRemaining = 0;
   failNextObserverClose = false;
@@ -164,6 +166,9 @@ class FakeZellij implements ZellijRuntimeAdapter {
   }
   async writeToPane(_sessionName: string, _paneId: string, data: Uint8Array): Promise<void> {
     this.targetedWrites.push(new TextDecoder().decode(data));
+  }
+  async paneAction(sessionName: string, tabId: number, action: TerminalPaneAction): Promise<void> {
+    this.paneActions.push({ sessionName, tabId, action });
   }
 }
 
@@ -373,6 +378,35 @@ describe("project-scoped terminal runtime", () => {
     await expect(runtime.writeInput({ workspaceId: workspace.id, tabId: tab.id }, "late"))
       .rejects.toThrow(/unavailable/i);
     expect(zellij.targetedWrites).toEqual([]);
+    await runtime.shutdown();
+  });
+
+  it("targets pane actions through the tab's stable runtime reference", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store: new TerminalWorkspaceStore({ homePath }), zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await runtime.createTab(workspace.id, { name: "agent", cwd: "projects/matrix-os" });
+
+    await runtime.paneAction(
+      { workspaceId: workspace.id, tabId: tab.id },
+      { type: "fullscreen" },
+    );
+
+    expect(zellij.paneActions).toEqual([{
+      sessionName: [...zellij.sessions.keys()][0],
+      tabId: 1,
+      action: { type: "fullscreen" },
+    }]);
+
+    await runtime.paneAction(
+      { workspaceId: workspace.id, tabId: tab.id },
+      { type: "close" },
+    );
+
+    expect(zellij.closedTabs).toEqual([1]);
+    expect((await runtime.listWorkspaces())[0]?.tabs[0]?.status).toBe("exited");
     await runtime.shutdown();
   });
 

--- a/tests/terminal-runtime/socket-api.test.ts
+++ b/tests/terminal-runtime/socket-api.test.ts
@@ -1,0 +1,162 @@
+import { chmod, mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TerminalRuntimeSocketClient } from "../../packages/terminal-runtime/src/socket-client.js";
+import { TerminalRuntimeSocketServer } from "../../packages/terminal-runtime/src/socket-server.js";
+import { encodeSocketFrame, SocketFrameDecoder } from "../../packages/terminal-runtime/src/socket-framing.js";
+import {
+  MAX_TERMINAL_RUNTIME_REQUEST_FRAME_BYTES,
+  MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES,
+  MAX_TERMINAL_SNAPSHOT_BYTES,
+} from "../../packages/terminal-runtime/src/limits.js";
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe("terminal runtime Unix socket API", () => {
+  it("keeps legacy five MiB snapshots within a finite socket-frame bound", () => {
+    const value = { type: "snapshot", ansi: "x".repeat(5 * 1024 * 1024) };
+    const frame = encodeSocketFrame(value);
+    expect(new SocketFrameDecoder().push(frame)).toEqual([value]);
+  });
+
+  it("keeps requests bounded while round-tripping a maximum control-heavy snapshot response", () => {
+    const oversizedRequestHeader = Buffer.alloc(4);
+    oversizedRequestHeader.writeUInt32BE(MAX_TERMINAL_RUNTIME_REQUEST_FRAME_BYTES + 1);
+    expect(() => new SocketFrameDecoder().push(oversizedRequestHeader))
+      .toThrow("Terminal runtime frame is too large");
+
+    const ansi = "\u0001".repeat(5 * 1024 * 1024);
+    const value = {
+      version: 1,
+      requestId: "req_0123456789abcdef0123456789abcdef",
+      ok: true,
+      result: { ansi, scrollback: [ansi] },
+    };
+    expect(MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES).toBeGreaterThan(MAX_TERMINAL_SNAPSHOT_BYTES);
+    const frame = encodeSocketFrame(value, MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES);
+    const decoded = new SocketFrameDecoder(MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES).push(frame);
+    expect(decoded).toHaveLength(1);
+    expect((decoded[0] as typeof value).result.ansi).toHaveLength(ansi.length);
+    expect((decoded[0] as typeof value).result.scrollback[0]).toHaveLength(ansi.length);
+  });
+
+  it("serves bounded workspace control over an owner-only socket", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "matrix-terminal-socket-"));
+    directories.push(directory);
+    await chmod(directory, 0o777);
+    const socketPath = join(directory, "terminal-runtime.sock");
+    const workspace = {
+      id: "tws_0123456789abcdef0123456789abcdef",
+      scope: "main" as const,
+      canonicalSize: { cols: 120, rows: 36 },
+      status: "running" as const,
+      revision: 1,
+      createdAt: "2026-08-11T12:00:00.000Z",
+      updatedAt: "2026-08-11T12:00:00.000Z",
+      tabs: [],
+    };
+    const tab = {
+      id: "tt_0123456789abcdef0123456789abcdef",
+      workspaceId: workspace.id,
+      name: "main",
+      cwd: "",
+      status: "running" as const,
+      revision: 1,
+      order: 0,
+      createdAt: workspace.createdAt,
+      updatedAt: workspace.updatedAt,
+    };
+    const socketSnapshotAnsi = "\u0001".repeat(1024 * 1024);
+    const socketSnapshot = {
+      schemaVersion: 1 as const,
+      terminalRef: { workspaceId: workspace.id, tabId: tab.id },
+      revision: 1,
+      presentationRevision: 7,
+      seq: 1,
+      ansi: socketSnapshotAnsi,
+      viewport: [],
+      scrollback: [socketSnapshotAnsi],
+      updatedAt: workspace.updatedAt,
+    };
+    const paneAction = vi.fn(async () => undefined);
+    const server = new TerminalRuntimeSocketServer({
+      socketPath,
+      runtime: {
+        listWorkspaces: async () => [workspace],
+        ensureWorkspace: async () => workspace,
+        createTab: async () => tab,
+        paneAction,
+        getSnapshot: async () => socketSnapshot,
+        resize: async () => ({ ...workspace, tabs: [tab] }),
+        attach: async () => ({
+          write: async () => undefined,
+          touch: () => undefined,
+          detach: async () => undefined,
+        }),
+        updateTabUiState: async (_ref, input) => ({
+          ...tab,
+          revision: 2,
+          uiState: {
+            placement: input.placement ?? "active",
+            lastSeenSeq: input.lastSeenSeq ?? null,
+            pinned: input.pinned ?? false,
+          },
+        }),
+      },
+    });
+    const originalUmask = process.umask();
+    const umaskSpy = vi.spyOn(process, "umask");
+    await server.start();
+    const client = new TerminalRuntimeSocketClient({ socketPath });
+
+    expect(umaskSpy.mock.calls).toContainEqual([0o177]);
+    expect(process.umask()).toBe(originalUmask);
+    umaskSpy.mockRestore();
+    expect((await stat(directory)).mode & 0o777).toBe(0o700);
+    expect((await stat(socketPath)).mode & 0o777).toBe(0o600);
+    expect(await client.listWorkspaces()).toEqual([workspace]);
+    expect((await client.ensureWorkspace()).id).toBe(workspace.id);
+    const created = await client.createTab(workspace.id, { name: "main", cwd: "" });
+    expect(created.workspaceId).toBe(workspace.id);
+    await client.paneAction(
+      { workspaceId: workspace.id, tabId: created.id },
+      { type: "focus", direction: "right" },
+    );
+    expect(paneAction).toHaveBeenCalledWith(
+      { workspaceId: workspace.id, tabId: created.id },
+      { type: "focus", direction: "right" },
+    );
+    const servedSnapshot = await client.getSnapshot({ workspaceId: workspace.id, tabId: created.id });
+    expect((servedSnapshot as typeof socketSnapshot).ansi).toHaveLength(socketSnapshotAnsi.length);
+    expect((servedSnapshot as typeof socketSnapshot).scrollback[0]).toHaveLength(socketSnapshotAnsi.length);
+    const streamedSnapshot = await new Promise<Record<string, unknown>>((resolve, reject) => {
+      const stream = client.attach({
+        ref: socketSnapshot.terminalRef,
+        viewerId: "desktop-test",
+        fromSeq: 0,
+        mode: "soft",
+        size: { cols: 120, rows: 36 },
+        onFrame: (frame) => {
+          if (frame.type === "snapshot") {
+            stream.close();
+            resolve(frame);
+          }
+        },
+        onClose: () => undefined,
+        onError: reject,
+      });
+    });
+    expect(streamedSnapshot.presentationRevision).toBe(7);
+    await expect(client.updateTabUiState(
+      { workspaceId: workspace.id, tabId: created.id },
+      { pinned: true, baseRevision: created.revision },
+    )).resolves.toMatchObject({ uiState: { pinned: true } });
+
+    await server.close();
+  });
+});

--- a/tests/terminal-runtime/workspace-store.test.ts
+++ b/tests/terminal-runtime/workspace-store.test.ts
@@ -93,4 +93,22 @@ describe("terminal workspace store", () => {
     expect(retried).toEqual(exited);
     expect(workspaceAfterRetry.revision).toBe(workspaceAfterExit.revision);
   });
+
+  it("advances presentation revision only for intentional snapshot replacement", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-presentation-revision-"));
+    homes.push(homePath);
+    const store = new TerminalWorkspaceStore({ homePath });
+    const workspace = await store.ensureWorkspace();
+    const tab = await store.createTab(workspace.id, { name: "revision", cwd: "" });
+    const ref = { workspaceId: workspace.id, tabId: tab.id };
+
+    await expect(store.checkpointTab(ref, { ansi: "one", viewport: [], scrollback: ["one"] }))
+      .resolves.toMatchObject({ presentationRevision: 0 });
+    await expect(store.checkpointTab(ref, { ansi: "two", viewport: [], scrollback: ["two"] }))
+      .resolves.toMatchObject({ presentationRevision: 0 });
+    await expect(store.importSnapshot(ref, { ansi: "replacement", viewport: [], scrollback: ["replacement"], seq: 1 }))
+      .resolves.toMatchObject({ presentationRevision: 1 });
+    await expect(store.checkpointTab(ref, { ansi: "three", viewport: [], scrollback: ["three"] }))
+      .resolves.toMatchObject({ presentationRevision: 1 });
+  });
 });

--- a/tests/terminal-runtime/zellij-real.integration.test.ts
+++ b/tests/terminal-runtime/zellij-real.integration.test.ts
@@ -1,0 +1,117 @@
+import { execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { access, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { ZellijCliRuntimeAdapter } from "../../packages/terminal-runtime/src/zellij-adapter.js";
+
+const execFileAsync = promisify(execFile);
+const binaryPath = process.env.MATRIX_TEST_ZELLIJ_BIN ?? "/usr/local/bin/zellij";
+let available = true;
+try { await access(binaryPath); } catch { available = false; }
+
+describe.runIf(available)("real bundled Zellij 0.44.3 integration", () => {
+  let homePath = "";
+  let sessionName = "";
+  let adapter: ZellijCliRuntimeAdapter;
+  const extraSessionNames: string[] = [];
+
+  beforeAll(async () => {
+    const version = await execFileAsync(binaryPath, ["--version"], { timeout: 5_000 });
+    expect(version.stdout.trim()).toBe("zellij 0.44.3");
+    homePath = await mkdtemp(join(tmpdir(), "matrix-zellij-real-"));
+    sessionName = `matrix-w-${randomBytes(16).toString("hex")}`;
+    adapter = new ZellijCliRuntimeAdapter({ homePath, binaryPath });
+    await adapter.ensureSession(sessionName, { cols: 100, rows: 30 });
+  }, 20_000);
+
+  afterAll(async () => {
+    await Promise.all(extraSessionNames.map((name) => adapter?.deleteSession(name).catch(() => undefined)));
+    await adapter?.deleteSession(sessionName).catch(() => undefined);
+    if (homePath) await rm(homePath, { recursive: true, force: true });
+  });
+
+  it("keeps structured tab/pane IDs stable across targeted input, observation, and reconciliation", async () => {
+    const firstName = `matrix-tab-${randomBytes(16).toString("hex")}`;
+    const secondName = `matrix-tab-${randomBytes(16).toString("hex")}`;
+    const first = await adapter.createTab(sessionName, { internalName: firstName, cwd: "", command: ["sh"] });
+    const second = await adapter.createTab(sessionName, { internalName: secondName, cwd: "", command: ["sh"] });
+    expect(first.tabId).not.toBe(second.tabId);
+    expect(first.paneId).toMatch(/^terminal_\d+$/);
+
+    let readyResolve!: () => void;
+    const ready = new Promise<void>((resolve) => { readyResolve = resolve; });
+    let observedResolve!: () => void;
+    const observed = new Promise<void>((resolve) => { observedResolve = resolve; });
+    const paneUpdates: string[] = [];
+    const observer = await adapter.subscribeWorkspace(sessionName, {
+      paneIds: [first.paneId, second.paneId],
+      onEvent: (event) => {
+        if (event.type !== "pane-update") return;
+        paneUpdates.push(`${event.paneId}:${event.ansi}`);
+        readyResolve();
+        if (event.paneId === first.paneId && event.ansi.includes("matrix-targeted-input")) observedResolve();
+      },
+    });
+    await Promise.race([
+      ready,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("observer did not become ready")), 10_000)),
+    ]);
+    await adapter.writeToPane(sessionName, first.paneId, new TextEncoder().encode("printf 'matrix-targeted-input\\n'\r"));
+    await Promise.race([observed, new Promise<never>((_, reject) => setTimeout(async () => {
+      const dump = await execFileAsync(binaryPath, ["--session", sessionName, "action", "dump-screen", "--pane-id", first.paneId, "--full", "--ansi"], {
+        timeout: 5_000,
+        env: { ...process.env, HOME: homePath, MATRIX_HOME: homePath, ZELLIJ_CONFIG_DIR: join(homePath, "system", "zellij") },
+      }).catch(() => ({ stdout: "<dump failed>" }));
+      reject(new Error(`observer did not receive targeted output; dump=${dump.stdout}; updates=${JSON.stringify(paneUpdates)}`));
+    }, 15_000))]);
+    await observer.close();
+
+    expect(await adapter.findTabByInternalName(sessionName, firstName)).toEqual(first);
+    await adapter.renameTab(sessionName, second.tabId, "renamed");
+    await adapter.closeTab(sessionName, second.tabId);
+    expect(await adapter.findTabByInternalName(sessionName, secondName)).toBeUndefined();
+  }, 30_000);
+
+  it("uses one substantially smaller Zellij server for 23 idle tabs", async () => {
+    const denseSession = `matrix-w-${randomBytes(16).toString("hex")}`;
+    extraSessionNames.push(denseSession);
+    await adapter.ensureSession(denseSession, { cols: 100, rows: 30 });
+    for (let index = 0; index < 23; index += 1) {
+      await adapter.createTab(denseSession, {
+        internalName: `matrix-tab-${randomBytes(16).toString("hex")}`,
+        cwd: "",
+        command: ["sh"],
+      });
+    }
+
+    const denseServers = await zellijServerRss([denseSession]);
+    expect(denseServers).toHaveLength(1);
+
+    const separateSessions = Array.from({ length: 23 }, () => `matrix-w-${randomBytes(16).toString("hex")}`);
+    extraSessionNames.push(...separateSessions);
+    for (const name of separateSessions) {
+      await adapter.ensureSession(name, { cols: 100, rows: 30 });
+      await adapter.createTab(name, {
+        internalName: `matrix-tab-${randomBytes(16).toString("hex")}`,
+        cwd: "",
+        command: ["sh"],
+      });
+    }
+
+    const separateServers = await zellijServerRss(separateSessions);
+    expect(separateServers).toHaveLength(23);
+    expect(denseServers[0]).toBeLessThan(separateServers.reduce((total, rss) => total + rss, 0) * 0.5);
+  }, 120_000);
+});
+
+async function zellijServerRss(sessionNames: string[]): Promise<number[]> {
+  const { stdout } = await execFileAsync("ps", ["-eo", "rss=,args="], { timeout: 5_000 });
+  return stdout.split("\n").flatMap((line) => {
+    if (!sessionNames.some((name) => line.includes(name))) return [];
+    const rss = Number.parseInt(line.trim().split(/\s+/, 1)[0] ?? "", 10);
+    return Number.isFinite(rss) ? [rss * 1024] : [];
+  });
+}


### PR DESCRIPTION
## Summary

- add the Zellij 0.44.3 structured adapter for one project-scoped server with multiple stable tabs and panes
- add crash-safe migration from legacy terminal sessions into project-scoped workspaces and durable rollback
- add the bounded terminal-runtime Unix-socket protocol, client/server, and service entrypoint
- route pane controls through stable tab IDs while preserving focused split panes
- recover the named primary pane after splits so runtime restarts can reattach without recreating active work

Layer 2 of 14. Depends on #1418; workspace process ownership in #1599 follows.

## Tests

- `pnpm install --frozen-lockfile`
- `pnpm --filter @matrix-os/terminal-runtime exec tsc --noEmit`
- 54 terminal-runtime tests across runtime, adapter, migration, socket, and store suites
- 2 real bundled-Zellij integration tests, including 23 tabs sharing one server
- pane-action targeting, close semantics, split-pane recovery, dense-startup readiness, and rollback regressions
- `bash scripts/review/check-patterns.sh` (0 violations)
- `git diff --check`
- PR size: 2,973 additions across 20 files

## Review/Monitoring

- GitHub CI and Greptile are being monitored on the exact latest head until green and 5/5.
- The repository-wide latest-Codex contract check currently stops at its version gate because Codex `0.154.0` is not yet in `main`'s verified contract list; this layer does not change that verifier.

## Invariants

### Source of truth

- Owner-controlled terminal workspace state from #1418 remains canonical.
- The migration journal is the durable source for cutover/rollback progress and reference backups.
- Structured Zellij tab and pane identifiers are canonical runtime identities; shell output is never parsed as identity.

### Lock/transaction scope

- Migration state and rewritten owner files use atomic writes with directory fsync.
- Tab activation is persisted in staged state before the staged file is durably promoted.
- The owner-only socket delegates mutations, including pane actions, to the serialized runtime.

### Acceptable orphan states

- Interrupted activation is rollback-safe: rollback inspects both final and staged workspace state before stopping Zellij sessions.
- Generated files are journaled before creation and removed during rollback; original content is restored from durable backups.
- A split tab retains a named primary pane, allowing restart recovery without deleting additional panes.

### Auth source of truth

- The host runtime is reachable only through an owner-protected Unix socket.
- The socket directory is validated and changed to mode 0700 before listen; the socket is mode 0600.
- Gateway request-principal authorization is introduced in #1431.

### Deferred scope

- No browser, desktop, mobile, CLI, or gateway path is switched in this layer.
- Client/gateway cutover and host service deployment remain in later layers.
