### PR TITLE
feat(desktop): cut over terminal workspace clients

### DIFF
--- a/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
@@ -479,7 +479,12 @@ function eventCopy(event: AgentThreadEvent): { title: string; detail: string } {
     case "user_input.answered": return { title: "Input answered", detail: "Input answer received" };
     case "file.changed": return { title: `File ${event.changeKind}`, detail: `${event.changeKind} file` };
     case "review.ready": return { title: "Review ready", detail: `${event.summary.changedFileCount} ${event.summary.changedFileCount === 1 ? "file" : "files"} changed, +${event.summary.additions} -${event.summary.deletions}${event.summary.partial ? ", partial" : ""}` };
-    case "terminal.bound": return { title: "Terminal bound", detail: event.terminalSessionId };
+    case "terminal.bound": return {
+      title: "Terminal bound",
+      detail: event.terminalRef
+        ? `${event.terminalRef.workspaceId}/${event.terminalRef.tabId}`
+        : event.terminalSessionId ?? "Terminal unavailable",
+    };
     case "thread.error": return { title: "Thread needs attention", detail: event.error.retryable ? "Refresh the thread or check the runtime." : "Open the workspace again." };
     case "thread.completed": return { title: "Thread completed", detail: event.outcome };
     case "user.message": return { title: "You", detail: event.text };

--- a/desktop/src/renderer/src/features/coding-agents/AgentThreadLists.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentThreadLists.tsx
@@ -4,6 +4,7 @@ import { Button } from "../../design/primitives";
 import { useCodingAgentWorkspace } from "../../stores/coding-agent-workspace";
 import { useTabs } from "../../stores/tabs";
 import { AgentWorkspaceSection as Section } from "./AgentWorkspaceSection";
+import { runtimeTerminalTabs, terminalRefKey } from "../../lib/terminal-workspaces";
 
 export function ThreadList({
   summary,
@@ -16,17 +17,16 @@ export function ThreadList({
   const requestTerminalSession = useTabs((s) => s.requestTerminalSession);
   const activeThreadId = useCodingAgentWorkspace((s) => s.activeThreadId);
   const loadThreadSnapshot = useCodingAgentWorkspace((s) => s.loadThreadSnapshot);
-  const findAttachableSessionName = (sessionId: string): string | null =>
-    summary.terminalSessions.items.find((session) => session.id === sessionId && session.attachable)?.name ?? null;
+  const terminalTabs = runtimeTerminalTabs(summary);
+  const findAttachableTab = (ref: AgentThreadSummary["terminalRef"]) =>
+    ref ? terminalTabs.find((tab) => tab.refKey === terminalRefKey(ref) && tab.attachable) ?? null : null;
   const openThread = onOpenThread ?? ((thread: AgentThreadSummary) => void loadThreadSnapshot(thread.id));
 
   return (
     <Section title="Active Threads" count={summary.activeThreads.items.length}>
       <div className="grid gap-2">
         {summary.activeThreads.items.map((thread) => {
-          const terminalSessionName = thread.terminalSessionId
-            ? findAttachableSessionName(thread.terminalSessionId)
-            : null;
+          const terminalTab = findAttachableTab(thread.terminalRef);
           const active = activeThreadId === thread.id;
 
           return (
@@ -52,15 +52,14 @@ export function ThreadList({
                 </div>
               </div>
               <div className="flex shrink-0 items-center gap-2">
-                {terminalSessionName ? (
+                {terminalTab ? (
                   <Button
                     variant="ghost"
                     aria-label={`Open terminal for ${thread.title}`}
                     title={`Open terminal for ${thread.title}`}
                     onClick={() => {
-                      if (!thread.terminalSessionId) return;
                       openTab({ kind: "terminals", title: "Terminal" });
-                      requestTerminalSession(terminalSessionName);
+                      requestTerminalSession(terminalTab.refKey);
                     }}
                   >
                     <SquareTerminal size={14} />

--- a/desktop/src/renderer/src/features/coding-agents/composer-seed.ts
+++ b/desktop/src/renderer/src/features/coding-agents/composer-seed.ts
@@ -53,7 +53,7 @@ export function hasComposerContent(current: AgentThreadComposerDraft): boolean {
   return current.prompt.trim().length > 0
     || Boolean(current.projectId)
     || Boolean(current.taskId)
-    || Boolean(current.terminalSessionId)
+    || Boolean(current.terminalRef)
     || Boolean(current.worktreeId)
     || Boolean(current.attachments?.length);
 }
@@ -64,7 +64,7 @@ export function clearComposerLaunchContext(current: AgentThreadComposerDraft): A
     ...current,
     projectId: undefined,
     taskId: undefined,
-    terminalSessionId: undefined,
+    terminalRef: undefined,
     worktreeId: undefined,
     attachments: attachments?.length ? attachments : undefined,
   };

--- a/desktop/src/renderer/src/features/palette/CommandPalette.tsx
+++ b/desktop/src/renderer/src/features/palette/CommandPalette.tsx
@@ -18,6 +18,7 @@ import { openProjectOverview } from "../../lib/project-navigation";
 import { HOSTED_SHELL_TAB_SPEC } from "../../lib/hosted-shell";
 import { handleNewAgentRunShortcut } from "../mission-control/shortcuts";
 import { openProviderSetupTerminal, providerSetupCommands, type ProviderSetupCommand } from "../coding-agents/provider-setup-terminal";
+import { runtimeTerminalTabs, type RuntimeTerminalTab } from "../../lib/terminal-workspaces";
 
 const EMPTY_REVIEWS: ReviewSummary[] = [];
 const MAX_PALETTE_REVIEWS = 10;
@@ -25,7 +26,6 @@ const MAX_PALETTE_THREADS = 20;
 const MAX_PALETTE_TERMINALS = 20;
 const GENERIC_THREAD_TITLE = "Coding agent run";
 const TERMINAL_REVIEW_STATUSES: ReviewSummary["status"][] = ["approved", "converged", "stopped"];
-const SESSION_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]{0,29}[a-z0-9])?$/;
 const SETUP_DISCONNECTED_ERROR = "Connect to your Matrix computer before opening setup.";
 const SETUP_TERMINAL_ERROR = "Could not open setup terminal. Try again from Terminal.";
 type PaletteCategory = "all" | "projects" | "actions" | "settings";
@@ -108,21 +108,20 @@ function paletteThreadCommands(
 }
 
 function paletteTerminalCommands(
-  summary: { terminalSessions?: { items: TerminalSessionSummary[] } } | null,
+  summary: RuntimeSummary | null,
   shellSessions: Array<{ name: string }>,
-): TerminalSessionSummary[] {
-  if (!summary?.terminalSessions) return [];
+): RuntimeTerminalTab[] {
+  if (!summary) return [];
   const shellSessionNames = new Set(shellSessions.map((session) => session.name));
-  const commands: TerminalSessionSummary[] = [];
+  const commands: RuntimeTerminalTab[] = [];
   const seen = new Set<string>();
-  for (const session of summary.terminalSessions.items) {
+  for (const session of runtimeTerminalTabs(summary)) {
     if (
       !session.attachable
-      || !SESSION_NAME_PATTERN.test(session.name)
-      || shellSessionNames.has(session.name)
-      || seen.has(session.name)
+      || shellSessionNames.has(session.refKey)
+      || seen.has(session.refKey)
     ) continue;
-    seen.add(session.name);
+    seen.add(session.refKey);
     commands.push(session);
     if (commands.length >= MAX_PALETTE_TERMINALS) break;
   }
@@ -436,7 +435,7 @@ export default function CommandPalette() {
                   icon={<SquareTerminal size={14} />}
                   label={`Open terminal ${session.name}`}
                   onSelect={() =>
-                    run(() => openTab({ kind: "terminal", sessionName: session.name, title: session.name }))
+                    run(() => openTab({ kind: "terminal", sessionName: session.refKey, title: session.name }))
                   }
                 />
               ))}

--- a/desktop/src/renderer/src/features/panels/InspectorTerminalPanel.tsx
+++ b/desktop/src/renderer/src/features/panels/InspectorTerminalPanel.tsx
@@ -2,6 +2,11 @@ import { ChevronLeft, Play, SquareTerminal } from "@renderer/lib/hugeicons";
 import { useState } from "react";
 import type { RuntimeSummary, TerminalSessionSummary } from "@matrix-os/contracts";
 import TerminalView from "../terminal/TerminalView";
+import { runtimeTerminalTabs, type RuntimeTerminalTab } from "../../lib/terminal-workspaces";
+
+type InspectorTerminal = Pick<RuntimeTerminalTab, "id" | "name" | "attachable" | "refKey"> & {
+  status: RuntimeTerminalTab["status"] | TerminalSessionSummary["status"];
+};
 
 const STATUS_COLOR: Record<string, string> = {
   running: "var(--success)",
@@ -33,7 +38,9 @@ export function InspectorTerminalPanel({
   emptyMessage?: string;
 }) {
   const [embeddedId, setEmbeddedId] = useState<string | null>(null);
-  const sessions = providedSessions ?? summary?.terminalSessions.items ?? [];
+  const sessions: InspectorTerminal[] = providedSessions
+    ? providedSessions.map((session) => ({ ...session, refKey: session.id }))
+    : summary ? runtimeTerminalTabs(summary) : [];
   // The embedded session must still exist and stay attachable; a refresh that
   // ends or detaches it drops the embed back to the list in the same render.
   const embedded = embeddedId
@@ -69,7 +76,7 @@ export function InspectorTerminalPanel({
           className="flex min-h-[240px] min-w-0 flex-1 flex-col overflow-hidden rounded-md border"
           style={{ borderColor: "var(--border-subtle)" }}
         >
-          <TerminalView key={`${chatId ?? "standalone"}:${embedded.name}`} sessionName={embedded.name} chatId={chatId} active={active} />
+          <TerminalView key={`${chatId ?? "standalone"}:${embedded.refKey}`} sessionName={embedded.refKey} chatId={chatId} active={active} />
         </div>
       </div>
     );
@@ -96,7 +103,7 @@ function SessionRow({
   session,
   onOpen,
 }: {
-  session: TerminalSessionSummary;
+  session: InspectorTerminal;
   onOpen: () => void;
 }) {
   return (

--- a/desktop/src/renderer/src/features/project/project-inspector-context.ts
+++ b/desktop/src/renderer/src/features/project/project-inspector-context.ts
@@ -62,15 +62,22 @@ export function buildProjectInspectorContext({
   const scopedActiveThreads = projectThreads(summary.activeThreads.items, projectId);
   const scopedAttentionThreads = projectThreads(summary.attentionThreads.items, projectId);
 
-  const terminalSessionId = selectedThread?.projectId === projectId
-    ? selectedThread.terminalSessionId
+  const terminalRef = selectedThread?.projectId === projectId
+    ? selectedThread.terminalRef
     : undefined;
-  const linkedTerminal = terminalSessionId
-    ? summary.terminalSessions.items.find((session) => session.id === terminalSessionId) ?? null
+  const linkedWorkspace = terminalRef
+    ? summary.terminalWorkspaces.items.find((workspace) => (
+        workspace.id === terminalRef.workspaceId
+        && workspace.scope === "project"
+        && workspace.projectId === projectId
+      )) ?? null
+    : null;
+  const linkedTerminal = linkedWorkspace
+    ? linkedWorkspace.tabs.find((tab) => tab.id === terminalRef?.tabId) ?? null
     : null;
   const terminalState: ProjectInspectorTerminalState = linkedTerminal
     ? "linked"
-    : terminalSessionId
+    : terminalRef
       ? "unavailable"
       : "unbound";
 
@@ -111,9 +118,11 @@ export function buildProjectInspectorContext({
       ...summary,
       activeThreads: { ...summary.activeThreads, items: scopedActiveThreads, hasMore: false },
       attentionThreads: { ...summary.attentionThreads, items: scopedAttentionThreads, hasMore: false },
-      terminalSessions: {
-        ...summary.terminalSessions,
-        items: linkedTerminal ? [linkedTerminal] : [],
+      terminalWorkspaces: {
+        ...summary.terminalWorkspaces,
+        items: linkedWorkspace && linkedTerminal
+          ? [{ ...linkedWorkspace, tabs: [linkedTerminal] }]
+          : [],
         hasMore: false,
       },
       previewSessions: { ...summary.previewSessions, items: scopedPreviews, hasMore: false },

--- a/tests/desktop/api-client.test.ts
+++ b/tests/desktop/api-client.test.ts
@@ -243,14 +243,14 @@ describe("createApiClient", () => {
     const image = new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], { type: "image/png" });
 
     await client.postBytes(
-      "/api/terminal/sessions/main/paste-assets",
+      "/api/terminal/workspaces/tws_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/tabs/tt_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/paste-assets",
       image,
       { "Content-Type": "image/png", "X-Matrix-Filename": "shot.png" },
       { timeoutMs: 30_000 },
     );
 
     const [url, init] = fetchFn.mock.calls[0]!;
-    expect(url).toBe("https://x.test/api/terminal/sessions/main/paste-assets?runtime=vm-2");
+    expect(url).toBe("https://x.test/api/terminal/workspaces/tws_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/tabs/tt_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/paste-assets?runtime=vm-2");
     expect(init).toMatchObject({ method: "POST", body: image });
     expect((init as RequestInit).headers).toEqual({
       "Content-Type": "image/png",

--- a/tests/desktop/chat-tab-render.test.tsx
+++ b/tests/desktop/chat-tab-render.test.tsx
@@ -35,6 +35,40 @@ function thread(id: string, title: string): AgentThread {
   };
 }
 
+function codingAgentSummaryFixture() {
+  return {
+    runtime: { id: "rt_primary", label: "Primary", status: "available" },
+    capabilities: [],
+    providers: [],
+    projects: { items: [], hasMore: false, limit: 20 },
+    activeThreads: {
+      items: [
+        {
+          id: "thread_server",
+          providerId: "codex",
+          title: "Server-backed run",
+          status: "running",
+          attention: "none",
+          createdAt: "2026-07-06T00:00:00.000Z",
+          updatedAt: "2026-07-06T00:01:00.000Z",
+        },
+      ],
+      hasMore: false,
+      limit: 20,
+    },
+    attentionThreads: { items: [], hasMore: false, limit: 20 },
+    terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
+    recentActivity: { items: [], hasMore: false, limit: 20 },
+    limits: {
+      maxPromptBytes: 16384,
+      maxAttachmentCount: 8,
+      maxTerminalInputBytes: 8192,
+      maxListItems: 20,
+    },
+    serverTime: "2026-07-06T00:03:00.000Z",
+  };
+}
+
 describe("ChatTab", () => {
   beforeEach(() => {
     class MockResizeObserver {

--- a/tests/desktop/chat-type-to-start.test.tsx
+++ b/tests/desktop/chat-type-to-start.test.tsx
@@ -44,7 +44,7 @@ function summaryFixture(): RuntimeSummary {
     },
     activeThreads: { items: [], hasMore: false, limit: 20 },
     attentionThreads: { items: [], hasMore: false, limit: 20 },
-    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
     previewSessions: { items: [], hasMore: false, limit: 50 },
     recentActivity: { items: [], hasMore: false, limit: 20 },
     limits: { maxPromptBytes: 16_384, maxAttachmentCount: 8, maxTerminalInputBytes: 8_192, maxListItems: 20 },

--- a/tests/desktop/coding-agent-chat-transcript.test.tsx
+++ b/tests/desktop/coding-agent-chat-transcript.test.tsx
@@ -557,7 +557,7 @@ describe("AgentConversationView transcript", () => {
             eventId: "evt_terminal_1",
             threadId: "thread_alpha",
             occurredAt: "2026-07-15T00:00:10.000Z",
-            terminalSessionId: "term_1",
+            terminalRef: { workspaceId: "tws_00000000000000000000000000000001", tabId: "tt_00000000000000000000000000000001" },
           } as AgentThreadEvent,
           {
             type: "thread.completed",

--- a/tests/desktop/coding-agent-runtime-client.test.ts
+++ b/tests/desktop/coding-agent-runtime-client.test.ts
@@ -180,7 +180,7 @@ function threadSnapshotBody() {
       title: "Fix desktop notifications",
       status: "waiting_for_approval",
       attention: "approval_required",
-      terminalSessionId: "matrix-abc1234",
+      terminalRef: { workspaceId: "tws_00000000000000000000000000000001", tabId: "tt_00000000000000000000000000000001" },
       createdAt: "2026-07-06T00:00:00.000Z",
       updatedAt: "2026-07-06T00:01:00.000Z",
     },

--- a/tests/desktop/coding-agent-thread-model.test.ts
+++ b/tests/desktop/coding-agent-thread-model.test.ts
@@ -41,7 +41,7 @@ function summary(overrides: {
       hasMore: overrides.attentionHasMore ?? false,
       limit: overrides.attentionLimit ?? 20,
     },
-    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
     recentActivity: { items: [], hasMore: false, limit: 20 },
     limits: {
       maxPromptBytes: 16384,

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -45,18 +45,20 @@ function summaryFixture({
   sameThreadTurns = true,
   files = false,
   sourceControl = false,
-  threadTerminalSessionId,
-  terminalSessionName = "matrix-abc1234",
+  threadTerminalRef,
+  terminalTabName = "matrix-abc1234",
   providers,
 }: {
   threadCreate?: boolean;
   sameThreadTurns?: boolean;
   files?: boolean;
   sourceControl?: boolean;
-  threadTerminalSessionId?: string;
-  terminalSessionName?: string;
+  threadTerminalRef?: { workspaceId: string; tabId: string };
+  terminalTabName?: string;
   providers?: RuntimeSummary["providers"];
 } = {}) {
+  const workspaceId = "tws_00000000000000000000000000000001";
+  const tabId = "tt_00000000000000000000000000000001";
   return {
     runtime: {
       id: "rt_primary",
@@ -121,7 +123,7 @@ function summaryFixture({
           title: "Fix settings route",
           status: "running",
           projectId: "matrix-os",
-          ...(threadTerminalSessionId ? { terminalSessionId: threadTerminalSessionId } : {}),
+          ...(threadTerminalRef ? { terminalRef: threadTerminalRef } : {}),
           createdAt: "2026-07-06T00:00:00.000Z",
           updatedAt: "2026-07-06T00:01:00.000Z",
         },
@@ -134,15 +136,28 @@ function summaryFixture({
       hasMore: false,
       limit: 20,
     },
-    terminalSessions: {
+    terminalWorkspaces: {
       items: [
         {
-          id: "matrix-abc1234",
-          name: terminalSessionName,
+          id: workspaceId,
+          scope: "project",
+          projectId: "matrix-os",
+          canonicalSize: { cols: 120, rows: 36 },
           status: "running",
-          attachable: true,
+          revision: 1,
           createdAt: "2026-07-06T00:00:00.000Z",
           updatedAt: "2026-07-06T00:02:00.000Z",
+          tabs: [{
+            id: tabId,
+            workspaceId,
+            name: terminalTabName,
+            cwd: "projects/matrix-os",
+            status: "running",
+            revision: 1,
+            order: 0,
+            createdAt: "2026-07-06T00:00:00.000Z",
+            updatedAt: "2026-07-06T00:02:00.000Z",
+          }],
         },
       ],
       hasMore: false,
@@ -365,7 +380,7 @@ function threadSnapshotFixture() {
       status: "waiting_for_approval",
       attention: "approval_required",
       projectId: "matrix-os",
-      terminalSessionId: "matrix-abc1234",
+      terminalRef: { workspaceId: "tws_00000000000000000000000000000001", tabId: "tt_00000000000000000000000000000001" },
       createdAt: "2026-07-06T00:00:00.000Z",
       updatedAt: "2026-07-06T00:04:00.000Z",
     },
@@ -438,7 +453,7 @@ function attentionThreadSnapshotFixture() {
       title: "Repair failed run",
       status: "failed",
       attention: "failed",
-      terminalSessionId: undefined,
+      terminalRef: undefined,
       updatedAt: "2026-07-06T00:06:00.000Z",
     },
     events: {
@@ -485,7 +500,7 @@ function resolvedAttentionApprovalSnapshotFixture() {
       title: "Approve deployment",
       status: "running",
       attention: "none",
-      terminalSessionId: undefined,
+      terminalRef: undefined,
       updatedAt: "2026-07-06T00:07:00.000Z",
     },
   };
@@ -579,7 +594,7 @@ function inputRequestedThreadSnapshotFixture() {
       title: "Fix settings route",
       status: "waiting_for_input",
       attention: "input_required",
-      terminalSessionId: "matrix-abc1234",
+      terminalRef: { workspaceId: "tws_00000000000000000000000000000001", tabId: "tt_00000000000000000000000000000001" },
       createdAt: "2026-07-06T00:00:00.000Z",
       updatedAt: "2026-07-06T00:06:00.000Z",
     },
@@ -643,7 +658,7 @@ function resolvedAttentionInputSnapshotFixture() {
       title: "Approve deployment",
       status: "running",
       attention: "none",
-      terminalSessionId: undefined,
+      terminalRef: undefined,
       updatedAt: "2026-07-06T00:08:00.000Z",
     },
   };
@@ -2436,7 +2451,7 @@ describe("ProjectChatsView", () => {
     useProjectView.getState().setSelectedThread("matrix-os", "thread_alpha");
     window.operator.invoke = vi.fn((channel: string) => {
       if (channel === "runtime:get-summary") {
-        return Promise.resolve(summaryFixture({ threadTerminalSessionId: "matrix-abc1234" }));
+        return Promise.resolve(summaryFixture({ threadTerminalRef: { workspaceId: "tws_00000000000000000000000000000001", tabId: "tt_00000000000000000000000000000001" } }));
       }
       if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
       if (channel === "runtime:get-thread-snapshot") return Promise.resolve(threadSnapshotFixture());
@@ -2455,8 +2470,8 @@ describe("ProjectChatsView", () => {
     window.operator.invoke = vi.fn((channel: string) => {
       if (channel === "runtime:get-summary") {
         return Promise.resolve(summaryFixture({
-          threadTerminalSessionId: "matrix-abc1234",
-          terminalSessionName: "friendly-shell",
+          threadTerminalRef: { workspaceId: "tws_00000000000000000000000000000001", tabId: "tt_00000000000000000000000000000001" },
+          terminalTabName: "friendly-shell",
         }));
       }
       if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
@@ -2475,13 +2490,19 @@ describe("ProjectChatsView", () => {
     useProjectView.getState().setSelectedThread("matrix-os", "thread_alpha");
     window.operator.invoke = vi.fn((channel: string) => {
       if (channel === "runtime:get-summary") {
-        return Promise.resolve(summaryFixture({ threadTerminalSessionId: "matrix-missing" }));
+        return Promise.resolve(summaryFixture({ threadTerminalRef: { workspaceId: "tws_00000000000000000000000000000002", tabId: "tt_00000000000000000000000000000002" } }));
       }
       if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
       if (channel === "runtime:get-thread-snapshot") {
         return Promise.resolve({
           ...threadSnapshotFixture(),
-          thread: { ...threadSnapshotFixture().thread, terminalSessionId: "matrix-missing" },
+          thread: {
+            ...threadSnapshotFixture().thread,
+            terminalRef: {
+              workspaceId: "tws_00000000000000000000000000000002",
+              tabId: "tt_00000000000000000000000000000002",
+            },
+          },
         });
       }
       return Promise.reject(new Error("unexpected channel"));
@@ -4304,7 +4325,7 @@ describe("ProjectChatsView", () => {
       },
       activeThreads: { items: [], hasMore: false, limit: 20 },
       attentionThreads: { items: [], hasMore: false, limit: 20 },
-      terminalSessions: { items: [], hasMore: false, limit: 20 },
+      terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
       previewSessions: { items: [], hasMore: false, limit: 50 },
       recentActivity: { items: [], hasMore: false, limit: 20 },
       limits: { maxPromptBytes: 16384, maxAttachmentCount: 8, maxTerminalInputBytes: 8192, maxListItems: 20 },

--- a/tests/desktop/command-palette.test.tsx
+++ b/tests/desktop/command-palette.test.tsx
@@ -10,7 +10,7 @@ vi.mock("../../desktop/src/renderer/src/lib/feature-flags", () => ({
 }));
 
 import CommandPalette from "../../desktop/src/renderer/src/features/palette/CommandPalette";
-import type { AgentThreadSummary, RuntimeSummary, TerminalSessionSummary } from "../../packages/contracts/src/index";
+import type { AgentThreadSummary, RuntimeSummary, TerminalSessionSummary, TerminalTab } from "../../packages/contracts/src/index";
 import { desktopQueryClient } from "../../desktop/src/renderer/src/lib/query-client";
 import { useBoard } from "../../desktop/src/renderer/src/stores/board";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
@@ -41,6 +41,7 @@ function runtimeSummaryWithThreads(options: {
   activeThreads?: AgentThreadSummary[];
   attentionThreads?: AgentThreadSummary[];
   terminalSessions?: TerminalSessionSummary[];
+  terminalTabs?: TerminalTab[];
 } = {}): RuntimeSummary {
   return {
     runtime: {
@@ -61,6 +62,21 @@ function runtimeSummaryWithThreads(options: {
     activeThreads: { items: options.activeThreads ?? [], hasMore: false, limit: 20 },
     attentionThreads: { items: options.attentionThreads ?? [], hasMore: false, limit: 20 },
     terminalSessions: { items: options.terminalSessions ?? [], hasMore: false, limit: 20 },
+    terminalWorkspaces: {
+      items: options.terminalTabs?.length ? [{
+        id: "tws_00000000000000000000000000000001",
+        scope: "project",
+        projectId: "matrix-os",
+        canonicalSize: { cols: 120, rows: 36 },
+        status: "running",
+        revision: 1,
+        createdAt: "2026-07-07T00:00:00.000Z",
+        updatedAt: "2026-07-07T00:00:00.000Z",
+        tabs: options.terminalTabs,
+      }] : [],
+      hasMore: false,
+      limit: 20,
+    },
     previewSessions: { items: [], hasMore: false, limit: 20 },
     recentActivity: { items: [], hasMore: false, limit: 20 },
   };
@@ -72,6 +88,21 @@ function terminalSessionSummary(id: string, overrides: Partial<TerminalSessionSu
     name: `matrix-${id}`,
     status: "running",
     attachable: true,
+    createdAt: "2026-07-07T00:00:00.000Z",
+    updatedAt: "2026-07-07T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function terminalTabSummary(id: string, overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id,
+    workspaceId: "tws_00000000000000000000000000000001",
+    name: `matrix-${id}`,
+    status: "running",
+    cwd: "projects/matrix-os",
+    revision: 1,
+    order: 0,
     createdAt: "2026-07-07T00:00:00.000Z",
     updatedAt: "2026-07-07T00:00:00.000Z",
     ...overrides,
@@ -198,18 +229,27 @@ describe("CommandPalette", () => {
     });
   });
 
-  it("opens terminal entries from canonical shell sessions, not workspace sessions", async () => {
+  it("does not duplicate a workspace tab already represented by the terminal store", async () => {
     const openTab = vi.fn();
     useSessions.setState({
       sessions: [{ name: "Workspace Only", attachName: "workspace-only", status: "active", source: "workspace" }],
     });
     useShellSessions.setState({
-      sessions: [{ name: "matrix-main", status: "active" }],
+      sessions: [{
+        name: "tws_00000000000000000000000000000001:tt_00000000000000000000000000000001",
+        workspaceId: "tws_00000000000000000000000000000001",
+        tabId: "tt_00000000000000000000000000000001",
+        revision: 1,
+        workspaceRevision: 1,
+        cwd: "projects/matrix-os",
+        status: "active",
+        subtitle: "matrix-main",
+      }],
     });
     useCodingAgentWorkspace.setState({
       summary: runtimeSummaryWithThreads({
-        terminalSessions: [
-          terminalSessionSummary("term_matrix_main", {
+        terminalTabs: [
+          terminalTabSummary("tt_00000000000000000000000000000001", {
             name: "matrix-main",
           }),
         ],
@@ -221,13 +261,7 @@ describe("CommandPalette", () => {
 
     expect(screen.queryByText("Workspace Only")).toBeNull();
     expect(screen.queryByText("Open terminal matrix-main")).toBeNull();
-    fireEvent.click(screen.getByText("matrix-main"));
-
-    expect(openTab).toHaveBeenCalledWith({
-      kind: "terminal",
-      sessionName: "matrix-main",
-      title: "matrix-main",
-    });
+    expect(openTab).not.toHaveBeenCalled();
   });
 
   it("no longer offers a retired Agents workspace entry", async () => {
@@ -460,20 +494,18 @@ describe("CommandPalette", () => {
     useShellSessions.setState({ sessions: [] });
     useCodingAgentWorkspace.setState({
       summary: runtimeSummaryWithThreads({
-        terminalSessions: [
-          terminalSessionSummary("term_attached_1", {
+        terminalTabs: [
+          terminalTabSummary("tt_00000000000000000000000000000001", {
             name: "matrix-review-758",
-            cwdLabel: "matrix-os",
           }),
-          terminalSessionSummary("term_unavailable_1", {
+          terminalTabSummary("tt_00000000000000000000000000000002", {
             name: "matrix-stale-review",
             status: "stale",
-            attachable: false,
           }),
-          terminalSessionSummary("term_invalid_name_1", {
+          terminalTabSummary("tt_00000000000000000000000000000003", {
             name: "Matrix-Review.123",
           }),
-          terminalSessionSummary("term_invalid_name_2", {
+          terminalTabSummary("tt_00000000000000000000000000000004", {
             name: "matrix-review-",
           }),
         ],
@@ -484,14 +516,14 @@ describe("CommandPalette", () => {
 
     expect(screen.getByText("Open terminal matrix-review-758")).toBeTruthy();
     expect(screen.queryByText("Open terminal matrix-stale-review")).toBeNull();
-    expect(screen.queryByText("Open terminal Matrix-Review.123")).toBeNull();
-    expect(screen.queryByText("Open terminal matrix-review-")).toBeNull();
+    expect(screen.getByText("Open terminal Matrix-Review.123")).toBeTruthy();
+    expect(screen.getByText("Open terminal matrix-review-")).toBeTruthy();
 
     fireEvent.click(screen.getByText("Open terminal matrix-review-758"));
 
     expect(openTab).toHaveBeenCalledWith({
       kind: "terminal",
-      sessionName: "matrix-review-758",
+      sessionName: "tws_00000000000000000000000000000001:tt_00000000000000000000000000000001",
       title: "matrix-review-758",
     });
   });

--- a/tests/desktop/composer-provider-preference.test.tsx
+++ b/tests/desktop/composer-provider-preference.test.tsx
@@ -38,7 +38,7 @@ function summaryWith(providers: unknown[]): RuntimeSummary {
     projects: { items: [], hasMore: false, limit: 20 },
     activeThreads: { items: [], hasMore: false, limit: 20 },
     attentionThreads: { items: [], hasMore: false, limit: 20 },
-    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
     previewSessions: { items: [], hasMore: false, limit: 50 },
     recentActivity: { items: [], hasMore: false, limit: 20 },
     limits: { maxPromptBytes: 16_384, maxAttachmentCount: 8, maxTerminalInputBytes: 8_192, maxListItems: 20 },

--- a/tests/desktop/conversation-hero.test.tsx
+++ b/tests/desktop/conversation-hero.test.tsx
@@ -44,7 +44,7 @@ function summaryFixture(): RuntimeSummary {
     },
     activeThreads: { items: [], hasMore: false, limit: 20 },
     attentionThreads: { items: [], hasMore: false, limit: 20 },
-    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
     previewSessions: { items: [], hasMore: false, limit: 50 },
     recentActivity: { items: [], hasMore: false, limit: 20 },
     limits: { maxPromptBytes: 16_384, maxAttachmentCount: 8, maxTerminalInputBytes: 8_192, maxListItems: 20 },

--- a/tests/desktop/draft-chat-replaces-selection.test.tsx
+++ b/tests/desktop/draft-chat-replaces-selection.test.tsx
@@ -66,7 +66,7 @@ function summaryFixture(): RuntimeSummary {
     },
     activeThreads: { items: [], hasMore: false, limit: 20 },
     attentionThreads: { items: [], hasMore: false, limit: 20 },
-    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
     previewSessions: { items: [], hasMore: false, limit: 50 },
     recentActivity: { items: [], hasMore: false, limit: 20 },
     limits: { maxPromptBytes: 16_384, maxAttachmentCount: 8, maxTerminalInputBytes: 8_192, maxListItems: 20 },

--- a/tests/desktop/draft-chat-send.test.tsx
+++ b/tests/desktop/draft-chat-send.test.tsx
@@ -50,7 +50,7 @@ function summaryFixture(providers: RuntimeSummary["providers"] = [{
     },
     activeThreads: { items: [], hasMore: false, limit: 20 },
     attentionThreads: { items: [], hasMore: false, limit: 20 },
-    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
     previewSessions: { items: [], hasMore: false, limit: 50 },
     recentActivity: { items: [], hasMore: false, limit: 20 },
     limits: { maxPromptBytes: 16_384, maxAttachmentCount: 8, maxTerminalInputBytes: 8_192, maxListItems: 20 },

--- a/tests/desktop/header-injection.test.ts
+++ b/tests/desktop/header-injection.test.ts
@@ -299,7 +299,7 @@ describe("shouldInjectAuth", () => {
   });
 
   it("injects for websocket upgrades to the same host", () => {
-    expect(shouldInjectAuth("wss://app.matrix-os.com/ws/terminal/session?session=x", GATEWAY)).toBe(true);
+    expect(shouldInjectAuth("wss://app.matrix-os.com/ws/terminal/tab?workspaceId=tws_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&tabId=tt_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", GATEWAY)).toBe(true);
   });
 
   it("never injects for other origins", () => {

--- a/tests/desktop/inspector-terminal-embed.test.tsx
+++ b/tests/desktop/inspector-terminal-embed.test.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { RuntimeSummary, TerminalSessionSummary } from "@matrix-os/contracts";
+import type { RuntimeSummary, TerminalTab } from "@matrix-os/contracts";
 import { AgentConversationInspector } from "../../desktop/src/renderer/src/features/coding-agents/AgentConversationInspector";
 import { InspectorTerminalPanel } from "../../desktop/src/renderer/src/features/panels/InspectorTerminalPanel";
 
@@ -33,17 +33,20 @@ afterEach(cleanup);
 
 const NOW = "2026-07-12T12:00:00.000Z";
 
-function session(partial: Partial<TerminalSessionSummary> & { id: string; name: string }): TerminalSessionSummary {
+function session(partial: Partial<TerminalTab> & { id: string; name: string }): TerminalTab {
   return {
+    workspaceId: "tws_00000000000000000000000000000001",
+    cwd: "projects/matrix-os",
     status: "running",
-    attachable: true,
+    revision: 1,
+    order: 0,
     createdAt: NOW,
     updatedAt: NOW,
     ...partial,
   };
 }
 
-function summaryWith(sessions: TerminalSessionSummary[]): RuntimeSummary {
+function summaryWith(sessions: TerminalTab[]): RuntimeSummary {
   return {
     runtime: { id: "rt_primary", label: "Primary", status: "available" },
     capabilities: [],
@@ -51,7 +54,7 @@ function summaryWith(sessions: TerminalSessionSummary[]): RuntimeSummary {
     projects: { items: [], hasMore: false, limit: 20 },
     activeThreads: { items: [], hasMore: false, limit: 20 },
     attentionThreads: { items: [], hasMore: false, limit: 20 },
-    terminalSessions: { items: sessions, hasMore: false, limit: 20 },
+    terminalWorkspaces: { items: [{ id: "tws_00000000000000000000000000000001", scope: "project", projectId: "matrix-os", canonicalSize: { cols: 120, rows: 36 }, status: "running", revision: 1, createdAt: NOW, updatedAt: NOW, tabs: sessions }], hasMore: false, limit: 20 },
     previewSessions: { items: [], hasMore: false, limit: 50 },
     recentActivity: { items: [], hasMore: false, limit: 20 },
     limits: { maxPromptBytes: 16_384, maxAttachmentCount: 8, maxTerminalInputBytes: 8_192, maxListItems: 20 },
@@ -69,7 +72,7 @@ describe("InspectorTerminalPanel", () => {
       <InspectorTerminalPanel
         summary={summaryWith([
           session({ id: "ts_1", name: "build-shell" }),
-          session({ id: "ts_2", name: "old-shell", attachable: false, status: "exited" }),
+          session({ id: "ts_2", name: "old-shell", status: "exited" }),
         ])}
         active
       />,
@@ -114,9 +117,9 @@ describe("InspectorTerminalPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open terminal deploy-shell" }));
 
     const embedded = screen.getByTestId("embedded-terminal");
-    expect(embedded.getAttribute("data-session")).toBe("deploy-shell");
+    expect(embedded.getAttribute("data-session")).toBe("tws_00000000000000000000000000000001:ts_2");
     expect(embedded.getAttribute("data-active")).toBe("true");
-    expect(terminalViewMock.lastProps?.sessionName).toBe("deploy-shell");
+    expect(terminalViewMock.lastProps?.sessionName).toBe("tws_00000000000000000000000000000001:ts_2");
     expect(terminalViewMock.lastProps?.chatId).toBe("chat_selected");
     // Exactly one session embeds at a time; the list is replaced, not stacked.
     expect(screen.queryByRole("button", { name: "Open terminal build-shell" })).toBeNull();
@@ -153,7 +156,7 @@ describe("InspectorTerminalPanel", () => {
     view.rerender(
       <Tooltip.Provider>
         <InspectorTerminalPanel
-          summary={summaryWith([session({ id: "ts_1", name: "build-shell", attachable: false, status: "exited" })])}
+          summary={summaryWith([session({ id: "ts_1", name: "build-shell", status: "exited" })])}
           active
         />
       </Tooltip.Provider>,

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -527,7 +527,7 @@ describe("IPC contract", () => {
         hasMore: false,
         limit: 20,
       },
-      terminalSessions: {
+      terminalWorkspaces: {
         items: [],
         limit: 20,
         hasMore: false,

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -376,7 +376,7 @@ describe("registerIpcHandlers", () => {
         hasMore: false,
         limit: 20,
       },
-      terminalSessions: {
+      terminalWorkspaces: {
         items: [],
         limit: 20,
         hasMore: false,

--- a/tests/desktop/kernel-wiring.test.ts
+++ b/tests/desktop/kernel-wiring.test.ts
@@ -58,7 +58,7 @@ function codingAgentAttentionSummaryFixture() {
       hasMore: false,
       limit: 20,
     },
-    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
     recentActivity: { items: [], hasMore: false, limit: 20 },
     limits: {
       maxPromptBytes: 16384,

--- a/tests/desktop/panels-preview-chrome.test.tsx
+++ b/tests/desktop/panels-preview-chrome.test.tsx
@@ -27,7 +27,7 @@ function summaryWith(previews: PreviewSessionSummary[]): RuntimeSummary {
     projects: { items: [], hasMore: false, limit: 20 },
     activeThreads: { items: [], hasMore: false, limit: 20 },
     attentionThreads: { items: [], hasMore: false, limit: 20 },
-    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
     previewSessions: { items: previews, hasMore: false, limit: 50 },
     recentActivity: { items: [], hasMore: false, limit: 20 },
     limits: { maxPromptBytes: 16_384, maxAttachmentCount: 8, maxTerminalInputBytes: 8_192, maxListItems: 20 },

--- a/tests/desktop/plugins-skills.test.tsx
+++ b/tests/desktop/plugins-skills.test.tsx
@@ -21,6 +21,9 @@ import { useConnection } from "../../desktop/src/renderer/src/stores/connection"
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 import type { ApiClient } from "../../desktop/src/renderer/src/lib/api";
 
+const WORKSPACE_ID = `tws_${"a".repeat(32)}`;
+const TAB_ID = `tt_${"b".repeat(32)}`;
+
 const SKILLS = [
   {
     name: "code-review",
@@ -47,7 +50,8 @@ function makeApi(opts: FakeApiOptions = {}) {
       throw new AppError("notFound");
     }),
     post: vi.fn(async (path: string) => {
-      if (path === "/api/terminal/sessions") return { name: "plugins-skills" };
+      if (path === "/api/terminal/workspaces/ensure") return { workspace: { id: WORKSPACE_ID } };
+      if (path === `/api/terminal/workspaces/${WORKSPACE_ID}/tabs`) return { tab: { id: TAB_ID } };
       throw new AppError("notFound");
     }),
     delete: vi.fn(),

--- a/tests/desktop/project-chat.test.ts
+++ b/tests/desktop/project-chat.test.ts
@@ -41,7 +41,7 @@ function summaryWithThreads(): RuntimeSummary {
       limit: 20,
     },
     attentionThreads: { items: [], hasMore: false, limit: 20 },
-    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
     previewSessions: { items: [], hasMore: false, limit: 50 },
     recentActivity: { items: [], hasMore: false, limit: 20 },
     limits: { maxPromptBytes: 16_384, maxAttachmentCount: 8, maxTerminalInputBytes: 8_192, maxListItems: 20 },

--- a/tests/desktop/project-chats-view-layout.test.tsx
+++ b/tests/desktop/project-chats-view-layout.test.tsx
@@ -87,7 +87,7 @@ function summaryFixture(): RuntimeSummary {
     },
     activeThreads: { items: [], hasMore: false, limit: 20 },
     attentionThreads: { items: [], hasMore: false, limit: 20 },
-    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
     previewSessions: { items: [], hasMore: false, limit: 50 },
     recentActivity: { items: [], hasMore: false, limit: 20 },
     limits: { maxPromptBytes: 16_384, maxAttachmentCount: 8, maxTerminalInputBytes: 8_192, maxListItems: 20 },
@@ -507,14 +507,27 @@ describe("ProjectChatsView hero layout", () => {
       if (channel === "runtime:get-summary") {
         return {
           ...summaryFixture(),
-          terminalSessions: {
+          terminalWorkspaces: {
             items: [{
-              id: "term_cached",
-              name: "cached-shell",
+              id: "tws_00000000000000000000000000000001",
+              scope: "project",
+              projectId: "matrix-os",
+              canonicalSize: { cols: 120, rows: 36 },
               status: "running",
-              attachable: true,
+              revision: 1,
               createdAt: NOW,
               updatedAt: NOW,
+              tabs: [{
+                id: "tt_00000000000000000000000000000001",
+                workspaceId: "tws_00000000000000000000000000000001",
+                name: "cached-shell",
+                cwd: "projects/matrix-os",
+                status: "running",
+                revision: 1,
+                order: 0,
+                createdAt: NOW,
+                updatedAt: NOW,
+              }],
             }],
             hasMore: false,
             limit: 20,
@@ -529,7 +542,10 @@ describe("ProjectChatsView hero layout", () => {
             ...workspace.projectThreads,
             items: workspace.projectThreads.items.map((thread) => ({
               ...thread,
-              terminalSessionId: "term_cached",
+              terminalRef: {
+                workspaceId: "tws_00000000000000000000000000000001",
+                tabId: "tt_00000000000000000000000000000001",
+              },
             })),
           },
         };

--- a/tests/desktop/project-inspector-context.test.ts
+++ b/tests/desktop/project-inspector-context.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
-import type { AgentThreadSummary, ReviewSummary, RuntimeSummary } from "@matrix-os/contracts";
+import type { AgentThreadSummary, ReviewSummary, RuntimeSummary, TerminalRef } from "@matrix-os/contracts";
 import { buildProjectInspectorContext } from "../../desktop/src/renderer/src/features/project/project-inspector-context";
 
 const NOW = "2026-08-18T12:00:00.000Z";
+const MATRIX_WORKSPACE_ID = "tws_00000000000000000000000000000001";
+const MATRIX_TAB_ID = "tt_00000000000000000000000000000001";
+const OTHER_WORKSPACE_ID = "tws_00000000000000000000000000000002";
+const OTHER_TAB_ID = "tt_00000000000000000000000000000002";
 
-function thread(id: string, projectId: string, terminalSessionId?: string): AgentThreadSummary {
+function thread(id: string, projectId: string, terminalRef?: TerminalRef): AgentThreadSummary {
   return {
     id,
     providerId: "codex",
@@ -12,7 +16,7 @@ function thread(id: string, projectId: string, terminalSessionId?: string): Agen
     status: "running",
     attention: "none",
     projectId,
-    terminalSessionId,
+    terminalRef,
     createdAt: NOW,
     updatedAt: NOW,
   };
@@ -29,7 +33,10 @@ function summary(): RuntimeSummary {
     providers: [],
     projects: { items: [], hasMore: false, limit: 20 },
     activeThreads: {
-      items: [thread("thread_matrix", "matrix-os", "term_matrix"), thread("thread_other", "website", "term_other")],
+      items: [
+        thread("thread_matrix", "matrix-os", { workspaceId: MATRIX_WORKSPACE_ID, tabId: MATRIX_TAB_ID }),
+        thread("thread_other", "website", { workspaceId: OTHER_WORKSPACE_ID, tabId: OTHER_TAB_ID }),
+      ],
       hasMore: false,
       limit: 20,
     },
@@ -38,10 +45,50 @@ function summary(): RuntimeSummary {
       hasMore: false,
       limit: 20,
     },
-    terminalSessions: {
+    terminalWorkspaces: {
       items: [
-        { id: "term_matrix", name: "matrix", status: "running", attachable: true, createdAt: NOW, updatedAt: NOW },
-        { id: "term_other", name: "website", status: "running", attachable: true, createdAt: NOW, updatedAt: NOW },
+        {
+          id: MATRIX_WORKSPACE_ID,
+          scope: "project",
+          projectId: "matrix-os",
+          canonicalSize: { cols: 120, rows: 40 },
+          status: "running",
+          revision: 1,
+          createdAt: NOW,
+          updatedAt: NOW,
+          tabs: [{
+            id: MATRIX_TAB_ID,
+            workspaceId: MATRIX_WORKSPACE_ID,
+            name: "matrix",
+            cwd: "projects/matrix-os",
+            status: "running",
+            revision: 1,
+            order: 0,
+            createdAt: NOW,
+            updatedAt: NOW,
+          }],
+        },
+        {
+          id: OTHER_WORKSPACE_ID,
+          scope: "project",
+          projectId: "website",
+          canonicalSize: { cols: 120, rows: 40 },
+          status: "running",
+          revision: 1,
+          createdAt: NOW,
+          updatedAt: NOW,
+          tabs: [{
+            id: OTHER_TAB_ID,
+            workspaceId: OTHER_WORKSPACE_ID,
+            name: "website",
+            cwd: "projects/website",
+            status: "running",
+            revision: 1,
+            order: 0,
+            createdAt: NOW,
+            updatedAt: NOW,
+          }],
+        },
       ],
       hasMore: false,
       limit: 20,
@@ -95,7 +142,8 @@ describe("buildProjectInspectorContext", () => {
     expect(context.summary.previewSessions.items.map((item) => item.id)).toEqual(["preview_matrix"]);
     expect(context.summary.activeThreads.items.map((item) => item.id)).toEqual(["thread_matrix"]);
     expect(context.summary.attentionThreads.items.map((item) => item.id)).toEqual(["thread_attention"]);
-    expect(context.summary.terminalSessions.items.map((item) => item.id)).toEqual(["term_matrix"]);
+    expect(context.summary.terminalWorkspaces.items.map((item) => item.id)).toEqual([MATRIX_WORKSPACE_ID]);
+    expect(context.summary.terminalWorkspaces.items[0]?.tabs.map((item) => item.id)).toEqual([MATRIX_TAB_ID]);
     expect(context.summary.recentActivity.items).toEqual([]);
     expect(context.terminalState).toBe("linked");
     expect(context.counts).toEqual({ changes: 1, files: undefined, terminal: 1, preview: 1, activity: 2 });
@@ -106,11 +154,14 @@ describe("buildProjectInspectorContext", () => {
     const context = buildProjectInspectorContext({
       projectId: "matrix-os",
       summary: summary(),
-      selectedThread: thread("thread_missing", "matrix-os", "term_missing"),
+      selectedThread: thread("thread_missing", "matrix-os", {
+        workspaceId: MATRIX_WORKSPACE_ID,
+        tabId: "tt_00000000000000000000000000000003",
+      }),
       reviews: [],
     });
 
-    expect(context.summary.terminalSessions.items).toEqual([]);
+    expect(context.summary.terminalWorkspaces.items).toEqual([]);
     expect(context.terminalState).toBe("unavailable");
     expect(context.counts.terminal).toBe(0);
     expect(context.defaultTab).toBe("preview");

--- a/tests/desktop/project-task-chat-flow.test.ts
+++ b/tests/desktop/project-task-chat-flow.test.ts
@@ -27,7 +27,7 @@ function summary(): RuntimeSummary {
     projects: { items: [{ id: "desktop", label: "Desktop", status: "available", taskCount: 1, threadCount: 0, attentionCount: 0 }], hasMore: false, limit: 20 },
     activeThreads: { items: [], hasMore: false, limit: 20 },
     attentionThreads: { items: [], hasMore: false, limit: 20 },
-    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
     previewSessions: { items: [], hasMore: false, limit: 50 },
     recentActivity: { items: [], hasMore: false, limit: 20 },
     limits: { maxPromptBytes: 24_000, maxAttachmentCount: 8, maxTerminalInputBytes: 8_192, maxListItems: 20 },

--- a/tests/desktop/project-workspaces-store.test.ts
+++ b/tests/desktop/project-workspaces-store.test.ts
@@ -63,7 +63,7 @@ function summaryWith(projects: Array<{ id: string; label: string }>): RuntimeSum
     },
     activeThreads: { items: [], hasMore: false, limit: 20 },
     attentionThreads: { items: [], hasMore: false, limit: 20 },
-    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
     previewSessions: { items: [], hasMore: false, limit: 50 },
     recentActivity: { items: [], hasMore: false, limit: 20 },
     limits: { maxPromptBytes: 16_384, maxAttachmentCount: 8, maxTerminalInputBytes: 8_192, maxListItems: 20 },

--- a/tests/desktop/thread-list-status.test.tsx
+++ b/tests/desktop/thread-list-status.test.tsx
@@ -104,7 +104,7 @@ function summaryFixture(): RuntimeSummary {
     projects: { items: [{ id: "matrix-os", label: "Matrix OS", status: "available", taskCount: 0, threadCount: 4, attentionCount: 0 }], hasMore: false, limit: 20 },
     activeThreads: { items: [], hasMore: false, limit: 20 },
     attentionThreads: { items: [], hasMore: false, limit: 20 },
-    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
     previewSessions: { items: [], hasMore: false, limit: 50 },
     recentActivity: { items: [], hasMore: false, limit: 20 },
     limits: { maxPromptBytes: 16_384, maxAttachmentCount: 8, maxTerminalInputBytes: 8_192, maxListItems: 20 },

--- a/tests/desktop/unified-threads.test.ts
+++ b/tests/desktop/unified-threads.test.ts
@@ -49,7 +49,7 @@ function runtimeSummary(overrides: Partial<RuntimeSummary> = {}): RuntimeSummary
     projects: { items: [], hasMore: false, limit: 20 },
     activeThreads: { items: [], hasMore: false, limit: 20 },
     attentionThreads: { items: [], hasMore: false, limit: 20 },
-    terminalSessions: { items: [], hasMore: false, limit: 20 },
+    terminalWorkspaces: { items: [], hasMore: false, limit: 20 },
     recentActivity: { items: [], hasMore: false, limit: 20 },
     limits: {
       maxPromptBytes: 16384,


### PR DESCRIPTION
## Summary

- cut Desktop coding-agent, command-palette, inspector, and project clients over to canonical terminal workspace/tab references
- preserve legacy compatibility only at explicit adapter boundaries
- keep terminal selection scoped to the owning project and thread so stale or unrelated sessions are never borrowed

## Stack

Layer 11 of 14. Depends on #1437; #1441 follows. This PR is one commit and must merge through the Graphite stack.

## Tests

- Desktop TypeScript typecheck
- pattern scan: 0 violations
- Desktop production build
- 2,481 Desktop tests pass across the broad suite and the process-permission rerun (the six sandbox-blocked child-process cases passed in the 33-test release subset outside the sandbox)
- React Doctor: unchanged parent baseline (48/100, 254 existing findings; no new diff finding)
- diff hygiene

## Screenshot evidence

The client-reference cutover does not alter the Terminal layout. Exact-head representative Desktop Terminal state:

![Desktop Terminal session list](https://raw.githubusercontent.com/HamedMP/matrix-os/151dc35660dff4b0b206c2cda7f2fb4e5691962b/docs/review-assets/mat-300-terminal-session-list.png)

## Review/Monitoring

- GitHub CI and Greptile are being monitored on the latest head; merge readiness requires current-head CI and Greptile 5/5.

## Invariants

- **Source of truth:** `RuntimeSummary.terminalWorkspaces` and each thread’s `{ workspaceId, tabId }` terminal reference are canonical. Desktop derives display rows through the bounded terminal-workspace adapter and does not select an unrelated legacy session.
- **Lock/transaction scope:** this layer changes renderer-side projection and navigation only. It adds no database writes, locks, transactions, or network calls inside a critical section.
- **Acceptable orphan states:** a stale thread terminal reference is rendered as unavailable/unbound and is not silently rebound. A failed open leaves the current UI selection intact.
- **Auth source of truth:** the existing authenticated Desktop runtime connection and gateway API client remain authoritative; this PR adds no auth path or fallback.
- **Deferred scope:** native runtime removal, production activation, and documentation/operational guidance remain in later stack layers. Legacy compatibility fields remain only where older gateways or explicit test adapters still require them.



