### PR TITLE
feat(ai-policy): add funded AI metering

### DIFF
--- a/packages/contracts/src/funded-ai.ts
+++ b/packages/contracts/src/funded-ai.ts
@@ -10,6 +10,7 @@ const RuntimeSlotSchema = z.string().min(1).max(80).regex(/^[a-z0-9][a-z0-9_-]*$
 const UniqueModelIdsSchema = z.array(ProviderModelReferenceSchema).max(64)
   .refine((models) => new Set(models).size === models.length, "Model IDs must be unique");
 const TokenIdSchema = canonicalReferenceId(80);
+const MicrousdSchema = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
 const OpaqueCredentialSchema = z.string()
   .min(64)
   .max(256)
@@ -33,6 +34,7 @@ export const FundedAiEffectivePolicySchema = z.object({
   globalRevision: RevisionSchema,
   runtimeRevision: RevisionSchema,
   allowedModelIds: UniqueModelIdsSchema,
+  monthlyBudgetMicrousd: MicrousdSchema,
   checkedAt: IsoTimestampSchema,
   staleAfter: IsoTimestampSchema,
 }).strict().superRefine((value, ctx) => {
@@ -76,7 +78,36 @@ export const FundedAiAuthorizationRequestSchema = z.object({
   credential: OpaqueCredentialSchema,
   requestId: canonicalReferenceId(160),
   modelId: ProviderModelReferenceSchema,
+  maxCostMicrousd: MicrousdSchema.min(1),
 }).strict();
+
+export const FundedAiFundingSummarySchema = z.object({
+  asOf: IsoTimestampSchema,
+  periodStart: IsoTimestampSchema,
+  monthlyBudgetMicrousd: MicrousdSchema,
+  settledThisMonthMicrousd: MicrousdSchema,
+  reservedMicrousd: MicrousdSchema,
+  reservedThisMonthMicrousd: MicrousdSchema,
+  promotionalBalanceMicrousd: MicrousdSchema,
+  addonBalanceMicrousd: MicrousdSchema,
+  creditBalanceMicrousd: MicrousdSchema,
+  remainingBalanceMicrousd: MicrousdSchema,
+  remainingBudgetMicrousd: MicrousdSchema,
+}).strict().superRefine((value, ctx) => {
+  if (value.creditBalanceMicrousd !== value.promotionalBalanceMicrousd + value.addonBalanceMicrousd) {
+    ctx.addIssue({ code: "custom", path: ["creditBalanceMicrousd"], message: "Credit buckets must equal total credit" });
+  }
+  if (value.remainingBalanceMicrousd !== Math.max(0, value.creditBalanceMicrousd - value.reservedMicrousd)) {
+    ctx.addIssue({ code: "custom", path: ["remainingBalanceMicrousd"], message: "Remaining credit is inconsistent" });
+  }
+  const expectedBudget = Math.max(
+    0,
+    value.monthlyBudgetMicrousd - value.settledThisMonthMicrousd - value.reservedThisMonthMicrousd,
+  );
+  if (value.remainingBudgetMicrousd !== expectedBudget) {
+    ctx.addIssue({ code: "custom", path: ["remainingBudgetMicrousd"], message: "Remaining budget is inconsistent" });
+  }
+});
 
 export const FundedAiAuthorizationResponseSchema = z.object({
   contractVersion: z.literal(1),
@@ -88,6 +119,71 @@ export const FundedAiAuthorizationResponseSchema = z.object({
     expiresAt: IsoTimestampSchema,
   }).strict(),
   policy: FundedAiEffectivePolicySchema,
+  funding: FundedAiFundingSummarySchema,
+  reservation: z.object({
+    reservationId: canonicalReferenceId(160),
+    requestId: canonicalReferenceId(160),
+    modelId: ProviderModelReferenceSchema,
+    reservedMicrousd: MicrousdSchema.min(1),
+    remainingBalanceMicrousd: MicrousdSchema,
+    remainingBudgetMicrousd: MicrousdSchema,
+    periodStart: IsoTimestampSchema,
+    expiresAt: IsoTimestampSchema,
+    status: z.literal("reserved"),
+  }).strict(),
+}).strict();
+
+export const FundedAiSettlementRequestSchema = z.object({
+  reservationId: canonicalReferenceId(160),
+  tokenId: TokenIdSchema,
+  actualCostMicrousd: MicrousdSchema,
+}).strict();
+
+export const FundedAiStartRequestSchema = z.object({
+  reservationId: canonicalReferenceId(160),
+  tokenId: TokenIdSchema,
+}).strict();
+
+export const FundedAiStartResponseSchema = z.object({
+  contractVersion: z.literal(1),
+  reservationId: canonicalReferenceId(160),
+  requestId: canonicalReferenceId(160),
+  tokenId: TokenIdSchema,
+  startedAt: IsoTimestampSchema,
+  expiresAt: IsoTimestampSchema,
+  status: z.literal("in_flight"),
+}).strict();
+
+export const FundedAiSettlementResponseSchema = z.object({
+  contractVersion: z.literal(1),
+  reservationId: canonicalReferenceId(160),
+  requestId: canonicalReferenceId(160),
+  tokenId: TokenIdSchema,
+  actualCostMicrousd: MicrousdSchema,
+  releasedMicrousd: MicrousdSchema,
+  remainingBalanceMicrousd: MicrousdSchema,
+  remainingBudgetMicrousd: MicrousdSchema,
+  funding: FundedAiFundingSummarySchema,
+  settledAt: IsoTimestampSchema,
+  status: z.literal("settled"),
+}).strict();
+
+export const FundedAiReleaseRequestSchema = z.object({
+  reservationId: canonicalReferenceId(160),
+  tokenId: TokenIdSchema,
+  reason: z.literal("pre_upstream_failure"),
+}).strict();
+
+export const FundedAiReleaseResponseSchema = z.object({
+  contractVersion: z.literal(1),
+  reservationId: canonicalReferenceId(160),
+  requestId: canonicalReferenceId(160),
+  tokenId: TokenIdSchema,
+  releasedMicrousd: MicrousdSchema.min(1),
+  releasedAt: IsoTimestampSchema,
+  reason: z.literal("pre_upstream_failure"),
+  status: z.literal("released"),
+  funding: FundedAiFundingSummarySchema,
 }).strict();
 
 const SafeErrorSchema = z.discriminatedUnion("code", [
@@ -96,6 +192,12 @@ const SafeErrorSchema = z.discriminatedUnion("code", [
   z.object({ code: z.literal("model_not_allowed"), message: z.literal("This model is not available") }).strict(),
   z.object({ code: z.literal("rate_limited"), message: z.literal("Try again later") }).strict(),
   z.object({ code: z.literal("revision_conflict"), message: z.literal("Policy changed; refresh and try again") }).strict(),
+  z.object({ code: z.literal("insufficient_credit"), message: z.literal("Not enough Matrix AI credit") }).strict(),
+  z.object({ code: z.literal("budget_exceeded"), message: z.literal("Monthly AI budget reached") }).strict(),
+  z.object({ code: z.literal("idempotency_conflict"), message: z.literal("Request already used") }).strict(),
+  z.object({ code: z.literal("reservation_expired"), message: z.literal("AI usage reservation expired") }).strict(),
+  z.object({ code: z.literal("over_settlement"), message: z.literal("AI usage exceeds its reservation") }).strict(),
+  z.object({ code: z.literal("reservation_closed"), message: z.literal("AI usage reservation is already closed") }).strict(),
   z.object({ code: z.literal("invalid_request"), message: z.literal("Invalid request") }).strict(),
   z.object({ code: z.literal("not_found"), message: z.literal("Runtime not found") }).strict(),
   z.object({ code: z.literal("unavailable"), message: z.literal("Service unavailable") }).strict(),
@@ -109,4 +211,11 @@ export type FundedAiEffectivePolicy = z.infer<typeof FundedAiEffectivePolicySche
 export type FundedAiRuntimeCredentialIssueResponse = z.infer<typeof FundedAiRuntimeCredentialIssueResponseSchema>;
 export type FundedAiAuthorizationRequest = z.infer<typeof FundedAiAuthorizationRequestSchema>;
 export type FundedAiAuthorizationResponse = z.infer<typeof FundedAiAuthorizationResponseSchema>;
+export type FundedAiSettlementRequest = z.infer<typeof FundedAiSettlementRequestSchema>;
+export type FundedAiSettlementResponse = z.infer<typeof FundedAiSettlementResponseSchema>;
+export type FundedAiStartRequest = z.infer<typeof FundedAiStartRequestSchema>;
+export type FundedAiStartResponse = z.infer<typeof FundedAiStartResponseSchema>;
+export type FundedAiReleaseRequest = z.infer<typeof FundedAiReleaseRequestSchema>;
+export type FundedAiReleaseResponse = z.infer<typeof FundedAiReleaseResponseSchema>;
+export type FundedAiFundingSummary = z.infer<typeof FundedAiFundingSummarySchema>;
 export type FundedAiSafeError = z.infer<typeof FundedAiSafeErrorSchema>;

--- a/packages/platform/src/ai-funded-metering-repository.ts
+++ b/packages/platform/src/ai-funded-metering-repository.ts
@@ -1,0 +1,721 @@
+import { createHash, createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+import {
+  FUNDED_AI_AUDIENCE,
+  FUNDED_AI_SCOPE,
+  FundedAiAuthorizationRequestSchema,
+  FundedAiAuthorizationResponseSchema,
+  FundedAiFundingSummarySchema,
+  FundedAiReleaseRequestSchema,
+  FundedAiReleaseResponseSchema,
+  FundedAiSettlementRequestSchema,
+  FundedAiSettlementResponseSchema,
+  FundedAiStartRequestSchema,
+  FundedAiStartResponseSchema,
+  type FundedAiAuthorizationResponse,
+  type FundedAiFundingSummary,
+  type FundedAiReleaseResponse,
+  type FundedAiSettlementResponse,
+  type FundedAiStartResponse,
+} from "@matrix-os/contracts";
+import { sql } from "kysely";
+import { z } from "zod/v4";
+import type { PlatformDB } from "./db.js";
+import { AiFundedPolicyError } from "./ai-funded-policy-errors.js";
+
+const TOKEN_PATTERN = /^sk-matrix-funded-([A-Za-z0-9][A-Za-z0-9_.:-]{0,79})\.([A-Za-z0-9_-]{43})$/;
+const ReferenceSchema = z.string().min(1).max(160).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/);
+const IdentitySchema = z.object({
+  ownerId: ReferenceSchema,
+  machineId: ReferenceSchema,
+  runtimeSlot: z.string().min(1).max(80).regex(/^[a-z0-9][a-z0-9_-]*$/),
+}).strict();
+const MoneySchema = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
+const GrantSchema = z.object({
+  entryId: ReferenceSchema,
+  identity: IdentitySchema,
+  kind: z.enum(["promotional_grant", "addon_grant"]),
+  amountMicrousd: MoneySchema.min(1),
+  sourceReference: ReferenceSchema,
+}).strict();
+const CleanupSchema = z.object({ limit: z.number().int().min(1).max(1_000) }).strict();
+const ModelIdsSchema = z.array(z.string().min(3).max(200)).max(64);
+
+export interface AiFundedMeteringRepositoryOptions {
+  db: PlatformDB;
+  credentialHashSecret: string;
+  now: () => Date;
+  policyFreshnessMs: number;
+  reservationTtlMs: number;
+  inFlightTtlMs: number;
+  reservationIdFactory?: () => string;
+}
+
+type BalanceSnapshot = {
+  credit_balance_microusd: unknown;
+  promotional_balance_microusd: unknown;
+  addon_balance_microusd: unknown;
+  reserved_microusd: unknown;
+  month_period_start: string;
+  month_spent_microusd: unknown;
+  month_reserved_microusd: unknown;
+};
+
+function exactInteger(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) throw new Error("Funded AI monetary total exceeds safe integer range");
+  return parsed;
+}
+
+function hashesEqual(left: string, right: string): boolean {
+  const a = Buffer.from(left, "hex");
+  const b = Buffer.from(right, "hex");
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+function parseModels(value: string): string[] {
+  try {
+    return ModelIdsSchema.parse(JSON.parse(value));
+  } catch (error) {
+    throw new Error("Invalid funded AI policy model configuration", { cause: error });
+  }
+}
+
+function intersectModels(globalModels: string[], runtimeModels: string[]): string[] {
+  const runtimeSet = new Set(runtimeModels);
+  return globalModels.filter((model) => runtimeSet.has(model));
+}
+
+function utcMonthStart(at: Date): string {
+  return new Date(Date.UTC(at.getUTCFullYear(), at.getUTCMonth(), 1)).toISOString();
+}
+
+function fundingSummary(
+  balance: BalanceSnapshot,
+  monthlyBudgetMicrousd: number,
+  asOf: string,
+): FundedAiFundingSummary {
+  const creditBalanceMicrousd = exactInteger(balance.credit_balance_microusd);
+  const reservedMicrousd = exactInteger(balance.reserved_microusd);
+  const settledThisMonthMicrousd = exactInteger(balance.month_spent_microusd);
+  const reservedThisMonthMicrousd = exactInteger(balance.month_reserved_microusd);
+  return FundedAiFundingSummarySchema.parse({
+    asOf,
+    periodStart: balance.month_period_start,
+    monthlyBudgetMicrousd,
+    settledThisMonthMicrousd,
+    reservedMicrousd,
+    reservedThisMonthMicrousd,
+    promotionalBalanceMicrousd: exactInteger(balance.promotional_balance_microusd),
+    addonBalanceMicrousd: exactInteger(balance.addon_balance_microusd),
+    creditBalanceMicrousd,
+    remainingBalanceMicrousd: Math.max(0, creditBalanceMicrousd - reservedMicrousd),
+    remainingBudgetMicrousd: Math.max(
+      0,
+      monthlyBudgetMicrousd - settledThisMonthMicrousd - reservedThisMonthMicrousd,
+    ),
+  });
+}
+
+export function createAiFundedMeteringRepository(options: AiFundedMeteringRepositoryOptions) {
+  if (!options.db || options.credentialHashSecret.length < 32) {
+    throw new Error("Funded AI metering dependencies are misconfigured");
+  }
+  if (options.policyFreshnessMs < 1_000 || options.policyFreshnessMs > 5 * 60_000
+    || options.reservationTtlMs < 30_000 || options.reservationTtlMs > 15 * 60_000
+    || options.inFlightTtlMs < 60_000 || options.inFlightTtlMs > 60 * 60_000) {
+    throw new Error("Funded AI metering time limits are misconfigured");
+  }
+  const reservationIdFactory = options.reservationIdFactory ?? randomUUID;
+  const hashCredential = (credential: string) => createHmac("sha256", options.credentialHashSecret)
+    .update(credential).digest("hex");
+
+  async function grantCredit(input: z.input<typeof GrantSchema>) {
+    const grant = GrantSchema.parse(input);
+    const at = options.now().toISOString();
+    await options.db.ready;
+    return options.db.transaction(async (trx) => {
+      const machine = await trx.executor.selectFrom("user_machines").select([
+        "machine_id", "clerk_user_id", "runtime_slot", "deleted_at",
+      ]).where("machine_id", "=", grant.identity.machineId).forUpdate().executeTakeFirst();
+      if (!machine || machine.clerk_user_id !== grant.identity.ownerId
+        || machine.runtime_slot !== grant.identity.runtimeSlot || machine.deleted_at !== null) {
+        throw new AiFundedPolicyError("identity_mismatch");
+      }
+      const inserted = await trx.executor.insertInto("ai_funded_credit_ledger").values({
+        entry_id: grant.entryId,
+        owner_id: grant.identity.ownerId,
+        machine_id: grant.identity.machineId,
+        runtime_slot: grant.identity.runtimeSlot,
+        kind: grant.kind,
+        amount_microusd: grant.amountMicrousd,
+        source_reference: grant.sourceReference,
+        reservation_id: null,
+        period_start: null,
+        created_at: at,
+      }).onConflict((conflict) => conflict.column("entry_id").doNothing())
+        .returning("entry_id").executeTakeFirst();
+      const stored = await trx.executor.selectFrom("ai_funded_credit_ledger")
+        .selectAll().where("entry_id", "=", grant.entryId).executeTakeFirstOrThrow();
+      if (stored.owner_id !== grant.identity.ownerId || stored.machine_id !== grant.identity.machineId
+        || stored.runtime_slot !== grant.identity.runtimeSlot || stored.kind !== grant.kind
+        || exactInteger(stored.amount_microusd) !== grant.amountMicrousd
+        || stored.source_reference !== grant.sourceReference || stored.reservation_id !== null) {
+        throw new AiFundedPolicyError("idempotency_conflict");
+      }
+      if (inserted) {
+        const bucketUpdate = grant.kind === "promotional_grant"
+          ? { promotional_balance_microusd: sql<number>`promotional_balance_microusd + ${grant.amountMicrousd}` }
+          : { addon_balance_microusd: sql<number>`addon_balance_microusd + ${grant.amountMicrousd}` };
+        const balance = await trx.executor.updateTable("ai_funded_runtime_balances").set({
+          credit_balance_microusd: sql<number>`credit_balance_microusd + ${grant.amountMicrousd}`,
+          ...bucketUpdate,
+          updated_at: at,
+        }).where("machine_id", "=", grant.identity.machineId)
+          .where("owner_id", "=", grant.identity.ownerId)
+          .where("runtime_slot", "=", grant.identity.runtimeSlot)
+          .where(sql<boolean>`credit_balance_microusd <= ${Number.MAX_SAFE_INTEGER - grant.amountMicrousd}`)
+          .returning("machine_id").executeTakeFirst();
+        if (!balance) throw new Error("Funded AI credit balance exceeds supported bounds");
+      }
+      return { ...grant, createdAt: stored.created_at };
+    });
+  }
+
+  async function authorize(input: z.input<typeof FundedAiAuthorizationRequestSchema>): Promise<FundedAiAuthorizationResponse> {
+    const request = FundedAiAuthorizationRequestSchema.parse(input);
+    const tokenMatch = TOKEN_PATTERN.exec(request.credential);
+    if (!tokenMatch) throw new AiFundedPolicyError("unauthorized");
+    const checked = options.now();
+    const checkedAt = checked.toISOString();
+    const periodStart = utcMonthStart(checked);
+    const payloadHash = createHash("sha256").update(JSON.stringify({
+      tokenId: tokenMatch[1], requestId: request.requestId,
+      modelId: request.modelId, maxCostMicrousd: request.maxCostMicrousd,
+    })).digest("hex");
+    await options.db.ready;
+    return options.db.transaction(async (trx) => {
+      const credential = await trx.executor.selectFrom("ai_runtime_credentials")
+        .selectAll().where("token_id", "=", tokenMatch[1]).executeTakeFirst();
+      if (!credential || !hashesEqual(credential.token_hash, hashCredential(request.credential))
+        || credential.revoked_at !== null || Date.parse(credential.expires_at) <= checked.getTime()
+        || credential.audience !== FUNDED_AI_AUDIENCE || credential.scope !== FUNDED_AI_SCOPE) {
+        throw new AiFundedPolicyError("unauthorized");
+      }
+      const runtime = await trx.executor.selectFrom("ai_funded_runtime_policies")
+        .selectAll().where("machine_id", "=", credential.machine_id).forUpdate().executeTakeFirst();
+      const machine = await trx.executor.selectFrom("user_machines").select([
+        "clerk_user_id", "runtime_slot", "status", "activation_state", "deleted_at",
+      ]).where("machine_id", "=", credential.machine_id).executeTakeFirst();
+      const global = await trx.executor.selectFrom("ai_funded_global_policy")
+        .selectAll().where("policy_id", "=", "default").executeTakeFirstOrThrow();
+      if (!runtime || !machine || machine.clerk_user_id !== credential.owner_id
+        || machine.runtime_slot !== credential.runtime_slot || machine.status !== "running"
+        || machine.activation_state !== "authorized" || machine.deleted_at !== null
+        || runtime.owner_id !== credential.owner_id || runtime.runtime_slot !== credential.runtime_slot) {
+        throw new AiFundedPolicyError("unauthorized");
+      }
+      if (!global.enabled || !runtime.enabled
+        || (runtime.expires_at !== null && Date.parse(runtime.expires_at) <= checked.getTime())) {
+        throw new AiFundedPolicyError("access_disabled");
+      }
+      const allowedModelIds = intersectModels(parseModels(global.allowed_model_ids), parseModels(runtime.allowed_model_ids));
+      if (!allowedModelIds.includes(request.modelId)) throw new AiFundedPolicyError("model_not_allowed");
+
+      const identity = {
+        ownerId: credential.owner_id,
+        machineId: credential.machine_id,
+        runtimeSlot: credential.runtime_slot,
+      };
+      const reset = await trx.executor.updateTable("ai_funded_runtime_balances").set({
+        month_period_start: periodStart,
+        month_spent_microusd: sql<number>`CASE WHEN month_period_start = ${periodStart} THEN month_spent_microusd ELSE 0 END`,
+        month_reserved_microusd: sql<number>`CASE WHEN month_period_start = ${periodStart} THEN month_reserved_microusd ELSE 0 END`,
+        updated_at: checkedAt,
+      }).where("machine_id", "=", identity.machineId).where("owner_id", "=", identity.ownerId)
+        .where("runtime_slot", "=", identity.runtimeSlot).returning("machine_id").executeTakeFirst();
+      if (!reset) throw new AiFundedPolicyError("access_disabled");
+
+      const existing = await trx.executor.selectFrom("ai_funded_usage_reservations")
+        .select(["payload_hash", "authorization_response"])
+        .where("token_id", "=", credential.token_id).where("request_id", "=", request.requestId)
+        .executeTakeFirst();
+      if (existing) {
+        if (existing.payload_hash !== payloadHash) throw new AiFundedPolicyError("idempotency_conflict");
+        return FundedAiAuthorizationResponseSchema.parse(JSON.parse(existing.authorization_response));
+      }
+
+      const monthlyBudget = exactInteger(runtime.monthly_budget_microusd);
+      const reserved = await trx.executor.updateTable("ai_funded_runtime_balances").set({
+        reserved_microusd: sql<number>`reserved_microusd + ${request.maxCostMicrousd}`,
+        month_reserved_microusd: sql<number>`month_reserved_microusd + ${request.maxCostMicrousd}`,
+        updated_at: checkedAt,
+      }).where("machine_id", "=", identity.machineId)
+        .where(sql<boolean>`reserved_microusd <= ${Number.MAX_SAFE_INTEGER - request.maxCostMicrousd}`)
+        .where(sql<boolean>`credit_balance_microusd - reserved_microusd >= ${request.maxCostMicrousd}`)
+        .where(sql<boolean>`${monthlyBudget} - month_spent_microusd - month_reserved_microusd >= ${request.maxCostMicrousd}`)
+        .returning([
+          "credit_balance_microusd", "promotional_balance_microusd", "addon_balance_microusd",
+          "reserved_microusd", "month_period_start", "month_spent_microusd", "month_reserved_microusd",
+        ])
+        .executeTakeFirst();
+      if (!reserved) {
+        const balance = await trx.executor.selectFrom("ai_funded_runtime_balances")
+          .selectAll().where("machine_id", "=", identity.machineId).executeTakeFirstOrThrow();
+        const availableBudget = monthlyBudget - exactInteger(balance.month_spent_microusd)
+          - exactInteger(balance.month_reserved_microusd);
+        if (request.maxCostMicrousd > availableBudget) throw new AiFundedPolicyError("budget_exceeded");
+        throw new AiFundedPolicyError("insufficient_credit");
+      }
+      const remainingBalance = exactInteger(reserved.credit_balance_microusd) - exactInteger(reserved.reserved_microusd);
+      const remainingBudget = monthlyBudget - exactInteger(reserved.month_spent_microusd)
+        - exactInteger(reserved.month_reserved_microusd);
+
+      const reservationId = ReferenceSchema.parse(reservationIdFactory());
+      const expiresAt = new Date(checked.getTime() + options.reservationTtlMs).toISOString();
+      const response = FundedAiAuthorizationResponseSchema.parse({
+        contractVersion: 1,
+        authorized: true,
+        identity: {
+          tokenId: credential.token_id,
+          ...identity,
+          audience: FUNDED_AI_AUDIENCE,
+          scope: FUNDED_AI_SCOPE,
+          expiresAt: credential.expires_at,
+        },
+        policy: {
+          enabled: true,
+          globalRevision: global.revision,
+          runtimeRevision: runtime.revision,
+          allowedModelIds,
+          monthlyBudgetMicrousd: monthlyBudget,
+          checkedAt,
+          staleAfter: new Date(checked.getTime() + options.policyFreshnessMs).toISOString(),
+        },
+        funding: fundingSummary(reserved, monthlyBudget, checkedAt),
+        reservation: {
+          reservationId,
+          requestId: request.requestId,
+          modelId: request.modelId,
+          reservedMicrousd: request.maxCostMicrousd,
+          remainingBalanceMicrousd: remainingBalance,
+          remainingBudgetMicrousd: remainingBudget,
+          periodStart,
+          expiresAt,
+          status: "reserved",
+        },
+      });
+      await trx.executor.insertInto("ai_funded_usage_reservations").values({
+        reservation_id: reservationId,
+        request_id: request.requestId,
+        payload_hash: payloadHash,
+        authorization_response: JSON.stringify(response),
+        settlement_response: null,
+        start_response: null,
+        release_response: null,
+        release_reason: null,
+        token_id: credential.token_id,
+        ...{
+          owner_id: identity.ownerId,
+          machine_id: identity.machineId,
+          runtime_slot: identity.runtimeSlot,
+        },
+        model_id: request.modelId,
+        reserved_microusd: request.maxCostMicrousd,
+        actual_microusd: null,
+        period_start: periodStart,
+        status: "reserved",
+        created_at: checkedAt,
+        started_at: null,
+        expires_at: expiresAt,
+        settled_at: null,
+        released_at: null,
+      }).execute();
+      return response;
+    });
+  }
+
+  async function startReservation(
+    input: z.input<typeof FundedAiStartRequestSchema>,
+  ): Promise<FundedAiStartResponse> {
+    const request = FundedAiStartRequestSchema.parse(input);
+    const checked = options.now();
+    const checkedAt = checked.toISOString();
+    await options.db.ready;
+    return options.db.transaction(async (trx) => {
+      const reservation = await trx.executor.selectFrom("ai_funded_usage_reservations")
+        .selectAll().where("reservation_id", "=", request.reservationId)
+        .where("token_id", "=", request.tokenId).forUpdate().executeTakeFirst();
+      if (!reservation) throw new AiFundedPolicyError("unauthorized");
+      if (reservation.status === "in_flight") {
+        if (reservation.start_response === null) throw new Error("In-flight reservation is missing its response");
+        return FundedAiStartResponseSchema.parse(JSON.parse(reservation.start_response));
+      }
+      if (reservation.status !== "reserved") throw new AiFundedPolicyError("reservation_closed");
+      if (Date.parse(reservation.expires_at) <= checked.getTime()) {
+        throw new AiFundedPolicyError("reservation_expired");
+      }
+      const claimed = await trx.executor.updateTable("ai_funded_usage_reservations")
+        .set({ status: "starting" }).where("reservation_id", "=", reservation.reservation_id)
+        .where("status", "=", "reserved").returning("reservation_id").executeTakeFirst();
+      if (!claimed) {
+        const latest = await trx.executor.selectFrom("ai_funded_usage_reservations")
+          .select(["status", "start_response"])
+          .where("reservation_id", "=", reservation.reservation_id).executeTakeFirstOrThrow();
+        if (latest.status === "in_flight" && latest.start_response !== null) {
+          return FundedAiStartResponseSchema.parse(JSON.parse(latest.start_response));
+        }
+        if (latest.status === "starting") throw new AiFundedPolicyError("rate_limited");
+        throw new AiFundedPolicyError("reservation_closed");
+      }
+      const expiresAt = new Date(checked.getTime() + options.inFlightTtlMs).toISOString();
+      const response = FundedAiStartResponseSchema.parse({
+        contractVersion: 1,
+        reservationId: reservation.reservation_id,
+        requestId: reservation.request_id,
+        tokenId: reservation.token_id,
+        startedAt: checkedAt,
+        expiresAt,
+        status: "in_flight",
+      });
+      const updated = await trx.executor.updateTable("ai_funded_usage_reservations").set({
+        status: "in_flight",
+        started_at: checkedAt,
+        expires_at: expiresAt,
+        start_response: JSON.stringify(response),
+      }).where("reservation_id", "=", reservation.reservation_id).where("status", "=", "starting")
+        .returning("reservation_id").executeTakeFirst();
+      if (!updated) {
+        const latest = await trx.executor.selectFrom("ai_funded_usage_reservations")
+          .select(["status", "start_response"]).where("reservation_id", "=", reservation.reservation_id)
+          .executeTakeFirstOrThrow();
+        if (latest.status === "in_flight" && latest.start_response !== null) {
+          return FundedAiStartResponseSchema.parse(JSON.parse(latest.start_response));
+        }
+        throw new AiFundedPolicyError("reservation_closed");
+      }
+      return response;
+    });
+  }
+
+  async function settleReservation(
+    input: z.input<typeof FundedAiSettlementRequestSchema>,
+  ): Promise<FundedAiSettlementResponse> {
+    const request = FundedAiSettlementRequestSchema.parse(input);
+    const checked = options.now();
+    const checkedAt = checked.toISOString();
+    await options.db.ready;
+    return options.db.transaction(async (trx) => {
+      const locator = await trx.executor.selectFrom("ai_funded_usage_reservations")
+        .select(["machine_id"]).where("reservation_id", "=", request.reservationId)
+        .where("token_id", "=", request.tokenId).executeTakeFirst();
+      if (!locator) throw new AiFundedPolicyError("unauthorized");
+      const runtime = await trx.executor.selectFrom("ai_funded_runtime_policies")
+        .select(["monthly_budget_microusd"]).where("machine_id", "=", locator.machine_id)
+        .executeTakeFirstOrThrow();
+      const reservation = await trx.executor.selectFrom("ai_funded_usage_reservations")
+        .selectAll().where("reservation_id", "=", request.reservationId)
+        .where("token_id", "=", request.tokenId).forUpdate().executeTakeFirstOrThrow();
+      if (reservation.status === "settled") {
+        if (exactInteger(reservation.actual_microusd) !== request.actualCostMicrousd) {
+          throw new AiFundedPolicyError("idempotency_conflict");
+        }
+        if (reservation.settlement_response === null) throw new Error("Settled reservation is missing its response");
+        return FundedAiSettlementResponseSchema.parse(JSON.parse(reservation.settlement_response));
+      }
+      if (reservation.status !== "in_flight" && reservation.status !== "expired") {
+        throw new AiFundedPolicyError("reservation_closed");
+      }
+      if (reservation.status === "expired" || Date.parse(reservation.expires_at) <= checked.getTime()) {
+        throw new AiFundedPolicyError("reservation_expired");
+      }
+      const reserved = exactInteger(reservation.reserved_microusd);
+      if (request.actualCostMicrousd > reserved) throw new AiFundedPolicyError("over_settlement");
+      const claimed = await trx.executor.updateTable("ai_funded_usage_reservations")
+        .set({ status: "settling" }).where("reservation_id", "=", reservation.reservation_id)
+        .where("status", "=", "in_flight").returning("reservation_id").executeTakeFirst();
+      if (!claimed) {
+        const latest = await trx.executor.selectFrom("ai_funded_usage_reservations").selectAll()
+          .where("reservation_id", "=", reservation.reservation_id).executeTakeFirstOrThrow();
+        if (latest.status === "settled" && exactInteger(latest.actual_microusd) === request.actualCostMicrousd
+          && latest.settlement_response !== null) {
+          return FundedAiSettlementResponseSchema.parse(JSON.parse(latest.settlement_response));
+        }
+        if (latest.status === "settled") throw new AiFundedPolicyError("idempotency_conflict");
+        if (latest.status === "settling") throw new AiFundedPolicyError("rate_limited");
+        throw new AiFundedPolicyError("reservation_closed");
+      }
+      const currentPeriod = utcMonthStart(checked);
+      const currentBalance = await trx.executor.updateTable("ai_funded_runtime_balances").set({
+        month_period_start: currentPeriod,
+        month_spent_microusd: sql<number>`CASE WHEN month_period_start = ${currentPeriod} THEN month_spent_microusd ELSE 0 END`,
+        month_reserved_microusd: sql<number>`CASE WHEN month_period_start = ${currentPeriod} THEN month_reserved_microusd ELSE 0 END`,
+        updated_at: checkedAt,
+      }).where("machine_id", "=", locator.machine_id).returningAll().executeTakeFirstOrThrow();
+      const promotionalDebit = Math.min(
+        request.actualCostMicrousd,
+        exactInteger(currentBalance.promotional_balance_microusd),
+      );
+      const addonDebit = request.actualCostMicrousd - promotionalDebit;
+      if (promotionalDebit > 0) {
+        await trx.executor.insertInto("ai_funded_credit_ledger").values({
+          entry_id: `usage:${reservation.reservation_id}:promotional`,
+          owner_id: reservation.owner_id,
+          machine_id: reservation.machine_id,
+          runtime_slot: reservation.runtime_slot,
+          kind: "promotional_debit",
+          amount_microusd: -promotionalDebit,
+          source_reference: reservation.request_id,
+          reservation_id: reservation.reservation_id,
+          period_start: reservation.period_start,
+          created_at: checkedAt,
+        }).execute();
+      }
+      if (addonDebit > 0) {
+        await trx.executor.insertInto("ai_funded_credit_ledger").values({
+          entry_id: `usage:${reservation.reservation_id}:addon`,
+          owner_id: reservation.owner_id,
+          machine_id: reservation.machine_id,
+          runtime_slot: reservation.runtime_slot,
+          kind: "addon_debit",
+          amount_microusd: -addonDebit,
+          source_reference: reservation.request_id,
+          reservation_id: reservation.reservation_id,
+          period_start: reservation.period_start,
+          created_at: checkedAt,
+        }).execute();
+      }
+      const balance = await trx.executor.updateTable("ai_funded_runtime_balances").set({
+        credit_balance_microusd: sql<number>`credit_balance_microusd - ${request.actualCostMicrousd}`,
+        promotional_balance_microusd: sql<number>`promotional_balance_microusd - ${promotionalDebit}`,
+        addon_balance_microusd: sql<number>`addon_balance_microusd - ${addonDebit}`,
+        reserved_microusd: sql<number>`reserved_microusd - ${reserved}`,
+        month_spent_microusd: sql<number>`CASE WHEN month_period_start = ${reservation.period_start} THEN month_spent_microusd + ${request.actualCostMicrousd} ELSE month_spent_microusd END`,
+        month_reserved_microusd: sql<number>`CASE WHEN month_period_start = ${reservation.period_start} THEN month_reserved_microusd - ${reserved} ELSE month_reserved_microusd END`,
+        updated_at: checkedAt,
+      }).where("machine_id", "=", reservation.machine_id)
+        .where(sql<boolean>`reserved_microusd >= ${reserved}`)
+        .where(sql<boolean>`credit_balance_microusd >= ${request.actualCostMicrousd}`)
+        .returningAll().executeTakeFirst();
+      if (!balance) throw new Error("Funded AI balance invariant violated");
+      const updated = await trx.executor.updateTable("ai_funded_usage_reservations").set({
+        status: "settled",
+        actual_microusd: request.actualCostMicrousd,
+        settled_at: checkedAt,
+      }).where("reservation_id", "=", reservation.reservation_id).where("status", "=", "settling")
+        .returningAll().executeTakeFirstOrThrow();
+      const monthlyBudget = exactInteger(runtime.monthly_budget_microusd);
+      const funding = fundingSummary(balance, monthlyBudget, checkedAt);
+      const response = FundedAiSettlementResponseSchema.parse({
+        contractVersion: 1,
+        reservationId: updated.reservation_id,
+        requestId: updated.request_id,
+        tokenId: updated.token_id,
+        actualCostMicrousd: request.actualCostMicrousd,
+        releasedMicrousd: reserved - request.actualCostMicrousd,
+        remainingBalanceMicrousd: funding.remainingBalanceMicrousd,
+        remainingBudgetMicrousd: funding.remainingBudgetMicrousd,
+        funding,
+        settledAt: checkedAt,
+        status: "settled",
+      });
+      await trx.executor.updateTable("ai_funded_usage_reservations")
+        .set({ settlement_response: JSON.stringify(response) })
+        .where("reservation_id", "=", reservation.reservation_id).execute();
+      return response;
+    });
+  }
+
+  async function releaseReservation(
+    input: z.input<typeof FundedAiReleaseRequestSchema>,
+  ): Promise<FundedAiReleaseResponse> {
+    const request = FundedAiReleaseRequestSchema.parse(input);
+    const checked = options.now();
+    const checkedAt = checked.toISOString();
+    const currentPeriod = utcMonthStart(checked);
+    await options.db.ready;
+    return options.db.transaction(async (trx) => {
+      const locator = await trx.executor.selectFrom("ai_funded_usage_reservations")
+        .select("machine_id").where("reservation_id", "=", request.reservationId)
+        .where("token_id", "=", request.tokenId).executeTakeFirst();
+      if (!locator) throw new AiFundedPolicyError("unauthorized");
+      const runtime = await trx.executor.selectFrom("ai_funded_runtime_policies")
+        .select("monthly_budget_microusd").where("machine_id", "=", locator.machine_id)
+        .executeTakeFirstOrThrow();
+      const reservation = await trx.executor.selectFrom("ai_funded_usage_reservations")
+        .selectAll().where("reservation_id", "=", request.reservationId)
+        .where("token_id", "=", request.tokenId).forUpdate().executeTakeFirstOrThrow();
+      if (reservation.status === "released") {
+        if (reservation.release_reason !== request.reason || reservation.release_response === null) {
+          throw new AiFundedPolicyError("idempotency_conflict");
+        }
+        return FundedAiReleaseResponseSchema.parse(JSON.parse(reservation.release_response));
+      }
+      if (reservation.status !== "reserved") throw new AiFundedPolicyError("reservation_closed");
+      if (Date.parse(reservation.expires_at) <= checked.getTime()) {
+        throw new AiFundedPolicyError("reservation_expired");
+      }
+      const claimed = await trx.executor.updateTable("ai_funded_usage_reservations")
+        .set({ status: "releasing" }).where("reservation_id", "=", reservation.reservation_id)
+        .where("status", "=", "reserved").returning("reservation_id").executeTakeFirst();
+      if (!claimed) {
+        const latest = await trx.executor.selectFrom("ai_funded_usage_reservations")
+          .select(["status", "release_reason", "release_response"])
+          .where("reservation_id", "=", reservation.reservation_id).executeTakeFirstOrThrow();
+        if (latest.status === "released" && latest.release_reason === request.reason
+          && latest.release_response !== null) {
+          return FundedAiReleaseResponseSchema.parse(JSON.parse(latest.release_response));
+        }
+        if (latest.status === "releasing") throw new AiFundedPolicyError("rate_limited");
+        throw new AiFundedPolicyError("reservation_closed");
+      }
+      const reset = await trx.executor.updateTable("ai_funded_runtime_balances").set({
+        month_period_start: currentPeriod,
+        month_spent_microusd: sql<number>`CASE WHEN month_period_start = ${currentPeriod} THEN month_spent_microusd ELSE 0 END`,
+        month_reserved_microusd: sql<number>`CASE WHEN month_period_start = ${currentPeriod} THEN month_reserved_microusd ELSE 0 END`,
+        updated_at: checkedAt,
+      }).where("machine_id", "=", locator.machine_id).returning("machine_id").executeTakeFirst();
+      if (!reset) throw new AiFundedPolicyError("access_disabled");
+      const reserved = exactInteger(reservation.reserved_microusd);
+      const balance = await trx.executor.updateTable("ai_funded_runtime_balances").set({
+        reserved_microusd: sql<number>`reserved_microusd - ${reserved}`,
+        month_reserved_microusd: sql<number>`CASE WHEN month_period_start = ${reservation.period_start} THEN month_reserved_microusd - ${reserved} ELSE month_reserved_microusd END`,
+        updated_at: checkedAt,
+      }).where("machine_id", "=", reservation.machine_id)
+        .where(sql<boolean>`reserved_microusd >= ${reserved}`).returningAll().executeTakeFirst();
+      if (!balance) throw new Error("Funded AI balance invariant violated");
+      const funding = fundingSummary(balance, exactInteger(runtime.monthly_budget_microusd), checkedAt);
+      const response = FundedAiReleaseResponseSchema.parse({
+        contractVersion: 1,
+        reservationId: reservation.reservation_id,
+        requestId: reservation.request_id,
+        tokenId: reservation.token_id,
+        releasedMicrousd: reserved,
+        releasedAt: checkedAt,
+        reason: request.reason,
+        status: "released",
+        funding,
+      });
+      const updated = await trx.executor.updateTable("ai_funded_usage_reservations").set({
+        status: "released",
+        release_reason: request.reason,
+        released_at: checkedAt,
+        release_response: JSON.stringify(response),
+      }).where("reservation_id", "=", reservation.reservation_id).where("status", "=", "releasing")
+        .returning("reservation_id").executeTakeFirst();
+      if (!updated) throw new Error("Funded AI reservation invariant violated");
+      return response;
+    });
+  }
+
+  async function cleanupExpiredReservations(input: z.input<typeof CleanupSchema>): Promise<number> {
+    const { limit } = CleanupSchema.parse(input);
+    const checked = options.now();
+    const checkedAt = checked.toISOString();
+    const currentPeriod = utcMonthStart(checked);
+    await options.db.ready;
+    return options.db.transaction(async (trx) => {
+      const expired = await trx.executor.selectFrom("ai_funded_usage_reservations")
+        .select([
+          "reservation_id", "request_id", "token_id", "owner_id", "machine_id", "runtime_slot",
+          "period_start", "reserved_microusd", "status",
+        ])
+        .where("status", "in", ["reserved", "in_flight"]).where("expires_at", "<=", checkedAt)
+        .orderBy("expires_at").orderBy("reservation_id").limit(limit).forUpdate().skipLocked().execute();
+      let cleaned = 0;
+      for (const reservation of expired) {
+        const claimedStatus = reservation.status === "in_flight" ? "settling" : "expired";
+        const claimed = await trx.executor.updateTable("ai_funded_usage_reservations")
+          .set({ status: claimedStatus }).where("reservation_id", "=", reservation.reservation_id)
+          .where("status", "=", reservation.status).returning("reservation_id").executeTakeFirst();
+        if (!claimed) continue;
+        cleaned += 1;
+        const reserved = exactInteger(reservation.reserved_microusd);
+        const currentBalance = await trx.executor.updateTable("ai_funded_runtime_balances").set({
+          month_period_start: currentPeriod,
+          month_spent_microusd: sql<number>`CASE WHEN month_period_start = ${currentPeriod} THEN month_spent_microusd ELSE 0 END`,
+          month_reserved_microusd: sql<number>`CASE WHEN month_period_start = ${currentPeriod} THEN month_reserved_microusd ELSE 0 END`,
+          updated_at: checkedAt,
+        }).where("machine_id", "=", reservation.machine_id).returningAll().executeTakeFirstOrThrow();
+        if (reservation.status === "in_flight") {
+          const promotionalDebit = Math.min(reserved, exactInteger(currentBalance.promotional_balance_microusd));
+          const addonDebit = reserved - promotionalDebit;
+          const debitRows = [
+            promotionalDebit > 0 ? {
+              entry_id: `usage:${reservation.reservation_id}:promotional`,
+              owner_id: reservation.owner_id,
+              machine_id: reservation.machine_id,
+              runtime_slot: reservation.runtime_slot,
+              kind: "promotional_debit",
+              amount_microusd: -promotionalDebit,
+              source_reference: reservation.request_id,
+              reservation_id: reservation.reservation_id,
+              period_start: reservation.period_start,
+              created_at: checkedAt,
+            } : null,
+            addonDebit > 0 ? {
+              entry_id: `usage:${reservation.reservation_id}:addon`,
+              owner_id: reservation.owner_id,
+              machine_id: reservation.machine_id,
+              runtime_slot: reservation.runtime_slot,
+              kind: "addon_debit",
+              amount_microusd: -addonDebit,
+              source_reference: reservation.request_id,
+              reservation_id: reservation.reservation_id,
+              period_start: reservation.period_start,
+              created_at: checkedAt,
+            } : null,
+          ].filter((row): row is NonNullable<typeof row> => row !== null);
+          if (debitRows.length > 0) await trx.executor.insertInto("ai_funded_credit_ledger").values(debitRows).execute();
+          const balance = await trx.executor.updateTable("ai_funded_runtime_balances").set({
+            credit_balance_microusd: sql<number>`credit_balance_microusd - ${reserved}`,
+            promotional_balance_microusd: sql<number>`promotional_balance_microusd - ${promotionalDebit}`,
+            addon_balance_microusd: sql<number>`addon_balance_microusd - ${addonDebit}`,
+            reserved_microusd: sql<number>`reserved_microusd - ${reserved}`,
+            month_spent_microusd: sql<number>`CASE WHEN month_period_start = ${reservation.period_start} THEN month_spent_microusd + ${reserved} ELSE month_spent_microusd END`,
+            month_reserved_microusd: sql<number>`CASE WHEN month_period_start = ${reservation.period_start} THEN month_reserved_microusd - ${reserved} ELSE month_reserved_microusd END`,
+            updated_at: checkedAt,
+          }).where("machine_id", "=", reservation.machine_id)
+            .where(sql<boolean>`reserved_microusd >= ${reserved}`)
+            .where(sql<boolean>`credit_balance_microusd >= ${reserved}`)
+            .returningAll().executeTakeFirst();
+          if (!balance) throw new Error("Funded AI balance invariant violated");
+          const runtime = await trx.executor.selectFrom("ai_funded_runtime_policies")
+            .select("monthly_budget_microusd").where("machine_id", "=", reservation.machine_id)
+            .executeTakeFirstOrThrow();
+          const funding = fundingSummary(balance, exactInteger(runtime.monthly_budget_microusd), checkedAt);
+          const response = FundedAiSettlementResponseSchema.parse({
+            contractVersion: 1,
+            reservationId: reservation.reservation_id,
+            requestId: reservation.request_id,
+            tokenId: reservation.token_id,
+            actualCostMicrousd: reserved,
+            releasedMicrousd: 0,
+            remainingBalanceMicrousd: funding.remainingBalanceMicrousd,
+            remainingBudgetMicrousd: funding.remainingBudgetMicrousd,
+            funding,
+            settledAt: checkedAt,
+            status: "settled",
+          });
+          const settled = await trx.executor.updateTable("ai_funded_usage_reservations").set({
+            status: "settled", actual_microusd: reserved, settled_at: checkedAt,
+            settlement_response: JSON.stringify(response),
+          }).where("reservation_id", "=", reservation.reservation_id).where("status", "=", "settling")
+            .returning("reservation_id").executeTakeFirst();
+          if (!settled) throw new Error("Funded AI reservation invariant violated");
+          continue;
+        }
+        const balance = await trx.executor.updateTable("ai_funded_runtime_balances").set({
+          reserved_microusd: sql<number>`reserved_microusd - ${reserved}`,
+          month_reserved_microusd: sql<number>`CASE WHEN month_period_start = ${reservation.period_start} THEN month_reserved_microusd - ${reserved} ELSE month_reserved_microusd END`,
+          updated_at: checkedAt,
+        }).where("machine_id", "=", reservation.machine_id)
+          .where(sql<boolean>`reserved_microusd >= ${reserved}`)
+          .returning("machine_id").executeTakeFirst();
+        if (!balance) throw new Error("Funded AI balance invariant violated");
+      }
+      return cleaned;
+    });
+  }
+
+  return { authorize, startReservation, settleReservation, releaseReservation, cleanupExpiredReservations, grantCredit };
+}

--- a/packages/platform/src/ai-funded-policy-errors.ts
+++ b/packages/platform/src/ai-funded-policy-errors.ts
@@ -1,0 +1,20 @@
+export type AiFundedPolicyErrorCode =
+  | "access_disabled"
+  | "budget_exceeded"
+  | "identity_mismatch"
+  | "idempotency_conflict"
+  | "insufficient_credit"
+  | "model_not_allowed"
+  | "over_settlement"
+  | "rate_limited"
+  | "reservation_expired"
+  | "reservation_closed"
+  | "revision_conflict"
+  | "unauthorized";
+
+export class AiFundedPolicyError extends Error {
+  constructor(readonly code: AiFundedPolicyErrorCode) {
+    super(code);
+    this.name = "AiFundedPolicyError";
+  }
+}

--- a/packages/platform/src/ai-funded-policy-repository.ts
+++ b/packages/platform/src/ai-funded-policy-repository.ts
@@ -1,11 +1,9 @@
-import { createHmac, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import { createHmac, randomBytes, randomUUID } from "node:crypto";
 import {
   FUNDED_AI_AUDIENCE,
   FUNDED_AI_SCOPE,
-  FundedAiAuthorizationResponseSchema,
   FundedAiGlobalPolicySchema,
   FundedAiRuntimeCredentialIssueResponseSchema,
-  type FundedAiAuthorizationResponse,
   type FundedAiGlobalPolicy,
   type FundedAiIdentity,
   type FundedAiRuntimeCredentialIssueResponse,
@@ -13,6 +11,10 @@ import {
 import { z } from "zod/v4";
 import { sql } from "kysely";
 import type { PlatformDB } from "./db.js";
+import { AiFundedPolicyError } from "./ai-funded-policy-errors.js";
+import { createAiFundedMeteringRepository } from "./ai-funded-metering-repository.js";
+
+export { AiFundedPolicyError, type AiFundedPolicyErrorCode } from "./ai-funded-policy-errors.js";
 
 const ModelIdsSchema = z.array(z.string().min(3).max(200).regex(/^[A-Za-z0-9][A-Za-z0-9._:/-]*$/))
   .max(64).refine((values) => new Set(values).size === values.length);
@@ -31,24 +33,10 @@ const RuntimePolicyUpdateSchema = z.object({
   expectedRevision: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER - 1),
   enabled: z.boolean(),
   allowedModelIds: ModelIdsSchema,
+  monthlyBudgetMicrousd: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
   expiresAt: z.string().datetime({ offset: true }).nullable(),
 }).strict();
 const TOKEN_PATTERN = /^sk-matrix-funded-([A-Za-z0-9][A-Za-z0-9_.:-]{0,79})\.([A-Za-z0-9_-]{43})$/;
-
-export type AiFundedPolicyErrorCode =
-  | "access_disabled"
-  | "identity_mismatch"
-  | "model_not_allowed"
-  | "rate_limited"
-  | "revision_conflict"
-  | "unauthorized";
-
-export class AiFundedPolicyError extends Error {
-  constructor(readonly code: AiFundedPolicyErrorCode) {
-    super(code);
-    this.name = "AiFundedPolicyError";
-  }
-}
 
 export interface AiFundedPolicyRepositoryOptions {
   db: PlatformDB;
@@ -59,6 +47,9 @@ export interface AiFundedPolicyRepositoryOptions {
   credentialTtlMs?: number;
   issueCooldownMs?: number;
   policyFreshnessMs?: number;
+  reservationTtlMs?: number;
+  inFlightTtlMs?: number;
+  reservationIdFactory?: () => string;
 }
 
 export type SetRuntimePolicyInput = z.infer<typeof RuntimePolicyUpdateSchema>;
@@ -82,10 +73,8 @@ function intersectModels(globalModels: string[], runtimeModels: string[]): strin
   return globalModels.filter((model) => runtimeSet.has(model));
 }
 
-function hashesEqual(left: string, right: string): boolean {
-  const a = Buffer.from(left, "hex");
-  const b = Buffer.from(right, "hex");
-  return a.length === b.length && timingSafeEqual(a, b);
+function utcMonthStart(at: Date): string {
+  return new Date(Date.UTC(at.getUTCFullYear(), at.getUTCMonth(), 1)).toISOString();
 }
 
 export function createAiFundedPolicyRepository(options: AiFundedPolicyRepositoryOptions) {
@@ -98,9 +87,13 @@ export function createAiFundedPolicyRepository(options: AiFundedPolicyRepository
   const credentialTtlMs = options.credentialTtlMs ?? 15 * 60_000;
   const issueCooldownMs = options.issueCooldownMs ?? 30_000;
   const policyFreshnessMs = options.policyFreshnessMs ?? 60_000;
+  const reservationTtlMs = options.reservationTtlMs ?? 5 * 60_000;
+  const inFlightTtlMs = options.inFlightTtlMs ?? 30 * 60_000;
   if (credentialTtlMs < 60_000 || credentialTtlMs > 60 * 60_000) throw new Error("Invalid credential TTL");
   if (issueCooldownMs < 1_000 || issueCooldownMs > credentialTtlMs) throw new Error("Invalid issue cooldown");
   if (policyFreshnessMs < 1_000 || policyFreshnessMs > 5 * 60_000) throw new Error("Invalid policy freshness");
+  if (reservationTtlMs < 30_000 || reservationTtlMs > 15 * 60_000) throw new Error("Invalid reservation TTL");
+  if (inFlightTtlMs < 60_000 || inFlightTtlMs > 60 * 60_000) throw new Error("Invalid in-flight TTL");
 
   const hashCredential = (credential: string) => createHmac("sha256", options.credentialHashSecret)
     .update(credential).digest("hex");
@@ -146,7 +139,8 @@ export function createAiFundedPolicyRepository(options: AiFundedPolicyRepository
     const parsed = RuntimePolicyUpdateSchema.parse(input);
     const identity = parsed.identity;
     const allowedModelIds = parsed.allowedModelIds;
-    const at = now().toISOString();
+    const policyTime = now();
+    const at = policyTime.toISOString();
     return options.db.transaction(async (trx) => {
       const machine = await trx.executor.selectFrom("user_machines").select([
         "machine_id", "clerk_user_id", "runtime_slot", "status", "activation_state", "deleted_at",
@@ -161,15 +155,30 @@ export function createAiFundedPolicyRepository(options: AiFundedPolicyRepository
         runtime_slot: identity.runtimeSlot,
         enabled: false,
         allowed_model_ids: "[]",
+        monthly_budget_microusd: 0,
         expires_at: null,
         next_issue_at: "1970-01-01T00:00:00.000Z",
         revision: 0,
         created_at: at,
         updated_at: at,
       }).onConflict((conflict) => conflict.column("machine_id").doNothing()).execute();
+      await trx.executor.insertInto("ai_funded_runtime_balances").values({
+        machine_id: identity.machineId,
+        owner_id: identity.ownerId,
+        runtime_slot: identity.runtimeSlot,
+        credit_balance_microusd: 0,
+        promotional_balance_microusd: 0,
+        addon_balance_microusd: 0,
+        reserved_microusd: 0,
+        month_period_start: utcMonthStart(policyTime),
+        month_spent_microusd: 0,
+        month_reserved_microusd: 0,
+        updated_at: at,
+      }).onConflict((conflict) => conflict.column("machine_id").doNothing()).execute();
       const row = await trx.executor.updateTable("ai_funded_runtime_policies").set({
         enabled: parsed.enabled,
         allowed_model_ids: JSON.stringify(allowedModelIds),
+        monthly_budget_microusd: parsed.monthlyBudgetMicrousd,
         expires_at: parsed.expiresAt,
         revision: parsed.expectedRevision + 1,
         updated_at: at,
@@ -182,6 +191,7 @@ export function createAiFundedPolicyRepository(options: AiFundedPolicyRepository
         enabled: row.enabled,
         revision: row.revision,
         allowedModelIds,
+        monthlyBudgetMicrousd: Number(row.monthly_budget_microusd),
         expiresAt: row.expires_at,
         updatedAt: row.updated_at,
       };
@@ -204,6 +214,7 @@ export function createAiFundedPolicyRepository(options: AiFundedPolicyRepository
       runtime_revision: number;
       global_models: string;
       runtime_models: string;
+      monthly_budget_microusd: number;
       token_id: string;
     };
     const issued = await sql<IssuedRow>`
@@ -212,6 +223,7 @@ export function createAiFundedPolicyRepository(options: AiFundedPolicyRepository
           runtime.machine_id,
           runtime.revision AS runtime_revision,
           runtime.allowed_model_ids AS runtime_models,
+          runtime.monthly_budget_microusd,
           global_policy.revision AS global_revision,
           global_policy.allowed_model_ids AS global_models
         FROM ai_funded_runtime_policies runtime
@@ -241,7 +253,7 @@ export function createAiFundedPolicyRepository(options: AiFundedPolicyRepository
         WHERE runtime.machine_id = eligible.machine_id
           AND runtime.next_issue_at <= ${checkedAt}
         RETURNING eligible.global_revision, eligible.runtime_revision,
-          eligible.global_models, eligible.runtime_models
+          eligible.global_models, eligible.runtime_models, eligible.monthly_budget_microusd
       ), inserted AS (
         INSERT INTO ai_runtime_credentials (
           token_id, token_hash, owner_id, machine_id, runtime_slot,
@@ -278,58 +290,7 @@ export function createAiFundedPolicyRepository(options: AiFundedPolicyRepository
         globalRevision: row.global_revision,
         runtimeRevision: row.runtime_revision,
         allowedModelIds,
-        checkedAt,
-        staleAfter: new Date(checked.getTime() + policyFreshnessMs).toISOString(),
-      },
-    });
-  }
-
-  async function authorize(input: { credential: string; modelId: string }): Promise<FundedAiAuthorizationResponse> {
-    const match = TOKEN_PATTERN.exec(input.credential);
-    if (!match) throw new AiFundedPolicyError("unauthorized");
-    await options.db.ready;
-    const checked = now();
-    const row = await options.db.executor.selectFrom("ai_runtime_credentials as credential")
-      .innerJoin("ai_funded_runtime_policies as runtime", "runtime.machine_id", "credential.machine_id")
-      .innerJoin("user_machines as machine", "machine.machine_id", "credential.machine_id")
-      .innerJoin("ai_funded_global_policy as global", (join) => join.onRef("global.policy_id", "=", "global.policy_id"))
-      .select([
-        "credential.token_id", "credential.token_hash", "credential.owner_id", "credential.machine_id",
-        "credential.runtime_slot", "credential.audience", "credential.scope", "credential.expires_at",
-        "credential.revoked_at", "runtime.enabled as runtime_enabled", "runtime.allowed_model_ids as runtime_models",
-        "runtime.expires_at as runtime_expires_at", "runtime.revision as runtime_revision",
-        "global.enabled as global_enabled", "global.allowed_model_ids as global_models", "global.revision as global_revision",
-        "machine.clerk_user_id", "machine.runtime_slot as machine_runtime_slot", "machine.status",
-        "machine.activation_state", "machine.deleted_at",
-      ]).where("credential.token_id", "=", match[1]).where("global.policy_id", "=", "default").executeTakeFirst();
-    if (!row || !hashesEqual(row.token_hash, hashCredential(input.credential)) || row.revoked_at !== null
-      || Date.parse(row.expires_at) <= checked.getTime() || row.audience !== FUNDED_AI_AUDIENCE || row.scope !== FUNDED_AI_SCOPE
-      || row.clerk_user_id !== row.owner_id || row.machine_runtime_slot !== row.runtime_slot
-      || row.status !== "running" || row.activation_state !== "authorized" || row.deleted_at !== null) {
-      throw new AiFundedPolicyError("unauthorized");
-    }
-    const runtimeCurrent = row.runtime_expires_at === null || Date.parse(row.runtime_expires_at) > checked.getTime();
-    if (!row.global_enabled || !row.runtime_enabled || !runtimeCurrent) throw new AiFundedPolicyError("access_disabled");
-    const allowedModelIds = intersectModels(parseModels(row.global_models), parseModels(row.runtime_models));
-    if (!allowedModelIds.includes(input.modelId)) throw new AiFundedPolicyError("model_not_allowed");
-    const checkedAt = checked.toISOString();
-    return FundedAiAuthorizationResponseSchema.parse({
-      contractVersion: 1,
-      authorized: true,
-      identity: {
-        tokenId: row.token_id,
-        ownerId: row.owner_id,
-        machineId: row.machine_id,
-        runtimeSlot: row.runtime_slot,
-        audience: FUNDED_AI_AUDIENCE,
-        scope: FUNDED_AI_SCOPE,
-        expiresAt: row.expires_at,
-      },
-      policy: {
-        enabled: true,
-        globalRevision: row.global_revision,
-        runtimeRevision: row.runtime_revision,
-        allowedModelIds,
+        monthlyBudgetMicrousd: Number(row.monthly_budget_microusd),
         checkedAt,
         staleAfter: new Date(checked.getTime() + policyFreshnessMs).toISOString(),
       },
@@ -346,7 +307,16 @@ export function createAiFundedPolicyRepository(options: AiFundedPolicyRepository
     return Number(result.numUpdatedRows) === 1;
   }
 
-  return { getGlobalPolicy, updateGlobalPolicy, setRuntimePolicy, issueRuntimeCredential, authorize, revokeRuntimeCredential };
+  const metering = createAiFundedMeteringRepository({
+    db: options.db,
+    credentialHashSecret: options.credentialHashSecret,
+    now,
+    policyFreshnessMs,
+    reservationTtlMs,
+    inFlightTtlMs,
+    reservationIdFactory: options.reservationIdFactory,
+  });
+  return { getGlobalPolicy, updateGlobalPolicy, setRuntimePolicy, issueRuntimeCredential, revokeRuntimeCredential, ...metering };
 }
 
 export type AiFundedPolicyRepository = ReturnType<typeof createAiFundedPolicyRepository>;

--- a/packages/platform/src/ai-funded-policy-routes.ts
+++ b/packages/platform/src/ai-funded-policy-routes.ts
@@ -1,6 +1,9 @@
 import {
   FundedAiAuthorizationRequestSchema,
   FundedAiSafeErrorSchema,
+  FundedAiReleaseRequestSchema,
+  FundedAiSettlementRequestSchema,
+  FundedAiStartRequestSchema,
   type FundedAiSafeError,
 } from "@matrix-os/contracts";
 import { Hono, type Context } from "hono";
@@ -16,6 +19,7 @@ const RELAY_BODY_LIMIT = 4 * 1024;
 const HandleSchema = z.string().min(1).max(63).regex(/^[a-z0-9][a-z0-9-]*$/);
 const EmptyBodySchema = z.object({}).strict();
 const RuntimeQuerySchema = z.object({ runtimeSlot: RuntimeSlotSchema }).strict();
+const CleanupBodySchema = z.object({ limit: z.number().int().min(1).max(1_000) }).strict();
 
 export type AiFundedControlPlaneConfig = { enabled: false } | {
   enabled: true;
@@ -69,6 +73,12 @@ function safeError(code: FundedAiSafeError["error"]["code"]): FundedAiSafeError 
     model_not_allowed: "This model is not available",
     rate_limited: "Try again later",
     revision_conflict: "Policy changed; refresh and try again",
+    insufficient_credit: "Not enough Matrix AI credit",
+    budget_exceeded: "Monthly AI budget reached",
+    idempotency_conflict: "Request already used",
+    reservation_expired: "AI usage reservation expired",
+    over_settlement: "AI usage exceeds its reservation",
+    reservation_closed: "AI usage reservation is already closed",
     invalid_request: "Invalid request",
     not_found: "Runtime not found",
     unavailable: "Service unavailable",
@@ -82,6 +92,12 @@ function policyErrorResponse(c: Context, error: unknown) {
     if (error.code === "identity_mismatch") return c.json(safeError("not_found"), 404);
     if (error.code === "rate_limited") return c.json(safeError("rate_limited"), 429);
     if (error.code === "revision_conflict") return c.json(safeError("revision_conflict"), 409);
+    if (error.code === "idempotency_conflict") return c.json(safeError("idempotency_conflict"), 409);
+    if (error.code === "reservation_expired") return c.json(safeError("reservation_expired"), 409);
+    if (error.code === "over_settlement") return c.json(safeError("over_settlement"), 409);
+    if (error.code === "reservation_closed") return c.json(safeError("reservation_closed"), 409);
+    if (error.code === "insufficient_credit") return c.json(safeError("insufficient_credit"), 402);
+    if (error.code === "budget_exceeded") return c.json(safeError("budget_exceeded"), 403);
     if (error.code === "model_not_allowed") return c.json(safeError("model_not_allowed"), 403);
     return c.json(safeError("access_disabled"), 403);
   }
@@ -109,6 +125,7 @@ export function createAiFundedRuntimeRoutes(options: {
   platformSecret: string;
   repository: AiFundedPolicyRepository;
 }) {
+  if (!options.repository || !options.db) throw new Error("Funded AI runtime dependencies are missing");
   if (options.platformSecret.length < 32) throw new Error("Funded AI runtime authentication is misconfigured");
   const app = new Hono();
   app.use("*", async (c, next) => {
@@ -156,6 +173,7 @@ export function createAiFundedRelayRoutes(options: {
   relayControlToken: string;
   repository: AiFundedPolicyRepository;
 }) {
+  if (!options.repository) throw new Error("Funded AI relay dependencies are missing");
   if (options.relayControlToken.length < 32) throw new Error("Funded AI relay authentication is misconfigured");
   const app = new Hono();
   app.use("*", async (c, next) => {
@@ -171,10 +189,43 @@ export function createAiFundedRelayRoutes(options: {
     const request = FundedAiAuthorizationRequestSchema.safeParse(await readStrictJson(c));
     if (!request.success) return c.json(safeError("invalid_request"), 400);
     try {
-      return c.json(await options.repository.authorize({
-        credential: request.data.credential,
-        modelId: request.data.modelId,
-      }), 200);
+      return c.json(await options.repository.authorize(request.data), 200);
+    } catch (error) {
+      return policyErrorResponse(c, error);
+    }
+  });
+  app.post("/settle", bodyLimit({ maxSize: RELAY_BODY_LIMIT }), async (c) => {
+    const request = FundedAiSettlementRequestSchema.safeParse(await readStrictJson(c));
+    if (!request.success) return c.json(safeError("invalid_request"), 400);
+    try {
+      return c.json(await options.repository.settleReservation(request.data), 200);
+    } catch (error) {
+      return policyErrorResponse(c, error);
+    }
+  });
+  app.post("/start", bodyLimit({ maxSize: RELAY_BODY_LIMIT }), async (c) => {
+    const request = FundedAiStartRequestSchema.safeParse(await readStrictJson(c));
+    if (!request.success) return c.json(safeError("invalid_request"), 400);
+    try {
+      return c.json(await options.repository.startReservation(request.data), 200);
+    } catch (error) {
+      return policyErrorResponse(c, error);
+    }
+  });
+  app.post("/release", bodyLimit({ maxSize: RELAY_BODY_LIMIT }), async (c) => {
+    const request = FundedAiReleaseRequestSchema.safeParse(await readStrictJson(c));
+    if (!request.success) return c.json(safeError("invalid_request"), 400);
+    try {
+      return c.json(await options.repository.releaseReservation(request.data), 200);
+    } catch (error) {
+      return policyErrorResponse(c, error);
+    }
+  });
+  app.post("/reservations/cleanup", bodyLimit({ maxSize: RUNTIME_BODY_LIMIT }), async (c) => {
+    const request = CleanupBodySchema.safeParse(await readStrictJson(c));
+    if (!request.success) return c.json(safeError("invalid_request"), 400);
+    try {
+      return c.json({ processed: await options.repository.cleanupExpiredReservations(request.data) }, 200);
     } catch (error) {
       return policyErrorResponse(c, error);
     }

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -111,6 +111,7 @@ export interface AiFundedRuntimePoliciesTable {
   runtime_slot: string;
   enabled: boolean;
   allowed_model_ids: string;
+  monthly_budget_microusd: number;
   expires_at: string | null;
   next_issue_at: string;
   revision: number;
@@ -129,6 +130,58 @@ export interface AiRuntimeCredentialsTable {
   issued_at: string;
   expires_at: string;
   revoked_at: string | null;
+}
+
+export interface AiFundedUsageReservationsTable {
+  reservation_id: string;
+  request_id: string;
+  payload_hash: string;
+  authorization_response: string;
+  settlement_response: string | null;
+  start_response: string | null;
+  release_response: string | null;
+  release_reason: string | null;
+  token_id: string;
+  owner_id: string;
+  machine_id: string;
+  runtime_slot: string;
+  model_id: string;
+  reserved_microusd: number;
+  actual_microusd: number | null;
+  period_start: string;
+  status: string;
+  created_at: string;
+  started_at: string | null;
+  expires_at: string;
+  settled_at: string | null;
+  released_at: string | null;
+}
+
+export interface AiFundedRuntimeBalancesTable {
+  machine_id: string;
+  owner_id: string;
+  runtime_slot: string;
+  credit_balance_microusd: number;
+  promotional_balance_microusd: number;
+  addon_balance_microusd: number;
+  reserved_microusd: number;
+  month_period_start: string;
+  month_spent_microusd: number;
+  month_reserved_microusd: number;
+  updated_at: string;
+}
+
+export interface AiFundedCreditLedgerTable {
+  entry_id: string;
+  owner_id: string;
+  machine_id: string;
+  runtime_slot: string;
+  kind: string;
+  amount_microusd: number;
+  source_reference: string;
+  reservation_id: string | null;
+  period_start: string | null;
+  created_at: string;
 }
 
 export interface ProvisioningJobsTable {
@@ -613,6 +666,9 @@ export interface PlatformDatabase {
   ai_funded_global_policy: AiFundedGlobalPolicyTable;
   ai_funded_runtime_policies: AiFundedRuntimePoliciesTable;
   ai_runtime_credentials: AiRuntimeCredentialsTable;
+  ai_funded_usage_reservations: AiFundedUsageReservationsTable;
+  ai_funded_credit_ledger: AiFundedCreditLedgerTable;
+  ai_funded_runtime_balances: AiFundedRuntimeBalancesTable;
   provisioning_jobs: ProvisioningJobsTable;
   billing_checkout_attempts: BillingCheckoutAttemptsTable;
   prebilling_provisioning_intents: PrebillingProvisioningIntentsTable;
@@ -1223,6 +1279,7 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
       runtime_slot TEXT NOT NULL,
       enabled BOOLEAN NOT NULL DEFAULT FALSE,
       allowed_model_ids TEXT NOT NULL DEFAULT '[]',
+      monthly_budget_microusd BIGINT NOT NULL DEFAULT 0 CHECK (monthly_budget_microusd >= 0),
       expires_at TEXT,
       next_issue_at TEXT NOT NULL DEFAULT '1970-01-01T00:00:00.000Z',
       revision INTEGER NOT NULL DEFAULT 0 CHECK (revision >= 0),
@@ -1231,6 +1288,7 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
     )
   `.execute(db);
   await sql`ALTER TABLE ai_funded_runtime_policies ADD COLUMN IF NOT EXISTS next_issue_at TEXT NOT NULL DEFAULT '1970-01-01T00:00:00.000Z'`.execute(db);
+  await sql`ALTER TABLE ai_funded_runtime_policies ADD COLUMN IF NOT EXISTS monthly_budget_microusd BIGINT NOT NULL DEFAULT 0 CHECK (monthly_budget_microusd >= 0)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_ai_funded_runtime_owner ON ai_funded_runtime_policies(owner_id, runtime_slot)`.execute(db);
   await sql`
     CREATE TABLE IF NOT EXISTS ai_runtime_credentials (
@@ -1247,6 +1305,90 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
     )
   `.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_ai_runtime_credentials_machine_issued ON ai_runtime_credentials(machine_id, issued_at DESC)`.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS ai_funded_runtime_balances (
+      machine_id TEXT PRIMARY KEY REFERENCES user_machines(machine_id) ON UPDATE CASCADE ON DELETE CASCADE,
+      owner_id TEXT NOT NULL,
+      runtime_slot TEXT NOT NULL,
+      credit_balance_microusd BIGINT NOT NULL DEFAULT 0 CHECK (credit_balance_microusd >= 0),
+      promotional_balance_microusd BIGINT NOT NULL DEFAULT 0 CHECK (promotional_balance_microusd >= 0),
+      addon_balance_microusd BIGINT NOT NULL DEFAULT 0 CHECK (addon_balance_microusd >= 0),
+      reserved_microusd BIGINT NOT NULL DEFAULT 0 CHECK (reserved_microusd >= 0),
+      month_period_start TEXT NOT NULL,
+      month_spent_microusd BIGINT NOT NULL DEFAULT 0 CHECK (month_spent_microusd >= 0),
+      month_reserved_microusd BIGINT NOT NULL DEFAULT 0 CHECK (month_reserved_microusd >= 0),
+      updated_at TEXT NOT NULL
+    )
+  `.execute(db);
+  const fundedAiMigrationTime = new Date();
+  const fundedAiMigrationAt = fundedAiMigrationTime.toISOString();
+  const fundedAiMigrationPeriodStart = new Date(Date.UTC(
+    fundedAiMigrationTime.getUTCFullYear(), fundedAiMigrationTime.getUTCMonth(), 1,
+  )).toISOString();
+  await sql`
+    INSERT INTO ai_funded_runtime_balances (
+      machine_id, owner_id, runtime_slot, credit_balance_microusd,
+      promotional_balance_microusd, addon_balance_microusd, reserved_microusd,
+      month_period_start, month_spent_microusd, month_reserved_microusd, updated_at
+    )
+    SELECT
+      machine_id, owner_id, runtime_slot, 0,
+      0, 0, 0,
+      ${fundedAiMigrationPeriodStart}, 0, 0, ${fundedAiMigrationAt}
+    FROM ai_funded_runtime_policies
+    ON CONFLICT (machine_id) DO NOTHING
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS ai_funded_usage_reservations (
+      reservation_id TEXT PRIMARY KEY,
+      request_id TEXT NOT NULL,
+      payload_hash TEXT NOT NULL CHECK (length(payload_hash) = 64),
+      authorization_response TEXT NOT NULL,
+      settlement_response TEXT,
+      start_response TEXT,
+      release_response TEXT,
+      release_reason TEXT,
+      token_id TEXT NOT NULL REFERENCES ai_runtime_credentials(token_id) ON UPDATE CASCADE ON DELETE CASCADE,
+      owner_id TEXT NOT NULL,
+      machine_id TEXT NOT NULL REFERENCES user_machines(machine_id) ON UPDATE CASCADE ON DELETE CASCADE,
+      runtime_slot TEXT NOT NULL,
+      model_id TEXT NOT NULL,
+      reserved_microusd BIGINT NOT NULL CHECK (reserved_microusd > 0),
+      actual_microusd BIGINT CHECK (actual_microusd >= 0),
+      period_start TEXT NOT NULL,
+      status TEXT NOT NULL CHECK (status IN ('reserved', 'starting', 'in_flight', 'settling', 'releasing', 'settled', 'released', 'expired')),
+      created_at TEXT NOT NULL,
+      started_at TEXT,
+      expires_at TEXT NOT NULL,
+      settled_at TEXT,
+      released_at TEXT,
+      UNIQUE (token_id, request_id)
+    )
+  `.execute(db);
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_ai_funded_reservations_runtime_status
+    ON ai_funded_usage_reservations(machine_id, runtime_slot, status, expires_at)
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS ai_funded_credit_ledger (
+      entry_id TEXT PRIMARY KEY,
+      owner_id TEXT NOT NULL,
+      machine_id TEXT NOT NULL REFERENCES user_machines(machine_id) ON UPDATE CASCADE ON DELETE CASCADE,
+      runtime_slot TEXT NOT NULL,
+      kind TEXT NOT NULL CHECK (kind IN ('promotional_grant', 'addon_grant', 'promotional_debit', 'addon_debit')),
+      amount_microusd BIGINT NOT NULL,
+      source_reference TEXT NOT NULL,
+      reservation_id TEXT REFERENCES ai_funded_usage_reservations(reservation_id) ON UPDATE CASCADE ON DELETE CASCADE,
+      period_start TEXT,
+      created_at TEXT NOT NULL,
+      CHECK (
+        (kind IN ('promotional_grant', 'addon_grant') AND amount_microusd > 0 AND reservation_id IS NULL AND period_start IS NULL)
+        OR (kind IN ('promotional_debit', 'addon_debit') AND amount_microusd < 0 AND reservation_id IS NOT NULL AND period_start IS NOT NULL)
+      )
+    )
+  `.execute(db);
+  await sql`CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_funded_ledger_reservation_kind ON ai_funded_credit_ledger(reservation_id, kind) WHERE reservation_id IS NOT NULL`.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_ai_funded_ledger_runtime ON ai_funded_credit_ledger(machine_id, runtime_slot, created_at)`.execute(db);
 
   await sql`
     CREATE TABLE IF NOT EXISTS provisioning_jobs (

--- a/tests/contracts/funded-ai.test.ts
+++ b/tests/contracts/funded-ai.test.ts
@@ -18,8 +18,23 @@ const policy = {
   globalRevision: 4,
   runtimeRevision: 2,
   allowedModelIds: ["anthropic/claude-sonnet-5"],
+  monthlyBudgetMicrousd: 1_000_000,
   checkedAt: now,
   staleAfter,
+} as const;
+
+const funding = {
+  asOf: now,
+  periodStart: "2026-08-01T00:00:00.000Z",
+  monthlyBudgetMicrousd: 1_000_000,
+  settledThisMonthMicrousd: 100_000,
+  reservedMicrousd: 200_000,
+  reservedThisMonthMicrousd: 200_000,
+  promotionalBalanceMicrousd: 600_000,
+  addonBalanceMicrousd: 400_000,
+  creditBalanceMicrousd: 1_000_000,
+  remainingBalanceMicrousd: 800_000,
+  remainingBudgetMicrousd: 700_000,
 } as const;
 
 describe("funded AI control-plane contracts", () => {
@@ -76,6 +91,7 @@ describe("funded AI control-plane contracts", () => {
       credential,
       requestId: "request_123",
       modelId: "anthropic/claude-sonnet-5",
+      maxCostMicrousd: 200_000,
     } as const;
     expect(FundedAiAuthorizationRequestSchema.parse(request)).toEqual(request);
     expect(FundedAiAuthorizationRequestSchema.safeParse({
@@ -97,6 +113,18 @@ describe("funded AI control-plane contracts", () => {
         expiresAt,
       },
       policy,
+      funding,
+      reservation: {
+        reservationId: "reservation_123",
+        requestId: request.requestId,
+        modelId: request.modelId,
+        reservedMicrousd: request.maxCostMicrousd,
+        remainingBalanceMicrousd: funding.remainingBalanceMicrousd,
+        remainingBudgetMicrousd: funding.remainingBudgetMicrousd,
+        periodStart: funding.periodStart,
+        expiresAt,
+        status: "reserved",
+      },
     } as const;
     expect(FundedAiAuthorizationResponseSchema.parse(response)).toEqual(response);
     expect(FundedAiAuthorizationResponseSchema.safeParse({ ...response, token: credential }).success).toBe(false);

--- a/tests/platform/ai-funded-metering.test.ts
+++ b/tests/platform/ai-funded-metering.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  AiFundedPolicyError,
+  createAiFundedPolicyRepository,
+} from "../../packages/platform/src/ai-funded-policy-repository.js";
+import { insertUserMachine, type PlatformDB } from "../../packages/platform/src/db.js";
+import { createTestPlatformDb, destroyTestPlatformDb } from "./platform-db-test-helper.js";
+
+const modelId = "anthropic/claude-sonnet-5";
+const otherModelId = "anthropic/claude-opus-5";
+const identity = { ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary" } as const;
+
+describe("funded AI metering", () => {
+  let db: PlatformDB;
+  let clock: Date;
+  let repo: ReturnType<typeof createAiFundedPolicyRepository>;
+
+  beforeEach(async () => {
+    ({ db } = await createTestPlatformDb());
+    await insertUserMachine(db, {
+      machineId: identity.machineId,
+      clerkUserId: identity.ownerId,
+      handle: "alice",
+      runtimeSlot: identity.runtimeSlot,
+      status: "running",
+      imageVersion: "v1",
+      provisionedAt: "2026-08-30T19:00:00.000Z",
+      activationState: "authorized",
+    });
+    clock = new Date("2026-08-30T20:00:00.000Z");
+    let tokenCounter = 0;
+    repo = createAiFundedPolicyRepository({
+      db,
+      credentialHashSecret: "h".repeat(32),
+      now: () => new Date(clock),
+      tokenIdFactory: () => `credential_${++tokenCounter}`,
+      tokenSecretFactory: () => "s".repeat(43),
+      credentialTtlMs: 60 * 60_000,
+      issueCooldownMs: 1_000,
+      reservationTtlMs: 5 * 60_000,
+    });
+  });
+
+  afterEach(async () => {
+    await destroyTestPlatformDb(db);
+  });
+
+  async function enableAndFund(input: { budget?: number; credit?: number } = {}) {
+    await repo.updateGlobalPolicy({
+      expectedRevision: 0,
+      enabled: true,
+      allowedModelIds: [modelId, otherModelId],
+    });
+    await repo.setRuntimePolicy({
+      identity,
+      expectedRevision: 0,
+      enabled: true,
+      allowedModelIds: [modelId],
+      monthlyBudgetMicrousd: input.budget ?? 1_000,
+      expiresAt: null,
+    });
+    if ((input.credit ?? 1_000) > 0) {
+      await repo.grantCredit({
+        entryId: "grant_1",
+        identity,
+        kind: "promotional_grant",
+        amountMicrousd: input.credit ?? 1_000,
+        sourceReference: "launch-credit-2026",
+      });
+    }
+    const issued = await repo.issueRuntimeCredential(identity);
+    return issued.credential;
+  }
+
+  it("atomically reserves worst-case cost so concurrent requests cannot overspend", async () => {
+    const credential = await enableAndFund({ budget: 100, credit: 100 });
+    const results = await Promise.allSettled([
+      repo.authorize({ credential: credential.token, requestId: "request_a", modelId, maxCostMicrousd: 80 }),
+      repo.authorize({ credential: credential.token, requestId: "request_b", modelId, maxCostMicrousd: 80 }),
+    ]);
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const rejection = results.find((result) => result.status === "rejected") as PromiseRejectedResult;
+    expect(rejection.reason).toMatchObject({ code: expect.stringMatching(/insufficient_credit|budget_exceeded/) });
+    const reservations = await db.executor.selectFrom("ai_funded_usage_reservations").selectAll().execute();
+    expect(reservations).toHaveLength(1);
+    expect(Number(reservations[0].reserved_microusd)).toBe(80);
+  });
+
+  it("replays the same reservation and rejects reuse with a different payload", async () => {
+    const credential = await enableAndFund();
+    const request = { credential: credential.token, requestId: "request_replay", modelId, maxCostMicrousd: 70 };
+    const first = await repo.authorize(request);
+    const replay = await repo.authorize(request);
+    expect(replay).toEqual(first);
+
+    await expect(repo.authorize({ ...request, maxCostMicrousd: 71 }))
+      .rejects.toMatchObject({ code: "idempotency_conflict" });
+    expect(await db.executor.selectFrom("ai_funded_usage_reservations").selectAll().execute()).toHaveLength(1);
+  });
+
+  it("settles actual usage exactly once, releases unused credit, and rejects over-settlement", async () => {
+    const credential = await enableAndFund({ budget: 200, credit: 200 });
+    const authorization = await repo.authorize({
+      credential: credential.token,
+      requestId: "request_settle",
+      modelId,
+      maxCostMicrousd: 100,
+    });
+    await expect(repo.settleReservation({
+      reservationId: authorization.reservation.reservationId,
+      tokenId: credential.tokenId,
+      actualCostMicrousd: 60,
+    })).rejects.toMatchObject({ code: "reservation_closed" });
+    const startRequest = { reservationId: authorization.reservation.reservationId, tokenId: credential.tokenId };
+    const started = await repo.startReservation(startRequest);
+    await expect(repo.startReservation(startRequest)).resolves.toEqual(started);
+    const settlementRequest = {
+      reservationId: authorization.reservation.reservationId,
+      tokenId: credential.tokenId,
+      actualCostMicrousd: 60,
+    };
+    const settlement = await repo.settleReservation(settlementRequest);
+    expect(settlement).toMatchObject({ actualCostMicrousd: 60, releasedMicrousd: 40, remainingBalanceMicrousd: 140 });
+    await expect(repo.settleReservation(settlementRequest)).resolves.toEqual(settlement);
+    await expect(repo.settleReservation({
+      reservationId: authorization.reservation.reservationId,
+      tokenId: credential.tokenId,
+      actualCostMicrousd: 61,
+    })).rejects.toMatchObject({ code: "idempotency_conflict" });
+
+    const ledger = await db.executor.selectFrom("ai_funded_credit_ledger")
+      .select(["kind", "amount_microusd"]).orderBy("created_at").execute();
+    expect(ledger.map((row) => [row.kind, Number(row.amount_microusd)])).toEqual([
+      ["promotional_grant", 200],
+      ["promotional_debit", -60],
+    ]);
+
+    const second = await repo.authorize({
+      credential: credential.token,
+      requestId: "request_over",
+      modelId,
+      maxCostMicrousd: 50,
+    });
+    await repo.startReservation({ reservationId: second.reservation.reservationId, tokenId: credential.tokenId });
+    await expect(repo.settleReservation({
+      reservationId: second.reservation.reservationId,
+      tokenId: credential.tokenId,
+      actualCostMicrousd: 51,
+    })).rejects.toMatchObject({ code: "over_settlement" });
+  });
+
+  it("enforces zero balance, model allowlist, monthly budget, and the global kill switch before reservation", async () => {
+    const credential = await enableAndFund({ budget: 50, credit: 0 });
+    await expect(repo.authorize({
+      credential: credential.token, requestId: "zero", modelId, maxCostMicrousd: 1,
+    })).rejects.toMatchObject({ code: "insufficient_credit" });
+
+    await repo.grantCredit({
+      entryId: "grant_later", identity, kind: "addon_grant", amountMicrousd: 100, sourceReference: "invoice_123",
+    });
+    await expect(repo.authorize({
+      credential: credential.token, requestId: "denied", modelId: otherModelId, maxCostMicrousd: 1,
+    })).rejects.toMatchObject({ code: "model_not_allowed" });
+    await expect(repo.authorize({
+      credential: credential.token, requestId: "budget", modelId, maxCostMicrousd: 51,
+    })).rejects.toMatchObject({ code: "budget_exceeded" });
+
+    await repo.updateGlobalPolicy({ expectedRevision: 1, enabled: false, allowedModelIds: [] });
+    await expect(repo.authorize({
+      credential: credential.token, requestId: "killed", modelId, maxCostMicrousd: 1,
+    })).rejects.toMatchObject({ code: "access_disabled" });
+    expect(await db.executor.selectFrom("ai_funded_usage_reservations").selectAll().execute()).toHaveLength(0);
+  });
+
+  it("resets monthly budget at the UTC month boundary without resetting credit", async () => {
+    clock = new Date("2026-08-31T23:30:00.000Z");
+    const credential = await enableAndFund({ budget: 100, credit: 200 });
+    const august = await repo.authorize({
+      credential: credential.token, requestId: "august", modelId, maxCostMicrousd: 80,
+    });
+    await repo.startReservation({ reservationId: august.reservation.reservationId, tokenId: credential.tokenId });
+    await repo.settleReservation({
+      reservationId: august.reservation.reservationId, tokenId: credential.tokenId, actualCostMicrousd: 80,
+    });
+    await expect(repo.authorize({
+      credential: credential.token, requestId: "august-over", modelId, maxCostMicrousd: 21,
+    })).rejects.toMatchObject({ code: "budget_exceeded" });
+
+    clock = new Date("2026-09-01T00:10:00.000Z");
+    await expect(repo.authorize({
+      credential: credential.token, requestId: "september", modelId, maxCostMicrousd: 80,
+    })).resolves.toMatchObject({ reservation: { periodStart: "2026-09-01T00:00:00.000Z" } });
+  });
+
+  it("recovers expired reservations through a bounded cleanup path", async () => {
+    const credential = await enableAndFund({ budget: 100, credit: 100 });
+    const first = await repo.authorize({
+      credential: credential.token, requestId: "expires", modelId, maxCostMicrousd: 100,
+    });
+    clock = new Date("2026-08-30T20:06:00.000Z");
+    expect(await repo.cleanupExpiredReservations({ limit: 10 })).toBe(1);
+    const row = await db.executor.selectFrom("ai_funded_usage_reservations")
+      .selectAll().where("reservation_id", "=", first.reservation.reservationId).executeTakeFirstOrThrow();
+    expect(row.status).toBe("expired");
+    await expect(repo.settleReservation({
+      reservationId: first.reservation.reservationId,
+      tokenId: credential.tokenId,
+      actualCostMicrousd: 10,
+    })).rejects.toMatchObject({ code: "reservation_expired" });
+    await expect(repo.authorize({
+      credential: credential.token, requestId: "after-expiry", modelId, maxCostMicrousd: 100,
+    })).resolves.toMatchObject({ authorized: true });
+  });
+
+  it("conservatively charges the full reservation when in-flight usage expires", async () => {
+    const credential = await enableAndFund({ budget: 100, credit: 100 });
+    const authorization = await repo.authorize({
+      credential: credential.token, requestId: "in_flight_expiry", modelId, maxCostMicrousd: 100,
+    });
+    const started = await repo.startReservation({
+      reservationId: authorization.reservation.reservationId,
+      tokenId: credential.tokenId,
+    });
+    await expect(repo.startReservation({
+      reservationId: authorization.reservation.reservationId,
+      tokenId: credential.tokenId,
+    })).resolves.toEqual(started);
+    clock = new Date("2026-08-30T20:31:00.000Z");
+    const cleanupCounts = await Promise.all([
+      repo.cleanupExpiredReservations({ limit: 10 }),
+      repo.cleanupExpiredReservations({ limit: 10 }),
+    ]);
+    expect(cleanupCounts.reduce((sum, count) => sum + count, 0)).toBe(1);
+    const reservation = await db.executor.selectFrom("ai_funded_usage_reservations")
+      .selectAll().where("reservation_id", "=", authorization.reservation.reservationId)
+      .executeTakeFirstOrThrow();
+    expect(reservation).toMatchObject({ status: "settled", actual_microusd: 100 });
+    expect(await db.executor.selectFrom("ai_funded_credit_ledger").select("amount_microusd")
+      .where("reservation_id", "=", reservation.reservation_id).execute())
+      .toEqual([{ amount_microusd: -100 }]);
+    await expect(repo.settleReservation({
+      reservationId: reservation.reservation_id,
+      tokenId: credential.tokenId,
+      actualCostMicrousd: 100,
+    })).resolves.toMatchObject({ status: "settled", actualCostMicrousd: 100, releasedMicrousd: 0 });
+  });
+
+  it("keeps grants immutable and idempotent by explicit billing/admin entry ID", async () => {
+    await enableAndFund({ credit: 100 });
+    const same = {
+      entryId: "addon_1", identity, kind: "addon_grant" as const,
+      amountMicrousd: 250, sourceReference: "invoice_abc",
+    };
+    const first = await repo.grantCredit(same);
+    await expect(repo.grantCredit(same)).resolves.toEqual(first);
+    await expect(repo.grantCredit({ ...same, amountMicrousd: 251 }))
+      .rejects.toMatchObject({ code: "idempotency_conflict" });
+    expect(await db.executor.selectFrom("ai_funded_credit_ledger")
+      .selectAll().where("entry_id", "=", "addon_1").execute()).toHaveLength(1);
+  });
+
+  it("tracks promotional and add-on balances without exposing ledger internals", async () => {
+    const credential = await enableAndFund({ budget: 200, credit: 50 });
+    await repo.grantCredit({
+      entryId: "addon_bucket", identity, kind: "addon_grant", amountMicrousd: 100, sourceReference: "invoice_bucket",
+    });
+    const authorization = await repo.authorize({
+      credential: credential.token, requestId: "bucketed", modelId, maxCostMicrousd: 120,
+    });
+    expect(authorization.funding).toMatchObject({
+      promotionalBalanceMicrousd: 50,
+      addonBalanceMicrousd: 100,
+      creditBalanceMicrousd: 150,
+      reservedMicrousd: 120,
+      remainingBalanceMicrousd: 30,
+      settledThisMonthMicrousd: 0,
+      asOf: "2026-08-30T20:00:00.000Z",
+      periodStart: "2026-08-01T00:00:00.000Z",
+    });
+    await repo.startReservation({ reservationId: authorization.reservation.reservationId, tokenId: credential.tokenId });
+    const settled = await repo.settleReservation({
+      reservationId: authorization.reservation.reservationId,
+      tokenId: credential.tokenId,
+      actualCostMicrousd: 80,
+    });
+    expect(settled.funding).toMatchObject({
+      promotionalBalanceMicrousd: 0,
+      addonBalanceMicrousd: 70,
+      creditBalanceMicrousd: 70,
+      reservedMicrousd: 0,
+      settledThisMonthMicrousd: 80,
+    });
+  });
+
+  it("releases definitive pre-upstream failures idempotently and closes settlement", async () => {
+    const credential = await enableAndFund({ budget: 100, credit: 100 });
+    const authorization = await repo.authorize({
+      credential: credential.token, requestId: "release_me", modelId, maxCostMicrousd: 80,
+    });
+    const request = {
+      reservationId: authorization.reservation.reservationId,
+      tokenId: credential.tokenId,
+      reason: "pre_upstream_failure" as const,
+    };
+    const released = await repo.releaseReservation(request);
+    expect(released).toMatchObject({ releasedMicrousd: 80, status: "released", funding: { reservedMicrousd: 0 } });
+    await expect(repo.releaseReservation(request)).resolves.toEqual(released);
+    await expect(repo.settleReservation({
+      reservationId: request.reservationId,
+      tokenId: request.tokenId,
+      actualCostMicrousd: 1,
+    })).rejects.toMatchObject({ code: "reservation_closed" });
+    await expect(repo.authorize({
+      credential: credential.token, requestId: "after_release", modelId, maxCostMicrousd: 100,
+    })).resolves.toMatchObject({ authorized: true });
+  });
+});

--- a/tests/platform/ai-funded-policy-repository.test.ts
+++ b/tests/platform/ai-funded-policy-repository.test.ts
@@ -57,7 +57,12 @@ describe("funded AI policy repository", () => {
       expectedRevision: 0,
       enabled: true,
       allowedModelIds: [models[0]],
+      monthlyBudgetMicrousd: 1_000,
       expiresAt: null,
+    });
+    await repo.grantCredit({
+      entryId: "grant_test", identity: { ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary" },
+      kind: "promotional_grant", amountMicrousd: 1_000, sourceReference: "test-fixture",
     });
     return repo;
   }
@@ -122,6 +127,7 @@ describe("funded AI policy repository", () => {
       expectedRevision: 0,
       enabled: true,
       allowedModelIds: [models[0]],
+      monthlyBudgetMicrousd: 1_000,
       expiresAt: null,
     })).rejects.toMatchObject({ code: "identity_mismatch" });
     await expect(repo.setRuntimePolicy({
@@ -129,6 +135,7 @@ describe("funded AI policy repository", () => {
       expectedRevision: -1,
       enabled: true,
       allowedModelIds: [models[0]],
+      monthlyBudgetMicrousd: 1_000,
       expiresAt: "not-a-timestamp",
     })).rejects.toMatchObject({ name: "ZodError" });
   });
@@ -160,11 +167,11 @@ describe("funded AI policy repository", () => {
     const repo = await enableRuntime();
     const identity = { ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary" } as const;
     const issued = await repo.issueRuntimeCredential(identity);
-    await expect(repo.authorize({ credential: issued.credential.token, modelId: models[0] }))
+    await expect(repo.authorize({ credential: issued.credential.token, requestId: "request_1", modelId: models[0], maxCostMicrousd: 100 }))
       .resolves.toMatchObject({ authorized: true, identity });
 
     await repo.revokeRuntimeCredential({ tokenId: issued.credential.tokenId, identity });
-    await expect(repo.authorize({ credential: issued.credential.token, modelId: models[0] }))
+    await expect(repo.authorize({ credential: issued.credential.token, requestId: "request_2", modelId: models[0], maxCostMicrousd: 100 }))
       .rejects.toMatchObject({ code: "unauthorized" });
 
     const nextRepo = createAiFundedPolicyRepository({
@@ -178,7 +185,7 @@ describe("funded AI policy repository", () => {
     });
     const second = await nextRepo.issueRuntimeCredential(identity);
     await repo.updateGlobalPolicy({ expectedRevision: 1, enabled: false, allowedModelIds: [] });
-    await expect(nextRepo.authorize({ credential: second.credential.token, modelId: models[0] }))
+    await expect(nextRepo.authorize({ credential: second.credential.token, requestId: "request_3", modelId: models[0], maxCostMicrousd: 100 }))
       .rejects.toMatchObject({ code: "access_disabled" });
   });
 
@@ -186,7 +193,7 @@ describe("funded AI policy repository", () => {
     const repo = await enableRuntime();
     const identity = { ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary" } as const;
     const issued = await repo.issueRuntimeCredential(identity);
-    await expect(repo.authorize({ credential: issued.credential.token, modelId: models[1] }))
+    await expect(repo.authorize({ credential: issued.credential.token, requestId: "request_4", modelId: models[1], maxCostMicrousd: 100 }))
       .rejects.toMatchObject({ code: "model_not_allowed" });
 
     const expired = createAiFundedPolicyRepository({
@@ -194,9 +201,9 @@ describe("funded AI policy repository", () => {
       credentialHashSecret: "h".repeat(32),
       now: () => new Date("2026-08-30T20:16:00.000Z"),
     });
-    await expect(expired.authorize({ credential: issued.credential.token, modelId: models[0] }))
+    await expect(expired.authorize({ credential: issued.credential.token, requestId: "request_5", modelId: models[0], maxCostMicrousd: 100 }))
       .rejects.toBeInstanceOf(AiFundedPolicyError);
-    await expect(expired.authorize({ credential: issued.credential.token, modelId: models[0] }))
+    await expect(expired.authorize({ credential: issued.credential.token, requestId: "request_6", modelId: models[0], maxCostMicrousd: 100 }))
       .rejects.toMatchObject({ code: "unauthorized" });
   });
 });

--- a/tests/platform/ai-funded-policy-routes.test.ts
+++ b/tests/platform/ai-funded-policy-routes.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { FundedAiRuntimeCredentialIssueResponseSchema } from "@matrix-os/contracts";
+import {
+  FundedAiAuthorizationResponseSchema,
+  FundedAiRuntimeCredentialIssueResponseSchema,
+  FundedAiSettlementResponseSchema,
+  FundedAiStartResponseSchema,
+} from "@matrix-os/contracts";
 import { createAiFundedPolicyRepository } from "../../packages/platform/src/ai-funded-policy-repository.js";
 import {
   createAiFundedRelayRoutes,
@@ -61,6 +66,11 @@ describe("funded AI policy routes", () => {
     await repository.setRuntimePolicy({
       identity: { ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary" },
       expectedRevision: 0, enabled: true, allowedModelIds: [modelId], expiresAt: null,
+      monthlyBudgetMicrousd: 1_000,
+    });
+    await repository.grantCredit({
+      entryId: "grant_routes", identity: { ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary" },
+      kind: "promotional_grant", amountMicrousd: 1_000, sourceReference: "route-fixture",
     });
     return {
       repository,
@@ -88,6 +98,10 @@ describe("funded AI policy routes", () => {
       AI_RELAY_CONTROL_TOKEN: relayControlToken,
       AI_FUNDED_CREDENTIAL_HASH_SECRET: hashSecret,
     })).toMatchObject({ enabled: true, credentialTtlMs: 900_000 });
+    expect(() => createAiFundedRelayRoutes({
+      relayControlToken,
+      repository: undefined as never,
+    })).toThrow(/dependencies/i);
   });
 
   it("issues a scoped credential from the authenticated running machine record", async () => {
@@ -193,7 +207,9 @@ describe("funded AI policy routes", () => {
       body: "{}",
     });
     const issued = FundedAiRuntimeCredentialIssueResponseSchema.parse(await issuedResponse.json());
-    const body = JSON.stringify({ credential: issued.credential.token, requestId: "request_123", modelId });
+    const body = JSON.stringify({
+      credential: issued.credential.token, requestId: "request_123", modelId, maxCostMicrousd: 100,
+    });
 
     const unauthenticated = await app.request("/internal/ai/funded/authorize", {
       method: "POST", headers: { "content-type": "application/json" }, body,
@@ -205,6 +221,32 @@ describe("funded AI policy routes", () => {
       body,
     });
     expect(authorized.status).toBe(200);
-    expect(await authorized.json()).toMatchObject({ authorized: true, identity: { ownerId: "user_alice" } });
+    const authorization = FundedAiAuthorizationResponseSchema.parse(await authorized.json());
+    expect(authorization).toMatchObject({ authorized: true, identity: { ownerId: "user_alice" } });
+
+    const lifecycleBody = {
+      reservationId: authorization.reservation.reservationId,
+      tokenId: issued.credential.tokenId,
+    };
+    const start = await app.request("/internal/ai/funded/start", {
+      method: "POST",
+      headers: { authorization: `Bearer ${relayControlToken}`, "content-type": "application/json" },
+      body: JSON.stringify(lifecycleBody),
+    });
+    expect(FundedAiStartResponseSchema.parse(await start.json())).toMatchObject({ status: "in_flight" });
+    const settle = await app.request("/internal/ai/funded/settle", {
+      method: "POST",
+      headers: { authorization: `Bearer ${relayControlToken}`, "content-type": "application/json" },
+      body: JSON.stringify({ ...lifecycleBody, actualCostMicrousd: 60 }),
+    });
+    expect(FundedAiSettlementResponseSchema.parse(await settle.json()))
+      .toMatchObject({ status: "settled", actualCostMicrousd: 60 });
+
+    const invalidRelease = await app.request("/internal/ai/funded/release", {
+      method: "POST",
+      headers: { authorization: `Bearer ${relayControlToken}`, "content-type": "application/json" },
+      body: JSON.stringify({ ...lifecycleBody, reason: "ambiguous_upstream_failure" }),
+    });
+    expect(invalidRelease.status).toBe(400);
   });
 });

--- a/tests/platform/ai-funded-policy-routes.test.ts
+++ b/tests/platform/ai-funded-policy-routes.test.ts
@@ -135,6 +135,14 @@ describe("funded AI policy routes", () => {
     await repository.setRuntimePolicy({
       identity: { ownerId: "user_alice", machineId: "machine_staging", runtimeSlot: "staging" },
       expectedRevision: 0, enabled: true, allowedModelIds: [modelId], expiresAt: null,
+      monthlyBudgetMicrousd: 1_000,
+    });
+    await repository.grantCredit({
+      entryId: "grant_routes_staging",
+      identity: { ownerId: "user_alice", machineId: "machine_staging", runtimeSlot: "staging" },
+      kind: "promotional_grant",
+      amountMicrousd: 1_000,
+      sourceReference: "route-fixture-staging",
     });
 
     const response = await app.request(fundedCredentialPath("alice", "staging"), {


### PR DESCRIPTION
## Summary

- add transactionally maintained per-runtime promotional/add-on balances and a bounded append-only credit ledger
- atomically reserve worst-case integer-microusd cost under global/runtime model policy, monthly budget, and available credit
- implement idempotent reserve → in-flight → settle/release lifecycle with exact replay and payload-conflict handling
- refund expired pre-upstream reservations and conservatively charge expired in-flight reservations at their full reserved amount
- return bounded funding summaries for provider settings without exposing ledger or provider internals

## Validation

- 23 parent-plus-metering contract/repository/route tests, including concurrent admission and cleanup races
- contracts and platform TypeScript checks
- `git diff codex/funded-ai-control-plane...HEAD --check`

## Invariants

- **Source of truth:** platform Postgres balances, reservations, and immutable ledger entries are authoritative; Cloudflare spend limits are secondary guardrails only.
- **Lock / transaction scope:** each grant, reservation, start, settlement, release, and cleanup claim is one Kysely transaction with conditional writes; concurrent reservations cannot overspend one balance.
- **Acceptable orphan states:** expired `reserved` rows refund; expired `in_flight` rows settle at full reserve, so a proxy crash after upstream start cannot create free usage.
- **Auth source of truth:** only the dedicated relay service credential may call metering routes; owner/runtime identity comes from the scoped credential binding.
- **Deferred scope:** Stripe/customer top-up routes, cleanup scheduling, Cloudflare forwarding, runtime credential delivery, and production activation remain in later layers.
