### PR TITLE
fix(desktop): restore sidebar chrome and terminal controls

### DIFF
--- a/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
@@ -114,6 +114,7 @@ export default function DesktopSurfaceFrame({
     || tab.kind === "terminals"
     || tab.kind === "settings"
     || tab.kind === "notes";
+  const terminalUsesSidebarChrome = tab.kind === "terminal" || tab.kind === "terminals";
   const sidebarHidesTitle = tab.kind === "terminal"
     || tab.kind === "terminals"
     || tab.kind === "settings"
@@ -236,7 +237,7 @@ export default function DesktopSurfaceFrame({
       sidebar={tab.kind === "settings" ? (
         <SettingsSidebar section={settingsSection} onSectionChange={setSettingsSection} />
       ) : undefined}
-      safeAreaLayout={sidebarOwnsChrome ? "sidebar" : "pane"}
+      safeAreaLayout={sidebarOwnsChrome && !terminalUsesSidebarChrome ? "sidebar" : "pane"}
       topBar={isWindow || surfaceChrome ? (
         <TopBar
           title={sidebarHidesTitle ? undefined : surfaceChrome ? surfaceChrome.title : tab.title}

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
@@ -109,7 +109,15 @@ export default function DesktopSurfaceFrame({
     : isDesktopHidden || isDesktopTransition || (isDesktopWindow && !tabWorkspaceActive) || (isTabbed && tabWorkspaceActive && active);
   const interactive = visible && active;
   const isNativeEmbed = tab.kind === "home" || tab.kind === "app" || tab.kind === "browser" || tab.kind === "vscode";
-  const sidebarOwnsChrome = tab.kind === "chat" || tab.kind === "settings" || tab.kind === "notes";
+  const sidebarOwnsChrome = tab.kind === "chat"
+    || tab.kind === "terminal"
+    || tab.kind === "terminals"
+    || tab.kind === "settings"
+    || tab.kind === "notes";
+  const sidebarHidesTitle = tab.kind === "terminal"
+    || tab.kind === "terminals"
+    || tab.kind === "settings"
+    || tab.kind === "notes";
   const requestedSettingsSection = useUi((state) => state.requestedSettingsSection);
   const [settingsSection, setSettingsSection] = useState<SettingsSectionId>("account");
   useEffect(() => {
@@ -231,7 +239,7 @@ export default function DesktopSurfaceFrame({
       safeAreaLayout={sidebarOwnsChrome ? "sidebar" : "pane"}
       topBar={isWindow || surfaceChrome ? (
         <TopBar
-          title={tab.kind === "settings" || tab.kind === "notes" ? undefined : surfaceChrome ? surfaceChrome.title : tab.title}
+          title={sidebarHidesTitle ? undefined : surfaceChrome ? surfaceChrome.title : tab.title}
           leftActions={surfaceChrome?.leftActions}
           rightActions={surfaceChrome?.rightActions}
           leftPaneWidth={surfaceChrome?.leftPaneWidth}

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
@@ -114,7 +114,6 @@ export default function DesktopSurfaceFrame({
     || tab.kind === "terminals"
     || tab.kind === "settings"
     || tab.kind === "notes";
-  const terminalUsesSidebarChrome = tab.kind === "terminal" || tab.kind === "terminals";
   const sidebarHidesTitle = tab.kind === "terminal"
     || tab.kind === "terminals"
     || tab.kind === "settings"
@@ -237,7 +236,7 @@ export default function DesktopSurfaceFrame({
       sidebar={tab.kind === "settings" ? (
         <SettingsSidebar section={settingsSection} onSectionChange={setSettingsSection} />
       ) : undefined}
-      safeAreaLayout={sidebarOwnsChrome && !terminalUsesSidebarChrome ? "sidebar" : "pane"}
+      safeAreaLayout={sidebarOwnsChrome ? "sidebar" : "pane"}
       topBar={isWindow || surfaceChrome ? (
         <TopBar
           title={sidebarHidesTitle ? undefined : surfaceChrome ? surfaceChrome.title : tab.title}

--- a/desktop/src/renderer/src/features/desktop-shell/OSWindow.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/OSWindow.tsx
@@ -134,8 +134,7 @@ export function TopBar({
         <div
           data-os-window-gesture-layer
           data-testid="desktop-window-drag-handle"
-          className="absolute inset-y-0 left-0 z-20"
-          style={{ width: controlsWidth }}
+          className="absolute inset-0 z-20"
           onPointerDown={onDragStart}
           onDoubleClick={handleDoubleClick}
         />

--- a/desktop/src/renderer/src/features/terminal/TerminalSessionSidebar.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalSessionSidebar.tsx
@@ -6,6 +6,7 @@ import { DESKTOP_Z_INDEX } from "../../design/layering";
 import type { ShellSessionSummary } from "../../stores/shell-sessions";
 import { OSWindowSafeView } from "../desktop-shell/OSWindow";
 import { DesktopNewSessionControl } from "./DesktopNewSessionControl";
+import { DesktopTerminalThemePicker } from "./DesktopTerminalThemePicker";
 import { relativeSessionActivity } from "./terminal-session-activity";
 import {
   terminalAgentLabel,
@@ -84,15 +85,18 @@ export function TerminalSessionSidebar({
             <SquareTerminal size={16} aria-hidden="true" />
             <h1 className="truncate text-base font-medium tracking-[-0.4px]" style={{ color: "var(--text-primary)" }}>Terminal</h1>
           </div>
-          <DesktopNewSessionControl
-            disabled={disabled}
-            creating={creating}
-            agentStatuses={agentStatuses}
-            checkingAgentStatuses={checkingAgentStatuses}
-            onRefreshAgentStatuses={onRefreshAgentStatuses}
-            onCreateShell={onCreate}
-            onCreateAgent={onCreateAgent}
-          />
+          <div data-terminal-sidebar-header-actions className="no-drag flex shrink-0 items-center gap-2">
+            <DesktopTerminalThemePicker />
+            <DesktopNewSessionControl
+              disabled={disabled}
+              creating={creating}
+              agentStatuses={agentStatuses}
+              checkingAgentStatuses={checkingAgentStatuses}
+              onRefreshAgentStatuses={onRefreshAgentStatuses}
+              onCreateShell={onCreate}
+              onCreateAgent={onCreateAgent}
+            />
+          </div>
         </div>
         <ul aria-label="Terminal sessions" className="min-h-0 flex-1 overflow-y-auto pb-4">
           {[...sessions].sort((left, right) => Number(Boolean(right.pinned)) - Number(Boolean(left.pinned))).map((session) => {

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -17,7 +17,6 @@ import {
 import TerminalView from "./TerminalView";
 import { TerminalSessionSidebar } from "./TerminalSessionSidebar";
 import { useTerminalAppearance } from "../../stores/terminal-appearance";
-import { DesktopTerminalThemePicker } from "./DesktopTerminalThemePicker";
 import {
   parseTerminalAgentStatuses,
   terminalAgentVisibleInstallCommand,
@@ -459,7 +458,6 @@ export default function TerminalsTab({
                 >
                   {statusLabel}
                 </span>
-                <DesktopTerminalThemePicker />
               </div>
             </header>
             <div data-terminal-detail className="flex min-h-0 flex-1">

--- a/tests/desktop/native-desktop-shell.test.tsx
+++ b/tests/desktop/native-desktop-shell.test.tsx
@@ -822,7 +822,6 @@ describe("native desktop shell", () => {
     expect(terminalChrome?.style.width).toBe("280px");
     expect(terminalChrome?.textContent).not.toContain("Terminal");
     expect((terminalWindow.querySelector("[data-os-window-gesture-layer]") as HTMLElement).className).toContain("inset-0");
-    expect((terminalWindow.querySelector('[data-os-window-safe-view="pane"]') as HTMLElement).style.paddingTop).toBe("48px");
     expect(screen.getByText("Chat content")).toBeTruthy();
     expect(screen.getByText("Terminal content")).toBeTruthy();
     expect(screen.getByTestId("desktop-surface-content-work").hasAttribute("inert")).toBe(true);

--- a/tests/desktop/native-desktop-shell.test.tsx
+++ b/tests/desktop/native-desktop-shell.test.tsx
@@ -817,12 +817,11 @@ describe("native desktop shell", () => {
     const workWindow = screen.getByRole("dialog", { name: "Chat window" });
     const terminalWindow = screen.getByRole("dialog", { name: "Terminal window" });
     const workChrome = workWindow.querySelector<HTMLElement>('[data-os-window-chrome-placement="sidebar"]');
-    const terminalChrome = terminalWindow.querySelector<HTMLElement>('[data-os-window-chrome-placement="full-width"]');
+    const terminalChrome = terminalWindow.querySelector<HTMLElement>('[data-os-window-chrome-placement="sidebar"]');
     expect(workChrome).toBeNull();
-    expect(terminalChrome?.style.width).toBe("100%");
-    expect(terminalChrome?.textContent).toContain("Terminal");
-    expect((terminalWindow.querySelector("[data-os-window-gesture-layer]") as HTMLElement).style.width).toBe("100%");
-    expect((terminalWindow.querySelector('[data-os-window-safe-view="pane"]') as HTMLElement).style.paddingTop).toBe("48px");
+    expect(terminalChrome?.style.width).toBe("280px");
+    expect(terminalChrome?.textContent).not.toContain("Terminal");
+    expect((terminalWindow.querySelector("[data-os-window-gesture-layer]") as HTMLElement).className).toContain("inset-0");
     expect(screen.getByText("Chat content")).toBeTruthy();
     expect(screen.getByText("Terminal content")).toBeTruthy();
     expect(screen.getByTestId("desktop-surface-content-work").hasAttribute("inert")).toBe(true);

--- a/tests/desktop/native-desktop-shell.test.tsx
+++ b/tests/desktop/native-desktop-shell.test.tsx
@@ -822,6 +822,7 @@ describe("native desktop shell", () => {
     expect(terminalChrome?.style.width).toBe("280px");
     expect(terminalChrome?.textContent).not.toContain("Terminal");
     expect((terminalWindow.querySelector("[data-os-window-gesture-layer]") as HTMLElement).className).toContain("inset-0");
+    expect((terminalWindow.querySelector('[data-os-window-safe-view="pane"]') as HTMLElement).style.paddingTop).toBe("48px");
     expect(screen.getByText("Chat content")).toBeTruthy();
     expect(screen.getByText("Terminal content")).toBeTruthy();
     expect(screen.getByTestId("desktop-surface-content-work").hasAttribute("inert")).toBe(true);

--- a/tests/desktop/os-window.test.tsx
+++ b/tests/desktop/os-window.test.tsx
@@ -27,7 +27,7 @@ describe("Electron OS window chrome", () => {
     expect(container.querySelector("[data-os-window-top-bar-overlay]")?.className).toContain("absolute");
   });
 
-  it("scopes the transparent gesture layer to the chrome-owning sidebar", () => {
+  it("keeps the transparent gesture layer full width when chrome uses the sidebar", () => {
     const onClose = vi.fn();
     const { container } = render(
       <TopBar
@@ -42,10 +42,8 @@ describe("Electron OS window chrome", () => {
     const gestureLayer = container.querySelector("[data-os-window-gesture-layer]") as HTMLElement;
     expect(gestureLayer).toBeTruthy();
     expect(gestureLayer?.className).toContain("z-20");
-    expect(gestureLayer.className).toContain("left-0");
-    expect(gestureLayer.className).toContain("inset-y-0");
-    expect(gestureLayer.className).not.toContain("inset-0");
-    expect(gestureLayer.style.width).toBe("280px");
+    expect(gestureLayer.className).toContain("inset-0");
+    expect(gestureLayer.style.width).toBe("");
     expect((container.querySelector('[data-os-window-chrome-placement="sidebar"]') as HTMLElement).style.width).toBe("280px");
     expect(gestureLayer?.className).not.toContain("bg-");
     expect(container.querySelector("[data-os-window-traffic-lights]")?.className).toContain("z-30");
@@ -135,7 +133,8 @@ describe("Electron OS window chrome", () => {
     );
 
     const gestureLayer = container.querySelector("[data-os-window-gesture-layer]") as HTMLElement;
-    expect(gestureLayer.style.width).toBe("100%");
+    expect(gestureLayer.className).toContain("inset-0");
+    expect(gestureLayer.style.width).toBe("");
   });
 
   it("applies topbar clearance only to the safe area for each window layout", () => {

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -229,7 +229,7 @@ describe("TerminalsTab", () => {
     expect(screen.queryByRole("navigation", { name: "Terminal breadcrumb" })).toBeNull();
   });
 
-  it("places a compact shell theme icon beside the session status pill", () => {
+  it("places the shell theme picker beside the new-session controls in the sidebar", () => {
     useShellSessions.setState({
       sessions: [{ name: "matrix-main", status: "active", placement: "active", createdAt: "2026-08-26T09:41:00.000Z" }],
     });
@@ -243,11 +243,14 @@ describe("TerminalsTab", () => {
     const active = screen.getByText("Active");
     expect(active.className).toContain("h-5");
     expect((active as HTMLElement).style.background).toBe("var(--bg-selected)");
-    const headerActions = header.querySelector("[data-terminal-header-actions]");
     const themeButton = screen.getByRole("button", { name: "Shell theme" });
+    const sidebarActions = document.querySelector("[data-terminal-sidebar-header-actions]");
+    const headerActions = header.querySelector("[data-terminal-header-actions]");
     expect(headerActions?.contains(active)).toBe(true);
-    expect(headerActions?.contains(themeButton)).toBe(true);
-    expect(headerActions?.classList.contains("no-drag")).toBe(true);
+    expect(headerActions?.contains(themeButton)).toBe(false);
+    expect(sidebarActions?.contains(themeButton)).toBe(true);
+    expect(sidebarActions?.contains(screen.getByRole("button", { name: "New shell session" }))).toBe(true);
+    expect(sidebarActions?.classList.contains("no-drag")).toBe(true);
     expect(themeButton.className).toContain("size-7");
     expect(themeButton.textContent).toBe("");
     expect(themeButton.closest("footer")).toBeNull();


### PR DESCRIPTION
## Summary

- restore full-width dragging across OS window top bars in sidebar layouts
- return Terminal and Terminals to titleless sidebar chrome
- move the Terminal theme picker beside the sidebar new-session (`+`) controls
- add renderer regressions for drag, terminal layout, title, and picker placement

## Tests

- `pnpm exec vitest run tests/desktop/os-window.test.tsx tests/desktop/native-desktop-shell.test.tsx --silent` — 46 passed
- `pnpm exec vitest run tests/desktop/terminals-tab.test.tsx tests/desktop/native-desktop-shell.test.tsx --silent` — 76 passed
- `pnpm --filter desktop typecheck` — passed
- `git diff --check` — passed
- `pnpm run test` — attempted before this focused follow-up, but the restricted local environment caused unrelated gateway, CLI, heartbeat, app-runtime, and host-script tests to hit repeated 20–120 second process/network timeouts

## Invariants

- **Source of truth:** `TopBar` owns the shared drag gesture layer; `DesktopSurfaceFrame` owns surface chrome and safe-area placement.
- **Lock/transaction scope:** none; renderer-only behavior with no persistence or database writes.
- **Acceptable orphan states:** none; no durable state is created or migrated.
- **Auth source of truth:** unchanged; no authentication or authorization paths are touched.
- **Deferred scope:** live Electron pointer verification is left to CI/manual review; focused renderer interaction coverage is included.
