### PR TITLE
feat(terminal-runtime): add workspace contracts and persistence

### DIFF
--- a/packages/contracts/src/agent-thread-contracts.ts
+++ b/packages/contracts/src/agent-thread-contracts.ts
@@ -19,7 +19,12 @@ const EventIdSchema = prefixedId("evt_");
 const ApprovalIdSchema = prefixedId("appr_");
 const RequestIdSchema = prefixedId("req_");
 const CorrelationIdSchema = prefixedId("corr_");
-const TerminalSessionIdSchema = referenceId(128);
+const TerminalWorkspaceIdSchema = z.string().regex(/^tws_[0-9a-f]{32}$/, "Invalid terminal workspace id");
+const TerminalTabIdSchema = z.string().regex(/^tt_[0-9a-f]{32}$/, "Invalid terminal tab id");
+const TerminalRefSchema = z.object({
+  workspaceId: TerminalWorkspaceIdSchema,
+  tabId: TerminalTabIdSchema,
+}).strict();
 const ReviewIdSchema = referenceId(128);
 const CursorSchema = referenceId(160);
 const SafeDisplayStringSchema = boundedDisplayText(120, 512);
@@ -56,7 +61,8 @@ export const AgentThreadSummarySchema = z.object({
   attention: AgentAttentionSchema.default("none"),
   projectId: ProjectIdSchema.optional(),
   taskId: TaskIdSchema.optional(),
-  terminalSessionId: TerminalSessionIdSchema.optional(),
+  terminalSessionId: referenceId(128).optional(),
+  terminalRef: TerminalRefSchema.optional(),
   eventCursor: CursorSchema.optional(),
   createdAt: IsoTimestampSchema,
   updatedAt: IsoTimestampSchema,
@@ -199,7 +205,8 @@ const CoreAgentThreadEventSchema = z.discriminatedUnion("type", [
   }).strict(),
   BaseThreadEventSchema.extend({
     type: z.literal("terminal.bound"),
-    terminalSessionId: TerminalSessionIdSchema,
+    terminalRef: TerminalRefSchema.optional(),
+    terminalSessionId: referenceId(128),
     terminalSessionCreatedAt: IsoTimestampSchema.optional(),
   }).strict(),
   BaseThreadEventSchema.extend({ type: z.literal("thread.error"), error: SafeClientErrorSchema }).strict(),

--- a/packages/contracts/src/canonical-chat-compatibility.ts
+++ b/packages/contracts/src/canonical-chat-compatibility.ts
@@ -274,12 +274,15 @@ function activityFromEvent(input: {
     return { ...base, type: "review.ready", reviewId: event.reviewId, summary: event.summary };
   }
   if (event.type === "terminal.bound") {
-    if (!event.terminalSessionCreatedAt) return null;
+    const terminalSessionId = event.terminalRef
+      ? `${event.terminalRef.workspaceId}:${event.terminalRef.tabId}`
+      : event.terminalSessionId;
+    if (!terminalSessionId) return null;
     return {
       ...base,
       type: "terminal.bound",
-      terminalSessionId: event.terminalSessionId,
-      terminalSessionCreatedAt: event.terminalSessionCreatedAt,
+      terminalSessionId,
+      terminalSessionCreatedAt: event.terminalSessionCreatedAt ?? event.occurredAt,
     };
   }
   if (event.type === "thread.error") {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -86,7 +86,13 @@ export const EventIdSchema = prefixedId("evt_");
 export const ApprovalIdSchema = prefixedId("appr_");
 export const RequestIdSchema = prefixedId("req_");
 export const CorrelationIdSchema = prefixedId("corr_");
+// Canonical Chat still stores terminal bindings as an opaque string. During
+// the workspace cutover that string is the stable `workspaceId:tabId` key;
+// keep this compatibility validator until Chat's persistence schema moves to
+// structured TerminalRef columns.
 export const TerminalSessionIdSchema = referenceId(128);
+export const TerminalWorkspaceIdSchema = z.string().regex(/^tws_[0-9a-f]{32}$/, "Invalid terminal workspace id");
+export const TerminalTabIdSchema = z.string().regex(/^tt_[0-9a-f]{32}$/, "Invalid terminal tab id");
 export const ReviewIdSchema = referenceId(128);
 export const WorktreeIdSchema = z.string().regex(/^wt_[a-z0-9]{12,40}$/, "Invalid worktree id");
 export const CursorSchema = referenceId(160);
@@ -115,6 +121,99 @@ export function createShellSessionName(): string {
   return `${pickShellSessionWord(SHELL_SESSION_ADJECTIVES)}-${pickShellSessionWord(SHELL_SESSION_NOUNS)}`;
 }
 export const SafeDisplayStringSchema = boundedDisplayText(120, 512);
+
+export const TerminalRefSchema = z.object({
+  workspaceId: TerminalWorkspaceIdSchema,
+  tabId: TerminalTabIdSchema,
+}).strict();
+
+export type TerminalRef = z.infer<typeof TerminalRefSchema>;
+
+export const TerminalGridSizeSchema = z.object({
+  cols: z.number().int().min(20).max(500),
+  rows: z.number().int().min(5).max(200),
+}).strict();
+
+export const TerminalTabStatusSchema = z.enum([
+  "starting",
+  "running",
+  "idle",
+  "exited",
+  "failed",
+  "unavailable",
+]);
+
+export const TerminalTabSchema = z.object({
+  id: TerminalTabIdSchema,
+  workspaceId: TerminalWorkspaceIdSchema,
+  name: SafeDisplayStringSchema,
+  cwd: z.string()
+    .max(4096)
+    .refine((value) => !value.startsWith("/") && !value.includes("\0") && !value.includes("\\"), {
+      message: "Terminal cwd must be owner-home relative",
+    })
+    .refine((value) => value === "" || value.split("/").every((part) => part !== "" && part !== "." && part !== ".."), {
+      message: "Terminal cwd cannot contain traversal",
+    }),
+  status: TerminalTabStatusSchema,
+  revision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  order: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  accessScope: z.enum(["owner", "chat", "legacy"]).optional(),
+  agent: z.object({
+    providerId: ProviderIdSchema,
+    threadId: ThreadIdSchema.optional(),
+  }).strict().optional(),
+  git: z.object({
+    branch: z.string().min(1).max(255),
+    dirty: z.boolean(),
+  }).strict().optional(),
+  uiState: z.object({
+    placement: z.enum(["active", "background"]).default("active"),
+    lastSeenSeq: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER).nullable().default(null),
+    pinned: z.boolean().default(false),
+    layoutName: SafeDisplayStringSchema.optional(),
+    legacyTabs: z.array(z.object({
+      name: SafeDisplayStringSchema.optional(),
+      focused: z.boolean().optional(),
+      createdAt: IsoTimestampSchema.optional(),
+    }).strict()).max(1_000).optional(),
+  }).strict().optional(),
+  exitCode: z.number().int().nullable().optional(),
+  createdAt: IsoTimestampSchema,
+  updatedAt: IsoTimestampSchema,
+}).strict();
+
+export type TerminalTab = z.infer<typeof TerminalTabSchema>;
+
+const TerminalWorkspaceBaseSchema = z.object({
+  id: TerminalWorkspaceIdSchema,
+  canonicalSize: TerminalGridSizeSchema,
+  status: z.enum(["maintenance", "starting", "running", "degraded", "stopped"]),
+  revision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  createdAt: IsoTimestampSchema,
+  updatedAt: IsoTimestampSchema,
+  tabs: z.array(TerminalTabSchema).max(10_000),
+});
+
+export const TerminalWorkspaceSchema = z.discriminatedUnion("scope", [
+  TerminalWorkspaceBaseSchema.extend({ scope: z.literal("main") }).strict(),
+  TerminalWorkspaceBaseSchema.extend({
+    scope: z.literal("project"),
+    projectId: ProjectIdSchema,
+  }).strict(),
+]).superRefine((workspace, context) => {
+  workspace.tabs.forEach((tab, index) => {
+    if (tab.workspaceId !== workspace.id) {
+      context.addIssue({
+        code: "custom",
+        path: ["tabs", index, "workspaceId"],
+        message: "Terminal tab must belong to its containing workspace",
+      });
+    }
+  });
+});
+
+export type TerminalWorkspace = z.infer<typeof TerminalWorkspaceSchema>;
 export const SafeAssistantPreviewSourceTextSchema = boundedText(16_000, 64 * 1024)
   .refine((value) => !UNSAFE_ASSISTANT_PREVIEW_TEXT.test(value), { message: "Text is not safe for assistant preview display" });
 export const SafeAssistantPreviewTextSchema = boundedText(243, 1024)
@@ -390,6 +489,7 @@ export const CreateAgentThreadRequestSchema = z.object({
   projectId: ProjectIdSchema.optional(),
   taskId: TaskIdSchema.optional(),
   terminalSessionId: TerminalSessionIdSchema.optional(),
+  terminalRef: TerminalRefSchema.optional(),
   worktreeId: WorktreeIdSchema.optional(),
   mode: AgentModeSchema.optional(),
   approvalPolicy: ApprovalPolicySchema.optional(),
@@ -451,6 +551,7 @@ export const AgentThreadComposerDraftSchema = z.object({
   projectId: ProjectIdSchema.optional(),
   taskId: TaskIdSchema.optional(),
   terminalSessionId: TerminalSessionIdSchema.optional(),
+  terminalRef: TerminalRefSchema.optional(),
   worktreeId: WorktreeIdSchema.optional(),
   mode: AgentModeSchema.optional(),
   approvalPolicy: ApprovalPolicySchema.optional(),
@@ -530,6 +631,7 @@ export const TerminalSessionSummarySchema = z.object({
 
 export type TerminalSessionSummary = z.infer<typeof TerminalSessionSummarySchema>;
 
+/** Legacy session protocol retained while older clients roll forward. */
 export const TerminalClientFrameSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("attach"),
@@ -538,18 +640,13 @@ export const TerminalClientFrameSchema = z.discriminatedUnion("type", [
     cols: z.number().int().min(20).max(500).optional(),
     rows: z.number().int().min(5).max(200).optional(),
   }).strict(),
-  z.object({
-    type: z.literal("input"),
-    data: z.string().min(1).max(64 * 1024),
-  }).strict(),
+  z.object({ type: z.literal("input"), data: z.string().min(1).max(64 * 1024) }).strict(),
   z.object({
     type: z.literal("resize"),
     cols: z.number().int().min(20).max(500),
     rows: z.number().int().min(5).max(200),
   }).strict(),
-  z.object({
-    type: z.literal("detach"),
-  }).strict(),
+  z.object({ type: z.literal("detach") }).strict(),
 ]);
 
 export const TerminalServerFrameSchema = z.discriminatedUnion("type", [
@@ -566,42 +663,106 @@ export const TerminalServerFrameSchema = z.discriminatedUnion("type", [
       ctx.addIssue({ code: "custom", message: "Attached frame requires a session identifier", path: ["sessionId"] });
     }
   }),
+  z.object({ type: z.literal("output"), seq: z.number().int().min(0).optional(), data: z.string().min(1).max(64 * 1024) }).strict(),
+  z.object({ type: z.literal("replay-start"), fromSeq: z.number().int().min(0).optional() }).strict(),
+  z.object({ type: z.literal("replay-evicted"), fromSeq: z.number().int().min(0).optional(), nextSeq: z.number().int().min(0) }).strict(),
+  z.object({ type: z.literal("replay-gap"), fromSeq: z.number().int().min(0).optional(), nextSeq: z.number().int().min(0) }).strict(),
+  z.object({ type: z.literal("replay-end"), nextSeq: z.number().int().min(0).optional(), toSeq: z.number().int().min(0).nullable().optional() }).strict(),
+  z.object({ type: z.literal("exit"), exitCode: z.number().int().nullable().optional(), code: z.number().int().nullable().optional() }).strict(),
+  z.object({ type: z.literal("error"), code: z.string().min(1).max(80).regex(SAFE_SLUG), message: boundedSafeErrorText(180, 720) }).strict(),
+  z.object({ type: z.literal("safe-error"), error: SafeClientErrorSchema }).strict(),
+]);
+
+export const TerminalTabClientFrameSchema = z.discriminatedUnion("type", [
   z.object({
-    type: z.literal("output"),
-    seq: z.number().int().min(0).optional(),
+    type: z.literal("input"),
+    terminalRef: TerminalRefSchema,
     data: z.string().min(1).max(64 * 1024),
   }).strict(),
   z.object({
+    type: z.literal("resize"),
+    terminalRef: TerminalRefSchema,
+    size: TerminalGridSizeSchema,
+    mode: z.enum(["hard", "soft"]),
+  }).strict(),
+  z.object({
+    type: z.literal("detach"),
+    terminalRef: TerminalRefSchema,
+  }).strict(),
+  z.object({
+    type: z.literal("ping"),
+    terminalRef: TerminalRefSchema,
+  }).strict(),
+]);
+
+const TerminalServerEventBaseSchema = z.object({
+  terminalRef: TerminalRefSchema,
+  revision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+});
+
+export const TerminalTabServerFrameSchema = z.discriminatedUnion("type", [
+  TerminalServerEventBaseSchema.extend({
+    type: z.literal("attached"),
+    canonicalSize: TerminalGridSizeSchema,
+    nextSeq: z.number().int().min(0),
+  }).strict(),
+  TerminalServerEventBaseSchema.extend({
+    type: z.literal("snapshot"),
+    canonicalSize: TerminalGridSizeSchema,
+    // Advances only when the snapshot intentionally replaces the rendered
+    // presentation; routine checkpoints preserve the current value.
+    presentationRevision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER).optional(),
+    seq: z.number().int().min(0),
+    ansi: z.string().max(5 * 1024 * 1024),
+    viewport: z.object({
+      top: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+      rows: z.number().int().min(1).max(200),
+    }).strict(),
+  }).strict(),
+  TerminalServerEventBaseSchema.extend({
+    type: z.literal("output"),
+    seq: z.number().int().min(0),
+    data: z.string().min(1).max(64 * 1024),
+  }).strict(),
+  TerminalServerEventBaseSchema.extend({
     type: z.literal("replay-start"),
-    fromSeq: z.number().int().min(0).optional(),
+    fromSeq: z.number().int().min(0),
   }).strict(),
-  z.object({
+  TerminalServerEventBaseSchema.extend({
     type: z.literal("replay-evicted"),
-    fromSeq: z.number().int().min(0).optional(),
+    fromSeq: z.number().int().min(0),
     nextSeq: z.number().int().min(0),
   }).strict(),
-  z.object({
+  TerminalServerEventBaseSchema.extend({
     type: z.literal("replay-gap"),
-    fromSeq: z.number().int().min(0).optional(),
+    fromSeq: z.number().int().min(0),
     nextSeq: z.number().int().min(0),
   }).strict(),
-  z.object({
+  TerminalServerEventBaseSchema.extend({
     type: z.literal("replay-end"),
-    nextSeq: z.number().int().min(0).optional(),
+    nextSeq: z.number().int().min(0),
     toSeq: z.number().int().min(0).nullable().optional(),
   }).strict(),
-  z.object({
+  TerminalServerEventBaseSchema.extend({
+    type: z.literal("canonical-size"),
+    canonicalSize: TerminalGridSizeSchema,
+  }).strict(),
+  TerminalServerEventBaseSchema.extend({
+    type: z.literal("pong"),
+  }).strict(),
+  TerminalServerEventBaseSchema.extend({
     type: z.literal("exit"),
-    exitCode: z.number().int().nullable().optional(),
-    code: z.number().int().nullable().optional(),
+    exitCode: z.number().int().nullable(),
   }).strict(),
   z.object({
     type: z.literal("error"),
+    terminalRef: TerminalRefSchema.optional(),
     code: z.string().min(1).max(80).regex(SAFE_SLUG),
     message: boundedSafeErrorText(180, 720),
   }).strict(),
   z.object({
     type: z.literal("safe-error"),
+    terminalRef: TerminalRefSchema.optional(),
     error: SafeClientErrorSchema,
   }).strict(),
 ]);
@@ -745,7 +906,17 @@ export const RuntimeSummarySchema = z.object({
     hasMore: false,
     limit: 20,
   }),
-  terminalSessions: boundedListSchema(TerminalSessionSummarySchema, 50),
+  terminalWorkspaces: boundedListSchema(TerminalWorkspaceSchema, 100).default({
+    items: [],
+    hasMore: false,
+    limit: 100,
+  }),
+  /** Compatibility projection for clients that have not migrated to workspace/tab refs yet. */
+  terminalSessions: boundedListSchema(TerminalSessionSummarySchema, 50).default({
+    items: [],
+    hasMore: false,
+    limit: 50,
+  }),
   previewSessions: boundedListSchema(PreviewSessionSummarySchema, 50).default({
     items: [],
     hasMore: false,
@@ -841,6 +1012,7 @@ export function buildCreateAgentThreadRequestFromComposer(input: {
     projectId: draft.projectId,
     taskId: draft.taskId,
     terminalSessionId: draft.terminalSessionId,
+    terminalRef: draft.terminalRef,
     worktreeId: draft.worktreeId,
     mode,
     approvalPolicy: draft.approvalPolicy ?? "on_request",

--- a/packages/terminal-runtime/package.json
+++ b/packages/terminal-runtime/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@matrix-os/terminal-runtime",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@matrix-os/contracts": "workspace:*",
+    "node-pty": "^1.1.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/terminal-runtime/src/index.ts
+++ b/packages/terminal-runtime/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./workspace-store.js";
+export * from "./runtime.js";

--- a/packages/terminal-runtime/src/runtime.ts
+++ b/packages/terminal-runtime/src/runtime.ts
@@ -1,0 +1,859 @@
+import {
+  TerminalRefSchema,
+  TerminalWorkspaceIdSchema,
+  type TerminalRef,
+  type TerminalTab,
+  type TerminalWorkspace,
+} from "@matrix-os/contracts";
+import { setTimeout as delay } from "node:timers/promises";
+import { z } from "zod/v4";
+import {
+  TerminalWorkspaceStore,
+  type TerminalRuntimeWorkspaceState,
+  type TerminalSnapshot,
+} from "./workspace-store.js";
+export interface ZellijRuntimeAdapter {
+  ensureSession(sessionName: string, size?: { cols: number; rows: number }): Promise<void>;
+  createTab(sessionName: string, input: {
+    internalName: string;
+    cwd: string;
+    command?: string[];
+  }): Promise<{ tabId: number; paneId: string }>;
+  openAttachment(sessionName: string, input: {
+    paneId: string;
+    size: { cols: number; rows: number };
+    onData: (data: Uint8Array) => void;
+    onExit: (exitCode: number | null) => void;
+  }): Promise<ZellijAttachment>;
+  subscribeWorkspace(sessionName: string, input: {
+    paneIds: string[];
+    onEvent: (event: ZellijObserverEvent) => void;
+  }): Promise<ZellijObserver>;
+  findTabByInternalName?(sessionName: string, internalName: string): Promise<{ tabId: number; paneId: string } | undefined>;
+  renameTab?(sessionName: string, tabId: number, name: string): Promise<void>;
+  closeTab?(sessionName: string, tabId: number): Promise<void>;
+  deleteSession?(sessionName: string): Promise<void>;
+  resizeSession?(sessionName: string, size: { cols: number; rows: number }): Promise<void>;
+  writeToPane?(sessionName: string, paneId: string, data: Uint8Array): Promise<void>;
+}
+
+export interface ZellijAttachment {
+  write(data: Uint8Array): Promise<void>;
+  resize(cols: number, rows: number): Promise<void>;
+  close(): Promise<void>;
+}
+export type ZellijObserverEvent =
+  | { type: "pane-update"; paneId: string; ansi: string; viewport: string[]; scrollback: string[] }
+  | { type: "pane-closed"; paneId: string };
+export interface ZellijObserver {
+  close(): Promise<void>;
+}
+export interface TerminalRuntimeOptions {
+  store: TerminalWorkspaceStore;
+  zellij: ZellijRuntimeAdapter;
+  maxAttachments?: number;
+  maxObservers?: number;
+  maxViewersPerTab?: number;
+  maxPendingInputBytes?: number;
+  viewerTtlMs?: number;
+  sweepIntervalMs?: number;
+  observerCloseTimeoutMs?: number;
+}
+export interface TerminalViewer {
+  write(data: string): Promise<void>;
+  touch(): void;
+  detach(): Promise<void>;
+}
+
+interface ViewerState {
+  id: string;
+  lastTouched: number;
+  send: (data: Uint8Array) => void | Promise<void>;
+  onExit?: (exitCode: number | null) => void | Promise<void>;
+}
+
+interface AttachmentState {
+  ref: TerminalRef;
+  handle: ZellijAttachment;
+  viewers: Map<string, ViewerState>;
+}
+
+interface InputQueueState {
+  chain: Promise<void>;
+  pendingBytes: number;
+  lastTouched: number;
+}
+
+interface ObserverState extends ZellijObserver {
+  readonly size: number;
+  add(observer: ZellijObserver, restore: () => Promise<ZellijObserver>): void;
+  restore(): Promise<ObserverState>;
+}
+
+export class TerminalRuntime {
+  private readonly store: TerminalWorkspaceStore;
+  private readonly zellij: ZellijRuntimeAdapter;
+  private readonly attachments = new Map<string, AttachmentState>();
+  private readonly observers = new Map<string, ObserverState>();
+  private readonly observerReservations = new Map<string, number>();
+  private readonly inputQueues = new Map<string, InputQueueState>();
+  private readonly terminatingTabKeys = new Set<string>();
+  private readonly closingPaneTabKeys = new Map<string, number>();
+  private readonly maxAttachments: number;
+  private readonly maxObservers: number;
+  private readonly maxViewersPerTab: number;
+  private readonly maxPendingInputBytes: number;
+  private readonly viewerTtlMs: number;
+  private readonly observerCloseTimeoutMs: number;
+  private readonly sweepTimer: NodeJS.Timeout;
+  private checkpointChain: Promise<void> = Promise.resolve();
+  private observerChain: Promise<void> = Promise.resolve();
+  private workspaceMutationChain: Promise<void> = Promise.resolve();
+  // Workspace mutations are globally serialized, so at most one deletion can
+  // own write admission at a time.
+  private deletingWorkspaceId: string | null = null;
+  private untrackedPaneClosures = 0;
+  private observerRetryQueued = false;
+  private shuttingDown = false;
+  private acceptingObserverEvents = true;
+
+  constructor(options: TerminalRuntimeOptions) {
+    this.store = options.store;
+    this.zellij = options.zellij;
+    this.maxAttachments = options.maxAttachments ?? 128;
+    this.maxObservers = z.number().int().min(1).max(1_024).parse(options.maxObservers ?? 128);
+    this.maxViewersPerTab = options.maxViewersPerTab ?? 8;
+    this.maxPendingInputBytes = options.maxPendingInputBytes ?? 1024 * 1024;
+    this.viewerTtlMs = options.viewerTtlMs ?? 2 * 60_000;
+    this.observerCloseTimeoutMs = z.number().int().min(1).max(30_000).parse(options.observerCloseTimeoutMs ?? 5_000);
+    this.sweepTimer = setInterval(() => {
+      void this.sweepStaleViewers().catch((error: unknown) => {
+        console.error("[terminal-runtime] stale viewer sweep failed", error instanceof Error ? error.name : "unknown_error");
+      });
+      this.queueMissingObserverRetry();
+    }, options.sweepIntervalMs ?? 30_000);
+    this.sweepTimer.unref();
+  }
+
+  async ensureWorkspace(input: { projectId?: string } = {}): Promise<TerminalWorkspace> {
+    const workspace = await this.store.ensureWorkspace(input);
+    await this.reconcileWorkspace(workspace.id);
+    return (await this.listWorkspaces()).find((candidate) => candidate.id === workspace.id)!;
+  }
+
+  async restoreAll(): Promise<void> {
+    for (const workspace of await this.listWorkspaces()) {
+      if (workspace.status !== "stopped") await this.reconcileWorkspace(workspace.id);
+    }
+  }
+
+  async createTab(workspaceIdInput: string, input: {
+    name: string;
+    cwd: string;
+    command?: string[];
+    agent?: TerminalTab["agent"];
+    git?: TerminalTab["git"];
+  }): Promise<TerminalTab> {
+    const workspaceId = TerminalWorkspaceIdSchema.parse(workspaceIdInput);
+    return this.runWorkspaceMutation(async () => {
+      const releaseObserverReservation = this.reserveObserverSlot(workspaceId);
+      let stagedTab: TerminalTab | undefined;
+      let runtimeIds: { tabId: number; paneId: string } | undefined;
+      let sessionName: string | undefined;
+      try {
+        const runtimeWorkspace = await this.requireRuntimeWorkspace(workspaceId);
+        sessionName = runtimeWorkspace.zellijSessionName;
+        await this.zellij.ensureSession(runtimeWorkspace.zellijSessionName, runtimeWorkspace.canonicalSize);
+        stagedTab = await this.store.createTab(workspaceId, input);
+        const stagedWorkspace = await this.requireRuntimeWorkspace(workspaceId);
+        const internalTab = stagedWorkspace.tabs[stagedTab.id];
+        if (!internalTab) throw new Error("Terminal tab staging failed");
+        runtimeIds = await this.zellij.createTab(stagedWorkspace.zellijSessionName, {
+          internalName: internalTab.zellijTabName,
+          cwd: internalTab.cwd,
+          ...(input.command ? { command: input.command } : {}),
+        });
+        const tab = await this.store.activateTab({ workspaceId, tabId: stagedTab.id }, runtimeIds);
+        await this.restartObserver(workspaceId);
+        return tab;
+      } catch (error) {
+        if (stagedTab && sessionName) {
+          try {
+            await this.rollbackTabCreation(sessionName, {
+              workspaceId,
+              tabId: stagedTab.id,
+            }, runtimeIds?.tabId);
+          } catch (rollbackError) {
+            console.error(
+              "[terminal-runtime] failed to roll back terminal tab creation",
+              rollbackError instanceof Error ? rollbackError.name : "unknown_error",
+            );
+          }
+        }
+        throw error;
+      } finally {
+        releaseObserverReservation();
+      }
+    });
+  }
+
+  listWorkspaces(): Promise<TerminalWorkspace[]> {
+    return this.store.listWorkspaces();
+  }
+
+  private reconcileWorkspace(workspaceId: string): Promise<void> {
+    return this.runWorkspaceMutation(() => this.reconcileWorkspaceNow(workspaceId));
+  }
+
+  private async reconcileWorkspaceNow(workspaceId: string): Promise<void> {
+    const workspace = await this.requireRuntimeWorkspace(workspaceId);
+    const needsObserver = Object.values(workspace.tabs)
+      .some((tab) => tab.status !== "exited" && tab.status !== "failed");
+    const releaseObserverReservation = needsObserver
+      ? this.reserveObserverSlot(workspaceId)
+      : () => undefined;
+    try {
+      await this.zellij.ensureSession(workspace.zellijSessionName, workspace.canonicalSize);
+      for (const tab of Object.values(workspace.tabs).sort((left, right) => left.order - right.order)) {
+        if (tab.status === "exited" || tab.status === "failed") continue;
+        let ids = await this.zellij.findTabByInternalName?.(workspace.zellijSessionName, tab.zellijTabName);
+        ids ??= await this.zellij.createTab(workspace.zellijSessionName, {
+          internalName: tab.zellijTabName,
+          cwd: tab.cwd,
+        });
+        await this.store.activateTab({ workspaceId, tabId: tab.id }, ids);
+      }
+      await this.restartObserver(workspaceId);
+    } finally {
+      releaseObserverReservation();
+    }
+  }
+
+  async renameTab(refInput: TerminalRef, input: { name: string; baseRevision: number }): Promise<TerminalTab> {
+    const ref = TerminalRefSchema.parse(refInput);
+    const workspace = await this.requireRuntimeWorkspace(ref.workspaceId);
+    const tab = workspace.tabs[ref.tabId];
+    if (!tab || tab.zellijTabId === null || !this.zellij.renameTab) throw new Error("Terminal tab unavailable");
+    await this.zellij.renameTab(workspace.zellijSessionName, tab.zellijTabId, input.name);
+    return this.store.renameTab(ref, input);
+  }
+
+  reorderTabs(workspaceId: string, input: { tabIds: string[]; baseRevision: number }): Promise<TerminalWorkspace> {
+    return this.store.reorderTabs(workspaceId, input);
+  }
+
+  updateTabUiState(ref: TerminalRef, input: {
+    placement?: "active" | "background";
+    lastSeenSeq?: number | null;
+    pinned?: boolean;
+    baseRevision: number;
+  }): Promise<TerminalTab> {
+    return this.store.updateTabUiState(ref, input);
+  }
+
+  async resize(refInput: TerminalRef, input: {
+    mode: "hard" | "soft";
+    size: { cols: number; rows: number };
+  }): Promise<TerminalWorkspace> {
+    const ref = TerminalRefSchema.parse(refInput);
+    const workspace = await this.requireRuntimeWorkspace(ref.workspaceId);
+    if (!workspace.tabs[ref.tabId]) throw new Error("Terminal tab not found");
+    if (input.mode === "soft") return (await this.listWorkspaces()).find((item) => item.id === ref.workspaceId)!;
+    const updated = await this.store.updateCanonicalSize(ref.workspaceId, input.size);
+    await this.zellij.resizeSession?.(workspace.zellijSessionName, updated.canonicalSize);
+    await Promise.all([...this.attachments.values()]
+      .filter((attachment) => attachment.ref.workspaceId === ref.workspaceId)
+      .map((attachment) => attachment.handle.resize(updated.canonicalSize.cols, updated.canonicalSize.rows)));
+    return updated;
+  }
+
+  async terminateTab(refInput: TerminalRef): Promise<void> {
+    const ref = TerminalRefSchema.parse(refInput);
+    const key = refKey(ref);
+    if (this.terminatingTabKeys.has(key)) throw new Error("Terminal tab termination in progress");
+    if (this.terminatingTabKeys.size >= this.maxAttachments * 2) {
+      throw new Error("Terminal tab termination capacity reached");
+    }
+    this.terminatingTabKeys.add(key);
+    try {
+      await this.runWorkspaceMutation(async () => {
+        const workspace = await this.requireRuntimeWorkspace(ref.workspaceId);
+        const tab = workspace.tabs[ref.tabId];
+        if (!tab || tab.zellijTabId === null || !this.zellij.closeTab) throw new Error("Terminal tab unavailable");
+        await this.drainTabInput(key);
+        await this.closeAttachment(key, true);
+        await this.zellij.closeTab(workspace.zellijSessionName, tab.zellijTabId);
+        await this.store.markTabExited(ref);
+        await this.restartObserver(ref.workspaceId);
+      });
+    } finally {
+      this.terminatingTabKeys.delete(key);
+    }
+  }
+
+  async writeInput(refInput: TerminalRef, dataInput: string): Promise<void> {
+    const ref = TerminalRefSchema.parse(refInput);
+    await this.enqueueWrite(ref, dataInput, async (data) => {
+      const workspace = await this.requireRuntimeWorkspace(ref.workspaceId);
+      const tab = workspace.tabs[ref.tabId];
+      if (
+        !tab ||
+        (tab.status !== "running" && tab.status !== "idle") ||
+        tab.zellijPaneId === null ||
+        !this.zellij.writeToPane
+      ) {
+        throw new Error("Terminal tab unavailable");
+      }
+      await this.zellij.writeToPane(workspace.zellijSessionName, tab.zellijPaneId, data);
+    });
+  }
+
+  async deletionImpact(workspaceIdInput: string): Promise<{ runningTabs: number; tabs: TerminalTab[] }> {
+    const workspaceId = TerminalWorkspaceIdSchema.parse(workspaceIdInput);
+    const workspace = (await this.listWorkspaces()).find((item) => item.id === workspaceId);
+    if (!workspace) throw new Error("Terminal workspace not found");
+    const tabs = workspace.tabs.filter((tab) => tab.status === "running" || tab.status === "starting" || tab.status === "idle");
+    return { runningTabs: tabs.length, tabs };
+  }
+
+  async deleteWorkspace(workspaceIdInput: string, input: { confirmTerminate: boolean }): Promise<void> {
+    const workspaceId = TerminalWorkspaceIdSchema.parse(workspaceIdInput);
+    await this.runWorkspaceMutation(async () => {
+      const impact = await this.deletionImpact(workspaceId);
+      if (impact.runningTabs > 0 && !input.confirmTerminate) throw new Error("Terminal termination confirmation required");
+      const workspace = await this.requireRuntimeWorkspace(workspaceId);
+      if (!this.zellij.deleteSession) throw new Error("Terminal workspace deletion unavailable");
+      this.deletingWorkspaceId = workspaceId;
+      try {
+        await this.drainWorkspaceInput(workspaceId);
+        for (const key of [...this.attachments.keys()]) {
+          if (key.startsWith(`${workspaceId}:`)) await this.closeAttachment(key, true);
+        }
+        const operation = this.observerChain.then(async () => {
+          const observer = this.observers.get(workspaceId);
+          if (observer) {
+            await observer.close();
+            if (this.observers.get(workspaceId) === observer) this.observers.delete(workspaceId);
+          }
+          await this.zellij.deleteSession!(workspace.zellijSessionName);
+          await this.store.removeWorkspace(workspaceId);
+        });
+        this.observerChain = operation.catch((error: unknown) => {
+          console.error(
+            "[terminal-runtime] failed to delete terminal workspace",
+            error instanceof Error ? error.name : "unknown_error",
+          );
+        });
+        await operation;
+      } finally {
+        if (this.deletingWorkspaceId === workspaceId) this.deletingWorkspaceId = null;
+      }
+    });
+  }
+
+  attach(refInput: TerminalRef, input: {
+    viewerId: string;
+    send: (data: Uint8Array) => void | Promise<void>;
+    onExit?: (exitCode: number | null) => void | Promise<void>;
+  }): Promise<TerminalViewer> {
+    return this.runWorkspaceMutation(() => this.attachNow(refInput, input));
+  }
+
+  private async attachNow(refInput: TerminalRef, input: {
+    viewerId: string;
+    send: (data: Uint8Array) => void | Promise<void>;
+    onExit?: (exitCode: number | null) => void | Promise<void>;
+  }): Promise<TerminalViewer> {
+    const ref = TerminalRefSchema.parse(refInput);
+    const viewerId = z.string().min(1).max(128).regex(/^[A-Za-z0-9_.:-]+$/).parse(input.viewerId);
+    await this.sweepStaleViewers();
+    const key = refKey(ref);
+    let attachment = this.attachments.get(key);
+    if (!attachment) {
+      if (this.attachments.size >= this.maxAttachments) throw new Error("Terminal attachment capacity reached");
+      const workspace = await this.requireRuntimeWorkspace(ref.workspaceId);
+      const tab = workspace.tabs[ref.tabId];
+      if (!tab || tab.zellijPaneId === null) throw new Error("Terminal tab unavailable");
+      const next: AttachmentState = {
+        ref,
+        handle: undefined as unknown as ZellijAttachment,
+        viewers: new Map(),
+      };
+      let openingExit: { exitCode: number | null; release: () => void } | undefined;
+      try {
+        next.handle = await this.zellij.openAttachment(workspace.zellijSessionName, {
+          paneId: tab.zellijPaneId,
+          size: workspace.canonicalSize,
+          onData: (data) => { void this.broadcast(key, data); },
+          onExit: (exitCode) => {
+            if (!this.attachments.has(key)) { openingExit ??= { exitCode, release: this.reservePaneClosure(key) }; return; }
+            const releasePaneClosure = this.reservePaneClosure(key);
+            void this.handleAttachmentExit(key, exitCode)
+              .catch((error: unknown) => { console.error("[terminal-runtime] failed to record terminal attachment exit", error); })
+              .finally(releasePaneClosure);
+          },
+        });
+        this.attachments.set(key, next);
+        if (openingExit) { await this.handleAttachmentExit(key, openingExit.exitCode); throw new Error("Terminal tab unavailable"); }
+      } finally { openingExit?.release(); }
+      attachment = next;
+    }
+    if (!attachment.viewers.has(viewerId) && attachment.viewers.size >= this.maxViewersPerTab) {
+      throw new Error("Terminal viewer capacity reached");
+    }
+    attachment.viewers.set(viewerId, {
+      id: viewerId,
+      lastTouched: Date.now(),
+      send: input.send,
+      ...(input.onExit ? { onExit: input.onExit } : {}),
+    });
+    let detached = false;
+    return {
+      write: async (data) => {
+        if (detached) throw new Error("Terminal viewer detached");
+        const viewer = attachment!.viewers.get(viewerId);
+        if (!viewer) throw new Error("Terminal viewer unavailable");
+        viewer.lastTouched = Date.now();
+        await this.enqueueWrite(ref, data, (encoded) => attachment!.handle.write(encoded));
+      },
+      touch: () => {
+        if (detached) return;
+        const viewer = attachment!.viewers.get(viewerId);
+        if (viewer) viewer.lastTouched = Date.now();
+      },
+      detach: async () => {
+        if (detached) return;
+        detached = true;
+        attachment!.viewers.delete(viewerId);
+        if (attachment!.viewers.size === 0) await this.closeAttachment(key);
+      },
+    };
+  }
+
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true;
+    clearInterval(this.sweepTimer);
+    await this.workspaceMutationChain;
+    await this.observerChain;
+    const observerEntries = [...this.observers.entries()];
+    const observerResults = await Promise.allSettled(observerEntries.map(([, observer]) => Promise.race([
+      observer.close(),
+      delay(this.observerCloseTimeoutMs, undefined, { ref: false }).then(() => {
+        throw new Error("Terminal observer close timed out");
+      }),
+    ])));
+    this.acceptingObserverEvents = false;
+    observerResults.forEach((result, index) => {
+      const entry = observerEntries[index];
+      if (result.status === "fulfilled" && entry && this.observers.get(entry[0]) === entry[1]) this.observers.delete(entry[0]);
+    });
+    await this.flushCheckpoints();
+    await Promise.all([...this.inputQueues.values()].map((queue) => queue.chain));
+    await Promise.all([...this.attachments.keys()].map((key) => this.closeAttachment(key, true)));
+    this.inputQueues.clear();
+    this.closingPaneTabKeys.clear();
+    this.untrackedPaneClosures = 0;
+    const observerFailure = observerResults.find((result) => result.status === "rejected");
+    if (observerFailure?.status === "rejected") throw observerFailure.reason;
+  }
+
+  getSnapshot(ref: TerminalRef): Promise<TerminalSnapshot | undefined> {
+    return this.store.readSnapshot(TerminalRefSchema.parse(ref));
+  }
+
+  async flushCheckpoints(): Promise<void> {
+    await this.checkpointChain;
+  }
+
+  private runWorkspaceMutation<T>(operation: () => Promise<T>): Promise<T> {
+    if (this.shuttingDown) return Promise.reject(new Error("Terminal runtime shutting down"));
+    const result = this.workspaceMutationChain.then(operation);
+    this.workspaceMutationChain = result.then(
+      () => undefined,
+      (error: unknown) => {
+        console.error(
+          "[terminal-runtime] workspace mutation failed",
+          error instanceof Error ? error.name : "unknown_error",
+        );
+      },
+    );
+    return result;
+  }
+
+  private async rollbackTabCreation(sessionName: string, ref: TerminalRef, zellijTabId?: number): Promise<void> {
+    try {
+      if (zellijTabId !== undefined) {
+        if (!this.zellij.closeTab) throw new Error("Terminal tab rollback unavailable");
+        await this.zellij.closeTab(sessionName, zellijTabId);
+      }
+    } finally {
+      await this.store.removeTab(ref);
+    }
+  }
+
+  private async restartObserver(workspaceId: string): Promise<void> {
+    const operation = this.observerChain.then(async () => { await this.replaceObserver(workspaceId); });
+    this.observerChain = operation.catch((error: unknown) => {
+      console.error(
+        "[terminal-runtime] failed to restart workspace observer",
+        error instanceof Error ? error.name : "unknown_error",
+      );
+    });
+    await operation;
+  }
+
+  private async replaceObserver(workspaceId: string): Promise<void> {
+    let existing = this.observers.get(workspaceId);
+    const workspace = await this.requireRuntimeWorkspace(workspaceId);
+    const paneRefs = new Map<string, TerminalRef>();
+    for (const tab of Object.values(workspace.tabs)) {
+      if (tab.zellijPaneId) paneRefs.set(tab.zellijPaneId, { workspaceId: workspace.id, tabId: tab.id });
+    }
+    if (paneRefs.size === 0) {
+      if (existing) {
+        await existing.close();
+        if (this.observers.get(workspaceId) === existing) this.observers.delete(workspaceId);
+      }
+      return;
+    }
+    let closedForCapacity: ObserverState | undefined;
+    if (existing && this.observerCount() >= this.maxObservers) {
+      await existing.close();
+      if (this.observers.get(workspaceId) === existing) this.observers.delete(workspaceId);
+      closedForCapacity = existing;
+      existing = undefined;
+    }
+    if (!existing && !this.observerReservations.has(workspaceId) && this.observerCount() >= this.maxObservers) {
+      throw new Error("Terminal observer capacity reached");
+    }
+    const observerInput = {
+      paneIds: [...paneRefs.keys()],
+      onEvent: (event: ZellijObserverEvent) => {
+        if (!this.acceptingObserverEvents) return;
+        const ref = paneRefs.get(event.paneId);
+        if (!ref) return;
+        if (event.type === "pane-closed") {
+          const key = refKey(ref);
+          const releasePaneClosure = this.reservePaneClosure(key);
+          this.checkpointChain = this.checkpointChain.then(async () => {
+            try {
+              if (this.attachments.has(key)) await this.handleAttachmentExit(key, null);
+              else {
+                await this.drainTabInput(key);
+                await this.retryPaneClosureCheckpoint(() => this.store.markTabExited(ref));
+              }
+            } finally {
+              releasePaneClosure();
+            }
+          }).catch((error: unknown) => {
+            console.error("[terminal-runtime] failed to record terminal tab exit", error);
+          });
+          return;
+        }
+        this.checkpointChain = this.checkpointChain
+          .then(async () => { await this.store.checkpointTab(ref, event); })
+          .catch((error: unknown) => {
+            console.error("[terminal-runtime] failed to checkpoint terminal tab", error);
+          });
+      },
+    };
+    const subscribeObserver = () => this.zellij.subscribeWorkspace(workspace.zellijSessionName, observerInput);
+    let replacement: ZellijObserver;
+    try {
+      replacement = await subscribeObserver();
+    } catch (error) {
+      if (closedForCapacity) {
+        try {
+          this.observers.set(workspaceId, await closedForCapacity.restore());
+        } catch (restoreError) {
+          this.observers.set(workspaceId, closedForCapacity);
+          this.queueMissingObserverRetry();
+          throw new AggregateError([error, restoreError], "Terminal observer restoration failed");
+        }
+      }
+      throw error;
+    }
+    if (existing) {
+      try {
+        await existing.close();
+      } catch (error) {
+        try {
+          await replacement.close();
+        } catch (replacementError) {
+          existing.add(replacement, subscribeObserver);
+          throw new AggregateError([error, replacementError], "Terminal observer replacement cleanup failed");
+        }
+        throw error;
+      }
+    }
+    this.observers.set(workspaceId, createObserverState(replacement, subscribeObserver));
+  }
+
+  private observerCount(): number {
+    return [...this.observers.values()].reduce((count, observer) => count + Math.max(1, observer.size), 0);
+  }
+
+  private queueMissingObserverRetry(): void {
+    if (this.shuttingDown || this.observerRetryQueued) return;
+    this.observerRetryQueued = true;
+    const operation = this.observerChain.then(async () => {
+      for (const [workspaceId, observer] of this.observers) {
+        if (observer.size > 0) continue;
+        try {
+          const restored = await observer.restore();
+          if (this.observers.get(workspaceId) === observer) this.observers.set(workspaceId, restored);
+          else await restored.close();
+        } catch (error) {
+          console.error(
+            "[terminal-runtime] failed to restore workspace observer",
+            error instanceof Error ? error.name : "unknown_error",
+          );
+        }
+      }
+    });
+    this.observerChain = operation.then(
+      () => { this.observerRetryQueued = false; },
+      (error: unknown) => {
+        this.observerRetryQueued = false;
+        console.error("[terminal-runtime] observer retry failed", error instanceof Error ? error.name : "unknown_error");
+      },
+    );
+  }
+
+  private reserveObserverSlot(workspaceId: string): () => void {
+    if (this.observers.has(workspaceId)) return () => undefined;
+    const currentReservations = this.observerReservations.get(workspaceId);
+    if (currentReservations !== undefined) {
+      this.observerReservations.set(workspaceId, currentReservations + 1);
+    } else {
+      if (this.observerCount() + this.observerReservations.size >= this.maxObservers) {
+        throw new Error("Terminal observer capacity reached");
+      }
+      this.observerReservations.set(workspaceId, 1);
+    }
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      const reservations = this.observerReservations.get(workspaceId);
+      if (reservations === undefined || reservations <= 1) this.observerReservations.delete(workspaceId);
+      else this.observerReservations.set(workspaceId, reservations - 1);
+    };
+  }
+
+  private async enqueueWrite(
+    ref: TerminalRef,
+    dataInput: string,
+    writer: (data: Uint8Array) => Promise<void>,
+  ): Promise<void> {
+    if (this.shuttingDown) throw new Error("Terminal runtime shutting down");
+    if (this.deletingWorkspaceId === ref.workspaceId) {
+      throw new Error("Terminal workspace deletion in progress");
+    }
+    const data = new TextEncoder().encode(z.string().min(1).max(64 * 1024).parse(dataInput));
+    const key = refKey(ref);
+    this.assertTabAcceptsInput(key);
+    let queue = this.inputQueues.get(key);
+    if (!queue) {
+      if (this.inputQueues.size >= this.maxAttachments * 2) {
+        const idle = [...this.inputQueues.entries()]
+          .filter(([, candidate]) => candidate.pendingBytes === 0)
+          .sort((left, right) => left[1].lastTouched - right[1].lastTouched)[0];
+        if (!idle) throw new Error("Terminal input queue capacity reached");
+        this.inputQueues.delete(idle[0]);
+      }
+      queue = { chain: Promise.resolve(), pendingBytes: 0, lastTouched: Date.now() };
+      this.inputQueues.set(key, queue);
+    }
+    if (queue.pendingBytes + data.byteLength > this.maxPendingInputBytes) {
+      throw new Error("Terminal input queue capacity reached");
+    }
+    queue.pendingBytes += data.byteLength;
+    queue.lastTouched = Date.now();
+    const write = queue.chain.then(() => {
+      // Admission gates are checked before the write joins this queue. Once
+      // admitted, the write must drain before termination, deletion, or
+      // shutdown closes the underlying runtime resource.
+      return writer(data);
+    });
+    queue.chain = write.catch((error: unknown) => {
+      console.error(
+        "[terminal-runtime] serialized input write failed",
+        error instanceof Error ? error.name : "unknown_error",
+      );
+    }).finally(() => {
+      queue!.pendingBytes -= data.byteLength;
+      queue!.lastTouched = Date.now();
+    });
+    await write;
+  }
+
+  private assertTabAcceptsInput(key: string): void {
+    if (this.terminatingTabKeys.has(key)) {
+      throw new Error("Terminal tab termination in progress");
+    }
+    if (this.closingPaneTabKeys.has(key) || this.untrackedPaneClosures > 0) {
+      throw new Error("Terminal tab closure in progress");
+    }
+  }
+
+  private reservePaneClosure(key: string): () => void {
+    let released = false;
+    const releaseOnce = (release: () => void) => () => {
+      if (released) return;
+      released = true;
+      release();
+    };
+    const existing = this.closingPaneTabKeys.get(key);
+    if (existing !== undefined) {
+      this.closingPaneTabKeys.set(key, existing + 1);
+      return releaseOnce(() => this.releasePaneClosure(key));
+    }
+    if (this.closingPaneTabKeys.size < this.maxAttachments * 2) {
+      this.closingPaneTabKeys.set(key, 1);
+      return releaseOnce(() => this.releasePaneClosure(key));
+    }
+    this.untrackedPaneClosures += 1;
+    return releaseOnce(() => { this.untrackedPaneClosures -= 1; });
+  }
+
+  private releasePaneClosure(key: string): void {
+    const count = this.closingPaneTabKeys.get(key);
+    if (count === undefined) return;
+    if (count === 1) this.closingPaneTabKeys.delete(key);
+    else this.closingPaneTabKeys.set(key, count - 1);
+  }
+
+  private async drainWorkspaceInput(workspaceId: string): Promise<void> {
+    const prefix = `${workspaceId}:`;
+    const queues = [...this.inputQueues.entries()]
+      .filter(([key]) => key.startsWith(prefix));
+    await Promise.all(queues.map(([, queue]) => queue.chain));
+    for (const [key, queue] of queues) {
+      if (queue.pendingBytes === 0 && this.inputQueues.get(key) === queue) {
+        this.inputQueues.delete(key);
+      }
+    }
+  }
+
+  private async drainTabInput(key: string): Promise<void> {
+    const queue = this.inputQueues.get(key);
+    if (!queue) return;
+    await queue.chain;
+    if (queue.pendingBytes === 0 && this.inputQueues.get(key) === queue) {
+      this.inputQueues.delete(key);
+    }
+  }
+
+  private async broadcast(key: string, data: Uint8Array): Promise<void> {
+    const attachment = this.attachments.get(key);
+    if (!attachment) return;
+    const failed: string[] = [];
+    for (const viewer of attachment.viewers.values()) {
+      try {
+        await viewer.send(data);
+      } catch (error) {
+        console.error(
+          "[terminal-runtime] viewer output send failed",
+          error instanceof Error ? error.name : "unknown_error",
+        );
+        failed.push(viewer.id);
+      }
+    }
+    for (const viewerId of failed) attachment.viewers.delete(viewerId);
+    if (attachment.viewers.size === 0) await this.closeAttachment(key);
+  }
+
+  private async closeAttachment(key: string, force = false): Promise<void> {
+    const attachment = this.attachments.get(key);
+    if (!attachment) return;
+    const releasePaneClosure = this.reservePaneClosure(key);
+    try {
+      await this.drainTabInput(key);
+      if (this.attachments.get(key) !== attachment) return;
+      if (!force && attachment.viewers.size > 0) return;
+      this.attachments.delete(key);
+      attachment.viewers.clear();
+      await attachment.handle.close();
+    } finally {
+      releasePaneClosure();
+    }
+  }
+
+  private async handleAttachmentExit(key: string, exitCode: number | null): Promise<void> {
+    const attachment = this.attachments.get(key);
+    if (!attachment) return;
+    await this.drainTabInput(key);
+    const viewers = [...attachment.viewers.values()];
+    let closeFailure: unknown;
+    try { await this.closeAttachment(key, true); }
+    catch (error: unknown) { closeFailure = error; }
+    let persistenceFailure: unknown;
+    try {
+      await this.retryPaneClosureCheckpoint(() => this.store.markTabExited(attachment.ref, exitCode));
+    }
+    catch (error: unknown) { persistenceFailure = error; }
+    for (const viewer of viewers) {
+      try { await viewer.onExit?.(exitCode); }
+      catch (error) { console.error("[terminal-runtime] terminal exit delivery failed", error); }
+    }
+    if (persistenceFailure) throw persistenceFailure;
+    if (closeFailure) throw closeFailure;
+  }
+
+  private async retryPaneClosureCheckpoint(operation: () => Promise<unknown>): Promise<void> {
+    try {
+      await operation();
+    } catch (error: unknown) {
+      console.warn(
+        "[terminal-runtime] retrying terminal pane closure checkpoint",
+        error instanceof Error ? error.name : "unknown_error",
+      );
+      await operation();
+    }
+  }
+
+  private async sweepStaleViewers(now = Date.now()): Promise<void> {
+    for (const [key, attachment] of this.attachments) {
+      for (const [viewerId, viewer] of attachment.viewers) {
+        if (now - viewer.lastTouched > this.viewerTtlMs) attachment.viewers.delete(viewerId);
+      }
+      if (attachment.viewers.size === 0) await this.closeAttachment(key);
+    }
+  }
+
+  private async requireRuntimeWorkspace(workspaceId: string): Promise<TerminalRuntimeWorkspaceState> {
+    const workspace = await this.store.getRuntimeWorkspace(workspaceId);
+    if (!workspace) throw new Error("Terminal workspace not found");
+    return workspace;
+  }
+}
+
+function createObserverState(
+  initialObserver: ZellijObserver,
+  initialRestore: () => Promise<ZellijObserver>,
+): ObserverState {
+  const observers = new Set([initialObserver]);
+  let restoreObserver = initialRestore;
+  return {
+    get size() { return observers.size; },
+    add: (observer, restore) => {
+      observers.add(observer);
+      restoreObserver = restore;
+    },
+    restore: async () => createObserverState(await restoreObserver(), restoreObserver),
+    close: async () => {
+      const current = [...observers];
+      const results = await Promise.allSettled(current.map((observer) => observer.close()));
+      for (const [index, result] of results.entries()) {
+        if (result.status === "fulfilled") observers.delete(current[index]!);
+      }
+      const failure = results.find((result) => result.status === "rejected");
+      if (failure?.status === "rejected") throw failure.reason;
+    },
+  };
+}
+
+function refKey(ref: TerminalRef): string {
+  return `${ref.workspaceId}:${ref.tabId}`;
+}

--- a/packages/terminal-runtime/src/workspace-store.ts
+++ b/packages/terminal-runtime/src/workspace-store.ts
@@ -1,0 +1,622 @@
+import { randomBytes } from "node:crypto";
+import { lstat, mkdir, open, readFile, rename, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import {
+  ProjectIdSchema,
+  SafeDisplayStringSchema,
+  TerminalGridSizeSchema,
+  TerminalRefSchema,
+  TerminalTabIdSchema,
+  TerminalTabSchema,
+  TerminalWorkspaceIdSchema,
+  TerminalWorkspaceSchema,
+  type TerminalRef,
+  type TerminalTab,
+  type TerminalWorkspace,
+} from "@matrix-os/contracts";
+import { z } from "zod/v4";
+
+const MAX_STATE_BYTES = 16 * 1024 * 1024;
+const MAX_SNAPSHOT_ANSI_BYTES = 5 * 1024 * 1024;
+// Zellij's ANSI string and its line arrays describe the same retained output.
+// JSON can expand each control character to six bytes (for example `\\u0001`),
+// so reserve that worst case for both representations plus bounded envelope
+// overhead. This remains a finite per-tab disk/read limit.
+const MAX_SNAPSHOT_BYTES = (MAX_SNAPSHOT_ANSI_BYTES * 6 * 2) + (4 * 1024 * 1024);
+const DEFAULT_SIZE = { cols: 120, rows: 36 } as const;
+const InternalTabSchema = TerminalTabSchema.omit({}).extend({
+  zellijTabName: z.string().regex(/^matrix-tab-[0-9a-f]{32}$/),
+  zellijTabId: z.number().int().min(0).nullable(),
+  zellijPaneId: z.string().regex(/^terminal_[0-9]+$/).nullable(),
+  migrationKey: z.string().min(1).max(256).optional(),
+}).strict();
+const InternalWorkspaceBaseSchema = z.object({
+  id: TerminalWorkspaceIdSchema,
+  zellijSessionName: z.string().regex(/^matrix-w-[0-9a-f]{32}$/),
+  canonicalSize: TerminalGridSizeSchema,
+  status: z.enum(["maintenance", "starting", "running", "degraded", "stopped"]),
+  revision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true }),
+  tabs: z.record(TerminalTabIdSchema, InternalTabSchema),
+});
+const InternalWorkspaceSchema = z.discriminatedUnion("scope", [
+  InternalWorkspaceBaseSchema.extend({ scope: z.literal("main") }).strict(),
+  InternalWorkspaceBaseSchema.extend({ scope: z.literal("project"), projectId: ProjectIdSchema }).strict(),
+]);
+const StateSchema = z.object({
+  schemaVersion: z.literal(2),
+  revision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  workspaces: z.record(TerminalWorkspaceIdSchema, InternalWorkspaceSchema),
+}).strict();
+const SnapshotSchema = z.object({
+  schemaVersion: z.literal(1),
+  terminalRef: TerminalRefSchema,
+  revision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  seq: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  ansi: z.string().max(MAX_SNAPSHOT_ANSI_BYTES),
+  viewport: z.array(z.string().max(16_384)).max(200),
+  scrollback: z.array(z.string().max(16_384)).max(100_000),
+  updatedAt: z.string().datetime({ offset: true }),
+}).strict();
+
+type State = z.infer<typeof StateSchema>;
+type InternalWorkspace = z.infer<typeof InternalWorkspaceSchema>;
+type InternalTab = z.infer<typeof InternalTabSchema>;
+export type TerminalRuntimeWorkspaceState = InternalWorkspace;
+export type TerminalRuntimeTabState = InternalTab;
+export type TerminalSnapshot = z.infer<typeof SnapshotSchema>;
+
+export class TerminalStateCorruptError extends Error {
+  constructor() {
+    super("Terminal workspace state is corrupt");
+    this.name = "TerminalStateCorruptError";
+  }
+}
+
+export interface TerminalWorkspaceStoreOptions {
+  homePath: string;
+  statePath?: string;
+  now?: () => Date;
+}
+
+export class TerminalWorkspaceStore {
+  private readonly statePath: string;
+  private readonly snapshotDirectory: string;
+  private readonly now: () => Date;
+  private writes: Promise<void> = Promise.resolve();
+
+  constructor(options: TerminalWorkspaceStoreOptions) {
+    this.statePath = options.statePath ?? join(options.homePath, "system", "terminal-workspaces.json");
+    this.snapshotDirectory = join(dirname(this.statePath), "terminal-workspaces", "scrollback");
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async ensureWorkspace(input: { projectId?: string } = {}): Promise<TerminalWorkspace> {
+    const projectId = input.projectId === undefined ? undefined : ProjectIdSchema.parse(input.projectId);
+    return this.mutate((state) => {
+      const existing = Object.values(state.workspaces).find((workspace) => projectId === undefined
+        ? workspace.scope === "main"
+        : workspace.scope === "project" && workspace.projectId === projectId);
+      if (existing) return this.toPublicWorkspace(existing);
+
+      const id = workspaceId();
+      const now = this.now().toISOString();
+      const workspace: InternalWorkspace = projectId === undefined
+        ? {
+            id,
+            scope: "main",
+            zellijSessionName: zellijWorkspaceName(),
+            canonicalSize: DEFAULT_SIZE,
+            status: "starting",
+            revision: 0,
+            createdAt: now,
+            updatedAt: now,
+            tabs: {},
+          }
+        : {
+            id,
+            scope: "project",
+            projectId,
+            zellijSessionName: zellijWorkspaceName(),
+            canonicalSize: DEFAULT_SIZE,
+            status: "starting",
+            revision: 0,
+            createdAt: now,
+            updatedAt: now,
+            tabs: {},
+          };
+      state.workspaces[id] = workspace;
+      state.revision += 1;
+      return this.toPublicWorkspace(workspace);
+    });
+  }
+
+  async createTab(workspaceIdInput: string, input: {
+    name: string;
+    cwd: string;
+    accessScope?: TerminalTab["accessScope"];
+    agent?: TerminalTab["agent"];
+    git?: TerminalTab["git"];
+  }): Promise<TerminalTab> {
+    const targetWorkspaceId = TerminalWorkspaceIdSchema.parse(workspaceIdInput);
+    const name = SafeDisplayStringSchema.parse(input.name);
+    const now = this.now().toISOString();
+    return this.mutate((state) => {
+      const workspace = state.workspaces[targetWorkspaceId];
+      if (!workspace) throw new Error("Terminal workspace not found");
+      const id = tabId();
+      const tab = InternalTabSchema.parse({
+        id,
+        workspaceId: targetWorkspaceId,
+        name,
+        cwd: input.cwd,
+        status: "starting",
+        revision: 0,
+        order: Object.keys(workspace.tabs).length,
+        accessScope: input.accessScope ?? "owner",
+        ...(input.agent ? { agent: input.agent } : {}),
+        ...(input.git ? { git: input.git } : {}),
+        createdAt: now,
+        updatedAt: now,
+        zellijTabName: zellijTabName(),
+        zellijTabId: null,
+        zellijPaneId: null,
+      });
+      workspace.tabs[id] = tab;
+      workspace.revision += 1;
+      workspace.updatedAt = now;
+      state.revision += 1;
+      return this.toPublicTab(tab);
+    });
+  }
+
+  async createMigratedTab(workspaceIdInput: string, input: {
+    migrationKey: string;
+    name: string;
+    cwd: string;
+    createdAt?: string;
+    uiState?: TerminalTab["uiState"];
+    agent?: TerminalTab["agent"];
+  }): Promise<TerminalTab> {
+    const targetWorkspaceId = TerminalWorkspaceIdSchema.parse(workspaceIdInput);
+    const migrationKey = z.string().min(1).max(256).parse(input.migrationKey);
+    const name = SafeDisplayStringSchema.parse(input.name);
+    return this.mutate((state) => {
+      const workspace = state.workspaces[targetWorkspaceId];
+      if (!workspace) throw new Error("Terminal workspace not found");
+      const existing = Object.values(workspace.tabs).find((tab) => tab.migrationKey === migrationKey);
+      if (existing) return this.toPublicTab(existing);
+      const id = tabId();
+      const now = this.now().toISOString();
+      const tab = InternalTabSchema.parse({
+        id,
+        workspaceId: targetWorkspaceId,
+        name,
+        cwd: input.cwd,
+        status: "starting",
+        revision: 0,
+        order: Object.keys(workspace.tabs).length,
+        accessScope: "legacy",
+        ...(input.agent ? { agent: input.agent } : {}),
+        ...(input.uiState ? { uiState: input.uiState } : {}),
+        createdAt: input.createdAt ?? now,
+        updatedAt: now,
+        zellijTabName: zellijTabName(),
+        zellijTabId: null,
+        zellijPaneId: null,
+        migrationKey,
+      });
+      workspace.tabs[id] = tab;
+      workspace.revision += 1;
+      workspace.updatedAt = now;
+      state.revision += 1;
+      return this.toPublicTab(tab);
+    });
+  }
+
+  async getTab(refInput: TerminalRef): Promise<TerminalTab | undefined> {
+    const ref = TerminalRefSchema.parse(refInput);
+    const state = await this.load();
+    const tab = state.workspaces[ref.workspaceId]?.tabs[ref.tabId];
+    return tab ? this.toPublicTab(tab) : undefined;
+  }
+
+  async listWorkspaces(): Promise<TerminalWorkspace[]> {
+    const state = await this.load();
+    return Object.values(state.workspaces)
+      .sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+      .map((workspace) => this.toPublicWorkspace(workspace));
+  }
+
+  async getRuntimeWorkspace(workspaceIdInput: string): Promise<InternalWorkspace | undefined> {
+    const targetWorkspaceId = TerminalWorkspaceIdSchema.parse(workspaceIdInput);
+    const workspace = (await this.load()).workspaces[targetWorkspaceId];
+    return workspace ? structuredClone(workspace) : undefined;
+  }
+
+  async activateTab(refInput: TerminalRef, runtimeIds: { tabId: number; paneId: string }): Promise<TerminalTab> {
+    const ref = TerminalRefSchema.parse(refInput);
+    const zellijTabId = z.number().int().min(0).parse(runtimeIds.tabId);
+    const zellijPaneId = z.string().regex(/^terminal_[0-9]+$/).parse(runtimeIds.paneId);
+    const now = this.now().toISOString();
+    return this.mutate((state) => {
+      const workspace = state.workspaces[ref.workspaceId];
+      const tab = workspace?.tabs[ref.tabId];
+      if (!workspace || !tab) throw new Error("Terminal tab not found");
+      tab.zellijTabId = zellijTabId;
+      tab.zellijPaneId = zellijPaneId;
+      tab.status = "running";
+      tab.revision += 1;
+      tab.updatedAt = now;
+      workspace.status = "running";
+      workspace.revision += 1;
+      workspace.updatedAt = now;
+      state.revision += 1;
+      return this.toPublicTab(tab);
+    });
+  }
+
+  async removeTab(refInput: TerminalRef): Promise<void> {
+    const ref = TerminalRefSchema.parse(refInput);
+    const now = this.now().toISOString();
+    await this.mutate((state) => {
+      const workspace = state.workspaces[ref.workspaceId];
+      const tab = workspace?.tabs[ref.tabId];
+      if (!workspace || !tab) throw new Error("Terminal tab not found");
+      delete workspace.tabs[ref.tabId];
+      Object.values(workspace.tabs)
+        .sort((left, right) => left.order - right.order)
+        .forEach((remaining, order) => { remaining.order = order; });
+      workspace.status = Object.values(workspace.tabs)
+        .some((remaining) => remaining.status !== "exited" && remaining.status !== "failed")
+        ? "running"
+        : "starting";
+      workspace.revision += 1;
+      workspace.updatedAt = now;
+      state.revision += 1;
+    });
+    await rm(this.snapshotPath(ref.tabId), { force: true });
+  }
+
+  async checkpointTab(refInput: TerminalRef, input: {
+    ansi: string;
+    viewport: string[];
+    scrollback: string[];
+  }): Promise<TerminalSnapshot> {
+    const ref = TerminalRefSchema.parse(refInput);
+    return this.mutate(async (state) => {
+      const workspace = state.workspaces[ref.workspaceId];
+      const tab = workspace?.tabs[ref.tabId];
+      if (!workspace || !tab) throw new Error("Terminal tab not found");
+      const previous = await this.readSnapshot(ref);
+      const now = this.now().toISOString();
+      tab.revision = Math.max(tab.revision, previous?.revision ?? 0) + 1;
+      tab.updatedAt = now;
+      workspace.revision += 1;
+      workspace.updatedAt = now;
+      state.revision += 1;
+      const snapshot = SnapshotSchema.parse({
+        schemaVersion: 1,
+        terminalRef: ref,
+        revision: tab.revision,
+        seq: (previous?.seq ?? -1) + 1,
+        ansi: input.ansi,
+        viewport: input.viewport,
+        scrollback: input.scrollback,
+        updatedAt: now,
+      });
+      await this.persistSnapshot(snapshot);
+      return snapshot;
+    });
+  }
+
+  async importSnapshot(refInput: TerminalRef, input: {
+    ansi: string;
+    viewport: string[];
+    scrollback: string[];
+    seq: number;
+  }): Promise<TerminalSnapshot> {
+    const ref = TerminalRefSchema.parse(refInput);
+    const seq = z.number().int().min(0).max(Number.MAX_SAFE_INTEGER).parse(input.seq);
+    return this.mutate(async (state) => {
+      const workspace = state.workspaces[ref.workspaceId];
+      const tab = workspace?.tabs[ref.tabId];
+      if (!workspace || !tab) throw new Error("Terminal tab not found");
+      const previous = await this.readSnapshot(ref);
+      if (
+        previous?.seq === seq &&
+        previous.ansi === input.ansi &&
+        JSON.stringify(previous.viewport) === JSON.stringify(input.viewport) &&
+        JSON.stringify(previous.scrollback) === JSON.stringify(input.scrollback)
+      ) {
+        return previous;
+      }
+      const now = this.now().toISOString();
+      tab.revision = Math.max(tab.revision, previous?.revision ?? 0) + 1;
+      tab.updatedAt = now;
+      workspace.revision += 1;
+      workspace.updatedAt = now;
+      state.revision += 1;
+      const snapshot = SnapshotSchema.parse({
+        schemaVersion: 1,
+        terminalRef: ref,
+        revision: tab.revision,
+        seq,
+        ansi: input.ansi,
+        viewport: input.viewport,
+        scrollback: input.scrollback,
+        updatedAt: now,
+      });
+      await this.persistSnapshot(snapshot);
+      return snapshot;
+    });
+  }
+
+  async renameTab(refInput: TerminalRef, input: { name: string; baseRevision: number }): Promise<TerminalTab> {
+    const ref = TerminalRefSchema.parse(refInput);
+    const name = SafeDisplayStringSchema.parse(input.name);
+    const baseRevision = z.number().int().min(0).parse(input.baseRevision);
+    const now = this.now().toISOString();
+    return this.mutate((state) => {
+      const workspace = state.workspaces[ref.workspaceId];
+      const tab = workspace?.tabs[ref.tabId];
+      if (!workspace || !tab) throw new Error("Terminal tab not found");
+      if (tab.revision !== baseRevision) throw new Error("Terminal tab revision conflict");
+      tab.name = name;
+      tab.revision += 1;
+      tab.updatedAt = now;
+      workspace.revision += 1;
+      workspace.updatedAt = now;
+      state.revision += 1;
+      return this.toPublicTab(tab);
+    });
+  }
+
+  async reorderTabs(workspaceIdInput: string, input: { tabIds: string[]; baseRevision: number }): Promise<TerminalWorkspace> {
+    const workspaceId = TerminalWorkspaceIdSchema.parse(workspaceIdInput);
+    const tabIds = z.array(TerminalTabIdSchema).max(10_000).parse(input.tabIds);
+    const baseRevision = z.number().int().min(0).parse(input.baseRevision);
+    const now = this.now().toISOString();
+    return this.mutate((state) => {
+      const workspace = state.workspaces[workspaceId];
+      if (!workspace) throw new Error("Terminal workspace not found");
+      if (workspace.revision !== baseRevision) throw new Error("Terminal workspace revision conflict");
+      const existingIds = Object.keys(workspace.tabs);
+      if (new Set(tabIds).size !== tabIds.length || tabIds.length !== existingIds.length ||
+          existingIds.some((id) => !tabIds.includes(id))) {
+        throw new Error("Terminal tab order is incomplete");
+      }
+      tabIds.forEach((id, order) => { workspace.tabs[id]!.order = order; });
+      workspace.revision += 1;
+      workspace.updatedAt = now;
+      state.revision += 1;
+      return this.toPublicWorkspace(workspace);
+    });
+  }
+
+  async updateTabUiState(refInput: TerminalRef, input: {
+    placement?: "active" | "background";
+    lastSeenSeq?: number | null;
+    pinned?: boolean;
+    baseRevision: number;
+  }): Promise<TerminalTab> {
+    const ref = TerminalRefSchema.parse(refInput);
+    const baseRevision = z.number().int().min(0).parse(input.baseRevision);
+    const now = this.now().toISOString();
+    return this.mutate((state) => {
+      const workspace = state.workspaces[ref.workspaceId];
+      const tab = workspace?.tabs[ref.tabId];
+      if (!workspace || !tab) throw new Error("Terminal tab not found");
+      if (tab.revision !== baseRevision) throw new Error("Terminal tab revision conflict");
+      tab.uiState = {
+        placement: input.placement ?? tab.uiState?.placement ?? "active",
+        lastSeenSeq: input.lastSeenSeq === undefined ? tab.uiState?.lastSeenSeq ?? null : input.lastSeenSeq,
+        pinned: input.pinned ?? tab.uiState?.pinned ?? false,
+        ...(tab.uiState?.layoutName ? { layoutName: tab.uiState.layoutName } : {}),
+        ...(tab.uiState?.legacyTabs ? { legacyTabs: tab.uiState.legacyTabs } : {}),
+      };
+      tab.revision += 1;
+      tab.updatedAt = now;
+      workspace.revision += 1;
+      workspace.updatedAt = now;
+      state.revision += 1;
+      return this.toPublicTab(tab);
+    });
+  }
+
+  async markTabExited(refInput: TerminalRef, exitCode: number | null = null): Promise<TerminalTab> {
+    const ref = TerminalRefSchema.parse(refInput);
+    const now = this.now().toISOString();
+    return this.mutate((state) => {
+      const workspace = state.workspaces[ref.workspaceId];
+      const tab = workspace?.tabs[ref.tabId];
+      if (!workspace || !tab) throw new Error("Terminal tab not found");
+      if (tab.status === "exited" && tab.exitCode === exitCode) return this.toPublicTab(tab);
+      tab.status = "exited";
+      tab.exitCode = exitCode;
+      tab.revision += 1;
+      tab.updatedAt = now;
+      workspace.revision += 1;
+      workspace.updatedAt = now;
+      state.revision += 1;
+      return this.toPublicTab(tab);
+    });
+  }
+
+  async updateCanonicalSize(workspaceIdInput: string, sizeInput: { cols: number; rows: number }): Promise<TerminalWorkspace> {
+    const workspaceId = TerminalWorkspaceIdSchema.parse(workspaceIdInput);
+    const size = TerminalGridSizeSchema.parse(sizeInput);
+    const now = this.now().toISOString();
+    return this.mutate((state) => {
+      const workspace = state.workspaces[workspaceId];
+      if (!workspace) throw new Error("Terminal workspace not found");
+      workspace.canonicalSize = size;
+      workspace.revision += 1;
+      workspace.updatedAt = now;
+      state.revision += 1;
+      return this.toPublicWorkspace(workspace);
+    });
+  }
+
+  async removeWorkspace(workspaceIdInput: string): Promise<TerminalRuntimeWorkspaceState> {
+    const workspaceId = TerminalWorkspaceIdSchema.parse(workspaceIdInput);
+    const workspace = await this.mutate((state) => {
+      const existing = state.workspaces[workspaceId];
+      if (!existing) throw new Error("Terminal workspace not found");
+      delete state.workspaces[workspaceId];
+      state.revision += 1;
+      return structuredClone(existing);
+    });
+    await Promise.all(Object.keys(workspace.tabs).map((id) => rm(this.snapshotPath(id), { force: true })));
+    return workspace;
+  }
+
+  async readSnapshot(refInput: TerminalRef): Promise<TerminalSnapshot | undefined> {
+    const ref = TerminalRefSchema.parse(refInput);
+    const path = this.snapshotPath(ref.tabId);
+    try {
+      const entry = await lstat(path);
+      if (!entry.isFile() || entry.isSymbolicLink() || entry.size > MAX_SNAPSHOT_BYTES) {
+        throw new TerminalStateCorruptError();
+      }
+      const snapshot = SnapshotSchema.parse(JSON.parse(await readFile(path, "utf8")));
+      if (snapshot.terminalRef.workspaceId !== ref.workspaceId) throw new TerminalStateCorruptError();
+      return snapshot;
+    } catch (error) {
+      if (isMissing(error)) return undefined;
+      if (error instanceof TerminalStateCorruptError) throw error;
+      throw new TerminalStateCorruptError();
+    }
+  }
+
+  private async mutate<T>(operation: (state: State) => T | Promise<T>): Promise<T> {
+    let resolveResult!: (value: T | PromiseLike<T>) => void;
+    let rejectResult!: (reason?: unknown) => void;
+    const result = new Promise<T>((resolve, reject) => {
+      resolveResult = resolve;
+      rejectResult = reject;
+    });
+    this.writes = this.writes.then(async () => {
+      try {
+        const state = await this.load();
+        const value = await operation(state);
+        await this.persist(state);
+        resolveResult(value);
+      } catch (error) {
+        rejectResult(error);
+      }
+    });
+    return result;
+  }
+
+  private async load(): Promise<State> {
+    try {
+      const entry = await lstat(this.statePath);
+      if (!entry.isFile() || entry.isSymbolicLink() || entry.size > MAX_STATE_BYTES) {
+        throw new TerminalStateCorruptError();
+      }
+      return StateSchema.parse(JSON.parse(await readFile(this.statePath, "utf8")));
+    } catch (error) {
+      if (isMissing(error)) return { schemaVersion: 2, revision: 0, workspaces: {} };
+      if (error instanceof TerminalStateCorruptError) throw error;
+      throw new TerminalStateCorruptError();
+    }
+  }
+
+  private async persist(state: State): Promise<void> {
+    const parsed = StateSchema.parse(state);
+    await writeTextAtomic(this.statePath, `${JSON.stringify(parsed, null, 2)}\n`);
+  }
+
+  private async persistSnapshot(snapshot: TerminalSnapshot): Promise<void> {
+    const content = `${JSON.stringify(SnapshotSchema.parse(snapshot))}\n`;
+    if (Buffer.byteLength(content) > MAX_SNAPSHOT_BYTES) throw new Error("Terminal snapshot capacity reached");
+    const target = this.snapshotPath(snapshot.terminalRef.tabId);
+    await writeTextAtomic(target, content);
+  }
+
+  private snapshotPath(tabIdInput: string): string {
+    return join(this.snapshotDirectory, `${TerminalTabIdSchema.parse(tabIdInput)}.json`);
+  }
+
+  private toPublicWorkspace(workspace: InternalWorkspace): TerminalWorkspace {
+    const tabs = Object.values(workspace.tabs)
+      .sort((left, right) => left.order - right.order || left.createdAt.localeCompare(right.createdAt))
+      .map((tab) => this.toPublicTab(tab));
+    const common = {
+      id: workspace.id,
+      canonicalSize: workspace.canonicalSize,
+      status: workspace.status,
+      revision: workspace.revision,
+      createdAt: workspace.createdAt,
+      updatedAt: workspace.updatedAt,
+      tabs,
+    };
+    return TerminalWorkspaceSchema.parse(workspace.scope === "main"
+      ? { ...common, scope: "main" }
+      : { ...common, scope: "project", projectId: workspace.projectId });
+  }
+
+  private toPublicTab(tab: InternalTab): TerminalTab {
+    const {
+      zellijTabName: _tabName,
+      zellijTabId: _tabId,
+      zellijPaneId: _paneId,
+      migrationKey: _migrationKey,
+      ...publicTab
+    } = tab;
+    return TerminalTabSchema.parse(publicTab);
+  }
+}
+
+async function writeTextAtomic(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const temporaryPath = `${path}.${randomBytes(8).toString("hex")}.tmp`;
+  const handle = await open(temporaryPath, "wx", 0o600);
+  try {
+    try {
+      await handle.writeFile(content, "utf8");
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await rename(temporaryPath, path);
+    const directoryHandle = await open(dirname(path), "r");
+    try {
+      await directoryHandle.sync();
+    } finally {
+      await directoryHandle.close();
+    }
+  } catch (error) {
+    try {
+      await rm(temporaryPath, { force: true });
+    } catch (cleanupError) {
+      console.error(
+        "terminal workspace temporary-file cleanup failed",
+        cleanupError instanceof Error ? cleanupError.name : "unknown_error",
+      );
+    }
+    throw error;
+  }
+}
+
+function workspaceId(): `tws_${string}` {
+  return `tws_${randomBytes(16).toString("hex")}`;
+}
+
+function tabId(): `tt_${string}` {
+  return `tt_${randomBytes(16).toString("hex")}`;
+}
+
+function zellijWorkspaceName(): string {
+  return `matrix-w-${randomBytes(16).toString("hex")}`;
+}
+
+function zellijTabName(): string {
+  return `matrix-tab-${randomBytes(16).toString("hex")}`;
+}
+
+function isMissing(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}

--- a/packages/terminal-runtime/tsconfig.json
+++ b/packages/terminal-runtime/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1021,6 +1021,25 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.3.0))(lightningcss@1.32.0)(msw@2.12.13(@types/node@25.5.0)(typescript@5.9.3))(sass@1.51.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/terminal-runtime:
+    dependencies:
+      '@matrix-os/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/ui:
     dependencies:
       '@matrix-os/contracts':

--- a/tests/contracts/coding-agent-project-conversations.test.ts
+++ b/tests/contracts/coding-agent-project-conversations.test.ts
@@ -344,7 +344,7 @@ describe("coding agent project conversation contracts", () => {
       providers: [],
       projects: { items: [], hasMore: false, limit: 20 },
       activeThreads: { items: [], hasMore: false, limit: 20 },
-      terminalSessions: { items: [], hasMore: false, limit: 20 },
+      terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
       recentActivity: { items: [], hasMore: false, limit: 20 },
       limits: {
         maxPromptBytes: 24_000,

--- a/tests/contracts/coding-agents.test.ts
+++ b/tests/contracts/coding-agents.test.ts
@@ -31,9 +31,9 @@ import {
   SafeAssistantPreviewSourceTextSchema,
   SafeAssistantPreviewTextSchema,
   SafeClientErrorSchema,
-  TerminalClientFrameSchema,
-  TerminalServerFrameSchema,
-  TerminalSessionSummarySchema,
+  TerminalTabClientFrameSchema,
+  TerminalTabServerFrameSchema,
+  TerminalWorkspaceSchema,
   ThreadIdSchema,
   UserInputAnswerRequestSchema,
   UserInputRequestSchema,
@@ -42,6 +42,30 @@ import {
 } from "../../packages/contracts/src/index.js";
 
 const now = "2026-07-06T12:00:00.000Z";
+const terminalRef = {
+  workspaceId: "tws_00000000000000000000000000000001",
+  tabId: "tt_00000000000000000000000000000001",
+} as const;
+const terminalWorkspace = {
+  id: terminalRef.workspaceId,
+  scope: "main" as const,
+  canonicalSize: { cols: 120, rows: 40 },
+  status: "running" as const,
+  revision: 1,
+  createdAt: now,
+  updatedAt: now,
+  tabs: [{
+    id: terminalRef.tabId,
+    workspaceId: terminalRef.workspaceId,
+    name: "main",
+    cwd: "",
+    status: "running" as const,
+    revision: 1,
+    order: 0,
+    createdAt: now,
+    updatedAt: now,
+  }],
+};
 
 describe("coding agent contracts", () => {
   it("matches the Desktop 10 MiB attachment boundary", () => {
@@ -148,17 +172,8 @@ describe("coding agent contracts", () => {
         hasMore: false,
         limit: 20,
       },
-      terminalSessions: {
-        items: [
-          {
-            id: "term_main",
-            name: "main",
-            status: "running",
-            attachable: true,
-            createdAt: now,
-            updatedAt: now,
-          },
-        ],
+      terminalWorkspaces: {
+        items: [terminalWorkspace],
         hasMore: false,
         limit: 20,
       },
@@ -176,7 +191,7 @@ describe("coding agent contracts", () => {
       id: "thread_attention",
       attention: "approval_required",
     });
-    expect(summary.terminalSessions.items[0]?.attachable).toBe(true);
+    expect(summary.terminalWorkspaces.items[0]?.tabs[0]?.id).toBe(terminalRef.tabId);
     expect(() =>
       RuntimeSummarySchema.parse({
         ...summary,
@@ -318,21 +333,15 @@ describe("coding agent contracts", () => {
       }),
     ).toThrow();
 
-    expect(TerminalClientFrameSchema.parse({ type: "resize", cols: 120, rows: 40 })).toEqual({
+    expect(TerminalTabClientFrameSchema.parse({ type: "resize", terminalRef, mode: "hard", size: { cols: 120, rows: 40 } })).toEqual({
       type: "resize",
-      cols: 120,
-      rows: 40,
+      terminalRef,
+      mode: "hard",
+      size: { cols: 120, rows: 40 },
     });
-    expect(() => TerminalClientFrameSchema.parse({ type: "resize", cols: 2000, rows: 40 })).toThrow();
+    expect(() => TerminalTabClientFrameSchema.parse({ type: "resize", terminalRef, mode: "hard", size: { cols: 2000, rows: 40 } })).toThrow();
 
-    expect(TerminalSessionSummarySchema.parse({
-      id: "term_main",
-      name: "main",
-      status: "running",
-      attachable: true,
-      createdAt: now,
-      updatedAt: now,
-    }).status).toBe("running");
+    expect(TerminalWorkspaceSchema.parse(terminalWorkspace).status).toBe("running");
   });
 
   it("validates coding-agent notification preferences without accepting extra payload data", () => {
@@ -898,26 +907,22 @@ describe("coding agent contracts", () => {
       updatedAt: now,
     }).status).toBe("running");
 
-    expect(TerminalServerFrameSchema.parse({
+    expect(TerminalTabServerFrameSchema.parse({
       type: "attached",
-      session: "main",
-      state: "running",
-      fromSeq: 0,
+      terminalRef,
+      revision: 1,
+      canonicalSize: { cols: 120, rows: 40 },
+      nextSeq: 0,
     }).type).toBe("attached");
-    expect(TerminalServerFrameSchema.parse({
-      type: "attached",
-      sessionId: "550e8400-e29b-41d4-a716-446655440000",
-      state: "running",
-    }).type).toBe("attached");
-    expect(TerminalServerFrameSchema.parse({ type: "replay-start", fromSeq: 0 }).type).toBe("replay-start");
-    expect(TerminalServerFrameSchema.parse({ type: "replay-end", toSeq: null }).type).toBe("replay-end");
-    expect(TerminalServerFrameSchema.parse({ type: "replay-evicted", fromSeq: 0, nextSeq: 10 }).type).toBe("replay-evicted");
-    expect(TerminalServerFrameSchema.parse({
+    expect(TerminalTabServerFrameSchema.parse({ type: "replay-start", terminalRef, revision: 1, fromSeq: 0 }).type).toBe("replay-start");
+    expect(TerminalTabServerFrameSchema.parse({ type: "replay-end", terminalRef, revision: 1, nextSeq: 10, toSeq: null }).type).toBe("replay-end");
+    expect(TerminalTabServerFrameSchema.parse({ type: "replay-evicted", terminalRef, revision: 1, fromSeq: 0, nextSeq: 10 }).type).toBe("replay-evicted");
+    expect(TerminalTabServerFrameSchema.parse({
       type: "error",
       code: "invalid_message",
       message: "Invalid message",
     }).type).toBe("error");
-    expect(TerminalServerFrameSchema.parse({
+    expect(TerminalTabServerFrameSchema.parse({
       type: "safe-error",
       error: {
         code: "session_unavailable",
@@ -955,7 +960,7 @@ describe("coding agent contracts", () => {
       ],
       projects: { items: [], hasMore: false, limit: 20 },
       activeThreads: { items: [], hasMore: false, limit: 20 },
-      terminalSessions: { items: [], hasMore: false, limit: 20 },
+      terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
       recentActivity: { items: [], hasMore: false, limit: 30 },
       limits: {
         maxPromptBytes: 24000,
@@ -968,7 +973,7 @@ describe("coding agent contracts", () => {
     const draft = AgentThreadComposerDraftSchema.parse({
       prompt: "  keep exact prompt whitespace\n",
       projectId: "repo-main",
-      terminalSessionId: "main",
+      terminalRef,
       approvalPolicy: "on_request",
       sandboxMode: "workspace_write",
     });
@@ -991,7 +996,7 @@ describe("coding agent contracts", () => {
         providerId: "codex",
         prompt: "  keep exact prompt whitespace\n",
         projectId: "repo-main",
-        terminalSessionId: "main",
+        terminalRef,
         mode: "review",
         approvalPolicy: "on_request",
         sandboxMode: "workspace_write",
@@ -1021,7 +1026,7 @@ describe("coding agent contracts", () => {
       }],
       projects: { items: [], hasMore: false, limit: 20 },
       activeThreads: { items: [], hasMore: false, limit: 20 },
-      terminalSessions: { items: [], hasMore: false, limit: 20 },
+      terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
       recentActivity: { items: [], hasMore: false, limit: 30 },
       limits: {
         maxPromptBytes: 24000,
@@ -1078,7 +1083,7 @@ describe("coding agent contracts", () => {
       ],
       projects: { items: [], hasMore: false, limit: 20 },
       activeThreads: { items: [], hasMore: false, limit: 20 },
-      terminalSessions: { items: [], hasMore: false, limit: 20 },
+      terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
       recentActivity: { items: [], hasMore: false, limit: 30 },
       limits: {
         maxPromptBytes: 24000,

--- a/tests/contracts/terminal-workspaces.test.ts
+++ b/tests/contracts/terminal-workspaces.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentThreadEventSchema,
+  CreateAgentThreadRequestSchema,
+  TerminalTabClientFrameSchema,
+  TerminalRefSchema,
+  TerminalTabServerFrameSchema,
+  TerminalTabSchema,
+  TerminalWorkspaceSchema,
+} from "../../packages/contracts/src/index.js";
+
+const now = "2026-08-11T12:00:00.000Z";
+
+describe("project-scoped terminal workspace contracts", () => {
+  it("represents a stable tab reference independently from Zellij runtime ids", () => {
+    const terminalRef = TerminalRefSchema.parse({
+      workspaceId: "tws_0123456789abcdef0123456789abcdef",
+      tabId: "tt_0123456789abcdef0123456789abcdef",
+    });
+
+    expect(terminalRef).toEqual({
+      workspaceId: "tws_0123456789abcdef0123456789abcdef",
+      tabId: "tt_0123456789abcdef0123456789abcdef",
+    });
+    expect(() => TerminalRefSchema.parse({ ...terminalRef, sessionId: "legacy" })).toThrow();
+  });
+
+  it("keeps internal Zellij identities out of public workspace and tab projections", () => {
+    const workspace = TerminalWorkspaceSchema.parse({
+      id: "tws_0123456789abcdef0123456789abcdef",
+      scope: "main",
+      canonicalSize: { cols: 120, rows: 36 },
+      status: "running",
+      revision: 3,
+      createdAt: now,
+      updatedAt: now,
+      tabs: [{
+        id: "tt_0123456789abcdef0123456789abcdef",
+        workspaceId: "tws_0123456789abcdef0123456789abcdef",
+        name: "main",
+        cwd: "",
+        status: "running",
+        revision: 2,
+        order: 0,
+        createdAt: now,
+        updatedAt: now,
+      }],
+    });
+
+    expect(workspace.scope).toBe("main");
+    expect(() => TerminalWorkspaceSchema.parse({ ...workspace, zellijSessionName: "matrix-private" })).toThrow();
+    expect(() => TerminalTabSchema.parse({ ...workspace.tabs[0], zellijPaneId: 9 })).toThrow();
+    expect(TerminalTabSchema.parse({
+      ...workspace.tabs[0],
+      uiState: { placement: "active", lastSeenSeq: null, pinned: true },
+    }).uiState?.pinned).toBe(true);
+  });
+
+  it("adds TerminalRef contracts while accepting legacy coding-agent ids during rollout", () => {
+    const terminalRef = {
+      workspaceId: "tws_0123456789abcdef0123456789abcdef",
+      tabId: "tt_0123456789abcdef0123456789abcdef",
+    };
+
+    expect(CreateAgentThreadRequestSchema.parse({
+      providerId: "codex",
+      prompt: "Continue in the selected terminal tab.",
+      terminalRef,
+      clientRequestId: "req_terminal_ref",
+    }).terminalRef).toEqual(terminalRef);
+    expect(CreateAgentThreadRequestSchema.parse({
+      providerId: "codex",
+      prompt: "Accept an old client during rollout.",
+      terminalSessionId: "legacy",
+      clientRequestId: "req_legacy_terminal",
+    }).terminalSessionId).toBe("legacy");
+
+    expect(AgentThreadEventSchema.parse({
+      type: "terminal.bound",
+      eventId: "evt_terminal_ref",
+      threadId: "thread_terminal_ref",
+      occurredAt: now,
+      terminalRef,
+      terminalSessionId: `${terminalRef.workspaceId}:${terminalRef.tabId}`,
+    }).terminalRef).toEqual(terminalRef);
+
+    expect(TerminalTabClientFrameSchema.parse({
+      type: "input",
+      terminalRef,
+      data: "ls\r",
+    }).terminalRef).toEqual(terminalRef);
+    const snapshotFrame = TerminalTabServerFrameSchema.parse({
+      type: "snapshot",
+      terminalRef,
+      canonicalSize: { cols: 120, rows: 36 },
+      revision: 4,
+      presentationRevision: 2,
+      seq: 12,
+      ansi: "ready$ ",
+      viewport: { top: 0, rows: 36 },
+    });
+    expect(snapshotFrame.revision).toBe(4);
+    expect(snapshotFrame.type === "snapshot" && snapshotFrame.presentationRevision).toBe(2);
+    expect(TerminalTabServerFrameSchema.parse({
+      type: "snapshot",
+      terminalRef,
+      canonicalSize: { cols: 120, rows: 36 },
+      revision: 5,
+      seq: 13,
+      ansi: "x".repeat(5 * 1024 * 1024),
+      viewport: { top: 0, rows: 36 },
+    }).ansi).toHaveLength(5 * 1024 * 1024);
+  });
+});

--- a/tests/terminal-runtime/runtime.test.ts
+++ b/tests/terminal-runtime/runtime.test.ts
@@ -1,0 +1,999 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  TerminalRuntime,
+  type ZellijAttachment,
+  type ZellijObserver,
+  type ZellijObserverEvent,
+  type ZellijRuntimeAdapter,
+} from "../../packages/terminal-runtime/src/runtime.js";
+import { TerminalWorkspaceStore } from "../../packages/terminal-runtime/src/workspace-store.js";
+
+const homes: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(homes.splice(0).map((home) => rm(home, { recursive: true, force: true })));
+});
+
+class FakeZellij implements ZellijRuntimeAdapter {
+  readonly sessions = new Map<string, Map<number, { name: string; paneId: string }>>();
+  readonly attachments = new Map<string, { handle: ZellijAttachment; emit: (data: Uint8Array) => void }>();
+  readonly writes: string[] = [];
+  readonly targetedWrites: string[] = [];
+  readonly observers = new Map<string, { paneIds: string[]; emit: (event: ZellijObserverEvent) => void }>();
+  readonly observerHandles: Array<{ closed: boolean }> = [];
+  readonly closedTabs: number[] = [];
+  readonly deletedSessions: string[] = [];
+  readonly renamedTabs: Array<{ tabId: number; name: string }> = [];
+  readonly resizedSessions: Array<{ cols: number; rows: number }> = [];
+  failNextSubscription = false;
+  subscriptionFailuresRemaining = 0;
+  failNextObserverClose = false;
+  failAllObserverCloses = false;
+  failNextCloseTab = false;
+  nextSubscriptionPause?: { started: () => void; wait: Promise<void> };
+  nextObserverClosePause?: { started: () => void; wait: Promise<void> };
+  nextAttachmentWritePause?: { started: () => void; wait: Promise<void> };
+  nextSessionDeletionPause?: { started: () => void; wait: Promise<void> };
+  nextSessionDeletedPause?: { started: () => void; wait: Promise<void> };
+  nextAttachmentOpenPause?: { started: () => void; wait: Promise<void> };
+  nextTabCreated?: () => void;
+  private nextTabId = 1;
+
+  async ensureSession(sessionName: string): Promise<void> {
+    if (!this.sessions.has(sessionName)) this.sessions.set(sessionName, new Map());
+  }
+
+  async createTab(sessionName: string, input: { internalName: string }): Promise<{ tabId: number; paneId: string }> {
+    const tabs = this.sessions.get(sessionName);
+    if (!tabs) throw new Error("missing session");
+    const tabId = this.nextTabId++;
+    const paneId = `terminal_${tabId}`;
+    tabs.set(tabId, { name: input.internalName, paneId });
+    this.nextTabCreated?.();
+    this.nextTabCreated = undefined;
+    return { tabId, paneId };
+  }
+
+  async findTabByInternalName(sessionName: string, internalName: string): Promise<{ tabId: number; paneId: string } | undefined> {
+    const entry = [...(this.sessions.get(sessionName)?.entries() ?? [])]
+      .find(([, tab]) => tab.name === internalName);
+    return entry ? { tabId: entry[0], paneId: entry[1].paneId } : undefined;
+  }
+
+  async openAttachment(
+    sessionName: string,
+    input: { paneId: string; onData: (data: Uint8Array) => void },
+  ): Promise<ZellijAttachment> {
+    const key = `${sessionName}:${input.paneId}`;
+    const pause = this.nextAttachmentOpenPause;
+    if (pause) {
+      this.nextAttachmentOpenPause = undefined;
+      pause.started();
+      await pause.wait;
+    }
+    const handle: ZellijAttachment = {
+      write: async (data) => {
+        const writePause = this.nextAttachmentWritePause;
+        if (writePause) {
+          this.nextAttachmentWritePause = undefined;
+          writePause.started();
+          await writePause.wait;
+        }
+        this.writes.push(new TextDecoder().decode(data));
+      },
+      resize: async () => undefined,
+      close: async () => { this.attachments.delete(key); },
+    };
+    this.attachments.set(key, { handle, emit: input.onData });
+    return handle;
+  }
+
+  async subscribeWorkspace(
+    sessionName: string,
+    input: { paneIds: string[]; onEvent: (event: ZellijObserverEvent) => void },
+  ): Promise<ZellijObserver> {
+    if (this.failNextSubscription || this.subscriptionFailuresRemaining > 0) {
+      this.failNextSubscription = false;
+      this.subscriptionFailuresRemaining = Math.max(0, this.subscriptionFailuresRemaining - 1);
+      throw new Error("observer subscription failed");
+    }
+    const pause = this.nextSubscriptionPause;
+    if (pause) {
+      this.nextSubscriptionPause = undefined;
+      pause.started();
+      await pause.wait;
+    }
+    const observer = { paneIds: input.paneIds, emit: input.onEvent };
+    const handleState = { closed: false };
+    this.observerHandles.push(handleState);
+    this.observers.set(sessionName, observer);
+    return {
+      close: async () => {
+        const closePause = this.nextObserverClosePause;
+        if (closePause) {
+          this.nextObserverClosePause = undefined;
+          closePause.started();
+          await closePause.wait;
+        }
+        if (this.failAllObserverCloses || this.failNextObserverClose) {
+          this.failNextObserverClose = false;
+          throw new Error("observer close failed");
+        }
+        handleState.closed = true;
+        if (this.observers.get(sessionName) === observer) this.observers.delete(sessionName);
+      },
+    };
+  }
+
+  get activeObserverCount(): number {
+    return this.observerHandles.filter((observer) => !observer.closed).length;
+  }
+
+  async closeTab(sessionName: string, tabId: number): Promise<void> {
+    if (this.failNextCloseTab) {
+      this.failNextCloseTab = false;
+      throw new Error("close tab failed");
+    }
+    this.closedTabs.push(tabId);
+    this.sessions.get(sessionName)?.delete(tabId);
+  }
+  async deleteSession(sessionName: string): Promise<void> {
+    const pause = this.nextSessionDeletionPause;
+    if (pause) {
+      this.nextSessionDeletionPause = undefined;
+      pause.started();
+      await pause.wait;
+    }
+    this.deletedSessions.push(sessionName);
+    this.sessions.delete(sessionName);
+    const deletedPause = this.nextSessionDeletedPause;
+    if (deletedPause) {
+      this.nextSessionDeletedPause = undefined;
+      deletedPause.started();
+      await deletedPause.wait;
+    }
+  }
+  async renameTab(_sessionName: string, tabId: number, name: string): Promise<void> {
+    this.renamedTabs.push({ tabId, name });
+  }
+  async resizeSession(_sessionName: string, size: { cols: number; rows: number }): Promise<void> {
+    this.resizedSessions.push(size);
+  }
+  async writeToPane(_sessionName: string, _paneId: string, data: Uint8Array): Promise<void> {
+    this.targetedWrites.push(new TextDecoder().decode(data));
+  }
+}
+
+describe("project-scoped terminal runtime", () => {
+  it("runs twenty-three tabs in exactly one Zellij server for their project", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({
+      store: new TerminalWorkspaceStore({ homePath }),
+      zellij,
+    });
+
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    for (let index = 0; index < 23; index += 1) {
+      await runtime.createTab(workspace.id, {
+        name: `tab ${index + 1}`,
+        cwd: "projects/matrix-os",
+      });
+    }
+
+    expect(zellij.sessions.size).toBe(1);
+    expect([...zellij.sessions.values()][0]?.size).toBe(23);
+    expect((await runtime.listWorkspaces())[0]?.tabs).toHaveLength(23);
+  });
+
+  it("shares one attachment per viewed tab while devices select and type independently", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store: new TerminalWorkspaceStore({ homePath }), zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const first = await runtime.createTab(workspace.id, { name: "one", cwd: "projects/matrix-os" });
+    const second = await runtime.createTab(workspace.id, { name: "two", cwd: "projects/matrix-os" });
+    const firstOutput: string[] = [];
+    const secondOutput: string[] = [];
+
+    const desktop = await runtime.attach({ workspaceId: workspace.id, tabId: first.id }, {
+      viewerId: "desktop",
+      send: (data) => { firstOutput.push(new TextDecoder().decode(data)); },
+    });
+    const mobile = await runtime.attach({ workspaceId: workspace.id, tabId: first.id }, {
+      viewerId: "mobile",
+      send: (data) => { secondOutput.push(new TextDecoder().decode(data)); },
+    });
+    expect(zellij.attachments.size).toBe(1);
+
+    const attachment = [...zellij.attachments.values()][0];
+    attachment?.emit(new TextEncoder().encode("shared output"));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(firstOutput).toEqual(["shared output"]);
+    expect(secondOutput).toEqual(["shared output"]);
+
+    await Promise.all([desktop.write("a"), mobile.write("b")]);
+    expect(zellij.writes).toEqual(["a", "b"]);
+
+    const mobileSecondTab = await runtime.attach({ workspaceId: workspace.id, tabId: second.id }, {
+      viewerId: "mobile-second-tab",
+      send: () => undefined,
+    });
+    expect(zellij.attachments.size).toBe(2);
+    await mobile.detach();
+    expect(zellij.attachments.size).toBe(2);
+    await desktop.detach();
+    expect(zellij.attachments.size).toBe(1);
+    await mobileSecondTab.detach();
+    expect(zellij.attachments.size).toBe(0);
+    expect((await runtime.listWorkspaces())[0]?.tabs.map((tab) => tab.status)).toEqual(["running", "running"]);
+  });
+
+  it("serializes agent input to a tab without creating a viewer attachment", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store: new TerminalWorkspaceStore({ homePath }), zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await runtime.createTab(workspace.id, { name: "agent", cwd: "projects/matrix-os" });
+    const ref = { workspaceId: workspace.id, tabId: tab.id };
+
+    await Promise.all([runtime.writeInput(ref, "first"), runtime.writeInput(ref, "second")]);
+
+    expect(zellij.targetedWrites).toEqual(["first", "second"]);
+    expect(zellij.attachments.size).toBe(0);
+    await runtime.shutdown();
+  });
+
+  it("rejects agent input after a tab has exited", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store: new TerminalWorkspaceStore({ homePath }), zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await runtime.createTab(workspace.id, { name: "agent", cwd: "projects/matrix-os" });
+    const ref = { workspaceId: workspace.id, tabId: tab.id };
+
+    await runtime.terminateTab(ref);
+
+    await expect(runtime.writeInput(ref, "late")).rejects.toThrow(/unavailable/i);
+    expect(zellij.targetedWrites).toEqual([]);
+    await runtime.shutdown();
+  });
+
+  it("rejects agent input while a pane-close checkpoint is pending", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const store = new TerminalWorkspaceStore({ homePath });
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store, zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await runtime.createTab(workspace.id, { name: "agent", cwd: "projects/matrix-os" });
+    const runtimeWorkspace = await store.getRuntimeWorkspace(workspace.id);
+    const runtimeTab = runtimeWorkspace?.tabs[tab.id];
+    let signalExitStarted = () => undefined;
+    let releaseExit = () => undefined;
+    const exitStarted = new Promise<void>((resolve) => { signalExitStarted = resolve; });
+    const exitRelease = new Promise<void>((resolve) => { releaseExit = resolve; });
+    const markTabExited = store.markTabExited.bind(store);
+    store.markTabExited = async (ref, exitCode = null) => {
+      signalExitStarted();
+      await exitRelease;
+      return markTabExited(ref, exitCode);
+    };
+
+    zellij.observers.get(runtimeWorkspace!.zellijSessionName)?.emit({
+      type: "pane-closed",
+      paneId: runtimeTab!.zellijPaneId!,
+    });
+    await exitStarted;
+    const lateWrite = runtime.writeInput({ workspaceId: workspace.id, tabId: tab.id }, "late").then(
+      () => "accepted" as const,
+      (error: unknown) => error instanceof Error ? error.message : "unknown",
+    );
+
+    releaseExit();
+    await runtime.flushCheckpoints();
+    await expect(lateWrite).resolves.toMatch(/clos|unavailable/i);
+    expect(zellij.targetedWrites).toEqual([]);
+    await runtime.shutdown();
+  });
+
+  it("drains admitted attachment input before a pane-close event closes the tab", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const store = new TerminalWorkspaceStore({ homePath });
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store, zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await runtime.createTab(workspace.id, { name: "agent", cwd: "projects/matrix-os" });
+    const ref = { workspaceId: workspace.id, tabId: tab.id };
+    const viewer = await runtime.attach(ref, { viewerId: "desktop", send: () => undefined });
+    const runtimeWorkspace = await store.getRuntimeWorkspace(workspace.id);
+    const runtimeTab = runtimeWorkspace?.tabs[tab.id];
+    let signalWriteStarted = () => undefined;
+    let releaseWrite = () => undefined;
+    const writeStarted = new Promise<void>((resolve) => { signalWriteStarted = resolve; });
+    const writeRelease = new Promise<void>((resolve) => { releaseWrite = resolve; });
+    zellij.nextAttachmentWritePause = { started: signalWriteStarted, wait: writeRelease };
+
+    const firstWrite = viewer.write("first admitted");
+    await writeStarted;
+    const queuedWrite = viewer.write("second admitted");
+    zellij.sessions.get(runtimeWorkspace!.zellijSessionName)?.delete(runtimeTab!.zellijTabId!);
+    zellij.observers.get(runtimeWorkspace!.zellijSessionName)?.emit({
+      type: "pane-closed",
+      paneId: runtimeTab!.zellijPaneId!,
+    });
+    const checkpoint = runtime.flushCheckpoints();
+    const finishedBeforeWrites = await Promise.race([
+      checkpoint.then(() => true),
+      new Promise<false>((resolve) => { setTimeout(() => { resolve(false); }, 100); }),
+    ]);
+
+    expect(finishedBeforeWrites).toBe(false);
+    releaseWrite();
+    await Promise.all([firstWrite, queuedWrite, checkpoint]);
+    expect(zellij.writes).toEqual(["first admitted", "second admitted"]);
+    expect(zellij.attachments.size).toBe(0);
+    await expect(store.getTab(ref)).resolves.toMatchObject({ status: "exited" });
+    await runtime.shutdown();
+  });
+
+  it("recovers a transient pane-close persistence failure without leaking the input gate", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const store = new TerminalWorkspaceStore({ homePath });
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store, zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await runtime.createTab(workspace.id, { name: "agent", cwd: "projects/matrix-os" });
+    const runtimeWorkspace = await store.getRuntimeWorkspace(workspace.id);
+    const runtimeTab = runtimeWorkspace?.tabs[tab.id];
+    const markTabExited = store.markTabExited.bind(store);
+    let attempts = 0;
+    store.markTabExited = async (ref, exitCode = null) => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("transient persistence failure");
+      return markTabExited(ref, exitCode);
+    };
+
+    zellij.observers.get(runtimeWorkspace!.zellijSessionName)?.emit({
+      type: "pane-closed",
+      paneId: runtimeTab!.zellijPaneId!,
+    });
+    await runtime.flushCheckpoints();
+
+    expect(attempts).toBe(2);
+    await expect(runtime.writeInput({ workspaceId: workspace.id, tabId: tab.id }, "late"))
+      .rejects.toThrow(/unavailable/i);
+    expect(zellij.targetedWrites).toEqual([]);
+    await runtime.shutdown();
+  });
+
+  it("checkpoints every background tab through one structured workspace observer", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const store = new TerminalWorkspaceStore({ homePath });
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store, zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await runtime.createTab(workspace.id, { name: "build", cwd: "projects/matrix-os" });
+    const runtimeWorkspace = await store.getRuntimeWorkspace(workspace.id);
+    const runtimeTab = runtimeWorkspace?.tabs[tab.id];
+
+    expect(zellij.observers.size).toBe(1);
+    zellij.observers.get(runtimeWorkspace!.zellijSessionName)?.emit({
+      type: "pane-update",
+      paneId: runtimeTab!.zellijPaneId!,
+      ansi: "\u001b[32mbuild complete\u001b[0m",
+      viewport: ["build complete", "$ "],
+      scrollback: ["running build"],
+    });
+    await runtime.flushCheckpoints();
+
+    expect(await runtime.getSnapshot({ workspaceId: workspace.id, tabId: tab.id })).toMatchObject({
+      ansi: "\u001b[32mbuild complete\u001b[0m",
+      viewport: ["build complete", "$ "],
+      scrollback: ["running build"],
+    });
+    expect(zellij.attachments.size).toBe(0);
+
+    await runtime.shutdown();
+    const restarted = new TerminalRuntime({ store: new TerminalWorkspaceStore({ homePath }), zellij: new FakeZellij() });
+    expect((await restarted.getSnapshot({ workspaceId: workspace.id, tabId: tab.id }))?.scrollback).toEqual(["running build"]);
+    await restarted.shutdown();
+  });
+
+  it("rejects a new active workspace at observer capacity without evicting an active observer", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({
+      store: new TerminalWorkspaceStore({ homePath }),
+      zellij,
+      maxObservers: 1,
+    });
+    const first = await runtime.ensureWorkspace({ projectId: "first-project" });
+    await runtime.createTab(first.id, { name: "first", cwd: "projects/first" });
+    const firstRuntimeWorkspace = await new TerminalWorkspaceStore({ homePath }).getRuntimeWorkspace(first.id);
+    const second = await runtime.ensureWorkspace({ projectId: "second-project" });
+    const secondRuntimeWorkspace = await new TerminalWorkspaceStore({ homePath }).getRuntimeWorkspace(second.id);
+
+    await expect(runtime.createTab(second.id, {
+      name: "second",
+      cwd: "projects/second",
+    })).rejects.toThrow("Terminal observer capacity reached");
+
+    expect(zellij.observers.has(firstRuntimeWorkspace!.zellijSessionName)).toBe(true);
+    expect(zellij.observers.has(secondRuntimeWorkspace!.zellijSessionName)).toBe(false);
+    expect(zellij.observers.size).toBe(1);
+    expect((await runtime.listWorkspaces()).find((workspace) => workspace.id === second.id)?.tabs).toEqual([]);
+    await runtime.shutdown();
+  });
+
+  it("keeps the existing workspace observer when its replacement subscription fails", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const store = new TerminalWorkspaceStore({ homePath });
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store, zellij, maxObservers: 1, sweepIntervalMs: 60_000 });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const first = await runtime.createTab(workspace.id, { name: "first", cwd: "projects/matrix-os" });
+    const second = await runtime.createTab(workspace.id, { name: "second", cwd: "projects/matrix-os" });
+    const runtimeWorkspace = await store.getRuntimeWorkspace(workspace.id);
+    const secondRuntimeTab = runtimeWorkspace?.tabs[second.id];
+
+    zellij.subscriptionFailuresRemaining = 2;
+    await expect(runtime.terminateTab({ workspaceId: workspace.id, tabId: first.id }))
+      .rejects.toThrow("Terminal observer restoration failed");
+
+    await expect.poll(() => zellij.activeObserverCount).toBe(1);
+    const observer = zellij.observers.get(runtimeWorkspace!.zellijSessionName);
+    expect(observer).toBeDefined();
+    observer?.emit({
+      type: "pane-update",
+      paneId: secondRuntimeTab!.zellijPaneId!,
+      ansi: "still observed",
+      viewport: ["still observed"],
+      scrollback: [],
+    });
+    await runtime.flushCheckpoints();
+    expect(await runtime.getSnapshot({ workspaceId: workspace.id, tabId: second.id })).toMatchObject({
+      ansi: "still observed",
+      viewport: ["still observed"],
+    });
+    await runtime.shutdown();
+  });
+
+  it("cleans up the replacement when the old observer cannot close", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const store = new TerminalWorkspaceStore({ homePath });
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store, zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const first = await runtime.createTab(workspace.id, { name: "first", cwd: "projects/matrix-os" });
+    await runtime.createTab(workspace.id, { name: "second", cwd: "projects/matrix-os" });
+
+    zellij.failNextObserverClose = true;
+    await expect(runtime.terminateTab({ workspaceId: workspace.id, tabId: first.id }))
+      .rejects.toThrow("observer close failed");
+    expect(zellij.activeObserverCount).toBe(1);
+
+    await runtime.shutdown();
+    expect(zellij.activeObserverCount).toBe(0);
+  });
+
+  it("does not accumulate observers when both sides of a replacement fail to close", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({
+      store: new TerminalWorkspaceStore({ homePath }),
+      zellij,
+      maxObservers: 2,
+    });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const first = await runtime.createTab(workspace.id, { name: "first", cwd: "projects/matrix-os" });
+    const second = await runtime.createTab(workspace.id, { name: "second", cwd: "projects/matrix-os" });
+    await runtime.createTab(workspace.id, { name: "third", cwd: "projects/matrix-os" });
+
+    zellij.failAllObserverCloses = true;
+    await expect(runtime.terminateTab({ workspaceId: workspace.id, tabId: first.id }))
+      .rejects.toThrow("Terminal observer replacement cleanup failed");
+    expect(zellij.activeObserverCount).toBe(2);
+    await expect(runtime.terminateTab({ workspaceId: workspace.id, tabId: second.id }))
+      .rejects.toThrow("observer close failed");
+    expect(zellij.activeObserverCount).toBe(2);
+
+    zellij.failAllObserverCloses = false;
+    await runtime.shutdown();
+    expect(zellij.activeObserverCount).toBe(0);
+  });
+
+  it("retains the last observer when closing a zero-pane workspace observer fails", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const store = new TerminalWorkspaceStore({ homePath });
+    const runtime = new TerminalRuntime({ store, zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await runtime.createTab(workspace.id, { name: "one", cwd: "projects/matrix-os" });
+    await store.removeTab({ workspaceId: workspace.id, tabId: tab.id });
+
+    zellij.failNextObserverClose = true;
+    await expect(runtime.ensureWorkspace({ projectId: "matrix-os" }))
+      .rejects.toThrow("observer close failed");
+    expect(zellij.activeObserverCount).toBe(1);
+
+    await runtime.shutdown();
+    expect(zellij.activeObserverCount).toBe(0);
+  });
+
+  it("retains observer ownership when workspace deletion cannot close it", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store: new TerminalWorkspaceStore({ homePath }), zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    await runtime.createTab(workspace.id, { name: "one", cwd: "projects/matrix-os" });
+
+    zellij.failNextObserverClose = true;
+    await expect(runtime.deleteWorkspace(workspace.id, { confirmTerminate: true }))
+      .rejects.toThrow("observer close failed");
+    expect(zellij.activeObserverCount).toBe(1);
+    expect(await runtime.listWorkspaces()).toHaveLength(1);
+    expect(zellij.deletedSessions).toEqual([]);
+
+    await runtime.shutdown();
+    expect(zellij.activeObserverCount).toBe(0);
+  });
+
+  it("rolls back the canonical and Zellij tab when initial observation fails", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store: new TerminalWorkspaceStore({ homePath }), zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    zellij.failNextSubscription = true;
+
+    await expect(runtime.createTab(workspace.id, { name: "failed", cwd: "projects/matrix-os" }))
+      .rejects.toThrow("observer subscription failed");
+
+    expect((await runtime.listWorkspaces())[0]?.tabs).toEqual([]);
+    expect([...zellij.sessions.values()][0]?.size).toBe(0);
+    expect(zellij.closedTabs).toEqual([1]);
+    await runtime.shutdown();
+  });
+
+  it("removes the canonical tab even when Zellij rollback fails", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store: new TerminalWorkspaceStore({ homePath }), zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    zellij.failNextSubscription = true;
+    zellij.failNextCloseTab = true;
+
+    await expect(runtime.createTab(workspace.id, { name: "failed", cwd: "projects/matrix-os" }))
+      .rejects.toThrow("observer subscription failed");
+    expect((await runtime.listWorkspaces())[0]?.tabs).toEqual([]);
+    await runtime.shutdown();
+  });
+
+  it("removes a replacement observer when workspace deletion overlaps its subscription", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const store = new TerminalWorkspaceStore({ homePath });
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store, zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const first = await runtime.createTab(workspace.id, { name: "first", cwd: "projects/matrix-os" });
+    await runtime.createTab(workspace.id, { name: "second", cwd: "projects/matrix-os" });
+    const runtimeWorkspace = await store.getRuntimeWorkspace(workspace.id);
+    let signalSubscriptionStarted = () => undefined;
+    let releaseSubscription = () => undefined;
+    const subscriptionStarted = new Promise<void>((resolve) => { signalSubscriptionStarted = resolve; });
+    const subscriptionRelease = new Promise<void>((resolve) => { releaseSubscription = resolve; });
+    zellij.nextSubscriptionPause = { started: signalSubscriptionStarted, wait: subscriptionRelease };
+
+    const restart = runtime.terminateTab({ workspaceId: workspace.id, tabId: first.id });
+    await subscriptionStarted;
+    const deletion = runtime.deleteWorkspace(workspace.id, { confirmTerminate: true });
+    const deletionFinishedBeforeRelease = await Promise.race([
+      deletion.then(() => true),
+      new Promise<false>((resolve) => { setTimeout(() => { resolve(false); }, 100); }),
+    ]);
+    releaseSubscription();
+    await Promise.all([restart, deletion]);
+
+    expect(deletionFinishedBeforeRelease).toBe(false);
+    expect(zellij.observers.has(runtimeWorkspace!.zellijSessionName)).toBe(false);
+    expect(await runtime.listWorkspaces()).toEqual([]);
+    expect(zellij.deletedSessions).toContain(runtimeWorkspace!.zellijSessionName);
+    await runtime.shutdown();
+  });
+
+  it("does not create a tab while deletion owns the workspace lifecycle", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const store = new TerminalWorkspaceStore({ homePath });
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store, zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    let signalDeletionStarted = () => undefined;
+    let releaseDeletion = () => undefined;
+    let signalTabCreated = () => undefined;
+    const deletionStarted = new Promise<void>((resolve) => { signalDeletionStarted = resolve; });
+    const deletionRelease = new Promise<void>((resolve) => { releaseDeletion = resolve; });
+    const tabCreated = new Promise<void>((resolve) => { signalTabCreated = resolve; });
+    zellij.nextSessionDeletionPause = { started: signalDeletionStarted, wait: deletionRelease };
+    zellij.nextTabCreated = signalTabCreated;
+
+    const deletion = runtime.deleteWorkspace(workspace.id, { confirmTerminate: false });
+    await deletionStarted;
+    const creation = runtime.createTab(workspace.id, { name: "racing", cwd: "projects/matrix-os" });
+    const tabCreatedBeforeDeletionFinished = await Promise.race([
+      tabCreated.then(() => true),
+      new Promise<false>((resolve) => { setTimeout(() => { resolve(false); }, 100); }),
+    ]);
+    releaseDeletion();
+    await deletion;
+    await expect(creation).rejects.toThrow("Terminal workspace not found");
+
+    expect(tabCreatedBeforeDeletionFinished).toBe(false);
+    expect(zellij.sessions.size).toBe(0);
+    expect(await runtime.listWorkspaces()).toEqual([]);
+    await runtime.shutdown();
+  });
+
+  it("does not reconcile a session while workspace deletion is removing canonical state", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const store = new TerminalWorkspaceStore({ homePath });
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store, zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    let signalDeleted = () => undefined;
+    let releaseDeletion = () => undefined;
+    const deleted = new Promise<void>((resolve) => { signalDeleted = resolve; });
+    const deletionRelease = new Promise<void>((resolve) => { releaseDeletion = resolve; });
+    zellij.nextSessionDeletedPause = { started: signalDeleted, wait: deletionRelease };
+
+    const deletion = runtime.deleteWorkspace(workspace.id, { confirmTerminate: false });
+    await deleted;
+    const reconciliation = runtime.ensureWorkspace({ projectId: "matrix-os" });
+    await new Promise<void>((resolve) => { setImmediate(resolve); });
+    releaseDeletion();
+    await deletion;
+    await expect(reconciliation).rejects.toThrow("Terminal workspace not found");
+    expect(zellij.sessions.size).toBe(0);
+    await runtime.shutdown();
+  });
+
+  it("drains a pending attachment before deleting its workspace", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store: new TerminalWorkspaceStore({ homePath }), zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await runtime.createTab(workspace.id, { name: "one", cwd: "projects/matrix-os" });
+    let signalOpening = () => undefined;
+    let releaseAttachment = () => undefined;
+    const opening = new Promise<void>((resolve) => { signalOpening = resolve; });
+    const attachmentRelease = new Promise<void>((resolve) => { releaseAttachment = resolve; });
+    zellij.nextAttachmentOpenPause = { started: signalOpening, wait: attachmentRelease };
+
+    const attachment = runtime.attach({ workspaceId: workspace.id, tabId: tab.id }, {
+      viewerId: "desktop",
+      send: () => undefined,
+    });
+    await opening;
+    const deletion = runtime.deleteWorkspace(workspace.id, { confirmTerminate: true });
+    const deletionFinishedBeforeRelease = await Promise.race([
+      deletion.then(() => true),
+      new Promise<false>((resolve) => { setTimeout(() => { resolve(false); }, 100); }),
+    ]);
+    releaseAttachment();
+    await Promise.all([attachment, deletion]);
+    expect(deletionFinishedBeforeRelease).toBe(false);
+    expect(zellij.attachments.size).toBe(0);
+    await runtime.shutdown();
+  });
+
+  it("drains a pending attachment before shutdown completes", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store: new TerminalWorkspaceStore({ homePath }), zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await runtime.createTab(workspace.id, { name: "one", cwd: "projects/matrix-os" });
+    let signalOpening = () => undefined;
+    let releaseAttachment = () => undefined;
+    const opening = new Promise<void>((resolve) => { signalOpening = resolve; });
+    const attachmentRelease = new Promise<void>((resolve) => { releaseAttachment = resolve; });
+    zellij.nextAttachmentOpenPause = { started: signalOpening, wait: attachmentRelease };
+    const attachment = runtime.attach({ workspaceId: workspace.id, tabId: tab.id }, {
+      viewerId: "desktop", send: () => undefined,
+    });
+    await opening;
+    const shutdown = runtime.shutdown();
+    const finishedEarly = await Promise.race([
+      shutdown.then(() => true),
+      new Promise<false>((resolve) => { setTimeout(() => { resolve(false); }, 100); }),
+    ]);
+    releaseAttachment();
+    await Promise.all([attachment, shutdown]);
+    expect(finishedEarly).toBe(false);
+    expect(zellij.attachments.size).toBe(0);
+  });
+
+  it("drains queued terminal writes before shutdown closes attachments", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store: new TerminalWorkspaceStore({ homePath }), zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await runtime.createTab(workspace.id, { name: "one", cwd: "projects/matrix-os" });
+    const viewer = await runtime.attach({ workspaceId: workspace.id, tabId: tab.id }, {
+      viewerId: "desktop", send: () => undefined,
+    });
+    let signalWriteStarted = () => undefined;
+    let releaseWrite = () => undefined;
+    const writeStarted = new Promise<void>((resolve) => { signalWriteStarted = resolve; });
+    const writeRelease = new Promise<void>((resolve) => { releaseWrite = resolve; });
+    zellij.nextAttachmentWritePause = { started: signalWriteStarted, wait: writeRelease };
+
+    const write = viewer.write("pending");
+    await writeStarted;
+    const shutdown = runtime.shutdown();
+    const finishedBeforeWrite = await Promise.race([
+      shutdown.then(() => true),
+      new Promise<false>((resolve) => { setTimeout(() => { resolve(false); }, 100); }),
+    ]);
+    expect(finishedBeforeWrite).toBe(false);
+
+    releaseWrite();
+    await Promise.all([write, shutdown]);
+    expect(zellij.writes).toEqual(["pending"]);
+    expect(zellij.attachments.size).toBe(0);
+  });
+
+  it("drains admitted input without stranding a viewer that reconnects during cleanup", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store: new TerminalWorkspaceStore({ homePath }), zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await runtime.createTab(workspace.id, { name: "one", cwd: "projects/matrix-os" });
+    const ref = { workspaceId: workspace.id, tabId: tab.id };
+    const viewer = await runtime.attach(ref, { viewerId: "desktop", send: () => undefined });
+    let signalWriteStarted = () => undefined;
+    let releaseWrite = () => undefined;
+    const writeStarted = new Promise<void>((resolve) => { signalWriteStarted = resolve; });
+    const writeRelease = new Promise<void>((resolve) => { releaseWrite = resolve; });
+    zellij.nextAttachmentWritePause = { started: signalWriteStarted, wait: writeRelease };
+
+    const write = viewer.write("admitted");
+    await writeStarted;
+    const reconnecting = runtime.attach(ref, { viewerId: "mobile", send: () => undefined });
+    await Promise.resolve();
+    const detach = viewer.detach();
+    await new Promise<void>((resolve) => { setImmediate(resolve); });
+    try {
+      expect(zellij.attachments.size).toBe(1);
+    } finally {
+      releaseWrite();
+      await write;
+    }
+    const reconnected = await reconnecting;
+    await detach;
+    expect(zellij.attachments.size).toBe(1);
+    await reconnected.write("after reconnect");
+    expect(zellij.writes).toEqual(["admitted", "after reconnect"]);
+    await reconnected.detach();
+    await runtime.shutdown();
+  });
+
+  it("drains admitted input and rejects new writes while terminating a tab", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store: new TerminalWorkspaceStore({ homePath }), zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await runtime.createTab(workspace.id, { name: "one", cwd: "projects/matrix-os" });
+    const ref = { workspaceId: workspace.id, tabId: tab.id };
+    const viewer = await runtime.attach(ref, { viewerId: "desktop", send: () => undefined });
+    let signalWriteStarted = () => undefined;
+    let releaseWrite = () => undefined;
+    const writeStarted = new Promise<void>((resolve) => { signalWriteStarted = resolve; });
+    const writeRelease = new Promise<void>((resolve) => { releaseWrite = resolve; });
+    zellij.nextAttachmentWritePause = { started: signalWriteStarted, wait: writeRelease };
+
+    const write = viewer.write("admitted");
+    await writeStarted;
+    const queuedWrite = viewer.write("queued-before-termination");
+    const termination = runtime.terminateTab(ref);
+    const lateWrite = runtime.writeInput(ref, "late").then(
+      () => "accepted" as const,
+      (error: unknown) => error instanceof Error ? error.message : "unknown",
+    );
+    const finishedBeforeWrite = await Promise.race([
+      termination.then(() => true),
+      new Promise<false>((resolve) => { setTimeout(() => { resolve(false); }, 100); }),
+    ]);
+
+    expect(finishedBeforeWrite).toBe(false);
+    await expect(lateWrite).resolves.toMatch(/terminat/i);
+    releaseWrite();
+    await Promise.all([write, queuedWrite, termination]);
+    expect(zellij.writes).toEqual(["admitted", "queued-before-termination"]);
+    expect(zellij.targetedWrites).toEqual([]);
+    expect(zellij.closedTabs).toHaveLength(1);
+    await runtime.shutdown();
+  });
+
+  it("drains admitted input and rejects new writes while deleting a workspace", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store: new TerminalWorkspaceStore({ homePath }), zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await runtime.createTab(workspace.id, { name: "one", cwd: "projects/matrix-os" });
+    const ref = { workspaceId: workspace.id, tabId: tab.id };
+    const viewer = await runtime.attach(ref, { viewerId: "desktop", send: () => undefined });
+    let signalWriteStarted = () => undefined;
+    let releaseWrite = () => undefined;
+    const writeStarted = new Promise<void>((resolve) => { signalWriteStarted = resolve; });
+    const writeRelease = new Promise<void>((resolve) => { releaseWrite = resolve; });
+    zellij.nextAttachmentWritePause = { started: signalWriteStarted, wait: writeRelease };
+    let signalDeletionStarted = () => undefined;
+    let releaseDeletion = () => undefined;
+    const deletionStarted = new Promise<void>((resolve) => { signalDeletionStarted = resolve; });
+    const deletionRelease = new Promise<void>((resolve) => { releaseDeletion = resolve; });
+    zellij.nextSessionDeletionPause = { started: signalDeletionStarted, wait: deletionRelease };
+
+    const write = viewer.write("admitted");
+    await writeStarted;
+    const deletion = runtime.deleteWorkspace(workspace.id, { confirmTerminate: true });
+    const deletionReachedSessionBeforeWrite = await Promise.race([
+      deletionStarted.then(() => true),
+      new Promise<false>((resolve) => { setTimeout(() => { resolve(false); }, 100); }),
+    ]);
+    releaseWrite();
+    await write;
+    await deletionStarted;
+    const lateWrite = runtime.writeInput(ref, "late").then(
+      () => "accepted" as const,
+      (error: unknown) => error instanceof Error ? error.message : "unknown",
+    );
+    const lateWriteResult = await lateWrite;
+    releaseDeletion();
+    await deletion;
+
+    expect(deletionReachedSessionBeforeWrite).toBe(false);
+    expect(lateWriteResult).toMatch(/delet/i);
+    expect(zellij.writes).toEqual(["admitted"]);
+    expect(zellij.targetedWrites).toEqual([]);
+    await runtime.shutdown();
+  });
+
+  it("stops observer events before the final shutdown checkpoint drain", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const store = new TerminalWorkspaceStore({ homePath });
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store, zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await runtime.createTab(workspace.id, { name: "one", cwd: "projects/matrix-os" });
+    const runtimeWorkspace = await store.getRuntimeWorkspace(workspace.id);
+    const runtimeTab = runtimeWorkspace!.tabs[tab.id]!;
+    const observer = zellij.observers.get(runtimeWorkspace!.zellijSessionName)!;
+    let signalObserverClosing = () => undefined;
+    let releaseObserverClose = () => undefined;
+    const observerClosing = new Promise<void>((resolve) => { signalObserverClosing = resolve; });
+    const observerCloseRelease = new Promise<void>((resolve) => { releaseObserverClose = resolve; });
+    zellij.nextObserverClosePause = { started: signalObserverClosing, wait: observerCloseRelease };
+    let signalCheckpointStarted = () => undefined;
+    let releaseCheckpoint = () => undefined;
+    const checkpointStarted = new Promise<void>((resolve) => { signalCheckpointStarted = resolve; });
+    const checkpointRelease = new Promise<void>((resolve) => { releaseCheckpoint = resolve; });
+    const checkpointTab = store.checkpointTab.bind(store);
+    store.checkpointTab = async (...args) => {
+      signalCheckpointStarted();
+      await checkpointRelease;
+      return checkpointTab(...args);
+    };
+
+    const shutdown = runtime.shutdown();
+    await observerClosing;
+    observer.emit({
+      type: "pane-update",
+      paneId: runtimeTab.zellijPaneId!,
+      ansi: "late output",
+      viewport: ["late output"],
+      scrollback: [],
+    });
+    await checkpointStarted;
+    releaseObserverClose();
+    await new Promise<void>((resolve) => { setImmediate(resolve); });
+    observer.emit({
+      type: "pane-update",
+      paneId: runtimeTab.zellijPaneId!,
+      ansi: "too late",
+      viewport: ["too late"],
+      scrollback: [],
+    });
+    const finishedBeforeCheckpoint = await Promise.race([
+      shutdown.then(() => true),
+      new Promise<false>((resolve) => { setTimeout(() => { resolve(false); }, 100); }),
+    ]);
+    expect(finishedBeforeCheckpoint).toBe(false);
+
+    releaseCheckpoint();
+    await shutdown;
+    expect(await runtime.getSnapshot({ workspaceId: workspace.id, tabId: tab.id })).toMatchObject({
+      ansi: "late output",
+      viewport: ["late output"],
+    });
+  });
+
+  it("reconciles stable Matrix tab IDs after the Zellij server restarts", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const store = new TerminalWorkspaceStore({ homePath });
+    const firstZellij = new FakeZellij();
+    const firstRuntime = new TerminalRuntime({ store, zellij: firstZellij });
+    const workspace = await firstRuntime.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await firstRuntime.createTab(workspace.id, { name: "agent", cwd: "projects/matrix-os" });
+    await firstRuntime.shutdown();
+
+    const restartedZellij = new FakeZellij();
+    const restartedRuntime = new TerminalRuntime({
+      store: new TerminalWorkspaceStore({ homePath }),
+      zellij: restartedZellij,
+    });
+    await restartedRuntime.restoreAll();
+
+    const restored = (await restartedRuntime.listWorkspaces())[0]!;
+    expect(restored.tabs[0]?.id).toBe(tab.id);
+    expect(restartedZellij.sessions.size).toBe(1);
+    expect([...restartedZellij.sessions.values()][0]?.size).toBe(1);
+    await restartedRuntime.shutdown();
+  });
+
+  it("separates detach, tab termination, canonical hard sizing, and confirmed workspace deletion", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const zellij = new FakeZellij();
+    const runtime = new TerminalRuntime({ store: new TerminalWorkspaceStore({ homePath }), zellij });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+    const first = await runtime.createTab(workspace.id, { name: "one", cwd: "projects/matrix-os" });
+    const second = await runtime.createTab(workspace.id, { name: "two", cwd: "projects/matrix-os" });
+
+    const renamed = await runtime.renameTab({ workspaceId: workspace.id, tabId: first.id }, {
+      name: "build",
+      baseRevision: first.revision,
+    });
+    expect(renamed.name).toBe("build");
+    await runtime.resize({ workspaceId: workspace.id, tabId: first.id }, { mode: "soft", size: { cols: 40, rows: 10 } });
+    expect(zellij.resizedSessions).toEqual([]);
+    await runtime.resize({ workspaceId: workspace.id, tabId: first.id }, { mode: "hard", size: { cols: 160, rows: 48 } });
+    expect(zellij.resizedSessions).toEqual([{ cols: 160, rows: 48 }]);
+
+    await runtime.terminateTab({ workspaceId: workspace.id, tabId: first.id });
+    expect(zellij.closedTabs).toHaveLength(1);
+    expect((await runtime.listWorkspaces())[0]?.tabs.find((tab) => tab.id === second.id)?.status).toBe("running");
+    expect((await runtime.deletionImpact(workspace.id)).runningTabs).toBe(1);
+    await expect(runtime.deleteWorkspace(workspace.id, { confirmTerminate: false })).rejects.toThrow(/confirmation/i);
+    await runtime.deleteWorkspace(workspace.id, { confirmTerminate: true });
+    expect(zellij.deletedSessions).toHaveLength(1);
+    await runtime.shutdown();
+  });
+});

--- a/tests/terminal-runtime/workspace-store.test.ts
+++ b/tests/terminal-runtime/workspace-store.test.ts
@@ -1,0 +1,96 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { TerminalWorkspaceStore } from "../../packages/terminal-runtime/src/workspace-store.js";
+
+const homes: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(homes.splice(0).map((home) => rm(home, { recursive: true, force: true })));
+});
+
+describe("terminal workspace store", () => {
+  it("makes workspace state and background scrollback renames directory-durable", async () => {
+    const source = await readFile(
+      join(process.cwd(), "packages/terminal-runtime/src/workspace-store.ts"),
+      "utf8",
+    );
+    expect(source).toContain("await writeTextAtomic(this.statePath");
+    expect(source).toContain("await writeTextAtomic(target, content)");
+    expect(source).toContain('const directoryHandle = await open(dirname(path), "r")');
+    expect(source).toContain("await directoryHandle.sync()");
+    expect(source).toContain("await rm(temporaryPath, { force: true })");
+  });
+
+  it("enforces one durable workspace per project and one reserved main workspace", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-workspaces-"));
+    homes.push(homePath);
+    const store = new TerminalWorkspaceStore({ homePath });
+
+    const main = await store.ensureWorkspace();
+    const firstProject = await store.ensureWorkspace({ projectId: "matrix-os" });
+    const sameProject = await store.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await store.createTab(firstProject.id, { name: "tests", cwd: "projects/matrix-os" });
+    const pinnedTab = await store.updateTabUiState(
+      { workspaceId: firstProject.id, tabId: tab.id },
+      { pinned: true, baseRevision: tab.revision },
+    );
+
+    expect(main.scope).toBe("main");
+    expect(sameProject.id).toBe(firstProject.id);
+    expect(tab.workspaceId).toBe(firstProject.id);
+    expect((await store.listWorkspaces()).map((workspace) => workspace.id)).toEqual([main.id, firstProject.id]);
+
+    const restarted = new TerminalWorkspaceStore({ homePath });
+    expect(await restarted.getTab({ workspaceId: firstProject.id, tabId: tab.id })).toMatchObject({
+      name: "tests",
+      accessScope: "owner",
+      revision: pinnedTab.revision,
+      uiState: { pinned: true },
+    });
+
+    const persisted = JSON.parse(await readFile(join(homePath, "system", "terminal-workspaces.json"), "utf8"));
+    expect(persisted.schemaVersion).toBe(2);
+    expect(persisted.workspaces[firstProject.id].zellijSessionName).toMatch(/^matrix-w-[0-9a-f]{32}$/);
+    expect(persisted.workspaces[firstProject.id].tabs[tab.id].zellijTabName).toMatch(/^matrix-tab-[0-9a-f]{32}$/);
+    expect(JSON.stringify(await store.listWorkspaces())).not.toContain("zellij");
+  });
+
+  it("persists a control-heavy snapshot at the public ANSI limit", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-snapshot-capacity-"));
+    homes.push(homePath);
+    const store = new TerminalWorkspaceStore({ homePath });
+    const workspace = await store.ensureWorkspace();
+    const tab = await store.createTab(workspace.id, { name: "capacity", cwd: "" });
+    const ansi = "\u0001".repeat(5 * 1024 * 1024);
+    const scrollback = Array.from(
+      { length: Math.ceil(ansi.length / 16_384) },
+      (_, index) => ansi.slice(index * 16_384, (index + 1) * 16_384),
+    );
+
+    await expect(store.importSnapshot(
+      { workspaceId: workspace.id, tabId: tab.id },
+      { ansi, viewport: [], scrollback, seq: 1 },
+    )).resolves.toMatchObject({ ansi, scrollback, seq: 1 });
+    await expect(store.readSnapshot({ workspaceId: workspace.id, tabId: tab.id }))
+      .resolves.toMatchObject({ ansi, scrollback, seq: 1 });
+  });
+
+  it("does not advance revisions when an exited-tab checkpoint is retried", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-exit-retry-"));
+    homes.push(homePath);
+    const store = new TerminalWorkspaceStore({ homePath });
+    const workspace = await store.ensureWorkspace({ projectId: "matrix-os" });
+    const tab = await store.createTab(workspace.id, { name: "agent", cwd: "projects/matrix-os" });
+    const ref = { workspaceId: workspace.id, tabId: tab.id };
+
+    const exited = await store.markTabExited(ref, 0);
+    const workspaceAfterExit = (await store.listWorkspaces()).find((entry) => entry.id === workspace.id)!;
+    const retried = await store.markTabExited(ref, 0);
+    const workspaceAfterRetry = (await store.listWorkspaces()).find((entry) => entry.id === workspace.id)!;
+
+    expect(retried).toEqual(exited);
+    expect(workspaceAfterRetry.revision).toBe(workspaceAfterExit.revision);
+  });
+});


### PR DESCRIPTION
## Summary

- define stable project-scoped workspace, tab, and terminal-reference contracts while retaining legacy compatibility for the stack
- add owner-scoped atomic workspace persistence, bounded snapshots, and serialized runtime reconciliation
- make observer replacement and shutdown drain ownership, queued writes, and final checkpoints deterministically

Layer 1 of 14. The concrete Zellij adapter, migration, and protected Unix-socket API follow in #1416.

## Tests

- `pnpm install --frozen-lockfile`
- `pnpm --filter @matrix-os/terminal-runtime exec tsc --noEmit`
- 25 focused contract/store/runtime tests
- shutdown, observer-replacement, queued-write, and final-checkpoint regressions
- `pnpm run check:patterns` (0 violations)
- `git diff --check`
- PR size: 2,591 additions across 14 files

## Review/Monitoring

- GitHub CI and Greptile are being monitored on the latest head until green and 5/5.

## Invariants

### Source of truth

- Owner-controlled terminal workspace state is canonical; public consumers identify terminals only through `TerminalRef`.
- Internal Zellij names are opaque implementation details reconciled by the runtime.

### Lock/transaction scope

- Workspace-store mutations are serialized per owner state file and revision-checked at the write boundary.
- State and retained snapshots are written atomically with bounded payloads.
- Runtime tab creation, reconciliation, attachment acquisition, and workspace deletion are serialized through one bounded promise chain; observer replacement and cleanup use a separate serialized chain.
- Shutdown closes lifecycle admission, drains observers and queued writes, awaits the mutation chain, and flushes final checkpoints before attachments close.

### Acceptable orphan states

- A tab may exist without an attached viewer; reconciliation restores missing runtime attachments from canonical workspace state.
- If initial workspace observation fails after tab activation, creation attempts to close the Zellij tab and atomically removes the canonical tab before returning the error; a failed close may leave a live Zellij tab until later session cleanup, but canonical reconciliation cannot recreate it.

### Auth source of truth

- This layer exposes no network endpoint.
- The owner-only Unix-socket transport and gateway principal authorization are introduced in later stack layers.

### Deferred scope

- The concrete Zellij adapter, migration, socket transport, gateway/client cutover, deployment wiring, and user-facing surfaces are intentionally deferred to later layers.

