### PR TITLE
fix(terminal): copy Claude auth links

### DIFF
--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -34,6 +34,7 @@ import {
   terminalPasteFiles,
 } from "./terminal-rich-paste";
 import { getDesktopTerminalXtermTheme } from "./terminal-appearance";
+import { decodeOsc52Clipboard } from "./terminal-osc52";
 
 const GAP_MARKER = "\r\n\x1b[2m── output gap ──\x1b[0m\r\n";
 
@@ -138,6 +139,12 @@ export default function TerminalView({
     terminal.loadAddon(fit);
     terminal.loadAddon(serialize);
     terminal.open(host);
+    const osc52Disposable = terminal.parser.registerOscHandler(52, (data) => {
+      const decoded = decodeOsc52Clipboard(data);
+      if (!decoded.handled) return false;
+      if (decoded.text !== null) void copyDesktopTerminalText(decoded.text);
+      return true;
+    });
     terminal.attachCustomKeyEventHandler((event) => {
       const action = classifyTerminalClipboardShortcut({
         type: event.type as "keydown" | "keyup" | "keypress",
@@ -244,6 +251,7 @@ export default function TerminalView({
       host.removeEventListener("mouseup", onLinkMouseUp, true);
       host.removeEventListener("contextmenu", onTerminalContextMenu, true);
       linkProviderDisposable.dispose();
+      osc52Disposable.dispose();
       observer.disconnect();
       if (rafId !== null) {
         cancelAnimationFrame(rafId);

--- a/desktop/src/renderer/src/features/terminal/terminal-osc52.ts
+++ b/desktop/src/renderer/src/features/terminal/terminal-osc52.ts
@@ -1,0 +1,24 @@
+const MAX_OSC52_BASE64_LENGTH = 1_000_000;
+const OSC52_ALLOWED_TARGETS = new Set(["", "c", "p", "s", "0", "1", "2", "3", "4", "5", "6", "7"]);
+
+export type Osc52ClipboardPayload =
+  | { handled: false }
+  | { handled: true; text: string | null };
+
+export function decodeOsc52Clipboard(data: string): Osc52ClipboardPayload {
+  const separator = data.indexOf(";");
+  if (separator < 0 || !OSC52_ALLOWED_TARGETS.has(data.slice(0, separator))) {
+    return { handled: false };
+  }
+  const payload = data.slice(separator + 1);
+  if (payload === "" || payload === "?") return { handled: true, text: null };
+  if (payload.length > MAX_OSC52_BASE64_LENGTH || !/^[A-Za-z0-9+/=]+$/.test(payload)) {
+    return { handled: false };
+  }
+  try {
+    const bytes = Uint8Array.from(atob(payload), (character) => character.charCodeAt(0));
+    return { handled: true, text: new TextDecoder().decode(bytes) };
+  } catch {
+    return { handled: false };
+  }
+}

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -30,6 +30,7 @@ const { createdFitAddons, createdTerminals, resizeObserverCallbacks } = vi.hoist
     };
     options: { theme?: unknown };
     registeredProviders: unknown[];
+    oscHandlers: Map<number, (data: string) => boolean>;
     dataCallback?: (data: string) => void;
     element: HTMLElement | null;
     focus: ReturnType<typeof vi.fn>;
@@ -69,6 +70,13 @@ vi.mock("@xterm/xterm", () => ({
       };
     };
     registeredProviders: unknown[] = [];
+    oscHandlers = new Map<number, (data: string) => boolean>();
+    parser = {
+      registerOscHandler: (identifier: number, handler: (data: string) => boolean) => {
+        this.oscHandlers.set(identifier, handler);
+        return { dispose: () => this.oscHandlers.delete(identifier) };
+      },
+    };
     selection = "";
     customKeyEventHandler?: (event: KeyboardEvent) => boolean;
     paste = vi.fn((text: string) => this.dataCallback?.(text));
@@ -497,6 +505,25 @@ describe("TerminalView session switching", () => {
     expect(preventDefault).toHaveBeenCalledOnce();
     expect(writeText).toHaveBeenCalledOnce();
     expect(writeText).toHaveBeenCalledWith("HTTP/1.1 401 Unauthorized\nλ-value: 👩🏽‍💻");
+    expect(attachmentWrite).not.toHaveBeenCalled();
+  });
+
+  it("copies the exact Claude authentication URL emitted after the user presses c", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    render(<TerminalView sessionName="alpha" />);
+    const terminal = createdTerminals.at(-1)!;
+    const authUrl = "https://claude.ai/oauth/authorize?code=true&client_id=matrix-os-desktop";
+    const encodedUrl = btoa(authUrl);
+
+    const handled = terminal.oscHandlers.get(52)?.(`c;${encodedUrl}`);
+
+    expect(handled).toBe(true);
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(authUrl));
+    expect(writeText).toHaveBeenCalledOnce();
     expect(attachmentWrite).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- handle bounded, allowlisted OSC 52 clipboard writes in Electron Terminal
- copy the exact Claude authentication URL when Claude Code asks the user to press plain `c`
- reject clipboard reads, unsupported targets, invalid base64, and oversized payloads

## Tests

- `flox activate -- bun run test -- tests/desktop/terminal-view.test.tsx` — 35/35 passed
- `flox activate -- bun run typecheck` — passed
- `flox activate -- bun run check:patterns` — 0 violations; 5 unrelated repository warnings
- `flox activate -- bun run build:desktop` — passed
- Electron Desktop manual validation against Preview Computer `pr-1476` — Human Review passed

## Review / Monitoring

- exact head: `dd740bd19440a9f7c54a02c9e137df53d21a2911`
- Human Review passed for the Claude auth copy flow
- awaiting exact-head Greptile 5/5 before adding `ready-for-ci`

## Invariants

- **Source of truth:** Claude Code remains the source of the authentication URL; Electron only decodes its OSC 52 write request.
- **Lock/transaction scope:** not applicable; no database or shared persistence changes.
- **Acceptable orphan states:** a rejected or failed clipboard write leaves the system clipboard unchanged.
- **Auth source of truth:** existing Claude and Matrix authentication remain unchanged; the deep link or browser flow is not opened automatically.
- **Deferred scope:** generic terminal selection, Canvas behavior, mouse reporting, scrollback, clipboard history, and clipboard reads are excluded.