### PR TITLE
feat(gateway): add provider settings persistence and routes

### DIFF
--- a/packages/contracts/src/provider-settings.ts
+++ b/packages/contracts/src/provider-settings.ts
@@ -389,7 +389,9 @@ export const ProviderSettingsMutationSchema = z.discriminatedUnion("type", [
     displayName: DisplayNameSchema.optional(), accentColor: ProviderAccentColorSchema.nullable().optional() }).strict()
     .refine((value) => value.displayName !== undefined || value.accentColor !== undefined, { message: "Harness update requires a change" }),
   z.object({ type: z.literal("set_harness_enabled"), ...MutationBase, harnessInstanceId: ReferenceIdSchema, enabled: z.boolean() }).strict(),
-  z.object({ type: z.literal("set_route"), ...MutationBase, harnessInstanceId: ReferenceIdSchema, route: ProviderConfigurableRouteSchema }).strict(),
+  z.object({ type: z.literal("set_route"), ...MutationBase, harnessInstanceId: ReferenceIdSchema,
+    route: ProviderConfigurableRouteSchema, accessSourceId: ReferenceIdSchema,
+    accountId: ReferenceIdSchema.nullable() }).strict(),
   z.object({ type: z.literal("select_account"), ...MutationBase, harnessInstanceId: ReferenceIdSchema, accountId: ReferenceIdSchema }).strict(),
   z.object({ type: z.literal("select_access_source"), ...MutationBase, harnessInstanceId: ReferenceIdSchema, accessSourceId: ReferenceIdSchema }).strict(),
   z.object({ type: z.literal("start_login"), ...MutationBase, harnessInstanceId: ReferenceIdSchema,

--- a/packages/gateway/src/ai-providers/provider-settings-coordinators.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-coordinators.ts
@@ -1,0 +1,51 @@
+import type {
+  AiProviderSnapshotV3,
+  ProviderConnectionAttempt,
+  ProviderDependencyCounts,
+  ProviderHarnessKind,
+  ProviderSettingsMutation,
+} from "@matrix-os/contracts";
+import type { ProviderConfigurationMutation } from "./provider-settings-mutations.js";
+import type { ProviderSettingsDependencyReader } from "./provider-settings-projector.js";
+
+export interface CanonicalProviderSnapshotReader {
+  getSnapshot(options?: { refresh?: boolean }): Promise<AiProviderSnapshotV3>;
+}
+
+export interface ProviderAccountDependencyCoordinator extends ProviderSettingsDependencyReader {
+  reassignDependencies(input: {
+    fromAccountId: string;
+    target: Extract<ProviderSettingsMutation, { type: "reassign_account" }>["target"];
+    scope: Extract<ProviderSettingsMutation, { type: "reassign_account" }>["scope"];
+    dependencyGuard: ProviderDependencyCounts;
+    harnessInstanceIds: string[];
+    idempotencyKey: string;
+  }): Promise<void>;
+}
+
+/** Implementations must durably deduplicate by idempotencyKey. */
+export interface ProviderAccountLifecycleCoordinator {
+  logout(input: { accountId: string; idempotencyKey: string }): Promise<void>;
+  remove(input: { accountId: string; idempotencyKey: string }): Promise<void>;
+}
+
+/** Applies settings to the real runtime/control plane and durably deduplicates the key. */
+export interface ProviderSettingsRuntimeCoordinator {
+  applyConfiguration(input: {
+    mutation: ProviderConfigurationMutation;
+    idempotencyKey: string;
+  }): Promise<void>;
+}
+
+/** Creates/adopts the actual auth surface and durably deduplicates by mutation key. */
+export interface ProviderLoginCoordinator {
+  startLogin(input: {
+    mutation: Extract<ProviderSettingsMutation, { type: "start_login" }>;
+    harness: {
+      id: string;
+      harness: ProviderHarnessKind;
+      providerId: string;
+      modelId: string;
+    };
+  }): Promise<ProviderConnectionAttempt>;
+}

--- a/packages/gateway/src/ai-providers/provider-settings-errors.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-errors.ts
@@ -1,0 +1,19 @@
+type ProviderSettingsErrorCode = "invalid_request" | "configuration_unavailable"
+  | "projection_unavailable" | "revision_conflict" | "not_found" | "account_in_use"
+  | "dependency_unavailable" | "lifecycle_unavailable" | "invalid_route"
+  | "idempotency_conflict" | "runtime_unavailable";
+
+export class ProviderSettingsStoreError extends Error {
+  constructor(
+    readonly code: ProviderSettingsErrorCode,
+    readonly status: 400 | 404 | 409 | 503,
+    readonly details: { latestRevision?: number } = {},
+  ) {
+    super(code);
+    this.name = "ProviderSettingsStoreError";
+  }
+
+  get latestRevision(): number | undefined {
+    return this.details.latestRevision;
+  }
+}

--- a/packages/gateway/src/ai-providers/provider-settings-mutations.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-mutations.ts
@@ -1,0 +1,140 @@
+import type {
+  AiProviderSnapshotV3,
+  ProviderSettingsMutation,
+  ProviderSettingsSnapshot,
+} from "@matrix-os/contracts";
+import { ProviderSettingsStoreError } from "./provider-settings-errors.js";
+import {
+  providerDriverId,
+  type ProviderSettingsConfiguration,
+} from "./provider-settings-persistence.js";
+
+export type ProviderConfigurationMutation = Exclude<ProviderSettingsMutation,
+  | { type: "start_login" }
+  | { type: "logout_account" }
+  | { type: "remove_account" }
+  | { type: "reassign_account" }>;
+
+export function applyProviderConfigurationMutation(input: {
+  mutation: ProviderSettingsMutation;
+  config: ProviderSettingsConfiguration;
+  canonical: AiProviderSnapshotV3;
+  snapshot: ProviderSettingsSnapshot;
+  id: () => string;
+}): boolean {
+  const mutation = input.mutation as ProviderConfigurationMutation;
+  const harness = "harnessInstanceId" in mutation
+    ? input.config.harnesses.find((candidate) => candidate.id === mutation.harnessInstanceId)
+    : undefined;
+
+  switch (mutation.type) {
+    case "add_harness": {
+      if (input.config.harnesses.length >= 128) {
+        throw new ProviderSettingsStoreError("invalid_request", 400);
+      }
+      const source = input.snapshot.accessSources.find((candidate) => candidate.id === mutation.accessSourceId);
+      const account = mutation.accountId === null
+        ? null
+        : input.snapshot.accounts.find((candidate) => candidate.id === mutation.accountId) ?? null;
+      const gatewayAllowed = source?.kind !== "matrix_gateway"
+        || input.snapshot.gatewayPolicy?.allowedModelIds.includes(mutation.route.modelId);
+      if (!source || !gatewayAllowed || source.providerId !== mutation.route.providerId
+        || !source.eligibleModelIds.includes(mutation.route.modelId)
+        || (source.kind === "matrix_gateway" ? account !== null : account?.id !== source.accountId)) {
+        throw new ProviderSettingsStoreError("invalid_route", 400);
+      }
+      input.config.harnesses.push({
+        id: `harness_${input.id()}`,
+        driverId: providerDriverId(mutation.harness, input.canonical),
+        harness: mutation.harness,
+        displayName: mutation.displayName,
+        accentColor: mutation.accentColor ?? null,
+        enabled: false,
+        selectedAccountId: account?.id ?? null,
+        accessSourceId: source.id,
+        route: mutation.route,
+      });
+      return true;
+    }
+    case "update_harness":
+      if (!harness) throw new ProviderSettingsStoreError("not_found", 404);
+      if (mutation.displayName !== undefined) harness.displayName = mutation.displayName;
+      if (mutation.accentColor !== undefined) harness.accentColor = mutation.accentColor;
+      return true;
+    case "set_harness_enabled": {
+      if (!harness) throw new ProviderSettingsStoreError("not_found", 404);
+      const driver = input.canonical.drivers.find((candidate) => candidate.id === harness.driverId);
+      if (mutation.enabled && driver?.installState !== "installed") {
+        throw new ProviderSettingsStoreError("invalid_request", 400);
+      }
+      harness.enabled = mutation.enabled;
+      return true;
+    }
+    case "set_route": {
+      if (!harness || harness.harness === "claude") {
+        throw new ProviderSettingsStoreError("invalid_route", 400);
+      }
+      const source = harness.accessSourceId === null
+        ? undefined
+        : input.snapshot.accessSources.find((candidate) => candidate.id === harness.accessSourceId);
+      const gatewayAllowed = source?.kind !== "matrix_gateway"
+        || input.snapshot.gatewayPolicy?.allowedModelIds.includes(mutation.route.modelId);
+      if (!source || !gatewayAllowed || source.providerId !== mutation.route.providerId
+        || !source.eligibleModelIds.includes(mutation.route.modelId)) {
+        throw new ProviderSettingsStoreError("invalid_route", 400);
+      }
+      harness.route = mutation.route;
+      return true;
+    }
+    case "select_account": {
+      if (!harness) throw new ProviderSettingsStoreError("not_found", 404);
+      const account = input.snapshot.accounts.find((candidate) => candidate.id === mutation.accountId);
+      const source = account
+        && input.snapshot.accessSources.find((candidate) => candidate.id === account.accessSourceId);
+      if (!account || !source || source.providerId !== harness.route.providerId
+        || !source.eligibleModelIds.includes(harness.route.modelId)) {
+        throw new ProviderSettingsStoreError("invalid_route", 400);
+      }
+      harness.selectedAccountId = account.id;
+      harness.accessSourceId = account.accessSourceId;
+      return true;
+    }
+    case "select_access_source": {
+      if (!harness) throw new ProviderSettingsStoreError("not_found", 404);
+      const source = input.snapshot.accessSources.find((candidate) => candidate.id === mutation.accessSourceId);
+      const gatewayAllowed = source?.kind !== "matrix_gateway"
+        || input.snapshot.gatewayPolicy?.allowedModelIds.includes(harness.route.modelId);
+      if (!source || !gatewayAllowed || source.providerId !== harness.route.providerId
+        || !source.eligibleModelIds.includes(harness.route.modelId)) {
+        throw new ProviderSettingsStoreError("invalid_route", 400);
+      }
+      harness.accessSourceId = source.id;
+      harness.selectedAccountId = source.accountId;
+      return true;
+    }
+    case "set_gateway_budget":
+      if (!input.config.gatewayPolicy) throw new ProviderSettingsStoreError("not_found", 404);
+      input.config.gatewayPolicy.monthlyBudgetMicrousd = mutation.monthlyBudgetMicrousd;
+      return true;
+    case "set_gateway_allowlist": {
+      const policy = input.config.gatewayPolicy;
+      const source = policy
+        ? input.snapshot.accessSources.find((candidate) => candidate.id === policy.accessSourceId)
+        : undefined;
+      if (!policy || !source
+        || mutation.allowedModelIds.some((modelId) => !source.eligibleModelIds.includes(modelId))) {
+        throw new ProviderSettingsStoreError("invalid_route", 400);
+      }
+      const activeGatewayModels = input.config.harnesses
+        .filter((candidate) => candidate.accessSourceId === policy.accessSourceId)
+        .map((candidate) => candidate.route.modelId);
+      if (activeGatewayModels.some((modelId) => !mutation.allowedModelIds.includes(modelId))) {
+        throw new ProviderSettingsStoreError("invalid_route", 400);
+      }
+      policy.allowedModelIds = [...mutation.allowedModelIds];
+      return true;
+    }
+    default:
+      return false;
+  }
+}

--- a/packages/gateway/src/ai-providers/provider-settings-mutations.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-mutations.ts
@@ -71,19 +71,23 @@ export function applyProviderConfigurationMutation(input: {
       return true;
     }
     case "set_route": {
-      if (!harness || harness.harness === "claude") {
+      if (!harness || harness.route.kind !== "configurable") {
         throw new ProviderSettingsStoreError("invalid_route", 400);
       }
-      const source = harness.accessSourceId === null
-        ? undefined
-        : input.snapshot.accessSources.find((candidate) => candidate.id === harness.accessSourceId);
+      const source = input.snapshot.accessSources.find((candidate) => candidate.id === mutation.accessSourceId);
+      const account = mutation.accountId === null
+        ? null
+        : input.snapshot.accounts.find((candidate) => candidate.id === mutation.accountId) ?? null;
       const gatewayAllowed = source?.kind !== "matrix_gateway"
         || input.snapshot.gatewayPolicy?.allowedModelIds.includes(mutation.route.modelId);
       if (!source || !gatewayAllowed || source.providerId !== mutation.route.providerId
-        || !source.eligibleModelIds.includes(mutation.route.modelId)) {
+        || !source.eligibleModelIds.includes(mutation.route.modelId)
+        || (source.kind === "matrix_gateway" ? account !== null : account?.id !== source.accountId)) {
         throw new ProviderSettingsStoreError("invalid_route", 400);
       }
       harness.route = mutation.route;
+      harness.accessSourceId = source.id;
+      harness.selectedAccountId = account?.id ?? null;
       return true;
     }
     case "select_account": {

--- a/packages/gateway/src/ai-providers/provider-settings-persistence.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-persistence.ts
@@ -1,0 +1,223 @@
+import { chmod, lstat, mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { basename, dirname } from "node:path";
+import { join } from "node:path";
+import {
+  ProviderAccentColorSchema,
+  ProviderConnectionAttemptSchema,
+  ProviderGatewayPolicySchema,
+  ProviderHarnessKindSchema,
+  ProviderHarnessRouteSchema,
+  ProviderLoginMethodSchema,
+  type AiProviderSnapshotV3,
+  type ProviderHarnessKind,
+} from "@matrix-os/contracts";
+import { z } from "zod/v4";
+
+const MAX_FILE_BYTES = 1024 * 1024;
+export const MAX_PROVIDER_SETTINGS_RECEIPTS = 256;
+const SafeRefSchema = z.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/);
+
+export const HarnessConfigurationSchema = z.object({
+  id: SafeRefSchema,
+  driverId: SafeRefSchema,
+  harness: ProviderHarnessKindSchema,
+  displayName: z.string().min(1).max(120),
+  accentColor: ProviderAccentColorSchema.nullable(),
+  enabled: z.boolean(),
+  selectedAccountId: SafeRefSchema.nullable(),
+  accessSourceId: SafeRefSchema.nullable(),
+  route: ProviderHarnessRouteSchema,
+}).strict();
+
+export const AccountConfigurationSchema = z.object({
+  id: SafeRefSchema,
+  providerId: SafeRefSchema,
+  displayName: z.string().min(1).max(120),
+  authMethod: ProviderLoginMethodSchema,
+  accessSourceId: SafeRefSchema,
+}).strict();
+
+const ReceiptSchema = z.object({
+  key: SafeRefSchema,
+  payloadHash: z.string().length(64).regex(/^[a-f0-9]+$/),
+  appliedRevision: z.number().int().min(1).max(Number.MAX_SAFE_INTEGER),
+  attempt: ProviderConnectionAttemptSchema.optional(),
+}).strict();
+
+export const ProviderSettingsConfigurationSchema = z.object({
+  schemaVersion: z.literal(1),
+  revision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  harnesses: z.array(HarnessConfigurationSchema).max(128),
+  accountProfiles: z.array(AccountConfigurationSchema).max(128),
+  gatewayPolicy: ProviderGatewayPolicySchema.nullable(),
+  receipts: z.array(ReceiptSchema).max(MAX_PROVIDER_SETTINGS_RECEIPTS),
+}).strict().superRefine((config, context) => {
+  const unique = (values: string[]) => new Set(values).size === values.length;
+  if (!unique(config.harnesses.map((harness) => harness.id))) {
+    context.addIssue({ code: "custom", path: ["harnesses"], message: "Duplicate harness id" });
+  }
+  if (!unique(config.accountProfiles.map((account) => account.id))) {
+    context.addIssue({ code: "custom", path: ["accountProfiles"], message: "Duplicate account id" });
+  }
+  if (!unique(config.receipts.map((receipt) => receipt.key))) {
+    context.addIssue({ code: "custom", path: ["receipts"], message: "Duplicate idempotency key" });
+  }
+  if (config.receipts.some((receipt) => receipt.appliedRevision > config.revision)) {
+    context.addIssue({ code: "custom", path: ["receipts"], message: "Receipt exceeds settings revision" });
+  }
+});
+
+const ProviderSecretDocumentSchema = z.object({
+  version: z.literal(1),
+  accounts: z.record(SafeRefSchema, z.string().min(1).max(64 * 1024)),
+}).strict();
+
+export type HarnessConfiguration = z.infer<typeof HarnessConfigurationSchema>;
+export type AccountConfiguration = z.infer<typeof AccountConfigurationSchema>;
+export type ProviderSettingsConfiguration = z.infer<typeof ProviderSettingsConfigurationSchema>;
+export type ProviderSecretDocument = z.infer<typeof ProviderSecretDocumentSchema>;
+
+function isMissing(error: unknown): boolean {
+  return error instanceof Error && "code" in error
+    && (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+async function readBoundedJson(path: string): Promise<unknown> {
+  const metadata = await lstat(path);
+  if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.size > MAX_FILE_BYTES) {
+    throw new Error("Unsafe provider settings file");
+  }
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+export async function writeProviderJsonAtomic(path: string, value: unknown): Promise<void> {
+  const directory = dirname(path);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const metadata = await lstat(directory);
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) throw new Error("Unsafe provider settings directory");
+  await chmod(directory, 0o700);
+  const temporaryPath = join(directory, `.${basename(path)}.tmp`);
+  let temporaryCreated = false;
+  try {
+    try {
+      const temporaryMetadata = await lstat(temporaryPath);
+      if (!temporaryMetadata.isFile() || temporaryMetadata.isSymbolicLink()) {
+        throw new Error("Unsafe provider settings temporary file");
+      }
+      await unlink(temporaryPath);
+    } catch (error) {
+      if (!isMissing(error)) throw error;
+    }
+    await writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, { flag: "wx", mode: 0o600 });
+    temporaryCreated = true;
+    await rename(temporaryPath, path);
+    temporaryCreated = false;
+    await chmod(path, 0o600);
+  } catch (error) {
+    if (temporaryCreated) {
+      await unlink(temporaryPath).catch((cleanupError: unknown) => {
+        if (!isMissing(cleanupError)) console.warn("[provider-settings] Failed to clean temporary settings file");
+      });
+    }
+    throw error;
+  }
+}
+
+function driverIdForHarness(kind: ProviderHarnessKind, canonical: AiProviderSnapshotV3): string {
+  if (kind !== "claude") return kind;
+  return canonical.drivers.some((driver) => driver.id === "claude_code") ? "claude_code" : "kernel";
+}
+
+function harnessKindForDriver(driverId: string): ProviderHarnessKind {
+  if (driverId === "kernel" || driverId === "claude_code") return "claude";
+  return ProviderHarnessKindSchema.catch("opencode").parse(driverId);
+}
+
+export function initialProviderSettingsConfiguration(canonical: AiProviderSnapshotV3): ProviderSettingsConfiguration {
+  const harnesses = canonical.drivers.flatMap((driver): HarnessConfiguration[] => {
+    const candidates = canonical.instances.filter((instance) => instance.driverId === driver.id);
+    const instance = candidates.find((candidate) => candidate.id === canonical.active.providerInstanceId)
+      ?? candidates.find((candidate) => candidate.readiness.state === "ready")
+      ?? candidates[0];
+    const modelId = instance?.defaultModelId ?? instance?.modelIds[0];
+    if (!instance || !modelId) return [];
+    const harness = harnessKindForDriver(driver.id);
+    return [{
+      id: `harness_${driver.id}`,
+      driverId: driver.id,
+      harness,
+      displayName: driver.displayName,
+      accentColor: null,
+      enabled: driver.installState === "installed",
+      selectedAccountId: instance.accountId,
+      accessSourceId: instance.accessSourceId,
+      route: { kind: harness === "claude" ? "fixed" : "configurable", providerId: instance.vendor, modelId },
+    }];
+  });
+  const gateway = canonical.accessSources.find((source) =>
+    source.fundingKind === "matrix_included" || source.fundingKind === "matrix_addon");
+  return {
+    schemaVersion: 1,
+    revision: 0,
+    harnesses,
+    accountProfiles: canonical.accounts.flatMap((account) => {
+      if (account.authMethod === null) return [];
+      const instance = canonical.instances.find((candidate) => {
+        if (candidate.accountId !== account.id) return false;
+        const source = canonical.accessSources.find((value) => value.id === candidate.accessSourceId);
+        return account.authMethod === "api_key"
+          ? source?.fundingKind === "owner_api_key"
+          : source?.fundingKind === "owner_account";
+      });
+      if (!instance) return [];
+      return [{
+        id: account.id,
+        providerId: account.vendor,
+        displayName: account.accountLabel ?? `${account.vendor} account`,
+        authMethod: account.authMethod === "provider_profile" ? "terminal" as const
+          : account.authMethod === "oauth_pkce" ? "oauth" as const : "api_key" as const,
+        accessSourceId: instance.accessSourceId,
+      }];
+    }),
+    gatewayPolicy: gateway ? {
+      accessSourceId: gateway.id,
+      monthlyBudgetMicrousd: null,
+      allowedModelIds: [...gateway.eligibleModelIds],
+      topUpEnabled: false,
+    } : null,
+    receipts: [],
+  };
+}
+
+export function providerDriverId(kind: ProviderHarnessKind, canonical: AiProviderSnapshotV3): string {
+  return driverIdForHarness(kind, canonical);
+}
+
+export async function readProviderSettingsConfiguration(
+  path: string,
+  canonical: AiProviderSnapshotV3,
+): Promise<ProviderSettingsConfiguration> {
+  try {
+    const value = ProviderSettingsConfigurationSchema.parse(await readBoundedJson(path));
+    await chmod(path, 0o600);
+    return value;
+  } catch (error) {
+    if (isMissing(error)) {
+      const initial = initialProviderSettingsConfiguration(canonical);
+      await writeProviderJsonAtomic(path, initial);
+      return initial;
+    }
+    throw error;
+  }
+}
+
+export async function readProviderSecrets(path: string): Promise<ProviderSecretDocument> {
+  try {
+    const value = ProviderSecretDocumentSchema.parse(await readBoundedJson(path));
+    await chmod(path, 0o600);
+    return value;
+  } catch (error) {
+    if (isMissing(error)) return { version: 1, accounts: {} };
+    throw error;
+  }
+}

--- a/packages/gateway/src/ai-providers/provider-settings-projector.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-projector.ts
@@ -1,0 +1,249 @@
+import {
+  ProviderSettingsSnapshotSchema,
+  type AiProviderReadiness,
+  type AiProviderSnapshotV3,
+  type ProviderAccount,
+  type ProviderDependencyCounts,
+  type ProviderHarnessInstance,
+  type ProviderHarnessKind,
+  type ProviderSettingsSupportedAction,
+  type ProviderSettingsSnapshot,
+} from "@matrix-os/contracts";
+import type { HarnessConfiguration, ProviderSettingsConfiguration } from "./provider-settings-persistence.js";
+
+export interface ProviderSettingsDependencyReader {
+  getAccountDependencies(input: {
+    accountId: string;
+    harnessInstanceIds: string[];
+  }): Promise<ProviderDependencyCounts>;
+}
+
+function authState(readiness: AiProviderReadiness): ProviderHarnessInstance["authState"] {
+  if (readiness.state === "ready") return "authenticated";
+  if (readiness.state === "expired") return "expired";
+  if (readiness.state === "invalid") return "failed";
+  if (["setup_required", "auth_required", "disabled"].includes(readiness.state)) return "unauthenticated";
+  return "unknown";
+}
+
+function connectivity(readiness: AiProviderReadiness): ProviderHarnessInstance["connectivity"] {
+  if (readiness.state === "ready") return "online";
+  if (readiness.state === "stale") return "degraded";
+  if (readiness.state === "unavailable" || readiness.state === "disabled") return "offline";
+  return "unknown";
+}
+
+function loginMethods(kind: ProviderHarnessKind) {
+  return kind === "codex"
+    ? ["terminal", "oauth", "api_key"] as const
+    : ["terminal", "api_key"] as const;
+}
+
+function selectedCanonicalSources(
+  canonical: AiProviderSnapshotV3,
+  config: ProviderSettingsConfiguration,
+) {
+  const sourceByAccount = new Map<string, string>();
+  for (const account of canonical.accounts) {
+    const stored = config.accountProfiles.find((profile) => profile.id === account.id);
+    const instance = canonical.instances.find((candidate) => {
+      if (candidate.accountId !== account.id) return false;
+      const source = canonical.accessSources.find((value) => value.id === candidate.accessSourceId);
+      return account.authMethod === "api_key" || stored?.authMethod === "api_key"
+        ? source?.fundingKind === "owner_api_key"
+        : source?.fundingKind === "owner_account";
+    });
+    const accessSourceId = instance?.accessSourceId ?? stored?.accessSourceId;
+    if (accessSourceId) sourceByAccount.set(account.id, accessSourceId);
+  }
+  const sourceIds = new Set([
+    ...canonical.accessSources
+      .filter((source) => source.fundingKind === "matrix_included" || source.fundingKind === "matrix_addon")
+      .map((source) => source.id),
+    ...sourceByAccount.values(),
+  ]);
+  return { sourceByAccount, sourceIds };
+}
+
+function projectAccessSources(
+  canonical: AiProviderSnapshotV3,
+  config: ProviderSettingsConfiguration,
+) {
+  const { sourceByAccount, sourceIds } = selectedCanonicalSources(canonical, config);
+  const accountBySource = new Map([...sourceByAccount].map(([accountId, sourceId]) => [sourceId, accountId]));
+  const sources = canonical.accessSources.filter((source) => sourceIds.has(source.id)).map((source) => {
+    const matrix = source.fundingKind === "matrix_included" || source.fundingKind === "matrix_addon";
+    return {
+      id: source.id,
+      kind: matrix ? "matrix_gateway" as const : "provider_account" as const,
+      fundingKind: source.fundingKind,
+      providerId: source.vendor,
+      accountId: accountBySource.get(source.id) ?? null,
+      displayName: source.displayName,
+      readiness: {
+        state: source.state,
+        checkedAt: source.checkedAt,
+        staleAfter: source.staleAfter,
+        action: source.action,
+        safeReason: source.safeReason,
+      },
+      eligibleModelIds: [...source.eligibleModelIds],
+      usage: {
+        kind: "unavailable" as const,
+        authority: "unavailable" as const,
+        state: "unavailable" as const,
+        scope: matrix ? "owner_entitlement" as const : "account" as const,
+        reason: matrix ? "ledger_not_available" as const
+          : source.state === "ready" ? "provider_does_not_report" as const : "not_authenticated" as const,
+        asOf: null,
+      },
+    };
+  });
+  return { sources, sourceByAccount };
+}
+
+async function projectAccounts(input: {
+  canonical: AiProviderSnapshotV3;
+  config: ProviderSettingsConfiguration;
+  sourceByAccount: Map<string, string>;
+  sourceIds: Set<string>;
+  dependencies?: ProviderSettingsDependencyReader;
+}): Promise<ProviderAccount[]> {
+  const accounts = await Promise.all(input.canonical.accounts.map(async (account): Promise<ProviderAccount | null> => {
+    const accessSourceId = input.sourceByAccount.get(account.id);
+    const stored = input.config.accountProfiles.find((profile) => profile.id === account.id);
+    if (!accessSourceId || !input.sourceIds.has(accessSourceId) || (account.authMethod === null && !stored)) return null;
+    const selectedHarnesses = input.config.harnesses.filter((harness) => harness.selectedAccountId === account.id);
+    const dependencies = input.dependencies
+      ? await input.dependencies.getAccountDependencies({
+          accountId: account.id,
+          harnessInstanceIds: selectedHarnesses.map((harness) => harness.id),
+        })
+      : { activeChatCount: 0, resumableChatCount: 0, harnessInstanceCount: selectedHarnesses.length };
+    return {
+      id: account.id,
+      providerId: account.vendor,
+      displayName: account.accountLabel ?? stored?.displayName ?? `${account.vendor} account`,
+      authMethod: account.authMethod === "provider_profile" ? "terminal"
+        : account.authMethod === "oauth_pkce" ? "oauth"
+          : account.authMethod === "api_key" ? "api_key" : stored!.authMethod,
+      authState: authState(account),
+      lastCheckedAt: account.checkedAt,
+      accessSourceId,
+      dependencies,
+    };
+  }));
+  return accounts.filter((account): account is ProviderAccount => account !== null);
+}
+
+function projectHarness(input: {
+  stored: HarnessConfiguration;
+  canonical: AiProviderSnapshotV3;
+  accounts: ProviderAccount[];
+  sources: ReturnType<typeof projectAccessSources>["sources"];
+  allowedGatewayModels: ReadonlySet<string>;
+}): ProviderHarnessInstance | null {
+  const model = input.canonical.models.find((candidate) => candidate.id === input.stored.route.modelId);
+  if (!model || model.vendor !== input.stored.route.providerId) return null;
+  const driver = input.canonical.drivers.find((candidate) => candidate.id === input.stored.driverId);
+  const source = input.stored.accessSourceId === null
+    ? undefined
+    : input.sources.find((candidate) => candidate.id === input.stored.accessSourceId);
+  const sourceEligible = source?.providerId === input.stored.route.providerId
+    && source.eligibleModelIds.includes(input.stored.route.modelId)
+    && (source.kind !== "matrix_gateway" || input.allowedGatewayModels.has(input.stored.route.modelId));
+  const selectedAccountId = sourceEligible && source?.kind === "provider_account"
+    && source.accountId && input.accounts.some((account) => account.id === source.accountId)
+    ? source.accountId : null;
+  const readiness = sourceEligible ? source.readiness : {
+    state: "unknown" as const,
+    checkedAt: null,
+    staleAfter: null,
+    action: "retry" as const,
+    safeReason: "unknown" as const,
+  };
+  const accounts = input.accounts.filter((account) => account.providerId === input.stored.route.providerId);
+  return {
+    id: input.stored.id,
+    harness: input.stored.harness,
+    displayName: input.stored.displayName,
+    accentColor: input.stored.accentColor,
+    enabled: Boolean(input.stored.enabled && driver?.installState === "installed"),
+    version: null,
+    installState: driver?.installState ?? "missing",
+    authState: authState(readiness),
+    loginMethods: [...loginMethods(input.stored.harness)],
+    recommendedLoginMethod: "terminal",
+    connectivity: connectivity(readiness),
+    accountIds: accounts.map((account) => account.id),
+    selectedAccountId,
+    accessSourceId: sourceEligible ? source!.id : null,
+    route: input.stored.route,
+    activeChatCount: selectedAccountId
+      ? accounts.find((account) => account.id === selectedAccountId)!.dependencies.activeChatCount
+      : 0,
+  };
+}
+
+export async function projectProviderSettings(input: {
+  canonical: AiProviderSnapshotV3;
+  config: ProviderSettingsConfiguration;
+  now: Date;
+  dependencies?: ProviderSettingsDependencyReader;
+  supportedActions: ProviderSettingsSupportedAction[];
+}): Promise<ProviderSettingsSnapshot> {
+  const { sources, sourceByAccount } = projectAccessSources(input.canonical, input.config);
+  const accounts = await projectAccounts({
+    canonical: input.canonical,
+    config: input.config,
+    sourceByAccount,
+    sourceIds: new Set(sources.map((source) => source.id)),
+    dependencies: input.dependencies,
+  });
+  const modelsByVendor = new Map<string, typeof input.canonical.models>();
+  for (const model of input.canonical.models) {
+    modelsByVendor.set(model.vendor, [...(modelsByVendor.get(model.vendor) ?? []), model]);
+  }
+  const modelProviders = [...modelsByVendor].map(([id, models]) => ({
+    id,
+    displayName: id[0]!.toUpperCase() + id.slice(1),
+    models: models.map((model) => ({
+      id: model.id,
+      displayName: model.displayName,
+      enabled: model.status !== "retired" && model.status !== "unavailable",
+    })),
+  }));
+  const gatewayPolicy = input.config.gatewayPolicy
+    && sources.some((source) => source.id === input.config.gatewayPolicy?.accessSourceId && source.kind === "matrix_gateway")
+    ? input.config.gatewayPolicy : null;
+  const allowedGatewayModels = new Set(gatewayPolicy?.allowedModelIds ?? []);
+  const harnesses = input.config.harnesses.flatMap((stored) => {
+    const harness = projectHarness({
+      stored,
+      canonical: input.canonical,
+      accounts,
+      sources,
+      allowedGatewayModels,
+    });
+    return harness ? [harness] : [];
+  });
+  return ProviderSettingsSnapshotSchema.parse({
+    contractVersion: 1,
+    projectionOf: {
+      contract: "AiProviderSnapshotV3",
+      contractVersion: 3,
+      revision: input.canonical.revision,
+    },
+    revision: input.config.revision,
+    refreshedAt: input.now.toISOString(),
+    access: input.supportedActions.length > 0
+      ? { mode: "writable" }
+      : { mode: "read_only", reason: "runtime_unavailable" },
+    supportedActions: input.supportedActions,
+    modelProviders,
+    accessSources: sources,
+    accounts,
+    harnesses,
+    gatewayPolicy,
+  });
+}

--- a/packages/gateway/src/ai-providers/provider-settings-routes.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-routes.ts
@@ -1,0 +1,179 @@
+import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import {
+  ProviderDependencyCountsSchema,
+  ProviderSettingsMutationSchema,
+  type ProviderSettingsMutation,
+} from "@matrix-os/contracts";
+import { z } from "zod/v4";
+import {
+  ProviderSettingsStoreError,
+  type ProviderSettingsStoreWriter,
+} from "./provider-settings-store.js";
+
+const PROVIDER_SETTINGS_BODY_LIMIT = 64 * 1024;
+const DeleteAccountBodySchema = z.object({
+  expectedRevision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  idempotencyKey: z.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/),
+  dependencyGuard: ProviderDependencyCountsSchema,
+  confirmation: z.literal("remove_account"),
+}).strict();
+
+export interface ProviderSettingsRouteOptions {
+  store: ProviderSettingsStoreWriter;
+  getPrincipal: (context: Context) => unknown;
+}
+
+function bodyTooLarge(context: Context) {
+  return context.json({
+    error: { code: "body_too_large", message: "Request body is too large." },
+  }, 413);
+}
+
+function invalidRequest(context: Context) {
+  return context.json({
+    error: { code: "invalid_request", message: "Invalid provider settings request." },
+  }, 400);
+}
+
+function authorize(context: Context, options: ProviderSettingsRouteOptions): Response | null {
+  try {
+    const principal = options.getPrincipal(context);
+    if (principal) return null;
+  } catch (error) {
+    console.warn(
+      "[provider-settings] Request authentication failed:",
+      error instanceof Error ? error.name : "UnknownError",
+    );
+  }
+  return context.json({
+    error: { code: "unauthorized", message: "Authentication is required." },
+  }, 401);
+}
+
+async function readJson(context: Context): Promise<unknown> {
+  try {
+    return await context.req.json();
+  } catch (error) {
+    if (!(error instanceof SyntaxError) && !(error instanceof TypeError)) {
+      console.warn(
+        "[provider-settings] Failed to read request body:",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+    }
+    return undefined;
+  }
+}
+
+function handleStoreError(context: Context, error: unknown) {
+  if (error instanceof ProviderSettingsStoreError) {
+    switch (error.code) {
+      case "revision_conflict":
+        return context.json({
+          error: {
+            code: "revision_conflict",
+            message: "Provider settings changed. Refresh and try again.",
+          },
+          ...(error.latestRevision === undefined ? {} : { latestRevision: error.latestRevision }),
+        }, 409);
+      case "not_found":
+        return context.json({
+          error: { code: "not_found", message: "Provider settings item was not found." },
+        }, 404);
+      case "account_in_use":
+        return context.json({
+          error: {
+            code: "account_in_use",
+            message: "Reassign active chats before removing this account.",
+          },
+        }, 409);
+      case "dependency_unavailable":
+      case "lifecycle_unavailable":
+      case "runtime_unavailable":
+      case "configuration_unavailable":
+      case "projection_unavailable":
+        return context.json({
+          error: {
+            code: "provider_settings_unavailable",
+            message: "Provider settings are unavailable.",
+          },
+        }, 503);
+      case "invalid_request":
+      case "invalid_route":
+        return invalidRequest(context);
+      case "idempotency_conflict":
+        return context.json({
+          error: {
+            code: "idempotency_conflict",
+            message: "This request key was already used for a different change.",
+          },
+        }, 409);
+    }
+  }
+  console.warn(
+    "[provider-settings] Provider settings request failed:",
+    error instanceof Error ? error.name : "UnknownError",
+  );
+  return context.json({
+    error: {
+      code: "provider_settings_unavailable",
+      message: "Provider settings are unavailable.",
+    },
+  }, 503);
+}
+
+export function createProviderSettingsRoutes(options: ProviderSettingsRouteOptions): Hono {
+  if (!options.store) throw new Error("Provider settings store is required");
+  if (!options.getPrincipal) throw new Error("Provider settings principal resolver is required");
+
+  const app = new Hono();
+  const mutationBodyLimit = bodyLimit({
+    maxSize: PROVIDER_SETTINGS_BODY_LIMIT,
+    onError: bodyTooLarge,
+  });
+
+  app.get("/provider-settings", async (context) => {
+    const authError = authorize(context, options);
+    if (authError) return authError;
+    try {
+      return context.json(await options.store.getSnapshot());
+    } catch (error) {
+      return handleStoreError(context, error);
+    }
+  });
+
+  app.post("/provider-settings/actions", mutationBodyLimit, async (context) => {
+    const authError = authorize(context, options);
+    if (authError) return authError;
+    const mutation = ProviderSettingsMutationSchema.safeParse(await readJson(context));
+    if (!mutation.success) return invalidRequest(context);
+    try {
+      return context.json(await options.store.mutate(mutation.data));
+    } catch (error) {
+      return handleStoreError(context, error);
+    }
+  });
+
+  app.delete("/provider-settings/accounts/:accountId", mutationBodyLimit, async (context) => {
+    const authError = authorize(context, options);
+    if (authError) return authError;
+    const body = DeleteAccountBodySchema.safeParse(await readJson(context));
+    if (!body.success) return invalidRequest(context);
+    const mutation = ProviderSettingsMutationSchema.safeParse({
+      type: "remove_account",
+      expectedRevision: body.data.expectedRevision,
+      idempotencyKey: body.data.idempotencyKey,
+      accountId: context.req.param("accountId"),
+      dependencyGuard: body.data.dependencyGuard,
+      confirmation: body.data.confirmation,
+    } satisfies ProviderSettingsMutation);
+    if (!mutation.success) return invalidRequest(context);
+    try {
+      return context.json(await options.store.mutate(mutation.data));
+    } catch (error) {
+      return handleStoreError(context, error);
+    }
+  });
+
+  return app;
+}

--- a/packages/gateway/src/ai-providers/provider-settings-store.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-store.ts
@@ -1,0 +1,499 @@
+import { createHash, randomUUID } from "node:crypto";
+import { basename, dirname, join, resolve } from "node:path";
+import {
+  AiProviderSnapshotV3Schema,
+  ProviderConnectionAttemptSchema,
+  ProviderDependencyCountsSchema,
+  ProviderSettingsMutationResponseSchema,
+  ProviderSettingsMutationSchema,
+  type AiProviderSnapshotV3,
+  type ProviderConnectionAttempt,
+  type ProviderDependencyCounts,
+  type ProviderHarnessKind,
+  type ProviderLoginMethod,
+  type ProviderSettingsMutation,
+  type ProviderSettingsMutationResponse,
+  type ProviderSettingsSnapshot,
+  type ProviderSettingsSupportedAction,
+} from "@matrix-os/contracts";
+import { z } from "zod/v4";
+import {
+  MAX_PROVIDER_SETTINGS_RECEIPTS,
+  ProviderSettingsConfigurationSchema,
+  readProviderSecrets,
+  readProviderSettingsConfiguration,
+  writeProviderJsonAtomic,
+  type ProviderSettingsConfiguration,
+} from "./provider-settings-persistence.js";
+import { ProviderSettingsStoreError } from "./provider-settings-errors.js";
+import {
+  applyProviderConfigurationMutation,
+  type ProviderConfigurationMutation,
+} from "./provider-settings-mutations.js";
+import { projectProviderSettings } from "./provider-settings-projector.js";
+import type {
+  CanonicalProviderSnapshotReader,
+  ProviderAccountDependencyCoordinator,
+  ProviderAccountLifecycleCoordinator,
+  ProviderLoginCoordinator,
+  ProviderSettingsRuntimeCoordinator,
+} from "./provider-settings-coordinators.js";
+
+const CONFIG_PATH = "system/ai-providers/settings.json";
+const PRIVATE_DIRECTORY = ".matrix-private";
+const DEFAULT_PROJECTION_AGE_MS = 5 * 60_000;
+const SECRET_MAX_CHARS = 64 * 1024;
+const CONFIGURATION_ACTIONS = [
+  "add_harness",
+  "update_harness",
+  "set_harness_enabled",
+  "set_route",
+  "select_account",
+  "select_access_source",
+] as const satisfies readonly ProviderSettingsSupportedAction[];
+
+export { ProviderSettingsStoreError } from "./provider-settings-errors.js";
+export type {
+  CanonicalProviderSnapshotReader,
+  ProviderAccountDependencyCoordinator,
+  ProviderAccountLifecycleCoordinator,
+  ProviderLoginCoordinator,
+  ProviderSettingsRuntimeCoordinator,
+} from "./provider-settings-coordinators.js";
+export interface ProviderSettingsStoreWriter {
+  getSnapshot(): Promise<ProviderSettingsSnapshot>;
+  mutate(mutation: ProviderSettingsMutation): Promise<ProviderSettingsMutationResponse>;
+}
+interface ProviderSettingsStoreOptions {
+  homePath: string;
+  providerSnapshotReader: CanonicalProviderSnapshotReader;
+  privateRootPath?: string;
+  dependencyCoordinator?: ProviderAccountDependencyCoordinator;
+  accountLifecycle?: ProviderAccountLifecycleCoordinator;
+  loginCoordinator?: ProviderLoginCoordinator;
+  runtimeCoordinator?: ProviderSettingsRuntimeCoordinator;
+  now?: () => Date;
+  idGenerator?: () => string;
+  maxProjectionAgeMs?: number;
+}
+
+function hashMutation(mutation: ProviderSettingsMutation): string {
+  return createHash("sha256").update(JSON.stringify(mutation)).digest("hex");
+}
+
+function sameCounts(left: ProviderDependencyCounts, right: ProviderDependencyCounts): boolean {
+  return left.activeChatCount === right.activeChatCount
+    && left.resumableChatCount === right.resumableChatCount
+    && left.harnessInstanceCount === right.harnessInstanceCount;
+}
+
+function loginMethods(kind: ProviderHarnessKind): readonly ProviderLoginMethod[] {
+  return kind === "codex"
+    ? ["terminal", "oauth", "api_key"] as const
+    : ["terminal", "api_key"] as const;
+}
+
+export class ProviderSettingsStore implements ProviderSettingsStoreWriter {
+  readonly configurationPath: string;
+  readonly secretsPath: string;
+  readonly #reader: CanonicalProviderSnapshotReader;
+  readonly #dependencies?: ProviderAccountDependencyCoordinator;
+  readonly #lifecycle?: ProviderAccountLifecycleCoordinator;
+  readonly #login?: ProviderLoginCoordinator;
+  readonly #runtime?: ProviderSettingsRuntimeCoordinator;
+  readonly #now: () => Date;
+  readonly #id: () => string;
+  readonly #maxProjectionAgeMs: number;
+  #writeTail: Promise<void> = Promise.resolve();
+
+  constructor(options: ProviderSettingsStoreOptions) {
+    if (!options.homePath) throw new Error("Provider settings home path is required");
+    if (!options.providerSnapshotReader) throw new Error("Canonical provider snapshot reader is required");
+    const homePath = resolve(options.homePath);
+    this.configurationPath = join(homePath, CONFIG_PATH);
+    const privateRoot = resolve(options.privateRootPath
+      ?? join(dirname(homePath), PRIVATE_DIRECTORY, basename(homePath)));
+    if (privateRoot === homePath || privateRoot.startsWith(`${homePath}/`)) {
+      throw new Error("Provider secret storage must be outside the synced owner home");
+    }
+    this.secretsPath = join(privateRoot, "ai-provider-secrets.json");
+    this.#reader = options.providerSnapshotReader;
+    this.#dependencies = options.dependencyCoordinator;
+    this.#lifecycle = options.accountLifecycle;
+    this.#login = options.loginCoordinator;
+    this.#runtime = options.runtimeCoordinator;
+    this.#now = options.now ?? (() => new Date());
+    this.#id = options.idGenerator ?? randomUUID;
+    this.#maxProjectionAgeMs = Math.max(
+      1,
+      Math.min(options.maxProjectionAgeMs ?? DEFAULT_PROJECTION_AGE_MS, 30 * 60_000),
+    );
+  }
+
+  async #serialize<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.#writeTail;
+    let release = () => {};
+    this.#writeTail = new Promise<void>((resolve) => { release = resolve; });
+    await previous;
+    try { return await operation(); } finally { release(); }
+  }
+
+  async #canonical(refresh = false): Promise<AiProviderSnapshotV3> {
+    try {
+      const snapshot = AiProviderSnapshotV3Schema.parse(await this.#reader.getSnapshot({ refresh }));
+      const age = this.#now().getTime() - Date.parse(snapshot.refreshedAt);
+      if (!Number.isFinite(age) || age < -60_000 || age > this.#maxProjectionAgeMs) {
+        throw new Error("Stale canonical provider projection");
+      }
+      return snapshot;
+    } catch (error) {
+      console.warn(
+        "[provider-settings] Canonical provider projection unavailable:",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+      throw new ProviderSettingsStoreError("projection_unavailable", 503);
+    }
+  }
+
+  async #configuration(canonical: AiProviderSnapshotV3): Promise<ProviderSettingsConfiguration> {
+    try {
+      return await readProviderSettingsConfiguration(this.configurationPath, canonical);
+    } catch (error) {
+      console.warn(
+        "[provider-settings] Owner provider configuration unavailable:",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+      throw new ProviderSettingsStoreError("configuration_unavailable", 503);
+    }
+  }
+
+  async #project(canonical: AiProviderSnapshotV3, config: ProviderSettingsConfiguration) {
+    try {
+      return await projectProviderSettings({
+        canonical,
+        config,
+        now: this.#now(),
+        dependencies: this.#dependencies,
+        supportedActions: this.#supportedActions(config),
+      });
+    } catch (error) {
+      if (error instanceof ProviderSettingsStoreError) throw error;
+      console.warn(
+        "[provider-settings] Provider settings projection failed:",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+      throw new ProviderSettingsStoreError("projection_unavailable", 503);
+    }
+  }
+
+  #supportedActions(config: ProviderSettingsConfiguration): ProviderSettingsSupportedAction[] {
+    const actions: ProviderSettingsSupportedAction[] = this.#runtime ? [...CONFIGURATION_ACTIONS] : [];
+    if (this.#runtime && config.gatewayPolicy) actions.push("set_gateway_budget", "set_gateway_allowlist");
+    if (this.#login) actions.push("start_login");
+    if (this.#lifecycle) actions.push("logout_account");
+    if (this.#lifecycle && this.#dependencies) actions.push("remove_account");
+    if (this.#dependencies) actions.push("reassign_account");
+    return actions;
+  }
+
+  #assertSupported(
+    type: ProviderSettingsMutation["type"],
+    config: ProviderSettingsConfiguration,
+  ): void {
+    if (this.#supportedActions(config).includes(type)) return;
+    if (type === "remove_account" || type === "reassign_account") {
+      throw new ProviderSettingsStoreError("dependency_unavailable", 503);
+    }
+    if (type === "start_login" || type === "logout_account") {
+      throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+    }
+    throw new ProviderSettingsStoreError("runtime_unavailable", 503);
+  }
+
+  async getSnapshot(): Promise<ProviderSettingsSnapshot> {
+    return await this.#serialize(async () => {
+      const canonical = await this.#canonical();
+      return await this.#project(canonical, await this.#configuration(canonical));
+    });
+  }
+
+  async setAccountSecret(accountId: string, value: string): Promise<void> {
+    await this.#serialize(async () => {
+      const canonical = await this.#canonical();
+      if (!canonical.accounts.some((account) => account.id === accountId)) {
+        throw new ProviderSettingsStoreError("not_found", 404);
+      }
+      const secrets = await this.#readSecrets();
+      secrets.accounts[accountId] = z.string().min(1).max(SECRET_MAX_CHARS).parse(value);
+      await writeProviderJsonAtomic(this.secretsPath, secrets);
+    });
+  }
+
+  async #readSecrets() {
+    try { return await readProviderSecrets(this.secretsPath); }
+    catch (error) {
+      console.warn("[provider-settings] Provider secret storage unavailable");
+      throw new ProviderSettingsStoreError("configuration_unavailable", 503);
+    }
+  }
+
+  async #deleteSecret(accountId: string): Promise<void> {
+    const secrets = await this.#readSecrets();
+    if (!(accountId in secrets.accounts)) return;
+    delete secrets.accounts[accountId];
+    await writeProviderJsonAtomic(this.secretsPath, secrets);
+  }
+
+  async #coordinate(
+    operation: () => Promise<void>,
+    code: "lifecycle_unavailable" | "dependency_unavailable",
+  ): Promise<void> {
+    try {
+      await operation();
+    } catch (error) {
+      if (error instanceof ProviderSettingsStoreError) throw error;
+      console.warn("[provider-settings] Provider coordination failed");
+      throw new ProviderSettingsStoreError(code, 503);
+    }
+  }
+
+  async #exactDependencies(
+    accountId: string,
+    config: ProviderSettingsConfiguration,
+    expected: ProviderDependencyCounts,
+  ): Promise<ProviderDependencyCounts> {
+    if (!this.#dependencies) throw new ProviderSettingsStoreError("dependency_unavailable", 503);
+    const harnessInstanceIds = config.harnesses
+      .filter((harness) => harness.selectedAccountId === accountId)
+      .map((harness) => harness.id);
+    let actual: ProviderDependencyCounts;
+    try {
+      actual = ProviderDependencyCountsSchema.parse(
+        await this.#dependencies.getAccountDependencies({ accountId, harnessInstanceIds }),
+      );
+    } catch (error) {
+      console.warn("[provider-settings] Account dependency check unavailable");
+      throw new ProviderSettingsStoreError("dependency_unavailable", 503);
+    }
+    if (!sameCounts(actual, expected)) {
+      throw new ProviderSettingsStoreError("revision_conflict", 409, {
+        latestRevision: config.revision,
+      });
+    }
+    return actual;
+  }
+
+  async #connectionAttempt(
+    mutation: Extract<ProviderSettingsMutation, { type: "start_login" }>,
+    harness: ProviderSettingsConfiguration["harnesses"][number],
+    snapshot: ProviderSettingsSnapshot,
+  ): Promise<ProviderConnectionAttempt> {
+    if (!loginMethods(harness.harness).includes(mutation.method)) {
+      throw new ProviderSettingsStoreError("invalid_request", 400);
+    }
+    const account = mutation.accountId === null
+      ? null
+      : snapshot.accounts.find((candidate) => candidate.id === mutation.accountId);
+    if (mutation.accountId !== null && !account) {
+      throw new ProviderSettingsStoreError("not_found", 404);
+    }
+    if (account && account.providerId !== harness.route.providerId) {
+      throw new ProviderSettingsStoreError("invalid_route", 400);
+    }
+    if (!this.#login) throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+    try {
+      const attempt = ProviderConnectionAttemptSchema.parse(await this.#login.startLogin({
+        mutation,
+        harness: {
+          id: harness.id,
+          harness: harness.harness,
+          providerId: harness.route.providerId,
+          modelId: harness.route.modelId,
+        },
+      }));
+      if (attempt.harnessInstanceId !== harness.id || attempt.accountId !== mutation.accountId
+        || attempt.method !== mutation.method) {
+        throw new Error("Incoherent provider login attempt");
+      }
+      return attempt;
+    } catch (error) {
+      if (error instanceof ProviderSettingsStoreError) throw error;
+      console.warn("[provider-settings] Provider login coordination failed");
+      throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+    }
+  }
+
+  async #persist(
+    config: ProviderSettingsConfiguration,
+    mutation: ProviderSettingsMutation,
+    payloadHash: string,
+    attempt?: ProviderConnectionAttempt,
+  ) {
+    config.revision += 1;
+    config.receipts.push({
+      key: mutation.idempotencyKey,
+      payloadHash,
+      appliedRevision: config.revision,
+      ...(attempt ? { attempt } : {}),
+    });
+    if (config.receipts.length > MAX_PROVIDER_SETTINGS_RECEIPTS) {
+      config.receipts.splice(0, config.receipts.length - MAX_PROVIDER_SETTINGS_RECEIPTS);
+    }
+    const validated = ProviderSettingsConfigurationSchema.parse(config);
+    try { await writeProviderJsonAtomic(this.configurationPath, validated); }
+    catch (error) {
+      console.warn(
+        "[provider-settings] Failed to persist owner provider configuration:",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+      throw new ProviderSettingsStoreError("configuration_unavailable", 503);
+    }
+    return validated;
+  }
+
+  async mutate(input: ProviderSettingsMutation): Promise<ProviderSettingsMutationResponse> {
+    const parsed = ProviderSettingsMutationSchema.safeParse(input);
+    if (!parsed.success) throw new ProviderSettingsStoreError("invalid_request", 400);
+    return await this.#serialize(async () => {
+      let canonical = await this.#canonical();
+      let config = await this.#configuration(canonical);
+      const mutation = parsed.data;
+      const payloadHash = hashMutation(mutation);
+      const duplicate = config.receipts.find((receipt) => receipt.key === mutation.idempotencyKey);
+      if (duplicate) {
+        if (duplicate.payloadHash !== payloadHash) {
+          throw new ProviderSettingsStoreError("idempotency_conflict", 409);
+        }
+        const snapshot = await this.#project(canonical, config);
+        const attempt = duplicate.attempt === undefined
+          ? undefined
+          : ProviderConnectionAttemptSchema.parse(duplicate.attempt);
+        return attempt
+          ? { kind: "login_attempt", snapshot, attempt }
+          : { kind: "snapshot", snapshot };
+      }
+      if (mutation.expectedRevision !== config.revision) {
+        throw new ProviderSettingsStoreError("revision_conflict", 409, {
+          latestRevision: config.revision,
+        });
+      }
+      this.#assertSupported(mutation.type, config);
+      const snapshot = await this.#project(canonical, config);
+      for (const account of snapshot.accounts) {
+        if (config.accountProfiles.some((profile) => profile.id === account.id)) continue;
+        config.accountProfiles.push({
+          id: account.id,
+          providerId: account.providerId,
+          displayName: account.displayName,
+          authMethod: account.authMethod,
+          accessSourceId: account.accessSourceId,
+        });
+      }
+      let attempt: ProviderConnectionAttempt | undefined;
+      const handled = applyProviderConfigurationMutation({
+        mutation,
+        config,
+        canonical,
+        snapshot,
+        id: this.#id,
+      });
+      if (handled) {
+        try {
+          await this.#runtime!.applyConfiguration({
+            mutation: mutation as ProviderConfigurationMutation,
+            idempotencyKey: mutation.idempotencyKey,
+          });
+          canonical = await this.#canonical(true);
+        } catch (error) {
+          if (error instanceof ProviderSettingsStoreError) throw error;
+          console.warn("[provider-settings] Provider runtime configuration failed");
+          throw new ProviderSettingsStoreError("runtime_unavailable", 503);
+        }
+      }
+      if (!handled) {
+        switch (mutation.type) {
+        case "start_login": {
+          const harness = config.harnesses.find((candidate) => candidate.id === mutation.harnessInstanceId);
+          if (!harness) throw new ProviderSettingsStoreError("not_found", 404);
+          attempt = await this.#connectionAttempt(mutation, harness, snapshot);
+          break;
+        }
+        case "logout_account":
+          if (!snapshot.accounts.some((account) => account.id === mutation.accountId)
+            && !config.accountProfiles.some((account) => account.id === mutation.accountId)) {
+            throw new ProviderSettingsStoreError("not_found", 404);
+          }
+          if (!this.#lifecycle) throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+          await this.#coordinate(() => this.#lifecycle!.logout({
+            accountId: mutation.accountId,
+            idempotencyKey: mutation.idempotencyKey,
+          }), "lifecycle_unavailable");
+          await this.#deleteSecret(mutation.accountId);
+          canonical = await this.#canonical(true);
+          break;
+        case "remove_account": {
+          if (!snapshot.accounts.some((account) => account.id === mutation.accountId)
+            && !config.accountProfiles.some((account) => account.id === mutation.accountId)) {
+            throw new ProviderSettingsStoreError("not_found", 404);
+          }
+          const accountStillCanonical = snapshot.accounts.some((account) => account.id === mutation.accountId);
+          const counts = accountStillCanonical
+            ? await this.#exactDependencies(mutation.accountId, config, mutation.dependencyGuard)
+            : mutation.dependencyGuard;
+          if (Object.values(counts).some((count) => count > 0)) {
+            throw new ProviderSettingsStoreError("account_in_use", 409);
+          }
+          if (!this.#lifecycle) throw new ProviderSettingsStoreError("lifecycle_unavailable", 503);
+          await this.#coordinate(() => this.#lifecycle!.remove({
+            accountId: mutation.accountId,
+            idempotencyKey: mutation.idempotencyKey,
+          }), "lifecycle_unavailable");
+          await this.#deleteSecret(mutation.accountId);
+          config.accountProfiles = config.accountProfiles.filter((profile) => profile.id !== mutation.accountId);
+          canonical = await this.#canonical(true);
+          break;
+        }
+        case "reassign_account": {
+          if (!snapshot.accounts.some((account) => account.id === mutation.fromAccountId)
+            && !config.accountProfiles.some((account) => account.id === mutation.fromAccountId)) {
+            throw new ProviderSettingsStoreError("not_found", 404);
+          }
+          const target = mutation.target;
+          const targetSourceId = target.kind === "account"
+            ? snapshot.accounts.find((account) => account.id === target.accountId)?.accessSourceId
+            : target.accessSourceId;
+          const targetSource = snapshot.accessSources.find((source) => source.id === targetSourceId);
+          if (!targetSource) throw new ProviderSettingsStoreError("not_found", 404);
+          const affected = config.harnesses.filter((candidate) => candidate.selectedAccountId === mutation.fromAccountId);
+          if ((mutation.scope === "harnesses" || mutation.scope === "all_dependencies")
+            && affected.some((candidate) => candidate.route.providerId !== targetSource.providerId
+              || !targetSource.eligibleModelIds.includes(candidate.route.modelId))) {
+            throw new ProviderSettingsStoreError("invalid_route", 400);
+          }
+          await this.#coordinate(() => this.#dependencies!.reassignDependencies({
+            fromAccountId: mutation.fromAccountId,
+            target: mutation.target,
+            scope: mutation.scope,
+            dependencyGuard: mutation.dependencyGuard,
+            harnessInstanceIds: affected.map((candidate) => candidate.id),
+            idempotencyKey: mutation.idempotencyKey,
+          }), "dependency_unavailable");
+          if (mutation.scope === "harnesses" || mutation.scope === "all_dependencies") {
+            for (const candidate of affected) {
+              candidate.accessSourceId = targetSource.id;
+              candidate.selectedAccountId = targetSource.accountId;
+            }
+          }
+          break;
+        }
+        }
+      }
+
+      config = await this.#persist(config, mutation, payloadHash, attempt);
+      const projected = await this.#project(canonical, config);
+      return ProviderSettingsMutationResponseSchema.parse(attempt
+        ? { kind: "login_attempt", snapshot: projected, attempt }
+        : { kind: "snapshot", snapshot: projected });
+    });
+  }
+}

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -235,6 +235,8 @@ import {
 import { createSettingsRoutes } from "./routes/settings.js";
 import { AiProviderService } from "./ai-providers/service.js";
 import { createAiProviderRoutes } from "./ai-providers/routes.js";
+import { ProviderSettingsStore } from "./ai-providers/provider-settings-store.js";
+import { createProviderSettingsRoutes } from "./ai-providers/provider-settings-routes.js";
 import { createHermesRoutes } from "./routes/hermes.js";
 import {
   createHermesDashboardClient,
@@ -4153,6 +4155,10 @@ export async function createGateway(config: GatewayConfig) {
   });
   await agentRuntimeServices.controller.reconcile();
   const aiProviderService = new AiProviderService({ homePath });
+  const providerSettingsStore = new ProviderSettingsStore({
+    homePath,
+    providerSnapshotReader: aiProviderService,
+  });
   const canonicalExecutableDriverKinds = [
     "kernel" as const,
     "hermes" as const,
@@ -4231,6 +4237,10 @@ export async function createGateway(config: GatewayConfig) {
   }));
   app.route("/api/ai", createAiProviderRoutes({
     service: aiProviderService,
+    getPrincipal: (c) => requireRequestPrincipal(c),
+  }));
+  app.route("/api/ai", createProviderSettingsRoutes({
+    store: providerSettingsStore,
     getPrincipal: (c) => requireRequestPrincipal(c),
   }));
 

--- a/tests/contracts/provider-settings.test.ts
+++ b/tests/contracts/provider-settings.test.ts
@@ -282,7 +282,26 @@ describe("provider settings contracts", () => {
       ...mutationBase,
       harnessInstanceId: "harness_hermes",
       route: { kind: "fixed", providerId: "anthropic", modelId: "anthropic/claude-opus-5" },
+      accessSourceId: "source_personal",
+      accountId: "account_personal",
     }).success).toBe(false);
+  });
+
+  it("requires route, access source, and account to change atomically", () => {
+    expect(ProviderSettingsMutationSchema.safeParse({
+      type: "set_route",
+      ...mutationBase,
+      harnessInstanceId: "harness_hermes",
+      route: { kind: "configurable", providerId: "openai", modelId: "openai/gpt-5.6" },
+    }).success).toBe(false);
+    expect(ProviderSettingsMutationSchema.safeParse({
+      type: "set_route",
+      ...mutationBase,
+      harnessInstanceId: "harness_hermes",
+      route: { kind: "configurable", providerId: "openai", modelId: "openai/gpt-5.6" },
+      accessSourceId: "source_openai",
+      accountId: "account_openai",
+    }).success).toBe(true);
   });
 
   it.each(["missing", "installing", "failed", "unknown"] as const)(
@@ -381,6 +400,8 @@ describe("provider settings contracts", () => {
       ...mutationBase,
       harnessInstanceId: "harness_hermes",
       route: { kind: "configurable", providerId: "anthropic", modelId: "anthropic/claude-opus-5" },
+      accessSourceId: "source_personal",
+      accountId: "account_personal",
     },
     { type: "select_account", ...mutationBase, harnessInstanceId: "harness_hermes", accountId: "account_personal" },
     { type: "select_access_source", ...mutationBase, harnessInstanceId: "harness_hermes", accessSourceId: "source_matrix" },

--- a/tests/gateway/provider-settings-capabilities.test.ts
+++ b/tests/gateway/provider-settings-capabilities.test.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ProviderSettingsMutation } from "@matrix-os/contracts";
+import { ProviderSettingsStore } from "../../packages/gateway/src/ai-providers/provider-settings-store.js";
+import {
+  PROVIDER_SETTINGS_NOW,
+  providerSettingsCanonicalFixture,
+} from "./provider-settings-test-support.js";
+
+describe("provider settings fail-closed capabilities", () => {
+  let homePath: string | undefined;
+
+  afterEach(async () => {
+    if (homePath) await rm(homePath, { recursive: true, force: true });
+  });
+
+  it("advertises no actions and rejects every mutation with default server dependencies", async () => {
+    homePath = await mkdtemp(join(tmpdir(), "provider-settings-capabilities-"));
+    const canonical = providerSettingsCanonicalFixture();
+    const store = new ProviderSettingsStore({
+      homePath,
+      providerSnapshotReader: { getSnapshot: async () => structuredClone(canonical) },
+      now: () => PROVIDER_SETTINGS_NOW,
+    });
+    const snapshot = await store.getSnapshot();
+    expect(snapshot.access).toEqual({ mode: "read_only", reason: "runtime_unavailable" });
+    expect(snapshot.supportedActions).toEqual([]);
+
+    const base = { expectedRevision: 0 } as const;
+    const mutations: ProviderSettingsMutation[] = [
+      {
+        ...base,
+        type: "add_harness",
+        idempotencyKey: "unsupported_01",
+        harness: "opencode",
+        displayName: "OpenCode",
+        route: { kind: "configurable", providerId: "anthropic", modelId: "claude-sonnet-5" },
+        accessSourceId: "matrix_included",
+        accountId: null,
+      },
+      { ...base, type: "update_harness", idempotencyKey: "unsupported_02", harnessInstanceId: "harness_kernel", displayName: "Claude" },
+      { ...base, type: "set_harness_enabled", idempotencyKey: "unsupported_03", harnessInstanceId: "harness_kernel", enabled: false },
+      { ...base, type: "set_route", idempotencyKey: "unsupported_04", harnessInstanceId: "harness_kernel", route: { kind: "configurable", providerId: "anthropic", modelId: "claude-sonnet-5" } },
+      { ...base, type: "select_account", idempotencyKey: "unsupported_05", harnessInstanceId: "harness_kernel", accountId: "owner_anthropic" },
+      { ...base, type: "select_access_source", idempotencyKey: "unsupported_06", harnessInstanceId: "harness_kernel", accessSourceId: "matrix_included" },
+      { ...base, type: "start_login", idempotencyKey: "unsupported_07", harnessInstanceId: "harness_kernel", accountId: null, method: "terminal" },
+      { ...base, type: "logout_account", idempotencyKey: "unsupported_08", accountId: "owner_anthropic" },
+      {
+        ...base,
+        type: "remove_account",
+        idempotencyKey: "unsupported_09",
+        accountId: "owner_anthropic",
+        dependencyGuard: { activeChatCount: 0, resumableChatCount: 0, harnessInstanceCount: 0 },
+        confirmation: "remove_account",
+      },
+      {
+        ...base,
+        type: "reassign_account",
+        idempotencyKey: "unsupported_10",
+        fromAccountId: "owner_anthropic",
+        target: { kind: "access_source", accessSourceId: "matrix_included" },
+        scope: "all_dependencies",
+        dependencyGuard: { activeChatCount: 0, resumableChatCount: 0, harnessInstanceCount: 0 },
+      },
+      { ...base, type: "set_gateway_budget", idempotencyKey: "unsupported_11", monthlyBudgetMicrousd: 1 },
+      { ...base, type: "set_gateway_allowlist", idempotencyKey: "unsupported_12", allowedModelIds: ["claude-sonnet-5"] },
+    ];
+
+    for (const mutation of mutations) {
+      await expect(store.mutate(mutation)).rejects.toMatchObject({ status: 503 });
+    }
+  });
+});

--- a/tests/gateway/provider-settings-capabilities.test.ts
+++ b/tests/gateway/provider-settings-capabilities.test.ts
@@ -42,7 +42,7 @@ describe("provider settings fail-closed capabilities", () => {
       },
       { ...base, type: "update_harness", idempotencyKey: "unsupported_02", harnessInstanceId: "harness_kernel", displayName: "Claude" },
       { ...base, type: "set_harness_enabled", idempotencyKey: "unsupported_03", harnessInstanceId: "harness_kernel", enabled: false },
-      { ...base, type: "set_route", idempotencyKey: "unsupported_04", harnessInstanceId: "harness_kernel", route: { kind: "configurable", providerId: "anthropic", modelId: "claude-sonnet-5" } },
+      { ...base, type: "set_route", idempotencyKey: "unsupported_04", harnessInstanceId: "harness_kernel", route: { kind: "configurable", providerId: "anthropic", modelId: "claude-sonnet-5" }, accessSourceId: "matrix_included", accountId: null },
       { ...base, type: "select_account", idempotencyKey: "unsupported_05", harnessInstanceId: "harness_kernel", accountId: "owner_anthropic" },
       { ...base, type: "select_access_source", idempotencyKey: "unsupported_06", harnessInstanceId: "harness_kernel", accessSourceId: "matrix_included" },
       { ...base, type: "start_login", idempotencyKey: "unsupported_07", harnessInstanceId: "harness_kernel", accountId: null, method: "terminal" },

--- a/tests/gateway/provider-settings-mutations.test.ts
+++ b/tests/gateway/provider-settings-mutations.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AiProviderSnapshotV3,
+  ProviderSettingsSnapshot,
+} from "@matrix-os/contracts";
+import { applyProviderConfigurationMutation } from "../../packages/gateway/src/ai-providers/provider-settings-mutations.js";
+import type { ProviderSettingsConfiguration } from "../../packages/gateway/src/ai-providers/provider-settings-persistence.js";
+import { providerSettingsCanonicalFixture } from "./provider-settings-test-support.js";
+
+describe("provider settings configuration mutations", () => {
+  it("switches provider, model, source, and account as one route mutation", () => {
+    const config = {
+      version: 1,
+      revision: 0,
+      harnesses: [{
+        id: "harness_generic",
+        driverId: "kernel",
+        harness: "opencode" as const,
+        displayName: "OpenCode",
+        accentColor: null,
+        enabled: true,
+        selectedAccountId: "account_anthropic",
+        accessSourceId: "source_anthropic",
+        route: { kind: "configurable" as const, providerId: "anthropic", modelId: "anthropic/claude" },
+      }],
+      accountProfiles: [],
+      gatewayPolicy: null,
+      receipts: [],
+    } satisfies ProviderSettingsConfiguration;
+    const snapshot = {
+      accessSources: [{
+        id: "source_openai",
+        kind: "provider_account",
+        providerId: "openai",
+        accountId: "account_openai",
+        eligibleModelIds: ["openai/gpt-5.6"],
+      }],
+      accounts: [{ id: "account_openai" }],
+      gatewayPolicy: null,
+    } as unknown as ProviderSettingsSnapshot;
+
+    expect(applyProviderConfigurationMutation({
+      mutation: {
+        type: "set_route",
+        expectedRevision: 0,
+        idempotencyKey: "route_openai_1",
+        harnessInstanceId: "harness_generic",
+        route: { kind: "configurable", providerId: "openai", modelId: "openai/gpt-5.6" },
+        accessSourceId: "source_openai",
+        accountId: "account_openai",
+      },
+      config,
+      canonical: providerSettingsCanonicalFixture() as AiProviderSnapshotV3,
+      snapshot,
+      id: () => "unused",
+    })).toBe(true);
+    expect(config.harnesses[0]).toMatchObject({
+      route: { providerId: "openai", modelId: "openai/gpt-5.6" },
+      accessSourceId: "source_openai",
+      selectedAccountId: "account_openai",
+    });
+  });
+
+  it("rejects an incoherent final account/source tuple without partially changing the harness", () => {
+    const originalHarness = {
+      id: "harness_generic",
+      driverId: "kernel",
+      harness: "hermes" as const,
+      displayName: "Hermes",
+      accentColor: null,
+      enabled: true,
+      selectedAccountId: null,
+      accessSourceId: "source_matrix",
+      route: { kind: "configurable" as const, providerId: "anthropic", modelId: "anthropic/claude" },
+    };
+    const config = {
+      version: 1,
+      revision: 0,
+      harnesses: [structuredClone(originalHarness)],
+      accountProfiles: [],
+      gatewayPolicy: null,
+      receipts: [],
+    } satisfies ProviderSettingsConfiguration;
+    const snapshot = {
+      accessSources: [{
+        id: "source_openai",
+        kind: "provider_account",
+        providerId: "openai",
+        accountId: "account_openai",
+        eligibleModelIds: ["openai/gpt-5.6"],
+      }],
+      accounts: [{ id: "account_other" }],
+      gatewayPolicy: null,
+    } as unknown as ProviderSettingsSnapshot;
+
+    expect(() => applyProviderConfigurationMutation({
+      mutation: {
+        type: "set_route",
+        expectedRevision: 0,
+        idempotencyKey: "route_openai_invalid_1",
+        harnessInstanceId: "harness_generic",
+        route: { kind: "configurable", providerId: "openai", modelId: "openai/gpt-5.6" },
+        accessSourceId: "source_openai",
+        accountId: "account_other",
+      },
+      config,
+      canonical: providerSettingsCanonicalFixture(),
+      snapshot,
+      id: () => "unused",
+    })).toThrow("invalid_route");
+    expect(config.harnesses[0]).toEqual(originalHarness);
+  });
+});

--- a/tests/gateway/provider-settings-routes.test.ts
+++ b/tests/gateway/provider-settings-routes.test.ts
@@ -1,0 +1,235 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ProviderSettingsMutationResponseSchema,
+  type ProviderSettingsMutation,
+  type ProviderSettingsMutationResponse,
+  type ProviderSettingsSnapshot,
+} from "@matrix-os/contracts";
+import { createProviderSettingsRoutes } from "../../packages/gateway/src/ai-providers/provider-settings-routes.js";
+import { ProviderSettingsStoreError } from "../../packages/gateway/src/ai-providers/provider-settings-store.js";
+
+const snapshot: ProviderSettingsSnapshot = {
+  contractVersion: 1,
+  projectionOf: { contract: "AiProviderSnapshotV3", contractVersion: 3, revision: 12 },
+  revision: 0,
+  refreshedAt: "2026-08-30T10:00:00.000Z",
+  access: { mode: "writable" },
+  supportedActions: [
+    "add_harness",
+    "update_harness",
+    "set_harness_enabled",
+    "set_route",
+    "select_account",
+    "select_access_source",
+    "set_gateway_budget",
+    "set_gateway_allowlist",
+  ],
+  modelProviders: [{
+    id: "anthropic",
+    displayName: "Anthropic",
+    models: [{ id: "anthropic/claude-opus-5", displayName: "Claude Opus 5", enabled: true }],
+  }],
+  accessSources: [{
+    id: "source_matrix",
+    kind: "matrix_gateway",
+    fundingKind: "matrix_included",
+    providerId: "anthropic",
+    accountId: null,
+    displayName: "Matrix AI",
+    readiness: {
+      state: "ready",
+      checkedAt: "2026-08-30T10:00:00.000Z",
+      staleAfter: "2026-08-30T10:05:00.000Z",
+      action: "none",
+      safeReason: null,
+    },
+    eligibleModelIds: ["anthropic/claude-opus-5"],
+    usage: {
+      kind: "managed_credit",
+      authority: "matrix_ledger",
+      state: "current",
+      scope: "owner_entitlement",
+      currency: "USD",
+      usedMicrousd: 0,
+      remainingMicrousd: 0,
+      limitMicrousd: 0,
+      periodStartedAt: "2026-08-30T10:00:00.000Z",
+      resetsAt: null,
+      asOf: "2026-08-30T10:00:00.000Z",
+    },
+  }],
+  accounts: [],
+  harnesses: [],
+  gatewayPolicy: {
+    accessSourceId: "source_matrix",
+    monthlyBudgetMicrousd: 10_000_000,
+    allowedModelIds: ["anthropic/claude-opus-5"],
+    topUpEnabled: false,
+  },
+};
+
+function createApp(options: {
+  getSnapshot?: () => Promise<ProviderSettingsSnapshot>;
+  mutate?: (input: ProviderSettingsMutation) => Promise<ProviderSettingsMutationResponse>;
+  getPrincipal?: () => unknown;
+} = {}) {
+  const getSnapshot = vi.fn(options.getSnapshot ?? (async () => snapshot));
+  const mutate = vi.fn(options.mutate ?? (async () => ({
+    kind: "snapshot" as const,
+    snapshot: { ...snapshot, revision: 1 },
+  })));
+  const getPrincipal = vi.fn(options.getPrincipal ?? (() => ({ userId: "owner_123" })));
+  const app = new Hono();
+  app.route("/api/ai", createProviderSettingsRoutes({
+    store: { getSnapshot, mutate },
+    getPrincipal,
+  }));
+  return { app, getSnapshot, mutate, getPrincipal };
+}
+
+describe("provider settings routes", () => {
+  it("authenticates reads and returns the secret-free snapshot", async () => {
+    const { app, getPrincipal, getSnapshot } = createApp();
+    const response = await app.request("/api/ai/provider-settings");
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(snapshot);
+    expect(getPrincipal).toHaveBeenCalledOnce();
+    expect(getSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it("validates each revisioned action before mutation", async () => {
+    const { app, mutate } = createApp();
+    const invalid = await app.request("/api/ai/provider-settings/actions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "set_gateway_budget", monthlyBudgetMicrousd: 20_000_000 }),
+    });
+    expect(invalid.status).toBe(400);
+    expect(mutate).not.toHaveBeenCalled();
+
+    const valid = await app.request("/api/ai/provider-settings/actions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        type: "set_gateway_budget",
+        expectedRevision: 0,
+        idempotencyKey: "budget_1",
+        monthlyBudgetMicrousd: 20_000_000,
+      }),
+    });
+    expect(valid.status).toBe(200);
+    expect(ProviderSettingsMutationResponseSchema.safeParse(await valid.json()).success).toBe(true);
+    expect(mutate).toHaveBeenCalledWith({
+      type: "set_gateway_budget",
+      expectedRevision: 0,
+      idempotencyKey: "budget_1",
+      monthlyBudgetMicrousd: 20_000_000,
+    });
+  });
+
+  it("rejects unauthenticated reads and mutations before touching the store", async () => {
+    const { app, getSnapshot, mutate } = createApp({
+      getPrincipal: () => { throw new Error("private authentication detail"); },
+    });
+    expect((await app.request("/api/ai/provider-settings")).status).toBe(401);
+    expect((await app.request("/api/ai/provider-settings/actions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        type: "set_gateway_budget",
+        expectedRevision: 0,
+        idempotencyKey: "budget_1",
+        monthlyBudgetMicrousd: 20_000_000,
+      }),
+    })).status).toBe(401);
+    expect(getSnapshot).not.toHaveBeenCalled();
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("applies body limits to POST and DELETE mutations", async () => {
+    const { app, mutate } = createApp();
+    const oversizedBody = JSON.stringify({
+      type: "set_gateway_allowlist",
+      expectedRevision: 0,
+      idempotencyKey: "allowlist_large_1",
+      allowedModelIds: Array.from({ length: 5_000 }, (_, index) => `model_${index}_${"x".repeat(20)}`),
+    });
+    const post = await app.request("/api/ai/provider-settings/actions", {
+      method: "POST",
+      headers: { "content-type": "application/json", "content-length": String(oversizedBody.length) },
+      body: oversizedBody,
+    });
+    expect(post.status).toBe(413);
+
+    const deleteBody = JSON.stringify({
+      expectedRevision: 0,
+      idempotencyKey: "remove_large_1",
+      dependencyGuard: { activeChatCount: 0, resumableChatCount: 0, harnessInstanceCount: 0 },
+      confirmation: "remove_account",
+      padding: "x".repeat(70_000),
+    });
+    const remove = await app.request("/api/ai/provider-settings/accounts/account_personal", {
+      method: "DELETE",
+      headers: { "content-type": "application/json", "content-length": String(deleteBody.length) },
+      body: deleteBody,
+    });
+    expect(remove.status).toBe(413);
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("supports a bounded DELETE account route without conflating logout", async () => {
+    const { app, mutate } = createApp();
+    const response = await app.request("/api/ai/provider-settings/accounts/account_personal", {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        expectedRevision: 4,
+        idempotencyKey: "remove_personal_1",
+        dependencyGuard: { activeChatCount: 0, resumableChatCount: 0, harnessInstanceCount: 0 },
+        confirmation: "remove_account",
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(mutate).toHaveBeenCalledWith({
+      type: "remove_account",
+      expectedRevision: 4,
+      idempotencyKey: "remove_personal_1",
+      accountId: "account_personal",
+      dependencyGuard: { activeChatCount: 0, resumableChatCount: 0, harnessInstanceCount: 0 },
+      confirmation: "remove_account",
+    });
+  });
+
+  it("maps typed conflicts and internal failures to provider-neutral errors", async () => {
+    const conflict = createApp({
+      mutate: async () => {
+        throw new ProviderSettingsStoreError("revision_conflict", 409, { latestRevision: 7 });
+      },
+    });
+    const conflictResponse = await conflict.app.request("/api/ai/provider-settings/actions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        type: "set_gateway_budget",
+        expectedRevision: 0,
+        idempotencyKey: "budget_conflict_1",
+        monthlyBudgetMicrousd: 20_000_000,
+      }),
+    });
+    expect(conflictResponse.status).toBe(409);
+    expect(await conflictResponse.json()).toEqual({
+      error: { code: "revision_conflict", message: "Provider settings changed. Refresh and try again." },
+      latestRevision: 7,
+    });
+
+    const failure = createApp({
+      getSnapshot: async () => { throw new Error("Anthropic sk-secret at /opt/private"); },
+    });
+    const failedResponse = await failure.app.request("/api/ai/provider-settings");
+    expect(failedResponse.status).toBe(503);
+    expect(await failedResponse.json()).toEqual({
+      error: { code: "provider_settings_unavailable", message: "Provider settings are unavailable." },
+    });
+  });
+});

--- a/tests/gateway/provider-settings-store.test.ts
+++ b/tests/gateway/provider-settings-store.test.ts
@@ -1,0 +1,482 @@
+import { mkdir, mkdtemp, readFile, readlink, rm, stat, symlink, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AiProviderSnapshotV3Schema,
+  ProviderSettingsSnapshotSchema,
+  type AiProviderSnapshotV3,
+  type ProviderDependencyCounts,
+} from "@matrix-os/contracts";
+import {
+  ProviderSettingsStore,
+  ProviderSettingsStoreError,
+  type ProviderAccountDependencyCoordinator,
+  type ProviderAccountLifecycleCoordinator,
+  type ProviderLoginCoordinator,
+  type ProviderSettingsRuntimeCoordinator,
+} from "../../packages/gateway/src/ai-providers/provider-settings-store.js";
+import {
+  PROVIDER_SETTINGS_NOW as NOW,
+  providerReady as ready,
+  providerSettingsCanonicalFixture,
+} from "./provider-settings-test-support.js";
+
+describe("ProviderSettingsStore", () => {
+  let homePath: string;
+  let privateRootPath: string;
+  let canonical: AiProviderSnapshotV3;
+  let dependencyCounts: Omit<ProviderDependencyCounts, "harnessInstanceCount">;
+  let dependencies: ProviderAccountDependencyCoordinator;
+  let lifecycle: ProviderAccountLifecycleCoordinator;
+  let login: ProviderLoginCoordinator;
+  let runtime: ProviderSettingsRuntimeCoordinator;
+
+  beforeEach(async () => {
+    homePath = await mkdtemp(join(tmpdir(), "provider-settings-store-"));
+    privateRootPath = join(dirname(homePath), `.matrix-private-${homePath.split("-").at(-1)}`);
+    canonical = providerSettingsCanonicalFixture();
+    dependencyCounts = { activeChatCount: 0, resumableChatCount: 0 };
+    dependencies = {
+      getAccountDependencies: vi.fn(async ({ harnessInstanceIds }) => ({
+        ...dependencyCounts,
+        harnessInstanceCount: harnessInstanceIds.length,
+      })),
+      reassignDependencies: vi.fn(async () => undefined),
+    };
+    lifecycle = {
+      logout: vi.fn(async ({ accountId }) => {
+        canonical = AiProviderSnapshotV3Schema.parse({
+          ...canonical,
+          revision: canonical.revision + 1,
+          accounts: canonical.accounts.map((account) => account.id === accountId ? {
+            ...account,
+            authMethod: null,
+            state: "setup_required",
+            checkedAt: null,
+            staleAfter: null,
+            action: "connect",
+          } : account),
+          accessSources: canonical.accessSources.map((source) => source.id === "owner_anthropic_profile" ? {
+            ...source,
+            state: "setup_required",
+            checkedAt: null,
+            staleAfter: null,
+            action: "connect",
+          } : source),
+          instances: canonical.instances.map((instance) => instance.accountId === accountId ? {
+            ...instance,
+            readiness: {
+              state: "setup_required",
+              checkedAt: null,
+              staleAfter: null,
+              action: "connect",
+              safeReason: null,
+            },
+            defaultModelId: null,
+          } : instance),
+        });
+      }),
+      remove: vi.fn(async ({ accountId }) => {
+        canonical = AiProviderSnapshotV3Schema.parse({
+          ...canonical,
+          revision: canonical.revision + 1,
+          accounts: canonical.accounts.filter((account) => account.id !== accountId),
+          accessSources: canonical.accessSources.filter((source) => source.id !== "owner_anthropic_profile"),
+          instances: canonical.instances.filter((instance) => instance.accountId !== accountId),
+          models: canonical.models.map((model) => ({
+            ...model,
+            eligibleAccessSourceIds: model.eligibleAccessSourceIds.filter((id) => id !== "owner_anthropic_profile"),
+            dataPolicies: model.dataPolicies.filter((policy) => policy.accessSourceId !== "owner_anthropic_profile"),
+          })),
+        });
+      }),
+    };
+    login = {
+      startLogin: vi.fn(async ({ mutation }) => ({
+        id: "attempt_real_terminal_1",
+        harnessInstanceId: mutation.harnessInstanceId,
+        accountId: mutation.accountId,
+        method: mutation.method,
+        state: "pending",
+        action: { kind: "open_terminal", terminalSessionId: "terminal_real_1" },
+        expiresAt: new Date(NOW.getTime() + 10 * 60_000).toISOString(),
+        safeFailure: null,
+      })),
+    };
+    runtime = {
+      applyConfiguration: vi.fn(async () => undefined),
+    };
+  });
+
+  afterEach(async () => {
+    await rm(homePath, { recursive: true, force: true });
+    await rm(privateRootPath, { recursive: true, force: true });
+  });
+
+  function createStore(options: {
+    withDependencies?: boolean;
+    withLifecycle?: boolean;
+    withLogin?: boolean;
+    withRuntime?: boolean;
+    snapshot?: () => AiProviderSnapshotV3;
+  } = {}) {
+    let nextId = 0;
+    return new ProviderSettingsStore({
+      homePath,
+      privateRootPath,
+      providerSnapshotReader: {
+        getSnapshot: async () => structuredClone((options.snapshot ?? (() => canonical))()),
+      },
+      dependencyCoordinator: options.withDependencies === false ? undefined : dependencies,
+      accountLifecycle: options.withLifecycle === false ? undefined : lifecycle,
+      loginCoordinator: options.withLogin === false ? undefined : login,
+      runtimeCoordinator: options.withRuntime === false ? undefined : runtime,
+      now: () => NOW,
+      idGenerator: () => `generated_${++nextId}`,
+    });
+  }
+
+  it("projects fresh V3 truth and persists owner configuration without readiness or usage copies", async () => {
+    const store = createStore();
+    const initial = await store.getSnapshot();
+    expect(ProviderSettingsSnapshotSchema.safeParse(initial).success).toBe(true);
+    expect(initial).toMatchObject({
+      projectionOf: { contract: "AiProviderSnapshotV3", contractVersion: 3, revision: 7 },
+      revision: 0,
+      access: { mode: "writable" },
+    });
+    expect(initial.accessSources[0]!.usage).toMatchObject({
+      kind: "unavailable",
+      authority: "unavailable",
+      reason: "ledger_not_available",
+    });
+
+    const response = await store.mutate({
+      type: "add_harness",
+      expectedRevision: 0,
+      idempotencyKey: "add_opencode_1",
+      harness: "opencode",
+      displayName: "OpenCode",
+      route: { kind: "configurable", providerId: "anthropic", modelId: "claude-sonnet-5" },
+      accessSourceId: "matrix_included",
+      accountId: null,
+    });
+    expect(response.kind).toBe("snapshot");
+    expect(response.snapshot.revision).toBe(1);
+    expect(response.snapshot.harnesses).toEqual(expect.arrayContaining([
+      expect.objectContaining({ harness: "opencode", enabled: false, installState: "missing" }),
+    ]));
+    const stored = await readFile(store.configurationPath, "utf8");
+    expect((await stat(store.configurationPath)).mode & 0o777).toBe(0o600);
+    expect(stored).not.toMatch(/"readiness"|"usage"|apiKey|accessToken/);
+  });
+
+  it("is read-only and rejects cosmetic mutations without a runtime coordinator", async () => {
+    const store = createStore({
+      withRuntime: false,
+      withLogin: false,
+      withLifecycle: false,
+      withDependencies: false,
+    });
+    const snapshot = await store.getSnapshot();
+    expect(snapshot.access).toEqual({ mode: "read_only", reason: "runtime_unavailable" });
+    expect(snapshot.supportedActions).toEqual([]);
+    await expect(store.mutate({
+      type: "set_gateway_budget",
+      expectedRevision: 0,
+      idempotencyKey: "budget_unwired_1",
+      monthlyBudgetMicrousd: 1,
+    })).rejects.toMatchObject({ code: "runtime_unavailable" });
+  });
+
+  it("rejects missing, malformed, and stale canonical projections", async () => {
+    expect(() => new ProviderSettingsStore({
+      homePath,
+      providerSnapshotReader: undefined as never,
+    })).toThrow("Canonical provider snapshot reader is required");
+    const stale = { ...canonical, refreshedAt: "2026-08-30T09:00:00.000Z" };
+    await expect(createStore({ snapshot: () => stale }).getSnapshot())
+      .rejects.toMatchObject({ code: "projection_unavailable" });
+  });
+
+  it("enforces revision concurrency and bounded idempotency", async () => {
+    const store = createStore();
+    const mutation = {
+      type: "set_gateway_budget" as const,
+      expectedRevision: 0,
+      idempotencyKey: "budget_1",
+      monthlyBudgetMicrousd: 2_000_000,
+    };
+    expect((await store.mutate(mutation)).snapshot.revision).toBe(1);
+    expect((await store.mutate(mutation)).snapshot.revision).toBe(1);
+    await expect(store.mutate({ ...mutation, monthlyBudgetMicrousd: 3_000_000 }))
+      .rejects.toMatchObject({ code: "idempotency_conflict" });
+
+    const results = await Promise.allSettled([
+      store.mutate({ ...mutation, expectedRevision: 1, idempotencyKey: "budget_2", monthlyBudgetMicrousd: 3_000_000 }),
+      store.mutate({ ...mutation, expectedRevision: 1, idempotencyKey: "budget_3", monthlyBudgetMicrousd: 4_000_000 }),
+    ]);
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(results.find((result) => result.status === "rejected"))
+      .toMatchObject({ reason: expect.objectContaining({ code: "revision_conflict" }) });
+  });
+
+  it("returns an idempotent visible Terminal login attempt and keeps secrets outside sync/export", async () => {
+    const store = createStore();
+    const mutation = {
+      type: "start_login" as const,
+      expectedRevision: 0,
+      idempotencyKey: "login_1",
+      harnessInstanceId: "harness_kernel",
+      accountId: null,
+      method: "terminal" as const,
+    };
+    const first = await store.mutate(mutation);
+    const retried = await store.mutate(mutation);
+    expect(first).toMatchObject({
+      kind: "login_attempt",
+      attempt: { state: "pending", action: { kind: "open_terminal" } },
+    });
+    expect(retried).toEqual(first);
+    expect(login.startLogin).toHaveBeenCalledOnce();
+    expect(first.kind === "login_attempt" && first.attempt.action).toEqual({
+      kind: "open_terminal",
+      terminalSessionId: "terminal_real_1",
+    });
+
+    await store.setAccountSecret("owner_anthropic", "secret-value");
+    expect(store.secretsPath.startsWith(homePath)).toBe(false);
+    expect((await stat(store.secretsPath)).mode & 0o777).toBe(0o600);
+    expect(JSON.stringify(await store.getSnapshot())).not.toContain("secret-value");
+  });
+
+  it("does not fabricate login sessions and rejects account/provider mismatches", async () => {
+    await expect(createStore({ withLogin: false }).mutate({
+      type: "start_login",
+      expectedRevision: 0,
+      idempotencyKey: "login_unwired_1",
+      harnessInstanceId: "harness_kernel",
+      accountId: null,
+      method: "terminal",
+    })).rejects.toMatchObject({ code: "lifecycle_unavailable" });
+
+    canonical = AiProviderSnapshotV3Schema.parse({
+      ...canonical,
+      accessSources: [...canonical.accessSources, {
+        id: "owner_openai_profile",
+        displayName: "OpenAI account",
+        fundingKind: "owner_account",
+        vendor: "openai",
+        accountLabel: "OpenAI",
+        eligibleModelIds: ["gpt-5"],
+        policyVersion: "policy_1",
+        ...ready,
+      }],
+      accounts: [...canonical.accounts, {
+        id: "owner_openai",
+        vendor: "openai",
+        authMethod: "provider_profile",
+        accountLabel: "OpenAI",
+        ...ready,
+      }],
+      instances: [...canonical.instances, {
+        id: "kernel_openai",
+        driverId: "kernel",
+        vendor: "openai",
+        accountId: "owner_openai",
+        accessSourceId: "owner_openai_profile",
+        label: "OpenAI",
+        readiness: ready,
+        capabilitySnapshot: ["tools", "resume"],
+        modelIds: ["gpt-5"],
+        defaultModelId: "gpt-5",
+        catalogVersion: "catalog_1",
+      }],
+      models: [...canonical.models, {
+        id: "gpt-5",
+        vendor: "openai",
+        displayName: "GPT-5",
+        status: "current",
+        capabilities: ["tools", "reasoning"],
+        effortControls: ["high"],
+        eligibleAccessSourceIds: ["owner_openai_profile"],
+        dataPolicies: [{
+          accessSourceId: "owner_openai_profile",
+          route: "owner_direct",
+          disclosureKey: "owner-openai",
+        }],
+        aliases: [],
+        catalogVersion: "catalog_1",
+      }],
+    });
+    await expect(createStore().mutate({
+      type: "start_login",
+      expectedRevision: 0,
+      idempotencyKey: "login_wrong_provider_1",
+      harnessInstanceId: "harness_kernel",
+      accountId: "owner_openai",
+      method: "terminal",
+    })).rejects.toMatchObject({ code: "invalid_route" });
+    expect(login.startLogin).not.toHaveBeenCalled();
+
+    login.startLogin = vi.fn(async ({ mutation }) => ({
+      id: "attempt_wrong_1",
+      harnessInstanceId: "harness_other",
+      accountId: mutation.accountId,
+      method: mutation.method,
+      state: "pending",
+      action: { kind: "open_terminal", terminalSessionId: "terminal_wrong_1" },
+      expiresAt: new Date(NOW.getTime() + 60_000).toISOString(),
+      safeFailure: null,
+    }));
+    await expect(createStore().mutate({
+      type: "start_login",
+      expectedRevision: 0,
+      idempotencyKey: "login_incoherent_1",
+      harnessInstanceId: "harness_kernel",
+      accountId: null,
+      method: "terminal",
+    })).rejects.toMatchObject({ code: "lifecycle_unavailable" });
+  });
+
+  it("recovers a deterministic stale atomic-write temp and validates receipt attempts", async () => {
+    const store = createStore();
+    const tempPath = join(dirname(store.configurationPath), ".settings.json.tmp");
+    await mkdir(dirname(tempPath), { recursive: true });
+    await writeFile(tempPath, "stale", { mode: 0o600 });
+    await store.mutate({
+      type: "set_gateway_budget",
+      expectedRevision: 0,
+      idempotencyKey: "budget_atomic_1",
+      monthlyBudgetMicrousd: 2_000_000,
+    });
+    await expect(stat(tempPath)).rejects.toMatchObject({ code: "ENOENT" });
+
+    const sentinelPath = join(homePath, "sentinel.txt");
+    await writeFile(sentinelPath, "untouched");
+    await symlink(sentinelPath, tempPath);
+    await expect(store.mutate({
+      type: "set_gateway_budget",
+      expectedRevision: 1,
+      idempotencyKey: "budget_atomic_2",
+      monthlyBudgetMicrousd: 3_000_000,
+    })).rejects.toMatchObject({ code: "configuration_unavailable" });
+    expect(await readlink(tempPath)).toBe(sentinelPath);
+    expect(await readFile(sentinelPath, "utf8")).toBe("untouched");
+    await unlink(tempPath);
+
+    const persisted = JSON.parse(await readFile(store.configurationPath, "utf8"));
+    persisted.receipts[0].attempt = { secret: "must-not-persist" };
+    await writeFile(store.configurationPath, JSON.stringify(persisted), { mode: 0o600 });
+    await expect(store.getSnapshot()).rejects.toMatchObject({ code: "configuration_unavailable" });
+  });
+
+  it("keeps logout distinct and blocks removal until exact dependencies are reassigned", async () => {
+    const store = createStore();
+    let response = await store.mutate({
+      type: "select_account",
+      expectedRevision: 0,
+      idempotencyKey: "select_owner_1",
+      harnessInstanceId: "harness_kernel",
+      accountId: "owner_anthropic",
+    });
+    await store.setAccountSecret("owner_anthropic", "secret-value");
+    response = await store.mutate({
+      type: "logout_account",
+      expectedRevision: response.snapshot.revision,
+      idempotencyKey: "logout_owner_1",
+      accountId: "owner_anthropic",
+    });
+    expect(response.snapshot.accounts).toEqual([
+      expect.objectContaining({ id: "owner_anthropic", authState: "unauthenticated" }),
+    ]);
+    expect(await readFile(store.secretsPath, "utf8")).not.toContain("secret-value");
+
+    await expect(store.mutate({
+      type: "remove_account",
+      expectedRevision: response.snapshot.revision,
+      idempotencyKey: "remove_owner_1",
+      accountId: "owner_anthropic",
+      dependencyGuard: { activeChatCount: 0, resumableChatCount: 0, harnessInstanceCount: 1 },
+      confirmation: "remove_account",
+    })).rejects.toMatchObject({ code: "account_in_use" });
+
+    response = await store.mutate({
+      type: "reassign_account",
+      expectedRevision: response.snapshot.revision,
+      idempotencyKey: "reassign_owner_1",
+      fromAccountId: "owner_anthropic",
+      target: { kind: "access_source", accessSourceId: "matrix_included" },
+      scope: "all_dependencies",
+      dependencyGuard: { activeChatCount: 0, resumableChatCount: 0, harnessInstanceCount: 1 },
+    });
+    expect(dependencies.reassignDependencies).toHaveBeenCalledOnce();
+
+    response = await store.mutate({
+      type: "remove_account",
+      expectedRevision: response.snapshot.revision,
+      idempotencyKey: "remove_owner_2",
+      accountId: "owner_anthropic",
+      dependencyGuard: { activeChatCount: 0, resumableChatCount: 0, harnessInstanceCount: 0 },
+      confirmation: "remove_account",
+    });
+    expect(response.snapshot.accounts).toEqual([]);
+    expect(lifecycle.remove).toHaveBeenCalledWith({
+      accountId: "owner_anthropic",
+      idempotencyKey: "remove_owner_2",
+    });
+    expect(dependencies.reassignDependencies).toHaveBeenCalledWith(expect.objectContaining({
+      idempotencyKey: "reassign_owner_1",
+    }));
+  });
+
+  it("recovers an idempotent account removal after owner-config persistence fails", async () => {
+    const store = createStore();
+    await store.getSnapshot();
+    const tempPath = join(dirname(store.configurationPath), ".settings.json.tmp");
+    const sentinelPath = join(homePath, "remove-sentinel.txt");
+    await writeFile(sentinelPath, "untouched");
+    await symlink(sentinelPath, tempPath);
+    const mutation = {
+      type: "remove_account" as const,
+      expectedRevision: 0,
+      idempotencyKey: "remove_recovery_1",
+      accountId: "owner_anthropic",
+      dependencyGuard: { activeChatCount: 0, resumableChatCount: 0, harnessInstanceCount: 0 },
+      confirmation: "remove_account" as const,
+    };
+    await expect(store.mutate(mutation)).rejects.toMatchObject({ code: "configuration_unavailable" });
+    expect(canonical.accounts).toEqual([]);
+    await unlink(tempPath);
+
+    const response = await store.mutate(mutation);
+    expect(response.snapshot.accounts).toEqual([]);
+    expect(lifecycle.remove).toHaveBeenNthCalledWith(1, {
+      accountId: "owner_anthropic",
+      idempotencyKey: "remove_recovery_1",
+    });
+    expect(lifecycle.remove).toHaveBeenNthCalledWith(2, {
+      accountId: "owner_anthropic",
+      idempotencyKey: "remove_recovery_1",
+    });
+  });
+
+  it("fails closed without dependency and lifecycle coordinators and preserves malformed owner files", async () => {
+    const store = createStore({ withDependencies: false, withLifecycle: false });
+    await expect(store.mutate({
+      type: "remove_account",
+      expectedRevision: 0,
+      idempotencyKey: "remove_unwired_1",
+      accountId: "owner_anthropic",
+      dependencyGuard: { activeChatCount: 0, resumableChatCount: 0, harnessInstanceCount: 0 },
+      confirmation: "remove_account",
+    })).rejects.toMatchObject({ code: "dependency_unavailable" });
+
+    await mkdir(dirname(store.configurationPath), { recursive: true });
+    await writeFile(store.configurationPath, "{not valid json", { mode: 0o600 });
+    await expect(store.getSnapshot()).rejects.toBeInstanceOf(ProviderSettingsStoreError);
+    await expect(store.getSnapshot()).rejects.toMatchObject({ code: "configuration_unavailable" });
+    expect(await readFile(store.configurationPath, "utf8")).toBe("{not valid json");
+  });
+});

--- a/tests/gateway/provider-settings-test-support.ts
+++ b/tests/gateway/provider-settings-test-support.ts
@@ -1,0 +1,126 @@
+import {
+  AiProviderSnapshotV3Schema,
+  type AiProviderSnapshotV3,
+} from "@matrix-os/contracts";
+
+export const PROVIDER_SETTINGS_NOW = new Date("2026-08-30T10:00:00.000Z");
+const LATER = "2026-08-30T10:05:00.000Z";
+export const providerReady = {
+  state: "ready" as const,
+  checkedAt: PROVIDER_SETTINGS_NOW.toISOString(),
+  staleAfter: LATER,
+  action: "none" as const,
+  safeReason: null,
+};
+
+export function providerSettingsCanonicalFixture(): AiProviderSnapshotV3 {
+  return AiProviderSnapshotV3Schema.parse({
+    contractVersion: 3,
+    revision: 7,
+    refreshedAt: PROVIDER_SETTINGS_NOW.toISOString(),
+    accessSources: [
+      {
+        id: "matrix_included",
+        displayName: "Matrix AI",
+        fundingKind: "matrix_included",
+        vendor: "anthropic",
+        accountLabel: "Included",
+        eligibleModelIds: ["claude-sonnet-5"],
+        policyVersion: "policy_1",
+        ...providerReady,
+      },
+      {
+        id: "owner_anthropic_profile",
+        displayName: "Anthropic account",
+        fundingKind: "owner_account",
+        vendor: "anthropic",
+        accountLabel: "Personal",
+        eligibleModelIds: ["claude-sonnet-5", "claude-opus-5"],
+        policyVersion: "policy_1",
+        ...providerReady,
+      },
+    ],
+    accounts: [{
+      id: "owner_anthropic",
+      vendor: "anthropic",
+      authMethod: "provider_profile",
+      accountLabel: "Personal",
+      ...providerReady,
+    }],
+    drivers: [{
+      id: "kernel",
+      displayName: "Matrix Agent",
+      kind: "agent_sdk",
+      installState: "installed",
+      health: "ready",
+      capabilities: ["tools", "resume"],
+      setupActions: [],
+    }],
+    instances: [
+      {
+        id: "kernel_matrix",
+        driverId: "kernel",
+        vendor: "anthropic",
+        accountId: null,
+        accessSourceId: "matrix_included",
+        label: "Matrix AI",
+        readiness: providerReady,
+        capabilitySnapshot: ["tools", "resume"],
+        modelIds: ["claude-sonnet-5"],
+        defaultModelId: "claude-sonnet-5",
+        catalogVersion: "catalog_1",
+      },
+      {
+        id: "kernel_owner",
+        driverId: "kernel",
+        vendor: "anthropic",
+        accountId: "owner_anthropic",
+        accessSourceId: "owner_anthropic_profile",
+        label: "Personal Anthropic",
+        readiness: providerReady,
+        capabilitySnapshot: ["tools", "resume"],
+        modelIds: ["claude-sonnet-5", "claude-opus-5"],
+        defaultModelId: "claude-opus-5",
+        catalogVersion: "catalog_1",
+      },
+    ],
+    models: [
+      {
+        id: "claude-sonnet-5",
+        vendor: "anthropic",
+        displayName: "Claude Sonnet 5",
+        status: "current",
+        capabilities: ["tools", "reasoning"],
+        effortControls: ["low", "high"],
+        eligibleAccessSourceIds: ["matrix_included", "owner_anthropic_profile"],
+        dataPolicies: [
+          { accessSourceId: "matrix_included", route: "matrix_relay", disclosureKey: "matrix-anthropic" },
+          { accessSourceId: "owner_anthropic_profile", route: "owner_direct", disclosureKey: "owner-anthropic" },
+        ],
+        aliases: [],
+        catalogVersion: "catalog_1",
+      },
+      {
+        id: "claude-opus-5",
+        vendor: "anthropic",
+        displayName: "Claude Opus 5",
+        status: "current",
+        capabilities: ["tools", "reasoning"],
+        effortControls: ["high"],
+        eligibleAccessSourceIds: ["owner_anthropic_profile"],
+        dataPolicies: [{
+          accessSourceId: "owner_anthropic_profile",
+          route: "owner_direct",
+          disclosureKey: "owner-anthropic",
+        }],
+        aliases: [],
+        catalogVersion: "catalog_1",
+      },
+    ],
+    active: {
+      providerInstanceId: "kernel_matrix",
+      accessSourceId: "matrix_included",
+      modelId: "claude-sonnet-5",
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- add owner-local, permission-hardened provider configuration and separately protected secret persistence
- project the canonical V3 provider snapshot into the shared provider-settings contract
- add authenticated, body-limited, revisioned provider-settings reads and mutations with atomic route switching and idempotency receipts
- wire the initial production surface read-only unless an explicit runtime coordinator advertises each mutation

## Validation

- focused gateway provider-settings persistence, projection, route, mutation, and store tests
- gateway TypeScript check
- `git diff codex/provider-settings-foundation...HEAD --check`

## Invariants

- **Source of truth:** the canonical provider snapshot supplies observed runtime truth; owner files store identity/configuration, with secrets isolated under the private Matrix directory.
- **Lock / transaction scope:** mutations serialize per store instance and persist via exclusive temporary create plus atomic rename; there are no database writes in this slice.
- **Acceptable orphan states:** a runtime mutation may succeed before the owner file is replaced; idempotency receipts and a forced canonical refresh make retry explicit and bounded.
- **Auth source of truth:** existing gateway authentication protects both routes; provider credentials never appear in responses or authorization paths.
- **Deferred scope:** real driver inventory/login/logout, Matrix-funded balances, add-on billing, and Cloudflare forwarding remain capability-disabled for later stack layers.
