### PR TITLE
feat(settings): unify agents and providers across shells

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -28,6 +28,7 @@
     "@fontsource/instrument-serif": "^5.3.0",
     "@fontsource/jetbrains-mono": "^5.2.5",
     "@finnaai/matrix": "workspace:*",
+    "@matrix-os/ui": "workspace:*",
     "@hugeicons/core-free-icons": "^4.3.0",
     "@hugeicons/react": "^1.1.9",
     "@lexical/react": "^0.41.0",

--- a/desktop/src/renderer/src/features/chat/use-provider-setup.ts
+++ b/desktop/src/renderer/src/features/chat/use-provider-setup.ts
@@ -17,14 +17,6 @@ import { findProviderForSetupAction } from "../coding-agents/provider-readiness"
 
 const SETUP_ERROR = "Could not open setup. Open Settings to continue.";
 
-function settingsSectionForInstance(
-  instance: CanonicalProviderInstanceDescriptor,
-): "agent" | "providers" {
-  return instance.driverKind === "hermes" || instance.driverKind === "openclaw"
-    ? "agent"
-    : "providers";
-}
-
 export function useProviderSetup(
   providers: AgentProviderSummary[],
   onRefresh?: () => Promise<void>,
@@ -40,7 +32,7 @@ export function useProviderSetup(
     action: CanonicalProviderSetupAction,
   ) => {
     if (action.kind === "open_settings") {
-      requestSettingsSection(settingsSectionForInstance(instance));
+      requestSettingsSection("agents-providers");
       openTab({ kind: "settings", title: "Settings" });
       return;
     }

--- a/desktop/src/renderer/src/features/settings/AgentsProvidersAdapter.tsx
+++ b/desktop/src/renderer/src/features/settings/AgentsProvidersAdapter.tsx
@@ -1,0 +1,172 @@
+import {
+  AgentsProvidersView,
+  useProviderSettingsController,
+} from "@matrix-os/ui";
+import "@matrix-os/ui/agents-providers.css";
+import { useCallback, useMemo, useState } from "react";
+import type { ApiClient } from "../../lib/api";
+import { useConnection } from "../../stores/connection";
+import {
+  createDesktopProviderSettingsTransport,
+  desktopProviderIdentityKey,
+  openExistingProviderTerminalSession,
+  openProviderAuthorizationPath,
+} from "./provider-settings-desktop-adapter";
+
+const ACTION_ERROR = "Provider action is unavailable. Refresh and try again.";
+
+function ProviderSettingsUnavailable({
+  signedOut,
+  failed = false,
+  onRetry,
+}: {
+  signedOut: boolean;
+  failed?: boolean;
+  onRetry?: () => void;
+}) {
+  return (
+    <div className="matrix-agents-providers">
+      <header className="matrix-ap-page-head">
+        <div>
+          <span className="matrix-ap-eyebrow">Settings</span>
+          <h1>Agents &amp; providers</h1>
+          <p>Choose which harness runs a task, which model it uses, and who funds the route.</p>
+        </div>
+      </header>
+      <div className="matrix-ap-empty-state" role="status">
+        <strong>
+          {signedOut
+            ? "Sign in to manage providers"
+            : failed ? "Provider settings are unavailable" : "Loading provider settings"}
+        </strong>
+        <span>
+          {signedOut
+            ? "Provider settings are scoped to your Matrix account and selected computer."
+            : failed
+              ? "The settings response could not be loaded safely. Refresh and try again."
+              : "Checking this computer’s agents, accounts, and model routes…"}
+        </span>
+        {failed && onRetry ? (
+          <button
+            type="button"
+            className="matrix-ap-button matrix-ap-button-primary"
+            aria-label="Retry provider settings"
+            onClick={onRetry}
+          >
+            Retry
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ConnectedAgentsProvidersAdapter({
+  api,
+  identityKey,
+  platformHost,
+  runtimeSlot,
+}: {
+  api: ApiClient;
+  identityKey: string;
+  platformHost: string;
+  runtimeSlot: string;
+}) {
+  const runtimeApi = useMemo(() => api.forRuntime(runtimeSlot), [api, runtimeSlot]);
+  const transport = useMemo(
+    () => createDesktopProviderSettingsTransport(runtimeApi),
+    [runtimeApi],
+  );
+  const controller = useProviderSettingsController({ identityKey, transport });
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const isIdentityCurrent = useCallback(
+    () => desktopProviderIdentityKey(useConnection.getState()) === identityKey,
+    [identityKey],
+  );
+
+  const openTerminal = useCallback((terminalSessionId: string) => {
+    setActionError(null);
+    void openExistingProviderTerminalSession(runtimeApi, terminalSessionId, isIdentityCurrent)
+      .then((opened) => {
+        if (!opened && isIdentityCurrent()) setActionError(ACTION_ERROR);
+      })
+      .catch((error: unknown) => {
+        console.error(
+          "[provider-settings] Could not open terminal session:",
+          error instanceof Error ? error.name : typeof error,
+        );
+        if (isIdentityCurrent()) setActionError(ACTION_ERROR);
+      });
+  }, [isIdentityCurrent, runtimeApi]);
+
+  const openBrowser = useCallback((authorizationPath: string) => {
+    setActionError(null);
+    void openProviderAuthorizationPath({ authorizationPath, platformHost, runtimeSlot })
+      .then((opened) => {
+        if (!opened && isIdentityCurrent()) setActionError(ACTION_ERROR);
+      });
+  }, [isIdentityCurrent, platformHost, runtimeSlot]);
+
+  if (controller.snapshot === null) {
+    return (
+      <ProviderSettingsUnavailable
+        signedOut={false}
+        failed={controller.error !== null}
+        onRetry={() => void controller.refresh()}
+      />
+    );
+  }
+
+  return (
+    <AgentsProvidersView
+      snapshot={controller.snapshot}
+      selectedHarnessId={controller.selectedHarnessId}
+      connectionAttempt={controller.connectionAttempt}
+      busy={controller.busy}
+      error={controller.error ?? actionError}
+      onSelectHarness={controller.onSelectHarness}
+      onRefresh={() => {
+        setActionError(null);
+        void controller.refresh();
+      }}
+      onMutate={(intent) => {
+        setActionError(null);
+        void controller.mutate(intent);
+      }}
+      onOpenTerminal={openTerminal}
+      onOpenBrowser={openBrowser}
+      onAddCredit={() => setActionError(ACTION_ERROR)}
+    />
+  );
+}
+
+export default function AgentsProvidersAdapter() {
+  const status = useConnection((state) => state.status);
+  const handle = useConnection((state) => state.handle);
+  const platformHost = useConnection((state) => state.platformHost);
+  const runtimeSlot = useConnection((state) => state.runtimeSlot);
+  const authGeneration = useConnection((state) => state.authGeneration);
+  const api = useConnection((state) => state.api);
+  const identityKey = desktopProviderIdentityKey({
+    status,
+    handle,
+    platformHost,
+    runtimeSlot,
+    authGeneration,
+  });
+
+  if (status !== "signed-in" || api === null) {
+    return <ProviderSettingsUnavailable signedOut={status === "signed-out"} />;
+  }
+
+  return (
+    <ConnectedAgentsProvidersAdapter
+      key={identityKey}
+      api={api}
+      identityKey={identityKey}
+      platformHost={platformHost}
+      runtimeSlot={runtimeSlot}
+    />
+  );
+}

--- a/desktop/src/renderer/src/features/settings/SettingsView.tsx
+++ b/desktop/src/renderer/src/features/settings/SettingsView.tsx
@@ -15,7 +15,7 @@ import { useEffect, useState } from "react";
 import AccountSection from "./sections/AccountSection";
 import AppearanceSection from "./sections/AppearanceSection";
 import RuntimeSection from "./sections/RuntimeSection";
-import AgentSection from "./sections/AgentSection";
+import AgentsProvidersAdapter from "./AgentsProvidersAdapter";
 import IdentityPersonalitySection from "./sections/IdentityPersonalitySection";
 import BillingSection from "./sections/BillingSection";
 import IntegrationsSettingsSection from "../integrations/IntegrationsSettingsSection";
@@ -23,7 +23,6 @@ import CliSection from "../plugins/CliSection";
 import McpServersSection from "../plugins/McpServersSection";
 import SkillsSection from "../plugins/SkillsSection";
 import CronSection from "./sections/CronSection";
-import ProvidersSection from "./sections/ProvidersSection";
 import SystemSection from "./sections/SystemSection";
 import { useUi } from "../../stores/ui";
 
@@ -69,15 +68,6 @@ export function isSettingsSectionId(value: string): value is SettingsSectionId {
 export function resolveSettingsSectionId(value: string): SettingsSectionId | null {
   if (value === "agent" || value === "providers") return "agents-providers";
   return isSettingsSectionId(value) ? value : null;
-}
-
-function AgentsProvidersAdapter() {
-  return (
-    <div data-settings-adapter="agents-providers-legacy">
-      <AgentSection />
-      <ProvidersSection />
-    </div>
-  );
 }
 
 export function SettingsSidebar({

--- a/desktop/src/renderer/src/features/settings/SettingsView.tsx
+++ b/desktop/src/renderer/src/features/settings/SettingsView.tsx
@@ -16,6 +16,7 @@ import AccountSection from "./sections/AccountSection";
 import AppearanceSection from "./sections/AppearanceSection";
 import RuntimeSection from "./sections/RuntimeSection";
 import AgentSection from "./sections/AgentSection";
+import IdentityPersonalitySection from "./sections/IdentityPersonalitySection";
 import BillingSection from "./sections/BillingSection";
 import IntegrationsSettingsSection from "../integrations/IntegrationsSettingsSection";
 import CliSection from "../plugins/CliSection";
@@ -31,8 +32,8 @@ export type SettingsSectionId =
   | "appearance"
   | "billing"
   | "runtime"
-  | "agent"
-  | "providers"
+  | "agents-providers"
+  | "identity-personality"
   | "services"
   | "mcps"
   | "skills"
@@ -48,8 +49,8 @@ const SECTIONS: { id: SettingsSectionId; label: string; icon: React.ReactNode; g
   { id: "mcps", label: "MCPs", icon: <Server size={15} />, group: "Integrations" },
   { id: "skills", label: "Skills", icon: <Sparkles size={15} />, group: "Integrations" },
   { id: "cli", label: "CLI", icon: <SquareTerminal size={15} />, group: "Integrations" },
-  { id: "agent", label: "Agent (Hermes)", icon: <Sparkles size={15} />, group: "Machine" },
-  { id: "providers", label: "Providers", icon: <Bot size={15} />, group: "Machine" },
+  { id: "agents-providers", label: "Agents & providers", icon: <Bot size={15} />, group: "Machine" },
+  { id: "identity-personality", label: "Identity & personality", icon: <Sparkles size={15} />, group: "Machine" },
   { id: "runtime", label: "Computers", icon: <Server size={15} />, group: "Machine" },
   { id: "cron", label: "Schedules", icon: <Clock size={15} />, group: "Machine" },
   { id: "system", label: "System", icon: <Cpu size={15} />, group: "Machine" },
@@ -63,6 +64,20 @@ const SECTION_GROUPS = Object.keys(SECTIONS_BY_GROUP);
 
 export function isSettingsSectionId(value: string): value is SettingsSectionId {
   return SECTIONS.some((candidate) => candidate.id === value);
+}
+
+export function resolveSettingsSectionId(value: string): SettingsSectionId | null {
+  if (value === "agent" || value === "providers") return "agents-providers";
+  return isSettingsSectionId(value) ? value : null;
+}
+
+function AgentsProvidersAdapter() {
+  return (
+    <div data-settings-adapter="agents-providers-legacy">
+      <AgentSection />
+      <ProvidersSection />
+    </div>
+  );
 }
 
 export function SettingsSidebar({
@@ -125,7 +140,8 @@ export default function SettingsView({
   useEffect(() => {
     if (!requestedSection) return;
     if (controlledSection !== undefined) return;
-    if (isSettingsSectionId(requestedSection)) setLocalSection(requestedSection);
+    const resolvedSection = resolveSettingsSectionId(requestedSection);
+    if (resolvedSection) setLocalSection(resolvedSection);
     useUi.getState().clearRequestedSettingsSection();
   }, [controlledSection, requestedSection]);
 
@@ -140,8 +156,8 @@ export default function SettingsView({
           {section === "billing" ? <BillingSection /> : null}
           {section === "appearance" ? <AppearanceSection /> : null}
           {section === "runtime" ? <RuntimeSection /> : null}
-          {section === "agent" ? <AgentSection /> : null}
-          {section === "providers" ? <ProvidersSection /> : null}
+          {section === "agents-providers" ? <AgentsProvidersAdapter /> : null}
+          {section === "identity-personality" ? <IdentityPersonalitySection /> : null}
           {section === "services" ? <IntegrationsSettingsSection /> : null}
           {section === "mcps" ? <McpServersSection /> : null}
           {section === "skills" ? <SkillsSection /> : null}

--- a/desktop/src/renderer/src/features/settings/provider-settings-desktop-adapter.ts
+++ b/desktop/src/renderer/src/features/settings/provider-settings-desktop-adapter.ts
@@ -1,0 +1,147 @@
+import {
+  ProviderConnectionAttemptActionSchema,
+  ProviderSettingsMutationResponseSchema,
+  ProviderSettingsMutationSchema,
+  ProviderSettingsSnapshotSchema,
+  type ProviderSettingsMutation,
+  type ProviderSettingsMutationResponse,
+  type ProviderSettingsSnapshot,
+} from "@matrix-os/contracts";
+import type {
+  ProviderSettingsTransport,
+  ProviderSettingsTransportErrorCode,
+} from "@matrix-os/ui";
+import { AppError } from "../../../../shared/app-error";
+import { buildGatewayUrl, type ApiClient } from "../../lib/api";
+import { invoke } from "../../lib/operator";
+import { isValidShellSessionName, useShellSessions } from "../../stores/shell-sessions";
+import { useTabs } from "../../stores/tabs";
+
+const PROVIDER_SETTINGS_PATH = "/api/ai/provider-settings";
+const PROVIDER_SETTINGS_ACTIONS_PATH = "/api/ai/provider-settings/actions";
+const MAX_RESPONSE_BYTES = 1024 * 1024;
+const MAX_MUTATION_BYTES = 64 * 1024;
+
+export function desktopProviderIdentityKey(identity: {
+  status: "loading" | "signed-out" | "signed-in";
+  handle: string | null;
+  platformHost: string;
+  runtimeSlot: string;
+  authGeneration: number;
+}): string {
+  return [
+    identity.status,
+    identity.handle ?? "none",
+    identity.platformHost,
+    identity.runtimeSlot,
+    identity.authGeneration,
+  ].join("|");
+}
+
+class DesktopProviderSettingsTransportError extends Error {
+  constructor(readonly code: ProviderSettingsTransportErrorCode) {
+    super("Provider settings are unavailable.");
+    this.name = "DesktopProviderSettingsTransportError";
+  }
+}
+
+function mapTransportError(error: unknown): DesktopProviderSettingsTransportError {
+  if (error instanceof DesktopProviderSettingsTransportError) return error;
+  if (error instanceof AppError) {
+    if (error.detail === "revision_conflict"
+      || error.detail === "idempotency_conflict"
+      || error.detail === "provider_settings_unavailable") {
+      return new DesktopProviderSettingsTransportError(error.detail);
+    }
+  }
+  return new DesktopProviderSettingsTransportError("unavailable");
+}
+
+export function createDesktopProviderSettingsTransport(api: ApiClient): ProviderSettingsTransport & {
+  getSnapshot(signal: AbortSignal): Promise<ProviderSettingsSnapshot>;
+  mutate(mutation: ProviderSettingsMutation, signal: AbortSignal): Promise<ProviderSettingsMutationResponse>;
+} {
+  return {
+    async getSnapshot(signal) {
+      try {
+        const value = await api.get<unknown>(PROVIDER_SETTINGS_PATH, {
+          maxBytes: MAX_RESPONSE_BYTES,
+          signal,
+        });
+        const parsed = ProviderSettingsSnapshotSchema.safeParse(value);
+        if (!parsed.success) throw new DesktopProviderSettingsTransportError("invalid_response");
+        return parsed.data;
+      } catch (error) {
+        throw mapTransportError(error);
+      }
+    },
+    async mutate(input, signal) {
+      const mutation = ProviderSettingsMutationSchema.safeParse(input);
+      if (!mutation.success) throw new DesktopProviderSettingsTransportError("invalid_request");
+      const encoded = new TextEncoder().encode(JSON.stringify(mutation.data));
+      if (encoded.byteLength > MAX_MUTATION_BYTES) {
+        throw new DesktopProviderSettingsTransportError("invalid_request");
+      }
+      try {
+        const value = await api.post<unknown>(PROVIDER_SETTINGS_ACTIONS_PATH, mutation.data, {
+          maxBytes: MAX_RESPONSE_BYTES,
+          signal,
+        });
+        const parsed = ProviderSettingsMutationResponseSchema.safeParse(value);
+        if (!parsed.success) throw new DesktopProviderSettingsTransportError("invalid_response");
+        return parsed.data;
+      } catch (error) {
+        throw mapTransportError(error);
+      }
+    },
+  };
+}
+
+export async function openExistingProviderTerminalSession(
+  api: ApiClient,
+  terminalSessionId: string,
+  isIdentityCurrent: () => boolean = () => true,
+): Promise<boolean> {
+  if (!isValidShellSessionName(terminalSessionId)) return false;
+  const sessions = await useShellSessions.getState().load(api);
+  if (!isIdentityCurrent()) return false;
+  const exists = sessions?.some((session) => (
+    session.name === terminalSessionId && session.status === "active"
+  )) ?? false;
+  if (!exists) return false;
+  useTabs.getState().openTab({ kind: "terminals", title: "Terminal" });
+  useTabs.getState().requestTerminalSession(terminalSessionId);
+  return true;
+}
+
+type OpenExternal = (url: string) => Promise<unknown>;
+
+export async function openProviderAuthorizationPath(input: {
+  authorizationPath: string;
+  platformHost: string;
+  runtimeSlot: string;
+  openExternal?: OpenExternal;
+}): Promise<boolean> {
+  const action = ProviderConnectionAttemptActionSchema.safeParse({
+    kind: "open_browser",
+    authorizationPath: input.authorizationPath,
+  });
+  if (!action.success || action.data.kind !== "open_browser") return false;
+  const url = buildGatewayUrl(input.platformHost, action.data.authorizationPath, input.runtimeSlot);
+  try {
+    if (new URL(url).protocol !== "https:") return false;
+  } catch {
+    return false;
+  }
+  try {
+    const openExternal = input.openExternal ?? ((target) => invoke("shell:open-external", { url: target }));
+    await openExternal(url);
+    return true;
+  } catch (error) {
+    console.error(
+      "[provider-settings] Could not open authorization page:",
+      error instanceof Error ? error.name : typeof error,
+    );
+    return false;
+  }
+}

--- a/desktop/src/renderer/src/features/settings/provider-settings-desktop-adapter.ts
+++ b/desktop/src/renderer/src/features/settings/provider-settings-desktop-adapter.ts
@@ -130,7 +130,8 @@ export async function openProviderAuthorizationPath(input: {
   const url = buildGatewayUrl(input.platformHost, action.data.authorizationPath, input.runtimeSlot);
   try {
     if (new URL(url).protocol !== "https:") return false;
-  } catch {
+  } catch (error) {
+    console.warn("[provider-settings] Invalid authorization URL:", error instanceof Error ? error.name : typeof error);
     return false;
   }
   try {

--- a/desktop/src/renderer/src/features/settings/sections/AgentSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/AgentSection.tsx
@@ -11,7 +11,6 @@ import { openProviderSetupTerminal, providerSetupCommands, type ProviderSetupCom
 import { Card, Empty, SettingsSectionHeader } from "./section-kit";
 import AgentRuntimeSettingsCard from "./AgentRuntimeSettingsCard";
 
-const SOUL_PATH = "/files/system/soul.md";
 const AGENT_PATH = "/api/settings/agent";
 const CREDENTIALS_PATH = "/api/agents/credentials/status";
 
@@ -88,107 +87,6 @@ function Segmented<T extends string>({
         );
       })}
     </div>
-  );
-}
-
-function SoulEditor() {
-  const api = useConnection((s) => s.api);
-  const [soul, setSoul] = useState("");
-  const [baseline, setBaseline] = useState("");
-  const [loaded, setLoaded] = useState(false);
-  const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
-  const [error, setError] = useState<string | null>(null);
-  const mountedRef = useRef(true);
-  const saveSeqRef = useRef(0);
-  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      mountedRef.current = false;
-      if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!api) return;
-    let cancelled = false;
-    api
-      .getText(SOUL_PATH)
-      .then((text) => {
-        if (cancelled) return;
-        setSoul(text);
-        setBaseline(text);
-        setLoaded(true);
-        setError(null);
-      })
-      .catch((err: unknown) => {
-        if (!cancelled) {
-          setLoaded(true);
-          setError(toUserMessage(err));
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [api]);
-
-  const dirty = soul !== baseline;
-  const save = async () => {
-    if (!api || !dirty) return;
-    const saveSeq = saveSeqRef.current + 1;
-    saveSeqRef.current = saveSeq;
-    const nextSoul = soul;
-    if (savedTimerRef.current) {
-      clearTimeout(savedTimerRef.current);
-      savedTimerRef.current = null;
-    }
-    setStatus("saving");
-    setError(null);
-    try {
-      await api.putText(SOUL_PATH, nextSoul);
-      if (!mountedRef.current || saveSeqRef.current !== saveSeq) return;
-      setBaseline(nextSoul);
-      setError(null);
-      setStatus("saved");
-      savedTimerRef.current = setTimeout(() => {
-        savedTimerRef.current = null;
-        if (mountedRef.current && saveSeqRef.current === saveSeq) setStatus("idle");
-      }, 1500);
-    } catch (err: unknown) {
-      if (!mountedRef.current || saveSeqRef.current !== saveSeq) return;
-      setError(toUserMessage(err));
-      setStatus("error");
-    }
-  };
-
-  return (
-    <Card>
-      <div className="flex items-center justify-between">
-        <span className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>SOUL · system/soul.md</span>
-        <div className="flex items-center gap-2">
-          {status === "saved" ? <span className="text-xs" style={{ color: "var(--success)" }}>Saved</span> : null}
-          <Button variant="primary" disabled={!dirty || status === "saving"} onClick={() => void save()}>
-            <Save size={13} />
-            {status === "saving" ? "Saving…" : "Save"}
-          </Button>
-        </div>
-      </div>
-      {!loaded ? (
-        <Empty text="Loading…" />
-      ) : (
-        <textarea
-          value={soul}
-          onChange={(e) => setSoul(e.target.value)}
-          spellCheck={false}
-          aria-label="SOUL system instructions"
-          className="min-h-[260px] w-full resize-y rounded-lg border bg-transparent p-3 font-mono text-xs leading-relaxed outline-none"
-          style={{ borderColor: "var(--border-default)", color: "var(--text-primary)", background: "var(--bg-sunken)" }}
-          placeholder="# SOUL&#10;&#10;You are Hermes, the Matrix OS agent…"
-          data-selectable
-        />
-      )}
-      {error ? <span className="text-xs" style={{ color: "var(--danger)" }}>{error}</span> : null}
-    </Card>
   );
 }
 
@@ -466,16 +364,15 @@ function RuntimeProvidersCard() {
 export default function AgentSection() {
   const runtimeScope = useConnection((state) => `${state.runtimeSlot}:${state.authGeneration}`);
   return (
-    <>
+    <div data-provider-settings-adapter="legacy">
       <SettingsSectionHeader
-        title="Agent"
-        description="Tune Matrix Chat, choose the runtime for messaging channels, authenticate providers, edit SOUL, and check which coding agents are connected."
+        title="Agents & providers"
+        description="Choose harnesses, models, and access sources, then authenticate the accounts they use."
       />
       <ModelEffortCard />
       <AgentRuntimeSettingsCard key={runtimeScope} />
       <RuntimeProvidersCard />
       <ProvidersCard />
-      <SoulEditor />
-    </>
+    </div>
   );
 }

--- a/desktop/src/renderer/src/features/settings/sections/IdentityPersonalitySection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/IdentityPersonalitySection.tsx
@@ -1,0 +1,121 @@
+import { Save } from "@renderer/lib/hugeicons";
+import { useEffect, useRef, useState } from "react";
+import { Button } from "../../../design/primitives";
+import { toUserMessage } from "../../../lib/errors";
+import { useConnection } from "../../../stores/connection";
+import { Card, Empty, SettingsSectionHeader } from "./section-kit";
+
+const SOUL_PATH = "/files/system/soul.md";
+
+function SoulEditor() {
+  const api = useConnection((state) => state.api);
+  const [soul, setSoul] = useState("");
+  const [baseline, setBaseline] = useState("");
+  const [loaded, setLoaded] = useState(false);
+  const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+  const saveSeqRef = useRef(0);
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!api) return;
+    let cancelled = false;
+    api
+      .getText(SOUL_PATH)
+      .then((text) => {
+        if (cancelled) return;
+        setSoul(text);
+        setBaseline(text);
+        setLoaded(true);
+        setError(null);
+      })
+      .catch((cause: unknown) => {
+        if (!cancelled) {
+          setLoaded(true);
+          setError(toUserMessage(cause));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api]);
+
+  const dirty = soul !== baseline;
+  const save = async () => {
+    if (!api || !dirty) return;
+    const saveSeq = saveSeqRef.current + 1;
+    saveSeqRef.current = saveSeq;
+    const nextSoul = soul;
+    if (savedTimerRef.current) {
+      clearTimeout(savedTimerRef.current);
+      savedTimerRef.current = null;
+    }
+    setStatus("saving");
+    setError(null);
+    try {
+      await api.putText(SOUL_PATH, nextSoul);
+      if (!mountedRef.current || saveSeqRef.current !== saveSeq) return;
+      setBaseline(nextSoul);
+      setError(null);
+      setStatus("saved");
+      savedTimerRef.current = setTimeout(() => {
+        savedTimerRef.current = null;
+        if (mountedRef.current && saveSeqRef.current === saveSeq) setStatus("idle");
+      }, 1500);
+    } catch (cause: unknown) {
+      if (!mountedRef.current || saveSeqRef.current !== saveSeq) return;
+      setError(toUserMessage(cause));
+      setStatus("error");
+    }
+  };
+
+  return (
+    <Card>
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>SOUL · system/soul.md</span>
+        <div className="flex items-center gap-2">
+          {status === "saved" ? <span className="text-xs" style={{ color: "var(--success)" }}>Saved</span> : null}
+          <Button variant="primary" disabled={!dirty || status === "saving"} onClick={() => void save()}>
+            <Save size={13} />
+            {status === "saving" ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </div>
+      {!loaded ? (
+        <Empty text="Loading…" />
+      ) : (
+        <textarea
+          value={soul}
+          onChange={(event) => setSoul(event.target.value)}
+          spellCheck={false}
+          aria-label="SOUL system instructions"
+          className="min-h-[260px] w-full resize-y rounded-lg border bg-transparent p-3 font-mono text-xs leading-relaxed outline-none"
+          style={{ borderColor: "var(--border-default)", color: "var(--text-primary)", background: "var(--bg-sunken)" }}
+          placeholder="# SOUL&#10;&#10;You are Hermes, the Matrix OS agent…"
+          data-selectable
+        />
+      )}
+      {error ? <span className="text-xs" style={{ color: "var(--danger)" }}>{error}</span> : null}
+    </Card>
+  );
+}
+
+export default function IdentityPersonalitySection() {
+  return (
+    <>
+      <SettingsSectionHeader
+        title="Identity & personality"
+        description="Define the identity, tone, and boundaries Matrix uses when it works with you."
+      />
+      <SoulEditor />
+    </>
+  );
+}

--- a/desktop/src/renderer/src/lib/api.ts
+++ b/desktop/src/renderer/src/lib/api.ts
@@ -35,21 +35,26 @@ export interface BoundedReadOptions {
 export interface RequestTimeoutOptions {
   /** Internal operation-specific timeout. Every request remains bounded. */
   timeoutMs?: number;
-  /** Cancellation propagated from the owning UI lifecycle. */
+  /** Caller lifecycle cancellation, always composed with the internal timeout. */
   signal?: AbortSignal;
 }
 
+export interface JsonRequestOptions extends RequestTimeoutOptions {
+  /** Hard cap on JSON response bytes before parsing. */
+  maxBytes?: number;
+}
+
 export interface ApiClient {
-  get<T>(path: string, options?: RequestTimeoutOptions): Promise<T>;
+  get<T>(path: string, options?: JsonRequestOptions): Promise<T>;
   getText(path: string, options?: BoundedReadOptions): Promise<string>;
   getBlob(path: string, options?: BoundedReadOptions): Promise<Blob>;
-  post<T>(path: string, body: unknown, options?: RequestTimeoutOptions): Promise<T>;
+  post<T>(path: string, body: unknown, options?: JsonRequestOptions): Promise<T>;
   postBytes<T>(path: string, body: Blob, headers: Record<string, string>, options?: RequestTimeoutOptions): Promise<T>;
-  patch<T>(path: string, body: unknown, options?: RequestTimeoutOptions): Promise<T>;
-  put<T>(path: string, body: unknown, options?: RequestTimeoutOptions): Promise<T>;
+  patch<T>(path: string, body: unknown, options?: JsonRequestOptions): Promise<T>;
+  put<T>(path: string, body: unknown, options?: JsonRequestOptions): Promise<T>;
   putBytes<T>(path: string, body: Blob, headers: Record<string, string>, options?: RequestTimeoutOptions): Promise<T>;
-  delete<T>(path: string, options?: RequestTimeoutOptions): Promise<T>;
-  putText<T>(path: string, body: string, options?: RequestTimeoutOptions): Promise<T>;
+  delete<T>(path: string, options?: JsonRequestOptions): Promise<T>;
+  putText<T>(path: string, body: string, options?: JsonRequestOptions): Promise<T>;
   /** Returns a client whose requests remain bound to one runtime slot. */
   forRuntime(runtimeSlot: string): ApiClient;
   baseUrl: string;
@@ -69,11 +74,15 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
     requestOptions?: RequestTimeoutOptions,
   ): Promise<Response> {
     const url = buildGatewayUrl(options.baseUrl, path, options.getRuntimeSlot());
+    const initSignal = init.signal ?? undefined;
+    const callerSignal = initSignal && requestOptions?.signal
+      ? AbortSignal.any([initSignal, requestOptions.signal])
+      : initSignal ?? requestOptions?.signal;
     let response: Response;
     try {
       response = await fetchFn(url, {
         ...init,
-        signal: signalWithTimeout(requestOptions?.signal, requestOptions?.timeoutMs ?? API_TIMEOUT_MS),
+        signal: signalWithTimeout(callerSignal, requestOptions?.timeoutMs ?? API_TIMEOUT_MS),
       });
     } catch (err: unknown) {
       throw new AppError(classifyTransportError(err), { cause: err });
@@ -95,9 +104,15 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
     return response;
   }
 
-  async function request<T>(path: string, init: RequestInit, options?: RequestTimeoutOptions): Promise<T> {
+  async function request<T>(path: string, init: RequestInit, options?: JsonRequestOptions): Promise<T> {
     const response = await send(path, init, options);
     try {
+      if (options?.maxBytes !== undefined) {
+        const chunks = await readBoundedBytes(response, options.maxBytes);
+        const decoder = new TextDecoder();
+        const text = chunks.map((chunk) => decoder.decode(chunk, { stream: true })).join("") + decoder.decode();
+        return JSON.parse(text) as T;
+      }
       return (await response.json()) as T;
     } catch (err: unknown) {
       throw new AppError("server", { cause: err });

--- a/desktop/src/renderer/src/stores/ui.ts
+++ b/desktop/src/renderer/src/stores/ui.ts
@@ -2,6 +2,10 @@
 // store; this only tracks ephemeral open/closed flags.
 import { create } from "zustand";
 
+function normalizeRequestedSettingsSection(section: string): string {
+  return section === "agent" || section === "providers" ? "agents-providers" : section;
+}
+
 interface UiState {
   createProjectOpen: boolean;
   composerOpen: boolean;
@@ -59,6 +63,8 @@ export const useUi = create<UiState>()((set) => ({
   requestDesktopBackgroundRefresh: () => set((state) => ({
     desktopBackgroundRefreshRequest: (state.desktopBackgroundRefreshRequest + 1) % 1_000_000,
   })),
-  requestSettingsSection: (section) => set({ requestedSettingsSection: section }),
+  requestSettingsSection: (section) => set({
+    requestedSettingsSection: normalizeRequestedSettingsSection(section),
+  }),
   clearRequestedSettingsSection: () => set({ requestedSettingsSection: null }),
 }));

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,11 @@
   "types": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./styles.css": "./src/styles.css"
+    "./styles.css": "./src/styles.css",
+    "./agents-providers.css": "./src/agents-providers/agents-providers.css"
+  },
+  "dependencies": {
+    "@matrix-os/contracts": "workspace:*"
   },
   "peerDependencies": {
     "react": "^19.0.0",

--- a/packages/ui/src/Tooltip.tsx
+++ b/packages/ui/src/Tooltip.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, type HTMLAttributes, type ReactNode } from "react";
 import { cn } from "./cn.js";
 
-export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
+export interface TooltipProps extends Omit<HTMLAttributes<HTMLDivElement>, "content"> {
   content: ReactNode;
   children: ReactNode;
   position?: "top" | "bottom" | "left" | "right";
@@ -40,14 +40,15 @@ export function Tooltip({
   ...rest
 }: TooltipProps) {
   const [visible, setVisible] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const show = () => {
     timerRef.current = setTimeout(() => setVisible(true), delay);
   };
 
   const hide = () => {
-    clearTimeout(timerRef.current);
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+    timerRef.current = null;
     setVisible(false);
   };
 

--- a/packages/ui/src/agents-providers/AccountsPanel.tsx
+++ b/packages/ui/src/agents-providers/AccountsPanel.tsx
@@ -3,6 +3,7 @@ import type {
   ProviderAccount,
   ProviderAccessSource,
   ProviderConnectionAttempt,
+  ProviderGatewayPolicy,
   ProviderHarnessInstance,
 } from "@matrix-os/contracts";
 import { RemovalDialog } from "./RemovalDialog.js";
@@ -35,6 +36,8 @@ export function AccountsPanel({
   harness,
   accounts,
   sources,
+  allHarnesses,
+  gatewayPolicy,
   attempt,
   disabled,
   canLogin,
@@ -48,6 +51,8 @@ export function AccountsPanel({
   harness: ProviderHarnessInstance;
   accounts: ProviderAccount[];
   sources: ProviderAccessSource[];
+  allHarnesses: ProviderHarnessInstance[];
+  gatewayPolicy: ProviderGatewayPolicy | null;
   attempt: ProviderConnectionAttempt | null;
   disabled: boolean;
   canLogin: boolean;
@@ -169,6 +174,8 @@ export function AccountsPanel({
           account={removeAccount}
           accounts={accounts}
           sources={sources.filter((source) => source.providerId === removeAccount.providerId)}
+          harnesses={allHarnesses}
+          gatewayPolicy={gatewayPolicy}
           disabled={disabled}
           canRemove={canRemove}
           canReassign={canReassign}

--- a/packages/ui/src/agents-providers/AccountsPanel.tsx
+++ b/packages/ui/src/agents-providers/AccountsPanel.tsx
@@ -1,0 +1,181 @@
+import { useState } from "react";
+import type {
+  ProviderAccount,
+  ProviderAccessSource,
+  ProviderConnectionAttempt,
+  ProviderHarnessInstance,
+} from "@matrix-os/contracts";
+import { RemovalDialog } from "./RemovalDialog.js";
+import type { ProviderSettingsMutationIntent } from "./types.js";
+import { authLabel, titleCase, usageLines } from "./utils.js";
+
+function AttemptAction({
+  attempt,
+  onOpenTerminal,
+  onOpenBrowser,
+}: {
+  attempt: ProviderConnectionAttempt;
+  onOpenTerminal: (sessionId: string) => void;
+  onOpenBrowser: (path: string) => void;
+}) {
+  const action = attempt.action;
+  if (action.kind === "open_terminal") {
+    return <button type="button" className="matrix-ap-button matrix-ap-button-primary" onClick={() => onOpenTerminal(action.terminalSessionId)}>Continue in Terminal</button>;
+  }
+  if (action.kind === "open_browser") {
+    return <button type="button" className="matrix-ap-button matrix-ap-button-primary" onClick={() => onOpenBrowser(action.authorizationPath)}>Continue in browser</button>;
+  }
+  if (action.kind === "enter_api_key") return <span className="matrix-ap-help">Continue in the secure credential prompt.</span>;
+  if (action.kind === "wait") return <span className="matrix-ap-help">Waiting for authentication…</span>;
+  if (action.kind === "retry") return <span className="matrix-ap-help">Authentication needs to be retried.</span>;
+  return null;
+}
+
+export function AccountsPanel({
+  harness,
+  accounts,
+  sources,
+  attempt,
+  disabled,
+  canLogin,
+  canLogout,
+  canRemove,
+  canReassign,
+  onMutate,
+  onOpenTerminal,
+  onOpenBrowser,
+}: {
+  harness: ProviderHarnessInstance;
+  accounts: ProviderAccount[];
+  sources: ProviderAccessSource[];
+  attempt: ProviderConnectionAttempt | null;
+  disabled: boolean;
+  canLogin: boolean;
+  canLogout: boolean;
+  canRemove: boolean;
+  canReassign: boolean;
+  onMutate: (intent: ProviderSettingsMutationIntent) => void;
+  onOpenTerminal: (sessionId: string) => void;
+  onOpenBrowser: (path: string) => void;
+}) {
+  const [removeAccount, setRemoveAccount] = useState<ProviderAccount | null>(null);
+  const [showLoginMethods, setShowLoginMethods] = useState(false);
+
+  return (
+    <section className="matrix-ap-panel" aria-labelledby="matrix-ap-accounts-title">
+      <div className="matrix-ap-panel-head">
+        <div>
+          <span className="matrix-ap-eyebrow">Authentication</span>
+          <h3 id="matrix-ap-accounts-title">Accounts</h3>
+        </div>
+        <button
+          type="button"
+          className="matrix-ap-button"
+          disabled={disabled || !canLogin}
+          onClick={() => setShowLoginMethods((open) => !open)}
+          title={canLogin ? undefined : "Adding accounts is not available"}
+        >
+          + Add account
+        </button>
+      </div>
+
+      {showLoginMethods ? (
+        <div className="matrix-ap-login-methods" aria-label="Login methods">
+          {harness.loginMethods.map((method) => (
+            <button
+              type="button"
+              className="matrix-ap-button"
+              key={method}
+              onClick={() => {
+                onMutate({ type: "start_login", harnessInstanceId: harness.id, accountId: null, method });
+                setShowLoginMethods(false);
+              }}
+            >
+              {method === harness.recommendedLoginMethod ? "Recommended · " : ""}{titleCase(method)}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {attempt ? (
+        <div className="matrix-ap-attempt" role="status">
+          <span>Authentication {titleCase(attempt.state).toLowerCase()}</span>
+          <AttemptAction attempt={attempt} onOpenTerminal={onOpenTerminal} onOpenBrowser={onOpenBrowser} />
+        </div>
+      ) : null}
+
+      <div className="matrix-ap-account-list">
+        {accounts.length === 0 ? (
+          <p className="matrix-ap-empty">No provider accounts yet. Matrix gateway can still fund eligible models.</p>
+        ) : accounts.map((account) => {
+          const source = sources.find((candidate) => candidate.id === account.accessSourceId);
+          const usage = source ? usageLines(source.usage) : null;
+          const selected = harness.selectedAccountId === account.id;
+          return (
+            <article className="matrix-ap-account" key={account.id} data-testid={`account-${account.id}`}>
+              <div className="matrix-ap-account-main">
+                <span className="matrix-ap-avatar" aria-hidden="true">{account.displayName.slice(0, 1).toUpperCase()}</span>
+                <div>
+                  <strong>{account.displayName}</strong>
+                  <span>{authLabel(account.authState)} · {titleCase(account.authMethod)}</span>
+                </div>
+                {selected ? <span className="matrix-ap-selected-tag">Selected</span> : null}
+              </div>
+              <div className="matrix-ap-account-usage">
+                <strong>{usage?.primary ?? "Usage unavailable"}</strong>
+                {usage?.secondary ? <span>{usage.secondary}</span> : null}
+                {usage?.stale ? <span>Stale</span> : null}
+              </div>
+              <div className="matrix-ap-account-actions">
+                {account.authState === "authenticated" ? (
+                  <button
+                    type="button"
+                    className="matrix-ap-link-button"
+                    disabled={disabled || !canLogout}
+                    onClick={() => onMutate({ type: "logout_account", accountId: account.id })}
+                    aria-label={`Log out ${account.displayName}`}
+                    title={canLogout ? undefined : "Logout is not available"}
+                  >Log out</button>
+                ) : (
+                  <button
+                    type="button"
+                    className="matrix-ap-link-button"
+                    disabled={disabled || !canLogin}
+                    onClick={() => onMutate({ type: "start_login", harnessInstanceId: harness.id, accountId: account.id, method: account.authMethod })}
+                    aria-label={`Log in ${account.displayName}`}
+                    title={canLogin ? undefined : "Login is not available"}
+                  >Log in</button>
+                )}
+                <button
+                  type="button"
+                  className="matrix-ap-link-button matrix-ap-danger-text"
+                  disabled={disabled || (!canRemove && !canReassign)}
+                  onClick={() => setRemoveAccount(account)}
+                  aria-label={`Remove ${account.displayName}`}
+                  title={canRemove || canReassign ? undefined : "Account removal is not available"}
+                >Remove</button>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+
+      {!canLogin || !canLogout || (!canRemove && !canReassign) ? (
+        <p className="matrix-ap-help">Some account actions are unavailable in this runtime.</p>
+      ) : null}
+
+      {removeAccount ? (
+        <RemovalDialog
+          account={removeAccount}
+          accounts={accounts}
+          sources={sources.filter((source) => source.providerId === removeAccount.providerId)}
+          disabled={disabled}
+          canRemove={canRemove}
+          canReassign={canReassign}
+          onMutate={onMutate}
+          onClose={() => setRemoveAccount(null)}
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/packages/ui/src/agents-providers/AddHarnessDialog.tsx
+++ b/packages/ui/src/agents-providers/AddHarnessDialog.tsx
@@ -1,0 +1,145 @@
+import { useMemo, useState } from "react";
+import type { ProviderHarnessKind, ProviderSettingsSnapshot } from "@matrix-os/contracts";
+import { FeatureDialog } from "./FeatureDialog.js";
+import type { ProviderSettingsMutationIntent } from "./types.js";
+
+const HARNESS_CATALOG: ReadonlyArray<{
+  id: ProviderHarnessKind;
+  label: string;
+  routeKind: "configurable" | "fixed";
+  preferredProvider: string | null;
+}> = [
+  { id: "hermes", label: "Hermes", routeKind: "configurable", preferredProvider: null },
+  { id: "openclaw", label: "OpenClaw", routeKind: "configurable", preferredProvider: null },
+  { id: "pi", label: "Pi", routeKind: "configurable", preferredProvider: null },
+  { id: "opencode", label: "OpenCode", routeKind: "configurable", preferredProvider: null },
+  { id: "codex", label: "Codex", routeKind: "fixed", preferredProvider: "openai" },
+  { id: "claude", label: "Claude", routeKind: "fixed", preferredProvider: "anthropic" },
+];
+
+export function AddHarnessDialog({
+  snapshot,
+  onMutate,
+  onClose,
+}: {
+  snapshot: ProviderSettingsSnapshot;
+  onMutate: (intent: ProviderSettingsMutationIntent) => void;
+  onClose: () => void;
+}) {
+  const existing = new Set(snapshot.harnesses.map((harness) => harness.harness));
+  const firstAvailable = HARNESS_CATALOG.find((entry) => !existing.has(entry.id)) ?? HARNESS_CATALOG[0]!;
+  const [kind, setKind] = useState<ProviderHarnessKind>(firstAvailable.id);
+  const selectedCatalog = HARNESS_CATALOG.find((entry) => entry.id === kind) ?? firstAvailable;
+  const defaultProvider = snapshot.modelProviders.find((provider) => provider.id === selectedCatalog.preferredProvider)
+    ?? snapshot.modelProviders[0]
+    ?? null;
+  const [displayName, setDisplayName] = useState(selectedCatalog.label);
+  const [providerId, setProviderId] = useState(defaultProvider?.id ?? "");
+  const provider = snapshot.modelProviders.find((candidate) => candidate.id === providerId) ?? defaultProvider;
+  const firstModel = provider?.models.find((model) => model.enabled) ?? null;
+  const [modelId, setModelId] = useState(firstModel?.id ?? "");
+  const eligibleSources = useMemo(() => snapshot.accessSources.filter((source) =>
+    source.providerId === providerId && source.eligibleModelIds.includes(modelId)), [modelId, providerId, snapshot.accessSources]);
+  const [sourceId, setSourceId] = useState(eligibleSources[0]?.id ?? "");
+  const selectedSource = eligibleSources.find((source) => source.id === sourceId) ?? eligibleSources[0] ?? null;
+  const canAdd = displayName.trim() !== "" && provider !== null && modelId !== "" && selectedSource !== null;
+
+  const selectKind = (nextKind: ProviderHarnessKind) => {
+    const catalog = HARNESS_CATALOG.find((entry) => entry.id === nextKind) ?? HARNESS_CATALOG[0]!;
+    const nextProvider = snapshot.modelProviders.find((candidate) => candidate.id === catalog.preferredProvider)
+      ?? snapshot.modelProviders[0]
+      ?? null;
+    const nextModel = nextProvider?.models.find((model) => model.enabled) ?? null;
+    const nextSource = snapshot.accessSources.find((source) => source.providerId === nextProvider?.id
+      && nextModel !== null && source.eligibleModelIds.includes(nextModel.id));
+    setKind(nextKind);
+    setDisplayName(catalog.label);
+    setProviderId(nextProvider?.id ?? "");
+    setModelId(nextModel?.id ?? "");
+    setSourceId(nextSource?.id ?? "");
+  };
+
+  const selectProvider = (nextProviderId: string) => {
+    const nextProvider = snapshot.modelProviders.find((candidate) => candidate.id === nextProviderId) ?? null;
+    const nextModel = nextProvider?.models.find((model) => model.enabled) ?? null;
+    const nextSource = snapshot.accessSources.find((source) => source.providerId === nextProviderId
+      && nextModel !== null && source.eligibleModelIds.includes(nextModel.id));
+    setProviderId(nextProviderId);
+    setModelId(nextModel?.id ?? "");
+    setSourceId(nextSource?.id ?? "");
+  };
+
+  const selectModel = (nextModelId: string) => {
+    const nextSource = snapshot.accessSources.find((source) => source.providerId === providerId
+      && source.eligibleModelIds.includes(nextModelId));
+    setModelId(nextModelId);
+    setSourceId(nextSource?.id ?? "");
+  };
+
+  const add = () => {
+    if (!canAdd || selectedSource === null) return;
+    onMutate({
+      type: "add_harness",
+      harness: kind,
+      displayName: displayName.trim(),
+      route: {
+        kind: selectedCatalog.routeKind,
+        providerId,
+        modelId,
+      },
+      accessSourceId: selectedSource.id,
+      accountId: selectedSource.accountId,
+    });
+    onClose();
+  };
+
+  return (
+    <FeatureDialog title="Add harness" onClose={onClose}>
+      <div className="matrix-ap-driver-grid">
+        {HARNESS_CATALOG.map((entry) => (
+          <label key={entry.id} data-selected={entry.id === kind ? "true" : undefined} data-installed={existing.has(entry.id) ? "true" : undefined}>
+            <input
+              type="radio"
+              name="harness-kind"
+              value={entry.id}
+              checked={entry.id === kind}
+              disabled={existing.has(entry.id)}
+              onChange={() => selectKind(entry.id)}
+            />
+            <span>{entry.label}</span>
+            {existing.has(entry.id) ? <small>Added</small> : null}
+          </label>
+        ))}
+      </div>
+      <label className="matrix-ap-field">
+        <span>Display name</span>
+        <input value={displayName} onChange={(event) => setDisplayName(event.target.value)} maxLength={120} />
+      </label>
+      <div className="matrix-ap-form-grid">
+        <label className="matrix-ap-field">
+          <span>Model provider</span>
+          <select value={providerId} onChange={(event) => selectProvider(event.target.value)} disabled={selectedCatalog.routeKind === "fixed"}>
+            {snapshot.modelProviders.map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.displayName}</option>)}
+          </select>
+        </label>
+        <label className="matrix-ap-field">
+          <span>Model</span>
+          <select value={modelId} onChange={(event) => selectModel(event.target.value)} disabled={selectedCatalog.routeKind === "fixed"}>
+            {provider?.models.filter((model) => model.enabled).map((model) => <option key={model.id} value={model.id}>{model.displayName}</option>)}
+          </select>
+        </label>
+      </div>
+      <label className="matrix-ap-field">
+        <span>Access source</span>
+        <select value={selectedSource?.id ?? ""} onChange={(event) => setSourceId(event.target.value)}>
+          {eligibleSources.map((source) => <option key={source.id} value={source.id}>{source.displayName}</option>)}
+        </select>
+      </label>
+      <p className="matrix-ap-help">Authentication opens in a visible Terminal, browser, or secure credential prompt after the harness is added.</p>
+      <div className="matrix-ap-dialog-actions">
+        <button type="button" className="matrix-ap-button" onClick={onClose}>Cancel</button>
+        <button type="button" className="matrix-ap-button matrix-ap-button-primary" disabled={!canAdd} onClick={add}>Add harness</button>
+      </div>
+    </FeatureDialog>
+  );
+}

--- a/packages/ui/src/agents-providers/AddHarnessDialog.tsx
+++ b/packages/ui/src/agents-providers/AddHarnessDialog.tsx
@@ -17,6 +17,18 @@ const HARNESS_CATALOG: ReadonlyArray<{
   { id: "claude", label: "Claude", routeKind: "fixed", preferredProvider: "anthropic" },
 ];
 
+function sourceSupportsRoute(
+  snapshot: ProviderSettingsSnapshot,
+  source: ProviderSettingsSnapshot["accessSources"][number],
+  providerId: string,
+  modelId: string,
+): boolean {
+  if (source.providerId !== providerId || !source.eligibleModelIds.includes(modelId)) return false;
+  if (source.kind !== "matrix_gateway") return true;
+  return snapshot.gatewayPolicy?.accessSourceId === source.id
+    && snapshot.gatewayPolicy.allowedModelIds.includes(modelId);
+}
+
 export function AddHarnessDialog({
   snapshot,
   onMutate,
@@ -39,7 +51,7 @@ export function AddHarnessDialog({
   const firstModel = provider?.models.find((model) => model.enabled) ?? null;
   const [modelId, setModelId] = useState(firstModel?.id ?? "");
   const eligibleSources = useMemo(() => snapshot.accessSources.filter((source) =>
-    source.providerId === providerId && source.eligibleModelIds.includes(modelId)), [modelId, providerId, snapshot.accessSources]);
+    sourceSupportsRoute(snapshot, source, providerId, modelId)), [modelId, providerId, snapshot]);
   const [sourceId, setSourceId] = useState(eligibleSources[0]?.id ?? "");
   const selectedSource = eligibleSources.find((source) => source.id === sourceId) ?? eligibleSources[0] ?? null;
   const canAdd = displayName.trim() !== "" && provider !== null && modelId !== "" && selectedSource !== null;
@@ -50,8 +62,8 @@ export function AddHarnessDialog({
       ?? snapshot.modelProviders[0]
       ?? null;
     const nextModel = nextProvider?.models.find((model) => model.enabled) ?? null;
-    const nextSource = snapshot.accessSources.find((source) => source.providerId === nextProvider?.id
-      && nextModel !== null && source.eligibleModelIds.includes(nextModel.id));
+    const nextSource = nextModel === null ? undefined : snapshot.accessSources.find((source) =>
+      sourceSupportsRoute(snapshot, source, nextProvider?.id ?? "", nextModel.id));
     setKind(nextKind);
     setDisplayName(catalog.label);
     setProviderId(nextProvider?.id ?? "");
@@ -62,16 +74,16 @@ export function AddHarnessDialog({
   const selectProvider = (nextProviderId: string) => {
     const nextProvider = snapshot.modelProviders.find((candidate) => candidate.id === nextProviderId) ?? null;
     const nextModel = nextProvider?.models.find((model) => model.enabled) ?? null;
-    const nextSource = snapshot.accessSources.find((source) => source.providerId === nextProviderId
-      && nextModel !== null && source.eligibleModelIds.includes(nextModel.id));
+    const nextSource = nextModel === null ? undefined : snapshot.accessSources.find((source) =>
+      sourceSupportsRoute(snapshot, source, nextProviderId, nextModel.id));
     setProviderId(nextProviderId);
     setModelId(nextModel?.id ?? "");
     setSourceId(nextSource?.id ?? "");
   };
 
   const selectModel = (nextModelId: string) => {
-    const nextSource = snapshot.accessSources.find((source) => source.providerId === providerId
-      && source.eligibleModelIds.includes(nextModelId));
+    const nextSource = snapshot.accessSources.find((source) =>
+      sourceSupportsRoute(snapshot, source, providerId, nextModelId));
     setModelId(nextModelId);
     setSourceId(nextSource?.id ?? "");
   };

--- a/packages/ui/src/agents-providers/AgentsProvidersView.tsx
+++ b/packages/ui/src/agents-providers/AgentsProvidersView.tsx
@@ -1,0 +1,140 @@
+import { useState } from "react";
+import type { ProviderSettingsSnapshot } from "@matrix-os/contracts";
+import { AccountsPanel } from "./AccountsPanel.js";
+import { AddHarnessDialog } from "./AddHarnessDialog.js";
+import { GatewayPanel } from "./GatewayPanel.js";
+import { HarnessEditor } from "./HarnessEditor.js";
+import { HarnessRail } from "./HarnessRail.js";
+import type { AgentsProvidersViewProps, ProviderSettingsMutationIntent } from "./types.js";
+import { relativeCheckedAt, selectedHarness, titleCase } from "./utils.js";
+
+export type { AgentsProvidersViewProps, ProviderSettingsMutationIntent } from "./types.js";
+
+type SupportedAction = ProviderSettingsMutationIntent["type"] | "add_credit" | "submit_api_key";
+
+function supportedActions(snapshot: ProviderSettingsSnapshot): readonly SupportedAction[] {
+  return (snapshot as ProviderSettingsSnapshot & { supportedActions?: readonly SupportedAction[] }).supportedActions ?? [];
+}
+
+export function AgentsProvidersView({
+  snapshot,
+  selectedHarnessId,
+  connectionAttempt = null,
+  busy = false,
+  error = null,
+  onSelectHarness,
+  onRefresh,
+  onMutate,
+  onOpenTerminal,
+  onOpenBrowser,
+  onAddCredit,
+}: AgentsProvidersViewProps) {
+  const [addOpen, setAddOpen] = useState(false);
+  const harness = selectedHarness(snapshot, selectedHarnessId);
+  const actions = supportedActions(snapshot);
+  const supports = (action: SupportedAction) => actions.includes(action);
+  const readOnly = snapshot.access.mode === "read_only";
+  const mutationsDisabled = busy || readOnly;
+  const selectedId = harness?.id ?? null;
+  const gatewaySource = snapshot.gatewayPolicy === null
+    ? snapshot.accessSources.find((source) => source.kind === "matrix_gateway") ?? null
+    : snapshot.accessSources.find((source) => source.id === snapshot.gatewayPolicy?.accessSourceId) ?? null;
+  const gatewayProvider = gatewaySource === null
+    ? null
+    : snapshot.modelProviders.find((provider) => provider.id === gatewaySource.providerId) ?? null;
+
+  return (
+    <div className="matrix-agents-providers" aria-busy={busy ? "true" : undefined}>
+      <header className="matrix-ap-page-head">
+        <div>
+          <span className="matrix-ap-eyebrow">Settings</span>
+          <h1>Agents &amp; providers</h1>
+          <p>Choose which harness runs a task, which model it uses, and who funds the route.</p>
+        </div>
+        <div className="matrix-ap-refresh">
+          <span>Checked {relativeCheckedAt(snapshot.refreshedAt)}</span>
+          <button type="button" className="matrix-ap-icon-button" aria-label="Refresh provider status" onClick={onRefresh} disabled={busy}>↻</button>
+        </div>
+      </header>
+
+      {snapshot.access.mode === "read_only" ? (
+        <div className="matrix-ap-notice" data-tone="neutral" role="status">
+          <strong>Read only</strong>
+          <span>{snapshot.access.reason === "remote_policy" ? "Your organization controls these settings." : `Changes are unavailable: ${titleCase(snapshot.access.reason).toLowerCase()}.`}</span>
+        </div>
+      ) : null}
+      {error ? (
+        <div className="matrix-ap-notice" data-tone="danger" role="alert">
+          <strong>Settings could not be updated</strong>
+          <span>Changes were not saved. Refresh and try again.</span>
+        </div>
+      ) : null}
+
+      <div className="matrix-ap-workspace">
+        <HarnessRail
+          harnesses={snapshot.harnesses}
+          selectedId={selectedId}
+          disabled={mutationsDisabled}
+          canAdd={supports("add_harness")}
+          onSelect={onSelectHarness}
+          onAdd={() => setAddOpen(true)}
+        />
+        <main className="matrix-ap-main">
+          {harness ? (
+            <>
+              <HarnessEditor
+                snapshot={snapshot}
+                harness={harness}
+                disabled={mutationsDisabled}
+                canUpdate={supports("update_harness")}
+                canEnable={supports("set_harness_enabled")}
+                canSetRoute={supports("set_route")}
+                canSelectSource={supports("select_access_source")}
+                canSelectAccount={supports("select_account")}
+                onMutate={onMutate}
+              />
+              <AccountsPanel
+                harness={harness}
+                accounts={snapshot.accounts.filter((account) => harness.accountIds.includes(account.id))}
+                sources={snapshot.accessSources}
+                attempt={connectionAttempt?.harnessInstanceId === harness.id ? connectionAttempt : null}
+                disabled={mutationsDisabled}
+                canLogin={supports("start_login")}
+                canLogout={supports("logout_account")}
+                canRemove={supports("remove_account")}
+                canReassign={supports("reassign_account")}
+                onMutate={onMutate}
+                onOpenTerminal={onOpenTerminal}
+                onOpenBrowser={onOpenBrowser}
+              />
+              {gatewaySource ? (
+                <GatewayPanel
+                  source={gatewaySource}
+                  policy={snapshot.gatewayPolicy}
+                  provider={gatewayProvider}
+                  disabled={mutationsDisabled}
+                  canSetBudget={supports("set_gateway_budget")}
+                  canSetAllowlist={supports("set_gateway_allowlist")}
+                  canAddCredit={supports("add_credit")}
+                  onMutate={onMutate}
+                  onAddCredit={onAddCredit}
+                  onRefresh={onRefresh}
+                />
+              ) : null}
+            </>
+          ) : (
+            <div className="matrix-ap-empty-state">
+              <strong>No harnesses configured</strong>
+              <span>Add Hermes, OpenClaw, Pi, OpenCode, Codex, or Claude to begin.</span>
+              <button type="button" className="matrix-ap-button matrix-ap-button-primary" disabled={mutationsDisabled || !supports("add_harness")} onClick={() => setAddOpen(true)}>Add harness</button>
+            </div>
+          )}
+        </main>
+      </div>
+
+      {addOpen && supports("add_harness") ? (
+        <AddHarnessDialog snapshot={snapshot} onMutate={onMutate} onClose={() => setAddOpen(false)} />
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/agents-providers/AgentsProvidersView.tsx
+++ b/packages/ui/src/agents-providers/AgentsProvidersView.tsx
@@ -97,6 +97,8 @@ export function AgentsProvidersView({
                 harness={harness}
                 accounts={snapshot.accounts.filter((account) => harness.accountIds.includes(account.id))}
                 sources={snapshot.accessSources}
+                allHarnesses={snapshot.harnesses}
+                gatewayPolicy={snapshot.gatewayPolicy}
                 attempt={connectionAttempt?.harnessInstanceId === harness.id ? connectionAttempt : null}
                 disabled={mutationsDisabled}
                 canLogin={supports("start_login")}

--- a/packages/ui/src/agents-providers/FeatureDialog.tsx
+++ b/packages/ui/src/agents-providers/FeatureDialog.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef, type ReactNode } from "react";
+
+export function FeatureDialog({
+  title,
+  children,
+  onClose,
+}: {
+  title: string;
+  children: ReactNode;
+  onClose: () => void;
+}) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    dialogRef.current?.querySelector<HTMLElement>("button, input, select")?.focus();
+  }, []);
+
+  return (
+    <div
+      className="matrix-ap-dialog-backdrop"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        className="matrix-ap-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") onClose();
+        }}
+      >
+        <div className="matrix-ap-dialog-head">
+          <h3>{title}</h3>
+          <button type="button" className="matrix-ap-icon-button" aria-label="Close dialog" onClick={onClose}>×</button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/agents-providers/GatewayPanel.tsx
+++ b/packages/ui/src/agents-providers/GatewayPanel.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from "react";
+import type { ProviderAccessSource, ProviderGatewayPolicy, ProviderModelProvider } from "@matrix-os/contracts";
+import type { ProviderSettingsMutationIntent } from "./types.js";
+import { gatewayCreditLines, shortDate, titleCase } from "./utils.js";
+
+export function GatewayPanel({
+  source,
+  policy,
+  provider,
+  disabled,
+  canSetBudget,
+  canSetAllowlist,
+  canAddCredit,
+  onMutate,
+  onAddCredit,
+  onRefresh,
+}: {
+  source: ProviderAccessSource;
+  policy: ProviderGatewayPolicy | null;
+  provider: ProviderModelProvider | null;
+  disabled: boolean;
+  canSetBudget: boolean;
+  canSetAllowlist: boolean;
+  canAddCredit: boolean;
+  onMutate: (intent: ProviderSettingsMutationIntent) => void;
+  onAddCredit: (sourceId: string) => void;
+  onRefresh: () => void;
+}) {
+  const budget = policy?.monthlyBudgetMicrousd ?? null;
+  const [budgetUsd, setBudgetUsd] = useState(budget === null ? "" : String(budget / 1_000_000));
+  useEffect(() => {
+    setBudgetUsd(budget === null ? "" : String(budget / 1_000_000));
+  }, [budget]);
+  const credit = gatewayCreditLines(source);
+  const usageAsOf = source.usage.asOf;
+  const ready = source.readiness.state === "ready";
+
+  const saveBudget = () => {
+    const trimmed = budgetUsd.trim();
+    if (trimmed === "") {
+      onMutate({ type: "set_gateway_budget", monthlyBudgetMicrousd: null });
+      return;
+    }
+    const parsed = Number(trimmed);
+    if (!Number.isFinite(parsed) || parsed < 0) return;
+    onMutate({ type: "set_gateway_budget", monthlyBudgetMicrousd: Math.round(parsed * 1_000_000) });
+  };
+
+  return (
+    <section className="matrix-ap-panel matrix-ap-gateway" aria-labelledby="matrix-ap-gateway-title">
+      <div className="matrix-ap-panel-head">
+        <div>
+          <span className="matrix-ap-eyebrow">Access source</span>
+          <h3 id="matrix-ap-gateway-title">Matrix gateway</h3>
+        </div>
+        <span className="matrix-ap-status-chip" data-state={ready ? "ready" : "attention"}>
+          <i aria-hidden="true" />{titleCase(source.readiness.state)}
+        </span>
+      </div>
+
+      <div className="matrix-ap-credit-row">
+        <div>
+          <strong>{credit.primary}</strong>
+          {credit.secondary ? <span>{credit.secondary}</span> : null}
+          {credit.stale ? <span>Credit last confirmed {shortDate(usageAsOf)}</span> : null}
+        </div>
+        <div className="matrix-ap-actions">
+          {!ready && source.readiness.action === "retry" ? (
+            <button type="button" className="matrix-ap-button" onClick={onRefresh}>Retry</button>
+          ) : null}
+          {policy?.topUpEnabled ? (
+            <button
+              type="button"
+              className="matrix-ap-button matrix-ap-button-primary"
+              onClick={() => onAddCredit(source.id)}
+              disabled={disabled || !canAddCredit}
+              title={canAddCredit ? undefined : "Adding credit is not available yet"}
+            >
+              Add credit
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {policy ? (
+        <div className="matrix-ap-policy-grid">
+          <label className="matrix-ap-field">
+            <span>Monthly budget</span>
+            <span className="matrix-ap-money-input">
+              <i aria-hidden="true">$</i>
+              <input
+                aria-label="Monthly budget in USD"
+                inputMode="decimal"
+                value={budgetUsd}
+                onChange={(event) => setBudgetUsd(event.target.value)}
+                disabled={disabled || !canSetBudget}
+                title={canSetBudget ? undefined : "Changing the gateway budget is not available"}
+                placeholder="No limit"
+              />
+            </span>
+          </label>
+          <button
+            type="button"
+            className="matrix-ap-button"
+            disabled={disabled || !canSetBudget}
+            title={canSetBudget ? undefined : "Changing the gateway budget is not available"}
+            onClick={saveBudget}
+          >
+            Save budget
+          </button>
+          <fieldset
+            className="matrix-ap-allowlist"
+            disabled={disabled || !canSetAllowlist}
+            title={canSetAllowlist ? undefined : "Changing the gateway model list is not available"}
+          >
+            <legend>Models available through Matrix</legend>
+            {provider?.models
+              .filter((model) => source.eligibleModelIds.includes(model.id))
+              .map((model) => {
+                const checked = policy.allowedModelIds.includes(model.id);
+                return (
+                  <label key={model.id}>
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      aria-label={`Allow ${model.displayName}`}
+                      onChange={() => onMutate({
+                        type: "set_gateway_allowlist",
+                        allowedModelIds: checked
+                          ? policy.allowedModelIds.filter((id) => id !== model.id)
+                          : [...policy.allowedModelIds, model.id],
+                      })}
+                    />
+                    <span>{model.displayName}</span>
+                  </label>
+                );
+              })}
+          </fieldset>
+          {!canSetBudget || !canSetAllowlist ? (
+            <p className="matrix-ap-help">Some gateway controls are unavailable in this runtime.</p>
+          ) : null}
+        </div>
+      ) : (
+        <p className="matrix-ap-help">Budget and model controls will appear when Matrix gateway policy is available.</p>
+      )}
+    </section>
+  );
+}

--- a/packages/ui/src/agents-providers/HarnessEditor.tsx
+++ b/packages/ui/src/agents-providers/HarnessEditor.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useState } from "react";
+import type {
+  ProviderAccentColor,
+  ProviderHarnessInstance,
+  ProviderModelProvider,
+  ProviderSettingsSnapshot,
+} from "@matrix-os/contracts";
+import type { ProviderSettingsMutationIntent } from "./types.js";
+import { authLabel, titleCase } from "./utils.js";
+
+const ACCENTS: ProviderAccentColor[] = ["blue", "green", "orange", "red", "purple", "cyan", "teal"];
+
+function providerFor(snapshot: ProviderSettingsSnapshot, harness: ProviderHarnessInstance): ProviderModelProvider | null {
+  return snapshot.modelProviders.find((provider) => provider.id === harness.route.providerId) ?? null;
+}
+
+export function HarnessEditor({
+  snapshot,
+  harness,
+  disabled,
+  canUpdate,
+  canEnable,
+  canSetRoute,
+  canSelectSource,
+  canSelectAccount,
+  onMutate,
+}: {
+  snapshot: ProviderSettingsSnapshot;
+  harness: ProviderHarnessInstance;
+  disabled: boolean;
+  canUpdate: boolean;
+  canEnable: boolean;
+  canSetRoute: boolean;
+  canSelectSource: boolean;
+  canSelectAccount: boolean;
+  onMutate: (intent: ProviderSettingsMutationIntent) => void;
+}) {
+  const [displayName, setDisplayName] = useState(harness.displayName);
+  useEffect(() => setDisplayName(harness.displayName), [harness.displayName, harness.id]);
+  const provider = providerFor(snapshot, harness);
+  const model = provider?.models.find((candidate) => candidate.id === harness.route.modelId) ?? null;
+  const accessSource = snapshot.accessSources.find((source) => source.id === harness.accessSourceId) ?? null;
+  const account = snapshot.accounts.find((candidate) => candidate.id === harness.selectedAccountId) ?? null;
+  const sources = snapshot.accessSources.filter((source) => source.providerId === harness.route.providerId
+    && source.eligibleModelIds.includes(harness.route.modelId));
+  const accounts = snapshot.accounts.filter((candidate) => {
+    if (!harness.accountIds.includes(candidate.id)) return false;
+    const candidateSource = snapshot.accessSources.find((source) => source.id === candidate.accessSourceId);
+    return candidateSource?.providerId === harness.route.providerId
+      && candidateSource.eligibleModelIds.includes(harness.route.modelId);
+  });
+  const gatewaySource = sources.find((source) => source.kind === "matrix_gateway") ?? null;
+  const routeProviders = accessSource === null
+    ? snapshot.modelProviders
+    : snapshot.modelProviders.filter((candidate) => candidate.id === accessSource.providerId);
+  const mutableRoute = harness.route.kind === "configurable";
+
+  const changeProvider = (nextProviderId: string) => {
+    const nextProvider = snapshot.modelProviders.find((candidate) => candidate.id === nextProviderId);
+    const nextModel = nextProvider?.models.find((candidate) => candidate.enabled
+      && (accessSource === null || accessSource.eligibleModelIds.includes(candidate.id)));
+    if (!nextModel) return;
+    onMutate({
+      type: "set_route",
+      harnessInstanceId: harness.id,
+      route: { kind: "configurable", providerId: nextProviderId, modelId: nextModel.id },
+    });
+  };
+
+  return (
+    <section className="matrix-ap-editor" aria-labelledby="matrix-ap-harness-title">
+      <div className="matrix-ap-editor-head">
+        <div className="matrix-ap-title-lockup">
+          <span className="matrix-ap-harness-mark" data-accent={harness.accentColor ?? "none"} aria-hidden="true">
+            {harness.displayName.slice(0, 1).toUpperCase()}
+          </span>
+          <div>
+            <h2 id="matrix-ap-harness-title">{harness.displayName}</h2>
+            <p>{titleCase(harness.harness)}{harness.version ? ` · ${harness.version}` : ""}</p>
+          </div>
+        </div>
+        <label className="matrix-ap-switch">
+          <input
+            type="checkbox"
+            role="switch"
+            aria-label={`Enable ${harness.displayName}`}
+            checked={harness.enabled}
+            disabled={disabled || !canEnable || harness.installState !== "installed"}
+            onChange={() => onMutate({ type: "set_harness_enabled", harnessInstanceId: harness.id, enabled: !harness.enabled })}
+          />
+          <span aria-hidden="true" />
+        </label>
+      </div>
+
+      <div className="matrix-ap-state-strip">
+        <span data-state={harness.connectivity}>{titleCase(harness.connectivity)}</span>
+        <span>{titleCase(harness.installState)}</span>
+        <span>{authLabel(harness.authState)}</span>
+        {harness.activeChatCount > 0 ? <span>{harness.activeChatCount} active chat{harness.activeChatCount === 1 ? "" : "s"}</span> : null}
+      </div>
+
+      {harness.installState !== "installed" ? (
+        <div className="matrix-ap-notice" data-tone="warning">
+          <div><strong>{harness.displayName} is not installed</strong><span>Install this harness from Terminal before enabling it here.</span></div>
+          <button type="button" className="matrix-ap-button" disabled aria-label={`Install ${harness.displayName}`} title="Harness installation is not available from this runtime">Install unavailable</button>
+        </div>
+      ) : null}
+      {harness.connectivity === "offline" ? (
+        <div className="matrix-ap-notice" data-tone="warning"><strong>Offline</strong><span>Saved settings are visible, but changes may not reach this computer.</span></div>
+      ) : null}
+
+      <div className="matrix-ap-panel">
+        <span className="matrix-ap-eyebrow">Instance</span>
+        <div className="matrix-ap-form-grid matrix-ap-form-grid-name">
+          <label className="matrix-ap-field">
+            <span>Display name</span>
+            <input
+              value={displayName}
+              maxLength={120}
+              disabled={disabled || !canUpdate}
+              onChange={(event) => setDisplayName(event.target.value)}
+              onBlur={() => {
+                const next = displayName.trim();
+                if (next && next !== harness.displayName) onMutate({ type: "update_harness", harnessInstanceId: harness.id, displayName: next });
+              }}
+            />
+          </label>
+          <fieldset className="matrix-ap-accents" disabled={disabled || !canUpdate}>
+            <legend>Accent color</legend>
+            <div>
+              {ACCENTS.map((accent) => (
+                <button
+                  key={accent}
+                  type="button"
+                  className="matrix-ap-accent"
+                  data-accent={accent}
+                  data-selected={accent === harness.accentColor ? "true" : undefined}
+                  aria-label={`Use ${accent} accent`}
+                  onClick={() => onMutate({ type: "update_harness", harnessInstanceId: harness.id, accentColor: accent })}
+                />
+              ))}
+            </div>
+          </fieldset>
+        </div>
+      </div>
+
+      <div className="matrix-ap-panel">
+        <div className="matrix-ap-panel-head">
+          <div><span className="matrix-ap-eyebrow">Model route</span><h3>Provider and model</h3></div>
+          {!mutableRoute ? <span className="matrix-ap-fixed-tag">Fixed by {harness.displayName}</span> : null}
+        </div>
+        <div className="matrix-ap-form-grid">
+          <label className="matrix-ap-field">
+            <span>Model provider</span>
+            <select
+              aria-label="Model provider"
+              value={harness.route.providerId}
+              disabled={disabled || !canSetRoute || !mutableRoute}
+              title={!canSetRoute ? "Changing the model route is not available" : undefined}
+              onChange={(event) => changeProvider(event.target.value)}
+            >
+              {routeProviders.map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.displayName}</option>)}
+            </select>
+          </label>
+          <label className="matrix-ap-field">
+            <span>Model</span>
+            <select
+              aria-label="Model"
+              value={harness.route.modelId}
+              disabled={disabled || !canSetRoute || !mutableRoute}
+              title={!canSetRoute ? "Changing the model route is not available" : undefined}
+              onChange={(event) => onMutate({
+                type: "set_route",
+                harnessInstanceId: harness.id,
+                route: { kind: "configurable", providerId: harness.route.providerId, modelId: event.target.value },
+              })}
+            >
+              {provider?.models
+                .filter((candidate) => candidate.enabled && (accessSource === null || accessSource.eligibleModelIds.includes(candidate.id)))
+                .map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.displayName}</option>)}
+            </select>
+          </label>
+        </div>
+      </div>
+
+      <div className="matrix-ap-panel">
+        <span className="matrix-ap-eyebrow">Signal path</span>
+        <div className="matrix-ap-signal-path" data-testid="provider-signal-path">
+          <span><small>Harness</small><strong>{harness.displayName}</strong></span>
+          <i aria-hidden="true">›</i>
+          <span><small>Model</small><strong>{model?.displayName ?? harness.route.modelId}</strong></span>
+          <i aria-hidden="true">›</i>
+          <span><small>Access</small><strong>{accessSource?.displayName ?? "Not selected"}</strong></span>
+        </div>
+        <div className="matrix-ap-form-grid">
+          <label className="matrix-ap-field">
+            <span>Access source</span>
+            <select
+              aria-label="Access source"
+              value={harness.accessSourceId ?? ""}
+              disabled={disabled || !canSelectSource}
+              title={!canSelectSource ? "Changing the access source is not available" : undefined}
+              onChange={(event) => onMutate({ type: "select_access_source", harnessInstanceId: harness.id, accessSourceId: event.target.value })}
+            >
+              <option value="" disabled>Select an access source</option>
+              {sources.map((source) => <option key={source.id} value={source.id}>{source.displayName}</option>)}
+            </select>
+          </label>
+          <label className="matrix-ap-field">
+            <span>Account</span>
+            <select
+              aria-label="Account"
+              value={harness.selectedAccountId ?? ""}
+              disabled={disabled || !canSelectAccount || (accounts.length === 0 && gatewaySource === null)}
+              title={!canSelectAccount ? "Changing the account is not available" : undefined}
+              onChange={(event) => {
+                const accountId = event.target.value;
+                if (accountId !== "" && canSelectAccount) {
+                  onMutate({ type: "select_account", harnessInstanceId: harness.id, accountId });
+                } else if (accountId === "" && gatewaySource !== null && canSelectSource) {
+                  onMutate({ type: "select_access_source", harnessInstanceId: harness.id, accessSourceId: gatewaySource.id });
+                }
+              }}
+            >
+              {gatewaySource ? <option value="">Matrix gateway / no account</option> : <option value="" disabled>Select an account</option>}
+              {accounts.map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.displayName}</option>)}
+            </select>
+          </label>
+        </div>
+        {account ? <p className="matrix-ap-help">Selected account: {account.displayName}</p> : null}
+        {!canSetRoute || !canSelectSource || !canSelectAccount ? (
+          <p className="matrix-ap-help">Some routing controls are unavailable in this runtime.</p>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/packages/ui/src/agents-providers/HarnessEditor.tsx
+++ b/packages/ui/src/agents-providers/HarnessEditor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import type {
+  ProviderAccessSource,
   ProviderAccentColor,
   ProviderHarnessInstance,
   ProviderModelProvider,
@@ -12,6 +13,27 @@ const ACCENTS: ProviderAccentColor[] = ["blue", "green", "orange", "red", "purpl
 
 function providerFor(snapshot: ProviderSettingsSnapshot, harness: ProviderHarnessInstance): ProviderModelProvider | null {
   return snapshot.modelProviders.find((provider) => provider.id === harness.route.providerId) ?? null;
+}
+
+function sourceSupportsModel(
+  snapshot: ProviderSettingsSnapshot,
+  source: ProviderAccessSource,
+  modelId: string,
+): boolean {
+  if (!source.eligibleModelIds.includes(modelId)) return false;
+  if (source.kind !== "matrix_gateway") return true;
+  return snapshot.gatewayPolicy?.accessSourceId === source.id
+    && snapshot.gatewayPolicy.allowedModelIds.includes(modelId);
+}
+
+function routeTargetForProvider(snapshot: ProviderSettingsSnapshot, provider: ProviderModelProvider) {
+  for (const model of provider.models) {
+    if (!model.enabled) continue;
+    const source = snapshot.accessSources.find((candidate) =>
+      candidate.providerId === provider.id && sourceSupportsModel(snapshot, candidate, model.id));
+    if (source) return { model, source };
+  }
+  return null;
 }
 
 export function HarnessEditor({
@@ -42,28 +64,45 @@ export function HarnessEditor({
   const accessSource = snapshot.accessSources.find((source) => source.id === harness.accessSourceId) ?? null;
   const account = snapshot.accounts.find((candidate) => candidate.id === harness.selectedAccountId) ?? null;
   const sources = snapshot.accessSources.filter((source) => source.providerId === harness.route.providerId
-    && source.eligibleModelIds.includes(harness.route.modelId));
+    && sourceSupportsModel(snapshot, source, harness.route.modelId));
   const accounts = snapshot.accounts.filter((candidate) => {
     if (!harness.accountIds.includes(candidate.id)) return false;
     const candidateSource = snapshot.accessSources.find((source) => source.id === candidate.accessSourceId);
     return candidateSource?.providerId === harness.route.providerId
-      && candidateSource.eligibleModelIds.includes(harness.route.modelId);
+      && sourceSupportsModel(snapshot, candidateSource, harness.route.modelId);
   });
   const gatewaySource = sources.find((source) => source.kind === "matrix_gateway") ?? null;
-  const routeProviders = accessSource === null
-    ? snapshot.modelProviders
-    : snapshot.modelProviders.filter((candidate) => candidate.id === accessSource.providerId);
+  const routeProviders = snapshot.modelProviders.filter((candidate) => routeTargetForProvider(snapshot, candidate) !== null);
   const mutableRoute = harness.route.kind === "configurable";
 
   const changeProvider = (nextProviderId: string) => {
     const nextProvider = snapshot.modelProviders.find((candidate) => candidate.id === nextProviderId);
-    const nextModel = nextProvider?.models.find((candidate) => candidate.enabled
-      && (accessSource === null || accessSource.eligibleModelIds.includes(candidate.id)));
-    if (!nextModel) return;
+    const target = nextProvider ? routeTargetForProvider(snapshot, nextProvider) : null;
+    if (!target) return;
     onMutate({
       type: "set_route",
       harnessInstanceId: harness.id,
-      route: { kind: "configurable", providerId: nextProviderId, modelId: nextModel.id },
+      route: { kind: "configurable", providerId: nextProviderId, modelId: target.model.id },
+      accessSourceId: target.source.id,
+      accountId: target.source.accountId,
+    });
+  };
+
+  const changeModel = (nextModelId: string) => {
+    const targetSource = snapshot.accessSources.find((candidate) =>
+      candidate.id === harness.accessSourceId
+      && candidate.providerId === harness.route.providerId
+      && sourceSupportsModel(snapshot, candidate, nextModelId))
+      ?? snapshot.accessSources.find((candidate) =>
+        candidate.providerId === harness.route.providerId
+        && sourceSupportsModel(snapshot, candidate, nextModelId));
+    if (!targetSource) return;
+    onMutate({
+      type: "set_route",
+      harnessInstanceId: harness.id,
+      route: { kind: "configurable", providerId: harness.route.providerId, modelId: nextModelId },
+      accessSourceId: targetSource.id,
+      accountId: targetSource.accountId,
     });
   };
 
@@ -169,14 +208,11 @@ export function HarnessEditor({
               value={harness.route.modelId}
               disabled={disabled || !canSetRoute || !mutableRoute}
               title={!canSetRoute ? "Changing the model route is not available" : undefined}
-              onChange={(event) => onMutate({
-                type: "set_route",
-                harnessInstanceId: harness.id,
-                route: { kind: "configurable", providerId: harness.route.providerId, modelId: event.target.value },
-              })}
+              onChange={(event) => changeModel(event.target.value)}
             >
               {provider?.models
-                .filter((candidate) => candidate.enabled && (accessSource === null || accessSource.eligibleModelIds.includes(candidate.id)))
+                .filter((candidate) => candidate.enabled && snapshot.accessSources.some((source) =>
+                  source.providerId === harness.route.providerId && sourceSupportsModel(snapshot, source, candidate.id)))
                 .map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.displayName}</option>)}
             </select>
           </label>

--- a/packages/ui/src/agents-providers/HarnessRail.tsx
+++ b/packages/ui/src/agents-providers/HarnessRail.tsx
@@ -1,0 +1,76 @@
+import type { ProviderHarnessInstance } from "@matrix-os/contracts";
+import { authLabel, titleCase } from "./utils.js";
+
+function railStatus(harness: ProviderHarnessInstance): string {
+  if (harness.installState !== "installed") return titleCase(harness.installState);
+  if (harness.connectivity === "offline") return "Offline";
+  if (!harness.enabled) return "Disabled";
+  return authLabel(harness.authState);
+}
+
+export function HarnessRail({
+  harnesses,
+  selectedId,
+  disabled,
+  canAdd,
+  onSelect,
+  onAdd,
+}: {
+  harnesses: ProviderHarnessInstance[];
+  selectedId: string | null;
+  disabled: boolean;
+  canAdd: boolean;
+  onSelect: (id: string) => void;
+  onAdd: () => void;
+}) {
+  return (
+    <nav className="matrix-ap-rail" aria-label="Agent harnesses">
+      <div className="matrix-ap-rail-head">
+        <span>Harnesses</span>
+        <button
+          type="button"
+          className="matrix-ap-add-button"
+          aria-label="Add harness"
+          onClick={onAdd}
+          disabled={disabled || !canAdd}
+          title={canAdd ? "Add harness" : "Adding harnesses is not available"}
+        >
+          <span aria-hidden="true">+</span>
+        </button>
+      </div>
+      <div className="matrix-ap-rail-list">
+        {harnesses.map((harness) => {
+          const selected = harness.id === selectedId;
+          const status = railStatus(harness);
+          return (
+            <button
+              key={harness.id}
+              type="button"
+              className="matrix-ap-rail-item"
+              data-selected={selected ? "true" : undefined}
+              aria-current={selected ? "true" : undefined}
+              onClick={() => onSelect(harness.id)}
+            >
+              <span
+                className="matrix-ap-harness-mark"
+                data-accent={harness.accentColor ?? "none"}
+                aria-hidden="true"
+              >
+                {harness.displayName.slice(0, 1).toUpperCase()}
+              </span>
+              <span className="matrix-ap-rail-copy">
+                <span className="matrix-ap-rail-name">
+                  {harness.displayName}
+                  {harness.version ? <span>{harness.version}</span> : null}
+                </span>
+                <span className="matrix-ap-rail-status" data-state={status.toLowerCase().replaceAll(" ", "-")}>
+                  <i aria-hidden="true" />{status}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/packages/ui/src/agents-providers/RemovalDialog.tsx
+++ b/packages/ui/src/agents-providers/RemovalDialog.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
-import type { ProviderAccount, ProviderAccessSource } from "@matrix-os/contracts";
+import type {
+  ProviderAccount,
+  ProviderAccessSource,
+  ProviderGatewayPolicy,
+  ProviderHarnessInstance,
+} from "@matrix-os/contracts";
 import { FeatureDialog } from "./FeatureDialog.js";
 import type { ProviderSettingsMutationIntent } from "./types.js";
 import { dependenciesTotal } from "./utils.js";
@@ -12,6 +17,8 @@ export function RemovalDialog({
   account,
   accounts,
   sources,
+  harnesses,
+  gatewayPolicy,
   disabled,
   canRemove,
   canReassign,
@@ -21,24 +28,49 @@ export function RemovalDialog({
   account: ProviderAccount;
   accounts: ProviderAccount[];
   sources: ProviderAccessSource[];
+  harnesses: ProviderHarnessInstance[];
+  gatewayPolicy: ProviderGatewayPolicy | null;
   disabled: boolean;
   canRemove: boolean;
   canReassign: boolean;
   onMutate: (intent: ProviderSettingsMutationIntent) => void;
   onClose: () => void;
 }) {
+  const affectedHarnesses = harnesses.filter((harness) => harness.selectedAccountId === account.id);
+  const sourceSupportsEveryRoute = (source: ProviderAccessSource) => (
+    source.providerId === account.providerId
+    && affectedHarnesses.every((harness) => source.eligibleModelIds.includes(harness.route.modelId))
+    && (source.kind !== "matrix_gateway"
+      || (gatewayPolicy?.accessSourceId === source.id
+        && affectedHarnesses.every((harness) => gatewayPolicy.allowedModelIds.includes(harness.route.modelId))))
+  );
   const alternatives = [
-    ...sources.filter((source) => source.id !== account.accessSourceId),
-    ...accounts.filter((candidate) => candidate.id !== account.id && candidate.providerId === account.providerId),
+    ...sources
+      .filter((source) => source.id !== account.accessSourceId
+        && source.kind !== "provider_account"
+        && sourceSupportsEveryRoute(source))
+      .map((source) => ({
+        key: `source:${source.id}`,
+        label: source.displayName,
+        target: { kind: "access_source" as const, accessSourceId: source.id },
+      })),
+    ...accounts
+      .filter((candidate) => candidate.id !== account.id && candidate.providerId === account.providerId)
+      .flatMap((candidate) => {
+        const source = sources.find((value) => value.id === candidate.accessSourceId);
+        return source && sourceSupportsEveryRoute(source) ? [{
+          key: `account:${candidate.id}`,
+          label: candidate.displayName,
+          target: { kind: "account" as const, accountId: candidate.id },
+        }] : [];
+      }),
   ];
-  const [targetId, setTargetId] = useState(alternatives[0]?.id ?? "");
+  const [targetKey, setTargetKey] = useState(alternatives[0]?.key ?? "");
   const hasDependencies = dependenciesTotal(account.dependencies) > 0;
 
   const reassign = () => {
-    const targetAccount = accounts.find((candidate) => candidate.id === targetId);
-    const target = targetAccount
-      ? { kind: "account" as const, accountId: targetAccount.id }
-      : { kind: "access_source" as const, accessSourceId: targetId };
+    const target = alternatives.find((alternative) => alternative.key === targetKey)?.target;
+    if (!target) return;
     onMutate({
       type: "reassign_account",
       fromAccountId: account.id,
@@ -70,9 +102,9 @@ export function RemovalDialog({
           </p>
           <label className="matrix-ap-field">
             <span>Reassign to</span>
-            <select value={targetId} onChange={(event) => setTargetId(event.target.value)} disabled={disabled || !canReassign}>
+            <select value={targetKey} onChange={(event) => setTargetKey(event.target.value)} disabled={disabled || !canReassign}>
               {alternatives.map((alternative) => (
-                <option key={alternative.id} value={alternative.id}>{alternative.displayName}</option>
+                <option key={alternative.key} value={alternative.key}>{alternative.label}</option>
               ))}
             </select>
           </label>
@@ -82,7 +114,7 @@ export function RemovalDialog({
             <button
               type="button"
               className="matrix-ap-button matrix-ap-button-primary"
-              disabled={disabled || !canReassign || targetId === ""}
+              disabled={disabled || !canReassign || targetKey === ""}
               onClick={reassign}
               title={canReassign ? undefined : "Reassignment is not available"}
             >

--- a/packages/ui/src/agents-providers/RemovalDialog.tsx
+++ b/packages/ui/src/agents-providers/RemovalDialog.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import type { ProviderAccount, ProviderAccessSource } from "@matrix-os/contracts";
+import { FeatureDialog } from "./FeatureDialog.js";
+import type { ProviderSettingsMutationIntent } from "./types.js";
+import { dependenciesTotal } from "./utils.js";
+
+function countLabel(count: number, singular: string): string {
+  return `${count} ${singular}${count === 1 ? "" : "s"}`;
+}
+
+export function RemovalDialog({
+  account,
+  accounts,
+  sources,
+  disabled,
+  canRemove,
+  canReassign,
+  onMutate,
+  onClose,
+}: {
+  account: ProviderAccount;
+  accounts: ProviderAccount[];
+  sources: ProviderAccessSource[];
+  disabled: boolean;
+  canRemove: boolean;
+  canReassign: boolean;
+  onMutate: (intent: ProviderSettingsMutationIntent) => void;
+  onClose: () => void;
+}) {
+  const alternatives = [
+    ...sources.filter((source) => source.id !== account.accessSourceId),
+    ...accounts.filter((candidate) => candidate.id !== account.id && candidate.providerId === account.providerId),
+  ];
+  const [targetId, setTargetId] = useState(alternatives[0]?.id ?? "");
+  const hasDependencies = dependenciesTotal(account.dependencies) > 0;
+
+  const reassign = () => {
+    const targetAccount = accounts.find((candidate) => candidate.id === targetId);
+    const target = targetAccount
+      ? { kind: "account" as const, accountId: targetAccount.id }
+      : { kind: "access_source" as const, accessSourceId: targetId };
+    onMutate({
+      type: "reassign_account",
+      fromAccountId: account.id,
+      target,
+      scope: "all_dependencies",
+      dependencyGuard: account.dependencies,
+    });
+    onClose();
+  };
+
+  const remove = () => {
+    onMutate({
+      type: "remove_account",
+      accountId: account.id,
+      dependencyGuard: account.dependencies,
+      confirmation: "remove_account",
+    });
+    onClose();
+  };
+
+  return (
+    <FeatureDialog title={`Remove ${account.displayName}`} onClose={onClose}>
+      {hasDependencies ? (
+        <>
+          <p className="matrix-ap-dialog-copy">
+            This account is still used by {countLabel(account.dependencies.activeChatCount, "active chat")}, {" "}
+            {countLabel(account.dependencies.resumableChatCount, "resumable chat")}, and {" "}
+            {countLabel(account.dependencies.harnessInstanceCount, "harness")}.
+          </p>
+          <label className="matrix-ap-field">
+            <span>Reassign to</span>
+            <select value={targetId} onChange={(event) => setTargetId(event.target.value)} disabled={disabled || !canReassign}>
+              {alternatives.map((alternative) => (
+                <option key={alternative.id} value={alternative.id}>{alternative.displayName}</option>
+              ))}
+            </select>
+          </label>
+          <p className="matrix-ap-help">Reassign dependencies first. You can remove the account after the refreshed snapshot shows no remaining use.</p>
+          <div className="matrix-ap-dialog-actions">
+            <button type="button" className="matrix-ap-button" onClick={onClose}>Cancel</button>
+            <button
+              type="button"
+              className="matrix-ap-button matrix-ap-button-primary"
+              disabled={disabled || !canReassign || targetId === ""}
+              onClick={reassign}
+              title={canReassign ? undefined : "Reassignment is not available"}
+            >
+              Reassign dependencies
+            </button>
+          </div>
+        </>
+      ) : (
+        <>
+          <p className="matrix-ap-dialog-copy">This signs the account out and removes its saved Matrix configuration. Provider-side data is not deleted.</p>
+          <div className="matrix-ap-dialog-actions">
+            <button type="button" className="matrix-ap-button" onClick={onClose}>Cancel</button>
+            <button
+              type="button"
+              className="matrix-ap-button matrix-ap-button-danger"
+              disabled={disabled || !canRemove}
+              onClick={remove}
+              title={canRemove ? undefined : "Removing accounts is not available"}
+            >
+              Remove account
+            </button>
+          </div>
+        </>
+      )}
+    </FeatureDialog>
+  );
+}

--- a/packages/ui/src/agents-providers/agents-providers.css
+++ b/packages/ui/src/agents-providers/agents-providers.css
@@ -1,0 +1,301 @@
+.matrix-agents-providers {
+  --matrix-ap-surface: var(--ap-surface, var(--bg-surface, var(--card)));
+  --matrix-ap-sunken: var(--ap-sunken, var(--bg-sunken, var(--muted)));
+  --matrix-ap-overlay: var(--ap-overlay, var(--bg-overlay, var(--background)));
+  --matrix-ap-text: var(--ap-text, var(--text-primary, var(--foreground)));
+  --matrix-ap-muted: var(--ap-muted, var(--text-secondary, var(--muted-foreground)));
+  --matrix-ap-faint: var(--ap-faint, var(--text-tertiary, var(--muted-foreground)));
+  --matrix-ap-border: var(--ap-border, var(--border-subtle, var(--border)));
+  --matrix-ap-border-strong: var(--ap-border-strong, var(--border-default, var(--border)));
+  --matrix-ap-accent: var(--ap-accent, var(--accent, var(--primary)));
+  --matrix-ap-accent-muted: var(--ap-accent-muted, var(--accent-muted, var(--secondary)));
+  --matrix-ap-success: var(--ap-success, var(--success, var(--forest)));
+  --matrix-ap-warning: var(--ap-warning, var(--warning, var(--ember)));
+  --matrix-ap-danger: var(--ap-danger, var(--danger, var(--destructive)));
+  --matrix-ap-focus: var(--ap-focus, var(--ring, var(--accent)));
+  color: var(--matrix-ap-text);
+  font-family: inherit;
+  min-width: 0;
+}
+
+.matrix-agents-providers *,
+.matrix-agents-providers *::before,
+.matrix-agents-providers *::after { box-sizing: border-box; }
+
+.matrix-agents-providers button,
+.matrix-agents-providers input,
+.matrix-agents-providers select { font: inherit; }
+
+.matrix-agents-providers button:focus-visible,
+.matrix-agents-providers input:focus-visible,
+.matrix-agents-providers select:focus-visible {
+  outline: 2px solid var(--matrix-ap-focus);
+  outline-offset: 2px;
+}
+
+.matrix-ap-page-head,
+.matrix-ap-editor-head,
+.matrix-ap-panel-head,
+.matrix-ap-credit-row,
+.matrix-ap-dialog-head,
+.matrix-ap-dialog-actions,
+.matrix-ap-actions {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.matrix-ap-page-head { gap: 24px; margin-bottom: 24px; }
+.matrix-ap-page-head h1 { font-size: 24px; font-weight: 650; letter-spacing: -0.04em; margin: 3px 0 5px; }
+.matrix-ap-page-head p { color: var(--matrix-ap-muted); font-size: 13px; margin: 0; }
+.matrix-ap-eyebrow { color: var(--matrix-ap-faint); font-size: 11px; font-weight: 650; letter-spacing: 0.08em; text-transform: uppercase; }
+.matrix-ap-refresh { align-items: center; color: var(--matrix-ap-faint); display: flex; font-size: 12px; gap: 8px; white-space: nowrap; }
+
+.matrix-ap-icon-button,
+.matrix-ap-add-button {
+  align-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  color: var(--matrix-ap-muted);
+  cursor: pointer;
+  display: inline-flex;
+  height: 30px;
+  justify-content: center;
+  width: 30px;
+}
+.matrix-ap-icon-button:hover:not(:disabled),
+.matrix-ap-add-button:hover:not(:disabled) { background: var(--matrix-ap-sunken); color: var(--matrix-ap-text); }
+
+.matrix-ap-workspace {
+  border: 1px solid var(--matrix-ap-border);
+  border-radius: 12px;
+  display: grid;
+  grid-template-columns: minmax(180px, 226px) minmax(0, 1fr);
+  min-height: 660px;
+  overflow: hidden;
+}
+
+.matrix-ap-rail { background: var(--matrix-ap-sunken); border-right: 1px solid var(--matrix-ap-border); min-width: 0; padding: 12px 9px; }
+.matrix-ap-rail-head { align-items: center; color: var(--matrix-ap-faint); display: flex; font-size: 11px; font-weight: 650; justify-content: space-between; letter-spacing: 0.08em; padding: 0 5px 8px 8px; text-transform: uppercase; }
+.matrix-ap-add-button { background: var(--matrix-ap-surface); border-color: var(--matrix-ap-border); color: var(--matrix-ap-text); font-size: 20px; height: 27px; width: 27px; }
+.matrix-ap-rail-list { display: flex; flex-direction: column; gap: 3px; }
+.matrix-ap-rail-item {
+  align-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  color: var(--matrix-ap-text);
+  cursor: pointer;
+  display: flex;
+  gap: 10px;
+  min-width: 0;
+  padding: 9px;
+  text-align: left;
+  width: 100%;
+}
+.matrix-ap-rail-item:hover { background: color-mix(in srgb, var(--matrix-ap-surface) 68%, transparent); }
+.matrix-ap-rail-item[data-selected="true"] { background: var(--matrix-ap-surface); border-color: var(--matrix-ap-border); box-shadow: 0 1px 2px color-mix(in srgb, var(--matrix-ap-text) 7%, transparent); }
+.matrix-ap-harness-mark,
+.matrix-ap-avatar {
+  align-items: center;
+  background: var(--matrix-ap-accent-muted);
+  border: 1px solid color-mix(in srgb, var(--matrix-ap-accent) 24%, var(--matrix-ap-border));
+  border-radius: 8px;
+  color: var(--matrix-ap-mark, var(--matrix-ap-accent));
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 13px;
+  font-weight: 750;
+  height: 31px;
+  justify-content: center;
+  width: 31px;
+}
+.matrix-ap-harness-mark[data-accent="green"] { --matrix-ap-mark: var(--ap-green, var(--matrix-ap-success)); }
+.matrix-ap-harness-mark[data-accent="orange"] { --matrix-ap-mark: var(--ap-orange, var(--matrix-ap-warning)); }
+.matrix-ap-harness-mark[data-accent="red"] { --matrix-ap-mark: var(--ap-red, var(--matrix-ap-danger)); }
+.matrix-ap-harness-mark[data-accent="purple"] { --matrix-ap-mark: var(--ap-purple, var(--matrix-ap-accent)); }
+.matrix-ap-harness-mark[data-accent="cyan"] { --matrix-ap-mark: var(--ap-cyan, var(--matrix-ap-accent)); }
+.matrix-ap-harness-mark[data-accent="teal"] { --matrix-ap-mark: var(--ap-teal, var(--matrix-ap-accent)); }
+.matrix-ap-rail-copy { display: flex; flex: 1; flex-direction: column; gap: 3px; min-width: 0; }
+.matrix-ap-rail-name { align-items: baseline; display: flex; font-size: 13px; font-weight: 620; gap: 6px; overflow: hidden; white-space: nowrap; }
+.matrix-ap-rail-name span { color: var(--matrix-ap-faint); font-size: 10px; font-weight: 500; overflow: hidden; text-overflow: ellipsis; }
+.matrix-ap-rail-status { align-items: center; color: var(--matrix-ap-muted); display: flex; font-size: 11px; gap: 5px; }
+.matrix-ap-rail-status i,
+.matrix-ap-status-chip i { background: var(--matrix-ap-warning); border-radius: 50%; height: 6px; width: 6px; }
+.matrix-ap-rail-status[data-state="authenticated"] i,
+.matrix-ap-status-chip[data-state="ready"] i { background: var(--matrix-ap-success); }
+.matrix-ap-rail-status[data-state="offline"] i,
+.matrix-ap-rail-status[data-state="failed"] i { background: var(--matrix-ap-danger); }
+
+.matrix-ap-main { background: var(--matrix-ap-overlay); min-width: 0; padding: 24px; }
+.matrix-ap-editor { min-width: 0; }
+.matrix-ap-title-lockup { align-items: center; display: flex; gap: 12px; }
+.matrix-ap-title-lockup .matrix-ap-harness-mark { height: 40px; width: 40px; }
+.matrix-ap-title-lockup h2 { font-size: 20px; letter-spacing: -0.025em; margin: 0; }
+.matrix-ap-title-lockup p { color: var(--matrix-ap-faint); font-size: 12px; margin: 3px 0 0; }
+.matrix-ap-switch input { height: 1px; opacity: 0; position: absolute; width: 1px; }
+.matrix-ap-switch span { background: var(--matrix-ap-border-strong); border-radius: 999px; cursor: pointer; display: block; height: 22px; padding: 2px; transition: background 120ms ease; width: 39px; }
+.matrix-ap-switch span::after { background: var(--matrix-ap-surface); border-radius: 50%; box-shadow: 0 1px 2px color-mix(in srgb, var(--matrix-ap-text) 18%, transparent); content: ""; display: block; height: 18px; transition: transform 120ms ease; width: 18px; }
+.matrix-ap-switch input:checked + span { background: var(--matrix-ap-accent); }
+.matrix-ap-switch input:checked + span::after { transform: translateX(17px); }
+.matrix-ap-switch input:disabled + span { cursor: not-allowed; opacity: 0.45; }
+
+.matrix-ap-state-strip { align-items: center; color: var(--matrix-ap-faint); display: flex; flex-wrap: wrap; font-size: 11px; gap: 6px; margin: 14px 0 18px 52px; }
+.matrix-ap-state-strip span { border-right: 1px solid var(--matrix-ap-border); padding-right: 6px; }
+.matrix-ap-state-strip span:last-child { border-right: 0; }
+.matrix-ap-state-strip span[data-state="offline"] { color: var(--matrix-ap-danger); }
+
+.matrix-ap-panel {
+  background: var(--matrix-ap-surface);
+  border: 1px solid var(--matrix-ap-border);
+  border-radius: 11px;
+  margin-bottom: 14px;
+  padding: 16px;
+}
+.matrix-ap-panel-head { gap: 16px; margin-bottom: 14px; }
+.matrix-ap-panel-head h3 { font-size: 14px; font-weight: 650; margin: 2px 0 0; }
+.matrix-ap-status-chip,
+.matrix-ap-fixed-tag,
+.matrix-ap-selected-tag { align-items: center; background: var(--matrix-ap-sunken); border: 1px solid var(--matrix-ap-border); border-radius: 999px; color: var(--matrix-ap-muted); display: inline-flex; font-size: 10px; gap: 5px; padding: 3px 8px; white-space: nowrap; }
+
+.matrix-ap-form-grid { display: grid; gap: 12px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.matrix-ap-form-grid-name { grid-template-columns: minmax(0, 1fr) auto; }
+.matrix-ap-field { color: var(--matrix-ap-muted); display: flex; flex-direction: column; font-size: 11px; font-weight: 600; gap: 6px; }
+.matrix-ap-field input,
+.matrix-ap-field select,
+.matrix-ap-money-input {
+  background: var(--matrix-ap-overlay);
+  border: 1px solid var(--matrix-ap-border-strong);
+  border-radius: 8px;
+  color: var(--matrix-ap-text);
+  font-size: 13px;
+  height: 34px;
+  min-width: 0;
+  padding: 0 10px;
+  width: 100%;
+}
+.matrix-ap-field input:disabled,
+.matrix-ap-field select:disabled { color: var(--matrix-ap-faint); opacity: 0.68; }
+.matrix-ap-accents { border: 0; margin: 0; padding: 0; }
+.matrix-ap-accents legend { color: var(--matrix-ap-muted); font-size: 11px; font-weight: 600; margin-bottom: 8px; }
+.matrix-ap-accents > div { display: flex; gap: 6px; }
+.matrix-ap-accent { background: var(--matrix-ap-accent); border: 2px solid var(--matrix-ap-surface); border-radius: 50%; box-shadow: 0 0 0 1px var(--matrix-ap-border); cursor: pointer; height: 24px; width: 24px; }
+.matrix-ap-accent[data-accent="green"] { background: var(--ap-green, var(--matrix-ap-success)); }
+.matrix-ap-accent[data-accent="orange"] { background: var(--ap-orange, var(--matrix-ap-warning)); }
+.matrix-ap-accent[data-accent="red"] { background: var(--ap-red, var(--matrix-ap-danger)); }
+.matrix-ap-accent[data-accent="purple"] { background: var(--ap-purple, var(--matrix-ap-accent)); }
+.matrix-ap-accent[data-accent="cyan"] { background: var(--ap-cyan, var(--matrix-ap-accent)); }
+.matrix-ap-accent[data-accent="teal"] { background: var(--ap-teal, var(--matrix-ap-accent)); }
+.matrix-ap-accent[data-selected="true"] { box-shadow: 0 0 0 2px var(--matrix-ap-surface), 0 0 0 4px var(--matrix-ap-accent); }
+
+.matrix-ap-signal-path { align-items: stretch; display: grid; gap: 8px; grid-template-columns: 1fr auto 1fr auto 1fr; margin: 9px 0 14px; }
+.matrix-ap-signal-path > span { background: var(--matrix-ap-sunken); border: 1px solid var(--matrix-ap-border); border-radius: 8px; display: flex; flex-direction: column; min-width: 0; padding: 9px 10px; }
+.matrix-ap-signal-path small { color: var(--matrix-ap-faint); font-size: 9px; letter-spacing: 0.06em; text-transform: uppercase; }
+.matrix-ap-signal-path strong { font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.matrix-ap-signal-path > i { align-self: center; color: var(--matrix-ap-faint); font-style: normal; }
+
+.matrix-ap-notice { align-items: center; background: var(--matrix-ap-sunken); border: 1px solid var(--matrix-ap-border); border-radius: 9px; display: flex; gap: 10px; margin-bottom: 14px; padding: 10px 12px; }
+.matrix-ap-notice > div,
+.matrix-ap-notice:not(:has(div)) { font-size: 12px; }
+.matrix-ap-notice div { display: flex; flex: 1; flex-direction: column; }
+.matrix-ap-notice span { color: var(--matrix-ap-muted); font-size: 11px; }
+.matrix-ap-notice[data-tone="warning"] { border-color: color-mix(in srgb, var(--matrix-ap-warning) 42%, var(--matrix-ap-border)); }
+.matrix-ap-notice[data-tone="danger"] { border-color: color-mix(in srgb, var(--matrix-ap-danger) 42%, var(--matrix-ap-border)); }
+
+.matrix-ap-button,
+.matrix-ap-link-button {
+  background: var(--matrix-ap-overlay);
+  border: 1px solid var(--matrix-ap-border-strong);
+  border-radius: 7px;
+  color: var(--matrix-ap-text);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 620;
+  min-height: 30px;
+  padding: 6px 10px;
+}
+.matrix-ap-button:hover:not(:disabled) { background: var(--matrix-ap-sunken); }
+.matrix-ap-button-primary { background: var(--matrix-ap-accent); border-color: var(--matrix-ap-accent); color: var(--ap-on-accent, var(--matrix-ap-surface)); }
+.matrix-ap-button-danger { background: var(--matrix-ap-danger); border-color: var(--matrix-ap-danger); color: var(--ap-on-danger, var(--matrix-ap-surface)); }
+.matrix-ap-button:disabled,
+.matrix-ap-link-button:disabled,
+.matrix-ap-icon-button:disabled,
+.matrix-ap-add-button:disabled { cursor: not-allowed; opacity: 0.45; }
+.matrix-ap-link-button { background: transparent; border: 0; color: var(--matrix-ap-muted); min-height: auto; padding: 3px; }
+.matrix-ap-danger-text { color: var(--matrix-ap-danger); }
+
+.matrix-ap-account-list { display: flex; flex-direction: column; gap: 8px; }
+.matrix-ap-account { align-items: center; background: var(--matrix-ap-sunken); border: 1px solid var(--matrix-ap-border); border-radius: 9px; display: grid; gap: 12px; grid-template-columns: minmax(0, 1.5fr) minmax(110px, 1fr) auto; padding: 10px; }
+.matrix-ap-account-main { align-items: center; display: flex; gap: 9px; min-width: 0; }
+.matrix-ap-avatar { border-radius: 50%; height: 28px; width: 28px; }
+.matrix-ap-account-main > div,
+.matrix-ap-account-usage { display: flex; flex-direction: column; min-width: 0; }
+.matrix-ap-account strong { font-size: 12px; }
+.matrix-ap-account span { color: var(--matrix-ap-faint); font-size: 10px; }
+.matrix-ap-account-actions { display: flex; gap: 7px; }
+.matrix-ap-login-methods,
+.matrix-ap-attempt { align-items: center; background: var(--matrix-ap-sunken); border: 1px solid var(--matrix-ap-border); border-radius: 9px; display: flex; flex-wrap: wrap; gap: 7px; margin-bottom: 10px; padding: 9px; }
+.matrix-ap-attempt { justify-content: space-between; }
+.matrix-ap-attempt > span { font-size: 12px; }
+
+.matrix-ap-credit-row { background: var(--matrix-ap-sunken); border: 1px solid var(--matrix-ap-border); border-radius: 9px; gap: 12px; margin-bottom: 14px; padding: 11px; }
+.matrix-ap-credit-row > div:first-child { display: flex; flex-direction: column; }
+.matrix-ap-credit-row strong { font-size: 16px; letter-spacing: -0.02em; }
+.matrix-ap-credit-row span { color: var(--matrix-ap-faint); font-size: 10px; }
+.matrix-ap-policy-grid { align-items: end; display: grid; gap: 10px; grid-template-columns: minmax(0, 1fr) auto; }
+.matrix-ap-money-input { align-items: center; display: flex; padding: 0; }
+.matrix-ap-money-input i { color: var(--matrix-ap-faint); font-style: normal; padding-left: 9px; }
+.matrix-ap-money-input input { border: 0; height: 32px; padding-left: 4px; }
+.matrix-ap-allowlist { border: 0; grid-column: 1 / -1; margin: 4px 0 0; padding: 0; }
+.matrix-ap-allowlist legend { color: var(--matrix-ap-muted); font-size: 11px; font-weight: 620; margin-bottom: 7px; }
+.matrix-ap-allowlist label { align-items: center; color: var(--matrix-ap-text); display: inline-flex; font-size: 11px; gap: 6px; margin: 0 14px 5px 0; }
+.matrix-ap-allowlist input { accent-color: var(--matrix-ap-accent); }
+
+.matrix-ap-help,
+.matrix-ap-empty,
+.matrix-ap-dialog-copy { color: var(--matrix-ap-muted); font-size: 11px; line-height: 1.5; margin: 8px 0 0; }
+.matrix-ap-empty-state { align-items: center; display: flex; flex-direction: column; gap: 7px; justify-content: center; min-height: 420px; text-align: center; }
+.matrix-ap-empty-state span { color: var(--matrix-ap-muted); font-size: 12px; }
+
+.matrix-ap-dialog-backdrop { align-items: center; background: color-mix(in srgb, var(--matrix-ap-text) 28%, transparent); display: flex; inset: 0; justify-content: center; padding: 20px; position: fixed; z-index: var(--ap-dialog-z, 1000); }
+.matrix-ap-dialog { background: var(--matrix-ap-overlay); border: 1px solid var(--matrix-ap-border); border-radius: 14px; box-shadow: 0 18px 48px color-mix(in srgb, var(--matrix-ap-text) 20%, transparent); max-height: min(720px, 86vh); max-width: 600px; overflow: auto; padding: 18px; width: min(600px, 94vw); }
+.matrix-ap-dialog-head { margin-bottom: 16px; }
+.matrix-ap-dialog-head h3 { font-size: 19px; letter-spacing: -0.025em; margin: 0; }
+.matrix-ap-dialog-actions { gap: 8px; justify-content: flex-end; margin-top: 18px; }
+.matrix-ap-driver-grid { display: grid; gap: 7px; grid-template-columns: repeat(2, minmax(0, 1fr)); margin-bottom: 15px; }
+.matrix-ap-driver-grid label { align-items: center; background: var(--matrix-ap-surface); border: 1px solid var(--matrix-ap-border); border-radius: 9px; cursor: pointer; display: flex; gap: 8px; min-height: 46px; padding: 10px; }
+.matrix-ap-driver-grid label[data-selected="true"] { border-color: var(--matrix-ap-accent); box-shadow: inset 0 0 0 1px var(--matrix-ap-accent); }
+.matrix-ap-driver-grid label[data-installed="true"] { cursor: not-allowed; opacity: 0.5; }
+.matrix-ap-driver-grid input { accent-color: var(--matrix-ap-accent); }
+.matrix-ap-driver-grid span { font-size: 13px; font-weight: 620; }
+.matrix-ap-driver-grid small { color: var(--matrix-ap-faint); font-size: 10px; margin-left: auto; }
+
+@media (max-width: 760px) {
+  .matrix-ap-page-head { align-items: flex-start; flex-direction: column; }
+  .matrix-ap-workspace { grid-template-columns: 1fr; }
+  .matrix-ap-rail { border-bottom: 1px solid var(--matrix-ap-border); border-right: 0; }
+  .matrix-ap-rail-list { flex-direction: row; overflow-x: auto; padding-bottom: 2px; }
+  .matrix-ap-rail-item { flex: 0 0 170px; }
+  .matrix-ap-main { padding: 16px; }
+  .matrix-ap-account { align-items: flex-start; grid-template-columns: 1fr auto; }
+  .matrix-ap-account-usage { grid-column: 1; }
+  .matrix-ap-account-actions { grid-column: 2; grid-row: 1 / span 2; }
+}
+
+@media (max-width: 520px) {
+  .matrix-ap-form-grid,
+  .matrix-ap-form-grid-name,
+  .matrix-ap-policy-grid { grid-template-columns: 1fr; }
+  .matrix-ap-policy-grid > .matrix-ap-button { justify-self: start; }
+  .matrix-ap-signal-path { grid-template-columns: 1fr; }
+  .matrix-ap-signal-path > i { display: none; }
+  .matrix-ap-account { grid-template-columns: 1fr; }
+  .matrix-ap-account-actions,
+  .matrix-ap-account-usage { grid-column: 1; grid-row: auto; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .matrix-agents-providers .matrix-ap-switch span,
+  .matrix-agents-providers .matrix-ap-switch span::after { transition: none; }
+}

--- a/packages/ui/src/agents-providers/provider-settings-controller.ts
+++ b/packages/ui/src/agents-providers/provider-settings-controller.ts
@@ -1,0 +1,304 @@
+import { useEffect, useMemo, useSyncExternalStore } from "react";
+import {
+  ProviderSettingsMutationResponseSchema,
+  ProviderSettingsMutationSchema,
+  ProviderSettingsSnapshotSchema,
+  type ProviderConnectionAttempt,
+  type ProviderSettingsMutation,
+  type ProviderSettingsSnapshot,
+} from "@matrix-os/contracts";
+import type { ProviderSettingsMutationIntent } from "./types.js";
+
+const LOAD_ERROR = "Provider settings are unavailable.";
+const MUTATION_ERROR = "Changes were not saved. Refresh and try again.";
+const CONFLICT_ERROR = "Provider settings changed. Latest settings were loaded.";
+const MAX_LISTENERS = 64;
+const MAX_ACTIVE_REQUESTS = 4;
+
+export type ProviderSettingsTransportErrorCode =
+  | "idempotency_conflict"
+  | "invalid_request"
+  | "invalid_response"
+  | "provider_settings_unavailable"
+  | "revision_conflict"
+  | "unavailable";
+
+/** A deliberately message-safe transport error. Upstream details must stay out of UI state. */
+export class ProviderSettingsTransportError extends Error {
+  constructor(
+    readonly code: ProviderSettingsTransportErrorCode,
+    _unsafeCause?: string,
+  ) {
+    super(LOAD_ERROR);
+    this.name = "ProviderSettingsTransportError";
+  }
+}
+
+export interface ProviderSettingsTransport {
+  getSnapshot(signal: AbortSignal): Promise<unknown>;
+  mutate(mutation: ProviderSettingsMutation, signal: AbortSignal): Promise<unknown>;
+}
+
+export interface ProviderSettingsControllerState {
+  identityKey: string;
+  snapshot: ProviderSettingsSnapshot | null;
+  selectedHarnessId: string | null;
+  connectionAttempt: ProviderConnectionAttempt | null;
+  busy: boolean;
+  error: string | null;
+}
+
+export interface ProviderSettingsControllerOptions {
+  identityKey: string;
+  transport: ProviderSettingsTransport;
+}
+
+interface ApplySnapshotOptions {
+  operationId: number;
+  connectionAttempt?: ProviderConnectionAttempt | null;
+}
+
+function hasErrorCode(error: unknown, code: ProviderSettingsTransportErrorCode): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && (error as { code?: unknown }).code === code;
+}
+
+function createIdempotencyKey(): string {
+  const randomUUID = globalThis.crypto?.randomUUID;
+  if (typeof randomUUID !== "function") throw new ProviderSettingsTransportError("unavailable");
+  return randomUUID.call(globalThis.crypto);
+}
+
+function isConnectionAttemptActive(
+  attempt: ProviderConnectionAttempt,
+  snapshot: ProviderSettingsSnapshot,
+): boolean {
+  if (attempt.state !== "pending" && attempt.state !== "authorized") return false;
+  if (Date.parse(attempt.expiresAt) <= Date.parse(snapshot.refreshedAt)) return false;
+  const harness = snapshot.harnesses.find((candidate) => candidate.id === attempt.harnessInstanceId);
+  if (harness === undefined || harness.authState === "authenticated") return false;
+  if (attempt.accountId === null) return true;
+  const account = snapshot.accounts.find((candidate) => candidate.id === attempt.accountId);
+  return account !== undefined && account.authState !== "authenticated";
+}
+
+/**
+ * Framework-neutral state coordinator. It accepts only a transport and never
+ * persists, fetches, or applies optimistic provider state itself.
+ */
+export class ProviderSettingsController {
+  private state: ProviderSettingsControllerState;
+  private readonly listeners = new Set<() => void>();
+  private readonly requests = new Set<AbortController>();
+  private operationClock = 0;
+  private appliedOperationId = 0;
+  private activeRefreshes = 0;
+  private pendingMutations = 0;
+  private mutationTail: Promise<void> = Promise.resolve();
+  private disposed = false;
+
+  constructor(private readonly options: ProviderSettingsControllerOptions) {
+    this.state = {
+      identityKey: options.identityKey,
+      snapshot: null,
+      selectedHarnessId: null,
+      connectionAttempt: null,
+      busy: false,
+      error: null,
+    };
+  }
+
+  getState = (): ProviderSettingsControllerState => this.state;
+
+  subscribe = (listener: () => void): (() => void) => {
+    if (this.disposed) return () => undefined;
+    if (this.listeners.size >= MAX_LISTENERS && !this.listeners.has(listener)) {
+      throw new Error("Provider settings subscription limit reached.");
+    }
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  selectHarness = (harnessInstanceId: string): void => {
+    if (!this.state.snapshot?.harnesses.some((harness) => harness.id === harnessInstanceId)) return;
+    this.update({ selectedHarnessId: harnessInstanceId });
+  };
+
+  refresh = async (): Promise<void> => {
+    if (this.disposed) return;
+    if (this.pendingMutations > 0) await this.mutationTail;
+    if (!this.disposed) await this.runRefresh();
+  };
+
+  mutate = (intent: ProviderSettingsMutationIntent): Promise<void> => {
+    if (this.disposed) return Promise.resolve();
+    this.pendingMutations += 1;
+    this.syncBusy();
+
+    const execution = this.mutationTail.then(async () => this.runMutation(intent));
+    const tracked = execution.finally(() => {
+      this.pendingMutations -= 1;
+      this.syncBusy();
+    });
+    this.mutationTail = tracked.catch(() => undefined);
+    return tracked;
+  };
+
+  dispose = (): void => {
+    if (this.disposed) return;
+    this.disposed = true;
+    for (const request of this.requests) request.abort();
+    this.requests.clear();
+    this.listeners.clear();
+  };
+
+  private async runRefresh(): Promise<boolean> {
+    const operationId = ++this.operationClock;
+    const request = this.beginRequest("refresh");
+    try {
+      const raw = await this.options.transport.getSnapshot(request.signal);
+      const parsed = ProviderSettingsSnapshotSchema.safeParse(raw);
+      if (!parsed.success) throw new ProviderSettingsTransportError("invalid_response");
+      return this.applySnapshot(parsed.data, { operationId });
+    } catch {
+      if (!this.disposed && operationId >= this.appliedOperationId) this.update({ error: LOAD_ERROR });
+      return false;
+    } finally {
+      this.endRequest(request, "refresh");
+    }
+  }
+
+  private async runMutation(intent: ProviderSettingsMutationIntent): Promise<void> {
+    if (this.disposed) return;
+    const current = this.state.snapshot;
+    if (current === null
+      || current.access.mode !== "writable"
+      || !current.supportedActions.includes(intent.type)) {
+      this.update({ error: MUTATION_ERROR });
+      return;
+    }
+
+    let idempotencyKey: string;
+    try {
+      idempotencyKey = createIdempotencyKey();
+    } catch {
+      this.update({ error: MUTATION_ERROR });
+      return;
+    }
+    const parsedMutation = ProviderSettingsMutationSchema.safeParse({
+      ...intent,
+      expectedRevision: current.revision,
+      idempotencyKey,
+    });
+    if (!parsedMutation.success) {
+      this.update({ error: MUTATION_ERROR });
+      return;
+    }
+
+    const operationId = ++this.operationClock;
+    const request = this.beginRequest("mutation");
+    try {
+      const raw = await this.options.transport.mutate(parsedMutation.data, request.signal);
+      const parsed = ProviderSettingsMutationResponseSchema.safeParse(raw);
+      if (!parsed.success) throw new ProviderSettingsTransportError("invalid_response");
+      this.applySnapshot(parsed.data.snapshot, {
+        operationId,
+        connectionAttempt: parsed.data.kind === "login_attempt" ? parsed.data.attempt : null,
+      });
+    } catch (error) {
+      if (this.disposed) return;
+      if (hasErrorCode(error, "revision_conflict")) {
+        const refreshed = await this.runRefresh();
+        if (refreshed) this.update({ error: CONFLICT_ERROR });
+        return;
+      }
+      if (operationId >= this.appliedOperationId) this.update({ error: MUTATION_ERROR });
+    } finally {
+      this.endRequest(request, "mutation");
+    }
+  }
+
+  private applySnapshot(snapshot: ProviderSettingsSnapshot, options: ApplySnapshotOptions): boolean {
+    if (this.disposed || options.operationId < this.appliedOperationId) return false;
+    this.appliedOperationId = options.operationId;
+    const selectedHarnessId = this.state.selectedHarnessId !== null
+      && snapshot.harnesses.some((harness) => harness.id === this.state.selectedHarnessId)
+      ? this.state.selectedHarnessId
+      : snapshot.harnesses[0]?.id ?? null;
+    const previousAttempt = this.state.connectionAttempt;
+    const candidateAttempt = options.connectionAttempt !== undefined
+      ? options.connectionAttempt
+      : previousAttempt;
+    const connectionAttempt = candidateAttempt !== null
+      && isConnectionAttemptActive(candidateAttempt, snapshot)
+      ? candidateAttempt
+      : null;
+    this.update({ snapshot, selectedHarnessId, connectionAttempt, error: null });
+    return true;
+  }
+
+  private beginRequest(kind: "refresh" | "mutation"): AbortController {
+    if (this.requests.size >= MAX_ACTIVE_REQUESTS) {
+      const oldest = this.requests.values().next().value;
+      if (oldest !== undefined) {
+        oldest.abort();
+        this.requests.delete(oldest);
+      }
+    }
+    const request = new AbortController();
+    this.requests.add(request);
+    if (kind === "refresh") {
+      this.activeRefreshes += 1;
+      this.syncBusy();
+    }
+    return request;
+  }
+
+  private endRequest(request: AbortController, kind: "refresh" | "mutation"): void {
+    this.requests.delete(request);
+    if (kind === "refresh") {
+      this.activeRefreshes -= 1;
+      this.syncBusy();
+    }
+  }
+
+  private syncBusy(): void {
+    if (!this.disposed) this.update({ busy: this.activeRefreshes > 0 || this.pendingMutations > 0 });
+  }
+
+  private update(patch: Partial<ProviderSettingsControllerState>): void {
+    if (this.disposed) return;
+    this.state = { ...this.state, ...patch };
+    for (const listener of this.listeners) listener();
+  }
+}
+
+export interface UseProviderSettingsControllerResult extends ProviderSettingsControllerState {
+  onSelectHarness: (harnessInstanceId: string) => void;
+  refresh: () => Promise<void>;
+  mutate: (intent: ProviderSettingsMutationIntent) => Promise<void>;
+}
+
+export function useProviderSettingsController(
+  options: ProviderSettingsControllerOptions,
+): UseProviderSettingsControllerResult {
+  const controller = useMemo(
+    () => new ProviderSettingsController(options),
+    [options.identityKey, options.transport],
+  );
+  const state = useSyncExternalStore(controller.subscribe, controller.getState, controller.getState);
+
+  useEffect(() => {
+    void controller.refresh();
+    return controller.dispose;
+  }, [controller]);
+
+  return {
+    ...state,
+    onSelectHarness: controller.selectHarness,
+    refresh: controller.refresh,
+    mutate: controller.mutate,
+  };
+}

--- a/packages/ui/src/agents-providers/provider-settings-controller.ts
+++ b/packages/ui/src/agents-providers/provider-settings-controller.ts
@@ -162,7 +162,8 @@ export class ProviderSettingsController {
       const parsed = ProviderSettingsSnapshotSchema.safeParse(raw);
       if (!parsed.success) throw new ProviderSettingsTransportError("invalid_response");
       return this.applySnapshot(parsed.data, { operationId });
-    } catch {
+    } catch (error) {
+      console.warn("[provider-settings] Provider settings refresh failed:", error instanceof Error ? error.name : typeof error);
       if (!this.disposed && operationId >= this.appliedOperationId) this.update({ error: LOAD_ERROR });
       return false;
     } finally {
@@ -183,7 +184,8 @@ export class ProviderSettingsController {
     let idempotencyKey: string;
     try {
       idempotencyKey = createIdempotencyKey();
-    } catch {
+    } catch (error) {
+      console.warn("[provider-settings] Could not create mutation idempotency key:", error instanceof Error ? error.name : typeof error);
       this.update({ error: MUTATION_ERROR });
       return;
     }

--- a/packages/ui/src/agents-providers/types.ts
+++ b/packages/ui/src/agents-providers/types.ts
@@ -20,7 +20,13 @@ export type ProviderSettingsMutationIntent =
     }
   | { type: "update_harness"; harnessInstanceId: string; displayName?: string; accentColor?: ProviderAccentColor | null }
   | { type: "set_harness_enabled"; harnessInstanceId: string; enabled: boolean }
-  | { type: "set_route"; harnessInstanceId: string; route: ProviderConfigurableRoute }
+  | {
+      type: "set_route";
+      harnessInstanceId: string;
+      route: ProviderConfigurableRoute;
+      accessSourceId: string;
+      accountId: string | null;
+    }
   | { type: "select_account"; harnessInstanceId: string; accountId: string }
   | { type: "select_access_source"; harnessInstanceId: string; accessSourceId: string }
   | { type: "start_login"; harnessInstanceId: string; accountId: string | null; method: ProviderLoginMethod }

--- a/packages/ui/src/agents-providers/types.ts
+++ b/packages/ui/src/agents-providers/types.ts
@@ -1,0 +1,56 @@
+import type {
+  ProviderAccentColor,
+  ProviderConfigurableRoute,
+  ProviderDependencyCounts,
+  ProviderHarnessKind,
+  ProviderHarnessRoute,
+  ProviderLoginMethod,
+  ProviderSettingsSnapshot,
+} from "@matrix-os/contracts";
+
+export type ProviderSettingsMutationIntent =
+  | {
+      type: "add_harness";
+      harness: ProviderHarnessKind;
+      displayName: string;
+      accentColor?: ProviderAccentColor | null;
+      route: ProviderHarnessRoute;
+      accessSourceId: string;
+      accountId: string | null;
+    }
+  | { type: "update_harness"; harnessInstanceId: string; displayName?: string; accentColor?: ProviderAccentColor | null }
+  | { type: "set_harness_enabled"; harnessInstanceId: string; enabled: boolean }
+  | { type: "set_route"; harnessInstanceId: string; route: ProviderConfigurableRoute }
+  | { type: "select_account"; harnessInstanceId: string; accountId: string }
+  | { type: "select_access_source"; harnessInstanceId: string; accessSourceId: string }
+  | { type: "start_login"; harnessInstanceId: string; accountId: string | null; method: ProviderLoginMethod }
+  | { type: "logout_account"; accountId: string }
+  | {
+      type: "remove_account";
+      accountId: string;
+      dependencyGuard: ProviderDependencyCounts;
+      confirmation: "remove_account";
+    }
+  | {
+      type: "reassign_account";
+      fromAccountId: string;
+      target: { kind: "account"; accountId: string } | { kind: "access_source"; accessSourceId: string };
+      scope: "all_dependencies";
+      dependencyGuard: ProviderDependencyCounts;
+    }
+  | { type: "set_gateway_budget"; monthlyBudgetMicrousd: number | null }
+  | { type: "set_gateway_allowlist"; allowedModelIds: string[] };
+
+export interface AgentsProvidersViewProps {
+  snapshot: ProviderSettingsSnapshot;
+  selectedHarnessId: string | null;
+  connectionAttempt?: import("@matrix-os/contracts").ProviderConnectionAttempt | null;
+  busy?: boolean;
+  error?: string | null;
+  onSelectHarness: (harnessInstanceId: string) => void;
+  onRefresh: () => void;
+  onMutate: (intent: ProviderSettingsMutationIntent) => void;
+  onOpenTerminal: (terminalSessionId: string) => void;
+  onOpenBrowser: (authorizationPath: string) => void;
+  onAddCredit: (accessSourceId: string) => void;
+}

--- a/packages/ui/src/agents-providers/utils.ts
+++ b/packages/ui/src/agents-providers/utils.ts
@@ -1,0 +1,91 @@
+import type {
+  ProviderAccessSource,
+  ProviderAuthenticationState,
+  ProviderDependencyCounts,
+  ProviderHarnessInstance,
+  ProviderSettingsSnapshot,
+  ProviderUsage,
+} from "@matrix-os/contracts";
+
+export function money(microusd: number, currency = "USD"): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(microusd / 1_000_000);
+}
+
+export function shortDate(value: string | null): string | null {
+  if (value === null) return null;
+  return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric" }).format(new Date(value));
+}
+
+export function relativeCheckedAt(value: string, now = Date.now()): string {
+  const checkedAt = new Date(value).getTime();
+  if (!Number.isFinite(checkedAt)) return "at an unknown time";
+  const elapsedSeconds = Math.max(0, Math.round((now - checkedAt) / 1_000));
+  if (elapsedSeconds < 60) return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(-elapsedSeconds, "second");
+  const elapsedMinutes = Math.round(elapsedSeconds / 60);
+  if (elapsedMinutes < 60) return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(-elapsedMinutes, "minute");
+  const elapsedHours = Math.round(elapsedMinutes / 60);
+  if (elapsedHours < 24) return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(-elapsedHours, "hour");
+  return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(-Math.round(elapsedHours / 24), "day");
+}
+
+export function titleCase(value: string): string {
+  return value.split("_").map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`).join(" ");
+}
+
+export function authLabel(state: ProviderAuthenticationState): string {
+  if (state === "authenticated") return "Authenticated";
+  if (state === "unauthenticated") return "Not authenticated";
+  return titleCase(state);
+}
+
+export function usageLines(usage: ProviderUsage): { primary: string; secondary: string | null; stale: boolean } {
+  if (usage.kind === "managed_credit") {
+    return {
+      primary: `${money(usage.remainingMicrousd, usage.currency)} remaining`,
+      secondary: `${money(usage.usedMicrousd, usage.currency)} used of ${money(usage.limitMicrousd, usage.currency)}`,
+      stale: usage.state === "stale",
+    };
+  }
+  if (usage.kind === "metered_api") {
+    const balance = usage.providerBalance === null
+      ? null
+      : `${money(usage.providerBalance.remainingMicrousd, usage.currency)} provider balance`;
+    return {
+      primary: `${money(usage.observedUsageMicrousd, usage.currency)} observed`,
+      secondary: balance,
+      stale: usage.state === "stale" || usage.providerBalance?.state === "stale",
+    };
+  }
+  if (usage.kind === "subscription_allowance") {
+    return {
+      primary: `${Math.round(usage.usedBasisPoints / 100)}% used`,
+      secondary: usage.resetsAt === null ? null : `Resets ${shortDate(usage.resetsAt)}`,
+      stale: usage.state === "stale",
+    };
+  }
+  return {
+    primary: "Usage unavailable",
+    secondary: titleCase(usage.reason),
+    stale: false,
+  };
+}
+
+export function gatewayCreditLines(source: ProviderAccessSource): { primary: string; secondary: string | null; stale: boolean } {
+  if (source.usage.kind !== "managed_credit") {
+    return { primary: "Credit unavailable", secondary: source.usage.kind === "unavailable" ? titleCase(source.usage.reason) : null, stale: false };
+  }
+  return usageLines(source.usage);
+}
+
+export function selectedHarness(snapshot: ProviderSettingsSnapshot, id: string | null): ProviderHarnessInstance | null {
+  return snapshot.harnesses.find((harness) => harness.id === id) ?? snapshot.harnesses[0] ?? null;
+}
+
+export function dependenciesTotal(dependencies: ProviderDependencyCounts): number {
+  return dependencies.activeChatCount + dependencies.resumableChatCount + dependencies.harnessInstanceCount;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -21,3 +21,9 @@ export { Tooltip } from "./Tooltip.js";
 export type { TooltipProps } from "./Tooltip.js";
 
 export { cn } from "./cn.js";
+
+export { AgentsProvidersView } from "./agents-providers/AgentsProvidersView.js";
+export type {
+  AgentsProvidersViewProps,
+  ProviderSettingsMutationIntent,
+} from "./agents-providers/AgentsProvidersView.js";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -27,3 +27,16 @@ export type {
   AgentsProvidersViewProps,
   ProviderSettingsMutationIntent,
 } from "./agents-providers/AgentsProvidersView.js";
+
+export {
+  ProviderSettingsController,
+  ProviderSettingsTransportError,
+  useProviderSettingsController,
+} from "./agents-providers/provider-settings-controller.js";
+export type {
+  ProviderSettingsControllerState,
+  ProviderSettingsControllerOptions,
+  ProviderSettingsTransport,
+  ProviderSettingsTransportErrorCode,
+  UseProviderSettingsControllerResult,
+} from "./agents-providers/provider-settings-controller.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,9 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
+      '@matrix-os/ui':
+        specifier: workspace:*
+        version: link:../packages/ui
       '@radix-ui/react-context-menu':
         specifier: ^2.2.16
         version: 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -939,6 +942,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@matrix-os/contracts':
+        specifier: workspace:*
+        version: link:../contracts
       react:
         specifier: ^19.0.0
         version: 19.2.3
@@ -1012,6 +1018,9 @@ importers:
       '@matrix-os/observability':
         specifier: workspace:*
         version: link:../packages/observability
+      '@matrix-os/ui':
+        specifier: workspace:*
+        version: link:../packages/ui
       '@react-three/drei':
         specifier: ^10.7.7
         version: 10.7.7(@react-three/fiber@9.6.1(55bcdcd534dc5f40e9f34a7ab33a16a6))(@types/react@19.2.14)(@types/three@0.183.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.184.0)

--- a/shell/next.config.ts
+++ b/shell/next.config.ts
@@ -13,7 +13,7 @@ const nextConfig: NextConfig = {
     NEXT_PUBLIC_PLATFORM_SHELL_ASSET_PREFIX: platformShellAssetPrefix ?? "",
   },
   reactCompiler: true,
-  transpilePackages: ["@matrix-os/contracts", "@matrix-os/observability"],
+  transpilePackages: ["@matrix-os/contracts", "@matrix-os/observability", "@matrix-os/ui"],
   // Allow HMR websockets when the dev shell is reached through a tunnel
   // (staging/dev.matrix-os.com) rather than localhost. Next 16 blocks dev
   // resources on cross-origin hostnames by default.

--- a/shell/package.json
+++ b/shell/package.json
@@ -30,6 +30,7 @@
     "@matrix-os/brand": "workspace:*",
     "@matrix-os/contracts": "workspace:*",
     "@matrix-os/observability": "workspace:*",
+    "@matrix-os/ui": "workspace:*",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.1",
     "@streamdown/cjk": "^1.0.2",

--- a/shell/src/app/globals.css
+++ b/shell/src/app/globals.css
@@ -2,6 +2,7 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "@clerk/ui/themes/shadcn.css";
+@import "@matrix-os/ui/agents-providers.css";
 
 /* Opt-in command-list motion: immediate entry, delayed fade on exit. */
 [data-instant-list-hover] {

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -60,6 +60,7 @@ import {
   TERMINAL_SETUP_WINDOW_PATH,
   type TerminalLaunchAction,
 } from "@/lib/terminal-launch";
+import { enqueueExistingTerminalSession } from "@/lib/provider-terminal-session";
 import {
   loadShellSnapshot,
   saveShellSnapshot,
@@ -424,7 +425,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
     focusOrOpen(name ?? apps.find((app) => app.path === path)?.name ?? "App", path);
   }, [apps, focusOrOpen]);
 
-  const openSetupTerminal = (action: TerminalLaunchAction) => {
+  const focusTerminalForHandoff = (handoff: (targetId?: string) => void) => {
     const windows = useWindowManager.getState().windows;
     const focusedId = useWindowManager.getState().focusedWindowId;
     const focusedTerminal = windows.find((w) => w.id === focusedId && w.path.startsWith("__terminal__"));
@@ -457,7 +458,17 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
           );
         }
       }
-      enqueueTerminalLaunch(action, win?.id);
+      handoff(win?.id);
+    });
+  };
+
+  const openSetupTerminal = (action: TerminalLaunchAction) => {
+    focusTerminalForHandoff((targetId) => enqueueTerminalLaunch(action, targetId));
+  };
+
+  const openExistingProviderTerminal = (sessionId: string) => {
+    focusTerminalForHandoff((targetId) => {
+      if (targetId) enqueueExistingTerminalSession(sessionId, targetId);
     });
   };
 
@@ -1612,6 +1623,10 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
         onOpenAgentTerminal={(action) => {
           setSettingsOpen(false);
           openSetupTerminal(action);
+        }}
+        onOpenProviderTerminalSession={(sessionId) => {
+          setSettingsOpen(false);
+          openExistingProviderTerminal(sessionId);
         }}
       />
       {/* Single ChatPopover instance shared by desktop + mobile dock

--- a/shell/src/components/Settings.tsx
+++ b/shell/src/components/Settings.tsx
@@ -151,6 +151,7 @@ interface SettingsProps {
     collectAcquisitionSource?: boolean;
   };
   onOpenAgentTerminal?: (action: TerminalLaunchAction) => void;
+  onOpenProviderTerminalSession?: (sessionId: string) => void;
 }
 
 export function Settings({
@@ -189,7 +190,7 @@ function SettingsFrame({
   billingCheckoutReturnPath,
   billingCheckoutRuntimeSlot,
   onboardingDefaultInstalls,
-  onOpenAgentTerminal,
+  onOpenProviderTerminalSession,
   billingActive,
   showBillingSection,
 }: SettingsFrameProps) {
@@ -400,7 +401,9 @@ function SettingsFrame({
 
             <main className="min-h-0 min-w-0 flex-1 overflow-y-auto overscroll-contain">
               {activeSection === "appearance" && <AppearanceSection />}
-              {activeSection === "agents-providers" && <AgentSection onOpenTerminal={onOpenAgentTerminal} />}
+              {activeSection === "agents-providers" && (
+                <AgentSection onOpenTerminal={onOpenProviderTerminalSession} />
+              )}
               {activeSection === "identity-personality" && <IdentityPersonalitySection />}
               {activeSection === "channels" && <ChannelsSection />}
               {activeSection === "integrations" && <IntegrationsSection />}

--- a/shell/src/components/Settings.tsx
+++ b/shell/src/components/Settings.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/hugeicons";
 import { AppearanceSection } from "./settings/sections/AppearanceSection";
 import { AgentSection } from "./settings/sections/AgentSection";
+import { IdentityPersonalitySection } from "./settings/sections/IdentityPersonalitySection";
 import { ChannelsSection } from "./settings/sections/ChannelsSection";
 import { IntegrationsSection } from "./settings/sections/IntegrationsSection";
 import { SkillsSection } from "./settings/sections/SkillsSection";
@@ -46,7 +47,8 @@ import type { TerminalLaunchAction } from "@/lib/terminal-launch";
 
 const sections = [
   { id: "appearance", label: "Appearance", icon: PaletteIcon },
-  { id: "agent", label: "Agent", icon: UserIcon },
+  { id: "agents-providers", label: "Agents & providers", icon: SparklesIcon },
+  { id: "identity-personality", label: "Identity & personality", icon: UserIcon },
   { id: "channels", label: "Channels", icon: MessageSquareIcon },
   { id: "integrations", label: "Services", icon: CableIcon },
   { id: "skills", label: "Skills", icon: SparklesIcon },
@@ -59,7 +61,13 @@ const sections = [
 
 export type SettingsSectionId = typeof sections[number]["id"];
 type SectionId = SettingsSectionId | "default-installs";
+type LegacySettingsSectionId = "agent" | "providers";
+type SettingsSectionInputId = SectionId | LegacySettingsSectionId;
 type SettingsSection = { id: SectionId; label: string; icon: typeof PaletteIcon };
+
+function normalizeSettingsSectionId(section: SettingsSectionInputId): SectionId {
+  return section === "agent" || section === "providers" ? "agents-providers" : section;
+}
 
 // Sections temporarily hidden from the Settings nav for the paid-beta scope.
 // The section components and render branches below are intentionally kept so a
@@ -127,8 +135,8 @@ function SettingsAccountFooter() {
 interface SettingsProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  defaultSection?: SectionId;
-  lockedSection?: SectionId;
+  defaultSection?: SettingsSectionInputId;
+  lockedSection?: SettingsSectionInputId;
   billingActiveOverride?: boolean | null;
   closeDisabled?: boolean;
   billingMode?: "settings" | "provisioning" | "device-setup" | "add-computer";
@@ -186,12 +194,18 @@ function SettingsFrame({
   showBillingSection,
 }: SettingsFrameProps) {
   const onboardingMode = onboardingDefaultInstalls !== undefined;
+  const canonicalDefaultSection = normalizeSettingsSectionId(defaultSection);
+  const canonicalLockedSection = lockedSection === undefined
+    ? undefined
+    : normalizeSettingsSectionId(lockedSection);
   const resolvedDefaultSection = onboardingMode
     ? "default-installs"
-    : !showBillingSection && defaultSection === "billing"
+    : !showBillingSection && canonicalDefaultSection === "billing"
       ? "appearance"
-      : defaultSection;
-  const resolvedLockedSection = !showBillingSection && lockedSection === "billing" ? undefined : lockedSection;
+      : canonicalDefaultSection;
+  const resolvedLockedSection = !showBillingSection && canonicalLockedSection === "billing"
+    ? undefined
+    : canonicalLockedSection;
   const standardFrameSections: SettingsSection[] = showBillingSection
     ? visibleSections
     : visibleSections.filter((section) => section.id !== "billing");
@@ -386,7 +400,8 @@ function SettingsFrame({
 
             <main className="min-h-0 min-w-0 flex-1 overflow-y-auto overscroll-contain">
               {activeSection === "appearance" && <AppearanceSection />}
-              {activeSection === "agent" && <AgentSection onOpenTerminal={onOpenAgentTerminal} />}
+              {activeSection === "agents-providers" && <AgentSection onOpenTerminal={onOpenAgentTerminal} />}
+              {activeSection === "identity-personality" && <IdentityPersonalitySection />}
               {activeSection === "channels" && <ChannelsSection />}
               {activeSection === "integrations" && <IntegrationsSection />}
               {activeSection === "skills" && <SkillsSection />}

--- a/shell/src/components/mobile/MobileShell.tsx
+++ b/shell/src/components/mobile/MobileShell.tsx
@@ -50,6 +50,7 @@ import { AppViewer } from "@/components/AppViewer";
 import { Settings } from "@/components/Settings";
 import { PreviewWindow } from "@/components/preview-window/PreviewWindow";
 import { enqueueTerminalLaunch, type TerminalLaunchAction } from "@/lib/terminal-launch";
+import { enqueueExistingTerminalSession } from "@/lib/provider-terminal-session";
 
 interface MobileApp {
   id: string;
@@ -318,6 +319,20 @@ export function MobileShell({ launchAppPath, onOpenCommandPalette, cacheScope }:
     enqueueTerminalLaunch(action, id);
   }, []);
 
+  const openExistingProviderTerminal = useCallback((sessionId: string) => {
+    const terminal = BUILT_IN_APPS.find((app) => app.path === "__terminal__");
+    if (!terminal) return;
+    const terminals = stackRef.current.filter((entry) => entry.app.path === "__terminal__");
+    const reusable = terminals[terminals.length - 1];
+    const id = reusable?.id ?? `term:${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+    setOpenStack((previous) => reusable
+      ? [...previous.filter((entry) => entry.id !== reusable.id), reusable]
+      : [...previous, { id, app: terminal, openedAt: Date.now() }]);
+    setSettingsOpen(false);
+    setView("app");
+    enqueueExistingTerminalSession(sessionId, id);
+  }, []);
+
   useEffect(() => {
     if (!launchAppPath || launchPathConsumedRef.current === launchAppPath) return;
     const app = apps.find((candidate) => candidate.path === launchAppPath);
@@ -555,6 +570,7 @@ export function MobileShell({ launchAppPath, onOpenCommandPalette, cacheScope }:
         open={settingsOpen}
         onOpenChange={setSettingsOpen}
         onOpenAgentTerminal={openAgentSetupTerminal}
+        onOpenProviderTerminalSession={openExistingProviderTerminal}
       />
     </div>
     </MotionConfig>

--- a/shell/src/components/settings/sections/AgentSection.tsx
+++ b/shell/src/components/settings/sections/AgentSection.tsx
@@ -1,15 +1,49 @@
-import { AgentRuntimePanel } from "./AgentRuntimePanel";
-import type { TerminalLaunchAction } from "@/lib/terminal-launch";
+"use client";
+
+import { useMemo } from "react";
+import { AgentsProvidersView, useProviderSettingsController } from "@matrix-os/ui";
+import { getGatewayUrl } from "@/lib/gateway";
+import { openProviderAuthorizationPath } from "@/lib/provider-browser-action";
+import { createProviderSettingsTransport } from "@/lib/provider-settings-transport";
 
 export function AgentSection({
   onOpenTerminal,
 }: {
-  onOpenTerminal?: (action: TerminalLaunchAction) => void;
+  onOpenTerminal?: (terminalSessionId: string) => void;
 }) {
+  const transport = useMemo(() => createProviderSettingsTransport(), []);
+  const controller = useProviderSettingsController({
+    identityKey: getGatewayUrl(),
+    transport,
+  });
+
+  if (controller.snapshot === null) {
+    const unavailable = controller.error !== null;
+    return (
+      <div className="matrix-agents-providers" aria-busy={unavailable ? undefined : "true"} data-provider-settings-adapter="shared">
+        <div className="matrix-ap-empty-state" role={unavailable ? "alert" : "status"}>
+          <strong>{unavailable ? "Provider settings are unavailable" : "Loading agents & providers"}</strong>
+          <span>{unavailable ? "Refresh Settings to try again." : "Checking this computer’s provider state…"}</span>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="mx-auto max-w-3xl space-y-6 p-6" data-provider-settings-adapter="legacy">
-      <h2 className="text-lg font-semibold">Agents &amp; providers</h2>
-      <AgentRuntimePanel onOpenTerminal={onOpenTerminal} />
+    <div data-provider-settings-adapter="shared">
+      <AgentsProvidersView
+        snapshot={controller.snapshot}
+        selectedHarnessId={controller.selectedHarnessId}
+        connectionAttempt={controller.connectionAttempt}
+        busy={controller.busy}
+        error={controller.error}
+        onSelectHarness={controller.onSelectHarness}
+        onRefresh={() => { void controller.refresh(); }}
+        onMutate={(intent) => { void controller.mutate(intent); }}
+        onOpenTerminal={(sessionId) => { onOpenTerminal?.(sessionId); }}
+        onOpenBrowser={openProviderAuthorizationPath}
+        onAddCredit={() => undefined}
+      />
     </div>
   );
 }

--- a/shell/src/components/settings/sections/AgentSection.tsx
+++ b/shell/src/components/settings/sections/AgentSection.tsx
@@ -1,132 +1,15 @@
-"use client";
-
-import { useState, useEffect } from "react";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { MarkdownEditor } from "../MarkdownEditor";
-import { getGatewayUrl } from "@/lib/gateway";
-import { UserIcon } from "@/lib/hugeicons";
 import { AgentRuntimePanel } from "./AgentRuntimePanel";
 import type { TerminalLaunchAction } from "@/lib/terminal-launch";
-
-const GATEWAY = getGatewayUrl();
-const AGENT_FETCH_TIMEOUT_MS = 10_000;
-
-interface Identity {
-  handle?: string;
-  aiHandle?: string;
-  displayName?: string;
-}
 
 export function AgentSection({
   onOpenTerminal,
 }: {
   onOpenTerminal?: (action: TerminalLaunchAction) => void;
 }) {
-  const [identity, setIdentity] = useState<Identity>({});
-  const [soulContent, setSoulContent] = useState("");
-  const [saving, setSaving] = useState(false);
-
-  // react-doctor-disable-next-line react-doctor/no-fetch-in-effect -- guarded run-once mount load (empty deps): both requests carry AbortSignal.timeout, the `cancelled` flag gates every setState, and the controller aborts in cleanup, so this is the correct fetch-on-mount pattern; a data-fetching library would add no safety here.
-  useEffect(() => {
-    let cancelled = false;
-
-    fetch(`${GATEWAY}/api/identity`, {
-      signal: AbortSignal.timeout(AGENT_FETCH_TIMEOUT_MS),
-    })
-      .then((r) => r.ok ? r.json() : {})
-      .then((data) => { if (!cancelled) setIdentity(data); })
-      .catch((error: unknown) => {
-        if (!cancelled) {
-          console.warn("Failed to load identity settings", error);
-        }
-      });
-
-    fetch(`${GATEWAY}/files/system/soul.md`, {
-      signal: AbortSignal.timeout(AGENT_FETCH_TIMEOUT_MS),
-    })
-      .then((r) => r.ok ? r.text() : "")
-      .then((text) => { if (!cancelled) setSoulContent(text); })
-      .catch((error: unknown) => {
-        if (!cancelled) {
-          console.warn("Failed to load soul settings", error);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const handleSaveSoul = async (content: string) => {
-    setSaving(true);
-    // react-doctor-disable-next-line react-hooks-js/todo -- React Compiler bailout on the try/finally needed to reset `saving` on every path; the code is correct and the finalizer must run whether the request resolves, rejects, or throws.
-    try {
-      const response = await fetch(`${GATEWAY}/files/system/soul.md`, {
-        method: "PUT",
-        signal: AbortSignal.timeout(AGENT_FETCH_TIMEOUT_MS),
-        headers: { "Content-Type": "text/markdown; charset=utf-8" },
-        body: content,
-      });
-      if (!response.ok) throw new Error("SOUL update failed");
-      setSoulContent(content);
-    } finally {
-      setSaving(false);
-    }
-  };
-
   return (
-    <div className="max-w-3xl mx-auto p-6 space-y-6">
-      <h2 className="text-lg font-semibold">Agent</h2>
-
+    <div className="mx-auto max-w-3xl space-y-6 p-6" data-provider-settings-adapter="legacy">
+      <h2 className="text-lg font-semibold">Agents &amp; providers</h2>
       <AgentRuntimePanel onOpenTerminal={onOpenTerminal} />
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-sm flex items-center gap-2">
-            <UserIcon className="size-4" />
-            Identity
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <div className="flex flex-wrap gap-4 text-sm">
-            <div>
-              <span className="text-muted-foreground">Display Name</span>
-              <p className="font-medium">{identity.displayName || "Not set"}</p>
-            </div>
-            <div>
-              <span className="text-muted-foreground">Handle</span>
-              <p className="font-medium">
-                {identity.handle ? (
-                  <Badge variant="secondary">@{identity.handle}:matrix-os.com</Badge>
-                ) : "Not set"}
-              </p>
-            </div>
-            <div>
-              <span className="text-muted-foreground">AI Handle</span>
-              <p className="font-medium">
-                {identity.aiHandle ? (
-                  <Badge variant="secondary">@{identity.aiHandle}:matrix-os.com</Badge>
-                ) : "Not set"}
-              </p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-sm">SOUL (Personality)</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <MarkdownEditor
-            content={soulContent}
-            onSave={handleSaveSoul}
-            saving={saving}
-            placeholder="Define your agent's personality, tone, and boundaries..."
-          />
-        </CardContent>
-      </Card>
     </div>
   );
 }

--- a/shell/src/components/settings/sections/IdentityPersonalitySection.tsx
+++ b/shell/src/components/settings/sections/IdentityPersonalitySection.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { getGatewayUrl } from "@/lib/gateway";
+import { UserIcon } from "@/lib/hugeicons";
+import { MarkdownEditor } from "../MarkdownEditor";
+
+const GATEWAY = getGatewayUrl();
+const IDENTITY_FETCH_TIMEOUT_MS = 10_000;
+
+interface Identity {
+  handle?: string;
+  aiHandle?: string;
+  displayName?: string;
+}
+
+export function IdentityPersonalitySection() {
+  const [identity, setIdentity] = useState<Identity>({});
+  const [soulContent, setSoulContent] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  // react-doctor-disable-next-line react-doctor/no-fetch-in-effect -- guarded run-once mount load: requests are bounded and every state update is cancellation-gated.
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch(`${GATEWAY}/api/identity`, {
+      signal: AbortSignal.timeout(IDENTITY_FETCH_TIMEOUT_MS),
+    })
+      .then((response) => response.ok ? response.json() : {})
+      .then((data) => { if (!cancelled) setIdentity(data); })
+      .catch((error: unknown) => {
+        if (!cancelled) console.warn("Failed to load identity settings", error);
+      });
+
+    fetch(`${GATEWAY}/files/system/soul.md`, {
+      signal: AbortSignal.timeout(IDENTITY_FETCH_TIMEOUT_MS),
+    })
+      .then((response) => response.ok ? response.text() : "")
+      .then((text) => { if (!cancelled) setSoulContent(text); })
+      .catch((error: unknown) => {
+        if (!cancelled) console.warn("Failed to load soul settings", error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSaveSoul = async (content: string) => {
+    setSaving(true);
+    // react-doctor-disable-next-line react-hooks-js/todo -- the finalizer must reset `saving` after every request outcome.
+    try {
+      const response = await fetch(`${GATEWAY}/files/system/soul.md`, {
+        method: "PUT",
+        signal: AbortSignal.timeout(IDENTITY_FETCH_TIMEOUT_MS),
+        headers: { "Content-Type": "text/markdown; charset=utf-8" },
+        body: content,
+      });
+      if (!response.ok) throw new Error("SOUL update failed");
+      setSoulContent(content);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-6">
+      <h2 className="text-lg font-semibold">Identity &amp; personality</h2>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-sm">
+            <UserIcon className="size-4" />
+            Identity
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex flex-wrap gap-4 text-sm">
+            <div>
+              <span className="text-muted-foreground">Display Name</span>
+              <p className="font-medium">{identity.displayName || "Not set"}</p>
+            </div>
+            <div>
+              <span className="text-muted-foreground">Handle</span>
+              <p className="font-medium">
+                {identity.handle ? <Badge variant="secondary">@{identity.handle}:matrix-os.com</Badge> : "Not set"}
+              </p>
+            </div>
+            <div>
+              <span className="text-muted-foreground">AI Handle</span>
+              <p className="font-medium">
+                {identity.aiHandle ? <Badge variant="secondary">@{identity.aiHandle}:matrix-os.com</Badge> : "Not set"}
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">SOUL (Personality)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <MarkdownEditor
+            content={soulContent}
+            onSave={handleSaveSoul}
+            saving={saving}
+            placeholder="Define your agent's personality, tone, and boundaries..."
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -11,7 +11,7 @@ import { getGatewayUrl } from "@/lib/gateway";
 import { isTerminalDebugEnabled } from "@/lib/terminal-debug";
 import { drainTerminalLaunchQueue, TERMINAL_LAUNCH_EVENT } from "@/lib/terminal-launch";
 import {
-  drainExistingTerminalSessionQueue,
+  drainExistingTerminalSessionQueueWithRetry,
   PROVIDER_TERMINAL_SESSION_EVENT,
 } from "@/lib/provider-terminal-session";
 import { useTerminalSettings, type TerminalThemeId } from "@/stores/terminal-settings";
@@ -294,6 +294,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
   // react-doctor-disable-next-line react-hooks-js/refs -- latest-value mirror of `sidebarOpen`, read synchronously inside the layout-persistence callback that must not re-subscribe when the sidebar toggles
   sidebarOpenRef.current = sidebarOpen;
   const mountedRef = useRef(false);
+  const providerDrainInflightRef = useRef<Promise<void> | null>(null);
   const pendingPaneSessionsRef = useRef<Map<string, string> | null>(null);
   if (pendingPaneSessionsRef.current === null) pendingPaneSessionsRef.current = new Map();
   const closingPaneIdsRef = useRef<Set<string> | null>(null);
@@ -649,20 +650,28 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     return () => window.removeEventListener(TERMINAL_LAUNCH_EVENT, handleLaunch);
   }, [initialized, launchTargetId]);
 
-  const drainProviderSessions = useEffectEvent(async (event?: Event) => {
+  const drainProviderSessions = useEffectEvent((event?: Event): Promise<void> => {
     const eventTargetId = event instanceof CustomEvent ? event.detail?.targetId : undefined;
-    if (typeof eventTargetId === "string" && eventTargetId !== launchTargetId) return;
-    const sessionIds = await drainExistingTerminalSessionQueue(launchTargetId);
-    if (!mountedRef.current) return;
-    for (const sessionId of sessionIds) {
-      const existingTab = tabsRef.current.find((tab) => getSessionIds(tab.paneTree).includes(sessionId));
-      if (existingTab) {
-        setActiveTabId(existingTab.id);
-        requestPaneFocus(getPaneIdsForSession(existingTab.paneTree, sessionId)[0] ?? getFirstPaneId(existingTab.paneTree));
-      } else {
-        addSessionTab(formatShellDisplayName(sessionId), sessionId);
+    if (typeof eventTargetId === "string" && eventTargetId !== launchTargetId) return Promise.resolve();
+    if (providerDrainInflightRef.current) return providerDrainInflightRef.current;
+    const operation = (async () => {
+      const sessionIds = await drainExistingTerminalSessionQueueWithRetry(launchTargetId);
+      if (!mountedRef.current) return;
+      for (const sessionId of sessionIds) {
+        const existingTab = tabsRef.current.find((tab) => getSessionIds(tab.paneTree).includes(sessionId));
+        if (existingTab) {
+          setActiveTabId(existingTab.id);
+          requestPaneFocus(getPaneIdsForSession(existingTab.paneTree, sessionId)[0] ?? getFirstPaneId(existingTab.paneTree));
+        } else {
+          addSessionTab(formatShellDisplayName(sessionId), sessionId);
+        }
       }
-    }
+    })();
+    providerDrainInflightRef.current = operation;
+    void operation.finally(() => {
+      if (providerDrainInflightRef.current === operation) providerDrainInflightRef.current = null;
+    });
+    return operation;
   });
 
   useEffect(() => {

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -12,6 +12,7 @@ import { isTerminalDebugEnabled } from "@/lib/terminal-debug";
 import { drainTerminalLaunchQueue, TERMINAL_LAUNCH_EVENT } from "@/lib/terminal-launch";
 import {
   drainExistingTerminalSessionQueueWithRetry,
+  hasQueuedExistingTerminalSession,
   PROVIDER_TERMINAL_SESSION_EVENT,
 } from "@/lib/provider-terminal-session";
 import { useTerminalSettings, type TerminalThemeId } from "@/stores/terminal-settings";
@@ -295,6 +296,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
   sidebarOpenRef.current = sidebarOpen;
   const mountedRef = useRef(false);
   const providerDrainInflightRef = useRef<Promise<void> | null>(null);
+  const providerDrainRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingPaneSessionsRef = useRef<Map<string, string> | null>(null);
   if (pendingPaneSessionsRef.current === null) pendingPaneSessionsRef.current = new Map();
   const closingPaneIdsRef = useRef<Set<string> | null>(null);
@@ -654,6 +656,10 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     const eventTargetId = event instanceof CustomEvent ? event.detail?.targetId : undefined;
     if (typeof eventTargetId === "string" && eventTargetId !== launchTargetId) return Promise.resolve();
     if (providerDrainInflightRef.current) return providerDrainInflightRef.current;
+    if (providerDrainRetryTimerRef.current) {
+      clearTimeout(providerDrainRetryTimerRef.current);
+      providerDrainRetryTimerRef.current = null;
+    }
     const operation = (async () => {
       const sessionIds = await drainExistingTerminalSessionQueueWithRetry(launchTargetId);
       if (!mountedRef.current) return;
@@ -670,6 +676,13 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     providerDrainInflightRef.current = operation;
     void operation.finally(() => {
       if (providerDrainInflightRef.current === operation) providerDrainInflightRef.current = null;
+      if (mountedRef.current && hasQueuedExistingTerminalSession(launchTargetId)
+        && providerDrainRetryTimerRef.current === null) {
+        providerDrainRetryTimerRef.current = setTimeout(() => {
+          providerDrainRetryTimerRef.current = null;
+          void drainProviderSessions();
+        }, 5_000);
+      }
     });
     return operation;
   });
@@ -681,7 +694,13 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     };
     void drainProviderSessions();
     window.addEventListener(PROVIDER_TERMINAL_SESSION_EVENT, handleProviderSession);
-    return () => window.removeEventListener(PROVIDER_TERMINAL_SESSION_EVENT, handleProviderSession);
+    return () => {
+      window.removeEventListener(PROVIDER_TERMINAL_SESSION_EVENT, handleProviderSession);
+      if (providerDrainRetryTimerRef.current) {
+        clearTimeout(providerDrainRetryTimerRef.current);
+        providerDrainRetryTimerRef.current = null;
+      }
+    };
   }, [initialized, launchTargetId]);
 
   const flushLayout = useEffectEvent(() => {

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -10,6 +10,10 @@ import { TerminalDesignTabStrip } from "./TerminalDesignTabStrip";
 import { getGatewayUrl } from "@/lib/gateway";
 import { isTerminalDebugEnabled } from "@/lib/terminal-debug";
 import { drainTerminalLaunchQueue, TERMINAL_LAUNCH_EVENT } from "@/lib/terminal-launch";
+import {
+  drainExistingTerminalSessionQueue,
+  PROVIDER_TERMINAL_SESSION_EVENT,
+} from "@/lib/provider-terminal-session";
 import { useTerminalSettings, type TerminalThemeId } from "@/stores/terminal-settings";
 import { isShellThemeId } from "@/stores/terminal-defaults";
 import { getTerminalThemePreset } from "./terminal-themes";
@@ -643,6 +647,32 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     drainLaunches();
     window.addEventListener(TERMINAL_LAUNCH_EVENT, handleLaunch);
     return () => window.removeEventListener(TERMINAL_LAUNCH_EVENT, handleLaunch);
+  }, [initialized, launchTargetId]);
+
+  const drainProviderSessions = useEffectEvent(async (event?: Event) => {
+    const eventTargetId = event instanceof CustomEvent ? event.detail?.targetId : undefined;
+    if (typeof eventTargetId === "string" && eventTargetId !== launchTargetId) return;
+    const sessionIds = await drainExistingTerminalSessionQueue(launchTargetId);
+    if (!mountedRef.current) return;
+    for (const sessionId of sessionIds) {
+      const existingTab = tabsRef.current.find((tab) => getSessionIds(tab.paneTree).includes(sessionId));
+      if (existingTab) {
+        setActiveTabId(existingTab.id);
+        requestPaneFocus(getPaneIdsForSession(existingTab.paneTree, sessionId)[0] ?? getFirstPaneId(existingTab.paneTree));
+      } else {
+        addSessionTab(formatShellDisplayName(sessionId), sessionId);
+      }
+    }
+  });
+
+  useEffect(() => {
+    if (!initialized) return;
+    const handleProviderSession = (event: Event) => {
+      void drainProviderSessions(event);
+    };
+    void drainProviderSessions();
+    window.addEventListener(PROVIDER_TERMINAL_SESSION_EVENT, handleProviderSession);
+    return () => window.removeEventListener(PROVIDER_TERMINAL_SESSION_EVENT, handleProviderSession);
   }, [initialized, launchTargetId]);
 
   const flushLayout = useEffectEvent(() => {

--- a/shell/src/lib/provider-browser-action.ts
+++ b/shell/src/lib/provider-browser-action.ts
@@ -1,0 +1,19 @@
+import { ProviderConnectionAttemptActionSchema } from "@matrix-os/contracts";
+import { getGatewayUrl } from "./gateway";
+
+export function openProviderAuthorizationPath(authorizationPath: string): boolean {
+  const action = ProviderConnectionAttemptActionSchema.safeParse({
+    kind: "open_browser",
+    authorizationPath,
+  });
+  if (!action.success || action.data.kind !== "open_browser" || typeof window === "undefined") {
+    return false;
+  }
+
+  window.open(
+    `${getGatewayUrl()}${action.data.authorizationPath}`,
+    "_blank",
+    "noopener,noreferrer",
+  );
+  return true;
+}

--- a/shell/src/lib/provider-settings-transport.ts
+++ b/shell/src/lib/provider-settings-transport.ts
@@ -1,0 +1,132 @@
+import {
+  ProviderSettingsMutationResponseSchema,
+  ProviderSettingsMutationSchema,
+  ProviderSettingsSnapshotSchema,
+  type ProviderSettingsMutation,
+  type ProviderSettingsMutationResponse,
+  type ProviderSettingsSnapshot,
+} from "@matrix-os/contracts";
+import { ProviderSettingsTransportError } from "@matrix-os/ui";
+import { getGatewayUrl } from "./gateway";
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const MAX_RESPONSE_BYTES = 1024 * 1024;
+const MAX_MUTATION_BYTES = 64 * 1024;
+
+export { ProviderSettingsTransportError } from "@matrix-os/ui";
+
+type Fetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+export interface ProviderSettingsTransport {
+  getSnapshot(signal?: AbortSignal): Promise<ProviderSettingsSnapshot>;
+  mutate(mutation: ProviderSettingsMutation, signal?: AbortSignal): Promise<ProviderSettingsMutationResponse>;
+}
+
+function requestSignal(signal?: AbortSignal): AbortSignal {
+  const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+async function boundedJson(response: Response): Promise<unknown> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_RESPONSE_BYTES) {
+    throw new ProviderSettingsTransportError("invalid_response");
+  }
+  if (!response.body) {
+    throw new ProviderSettingsTransportError("invalid_response");
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_RESPONSE_BYTES) {
+        await reader.cancel();
+        throw new ProviderSettingsTransportError("invalid_response");
+      }
+      chunks.push(value);
+    }
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return JSON.parse(new TextDecoder().decode(bytes));
+  } catch (error) {
+    if (error instanceof ProviderSettingsTransportError) throw error;
+    throw new ProviderSettingsTransportError("invalid_response");
+  }
+}
+
+async function fetchJson(
+  fetcher: Fetcher,
+  path: string,
+  init: RequestInit,
+): Promise<unknown> {
+  let response: Response;
+  try {
+    response = await fetcher(`${getGatewayUrl()}${path}`, init);
+  } catch {
+    throw new ProviderSettingsTransportError("unavailable");
+  }
+  if (!response.ok) {
+    let value: unknown;
+    try {
+      value = await boundedJson(response);
+    } catch {
+      throw new ProviderSettingsTransportError("unavailable");
+    }
+    const code = value && typeof value === "object"
+      && "error" in value && value.error && typeof value.error === "object"
+      && "code" in value.error && typeof value.error.code === "string"
+      ? value.error.code
+      : null;
+    if (code === "revision_conflict"
+      || code === "idempotency_conflict"
+      || code === "provider_settings_unavailable") {
+      throw new ProviderSettingsTransportError(code);
+    }
+    throw new ProviderSettingsTransportError("unavailable");
+  }
+  return await boundedJson(response);
+}
+
+export function createProviderSettingsTransport(
+  options: { fetcher?: Fetcher } = {},
+): ProviderSettingsTransport {
+  const fetcher = options.fetcher ?? fetch;
+  return {
+    async getSnapshot(signal) {
+      const value = await fetchJson(fetcher, "/api/ai/provider-settings", {
+        cache: "no-store",
+        headers: { Accept: "application/json" },
+        signal: requestSignal(signal),
+      });
+      const parsed = ProviderSettingsSnapshotSchema.safeParse(value);
+      if (!parsed.success) throw new ProviderSettingsTransportError("invalid_response");
+      return parsed.data;
+    },
+    async mutate(input, signal) {
+      const mutation = ProviderSettingsMutationSchema.safeParse(input);
+      if (!mutation.success) throw new ProviderSettingsTransportError("invalid_request");
+      const body = JSON.stringify(mutation.data);
+      if (new TextEncoder().encode(body).byteLength > MAX_MUTATION_BYTES) {
+        throw new ProviderSettingsTransportError("invalid_request");
+      }
+      const value = await fetchJson(fetcher, "/api/ai/provider-settings/actions", {
+        method: "POST",
+        cache: "no-store",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body,
+        signal: requestSignal(signal),
+      });
+      const parsed = ProviderSettingsMutationResponseSchema.safeParse(value);
+      if (!parsed.success) throw new ProviderSettingsTransportError("invalid_response");
+      return parsed.data;
+    },
+  };
+}

--- a/shell/src/lib/provider-settings-transport.ts
+++ b/shell/src/lib/provider-settings-transport.ts
@@ -70,14 +70,16 @@ async function fetchJson(
   let response: Response;
   try {
     response = await fetcher(`${getGatewayUrl()}${path}`, init);
-  } catch {
+  } catch (error) {
+    console.warn("[provider-settings] Provider settings request failed:", error instanceof Error ? error.name : typeof error);
     throw new ProviderSettingsTransportError("unavailable");
   }
   if (!response.ok) {
     let value: unknown;
     try {
       value = await boundedJson(response);
-    } catch {
+    } catch (error) {
+      console.warn("[provider-settings] Provider settings error response was invalid:", error instanceof Error ? error.name : typeof error);
       throw new ProviderSettingsTransportError("unavailable");
     }
     const code = value && typeof value === "object"

--- a/shell/src/lib/provider-terminal-session.ts
+++ b/shell/src/lib/provider-terminal-session.ts
@@ -3,6 +3,7 @@ import { isCanonicalShellSessionId } from "../components/terminal/terminal-sessi
 
 const QUEUE_KEY = "matrix:provider-terminal-session-queue";
 const QUEUE_LIMIT = 8;
+const QUEUE_TTL_MS = 10 * 60_000;
 const RESPONSE_LIMIT_BYTES = 64 * 1024;
 const TARGET_ID_PATTERN = /^[A-Za-z0-9:_-]{1,128}$/;
 export const PROVIDER_TERMINAL_SESSION_EVENT = "matrix:provider-terminal-session";
@@ -10,6 +11,7 @@ export const PROVIDER_TERMINAL_SESSION_EVENT = "matrix:provider-terminal-session
 interface QueuedSession {
   sessionId: string;
   targetId?: string;
+  expiresAt: number;
 }
 
 type Fetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
@@ -19,14 +21,25 @@ function readQueue(): QueuedSession[] {
   try {
     const value = JSON.parse(window.sessionStorage.getItem(QUEUE_KEY) ?? "[]") as unknown;
     if (!Array.isArray(value)) return [];
-    return value.flatMap((entry): QueuedSession[] => {
+    const now = Date.now();
+    const queue = value.flatMap((entry): QueuedSession[] => {
       if (!entry || typeof entry !== "object") return [];
-      const item = entry as { sessionId?: unknown; targetId?: unknown };
+      const item = entry as { sessionId?: unknown; targetId?: unknown; expiresAt?: unknown };
       if (typeof item.sessionId !== "string" || !isCanonicalShellSessionId(item.sessionId)) return [];
       if (item.targetId !== undefined
         && (typeof item.targetId !== "string" || !TARGET_ID_PATTERN.test(item.targetId))) return [];
-      return [{ sessionId: item.sessionId, ...(item.targetId ? { targetId: item.targetId } : {}) }];
+      if (!Number.isSafeInteger(item.expiresAt) || (item.expiresAt as number) <= now
+        || (item.expiresAt as number) > now + QUEUE_TTL_MS) return [];
+      return [{
+        sessionId: item.sessionId,
+        ...(item.targetId ? { targetId: item.targetId } : {}),
+        expiresAt: item.expiresAt as number,
+      }];
     }).slice(-QUEUE_LIMIT);
+    if (queue.length !== value.length) {
+      window.sessionStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+    }
+    return queue;
   } catch (error) {
     console.warn("[provider-settings] Could not read terminal handoff queue:", error instanceof Error ? error.name : typeof error);
     return [];
@@ -46,7 +59,11 @@ export function enqueueExistingTerminalSession(sessionId: string, targetId?: str
   if (typeof window === "undefined") return false;
   if (!isCanonicalShellSessionId(sessionId)) return false;
   if (targetId !== undefined && !TARGET_ID_PATTERN.test(targetId)) return false;
-  writeQueue([...readQueue(), { sessionId, ...(targetId ? { targetId } : {}) }]);
+  writeQueue([...readQueue(), {
+    sessionId,
+    ...(targetId ? { targetId } : {}),
+    expiresAt: Date.now() + QUEUE_TTL_MS,
+  }]);
   window.dispatchEvent(new CustomEvent(PROVIDER_TERMINAL_SESSION_EVENT, { detail: { targetId } }));
   return true;
 }
@@ -119,7 +136,7 @@ export async function drainExistingTerminalSessionQueue(
   }
 }
 
-function hasQueuedSessionForTarget(targetId?: string): boolean {
+export function hasQueuedExistingTerminalSession(targetId?: string): boolean {
   return readQueue().some((entry) => !targetId || entry.targetId === targetId || !entry.targetId);
 }
 
@@ -144,7 +161,7 @@ export async function drainExistingTerminalSessionQueueWithRetry(
     })) {
       accepted.add(sessionId);
     }
-    if (!hasQueuedSessionForTarget(targetId) || attempt === maxAttempts - 1) break;
+    if (!hasQueuedExistingTerminalSession(targetId) || attempt === maxAttempts - 1) break;
     await wait(Math.min(250 * (2 ** attempt), 2_000));
   }
   return [...accepted];

--- a/shell/src/lib/provider-terminal-session.ts
+++ b/shell/src/lib/provider-terminal-session.ts
@@ -27,7 +27,8 @@ function readQueue(): QueuedSession[] {
         && (typeof item.targetId !== "string" || !TARGET_ID_PATTERN.test(item.targetId))) return [];
       return [{ sessionId: item.sessionId, ...(item.targetId ? { targetId: item.targetId } : {}) }];
     }).slice(-QUEUE_LIMIT);
-  } catch {
+  } catch (error) {
+    console.warn("[provider-settings] Could not read terminal handoff queue:", error instanceof Error ? error.name : typeof error);
     return [];
   }
 }
@@ -36,8 +37,8 @@ function writeQueue(queue: QueuedSession[]): void {
   if (typeof window === "undefined") return;
   try {
     window.sessionStorage.setItem(QUEUE_KEY, JSON.stringify(queue.slice(-QUEUE_LIMIT)));
-  } catch {
-    // Session storage can be disabled; the handoff safely becomes a no-op.
+  } catch (error) {
+    console.warn("[provider-settings] Could not persist terminal handoff queue:", error instanceof Error ? error.name : typeof error);
   }
 }
 
@@ -79,7 +80,12 @@ async function listActiveSessions(fetcher: Fetcher): Promise<Set<string>> {
     offset += chunk.byteLength;
   }
   let value: unknown;
-  try { value = JSON.parse(new TextDecoder().decode(bytes)); } catch { return new Set(); }
+  try {
+    value = JSON.parse(new TextDecoder().decode(bytes));
+  } catch (error) {
+    console.warn("[provider-settings] Invalid terminal session response:", error instanceof Error ? error.name : typeof error);
+    return new Set();
+  }
   if (!value || typeof value !== "object" || !Array.isArray((value as { sessions?: unknown }).sessions)) return new Set();
   const sessions = (value as { sessions: unknown[] }).sessions;
   if (sessions.length > 256) return new Set();
@@ -98,18 +104,17 @@ export async function drainExistingTerminalSessionQueue(
   targetId?: string,
   options: { fetcher?: Fetcher } = {},
 ): Promise<string[]> {
-  const matched: QueuedSession[] = [];
-  const remaining: QueuedSession[] = [];
-  for (const entry of readQueue()) {
-    if (!targetId || entry.targetId === targetId || !entry.targetId) matched.push(entry);
-    else remaining.push(entry);
-  }
-  writeQueue(remaining);
+  const queued = readQueue();
+  const matchesTarget = (entry: QueuedSession) => !targetId || entry.targetId === targetId || !entry.targetId;
+  const matched = queued.filter(matchesTarget);
   if (matched.length === 0) return [];
   try {
     const active = await listActiveSessions(options.fetcher ?? fetch);
-    return [...new Set(matched.map((entry) => entry.sessionId).filter((id) => active.has(id)))];
-  } catch {
+    const accepted = new Set(matched.map((entry) => entry.sessionId).filter((id) => active.has(id)));
+    writeQueue(queued.filter((entry) => !(matchesTarget(entry) && accepted.has(entry.sessionId))));
+    return [...accepted];
+  } catch (error) {
+    console.warn("[provider-settings] Terminal session handoff failed:", error instanceof Error ? error.name : typeof error);
     return [];
   }
 }

--- a/shell/src/lib/provider-terminal-session.ts
+++ b/shell/src/lib/provider-terminal-session.ts
@@ -118,3 +118,34 @@ export async function drainExistingTerminalSessionQueue(
     return [];
   }
 }
+
+function hasQueuedSessionForTarget(targetId?: string): boolean {
+  return readQueue().some((entry) => !targetId || entry.targetId === targetId || !entry.targetId);
+}
+
+export async function drainExistingTerminalSessionQueueWithRetry(
+  targetId?: string,
+  options: {
+    fetcher?: Fetcher;
+    wait?: (delayMs: number) => Promise<void>;
+    maxAttempts?: number;
+  } = {},
+): Promise<string[]> {
+  const maxAttempts = Number.isSafeInteger(options.maxAttempts)
+    ? Math.max(1, Math.min(options.maxAttempts!, 8))
+    : 6;
+  const wait = options.wait ?? ((delayMs: number) => new Promise<void>((resolve) => {
+    setTimeout(resolve, delayMs);
+  }));
+  const accepted = new Set<string>();
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    for (const sessionId of await drainExistingTerminalSessionQueue(targetId, {
+      ...(options.fetcher ? { fetcher: options.fetcher } : {}),
+    })) {
+      accepted.add(sessionId);
+    }
+    if (!hasQueuedSessionForTarget(targetId) || attempt === maxAttempts - 1) break;
+    await wait(Math.min(250 * (2 ** attempt), 2_000));
+  }
+  return [...accepted];
+}

--- a/shell/src/lib/provider-terminal-session.ts
+++ b/shell/src/lib/provider-terminal-session.ts
@@ -22,21 +22,24 @@ function readQueue(): QueuedSession[] {
     const value = JSON.parse(window.sessionStorage.getItem(QUEUE_KEY) ?? "[]") as unknown;
     if (!Array.isArray(value)) return [];
     const now = Date.now();
+    let migratedLegacyEntry = false;
     const queue = value.flatMap((entry): QueuedSession[] => {
       if (!entry || typeof entry !== "object") return [];
       const item = entry as { sessionId?: unknown; targetId?: unknown; expiresAt?: unknown };
       if (typeof item.sessionId !== "string" || !isCanonicalShellSessionId(item.sessionId)) return [];
       if (item.targetId !== undefined
         && (typeof item.targetId !== "string" || !TARGET_ID_PATTERN.test(item.targetId))) return [];
-      if (!Number.isSafeInteger(item.expiresAt) || (item.expiresAt as number) <= now
-        || (item.expiresAt as number) > now + QUEUE_TTL_MS) return [];
+      const expiresAt = item.expiresAt === undefined ? now + QUEUE_TTL_MS : item.expiresAt;
+      if (!Number.isSafeInteger(expiresAt) || (expiresAt as number) <= now
+        || (expiresAt as number) > now + QUEUE_TTL_MS) return [];
+      migratedLegacyEntry ||= item.expiresAt === undefined;
       return [{
         sessionId: item.sessionId,
         ...(item.targetId ? { targetId: item.targetId } : {}),
-        expiresAt: item.expiresAt as number,
+        expiresAt: expiresAt as number,
       }];
     }).slice(-QUEUE_LIMIT);
-    if (queue.length !== value.length) {
+    if (queue.length !== value.length || migratedLegacyEntry) {
       window.sessionStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
     }
     return queue;

--- a/shell/src/lib/provider-terminal-session.ts
+++ b/shell/src/lib/provider-terminal-session.ts
@@ -1,0 +1,115 @@
+import { getGatewayUrl } from "./gateway";
+import { isCanonicalShellSessionId } from "../components/terminal/terminal-session-id";
+
+const QUEUE_KEY = "matrix:provider-terminal-session-queue";
+const QUEUE_LIMIT = 8;
+const RESPONSE_LIMIT_BYTES = 64 * 1024;
+const TARGET_ID_PATTERN = /^[A-Za-z0-9:_-]{1,128}$/;
+export const PROVIDER_TERMINAL_SESSION_EVENT = "matrix:provider-terminal-session";
+
+interface QueuedSession {
+  sessionId: string;
+  targetId?: string;
+}
+
+type Fetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+function readQueue(): QueuedSession[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const value = JSON.parse(window.sessionStorage.getItem(QUEUE_KEY) ?? "[]") as unknown;
+    if (!Array.isArray(value)) return [];
+    return value.flatMap((entry): QueuedSession[] => {
+      if (!entry || typeof entry !== "object") return [];
+      const item = entry as { sessionId?: unknown; targetId?: unknown };
+      if (typeof item.sessionId !== "string" || !isCanonicalShellSessionId(item.sessionId)) return [];
+      if (item.targetId !== undefined
+        && (typeof item.targetId !== "string" || !TARGET_ID_PATTERN.test(item.targetId))) return [];
+      return [{ sessionId: item.sessionId, ...(item.targetId ? { targetId: item.targetId } : {}) }];
+    }).slice(-QUEUE_LIMIT);
+  } catch {
+    return [];
+  }
+}
+
+function writeQueue(queue: QueuedSession[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(QUEUE_KEY, JSON.stringify(queue.slice(-QUEUE_LIMIT)));
+  } catch {
+    // Session storage can be disabled; the handoff safely becomes a no-op.
+  }
+}
+
+export function enqueueExistingTerminalSession(sessionId: string, targetId?: string): boolean {
+  if (typeof window === "undefined") return false;
+  if (!isCanonicalShellSessionId(sessionId)) return false;
+  if (targetId !== undefined && !TARGET_ID_PATTERN.test(targetId)) return false;
+  writeQueue([...readQueue(), { sessionId, ...(targetId ? { targetId } : {}) }]);
+  window.dispatchEvent(new CustomEvent(PROVIDER_TERMINAL_SESSION_EVENT, { detail: { targetId } }));
+  return true;
+}
+
+async function listActiveSessions(fetcher: Fetcher): Promise<Set<string>> {
+  const response = await fetcher(`${getGatewayUrl()}/api/terminal/sessions`, {
+    cache: "no-store",
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(10_000),
+  });
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (!response.ok || (Number.isFinite(declaredLength) && declaredLength > RESPONSE_LIMIT_BYTES)) return new Set();
+  if (!response.body) return new Set();
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > RESPONSE_LIMIT_BYTES) {
+      await reader.cancel();
+      return new Set();
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  let value: unknown;
+  try { value = JSON.parse(new TextDecoder().decode(bytes)); } catch { return new Set(); }
+  if (!value || typeof value !== "object" || !Array.isArray((value as { sessions?: unknown }).sessions)) return new Set();
+  const sessions = (value as { sessions: unknown[] }).sessions;
+  if (sessions.length > 256) return new Set();
+  const active = new Set<string>();
+  for (const entry of sessions) {
+    if (!entry || typeof entry !== "object") return new Set();
+    const session = entry as { name?: unknown; status?: unknown };
+    if (typeof session.name !== "string" || !isCanonicalShellSessionId(session.name)
+      || (session.status !== "active" && session.status !== "exited")) return new Set();
+    if (session.status === "active") active.add(session.name);
+  }
+  return active;
+}
+
+export async function drainExistingTerminalSessionQueue(
+  targetId?: string,
+  options: { fetcher?: Fetcher } = {},
+): Promise<string[]> {
+  const matched: QueuedSession[] = [];
+  const remaining: QueuedSession[] = [];
+  for (const entry of readQueue()) {
+    if (!targetId || entry.targetId === targetId || !entry.targetId) matched.push(entry);
+    else remaining.push(entry);
+  }
+  writeQueue(remaining);
+  if (matched.length === 0) return [];
+  try {
+    const active = await listActiveSessions(options.fetcher ?? fetch);
+    return [...new Set(matched.map((entry) => entry.sessionId).filter((id) => active.has(id)))];
+  } catch {
+    return [];
+  }
+}

--- a/tests/desktop/agent-section.test.tsx
+++ b/tests/desktop/agent-section.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AgentSection from "../../desktop/src/renderer/src/features/settings/sections/AgentSection";
+import IdentityPersonalitySection from "../../desktop/src/renderer/src/features/settings/sections/IdentityPersonalitySection";
 import { AppError } from "../../desktop/src/renderer/src/lib/errors";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
@@ -197,6 +198,35 @@ describe("AgentSection", () => {
     cleanup();
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it("keeps the provider adapter separate from identity and personality", async () => {
+    render(<AgentSection />);
+
+    const heading = screen.getByRole("heading", { name: "Agents & providers" });
+    expect(heading).toBeTruthy();
+    expect(heading.closest("[data-provider-settings-adapter='legacy']")).toBeTruthy();
+    expect(screen.queryByRole("textbox", { name: "SOUL system instructions" })).toBeNull();
+
+    cleanup();
+    render(<IdentityPersonalitySection />);
+
+    expect(screen.getByRole("heading", { name: "Identity & personality" })).toBeTruthy();
+    expect(await screen.findByRole("textbox", { name: "SOUL system instructions" })).toBeTruthy();
+  });
+
+  it("persists personality changes to the owner-controlled SOUL file", async () => {
+    api.putText.mockResolvedValue(undefined);
+    render(<IdentityPersonalitySection />);
+
+    const editor = await screen.findByRole("textbox", { name: "SOUL system instructions" });
+    fireEvent.change(editor, { target: { value: "# Updated SOUL" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(api.putText).toHaveBeenCalledWith(
+      "/files/system/soul.md",
+      "# Updated SOUL",
+    ));
   });
 
   it("renders the additive runtime and provider controls and sends revisioned updates", async () => {

--- a/tests/desktop/agents-providers-adapter.test.tsx
+++ b/tests/desktop/agents-providers-adapter.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
+
+const mocks = vi.hoisted(() => ({
+  controller: vi.fn(),
+  view: vi.fn((props: { snapshot: unknown }) => (
+    <div data-testid="shared-agents-providers-view">{props.snapshot ? "ready" : "missing"}</div>
+  )),
+}));
+
+vi.mock("@matrix-os/ui", () => ({
+  AgentsProvidersView: mocks.view,
+  useProviderSettingsController: mocks.controller,
+}));
+
+import AgentsProvidersAdapter from "../../desktop/src/renderer/src/features/settings/AgentsProvidersAdapter";
+
+describe("desktop shared agents and providers adapter", () => {
+  beforeEach(() => {
+    mocks.controller.mockReset();
+    mocks.view.mockClear();
+    mocks.controller.mockReturnValue({
+      snapshot: { revision: 1 },
+      selectedHarnessId: "harness_codex",
+      connectionAttempt: null,
+      busy: false,
+      error: null,
+      onSelectHarness: vi.fn(),
+      refresh: vi.fn(),
+      mutate: vi.fn(),
+    });
+    const pinned = { get: vi.fn(), post: vi.fn() };
+    useConnection.setState({
+      status: "signed-in",
+      handle: "alice",
+      platformHost: "https://app.matrix-os.com",
+      runtimeSlot: "vm-2",
+      authGeneration: 7,
+      api: { forRuntime: vi.fn(() => pinned) } as never,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    useConnection.setState(useConnection.getInitialState(), true);
+  });
+
+  it("renders the shared view with a runtime- and credential-scoped controller", () => {
+    render(<AgentsProvidersAdapter />);
+
+    expect(screen.getByTestId("shared-agents-providers-view").textContent).toBe("ready");
+    expect(mocks.controller).toHaveBeenCalledWith(expect.objectContaining({
+      identityKey: "signed-in|alice|https://app.matrix-os.com|vm-2|7",
+      transport: expect.objectContaining({
+        getSnapshot: expect.any(Function),
+        mutate: expect.any(Function),
+      }),
+    }));
+    expect(useConnection.getState().api?.forRuntime).toHaveBeenCalledWith("vm-2");
+  });
+
+  it("changes controller identity when the trusted credential generation changes", () => {
+    render(<AgentsProvidersAdapter />);
+    act(() => useConnection.setState({ authGeneration: 8 }));
+
+    expect(mocks.controller).toHaveBeenLastCalledWith(expect.objectContaining({
+      identityKey: "signed-in|alice|https://app.matrix-os.com|vm-2|8",
+    }));
+  });
+
+  it("offers a safe retry when the initial provider snapshot cannot load", () => {
+    const refresh = vi.fn();
+    mocks.controller.mockReturnValue({
+      snapshot: null,
+      selectedHarnessId: null,
+      connectionAttempt: null,
+      busy: false,
+      error: "unsafe upstream detail must not render",
+      onSelectHarness: vi.fn(),
+      refresh,
+      mutate: vi.fn(),
+    });
+    render(<AgentsProvidersAdapter />);
+
+    expect(screen.queryByText("unsafe upstream detail must not render")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Retry provider settings" }));
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/desktop/api-client.test.ts
+++ b/tests/desktop/api-client.test.ts
@@ -84,6 +84,18 @@ describe("createApiClient", () => {
     expect((init as RequestInit).signal!.aborted).toBe(true);
   });
 
+  it("rejects JSON responses that exceed the configured byte limit", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(200, { value: "x".repeat(128) }));
+    const client = createApiClient({
+      baseUrl: "https://app.matrix-os.com",
+      getRuntimeSlot: () => "primary",
+      fetchFn,
+    });
+
+    await expect(client.get("/api/ai/provider-settings", { maxBytes: 32 }))
+      .rejects.toMatchObject({ category: "server" });
+  });
+
   it("maps 401 to unauthorized AppError", async () => {
     const fetchFn = vi.fn().mockResolvedValue(jsonResponse(401, {}));
     const client = createApiClient({

--- a/tests/desktop/provider-settings-adapter.test.ts
+++ b/tests/desktop/provider-settings-adapter.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProviderSettingsMutation, ProviderSettingsSnapshot } from "@matrix-os/contracts";
+import { AppError } from "../../desktop/src/shared/app-error";
+import {
+  createDesktopProviderSettingsTransport,
+  desktopProviderIdentityKey,
+  openExistingProviderTerminalSession,
+  openProviderAuthorizationPath,
+} from "../../desktop/src/renderer/src/features/settings/provider-settings-desktop-adapter";
+import type { ApiClient } from "../../desktop/src/renderer/src/lib/api";
+import { useShellSessions } from "../../desktop/src/renderer/src/stores/shell-sessions";
+import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
+
+const checkedAt = "2026-08-30T10:00:00.000Z";
+
+function snapshot(revision = 1): ProviderSettingsSnapshot {
+  return {
+    contractVersion: 1,
+    projectionOf: { contract: "AiProviderSnapshotV3", contractVersion: 3, revision },
+    revision,
+    refreshedAt: checkedAt,
+    access: { mode: "writable" },
+    supportedActions: ["set_harness_enabled"],
+    modelProviders: [{
+      id: "anthropic",
+      displayName: "Anthropic",
+      models: [{ id: "anthropic/claude-sonnet-5", displayName: "Claude Sonnet 5", enabled: true }],
+    }],
+    accessSources: [{
+      id: "source_matrix",
+      kind: "matrix_gateway",
+      fundingKind: "matrix_included",
+      providerId: "anthropic",
+      accountId: null,
+      displayName: "Matrix AI",
+      readiness: { state: "ready", checkedAt, staleAfter: null, action: "none", safeReason: null },
+      eligibleModelIds: ["anthropic/claude-sonnet-5"],
+      usage: {
+        kind: "unavailable",
+        authority: "unavailable",
+        state: "unavailable",
+        scope: "owner_entitlement",
+        reason: "ledger_not_available",
+        asOf: checkedAt,
+      },
+    }],
+    accounts: [],
+    harnesses: [{
+      id: "harness_hermes",
+      harness: "hermes",
+      displayName: "Hermes",
+      accentColor: "teal",
+      enabled: true,
+      version: "1.0.0",
+      installState: "installed",
+      authState: "authenticated",
+      loginMethods: ["terminal"],
+      recommendedLoginMethod: "terminal",
+      connectivity: "online",
+      accountIds: [],
+      selectedAccountId: null,
+      accessSourceId: "source_matrix",
+      route: { kind: "configurable", providerId: "anthropic", modelId: "anthropic/claude-sonnet-5" },
+      activeChatCount: 0,
+    }],
+    gatewayPolicy: {
+      accessSourceId: "source_matrix",
+      monthlyBudgetMicrousd: null,
+      allowedModelIds: ["anthropic/claude-sonnet-5"],
+      topUpEnabled: false,
+    },
+  };
+}
+
+function api(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    baseUrl: "https://app.matrix-os.com",
+    forRuntime: vi.fn(),
+    get: vi.fn(),
+    getText: vi.fn(),
+    getBlob: vi.fn(),
+    post: vi.fn(),
+    postBytes: vi.fn(),
+    patch: vi.fn(),
+    put: vi.fn(),
+    putBytes: vi.fn(),
+    delete: vi.fn(),
+    putText: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useShellSessions.setState({ sessions: [], loading: false, creating: false, error: null });
+  useTabs.setState({
+    tabs: [],
+    activeTabId: null,
+    terminalSessionRequest: null,
+    terminalSessionRequestSequence: 0,
+  });
+});
+
+describe("desktop provider settings transport", () => {
+  it("uses the authenticated runtime-bound API with bounded, abortable JSON reads", async () => {
+    const get = vi.fn().mockResolvedValue(snapshot());
+    const client = api({ get });
+    const transport = createDesktopProviderSettingsTransport(client);
+    const abort = new AbortController();
+
+    await expect(transport.getSnapshot(abort.signal)).resolves.toEqual(snapshot());
+    expect(get).toHaveBeenCalledWith("/api/ai/provider-settings", {
+      maxBytes: 1024 * 1024,
+      signal: abort.signal,
+    });
+  });
+
+  it("validates mutations and responses and preserves only controller-safe conflicts", async () => {
+    const mutation: ProviderSettingsMutation = {
+      type: "set_harness_enabled",
+      harnessInstanceId: "harness_hermes",
+      enabled: false,
+      expectedRevision: 1,
+      idempotencyKey: "11111111-1111-4111-8111-111111111111",
+    };
+    const post = vi.fn().mockResolvedValue({ kind: "snapshot", snapshot: snapshot(2) });
+    const transport = createDesktopProviderSettingsTransport(api({ post }));
+    await expect(transport.mutate(mutation, new AbortController().signal))
+      .resolves.toMatchObject({ kind: "snapshot", snapshot: { revision: 2 } });
+    expect(post).toHaveBeenCalledWith("/api/ai/provider-settings/actions", mutation, expect.objectContaining({
+      maxBytes: 1024 * 1024,
+      signal: expect.any(AbortSignal),
+    }));
+
+    const conflicted = createDesktopProviderSettingsTransport(api({
+      post: vi.fn().mockRejectedValue(new AppError("server", { detail: "revision_conflict" })),
+    }));
+    await expect(conflicted.mutate(mutation, new AbortController().signal))
+      .rejects.toMatchObject({ code: "revision_conflict", message: "Provider settings are unavailable." });
+  });
+
+  it("rejects invalid or secret-shaped response data before it reaches shared UI state", async () => {
+    const transport = createDesktopProviderSettingsTransport(api({
+      get: vi.fn().mockResolvedValue({ ...snapshot(), gatewayToken: "secret" }),
+    }));
+    await expect(transport.getSnapshot(new AbortController().signal))
+      .rejects.toMatchObject({ code: "invalid_response" });
+  });
+});
+
+describe("desktop provider connection actions", () => {
+  it("scopes provider state to owner, runtime slot, host, and credential generation", () => {
+    expect(desktopProviderIdentityKey({
+      status: "signed-in",
+      handle: "alice",
+      platformHost: "https://app.matrix-os.com",
+      runtimeSlot: "vm-2",
+      authGeneration: 7,
+    })).toBe("signed-in|alice|https://app.matrix-os.com|vm-2|7");
+  });
+
+  it("opens and requests only the exact existing canonical Terminal session without creating one", async () => {
+    const get = vi.fn().mockResolvedValue({
+      sessions: [{ name: "provider-login", status: "active", cwd: "projects" }],
+    });
+    const post = vi.fn();
+    const opened = await openExistingProviderTerminalSession(api({ get, post }), "provider-login");
+
+    expect(opened).toBe(true);
+    expect(get).toHaveBeenCalledWith("/api/terminal/sessions");
+    expect(post).not.toHaveBeenCalled();
+    expect(useTabs.getState().tabs).toEqual([expect.objectContaining({ kind: "terminals", title: "Terminal" })]);
+    expect(useTabs.getState().terminalSessionRequest?.sessionName).toBe("provider-login");
+  });
+
+  it("rejects invalid, missing, or exited sessions without opening Terminal", async () => {
+    const get = vi.fn().mockResolvedValue({ sessions: [{ name: "provider-login", status: "exited" }] });
+    const client = api({ get });
+    await expect(openExistingProviderTerminalSession(client, "../../secret")).resolves.toBe(false);
+    await expect(openExistingProviderTerminalSession(client, "provider-login")).resolves.toBe(false);
+    expect(useTabs.getState().tabs).toEqual([]);
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not open a provider login session after the desktop identity changes", async () => {
+    const get = vi.fn().mockResolvedValue({
+      sessions: [{ name: "provider-login", status: "active", cwd: "projects" }],
+    });
+    await expect(openExistingProviderTerminalSession(
+      api({ get }),
+      "provider-login",
+      () => false,
+    )).resolves.toBe(false);
+    expect(useTabs.getState().tabs).toEqual([]);
+    expect(useTabs.getState().terminalSessionRequest).toBeNull();
+  });
+
+  it("opens only the schema-approved owner-relative authorization path through HTTPS IPC", async () => {
+    const openExternal = vi.fn().mockResolvedValue({ ok: true });
+    await expect(openProviderAuthorizationPath({
+      authorizationPath: "/api/ai/providers/login-attempts/attempt_browser/authorize",
+      platformHost: "https://app.matrix-os.com",
+      runtimeSlot: "vm-2",
+      openExternal,
+    })).resolves.toBe(true);
+    expect(openExternal).toHaveBeenCalledWith("https://app.matrix-os.com/api/ai/providers/login-attempts/attempt_browser/authorize?runtime=vm-2");
+
+    await expect(openProviderAuthorizationPath({
+      authorizationPath: "https://evil.example/authorize",
+      platformHost: "https://app.matrix-os.com",
+      runtimeSlot: "primary",
+      openExternal,
+    })).resolves.toBe(false);
+    expect(openExternal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/desktop/provider-setup-routing.test.tsx
+++ b/tests/desktop/provider-setup-routing.test.tsx
@@ -93,12 +93,12 @@ describe("system harness setup routing", () => {
     vi.restoreAllMocks();
   });
 
-  it.each(["hermes", "openclaw"] as const)("routes %s configuration to Agent settings", (driverKind) => {
+  it.each(["hermes", "openclaw"] as const)("routes %s configuration to Agents & providers", (driverKind) => {
     render(<Harness driverKind={driverKind} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Configure" }));
 
-    expect(useUi.getState().requestedSettingsSection).toBe("agent");
+    expect(useUi.getState().requestedSettingsSection).toBe("agents-providers");
     expect(useTabs.getState().tabs.some((tab) => tab.kind === "settings")).toBe(true);
   });
 

--- a/tests/desktop/settings-view.test.tsx
+++ b/tests/desktop/settings-view.test.tsx
@@ -46,21 +46,39 @@ describe("SettingsView", () => {
     expect(screen.getByRole("heading", { name: "Account" })).not.toBeNull();
     expect(screen.queryByRole("button", { name: "Projects" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Channels" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Agents & providers" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Identity & personality" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Providers" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Agent (Hermes)" })).toBeNull();
   });
 
-  it("opens the requested section and consumes the deep-link request", async () => {
-    useUi.getState().requestSettingsSection("agent");
+  it.each(["agent", "providers"] as const)("maps the legacy %s deep link to Agents & providers and consumes it", async (legacySection) => {
+    useUi.setState({ requestedSettingsSection: legacySection });
 
     render(<SettingsView />);
 
-    // The unified Agent section renders instead of the default Account.
-    await waitFor(() => expect(screen.getByRole("heading", { name: "Agent" })).not.toBeNull());
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Agents & providers" })).not.toBeNull());
+    expect(useUi.getState().requestedSettingsSection).toBeNull();
+  });
+
+  it.each(["agent", "providers"] as const)("normalizes the legacy %s section at the request boundary", (legacySection) => {
+    useUi.getState().requestSettingsSection(legacySection);
+
+    expect(useUi.getState().requestedSettingsSection).toBe("agents-providers");
+  });
+
+  it("opens Identity & personality as a first-class section", async () => {
+    useUi.getState().requestSettingsSection("identity-personality");
+
+    render(<SettingsView />);
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Identity & personality" })).not.toBeNull());
     expect(useUi.getState().requestedSettingsSection).toBeNull();
   });
 
   it("keeps the selected navigation highlight in sync with the visible section", () => {
     render(<SettingsView />);
-    const providers = screen.getByRole("button", { name: "Providers" });
+    const providers = screen.getByRole("button", { name: "Agents & providers" });
     const services = screen.getByRole("button", { name: "Services" });
 
     fireEvent.click(providers);

--- a/tests/shell/agent-section.test.tsx
+++ b/tests/shell/agent-section.test.tsx
@@ -5,6 +5,7 @@ import "@testing-library/jest-dom/vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AgentSection } from "../../shell/src/components/settings/sections/AgentSection.js";
+import { IdentityPersonalitySection } from "../../shell/src/components/settings/sections/IdentityPersonalitySection.js";
 
 vi.mock("../../shell/src/components/settings/sections/AgentRuntimePanel.js", () => ({
   AgentRuntimePanel: () => <div>Runtime settings</div>,
@@ -14,7 +15,18 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe("Canvas Agent section", () => {
+describe("Canvas settings sections", () => {
+  it("keeps the provider adapter separate from identity and personality", () => {
+    vi.stubGlobal("fetch", vi.fn());
+    render(<AgentSection />);
+
+    const heading = screen.getByRole("heading", { name: "Agents & providers" });
+    expect(heading).toBeVisible();
+    expect(heading.closest("[data-provider-settings-adapter='legacy']")).toBeTruthy();
+    expect(screen.getByText("Runtime settings")).toBeVisible();
+    expect(screen.queryByText("SOUL (Personality)")).toBeNull();
+  });
+
   it("persists SOUL to its owner-controlled file", async () => {
     const fetcher = vi.fn(async (input: RequestInfo | URL) => (
       String(input).endsWith("/files/system/soul.md")
@@ -22,7 +34,9 @@ describe("Canvas Agent section", () => {
         : Response.json({ displayName: "Matrix" })
     ));
     vi.stubGlobal("fetch", fetcher);
-    render(<AgentSection />);
+    render(<IdentityPersonalitySection />);
+
+    expect(screen.getByRole("heading", { name: "Identity & personality" })).toBeVisible();
 
     expect(await screen.findByText("Original soul")).toBeVisible();
     fireEvent.click(screen.getByRole("button", { name: "Edit" }));

--- a/tests/shell/agent-section.test.tsx
+++ b/tests/shell/agent-section.test.tsx
@@ -7,24 +7,73 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { AgentSection } from "../../shell/src/components/settings/sections/AgentSection.js";
 import { IdentityPersonalitySection } from "../../shell/src/components/settings/sections/IdentityPersonalitySection.js";
 
-vi.mock("../../shell/src/components/settings/sections/AgentRuntimePanel.js", () => ({
-  AgentRuntimePanel: () => <div>Runtime settings</div>,
+const providerControllerState = vi.hoisted(() => ({
+  snapshot: {} as unknown,
+  error: null as string | null,
+}));
+
+vi.mock("@matrix-os/ui", () => ({
+  AgentsProvidersView: ({
+    onOpenTerminal,
+    onOpenBrowser,
+  }: {
+    onOpenTerminal: (sessionId: string) => void;
+    onOpenBrowser: (path: string) => void;
+  }) => (
+    <div>
+      <h2>Agents &amp; providers</h2>
+      <button onClick={() => onOpenTerminal("provider-login")}>Continue in Terminal</button>
+      <button onClick={() => onOpenBrowser("/api/ai/providers/login-attempts/attempt-1/authorize")}>Continue in browser</button>
+    </div>
+  ),
+  useProviderSettingsController: () => ({
+    snapshot: providerControllerState.snapshot,
+    selectedHarnessId: null,
+    connectionAttempt: null,
+    busy: false,
+    error: providerControllerState.error,
+    onSelectHarness: vi.fn(),
+    refresh: vi.fn(),
+    mutate: vi.fn(),
+  }),
+  ProviderSettingsTransportError: class ProviderSettingsTransportError extends Error {
+    code: string;
+    constructor(code: string) {
+      super("Provider settings are unavailable.");
+      this.code = code;
+    }
+  },
 }));
 
 afterEach(() => {
+  providerControllerState.snapshot = {};
+  providerControllerState.error = null;
   vi.unstubAllGlobals();
 });
 
 describe("Canvas settings sections", () => {
-  it("keeps the provider adapter separate from identity and personality", () => {
+  it("renders the shared provider adapter separately from identity and personality", () => {
     vi.stubGlobal("fetch", vi.fn());
-    render(<AgentSection />);
+    const onOpenTerminal = vi.fn();
+    render(<AgentSection onOpenTerminal={onOpenTerminal} />);
 
     const heading = screen.getByRole("heading", { name: "Agents & providers" });
     expect(heading).toBeVisible();
-    expect(heading.closest("[data-provider-settings-adapter='legacy']")).toBeTruthy();
-    expect(screen.getByText("Runtime settings")).toBeVisible();
+    expect(heading.closest("[data-provider-settings-adapter='shared']")).toBeTruthy();
     expect(screen.queryByText("SOUL (Personality)")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue in Terminal" }));
+    expect(onOpenTerminal).toHaveBeenCalledWith("provider-login");
+  });
+
+  it("shows a safe unavailable state when the first provider read fails", () => {
+    providerControllerState.snapshot = null;
+    providerControllerState.error = "Provider settings are unavailable.";
+
+    render(<AgentSection />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Provider settings are unavailable");
+    expect(screen.queryByText(/Anthropic|secret|private/i)).toBeNull();
   });
 
   it("persists SOUL to its owner-controlled file", async () => {

--- a/tests/shell/mobile-shell.test.tsx
+++ b/tests/shell/mobile-shell.test.tsx
@@ -11,6 +11,7 @@ import { setDesktopViewport, setPhoneViewport } from "./mobile-shell-test-utils.
 let fileChangeHandler: ((path: string, event: "add" | "change" | "unlink") => void) | null = null;
 const settingsMock = vi.hoisted(() => ({
   onOpenAgentTerminal: undefined as undefined | ((action: "openclaw-install") => void),
+  onOpenProviderTerminalSession: undefined as undefined | ((sessionId: string) => void),
 }));
 
 vi.mock("../../shell/src/hooks/useFileWatcher.js", () => ({
@@ -36,9 +37,21 @@ vi.mock("../../shell/src/components/terminal/TerminalApp.js", () => ({
 }));
 
 vi.mock("../../shell/src/components/Settings.js", () => ({
-  Settings: ({ onOpenAgentTerminal }: { onOpenAgentTerminal?: (action: "openclaw-install") => void }) => {
+  Settings: ({
+    onOpenAgentTerminal,
+    onOpenProviderTerminalSession,
+  }: {
+    onOpenAgentTerminal?: (action: "openclaw-install") => void;
+    onOpenProviderTerminalSession?: (sessionId: string) => void;
+  }) => {
     settingsMock.onOpenAgentTerminal = onOpenAgentTerminal;
-    return <button onClick={() => onOpenAgentTerminal?.("openclaw-install")}>Install OpenClaw from Settings</button>;
+    settingsMock.onOpenProviderTerminalSession = onOpenProviderTerminalSession;
+    return (
+      <>
+        <button onClick={() => onOpenAgentTerminal?.("openclaw-install")}>Install OpenClaw from Settings</button>
+        <button onClick={() => onOpenProviderTerminalSession?.("provider-login")}>Continue provider login</button>
+      </>
+    );
   },
 }));
 
@@ -118,6 +131,7 @@ describe("mobile shell", () => {
     });
     setDesktopViewport();
     settingsMock.onOpenAgentTerminal = undefined;
+    settingsMock.onOpenProviderTerminalSession = undefined;
     window.sessionStorage.clear();
   });
 
@@ -200,6 +214,21 @@ describe("mobile shell", () => {
 
     expect(await screen.findByTestId("terminal-app")).toBeTruthy();
     expect(window.sessionStorage.getItem("matrix:terminal-launch-queue")).toContain("openclaw-install");
+  });
+
+  it("focuses a visible terminal for an existing provider session without queuing a command", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve({
+      ok: true,
+      json: async () => [],
+    })));
+    const MobileShell = await loadMobileShell();
+
+    render(<MobileShell />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue provider login" }));
+
+    expect(await screen.findByTestId("terminal-app")).toBeTruthy();
+    expect(window.sessionStorage.getItem("matrix:provider-terminal-session-queue")).toContain("provider-login");
+    expect(window.sessionStorage.getItem("matrix:terminal-launch-queue")).toBeNull();
   });
 
   it("hides the bottom dock while the terminal command composer is focused", async () => {

--- a/tests/shell/provider-browser-action.test.ts
+++ b/tests/shell/provider-browser-action.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { openProviderAuthorizationPath } from "../../shell/src/lib/provider-browser-action.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("provider browser authorization", () => {
+  it("opens only a contract-valid gateway-relative authorization path", () => {
+    window.history.replaceState({}, "", "/vm/preview/settings?runtime=pr-1");
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+
+    expect(openProviderAuthorizationPath("/api/ai/providers/login-attempts/attempt-1/authorize")).toBe(true);
+    expect(open).toHaveBeenCalledWith(
+      `${window.location.origin}/vm/preview/~runtime/pr-1/api/ai/providers/login-attempts/attempt-1/authorize`,
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it.each([
+    "https://provider.example/authorize?token=secret",
+    "//provider.example/authorize",
+    "/api/ai/providers/login-attempts/../authorize",
+    "/api/ai/providers/login-attempts/attempt-1/authorize?token=secret",
+  ])("rejects non-canonical or external paths: %s", (path) => {
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+    expect(openProviderAuthorizationPath(path)).toBe(false);
+    expect(open).not.toHaveBeenCalled();
+  });
+});

--- a/tests/shell/provider-settings-transport.test.ts
+++ b/tests/shell/provider-settings-transport.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProviderSettingsSnapshotSchema } from "@matrix-os/contracts";
+
+vi.mock("@matrix-os/ui", () => ({
+  ProviderSettingsTransportError: class ProviderSettingsTransportError extends Error {
+    constructor(readonly code: string) {
+      super("Provider settings are unavailable.");
+      this.name = "ProviderSettingsTransportError";
+    }
+  },
+}));
+
+import {
+  createProviderSettingsTransport,
+  ProviderSettingsTransportError,
+} from "../../shell/src/lib/provider-settings-transport.js";
+
+const snapshot = ProviderSettingsSnapshotSchema.parse({
+  contractVersion: 1,
+  projectionOf: { contract: "AiProviderSnapshotV3", contractVersion: 3, revision: 4 },
+  revision: 2,
+  refreshedAt: "2026-08-30T10:00:00.000Z",
+  access: { mode: "read_only", reason: "runtime_unavailable" },
+  supportedActions: [],
+  modelProviders: [{
+    id: "anthropic",
+    displayName: "Anthropic",
+    models: [{ id: "claude-opus-5", displayName: "Claude Opus 5", enabled: true }],
+  }],
+  accessSources: [{
+    id: "matrix_included",
+    kind: "matrix_gateway",
+    fundingKind: "matrix_included",
+    providerId: "anthropic",
+    accountId: null,
+    displayName: "Matrix AI",
+    readiness: {
+      state: "ready",
+      checkedAt: "2026-08-30T10:00:00.000Z",
+      staleAfter: "2026-08-30T10:05:00.000Z",
+      action: "none",
+      safeReason: null,
+    },
+    eligibleModelIds: ["claude-opus-5"],
+    usage: {
+      kind: "unavailable",
+      authority: "unavailable",
+      state: "unavailable",
+      scope: "owner_entitlement",
+      reason: "ledger_not_available",
+      asOf: null,
+    },
+  }],
+  accounts: [],
+  harnesses: [{
+    id: "harness_kernel",
+    harness: "claude",
+    displayName: "Claude",
+    accentColor: null,
+    enabled: true,
+    version: null,
+    installState: "installed",
+    authState: "authenticated",
+    loginMethods: ["terminal"],
+    recommendedLoginMethod: "terminal",
+    connectivity: "online",
+    accountIds: [],
+    selectedAccountId: null,
+    accessSourceId: "matrix_included",
+    route: { kind: "fixed", providerId: "anthropic", modelId: "claude-opus-5" },
+    activeChatCount: 0,
+  }],
+  gatewayPolicy: {
+    accessSourceId: "matrix_included",
+    monthlyBudgetMicrousd: null,
+    allowedModelIds: ["claude-opus-5"],
+    topUpEnabled: false,
+  },
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("provider settings shell transport", () => {
+  it("loads and schema-validates a bounded no-store snapshot from the active gateway", async () => {
+    const fetcher = vi.fn(async () => Response.json(snapshot));
+    const transport = createProviderSettingsTransport({ fetcher });
+
+    await expect(transport.getSnapshot()).resolves.toEqual(snapshot);
+    expect(fetcher).toHaveBeenCalledWith(
+      `${window.location.origin}/api/ai/provider-settings`,
+      expect.objectContaining({ cache: "no-store", signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("validates mutation inputs and responses without exposing upstream details", async () => {
+    const fetcher = vi.fn(async () => new Response("Anthropic sk-secret at /opt/private", { status: 503 }));
+    const transport = createProviderSettingsTransport({ fetcher });
+    await expect(transport.mutate({ type: "bad_action" })).rejects.toEqual(
+      expect.objectContaining({ code: "invalid_request", message: "Provider settings are unavailable." }),
+    );
+    expect(fetcher).not.toHaveBeenCalled();
+
+    await expect(transport.mutate({
+      type: "set_gateway_budget",
+      expectedRevision: 2,
+      idempotencyKey: "budget_1",
+      monthlyBudgetMicrousd: 2_000_000,
+    })).rejects.toBeInstanceOf(ProviderSettingsTransportError);
+    await expect(transport.mutate({
+      type: "set_gateway_budget",
+      expectedRevision: 2,
+      idempotencyKey: "budget_2",
+      monthlyBudgetMicrousd: 2_000_000,
+    })).rejects.not.toThrow(/Anthropic|secret|private/i);
+  });
+
+  it("rejects oversized or malformed successful responses", async () => {
+    const oversized = vi.fn(async () => new Response("x".repeat(1_100_000), {
+      headers: { "content-length": "1100000" },
+    }));
+    await expect(createProviderSettingsTransport({ fetcher: oversized }).getSnapshot())
+      .rejects.toEqual(expect.objectContaining({ code: "invalid_response" }));
+
+    const malformed = vi.fn(async () => Response.json({ ...snapshot, revision: "not-a-number" }));
+    await expect(createProviderSettingsTransport({ fetcher: malformed }).getSnapshot())
+      .rejects.toEqual(expect.objectContaining({ code: "invalid_response" }));
+  });
+
+  it("preserves only allowlisted conflict codes from bounded error bodies", async () => {
+    const conflict = vi.fn(async () => Response.json({
+      error: { code: "revision_conflict", message: "Anthropic sk-secret at /opt/private" },
+    }, { status: 409 }));
+    const transport = createProviderSettingsTransport({ fetcher: conflict });
+
+    await expect(transport.mutate({
+      type: "set_gateway_budget",
+      expectedRevision: 2,
+      idempotencyKey: "budget_conflict",
+      monthlyBudgetMicrousd: 2_000_000,
+    })).rejects.toEqual(expect.objectContaining({
+      code: "revision_conflict",
+      message: "Provider settings are unavailable.",
+    }));
+
+    const unknown = vi.fn(async () => Response.json({
+      error: { code: "database_failed", message: "/private/db" },
+    }, { status: 500 }));
+    await expect(createProviderSettingsTransport({ fetcher: unknown }).getSnapshot())
+      .rejects.toEqual(expect.objectContaining({ code: "unavailable" }));
+  });
+});

--- a/tests/shell/provider-terminal-session.test.ts
+++ b/tests/shell/provider-terminal-session.test.ts
@@ -47,4 +47,31 @@ describe("provider terminal session handoff", () => {
     await expect(drainExistingTerminalSessionQueue("window-b", { fetcher: validFetcher }))
       .resolves.toEqual(["other-login"]);
   });
+
+  it("retains matched handoffs until the server confirms the session is active", async () => {
+    enqueueExistingTerminalSession("provider-login", "window-a");
+    const unavailable = vi.fn(async () => {
+      throw new TypeError("offline");
+    });
+
+    await expect(drainExistingTerminalSessionQueue("window-a", { fetcher: unavailable }))
+      .resolves.toEqual([]);
+    expect(sessionStorage.getItem("matrix:provider-terminal-session-queue"))
+      .toContain("provider-login");
+
+    const inactive = vi.fn(async () => Response.json({
+      sessions: [{ name: "provider-login", status: "exited" }],
+    }));
+    await expect(drainExistingTerminalSessionQueue("window-a", { fetcher: inactive }))
+      .resolves.toEqual([]);
+    expect(sessionStorage.getItem("matrix:provider-terminal-session-queue"))
+      .toContain("provider-login");
+
+    const active = vi.fn(async () => Response.json({
+      sessions: [{ name: "provider-login", status: "active" }],
+    }));
+    await expect(drainExistingTerminalSessionQueue("window-a", { fetcher: active }))
+      .resolves.toEqual(["provider-login"]);
+    expect(sessionStorage.getItem("matrix:provider-terminal-session-queue")).toBe("[]");
+  });
 });

--- a/tests/shell/provider-terminal-session.test.ts
+++ b/tests/shell/provider-terminal-session.test.ts
@@ -5,6 +5,7 @@ import {
   drainExistingTerminalSessionQueue,
   drainExistingTerminalSessionQueueWithRetry,
   enqueueExistingTerminalSession,
+  hasQueuedExistingTerminalSession,
 } from "../../shell/src/lib/provider-terminal-session.js";
 
 afterEach(() => {
@@ -109,5 +110,16 @@ describe("provider terminal session handoff", () => {
     expect(wait).toHaveBeenCalledTimes(3);
     expect(sessionStorage.getItem("matrix:provider-terminal-session-queue"))
       .toContain("provider-login");
+    expect(hasQueuedExistingTerminalSession("window-a")).toBe(true);
+  });
+
+  it("expires retained handoffs so background retries remain bounded", () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    enqueueExistingTerminalSession("provider-login", "window-a");
+
+    expect(hasQueuedExistingTerminalSession("window-a")).toBe(true);
+    now.mockReturnValue(11 * 60_000);
+    expect(hasQueuedExistingTerminalSession("window-a")).toBe(false);
+    expect(sessionStorage.getItem("matrix:provider-terminal-session-queue")).toBe("[]");
   });
 });

--- a/tests/shell/provider-terminal-session.test.ts
+++ b/tests/shell/provider-terminal-session.test.ts
@@ -122,4 +122,19 @@ describe("provider terminal session handoff", () => {
     expect(hasQueuedExistingTerminalSession("window-a")).toBe(false);
     expect(sessionStorage.getItem("matrix:provider-terminal-session-queue")).toBe("[]");
   });
+
+  it("migrates the preceding queue format without making its lifetime unbounded", () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    sessionStorage.setItem("matrix:provider-terminal-session-queue", JSON.stringify([
+      { sessionId: "provider-login", targetId: "window-a" },
+    ]));
+
+    expect(hasQueuedExistingTerminalSession("window-a")).toBe(true);
+    expect(JSON.parse(sessionStorage.getItem("matrix:provider-terminal-session-queue") ?? "[]"))
+      .toEqual([{ sessionId: "provider-login", targetId: "window-a", expiresAt: 601_000 }]);
+
+    now.mockReturnValue(601_001);
+    expect(hasQueuedExistingTerminalSession("window-a")).toBe(false);
+    expect(sessionStorage.getItem("matrix:provider-terminal-session-queue")).toBe("[]");
+  });
 });

--- a/tests/shell/provider-terminal-session.test.ts
+++ b/tests/shell/provider-terminal-session.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  drainExistingTerminalSessionQueue,
+  enqueueExistingTerminalSession,
+} from "../../shell/src/lib/provider-terminal-session.js";
+
+afterEach(() => {
+  sessionStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe("provider terminal session handoff", () => {
+  it("queues only opaque canonical session ids and targets the active terminal", () => {
+    expect(enqueueExistingTerminalSession("term_observe_abc123", "window-a")).toBe(false);
+    expect(enqueueExistingTerminalSession("provider-login", "window-a")).toBe(true);
+  });
+
+  it("attaches only a listed non-exited session and never creates or executes anything", async () => {
+    const fetcher = vi.fn(async () => Response.json({
+      sessions: [
+        { name: "provider-login", status: "active" },
+        { name: "old-login", status: "exited" },
+      ],
+    }));
+    enqueueExistingTerminalSession("provider-login", "window-a");
+    enqueueExistingTerminalSession("old-login", "window-a");
+
+    await expect(drainExistingTerminalSessionQueue("window-a", { fetcher }))
+      .resolves.toEqual(["provider-login"]);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledWith(
+      `${window.location.origin}/api/terminal/sessions`,
+      expect.objectContaining({ cache: "no-store", signal: expect.any(AbortSignal) }),
+    );
+    expect(fetcher.mock.calls.every(([, init]) => init?.method !== "POST")).toBe(true);
+  });
+
+  it("fails closed on malformed lists and keeps other terminal targets queued", async () => {
+    const fetcher = vi.fn(async () => Response.json({ sessions: [{ name: "provider-login", status: 42 }] }));
+    enqueueExistingTerminalSession("provider-login", "window-a");
+    enqueueExistingTerminalSession("other-login", "window-b");
+
+    await expect(drainExistingTerminalSessionQueue("window-a", { fetcher })).resolves.toEqual([]);
+    const validFetcher = vi.fn(async () => Response.json({ sessions: [{ name: "other-login", status: "active" }] }));
+    await expect(drainExistingTerminalSessionQueue("window-b", { fetcher: validFetcher }))
+      .resolves.toEqual(["other-login"]);
+  });
+});

--- a/tests/shell/provider-terminal-session.test.ts
+++ b/tests/shell/provider-terminal-session.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   drainExistingTerminalSessionQueue,
+  drainExistingTerminalSessionQueueWithRetry,
   enqueueExistingTerminalSession,
 } from "../../shell/src/lib/provider-terminal-session.js";
 
@@ -73,5 +74,40 @@ describe("provider terminal session handoff", () => {
     await expect(drainExistingTerminalSessionQueue("window-a", { fetcher: active }))
       .resolves.toEqual(["provider-login"]);
     expect(sessionStorage.getItem("matrix:provider-terminal-session-queue")).toBe("[]");
+  });
+
+  it("retries retained handoffs with a bounded backoff until the session becomes active", async () => {
+    enqueueExistingTerminalSession("provider-login", "window-a");
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(Response.json({ sessions: [{ name: "provider-login", status: "exited" }] }))
+      .mockResolvedValueOnce(Response.json({ sessions: [{ name: "provider-login", status: "active" }] }));
+    const wait = vi.fn(async () => {});
+
+    await expect(drainExistingTerminalSessionQueueWithRetry("window-a", {
+      fetcher,
+      wait,
+      maxAttempts: 3,
+    })).resolves.toEqual(["provider-login"]);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenCalledWith(250);
+    expect(sessionStorage.getItem("matrix:provider-terminal-session-queue")).toBe("[]");
+  });
+
+  it("stops retrying after the bounded attempt count and preserves the handoff", async () => {
+    enqueueExistingTerminalSession("provider-login", "window-a");
+    const fetcher = vi.fn(async () => Response.json({
+      sessions: [{ name: "provider-login", status: "exited" }],
+    }));
+    const wait = vi.fn(async () => {});
+
+    await expect(drainExistingTerminalSessionQueueWithRetry("window-a", {
+      fetcher,
+      wait,
+      maxAttempts: 4,
+    })).resolves.toEqual([]);
+    expect(fetcher).toHaveBeenCalledTimes(4);
+    expect(wait).toHaveBeenCalledTimes(3);
+    expect(sessionStorage.getItem("matrix:provider-terminal-session-queue"))
+      .toContain("provider-login");
   });
 });

--- a/tests/shell/settings-panel.test.tsx
+++ b/tests/shell/settings-panel.test.tsx
@@ -29,7 +29,10 @@ vi.mock("../../shell/src/components/settings/sections/AppearanceSection.js", () 
   AppearanceSection: () => <div>Appearance settings</div>,
 }));
 vi.mock("../../shell/src/components/settings/sections/AgentSection.js", () => ({
-  AgentSection: () => <div>Agent settings</div>,
+  AgentSection: () => <div>Agents and providers settings</div>,
+}));
+vi.mock("../../shell/src/components/settings/sections/IdentityPersonalitySection.js", () => ({
+  IdentityPersonalitySection: () => <div>Identity and personality settings</div>,
 }));
 vi.mock("../../shell/src/components/settings/sections/ChannelsSection.js", () => ({
   ChannelsSection: () => <div>Channel settings</div>,
@@ -75,16 +78,29 @@ describe("Settings panel", () => {
     expect(accountRegion.className).toContain("sm:mt-auto");
   });
 
-  it("unhides only the Agent section from the deferred settings set", async () => {
+  it("shows canonical Agents & providers and Identity & personality sections", async () => {
     const { Settings } = await import("../../shell/src/components/Settings.js");
 
     render(<Settings open onOpenChange={() => {}} />);
 
-    await waitFor(() => expect(screen.getByRole("button", { name: "Agent" }).isConnected).toBe(true));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Agents & providers" }).isConnected).toBe(true));
+    expect(screen.getByRole("button", { name: "Identity & personality" }).isConnected).toBe(true);
     expect(screen.queryByRole("button", { name: "Channels" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Skills" })).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Agent" }));
-    expect(screen.getByText("Agent settings").isConnected).toBe(true);
+    expect(screen.queryByRole("button", { name: "Agent" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Agents & providers" }));
+    expect(screen.getByText("Agents and providers settings").isConnected).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: "Identity & personality" }));
+    expect(screen.getByText("Identity and personality settings").isConnected).toBe(true);
+  });
+
+  it.each(["agent", "providers"] as const)("maps the legacy %s deep link to Agents & providers", async (legacySection) => {
+    const { Settings } = await import("../../shell/src/components/Settings.js");
+
+    render(<Settings open defaultSection={legacySection} onOpenChange={() => {}} />);
+
+    await waitFor(() => expect(screen.getByText("Agents and providers settings").isConnected).toBe(true));
+    expect(screen.getByRole("button", { name: "Agents & providers" }).getAttribute("aria-current")).toBe("page");
   });
 
   it("honors a Desktop deep link when Settings opens", async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -70,6 +70,7 @@ import {
 import type { ShellSessionSummary } from "../../shell/src/components/terminal/terminal-session-state.js";
 import { getTerminalThemePreset } from "../../shell/src/components/terminal/terminal-themes.js";
 import { ChevronsLeftIcon, ChevronsRightIcon } from "../../shell/src/lib/hugeicons.js";
+import { enqueueExistingTerminalSession } from "../../shell/src/lib/provider-terminal-session.js";
 import { expectRenderedIcon } from "../helpers/rendered-icon";
 
 function normalizeCssColor(color: string) {
@@ -252,6 +253,33 @@ describe("TerminalApp", () => {
       sessionId: "canvas-session-123",
     });
     expect((props.paneTree as { compatMode?: string }).compatMode).toBeUndefined();
+  });
+
+  it("attaches an active provider login session without creating or executing a command", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/agents")) return Promise.resolve(mockJsonResponse(completeAgentStatusResponse()));
+      if (url.includes("/api/files/tree")) return Promise.resolve(mockJsonResponse([]));
+      if (url.includes("/api/terminal/layout")) return Promise.resolve(mockJsonResponse({}));
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve(Response.json({ sessions: [
+          { name: "main", status: "active" },
+          { name: "provider-login", status: "active" },
+        ] }));
+      }
+      return Promise.resolve(mockJsonResponse({}));
+    });
+    enqueueExistingTerminalSession("provider-login");
+
+    render(<TerminalApp />);
+
+    await vi.waitFor(() => {
+      const props = paneGridSpy.mock.lastCall?.[0] as {
+        paneTree?: { type: "pane"; sessionId?: string };
+      };
+      expect(props.paneTree?.sessionId).toBe("provider-login");
+    });
+    expect(terminalSessionPostBodies()).toEqual([]);
   });
 
   it("marks canvas-provided Codex shell sessions for Codex TUI compatibility", async () => {

--- a/tests/ui/agents-providers-view.test.tsx
+++ b/tests/ui/agents-providers-view.test.tsx
@@ -376,7 +376,7 @@ describe("AgentsProvidersView", () => {
     expect(dialog).toHaveTextContent("2 active chats");
     expect(dialog).toHaveTextContent("1 resumable chat");
     expect(within(dialog).queryByRole("button", { name: "Remove account" })).toBeNull();
-    fireEvent.change(within(dialog).getByLabelText("Reassign to"), { target: { value: "source_matrix" } });
+    fireEvent.change(within(dialog).getByLabelText("Reassign to"), { target: { value: "source:source_matrix" } });
     fireEvent.click(within(dialog).getByRole("button", { name: "Reassign dependencies" }));
 
     expect(onMutate).toHaveBeenCalledWith(expect.objectContaining({
@@ -385,6 +385,19 @@ describe("AgentsProvidersView", () => {
       target: { kind: "access_source", accessSourceId: "source_matrix" },
       scope: "all_dependencies",
     }));
+  });
+
+  it("offers only reassignment targets that serve every dependent harness route", () => {
+    setup();
+    fireEvent.click(within(screen.getByTestId("account-account_personal"))
+      .getByRole("button", { name: "Remove Personal" }));
+
+    const choices = within(screen.getByRole("dialog", { name: "Remove Personal" }))
+      .getAllByRole("option")
+      .map((option) => option.textContent);
+    expect(choices).toContain("Matrix AI included credit");
+    expect(choices).not.toContain("Work");
+    expect(choices).not.toContain("Work Anthropic key");
   });
 
   it("opens only opaque terminal session ids and owner-gateway authorization paths", () => {
@@ -496,6 +509,19 @@ describe("AgentsProvidersView", () => {
       accountId: null,
     }));
     expect(within(dialog).queryByLabelText(/API key/i)).toBeNull();
+  });
+
+  it("does not offer a Matrix gateway source for a model outside its allowlist", () => {
+    setup();
+    fireEvent.click(screen.getByRole("button", { name: "Add harness" }));
+    const dialog = screen.getByRole("dialog", { name: "Add harness" });
+    fireEvent.click(within(dialog).getByRole("radio", { name: "OpenCode" }));
+    fireEvent.change(within(dialog).getByLabelText("Model"), {
+      target: { value: "anthropic/claude-sonnet-5" },
+    });
+
+    expect(within(within(dialog).getByLabelText("Access source"))
+      .queryByRole("option", { name: "Matrix AI included credit" })).toBeNull();
   });
 });
 

--- a/tests/ui/agents-providers-view.test.tsx
+++ b/tests/ui/agents-providers-view.test.tsx
@@ -120,6 +120,31 @@ function snapshot(): ProviderSettingsSnapshot {
           asOf: now,
         },
       },
+      {
+        id: "source_openai",
+        kind: "provider_account",
+        fundingKind: "owner_subscription",
+        providerId: "openai",
+        accountId: "account_openai",
+        displayName: "Personal OpenAI subscription",
+        readiness: {
+          state: "ready",
+          checkedAt: now,
+          staleAfter: later,
+          action: "none",
+          safeReason: null,
+        },
+        eligibleModelIds: ["openai/gpt-5.6"],
+        usage: {
+          kind: "subscription_allowance",
+          authority: "provider_allowance",
+          state: "current",
+          scope: "account",
+          usedBasisPoints: 1_000,
+          resetsAt: later,
+          asOf: now,
+        },
+      },
     ],
     accounts: [
       {
@@ -140,6 +165,16 @@ function snapshot(): ProviderSettingsSnapshot {
         authState: "unauthenticated",
         lastCheckedAt: now,
         accessSourceId: "source_work",
+        dependencies: { activeChatCount: 0, resumableChatCount: 0, harnessInstanceCount: 0 },
+      },
+      {
+        id: "account_openai",
+        providerId: "openai",
+        displayName: "OpenAI personal",
+        authMethod: "oauth",
+        authState: "authenticated",
+        lastCheckedAt: now,
+        accessSourceId: "source_openai",
         dependencies: { activeChatCount: 0, resumableChatCount: 0, harnessInstanceCount: 0 },
       },
     ],
@@ -242,17 +277,19 @@ describe("AgentsProvidersView", () => {
     expect(screen.getByTestId("provider-signal-path")).toHaveTextContent("Personal Anthropic subscription");
   });
 
-  it("emits controlled route and enable intents without exposing incompatible providers", () => {
+  it("switches a generic harness to another provider as one coherent route intent", () => {
     const { onMutate } = setup();
 
-    expect(within(screen.getByLabelText("Model provider")).queryByRole("option", { name: "OpenAI" })).toBeNull();
-    fireEvent.change(screen.getByLabelText("Model"), { target: { value: "anthropic/claude-sonnet-5" } });
+    expect(within(screen.getByLabelText("Model provider")).getByRole("option", { name: "OpenAI" })).toBeVisible();
+    fireEvent.change(screen.getByLabelText("Model provider"), { target: { value: "openai" } });
     fireEvent.click(screen.getByRole("switch", { name: "Enable Hermes" }));
 
     expect(onMutate).toHaveBeenCalledWith({
       type: "set_route",
       harnessInstanceId: "harness_hermes",
-      route: { kind: "configurable", providerId: "anthropic", modelId: "anthropic/claude-sonnet-5" },
+      route: { kind: "configurable", providerId: "openai", modelId: "openai/gpt-5.6" },
+      accessSourceId: "source_openai",
+      accountId: "account_openai",
     });
     expect(onMutate).toHaveBeenCalledWith({ type: "set_harness_enabled", harnessInstanceId: "harness_hermes", enabled: false });
   });
@@ -263,6 +300,7 @@ describe("AgentsProvidersView", () => {
     harness.route = { kind: "configurable", providerId: "anthropic", modelId: "anthropic/claude-sonnet-5" };
     harness.accessSourceId = "source_matrix";
     harness.selectedAccountId = null;
+    next.gatewayPolicy!.allowedModelIds = ["anthropic/claude-opus-5", "anthropic/claude-sonnet-5"];
     const { onMutate } = setup({ snapshot: next });
 
     fireEvent.change(screen.getByLabelText("Access source"), { target: { value: "source_personal" } });

--- a/tests/ui/agents-providers-view.test.tsx
+++ b/tests/ui/agents-providers-view.test.tsx
@@ -1,0 +1,479 @@
+// @vitest-environment jsdom
+import React from "react";
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  ProviderConnectionAttempt,
+  ProviderSettingsSnapshot,
+} from "@matrix-os/contracts";
+import {
+  AgentsProvidersView,
+  type ProviderSettingsMutationIntent,
+} from "../../packages/ui/src/agents-providers/AgentsProvidersView";
+
+const now = "2026-08-30T10:00:00.000Z";
+const later = "2026-09-30T10:00:00.000Z";
+
+function snapshot(): ProviderSettingsSnapshot {
+  const value = {
+    contractVersion: 1,
+    projectionOf: { contract: "AiProviderSnapshotV3", contractVersion: 3, revision: 12 },
+    revision: 12,
+    refreshedAt: now,
+    access: { mode: "writable" },
+    modelProviders: [
+      {
+        id: "anthropic",
+        displayName: "Anthropic",
+        models: [
+          { id: "anthropic/claude-opus-5", displayName: "Claude Opus 5", enabled: true },
+          { id: "anthropic/claude-sonnet-5", displayName: "Claude Sonnet 5", enabled: true },
+        ],
+      },
+      {
+        id: "openai",
+        displayName: "OpenAI",
+        models: [{ id: "openai/gpt-5.6", displayName: "GPT-5.6", enabled: true }],
+      },
+    ],
+    accessSources: [
+      {
+        id: "source_matrix",
+        kind: "matrix_gateway",
+        fundingKind: "matrix_included",
+        providerId: "anthropic",
+        accountId: null,
+        displayName: "Matrix AI included credit",
+        readiness: {
+          state: "ready",
+          checkedAt: now,
+          staleAfter: later,
+          action: "none",
+          safeReason: null,
+        },
+        eligibleModelIds: ["anthropic/claude-opus-5", "anthropic/claude-sonnet-5"],
+        usage: {
+          kind: "managed_credit",
+          authority: "matrix_ledger",
+          state: "current",
+          scope: "owner_entitlement",
+          currency: "USD",
+          usedMicrousd: 250_000,
+          remainingMicrousd: 750_000,
+          limitMicrousd: 1_000_000,
+          periodStartedAt: now,
+          resetsAt: later,
+          asOf: now,
+        },
+      },
+      {
+        id: "source_personal",
+        kind: "provider_account",
+        fundingKind: "owner_subscription",
+        providerId: "anthropic",
+        accountId: "account_personal",
+        displayName: "Personal Anthropic subscription",
+        readiness: {
+          state: "ready",
+          checkedAt: now,
+          staleAfter: later,
+          action: "none",
+          safeReason: null,
+        },
+        eligibleModelIds: ["anthropic/claude-opus-5", "anthropic/claude-sonnet-5"],
+        usage: {
+          kind: "subscription_allowance",
+          authority: "provider_allowance",
+          state: "current",
+          scope: "account",
+          usedBasisPoints: 2_500,
+          resetsAt: later,
+          asOf: now,
+        },
+      },
+      {
+        id: "source_work",
+        kind: "provider_account",
+        fundingKind: "owner_api_key",
+        providerId: "anthropic",
+        accountId: "account_work",
+        displayName: "Work Anthropic key",
+        readiness: {
+          state: "auth_required",
+          checkedAt: now,
+          staleAfter: later,
+          action: "enter_api_key",
+          safeReason: "auth",
+        },
+        eligibleModelIds: ["anthropic/claude-sonnet-5"],
+        usage: {
+          kind: "metered_api",
+          authority: "matrix_observed",
+          state: "current",
+          scope: "account",
+          currency: "USD",
+          observedUsageMicrousd: 125_000,
+          providerBalance: null,
+          periodStartedAt: now,
+          resetsAt: later,
+          asOf: now,
+        },
+      },
+    ],
+    accounts: [
+      {
+        id: "account_personal",
+        providerId: "anthropic",
+        displayName: "Personal",
+        authMethod: "terminal",
+        authState: "authenticated",
+        lastCheckedAt: now,
+        accessSourceId: "source_personal",
+        dependencies: { activeChatCount: 2, resumableChatCount: 1, harnessInstanceCount: 1 },
+      },
+      {
+        id: "account_work",
+        providerId: "anthropic",
+        displayName: "Work",
+        authMethod: "api_key",
+        authState: "unauthenticated",
+        lastCheckedAt: now,
+        accessSourceId: "source_work",
+        dependencies: { activeChatCount: 0, resumableChatCount: 0, harnessInstanceCount: 0 },
+      },
+    ],
+    harnesses: [
+      {
+        id: "harness_hermes",
+        harness: "hermes",
+        displayName: "Hermes",
+        accentColor: "teal",
+        enabled: true,
+        version: "1.8.0",
+        installState: "installed",
+        authState: "authenticated",
+        loginMethods: ["terminal", "oauth", "api_key"],
+        recommendedLoginMethod: "terminal",
+        connectivity: "online",
+        accountIds: ["account_personal", "account_work"],
+        selectedAccountId: "account_personal",
+        accessSourceId: "source_personal",
+        route: { kind: "configurable", providerId: "anthropic", modelId: "anthropic/claude-opus-5" },
+        activeChatCount: 2,
+      },
+      {
+        id: "harness_claude",
+        harness: "claude",
+        displayName: "Claude",
+        accentColor: "orange",
+        enabled: true,
+        version: "2.1.251",
+        installState: "installed",
+        authState: "authenticated",
+        loginMethods: ["terminal"],
+        recommendedLoginMethod: "terminal",
+        connectivity: "online",
+        accountIds: ["account_personal"],
+        selectedAccountId: null,
+        accessSourceId: "source_matrix",
+        route: { kind: "fixed", providerId: "anthropic", modelId: "anthropic/claude-opus-5" },
+        activeChatCount: 0,
+      },
+    ],
+    gatewayPolicy: {
+      accessSourceId: "source_matrix",
+      monthlyBudgetMicrousd: 1_000_000,
+      allowedModelIds: ["anthropic/claude-opus-5"],
+      topUpEnabled: true,
+    },
+  } as ProviderSettingsSnapshot;
+  Object.assign(value, {
+    supportedActions: [
+      "add_harness", "update_harness", "set_harness_enabled", "set_route",
+      "select_account", "select_access_source", "start_login", "logout_account",
+      "remove_account", "reassign_account", "set_gateway_budget", "set_gateway_allowlist",
+      "add_credit", "submit_api_key",
+    ],
+  });
+  return value;
+}
+
+function setup(overrides: Partial<React.ComponentProps<typeof AgentsProvidersView>> = {}) {
+  const onMutate = vi.fn<(intent: ProviderSettingsMutationIntent) => void>();
+  const props: React.ComponentProps<typeof AgentsProvidersView> = {
+    snapshot: snapshot(),
+    selectedHarnessId: "harness_hermes",
+    onSelectHarness: vi.fn(),
+    onRefresh: vi.fn(),
+    onMutate,
+    onOpenTerminal: vi.fn(),
+    onOpenBrowser: vi.fn(),
+    onAddCredit: vi.fn(),
+    ...overrides,
+  };
+  return { ...render(<AgentsProvidersView {...props} />), props, onMutate };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("AgentsProvidersView", () => {
+  it("derives the last checked label from the snapshot refresh time", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-08-30T10:02:00.000Z");
+    setup();
+
+    expect(screen.getByText("Checked 2 minutes ago")).toBeVisible();
+  });
+
+  it("renders the T3-derived harness rail with add at the top and a selected editor", () => {
+    setup();
+
+    const rail = screen.getByRole("navigation", { name: "Agent harnesses" });
+    const controls = within(rail).getAllByRole("button");
+    expect(controls[0]).toHaveAccessibleName("Add harness");
+    expect(within(rail).getByRole("button", { name: /Hermes/ })).toHaveAttribute("aria-current", "true");
+    expect(screen.getByRole("heading", { name: "Hermes" })).toBeVisible();
+    expect(screen.getByLabelText("Model provider")).toHaveValue("anthropic");
+    expect(screen.getByLabelText("Model")).toHaveValue("anthropic/claude-opus-5");
+    expect(screen.getByTestId("provider-signal-path")).toHaveTextContent("Personal Anthropic subscription");
+  });
+
+  it("emits controlled route and enable intents without exposing incompatible providers", () => {
+    const { onMutate } = setup();
+
+    expect(within(screen.getByLabelText("Model provider")).queryByRole("option", { name: "OpenAI" })).toBeNull();
+    fireEvent.change(screen.getByLabelText("Model"), { target: { value: "anthropic/claude-sonnet-5" } });
+    fireEvent.click(screen.getByRole("switch", { name: "Enable Hermes" }));
+
+    expect(onMutate).toHaveBeenCalledWith({
+      type: "set_route",
+      harnessInstanceId: "harness_hermes",
+      route: { kind: "configurable", providerId: "anthropic", modelId: "anthropic/claude-sonnet-5" },
+    });
+    expect(onMutate).toHaveBeenCalledWith({ type: "set_harness_enabled", harnessInstanceId: "harness_hermes", enabled: false });
+  });
+
+  it("emits compatible access-source and account intents and never sends a blank account", () => {
+    const next = snapshot();
+    const harness = next.harnesses[0]!;
+    harness.route = { kind: "configurable", providerId: "anthropic", modelId: "anthropic/claude-sonnet-5" };
+    harness.accessSourceId = "source_matrix";
+    harness.selectedAccountId = null;
+    const { onMutate } = setup({ snapshot: next });
+
+    fireEvent.change(screen.getByLabelText("Access source"), { target: { value: "source_personal" } });
+    fireEvent.change(screen.getByLabelText("Account"), { target: { value: "account_work" } });
+    fireEvent.change(screen.getByLabelText("Account"), { target: { value: "" } });
+
+    expect(onMutate).toHaveBeenCalledWith({ type: "select_access_source", harnessInstanceId: "harness_hermes", accessSourceId: "source_personal" });
+    expect(onMutate).toHaveBeenCalledWith({ type: "select_account", harnessInstanceId: "harness_hermes", accountId: "account_work" });
+    expect(onMutate).toHaveBeenCalledWith({ type: "select_access_source", harnessInstanceId: "harness_hermes", accessSourceId: "source_matrix" });
+    expect(onMutate).not.toHaveBeenCalledWith(expect.objectContaining({ type: "select_account", accountId: "" }));
+  });
+
+  it("keeps fixed harness routes visible but immutable", () => {
+    setup({ selectedHarnessId: "harness_claude" });
+
+    expect(screen.getByText("Fixed by Claude")).toBeVisible();
+    expect(screen.getByLabelText("Model provider")).toBeDisabled();
+    expect(screen.getByLabelText("Model")).toBeDisabled();
+  });
+
+  it("shows exact, stale, and unavailable gateway credit without inventing balances", () => {
+    const current = snapshot();
+    const { rerender } = setup({ snapshot: current });
+    expect(screen.getByText("$0.75 remaining")).toBeVisible();
+    expect(screen.getByText("$0.25 used of $1.00")).toBeVisible();
+
+    const stale = structuredClone(current);
+    stale.accessSources[0]!.usage = { ...stale.accessSources[0]!.usage, state: "stale" } as typeof stale.accessSources[0]["usage"];
+    rerender(<AgentsProvidersView {...setupProps(stale)} />);
+    expect(screen.getByText(/Credit last confirmed/)).toBeVisible();
+
+    const unavailable = structuredClone(current);
+    unavailable.accessSources[0]!.usage = {
+      kind: "unavailable",
+      authority: "unavailable",
+      state: "unavailable",
+      scope: "owner_entitlement",
+      reason: "ledger_not_available",
+      asOf: null,
+    };
+    rerender(<AgentsProvidersView {...setupProps(unavailable)} />);
+    expect(screen.getByText("Credit unavailable")).toBeVisible();
+    expect(screen.queryByText("$0.00 remaining")).toBeNull();
+  });
+
+  it("shows per-account usage and keeps login, logout, and remove distinct", () => {
+    const { onMutate } = setup();
+    const personal = screen.getByTestId("account-account_personal");
+    const work = screen.getByTestId("account-account_work");
+
+    expect(within(personal).getByText("25% used")).toBeVisible();
+    expect(within(work).getByText("$0.13 observed")).toBeVisible();
+    fireEvent.click(within(personal).getByRole("button", { name: "Log out Personal" }));
+    fireEvent.click(within(work).getByRole("button", { name: "Log in Work" }));
+    fireEvent.click(within(work).getByRole("button", { name: "Remove Work" }));
+    fireEvent.click(screen.getByRole("button", { name: "Remove account" }));
+
+    expect(onMutate).toHaveBeenCalledWith({ type: "logout_account", accountId: "account_personal" });
+    expect(onMutate).toHaveBeenCalledWith({ type: "start_login", harnessInstanceId: "harness_hermes", accountId: "account_work", method: "api_key" });
+    expect(onMutate).toHaveBeenCalledWith(expect.objectContaining({
+      type: "remove_account",
+      accountId: "account_work",
+      confirmation: "remove_account",
+    }));
+  });
+
+  it("requires dependency reassignment before removing an account in use", () => {
+    const { onMutate } = setup();
+    const personal = screen.getByTestId("account-account_personal");
+    fireEvent.click(within(personal).getByRole("button", { name: "Remove Personal" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Remove Personal" });
+    expect(dialog).toHaveTextContent("2 active chats");
+    expect(dialog).toHaveTextContent("1 resumable chat");
+    expect(within(dialog).queryByRole("button", { name: "Remove account" })).toBeNull();
+    fireEvent.change(within(dialog).getByLabelText("Reassign to"), { target: { value: "source_matrix" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Reassign dependencies" }));
+
+    expect(onMutate).toHaveBeenCalledWith(expect.objectContaining({
+      type: "reassign_account",
+      fromAccountId: "account_personal",
+      target: { kind: "access_source", accessSourceId: "source_matrix" },
+      scope: "all_dependencies",
+    }));
+  });
+
+  it("opens only opaque terminal session ids and owner-gateway authorization paths", () => {
+    const terminalAttempt: ProviderConnectionAttempt = {
+      id: "attempt_terminal",
+      harnessInstanceId: "harness_hermes",
+      accountId: null,
+      method: "terminal",
+      state: "pending",
+      action: { kind: "open_terminal", terminalSessionId: "provider-login-123" },
+      expiresAt: later,
+      safeFailure: null,
+    };
+    const onOpenTerminal = vi.fn();
+    const onOpenBrowser = vi.fn();
+    const { rerender } = setup({ connectionAttempt: terminalAttempt, onOpenTerminal, onOpenBrowser });
+    fireEvent.click(screen.getByRole("button", { name: "Continue in Terminal" }));
+    expect(onOpenTerminal).toHaveBeenCalledWith("provider-login-123");
+
+    const browserAttempt: ProviderConnectionAttempt = {
+      ...terminalAttempt,
+      id: "attempt_browser",
+      method: "oauth",
+      action: { kind: "open_browser", authorizationPath: "/api/ai/providers/login-attempts/attempt_browser/authorize" },
+    };
+    rerender(<AgentsProvidersView {...setupProps(snapshot(), { connectionAttempt: browserAttempt, onOpenTerminal, onOpenBrowser })} />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue in browser" }));
+    expect(onOpenBrowser).toHaveBeenCalledWith("/api/ai/providers/login-attempts/attempt_browser/authorize");
+  });
+
+  it("controls gateway budget, model allowlist, refresh, and add-on credit", () => {
+    const onRefresh = vi.fn();
+    const onAddCredit = vi.fn();
+    const { onMutate } = setup({ onRefresh, onAddCredit });
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh provider status" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add credit" }));
+    fireEvent.change(screen.getByLabelText("Monthly budget in USD"), { target: { value: "2.5" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save budget" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Allow Claude Sonnet 5" }));
+
+    expect(onRefresh).toHaveBeenCalledOnce();
+    expect(onAddCredit).toHaveBeenCalledWith("source_matrix");
+    expect(onMutate).toHaveBeenCalledWith({ type: "set_gateway_budget", monthlyBudgetMicrousd: 2_500_000 });
+    expect(onMutate).toHaveBeenCalledWith({
+      type: "set_gateway_allowlist",
+      allowedModelIds: ["anthropic/claude-opus-5", "anthropic/claude-sonnet-5"],
+    });
+  });
+
+  it("shows install, offline, busy, and read-only states without inventing an install capability", () => {
+    const base = snapshot();
+    base.harnesses.push({
+      ...base.harnesses[0]!,
+      id: "harness_pi",
+      harness: "pi",
+      displayName: "Pi",
+      enabled: false,
+      version: null,
+      installState: "missing",
+      connectivity: "offline",
+      accountIds: [],
+      selectedAccountId: null,
+      accessSourceId: "source_matrix",
+      activeChatCount: 0,
+    });
+    const { rerender } = setup({ snapshot: base, selectedHarnessId: "harness_pi" });
+    expect(screen.getAllByText("Offline")).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "Install Pi" })).toBeDisabled();
+
+    const readOnly = structuredClone(base);
+    readOnly.access = { mode: "read_only", reason: "remote_policy" };
+    Object.assign(readOnly, { supportedActions: [] });
+    rerender(<AgentsProvidersView {...setupProps(readOnly, { selectedHarnessId: "harness_pi", busy: true })} />);
+    expect(screen.getByRole("status")).toHaveTextContent("Read only");
+    expect(screen.getByRole("button", { name: "Install Pi" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Add harness" })).toBeDisabled();
+  });
+
+  it("keeps unsupported future account and credit actions visible but explanatory and disabled", () => {
+    const limited = snapshot();
+    Object.assign(limited, {
+      supportedActions: [
+        "add_harness", "update_harness", "set_harness_enabled", "set_route",
+        "select_account", "select_access_source", "set_gateway_budget", "set_gateway_allowlist",
+      ],
+    });
+    setup({ snapshot: limited });
+
+    expect(screen.getByRole("button", { name: "+ Add account" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Log out Personal" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Remove Personal" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Add credit" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Add credit" })).toHaveAttribute("title", "Adding credit is not available yet");
+  });
+
+  it("adds a harness from the top-rail flow without collecting credentials", () => {
+    const { onMutate } = setup();
+    fireEvent.click(screen.getByRole("button", { name: "Add harness" }));
+    const dialog = screen.getByRole("dialog", { name: "Add harness" });
+    fireEvent.click(within(dialog).getByRole("radio", { name: "OpenCode" }));
+    fireEvent.change(within(dialog).getByLabelText("Display name"), { target: { value: "OpenCode Work" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Add harness" }));
+
+    expect(onMutate).toHaveBeenCalledWith(expect.objectContaining({
+      type: "add_harness",
+      harness: "opencode",
+      displayName: "OpenCode Work",
+      accountId: null,
+    }));
+    expect(within(dialog).queryByLabelText(/API key/i)).toBeNull();
+  });
+});
+
+function setupProps(
+  nextSnapshot: ProviderSettingsSnapshot,
+  overrides: Partial<React.ComponentProps<typeof AgentsProvidersView>> = {},
+): React.ComponentProps<typeof AgentsProvidersView> {
+  return {
+    snapshot: nextSnapshot,
+    selectedHarnessId: "harness_hermes",
+    onSelectHarness: vi.fn(),
+    onRefresh: vi.fn(),
+    onMutate: vi.fn(),
+    onOpenTerminal: vi.fn(),
+    onOpenBrowser: vi.fn(),
+    onAddCredit: vi.fn(),
+    ...overrides,
+  };
+}

--- a/tests/ui/provider-settings-controller.test.tsx
+++ b/tests/ui/provider-settings-controller.test.tsx
@@ -1,0 +1,391 @@
+// @vitest-environment jsdom
+import React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  ProviderSettingsMutation,
+  ProviderSettingsMutationResponse,
+  ProviderSettingsSnapshot,
+} from "@matrix-os/contracts";
+import {
+  ProviderSettingsController,
+  ProviderSettingsTransportError,
+  useProviderSettingsController,
+  type ProviderSettingsTransport,
+} from "../../packages/ui/src/agents-providers/provider-settings-controller";
+
+const checkedAt = "2026-08-30T10:00:00.000Z";
+
+function snapshot(revision: number, harnessIds = ["harness_one"]): ProviderSettingsSnapshot {
+  return {
+    contractVersion: 1,
+    projectionOf: { contract: "AiProviderSnapshotV3", contractVersion: 3, revision },
+    revision,
+    refreshedAt: checkedAt,
+    access: { mode: "writable" },
+    supportedActions: ["update_harness", "set_harness_enabled", "start_login"],
+    modelProviders: [{
+      id: "anthropic",
+      displayName: "Anthropic",
+      models: [{ id: "anthropic/claude-sonnet-5", displayName: "Claude Sonnet 5", enabled: true }],
+    }],
+    accessSources: [{
+      id: "source_matrix",
+      kind: "matrix_gateway",
+      fundingKind: "matrix_included",
+      providerId: "anthropic",
+      accountId: null,
+      displayName: "Matrix AI",
+      readiness: { state: "ready", checkedAt, staleAfter: null, action: "none", safeReason: null },
+      eligibleModelIds: ["anthropic/claude-sonnet-5"],
+      usage: {
+        kind: "unavailable",
+        authority: "unavailable",
+        state: "unavailable",
+        scope: "owner_entitlement",
+        reason: "ledger_not_available",
+        asOf: checkedAt,
+      },
+    }],
+    accounts: [],
+    harnesses: harnessIds.map((id, index) => ({
+      id,
+      harness: "hermes" as const,
+      displayName: `Hermes ${index + 1}`,
+      accentColor: "teal" as const,
+      enabled: true,
+      version: "1.0.0",
+      installState: "installed" as const,
+      authState: "authenticated" as const,
+      loginMethods: ["terminal" as const],
+      recommendedLoginMethod: "terminal" as const,
+      connectivity: "online" as const,
+      accountIds: [],
+      selectedAccountId: null,
+      accessSourceId: "source_matrix",
+      route: {
+        kind: "configurable" as const,
+        providerId: "anthropic",
+        modelId: "anthropic/claude-sonnet-5",
+      },
+      activeChatCount: 0,
+    })),
+    gatewayPolicy: {
+      accessSourceId: "source_matrix",
+      monthlyBudgetMicrousd: null,
+      allowedModelIds: ["anthropic/claude-sonnet-5"],
+      topUpEnabled: false,
+    },
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function transport(options: {
+  getSnapshot?: ProviderSettingsTransport["getSnapshot"];
+  mutate?: ProviderSettingsTransport["mutate"];
+} = {}) {
+  return {
+    getSnapshot: vi.fn(options.getSnapshot ?? (async () => snapshot(1))),
+    mutate: vi.fn(options.mutate ?? (async () => ({ kind: "snapshot", snapshot: snapshot(2) }))),
+  } satisfies ProviderSettingsTransport;
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("ProviderSettingsController", () => {
+  it("parses the initial snapshot and selects its first harness", async () => {
+    const gateway = transport();
+    const controller = new ProviderSettingsController({ identityKey: "owner-a:primary", transport: gateway });
+
+    await controller.refresh();
+
+    expect(controller.getState().snapshot?.revision).toBe(1);
+    expect(controller.getState().selectedHarnessId).toBe("harness_one");
+    expect(controller.getState().error).toBeNull();
+  });
+
+  it("adds the current revision and a crypto UUID, then exposes a parsed login attempt", async () => {
+    vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue("11111111-1111-4111-8111-111111111111");
+    const response: ProviderSettingsMutationResponse = {
+      kind: "login_attempt",
+      snapshot: {
+        ...snapshot(2),
+        harnesses: snapshot(2).harnesses.map((harness) => ({ ...harness, authState: "authenticating" })),
+      },
+      attempt: {
+        id: "attempt_one",
+        harnessInstanceId: "harness_one",
+        accountId: null,
+        method: "terminal",
+        state: "pending",
+        action: { kind: "open_terminal", terminalSessionId: "matrix-login" },
+        expiresAt: "2026-08-30T10:10:00.000Z",
+        safeFailure: null,
+      },
+    };
+    const gateway = transport({ mutate: async () => response });
+    const controller = new ProviderSettingsController({ identityKey: "owner-a:primary", transport: gateway });
+    await controller.refresh();
+
+    await controller.mutate({
+      type: "start_login",
+      harnessInstanceId: "harness_one",
+      accountId: null,
+      method: "terminal",
+    });
+
+    expect(gateway.mutate).toHaveBeenCalledWith({
+      type: "start_login",
+      harnessInstanceId: "harness_one",
+      accountId: null,
+      method: "terminal",
+      expectedRevision: 1,
+      idempotencyKey: "11111111-1111-4111-8111-111111111111",
+    }, expect.any(AbortSignal));
+    expect(controller.getState().snapshot?.revision).toBe(2);
+    expect(controller.getState().connectionAttempt?.id).toBe("attempt_one");
+  });
+
+  it("serializes mutations and reads the latest confirmed revision when each starts", async () => {
+    const first = deferred<ProviderSettingsMutationResponse>();
+    const requests: ProviderSettingsMutation[] = [];
+    const gateway = transport({
+      mutate: async (mutation) => {
+        requests.push(mutation);
+        if (requests.length === 1) return first.promise;
+        return { kind: "snapshot", snapshot: snapshot(3) };
+      },
+    });
+    const controller = new ProviderSettingsController({ identityKey: "owner-a:primary", transport: gateway });
+    await controller.refresh();
+
+    const one = controller.mutate({ type: "update_harness", harnessInstanceId: "harness_one", displayName: "One" });
+    const two = controller.mutate({ type: "set_harness_enabled", harnessInstanceId: "harness_one", enabled: false });
+    await Promise.resolve();
+    expect(gateway.mutate).toHaveBeenCalledTimes(1);
+
+    first.resolve({ kind: "snapshot", snapshot: snapshot(2) });
+    await Promise.all([one, two]);
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.expectedRevision).toBe(1);
+    expect(requests[1]?.expectedRevision).toBe(2);
+    expect(controller.getState().snapshot?.revision).toBe(3);
+    expect(controller.getState().busy).toBe(false);
+  });
+
+  it("keeps the last server-confirmed snapshot while a mutation is pending", async () => {
+    const response = deferred<ProviderSettingsMutationResponse>();
+    const gateway = transport({ mutate: async () => response.promise });
+    const controller = new ProviderSettingsController({ identityKey: "owner-a:primary", transport: gateway });
+    await controller.refresh();
+
+    const mutation = controller.mutate({
+      type: "update_harness",
+      harnessInstanceId: "harness_one",
+      displayName: "Confirmed later",
+    });
+    await Promise.resolve();
+
+    expect(controller.getState().snapshot?.revision).toBe(1);
+    response.resolve({ kind: "snapshot", snapshot: snapshot(2) });
+    await mutation;
+    expect(controller.getState().snapshot?.revision).toBe(2);
+  });
+
+  it("fails closed when the server does not advertise an action", async () => {
+    const gateway = transport();
+    const controller = new ProviderSettingsController({ identityKey: "owner-a:primary", transport: gateway });
+    await controller.refresh();
+
+    await controller.mutate({ type: "set_gateway_budget", monthlyBudgetMicrousd: 1_000_000 });
+
+    expect(gateway.mutate).not.toHaveBeenCalled();
+    expect(controller.getState().snapshot?.revision).toBe(1);
+    expect(controller.getState().error).toBe("Changes were not saved. Refresh and try again.");
+  });
+
+  it("does not let an older refresh overwrite a later mutation response", async () => {
+    const staleRefresh = deferred<unknown>();
+    let loads = 0;
+    const gateway = transport({
+      getSnapshot: async () => {
+        loads += 1;
+        return loads === 1 ? snapshot(1) : staleRefresh.promise;
+      },
+      mutate: async () => ({ kind: "snapshot", snapshot: snapshot(2) }),
+    });
+    const controller = new ProviderSettingsController({ identityKey: "owner-a:primary", transport: gateway });
+    await controller.refresh();
+
+    const refresh = controller.refresh();
+    await controller.mutate({ type: "update_harness", harnessInstanceId: "harness_one", displayName: "Latest" });
+    staleRefresh.resolve(snapshot(1));
+    await refresh;
+
+    expect(controller.getState().snapshot?.revision).toBe(2);
+  });
+
+  it("reloads authoritative state after a revision conflict and never exposes raw errors", async () => {
+    let loads = 0;
+    const gateway = transport({
+      getSnapshot: async () => snapshot(++loads),
+      mutate: async () => {
+        throw new ProviderSettingsTransportError("revision_conflict", "Anthropic sk-secret /private/path");
+      },
+    });
+    const controller = new ProviderSettingsController({ identityKey: "owner-a:primary", transport: gateway });
+    await controller.refresh();
+
+    await controller.mutate({ type: "update_harness", harnessInstanceId: "harness_one", displayName: "Conflict" });
+
+    expect(gateway.getSnapshot).toHaveBeenCalledTimes(2);
+    expect(controller.getState().snapshot?.revision).toBe(2);
+    expect(controller.getState().error).toBe("Provider settings changed. Latest settings were loaded.");
+    expect(controller.getState().error).not.toContain("Anthropic");
+  });
+
+  it("keeps a selected harness while it exists and falls back after removal", async () => {
+    let next = snapshot(1, ["harness_one", "harness_two"]);
+    const gateway = transport({ getSnapshot: async () => next });
+    const controller = new ProviderSettingsController({ identityKey: "owner-a:primary", transport: gateway });
+    await controller.refresh();
+    controller.selectHarness("harness_two");
+
+    next = snapshot(2, ["harness_one", "harness_two"]);
+    await controller.refresh();
+    expect(controller.getState().selectedHarnessId).toBe("harness_two");
+
+    next = snapshot(3, ["harness_one"]);
+    await controller.refresh();
+    expect(controller.getState().selectedHarnessId).toBe("harness_one");
+  });
+
+  it("fails closed on malformed responses with an allowlisted generic message", async () => {
+    const gateway = transport({ getSnapshot: async () => ({ secret: "sk-private" }) });
+    const controller = new ProviderSettingsController({ identityKey: "owner-a:primary", transport: gateway });
+
+    await controller.refresh();
+
+    expect(controller.getState().snapshot).toBeNull();
+    expect(controller.getState().error).toBe("Provider settings are unavailable.");
+  });
+
+  it("caps tracked requests by aborting the oldest refresh", async () => {
+    const signals: AbortSignal[] = [];
+    const gateway = transport({
+      getSnapshot: async (signal) => {
+        signals.push(signal);
+        return await new Promise<never>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), { once: true });
+        });
+      },
+    });
+    const controller = new ProviderSettingsController({ identityKey: "owner-a:primary", transport: gateway });
+
+    const refreshes = Array.from({ length: 5 }, () => controller.refresh());
+    await waitFor(() => expect(signals).toHaveLength(5));
+    expect(signals[0]?.aborted).toBe(true);
+    controller.dispose();
+    await Promise.all(refreshes);
+  });
+
+  it("caps subscriptions rather than growing the listener registry indefinitely", () => {
+    const controller = new ProviderSettingsController({ identityKey: "owner-a:primary", transport: transport() });
+    const unsubscribers = Array.from({ length: 64 }, () => controller.subscribe(() => undefined));
+
+    expect(() => controller.subscribe(() => undefined)).toThrow("subscription limit");
+    unsubscribers.forEach((unsubscribe) => unsubscribe());
+  });
+
+  it("clears a retained login attempt after it expires or authentication succeeds", async () => {
+    let next = snapshot(1);
+    const gateway = transport({
+      getSnapshot: async () => next,
+      mutate: async () => {
+        const responseSnapshot = snapshot(next.revision + 1);
+        return {
+          kind: "login_attempt",
+          snapshot: {
+            ...responseSnapshot,
+            harnesses: responseSnapshot.harnesses.map((harness) => ({ ...harness, authState: "authenticating" })),
+          },
+          attempt: {
+            id: "attempt_one",
+            harnessInstanceId: "harness_one",
+            accountId: null,
+            method: "terminal",
+            state: "pending",
+            action: { kind: "open_terminal", terminalSessionId: "matrix-login" },
+            expiresAt: "2026-08-30T10:10:00.000Z",
+            safeFailure: null,
+          },
+        };
+      },
+    });
+    const controller = new ProviderSettingsController({ identityKey: "owner-a:primary", transport: gateway });
+    await controller.refresh();
+    await controller.mutate({ type: "start_login", harnessInstanceId: "harness_one", accountId: null, method: "terminal" });
+    expect(controller.getState().connectionAttempt?.id).toBe("attempt_one");
+
+    next = {
+      ...snapshot(3),
+      refreshedAt: "2026-08-30T10:11:00.000Z",
+      harnesses: snapshot(3).harnesses.map((harness) => ({ ...harness, authState: "unauthenticated" })),
+    };
+    await controller.refresh();
+    expect(controller.getState().connectionAttempt).toBeNull();
+
+    await controller.mutate({ type: "start_login", harnessInstanceId: "harness_one", accountId: null, method: "terminal" });
+    expect(controller.getState().connectionAttempt?.id).toBe("attempt_one");
+    next = snapshot(4);
+    await controller.refresh();
+    expect(controller.getState().connectionAttempt).toBeNull();
+  });
+});
+
+describe("useProviderSettingsController", () => {
+  it("loads through React strict-mode effect replay", async () => {
+    const gateway = transport();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <React.StrictMode>{children}</React.StrictMode>
+    );
+    const { result } = renderHook(
+      () => useProviderSettingsController({ identityKey: "owner-a:primary", transport: gateway }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.snapshot?.revision).toBe(1));
+  });
+
+  it("clears prior-owner state immediately and ignores its late response", async () => {
+    const ownerALoad = deferred<unknown>();
+    const ownerA = transport({ getSnapshot: async () => ownerALoad.promise });
+    const ownerB = transport({ getSnapshot: async () => snapshot(20, ["harness_two"]) });
+    const { result, rerender } = renderHook(
+      ({ identityKey, currentTransport }) => useProviderSettingsController({
+        identityKey,
+        transport: currentTransport,
+      }),
+      { initialProps: { identityKey: "owner-a:primary", currentTransport: ownerA as ProviderSettingsTransport } },
+    );
+
+    expect(result.current.snapshot).toBeNull();
+    rerender({ identityKey: "owner-b:primary", currentTransport: ownerB });
+    expect(result.current.snapshot).toBeNull();
+
+    await waitFor(() => expect(result.current.snapshot?.revision).toBe(20));
+    await act(async () => ownerALoad.resolve(snapshot(10)));
+    expect(result.current.snapshot?.revision).toBe(20);
+    expect(result.current.identityKey).toBe("owner-b:primary");
+  });
+});


### PR DESCRIPTION
## Summary

- bring the T3-inspired Agents & providers control-center design into a shared Matrix UI package
- add the top-level harness picker/add flow, provider/model/source routing, account login state, usage and credit surfaces, logout/removal guards, and future multi-account shape
- use one bounded controller and schema-validated transport across Canvas, Web Desktop, mobile shell, and Electron
- open only server-created existing login sessions in Terminal and exact relative authorization paths in the browser

## Safety and parity

- mutations are revisioned, idempotent, serialized, and fail closed by advertised capability
- identity/runtime changes cancel and clear stale provider state
- all renderers share business logic and visual components; adapters only supply transport, navigation, and Terminal handoff
- retained Terminal handoffs are capped, expire after ten minutes, migrate the immediately preceding queue format, and retry until accepted or expired

## Validation

- 107 focused shared UI, handoff, and Terminal integration tests passed
- strict shell and Electron renderer typechecks passed
- Greptile 5/5 on exact head `b94327eff739fb2d5471bab7ea3566bdbb520a1f` with zero unresolved threads

## Review and monitoring

- draft until label-triggered CI is green and every later stack layer is exact-head 5/5
- verify Canvas first, then Web Desktop and Electron, against the same gateway snapshot and action results
- monitor provider-login handoff warnings and bounded retry expiry without exposing provider or credential details

## Invariants

- **Source of truth:** the shared `@matrix-os/ui` Agents & providers package owns presentation and interaction logic; the gateway provider-settings snapshot owns runtime state.
- **Lock / transaction scope:** the browser controller serializes revisioned mutations per mounted identity/runtime; it adds no database writes or cross-process locks.
- **Acceptable orphan states:** an existing server-created login terminal may outlive a client handoff. The client retains only a capped, ten-minute session identifier queue and never creates or executes a terminal command itself.
- **Auth source of truth:** gateway authentication and server-advertised capabilities remain authoritative. The clients accept only canonical session IDs and exact owner-gateway relative authorization paths; credentials never enter UI state.
- **Deferred scope:** funded relay activation, add-on checkout, and simultaneous accounts inside single-account provider CLIs land in later stack layers or follow-up billing work.

Stack parent: #1453
