### PR TITLE
docs(brand): align guidelines with approved identity

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,124 +1,174 @@
 ---
-version: "0.1.0"
-name: "matrix os"
-# Wordmark: always lowercase "matrix os" — never "Matrix OS" or "MatrixOS".
-# Applies to UI wordmarks, marketing copy, titles, and docs. (The repo/dir
-# slug "matrix-os" and the domain matrix-os.com keep their hyphenated form.)
-wordmark: "matrix os"
+version: "1.0.0"
+name: "Matrix OS"
+wordmark: "Matrix OS"
 tagline: "Technology that understands you."
-description: >
-  matrix os is your personal cloud computer — a calm, intelligent space that
-  keeps you in flow, wherever you are. The visual language is warm, organic,
-  and approachable. It draws from natural materials (forest, sand, terracotta)
-  rather than neon/tech aesthetics.
+brandSource:
+  kind: "figma"
+  fileKey: "xPG2FeYRtC9owCKSVXCqWA"
+  nodeId: "1:846"
+  url: "https://www.figma.com/design/xPG2FeYRtC9owCKSVXCqWA/brand?node-id=1-846"
+  capturedAt: "2026-08-30"
 
-pillars:
-  - Warm
-  - Personal
-  - Seamless
-  - Mindful
-  - Trusted
-  - Calm
+brand:
+  teal: "#0E3422"
+  coral: "#D06E53"
+  gold: "#F1C379"
+  green: "#BED77B"
+  blue: "#C5D6E2"
+  ink: "#1F2D1D"
+  paper: "#FCFCF8"
+  canvas: "#F4F7ED"
 
-colors:
-  forest: "#434E3F"
-  cream: "#E0E1CA"
-  ember: "#D06F25"
-  deep: "#32352E"
+colorScales:
+  green:
+    50: "#F4F7ED"
+    100: "#E4EDD4"
+    200: "#CEE0AE"
+    300: "#BED77B"
+    400: "#9AC059"
+    500: "#748E59"
+    600: "#62783A"
+    700: "#475926"
+    800: "#2B3715"
+    900: "#171F0A"
+  teal:
+    50: "#EEF7F2"
+    100: "#C9E8D9"
+    200: "#97D8B9"
+    300: "#5EC996"
+    400: "#34B275"
+    500: "#288A5B"
+    600: "#1B6541"
+    700: "#13492F"
+    800: "#0E3422"
+    900: "#061810"
+  coral:
+    50: "#FAEEEB"
+    100: "#F2D6CF"
+    200: "#E6B5A8"
+    300: "#DA9481"
+    400: "#D06E53"
+    500: "#BA5236"
+    600: "#8F432D"
+    700: "#6B3324"
+    800: "#442118"
+    900: "#25130E"
+  gold:
+    50: "#FCF5E8"
+    100: "#FAEAD1"
+    200: "#F6DAAC"
+    300: "#F1C379"
+    400: "#E0AA52"
+    500: "#D2932D"
+    600: "#A37429"
+    700: "#775622"
+    800: "#4D3919"
+    900: "#251C0E"
+  blue:
+    50: "#EDF3F7"
+    100: "#C5D6E2"
+    200: "#9DBFD7"
+    300: "#71A9D0"
+    400: "#5CA0D1"
+    500: "#3B85BA"
+    600: "#306991"
+    700: "#254D6A"
+    800: "#193143"
+    900: "#0F1B24"
+  neutral:
+    50: "#FFFFFF"
+    100: "#F3F2F2"
+    200: "#E1E0E0"
+    300: "#C8C6C6"
+    400: "#A8A4A4"
+    500: "#827D7D"
+    600: "#635F5F"
+    700: "#413E3E"
+    800: "#242323"
+    900: "#0D0C0C"
 
-  background: "#FAFAF5"
-  foreground: "#32352E"
-  card: "#FFFFFF"
-  card-foreground: "#32352E"
-  primary: "#434E3F"
-  primary-foreground: "#FAFAF5"
-  secondary: "#E0E1CA"
-  secondary-foreground: "#32352E"
-  accent: "#D06F25"
-  accent-foreground: "#FFFFFF"
-  muted: "#F0EDE4"
-  muted-foreground: "#7A7768"
-  border: "#D6D3C8"
-  input: "#D6D3C8"
-  ring: "#434E3F"
-  destructive: "#C4342D"
-  success: "#3A7D44"
-  warning: "#D49B2A"
-
-  sand-light: "#F7F1E7"
-  sand-mid: "#F3EAE0"
-  sand-warm: "#D6AB8B"
-
-  gradient-deep: "#32352E"
-  gradient-mid: "#434E3F"
-  gradient-light: "#E0E1CA"
-  gradient-accent: "#D06F25"
-
-  # OS shell accent. The marketing surfaces use `forest` as primary; the OS shell
-  # (desktop/terminal/mobile) uses a calmer green accent on its own tokens.
-  # Sage-teal #8CC7BE was retired 2026-06-14: the OS accent is now `lichen`
-  # (#9AA48C) in both light and dark, and focus rings use `ember`. Dark-mode
-  # `primary`/`accent` resolve to `lichen`; dark `ring` resolves to `ember`.
-  lichen: "#9AA48C"      # OS shell accent (replaces sage-teal)
-  moss: "#6A8A7A"        # deeper green — gradients, secondary
-  os-accent: "#9AA48C"
-  os-accent-ring: "#D06F25"
+semanticColors:
+  background: "#F4F7ED"
+  foreground: "#1F2D1D"
+  surface: "#FCFCF8"
+  surfaceElevated: "#FFFFFF"
+  border: "#E0E1CA"
+  primary: "#0E3422"
+  primaryForeground: "#FCFCF8"
+  accent: "#D06E53"
+  focus: "#F1C379"
+  success: "#288A5B"
+  warning: "#D2932D"
+  danger: "#BA5236"
+  info: "#3B85BA"
+  muted: "#F3F2F2"
+  mutedForeground: "#635F5F"
 
 typography:
   display:
-    fontFamily: "Orbitron"
-    fontSize: "3rem"
-    fontWeight: 700
+    fontFamily: "Bricolage Grotesque"
+    fontSize: "72px"
+    fontWeight: 800
     lineHeight: 1.1
     letterSpacing: "-0.02em"
   h1:
-    fontFamily: "Orbitron"
-    fontSize: "2.25rem"
-    fontWeight: 600
+    fontFamily: "Bricolage Grotesque"
+    fontSize: "48px"
+    fontWeight: 700
     lineHeight: 1.15
     letterSpacing: "-0.01em"
   h2:
-    fontFamily: "Orbitron"
-    fontSize: "1.75rem"
+    fontFamily: "Bricolage Grotesque"
+    fontSize: "36px"
     fontWeight: 600
     lineHeight: 1.2
+    letterSpacing: "-0.005em"
   h3:
-    fontFamily: "Inter"
-    fontSize: "1.25rem"
-    fontWeight: 600
-    lineHeight: 1.3
-  h4:
-    fontFamily: "Inter"
-    fontSize: "1.125rem"
-    fontWeight: 600
-    lineHeight: 1.4
-  body:
-    fontFamily: "Inter"
-    fontSize: "1rem"
-    fontWeight: 400
-    lineHeight: 1.6
-  body-small:
-    fontFamily: "Inter"
-    fontSize: "0.875rem"
-    fontWeight: 400
-    lineHeight: 1.5
-  caption:
-    fontFamily: "Inter"
-    fontSize: "0.75rem"
-    fontWeight: 400
-    lineHeight: 1.4
-  mono:
-    fontFamily: "JetBrains Mono"
-    fontSize: "0.875rem"
-    fontWeight: 400
-    lineHeight: 1.5
-  label:
-    fontFamily: "Inter"
-    fontSize: "0.75rem"
+    fontFamily: "Bricolage Grotesque"
+    fontSize: "28px"
+    fontWeight: 500
+    lineHeight: 1.25
+  subtitle:
+    fontFamily: "Bricolage Grotesque"
+    fontSize: "22px"
     fontWeight: 500
     lineHeight: 1.4
-    letterSpacing: "0.05em"
+  bodyLarge:
+    fontFamily: "Geist"
+    fontSize: "18px"
+    fontWeight: 400
+    lineHeight: 1.55
+  body:
+    fontFamily: "Geist"
+    fontSize: "16px"
+    fontWeight: 400
+    lineHeight: 1.6
+    letterSpacing: "0.005em"
+  bodySmall:
+    fontFamily: "Geist"
+    fontSize: "14px"
+    fontWeight: 400
+    lineHeight: 1.6
+    letterSpacing: "0.01em"
+  caption:
+    fontFamily: "Geist"
+    fontSize: "12px"
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: "0.015em"
+  label:
+    fontFamily: "Geist"
+    fontSize: "11px"
+    fontWeight: 700
+    lineHeight: 1.3
+    letterSpacing: "3px"
     textTransform: "uppercase"
+  machine:
+    fontFamily: "Geist Mono"
+    fontSize: "14px"
+    fontWeight: 400
+    lineHeight: 1.5
 
 spacing:
   xs: "4px"
@@ -132,308 +182,217 @@ spacing:
 
 rounded:
   sm: "6px"
-  md: "10px"
-  lg: "14px"
-  xl: "20px"
-  2xl: "28px"
+  md: "8px"
+  lg: "12px"
+  xl: "16px"
+  2xl: "24px"
   full: "9999px"
 
 shadows:
-  xs: "0 1px 2px rgba(50, 53, 46, 0.04)"
-  sm: "0 2px 4px rgba(50, 53, 46, 0.06)"
-  md: "0 4px 12px rgba(50, 53, 46, 0.08)"
-  lg: "0 8px 24px rgba(50, 53, 46, 0.10)"
-  xl: "0 16px 48px rgba(50, 53, 46, 0.12)"
-
-components:
-  button-primary:
-    backgroundColor: "{colors.primary}"
-    textColor: "{colors.primary-foreground}"
-    rounded: "{rounded.xl}"
-    fontSize: "{typography.body-small.fontSize}"
-    fontWeight: 500
-    paddingX: "{spacing.lg}"
-    paddingY: "{spacing.sm}"
-  button-primary-hover:
-    backgroundColor: "{colors.deep}"
-  button-accent:
-    backgroundColor: "{colors.accent}"
-    textColor: "{colors.accent-foreground}"
-    rounded: "{rounded.xl}"
-  button-accent-hover:
-    backgroundColor: "#B85E1F"
-  button-secondary:
-    backgroundColor: "transparent"
-    textColor: "{colors.foreground}"
-    borderColor: "{colors.border}"
-    rounded: "{rounded.xl}"
-  button-ghost:
-    backgroundColor: "transparent"
-    textColor: "{colors.foreground}"
-    rounded: "{rounded.xl}"
-  card:
-    backgroundColor: "{colors.card}"
-    borderColor: "{colors.border}"
-    rounded: "{rounded.xl}"
-    shadow: "{shadows.sm}"
-    padding: "{spacing.lg}"
-  card-hover:
-    shadow: "{shadows.md}"
-  input:
-    backgroundColor: "{colors.card}"
-    borderColor: "{colors.input}"
-    rounded: "{rounded.lg}"
-    fontSize: "{typography.body.fontSize}"
-    paddingX: "{spacing.md}"
-    paddingY: "{spacing.sm}"
-  badge:
-    rounded: "{rounded.full}"
-    fontSize: "{typography.caption.fontSize}"
-    fontWeight: 500
-    paddingX: "{spacing.sm}"
-    paddingY: "2px"
+  xs: "0 1px 2px rgba(31, 45, 29, 0.05)"
+  sm: "0 2px 8px rgba(31, 45, 29, 0.07)"
+  md: "0 4px 24px rgba(31, 45, 29, 0.08)"
+  lg: "0 12px 36px rgba(31, 45, 29, 0.12)"
+  xl: "0 24px 64px rgba(31, 45, 29, 0.16)"
 ---
 
-## Overview
+# Matrix OS brand and interface guidelines
 
-Matrix OS is a personal cloud computer. The design language communicates warmth,
-trust, and calm intelligence. Every surface should feel like a well-made
-physical object — natural materials, soft edges, generous whitespace, deliberate
-restraint.
+This document is the repository contract for the Matrix OS identity. The
+[approved Figma brand frame](https://www.figma.com/design/xPG2FeYRtC9owCKSVXCqWA/brand?node-id=1-846)
+is the upstream visual source. This file translates that work into stable,
+reviewable rules for product design and implementation.
 
-The palette is drawn from forest, sand, and ember. Green conveys stability and
-trust. Cream provides warmth and breathing room. Orange is the spark — used
-sparingly for primary calls to action and moments that need attention.
+If Figma and this document disagree, reconcile the difference in a dedicated
+brand PR before changing product UI. Product code must consume the canonical
+tokens rather than creating a third interpretation.
 
-This is not a developer tool aesthetic. This is a living space.
+## Identity
 
-## Colors
+### Product name and wordmark
 
-### Brand Colors
+- The product and wordmark are written **Matrix OS**.
+- Never collapse the name to “MatrixOS”.
+- Keep the capitalization shown in the approved lockup; do not force the
+  wordmark to all caps or all lowercase.
+- Repository names, package names, domains, and URL slugs may use `matrix-os`.
 
-| Name     | Hex       | Role                                        |
-|----------|-----------|---------------------------------------------|
-| Forest   | `#434E3F` | Primary brand, buttons, text emphasis        |
-| Cream    | `#E0E1CA` | Secondary surfaces, backgrounds, warmth      |
-| Ember    | `#D06F25` | Accent, CTAs, highlights, active states      |
-| Deep     | `#32352E` | Primary text, darkest tone, depth            |
+### Mark
 
-### Usage Rules
+The canonical mark is the dotted rabbit/growth glyph shown in the Figma brand
+card and implemented by `rabbitMarkSvg()` in `@matrix-os/brand`.
 
-- **Forest** is the workhorse — headers, primary buttons, icons, nav active states
-- **Cream** is the resting surface — card backgrounds, secondary fills, hover states
-- **Ember** is reserved for action — one primary CTA per view, notification badges,
-  active toggles. Using it everywhere dilutes its power.
-- **Deep** is for text and depth — body copy, title bars, shadows, overlays
-- **White** (`#FFFFFF`) for card surfaces and elevated elements
-- **Background** (`#FAFAF5`) is a warm off-white, never pure white
+- Primary app tile: Green `#BED77B` mark on Teal `#0E3422`.
+- Monochrome use is allowed when the mark inherits the surrounding text color.
+- Preserve the original proportions. Never redraw, stretch, rotate, outline,
+  or add effects to the glyph.
+- Use the mark without the wordmark where space is constrained; otherwise pair
+  it with the title-case Matrix OS wordmark.
 
-### Semantic Colors
+## Character
 
-| Token        | Hex       | Usage                          |
-|--------------|-----------|--------------------------------|
-| Destructive  | `#C4342D` | Errors, delete, danger         |
-| Success      | `#3A7D44` | Positive states, confirmations |
-| Warning      | `#D49B2A` | Warnings, caution states       |
+Matrix OS should feel capable, optimistic, tactile, and composed. It is a
+powerful computer without the coldness or visual noise associated with typical
+developer tooling.
 
-All semantic colors are warm-tinted to sit comfortably in the palette. Avoid
-pure red (#ff0000) or pure green (#00ff00).
+1. **Expressive, not ornamental.** Use personality in type and color, not
+   decoration without purpose.
+2. **Calm, not empty.** Preserve focus with clear hierarchy and generous space.
+3. **Organic, not rustic.** Rounded geometry and living colors should still
+   feel precise.
+4. **Technical, not intimidating.** Machine information is legible and direct.
+5. **Bright, not childish.** Supporting colors are signals, not confetti.
 
-### Contrast Notes
+## Color
 
-- Deep (#32352E) on Background (#FAFAF5): **13.2:1** — exceeds AAA
-- Deep (#32352E) on Cream (#E0E1CA): **7.8:1** — exceeds AAA
-- Forest (#434E3F) on White (#FFFFFF): **8.1:1** — exceeds AAA
-- Ember (#D06F25) on White (#FFFFFF): **3.6:1** — meets AA for large text only;
-  pair with Deep text on ember backgrounds for body copy
+### Core palette
+
+| Name | Hex | Primary role |
+| --- | --- | --- |
+| Teal | `#0E3422` | Identity, primary actions, navigation, strong text |
+| Coral | `#D06E53` | Attention, warmth, destructive emphasis |
+| Gold | `#F1C379` | Focus, selected highlights, optimistic emphasis |
+| Green | `#BED77B` | Brand mark, success, active and ready states |
+| Blue | `#C5D6E2` | Informational and passive supporting surfaces |
+
+Teal is the anchor. The other four colors create rhythm and communicate state.
+Do not give every color equal weight in one view.
+
+### Surfaces and text
+
+- Default canvas: Green 50 `#F4F7ED`.
+- Brand paper/card: `#FCFCF8`.
+- Elevated neutral surface: Neutral 50 `#FFFFFF`.
+- Primary ink: `#1F2D1D`.
+- Default border: `#E0E1CA`.
+- Muted text: Neutral 600 `#635F5F`.
+- Default focus ring: Gold `#F1C379` with a visible offset.
+
+### Accessibility
+
+| Combination | Contrast | Guidance |
+| --- | ---: | --- |
+| Teal on paper | 13.32:1 | AAA for text and controls |
+| Ink on paper | 14.07:1 | AAA for body text |
+| Ink on Green | 9.09:1 | AAA for dark text on positive fills |
+| Teal on Blue | 9.19:1 | AAA for informational surfaces |
+| Coral on paper | 3.38:1 | Large text and non-text emphasis only |
+
+Coral is not a default text color or a small-button text/background pair. Use
+Teal for primary actions and reserve Coral for accents or pair it with a dark
+foreground after checking the exact contrast.
 
 ## Typography
 
-### Font Stack
+### Families
 
-| Role      | Font            | Usage                                    |
-|-----------|-----------------|------------------------------------------|
-| Display   | Orbitron        | Logo, hero headings, marketing surfaces  |
-| UI / Body | Inter           | All interface text, body, labels          |
-| Code      | JetBrains Mono  | Terminal, code blocks, technical data     |
+| Role | Family | Use |
+| --- | --- | --- |
+| Display and headings | Bricolage Grotesque | Wordmark, hero text, product headings |
+| Body and UI | Geist | Navigation, controls, forms, prose, labels |
+| Code and machine voice | Geist Mono | Terminal, commands, paths, IDs, technical state |
 
-Orbitron is the brand voice — geometric, futuristic, distinctive. Use it for
-headings that identify Matrix OS (hero sections, page titles, onboarding).
-Do NOT use Orbitron for body text, labels, or navigation — it is not designed
-for readability at small sizes.
+Bricolage Grotesque supplies the recognizable voice. Geist supplies quiet,
+high-legibility interface copy. Geist Mono identifies content produced by or
+addressed to the machine. Do not substitute another family per platform.
 
-Inter handles everything else. It is neutral, highly legible, and has excellent
-support for all weights and sizes.
+### Scale
 
-### Type Scale
+| Style | Family | Size | Weight | Line height | Tracking |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Display | Bricolage Grotesque | 72px | 800 | 110% | -2% |
+| Heading 1 | Bricolage Grotesque | 48px | 700 | 115% | -1% |
+| Heading 2 | Bricolage Grotesque | 36px | 600 | 120% | -0.5% |
+| Heading 3 | Bricolage Grotesque | 28px | 500 | 125% | 0 |
+| Subtitle | Bricolage Grotesque | 22px | 500 | 140% | 0 |
+| Body large | Geist | 18px | 400 | 155% | 0 |
+| Body | Geist | 16px | 400 | 160% | 0.5% |
+| Body small | Geist | 14px | 400 | 160% | 1% |
+| Caption | Geist | 12px | 400 | 150% | 1.5% |
+| Overline / label | Geist | 11px | 700 | 130% | 3px |
+| Machine | Geist Mono | 14px | 400 | 150% | 0 |
 
-| Level       | Font     | Size   | Weight | Line Height | Use For                     |
-|-------------|----------|--------|--------|-------------|-----------------------------|
-| Display     | Orbitron | 3rem   | 700    | 1.1         | Hero headlines, landing page |
-| H1          | Orbitron | 2.25rem| 600    | 1.15        | Page titles                  |
-| H2          | Orbitron | 1.75rem| 600    | 1.2         | Section headings             |
-| H3          | Inter    | 1.25rem| 600    | 1.3         | Subtitles, subsections       |
-| H4          | Inter    | 1.125rem| 600   | 1.4         | Card titles, group labels    |
-| Body        | Inter    | 1rem   | 400    | 1.6         | Paragraphs, descriptions     |
-| Body Small  | Inter    | 0.875rem| 400   | 1.5         | Secondary text, metadata     |
-| Caption     | Inter    | 0.75rem| 400    | 1.4         | Timestamps, footnotes        |
-| Label       | Inter    | 0.75rem| 500    | 1.4         | Uppercase tags, categories   |
-| Mono        | JetBrains| 0.875rem| 400   | 1.5         | Code, terminal, data         |
+Scale display styles down fluidly on compact screens; do not reduce body text
+below 14px or touch targets below 44px. Labels may use uppercase only when they
+remain short.
 
-## Layout
+## Layout and shape
 
-### Spacing Scale
-
-Built on a 4px base grid. Every spacing value is a multiple of 4.
-
-| Token | Value | Use For                          |
-|-------|-------|----------------------------------|
-| xs    | 4px   | Tight gaps, icon padding         |
-| sm    | 8px   | Inline spacing, small gaps       |
-| md    | 16px  | Default padding, component gaps  |
-| lg    | 24px  | Card padding, section spacing    |
-| xl    | 32px  | Large gaps between groups        |
-| 2xl   | 48px  | Section breaks                   |
-| 3xl   | 64px  | Page section padding             |
-| 4xl   | 96px  | Hero/landing section padding     |
-
-### Principles
-
-- Generous whitespace. When in doubt, add more space, not less.
-- Content width: `max-w-6xl` (1152px) for full layouts, `max-w-3xl` for reading.
-- Mobile-first. Every layout must work at 320px width.
-- The shell is full viewport (`100vh × 100vw`, `overflow: hidden`).
-
-## Elevation & Depth
-
-### Shadows
-
-| Level | Value                                  | Use For                    |
-|-------|----------------------------------------|----------------------------|
-| xs    | `0 1px 2px rgba(50,53,46,0.04)`       | Inputs, subtle lift        |
-| sm    | `0 2px 4px rgba(50,53,46,0.06)`       | Cards at rest              |
-| md    | `0 4px 12px rgba(50,53,46,0.08)`      | Cards on hover, dropdowns  |
-| lg    | `0 8px 24px rgba(50,53,46,0.10)`      | Floating panels, modals    |
-| xl    | `0 16px 48px rgba(50,53,46,0.12)`     | Windows, dialogs           |
-
-Shadow color is always derived from Deep (`#32352E`), never pure black.
-
-### Glass-morphism
-
-Floating/transient elements use frosted glass:
-
-```css
-background: rgba(255, 255, 255, 0.80);
-backdrop-filter: blur(12px);
-border: 1px solid var(--border);
-```
-
-Heavier variant for input bars:
-```css
-background: rgba(255, 255, 255, 0.90);
-backdrop-filter: blur(16px);
-```
-
-## Shapes
-
-### Border Radius
-
-Every interactive element has rounded corners. No sharp edges.
-
-| Token | Value  | Use For                         |
-|-------|--------|---------------------------------|
-| sm    | 6px    | Small chips, tags, inline code  |
-| md    | 10px   | Inputs, small buttons           |
-| lg    | 14px   | Cards, panels, dialogs          |
-| xl    | 20px   | Feature cards, windows          |
-| 2xl   | 28px   | Hero cards, large containers    |
-| full  | 9999px | Pills, badges, avatars, FABs    |
-
-Default component radius is `xl` (20px). When nesting rounded elements,
-inner elements should use a smaller radius than their container.
+- Use a 4px spacing grid. Prefer 8, 16, 24, 32, 48, and 64px intervals.
+- Default component radius is 12px; brand cards use 16px; swatches and compact
+  controls use 8px; pills use the full radius.
+- Use whitespace before dividers, and dividers before additional containers.
+- Keep onboarding and other focused tasks within a narrow, single-purpose
+  composition. Do not borrow full Settings chrome for one decision.
+- Desktop, web, and mobile may arrange content differently, but hierarchy,
+  tokens, copy, and interaction outcomes remain equivalent.
 
 ## Components
 
 ### Buttons
 
-Buttons are pill-shaped (rounded-xl to rounded-full) with clear hierarchy:
+- Primary: Teal background, paper foreground, 12px radius.
+- Secondary: paper or transparent background, Teal text, subtle border.
+- Quiet: transparent with no persistent container.
+- Destructive: use a Coral-scale semantic color only for destructive actions.
+- Focus: Gold ring, never color-only state indication.
+- Keep one dominant primary action per region.
 
-| Variant   | Background   | Text          | Border | Use For                     |
-|-----------|-------------|---------------|--------|-----------------------------|
-| Primary   | Forest      | White         | None   | Main action per view        |
-| Accent    | Ember       | White         | None   | CTAs, sign up, "Get started"|
-| Secondary | Transparent | Deep          | Border | Secondary actions           |
-| Ghost     | Transparent | Deep          | None   | Tertiary, toolbar actions   |
+### Cards and panels
 
-- One accent button per view maximum
-- Primary for the most important action in a section
-- Hover state: darken background slightly, lift shadow
-- Active state: scale down 1-2%
-- Disabled: 40% opacity, no pointer events
-
-### Cards
-
-Cards are the primary content container.
-
-- Background: white (`#FFFFFF`)
-- Border: 1px solid `var(--border)`
-- Radius: `xl` (20px)
-- Shadow: `sm` at rest, `md` on hover
-- Padding: `lg` (24px)
-
-Glass variant for floating/overlay cards:
-```css
-background: rgba(255, 255, 255, 0.80);
-backdrop-filter: blur(12px);
-```
+- Default card: paper surface, subtle border, 16px radius, small or medium
+  ink-tinted shadow.
+- Nested content should usually use spacing or Green/Blue 50 surfaces rather
+  than another elevated card.
+- Glass and blur are reserved for transient overlays where seeing the spatial
+  context underneath helps the user.
 
 ### Inputs
 
-- Background: white
-- Border: 1px solid `var(--input)`
-- Radius: `lg` (14px)
-- Focus: 2px ring in Forest color
-- Padding: `sm` vertical, `md` horizontal
-- Placeholder text: `var(--muted-foreground)`
+- Use Geist at 14–16px.
+- Use paper surfaces, an 8–12px radius, and a clearly visible Gold focus ring.
+- Labels remain visible; placeholders explain format, never replace labels.
+- Errors use text and an icon in addition to color.
 
-### Icons
+### Status and semantic color
 
-- Style: line/outline, 1.5px stroke weight
-- Library: Lucide
-- Size: 16px (inline), 20px (buttons), 24px (navigation)
-- Color: inherits text color
+- Green/Teal: ready, connected, successful.
+- Gold: pending, selected, needs attention without failure.
+- Coral: failed, destructive, urgent.
+- Blue: informational, syncing, neutral progress.
+- Never encode state by color alone.
 
-### Pattern System
+### Window controls
 
-A topographic/organic line pattern is used for decorative backgrounds:
-- Stroke color: `rgba(67, 78, 63, 0.06)` (Forest at 6% opacity)
-- Used on: landing page hero, empty states, onboarding
-- Never competes with content — purely decorative, behind everything
+Matrix-owned window controls use Coral, Gold, and Green. They should not copy
+platform traffic-light values when Matrix chrome is being rendered. Native
+system chrome remains native.
 
-## Do's and Don'ts
+## Motion
 
-### Do
+- Use 120–240ms transitions for local interface changes.
+- Prefer opacity and short translations; avoid gratuitous scale and parallax.
+- Loading animation should communicate progress without preventing work.
+- Respect reduced-motion settings on every platform.
 
-- Use generous whitespace — let content breathe
-- Use Forest for structure, Ember for action, Cream for warmth
-- Keep corners rounded (`xl` for cards, `full` for pills)
-- Use Inter for all UI text including subtitles, card titles, and descriptions
-- Use Orbitron only for H1/H2 display headings and large stat numbers
-- Match shadow color to the palette (Deep-tinted, never black)
-- Use backdrop blur on floating elements
-- Animate with purpose: 150-300ms, ease-out for enter, ease-in for exit
-- Design for the smallest viewport first (320px)
-- Maintain warm off-white backgrounds — never pure white pages
+## Cross-platform implementation status
 
-### Don't
+This document defines the target brand contract. Cross-platform implementation
+parity is tracked separately across web, Electron desktop, native desktop, and
+mobile. Until that work lands:
 
-- Use sharp corners (`rounded-none`) anywhere
-- Use Orbitron for subtitles (H3+), body text, card titles, or small labels
-- Use Ember on everything — it's an accent, not a primary
-- Use pure black text or shadows (`#000000`)
-- Use neon, high-saturation, or cool-toned accent colors
-- Add heavy gradients — keep it flat with subtle depth from blur/shadow
-- Put more than one Ember/accent CTA in a single view
-- Mix font families in the same element
-- Use dark backgrounds in the default theme (this is a light-mode OS)
-- Ignore `prefers-reduced-motion` — always provide reduced-motion fallbacks
+- Figma and this document outrank existing product CSS or platform-local tokens.
+- `@matrix-os/brand` is the intended shared implementation boundary.
+- Existing legacy values may remain temporarily, but new UI must not copy them.
+- A parity PR should migrate implementations and tests without redefining the
+  brand in platform-specific terms.
+
+## Review checklist
+
+- [ ] Uses Matrix OS capitalization and the canonical mark.
+- [ ] Uses Bricolage Grotesque, Geist, and Geist Mono in their defined roles.
+- [ ] Uses semantic tokens backed by the approved palette rather than ad-hoc hex.
+- [ ] Meets WCAG AA for text, controls, focus, and non-text state indicators.
+- [ ] Preserves equivalent hierarchy and outcomes across form factors.
+- [ ] Keeps decoration subordinate to content and action.
+- [ ] Includes reduced-motion and keyboard/focus behavior.

--- a/design/README.md
+++ b/design/README.md
@@ -1,52 +1,58 @@
-# Matrix OS Design System
+# Matrix OS design system
 
-This directory contains the full design system specification for Matrix OS.
+The approved Figma brand file is the upstream visual source. [`DESIGN.md`](../DESIGN.md)
+is the canonical repository contract that translates it into implementation
+rules. The documents in this directory expand individual foundations and
+components without redefining them.
+
+## Authority
+
+1. [Approved Figma frame](https://www.figma.com/design/xPG2FeYRtC9owCKSVXCqWA/brand?node-id=1-846)
+2. [`DESIGN.md`](../DESIGN.md)
+3. Foundation and component guidance in this directory
+4. Shared implementation tokens in `@matrix-os/brand`
+5. Platform-local styling
+
+When two levels disagree, fix the lower level; do not create another token set.
+Changes to the visual source must be reconciled into `DESIGN.md` through a
+focused brand PR before product code adopts them.
 
 ## Structure
 
-```
-DESIGN.md                    ← Source of truth (YAML tokens + design rationale)
+```text
+DESIGN.md                    canonical contract and compact token reference
 design/
-├── README.md                ← This file
+├── README.md                authority and contribution workflow
 ├── foundations/
-│   ├── colors.md            ← Color palette, usage rules, accessibility
-│   ├── typography.md        ← Font stack, type scale, usage
-│   ├── spacing.md           ← Spacing scale, layout grid, principles
-│   └── elevation.md         ← Shadows, glass-morphism, z-index
-├── components/
-│   ├── button.md            ← Button variants, states, anatomy
-│   ├── card.md              ← Card types, glass variant, layout
-│   ├── input.md             ← Text inputs, textareas, selects
-│   ├── badge.md             ← Tags, pills, status indicators
-│   ├── dialog.md            ← Modals, sheets, drawers
-│   ├── navigation.md        ← Dock, tabs, breadcrumbs
-│   └── app-chrome.md        ← Window chrome, title bar, traffic lights
+│   ├── colors.md            palette, semantics, accessibility
+│   ├── typography.md        family roles and type scale
+│   ├── spacing.md           spacing and responsive layout
+│   └── elevation.md         depth, overlays, and layering
+└── components/
+    ├── button.md
+    ├── card.md
+    ├── input.md
+    ├── badge.md
+    ├── dialog.md
+    ├── navigation.md
+    └── app-chrome.md
 ```
 
-## How to Use
+## Implementation
 
-### For AI-assisted app generation
+- New landing-adjacent, auth, onboarding, billing, and provisioning UI consumes
+  `@matrix-os/brand` rather than platform-local hex values.
+- Web, Electron, native desktop, and mobile may use native primitives, but must
+  preserve the same token roles, content hierarchy, states, and outcomes.
+- Cross-platform migration and parity testing are intentionally tracked outside
+  the brand-contract PR.
+- The public reference at `shell/public/brand-guidelines.html` is a rendered
+  summary. It must agree with `DESIGN.md`, never become a separate authority.
 
-Include `DESIGN.md` in the AI context. It contains all tokens as YAML
-frontmatter and all design rationale as prose — optimized to fit in 2-5K
-tokens.
+## Principles
 
-### For frontend development
-
-The tokens in `DESIGN.md` map directly to CSS custom properties in
-`shell/src/app/globals.css`. When updating the design system, update both
-files.
-
-### For app developers
-
-Apps built on Matrix OS should read the component specs in `design/components/`
-to understand available patterns. The OS injects theme CSS variables into app
-iframes via the bridge.
-
-## Design Principles
-
-1. **Warm, not cold** — natural materials, forest/sand/ember palette
-2. **Calm, not busy** — generous whitespace, restrained animation
-3. **Rounded, not sharp** — soft corners everywhere, pill buttons
-4. **Light, not dark** — warm off-white backgrounds, white card surfaces
-5. **Purposeful, not decorative** — every element earns its place
+1. Expressive, not ornamental.
+2. Calm, not empty.
+3. Organic, not rustic.
+4. Technical, not intimidating.
+5. Bright, not childish.

--- a/design/components/app-chrome.md
+++ b/design/components/app-chrome.md
@@ -32,7 +32,7 @@ The window frame surrounding every app in the Matrix OS desktop.
 | Property     | Value                        |
 |--------------|------------------------------|
 | Height       | 32px                         |
-| Background   | `--card`                     |
+| Background   | Paper `#FCFCF8`              |
 | Border       | 1px bottom `--border`        |
 | Title font   | Body small (0.875rem), 500   |
 | Title align  | Center                       |
@@ -40,13 +40,14 @@ The window frame surrounding every app in the Matrix OS desktop.
 
 ## Traffic Lights
 
-macOS-style window controls at top-left of the title bar.
+Matrix-owned window controls at the top-left of the title bar use the brand
+palette. Native macOS or Windows chrome remains platform-native.
 
-| Button   | Color     | Hex       |
-|----------|-----------|-----------|
-| Close    | Red       | `#FF5F57` |
-| Minimize | Yellow    | `#FEBC2E` |
-| Maximize | Green     | `#28C840` |
+| Button   | Color        | Hex       |
+|----------|--------------|-----------|
+| Close    | Coral 500    | `#BA5236` |
+| Minimize | Gold 300     | `#F1C379` |
+| Maximize | Green 300    | `#BED77B` |
 
 - Size: 12×12px (`rounded-full`)
 - Gap: 8px between dots
@@ -58,7 +59,7 @@ macOS-style window controls at top-left of the title bar.
 
 | Property    | Value                   |
 |-------------|-------------------------|
-| Radius      | `xl` (20px)             |
+| Radius      | 16px                     |
 | Shadow      | `xl`                    |
 | Border      | 1px solid `--border`    |
 | Background  | `--card`                |

--- a/design/components/app-chrome.md
+++ b/design/components/app-chrome.md
@@ -3,9 +3,9 @@ title: App Chrome
 description: Window chrome, title bar, and traffic lights for app windows.
 status: stable
 tokens:
-  - colors.card
-  - colors.foreground
-  - colors.border
+  - semanticColors.surface
+  - semanticColors.foreground
+  - semanticColors.border
   - rounded.xl
   - shadows.xl
 ---
@@ -33,7 +33,7 @@ The window frame surrounding every app in the Matrix OS desktop.
 |--------------|------------------------------|
 | Height       | 32px                         |
 | Background   | Paper `#FCFCF8`              |
-| Border       | 1px bottom `--border`        |
+| Border       | 1px bottom `semanticColors.border` |
 | Title font   | Body small (0.875rem), 500   |
 | Title align  | Center                       |
 | Draggable    | Yes (except over controls)   |
@@ -53,7 +53,7 @@ palette. Native macOS or Windows chrome remains platform-native.
 - Gap: 8px between dots
 - Left padding: 12px from window edge
 - Hover: brighten slightly
-- Inactive window: all three become `--muted` (gray)
+- Inactive window: all three use `semanticColors.muted`
 
 ## Window Frame
 
@@ -61,8 +61,8 @@ palette. Native macOS or Windows chrome remains platform-native.
 |-------------|-------------------------|
 | Radius      | 16px                     |
 | Shadow      | `xl`                    |
-| Border      | 1px solid `--border`    |
-| Background  | `--card`                |
+| Border      | 1px solid `semanticColors.border` |
+| Background  | `semanticColors.surface` |
 | Min size    | 320×200px               |
 | Resize      | Bottom-right corner     |
 

--- a/design/components/badge.md
+++ b/design/components/badge.md
@@ -3,10 +3,10 @@ title: Badge
 description: Tags, pills, and status indicators.
 status: stable
 tokens:
-  - colors.primary
-  - colors.accent
-  - colors.secondary
-  - colors.muted
+  - semanticColors.primary
+  - semanticColors.accent
+  - semanticColors.muted
+  - semanticColors.foreground
   - rounded.full
   - typography.caption
 ---
@@ -29,11 +29,11 @@ Small labels for categorization, status, and metadata.
 |-----------|-------------------------|-------------------|-----------------------------|
 | Default   | Teal 100                | Teal 800          | Categories, tags            |
 | Accent    | Green 200               | Ink               | Highlights, new, featured   |
-| Muted     | `--muted`               | `--muted-fg`      | Metadata, secondary info    |
+| Muted     | `semanticColors.muted`   | `semanticColors.mutedForeground` | Metadata, secondary info |
 | Success   | Green 200               | Teal 800          | Active, online, completed   |
 | Warning   | Gold 200                | Gold 800          | Pending, attention needed   |
 | Danger    | Coral 100               | Coral 700         | Error, offline, critical    |
-| Outline   | transparent             | `--foreground`    | Subtle categorization       |
+| Outline   | transparent             | `semanticColors.foreground` | Subtle categorization    |
 
 ## Properties
 

--- a/design/components/badge.md
+++ b/design/components/badge.md
@@ -27,12 +27,12 @@ Small labels for categorization, status, and metadata.
 
 | Variant   | Background              | Text              | Use For                     |
 |-----------|-------------------------|-------------------|-----------------------------|
-| Default   | `--primary` @ 10%       | `--primary`       | Categories, tags            |
-| Accent    | `--accent` @ 10%        | `--accent`        | Highlights, new, featured   |
+| Default   | Teal 100                | Teal 800          | Categories, tags            |
+| Accent    | Green 200               | Ink               | Highlights, new, featured   |
 | Muted     | `--muted`               | `--muted-fg`      | Metadata, secondary info    |
-| Success   | `--success` @ 10%       | `--success`       | Active, online, completed   |
-| Warning   | `--warning` @ 10%       | `--warning`       | Pending, attention needed   |
-| Danger    | `--destructive` @ 10%   | `--destructive`   | Error, offline, critical    |
+| Success   | Green 200               | Teal 800          | Active, online, completed   |
+| Warning   | Gold 200                | Gold 800          | Pending, attention needed   |
+| Danger    | Coral 100               | Coral 700         | Error, offline, critical    |
 | Outline   | transparent             | `--foreground`    | Subtle categorization       |
 
 ## Properties

--- a/design/components/button.md
+++ b/design/components/button.md
@@ -3,11 +3,12 @@ title: Button
 description: Buttons trigger actions with one clear visual hierarchy.
 status: stable
 tokens:
-  - colors.primary
-  - colors.secondary
-  - colors.foreground
-  - colors.border
-  - rounded.xl
+  - semanticColors.primary
+  - semanticColors.primaryForeground
+  - semanticColors.surface
+  - semanticColors.foreground
+  - semanticColors.border
+  - rounded.lg
   - rounded.full
 ---
 

--- a/design/components/button.md
+++ b/design/components/button.md
@@ -1,10 +1,10 @@
 ---
 title: Button
-description: Buttons trigger actions. Four variants with clear hierarchy.
+description: Buttons trigger actions with one clear visual hierarchy.
 status: stable
 tokens:
   - colors.primary
-  - colors.accent
+  - colors.secondary
   - colors.foreground
   - colors.border
   - rounded.xl
@@ -28,12 +28,14 @@ Buttons are the primary way users trigger actions.
 
 ## Variants
 
-| Variant   | Background       | Text Color       | Border           | Use For                       |
-|-----------|------------------|------------------|------------------|-------------------------------|
-| Primary   | `--primary`      | `--primary-fg`   | none             | Main action in a section      |
-| Accent    | `--accent`       | `--accent-fg`    | none             | CTAs: sign up, get started    |
-| Secondary | transparent      | `--foreground`   | `--border`       | Secondary actions             |
-| Ghost     | transparent      | `--foreground`   | none             | Tertiary, toolbar, icon-only  |
+| Variant     | Background       | Text Color       | Border           | Use For                       |
+|-------------|------------------|------------------|------------------|-------------------------------|
+| Primary     | Teal 800         | Paper            | none             | The single main action        |
+| Secondary   | Paper            | Ink              | Border           | Alternative actions           |
+| Quiet/Ghost | transparent      | Ink              | none             | Toolbars and tertiary actions |
+| Destructive | Coral 500        | Paper or Ink*     | none             | Confirmed destructive actions |
+
+*Choose the text color that passes WCAG contrast at the rendered token value.
 
 ## Sizes
 
@@ -51,20 +53,20 @@ Buttons are the primary way users trigger actions.
 | Default  | As specified per variant                       |
 | Hover    | Darken background 8%, elevate shadow to `sm`   |
 | Active   | Scale to 0.98, shadow to `xs`                  |
-| Focus    | 2px ring in `--ring` color, offset 2px         |
+| Focus    | 2px Gold 300 ring, offset 2px                   |
 | Disabled | 40% opacity, `pointer-events: none`            |
 | Loading  | Replace label with spinner, maintain width     |
 
 ## Shape
 
-- Default radius: `rounded-xl` (20px)
+- Default radius: 12px
 - Pill variant: `rounded-full` for chips, tags, and compact actions
 - Never use sharp corners on buttons
 
 ## Usage Rules
 
-1. **One accent button per view.** Accent (Ember) is the loudest — use it only
-   for the single most important CTA.
+1. **One primary button per decision area.** Use it only for the action that
+   advances the user.
 2. **Primary for section-level actions.** "Save", "Create", "Send" — the main
    thing the user came to do.
 3. **Secondary for alternatives.** "Cancel", "Back", "Export" — present but
@@ -76,7 +78,7 @@ Buttons are the primary way users trigger actions.
 
 ```tsx
 <Button>Save Changes</Button>
-<Button variant="accent">Get Started</Button>
+<Button>Get Started</Button>
 <Button variant="secondary">Cancel</Button>
 <Button variant="ghost" size="icon"><Settings /></Button>
 ```
@@ -89,6 +91,6 @@ Buttons are the primary way users trigger actions.
 - Show loading state when the action is async
 
 **Don't:**
-- Put two accent buttons next to each other
+- Put two primary buttons next to each other
 - Use long labels — keep to 1-3 words
 - Disable without explanation (use a tooltip on the disabled button)

--- a/design/components/card.md
+++ b/design/components/card.md
@@ -3,9 +3,9 @@ title: Card
 description: Cards are the primary content container in Matrix OS.
 status: stable
 tokens:
-  - colors.card
-  - colors.card-foreground
-  - colors.border
+  - semanticColors.surface
+  - semanticColors.foreground
+  - semanticColors.border
   - rounded.xl
   - shadows.sm
   - shadows.md
@@ -54,7 +54,7 @@ Cards group related content and actions into a single surface.
 |-------------|-------------------------|
 | Radius      | 16px                     |
 | Padding     | `lg` (24px)             |
-| Border      | 1px solid `--border`    |
+| Border      | 1px solid `semanticColors.border` |
 | Shadow rest | `sm`                    |
 | Shadow hover| `md` (if interactive)   |
 
@@ -65,7 +65,7 @@ Cards group related content and actions into a single surface.
 | Default  | `shadow-sm`, static                              |
 | Hover    | `shadow-md`, slight lift (if card is clickable)  |
 | Active   | Scale 0.99 (if card is clickable)                |
-| Selected | 2px border in `--primary`, `shadow-md`           |
+| Selected | 2px border in `semanticColors.primary`, `shadow-md` |
 
 ## Sizing
 

--- a/design/components/card.md
+++ b/design/components/card.md
@@ -42,17 +42,17 @@ Cards group related content and actions into a single surface.
 
 | Variant   | Background                    | Border | Shadow | Use For                      |
 |-----------|-------------------------------|--------|--------|------------------------------|
-| Default   | `--card` (white)              | 1px    | `sm`   | Standard content containers  |
-| Muted     | `--muted`                     | none   | none   | Nested/secondary content     |
-| Glass     | `rgba(255,255,255,0.80)` blur | 1px    | `lg`   | Floating/overlay cards       |
-| Elevated  | `--card` (white)              | 1px    | `md`   | Feature cards, highlights    |
-| Accent    | `--secondary` (cream)         | 1px    | `sm`   | Callouts, tips, warm fills   |
+| Default   | Paper `#FCFCF8`               | 1px    | `sm`   | Standard content containers  |
+| Muted     | Green 50 or Blue 50           | none   | none   | Nested/secondary content     |
+| Glass     | Paper at 80% with blur        | 1px    | `lg`   | Floating/overlay cards       |
+| Elevated  | Paper `#FCFCF8`               | 1px    | `md`   | Feature cards, highlights    |
+| Accent    | Green 100 or Blue 100         | 1px    | `sm`   | Callouts and helpful context |
 
 ## Properties
 
 | Property    | Value                   |
 |-------------|-------------------------|
-| Radius      | `xl` (20px)             |
+| Radius      | 16px                     |
 | Padding     | `lg` (24px)             |
 | Border      | 1px solid `--border`    |
 | Shadow rest | `sm`                    |
@@ -78,7 +78,7 @@ Minimum card width: 240px (prevents content from becoming illegible).
 
 When nesting cards (e.g., a card inside a card), the inner card should use:
 - Variant: `muted` (to differentiate from parent)
-- Radius: `lg` (14px — one step smaller than parent's `xl`)
+- Radius: 12px — one step smaller than the parent's radius
 - Shadow: none (the parent provides elevation)
 
 ## Code Example
@@ -101,7 +101,7 @@ When nesting cards (e.g., a card inside a card), the inner card should use:
 
 Glass variant:
 ```tsx
-<Card className="bg-white/80 backdrop-blur-md shadow-lg">
+<Card className="bg-[rgba(252,252,248,0.80)] backdrop-blur-md shadow-lg">
   ...
 </Card>
 ```

--- a/design/components/dialog.md
+++ b/design/components/dialog.md
@@ -43,12 +43,12 @@ Dialogs interrupt the user to request information or confirmation.
 
 | Property    | Value                        |
 |-------------|------------------------------|
-| Radius      | `xl` (20px)                  |
+| Radius      | 16px                         |
 | Shadow      | `xl`                         |
 | Padding     | `lg` (24px)                  |
-| Background  | `--card` (white)             |
+| Background  | Paper `#FCFCF8`              |
 | Border      | 1px solid `--border`         |
-| Backdrop    | `rgba(50, 53, 46, 0.40)` blur 8px |
+| Backdrop    | `rgba(31, 45, 29, 0.40)` blur 8px |
 
 ## Behavior (from UX Guide)
 

--- a/design/components/dialog.md
+++ b/design/components/dialog.md
@@ -3,9 +3,9 @@ title: Dialog
 description: Modals, sheets, and drawers for focused interactions.
 status: stable
 tokens:
-  - colors.card
-  - colors.foreground
-  - colors.border
+  - semanticColors.surface
+  - semanticColors.foreground
+  - semanticColors.border
   - rounded.xl
   - shadows.xl
 ---
@@ -47,7 +47,7 @@ Dialogs interrupt the user to request information or confirmation.
 | Shadow      | `xl`                         |
 | Padding     | `lg` (24px)                  |
 | Background  | Paper `#FCFCF8`              |
-| Border      | 1px solid `--border`         |
+| Border      | 1px solid `semanticColors.border` |
 | Backdrop    | `rgba(31, 45, 29, 0.40)` blur 8px |
 
 ## Behavior (from UX Guide)

--- a/design/components/input.md
+++ b/design/components/input.md
@@ -37,9 +37,9 @@ Form inputs for collecting user data.
 | Property    | Value                     |
 |-------------|---------------------------|
 | Height      | 40px (md), 32px (sm)      |
-| Radius      | `lg` (14px)               |
+| Radius      | 12px                       |
 | Padding     | 8px vertical, 16px horiz  |
-| Font        | Inter, body-small (0.875rem) |
+| Font        | Geist, body-small (0.875rem) |
 | Placeholder | `--muted-foreground`      |
 | Border      | 1px solid `--input`       |
 
@@ -49,7 +49,7 @@ Form inputs for collecting user data.
 |----------|-------------------------------------------------|
 | Default  | 1px border `--input`                             |
 | Hover    | Border darkens slightly                          |
-| Focus    | 2px ring in `--ring`, border becomes `--ring`    |
+| Focus    | 2px Gold 300 ring; border becomes Gold 500       |
 | Error    | Border and ring become `--destructive`           |
 | Disabled | 50% opacity, `--muted` background                |
 
@@ -59,7 +59,7 @@ The main command input uses the glass variant — centered at viewport bottom,
 full-width within constraints:
 
 ```tsx
-<div className="flex items-center gap-2 rounded-xl border bg-white/90
+<div className="flex items-center gap-2 rounded-xl border bg-[rgba(252,252,248,0.90)]
                 backdrop-blur-md px-4 py-2 shadow-lg">
   <Input className="border-0 bg-transparent shadow-none
                     focus-visible:ring-0" />

--- a/design/components/input.md
+++ b/design/components/input.md
@@ -3,11 +3,11 @@ title: Input
 description: Text inputs, textareas, and select fields.
 status: stable
 tokens:
-  - colors.card
-  - colors.input
-  - colors.foreground
-  - colors.muted-foreground
-  - colors.ring
+  - semanticColors.surface
+  - semanticColors.border
+  - semanticColors.foreground
+  - semanticColors.mutedForeground
+  - semanticColors.focus
   - rounded.lg
 ---
 
@@ -29,7 +29,7 @@ Form inputs for collecting user data.
 
 | Variant   | Background | Border          | Use For                    |
 |-----------|------------|-----------------|----------------------------|
-| Default   | `--card`   | 1px `--input`   | Standard form fields       |
+| Default   | `semanticColors.surface` | 1px `semanticColors.border` | Standard form fields |
 | Ghost     | transparent| none            | Inline editing, search bars|
 
 ## Properties
@@ -40,18 +40,18 @@ Form inputs for collecting user data.
 | Radius      | 12px                       |
 | Padding     | 8px vertical, 16px horiz  |
 | Font        | Geist, body-small (0.875rem) |
-| Placeholder | `--muted-foreground`      |
-| Border      | 1px solid `--input`       |
+| Placeholder | `semanticColors.mutedForeground` |
+| Border      | 1px solid `semanticColors.border` |
 
 ## States
 
 | State    | Change                                          |
 |----------|-------------------------------------------------|
-| Default  | 1px border `--input`                             |
+| Default  | 1px border `semanticColors.border`                |
 | Hover    | Border darkens slightly                          |
 | Focus    | 2px Gold 300 ring; border becomes Gold 500       |
-| Error    | Border and ring become `--destructive`           |
-| Disabled | 50% opacity, `--muted` background                |
+| Error    | Border and ring become `semanticColors.danger`    |
+| Disabled | 50% opacity, `semanticColors.muted` background    |
 
 ## Input Bar Pattern (Shell)
 

--- a/design/components/navigation.md
+++ b/design/components/navigation.md
@@ -23,7 +23,7 @@ The dock is the primary launcher and task indicator.
 |-------------|------------------------------------------|
 | Position    | Left side (desktop), bottom (mobile)     |
 | Width       | 56px (desktop), full width (mobile)      |
-| Background  | `--card` @ 40% with backdrop blur        |
+| Background  | Paper at 40% with backdrop blur          |
 | Border      | 1px `--border` @ 40% on the right edge   |
 | Icon size   | 40×40px with `xl` radius                 |
 | Gap         | `sm` (8px) between icons                 |
@@ -34,8 +34,8 @@ The dock is the primary launcher and task indicator.
 |----------|-------------------------------------------------|
 | Default  | `--card` background, `--border` border, `shadow-sm` |
 | Hover    | `shadow-md`, scale 1.05                          |
-| Active   | Running indicator dot below (6px, `--primary`)   |
-| Selected | `--primary` background, white icon               |
+| Active   | Running indicator dot below (6px, Green 300)      |
+| Selected | Teal 800 background, Paper icon                   |
 
 ### Behavior
 

--- a/design/components/navigation.md
+++ b/design/components/navigation.md
@@ -3,10 +3,10 @@ title: Navigation
 description: Dock, tabs, and navigation patterns.
 status: stable
 tokens:
-  - colors.primary
-  - colors.card
-  - colors.border
-  - colors.muted
+  - semanticColors.primary
+  - semanticColors.surface
+  - semanticColors.border
+  - semanticColors.muted
   - rounded.xl
   - rounded.full
 ---
@@ -24,7 +24,7 @@ The dock is the primary launcher and task indicator.
 | Position    | Left side (desktop), bottom (mobile)     |
 | Width       | 56px (desktop), full width (mobile)      |
 | Background  | Paper at 40% with backdrop blur          |
-| Border      | 1px `--border` @ 40% on the right edge   |
+| Border      | 1px `semanticColors.border` at 40%       |
 | Icon size   | 40×40px with `xl` radius                 |
 | Gap         | `sm` (8px) between icons                 |
 
@@ -32,7 +32,7 @@ The dock is the primary launcher and task indicator.
 
 | State    | Visual                                         |
 |----------|-------------------------------------------------|
-| Default  | `--card` background, `--border` border, `shadow-sm` |
+| Default  | Surface background, semantic border, `shadow-sm`    |
 | Hover    | `shadow-md`, scale 1.05                          |
 | Active   | Running indicator dot below (6px, Green 300)      |
 | Selected | Teal 800 background, Paper icon                   |
@@ -54,9 +54,9 @@ Used in bottom panel and within apps.
 |------------|-----------------------------------|
 | Height     | 36px                              |
 | Font       | Body small (0.875rem), weight 500 |
-| Radius     | `lg` (14px) for tab container     |
-| Active bg  | `--card` with `shadow-sm`         |
-| Inactive   | transparent, `--muted-foreground` |
+| Radius     | `rounded.lg` (12px) for tab container |
+| Active bg  | `semanticColors.surface` with `shadow-sm` |
+| Inactive   | transparent, `semanticColors.mutedForeground` |
 | Gap        | `xs` (4px) between tabs           |
 
 ### Toggle Behavior
@@ -76,7 +76,7 @@ Home  /  Settings  /  Appearance
  link     link         current (not linked)
 ```
 
-- Separator: `/` in `--muted-foreground`
-- Links: `--foreground`, underline on hover
-- Current: `--muted-foreground`, no underline
+- Separator: `/` in `semanticColors.mutedForeground`
+- Links: `semanticColors.foreground`, underline on hover
+- Current: `semanticColors.mutedForeground`, no underline
 - Font: Body small

--- a/design/foundations/colors.md
+++ b/design/foundations/colors.md
@@ -1,106 +1,70 @@
 ---
 title: Colors
-description: Matrix OS color palette, semantic tokens, and usage guidelines.
+description: Approved Matrix OS palette, semantic roles, and accessibility rules.
 status: stable
+source: Figma xPG2FeYRtC9owCKSVXCqWA, node 1:846
 ---
 
 # Colors
 
-## Brand Palette
+## Core palette
 
-Four colors define the Matrix OS identity.
+| Name | Hex | RGB | Role |
+| --- | --- | --- | --- |
+| Teal | `#0E3422` | `14, 52, 34` | Identity, primary action, navigation |
+| Coral | `#D06E53` | `208, 110, 83` | Attention, warmth, destructive emphasis |
+| Gold | `#F1C379` | `241, 195, 121` | Focus, selection, optimistic emphasis |
+| Green | `#BED77B` | `190, 215, 123` | Mark, success, ready states |
+| Blue | `#C5D6E2` | `197, 214, 226` | Information, passive progress |
 
-| Name   | Hex       | RGB              | Role                                          |
-|--------|-----------|------------------|-----------------------------------------------|
-| Forest | `#434E3F` | `67, 78, 63`    | Primary brand, structural elements, authority  |
-| Cream  | `#E0E1CA` | `224, 225, 202`  | Warmth, secondary surfaces, resting states     |
-| Ember  | `#D06F25` | `208, 111, 37`   | Action, energy, calls to attention             |
-| Deep   | `#32352E` | `50, 53, 46`     | Text, depth, grounding                         |
+Teal anchors the composition. Use the supporting colors deliberately; a view
+should not give all five equal visual weight.
 
-## UI Token Map
+## Full scales
 
-These CSS custom properties are the closed token set. All UI code must reference
-tokens — never hardcode hex values.
+| Step | Green | Teal | Coral | Gold | Blue | Neutral |
+| ---: | --- | --- | --- | --- | --- | --- |
+| 50 | `#F4F7ED` | `#EEF7F2` | `#FAEEEB` | `#FCF5E8` | `#EDF3F7` | `#FFFFFF` |
+| 100 | `#E4EDD4` | `#C9E8D9` | `#F2D6CF` | `#FAEAD1` | `#C5D6E2` | `#F3F2F2` |
+| 200 | `#CEE0AE` | `#97D8B9` | `#E6B5A8` | `#F6DAAC` | `#9DBFD7` | `#E1E0E0` |
+| 300 | `#BED77B` | `#5EC996` | `#DA9481` | `#F1C379` | `#71A9D0` | `#C8C6C6` |
+| 400 | `#9AC059` | `#34B275` | `#D06E53` | `#E0AA52` | `#5CA0D1` | `#A8A4A4` |
+| 500 | `#748E59` | `#288A5B` | `#BA5236` | `#D2932D` | `#3B85BA` | `#827D7D` |
+| 600 | `#62783A` | `#1B6541` | `#8F432D` | `#A37429` | `#306991` | `#635F5F` |
+| 700 | `#475926` | `#13492F` | `#6B3324` | `#775622` | `#254D6A` | `#413E3E` |
+| 800 | `#2B3715` | `#0E3422` | `#442118` | `#4D3919` | `#193143` | `#242323` |
+| 900 | `#171F0A` | `#061810` | `#25130E` | `#251C0E` | `#0F1B24` | `#0D0C0C` |
 
-### Surfaces
+## Semantic mapping
 
-| Token                  | Value     | Usage                              |
-|------------------------|-----------|-------------------------------------|
-| `--background`         | `#FAFAF5` | Page/canvas background (warm white) |
-| `--foreground`         | `#32352E` | Primary text                        |
-| `--card`               | `#FFFFFF` | Card/panel surfaces                 |
-| `--card-foreground`    | `#32352E` | Text on cards                       |
-| `--popover`            | `#FFFFFF` | Popover/dropdown surfaces           |
-| `--popover-foreground` | `#32352E` | Text on popovers                    |
-| `--muted`              | `#F0EDE4` | Muted backgrounds, disabled fills   |
-| `--muted-foreground`   | `#7A7768` | De-emphasized text                  |
-
-### Interactive
-
-| Token                     | Value     | Usage                         |
-|---------------------------|-----------|-------------------------------|
-| `--primary`               | `#434E3F` | Primary buttons, active nav   |
-| `--primary-foreground`    | `#FAFAF5` | Text on primary               |
-| `--secondary`             | `#E0E1CA` | Secondary buttons, fills      |
-| `--secondary-foreground`  | `#32352E` | Text on secondary             |
-| `--accent`                | `#D06F25` | CTA buttons, highlights       |
-| `--accent-foreground`     | `#FFFFFF` | Text on accent                |
-
-### Chrome
-
-| Token       | Value     | Usage                           |
-|-------------|-----------|----------------------------------|
-| `--border`  | `#D6D3C8` | All borders (warm gray)          |
-| `--input`   | `#D6D3C8` | Input borders                    |
-| `--ring`    | `#434E3F` | Focus rings                      |
-
-### Semantic
-
-| Token           | Value     | Usage                         |
-|-----------------|-----------|-------------------------------|
-| `--destructive` | `#C4342D` | Errors, delete, danger        |
-| `--success`     | `#3A7D44` | Positive, confirmation        |
-| `--warning`     | `#D49B2A` | Warnings, caution             |
-
-### Gradient (Background/Desktop)
-
-| Token              | Value     |
-|--------------------|-----------|
-| `--gradient-deep`  | `#32352E` |
-| `--gradient-mid`   | `#434E3F` |
-| `--gradient-light` | `#E0E1CA` |
-| `--gradient-accent`| `#D06F25` |
+| Role | Value | Guidance |
+| --- | --- | --- |
+| Canvas | Green 50 `#F4F7ED` | Default page/background tint |
+| Paper | `#FCFCF8` | Brand cards and primary surfaces |
+| Elevated surface | Neutral 50 `#FFFFFF` | Menus, dialogs, raised content |
+| Foreground | `#1F2D1D` | Primary ink |
+| Muted foreground | Neutral 600 `#635F5F` | Secondary copy |
+| Border | `#E0E1CA` | Quiet warm divider/border |
+| Primary | Teal 800 `#0E3422` | Main controls and active navigation |
+| Accent | Coral 400 `#D06E53` | Attention and warmth, not body text |
+| Focus | Gold 300 `#F1C379` | Keyboard focus and selection ring |
+| Success | Teal 500 `#288A5B` | Connected and completed |
+| Warning | Gold 500 `#D2932D` | Pending and caution |
+| Danger | Coral 500 `#BA5236` | Errors and destructive actions |
+| Info | Blue 500 `#3B85BA` | Information and neutral progress |
 
 ## Accessibility
 
-All text/background combinations must meet WCAG AA (4.5:1 for body, 3:1 for
-large text).
+All body text and controls meet WCAG AA. State is never communicated by color
+alone.
 
-| Combination                        | Ratio    | Passes        |
-|------------------------------------|----------|---------------|
-| Deep on Background (#32352E / #FAFAF5) | 13.2:1 | AAA           |
-| Deep on Cream (#32352E / #E0E1CA)      | 7.8:1  | AAA           |
-| Forest on White (#434E3F / #FFFFFF)    | 8.1:1  | AAA           |
-| Forest on Background (#434E3F / #FAFAF5)| 7.6:1 | AAA           |
-| Ember on White (#D06F25 / #FFFFFF)     | 3.6:1  | AA large only |
-| White on Ember (#FFFFFF / #D06F25)     | 3.6:1  | AA large only |
-| White on Forest (#FFFFFF / #434E3F)    | 8.1:1  | AAA           |
+| Combination | Ratio | Result |
+| --- | ---: | --- |
+| Teal on paper | 13.32:1 | AAA |
+| Ink on paper | 14.07:1 | AAA |
+| Ink on Green | 9.09:1 | AAA |
+| Teal on Blue | 9.19:1 | AAA |
+| Coral on paper | 3.38:1 | Large text/non-text only |
 
-**Rule**: Never use Ember as a background for small body text. Pair Ember
-backgrounds with white text at 18px+ or bold 14px+. For smaller text on
-Ember, use Deep instead.
-
-## Usage Rules
-
-1. **One Ember accent per view.** Ember is the loudest color — using it on
-   multiple elements in the same view creates visual noise.
-2. **Forest is structural.** It carries authority. Use for headers, primary
-   buttons, navigation active states, and icons.
-3. **Cream is warmth.** It fills space without demanding attention. Secondary
-   surfaces, hover states, sidebar backgrounds.
-4. **Deep is text.** Almost all body text uses Deep. Reserve Forest for headings
-   and interactive text (links, button labels).
-5. **Never use pure black** (`#000000`). Deep (#32352E) is the darkest value
-   in the system.
-6. **Never use pure white backgrounds** for the page. Use Background (#FAFAF5).
-   Cards and elevated surfaces may be white (#FFFFFF).
+Use Teal for small interactive text and button fills. Coral needs dark text or a
+larger/non-text application after checking the exact pair.

--- a/design/foundations/elevation.md
+++ b/design/foundations/elevation.md
@@ -8,15 +8,15 @@ status: stable
 
 ## Shadow Scale
 
-Shadow color is always derived from Deep (`#32352E`), never pure black.
+Shadow color is derived from brand Ink (`#1F2D1D`), never pure black.
 
 | Level | Value                                    | Use For                      |
 |-------|------------------------------------------|------------------------------|
-| xs    | `0 1px 2px rgba(50, 53, 46, 0.04)`     | Inputs, subtle lift          |
-| sm    | `0 2px 4px rgba(50, 53, 46, 0.06)`     | Cards at rest                |
-| md    | `0 4px 12px rgba(50, 53, 46, 0.08)`    | Cards on hover, dropdowns    |
-| lg    | `0 8px 24px rgba(50, 53, 46, 0.10)`    | Floating panels, modals      |
-| xl    | `0 16px 48px rgba(50, 53, 46, 0.12)`   | Windows, full dialogs        |
+| xs    | `0 1px 2px rgba(31, 45, 29, 0.05)`     | Inputs, subtle lift          |
+| sm    | `0 2px 8px rgba(31, 45, 29, 0.07)`     | Cards at rest                |
+| md    | `0 4px 24px rgba(31, 45, 29, 0.08)`    | Cards on hover, dropdowns    |
+| lg    | `0 12px 36px rgba(31, 45, 29, 0.12)`   | Floating panels, modals      |
+| xl    | `0 24px 64px rgba(31, 45, 29, 0.16)`   | Windows, full dialogs        |
 
 ## Glass-morphism
 
@@ -25,9 +25,9 @@ with the content behind them.
 
 | Variant  | Background               | Blur    | Use For                    |
 |----------|--------------------------|---------|----------------------------|
-| Light    | `rgba(255,255,255,0.70)` | 12px    | Tooltips, light overlays   |
-| Standard | `rgba(255,255,255,0.80)` | 12px    | Panels, sidebars, popovers|
-| Heavy    | `rgba(255,255,255,0.90)` | 16px    | Input bars, dialogs        |
+| Light    | `rgba(252,252,248,0.70)` | 12px    | Tooltips, light overlays   |
+| Standard | `rgba(252,252,248,0.82)` | 12px    | Panels, sidebars, popovers |
+| Heavy    | `rgba(252,252,248,0.92)` | 16px    | Input bars, dialogs        |
 
 Always pair glass surfaces with `border: 1px solid var(--border)` for a
 visible edge.
@@ -55,5 +55,5 @@ From the UX Guide — material type determines visual treatment:
   background, `sm` or `md` shadow
 - **Transient surfaces** (popovers, tooltips, drawers): glass-morphism with
   backdrop blur, `lg` shadow
-- **Overlays** (mission control, modal backdrops): `rgba(50, 53, 46, 0.40)`
+- **Overlays** (mission control, modal backdrops): `rgba(31, 45, 29, 0.40)`
   with `backdrop-filter: blur(8px)`

--- a/design/foundations/typography.md
+++ b/design/foundations/typography.md
@@ -1,112 +1,70 @@
 ---
 title: Typography
-description: Matrix OS font stack, type scale, and usage guidelines.
+description: Approved Matrix OS font families, type scale, and usage rules.
 status: stable
+source: Figma xPG2FeYRtC9owCKSVXCqWA, node 1:846
 ---
 
 # Typography
 
-## Font Stack
+## Families
 
-| Role    | Font           | Variable          | Loaded Via          |
-|---------|----------------|-------------------|---------------------|
-| Display | Orbitron       | `--font-display`  | `next/font/google`  |
-| UI      | Inter          | `--font-sans`     | `next/font/google`  |
-| Code    | JetBrains Mono | `--font-mono`     | `next/font/google`  |
+| Role | Family | Use |
+| --- | --- | --- |
+| Display and headings | **Bricolage Grotesque** | Wordmark, hero text, product headings |
+| Body and UI | **Geist** | Controls, navigation, forms, prose, labels |
+| Code and machine voice | **Geist Mono** | Terminal, commands, paths, IDs, technical state |
 
-## When to Use Each Font
+The family roles are shared across web, desktop, and mobile. Native shells may
+bundle the font differently, but must not substitute a platform-specific brand
+voice.
 
-### Orbitron (Display)
+### Bricolage Grotesque
 
-Orbitron is the Matrix OS brand typeface — geometric, futuristic, immediately
-recognizable. It signals "this is Matrix OS."
+Use for expressive hierarchy: wordmark, display, H1–H3, and short subtitles.
+Keep long-form copy and dense controls in Geist.
 
-**Use for:**
-- Logo lockup
-- Hero headlines on landing/marketing pages
-- Page titles in the shell (e.g., "Settings", "Mission Control")
-- Onboarding headings
-- App names in large formats (gallery, splash screens)
+### Geist
 
-**Never use for:**
-- Body text or paragraphs
-- Button labels
-- Navigation items
-- Form labels or placeholder text
-- Any text below 16px
-- Inline with Inter in the same line
+Use for all interface and reading text. Default to Regular 400 for prose,
+Medium/SemiBold for control emphasis, and Bold 700 for short overlines.
 
-### Inter (UI)
+### Geist Mono
 
-Inter is the workhorse. All interactive and readable text uses Inter.
+Use when the content belongs to the machine: terminal output, commands, paths,
+IDs, hashes, versions, and compact technical status. Do not use it merely to
+make ordinary copy feel technical.
 
-**Use for:**
-- Body copy, descriptions, paragraphs
-- Button labels, navigation, tabs
-- Form labels, inputs, placeholders
-- Card titles (h4 and below)
-- Tooltips, toasts, alerts
-- Metadata, timestamps, captions
+## Scale
 
-### JetBrains Mono (Code)
+| Style | Family | Size | Weight | Line height | Tracking |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Display | Bricolage Grotesque | 72px | 800 | 110% | -2% |
+| Heading 1 | Bricolage Grotesque | 48px | 700 | 115% | -1% |
+| Heading 2 | Bricolage Grotesque | 36px | 600 | 120% | -0.5% |
+| Heading 3 | Bricolage Grotesque | 28px | 500 | 125% | 0 |
+| Subtitle | Bricolage Grotesque | 22px | 500 | 140% | 0 |
+| Body large | Geist | 18px | 400 | 155% | 0 |
+| Body | Geist | 16px | 400 | 160% | 0.5% |
+| Body small | Geist | 14px | 400 | 160% | 1% |
+| Caption | Geist | 12px | 400 | 150% | 1.5% |
+| Overline / label | Geist | 11px | 700 | 130% | 3px |
+| Machine | Geist Mono | 14px | 400 | 150% | 0 |
 
-**Use for:**
-- Terminal output
-- Code blocks and inline code
-- Technical data (IDs, hashes, file paths)
-- Mono-spaced labels (status badges, version numbers)
+## Responsive use
 
-## Type Scale
+- Display and H1 may use `clamp()` to reach the specified desktop size.
+- H1 should generally resolve to 34–40px on a phone; H2 to 28–32px.
+- Body text stays 16px for reading surfaces and never drops below 14px for UI.
+- Use uppercase only for short overlines and labels.
+- Avoid center-aligned body copy longer than two lines.
+- Preserve hierarchy rather than matching line breaks across form factors.
 
-| Level       | Font     | Size     | Weight | Line Height | Letter Spacing |
-|-------------|----------|----------|--------|-------------|----------------|
-| Display     | Orbitron | 3rem     | 700    | 1.1         | -0.02em        |
-| H1          | Orbitron | 2.25rem  | 600    | 1.15        | -0.01em        |
-| H2          | Orbitron | 1.75rem  | 600    | 1.2         | 0              |
-| H3          | Inter    | 1.25rem  | 600    | 1.3         | 0              |
-| H4          | Inter    | 1.125rem | 600    | 1.4         | 0              |
-| Body        | Inter    | 1rem     | 400    | 1.6         | 0              |
-| Body Small  | Inter    | 0.875rem | 400    | 1.5         | 0              |
-| Caption     | Inter    | 0.75rem  | 400    | 1.4         | 0              |
-| Label       | Inter    | 0.75rem  | 500    | 1.4         | 0.05em         |
-| Mono        | JB Mono  | 0.875rem | 400    | 1.5         | 0              |
+## Font loading
 
-## Responsive Behavior
-
-On viewports below 768px:
-
-| Level   | Desktop  | Mobile   |
-|---------|----------|----------|
-| Display | 3rem     | 2rem     |
-| H1      | 2.25rem  | 1.75rem  |
-| H2      | 1.75rem  | 1.5rem   |
-| H3      | 1.25rem  | 1.125rem |
-
-Body, caption, and label sizes remain the same across breakpoints.
-
-## Text Color
-
-| Purpose              | Token                    |
-|----------------------|--------------------------|
-| Primary text         | `--foreground` (#32352E) |
-| Secondary/meta text  | `--muted-foreground`     |
-| Text on primary bg   | `--primary-foreground`   |
-| Text on accent bg    | `--accent-foreground`    |
-| Link text            | `--primary` (#434E3F)    |
-| Link hover           | `--accent` (#D06F25)     |
-| Disabled text        | `--muted-foreground` @ 60% opacity |
-
-## Do's and Don'ts
-
-**Do:**
-- Use Orbitron for moments that say "Matrix OS"
-- Use Inter weight 400 for body, 500 for labels, 600 for emphasis
-- Use the Label style (uppercase, tracked, 0.75rem) for category tags
-- Maintain consistent line heights for vertical rhythm
-
-**Don't:**
-- Mix Orbitron and Inter on the same line
-- Use Orbitron below 16px (it becomes illegible)
-- Use font weights below 400 (thin/light) — they don't read well on screens
-- Center-align body text longer than 2 lines
-- Use all-caps for anything except Labels and short status indicators
+- Load only the weights used by the current surface.
+- Use variable font files where supported.
+- Prevent synthetic bold and italic styles.
+- Keep fallback stacks metric-compatible enough to avoid layout shifts.
+- Terminal/editor font preferences are product settings; the branded machine
+  voice around those surfaces remains Geist Mono.

--- a/shell/public/brand-guidelines.html
+++ b/shell/public/brand-guidelines.html
@@ -1,403 +1,545 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Matrix OS — Brand Guidelines</title>
-<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400;500&family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
-<style>
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { background: #FAFAF9; color: #1c1917; font-family: 'Inter', sans-serif; }
-
-  /* ─── PAGE 1: Brand Guidelines L000 ─── */
-  .page { width: 1440px; margin: 0 auto 80px; display: flex; background: #fff; }
-  .sidebar { width: 300px; padding: 48px; border-right: 1px solid #e5e5e4; }
-  .sidebar .dot { width: 10px; height: 10px; border-radius: 50%; background: #9AA48C; display: inline-block; margin-right: 8px; vertical-align: middle; }
-  .sidebar .code { font-size: 11px; letter-spacing: 0.1em; color: #6c7178; display: inline-block; vertical-align: middle; }
-  .sidebar .desc { font-size: 11px; color: #6c7178; line-height: 1.5; margin-top: 14px; }
-  .content { flex: 1; padding: 0 48px; }
-  .section { border-top: 1px solid #e5e5e4; padding: 28px 0; display: flex; gap: 0; }
-  .section .num { width: 40px; font-size: 11px; color: #6c7178; letter-spacing: 0.05em; flex-shrink: 0; }
-  .section .center { flex: 1; display: flex; align-items: center; min-height: 160px; }
-  .section .description { width: 260px; flex-shrink: 0; }
-  .section .description h3 { font-size: 13px; font-weight: 500; margin-bottom: 12px; }
-  .section .description p { font-size: 11px; color: #6c7178; line-height: 1.6; }
-
-  .wordmark-display { font-family: 'Inter', sans-serif; font-weight: 600; letter-spacing: 0.15em; text-transform: uppercase; }
-  .wordmark-lg {
-    font-size: 52px;
-    background: linear-gradient(90deg, #1c1917 0%, #1c1917 35%, #9AA48C 50%, #1c1917 65%, #1c1917 100%);
-    background-size: 200% 100%;
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
-    animation: shimmer 6s ease-in-out infinite;
-  }
-  @keyframes shimmer {
-    0% { background-position: 200% 0; }
-    100% { background-position: -200% 0; }
-  }
-  .wordmark-serif { font-family: 'Cormorant Garamond', serif; font-weight: 300; font-size: 48px; letter-spacing: 0.02em; }
-  .lockup-text { font-family: 'Inter', sans-serif; font-weight: 600; letter-spacing: 0.15em; text-transform: uppercase; font-size: 42px; }
-  .lockup-sub { font-family: 'Inter', sans-serif; font-weight: 300; letter-spacing: 0.3em; text-transform: uppercase; font-size: 14px; color: #6c7178; margin-top: 8px; }
-
-  /* Logo mark */
-  .logomark { width: 160px; height: 160px; display: flex; align-items: center; justify-content: center; }
-  .logomark img { width: 100%; height: 100%; object-fit: contain; }
-
-  /* ─── PAGE 2: Wordmark Spacing ─── */
-  .page-narrow { width: 1080px; margin: 0 auto 80px; background: #fff; padding: 40px 60px; }
-  .page-header { display: flex; border-top: 1px solid #e5e5e4; padding: 16px 0; margin-bottom: 0; }
-  .page-header span { flex: 1; font-size: 11px; color: #6c7178; }
-  .spacing-row { border-top: 1px solid #f0f0ef; padding: 16px 0; display: flex; align-items: baseline; }
-  .spacing-row .label { width: 240px; font-size: 11px; color: #6c7178; flex-shrink: 0; }
-  .spacing-row .sample { flex: 1; padding-left: 40px; }
-  .spacing-row .sample span { font-family: 'Inter', sans-serif; font-weight: 500; }
-
-  /* ─── PAGE 3: Color Palette ─── */
-  .color-header { display: flex; align-items: center; border-top: 1px solid #e5e5e4; padding: 16px 0; }
-  .color-header .brand { font-size: 12px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; }
-  .color-header .spacer { flex: 1; height: 1px; background: #e5e5e4; margin: 0 16px; }
-  .color-header .label { font-size: 11px; color: #6c7178; }
-  .color-grid { display: flex; border-top: 1px solid #e5e5e4; padding: 20px 0; }
-  .color-swatch { flex: 1; text-align: center; padding: 20px 0; }
-  .color-swatch .num { font-size: 10px; color: #9a9a9a; letter-spacing: 0.1em; margin-bottom: 12px; }
-  .color-swatch .circle { width: 120px; height: 120px; border-radius: 50%; margin: 0 auto 20px; }
-  .color-swatch .name { font-size: 13px; font-weight: 500; margin-bottom: 8px; }
-  .color-swatch .role { font-size: 10px; color: #6c7178; margin-bottom: 8px; }
-  .color-swatch .hex { font-size: 10px; color: #9a9a9a; font-family: 'JetBrains Mono', monospace; }
-  .color-footer { display: flex; border-top: 1px solid #e5e5e4; padding: 14px 0; }
-  .color-footer .brand { font-size: 10px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; }
-  .color-footer .spacer { flex: 1; height: 1px; background: #e5e5e4; margin: 0 12px; align-self: center; }
-  .color-footer .label { font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: #6c7178; }
-
-  /* ─── PAGE 4: Typography ─── */
-  .type-row { border-top: 1px solid #e5e5e4; padding: 32px 0; display: flex; }
-  .type-row .num { width: 40px; font-size: 11px; color: #6c7178; flex-shrink: 0; }
-  .type-row .sample { flex: 1; }
-  .type-row .sample .font-name { font-size: 10px; color: #9a9a9a; letter-spacing: 0.1em; text-transform: uppercase; margin-bottom: 12px; }
-  .type-row .sample .preview { margin-bottom: 8px; }
-  .type-row .meta { width: 260px; flex-shrink: 0; }
-  .type-row .meta h3 { font-size: 13px; font-weight: 500; margin-bottom: 12px; }
-  .type-row .meta p { font-size: 11px; color: #6c7178; line-height: 1.6; }
-  .type-row .meta .weights { margin-top: 12px; display: flex; gap: 8px; flex-wrap: wrap; }
-  .type-row .meta .weights span { font-size: 10px; color: #9a9a9a; border: 1px solid #e5e5e4; border-radius: 4px; padding: 2px 8px; }
-
-  /* ─── Scroll reveal animations ─── */
-  .reveal {
-    opacity: 0;
-    transform: translateY(24px);
-    transition: opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1), transform 0.8s cubic-bezier(0.16, 1, 0.3, 1);
-  }
-  .reveal.visible {
-    opacity: 1;
-    transform: translateY(0);
-  }
-
-  /* Stagger children inside color grids */
-  .color-swatch.reveal { transition-delay: var(--delay, 0ms); }
-
-  /* Highlight flash on reveal */
-  .section.reveal.visible, .spacing-row.reveal.visible, .type-row.reveal.visible {
-    animation: highlightFade 1.2s ease-out;
-  }
-  @keyframes highlightFade {
-    0% { background: rgba(154, 164, 140, 0.08); }
-    100% { background: transparent; }
-  }
-</style>
-<script src="https://mcp.figma.com/mcp/html-to-design/capture.js" async></script>
-</head>
-<body>
-
-<!-- ═══════════════════════════════════════════════════════ -->
-<!-- PAGE 1: BRAND GUIDELINES L000                          -->
-<!-- ═══════════════════════════════════════════════════════ -->
-<div class="page">
-  <div class="sidebar">
-    <div><span class="dot"></span><span class="code">L000</span></div>
-    <p class="desc">Matrix OS is an AI operating system — a personal desktop in the cloud where you can create any app you imagine.</p>
-  </div>
-  <div class="content">
-    <!-- Section 01: Logomark -->
-    <div class="section reveal">
-      <div class="num">01</div>
-      <div class="center">
-        <div class="logomark"><img src="/logo-rabbit.png" alt="Matrix OS Logo" /></div>
-      </div>
-      <div class="description">
-        <h3>Logomark</h3>
-        <p>The Matrix OS mark is an organic, nature-inspired symbol. It represents growth, interconnection, and natural intelligence — the feeling of entering a new dimension of computing.</p>
-      </div>
-    </div>
-
-    <!-- Section 02: Wordmark -->
-    <div class="section reveal">
-      <div class="num">02</div>
-      <div class="center">
-        <span class="wordmark-display wordmark-lg">MATRIX OS</span>
-      </div>
-      <div class="description">
-        <h3>Wordmark</h3>
-        <p>The primary wordmark uses Inter in semibold weight with generous letter-spacing. Clean, geometric, and modern — reflecting the system's precision.</p>
-      </div>
-    </div>
-
-    <!-- Section 03: Lockup -->
-    <div class="section reveal">
-      <div class="num">03</div>
-      <div class="center">
-        <div>
-          <div class="lockup-text">MATRIX OS</div>
-          <div class="lockup-sub">Your AI Operating System</div>
-        </div>
-      </div>
-      <div class="description">
-        <h3>Lockup</h3>
-        <p>The full lockup pairs the wordmark with the tagline "Your AI Operating System." Used when introducing the brand to new audiences or in marketing contexts.</p>
-      </div>
-    </div>
-
-    <!-- Section 04: Serif Mark -->
-    <div class="section reveal">
-      <div class="num">04</div>
-      <div class="center">
-        <span class="wordmark-serif">Matrix OS</span>
-      </div>
-      <div class="description">
-        <h3>Editorial Mark</h3>
-        <p>The editorial variant uses Cormorant Garamond Light for premium, editorial contexts — the onboarding screen, marketing pages, and display typography. Evokes warmth and sophistication.</p>
-      </div>
-    </div>
-  </div>
-</div>
-
-<!-- ═══════════════════════════════════════════════════════ -->
-<!-- PAGE 2: WORDMARK SPACING                               -->
-<!-- ═══════════════════════════════════════════════════════ -->
-<div class="page-narrow">
-  <div class="page-header">
-    <span>Matrix OS</span>
-    <span>Wordmark Spacing</span>
-    <span>Positive</span>
-    <span>2026-04-10</span>
-  </div>
-
-  <div class="spacing-row reveal">
-    <div class="label">48px (Spacing 0.15em)</div>
-    <div class="sample"><span style="font-size:96px;font-weight:600;letter-spacing:0.15em;">MATRIX OS</span></div>
-  </div>
-  <div class="spacing-row reveal">
-    <div class="label">36px (Spacing 0.15em)</div>
-    <div class="sample"><span style="font-size:72px;font-weight:600;letter-spacing:0.15em;">MATRIX OS</span></div>
-  </div>
-  <div class="spacing-row reveal">
-    <div class="label">24px (Spacing 0.12em)</div>
-    <div class="sample"><span style="font-size:48px;font-weight:600;letter-spacing:0.12em;">MATRIX OS</span></div>
-  </div>
-  <div class="spacing-row reveal">
-    <div class="label">18px (Spacing 0.10em)</div>
-    <div class="sample"><span style="font-size:36px;font-weight:600;letter-spacing:0.10em;">MATRIX OS</span></div>
-  </div>
-  <div class="spacing-row reveal">
-    <div class="label">14px (Spacing 0.08em)</div>
-    <div class="sample"><span style="font-size:28px;font-weight:600;letter-spacing:0.08em;">MATRIX OS</span></div>
-  </div>
-  <div class="spacing-row reveal">
-    <div class="label">11px (Spacing 0.06em)</div>
-    <div class="sample"><span style="font-size:22px;font-weight:600;letter-spacing:0.06em;">MATRIX OS</span></div>
-  </div>
-  <div class="spacing-row reveal">
-    <div class="label">9px (Spacing 0.04em)</div>
-    <div class="sample"><span style="font-size:18px;font-weight:500;letter-spacing:0.04em;">MATRIX OS</span></div>
-  </div>
-</div>
-
-<!-- ═══════════════════════════════════════════════════════ -->
-<!-- PAGE 3: COLOR PALETTE                                  -->
-<!-- ═══════════════════════════════════════════════════════ -->
-<div class="page-narrow">
-  <div class="color-header">
-    <span class="brand">MATRIX OS</span>
-    <span class="spacer"></span>
-    <span class="label">Color System</span>
-    <span class="spacer"></span>
-    <span class="label">2026</span>
-  </div>
-
-  <div class="color-grid">
-    <div class="color-swatch reveal">
-      <div class="num">01</div>
-      <div class="circle" style="background: #9AA48C;"></div>
-      <div class="name">Lichen</div>
-      <div class="role">OS accent</div>
-      <div class="hex">#9AA48C</div>
-    </div>
-    <div class="color-swatch reveal">
-      <div class="num">02</div>
-      <div class="circle" style="background: #6A8A7A;"></div>
-      <div class="name">Moss</div>
-      <div class="role">Gradient Accent</div>
-      <div class="hex">#6A8A7A</div>
-    </div>
-    <div class="color-swatch reveal">
-      <div class="num">03</div>
-      <div class="circle" style="background: #323D2E;"></div>
-      <div class="name">Forest</div>
-      <div class="role">Gradient Deep</div>
-      <div class="hex">#323D2E</div>
-    </div>
-    <div class="color-swatch reveal">
-      <div class="num">04</div>
-      <div class="circle" style="background: #FAFAF9; border: 1px solid #e5e5e4;"></div>
-      <div class="name">Stone</div>
-      <div class="role">Background</div>
-      <div class="hex">#FAFAF9</div>
-    </div>
-    <div class="color-swatch reveal">
-      <div class="num">05</div>
-      <div class="circle" style="background: #1C1917;"></div>
-      <div class="name">Ink</div>
-      <div class="role">Foreground</div>
-      <div class="hex">#1C1917</div>
-    </div>
-  </div>
-
-  <!-- Secondary colors -->
-  <div class="color-grid" style="padding-top: 0;">
-    <div class="color-swatch reveal">
-      <div class="num">06</div>
-      <div class="circle" style="background: #9AA48C;"></div>
-      <div class="name">Lichen</div>
-      <div class="role">Gradient Mid</div>
-      <div class="hex">#9AA48C</div>
-    </div>
-    <div class="color-swatch reveal">
-      <div class="num">07</div>
-      <div class="circle" style="background: #E5E5E4; border: 1px solid #d4d4d3;"></div>
-      <div class="name">Pebble</div>
-      <div class="role">Border / Input</div>
-      <div class="hex">#E5E5E4</div>
-    </div>
-    <div class="color-swatch reveal">
-      <div class="num">08</div>
-      <div class="circle" style="background: #EF4444;"></div>
-      <div class="name">Ember</div>
-      <div class="role">Destructive</div>
-      <div class="hex">#EF4444</div>
-    </div>
-    <div class="color-swatch reveal">
-      <div class="num">09</div>
-      <div class="circle" style="background: #22C55E;"></div>
-      <div class="name">Fern</div>
-      <div class="role">Success</div>
-      <div class="hex">#22C55E</div>
-    </div>
-    <div class="color-swatch reveal">
-      <div class="num">10</div>
-      <div class="circle" style="background: #EAB308;"></div>
-      <div class="name">Amber</div>
-      <div class="role">Warning</div>
-      <div class="hex">#EAB308</div>
-    </div>
-  </div>
-
-  <div class="color-footer">
-    <span class="brand">MATRIX OS</span>
-    <span class="spacer"></span>
-    <span class="label">COLORS</span>
-  </div>
-</div>
-
-<!-- ═══════════════════════════════════════════════════════ -->
-<!-- PAGE 4: TYPOGRAPHY                                     -->
-<!-- ═══════════════════════════════════════════════════════ -->
-<div class="page-narrow">
-  <div class="color-header">
-    <span class="brand">MATRIX OS</span>
-    <span class="spacer"></span>
-    <span class="label">Typography</span>
-    <span class="spacer"></span>
-    <span class="label">2026</span>
-  </div>
-
-  <div class="type-row reveal">
-    <div class="num">01</div>
-    <div class="sample">
-      <div class="font-name">Cormorant Garamond</div>
-      <div class="preview" style="font-family: 'Cormorant Garamond', serif; font-weight: 300; font-size: 64px; line-height: 1.1;">Aa</div>
-      <div style="font-family: 'Cormorant Garamond', serif; font-weight: 300; font-size: 24px; color: #6c7178; line-height: 1.4;">The quick brown fox jumps over the lazy dog</div>
-    </div>
-    <div class="meta">
-      <h3>Display / Headline</h3>
-      <p>Used for editorial headings, the onboarding screen, marketing display text, and premium UI moments. Evokes warmth and sophistication.</p>
-      <div class="weights">
-        <span>Light 300</span>
-        <span>Regular 400</span>
-        <span>Medium 500</span>
-      </div>
-    </div>
-  </div>
-
-  <div class="type-row reveal">
-    <div class="num">02</div>
-    <div class="sample">
-      <div class="font-name">Inter</div>
-      <div class="preview" style="font-family: 'Inter', sans-serif; font-weight: 400; font-size: 64px; line-height: 1.1;">Aa</div>
-      <div style="font-family: 'Inter', sans-serif; font-weight: 400; font-size: 16px; color: #6c7178; line-height: 1.5;">The quick brown fox jumps over the lazy dog</div>
-    </div>
-    <div class="meta">
-      <h3>Body / UI</h3>
-      <p>The primary interface font. Used for all body text, buttons, labels, navigation, and form elements. Clean, geometric, highly legible at all sizes.</p>
-      <div class="weights">
-        <span>Regular 400</span>
-        <span>Medium 500</span>
-        <span>Semibold 600</span>
-      </div>
-    </div>
-  </div>
-
-  <div class="type-row reveal">
-    <div class="num">03</div>
-    <div class="sample">
-      <div class="font-name">JetBrains Mono</div>
-      <div class="preview" style="font-family: 'JetBrains Mono', monospace; font-weight: 400; font-size: 64px; line-height: 1.1;">Aa</div>
-      <div style="font-family: 'JetBrains Mono', monospace; font-weight: 400; font-size: 14px; color: #6c7178; line-height: 1.5;">const matrix = new MatrixOS();</div>
-    </div>
-    <div class="meta">
-      <h3>Code / Monospace</h3>
-      <p>Used in the terminal, code blocks, and technical UI elements. Optimized for code readability with distinct character shapes and ligatures.</p>
-      <div class="weights">
-        <span>Regular 400</span>
-      </div>
-    </div>
-  </div>
-
-  <div class="color-footer">
-    <span class="brand">MATRIX OS</span>
-    <span class="spacer"></span>
-    <span class="label">TYPE</span>
-  </div>
-</div>
-
-<script>
-  // Scroll-triggered reveal with staggered delays for color swatches
-  document.querySelectorAll('.color-grid').forEach(grid => {
-    grid.querySelectorAll('.color-swatch.reveal').forEach((swatch, i) => {
-      swatch.style.setProperty('--delay', `${i * 120}ms`);
-    });
-  });
-
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting) {
-        entry.target.classList.add('visible');
-        observer.unobserve(entry.target);
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Matrix OS — Brand Guidelines</title>
+    <meta
+      name="description"
+      content="The canonical Matrix OS identity, color, typography, and interface principles."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wdth,wght@12..96,75..100,400..800&family=Geist+Mono:wght@400;500&family=Geist:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --teal: #0e3422;
+        --coral: #d06e53;
+        --gold: #f1c379;
+        --green: #bed77b;
+        --blue: #c5d6e2;
+        --ink: #1f2d1d;
+        --paper: #fcfcf8;
+        --canvas: #f4f7ed;
+        --border: #e0e1ca;
       }
-    });
-  }, { threshold: 0.15, rootMargin: '0px 0px -60px 0px' });
 
-  document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
-</script>
-</body>
+      * {
+        box-sizing: border-box;
+      }
+
+      html {
+        scroll-behavior: smooth;
+      }
+
+      body {
+        margin: 0;
+        color: var(--ink);
+        background:
+          radial-gradient(circle at 8% 0%, rgba(190, 215, 123, 0.34), transparent 28rem),
+          var(--canvas);
+        font-family: "Geist", system-ui, sans-serif;
+        font-size: 16px;
+        line-height: 1.6;
+      }
+
+      a {
+        color: inherit;
+      }
+
+      main {
+        width: min(1120px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 24px 0 96px;
+      }
+
+      header,
+      section {
+        border: 1px solid var(--border);
+        border-radius: 24px;
+        background: rgba(252, 252, 248, 0.92);
+        box-shadow: 0 12px 36px rgba(31, 45, 29, 0.08);
+      }
+
+      header {
+        min-height: 620px;
+        padding: clamp(24px, 6vw, 72px);
+        display: grid;
+        grid-template-rows: auto 1fr auto;
+        overflow: hidden;
+        position: relative;
+      }
+
+      header::after {
+        content: "";
+        width: min(480px, 58vw);
+        aspect-ratio: 1;
+        position: absolute;
+        right: -13%;
+        bottom: -39%;
+        border-radius: 50%;
+        background: var(--green);
+        opacity: 0.72;
+      }
+
+      .eyebrow,
+      .section-index {
+        font-size: 11px;
+        font-weight: 700;
+        line-height: 1.3;
+        letter-spacing: 3px;
+        text-transform: uppercase;
+      }
+
+      .brand-lockup {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-family: "Bricolage Grotesque", sans-serif;
+        font-size: 20px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+      }
+
+      .mark {
+        width: 44px;
+        height: 44px;
+        display: grid;
+        place-items: center;
+        border-radius: 12px;
+        background: var(--teal);
+      }
+
+      .mark::before {
+        content: "";
+        width: 22px;
+        height: 28px;
+        background: var(--green);
+        mask: url("/matrix-logo.svg") center / contain no-repeat;
+      }
+
+      .hero-copy {
+        align-self: center;
+        max-width: 780px;
+        position: relative;
+        z-index: 1;
+      }
+
+      h1,
+      h2,
+      h3 {
+        margin: 0;
+        font-family: "Bricolage Grotesque", sans-serif;
+      }
+
+      h1 {
+        max-width: 760px;
+        font-size: clamp(54px, 9vw, 96px);
+        font-weight: 800;
+        line-height: 0.98;
+        letter-spacing: -0.035em;
+      }
+
+      h2 {
+        font-size: clamp(36px, 5vw, 56px);
+        font-weight: 700;
+        line-height: 1.08;
+        letter-spacing: -0.02em;
+      }
+
+      h3 {
+        font-size: 22px;
+        font-weight: 600;
+        line-height: 1.35;
+      }
+
+      .lede {
+        max-width: 610px;
+        margin: 24px 0 0;
+        font-size: 18px;
+      }
+
+      .source {
+        width: fit-content;
+        padding: 8px 12px;
+        position: relative;
+        z-index: 1;
+        border: 1px solid rgba(14, 52, 34, 0.16);
+        border-radius: 999px;
+        font-family: "Geist Mono", monospace;
+        font-size: 12px;
+        text-decoration: none;
+      }
+
+      section {
+        margin-top: 24px;
+        padding: clamp(24px, 5vw, 56px);
+      }
+
+      .section-head {
+        display: grid;
+        grid-template-columns: 120px 1fr;
+        gap: 24px;
+        margin-bottom: 40px;
+      }
+
+      .section-head p {
+        max-width: 640px;
+        margin: 12px 0 0;
+      }
+
+      .swatches {
+        display: grid;
+        grid-template-columns: repeat(5, 1fr);
+        gap: 12px;
+      }
+
+      .swatch {
+        min-height: 230px;
+        padding: 18px;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-end;
+        border-radius: 16px;
+      }
+
+      .swatch strong {
+        font-family: "Bricolage Grotesque", sans-serif;
+        font-size: 20px;
+      }
+
+      .swatch code,
+      .meta,
+      .scale-label {
+        font-family: "Geist Mono", monospace;
+        font-size: 12px;
+      }
+
+      .teal {
+        color: var(--paper);
+        background: var(--teal);
+      }
+
+      .coral {
+        color: #0d0c0c;
+        background: var(--coral);
+      }
+
+      .gold {
+        background: var(--gold);
+      }
+
+      .green {
+        background: var(--green);
+      }
+
+      .blue {
+        background: var(--blue);
+      }
+
+      .scale-grid {
+        margin-top: 36px;
+        display: grid;
+        gap: 8px;
+      }
+
+      .scale-row {
+        display: grid;
+        grid-template-columns: 72px repeat(10, 1fr);
+        gap: 4px;
+        align-items: center;
+      }
+
+      .scale-chip {
+        min-height: 38px;
+        border: 1px solid rgba(31, 45, 29, 0.08);
+        border-radius: 8px;
+      }
+
+      .type-grid {
+        display: grid;
+        grid-template-columns: 1.3fr 0.7fr;
+        gap: 40px;
+      }
+
+      .display-sample {
+        font-family: "Bricolage Grotesque", sans-serif;
+        font-size: clamp(48px, 8vw, 72px);
+        font-weight: 800;
+        line-height: 1.1;
+        letter-spacing: -0.02em;
+      }
+
+      .body-sample {
+        max-width: 520px;
+        margin-top: 28px;
+        font-size: 18px;
+        line-height: 1.55;
+      }
+
+      .machine {
+        min-height: 100%;
+        padding: 24px;
+        border-radius: 16px;
+        color: var(--green);
+        background: var(--teal);
+        font-family: "Geist Mono", monospace;
+        font-size: 14px;
+        line-height: 1.65;
+      }
+
+      .type-roles,
+      .principles,
+      .contrast {
+        margin-top: 36px;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 12px;
+      }
+
+      .role,
+      .principle,
+      .contrast-card {
+        padding: 22px;
+        border: 1px solid var(--border);
+        border-radius: 16px;
+      }
+
+      .role p,
+      .principle p,
+      .contrast-card p {
+        margin: 8px 0 0;
+      }
+
+      .contrast-card strong {
+        display: block;
+        font-family: "Bricolage Grotesque", sans-serif;
+        font-size: 36px;
+        line-height: 1.1;
+      }
+
+      .approved {
+        color: var(--paper);
+        background: var(--teal);
+        border-color: var(--teal);
+      }
+
+      footer {
+        padding: 44px 8px 0;
+        display: flex;
+        justify-content: space-between;
+        gap: 20px;
+        font-size: 13px;
+      }
+
+      @media (max-width: 800px) {
+        header {
+          min-height: 560px;
+        }
+
+        .section-head,
+        .type-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .swatches {
+          grid-template-columns: repeat(2, 1fr);
+        }
+
+        .swatch:last-child {
+          grid-column: span 2;
+        }
+
+        .scale-row {
+          grid-template-columns: repeat(5, 1fr);
+        }
+
+        .scale-label {
+          grid-column: 1 / -1;
+        }
+
+        .type-roles,
+        .principles,
+        .contrast {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      @media (max-width: 520px) {
+        main {
+          width: min(100% - 20px, 1120px);
+          padding-top: 10px;
+        }
+
+        header,
+        section {
+          border-radius: 18px;
+        }
+
+        .swatches {
+          grid-template-columns: 1fr;
+        }
+
+        .swatch:last-child {
+          grid-column: auto;
+        }
+
+        footer {
+          flex-direction: column;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="brand-lockup">
+          <span class="mark" aria-hidden="true"></span>
+          <span>Matrix OS</span>
+        </div>
+        <div class="hero-copy">
+          <p class="eyebrow">Brand guidelines · 2026</p>
+          <h1>Technology that understands you.</h1>
+          <p class="lede">
+            A capable, optimistic, and composed identity for an operating system
+            that makes powerful computing feel human.
+          </p>
+        </div>
+        <a
+          class="source"
+          href="https://www.figma.com/design/xPG2FeYRtC9owCKSVXCqWA/brand?node-id=1-846"
+        >
+          Approved source · Figma 1:846
+        </a>
+      </header>
+
+      <section id="color">
+        <div class="section-head">
+          <span class="section-index">01 · Color</span>
+          <div>
+            <h2>Living color, grounded by teal.</h2>
+            <p>
+              Teal anchors the identity. Coral, Gold, Green, and Blue create
+              rhythm and communicate state. Give every screen one dominant
+              color relationship instead of using the whole palette at once.
+            </p>
+          </div>
+        </div>
+        <div class="swatches">
+          <div class="swatch teal"><strong>Teal</strong><code>#0E3422</code></div>
+          <div class="swatch coral"><strong>Coral</strong><code>#D06E53</code></div>
+          <div class="swatch gold"><strong>Gold</strong><code>#F1C379</code></div>
+          <div class="swatch green"><strong>Green</strong><code>#BED77B</code></div>
+          <div class="swatch blue"><strong>Blue</strong><code>#C5D6E2</code></div>
+        </div>
+
+        <div class="scale-grid" aria-label="Color scales from 50 to 900">
+          <div class="scale-row">
+            <span class="scale-label">Green</span>
+            <i class="scale-chip" style="background:#F4F7ED"></i><i class="scale-chip" style="background:#E4EDD4"></i><i class="scale-chip" style="background:#CEE0AE"></i><i class="scale-chip" style="background:#BED77B"></i><i class="scale-chip" style="background:#9AC059"></i><i class="scale-chip" style="background:#748E59"></i><i class="scale-chip" style="background:#62783A"></i><i class="scale-chip" style="background:#475926"></i><i class="scale-chip" style="background:#2B3715"></i><i class="scale-chip" style="background:#171F0A"></i>
+          </div>
+          <div class="scale-row">
+            <span class="scale-label">Teal</span>
+            <i class="scale-chip" style="background:#EEF7F2"></i><i class="scale-chip" style="background:#C9E8D9"></i><i class="scale-chip" style="background:#97D8B9"></i><i class="scale-chip" style="background:#5EC996"></i><i class="scale-chip" style="background:#34B275"></i><i class="scale-chip" style="background:#288A5B"></i><i class="scale-chip" style="background:#1B6541"></i><i class="scale-chip" style="background:#13492F"></i><i class="scale-chip" style="background:#0E3422"></i><i class="scale-chip" style="background:#061810"></i>
+          </div>
+          <div class="scale-row">
+            <span class="scale-label">Coral</span>
+            <i class="scale-chip" style="background:#FAEEEB"></i><i class="scale-chip" style="background:#F2D6CF"></i><i class="scale-chip" style="background:#E6B5A8"></i><i class="scale-chip" style="background:#DA9481"></i><i class="scale-chip" style="background:#D06E53"></i><i class="scale-chip" style="background:#BA5236"></i><i class="scale-chip" style="background:#8F432D"></i><i class="scale-chip" style="background:#6B3324"></i><i class="scale-chip" style="background:#442118"></i><i class="scale-chip" style="background:#25130E"></i>
+          </div>
+          <div class="scale-row">
+            <span class="scale-label">Gold</span>
+            <i class="scale-chip" style="background:#FCF5E8"></i><i class="scale-chip" style="background:#FAEAD1"></i><i class="scale-chip" style="background:#F6DAAC"></i><i class="scale-chip" style="background:#F1C379"></i><i class="scale-chip" style="background:#E0AA52"></i><i class="scale-chip" style="background:#D2932D"></i><i class="scale-chip" style="background:#A37429"></i><i class="scale-chip" style="background:#775622"></i><i class="scale-chip" style="background:#4D3919"></i><i class="scale-chip" style="background:#251C0E"></i>
+          </div>
+          <div class="scale-row">
+            <span class="scale-label">Blue</span>
+            <i class="scale-chip" style="background:#EDF3F7"></i><i class="scale-chip" style="background:#C5D6E2"></i><i class="scale-chip" style="background:#9DBFD7"></i><i class="scale-chip" style="background:#71A9D0"></i><i class="scale-chip" style="background:#5CA0D1"></i><i class="scale-chip" style="background:#3B85BA"></i><i class="scale-chip" style="background:#306991"></i><i class="scale-chip" style="background:#254D6A"></i><i class="scale-chip" style="background:#193143"></i><i class="scale-chip" style="background:#0F1B24"></i>
+          </div>
+        </div>
+      </section>
+
+      <section id="type">
+        <div class="section-head">
+          <span class="section-index">02 · Type</span>
+          <div>
+            <h2>Expressive when speaking. Quiet when working.</h2>
+            <p>
+              Bricolage Grotesque gives the brand a distinct voice. Geist keeps
+              product UI crisp. Geist Mono separates machine output from human
+              language.
+            </p>
+          </div>
+        </div>
+        <div class="type-grid">
+          <div>
+            <div class="display-sample">Build what matters.</div>
+            <p class="body-sample">
+              Matrix OS brings tools, conversations, and autonomous work into
+              one calm environment. Hierarchy should be obvious before color or
+              decoration is added.
+            </p>
+          </div>
+          <div class="machine">
+            <div>matrix@os ~ % start</div>
+            <div>✓ workspace ready</div>
+            <div>✓ providers connected</div>
+            <div>→ opening Canvas</div>
+          </div>
+        </div>
+        <div class="type-roles">
+          <div class="role"><h3>Bricolage Grotesque</h3><p>Display, page titles, section headings, and the wordmark.</p></div>
+          <div class="role"><h3>Geist</h3><p>Body copy, controls, labels, navigation, and dense product UI.</p></div>
+          <div class="role"><h3>Geist Mono</h3><p>Code, terminals, identifiers, timestamps, and machine status.</p></div>
+        </div>
+      </section>
+
+      <section id="principles">
+        <div class="section-head">
+          <span class="section-index">03 · System</span>
+          <div>
+            <h2>Minimal is a behavior.</h2>
+            <p>
+              A slim interface is not merely sparse. It prioritizes one action,
+              responds quickly, and removes every element that does not improve
+              comprehension or control.
+            </p>
+          </div>
+        </div>
+        <div class="principles">
+          <div class="principle"><h3>One clear next step</h3><p>Reserve primary styling for the action that advances the user.</p></div>
+          <div class="principle"><h3>Structure before decoration</h3><p>Use spacing, type, and grouping before adding borders or color.</p></div>
+          <div class="principle"><h3>Platform-aware parity</h3><p>Share tokens and behavior while respecting native shell conventions.</p></div>
+          <div class="principle"><h3>Calm motion</h3><p>Use short transitions to explain state changes, never to delay them.</p></div>
+          <div class="principle"><h3>Accessible by default</h3><p>Keyboard, focus, contrast, zoom, and reduced motion are design inputs.</p></div>
+          <div class="principle"><h3>Real states</h3><p>Design loading, empty, error, reconnecting, and success alongside the ideal path.</p></div>
+        </div>
+      </section>
+
+      <section id="accessibility">
+        <div class="section-head">
+          <span class="section-index">04 · Access</span>
+          <div>
+            <h2>Color earns its place through contrast.</h2>
+            <p>
+              Use Ink or Teal for long-form text. Supporting colors are best as
+              surfaces, indicators, and large accents unless their pairing has
+              been tested at the rendered size.
+            </p>
+          </div>
+        </div>
+        <div class="contrast">
+          <div class="contrast-card approved"><strong>13.32:1</strong><p>Teal on Paper · AAA</p></div>
+          <div class="contrast-card"><strong>14.07:1</strong><p>Ink on Paper · AAA</p></div>
+          <div class="contrast-card"><strong>9.09:1</strong><p>Ink on Green · AAA</p></div>
+        </div>
+      </section>
+
+      <footer>
+        <span>Matrix OS brand guidelines · v1.0</span>
+        <span class="meta">Figma xPG2FeYRtC9owCKSVXCqWA · node 1:846</span>
+      </footer>
+    </main>
+  </body>
 </html>

--- a/shell/public/brand-guidelines.html
+++ b/shell/public/brand-guidelines.html
@@ -35,6 +35,12 @@
         scroll-behavior: smooth;
       }
 
+      @media (prefers-reduced-motion: reduce) {
+        html {
+          scroll-behavior: auto;
+        }
+      }
+
       body {
         margin: 0;
         color: var(--ink);

--- a/tests/brand/guidelines.test.ts
+++ b/tests/brand/guidelines.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+function readRepoFile(path: string): string {
+  return readFileSync(resolve(process.cwd(), path), "utf8");
+}
+
+describe("Matrix OS brand guidelines", () => {
+  const design = readRepoFile("DESIGN.md");
+  const colors = readRepoFile("design/foundations/colors.md");
+  const typography = readRepoFile("design/foundations/typography.md");
+  const publicGuide = readRepoFile("shell/public/brand-guidelines.html");
+
+  it("records the approved Figma frame as the upstream visual source", () => {
+    expect(design).toContain("xPG2FeYRtC9owCKSVXCqWA");
+    expect(design).toContain("node-id=1-846");
+    expect(design).toContain('wordmark: "Matrix OS"');
+  });
+
+  it("defines the five-color Figma brand palette", () => {
+    for (const [name, hex] of [
+      ["teal", "#0E3422"],
+      ["coral", "#D06E53"],
+      ["gold", "#F1C379"],
+      ["green", "#BED77B"],
+      ["blue", "#C5D6E2"],
+    ] as const) {
+      expect(design).toContain(`${name}: "${hex}"`);
+      expect(colors).toContain(hex);
+      expect(publicGuide).toContain(hex);
+    }
+  });
+
+  it("uses the approved type families and retires the superseded stack", () => {
+    for (const family of ["Bricolage Grotesque", "Geist", "Geist Mono"]) {
+      expect(design).toContain(family);
+      expect(typography).toContain(family);
+      expect(publicGuide).toContain(family);
+    }
+
+    for (const retired of ["Orbitron", "Instrument Serif", "Instrument Sans"]) {
+      expect(design).not.toContain(retired);
+      expect(typography).not.toContain(retired);
+      expect(publicGuide).not.toContain(retired);
+    }
+  });
+
+  it("keeps implementation parity outside this brand-contract document", () => {
+    expect(design).toContain("Cross-platform implementation status");
+    expect(design).toContain("tracked separately");
+  });
+});

--- a/tests/brand/guidelines.test.ts
+++ b/tests/brand/guidelines.test.ts
@@ -12,6 +12,15 @@ describe("Matrix OS brand guidelines", () => {
   const colors = readRepoFile("design/foundations/colors.md");
   const typography = readRepoFile("design/foundations/typography.md");
   const publicGuide = readRepoFile("shell/public/brand-guidelines.html");
+  const componentGuides = [
+    "app-chrome",
+    "badge",
+    "button",
+    "card",
+    "dialog",
+    "input",
+    "navigation",
+  ].map((name) => readRepoFile(`design/components/${name}.md`));
 
   it("records the approved Figma frame as the upstream visual source", () => {
     expect(design).toContain("xPG2FeYRtC9owCKSVXCqWA");
@@ -29,7 +38,9 @@ describe("Matrix OS brand guidelines", () => {
     ] as const) {
       expect(design).toContain(`${name}: "${hex}"`);
       expect(colors).toContain(hex);
-      expect(publicGuide).toContain(hex);
+      expect(publicGuide).toMatch(
+        new RegExp(`--${name}:\\s*${hex.toLowerCase()};`, "i"),
+      );
     }
   });
 
@@ -50,5 +61,17 @@ describe("Matrix OS brand guidelines", () => {
   it("keeps implementation parity outside this brand-contract document", () => {
     expect(design).toContain("Cross-platform implementation status");
     expect(design).toContain("tracked separately");
+  });
+
+  it("uses canonical semantic token names throughout component guidance", () => {
+    for (const guide of componentGuides) {
+      expect(guide).not.toContain("colors.");
+    }
+    expect(componentGuides.join("\n")).not.toContain("(14px)");
+  });
+
+  it("disables smooth scrolling when reduced motion is requested", () => {
+    expect(publicGuide).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(publicGuide).toMatch(/scroll-behavior:\s*auto/);
   });
 });


### PR DESCRIPTION
## Summary

- align the canonical Matrix OS brand contract with the approved Figma frame
- define the title-case wordmark, dotted rabbit/growth mark, five-color palette, complete scales, semantic roles, and Bricolage Grotesque / Geist / Geist Mono type system
- refresh foundation and component guidance plus the browser-rendered public brand reference
- add regression coverage that prevents the canonical source, palette, typography, or implementation boundary from drifting

## Approved source

- Figma: https://www.figma.com/design/xPG2FeYRtC9owCKSVXCqWA/brand?node-id=1-846
- Captured in `DESIGN.md` as the upstream visual source for this contract

## Scope boundary

This PR defines the brand base only. Applying the tokens and behavior consistently across web, Electron desktop, native desktop, and mobile is intentionally tracked separately so the parity work can migrate implementations without redefining the brand.

## Validation

- `flox activate -- bun run typecheck` — passed on Node 24
- `flox activate -- bun run test -- tests/brand/guidelines.test.ts` — 4 tests passed
- `bun run check:patterns` — 0 violations (existing advisory warnings only)
- desktop and 390px mobile visual review — passed
- Lighthouse snapshot: Accessibility 100, Best Practices 100, SEO 100, Agentic Browsing 100
- full `flox activate -- bun run test` — all reported suites passed before the run entered an extended no-output period and was interrupted; no failure was reported

## Invariants

- **Source of truth:** approved Figma frame → `DESIGN.md` → focused `design/` guidance → `@matrix-os/brand` → platform implementations
- **Locks / transactions:** not applicable; documentation, static HTML, and a read-only regression test only
- **Orphan cleanup:** not applicable; no persisted or external resources are created by product code
- **Auth / authorization:** unchanged
- **Deferred:** shared token migration and UI/function/test parity across web, Electron, native desktop, and mobile; historical specs are not rewritten by this brand-contract PR
