### PR TITLE
feat(ai-gateway): rotate funded runtime credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,16 @@ MATRIX_FUNDED_AI_GLOBAL_RATE_LIMIT=180
 MATRIX_FUNDED_AI_RUNTIME_CONCURRENCY=2
 MATRIX_FUNDED_AI_RATE_LIMIT=60
 
+# Platform-only rollout switch. When enabled, newly provisioned customer VPSes
+# receive the relay URL plus their existing scoped platform verification token;
+# they never receive Cloudflare or relay-service credentials.
+MATRIX_FUNDED_AI_RUNTIME_ENABLED=false
+MATRIX_FUNDED_AI_RELAY_URL=
+
+# Customer gateway acquisition/run bounds (normally use these defaults).
+MATRIX_FUNDED_AI_CREDENTIAL_TIMEOUT_MS=5000
+MATRIX_FUNDED_AI_RUN_TIMEOUT_MS=600000
+
 # Optional: Gemini API key for image generation (Nano Banana)
 GEMINI_API_KEY=
 

--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -398,6 +398,8 @@ write_files:
       MATRIX_AUTH_TOKEN={{platformVerificationToken}}
       MATRIX_FUNDED_AI_RUNTIME_TOKEN={{fundedAiRuntimeToken}}
       MATRIX_CODE_PROXY_TOKEN={{platformVerificationToken}}
+      MATRIX_FUNDED_AI_ENABLED={{fundedAiEnabled}}
+      MATRIX_FUNDED_AI_RELAY_URL={{fundedAiRelayUrl}}
       MATRIX_HOST_BUNDLE_URL={{hostBundleUrl}}
       POSTHOG_TOKEN={{posthogToken}}
       POSTHOG_PROJECT_TOKEN={{posthogProjectToken}}

--- a/packages/gateway/src/ai-providers/credential-store.ts
+++ b/packages/gateway/src/ai-providers/credential-store.ts
@@ -6,6 +6,7 @@ import {
   type KernelCredentialSources,
 } from "../kernel-credentials.js";
 import { normalizeKernelModel, type KernelModel } from "../kernel-settings.js";
+import type { MatrixFundedCredentialProvider } from "../funded-ai-credential-manager.js";
 
 const SavedKernelConfigSchema = z.object({
   kernel: z.object({
@@ -21,15 +22,25 @@ export interface AiProviderCredentialSnapshot {
 export class ProviderCredentialStore {
   readonly #homePath: string;
   readonly #env: NodeJS.ProcessEnv;
+  readonly #fundedCredentialProvider?: MatrixFundedCredentialProvider;
 
-  constructor(options: { homePath: string; env?: NodeJS.ProcessEnv }) {
+  constructor(options: {
+    homePath: string;
+    env?: NodeJS.ProcessEnv;
+    fundedCredentialProvider?: MatrixFundedCredentialProvider;
+  }) {
     if (!options.homePath) throw new Error("AI provider home path is required");
     this.#homePath = options.homePath;
     this.#env = options.env ?? process.env;
+    this.#fundedCredentialProvider = options.fundedCredentialProvider;
   }
 
   async read(): Promise<AiProviderCredentialSnapshot> {
-    const credentials = await resolveKernelCredentialSources(this.#homePath, this.#env);
+    const credentials = await resolveKernelCredentialSources(
+      this.#homePath,
+      this.#env,
+      this.#fundedCredentialProvider,
+    );
     let savedModel: KernelModel | null = null;
     try {
       const parsed = SavedKernelConfigSchema.safeParse(JSON.parse(

--- a/packages/gateway/src/ai-providers/service.ts
+++ b/packages/gateway/src/ai-providers/service.ts
@@ -16,6 +16,7 @@ import {
   buildBundledModelCatalog,
   eligibleModelsForSource,
 } from "./model-catalog.js";
+import type { MatrixFundedCredentialProvider } from "../funded-ai-credential-manager.js";
 
 const HEALTH_TIMEOUT_MS = 2_000;
 const KERNEL_CAPABILITIES = [
@@ -43,6 +44,7 @@ interface AiProviderServiceOptions {
   healthCache?: ProviderHealthCache<AiProviderReadiness>;
   healthTimeoutMs?: number;
   driverInventory?: (signal: AbortSignal) => Promise<AiProviderSnapshotV3["drivers"]>;
+  fundedCredentialProvider?: MatrixFundedCredentialProvider;
 }
 
 function readinessForObservation(
@@ -120,6 +122,7 @@ export class AiProviderService implements AiProviderSnapshotReader {
     this.#credentials = new ProviderCredentialStore({
       homePath: options.homePath,
       env: options.env,
+      fundedCredentialProvider: options.fundedCredentialProvider,
     });
     this.#now = options.now ?? (() => new Date());
     this.#healthProbe = options.healthProbe;

--- a/packages/gateway/src/chat/claude-provider-adapter.ts
+++ b/packages/gateway/src/chat/claude-provider-adapter.ts
@@ -1,6 +1,9 @@
 import { z } from "zod/v4";
 import { buildAgentLaunch } from "../agent-launcher.js";
-import { buildKernelEnv } from "../kernel-credentials.js";
+import {
+  buildKernelCredentialLaunch,
+  type KernelCredentialLaunch,
+} from "../kernel-credentials.js";
 import {
   CanonicalProviderRunEventSchema,
   parseCanonicalProviderRunInput,
@@ -101,6 +104,7 @@ export function createClaudeChatProviderAdapter(options: {
   spawnFn?: CanonicalCliSpawn;
   timeoutMs?: number;
   resolveCredentialEnv?: () => Promise<Record<string, string | undefined> | undefined>;
+  resolveCredentialLaunch?: () => Promise<KernelCredentialLaunch>;
 }): CanonicalChatProviderAdapter<ClaudeChatState> {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
@@ -132,9 +136,15 @@ export function createClaudeChatProviderAdapter(options: {
       const separator = launch.args.indexOf("--");
       launch.args.splice(separator < 0 ? launch.args.length : separator, 0, "--resume", resumeState.sessionId);
     }
-    const credentialEnv = await (
-      options.resolveCredentialEnv ?? (() => buildKernelEnv(options.homePath))
-    )();
+    const credentialLaunch = options.resolveCredentialLaunch
+      ? await options.resolveCredentialLaunch()
+      : {
+          env: await (
+            options.resolveCredentialEnv
+            ?? (() => buildKernelCredentialLaunch(options.homePath).then((value) => value.env))
+          )(),
+        };
+    const credentialEnv = credentialLaunch.env;
     const runEnv = credentialEnv === undefined
       ? launch.env
       : definedEnvironment({ ...credentialEnv, ...launch.env });
@@ -321,7 +331,7 @@ export function createClaudeChatProviderAdapter(options: {
       env: runEnv,
       replaceEnv: credentialEnv !== undefined,
       signal: input.signal,
-      timeoutMs,
+      timeoutMs: Math.min(timeoutMs, credentialLaunch.fundedRunTimeoutMs ?? timeoutMs),
       maxStdoutBytes: MAX_STREAM_BYTES,
       spawnFn: options.spawnFn,
       onStdout(chunk) {

--- a/packages/gateway/src/dispatcher.ts
+++ b/packages/gateway/src/dispatcher.ts
@@ -25,9 +25,10 @@ import {
   aiTokensTotal,
 } from "./metrics.js";
 import {
-  buildKernelEnv,
+  buildKernelCredentialLaunch,
   type KernelCredentialAccessSourceId,
 } from "./kernel-credentials.js";
+import type { MatrixFundedCredentialProvider } from "./funded-ai-credential-manager.js";
 import type { KernelEffort, KernelModel } from "./kernel-settings.js";
 
 export type SpawnFn = typeof spawnKernel;
@@ -38,6 +39,7 @@ export interface DispatchOptions {
   maxTurns?: number;
   spawnFn?: SpawnFn;
   maxConcurrency?: number;
+  fundedCredentialProvider?: MatrixFundedCredentialProvider;
   /** Called once per completed kernel query with usage metadata only
       (trace/session id, model, latency, token counts, error category input).
       Never receives message content. Failures are swallowed. */
@@ -126,6 +128,25 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
   let active = 0;
   let batchRunning = false;
 
+  function fundedAbortController(
+    existing: AbortController | undefined,
+    timeoutMs: number | undefined,
+  ): { controller: AbortController | undefined; cleanup: () => void } {
+    if (timeoutMs === undefined) return { controller: existing, cleanup: () => {} };
+    const controller = new AbortController();
+    const forwardAbort = () => controller.abort(existing?.signal.reason);
+    if (existing?.signal.aborted) forwardAbort();
+    else existing?.signal.addEventListener("abort", forwardAbort, { once: true });
+    const timer = setTimeout(() => controller.abort(new Error("Matrix AI run deadline exceeded")), timeoutMs);
+    return {
+      controller,
+      cleanup: () => {
+        clearTimeout(timer);
+        existing?.signal.removeEventListener("abort", forwardAbort);
+      },
+    };
+  }
+
   function logNonFatal(label: string, err: unknown) {
     console.warn(label, err instanceof Error ? err.message : String(err));
   }
@@ -188,6 +209,13 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
         });
       }
 
+      const credentialLaunch = await buildKernelCredentialLaunch(
+        homePath,
+        process.env,
+        entry.kernelOverrides?.accessSourceId,
+        opts.fundedCredentialProvider,
+      );
+      const deadline = fundedAbortController(entry.abortController, credentialLaunch.fundedRunTimeoutMs);
       const config: KernelConfig = {
         db,
         homePath,
@@ -196,18 +224,21 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
         effort: entry.kernelOverrides?.effort,
         workingDirectory: entry.kernelOverrides?.workingDirectory,
         maxTurns: opts.maxTurns,
-        env: await buildKernelEnv(homePath, process.env, entry.kernelOverrides?.accessSourceId),
+        env: credentialLaunch.env,
       };
-
-      for await (const event of spawnFn(message, config, entry.abortController)) {
-        await entry.onEvent(event);
-        if (event.type === "init") {
-          resultSessionId = event.sessionId;
-        } else if (event.type === "tool_start") {
-          toolsUsed.push(event.tool);
-        } else if (event.type === "result") {
-          resultData = event.data;
+      try {
+        for await (const event of spawnFn(message, config, deadline.controller)) {
+          await entry.onEvent(event);
+          if (event.type === "init") {
+            resultSessionId = event.sessionId;
+          } else if (event.type === "tool_start") {
+            toolsUsed.push(event.tool);
+          } else if (event.type === "result") {
+            resultData = event.data;
+          }
         }
+      } finally {
+        deadline.cleanup();
       }
 
       completeTask(db, processId, { message: entry.message });
@@ -325,16 +356,23 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
           let batchResultData: KernelResult | undefined;
           let batchSessionId = "";
 
+          const credentialLaunch = await buildKernelCredentialLaunch(
+            homePath,
+            process.env,
+            undefined,
+            opts.fundedCredentialProvider,
+          );
+          const deadline = fundedAbortController(undefined, credentialLaunch.fundedRunTimeoutMs);
           const config: KernelConfig = {
             db,
             homePath,
             model: opts.model,
             maxTurns: opts.maxTurns,
-            env: await buildKernelEnv(homePath),
+            env: credentialLaunch.env,
           };
 
           try {
-            for await (const event of spawnFn(batchEntry.message, config)) {
+            for await (const event of spawnFn(batchEntry.message, config, deadline.controller)) {
               batchEntry.onEvent(event);
               if (event.type === "init") batchSessionId = event.sessionId;
               if (event.type === "result") batchResultData = event.data;
@@ -350,6 +388,8 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
               error: err,
             });
             throw err;
+          } finally {
+            deadline.cleanup();
           }
 
           const durationMs = Date.now() - startTime;

--- a/packages/gateway/src/funded-ai-credential-manager.ts
+++ b/packages/gateway/src/funded-ai-credential-manager.ts
@@ -110,11 +110,13 @@ export function loadFundedAiRuntimeConfig(
     machineId: parseConfigValue(IdentityValueSchema, env.MATRIX_MACHINE_ID),
     runtimeSlot: parseConfigValue(RuntimeSlotSchema, env.MATRIX_RUNTIME_SLOT),
   };
+  const issueUrl = new URL(
+    `/internal/containers/${encodeURIComponent(handle)}/ai/funded-credential`,
+    platform,
+  );
+  issueUrl.searchParams.set("runtimeSlot", identity.runtimeSlot);
   return {
-    issueUrl: new URL(
-      `/internal/containers/${encodeURIComponent(handle)}/ai/funded-credential`,
-      platform,
-    ).toString(),
+    issueUrl: issueUrl.toString(),
     relayBaseUrl: relay.toString().replace(/\/$/, ""),
     runtimeAuthToken,
     identity,

--- a/packages/gateway/src/funded-ai-credential-manager.ts
+++ b/packages/gateway/src/funded-ai-credential-manager.ts
@@ -1,0 +1,312 @@
+import {
+  FundedAiRuntimeCredentialIssueResponseSchema,
+  type FundedAiRuntimeCredentialIssueResponse,
+} from "@matrix-os/contracts";
+import { z } from "zod/v4";
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 5_000;
+const DEFAULT_MAX_RUN_MS = 10 * 60_000;
+const MIN_RUN_MS = 60_000;
+const MAX_RUN_MS = 10 * 60_000;
+const EXPIRY_SAFETY_MS = 60_000;
+const MAX_REFRESH_JITTER_MS = 30_000;
+const MAX_RESPONSE_BYTES = 16 * 1024;
+const MAX_ATTEMPTS = 3;
+const SAFE_MESSAGE = "Matrix AI is temporarily unavailable";
+
+const HandleSchema = z.string().min(1).max(63).regex(/^[a-z0-9][a-z0-9-]*$/);
+const IdentityValueSchema = z.string().min(1).max(160).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/);
+const RuntimeSlotSchema = z.string().min(1).max(80).regex(/^[a-z0-9][a-z0-9_-]*$/);
+const AuthTokenSchema = z.string().min(32).max(512).regex(/^[A-Za-z0-9._~+/=-]+$/);
+
+export interface FundedAiRuntimeConfig {
+  issueUrl: string;
+  relayBaseUrl: string;
+  platformAuthToken: string;
+  identity: { ownerId: string; machineId: string; runtimeSlot: string };
+  maxRunMs: number;
+  requestTimeoutMs: number;
+}
+
+export interface FundedAiCredentialLease {
+  token: string;
+  tokenId: string;
+  expiresAt: string;
+  relayBaseUrl: string;
+  maxRunMs: number;
+}
+
+export interface MatrixFundedCredentialProvider {
+  readonly enabled: true;
+  readonly maxRunMs: number;
+  getCredential(options?: {
+    minValidityMs?: number;
+    forceRefresh?: boolean;
+    signal?: AbortSignal;
+  }): Promise<FundedAiCredentialLease>;
+  invalidate(tokenId?: string): void;
+  close(): void;
+}
+
+export class FundedAiCredentialError extends Error {
+  constructor() {
+    super(SAFE_MESSAGE);
+    this.name = "FundedAiCredentialError";
+  }
+}
+
+function boundedInteger(raw: string | undefined, fallback: number, min: number, max: number): number {
+  if (raw === undefined || raw === "") return fallback;
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw new Error("Funded AI runtime is misconfigured");
+  }
+  return value;
+}
+
+function parseServiceUrl(raw: string | undefined, originOnly: boolean): URL {
+  try {
+    if (!raw || raw.length > 2_048 || !/^[A-Za-z0-9:/._~%\[\]-]+$/.test(raw)) {
+      throw new Error("invalid");
+    }
+    const url = new URL(raw ?? "");
+    const loopback = url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "::1";
+    if ((url.protocol !== "https:" && !(loopback && url.protocol === "http:"))
+      || url.username || url.password || url.search || url.hash
+      || (originOnly && url.pathname !== "/")) {
+      throw new Error("invalid");
+    }
+    return url;
+  } catch {
+    throw new Error("Funded AI runtime is misconfigured");
+  }
+}
+
+export function loadFundedAiRuntimeConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): FundedAiRuntimeConfig | undefined {
+  if (env.MATRIX_FUNDED_AI_ENABLED !== "true" && env.MATRIX_FUNDED_AI_ENABLED !== "1") return undefined;
+  try {
+    const platform = parseServiceUrl(env.PLATFORM_INTERNAL_URL, true);
+    const relay = parseServiceUrl(env.MATRIX_FUNDED_AI_RELAY_URL, false);
+    const handle = HandleSchema.parse(env.MATRIX_HANDLE);
+    const platformAuthToken = AuthTokenSchema.parse(env.MATRIX_AUTH_TOKEN);
+    const identity = {
+      ownerId: IdentityValueSchema.parse(env.MATRIX_CLERK_USER_ID),
+      machineId: IdentityValueSchema.parse(env.MATRIX_MACHINE_ID),
+      runtimeSlot: RuntimeSlotSchema.parse(env.MATRIX_RUNTIME_SLOT),
+    };
+    return {
+      issueUrl: new URL(
+        `/internal/containers/${encodeURIComponent(handle)}/ai/funded-credential`,
+        platform,
+      ).toString(),
+      relayBaseUrl: relay.toString().replace(/\/$/, ""),
+      platformAuthToken,
+      identity,
+      maxRunMs: boundedInteger(
+        env.MATRIX_FUNDED_AI_RUN_TIMEOUT_MS,
+        DEFAULT_MAX_RUN_MS,
+        MIN_RUN_MS,
+        MAX_RUN_MS,
+      ),
+      requestTimeoutMs: boundedInteger(
+        env.MATRIX_FUNDED_AI_CREDENTIAL_TIMEOUT_MS,
+        DEFAULT_REQUEST_TIMEOUT_MS,
+        500,
+        10_000,
+      ),
+    };
+  } catch {
+    throw new Error("Funded AI runtime is misconfigured");
+  }
+}
+
+async function readBoundedJson(response: Response): Promise<unknown> {
+  const declared = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > MAX_RESPONSE_BYTES) throw new FundedAiCredentialError();
+  if (!response.body) throw new FundedAiCredentialError();
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      size += next.value.byteLength;
+      if (size > MAX_RESPONSE_BYTES) {
+        await reader.cancel().catch((error: unknown) => {
+          console.warn(
+            "[funded-ai-credentials] response cancellation failed:",
+            error instanceof Error ? error.name : "UnknownError",
+          );
+        });
+        throw new FundedAiCredentialError();
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+  } catch {
+    throw new FundedAiCredentialError();
+  }
+}
+
+async function discardResponse(response: Response): Promise<void> {
+  await response.body?.cancel().catch((error: unknown) => {
+    console.warn(
+      "[funded-ai-credentials] response cancellation failed:",
+      error instanceof Error ? error.name : "UnknownError",
+    );
+  });
+}
+
+function defaultSleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) return reject(new FundedAiCredentialError());
+    const abort = () => {
+      clearTimeout(timer);
+      reject(new FundedAiCredentialError());
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", abort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", abort, { once: true });
+  });
+}
+
+function abortSignal(
+  input: AbortSignal | undefined,
+  timeoutMs: number,
+  makeTimeoutSignal: (ms: number) => AbortSignal,
+): AbortSignal {
+  const timeout = makeTimeoutSignal(timeoutMs);
+  return input ? AbortSignal.any([input, timeout]) : timeout;
+}
+
+export function createFundedAiCredentialManager(
+  config: FundedAiRuntimeConfig,
+  dependencies: {
+    fetchFn?: typeof fetch;
+    now?: () => number;
+    random?: () => number;
+    sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
+    makeTimeoutSignal?: (ms: number) => AbortSignal;
+  } = {},
+): MatrixFundedCredentialProvider {
+  const fetchFn = dependencies.fetchFn ?? fetch;
+  const now = dependencies.now ?? Date.now;
+  const random = dependencies.random ?? Math.random;
+  const sleep = dependencies.sleep ?? defaultSleep;
+  const makeTimeoutSignal = dependencies.makeTimeoutSignal ?? AbortSignal.timeout;
+  let cached: FundedAiCredentialLease | undefined;
+  let inFlight: Promise<FundedAiCredentialLease> | undefined;
+  let closed = false;
+  const lifetime = new AbortController();
+
+  function validateIssued(
+    value: FundedAiRuntimeCredentialIssueResponse,
+    minValidityMs: number,
+  ): FundedAiCredentialLease {
+    if (!value.policy.enabled
+      || value.identity.ownerId !== config.identity.ownerId
+      || value.identity.machineId !== config.identity.machineId
+      || value.identity.runtimeSlot !== config.identity.runtimeSlot
+      || Date.parse(value.credential.expiresAt) - now() < minValidityMs) {
+      throw new FundedAiCredentialError();
+    }
+    return {
+      token: value.credential.token,
+      tokenId: value.credential.tokenId,
+      expiresAt: value.credential.expiresAt,
+      relayBaseUrl: config.relayBaseUrl,
+      maxRunMs: config.maxRunMs,
+    };
+  }
+
+  async function acquire(minValidityMs: number, callerSignal?: AbortSignal): Promise<FundedAiCredentialLease> {
+    const callerAndLifetime = callerSignal
+      ? AbortSignal.any([callerSignal, lifetime.signal])
+      : lifetime.signal;
+    const signal = abortSignal(callerAndLifetime, config.requestTimeoutMs, makeTimeoutSignal);
+    let lastTransient = false;
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+      try {
+        const response = await fetchFn(config.issueUrl, {
+          method: "POST",
+          redirect: "error",
+          signal,
+          headers: {
+            authorization: `Bearer ${config.platformAuthToken}`,
+            "content-type": "application/json",
+            accept: "application/json",
+          },
+          body: "{}",
+        });
+        if (!response.ok) {
+          await discardResponse(response);
+          lastTransient = [429, 502, 503, 504].includes(response.status);
+          if (!lastTransient) throw new FundedAiCredentialError();
+        } else {
+          const parsed = FundedAiRuntimeCredentialIssueResponseSchema.safeParse(await readBoundedJson(response));
+          if (!parsed.success) throw new FundedAiCredentialError();
+          return validateIssued(parsed.data, minValidityMs);
+        }
+      } catch (error) {
+        if (error instanceof FundedAiCredentialError) throw error;
+        lastTransient = !signal.aborted;
+      }
+      if (!lastTransient || attempt === MAX_ATTEMPTS - 1) break;
+      const delay = 100 * (2 ** attempt) + Math.floor(random() * 100);
+      await sleep(delay, signal);
+    }
+    throw new FundedAiCredentialError();
+  }
+
+  return {
+    enabled: true,
+    maxRunMs: config.maxRunMs,
+    async getCredential(options = {}) {
+      if (closed) throw new FundedAiCredentialError();
+      const minValidityMs = Math.max(
+        options.minValidityMs ?? config.maxRunMs + EXPIRY_SAFETY_MS,
+        EXPIRY_SAFETY_MS,
+      );
+      const refreshJitter = Math.floor(random() * MAX_REFRESH_JITTER_MS);
+      if (!options.forceRefresh && cached
+        && Date.parse(cached.expiresAt) - now() >= minValidityMs + refreshJitter) {
+        return cached;
+      }
+      if (!inFlight) {
+        inFlight = acquire(minValidityMs, options.signal)
+          .then((lease) => {
+            if (closed) throw new FundedAiCredentialError();
+            cached = lease;
+            return lease;
+          })
+          .finally(() => {
+            inFlight = undefined;
+          });
+      }
+      return await inFlight;
+    },
+    invalidate(tokenId) {
+      if (!tokenId || cached?.tokenId === tokenId) cached = undefined;
+    },
+    close() {
+      closed = true;
+      cached = undefined;
+      lifetime.abort();
+    },
+  };
+}

--- a/packages/gateway/src/funded-ai-credential-manager.ts
+++ b/packages/gateway/src/funded-ai-credential-manager.ts
@@ -55,71 +55,82 @@ export class FundedAiCredentialError extends Error {
   }
 }
 
+export class FundedAiRuntimeConfigError extends Error {
+  constructor(cause?: unknown) {
+    super("Funded AI runtime is misconfigured", cause === undefined ? undefined : { cause });
+    this.name = "FundedAiRuntimeConfigError";
+  }
+}
+
+function parseConfigValue<T>(schema: z.ZodType<T>, value: unknown): T {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) throw new FundedAiRuntimeConfigError(parsed.error);
+  return parsed.data;
+}
+
 function boundedInteger(raw: string | undefined, fallback: number, min: number, max: number): number {
   if (raw === undefined || raw === "") return fallback;
   const value = Number(raw);
   if (!Number.isSafeInteger(value) || value < min || value > max) {
-    throw new Error("Funded AI runtime is misconfigured");
+    throw new FundedAiRuntimeConfigError();
   }
   return value;
 }
 
 function parseServiceUrl(raw: string | undefined, originOnly: boolean): URL {
-  try {
-    if (!raw || raw.length > 2_048 || !/^[A-Za-z0-9:/._~%\[\]-]+$/.test(raw)) {
-      throw new Error("invalid");
-    }
-    const url = new URL(raw ?? "");
-    const loopback = url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "::1";
-    if ((url.protocol !== "https:" && !(loopback && url.protocol === "http:"))
-      || url.username || url.password || url.search || url.hash
-      || (originOnly && url.pathname !== "/")) {
-      throw new Error("invalid");
-    }
-    return url;
-  } catch {
-    throw new Error("Funded AI runtime is misconfigured");
+  if (!raw || raw.length > 2_048 || !/^[A-Za-z0-9:/._~%\[\]-]+$/.test(raw)) {
+    throw new FundedAiRuntimeConfigError();
   }
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch (error) {
+    if (!(error instanceof TypeError)) throw error;
+    throw new FundedAiRuntimeConfigError(error);
+  }
+  const loopback = url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "::1";
+  if ((url.protocol !== "https:" && !(loopback && url.protocol === "http:"))
+    || url.username || url.password || url.search || url.hash
+    || (originOnly && url.pathname !== "/")) {
+    throw new FundedAiRuntimeConfigError();
+  }
+  return url;
 }
 
 export function loadFundedAiRuntimeConfig(
   env: NodeJS.ProcessEnv = process.env,
 ): FundedAiRuntimeConfig | undefined {
   if (env.MATRIX_FUNDED_AI_ENABLED !== "true" && env.MATRIX_FUNDED_AI_ENABLED !== "1") return undefined;
-  try {
-    const platform = parseServiceUrl(env.PLATFORM_INTERNAL_URL, true);
-    const relay = parseServiceUrl(env.MATRIX_FUNDED_AI_RELAY_URL, false);
-    const handle = HandleSchema.parse(env.MATRIX_HANDLE);
-    const runtimeAuthToken = AuthTokenSchema.parse(env.MATRIX_FUNDED_AI_RUNTIME_TOKEN);
-    const identity = {
-      ownerId: IdentityValueSchema.parse(env.MATRIX_CLERK_USER_ID),
-      machineId: IdentityValueSchema.parse(env.MATRIX_MACHINE_ID),
-      runtimeSlot: RuntimeSlotSchema.parse(env.MATRIX_RUNTIME_SLOT),
-    };
-    return {
-      issueUrl: new URL(
-        `/internal/containers/${encodeURIComponent(handle)}/ai/funded-credential`,
-        platform,
-      ).toString(),
-      relayBaseUrl: relay.toString().replace(/\/$/, ""),
-      runtimeAuthToken,
-      identity,
-      maxRunMs: boundedInteger(
-        env.MATRIX_FUNDED_AI_RUN_TIMEOUT_MS,
-        DEFAULT_MAX_RUN_MS,
-        MIN_RUN_MS,
-        MAX_RUN_MS,
-      ),
-      requestTimeoutMs: boundedInteger(
-        env.MATRIX_FUNDED_AI_CREDENTIAL_TIMEOUT_MS,
-        DEFAULT_REQUEST_TIMEOUT_MS,
-        500,
-        10_000,
-      ),
-    };
-  } catch {
-    throw new Error("Funded AI runtime is misconfigured");
-  }
+  const platform = parseServiceUrl(env.PLATFORM_INTERNAL_URL, true);
+  const relay = parseServiceUrl(env.MATRIX_FUNDED_AI_RELAY_URL, false);
+  const handle = parseConfigValue(HandleSchema, env.MATRIX_HANDLE);
+  const runtimeAuthToken = parseConfigValue(AuthTokenSchema, env.MATRIX_FUNDED_AI_RUNTIME_TOKEN);
+  const identity = {
+    ownerId: parseConfigValue(IdentityValueSchema, env.MATRIX_CLERK_USER_ID),
+    machineId: parseConfigValue(IdentityValueSchema, env.MATRIX_MACHINE_ID),
+    runtimeSlot: parseConfigValue(RuntimeSlotSchema, env.MATRIX_RUNTIME_SLOT),
+  };
+  return {
+    issueUrl: new URL(
+      `/internal/containers/${encodeURIComponent(handle)}/ai/funded-credential`,
+      platform,
+    ).toString(),
+    relayBaseUrl: relay.toString().replace(/\/$/, ""),
+    runtimeAuthToken,
+    identity,
+    maxRunMs: boundedInteger(
+      env.MATRIX_FUNDED_AI_RUN_TIMEOUT_MS,
+      DEFAULT_MAX_RUN_MS,
+      MIN_RUN_MS,
+      MAX_RUN_MS,
+    ),
+    requestTimeoutMs: boundedInteger(
+      env.MATRIX_FUNDED_AI_CREDENTIAL_TIMEOUT_MS,
+      DEFAULT_REQUEST_TIMEOUT_MS,
+      500,
+      10_000,
+    ),
+  };
 }
 
 async function readBoundedJson(response: Response): Promise<unknown> {
@@ -156,7 +167,8 @@ async function readBoundedJson(response: Response): Promise<unknown> {
   }
   try {
     return JSON.parse(new TextDecoder().decode(bytes)) as unknown;
-  } catch {
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) throw error;
     throw new FundedAiCredentialError();
   }
 }

--- a/packages/gateway/src/funded-ai-credential-manager.ts
+++ b/packages/gateway/src/funded-ai-credential-manager.ts
@@ -55,6 +55,13 @@ export class FundedAiCredentialError extends Error {
   }
 }
 
+export class FundedAiCredentialUnexpectedError extends Error {
+  constructor(cause: unknown) {
+    super("Matrix AI credential processing failed", { cause });
+    this.name = "FundedAiCredentialUnexpectedError";
+  }
+}
+
 export class FundedAiRuntimeConfigError extends Error {
   constructor(cause?: unknown) {
     super("Funded AI runtime is misconfigured", cause === undefined ? undefined : { cause });
@@ -272,12 +279,24 @@ export function createFundedAiCredentialManager(
           lastTransient = [429, 502, 503, 504].includes(response.status);
           if (!lastTransient) throw new FundedAiCredentialError();
         } else {
-          const parsed = FundedAiRuntimeCredentialIssueResponseSchema.safeParse(await readBoundedJson(response));
+          let payload: unknown;
+          try {
+            payload = await readBoundedJson(response);
+          } catch (error) {
+            if (error instanceof FundedAiCredentialError) throw error;
+            console.error(
+              "[funded-ai-credentials] unexpected response processing failure:",
+              error instanceof Error ? error.name : "UnknownError",
+            );
+            throw new FundedAiCredentialUnexpectedError(error);
+          }
+          const parsed = FundedAiRuntimeCredentialIssueResponseSchema.safeParse(payload);
           if (!parsed.success) throw new FundedAiCredentialError();
           return validateIssued(parsed.data, minValidityMs);
         }
       } catch (error) {
-        if (error instanceof FundedAiCredentialError) throw error;
+        if (error instanceof FundedAiCredentialError
+          || error instanceof FundedAiCredentialUnexpectedError) throw error;
         lastTransient = !signal.aborted;
       }
       if (!lastTransient || attempt === MAX_ATTEMPTS - 1) break;

--- a/packages/gateway/src/funded-ai-credential-manager.ts
+++ b/packages/gateway/src/funded-ai-credential-manager.ts
@@ -22,7 +22,7 @@ const AuthTokenSchema = z.string().min(32).max(512).regex(/^[A-Za-z0-9._~+/=-]+$
 export interface FundedAiRuntimeConfig {
   issueUrl: string;
   relayBaseUrl: string;
-  platformAuthToken: string;
+  runtimeAuthToken: string;
   identity: { ownerId: string; machineId: string; runtimeSlot: string };
   maxRunMs: number;
   requestTimeoutMs: number;
@@ -90,7 +90,7 @@ export function loadFundedAiRuntimeConfig(
     const platform = parseServiceUrl(env.PLATFORM_INTERNAL_URL, true);
     const relay = parseServiceUrl(env.MATRIX_FUNDED_AI_RELAY_URL, false);
     const handle = HandleSchema.parse(env.MATRIX_HANDLE);
-    const platformAuthToken = AuthTokenSchema.parse(env.MATRIX_AUTH_TOKEN);
+    const runtimeAuthToken = AuthTokenSchema.parse(env.MATRIX_FUNDED_AI_RUNTIME_TOKEN);
     const identity = {
       ownerId: IdentityValueSchema.parse(env.MATRIX_CLERK_USER_ID),
       machineId: IdentityValueSchema.parse(env.MATRIX_MACHINE_ID),
@@ -102,7 +102,7 @@ export function loadFundedAiRuntimeConfig(
         platform,
       ).toString(),
       relayBaseUrl: relay.toString().replace(/\/$/, ""),
-      platformAuthToken,
+      runtimeAuthToken,
       identity,
       maxRunMs: boundedInteger(
         env.MATRIX_FUNDED_AI_RUN_TIMEOUT_MS,
@@ -247,7 +247,7 @@ export function createFundedAiCredentialManager(
           redirect: "error",
           signal,
           headers: {
-            authorization: `Bearer ${config.platformAuthToken}`,
+            authorization: `Bearer ${config.runtimeAuthToken}`,
             "content-type": "application/json",
             accept: "application/json",
           },

--- a/packages/gateway/src/kernel-credentials.ts
+++ b/packages/gateway/src/kernel-credentials.ts
@@ -1,6 +1,10 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { z } from "zod/v4";
+import type {
+  FundedAiCredentialLease,
+  MatrixFundedCredentialProvider,
+} from "./funded-ai-credential-manager.js";
 
 export type KernelCredentialMode = "platform" | "api_key" | "claude_login";
 export const KernelCredentialAccessSourceIdSchema = z.enum([
@@ -29,6 +33,7 @@ interface KernelCredentialResolution {
   mode: KernelCredentialMode;
   env?: Record<string, string | undefined>;
   sources: KernelCredentialSources;
+  fundedRunTimeoutMs?: number;
 }
 
 function hasClaudeOauthConfig(value: unknown): boolean {
@@ -50,22 +55,29 @@ function observationForReadFailure(err: unknown): KernelCredentialObservationSta
   return err instanceof SyntaxError ? "invalid" : "unavailable";
 }
 
-function isFundedAccessEnabled(env: NodeJS.ProcessEnv): boolean {
-  const value = env.MATRIX_FUNDED_AI_ENABLED?.trim().toLowerCase();
-  return value === "1" || value === "true";
+function applyFundedCredential(
+  env: Record<string, string | undefined>,
+  lease: FundedAiCredentialLease,
+): void {
+  env.ANTHROPIC_API_KEY = lease.token;
+  env.ANTHROPIC_BASE_URL = lease.relayBaseUrl;
+  delete env.ANTHROPIC_AUTH_TOKEN;
+  delete env.MATRIX_AUTH_TOKEN;
+  delete env.UPGRADE_TOKEN;
+  delete env.MATRIX_CODE_PROXY_TOKEN;
+  delete env.AI_RELAY_CONTROL_TOKEN;
+  delete env.CF_AIG_AUTHORIZATION;
 }
 
 async function resolveKernelCredentials(
   homePath: string,
   baseEnv: NodeJS.ProcessEnv = process.env,
   requestedAccessSourceId?: KernelCredentialAccessSourceId,
+  fundedProvider?: MatrixFundedCredentialProvider,
+  acquireFundedCredential = true,
 ): Promise<KernelCredentialResolution> {
   const env = { ...baseEnv };
-  const matrixState = isFundedAccessEnabled(baseEnv)
-    && typeof baseEnv.ANTHROPIC_API_KEY === "string"
-    && baseEnv.ANTHROPIC_API_KEY.trim().length > 0
-    ? "ready" as const
-    : "disabled" as const;
+  const matrixState = fundedProvider?.enabled ? "ready" as const : "disabled" as const;
   let apiKeyState: KernelCredentialObservationState = "setup_required";
   let profileState: KernelCredentialObservationState = "setup_required";
   let ownerApiKey: string | undefined;
@@ -118,8 +130,10 @@ async function resolveKernelCredentials(
   };
 
   if (requestedAccessSourceId === "matrix_included") {
-    if (matrixState !== "ready") throw new Error("Selected AI access is unavailable");
-    return { mode: "platform", env, sources };
+    if (!fundedProvider) throw new Error("Selected AI access is unavailable");
+    const lease = await fundedProvider.getCredential();
+    applyFundedCredential(env, lease);
+    return { mode: "platform", env, sources, fundedRunTimeoutMs: lease.maxRunMs };
   }
   if (requestedAccessSourceId === "owner_anthropic_key") {
     if (ownerApiKey === undefined) throw new Error("Selected AI access is unavailable");
@@ -146,15 +160,46 @@ async function resolveKernelCredentials(
     delete env.ANTHROPIC_BASE_URL;
     return { mode: selectedMode, env, sources };
   }
+  if (fundedProvider && acquireFundedCredential) {
+    const lease = await fundedProvider.getCredential();
+    applyFundedCredential(env, lease);
+    return { mode: selectedMode, env, sources, fundedRunTimeoutMs: lease.maxRunMs };
+  }
   return { mode: selectedMode, sources };
+}
+
+export interface KernelCredentialLaunch {
+  env?: Record<string, string | undefined>;
+  fundedRunTimeoutMs?: number;
+}
+
+export async function buildKernelCredentialLaunch(
+  homePath: string,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+  requestedAccessSourceId?: KernelCredentialAccessSourceId,
+  fundedProvider?: MatrixFundedCredentialProvider,
+): Promise<KernelCredentialLaunch> {
+  const resolved = await resolveKernelCredentials(
+    homePath,
+    baseEnv,
+    requestedAccessSourceId,
+    fundedProvider,
+  );
+  return { env: resolved.env, fundedRunTimeoutMs: resolved.fundedRunTimeoutMs };
 }
 
 export async function buildKernelEnv(
   homePath: string,
   baseEnv: NodeJS.ProcessEnv = process.env,
   requestedAccessSourceId?: KernelCredentialAccessSourceId,
+  fundedProvider?: MatrixFundedCredentialProvider,
 ): Promise<Record<string, string | undefined> | undefined> {
-  return (await resolveKernelCredentials(homePath, baseEnv, requestedAccessSourceId)).env;
+  return (await buildKernelCredentialLaunch(
+    homePath,
+    baseEnv,
+    requestedAccessSourceId,
+    fundedProvider,
+  )).env;
 }
 
 export async function resolveKernelCredentialMode(homePath: string): Promise<KernelCredentialMode> {
@@ -164,6 +209,13 @@ export async function resolveKernelCredentialMode(homePath: string): Promise<Ker
 export async function resolveKernelCredentialSources(
   homePath: string,
   baseEnv: NodeJS.ProcessEnv = process.env,
+  fundedProvider?: MatrixFundedCredentialProvider,
 ): Promise<KernelCredentialSources> {
-  return (await resolveKernelCredentials(homePath, baseEnv)).sources;
+  return (await resolveKernelCredentials(
+    homePath,
+    baseEnv,
+    undefined,
+    fundedProvider,
+    false,
+  )).sources;
 }

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -13,6 +13,11 @@ import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import { installPostHogHonoErrorTracking, resolveOwnerTelemetryDistinctId } from "@matrix-os/observability";
 import { createDispatcher, type Dispatcher, type BatchEntry, type DispatchContext } from "./dispatcher.js";
+import {
+  createFundedAiCredentialManager,
+  loadFundedAiRuntimeConfig,
+} from "./funded-ai-credential-manager.js";
+import { buildKernelCredentialLaunch } from "./kernel-credentials.js";
 import { createAllowedOriginController } from "./allowed-origins.js";
 import { createAiGenerationRecorder } from "./ai-analytics.js";
 import { createWatcher, type Watcher } from "./watcher.js";
@@ -396,6 +401,10 @@ const MAX_MAIN_WS_CLIENTS = 100;
 export async function createGateway(config: GatewayConfig) {
   const { homePath: rawHomePath, port = 4000, syncReport } = config;
   const homePath = resolve(rawHomePath);
+  const fundedAiRuntimeConfig = loadFundedAiRuntimeConfig(process.env);
+  const fundedCredentialProvider = fundedAiRuntimeConfig
+    ? createFundedAiCredentialManager(fundedAiRuntimeConfig)
+    : undefined;
   const runningVersion = getVersion(
     config.runningVersion ? { version: config.runningVersion } : undefined,
   );
@@ -558,6 +567,7 @@ export async function createGateway(config: GatewayConfig) {
     maxTurns: config.maxTurns,
     spawnFn: config.spawnFn,
     onAiGeneration: recordAiGeneration,
+    fundedCredentialProvider,
   });
 
   const watcher: Watcher = createWatcher(homePath);
@@ -4159,6 +4169,7 @@ export async function createGateway(config: GatewayConfig) {
   await agentRuntimeServices.controller.reconcile();
   const aiProviderService = new AiProviderService({
     homePath,
+    fundedCredentialProvider,
     driverInventory: createProviderDriverInventoryReader({
       detectAgentInstallations: agentCredentialLauncher.detectAgentInstallations,
       runtimeSource: agentRuntimeServices.source,
@@ -4216,7 +4227,15 @@ export async function createGateway(config: GatewayConfig) {
       createHermesChatProviderAdapter({ homePath }),
     ];
     if (codingAgentProviders.some((provider) => provider.providerId === "claude")) {
-      canonicalAdapters.push(createClaudeChatProviderAdapter({ homePath }));
+      canonicalAdapters.push(createClaudeChatProviderAdapter({
+        homePath,
+        resolveCredentialLaunch: () => buildKernelCredentialLaunch(
+          homePath,
+          process.env,
+          undefined,
+          fundedCredentialProvider,
+        ),
+      }));
     }
     if (codingAgentThreadStore) {
       if (codingAgentProviders.some((provider) => provider.providerId === "codex")) {
@@ -4575,6 +4594,7 @@ export async function createGateway(config: GatewayConfig) {
       codingAgentWorkspaceRuntime = null;
       await agentRuntimeServices.controller.close();
       aiProviderService.close();
+      fundedCredentialProvider?.close();
       await codingAgentTurnLifecycle.shutdown();
       await codexEventBridge?.shutdown();
       codingAgentThreadStream?.shutdown();

--- a/packages/platform/src/customer-vps-cloud-init.ts
+++ b/packages/platform/src/customer-vps-cloud-init.ts
@@ -21,6 +21,8 @@ export interface CustomerHostConfig {
   posthogHost: string;
   posthogPublicHost: string;
   posthogApiHost: string;
+  fundedAiEnabled: string;
+  fundedAiRelayUrl: string;
   imageSource?: 'snapshot' | 'clean_image';
   targetBundleSha256?: string;
   snapshotSourceVersion?: string;

--- a/packages/platform/src/customer-vps-config.ts
+++ b/packages/platform/src/customer-vps-config.ts
@@ -67,24 +67,26 @@ function fundedAiRuntimeFromEnv(env: NodeJS.ProcessEnv): {
   if (!enabledFromEnv(env.MATRIX_FUNDED_AI_RUNTIME_ENABLED)) {
     return { fundedAiEnabled: false, fundedAiRelayUrl: '' };
   }
-  try {
-    const raw = env.MATRIX_FUNDED_AI_RELAY_URL ?? '';
-    if (!raw || raw.length > 2_048 || !/^[A-Za-z0-9:/._~%\[\]-]+$/.test(raw)) {
-      throw new Error('invalid');
-    }
-    const url = new URL(raw);
-    const loopback = ['127.0.0.1', 'localhost', '::1'].includes(url.hostname);
-    if ((url.protocol !== 'https:' && !(loopback && url.protocol === 'http:'))
-      || url.username || url.password || url.search || url.hash) {
-      throw new Error('invalid');
-    }
-    return {
-      fundedAiEnabled: true,
-      fundedAiRelayUrl: url.toString().replace(/\/$/, ''),
-    };
-  } catch {
+  const raw = env.MATRIX_FUNDED_AI_RELAY_URL ?? '';
+  if (!raw || raw.length > 2_048 || !/^[A-Za-z0-9:/._~%\[\]-]+$/.test(raw)) {
     throw new Error('Funded AI runtime is misconfigured');
   }
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch (error) {
+    if (!(error instanceof TypeError)) throw error;
+    throw new Error('Funded AI runtime is misconfigured');
+  }
+  const loopback = ['127.0.0.1', 'localhost', '::1'].includes(url.hostname);
+  if ((url.protocol !== 'https:' && !(loopback && url.protocol === 'http:'))
+    || url.username || url.password || url.search || url.hash) {
+    throw new Error('Funded AI runtime is misconfigured');
+  }
+  return {
+    fundedAiEnabled: true,
+    fundedAiRelayUrl: url.toString().replace(/\/$/, ''),
+  };
 }
 
 export function loadCustomerVpsConfig(env: NodeJS.ProcessEnv = process.env): CustomerVpsConfig {

--- a/packages/platform/src/customer-vps-config.ts
+++ b/packages/platform/src/customer-vps-config.ts
@@ -23,6 +23,8 @@ export interface CustomerVpsConfig {
   posthogHost: string;
   posthogPublicHost: string;
   posthogApiHost: string;
+  fundedAiEnabled: boolean;
+  fundedAiRelayUrl: string;
   provisionEtaSeconds: number;
   registrationTokenTtlMs: number;
   reconciliationBatchSize: number;
@@ -58,6 +60,33 @@ function enabledFromEnv(value: string | undefined): boolean {
   return value === 'true';
 }
 
+function fundedAiRuntimeFromEnv(env: NodeJS.ProcessEnv): {
+  fundedAiEnabled: boolean;
+  fundedAiRelayUrl: string;
+} {
+  if (!enabledFromEnv(env.MATRIX_FUNDED_AI_RUNTIME_ENABLED)) {
+    return { fundedAiEnabled: false, fundedAiRelayUrl: '' };
+  }
+  try {
+    const raw = env.MATRIX_FUNDED_AI_RELAY_URL ?? '';
+    if (!raw || raw.length > 2_048 || !/^[A-Za-z0-9:/._~%\[\]-]+$/.test(raw)) {
+      throw new Error('invalid');
+    }
+    const url = new URL(raw);
+    const loopback = ['127.0.0.1', 'localhost', '::1'].includes(url.hostname);
+    if ((url.protocol !== 'https:' && !(loopback && url.protocol === 'http:'))
+      || url.username || url.password || url.search || url.hash) {
+      throw new Error('invalid');
+    }
+    return {
+      fundedAiEnabled: true,
+      fundedAiRelayUrl: url.toString().replace(/\/$/, ''),
+    };
+  } catch {
+    throw new Error('Funded AI runtime is misconfigured');
+  }
+}
+
 export function loadCustomerVpsConfig(env: NodeJS.ProcessEnv = process.env): CustomerVpsConfig {
   const platformUrl = env.PLATFORM_PUBLIC_URL ?? `http://localhost:${env.PLATFORM_PORT ?? 9000}`;
   const imageVersion = env.CUSTOMER_VPS_IMAGE_VERSION ?? 'stable';
@@ -65,6 +94,7 @@ export function loadCustomerVpsConfig(env: NodeJS.ProcessEnv = process.env): Cus
   const snapshotArchitecture = GoldenSnapshotBuildArchitectureSchema.parse(
     env.GOLDEN_SNAPSHOT_ARCHITECTURE ?? 'x86',
   );
+  const fundedAiRuntime = fundedAiRuntimeFromEnv(env);
   return {
     hetznerApiToken: env.HETZNER_API_TOKEN ?? '',
     location: env.HETZNER_LOCATION ?? 'nbg1',
@@ -89,6 +119,7 @@ export function loadCustomerVpsConfig(env: NodeJS.ProcessEnv = process.env): Cus
     posthogHost: env.POSTHOG_HOST ?? env.NEXT_PUBLIC_POSTHOG_HOST ?? '',
     posthogPublicHost: env.NEXT_PUBLIC_POSTHOG_HOST ?? DEFAULT_POSTHOG_PUBLIC_HOST,
     posthogApiHost: env.NEXT_PUBLIC_POSTHOG_API_HOST ?? '',
+    ...fundedAiRuntime,
     provisionEtaSeconds: numberFromEnv(env.CUSTOMER_VPS_PROVISION_ETA_SECONDS, 90),
     // Clean-image bootstrap allows 15 minutes for the host bundle download
     // and 30 minutes for prerequisite preparation before Gateway can register.

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -252,6 +252,8 @@ const DEFAULT_CLOUD_INIT_TEMPLATE = [
   '      MATRIX_AUTH_TOKEN={{platformVerificationToken}}',
   '      MATRIX_FUNDED_AI_RUNTIME_TOKEN={{fundedAiRuntimeToken}}',
   '      MATRIX_CODE_PROXY_TOKEN={{platformVerificationToken}}',
+  '      MATRIX_FUNDED_AI_ENABLED={{fundedAiEnabled}}',
+  '      MATRIX_FUNDED_AI_RELAY_URL={{fundedAiRelayUrl}}',
   '      POSTHOG_TOKEN={{posthogToken}}',
   '      POSTHOG_PROJECT_TOKEN={{posthogProjectToken}}',
   '      POSTHOG_HOST={{posthogHost}}',
@@ -375,6 +377,8 @@ function buildHostConfig(
     posthogHost: config.posthogHost,
     posthogPublicHost: config.posthogPublicHost,
     posthogApiHost: config.posthogApiHost,
+    fundedAiEnabled: config.fundedAiEnabled ? 'true' : 'false',
+    fundedAiRelayUrl: config.fundedAiRelayUrl,
   };
 }
 

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -410,10 +410,13 @@ read_env_value() {
 }
 
 write_env() {
-  local auth_token code_token postgres_password
+  local auth_token code_token postgres_password funded_ai_enabled funded_ai_relay_url platform_internal_url
   auth_token="$(read_env_value /opt/matrix/env/host.env MATRIX_AUTH_TOKEN || random_secret)"
   code_token="$(read_env_value /opt/matrix/env/host.env MATRIX_CODE_PROXY_TOKEN || random_secret)"
   postgres_password="$(read_env_value /opt/matrix/env/postgres.env POSTGRES_PASSWORD || random_secret | tr '/+' 'ab')"
+  funded_ai_enabled="$(read_env_value /opt/matrix/env/host.env MATRIX_FUNDED_AI_ENABLED || printf 'false')"
+  funded_ai_relay_url="$(read_env_value /opt/matrix/env/host.env MATRIX_FUNDED_AI_RELAY_URL || true)"
+  platform_internal_url="$(read_env_value /opt/matrix/env/host.env PLATFORM_INTERNAL_URL || true)"
 
   cat >/opt/matrix/env/postgres.env <<EOF
 POSTGRES_DB=matrix
@@ -435,6 +438,9 @@ MATRIX_IMAGE_VERSION=${DEFAULT_CHANNEL}
 MATRIX_UPDATE_CHANNEL=${DEFAULT_CHANNEL}
 MATRIX_AUTH_TOKEN=${auth_token}
 MATRIX_CODE_PROXY_TOKEN=${code_token}
+MATRIX_FUNDED_AI_ENABLED=${funded_ai_enabled}
+MATRIX_FUNDED_AI_RELAY_URL=${funded_ai_relay_url}
+PLATFORM_INTERNAL_URL=${platform_internal_url}
 MATRIX_HOST_BUNDLE_URL=${MATRIX_HOST_BUNDLE_URL}
 MATRIX_HOME=${MATRIX_HOME_DIR}
 DATABASE_URL=postgresql://matrix:${postgres_password}@127.0.0.1:5432/matrix

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -410,12 +410,13 @@ read_env_value() {
 }
 
 write_env() {
-  local auth_token code_token postgres_password funded_ai_enabled funded_ai_relay_url platform_internal_url
+  local auth_token code_token postgres_password funded_ai_enabled funded_ai_relay_url funded_ai_runtime_token platform_internal_url
   auth_token="$(read_env_value /opt/matrix/env/host.env MATRIX_AUTH_TOKEN || random_secret)"
   code_token="$(read_env_value /opt/matrix/env/host.env MATRIX_CODE_PROXY_TOKEN || random_secret)"
   postgres_password="$(read_env_value /opt/matrix/env/postgres.env POSTGRES_PASSWORD || random_secret | tr '/+' 'ab')"
   funded_ai_enabled="$(read_env_value /opt/matrix/env/host.env MATRIX_FUNDED_AI_ENABLED || printf 'false')"
   funded_ai_relay_url="$(read_env_value /opt/matrix/env/host.env MATRIX_FUNDED_AI_RELAY_URL || true)"
+  funded_ai_runtime_token="$(read_env_value /opt/matrix/env/host.env MATRIX_FUNDED_AI_RUNTIME_TOKEN || true)"
   platform_internal_url="$(read_env_value /opt/matrix/env/host.env PLATFORM_INTERNAL_URL || true)"
 
   cat >/opt/matrix/env/postgres.env <<EOF
@@ -440,6 +441,7 @@ MATRIX_AUTH_TOKEN=${auth_token}
 MATRIX_CODE_PROXY_TOKEN=${code_token}
 MATRIX_FUNDED_AI_ENABLED=${funded_ai_enabled}
 MATRIX_FUNDED_AI_RELAY_URL=${funded_ai_relay_url}
+MATRIX_FUNDED_AI_RUNTIME_TOKEN=${funded_ai_runtime_token}
 PLATFORM_INTERNAL_URL=${platform_internal_url}
 MATRIX_HOST_BUNDLE_URL=${MATRIX_HOST_BUNDLE_URL}
 MATRIX_HOME=${MATRIX_HOME_DIR}

--- a/specs/118-ai-gateway-provider-auth/contracts/relay.md
+++ b/specs/118-ai-gateway-provider-auth/contracts/relay.md
@@ -14,7 +14,14 @@ The central relay is the only holder of the funded upstream credential. A custom
 
 ## Implementation checkpoint
 
-The first PR implements the fixed Cloudflare transport, a distinct funded-only HMAC audience, explicit model/path/field/header policy, bounded request/response streaming, global and per-runtime admission, and shutdown cancellation behind a startup feature flag. Owner identity, expiry, per-runtime revocation, recurring eligibility refresh, request correlation, token-aware reservation, and production VPS issuance described below are target requirements for the subsequent activation slices; funded access remains disabled until they land.
+The control plane now issues short-lived, opaque, runtime-scoped credentials
+from an authenticated handle route while retaining only token hashes centrally.
+The owner gateway validates the returned owner/machine/runtime identity, keeps
+the credential in memory, refreshes with singleflight and bounded jitter/backoff,
+and refuses credentials too close to expiry. Customer hosts receive no relay
+service token or Cloudflare credential. The Cloudflare forwarder and production
+activation remain disabled until reservation/start/settlement and relay policy
+enforcement are wired end to end.
 
 ## Accepted Anthropic surface
 

--- a/specs/118-ai-gateway-provider-auth/sdk-verification.md
+++ b/specs/118-ai-gateway-provider-auth/sdk-verification.md
@@ -64,6 +64,7 @@ times.
 | Cloudflare Anthropic streaming | Protocol pass; live Unified Billing blocked | The fake provider proves the Agent SDK's Anthropic streaming and required beta-header behavior through the Matrix-compatible boundary. No Cloudflare gateway credential was available for an external inference call. |
 | Cloudflare privacy / metadata | Contract pass | Funded requests must send `cf-aig-collect-log-payload: false` and `cf-aig-zdr: true`; metadata is allowlisted, content-free, and capped at Cloudflare's five-entry limit. |
 | Cloudflare spend controls | Documentation verified; live enforcement blocked | Gateway rules can scope budgets by model/provider/custom metadata, including split-by-user. They are eventually consistent and are not Matrix's hard customer balance. Matrix remains authoritative for eligibility, add-on credit, and hard admission. |
+| Runtime credential refresh (`0.3.240`) | Pass with bounded-run injection | A loopback Anthropic fixture returned `401` on the first Messages call. `settings.apiKeyHelper` ran again and the same V1 `query()` retried with the replacement token. The undocumented `getHostAuthToken` callback was not invoked for either a normal API-key environment or a host-managed custom environment. Matrix therefore acquires one short-lived runtime credential in the gateway, injects it only into a bounded Agent SDK/Claude CLI run, and reacquires for the next run when the cached credential is inside its safety window. This preserves one in-memory singleflight path instead of executing an external key-helper command with separate cache state. |
 
 ## Frozen provider contracts
 
@@ -104,3 +105,14 @@ times.
   models receive neither field.
 - Results normalize cumulative `modelUsage`, and no-fallback refusals reach the
   shell as a safe generic terminal error.
+- Matrix-funded runtime credentials are fetched from the authenticated,
+  handle-scoped platform endpoint with a five-second acquisition deadline,
+  bounded retry/backoff, response-size cap, exact returned-identity checks,
+  singleflight refresh, expiry jitter, and a near-expiry refusal. The opaque
+  credential is held only in gateway memory and is cleared on shutdown.
+- Funded kernel and Claude CLI runs are capped at ten minutes, which leaves a
+  one-minute safety margin inside the default fifteen-minute credential. There
+  is no fallback to a legacy static Anthropic key or indefinite HMAC relay key.
+- Customer hosts receive only the relay URL, enable flag, and their existing
+  scoped platform verification token in the protected host environment. Relay
+  service tokens and Cloudflare credentials are never provisioned to the VPS.

--- a/tests/gateway/ai-provider-service.test.ts
+++ b/tests/gateway/ai-provider-service.test.ts
@@ -7,8 +7,19 @@ import {
   AiProviderService,
   type AiProviderHealthProbe,
 } from "../../packages/gateway/src/ai-providers/service.js";
+import type { MatrixFundedCredentialProvider } from "../../packages/gateway/src/funded-ai-credential-manager.js";
 
 const NOW = new Date("2026-08-29T21:00:00.000Z");
+
+function fundedProvider(): MatrixFundedCredentialProvider {
+  return {
+    enabled: true,
+    maxRunMs: 600_000,
+    getCredential: async () => { throw new Error("readiness must not acquire a credential"); },
+    invalidate: () => {},
+    close: () => {},
+  };
+}
 
 describe("AiProviderService", () => {
   let homePath: string;
@@ -35,6 +46,9 @@ describe("AiProviderService", () => {
         ANTHROPIC_API_KEY: options.platformKey,
         MATRIX_FUNDED_AI_ENABLED: options.fundedEnabled === false ? "0" : "1",
       } : {},
+      fundedCredentialProvider: options.platformKey && options.fundedEnabled !== false
+        ? fundedProvider()
+        : undefined,
       now: () => NOW,
       healthProbe: options.healthProbe,
       healthTimeoutMs: options.healthTimeoutMs,

--- a/tests/gateway/chat-claude-provider.test.ts
+++ b/tests/gateway/chat-claude-provider.test.ts
@@ -330,6 +330,42 @@ describe("Claude canonical Chat Provider adapter", () => {
     });
   });
 
+  it("uses the rotating funded credential and its shorter run deadline", async () => {
+    const stdout = new FakeStream();
+    const stderr = new FakeStream();
+    const process = new EventEmitter() as EventEmitter & {
+      stdout: FakeStream;
+      stderr: FakeStream;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    process.stdout = stdout;
+    process.stderr = stderr;
+    process.kill = vi.fn(() => queueMicrotask(() => process.emit("exit", null, "SIGTERM")));
+    const spawnFn = vi.fn(() => process);
+    const adapter = createClaudeChatProviderAdapter({
+      homePath: "/home/matrix/home",
+      spawnFn,
+      timeoutMs: 60_000,
+      resolveCredentialLaunch: vi.fn(async () => ({
+        env: {
+          ANTHROPIC_API_KEY: `sk-matrix-funded-credential_123.${"A".repeat(43)}`,
+          ANTHROPIC_BASE_URL: "https://relay.matrix-os.com",
+        },
+        fundedRunTimeoutMs: 10,
+      })),
+    });
+
+    const events = [];
+    for await (const event of adapter.start(baseInput)) events.push(event);
+
+    expect(spawnFn.mock.calls[0]![2].env).toMatchObject({
+      ANTHROPIC_API_KEY: expect.stringMatching(/^sk-matrix-funded-/),
+      ANTHROPIC_BASE_URL: "https://relay.matrix-os.com",
+    });
+    expect(process.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(events.at(-1)).toMatchObject({ type: "run.completed", outcome: "failed" });
+  });
+
   it("resumes the persisted Claude session and maps full access explicitly", async () => {
     const spawnFn = vi.fn(() => child([
       JSON.stringify({ type: "result", subtype: "success", is_error: false, result: "resumed", session_id: "claude_session" }),

--- a/tests/gateway/chat-provider-catalog.test.ts
+++ b/tests/gateway/chat-provider-catalog.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentRuntimeSource } from "../../packages/gateway/src/agent-config/service.js";
 import { AiProviderService } from "../../packages/gateway/src/ai-providers/service.js";
+import type { MatrixFundedCredentialProvider } from "../../packages/gateway/src/funded-ai-credential-manager.js";
 import {
   ProviderCatalogUnavailableError,
   createChatProviderCatalogService,
@@ -101,6 +102,16 @@ function codingRegistry(
   };
 }
 
+function fundedProvider(): MatrixFundedCredentialProvider {
+  return {
+    enabled: true,
+    maxRunMs: 600_000,
+    getCredential: async () => { throw new Error("catalog must not acquire a credential"); },
+    invalidate: () => {},
+    close: () => {},
+  };
+}
+
 describe("canonical Chat Provider catalog", () => {
   it("projects runnable Agent SDK instances from the canonical funding and account snapshot", async () => {
     const homePath = mkdtempSync(join(tmpdir(), "chat-provider-kernel-"));
@@ -112,6 +123,7 @@ describe("canonical Chat Provider catalog", () => {
         ANTHROPIC_API_KEY: "platform-secret",
         MATRIX_FUNDED_AI_ENABLED: "1",
       },
+      fundedCredentialProvider: fundedProvider(),
     });
     try {
       const service = createChatProviderCatalogService({

--- a/tests/gateway/dispatcher-overrides.test.ts
+++ b/tests/gateway/dispatcher-overrides.test.ts
@@ -7,6 +7,7 @@ import {
   createDispatcher,
   type SpawnFn,
 } from "../../packages/gateway/src/dispatcher.js";
+import type { MatrixFundedCredentialProvider } from "../../packages/gateway/src/funded-ai-credential-manager.js";
 
 const temporaryHomePaths: string[] = [];
 
@@ -93,6 +94,50 @@ describe("dispatcher per-message kernel overrides", () => {
     expect(configs[0].env?.HOME).toBe(homePath);
     expect(configs[0].env?.ANTHROPIC_API_KEY).toBeUndefined();
     expect(configs[1].env?.ANTHROPIC_API_KEY).toBe("sk-ant-owner-key");
+  });
+
+  it("injects rotating Matrix credentials and aborts the funded run at its bounded deadline", async () => {
+      const provider: MatrixFundedCredentialProvider = {
+        enabled: true,
+        maxRunMs: 250,
+        getCredential: vi.fn(async () => ({
+          token: `sk-matrix-funded-credential_123.${"A".repeat(43)}`,
+          tokenId: "credential_123",
+          expiresAt: "2099-01-01T00:00:00.000Z",
+          relayBaseUrl: "https://relay.matrix-os.com",
+          maxRunMs: 250,
+        })),
+        invalidate: vi.fn(),
+        close: vi.fn(),
+      };
+      const seen: KernelConfig[] = [];
+      const spawn = vi.fn<SpawnFn>(async function* (_message, config, controller) {
+        seen.push(config);
+        await new Promise<void>((_resolve, reject) => {
+          controller?.signal.addEventListener("abort", () => reject(new Error("run aborted")), { once: true });
+        });
+        yield resultEvent();
+      });
+      const dispatcher = createDispatcher({
+        homePath: makeHomePath(),
+        spawnFn: spawn,
+        maxConcurrency: 1,
+        fundedCredentialProvider: provider,
+      });
+      const dispatched = dispatcher.dispatch(
+        "use included AI",
+        undefined,
+        () => {},
+        undefined,
+        undefined,
+        { accessSourceId: "matrix_included" },
+      );
+      await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(1));
+      expect(seen[0].env).toMatchObject({
+        ANTHROPIC_API_KEY: expect.stringMatching(/^sk-matrix-funded-/),
+        ANTHROPIC_BASE_URL: "https://relay.matrix-os.com",
+      });
+      await expect(dispatched).rejects.toThrow("run aborted");
   });
 
   it("passes a validated working directory to only the selected queued dispatch", async () => {

--- a/tests/gateway/funded-ai-credential-manager.test.ts
+++ b/tests/gateway/funded-ai-credential-manager.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   FundedAiCredentialError,
+  FundedAiCredentialUnexpectedError,
   FundedAiRuntimeConfigError,
   createFundedAiCredentialManager,
   loadFundedAiRuntimeConfig,
@@ -164,6 +165,32 @@ describe("funded AI runtime credential manager", () => {
     const error = await denied.getCredential().catch((caught: unknown) => caught);
     expect(error).toBeInstanceOf(FundedAiCredentialError);
     expect(String(error)).not.toContain("owner details");
+  });
+
+  it("does not disguise unexpected response-processing failures as transient service errors", async () => {
+    const unexpected = new RangeError("private response reader invariant");
+    const fetchFn = vi.fn(async () => new Response(new ReadableStream({
+      pull() {
+        throw unexpected;
+      },
+    }), { status: 200 }));
+    const sleep = vi.fn(async () => {});
+    const manager = createFundedAiCredentialManager(loadFundedAiRuntimeConfig(runtimeEnv())!, {
+      fetchFn,
+      now: () => NOW,
+      random: () => 0,
+      sleep,
+    });
+
+    const error = await manager.getCredential().catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(FundedAiCredentialUnexpectedError);
+    expect(error).toMatchObject({
+      message: "Matrix AI credential processing failed",
+      cause: unexpected,
+    });
+    expect(String(error)).not.toContain("private response reader invariant");
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
   });
 
   it("uses a request deadline and refuses use after close", async () => {

--- a/tests/gateway/funded-ai-credential-manager.test.ts
+++ b/tests/gateway/funded-ai-credential-manager.test.ts
@@ -41,6 +41,7 @@ function issueResponse(expiresAt = new Date(NOW + 15 * 60_000).toISOString()) {
       globalRevision: 1,
       runtimeRevision: 1,
       allowedModelIds: ["anthropic/claude-sonnet-5"],
+      monthlyBudgetMicrousd: 5_000_000,
       checkedAt: new Date(NOW).toISOString(),
       staleAfter: new Date(NOW + 60_000).toISOString(),
     },

--- a/tests/gateway/funded-ai-credential-manager.test.ts
+++ b/tests/gateway/funded-ai-credential-manager.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   FundedAiCredentialError,
+  FundedAiRuntimeConfigError,
   createFundedAiCredentialManager,
   loadFundedAiRuntimeConfig,
 } from "../../packages/gateway/src/funded-ai-credential-manager.js";
@@ -54,8 +55,11 @@ describe("funded AI runtime credential manager", () => {
 
   it("is disabled by default and fails startup closed for partial or unsafe configuration", () => {
     expect(loadFundedAiRuntimeConfig({})).toBeUndefined();
-    expect(() => loadFundedAiRuntimeConfig(runtimeEnv({ MATRIX_FUNDED_AI_RUNTIME_TOKEN: "short" })))
-      .toThrow("Funded AI runtime is misconfigured");
+    const invalidToken = () => loadFundedAiRuntimeConfig(runtimeEnv({
+      MATRIX_FUNDED_AI_RUNTIME_TOKEN: "short",
+    }));
+    expect(invalidToken).toThrow(FundedAiRuntimeConfigError);
+    expect(invalidToken).toThrow("Funded AI runtime is misconfigured");
     expect(() => loadFundedAiRuntimeConfig(runtimeEnv({ MATRIX_FUNDED_AI_RUNTIME_TOKEN: undefined })))
       .toThrow("Funded AI runtime is misconfigured");
     expect(() => loadFundedAiRuntimeConfig(runtimeEnv({ MATRIX_FUNDED_AI_RELAY_URL: "http://relay.example" })))

--- a/tests/gateway/funded-ai-credential-manager.test.ts
+++ b/tests/gateway/funded-ai-credential-manager.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  FundedAiCredentialError,
+  createFundedAiCredentialManager,
+  loadFundedAiRuntimeConfig,
+} from "../../packages/gateway/src/funded-ai-credential-manager.js";
+
+const TOKEN_ID = "credential_123";
+const TOKEN = `sk-matrix-funded-${TOKEN_ID}.${"A".repeat(43)}`;
+const NOW = Date.parse("2026-08-30T10:00:00.000Z");
+
+function runtimeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    MATRIX_FUNDED_AI_ENABLED: "true",
+    MATRIX_FUNDED_AI_RELAY_URL: "https://relay.matrix-os.com",
+    PLATFORM_INTERNAL_URL: "https://platform.matrix-os.com",
+    MATRIX_AUTH_TOKEN: "p".repeat(64),
+    MATRIX_HANDLE: "alice",
+    MATRIX_CLERK_USER_ID: "user_123",
+    MATRIX_MACHINE_ID: "machine_123",
+    MATRIX_RUNTIME_SLOT: "primary",
+    MATRIX_FUNDED_AI_RUN_TIMEOUT_MS: "600000",
+    ...overrides,
+  };
+}
+
+function issueResponse(expiresAt = new Date(NOW + 15 * 60_000).toISOString()) {
+  return {
+    contractVersion: 1,
+    credential: {
+      token: TOKEN,
+      tokenId: TOKEN_ID,
+      audience: "matrix-funded-relay",
+      scope: "ai:invoke",
+      issuedAt: new Date(NOW).toISOString(),
+      expiresAt,
+    },
+    identity: { ownerId: "user_123", machineId: "machine_123", runtimeSlot: "primary" },
+    policy: {
+      enabled: true,
+      globalRevision: 1,
+      runtimeRevision: 1,
+      allowedModelIds: ["anthropic/claude-sonnet-5"],
+      checkedAt: new Date(NOW).toISOString(),
+      staleAfter: new Date(NOW + 60_000).toISOString(),
+    },
+  };
+}
+
+describe("funded AI runtime credential manager", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("is disabled by default and fails startup closed for partial or unsafe configuration", () => {
+    expect(loadFundedAiRuntimeConfig({})).toBeUndefined();
+    expect(() => loadFundedAiRuntimeConfig(runtimeEnv({ MATRIX_AUTH_TOKEN: "short" })))
+      .toThrow("Funded AI runtime is misconfigured");
+    expect(() => loadFundedAiRuntimeConfig(runtimeEnv({ MATRIX_FUNDED_AI_RELAY_URL: "http://relay.example" })))
+      .toThrow("Funded AI runtime is misconfigured");
+    expect(() => loadFundedAiRuntimeConfig(runtimeEnv({ PLATFORM_INTERNAL_URL: "https://user:pass@example.com" })))
+      .toThrow("Funded AI runtime is misconfigured");
+    expect(() => loadFundedAiRuntimeConfig(runtimeEnv({
+      MATRIX_FUNDED_AI_RELAY_URL: "https://relay.example/path;touch-pwned",
+    }))).toThrow("Funded AI runtime is misconfigured");
+  });
+
+  it("derives the issue endpoint from the validated local handle", () => {
+    const config = loadFundedAiRuntimeConfig(runtimeEnv());
+    expect(config).toMatchObject({
+      issueUrl: "https://platform.matrix-os.com/internal/containers/alice/ai/funded-credential",
+      relayBaseUrl: "https://relay.matrix-os.com",
+      identity: { ownerId: "user_123", machineId: "machine_123", runtimeSlot: "primary" },
+      maxRunMs: 600_000,
+    });
+  });
+
+  it("singleflights acquisition, caches only a sufficiently fresh token, and can invalidate it", async () => {
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify(issueResponse()), { status: 200 }));
+    const config = loadFundedAiRuntimeConfig(runtimeEnv())!;
+    const manager = createFundedAiCredentialManager(config, {
+      fetchFn,
+      now: () => NOW,
+      random: () => 0,
+      sleep: async () => {},
+    });
+
+    const [first, second] = await Promise.all([
+      manager.getCredential(),
+      manager.getCredential(),
+    ]);
+    expect(first).toEqual(second);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledWith(config.issueUrl, expect.objectContaining({
+      method: "POST",
+      redirect: "error",
+      headers: expect.objectContaining({ authorization: `Bearer ${"p".repeat(64)}` }),
+    }));
+
+    await manager.getCredential();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    manager.invalidate(TOKEN_ID);
+    await manager.getCredential();
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects mismatched identity, disabled policy, oversized bodies, and near-expiry credentials safely", async () => {
+    const cases: unknown[] = [
+      { ...issueResponse(), identity: { ownerId: "spoof", machineId: "machine_123", runtimeSlot: "primary" } },
+      { ...issueResponse(), policy: { ...issueResponse().policy, enabled: false, allowedModelIds: [] } },
+      issueResponse(new Date(NOW + 60_000).toISOString()),
+      "x".repeat(20_000),
+    ];
+    for (const value of cases) {
+      const fetchFn = vi.fn(async () => new Response(
+        typeof value === "string" ? value : JSON.stringify(value),
+        { status: 200 },
+      ));
+      const manager = createFundedAiCredentialManager(loadFundedAiRuntimeConfig(runtimeEnv())!, {
+        fetchFn,
+        now: () => NOW,
+        random: () => 0,
+        sleep: async () => {},
+      });
+      await expect(manager.getCredential()).rejects.toEqual(expect.objectContaining({
+        name: "FundedAiCredentialError",
+        message: "Matrix AI is temporarily unavailable",
+      }));
+    }
+  });
+
+  it("retries only transient failures with bounded backoff and never exposes raw errors", async () => {
+    const sleep = vi.fn(async () => {});
+    const fetchFn = vi.fn()
+      .mockRejectedValueOnce(new Error("connect ECONNREFUSED secret.internal"))
+      .mockResolvedValueOnce(new Response(JSON.stringify(issueResponse()), { status: 200 }));
+    const manager = createFundedAiCredentialManager(loadFundedAiRuntimeConfig(runtimeEnv())!, {
+      fetchFn,
+      now: () => NOW,
+      random: () => 0,
+      sleep,
+    });
+    await expect(manager.getCredential()).resolves.toMatchObject({ tokenId: TOKEN_ID });
+    expect(sleep).toHaveBeenCalledWith(100, expect.any(AbortSignal));
+
+    const denied = createFundedAiCredentialManager(loadFundedAiRuntimeConfig(runtimeEnv())!, {
+      fetchFn: vi.fn(async () => new Response("owner details", { status: 403 })),
+      now: () => NOW,
+      random: () => 0,
+      sleep: async () => {},
+    });
+    const error = await denied.getCredential().catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(FundedAiCredentialError);
+    expect(String(error)).not.toContain("owner details");
+  });
+
+  it("uses a request deadline and refuses use after close", async () => {
+    const deadline = new AbortController();
+    const fetchFn = vi.fn((_url: string, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+      }));
+    const manager = createFundedAiCredentialManager(loadFundedAiRuntimeConfig(runtimeEnv())!, {
+      fetchFn,
+      now: () => NOW,
+      random: () => 0,
+      makeTimeoutSignal: () => deadline.signal,
+    });
+    const pending = manager.getCredential();
+    deadline.abort();
+    await expect(pending).rejects.toBeInstanceOf(FundedAiCredentialError);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    manager.close();
+    await expect(manager.getCredential()).rejects.toBeInstanceOf(FundedAiCredentialError);
+  });
+});

--- a/tests/gateway/funded-ai-credential-manager.test.ts
+++ b/tests/gateway/funded-ai-credential-manager.test.ts
@@ -74,11 +74,17 @@ describe("funded AI runtime credential manager", () => {
   it("derives the issue endpoint from the validated local handle", () => {
     const config = loadFundedAiRuntimeConfig(runtimeEnv());
     expect(config).toMatchObject({
-      issueUrl: "https://platform.matrix-os.com/internal/containers/alice/ai/funded-credential",
+      issueUrl: "https://platform.matrix-os.com/internal/containers/alice/ai/funded-credential?runtimeSlot=primary",
       relayBaseUrl: "https://relay.matrix-os.com",
       identity: { ownerId: "user_123", machineId: "machine_123", runtimeSlot: "primary" },
       maxRunMs: 600_000,
     });
+
+    expect(loadFundedAiRuntimeConfig(runtimeEnv({ MATRIX_RUNTIME_SLOT: "staging" })))
+      .toMatchObject({
+        issueUrl: "https://platform.matrix-os.com/internal/containers/alice/ai/funded-credential?runtimeSlot=staging",
+        identity: { runtimeSlot: "staging" },
+      });
   });
 
   it("singleflights acquisition, caches only a sufficiently fresh token, and can invalidate it", async () => {

--- a/tests/gateway/funded-ai-credential-manager.test.ts
+++ b/tests/gateway/funded-ai-credential-manager.test.ts
@@ -14,7 +14,8 @@ function runtimeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     MATRIX_FUNDED_AI_ENABLED: "true",
     MATRIX_FUNDED_AI_RELAY_URL: "https://relay.matrix-os.com",
     PLATFORM_INTERNAL_URL: "https://platform.matrix-os.com",
-    MATRIX_AUTH_TOKEN: "p".repeat(64),
+    MATRIX_AUTH_TOKEN: "legacy-stable-token-must-not-authorize-funded-ai",
+    MATRIX_FUNDED_AI_RUNTIME_TOKEN: "p".repeat(64),
     MATRIX_HANDLE: "alice",
     MATRIX_CLERK_USER_ID: "user_123",
     MATRIX_MACHINE_ID: "machine_123",
@@ -53,7 +54,9 @@ describe("funded AI runtime credential manager", () => {
 
   it("is disabled by default and fails startup closed for partial or unsafe configuration", () => {
     expect(loadFundedAiRuntimeConfig({})).toBeUndefined();
-    expect(() => loadFundedAiRuntimeConfig(runtimeEnv({ MATRIX_AUTH_TOKEN: "short" })))
+    expect(() => loadFundedAiRuntimeConfig(runtimeEnv({ MATRIX_FUNDED_AI_RUNTIME_TOKEN: "short" })))
+      .toThrow("Funded AI runtime is misconfigured");
+    expect(() => loadFundedAiRuntimeConfig(runtimeEnv({ MATRIX_FUNDED_AI_RUNTIME_TOKEN: undefined })))
       .toThrow("Funded AI runtime is misconfigured");
     expect(() => loadFundedAiRuntimeConfig(runtimeEnv({ MATRIX_FUNDED_AI_RELAY_URL: "http://relay.example" })))
       .toThrow("Funded AI runtime is misconfigured");

--- a/tests/gateway/kernel-credentials.test.ts
+++ b/tests/gateway/kernel-credentials.test.ts
@@ -3,10 +3,28 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  buildKernelCredentialLaunch,
   buildKernelEnv,
   resolveKernelCredentialMode,
   resolveKernelCredentialSources,
 } from "../../packages/gateway/src/kernel-credentials.js";
+import type { MatrixFundedCredentialProvider } from "../../packages/gateway/src/funded-ai-credential-manager.js";
+
+function fundedProvider(): MatrixFundedCredentialProvider {
+  return {
+    enabled: true,
+    maxRunMs: 600_000,
+    getCredential: async () => ({
+      token: `sk-matrix-funded-credential_123.${"A".repeat(43)}`,
+      tokenId: "credential_123",
+      expiresAt: "2026-08-30T10:15:00.000Z",
+      relayBaseUrl: "https://relay.matrix-os.com",
+      maxRunMs: 600_000,
+    }),
+    invalidate: () => {},
+    close: () => {},
+  };
+}
 
 describe("kernel credential resolution", () => {
   let homePath: string;
@@ -71,10 +89,50 @@ describe("kernel credential resolution", () => {
         MATRIX_FUNDED_AI_ENABLED: "1",
       },
       "matrix_included",
+      fundedProvider(),
     )).resolves.toMatchObject({
-      ANTHROPIC_API_KEY: "platform-key",
-      ANTHROPIC_BASE_URL: "https://relay.example.com",
+      ANTHROPIC_API_KEY: expect.stringMatching(/^sk-matrix-funded-/),
+      ANTHROPIC_BASE_URL: "https://relay.matrix-os.com",
     });
+  });
+
+  it("never treats a static platform key as Matrix-funded access", async () => {
+    const env = {
+      ANTHROPIC_API_KEY: "legacy-platform-key",
+      ANTHROPIC_BASE_URL: "https://legacy.example",
+      MATRIX_FUNDED_AI_ENABLED: "1",
+    };
+    await expect(buildKernelEnv(homePath, env, "matrix_included"))
+      .rejects.toThrow("Selected AI access is unavailable");
+    await expect(resolveKernelCredentialSources(homePath, env)).resolves.toMatchObject({
+      matrixIncluded: { state: "disabled" },
+    });
+  });
+
+  it("returns a bounded funded launch without exposing token metadata in source snapshots", async () => {
+    const provider = fundedProvider();
+    const launch = await buildKernelCredentialLaunch(homePath, {
+      MATRIX_AUTH_TOKEN: "platform-auth-secret",
+      UPGRADE_TOKEN: "upgrade-secret",
+      MATRIX_CODE_PROXY_TOKEN: "code-proxy-secret",
+      AI_RELAY_CONTROL_TOKEN: "relay-control-secret",
+      CF_AIG_AUTHORIZATION: "cloudflare-secret",
+    }, "matrix_included", provider);
+    expect(launch).toMatchObject({
+      fundedRunTimeoutMs: 600_000,
+      env: {
+        ANTHROPIC_API_KEY: expect.stringMatching(/^sk-matrix-funded-/),
+        ANTHROPIC_BASE_URL: "https://relay.matrix-os.com",
+      },
+    });
+    expect(launch.env).not.toHaveProperty("MATRIX_AUTH_TOKEN");
+    expect(launch.env).not.toHaveProperty("UPGRADE_TOKEN");
+    expect(launch.env).not.toHaveProperty("MATRIX_CODE_PROXY_TOKEN");
+    expect(launch.env).not.toHaveProperty("AI_RELAY_CONTROL_TOKEN");
+    expect(launch.env).not.toHaveProperty("CF_AIG_AUTHORIZATION");
+    const sources = await resolveKernelCredentialSources(homePath, {}, provider);
+    expect(sources.matrixIncluded.state).toBe("ready");
+    expect(JSON.stringify(sources)).not.toContain("credential_123");
   });
 
   it("honors an explicit owner source and fails closed when it is unavailable", async () => {
@@ -105,7 +163,7 @@ describe("kernel credential resolution", () => {
     const sources = await resolveKernelCredentialSources(homePath, {
       ANTHROPIC_API_KEY: "platform-key",
       MATRIX_FUNDED_AI_ENABLED: "1",
-    });
+    }, fundedProvider());
 
     expect(sources).toEqual({
       selectedMode: "api_key",

--- a/tests/gateway/settings-agent-summary.test.ts
+++ b/tests/gateway/settings-agent-summary.test.ts
@@ -6,6 +6,17 @@ import { Hono } from "hono";
 import { createSettingsRoutes } from "../../packages/gateway/src/routes/settings.js";
 import { buildAgentSettingsView } from "../../packages/gateway/src/agent-config/service.js";
 import { AiProviderService } from "../../packages/gateway/src/ai-providers/service.js";
+import type { MatrixFundedCredentialProvider } from "../../packages/gateway/src/funded-ai-credential-manager.js";
+
+function fundedProvider(): MatrixFundedCredentialProvider {
+  return {
+    enabled: true,
+    maxRunMs: 600_000,
+    getCredential: async () => { throw new Error("settings must not acquire a credential"); },
+    invalidate: () => {},
+    close: () => {},
+  };
+}
 
 function stubChannelManager() {
   return {
@@ -279,6 +290,7 @@ describe("current and legacy Anthropic models", () => {
         ANTHROPIC_API_KEY: "platform-secret",
         MATRIX_FUNDED_AI_ENABLED: "1",
       },
+      fundedCredentialProvider: fundedProvider(),
     });
     try {
       const providerSnapshot = await providerService.getSnapshot();

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -63,6 +63,8 @@ describe('platform/customer-vps-cloud-init', () => {
     posthogHost: 'https://eu.i.posthog.com',
     posthogPublicHost: 'https://eu.posthog.com',
     posthogApiHost: '/relay',
+    fundedAiEnabled: 'true',
+    fundedAiRelayUrl: 'https://relay.matrix-os.com',
   };
 
   function runRestoreWithFakeMatrixctl(
@@ -225,6 +227,10 @@ exit 99
     expect(rendered).not.toContain('MATRIX_CODE_PROXY_TOKEN=\n');
     expect(rendered).not.toContain('MATRIX_FUNDED_AI_RUNTIME_TOKEN=\n');
     expect(rendered).not.toContain('PLATFORM_INTERNAL_URL=\n');
+    expect(rendered).toContain('MATRIX_FUNDED_AI_ENABLED=true');
+    expect(rendered).toContain('MATRIX_FUNDED_AI_RELAY_URL=https://relay.matrix-os.com');
+    expect(rendered).not.toContain('AI_RELAY_CONTROL_TOKEN');
+    expect(rendered).not.toContain('CF_AIG_AUTHORIZATION');
   });
 
   it('never renders shared R2 credentials into customer cloud-init', () => {

--- a/tests/platform/customer-vps-config.test.ts
+++ b/tests/platform/customer-vps-config.test.ts
@@ -2,6 +2,31 @@ import { describe, expect, it } from 'vitest';
 import { loadCustomerVpsConfig } from '../../packages/platform/src/customer-vps-config.js';
 
 describe('customer VPS bootstrap configuration', () => {
+  it('keeps funded AI disabled unless a valid relay is explicitly configured', () => {
+    expect(loadCustomerVpsConfig({})).toMatchObject({
+      fundedAiEnabled: false,
+      fundedAiRelayUrl: '',
+    });
+    expect(loadCustomerVpsConfig({
+      MATRIX_FUNDED_AI_RUNTIME_ENABLED: 'true',
+      MATRIX_FUNDED_AI_RELAY_URL: 'https://relay.matrix-os.com',
+    })).toMatchObject({
+      fundedAiEnabled: true,
+      fundedAiRelayUrl: 'https://relay.matrix-os.com',
+    });
+    expect(() => loadCustomerVpsConfig({
+      MATRIX_FUNDED_AI_RUNTIME_ENABLED: 'true',
+      MATRIX_FUNDED_AI_RELAY_URL: 'http://public-relay.example',
+    })).toThrow('Funded AI runtime is misconfigured');
+    expect(() => loadCustomerVpsConfig({
+      MATRIX_FUNDED_AI_RUNTIME_ENABLED: 'true',
+      MATRIX_FUNDED_AI_RELAY_URL: 'https://relay.example/path;touch-pwned',
+    })).toThrow('Funded AI runtime is misconfigured');
+    expect(() => loadCustomerVpsConfig({
+      MATRIX_FUNDED_AI_RUNTIME_ENABLED: 'true',
+    })).toThrow('Funded AI runtime is misconfigured');
+  });
+
   it('keeps registration tokens at the bounded clean-bootstrap lifetime', () => {
     expect(loadCustomerVpsConfig({}).registrationTokenTtlMs).toBe(60 * 60 * 1000);
     expect(loadCustomerVpsConfig({

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -1455,6 +1455,23 @@ describe('platform/customer-vps', () => {
     expect(createInput?.userData).not.toContain('PIPEDREAM_CLIENT_SECRET');
   });
 
+  it('templates only the funded runtime flag and relay URL into customer hosts', async () => {
+    const { service, hetzner } = createService({
+      config: createTestConfig({
+        fundedAiEnabled: true,
+        fundedAiRelayUrl: 'https://relay.matrix-os.com',
+      }),
+    });
+
+    await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+
+    const createInput = vi.mocked(hetzner.createServer).mock.calls[0]?.[0];
+    expect(createInput?.userData).toContain('MATRIX_FUNDED_AI_ENABLED=true');
+    expect(createInput?.userData).toContain('MATRIX_FUNDED_AI_RELAY_URL=https://relay.matrix-os.com');
+    expect(createInput?.userData).not.toContain('AI_RELAY_CONTROL_TOKEN');
+    expect(createInput?.userData).not.toContain('CF_AIG_AUTHORIZATION');
+  });
+
   it('never templates platform R2 credentials into provisioned customer hosts', async () => {
     const { service, hetzner } = createService();
 

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { createHmac } from 'node:crypto';
 import {
   claimUserMachineDelete,
   claimRunningUserMachineResize,
@@ -36,6 +35,7 @@ import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-
 import {
   buildPlatformRuntimeVerificationToken,
   timingSafeTokenEquals,
+  buildPlatformVerificationToken,
 } from '../../packages/platform/src/platform-token.js';
 
 describe('platform/customer-vps', () => {
@@ -1429,7 +1429,7 @@ describe('platform/customer-vps', () => {
 
     await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
 
-    const expected = createHmac('sha256', 'platform-secret').update('alice').digest('hex');
+    const expected = buildPlatformVerificationToken('alice', 'platform-secret');
     const createInput = vi.mocked(hetzner.createServer).mock.calls[0]?.[0];
     const fundedRuntimeToken = createInput?.userData
       .match(/^\s*MATRIX_FUNDED_AI_RUNTIME_TOKEN=([^\s]+)$/m)?.[1];
@@ -1468,6 +1468,14 @@ describe('platform/customer-vps', () => {
     const createInput = vi.mocked(hetzner.createServer).mock.calls[0]?.[0];
     expect(createInput?.userData).toContain('MATRIX_FUNDED_AI_ENABLED=true');
     expect(createInput?.userData).toContain('MATRIX_FUNDED_AI_RELAY_URL=https://relay.matrix-os.com');
+    const machine = await getActiveUserMachineByHandle(db, 'alice');
+    const fundedToken = buildPlatformRuntimeVerificationToken({
+      handle: 'alice',
+      machineId: machine!.machineId,
+      runtimeSlot: machine!.runtimeSlot,
+    }, 'platform-secret');
+    expect(createInput?.userData).toContain(`MATRIX_FUNDED_AI_RUNTIME_TOKEN=${fundedToken}`);
+    expect(fundedToken).not.toBe(buildPlatformVerificationToken('alice', 'platform-secret'));
     expect(createInput?.userData).not.toContain('AI_RELAY_CONTROL_TOKEN');
     expect(createInput?.userData).not.toContain('CF_AIG_AUTHORIZATION');
   });

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -36,6 +36,8 @@ describe("self-host server installer", () => {
     expect(script).toContain("[[ \"$MATRIX_DOMAIN\" =~ ^[A-Za-z0-9]");
     expect(script).toContain("openssl rand -hex 32");
     expect(script).toContain("read_env_value /opt/matrix/env/host.env MATRIX_AUTH_TOKEN || random_secret");
+    expect(script).toContain("read_env_value /opt/matrix/env/host.env MATRIX_FUNDED_AI_RUNTIME_TOKEN || true");
+    expect(script).toContain("MATRIX_FUNDED_AI_RUNTIME_TOKEN=${funded_ai_runtime_token}");
     expect(script).toContain("read_env_value /opt/matrix/env/host.env MATRIX_CODE_PROXY_TOKEN || random_secret");
     expect(script).toContain("read_env_value /opt/matrix/env/postgres.env POSTGRES_PASSWORD || random_secret");
     expect(script).toContain("cleanup_install_tmp");


### PR DESCRIPTION
## Summary

- issue short-lived, scoped Matrix-funded AI credentials to each VPS through the existing machine-authenticated platform path
- cache credentials only in gateway memory with singleflight refresh, bounded retries, expiry safety, response limits, and explicit shutdown
- inject funded credentials into bounded kernel and Claude Chat runs without falling back to owner or platform secrets
- strip platform, relay, and Cloudflare authority from every spawned child environment
- provision only the enable flag, relay URL, and existing scoped machine identity onto customer VPSes

## Validation

- 213 focused gateway and platform tests
- `tsc --noEmit` for `@matrix-os/gateway`
- `tsc --noEmit` for `@matrix-os/platform`
- `git diff --check`

## Invariants

- **Source of truth:** platform Postgres owns runtime policy and credential records; the VPS holds only the current short-lived opaque credential in memory.
- **Lock / transaction scope:** credential issuance uses the control-plane repository transaction and lease; gateway refreshes are singleflight per process.
- **Acceptable orphan states:** an issued credential may remain valid until its short expiry if a VPS disappears; no reusable provider, relay, or platform secret is written to customer storage.
- **Auth source of truth:** the existing scoped machine bearer authenticates credential issuance; the returned credential has only `matrix-funded-relay` / `ai:invoke` authority.
- **Deferred scope:** Cloudflare forwarding, reservation settlement, promo grants, add-on checkout, and production activation remain disabled for later stack layers.

## SDK verification

- the pinned Claude Agent SDK `0.3.240` refreshes `apiKeyHelper` after a 401 in the documented spike
- Matrix still uses bounded-run injection as the provider-neutral, fail-closed refresh path
- `0.3.251` remains inside the repository's seven-day dependency quarantine
