### PR TITLE
feat(gateway): wire provider login runtime

### DIFF
--- a/packages/contracts/src/provider-settings.ts
+++ b/packages/contracts/src/provider-settings.ts
@@ -201,8 +201,8 @@ export const ProviderHarnessInstanceSchema = z.object({
   version: canonicalSafeLabel(64, 256).nullable(),
   installState: ProviderHarnessInstallStateSchema,
   authState: ProviderAuthenticationStateSchema,
-  loginMethods: z.array(ProviderLoginMethodSchema).min(1).max(3),
-  recommendedLoginMethod: ProviderLoginMethodSchema,
+  loginMethods: z.array(ProviderLoginMethodSchema).max(3),
+  recommendedLoginMethod: ProviderLoginMethodSchema.nullable(),
   connectivity: ProviderConnectivityStateSchema,
   accountIds: z.array(ReferenceIdSchema).max(32),
   selectedAccountId: ReferenceIdSchema.nullable(),
@@ -213,7 +213,12 @@ export const ProviderHarnessInstanceSchema = z.object({
   if (!unique(harness.accountIds) || !unique(harness.loginMethods)) {
     ctx.addIssue({ code: "custom", message: "Harness account and login method sets must be unique" });
   }
-  if (!harness.loginMethods.includes(harness.recommendedLoginMethod)) {
+  if (harness.loginMethods.length === 0 && harness.recommendedLoginMethod !== null) {
+    ctx.addIssue({ code: "custom", path: ["recommendedLoginMethod"], message: "Unavailable login cannot recommend a method" });
+  }
+  if (harness.loginMethods.length > 0
+    && (harness.recommendedLoginMethod === null
+      || !harness.loginMethods.includes(harness.recommendedLoginMethod))) {
     ctx.addIssue({ code: "custom", path: ["recommendedLoginMethod"], message: "Recommended login must be supported" });
   }
   if (harness.selectedAccountId !== null && !harness.accountIds.includes(harness.selectedAccountId)) {

--- a/packages/gateway/src/ai-providers/DOMAIN.md
+++ b/packages/gateway/src/ai-providers/DOMAIN.md
@@ -8,4 +8,10 @@ This directory owns the secret-free provider snapshot consumed by Chat and Setti
 - `model-catalog.ts` is a bounded bundled policy. Remote catalogs, executable driver definitions, arbitrary URLs, and owner mutations are not accepted here.
 - `GET /api/ai/providers` is read-only and runs behind the gateway's authenticated API boundary. Route failures expose only a generic message.
 
-Provider connect/disconnect mutations, funded-relay activation, remote catalog refresh, metering, and add-on purchases are intentionally deferred to later delivery phases.
+Provider Settings now derives Hermes, OpenClaw, Claude, Codex, OpenCode, and Pi driver installation state from the existing runtime and executable probes. A driver without a canonical provider/model/access-source instance remains inventory-only; Settings does not invent a routable harness from a binary alone.
+
+The first mutation seam is intentionally narrow:
+
+- Configured, installed Claude and Codex harnesses can start their allowlisted foreground login command in the server-owned canonical shell registry. The returned terminal name is the real attach target, login receipts are bounded and durable, and expired receipts cannot reopen a stale attempt.
+- Runtime configuration actions are advertised only from a coordinator's explicit per-action capability list. The default server does not wire one yet because the current provider-settings revision is not the agent-runtime revision and fixed coding-agent routes are chat-scoped.
+- Logout, account deletion/reassignment, global route changes, funded-relay activation, metering, and add-on purchases remain fail-closed until their atomic owners exist. Persisting a Settings preference alone is never reported as a successful runtime change.

--- a/packages/gateway/src/ai-providers/provider-driver-inventory.ts
+++ b/packages/gateway/src/ai-providers/provider-driver-inventory.ts
@@ -1,0 +1,76 @@
+import type { AiProviderSnapshotV3 } from "@matrix-os/contracts";
+import type { AgentStatus } from "../agent-launcher.js";
+import type { AgentRuntimeSource } from "../agent-config/service.js";
+
+type Driver = AiProviderSnapshotV3["drivers"][number];
+
+function runtimeHealth(health: "healthy" | "degraded" | "stopped" | "unreachable" | "unknown") {
+  if (health === "healthy") return "ready" as const;
+  if (health === "unreachable") return "unavailable" as const;
+  return health;
+}
+
+function runtimeDriver(runtime: Awaited<ReturnType<AgentRuntimeSource>>["runtime"]["options"][number]): Driver {
+  return {
+    id: runtime.id,
+    displayName: runtime.displayName,
+    kind: "cli",
+    installState: runtime.installState,
+    health: runtimeHealth(runtime.health),
+    capabilities: ["tools", "resume", "reasoning"],
+    setupActions: runtime.installState === "missing"
+      ? ["install"]
+      : runtime.selectionState === "action_required"
+        ? ["open_terminal"]
+        : [],
+  };
+}
+
+function agentDriver(agent: AgentStatus): Driver {
+  const id = agent.id === "claude" ? "claude_code" : agent.id;
+  const setupActions: Driver["setupActions"] = agent.installState === "missing"
+    ? ["install"]
+    : agent.installState === "installed" && agent.authState === "required"
+      ? ["connect_account", "open_terminal"]
+      : agent.installState === "installed" && (agent.id === "opencode" || agent.id === "pi")
+        ? ["open_terminal"]
+        : [];
+  const health = agent.installState !== "installed"
+    ? agent.installState === "missing" ? "stopped" as const : "unknown" as const
+    : agent.authState === "ok" ? "ready" as const
+      : agent.authState === "required" ? "stopped" as const
+        : agent.authState === "error" ? "unavailable" as const : "unknown" as const;
+  return {
+    id,
+    displayName: agent.displayName,
+    kind: "cli",
+    installState: agent.installState,
+    health,
+    capabilities: ["tools", "resume", "reasoning", "project_context"],
+    setupActions,
+  };
+}
+
+export function createProviderDriverInventoryReader(options: {
+  detectAgentInstallations: () => Promise<{ agents: AgentStatus[] }>;
+  runtimeSource: AgentRuntimeSource;
+}): (signal: AbortSignal) => Promise<AiProviderSnapshotV3["drivers"]> {
+  if (typeof options.detectAgentInstallations !== "function") {
+    throw new Error("Agent installation inventory is required");
+  }
+  if (typeof options.runtimeSource !== "function") {
+    throw new Error("Agent runtime inventory is required");
+  }
+  return async (signal) => {
+    signal.throwIfAborted();
+    const [runtime, installations] = await Promise.all([
+      options.runtimeSource(signal),
+      options.detectAgentInstallations(),
+    ]);
+    signal.throwIfAborted();
+    return [
+      ...runtime.runtime.options.map(runtimeDriver),
+      ...installations.agents.map(agentDriver),
+    ];
+  };
+}

--- a/packages/gateway/src/ai-providers/provider-settings-capability-policy.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-capability-policy.ts
@@ -12,6 +12,7 @@ import type {
   ProviderLoginCoordinator,
   ProviderSettingsRuntimeCoordinator,
 } from "./provider-settings-coordinators.js";
+import { resolveProviderSettingsDriverId } from "./provider-settings-driver-id.js";
 
 export function coordinatorLoginHarness(input: {
   harness: ProviderSettingsConfiguration["harnesses"][number];
@@ -22,9 +23,11 @@ export function coordinatorLoginHarness(input: {
   harness: ProviderHarnessKind;
   installState: ProviderHarnessInstallState;
 } {
-  const driverId = input.harness.driverId === "kernel" && input.harness.harness === "claude"
-    ? "claude_code"
-    : input.harness.driverId;
+  const driverId = resolveProviderSettingsDriverId({
+    driverId: input.harness.driverId,
+    harness: input.harness.harness,
+    canonical: input.canonical,
+  });
   const driver = input.canonical.drivers.find((candidate) => candidate.id === driverId);
   return {
     id: input.harness.id,

--- a/packages/gateway/src/ai-providers/provider-settings-capability-policy.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-capability-policy.ts
@@ -1,0 +1,70 @@
+import type {
+  AiProviderSnapshotV3,
+  ProviderHarnessInstallState,
+  ProviderHarnessKind,
+  ProviderLoginMethod,
+  ProviderSettingsSupportedAction,
+} from "@matrix-os/contracts";
+import type { ProviderSettingsConfiguration } from "./provider-settings-persistence.js";
+import type {
+  ProviderAccountDependencyCoordinator,
+  ProviderAccountLifecycleCoordinator,
+  ProviderLoginCoordinator,
+  ProviderSettingsRuntimeCoordinator,
+} from "./provider-settings-coordinators.js";
+
+export function coordinatorLoginHarness(input: {
+  harness: ProviderSettingsConfiguration["harnesses"][number];
+  canonical: AiProviderSnapshotV3;
+}): {
+  id: string;
+  driverId: string;
+  harness: ProviderHarnessKind;
+  installState: ProviderHarnessInstallState;
+} {
+  const driverId = input.harness.driverId === "kernel" && input.harness.harness === "claude"
+    ? "claude_code"
+    : input.harness.driverId;
+  const driver = input.canonical.drivers.find((candidate) => candidate.id === driverId);
+  return {
+    id: input.harness.id,
+    driverId,
+    harness: input.harness.harness,
+    installState: driver?.installState ?? "missing",
+  };
+}
+
+export function coordinatorLoginMethods(input: {
+  login?: ProviderLoginCoordinator;
+  harness: ProviderSettingsConfiguration["harnesses"][number];
+  canonical: AiProviderSnapshotV3;
+}): readonly ProviderLoginMethod[] {
+  if (!input.login) return [];
+  return input.login.supportedMethods(coordinatorLoginHarness(input));
+}
+
+export function supportedProviderSettingsActions(input: {
+  runtime?: ProviderSettingsRuntimeCoordinator;
+  login?: ProviderLoginCoordinator;
+  lifecycle?: ProviderAccountLifecycleCoordinator;
+  dependencies?: ProviderAccountDependencyCoordinator;
+  config: ProviderSettingsConfiguration;
+  canonical: AiProviderSnapshotV3;
+}): ProviderSettingsSupportedAction[] {
+  const actions: ProviderSettingsSupportedAction[] = input.runtime
+    ? input.runtime.supportedActions.filter((action) =>
+        input.config.gatewayPolicy !== null
+        || (action !== "set_gateway_budget" && action !== "set_gateway_allowlist"))
+    : [];
+  if (input.login && input.config.harnesses.some((harness) => coordinatorLoginMethods({
+      login: input.login,
+      harness,
+      canonical: input.canonical,
+    }).length > 0)) {
+    actions.push("start_login");
+  }
+  if (input.lifecycle) actions.push("logout_account");
+  if (input.lifecycle && input.dependencies) actions.push("remove_account");
+  if (input.dependencies) actions.push("reassign_account");
+  return actions;
+}

--- a/packages/gateway/src/ai-providers/provider-settings-coordinators.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-coordinators.ts
@@ -2,7 +2,9 @@ import type {
   AiProviderSnapshotV3,
   ProviderConnectionAttempt,
   ProviderDependencyCounts,
+  ProviderHarnessInstallState,
   ProviderHarnessKind,
+  ProviderLoginMethod,
   ProviderSettingsMutation,
 } from "@matrix-os/contracts";
 import type { ProviderConfigurationMutation } from "./provider-settings-mutations.js";
@@ -31,6 +33,7 @@ export interface ProviderAccountLifecycleCoordinator {
 
 /** Applies settings to the real runtime/control plane and durably deduplicates the key. */
 export interface ProviderSettingsRuntimeCoordinator {
+  readonly supportedActions: readonly ProviderConfigurationMutation["type"][];
   applyConfiguration(input: {
     mutation: ProviderConfigurationMutation;
     idempotencyKey: string;
@@ -39,13 +42,21 @@ export interface ProviderSettingsRuntimeCoordinator {
 
 /** Creates/adopts the actual auth surface and durably deduplicates by mutation key. */
 export interface ProviderLoginCoordinator {
+  supportedMethods(harness: {
+    id: string;
+    driverId: string;
+    harness: ProviderHarnessKind;
+    installState: ProviderHarnessInstallState;
+  }): readonly ProviderLoginMethod[];
   startLogin(input: {
     mutation: Extract<ProviderSettingsMutation, { type: "start_login" }>;
     harness: {
       id: string;
+      driverId: string;
       harness: ProviderHarnessKind;
       providerId: string;
       modelId: string;
+      installState: ProviderHarnessInstallState;
     };
   }): Promise<ProviderConnectionAttempt>;
 }

--- a/packages/gateway/src/ai-providers/provider-settings-driver-id.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-driver-id.ts
@@ -1,0 +1,14 @@
+import type { AiProviderSnapshotV3, ProviderHarnessKind } from "@matrix-os/contracts";
+
+export function resolveProviderSettingsDriverId(input: {
+  driverId: string;
+  harness: ProviderHarnessKind;
+  canonical: AiProviderSnapshotV3;
+}): string {
+  if (input.harness === "claude"
+    && input.driverId === "kernel"
+    && input.canonical.drivers.some((driver) => driver.id === "claude_code")) {
+    return "claude_code";
+  }
+  return input.driverId;
+}

--- a/packages/gateway/src/ai-providers/provider-settings-mutations.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-mutations.ts
@@ -8,6 +8,7 @@ import {
   providerDriverId,
   type ProviderSettingsConfiguration,
 } from "./provider-settings-persistence.js";
+import { resolveProviderSettingsDriverId } from "./provider-settings-driver-id.js";
 
 export type ProviderConfigurationMutation = Exclude<ProviderSettingsMutation,
   | { type: "start_login" }
@@ -63,7 +64,12 @@ export function applyProviderConfigurationMutation(input: {
       return true;
     case "set_harness_enabled": {
       if (!harness) throw new ProviderSettingsStoreError("not_found", 404);
-      const driver = input.canonical.drivers.find((candidate) => candidate.id === harness.driverId);
+      const driverId = resolveProviderSettingsDriverId({
+        driverId: harness.driverId,
+        harness: harness.harness,
+        canonical: input.canonical,
+      });
+      const driver = input.canonical.drivers.find((candidate) => candidate.id === driverId);
       if (mutation.enabled && driver?.installState !== "installed") {
         throw new ProviderSettingsStoreError("invalid_request", 400);
       }

--- a/packages/gateway/src/ai-providers/provider-settings-persistence.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-persistence.ts
@@ -12,6 +12,7 @@ import {
   type ProviderHarnessKind,
 } from "@matrix-os/contracts";
 import { z } from "zod/v4";
+import { resolveProviderSettingsDriverId } from "./provider-settings-driver-id.js";
 
 const MAX_FILE_BYTES = 1024 * 1024;
 export const MAX_PROVIDER_SETTINGS_RECEIPTS = 256;
@@ -124,8 +125,11 @@ export async function writeProviderJsonAtomic(path: string, value: unknown): Pro
 }
 
 function driverIdForHarness(kind: ProviderHarnessKind, canonical: AiProviderSnapshotV3): string {
-  if (kind !== "claude") return kind;
-  return canonical.drivers.some((driver) => driver.id === "claude_code") ? "claude_code" : "kernel";
+  return resolveProviderSettingsDriverId({
+    driverId: kind === "claude" ? "kernel" : kind,
+    harness: kind,
+    canonical,
+  });
 }
 
 function harnessKindForDriver(driverId: string): ProviderHarnessKind {

--- a/packages/gateway/src/ai-providers/provider-settings-projector.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-projector.ts
@@ -6,6 +6,7 @@ import {
   type ProviderDependencyCounts,
   type ProviderHarnessInstance,
   type ProviderHarnessKind,
+  type ProviderLoginMethod,
   type ProviderSettingsSupportedAction,
   type ProviderSettingsSnapshot,
 } from "@matrix-os/contracts";
@@ -33,7 +34,7 @@ function connectivity(readiness: AiProviderReadiness): ProviderHarnessInstance["
   return "unknown";
 }
 
-function loginMethods(kind: ProviderHarnessKind) {
+function defaultLoginMethods(kind: ProviderHarnessKind) {
   return kind === "codex"
     ? ["terminal", "oauth", "api_key"] as const
     : ["terminal", "api_key"] as const;
@@ -142,6 +143,7 @@ function projectHarness(input: {
   accounts: ProviderAccount[];
   sources: ReturnType<typeof projectAccessSources>["sources"];
   allowedGatewayModels: ReadonlySet<string>;
+  loginMethods?: (harness: HarnessConfiguration) => readonly ProviderLoginMethod[];
 }): ProviderHarnessInstance | null {
   const model = input.canonical.models.find((candidate) => candidate.id === input.stored.route.modelId);
   if (!model || model.vendor !== input.stored.route.providerId) return null;
@@ -163,6 +165,9 @@ function projectHarness(input: {
     safeReason: "unknown" as const,
   };
   const accounts = input.accounts.filter((account) => account.providerId === input.stored.route.providerId);
+  const visibleMethods = input.loginMethods === undefined
+    ? defaultLoginMethods(input.stored.harness)
+    : input.loginMethods(input.stored);
   return {
     id: input.stored.id,
     harness: input.stored.harness,
@@ -172,8 +177,8 @@ function projectHarness(input: {
     version: null,
     installState: driver?.installState ?? "missing",
     authState: authState(readiness),
-    loginMethods: [...loginMethods(input.stored.harness)],
-    recommendedLoginMethod: "terminal",
+    loginMethods: [...visibleMethods],
+    recommendedLoginMethod: visibleMethods[0] ?? null,
     connectivity: connectivity(readiness),
     accountIds: accounts.map((account) => account.id),
     selectedAccountId,
@@ -191,6 +196,7 @@ export async function projectProviderSettings(input: {
   now: Date;
   dependencies?: ProviderSettingsDependencyReader;
   supportedActions: ProviderSettingsSupportedAction[];
+  loginMethods?: (harness: HarnessConfiguration) => readonly ProviderLoginMethod[];
 }): Promise<ProviderSettingsSnapshot> {
   const { sources, sourceByAccount } = projectAccessSources(input.canonical, input.config);
   const accounts = await projectAccounts({
@@ -224,6 +230,7 @@ export async function projectProviderSettings(input: {
       accounts,
       sources,
       allowedGatewayModels,
+      loginMethods: input.loginMethods,
     });
     return harness ? [harness] : [];
   });

--- a/packages/gateway/src/ai-providers/provider-settings-projector.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-projector.ts
@@ -11,6 +11,7 @@ import {
   type ProviderSettingsSnapshot,
 } from "@matrix-os/contracts";
 import type { HarnessConfiguration, ProviderSettingsConfiguration } from "./provider-settings-persistence.js";
+import { resolveProviderSettingsDriverId } from "./provider-settings-driver-id.js";
 
 export interface ProviderSettingsDependencyReader {
   getAccountDependencies(input: {
@@ -147,7 +148,12 @@ function projectHarness(input: {
 }): ProviderHarnessInstance | null {
   const model = input.canonical.models.find((candidate) => candidate.id === input.stored.route.modelId);
   if (!model || model.vendor !== input.stored.route.providerId) return null;
-  const driver = input.canonical.drivers.find((candidate) => candidate.id === input.stored.driverId);
+  const driverId = resolveProviderSettingsDriverId({
+    driverId: input.stored.driverId,
+    harness: input.stored.harness,
+    canonical: input.canonical,
+  });
+  const driver = input.canonical.drivers.find((candidate) => candidate.id === driverId);
   const source = input.stored.accessSourceId === null
     ? undefined
     : input.sources.find((candidate) => candidate.id === input.stored.accessSourceId);

--- a/packages/gateway/src/ai-providers/provider-settings-receipts.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-receipts.ts
@@ -1,0 +1,34 @@
+import { createHash } from "node:crypto";
+import {
+  ProviderConnectionAttemptSchema,
+  type ProviderConnectionAttempt,
+  type ProviderDependencyCounts,
+  type ProviderSettingsMutation,
+} from "@matrix-os/contracts";
+
+export function hashProviderSettingsMutation(mutation: ProviderSettingsMutation): string {
+  return createHash("sha256").update(JSON.stringify(mutation)).digest("hex");
+}
+
+export function sameProviderDependencyCounts(
+  left: ProviderDependencyCounts,
+  right: ProviderDependencyCounts,
+): boolean {
+  return left.activeChatCount === right.activeChatCount
+    && left.resumableChatCount === right.resumableChatCount
+    && left.harnessInstanceCount === right.harnessInstanceCount;
+}
+
+export function currentProviderConnectionAttempt(
+  value: unknown,
+  now: Date,
+): ProviderConnectionAttempt {
+  const attempt = ProviderConnectionAttemptSchema.parse(value);
+  if (Date.parse(attempt.expiresAt) > now.getTime() || attempt.state !== "pending") return attempt;
+  return ProviderConnectionAttemptSchema.parse({
+    ...attempt,
+    state: "expired",
+    action: { kind: "none" },
+    safeFailure: "expired",
+  });
+}

--- a/packages/gateway/src/ai-providers/provider-settings-store.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-store.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { basename, dirname, join, resolve } from "node:path";
 import {
   AiProviderSnapshotV3Schema,
@@ -9,8 +9,6 @@ import {
   type AiProviderSnapshotV3,
   type ProviderConnectionAttempt,
   type ProviderDependencyCounts,
-  type ProviderHarnessKind,
-  type ProviderLoginMethod,
   type ProviderSettingsMutation,
   type ProviderSettingsMutationResponse,
   type ProviderSettingsSnapshot,
@@ -38,20 +36,21 @@ import type {
   ProviderLoginCoordinator,
   ProviderSettingsRuntimeCoordinator,
 } from "./provider-settings-coordinators.js";
+import {
+  coordinatorLoginHarness,
+  coordinatorLoginMethods,
+  supportedProviderSettingsActions,
+} from "./provider-settings-capability-policy.js";
+import {
+  currentProviderConnectionAttempt,
+  hashProviderSettingsMutation,
+  sameProviderDependencyCounts,
+} from "./provider-settings-receipts.js";
 
 const CONFIG_PATH = "system/ai-providers/settings.json";
 const PRIVATE_DIRECTORY = ".matrix-private";
 const DEFAULT_PROJECTION_AGE_MS = 5 * 60_000;
 const SECRET_MAX_CHARS = 64 * 1024;
-const CONFIGURATION_ACTIONS = [
-  "add_harness",
-  "update_harness",
-  "set_harness_enabled",
-  "set_route",
-  "select_account",
-  "select_access_source",
-] as const satisfies readonly ProviderSettingsSupportedAction[];
-
 export { ProviderSettingsStoreError } from "./provider-settings-errors.js";
 export type {
   CanonicalProviderSnapshotReader,
@@ -75,22 +74,6 @@ interface ProviderSettingsStoreOptions {
   now?: () => Date;
   idGenerator?: () => string;
   maxProjectionAgeMs?: number;
-}
-
-function hashMutation(mutation: ProviderSettingsMutation): string {
-  return createHash("sha256").update(JSON.stringify(mutation)).digest("hex");
-}
-
-function sameCounts(left: ProviderDependencyCounts, right: ProviderDependencyCounts): boolean {
-  return left.activeChatCount === right.activeChatCount
-    && left.resumableChatCount === right.resumableChatCount
-    && left.harnessInstanceCount === right.harnessInstanceCount;
-}
-
-function loginMethods(kind: ProviderHarnessKind): readonly ProviderLoginMethod[] {
-  return kind === "codex"
-    ? ["terminal", "oauth", "api_key"] as const
-    : ["terminal", "api_key"] as const;
 }
 
 export class ProviderSettingsStore implements ProviderSettingsStoreWriter {
@@ -174,7 +157,12 @@ export class ProviderSettingsStore implements ProviderSettingsStoreWriter {
         config,
         now: this.#now(),
         dependencies: this.#dependencies,
-        supportedActions: this.#supportedActions(config),
+        supportedActions: this.#supportedActions(config, canonical),
+        loginMethods: (harness) => coordinatorLoginMethods({
+          login: this.#login,
+          harness,
+          canonical,
+        }),
       });
     } catch (error) {
       if (error instanceof ProviderSettingsStoreError) throw error;
@@ -186,21 +174,26 @@ export class ProviderSettingsStore implements ProviderSettingsStoreWriter {
     }
   }
 
-  #supportedActions(config: ProviderSettingsConfiguration): ProviderSettingsSupportedAction[] {
-    const actions: ProviderSettingsSupportedAction[] = this.#runtime ? [...CONFIGURATION_ACTIONS] : [];
-    if (this.#runtime && config.gatewayPolicy) actions.push("set_gateway_budget", "set_gateway_allowlist");
-    if (this.#login) actions.push("start_login");
-    if (this.#lifecycle) actions.push("logout_account");
-    if (this.#lifecycle && this.#dependencies) actions.push("remove_account");
-    if (this.#dependencies) actions.push("reassign_account");
-    return actions;
+  #supportedActions(
+    config: ProviderSettingsConfiguration,
+    canonical: AiProviderSnapshotV3,
+  ): ProviderSettingsSupportedAction[] {
+    return supportedProviderSettingsActions({
+      runtime: this.#runtime,
+      login: this.#login,
+      lifecycle: this.#lifecycle,
+      dependencies: this.#dependencies,
+      config,
+      canonical,
+    });
   }
 
   #assertSupported(
     type: ProviderSettingsMutation["type"],
     config: ProviderSettingsConfiguration,
+    canonical: AiProviderSnapshotV3,
   ): void {
-    if (this.#supportedActions(config).includes(type)) return;
+    if (this.#supportedActions(config, canonical).includes(type)) return;
     if (type === "remove_account" || type === "reassign_account") {
       throw new ProviderSettingsStoreError("dependency_unavailable", 503);
     }
@@ -275,7 +268,7 @@ export class ProviderSettingsStore implements ProviderSettingsStoreWriter {
       console.warn("[provider-settings] Account dependency check unavailable");
       throw new ProviderSettingsStoreError("dependency_unavailable", 503);
     }
-    if (!sameCounts(actual, expected)) {
+    if (!sameProviderDependencyCounts(actual, expected)) {
       throw new ProviderSettingsStoreError("revision_conflict", 409, {
         latestRevision: config.revision,
       });
@@ -287,8 +280,10 @@ export class ProviderSettingsStore implements ProviderSettingsStoreWriter {
     mutation: Extract<ProviderSettingsMutation, { type: "start_login" }>,
     harness: ProviderSettingsConfiguration["harnesses"][number],
     snapshot: ProviderSettingsSnapshot,
+    canonical: AiProviderSnapshotV3,
   ): Promise<ProviderConnectionAttempt> {
-    if (!loginMethods(harness.harness).includes(mutation.method)) {
+    const methods = coordinatorLoginMethods({ login: this.#login, harness, canonical });
+    if (!methods.includes(mutation.method)) {
       throw new ProviderSettingsStoreError("invalid_request", 400);
     }
     const account = mutation.accountId === null
@@ -305,8 +300,7 @@ export class ProviderSettingsStore implements ProviderSettingsStoreWriter {
       const attempt = ProviderConnectionAttemptSchema.parse(await this.#login.startLogin({
         mutation,
         harness: {
-          id: harness.id,
-          harness: harness.harness,
+          ...coordinatorLoginHarness({ harness, canonical }),
           providerId: harness.route.providerId,
           modelId: harness.route.modelId,
         },
@@ -358,7 +352,7 @@ export class ProviderSettingsStore implements ProviderSettingsStoreWriter {
       let canonical = await this.#canonical();
       let config = await this.#configuration(canonical);
       const mutation = parsed.data;
-      const payloadHash = hashMutation(mutation);
+      const payloadHash = hashProviderSettingsMutation(mutation);
       const duplicate = config.receipts.find((receipt) => receipt.key === mutation.idempotencyKey);
       if (duplicate) {
         if (duplicate.payloadHash !== payloadHash) {
@@ -367,7 +361,7 @@ export class ProviderSettingsStore implements ProviderSettingsStoreWriter {
         const snapshot = await this.#project(canonical, config);
         const attempt = duplicate.attempt === undefined
           ? undefined
-          : ProviderConnectionAttemptSchema.parse(duplicate.attempt);
+          : currentProviderConnectionAttempt(duplicate.attempt, this.#now());
         return attempt
           ? { kind: "login_attempt", snapshot, attempt }
           : { kind: "snapshot", snapshot };
@@ -377,7 +371,7 @@ export class ProviderSettingsStore implements ProviderSettingsStoreWriter {
           latestRevision: config.revision,
         });
       }
-      this.#assertSupported(mutation.type, config);
+      this.#assertSupported(mutation.type, config, canonical);
       const snapshot = await this.#project(canonical, config);
       for (const account of snapshot.accounts) {
         if (config.accountProfiles.some((profile) => profile.id === account.id)) continue;
@@ -415,7 +409,7 @@ export class ProviderSettingsStore implements ProviderSettingsStoreWriter {
         case "start_login": {
           const harness = config.harnesses.find((candidate) => candidate.id === mutation.harnessInstanceId);
           if (!harness) throw new ProviderSettingsStoreError("not_found", 404);
-          attempt = await this.#connectionAttempt(mutation, harness, snapshot);
+          attempt = await this.#connectionAttempt(mutation, harness, snapshot, canonical);
           break;
         }
         case "logout_account":

--- a/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
+++ b/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
@@ -1,0 +1,201 @@
+import { createHash } from "node:crypto";
+import { lstat, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { ProviderConnectionAttemptSchema } from "@matrix-os/contracts";
+import { z } from "zod/v4";
+import type { ShellRegistry } from "../shell/registry.js";
+import { ProviderSettingsStoreError } from "./provider-settings-errors.js";
+import { writeProviderJsonAtomic } from "./provider-settings-persistence.js";
+import type { ProviderLoginCoordinator } from "./provider-settings-coordinators.js";
+import { currentProviderConnectionAttempt } from "./provider-settings-receipts.js";
+
+const MAX_RECEIPTS = 64;
+const MAX_FILE_BYTES = 256 * 1024;
+const LOGIN_LIFETIME_MS = 10 * 60_000;
+const SafeRefSchema = z.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/);
+const EnabledHarnessSchema = z.enum(["codex", "claude"]);
+const ReceiptSchema = z.object({
+  key: SafeRefSchema,
+  payloadHash: z.string().length(64).regex(/^[a-f0-9]+$/),
+  attempt: ProviderConnectionAttemptSchema,
+}).strict();
+const ReceiptDocumentSchema = z.object({
+  version: z.literal(1),
+  receipts: z.array(ReceiptSchema).max(MAX_RECEIPTS),
+}).strict();
+
+type LoginHarness = Parameters<ProviderLoginCoordinator["supportedMethods"]>[0];
+type LoginInput = Parameters<ProviderLoginCoordinator["startLogin"]>[0];
+type LoginRegistry = Pick<ShellRegistry, "create" | "get" | "delete">;
+type ReceiptDocument = z.infer<typeof ReceiptDocumentSchema>;
+type ReceiptWriter = (path: string, value: ReceiptDocument) => Promise<void>;
+
+const LOGIN_COMMANDS = {
+  codex: {
+    agent: "codex" as const,
+    command: "sh -lc 'export MATRIX_NODE_PREFIX=\"${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}\"; export PATH=\"$MATRIX_NODE_PREFIX/bin:$PATH\"; codex login --device-auth'",
+  },
+  claude: {
+    agent: "claude" as const,
+    command: "sh -lc 'export MATRIX_NODE_PREFIX=\"${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}\"; export PATH=\"$MATRIX_NODE_PREFIX/bin:$PATH\"; claude'",
+  },
+} as const;
+
+function isMissing(error: unknown): boolean {
+  return error instanceof Error && "code" in error
+    && (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function isMissingSession(error: unknown): boolean {
+  return error instanceof Error && "code" in error
+    && (error as { code?: unknown }).code === "session_not_found";
+}
+
+async function readReceipts(path: string) {
+  try {
+    const metadata = await lstat(path);
+    if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.size > MAX_FILE_BYTES) {
+      throw new Error("Unsafe provider login receipt file");
+    }
+    return ReceiptDocumentSchema.parse(JSON.parse(await readFile(path, "utf8")));
+  } catch (error) {
+    if (isMissing(error)) return { version: 1 as const, receipts: [] };
+    throw error;
+  }
+}
+
+function payloadHash(input: LoginInput): string {
+  return createHash("sha256").update(JSON.stringify(input)).digest("hex");
+}
+
+function supportsHarness(
+  enabledHarnesses: ReadonlySet<"codex" | "claude">,
+  harness: LoginHarness,
+): harness is LoginHarness & { harness: "codex" | "claude" } {
+  return harness.installState === "installed"
+    && (
+      (harness.harness === "codex" && harness.driverId === "codex")
+      || (harness.harness === "claude" && harness.driverId === "claude_code")
+    )
+    && enabledHarnesses.has(harness.harness);
+}
+
+export function createProviderTerminalLoginCoordinator(options: {
+  homePath: string;
+  registry: LoginRegistry;
+  enabledHarnesses: readonly ("codex" | "claude")[];
+  now?: () => Date;
+  persistReceipt?: ReceiptWriter;
+}): ProviderLoginCoordinator {
+  if (!options.homePath) throw new Error("Provider login home path is required");
+  if (!options.registry?.create || !options.registry.get || !options.registry.delete) {
+    throw new Error("Provider login shell registry is required");
+  }
+  const enabledHarnesses = new Set(EnabledHarnessSchema.array().max(2).parse(options.enabledHarnesses));
+  const receiptsPath = join(options.homePath, "system/ai-providers/login-receipts.json");
+  const now = options.now ?? (() => new Date());
+  const persistReceipt = options.persistReceipt ?? writeProviderJsonAtomic;
+  let tail: Promise<void> = Promise.resolve();
+
+  async function serialize<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = tail;
+    let release = () => {};
+    tail = new Promise<void>((resolve) => { release = resolve; });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  return {
+    supportedMethods(harness) {
+      return supportsHarness(enabledHarnesses, harness)
+        ? ["terminal"]
+        : [];
+    },
+
+    async startLogin(input) {
+      return await serialize(async () => {
+        if (input.harness.id !== input.mutation.harnessInstanceId
+          || input.mutation.method !== "terminal"
+          || !supportsHarness(enabledHarnesses, input.harness)) {
+          throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+        }
+        const hash = payloadHash(input);
+        const document = await readReceipts(receiptsPath);
+        const duplicate = document.receipts.find((receipt) => receipt.key === input.mutation.idempotencyKey);
+        if (duplicate) {
+          if (duplicate.payloadHash !== hash) {
+            throw new ProviderSettingsStoreError("idempotency_conflict", 409);
+          }
+          const attempt = currentProviderConnectionAttempt(duplicate.attempt, now());
+          if (attempt.state !== "expired" && attempt.action.kind === "open_terminal") {
+            try {
+              await options.registry.get(attempt.action.terminalSessionId);
+            } catch (error) {
+              if (!isMissingSession(error)) throw error;
+              const command = LOGIN_COMMANDS[input.harness.harness];
+              await options.registry.create({
+                name: attempt.action.terminalSessionId,
+                cwd: "~",
+                cmd: command.command,
+                agent: command.agent,
+                exclusive: false,
+              });
+            }
+          }
+          return attempt;
+        }
+
+        const command = LOGIN_COMMANDS[input.harness.harness];
+        const sessionName = `provider-login-${input.harness.harness}-${hash.slice(0, 16)}`;
+        const attempt = ProviderConnectionAttemptSchema.parse({
+          id: `attempt_${hash.slice(0, 24)}`,
+          harnessInstanceId: input.mutation.harnessInstanceId,
+          accountId: input.mutation.accountId,
+          method: "terminal",
+          state: "pending",
+          action: { kind: "open_terminal", terminalSessionId: sessionName },
+          expiresAt: new Date(now().getTime() + LOGIN_LIFETIME_MS).toISOString(),
+          safeFailure: null,
+        });
+        const session = await options.registry.create({
+          name: sessionName,
+          cwd: "~",
+          cmd: command.command,
+          agent: command.agent,
+          exclusive: false,
+        });
+        if (session.name !== sessionName) {
+          throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+        }
+        document.receipts.push({
+          key: input.mutation.idempotencyKey,
+          payloadHash: hash,
+          attempt,
+        });
+        if (document.receipts.length > MAX_RECEIPTS) {
+          document.receipts.splice(0, document.receipts.length - MAX_RECEIPTS);
+        }
+        try {
+          await persistReceipt(receiptsPath, ReceiptDocumentSchema.parse(document));
+        } catch (error) {
+          await options.registry.delete(sessionName, { force: true }).catch((cleanupError: unknown) => {
+            console.warn(
+              "[provider-login] Failed to clean up unrecorded login session:",
+              cleanupError instanceof Error ? cleanupError.name : "UnknownError",
+            );
+          });
+          console.warn(
+            "[provider-login] Failed to persist login receipt:",
+            error instanceof Error ? error.name : "UnknownError",
+          );
+          throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+        }
+        return attempt;
+      });
+    },
+  };
+}

--- a/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
+++ b/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
@@ -423,10 +423,26 @@ export function createProviderTerminalLoginCoordinator(options: {
             if (canonicalSession.name !== canonicalSessionName) {
               throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
             }
-            // A full-digest canonical name is itself the durable exact identity
-            // marker. It is safe to adopt when bounded receipts have expired or
-            // been evicted; unrelated/legacy names are never accepted here.
-            adoptedExpiredSession = true;
+            if (canonicalSession.agent === command.agent) {
+              // A full-digest canonical name plus an observed matching foreground
+              // agent is the durable exact identity/liveness marker. It remains
+              // safe to adopt after bounded receipts have been evicted.
+              adoptedExpiredSession = true;
+            } else {
+              // Zellij sessions outlive their foreground command. Replace a
+              // canonical shell whose login process exited before relaunching;
+              // creating against the still-live shell would silently leave the
+              // user at a prompt instead of restarting authentication.
+              try {
+                await options.registry.delete(canonicalSessionName, { force: true });
+              } catch (deleteError) {
+                console.warn(
+                  "[provider-login] Failed to replace inactive login session:",
+                  deleteError instanceof Error ? deleteError.name : "UnknownError",
+                );
+                throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+              }
+            }
           } catch (error) {
             if (!isMissingSession(error)) throw error;
           }

--- a/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
+++ b/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
@@ -85,6 +85,26 @@ function loginSessionName(recoveryHash: string): string {
   return `provider-login-${recoveryHash.slice(0, 24)}`;
 }
 
+function isExpiredCanonicalRecoveryReceipt(
+  receipt: ReceiptDocument["receipts"][number],
+  recoveryHash: string,
+  input: LoginInput,
+  currentTime: Date,
+): boolean {
+  if (receipt.recoveryHash !== recoveryHash
+    || currentProviderConnectionAttempt(receipt.attempt, currentTime).state !== "expired"
+    || receipt.attempt.harnessInstanceId !== input.mutation.harnessInstanceId
+    || receipt.attempt.accountId !== input.mutation.accountId
+    || receipt.attempt.method !== input.mutation.method
+    || receipt.attempt.action.kind !== "open_terminal") {
+    return false;
+  }
+  // The recovery hash binds provider, harness, driver, instance, account, and
+  // method. Requiring its canonical session name additionally prevents a
+  // migrated legacy or unrelated terminal from being adopted by this path.
+  return receipt.attempt.action.terminalSessionId === loginSessionName(recoveryHash);
+}
+
 function legacyLoginSessionName(harness: "codex" | "claude", legacyPayloadHash: string): string {
   return `provider-login-${harness}-${legacyPayloadHash.slice(0, 16)}`;
 }
@@ -302,6 +322,13 @@ export function createProviderTerminalLoginCoordinator(options: {
           return attempt;
         }
 
+        const canAdoptExpiredSession = [...document.receipts, ...recoveryDocument.receipts]
+          .some((receipt) => isExpiredCanonicalRecoveryReceipt(
+            receipt,
+            recoveryHash,
+            input,
+            currentTime,
+          ));
         recoveryDocument.receipts = recoveryDocument.receipts.filter((receipt) =>
           receipt.recoveryHash !== recoveryHash);
         const command = LOGIN_COMMANDS[input.harness.harness];
@@ -322,16 +349,21 @@ export function createProviderTerminalLoginCoordinator(options: {
           recoveryHash,
           attempt,
         });
+        let adoptedExpiredSession = false;
         try {
           await options.registry.get(sessionName);
-          try {
-            await options.registry.delete(sessionName, { force: true });
-          } catch (error) {
-            console.warn(
-              "[provider-login] Failed to reconcile unrecorded login session:",
-              error instanceof Error ? error.name : "UnknownError",
-            );
-            throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+          if (canAdoptExpiredSession) {
+            adoptedExpiredSession = true;
+          } else {
+            try {
+              await options.registry.delete(sessionName, { force: true });
+            } catch (error) {
+              console.warn(
+                "[provider-login] Failed to reconcile unrecorded login session:",
+                error instanceof Error ? error.name : "UnknownError",
+              );
+              throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+            }
           }
         } catch (error) {
           if (!isMissingSession(error)) throw error;
@@ -346,13 +378,15 @@ export function createProviderTerminalLoginCoordinator(options: {
           );
           throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
         }
-        const session = await options.registry.create({
-          name: sessionName,
-          cwd: "~",
-          cmd: command.command,
-          agent: command.agent,
-          exclusive: false,
-        });
+        const session = adoptedExpiredSession
+          ? { name: sessionName }
+          : await options.registry.create({
+            name: sessionName,
+            cwd: "~",
+            cmd: command.command,
+            agent: command.agent,
+            exclusive: false,
+          });
         if (session.name !== sessionName) {
           throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
         }
@@ -360,13 +394,15 @@ export function createProviderTerminalLoginCoordinator(options: {
         try {
           await persistReceipt(receiptsPath, ReceiptDocumentSchema.parse(document));
         } catch (error) {
-          try {
-            await options.registry.delete(sessionName, { force: true });
-          } catch (cleanupError) {
-            console.warn(
-              "[provider-login] Failed to clean up unrecorded login session:",
-              cleanupError instanceof Error ? cleanupError.name : "UnknownError",
-            );
+          if (!adoptedExpiredSession) {
+            try {
+              await options.registry.delete(sessionName, { force: true });
+            } catch (cleanupError) {
+              console.warn(
+                "[provider-login] Failed to clean up unrecorded login session:",
+                cleanupError instanceof Error ? cleanupError.name : "UnknownError",
+              );
+            }
           }
           console.warn(
             "[provider-login] Failed to persist login receipt:",

--- a/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
+++ b/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
@@ -84,6 +84,31 @@ function loginSessionName(recoveryHash: string): string {
   return `provider-login-${recoveryHash.slice(0, 24)}`;
 }
 
+function legacyLoginSessionName(harness: "codex" | "claude", legacyPayloadHash: string): string {
+  return `provider-login-${harness}-${legacyPayloadHash.slice(0, 16)}`;
+}
+
+function matchesLegacyLoginPayload(
+  input: LoginInput,
+  receipt: ReceiptDocument["receipts"][number],
+): boolean {
+  if (receipt.recoveryHash !== undefined) return false;
+  // A successful legacy start advanced settings once. Looking back any farther could
+  // adopt a terminal across intervening route or account changes.
+  const revisions = [input.mutation.expectedRevision];
+  if (input.mutation.expectedRevision > 0) {
+    revisions.push(input.mutation.expectedRevision - 1);
+  }
+  return revisions.some((expectedRevision) => payloadHash({
+    ...input,
+    mutation: {
+      ...input.mutation,
+      expectedRevision,
+      idempotencyKey: receipt.key,
+    },
+  }) === receipt.payloadHash);
+}
+
 function appendBoundedReceipt(document: ReceiptDocument, receipt: ReceiptDocument["receipts"][number]): void {
   document.receipts.push(receipt);
   if (document.receipts.length > MAX_RECEIPTS) {
@@ -180,9 +205,50 @@ export function createProviderTerminalLoginCoordinator(options: {
           return attempt;
         }
 
-        const activeRecoveryReceipts = recoveryDocument.receipts.filter((receipt) =>
+        const currentTime = now();
+        const liveLegacyReceipts = [];
+        for (const receipt of document.receipts) {
+          const attempt = currentProviderConnectionAttempt(receipt.attempt, currentTime);
+          if (!matchesLegacyLoginPayload(input, receipt)
+            || attempt.state === "expired"
+            || attempt.action.kind !== "open_terminal"
+            || attempt.action.terminalSessionId !== legacyLoginSessionName(
+              input.harness.harness,
+              receipt.payloadHash,
+            )) {
+            continue;
+          }
+          try {
+            await options.registry.get(attempt.action.terminalSessionId);
+            liveLegacyReceipts.push(receipt);
+          } catch (error) {
+            if (!isMissingSession(error)) throw error;
+          }
+        }
+        if (liveLegacyReceipts.length > 1) {
+          throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+        }
+        const legacyReceipt = liveLegacyReceipts[0];
+        if (legacyReceipt) {
+          const legacyIndex = document.receipts.indexOf(legacyReceipt);
+          document.receipts[legacyIndex] = ReceiptSchema.parse({
+            ...legacyReceipt,
+            recoveryHash,
+          });
+          try {
+            await persistReceipt(receiptsPath, ReceiptDocumentSchema.parse(document));
+          } catch (error) {
+            console.warn(
+              "[provider-login] Failed to upgrade legacy login receipt:",
+              error instanceof Error ? error.name : "UnknownError",
+            );
+            throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+          }
+        }
+
+        const activeRecoveryReceipts = [...document.receipts, ...recoveryDocument.receipts].filter((receipt) =>
           receipt.recoveryHash === recoveryHash
-          && currentProviderConnectionAttempt(receipt.attempt, now()).state !== "expired");
+          && currentProviderConnectionAttempt(receipt.attempt, currentTime).state !== "expired");
         const activeRecoveryAttempts = new Map(activeRecoveryReceipts.map((receipt) => [
           JSON.stringify(receipt.attempt),
           receipt.attempt,

--- a/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
+++ b/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
@@ -12,6 +12,7 @@ import { currentProviderConnectionAttempt } from "./provider-settings-receipts.j
 const MAX_RECEIPTS = 64;
 const MAX_FILE_BYTES = 256 * 1024;
 const LOGIN_LIFETIME_MS = 10 * 60_000;
+const MAX_LEGACY_REVISION_LOOKBACK = 64;
 const SafeRefSchema = z.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/);
 const EnabledHarnessSchema = z.enum(["codex", "claude"]);
 const ReceiptSchema = z.object({
@@ -93,20 +94,28 @@ function matchesLegacyLoginPayload(
   receipt: ReceiptDocument["receipts"][number],
 ): boolean {
   if (receipt.recoveryHash !== undefined) return false;
-  // A successful legacy start advanced settings once. Looking back any farther could
-  // adopt a terminal across intervening route or account changes.
-  const revisions = [input.mutation.expectedRevision];
-  if (input.mutation.expectedRevision > 0) {
-    revisions.push(input.mutation.expectedRevision - 1);
+  // Legacy receipts did not persist their recovery identity. Recompute the exact
+  // legacy payload across a bounded revision window so unrelated provider, account,
+  // harness, or method changes can never match while recovery work stays capped.
+  const oldestRevision = Math.max(
+    0,
+    input.mutation.expectedRevision - MAX_LEGACY_REVISION_LOOKBACK,
+  );
+  for (let expectedRevision = input.mutation.expectedRevision;
+    expectedRevision >= oldestRevision;
+    expectedRevision -= 1) {
+    if (payloadHash({
+      ...input,
+      mutation: {
+        ...input.mutation,
+        expectedRevision,
+        idempotencyKey: receipt.key,
+      },
+    }) === receipt.payloadHash) {
+      return true;
+    }
   }
-  return revisions.some((expectedRevision) => payloadHash({
-    ...input,
-    mutation: {
-      ...input.mutation,
-      expectedRevision,
-      idempotencyKey: receipt.key,
-    },
-  }) === receipt.payloadHash);
+  return false;
 }
 
 function appendBoundedReceipt(document: ReceiptDocument, receipt: ReceiptDocument["receipts"][number]): void {

--- a/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
+++ b/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
@@ -138,7 +138,8 @@ function matchesLegacyLoginPayload(
   return false;
 }
 
-function appendBoundedReceipt(document: ReceiptDocument, receipt: ReceiptDocument["receipts"][number]): void {
+function replaceBoundedReceipt(document: ReceiptDocument, receipt: ReceiptDocument["receipts"][number]): void {
+  document.receipts = document.receipts.filter((candidate) => candidate.key !== receipt.key);
   document.receipts.push(receipt);
   if (document.receipts.length > MAX_RECEIPTS) {
     document.receipts.splice(0, document.receipts.length - MAX_RECEIPTS);
@@ -205,6 +206,7 @@ export function createProviderTerminalLoginCoordinator(options: {
         const recoveryHash = recoveryIdentityHash(input);
         const document = await readReceipts(receiptsPath);
         const recoveryDocument = await readReceipts(recoveryPath);
+        const currentTime = now();
         const matchingReceipts = [...document.receipts, ...recoveryDocument.receipts]
           .filter((receipt) => receipt.key === input.mutation.idempotencyKey);
         if (new Set(matchingReceipts.map((receipt) => receipt.payloadHash)).size > 1) {
@@ -215,8 +217,14 @@ export function createProviderTerminalLoginCoordinator(options: {
           if (duplicate.payloadHash !== hash) {
             throw new ProviderSettingsStoreError("idempotency_conflict", 409);
           }
-          const attempt = currentProviderConnectionAttempt(duplicate.attempt, now());
-          if (attempt.state !== "expired" && attempt.action.kind === "open_terminal") {
+          const attempt = currentProviderConnectionAttempt(duplicate.attempt, currentTime);
+          const renewExpired = isExpiredCanonicalRecoveryReceipt(
+            duplicate,
+            recoveryHash,
+            input,
+            currentTime,
+          );
+          if (!renewExpired && attempt.state !== "expired" && attempt.action.kind === "open_terminal") {
             try {
               await options.registry.get(attempt.action.terminalSessionId);
             } catch (error) {
@@ -231,10 +239,9 @@ export function createProviderTerminalLoginCoordinator(options: {
               });
             }
           }
-          return attempt;
+          if (!renewExpired) return attempt;
         }
 
-        const currentTime = now();
         const liveLegacyReceipts = [];
         for (const receipt of document.receipts) {
           const attempt = currentProviderConnectionAttempt(receipt.attempt, currentTime);
@@ -291,7 +298,7 @@ export function createProviderTerminalLoginCoordinator(options: {
           if (attempt.action.kind !== "open_terminal") {
             throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
           }
-          appendBoundedReceipt(recoveryDocument, ReceiptSchema.parse({
+          replaceBoundedReceipt(recoveryDocument, ReceiptSchema.parse({
             key: input.mutation.idempotencyKey,
             payloadHash: hash,
             recoveryHash,
@@ -368,7 +375,7 @@ export function createProviderTerminalLoginCoordinator(options: {
         } catch (error) {
           if (!isMissingSession(error)) throw error;
         }
-        appendBoundedReceipt(recoveryDocument, receipt);
+        replaceBoundedReceipt(recoveryDocument, receipt);
         try {
           await writeProviderJsonAtomic(recoveryPath, ReceiptDocumentSchema.parse(recoveryDocument));
         } catch (error) {
@@ -390,7 +397,7 @@ export function createProviderTerminalLoginCoordinator(options: {
         if (session.name !== sessionName) {
           throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
         }
-        appendBoundedReceipt(document, receipt);
+        replaceBoundedReceipt(document, receipt);
         try {
           await persistReceipt(receiptsPath, ReceiptDocumentSchema.parse(document));
         } catch (error) {

--- a/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
+++ b/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
@@ -14,11 +14,13 @@ const MAX_FILE_BYTES = 256 * 1024;
 const LOGIN_LIFETIME_MS = 10 * 60_000;
 const MAX_LEGACY_REVISION_LOOKBACK = 64;
 const SafeRefSchema = z.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/);
+const DigestSchema = z.string().length(64).regex(/^[a-f0-9]+$/);
 const EnabledHarnessSchema = z.enum(["codex", "claude"]);
 const ReceiptSchema = z.object({
   key: SafeRefSchema,
-  payloadHash: z.string().length(64).regex(/^[a-f0-9]+$/),
-  recoveryHash: z.string().length(64).regex(/^[a-f0-9]+$/).optional(),
+  payloadHash: DigestSchema,
+  recoveryHash: DigestSchema.optional(),
+  legacyPayloadHash: DigestSchema.optional(),
   attempt: ProviderConnectionAttemptSchema,
 }).strict();
 const ReceiptDocumentSchema = z.object({
@@ -85,24 +87,40 @@ function loginSessionName(recoveryHash: string): string {
   return `provider-login-${recoveryHash.slice(0, 24)}`;
 }
 
-function isExpiredCanonicalRecoveryReceipt(
+interface RecoverySession {
+  name: string;
+  legacyPayloadHash?: string;
+}
+
+function exactRecoverySession(
   receipt: ReceiptDocument["receipts"][number],
   recoveryHash: string,
   input: LoginInput,
-  currentTime: Date,
-): boolean {
+): RecoverySession | null {
   if (receipt.recoveryHash !== recoveryHash
-    || currentProviderConnectionAttempt(receipt.attempt, currentTime).state !== "expired"
     || receipt.attempt.harnessInstanceId !== input.mutation.harnessInstanceId
     || receipt.attempt.accountId !== input.mutation.accountId
     || receipt.attempt.method !== input.mutation.method
     || receipt.attempt.action.kind !== "open_terminal") {
-    return false;
+    return null;
   }
-  // The recovery hash binds provider, harness, driver, instance, account, and
-  // method. Requiring its canonical session name additionally prevents a
-  // migrated legacy or unrelated terminal from being adopted by this path.
-  return receipt.attempt.action.terminalSessionId === loginSessionName(recoveryHash);
+  const sessionName = receipt.attempt.action.terminalSessionId;
+  if (sessionName === loginSessionName(recoveryHash)) return { name: sessionName };
+  if (input.harness.harness !== "codex" && input.harness.harness !== "claude") return null;
+  const legacyPayloadHash = receipt.legacyPayloadHash ?? receipt.payloadHash;
+  return sessionName === legacyLoginSessionName(input.harness.harness, legacyPayloadHash)
+    ? { name: sessionName, legacyPayloadHash }
+    : null;
+}
+
+function expiredRecoverySession(
+  receipt: ReceiptDocument["receipts"][number],
+  recoveryHash: string,
+  input: LoginInput,
+  currentTime: Date,
+): RecoverySession | null {
+  if (currentProviderConnectionAttempt(receipt.attempt, currentTime).state !== "expired") return null;
+  return exactRecoverySession(receipt, recoveryHash, input);
 }
 
 function legacyLoginSessionName(harness: "codex" | "claude", legacyPayloadHash: string): string {
@@ -218,12 +236,12 @@ export function createProviderTerminalLoginCoordinator(options: {
             throw new ProviderSettingsStoreError("idempotency_conflict", 409);
           }
           const attempt = currentProviderConnectionAttempt(duplicate.attempt, currentTime);
-          const renewExpired = isExpiredCanonicalRecoveryReceipt(
+          const renewExpired = expiredRecoverySession(
             duplicate,
             recoveryHash,
             input,
             currentTime,
-          );
+          ) !== null;
           if (!renewExpired && attempt.state !== "expired" && attempt.action.kind === "open_terminal") {
             try {
               await options.registry.get(attempt.action.terminalSessionId);
@@ -270,6 +288,7 @@ export function createProviderTerminalLoginCoordinator(options: {
           document.receipts[legacyIndex] = ReceiptSchema.parse({
             ...legacyReceipt,
             recoveryHash,
+            legacyPayloadHash: legacyReceipt.payloadHash,
           });
           try {
             await persistReceipt(receiptsPath, ReceiptDocumentSchema.parse(document));
@@ -285,15 +304,26 @@ export function createProviderTerminalLoginCoordinator(options: {
         const activeRecoveryReceipts = [...document.receipts, ...recoveryDocument.receipts].filter((receipt) =>
           receipt.recoveryHash === recoveryHash
           && currentProviderConnectionAttempt(receipt.attempt, currentTime).state !== "expired");
-        const activeRecoveryAttempts = new Map(activeRecoveryReceipts.map((receipt) => [
-          JSON.stringify(receipt.attempt),
-          receipt.attempt,
-        ]));
+        const activeRecoveryAttempts = new Map<string, typeof activeRecoveryReceipts>();
+        for (const receipt of activeRecoveryReceipts) {
+          const key = JSON.stringify(receipt.attempt);
+          activeRecoveryAttempts.set(key, [...(activeRecoveryAttempts.get(key) ?? []), receipt]);
+        }
         if (activeRecoveryAttempts.size > 1) {
           throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
         }
-        const recoverable = activeRecoveryAttempts.values().next().value;
-        if (recoverable) {
+        const recoverableReceipts = activeRecoveryAttempts.values().next().value;
+        if (recoverableReceipts) {
+          const recoverySessions = new Map<string, RecoverySession>();
+          for (const candidate of recoverableReceipts) {
+            const session = exactRecoverySession(candidate, recoveryHash, input);
+            if (session) recoverySessions.set(JSON.stringify(session), session);
+          }
+          if (recoverySessions.size !== 1) {
+            throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+          }
+          const recoverySession = recoverySessions.values().next().value!;
+          const recoverable = recoverableReceipts[0]!.attempt;
           const attempt = currentProviderConnectionAttempt(recoverable, now());
           if (attempt.action.kind !== "open_terminal") {
             throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
@@ -302,6 +332,9 @@ export function createProviderTerminalLoginCoordinator(options: {
             key: input.mutation.idempotencyKey,
             payloadHash: hash,
             recoveryHash,
+            ...(recoverySession.legacyPayloadHash
+              ? { legacyPayloadHash: recoverySession.legacyPayloadHash }
+              : {}),
             attempt: recoverable,
           }));
           try {
@@ -329,17 +362,50 @@ export function createProviderTerminalLoginCoordinator(options: {
           return attempt;
         }
 
-        const canAdoptExpiredSession = [...document.receipts, ...recoveryDocument.receipts]
-          .some((receipt) => isExpiredCanonicalRecoveryReceipt(
-            receipt,
-            recoveryHash,
-            input,
-            currentTime,
-          ));
+        const expiredRecoverySessions = new Map<string, RecoverySession>();
+        for (const candidate of [...document.receipts, ...recoveryDocument.receipts]) {
+          const session = expiredRecoverySession(candidate, recoveryHash, input, currentTime);
+          if (session) expiredRecoverySessions.set(JSON.stringify(session), session);
+        }
+        if (expiredRecoverySessions.size > 1) {
+          throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+        }
+        const expiredSession = expiredRecoverySessions.values().next().value;
         recoveryDocument.receipts = recoveryDocument.receipts.filter((receipt) =>
           receipt.recoveryHash !== recoveryHash);
         const command = LOGIN_COMMANDS[input.harness.harness];
-        const sessionName = loginSessionName(recoveryHash);
+        const canonicalSessionName = loginSessionName(recoveryHash);
+        let sessionName = canonicalSessionName;
+        let adoptedExpiredSession = false;
+        if (expiredSession) {
+          try {
+            await options.registry.get(expiredSession.name);
+            sessionName = expiredSession.name;
+            adoptedExpiredSession = true;
+          } catch (error) {
+            if (!isMissingSession(error)) throw error;
+          }
+        }
+        if (!adoptedExpiredSession) {
+          try {
+            await options.registry.get(canonicalSessionName);
+            if (expiredSession?.name === canonicalSessionName) {
+              adoptedExpiredSession = true;
+            } else {
+              try {
+                await options.registry.delete(canonicalSessionName, { force: true });
+              } catch (error) {
+                console.warn(
+                  "[provider-login] Failed to reconcile unrecorded login session:",
+                  error instanceof Error ? error.name : "UnknownError",
+                );
+                throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+              }
+            }
+          } catch (error) {
+            if (!isMissingSession(error)) throw error;
+          }
+        }
         const attempt = ProviderConnectionAttemptSchema.parse({
           id: `attempt_${hash.slice(0, 24)}`,
           harnessInstanceId: input.mutation.harnessInstanceId,
@@ -354,27 +420,11 @@ export function createProviderTerminalLoginCoordinator(options: {
           key: input.mutation.idempotencyKey,
           payloadHash: hash,
           recoveryHash,
+          ...(expiredSession?.legacyPayloadHash
+            ? { legacyPayloadHash: expiredSession.legacyPayloadHash }
+            : {}),
           attempt,
         });
-        let adoptedExpiredSession = false;
-        try {
-          await options.registry.get(sessionName);
-          if (canAdoptExpiredSession) {
-            adoptedExpiredSession = true;
-          } else {
-            try {
-              await options.registry.delete(sessionName, { force: true });
-            } catch (error) {
-              console.warn(
-                "[provider-login] Failed to reconcile unrecorded login session:",
-                error instanceof Error ? error.name : "UnknownError",
-              );
-              throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
-            }
-          }
-        } catch (error) {
-          if (!isMissingSession(error)) throw error;
-        }
         replaceBoundedReceipt(recoveryDocument, receipt);
         try {
           await writeProviderJsonAtomic(recoveryPath, ReceiptDocumentSchema.parse(recoveryDocument));

--- a/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
+++ b/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
@@ -30,7 +30,7 @@ const ReceiptDocumentSchema = z.object({
 
 type LoginHarness = Parameters<ProviderLoginCoordinator["supportedMethods"]>[0];
 type LoginInput = Parameters<ProviderLoginCoordinator["startLogin"]>[0];
-type LoginRegistry = Pick<ShellRegistry, "create" | "get" | "delete">;
+type LoginRegistry = Pick<ShellRegistry, "create" | "get" | "delete" | "rename">;
 type ReceiptDocument = z.infer<typeof ReceiptDocumentSchema>;
 type ReceiptWriter = (path: string, value: ReceiptDocument) => Promise<void>;
 
@@ -84,7 +84,11 @@ function recoveryIdentityHash(input: LoginInput): string {
 }
 
 function loginSessionName(recoveryHash: string): string {
-  return `provider-login-${recoveryHash.slice(0, 24)}`;
+  // The complete recovery digest makes the live terminal name a durable,
+  // exact identity marker. That lets retries recover it even after the
+  // bounded receipt documents evict older entries, without another growing
+  // index or adopting a terminal from a merely truncated-name collision.
+  return `provider-login-${recoveryHash}`;
 }
 
 interface RecoverySession {
@@ -184,7 +188,8 @@ export function createProviderTerminalLoginCoordinator(options: {
   persistReceipt?: ReceiptWriter;
 }): ProviderLoginCoordinator {
   if (!options.homePath) throw new Error("Provider login home path is required");
-  if (!options.registry?.create || !options.registry.get || !options.registry.delete) {
+  if (!options.registry?.create || !options.registry.get || !options.registry.delete
+    || !options.registry.rename) {
     throw new Error("Provider login shell registry is required");
   }
   const enabledHarnesses = new Set(EnabledHarnessSchema.array().max(2).parse(options.enabledHarnesses));
@@ -284,15 +289,41 @@ export function createProviderTerminalLoginCoordinator(options: {
         }
         const legacyReceipt = liveLegacyReceipts[0];
         if (legacyReceipt) {
+          if (legacyReceipt.attempt.action.kind !== "open_terminal") {
+            throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+          }
+          const legacySessionName = legacyReceipt.attempt.action.terminalSessionId;
+          const canonicalSessionName = loginSessionName(recoveryHash);
+          try {
+            await options.registry.rename(legacySessionName, canonicalSessionName);
+          } catch (error) {
+            console.warn(
+              "[provider-login] Failed to canonicalize legacy login session:",
+              error instanceof Error ? error.name : "UnknownError",
+            );
+            throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+          }
           const legacyIndex = document.receipts.indexOf(legacyReceipt);
           document.receipts[legacyIndex] = ReceiptSchema.parse({
             ...legacyReceipt,
             recoveryHash,
             legacyPayloadHash: legacyReceipt.payloadHash,
+            attempt: {
+              ...legacyReceipt.attempt,
+              action: { kind: "open_terminal", terminalSessionId: canonicalSessionName },
+            },
           });
           try {
             await persistReceipt(receiptsPath, ReceiptDocumentSchema.parse(document));
           } catch (error) {
+            try {
+              await options.registry.rename(canonicalSessionName, legacySessionName);
+            } catch (rollbackError) {
+              console.warn(
+                "[provider-login] Failed to roll back canonicalized login session:",
+                rollbackError instanceof Error ? rollbackError.name : "UnknownError",
+              );
+            }
             console.warn(
               "[provider-login] Failed to upgrade legacy login receipt:",
               error instanceof Error ? error.name : "UnknownError",
@@ -388,20 +419,14 @@ export function createProviderTerminalLoginCoordinator(options: {
         }
         if (!adoptedExpiredSession) {
           try {
-            await options.registry.get(canonicalSessionName);
-            if (expiredSession?.name === canonicalSessionName) {
-              adoptedExpiredSession = true;
-            } else {
-              try {
-                await options.registry.delete(canonicalSessionName, { force: true });
-              } catch (error) {
-                console.warn(
-                  "[provider-login] Failed to reconcile unrecorded login session:",
-                  error instanceof Error ? error.name : "UnknownError",
-                );
-                throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
-              }
+            const canonicalSession = await options.registry.get(canonicalSessionName);
+            if (canonicalSession.name !== canonicalSessionName) {
+              throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
             }
+            // A full-digest canonical name is itself the durable exact identity
+            // marker. It is safe to adopt when bounded receipts have expired or
+            // been evicted; unrelated/legacy names are never accepted here.
+            adoptedExpiredSession = true;
           } catch (error) {
             if (!isMissingSession(error)) throw error;
           }

--- a/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
+++ b/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
@@ -30,7 +30,8 @@ const ReceiptDocumentSchema = z.object({
 
 type LoginHarness = Parameters<ProviderLoginCoordinator["supportedMethods"]>[0];
 type LoginInput = Parameters<ProviderLoginCoordinator["startLogin"]>[0];
-type LoginRegistry = Pick<ShellRegistry, "create" | "get" | "delete" | "rename">;
+type LoginRegistry = Pick<ShellRegistry,
+  "create" | "get" | "delete" | "rename" | "observeAgentLiveness">;
 type ReceiptDocument = z.infer<typeof ReceiptDocumentSchema>;
 type ReceiptWriter = (path: string, value: ReceiptDocument) => Promise<void>;
 
@@ -84,11 +85,11 @@ function recoveryIdentityHash(input: LoginInput): string {
 }
 
 function loginSessionName(recoveryHash: string): string {
-  // The complete recovery digest makes the live terminal name a durable,
-  // exact identity marker. That lets retries recover it even after the
-  // bounded receipt documents evict older entries, without another growing
-  // index or adopting a terminal from a merely truncated-name collision.
-  return `provider-login-${recoveryHash}`;
+  // Base36 preserves all 256 digest bits while staying inside the shell's
+  // lowercase 64-character session-name contract. Fixed-width padding keeps
+  // the mapping bijective for digests with leading zeroes.
+  const encoded = BigInt(`0x${recoveryHash}`).toString(36).padStart(50, "0");
+  return `provider-auth-${encoded}`;
 }
 
 interface RecoverySession {
@@ -189,7 +190,7 @@ export function createProviderTerminalLoginCoordinator(options: {
 }): ProviderLoginCoordinator {
   if (!options.homePath) throw new Error("Provider login home path is required");
   if (!options.registry?.create || !options.registry.get || !options.registry.delete
-    || !options.registry.rename) {
+    || !options.registry.rename || !options.registry.observeAgentLiveness) {
     throw new Error("Provider login shell registry is required");
   }
   const enabledHarnesses = new Set(EnabledHarnessSchema.array().max(2).parse(options.enabledHarnesses));
@@ -227,6 +228,8 @@ export function createProviderTerminalLoginCoordinator(options: {
         }
         const hash = payloadHash(input);
         const recoveryHash = recoveryIdentityHash(input);
+        const command = LOGIN_COMMANDS[input.harness.harness];
+        const canonicalSessionName = loginSessionName(recoveryHash);
         const document = await readReceipts(receiptsPath);
         const recoveryDocument = await readReceipts(recoveryPath);
         const currentTime = now();
@@ -235,10 +238,70 @@ export function createProviderTerminalLoginCoordinator(options: {
         if (new Set(matchingReceipts.map((receipt) => receipt.payloadHash)).size > 1) {
           throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
         }
-        const duplicate = matchingReceipts[0];
+        let duplicate = matchingReceipts[0];
         if (duplicate) {
           if (duplicate.payloadHash !== hash) {
             throw new ProviderSettingsStoreError("idempotency_conflict", 409);
+          }
+          if (duplicate.attempt.action.kind === "open_terminal"
+            && duplicate.attempt.action.terminalSessionId !== canonicalSessionName) {
+            let canonicalSession: Awaited<ReturnType<LoginRegistry["get"]>> | null = null;
+            try {
+              canonicalSession = await options.registry.get(canonicalSessionName);
+            } catch (error) {
+              if (!isMissingSession(error)) throw error;
+            }
+            if (canonicalSession) {
+              // A surviving canonical session means a prior migration crossed
+              // the runtime/persistence boundary. Never recreate the legacy
+              // name while that authoritative identity remains live.
+              if (canonicalSession.name !== canonicalSessionName
+                || await options.registry.observeAgentLiveness(
+                  canonicalSessionName,
+                  command.agent,
+                ) !== "running") {
+                throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+              }
+              try {
+                await options.registry.get(duplicate.attempt.action.terminalSessionId);
+                throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+              } catch (error) {
+                if (!isMissingSession(error)) throw error;
+              }
+              const repaired = ReceiptSchema.parse({
+                ...duplicate,
+                recoveryHash,
+                legacyPayloadHash: duplicate.legacyPayloadHash ?? duplicate.payloadHash,
+                attempt: {
+                  ...duplicate.attempt,
+                  action: { kind: "open_terminal", terminalSessionId: canonicalSessionName },
+                },
+              });
+              const repairDocument = (candidate: ReceiptDocument) => {
+                candidate.receipts = candidate.receipts.map((receipt) => (
+                  receipt.key === duplicate!.key && receipt.payloadHash === duplicate!.payloadHash
+                    ? repaired
+                    : receipt
+                ));
+              };
+              try {
+                if (document.receipts.includes(duplicate)) {
+                  repairDocument(document);
+                  await persistReceipt(receiptsPath, ReceiptDocumentSchema.parse(document));
+                }
+                if (recoveryDocument.receipts.includes(duplicate)) {
+                  repairDocument(recoveryDocument);
+                  await writeProviderJsonAtomic(recoveryPath, ReceiptDocumentSchema.parse(recoveryDocument));
+                }
+              } catch (error) {
+                console.warn(
+                  "[provider-login] Failed to repair canonical login receipt:",
+                  error instanceof Error ? error.name : "UnknownError",
+                );
+                throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+              }
+              duplicate = repaired;
+            }
           }
           const attempt = currentProviderConnectionAttempt(duplicate.attempt, currentTime);
           const renewExpired = expiredRecoverySession(
@@ -252,7 +315,6 @@ export function createProviderTerminalLoginCoordinator(options: {
               await options.registry.get(attempt.action.terminalSessionId);
             } catch (error) {
               if (!isMissingSession(error)) throw error;
-              const command = LOGIN_COMMANDS[input.harness.harness];
               await options.registry.create({
                 name: attempt.action.terminalSessionId,
                 cwd: "~",
@@ -293,7 +355,6 @@ export function createProviderTerminalLoginCoordinator(options: {
             throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
           }
           const legacySessionName = legacyReceipt.attempt.action.terminalSessionId;
-          const canonicalSessionName = loginSessionName(recoveryHash);
           try {
             await options.registry.rename(legacySessionName, canonicalSessionName);
           } catch (error) {
@@ -381,12 +442,11 @@ export function createProviderTerminalLoginCoordinator(options: {
             await options.registry.get(attempt.action.terminalSessionId);
           } catch (error) {
             if (!isMissingSession(error)) throw error;
-            const recoveryCommand = LOGIN_COMMANDS[input.harness.harness];
             await options.registry.create({
               name: attempt.action.terminalSessionId,
               cwd: "~",
-              cmd: recoveryCommand.command,
-              agent: recoveryCommand.agent,
+              cmd: command.command,
+              agent: command.agent,
               exclusive: false,
             });
           }
@@ -404,8 +464,6 @@ export function createProviderTerminalLoginCoordinator(options: {
         const expiredSession = expiredRecoverySessions.values().next().value;
         recoveryDocument.receipts = recoveryDocument.receipts.filter((receipt) =>
           receipt.recoveryHash !== recoveryHash);
-        const command = LOGIN_COMMANDS[input.harness.harness];
-        const canonicalSessionName = loginSessionName(recoveryHash);
         let sessionName = canonicalSessionName;
         let adoptedExpiredSession = false;
         if (expiredSession) {
@@ -423,25 +481,19 @@ export function createProviderTerminalLoginCoordinator(options: {
             if (canonicalSession.name !== canonicalSessionName) {
               throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
             }
-            if (canonicalSession.agent === command.agent) {
+            if (await options.registry.observeAgentLiveness(
+              canonicalSessionName,
+              command.agent,
+            ) === "running") {
               // A full-digest canonical name plus an observed matching foreground
               // agent is the durable exact identity/liveness marker. It remains
               // safe to adopt after bounded receipts have been evicted.
               adoptedExpiredSession = true;
             } else {
-              // Zellij sessions outlive their foreground command. Replace a
-              // canonical shell whose login process exited before relaunching;
-              // creating against the still-live shell would silently leave the
-              // user at a prompt instead of restarting authentication.
-              try {
-                await options.registry.delete(canonicalSessionName, { force: true });
-              } catch (deleteError) {
-                console.warn(
-                  "[provider-login] Failed to replace inactive login session:",
-                  deleteError instanceof Error ? deleteError.name : "UnknownError",
-                );
-                throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
-              }
+              // The production terminal wrapper can hide the foreground agent.
+              // Unknown is not evidence that the login exited: fail closed so
+              // we neither kill an active login nor adopt a stale shell prompt.
+              throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
             }
           } catch (error) {
             if (!isMissingSession(error)) throw error;

--- a/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
+++ b/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
@@ -17,6 +17,7 @@ const EnabledHarnessSchema = z.enum(["codex", "claude"]);
 const ReceiptSchema = z.object({
   key: SafeRefSchema,
   payloadHash: z.string().length(64).regex(/^[a-f0-9]+$/),
+  recoveryHash: z.string().length(64).regex(/^[a-f0-9]+$/).optional(),
   attempt: ProviderConnectionAttemptSchema,
 }).strict();
 const ReceiptDocumentSchema = z.object({
@@ -68,9 +69,19 @@ function payloadHash(input: LoginInput): string {
   return createHash("sha256").update(JSON.stringify(input)).digest("hex");
 }
 
-function loginSessionName(idempotencyKey: string): string {
-  const keyHash = createHash("sha256").update(idempotencyKey).digest("hex");
-  return `provider-login-${keyHash.slice(0, 24)}`;
+function recoveryIdentityHash(input: LoginInput): string {
+  return createHash("sha256").update(JSON.stringify({
+    providerId: input.harness.providerId,
+    harness: input.harness.harness,
+    driverId: input.harness.driverId,
+    harnessInstanceId: input.mutation.harnessInstanceId,
+    accountId: input.mutation.accountId,
+    method: input.mutation.method,
+  })).digest("hex");
+}
+
+function loginSessionName(recoveryHash: string): string {
+  return `provider-login-${recoveryHash.slice(0, 24)}`;
 }
 
 function appendBoundedReceipt(document: ReceiptDocument, receipt: ReceiptDocument["receipts"][number]): void {
@@ -137,6 +148,7 @@ export function createProviderTerminalLoginCoordinator(options: {
           throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
         }
         const hash = payloadHash(input);
+        const recoveryHash = recoveryIdentityHash(input);
         const document = await readReceipts(receiptsPath);
         const recoveryDocument = await readReceipts(recoveryPath);
         const matchingReceipts = [...document.receipts, ...recoveryDocument.receipts]
@@ -168,8 +180,57 @@ export function createProviderTerminalLoginCoordinator(options: {
           return attempt;
         }
 
+        const activeRecoveryReceipts = recoveryDocument.receipts.filter((receipt) =>
+          receipt.recoveryHash === recoveryHash
+          && currentProviderConnectionAttempt(receipt.attempt, now()).state !== "expired");
+        const activeRecoveryAttempts = new Map(activeRecoveryReceipts.map((receipt) => [
+          JSON.stringify(receipt.attempt),
+          receipt.attempt,
+        ]));
+        if (activeRecoveryAttempts.size > 1) {
+          throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+        }
+        const recoverable = activeRecoveryAttempts.values().next().value;
+        if (recoverable) {
+          const attempt = currentProviderConnectionAttempt(recoverable, now());
+          if (attempt.action.kind !== "open_terminal") {
+            throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+          }
+          appendBoundedReceipt(recoveryDocument, ReceiptSchema.parse({
+            key: input.mutation.idempotencyKey,
+            payloadHash: hash,
+            recoveryHash,
+            attempt: recoverable,
+          }));
+          try {
+            await writeProviderJsonAtomic(recoveryPath, ReceiptDocumentSchema.parse(recoveryDocument));
+          } catch (error) {
+            console.warn(
+              "[provider-login] Failed to persist login recovery alias:",
+              error instanceof Error ? error.name : "UnknownError",
+            );
+            throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+          }
+          try {
+            await options.registry.get(attempt.action.terminalSessionId);
+          } catch (error) {
+            if (!isMissingSession(error)) throw error;
+            const recoveryCommand = LOGIN_COMMANDS[input.harness.harness];
+            await options.registry.create({
+              name: attempt.action.terminalSessionId,
+              cwd: "~",
+              cmd: recoveryCommand.command,
+              agent: recoveryCommand.agent,
+              exclusive: false,
+            });
+          }
+          return attempt;
+        }
+
+        recoveryDocument.receipts = recoveryDocument.receipts.filter((receipt) =>
+          receipt.recoveryHash !== recoveryHash);
         const command = LOGIN_COMMANDS[input.harness.harness];
-        const sessionName = loginSessionName(input.mutation.idempotencyKey);
+        const sessionName = loginSessionName(recoveryHash);
         const attempt = ProviderConnectionAttemptSchema.parse({
           id: `attempt_${hash.slice(0, 24)}`,
           harnessInstanceId: input.mutation.harnessInstanceId,
@@ -183,6 +244,7 @@ export function createProviderTerminalLoginCoordinator(options: {
         const receipt = ReceiptSchema.parse({
           key: input.mutation.idempotencyKey,
           payloadHash: hash,
+          recoveryHash,
           attempt,
         });
         try {

--- a/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
+++ b/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
@@ -68,6 +68,18 @@ function payloadHash(input: LoginInput): string {
   return createHash("sha256").update(JSON.stringify(input)).digest("hex");
 }
 
+function loginSessionName(idempotencyKey: string): string {
+  const keyHash = createHash("sha256").update(idempotencyKey).digest("hex");
+  return `provider-login-${keyHash.slice(0, 24)}`;
+}
+
+function appendBoundedReceipt(document: ReceiptDocument, receipt: ReceiptDocument["receipts"][number]): void {
+  document.receipts.push(receipt);
+  if (document.receipts.length > MAX_RECEIPTS) {
+    document.receipts.splice(0, document.receipts.length - MAX_RECEIPTS);
+  }
+}
+
 function supportsHarness(
   enabledHarnesses: ReadonlySet<"codex" | "claude">,
   harness: LoginHarness,
@@ -93,6 +105,7 @@ export function createProviderTerminalLoginCoordinator(options: {
   }
   const enabledHarnesses = new Set(EnabledHarnessSchema.array().max(2).parse(options.enabledHarnesses));
   const receiptsPath = join(options.homePath, "system/ai-providers/login-receipts.json");
+  const recoveryPath = join(options.homePath, "system/ai-providers/login-recovery.json");
   const now = options.now ?? (() => new Date());
   const persistReceipt = options.persistReceipt ?? writeProviderJsonAtomic;
   let tail: Promise<void> = Promise.resolve();
@@ -125,7 +138,13 @@ export function createProviderTerminalLoginCoordinator(options: {
         }
         const hash = payloadHash(input);
         const document = await readReceipts(receiptsPath);
-        const duplicate = document.receipts.find((receipt) => receipt.key === input.mutation.idempotencyKey);
+        const recoveryDocument = await readReceipts(recoveryPath);
+        const matchingReceipts = [...document.receipts, ...recoveryDocument.receipts]
+          .filter((receipt) => receipt.key === input.mutation.idempotencyKey);
+        if (new Set(matchingReceipts.map((receipt) => receipt.payloadHash)).size > 1) {
+          throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+        }
+        const duplicate = matchingReceipts[0];
         if (duplicate) {
           if (duplicate.payloadHash !== hash) {
             throw new ProviderSettingsStoreError("idempotency_conflict", 409);
@@ -150,7 +169,7 @@ export function createProviderTerminalLoginCoordinator(options: {
         }
 
         const command = LOGIN_COMMANDS[input.harness.harness];
-        const sessionName = `provider-login-${input.harness.harness}-${hash.slice(0, 16)}`;
+        const sessionName = loginSessionName(input.mutation.idempotencyKey);
         const attempt = ProviderConnectionAttemptSchema.parse({
           id: `attempt_${hash.slice(0, 24)}`,
           harnessInstanceId: input.mutation.harnessInstanceId,
@@ -161,6 +180,35 @@ export function createProviderTerminalLoginCoordinator(options: {
           expiresAt: new Date(now().getTime() + LOGIN_LIFETIME_MS).toISOString(),
           safeFailure: null,
         });
+        const receipt = ReceiptSchema.parse({
+          key: input.mutation.idempotencyKey,
+          payloadHash: hash,
+          attempt,
+        });
+        try {
+          await options.registry.get(sessionName);
+          try {
+            await options.registry.delete(sessionName, { force: true });
+          } catch (error) {
+            console.warn(
+              "[provider-login] Failed to reconcile unrecorded login session:",
+              error instanceof Error ? error.name : "UnknownError",
+            );
+            throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+          }
+        } catch (error) {
+          if (!isMissingSession(error)) throw error;
+        }
+        appendBoundedReceipt(recoveryDocument, receipt);
+        try {
+          await writeProviderJsonAtomic(recoveryPath, ReceiptDocumentSchema.parse(recoveryDocument));
+        } catch (error) {
+          console.warn(
+            "[provider-login] Failed to persist login recovery metadata:",
+            error instanceof Error ? error.name : "UnknownError",
+          );
+          throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+        }
         const session = await options.registry.create({
           name: sessionName,
           cwd: "~",
@@ -171,23 +219,18 @@ export function createProviderTerminalLoginCoordinator(options: {
         if (session.name !== sessionName) {
           throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
         }
-        document.receipts.push({
-          key: input.mutation.idempotencyKey,
-          payloadHash: hash,
-          attempt,
-        });
-        if (document.receipts.length > MAX_RECEIPTS) {
-          document.receipts.splice(0, document.receipts.length - MAX_RECEIPTS);
-        }
+        appendBoundedReceipt(document, receipt);
         try {
           await persistReceipt(receiptsPath, ReceiptDocumentSchema.parse(document));
         } catch (error) {
-          await options.registry.delete(sessionName, { force: true }).catch((cleanupError: unknown) => {
+          try {
+            await options.registry.delete(sessionName, { force: true });
+          } catch (cleanupError) {
             console.warn(
               "[provider-login] Failed to clean up unrecorded login session:",
               cleanupError instanceof Error ? cleanupError.name : "UnknownError",
             );
-          });
+          }
           console.warn(
             "[provider-login] Failed to persist login receipt:",
             error instanceof Error ? error.name : "UnknownError",

--- a/packages/gateway/src/ai-providers/service.ts
+++ b/packages/gateway/src/ai-providers/service.ts
@@ -1,6 +1,7 @@
 import {
   AiProviderReadinessSchema,
   AiProviderSnapshotV3Schema,
+  AiProviderDriverViewSchema,
   type AiAccessSourceView,
   type AiProviderAccountView,
   type AiProviderReadiness,
@@ -41,6 +42,7 @@ interface AiProviderServiceOptions {
   healthProbe?: AiProviderHealthProbe;
   healthCache?: ProviderHealthCache<AiProviderReadiness>;
   healthTimeoutMs?: number;
+  driverInventory?: (signal: AbortSignal) => Promise<AiProviderSnapshotV3["drivers"]>;
 }
 
 function readinessForObservation(
@@ -111,6 +113,7 @@ export class AiProviderService implements AiProviderSnapshotReader {
   readonly #healthCache: ProviderHealthCache<AiProviderReadiness>;
   readonly #ownsHealthCache: boolean;
   readonly #healthTimeoutMs: number;
+  readonly #driverInventory?: AiProviderServiceOptions["driverInventory"];
 
   constructor(options: AiProviderServiceOptions) {
     if (!options.homePath) throw new Error("AI provider home path is required");
@@ -126,6 +129,48 @@ export class AiProviderService implements AiProviderSnapshotReader {
       1,
       Math.min(options.healthTimeoutMs ?? HEALTH_TIMEOUT_MS, HEALTH_TIMEOUT_MS),
     );
+    this.#driverInventory = options.driverInventory;
+  }
+
+  async #drivers(): Promise<AiProviderSnapshotV3["drivers"]> {
+    const kernel = AiProviderDriverViewSchema.parse({
+      id: "kernel",
+      displayName: "Matrix Agent",
+      kind: "agent_sdk",
+      installState: "installed",
+      health: "ready",
+      capabilities: [...KERNEL_CAPABILITIES],
+      setupActions: [],
+    });
+    if (!this.#driverInventory) return [kernel];
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const deadline = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          controller.abort();
+          reject(new Error("Driver inventory timed out"));
+        }, 6_000);
+      });
+      const discovered = AiProviderDriverViewSchema.array().max(19).parse(
+        await Promise.race([this.#driverInventory(controller.signal), deadline]),
+      );
+      const seen = new Set([kernel.id]);
+      const unique = discovered.filter((driver) => {
+        if (seen.has(driver.id)) return false;
+        seen.add(driver.id);
+        return true;
+      });
+      return [kernel, ...unique];
+    } catch (error) {
+      console.warn(
+        "[ai-providers] Driver inventory unavailable:",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+      return [kernel];
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
   }
 
   async #resolveOwnerReadiness(
@@ -315,15 +360,7 @@ export class AiProviderService implements AiProviderSnapshotReader {
       refreshedAt: now,
       accessSources,
       accounts,
-      drivers: [{
-        id: "kernel",
-        displayName: "Matrix Agent",
-        kind: "agent_sdk",
-        installState: "installed",
-        health: "ready",
-        capabilities: [...KERNEL_CAPABILITIES],
-        setupActions: [],
-      }],
+      drivers: await this.#drivers(),
       instances,
       models: catalog,
       active,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -237,6 +237,8 @@ import { AiProviderService } from "./ai-providers/service.js";
 import { createAiProviderRoutes } from "./ai-providers/routes.js";
 import { ProviderSettingsStore } from "./ai-providers/provider-settings-store.js";
 import { createProviderSettingsRoutes } from "./ai-providers/provider-settings-routes.js";
+import { createProviderDriverInventoryReader } from "./ai-providers/provider-driver-inventory.js";
+import { createProviderTerminalLoginCoordinator } from "./ai-providers/provider-terminal-login-coordinator.js";
 import { createHermesRoutes } from "./routes/hermes.js";
 import {
   createHermesDashboardClient,
@@ -4154,10 +4156,24 @@ export async function createGateway(config: GatewayConfig) {
     client: hermesClient,
   });
   await agentRuntimeServices.controller.reconcile();
-  const aiProviderService = new AiProviderService({ homePath });
+  const aiProviderService = new AiProviderService({
+    homePath,
+    driverInventory: createProviderDriverInventoryReader({
+      detectAgentInstallations: agentCredentialLauncher.detectAgentInstallations,
+      runtimeSource: agentRuntimeServices.source,
+    }),
+  });
+  const providerLoginCoordinator = createProviderTerminalLoginCoordinator({
+    homePath,
+    registry: zellijShellRegistry,
+    enabledHarnesses: codingAgentWorkspaceAgents.filter(
+      (agent): agent is "codex" | "claude" => agent === "codex" || agent === "claude",
+    ),
+  });
   const providerSettingsStore = new ProviderSettingsStore({
     homePath,
     providerSnapshotReader: aiProviderService,
+    loginCoordinator: providerLoginCoordinator,
   });
   const canonicalExecutableDriverKinds = [
     "kernel" as const,

--- a/packages/gateway/src/shell/registry.ts
+++ b/packages/gateway/src/shell/registry.ts
@@ -114,6 +114,7 @@ type RegistryFile = z.infer<typeof RegistryFileSchema>;
 type ShellSessionReference = z.infer<typeof ShellSessionReferenceSchema>;
 export type ShellPlacement = z.infer<typeof ShellPlacementSchema>;
 export type ShellVisualStatus = z.infer<typeof ShellVisualStatusSchema>;
+export type ShellAgentLiveness = "running" | "stopped" | "unknown";
 export type ShellSessionAliasSource = z.infer<typeof ShellSessionReferenceSourceSchema>;
 export interface ShellSessionAlias {
   name: string;
@@ -248,6 +249,30 @@ export class ShellRegistry {
         await this.write(file);
       }
       return this.decorateSession(session, file);
+    });
+  }
+
+  async observeAgentLiveness(name: string, agent: AgentKind): Promise<ShellAgentLiveness> {
+    return this.withMutationLock(async () => {
+      const safeName = validateSessionName(name);
+      const file = await this.read();
+      const targetName = this.resolveSessionName(file, safeName);
+      const live = await this.options.adapter.listSessions();
+      if (!live.includes(targetName)) {
+        throw shellError("session_not_found", "Session not found", 404);
+      }
+      const [runtime, snapshot] = await Promise.all([
+        this.readFocusedPaneRuntime(targetName),
+        this.readAgentSnapshot(targetName),
+      ]);
+      if (!runtime.observed) return "unknown";
+      const observedAgent = inferAgentFromCommand(runtime.command ?? undefined);
+      if (observedAgent) return observedAgent === agent ? "running" : "stopped";
+      const executable = runtime.command?.trim().split(/\s+/, 1)[0]?.split("/").pop();
+      if (executable !== "matrix-terminal-shell") return "stopped";
+      return snapshot && snapshot.agent === agent && snapshot.phase !== "ended"
+        ? "running"
+        : "unknown";
     });
   }
 

--- a/tests/contracts/provider-settings.test.ts
+++ b/tests/contracts/provider-settings.test.ts
@@ -150,6 +150,12 @@ describe("provider settings contracts", () => {
       ...makeSnapshot(),
       projectionOf: { contract: "AiProviderSnapshotV3", contractVersion: 3, revision: 11 },
     }).success).toBe(true);
+    const unavailableLogin = makeSnapshot();
+    unavailableLogin.harnesses[0]!.loginMethods = [];
+    unavailableLogin.harnesses[0]!.recommendedLoginMethod = null;
+    expect(ProviderSettingsSnapshotSchema.safeParse(unavailableLogin).success).toBe(true);
+    unavailableLogin.harnesses[0]!.recommendedLoginMethod = "terminal";
+    expect(ProviderSettingsSnapshotSchema.safeParse(unavailableLogin).success).toBe(false);
   });
 
   it("keeps accounts owner-funded, opaque, reciprocal, and secret-free", () => {

--- a/tests/gateway/ai-provider-service.test.ts
+++ b/tests/gateway/ai-provider-service.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { AiProviderSnapshotV3Schema } from "@matrix-os/contracts";
+import { AiProviderSnapshotV3Schema, type AiProviderSnapshotV3 } from "@matrix-os/contracts";
 import {
   AiProviderService,
   type AiProviderHealthProbe,
@@ -27,6 +27,7 @@ describe("AiProviderService", () => {
     fundedEnabled?: boolean;
     healthProbe?: AiProviderHealthProbe;
     healthTimeoutMs?: number;
+    driverInventory?: () => Promise<AiProviderSnapshotV3["drivers"]>;
   } = {}) {
     return new AiProviderService({
       homePath,
@@ -37,6 +38,9 @@ describe("AiProviderService", () => {
       now: () => NOW,
       healthProbe: options.healthProbe,
       healthTimeoutMs: options.healthTimeoutMs,
+      driverInventory: options.driverInventory === undefined
+        ? undefined
+        : async () => options.driverInventory!(),
     });
   }
 
@@ -66,6 +70,22 @@ describe("AiProviderService", () => {
       modelId: "claude-sonnet-5",
     });
     expect(JSON.stringify(snapshot)).not.toContain("platform-secret");
+  });
+
+  it("adds only validated real driver inventory while keeping the kernel driver canonical", async () => {
+    const snapshot = await createService({
+      driverInventory: async () => [{
+        id: "codex",
+        displayName: "Codex",
+        kind: "cli",
+        installState: "installed",
+        health: "ready",
+        capabilities: ["tools", "resume", "project_context"],
+        setupActions: ["connect_account", "open_terminal"],
+      }],
+    }).getSnapshot();
+    expect(snapshot.drivers.map((driver) => driver.id)).toEqual(["kernel", "codex"]);
+    expect(AiProviderSnapshotV3Schema.safeParse(snapshot).success).toBe(true);
   });
 
   it("does not label a legacy platform key as Matrix-funded access", async () => {

--- a/tests/gateway/provider-settings-driver-inventory.test.ts
+++ b/tests/gateway/provider-settings-driver-inventory.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { createProviderDriverInventoryReader } from "../../packages/gateway/src/ai-providers/provider-driver-inventory.js";
+
+describe("provider settings driver inventory", () => {
+  it("maps the existing runtime and executable probes into the six real harness drivers", async () => {
+    const detectAgentInstallations = vi.fn(async () => ({
+      agents: [
+        { id: "claude", command: "claude", displayName: "Claude", installState: "installed", installed: true, authState: "ok", workspaceCompatibility: "not_applicable", version: "2.1.251", errorCode: null },
+        { id: "codex", command: "codex", displayName: "Codex", installState: "installed", installed: true, authState: "required", workspaceCompatibility: "compatible", version: "0.147.0", errorCode: null },
+        { id: "opencode", command: "opencode", displayName: "OpenCode", installState: "missing", installed: false, authState: "unknown", workspaceCompatibility: "not_applicable", errorCode: null },
+        { id: "pi", command: "pi", displayName: "Pi", installState: "unknown", installed: null, authState: "unknown", workspaceCompatibility: "not_applicable", errorCode: null },
+      ],
+    }));
+    const runtimeSource = vi.fn(async () => ({
+      runtime: {
+        selected: "hermes" as const,
+        transition: null,
+        options: [
+          { id: "hermes" as const, displayName: "Hermes", installState: "installed" as const, health: "healthy" as const, selectionState: "active" as const, configured: true, capabilities: ["provider_catalog" as const, "model_selection" as const] },
+          { id: "openclaw" as const, displayName: "OpenClaw", installState: "missing" as const, health: "stopped" as const, selectionState: "action_required" as const, configured: false, capabilities: ["install" as const], setupAction: "install" as const },
+        ],
+      },
+      providers: [],
+      messaging: { runtime: "hermes" as const, provider: "anthropic", model: "claude-sonnet-5", configured: true },
+    }));
+    const read = createProviderDriverInventoryReader({ detectAgentInstallations, runtimeSource });
+    const drivers = await read(AbortSignal.timeout(1_000));
+
+    expect(drivers.map((driver) => driver.id)).toEqual([
+      "hermes", "openclaw", "claude_code", "codex", "opencode", "pi",
+    ]);
+    expect(drivers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "hermes", installState: "installed", health: "ready" }),
+      expect.objectContaining({ id: "openclaw", installState: "missing", setupActions: ["install"] }),
+      expect.objectContaining({ id: "claude_code", installState: "installed", health: "ready", setupActions: [] }),
+      expect.objectContaining({ id: "codex", installState: "installed", health: "stopped", setupActions: ["connect_account", "open_terminal"] }),
+      expect.objectContaining({ id: "opencode", installState: "missing", setupActions: ["install"] }),
+    ]));
+  });
+
+  it("verifies both canonical inventory dependencies at registration time", () => {
+    expect(() => createProviderDriverInventoryReader({
+      detectAgentInstallations: undefined as never,
+      runtimeSource: vi.fn(),
+    })).toThrow("Agent installation inventory is required");
+    expect(() => createProviderDriverInventoryReader({
+      detectAgentInstallations: vi.fn(),
+      runtimeSource: undefined as never,
+    })).toThrow("Agent runtime inventory is required");
+  });
+});

--- a/tests/gateway/provider-settings-login-coordinator.test.ts
+++ b/tests/gateway/provider-settings-login-coordinator.test.ts
@@ -237,7 +237,64 @@ describe("provider terminal login coordinator", () => {
         installState: "installed",
       },
     })).rejects.toMatchObject({ code: "lifecycle_unavailable" });
-    expect(registry.delete).toHaveBeenCalledWith(expect.stringMatching(/^provider-login-claude-/), { force: true });
+    expect(registry.delete).toHaveBeenCalledWith(expect.stringMatching(/^provider-login-[a-f0-9]{24}$/), { force: true });
     expect(sessions.size).toBe(0);
+  });
+
+  it("recovers an orphan after receipt and deletion failures without launching a changed retry", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const persistReceipt = vi.fn(async () => {
+      throw new Error("disk unavailable with secret-provider-token");
+    });
+    registry.delete.mockRejectedValueOnce(new Error("delete failed with secret-provider-token"));
+    const input = {
+      mutation: {
+        type: "start_login" as const,
+        expectedRevision: 0,
+        idempotencyKey: "login_orphan_recovery_1",
+        harnessInstanceId: "harness_claude",
+        accountId: null,
+        method: "terminal" as const,
+      },
+      harness: {
+        id: "harness_claude",
+        driverId: "claude_code",
+        harness: "claude" as const,
+        providerId: "anthropic",
+        modelId: "claude-sonnet-5",
+        installState: "installed" as const,
+      },
+    };
+    const failed = createProviderTerminalLoginCoordinator({
+      homePath,
+      registry,
+      enabledHarnesses: ["claude"],
+      now: () => now,
+      persistReceipt,
+    });
+
+    await expect(failed.startLogin(input)).rejects.toMatchObject({ code: "lifecycle_unavailable" });
+    expect(sessions.size).toBe(1);
+    expect(registry.create).toHaveBeenCalledOnce();
+    const orphanName = [...sessions][0];
+    expect(orphanName).toMatch(/^provider-login-[a-f0-9]{24}$/);
+
+    const recovery = await readFile(join(homePath, "system/ai-providers/login-recovery.json"), "utf8");
+    expect(recovery).toContain("login_orphan_recovery_1");
+    expect(recovery).toContain(orphanName);
+    expect(recovery).not.toMatch(/secret-provider-token|sh -lc|claude-sonnet-5/i);
+    expect(JSON.stringify(warning.mock.calls)).not.toContain("secret-provider-token");
+
+    const restarted = coordinator(["claude"]);
+    await expect(restarted.startLogin({
+      ...input,
+      harness: { ...input.harness, modelId: "claude-opus-5" },
+    })).rejects.toMatchObject({ code: "idempotency_conflict" });
+    expect(registry.create).toHaveBeenCalledOnce();
+
+    const recovered = await restarted.startLogin(input);
+    expect(recovered.action).toEqual({ kind: "open_terminal", terminalSessionId: orphanName });
+    expect(registry.create).toHaveBeenCalledOnce();
+    expect(sessions).toEqual(new Set([orphanName]));
   });
 });

--- a/tests/gateway/provider-settings-login-coordinator.test.ts
+++ b/tests/gateway/provider-settings-login-coordinator.test.ts
@@ -257,6 +257,65 @@ describe("provider terminal login coordinator", () => {
     expect(registry.delete).not.toHaveBeenCalled();
   });
 
+  it("renews an expired same-key recovery receipt after the initial terminal create fails", async () => {
+    let checkedAt = new Date(now);
+    const login = createProviderTerminalLoginCoordinator({
+      homePath,
+      registry,
+      enabledHarnesses: ["claude"],
+      now: () => new Date(checkedAt),
+    });
+    const input = {
+      mutation: {
+        type: "start_login" as const,
+        expectedRevision: 0,
+        idempotencyKey: "login_create_failure_retry",
+        harnessInstanceId: "harness_claude",
+        accountId: "owner_anthropic",
+        method: "terminal" as const,
+      },
+      harness: {
+        id: "harness_claude",
+        driverId: "claude_code",
+        harness: "claude" as const,
+        providerId: "anthropic",
+        modelId: "claude-sonnet-5",
+        installState: "installed" as const,
+      },
+    };
+    registry.create.mockRejectedValueOnce(new Error("terminal create unavailable"));
+
+    await expect(login.startLogin(input)).rejects.toThrow("terminal create unavailable");
+    checkedAt = new Date(now.getTime() + 10 * 60_000 + 1);
+
+    const retried = await login.startLogin(input);
+
+    expect(retried).toMatchObject({
+      state: "pending",
+      harnessInstanceId: input.mutation.harnessInstanceId,
+      accountId: input.mutation.accountId,
+      method: input.mutation.method,
+      action: { kind: "open_terminal" },
+    });
+    expect(Date.parse(retried.expiresAt) - checkedAt.getTime()).toBe(10 * 60_000);
+    expect(registry.create).toHaveBeenCalledTimes(2);
+    expect(sessions).toEqual(new Set([
+      retried.action.kind === "open_terminal" ? retried.action.terminalSessionId : "",
+    ]));
+
+    for (const file of ["login-recovery.json", "login-receipts.json"]) {
+      const document = JSON.parse(await readFile(
+        join(homePath, "system/ai-providers", file),
+        "utf8",
+      )) as { receipts: Array<{ key: string; attempt: unknown }> };
+      expect(document.receipts).toHaveLength(1);
+      expect(document.receipts).toContainEqual(expect.objectContaining({
+        key: input.mutation.idempotencyKey,
+        attempt: retried,
+      }));
+    }
+  });
+
   it("rejects unsupported methods and idempotency-key payload conflicts before launch", async () => {
     const login = coordinator();
     const base = {

--- a/tests/gateway/provider-settings-login-coordinator.test.ts
+++ b/tests/gateway/provider-settings-login-coordinator.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createProviderTerminalLoginCoordinator,
 } from "../../packages/gateway/src/ai-providers/provider-terminal-login-coordinator.js";
+import { SESSION_NAME_PATTERN } from "../../packages/gateway/src/shell/names.js";
 
 describe("provider terminal login coordinator", () => {
   let homePath: string;
@@ -39,6 +40,9 @@ describe("provider terminal login coordinator", () => {
       if (agent) runningAgents.set(nextName, agent);
       return { name: nextName, agent };
     }),
+    observeAgentLiveness: vi.fn(async (name: string, agent: "codex" | "claude") => (
+      runningAgents.get(name) === agent ? "running" as const : "unknown" as const
+    )),
   };
 
   beforeEach(async () => {
@@ -49,6 +53,7 @@ describe("provider terminal login coordinator", () => {
     registry.create.mockClear();
     registry.delete.mockClear();
     registry.rename.mockClear();
+    registry.observeAgentLiveness.mockClear();
   });
 
   afterEach(async () => {
@@ -100,6 +105,10 @@ describe("provider terminal login coordinator", () => {
       safeFailure: null,
     });
     expect(Date.parse(attempt.expiresAt) - now.getTime()).toBe(10 * 60_000);
+    expect(attempt.action.kind === "open_terminal" && attempt.action.terminalSessionId)
+      .toMatch(SESSION_NAME_PATTERN);
+    expect(attempt.action.kind === "open_terminal" && attempt.action.terminalSessionId.length)
+      .toBeLessThanOrEqual(64);
     expect(registry.create).toHaveBeenCalledWith(expect.objectContaining({
       name: attempt.action.kind === "open_terminal" ? attempt.action.terminalSessionId : "",
       cwd: "~",
@@ -397,7 +406,7 @@ describe("provider terminal login coordinator", () => {
         installState: "installed",
       },
     })).rejects.toMatchObject({ code: "lifecycle_unavailable" });
-    expect(registry.delete).toHaveBeenCalledWith(expect.stringMatching(/^provider-login-[a-f0-9]{64}$/), { force: true });
+    expect(registry.delete).toHaveBeenCalledWith(expect.stringMatching(/^provider-auth-[a-z0-9]{50}$/), { force: true });
     expect(sessions.size).toBe(0);
   });
 
@@ -437,7 +446,7 @@ describe("provider terminal login coordinator", () => {
     expect(sessions.size).toBe(1);
     expect(registry.create).toHaveBeenCalledOnce();
     const orphanName = [...sessions][0];
-    expect(orphanName).toMatch(/^provider-login-[a-f0-9]{64}$/);
+    expect(orphanName).toMatch(/^provider-auth-[a-z0-9]{50}$/);
 
     const recovery = await readFile(join(homePath, "system/ai-providers/login-recovery.json"), "utf8");
     expect(recovery).toContain("login_orphan_recovery_1");

--- a/tests/gateway/provider-settings-login-coordinator.test.ts
+++ b/tests/gateway/provider-settings-login-coordinator.test.ts
@@ -22,6 +22,17 @@ describe("provider terminal login coordinator", () => {
     delete: vi.fn(async (name: string) => {
       sessions.delete(name);
     }),
+    rename: vi.fn(async (name: string, nextName: string) => {
+      if (!sessions.delete(name)) {
+        throw Object.assign(new Error("missing"), { code: "session_not_found" });
+      }
+      if (sessions.has(nextName)) {
+        sessions.add(name);
+        throw Object.assign(new Error("exists"), { code: "session_exists" });
+      }
+      sessions.add(nextName);
+      return { name: nextName };
+    }),
   };
 
   beforeEach(async () => {
@@ -30,6 +41,7 @@ describe("provider terminal login coordinator", () => {
     registry.get.mockClear();
     registry.create.mockClear();
     registry.delete.mockClear();
+    registry.rename.mockClear();
   });
 
   afterEach(async () => {
@@ -378,7 +390,7 @@ describe("provider terminal login coordinator", () => {
         installState: "installed",
       },
     })).rejects.toMatchObject({ code: "lifecycle_unavailable" });
-    expect(registry.delete).toHaveBeenCalledWith(expect.stringMatching(/^provider-login-[a-f0-9]{24}$/), { force: true });
+    expect(registry.delete).toHaveBeenCalledWith(expect.stringMatching(/^provider-login-[a-f0-9]{64}$/), { force: true });
     expect(sessions.size).toBe(0);
   });
 
@@ -418,7 +430,7 @@ describe("provider terminal login coordinator", () => {
     expect(sessions.size).toBe(1);
     expect(registry.create).toHaveBeenCalledOnce();
     const orphanName = [...sessions][0];
-    expect(orphanName).toMatch(/^provider-login-[a-f0-9]{24}$/);
+    expect(orphanName).toMatch(/^provider-login-[a-f0-9]{64}$/);
 
     const recovery = await readFile(join(homePath, "system/ai-providers/login-recovery.json"), "utf8");
     expect(recovery).toContain("login_orphan_recovery_1");

--- a/tests/gateway/provider-settings-login-coordinator.test.ts
+++ b/tests/gateway/provider-settings-login-coordinator.test.ts
@@ -1,0 +1,243 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createProviderTerminalLoginCoordinator,
+} from "../../packages/gateway/src/ai-providers/provider-terminal-login-coordinator.js";
+
+describe("provider terminal login coordinator", () => {
+  let homePath: string;
+  const now = new Date("2026-08-30T12:00:00.000Z");
+  const sessions = new Set<string>();
+  const registry = {
+    get: vi.fn(async (name: string) => {
+      if (!sessions.has(name)) throw Object.assign(new Error("missing"), { code: "session_not_found" });
+      return { name };
+    }),
+    create: vi.fn(async (input: { name: string }) => {
+      sessions.add(input.name);
+      return { name: input.name };
+    }),
+    delete: vi.fn(async (name: string) => {
+      sessions.delete(name);
+    }),
+  };
+
+  beforeEach(async () => {
+    homePath = await mkdtemp(join(tmpdir(), "provider-terminal-login-"));
+    sessions.clear();
+    registry.get.mockClear();
+    registry.create.mockClear();
+    registry.delete.mockClear();
+  });
+
+  afterEach(async () => {
+    await rm(homePath, { recursive: true, force: true });
+  });
+
+  function coordinator(enabledHarnesses: Array<"codex" | "claude"> = ["codex", "claude"]) {
+    return createProviderTerminalLoginCoordinator({
+      homePath,
+      registry,
+      enabledHarnesses,
+      now: () => now,
+    });
+  }
+
+  it("creates a visible canonical session with the allowlisted Codex device-login command", async () => {
+    const login = coordinator();
+    expect(login.supportedMethods({
+      id: "harness_codex",
+      driverId: "codex",
+      harness: "codex",
+      installState: "installed",
+    })).toEqual(["terminal"]);
+
+    const attempt = await login.startLogin({
+      mutation: {
+        type: "start_login",
+        expectedRevision: 0,
+        idempotencyKey: "login_codex_1",
+        harnessInstanceId: "harness_codex",
+        accountId: null,
+        method: "terminal",
+      },
+      harness: {
+        id: "harness_codex",
+        driverId: "codex",
+        harness: "codex",
+        providerId: "openai",
+        modelId: "gpt-5",
+        installState: "installed",
+      },
+    });
+
+    expect(attempt).toMatchObject({
+      harnessInstanceId: "harness_codex",
+      method: "terminal",
+      state: "pending",
+      action: { kind: "open_terminal" },
+      safeFailure: null,
+    });
+    expect(Date.parse(attempt.expiresAt) - now.getTime()).toBe(10 * 60_000);
+    expect(registry.create).toHaveBeenCalledWith(expect.objectContaining({
+      name: attempt.action.kind === "open_terminal" ? attempt.action.terminalSessionId : "",
+      cwd: "~",
+      agent: "codex",
+      exclusive: false,
+      cmd: "sh -lc 'export MATRIX_NODE_PREFIX=\"${MATRIX_NODE_PREFIX:-/opt/matrix/runtime/node}\"; export PATH=\"$MATRIX_NODE_PREFIX/bin:$PATH\"; codex login --device-auth'",
+    }));
+  });
+
+  it("supports only installed, server-enabled Codex and Claude terminal login", () => {
+    const login = coordinator(["claude"]);
+    expect(login.supportedMethods({
+      id: "harness_kernel",
+      driverId: "kernel",
+      harness: "claude",
+      installState: "installed",
+    })).toEqual([]);
+    expect(login.supportedMethods({
+      id: "harness_kernel",
+      driverId: "claude_code",
+      harness: "claude",
+      installState: "installed",
+    })).toEqual(["terminal"]);
+    expect(login.supportedMethods({
+      id: "harness_codex",
+      driverId: "codex",
+      harness: "codex",
+      installState: "installed",
+    })).toEqual([]);
+    expect(login.supportedMethods({
+      id: "harness_claude",
+      driverId: "claude_code",
+      harness: "claude",
+      installState: "missing",
+    })).toEqual([]);
+    expect(login.supportedMethods({
+      id: "harness_opencode",
+      driverId: "opencode",
+      harness: "opencode",
+      installState: "installed",
+    })).toEqual([]);
+  });
+
+  it("refuses to launch a configured harness when the canonical CLI driver is not installed", async () => {
+    const login = coordinator(["claude"]);
+    await expect(login.startLogin({
+      mutation: {
+        type: "start_login",
+        expectedRevision: 0,
+        idempotencyKey: "missing_claude_1",
+        harnessInstanceId: "harness_kernel",
+        accountId: null,
+        method: "terminal",
+      },
+      harness: {
+        id: "harness_kernel",
+        driverId: "claude_code",
+        harness: "claude",
+        providerId: "anthropic",
+        modelId: "claude-sonnet-5",
+        installState: "missing",
+      },
+    })).rejects.toMatchObject({ code: "lifecycle_unavailable" });
+    expect(registry.create).not.toHaveBeenCalled();
+  });
+
+  it("durably deduplicates a login key and adopts the same real session after restart", async () => {
+    const input = {
+      mutation: {
+        type: "start_login" as const,
+        expectedRevision: 0,
+        idempotencyKey: "login_claude_1",
+        harnessInstanceId: "harness_kernel",
+        accountId: null,
+        method: "terminal" as const,
+      },
+      harness: {
+        id: "harness_kernel",
+        driverId: "claude_code",
+        harness: "claude" as const,
+        providerId: "anthropic",
+        modelId: "claude-sonnet-5",
+        installState: "installed" as const,
+      },
+    };
+    const first = await coordinator().startLogin(input);
+    const second = await coordinator().startLogin(input);
+    expect(second).toEqual(first);
+    expect(registry.create).toHaveBeenCalledOnce();
+    const receipts = await readFile(join(homePath, "system/ai-providers/login-receipts.json"), "utf8");
+    expect(receipts).toContain("login_claude_1");
+    expect(receipts).not.toMatch(/token|secret|apiKey/i);
+  });
+
+  it("rejects unsupported methods and idempotency-key payload conflicts before launch", async () => {
+    const login = coordinator();
+    const base = {
+      mutation: {
+        type: "start_login" as const,
+        expectedRevision: 0,
+        idempotencyKey: "login_conflict_1",
+        harnessInstanceId: "harness_kernel",
+        accountId: null,
+        method: "terminal" as const,
+      },
+      harness: {
+        id: "harness_kernel",
+        driverId: "claude_code",
+        harness: "claude" as const,
+        providerId: "anthropic",
+        modelId: "claude-sonnet-5",
+        installState: "installed" as const,
+      },
+    };
+    await login.startLogin(base);
+    await expect(login.startLogin({
+      ...base,
+      mutation: { ...base.mutation, harnessInstanceId: "harness_other" },
+      harness: { ...base.harness, id: "harness_other" },
+    })).rejects.toMatchObject({ code: "idempotency_conflict" });
+    await expect(login.startLogin({
+      ...base,
+      mutation: { ...base.mutation, idempotencyKey: "login_oauth_1", method: "oauth" },
+    })).rejects.toMatchObject({ code: "lifecycle_unavailable" });
+    expect(registry.create).toHaveBeenCalledOnce();
+  });
+
+  it("deletes a newly-created login session when receipt persistence fails", async () => {
+    const persistReceipt = vi.fn(async () => {
+      throw new Error("disk unavailable");
+    });
+    const login = createProviderTerminalLoginCoordinator({
+      homePath,
+      registry,
+      enabledHarnesses: ["claude"],
+      now: () => now,
+      persistReceipt,
+    });
+    await expect(login.startLogin({
+      mutation: {
+        type: "start_login",
+        expectedRevision: 0,
+        idempotencyKey: "login_persist_failure_1",
+        harnessInstanceId: "harness_claude",
+        accountId: null,
+        method: "terminal",
+      },
+      harness: {
+        id: "harness_claude",
+        driverId: "claude_code",
+        harness: "claude",
+        providerId: "anthropic",
+        modelId: "claude-sonnet-5",
+        installState: "installed",
+      },
+    })).rejects.toMatchObject({ code: "lifecycle_unavailable" });
+    expect(registry.delete).toHaveBeenCalledWith(expect.stringMatching(/^provider-login-claude-/), { force: true });
+    expect(sessions.size).toBe(0);
+  });
+});

--- a/tests/gateway/provider-settings-login-coordinator.test.ts
+++ b/tests/gateway/provider-settings-login-coordinator.test.ts
@@ -297,4 +297,109 @@ describe("provider terminal login coordinator", () => {
     expect(registry.create).toHaveBeenCalledOnce();
     expect(sessions).toEqual(new Set([orphanName]));
   });
+
+  it("adopts an orphan on a fresh-key retry without launching another login", async () => {
+    const persistReceipt = vi.fn(async () => {
+      throw new Error("disk unavailable");
+    });
+    registry.delete.mockRejectedValueOnce(new Error("delete unavailable"));
+    const input = {
+      mutation: {
+        type: "start_login" as const,
+        expectedRevision: 0,
+        idempotencyKey: "login_fresh_key_original",
+        harnessInstanceId: "harness_claude",
+        accountId: "owner_anthropic",
+        method: "terminal" as const,
+      },
+      harness: {
+        id: "harness_claude",
+        driverId: "claude_code",
+        harness: "claude" as const,
+        providerId: "anthropic",
+        modelId: "claude-sonnet-5",
+        installState: "installed" as const,
+      },
+    };
+    const failed = createProviderTerminalLoginCoordinator({
+      homePath,
+      registry,
+      enabledHarnesses: ["claude"],
+      now: () => now,
+      persistReceipt,
+    });
+
+    await expect(failed.startLogin(input)).rejects.toMatchObject({ code: "lifecycle_unavailable" });
+    const orphanName = [...sessions][0]!;
+    const recovered = await failed.startLogin({
+      ...input,
+      mutation: {
+        ...input.mutation,
+        expectedRevision: 1,
+        idempotencyKey: "login_fresh_key_retry",
+      },
+    });
+
+    expect(recovered.action).toEqual({ kind: "open_terminal", terminalSessionId: orphanName });
+    expect(registry.create).toHaveBeenCalledOnce();
+    expect(sessions).toEqual(new Set([orphanName]));
+  });
+
+  it("recovers a fresh-key orphan after restart and remembers its conflict hash", async () => {
+    const persistReceipt = vi.fn(async () => {
+      throw new Error("disk unavailable with secret-provider-token");
+    });
+    registry.delete.mockRejectedValueOnce(new Error("delete failed with secret-provider-token"));
+    const input = {
+      mutation: {
+        type: "start_login" as const,
+        expectedRevision: 0,
+        idempotencyKey: "login_restart_original",
+        harnessInstanceId: "harness_claude",
+        accountId: null,
+        method: "terminal" as const,
+      },
+      harness: {
+        id: "harness_claude",
+        driverId: "claude_code",
+        harness: "claude" as const,
+        providerId: "anthropic",
+        modelId: "claude-sonnet-5",
+        installState: "installed" as const,
+      },
+    };
+    const failed = createProviderTerminalLoginCoordinator({
+      homePath,
+      registry,
+      enabledHarnesses: ["claude"],
+      now: () => now,
+      persistReceipt,
+    });
+    await expect(failed.startLogin(input)).rejects.toMatchObject({ code: "lifecycle_unavailable" });
+    const orphanName = [...sessions][0]!;
+
+    const restarted = coordinator(["claude"]);
+    const freshInput = {
+      ...input,
+      mutation: {
+        ...input.mutation,
+        expectedRevision: 2,
+        idempotencyKey: "login_restart_fresh_key",
+      },
+    };
+    const recovered = await restarted.startLogin(freshInput);
+    expect(recovered.action).toEqual({ kind: "open_terminal", terminalSessionId: orphanName });
+    expect(registry.create).toHaveBeenCalledOnce();
+    expect(sessions).toEqual(new Set([orphanName]));
+
+    await expect(restarted.startLogin({
+      ...freshInput,
+      harness: { ...freshInput.harness, modelId: "claude-opus-5" },
+    })).rejects.toMatchObject({ code: "idempotency_conflict" });
+    expect(registry.create).toHaveBeenCalledOnce();
+
+    const recovery = await readFile(join(homePath, "system/ai-providers/login-recovery.json"), "utf8");
+    expect(recovery).toContain("login_restart_fresh_key");
+    expect(recovery).not.toMatch(/secret-provider-token|sh -lc|claude-sonnet-5/i);
+  });
 });

--- a/tests/gateway/provider-settings-login-coordinator.test.ts
+++ b/tests/gateway/provider-settings-login-coordinator.test.ts
@@ -175,6 +175,88 @@ describe("provider terminal login coordinator", () => {
     expect(receipts).not.toMatch(/token|secret|apiKey/i);
   });
 
+  it("adopts the exact live login session on a fresh-key retry after its receipt expires", async () => {
+    let checkedAt = new Date(now);
+    const login = createProviderTerminalLoginCoordinator({
+      homePath,
+      registry,
+      enabledHarnesses: ["claude"],
+      now: () => new Date(checkedAt),
+    });
+    const input = {
+      mutation: {
+        type: "start_login" as const,
+        expectedRevision: 0,
+        idempotencyKey: "login_expiring_original",
+        harnessInstanceId: "harness_claude",
+        accountId: "owner_anthropic",
+        method: "terminal" as const,
+      },
+      harness: {
+        id: "harness_claude",
+        driverId: "claude_code",
+        harness: "claude" as const,
+        providerId: "anthropic",
+        modelId: "claude-sonnet-5",
+        installState: "installed" as const,
+      },
+    };
+    const original = await login.startLogin(input);
+    expect(original.action.kind).toBe("open_terminal");
+
+    checkedAt = new Date(Date.parse(original.expiresAt) + 1);
+    let retried = await login.startLogin({
+      ...input,
+      mutation: {
+        ...input.mutation,
+        expectedRevision: 1,
+        idempotencyKey: "login_expiring_retry",
+      },
+    });
+
+    expect(retried).toMatchObject({
+      harnessInstanceId: input.mutation.harnessInstanceId,
+      accountId: input.mutation.accountId,
+      method: input.mutation.method,
+      state: "pending",
+      action: original.action,
+    });
+    expect(Date.parse(retried.expiresAt) - checkedAt.getTime()).toBe(10 * 60_000);
+    expect(registry.create).toHaveBeenCalledOnce();
+    expect(registry.delete).not.toHaveBeenCalled();
+    expect(sessions).toEqual(new Set([
+      original.action.kind === "open_terminal" ? original.action.terminalSessionId : "",
+    ]));
+
+    for (let retry = 2; retry <= 70; retry += 1) {
+      checkedAt = new Date(Date.parse(retried.expiresAt) + 1);
+      retried = await login.startLogin({
+        ...input,
+        mutation: {
+          ...input.mutation,
+          expectedRevision: retry,
+          idempotencyKey: `login_expiring_retry_${retry}`,
+        },
+      });
+      expect(retried.action).toEqual(original.action);
+    }
+
+    const receiptDocument = JSON.parse(await readFile(
+      join(homePath, "system/ai-providers/login-receipts.json"),
+      "utf8",
+    )) as { receipts: Array<{ key: string }> };
+    const recoveryDocument = JSON.parse(await readFile(
+      join(homePath, "system/ai-providers/login-recovery.json"),
+      "utf8",
+    )) as { receipts: Array<{ key: string }> };
+    expect(receiptDocument.receipts).toHaveLength(64);
+    expect(receiptDocument.receipts.at(-1)?.key).toBe("login_expiring_retry_70");
+    expect(recoveryDocument.receipts).toHaveLength(1);
+    expect(recoveryDocument.receipts[0]?.key).toBe("login_expiring_retry_70");
+    expect(registry.create).toHaveBeenCalledOnce();
+    expect(registry.delete).not.toHaveBeenCalled();
+  });
+
   it("rejects unsupported methods and idempotency-key payload conflicts before launch", async () => {
     const login = coordinator();
     const base = {

--- a/tests/gateway/provider-settings-login-coordinator.test.ts
+++ b/tests/gateway/provider-settings-login-coordinator.test.ts
@@ -10,17 +10,20 @@ describe("provider terminal login coordinator", () => {
   let homePath: string;
   const now = new Date("2026-08-30T12:00:00.000Z");
   const sessions = new Set<string>();
+  const runningAgents = new Map<string, "codex" | "claude">();
   const registry = {
     get: vi.fn(async (name: string) => {
       if (!sessions.has(name)) throw Object.assign(new Error("missing"), { code: "session_not_found" });
-      return { name };
+      return { name, agent: runningAgents.get(name) };
     }),
-    create: vi.fn(async (input: { name: string }) => {
+    create: vi.fn(async (input: { name: string; agent?: "codex" | "claude" }) => {
       sessions.add(input.name);
-      return { name: input.name };
+      if (input.agent) runningAgents.set(input.name, input.agent);
+      return { name: input.name, agent: input.agent };
     }),
     delete: vi.fn(async (name: string) => {
       sessions.delete(name);
+      runningAgents.delete(name);
     }),
     rename: vi.fn(async (name: string, nextName: string) => {
       if (!sessions.delete(name)) {
@@ -31,13 +34,17 @@ describe("provider terminal login coordinator", () => {
         throw Object.assign(new Error("exists"), { code: "session_exists" });
       }
       sessions.add(nextName);
-      return { name: nextName };
+      const agent = runningAgents.get(name);
+      runningAgents.delete(name);
+      if (agent) runningAgents.set(nextName, agent);
+      return { name: nextName, agent };
     }),
   };
 
   beforeEach(async () => {
     homePath = await mkdtemp(join(tmpdir(), "provider-terminal-login-"));
     sessions.clear();
+    runningAgents.clear();
     registry.get.mockClear();
     registry.create.mockClear();
     registry.delete.mockClear();

--- a/tests/gateway/provider-settings-login-legacy-migration.test.ts
+++ b/tests/gateway/provider-settings-login-legacy-migration.test.ts
@@ -1,0 +1,153 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createProviderTerminalLoginCoordinator,
+} from "../../packages/gateway/src/ai-providers/provider-terminal-login-coordinator.js";
+
+describe("provider terminal login legacy migration", () => {
+  let homePath: string;
+  const now = new Date("2026-08-30T12:00:00.000Z");
+  const sessions = new Set<string>();
+  const registry = {
+    get: vi.fn(async (name: string) => {
+      if (!sessions.has(name)) throw Object.assign(new Error("missing"), { code: "session_not_found" });
+      return { name };
+    }),
+    create: vi.fn(async (input: { name: string }) => {
+      sessions.add(input.name);
+      return { name: input.name };
+    }),
+    delete: vi.fn(async (name: string) => {
+      sessions.delete(name);
+    }),
+  };
+  const legacyInput = {
+    mutation: {
+      type: "start_login" as const,
+      expectedRevision: 0,
+      idempotencyKey: "login_legacy_original",
+      harnessInstanceId: "harness_claude",
+      accountId: "owner_anthropic",
+      method: "terminal" as const,
+    },
+    harness: {
+      id: "harness_claude",
+      driverId: "claude_code",
+      harness: "claude" as const,
+      providerId: "anthropic",
+      modelId: "claude-sonnet-5",
+      installState: "installed" as const,
+    },
+  };
+
+  beforeEach(async () => {
+    homePath = await mkdtemp(join(tmpdir(), "provider-terminal-login-legacy-"));
+    sessions.clear();
+    registry.get.mockClear();
+    registry.create.mockClear();
+    registry.delete.mockClear();
+  });
+
+  afterEach(async () => {
+    await rm(homePath, { recursive: true, force: true });
+  });
+
+  function coordinator() {
+    return createProviderTerminalLoginCoordinator({
+      homePath,
+      registry,
+      enabledHarnesses: ["claude"],
+      now: () => now,
+    });
+  }
+
+  async function seedLegacyLoginReceipt() {
+    const hash = createHash("sha256").update(JSON.stringify(legacyInput)).digest("hex");
+    const sessionName = `provider-login-claude-${hash.slice(0, 16)}`;
+    const receipt = {
+      key: legacyInput.mutation.idempotencyKey,
+      payloadHash: hash,
+      attempt: {
+        id: `attempt_${hash.slice(0, 24)}`,
+        harnessInstanceId: legacyInput.mutation.harnessInstanceId,
+        accountId: legacyInput.mutation.accountId,
+        method: legacyInput.mutation.method,
+        state: "pending",
+        action: { kind: "open_terminal", terminalSessionId: sessionName },
+        expiresAt: new Date(now.getTime() + 10 * 60_000).toISOString(),
+        safeFailure: null,
+      },
+    };
+    await mkdir(join(homePath, "system/ai-providers"), { recursive: true });
+    await writeFile(
+      join(homePath, "system/ai-providers/login-receipts.json"),
+      JSON.stringify({ version: 1, receipts: [receipt] }),
+    );
+    sessions.add(sessionName);
+    return { receipt, sessionName };
+  }
+
+  it("migrates a live legacy receipt on a fresh-key retry without duplicating its terminal", async () => {
+    const legacy = await seedLegacyLoginReceipt();
+
+    const recovered = await coordinator().startLogin({
+      ...legacyInput,
+      mutation: {
+        ...legacyInput.mutation,
+        expectedRevision: 1,
+        idempotencyKey: "login_legacy_fresh_key",
+      },
+    });
+
+    expect(recovered.action).toEqual({
+      kind: "open_terminal",
+      terminalSessionId: legacy.sessionName,
+    });
+    expect(registry.create).not.toHaveBeenCalled();
+    expect(sessions).toEqual(new Set([legacy.sessionName]));
+
+    const receipts = JSON.parse(await readFile(
+      join(homePath, "system/ai-providers/login-receipts.json"),
+      "utf8",
+    )) as { receipts: Array<{ key: string; recoveryHash?: string }> };
+    const upgraded = receipts.receipts.find((receipt) => receipt.key === legacy.receipt.key);
+    expect(upgraded?.recoveryHash).toMatch(/^[a-f0-9]{64}$/);
+
+    const recovery = JSON.parse(await readFile(
+      join(homePath, "system/ai-providers/login-recovery.json"),
+      "utf8",
+    )) as { receipts: Array<{ key: string; recoveryHash?: string }> };
+    expect(recovery.receipts).toContainEqual(expect.objectContaining({
+      key: "login_legacy_fresh_key",
+      recoveryHash: upgraded?.recoveryHash,
+    }));
+  });
+
+  it.each([
+    ["provider", { providerId: "openai", accountId: "owner_anthropic" }],
+    ["account", { providerId: "anthropic", accountId: "owner_other" }],
+  ])("does not migrate a legacy receipt across a changed %s identity", async (_field, changed) => {
+    const legacy = await seedLegacyLoginReceipt();
+
+    const attempt = await coordinator().startLogin({
+      ...legacyInput,
+      mutation: {
+        ...legacyInput.mutation,
+        expectedRevision: 1,
+        idempotencyKey: "login_legacy_isolation_fresh",
+        accountId: changed.accountId,
+      },
+      harness: { ...legacyInput.harness, providerId: changed.providerId },
+    });
+
+    expect(attempt.action).toMatchObject({ kind: "open_terminal" });
+    expect(attempt.action.kind === "open_terminal" && attempt.action.terminalSessionId)
+      .not.toBe(legacy.sessionName);
+    expect(registry.create).toHaveBeenCalledOnce();
+    expect(sessions).toContain(legacy.sessionName);
+    expect(sessions.size).toBe(2);
+  });
+});

--- a/tests/gateway/provider-settings-login-legacy-migration.test.ts
+++ b/tests/gateway/provider-settings-login-legacy-migration.test.ts
@@ -23,6 +23,17 @@ describe("provider terminal login legacy migration", () => {
     delete: vi.fn(async (name: string) => {
       sessions.delete(name);
     }),
+    rename: vi.fn(async (name: string, nextName: string) => {
+      if (!sessions.delete(name)) {
+        throw Object.assign(new Error("missing"), { code: "session_not_found" });
+      }
+      if (sessions.has(nextName)) {
+        sessions.add(name);
+        throw Object.assign(new Error("exists"), { code: "session_exists" });
+      }
+      sessions.add(nextName);
+      return { name: nextName };
+    }),
   };
   const legacyInput = {
     mutation: {
@@ -49,6 +60,7 @@ describe("provider terminal login legacy migration", () => {
     registry.get.mockClear();
     registry.create.mockClear();
     registry.delete.mockClear();
+    registry.rename.mockClear();
   });
 
   afterEach(async () => {
@@ -102,12 +114,16 @@ describe("provider terminal login legacy migration", () => {
       },
     });
 
-    expect(recovered.action).toEqual({
+    expect(recovered.action).toMatchObject({
       kind: "open_terminal",
-      terminalSessionId: legacy.sessionName,
+      terminalSessionId: expect.stringMatching(/^provider-login-[a-f0-9]{64}$/),
     });
+    const recoveredSessionName = recovered.action.kind === "open_terminal"
+      ? recovered.action.terminalSessionId
+      : "";
     expect(registry.create).not.toHaveBeenCalled();
-    expect(sessions).toEqual(new Set([legacy.sessionName]));
+    expect(registry.rename).toHaveBeenCalledWith(legacy.sessionName, recoveredSessionName);
+    expect(sessions).toEqual(new Set([recoveredSessionName]));
 
     const receipts = JSON.parse(await readFile(
       join(homePath, "system/ai-providers/login-receipts.json"),
@@ -138,12 +154,16 @@ describe("provider terminal login legacy migration", () => {
       },
     });
 
-    expect(recovered.action).toEqual({
+    expect(recovered.action).toMatchObject({
       kind: "open_terminal",
-      terminalSessionId: legacy.sessionName,
+      terminalSessionId: expect.stringMatching(/^provider-login-[a-f0-9]{64}$/),
     });
+    const recoveredSessionName = recovered.action.kind === "open_terminal"
+      ? recovered.action.terminalSessionId
+      : "";
     expect(registry.create).not.toHaveBeenCalled();
-    expect(sessions).toEqual(new Set([legacy.sessionName]));
+    expect(registry.rename).toHaveBeenCalledWith(legacy.sessionName, recoveredSessionName);
+    expect(sessions).toEqual(new Set([recoveredSessionName]));
   });
 
   it("renews an expired migrated legacy session without creating a canonical duplicate", async () => {
@@ -163,10 +183,13 @@ describe("provider terminal login legacy migration", () => {
         idempotencyKey: "login_legacy_migrated_key",
       },
     });
-    expect(migrated.action).toEqual({
+    expect(migrated.action).toMatchObject({
       kind: "open_terminal",
-      terminalSessionId: legacy.sessionName,
+      terminalSessionId: expect.stringMatching(/^provider-login-[a-f0-9]{64}$/),
     });
+    const migratedSessionName = migrated.action.kind === "open_terminal"
+      ? migrated.action.terminalSessionId
+      : "";
 
     checkedAt = new Date(Date.parse(migrated.expiresAt) + 1);
     const renewed = await login.startLogin({
@@ -180,7 +203,7 @@ describe("provider terminal login legacy migration", () => {
 
     expect(renewed).toMatchObject({
       state: "pending",
-      action: { kind: "open_terminal", terminalSessionId: legacy.sessionName },
+      action: { kind: "open_terminal", terminalSessionId: migratedSessionName },
     });
     expect(Date.parse(renewed.expiresAt) - checkedAt.getTime()).toBe(10 * 60_000);
 
@@ -195,7 +218,7 @@ describe("provider terminal login legacy migration", () => {
     });
     expect(sameKeyRenewal.action).toEqual({
       kind: "open_terminal",
-      terminalSessionId: legacy.sessionName,
+      terminalSessionId: migratedSessionName,
     });
 
     let latest = sameKeyRenewal;
@@ -211,7 +234,7 @@ describe("provider terminal login legacy migration", () => {
       });
       expect(latest.action).toEqual({
         kind: "open_terminal",
-        terminalSessionId: legacy.sessionName,
+        terminalSessionId: migratedSessionName,
       });
     }
 
@@ -227,7 +250,81 @@ describe("provider terminal login legacy migration", () => {
     expect(recovery.receipts).toHaveLength(1);
     expect(registry.create).not.toHaveBeenCalled();
     expect(registry.delete).not.toHaveBeenCalled();
-    expect(sessions).toEqual(new Set([legacy.sessionName]));
+    expect(registry.rename).toHaveBeenCalledOnce();
+    expect(sessions).toEqual(new Set([migratedSessionName]));
+  });
+
+  it("keeps a migrated legacy identity recoverable after both bounded receipt documents evict it", async () => {
+    const legacy = await seedLegacyLoginReceipt();
+    let checkedAt = new Date(now);
+    const login = createProviderTerminalLoginCoordinator({
+      homePath,
+      registry,
+      enabledHarnesses: ["claude"],
+      now: () => new Date(checkedAt),
+    });
+    const migrated = await login.startLogin({
+      ...legacyInput,
+      mutation: {
+        ...legacyInput.mutation,
+        expectedRevision: 1,
+        idempotencyKey: "login_legacy_migrated_durable",
+      },
+    });
+    expect(migrated.action).toMatchObject({
+      kind: "open_terminal",
+      terminalSessionId: expect.stringMatching(/^provider-login-[a-f0-9]{64}$/),
+    });
+    const migratedSessionName = migrated.action.kind === "open_terminal"
+      ? migrated.action.terminalSessionId
+      : "";
+    expect(migratedSessionName).not.toBe(legacy.sessionName);
+    expect(registry.rename).toHaveBeenCalledWith(legacy.sessionName, migratedSessionName);
+    expect(sessions).toContain(migratedSessionName);
+    expect(sessions).not.toContain(legacy.sessionName);
+
+    for (let index = 0; index < 65; index += 1) {
+      await login.startLogin({
+        ...legacyInput,
+        mutation: {
+          ...legacyInput.mutation,
+          expectedRevision: index + 2,
+          idempotencyKey: `login_eviction_${index}`,
+          accountId: `owner_other_${index}`,
+        },
+      });
+    }
+
+    const receipts = await readFile(
+      join(homePath, "system/ai-providers/login-receipts.json"),
+      "utf8",
+    );
+    const recovery = await readFile(
+      join(homePath, "system/ai-providers/login-recovery.json"),
+      "utf8",
+    );
+    expect(receipts).not.toContain(migratedSessionName);
+    expect(recovery).not.toContain(migratedSessionName);
+
+    checkedAt = new Date(Date.parse(migrated.expiresAt) + 1);
+    const createCountBeforeRetry = registry.create.mock.calls.length;
+    const deleteCountBeforeRetry = registry.delete.mock.calls.length;
+    const recovered = await login.startLogin({
+      ...legacyInput,
+      mutation: {
+        ...legacyInput.mutation,
+        expectedRevision: 67,
+        idempotencyKey: "login_legacy_after_document_eviction",
+      },
+    });
+
+    expect(recovered.action).toEqual({
+      kind: "open_terminal",
+      terminalSessionId: migratedSessionName,
+    });
+    expect(registry.create).toHaveBeenCalledTimes(createCountBeforeRetry);
+    expect(registry.delete).toHaveBeenCalledTimes(deleteCountBeforeRetry);
+    expect(sessions).toContain(migratedSessionName);
   });
 
   it.each([

--- a/tests/gateway/provider-settings-login-legacy-migration.test.ts
+++ b/tests/gateway/provider-settings-login-legacy-migration.test.ts
@@ -126,6 +126,26 @@ describe("provider terminal login legacy migration", () => {
     }));
   });
 
+  it("migrates a live legacy receipt across intervening settings revisions", async () => {
+    const legacy = await seedLegacyLoginReceipt();
+
+    const recovered = await coordinator().startLogin({
+      ...legacyInput,
+      mutation: {
+        ...legacyInput.mutation,
+        expectedRevision: 4,
+        idempotencyKey: "login_legacy_later_retry",
+      },
+    });
+
+    expect(recovered.action).toEqual({
+      kind: "open_terminal",
+      terminalSessionId: legacy.sessionName,
+    });
+    expect(registry.create).not.toHaveBeenCalled();
+    expect(sessions).toEqual(new Set([legacy.sessionName]));
+  });
+
   it.each([
     ["provider", { providerId: "openai", accountId: "owner_anthropic" }],
     ["account", { providerId: "anthropic", accountId: "owner_other" }],

--- a/tests/gateway/provider-settings-login-legacy-migration.test.ts
+++ b/tests/gateway/provider-settings-login-legacy-migration.test.ts
@@ -11,17 +11,20 @@ describe("provider terminal login legacy migration", () => {
   let homePath: string;
   const now = new Date("2026-08-30T12:00:00.000Z");
   const sessions = new Set<string>();
+  const runningAgents = new Map<string, "codex" | "claude">();
   const registry = {
     get: vi.fn(async (name: string) => {
       if (!sessions.has(name)) throw Object.assign(new Error("missing"), { code: "session_not_found" });
-      return { name };
+      return { name, agent: runningAgents.get(name) };
     }),
-    create: vi.fn(async (input: { name: string }) => {
+    create: vi.fn(async (input: { name: string; agent?: "codex" | "claude" }) => {
       sessions.add(input.name);
-      return { name: input.name };
+      if (input.agent) runningAgents.set(input.name, input.agent);
+      return { name: input.name, agent: input.agent };
     }),
     delete: vi.fn(async (name: string) => {
       sessions.delete(name);
+      runningAgents.delete(name);
     }),
     rename: vi.fn(async (name: string, nextName: string) => {
       if (!sessions.delete(name)) {
@@ -32,7 +35,10 @@ describe("provider terminal login legacy migration", () => {
         throw Object.assign(new Error("exists"), { code: "session_exists" });
       }
       sessions.add(nextName);
-      return { name: nextName };
+      const agent = runningAgents.get(name);
+      runningAgents.delete(name);
+      if (agent) runningAgents.set(nextName, agent);
+      return { name: nextName, agent };
     }),
   };
   const legacyInput = {
@@ -57,6 +63,7 @@ describe("provider terminal login legacy migration", () => {
   beforeEach(async () => {
     homePath = await mkdtemp(join(tmpdir(), "provider-terminal-login-legacy-"));
     sessions.clear();
+    runningAgents.clear();
     registry.get.mockClear();
     registry.create.mockClear();
     registry.delete.mockClear();
@@ -99,6 +106,7 @@ describe("provider terminal login legacy migration", () => {
       JSON.stringify({ version: 1, receipts: [receipt] }),
     );
     sessions.add(sessionName);
+    runningAgents.set(sessionName, "claude");
     return { receipt, sessionName };
   }
 
@@ -325,6 +333,122 @@ describe("provider terminal login legacy migration", () => {
     expect(registry.create).toHaveBeenCalledTimes(createCountBeforeRetry);
     expect(registry.delete).toHaveBeenCalledTimes(deleteCountBeforeRetry);
     expect(sessions).toContain(migratedSessionName);
+  });
+
+  it("restarts an evicted canonical session whose login process has exited", async () => {
+    const legacy = await seedLegacyLoginReceipt();
+    let checkedAt = new Date(now);
+    const login = createProviderTerminalLoginCoordinator({
+      homePath,
+      registry,
+      enabledHarnesses: ["claude"],
+      now: () => new Date(checkedAt),
+    });
+    const migrated = await login.startLogin({
+      ...legacyInput,
+      mutation: {
+        ...legacyInput.mutation,
+        expectedRevision: 1,
+        idempotencyKey: "login_legacy_migrated_stale",
+      },
+    });
+    const migratedSessionName = migrated.action.kind === "open_terminal"
+      ? migrated.action.terminalSessionId
+      : "";
+
+    for (let index = 0; index < 65; index += 1) {
+      await login.startLogin({
+        ...legacyInput,
+        mutation: {
+          ...legacyInput.mutation,
+          expectedRevision: index + 2,
+          idempotencyKey: `login_stale_eviction_${index}`,
+          accountId: `owner_stale_other_${index}`,
+        },
+      });
+    }
+    runningAgents.delete(migratedSessionName);
+    checkedAt = new Date(Date.parse(migrated.expiresAt) + 1);
+    const createCountBeforeRetry = registry.create.mock.calls.length;
+    const deleteCountBeforeRetry = registry.delete.mock.calls.length;
+
+    const recovered = await login.startLogin({
+      ...legacyInput,
+      mutation: {
+        ...legacyInput.mutation,
+        expectedRevision: 67,
+        idempotencyKey: "login_legacy_after_stale_eviction",
+      },
+    });
+
+    expect(recovered.action).toEqual({
+      kind: "open_terminal",
+      terminalSessionId: migratedSessionName,
+    });
+    expect(registry.delete).toHaveBeenCalledTimes(deleteCountBeforeRetry + 1);
+    expect(registry.delete).toHaveBeenLastCalledWith(migratedSessionName, { force: true });
+    expect(registry.create).toHaveBeenCalledTimes(createCountBeforeRetry + 1);
+    expect(registry.create).toHaveBeenLastCalledWith(expect.objectContaining({
+      name: migratedSessionName,
+      agent: "claude",
+    }));
+    expect(sessions).toContain(migratedSessionName);
+    expect(runningAgents.get(migratedSessionName)).toBe("claude");
+  });
+
+  it("recovers the canonical identity when migration persistence and rollback both fail", async () => {
+    const legacy = await seedLegacyLoginReceipt();
+    const persistReceipt = vi.fn(async (path: string, value: unknown) => {
+      await writeFile(path, JSON.stringify(value));
+    });
+    persistReceipt.mockRejectedValueOnce(new Error("persist failed"));
+    registry.rename
+      .mockImplementationOnce(async (name: string, nextName: string) => {
+        sessions.delete(name);
+        sessions.add(nextName);
+        const agent = runningAgents.get(name);
+        runningAgents.delete(name);
+        if (agent) runningAgents.set(nextName, agent);
+        return { name: nextName, agent };
+      })
+      .mockRejectedValueOnce(new Error("rollback failed"));
+    const login = createProviderTerminalLoginCoordinator({
+      homePath,
+      registry,
+      enabledHarnesses: ["claude"],
+      now: () => now,
+      persistReceipt,
+    });
+    const input = {
+      ...legacyInput,
+      mutation: {
+        ...legacyInput.mutation,
+        expectedRevision: 1,
+        idempotencyKey: "login_legacy_rollback_failure",
+      },
+    };
+
+    await expect(login.startLogin(input)).rejects.toMatchObject({
+      code: "lifecycle_unavailable",
+    });
+    const canonicalSessionName = [...sessions][0]!;
+    expect(canonicalSessionName).toMatch(/^provider-login-[a-f0-9]{64}$/);
+    expect(sessions).not.toContain(legacy.sessionName);
+
+    const recovered = await login.startLogin(input);
+
+    expect(recovered.action).toEqual({
+      kind: "open_terminal",
+      terminalSessionId: canonicalSessionName,
+    });
+    expect(registry.create).not.toHaveBeenCalled();
+    expect(sessions).toEqual(new Set([canonicalSessionName]));
+    const receipts = await readFile(
+      join(homePath, "system/ai-providers/login-receipts.json"),
+      "utf8",
+    );
+    expect(receipts).toContain("login_legacy_rollback_failure");
+    expect(receipts).toContain(canonicalSessionName);
   });
 
   it.each([

--- a/tests/gateway/provider-settings-login-legacy-migration.test.ts
+++ b/tests/gateway/provider-settings-login-legacy-migration.test.ts
@@ -146,6 +146,90 @@ describe("provider terminal login legacy migration", () => {
     expect(sessions).toEqual(new Set([legacy.sessionName]));
   });
 
+  it("renews an expired migrated legacy session without creating a canonical duplicate", async () => {
+    const legacy = await seedLegacyLoginReceipt();
+    let checkedAt = new Date(now);
+    const login = createProviderTerminalLoginCoordinator({
+      homePath,
+      registry,
+      enabledHarnesses: ["claude"],
+      now: () => new Date(checkedAt),
+    });
+    const migrated = await login.startLogin({
+      ...legacyInput,
+      mutation: {
+        ...legacyInput.mutation,
+        expectedRevision: 1,
+        idempotencyKey: "login_legacy_migrated_key",
+      },
+    });
+    expect(migrated.action).toEqual({
+      kind: "open_terminal",
+      terminalSessionId: legacy.sessionName,
+    });
+
+    checkedAt = new Date(Date.parse(migrated.expiresAt) + 1);
+    const renewed = await login.startLogin({
+      ...legacyInput,
+      mutation: {
+        ...legacyInput.mutation,
+        expectedRevision: 2,
+        idempotencyKey: "login_legacy_after_expiry",
+      },
+    });
+
+    expect(renewed).toMatchObject({
+      state: "pending",
+      action: { kind: "open_terminal", terminalSessionId: legacy.sessionName },
+    });
+    expect(Date.parse(renewed.expiresAt) - checkedAt.getTime()).toBe(10 * 60_000);
+
+    checkedAt = new Date(Date.parse(renewed.expiresAt) + 1);
+    const sameKeyRenewal = await login.startLogin({
+      ...legacyInput,
+      mutation: {
+        ...legacyInput.mutation,
+        expectedRevision: 2,
+        idempotencyKey: "login_legacy_after_expiry",
+      },
+    });
+    expect(sameKeyRenewal.action).toEqual({
+      kind: "open_terminal",
+      terminalSessionId: legacy.sessionName,
+    });
+
+    let latest = sameKeyRenewal;
+    for (let revision = 3; revision <= 70; revision += 1) {
+      checkedAt = new Date(Date.parse(latest.expiresAt) + 1);
+      latest = await login.startLogin({
+        ...legacyInput,
+        mutation: {
+          ...legacyInput.mutation,
+          expectedRevision: revision,
+          idempotencyKey: `login_legacy_after_expiry_${revision}`,
+        },
+      });
+      expect(latest.action).toEqual({
+        kind: "open_terminal",
+        terminalSessionId: legacy.sessionName,
+      });
+    }
+
+    const receipts = JSON.parse(await readFile(
+      join(homePath, "system/ai-providers/login-receipts.json"),
+      "utf8",
+    )) as { receipts: unknown[] };
+    const recovery = JSON.parse(await readFile(
+      join(homePath, "system/ai-providers/login-recovery.json"),
+      "utf8",
+    )) as { receipts: unknown[] };
+    expect(receipts.receipts).toHaveLength(64);
+    expect(recovery.receipts).toHaveLength(1);
+    expect(registry.create).not.toHaveBeenCalled();
+    expect(registry.delete).not.toHaveBeenCalled();
+    expect(sessions).toEqual(new Set([legacy.sessionName]));
+  });
+
   it.each([
     ["provider", { providerId: "openai", accountId: "owner_anthropic" }],
     ["account", { providerId: "anthropic", accountId: "owner_other" }],

--- a/tests/gateway/provider-settings-login-legacy-migration.test.ts
+++ b/tests/gateway/provider-settings-login-legacy-migration.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createProviderTerminalLoginCoordinator,
 } from "../../packages/gateway/src/ai-providers/provider-terminal-login-coordinator.js";
+import { SESSION_NAME_PATTERN } from "../../packages/gateway/src/shell/names.js";
 
 describe("provider terminal login legacy migration", () => {
   let homePath: string;
@@ -40,6 +41,9 @@ describe("provider terminal login legacy migration", () => {
       if (agent) runningAgents.set(nextName, agent);
       return { name: nextName, agent };
     }),
+    observeAgentLiveness: vi.fn(async (name: string, agent: "codex" | "claude") => (
+      runningAgents.get(name) === agent ? "running" as const : "unknown" as const
+    )),
   };
   const legacyInput = {
     mutation: {
@@ -68,6 +72,7 @@ describe("provider terminal login legacy migration", () => {
     registry.create.mockClear();
     registry.delete.mockClear();
     registry.rename.mockClear();
+    registry.observeAgentLiveness.mockClear();
   });
 
   afterEach(async () => {
@@ -124,13 +129,15 @@ describe("provider terminal login legacy migration", () => {
 
     expect(recovered.action).toMatchObject({
       kind: "open_terminal",
-      terminalSessionId: expect.stringMatching(/^provider-login-[a-f0-9]{64}$/),
+      terminalSessionId: expect.stringMatching(/^provider-auth-[a-z0-9]{50}$/),
     });
     const recoveredSessionName = recovered.action.kind === "open_terminal"
       ? recovered.action.terminalSessionId
       : "";
     expect(registry.create).not.toHaveBeenCalled();
     expect(registry.rename).toHaveBeenCalledWith(legacy.sessionName, recoveredSessionName);
+    expect(recoveredSessionName).toMatch(SESSION_NAME_PATTERN);
+    expect(recoveredSessionName.length).toBeLessThanOrEqual(64);
     expect(sessions).toEqual(new Set([recoveredSessionName]));
 
     const receipts = JSON.parse(await readFile(
@@ -164,7 +171,7 @@ describe("provider terminal login legacy migration", () => {
 
     expect(recovered.action).toMatchObject({
       kind: "open_terminal",
-      terminalSessionId: expect.stringMatching(/^provider-login-[a-f0-9]{64}$/),
+      terminalSessionId: expect.stringMatching(/^provider-auth-[a-z0-9]{50}$/),
     });
     const recoveredSessionName = recovered.action.kind === "open_terminal"
       ? recovered.action.terminalSessionId
@@ -193,7 +200,7 @@ describe("provider terminal login legacy migration", () => {
     });
     expect(migrated.action).toMatchObject({
       kind: "open_terminal",
-      terminalSessionId: expect.stringMatching(/^provider-login-[a-f0-9]{64}$/),
+      terminalSessionId: expect.stringMatching(/^provider-auth-[a-z0-9]{50}$/),
     });
     const migratedSessionName = migrated.action.kind === "open_terminal"
       ? migrated.action.terminalSessionId
@@ -281,7 +288,7 @@ describe("provider terminal login legacy migration", () => {
     });
     expect(migrated.action).toMatchObject({
       kind: "open_terminal",
-      terminalSessionId: expect.stringMatching(/^provider-login-[a-f0-9]{64}$/),
+      terminalSessionId: expect.stringMatching(/^provider-auth-[a-z0-9]{50}$/),
     });
     const migratedSessionName = migrated.action.kind === "open_terminal"
       ? migrated.action.terminalSessionId
@@ -335,7 +342,7 @@ describe("provider terminal login legacy migration", () => {
     expect(sessions).toContain(migratedSessionName);
   });
 
-  it("restarts an evicted canonical session whose login process has exited", async () => {
+  it("fails closed without deleting an evicted canonical session whose foreground liveness is unavailable", async () => {
     const legacy = await seedLegacyLoginReceipt();
     let checkedAt = new Date(now);
     const login = createProviderTerminalLoginCoordinator({
@@ -372,28 +379,19 @@ describe("provider terminal login legacy migration", () => {
     const createCountBeforeRetry = registry.create.mock.calls.length;
     const deleteCountBeforeRetry = registry.delete.mock.calls.length;
 
-    const recovered = await login.startLogin({
+    await expect(login.startLogin({
       ...legacyInput,
       mutation: {
         ...legacyInput.mutation,
         expectedRevision: 67,
         idempotencyKey: "login_legacy_after_stale_eviction",
       },
-    });
+    })).rejects.toMatchObject({ code: "lifecycle_unavailable" });
 
-    expect(recovered.action).toEqual({
-      kind: "open_terminal",
-      terminalSessionId: migratedSessionName,
-    });
-    expect(registry.delete).toHaveBeenCalledTimes(deleteCountBeforeRetry + 1);
-    expect(registry.delete).toHaveBeenLastCalledWith(migratedSessionName, { force: true });
-    expect(registry.create).toHaveBeenCalledTimes(createCountBeforeRetry + 1);
-    expect(registry.create).toHaveBeenLastCalledWith(expect.objectContaining({
-      name: migratedSessionName,
-      agent: "claude",
-    }));
+    expect(registry.delete).toHaveBeenCalledTimes(deleteCountBeforeRetry);
+    expect(registry.create).toHaveBeenCalledTimes(createCountBeforeRetry);
     expect(sessions).toContain(migratedSessionName);
-    expect(runningAgents.get(migratedSessionName)).toBe("claude");
+    expect(runningAgents.has(migratedSessionName)).toBe(false);
   });
 
   it("recovers the canonical identity when migration persistence and rollback both fail", async () => {
@@ -432,7 +430,7 @@ describe("provider terminal login legacy migration", () => {
       code: "lifecycle_unavailable",
     });
     const canonicalSessionName = [...sessions][0]!;
-    expect(canonicalSessionName).toMatch(/^provider-login-[a-f0-9]{64}$/);
+    expect(canonicalSessionName).toMatch(/^provider-auth-[a-z0-9]{50}$/);
     expect(sessions).not.toContain(legacy.sessionName);
 
     const recovered = await login.startLogin(input);
@@ -449,6 +447,14 @@ describe("provider terminal login legacy migration", () => {
     );
     expect(receipts).toContain("login_legacy_rollback_failure");
     expect(receipts).toContain(canonicalSessionName);
+
+    const originalKeyRecovery = await login.startLogin(legacyInput);
+    expect(originalKeyRecovery.action).toEqual({
+      kind: "open_terminal",
+      terminalSessionId: canonicalSessionName,
+    });
+    expect(registry.create).not.toHaveBeenCalled();
+    expect(sessions).toEqual(new Set([canonicalSessionName]));
   });
 
   it.each([

--- a/tests/gateway/provider-settings-runtime-wiring.test.ts
+++ b/tests/gateway/provider-settings-runtime-wiring.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+import { AiProviderSnapshotV3Schema } from "@matrix-os/contracts";
+import { ProviderSettingsStore } from "../../packages/gateway/src/ai-providers/provider-settings-store.js";
+import { initialProviderSettingsConfiguration } from "../../packages/gateway/src/ai-providers/provider-settings-persistence.js";
+import {
+  PROVIDER_SETTINGS_NOW,
+  providerSettingsCanonicalFixture,
+} from "./provider-settings-test-support.js";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("provider settings runtime capability wiring", () => {
+  it("wires the server-owned shell registry and canonical driver probes without lifecycle or route fiction", async () => {
+    const source = await readFile(new URL("../../packages/gateway/src/server.ts", import.meta.url), "utf8");
+    expect(source).toContain("createProviderDriverInventoryReader({");
+    expect(source).toContain("detectAgentInstallations: agentCredentialLauncher.detectAgentInstallations");
+    expect(source).toContain("runtimeSource: agentRuntimeServices.source");
+    expect(source).toContain("createProviderTerminalLoginCoordinator({");
+    expect(source).toContain("registry: zellijShellRegistry");
+    expect(source).toContain("loginCoordinator: providerLoginCoordinator");
+    expect(source).not.toContain("accountLifecycle: provider");
+    expect(source).not.toContain("runtimeCoordinator: provider");
+  });
+
+  it("advertises terminal login when one projected harness is supported and rejects another harness", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "provider-runtime-capabilities-"));
+    try {
+      const base = providerSettingsCanonicalFixture();
+      const canonical = AiProviderSnapshotV3Schema.parse({
+        ...base,
+        drivers: [...base.drivers, {
+          id: "opencode",
+          displayName: "OpenCode",
+          kind: "cli",
+          installState: "installed",
+          health: "ready",
+          capabilities: ["tools", "resume"],
+          setupActions: ["open_terminal"],
+        }],
+        instances: [...base.instances, {
+          id: "opencode_matrix",
+          driverId: "opencode",
+          vendor: "anthropic",
+          accountId: null,
+          accessSourceId: "matrix_included",
+          label: "OpenCode",
+          readiness: base.instances[0]!.readiness,
+          capabilitySnapshot: ["tools", "resume"],
+          modelIds: ["claude-sonnet-5"],
+          defaultModelId: "claude-sonnet-5",
+          catalogVersion: "catalog_1",
+        }],
+      });
+      const login = {
+        supportedMethods: vi.fn(({ harness }: { harness: string }) =>
+          harness === "claude" ? ["terminal" as const] : []),
+        startLogin: vi.fn(),
+      };
+      const store = new ProviderSettingsStore({
+        homePath,
+        providerSnapshotReader: { getSnapshot: async () => structuredClone(canonical) },
+        loginCoordinator: login,
+        now: () => PROVIDER_SETTINGS_NOW,
+      });
+      const snapshot = await store.getSnapshot();
+      expect(snapshot.supportedActions).toEqual(["start_login"]);
+      expect(snapshot.harnesses[0]?.loginMethods).toEqual(["terminal"]);
+      expect(snapshot.harnesses[0]?.recommendedLoginMethod).toBe("terminal");
+      expect(snapshot.harnesses.map((harness) => harness.harness)).toEqual(["claude", "opencode"]);
+      expect(snapshot.harnesses[1]?.loginMethods).toEqual([]);
+      expect(snapshot.harnesses[1]?.recommendedLoginMethod).toBeNull();
+
+      await expect(store.mutate({
+        type: "start_login",
+        expectedRevision: 0,
+        idempotencyKey: "unsupported_oauth_1",
+        harnessInstanceId: "harness_kernel",
+        accountId: null,
+        method: "oauth",
+      })).rejects.toMatchObject({ code: "invalid_request" });
+      expect(login.startLogin).not.toHaveBeenCalled();
+
+      await expect(store.mutate({
+        type: "start_login",
+        expectedRevision: 0,
+        idempotencyKey: "unsupported_opencode_1",
+        harnessInstanceId: "harness_opencode",
+        accountId: null,
+        method: "terminal",
+      })).rejects.toMatchObject({ code: "invalid_request" });
+      expect(login.startLogin).not.toHaveBeenCalled();
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps real driver rows inventory-only until they have a canonical provider instance", () => {
+    const base = providerSettingsCanonicalFixture();
+    const config = initialProviderSettingsConfiguration(AiProviderSnapshotV3Schema.parse({
+      ...base,
+      drivers: [...base.drivers, {
+        id: "codex",
+        displayName: "Codex",
+        kind: "cli",
+        installState: "installed",
+        health: "ready",
+        capabilities: ["tools", "resume", "project_context"],
+        setupActions: ["connect_account", "open_terminal"],
+      }],
+    }));
+    expect(config.harnesses.map((harness) => harness.id)).toEqual(["harness_kernel"]);
+  });
+
+  it("returns an expired terminal attempt instead of reviving a stale durable receipt", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "provider-runtime-expiry-"));
+    let now = PROVIDER_SETTINGS_NOW;
+    try {
+      const canonical = providerSettingsCanonicalFixture();
+      const store = new ProviderSettingsStore({
+        homePath,
+        providerSnapshotReader: { getSnapshot: async () => ({
+          ...structuredClone(canonical),
+          refreshedAt: now.toISOString(),
+        }) },
+        loginCoordinator: {
+          supportedMethods: () => ["terminal"],
+          startLogin: async ({ mutation }) => ({
+            id: "attempt_expiring_1",
+            harnessInstanceId: mutation.harnessInstanceId,
+            accountId: mutation.accountId,
+            method: mutation.method,
+            state: "pending",
+            action: { kind: "open_terminal", terminalSessionId: "provider-login-claude-expiring" },
+            expiresAt: new Date(now.getTime() + 10 * 60_000).toISOString(),
+            safeFailure: null,
+          }),
+        },
+        now: () => now,
+      });
+      const mutation = {
+        type: "start_login" as const,
+        expectedRevision: 0,
+        idempotencyKey: "expiring_login_1",
+        harnessInstanceId: "harness_kernel",
+        accountId: null,
+        method: "terminal" as const,
+      };
+      expect((await store.mutate(mutation)).kind).toBe("login_attempt");
+      now = new Date(PROVIDER_SETTINGS_NOW.getTime() + 11 * 60_000);
+      const duplicate = await store.mutate(mutation);
+      expect(duplicate).toMatchObject({
+        kind: "login_attempt",
+        attempt: { state: "expired", action: { kind: "none" }, safeFailure: "expired" },
+      });
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/gateway/provider-settings-store.test.ts
+++ b/tests/gateway/provider-settings-store.test.ts
@@ -183,6 +183,74 @@ describe("ProviderSettingsStore", () => {
     expect(stored).not.toMatch(/"readiness"|"usage"|apiKey|accessToken/);
   });
 
+  it("normalizes a persisted legacy Claude driver to canonical inventory for projection and login", async () => {
+    canonical = AiProviderSnapshotV3Schema.parse({
+      ...canonical,
+      drivers: canonical.drivers.filter((driver) => driver.id === "claude_code"),
+      instances: canonical.instances.map((instance) => ({ ...instance, driverId: "claude_code" })),
+    });
+    login.supportedMethods = vi.fn(({ driverId, installState }) =>
+      driverId === "claude_code" && installState === "installed" ? ["terminal"] : []);
+    const store = createStore();
+    await mkdir(dirname(store.configurationPath), { recursive: true });
+    await writeFile(store.configurationPath, JSON.stringify({
+      schemaVersion: 1,
+      revision: 0,
+      harnesses: [{
+        id: "harness_legacy_claude",
+        driverId: "kernel",
+        harness: "claude",
+        displayName: "Claude",
+        accentColor: null,
+        enabled: true,
+        selectedAccountId: null,
+        accessSourceId: "matrix_included",
+        route: { kind: "fixed", providerId: "anthropic", modelId: "claude-sonnet-5" },
+      }],
+      accountProfiles: [],
+      gatewayPolicy: {
+        accessSourceId: "matrix_included",
+        monthlyBudgetMicrousd: null,
+        allowedModelIds: ["claude-sonnet-5"],
+        topUpEnabled: false,
+      },
+      receipts: [],
+    }), { mode: 0o600 });
+
+    const snapshot = await store.getSnapshot();
+    expect(snapshot.supportedActions).toContain("start_login");
+    expect(snapshot.harnesses).toContainEqual(expect.objectContaining({
+      id: "harness_legacy_claude",
+      harness: "claude",
+      enabled: true,
+      installState: "installed",
+      loginMethods: ["terminal"],
+      recommendedLoginMethod: "terminal",
+    }));
+
+    await expect(store.mutate({
+      type: "start_login",
+      expectedRevision: 0,
+      idempotencyKey: "legacy_claude_login_1",
+      harnessInstanceId: "harness_legacy_claude",
+      accountId: null,
+      method: "terminal",
+    })).resolves.toMatchObject({
+      kind: "login_attempt",
+      snapshot: {
+        harnesses: [expect.objectContaining({ enabled: true, installState: "installed" })],
+      },
+    });
+    expect(login.startLogin).toHaveBeenCalledWith(expect.objectContaining({
+      harness: expect.objectContaining({
+        id: "harness_legacy_claude",
+        driverId: "claude_code",
+        harness: "claude",
+        installState: "installed",
+      }),
+    }));
+  });
+
   it("is read-only and rejects cosmetic mutations without a runtime coordinator", async () => {
     const store = createStore({
       withRuntime: false,

--- a/tests/gateway/provider-settings-store.test.ts
+++ b/tests/gateway/provider-settings-store.test.ts
@@ -249,6 +249,27 @@ describe("ProviderSettingsStore", () => {
         installState: "installed",
       }),
     }));
+
+    await expect(store.mutate({
+      type: "set_harness_enabled",
+      expectedRevision: 1,
+      idempotencyKey: "legacy_claude_disable_1",
+      harnessInstanceId: "harness_legacy_claude",
+      enabled: false,
+    })).resolves.toMatchObject({
+      kind: "snapshot",
+      snapshot: { harnesses: [expect.objectContaining({ enabled: false })] },
+    });
+    await expect(store.mutate({
+      type: "set_harness_enabled",
+      expectedRevision: 2,
+      idempotencyKey: "legacy_claude_enable_1",
+      harnessInstanceId: "harness_legacy_claude",
+      enabled: true,
+    })).resolves.toMatchObject({
+      kind: "snapshot",
+      snapshot: { harnesses: [expect.objectContaining({ enabled: true })] },
+    });
   });
 
   it("is read-only and rejects cosmetic mutations without a runtime coordinator", async () => {

--- a/tests/gateway/provider-settings-store.test.ts
+++ b/tests/gateway/provider-settings-store.test.ts
@@ -93,6 +93,7 @@ describe("ProviderSettingsStore", () => {
       }),
     };
     login = {
+      supportedMethods: vi.fn(() => ["terminal", "oauth", "api_key"]),
       startLogin: vi.fn(async ({ mutation }) => ({
         id: "attempt_real_terminal_1",
         harnessInstanceId: mutation.harnessInstanceId,
@@ -105,6 +106,16 @@ describe("ProviderSettingsStore", () => {
       })),
     };
     runtime = {
+      supportedActions: [
+        "add_harness",
+        "update_harness",
+        "set_harness_enabled",
+        "set_route",
+        "select_account",
+        "select_access_source",
+        "set_gateway_budget",
+        "set_gateway_allowlist",
+      ],
       applyConfiguration: vi.fn(async () => undefined),
     };
   });

--- a/tests/gateway/provider-settings-test-support.ts
+++ b/tests/gateway/provider-settings-test-support.ts
@@ -47,15 +47,26 @@ export function providerSettingsCanonicalFixture(): AiProviderSnapshotV3 {
       accountLabel: "Personal",
       ...providerReady,
     }],
-    drivers: [{
-      id: "kernel",
-      displayName: "Matrix Agent",
-      kind: "agent_sdk",
-      installState: "installed",
-      health: "ready",
-      capabilities: ["tools", "resume"],
-      setupActions: [],
-    }],
+    drivers: [
+      {
+        id: "kernel",
+        displayName: "Matrix Agent",
+        kind: "agent_sdk",
+        installState: "installed",
+        health: "ready",
+        capabilities: ["tools", "resume"],
+        setupActions: [],
+      },
+      {
+        id: "claude_code",
+        displayName: "Claude",
+        kind: "cli",
+        installState: "installed",
+        health: "ready",
+        capabilities: ["tools", "resume"],
+        setupActions: [],
+      },
+    ],
     instances: [
       {
         id: "kernel_matrix",

--- a/tests/gateway/shell-registry.test.ts
+++ b/tests/gateway/shell-registry.test.ts
@@ -19,6 +19,36 @@ afterEach(async () => {
 });
 
 describe("shell registry", () => {
+  it("reports trustworthy agent liveness through the managed terminal wrapper", async () => {
+    const root = await tempRoot();
+    const agentStateStore = new AgentSessionStateStore({ homePath: root });
+    await agentStateStore.apply({
+      sessionName: "main",
+      agent: "claude",
+      type: "turn-started",
+      occurredAt: "2026-08-31T12:00:00.000Z",
+    });
+    let command = "/home/matrix/home/system/zellij/matrix-terminal-shell";
+    const adapter = {
+      listSessions: vi.fn(async () => ["main"]),
+      createSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+      focusedPaneRuntime: vi.fn(async () => ({ cwd: root, command, observed: true })),
+    };
+    const registry = new ShellRegistry({ homePath: root, adapter, agentStateStore });
+
+    await expect(registry.observeAgentLiveness("main", "claude")).resolves.toBe("running");
+    await agentStateStore.apply({
+      sessionName: "main",
+      agent: "claude",
+      type: "session-ended",
+      occurredAt: "2026-08-31T12:01:00.000Z",
+    });
+    await expect(registry.observeAgentLiveness("main", "claude")).resolves.toBe("unknown");
+    command = "zsh";
+    await expect(registry.observeAgentLiveness("main", "claude")).resolves.toBe("stopped");
+  });
+
   it("decorates listed sessions concurrently", async () => {
     const root = await tempRoot();
     const live = new Set<string>();


### PR DESCRIPTION
## Summary

- inventory the six supported agent drivers from the real runtime and installation probes
- expose terminal login only for installed, enabled Codex and Claude harnesses
- open deterministic visible Zellij sessions for provider authentication with bounded, durable idempotency receipts
- keep route mutation, account logout/removal, gateway funding, and metering fail-closed until their coordinators land in later stack layers

## Validation

- `node_modules/.bin/tsc --noEmit -p packages/gateway/tsconfig.json`
- 37 focused gateway provider/settings tests
- `git diff codex/claude-sdk-fable5...HEAD --check`

## Invariants

- **Source of truth:** driver availability comes from the existing agent installation and runtime services; login receipts are durable configuration under the owners Matrix home.
- **Lock / transaction scope:** login creation is serialized within the gateway process and idempotency is persisted atomically; no database writes are introduced.
- **Acceptable orphan states:** a visible login terminal may outlive its receipt or vice versa after a crash; an idempotent retry reconciles a missing live session without duplicating a named session.
- **Auth source of truth:** existing gateway authentication protects provider settings routes; CLI authentication remains owned by the provider CLI and is never copied into Matrix settings.
- **Deferred scope:** generic harness route creation, safe logout/removal, Matrix-funded usage/metering, and add-on billing remain disabled until their dedicated coordinators land later in this stack. Extracting provider-settings composition from the oversized gateway entrypoint is tracked in #1463.