### PR TITLE
feat(ai): expose Claude Fable 5 safely

### DIFF
--- a/specs/118-ai-gateway-provider-auth/research.md
+++ b/specs/118-ai-gateway-provider-auth/research.md
@@ -29,17 +29,28 @@ Primary sources:
 
 ### Kernel and Agent SDK
 
-- `packages/kernel/package.json` declares `@anthropic-ai/claude-agent-sdk` `^0.2.74`; the lockfile resolves `0.2.79`. The npm registry reports `0.3.251` as current on 2026-08-29.
+- Production pins `@anthropic-ai/claude-agent-sdk` `0.3.240`. The npm registry
+  reports `0.3.251` as current, but its 2026-08-28 publication date keeps it
+  quarantined by the workspace's seven-day `minimumReleaseAge` policy as of
+  2026-08-30. The exact-version compatibility job remains the upgrade gate;
+  production must not bypass the release-age policy.
 - Matrix uses the supported V1 `query()` plus `resume` path. This is the correct base: the Agent SDK changelog says the experimental V2 interface was removed in `0.3.142`.
-- The SDK upgrade is not a mechanical version bump. Newer releases change first-turn MCP connection behavior, deprecate `Skill` in `allowedTools` in favor of the `skills` option, improve canonical model/provider usage reporting, add structured refusals, and change task-tool defaults. Matrix must spike all of these against the real in-process MCP server, hooks, permissions, resume, cancellation, and subagents before updating the lockfile.
-- `packages/kernel/src/options.ts` currently explicitly allows `Task`, `TaskOutput`, and `Skill`. The upgrade should migrate the deprecated skill configuration and make task/subagent capability tests explicit.
+- The SDK upgrade is not a mechanical version bump. The exact `0.3.251`
+  compatibility harness verifies first-turn MCP, explicit skills, canonical usage,
+  structured refusals, hooks, permissions, resume, cancellation, and subagents
+  before production may update the lockfile.
+- `packages/kernel/src/options.ts` uses the supported `skills: "all"` option;
+  the deprecated `Skill` allowlist entry has been removed. Task/subagent
+  capability remains covered by the exact-version compatibility harness.
 
 Source: [Claude Agent SDK TypeScript changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md).
 
 ### Models
 
-- `packages/gateway/src/kernel-settings.ts` currently hard-codes Claude Opus 4.6, Sonnet 4.5, and Haiku 4.5.
 - The current Anthropic family is Claude Fable 5, Opus 5, Sonnet 5, and Haiku 4.5. Anthropic documents material Sonnet 5 request-behavior differences, so controls cannot be copied blindly from older models.
+- Claude Fable 5 is generally available as `claude-fable-5`, with a 1M-token
+  context window, up to 128K output tokens, and $10/$50 per million input/output
+  tokens. Invitation-only Mythos is deliberately absent from the Matrix catalog.
 - Recommended Matrix-funded default: **Claude Sonnet 5**, with Haiku 4.5 available for low-cost/background classifications once quality tests pass. Opus 5 is owner-funded/add-on at launch. Fable 5 is not included by default because its documented retention posture requires a deliberate policy and user disclosure.
 - Model data should move from duplicated arrays to a bounded, validated catalog with a shipped fallback. Existing Chats keep their bound model ID; a retired model becomes non-runnable until the user explicitly selects a compatible model.
 

--- a/specs/118-ai-gateway-provider-auth/sdk-verification.md
+++ b/specs/118-ai-gateway-provider-auth/sdk-verification.md
@@ -5,8 +5,10 @@
 **Target**: `@anthropic-ai/claude-agent-sdk@0.3.251`
 
 **Production version after Phase 1**: `0.3.240`, the newest release old enough
-to satisfy the workspace's seven-day `minimumReleaseAge` policy. The exact
-`0.3.251` compatibility job remains the forward-compatibility gate.
+to satisfy the workspace's seven-day `minimumReleaseAge` policy as of
+2026-08-30. Upstream `0.3.251` was published on 2026-08-28, so the exact target
+remains quarantined until normal policy resolution accepts it. Do not bypass
+the workspace policy or add a package exception to install it.
 
 ## Reproduce
 
@@ -87,10 +89,16 @@ times.
 
 - Production dependencies are pinned to `0.3.240`; the lockfile resolves the
   matching platform packages and MCP SDK peer range.
+- `0.3.251` remains the verified upstream target, not the installed production
+  version, until pnpm accepts it under the unchanged seven-day release-age
+  policy.
 - V1 `query()` plus `resume` remains the kernel path.
 - Skills use `skills: "all"`; the deprecated `Skill` allowlist entry is gone.
 - Claude Fable 5, Opus 5, Sonnet 5, and Haiku 4.5 are the current catalog.
-  Existing 4.x model IDs remain valid legacy choices and are never rewritten.
+  Fable's documented limits are a 1M-token context window and up to 128K output
+  tokens, with $10/$50 per million input/output tokens. Existing 4.x model IDs
+  remain valid legacy choices and are never rewritten; invitation-only Mythos
+  is not exposed.
 - Effort and adaptive thinking are emitted only for models whose current API
   contract supports them. Claude 5 exposes `xhigh`; Haiku and unknown/custom
   models receive neither field.

--- a/tests/kernel/agent-sdk-upgrade.test.ts
+++ b/tests/kernel/agent-sdk-upgrade.test.ts
@@ -1,4 +1,6 @@
 import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -100,6 +102,25 @@ describe("production Agent SDK upgrade", () => {
     });
     expect(resolveKernelSdkControls("claude-haiku-4-5", "max")).toEqual({});
     expect(resolveKernelSdkControls("owner-custom-model", "high")).toEqual({});
+  });
+
+  it("verifies Fable controls against the production-pinned SDK declaration", () => {
+    const require = createRequire(import.meta.url);
+    const sdkDirectory = dirname(require.resolve("@anthropic-ai/claude-agent-sdk"));
+    const sdkPackage = JSON.parse(readFileSync(join(sdkDirectory, "package.json"), "utf8")) as {
+      version: string;
+      claudeCodeVersion: string;
+    };
+    const sdkTypes = readFileSync(join(sdkDirectory, "sdk.d.ts"), "utf8");
+
+    expect(sdkPackage).toMatchObject({ version: "0.3.240", claudeCodeVersion: "2.1.240" });
+    expect(sdkTypes).toContain("Examples: 'claude-sonnet-5', 'claude-opus-4-8', 'claude-fable-5'");
+    expect(sdkTypes).toMatch(/`'max'` — Maximum effort \(Fable 5,/);
+    expect(sdkTypes).toContain("thinking?: ThinkingConfig;");
+    expect(resolveKernelSdkControls("claude-fable-5", "max")).toEqual({
+      effort: "max",
+      thinking: { type: "adaptive" },
+    });
   });
 
   it("normalizes cumulative modelUsage across main and subagent calls", () => {

--- a/tests/kernel/agent-sdk-upgrade.test.ts
+++ b/tests/kernel/agent-sdk-upgrade.test.ts
@@ -16,6 +16,10 @@ import {
   normalizeKernelModel,
   resolveKernelModelOption,
 } from "../../packages/gateway/src/kernel-settings.js";
+import {
+  buildBundledModelCatalog,
+  OWNER_ANTHROPIC_MODEL_IDS,
+} from "../../packages/gateway/src/ai-providers/model-catalog.js";
 import { calculateCost } from "../../packages/proxy/src/cost.js";
 
 describe("production Agent SDK upgrade", () => {
@@ -45,6 +49,13 @@ describe("production Agent SDK upgrade", () => {
       "claude-haiku-4-5",
     ]);
     expect(KERNEL_EFFORTS).toEqual(["low", "medium", "high", "xhigh", "max"]);
+    expect(KERNEL_MODEL_IDS).not.toContain("claude-mythos-5");
+    expect(OWNER_ANTHROPIC_MODEL_IDS).toContain("claude-fable-5");
+    expect(buildBundledModelCatalog().find((model) => model.id === "claude-fable-5"))
+      .toMatchObject({
+        status: "current",
+        eligibleAccessSourceIds: ["owner_anthropic_key", "owner_anthropic_profile"],
+      });
     expect(normalizeKernelModel("claude-sonnet-4-5")).toBe("claude-sonnet-4-5");
     expect(resolveKernelModelOption("claude-sonnet-4-5")).toMatchObject({
       id: "claude-sonnet-4-5",
@@ -71,6 +82,10 @@ describe("production Agent SDK upgrade", () => {
   });
 
   it("only sends effort and adaptive thinking to models that support them", () => {
+    expect(resolveKernelSdkControls("claude-fable-5", "max")).toEqual({
+      effort: "max",
+      thinking: { type: "adaptive" },
+    });
     expect(resolveKernelSdkControls("claude-sonnet-5", "xhigh")).toEqual({
       effort: "xhigh",
       thinking: { type: "adaptive" },


### PR DESCRIPTION
## Summary
- expose Claude Fable 5 through owner Anthropic key/profile access only
- keep Matrix-funded access on its explicit Sonnet policy and preserve existing defaults and legacy model IDs
- reject incompatible saved Fable routes instead of silently substituting another model
- keep invite-only Mythos out of the public catalog

## SDK release gate
Anthropic Agent SDK 0.3.251 is the verified upstream target, but it is still inside Matrix's mandatory seven-day package quarantine. Production remains on policy-eligible 0.3.240 until that window expires; no supply-chain bypass was added.

## Validation
- 15 focused tests passed
- 102 broader gateway/settings/catalog tests passed
- 22 relay/contracts tests passed
- gateway typecheck passed

Stack parent: #1448