### PR TITLE
feat(ai-gateway): enforce funded relay reservations

### DIFF
--- a/packages/contracts/src/funded-ai.ts
+++ b/packages/contracts/src/funded-ai.ts
@@ -229,6 +229,20 @@ export const FundedAiSettlementRequestSchema = z.object({
   actualCostMicrousd: MicrousdSchema,
 }).strict();
 
+export const FundedAiFinalizationRequestSchema = z.discriminatedUnion("mode", [
+  z.object({
+    reservationId: canonicalReferenceId(160),
+    tokenId: TokenIdSchema,
+    mode: z.literal("exact"),
+    actualCostMicrousd: MicrousdSchema,
+  }).strict(),
+  z.object({
+    reservationId: canonicalReferenceId(160),
+    tokenId: TokenIdSchema,
+    mode: z.literal("conservative"),
+  }).strict(),
+]);
+
 export const FundedAiStartRequestSchema = z.object({
   reservationId: canonicalReferenceId(160),
   tokenId: TokenIdSchema,
@@ -256,6 +270,10 @@ export const FundedAiSettlementResponseSchema = z.object({
   funding: FundedAiFundingSummarySchema,
   settledAt: IsoTimestampSchema,
   status: z.literal("settled"),
+}).strict();
+
+export const FundedAiFinalizationResponseSchema = FundedAiSettlementResponseSchema.extend({
+  finalizationMode: z.enum(["exact", "conservative"]),
 }).strict();
 
 export const FundedAiReleaseRequestSchema = z.object({
@@ -310,6 +328,8 @@ export type FundedAiPolicyCheckRequest = z.infer<typeof FundedAiPolicyCheckReque
 export type FundedAiPolicyCheckResponse = z.infer<typeof FundedAiPolicyCheckResponseSchema>;
 export type FundedAiSettlementRequest = z.infer<typeof FundedAiSettlementRequestSchema>;
 export type FundedAiSettlementResponse = z.infer<typeof FundedAiSettlementResponseSchema>;
+export type FundedAiFinalizationRequest = z.infer<typeof FundedAiFinalizationRequestSchema>;
+export type FundedAiFinalizationResponse = z.infer<typeof FundedAiFinalizationResponseSchema>;
 export type FundedAiStartRequest = z.infer<typeof FundedAiStartRequestSchema>;
 export type FundedAiStartResponse = z.infer<typeof FundedAiStartResponseSchema>;
 export type FundedAiReleaseRequest = z.infer<typeof FundedAiReleaseRequestSchema>;

--- a/packages/contracts/src/funded-ai.ts
+++ b/packages/contracts/src/funded-ai.ts
@@ -127,6 +127,23 @@ export const FundedAiAuthorizationRequestSchema = z.object({
   maxCostMicrousd: MicrousdSchema.min(1),
 }).strict();
 
+export const FundedAiPolicyCheckRequestSchema = z.object({
+  credential: OpaqueCredentialSchema,
+  modelId: ProviderModelReferenceSchema,
+}).strict();
+
+export const FundedAiPolicyCheckResponseSchema = z.object({
+  contractVersion: z.literal(1),
+  authorized: z.literal(true),
+  identity: FundedAiIdentitySchema.extend({
+    tokenId: TokenIdSchema,
+    audience: z.literal(FUNDED_AI_AUDIENCE),
+    scope: z.literal(FUNDED_AI_SCOPE),
+    expiresAt: IsoTimestampSchema,
+  }).strict(),
+  policy: FundedAiEffectivePolicySchema,
+}).strict();
+
 export const FundedAiFundingSummarySchema = z.object({
   asOf: IsoTimestampSchema,
   periodStart: IsoTimestampSchema,
@@ -289,6 +306,8 @@ export type FundedAiEffectivePolicy = z.infer<typeof FundedAiEffectivePolicySche
 export type FundedAiRuntimeCredentialIssueResponse = z.infer<typeof FundedAiRuntimeCredentialIssueResponseSchema>;
 export type FundedAiAuthorizationRequest = z.infer<typeof FundedAiAuthorizationRequestSchema>;
 export type FundedAiAuthorizationResponse = z.infer<typeof FundedAiAuthorizationResponseSchema>;
+export type FundedAiPolicyCheckRequest = z.infer<typeof FundedAiPolicyCheckRequestSchema>;
+export type FundedAiPolicyCheckResponse = z.infer<typeof FundedAiPolicyCheckResponseSchema>;
 export type FundedAiSettlementRequest = z.infer<typeof FundedAiSettlementRequestSchema>;
 export type FundedAiSettlementResponse = z.infer<typeof FundedAiSettlementResponseSchema>;
 export type FundedAiStartRequest = z.infer<typeof FundedAiStartRequestSchema>;

--- a/packages/platform/src/ai-funded-metering-repository.ts
+++ b/packages/platform/src/ai-funded-metering-repository.ts
@@ -5,6 +5,8 @@ import {
   FundedAiAuthorizationRequestSchema,
   FundedAiAuthorizationResponseSchema,
   FundedAiFundingSummarySchema,
+  FundedAiPolicyCheckRequestSchema,
+  FundedAiPolicyCheckResponseSchema,
   FundedAiReleaseRequestSchema,
   FundedAiReleaseResponseSchema,
   FundedAiSettlementRequestSchema,
@@ -14,6 +16,7 @@ import {
   IsoTimestampSchema,
   type FundedAiAuthorizationResponse,
   type FundedAiFundingSummary,
+  type FundedAiPolicyCheckResponse,
   type FundedAiReleaseResponse,
   type FundedAiSettlementResponse,
   type FundedAiStartResponse,
@@ -371,6 +374,73 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
         if (!balance) throw new Error("Funded AI credit balance exceeds supported bounds");
       }
       return { ...grant, createdAt: stored.created_at };
+    });
+  }
+
+  async function checkPolicy(
+    input: z.input<typeof FundedAiPolicyCheckRequestSchema>,
+  ): Promise<FundedAiPolicyCheckResponse> {
+    const request = FundedAiPolicyCheckRequestSchema.parse(input);
+    const tokenMatch = TOKEN_PATTERN.exec(request.credential);
+    if (!tokenMatch) throw new AiFundedPolicyError("unauthorized");
+    const checked = options.now();
+    const checkedAt = checked.toISOString();
+    await options.db.ready;
+    const row = await options.db.executor.selectFrom("ai_runtime_credentials as credential")
+      .innerJoin("ai_funded_runtime_policies as runtime", "runtime.machine_id", "credential.machine_id")
+      .innerJoin("user_machines as machine", "machine.machine_id", "credential.machine_id")
+      .innerJoin("ai_funded_global_policy as global_policy", (join) => (
+        join.on("global_policy.policy_id", "=", "default")
+      ))
+      .select([
+        "credential.token_id", "credential.token_hash", "credential.owner_id", "credential.machine_id",
+        "credential.runtime_slot", "credential.audience", "credential.scope", "credential.expires_at",
+        "credential.revoked_at", "runtime.owner_id as runtime_owner_id",
+        "runtime.runtime_slot as policy_runtime_slot", "runtime.enabled as runtime_enabled",
+        "runtime.expires_at as runtime_expires_at", "runtime.revision as runtime_revision",
+        "runtime.allowed_model_ids as runtime_models", "runtime.monthly_budget_microusd",
+        "machine.clerk_user_id", "machine.runtime_slot as machine_runtime_slot", "machine.status",
+        "machine.activation_state", "machine.deleted_at", "global_policy.enabled as global_enabled",
+        "global_policy.revision as global_revision", "global_policy.allowed_model_ids as global_models",
+      ])
+      .where("credential.token_id", "=", tokenMatch[1])
+      .where("global_policy.policy_id", "=", "default")
+      .executeTakeFirst();
+    if (!row || !hashesEqual(row.token_hash, hashCredential(request.credential))
+      || row.revoked_at !== null || Date.parse(row.expires_at) <= checked.getTime()
+      || row.audience !== FUNDED_AI_AUDIENCE || row.scope !== FUNDED_AI_SCOPE
+      || row.clerk_user_id !== row.owner_id || row.machine_runtime_slot !== row.runtime_slot
+      || row.status !== "running" || row.activation_state !== "authorized" || row.deleted_at !== null
+      || row.runtime_owner_id !== row.owner_id || row.policy_runtime_slot !== row.runtime_slot) {
+      throw new AiFundedPolicyError("unauthorized");
+    }
+    if (!row.global_enabled || !row.runtime_enabled
+      || (row.runtime_expires_at !== null && Date.parse(row.runtime_expires_at) <= checked.getTime())) {
+      throw new AiFundedPolicyError("access_disabled");
+    }
+    const allowedModelIds = intersectModels(parseModels(row.global_models), parseModels(row.runtime_models));
+    if (!allowedModelIds.includes(request.modelId)) throw new AiFundedPolicyError("model_not_allowed");
+    return FundedAiPolicyCheckResponseSchema.parse({
+      contractVersion: 1,
+      authorized: true,
+      identity: {
+        tokenId: row.token_id,
+        ownerId: row.owner_id,
+        machineId: row.machine_id,
+        runtimeSlot: row.runtime_slot,
+        audience: FUNDED_AI_AUDIENCE,
+        scope: FUNDED_AI_SCOPE,
+        expiresAt: row.expires_at,
+      },
+      policy: {
+        enabled: true,
+        globalRevision: row.global_revision,
+        runtimeRevision: row.runtime_revision,
+        allowedModelIds,
+        monthlyBudgetMicrousd: exactInteger(row.monthly_budget_microusd),
+        checkedAt,
+        staleAfter: new Date(checked.getTime() + options.policyFreshnessMs).toISOString(),
+      },
     });
   }
 
@@ -971,6 +1041,7 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
   return {
     getFundingSummary,
     getRuntimeFundingSummary,
+    checkPolicy,
     authorize,
     startReservation,
     settleReservation,

--- a/packages/platform/src/ai-funded-metering-repository.ts
+++ b/packages/platform/src/ai-funded-metering-repository.ts
@@ -5,6 +5,8 @@ import {
   FundedAiAuthorizationRequestSchema,
   FundedAiAuthorizationResponseSchema,
   FundedAiFundingSummarySchema,
+  FundedAiFinalizationRequestSchema,
+  FundedAiFinalizationResponseSchema,
   FundedAiPolicyCheckRequestSchema,
   FundedAiPolicyCheckResponseSchema,
   FundedAiReleaseRequestSchema,
@@ -16,6 +18,7 @@ import {
   IsoTimestampSchema,
   type FundedAiAuthorizationResponse,
   type FundedAiFundingSummary,
+  type FundedAiFinalizationResponse,
   type FundedAiPolicyCheckResponse,
   type FundedAiReleaseResponse,
   type FundedAiSettlementResponse,
@@ -584,6 +587,7 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
         payload_hash: payloadHash,
         authorization_response: JSON.stringify(response),
         settlement_response: null,
+        finalization_mode: null,
         start_response: null,
         release_response: null,
         release_reason: null,
@@ -687,6 +691,17 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
     input: z.input<typeof FundedAiSettlementRequestSchema>,
   ): Promise<FundedAiSettlementResponse> {
     const request = FundedAiSettlementRequestSchema.parse(input);
+    return (await settleReservationInternal(request, "exact")).response;
+  }
+
+  async function settleReservationInternal(request: {
+    reservationId: string;
+    tokenId: string;
+    actualCostMicrousd: number | null;
+  }, finalizationMode: "exact" | "conservative"): Promise<{
+    response: FundedAiSettlementResponse;
+    finalizationMode: "exact" | "conservative";
+  }> {
     const checked = options.now();
     const checkedAt = checked.toISOString();
     await options.db.ready;
@@ -701,12 +716,17 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
       const reservation = await trx.executor.selectFrom("ai_funded_usage_reservations")
         .selectAll().where("reservation_id", "=", request.reservationId)
         .where("token_id", "=", request.tokenId).forUpdate().executeTakeFirstOrThrow();
+      const reserved = exactInteger(reservation.reserved_microusd);
+      const actualCostMicrousd = request.actualCostMicrousd ?? reserved;
       if (reservation.status === "settled") {
-        if (exactInteger(reservation.actual_microusd) !== request.actualCostMicrousd) {
+        if (exactInteger(reservation.actual_microusd) !== actualCostMicrousd) {
           throw new AiFundedPolicyError("idempotency_conflict");
         }
         if (reservation.settlement_response === null) throw new Error("Settled reservation is missing its response");
-        return FundedAiSettlementResponseSchema.parse(JSON.parse(reservation.settlement_response));
+        return {
+          response: FundedAiSettlementResponseSchema.parse(JSON.parse(reservation.settlement_response)),
+          finalizationMode: reservation.finalization_mode === "conservative" ? "conservative" : "exact",
+        } as const;
       }
       if (reservation.status !== "in_flight" && reservation.status !== "expired") {
         throw new AiFundedPolicyError("reservation_closed");
@@ -714,8 +734,7 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
       if (reservation.status === "expired" || Date.parse(reservation.expires_at) <= checked.getTime()) {
         throw new AiFundedPolicyError("reservation_expired");
       }
-      const reserved = exactInteger(reservation.reserved_microusd);
-      if (request.actualCostMicrousd > reserved) throw new AiFundedPolicyError("over_settlement");
+      if (actualCostMicrousd > reserved) throw new AiFundedPolicyError("over_settlement");
       const reservationIdentity = {
         ownerId: reservation.owner_id,
         machineId: reservation.machine_id,
@@ -735,9 +754,12 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
       if (!claimed) {
         const latest = await trx.executor.selectFrom("ai_funded_usage_reservations").selectAll()
           .where("reservation_id", "=", reservation.reservation_id).executeTakeFirstOrThrow();
-        if (latest.status === "settled" && exactInteger(latest.actual_microusd) === request.actualCostMicrousd
+        if (latest.status === "settled" && exactInteger(latest.actual_microusd) === actualCostMicrousd
           && latest.settlement_response !== null) {
-          return FundedAiSettlementResponseSchema.parse(JSON.parse(latest.settlement_response));
+          return {
+            response: FundedAiSettlementResponseSchema.parse(JSON.parse(latest.settlement_response)),
+            finalizationMode: latest.finalization_mode === "conservative" ? "conservative" : "exact",
+          } as const;
         }
         if (latest.status === "settled") throw new AiFundedPolicyError("idempotency_conflict");
         if (latest.status === "settling") throw new AiFundedPolicyError("rate_limited");
@@ -754,7 +776,7 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
         trx.executor,
         reservationIdentity,
         reservation,
-        request.actualCostMicrousd,
+        actualCostMicrousd,
         currentBalance,
       );
       let appliedPromotionalDebit = promotionalDebit;
@@ -790,8 +812,9 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
       );
       const updated = await trx.executor.updateTable("ai_funded_usage_reservations").set({
         status: "settled",
-        actual_microusd: request.actualCostMicrousd,
+        actual_microusd: actualCostMicrousd,
         settled_at: checkedAt,
+        finalization_mode: finalizationMode,
       }).where("reservation_id", "=", reservation.reservation_id).where("status", "=", "settling")
         .returningAll().executeTakeFirstOrThrow();
       const monthlyBudget = exactInteger(runtime.monthly_budget_microusd);
@@ -806,8 +829,8 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
         reservationId: updated.reservation_id,
         requestId: updated.request_id,
         tokenId: updated.token_id,
-        actualCostMicrousd: request.actualCostMicrousd,
-        releasedMicrousd: reserved - request.actualCostMicrousd,
+        actualCostMicrousd,
+        releasedMicrousd: reserved - actualCostMicrousd,
         remainingBalanceMicrousd: funding.remainingBalanceMicrousd,
         remainingBudgetMicrousd: funding.remainingBudgetMicrousd,
         funding,
@@ -817,9 +840,24 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
       await trx.executor.updateTable("ai_funded_usage_reservations")
         .set({ settlement_response: JSON.stringify(response) })
         .where("reservation_id", "=", reservation.reservation_id).execute();
-      return response;
+      return { response, finalizationMode } as const;
     });
     return result;
+  }
+
+  async function finalizeReservation(
+    input: z.input<typeof FundedAiFinalizationRequestSchema>,
+  ): Promise<FundedAiFinalizationResponse> {
+    const request = FundedAiFinalizationRequestSchema.parse(input);
+    const settlement = await settleReservationInternal({
+      reservationId: request.reservationId,
+      tokenId: request.tokenId,
+      actualCostMicrousd: request.mode === "exact" ? request.actualCostMicrousd : null,
+    }, request.mode);
+    return FundedAiFinalizationResponseSchema.parse({
+      ...settlement.response,
+      finalizationMode: settlement.finalizationMode,
+    });
   }
 
   async function releaseReservation(
@@ -1014,6 +1052,7 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
           });
           const settled = await trx.executor.updateTable("ai_funded_usage_reservations").set({
             status: "settled", actual_microusd: reserved, settled_at: checkedAt,
+            finalization_mode: "conservative",
             settlement_response: JSON.stringify(response),
           }).where("reservation_id", "=", reservation.reservation_id).where("status", "=", "settling")
             .returning("reservation_id").executeTakeFirst();
@@ -1045,6 +1084,7 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
     authorize,
     startReservation,
     settleReservation,
+    finalizeReservation,
     releaseReservation,
     cleanupExpiredReservations,
     grantCredit,

--- a/packages/platform/src/ai-funded-metering-repository.ts
+++ b/packages/platform/src/ai-funded-metering-repository.ts
@@ -796,7 +796,7 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
         );
       }
       const chargedMicrousd = appliedPromotionalDebit + addonDebit;
-      if (attributed && chargedMicrousd !== request.actualCostMicrousd) {
+      if (attributed && chargedMicrousd !== actualCostMicrousd) {
         throw new Error("Funded AI attributed reservation debit invariant violated");
       }
       // A migrated reservation may lack source attribution. Charge every live,
@@ -805,7 +805,7 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
       await recordUsageFunding(
         trx.executor,
         reservation,
-        request.actualCostMicrousd,
+        actualCostMicrousd,
         appliedPromotionalDebit,
         addonDebit,
         checkedAt,

--- a/packages/platform/src/ai-funded-policy-routes.ts
+++ b/packages/platform/src/ai-funded-policy-routes.ts
@@ -5,6 +5,7 @@ import {
   FundedAiOperatorRuntimePolicyResponseSchema,
   FundedAiOperatorRuntimePolicyUpdateRequestSchema,
   FundedAiPromotionalGrantResponseSchema,
+  FundedAiFinalizationRequestSchema,
   FundedAiPolicyCheckRequestSchema,
   FundedAiSafeErrorSchema,
   FundedAiReleaseRequestSchema,
@@ -418,6 +419,15 @@ export function createAiFundedRelayRoutes(options: {
     if (!request.success) return c.json(safeError("invalid_request"), 400);
     try {
       return c.json(await options.repository.settleReservation(request.data), 200);
+    } catch (error) {
+      return policyErrorResponse(c, error);
+    }
+  });
+  app.post("/finalize", bodyLimit({ maxSize: RELAY_BODY_LIMIT }), async (c) => {
+    const request = FundedAiFinalizationRequestSchema.safeParse(await readStrictJson(c));
+    if (!request.success) return c.json(safeError("invalid_request"), 400);
+    try {
+      return c.json(await options.repository.finalizeReservation(request.data), 200);
     } catch (error) {
       return policyErrorResponse(c, error);
     }

--- a/packages/platform/src/ai-funded-policy-routes.ts
+++ b/packages/platform/src/ai-funded-policy-routes.ts
@@ -5,6 +5,7 @@ import {
   FundedAiOperatorRuntimePolicyResponseSchema,
   FundedAiOperatorRuntimePolicyUpdateRequestSchema,
   FundedAiPromotionalGrantResponseSchema,
+  FundedAiPolicyCheckRequestSchema,
   FundedAiSafeErrorSchema,
   FundedAiReleaseRequestSchema,
   FundedAiRuntimeFundingSummaryResponseSchema,
@@ -399,6 +400,15 @@ export function createAiFundedRelayRoutes(options: {
     if (!request.success) return c.json(safeError("invalid_request"), 400);
     try {
       return c.json(await options.repository.authorize(request.data), 200);
+    } catch (error) {
+      return policyErrorResponse(c, error);
+    }
+  });
+  app.post("/check", bodyLimit({ maxSize: RELAY_BODY_LIMIT }), async (c) => {
+    const request = FundedAiPolicyCheckRequestSchema.safeParse(await readStrictJson(c));
+    if (!request.success) return c.json(safeError("invalid_request"), 400);
+    try {
+      return c.json(await options.repository.checkPolicy(request.data), 200);
     } catch (error) {
       return policyErrorResponse(c, error);
     }

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -138,6 +138,7 @@ export interface AiFundedUsageReservationsTable {
   payload_hash: string;
   authorization_response: string;
   settlement_response: string | null;
+  finalization_mode: string | null;
   start_response: string | null;
   release_response: string | null;
   release_reason: string | null;
@@ -1376,6 +1377,7 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
       payload_hash TEXT NOT NULL CHECK (length(payload_hash) = 64),
       authorization_response TEXT NOT NULL,
       settlement_response TEXT,
+      finalization_mode TEXT CHECK (finalization_mode IN ('exact', 'conservative')),
       start_response TEXT,
       release_response TEXT,
       release_reason TEXT,
@@ -1427,6 +1429,11 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
       EXCEPTION WHEN duplicate_object THEN NULL;
       END;
     END $$
+  `.execute(db);
+  await sql`
+    ALTER TABLE ai_funded_usage_reservations
+    ADD COLUMN IF NOT EXISTS finalization_mode TEXT
+    CHECK (finalization_mode IN ('exact', 'conservative'))
   `.execute(db);
   await sql`
     CREATE INDEX IF NOT EXISTS idx_ai_funded_reservations_runtime_status

--- a/packages/proxy/DOMAIN.md
+++ b/packages/proxy/DOMAIN.md
@@ -40,7 +40,9 @@
 - Only explicit top-level Anthropic fields, client-defined tools, and operator-allowlisted beta identifiers are reconstructed for upstream forwarding; server tools, service-tier overrides, and unknown fields are rejected.
 - Downstream cancellation propagates to the Cloudflare request, and admission leases remain held until the response stream completes or is cancelled.
 - The relay is conversation-stateless. Restarting it can drop in-flight streams but cannot corrupt Chat state; the owner kernel handles retry/resume deliberately.
-- Cloudflare token counting feeds a conservative, expiring integer-microusd estimate. Matrix reserves that worst case atomically, then the relay marks it in-flight immediately before generation. This layer deliberately leaves exact stream settlement to the next layer; expired in-flight reservations are charged conservatively by platform cleanup.
+- Cloudflare token counting feeds a conservative, expiring integer-microusd estimate. Matrix reserves that worst case atomically, then the relay marks it in-flight immediately before generation.
+- A complete valid Anthropic SSE or JSON response is priced with the reservation's versioned integer-microusd table and finalized exactly once through the idempotent platform API. Malformed, truncated, cancelled, timed-out, oversized, or otherwise ambiguous post-start responses finalize at the full reservation; the relay never releases after start.
+- Failed finalizations enter a capped, expiring retry queue with bounded batches and a shutdown drain. Queue expiry/eviction falls back to the platform's conservative in-flight expiry cleanup rather than risking free upstream usage.
 
 ## Tests
 

--- a/packages/proxy/DOMAIN.md
+++ b/packages/proxy/DOMAIN.md
@@ -11,22 +11,22 @@
 ## Source Of Truth
 
 - Funded relay availability and safety limits are validated process configuration.
-- The enabled model list is an explicit operator allowlist. Remote/client model values cannot expand it.
-- Runtime identity is derived from a verified `sk-matrix-funded-<handle>.<hmac>` credential with a funded-only HMAC audience. Legacy `sk-proxy-*` credentials cannot invoke the funded relay. Caller identity headers are ignored.
-- Cloudflare spend limits are a defense-in-depth fuse. Future per-owner balances and add-on credits belong to platform PostgreSQL through Kysely.
+- The native-to-canonical model map is exact and code-versioned. Layer A supports only `claude-sonnet-5` -> `anthropic/claude-sonnet-5`; remote/client values cannot expand it.
+- Runtime identity comes only from the platform's short-lived opaque credential check. Legacy indefinite handle-HMAC credentials are not verified locally and fail platform authorization. Caller identity headers are ignored.
+- Matrix PostgreSQL/Kysely policy, monthly budgets, reservations, and credit ledger are authoritative. Cloudflare spend limits remain only a defense-in-depth fuse.
 - Chat content remains in the owner runtime and is never persisted by this package.
 
 ## Public API
 
 - `resolveFundedRelayConfig()` parses and fails closed on enabled relay configuration.
 - `createFundedRelay()` registers the bounded `/v1/messages` and `/v1/messages/count_tokens` surface and exposes shutdown cleanup.
-- `buildFundedProxyApiKey()` / `parseFundedProxyApiKey()` provide the funded runtime HMAC credential contract. The legacy proxy credential helpers remain isolated from this audience.
+- `mapFundedModel()` and the versioned integer-microusd estimator define the bounded model and pricing contract.
 - Other modules under `src/` are internal unless exported deliberately.
 
 ## Auth And Trust Boundaries
 
-- The customer runtime sends its funded-audience HMAC credential in the Anthropic SDK `x-api-key` field. Raw provider and legacy proxy API keys bypass the funded route and remain subject to their existing owner/legacy handler until that migration is complete.
-- The relay derives an opaque Cloudflare `runtime_id` with HMAC and does not trust `x-matrix-user`, forwarded headers, Cloudflare metadata headers, provider authorization, target URLs, or model policy from the caller.
+- The customer runtime sends a short-lived platform-issued credential in the Anthropic SDK `x-api-key` field. The relay sends it only to the dedicated platform policy/reservation API over service authentication.
+- Platform-verified owner/runtime identity is HMAC-projected into exactly five primitive, content-free Cloudflare metadata fields. The relay does not trust `x-matrix-user`, forwarded headers, Cloudflare metadata/auth headers, target URLs, or model policy from the caller.
 - Cloudflare is always the fixed official `gateway.ai.cloudflare.com/.../anthropic` endpoint. Redirects are rejected.
 - The central Cloudflare gateway token is replaced server-side and never returned or forwarded from a customer runtime.
 - Cloudflare payload collection is disabled and ZDR is requested on every funded call. Product policy must still account for the selected model's documented upstream retention behavior.
@@ -34,13 +34,13 @@
 
 ## Concurrency And Recovery
 
-- Global and per-runtime concurrency plus per-minute admission limits are enforced before upstream dispatch. The default global minute budget leaves headroom below Cloudflare Unified Billing's documented gateway limit.
+- Global rate/concurrency admission happens before parsing, platform-verified per-runtime rate admission happens before token counting, and per-runtime generation concurrency is acquired only after Matrix credit is reserved.
 - The runtime admission registry has an operator-configured hard cap. Expired inactive entries are evicted opportunistically when capacity is reached; shutdown clears the registry and denies new leases.
-- Admission happens immediately after funded credential verification and before body parsing. Request bodies, nested JSON, model/tool/message counts, response bytes, inbound request time, first-response time, total stream duration, and forwarded headers are bounded.
+- Request bodies, nested JSON, model/tool/message counts, control responses, response streams, inbound request time, first-response time, total stream duration, and forwarded headers are bounded.
 - Only explicit top-level Anthropic fields, client-defined tools, and operator-allowlisted beta identifiers are reconstructed for upstream forwarding; server tools, service-tier overrides, and unknown fields are rejected.
 - Downstream cancellation propagates to the Cloudflare request, and admission leases remain held until the response stream completes or is cancelled.
 - The relay is conversation-stateless. Restarting it can drop in-flight streams but cannot corrupt Chat state; the owner kernel handles retry/resume deliberately.
-- Cloudflare spend limits are eventually consistent and are not an atomic balance. Future metering reserves Matrix credit transactionally before dispatch and reconciles final usage afterward.
+- Cloudflare token counting feeds a conservative, expiring integer-microusd estimate. Matrix reserves that worst case atomically, then the relay marks it in-flight immediately before generation. This layer deliberately leaves exact stream settlement to the next layer; expired in-flight reservations are charged conservatively by platform cleanup.
 
 ## Tests
 

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.19.9",
+    "@matrix-os/contracts": "workspace:*",
     "@matrix-os/observability": "workspace:*",
     "better-sqlite3": "^12.10.0",
     "hono": "^4.11.9",

--- a/packages/proxy/src/auth.ts
+++ b/packages/proxy/src/auth.ts
@@ -19,10 +19,6 @@ function signatureForHandle(handle: string, secret: string): string {
   return createHmac("sha256", secret).update(`proxy:${handle}`).digest("base64url");
 }
 
-function fundedSignatureForHandle(handle: string, secret: string): string {
-  return createHmac("sha256", secret).update(`funded-proxy:${handle}`).digest("base64url");
-}
-
 export function buildProxyApiKey(handle: string, secret: string): string {
   return `${PROXY_API_KEY_PREFIX}${handle}.${signatureForHandle(handle, secret)}`;
 }
@@ -42,27 +38,8 @@ export function parseProxyApiKey(
   return timingSafeCompare(signature, expected) ? { handle } : null;
 }
 
-export function buildFundedProxyApiKey(handle: string, secret: string): string {
-  return `${FUNDED_PROXY_API_KEY_PREFIX}${handle}.${fundedSignatureForHandle(handle, secret)}`;
-}
-
 export function isFundedProxyApiKey(key: string): boolean {
   return key.startsWith(FUNDED_PROXY_API_KEY_PREFIX);
-}
-
-export function parseFundedProxyApiKey(
-  key: string,
-  secret: string | undefined,
-): { handle: string } | null {
-  if (!secret || !isFundedProxyApiKey(key)) return null;
-  const rest = key.slice(FUNDED_PROXY_API_KEY_PREFIX.length);
-  const separator = rest.lastIndexOf(".");
-  if (separator <= 0 || separator === rest.length - 1) return null;
-  const handle = rest.slice(0, separator);
-  const signature = rest.slice(separator + 1);
-  if (!/^[a-z][a-z0-9-]{2,30}$/.test(handle)) return null;
-  const expected = fundedSignatureForHandle(handle, secret);
-  return timingSafeCompare(signature, expected) ? { handle } : null;
 }
 
 export function isAuthorizedProxyAdminRequest(

--- a/packages/proxy/src/funded-relay-admission.ts
+++ b/packages/proxy/src/funded-relay-admission.ts
@@ -36,7 +36,7 @@ export class AdmissionController {
     this.cleanupTimer.unref?.();
   }
 
-  acquire(runtimeId: string): AdmissionLease | null {
+  acquireGlobal(): AdmissionLease | null {
     if (this.closed || this.active >= this.config.globalConcurrency) return null;
     const now = this.now();
     this.sweep(now, false);
@@ -45,9 +45,25 @@ export class AdmissionController {
       this.globalWindowStartedAt = now;
     }
     if (this.globalCount >= this.config.globalRateLimitPerMinute) return null;
+    this.globalCount += 1;
+    this.active += 1;
+    let released = false;
+    return {
+      release: () => {
+        if (released) return;
+        released = true;
+        this.active = Math.max(0, this.active - 1);
+      },
+    };
+  }
+
+  admitRuntime(runtimeId: string): boolean {
+    if (this.closed) return false;
+    const now = this.now();
+    this.sweep(now, false);
     let state = this.runtimes.get(runtimeId);
     if (!state) {
-      if (this.runtimes.size >= this.config.maxRuntimeEntries) return null;
+      if (this.runtimes.size >= this.config.maxRuntimeEntries) return false;
       state = { active: 0, count: 0, windowStartedAt: now, lastTouchedAt: now };
       this.runtimes.set(runtimeId, state);
     }
@@ -56,14 +72,17 @@ export class AdmissionController {
       state.windowStartedAt = now;
     }
     state.lastTouchedAt = now;
-    if (state.active >= this.config.runtimeConcurrency || state.count >= this.config.rateLimitPerMinute) {
-      return null;
-    }
-
-    state.active += 1;
+    if (state.count >= this.config.rateLimitPerMinute) return false;
     state.count += 1;
-    this.active += 1;
-    this.globalCount += 1;
+    return true;
+  }
+
+  acquireResources(runtimeId: string): AdmissionLease | null {
+    if (this.closed) return null;
+    const state = this.runtimes.get(runtimeId);
+    if (!state || state.active >= this.config.runtimeConcurrency) return null;
+    state.active += 1;
+    state.lastTouchedAt = this.now();
     let released = false;
     return {
       release: () => {
@@ -71,7 +90,6 @@ export class AdmissionController {
         released = true;
         state.active = Math.max(0, state.active - 1);
         state.lastTouchedAt = this.now();
-        this.active = Math.max(0, this.active - 1);
       },
     };
   }

--- a/packages/proxy/src/funded-relay-config.ts
+++ b/packages/proxy/src/funded-relay-config.ts
@@ -1,5 +1,8 @@
 const DEFAULT_BODY_LIMIT_BYTES = 2 * 1024 * 1024;
 const DEFAULT_RESPONSE_LIMIT_BYTES = 32 * 1024 * 1024;
+const DEFAULT_CONTROL_RESPONSE_LIMIT_BYTES = 64 * 1024;
+const DEFAULT_PLATFORM_TIMEOUT_MS = 5_000;
+const DEFAULT_COUNT_TOKENS_TIMEOUT_MS = 10_000;
 const DEFAULT_FIRST_RESPONSE_TIMEOUT_MS = 10_000;
 const DEFAULT_TIMEOUT_MS = 10 * 60_000;
 const DEFAULT_GLOBAL_CONCURRENCY = 64;
@@ -10,19 +13,22 @@ const DEFAULT_RUNTIME_REGISTRY_SIZE = 10_000;
 const CLOUDFLARE_GATEWAY_HOST = "gateway.ai.cloudflare.com";
 
 export const COUNT_TOKENS_BODY_LIMIT_BYTES = 256 * 1024;
-export const MODEL_ID = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
 export const BETA_ID = /^[a-zA-Z0-9][a-zA-Z0-9._=-]{0,127}$/;
 
 export interface FundedRelayConfig {
   gatewayBaseUrl: string;
   gatewayToken: string;
-  sharedSecret: string;
-  allowedModels: ReadonlySet<string>;
+  platformBaseUrl: string;
+  relayControlToken: string;
+  metadataSecret: string;
   allowedBetas: ReadonlySet<string>;
+  platformTimeoutMs: number;
+  countTokensTimeoutMs: number;
   firstResponseTimeoutMs: number;
   timeoutMs: number;
   maxBodyBytes: number;
   maxResponseBytes: number;
+  maxControlResponseBytes: number;
   globalConcurrency: number;
   globalRateLimitPerMinute: number;
   runtimeConcurrency: number;
@@ -45,7 +51,7 @@ function readRequired(env: NodeJS.ProcessEnv, name: string, maxLength = 4_096): 
 
 function readSecret(env: NodeJS.ProcessEnv, name: string): string {
   const value = readRequired(env, name);
-  if (value.length < 16) throw new Error(`${name} must be at least 16 characters`);
+  if (value.length < 32) throw new Error(`${name} must be at least 32 characters`);
   return value;
 }
 
@@ -71,9 +77,7 @@ function readGatewayBaseUrl(env: NodeJS.ProcessEnv): string {
   try {
     url = new URL(raw);
   } catch (error) {
-    if (error instanceof TypeError) {
-      throw new Error("CLOUDFLARE_AI_GATEWAY_URL must be a valid URL");
-    }
+    if (error instanceof TypeError) throw new Error("CLOUDFLARE_AI_GATEWAY_URL must be a valid URL");
     throw error;
   }
   const path = url.pathname.replace(/\/$/, "");
@@ -83,28 +87,28 @@ function readGatewayBaseUrl(env: NodeJS.ProcessEnv): string {
     && /^[a-f0-9]{32}$/.test(pathSegments[1] ?? "")
     && /^[a-zA-Z0-9_-]{1,64}$/.test(pathSegments[2] ?? "")
     && pathSegments[3] === "anthropic";
-  if (
-    url.protocol !== "https:"
-    || url.hostname !== CLOUDFLARE_GATEWAY_HOST
-    || url.port !== ""
-    || url.username !== ""
-    || url.password !== ""
-    || url.search !== ""
-    || url.hash !== ""
-    || !isExpectedPath
-  ) {
+  if (url.protocol !== "https:" || url.hostname !== CLOUDFLARE_GATEWAY_HOST || url.port !== ""
+    || url.username !== "" || url.password !== "" || url.search !== "" || url.hash !== "" || !isExpectedPath) {
     throw new Error("CLOUDFLARE_AI_GATEWAY_URL must be an official Anthropic gateway URL");
   }
   return `${url.origin}${path}`;
 }
 
-function readAllowedModels(env: NodeJS.ProcessEnv): ReadonlySet<string> {
-  const raw = readRequired(env, "MATRIX_FUNDED_AI_MODELS", 4_096);
-  const models = [...new Set(raw.split(",").map((entry) => entry.trim()).filter(Boolean))];
-  if (models.length === 0 || models.length > 32 || models.some((model) => !MODEL_ID.test(model))) {
-    throw new Error("MATRIX_FUNDED_AI_MODELS must contain 1 to 32 valid model IDs");
+function readPlatformBaseUrl(env: NodeJS.ProcessEnv): string {
+  const raw = readRequired(env, "PLATFORM_INTERNAL_URL", 2_048);
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch (error) {
+    if (error instanceof TypeError) throw new Error("PLATFORM_INTERNAL_URL must be a valid URL");
+    throw error;
   }
-  return new Set(models);
+  if (!(["http:", "https:"] as const).includes(url.protocol as "http:" | "https:")
+    || url.username !== "" || url.password !== "" || url.search !== "" || url.hash !== ""
+    || (url.pathname !== "" && url.pathname !== "/")) {
+    throw new Error("PLATFORM_INTERNAL_URL must be an HTTP(S) origin without credentials or a path");
+  }
+  return url.origin;
 }
 
 function readAllowedBetas(env: NodeJS.ProcessEnv): ReadonlySet<string> {
@@ -121,69 +125,52 @@ export function resolveFundedRelayConfig(
   env: NodeJS.ProcessEnv = process.env,
 ): FundedRelayConfig | null {
   if (!readEnabled(env.MATRIX_FUNDED_AI_ENABLED)) return null;
-
+  const gatewayBaseUrl = readGatewayBaseUrl(env);
+  const platformBaseUrl = readPlatformBaseUrl(env);
+  const gatewayToken = readSecret(env, "CLOUDFLARE_AI_GATEWAY_TOKEN");
+  const relayControlToken = readSecret(env, "AI_RELAY_CONTROL_TOKEN");
+  const metadataSecret = readSecret(env, "AI_RELAY_METADATA_SECRET");
+  if (new Set([gatewayToken, relayControlToken, metadataSecret]).size !== 3) {
+    throw new Error("Funded AI relay credentials must be distinct");
+  }
   return {
-    gatewayBaseUrl: readGatewayBaseUrl(env),
-    gatewayToken: readSecret(env, "CLOUDFLARE_AI_GATEWAY_TOKEN"),
-    sharedSecret: readSecret(env, "PROXY_SHARED_SECRET"),
-    allowedModels: readAllowedModels(env),
+    gatewayBaseUrl,
+    gatewayToken,
+    platformBaseUrl,
+    relayControlToken,
+    metadataSecret,
     allowedBetas: readAllowedBetas(env),
+    platformTimeoutMs: readInteger(env, "MATRIX_FUNDED_AI_PLATFORM_TIMEOUT_MS", DEFAULT_PLATFORM_TIMEOUT_MS, 500, 30_000),
+    countTokensTimeoutMs: readInteger(
+      env, "MATRIX_FUNDED_AI_COUNT_TOKENS_TIMEOUT_MS", DEFAULT_COUNT_TOKENS_TIMEOUT_MS, 500, 60_000,
+    ),
     firstResponseTimeoutMs: readInteger(
-      env,
-      "MATRIX_FUNDED_AI_FIRST_RESPONSE_TIMEOUT_MS",
-      DEFAULT_FIRST_RESPONSE_TIMEOUT_MS,
-      1_000,
-      60_000,
+      env, "MATRIX_FUNDED_AI_FIRST_RESPONSE_TIMEOUT_MS", DEFAULT_FIRST_RESPONSE_TIMEOUT_MS, 1_000, 60_000,
     ),
     timeoutMs: readInteger(env, "MATRIX_FUNDED_AI_TIMEOUT_MS", DEFAULT_TIMEOUT_MS, 10_000, 15 * 60_000),
     maxBodyBytes: readInteger(
-      env,
-      "MATRIX_FUNDED_AI_MAX_BODY_BYTES",
-      DEFAULT_BODY_LIMIT_BYTES,
-      256,
-      8 * 1024 * 1024,
+      env, "MATRIX_FUNDED_AI_MAX_BODY_BYTES", DEFAULT_BODY_LIMIT_BYTES, 256, 8 * 1024 * 1024,
     ),
     maxResponseBytes: readInteger(
-      env,
-      "MATRIX_FUNDED_AI_MAX_RESPONSE_BYTES",
-      DEFAULT_RESPONSE_LIMIT_BYTES,
-      1_024,
-      128 * 1024 * 1024,
+      env, "MATRIX_FUNDED_AI_MAX_RESPONSE_BYTES", DEFAULT_RESPONSE_LIMIT_BYTES, 1_024, 128 * 1024 * 1024,
+    ),
+    maxControlResponseBytes: readInteger(
+      env, "MATRIX_FUNDED_AI_MAX_CONTROL_RESPONSE_BYTES", DEFAULT_CONTROL_RESPONSE_LIMIT_BYTES, 1_024, 1024 * 1024,
     ),
     globalConcurrency: readInteger(
-      env,
-      "MATRIX_FUNDED_AI_GLOBAL_CONCURRENCY",
-      DEFAULT_GLOBAL_CONCURRENCY,
-      1,
-      10_000,
+      env, "MATRIX_FUNDED_AI_GLOBAL_CONCURRENCY", DEFAULT_GLOBAL_CONCURRENCY, 1, 10_000,
     ),
     globalRateLimitPerMinute: readInteger(
-      env,
-      "MATRIX_FUNDED_AI_GLOBAL_RATE_LIMIT",
-      DEFAULT_GLOBAL_RATE_LIMIT,
-      1,
-      10_000,
+      env, "MATRIX_FUNDED_AI_GLOBAL_RATE_LIMIT", DEFAULT_GLOBAL_RATE_LIMIT, 1, 10_000,
     ),
     runtimeConcurrency: readInteger(
-      env,
-      "MATRIX_FUNDED_AI_RUNTIME_CONCURRENCY",
-      DEFAULT_RUNTIME_CONCURRENCY,
-      1,
-      100,
+      env, "MATRIX_FUNDED_AI_RUNTIME_CONCURRENCY", DEFAULT_RUNTIME_CONCURRENCY, 1, 100,
     ),
     rateLimitPerMinute: readInteger(
-      env,
-      "MATRIX_FUNDED_AI_RATE_LIMIT",
-      DEFAULT_RATE_LIMIT,
-      1,
-      10_000,
+      env, "MATRIX_FUNDED_AI_RATE_LIMIT", DEFAULT_RATE_LIMIT, 1, 10_000,
     ),
     maxRuntimeEntries: readInteger(
-      env,
-      "MATRIX_FUNDED_AI_MAX_RUNTIME_ENTRIES",
-      DEFAULT_RUNTIME_REGISTRY_SIZE,
-      1,
-      100_000,
+      env, "MATRIX_FUNDED_AI_MAX_RUNTIME_ENTRIES", DEFAULT_RUNTIME_REGISTRY_SIZE, 1, 100_000,
     ),
   };
 }

--- a/packages/proxy/src/funded-relay-config.ts
+++ b/packages/proxy/src/funded-relay-config.ts
@@ -10,6 +10,10 @@ const DEFAULT_GLOBAL_RATE_LIMIT = 180;
 const DEFAULT_RUNTIME_CONCURRENCY = 2;
 const DEFAULT_RATE_LIMIT = 60;
 const DEFAULT_RUNTIME_REGISTRY_SIZE = 10_000;
+const DEFAULT_SETTLEMENT_QUEUE_CAPACITY = 1_024;
+const DEFAULT_SETTLEMENT_BATCH_SIZE = 16;
+const DEFAULT_SETTLEMENT_RETRY_INTERVAL_MS = 5_000;
+const DEFAULT_SETTLEMENT_TTL_MS = 25 * 60_000;
 const CLOUDFLARE_GATEWAY_HOST = "gateway.ai.cloudflare.com";
 
 export const COUNT_TOKENS_BODY_LIMIT_BYTES = 256 * 1024;
@@ -34,6 +38,10 @@ export interface FundedRelayConfig {
   runtimeConcurrency: number;
   rateLimitPerMinute: number;
   maxRuntimeEntries: number;
+  settlementQueueCapacity: number;
+  settlementBatchSize: number;
+  settlementRetryIntervalMs: number;
+  settlementTtlMs: number;
 }
 
 function readEnabled(value: string | undefined): boolean {
@@ -171,6 +179,18 @@ export function resolveFundedRelayConfig(
     ),
     maxRuntimeEntries: readInteger(
       env, "MATRIX_FUNDED_AI_MAX_RUNTIME_ENTRIES", DEFAULT_RUNTIME_REGISTRY_SIZE, 1, 100_000,
+    ),
+    settlementQueueCapacity: readInteger(
+      env, "MATRIX_FUNDED_AI_SETTLEMENT_QUEUE_CAPACITY", DEFAULT_SETTLEMENT_QUEUE_CAPACITY, 1, 10_000,
+    ),
+    settlementBatchSize: readInteger(
+      env, "MATRIX_FUNDED_AI_SETTLEMENT_BATCH_SIZE", DEFAULT_SETTLEMENT_BATCH_SIZE, 1, 100,
+    ),
+    settlementRetryIntervalMs: readInteger(
+      env, "MATRIX_FUNDED_AI_SETTLEMENT_RETRY_INTERVAL_MS", DEFAULT_SETTLEMENT_RETRY_INTERVAL_MS, 500, 60_000,
+    ),
+    settlementTtlMs: readInteger(
+      env, "MATRIX_FUNDED_AI_SETTLEMENT_TTL_MS", DEFAULT_SETTLEMENT_TTL_MS, 60_000, 30 * 60_000,
     ),
   };
 }

--- a/packages/proxy/src/funded-relay-config.ts
+++ b/packages/proxy/src/funded-relay-config.ts
@@ -117,8 +117,7 @@ export function normalizeFundedPlatformOrigin(raw: string): string {
   const rawHostname = rawAuthority.startsWith("[") && closingBracket >= 0
     ? rawAuthority.slice(0, closingBracket + 1).toLowerCase()
     : (rawAuthority.split(":", 1)[0] ?? "").toLowerCase();
-  const isExactLoopback = rawHostname === "localhost"
-    || rawHostname === "127.0.0.1"
+  const isExactLoopback = rawHostname === "127.0.0.1"
     || rawHostname === "[::1]";
   if (!exactOrigin
     || !(["http:", "https:"] as const).includes(url.protocol as "http:" | "https:")
@@ -126,7 +125,7 @@ export function normalizeFundedPlatformOrigin(raw: string): string {
     || (rawSuffix !== "" && rawSuffix !== "/")
     || (url.protocol === "http:" && !isExactLoopback)) {
     throw new Error(
-      "PLATFORM_INTERNAL_URL must be an HTTPS origin or an exact loopback HTTP origin without credentials or a path",
+      "PLATFORM_INTERNAL_URL must be an HTTPS origin or a literal loopback HTTP origin without credentials or a path",
     );
   }
   return url.origin;

--- a/packages/proxy/src/funded-relay-config.ts
+++ b/packages/proxy/src/funded-relay-config.ts
@@ -102,8 +102,8 @@ function readGatewayBaseUrl(env: NodeJS.ProcessEnv): string {
   return `${url.origin}${path}`;
 }
 
-function readPlatformBaseUrl(env: NodeJS.ProcessEnv): string {
-  const raw = readRequired(env, "PLATFORM_INTERNAL_URL", 2_048);
+export function normalizeFundedPlatformOrigin(raw: string): string {
+  const exactOrigin = /^(https?):\/\/([^/?#]*)(.*)$/i.exec(raw);
   let url: URL;
   try {
     url = new URL(raw);
@@ -111,12 +111,29 @@ function readPlatformBaseUrl(env: NodeJS.ProcessEnv): string {
     if (error instanceof TypeError) throw new Error("PLATFORM_INTERNAL_URL must be a valid URL");
     throw error;
   }
-  if (!(["http:", "https:"] as const).includes(url.protocol as "http:" | "https:")
+  const rawAuthority = exactOrigin?.[2] ?? "";
+  const rawSuffix = exactOrigin?.[3] ?? "";
+  const closingBracket = rawAuthority.indexOf("]");
+  const rawHostname = rawAuthority.startsWith("[") && closingBracket >= 0
+    ? rawAuthority.slice(0, closingBracket + 1).toLowerCase()
+    : (rawAuthority.split(":", 1)[0] ?? "").toLowerCase();
+  const isExactLoopback = rawHostname === "localhost"
+    || rawHostname === "127.0.0.1"
+    || rawHostname === "[::1]";
+  if (!exactOrigin
+    || !(["http:", "https:"] as const).includes(url.protocol as "http:" | "https:")
     || url.username !== "" || url.password !== "" || url.search !== "" || url.hash !== ""
-    || (url.pathname !== "" && url.pathname !== "/")) {
-    throw new Error("PLATFORM_INTERNAL_URL must be an HTTP(S) origin without credentials or a path");
+    || (rawSuffix !== "" && rawSuffix !== "/")
+    || (url.protocol === "http:" && !isExactLoopback)) {
+    throw new Error(
+      "PLATFORM_INTERNAL_URL must be an HTTPS origin or an exact loopback HTTP origin without credentials or a path",
+    );
   }
   return url.origin;
+}
+
+function readPlatformBaseUrl(env: NodeJS.ProcessEnv): string {
+  return normalizeFundedPlatformOrigin(readRequired(env, "PLATFORM_INTERNAL_URL", 2_048));
 }
 
 function readAllowedBetas(env: NodeJS.ProcessEnv): ReadonlySet<string> {

--- a/packages/proxy/src/funded-relay-model.ts
+++ b/packages/proxy/src/funded-relay-model.ts
@@ -1,0 +1,58 @@
+import { z } from "zod/v4";
+
+const NATIVE_SONNET_5 = "claude-sonnet-5";
+const CANONICAL_SONNET_5 = "anthropic/claude-sonnet-5";
+const LONG_CONTEXT_THRESHOLD = 200_000;
+const SAFETY_MARGIN_NUMERATOR = 120;
+const SAFETY_MARGIN_DENOMINATOR = 100;
+const TokenCountSchema = z.number().int().nonnegative().max(10_000_000);
+const OutputTokenCountSchema = z.number().int().positive().max(128_000);
+
+const PRICING = {
+  [CANONICAL_SONNET_5]: {
+    version: "anthropic-2026-08-29",
+    validThrough: "2026-08-31T23:59:59.999Z",
+    inputMicrousdPerToken: 2,
+    outputMicrousdPerToken: 10,
+    longInputMicrousdPerToken: 4,
+    longOutputMicrousdPerToken: 15,
+  },
+} as const;
+
+export interface FundedModelMapping {
+  nativeModelId: typeof NATIVE_SONNET_5;
+  canonicalModelId: typeof CANONICAL_SONNET_5;
+}
+
+export function mapFundedModel(modelId: string): FundedModelMapping {
+  if (modelId !== NATIVE_SONNET_5) throw new Error("Unsupported funded AI model");
+  return { nativeModelId: NATIVE_SONNET_5, canonicalModelId: CANONICAL_SONNET_5 };
+}
+
+export function estimateWorstCaseMicrousd(input: {
+  canonicalModelId: string;
+  inputTokens: number;
+  maxOutputTokens: number;
+  now: Date;
+}): { amountMicrousd: number; pricingVersion: string; pricingValidThrough: string } {
+  const pricing = PRICING[input.canonicalModelId as keyof typeof PRICING];
+  if (!pricing) throw new Error("Funded AI pricing is unavailable");
+  if (input.now.getTime() > Date.parse(pricing.validThrough)) {
+    throw new Error("Funded AI pricing has expired");
+  }
+  const inputTokens = TokenCountSchema.parse(input.inputTokens);
+  const maxOutputTokens = OutputTokenCountSchema.parse(input.maxOutputTokens);
+  const isLongContext = inputTokens > LONG_CONTEXT_THRESHOLD;
+  const inputRate = isLongContext ? pricing.longInputMicrousdPerToken : pricing.inputMicrousdPerToken;
+  const outputRate = isLongContext ? pricing.longOutputMicrousdPerToken : pricing.outputMicrousdPerToken;
+  const base = inputTokens * inputRate + maxOutputTokens * outputRate;
+  const amountMicrousd = Math.ceil(base * SAFETY_MARGIN_NUMERATOR / SAFETY_MARGIN_DENOMINATOR);
+  if (!Number.isSafeInteger(amountMicrousd) || amountMicrousd <= 0) {
+    throw new Error("Funded AI cost estimate exceeds supported bounds");
+  }
+  return {
+    amountMicrousd,
+    pricingVersion: pricing.version,
+    pricingValidThrough: pricing.validThrough,
+  };
+}

--- a/packages/proxy/src/funded-relay-model.ts
+++ b/packages/proxy/src/funded-relay-model.ts
@@ -1,23 +1,45 @@
 import { z } from "zod/v4";
 
 const NATIVE_SONNET_5 = "claude-sonnet-5";
+// Cloudflare's catalog identifier; provider-native Anthropic requests use the
+// bare ID above. https://developers.cloudflare.com/ai/models/anthropic/claude-sonnet-5/
 const CANONICAL_SONNET_5 = "anthropic/claude-sonnet-5";
-const LONG_CONTEXT_THRESHOLD = 200_000;
 const SAFETY_MARGIN_NUMERATOR = 120;
 const SAFETY_MARGIN_DENOMINATOR = 100;
 const TokenCountSchema = z.number().int().nonnegative().max(10_000_000);
 const OutputTokenCountSchema = z.number().int().positive().max(128_000);
 
-const PRICING = {
-  [CANONICAL_SONNET_5]: {
-    version: "anthropic-2026-08-29",
-    validThrough: "2026-08-31T23:59:59.999Z",
-    inputMicrousdPerToken: 2,
-    outputMicrousdPerToken: 10,
-    longInputMicrousdPerToken: 4,
-    longOutputMicrousdPerToken: 15,
-  },
-} as const;
+interface FundedPricing {
+  canonicalModelId: typeof CANONICAL_SONNET_5;
+  version: string;
+  validThrough: string;
+  inputRateTenths: number;
+  outputRateTenths: number;
+  cacheReadRateTenths: number;
+  cacheWrite5mRateTenths: number;
+  cacheWrite1hRateTenths: number;
+}
+
+// Anthropic made Sonnet 5's $2/$10 introductory rate permanent on 2026-08-31.
+// https://platform.claude.com/docs/en/about-claude/pricing
+// Keep the review horizon deliberately short so a stale list price fails closed.
+const CURRENT_PRICING: FundedPricing = {
+  canonicalModelId: CANONICAL_SONNET_5,
+  version: "anthropic-2026-08-31-standard",
+  validThrough: "2026-09-30T23:59:59.999Z",
+  inputRateTenths: 20,
+  outputRateTenths: 100,
+  cacheReadRateTenths: 2,
+  cacheWrite5mRateTenths: 25,
+  cacheWrite1hRateTenths: 40,
+};
+
+// Retain the previous version only for safe settlement of reservations created
+// before this deployment. It is never selected for new reservations.
+const SETTLEMENT_PRICING: Readonly<Record<string, FundedPricing>> = {
+  "anthropic-2026-08-29": { ...CURRENT_PRICING, version: "anthropic-2026-08-29" },
+  [CURRENT_PRICING.version]: CURRENT_PRICING,
+};
 
 export interface FundedModelMapping {
   nativeModelId: typeof NATIVE_SONNET_5;
@@ -28,7 +50,8 @@ export interface FundedTokenUsage {
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens: number;
-  cacheWriteTokens: number;
+  cacheWrite5mTokens: number;
+  cacheWrite1hTokens: number;
 }
 
 export function mapFundedModel(modelId: string): FundedModelMapping {
@@ -42,18 +65,23 @@ export function estimateWorstCaseMicrousd(input: {
   maxOutputTokens: number;
   now: Date;
 }): { amountMicrousd: number; pricingVersion: string; pricingValidThrough: string } {
-  const pricing = PRICING[input.canonicalModelId as keyof typeof PRICING];
+  const pricing = CURRENT_PRICING.canonicalModelId === input.canonicalModelId
+    ? CURRENT_PRICING
+    : null;
   if (!pricing) throw new Error("Funded AI pricing is unavailable");
   if (input.now.getTime() > Date.parse(pricing.validThrough)) {
     throw new Error("Funded AI pricing has expired");
   }
   const inputTokens = TokenCountSchema.parse(input.inputTokens);
   const maxOutputTokens = OutputTokenCountSchema.parse(input.maxOutputTokens);
-  const isLongContext = inputTokens > LONG_CONTEXT_THRESHOLD;
-  const inputRate = isLongContext ? pricing.longInputMicrousdPerToken : pricing.inputMicrousdPerToken;
-  const outputRate = isLongContext ? pricing.longOutputMicrousdPerToken : pricing.outputMicrousdPerToken;
-  const base = inputTokens * inputRate + maxOutputTokens * outputRate;
-  const amountMicrousd = Math.ceil(base * SAFETY_MARGIN_NUMERATOR / SAFETY_MARGIN_DENOMINATOR);
+  // Any counted input token may become a 1-hour cache write, the most
+  // expensive supported input operation. Reserving that upper bound keeps
+  // admission safe even when cache_control is nested in prompt content.
+  const baseTenths = inputTokens * pricing.cacheWrite1hRateTenths
+    + maxOutputTokens * pricing.outputRateTenths;
+  const amountMicrousd = Math.ceil(
+    baseTenths * SAFETY_MARGIN_NUMERATOR / SAFETY_MARGIN_DENOMINATOR / 10,
+  );
   if (!Number.isSafeInteger(amountMicrousd) || amountMicrousd <= 0) {
     throw new Error("Funded AI cost estimate exceeds supported bounds");
   }
@@ -69,21 +97,22 @@ export function priceActualUsageMicrousd(input: {
   pricingVersion: string;
   usage: FundedTokenUsage;
 }): number {
-  const pricing = PRICING[input.canonicalModelId as keyof typeof PRICING];
-  if (!pricing || pricing.version !== input.pricingVersion) {
+  const pricing = SETTLEMENT_PRICING[input.pricingVersion];
+  if (!pricing || pricing.canonicalModelId !== input.canonicalModelId) {
     throw new Error("Funded AI pricing version is unavailable");
   }
   const inputTokens = TokenCountSchema.parse(input.usage.inputTokens);
   const outputTokens = TokenCountSchema.parse(input.usage.outputTokens);
   const cacheReadTokens = TokenCountSchema.parse(input.usage.cacheReadTokens);
-  const cacheWriteTokens = TokenCountSchema.parse(input.usage.cacheWriteTokens);
-  const totalInputTokens = inputTokens + cacheReadTokens + cacheWriteTokens;
-  const isLongContext = totalInputTokens > LONG_CONTEXT_THRESHOLD;
+  const cacheWrite5mTokens = TokenCountSchema.parse(input.usage.cacheWrite5mTokens);
+  const cacheWrite1hTokens = TokenCountSchema.parse(input.usage.cacheWrite1hTokens);
   // Rates are stored in tenths of a microusd so discounted cache pricing
   // remains integer-only through the calculation.
-  const numerator = isLongContext
-    ? inputTokens * 40 + outputTokens * 150 + cacheReadTokens * 4 + cacheWriteTokens * 50
-    : inputTokens * 20 + outputTokens * 100 + cacheReadTokens * 2 + cacheWriteTokens * 25;
+  const numerator = inputTokens * pricing.inputRateTenths
+    + outputTokens * pricing.outputRateTenths
+    + cacheReadTokens * pricing.cacheReadRateTenths
+    + cacheWrite5mTokens * pricing.cacheWrite5mRateTenths
+    + cacheWrite1hTokens * pricing.cacheWrite1hRateTenths;
   const amountMicrousd = Math.ceil(numerator / 10);
   if (!Number.isSafeInteger(amountMicrousd) || amountMicrousd < 0) {
     throw new Error("Funded AI actual cost exceeds supported bounds");

--- a/packages/proxy/src/funded-relay-model.ts
+++ b/packages/proxy/src/funded-relay-model.ts
@@ -24,6 +24,13 @@ export interface FundedModelMapping {
   canonicalModelId: typeof CANONICAL_SONNET_5;
 }
 
+export interface FundedTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+}
+
 export function mapFundedModel(modelId: string): FundedModelMapping {
   if (modelId !== NATIVE_SONNET_5) throw new Error("Unsupported funded AI model");
   return { nativeModelId: NATIVE_SONNET_5, canonicalModelId: CANONICAL_SONNET_5 };
@@ -55,4 +62,31 @@ export function estimateWorstCaseMicrousd(input: {
     pricingVersion: pricing.version,
     pricingValidThrough: pricing.validThrough,
   };
+}
+
+export function priceActualUsageMicrousd(input: {
+  canonicalModelId: string;
+  pricingVersion: string;
+  usage: FundedTokenUsage;
+}): number {
+  const pricing = PRICING[input.canonicalModelId as keyof typeof PRICING];
+  if (!pricing || pricing.version !== input.pricingVersion) {
+    throw new Error("Funded AI pricing version is unavailable");
+  }
+  const inputTokens = TokenCountSchema.parse(input.usage.inputTokens);
+  const outputTokens = TokenCountSchema.parse(input.usage.outputTokens);
+  const cacheReadTokens = TokenCountSchema.parse(input.usage.cacheReadTokens);
+  const cacheWriteTokens = TokenCountSchema.parse(input.usage.cacheWriteTokens);
+  const totalInputTokens = inputTokens + cacheReadTokens + cacheWriteTokens;
+  const isLongContext = totalInputTokens > LONG_CONTEXT_THRESHOLD;
+  // Rates are stored in tenths of a microusd so discounted cache pricing
+  // remains integer-only through the calculation.
+  const numerator = isLongContext
+    ? inputTokens * 40 + outputTokens * 150 + cacheReadTokens * 4 + cacheWriteTokens * 50
+    : inputTokens * 20 + outputTokens * 100 + cacheReadTokens * 2 + cacheWriteTokens * 25;
+  const amountMicrousd = Math.ceil(numerator / 10);
+  if (!Number.isSafeInteger(amountMicrousd) || amountMicrousd < 0) {
+    throw new Error("Funded AI actual cost exceeds supported bounds");
+  }
+  return amountMicrousd;
 }

--- a/packages/proxy/src/funded-relay-platform-client.ts
+++ b/packages/proxy/src/funded-relay-platform-client.ts
@@ -1,0 +1,104 @@
+import {
+  FundedAiAuthorizationResponseSchema,
+  FundedAiPolicyCheckResponseSchema,
+  FundedAiReleaseResponseSchema,
+  FundedAiStartResponseSchema,
+  type FundedAiAuthorizationResponse,
+  type FundedAiPolicyCheckResponse,
+  type FundedAiReleaseResponse,
+  type FundedAiStartResponse,
+} from "@matrix-os/contracts";
+import type { z } from "zod/v4";
+import type { FundedRelayConfig } from "./funded-relay-config.js";
+
+export class FundedControlPlaneError extends Error {
+  constructor(readonly status: number) {
+    super("Funded AI control-plane request failed");
+    this.name = "FundedControlPlaneError";
+  }
+}
+
+async function readBoundedText(response: Response, maxBytes: number): Promise<string> {
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null && Number(declaredLength) > maxBytes) {
+    await response.body?.cancel("control response too large");
+    throw new Error("Funded AI control response exceeded its limit");
+  }
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let seen = 0;
+  let output = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      seen += value.byteLength;
+      if (seen > maxBytes) {
+        await reader.cancel("control response too large");
+        throw new Error("Funded AI control response exceeded its limit");
+      }
+      output += decoder.decode(value, { stream: true });
+    }
+    output += decoder.decode();
+    return output;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export interface FundedPlatformClient {
+  check(input: { credential: string; modelId: string }, signal: AbortSignal): Promise<FundedAiPolicyCheckResponse>;
+  authorize(input: {
+    credential: string;
+    requestId: string;
+    modelId: string;
+    maxCostMicrousd: number;
+  }, signal: AbortSignal): Promise<FundedAiAuthorizationResponse>;
+  start(input: { reservationId: string; tokenId: string }, signal: AbortSignal): Promise<FundedAiStartResponse>;
+  release(input: {
+    reservationId: string;
+    tokenId: string;
+    reason: "pre_upstream_failure";
+  }, signal: AbortSignal): Promise<FundedAiReleaseResponse>;
+}
+
+export function createFundedPlatformClient(options: Pick<
+  FundedRelayConfig,
+  "platformBaseUrl" | "relayControlToken" | "platformTimeoutMs" | "maxControlResponseBytes"
+> & { fetch: typeof fetch }): FundedPlatformClient {
+  async function call<T>(
+    action: "authorize" | "check" | "release" | "start",
+    body: unknown,
+    schema: z.ZodType<T>,
+    lifetimeSignal: AbortSignal,
+  ): Promise<T> {
+    const response = await options.fetch(`${options.platformBaseUrl}/internal/ai/funded/${action}`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${options.relayControlToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+      redirect: "error",
+      signal: AbortSignal.any([lifetimeSignal, AbortSignal.timeout(options.platformTimeoutMs)]),
+    });
+    const text = await readBoundedText(response, options.maxControlResponseBytes);
+    if (!response.ok) throw new FundedControlPlaneError(response.status);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text) as unknown;
+    } catch (error) {
+      if (error instanceof SyntaxError) throw new Error("Funded AI control response was invalid");
+      throw error;
+    }
+    return schema.parse(parsed);
+  }
+
+  return {
+    check: (input, signal) => call("check", input, FundedAiPolicyCheckResponseSchema, signal),
+    authorize: (input, signal) => call("authorize", input, FundedAiAuthorizationResponseSchema, signal),
+    start: (input, signal) => call("start", input, FundedAiStartResponseSchema, signal),
+    release: (input, signal) => call("release", input, FundedAiReleaseResponseSchema, signal),
+  };
+}

--- a/packages/proxy/src/funded-relay-platform-client.ts
+++ b/packages/proxy/src/funded-relay-platform-client.ts
@@ -12,7 +12,10 @@ import {
   type FundedAiStartResponse,
 } from "@matrix-os/contracts";
 import type { z } from "zod/v4";
-import type { FundedRelayConfig } from "./funded-relay-config.js";
+import {
+  normalizeFundedPlatformOrigin,
+  type FundedRelayConfig,
+} from "./funded-relay-config.js";
 
 export class FundedControlPlaneError extends Error {
   constructor(readonly status: number) {
@@ -71,23 +74,29 @@ export function createFundedPlatformClient(options: Pick<
   FundedRelayConfig,
   "platformBaseUrl" | "relayControlToken" | "platformTimeoutMs" | "maxControlResponseBytes"
 > & { fetch: typeof fetch }): FundedPlatformClient {
+  const platformBaseUrl = normalizeFundedPlatformOrigin(options.platformBaseUrl);
+  const relayControlToken = options.relayControlToken;
+  const platformTimeoutMs = options.platformTimeoutMs;
+  const maxControlResponseBytes = options.maxControlResponseBytes;
+  const fetchImpl = options.fetch;
+
   async function call<T>(
     action: "authorize" | "check" | "finalize" | "release" | "start",
     body: unknown,
     schema: z.ZodType<T>,
     lifetimeSignal: AbortSignal,
   ): Promise<T> {
-    const response = await options.fetch(`${options.platformBaseUrl}/internal/ai/funded/${action}`, {
+    const response = await fetchImpl(`${platformBaseUrl}/internal/ai/funded/${action}`, {
       method: "POST",
       headers: {
-        authorization: `Bearer ${options.relayControlToken}`,
+        authorization: `Bearer ${relayControlToken}`,
         "content-type": "application/json",
       },
       body: JSON.stringify(body),
       redirect: "error",
-      signal: AbortSignal.any([lifetimeSignal, AbortSignal.timeout(options.platformTimeoutMs)]),
+      signal: AbortSignal.any([lifetimeSignal, AbortSignal.timeout(platformTimeoutMs)]),
     });
-    const text = await readBoundedText(response, options.maxControlResponseBytes);
+    const text = await readBoundedText(response, maxControlResponseBytes);
     if (!response.ok) throw new FundedControlPlaneError(response.status);
     let parsed: unknown;
     try {

--- a/packages/proxy/src/funded-relay-platform-client.ts
+++ b/packages/proxy/src/funded-relay-platform-client.ts
@@ -1,9 +1,12 @@
 import {
   FundedAiAuthorizationResponseSchema,
+  FundedAiFinalizationResponseSchema,
   FundedAiPolicyCheckResponseSchema,
   FundedAiReleaseResponseSchema,
   FundedAiStartResponseSchema,
   type FundedAiAuthorizationResponse,
+  type FundedAiFinalizationRequest,
+  type FundedAiFinalizationResponse,
   type FundedAiPolicyCheckResponse,
   type FundedAiReleaseResponse,
   type FundedAiStartResponse,
@@ -61,6 +64,7 @@ export interface FundedPlatformClient {
     tokenId: string;
     reason: "pre_upstream_failure";
   }, signal: AbortSignal): Promise<FundedAiReleaseResponse>;
+  finalize(input: FundedAiFinalizationRequest, signal: AbortSignal): Promise<FundedAiFinalizationResponse>;
 }
 
 export function createFundedPlatformClient(options: Pick<
@@ -68,7 +72,7 @@ export function createFundedPlatformClient(options: Pick<
   "platformBaseUrl" | "relayControlToken" | "platformTimeoutMs" | "maxControlResponseBytes"
 > & { fetch: typeof fetch }): FundedPlatformClient {
   async function call<T>(
-    action: "authorize" | "check" | "release" | "start",
+    action: "authorize" | "check" | "finalize" | "release" | "start",
     body: unknown,
     schema: z.ZodType<T>,
     lifetimeSignal: AbortSignal,
@@ -100,5 +104,6 @@ export function createFundedPlatformClient(options: Pick<
     authorize: (input, signal) => call("authorize", input, FundedAiAuthorizationResponseSchema, signal),
     start: (input, signal) => call("start", input, FundedAiStartResponseSchema, signal),
     release: (input, signal) => call("release", input, FundedAiReleaseResponseSchema, signal),
+    finalize: (input, signal) => call("finalize", input, FundedAiFinalizationResponseSchema, signal),
   };
 }

--- a/packages/proxy/src/funded-relay-request.ts
+++ b/packages/proxy/src/funded-relay-request.ts
@@ -1,5 +1,7 @@
 import { z } from "zod/v4";
-import { BETA_ID, MODEL_ID } from "./funded-relay-config.js";
+import { BETA_ID } from "./funded-relay-config.js";
+
+const MODEL_ID = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
 
 const MAX_JSON_DEPTH = 16;
 const MAX_JSON_ARRAY_ITEMS = 2_048;
@@ -121,7 +123,19 @@ export type FundedRequest = z.infer<typeof FundedRequestSchema>;
 
 export function serializeFundedRequest(value: unknown): { body: string; request: FundedRequest } {
   const request = FundedRequestSchema.parse(value);
-  return { body: JSON.stringify(request), request };
+  const { metadata: _callerMetadata, ...forwarded } = request;
+  return { body: JSON.stringify(forwarded), request };
+}
+
+export function serializeCountTokensRequest(request: FundedRequest): string {
+  return JSON.stringify({
+    model: request.model,
+    messages: request.messages,
+    ...(request.system === undefined ? {} : { system: request.system }),
+    ...(request.tools === undefined ? {} : { tools: request.tools }),
+    ...(request.tool_choice === undefined ? {} : { tool_choice: request.tool_choice }),
+    ...(request.thinking === undefined ? {} : { thinking: request.thinking }),
+  });
 }
 
 export function resolveRequestedBetas(

--- a/packages/proxy/src/funded-relay-settlement-queue.ts
+++ b/packages/proxy/src/funded-relay-settlement-queue.ts
@@ -1,0 +1,105 @@
+import type { FundedAiFinalizationRequest } from "@matrix-os/contracts";
+
+interface PendingSettlement {
+  task: FundedAiFinalizationRequest;
+  expiresAt: number;
+}
+
+export class SettlementRetryQueue {
+  private readonly pending = new Map<string, PendingSettlement>();
+  private readonly timer: ReturnType<typeof setInterval>;
+  private flushing: Promise<void> | null = null;
+  private closing = false;
+
+  constructor(private readonly options: {
+    capacity: number;
+    ttlMs: number;
+    retryIntervalMs: number;
+    batchSize?: number;
+    now: () => number;
+    finalize: (task: FundedAiFinalizationRequest) => Promise<unknown>;
+  }) {
+    this.timer = setInterval(() => {
+      this.sweepExpired();
+      void this.flush();
+    }, options.retryIntervalMs);
+    this.timer.unref?.();
+  }
+
+  get pendingCount(): number {
+    return this.pending.size;
+  }
+
+  get pendingIds(): string[] {
+    return [...this.pending.keys()];
+  }
+
+  enqueue(task: FundedAiFinalizationRequest): void {
+    if (this.closing) return;
+    this.sweepExpired();
+    const existing = this.pending.get(task.reservationId);
+    if (existing) {
+      if (JSON.stringify(existing.task) !== JSON.stringify(task)) {
+        console.warn("[proxy] Conflicting funded AI finalization was ignored");
+      }
+      return;
+    }
+    if (this.pending.size >= this.options.capacity) {
+      const oldest = this.pending.keys().next().value as string | undefined;
+      if (oldest !== undefined) this.pending.delete(oldest);
+      console.warn("[proxy] Funded AI finalization queue evicted its oldest work");
+    }
+    this.pending.set(task.reservationId, {
+      task,
+      expiresAt: this.options.now() + this.options.ttlMs,
+    });
+    void this.flush();
+  }
+
+  sweepExpired(): void {
+    const now = this.options.now();
+    for (const [reservationId, item] of this.pending) {
+      if (item.expiresAt <= now) this.pending.delete(reservationId);
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.flushing) return this.flushing;
+    const running = this.flushOnce();
+    this.flushing = running;
+    try {
+      await running;
+    } finally {
+      if (this.flushing === running) this.flushing = null;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.closing) return;
+    this.closing = true;
+    clearInterval(this.timer);
+    await this.flush();
+    if (this.pending.size > 0) await this.flush();
+    this.pending.clear();
+  }
+
+  private async flushOnce(): Promise<void> {
+    this.sweepExpired();
+    const batchSize = this.options.batchSize ?? 16;
+    const batch = [...this.pending].slice(0, batchSize);
+    await Promise.all(batch.map(async ([reservationId, item]) => {
+      try {
+        await this.options.finalize(item.task);
+        if (this.pending.get(reservationId) === item) this.pending.delete(reservationId);
+      } catch (error) {
+        const status = typeof error === "object" && error !== null && "status" in error
+          ? Number((error as { status: unknown }).status) : null;
+        if (status !== null && status >= 400 && status < 500 && status !== 408 && status !== 429) {
+          this.pending.delete(reservationId);
+        }
+        const errorName = error instanceof Error ? error.name : "UnknownError";
+        console.warn("[proxy] Funded AI finalization retry failed", { errorName, status });
+      }
+    }));
+  }
+}

--- a/packages/proxy/src/funded-relay-stream.ts
+++ b/packages/proxy/src/funded-relay-stream.ts
@@ -19,10 +19,26 @@ export function boundedBody(
   lease: AdmissionLease,
   abortUpstream: (reason?: unknown) => void,
   lifetimeSignal: AbortSignal,
+  observer?: {
+    push(chunk: Uint8Array): void;
+    complete(): void;
+    ambiguous(): void;
+  },
 ): ReadableStream<Uint8Array> {
   const reader = source.getReader();
   let seen = 0;
   let settled = false;
+  let terminalReported = false;
+  const reportComplete = (): void => {
+    if (terminalReported) return;
+    terminalReported = true;
+    observer?.complete();
+  };
+  const reportAmbiguous = (): void => {
+    if (terminalReported) return;
+    terminalReported = true;
+    observer?.ambiguous();
+  };
   const settle = (): void => {
     if (settled) return;
     settled = true;
@@ -30,6 +46,7 @@ export function boundedBody(
     lease.release();
   };
   const onLifetimeAbort = (): void => {
+    reportAmbiguous();
     void reader.cancel("request lifetime ended").catch((error: unknown) => {
       const errorName = error instanceof Error ? error.name : "UnknownError";
       console.warn("[proxy] Funded AI response cancellation failed", { errorName });
@@ -47,6 +64,7 @@ export function boundedBody(
       try {
         const result = await reader.read();
         if (result.done) {
+          reportComplete();
           settle();
           reader.releaseLock();
           controller.close();
@@ -54,14 +72,17 @@ export function boundedBody(
         }
         seen += result.value.byteLength;
         if (seen > maxBytes) {
+          reportAmbiguous();
           abortUpstream("response limit exceeded");
           await reader.cancel("response limit exceeded");
           settle();
           controller.error(new Error("AI response exceeded the configured limit"));
           return;
         }
+        observer?.push(result.value);
         controller.enqueue(result.value);
       } catch (error) {
+        reportAmbiguous();
         settle();
         if (!lifetimeSignal.aborted) {
           const errorName = error instanceof Error ? error.name : "UnknownError";
@@ -71,6 +92,7 @@ export function boundedBody(
       }
     },
     async cancel(reason) {
+      reportAmbiguous();
       abortUpstream(reason);
       try {
         await reader.cancel(reason);

--- a/packages/proxy/src/funded-relay-usage.ts
+++ b/packages/proxy/src/funded-relay-usage.ts
@@ -3,16 +3,35 @@ import { priceActualUsageMicrousd, type FundedTokenUsage } from "./funded-relay-
 
 const DEFAULT_CAPTURE_LIMIT = 1024 * 1024;
 const TokenSchema = z.number().int().nonnegative().max(10_000_000);
+const CacheCreationSchema = z.object({
+  ephemeral_5m_input_tokens: TokenSchema,
+  ephemeral_1h_input_tokens: TokenSchema,
+}).strict();
 const UsageSchema = z.object({
   input_tokens: TokenSchema,
   output_tokens: TokenSchema.optional(),
   cache_read_input_tokens: TokenSchema.optional(),
   cache_creation_input_tokens: TokenSchema.optional(),
+  cache_creation: CacheCreationSchema.optional(),
+}).superRefine((usage, ctx) => {
+  const total = usage.cache_creation_input_tokens ?? 0;
+  if (total === 0 && usage.cache_creation === undefined) return;
+  if (usage.cache_creation === undefined) {
+    ctx.addIssue({ code: "custom", message: "Cache creation TTL breakdown is required" });
+    return;
+  }
+  if (
+    usage.cache_creation.ephemeral_5m_input_tokens
+      + usage.cache_creation.ephemeral_1h_input_tokens
+    !== total
+  ) {
+    ctx.addIssue({ code: "custom", message: "Cache creation usage is inconsistent" });
+  }
 });
 const JsonResponseSchema = z.object({
   type: z.literal("message"),
   model: z.string(),
-  usage: UsageSchema.extend({ output_tokens: TokenSchema }),
+  usage: UsageSchema.safeExtend({ output_tokens: TokenSchema }),
 });
 
 export type FundedFinalization =
@@ -29,7 +48,8 @@ function toUsage(input: z.infer<typeof UsageSchema>, outputTokens: number): Fund
     inputTokens: input.input_tokens,
     outputTokens,
     cacheReadTokens: input.cache_read_input_tokens ?? 0,
-    cacheWriteTokens: input.cache_creation_input_tokens ?? 0,
+    cacheWrite5mTokens: input.cache_creation?.ephemeral_5m_input_tokens ?? 0,
+    cacheWrite1hTokens: input.cache_creation?.ephemeral_1h_input_tokens ?? 0,
   };
 }
 

--- a/packages/proxy/src/funded-relay-usage.ts
+++ b/packages/proxy/src/funded-relay-usage.ts
@@ -1,0 +1,174 @@
+import { z } from "zod/v4";
+import { priceActualUsageMicrousd, type FundedTokenUsage } from "./funded-relay-model.js";
+
+const DEFAULT_CAPTURE_LIMIT = 1024 * 1024;
+const TokenSchema = z.number().int().nonnegative().max(10_000_000);
+const UsageSchema = z.object({
+  input_tokens: TokenSchema,
+  output_tokens: TokenSchema.optional(),
+  cache_read_input_tokens: TokenSchema.optional(),
+  cache_creation_input_tokens: TokenSchema.optional(),
+});
+const JsonResponseSchema = z.object({
+  type: z.literal("message"),
+  model: z.string(),
+  usage: UsageSchema.extend({ output_tokens: TokenSchema }),
+});
+
+export type FundedFinalization =
+  | { mode: "exact"; actualCostMicrousd: number }
+  | { mode: "conservative" };
+
+export interface FundedUsageTracker {
+  push(chunk: Uint8Array): void;
+  complete(): FundedFinalization;
+}
+
+function toUsage(input: z.infer<typeof UsageSchema>, outputTokens: number): FundedTokenUsage {
+  return {
+    inputTokens: input.input_tokens,
+    outputTokens,
+    cacheReadTokens: input.cache_read_input_tokens ?? 0,
+    cacheWriteTokens: input.cache_creation_input_tokens ?? 0,
+  };
+}
+
+export function createFundedUsageTracker(options: {
+  contentType: string;
+  nativeModelId: string;
+  canonicalModelId: string;
+  pricingVersion: string;
+  maxCaptureBytes?: number;
+}): FundedUsageTracker {
+  const maxCaptureBytes = options.maxCaptureBytes ?? DEFAULT_CAPTURE_LIMIT;
+  const isSse = options.contentType.toLowerCase().startsWith("text/event-stream");
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let buffer = "";
+  let seenBytes = 0;
+  let invalid = false;
+  let completed = false;
+  let startUsage: z.infer<typeof UsageSchema> | null = null;
+  let outputTokens: number | null = null;
+  let sawStop = false;
+
+  function processSseEvent(block: string): void {
+    const data = block.split(/\r?\n/).filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trimStart()).join("\n");
+    if (data === "" || data === "[DONE]") return;
+    let value: unknown;
+    try {
+      value = JSON.parse(data) as unknown;
+    } catch (error) {
+      if (!(error instanceof Error)) console.warn("[proxy] Funded AI usage event parse failed");
+      invalid = true;
+      return;
+    }
+    if (typeof value !== "object" || value === null || !("type" in value)) {
+      invalid = true;
+      return;
+    }
+    const event = value as Record<string, unknown>;
+    if (event.type === "message_start") {
+      if (startUsage !== null || sawStop || typeof event.message !== "object" || event.message === null) {
+        invalid = true;
+        return;
+      }
+      const message = event.message as Record<string, unknown>;
+      const usage = UsageSchema.safeParse(message.usage);
+      if (message.type !== "message" || message.model !== options.nativeModelId || !usage.success) {
+        invalid = true;
+        return;
+      }
+      startUsage = usage.data;
+      return;
+    }
+    if (event.type === "message_delta") {
+      const usage = z.object({ output_tokens: TokenSchema }).safeParse(event.usage);
+      if (startUsage === null || sawStop || !usage.success || outputTokens !== null) {
+        invalid = true;
+        return;
+      }
+      outputTokens = usage.data.output_tokens;
+      return;
+    }
+    if (event.type === "message_stop") {
+      if (startUsage === null || outputTokens === null || sawStop) invalid = true;
+      sawStop = true;
+      return;
+    }
+    if (event.type === "error") invalid = true;
+  }
+
+  function processAvailableEvents(final: boolean): void {
+    while (true) {
+      const separator = /\r?\n\r?\n/.exec(buffer);
+      if (!separator || separator.index === undefined) break;
+      const block = buffer.slice(0, separator.index);
+      buffer = buffer.slice(separator.index + separator[0].length);
+      processSseEvent(block);
+    }
+    if (final && buffer.trim() !== "") {
+      processSseEvent(buffer);
+      buffer = "";
+    }
+  }
+
+  return {
+    push(chunk) {
+      if (completed || invalid) return;
+      seenBytes += chunk.byteLength;
+      if (seenBytes > maxCaptureBytes) {
+        invalid = true;
+        buffer = "";
+        return;
+      }
+      try {
+        buffer += decoder.decode(chunk, { stream: true });
+        if (isSse) processAvailableEvents(false);
+      } catch (error) {
+        if (!(error instanceof Error)) console.warn("[proxy] Funded AI usage decoding failed");
+        invalid = true;
+        buffer = "";
+      }
+    },
+    complete() {
+      if (completed) return { mode: "conservative" };
+      completed = true;
+      try {
+        buffer += decoder.decode();
+      } catch (error) {
+        if (!(error instanceof Error)) console.warn("[proxy] Funded AI usage decoding failed");
+        invalid = true;
+      }
+      let usage: FundedTokenUsage | null = null;
+      if (!invalid && isSse) {
+        processAvailableEvents(true);
+        if (!invalid && startUsage !== null && outputTokens !== null && sawStop) {
+          usage = toUsage(startUsage, outputTokens);
+        }
+      } else if (!invalid) {
+        try {
+          const parsed = JsonResponseSchema.parse(JSON.parse(buffer) as unknown);
+          if (parsed.model === options.nativeModelId) usage = toUsage(parsed.usage, parsed.usage.output_tokens);
+        } catch (error) {
+          if (!(error instanceof Error)) console.warn("[proxy] Funded AI usage response parse failed");
+          invalid = true;
+        }
+      }
+      if (!usage) return { mode: "conservative" };
+      try {
+        return {
+          mode: "exact",
+          actualCostMicrousd: priceActualUsageMicrousd({
+            canonicalModelId: options.canonicalModelId,
+            pricingVersion: options.pricingVersion,
+            usage,
+          }),
+        };
+      } catch (error) {
+        if (!(error instanceof Error)) console.warn("[proxy] Funded AI usage pricing failed");
+        return { mode: "conservative" };
+      }
+    },
+  };
+}

--- a/packages/proxy/src/funded-relay.ts
+++ b/packages/proxy/src/funded-relay.ts
@@ -382,10 +382,14 @@ export function createFundedRelay(dependencies: FundedRelayDependencies | null):
       signal: generationSignal,
     };
     try {
-      await platform.start(
+      const started = await platform.start(
         { reservationId: reservation.reservationId, tokenId: authorization.identity.tokenId },
         state.lifetimeSignal,
       );
+      if (started.reservationId !== reservation.reservationId
+        || started.requestId !== requestId || started.tokenId !== authorization.identity.tokenId) {
+        throw new Error("Funded AI start response did not match its reservation");
+      }
       const upstream = await fetchImpl(generationUrl, generationInit);
       clearTimeout(firstResponseTimer);
       if (!upstream.ok) {
@@ -430,6 +434,12 @@ export function createFundedRelay(dependencies: FundedRelayDependencies | null):
       return new Response(responseBody, { status: upstream.status, headers: safeUpstreamHeaders(upstream) });
     } catch (error) {
       clearTimeout(firstResponseTimer);
+      if (error instanceof FundedControlPlaneError) {
+        await releaseBeforeStart(reservation.reservationId, authorization.identity.tokenId);
+        resourceLease.release();
+        state.resourceLease = null;
+        return controlPlaneError(c, error);
+      }
       enqueueFinalization({ mode: "conservative" });
       resourceLease.release();
       state.resourceLease = null;

--- a/packages/proxy/src/funded-relay.ts
+++ b/packages/proxy/src/funded-relay.ts
@@ -18,7 +18,9 @@ import {
   serializeFundedRequest,
   type FundedRequest,
 } from "./funded-relay-request.js";
+import { SettlementRetryQueue } from "./funded-relay-settlement-queue.js";
 import { boundedBody, safeUpstreamHeaders } from "./funded-relay-stream.js";
+import { createFundedUsageTracker, type FundedFinalization } from "./funded-relay-usage.js";
 
 const MESSAGES_PATH = "/v1/messages";
 const COUNT_TOKENS_PATH = "/v1/messages/count_tokens";
@@ -50,7 +52,7 @@ interface ActiveRequestState {
 
 export interface FundedRelay {
   register(app: Hono): void;
-  close(): void;
+  close(): Promise<void>;
 }
 
 function opaqueRef(secret: string, domain: string, value: string): string {
@@ -164,7 +166,7 @@ function createDisabledRelay(): FundedRelay {
         return errorResponse(c, 403, "permission_error", "Matrix-funded AI is disabled");
       });
     },
-    close() {
+    async close() {
       // Disabled relays own no resources.
     },
   };
@@ -178,6 +180,14 @@ export function createFundedRelay(dependencies: FundedRelayDependencies | null):
   const requestIdFactory = config.requestIdFactory ?? randomUUID;
   const admission = new AdmissionController(config, () => now().getTime());
   const platform = config.platformClient ?? createFundedPlatformClient({ ...config, fetch: fetchImpl });
+  const settlementQueue = new SettlementRetryQueue({
+    capacity: config.settlementQueueCapacity,
+    batchSize: config.settlementBatchSize,
+    ttlMs: config.settlementTtlMs,
+    retryIntervalMs: config.settlementRetryIntervalMs,
+    now: () => now().getTime(),
+    finalize: (task) => platform.finalize(task, AbortSignal.timeout(config.platformTimeoutMs)),
+  });
   const activeRequests = new Set<AbortController>();
   const requestStates = new WeakMap<Context, ActiveRequestState>();
 
@@ -297,19 +307,20 @@ export function createFundedRelay(dependencies: FundedRelayDependencies | null):
     }
     if (c.req.path === COUNT_TOKENS_PATH) return counted.response;
 
-    let maxCostMicrousd: number;
+    let estimate: ReturnType<typeof estimateWorstCaseMicrousd>;
     try {
-      maxCostMicrousd = estimateWorstCaseMicrousd({
+      estimate = estimateWorstCaseMicrousd({
         canonicalModelId: model.canonicalModelId,
         inputTokens: counted.inputTokens,
         maxOutputTokens: parsedBody.max_tokens!,
         now: now(),
-      }).amountMicrousd;
+      });
     } catch (error) {
       const errorName = error instanceof Error ? error.name : "UnknownError";
       console.warn("[proxy] Funded AI pricing unavailable", { errorName });
       return errorResponse(c, 503, "api_error", "AI access is temporarily unavailable");
     }
+    const maxCostMicrousd = estimate.amountMicrousd;
 
     let authorization: Awaited<ReturnType<FundedPlatformClient["authorize"]>>;
     try {
@@ -345,6 +356,17 @@ export function createFundedRelay(dependencies: FundedRelayDependencies | null):
       },
     };
     state.resourceLease = resourceLease;
+    const finalizationLocator = {
+      reservationId: reservation.reservationId,
+      tokenId: authorization.identity.tokenId,
+    };
+    const enqueueFinalization = (result: FundedFinalization): void => {
+      if (result.mode === "exact" && result.actualCostMicrousd <= reservation.reservedMicrousd) {
+        settlementQueue.enqueue({ ...finalizationLocator, ...result });
+      } else {
+        settlementQueue.enqueue({ ...finalizationLocator, mode: "conservative" });
+      }
+    };
 
     const firstResponseController = new AbortController();
     const firstResponseTimer = setTimeout(() => {
@@ -367,6 +389,7 @@ export function createFundedRelay(dependencies: FundedRelayDependencies | null):
       const upstream = await fetchImpl(generationUrl, generationInit);
       clearTimeout(firstResponseTimer);
       if (!upstream.ok) {
+        enqueueFinalization({ mode: "conservative" });
         await upstream.body?.cancel("upstream rejected request");
         resourceLease.release();
         state.resourceLease = null;
@@ -377,6 +400,7 @@ export function createFundedRelay(dependencies: FundedRelayDependencies | null):
         return errorResponse(c, 502, "api_error", "AI access is temporarily unavailable");
       }
       if (!upstream.body) {
+        enqueueFinalization({ mode: "conservative" });
         resourceLease.release();
         state.resourceLease = null;
         return new Response(null, { status: upstream.status, headers: safeUpstreamHeaders(upstream) });
@@ -387,11 +411,26 @@ export function createFundedRelay(dependencies: FundedRelayDependencies | null):
         resourceLease,
         (reason) => state.controller.abort(reason),
         state.lifetimeSignal,
+        (() => {
+          const tracker = createFundedUsageTracker({
+            contentType: upstream.headers.get("content-type") ?? "application/json",
+            nativeModelId: model.nativeModelId,
+            canonicalModelId: model.canonicalModelId,
+            pricingVersion: estimate.pricingVersion,
+            maxCaptureBytes: config.maxResponseBytes,
+          });
+          return {
+            push: (chunk: Uint8Array) => tracker.push(chunk),
+            complete: () => enqueueFinalization(tracker.complete()),
+            ambiguous: () => enqueueFinalization({ mode: "conservative" }),
+          };
+        })(),
       );
       state.handedOff = true;
       return new Response(responseBody, { status: upstream.status, headers: safeUpstreamHeaders(upstream) });
     } catch (error) {
       clearTimeout(firstResponseTimer);
+      enqueueFinalization({ mode: "conservative" });
       resourceLease.release();
       state.resourceLease = null;
       const errorName = error instanceof Error ? error.name : "UnknownError";
@@ -459,10 +498,11 @@ export function createFundedRelay(dependencies: FundedRelayDependencies | null):
         return state ? handle(c, state) : next();
       });
     },
-    close() {
+    async close() {
       for (const controller of activeRequests) controller.abort("relay shutting down");
       activeRequests.clear();
       admission.close();
+      await settlementQueue.close();
     },
   };
 }

--- a/packages/proxy/src/funded-relay.ts
+++ b/packages/proxy/src/funded-relay.ts
@@ -1,36 +1,50 @@
-import { createHmac } from "node:crypto";
+import { createHmac, randomUUID } from "node:crypto";
+import { FundedAiPolicyCheckRequestSchema, type FundedAiIdentity } from "@matrix-os/contracts";
 import type { Context, Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
+import { z } from "zod/v4";
+import { isFundedProxyApiKey } from "./auth.js";
+import { AdmissionController, type AdmissionLease } from "./funded-relay-admission.js";
+import { COUNT_TOKENS_BODY_LIMIT_BYTES, type FundedRelayConfig } from "./funded-relay-config.js";
+import { estimateWorstCaseMicrousd, mapFundedModel } from "./funded-relay-model.js";
 import {
-  isFundedProxyApiKey,
-  parseFundedProxyApiKey,
-} from "./auth.js";
-import {
-  AdmissionController,
-  type AdmissionLease,
-} from "./funded-relay-admission.js";
-import {
-  COUNT_TOKENS_BODY_LIMIT_BYTES,
-  type FundedRelayConfig,
-} from "./funded-relay-config.js";
+  createFundedPlatformClient,
+  FundedControlPlaneError,
+  type FundedPlatformClient,
+} from "./funded-relay-platform-client.js";
 import {
   resolveRequestedBetas,
+  serializeCountTokensRequest,
   serializeFundedRequest,
+  type FundedRequest,
 } from "./funded-relay-request.js";
 import { boundedBody, safeUpstreamHeaders } from "./funded-relay-stream.js";
 
 const MESSAGES_PATH = "/v1/messages";
 const COUNT_TOKENS_PATH = "/v1/messages/count_tokens";
+const CountTokensResponseSchema = z.object({
+  input_tokens: z.number().int().nonnegative().max(10_000_000),
+}).strict();
 
 interface FundedRelayDependencies extends FundedRelayConfig {
   fetch?: typeof fetch;
-  now?: () => number;
+  now?: () => Date;
+  requestIdFactory?: () => string;
+  platformClient?: FundedPlatformClient;
 }
 
+type VerifiedFundedIdentity = FundedAiIdentity & {
+  tokenId: string;
+  audience: string;
+  scope: string;
+  expiresAt: string;
+};
+
 interface ActiveRequestState {
-  activeLease: AdmissionLease;
   controller: AbortController;
+  globalLease: AdmissionLease;
   lifetimeSignal: AbortSignal;
+  resourceLease: AdmissionLease | null;
   handedOff: boolean;
 }
 
@@ -39,25 +53,107 @@ export interface FundedRelay {
   close(): void;
 }
 
-function opaqueRuntimeId(handle: string, sharedSecret: string): string {
-  return createHmac("sha256", sharedSecret)
-    .update(`funded-runtime:${handle}`)
-    .digest("base64url");
+function opaqueRef(secret: string, domain: string, value: string): string {
+  return createHmac("sha256", secret).update(`${domain}:${value}`).digest("base64url");
+}
+
+function runtimeAdmissionRef(identity: FundedAiIdentity, secret: string): string {
+  return opaqueRef(secret, "admission-runtime", `${identity.ownerId}:${identity.machineId}:${identity.runtimeSlot}`);
+}
+
+function cloudflareMetadata(input: {
+  identity: FundedAiIdentity;
+  canonicalModelId: string;
+  requestId: string;
+  secret: string;
+}): Record<string, string> {
+  return {
+    access_source: "matrix_funded",
+    matrix_user_ref: opaqueRef(input.secret, "owner", input.identity.ownerId),
+    model_ref: opaqueRef(input.secret, "model", input.canonicalModelId),
+    run_ref: opaqueRef(input.secret, "run", input.requestId),
+    runtime_ref: opaqueRef(
+      input.secret,
+      "runtime",
+      `${input.identity.machineId}:${input.identity.runtimeSlot}`,
+    ),
+  };
 }
 
 function errorResponse(
   c: Context,
-  status: 400 | 401 | 403 | 404 | 413 | 415 | 429 | 502 | 504,
+  status: 400 | 401 | 403 | 404 | 413 | 415 | 429 | 502 | 503 | 504,
   type: string,
   message: string,
 ): Response {
   return c.json({ type: "error", error: { type, message } }, status);
 }
 
-function isTimeoutSignal(signal: AbortSignal): boolean {
-  return signal.aborted
-    && signal.reason instanceof Error
-    && signal.reason.name === "TimeoutError";
+function controlPlaneError(c: Context, error: unknown): Response {
+  if (error instanceof FundedControlPlaneError) {
+    if (error.status === 401) return errorResponse(c, 401, "authentication_error", "Unauthorized");
+    if (error.status === 402 || error.status === 403) {
+      return errorResponse(c, 403, "permission_error", "Matrix-funded AI is unavailable");
+    }
+    if (error.status === 429) {
+      return errorResponse(c, 429, "rate_limit_error", "AI capacity is temporarily limited");
+    }
+  }
+  const errorName = error instanceof Error ? error.name : "UnknownError";
+  console.warn("[proxy] Funded AI control request failed", { errorName });
+  return errorResponse(c, 503, "api_error", "AI access is temporarily unavailable");
+}
+
+async function readBoundedText(response: Response, maxBytes: number): Promise<string> {
+  const declared = response.headers.get("content-length");
+  if (declared !== null && Number(declared) > maxBytes) {
+    await response.body?.cancel("response limit exceeded");
+    throw new Error("AI response exceeded the configured limit");
+  }
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let output = "";
+  let seen = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      seen += value.byteLength;
+      if (seen > maxBytes) {
+        await reader.cancel("response limit exceeded");
+        throw new Error("AI response exceeded the configured limit");
+      }
+      output += decoder.decode(value, { stream: true });
+    }
+    output += decoder.decode();
+    return output;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function cloudflareHeaders(input: {
+  anthropicBeta: string | null;
+  gatewayToken: string;
+  metadata: Record<string, string>;
+}): Headers {
+  const headers = new Headers({
+    "content-type": "application/json",
+    "anthropic-version": "2023-06-01",
+    "cf-aig-authorization": `Bearer ${input.gatewayToken}`,
+    "cf-aig-collect-log-payload": "false",
+    "cf-aig-zdr": "true",
+    "cf-aig-metadata": JSON.stringify(input.metadata),
+  });
+  if (input.anthropicBeta) headers.set("anthropic-beta", input.anthropicBeta);
+  return headers;
+}
+
+function identitiesMatch(left: VerifiedFundedIdentity, right: VerifiedFundedIdentity): boolean {
+  return left.tokenId === right.tokenId && left.ownerId === right.ownerId
+    && left.machineId === right.machineId && left.runtimeSlot === right.runtimeSlot
+    && left.audience === right.audience && left.scope === right.scope && left.expiresAt === right.expiresAt;
 }
 
 function createDisabledRelay(): FundedRelay {
@@ -69,84 +165,211 @@ function createDisabledRelay(): FundedRelay {
       });
     },
     close() {
-      // No resources are created while the funded relay is disabled.
+      // Disabled relays own no resources.
     },
   };
 }
 
 export function createFundedRelay(dependencies: FundedRelayDependencies | null): FundedRelay {
   if (!dependencies) return createDisabledRelay();
-
-  const fetchImpl = dependencies.fetch ?? fetch;
-  const admission = new AdmissionController(dependencies, dependencies.now ?? Date.now);
+  const config = dependencies;
+  const fetchImpl = config.fetch ?? fetch;
+  const now = config.now ?? (() => new Date());
+  const requestIdFactory = config.requestIdFactory ?? randomUUID;
+  const admission = new AdmissionController(config, () => now().getTime());
+  const platform = config.platformClient ?? createFundedPlatformClient({ ...config, fetch: fetchImpl });
   const activeRequests = new Set<AbortController>();
   const requestStates = new WeakMap<Context, ActiveRequestState>();
 
-  const handler = async (c: Context, state: ActiveRequestState): Promise<Response> => {
-    let requestBody: string;
-    let parsedBody: ReturnType<typeof serializeFundedRequest>["request"];
-    let anthropicBeta: string | null;
+  async function releaseBeforeStart(
+    reservationId: string,
+    tokenId: string,
+  ): Promise<void> {
     try {
-      const rawBody = await c.req.text();
-      const serialized = serializeFundedRequest(JSON.parse(rawBody));
-      requestBody = serialized.body;
-      parsedBody = serialized.request;
-      anthropicBeta = resolveRequestedBetas(
-        c.req.header("anthropic-beta"),
-        dependencies.allowedBetas,
+      await platform.release(
+        { reservationId, tokenId, reason: "pre_upstream_failure" },
+        AbortSignal.timeout(config.platformTimeoutMs),
       );
     } catch (error) {
+      const errorName = error instanceof Error ? error.name : "UnknownError";
+      console.warn("[proxy] Funded AI pre-start release failed", { errorName });
+    }
+  }
+
+  async function countTokens(input: {
+    requestBody: string;
+    headers: Headers;
+    signal: AbortSignal;
+  }): Promise<{ response: Response; inputTokens: number }> {
+    const response = await fetchImpl(`${config.gatewayBaseUrl}${COUNT_TOKENS_PATH}`, {
+      method: "POST",
+      headers: input.headers,
+      body: input.requestBody,
+      redirect: "error",
+      signal: AbortSignal.any([input.signal, AbortSignal.timeout(config.countTokensTimeoutMs)]),
+    });
+    const text = await readBoundedText(response, config.maxControlResponseBytes);
+    if (!response.ok) {
+      if (response.status === 429) throw new FundedControlPlaneError(429);
+      throw new Error("AI token counting failed");
+    }
+    let value: unknown;
+    try {
+      value = JSON.parse(text) as unknown;
+    } catch (error) {
+      if (error instanceof SyntaxError) throw new Error("AI token count response was invalid");
+      throw error;
+    }
+    const parsed = CountTokensResponseSchema.parse(value);
+    return {
+      response: new Response(JSON.stringify(parsed), { status: 200, headers: safeUpstreamHeaders(response) }),
+      inputTokens: parsed.input_tokens,
+    };
+  }
+
+  async function handle(c: Context, state: ActiveRequestState): Promise<Response> {
+    let parsedBody: FundedRequest;
+    let requestBody: string;
+    let anthropicBeta: string | null;
+    let model: ReturnType<typeof mapFundedModel>;
+    try {
+      const serialized = serializeFundedRequest(JSON.parse(await c.req.text()));
+      parsedBody = serialized.request;
+      requestBody = serialized.body;
+      anthropicBeta = resolveRequestedBetas(c.req.header("anthropic-beta"), config.allowedBetas);
+      model = mapFundedModel(parsedBody.model);
+    } catch (error) {
       if (error instanceof Error && error.name === "BodyLimitError") throw error;
+      if (error instanceof Error && error.message === "Unsupported funded AI model") {
+        return errorResponse(c, 403, "permission_error", "This model is not enabled");
+      }
       return errorResponse(c, 400, "invalid_request_error", "Invalid AI request");
     }
     if (c.req.path === MESSAGES_PATH && parsedBody.max_tokens === undefined) {
       return errorResponse(c, 400, "invalid_request_error", "Invalid AI request");
     }
-    if (!dependencies.allowedModels.has(parsedBody.model)) {
-      return errorResponse(c, 403, "permission_error", "This model is not enabled");
-    }
 
-    const runtime = parseFundedProxyApiKey(
-      c.req.header("x-api-key") ?? "",
-      dependencies.sharedSecret,
-    );
-    if (!runtime) return errorResponse(c, 401, "authentication_error", "Unauthorized");
-    const headers = new Headers({
-      "content-type": "application/json",
-      "anthropic-version": "2023-06-01",
-      "cf-aig-authorization": `Bearer ${dependencies.gatewayToken}`,
-      "cf-aig-collect-log-payload": "false",
-      "cf-aig-zdr": "true",
-      "cf-aig-metadata": JSON.stringify({
-        runtime_id: opaqueRuntimeId(runtime.handle, dependencies.sharedSecret),
-        access_source: "matrix_included",
+    const credential = c.req.header("x-api-key") ?? "";
+    const checkInput = FundedAiPolicyCheckRequestSchema.safeParse({
+      credential,
+      modelId: model.canonicalModelId,
+    });
+    if (!checkInput.success) return errorResponse(c, 401, "authentication_error", "Unauthorized");
+    let checked: Awaited<ReturnType<FundedPlatformClient["check"]>>;
+    try {
+      checked = await platform.check(checkInput.data, state.lifetimeSignal);
+    } catch (error) {
+      return controlPlaneError(c, error);
+    }
+    const runtimeRef = runtimeAdmissionRef(checked.identity, config.metadataSecret);
+    if (!admission.admitRuntime(runtimeRef)) {
+      return errorResponse(c, 429, "rate_limit_error", "AI capacity is temporarily limited");
+    }
+    const requestId = requestIdFactory();
+    const upstreamHeaders = cloudflareHeaders({
+      anthropicBeta,
+      gatewayToken: config.gatewayToken,
+      metadata: cloudflareMetadata({
+        identity: checked.identity,
+        canonicalModelId: model.canonicalModelId,
+        requestId,
+        secret: config.metadataSecret,
       }),
     });
-    if (anthropicBeta) headers.set("anthropic-beta", anthropicBeta);
+
+    let counted: Awaited<ReturnType<typeof countTokens>>;
+    try {
+      counted = await countTokens({
+        requestBody: serializeCountTokensRequest(parsedBody),
+        headers: upstreamHeaders,
+        signal: state.lifetimeSignal,
+      });
+    } catch (error) {
+      if (state.lifetimeSignal.aborted || (error instanceof DOMException && error.name === "TimeoutError")) {
+        return errorResponse(c, 504, "timeout_error", "AI access timed out");
+      }
+      if (error instanceof FundedControlPlaneError && error.status === 429) {
+        return errorResponse(c, 429, "rate_limit_error", "AI capacity is temporarily limited");
+      }
+      const errorName = error instanceof Error ? error.name : "UnknownError";
+      console.warn("[proxy] Funded AI token counting failed", { errorName });
+      return errorResponse(c, 502, "api_error", "AI access is temporarily unavailable");
+    }
+    if (c.req.path === COUNT_TOKENS_PATH) return counted.response;
+
+    let maxCostMicrousd: number;
+    try {
+      maxCostMicrousd = estimateWorstCaseMicrousd({
+        canonicalModelId: model.canonicalModelId,
+        inputTokens: counted.inputTokens,
+        maxOutputTokens: parsedBody.max_tokens!,
+        now: now(),
+      }).amountMicrousd;
+    } catch (error) {
+      const errorName = error instanceof Error ? error.name : "UnknownError";
+      console.warn("[proxy] Funded AI pricing unavailable", { errorName });
+      return errorResponse(c, 503, "api_error", "AI access is temporarily unavailable");
+    }
+
+    let authorization: Awaited<ReturnType<FundedPlatformClient["authorize"]>>;
+    try {
+      authorization = await platform.authorize({
+        credential,
+        requestId,
+        modelId: model.canonicalModelId,
+        maxCostMicrousd,
+      }, state.lifetimeSignal);
+    } catch (error) {
+      return controlPlaneError(c, error);
+    }
+    const reservation = authorization.reservation;
+    if (!identitiesMatch(checked.identity, authorization.identity)
+      || reservation.requestId !== requestId || reservation.modelId !== model.canonicalModelId
+      || reservation.reservedMicrousd !== maxCostMicrousd) {
+      await releaseBeforeStart(reservation.reservationId, authorization.identity.tokenId);
+      return errorResponse(c, 503, "api_error", "AI access is temporarily unavailable");
+    }
+    const acquiredLease = admission.acquireResources(runtimeRef);
+    if (!acquiredLease) {
+      await releaseBeforeStart(reservation.reservationId, authorization.identity.tokenId);
+      return errorResponse(c, 429, "rate_limit_error", "AI capacity is temporarily limited");
+    }
+    let resourceReleased = false;
+    const resourceLease: AdmissionLease = {
+      release: () => {
+        if (resourceReleased) return;
+        resourceReleased = true;
+        acquiredLease.release();
+        state.globalLease.release();
+        activeRequests.delete(state.controller);
+      },
+    };
+    state.resourceLease = resourceLease;
 
     const firstResponseController = new AbortController();
     const firstResponseTimer = setTimeout(() => {
       firstResponseController.abort(new DOMException("AI first response timed out", "TimeoutError"));
-    }, dependencies.firstResponseTimeoutMs);
-    const fetchSignal = AbortSignal.any([
-      state.lifetimeSignal,
-      firstResponseController.signal,
-    ]);
-
+    }, config.firstResponseTimeoutMs);
+    const generationSignal = AbortSignal.any([state.lifetimeSignal, firstResponseController.signal]);
+    const generationUrl = `${config.gatewayBaseUrl}${MESSAGES_PATH}`;
+    const generationInit: RequestInit = {
+      method: "POST",
+      headers: upstreamHeaders,
+      body: requestBody,
+      redirect: "error",
+      signal: generationSignal,
+    };
     try {
-      const upstream = await fetchImpl(`${dependencies.gatewayBaseUrl}${c.req.path}`, {
-        method: "POST",
-        headers,
-        body: requestBody,
-        redirect: "error",
-        signal: fetchSignal,
-      });
+      await platform.start(
+        { reservationId: reservation.reservationId, tokenId: authorization.identity.tokenId },
+        state.lifetimeSignal,
+      );
+      const upstream = await fetchImpl(generationUrl, generationInit);
       clearTimeout(firstResponseTimer);
       if (!upstream.ok) {
-        void upstream.body?.cancel().catch((error: unknown) => {
-          const errorName = error instanceof Error ? error.name : "UnknownError";
-          console.warn("[proxy] Funded AI rejected-response cleanup failed", { errorName });
-        });
+        await upstream.body?.cancel("upstream rejected request");
+        resourceLease.release();
+        state.resourceLease = null;
         if (upstream.status === 429) {
           return errorResponse(c, 429, "rate_limit_error", "AI capacity is temporarily limited");
         }
@@ -154,77 +377,60 @@ export function createFundedRelay(dependencies: FundedRelayDependencies | null):
         return errorResponse(c, 502, "api_error", "AI access is temporarily unavailable");
       }
       if (!upstream.body) {
+        resourceLease.release();
+        state.resourceLease = null;
         return new Response(null, { status: upstream.status, headers: safeUpstreamHeaders(upstream) });
       }
       const responseBody = boundedBody(
         upstream.body,
-        dependencies.maxResponseBytes,
-        state.activeLease,
+        config.maxResponseBytes,
+        resourceLease,
         (reason) => state.controller.abort(reason),
         state.lifetimeSignal,
       );
       state.handedOff = true;
-      return new Response(responseBody, {
-        status: upstream.status,
-        headers: safeUpstreamHeaders(upstream),
-      });
+      return new Response(responseBody, { status: upstream.status, headers: safeUpstreamHeaders(upstream) });
     } catch (error) {
       clearTimeout(firstResponseTimer);
+      resourceLease.release();
+      state.resourceLease = null;
       const errorName = error instanceof Error ? error.name : "UnknownError";
       console.warn("[proxy] Funded AI upstream request failed", { errorName });
-      if (isTimeoutSignal(firstResponseController.signal) || isTimeoutSignal(state.lifetimeSignal)) {
+      if (state.lifetimeSignal.aborted || firstResponseController.signal.aborted) {
         return errorResponse(c, 504, "timeout_error", "AI access timed out");
       }
       return errorResponse(c, 502, "api_error", "AI access is temporarily unavailable");
     }
-  };
+  }
 
   return {
     register(app) {
       app.use("/v1/*", async (c, next) => {
         const providedKey = c.req.header("x-api-key") ?? "";
         if (!isFundedProxyApiKey(providedKey)) return next();
-        if (c.req.method !== "POST") {
+        if (c.req.method !== "POST") return errorResponse(c, 404, "not_found_error", "AI route not found");
+        if (c.req.path !== MESSAGES_PATH && c.req.path !== COUNT_TOKENS_PATH) {
           return errorResponse(c, 404, "not_found_error", "AI route not found");
         }
-        const path = c.req.path;
-        if (path !== MESSAGES_PATH && path !== COUNT_TOKENS_PATH) {
-          return errorResponse(c, 404, "not_found_error", "AI route not found");
-        }
-        if (new URL(c.req.url).search !== "") {
-          return errorResponse(c, 404, "not_found_error", "AI route not found");
-        }
+        if (new URL(c.req.url).search !== "") return errorResponse(c, 404, "not_found_error", "AI route not found");
         if (!c.req.header("content-type")?.toLowerCase().startsWith("application/json")) {
           return errorResponse(c, 415, "invalid_request_error", "Content-Type must be application/json");
         }
-
-        const runtime = parseFundedProxyApiKey(providedKey, dependencies.sharedSecret);
-        if (!runtime) return errorResponse(c, 401, "authentication_error", "Unauthorized");
-        const runtimeId = opaqueRuntimeId(runtime.handle, dependencies.sharedSecret);
-        const lease = admission.acquire(runtimeId);
-        if (!lease) {
+        const globalLease = admission.acquireGlobal();
+        if (!globalLease) {
           return errorResponse(c, 429, "rate_limit_error", "AI capacity is temporarily limited");
         }
-
         const controller = new AbortController();
         activeRequests.add(controller);
-        let released = false;
-        const activeLease: AdmissionLease = {
-          release: () => {
-            if (released) return;
-            released = true;
-            activeRequests.delete(controller);
-            lease.release();
-          },
-        };
         const state: ActiveRequestState = {
-          activeLease,
           controller,
+          globalLease,
           lifetimeSignal: AbortSignal.any([
             c.req.raw.signal,
             controller.signal,
-            AbortSignal.timeout(dependencies.timeoutMs),
+            AbortSignal.timeout(config.timeoutMs),
           ]),
+          resourceLease: null,
           handedOff: false,
         };
         requestStates.set(c, state);
@@ -232,35 +438,25 @@ export function createFundedRelay(dependencies: FundedRelayDependencies | null):
           await next();
         } finally {
           requestStates.delete(c);
-          if (!state.handedOff) activeLease.release();
+          if (!state.handedOff) {
+            state.resourceLease?.release();
+            state.globalLease.release();
+            activeRequests.delete(controller);
+          }
         }
       });
 
-      const createRequestBodyLimit = (maxSize: number) => bodyLimit({
+      const limit = (maxSize: number) => bodyLimit({
         maxSize,
-        onError: (c: Context) => errorResponse(
-          c,
-          413,
-          "invalid_request_error",
-          "AI request is too large",
-        ),
+        onError: (c: Context) => errorResponse(c, 413, "invalid_request_error", "AI request is too large"),
       });
-      const messageBodyLimit = createRequestBodyLimit(dependencies.maxBodyBytes);
-      const countTokensBodyLimit = createRequestBodyLimit(
-        Math.min(dependencies.maxBodyBytes, COUNT_TOKENS_BODY_LIMIT_BYTES),
-      );
-      app.use(MESSAGES_PATH, async (c, next) => {
-        if (!requestStates.has(c)) return next();
-        return messageBodyLimit(c, next);
-      });
-      app.use(COUNT_TOKENS_PATH, async (c, next) => {
-        if (!requestStates.has(c)) return next();
-        return countTokensBodyLimit(c, next);
-      });
+      const messagesLimit = limit(config.maxBodyBytes);
+      const countLimit = limit(Math.min(config.maxBodyBytes, COUNT_TOKENS_BODY_LIMIT_BYTES));
+      app.use(MESSAGES_PATH, async (c, next) => requestStates.has(c) ? messagesLimit(c, next) : next());
+      app.use(COUNT_TOKENS_PATH, async (c, next) => requestStates.has(c) ? countLimit(c, next) : next());
       app.all("/v1/*", async (c, next) => {
         const state = requestStates.get(c);
-        if (!state) return next();
-        return handler(c, state);
+        return state ? handle(c, state) : next();
       });
     },
     close() {

--- a/packages/proxy/src/main.ts
+++ b/packages/proxy/src/main.ts
@@ -336,10 +336,10 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   if (isShuttingDown) return;
   isShuttingDown = true;
   console.log(`[proxy] Received ${signal}, shutting down`);
-  fundedRelay.close();
   server.close();
   const forceExit = setTimeout(() => process.exit(1), 6_000);
   try {
+    await fundedRelay.close();
     await posthogErrorTracker.shutdown();
   } catch (err: unknown) {
     console.warn('[proxy] Failed during shutdown:', err instanceof Error ? err.message : String(err));

--- a/packages/proxy/src/main.ts
+++ b/packages/proxy/src/main.ts
@@ -14,10 +14,7 @@ const PORT = Number(process.env.PROXY_PORT ?? 8080);
 const PROXY_FETCH_TIMEOUT_MS = 30_000;
 const PROXY_ADMIN_TOKEN = process.env.PROXY_ADMIN_TOKEN ?? process.env.PROXY_AUTH_TOKEN ?? process.env.PLATFORM_SECRET;
 const PROXY_SHARED_SECRET = process.env.PROXY_SHARED_SECRET ?? process.env.PLATFORM_SECRET;
-const fundedRelayConfig = resolveFundedRelayConfig({
-  ...process.env,
-  PROXY_SHARED_SECRET,
-});
+const fundedRelayConfig = resolveFundedRelayConfig(process.env);
 
 const app = new Hono();
 const posthogErrorTracker = installPostHogHonoErrorTracking(app, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -862,6 +862,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.19.9
         version: 1.19.11(hono@4.12.8)
+      '@matrix-os/contracts':
+        specifier: workspace:*
+        version: link:../contracts
       '@matrix-os/observability':
         specifier: workspace:*
         version: link:../observability

--- a/tests/contracts/funded-ai.test.ts
+++ b/tests/contracts/funded-ai.test.ts
@@ -9,6 +9,8 @@ import {
   FundedAiOperatorRuntimePolicyResponseSchema,
   FundedAiPromotionalGrantResponseSchema,
   FundedAiRuntimeFundingSummaryResponseSchema,
+  FundedAiPolicyCheckRequestSchema,
+  FundedAiPolicyCheckResponseSchema,
   FundedAiRuntimeCredentialIssueResponseSchema,
   FundedAiSafeErrorSchema,
 } from "@matrix-os/contracts";
@@ -134,6 +136,31 @@ describe("funded AI control-plane contracts", () => {
     } as const;
     expect(FundedAiAuthorizationResponseSchema.parse(response)).toEqual(response);
     expect(FundedAiAuthorizationResponseSchema.safeParse({ ...response, token: credential }).success).toBe(false);
+  });
+
+  it("checks policy without accepting caller identity, request cost, or exposing funding", () => {
+    const request = { credential, modelId: "anthropic/claude-sonnet-5" } as const;
+    expect(FundedAiPolicyCheckRequestSchema.parse(request)).toEqual(request);
+    expect(FundedAiPolicyCheckRequestSchema.safeParse({ ...request, ownerId: "user_bob" }).success).toBe(false);
+    expect(FundedAiPolicyCheckRequestSchema.safeParse({ ...request, maxCostMicrousd: 1 }).success).toBe(false);
+
+    const response = {
+      contractVersion: 1,
+      authorized: true,
+      identity: {
+        tokenId,
+        ownerId: "user_alice",
+        machineId: "machine_123",
+        runtimeSlot: "primary",
+        audience: "matrix-funded-relay",
+        scope: "ai:invoke",
+        expiresAt,
+      },
+      policy,
+    } as const;
+    expect(FundedAiPolicyCheckResponseSchema.parse(response)).toEqual(response);
+    expect(FundedAiPolicyCheckResponseSchema.safeParse({ ...response, funding }).success).toBe(false);
+    expect(FundedAiPolicyCheckResponseSchema.safeParse({ ...response, credential }).success).toBe(false);
   });
 
   it("allows only coarse, secret-free control-plane errors", () => {

--- a/tests/contracts/funded-ai.test.ts
+++ b/tests/contracts/funded-ai.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   FundedAiAuthorizationRequestSchema,
   FundedAiAuthorizationResponseSchema,
+  FundedAiFinalizationRequestSchema,
   FundedAiGlobalPolicySchema,
   FundedAiOperatorGlobalPolicyUpdateRequestSchema,
   FundedAiOperatorGlobalPolicyResponseSchema,
@@ -161,6 +162,22 @@ describe("funded AI control-plane contracts", () => {
     expect(FundedAiPolicyCheckResponseSchema.parse(response)).toEqual(response);
     expect(FundedAiPolicyCheckResponseSchema.safeParse({ ...response, funding }).success).toBe(false);
     expect(FundedAiPolicyCheckResponseSchema.safeParse({ ...response, credential }).success).toBe(false);
+  });
+
+  it("distinguishes exact completion from conservative post-start finalization", () => {
+    const locator = { reservationId: "reservation_123", tokenId } as const;
+    expect(FundedAiFinalizationRequestSchema.parse({
+      ...locator, mode: "exact", actualCostMicrousd: 42,
+    })).toEqual({ ...locator, mode: "exact", actualCostMicrousd: 42 });
+    expect(FundedAiFinalizationRequestSchema.parse({
+      ...locator, mode: "conservative",
+    })).toEqual({ ...locator, mode: "conservative" });
+    expect(FundedAiFinalizationRequestSchema.safeParse({
+      ...locator, mode: "conservative", actualCostMicrousd: 1,
+    }).success).toBe(false);
+    expect(FundedAiFinalizationRequestSchema.safeParse({
+      ...locator, mode: "exact",
+    }).success).toBe(false);
   });
 
   it("allows only coarse, secret-free control-plane errors", () => {

--- a/tests/platform/ai-funded-metering.test.ts
+++ b/tests/platform/ai-funded-metering.test.ts
@@ -945,21 +945,13 @@ describe("funded AI metering", () => {
       status: "in_flight",
       expiresAt: "2026-08-30T20:10:00.000Z",
     });
-    await insertLegacyReservation({
-      tokenId: credential.tokenId,
-      reservationId: "legacy_finalization_without_backing",
-      requestId: "legacy_finalization_without_backing_request",
-      reservedMicrousd: 5,
-      status: "in_flight",
-      expiresAt: "2026-08-30T20:10:00.000Z",
-    });
 
     clock = new Date("2026-08-30T20:04:00.000Z");
     expect(await repo.getFundingSummary(identity)).toMatchObject({
       creditBalanceMicrousd: 7,
       promotionalBalanceMicrousd: 0,
       addonBalanceMicrousd: 7,
-      reservedMicrousd: 15,
+      reservedMicrousd: 10,
     });
     const settlement = await repo.settleReservation({
       reservationId: "legacy_settlement_without_backing",
@@ -1003,26 +995,6 @@ describe("funded AI metering", () => {
       promotionalBalanceMicrousd: 0,
       addonBalanceMicrousd: 5,
       reservedMicrousd: 5,
-    });
-
-    await expect(repo.finalizeReservation({
-      reservationId: "legacy_finalization_without_backing",
-      tokenId: credential.tokenId,
-      mode: "conservative",
-    })).rejects.toMatchObject({ code: "reservation_expired" });
-    await expect(db.executor.selectFrom("ai_funded_usage_reservations")
-      .select(["status", "actual_microusd"])
-      .where("reservation_id", "=", "legacy_finalization_without_backing")
-      .executeTakeFirstOrThrow()).resolves.toEqual({ status: "expired", actual_microusd: null });
-    expect(await repo.getFundingSummary(identity)).toMatchObject({
-      creditBalanceMicrousd: 5,
-      promotionalBalanceMicrousd: 0,
-      addonBalanceMicrousd: 5,
-      reservedMicrousd: 5,
-      settledThisMonthMicrousd: 5,
-      fundingShortfallMicrousd: 3,
-      remainingBalanceMicrousd: 0,
-      remainingBudgetMicrousd: 10,
     });
 
     await repo.startReservation({

--- a/tests/platform/ai-funded-metering.test.ts
+++ b/tests/platform/ai-funded-metering.test.ts
@@ -945,13 +945,21 @@ describe("funded AI metering", () => {
       status: "in_flight",
       expiresAt: "2026-08-30T20:10:00.000Z",
     });
+    await insertLegacyReservation({
+      tokenId: credential.tokenId,
+      reservationId: "legacy_finalization_without_backing",
+      requestId: "legacy_finalization_without_backing_request",
+      reservedMicrousd: 5,
+      status: "in_flight",
+      expiresAt: "2026-08-30T20:10:00.000Z",
+    });
 
     clock = new Date("2026-08-30T20:04:00.000Z");
     expect(await repo.getFundingSummary(identity)).toMatchObject({
       creditBalanceMicrousd: 7,
       promotionalBalanceMicrousd: 0,
       addonBalanceMicrousd: 7,
-      reservedMicrousd: 10,
+      reservedMicrousd: 15,
     });
     const settlement = await repo.settleReservation({
       reservationId: "legacy_settlement_without_backing",
@@ -990,6 +998,22 @@ describe("funded AI metering", () => {
       { kind: "addon_debit", amount_microusd: -2 },
       { kind: "usage_shortfall", amount_microusd: -3 },
     ]);
+    expect(await repo.getFundingSummary(identity)).toMatchObject({
+      creditBalanceMicrousd: 5,
+      promotionalBalanceMicrousd: 0,
+      addonBalanceMicrousd: 5,
+      reservedMicrousd: 5,
+    });
+
+    await expect(repo.finalizeReservation({
+      reservationId: "legacy_finalization_without_backing",
+      tokenId: credential.tokenId,
+      mode: "conservative",
+    })).rejects.toMatchObject({ code: "reservation_expired" });
+    await expect(db.executor.selectFrom("ai_funded_usage_reservations")
+      .select(["status", "actual_microusd"])
+      .where("reservation_id", "=", "legacy_finalization_without_backing")
+      .executeTakeFirstOrThrow()).resolves.toEqual({ status: "expired", actual_microusd: null });
     expect(await repo.getFundingSummary(identity)).toMatchObject({
       creditBalanceMicrousd: 5,
       promotionalBalanceMicrousd: 0,

--- a/tests/platform/ai-funded-metering.test.ts
+++ b/tests/platform/ai-funded-metering.test.ts
@@ -195,6 +195,9 @@ describe("funded AI metering", () => {
     };
     const settlement = await repo.settleReservation(settlementRequest);
     expect(settlement).toMatchObject({ actualCostMicrousd: 60, releasedMicrousd: 40, remainingBalanceMicrousd: 140 });
+    expect(await db.executor.selectFrom("ai_funded_usage_reservations").select("finalization_mode")
+      .where("reservation_id", "=", authorization.reservation.reservationId).executeTakeFirstOrThrow())
+      .toEqual({ finalization_mode: "exact" });
     await expect(repo.settleReservation(settlementRequest)).resolves.toEqual(settlement);
     await expect(repo.settleReservation({
       reservationId: authorization.reservation.reservationId,
@@ -221,6 +224,26 @@ describe("funded AI metering", () => {
       tokenId: credential.tokenId,
       actualCostMicrousd: 51,
     })).rejects.toMatchObject({ code: "over_settlement" });
+  });
+
+  it("finalizes ambiguous post-start usage at the full reservation", async () => {
+    const credential = await enableAndFund({ budget: 200, credit: 200 });
+    const authorization = await repo.authorize({
+      credential: credential.token, requestId: "request_ambiguous", modelId, maxCostMicrousd: 100,
+    });
+    const locator = {
+      reservationId: authorization.reservation.reservationId,
+      tokenId: credential.tokenId,
+    };
+    await repo.startReservation(locator);
+    const finalized = await repo.finalizeReservation({ ...locator, mode: "conservative" });
+    expect(finalized).toMatchObject({ actualCostMicrousd: 100, releasedMicrousd: 0, status: "settled" });
+    expect(await db.executor.selectFrom("ai_funded_usage_reservations").select("finalization_mode")
+      .where("reservation_id", "=", locator.reservationId).executeTakeFirstOrThrow())
+      .toEqual({ finalization_mode: "conservative" });
+    await expect(repo.finalizeReservation({ ...locator, mode: "conservative" })).resolves.toEqual(finalized);
+    await expect(repo.finalizeReservation({ ...locator, mode: "exact", actualCostMicrousd: 60 }))
+      .rejects.toMatchObject({ code: "idempotency_conflict" });
   });
 
   it("enforces zero balance, model allowlist, monthly budget, and the global kill switch before reservation", async () => {
@@ -308,7 +331,9 @@ describe("funded AI metering", () => {
     const reservation = await db.executor.selectFrom("ai_funded_usage_reservations")
       .selectAll().where("reservation_id", "=", authorization.reservation.reservationId)
       .executeTakeFirstOrThrow();
-    expect(reservation).toMatchObject({ status: "settled", actual_microusd: 100 });
+    expect(reservation).toMatchObject({
+      status: "settled", actual_microusd: 100, finalization_mode: "conservative",
+    });
     expect(await db.executor.selectFrom("ai_funded_credit_ledger").select("amount_microusd")
       .where("reservation_id", "=", reservation.reservation_id).execute())
       .toEqual([{ amount_microusd: -100 }]);

--- a/tests/platform/ai-funded-policy-repository.test.ts
+++ b/tests/platform/ai-funded-policy-repository.test.ts
@@ -206,4 +206,68 @@ describe("funded AI policy repository", () => {
     await expect(expired.authorize({ credential: issued.credential.token, requestId: "request_6", modelId: models[0], maxCostMicrousd: 100 }))
       .rejects.toMatchObject({ code: "unauthorized" });
   });
+
+  it("checks the current effective policy without mutating balances or reservations", async () => {
+    const repo = await enableRuntime();
+    const identity = { ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary" } as const;
+    const issued = await repo.issueRuntimeCredential(identity);
+    const balanceBefore = await db.executor.selectFrom("ai_funded_runtime_balances")
+      .selectAll().where("machine_id", "=", identity.machineId).executeTakeFirstOrThrow();
+
+    await expect(repo.checkPolicy({ credential: issued.credential.token, modelId: models[0] }))
+      .resolves.toMatchObject({
+        authorized: true,
+        identity: { ...identity, tokenId: issued.credential.tokenId },
+        policy: { enabled: true, allowedModelIds: [models[0]] },
+      });
+    await expect(repo.checkPolicy({
+      credential: issued.credential.token,
+      modelId: models[0],
+      maxCostMicrousd: 1,
+    } as never)).rejects.toMatchObject({ name: "ZodError" });
+    await expect(repo.checkPolicy({ credential: issued.credential.token, modelId: models[1] }))
+      .rejects.toMatchObject({ code: "model_not_allowed" });
+
+    const balanceAfter = await db.executor.selectFrom("ai_funded_runtime_balances")
+      .selectAll().where("machine_id", "=", identity.machineId).executeTakeFirstOrThrow();
+    expect(balanceAfter).toEqual(balanceBefore);
+    expect(await db.executor.selectFrom("ai_funded_usage_reservations").select("reservation_id").execute()).toEqual([]);
+  });
+
+  it("checks credential, canonical machine binding, and live enablement on every request", async () => {
+    const repo = await enableRuntime();
+    const identity = { ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary" } as const;
+    const issued = await repo.issueRuntimeCredential(identity);
+
+    await expect(repo.checkPolicy({
+      credential: `sk-matrix-funded-${issued.credential.tokenId}.${"x".repeat(43)}`,
+      modelId: models[0],
+    })).rejects.toMatchObject({ code: "unauthorized" });
+
+    await db.executor.updateTable("user_machines").set({ status: "stopped" })
+      .where("machine_id", "=", identity.machineId).execute();
+    await expect(repo.checkPolicy({ credential: issued.credential.token, modelId: models[0] }))
+      .rejects.toMatchObject({ code: "unauthorized" });
+
+    await db.executor.updateTable("user_machines").set({ status: "running" })
+      .where("machine_id", "=", identity.machineId).execute();
+    await repo.updateGlobalPolicy({ expectedRevision: 1, enabled: false, allowedModelIds: models });
+    await expect(repo.checkPolicy({ credential: issued.credential.token, modelId: models[0] }))
+      .rejects.toMatchObject({ code: "access_disabled" });
+
+    await repo.updateGlobalPolicy({ expectedRevision: 2, enabled: true, allowedModelIds: models });
+    await db.executor.updateTable("ai_funded_runtime_policies")
+      .set({ expires_at: "2026-08-30T19:59:59.000Z" })
+      .where("machine_id", "=", identity.machineId).execute();
+    await expect(repo.checkPolicy({ credential: issued.credential.token, modelId: models[0] }))
+      .rejects.toMatchObject({ code: "access_disabled" });
+
+    const expired = createAiFundedPolicyRepository({
+      db,
+      credentialHashSecret: "h".repeat(32),
+      now: () => new Date("2026-08-30T20:16:00.000Z"),
+    });
+    await expect(expired.checkPolicy({ credential: issued.credential.token, modelId: models[0] }))
+      .rejects.toMatchObject({ code: "unauthorized" });
+  });
 });

--- a/tests/platform/ai-funded-policy-routes.test.ts
+++ b/tests/platform/ai-funded-policy-routes.test.ts
@@ -544,7 +544,7 @@ describe("funded AI policy routes", () => {
 
   it("finalizes ambiguous post-start usage at the reserved amount", async () => {
     const { app } = await createTestApp();
-    const issuedResponse = await app.request("/internal/containers/alice/ai/funded-credential", {
+    const issuedResponse = await app.request(fundedCredentialPath(), {
       method: "POST",
       headers: { authorization: `Bearer ${bearerFor("alice")}`, "content-type": "application/json" },
       body: "{}",
@@ -576,7 +576,7 @@ describe("funded AI policy routes", () => {
 
   it("checks policy through service auth without reserving credit", async () => {
     const { app } = await createTestApp();
-    const issuedResponse = await app.request("/internal/containers/alice/ai/funded-credential", {
+    const issuedResponse = await app.request(fundedCredentialPath(), {
       method: "POST",
       headers: { authorization: `Bearer ${bearerFor("alice")}`, "content-type": "application/json" },
       body: "{}",

--- a/tests/platform/ai-funded-policy-routes.test.ts
+++ b/tests/platform/ai-funded-policy-routes.test.ts
@@ -4,6 +4,7 @@ import {
   FundedAiOperatorGlobalPolicyResponseSchema,
   FundedAiOperatorRuntimePolicyResponseSchema,
   FundedAiPromotionalGrantResponseSchema,
+  FundedAiFinalizationResponseSchema,
   FundedAiPolicyCheckResponseSchema,
   FundedAiRuntimeCredentialIssueResponseSchema,
   FundedAiRuntimeFundingSummaryResponseSchema,
@@ -539,6 +540,38 @@ describe("funded AI policy routes", () => {
       body: JSON.stringify({ ...lifecycleBody, reason: "ambiguous_upstream_failure" }),
     });
     expect(invalidRelease.status).toBe(400);
+  });
+
+  it("finalizes ambiguous post-start usage at the reserved amount", async () => {
+    const { app } = await createTestApp();
+    const issuedResponse = await app.request("/internal/containers/alice/ai/funded-credential", {
+      method: "POST",
+      headers: { authorization: `Bearer ${bearerFor("alice")}`, "content-type": "application/json" },
+      body: "{}",
+    });
+    const issued = FundedAiRuntimeCredentialIssueResponseSchema.parse(await issuedResponse.json());
+    const authorizationResponse = await app.request("/internal/ai/funded/authorize", {
+      method: "POST",
+      headers: { authorization: `Bearer ${relayControlToken}`, "content-type": "application/json" },
+      body: JSON.stringify({
+        credential: issued.credential.token, requestId: "request_finalize", modelId, maxCostMicrousd: 100,
+      }),
+    });
+    const authorization = FundedAiAuthorizationResponseSchema.parse(await authorizationResponse.json());
+    const locator = { reservationId: authorization.reservation.reservationId, tokenId: issued.credential.tokenId };
+    await app.request("/internal/ai/funded/start", {
+      method: "POST",
+      headers: { authorization: `Bearer ${relayControlToken}`, "content-type": "application/json" },
+      body: JSON.stringify(locator),
+    });
+    const finalized = await app.request("/internal/ai/funded/finalize", {
+      method: "POST",
+      headers: { authorization: `Bearer ${relayControlToken}`, "content-type": "application/json" },
+      body: JSON.stringify({ ...locator, mode: "conservative" }),
+    });
+    expect(finalized.status).toBe(200);
+    expect(FundedAiFinalizationResponseSchema.parse(await finalized.json()))
+      .toMatchObject({ finalizationMode: "conservative", actualCostMicrousd: 100, releasedMicrousd: 0 });
   });
 
   it("checks policy through service auth without reserving credit", async () => {

--- a/tests/platform/ai-funded-policy-routes.test.ts
+++ b/tests/platform/ai-funded-policy-routes.test.ts
@@ -4,6 +4,7 @@ import {
   FundedAiOperatorGlobalPolicyResponseSchema,
   FundedAiOperatorRuntimePolicyResponseSchema,
   FundedAiPromotionalGrantResponseSchema,
+  FundedAiPolicyCheckResponseSchema,
   FundedAiRuntimeCredentialIssueResponseSchema,
   FundedAiRuntimeFundingSummaryResponseSchema,
   FundedAiSettlementResponseSchema,
@@ -538,5 +539,43 @@ describe("funded AI policy routes", () => {
       body: JSON.stringify({ ...lifecycleBody, reason: "ambiguous_upstream_failure" }),
     });
     expect(invalidRelease.status).toBe(400);
+  });
+
+  it("checks policy through service auth without reserving credit", async () => {
+    const { app } = await createTestApp();
+    const issuedResponse = await app.request("/internal/containers/alice/ai/funded-credential", {
+      method: "POST",
+      headers: { authorization: `Bearer ${bearerFor("alice")}`, "content-type": "application/json" },
+      body: "{}",
+    });
+    const issued = FundedAiRuntimeCredentialIssueResponseSchema.parse(await issuedResponse.json());
+    const body = JSON.stringify({ credential: issued.credential.token, modelId });
+
+    expect((await app.request("/internal/ai/funded/check", {
+      method: "POST", headers: { "content-type": "application/json" }, body,
+    })).status).toBe(401);
+    const checked = await app.request("/internal/ai/funded/check", {
+      method: "POST",
+      headers: { authorization: `Bearer ${relayControlToken}`, "content-type": "application/json" },
+      body,
+    });
+    expect(checked.status).toBe(200);
+    expect(FundedAiPolicyCheckResponseSchema.parse(await checked.json())).toMatchObject({
+      authorized: true,
+      identity: { ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary" },
+    });
+    const extraField = await app.request("/internal/ai/funded/check", {
+      method: "POST",
+      headers: { authorization: `Bearer ${relayControlToken}`, "content-type": "application/json" },
+      body: JSON.stringify({ credential: issued.credential.token, modelId, maxCostMicrousd: 1 }),
+    });
+    expect(extraField.status).toBe(400);
+    const oversized = await app.request("/internal/ai/funded/check", {
+      method: "POST",
+      headers: { authorization: `Bearer ${relayControlToken}`, "content-type": "application/json" },
+      body: JSON.stringify({ credential: issued.credential.token, modelId, padding: "x".repeat(5_000) }),
+    });
+    expect(oversized.status).toBe(413);
+    expect(await db.executor.selectFrom("ai_funded_usage_reservations").select("reservation_id").execute()).toEqual([]);
   });
 });

--- a/tests/proxy/auth.test.ts
+++ b/tests/proxy/auth.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
-  buildFundedProxyApiKey,
   buildProxyApiKey,
+  isFundedProxyApiKey,
   isAuthorizedProxyAdminRequest,
-  parseFundedProxyApiKey,
   parseProxyApiKey,
 } from "../../packages/proxy/src/auth.js";
 
@@ -37,14 +36,10 @@ describe("proxy auth", () => {
     expect(parseProxyApiKey(key, "wrong-secret")).toBeNull();
   });
 
-  it("keeps funded relay credentials in a distinct HMAC audience", () => {
-    const sharedSecret = "proxy-shared-secret";
-    const legacyKey = buildProxyApiKey("alice", sharedSecret);
-    const fundedKey = buildFundedProxyApiKey("alice", sharedSecret);
-
-    expect(fundedKey).not.toBe(legacyKey);
-    expect(parseFundedProxyApiKey(fundedKey, sharedSecret)).toEqual({ handle: "alice" });
-    expect(parseFundedProxyApiKey(legacyKey, sharedSecret)).toBeNull();
-    expect(parseProxyApiKey(fundedKey, sharedSecret)).toBeNull();
+  it("recognizes funded credentials as opaque platform authority, never local handle HMAC auth", () => {
+    const fundedKey = `sk-matrix-funded-credential_123.${"s".repeat(43)}`;
+    expect(isFundedProxyApiKey(fundedKey)).toBe(true);
+    expect(isFundedProxyApiKey(buildProxyApiKey("alice", "proxy-shared-secret"))).toBe(false);
+    expect(parseProxyApiKey(fundedKey, "proxy-shared-secret")).toBeNull();
   });
 });

--- a/tests/proxy/funded-relay-platform-security.test.ts
+++ b/tests/proxy/funded-relay-platform-security.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveFundedRelayConfig } from "../../packages/proxy/src/funded-relay-config.js";
+import { createFundedPlatformClient } from "../../packages/proxy/src/funded-relay-platform-client.js";
+
+const GATEWAY_URL =
+  "https://gateway.ai.cloudflare.com/v1/0123456789abcdef0123456789abcdef/matrix/anthropic";
+const SECRET_A = "a".repeat(32);
+const SECRET_B = "b".repeat(32);
+const SECRET_C = "c".repeat(32);
+
+function enabledEnv(platformBaseUrl: string): NodeJS.ProcessEnv {
+  return {
+    MATRIX_FUNDED_AI_ENABLED: "1",
+    CLOUDFLARE_AI_GATEWAY_URL: GATEWAY_URL,
+    CLOUDFLARE_AI_GATEWAY_TOKEN: SECRET_A,
+    PLATFORM_INTERNAL_URL: platformBaseUrl,
+    AI_RELAY_CONTROL_TOKEN: SECRET_B,
+    AI_RELAY_METADATA_SECRET: SECRET_C,
+  };
+}
+
+function clientOptions(platformBaseUrl: string, fetchImpl = vi.fn() as unknown as typeof fetch) {
+  return {
+    platformBaseUrl,
+    relayControlToken: SECRET_B,
+    platformTimeoutMs: 5_000,
+    maxControlResponseBytes: 64 * 1024,
+    fetch: fetchImpl,
+  };
+}
+
+describe("funded relay platform transport security", () => {
+  it.each([
+    ["remote HTTPS", "https://platform.matrix-os.com", "https://platform.matrix-os.com"],
+    ["localhost HTTP", "http://localhost:8787", "http://localhost:8787"],
+    ["canonical IPv4 loopback HTTP", "http://127.0.0.1:8787/", "http://127.0.0.1:8787"],
+    ["canonical IPv6 loopback HTTP", "http://[::1]:8787", "http://[::1]:8787"],
+  ])("accepts %s", (_label, input, expected) => {
+    expect(resolveFundedRelayConfig(enabledEnv(input))?.platformBaseUrl).toBe(expected);
+    expect(() => createFundedPlatformClient(clientOptions(input))).not.toThrow();
+  });
+
+  it.each([
+    ["remote host", "http://platform.matrix-os.com"],
+    ["private IPv4", "http://10.0.0.1:8787"],
+    ["adjacent IPv4", "http://127.0.0.2:8787"],
+    ["localhost suffix", "http://localhost.example.com:8787"],
+    ["localhost trailing dot", "http://localhost.:8787"],
+    ["short IPv4 alias", "http://127.1:8787"],
+    ["integer IPv4 alias", "http://2130706433:8787"],
+    ["hex IPv4 alias", "http://0x7f000001:8787"],
+    ["octal IPv4 alias", "http://0177.0.0.1:8787"],
+    ["expanded IPv6 alias", "http://[0:0:0:0:0:0:0:1]:8787"],
+    ["IPv4-mapped IPv6", "http://[::ffff:127.0.0.1]:8787"],
+    ["HTTPS userinfo", "https://relay:secret@platform.matrix-os.com"],
+    ["loopback userinfo", "http://relay:secret@localhost:8787"],
+    ["query", "https://platform.matrix-os.com?target=http://example.com"],
+    ["empty query", "https://platform.matrix-os.com?"],
+    ["fragment", "https://platform.matrix-os.com#control"],
+    ["control path", "https://platform.matrix-os.com/internal"],
+    ["double-slash path", "https://platform.matrix-os.com//internal"],
+    ["normalized traversal path", "https://platform.matrix-os.com/%2e%2e"],
+    ["backslash authority", String.raw`http:\\platform.matrix-os.com`],
+  ])("rejects %s without creating a credential-bearing client", (_label, input) => {
+    const fetchMock = vi.fn();
+    expect(() => resolveFundedRelayConfig(enabledEnv(input))).toThrow(/HTTPS|origin/i);
+    expect(() => createFundedPlatformClient(clientOptions(input, fetchMock as typeof fetch)))
+      .toThrow(/HTTPS|origin/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("snapshots the validated origin and relay bearer before accepting runtime credentials", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      expect(String(input)).toBe("https://platform.matrix-os.com/internal/ai/funded/check");
+      expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer ${SECRET_B}`);
+      expect(JSON.parse(String(init?.body))).toEqual({
+        credential: "runtime-credential",
+        modelId: "anthropic/claude-sonnet-5",
+      });
+      throw new Error("test stop");
+    });
+    const options = clientOptions("https://platform.matrix-os.com", fetchMock as typeof fetch);
+    const client = createFundedPlatformClient(options);
+
+    options.platformBaseUrl = "http://platform.matrix-os.com";
+    options.relayControlToken = "mutated-plaintext-bearer";
+
+    await expect(client.check({
+      credential: "runtime-credential",
+      modelId: "anthropic/claude-sonnet-5",
+    }, new AbortController().signal)).rejects.toThrow("test stop");
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/proxy/funded-relay-platform-security.test.ts
+++ b/tests/proxy/funded-relay-platform-security.test.ts
@@ -32,7 +32,6 @@ function clientOptions(platformBaseUrl: string, fetchImpl = vi.fn() as unknown a
 describe("funded relay platform transport security", () => {
   it.each([
     ["remote HTTPS", "https://platform.matrix-os.com", "https://platform.matrix-os.com"],
-    ["localhost HTTP", "http://localhost:8787", "http://localhost:8787"],
     ["canonical IPv4 loopback HTTP", "http://127.0.0.1:8787/", "http://127.0.0.1:8787"],
     ["canonical IPv6 loopback HTTP", "http://[::1]:8787", "http://[::1]:8787"],
   ])("accepts %s", (_label, input, expected) => {
@@ -42,6 +41,7 @@ describe("funded relay platform transport security", () => {
 
   it.each([
     ["remote host", "http://platform.matrix-os.com"],
+    ["localhost hostname", "http://localhost:8787"],
     ["private IPv4", "http://10.0.0.1:8787"],
     ["adjacent IPv4", "http://127.0.0.2:8787"],
     ["localhost suffix", "http://localhost.example.com:8787"],

--- a/tests/proxy/funded-relay-settlement-queue.test.ts
+++ b/tests/proxy/funded-relay-settlement-queue.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { SettlementRetryQueue } from "../../packages/proxy/src/funded-relay-settlement-queue.js";
+
+function task(reservationId: string) {
+  return { reservationId, tokenId: "credential_123", mode: "exact" as const, actualCostMicrousd: 42 };
+}
+
+describe("funded settlement retry queue", () => {
+  it("retries idempotent finalization and removes it only after success", async () => {
+    const finalize = vi.fn()
+      .mockRejectedValueOnce(new Error("private platform failure"))
+      .mockResolvedValueOnce(undefined);
+    const queue = new SettlementRetryQueue({
+      capacity: 2, ttlMs: 60_000, retryIntervalMs: 60_000, now: () => 0, finalize,
+    });
+    queue.enqueue(task("reservation_1"));
+    await vi.waitFor(() => expect(finalize).toHaveBeenCalledTimes(1));
+    expect(queue.pendingCount).toBe(1);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await queue.flush();
+    expect(finalize).toHaveBeenCalledTimes(2);
+    expect(queue.pendingCount).toBe(0);
+    await queue.close();
+  });
+
+  it("caps entries, evicts oldest work, and drops stale retries", async () => {
+    let clock = 0;
+    const finalize = vi.fn().mockRejectedValue(new Error("unavailable"));
+    const queue = new SettlementRetryQueue({
+      capacity: 1, ttlMs: 100, retryIntervalMs: 60_000, now: () => clock, finalize,
+    });
+    queue.enqueue(task("reservation_old"));
+    await vi.waitFor(() => expect(finalize).toHaveBeenCalled());
+    queue.enqueue(task("reservation_new"));
+    expect(queue.pendingIds).toEqual(["reservation_new"]);
+    clock = 101;
+    queue.sweepExpired();
+    expect(queue.pendingCount).toBe(0);
+    await queue.close();
+  });
+
+  it("performs one explicit final drain during shutdown", async () => {
+    const finalize = vi.fn()
+      .mockRejectedValueOnce(new Error("unavailable"))
+      .mockResolvedValueOnce(undefined);
+    const queue = new SettlementRetryQueue({
+      capacity: 2, ttlMs: 60_000, retryIntervalMs: 60_000, now: () => 0, finalize,
+    });
+    queue.enqueue(task("reservation_shutdown"));
+    await vi.waitFor(() => expect(finalize).toHaveBeenCalledTimes(1));
+    await queue.close();
+    expect(finalize).toHaveBeenCalledTimes(2);
+    expect(queue.pendingCount).toBe(0);
+  });
+});

--- a/tests/proxy/funded-relay-usage.test.ts
+++ b/tests/proxy/funded-relay-usage.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { priceActualUsageMicrousd } from "../../packages/proxy/src/funded-relay-model.js";
 import { createFundedUsageTracker } from "../../packages/proxy/src/funded-relay-usage.js";
 
 const encoder = new TextEncoder();
@@ -6,15 +7,29 @@ const options = {
   contentType: "text/event-stream",
   nativeModelId: "claude-sonnet-5",
   canonicalModelId: "anthropic/claude-sonnet-5",
-  pricingVersion: "anthropic-2026-08-29",
+  pricingVersion: "anthropic-2026-08-31-standard",
 } as const;
 
 describe("funded relay usage parsing", () => {
+  it("uses standard Sonnet 5 rates throughout the full context window", () => {
+    expect(priceActualUsageMicrousd({
+      canonicalModelId: options.canonicalModelId,
+      pricingVersion: options.pricingVersion,
+      usage: {
+        inputTokens: 200_001,
+        outputTokens: 10,
+        cacheReadTokens: 0,
+        cacheWrite5mTokens: 0,
+        cacheWrite1hTokens: 0,
+      },
+    })).toBe(400_102);
+  });
+
   it("prices a complete valid Anthropic SSE stream in integer microusd", () => {
     const tracker = createFundedUsageTracker(options);
     const stream = [
       "event: message_start\n",
-      "data: {\"type\":\"message_start\",\"message\":{\"type\":\"message\",\"model\":\"claude-sonnet-5\",\"usage\":{\"input_tokens\":100,\"output_tokens\":0,\"cache_read_input_tokens\":10,\"cache_creation_input_tokens\":2}}}\n\n",
+      "data: {\"type\":\"message_start\",\"message\":{\"type\":\"message\",\"model\":\"claude-sonnet-5\",\"usage\":{\"input_tokens\":100,\"output_tokens\":0,\"cache_read_input_tokens\":10,\"cache_creation_input_tokens\":5,\"cache_creation\":{\"ephemeral_5m_input_tokens\":2,\"ephemeral_1h_input_tokens\":3}}}}\n\n",
       "event: content_block_delta\n",
       "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n",
       "event: message_delta\n",
@@ -24,7 +39,7 @@ describe("funded relay usage parsing", () => {
     ].join("");
     tracker.push(encoder.encode(stream.slice(0, 117)));
     tracker.push(encoder.encode(stream.slice(117)));
-    expect(tracker.complete()).toEqual({ mode: "exact", actualCostMicrousd: 407 });
+    expect(tracker.complete()).toEqual({ mode: "exact", actualCostMicrousd: 419 });
   });
 
   it("treats truncated, malformed, duplicate-stop, and model-mismatch streams conservatively", () => {
@@ -58,13 +73,44 @@ describe("funded relay usage parsing", () => {
         input_tokens: 100,
         output_tokens: 20,
         cache_read_input_tokens: 10,
-        cache_creation_input_tokens: 2,
+        cache_creation_input_tokens: 5,
+        cache_creation: {
+          ephemeral_5m_input_tokens: 2,
+          ephemeral_1h_input_tokens: 3,
+        },
       },
     })));
-    expect(tracker.complete()).toEqual({ mode: "exact", actualCostMicrousd: 407 });
+    expect(tracker.complete()).toEqual({ mode: "exact", actualCostMicrousd: 419 });
 
     const missing = createFundedUsageTracker({ ...options, contentType: "application/json" });
     missing.push(encoder.encode("{\"type\":\"message\"}"));
     expect(missing.complete()).toEqual({ mode: "conservative" });
+  });
+
+  it("fails closed when cache creation usage lacks an exact TTL breakdown", () => {
+    for (const usage of [
+      {
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_creation_input_tokens: 2,
+      },
+      {
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_creation_input_tokens: 2,
+        cache_creation: {
+          ephemeral_5m_input_tokens: 1,
+          ephemeral_1h_input_tokens: 0,
+        },
+      },
+    ]) {
+      const tracker = createFundedUsageTracker({ ...options, contentType: "application/json" });
+      tracker.push(encoder.encode(JSON.stringify({
+        type: "message",
+        model: "claude-sonnet-5",
+        usage,
+      })));
+      expect(tracker.complete()).toEqual({ mode: "conservative" });
+    }
   });
 });

--- a/tests/proxy/funded-relay-usage.test.ts
+++ b/tests/proxy/funded-relay-usage.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { createFundedUsageTracker } from "../../packages/proxy/src/funded-relay-usage.js";
+
+const encoder = new TextEncoder();
+const options = {
+  contentType: "text/event-stream",
+  nativeModelId: "claude-sonnet-5",
+  canonicalModelId: "anthropic/claude-sonnet-5",
+  pricingVersion: "anthropic-2026-08-29",
+} as const;
+
+describe("funded relay usage parsing", () => {
+  it("prices a complete valid Anthropic SSE stream in integer microusd", () => {
+    const tracker = createFundedUsageTracker(options);
+    const stream = [
+      "event: message_start\n",
+      "data: {\"type\":\"message_start\",\"message\":{\"type\":\"message\",\"model\":\"claude-sonnet-5\",\"usage\":{\"input_tokens\":100,\"output_tokens\":0,\"cache_read_input_tokens\":10,\"cache_creation_input_tokens\":2}}}\n\n",
+      "event: content_block_delta\n",
+      "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n",
+      "event: message_delta\n",
+      "data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":20}}\n\n",
+      "event: message_stop\n",
+      "data: {\"type\":\"message_stop\"}\n\n",
+    ].join("");
+    tracker.push(encoder.encode(stream.slice(0, 117)));
+    tracker.push(encoder.encode(stream.slice(117)));
+    expect(tracker.complete()).toEqual({ mode: "exact", actualCostMicrousd: 407 });
+  });
+
+  it("treats truncated, malformed, duplicate-stop, and model-mismatch streams conservatively", () => {
+    for (const stream of [
+      "data: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-5\",\"usage\":{\"input_tokens\":1}}}\n\n",
+      "data: {not-json}\n\n",
+      [
+        "data: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-opus-5\",\"usage\":{\"input_tokens\":1}}}\n\n",
+        "data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":1}}\n\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+      ].join(""),
+      [
+        "data: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-5\",\"usage\":{\"input_tokens\":1}}}\n\n",
+        "data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":1}}\n\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+      ].join(""),
+    ]) {
+      const tracker = createFundedUsageTracker(options);
+      tracker.push(encoder.encode(stream));
+      expect(tracker.complete()).toEqual({ mode: "conservative" });
+    }
+  });
+
+  it("prices a complete bounded JSON response and rejects missing usage", () => {
+    const tracker = createFundedUsageTracker({ ...options, contentType: "application/json" });
+    tracker.push(encoder.encode(JSON.stringify({
+      type: "message",
+      model: "claude-sonnet-5",
+      usage: {
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_read_input_tokens: 10,
+        cache_creation_input_tokens: 2,
+      },
+    })));
+    expect(tracker.complete()).toEqual({ mode: "exact", actualCostMicrousd: 407 });
+
+    const missing = createFundedUsageTracker({ ...options, contentType: "application/json" });
+    missing.push(encoder.encode("{\"type\":\"message\"}"));
+    expect(missing.complete()).toEqual({ mode: "conservative" });
+  });
+});

--- a/tests/proxy/funded-relay.test.ts
+++ b/tests/proxy/funded-relay.test.ts
@@ -470,6 +470,44 @@ describe("Cloudflare funded relay control-plane ordering", () => {
     await relay.close();
   });
 
+  it("releases a reservation when the control plane definitively rejects start", async () => {
+    const events: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/check")) return json(checkResponse());
+      if (url.endsWith("/v1/messages/count_tokens")) return json({ input_tokens: 1_000 });
+      if (url.endsWith("/authorize")) return json(authorizationResponse("request_123"));
+      if (url.endsWith("/start")) {
+        events.push("start_denied");
+        return json({ error: { code: "rate_limited", message: "Try again" } }, 429);
+      }
+      if (url.endsWith("/release")) {
+        events.push("release");
+        return json({
+          contractVersion: 1,
+          reservationId: "reservation_123",
+          requestId: "request_123",
+          tokenId: "credential_123",
+          releasedMicrousd: RESERVED_MICROUSD,
+          releasedAt: NOW.toISOString(),
+          reason: "pre_upstream_failure",
+          status: "released",
+          funding: authorizationResponse("request_123").funding,
+        });
+      }
+      if (url.endsWith("/finalize")) events.push("finalize");
+      else events.push("generate");
+      return json({});
+    });
+    const relay = configuredRelay(fetchMock as typeof fetch);
+    const app = new Hono();
+    relay.register(app);
+
+    expect((await app.request("/v1/messages", fundedRequest())).status).toBe(429);
+    expect(events).toEqual(["start_denied", "release"]);
+    await relay.close();
+  });
+
   it("never releases an in-flight reservation after generation fetch fails", async () => {
     const events: string[] = [];
     const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {

--- a/tests/proxy/funded-relay.test.ts
+++ b/tests/proxy/funded-relay.test.ts
@@ -14,6 +14,7 @@ const GATEWAY_URL =
 const PLATFORM_URL = "https://platform.internal.example";
 const NATIVE_MODEL = "claude-sonnet-5";
 const CANONICAL_MODEL = "anthropic/claude-sonnet-5";
+const RESERVED_MICROUSD = 6_000;
 const CREDENTIAL = `sk-matrix-funded-credential_123.${"s".repeat(43)}`;
 const NOW = new Date("2026-08-30T20:00:00.000Z");
 
@@ -63,13 +64,14 @@ function authorizationResponse(requestId: string, reservationId = "reservation_1
     contractVersion: 1, authorized: true, identity: identity(), policy: policy(),
     funding: {
       asOf: NOW.toISOString(), periodStart: "2026-08-01T00:00:00.000Z", monthlyBudgetMicrousd: 100_000,
-      settledThisMonthMicrousd: 0, reservedMicrousd: 3_600, reservedThisMonthMicrousd: 3_600,
+      settledThisMonthMicrousd: 0, reservedMicrousd: RESERVED_MICROUSD,
+      reservedThisMonthMicrousd: RESERVED_MICROUSD,
       promotionalBalanceMicrousd: 100_000, addonBalanceMicrousd: 0, creditBalanceMicrousd: 100_000,
-      remainingBalanceMicrousd: 96_400, remainingBudgetMicrousd: 96_400,
+      remainingBalanceMicrousd: 94_000, remainingBudgetMicrousd: 94_000,
     },
     reservation: {
-      reservationId, requestId, modelId: CANONICAL_MODEL, reservedMicrousd: 3_600,
-      remainingBalanceMicrousd: 96_400, remainingBudgetMicrousd: 96_400,
+      reservationId, requestId, modelId: CANONICAL_MODEL, reservedMicrousd: RESERVED_MICROUSD,
+      remainingBalanceMicrousd: 94_000, remainingBudgetMicrousd: 94_000,
       periodStart: "2026-08-01T00:00:00.000Z", expiresAt: "2026-08-30T20:05:00.000Z", status: "reserved",
     },
   };
@@ -94,9 +96,9 @@ function finalizationResponse(input: {
     requestId: input.requestId,
     tokenId: "credential_123",
     actualCostMicrousd: input.actualCostMicrousd,
-    releasedMicrousd: 3_600 - input.actualCostMicrousd,
-    remainingBalanceMicrousd: 96_400,
-    remainingBudgetMicrousd: 96_400,
+    releasedMicrousd: RESERVED_MICROUSD - input.actualCostMicrousd,
+    remainingBalanceMicrousd: 94_000,
+    remainingBudgetMicrousd: 94_000,
     funding: authorizationResponse(input.requestId).funding,
     settledAt: NOW.toISOString(),
     status: "settled",
@@ -138,7 +140,7 @@ describe("funded relay configuration and pricing", () => {
     });
   });
 
-  it("maps exactly Sonnet 5 and prices only a current version with integer safety margin", () => {
+  it("maps exactly Sonnet 5 and reserves the current maximum cache-write price", () => {
     expect(mapFundedModel(NATIVE_MODEL)).toEqual({
       nativeModelId: NATIVE_MODEL, canonicalModelId: CANONICAL_MODEL,
     });
@@ -147,10 +149,17 @@ describe("funded relay configuration and pricing", () => {
     }
     expect(estimateWorstCaseMicrousd({
       canonicalModelId: CANONICAL_MODEL, inputTokens: 1_000, maxOutputTokens: 100, now: NOW,
-    })).toMatchObject({ amountMicrousd: 3_600, pricingVersion: "anthropic-2026-08-29" });
+    })).toMatchObject({
+      amountMicrousd: 6_000,
+      pricingVersion: "anthropic-2026-08-31-standard",
+      pricingValidThrough: "2026-09-30T23:59:59.999Z",
+    });
+    expect(estimateWorstCaseMicrousd({
+      canonicalModelId: CANONICAL_MODEL, inputTokens: 200_001, maxOutputTokens: 1, now: NOW,
+    })).toMatchObject({ amountMicrousd: 960_017 });
     expect(() => estimateWorstCaseMicrousd({
       canonicalModelId: CANONICAL_MODEL, inputTokens: 1, maxOutputTokens: 1,
-      now: new Date("2026-09-01T00:00:00.000Z"),
+      now: new Date("2026-10-01T00:00:00.000Z"),
     })).toThrow(/expired/i);
     expect(() => estimateWorstCaseMicrousd({
       canonicalModelId: "anthropic/unknown", inputTokens: 1, maxOutputTokens: 1, now: NOW,
@@ -178,7 +187,7 @@ describe("Cloudflare funded relay control-plane ordering", () => {
         if (action === "authorize") {
           expect(body).toEqual({
             credential: CREDENTIAL, requestId: "request_123",
-            modelId: CANONICAL_MODEL, maxCostMicrousd: 3_600,
+            modelId: CANONICAL_MODEL, maxCostMicrousd: RESERVED_MICROUSD,
           });
           return json(authorizationResponse("request_123"));
         }
@@ -371,7 +380,7 @@ describe("Cloudflare funded relay control-plane ordering", () => {
     await relay.close();
   });
 
-  it("fails closed on expired pricing after count and before reserve or generation", async () => {
+  it("fails closed after the deliberate pricing review horizon", async () => {
     const events: string[] = [];
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const url = String(input);
@@ -384,7 +393,7 @@ describe("Cloudflare funded relay control-plane ordering", () => {
       return json({});
     });
     const relay = configuredRelay(fetchMock as typeof fetch, {
-      now: () => new Date("2026-09-01T00:00:00.000Z"),
+      now: () => new Date("2026-10-01T00:00:00.000Z"),
     });
     const app = new Hono();
     relay.register(app);
@@ -421,7 +430,7 @@ describe("Cloudflare funded relay control-plane ordering", () => {
           reservationId: body.reservationId,
           requestId: "request_2",
           tokenId: "credential_123",
-          releasedMicrousd: 3_600,
+          releasedMicrousd: RESERVED_MICROUSD,
           releasedAt: NOW.toISOString(),
           reason: "pre_upstream_failure",
           status: "released",
@@ -434,7 +443,7 @@ describe("Cloudflare funded relay control-plane ordering", () => {
         return json(finalizationResponse({
           requestId: "request_1",
           reservationId: body.reservationId,
-          actualCostMicrousd: 3_600,
+          actualCostMicrousd: RESERVED_MICROUSD,
           finalizationMode: "conservative",
         }));
       }
@@ -474,7 +483,8 @@ describe("Cloudflare funded relay control-plane ordering", () => {
         const body = JSON.parse(String(init?.body));
         events.push(`finalize:${body.mode}`);
         return json(finalizationResponse({
-          requestId: "request_123", actualCostMicrousd: 3_600, finalizationMode: "conservative",
+          requestId: "request_123", actualCostMicrousd: RESERVED_MICROUSD,
+          finalizationMode: "conservative",
         }));
       }
       events.push("generation_failure");
@@ -506,7 +516,8 @@ describe("Cloudflare funded relay control-plane ordering", () => {
         const body = JSON.parse(String(init?.body));
         events.push(`finalize:${body.mode}`);
         return json(finalizationResponse({
-          requestId: "request_123", actualCostMicrousd: 3_600, finalizationMode: "conservative",
+          requestId: "request_123", actualCostMicrousd: RESERVED_MICROUSD,
+          finalizationMode: "conservative",
         }));
       }
       return new Response(new ReadableStream<Uint8Array>({

--- a/tests/proxy/funded-relay.test.ts
+++ b/tests/proxy/funded-relay.test.ts
@@ -82,6 +82,28 @@ function startResponse(requestId: string, reservationId = "reservation_123") {
   };
 }
 
+function finalizationResponse(input: {
+  requestId: string;
+  reservationId?: string;
+  actualCostMicrousd: number;
+  finalizationMode: "exact" | "conservative";
+}) {
+  return {
+    contractVersion: 1,
+    reservationId: input.reservationId ?? "reservation_123",
+    requestId: input.requestId,
+    tokenId: "credential_123",
+    actualCostMicrousd: input.actualCostMicrousd,
+    releasedMicrousd: 3_600 - input.actualCostMicrousd,
+    remainingBalanceMicrousd: 96_400,
+    remainingBudgetMicrousd: 96_400,
+    funding: authorizationResponse(input.requestId).funding,
+    settledAt: NOW.toISOString(),
+    status: "settled",
+    finalizationMode: input.finalizationMode,
+  };
+}
+
 function json(value: unknown, status = 200): Response {
   return new Response(JSON.stringify(value), { status, headers: { "content-type": "application/json" } });
 }
@@ -164,6 +186,17 @@ describe("Cloudflare funded relay control-plane ordering", () => {
           expect(body).toEqual({ reservationId: "reservation_123", tokenId: "credential_123" });
           return json(startResponse("request_123"));
         }
+        if (action === "finalize") {
+          expect(body).toEqual({
+            reservationId: "reservation_123",
+            tokenId: "credential_123",
+            mode: "exact",
+            actualCostMicrousd: 2_100,
+          });
+          return json(finalizationResponse({
+            requestId: "request_123", actualCostMicrousd: 2_100, finalizationMode: "exact",
+          }));
+        }
         throw new Error(`unexpected platform action ${action}`);
       }
 
@@ -191,7 +224,10 @@ describe("Cloudflare funded relay control-plane ordering", () => {
       }
       expect(forwarded.max_tokens).toBe(100);
       events.push("cloudflare_generate");
-      return json({ id: "msg_1", model: NATIVE_MODEL });
+      return json({
+        id: "msg_1", type: "message", model: NATIVE_MODEL,
+        usage: { input_tokens: 1_000, output_tokens: 10 },
+      });
     });
     const relay = configuredRelay(fetchMock as typeof fetch);
     const app = new Hono();
@@ -208,9 +244,10 @@ describe("Cloudflare funded relay control-plane ordering", () => {
       "x-matrix-user": "mallory",
     }));
     expect(response.status).toBe(200);
-    expect(events).toEqual(["check", "cloudflare_count", "authorize", "start", "cloudflare_generate"]);
-    expect(events).not.toContain("settle");
-    relay.close();
+    await response.text();
+    await vi.waitFor(() => expect(events).toContain("finalize"));
+    expect(events).toEqual(["check", "cloudflare_count", "authorize", "start", "cloudflare_generate", "finalize"]);
+    await relay.close();
   });
 
   it("uses a zero-cost policy check for count_tokens without reserving or starting", async () => {
@@ -234,7 +271,7 @@ describe("Cloudflare funded relay control-plane ordering", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ input_tokens: 42 });
     expect(events).toEqual(["check", "cloudflare_count"]);
-    relay.close();
+    await relay.close();
   });
 
   it("never reaches Cloudflare when platform policy denies an opaque or legacy credential", async () => {
@@ -258,7 +295,7 @@ describe("Cloudflare funded relay control-plane ordering", () => {
     }));
     expect(legacy.status).toBe(401);
     expect(cloudflareFetch).not.toHaveBeenCalled();
-    relay.close();
+    await relay.close();
   });
 
   it("times out platform checks without contacting Cloudflare", async () => {
@@ -277,7 +314,7 @@ describe("Cloudflare funded relay control-plane ordering", () => {
     relay.register(app);
     expect((await app.request("/v1/messages", fundedRequest())).status).toBe(503);
     expect(cloudflareFetch).not.toHaveBeenCalled();
-    relay.close();
+    await relay.close();
   });
 
   it("does not start or generate when reservation authorization denies after counting", async () => {
@@ -301,7 +338,7 @@ describe("Cloudflare funded relay control-plane ordering", () => {
     relay.register(app);
     expect((await app.request("/v1/messages", fundedRequest())).status).toBe(403);
     expect(events).toEqual(["check", "cloudflare_count", "authorize_denied"]);
-    relay.close();
+    await relay.close();
   });
 
   it("rejects unsupported models before platform or Cloudflare calls", async () => {
@@ -312,7 +349,7 @@ describe("Cloudflare funded relay control-plane ordering", () => {
     const response = await app.request("/v1/messages", fundedRequest(requestBody({ model: "claude-opus-5" })));
     expect(response.status).toBe(403);
     expect(fetchMock).not.toHaveBeenCalled();
-    relay.close();
+    await relay.close();
   });
 
   it("times out bounded token counting and does not reserve or generate", async () => {
@@ -331,7 +368,7 @@ describe("Cloudflare funded relay control-plane ordering", () => {
     const response = await app.request("/v1/messages", fundedRequest());
     expect(response.status).toBe(504);
     expect(events).toEqual(["check", "cloudflare_count"]);
-    relay.close();
+    await relay.close();
   });
 
   it("fails closed on expired pricing after count and before reserve or generation", async () => {
@@ -354,7 +391,7 @@ describe("Cloudflare funded relay control-plane ordering", () => {
     const response = await app.request("/v1/messages", fundedRequest());
     expect(response.status).toBe(503);
     expect(events).toEqual(["check", "cloudflare_count"]);
-    relay.close();
+    await relay.close();
   });
 
   it("releases only a definitive resource denial before start", async () => {
@@ -391,6 +428,16 @@ describe("Cloudflare funded relay control-plane ordering", () => {
           funding: authorizationResponse("request_2").funding,
         });
       }
+      if (url.endsWith("/finalize")) {
+        const body = JSON.parse(String(init?.body));
+        events.push(`finalize:${body.reservationId}:${body.mode}`);
+        return json(finalizationResponse({
+          requestId: "request_1",
+          reservationId: body.reservationId,
+          actualCostMicrousd: 3_600,
+          finalizationMode: "conservative",
+        }));
+      }
       events.push("generate");
       if (events.filter((event) => event === "generate").length === 1) await firstPending;
       return json({ id: "msg" });
@@ -411,7 +458,7 @@ describe("Cloudflare funded relay control-plane ordering", () => {
     expect(events).not.toContain("start:reservation_2");
     releaseFirst?.();
     await (await first).text();
-    relay.close();
+    await relay.close();
   });
 
   it("never releases an in-flight reservation after generation fetch fails", async () => {
@@ -423,6 +470,13 @@ describe("Cloudflare funded relay control-plane ordering", () => {
       if (url.endsWith("/authorize")) return json(authorizationResponse("request_123"));
       if (url.endsWith("/start")) { events.push("start"); return json(startResponse("request_123")); }
       if (url.endsWith("/release")) events.push("release");
+      if (url.endsWith("/finalize")) {
+        const body = JSON.parse(String(init?.body));
+        events.push(`finalize:${body.mode}`);
+        return json(finalizationResponse({
+          requestId: "request_123", actualCostMicrousd: 3_600, finalizationMode: "conservative",
+        }));
+      }
       events.push("generation_failure");
       throw new Error(`private upstream failure ${String(init?.body).slice(0, 10)}`);
     });
@@ -432,9 +486,48 @@ describe("Cloudflare funded relay control-plane ordering", () => {
     relay.register(app);
     const response = await app.request("/v1/messages", fundedRequest());
     expect(response.status).toBe(502);
-    expect(events).toEqual(["start", "generation_failure"]);
+    await vi.waitFor(() => expect(events).toContain("finalize:conservative"));
+    expect(events).toEqual(["start", "generation_failure", "finalize:conservative"]);
     expect(JSON.stringify(warn.mock.calls)).not.toContain("private upstream failure");
-    relay.close();
+    await relay.close();
+  });
+
+  it("finalizes downstream-cancelled streams conservatively without release", async () => {
+    const events: string[] = [];
+    const upstreamCancel = vi.fn();
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/check")) return json(checkResponse());
+      if (url.endsWith("/v1/messages/count_tokens")) return json({ input_tokens: 1_000 });
+      if (url.endsWith("/authorize")) return json(authorizationResponse("request_123"));
+      if (url.endsWith("/start")) { events.push("start"); return json(startResponse("request_123")); }
+      if (url.endsWith("/release")) { events.push("release"); return json({}); }
+      if (url.endsWith("/finalize")) {
+        const body = JSON.parse(String(init?.body));
+        events.push(`finalize:${body.mode}`);
+        return json(finalizationResponse({
+          requestId: "request_123", actualCostMicrousd: 3_600, finalizationMode: "conservative",
+        }));
+      }
+      return new Response(new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(
+            "data: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-5\",\"usage\":{\"input_tokens\":1000}}}\n\n",
+          ));
+        },
+        cancel: upstreamCancel,
+      }), { status: 200, headers: { "content-type": "text/event-stream" } });
+    });
+    const relay = configuredRelay(fetchMock as typeof fetch);
+    const app = new Hono();
+    relay.register(app);
+    const response = await app.request("/v1/messages", fundedRequest(requestBody({ stream: true })));
+    expect(response.status).toBe(200);
+    await response.body?.cancel("client disconnected");
+    await vi.waitFor(() => expect(events).toContain("finalize:conservative"));
+    expect(events).toEqual(["start", "finalize:conservative"]);
+    expect(upstreamCancel).toHaveBeenCalled();
+    await relay.close();
   });
 
   it("applies global admission before parsing", async () => {
@@ -445,7 +538,7 @@ describe("Cloudflare funded relay control-plane ordering", () => {
     expect((await app.request("/v1/messages", fundedRequest("{not-json"))).status).toBe(400);
     expect((await app.request("/v1/messages", fundedRequest())).status).toBe(429);
     expect(fetchMock).not.toHaveBeenCalled();
-    relay.close();
+    await relay.close();
   });
 
   it("holds global concurrency across policy checks and denies without another fetch", async () => {
@@ -462,7 +555,7 @@ describe("Cloudflare funded relay control-plane ordering", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
     finishCheck?.(json({ error: { code: "unauthorized", message: "Unauthorized" } }, 401));
     expect((await first).status).toBe(401);
-    relay.close();
+    await relay.close();
   });
 
   it("rejects invalid routes, queries, content types, and oversized bodies before fetch", async () => {
@@ -478,7 +571,7 @@ describe("Cloudflare funded relay control-plane ordering", () => {
     expect((await app.request("/v1/messages", fundedRequest(requestBody({ maxTokens: 100 }) + " ".repeat(256)))).status)
       .toBe(413);
     expect(fetchMock).not.toHaveBeenCalled();
-    relay.close();
+    await relay.close();
   });
 });
 
@@ -505,6 +598,6 @@ describe("funded relay bounded resources", () => {
     expect(legacy.status).toBe(200);
     expect(await legacy.json()).toEqual({ route: "legacy" });
     expect((await app.request("/v1/messages", fundedRequest())).status).toBe(403);
-    relay.close();
+    await relay.close();
   });
 });

--- a/tests/proxy/funded-relay.test.ts
+++ b/tests/proxy/funded-relay.test.ts
@@ -1,609 +1,510 @@
+import { createHmac } from "node:crypto";
 import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
-import { buildFundedProxyApiKey, buildProxyApiKey } from "../../packages/proxy/src/auth.js";
-import {
-  createFundedRelay,
-  resolveFundedRelayConfig,
-} from "../../packages/proxy/src/funded-relay.js";
+import { buildProxyApiKey } from "../../packages/proxy/src/auth.js";
+import { createFundedRelay, resolveFundedRelayConfig } from "../../packages/proxy/src/funded-relay.js";
+import { estimateWorstCaseMicrousd, mapFundedModel } from "../../packages/proxy/src/funded-relay-model.js";
 import { boundedBody } from "../../packages/proxy/src/funded-relay-stream.js";
 
-const SHARED_SECRET = "shared-secret-with-enough-entropy";
-const GATEWAY_TOKEN = "cloudflare-gateway-token";
+const GATEWAY_TOKEN = "cloudflare-unified-billing-token-123456789";
+const RELAY_TOKEN = "platform-relay-control-token-123456789";
+const METADATA_SECRET = "metadata-hmac-secret-123456789012345";
 const GATEWAY_URL =
   "https://gateway.ai.cloudflare.com/v1/0123456789abcdef0123456789abcdef/matrix/anthropic";
+const PLATFORM_URL = "https://platform.internal.example";
+const NATIVE_MODEL = "claude-sonnet-5";
+const CANONICAL_MODEL = "anthropic/claude-sonnet-5";
+const CREDENTIAL = `sk-matrix-funded-credential_123.${"s".repeat(43)}`;
+const NOW = new Date("2026-08-30T20:00:00.000Z");
 
 function enabledEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return {
     MATRIX_FUNDED_AI_ENABLED: "1",
-    MATRIX_FUNDED_AI_MODELS: "claude-sonnet-5,claude-haiku-4-5",
     MATRIX_FUNDED_AI_BETAS: "context-1m-2025-08-07",
     CLOUDFLARE_AI_GATEWAY_URL: GATEWAY_URL,
     CLOUDFLARE_AI_GATEWAY_TOKEN: GATEWAY_TOKEN,
-    PROXY_SHARED_SECRET: SHARED_SECRET,
+    PLATFORM_INTERNAL_URL: PLATFORM_URL,
+    AI_RELAY_CONTROL_TOKEN: RELAY_TOKEN,
+    AI_RELAY_METADATA_SECRET: METADATA_SECRET,
     ...overrides,
   };
 }
 
-function requestBody(model = "claude-sonnet-5", stream = false): string {
+function requestBody(input: { maxTokens?: number; model?: string; stream?: boolean } = {}): string {
   return JSON.stringify({
-    model,
-    max_tokens: 1024,
-    stream,
+    model: input.model ?? NATIVE_MODEL,
+    max_tokens: input.maxTokens ?? 100,
+    stream: input.stream ?? false,
     messages: [{ role: "user", content: "hello" }],
   });
 }
 
-describe("funded relay configuration", () => {
-  it("stays disabled unless explicitly enabled", () => {
+function policy() {
+  return {
+    enabled: true, globalRevision: 2, runtimeRevision: 3,
+    allowedModelIds: [CANONICAL_MODEL], monthlyBudgetMicrousd: 100_000,
+    checkedAt: NOW.toISOString(), staleAfter: "2026-08-30T20:01:00.000Z",
+  };
+}
+
+function identity() {
+  return {
+    tokenId: "credential_123", ownerId: "user_alice", machineId: "machine_123", runtimeSlot: "primary",
+    audience: "matrix-funded-relay", scope: "ai:invoke", expiresAt: "2026-08-30T20:15:00.000Z",
+  };
+}
+
+function checkResponse() {
+  return { contractVersion: 1, authorized: true, identity: identity(), policy: policy() };
+}
+
+function authorizationResponse(requestId: string, reservationId = "reservation_123") {
+  return {
+    contractVersion: 1, authorized: true, identity: identity(), policy: policy(),
+    funding: {
+      asOf: NOW.toISOString(), periodStart: "2026-08-01T00:00:00.000Z", monthlyBudgetMicrousd: 100_000,
+      settledThisMonthMicrousd: 0, reservedMicrousd: 3_600, reservedThisMonthMicrousd: 3_600,
+      promotionalBalanceMicrousd: 100_000, addonBalanceMicrousd: 0, creditBalanceMicrousd: 100_000,
+      remainingBalanceMicrousd: 96_400, remainingBudgetMicrousd: 96_400,
+    },
+    reservation: {
+      reservationId, requestId, modelId: CANONICAL_MODEL, reservedMicrousd: 3_600,
+      remainingBalanceMicrousd: 96_400, remainingBudgetMicrousd: 96_400,
+      periodStart: "2026-08-01T00:00:00.000Z", expiresAt: "2026-08-30T20:05:00.000Z", status: "reserved",
+    },
+  };
+}
+
+function startResponse(requestId: string, reservationId = "reservation_123") {
+  return {
+    contractVersion: 1, reservationId, requestId, tokenId: "credential_123",
+    startedAt: NOW.toISOString(), expiresAt: "2026-08-30T20:30:00.000Z", status: "in_flight",
+  };
+}
+
+function json(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), { status, headers: { "content-type": "application/json" } });
+}
+
+function configuredRelay(fetchImpl: typeof fetch, overrides: Record<string, unknown> = {}) {
+  const config = resolveFundedRelayConfig(enabledEnv());
+  expect(config).not.toBeNull();
+  return createFundedRelay({
+    ...config!, fetch: fetchImpl, now: () => NOW, requestIdFactory: () => "request_123", ...overrides,
+  });
+}
+
+function fundedRequest(body = requestBody(), headers: Record<string, string> = {}): RequestInit {
+  return {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-api-key": CREDENTIAL, ...headers },
+    body,
+  };
+}
+
+describe("funded relay configuration and pricing", () => {
+  it("stays disabled by default and fails closed without distinct dedicated authority", () => {
     expect(resolveFundedRelayConfig({})).toBeNull();
     expect(resolveFundedRelayConfig({ MATRIX_FUNDED_AI_ENABLED: "0" })).toBeNull();
-  });
-
-  it("fails closed when enabled configuration is incomplete", () => {
     expect(() => resolveFundedRelayConfig({ MATRIX_FUNDED_AI_ENABLED: "1" }))
       .toThrow("CLOUDFLARE_AI_GATEWAY_URL");
+    expect(() => resolveFundedRelayConfig(enabledEnv({ AI_RELAY_METADATA_SECRET: RELAY_TOKEN })))
+      .toThrow(/distinct/i);
+    expect(resolveFundedRelayConfig(enabledEnv())).toMatchObject({
+      gatewayBaseUrl: GATEWAY_URL, platformBaseUrl: PLATFORM_URL,
+      gatewayToken: GATEWAY_TOKEN, relayControlToken: RELAY_TOKEN, metadataSecret: METADATA_SECRET,
+    });
   });
 
-  it("accepts only the fixed Cloudflare Anthropic gateway shape", () => {
-    expect(resolveFundedRelayConfig(enabledEnv())).toMatchObject({
-      gatewayBaseUrl: GATEWAY_URL,
-      allowedModels: new Set(["claude-sonnet-5", "claude-haiku-4-5"]),
-      gatewayToken: GATEWAY_TOKEN,
-      sharedSecret: SHARED_SECRET,
-      allowedBetas: new Set(["context-1m-2025-08-07"]),
-      firstResponseTimeoutMs: 10_000,
+  it("maps exactly Sonnet 5 and prices only a current version with integer safety margin", () => {
+    expect(mapFundedModel(NATIVE_MODEL)).toEqual({
+      nativeModelId: NATIVE_MODEL, canonicalModelId: CANONICAL_MODEL,
     });
-
-    expect(() => resolveFundedRelayConfig(enabledEnv({
-      CLOUDFLARE_AI_GATEWAY_URL: "https://api.anthropic.com",
-    }))).toThrow("CLOUDFLARE_AI_GATEWAY_URL");
+    for (const model of [CANONICAL_MODEL, "claude-sonnet-5-20260829", "claude-opus-5", "sonnet"]) {
+      expect(() => mapFundedModel(model)).toThrow(/model/i);
+    }
+    expect(estimateWorstCaseMicrousd({
+      canonicalModelId: CANONICAL_MODEL, inputTokens: 1_000, maxOutputTokens: 100, now: NOW,
+    })).toMatchObject({ amountMicrousd: 3_600, pricingVersion: "anthropic-2026-08-29" });
+    expect(() => estimateWorstCaseMicrousd({
+      canonicalModelId: CANONICAL_MODEL, inputTokens: 1, maxOutputTokens: 1,
+      now: new Date("2026-09-01T00:00:00.000Z"),
+    })).toThrow(/expired/i);
+    expect(() => estimateWorstCaseMicrousd({
+      canonicalModelId: "anthropic/unknown", inputTokens: 1, maxOutputTokens: 1, now: NOW,
+    })).toThrow(/pricing/i);
   });
 });
 
-describe("Cloudflare funded relay", () => {
-  it("cancels an upstream body when its lifetime already expired", async () => {
-    const cancel = vi.fn();
-    const source = new ReadableStream<Uint8Array>({ cancel });
-    const lifetime = AbortSignal.abort(new DOMException("expired", "TimeoutError"));
-    const release = vi.fn();
-
-    const body = boundedBody(source, 1_024, { release }, vi.fn(), lifetime);
-    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
-    expect(release).toHaveBeenCalledOnce();
-    await body.cancel();
-  });
-
-  it("derives opaque metadata from runtime auth and strips caller credentials", async () => {
-    const upstreamFetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+describe("Cloudflare funded relay control-plane ordering", () => {
+  it("checks policy, counts, reserves, acquires, starts, then generates with five opaque metadata fields", async () => {
+    const events: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
       const headers = new Headers(init?.headers);
+      expect(init?.redirect).toBe("error");
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      if (url.startsWith(PLATFORM_URL)) {
+        expect(headers.get("authorization")).toBe(`Bearer ${RELAY_TOKEN}`);
+        const action = url.slice(`${PLATFORM_URL}/internal/ai/funded/`.length);
+        events.push(action);
+        const body = JSON.parse(String(init?.body));
+        if (action === "check") {
+          expect(body).toEqual({ credential: CREDENTIAL, modelId: CANONICAL_MODEL });
+          return json(checkResponse());
+        }
+        if (action === "authorize") {
+          expect(body).toEqual({
+            credential: CREDENTIAL, requestId: "request_123",
+            modelId: CANONICAL_MODEL, maxCostMicrousd: 3_600,
+          });
+          return json(authorizationResponse("request_123"));
+        }
+        if (action === "start") {
+          expect(body).toEqual({ reservationId: "reservation_123", tokenId: "credential_123" });
+          return json(startResponse("request_123"));
+        }
+        throw new Error(`unexpected platform action ${action}`);
+      }
+
       expect(headers.get("x-api-key")).toBeNull();
       expect(headers.get("authorization")).toBeNull();
+      expect(headers.get("cf-aig-api-token")).toBeNull();
       expect(headers.get("cf-aig-authorization")).toBe(`Bearer ${GATEWAY_TOKEN}`);
       expect(headers.get("cf-aig-collect-log-payload")).toBe("false");
       expect(headers.get("cf-aig-zdr")).toBe("true");
-      expect(JSON.parse(headers.get("cf-aig-metadata") ?? "{}")).toEqual({
-        runtime_id: expect.not.stringContaining("alice"),
-        access_source: "matrix_included",
-      });
-      expect(init?.redirect).toBe("error");
-      expect(init?.signal).toBeInstanceOf(AbortSignal);
-      return new Response(JSON.stringify({ id: "msg_1", model: "claude-sonnet-5" }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
-    });
-    const config = resolveFundedRelayConfig(enabledEnv());
-    expect(config).not.toBeNull();
-    const relay = createFundedRelay({ ...config!, fetch: upstreamFetch as typeof fetch });
-    const app = new Hono();
-    relay.register(app);
-
-    const response = await app.request("/v1/messages", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-api-key": buildFundedProxyApiKey("alice", SHARED_SECRET),
-        "x-matrix-user": "mallory",
-        authorization: "Bearer attacker-controlled",
-      },
-      body: requestBody(),
-    });
-
-    expect(response.status).toBe(200);
-    expect(upstreamFetch).toHaveBeenCalledOnce();
-    expect(String(upstreamFetch.mock.calls[0]?.[0])).toBe(`${GATEWAY_URL}/v1/messages`);
-    relay.close();
-  });
-
-  it("does not fund raw provider keys, unsupported paths, models, or oversized bodies", async () => {
-    const upstreamFetch = vi.fn();
-    const config = resolveFundedRelayConfig(enabledEnv({
-      MATRIX_FUNDED_AI_MAX_BODY_BYTES: "256",
-    }));
-    expect(config).not.toBeNull();
-    const relay = createFundedRelay({ ...config!, fetch: upstreamFetch as typeof fetch });
-    const app = new Hono();
-    relay.register(app);
-    const proxyKey = buildFundedProxyApiKey("alice", SHARED_SECRET);
-
-    const rawKey = await app.request("/v1/messages", {
-      method: "POST",
-      headers: { "content-type": "application/json", "x-api-key": "sk-ant-secret" },
-      body: requestBody(),
-    });
-    expect(rawKey.status).toBe(404);
-
-    const wrongPath = await app.request("/v1/complete", {
-      method: "POST",
-      headers: { "content-type": "application/json", "x-api-key": proxyKey },
-      body: requestBody(),
-    });
-    expect(wrongPath.status).toBe(404);
-
-    const queryString = await app.request("/v1/messages?target=attacker-controlled", {
-      method: "POST",
-      headers: { "content-type": "application/json", "x-api-key": proxyKey },
-      body: requestBody(),
-    });
-    expect(queryString.status).toBe(404);
-
-    const wrongModel = await app.request("/v1/messages", {
-      method: "POST",
-      headers: { "content-type": "application/json", "x-api-key": proxyKey },
-      body: requestBody("claude-fable-5"),
-    });
-    expect(wrongModel.status).toBe(403);
-
-    const oversizedBody = JSON.stringify({
-      model: "claude-sonnet-5",
-      max_tokens: 1024,
-      messages: [{ role: "user", content: "x".repeat(512) }],
-    });
-    const oversized = await app.request("/v1/messages", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "content-length": String(oversizedBody.length),
-        "x-api-key": proxyKey,
-      },
-      body: oversizedBody,
-    });
-    expect(oversized.status).toBe(413);
-    expect(upstreamFetch).not.toHaveBeenCalled();
-    relay.close();
-  });
-
-  it("aborts active upstream streams when the relay closes", async () => {
-    let upstreamSignal: AbortSignal | undefined;
-    const upstreamFetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
-      upstreamSignal = init?.signal ?? undefined;
-      return new Response(new ReadableStream<Uint8Array>({
-        start() {
-          // Intentionally remains open until relay shutdown aborts the request.
-        },
-      }), {
-        headers: { "content-type": "text/event-stream" },
-      });
-    });
-    const config = resolveFundedRelayConfig(enabledEnv());
-    expect(config).not.toBeNull();
-    const relay = createFundedRelay({ ...config!, fetch: upstreamFetch as typeof fetch });
-    const app = new Hono();
-    relay.register(app);
-
-    const response = await app.request("/v1/messages", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-api-key": buildFundedProxyApiKey("alice", SHARED_SECRET),
-      },
-      body: requestBody("claude-sonnet-5", true),
-    });
-
-    expect(response.status).toBe(200);
-    expect(upstreamSignal?.aborted).toBe(false);
-    relay.close();
-    expect(upstreamSignal?.aborted).toBe(true);
-    await response.body?.cancel();
-  });
-
-  it("releases admission when the total timeout fires after response headers", async () => {
-    const upstreamFetch = vi.fn(async () => {
-      if (upstreamFetch.mock.calls.length === 1) {
-        return new Response(new ReadableStream<Uint8Array>({
-          start() {
-            // Simulate an upstream body that never produces bytes or closes.
-          },
-        }), {
-          headers: { "content-type": "text/event-stream" },
-        });
+      const metadata = JSON.parse(headers.get("cf-aig-metadata") ?? "{}");
+      expect(Object.keys(metadata).sort()).toEqual([
+        "access_source", "matrix_user_ref", "model_ref", "run_ref", "runtime_ref",
+      ]);
+      expect(Object.values(metadata).every((value) => ["string", "number", "boolean"].includes(typeof value)))
+        .toBe(true);
+      expect(JSON.stringify(metadata)).not.toContain("user_alice");
+      expect(JSON.stringify(metadata)).not.toContain("machine_123");
+      const forwarded = JSON.parse(String(init?.body));
+      expect(forwarded).not.toHaveProperty("metadata");
+      if (url.endsWith("/v1/messages/count_tokens")) {
+        expect(forwarded).not.toHaveProperty("max_tokens");
+        expect(forwarded).not.toHaveProperty("stream");
+        events.push("cloudflare_count");
+        return json({ input_tokens: 1_000 });
       }
-      return new Response(JSON.stringify({ id: "msg_after_timeout" }), {
-        headers: { "content-type": "application/json" },
-      });
+      expect(forwarded.max_tokens).toBe(100);
+      events.push("cloudflare_generate");
+      return json({ id: "msg_1", model: NATIVE_MODEL });
     });
-    const config = resolveFundedRelayConfig(enabledEnv({
-      MATRIX_FUNDED_AI_RUNTIME_CONCURRENCY: "1",
-    }));
-    expect(config).not.toBeNull();
-    const relay = createFundedRelay({
-      ...config!,
-      fetch: upstreamFetch as typeof fetch,
-      timeoutMs: 20,
-    });
+    const relay = configuredRelay(fetchMock as typeof fetch);
     const app = new Hono();
     relay.register(app);
-    const headers = {
-      "content-type": "application/json",
-      "x-api-key": buildFundedProxyApiKey("alice", SHARED_SECRET),
-    };
-
-    const stalled = await app.request("/v1/messages", {
-      method: "POST",
-      headers,
-      body: requestBody("claude-sonnet-5", true),
+    const bodyWithCallerMetadata = JSON.stringify({
+      ...JSON.parse(requestBody()),
+      metadata: { user_id: "raw-caller-id" },
     });
-    expect(stalled.status).toBe(200);
-
-    const blocked = await app.request("/v1/messages", {
-      method: "POST",
-      headers,
-      body: requestBody(),
-    });
-    expect(blocked.status).toBe(429);
-
-    await new Promise((resolve) => setTimeout(resolve, 40));
-    const admitted = await app.request("/v1/messages", {
-      method: "POST",
-      headers,
-      body: requestBody(),
-    });
-    expect(admitted.status).toBe(200);
-    await admitted.text();
-
-    await stalled.body?.cancel();
+    const response = await app.request("/v1/messages", fundedRequest(bodyWithCallerMetadata, {
+      authorization: "Bearer caller-secret",
+      "cf-aig-authorization": "Bearer caller-cloudflare",
+      "cf-aig-api-token": "caller-token",
+      "cf-aig-metadata": JSON.stringify({ prompt: "secret" }),
+      "x-matrix-user": "mallory",
+    }));
+    expect(response.status).toBe(200);
+    expect(events).toEqual(["check", "cloudflare_count", "authorize", "start", "cloudflare_generate"]);
+    expect(events).not.toContain("settle");
     relay.close();
   });
 
-  it("enforces per-runtime admission limits and maps upstream failures safely", async () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    let releaseFirst: (() => void) | undefined;
-    const firstPending = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
-    const upstreamFetch = vi.fn(async () => {
-      if (upstreamFetch.mock.calls.length === 1) {
-        await firstPending;
-        return new Response(JSON.stringify({ id: "msg_1" }), {
-          headers: { "content-type": "application/json" },
-        });
+  it("uses a zero-cost policy check for count_tokens without reserving or starting", async () => {
+    const events: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/check")) { events.push("check"); return json(checkResponse()); }
+      if (url.endsWith("/v1/messages/count_tokens")) {
+        events.push("cloudflare_count");
+        return json({ input_tokens: 42 });
       }
-      throw new Error("secret upstream detail");
+      throw new Error(`unexpected fetch ${url}`);
     });
-    const config = resolveFundedRelayConfig(enabledEnv({
-      MATRIX_FUNDED_AI_RUNTIME_CONCURRENCY: "1",
-      MATRIX_FUNDED_AI_RATE_LIMIT: "2",
+    const relay = configuredRelay(fetchMock as typeof fetch);
+    const app = new Hono();
+    relay.register(app);
+    const response = await app.request(
+      "/v1/messages/count_tokens",
+      fundedRequest(JSON.stringify({ model: NATIVE_MODEL, messages: [{ role: "user", content: "hello" }] })),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ input_tokens: 42 });
+    expect(events).toEqual(["check", "cloudflare_count"]);
+    relay.close();
+  });
+
+  it("never reaches Cloudflare when platform policy denies an opaque or legacy credential", async () => {
+    const cloudflareFetch = vi.fn();
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.startsWith(PLATFORM_URL)) {
+        return json({ error: { code: "unauthorized", message: "Unauthorized" } }, 401);
+      }
+      cloudflareFetch();
+      return json({ id: "must_not_happen" });
+    });
+    const relay = configuredRelay(fetchMock as typeof fetch);
+    const app = new Hono();
+    relay.register(app);
+    expect((await app.request("/v1/messages", fundedRequest())).status).toBe(401);
+    const legacySignature = createHmac("sha256", "old-shared-secret")
+      .update("funded-proxy:alice").digest("base64url");
+    const legacy = await app.request("/v1/messages", fundedRequest(requestBody(), {
+      "x-api-key": `sk-matrix-funded-alice.${legacySignature}`,
     }));
-    expect(config).not.toBeNull();
-    const relay = createFundedRelay({ ...config!, fetch: upstreamFetch as typeof fetch });
-    const app = new Hono();
-    relay.register(app);
-    const headers = {
-      "content-type": "application/json",
-      "x-api-key": buildFundedProxyApiKey("alice", SHARED_SECRET),
-    };
-
-    const first = app.request("/v1/messages", { method: "POST", headers, body: requestBody() });
-    await vi.waitFor(() => expect(upstreamFetch).toHaveBeenCalledTimes(1));
-    const concurrent = await app.request("/v1/messages", {
-      method: "POST",
-      headers,
-      body: requestBody(),
-    });
-    expect(concurrent.status).toBe(429);
-
-    releaseFirst?.();
-    await (await first).text();
-
-    const failure = await app.request("/v1/messages", {
-      method: "POST",
-      headers,
-      body: requestBody(),
-    });
-    expect(failure.status).toBe(502);
-    expect(await failure.text()).not.toContain("secret upstream detail");
-
-    const rateLimited = await app.request("/v1/messages", {
-      method: "POST",
-      headers,
-      body: requestBody(),
-    });
-    expect(rateLimited.status).toBe(429);
-    expect(upstreamFetch).toHaveBeenCalledTimes(2);
-    expect(JSON.stringify(warn.mock.calls)).not.toContain("secret upstream detail");
-    warn.mockRestore();
+    expect(legacy.status).toBe(401);
+    expect(cloudflareFetch).not.toHaveBeenCalled();
     relay.close();
   });
 
-  it("enforces a global minute budget across distinct runtimes", async () => {
-    const upstreamFetch = vi.fn(async () => new Response(JSON.stringify({ id: "msg_1" }), {
-      headers: { "content-type": "application/json" },
-    }));
-    const config = resolveFundedRelayConfig(enabledEnv({
-      MATRIX_FUNDED_AI_GLOBAL_RATE_LIMIT: "2",
-      MATRIX_FUNDED_AI_RATE_LIMIT: "10",
-    }));
-    expect(config).not.toBeNull();
-    const relay = createFundedRelay({ ...config!, fetch: upstreamFetch as typeof fetch, now: () => 0 });
-    const app = new Hono();
-    relay.register(app);
-
-    for (const handle of ["alice", "bobbb"]) {
-      const response = await app.request("/v1/messages", {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-api-key": buildFundedProxyApiKey(handle, SHARED_SECRET),
-        },
-        body: requestBody(),
-      });
-      expect(response.status).toBe(200);
-      await response.text();
-    }
-
-    const limited = await app.request("/v1/messages", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-api-key": buildFundedProxyApiKey("carol", SHARED_SECRET),
-      },
-      body: requestBody(),
-    });
-    expect(limited.status).toBe(429);
-    expect(upstreamFetch).toHaveBeenCalledTimes(2);
-    relay.close();
-  });
-
-  it("rejects funded credentials while disabled without falling through to legacy routing", async () => {
-    const app = new Hono();
-    const relay = createFundedRelay(null);
-    relay.register(app);
-    app.all("/v1/*", (c) => c.json({ route: "legacy" }));
-
-    const funded = await app.request("/v1/messages", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-api-key": buildFundedProxyApiKey("alice", SHARED_SECRET),
-      },
-      body: requestBody(),
-    });
-    expect(funded.status).toBe(403);
-    expect(await funded.text()).not.toContain("legacy");
-
-    const legacy = await app.request("/v1/messages", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-api-key": buildProxyApiKey("alice", SHARED_SECRET),
-      },
-      body: requestBody(),
-    });
-    expect(legacy.status).toBe(200);
-    expect(await legacy.json()).toEqual({ route: "legacy" });
-    relay.close();
-  });
-
-  it("forwards only bounded allowlisted request fields and beta values", async () => {
-    const upstreamFetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
-      expect(JSON.parse(String(init?.body))).toEqual({
-        model: "claude-sonnet-5",
-        max_tokens: 1024,
-        stream: false,
-        messages: [{ role: "user", content: "hello" }],
-        tools: [{ name: "lookup", description: "Lookup", input_schema: { type: "object" } }],
-      });
-      expect(new Headers(init?.headers).get("anthropic-beta"))
-        .toBe("context-1m-2025-08-07");
-      return new Response(JSON.stringify({ id: "msg_1" }), {
-        headers: { "content-type": "application/json" },
-      });
-    });
-    const config = resolveFundedRelayConfig(enabledEnv());
-    expect(config).not.toBeNull();
-    const relay = createFundedRelay({ ...config!, fetch: upstreamFetch as typeof fetch });
-    const app = new Hono();
-    relay.register(app);
-    const headers = {
-      "content-type": "application/json",
-      "anthropic-beta": "context-1m-2025-08-07",
-      "x-api-key": buildFundedProxyApiKey("alice", SHARED_SECRET),
-    };
-
-    const accepted = await app.request("/v1/messages", {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        model: "claude-sonnet-5",
-        max_tokens: 1024,
-        stream: false,
-        messages: [{ role: "user", content: "hello" }],
-        tools: [{ name: "lookup", description: "Lookup", input_schema: { type: "object" } }],
-      }),
-    });
-    expect(accepted.status).toBe(200);
-    await accepted.text();
-
-    for (const body of [
-      { ...JSON.parse(requestBody()), service_tier: "priority_only" },
-      {
-        ...JSON.parse(requestBody()),
-        tools: [{ type: "web_search_20250305", name: "web_search" }],
-      },
-    ]) {
-      const rejected = await app.request("/v1/messages", {
-        method: "POST",
-        headers,
-        body: JSON.stringify(body),
-      });
-      expect(rejected.status).toBe(400);
-    }
-    const rejectedBeta = await app.request("/v1/messages", {
-      method: "POST",
-      headers: { ...headers, "anthropic-beta": "unapproved-beta-2026-01-01" },
-      body: requestBody(),
-    });
-    expect(rejectedBeta.status).toBe(400);
-    expect(upstreamFetch).toHaveBeenCalledOnce();
-    relay.close();
-  });
-
-  it("admits authenticated requests before parsing their bodies", async () => {
-    const upstreamFetch = vi.fn(async () => new Response(JSON.stringify({ id: "unexpected" })));
-    const config = resolveFundedRelayConfig(enabledEnv({ MATRIX_FUNDED_AI_RATE_LIMIT: "1" }));
-    expect(config).not.toBeNull();
-    const relay = createFundedRelay({ ...config!, fetch: upstreamFetch as typeof fetch });
-    const app = new Hono();
-    relay.register(app);
-    const headers = {
-      "content-type": "application/json",
-      "x-api-key": buildFundedProxyApiKey("alice", SHARED_SECRET),
-    };
-
-    const malformed = await app.request("/v1/messages", {
-      method: "POST",
-      headers,
-      body: "{not-json",
-    });
-    expect(malformed.status).toBe(400);
-
-    const limited = await app.request("/v1/messages", {
-      method: "POST",
-      headers,
-      body: requestBody(),
-    });
-    expect(limited.status).toBe(429);
-    expect(upstreamFetch).not.toHaveBeenCalled();
-    relay.close();
-  });
-
-  it("uses a short first-response deadline without shortening valid streams", async () => {
-    const upstreamFetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
-      if (upstreamFetch.mock.calls.length === 1) {
+  it("times out platform checks without contacting Cloudflare", async () => {
+    const cloudflareFetch = vi.fn();
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      if (String(input).startsWith(PLATFORM_URL)) {
         return await new Promise<Response>((_resolve, reject) => {
           init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
         });
       }
-      return new Response(JSON.stringify({ id: "msg_after_timeout" }), {
-        headers: { "content-type": "application/json" },
+      cloudflareFetch();
+      return json({});
+    });
+    const relay = configuredRelay(fetchMock as typeof fetch, { platformTimeoutMs: 20 });
+    const app = new Hono();
+    relay.register(app);
+    expect((await app.request("/v1/messages", fundedRequest())).status).toBe(503);
+    expect(cloudflareFetch).not.toHaveBeenCalled();
+    relay.close();
+  });
+
+  it("does not start or generate when reservation authorization denies after counting", async () => {
+    const events: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/check")) { events.push("check"); return json(checkResponse()); }
+      if (url.endsWith("/v1/messages/count_tokens")) {
+        events.push("cloudflare_count");
+        return json({ input_tokens: 1_000 });
+      }
+      if (url.endsWith("/authorize")) {
+        events.push("authorize_denied");
+        return json({ error: { code: "budget_exceeded", message: "Monthly AI budget reached" } }, 403);
+      }
+      events.push("unexpected_upstream");
+      return json({});
+    });
+    const relay = configuredRelay(fetchMock as typeof fetch);
+    const app = new Hono();
+    relay.register(app);
+    expect((await app.request("/v1/messages", fundedRequest())).status).toBe(403);
+    expect(events).toEqual(["check", "cloudflare_count", "authorize_denied"]);
+    relay.close();
+  });
+
+  it("rejects unsupported models before platform or Cloudflare calls", async () => {
+    const fetchMock = vi.fn();
+    const relay = configuredRelay(fetchMock as typeof fetch);
+    const app = new Hono();
+    relay.register(app);
+    const response = await app.request("/v1/messages", fundedRequest(requestBody({ model: "claude-opus-5" })));
+    expect(response.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
+    relay.close();
+  });
+
+  it("times out bounded token counting and does not reserve or generate", async () => {
+    const events: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/check")) { events.push("check"); return json(checkResponse()); }
+      events.push("cloudflare_count");
+      return await new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
       });
     });
-    const config = resolveFundedRelayConfig(enabledEnv({
-      MATRIX_FUNDED_AI_RUNTIME_CONCURRENCY: "1",
-    }));
-    expect(config).not.toBeNull();
-    const relay = createFundedRelay({
-      ...config!,
-      fetch: upstreamFetch as typeof fetch,
-      firstResponseTimeoutMs: 20,
-      timeoutMs: 1_000,
-    });
+    const relay = configuredRelay(fetchMock as typeof fetch, { countTokensTimeoutMs: 20 });
     const app = new Hono();
     relay.register(app);
-    const headers = {
-      "content-type": "application/json",
-      "x-api-key": buildFundedProxyApiKey("alice", SHARED_SECRET),
-    };
-
-    const timedOut = await app.request("/v1/messages", {
-      method: "POST",
-      headers,
-      body: requestBody(),
-    });
-    expect(timedOut.status).toBe(504);
-
-    const admitted = await app.request("/v1/messages", {
-      method: "POST",
-      headers,
-      body: requestBody(),
-    });
-    expect(admitted.status).toBe(200);
-    await admitted.text();
+    const response = await app.request("/v1/messages", fundedRequest());
+    expect(response.status).toBe(504);
+    expect(events).toEqual(["check", "cloudflare_count"]);
     relay.close();
   });
 
-  it("caps count_tokens bodies independently from message bodies", async () => {
-    const upstreamFetch = vi.fn();
-    const config = resolveFundedRelayConfig(enabledEnv({
-      MATRIX_FUNDED_AI_MAX_BODY_BYTES: String(2 * 1024 * 1024),
-    }));
-    expect(config).not.toBeNull();
-    const relay = createFundedRelay({ ...config!, fetch: upstreamFetch as typeof fetch });
+  it("fails closed on expired pricing after count and before reserve or generation", async () => {
+    const events: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/check")) { events.push("check"); return json(checkResponse()); }
+      if (url.endsWith("/v1/messages/count_tokens")) {
+        events.push("cloudflare_count");
+        return json({ input_tokens: 10 });
+      }
+      events.push("unexpected");
+      return json({});
+    });
+    const relay = configuredRelay(fetchMock as typeof fetch, {
+      now: () => new Date("2026-09-01T00:00:00.000Z"),
+    });
     const app = new Hono();
     relay.register(app);
-    const body = JSON.stringify({
-      model: "claude-sonnet-5",
-      messages: [{ role: "user", content: "x".repeat(300 * 1024) }],
-    });
-
-    const response = await app.request("/v1/messages/count_tokens", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "content-length": String(body.length),
-        "x-api-key": buildFundedProxyApiKey("alice", SHARED_SECRET),
-      },
-      body,
-    });
-    expect(response.status).toBe(413);
-    expect(upstreamFetch).not.toHaveBeenCalled();
+    const response = await app.request("/v1/messages", fundedRequest());
+    expect(response.status).toBe(503);
+    expect(events).toEqual(["check", "cloudflare_count"]);
     relay.close();
   });
 
-  it("aborts oversized upstream responses and releases admission", async () => {
-    let firstSignal: AbortSignal | undefined;
-    const upstreamFetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
-      if (upstreamFetch.mock.calls.length === 1) {
-        firstSignal = init?.signal ?? undefined;
-        return new Response(new Uint8Array(2_048), {
-          headers: { "content-type": "application/json" },
+  it("releases only a definitive resource denial before start", async () => {
+    let releaseFirst: (() => void) | undefined;
+    const firstPending = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    let reservation = 0;
+    const events: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/check")) return json(checkResponse());
+      if (url.endsWith("/v1/messages/count_tokens")) return json({ input_tokens: 1_000 });
+      if (url.endsWith("/authorize")) {
+        reservation += 1;
+        const requestId = JSON.parse(String(init?.body)).requestId as string;
+        return json(authorizationResponse(requestId, `reservation_${reservation}`));
+      }
+      if (url.endsWith("/start")) {
+        const body = JSON.parse(String(init?.body));
+        events.push(`start:${body.reservationId}`);
+        return json(startResponse("request_1", body.reservationId));
+      }
+      if (url.endsWith("/release")) {
+        const body = JSON.parse(String(init?.body));
+        events.push(`release:${body.reservationId}:${body.reason}`);
+        return json({
+          contractVersion: 1,
+          reservationId: body.reservationId,
+          requestId: "request_2",
+          tokenId: "credential_123",
+          releasedMicrousd: 3_600,
+          releasedAt: NOW.toISOString(),
+          reason: "pre_upstream_failure",
+          status: "released",
+          funding: authorizationResponse("request_2").funding,
         });
       }
-      return new Response(JSON.stringify({ id: "msg_after_limit" }), {
-        headers: { "content-type": "application/json" },
-      });
+      events.push("generate");
+      if (events.filter((event) => event === "generate").length === 1) await firstPending;
+      return json({ id: "msg" });
     });
-    const config = resolveFundedRelayConfig(enabledEnv({
-      MATRIX_FUNDED_AI_RUNTIME_CONCURRENCY: "1",
-    }));
-    expect(config).not.toBeNull();
-    const relay = createFundedRelay({
-      ...config!,
-      fetch: upstreamFetch as typeof fetch,
-      maxResponseBytes: 1_024,
+    let requestId = 0;
+    const relay = configuredRelay(fetchMock as typeof fetch, {
+      requestIdFactory: () => `request_${++requestId}`,
+      runtimeConcurrency: 1,
+      rateLimitPerMinute: 10,
     });
     const app = new Hono();
     relay.register(app);
-    const headers = {
-      "content-type": "application/json",
-      "x-api-key": buildFundedProxyApiKey("alice", SHARED_SECRET),
-    };
+    const first = app.request("/v1/messages", fundedRequest());
+    await vi.waitFor(() => expect(events).toContain("generate"));
+    const denied = await app.request("/v1/messages", fundedRequest());
+    expect(denied.status).toBe(429);
+    expect(events).toContain("release:reservation_2:pre_upstream_failure");
+    expect(events).not.toContain("start:reservation_2");
+    releaseFirst?.();
+    await (await first).text();
+    relay.close();
+  });
 
-    const oversized = await app.request("/v1/messages", {
-      method: "POST",
-      headers,
-      body: requestBody(),
+  it("never releases an in-flight reservation after generation fetch fails", async () => {
+    const events: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/check")) return json(checkResponse());
+      if (url.endsWith("/v1/messages/count_tokens")) return json({ input_tokens: 1_000 });
+      if (url.endsWith("/authorize")) return json(authorizationResponse("request_123"));
+      if (url.endsWith("/start")) { events.push("start"); return json(startResponse("request_123")); }
+      if (url.endsWith("/release")) events.push("release");
+      events.push("generation_failure");
+      throw new Error(`private upstream failure ${String(init?.body).slice(0, 10)}`);
     });
-    await expect(oversized.text()).rejects.toThrow("configured limit");
-    expect(firstSignal?.aborted).toBe(true);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const relay = configuredRelay(fetchMock as typeof fetch);
+    const app = new Hono();
+    relay.register(app);
+    const response = await app.request("/v1/messages", fundedRequest());
+    expect(response.status).toBe(502);
+    expect(events).toEqual(["start", "generation_failure"]);
+    expect(JSON.stringify(warn.mock.calls)).not.toContain("private upstream failure");
+    relay.close();
+  });
 
-    const admitted = await app.request("/v1/messages", {
-      method: "POST",
-      headers,
-      body: requestBody(),
-    });
-    expect(admitted.status).toBe(200);
-    await admitted.text();
+  it("applies global admission before parsing", async () => {
+    const fetchMock = vi.fn();
+    const relay = configuredRelay(fetchMock as typeof fetch, { globalRateLimitPerMinute: 1 });
+    const app = new Hono();
+    relay.register(app);
+    expect((await app.request("/v1/messages", fundedRequest("{not-json"))).status).toBe(400);
+    expect((await app.request("/v1/messages", fundedRequest())).status).toBe(429);
+    expect(fetchMock).not.toHaveBeenCalled();
+    relay.close();
+  });
+
+  it("holds global concurrency across policy checks and denies without another fetch", async () => {
+    let finishCheck: ((response: Response) => void) | undefined;
+    const fetchMock = vi.fn(async () => await new Promise<Response>((resolve) => {
+      finishCheck = resolve;
+    }));
+    const relay = configuredRelay(fetchMock as typeof fetch, { globalConcurrency: 1 });
+    const app = new Hono();
+    relay.register(app);
+    const first = app.request("/v1/messages", fundedRequest());
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    expect((await app.request("/v1/messages", fundedRequest())).status).toBe(429);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    finishCheck?.(json({ error: { code: "unauthorized", message: "Unauthorized" } }, 401));
+    expect((await first).status).toBe(401);
+    relay.close();
+  });
+
+  it("rejects invalid routes, queries, content types, and oversized bodies before fetch", async () => {
+    const fetchMock = vi.fn();
+    const relay = configuredRelay(fetchMock as typeof fetch, { maxBodyBytes: 128 });
+    const app = new Hono();
+    relay.register(app);
+    expect((await app.request("/v1/complete", fundedRequest())).status).toBe(404);
+    expect((await app.request("/v1/messages?debug=1", fundedRequest())).status).toBe(404);
+    expect((await app.request("/v1/messages", {
+      ...fundedRequest(), headers: { "content-type": "text/plain", "x-api-key": CREDENTIAL },
+    })).status).toBe(415);
+    expect((await app.request("/v1/messages", fundedRequest(requestBody({ maxTokens: 100 }) + " ".repeat(256)))).status)
+      .toBe(413);
+    expect(fetchMock).not.toHaveBeenCalled();
+    relay.close();
+  });
+});
+
+describe("funded relay bounded resources", () => {
+  it("cancels an upstream body when its lifetime already expired", async () => {
+    const cancel = vi.fn();
+    const body = boundedBody(
+      new ReadableStream<Uint8Array>({ cancel }), 1_024,
+      { release: vi.fn() }, vi.fn(),
+      AbortSignal.abort(new DOMException("expired", "TimeoutError")),
+    );
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+    await body.cancel();
+  });
+
+  it("does not confuse legacy owner-funded proxy credentials with funded access", async () => {
+    const app = new Hono();
+    const relay = createFundedRelay(null);
+    relay.register(app);
+    app.all("/v1/*", (c) => c.json({ route: "legacy" }));
+    const legacy = await app.request("/v1/messages", fundedRequest(requestBody(), {
+      "x-api-key": buildProxyApiKey("alice", "shared-secret-with-enough-entropy"),
+    }));
+    expect(legacy.status).toBe(200);
+    expect(await legacy.json()).toEqual({ route: "legacy" });
+    expect((await app.request("/v1/messages", fundedRequest())).status).toBe(403);
     relay.close();
   });
 });


### PR DESCRIPTION
## Summary

- route Matrix-funded Anthropic requests through Cloudflare AI Gateway only after platform policy and conservative credit reservation succeed
- settle exact bounded JSON/SSE usage; retain the full reservation for malformed, truncated, cancelled, or ambiguous post-start work
- use opaque HMAC metadata, strip caller authority, disable payload logging, and keep a capped TTL settlement retry queue with shutdown drain
- pin Sonnet 5 pricing in integer microusd with cache-read/write accounting and an explicit review horizon

## Safety and invariants

- **Source of truth:** Matrix Postgres budgets, allowlists, grants, reservations, and spend—not Cloudflare account limits.
- **Ordering:** policy check → reserve → mark in flight → upstream generation → exact/conservative finalize.
- **Failure mode:** definitive pre-start denials release; every post-start ambiguity charges the reservation and retries idempotently.
- **Privacy:** no owner/provider secrets or raw prompts are placed in Cloudflare metadata or client errors.

## Validation

- 67 focused contracts/platform/proxy/gateway tests on the relay head
- contracts, platform, proxy, and gateway TypeScript checks
- included in the restacked top validation: 817 changed-surface tests and all affected package typechecks
- `git diff --check`

Stack parent: #1459
