### PR TITLE
fix(chat): preserve event source through StrictMode replay

### DIFF
--- a/desktop/src/renderer/src/features/work/WorkTab.tsx
+++ b/desktop/src/renderer/src/features/work/WorkTab.tsx
@@ -228,6 +228,10 @@ export default function WorkTab({
   const measuredWidthRef = useRef(false);
   const pendingFocusRef = useRef<RefObject<HTMLButtonElement | null> | null>(null);
   const resizeCleanupRef = useRef<(() => void) | null>(null);
+  const pendingEventSourceDisposalRef = useRef<{
+    source: CanonicalChatEventSource;
+    cancelled: boolean;
+  } | null>(null);
   const surfaceChromeHost = useSurfaceChromeHost();
   const hostedChrome = surfaceChromeHost !== null;
   const [responsive, setResponsive] = useState<WorkResponsiveState>({
@@ -267,9 +271,23 @@ export default function WorkTab({
   );
 
   useEffect(() => {
+    const pendingDisposal = pendingEventSourceDisposalRef.current;
+    if (pendingDisposal?.source === eventSource) {
+      pendingDisposal.cancelled = true;
+      pendingEventSourceDisposalRef.current = null;
+    }
     if (!eventSource) return;
     void eventSource.start();
-    return () => eventSource.dispose();
+    return () => {
+      const disposal = { source: eventSource, cancelled: false };
+      pendingEventSourceDisposalRef.current = disposal;
+      queueMicrotask(() => {
+        if (!disposal.cancelled) disposal.source.dispose();
+        if (pendingEventSourceDisposalRef.current === disposal) {
+          pendingEventSourceDisposalRef.current = null;
+        }
+      });
+    };
   }, [eventSource]);
 
   useEffect(() => {

--- a/tests/desktop/work-tab.test.tsx
+++ b/tests/desktop/work-tab.test.tsx
@@ -34,10 +34,14 @@ vi.mock("@desktop/renderer/src/lib/canonical-chat-client", async (importOriginal
   return {
     ...actual,
     createCanonicalChatEventSource: () => {
+      let disposed = false;
       const source = {
-        subscribe: vi.fn(() => ({ dispose: vi.fn() })),
+        subscribe: vi.fn(() => {
+          if (disposed) throw new Error("Chat event source is disposed");
+          return { dispose: vi.fn() };
+        }),
         start: vi.fn(async () => undefined),
-        dispose: vi.fn(),
+        dispose: vi.fn(() => { disposed = true; }),
       };
       chatEventSourceFactory.sources.push(source);
       return source;
@@ -293,7 +297,27 @@ describe("WorkTab rail integration", () => {
     expect(eventSourceProps.project.at(-1)).toBe(thirdSource);
 
     view.unmount();
-    expect(thirdSource?.dispose).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(thirdSource?.dispose).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps the shared Chat event source alive through the StrictMode effect replay", async () => {
+    const view = render(
+      <React.StrictMode>
+        <WorkTab route="chat" active initialChatId="chat_global" initialChatView="conversation" />
+      </React.StrictMode>,
+    );
+
+    await screen.findByRole("button", { name: "Global chat" });
+    expect(chatEventSourceFactory.sources).toHaveLength(2);
+    const committedSource = chatEventSourceFactory.sources.find((source) => source.subscribe.mock.calls.length > 0);
+    const discardedSource = chatEventSourceFactory.sources.find((source) => source !== committedSource);
+    expect(discardedSource?.start).not.toHaveBeenCalled();
+    expect(discardedSource?.subscribe).not.toHaveBeenCalled();
+    expect(committedSource?.subscribe).toHaveBeenCalled();
+    expect(committedSource?.dispose).not.toHaveBeenCalled();
+
+    view.unmount();
+    await waitFor(() => expect(committedSource?.dispose).toHaveBeenCalledTimes(1));
   });
 
   it("opens a Global draft and the existing Create Project dialog state", async () => {


### PR DESCRIPTION
## Summary

- keep the shared canonical Chat event source alive through React StrictMode's development effect replay
- defer terminal disposal by one microtask while preserving cleanup on genuine unmounts and runtime identity changes
- add a regression test that reproduces the prior `Chat event source is disposed` WorkRail crash

## Tests

- `pnpm exec vitest run tests/desktop/work-tab.test.tsx` — 29 passed
- `pnpm exec vitest run tests/desktop/work-tab.test.tsx tests/desktop/work-rail.test.tsx tests/desktop/canonical-chat-event-source.test.ts tests/desktop/canonical-chat-route-controller.test.tsx tests/desktop/tab-content.test.tsx tests/desktop/native-desktop-shell.test.tsx --silent` — 131 passed
- full repository TypeScript gate using the pnpm equivalent of `bun run typecheck` — passed
- `pnpm run check:patterns` — 0 violations, 5 existing warnings
- `git diff --check` — passed
- `pnpm run test` — environment-wide gate remained red: unrelated template-build and Codex app-server subprocess tests timed out/failed; stopped after the gate was irrecoverably red

## Invariants

- **Source of truth:** the existing `WorkTab`-owned canonical Chat event source remains the single source shared by the rail and Chat content.
- **Lock/transaction scope:** none; this is renderer-only lifecycle management.
- **Acceptable orphan states:** none introduced; real unmounts and runtime identity replacements still dispose sockets and reconnect timers.
- **Auth source of truth:** unchanged; WebSocket credentials continue to come from the authenticated gateway token endpoint.
- **Deferred scope:** no gateway, canonical Chat contract, persistence, or production update-channel changes.
