### PR TITLE
docs(readme): add future-facing remark

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Matrix OS gives you a hosted cloud computer: browser desktop, files, terminal se
 
 It is not a chat box beside your software. The AI is the kernel. The shell, gateway, files, apps, terminal, channels, and agents are one operating environment.
 
+> This is the future.
+
 <p align="center">
   <img src="https://matrix-os.com/images/app-screenshot.jpg" alt="Matrix OS browser desktop with generated apps" width="900">
 </p>


### PR DESCRIPTION
## Summary

- Add a short, visible “This is the future.” remark to the README overview.

## Tests

- `bun run typecheck` — passed
- `bun run check:patterns` — passed with baseline warnings and no violations
- `bun run test` — stopped after unrelated existing failures across default-app,
  coding-agent, sync, CLI, and host-script test suites

## Invariants

### Source of truth

- Not applicable; this PR changes README prose only.

### Lock/transaction scope

- Not applicable; this PR performs no runtime or persistence operations.

### Acceptable orphan states

- None; this PR creates no persisted or external state.

### Auth source of truth

- Unchanged; this PR does not touch authentication.

### Deferred scope

- No product or runtime behavior changes are included.
