### PR TITLE
feat(native): migrate terminal workspace clients

### DIFF
--- a/apps/mobile/__tests__/gateway-client.test.ts
+++ b/apps/mobile/__tests__/gateway-client.test.ts
@@ -208,7 +208,7 @@ describe("GatewayClient", () => {
   it("routes websockets for hosted computers through the canonical platform origin", () => {
     const routed = new GatewayClient("https://app.matrix-os.com/vm/pr-919?runtime=pr-919");
     expect(routed.wsUrl).toBe("wss://app.matrix-os.com/ws?runtime=pr-919");
-    expect(routed.terminalWsUrl).toBe("wss://app.matrix-os.com/ws/terminal/session?runtime=pr-919");
+    expect(routed.terminalWsUrl).toBe("wss://app.matrix-os.com/ws/terminal/tab?runtime=pr-919");
 
     const primary = new GatewayClient("https://app.matrix-os.com/vm/neo");
     expect(primary.wsUrl).toBe("wss://app.matrix-os.com/ws");
@@ -581,7 +581,7 @@ describe("GatewayClient", () => {
         hasMore: false,
         limit: 20,
       },
-      terminalSessions: {
+      terminalWorkspaces: {
         items: [],
         limit: 20,
         hasMore: false,
@@ -609,7 +609,14 @@ describe("GatewayClient", () => {
     const client = new GatewayClient("http://localhost:4000", "token");
     await expect(client.getCodingAgentRuntimeSummary()).resolves.toEqual({
       ok: true,
-      summary,
+      summary: {
+        ...summary,
+        terminalSessions: {
+          items: [],
+          hasMore: false,
+          limit: 50,
+        },
+      },
     });
     expect(fetchMock).toHaveBeenCalledWith("http://localhost:4000/api/coding-agents/summary", expect.objectContaining({
       headers: expect.objectContaining({
@@ -742,7 +749,7 @@ describe("GatewayClient", () => {
         title: "Repair mobile route",
         status: "running",
         attention: "none",
-        terminalSessionId: "matrix-abc1234",
+        terminalRef: { workspaceId: "tws_00000000000000000000000000000001", tabId: "tt_00000000000000000000000000000001" },
         createdAt: "2026-07-06T00:00:00.000Z",
         updatedAt: "2026-07-06T00:01:00.000Z",
       },

--- a/apps/mobile/__tests__/live-terminal-session.test.tsx
+++ b/apps/mobile/__tests__/live-terminal-session.test.tsx
@@ -14,7 +14,9 @@ const mockSurfaceScrollToBottom = jest.fn();
 
 jest.mock("expo-router", () => ({
   Stack: { Screen: () => null },
-  useLocalSearchParams: () => ({ session: "main" }),
+  useLocalSearchParams: () => ({
+    session: "tws_00000000000000000000000000000001:tt_00000000000000000000000000000001",
+  }),
 }));
 
 jest.mock("@/app/_layout", () => ({
@@ -75,17 +77,19 @@ describe("live terminal session modal", () => {
     const rendered = render(<TerminalSessionScreen />);
 
     await waitFor(() => expect(mockConnect).toHaveBeenCalledWith(expect.objectContaining({
-      sessionId: "main",
+      sessionId: "tws_00000000000000000000000000000001:tt_00000000000000000000000000000001",
       onMessage: expect.any(Function),
       onStatus: expect.any(Function),
     })));
 
     const options = mockConnect.mock.calls[0]?.[0] as {
-      onMessage: (frame: { type: string; data?: string; replay?: string; sessionId?: string; canonicalSize?: { cols: number; rows: number } | null }) => void;
+      onMessage: (frame: { type: string; data?: string; ansi?: string; canonicalSize?: { cols: number; rows: number } }) => void;
     };
-    options.onMessage({ type: "attached", sessionId: "main", replay: "ready", canonicalSize: null });
+    options.onMessage({ type: "attached", canonicalSize: { cols: 100, rows: 30 } });
+    options.onMessage({ type: "snapshot", ansi: "ready" });
     options.onMessage({ type: "output", data: "\nhello" });
     expect(mockSurfaceClear).toHaveBeenCalled();
+    expect(mockSurfaceResize).toHaveBeenCalledWith(100, 30);
     expect(mockSurfaceWrite).toHaveBeenCalledWith("ready");
     expect(mockSurfaceWrite).toHaveBeenCalledWith("\nhello");
 

--- a/apps/mobile/__tests__/terminal-client.test.ts
+++ b/apps/mobile/__tests__/terminal-client.test.ts
@@ -8,9 +8,10 @@ import {
 } from "../lib/terminal-client";
 import { jsonResponse } from "./mobile-shell-test-utils";
 
-const SESSION_ID = "c4319d6a-a24c-4820-a0f8-f6f8a6ce76b9";
-const SHELL_NAME = "matrix-7af3c2e";
-const TWO_WORD_SESSION_NAME_PATTERN = /^[a-z]+-[a-z]+$/;
+const WORKSPACE_ID = "tws_00000000000000000000000000000001";
+const TAB_ID = "tt_00000000000000000000000000000001";
+const SESSION_ID = `${WORKSPACE_ID}:${TAB_ID}`;
+const TERMINAL_REF = { workspaceId: WORKSPACE_ID, tabId: TAB_ID };
 
 class MockWebSocket {
   static OPEN = 1;
@@ -39,91 +40,76 @@ describe("mobile terminal client", () => {
     jest.restoreAllMocks();
   });
 
-  it("parses only safe terminal session summaries", () => {
+  it("parses only safe terminal workspace/tab summaries", () => {
     expect(parseTerminalSessions([
-      { sessionId: SESSION_ID, cwd: "/home/matrix/home", state: "running", attachedClients: 1 },
-      { sessionId: "../../../secret", cwd: "/tmp", state: "running" },
-      { cwd: "/tmp" },
+      { id: WORKSPACE_ID, revision: 2, tabs: [{ id: TAB_ID, name: "Shell", cwd: "/home/matrix/home", status: "running", revision: 3 }] },
+      { id: "../../../secret", tabs: [] },
+      { tabs: [] },
     ])).toEqual([
-      { sessionId: SESSION_ID, cwd: "/home/matrix/home", state: "running", attachedClients: 1 },
+      { sessionId: SESSION_ID, workspaceId: WORKSPACE_ID, tabId: TAB_ID, workspaceRevision: 2, revision: 3, name: "Shell", cwd: "/home/matrix/home", state: "running" },
     ]);
   });
 
-  it("fetches shell sessions (by name) through the authenticated gateway", async () => {
+  it("fetches shared workspace tabs through the authenticated gateway", async () => {
     const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse({
-      sessions: [{ name: SHELL_NAME, visualStatus: "running", attachedClients: 1 }],
+      workspaces: [{ id: WORKSPACE_ID, revision: 2, tabs: [{ id: TAB_ID, name: "Shell", cwd: "~", status: "running", revision: 3 }] }],
     }));
 
     const gateway = new GatewayClient("https://app.matrix-os.test", "clerk-token");
     await expect(gateway.getTerminalSessions()).resolves.toEqual([
-      { sessionId: SHELL_NAME, cwd: "~", state: "running", visualStatus: "running", attachedClients: 1 },
+      { sessionId: SESSION_ID, workspaceId: WORKSPACE_ID, tabId: TAB_ID, workspaceRevision: 2, revision: 3, name: "Shell", cwd: "~", state: "running" },
     ]);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://app.matrix-os.test/api/terminal/sessions",
+      "https://app.matrix-os.test/api/terminal/workspaces",
       expect.objectContaining({
         headers: expect.objectContaining({ Authorization: "Bearer clerk-token" }),
       }),
     );
   });
 
-  it("deletes shell sessions by name (force) and rejects unsafe names locally", async () => {
+  it("terminates tabs by TerminalRef and rejects unsafe refs locally", async () => {
     const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse({}, { status: 404 }));
 
     const gateway = new GatewayClient("https://app.matrix-os.test", "clerk-token");
-    await expect(gateway.deleteTerminalSession(SHELL_NAME)).resolves.toBe(true);
+    await expect(gateway.deleteTerminalSession(SESSION_ID)).resolves.toBe(true);
     await expect(gateway.deleteTerminalSession("../bad")).resolves.toBe(false);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://app.matrix-os.test/api/terminal/sessions/${SHELL_NAME}?force=1`,
+      `https://app.matrix-os.test/api/terminal/workspaces/${WORKSPACE_ID}/tabs/${TAB_ID}`,
       expect.objectContaining({ method: "DELETE" }),
     );
   });
 
-  it("creates shell sessions with two-word names for every collision retry", async () => {
-    const postedNames: string[] = [];
+  it("creates a tab in the ensured main workspace", async () => {
     const fetchMock = jest.spyOn(global, "fetch").mockImplementation(async (input, init) => {
-      if (String(input).endsWith("/api/terminal/sessions") && init?.method === "POST") {
-        const body = JSON.parse(String(init.body ?? "{}")) as { name?: string };
-        if (typeof body.name === "string") postedNames.push(body.name);
-        if (postedNames.length <= 3) {
-          return jsonResponse({ error: { code: "session_exists", message: "Request failed" } }, { status: 409 });
-        }
-        return jsonResponse({ name: body.name }, { status: 201 });
-      }
+      if (String(input).endsWith("/api/terminal/workspaces/ensure") && init?.method === "POST") return jsonResponse({ workspace: { id: WORKSPACE_ID } });
+      if (String(input).endsWith(`/api/terminal/workspaces/${WORKSPACE_ID}/tabs`) && init?.method === "POST") return jsonResponse({ tab: { id: TAB_ID } }, { status: 201 });
       return jsonResponse({});
     });
 
     const gateway = new GatewayClient("https://app.matrix-os.test", "clerk-token");
     const created = await gateway.createTerminalSession();
 
-    expect(fetchMock).toHaveBeenCalledTimes(4);
-    expect(created).toBe(postedNames[3]);
-    expect(postedNames.slice(0, 3)).toEqual([
-      expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
-      expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
-      expect.stringMatching(TWO_WORD_SESSION_NAME_PATTERN),
-    ]);
-    expect(postedNames[3]).toMatch(TWO_WORD_SESSION_NAME_PATTERN);
-    expect(postedNames.every((name) => name.split("-").length === 2)).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(created).toBe(SESSION_ID);
   });
 
   it("builds token-authenticated terminal websocket URLs", () => {
-    expect(buildTerminalWebSocketUrl("https://app.matrix-os.test/", "ws token")).toBe(
-      "wss://app.matrix-os.test/ws/terminal?token=ws%20token",
+    expect(buildTerminalWebSocketUrl("https://app.matrix-os.test/", SESSION_ID, "ws token")).toBe(
+      `wss://app.matrix-os.test/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=mobile&token=ws+token`,
     );
     expect(isSafeSessionId(SESSION_ID)).toBe(true);
     expect(isSafeSessionId("../bad")).toBe(false);
   });
 
-  it("sends resize, input, and detach frames (no attach frame; name is in the query)", () => {
-    jest.useFakeTimers();
+  it("sends resize, input, and detach frames with the canonical TerminalRef", () => {
     const ws = new MockWebSocket() as unknown as WebSocket;
     const messages: unknown[] = [];
     const statuses: string[] = [];
     const connection = new MobileTerminalConnection(ws, {
-      sessionId: SHELL_NAME,
+      sessionId: SESSION_ID,
       cols: 220,
       rows: 70,
       onMessage: (frame) => messages.push(frame),
@@ -132,16 +118,6 @@ describe("mobile terminal client", () => {
 
     connection.attach();
     (ws as unknown as MockWebSocket).onopen?.();
-    (ws as unknown as MockWebSocket).onmessage?.({
-      data: JSON.stringify({
-        type: "attached",
-        session: SHELL_NAME,
-        state: "running",
-        canonicalSize: { cols: 220, rows: 70 },
-        lease: { epoch: 7 },
-      }),
-    });
-    jest.advanceTimersByTime(10_000);
     connection.sendInput("pwd\r");
     connection.resize(999, 999);
     (ws as unknown as MockWebSocket).onmessage?.({ data: JSON.stringify({ type: "output", data: "ok" }) });
@@ -149,72 +125,13 @@ describe("mobile terminal client", () => {
 
     expect(statuses).toEqual(["connecting", "open"]);
     expect((ws as unknown as MockWebSocket).sent.map((frame) => JSON.parse(frame))).toEqual([
-      { type: "ping" },
-      { type: "input", data: "pwd\r" },
-      { type: "resize", cols: 500, rows: 200 },
-      { type: "detach" },
+      { type: "resize", terminalRef: TERMINAL_REF, mode: "soft", size: { cols: 220, rows: 70 } },
+      { type: "input", terminalRef: TERMINAL_REF, data: "pwd\r" },
+      { type: "resize", terminalRef: TERMINAL_REF, mode: "soft", size: { cols: 500, rows: 200 } },
+      { type: "detach", terminalRef: TERMINAL_REF },
     ]);
-    expect(messages).toEqual([
-      {
-        type: "attached",
-        sessionId: SHELL_NAME,
-        state: "running",
-        canonicalSize: { cols: 220, rows: 70 },
-        leaseEpoch: 7,
-      },
-      { type: "output", data: "ok" },
-    ]);
+    expect(messages).toEqual([{ type: "output", data: "ok" }]);
     expect((ws as unknown as MockWebSocket).closed).toBe(true);
-    jest.useRealTimers();
-  });
-
-  it("parses canonical presentation frames and stops renewing when displaced", () => {
-    jest.useFakeTimers();
-    const ws = new MockWebSocket() as unknown as WebSocket;
-    const messages: unknown[] = [];
-    const connection = new MobileTerminalConnection(ws, {
-      sessionId: SHELL_NAME,
-      cols: 100,
-      rows: 30,
-      onMessage: (frame) => messages.push(frame),
-    });
-
-    connection.attach();
-    (ws as unknown as MockWebSocket).onopen?.();
-    (ws as unknown as MockWebSocket).onmessage?.({
-      data: JSON.stringify({
-        type: "attached",
-        session: SHELL_NAME,
-        state: "running",
-        canonicalSize: { cols: 100, rows: 30 },
-        lease: { epoch: 12 },
-      }),
-    });
-    (ws as unknown as MockWebSocket).onmessage?.({
-      data: JSON.stringify({ type: "canonical-size", cols: 96, rows: 28 }),
-    });
-    (ws as unknown as MockWebSocket).onmessage?.({
-      data: JSON.stringify({ type: "presentation-reset" }),
-    });
-    (ws as unknown as MockWebSocket).onmessage?.({
-      data: JSON.stringify({ type: "lease-revoked", epoch: 12 }),
-    });
-    jest.advanceTimersByTime(30_000);
-
-    expect(messages).toEqual([
-      {
-        type: "attached",
-        sessionId: SHELL_NAME,
-        state: "running",
-        canonicalSize: { cols: 100, rows: 30 },
-        leaseEpoch: 12,
-      },
-      { type: "canonical-size", cols: 96, rows: 28 },
-      { type: "presentation-reset" },
-      { type: "lease-revoked" },
-    ]);
-    expect((ws as unknown as MockWebSocket).sent).toEqual([]);
-    jest.useRealTimers();
   });
 
   it("opens terminal sockets with browser-compatible query auth and native bearer headers", async () => {
@@ -225,15 +142,13 @@ describe("mobile terminal client", () => {
     const gateway = new GatewayClient("https://app.matrix-os.test", "clerk-token");
     const terminalClient = new MobileTerminalClient(gateway);
     const connection = await terminalClient.connect({
-      sessionId: SHELL_NAME,
-      cols: 120,
-      rows: 40,
+      sessionId: SESSION_ID,
       onMessage: jest.fn(),
     });
 
     expect(connection).toBeTruthy();
     expect(webSocketMock).toHaveBeenCalledWith(
-      `wss://app.matrix-os.test/ws/terminal/session?session=${SHELL_NAME}&client=hard&cols=120&rows=40&lease=exclusive&token=ws-token`,
+      `wss://app.matrix-os.test/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=mobile&token=ws-token`,
       [],
       { headers: { Authorization: "Bearer clerk-token" } },
     );
@@ -247,15 +162,13 @@ describe("mobile terminal client", () => {
     const gateway = new GatewayClient("https://app.matrix-os.test", "clerk-token");
     const terminalClient = new MobileTerminalClient(gateway);
     const connection = await terminalClient.connect({
-      sessionId: SHELL_NAME,
-      cols: 120,
-      rows: 40,
+      sessionId: SESSION_ID,
       onMessage: jest.fn(),
     });
 
     expect(connection).toBeTruthy();
     expect(webSocketMock).toHaveBeenCalledWith(
-      `wss://app.matrix-os.test/ws/terminal/session?session=${SHELL_NAME}&client=hard&cols=120&rows=40&lease=exclusive`,
+      `wss://app.matrix-os.test/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=mobile`,
       [],
       { headers: { Authorization: "Bearer clerk-token" } },
     );
@@ -265,6 +178,7 @@ describe("mobile terminal client", () => {
     const ws = new MockWebSocket() as unknown as WebSocket;
     (ws as unknown as MockWebSocket).readyState = 0;
     const connection = new MobileTerminalConnection(ws, {
+      sessionId: SESSION_ID,
       cwd: "projects",
       onMessage: jest.fn(),
     });

--- a/apps/mobile/__tests__/terminal-state.test.ts
+++ b/apps/mobile/__tests__/terminal-state.test.ts
@@ -127,32 +127,77 @@ describe("mobile terminal state", () => {
     expect(refreshed.activeSessionId).toBeNull();
   });
 
-  it("parses gateway shell sessions by name with status, clients and tabs", () => {
+  it("reconciles the active terminal cwd from refreshed workspace tab metadata", () => {
+    const sessionId = `${`tws_${"a".repeat(32)}`}:${`tt_${"b".repeat(32)}`}`;
+    const attached = terminalReducer(initialTerminalState, {
+      type: "terminal.attached",
+      sessionId,
+    });
+    const refreshed = terminalReducer(attached, {
+      type: "sessions.loaded",
+      sessions: [{
+        sessionId,
+        workspaceId: `tws_${"a".repeat(32)}`,
+        tabId: `tt_${"b".repeat(32)}`,
+        revision: 2,
+        workspaceRevision: 3,
+        name: "matrix-runtime",
+        cwd: "/home/matrix/home/projects/matrix-os",
+        state: "running",
+      }],
+    });
+
+    expect(refreshed.activeSessionId).toBe(sessionId);
+    expect(refreshed.cwd).toBe("~/projects/matrix-os");
+  });
+
+  it("parses gateway workspaces into stable tab references with status and metadata", () => {
     const sessions = parseShellSessions([
       {
-        name: "matrix-7af3c2e",
-        status: "active",
-        visualStatus: "waiting",
-        agent: "claude",
-        subtitle: "Refactor the terminal sidebar",
-        lastAction: "Requested approval",
-        agentUpdatedAt: "2026-07-18T10:00:00.000Z",
-        model: "claude-sonnet-4-6",
-        strength: "high",
-        project: "Matrix OS",
-        repository: "HamedMP/matrix-os",
-        branch: "codex/session-context",
-        pullRequest: { number: 1032, url: "https://github.com/HamedMP/matrix-os/pull/1032" },
-        attachedClients: 2,
-        updatedAt: "2026-06-24T10:00:00Z",
-        tabs: [{ idx: 0, name: "claude", focused: true }, { idx: 1 }],
+        id: `tws_${"a".repeat(32)}`,
+        projectId: "proj_matrix_os",
+        revision: 4,
+        tabs: [{
+          id: `tt_${"b".repeat(32)}`,
+          name: "matrix-7af3c2e",
+          cwd: "/home/matrix/home/projects/matrix-os",
+          status: "running",
+          revision: 3,
+          visualStatus: "waiting",
+          agent: { providerId: "claude" },
+          subtitle: "Refactor the terminal sidebar",
+          lastAction: "Requested approval",
+          agentUpdatedAt: "2026-07-18T10:00:00.000Z",
+          model: "claude-sonnet-4-6",
+          strength: "high",
+          project: "Matrix OS",
+          repository: "HamedMP/matrix-os",
+          branch: "codex/session-context",
+          pullRequest: { number: 1032, url: "https://github.com/HamedMP/matrix-os/pull/1032" },
+          attachedClients: 2,
+          updatedAt: "2026-06-24T10:00:00Z",
+        }],
       },
-      { name: "INVALID NAME" }, // rejected
-      { name: "main", visualStatus: "running" },
+      { id: "INVALID WORKSPACE", tabs: [] }, // rejected
+      {
+        id: `tws_${"c".repeat(32)}`,
+        revision: 1,
+        tabs: [{
+          id: `tt_${"d".repeat(32)}`,
+          name: "main",
+          cwd: "/home/matrix/home",
+          status: "running",
+          revision: 1,
+          visualStatus: "running",
+        }],
+      },
     ]);
     expect(sessions).toHaveLength(2);
     expect(sessions[0]).toMatchObject({
-      sessionId: "matrix-7af3c2e",
+      sessionId: `${`tws_${"a".repeat(32)}`}:${`tt_${"b".repeat(32)}`}`,
+      workspaceId: `tws_${"a".repeat(32)}`,
+      tabId: `tt_${"b".repeat(32)}`,
+      projectId: "proj_matrix_os",
       state: "running",
       visualStatus: "waiting",
       attachedClients: 2,
@@ -167,21 +212,21 @@ describe("mobile terminal state", () => {
       branch: "codex/session-context",
       pullRequest: { number: 1032, url: "https://github.com/HamedMP/matrix-os/pull/1032" },
     });
-    expect(sessions[0]?.tabs).toEqual([{ idx: 0, name: "claude", focused: true }, { idx: 1 }]);
-    expect(sessions[1]?.sessionId).toBe("main");
+    expect(sessions[1]?.name).toBe("main");
   });
 
-  it("accepts the gateway's full canonical shell-session name format", () => {
-    const longestName = `a${"b".repeat(62)}_`;
-    expect(parseShellSessions([
-      { name: "dev_session", visualStatus: "running" },
-      { name: longestName, visualStatus: "idle" },
-      { name: "../unsafe", visualStatus: "running" },
-    ]).map((session) => session.sessionId)).toEqual(["dev_session", longestName]);
-  });
-
-  it("maps finished/exited shell sessions to an exited state", () => {
-    const [session] = parseShellSessions([{ name: "matrix-done01", visualStatus: "finished" }]);
+  it("maps exited workspace tabs to an exited state", () => {
+    const [session] = parseShellSessions([{
+      id: `tws_${"e".repeat(32)}`,
+      revision: 2,
+      tabs: [{
+        id: `tt_${"f".repeat(32)}`,
+        name: "matrix-done01",
+        cwd: "/home/matrix/home",
+        status: "exited",
+        revision: 2,
+      }],
+    }]);
     expect(session?.state).toBe("exited");
   });
 

--- a/apps/mobile/app/terminal-session/[session].tsx
+++ b/apps/mobile/app/terminal-session/[session].tsx
@@ -20,7 +20,7 @@ import {
   type MobileTerminalConnection,
   type TerminalServerFrame,
 } from "@/lib/terminal-client";
-import { isSafeShellSessionName } from "@/lib/terminal-state";
+import { isSafeSessionId } from "@/lib/terminal-state";
 import { colors } from "@/lib/theme";
 
 type LiveStatus = "connecting" | "attached" | "detached" | "ended" | "error";
@@ -29,11 +29,10 @@ const TERMINAL_HANDSHAKE_TIMEOUT_MS = 15_000;
 export default function TerminalSessionScreen() {
   const params = useLocalSearchParams<{ session?: string | string[] }>();
   const rawSession = Array.isArray(params.session) ? params.session[0] : params.session;
-  const session = rawSession && isSafeShellSessionName(rawSession) ? rawSession : null;
+  const session = rawSession && isSafeSessionId(rawSession) ? rawSession : null;
   const { client } = useGateway();
   const [status, setStatus] = useState<LiveStatus>("connecting");
   const [error, setError] = useState<string | null>(null);
-  const [leaseRevoked, setLeaseRevoked] = useState(false);
   const [fontScale, setFontScale] = useState(1);
   const surfaceRef = useRef<TerminalSurfaceHandle | null>(null);
   const connectionRef = useRef<MobileTerminalConnection | null>(null);
@@ -55,35 +54,20 @@ export default function TerminalSessionScreen() {
   const handleFrame = useCallback((frame: TerminalServerFrame) => {
     if (frame.type === "attached") {
       clearHandshakeTimeout();
-      setLeaseRevoked(false);
       setStatus("attached");
       setError(null);
       surfaceRef.current?.clear();
-      if (frame.canonicalSize) {
-        surfaceRef.current?.resize(frame.canonicalSize.cols, frame.canonicalSize.rows);
-      }
-      if (frame.replay) surfaceRef.current?.write(frame.replay);
+      surfaceRef.current?.resize(frame.canonicalSize.cols, frame.canonicalSize.rows);
       surfaceRef.current?.focus();
       return;
     }
-    if (frame.type === "canonical-size") {
-      surfaceRef.current?.resize(frame.cols, frame.rows);
-      return;
-    }
-    if (frame.type === "presentation-reset") {
-      surfaceRef.current?.reset();
+    if (frame.type === "snapshot") {
+      surfaceRef.current?.clear();
+      surfaceRef.current?.write(frame.ansi);
       return;
     }
     if (frame.type === "output") {
       surfaceRef.current?.write(frame.data);
-      return;
-    }
-    if (frame.type === "lease-revoked") {
-      clearHandshakeTimeout();
-      setLeaseRevoked(true);
-      setStatus("detached");
-      connectionRef.current?.close();
-      connectionRef.current = null;
       return;
     }
     if (frame.type === "exit") {
@@ -184,12 +168,12 @@ export default function TerminalSessionScreen() {
   }, [clearHandshakeTimeout, connect, session, terminalClient]);
 
   const sendData = useCallback((data: string) => {
-    if (!data || leaseRevoked) return;
+    if (!data) return;
     if (!connectionRef.current?.sendInput(data)) {
       setStatus("error");
       setError("Terminal unavailable. Try again.");
     }
-  }, [leaseRevoked]);
+  }, []);
 
   const handleResize = useCallback((cols: number, rows: number) => {
     gridRef.current = { cols, rows };
@@ -233,24 +217,7 @@ export default function TerminalSessionScreen() {
           </View>
         ) : null}
 
-        {leaseRevoked ? (
-          <View style={styles.overlay}>
-            <Text style={styles.overlayTitle}>Live on another device.</Text>
-            <Spacer size="lg" />
-            <Pressable
-              accessibilityRole="button"
-              onPress={() => {
-                setLeaseRevoked(false);
-                void connect();
-              }}
-              style={styles.retryButton}
-            >
-              <Text style={styles.retryText}>Resume here</Text>
-            </Pressable>
-          </View>
-        ) : null}
-
-        {status === "detached" && !leaseRevoked ? (
+        {status === "detached" ? (
           <View style={styles.overlay}>
             <Text style={styles.overlayTitle}>Terminal connection closed.</Text>
             <Spacer size="lg" />
@@ -291,7 +258,11 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   overlay: {
-    ...StyleSheet.absoluteFillObject,
+    position: "absolute",
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
     alignItems: "center",
     justifyContent: "center",
     paddingHorizontal: 24,

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -1,11 +1,11 @@
 import { encodeAppSlugPath } from "@/lib/app-slugs";
 import {
-  isSafeShellSessionName,
-  parseShellSessions,
+  isSafeSessionId,
+  parseTerminalSessions,
   type MobileTerminalSession,
 } from "@/lib/terminal-state";
 import { logMobileCodingAgentWarning } from "@/lib/coding-agent-diagnostics";
-import { SHELL_SESSION_CREATE_ATTEMPTS, twoWordShellSessionName } from "@/lib/shell-session-names";
+import { twoWordShellSessionName } from "@/lib/shell-session-names";
 import {
   AgentThreadEventSchema,
   AgentThreadSnapshotSchema,
@@ -437,8 +437,7 @@ export class GatewayClient {
   }
 
   get terminalWsUrl(): string {
-    // Shell-sessions endpoint: attach by session name passed in the query.
-    return this.withBaseQuery(`${this.wsBaseUrl}/ws/terminal/session`);
+    return this.withBaseQuery(`${this.wsBaseUrl}/ws/terminal/tab`);
   }
 
   setWebSocketToken(token: string | null, expiresAt?: number): void {
@@ -637,29 +636,16 @@ export class GatewayClient {
     };
   }
 
-  openTerminalWebSocket(
-    token?: string | null,
-    sessionName?: string,
-    fromSeq?: number,
-    presentation?: {
-      client: "hard" | "soft";
-      cols: number;
-      rows: number;
-      lease?: "exclusive";
-    },
-  ): WebSocket {
+  openTerminalWebSocket(token?: string | null, terminalRefKey?: string, fromSeq?: number): WebSocket {
     if (token || this.token) {
       assertSecureTokenTransport(this.baseUrl);
     }
     const params = new URLSearchParams();
-    if (sessionName) params.set("session", sessionName);
+    const [workspaceId, tabId] = terminalRefKey?.split(":") ?? [];
+    if (workspaceId) params.set("workspaceId", workspaceId);
+    if (tabId) params.set("tabId", tabId);
+    params.set("client", "mobile");
     if (typeof fromSeq === "number" && Number.isFinite(fromSeq)) params.set("fromSeq", String(fromSeq));
-    if (presentation) {
-      params.set("client", presentation.client);
-      params.set("cols", String(presentation.cols));
-      params.set("rows", String(presentation.rows));
-      if (presentation.lease) params.set("lease", presentation.lease);
-    }
     if (token) params.set("token", token);
     const query = params.toString();
     const wsUrl = query ? appendQuery(this.terminalWsUrl, query) : this.terminalWsUrl;
@@ -925,19 +911,19 @@ export class GatewayClient {
 
   async getTerminalSessions(): Promise<MobileTerminalSession[]> {
     try {
-      const res = await this.fetchGateway("/api/terminal/sessions");
+      const res = await this.fetchGateway("/api/terminal/workspaces");
       if (!res.ok) {
         await res.text().catch((err: unknown) => {
-          logGatewayCatchWarning("failed to read /api/terminal/sessions error body", err);
+          logGatewayCatchWarning("failed to read terminal workspace error body", err);
           return "";
         });
-        logGatewayStatusWarning("/api/terminal/sessions unavailable", res.status);
+        logGatewayStatusWarning("terminal workspaces unavailable", res.status);
         return [];
       }
-      const body = (await res.json()) as { sessions?: unknown };
-      return parseShellSessions(body?.sessions ?? body);
+      const body = (await res.json()) as { workspaces?: unknown };
+      return parseTerminalSessions(body?.workspaces ?? body);
     } catch (err: unknown) {
-      logGatewayCatchWarning("/api/terminal/sessions unavailable", err);
+      logGatewayCatchWarning("terminal workspaces unavailable", err);
       return [];
     }
   }
@@ -1495,53 +1481,72 @@ export class GatewayClient {
     }
   }
 
-  /** Create a new shell session and return its zellij name, or null on failure. */
+  /** Create a main-workspace terminal tab and return its serialized TerminalRef. */
   async createTerminalSession(): Promise<string | null> {
-    for (let attempt = 0; attempt < SHELL_SESSION_CREATE_ATTEMPTS; attempt += 1) {
-      const name = twoWordShellSessionName();
-      try {
-        const res = await this.fetchGateway("/api/terminal/sessions", {
-          method: "POST",
-          body: JSON.stringify({ name }),
-          headers: { "Content-Type": "application/json" },
+    const name = twoWordShellSessionName();
+    try {
+      const ensured = await this.fetchGateway("/api/terminal/workspaces/ensure", {
+        method: "POST",
+        body: "{}",
+        headers: { "Content-Type": "application/json" },
+      });
+      if (!ensured.ok) return null;
+      const ensuredBody = (await ensured.json().catch((err: unknown) => {
+        logGatewayCatchWarning("terminal workspace ensure returned invalid JSON", err);
+        return null;
+      })) as { workspace?: { id?: unknown } } | null;
+      const workspaceId = typeof ensuredBody?.workspace?.id === "string" ? ensuredBody.workspace.id : "";
+      if (!/^tws_[0-9a-f]{32}$/.test(workspaceId)) return null;
+      const res = await this.fetchGateway(`/api/terminal/workspaces/${workspaceId}/tabs`, {
+        method: "POST",
+        body: JSON.stringify({ name, cwd: "projects" }),
+        headers: { "Content-Type": "application/json" },
+      });
+      if (!res.ok) {
+        await res.text().catch((err: unknown) => {
+          logGatewayCatchWarning("failed to read terminal tab create error body", err);
+          return "";
         });
-        if (await isSessionExistsResponse(res) && attempt < SHELL_SESSION_CREATE_ATTEMPTS - 1) {
-          continue;
-        }
-        if (!res.ok) {
-          await res.text().catch((err: unknown) => {
-            logGatewayCatchWarning("failed to read terminal session create error body", err);
-            return "";
-          });
-          logGatewayStatusWarning("terminal session create failed", res.status);
-          return null;
-        }
-        const body = (await res.json().catch(() => null)) as { name?: unknown } | null;
-        const created = typeof body?.name === "string" ? body.name : name;
-        return isSafeShellSessionName(created) ? created : null;
-      } catch (err: unknown) {
-        logGatewayCatchWarning("terminal session create unavailable", err);
+        logGatewayStatusWarning("terminal tab create failed", res.status);
         return null;
       }
+      const body = (await res.json().catch((err: unknown) => {
+        logGatewayCatchWarning("terminal tab create returned invalid JSON", err);
+        return null;
+      })) as { tab?: { id?: unknown } } | null;
+      const tabId = typeof body?.tab?.id === "string" ? body.tab.id : "";
+      const created = `${workspaceId}:${tabId}`;
+      return isSafeSessionId(created) ? created : null;
+    } catch (err: unknown) {
+      logGatewayCatchWarning("terminal tab create unavailable", err);
+      return null;
     }
-    logGatewayWarning("terminal session create failed", "collision_exhausted");
-    return null;
   }
 
   /**
-   * Create a shell session that runs a provider setup command and return its
-   * zellij name for terminal handoff, or null on failure. The command is sent to
-   * the gateway inside the bounded foreground session and is never stored in
+   * Create a workspace tab that runs a provider setup command and return its
+   * serialized TerminalRef for handoff, or null on failure. The command is sent
+   * to the gateway inside the bounded foreground tab and is never stored in
    * shell state or rendered in the UI (CLAUDE.md: provider setup stays
    * terminal-backed and command-hidden).
    */
   async createProviderSetupSession(command: string): Promise<string | null> {
     if (typeof command !== "string" || command.length === 0) return null;
-    const name = `matrix-setup-${randomShellSuffix()}`;
+    const name = `Setup ${randomShellSuffix()}`;
     try {
-      const res = await this.fetchGateway("/api/terminal/sessions", {
+      const ensured = await this.fetchGateway("/api/terminal/workspaces/ensure", {
+        method: "POST", body: "{}", headers: { "Content-Type": "application/json" },
+      });
+      if (!ensured.ok) return null;
+      const ensuredBody = (await ensured.json().catch((err: unknown) => {
+        logGatewayCatchWarning("provider setup workspace ensure returned invalid JSON", err);
+        return null;
+      })) as { workspace?: { id?: unknown } } | null;
+      const workspaceId = typeof ensuredBody?.workspace?.id === "string" ? ensuredBody.workspace.id : "";
+      if (!/^tws_[0-9a-f]{32}$/.test(workspaceId)) return null;
+      const res = await this.fetchGateway(`/api/terminal/workspaces/${workspaceId}/tabs`, {
         method: "POST",
-        body: JSON.stringify({ name, cwd: "projects", cmd: command }),
+        body: JSON.stringify({ name, cwd: "projects", command: ["sh", "-lc", command] }),
         headers: { "Content-Type": "application/json" },
       });
       if (!res.ok) {
@@ -1552,27 +1557,32 @@ export class GatewayClient {
         logGatewayStatusWarning("provider setup session create failed", res.status);
         return null;
       }
-      const body = (await res.json().catch(() => null)) as { name?: unknown } | null;
-      const created = typeof body?.name === "string" ? body.name : name;
-      return isSafeShellSessionName(created) ? created : null;
-    } catch {
-      logGatewayWarning("provider setup session create unavailable", "unavailable");
+      const body = (await res.json().catch((err: unknown) => {
+        logGatewayCatchWarning("provider setup tab create returned invalid JSON", err);
+        return null;
+      })) as { tab?: { id?: unknown } } | null;
+      const tabId = typeof body?.tab?.id === "string" ? body.tab.id : "";
+      const created = `${workspaceId}:${tabId}`;
+      return isSafeSessionId(created) ? created : null;
+    } catch (err: unknown) {
+      logGatewayCatchWarning("provider setup tab create unavailable", err);
       return null;
     }
   }
 
-  async deleteTerminalSession(name: string): Promise<boolean> {
-    if (!isSafeShellSessionName(name)) return false;
+  async deleteTerminalSession(refKey: string): Promise<boolean> {
+    if (!isSafeSessionId(refKey)) return false;
+    const [workspaceId, tabId] = refKey.split(":");
     try {
       const res = await this.fetchGateway(
-        `/api/terminal/sessions/${encodeURIComponent(name)}?force=1`,
+        `/api/terminal/workspaces/${workspaceId}/tabs/${tabId}`,
         { method: "DELETE" },
       );
       if (res.ok || res.status === 404) return true;
-      logGatewayStatusWarning("terminal session delete unavailable", res.status);
+      logGatewayStatusWarning("terminal tab delete unavailable", res.status);
       return false;
-    } catch {
-      logGatewayWarning("terminal session delete unavailable", "unavailable");
+    } catch (err: unknown) {
+      logGatewayCatchWarning("terminal tab delete unavailable", err);
       return false;
     }
   }

--- a/apps/mobile/lib/terminal-client.ts
+++ b/apps/mobile/lib/terminal-client.ts
@@ -4,35 +4,19 @@ export { isSafeSessionId, parseTerminalSessions } from "@/lib/terminal-state";
 
 const WS_CONNECTING = 0;
 const WS_OPEN = 1;
-const LEASE_HEARTBEAT_INTERVAL_MS = 10_000;
 
 export type TerminalClientFrame =
-  | { type: "attach"; sessionId?: string; cwd?: string; fromSeq?: number }
-  | { type: "input"; data: string }
-  | { type: "resize"; cols: number; rows: number }
-  | { type: "ping" }
-  | { type: "detach" }
-  | { type: "destroy" };
+  | { type: "input"; terminalRef: TerminalRef; data: string }
+  | { type: "resize"; terminalRef: TerminalRef; mode: "soft"; size: { cols: number; rows: number } }
+  | { type: "detach"; terminalRef: TerminalRef }
+  | { type: "ping"; terminalRef: TerminalRef };
 
-export interface TerminalCanonicalSize {
-  cols: number;
-  rows: number;
-}
+type TerminalRef = { workspaceId: string; tabId: string };
 
 export type TerminalServerFrame =
-  | {
-      type: "attached";
-      sessionId: string;
-      state: "running" | "exited";
-      cwd?: string;
-      replay?: string;
-      canonicalSize: TerminalCanonicalSize | null;
-      leaseEpoch: number | null;
-    }
-  | { type: "canonical-size"; cols: number; rows: number }
-  | { type: "lease-revoked" }
-  | { type: "presentation-reset" }
-  | { type: "output"; data: string }
+  | { type: "attached"; terminalRef: TerminalRef; canonicalSize: { cols: number; rows: number }; revision: number; nextSeq: number }
+  | { type: "snapshot"; terminalRef: TerminalRef; ansi: string; seq: number; revision: number }
+  | { type: "output"; terminalRef: TerminalRef; data: string; seq: number; revision: number }
   | { type: "replay-start"; fromSeq?: number; toSeq?: number }
   | { type: "replay-end"; nextSeq?: number }
   | { type: "exit"; exitCode?: number | null }
@@ -59,27 +43,22 @@ export class MobileTerminalClient {
     return this.gateway.deleteTerminalSession(sessionId);
   }
 
-  /** Create a new shell session and return its name (to then attach by name). */
+  /** Create a terminal tab and return its serialized TerminalRef. */
   async createSession(): Promise<string | null> {
     return this.gateway.createTerminalSession();
   }
 
   async connect(options: MobileTerminalConnectOptions): Promise<MobileTerminalConnection | null> {
-    // Shell-sessions: the session name is required and is passed in the WS query
-    // (no attach frame). Attaching by name is what makes a session continuable
-    // across shell, desktop and mobile.
+    // The serialized TerminalRef selects the shared workspace tab in the WS query.
     if (!options.sessionId) return null;
     const token = await this.gateway.getWsToken();
     this.gateway.setWebSocketToken(token);
-    const cols = clampInteger(options.cols ?? 80, 1, 500);
-    const rows = clampInteger(options.rows ?? 24, 1, 200);
-    const ws = this.gateway.openTerminalWebSocket(token, options.sessionId, options.fromSeq, {
-      client: "hard",
-      cols,
-      rows,
-      lease: "exclusive",
+    const ws = this.gateway.openTerminalWebSocket(token, options.sessionId, options.fromSeq);
+    const connection = new MobileTerminalConnection(ws, options, async (fromSeq) => {
+      const nextToken = await this.gateway.getWsToken();
+      this.gateway.setWebSocketToken(nextToken);
+      return this.gateway.openTerminalWebSocket(nextToken, options.sessionId, fromSeq);
     });
-    const connection = new MobileTerminalConnection(ws, options);
     connection.attach();
     return connection;
   }
@@ -87,63 +66,84 @@ export class MobileTerminalClient {
 
 export class MobileTerminalConnection {
   private attached = false;
-  private leaseEpoch: number | null = null;
-  private leaseHeartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly terminalRef: TerminalRef;
+  private disposed = false;
+  private reconnectAttempt = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastSeq: number;
 
   constructor(
-    private readonly ws: WebSocket,
+    private ws: WebSocket,
     private readonly options: MobileTerminalConnectOptions,
-  ) {}
+    private readonly reconnect?: (fromSeq: number) => Promise<WebSocket>,
+  ) {
+    const [workspaceId, tabId] = options.sessionId?.split(":") ?? [];
+    if (!/^tws_[0-9a-f]{32}$/.test(workspaceId ?? "") || !/^tt_[0-9a-f]{32}$/.test(tabId ?? "")) {
+      throw new Error("Invalid terminal reference");
+    }
+    this.terminalRef = { workspaceId: workspaceId!, tabId: tabId! };
+    this.lastSeq = options.fromSeq ?? 0;
+  }
 
   attach(): void {
     this.options.onStatus?.("connecting");
+    this.bindSocket(this.ws);
+  }
 
-    // The session name, initial hard-grid dimensions, and exclusive lease are
-    // supplied in the WS query, so no attach or startup resize frame is needed.
-    this.ws.onopen = () => {
+  private bindSocket(ws: WebSocket): void {
+    // The TerminalRef is supplied in the WS query; announce the viewport once open.
+    ws.onopen = () => {
+      if (this.ws !== ws || this.disposed) return;
       this.attached = true;
+      this.reconnectAttempt = 0;
       this.options.onStatus?.("open");
-    };
-
-    this.ws.onmessage = (event) => {
-      const frame = parseTerminalServerFrame(event.data);
-      if (!frame) return;
-      if (frame.type === "attached") {
-        this.leaseEpoch = frame.leaseEpoch;
-        this.scheduleLeaseHeartbeat();
-      } else if (frame.type === "lease-revoked") {
-        this.leaseEpoch = null;
-        this.clearLeaseHeartbeat();
+      if (this.options.cols && this.options.rows) {
+        this.resize(this.options.cols, this.options.rows);
       }
-      this.options.onMessage(frame);
+      this.scheduleHeartbeat();
     };
 
-    this.ws.onerror = () => {
+    ws.onmessage = (event) => {
+      if (this.ws !== ws || this.disposed) return;
+      const frame = parseTerminalServerFrame(event.data);
+      if (frame) {
+        if ((frame.type === "snapshot" || frame.type === "output") && typeof frame.seq === "number") {
+          this.lastSeq = Math.max(this.lastSeq, frame.seq);
+        }
+        this.options.onMessage(frame);
+      }
+    };
+
+    ws.onerror = () => {
+      if (this.ws !== ws || this.disposed) return;
       this.options.onStatus?.("error");
     };
 
-    this.ws.onclose = () => {
+    ws.onclose = () => {
+      if (this.ws !== ws || this.disposed) return;
       this.attached = false;
-      this.leaseEpoch = null;
-      this.clearLeaseHeartbeat();
+      this.clearHeartbeat();
       this.options.onStatus?.("closed");
+      this.scheduleReconnect();
     };
   }
 
   sendInput(data: string): boolean {
-    return this.sendFrame({ type: "input", data });
+    return this.sendFrame({ type: "input", terminalRef: this.terminalRef, data });
   }
 
   resize(cols: number, rows: number): boolean {
     return this.sendFrame({
       type: "resize",
-      cols: clampInteger(cols, 1, 500),
-      rows: clampInteger(rows, 1, 200),
+      terminalRef: this.terminalRef,
+      mode: "soft",
+      size: { cols: clampInteger(cols, 20, 500), rows: clampInteger(rows, 5, 200) },
     });
   }
 
   detach(): boolean {
-    const sent = this.sendFrame({ type: "detach" });
+    const sent = this.sendFrame({ type: "detach", terminalRef: this.terminalRef });
     this.close();
     return sent;
   }
@@ -151,14 +151,15 @@ export class MobileTerminalConnection {
   destroy(): boolean {
     // Session deletion happens via the REST DELETE endpoint; over the shell WS we
     // simply detach this client (the endpoint has no "destroy" frame).
-    const sent = this.sendFrame({ type: "detach" });
+    const sent = this.sendFrame({ type: "detach", terminalRef: this.terminalRef });
     this.close();
     return sent;
   }
 
   close(): void {
-    this.clearLeaseHeartbeat();
-    this.leaseEpoch = null;
+    this.disposed = true;
+    this.clearReconnect();
+    this.clearHeartbeat();
     if (this.ws.readyState !== WS_CONNECTING && this.ws.readyState !== WS_OPEN) return;
     this.attached = false;
     this.ws.close();
@@ -170,113 +171,78 @@ export class MobileTerminalConnection {
     return true;
   }
 
-  private scheduleLeaseHeartbeat(): void {
-    this.clearLeaseHeartbeat();
-    if (this.leaseEpoch === null || !this.attached) return;
-    this.leaseHeartbeatTimer = setTimeout(() => {
-      this.leaseHeartbeatTimer = null;
-      if (this.leaseEpoch === null || !this.attached) return;
-      this.sendFrame({ type: "ping" });
-      this.scheduleLeaseHeartbeat();
-    }, LEASE_HEARTBEAT_INTERVAL_MS);
+  private scheduleReconnect(): void {
+    if (this.disposed || !this.reconnect || this.reconnectTimer) return;
+    const base = Math.min(500 * 2 ** Math.min(this.reconnectAttempt, 10), 30_000);
+    const delay = Math.floor(base * (0.5 + Math.random() * 0.5));
+    this.reconnectAttempt += 1;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.disposed) return;
+      void this.reconnect!(this.lastSeq + 1).then((next) => {
+        if (this.disposed) {
+          next.close();
+          return;
+        }
+        this.ws = next;
+        this.options.onStatus?.("connecting");
+        this.bindSocket(next);
+      }).catch((err: unknown) => {
+        console.warn("[mobile] terminal reconnect failed", err instanceof Error ? err.name : typeof err);
+        this.options.onStatus?.("error");
+        this.scheduleReconnect();
+      });
+    }, delay);
   }
 
-  private clearLeaseHeartbeat(): void {
-    if (this.leaseHeartbeatTimer === null) return;
-    clearTimeout(this.leaseHeartbeatTimer);
-    this.leaseHeartbeatTimer = null;
+  private scheduleHeartbeat(): void {
+    this.clearHeartbeat();
+    this.heartbeatTimer = setTimeout(() => {
+      this.heartbeatTimer = null;
+      if (this.disposed || !this.attached) return;
+      this.sendFrame({ type: "ping", terminalRef: this.terminalRef });
+      this.scheduleHeartbeat();
+    }, 30_000);
+  }
+
+  private clearHeartbeat(): void {
+    if (!this.heartbeatTimer) return;
+    clearTimeout(this.heartbeatTimer);
+    this.heartbeatTimer = null;
+  }
+
+  private clearReconnect(): void {
+    if (!this.reconnectTimer) return;
+    clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
   }
 }
 
-export function buildTerminalWebSocketUrl(baseUrl: string, token?: string | null): string {
-  const url = `${baseUrl.replace(/\/+$/, "").replace(/^http/, "ws")}/ws/terminal`;
-  if (!token) return url;
-  return `${url}?token=${encodeURIComponent(token)}`;
+export function buildTerminalWebSocketUrl(baseUrl: string, refKey: string, token?: string | null): string {
+  const [workspaceId, tabId] = refKey.split(":");
+  const url = new URL(`${baseUrl.replace(/\/+$/, "").replace(/^http/, "ws")}/ws/terminal/tab`);
+  url.searchParams.set("workspaceId", workspaceId ?? "");
+  url.searchParams.set("tabId", tabId ?? "");
+  url.searchParams.set("client", "mobile");
+  if (token) url.searchParams.set("token", token);
+  return url.toString();
 }
 
-export function parseTerminalServerFrame(data: unknown): TerminalServerFrame | null {
+function parseTerminalServerFrame(data: unknown): TerminalServerFrame | null {
   if (typeof data !== "string") return null;
   try {
-    const frame = JSON.parse(data) as Record<string, unknown>;
+    const frame = JSON.parse(data) as TerminalServerFrame;
     if (!frame || typeof frame !== "object" || typeof frame.type !== "string") return null;
-    if (frame.type === "attached") {
-      const sessionId = typeof frame.session === "string"
-        ? frame.session
-        : typeof frame.sessionId === "string"
-          ? frame.sessionId
-          : null;
-      if (!sessionId || (frame.state !== undefined && frame.state !== "running" && frame.state !== "exited")) {
-        return null;
-      }
-      const lease = frame.lease && typeof frame.lease === "object"
-        ? frame.lease as Record<string, unknown>
-        : null;
-      return {
-        type: "attached",
-        sessionId,
-        state: frame.state === "exited" ? "exited" : "running",
-        ...(typeof frame.cwd === "string" ? { cwd: frame.cwd } : {}),
-        ...(typeof frame.replay === "string" ? { replay: frame.replay } : {}),
-        canonicalSize: parseCanonicalSize(frame.canonicalSize),
-        leaseEpoch: Number.isSafeInteger(lease?.epoch) && (lease?.epoch as number) > 0
-          ? lease?.epoch as number
-          : null,
-      };
-    }
-    if (frame.type === "canonical-size") {
-      const size = parseCanonicalSize(frame);
-      return size ? { type: "canonical-size", ...size } : null;
-    }
-    if (frame.type === "lease-revoked") return { type: "lease-revoked" };
-    if (frame.type === "presentation-reset") return { type: "presentation-reset" };
-    if (frame.type === "output" && typeof frame.data === "string") {
-      return { type: "output", data: frame.data };
-    }
-    if (frame.type === "replay-start") {
-      return {
-        type: "replay-start",
-        ...(Number.isSafeInteger(frame.fromSeq) ? { fromSeq: frame.fromSeq as number } : {}),
-        ...(Number.isSafeInteger(frame.toSeq) ? { toSeq: frame.toSeq as number } : {}),
-      };
-    }
-    if (frame.type === "replay-end") {
-      return {
-        type: "replay-end",
-        ...(Number.isSafeInteger(frame.nextSeq) ? { nextSeq: frame.nextSeq as number } : {}),
-      };
-    }
-    if (frame.type === "exit") {
-      const rawExitCode = frame.code ?? frame.exitCode;
-      return {
-        type: "exit",
-        exitCode: typeof rawExitCode === "number" && Number.isFinite(rawExitCode)
-          ? rawExitCode
-          : rawExitCode === null
-            ? null
-            : undefined,
-      };
-    }
+    if (frame.type === "attached" && frame.terminalRef && typeof frame.nextSeq === "number") return frame;
+    if (frame.type === "snapshot" && typeof frame.ansi === "string") return frame;
+    if (frame.type === "output" && typeof frame.data === "string") return frame;
+    if (frame.type === "replay-start" || frame.type === "replay-end" || frame.type === "exit") return frame;
     if (frame.type === "error") return { type: "error", message: typeof frame.message === "string" ? frame.message : undefined };
     return null;
-  } catch {
+  } catch (err: unknown) {
+    console.warn("[mobile] terminal websocket frame was not valid JSON", err instanceof Error ? err.name : typeof err);
     return null;
   }
-}
-
-function parseCanonicalSize(value: unknown): TerminalCanonicalSize | null {
-  if (!value || typeof value !== "object") return null;
-  const size = value as Record<string, unknown>;
-  if (
-    !Number.isInteger(size.cols)
-    || (size.cols as number) < 1
-    || (size.cols as number) > 500
-    || !Number.isInteger(size.rows)
-    || (size.rows as number) < 1
-    || (size.rows as number) > 200
-  ) {
-    return null;
-  }
-  return { cols: size.cols as number, rows: size.rows as number };
 }
 
 function clampInteger(value: number, min: number, max: number): number {

--- a/apps/mobile/lib/terminal-state.ts
+++ b/apps/mobile/lib/terminal-state.ts
@@ -9,8 +9,14 @@ export type TerminalConnectionStatus =
 export type ShellVisualStatus = "running" | "waiting" | "finished" | "idle";
 
 export interface MobileTerminalSession {
-  /** The zellij session name (e.g. "matrix-7af3c2e"); the attach identifier. */
+  /** Local serialized TerminalRef key; never an internal Zellij name. */
   sessionId: string;
+  workspaceId: string;
+  tabId: string;
+  revision: number;
+  workspaceRevision: number;
+  projectId?: string;
+  name: string;
   cwd: string;
   state: "running" | "exited" | "destroyed" | string;
   createdAt?: string;
@@ -76,8 +82,7 @@ export const MAX_TERMINAL_OUTPUT_CHARS = 80_000;
 export const MAX_TERMINAL_INPUT_CHARS = 64_000;
 const MIN_TERMINAL_FONT_SCALE = 0.85;
 const MAX_TERMINAL_FONT_SCALE = 1.3;
-const SAFE_TERMINAL_SESSION_ID =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SAFE_TERMINAL_REF_KEY = /^tws_[0-9a-f]{32}:tt_[0-9a-f]{32}$/;
 
 export const initialTerminalState: TerminalState = {
   status: "idle",
@@ -119,13 +124,14 @@ export function terminalReducer(
           : null,
       };
     case "sessions.loaded": {
-      const activeSessionStillExists = state.activeSessionId
-        ? action.sessions.some((session) => session.sessionId === state.activeSessionId)
-        : false;
+      const activeSession = state.activeSessionId
+        ? action.sessions.find((session) => session.sessionId === state.activeSessionId)
+        : undefined;
       return {
         ...state,
         sessions: action.sessions,
-        activeSessionId: activeSessionStillExists ? state.activeSessionId : null,
+        activeSessionId: activeSession ? state.activeSessionId : null,
+        cwd: activeSession ? formatTerminalCwd(activeSession.cwd) : state.cwd,
       };
     }
     case "terminal.attached":
@@ -167,58 +173,32 @@ export function terminalReducer(
 }
 
 export function isSafeSessionId(value: string): boolean {
-  return SAFE_TERMINAL_SESSION_ID.test(value);
+  return SAFE_TERMINAL_REF_KEY.test(value);
 }
 
 export function parseTerminalSessions(value: unknown): MobileTerminalSession[] {
   if (!Array.isArray(value)) return [];
   return value.flatMap((entry) => {
     if (!entry || typeof entry !== "object") return [];
-    const candidate = entry as Record<string, unknown>;
-    if (typeof candidate.sessionId !== "string" || !isSafeSessionId(candidate.sessionId)) {
-      return [];
-    }
-    const session: MobileTerminalSession = {
-      sessionId: candidate.sessionId,
-      cwd: typeof candidate.cwd === "string" ? candidate.cwd : "~",
-      state: typeof candidate.state === "string" ? candidate.state : "running",
-    };
-    if (typeof candidate.createdAt === "string") session.createdAt = candidate.createdAt;
-    if (typeof candidate.lastAttachedAt === "string") session.lastAttachedAt = candidate.lastAttachedAt;
-    if (typeof candidate.attachedClients === "number") session.attachedClients = candidate.attachedClients;
-    if (typeof candidate.exitCode === "number" || candidate.exitCode === null) session.exitCode = candidate.exitCode;
-    return [session];
-  });
-}
-
-// Keep this aligned with the gateway's canonical SESSION_NAME_PATTERN.
-const SAFE_SHELL_SESSION_NAME = /^[a-z0-9][a-z0-9_-]{0,63}$/;
-
-export function isSafeShellSessionName(value: string): boolean {
-  return SAFE_SHELL_SESSION_NAME.test(value);
-}
-
-function mapShellState(status: unknown, visual: unknown): MobileTerminalSession["state"] {
-  if (visual === "finished" || status === "exited") return "exited";
-  return "running";
-}
-
-/**
- * Parse the gateway's shell-sessions response (`GET /api/terminal/sessions`,
- * `ShellSessionSummary[]`). The session `name` is the attach identifier and is
- * carried in `sessionId` so existing consumers keep working during migration.
- */
-export function parseShellSessions(value: unknown): MobileTerminalSession[] {
-  if (!Array.isArray(value)) return [];
-  return value.flatMap((entry) => {
-    if (!entry || typeof entry !== "object") return [];
-    const c = entry as Record<string, unknown>;
-    if (typeof c.name !== "string" || !isSafeShellSessionName(c.name)) return [];
-    const session: MobileTerminalSession = {
-      sessionId: c.name,
-      cwd: typeof c.cwd === "string" ? c.cwd : "~",
-      state: mapShellState(c.status, c.visualStatus),
-    };
+    const workspace = entry as Record<string, unknown>;
+    if (typeof workspace.id !== "string" || !/^tws_[0-9a-f]{32}$/.test(workspace.id) || !Array.isArray(workspace.tabs)) return [];
+    const workspaceRevision = typeof workspace.revision === "number" ? workspace.revision : 0;
+    const projectId = typeof workspace.projectId === "string" ? workspace.projectId : undefined;
+    return workspace.tabs.flatMap((tab) => {
+      if (!tab || typeof tab !== "object") return [];
+      const c = tab as Record<string, unknown>;
+      if (typeof c.id !== "string" || !/^tt_[0-9a-f]{32}$/.test(c.id) || typeof c.name !== "string") return [];
+      const session: MobileTerminalSession = {
+        sessionId: `${workspace.id}:${c.id}`,
+        workspaceId: workspace.id as string,
+        tabId: c.id,
+        revision: typeof c.revision === "number" ? c.revision : 0,
+        workspaceRevision,
+        ...(projectId ? { projectId } : {}),
+        name: c.name,
+        cwd: typeof c.cwd === "string" ? c.cwd : "",
+        state: c.status === "exited" || c.status === "failed" ? "exited" : "running",
+      };
     if (
       c.visualStatus === "running" ||
       c.visualStatus === "waiting" ||
@@ -232,8 +212,9 @@ export function parseShellSessions(value: unknown): MobileTerminalSession[] {
     }
     if (typeof c.updatedAt === "string") session.updatedAt = c.updatedAt;
     if (typeof c.unread === "boolean") session.unread = c.unread;
-    if (c.agent === "claude" || c.agent === "codex" || c.agent === "opencode" || c.agent === "pi") {
-      session.agent = c.agent;
+    const agent = c.agent && typeof c.agent === "object" ? (c.agent as Record<string, unknown>).providerId : undefined;
+    if (agent === "claude" || agent === "codex" || agent === "opencode" || agent === "pi") {
+      session.agent = agent;
     }
     if (typeof c.subtitle === "string") session.subtitle = c.subtitle;
     if (typeof c.lastAction === "string") session.lastAction = c.lastAction;
@@ -252,23 +233,12 @@ export function parseShellSessions(value: unknown): MobileTerminalSession[] {
         };
       }
     }
-    if (Array.isArray(c.tabs)) {
-      const tabs: NonNullable<MobileTerminalSession["tabs"]> = [];
-      for (const tab of c.tabs) {
-        if (!tab || typeof tab !== "object") continue;
-        const t = tab as Record<string, unknown>;
-        if (!Number.isInteger(t.idx)) continue;
-        tabs.push({
-          idx: t.idx as number,
-          ...(typeof t.name === "string" ? { name: t.name } : {}),
-          ...(typeof t.focused === "boolean" ? { focused: t.focused } : {}),
-        });
-      }
-      if (tabs.length > 0) session.tabs = tabs;
-    }
-    return [session];
+      return [session];
+    });
   });
 }
+
+export const parseShellSessions = parseTerminalSessions;
 
 export function buildTerminalControlSequence(key: TerminalControlKey): string {
   if (key.startsWith("ctrl-")) {

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -505,8 +505,7 @@ public final class AppModel: ObservableObject {
     private var isLoadingSystemInfo = false
     /// The project whose tasks the board renders.
     public private(set) var projectSlug: String
-    /// Maps workspace session ids / terminal ids to the zellij shell session name
-    /// required by `/ws/terminal/session`.
+    /// Maps cards and tab labels to stable `workspaceId:tabId` references.
     private var sessionAttachNames: [String: String] = [:]
     private let maxCachedTerminalSessions = 8
     private var terminalSessionAccessOrder: [String] = []
@@ -539,12 +538,12 @@ public final class AppModel: ObservableObject {
             // section, not inside project kanban.
             GatewayBoardLoader(client: client)
         },
-        makeTerminal: @escaping @MainActor (URL, PrincipalProvider, String, String) -> TerminalSession = { url, provider, session, name in
+        makeTerminal: @escaping @MainActor (URL, PrincipalProvider, String, String) -> TerminalSession = { url, provider, terminalRef, name in
             let tokenProvider = provider as any TokenProviding
             let client = ShellWSClient(
                 url: url,
                 tokenProvider: { await tokenProvider.token() ?? "" },
-                session: session,
+                terminalRef: terminalRef,
                 transport: URLSessionShellTransport()
             )
             return TerminalSession(displayName: name, client: client)
@@ -1022,74 +1021,25 @@ public final class AppModel: ObservableObject {
         }
     }
 
-    /// Loads the live zellij session list for the Terminals section.
+    /// Loads project-scoped terminal workspace tabs for the Terminals section.
     public func loadSessions() async {
         guard let client = gatewayClient() else { return }
-        struct SessionDTO: Decodable {
-            let name: String
-            let attachName: String
-            let status: String
-            let aliases: [String]
-
-            private enum CodingKeys: String, CodingKey {
-                case name, id, sessionId, terminalSessionId, status, state, runtime
-            }
-
-            private enum RuntimeKeys: String, CodingKey {
-                case status, zellijSession
-            }
-
-            init(from decoder: Decoder) throws {
-                let container = try decoder.container(keyedBy: CodingKeys.self)
-                let runtime = try? container.nestedContainer(keyedBy: RuntimeKeys.self, forKey: .runtime)
-                let directName = try container.decodeIfPresent(String.self, forKey: .name)
-                let zellijName = try runtime?.decodeIfPresent(String.self, forKey: .zellijSession)
-                let id = try container.decodeIfPresent(String.self, forKey: .id)
-                let terminalId = try container.decodeIfPresent(String.self, forKey: .terminalSessionId)
-                let sessionId = try container.decodeIfPresent(String.self, forKey: .sessionId)
-                name = directName
-                    ?? zellijName
-                    ?? terminalId
-                    ?? sessionId
-                    ?? id
-                    ?? ""
-                attachName = zellijName
-                    ?? directName
-                    ?? terminalId
-                    ?? sessionId
-                    ?? id
-                    ?? ""
-                aliases = [directName, zellijName, id, terminalId, sessionId]
-                    .compactMap { $0 }
-                    .filter { !$0.isEmpty }
-                status = try container.decodeIfPresent(String.self, forKey: .status)
-                    ?? container.decodeIfPresent(String.self, forKey: .state)
-                    ?? runtime?.decodeIfPresent(String.self, forKey: .status)
-                    ?? "active"
-            }
-        }
-        struct SessionsResponse: Decodable {
-            let sessions: [SessionDTO]
-        }
+        struct TabDTO: Decodable { let id: String; let name: String; let status: String }
+        struct WorkspaceDTO: Decodable { let id: String; let projectId: String?; let tabs: [TabDTO] }
+        struct WorkspacesResponse: Decodable { let workspaces: [WorkspaceDTO] }
+        struct ProjectResponse: Decodable { struct Project: Decodable { let id: String }; let project: Project }
         var byName: [String: WorkspaceSession] = [:]
         var nextAttachNames: [String: String] = [:]
-        func merge(_ dtos: [SessionDTO]) {
-            for dto in dtos where !dto.name.isEmpty {
-                byName[dto.name] = WorkspaceSession(name: dto.name, attachName: dto.attachName, status: dto.status)
-                for alias in dto.aliases {
-                    nextAttachNames[alias] = dto.attachName
+        if let project: ProjectResponse = try? await client.get("/api/projects/\(projectSlug)"),
+           let response: WorkspacesResponse = try? await client.get("/api/terminal/workspaces") {
+            for workspace in response.workspaces where workspace.projectId == project.project.id {
+                for tab in workspace.tabs {
+                    let ref = "\(workspace.id):\(tab.id)"
+                    byName[tab.name] = WorkspaceSession(name: tab.name, attachName: ref, status: tab.status)
+                    nextAttachNames[tab.name] = ref
+                    nextAttachNames[ref] = ref
                 }
-                nextAttachNames[dto.name] = dto.attachName
             }
-        }
-        if let response: SessionsResponse = try? await client.get("/api/terminal/sessions") {
-            merge(response.sessions)
-        }
-        if let response: SessionsResponse = try? await client.get("/api/sessions?limit=100") {
-            merge(response.sessions)
-        }
-        if let response: [SessionDTO] = try? await client.get("/api/terminal/pty-sessions") {
-            merge(response)
         }
         let loaded = Array(byName.values).sorted { lhs, rhs in
             if lhs.isActive != rhs.isActive { return lhs.isActive && !rhs.isActive }
@@ -1376,22 +1326,22 @@ public final class AppModel: ObservableObject {
             throw OperatorError.noSession
         }
 
-        // Existing session → attach by name. No session yet → connect to
-        // `/ws/terminal?cwd=` which auto-creates one (matrix shell connect -c).
+        // Current clients always attach through a stable workspace/tab ref.
         let requestedSession = card.linkedSessionId ?? ""
         let attachSession = sessionAttachName(for: requestedSession)
         let hasSession = !attachSession.isEmpty
+        guard hasSession else {
+            let err = OperatorError.noSession
+            openError = err
+            throw err
+        }
         let wsURL: URL
         do {
-            if hasSession {
-                wsURL = try profile.webSocketURL(
-                    path: "/ws/terminal/session",
-                    session: attachSession,
-                    fromSeq: Int?.none
-                )
-            } else {
-                wsURL = try profile.autoCreateTerminalURL(cwd: nil)
-            }
+            wsURL = try profile.webSocketURL(
+                path: "/ws/terminal/tab",
+                terminalRef: attachSession,
+                fromSeq: Int?.none
+            )
         } catch {
             let err = OperatorError.misconfigured
             openError = err
@@ -1402,11 +1352,6 @@ public final class AppModel: ObservableObject {
         let session = makeTerminal(wsURL, principal, attachSession, label)
         cacheTerminalSession(session, for: tabID)
         terminal = session
-        if !hasSession {
-            session.onNextAttach { [weak self] in
-                Task { await self?.loadSessions() }
-            }
-        }
         session.start()
         return session
     }
@@ -1964,7 +1909,7 @@ public final class AppModel: ObservableObject {
     /// Whether a task or terminal-session create request is in flight.
     @Published public private(set) var isCreatingWorkItem = false
 
-    /// Creates a new zellij session (Terminals section "+") and reloads the list.
+    /// Creates a new tab in the selected project workspace.
     public func createSession() {
         guard !isCreatingWorkItem, let client = gatewayClient() else { return }
         openError = nil
@@ -1972,22 +1917,27 @@ public final class AppModel: ObservableObject {
         let existingSessionNames = Set(sessions.map(\.name))
         Task { [weak self] in
             defer { Task { @MainActor in self?.isCreatingWorkItem = false } }
-            struct CreateSessionRequest: Encodable {
-                let name: String
-                let cwd: String?
-            }
-            struct CreateSessionResponse: Decodable {
-                let name: String?
-            }
+            struct EnsureRequest: Encodable { let projectId: String? }
+            struct WorkspaceDTO: Decodable { let id: String }
+            struct EnsureResponse: Decodable { let workspace: WorkspaceDTO }
+            struct CreateTabRequest: Encodable { let name: String; let cwd: String }
+            struct TabDTO: Decodable { let id: String; let name: String }
+            struct CreateTabResponse: Decodable { let tab: TabDTO }
+            struct ProjectResponse: Decodable { struct Project: Decodable { let id: String }; let project: Project }
             for attempt in 0..<shellSessionCreateAttempts {
                 let name = generatedShellSessionName()
                 do {
-                    let response: CreateSessionResponse = try await client.post(
-                        "/api/terminal/sessions",
-                        body: CreateSessionRequest(name: name, cwd: nil)
+                    let project: ProjectResponse = try await client.get("/api/projects/\(self?.projectSlug ?? "")")
+                    let ensured: EnsureResponse = try await client.post(
+                        "/api/terminal/workspaces/ensure",
+                        body: EnsureRequest(projectId: project.project.id)
+                    )
+                    let response: CreateTabResponse = try await client.post(
+                        "/api/terminal/workspaces/\(ensured.workspace.id)/tabs",
+                        body: CreateTabRequest(name: name, cwd: "projects/\(self?.projectSlug ?? "")")
                     )
                     await self?.loadSessions()
-                    let requestedName = response.name ?? name
+                    let requestedName = response.tab.name
                     if self?.sessions.contains(where: { $0.name == requestedName }) == true {
                         await MainActor.run { self?.openSession(named: requestedName) }
                     } else if let created = self?.sessions.first(where: { !existingSessionNames.contains($0.name) }) {

--- a/macos/Sources/Board/SessionsBoardLoader.swift
+++ b/macos/Sources/Board/SessionsBoardLoader.swift
@@ -1,67 +1,29 @@
-// MatrixBoard — zellij sessions as board cards.
-//
-// The user's original intent ("use the zellij sessions we have for the kanban
-// tasks") + the common reality that a fresh VPS has live sessions but no tasks.
-// This loader GETs `/api/sessions` (contracts/gateway-endpoints.md) and renders
-// each live zellij session as a card whose `linkedSessionId` opens its terminal.
-// `projectSlug` is ignored — sessions are not project-scoped.
 import Foundation
 import MatrixModel
 import MatrixNet
 
-/// Gateway sessions list response: `{ sessions: [...] }`.
-private struct SessionListEnvelope: Decodable {
-    let sessions: [SessionDTO]
+private struct TerminalWorkspacesEnvelope: Decodable {
+    let workspaces: [TerminalWorkspaceDTO]
 }
 
-/// One zellij session as returned by `GET /api/sessions`.
-private struct SessionDTO: Decodable {
+private struct TerminalWorkspaceDTO: Decodable {
+    let id: String
+    let projectId: String?
+    let tabs: [TerminalTabDTO]
+}
+
+private struct TerminalTabDTO: Decodable {
+    let id: String
     let name: String
     let status: String
     let updatedAt: String?
-
-    private enum CodingKeys: String, CodingKey {
-        case name, id, sessionId, terminalSessionId, status, state, runtime, updatedAt, lastActivityAt
-    }
-
-    private enum RuntimeKeys: String, CodingKey {
-        case status, zellijSession
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let runtime = try? container.nestedContainer(keyedBy: RuntimeKeys.self, forKey: .runtime)
-        name = try container.decodeIfPresent(String.self, forKey: .name)
-            ?? runtime?.decodeIfPresent(String.self, forKey: .zellijSession)
-            ?? container.decodeIfPresent(String.self, forKey: .sessionId)
-            ?? container.decodeIfPresent(String.self, forKey: .terminalSessionId)
-            ?? container.decode(String.self, forKey: .id)
-        status = try container.decodeIfPresent(String.self, forKey: .status)
-            ?? container.decodeIfPresent(String.self, forKey: .state)
-            ?? runtime?.decodeIfPresent(String.self, forKey: .status)
-            ?? "active"
-        updatedAt = try container.decodeIfPresent(String.self, forKey: .updatedAt)
-            ?? container.decodeIfPresent(String.self, forKey: .lastActivityAt)
-    }
-
-    func toCard(id: String, order: Double) -> Card {
-        let active = ["active", "running", "attached", "ready", "idle", "waiting"].contains(status.lowercased())
-        return Card(
-            id: id,
-            projectSlug: "",
-            title: name,
-            status: active ? .running : .complete,
-            priority: .normal,
-            order: order,
-            linkedSessionId: name,
-            updatedAt: updatedAt ?? "",
-            revision: nil
-        )
-    }
 }
 
-/// A `BoardLoading` that renders live zellij sessions as cards. Active sessions
-/// land in RUNNING; exited ones in COMPLETE. Opening a card attaches its terminal.
+private struct ProjectEnvelope: Decodable {
+    struct Project: Decodable { let id: String }
+    let project: Project
+}
+
 public struct SessionsBoardLoader: BoardLoading {
     private let client: GatewayHTTPClient
 
@@ -70,14 +32,25 @@ public struct SessionsBoardLoader: BoardLoading {
     }
 
     public func fetchTasks(projectSlug: String) async throws -> [Card] {
-        let envelope: SessionListEnvelope = try await client.get("/api/sessions")
-        var seenIDs: [String: Int] = [:]
-        return envelope.sessions.enumerated().map { index, session in
-            let baseID = "session:\(session.name)"
-            let count = seenIDs[baseID, default: 0]
-            seenIDs[baseID] = count + 1
-            let cardID = count == 0 ? baseID : "\(baseID):\(count + 1)"
-            return session.toCard(id: cardID, order: Double(index))
+        let project: ProjectEnvelope = try await client.get("/api/projects/\(projectSlug)")
+        let envelope: TerminalWorkspacesEnvelope = try await client.get("/api/terminal/workspaces")
+        let tabs = envelope.workspaces
+            .filter { $0.projectId == project.project.id }
+            .flatMap { workspace in workspace.tabs.map { (workspace.id, $0) } }
+        return tabs.enumerated().map { index, entry in
+            let (workspaceId, tab) = entry
+            let active = ["active", "running", "starting", "idle", "waiting"].contains(tab.status.lowercased())
+            return Card(
+                id: "terminal:\(workspaceId):\(tab.id)",
+                projectSlug: projectSlug,
+                title: tab.name,
+                status: active ? .running : .complete,
+                priority: .normal,
+                order: Double(index),
+                linkedSessionId: "\(workspaceId):\(tab.id)",
+                updatedAt: tab.updatedAt ?? "",
+                revision: nil
+            )
         }
     }
 }

--- a/macos/Sources/Net/VPSResolver.swift
+++ b/macos/Sources/Net/VPSResolver.swift
@@ -24,13 +24,13 @@ public enum VPSResolver {
         return url
     }
 
-    /// Builds a shell/board WebSocket URL `wss://<host><path>?session=&fromSeq=&runtime=`.
+    /// Builds a terminal-tab WebSocket URL with a stable workspace/tab ref.
     /// `fromSeq` is omitted when nil (initial attach / live tail).
     public static func webSocketURL(
         gatewayHost: String,
         runtimeSlot: String?,
         path: String,
-        session: String,
+        terminalRef: String,
         fromSeq: Int?
     ) throws -> URL {
         let host = gatewayHost.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -40,7 +40,13 @@ public enum VPSResolver {
         comps.scheme = "wss"
         comps.host = host
         comps.path = path
-        var items = [URLQueryItem(name: "session", value: session)]
+        let pieces = terminalRef.split(separator: ":", omittingEmptySubsequences: false)
+        guard pieces.count == 2 else { throw GatewayError.misconfigured }
+        var items = [
+            URLQueryItem(name: "workspaceId", value: String(pieces[0])),
+            URLQueryItem(name: "tabId", value: String(pieces[1])),
+            URLQueryItem(name: "client", value: "macos"),
+        ]
         if let fromSeq {
             items.append(URLQueryItem(name: "fromSeq", value: String(fromSeq)))
         }
@@ -48,28 +54,6 @@ public enum VPSResolver {
             items.append(URLQueryItem(name: "runtime", value: slot))
         }
         comps.queryItems = items
-        guard let url = comps.url else { throw GatewayError.misconfigured }
-        return url
-    }
-
-    /// Auto-create terminal URL: `/ws/terminal[?cwd=...]` (no session param) so the
-    /// gateway creates a new zellij session and attaches. Used when a card has no
-    /// linked session yet (matrix-shell connect-or-create semantics).
-    public static func autoCreateTerminalURL(
-        gatewayHost: String,
-        runtimeSlot: String?,
-        cwd: String?
-    ) throws -> URL {
-        let host = gatewayHost.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !host.isEmpty else { throw GatewayError.misconfigured }
-        var comps = URLComponents()
-        comps.scheme = "wss"
-        comps.host = host
-        comps.path = "/ws/terminal"
-        var items: [URLQueryItem] = []
-        if let cwd, !cwd.isEmpty { items.append(URLQueryItem(name: "cwd", value: cwd)) }
-        if let slot = normalizedSlot(runtimeSlot) { items.append(URLQueryItem(name: "runtime", value: slot)) }
-        comps.queryItems = items.isEmpty ? nil : items
         guard let url = comps.url else { throw GatewayError.misconfigured }
         return url
     }
@@ -101,17 +85,14 @@ public struct ConnectionProfile: Equatable, Sendable {
         try VPSResolver.gatewayBaseURL(gatewayHost: gatewayHost, runtimeSlot: runtimeSlot)
     }
 
-    public func webSocketURL(path: String, session: String, fromSeq: Int?) throws -> URL {
+    public func webSocketURL(path: String, terminalRef: String, fromSeq: Int?) throws -> URL {
         try VPSResolver.webSocketURL(
             gatewayHost: gatewayHost,
             runtimeSlot: runtimeSlot,
             path: path,
-            session: session,
+            terminalRef: terminalRef,
             fromSeq: fromSeq
         )
     }
 
-    public func autoCreateTerminalURL(cwd: String?) throws -> URL {
-        try VPSResolver.autoCreateTerminalURL(gatewayHost: gatewayHost, runtimeSlot: runtimeSlot, cwd: cwd)
-    }
 }

--- a/macos/Sources/Terminal/ShellMessages.swift
+++ b/macos/Sources/Terminal/ShellMessages.swift
@@ -1,133 +1,208 @@
-// Wire protocol for the shell terminal WebSocket.
-// Source of truth: packages/gateway/src/shell/ws.ts (+ @finnaai/matrix/shell-protocol).
 import Foundation
 
-/// Sentinel `fromSeq` requesting the live tail (recent replay + live output).
-/// Mirrors `SHELL_ATTACH_LIVE_TAIL_FROM_SEQ = Number.MAX_SAFE_INTEGER`.
 public let SHELL_ATTACH_LIVE_TAIL_FROM_SEQ: Int = 9_007_199_254_740_991
-
-/// Roughly how many recent events the server replays on a live-tail attach.
 public let SHELL_ATTACH_RECENT_REPLAY_EVENTS: Int = 50
 
-/// Client → server messages.
-public enum ClientMessage: Sendable, Equatable {
-    case input(data: String)
-    case resize(cols: Int, rows: Int)
-    case detach
-    case ping
-}
+public struct TerminalRef: Codable, Sendable, Equatable {
+    public let workspaceId: String
+    public let tabId: String
 
-extension ClientMessage: Codable {
-    private enum CodingKeys: String, CodingKey {
-        case type, data, cols, rows
+    private enum CodingKeys: String, CodingKey { case workspaceId, tabId }
+
+    private static func isValid(_ value: String, prefix: String) -> Bool {
+        value.range(of: "^\(prefix)_[0-9a-f]{32}$", options: .regularExpression) != nil
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        switch self {
-        case let .input(data):
-            try container.encode("input", forKey: .type)
-            try container.encode(data, forKey: .data)
-        case let .resize(cols, rows):
-            try container.encode("resize", forKey: .type)
-            try container.encode(cols, forKey: .cols)
-            try container.encode(rows, forKey: .rows)
-        case .detach:
-            try container.encode("detach", forKey: .type)
-        case .ping:
-            try container.encode("ping", forKey: .type)
-        }
+    public init?(key: String) {
+        let pieces = key.split(separator: ":", omittingEmptySubsequences: false)
+        guard pieces.count == 2,
+              Self.isValid(String(pieces[0]), prefix: "tws"),
+              Self.isValid(String(pieces[1]), prefix: "tt") else { return nil }
+        workspaceId = String(pieces[0])
+        tabId = String(pieces[1])
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let type = try container.decode(String.self, forKey: .type)
-        switch type {
-        case "input":
-            self = .input(data: try container.decode(String.self, forKey: .data))
-        case "resize":
-            self = .resize(
-                cols: try container.decode(Int.self, forKey: .cols),
-                rows: try container.decode(Int.self, forKey: .rows)
-            )
-        case "detach":
-            self = .detach
-        case "ping":
-            self = .ping
-        default:
+        let workspaceId = try container.decode(String.self, forKey: .workspaceId)
+        let tabId = try container.decode(String.self, forKey: .tabId)
+        guard Self.isValid(workspaceId, prefix: "tws"), Self.isValid(tabId, prefix: "tt") else {
             throw DecodingError.dataCorruptedError(
-                forKey: .type,
+                forKey: .workspaceId,
                 in: container,
-                debugDescription: "Unknown client message type: \(type)"
+                debugDescription: "Invalid terminal reference"
             )
+        }
+        self.workspaceId = workspaceId
+        self.tabId = tabId
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(workspaceId, forKey: .workspaceId)
+        try container.encode(tabId, forKey: .tabId)
+    }
+}
+
+public struct TerminalGridSize: Codable, Sendable, Equatable {
+    public let cols: Int
+    public let rows: Int
+}
+
+public struct TerminalViewport: Codable, Sendable, Equatable {
+    public let top: Int
+    public let rows: Int
+}
+
+public enum ClientMessage: Sendable, Equatable {
+    case input(ref: TerminalRef, data: String)
+    case resize(ref: TerminalRef, cols: Int, rows: Int)
+    case detach(ref: TerminalRef)
+    case ping(ref: TerminalRef)
+}
+
+extension ClientMessage: Encodable {
+    private enum CodingKeys: String, CodingKey { case type, terminalRef, data, mode, size }
+    private struct Size: Encodable { let cols: Int; let rows: Int }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .input(ref, data):
+            try container.encode("input", forKey: .type)
+            try container.encode(ref, forKey: .terminalRef)
+            try container.encode(data, forKey: .data)
+        case let .resize(ref, cols, rows):
+            try container.encode("resize", forKey: .type)
+            try container.encode(ref, forKey: .terminalRef)
+            try container.encode("soft", forKey: .mode)
+            try container.encode(Size(cols: cols, rows: rows), forKey: .size)
+        case let .detach(ref):
+            try container.encode("detach", forKey: .type)
+            try container.encode(ref, forKey: .terminalRef)
+        case let .ping(ref):
+            try container.encode("ping", forKey: .type)
+            try container.encode(ref, forKey: .terminalRef)
         }
     }
 }
 
-/// Server → client messages.
 public enum ServerMessage: Sendable, Equatable {
-    case attached(session: String, state: String, fromSeq: Int)
-    case output(seq: Int, data: String)
-    case exit(code: Int)
-    case error(code: String, message: String)
-    case pong
-    /// Requested seq was older than the buffer; client must clear and re-attach at live tail.
-    case replayEvicted(fromSeq: Int, nextSeq: Int)
+    case attached(ref: TerminalRef, canonicalSize: TerminalGridSize, revision: Int, nextSeq: Int)
+    case snapshot(ref: TerminalRef, canonicalSize: TerminalGridSize, revision: Int, seq: Int, ansi: String, viewport: TerminalViewport)
+    case output(ref: TerminalRef, revision: Int, seq: Int, data: String)
+    case exit(ref: TerminalRef, revision: Int, code: Int?)
+    case error(ref: TerminalRef?, code: String, message: String)
+    case pong(ref: TerminalRef, revision: Int)
+    case replayStart(ref: TerminalRef, revision: Int, fromSeq: Int)
+    case replayEvicted(ref: TerminalRef, revision: Int, fromSeq: Int, nextSeq: Int)
+    case replayGap(ref: TerminalRef, revision: Int, fromSeq: Int, nextSeq: Int)
+    case replayEnd(ref: TerminalRef, revision: Int, nextSeq: Int, toSeq: Int?)
+    case canonicalSize(ref: TerminalRef, revision: Int, size: TerminalGridSize)
 }
 
 extension ServerMessage: Decodable {
     private enum CodingKeys: String, CodingKey {
-        case type, session, sessionId, state, fromSeq, nextSeq, seq, data, code, message
+        case type, terminalRef, canonicalSize, revision, nextSeq, fromSeq, toSeq, seq, data, ansi, viewport, exitCode, code, message, error
     }
+
+    private struct SafeError: Decodable { let code: String; let safeMessage: String }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let type = try container.decode(String.self, forKey: .type)
         switch type {
         case "attached":
-            let session = try container.decodeIfPresent(String.self, forKey: .session)
-                ?? container.decode(String.self, forKey: .sessionId)
             self = .attached(
-                session: session,
-                state: try container.decodeIfPresent(String.self, forKey: .state) ?? "running",
-                fromSeq: try container.decodeIfPresent(Int.self, forKey: .fromSeq) ?? 0
+                ref: try container.decode(TerminalRef.self, forKey: .terminalRef),
+                canonicalSize: try container.decode(TerminalGridSize.self, forKey: .canonicalSize),
+                revision: try container.decode(Int.self, forKey: .revision),
+                nextSeq: try container.decodeIfPresent(Int.self, forKey: .nextSeq) ?? 0
+            )
+        case "snapshot":
+            self = .snapshot(
+                ref: try container.decode(TerminalRef.self, forKey: .terminalRef),
+                canonicalSize: try container.decode(TerminalGridSize.self, forKey: .canonicalSize),
+                revision: try container.decode(Int.self, forKey: .revision),
+                seq: try container.decode(Int.self, forKey: .seq),
+                ansi: try container.decode(String.self, forKey: .ansi),
+                viewport: try container.decode(TerminalViewport.self, forKey: .viewport)
             )
         case "output":
             self = .output(
-                seq: try container.decodeIfPresent(Int.self, forKey: .seq) ?? 0,
+                ref: try container.decode(TerminalRef.self, forKey: .terminalRef),
+                revision: try container.decode(Int.self, forKey: .revision),
+                seq: try container.decode(Int.self, forKey: .seq),
                 data: try container.decode(String.self, forKey: .data)
             )
         case "exit":
-            self = .exit(code: try container.decode(Int.self, forKey: .code))
+            self = .exit(
+                ref: try container.decode(TerminalRef.self, forKey: .terminalRef),
+                revision: try container.decode(Int.self, forKey: .revision),
+                code: try container.decodeIfPresent(Int.self, forKey: .exitCode)
+            )
         case "error":
             self = .error(
-                code: try container.decode(String.self, forKey: .code),
+                ref: try container.decodeIfPresent(TerminalRef.self, forKey: .terminalRef),
+                code: try container.decodeIfPresent(String.self, forKey: .code) ?? "terminal_error",
                 message: try container.decodeIfPresent(String.self, forKey: .message) ?? ""
             )
+        case "safe-error":
+            let error = try container.decode(SafeError.self, forKey: .error)
+            self = .error(
+                ref: try container.decodeIfPresent(TerminalRef.self, forKey: .terminalRef),
+                code: error.code,
+                message: error.safeMessage
+            )
         case "pong":
-            self = .pong
+            self = .pong(
+                ref: try container.decode(TerminalRef.self, forKey: .terminalRef),
+                revision: try container.decode(Int.self, forKey: .revision)
+            )
+        case "replay-start":
+            self = .replayStart(
+                ref: try container.decode(TerminalRef.self, forKey: .terminalRef),
+                revision: try container.decode(Int.self, forKey: .revision),
+                fromSeq: try container.decode(Int.self, forKey: .fromSeq)
+            )
         case "replay-evicted":
             self = .replayEvicted(
+                ref: try container.decode(TerminalRef.self, forKey: .terminalRef),
+                revision: try container.decode(Int.self, forKey: .revision),
                 fromSeq: try container.decode(Int.self, forKey: .fromSeq),
                 nextSeq: try container.decode(Int.self, forKey: .nextSeq)
             )
-        default:
-            throw DecodingError.dataCorruptedError(
-                forKey: .type,
-                in: container,
-                debugDescription: "Unknown server message type: \(type)"
+        case "replay-gap":
+            self = .replayGap(
+                ref: try container.decode(TerminalRef.self, forKey: .terminalRef),
+                revision: try container.decode(Int.self, forKey: .revision),
+                fromSeq: try container.decode(Int.self, forKey: .fromSeq),
+                nextSeq: try container.decode(Int.self, forKey: .nextSeq)
             )
+        case "replay-end":
+            self = .replayEnd(
+                ref: try container.decode(TerminalRef.self, forKey: .terminalRef),
+                revision: try container.decode(Int.self, forKey: .revision),
+                nextSeq: try container.decode(Int.self, forKey: .nextSeq),
+                toSeq: try container.decodeIfPresent(Int.self, forKey: .toSeq)
+            )
+        case "canonical-size":
+            self = .canonicalSize(
+                ref: try container.decode(TerminalRef.self, forKey: .terminalRef),
+                revision: try container.decode(Int.self, forKey: .revision),
+                size: try container.decode(TerminalGridSize.self, forKey: .canonicalSize)
+            )
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Unknown server message type")
         }
     }
 }
 
-/// Decoded events surfaced to consumers of the client.
 public enum ServerEvent: Sendable, Equatable {
     case attached(state: String, fromSeq: Int)
     case output(seq: Int, data: String)
     case exit(code: Int)
     case error(code: String, message: String)
     case reconnecting
-    /// Emitted after the client has reset its buffer and re-attached at live tail.
     case replayEvicted
 }

--- a/macos/Sources/Terminal/ShellWSClient.swift
+++ b/macos/Sources/Terminal/ShellWSClient.swift
@@ -14,7 +14,7 @@ import Foundation
 public actor ShellWSClient {
     private let baseURL: URL
     private let tokenProvider: @Sendable () async -> String
-    private let session: String
+    private let terminalRef: TerminalRef?
     private let transport: ShellTransport
     private let backoff: BackoffPolicy
     private let clock: ShellClock
@@ -23,10 +23,12 @@ public actor ShellWSClient {
 
     private var ring: ScrollbackRing
     private var lastSeqValue: Int = 0
+    private var lastRevisionValue: Int = -1
     private var pendingSize: (cols: Int, rows: Int)?
     private var pendingInputs: [String] = []
     private var isAttached = false
     private var runLoop: Task<Void, Never>?
+    private var heartbeatLoop: Task<Void, Never>?
     private var stopped = false
 
     private let eventStream: AsyncStream<ServerEvent>
@@ -35,7 +37,7 @@ public actor ShellWSClient {
     public init(
         url: URL,
         token: String,
-        session: String,
+        terminalRef: String,
         transport: ShellTransport,
         backoff: BackoffPolicy = .default,
         clock: ShellClock = SystemClock(),
@@ -44,7 +46,7 @@ public actor ShellWSClient {
         self.init(
             url: url,
             tokenProvider: { token },
-            session: session,
+            terminalRef: terminalRef,
             transport: transport,
             backoff: backoff,
             clock: clock,
@@ -55,7 +57,7 @@ public actor ShellWSClient {
     public init(
         url: URL,
         tokenProvider: @escaping @Sendable () async -> String,
-        session: String,
+        terminalRef: String,
         transport: ShellTransport,
         backoff: BackoffPolicy = .default,
         clock: ShellClock = SystemClock(),
@@ -63,7 +65,7 @@ public actor ShellWSClient {
     ) {
         self.baseURL = url
         self.tokenProvider = tokenProvider
-        self.session = session
+        self.terminalRef = TerminalRef(key: terminalRef)
         self.transport = transport
         self.backoff = backoff
         self.clock = clock
@@ -96,18 +98,20 @@ public actor ShellWSClient {
             }
             return
         }
-        await sendClient(.input(data: data))
+        guard let terminalRef else { return }
+        await sendClient(.input(ref: terminalRef, data: data))
     }
 
     /// Records a resize; sent immediately if connected and once after each attach.
     public func resize(cols: Int, rows: Int) async {
         pendingSize = (cols, rows)
-        await sendClient(.resize(cols: cols, rows: rows))
+        guard let terminalRef else { return }
+        await sendClient(.resize(ref: terminalRef, cols: cols, rows: rows))
     }
 
     /// Detaches (leave session running) and stops reconnecting.
     public func detach() async {
-        await sendClient(.detach)
+        if let terminalRef { await sendClient(.detach(ref: terminalRef)) }
         await shutdown()
     }
 
@@ -116,6 +120,8 @@ public actor ShellWSClient {
         stopped = true
         runLoop?.cancel()
         runLoop = nil
+        heartbeatLoop?.cancel()
+        heartbeatLoop = nil
         await transport.close()
         eventContinuation.finish()
     }
@@ -132,6 +138,8 @@ public actor ShellWSClient {
             let cleanly = await consume(frames)
             if stopped || Task.isCancelled { break }
             isAttached = false
+            heartbeatLoop?.cancel()
+            heartbeatLoop = nil
             attempt = cleanly ? 0 : attempt + 1
             if !cleanly && attempt == 2 {
                 eventContinuation.yield(.error(code: "connection_failed", message: "Terminal connection failed"))
@@ -160,24 +168,37 @@ public actor ShellWSClient {
               let message = try? decoder.decode(ServerMessage.self, from: data) else {
             return // ignore malformed/unknown frames
         }
+        if let frameRef = message.terminalRef, frameRef != terminalRef { return }
+        if let revision = message.revision {
+            guard revision >= lastRevisionValue else { return }
+            lastRevisionValue = revision
+        }
         switch message {
-        case let .attached(_, state, fromSeq):
+        case let .attached(_, _, _, nextSeq):
             isAttached = true
-            eventContinuation.yield(.attached(state: state, fromSeq: fromSeq))
+            eventContinuation.yield(.attached(state: "running", fromSeq: nextSeq))
+            startHeartbeat()
             // Resize once immediately after attach.
             if let size = pendingSize {
-                await sendClient(.resize(cols: size.cols, rows: size.rows))
+                if let terminalRef { await sendClient(.resize(ref: terminalRef, cols: size.cols, rows: size.rows)) }
             }
             await flushPendingInputs()
-        case let .output(seq, payload):
+        case let .output(_, _, seq, payload):
             lastSeqValue = max(lastSeqValue, seq)
             ring.append(seq: seq, data: payload)
             eventContinuation.yield(.output(seq: seq, data: payload))
-        case let .exit(code):
-            eventContinuation.yield(.exit(code: code))
-        case let .error(code, text):
+        case let .snapshot(_, _, _, seq, ansi, _):
+            lastSeqValue = max(lastSeqValue, seq)
+            ring.clear()
+            ring.append(seq: seq, data: ansi)
+            eventContinuation.yield(.output(seq: seq, data: ansi))
+        case let .exit(_, _, code):
+            eventContinuation.yield(.exit(code: code ?? 0))
+        case let .error(_, code, text):
             eventContinuation.yield(.error(code: code, message: text))
         case .pong:
+            break
+        case .replayStart, .replayEnd, .replayGap, .canonicalSize:
             break
         case .replayEvicted:
             // Unrecoverable gap: clear buffer + seq, re-attach at live tail.
@@ -196,8 +217,24 @@ public actor ShellWSClient {
         let inputs = pendingInputs
         pendingInputs.removeAll(keepingCapacity: true)
         for input in inputs {
-            await sendClient(.input(data: input))
+            if let terminalRef { await sendClient(.input(ref: terminalRef, data: input)) }
         }
+    }
+
+    private func startHeartbeat() {
+        heartbeatLoop?.cancel()
+        heartbeatLoop = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                await self.clock.sleep(seconds: 30)
+                await self.sendHeartbeat()
+            }
+        }
+    }
+
+    private func sendHeartbeat() async {
+        guard isAttached, let terminalRef else { return }
+        await sendClient(.ping(ref: terminalRef))
     }
 
     private func sendClient(_ message: ClientMessage) async {
@@ -211,13 +248,8 @@ public actor ShellWSClient {
     private func makeRequest(fromSeq: Int) async -> URLRequest {
         var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
         var items = components?.queryItems ?? []
-        items.removeAll { $0.name == "session" || $0.name == "fromSeq" || $0.name == "token" }
-        // Empty session = auto-create path (/ws/terminal?cwd=...): do not add a
-        // blank session param. Named attach keeps session + fromSeq.
-        if !session.isEmpty {
-            items.append(URLQueryItem(name: "session", value: session))
-            items.append(URLQueryItem(name: "fromSeq", value: String(fromSeq)))
-        }
+        items.removeAll { $0.name == "fromSeq" || $0.name == "token" }
+        items.append(URLQueryItem(name: "fromSeq", value: String(fromSeq)))
         components?.queryItems = items.isEmpty ? nil : items
         let url = components?.url ?? baseURL
         var request = URLRequest(url: url)
@@ -225,5 +257,43 @@ public actor ShellWSClient {
         let token = await tokenProvider()
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         return request
+    }
+}
+
+private extension ServerMessage {
+    var terminalRef: TerminalRef? {
+        switch self {
+        case let .attached(ref, _, _, _),
+             let .snapshot(ref, _, _, _, _, _),
+             let .output(ref, _, _, _),
+             let .exit(ref, _, _),
+             let .pong(ref, _),
+             let .replayStart(ref, _, _),
+             let .replayEvicted(ref, _, _, _),
+             let .replayGap(ref, _, _, _),
+             let .replayEnd(ref, _, _, _),
+             let .canonicalSize(ref, _, _):
+            return ref
+        case let .error(ref, _, _):
+            return ref
+        }
+    }
+
+    var revision: Int? {
+        switch self {
+        case let .attached(_, _, revision, _),
+             let .snapshot(_, _, revision, _, _, _),
+             let .output(_, revision, _, _),
+             let .exit(_, revision, _),
+             let .pong(_, revision),
+             let .replayStart(_, revision, _),
+             let .replayEvicted(_, revision, _, _),
+             let .replayGap(_, revision, _, _),
+             let .replayEnd(_, revision, _, _),
+             let .canonicalSize(_, revision, _):
+            return revision
+        case .error:
+            return nil
+        }
     }
 }

--- a/macos/Tests/AppTests/AppModelAuthTests.swift
+++ b/macos/Tests/AppTests/AppModelAuthTests.swift
@@ -795,30 +795,36 @@ final class AppModelAuthTests: XCTestCase {
         XCTAssertEqual(model.selectedCard?.id, "matrix_session_alpha")
     }
 
-    func testCreateSessionRetriesPureTwoWordCollisions() async throws {
+    func testCreateSessionCreatesProjectWorkspaceTab() async throws {
         let principal = PrincipalProvider(store: MemoryTokenStore())
         try await principal.setToken("token")
         let postedNames = LockedStringArray()
         AppTestURLProtocol.setHandler { req in
-            if req.url?.path == "/api/terminal/sessions", req.httpMethod == "POST" {
-                let name = appTestRequestName(req) ?? ""
-                postedNames.append(name)
-                if postedNames.values.count < shellSessionCreateAttempts {
-                    return (
-                        appTestHTTPResponse(req.url!, 409),
-                        Data(#"{"error":{"code":"session_exists","message":"Request failed"}}"#.utf8)
-                    )
-                }
+            if req.url?.path == "/api/projects/main" {
                 return (
-                    appTestHTTPResponse(req.url!, 201),
-                    Data(#"{"name":"\#(name)"}"#.utf8)
+                    appTestHTTPResponse(req.url!, 200),
+                    Data(#"{"project":{"id":"project_main"}}"#.utf8)
                 )
             }
-            if req.url?.path == "/api/terminal/sessions" {
+            if req.url?.path == "/api/terminal/workspaces/ensure", req.httpMethod == "POST" {
+                return (
+                    appTestHTTPResponse(req.url!, 200),
+                    Data(#"{"workspace":{"id":"tws_00000000000000000000000000000000"}}"#.utf8)
+                )
+            }
+            if req.url?.path == "/api/terminal/workspaces/tws_00000000000000000000000000000000/tabs", req.httpMethod == "POST" {
+                let name = appTestRequestName(req) ?? ""
+                postedNames.append(name)
+                return (
+                    appTestHTTPResponse(req.url!, 201),
+                    Data(#"{"tab":{"id":"tt_22222222222222222222222222222222","name":"\#(name)"}}"#.utf8)
+                )
+            }
+            if req.url?.path == "/api/terminal/workspaces" {
                 let name = postedNames.last ?? "swift-falcon"
                 return (
                     appTestHTTPResponse(req.url!, 200),
-                    Data(#"{"sessions":[{"name":"\#(name)","status":"active"}]}"#.utf8)
+                    Data(#"{"workspaces":[{"id":"tws_00000000000000000000000000000000","projectId":"project_main","tabs":[{"id":"tt_22222222222222222222222222222222","name":"\#(name)","status":"running"}]}]}"#.utf8)
                 )
             }
             return (appTestHTTPResponse(req.url!, 200), Data("{}".utf8))
@@ -846,7 +852,7 @@ final class AppModelAuthTests: XCTestCase {
         await fulfillment(of: [loaded], timeout: 5)
 
         let names = postedNames.values
-        XCTAssertEqual(names.count, shellSessionCreateAttempts)
+        XCTAssertEqual(names.count, 1)
         XCTAssertTrue(names.allSatisfy(isTwoWordShellSessionName))
         XCTAssertTrue(model.sessions.map(\.name).contains(names.last ?? ""))
     }

--- a/macos/Tests/NetTests/VPSResolverTests.swift
+++ b/macos/Tests/NetTests/VPSResolverTests.swift
@@ -24,20 +24,22 @@ final class VPSResolverTests: XCTestCase {
         }
     }
 
-    func testWebSocketURLBuildsWSSWithSessionAndSeq() throws {
+    func testWebSocketURLBuildsWSSWithTerminalRefAndSeq() throws {
         let url = try VPSResolver.webSocketURL(
             gatewayHost: "app.matrix-os.com",
             runtimeSlot: nil,
-            path: "/ws/terminal/session",
-            session: "card-42",
+            path: "/ws/terminal/tab",
+            terminalRef: "tws_project:tt_build",
             fromSeq: 100
         )
         let comps = URLComponents(url: url, resolvingAgainstBaseURL: false)!
         XCTAssertEqual(comps.scheme, "wss")
         XCTAssertEqual(comps.host, "app.matrix-os.com")
-        XCTAssertEqual(comps.path, "/ws/terminal/session")
+        XCTAssertEqual(comps.path, "/ws/terminal/tab")
         let items = Dictionary(uniqueKeysWithValues: (comps.queryItems ?? []).map { ($0.name, $0.value) })
-        XCTAssertEqual(items["session"], "card-42")
+        XCTAssertEqual(items["workspaceId"], "tws_project")
+        XCTAssertEqual(items["tabId"], "tt_build")
+        XCTAssertEqual(items["client"], "macos")
         XCTAssertEqual(items["fromSeq"], "100")
     }
 
@@ -45,27 +47,40 @@ final class VPSResolverTests: XCTestCase {
         let url = try VPSResolver.webSocketURL(
             gatewayHost: "app.matrix-os.com",
             runtimeSlot: nil,
-            path: "/ws/terminal/session",
-            session: "card-42",
+            path: "/ws/terminal/tab",
+            terminalRef: "tws_project:tt_build",
             fromSeq: nil
         )
         let comps = URLComponents(url: url, resolvingAgainstBaseURL: false)!
         let names = (comps.queryItems ?? []).map(\.name)
         XCTAssertFalse(names.contains("fromSeq"))
-        XCTAssertTrue(names.contains("session"))
+        XCTAssertTrue(names.contains("workspaceId"))
+        XCTAssertTrue(names.contains("tabId"))
     }
 
     func testWebSocketURLIncludesRuntimeSlot() throws {
         let url = try VPSResolver.webSocketURL(
             gatewayHost: "app.matrix-os.com",
             runtimeSlot: "staging",
-            path: "/ws/terminal/session",
-            session: "s",
+            path: "/ws/terminal/tab",
+            terminalRef: "tws_project:tt_build",
             fromSeq: nil
         )
         let comps = URLComponents(url: url, resolvingAgainstBaseURL: false)!
         let items = Dictionary(uniqueKeysWithValues: (comps.queryItems ?? []).map { ($0.name, $0.value) })
         XCTAssertEqual(items["runtime"], "staging")
+    }
+
+    func testWebSocketURLRejectsMalformedTerminalRef() {
+        XCTAssertThrowsError(try VPSResolver.webSocketURL(
+            gatewayHost: "app.matrix-os.com",
+            runtimeSlot: nil,
+            path: "/ws/terminal/tab",
+            terminalRef: "legacy-session-name",
+            fromSeq: nil
+        )) { error in
+            XCTAssertEqual(error as? GatewayError, .misconfigured)
+        }
     }
 
     func testConnectionProfileResolvesGatewayURL() throws {

--- a/macos/Tests/TerminalTests/ShellWSClientTests.swift
+++ b/macos/Tests/TerminalTests/ShellWSClientTests.swift
@@ -8,118 +8,117 @@ import XCTest
 final class ShellMessageCodecTests: XCTestCase {
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
+    private var ref: TerminalRef { TerminalRef(key: "tws_00000000000000000000000000000000:tt_11111111111111111111111111111111")! }
+
+    func testTerminalRefRejectsMalformedOrEmptyOpaqueIds() {
+        XCTAssertNil(TerminalRef(key: ":"))
+        XCTAssertNil(TerminalRef(key: "tws_main:tt_shell"))
+        XCTAssertNil(TerminalRef(key: "tws_00000000000000000000000000000000:"))
+    }
+
+    func testTerminalRefDecodingRejectsMalformedOpaqueIds() {
+        let json = #"{"workspaceId":"tws_main","tabId":"tt_shell"}"#
+        XCTAssertThrowsError(try decoder.decode(TerminalRef.self, from: Data(json.utf8)))
+    }
 
     // MARK: ClientMessage encoding
 
     func testClientInputEncodesWireShape() throws {
-        let data = try encoder.encode(ClientMessage.input(data: "ls -la\n"))
+        let data = try encoder.encode(ClientMessage.input(ref: ref, data: "ls -la\n"))
         let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         XCTAssertEqual(obj?["type"] as? String, "input")
         XCTAssertEqual(obj?["data"] as? String, "ls -la\n")
-        XCTAssertEqual(obj?.count, 2)
+        XCTAssertEqual((obj?["terminalRef"] as? [String: String])?["workspaceId"], "tws_00000000000000000000000000000000")
     }
 
     func testClientResizeEncodesWireShape() throws {
-        let data = try encoder.encode(ClientMessage.resize(cols: 120, rows: 40))
+        let data = try encoder.encode(ClientMessage.resize(ref: ref, cols: 120, rows: 40))
         let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         XCTAssertEqual(obj?["type"] as? String, "resize")
-        XCTAssertEqual(obj?["cols"] as? Int, 120)
-        XCTAssertEqual(obj?["rows"] as? Int, 40)
+        XCTAssertEqual(obj?["mode"] as? String, "soft")
+        let size = obj?["size"] as? [String: Int]
+        XCTAssertEqual(size?["cols"], 120)
+        XCTAssertEqual(size?["rows"], 40)
     }
 
     func testClientDetachEncodesWireShape() throws {
-        let data = try encoder.encode(ClientMessage.detach)
+        let data = try encoder.encode(ClientMessage.detach(ref: ref))
         let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         XCTAssertEqual(obj?["type"] as? String, "detach")
-        XCTAssertEqual(obj?.count, 1)
+        XCTAssertNotNil(obj?["terminalRef"])
     }
 
     func testClientPingEncodesWireShape() throws {
-        let data = try encoder.encode(ClientMessage.ping)
+        let data = try encoder.encode(ClientMessage.ping(ref: ref))
         let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         XCTAssertEqual(obj?["type"] as? String, "ping")
-        XCTAssertEqual(obj?.count, 1)
-    }
-
-    func testClientMessageRoundTrips() throws {
-        let cases: [ClientMessage] = [
-            .input(data: "x"),
-            .resize(cols: 80, rows: 24),
-            .detach,
-            .ping,
-        ]
-        for message in cases {
-            let encoded = try encoder.encode(message)
-            let decoded = try decoder.decode(ClientMessage.self, from: encoded)
-            XCTAssertEqual(decoded, message)
-        }
+        XCTAssertNotNil(obj?["terminalRef"])
     }
 
     // MARK: ServerMessage decoding
 
     func testServerAttachedDecodes() throws {
-        let json = #"{"type":"attached","session":"main","state":"running","fromSeq":12}"#
+        let json = #"{"type":"attached","terminalRef":{"workspaceId":"tws_00000000000000000000000000000000","tabId":"tt_11111111111111111111111111111111"},"canonicalSize":{"cols":120,"rows":40},"revision":4,"nextSeq":12}"#
         let message = try decoder.decode(ServerMessage.self, from: Data(json.utf8))
-        guard case let .attached(session, state, fromSeq) = message else {
+        guard case let .attached(ref, size, revision, nextSeq) = message else {
             return XCTFail("expected attached, got \(message)")
         }
-        XCTAssertEqual(session, "main")
-        XCTAssertEqual(state, "running")
-        XCTAssertEqual(fromSeq, 12)
-    }
-
-    func testServerAttachedAcceptsAutoCreateSessionIdShape() throws {
-        let json = #"{"type":"attached","sessionId":"matrix-sess_auto","state":"running"}"#
-        let message = try decoder.decode(ServerMessage.self, from: Data(json.utf8))
-        guard case let .attached(session, state, fromSeq) = message else {
-            return XCTFail("expected attached, got \(message)")
-        }
-        XCTAssertEqual(session, "matrix-sess_auto")
-        XCTAssertEqual(state, "running")
-        XCTAssertEqual(fromSeq, 0)
+        XCTAssertEqual(ref, self.ref)
+        XCTAssertEqual(size, TerminalGridSize(cols: 120, rows: 40))
+        XCTAssertEqual(revision, 4)
+        XCTAssertEqual(nextSeq, 12)
     }
 
     func testServerOutputDecodes() throws {
-        let json = #"{"type":"output","seq":7,"data":"hello"}"#
+        let json = #"{"type":"output","terminalRef":{"workspaceId":"tws_00000000000000000000000000000000","tabId":"tt_11111111111111111111111111111111"},"revision":5,"seq":7,"data":"hello"}"#
         let message = try decoder.decode(ServerMessage.self, from: Data(json.utf8))
-        guard case let .output(seq, data) = message else {
+        guard case let .output(ref, revision, seq, data) = message else {
             return XCTFail("expected output, got \(message)")
         }
+        XCTAssertEqual(ref, self.ref)
+        XCTAssertEqual(revision, 5)
         XCTAssertEqual(seq, 7)
         XCTAssertEqual(data, "hello")
     }
 
-    func testServerOutputAcceptsLegacyFrameWithoutSeq() throws {
-        let json = #"{"type":"output","data":"hello"}"#
+    func testServerSnapshotDecodesDurableState() throws {
+        let json = #"{"type":"snapshot","terminalRef":{"workspaceId":"tws_00000000000000000000000000000000","tabId":"tt_11111111111111111111111111111111"},"canonicalSize":{"cols":100,"rows":30},"revision":6,"seq":9,"ansi":"prompt","viewport":{"top":2,"rows":30}}"#
         let message = try decoder.decode(ServerMessage.self, from: Data(json.utf8))
-        guard case let .output(seq, data) = message else {
-            return XCTFail("expected output, got \(message)")
+        guard case let .snapshot(ref, size, revision, seq, ansi, viewport) = message else {
+            return XCTFail("expected snapshot, got \(message)")
         }
-        XCTAssertEqual(seq, 0)
-        XCTAssertEqual(data, "hello")
+        XCTAssertEqual(ref, self.ref)
+        XCTAssertEqual(size, TerminalGridSize(cols: 100, rows: 30))
+        XCTAssertEqual(revision, 6)
+        XCTAssertEqual(seq, 9)
+        XCTAssertEqual(ansi, "prompt")
+        XCTAssertEqual(viewport, TerminalViewport(top: 2, rows: 30))
     }
 
     func testServerExitDecodes() throws {
-        let json = #"{"type":"exit","code":0}"#
+        let json = #"{"type":"exit","terminalRef":{"workspaceId":"tws_00000000000000000000000000000000","tabId":"tt_11111111111111111111111111111111"},"revision":7,"exitCode":0}"#
         let message = try decoder.decode(ServerMessage.self, from: Data(json.utf8))
-        guard case let .exit(code) = message else {
+        guard case let .exit(ref, revision, code) = message else {
             return XCTFail("expected exit, got \(message)")
         }
+        XCTAssertEqual(ref, self.ref)
+        XCTAssertEqual(revision, 7)
         XCTAssertEqual(code, 0)
     }
 
     func testServerErrorDecodes() throws {
         let json = #"{"type":"error","code":"session_not_found","message":"Session not found"}"#
         let message = try decoder.decode(ServerMessage.self, from: Data(json.utf8))
-        guard case let .error(code, text) = message else {
+        guard case let .error(ref, code, text) = message else {
             return XCTFail("expected error, got \(message)")
         }
+        XCTAssertNil(ref)
         XCTAssertEqual(code, "session_not_found")
         XCTAssertEqual(text, "Session not found")
     }
 
     func testServerPongDecodes() throws {
-        let json = #"{"type":"pong"}"#
+        let json = #"{"type":"pong","terminalRef":{"workspaceId":"tws_00000000000000000000000000000000","tabId":"tt_11111111111111111111111111111111"},"revision":8}"#
         let message = try decoder.decode(ServerMessage.self, from: Data(json.utf8))
         guard case .pong = message else {
             return XCTFail("expected pong, got \(message)")
@@ -127,11 +126,13 @@ final class ShellMessageCodecTests: XCTestCase {
     }
 
     func testServerReplayEvictedDecodes() throws {
-        let json = #"{"type":"replay-evicted","fromSeq":3,"nextSeq":50}"#
+        let json = #"{"type":"replay-evicted","terminalRef":{"workspaceId":"tws_00000000000000000000000000000000","tabId":"tt_11111111111111111111111111111111"},"revision":9,"fromSeq":3,"nextSeq":50}"#
         let message = try decoder.decode(ServerMessage.self, from: Data(json.utf8))
-        guard case let .replayEvicted(fromSeq, nextSeq) = message else {
+        guard case let .replayEvicted(ref, revision, fromSeq, nextSeq) = message else {
             return XCTFail("expected replayEvicted, got \(message)")
         }
+        XCTAssertEqual(ref, self.ref)
+        XCTAssertEqual(revision, 9)
         XCTAssertEqual(fromSeq, 3)
         XCTAssertEqual(nextSeq, 50)
     }
@@ -152,9 +153,9 @@ final class ShellWSClientStateMachineTests: XCTestCase {
     func testFirstConnectAttachesAtLiveTail() async throws {
         let transport = MockShellTransport()
         let client = ShellWSClient(
-            url: URL(string: "wss://vps.example/ws/terminal/session")!,
+            url: URL(string: "wss://vps.example/ws/terminal/tab?workspaceId=tws_00000000000000000000000000000000&tabId=tt_11111111111111111111111111111111&client=macos")!,
             token: "secret-token",
-            session: "main",
+            terminalRef: "tws_00000000000000000000000000000000:tt_11111111111111111111111111111111",
             transport: transport,
             backoff: .test,
             clock: MockClock()
@@ -166,7 +167,8 @@ final class ShellWSClientStateMachineTests: XCTestCase {
         XCTAssertEqual(first?.value(forHTTPHeaderField: "Authorization"), "Bearer secret-token")
         let query = first?.url?.query ?? ""
         XCTAssertFalse(query.contains("token="), "token must not be in query: \(query)")
-        XCTAssertTrue(query.contains("session=main"))
+        XCTAssertTrue(query.contains("workspaceId=tws_00000000000000000000000000000000"))
+        XCTAssertTrue(query.contains("tabId=tt_11111111111111111111111111111111"))
         XCTAssertTrue(query.contains("fromSeq=\(SHELL_ATTACH_LIVE_TAIL_FROM_SEQ)"))
         await client.shutdown()
     }
@@ -176,9 +178,9 @@ final class ShellWSClientStateMachineTests: XCTestCase {
         let client = makeClient(transport: transport)
         await client.connect()
         await transport.waitForConnect(count: 1)
-        await transport.emit(#"{"type":"attached","session":"main","state":"running","fromSeq":0}"#)
-        await transport.emit(#"{"type":"output","seq":1,"data":"a"}"#)
-        await transport.emit(#"{"type":"output","seq":2,"data":"b"}"#)
+        await transport.emit(#"{"type":"attached","terminalRef":{"workspaceId":"tws_00000000000000000000000000000000","tabId":"tt_11111111111111111111111111111111"},"canonicalSize":{"cols":120,"rows":40},"revision":1,"nextSeq":0}"#)
+        await transport.emit(#"{"type":"output","terminalRef":{"workspaceId":"tws_00000000000000000000000000000000","tabId":"tt_11111111111111111111111111111111"},"revision":2,"seq":1,"data":"a"}"#)
+        await transport.emit(#"{"type":"output","terminalRef":{"workspaceId":"tws_00000000000000000000000000000000","tabId":"tt_11111111111111111111111111111111"},"revision":3,"seq":2,"data":"b"}"#)
         // drain the three events (attached + 2 output)
         var seen: [ServerEvent] = []
         let stream = await client.events
@@ -188,6 +190,26 @@ final class ShellWSClientStateMachineTests: XCTestCase {
         }
         let lastSeq = await client.lastSeq
         XCTAssertEqual(lastSeq, 2)
+        await client.shutdown()
+    }
+
+    func testIgnoresFramesForAnotherTabAndStaleRevisions() async throws {
+        let transport = MockShellTransport()
+        let client = makeClient(transport: transport)
+        await client.connect()
+        await transport.waitForConnect(count: 1)
+        await transport.emit(#"{"type":"attached","terminalRef":{"workspaceId":"tws_00000000000000000000000000000000","tabId":"tt_11111111111111111111111111111111"},"canonicalSize":{"cols":120,"rows":40},"revision":5,"nextSeq":0}"#)
+        await transport.emit(#"{"type":"output","terminalRef":{"workspaceId":"tws_00000000000000000000000000000000","tabId":"tt_22222222222222222222222222222222"},"revision":6,"seq":7,"data":"wrong tab"}"#)
+        await transport.emit(#"{"type":"output","terminalRef":{"workspaceId":"tws_00000000000000000000000000000000","tabId":"tt_11111111111111111111111111111111"},"revision":4,"seq":8,"data":"stale"}"#)
+        await transport.emit(#"{"type":"output","terminalRef":{"workspaceId":"tws_00000000000000000000000000000000","tabId":"tt_11111111111111111111111111111111"},"revision":6,"seq":9,"data":"current"}"#)
+
+        let events = await drain(client, count: 2)
+        XCTAssertEqual(events, [
+            .attached(state: "running", fromSeq: 0),
+            .output(seq: 9, data: "current")
+        ])
+        let lastSeq = await client.lastSeq
+        XCTAssertEqual(lastSeq, 9)
         await client.shutdown()
     }
 
@@ -201,7 +223,7 @@ final class ShellWSClientStateMachineTests: XCTestCase {
 
         await client.connect()
         await transport.waitForConnect(count: 1)
-        await transport.emit(#"{"type":"attached","session":"main","state":"running","fromSeq":0}"#)
+        await transport.emit(#"{"type":"attached","terminalRef":{"workspaceId":"tws_00000000000000000000000000000000","tabId":"tt_11111111111111111111111111111111"},"canonicalSize":{"cols":120,"rows":40},"revision":1,"nextSeq":0}"#)
         _ = await drain(client, count: 1)
 
         try await waitUntil(timeout: 3) {
@@ -213,6 +235,7 @@ final class ShellWSClientStateMachineTests: XCTestCase {
         let obj = try JSONSerialization.jsonObject(with: Data(frame.utf8)) as? [String: Any]
         XCTAssertEqual(obj?["type"] as? String, "input")
         XCTAssertEqual(obj?["data"] as? String, "echo hello\n")
+        XCTAssertEqual((obj?["terminalRef"] as? [String: String])?["tabId"], "tt_11111111111111111111111111111111")
         await client.shutdown()
     }
 
@@ -222,7 +245,7 @@ final class ShellWSClientStateMachineTests: XCTestCase {
         let client = makeClient(transport: transport, clock: clock)
         await client.connect()
         await transport.waitForConnect(count: 1)
-        await transport.emit(#"{"type":"output","seq":5,"data":"x"}"#)
+        await transport.emit(#"{"type":"output","terminalRef":{"workspaceId":"tws_00000000000000000000000000000000","tabId":"tt_11111111111111111111111111111111"},"revision":2,"seq":5,"data":"x"}"#)
         _ = await drain(client, count: 1)
         // simulate server-side disconnect → run loop parks in backoff sleep
         await transport.failCurrent()
@@ -240,11 +263,11 @@ final class ShellWSClientStateMachineTests: XCTestCase {
         let clock = MockClock()
         let tokenSource = SequenceTokenSource(["initial-token", "refreshed-token"])
         let client = ShellWSClient(
-            url: URL(string: "wss://vps.example/ws/terminal/session")!,
+            url: URL(string: "wss://vps.example/ws/terminal/tab?workspaceId=tws_00000000000000000000000000000000&tabId=tt_11111111111111111111111111111111&client=macos")!,
             tokenProvider: {
                 await tokenSource.next()
             },
-            session: "main",
+            terminalRef: "tws_00000000000000000000000000000000:tt_11111111111111111111111111111111",
             transport: transport,
             backoff: .test,
             clock: clock
@@ -295,13 +318,13 @@ final class ShellWSClientStateMachineTests: XCTestCase {
         let client = makeClient(transport: transport, clock: clock)
         await client.connect()
         await transport.waitForConnect(count: 1)
-        await transport.emit(#"{"type":"output","seq":9,"data":"y"}"#)
+        await transport.emit(#"{"type":"output","terminalRef":{"workspaceId":"tws_00000000000000000000000000000000","tabId":"tt_11111111111111111111111111111111"},"revision":3,"seq":9,"data":"y"}"#)
         _ = await drain(client, count: 1)
         let seqAfterOutput = await client.lastSeq
         XCTAssertEqual(seqAfterOutput, 9)
 
         // replay-evicted: client clears buffer + seq, drops the socket, re-attaches at live tail.
-        await transport.emit(#"{"type":"replay-evicted","fromSeq":6,"nextSeq":40}"#)
+        await transport.emit(#"{"type":"replay-evicted","terminalRef":{"workspaceId":"tws_00000000000000000000000000000000","tabId":"tt_11111111111111111111111111111111"},"revision":4,"fromSeq":6,"nextSeq":40}"#)
         _ = await drain(client, count: 1) // the .replayEvicted event
         await clock.waitForSleeper()
         await clock.advanceAll()
@@ -365,9 +388,9 @@ final class ShellWSClientStateMachineTests: XCTestCase {
 
     private func makeClient(transport: MockShellTransport, clock: MockClock = MockClock()) -> ShellWSClient {
         ShellWSClient(
-            url: URL(string: "wss://vps.example/ws/terminal/session")!,
+            url: URL(string: "wss://vps.example/ws/terminal/tab?workspaceId=tws_00000000000000000000000000000000&tabId=tt_11111111111111111111111111111111&client=macos")!,
             token: "secret-token",
-            session: "main",
+            terminalRef: "tws_00000000000000000000000000000000:tt_11111111111111111111111111111111",
             transport: transport,
             backoff: .test,
             clock: clock

--- a/shell/e2e/terminal-sizing.spec.ts
+++ b/shell/e2e/terminal-sizing.spec.ts
@@ -6,6 +6,10 @@ interface TerminalSizingState {
   confirmations: Array<{ cols: number; rows: number }>;
 }
 
+const WORKSPACE_ID = "tws_00000000000000000000000000000001";
+const TAB_ID = "tt_00000000000000000000000000000001";
+const TERMINAL_REF = { workspaceId: WORKSPACE_ID, tabId: TAB_ID };
+
 async function installTerminalGateway(page: Page): Promise<void> {
   await page.addInitScript(() => {
     const state: TerminalSizingState = { declarations: [], confirmations: [] };
@@ -45,26 +49,31 @@ async function installTerminalGateway(page: Page): Promise<void> {
           state.confirmations.push(canonical);
           this.receive({
             type: "attached",
-            session: parsed.searchParams.get("session") ?? "main",
-            state: "running",
-            fromSeq: 0,
+            terminalRef: TERMINAL_REF,
             canonicalSize: canonical,
+            revision: 1,
+            nextSeq: 0,
           });
-          this.receive({ type: "replay-start", fromSeq: 0 });
-          this.receive({ type: "output", seq: 0, data: "matrix@web:~$ real rows fill this pane" });
-          this.receive({ type: "replay-end", toSeq: 0 });
+          this.receive({ type: "replay-start", terminalRef: TERMINAL_REF, revision: 1, fromSeq: 0 });
+          this.receive({ type: "output", terminalRef: TERMINAL_REF, revision: 1, seq: 0, data: "matrix@web:~$ real rows fill this pane" });
+          this.receive({ type: "replay-end", terminalRef: TERMINAL_REF, revision: 1, nextSeq: 1, toSeq: 0 });
         }, 0);
       }
 
       send(raw: string): void {
-        const frame = JSON.parse(raw) as { type?: string; cols?: number; rows?: number };
-        if (frame.type === "resize" && frame.cols && frame.rows) {
-          const canonical = { cols: frame.cols, rows: frame.rows };
+        const frame = JSON.parse(raw) as { type?: string; size?: { cols?: number; rows?: number } };
+        if (frame.type === "resize" && frame.size?.cols && frame.size.rows) {
+          const canonical = { cols: frame.size.cols, rows: frame.size.rows };
           state.declarations.push({ source: "resize", ...canonical });
           state.confirmations.push(canonical);
-          window.setTimeout(() => this.receive({ type: "canonical-size", ...canonical }), 0);
+          window.setTimeout(() => this.receive({
+            type: "canonical-size",
+            terminalRef: TERMINAL_REF,
+            revision: 2,
+            canonicalSize: canonical,
+          }), 0);
         } else if (frame.type === "ping") {
-          window.setTimeout(() => this.receive({ type: "pong" }), 0);
+          window.setTimeout(() => this.receive({ type: "pong", terminalRef: TERMINAL_REF, revision: 2 }), 0);
         }
       }
 
@@ -124,10 +133,20 @@ async function mockShellApis(page: Page): Promise<void> {
     contentType: "application/json",
     body: JSON.stringify({ token: "terminal-e2e-token", expiresAt: Date.now() + 300_000 }),
   }));
-  await page.route("**/api/terminal/sessions", (route) => route.fulfill({
+  await page.route("**/api/terminal/workspaces", (route) => route.fulfill({
     status: 200,
     contentType: "application/json",
-    body: JSON.stringify({ sessions: [{ name: "main", status: "active" }] }),
+    body: JSON.stringify({ workspaces: [{
+      id: WORKSPACE_ID,
+      scope: "main",
+      internalName: "zw_00000000000000000000000000000001",
+      canonicalSize: { cols: 120, rows: 40 },
+      status: "running",
+      revision: 1,
+      createdAt: "2026-08-11T00:00:00.000Z",
+      updatedAt: "2026-08-11T00:00:00.000Z",
+      tabs: [{ id: TAB_ID, internalName: "mt_00000000000000000000000000000001", name: "Main", cwd: "projects", status: "running", revision: 1, createdAt: "2026-08-11T00:00:00.000Z", updatedAt: "2026-08-11T00:00:00.000Z" }],
+    }] }),
   }));
   await page.route("**/api/terminal/layout", (route) => {
     if (route.request().method() !== "GET") {
@@ -140,7 +159,7 @@ async function mockShellApis(page: Page): Promise<void> {
         tabs: [{
           id: "tab-main",
           label: "Main",
-          paneTree: { type: "pane", id: "pane-main", cwd: "projects", sessionId: "main" },
+          paneTree: { type: "pane", id: "pane-main", cwd: "projects", sessionId: `${WORKSPACE_ID}:${TAB_ID}` },
         }],
         activeTabId: "tab-main",
         sidebarOpen: false,

--- a/tests/e2e/api/auth-gates.e2e.test.ts
+++ b/tests/e2e/api/auth-gates.e2e.test.ts
@@ -60,8 +60,8 @@ describe("E2E: Authentication gates", () => {
     expect(res.status).toBe(401);
   });
 
-  it("rejects /api/terminal/sessions without token", async () => {
-    const res = await fetch(`${gw.url}/api/terminal/sessions`);
+  it("rejects /api/terminal/workspaces without token", async () => {
+    const res = await fetch(`${gw.url}/api/terminal/workspaces`);
     expect(res.status).toBe(401);
   });
 

--- a/tests/e2e/desktop/fixtures/stub-gateway.ts
+++ b/tests/e2e/desktop/fixtures/stub-gateway.ts
@@ -78,6 +78,8 @@ const HERMES_CONVERSATIONS = [
     updatedAt: HERMES_NOW - 1_800_000,
   },
 ] as const;
+const TERMINAL_TAB_ID = TERMINAL_TAB_IDS[0];
+const TERMINAL_REF = { workspaceId: TERMINAL_WORKSPACE_ID, tabId: TERMINAL_TAB_ID };
 
 function json(res: ServerResponse, status: number, body: unknown): void {
   res.writeHead(status, { "content-type": "application/json" });
@@ -145,7 +147,7 @@ function codingAgentThread(prompt = "Fix the failing auth tests"): AgentThreadSn
     status: "completed",
     attention: "completed",
     projectId: "matrix-os",
-    terminalSessionId: "matrix-task-1",
+    terminalRef: TERMINAL_REF,
     createdAt: NOW,
     updatedAt: NOW,
   };
@@ -283,7 +285,7 @@ export function codingAgentSnapshot(prompt = "Fix the failing auth tests"): Agen
           eventId: "evt_operator_terminal",
           threadId: thread.id,
           occurredAt: NOW,
-          terminalSessionId: "matrix-task-1",
+          terminalRef: TERMINAL_REF,
         },
         {
           type: "thread.completed",
@@ -523,16 +525,28 @@ export function codingAgentSummary(): RuntimeSummary {
       hasMore: false,
       limit: 50,
     },
-    terminalSessions: {
+    terminalWorkspaces: {
       items: [
         {
-          id: "matrix-task-1",
-          name: "Matrix shell",
+          id: TERMINAL_WORKSPACE_ID,
+          scope: "project",
+          projectId: "matrix-os",
+          canonicalSize: { cols: 120, rows: 40 },
           status: "running",
-          attachable: true,
-          cwdLabel: "matrix-os",
+          revision: 1,
           createdAt: NOW,
           updatedAt: NOW,
+          tabs: [{
+            id: TERMINAL_TAB_ID,
+            workspaceId: TERMINAL_WORKSPACE_ID,
+            name: "Matrix shell",
+            cwd: "projects/matrix-os",
+            status: "running",
+            revision: 1,
+            order: 0,
+            createdAt: NOW,
+            updatedAt: NOW,
+          }],
         },
       ],
       hasMore: false,
@@ -1080,34 +1094,6 @@ export async function startStubGateway(options: StubGatewayOptions = {}): Promis
       json(res, 201, { tab });
       return;
     }
-    if (path === "/api/terminal/sessions") {
-      json(res, 200, {
-        sessions: [
-          {
-            name: "matrix-task-1",
-            status: "active",
-            visualStatus: "running",
-            createdAt: "2026-07-08T08:30:00.000Z",
-            updatedAt: NOW,
-          },
-          {
-            name: "matrix-review",
-            status: "degraded",
-            visualStatus: "waiting",
-            createdAt: "2026-07-08T08:15:00.000Z",
-            updatedAt: NOW,
-          },
-          {
-            name: "matrix-closed",
-            status: "exited",
-            visualStatus: "finished",
-            createdAt: "2026-07-08T07:45:00.000Z",
-            updatedAt: NOW,
-          },
-        ],
-      });
-      return;
-    }
     if (req.method === "GET" && path === "/api/auth/ws-token") {
       json(res, 200, {
         token: "stub-ws-token",
@@ -1262,7 +1248,7 @@ export async function startStubGateway(options: StubGatewayOptions = {}): Promis
     if (path === "/api/sessions") {
       json(res, 200, {
         sessions: [
-          { id: "sess-orch-1", name: "Task 1 session", runtime: { zellijSession: "matrix-task-1" } },
+          { id: "sess-orch-1", name: "Task 1 session", runtime: { terminalRef: TERMINAL_REF } },
           { id: "sess-orch-2", name: "Orchestrator-only", runtime: {} },
         ],
         nextCursor: null,


### PR DESCRIPTION
## Summary

- migrate Expo mobile terminal clients from legacy session names to canonical workspace/tab `TerminalRef` values
- migrate the macOS terminal board, WebSocket client, and runtime resolver to shared terminal workspaces
- keep terminal handoff, reconnect, resizing, auth, bounded state, and cross-shell fixtures aligned with the gateway contract
- reconcile active-tab cwd from refreshed workspace metadata and log malformed/reconnect failures safely

## Stack

Layer 12 of 14. Depends on #1440 at `151dc35660dff4b0b206c2cda7f2fb4e5691962b`; #1446 follows.

## Review/Monitoring

- GitHub CI and Greptile are being monitored on the latest head; merge readiness requires current-head CI and Greptile 5/5.

## Invariants

- **Source of truth:** Gateway terminal workspaces and their tabs are canonical. Native clients persist only validated serialized `TerminalRef` keys and reconcile display metadata from bounded workspace listings.
- **Lock/transaction scope:** This layer adds no database writes or client-side lock. Connection replacement is guarded by attempt generations; the gateway remains responsible for atomic workspace/tab mutations.
- **Acceptable orphan states:** Ensuring the shared workspace may succeed before tab creation fails; that workspace is intentionally reusable. If terminal handoff persistence fails after tab creation, the tab remains discoverable through the canonical workspace listing.
- **Auth source of truth:** Existing Clerk bearer auth and short-lived gateway WebSocket tokens remain authoritative. Tokens are refreshed through the existing gateway client, and workspace/tab IDs are validated before REST or WebSocket URL construction.
- **Deferred scope:** Host deployment activation and operational documentation remain in later stack layers. Transitional runtime-summary compatibility fields are retained until those layers remove their consumers.

## Tests

- `pnpm --dir apps/mobile exec jest --runInBand` — 56 suites, 621 tests passed
- focused mobile terminal/provider/gateway suites — 111 tests passed
- `pnpm exec vitest run --config vitest.e2e.config.ts tests/e2e/api/auth-gates.e2e.test.ts` — 10 tests passed
- `pnpm exec vitest run tests/plugins/matrix-marketplace.test.ts` — 7 tests passed
- `pnpm run check:patterns` — 0 violations
- React Doctor changed-scope audit — introduced exhaustive-deps finding resolved; remaining findings are inherited from earlier stack layers or unchanged lines
- diff hygiene and manual legacy/error-handling sweep passed

## Environment notes

- Swift is unavailable on this Linux host; the `swift build + test` GitHub check is the authoritative macOS validation.
- A direct mobile `tsc --noEmit` run has pre-existing React Native dependency-type conflicts in untouched files; no diagnostics remain in this layer's changed files.

## Visual evidence

Pending exact-head native screenshot evidence from an available mobile/macOS runtime.



