### PR TITLE
test(desktop): stabilize restored sidebar controls

### DIFF
--- a/tests/desktop/inspector-files-panel.test.tsx
+++ b/tests/desktop/inspector-files-panel.test.tsx
@@ -274,7 +274,11 @@ describe("InspectorFilesPanel", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "Open README.md" }));
 
-    expect(await screen.findByRole("heading", { name: "Inspector files" })).toBeTruthy();
+    expect(await screen.findByRole(
+      "heading",
+      { name: "Inspector files" },
+      { timeout: 5_000 },
+    )).toBeTruthy();
   });
 
   it("previews a picked text file within the 1 MB cap", async () => {

--- a/tests/desktop/terminal-session-sidebar.test.tsx
+++ b/tests/desktop/terminal-session-sidebar.test.tsx
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import { TerminalSessionSidebar } from "../../desktop/src/renderer/src/features/terminal/TerminalSessionSidebar.js";
 
 describe("TerminalSessionSidebar", () => {
-  it("opens sessions from a non-squashing, scrollable list with active paths and no status dots", () => {
+  it("opens sessions from a non-squashing, scrollable list with active paths and sidebar controls", () => {
     const onSelect = vi.fn();
     const onCreate = vi.fn();
     const onDelete = vi.fn();
@@ -39,6 +39,6 @@ describe("TerminalSessionSidebar", () => {
     expect(screen.getByText("~/projects/matrix-os")).toBeTruthy();
     expect(container.querySelector("[data-terminal-session-status]")).toBeNull();
     expect(screen.getByRole("list", { name: "Terminal sessions" }).className).toContain("overflow-y-auto");
-    expect(screen.queryByRole("button", { name: "Shell theme" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Shell theme" })).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

- update the Terminal sidebar test to expect the restored shell theme picker
- give the lazy Markdown preview assertion a focused five-second CI timeout
- keep the changes test-only and scoped to the two failures on latest `main`

## Tests

- `pnpm exec vitest run tests/desktop/terminal-session-sidebar.test.tsx tests/desktop/inspector-files-panel.test.tsx --silent` — 17 passed
- `git diff --check` — passed
- full test/typecheck/pattern suites not run because this PR only updates two test assertions and the requester asked to stop after PR creation

## Review/Monitoring

- PR created without monitoring Greptile or CI, per requester instruction

## Invariants

- source of truth: existing desktop component behavior remains unchanged; tests now match the restored sidebar control placement
- lock/transaction scope: none; test-only change
- acceptable orphan states: none
- auth source of truth: unchanged
- deferred scope: no production code changes
