### PR TITLE
feat(ai-policy): add funded control plane and scoped runtime credential

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -396,6 +396,7 @@ write_files:
       PLATFORM_INTERNAL_URL={{platformInternalUrl}}
       UPGRADE_TOKEN={{platformVerificationToken}}
       MATRIX_AUTH_TOKEN={{platformVerificationToken}}
+      MATRIX_FUNDED_AI_RUNTIME_TOKEN={{fundedAiRuntimeToken}}
       MATRIX_CODE_PROXY_TOKEN={{platformVerificationToken}}
       MATRIX_HOST_BUNDLE_URL={{hostBundleUrl}}
       POSTHOG_TOKEN={{posthogToken}}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -25,6 +25,7 @@
     "#kernel-conversations": "./src/kernel-conversations.ts",
     "#os-view": "./src/os-view.ts",
     "#provider-settings": "./src/provider-settings.ts",
+    "#funded-ai": "./src/funded-ai.ts",
     "#safe-client-error": "./src/safe-client-error.ts",
     "#terminal-clipboard": "./src/terminal-clipboard.ts",
     "#terminal-links": "./src/terminal-links.ts"

--- a/packages/contracts/src/funded-ai.ts
+++ b/packages/contracts/src/funded-ai.ts
@@ -1,0 +1,112 @@
+import { z } from "zod/v4";
+import { canonicalReferenceId } from "#canonical-chat-primitives";
+import { IsoTimestampSchema, ProviderModelReferenceSchema } from "#contract-primitives";
+
+export const FUNDED_AI_AUDIENCE = "matrix-funded-relay" as const;
+export const FUNDED_AI_SCOPE = "ai:invoke" as const;
+
+const RevisionSchema = z.number().int().nonnegative();
+const RuntimeSlotSchema = z.string().min(1).max(80).regex(/^[a-z0-9][a-z0-9_-]*$/);
+const UniqueModelIdsSchema = z.array(ProviderModelReferenceSchema).max(64)
+  .refine((models) => new Set(models).size === models.length, "Model IDs must be unique");
+const TokenIdSchema = canonicalReferenceId(80);
+const OpaqueCredentialSchema = z.string()
+  .min(64)
+  .max(256)
+  .regex(/^sk-matrix-funded-[A-Za-z0-9][A-Za-z0-9_.:-]{0,79}\.[A-Za-z0-9_-]{43}$/);
+
+export const FundedAiIdentitySchema = z.object({
+  ownerId: canonicalReferenceId(160),
+  machineId: canonicalReferenceId(160),
+  runtimeSlot: RuntimeSlotSchema,
+}).strict();
+
+export const FundedAiGlobalPolicySchema = z.object({
+  enabled: z.boolean(),
+  revision: RevisionSchema,
+  allowedModelIds: UniqueModelIdsSchema,
+  updatedAt: IsoTimestampSchema,
+}).strict();
+
+export const FundedAiEffectivePolicySchema = z.object({
+  enabled: z.boolean(),
+  globalRevision: RevisionSchema,
+  runtimeRevision: RevisionSchema,
+  allowedModelIds: UniqueModelIdsSchema,
+  checkedAt: IsoTimestampSchema,
+  staleAfter: IsoTimestampSchema,
+}).strict().superRefine((value, ctx) => {
+  if (Date.parse(value.staleAfter) <= Date.parse(value.checkedAt)) {
+    ctx.addIssue({ code: "custom", path: ["staleAfter"], message: "Policy freshness must end after it was checked" });
+  }
+  if (Date.parse(value.staleAfter) - Date.parse(value.checkedAt) > 5 * 60_000) {
+    ctx.addIssue({ code: "custom", path: ["staleAfter"], message: "Policy freshness window is too long" });
+  }
+  if (!value.enabled && value.allowedModelIds.length > 0) {
+    ctx.addIssue({ code: "custom", path: ["allowedModelIds"], message: "Disabled policy cannot allow models" });
+  }
+});
+
+export const FundedAiRuntimeCredentialIssueResponseSchema = z.object({
+  contractVersion: z.literal(1),
+  credential: z.object({
+    token: OpaqueCredentialSchema,
+    tokenId: TokenIdSchema,
+    audience: z.literal(FUNDED_AI_AUDIENCE),
+    scope: z.literal(FUNDED_AI_SCOPE),
+    issuedAt: IsoTimestampSchema,
+    expiresAt: IsoTimestampSchema,
+  }).strict(),
+  identity: FundedAiIdentitySchema,
+  policy: FundedAiEffectivePolicySchema,
+}).strict().superRefine((value, ctx) => {
+  if (Date.parse(value.credential.expiresAt) <= Date.parse(value.credential.issuedAt)) {
+    ctx.addIssue({ code: "custom", path: ["credential", "expiresAt"], message: "Credential must expire after issuance" });
+  }
+  if (Date.parse(value.credential.expiresAt) - Date.parse(value.credential.issuedAt) > 60 * 60_000) {
+    ctx.addIssue({ code: "custom", path: ["credential", "expiresAt"], message: "Credential lifetime is too long" });
+  }
+  const tokenPrefix = `sk-matrix-funded-${value.credential.tokenId}.`;
+  if (!value.credential.token.startsWith(tokenPrefix)) {
+    ctx.addIssue({ code: "custom", path: ["credential", "tokenId"], message: "Credential token ID does not match" });
+  }
+});
+
+export const FundedAiAuthorizationRequestSchema = z.object({
+  credential: OpaqueCredentialSchema,
+  requestId: canonicalReferenceId(160),
+  modelId: ProviderModelReferenceSchema,
+}).strict();
+
+export const FundedAiAuthorizationResponseSchema = z.object({
+  contractVersion: z.literal(1),
+  authorized: z.literal(true),
+  identity: FundedAiIdentitySchema.extend({
+    tokenId: TokenIdSchema,
+    audience: z.literal(FUNDED_AI_AUDIENCE),
+    scope: z.literal(FUNDED_AI_SCOPE),
+    expiresAt: IsoTimestampSchema,
+  }).strict(),
+  policy: FundedAiEffectivePolicySchema,
+}).strict();
+
+const SafeErrorSchema = z.discriminatedUnion("code", [
+  z.object({ code: z.literal("unauthorized"), message: z.literal("Unauthorized") }).strict(),
+  z.object({ code: z.literal("access_disabled"), message: z.literal("Matrix-funded AI is unavailable") }).strict(),
+  z.object({ code: z.literal("model_not_allowed"), message: z.literal("This model is not available") }).strict(),
+  z.object({ code: z.literal("rate_limited"), message: z.literal("Try again later") }).strict(),
+  z.object({ code: z.literal("revision_conflict"), message: z.literal("Policy changed; refresh and try again") }).strict(),
+  z.object({ code: z.literal("invalid_request"), message: z.literal("Invalid request") }).strict(),
+  z.object({ code: z.literal("not_found"), message: z.literal("Runtime not found") }).strict(),
+  z.object({ code: z.literal("unavailable"), message: z.literal("Service unavailable") }).strict(),
+]);
+
+export const FundedAiSafeErrorSchema = z.object({ error: SafeErrorSchema }).strict();
+
+export type FundedAiIdentity = z.infer<typeof FundedAiIdentitySchema>;
+export type FundedAiGlobalPolicy = z.infer<typeof FundedAiGlobalPolicySchema>;
+export type FundedAiEffectivePolicy = z.infer<typeof FundedAiEffectivePolicySchema>;
+export type FundedAiRuntimeCredentialIssueResponse = z.infer<typeof FundedAiRuntimeCredentialIssueResponseSchema>;
+export type FundedAiAuthorizationRequest = z.infer<typeof FundedAiAuthorizationRequestSchema>;
+export type FundedAiAuthorizationResponse = z.infer<typeof FundedAiAuthorizationResponseSchema>;
+export type FundedAiSafeError = z.infer<typeof FundedAiSafeErrorSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -42,6 +42,7 @@ export * from "#hermes-configuration";
 export * from "#kernel-result";
 export * from "#kernel-conversations";
 export * from "#provider-settings";
+export * from "#funded-ai";
 export * from "#safe-client-error";
 export * from "#terminal-clipboard";
 export * from "#terminal-links";

--- a/packages/platform/src/ai-funded-policy-repository.ts
+++ b/packages/platform/src/ai-funded-policy-repository.ts
@@ -1,0 +1,346 @@
+import { createHmac, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import {
+  FUNDED_AI_AUDIENCE,
+  FUNDED_AI_SCOPE,
+  FundedAiAuthorizationResponseSchema,
+  FundedAiGlobalPolicySchema,
+  FundedAiRuntimeCredentialIssueResponseSchema,
+  type FundedAiAuthorizationResponse,
+  type FundedAiGlobalPolicy,
+  type FundedAiIdentity,
+  type FundedAiRuntimeCredentialIssueResponse,
+} from "@matrix-os/contracts";
+import { z } from "zod/v4";
+import { sql } from "kysely";
+import type { PlatformDB } from "./db.js";
+
+const ModelIdsSchema = z.array(z.string().min(3).max(200).regex(/^[A-Za-z0-9][A-Za-z0-9._:/-]*$/))
+  .max(64).refine((values) => new Set(values).size === values.length);
+const IdentitySchema = z.object({
+  ownerId: z.string().min(1).max(160),
+  machineId: z.string().min(1).max(160),
+  runtimeSlot: z.string().min(1).max(80),
+}).strict();
+const GlobalPolicyUpdateSchema = z.object({
+  expectedRevision: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER - 1),
+  enabled: z.boolean(),
+  allowedModelIds: ModelIdsSchema,
+}).strict();
+const RuntimePolicyUpdateSchema = z.object({
+  identity: IdentitySchema,
+  expectedRevision: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER - 1),
+  enabled: z.boolean(),
+  allowedModelIds: ModelIdsSchema,
+  expiresAt: z.string().datetime({ offset: true }).nullable(),
+}).strict();
+const TOKEN_PATTERN = /^sk-matrix-funded-([A-Za-z0-9][A-Za-z0-9_.:-]{0,79})\.([A-Za-z0-9_-]{43})$/;
+
+export type AiFundedPolicyErrorCode =
+  | "access_disabled"
+  | "identity_mismatch"
+  | "model_not_allowed"
+  | "rate_limited"
+  | "revision_conflict"
+  | "unauthorized";
+
+export class AiFundedPolicyError extends Error {
+  constructor(readonly code: AiFundedPolicyErrorCode) {
+    super(code);
+    this.name = "AiFundedPolicyError";
+  }
+}
+
+export interface AiFundedPolicyRepositoryOptions {
+  db: PlatformDB;
+  credentialHashSecret: string;
+  now?: () => Date;
+  tokenIdFactory?: () => string;
+  tokenSecretFactory?: () => string;
+  credentialTtlMs?: number;
+  issueCooldownMs?: number;
+  policyFreshnessMs?: number;
+}
+
+export type SetRuntimePolicyInput = z.infer<typeof RuntimePolicyUpdateSchema>;
+
+function parseModels(value: string): string[] {
+  try {
+    return ModelIdsSchema.parse(JSON.parse(value));
+  } catch (error) {
+    throw new Error("Invalid funded AI policy model configuration", { cause: error });
+  }
+}
+
+function intersectModels(globalModels: string[], runtimeModels: string[]): string[] {
+  const runtimeSet = new Set(runtimeModels);
+  return globalModels.filter((model) => runtimeSet.has(model));
+}
+
+function hashesEqual(left: string, right: string): boolean {
+  const a = Buffer.from(left, "hex");
+  const b = Buffer.from(right, "hex");
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export function createAiFundedPolicyRepository(options: AiFundedPolicyRepositoryOptions) {
+  if (options.credentialHashSecret.length < 32) {
+    throw new Error("Funded AI credential hash secret must be at least 32 characters");
+  }
+  const now = options.now ?? (() => new Date());
+  const tokenIdFactory = options.tokenIdFactory ?? randomUUID;
+  const tokenSecretFactory = options.tokenSecretFactory ?? (() => randomBytes(32).toString("base64url"));
+  const credentialTtlMs = options.credentialTtlMs ?? 15 * 60_000;
+  const issueCooldownMs = options.issueCooldownMs ?? 30_000;
+  const policyFreshnessMs = options.policyFreshnessMs ?? 60_000;
+  if (credentialTtlMs < 60_000 || credentialTtlMs > 60 * 60_000) throw new Error("Invalid credential TTL");
+  if (issueCooldownMs < 1_000 || issueCooldownMs > credentialTtlMs) throw new Error("Invalid issue cooldown");
+  if (policyFreshnessMs < 1_000 || policyFreshnessMs > 5 * 60_000) throw new Error("Invalid policy freshness");
+
+  const hashCredential = (credential: string) => createHmac("sha256", options.credentialHashSecret)
+    .update(credential).digest("hex");
+
+  async function getGlobalPolicy(): Promise<FundedAiGlobalPolicy> {
+    await options.db.ready;
+    const row = await options.db.executor.selectFrom("ai_funded_global_policy")
+      .selectAll().where("policy_id", "=", "default").executeTakeFirstOrThrow();
+    return FundedAiGlobalPolicySchema.parse({
+      enabled: row.enabled,
+      revision: row.revision,
+      allowedModelIds: parseModels(row.allowed_model_ids),
+      updatedAt: row.updated_at,
+    });
+  }
+
+  async function updateGlobalPolicy(input: {
+    expectedRevision: number;
+    enabled: boolean;
+    allowedModelIds: string[];
+  }): Promise<FundedAiGlobalPolicy> {
+    const parsed = GlobalPolicyUpdateSchema.parse(input);
+    const allowedModelIds = parsed.allowedModelIds;
+    const updatedAt = now().toISOString();
+    await options.db.ready;
+    const row = await options.db.executor.updateTable("ai_funded_global_policy").set({
+      enabled: parsed.enabled,
+      allowed_model_ids: JSON.stringify(allowedModelIds),
+      revision: parsed.expectedRevision + 1,
+      updated_at: updatedAt,
+    }).where("policy_id", "=", "default").where("revision", "=", parsed.expectedRevision)
+      .returningAll().executeTakeFirst();
+    if (!row) throw new AiFundedPolicyError("revision_conflict");
+    return FundedAiGlobalPolicySchema.parse({
+      enabled: row.enabled,
+      revision: row.revision,
+      allowedModelIds,
+      updatedAt: row.updated_at,
+    });
+  }
+
+  async function setRuntimePolicy(input: SetRuntimePolicyInput) {
+    const parsed = RuntimePolicyUpdateSchema.parse(input);
+    const identity = parsed.identity;
+    const allowedModelIds = parsed.allowedModelIds;
+    const at = now().toISOString();
+    return options.db.transaction(async (trx) => {
+      const machine = await trx.executor.selectFrom("user_machines").select([
+        "machine_id", "clerk_user_id", "runtime_slot", "status", "activation_state", "deleted_at",
+      ]).where("machine_id", "=", identity.machineId).forUpdate().executeTakeFirst();
+      if (!machine || machine.clerk_user_id !== identity.ownerId || machine.runtime_slot !== identity.runtimeSlot
+        || machine.status !== "running" || machine.activation_state !== "authorized" || machine.deleted_at !== null) {
+        throw new AiFundedPolicyError("identity_mismatch");
+      }
+      await trx.executor.insertInto("ai_funded_runtime_policies").values({
+        machine_id: identity.machineId,
+        owner_id: identity.ownerId,
+        runtime_slot: identity.runtimeSlot,
+        enabled: false,
+        allowed_model_ids: "[]",
+        expires_at: null,
+        next_issue_at: "1970-01-01T00:00:00.000Z",
+        revision: 0,
+        created_at: at,
+        updated_at: at,
+      }).onConflict((conflict) => conflict.column("machine_id").doNothing()).execute();
+      const row = await trx.executor.updateTable("ai_funded_runtime_policies").set({
+        enabled: parsed.enabled,
+        allowed_model_ids: JSON.stringify(allowedModelIds),
+        expires_at: parsed.expiresAt,
+        revision: parsed.expectedRevision + 1,
+        updated_at: at,
+      }).where("machine_id", "=", identity.machineId).where("owner_id", "=", identity.ownerId)
+        .where("runtime_slot", "=", identity.runtimeSlot).where("revision", "=", parsed.expectedRevision)
+        .returningAll().executeTakeFirst();
+      if (!row) throw new AiFundedPolicyError("revision_conflict");
+      return {
+        identity,
+        enabled: row.enabled,
+        revision: row.revision,
+        allowedModelIds,
+        expiresAt: row.expires_at,
+        updatedAt: row.updated_at,
+      };
+    });
+  }
+
+  async function issueRuntimeCredential(identityInput: FundedAiIdentity): Promise<FundedAiRuntimeCredentialIssueResponse> {
+    const identity = IdentitySchema.parse(identityInput);
+    await options.db.ready;
+    const checked = now();
+    const checkedAt = checked.toISOString();
+    const nextIssueAt = new Date(checked.getTime() + issueCooldownMs).toISOString();
+    const expiresAt = new Date(checked.getTime() + credentialTtlMs).toISOString();
+    const tokenId = tokenIdFactory();
+    const secret = tokenSecretFactory();
+    const credential = `sk-matrix-funded-${tokenId}.${secret}`;
+    if (!TOKEN_PATTERN.test(credential)) throw new Error("Credential generator returned invalid material");
+    type IssuedRow = {
+      global_revision: number;
+      runtime_revision: number;
+      global_models: string;
+      runtime_models: string;
+      token_id: string;
+    };
+    const issued = await sql<IssuedRow>`
+      WITH eligible AS (
+        SELECT
+          runtime.machine_id,
+          runtime.revision AS runtime_revision,
+          runtime.allowed_model_ids AS runtime_models,
+          global_policy.revision AS global_revision,
+          global_policy.allowed_model_ids AS global_models
+        FROM ai_funded_runtime_policies runtime
+        JOIN user_machines machine ON machine.machine_id = runtime.machine_id
+        JOIN ai_funded_global_policy global_policy ON global_policy.policy_id = 'default'
+        WHERE runtime.machine_id = ${identity.machineId}
+          AND runtime.owner_id = ${identity.ownerId}
+          AND runtime.runtime_slot = ${identity.runtimeSlot}
+          AND machine.clerk_user_id = ${identity.ownerId}
+          AND machine.runtime_slot = ${identity.runtimeSlot}
+          AND machine.status = 'running'
+          AND machine.activation_state = 'authorized'
+          AND machine.deleted_at IS NULL
+          AND runtime.enabled = TRUE
+          AND global_policy.enabled = TRUE
+          AND (runtime.expires_at IS NULL OR runtime.expires_at > ${checkedAt})
+          AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements_text(global_policy.allowed_model_ids::jsonb) global_model(value)
+            JOIN jsonb_array_elements_text(runtime.allowed_model_ids::jsonb) runtime_model(value)
+              ON runtime_model.value = global_model.value
+          )
+      ), leased AS (
+        UPDATE ai_funded_runtime_policies runtime
+        SET next_issue_at = ${nextIssueAt}
+        FROM eligible
+        WHERE runtime.machine_id = eligible.machine_id
+          AND runtime.next_issue_at <= ${checkedAt}
+        RETURNING eligible.global_revision, eligible.runtime_revision,
+          eligible.global_models, eligible.runtime_models
+      ), inserted AS (
+        INSERT INTO ai_runtime_credentials (
+          token_id, token_hash, owner_id, machine_id, runtime_slot,
+          audience, scope, issued_at, expires_at, revoked_at
+        )
+        SELECT ${tokenId}, ${hashCredential(credential)}, ${identity.ownerId}, ${identity.machineId},
+          ${identity.runtimeSlot}, ${FUNDED_AI_AUDIENCE}, ${FUNDED_AI_SCOPE}, ${checkedAt}, ${expiresAt}, NULL
+        FROM leased
+        RETURNING token_id
+      )
+      SELECT leased.*, inserted.token_id FROM leased CROSS JOIN inserted
+    `.execute(options.db.executor);
+    const row = issued.rows[0];
+    if (!row) {
+      const policy = await options.db.executor.selectFrom("ai_funded_runtime_policies as runtime")
+        .innerJoin("ai_funded_global_policy as global_policy", (join) => join.onRef("global_policy.policy_id", "=", "global_policy.policy_id"))
+        .select(["runtime.next_issue_at", "runtime.enabled as runtime_enabled", "runtime.expires_at",
+          "global_policy.enabled as global_enabled"])
+        .where("runtime.machine_id", "=", identity.machineId).where("runtime.owner_id", "=", identity.ownerId)
+        .where("runtime.runtime_slot", "=", identity.runtimeSlot).where("global_policy.policy_id", "=", "default")
+        .executeTakeFirst();
+      if (policy && policy.global_enabled && policy.runtime_enabled
+        && (policy.expires_at === null || Date.parse(policy.expires_at) > checked.getTime())
+        && policy.next_issue_at > checkedAt) throw new AiFundedPolicyError("rate_limited");
+      throw new AiFundedPolicyError(policy ? "access_disabled" : "identity_mismatch");
+    }
+    const allowedModelIds = intersectModels(parseModels(row.global_models), parseModels(row.runtime_models));
+    return FundedAiRuntimeCredentialIssueResponseSchema.parse({
+      contractVersion: 1,
+      credential: { token: credential, tokenId: row.token_id, audience: FUNDED_AI_AUDIENCE, scope: FUNDED_AI_SCOPE, issuedAt: checkedAt, expiresAt },
+      identity,
+      policy: {
+        enabled: true,
+        globalRevision: row.global_revision,
+        runtimeRevision: row.runtime_revision,
+        allowedModelIds,
+        checkedAt,
+        staleAfter: new Date(checked.getTime() + policyFreshnessMs).toISOString(),
+      },
+    });
+  }
+
+  async function authorize(input: { credential: string; modelId: string }): Promise<FundedAiAuthorizationResponse> {
+    const match = TOKEN_PATTERN.exec(input.credential);
+    if (!match) throw new AiFundedPolicyError("unauthorized");
+    await options.db.ready;
+    const checked = now();
+    const row = await options.db.executor.selectFrom("ai_runtime_credentials as credential")
+      .innerJoin("ai_funded_runtime_policies as runtime", "runtime.machine_id", "credential.machine_id")
+      .innerJoin("user_machines as machine", "machine.machine_id", "credential.machine_id")
+      .innerJoin("ai_funded_global_policy as global", (join) => join.onRef("global.policy_id", "=", "global.policy_id"))
+      .select([
+        "credential.token_id", "credential.token_hash", "credential.owner_id", "credential.machine_id",
+        "credential.runtime_slot", "credential.audience", "credential.scope", "credential.expires_at",
+        "credential.revoked_at", "runtime.enabled as runtime_enabled", "runtime.allowed_model_ids as runtime_models",
+        "runtime.expires_at as runtime_expires_at", "runtime.revision as runtime_revision",
+        "global.enabled as global_enabled", "global.allowed_model_ids as global_models", "global.revision as global_revision",
+        "machine.clerk_user_id", "machine.runtime_slot as machine_runtime_slot", "machine.status",
+        "machine.activation_state", "machine.deleted_at",
+      ]).where("credential.token_id", "=", match[1]).where("global.policy_id", "=", "default").executeTakeFirst();
+    if (!row || !hashesEqual(row.token_hash, hashCredential(input.credential)) || row.revoked_at !== null
+      || Date.parse(row.expires_at) <= checked.getTime() || row.audience !== FUNDED_AI_AUDIENCE || row.scope !== FUNDED_AI_SCOPE
+      || row.clerk_user_id !== row.owner_id || row.machine_runtime_slot !== row.runtime_slot
+      || row.status !== "running" || row.activation_state !== "authorized" || row.deleted_at !== null) {
+      throw new AiFundedPolicyError("unauthorized");
+    }
+    const runtimeCurrent = row.runtime_expires_at === null || Date.parse(row.runtime_expires_at) > checked.getTime();
+    if (!row.global_enabled || !row.runtime_enabled || !runtimeCurrent) throw new AiFundedPolicyError("access_disabled");
+    const allowedModelIds = intersectModels(parseModels(row.global_models), parseModels(row.runtime_models));
+    if (!allowedModelIds.includes(input.modelId)) throw new AiFundedPolicyError("model_not_allowed");
+    const checkedAt = checked.toISOString();
+    return FundedAiAuthorizationResponseSchema.parse({
+      contractVersion: 1,
+      authorized: true,
+      identity: {
+        tokenId: row.token_id,
+        ownerId: row.owner_id,
+        machineId: row.machine_id,
+        runtimeSlot: row.runtime_slot,
+        audience: FUNDED_AI_AUDIENCE,
+        scope: FUNDED_AI_SCOPE,
+        expiresAt: row.expires_at,
+      },
+      policy: {
+        enabled: true,
+        globalRevision: row.global_revision,
+        runtimeRevision: row.runtime_revision,
+        allowedModelIds,
+        checkedAt,
+        staleAfter: new Date(checked.getTime() + policyFreshnessMs).toISOString(),
+      },
+    });
+  }
+
+  async function revokeRuntimeCredential(input: { tokenId: string; identity: FundedAiIdentity }): Promise<boolean> {
+    const identity = IdentitySchema.parse(input.identity);
+    await options.db.ready;
+    const result = await options.db.executor.updateTable("ai_runtime_credentials").set({ revoked_at: now().toISOString() })
+      .where("token_id", "=", input.tokenId).where("owner_id", "=", identity.ownerId)
+      .where("machine_id", "=", identity.machineId).where("runtime_slot", "=", identity.runtimeSlot)
+      .where("revoked_at", "is", null).executeTakeFirst();
+    return Number(result.numUpdatedRows) === 1;
+  }
+
+  return { getGlobalPolicy, updateGlobalPolicy, setRuntimePolicy, issueRuntimeCredential, authorize, revokeRuntimeCredential };
+}
+
+export type AiFundedPolicyRepository = ReturnType<typeof createAiFundedPolicyRepository>;

--- a/packages/platform/src/ai-funded-policy-repository.ts
+++ b/packages/platform/src/ai-funded-policy-repository.ts
@@ -66,7 +66,13 @@ export type SetRuntimePolicyInput = z.infer<typeof RuntimePolicyUpdateSchema>;
 function parseModels(value: string): string[] {
   try {
     return ModelIdsSchema.parse(JSON.parse(value));
-  } catch (error) {
+  } catch (error: unknown) {
+    const category = error instanceof SyntaxError
+      ? "syntax_error"
+      : error instanceof z.ZodError
+        ? "schema_error"
+        : "unexpected_error";
+    console.error(`[ai-funded-policy] invalid stored model configuration (${category})`);
     throw new Error("Invalid funded AI policy model configuration", { cause: error });
   }
 }

--- a/packages/platform/src/ai-funded-policy-routes.ts
+++ b/packages/platform/src/ai-funded-policy-routes.ts
@@ -93,7 +93,11 @@ async function readStrictJson(c: Context): Promise<unknown> {
   if (text.trim() === "") return {};
   try {
     return JSON.parse(text) as unknown;
-  } catch {
+  } catch (error: unknown) {
+    const category = error instanceof SyntaxError ? "syntax_error" : "unexpected_error";
+    // Log only a coarse category. The request body may contain provider
+    // credentials and must never be included in platform logs.
+    console.warn(`[ai-funded-policy] invalid JSON body (${category})`);
     return Symbol.for("invalid-json");
   }
 }

--- a/packages/platform/src/ai-funded-policy-routes.ts
+++ b/packages/platform/src/ai-funded-policy-routes.ts
@@ -1,0 +1,175 @@
+import {
+  FundedAiAuthorizationRequestSchema,
+  FundedAiSafeErrorSchema,
+  type FundedAiSafeError,
+} from "@matrix-os/contracts";
+import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { z } from "zod/v4";
+import { getRunningUserMachineByHandle, type PlatformDB } from "./db.js";
+import { AiFundedPolicyError, type AiFundedPolicyRepository } from "./ai-funded-policy-repository.js";
+import { buildPlatformRuntimeVerificationToken, timingSafeTokenEquals } from "./platform-token.js";
+
+const RUNTIME_BODY_LIMIT = 1024;
+const RELAY_BODY_LIMIT = 4 * 1024;
+const HandleSchema = z.string().min(1).max(63).regex(/^[a-z0-9][a-z0-9-]*$/);
+const EmptyBodySchema = z.object({}).strict();
+
+export type AiFundedControlPlaneConfig = { enabled: false } | {
+  enabled: true;
+  platformSecret: string;
+  relayControlToken: string;
+  credentialHashSecret: string;
+  credentialTtlMs: number;
+  issueCooldownMs: number;
+  policyFreshnessMs: number;
+};
+
+function boundedInteger(raw: string | undefined, fallback: number, min: number, max: number): number {
+  if (raw === undefined) return fallback;
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw new Error("Funded AI control plane is misconfigured");
+  }
+  return value;
+}
+
+export function loadAiFundedControlPlaneConfig(env: NodeJS.ProcessEnv): AiFundedControlPlaneConfig {
+  if (env.MATRIX_FUNDED_AI_CONTROL_PLANE_ENABLED !== "true") return { enabled: false };
+  const platformSecret = env.PLATFORM_SECRET ?? "";
+  const relayControlToken = env.AI_RELAY_CONTROL_TOKEN ?? "";
+  const credentialHashSecret = env.AI_FUNDED_CREDENTIAL_HASH_SECRET ?? "";
+  const secrets = [platformSecret, relayControlToken, credentialHashSecret];
+  if (secrets.some((secret) => secret.length < 32) || new Set(secrets).size !== secrets.length) {
+    throw new Error("Funded AI control plane credentials are misconfigured");
+  }
+  return {
+    enabled: true,
+    platformSecret,
+    relayControlToken,
+    credentialHashSecret,
+    credentialTtlMs: boundedInteger(env.AI_FUNDED_CREDENTIAL_TTL_MS, 15 * 60_000, 60_000, 60 * 60_000),
+    issueCooldownMs: boundedInteger(env.AI_FUNDED_ISSUE_COOLDOWN_MS, 30_000, 1_000, 60 * 60_000),
+    policyFreshnessMs: boundedInteger(env.AI_FUNDED_POLICY_FRESHNESS_MS, 60_000, 1_000, 5 * 60_000),
+  };
+}
+
+function noStore(c: Context): void {
+  c.header("Cache-Control", "no-store, private");
+  c.header("CDN-Cache-Control", "no-store");
+  c.header("Cloudflare-CDN-Cache-Control", "no-store");
+}
+
+function safeError(code: FundedAiSafeError["error"]["code"]): FundedAiSafeError {
+  const message = {
+    unauthorized: "Unauthorized",
+    access_disabled: "Matrix-funded AI is unavailable",
+    model_not_allowed: "This model is not available",
+    rate_limited: "Try again later",
+    revision_conflict: "Policy changed; refresh and try again",
+    invalid_request: "Invalid request",
+    not_found: "Runtime not found",
+    unavailable: "Service unavailable",
+  }[code];
+  return FundedAiSafeErrorSchema.parse({ error: { code, message } });
+}
+
+function policyErrorResponse(c: Context, error: unknown) {
+  if (error instanceof AiFundedPolicyError) {
+    if (error.code === "unauthorized") return c.json(safeError("unauthorized"), 401);
+    if (error.code === "identity_mismatch") return c.json(safeError("not_found"), 404);
+    if (error.code === "rate_limited") return c.json(safeError("rate_limited"), 429);
+    if (error.code === "revision_conflict") return c.json(safeError("revision_conflict"), 409);
+    if (error.code === "model_not_allowed") return c.json(safeError("model_not_allowed"), 403);
+    return c.json(safeError("access_disabled"), 403);
+  }
+  const errorName = error instanceof Error ? error.name : typeof error;
+  console.error(`[ai-funded-policy] request failed (${errorName})`);
+  return c.json(safeError("unavailable"), 503);
+}
+
+async function readStrictJson(c: Context): Promise<unknown> {
+  const text = await c.req.text();
+  if (text.trim() === "") return {};
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return Symbol.for("invalid-json");
+  }
+}
+
+export function createAiFundedRuntimeRoutes(options: {
+  db: PlatformDB;
+  platformSecret: string;
+  repository: AiFundedPolicyRepository;
+}) {
+  if (options.platformSecret.length < 32) throw new Error("Funded AI runtime authentication is misconfigured");
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    noStore(c);
+    const parsedHandle = HandleSchema.safeParse(c.req.param("handle"));
+    if (!parsedHandle.success) return c.json(safeError("invalid_request"), 400);
+    return next();
+  });
+  app.post("/funded-credential", bodyLimit({ maxSize: RUNTIME_BODY_LIMIT }), async (c) => {
+    const handle = HandleSchema.parse(c.req.param("handle"));
+    let machine: Awaited<ReturnType<typeof getRunningUserMachineByHandle>>;
+    try {
+      machine = await getRunningUserMachineByHandle(options.db, handle);
+    } catch (error) {
+      return policyErrorResponse(c, error);
+    }
+    if (!machine) return c.json(safeError("unauthorized"), 401);
+    const authorization = c.req.header("authorization");
+    const token = authorization?.startsWith("Bearer ") ? authorization.slice(7) : undefined;
+    const expected = buildPlatformRuntimeVerificationToken({
+      handle,
+      machineId: machine.machineId,
+      runtimeSlot: machine.runtimeSlot,
+    }, options.platformSecret);
+    if (!timingSafeTokenEquals(token, expected)) return c.json(safeError("unauthorized"), 401);
+    const body = EmptyBodySchema.safeParse(await readStrictJson(c));
+    if (!body.success) return c.json(safeError("invalid_request"), 400);
+    try {
+      const issued = await options.repository.issueRuntimeCredential({
+        ownerId: machine.clerkUserId,
+        machineId: machine.machineId,
+        runtimeSlot: machine.runtimeSlot,
+      });
+      return c.json(issued, 200);
+    } catch (error) {
+      return policyErrorResponse(c, error);
+    }
+  });
+  return app;
+}
+
+export function createAiFundedRelayRoutes(options: {
+  relayControlToken: string;
+  repository: AiFundedPolicyRepository;
+}) {
+  if (options.relayControlToken.length < 32) throw new Error("Funded AI relay authentication is misconfigured");
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    noStore(c);
+    const authorization = c.req.header("authorization");
+    const token = authorization?.startsWith("Bearer ") ? authorization.slice(7) : undefined;
+    if (!timingSafeTokenEquals(token, options.relayControlToken)) {
+      return c.json(safeError("unauthorized"), 401);
+    }
+    return next();
+  });
+  app.post("/authorize", bodyLimit({ maxSize: RELAY_BODY_LIMIT }), async (c) => {
+    const request = FundedAiAuthorizationRequestSchema.safeParse(await readStrictJson(c));
+    if (!request.success) return c.json(safeError("invalid_request"), 400);
+    try {
+      return c.json(await options.repository.authorize({
+        credential: request.data.credential,
+        modelId: request.data.modelId,
+      }), 200);
+    } catch (error) {
+      return policyErrorResponse(c, error);
+    }
+  });
+  return app;
+}

--- a/packages/platform/src/ai-funded-policy-routes.ts
+++ b/packages/platform/src/ai-funded-policy-routes.ts
@@ -6,6 +6,7 @@ import {
 import { Hono, type Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { z } from "zod/v4";
+import { RuntimeSlotSchema } from "./customer-vps-schema.js";
 import { getRunningUserMachineByHandle, type PlatformDB } from "./db.js";
 import { AiFundedPolicyError, type AiFundedPolicyRepository } from "./ai-funded-policy-repository.js";
 import { buildPlatformRuntimeVerificationToken, timingSafeTokenEquals } from "./platform-token.js";
@@ -14,6 +15,7 @@ const RUNTIME_BODY_LIMIT = 1024;
 const RELAY_BODY_LIMIT = 4 * 1024;
 const HandleSchema = z.string().min(1).max(63).regex(/^[a-z0-9][a-z0-9-]*$/);
 const EmptyBodySchema = z.object({}).strict();
+const RuntimeQuerySchema = z.object({ runtimeSlot: RuntimeSlotSchema }).strict();
 
 export type AiFundedControlPlaneConfig = { enabled: false } | {
   enabled: true;
@@ -117,9 +119,11 @@ export function createAiFundedRuntimeRoutes(options: {
   });
   app.post("/funded-credential", bodyLimit({ maxSize: RUNTIME_BODY_LIMIT }), async (c) => {
     const handle = HandleSchema.parse(c.req.param("handle"));
+    const query = RuntimeQuerySchema.safeParse(Object.fromEntries(new URL(c.req.url).searchParams));
+    if (!query.success) return c.json(safeError("invalid_request"), 400);
     let machine: Awaited<ReturnType<typeof getRunningUserMachineByHandle>>;
     try {
-      machine = await getRunningUserMachineByHandle(options.db, handle);
+      machine = await getRunningUserMachineByHandle(options.db, handle, query.data.runtimeSlot);
     } catch (error) {
       return policyErrorResponse(c, error);
     }

--- a/packages/platform/src/customer-vps-cloud-init.ts
+++ b/packages/platform/src/customer-vps-cloud-init.ts
@@ -13,6 +13,7 @@ export interface CustomerHostConfig {
   platformRegisterUrl: string;
   platformInternalUrl: string;
   platformVerificationToken: string;
+  fundedAiRuntimeToken: string;
   registrationToken: string;
   postgresPassword: string;
   posthogToken: string;
@@ -29,6 +30,7 @@ const SECRET_KEYS = [
   'registrationToken',
   'postgresPassword',
   'platformVerificationToken',
+  'fundedAiRuntimeToken',
 ] as const;
 const REQUIRED_KEYS = ['hostBundleUrl', ...SECRET_KEYS] as const;
 

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -42,7 +42,10 @@ import {
   registrationTokenMatches,
   type RegistrationToken,
 } from './customer-vps-auth.js';
-import { buildPlatformVerificationToken } from './platform-token.js';
+import {
+  buildPlatformRuntimeVerificationToken,
+  buildPlatformVerificationToken,
+} from './platform-token.js';
 import type { HetznerClient } from './customer-vps-hetzner.js';
 import {
   CustomerVpsError,
@@ -247,6 +250,7 @@ const DEFAULT_CLOUD_INIT_TEMPLATE = [
   '      PLATFORM_INTERNAL_URL={{platformInternalUrl}}',
   '      UPGRADE_TOKEN={{platformVerificationToken}}',
   '      MATRIX_AUTH_TOKEN={{platformVerificationToken}}',
+  '      MATRIX_FUNDED_AI_RUNTIME_TOKEN={{fundedAiRuntimeToken}}',
   '      MATRIX_CODE_PROXY_TOKEN={{platformVerificationToken}}',
   '      POSTHOG_TOKEN={{posthogToken}}',
   '      POSTHOG_PROJECT_TOKEN={{posthogProjectToken}}',
@@ -359,6 +363,11 @@ function buildHostConfig(
     platformRegisterUrl: config.platformRegisterUrl,
     platformInternalUrl: new URL(config.platformRegisterUrl).origin,
     platformVerificationToken: buildPlatformVerificationToken(input.handle, config.platformSecret),
+    fundedAiRuntimeToken: buildPlatformRuntimeVerificationToken({
+      handle: input.handle,
+      machineId,
+      runtimeSlot: input.runtimeSlot,
+    }, config.platformSecret),
     registrationToken,
     postgresPassword,
     posthogToken: config.posthogToken,

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -97,6 +97,40 @@ interface UserMachinesTable {
   activation_authorized_at: Generated<string | null>;
 }
 
+export interface AiFundedGlobalPolicyTable {
+  policy_id: string;
+  enabled: boolean;
+  allowed_model_ids: string;
+  revision: number;
+  updated_at: string;
+}
+
+export interface AiFundedRuntimePoliciesTable {
+  machine_id: string;
+  owner_id: string;
+  runtime_slot: string;
+  enabled: boolean;
+  allowed_model_ids: string;
+  expires_at: string | null;
+  next_issue_at: string;
+  revision: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AiRuntimeCredentialsTable {
+  token_id: string;
+  token_hash: string;
+  owner_id: string;
+  machine_id: string;
+  runtime_slot: string;
+  audience: string;
+  scope: string;
+  issued_at: string;
+  expires_at: string;
+  revoked_at: string | null;
+}
+
 export interface ProvisioningJobsTable {
   job_id: string;
   machine_id: string;
@@ -576,6 +610,9 @@ export interface PlatformDatabase {
   users: UsersTable;
   containers: ContainersTable;
   user_machines: UserMachinesTable;
+  ai_funded_global_policy: AiFundedGlobalPolicyTable;
+  ai_funded_runtime_policies: AiFundedRuntimePoliciesTable;
+  ai_runtime_credentials: AiRuntimeCredentialsTable;
   provisioning_jobs: ProvisioningJobsTable;
   billing_checkout_attempts: BillingCheckoutAttemptsTable;
   prebilling_provisioning_intents: PrebillingProvisioningIntentsTable;
@@ -1164,6 +1201,52 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
     WHERE deleted_at IS NULL AND provisioning_class = 'preview'
   `.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_user_machines_hetzner ON user_machines(hetzner_server_id)`.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS ai_funded_global_policy (
+      policy_id TEXT PRIMARY KEY CHECK (policy_id = 'default'),
+      enabled BOOLEAN NOT NULL DEFAULT FALSE,
+      allowed_model_ids TEXT NOT NULL DEFAULT '[]',
+      revision INTEGER NOT NULL DEFAULT 0 CHECK (revision >= 0),
+      updated_at TEXT NOT NULL
+    )
+  `.execute(db);
+  await sql`
+    INSERT INTO ai_funded_global_policy (policy_id, enabled, allowed_model_ids, revision, updated_at)
+    VALUES ('default', FALSE, '[]', 0, '1970-01-01T00:00:00.000Z')
+    ON CONFLICT (policy_id) DO NOTHING
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS ai_funded_runtime_policies (
+      machine_id TEXT PRIMARY KEY REFERENCES user_machines(machine_id) ON UPDATE CASCADE ON DELETE CASCADE,
+      owner_id TEXT NOT NULL,
+      runtime_slot TEXT NOT NULL,
+      enabled BOOLEAN NOT NULL DEFAULT FALSE,
+      allowed_model_ids TEXT NOT NULL DEFAULT '[]',
+      expires_at TEXT,
+      next_issue_at TEXT NOT NULL DEFAULT '1970-01-01T00:00:00.000Z',
+      revision INTEGER NOT NULL DEFAULT 0 CHECK (revision >= 0),
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `.execute(db);
+  await sql`ALTER TABLE ai_funded_runtime_policies ADD COLUMN IF NOT EXISTS next_issue_at TEXT NOT NULL DEFAULT '1970-01-01T00:00:00.000Z'`.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_ai_funded_runtime_owner ON ai_funded_runtime_policies(owner_id, runtime_slot)`.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS ai_runtime_credentials (
+      token_id TEXT PRIMARY KEY,
+      token_hash TEXT UNIQUE NOT NULL CHECK (length(token_hash) = 64),
+      owner_id TEXT NOT NULL,
+      machine_id TEXT NOT NULL REFERENCES user_machines(machine_id) ON UPDATE CASCADE ON DELETE CASCADE,
+      runtime_slot TEXT NOT NULL,
+      audience TEXT NOT NULL CHECK (audience = 'matrix-funded-relay'),
+      scope TEXT NOT NULL CHECK (scope = 'ai:invoke'),
+      issued_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      revoked_at TEXT
+    )
+  `.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_ai_runtime_credentials_machine_issued ON ai_runtime_credentials(machine_id, issued_at DESC)`.execute(db);
 
   await sql`
     CREATE TABLE IF NOT EXISTS provisioning_jobs (

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -322,6 +322,8 @@ export function createApp(deps: {
   integrationRoutes?: Hono<any>;
   internalIntegrationRoutes?: Hono<any>;
   internalSyncRoutes?: Hono<any>;
+  internalFundedAiRuntimeRoutes?: Hono<any>;
+  internalFundedAiRelayRoutes?: Hono<any>;
   customerVpsService?: CustomerVpsService;
   goldenSnapshotService?: GoldenSnapshotService;
   goldenSnapshotConfig?: GoldenSnapshotRuntimeConfig;
@@ -724,6 +726,12 @@ export function createApp(deps: {
   }
   if (deps.internalSyncRoutes) {
     app.route('/internal/containers/:handle/sync', deps.internalSyncRoutes);
+  }
+  if (deps.internalFundedAiRuntimeRoutes) {
+    app.route('/internal/containers/:handle/ai', deps.internalFundedAiRuntimeRoutes);
+  }
+  if (deps.internalFundedAiRelayRoutes) {
+    app.route('/internal/ai/funded', deps.internalFundedAiRelayRoutes);
   }
   app.get('/vps/releases', async (c) => {
     if (!platformSecret) {

--- a/packages/platform/src/platform-startup.ts
+++ b/packages/platform/src/platform-startup.ts
@@ -42,6 +42,12 @@ import { logPlatformRouteError } from './platform-route-utils.js';
 import { CustomerVpsError } from './customer-vps-errors.js';
 import { dispatchBillingRuntimeActions } from './billing-runtime-actions.js';
 import { registerPlatformWebSocketUpgradeHandler } from './platform-websocket-upgrade.js';
+import { createAiFundedPolicyRepository } from './ai-funded-policy-repository.js';
+import {
+  createAiFundedRelayRoutes,
+  createAiFundedRuntimeRoutes,
+  loadAiFundedControlPlaneConfig,
+} from './ai-funded-policy-routes.js';
 import {
   createR2CapabilityGate,
   createStorageGatedHetznerClient,
@@ -156,6 +162,8 @@ type CreatePlatformApp = (deps: {
   integrationRoutes?: Hono<any>;
   internalIntegrationRoutes?: Hono<any>;
   internalSyncRoutes?: Hono<any>;
+  internalFundedAiRuntimeRoutes?: Hono<any>;
+  internalFundedAiRelayRoutes?: Hono<any>;
   customerVpsService?: CustomerVpsService;
   goldenSnapshotService?: GoldenSnapshotService;
   goldenSnapshotConfig?: GoldenSnapshotRuntimeConfig;
@@ -246,6 +254,31 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
   const atsDatabaseUrl = resolveAtsDatabaseUrl(process.env);
   const db = createPlatformDb(runtimeConfig.platformDatabaseUrl);
   await db.ready;
+  const fundedAiConfig = loadAiFundedControlPlaneConfig({
+    ...process.env,
+    PLATFORM_SECRET: platformSecret,
+  });
+  let internalFundedAiRuntimeRoutes: Hono | undefined;
+  let internalFundedAiRelayRoutes: Hono | undefined;
+  if (fundedAiConfig.enabled) {
+    const fundedAiRepository = createAiFundedPolicyRepository({
+      db,
+      credentialHashSecret: fundedAiConfig.credentialHashSecret,
+      credentialTtlMs: fundedAiConfig.credentialTtlMs,
+      issueCooldownMs: fundedAiConfig.issueCooldownMs,
+      policyFreshnessMs: fundedAiConfig.policyFreshnessMs,
+    });
+    internalFundedAiRuntimeRoutes = createAiFundedRuntimeRoutes({
+      db,
+      platformSecret: fundedAiConfig.platformSecret,
+      repository: fundedAiRepository,
+    });
+    internalFundedAiRelayRoutes = createAiFundedRelayRoutes({
+      relayControlToken: fundedAiConfig.relayControlToken,
+      repository: fundedAiRepository,
+    });
+    console.log('[platform] Funded AI control plane enabled; relay activation remains disabled');
+  }
   const atsDb = atsDatabaseUrl ? createAtsDb(atsDatabaseUrl) : undefined;
   await atsDb?.ready;
 
@@ -735,6 +768,8 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
     integrationRoutes,
     internalIntegrationRoutes,
     internalSyncRoutes,
+    internalFundedAiRuntimeRoutes,
+    internalFundedAiRelayRoutes,
     customerVpsService,
     goldenSnapshotService,
     goldenSnapshotConfig,

--- a/packages/platform/src/platform-token.ts
+++ b/packages/platform/src/platform-token.ts
@@ -18,3 +18,18 @@ export function timingSafeTokenEquals(actual: string | undefined, expected: stri
 export function buildPlatformVerificationToken(handle: string, platformSecret: string): string {
   return createHmac("sha256", platformSecret).update(handle).digest("hex");
 }
+
+export function buildPlatformRuntimeVerificationToken(
+  identity: { handle: string; machineId: string; runtimeSlot: string },
+  platformSecret: string,
+): string {
+  return createHmac("sha256", platformSecret)
+    .update(JSON.stringify([
+      "matrix-funded-ai-runtime",
+      1,
+      identity.handle,
+      identity.machineId,
+      identity.runtimeSlot,
+    ]))
+    .digest("hex");
+}

--- a/packages/ui/src/agents-providers/provider-settings-controller.ts
+++ b/packages/ui/src/agents-providers/provider-settings-controller.ts
@@ -142,7 +142,12 @@ export class ProviderSettingsController {
       this.pendingMutations -= 1;
       this.syncBusy();
     });
-    this.mutationTail = tracked.catch(() => undefined);
+    this.mutationTail = tracked.catch((error: unknown) => {
+      console.warn(
+        "[provider-settings] Mutation queue recovered:",
+        error instanceof Error ? error.name : typeof error,
+      );
+    });
     return tracked;
   };
 

--- a/tests/contracts/funded-ai.test.ts
+++ b/tests/contracts/funded-ai.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  FundedAiAuthorizationRequestSchema,
+  FundedAiAuthorizationResponseSchema,
+  FundedAiGlobalPolicySchema,
+  FundedAiRuntimeCredentialIssueResponseSchema,
+  FundedAiSafeErrorSchema,
+} from "@matrix-os/contracts";
+
+const now = "2026-08-30T20:00:00.000Z";
+const staleAfter = "2026-08-30T20:01:00.000Z";
+const expiresAt = "2026-08-30T20:15:00.000Z";
+const tokenId = "credential_123";
+const credential = `sk-matrix-funded-${tokenId}.${"s".repeat(43)}`;
+
+const policy = {
+  enabled: true,
+  globalRevision: 4,
+  runtimeRevision: 2,
+  allowedModelIds: ["anthropic/claude-sonnet-5"],
+  checkedAt: now,
+  staleAfter,
+} as const;
+
+describe("funded AI control-plane contracts", () => {
+  it("represents a bounded dynamic global policy without credentials", () => {
+    const value = {
+      enabled: true,
+      revision: 4,
+      allowedModelIds: ["anthropic/claude-sonnet-5"],
+      updatedAt: now,
+    } as const;
+    expect(FundedAiGlobalPolicySchema.parse(value)).toEqual(value);
+    expect(FundedAiGlobalPolicySchema.safeParse({
+      ...value,
+      allowedModelIds: [value.allowedModelIds[0], value.allowedModelIds[0]],
+    }).success).toBe(false);
+    expect(FundedAiGlobalPolicySchema.safeParse({ ...value, gatewayToken: "secret" }).success).toBe(false);
+  });
+
+  it("issues an opaque short-lived credential with explicit audience and scope", () => {
+    const value = {
+      contractVersion: 1,
+      credential: {
+        token: credential,
+        tokenId,
+        audience: "matrix-funded-relay",
+        scope: "ai:invoke",
+        issuedAt: now,
+        expiresAt,
+      },
+      identity: {
+        ownerId: "user_alice",
+        machineId: "machine_123",
+        runtimeSlot: "primary",
+      },
+      policy,
+    } as const;
+    expect(FundedAiRuntimeCredentialIssueResponseSchema.parse(value)).toEqual(value);
+    expect(FundedAiRuntimeCredentialIssueResponseSchema.safeParse({
+      ...value,
+      credential: { ...value.credential, scope: "admin" },
+    }).success).toBe(false);
+    expect(FundedAiRuntimeCredentialIssueResponseSchema.safeParse({
+      ...value,
+      tokenHash: "must-never-leave-the-platform",
+    }).success).toBe(false);
+    expect(FundedAiRuntimeCredentialIssueResponseSchema.safeParse({
+      ...value,
+      credential: { ...value.credential, expiresAt: "2026-08-30T22:00:00.000Z" },
+    }).success).toBe(false);
+  });
+
+  it("authorizes one model and request without accepting caller identity", () => {
+    const request = {
+      credential,
+      requestId: "request_123",
+      modelId: "anthropic/claude-sonnet-5",
+    } as const;
+    expect(FundedAiAuthorizationRequestSchema.parse(request)).toEqual(request);
+    expect(FundedAiAuthorizationRequestSchema.safeParse({
+      ...request,
+      ownerId: "user_bob",
+      machineId: "machine_other",
+    }).success).toBe(false);
+
+    const response = {
+      contractVersion: 1,
+      authorized: true,
+      identity: {
+        tokenId,
+        ownerId: "user_alice",
+        machineId: "machine_123",
+        runtimeSlot: "primary",
+        audience: "matrix-funded-relay",
+        scope: "ai:invoke",
+        expiresAt,
+      },
+      policy,
+    } as const;
+    expect(FundedAiAuthorizationResponseSchema.parse(response)).toEqual(response);
+    expect(FundedAiAuthorizationResponseSchema.safeParse({ ...response, token: credential }).success).toBe(false);
+  });
+
+  it("allows only coarse, secret-free control-plane errors", () => {
+    expect(FundedAiSafeErrorSchema.safeParse({
+      error: { code: "access_disabled", message: "Matrix-funded AI is unavailable" },
+    }).success).toBe(true);
+    expect(FundedAiSafeErrorSchema.safeParse({
+      error: { code: "database_error", message: "postgresql://secret@db.internal" },
+    }).success).toBe(false);
+  });
+});

--- a/tests/platform/ai-funded-policy-repository.test.ts
+++ b/tests/platform/ai-funded-policy-repository.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  AiFundedPolicyError,
+  createAiFundedPolicyRepository,
+} from "../../packages/platform/src/ai-funded-policy-repository.js";
+import { insertUserMachine, type PlatformDB } from "../../packages/platform/src/db.js";
+import {
+  createTestPlatformDb,
+  destroyTestPlatformDb,
+} from "./platform-db-test-helper.js";
+
+const now = "2026-08-30T20:00:00.000Z";
+const models = ["anthropic/claude-sonnet-5", "anthropic/claude-opus-5"];
+
+describe("funded AI policy repository", () => {
+  let db: PlatformDB;
+
+  beforeEach(async () => {
+    ({ db } = await createTestPlatformDb());
+    await insertUserMachine(db, {
+      machineId: "machine_123",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      runtimeSlot: "primary",
+      hetznerServerId: 123,
+      publicIPv4: "203.0.113.10",
+      status: "running",
+      imageVersion: "v1",
+      provisionedAt: "2026-08-30T19:00:00.000Z",
+      activationState: "authorized",
+    });
+  });
+
+  afterEach(async () => {
+    await destroyTestPlatformDb(db);
+  });
+
+  function repository(at = now) {
+    const tokenIds = ["credential_123", "credential_456"];
+    return createAiFundedPolicyRepository({
+      db,
+      credentialHashSecret: "h".repeat(32),
+      now: () => new Date(at),
+      tokenIdFactory: () => tokenIds.shift() ?? "credential_fallback",
+      tokenSecretFactory: () => "s".repeat(43),
+      credentialTtlMs: 15 * 60_000,
+      issueCooldownMs: 60_000,
+    });
+  }
+
+  async function enableRuntime() {
+    const repo = repository();
+    await repo.updateGlobalPolicy({ expectedRevision: 0, enabled: true, allowedModelIds: models });
+    await repo.setRuntimePolicy({
+      identity: { ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary" },
+      expectedRevision: 0,
+      enabled: true,
+      allowedModelIds: [models[0]],
+      expiresAt: null,
+    });
+    return repo;
+  }
+
+  it("seeds a fail-closed global policy and enforces optimistic concurrency", async () => {
+    const repo = repository();
+    expect(await repo.getGlobalPolicy()).toMatchObject({ enabled: false, revision: 0, allowedModelIds: [] });
+
+    const results = await Promise.allSettled([
+      repo.updateGlobalPolicy({ expectedRevision: 0, enabled: true, allowedModelIds: [models[0]] }),
+      repo.updateGlobalPolicy({ expectedRevision: 0, enabled: true, allowedModelIds: [models[1]] }),
+    ]);
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const rejection = results.find((result) => result.status === "rejected") as PromiseRejectedResult;
+    expect(rejection.reason).toMatchObject({ code: "revision_conflict" });
+    expect(await repo.getGlobalPolicy()).toMatchObject({ enabled: true, revision: 1 });
+  });
+
+  it("binds runtime eligibility to the canonical machine identity", async () => {
+    const repo = repository();
+    await expect(repo.setRuntimePolicy({
+      identity: { ownerId: "user_bob", machineId: "machine_123", runtimeSlot: "primary" },
+      expectedRevision: 0,
+      enabled: true,
+      allowedModelIds: [models[0]],
+      expiresAt: null,
+    })).rejects.toMatchObject({ code: "identity_mismatch" });
+    await expect(repo.setRuntimePolicy({
+      identity: { ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary" },
+      expectedRevision: -1,
+      enabled: true,
+      allowedModelIds: [models[0]],
+      expiresAt: "not-a-timestamp",
+    })).rejects.toMatchObject({ name: "ZodError" });
+  });
+
+  it("stores only a hash and bounds concurrent credential issuance", async () => {
+    const repo = await enableRuntime();
+    const identity = { ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary" } as const;
+    const results = await Promise.allSettled([
+      repo.issueRuntimeCredential(identity),
+      repo.issueRuntimeCredential(identity),
+    ]);
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const issued = results.find((result) => result.status === "fulfilled") as PromiseFulfilledResult<unknown>;
+    expect(issued.value).toMatchObject({
+      credential: { token: expect.stringMatching(/^sk-matrix-funded-/), tokenId: "credential_123" },
+      identity,
+    });
+
+    const rows = await db.executor.selectFrom("ai_runtime_credentials").selectAll().execute();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].token_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(JSON.stringify(rows[0])).not.toContain("sk-matrix-funded-");
+    expect(results.find((result) => result.status === "rejected")).toMatchObject({
+      reason: { code: "rate_limited" },
+    });
+  });
+
+  it("authorizes from the token binding and immediately observes revocation and policy changes", async () => {
+    const repo = await enableRuntime();
+    const identity = { ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary" } as const;
+    const issued = await repo.issueRuntimeCredential(identity);
+    await expect(repo.authorize({ credential: issued.credential.token, modelId: models[0] }))
+      .resolves.toMatchObject({ authorized: true, identity });
+
+    await repo.revokeRuntimeCredential({ tokenId: issued.credential.tokenId, identity });
+    await expect(repo.authorize({ credential: issued.credential.token, modelId: models[0] }))
+      .rejects.toMatchObject({ code: "unauthorized" });
+
+    const nextRepo = createAiFundedPolicyRepository({
+      db,
+      credentialHashSecret: "h".repeat(32),
+      now: () => new Date("2026-08-30T20:02:00.000Z"),
+      tokenIdFactory: () => "credential_456",
+      tokenSecretFactory: () => "t".repeat(43),
+      credentialTtlMs: 15 * 60_000,
+      issueCooldownMs: 60_000,
+    });
+    const second = await nextRepo.issueRuntimeCredential(identity);
+    await repo.updateGlobalPolicy({ expectedRevision: 1, enabled: false, allowedModelIds: [] });
+    await expect(nextRepo.authorize({ credential: second.credential.token, modelId: models[0] }))
+      .rejects.toMatchObject({ code: "access_disabled" });
+  });
+
+  it("rejects expired credentials and models outside the effective intersection", async () => {
+    const repo = await enableRuntime();
+    const identity = { ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary" } as const;
+    const issued = await repo.issueRuntimeCredential(identity);
+    await expect(repo.authorize({ credential: issued.credential.token, modelId: models[1] }))
+      .rejects.toMatchObject({ code: "model_not_allowed" });
+
+    const expired = createAiFundedPolicyRepository({
+      db,
+      credentialHashSecret: "h".repeat(32),
+      now: () => new Date("2026-08-30T20:16:00.000Z"),
+    });
+    await expect(expired.authorize({ credential: issued.credential.token, modelId: models[0] }))
+      .rejects.toBeInstanceOf(AiFundedPolicyError);
+    await expect(expired.authorize({ credential: issued.credential.token, modelId: models[0] }))
+      .rejects.toMatchObject({ code: "unauthorized" });
+  });
+});

--- a/tests/platform/ai-funded-policy-repository.test.ts
+++ b/tests/platform/ai-funded-policy-repository.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AiFundedPolicyError,
   createAiFundedPolicyRepository,
@@ -33,6 +33,7 @@ describe("funded AI policy repository", () => {
 
   afterEach(async () => {
     await destroyTestPlatformDb(db);
+    vi.restoreAllMocks();
   });
 
   function repository(at = now) {
@@ -73,6 +74,45 @@ describe("funded AI policy repository", () => {
     const rejection = results.find((result) => result.status === "rejected") as PromiseRejectedResult;
     expect(rejection.reason).toMatchObject({ code: "revision_conflict" });
     expect(await repo.getGlobalPolicy()).toMatchObject({ enabled: true, revision: 1 });
+  });
+
+  it("logs coarse diagnostics and preserves causes for corrupt stored model policy", async () => {
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const repo = repository();
+    const corruptValue = '{"sk-provider-secret-do-not-log"';
+    await db.executor.updateTable("ai_funded_global_policy")
+      .set({ allowed_model_ids: corruptValue })
+      .where("policy_id", "=", "default").execute();
+
+    const syntaxFailure = await repo.getGlobalPolicy().then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    expect(syntaxFailure).toMatchObject({
+      message: "Invalid funded AI policy model configuration",
+      cause: expect.any(SyntaxError),
+    });
+    expect(errorLog).toHaveBeenCalledWith(
+      "[ai-funded-policy] invalid stored model configuration (syntax_error)",
+    );
+
+    await db.executor.updateTable("ai_funded_global_policy")
+      .set({ allowed_model_ids: JSON.stringify(["model value must not be logged"]) })
+      .where("policy_id", "=", "default").execute();
+    const schemaFailure = await repo.getGlobalPolicy().then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    expect(schemaFailure).toMatchObject({
+      message: "Invalid funded AI policy model configuration",
+      cause: expect.objectContaining({ name: "ZodError" }),
+    });
+    expect(errorLog).toHaveBeenCalledWith(
+      "[ai-funded-policy] invalid stored model configuration (schema_error)",
+    );
+    expect(JSON.stringify(errorLog.mock.calls)).not.toMatch(
+      /sk-provider-secret-do-not-log|model value must not be logged/,
+    );
   });
 
   it("binds runtime eligibility to the canonical machine identity", async () => {

--- a/tests/platform/ai-funded-policy-routes.test.ts
+++ b/tests/platform/ai-funded-policy-routes.test.ts
@@ -101,6 +101,10 @@ describe("funded AI policy routes", () => {
       method: "POST",
       headers: { authorization: `Bearer ${bearerFor("alice", "machine_predecessor")}` },
     })).status).toBe(401);
+    expect((await app.request("/internal/containers/alice/ai/funded-credential", {
+      method: "POST",
+      headers: { authorization: `Bearer ${bearerFor("alice", "machine_123", "staging")}` },
+    })).status).toBe(401);
   });
 
   it("rejects missing auth, malformed or oversized bodies, caller identity fields, and legacy-only handles", async () => {

--- a/tests/platform/ai-funded-policy-routes.test.ts
+++ b/tests/platform/ai-funded-policy-routes.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FundedAiRuntimeCredentialIssueResponseSchema } from "@matrix-os/contracts";
+import { createAiFundedPolicyRepository } from "../../packages/platform/src/ai-funded-policy-repository.js";
+import {
+  createAiFundedRelayRoutes,
+  createAiFundedRuntimeRoutes,
+  loadAiFundedControlPlaneConfig,
+} from "../../packages/platform/src/ai-funded-policy-routes.js";
+import { insertContainer, insertUserMachine, type PlatformDB } from "../../packages/platform/src/db.js";
+import { createApp } from "../../packages/platform/src/main.js";
+import type { Orchestrator } from "../../packages/platform/src/orchestrator.js";
+import { buildPlatformRuntimeVerificationToken } from "../../packages/platform/src/platform-token.js";
+import { createTestPlatformDb, destroyTestPlatformDb } from "./platform-db-test-helper.js";
+
+const platformSecret = "platform-secret-for-tests-123456789";
+const relayControlToken = "relay-control-token-for-tests-123456";
+const hashSecret = "credential-hash-secret-for-tests-123";
+const now = "2026-08-30T20:00:00.000Z";
+const modelId = "anthropic/claude-sonnet-5";
+
+function bearerFor(handle: string, machineId = "machine_123", runtimeSlot = "primary"): string {
+  return buildPlatformRuntimeVerificationToken({ handle, machineId, runtimeSlot }, platformSecret);
+}
+
+function stubOrchestrator(): Orchestrator {
+  return {
+    provision: vi.fn(), start: vi.fn(), stop: vi.fn(), destroy: vi.fn(), upgrade: vi.fn(),
+    rollingRestart: vi.fn(), getInfo: vi.fn(), getImage: vi.fn(), listAll: vi.fn().mockReturnValue([]),
+    syncStates: vi.fn(),
+  };
+}
+
+describe("funded AI policy routes", () => {
+  let db: PlatformDB;
+
+  beforeEach(async () => {
+    ({ db } = await createTestPlatformDb());
+    await insertUserMachine(db, {
+      machineId: "machine_123", clerkUserId: "user_alice", handle: "alice", runtimeSlot: "primary",
+      status: "running", imageVersion: "v1", provisionedAt: "2026-08-30T19:00:00.000Z",
+      activationState: "authorized",
+    });
+  });
+
+  afterEach(async () => {
+    await destroyTestPlatformDb(db);
+    vi.restoreAllMocks();
+  });
+
+  async function createTestApp() {
+    const repository = createAiFundedPolicyRepository({
+      db, credentialHashSecret: hashSecret, now: () => new Date(now),
+      tokenIdFactory: () => "credential_123", tokenSecretFactory: () => "s".repeat(43),
+      issueCooldownMs: 60_000,
+    });
+    await repository.updateGlobalPolicy({ expectedRevision: 0, enabled: true, allowedModelIds: [modelId] });
+    await repository.setRuntimePolicy({
+      identity: { ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary" },
+      expectedRevision: 0, enabled: true, allowedModelIds: [modelId], expiresAt: null,
+    });
+    return {
+      repository,
+      app: createApp({
+        db,
+        orchestrator: stubOrchestrator(),
+        platformSecret,
+        internalFundedAiRuntimeRoutes: createAiFundedRuntimeRoutes({ db, platformSecret, repository }),
+        internalFundedAiRelayRoutes: createAiFundedRelayRoutes({ relayControlToken, repository }),
+      }),
+    };
+  }
+
+  it("fails closed unless dedicated, distinct secrets are configured", () => {
+    expect(loadAiFundedControlPlaneConfig({})).toEqual({ enabled: false });
+    expect(() => loadAiFundedControlPlaneConfig({
+      MATRIX_FUNDED_AI_CONTROL_PLANE_ENABLED: "true",
+      PLATFORM_SECRET: platformSecret,
+      AI_RELAY_CONTROL_TOKEN: platformSecret,
+      AI_FUNDED_CREDENTIAL_HASH_SECRET: hashSecret,
+    })).toThrow(/misconfigured/i);
+    expect(loadAiFundedControlPlaneConfig({
+      MATRIX_FUNDED_AI_CONTROL_PLANE_ENABLED: "true",
+      PLATFORM_SECRET: platformSecret,
+      AI_RELAY_CONTROL_TOKEN: relayControlToken,
+      AI_FUNDED_CREDENTIAL_HASH_SECRET: hashSecret,
+    })).toMatchObject({ enabled: true, credentialTtlMs: 900_000 });
+  });
+
+  it("issues a scoped credential from the authenticated running machine record", async () => {
+    const { app } = await createTestApp();
+    const response = await app.request("/internal/containers/alice/ai/funded-credential", {
+      method: "POST",
+      headers: { authorization: `Bearer ${bearerFor("alice")}`, "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    const issued = FundedAiRuntimeCredentialIssueResponseSchema.parse(await response.json());
+    expect(issued.identity).toEqual({ ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary" });
+    expect((await app.request("/internal/containers/alice/ai/funded-credential", {
+      method: "POST",
+      headers: { authorization: `Bearer ${bearerFor("alice", "machine_predecessor")}` },
+    })).status).toBe(401);
+  });
+
+  it("rejects missing auth, caller identity fields, oversized bodies, and legacy-only handles", async () => {
+    const { app } = await createTestApp();
+    expect((await app.request("/internal/containers/alice/ai/funded-credential", { method: "POST" })).status).toBe(401);
+    const spoofed = await app.request("/internal/containers/alice/ai/funded-credential", {
+      method: "POST",
+      headers: { authorization: `Bearer ${bearerFor("alice")}`, "content-type": "application/json" },
+      body: JSON.stringify({ ownerId: "user_bob", machineId: "machine_other" }),
+    });
+    expect(spoofed.status).toBe(400);
+    const oversized = await app.request("/internal/containers/alice/ai/funded-credential", {
+      method: "POST",
+      headers: { authorization: `Bearer ${bearerFor("alice")}`, "content-type": "application/json" },
+      body: JSON.stringify({ padding: "x".repeat(2_000) }),
+    });
+    expect(oversized.status).toBe(413);
+
+    await insertContainer(db, {
+      handle: "legacy", clerkUserId: "user_legacy", port: 5001, shellPort: 6001, status: "running",
+    });
+    const legacy = await app.request("/internal/containers/legacy/ai/funded-credential", {
+      method: "POST", headers: { authorization: `Bearer ${bearerFor("legacy")}` },
+    });
+    expect(legacy.status).toBe(401);
+  });
+
+  it("authorizes only through the dedicated timing-safe relay service credential", async () => {
+    const { app } = await createTestApp();
+    const issuedResponse = await app.request("/internal/containers/alice/ai/funded-credential", {
+      method: "POST",
+      headers: { authorization: `Bearer ${bearerFor("alice")}`, "content-type": "application/json" },
+      body: "{}",
+    });
+    const issued = FundedAiRuntimeCredentialIssueResponseSchema.parse(await issuedResponse.json());
+    const body = JSON.stringify({ credential: issued.credential.token, requestId: "request_123", modelId });
+
+    const unauthenticated = await app.request("/internal/ai/funded/authorize", {
+      method: "POST", headers: { "content-type": "application/json" }, body,
+    });
+    expect(unauthenticated.status).toBe(401);
+    const authorized = await app.request("/internal/ai/funded/authorize", {
+      method: "POST",
+      headers: { authorization: `Bearer ${relayControlToken}`, "content-type": "application/json" },
+      body,
+    });
+    expect(authorized.status).toBe(200);
+    expect(await authorized.json()).toMatchObject({ authorized: true, identity: { ownerId: "user_alice" } });
+  });
+});

--- a/tests/platform/ai-funded-policy-routes.test.ts
+++ b/tests/platform/ai-funded-policy-routes.test.ts
@@ -22,6 +22,10 @@ function bearerFor(handle: string, machineId = "machine_123", runtimeSlot = "pri
   return buildPlatformRuntimeVerificationToken({ handle, machineId, runtimeSlot }, platformSecret);
 }
 
+function fundedCredentialPath(handle = "alice", runtimeSlot = "primary"): string {
+  return `/internal/containers/${handle}/ai/funded-credential?runtimeSlot=${runtimeSlot}`;
+}
+
 function stubOrchestrator(): Orchestrator {
   return {
     provision: vi.fn(), start: vi.fn(), stop: vi.fn(), destroy: vi.fn(), upgrade: vi.fn(),
@@ -88,7 +92,7 @@ describe("funded AI policy routes", () => {
 
   it("issues a scoped credential from the authenticated running machine record", async () => {
     const { app } = await createTestApp();
-    const response = await app.request("/internal/containers/alice/ai/funded-credential", {
+    const response = await app.request(fundedCredentialPath(), {
       method: "POST",
       headers: { authorization: `Bearer ${bearerFor("alice")}`, "content-type": "application/json" },
       body: "{}",
@@ -97,28 +101,66 @@ describe("funded AI policy routes", () => {
     expect(response.headers.get("cache-control")).toContain("no-store");
     const issued = FundedAiRuntimeCredentialIssueResponseSchema.parse(await response.json());
     expect(issued.identity).toEqual({ ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary" });
-    expect((await app.request("/internal/containers/alice/ai/funded-credential", {
+    expect((await app.request(fundedCredentialPath(), {
       method: "POST",
       headers: { authorization: `Bearer ${bearerFor("alice", "machine_predecessor")}` },
     })).status).toBe(401);
-    expect((await app.request("/internal/containers/alice/ai/funded-credential", {
+    expect((await app.request(fundedCredentialPath(), {
       method: "POST",
       headers: { authorization: `Bearer ${bearerFor("alice", "machine_123", "staging")}` },
     })).status).toBe(401);
   });
 
+  it("resolves the requested runtime slot before verifying exact machine proof", async () => {
+    await insertUserMachine(db, {
+      machineId: "machine_staging", clerkUserId: "user_alice", handle: "alice", runtimeSlot: "staging",
+      status: "running", imageVersion: "v1", provisionedAt: "2026-08-30T19:30:00.000Z",
+      activationState: "authorized",
+    });
+    const { app, repository } = await createTestApp();
+    await repository.setRuntimePolicy({
+      identity: { ownerId: "user_alice", machineId: "machine_staging", runtimeSlot: "staging" },
+      expectedRevision: 0, enabled: true, allowedModelIds: [modelId], expiresAt: null,
+    });
+
+    const response = await app.request(fundedCredentialPath("alice", "staging"), {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${bearerFor("alice", "machine_staging", "staging")}`,
+        "content-type": "application/json",
+      },
+      body: "{}",
+    });
+
+    expect(response.status).toBe(200);
+    const issued = FundedAiRuntimeCredentialIssueResponseSchema.parse(await response.json());
+    expect(issued.identity).toEqual({
+      ownerId: "user_alice",
+      machineId: "machine_staging",
+      runtimeSlot: "staging",
+    });
+  });
+
   it("rejects missing auth, malformed or oversized bodies, caller identity fields, and legacy-only handles", async () => {
     const { app } = await createTestApp();
     const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    expect((await app.request("/internal/containers/alice/ai/funded-credential", { method: "POST" })).status).toBe(401);
-    const spoofed = await app.request("/internal/containers/alice/ai/funded-credential", {
+    expect((await app.request("/internal/containers/alice/ai/funded-credential", {
+      method: "POST",
+      headers: { authorization: `Bearer ${bearerFor("alice")}` },
+    })).status).toBe(400);
+    expect((await app.request(fundedCredentialPath("alice", "invalid_slot"), {
+      method: "POST",
+      headers: { authorization: `Bearer ${bearerFor("alice")}` },
+    })).status).toBe(400);
+    expect((await app.request(fundedCredentialPath(), { method: "POST" })).status).toBe(401);
+    const spoofed = await app.request(fundedCredentialPath(), {
       method: "POST",
       headers: { authorization: `Bearer ${bearerFor("alice")}`, "content-type": "application/json" },
       body: JSON.stringify({ ownerId: "user_bob", machineId: "machine_other" }),
     });
     expect(spoofed.status).toBe(400);
     const malformedSecret = "sk-provider-do-not-log";
-    const malformed = await app.request("/internal/containers/alice/ai/funded-credential", {
+    const malformed = await app.request(fundedCredentialPath(), {
       method: "POST",
       headers: { authorization: `Bearer ${bearerFor("alice")}`, "content-type": "application/json" },
       body: `{"credential":"${malformedSecret}"`,
@@ -127,7 +169,7 @@ describe("funded AI policy routes", () => {
     await expect(malformed.json()).resolves.toMatchObject({ error: { code: "invalid_request" } });
     expect(warning).toHaveBeenCalledWith("[ai-funded-policy] invalid JSON body (syntax_error)");
     expect(JSON.stringify(warning.mock.calls)).not.toContain(malformedSecret);
-    const oversized = await app.request("/internal/containers/alice/ai/funded-credential", {
+    const oversized = await app.request(fundedCredentialPath(), {
       method: "POST",
       headers: { authorization: `Bearer ${bearerFor("alice")}`, "content-type": "application/json" },
       body: JSON.stringify({ padding: "x".repeat(2_000) }),
@@ -137,7 +179,7 @@ describe("funded AI policy routes", () => {
     await insertContainer(db, {
       handle: "legacy", clerkUserId: "user_legacy", port: 5001, shellPort: 6001, status: "running",
     });
-    const legacy = await app.request("/internal/containers/legacy/ai/funded-credential", {
+    const legacy = await app.request(fundedCredentialPath("legacy"), {
       method: "POST", headers: { authorization: `Bearer ${bearerFor("legacy")}` },
     });
     expect(legacy.status).toBe(401);
@@ -145,7 +187,7 @@ describe("funded AI policy routes", () => {
 
   it("authorizes only through the dedicated timing-safe relay service credential", async () => {
     const { app } = await createTestApp();
-    const issuedResponse = await app.request("/internal/containers/alice/ai/funded-credential", {
+    const issuedResponse = await app.request(fundedCredentialPath(), {
       method: "POST",
       headers: { authorization: `Bearer ${bearerFor("alice")}`, "content-type": "application/json" },
       body: "{}",

--- a/tests/platform/ai-funded-policy-routes.test.ts
+++ b/tests/platform/ai-funded-policy-routes.test.ts
@@ -103,8 +103,9 @@ describe("funded AI policy routes", () => {
     })).status).toBe(401);
   });
 
-  it("rejects missing auth, caller identity fields, oversized bodies, and legacy-only handles", async () => {
+  it("rejects missing auth, malformed or oversized bodies, caller identity fields, and legacy-only handles", async () => {
     const { app } = await createTestApp();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     expect((await app.request("/internal/containers/alice/ai/funded-credential", { method: "POST" })).status).toBe(401);
     const spoofed = await app.request("/internal/containers/alice/ai/funded-credential", {
       method: "POST",
@@ -112,6 +113,16 @@ describe("funded AI policy routes", () => {
       body: JSON.stringify({ ownerId: "user_bob", machineId: "machine_other" }),
     });
     expect(spoofed.status).toBe(400);
+    const malformedSecret = "sk-provider-do-not-log";
+    const malformed = await app.request("/internal/containers/alice/ai/funded-credential", {
+      method: "POST",
+      headers: { authorization: `Bearer ${bearerFor("alice")}`, "content-type": "application/json" },
+      body: `{"credential":"${malformedSecret}"`,
+    });
+    expect(malformed.status).toBe(400);
+    await expect(malformed.json()).resolves.toMatchObject({ error: { code: "invalid_request" } });
+    expect(warning).toHaveBeenCalledWith("[ai-funded-policy] invalid JSON body (syntax_error)");
+    expect(JSON.stringify(warning.mock.calls)).not.toContain(malformedSecret);
     const oversized = await app.request("/internal/containers/alice/ai/funded-credential", {
       method: "POST",
       headers: { authorization: `Bearer ${bearerFor("alice")}`, "content-type": "application/json" },

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -33,6 +33,7 @@ describe('platform/customer-vps-cloud-init', () => {
         'https://app.matrix-os.com/system-bundles/0.0.0-pr10000.abcdef012345/matrix-host-bundle.tar.gz',
       registrationToken: 'r'.repeat(64),
       platformVerificationToken: 'v'.repeat(64),
+      fundedAiRuntimeToken: 'f'.repeat(64),
       postgresPassword: 'p'.repeat(48),
     };
     const template = await loadCustomerVpsCloudInitTemplate();
@@ -54,6 +55,7 @@ describe('platform/customer-vps-cloud-init', () => {
     platformRegisterUrl: 'https://platform.example/vps/register',
     platformInternalUrl: 'https://platform.example',
     platformVerificationToken: 'platform-verification-secret',
+    fundedAiRuntimeToken: 'funded-runtime-verification-secret',
     registrationToken: 'registration-secret',
     postgresPassword: 'postgres-secret',
     posthogToken: 'phc_public',
@@ -213,6 +215,7 @@ exit 99
     expect(rendered).toContain('UPGRADE_TOKEN=platform-verification-secret');
     expect(rendered).toContain('MATRIX_AUTH_TOKEN=platform-verification-secret');
     expect(rendered).toContain('MATRIX_CODE_PROXY_TOKEN=platform-verification-secret');
+    expect(rendered).toContain('MATRIX_FUNDED_AI_RUNTIME_TOKEN=funded-runtime-verification-secret');
     expect(rendered).toContain('PLATFORM_INTERNAL_URL=https://platform.example');
     expect(rendered).toContain('path: /opt/matrix/env/symphony.env');
     expect(rendered).toContain('MATRIX_HANDLE=alice');
@@ -220,6 +223,7 @@ exit 99
     expect(rendered).not.toContain('UPGRADE_TOKEN=\n');
     expect(rendered).not.toContain('MATRIX_AUTH_TOKEN=\n');
     expect(rendered).not.toContain('MATRIX_CODE_PROXY_TOKEN=\n');
+    expect(rendered).not.toContain('MATRIX_FUNDED_AI_RUNTIME_TOKEN=\n');
     expect(rendered).not.toContain('PLATFORM_INTERNAL_URL=\n');
   });
 
@@ -377,6 +381,7 @@ exit 99
     expect(cloudInit).toContain('UPGRADE_TOKEN={{platformVerificationToken}}');
     expect(cloudInit).toContain('MATRIX_AUTH_TOKEN={{platformVerificationToken}}');
     expect(cloudInit).toContain('MATRIX_CODE_PROXY_TOKEN={{platformVerificationToken}}');
+    expect(cloudInit).toContain('MATRIX_FUNDED_AI_RUNTIME_TOKEN={{fundedAiRuntimeToken}}');
     expect(cloudInit).toContain('PLATFORM_INTERNAL_URL={{platformInternalUrl}}');
     expect(cloudInit).toContain('POSTHOG_TOKEN={{posthogToken}}');
     expect(cloudInit).toContain('NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN={{posthogProjectToken}}');
@@ -697,7 +702,7 @@ exit 99
 
   it('redacts bootstrap secrets before logging rendered cloud-init', () => {
     const rendered = renderCloudInitTemplate(
-      'token={{registrationToken}}\npassword={{postgresPassword}}\nplatform={{platformVerificationToken}}\n',
+      'token={{registrationToken}}\npassword={{postgresPassword}}\nplatform={{platformVerificationToken}}\nfunded={{fundedAiRuntimeToken}}\n',
       input,
     );
 
@@ -706,6 +711,7 @@ exit 99
     expect(redacted).not.toContain('registration-secret');
     expect(redacted).not.toContain('postgres-secret');
     expect(redacted).not.toContain('platform-verification-secret');
+    expect(redacted).not.toContain('funded-runtime-verification-secret');
     expect(redacted).toContain('[redacted]');
   });
 

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -33,6 +33,10 @@ import {
   validateDbLatestPointer,
 } from '../../packages/platform/src/customer-vps-r2.js';
 import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+import {
+  buildPlatformRuntimeVerificationToken,
+  timingSafeTokenEquals,
+} from '../../packages/platform/src/platform-token.js';
 
 describe('platform/customer-vps', () => {
   let db: PlatformDB;
@@ -1420,16 +1424,33 @@ describe('platform/customer-vps', () => {
     await expect(getRunningUserMachineByHandle(db, 'alice-staging', 'primary')).resolves.toBeUndefined();
   });
 
-  it('templates the platform verification token into provisioned customer hosts', async () => {
+  it('templates legacy and exact runtime-bound verification tokens into provisioned customer hosts', async () => {
     const { service, hetzner } = createService();
 
     await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
 
     const expected = createHmac('sha256', 'platform-secret').update('alice').digest('hex');
     const createInput = vi.mocked(hetzner.createServer).mock.calls[0]?.[0];
+    const fundedRuntimeToken = createInput?.userData
+      .match(/^\s*MATRIX_FUNDED_AI_RUNTIME_TOKEN=([^\s]+)$/m)?.[1];
     expect(createInput?.userData).toContain(`UPGRADE_TOKEN=${expected}`);
     expect(createInput?.userData).toContain(`MATRIX_AUTH_TOKEN=${expected}`);
     expect(createInput?.userData).toContain(`MATRIX_CODE_PROXY_TOKEN=${expected}`);
+    expect(fundedRuntimeToken).toBe(buildPlatformRuntimeVerificationToken({
+      handle: 'alice',
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      runtimeSlot: 'primary',
+    }, 'platform-secret'));
+    expect(timingSafeTokenEquals(fundedRuntimeToken, buildPlatformRuntimeVerificationToken({
+      handle: 'alice',
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      runtimeSlot: 'staging',
+    }, 'platform-secret'))).toBe(false);
+    expect(timingSafeTokenEquals(fundedRuntimeToken, buildPlatformRuntimeVerificationToken({
+      handle: 'alice',
+      machineId: 'machine_predecessor',
+      runtimeSlot: 'primary',
+    }, 'platform-secret'))).toBe(false);
     expect(createInput?.userData).toContain('PLATFORM_INTERNAL_URL=http://localhost:9000');
     expect(createInput?.userData).not.toContain('PIPEDREAM_CLIENT_SECRET');
   });


### PR DESCRIPTION
## Summary

- add fail-closed global and per-runtime Matrix-funded AI policy records in platform Postgres
- issue short-lived opaque runtime credentials whose central representation is hash-only
- authorize relay requests against scope, audience, expiry, revocation, machine/runtime binding, model allowlists, and the effective policy intersection
- require a dedicated relay service credential distinct from runtime issuance and existing platform secrets
- keep funded relay activation disabled until metering and end-to-end relay integration land later in this stack

## Validation

- 13 focused funded policy contract/repository/route tests
- `node_modules/.bin/tsc --noEmit -p packages/contracts/tsconfig.json`
- `node_modules/.bin/tsc --noEmit -p packages/platform/tsconfig.json`
- `git diff codex/provider-runtime-coordinators...HEAD --check`

## Invariants

- **Source of truth:** platform Postgres owns global policy, runtime policy, and credential bindings; the runtime only receives the opaque credential.
- **Lock / transaction scope:** credential issuance and policy writes use Kysely transactions and database-enforced uniqueness/revision checks; no file persistence is authoritative.
- **Acceptable orphan states:** an issued runtime credential may expire unused; revocation and policy changes take effect at relay authorization, so a cached runtime copy cannot override platform state.
- **Auth source of truth:** the platform derives owner and machine identity from its authenticated running-machine record; caller-supplied identity fields are rejected, and relay authorization requires a separate timing-safe service credential.
- **Deferred scope:** exact balance reservation/settlement, runtime credential refresh delivery, Cloudflare forwarding integration, operator activation, Stripe add-on funding, and settings usage projection remain disabled for later stack layers.
