### PR TITLE
fix(terminal): support reliable clipboard shortcuts

### DIFF
--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -1,4 +1,5 @@
 import { Terminal } from "@xterm/xterm";
+import { classifyTerminalClipboardShortcut } from "@matrix-os/contracts";
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { WebglAddon } from "@xterm/addon-webgl";
@@ -25,6 +26,7 @@ import {
 import {
   bracketTerminalPaths,
   MAX_TERMINAL_PASTE_FILE_BYTES,
+  readTerminalClipboardFiles,
   safeTerminalUploadFilename,
   terminalPasteFiles,
 } from "./terminal-rich-paste";
@@ -79,6 +81,7 @@ export default function TerminalView({
   const fitRef = useRef<FitAddon | null>(null);
   const serializeRef = useRef<SerializeAddon | null>(null);
   const attachmentRef = useRef<ActiveAttachment | null>(null);
+  const pasteClipboardRef = useRef<() => Promise<void>>(async () => undefined);
   const endedRef = useRef(false);
   const hoveredLinkRef = useRef<TerminalLinkEntry | null>(null);
   const [socketState, setSocketState] = useState<ShellSocketState>("connecting");
@@ -129,21 +132,25 @@ export default function TerminalView({
     terminal.loadAddon(serialize);
     terminal.open(host);
     terminal.attachCustomKeyEventHandler((event) => {
-      if (event.type !== "keydown" || !terminal.hasSelection()) return true;
-      const key = event.key.toLowerCase();
-      const isMacCopy = key === "c"
-        && event.metaKey
-        && !event.ctrlKey
-        && !event.altKey
-        && !event.shiftKey;
-      const isTerminalCopy = key === "c"
-        && event.ctrlKey
-        && event.shiftKey
-        && !event.metaKey
-        && !event.altKey;
-      if (!isMacCopy && !isTerminalCopy) return true;
+      const action = classifyTerminalClipboardShortcut({
+        type: event.type as "keydown" | "keyup" | "keypress",
+        key: event.key,
+        isMac: event.metaKey,
+        metaKey: event.metaKey,
+        ctrlKey: event.ctrlKey,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+        repeat: event.repeat,
+        isComposing: event.isComposing,
+        hasSelection: terminal.hasSelection(),
+      });
+      if (action !== "copy" && action !== "paste") return true;
       event.preventDefault();
-      copyDesktopTerminalText(terminal.getSelection());
+      if (action === "copy") {
+        void copyDesktopTerminalText(terminal.getSelection());
+      } else {
+        void pasteClipboardRef.current();
+      }
       return false;
     });
     applyTerminalSurfaceTheme(terminal.element, theme.background);
@@ -348,6 +355,46 @@ export default function TerminalView({
       }
     };
 
+    const pasteFromClipboard = async () => {
+      const clipboard = navigator.clipboard;
+      if (!clipboard) {
+        if (!cancelled) setPasteError("Clipboard paste is unavailable. Try again.");
+        return;
+      }
+      const clipboardWithOptionalRead = clipboard as Clipboard & {
+        read?: () => Promise<ClipboardItems>;
+      };
+      if (typeof clipboardWithOptionalRead.read === "function") {
+        try {
+          const imageFiles = await readTerminalClipboardFiles(clipboardWithOptionalRead);
+          if (imageFiles.length > 0) {
+            await uploadAndPaste(imageFiles);
+            return;
+          }
+        } catch (error: unknown) {
+          console.warn("[terminal] clipboard image read unavailable", {
+            category: error instanceof DOMException ? error.name : "clipboard-error",
+          });
+        }
+      }
+      if (!clipboard.readText) {
+        if (!cancelled) setPasteError("Clipboard paste is unavailable. Try again.");
+        return;
+      }
+      try {
+        const text = await clipboard.readText();
+        if (cancelled || text.length === 0) return;
+        termRef.current?.paste(text);
+        setPasteError(null);
+      } catch (error: unknown) {
+        console.warn("[terminal] clipboard text read unavailable", {
+          category: error instanceof DOMException ? error.name : "clipboard-error",
+        });
+        if (!cancelled) setPasteError("Clipboard paste failed. Try again.");
+      }
+    };
+    pasteClipboardRef.current = pasteFromClipboard;
+
     const onPaste = (event: ClipboardEvent) => {
       const files = captureFiles(event);
       if (files.length > 0) void uploadAndPaste(files);
@@ -366,6 +413,9 @@ export default function TerminalView({
     host.addEventListener("drop", onDrop, { capture: true });
     return () => {
       cancelled = true;
+      if (pasteClipboardRef.current === pasteFromClipboard) {
+        pasteClipboardRef.current = async () => undefined;
+      }
       host.removeEventListener("paste", onPaste, { capture: true });
       host.removeEventListener("dragenter", onDrag, { capture: true });
       host.removeEventListener("dragover", onDrag, { capture: true });

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -135,7 +135,7 @@ export default function TerminalView({
       const action = classifyTerminalClipboardShortcut({
         type: event.type as "keydown" | "keyup" | "keypress",
         key: event.key,
-        isMac: event.metaKey,
+        isMac: navigator.platform.startsWith("Mac"),
         metaKey: event.metaKey,
         ctrlKey: event.ctrlKey,
         shiftKey: event.shiftKey,
@@ -144,12 +144,14 @@ export default function TerminalView({
         isComposing: event.isComposing,
         hasSelection: terminal.hasSelection(),
       });
-      if (action !== "copy" && action !== "paste") return true;
+      if (!action) return true;
       event.preventDefault();
       if (action === "copy") {
         void copyDesktopTerminalText(terminal.getSelection());
-      } else {
+      } else if (action === "paste") {
         void pasteClipboardRef.current();
+      } else {
+        terminal.selectAll();
       }
       return false;
     });

--- a/desktop/src/renderer/src/features/terminal/terminal-link-actions.ts
+++ b/desktop/src/renderer/src/features/terminal/terminal-link-actions.ts
@@ -2,6 +2,7 @@ import type { ILink, ILinkProvider, Terminal } from "@xterm/xterm";
 import {
   extractTerminalLinkMatches,
   resolveTerminalLink,
+  type TerminalClipboardResult,
   type TerminalLinkEntry,
 } from "@matrix-os/contracts";
 
@@ -91,7 +92,7 @@ export function openDesktopTerminalLink(link: TerminalLinkEntry): void {
   window.open(link.url, "_blank", "noopener,noreferrer");
 }
 
-function fallbackCopy(text: string): void {
+function fallbackCopy(text: string): boolean {
   const textarea = document.createElement("textarea");
   textarea.value = text;
   textarea.style.position = "fixed";
@@ -99,39 +100,40 @@ function fallbackCopy(text: string): void {
   document.body.appendChild(textarea);
   try {
     textarea.select();
-    document.execCommand("copy");
+    return typeof document.execCommand === "function" && document.execCommand("copy");
   } finally {
     textarea.remove();
   }
 }
 
-function tryFallbackCopy(text: string): void {
+function tryFallbackCopy(text: string): TerminalClipboardResult {
   try {
-    fallbackCopy(text);
-  } catch (err: unknown) {
-    console.warn(
-      "Desktop terminal fallback copy failed:",
-      err instanceof Error ? err.message : err,
-    );
-  }
-}
-
-export function copyDesktopTerminalText(text: string): void {
-  if (navigator.clipboard?.writeText) {
-    navigator.clipboard.writeText(text).catch((err: unknown) => {
-      console.warn(
-        "Desktop terminal clipboard write failed, using fallback:",
-        err instanceof Error ? err.message : err,
-      );
-      tryFallbackCopy(text);
+    return fallbackCopy(text) ? "success" : "unavailable";
+  } catch (error: unknown) {
+    console.warn("[terminal] fallback clipboard copy unavailable", {
+      category: error instanceof DOMException ? error.name : "clipboard-error",
     });
-    return;
+    return "unavailable";
   }
-  tryFallbackCopy(text);
 }
 
-export function copyDesktopTerminalLink(link: TerminalLinkEntry): void {
-  copyDesktopTerminalText(link.url);
+export async function copyDesktopTerminalText(text: string): Promise<TerminalClipboardResult> {
+  if (text.length === 0) return "empty";
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return "success";
+    } catch (error: unknown) {
+      console.warn("[terminal] clipboard copy unavailable; trying fallback", {
+        category: error instanceof DOMException ? error.name : "clipboard-error",
+      });
+    }
+  }
+  return tryFallbackCopy(text);
+}
+
+export function copyDesktopTerminalLink(link: TerminalLinkEntry): Promise<TerminalClipboardResult> {
+  return copyDesktopTerminalText(link.url);
 }
 
 export function activateDesktopTerminalLink(

--- a/desktop/src/renderer/src/features/terminal/terminal-rich-paste.ts
+++ b/desktop/src/renderer/src/features/terminal/terminal-rich-paste.ts
@@ -14,6 +14,10 @@ const MIME_BY_EXTENSION = new Map([
 
 export type TerminalPasteFile = { file: File; mimeType: string };
 
+type ClipboardLike = {
+  read?: () => Promise<Array<{ types: readonly string[]; getType(type: string): Promise<Blob> }>>;
+};
+
 export function terminalPasteMimeType(file: File): string | null {
   const typed = file.type.trim().toLowerCase();
   if (SUPPORTED_MIME_TYPES.has(typed)) return typed;
@@ -48,6 +52,24 @@ export function terminalPasteFiles(
         return supported ? [supported] : [];
       });
   return files.slice(0, MAX_TERMINAL_PASTE_FILES);
+}
+
+export async function readTerminalClipboardFiles(
+  clipboard: ClipboardLike | undefined,
+): Promise<TerminalPasteFile[]> {
+  if (!clipboard?.read) return [];
+  const items = await clipboard.read();
+  const supportedItems = items.flatMap((item) => {
+    const mimeType = item.types.find((type) => SUPPORTED_MIME_TYPES.has(type.toLowerCase()));
+    return mimeType ? [{ item, mimeType }] : [];
+  }).slice(0, MAX_TERMINAL_PASTE_FILES);
+  return Promise.all(supportedItems.map(async ({ item, mimeType }) => {
+    const blob = await item.getType(mimeType);
+    return {
+      file: new File([blob], "clipboard-image", { type: mimeType }),
+      mimeType,
+    };
+  }));
 }
 
 export function bracketTerminalPaths(paths: readonly string[]): string {

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -60,6 +60,7 @@ import {
   applyXtermScrollSurface,
   applyXtermSurfaceBackground,
   describeReadyState,
+  isAppleCommandPlatform,
   refreshTerminalRenderer,
   scrollTerminalViewportToBottom,
   shouldDisableWebglRenderer,
@@ -1576,7 +1577,7 @@ export function TerminalPane({
         const clipboardAction = classifyTerminalClipboardShortcut({
           type: ev.type as "keydown" | "keyup" | "keypress",
           key: ev.key,
-          isMac: navigator.platform.startsWith("Mac"),
+          isMac: isAppleCommandPlatform(navigator.platform),
           metaKey: ev.metaKey,
           ctrlKey: ev.ctrlKey,
           shiftKey: ev.shiftKey,

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -1895,7 +1895,7 @@ export function TerminalPane({
         const clipboardAction = classifyTerminalClipboardShortcut({
           type: ev.type as "keydown" | "keyup" | "keypress",
           key: ev.key,
-          isMac: ev.metaKey,
+          isMac: navigator.platform.startsWith("Mac"),
           metaKey: ev.metaKey,
           ctrlKey: ev.ctrlKey,
           shiftKey: ev.shiftKey,
@@ -1931,6 +1931,11 @@ export function TerminalPane({
             });
             showPasteError("Clipboard paste failed. Try again or paste a saved file with `mos shell paste-file`.");
           });
+          return false;
+        }
+        if (clipboardAction === "select-all") {
+          ev.preventDefault();
+          term.selectAll();
           return false;
         }
 

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -2,14 +2,12 @@
 
 import { useCallback, useEffect, useReducer, useRef, useState, type CSSProperties } from "react";
 import { getGatewayUrl, getGatewayWs } from "@/lib/gateway";
-import { capturePostHogEvent, capturePostHogLog } from "@/lib/posthog-client";
 import { createSocketHealth } from "@/lib/socket-health";
-import { isTerminalDebugEnabled } from "@/lib/terminal-debug";
 import { useTerminalSettings } from "@/stores/terminal-settings";
-import { buildAuthenticatedWebSocketUrl, getWebSocketAuthToken } from "@/lib/websocket-auth";
+import { buildAuthenticatedWebSocketUrl } from "@/lib/websocket-auth";
 import type { Theme } from "@/hooks/useTheme";
 import { useVisualViewport } from "@/hooks/useVisualViewport";
-import { ImageAddon, type IImageAddonOptions } from "@xterm/addon-image";
+import { ImageAddon } from "@xterm/addon-image";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { Terminal } from "@xterm/xterm";
 import { classifyTerminalClipboardShortcut } from "@matrix-os/contracts";
@@ -49,6 +47,30 @@ import {
   pasteClipboardIntoTerminal,
 } from "./terminal-rich-paste";
 import {
+  IMAGE_ADDON_OPTIONS,
+  MAX_OSC52_BASE64_LENGTH,
+  OSC52_ALLOWED_TARGETS,
+  TERMINAL_CANONICAL_MAX_COLS,
+  TERMINAL_CANONICAL_MAX_ROWS,
+  TERMINAL_FAST_SCROLL_SENSITIVITY,
+  TERMINAL_MINIMUM_READABLE_FONT_SIZE,
+  TERMINAL_SCROLLBACK_LINES,
+  TERMINAL_SCROLL_SENSITIVITY,
+  applyXtermScrollOptions,
+  applyXtermScrollSurface,
+  applyXtermSurfaceBackground,
+  describeReadyState,
+  refreshTerminalRenderer,
+  scrollTerminalViewportToBottom,
+  shouldDisableWebglRenderer,
+  suppressXtermNativeKeyboard,
+  terminalDebug,
+  terminalTelemetry,
+  toDisposableWebglAddon,
+  type CanonicalReplayRequest,
+  type DisposableWebglAddon,
+} from "./terminal-xterm-runtime";
+import {
   isCanonicalShellSessionId,
   isLegacyPtySessionId,
   terminalWebSocketPathForSession,
@@ -57,16 +79,9 @@ import { createXtermLogger } from "./xterm-logger";
 import { createColdReplayVisibility, type ColdReplayVisibility } from "./cold-replay-visibility";
 import { parseTerminalServerMessage, stripTerminalControls } from "./terminal-server-message";
 import { useTerminalFocusRequest } from "./useTerminalFocusRequest";
+import { useTerminalFilePaste } from "./useTerminalFilePaste";
 import type { TerminalCompatMode } from "@/stores/terminal-store";
 
-const MAX_OSC52_BASE64_LENGTH = 1_000_000;
-const OSC52_ALLOWED_TARGETS = new Set(["", "c", "p", "s", "0", "1", "2", "3", "4", "5", "6", "7"]);
-const BRACKETED_PASTE_OPEN = "\u001b[200~";
-const BRACKETED_PASTE_CLOSE = "\u001b[201~";
-const BRACKETED_PASTE_OVERHEAD = BRACKETED_PASTE_OPEN.length + BRACKETED_PASTE_CLOSE.length;
-const MAX_TERMINAL_INPUT = 65_536;
-const SUPPORTED_TERMINAL_PASTE_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
-const TERMINAL_PASTE_UPLOAD_TIMEOUT_MS = 30_000;
 const TERMINAL_OVERLAY_BASE_STYLE: CSSProperties = {
   position: "absolute",
   top: 8,
@@ -82,226 +97,6 @@ const TERMINAL_OVERLAY_BASE_STYLE: CSSProperties = {
   fontSize: 13,
   boxShadow: "0 2px 8px rgba(0,0,0,0.3)",
 };
-const TERMINAL_PASTE_MIME_BY_EXTENSION = new Map([
-  [".png", "image/png"],
-  [".jpg", "image/jpeg"],
-  [".jpeg", "image/jpeg"],
-  [".gif", "image/gif"],
-  [".webp", "image/webp"],
-]);
-const TERMINAL_SCROLLBACK_LINES = 10_000;
-const TERMINAL_SCROLL_SENSITIVITY = 1;
-const TERMINAL_FAST_SCROLL_SENSITIVITY = 5;
-const TERMINAL_MINIMUM_READABLE_FONT_SIZE = 10;
-const TERMINAL_CANONICAL_MAX_COLS = 500;
-const TERMINAL_CANONICAL_MAX_ROWS = 200;
-const IMAGE_ADDON_OPTIONS: IImageAddonOptions = {
-  enableSizeReports: false,
-  pixelLimit: 4_194_304,
-  storageLimit: 32,
-  showPlaceholder: true,
-  sixelSupport: true,
-  sixelScrolling: true,
-  sixelPaletteLimit: 256,
-  sixelSizeLimit: 8_000_000,
-  iipSupport: true,
-  iipSizeLimit: 8_000_000,
-};
-
-function shouldDisableWebglRenderer(suppressNativeKeyboard: boolean): boolean {
-  if (suppressNativeKeyboard) return true;
-  if (typeof navigator === "undefined") return false;
-  const userAgent = navigator.userAgent;
-  const isAppleMobile = /\b(iPad|iPhone|iPod)\b/.test(userAgent)
-    || (userAgent.includes("Macintosh") && navigator.maxTouchPoints > 1);
-  const isSafari = /Safari\//.test(userAgent) && !/(Chrome|CriOS|FxiOS|EdgiOS)\//.test(userAgent);
-  return isAppleMobile && isSafari;
-}
-
-function terminalPasteMimeType(file: File): string | null {
-  const typed = file.type.trim().toLowerCase();
-  if (SUPPORTED_TERMINAL_PASTE_MIME_TYPES.has(typed)) {
-    return typed;
-  }
-  const dot = file.name.lastIndexOf(".");
-  if (dot < 0) {
-    return null;
-  }
-  return TERMINAL_PASTE_MIME_BY_EXTENSION.get(file.name.slice(dot).toLowerCase()) ?? null;
-}
-
-function isSupportedTerminalPasteFile(file: File | null | undefined): file is File {
-  return Boolean(file && terminalPasteMimeType(file));
-}
-
-function filesFromTerminalFilePayload(payload: DataTransfer | ClipboardEvent["clipboardData"] | null): File[] {
-  if (!payload) {
-    return [];
-  }
-  const files: File[] = [];
-  const items = Array.from(payload.items ?? []);
-  for (const item of items) {
-    if (item.kind === "file") {
-      const file = item.getAsFile();
-      if (isSupportedTerminalPasteFile(file)) {
-        files.push(file);
-      }
-    }
-  }
-  if (files.length > 0) {
-    return files;
-  }
-  return Array.from(payload.files ?? []).filter(isSupportedTerminalPasteFile);
-}
-
-function terminalPasteUploadTimeout(): { signal: AbortSignal; cleanup: () => void } {
-  if (typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function") {
-    return { signal: AbortSignal.timeout(TERMINAL_PASTE_UPLOAD_TIMEOUT_MS), cleanup: () => {} };
-  }
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), TERMINAL_PASTE_UPLOAD_TIMEOUT_MS);
-  return {
-    signal: controller.signal,
-    cleanup: () => clearTimeout(timeout),
-  };
-}
-
-function splitBracketedPastePayload(parts: string[]): string[] {
-  const maxPayloadLength = MAX_TERMINAL_INPUT - BRACKETED_PASTE_OVERHEAD;
-  const payload = parts.filter((part) => part.length > 0).join(" ");
-  const chunks: string[] = [];
-  for (let index = 0; index < payload.length; index += maxPayloadLength) {
-    chunks.push(payload.slice(index, index + maxPayloadLength));
-  }
-  return chunks;
-}
-
-function scrollTerminalViewportToBottom(term: Terminal | null): void {
-  term?.scrollToBottom();
-}
-
-function terminalDebug(event: string, details: Record<string, unknown>): void {
-  if (!isTerminalDebugEnabled()) {
-    return;
-  }
-  console.info("[terminal-debug][pane]", event, details);
-}
-
-function suppressXtermNativeKeyboard(container: HTMLElement): void {
-  const helper = container.querySelector("textarea.xterm-helper-textarea");
-  if (!(helper instanceof HTMLTextAreaElement)) {
-    return;
-  }
-  helper.inputMode = "none";
-  helper.readOnly = true;
-  helper.autocomplete = "off";
-  helper.autocapitalize = "none";
-  helper.spellcheck = false;
-  helper.setAttribute("aria-hidden", "true");
-}
-
-function applyXtermSurfaceBackground(
-  xtermElement: HTMLElement | null | undefined,
-  background: string,
-): void {
-  if (!xtermElement) {
-    return;
-  }
-
-  xtermElement.style.backgroundColor = background;
-  for (const selector of [".xterm-viewport", ".xterm-scrollable-element"]) {
-    const surface = xtermElement.querySelector(selector);
-    if (surface instanceof HTMLElement) {
-      surface.style.backgroundColor = background;
-    }
-  }
-}
-
-function applyXtermScrollSurface(
-  xtermElement: HTMLElement | null | undefined,
-  background: string,
-): void {
-  if (!xtermElement) {
-    return;
-  }
-
-  applyXtermSurfaceBackground(xtermElement, background);
-  xtermElement.classList.add("matrix-terminal-xterm-root");
-  xtermElement.style.width = "100%";
-  xtermElement.style.height = "100%";
-  xtermElement.style.overscrollBehavior = "contain";
-  xtermElement.style.touchAction = "pan-y";
-
-  const viewport = xtermElement.querySelector(".xterm-viewport");
-  if (!(viewport instanceof HTMLElement)) {
-    return;
-  }
-
-  viewport.classList.add("matrix-terminal-xterm-viewport");
-  viewport.style.height = "100%";
-  viewport.style.overflowY = "scroll";
-  viewport.style.setProperty("scrollbar-gutter", "stable");
-  viewport.style.overscrollBehavior = "contain";
-  viewport.style.touchAction = "pan-y";
-}
-
-function applyXtermScrollOptions(term: Terminal): void {
-  term.options.scrollback = TERMINAL_SCROLLBACK_LINES;
-  term.options.scrollSensitivity = TERMINAL_SCROLL_SENSITIVITY;
-  term.options.fastScrollSensitivity = TERMINAL_FAST_SCROLL_SENSITIVITY;
-  term.options.scrollOnUserInput = true;
-}
-
-function refreshTerminalRenderer(term: Terminal): void {
-  if (term.rows <= 0) {
-    return;
-  }
-  term.refresh(0, term.rows - 1);
-}
-
-type DisposableWebglAddon = { dispose: () => void };
-type CanonicalReplayRequest = {
-  mode: "cold-replay" | "cursor-resume";
-  requestedSeq: number;
-};
-
-function toDisposableWebglAddon(addon: unknown): DisposableWebglAddon | null {
-  if (!addon || typeof addon !== "object") {
-    return null;
-  }
-  const dispose = (addon as { dispose?: unknown }).dispose;
-  return typeof dispose === "function" ? (addon as DisposableWebglAddon) : null;
-}
-
-function terminalTelemetry(event: string, properties: Record<string, string | number | boolean | undefined>): void {
-  const payload = {
-    source: "terminal-pane",
-    event,
-    ...properties,
-  };
-  capturePostHogEvent("shell_terminal_ws", payload);
-  capturePostHogLog(event.includes("error") ? "error" : "info", `terminal websocket ${event}`, payload);
-}
-
-function describeReadyState(ws: WebSocket | null): string {
-  if (!ws) {
-    return "null";
-  }
-
-  switch (ws.readyState) {
-    case WebSocket.CONNECTING:
-      return "CONNECTING";
-    case WebSocket.OPEN:
-      return "OPEN";
-    case WebSocket.CLOSING:
-      return "CLOSING";
-    case WebSocket.CLOSED:
-      return "CLOSED";
-    default:
-      return `UNKNOWN(${String((ws as { readyState?: unknown }).readyState)})`;
-  }
-}
-
 interface TerminalPaneProps {
   paneId: string;
   cwd: string;
@@ -558,6 +353,8 @@ export function TerminalPane({
     setPasteError(message);
   };
 
+  useTerminalFilePaste({ containerRef, cwd, sessionIdRef, wsRef });
+
   useEffect(() => {
     isClosingRef.current = !!isClosing;
   }, [isClosing]);
@@ -570,122 +367,6 @@ export function TerminalPane({
       hasReplayCursorRef.current = false;
     }
   }, [initialSessionId]);
-
-  // react-doctor-disable-next-line react-doctor/no-fetch-in-effect -- this effect only registers paste/drop listeners; the fetch runs later from those user event handlers with an AbortSignal timeout.
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    const sendBracketedPaste = (terminalPaths: string[]) => {
-      const ws = wsRef.current;
-      if (ws && ws.readyState === WebSocket.OPEN) {
-        for (const chunk of splitBracketedPastePayload(terminalPaths)) {
-          ws.send(JSON.stringify({
-            type: "input",
-            data: `${BRACKETED_PASTE_OPEN}${chunk}${BRACKETED_PASTE_CLOSE}`,
-          }));
-        }
-      }
-    };
-
-    const uploadAndPasteFiles = async (files: File[]) => {
-      const sessionId = sessionIdRef.current;
-      if (!sessionId) {
-        return;
-      }
-      const terminalPaths: string[] = [];
-      let authToken: string | null = null;
-      try {
-        authToken = await getWebSocketAuthToken();
-      } catch (err: unknown) {
-        console.warn("Terminal paste auth token unavailable:", err instanceof Error ? err.message : err);
-      }
-      for (const file of files) {
-        const mimeType = terminalPasteMimeType(file);
-        if (!mimeType) {
-          continue;
-        }
-        const uploadTimeout = terminalPasteUploadTimeout();
-        // react-doctor-disable-next-line react-doctor/react-compiler-unsupported-syntax, react-hooks-js/todo -- try/finally guarantees each paste upload timeout is cleaned up after this user-triggered event handler finishes.
-        try {
-          const headers: Record<string, string> = {
-            "Content-Type": mimeType,
-            "X-Matrix-Filename": file.name,
-          };
-          if (authToken) {
-            headers.Authorization = `Bearer ${authToken}`;
-          }
-          const url = new URL(`${getGatewayUrl()}/api/terminal/sessions/${encodeURIComponent(sessionId)}/paste-assets`);
-          url.searchParams.set("cwd", cwd || "projects");
-          // react-doctor-disable-next-line react-doctor/async-await-in-loop -- paste uploads are intentionally sequential to preserve terminal insertion order and avoid multiple simultaneous file bodies.
-          const res = await fetch(url.toString(), {
-            method: "POST",
-            credentials: "same-origin",
-            headers,
-            signal: uploadTimeout.signal,
-            body: file,
-          });
-          if (!res.ok) {
-            console.warn(`Terminal paste upload failed: ${res.status}`);
-            continue;
-          }
-          const payload = await res.json() as { terminalPath?: unknown };
-          if (typeof payload.terminalPath === "string") {
-            terminalPaths.push(payload.terminalPath);
-          }
-        } catch (err: unknown) {
-          console.warn("Terminal paste upload failed:", err instanceof Error ? err.message : err);
-        } finally {
-          uploadTimeout.cleanup();
-        }
-      }
-      if (terminalPaths.length > 0) {
-        sendBracketedPaste(terminalPaths);
-      }
-    };
-
-    const captureImagePayload = (event: ClipboardEvent | DragEvent): File[] => {
-      const files = "clipboardData" in event
-        ? filesFromTerminalFilePayload(event.clipboardData)
-        : filesFromTerminalFilePayload(event.dataTransfer);
-      if (files.length === 0) {
-        return [];
-      }
-      event.preventDefault();
-      event.stopPropagation();
-      if ("stopImmediatePropagation" in event) {
-        event.stopImmediatePropagation();
-      }
-      return files;
-    };
-
-    const onPaste = (event: ClipboardEvent) => {
-      const files = captureImagePayload(event);
-      if (files.length > 0) {
-        void uploadAndPasteFiles(files);
-      }
-    };
-    const onDrag = (event: DragEvent) => {
-      captureImagePayload(event);
-    };
-    const onDrop = (event: DragEvent) => {
-      const files = captureImagePayload(event);
-      if (files.length > 0) {
-        void uploadAndPasteFiles(files);
-      }
-    };
-
-    container.addEventListener("paste", onPaste, { capture: true });
-    container.addEventListener("dragenter", onDrag, { capture: true });
-    container.addEventListener("dragover", onDrag, { capture: true });
-    container.addEventListener("drop", onDrop, { capture: true });
-    return () => {
-      container.removeEventListener("paste", onPaste, { capture: true });
-      container.removeEventListener("dragenter", onDrag, { capture: true });
-      container.removeEventListener("dragover", onDrag, { capture: true });
-      container.removeEventListener("drop", onDrop, { capture: true });
-    };
-  }, [cwd]);
 
   // Bridge for the mobile accessory key bar. TerminalApp dispatches a custom
   // window event with the target paneId; we forward to this pane's PTY if it

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -12,6 +12,7 @@ import { useVisualViewport } from "@/hooks/useVisualViewport";
 import { ImageAddon, type IImageAddonOptions } from "@xterm/addon-image";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { Terminal } from "@xterm/xterm";
+import { classifyTerminalClipboardShortcut } from "@matrix-os/contracts";
 import type { TerminalFontFamily, TerminalThemeId } from "@/stores/terminal-settings";
 import { buildXtermTheme, getTerminalMinimumContrastRatio } from "./terminal-themes";
 import { TerminalSearchBar } from "./TerminalSearchBar";
@@ -1880,18 +1881,6 @@ export function TerminalPane({
           return false;
         }
 
-        if (ev.ctrlKey && ev.shiftKey && ev.key === "C") {
-          const selection = term.getSelection();
-          if (selection) {
-            navigator.clipboard.writeText(selection).catch((err: unknown) => {
-              console.warn("Clipboard copy failed:", err instanceof Error ? err.message : err);
-            });
-            term.clearSelection();
-            return false;
-          }
-          return true;
-        }
-
         if (ev.altKey && ev.shiftKey && ev.key.toUpperCase() === "C") {
           const block = commandBlockBufferRef.current.trim();
           if (block) {
@@ -1903,14 +1892,43 @@ export function TerminalPane({
           return true;
         }
 
-        if (ev.ctrlKey && ev.shiftKey && ev.key === "V") {
-          pasteClipboardIntoTerminal({
+        const clipboardAction = classifyTerminalClipboardShortcut({
+          type: ev.type as "keydown" | "keyup" | "keypress",
+          key: ev.key,
+          isMac: ev.metaKey,
+          metaKey: ev.metaKey,
+          ctrlKey: ev.ctrlKey,
+          shiftKey: ev.shiftKey,
+          altKey: ev.altKey,
+          repeat: ev.repeat,
+          isComposing: ev.isComposing,
+          hasSelection: term.getSelection().length > 0,
+        });
+        if (clipboardAction === "copy") {
+          ev.preventDefault();
+          const selection = term.getSelection();
+          void navigator.clipboard?.writeText(selection).catch((error: unknown) => {
+            console.warn("[terminal] clipboard copy unavailable", {
+              category: error instanceof DOMException ? error.name : "clipboard-error",
+            });
+            showPasteError("Clipboard copy failed. Try again.");
+          });
+          return false;
+        }
+        if (clipboardAction === "paste") {
+          ev.preventDefault();
+          void pasteClipboardIntoTerminal({
             clipboard: typeof navigator !== "undefined" ? navigator.clipboard : undefined,
             gatewayUrl: getGatewayUrl(),
             ws: wsRef.current,
-            submit: ev.altKey,
-          }).catch((err: unknown) => {
-            console.warn("Clipboard paste failed:", err instanceof Error ? err.message : err);
+          }).then((result) => {
+            if (result === "failed" || result === "unavailable") {
+              showPasteError("Clipboard paste failed. Try again or paste a saved file with `mos shell paste-file`.");
+            }
+          }).catch((error: unknown) => {
+            console.warn("[terminal] clipboard paste unavailable", {
+              category: error instanceof DOMException ? error.name : "clipboard-error",
+            });
             showPasteError("Clipboard paste failed. Try again or paste a saved file with `mos shell paste-file`.");
           });
           return false;

--- a/shell/src/components/terminal/terminal-file-paste.ts
+++ b/shell/src/components/terminal/terminal-file-paste.ts
@@ -1,0 +1,79 @@
+export const BRACKETED_PASTE_OPEN = "\u001b[200~";
+export const BRACKETED_PASTE_CLOSE = "\u001b[201~";
+
+const BRACKETED_PASTE_OVERHEAD = BRACKETED_PASTE_OPEN.length + BRACKETED_PASTE_CLOSE.length;
+const MAX_TERMINAL_INPUT = 65_536;
+const SUPPORTED_TERMINAL_PASTE_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+const TERMINAL_PASTE_UPLOAD_TIMEOUT_MS = 30_000;
+const TERMINAL_PASTE_MIME_BY_EXTENSION = new Map([
+  [".png", "image/png"],
+  [".jpg", "image/jpeg"],
+  [".jpeg", "image/jpeg"],
+  [".gif", "image/gif"],
+  [".webp", "image/webp"],
+]);
+
+export function terminalPasteMimeType(file: File): string | null {
+  const typed = file.type.trim().toLowerCase();
+  if (SUPPORTED_TERMINAL_PASTE_MIME_TYPES.has(typed)) {
+    return typed;
+  }
+  const dot = file.name.lastIndexOf(".");
+  if (dot < 0) {
+    return null;
+  }
+  return TERMINAL_PASTE_MIME_BY_EXTENSION.get(file.name.slice(dot).toLowerCase()) ?? null;
+}
+
+function isSupportedTerminalPasteFile(file: File | null | undefined): file is File {
+  return Boolean(file && terminalPasteMimeType(file));
+}
+
+export function filesFromTerminalFilePayload(
+  payload: DataTransfer | ClipboardEvent["clipboardData"] | null,
+): File[] {
+  if (!payload) {
+    return [];
+  }
+  const files: File[] = [];
+  const items = Array.from(payload.items ?? []);
+  for (const item of items) {
+    if (item.kind === "file") {
+      const file = item.getAsFile();
+      if (isSupportedTerminalPasteFile(file)) {
+        files.push(file);
+      }
+    }
+  }
+  if (files.length > 0) {
+    return files;
+  }
+  return Array.from(payload.files ?? []).filter(isSupportedTerminalPasteFile);
+}
+
+export function terminalPasteUploadTimeout(): { signal: AbortSignal; cleanup: () => void } {
+  if (typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function") {
+    return { signal: AbortSignal.timeout(TERMINAL_PASTE_UPLOAD_TIMEOUT_MS), cleanup: () => {} };
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TERMINAL_PASTE_UPLOAD_TIMEOUT_MS);
+  return {
+    signal: controller.signal,
+    cleanup: () => clearTimeout(timeout),
+  };
+}
+
+export function splitBracketedPastePayload(parts: string[]): string[] {
+  const maxPayloadLength = MAX_TERMINAL_INPUT - BRACKETED_PASTE_OVERHEAD;
+  const payload = parts.filter((part) => part.length > 0).join(" ");
+  const chunks: string[] = [];
+  for (let index = 0; index < payload.length; index += maxPayloadLength) {
+    chunks.push(payload.slice(index, index + maxPayloadLength));
+  }
+  return chunks;
+}

--- a/shell/src/components/terminal/terminal-rich-paste.ts
+++ b/shell/src/components/terminal/terminal-rich-paste.ts
@@ -35,6 +35,8 @@ type ClipboardImageBlob = {
   type: string;
 };
 
+export type TerminalRichPasteResult = "image" | "text" | "empty" | "unavailable" | "failed";
+
 export function bracketTerminalPaste(text: string): string {
   const safe = text.replace(/\x1b\[20[01]~/g, "");
   const capped = safe.slice(0, MAX_TERMINAL_INPUT - BRACKETED_PASTE_OVERHEAD);
@@ -45,8 +47,15 @@ export function sendBracketedTerminalPaste(ws: TerminalInputSink | null | undefi
   if (!ws || ws.readyState !== WebSocket.OPEN) {
     return false;
   }
-  ws.send(JSON.stringify({ type: "input", data: bracketTerminalPaste(text) }));
-  return true;
+  try {
+    ws.send(JSON.stringify({ type: "input", data: bracketTerminalPaste(text) }));
+    return true;
+  } catch (error: unknown) {
+    console.warn("[terminal] clipboard paste transport failed", {
+      category: error instanceof DOMException ? error.name : "transport-error",
+    });
+    return false;
+  }
 }
 
 function sendFormattedTerminalPaste(input: {
@@ -215,7 +224,7 @@ export async function pasteClipboardDataIntoTerminal(input: {
   gatewayUrl: string;
   ws: TerminalInputSink | null | undefined;
   submit?: boolean;
-}): Promise<"image" | "empty"> {
+}): Promise<"image" | "empty" | "failed"> {
   const imagePaths = await readClipboardDataImagePaths({
     clipboardData: input.clipboardData,
     gatewayUrl: input.gatewayUrl,
@@ -223,12 +232,12 @@ export async function pasteClipboardDataIntoTerminal(input: {
   if (imagePaths.length === 0) {
     return "empty";
   }
-  sendFormattedTerminalPaste({
+  const sent = sendFormattedTerminalPaste({
     ws: input.ws,
     text: formatTerminalPastePrompt(imagePaths),
     submit: input.submit,
   });
-  return "image";
+  return sent ? "image" : "failed";
 }
 
 export async function pasteClipboardIntoTerminal(input: {
@@ -236,7 +245,7 @@ export async function pasteClipboardIntoTerminal(input: {
   gatewayUrl: string;
   ws: TerminalInputSink | null | undefined;
   submit?: boolean;
-}): Promise<"image" | "text" | "empty" | "unavailable"> {
+}): Promise<TerminalRichPasteResult> {
   if (!input.clipboard?.read && !input.clipboard?.readText) {
     return "unavailable";
   }
@@ -248,15 +257,17 @@ export async function pasteClipboardIntoTerminal(input: {
         gatewayUrl: input.gatewayUrl,
       });
       if (imagePaths.length > 0) {
-        sendFormattedTerminalPaste({
+        const sent = sendFormattedTerminalPaste({
           ws: input.ws,
           text: formatTerminalPastePrompt(imagePaths),
           submit: input.submit,
         });
-        return "image";
+        return sent ? "image" : "failed";
       }
-    } catch (err: unknown) {
-      console.warn("Clipboard image paste failed:", err instanceof Error ? err.message : err);
+    } catch (error: unknown) {
+      console.warn("[terminal] clipboard image paste unavailable", {
+        category: error instanceof DOMException ? error.name : "clipboard-error",
+      });
     }
   }
 
@@ -264,10 +275,19 @@ export async function pasteClipboardIntoTerminal(input: {
     return "empty";
   }
 
-  const text = await input.clipboard.readText();
+  let text: string;
+  try {
+    text = await input.clipboard.readText();
+  } catch (error: unknown) {
+    console.warn("[terminal] clipboard text paste unavailable", {
+      category: error instanceof DOMException ? error.name : "clipboard-error",
+    });
+    return "unavailable";
+  }
   if (text.length === 0) {
     return "empty";
   }
-  sendFormattedTerminalPaste({ ws: input.ws, text, submit: input.submit });
-  return "text";
+  return sendFormattedTerminalPaste({ ws: input.ws, text, submit: input.submit })
+    ? "text"
+    : "failed";
 }

--- a/shell/src/components/terminal/terminal-xterm-runtime.ts
+++ b/shell/src/components/terminal/terminal-xterm-runtime.ts
@@ -1,0 +1,177 @@
+import type { IImageAddonOptions } from "@xterm/addon-image";
+import type { Terminal } from "@xterm/xterm";
+import { capturePostHogEvent, capturePostHogLog } from "@/lib/posthog-client";
+import { isTerminalDebugEnabled } from "@/lib/terminal-debug";
+
+export const MAX_OSC52_BASE64_LENGTH = 1_000_000;
+export const OSC52_ALLOWED_TARGETS = new Set([
+  "",
+  "c",
+  "p",
+  "s",
+  "0",
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+]);
+export const TERMINAL_SCROLLBACK_LINES = 10_000;
+export const TERMINAL_SCROLL_SENSITIVITY = 1;
+export const TERMINAL_FAST_SCROLL_SENSITIVITY = 5;
+export const TERMINAL_MINIMUM_READABLE_FONT_SIZE = 10;
+export const TERMINAL_CANONICAL_MAX_COLS = 500;
+export const TERMINAL_CANONICAL_MAX_ROWS = 200;
+export const IMAGE_ADDON_OPTIONS: IImageAddonOptions = {
+  enableSizeReports: false,
+  pixelLimit: 4_194_304,
+  storageLimit: 32,
+  showPlaceholder: true,
+  sixelSupport: true,
+  sixelScrolling: true,
+  sixelPaletteLimit: 256,
+  sixelSizeLimit: 8_000_000,
+  iipSupport: true,
+  iipSizeLimit: 8_000_000,
+};
+
+export type DisposableWebglAddon = { dispose: () => void };
+export type CanonicalReplayRequest = {
+  mode: "cold-replay" | "cursor-resume";
+  requestedSeq: number;
+};
+
+export function shouldDisableWebglRenderer(suppressNativeKeyboard: boolean): boolean {
+  if (suppressNativeKeyboard) return true;
+  if (typeof navigator === "undefined") return false;
+  const userAgent = navigator.userAgent;
+  const isAppleMobile = /\b(iPad|iPhone|iPod)\b/.test(userAgent)
+    || (userAgent.includes("Macintosh") && navigator.maxTouchPoints > 1);
+  const isSafari = /Safari\//.test(userAgent) && !/(Chrome|CriOS|FxiOS|EdgiOS)\//.test(userAgent);
+  return isAppleMobile && isSafari;
+}
+
+export function scrollTerminalViewportToBottom(term: Terminal | null): void {
+  term?.scrollToBottom();
+}
+
+export function terminalDebug(event: string, details: Record<string, unknown>): void {
+  if (!isTerminalDebugEnabled()) {
+    return;
+  }
+  console.info("[terminal-debug][pane]", event, details);
+}
+
+export function suppressXtermNativeKeyboard(container: HTMLElement): void {
+  const helper = container.querySelector("textarea.xterm-helper-textarea");
+  if (!(helper instanceof HTMLTextAreaElement)) {
+    return;
+  }
+  helper.inputMode = "none";
+  helper.readOnly = true;
+  helper.autocomplete = "off";
+  helper.autocapitalize = "none";
+  helper.spellcheck = false;
+  helper.setAttribute("aria-hidden", "true");
+}
+
+export function applyXtermSurfaceBackground(
+  xtermElement: HTMLElement | null | undefined,
+  background: string,
+): void {
+  if (!xtermElement) {
+    return;
+  }
+
+  xtermElement.style.backgroundColor = background;
+  for (const selector of [".xterm-viewport", ".xterm-scrollable-element"]) {
+    const surface = xtermElement.querySelector(selector);
+    if (surface instanceof HTMLElement) {
+      surface.style.backgroundColor = background;
+    }
+  }
+}
+
+export function applyXtermScrollSurface(
+  xtermElement: HTMLElement | null | undefined,
+  background: string,
+): void {
+  if (!xtermElement) {
+    return;
+  }
+
+  applyXtermSurfaceBackground(xtermElement, background);
+  xtermElement.classList.add("matrix-terminal-xterm-root");
+  xtermElement.style.width = "100%";
+  xtermElement.style.height = "100%";
+  xtermElement.style.overscrollBehavior = "contain";
+  xtermElement.style.touchAction = "pan-y";
+
+  const viewport = xtermElement.querySelector(".xterm-viewport");
+  if (!(viewport instanceof HTMLElement)) {
+    return;
+  }
+
+  viewport.classList.add("matrix-terminal-xterm-viewport");
+  viewport.style.height = "100%";
+  viewport.style.overflowY = "scroll";
+  viewport.style.setProperty("scrollbar-gutter", "stable");
+  viewport.style.overscrollBehavior = "contain";
+  viewport.style.touchAction = "pan-y";
+}
+
+export function applyXtermScrollOptions(term: Terminal): void {
+  term.options.scrollback = TERMINAL_SCROLLBACK_LINES;
+  term.options.scrollSensitivity = TERMINAL_SCROLL_SENSITIVITY;
+  term.options.fastScrollSensitivity = TERMINAL_FAST_SCROLL_SENSITIVITY;
+  term.options.scrollOnUserInput = true;
+}
+
+export function refreshTerminalRenderer(term: Terminal): void {
+  if (term.rows <= 0) {
+    return;
+  }
+  term.refresh(0, term.rows - 1);
+}
+
+export function toDisposableWebglAddon(addon: unknown): DisposableWebglAddon | null {
+  if (!addon || typeof addon !== "object") {
+    return null;
+  }
+  const dispose = (addon as { dispose?: unknown }).dispose;
+  return typeof dispose === "function" ? (addon as DisposableWebglAddon) : null;
+}
+
+export function terminalTelemetry(
+  event: string,
+  properties: Record<string, string | number | boolean | undefined>,
+): void {
+  const payload = {
+    source: "terminal-pane",
+    event,
+    ...properties,
+  };
+  capturePostHogEvent("shell_terminal_ws", payload);
+  capturePostHogLog(event.includes("error") ? "error" : "info", `terminal websocket ${event}`, payload);
+}
+
+export function describeReadyState(ws: WebSocket | null): string {
+  if (!ws) {
+    return "null";
+  }
+
+  switch (ws.readyState) {
+    case WebSocket.CONNECTING:
+      return "CONNECTING";
+    case WebSocket.OPEN:
+      return "OPEN";
+    case WebSocket.CLOSING:
+      return "CLOSING";
+    case WebSocket.CLOSED:
+      return "CLOSED";
+    default:
+      return `UNKNOWN(${String((ws as { readyState?: unknown }).readyState)})`;
+  }
+}

--- a/shell/src/components/terminal/terminal-xterm-runtime.ts
+++ b/shell/src/components/terminal/terminal-xterm-runtime.ts
@@ -43,6 +43,10 @@ export type CanonicalReplayRequest = {
   requestedSeq: number;
 };
 
+export function isAppleCommandPlatform(platform: string): boolean {
+  return /^(Mac|iPad|iPhone|iPod)/.test(platform);
+}
+
 export function shouldDisableWebglRenderer(suppressNativeKeyboard: boolean): boolean {
   if (suppressNativeKeyboard) return true;
   if (typeof navigator === "undefined") return false;

--- a/shell/src/components/terminal/useTerminalFilePaste.ts
+++ b/shell/src/components/terminal/useTerminalFilePaste.ts
@@ -1,0 +1,141 @@
+import { useEffect } from "react";
+import { getGatewayUrl } from "@/lib/gateway";
+import { getWebSocketAuthToken } from "@/lib/websocket-auth";
+import {
+  BRACKETED_PASTE_CLOSE,
+  BRACKETED_PASTE_OPEN,
+  filesFromTerminalFilePayload,
+  splitBracketedPastePayload,
+  terminalPasteMimeType,
+  terminalPasteUploadTimeout,
+} from "./terminal-file-paste";
+
+type CurrentRef<T> = { current: T };
+
+interface TerminalFilePasteOptions {
+  containerRef: CurrentRef<HTMLDivElement | null>;
+  cwd: string;
+  sessionIdRef: CurrentRef<string | null>;
+  wsRef: CurrentRef<WebSocket | null>;
+}
+
+export function useTerminalFilePaste({
+  containerRef,
+  cwd,
+  sessionIdRef,
+  wsRef,
+}: TerminalFilePasteOptions): void {
+  // react-doctor-disable-next-line react-doctor/no-fetch-in-effect -- this effect only registers paste/drop listeners; the fetch runs later from those user event handlers with an AbortSignal timeout.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const sendBracketedPaste = (terminalPaths: string[]) => {
+      const ws = wsRef.current;
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        for (const chunk of splitBracketedPastePayload(terminalPaths)) {
+          ws.send(JSON.stringify({
+            type: "input",
+            data: `${BRACKETED_PASTE_OPEN}${chunk}${BRACKETED_PASTE_CLOSE}`,
+          }));
+        }
+      }
+    };
+
+    const uploadAndPasteFiles = async (files: File[]) => {
+      const sessionId = sessionIdRef.current;
+      if (!sessionId) {
+        return;
+      }
+      const terminalPaths: string[] = [];
+      let authToken: string | null = null;
+      try {
+        authToken = await getWebSocketAuthToken();
+      } catch (err: unknown) {
+        console.warn("Terminal paste auth token unavailable:", err instanceof Error ? err.message : err);
+      }
+      for (const file of files) {
+        const mimeType = terminalPasteMimeType(file);
+        if (!mimeType) {
+          continue;
+        }
+        const uploadTimeout = terminalPasteUploadTimeout();
+        // react-doctor-disable-next-line react-doctor/react-compiler-unsupported-syntax, react-hooks-js/todo -- try/finally guarantees each paste upload timeout is cleaned up after this user-triggered event handler finishes.
+        try {
+          const headers: Record<string, string> = {
+            "Content-Type": mimeType,
+            "X-Matrix-Filename": file.name,
+          };
+          if (authToken) {
+            headers.Authorization = `Bearer ${authToken}`;
+          }
+          const url = new URL(`${getGatewayUrl()}/api/terminal/sessions/${encodeURIComponent(sessionId)}/paste-assets`);
+          url.searchParams.set("cwd", cwd || "projects");
+          // react-doctor-disable-next-line react-doctor/async-await-in-loop -- paste uploads are intentionally sequential to preserve terminal insertion order and avoid multiple simultaneous file bodies.
+          const res = await fetch(url.toString(), {
+            method: "POST",
+            credentials: "same-origin",
+            headers,
+            signal: uploadTimeout.signal,
+            body: file,
+          });
+          if (!res.ok) {
+            console.warn(`Terminal paste upload failed: ${res.status}`);
+            continue;
+          }
+          const payload = await res.json() as { terminalPath?: unknown };
+          if (typeof payload.terminalPath === "string") {
+            terminalPaths.push(payload.terminalPath);
+          }
+        } catch (err: unknown) {
+          console.warn("Terminal paste upload failed:", err instanceof Error ? err.message : err);
+        } finally {
+          uploadTimeout.cleanup();
+        }
+      }
+      if (terminalPaths.length > 0) {
+        sendBracketedPaste(terminalPaths);
+      }
+    };
+
+    const captureImagePayload = (event: ClipboardEvent | DragEvent): File[] => {
+      const files = "clipboardData" in event
+        ? filesFromTerminalFilePayload(event.clipboardData)
+        : filesFromTerminalFilePayload(event.dataTransfer);
+      if (files.length === 0) {
+        return [];
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      return files;
+    };
+
+    const onPaste = (event: ClipboardEvent) => {
+      const files = captureImagePayload(event);
+      if (files.length > 0) {
+        void uploadAndPasteFiles(files);
+      }
+    };
+    const onDrag = (event: DragEvent) => {
+      captureImagePayload(event);
+    };
+    const onDrop = (event: DragEvent) => {
+      const files = captureImagePayload(event);
+      if (files.length > 0) {
+        void uploadAndPasteFiles(files);
+      }
+    };
+
+    container.addEventListener("paste", onPaste, { capture: true });
+    container.addEventListener("dragenter", onDrag, { capture: true });
+    container.addEventListener("dragover", onDrag, { capture: true });
+    container.addEventListener("drop", onDrop, { capture: true });
+    return () => {
+      container.removeEventListener("paste", onPaste, { capture: true });
+      container.removeEventListener("dragenter", onDrag, { capture: true });
+      container.removeEventListener("dragover", onDrag, { capture: true });
+      container.removeEventListener("drop", onDrop, { capture: true });
+    };
+  }, [containerRef, cwd, sessionIdRef, wsRef]);
+}

--- a/specs/118-fix-terminal-clipboard/tasks.md
+++ b/specs/118-fix-terminal-clipboard/tasks.md
@@ -50,19 +50,19 @@
 
 ### Tests for User Story 1 — write and observe RED first
 
-- [ ] T008 [P] [US1] Add failing native shortcut, exact-selection, exactly-once paste, repeat, no-selection, and focused-pane tests in `tests/desktop/terminal-view.test.tsx`
-- [ ] T009 [P] [US1] Add failing typed Copy success/unavailable/fallback tests in `tests/desktop/terminal-link-actions.test.ts`
-- [ ] T010 [P] [US1] Add failing web Command/Ctrl shortcut, selection-preservation, exactly-once paste, shell-precedence, and focused-pane tests in `tests/shell/terminal-pane-clipboard.test.tsx`
-- [ ] T011 [P] [US1] Extend text/image/empty/unavailable result and send-once tests in `tests/shell/terminal-rich-paste.test.ts`
-- [ ] T012 [P] [US1] Preserve standard non-terminal native Edit behavior with regression assertions in `tests/desktop/menu-template.test.ts`
+- [x] T008 [P] [US1] Add failing native shortcut, exact-selection, exactly-once paste, repeat, no-selection, and focused-pane tests in `tests/desktop/terminal-view.test.tsx`
+- [x] T009 [P] [US1] Add failing typed Copy success/unavailable/fallback tests in `tests/desktop/terminal-link-actions.test.ts`
+- [x] T010 [P] [US1] Add failing web Command/Ctrl shortcut, selection-preservation, exactly-once paste, shell-precedence, and focused-pane tests in the existing full renderer harness `tests/shell/terminal-pane-scrolling.test.tsx`
+- [x] T011 [P] [US1] Extend text/image/empty/unavailable result and send-once tests in `tests/shell/terminal-rich-paste.test.ts`
+- [x] T012 [P] [US1] Preserve standard non-terminal native Edit behavior with regression assertions in `tests/desktop/menu-template.test.ts`
 
 ### Implementation for User Story 1
 
-- [ ] T013 [US1] Return bounded typed Copy outcomes while preserving the existing fallback path in `desktop/src/renderer/src/features/terminal/terminal-link-actions.ts`
-- [ ] T014 [US1] Classify and execute Command+C, Command+Shift+C, Command+V, and existing Ctrl+Shift shortcuts against the initiating xterm/session exactly once, without clearing selection or auto-submitting, in `desktop/src/renderer/src/features/terminal/TerminalView.tsx` and `desktop/src/renderer/src/features/terminal/terminal-rich-paste.ts`
-- [ ] T015 [US1] Return accurate text/image/empty/unavailable/failed send outcomes from `shell/src/components/terminal/terminal-rich-paste.ts`
-- [ ] T016 [US1] Classify and execute macOS and existing Ctrl+Shift terminal clipboard shortcuts against the focused pane, consume only handled events, and keep selection after Copy in `shell/src/components/terminal/TerminalPane.tsx`
-- [ ] T017 [US1] Run all User Story 1 tests in `tests/contracts/terminal-clipboard.test.ts`, `tests/desktop/terminal-view.test.tsx`, `tests/desktop/terminal-link-actions.test.ts`, `tests/desktop/menu-template.test.ts`, `tests/shell/terminal-pane-clipboard.test.tsx`, and `tests/shell/terminal-rich-paste.test.ts`
+- [x] T013 [US1] Return bounded typed Copy outcomes while preserving the existing fallback path in `desktop/src/renderer/src/features/terminal/terminal-link-actions.ts`
+- [x] T014 [US1] Classify and execute Command+C, Command+Shift+C, Command+V, and existing Ctrl+Shift shortcuts against the initiating xterm/session exactly once, without clearing selection or auto-submitting, in `desktop/src/renderer/src/features/terminal/TerminalView.tsx` and `desktop/src/renderer/src/features/terminal/terminal-rich-paste.ts`
+- [x] T015 [US1] Return accurate text/image/empty/unavailable/failed send outcomes from `shell/src/components/terminal/terminal-rich-paste.ts`
+- [x] T016 [US1] Classify and execute macOS and existing Ctrl+Shift terminal clipboard shortcuts against the focused pane, consume only handled events, and keep selection after Copy in `shell/src/components/terminal/TerminalPane.tsx`
+- [x] T017 [US1] Run all User Story 1 tests in `tests/contracts/terminal-clipboard.test.ts`, `tests/desktop/terminal-view.test.tsx`, `tests/desktop/terminal-link-actions.test.ts`, `tests/desktop/menu-template.test.ts`, `tests/shell/terminal-pane-scrolling.test.tsx`, and `tests/shell/terminal-rich-paste.test.ts`
 
 **Checkpoint**: Shortcut-only MVP is independently usable in native and web terminals. Preserve this phase as Graphite layer 2.
 
@@ -79,13 +79,13 @@
 - [ ] T018 [P] [US2] Upgrade the fake native xterm to install an inner child contextmenu mutation listener and add failing capture-order, `rightClickSelectsWord`, immutable-selection, and Copy-enablement tests in `tests/desktop/terminal-view.test.tsx`
 - [ ] T019 [P] [US2] Add failing immutable snapshot, Copy enablement, Escape/light-dismiss, and origin-focus restoration tests in `tests/desktop/terminal-link-context-menu.test.tsx`
 - [ ] T020 [P] [US2] Add failing general terminal Copy/Select All menu, optional-link action, immutable snapshot, and focus-restoration tests in `tests/shell/terminal-link-context-menu.test.tsx`
-- [ ] T021 [P] [US2] Add failing web inner-xterm context capture and exact multiline/right-click Copy tests in `tests/shell/terminal-pane-clipboard.test.tsx`
+- [ ] T021 [P] [US2] Add failing web inner-xterm context capture and exact multiline/right-click Copy tests in `tests/shell/terminal-pane-scrolling.test.tsx`
 
 ### Implementation for User Story 2
 
 - [ ] T022 [P] [US2] Set `rightClickSelectsWord: false`, capture secondary/contextmenu before xterm, snapshot full xterm selection, and restore still-valid origin focus in `desktop/src/renderer/src/features/terminal/TerminalView.tsx` and `desktop/src/renderer/src/features/terminal/TerminalLinkContextMenu.tsx`
 - [ ] T023 [P] [US2] Generalize the web link-only menu to terminal Copy/Select All plus optional link actions, set `rightClickSelectsWord: false`, and capture the immutable selection before xterm in `shell/src/components/terminal/TerminalPane.tsx` and `shell/src/components/terminal/TerminalLinkContextMenu.tsx`
-- [ ] T024 [US2] Run all User Story 2 tests in `tests/desktop/terminal-view.test.tsx`, `tests/desktop/terminal-link-context-menu.test.tsx`, `tests/shell/terminal-pane-clipboard.test.tsx`, and `tests/shell/terminal-link-context-menu.test.tsx`
+- [ ] T024 [US2] Run all User Story 2 tests in `tests/desktop/terminal-view.test.tsx`, `tests/desktop/terminal-link-context-menu.test.tsx`, `tests/shell/terminal-pane-scrolling.test.tsx`, and `tests/shell/terminal-link-context-menu.test.tsx`
 
 **Checkpoint**: Context-menu Copy is trustworthy and independently testable across both xterm implementations.
 
@@ -122,13 +122,13 @@
 ### Tests for User Story 4 — write and observe RED first
 
 - [ ] T031 [P] [US4] Add failing native Command+A/menu Select All, scrollback selection, passive-motion stability, empty-buffer, and Copy parity tests in `tests/desktop/terminal-view.test.tsx` and `tests/desktop/terminal-link-context-menu.test.tsx`
-- [ ] T032 [P] [US4] Add failing web Command+A/menu Select All, scrollback selection, passive-motion stability, empty-buffer, and Copy parity tests in `tests/shell/terminal-pane-clipboard.test.tsx` and `tests/shell/terminal-link-context-menu.test.tsx`
+- [ ] T032 [P] [US4] Add failing web Command+A/menu Select All, scrollback selection, passive-motion stability, empty-buffer, and Copy parity tests in `tests/shell/terminal-pane-scrolling.test.tsx` and `tests/shell/terminal-link-context-menu.test.tsx`
 
 ### Implementation for User Story 4
 
 - [ ] T033 [P] [US4] Route native Command+A and menu Select All to the originating `terminal.selectAll()` and preserve focus/selection in `desktop/src/renderer/src/features/terminal/TerminalView.tsx` and `desktop/src/renderer/src/features/terminal/TerminalLinkContextMenu.tsx`
 - [ ] T034 [P] [US4] Route web Command+A and menu Select All to the originating `terminal.selectAll()` and preserve focus/selection in `shell/src/components/terminal/TerminalPane.tsx` and `shell/src/components/terminal/TerminalLinkContextMenu.tsx`
-- [ ] T035 [US4] Run all User Story 4 tests in `tests/desktop/terminal-view.test.tsx`, `tests/desktop/terminal-link-context-menu.test.tsx`, `tests/shell/terminal-pane-clipboard.test.tsx`, and `tests/shell/terminal-link-context-menu.test.tsx`
+- [ ] T035 [US4] Run all User Story 4 tests in `tests/desktop/terminal-view.test.tsx`, `tests/desktop/terminal-link-context-menu.test.tsx`, `tests/shell/terminal-pane-scrolling.test.tsx`, and `tests/shell/terminal-link-context-menu.test.tsx`
 
 **Checkpoint**: Select All is independently usable in native and web terminals.
 
@@ -166,14 +166,14 @@
 ### Tests for User Story 6 — write and observe RED first
 
 - [ ] T043 [P] [US6] Add failing native clipboard denial, fallback failure, generic feedback, selection retention, stale-session cancellation, unmount, and exactly-once retry tests in `tests/desktop/terminal-link-actions.test.ts` and `tests/desktop/terminal-view.test.tsx`
-- [ ] T044 [P] [US6] Add failing web clipboard denial, disconnected transport, stale-pane cancellation, generic feedback, zero-write failure, and exactly-once retry tests in `tests/shell/terminal-rich-paste.test.ts` and `tests/shell/terminal-pane-clipboard.test.tsx`
+- [ ] T044 [P] [US6] Add failing web clipboard denial, disconnected transport, stale-pane cancellation, generic feedback, zero-write failure, and exactly-once retry tests in `tests/shell/terminal-rich-paste.test.ts` and `tests/shell/terminal-pane-scrolling.test.tsx`
 - [ ] T045 [US6] Add privacy assertions that UI and diagnostics never contain selected text, clipboard text, raw errors, provider details, paths, filenames, or session IDs in `tests/desktop/terminal-view.test.tsx` and `tests/shell/terminal-pane-privacy.test.tsx` after T043–T044
 
 ### Implementation for User Story 6
 
 - [ ] T046 [P] [US6] Add bounded native clipboard operation state, safe generic feedback, and session-generation/unmount cancellation in `desktop/src/renderer/src/features/terminal/TerminalView.tsx`, `desktop/src/renderer/src/features/terminal/terminal-link-actions.ts`, and `desktop/src/renderer/src/features/terminal/terminal-rich-paste.ts`
 - [ ] T047 [P] [US6] Add bounded web clipboard outcomes, safe generic feedback, and pane/socket generation cancellation in `shell/src/components/terminal/TerminalPane.tsx` and `shell/src/components/terminal/terminal-rich-paste.ts`
-- [ ] T048 [US6] Run all User Story 6 tests in `tests/desktop/terminal-link-actions.test.ts`, `tests/desktop/terminal-view.test.tsx`, `tests/shell/terminal-rich-paste.test.ts`, `tests/shell/terminal-pane-clipboard.test.tsx`, and `tests/shell/terminal-pane-privacy.test.tsx`
+- [ ] T048 [US6] Run all User Story 6 tests in `tests/desktop/terminal-link-actions.test.ts`, `tests/desktop/terminal-view.test.tsx`, `tests/shell/terminal-rich-paste.test.ts`, `tests/shell/terminal-pane-scrolling.test.tsx`, and `tests/shell/terminal-pane-privacy.test.tsx`
 
 **Checkpoint**: Clipboard failures are safe, private, retryable, and independently testable.
 
@@ -255,7 +255,7 @@ All stories -> E2E / CI / evidence / docs
 Task T018: Native inner-xterm context ordering tests in tests/desktop/terminal-view.test.tsx
 Task T019: Native menu snapshot/focus tests in tests/desktop/terminal-link-context-menu.test.tsx
 Task T020: Web menu snapshot/focus tests in tests/shell/terminal-link-context-menu.test.tsx
-Task T021: Web inner-xterm context ordering tests in tests/shell/terminal-pane-clipboard.test.tsx
+Task T021: Web inner-xterm context ordering tests in tests/shell/terminal-pane-scrolling.test.tsx
 ```
 
 ## Parallel Example: User Story 5

--- a/tests/desktop/menu-template.test.ts
+++ b/tests/desktop/menu-template.test.ts
@@ -2,6 +2,20 @@ import { describe, expect, it, vi } from "vitest";
 import { createAppMenuTemplate } from "../../desktop/src/main/platform/menu-template";
 
 describe("createAppMenuTemplate", () => {
+  it("preserves Electron's standard non-terminal Edit menu roles", () => {
+    const template = createAppMenuTemplate({
+      appName: "Matrix OS",
+      isPackaged: true,
+      openExternal: vi.fn(),
+      send: vi.fn(),
+      adjustZoom: vi.fn(),
+      checkForUpdates: vi.fn(),
+      quitApp: vi.fn(),
+    });
+
+    expect(template.some((item) => item.role === "editMenu")).toBe(true);
+  });
+
   it("offers Check for Updates in installed and development application menus", () => {
     for (const isPackaged of [true, false]) {
       const checkForUpdates = vi.fn();

--- a/tests/desktop/terminal-link-actions.test.ts
+++ b/tests/desktop/terminal-link-actions.test.ts
@@ -6,10 +6,13 @@ import {
   DesktopWebLinkProvider,
   activateDesktopTerminalLink,
   copyDesktopTerminalLink,
+  copyDesktopTerminalText,
   findDesktopTerminalLinkAtCell,
   findDesktopTerminalLinkAtPointer,
   resolveDesktopTerminalLink,
 } from "@desktop/renderer/src/features/terminal/terminal-link-actions";
+
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
 
 const LINK = {
   url: "https://example.org/final-check",
@@ -19,7 +22,14 @@ const LINK = {
 };
 
 describe("desktop terminal link actions", () => {
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalClipboardDescriptor) {
+      Object.defineProperty(navigator, "clipboard", originalClipboardDescriptor);
+    } else {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
+  });
 
   it("keeps a secondary-button OSC activation inert", () => {
     const open = vi.spyOn(window, "open").mockReturnValue(null);
@@ -73,6 +83,49 @@ describe("desktop terminal link actions", () => {
     copyDesktopTerminalLink(LINK);
 
     expect(writeText).toHaveBeenCalledWith(LINK.url);
+  });
+
+  it("returns success after writing the exact terminal selection", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const selection = "first row\nλ second row 👩🏽‍💻";
+
+    await expect(copyDesktopTerminalText(selection)).resolves.toBe("success");
+
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(writeText).toHaveBeenCalledWith(selection);
+  });
+
+  it("falls back when clipboard write is unavailable and reports success", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    const execCommand = vi.fn(() => true);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    await expect(copyDesktopTerminalText("fallback selection")).resolves.toBe("success");
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("reports unavailable when both clipboard paths reject the copy", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new DOMException("denied", "NotAllowedError")) },
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: vi.fn(() => false),
+    });
+
+    await expect(copyDesktopTerminalText("private selection")).resolves.toBe("unavailable");
   });
 
   it("detects plain-text URLs and does not activate them on secondary click", () => {

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -14,6 +14,7 @@ import {
 } from "@desktop/renderer/src/features/terminal/terminal-rich-paste";
 
 const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(navigator, "platform");
 const attachMock = vi.fn();
 const attachmentWrite = vi.fn();
 const attachmentResize = vi.fn();
@@ -153,6 +154,10 @@ vi.mock("@desktop/renderer/src/features/terminal/terminal-runtime", () => ({
 
 describe("TerminalView session switching", () => {
   beforeEach(() => {
+    Object.defineProperty(navigator, "platform", {
+      configurable: true,
+      value: "MacIntel",
+    });
     createdFitAddons.length = 0;
     createdTerminals.length = 0;
     resizeObserverCallbacks.length = 0;
@@ -197,6 +202,11 @@ describe("TerminalView session switching", () => {
       Object.defineProperty(navigator, "clipboard", originalClipboardDescriptor);
     } else {
       Reflect.deleteProperty(navigator, "clipboard");
+    }
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(navigator, "platform", originalPlatformDescriptor);
+    } else {
+      Reflect.deleteProperty(navigator, "platform");
     }
   });
 
@@ -523,6 +533,60 @@ describe("TerminalView session switching", () => {
 
     expect(withoutSelection).toBe(true);
     expect(repeated).toBe(true);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("selects all terminal scrollback with Command+A", () => {
+    render(<TerminalView sessionName="alpha" />);
+    const terminal = createdTerminals.at(-1)!;
+    const preventDefault = vi.fn();
+
+    const handled = terminal.customKeyEventHandler?.({
+      type: "keydown",
+      key: "a",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      repeat: false,
+      isComposing: false,
+      preventDefault,
+    } as unknown as KeyboardEvent);
+
+    expect(handled).toBe(false);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(terminal.selectAll).toHaveBeenCalledOnce();
+  });
+
+  it("does not treat Meta+C as a macOS shortcut on non-Mac platforms", () => {
+    Object.defineProperty(navigator, "platform", {
+      configurable: true,
+      value: "Linux x86_64",
+    });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    render(<TerminalView sessionName="alpha" />);
+    const terminal = createdTerminals.at(-1)!;
+    terminal.selection = "leave this selection alone";
+    const preventDefault = vi.fn();
+
+    const handled = terminal.customKeyEventHandler?.({
+      type: "keydown",
+      key: "c",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      repeat: false,
+      isComposing: false,
+      preventDefault,
+    } as unknown as KeyboardEvent);
+
+    expect(handled).toBe(true);
+    expect(preventDefault).not.toHaveBeenCalled();
     expect(writeText).not.toHaveBeenCalled();
   });
 

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -34,6 +34,7 @@ const { createdFitAddons, createdTerminals, resizeObserverCallbacks } = vi.hoist
     blur: ReturnType<typeof vi.fn>;
     selection: string;
     customKeyEventHandler?: (event: KeyboardEvent) => boolean;
+    paste: ReturnType<typeof vi.fn>;
     selectAll: ReturnType<typeof vi.fn>;
     reset: ReturnType<typeof vi.fn>;
   }>,
@@ -67,6 +68,7 @@ vi.mock("@xterm/xterm", () => ({
     registeredProviders: unknown[] = [];
     selection = "";
     customKeyEventHandler?: (event: KeyboardEvent) => boolean;
+    paste = vi.fn((text: string) => this.dataCallback?.(text));
     selectAll = vi.fn();
     reset = vi.fn();
 
@@ -452,7 +454,11 @@ describe("TerminalView session switching", () => {
     );
   });
 
-  it("copies the xterm selection with the desktop copy shortcut", () => {
+  it.each([
+    { label: "Command+C", metaKey: true, ctrlKey: false, shiftKey: false },
+    { label: "Command+Shift+C", metaKey: true, ctrlKey: false, shiftKey: true },
+    { label: "Ctrl+Shift+C", metaKey: false, ctrlKey: true, shiftKey: true },
+  ])("copies the exact xterm selection once with $label", async ({ metaKey, ctrlKey, shiftKey }) => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
@@ -460,23 +466,171 @@ describe("TerminalView session switching", () => {
     });
     render(<TerminalView sessionName="alpha" />);
     const terminal = createdTerminals.at(-1)!;
-    terminal.selection = "HTTP/1.1 401 Unauthorized";
+    terminal.selection = "HTTP/1.1 401 Unauthorized\nλ-value: 👩🏽‍💻";
     const preventDefault = vi.fn();
 
     const handled = terminal.customKeyEventHandler?.({
+      type: "keydown",
+      key: "c",
+      metaKey,
+      ctrlKey,
+      shiftKey,
+      altKey: false,
+      repeat: false,
+      isComposing: false,
+      preventDefault,
+    } as unknown as KeyboardEvent);
+
+    expect(handled).toBe(false);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(writeText).toHaveBeenCalledWith("HTTP/1.1 401 Unauthorized\nλ-value: 👩🏽‍💻");
+    expect(attachmentWrite).not.toHaveBeenCalled();
+  });
+
+  it("leaves copy unhandled without a selection and ignores repeated shortcuts", () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    render(<TerminalView sessionName="alpha" />);
+    const terminal = createdTerminals.at(-1)!;
+
+    const withoutSelection = terminal.customKeyEventHandler?.({
       type: "keydown",
       key: "c",
       metaKey: true,
       ctrlKey: false,
       shiftKey: false,
       altKey: false,
+      repeat: false,
+      isComposing: false,
+      preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent);
+    terminal.selection = "do not duplicate";
+    const repeated = terminal.customKeyEventHandler?.({
+      type: "keydown",
+      key: "c",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      repeat: true,
+      isComposing: false,
+      preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent);
+
+    expect(withoutSelection).toBe(true);
+    expect(repeated).toBe(true);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { label: "Command+V", metaKey: true, ctrlKey: false, shiftKey: false },
+    { label: "Ctrl+Shift+V", metaKey: false, ctrlKey: true, shiftKey: true },
+  ])("pastes clipboard text once without Enter with $label", async ({ metaKey, ctrlKey, shiftKey }) => {
+    const readText = vi.fn().mockResolvedValue("printf 'λ 👩🏽‍💻'");
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { readText },
+    });
+    render(<TerminalView sessionName="alpha" />);
+    const terminal = createdTerminals.at(-1)!;
+    const preventDefault = vi.fn();
+
+    const handled = terminal.customKeyEventHandler?.({
+      type: "keydown",
+      key: "v",
+      metaKey,
+      ctrlKey,
+      shiftKey,
+      altKey: false,
+      repeat: false,
+      isComposing: false,
       preventDefault,
     } as unknown as KeyboardEvent);
 
     expect(handled).toBe(false);
     expect(preventDefault).toHaveBeenCalledOnce();
-    expect(writeText).toHaveBeenCalledWith("HTTP/1.1 401 Unauthorized");
-    expect(attachmentWrite).not.toHaveBeenCalled();
+    await waitFor(() => expect(terminal.paste).toHaveBeenCalledWith("printf 'λ 👩🏽‍💻'"));
+    expect(readText).toHaveBeenCalledOnce();
+    expect(terminal.paste).toHaveBeenCalledOnce();
+    expect(attachmentWrite).toHaveBeenCalledOnce();
+    expect(attachmentWrite).toHaveBeenCalledWith("printf 'λ 👩🏽‍💻'");
+    expect(attachmentWrite.mock.calls[0]?.[0]).not.toMatch(/[\r\n]$/);
+  });
+
+  it("keeps rich image paste precedence for Command+V", async () => {
+    const blob = new Blob(["image"], { type: "image/png" });
+    const readText = vi.fn().mockResolvedValue("text fallback");
+    const read = vi.fn().mockResolvedValue([{
+      types: ["image/png"],
+      getType: vi.fn().mockResolvedValue(blob),
+    }]);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { read, readText },
+    });
+    const postBytes = vi.fn(async () => ({
+      terminalPath: "/home/matrix/home/data/terminal-paste/clipboard.png",
+    }));
+    useConnection.setState({ api: { postBytes } as never });
+    render(<TerminalView sessionName="alpha" />);
+    const terminal = createdTerminals.at(-1)!;
+
+    terminal.customKeyEventHandler?.({
+      type: "keydown",
+      key: "v",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      repeat: false,
+      isComposing: false,
+      preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent);
+
+    await waitFor(() => expect(attachmentWrite).toHaveBeenCalledWith(
+      "\x1b[200~/home/matrix/home/data/terminal-paste/clipboard.png\x1b[201~",
+    ));
+    expect(read).toHaveBeenCalledOnce();
+    expect(readText).not.toHaveBeenCalled();
+    expect(terminal.paste).not.toHaveBeenCalled();
+    expect(postBytes).toHaveBeenCalledOnce();
+  });
+
+  it("keeps clipboard shortcuts pane-local when multiple terminals exist", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    render(
+      <>
+        <TerminalView sessionName="alpha" active={false} />
+        <TerminalView sessionName="beta" />
+      </>,
+    );
+    const first = createdTerminals[0]!;
+    const focused = createdTerminals[1]!;
+    first.selection = "wrong pane";
+    focused.selection = "focused pane";
+
+    focused.customKeyEventHandler?.({
+      type: "keydown",
+      key: "c",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      repeat: false,
+      isComposing: false,
+      preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent);
+
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(writeText).toHaveBeenCalledWith("focused pane");
   });
 
   it("opens terminal actions on right click and copies the xterm selection", () => {

--- a/tests/e2e/desktop/project-folder-picker-layout.e2e.test.ts
+++ b/tests/e2e/desktop/project-folder-picker-layout.e2e.test.ts
@@ -82,7 +82,6 @@ suite("Desktop Add Project compact folder picker", () => {
 
   it("keeps the sticky list header flush with the toolbar while rows scroll beneath it", async () => {
     await page.getByRole("button", { name: "Chat", exact: true }).dblclick();
-    await page.getByRole("button", { name: "Show Chat navigation" }).click();
     await page.getByRole("navigation", { name: "Chat navigation" }).waitFor();
     await page.getByRole("button", { name: "Create project" }).click();
     const dialog = page.getByRole("dialog", { name: "Create a project" });

--- a/tests/observability/posthog-error-tracking.test.ts
+++ b/tests/observability/posthog-error-tracking.test.ts
@@ -641,15 +641,16 @@ describe("PostHog error tracking", () => {
   });
 
   it("tracks terminal websocket lifecycle without terminal output payloads", async () => {
-    const [terminalPane, gatewayServer] = await Promise.all([
+    const [terminalPane, terminalRuntime, gatewayServer] = await Promise.all([
       readFile("shell/src/components/terminal/TerminalPane.tsx", "utf8"),
+      readFile("shell/src/components/terminal/terminal-xterm-runtime.ts", "utf8"),
       readFile("packages/gateway/src/server.ts", "utf8"),
     ]);
 
-    expect(terminalPane).toContain('capturePostHogEvent("shell_terminal_ws"');
-    expect(terminalPane).toContain("capturePostHogLog");
+    expect(terminalRuntime).toContain('capturePostHogEvent("shell_terminal_ws"');
+    expect(terminalRuntime).toContain("capturePostHogLog");
     expect(terminalPane).toContain('track("schedule-reconnect"');
-    expect(terminalPane).not.toContain("capturePostHogEvent(\"shell_terminal_ws\", { data");
+    expect(terminalRuntime).not.toContain("capturePostHogEvent(\"shell_terminal_ws\", { data");
     expect(gatewayServer).toContain('posthogErrorTracker.captureEvent("gateway_terminal_ws"');
     expect(gatewayServer).toContain('captureTerminalEvent("attach-request"');
     expect(gatewayServer).not.toContain('captureTerminalEvent("input"');

--- a/tests/shell/terminal-file-paste.test.ts
+++ b/tests/shell/terminal-file-paste.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  BRACKETED_PASTE_CLOSE,
+  BRACKETED_PASTE_OPEN,
+  filesFromTerminalFilePayload,
+  splitBracketedPastePayload,
+  terminalPasteMimeType,
+} from "../../shell/src/components/terminal/terminal-file-paste.js";
+
+function file(name: string, type = ""): File {
+  return { name, type } as File;
+}
+
+describe("terminal file paste", () => {
+  it("accepts supported image MIME types and falls back to the filename extension", () => {
+    expect(terminalPasteMimeType(file("capture.bin", "IMAGE/PNG"))).toBe("image/png");
+    expect(terminalPasteMimeType(file("capture.JPEG"))).toBe("image/jpeg");
+    expect(terminalPasteMimeType(file("notes.txt", "text/plain"))).toBeNull();
+  });
+
+  it("captures every supported file item before asynchronous upload work starts", () => {
+    const png = file("one.png");
+    const webp = file("two.webp");
+    const payload = {
+      items: [
+        { kind: "file", getAsFile: () => png },
+        { kind: "string", getAsFile: () => null },
+        { kind: "file", getAsFile: () => webp },
+      ],
+      files: [],
+    } as unknown as DataTransfer;
+
+    expect(filesFromTerminalFilePayload(payload)).toEqual([png, webp]);
+  });
+
+  it("splits bracketed paste payloads without exceeding the terminal input limit", () => {
+    const chunks = splitBracketedPastePayload(["a".repeat(70_000), "tail"]);
+    const overhead = BRACKETED_PASTE_OPEN.length + BRACKETED_PASTE_CLOSE.length;
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks.join("")).toBe(`${"a".repeat(70_000)} tail`);
+    expect(chunks.every((chunk) => chunk.length + overhead <= 65_536)).toBe(true);
+  });
+});

--- a/tests/shell/terminal-pane-scrolling.test.tsx
+++ b/tests/shell/terminal-pane-scrolling.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
 import React from "react";
 import { act, render, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
 
 const createdTerminals = vi.hoisted(() => [] as Array<{
   options: Record<string, unknown>;
@@ -16,6 +18,9 @@ const createdTerminals = vi.hoisted(() => [] as Array<{
   resize: ReturnType<typeof vi.fn>;
   write: ReturnType<typeof vi.fn>;
   reset: ReturnType<typeof vi.fn>;
+  selection: string;
+  customKeyEventHandler?: (event: KeyboardEvent) => boolean;
+  clearSelection: ReturnType<typeof vi.fn>;
 }>);
 
 const createdFitAddons = vi.hoisted(() => [] as Array<{
@@ -166,6 +171,8 @@ vi.mock("@xterm/xterm", () => ({
       }
     };
     reset = vi.fn();
+    selection = "";
+    customKeyEventHandler?: (event: KeyboardEvent) => boolean;
     dispose = vi.fn();
     resize = vi.fn((cols: number, rows: number) => {
       this.cols = cols;
@@ -178,9 +185,11 @@ vi.mock("@xterm/xterm", () => ({
     });
     emitData = (data: string) => this.dataListener?.(data);
     onResize = vi.fn(() => ({ dispose: vi.fn() }));
-    attachCustomKeyEventHandler = vi.fn();
+    attachCustomKeyEventHandler = vi.fn((handler: (event: KeyboardEvent) => boolean) => {
+      this.customKeyEventHandler = handler;
+    });
     clearSelection = vi.fn();
-    getSelection = vi.fn(() => "");
+    getSelection = vi.fn(() => this.selection);
     scrollToBottom = vi.fn();
     registerLinkProvider = vi.fn();
 
@@ -462,6 +471,162 @@ describe("TerminalPane scrolling", () => {
     });
     socketHealthConfigs.length = 0;
     Reflect.deleteProperty(window, "visualViewport");
+  });
+
+  afterEach(() => {
+    if (originalClipboardDescriptor) {
+      Object.defineProperty(navigator, "clipboard", originalClipboardDescriptor);
+    } else {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
+  });
+
+  it.each([
+    { label: "Command+C", metaKey: true, ctrlKey: false, shiftKey: false },
+    { label: "Command+Shift+C", metaKey: true, ctrlKey: false, shiftKey: true },
+    { label: "Ctrl+Shift+C", metaKey: false, ctrlKey: true, shiftKey: true },
+  ])("copies the focused pane selection once with $label and keeps it selected", async ({ metaKey, ctrlKey, shiftKey }) => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    render(
+      <TerminalPane
+        paneId="pane-clipboard-copy"
+        cwd=""
+        theme={theme}
+        isFocused
+        sessionId="main"
+        isClosing={false}
+        shouldCacheOnUnmount={() => false}
+        shouldDestroyOnUnmount={() => false}
+        onFocus={() => {}}
+      />,
+    );
+    await waitFor(() => expect(createdTerminals[0]?.customKeyEventHandler).toBeTypeOf("function"));
+    const terminal = createdTerminals[0]!;
+    terminal.selection = "first row\nλ second row 👩🏽‍💻";
+    const preventDefault = vi.fn();
+
+    const handled = terminal.customKeyEventHandler?.({
+      type: "keydown",
+      key: "c",
+      metaKey,
+      ctrlKey,
+      shiftKey,
+      altKey: false,
+      repeat: false,
+      isComposing: false,
+      preventDefault,
+    } as unknown as KeyboardEvent);
+
+    expect(handled).toBe(false);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(writeText).toHaveBeenCalledWith("first row\nλ second row 👩🏽‍💻");
+    expect(terminal.clearSelection).not.toHaveBeenCalled();
+    expect(terminal.selection).toBe("first row\nλ second row 👩🏽‍💻");
+  });
+
+  it.each([
+    { label: "Command+V", metaKey: true, ctrlKey: false, shiftKey: false },
+    { label: "Ctrl+Shift+V", metaKey: false, ctrlKey: true, shiftKey: true },
+  ])("pastes into the initiating pane exactly once without Enter with $label", async ({ metaKey, ctrlKey, shiftKey }) => {
+    const readText = vi.fn().mockResolvedValue("printf 'λ 👩🏽‍💻'");
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { readText },
+    });
+    render(
+      <TerminalPane
+        paneId="pane-clipboard-paste"
+        cwd=""
+        theme={theme}
+        isFocused
+        sessionId="main"
+        isClosing={false}
+        shouldCacheOnUnmount={() => false}
+        shouldDestroyOnUnmount={() => false}
+        onFocus={() => {}}
+      />,
+    );
+    await waitFor(() => expect(WebSocketMock.instances).toHaveLength(1));
+    const terminal = createdTerminals[0]!;
+    const socket = WebSocketMock.instances[0]!;
+    socket.send.mockClear();
+    const preventDefault = vi.fn();
+
+    const handled = terminal.customKeyEventHandler?.({
+      type: "keydown",
+      key: "v",
+      metaKey,
+      ctrlKey,
+      shiftKey,
+      altKey: false,
+      repeat: false,
+      isComposing: false,
+      preventDefault,
+    } as unknown as KeyboardEvent);
+
+    expect(handled).toBe(false);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    await waitFor(() => expect(socket.send).toHaveBeenCalledOnce());
+    expect(readText).toHaveBeenCalledOnce();
+    expect(JSON.parse(socket.send.mock.calls[0]![0])).toEqual({
+      type: "input",
+      data: "\x1b[200~printf 'λ 👩🏽‍💻'\x1b[201~",
+    });
+  });
+
+  it("leaves clipboard shortcuts to the shell when no terminal action can run", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn() },
+    });
+    render(
+      <TerminalPane
+        paneId="pane-clipboard-precedence"
+        cwd=""
+        theme={theme}
+        isFocused
+        sessionId="main"
+        isClosing={false}
+        shouldCacheOnUnmount={() => false}
+        shouldDestroyOnUnmount={() => false}
+        onFocus={() => {}}
+      />,
+    );
+    await waitFor(() => expect(createdTerminals[0]?.customKeyEventHandler).toBeTypeOf("function"));
+    const terminal = createdTerminals[0]!;
+    const preventDefault = vi.fn();
+
+    const withoutSelection = terminal.customKeyEventHandler?.({
+      type: "keydown",
+      key: "c",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      repeat: false,
+      isComposing: false,
+      preventDefault,
+    } as unknown as KeyboardEvent);
+    const repeatedPaste = terminal.customKeyEventHandler?.({
+      type: "keydown",
+      key: "v",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      repeat: true,
+      isComposing: false,
+      preventDefault,
+    } as unknown as KeyboardEvent);
+
+    expect(withoutSelection).toBe(true);
+    expect(repeatedPaste).toBe(true);
+    expect(preventDefault).not.toHaveBeenCalled();
   });
 
   it("attaches desktop canonical sessions as hard clients with proposed dimensions", async () => {

--- a/tests/shell/terminal-pane-scrolling.test.tsx
+++ b/tests/shell/terminal-pane-scrolling.test.tsx
@@ -4,6 +4,7 @@ import { act, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(navigator, "platform");
 
 const createdTerminals = vi.hoisted(() => [] as Array<{
   options: Record<string, unknown>;
@@ -21,6 +22,7 @@ const createdTerminals = vi.hoisted(() => [] as Array<{
   selection: string;
   customKeyEventHandler?: (event: KeyboardEvent) => boolean;
   clearSelection: ReturnType<typeof vi.fn>;
+  selectAll: ReturnType<typeof vi.fn>;
 }>);
 
 const createdFitAddons = vi.hoisted(() => [] as Array<{
@@ -189,6 +191,7 @@ vi.mock("@xterm/xterm", () => ({
       this.customKeyEventHandler = handler;
     });
     clearSelection = vi.fn();
+    selectAll = vi.fn();
     getSelection = vi.fn(() => this.selection);
     scrollToBottom = vi.fn();
     registerLinkProvider = vi.fn();
@@ -428,6 +431,10 @@ function createCachedTerminal() {
 
 describe("TerminalPane scrolling", () => {
   beforeEach(() => {
+    Object.defineProperty(navigator, "platform", {
+      configurable: true,
+      value: "MacIntel",
+    });
     createdTerminals.length = 0;
     createdFitAddons.length = 0;
     createdWebglAddons.length = 0;
@@ -478,6 +485,11 @@ describe("TerminalPane scrolling", () => {
       Object.defineProperty(navigator, "clipboard", originalClipboardDescriptor);
     } else {
       Reflect.deleteProperty(navigator, "clipboard");
+    }
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(navigator, "platform", originalPlatformDescriptor);
+    } else {
+      Reflect.deleteProperty(navigator, "platform");
     }
   });
 
@@ -627,6 +639,86 @@ describe("TerminalPane scrolling", () => {
     expect(withoutSelection).toBe(true);
     expect(repeatedPaste).toBe(true);
     expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("selects all terminal scrollback with Command+A", async () => {
+    render(
+      <TerminalPane
+        paneId="pane-select-all"
+        cwd=""
+        theme={theme}
+        isFocused
+        sessionId="main"
+        isClosing={false}
+        shouldCacheOnUnmount={() => false}
+        shouldDestroyOnUnmount={() => false}
+        onFocus={() => {}}
+      />,
+    );
+    await waitFor(() => expect(createdTerminals[0]?.customKeyEventHandler).toBeTypeOf("function"));
+    const terminal = createdTerminals[0]!;
+    const preventDefault = vi.fn();
+
+    const handled = terminal.customKeyEventHandler?.({
+      type: "keydown",
+      key: "a",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      repeat: false,
+      isComposing: false,
+      preventDefault,
+    } as unknown as KeyboardEvent);
+
+    expect(handled).toBe(false);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(terminal.selectAll).toHaveBeenCalledOnce();
+  });
+
+  it("does not treat Meta+C as a macOS shortcut on non-Mac platforms", async () => {
+    Object.defineProperty(navigator, "platform", {
+      configurable: true,
+      value: "Linux x86_64",
+    });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    render(
+      <TerminalPane
+        paneId="pane-non-mac-meta"
+        cwd=""
+        theme={theme}
+        isFocused
+        sessionId="main"
+        isClosing={false}
+        shouldCacheOnUnmount={() => false}
+        shouldDestroyOnUnmount={() => false}
+        onFocus={() => {}}
+      />,
+    );
+    await waitFor(() => expect(createdTerminals[0]?.customKeyEventHandler).toBeTypeOf("function"));
+    const terminal = createdTerminals[0]!;
+    terminal.selection = "leave this selection alone";
+    const preventDefault = vi.fn();
+
+    const handled = terminal.customKeyEventHandler?.({
+      type: "keydown",
+      key: "c",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      repeat: false,
+      isComposing: false,
+      preventDefault,
+    } as unknown as KeyboardEvent);
+
+    expect(handled).toBe(true);
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(writeText).not.toHaveBeenCalled();
   });
 
   it("attaches desktop canonical sessions as hard clients with proposed dimensions", async () => {

--- a/tests/shell/terminal-rich-paste.test.ts
+++ b/tests/shell/terminal-rich-paste.test.ts
@@ -205,4 +205,65 @@ describe("terminal rich clipboard paste", () => {
     const sent = JSON.parse(ws.send.mock.calls[0]![0]);
     expect(sent.data).toContain("~/data/terminal-paste/paste-");
   });
+
+  it("pastes clipboard text exactly once without submitting it", async () => {
+    vi.stubGlobal("WebSocket", { OPEN: 1 });
+    const clipboard = { readText: vi.fn(async () => "first row\nλ second row 👩🏽‍💻") };
+    const ws = { readyState: 1, send: vi.fn() };
+
+    await expect(pasteClipboardIntoTerminal({
+      clipboard,
+      gatewayUrl: "https://gateway.example",
+      ws,
+    })).resolves.toBe("text");
+
+    expect(ws.send).toHaveBeenCalledOnce();
+    expect(JSON.parse(ws.send.mock.calls[0]![0])).toEqual({
+      type: "input",
+      data: "\x1b[200~first row\nλ second row 👩🏽‍💻\x1b[201~",
+    });
+  });
+
+  it("reports empty and unavailable clipboard reads without sending", async () => {
+    vi.stubGlobal("WebSocket", { OPEN: 1 });
+    const ws = { readyState: 1, send: vi.fn() };
+
+    await expect(pasteClipboardIntoTerminal({
+      clipboard: { readText: vi.fn(async () => "") },
+      gatewayUrl: "https://gateway.example",
+      ws,
+    })).resolves.toBe("empty");
+    await expect(pasteClipboardIntoTerminal({
+      clipboard: undefined,
+      gatewayUrl: "https://gateway.example",
+      ws,
+    })).resolves.toBe("unavailable");
+
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it("reports failed when text or image data cannot reach the terminal", async () => {
+    vi.stubGlobal("WebSocket", { OPEN: 1 });
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true })));
+    const disconnected = { readyState: 3, send: vi.fn() };
+    const blob = new Blob(["fake image"], { type: "image/png" });
+
+    await expect(pasteClipboardIntoTerminal({
+      clipboard: { readText: vi.fn(async () => "not delivered") },
+      gatewayUrl: "https://gateway.example",
+      ws: disconnected,
+    })).resolves.toBe("failed");
+    await expect(pasteClipboardIntoTerminal({
+      clipboard: {
+        read: vi.fn(async () => [{
+          types: ["image/png"],
+          getType: vi.fn(async () => blob),
+        }]),
+      },
+      gatewayUrl: "https://gateway.example",
+      ws: disconnected,
+    })).resolves.toBe("failed");
+
+    expect(disconnected.send).not.toHaveBeenCalled();
+  });
 });

--- a/tests/shell/terminal-xterm-runtime.test.ts
+++ b/tests/shell/terminal-xterm-runtime.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   applyXtermScrollOptions,
   describeReadyState,
+  isAppleCommandPlatform,
   shouldDisableWebglRenderer,
   toDisposableWebglAddon,
 } from "../../shell/src/components/terminal/terminal-xterm-runtime.js";
@@ -11,6 +12,15 @@ afterEach(() => {
 });
 
 describe("terminal xterm runtime", () => {
+  it.each(["MacIntel", "iPad", "iPhone", "iPod"])("recognizes %s as an Apple Command-key platform", (platform) => {
+    expect(isAppleCommandPlatform(platform)).toBe(true);
+  });
+
+  it("does not treat non-Apple platforms as Command-key platforms", () => {
+    expect(isAppleCommandPlatform("Linux armv8l")).toBe(false);
+    expect(isAppleCommandPlatform("Win32")).toBe(false);
+  });
+
   it("applies the terminal's bounded scroll behavior", () => {
     const term = { options: {} };
 

--- a/tests/shell/terminal-xterm-runtime.test.ts
+++ b/tests/shell/terminal-xterm-runtime.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  applyXtermScrollOptions,
+  describeReadyState,
+  shouldDisableWebglRenderer,
+  toDisposableWebglAddon,
+} from "../../shell/src/components/terminal/terminal-xterm-runtime.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("terminal xterm runtime", () => {
+  it("applies the terminal's bounded scroll behavior", () => {
+    const term = { options: {} };
+
+    applyXtermScrollOptions(term as never);
+
+    expect(term.options).toEqual({
+      scrollback: 10_000,
+      scrollSensitivity: 1,
+      fastScrollSensitivity: 5,
+      scrollOnUserInput: true,
+    });
+  });
+
+  it("disables WebGL for suppressed keyboards and Apple mobile Safari", () => {
+    vi.stubGlobal("navigator", {
+      userAgent: "Mozilla/5.0 (iPad) AppleWebKit/605.1.15 Version/17.0 Mobile/15E148 Safari/604.1",
+      maxTouchPoints: 5,
+    });
+
+    expect(shouldDisableWebglRenderer(false)).toBe(true);
+    expect(shouldDisableWebglRenderer(true)).toBe(true);
+  });
+
+  it("accepts only addons with a disposable lifecycle", () => {
+    const addon = { dispose: vi.fn() };
+
+    expect(toDisposableWebglAddon(addon)).toBe(addon);
+    expect(toDisposableWebglAddon({ dispose: true })).toBeNull();
+    expect(toDisposableWebglAddon(null)).toBeNull();
+  });
+
+  it("describes websocket states without exposing implementation objects", () => {
+    vi.stubGlobal("WebSocket", { CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3 });
+
+    expect(describeReadyState(null)).toBe("null");
+    expect(describeReadyState({ readyState: 1 } as WebSocket)).toBe("OPEN");
+    expect(describeReadyState({ readyState: 9 } as WebSocket)).toBe("UNKNOWN(9)");
+  });
+});


### PR DESCRIPTION
## Summary

- support Command+C, Command+Shift+C, Ctrl+Shift+C, Command+V, Ctrl+Shift+V, and Command+A in focused terminals
- preserve pane ownership and exactly-once paste behavior
- extract file-paste, xterm runtime, and paste-listener lifecycle helpers from `TerminalPane`
- keep non-terminal shortcut handling unchanged

## Validation

- native and web shortcut suites pass
- extracted runtime and file-paste unit suites pass
- exact multiline and Unicode copy/paste assertions pass
- `TerminalPane.tsx` is 1,980 lines at this layer, below the 2,000-line repository threshold
- full stack verification is recorded in PR #1425

## Invariants

- **Source of truth:** the focused xterm instance owns selection and paste destination; the shared shortcut classifier determines whether the terminal handles an event.
- **Lock/transaction scope:** not applicable; clipboard operations are client-local and use generation checks rather than database locks.
- **Acceptable orphan states:** none in this layer; text is written only to the initiating live terminal.
- **Auth source of truth:** unchanged; terminal transport remains authorized by the existing desktop attachment or authenticated shell WebSocket.
- **Deferred scope:** global clipboard history, background-pane shortcuts, non-terminal Edit-menu behavior changes, and decomposition of the remaining tightly coupled xterm/WebSocket lifecycle are excluded.

## Stack

2 of 5, after #1421 and before #1423.
