### PR TITLE
feat(ai-funding): add atomic credit checkout

### DIFF
--- a/desktop/src/renderer/src/features/settings/AgentsProvidersAdapter.tsx
+++ b/desktop/src/renderer/src/features/settings/AgentsProvidersAdapter.tsx
@@ -9,6 +9,7 @@ import { useConnection } from "../../stores/connection";
 import {
   createDesktopProviderSettingsTransport,
   desktopProviderIdentityKey,
+  openAiCreditCheckout,
   openExistingProviderTerminalSession,
   openProviderAuthorizationPath,
 } from "./provider-settings-desktop-adapter";
@@ -108,6 +109,19 @@ function ConnectedAgentsProvidersAdapter({
       });
   }, [isIdentityCurrent, platformHost, runtimeSlot]);
 
+  const addCredit = useCallback(async (
+    _accessSourceId: string,
+    packageId: "usd_5" | "usd_10" | "usd_25",
+    requestId: string,
+  ) => {
+    setActionError(null);
+    const opened = await openAiCreditCheckout({ api, runtimeSlot, packageId, requestId });
+    if (!opened) {
+      if (isIdentityCurrent()) setActionError(ACTION_ERROR);
+      throw new Error("Checkout unavailable");
+    }
+  }, [api, isIdentityCurrent, runtimeSlot]);
+
   if (controller.snapshot === null) {
     return (
       <ProviderSettingsUnavailable
@@ -136,7 +150,7 @@ function ConnectedAgentsProvidersAdapter({
       }}
       onOpenTerminal={openTerminal}
       onOpenBrowser={openBrowser}
-      onAddCredit={() => setActionError(ACTION_ERROR)}
+      onAddCredit={addCredit}
     />
   );
 }

--- a/desktop/src/renderer/src/features/settings/provider-settings-desktop-adapter.ts
+++ b/desktop/src/renderer/src/features/settings/provider-settings-desktop-adapter.ts
@@ -21,6 +21,7 @@ const PROVIDER_SETTINGS_PATH = "/api/ai/provider-settings";
 const PROVIDER_SETTINGS_ACTIONS_PATH = "/api/ai/provider-settings/actions";
 const MAX_RESPONSE_BYTES = 1024 * 1024;
 const MAX_MUTATION_BYTES = 64 * 1024;
+const MAX_CHECKOUT_RESPONSE_BYTES = 8 * 1024;
 
 export function desktopProviderIdentityKey(identity: {
   status: "loading" | "signed-out" | "signed-in";
@@ -115,6 +116,40 @@ export async function openExistingProviderTerminalSession(
 }
 
 type OpenExternal = (url: string) => Promise<unknown>;
+
+function isStripeCheckoutUrl(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" && url.hostname === "checkout.stripe.com";
+  } catch {
+    return false;
+  }
+}
+
+export async function openAiCreditCheckout(input: {
+  api: ApiClient;
+  runtimeSlot: string;
+  packageId: "usd_5" | "usd_10" | "usd_25";
+  requestId: string;
+  openExternal?: OpenExternal;
+}): Promise<boolean> {
+  try {
+    const result = await input.api.post<unknown>("/billing/ai-credit/checkout", {
+      packageId: input.packageId,
+      runtimeSlot: input.runtimeSlot,
+      requestId: input.requestId,
+    }, { maxBytes: MAX_CHECKOUT_RESPONSE_BYTES });
+    const url = result && typeof result === "object" ? (result as { url?: unknown }).url : undefined;
+    if (!isStripeCheckoutUrl(url)) return false;
+    const openExternal = input.openExternal ?? ((target) => invoke("shell:open-external", { url: target }));
+    await openExternal(url);
+    return true;
+  } catch (error) {
+    console.warn("[ai-credit] Checkout unavailable:", error instanceof Error ? error.name : typeof error);
+    return false;
+  }
+}
 
 export async function openProviderAuthorizationPath(input: {
   authorizationPath: string;

--- a/docs/dev/provider-settings-parity.md
+++ b/docs/dev/provider-settings-parity.md
@@ -176,9 +176,29 @@ Usage displays must state their authority:
 - unknown or stale values are labeled unavailable or stale, never estimated as
   exact.
 
-Add Credit remains unavailable until Stripe checkout can atomically create an
-idempotent add-on grant. The current snapshot therefore keeps
-`gatewayPolicy.topUpEnabled` false and never advertises `add_credit`.
+Add Credit is advertised only when the platform's authoritative checkout
+configuration is complete. The browser cannot choose an owner, machine, USD
+amount, Stripe Price, or ledger value: it sends one allowlisted package ID,
+runtime slot, and UUID, while Clerk authentication and the active machine row
+derive the exact owner/runtime. Web navigates to hosted Stripe Checkout and
+Electron opens that same validated `https://checkout.stripe.com` URL in the
+external browser. Both render the shared package picker and safe retry state.
+
+The signed `checkout.session.completed` webhook validates payment mode,
+complete/paid state, USD currency, exact total, package/Price metadata, and the
+owner/machine/runtime binding. It writes the webhook receipt and non-expiring
+add-on ledger grant in one database transaction. The ledger entry uses the
+Checkout Session ID with `ON CONFLICT`, so duplicate delivery cannot add credit
+twice; invalid, expired, or unpaid events return non-2xx and add no credit.
+Cloudflare remains the upstream billing/spend fuse while Matrix Postgres remains
+the user-credit authority.
+
+`gatewayPolicy.topUpEnabled` and `add_credit` fail closed unless
+`MATRIX_FUNDED_AI_ADDON_CHECKOUT_ENABLED=true`, Stripe signing is configured,
+and every server-owned `$5/$10/$25` Price ID is valid. Local provider JSON can
+never enable the button. Stripe Tax is off for add-on Checkout unless operators
+set `MATRIX_AI_CREDIT_STRIPE_TAX_REGISTRATIONS_VERIFIED=true` after confirming
+the required active tax registrations.
 
 ## Security and failure requirements
 

--- a/docs/dev/provider-settings-parity.md
+++ b/docs/dev/provider-settings-parity.md
@@ -184,12 +184,24 @@ derive the exact owner/runtime. Web navigates to hosted Stripe Checkout and
 Electron opens that same validated `https://checkout.stripe.com` URL in the
 external browser. Both render the shared package picker and safe retry state.
 
-The signed `checkout.session.completed` webhook validates payment mode,
-complete/paid state, USD currency, exact total, package/Price metadata, and the
-owner/machine/runtime binding. It writes the webhook receipt and non-expiring
-add-on ledger grant in one database transaction. The ledger entry uses the
-Checkout Session ID with `ON CONFLICT`, so duplicate delivery cannot add credit
-twice; invalid, expired, or unpaid events return non-2xx and add no credit.
+Creation first persists an immutable, bounded checkout claim. Active attempts
+are reused and each owner/runtime is durably limited to five new attempts per
+hour. The signed Checkout lifecycle validates payment mode, USD currency, exact
+pre-tax `amount_subtotal`, `amount_total >= amount_subtotal`, package/Price
+metadata, and the owner/machine/runtime binding against that claim rather than
+mutable environment configuration. Completed unpaid sessions wait for
+`checkout.session.async_payment_succeeded`; failed or expired sessions add no
+credit. The webhook receipt and non-expiring add-on ledger grant commit in one
+database transaction. The ledger entry uses the Checkout Session ID with
+`ON CONFLICT`, so duplicate delivery cannot add credit twice. Mismatches return
+non-2xx so Stripe retries; valid unpaid, failed, and expired lifecycle events
+are recorded as 2xx no-ops for credit.
+
+Any positive refund reverses the full associated add-on grant. Available
+unused credit is removed atomically; already consumed or reserved credit
+becomes durable debt and freezes further funded authorization. A dispute does
+the same while open or lost. A won dispute restores only the amount previously
+removed, clears that claim's debt, and unfreezes the runtime when safe.
 Cloudflare remains the upstream billing/spend fuse while Matrix Postgres remains
 the user-credit authority.
 

--- a/docs/dev/staging-platform-vps.md
+++ b/docs/dev/staging-platform-vps.md
@@ -210,7 +210,10 @@ account and production platform env:
    Preserve existing monthly and annual Price IDs in
    `STRIPE_LEGACY_PRICE_CATALOG_JSON` before replacing any current ID. Each
    billable computer uses its own full plan subscription.
-3. Enable automatic tax for Checkout and Portal; add required tax registrations.
+3. Enable automatic tax for subscription Checkout and Portal; add required tax
+   registrations. Funded AI add-on Checkout remains tax-disabled until those
+   registrations are verified and
+   `MATRIX_AI_CREDIT_STRIPE_TAX_REGISTRATIONS_VERIFIED=true` is set.
 4. Enable promotion codes in Checkout and Customer Portal (Stripe Coupons /
    Promotion Codes, not hardcoded discounts).
 5. Configure the production webhook endpoint
@@ -244,6 +247,15 @@ account and production platform env:
 14. Deploy the platform/app-shell Cloud Run service and verify the no-VPS flow
     directly on `app.matrix-os.com`; publishing a host bundle alone does not
     update this billing screen.
+15. To enable funded AI add-ons, create one-time USD Prices for `$5`, `$10`, and
+    `$25`; set `STRIPE_PRICE_AI_CREDIT_USD_5`,
+    `STRIPE_PRICE_AI_CREDIT_USD_10`, and
+    `STRIPE_PRICE_AI_CREDIT_USD_25`; then set
+    `MATRIX_FUNDED_AI_ADDON_CHECKOUT_ENABLED=true`. Partial catalogs fail closed.
+16. Restrict the Stripe API key to the resources Matrix billing needs and apply
+    a Stripe-side IP allowlist for the platform egress addresses where the
+    deployment topology supports stable egress. Never expose this key to a VPS
+    or renderer.
 
 After production env is set, merge the stack, build a host bundle from `main`,
 publish it, promote it to `stable`, deploy the fleet by `stable`, and verify

--- a/docs/platform/dev/deployment.md
+++ b/docs/platform/dev/deployment.md
@@ -113,6 +113,9 @@ STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual
 STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly
 STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual
 STRIPE_LEGACY_PRICE_CATALOG_JSON=stripe-legacy-price-catalog-json
+STRIPE_PRICE_AI_CREDIT_USD_5=stripe-price-ai-credit-usd-5
+STRIPE_PRICE_AI_CREDIT_USD_10=stripe-price-ai-credit-usd-10
+STRIPE_PRICE_AI_CREDIT_USD_25=stripe-price-ai-credit-usd-25
 ```
 
 Annual IDs are retained only to recognize and manage existing subscriptions;
@@ -123,9 +126,17 @@ List every replaced live Price ID before changing the current monthly secrets,
 so existing customers keep their original subscription and entitlement. The
 current price IDs take precedence if an ID appears in both catalogs.
 
-Stripe automatic tax is enabled in Checkout. Before promotion, verify the live
-account has the required tax registrations; enabling automatic tax alone does
-not create registrations.
+Stripe automatic tax is enabled in subscription Checkout. Before promotion,
+verify the live account has the required tax registrations; enabling automatic
+tax alone does not create registrations.
+
+Funded AI add-on credit remains disabled unless the three one-time USD Prices,
+Stripe secret/signing secret, and
+`MATRIX_FUNDED_AI_ADDON_CHECKOUT_ENABLED=true` are all present. Set
+`MATRIX_AI_CREDIT_STRIPE_TAX_REGISTRATIONS_VERIFIED=true` only after the Stripe
+account has the required active tax registrations; otherwise add-on Checkout
+deliberately creates sessions with automatic tax disabled. Use a restricted
+Stripe key and, where Cloud Run has stable egress, a Stripe IP allowlist.
 
 The two portal configurations are required to enable the customer-facing
 add-computer flow, but their absence does not block an otherwise healthy

--- a/packages/contracts/src/funded-ai.ts
+++ b/packages/contracts/src/funded-ai.ts
@@ -145,6 +145,8 @@ export const FundedAiPolicyCheckResponseSchema = z.object({
 }).strict();
 
 export const FundedAiFundingSummarySchema = z.object({
+  /** Platform-authoritative capability; local runtime JSON cannot enable purchases. */
+  topUpEnabled: z.boolean().optional(),
   asOf: IsoTimestampSchema,
   periodStart: IsoTimestampSchema,
   monthlyBudgetMicrousd: MicrousdSchema,

--- a/packages/gateway/src/ai-providers/provider-settings-projector.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-projector.ts
@@ -280,6 +280,10 @@ export async function projectProviderSettings(input: {
   fundedPolicyAuthoritative?: boolean;
   loginMethods?: (harness: HarnessConfiguration) => readonly ProviderLoginMethod[];
 }): Promise<ProviderSettingsSnapshot> {
+  const supportedActions = input.fundingSummary?.topUpEnabled === true
+    && !input.supportedActions.includes("add_credit")
+    ? [...input.supportedActions, "add_credit" as const]
+    : input.supportedActions;
   const { sources, sourceByAccount } = projectAccessSources(
     input.canonical,
     input.config,
@@ -319,8 +323,9 @@ export async function projectProviderSettings(input: {
         monthlyBudgetMicrousd: input.fundedPolicyAuthoritative
           ? input.fundingSummary?.monthlyBudgetMicrousd ?? null
           : input.config.gatewayPolicy.monthlyBudgetMicrousd,
-        // Stripe top-ups are not wired yet; schemas alone never advertise purchase capability.
-        topUpEnabled: false,
+        // Only the machine-authenticated platform funding response can enable
+        // purchase. Owner-controlled provider JSON remains incapable of doing so.
+        topUpEnabled: input.fundingSummary?.topUpEnabled === true,
       } : null;
   const allowedGatewayModels = new Set(gatewayPolicy?.allowedModelIds ?? []);
   const harnesses = input.config.harnesses.flatMap((stored) => {
@@ -343,10 +348,10 @@ export async function projectProviderSettings(input: {
     },
     revision: input.config.revision,
     refreshedAt: input.now.toISOString(),
-    access: input.supportedActions.length > 0
+    access: supportedActions.length > 0
       ? { mode: "writable" }
       : { mode: "read_only", reason: "runtime_unavailable" },
-    supportedActions: input.supportedActions,
+    supportedActions,
     modelProviders,
     accessSources: sources,
     accounts,

--- a/packages/platform/src/ai-credit-checkout-store.ts
+++ b/packages/platform/src/ai-credit-checkout-store.ts
@@ -1,0 +1,262 @@
+import { createHash } from "node:crypto";
+import { sql } from "kysely";
+import type { AiCreditPackageId } from "./ai-credit-checkout.js";
+import type { PlatformDB, PlatformDatabase } from "./db.js";
+
+const CHECKOUT_WINDOW_MS = 60 * 60_000;
+const CHECKOUT_ACTIVE_MS = 24 * 60 * 60_000;
+export const AI_CREDIT_CHECKOUTS_PER_HOUR = 5;
+
+export class AiCreditCheckoutStoreError extends Error {
+  constructor(readonly code: "conflict" | "rate_limited" | "not_found" | "verification_failed") {
+    super(code);
+  }
+}
+
+export interface AiCreditCheckoutClaimInput {
+  requestId: string;
+  ownerId: string;
+  machineId: string;
+  runtimeSlot: string;
+  packageId: AiCreditPackageId;
+  priceId: string;
+  amountMicrousd: number;
+  amountCents: number;
+  currency: "usd";
+  automaticTax: boolean;
+  idempotencyKey: string;
+}
+
+export type AiCreditCheckoutClaim = PlatformDatabase["ai_credit_checkout_claims"];
+
+function exactClaimMatch(row: PlatformDatabase["ai_credit_checkout_claims"], input: AiCreditCheckoutClaimInput) {
+  return row.owner_id === input.ownerId && row.machine_id === input.machineId
+    && row.runtime_slot === input.runtimeSlot && row.package_id === input.packageId
+    && row.stripe_price_id === input.priceId && Number(row.amount_microusd) === input.amountMicrousd
+    && row.amount_cents === input.amountCents && row.currency === input.currency
+    && row.automatic_tax === input.automaticTax && row.idempotency_key === input.idempotencyKey;
+}
+
+function sameRequestMatch(row: PlatformDatabase["ai_credit_checkout_claims"], input: AiCreditCheckoutClaimInput) {
+  return row.owner_id === input.ownerId && row.machine_id === input.machineId
+    && row.runtime_slot === input.runtimeSlot && row.package_id === input.packageId
+    && row.idempotency_key === input.idempotencyKey;
+}
+
+export async function prepareAiCreditCheckoutClaim(
+  db: PlatformDB,
+  input: AiCreditCheckoutClaimInput,
+  at: Date,
+) {
+  const createdAt = at.toISOString();
+  const expiresAt = new Date(at.getTime() + CHECKOUT_ACTIVE_MS).toISOString();
+  const windowStart = new Date(at.getTime() - CHECKOUT_WINDOW_MS).toISOString();
+  return db.transaction(async (trx) => {
+    const machine = await trx.executor.selectFrom("user_machines").select([
+      "clerk_user_id", "runtime_slot", "status", "activation_state", "deleted_at",
+    ]).where("machine_id", "=", input.machineId).forUpdate().executeTakeFirst();
+    if (!machine || machine.clerk_user_id !== input.ownerId || machine.runtime_slot !== input.runtimeSlot
+      || machine.status !== "running" || machine.activation_state !== "authorized" || machine.deleted_at !== null) {
+      throw new AiCreditCheckoutStoreError("verification_failed");
+    }
+    await trx.executor.updateTable("ai_credit_checkout_claims").set({
+      status: "expired", updated_at: createdAt,
+    }).where("owner_id", "=", input.ownerId).where("runtime_slot", "=", input.runtimeSlot)
+      .where("status", "in", ["creating", "open", "awaiting_payment"])
+      .where("expires_at", "<=", createdAt).execute();
+
+    const existing = await trx.executor.selectFrom("ai_credit_checkout_claims")
+      .selectAll().where("request_id", "=", input.requestId).forUpdate().executeTakeFirst();
+    if (existing) {
+      if (!sameRequestMatch(existing, input)) throw new AiCreditCheckoutStoreError("conflict");
+      return existing;
+    }
+    const active = await trx.executor.selectFrom("ai_credit_checkout_claims").selectAll()
+      .where("owner_id", "=", input.ownerId).where("runtime_slot", "=", input.runtimeSlot)
+      .where("status", "in", ["creating", "open", "awaiting_payment"])
+      .forUpdate().executeTakeFirst();
+    if (active) {
+      if (active.machine_id !== input.machineId || active.package_id !== input.packageId) {
+        throw new AiCreditCheckoutStoreError("conflict");
+      }
+      return active;
+    }
+    const recent = await trx.executor.selectFrom("ai_credit_checkout_claims")
+      .select(({ fn }) => fn.countAll<number>().as("count"))
+      .where("owner_id", "=", input.ownerId).where("runtime_slot", "=", input.runtimeSlot)
+      .where("created_at", ">=", windowStart)
+      .executeTakeFirstOrThrow();
+    if (Number(recent.count) >= AI_CREDIT_CHECKOUTS_PER_HOUR) {
+      throw new AiCreditCheckoutStoreError("rate_limited");
+    }
+    await trx.executor.insertInto("ai_credit_checkout_claims").values({
+      request_id: input.requestId, owner_id: input.ownerId, machine_id: input.machineId,
+      runtime_slot: input.runtimeSlot, package_id: input.packageId, stripe_price_id: input.priceId,
+      amount_microusd: input.amountMicrousd, amount_cents: input.amountCents, currency: input.currency,
+      automatic_tax: input.automaticTax, idempotency_key: input.idempotencyKey,
+      stripe_session_id: null, checkout_url: null, payment_intent_id: null, charge_id: null,
+      status: "creating", granted_microusd: 0, reversed_microusd: 0,
+      reversal_debt_microusd: 0, refunded_at: null, dispute_status: "none",
+      created_at: createdAt, updated_at: createdAt, expires_at: expiresAt,
+    }).onConflict((conflict) => conflict.column("request_id").doNothing()).execute();
+    const stored = await trx.executor.selectFrom("ai_credit_checkout_claims").selectAll()
+      .where("request_id", "=", input.requestId).executeTakeFirstOrThrow();
+    if (!exactClaimMatch(stored, input)) throw new AiCreditCheckoutStoreError("conflict");
+    return stored;
+  });
+}
+
+export async function finalizeAiCreditCheckoutClaim(
+  db: PlatformDB,
+  requestId: string,
+  session: { id: string; url: string },
+  at: string,
+) {
+  return db.transaction(async (trx) => {
+    await trx.executor.updateTable("ai_credit_checkout_claims").set({
+      stripe_session_id: session.id, checkout_url: session.url, status: "open", updated_at: at,
+    }).where("request_id", "=", requestId).where("stripe_session_id", "is", null).execute();
+    const stored = await trx.executor.selectFrom("ai_credit_checkout_claims").selectAll()
+      .where("request_id", "=", requestId).forUpdate().executeTakeFirst();
+    if (!stored || stored.stripe_session_id !== session.id || stored.checkout_url !== session.url) {
+      throw new AiCreditCheckoutStoreError("conflict");
+    }
+    return stored;
+  });
+}
+
+export async function getClaimByRequestId(db: PlatformDB, requestId: string, lock = false) {
+  let query = db.executor.selectFrom("ai_credit_checkout_claims").selectAll()
+    .where("request_id", "=", requestId);
+  if (lock) query = query.forUpdate();
+  return query.executeTakeFirst();
+}
+
+export async function getClaimByPaymentReference(
+  db: PlatformDB,
+  paymentIntentId: string | null,
+  chargeId: string | null,
+) {
+  if (!paymentIntentId && !chargeId) return undefined;
+  return db.executor.selectFrom("ai_credit_checkout_claims").selectAll()
+    .where((eb) => eb.or([
+      ...(paymentIntentId ? [eb("payment_intent_id", "=", paymentIntentId)] : []),
+      ...(chargeId ? [eb("charge_id", "=", chargeId)] : []),
+    ])).forUpdate().executeTakeFirst();
+}
+
+export async function markClaimSession(
+  trx: PlatformDB,
+  input: { requestId: string; sessionId: string; paymentIntentId: string | null; status: string; at: string },
+) {
+  const allowedPriorStatuses = input.status === "paid"
+    ? ["creating", "open", "awaiting_payment", "payment_failed", "paid"]
+    : input.status === "awaiting_payment"
+      ? ["creating", "open", "awaiting_payment"]
+      : input.status === "payment_failed"
+        ? ["creating", "open", "awaiting_payment", "payment_failed"]
+        : ["creating", "open", "awaiting_payment", "payment_failed", "expired"];
+  const updated = await trx.executor.updateTable("ai_credit_checkout_claims").set({
+    stripe_session_id: input.sessionId,
+    ...(input.paymentIntentId ? { payment_intent_id: input.paymentIntentId } : {}),
+    status: input.status,
+    updated_at: input.at,
+  }).where("request_id", "=", input.requestId)
+    .where("status", "in", allowedPriorStatuses)
+    .where((eb) => eb.or([eb("stripe_session_id", "is", null), eb("stripe_session_id", "=", input.sessionId)]))
+    .returningAll().executeTakeFirst();
+  if (!updated) throw new AiCreditCheckoutStoreError("verification_failed");
+  return updated;
+}
+
+export async function reverseClaimCredit(
+  trx: PlatformDB,
+  claim: PlatformDatabase["ai_credit_checkout_claims"],
+  sourceReference: string,
+  at: string,
+  freeze: boolean,
+) {
+  if (Number(claim.granted_microusd) <= 0 || Number(claim.reversed_microusd) > 0) return claim;
+  const balance = await trx.executor.selectFrom("ai_funded_runtime_balances").selectAll()
+    .where("machine_id", "=", claim.machine_id).forUpdate().executeTakeFirstOrThrow();
+  const removable = Math.min(
+    Number(claim.granted_microusd), Number(balance.addon_balance_microusd),
+    Math.max(0, Number(balance.credit_balance_microusd) - Number(balance.reserved_microusd)),
+  );
+  const debt = Number(claim.granted_microusd) - removable;
+  if (removable > 0) {
+    const reversalId = createHash("sha256").update(sourceReference).digest("hex").slice(0, 16);
+    const inserted = await trx.executor.insertInto("ai_funded_credit_ledger").values({
+      entry_id: `addon-reversal:${claim.request_id}:${reversalId}`, owner_id: claim.owner_id,
+      machine_id: claim.machine_id, runtime_slot: claim.runtime_slot, kind: "addon_reversal",
+      amount_microusd: -removable, source_reference: sourceReference, reservation_id: null,
+      period_start: null, expires_at: null, created_at: at,
+    }).onConflict((conflict) => conflict.column("entry_id").doNothing())
+      .returning("entry_id").executeTakeFirst();
+    if (inserted) {
+      await trx.executor.updateTable("ai_funded_runtime_balances").set({
+        credit_balance_microusd: sql<number>`credit_balance_microusd - ${removable}`,
+        addon_balance_microusd: sql<number>`addon_balance_microusd - ${removable}`,
+        updated_at: at,
+      }).where("machine_id", "=", claim.machine_id).execute();
+    }
+  }
+  await trx.executor.insertInto("ai_funded_credit_restrictions").values({
+    machine_id: claim.machine_id, owner_id: claim.owner_id, runtime_slot: claim.runtime_slot,
+    debt_microusd: debt, frozen: freeze || debt > 0, updated_at: at,
+  }).onConflict((conflict) => conflict.column("machine_id").doUpdateSet({
+    debt_microusd: sql<number>`ai_funded_credit_restrictions.debt_microusd + ${debt}`,
+    frozen: sql<boolean>`ai_funded_credit_restrictions.frozen OR ${freeze || debt > 0}`,
+    updated_at: at,
+  })).execute();
+  return trx.executor.updateTable("ai_credit_checkout_claims").set({
+    reversed_microusd: Number(claim.granted_microusd), reversal_debt_microusd: debt, updated_at: at,
+  }).where("request_id", "=", claim.request_id).where("reversed_microusd", "=", 0)
+    .returningAll().executeTakeFirstOrThrow();
+}
+
+export async function restoreDisputedClaimCredit(
+  trx: PlatformDB,
+  claim: PlatformDatabase["ai_credit_checkout_claims"],
+  at: string,
+) {
+  if (claim.dispute_status !== "open" || claim.refunded_at !== null || Number(claim.reversed_microusd) === 0) return;
+  const restoreToBalance = Number(claim.reversed_microusd) - Number(claim.reversal_debt_microusd);
+  if (restoreToBalance > 0) {
+    const restoreId = createHash("sha256").update(claim.charge_id ?? claim.request_id).digest("hex").slice(0, 16);
+    const inserted = await trx.executor.insertInto("ai_funded_credit_ledger").values({
+      entry_id: `addon-restore:${claim.request_id}:${restoreId}`, owner_id: claim.owner_id, machine_id: claim.machine_id,
+      runtime_slot: claim.runtime_slot, kind: "addon_grant", amount_microusd: restoreToBalance,
+      source_reference: claim.charge_id ?? claim.payment_intent_id ?? claim.request_id,
+      reservation_id: null, period_start: null, expires_at: null, created_at: at,
+    }).onConflict((conflict) => conflict.column("entry_id").doNothing())
+      .returning("entry_id").executeTakeFirst();
+    if (inserted) {
+      const restored = await trx.executor.updateTable("ai_funded_runtime_balances").set({
+        credit_balance_microusd: sql<number>`credit_balance_microusd + ${restoreToBalance}`,
+        addon_balance_microusd: sql<number>`addon_balance_microusd + ${restoreToBalance}`,
+        updated_at: at,
+      }).where("machine_id", "=", claim.machine_id)
+        .where(sql<boolean>`credit_balance_microusd <= ${Number.MAX_SAFE_INTEGER - restoreToBalance}`)
+        .where(sql<boolean>`addon_balance_microusd <= ${Number.MAX_SAFE_INTEGER - restoreToBalance}`)
+        .returning("machine_id").executeTakeFirst();
+      if (!restored) throw new Error("Funded AI credit restoration exceeds supported bounds");
+    }
+  }
+  await trx.executor.updateTable("ai_credit_checkout_claims").set({
+    reversed_microusd: 0, reversal_debt_microusd: 0, dispute_status: "won", updated_at: at,
+  }).where("request_id", "=", claim.request_id).execute();
+  await trx.executor.updateTable("ai_funded_credit_restrictions").set({
+    debt_microusd: sql<number>`GREATEST(0, debt_microusd - ${Number(claim.reversal_debt_microusd)})`,
+    frozen: sql<boolean>`
+      GREATEST(0, debt_microusd - ${Number(claim.reversal_debt_microusd)}) > 0
+      OR EXISTS (
+        SELECT 1 FROM ai_credit_checkout_claims adverse
+        WHERE adverse.machine_id = ${claim.machine_id}
+          AND adverse.request_id <> ${claim.request_id}
+          AND adverse.dispute_status IN ('open', 'lost')
+      )
+    `,
+    updated_at: at,
+  }).where("machine_id", "=", claim.machine_id).execute();
+}

--- a/packages/platform/src/ai-credit-checkout-store.ts
+++ b/packages/platform/src/ai-credit-checkout-store.ts
@@ -215,13 +215,15 @@ export async function reverseClaimCredit(
     .returningAll().executeTakeFirstOrThrow();
 }
 
-export async function restoreDisputedClaimCredit(
+export async function settleWonDisputeCredit(
   trx: PlatformDB,
   claim: PlatformDatabase["ai_credit_checkout_claims"],
   at: string,
 ) {
-  if (claim.dispute_status !== "open" || claim.refunded_at !== null || Number(claim.reversed_microusd) === 0) return;
-  const restoreToBalance = Number(claim.reversed_microusd) - Number(claim.reversal_debt_microusd);
+  const shouldRestore = claim.refunded_at === null && Number(claim.reversed_microusd) > 0;
+  const restoreToBalance = shouldRestore
+    ? Number(claim.reversed_microusd) - Number(claim.reversal_debt_microusd)
+    : 0;
   if (restoreToBalance > 0) {
     const restoreId = createHash("sha256").update(claim.charge_id ?? claim.request_id).digest("hex").slice(0, 16);
     const inserted = await trx.executor.insertInto("ai_funded_credit_ledger").values({
@@ -243,17 +245,19 @@ export async function restoreDisputedClaimCredit(
       if (!restored) throw new Error("Funded AI credit restoration exceeds supported bounds");
     }
   }
-  await trx.executor.updateTable("ai_credit_checkout_claims").set({
-    reversed_microusd: 0, reversal_debt_microusd: 0, dispute_status: "won", updated_at: at,
-  }).where("request_id", "=", claim.request_id).execute();
+  if (shouldRestore) {
+    await trx.executor.updateTable("ai_credit_checkout_claims").set({
+      reversed_microusd: 0, reversal_debt_microusd: 0, updated_at: at,
+    }).where("request_id", "=", claim.request_id).where("dispute_status", "=", "won").execute();
+  }
+  const clearedDebt = shouldRestore ? Number(claim.reversal_debt_microusd) : 0;
   await trx.executor.updateTable("ai_funded_credit_restrictions").set({
-    debt_microusd: sql<number>`GREATEST(0, debt_microusd - ${Number(claim.reversal_debt_microusd)})`,
+    debt_microusd: sql<number>`GREATEST(0, debt_microusd - ${clearedDebt})`,
     frozen: sql<boolean>`
-      GREATEST(0, debt_microusd - ${Number(claim.reversal_debt_microusd)}) > 0
+      GREATEST(0, debt_microusd - ${clearedDebt}) > 0
       OR EXISTS (
         SELECT 1 FROM ai_credit_checkout_claims adverse
         WHERE adverse.machine_id = ${claim.machine_id}
-          AND adverse.request_id <> ${claim.request_id}
           AND adverse.dispute_status IN ('open', 'lost')
       )
     `,

--- a/packages/platform/src/ai-credit-checkout-store.ts
+++ b/packages/platform/src/ai-credit-checkout-store.ts
@@ -176,7 +176,25 @@ export async function reverseClaimCredit(
   at: string,
   freeze: boolean,
 ) {
-  if (Number(claim.granted_microusd) <= 0 || Number(claim.reversed_microusd) > 0) return claim;
+  if (Number(claim.granted_microusd) <= 0) return claim;
+  if (Number(claim.reversed_microusd) > 0) {
+    if (freeze) {
+      // A refund may have already reversed the grant without freezing the
+      // runtime. A later dispute must still apply its restriction atomically.
+      await trx.executor.insertInto("ai_funded_credit_restrictions").values({
+        machine_id: claim.machine_id,
+        owner_id: claim.owner_id,
+        runtime_slot: claim.runtime_slot,
+        debt_microusd: 0,
+        frozen: true,
+        updated_at: at,
+      }).onConflict((conflict) => conflict.column("machine_id").doUpdateSet({
+        frozen: true,
+        updated_at: at,
+      })).execute();
+    }
+    return claim;
+  }
   const balance = await trx.executor.selectFrom("ai_funded_runtime_balances").selectAll()
     .where("machine_id", "=", claim.machine_id).forUpdate().executeTakeFirstOrThrow();
   const removable = Math.min(

--- a/packages/platform/src/ai-credit-checkout-webhook.ts
+++ b/packages/platform/src/ai-credit-checkout-webhook.ts
@@ -1,0 +1,197 @@
+import { z } from "zod/v4";
+import type { AiFundedPolicyRepository } from "./ai-funded-policy-repository.js";
+import {
+  assertAiCreditCheckoutMetadata,
+  isAiCreditCheckoutObject,
+  parseAiCreditCheckoutSession,
+  readAiCreditCheckoutRequestId,
+  type AiCreditCheckoutClaimExpectation,
+} from "./ai-credit-checkout.js";
+import {
+  getClaimByPaymentReference,
+  getClaimByRequestId,
+  markClaimSession,
+  restoreDisputedClaimCredit,
+  reverseClaimCredit,
+  type AiCreditCheckoutClaim,
+} from "./ai-credit-checkout-store.js";
+import type { PlatformDB } from "./db.js";
+
+interface StripeWebhookEvent {
+  id: string;
+  type: string;
+  created: number;
+  data: { object: unknown };
+}
+
+const AI_SESSION_EVENTS = [
+  "checkout.session.completed", "checkout.session.async_payment_succeeded",
+  "checkout.session.async_payment_failed", "checkout.session.expired",
+] as const;
+const StripeReferenceSchema = z.string().min(3).max(255);
+const StripeExpandableReferenceSchema = z.union([
+  StripeReferenceSchema,
+  z.object({ id: StripeReferenceSchema }).passthrough(),
+]).nullable().optional();
+const StripeRefundedChargeSchema = z.object({
+  id: StripeReferenceSchema,
+  payment_intent: StripeExpandableReferenceSchema,
+  amount_refunded: z.number().int().positive(),
+  currency: z.string().length(3).regex(/^[a-z]{3}$/),
+}).passthrough();
+const StripeDisputeSchema = z.object({
+  id: StripeReferenceSchema,
+  charge: StripeExpandableReferenceSchema,
+  payment_intent: StripeExpandableReferenceSchema,
+  status: z.string().min(2).max(64).regex(/^[a-z_]+$/),
+}).passthrough();
+
+type AiWebhookResult = { received: true; processed: true } | { received: true; ignored: true };
+
+function expandableStripeId(value: string | { id: string } | null | undefined): string | null {
+  return typeof value === "string" ? value : value?.id ?? null;
+}
+
+function claimExpectation(claim: AiCreditCheckoutClaim): AiCreditCheckoutClaimExpectation {
+  if (claim.package_id !== "usd_5" && claim.package_id !== "usd_10" && claim.package_id !== "usd_25") {
+    throw new Error("Funded AI checkout claim package is invalid");
+  }
+  if (claim.currency !== "usd") throw new Error("Funded AI checkout claim currency is invalid");
+  return {
+    requestId: claim.request_id, ownerId: claim.owner_id, machineId: claim.machine_id,
+    runtimeSlot: claim.runtime_slot, packageId: claim.package_id, priceId: claim.stripe_price_id,
+    amountMicrousd: Number(claim.amount_microusd), amountCents: claim.amount_cents, currency: claim.currency,
+  };
+}
+
+async function processSessionEvent(options: {
+  event: StripeWebhookEvent;
+  trx: PlatformDB;
+  repository: Pick<AiFundedPolicyRepository, "grantCreditInTransaction">;
+  at: string;
+}): Promise<AiWebhookResult | null> {
+  if (!AI_SESSION_EVENTS.includes(options.event.type as typeof AI_SESSION_EVENTS[number])
+    || !isAiCreditCheckoutObject(options.event.data.object)) return null;
+  const requestId = readAiCreditCheckoutRequestId(options.event.data.object);
+  if (!requestId) throw new Error("Funded AI checkout claim is invalid");
+  const claim = await getClaimByRequestId(options.trx, requestId, true);
+  if (!claim) throw new Error("Funded AI checkout claim is missing");
+  const session = parseAiCreditCheckoutSession(options.event.data.object, claimExpectation(claim));
+  if (options.event.type === "checkout.session.expired") {
+    if (session.status !== "expired" || session.paymentStatus === "paid") {
+      throw new Error("Funded AI expired checkout verification failed");
+    }
+    await markClaimSession(options.trx, {
+      requestId, sessionId: session.sessionId, paymentIntentId: session.paymentIntentId,
+      status: "expired", at: options.at,
+    });
+    return { received: true, processed: true };
+  }
+  if (session.status !== "complete") throw new Error("Funded AI checkout is incomplete");
+  if (options.event.type === "checkout.session.async_payment_failed") {
+    if (session.paymentStatus === "paid") throw new Error("Funded AI failed payment is marked paid");
+    await markClaimSession(options.trx, {
+      requestId, sessionId: session.sessionId, paymentIntentId: session.paymentIntentId,
+      status: "payment_failed", at: options.at,
+    });
+    return { received: true, processed: true };
+  }
+  if (session.paymentStatus !== "paid") {
+    if (options.event.type === "checkout.session.async_payment_succeeded") {
+      throw new Error("Funded AI async payment is unpaid");
+    }
+    await markClaimSession(options.trx, {
+      requestId, sessionId: session.sessionId, paymentIntentId: session.paymentIntentId,
+      status: "awaiting_payment", at: options.at,
+    });
+    return { received: true, processed: true };
+  }
+  await markClaimSession(options.trx, {
+    requestId, sessionId: session.sessionId, paymentIntentId: session.paymentIntentId,
+    status: "paid", at: options.at,
+  });
+  await options.repository.grantCreditInTransaction(options.trx, {
+    entryId: `addon:${session.sessionId}`, identity: session.identity, kind: "addon_grant",
+    amountMicrousd: session.amountMicrousd, sourceReference: session.sessionId, expiresAt: null,
+  }, options.at);
+  const granted = await options.trx.executor.updateTable("ai_credit_checkout_claims").set({
+    granted_microusd: session.amountMicrousd, updated_at: options.at,
+  }).where("request_id", "=", requestId)
+    .where((eb) => eb.or([
+      eb("granted_microusd", "=", 0), eb("granted_microusd", "=", session.amountMicrousd),
+    ])).returning("request_id").executeTakeFirst();
+  if (!granted) throw new Error("Funded AI checkout grant conflicts with claim");
+  return { received: true, processed: true };
+}
+
+async function processRefundEvent(event: StripeWebhookEvent, trx: PlatformDB, at: string) {
+  if (event.type !== "charge.refunded") return null;
+  const charge = StripeRefundedChargeSchema.parse(event.data.object);
+  const paymentIntentId = expandableStripeId(charge.payment_intent);
+  const metadataRequestId = readAiCreditCheckoutRequestId(event.data.object);
+  const claim = await getClaimByPaymentReference(trx, paymentIntentId, charge.id)
+    ?? (metadataRequestId ? await getClaimByRequestId(trx, metadataRequestId, true) : undefined);
+  if (!claim && !metadataRequestId) return { received: true, ignored: true } as const;
+  if (!claim || claim.currency !== charge.currency || Number(claim.granted_microusd) <= 0) {
+    throw new Error("Funded AI refund claim is missing");
+  }
+  if (metadataRequestId) assertAiCreditCheckoutMetadata(event.data.object, claimExpectation(claim));
+  await trx.executor.updateTable("ai_credit_checkout_claims").set({
+    charge_id: charge.id, payment_intent_id: paymentIntentId ?? claim.payment_intent_id,
+    refunded_at: at, updated_at: at,
+  }).where("request_id", "=", claim.request_id)
+    .where((eb) => eb.or([eb("charge_id", "is", null), eb("charge_id", "=", charge.id)]))
+    .executeTakeFirstOrThrow();
+  await reverseClaimCredit(trx, claim, charge.id, at, false);
+  return { received: true, processed: true } as const;
+}
+
+async function processDisputeEvent(event: StripeWebhookEvent, trx: PlatformDB, at: string) {
+  if (event.type !== "charge.dispute.created" && event.type !== "charge.dispute.closed") return null;
+  const dispute = StripeDisputeSchema.parse(event.data.object);
+  const chargeId = expandableStripeId(dispute.charge);
+  const paymentIntentId = expandableStripeId(dispute.payment_intent);
+  const metadataRequestId = readAiCreditCheckoutRequestId(event.data.object);
+  const claim = await getClaimByPaymentReference(trx, paymentIntentId, chargeId)
+    ?? (metadataRequestId ? await getClaimByRequestId(trx, metadataRequestId, true) : undefined);
+  if (!claim && !metadataRequestId) return { received: true, ignored: true } as const;
+  if (!claim || !chargeId || Number(claim.granted_microusd) <= 0) {
+    throw new Error("Funded AI dispute claim is missing");
+  }
+  if (event.type === "charge.dispute.closed" && dispute.status !== "won" && dispute.status !== "lost") {
+    throw new Error("Funded AI dispute resolution is invalid");
+  }
+  if (metadataRequestId) assertAiCreditCheckoutMetadata(event.data.object, claimExpectation(claim));
+  await trx.executor.updateTable("ai_credit_checkout_claims").set({
+    charge_id: chargeId, payment_intent_id: paymentIntentId ?? claim.payment_intent_id,
+    dispute_status: event.type === "charge.dispute.created" ? "open" : dispute.status,
+    updated_at: at,
+  }).where("request_id", "=", claim.request_id)
+    .where((eb) => eb.or([eb("charge_id", "is", null), eb("charge_id", "=", chargeId)]))
+    .executeTakeFirstOrThrow();
+  const updatedClaim = await getClaimByRequestId(trx, claim.request_id, true);
+  if (!updatedClaim) throw new Error("Funded AI dispute claim is missing");
+  if (event.type === "charge.dispute.closed" && dispute.status === "won") {
+    await restoreDisputedClaimCredit(trx, { ...updatedClaim, dispute_status: claim.dispute_status }, at);
+  } else {
+    await reverseClaimCredit(trx, updatedClaim, dispute.id, at, true);
+  }
+  return { received: true, processed: true } as const;
+}
+
+export async function processAiCreditWebhookEvent(options: {
+  event: StripeWebhookEvent;
+  trx: PlatformDB;
+  repository?: Pick<AiFundedPolicyRepository, "grantCreditInTransaction">;
+  at: string;
+}): Promise<AiWebhookResult | null> {
+  const isMatrixSession = AI_SESSION_EVENTS.includes(options.event.type as typeof AI_SESSION_EVENTS[number])
+    && isAiCreditCheckoutObject(options.event.data.object);
+  if (isMatrixSession && !options.repository) throw new Error("Funded AI credit ledger is unavailable");
+  if (options.repository) {
+    const session = await processSessionEvent({ ...options, repository: options.repository });
+    if (session) return session;
+  }
+  return await processRefundEvent(options.event, options.trx, options.at)
+    ?? await processDisputeEvent(options.event, options.trx, options.at);
+}

--- a/packages/platform/src/ai-credit-checkout-webhook.ts
+++ b/packages/platform/src/ai-credit-checkout-webhook.ts
@@ -11,8 +11,8 @@ import {
   getClaimByPaymentReference,
   getClaimByRequestId,
   markClaimSession,
-  restoreDisputedClaimCredit,
   reverseClaimCredit,
+  settleWonDisputeCredit,
   type AiCreditCheckoutClaim,
 } from "./ai-credit-checkout-store.js";
 import type { PlatformDB } from "./db.js";
@@ -162,19 +162,25 @@ async function processDisputeEvent(event: StripeWebhookEvent, trx: PlatformDB, a
     throw new Error("Funded AI dispute resolution is invalid");
   }
   if (metadataRequestId) assertAiCreditCheckoutMetadata(event.data.object, claimExpectation(claim));
-  await trx.executor.updateTable("ai_credit_checkout_claims").set({
+  // Stripe retries and delivery reordering must not turn a terminal dispute
+  // back into an open one, or change one terminal resolution into another.
+  if (claim.dispute_status === "won" || claim.dispute_status === "lost") {
+    return { received: true, processed: true } as const;
+  }
+  const nextStatus = event.type === "charge.dispute.created" ? "open" : dispute.status;
+  const transitioned = await trx.executor.updateTable("ai_credit_checkout_claims").set({
     charge_id: chargeId, payment_intent_id: paymentIntentId ?? claim.payment_intent_id,
-    dispute_status: event.type === "charge.dispute.created" ? "open" : dispute.status,
+    dispute_status: nextStatus,
     updated_at: at,
   }).where("request_id", "=", claim.request_id)
+    .where("dispute_status", "in", ["none", "open"])
     .where((eb) => eb.or([eb("charge_id", "is", null), eb("charge_id", "=", chargeId)]))
-    .executeTakeFirstOrThrow();
-  const updatedClaim = await getClaimByRequestId(trx, claim.request_id, true);
-  if (!updatedClaim) throw new Error("Funded AI dispute claim is missing");
+    .returningAll().executeTakeFirst();
+  if (!transitioned) throw new Error("Funded AI dispute transition conflicted");
   if (event.type === "charge.dispute.closed" && dispute.status === "won") {
-    await restoreDisputedClaimCredit(trx, { ...updatedClaim, dispute_status: claim.dispute_status }, at);
+    await settleWonDisputeCredit(trx, transitioned, at);
   } else {
-    await reverseClaimCredit(trx, updatedClaim, dispute.id, at, true);
+    await reverseClaimCredit(trx, transitioned, dispute.id, at, true);
   }
   return { received: true, processed: true } as const;
 }

--- a/packages/platform/src/ai-credit-checkout.ts
+++ b/packages/platform/src/ai-credit-checkout.ts
@@ -83,19 +83,41 @@ const AiCreditCheckoutMetadataSchema = z.object({
   matrix_ai_credit_microusd: z.string().regex(/^[1-9][0-9]{0,15}$/),
 }).passthrough();
 
-const AiCreditCompletedSessionSchema = z.object({
+const StripeExpandableIdSchema = z.union([
+  z.string().min(3).max(255),
+  z.object({ id: z.string().min(3).max(255) }).passthrough(),
+]).nullable().optional();
+
+const AiCreditSessionSchema = z.object({
   id: z.string().min(3).max(255).regex(/^cs_[A-Za-z0-9_]+$/),
   mode: z.literal("payment"),
-  status: z.literal("complete"),
-  payment_status: z.literal("paid"),
+  status: z.enum(["open", "complete", "expired"]),
+  payment_status: z.enum(["paid", "unpaid", "no_payment_required"]),
+  amount_subtotal: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
   amount_total: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
   currency: z.literal("usd"),
   client_reference_id: z.string().min(1).max(160),
+  payment_intent: StripeExpandableIdSchema,
   metadata: AiCreditCheckoutMetadataSchema,
 }).passthrough();
 
-export interface AiCreditCheckoutCompletion {
+export interface AiCreditCheckoutClaimExpectation {
+  requestId: string;
+  ownerId: string;
+  machineId: string;
+  runtimeSlot: string;
+  packageId: AiCreditPackageId;
+  priceId: string;
+  amountMicrousd: number;
+  amountCents: number;
+  currency: "usd";
+}
+
+export interface AiCreditCheckoutSession {
   sessionId: string;
+  paymentIntentId: string | null;
+  status: "open" | "complete" | "expired";
+  paymentStatus: "paid" | "unpaid" | "no_payment_required";
   requestId: string;
   identity: { ownerId: string; machineId: string; runtimeSlot: string };
   packageId: AiCreditPackageId;
@@ -109,31 +131,56 @@ export function isAiCreditCheckoutObject(value: unknown): boolean {
     && (metadata as { matrix_checkout_kind?: unknown }).matrix_checkout_kind === AI_CREDIT_CHECKOUT_KIND);
 }
 
-export function parseAiCreditCheckoutCompletion(
+export function readAiCreditCheckoutRequestId(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  const parsed = AiCreditCheckoutMetadataSchema.safeParse((value as { metadata?: unknown }).metadata);
+  return parsed.success ? parsed.data.matrix_ai_credit_request_id : null;
+}
+
+export function assertAiCreditCheckoutMetadata(
   value: unknown,
-  config: AiCreditCheckoutConfig,
-): AiCreditCheckoutCompletion {
-  if (!config.enabled) throw new Error("Funded AI add-on checkout is unavailable");
-  const session = AiCreditCompletedSessionSchema.parse(value);
-  const packageConfig = findAiCreditPackage(config, session.metadata.matrix_ai_credit_package_id);
+  claim: AiCreditCheckoutClaimExpectation,
+) {
+  if (!value || typeof value !== "object") throw new Error("Funded AI checkout metadata is missing");
+  const metadata = AiCreditCheckoutMetadataSchema.parse((value as { metadata?: unknown }).metadata);
+  if (metadata.matrix_owner_id !== claim.ownerId || metadata.matrix_machine_id !== claim.machineId
+    || metadata.matrix_runtime_slot !== claim.runtimeSlot
+    || metadata.matrix_ai_credit_request_id !== claim.requestId
+    || metadata.matrix_ai_credit_package_id !== claim.packageId
+    || metadata.matrix_ai_credit_price_id !== claim.priceId
+    || Number(metadata.matrix_ai_credit_microusd) !== claim.amountMicrousd) {
+    throw new Error("Funded AI add-on checkout verification failed");
+  }
+  return metadata;
+}
+
+export function parseAiCreditCheckoutSession(
+  value: unknown,
+  claim: AiCreditCheckoutClaimExpectation,
+): AiCreditCheckoutSession {
+  const session = AiCreditSessionSchema.parse(value);
+  assertAiCreditCheckoutMetadata(value, claim);
   const amountMicrousd = Number(session.metadata.matrix_ai_credit_microusd);
-  if (!packageConfig
-    || session.client_reference_id !== session.metadata.matrix_owner_id
-    || session.amount_total !== packageConfig.amountCents
-    || session.currency !== packageConfig.currency
-    || session.metadata.matrix_ai_credit_price_id !== packageConfig.priceId
-    || amountMicrousd !== packageConfig.amountMicrousd) {
+  if (session.client_reference_id !== claim.ownerId
+    || amountMicrousd !== claim.amountMicrousd || session.amount_subtotal !== claim.amountCents
+    || session.amount_total < session.amount_subtotal
+    || session.currency !== claim.currency) {
     throw new Error("Funded AI add-on checkout verification failed");
   }
   return {
     sessionId: session.id,
+    paymentIntentId: typeof session.payment_intent === "string"
+      ? session.payment_intent
+      : session.payment_intent?.id ?? null,
+    status: session.status,
+    paymentStatus: session.payment_status,
     requestId: session.metadata.matrix_ai_credit_request_id,
     identity: {
       ownerId: session.metadata.matrix_owner_id,
       machineId: session.metadata.matrix_machine_id,
       runtimeSlot: session.metadata.matrix_runtime_slot,
     },
-    packageId: packageConfig.id,
-    amountMicrousd: packageConfig.amountMicrousd,
+    packageId: claim.packageId,
+    amountMicrousd: claim.amountMicrousd,
   };
 }

--- a/packages/platform/src/ai-credit-checkout.ts
+++ b/packages/platform/src/ai-credit-checkout.ts
@@ -1,0 +1,139 @@
+import { z } from "zod/v4";
+import { RuntimeSlotSchema } from "./customer-vps-schema.js";
+
+const StripePriceIdSchema = z.string().min(8).max(255).regex(/^price_[A-Za-z0-9_]+$/);
+export const AiCreditPackageIdSchema = z.enum(["usd_5", "usd_10", "usd_25"]);
+export type AiCreditPackageId = z.infer<typeof AiCreditPackageIdSchema>;
+
+export const AiCreditCheckoutRequestSchema = z.object({
+  packageId: AiCreditPackageIdSchema,
+  runtimeSlot: RuntimeSlotSchema.optional().default("primary"),
+  requestId: z.uuid(),
+}).strict();
+
+export interface AiCreditPackage {
+  id: AiCreditPackageId;
+  amountUsd: 5 | 10 | 25;
+  amountMicrousd: number;
+  amountCents: number;
+  currency: "usd";
+  priceId: string;
+}
+
+export type AiCreditCheckoutConfig = { enabled: false } | {
+  enabled: true;
+  automaticTax: boolean;
+  packages: readonly AiCreditPackage[];
+};
+
+const PACKAGE_DEFINITIONS = [
+  { id: "usd_5", amountUsd: 5, envKey: "STRIPE_PRICE_AI_CREDIT_USD_5" },
+  { id: "usd_10", amountUsd: 10, envKey: "STRIPE_PRICE_AI_CREDIT_USD_10" },
+  { id: "usd_25", amountUsd: 25, envKey: "STRIPE_PRICE_AI_CREDIT_USD_25" },
+] as const;
+
+export const AI_CREDIT_CHECKOUT_KIND = "ai_credit_addon";
+
+export function loadAiCreditCheckoutConfig(env: NodeJS.ProcessEnv): AiCreditCheckoutConfig {
+  if (env.MATRIX_FUNDED_AI_ADDON_CHECKOUT_ENABLED !== "true") return { enabled: false };
+  if (!env.STRIPE_SECRET_KEY || !env.STRIPE_WEBHOOK_SECRET) return { enabled: false };
+  const configured = PACKAGE_DEFINITIONS.map((definition) => {
+    const parsed = StripePriceIdSchema.safeParse(env[definition.envKey]);
+    if (!parsed.success) return null;
+    return {
+      id: definition.id,
+      amountUsd: definition.amountUsd,
+      amountMicrousd: definition.amountUsd * 1_000_000,
+      amountCents: definition.amountUsd * 100,
+      currency: "usd" as const,
+      priceId: parsed.data,
+    };
+  });
+  // A partially configured catalog creates ambiguous product behavior. Fail
+  // closed instead of silently exposing a subset that differs across shells.
+  if (configured.some((entry) => entry === null)) return { enabled: false };
+  const packages = configured as AiCreditPackage[];
+  if (new Set(packages.map((entry) => entry.priceId)).size !== packages.length) {
+    throw new Error("Funded AI add-on checkout is misconfigured");
+  }
+  return {
+    enabled: true,
+    // Enabling Stripe Tax without active registrations silently collects
+    // nothing. Operations must explicitly attest that registrations are live.
+    automaticTax: env.MATRIX_AI_CREDIT_STRIPE_TAX_REGISTRATIONS_VERIFIED === "true",
+    packages,
+  };
+}
+
+export function findAiCreditPackage(
+  config: AiCreditCheckoutConfig,
+  packageId: AiCreditPackageId,
+): AiCreditPackage | undefined {
+  return config.enabled ? config.packages.find((entry) => entry.id === packageId) : undefined;
+}
+
+const AiCreditCheckoutMetadataSchema = z.object({
+  matrix_checkout_kind: z.literal(AI_CREDIT_CHECKOUT_KIND),
+  matrix_owner_id: z.string().min(1).max(160).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/),
+  matrix_machine_id: z.string().min(1).max(160).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/),
+  matrix_runtime_slot: RuntimeSlotSchema,
+  matrix_ai_credit_package_id: AiCreditPackageIdSchema,
+  matrix_ai_credit_request_id: z.uuid(),
+  matrix_ai_credit_price_id: StripePriceIdSchema,
+  matrix_ai_credit_microusd: z.string().regex(/^[1-9][0-9]{0,15}$/),
+}).passthrough();
+
+const AiCreditCompletedSessionSchema = z.object({
+  id: z.string().min(3).max(255).regex(/^cs_[A-Za-z0-9_]+$/),
+  mode: z.literal("payment"),
+  status: z.literal("complete"),
+  payment_status: z.literal("paid"),
+  amount_total: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+  currency: z.literal("usd"),
+  client_reference_id: z.string().min(1).max(160),
+  metadata: AiCreditCheckoutMetadataSchema,
+}).passthrough();
+
+export interface AiCreditCheckoutCompletion {
+  sessionId: string;
+  requestId: string;
+  identity: { ownerId: string; machineId: string; runtimeSlot: string };
+  packageId: AiCreditPackageId;
+  amountMicrousd: number;
+}
+
+export function isAiCreditCheckoutObject(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const metadata = (value as { metadata?: unknown }).metadata;
+  return Boolean(metadata && typeof metadata === "object"
+    && (metadata as { matrix_checkout_kind?: unknown }).matrix_checkout_kind === AI_CREDIT_CHECKOUT_KIND);
+}
+
+export function parseAiCreditCheckoutCompletion(
+  value: unknown,
+  config: AiCreditCheckoutConfig,
+): AiCreditCheckoutCompletion {
+  if (!config.enabled) throw new Error("Funded AI add-on checkout is unavailable");
+  const session = AiCreditCompletedSessionSchema.parse(value);
+  const packageConfig = findAiCreditPackage(config, session.metadata.matrix_ai_credit_package_id);
+  const amountMicrousd = Number(session.metadata.matrix_ai_credit_microusd);
+  if (!packageConfig
+    || session.client_reference_id !== session.metadata.matrix_owner_id
+    || session.amount_total !== packageConfig.amountCents
+    || session.currency !== packageConfig.currency
+    || session.metadata.matrix_ai_credit_price_id !== packageConfig.priceId
+    || amountMicrousd !== packageConfig.amountMicrousd) {
+    throw new Error("Funded AI add-on checkout verification failed");
+  }
+  return {
+    sessionId: session.id,
+    requestId: session.metadata.matrix_ai_credit_request_id,
+    identity: {
+      ownerId: session.metadata.matrix_owner_id,
+      machineId: session.metadata.matrix_machine_id,
+      runtimeSlot: session.metadata.matrix_runtime_slot,
+    },
+    packageId: packageConfig.id,
+    amountMicrousd: packageConfig.amountMicrousd,
+  };
+}

--- a/packages/platform/src/ai-funded-metering-repository.ts
+++ b/packages/platform/src/ai-funded-metering-repository.ts
@@ -400,6 +400,7 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
     const row = await options.db.executor.selectFrom("ai_runtime_credentials as credential")
       .innerJoin("ai_funded_runtime_policies as runtime", "runtime.machine_id", "credential.machine_id")
       .innerJoin("user_machines as machine", "machine.machine_id", "credential.machine_id")
+      .leftJoin("ai_funded_credit_restrictions as restriction", "restriction.machine_id", "credential.machine_id")
       .innerJoin("ai_funded_global_policy as global_policy", (join) => (
         join.on("global_policy.policy_id", "=", "default")
       ))
@@ -413,6 +414,7 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
         "machine.clerk_user_id", "machine.runtime_slot as machine_runtime_slot", "machine.status",
         "machine.activation_state", "machine.deleted_at", "global_policy.enabled as global_enabled",
         "global_policy.revision as global_revision", "global_policy.allowed_model_ids as global_models",
+        "restriction.debt_microusd as funding_debt_microusd", "restriction.frozen as funding_frozen",
       ])
       .where("credential.token_id", "=", tokenMatch[1])
       .where("global_policy.policy_id", "=", "default")
@@ -426,6 +428,7 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
       throw new AiFundedPolicyError("unauthorized");
     }
     if (!row.global_enabled || !row.runtime_enabled
+      || row.funding_frozen === true || exactInteger(row.funding_debt_microusd ?? 0) > 0
       || (row.runtime_expires_at !== null && Date.parse(row.runtime_expires_at) <= checked.getTime())) {
       throw new AiFundedPolicyError("access_disabled");
     }
@@ -482,13 +485,17 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
       ]).where("machine_id", "=", credential.machine_id).executeTakeFirst();
       const global = await trx.executor.selectFrom("ai_funded_global_policy")
         .selectAll().where("policy_id", "=", "default").executeTakeFirstOrThrow();
+      const restriction = await trx.executor.selectFrom("ai_funded_credit_restrictions")
+        .select(["debt_microusd", "frozen"]).where("machine_id", "=", credential.machine_id)
+        .forUpdate().executeTakeFirst();
       if (!runtime || !machine || machine.clerk_user_id !== credential.owner_id
         || machine.runtime_slot !== credential.runtime_slot || machine.status !== "running"
         || machine.activation_state !== "authorized" || machine.deleted_at !== null
         || runtime.owner_id !== credential.owner_id || runtime.runtime_slot !== credential.runtime_slot) {
         throw new AiFundedPolicyError("unauthorized");
       }
-      if (!global.enabled || !runtime.enabled
+      if (!global.enabled || !runtime.enabled || restriction?.frozen === true
+        || exactInteger(restriction?.debt_microusd ?? 0) > 0
         || (runtime.expires_at !== null && Date.parse(runtime.expires_at) <= checked.getTime())) {
         throw new AiFundedPolicyError("access_disabled");
       }

--- a/packages/platform/src/ai-funded-metering-repository.ts
+++ b/packages/platform/src/ai-funded-metering-repository.ts
@@ -300,84 +300,92 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
     return (await getRuntimeFundingSummary(identityInput)).funding;
   }
 
-  async function grantCredit(input: z.input<typeof GrantSchema>) {
+  async function grantCreditInTransaction(
+    transaction: PlatformDB,
+    input: z.input<typeof GrantSchema>,
+    createdAt = options.now().toISOString(),
+  ) {
     const grant = GrantSchema.parse(input);
-    const at = options.now().toISOString();
+    const at = IsoTimestampSchema.parse(createdAt);
     if (grant.expiresAt !== null && grant.expiresAt <= at) {
       throw new AiFundedPolicyError("access_disabled");
     }
-    await options.db.ready;
-    return options.db.transaction(async (trx) => {
-      const machine = await trx.executor.selectFrom("user_machines").select([
+    await transaction.ready;
+    const machine = await transaction.executor.selectFrom("user_machines").select([
         "machine_id", "clerk_user_id", "runtime_slot", "deleted_at",
       ]).where("machine_id", "=", grant.identity.machineId).forUpdate().executeTakeFirst();
-      if (!machine || machine.clerk_user_id !== grant.identity.ownerId
-        || machine.runtime_slot !== grant.identity.runtimeSlot || machine.deleted_at !== null) {
-        throw new AiFundedPolicyError("identity_mismatch");
-      }
-      const inserted = await trx.executor.insertInto("ai_funded_credit_ledger").values({
-        entry_id: grant.entryId,
-        owner_id: grant.identity.ownerId,
-        machine_id: grant.identity.machineId,
-        runtime_slot: grant.identity.runtimeSlot,
-        kind: grant.kind,
-        amount_microusd: grant.amountMicrousd,
-        source_reference: grant.sourceReference,
-        reservation_id: null,
-        period_start: null,
-        expires_at: grant.expiresAt,
-        created_at: at,
-      }).onConflict((conflict) => conflict.column("entry_id").doNothing())
-        .returning("entry_id").executeTakeFirst();
-      const stored = await trx.executor.selectFrom("ai_funded_credit_ledger")
-        .selectAll().where("entry_id", "=", grant.entryId).executeTakeFirstOrThrow();
-      if (stored.owner_id !== grant.identity.ownerId || stored.machine_id !== grant.identity.machineId
-        || stored.runtime_slot !== grant.identity.runtimeSlot || stored.kind !== grant.kind
-        || exactInteger(stored.amount_microusd) !== grant.amountMicrousd
-        || stored.source_reference !== grant.sourceReference || stored.reservation_id !== null
-        || stored.expires_at !== grant.expiresAt) {
-        throw new AiFundedPolicyError("idempotency_conflict");
-      }
-      if (inserted) {
-        if (grant.kind === "promotional_grant") {
-          await reconcileExpiredPromotionalCredit(trx.executor, grant.identity, at);
-          const activeGrantCount = await trx.executor.selectFrom("ai_funded_promotional_grant_balances")
-            .select(({ fn }) => fn.countAll<number>().as("count"))
-            .where("owner_id", "=", grant.identity.ownerId)
-            .where("machine_id", "=", grant.identity.machineId)
-            .where("runtime_slot", "=", grant.identity.runtimeSlot)
-            .where("remaining_microusd", ">", 0).executeTakeFirstOrThrow();
-          if (exactInteger(activeGrantCount.count) >= MAX_PROMOTIONAL_GRANTS_PER_RUNTIME) {
-            throw new AiFundedPolicyError("rate_limited");
-          }
-          await trx.executor.insertInto("ai_funded_promotional_grant_balances").values({
-            grant_entry_id: grant.entryId,
-            owner_id: grant.identity.ownerId,
-            machine_id: grant.identity.machineId,
-            runtime_slot: grant.identity.runtimeSlot,
-            remaining_microusd: grant.amountMicrousd,
-            expires_at: grant.expiresAt,
-            created_at: at,
-            updated_at: at,
-            revision: 0,
-          }).execute();
-        }
-        const bucketUpdate = grant.kind === "promotional_grant"
-          ? { promotional_balance_microusd: sql<number>`promotional_balance_microusd + ${grant.amountMicrousd}` }
-          : { addon_balance_microusd: sql<number>`addon_balance_microusd + ${grant.amountMicrousd}` };
-        const balance = await trx.executor.updateTable("ai_funded_runtime_balances").set({
-          credit_balance_microusd: sql<number>`credit_balance_microusd + ${grant.amountMicrousd}`,
-          ...bucketUpdate,
-          updated_at: at,
-        }).where("machine_id", "=", grant.identity.machineId)
+    if (!machine || machine.clerk_user_id !== grant.identity.ownerId
+      || machine.runtime_slot !== grant.identity.runtimeSlot || machine.deleted_at !== null) {
+      throw new AiFundedPolicyError("identity_mismatch");
+    }
+    const inserted = await transaction.executor.insertInto("ai_funded_credit_ledger").values({
+      entry_id: grant.entryId,
+      owner_id: grant.identity.ownerId,
+      machine_id: grant.identity.machineId,
+      runtime_slot: grant.identity.runtimeSlot,
+      kind: grant.kind,
+      amount_microusd: grant.amountMicrousd,
+      source_reference: grant.sourceReference,
+      reservation_id: null,
+      period_start: null,
+      expires_at: grant.expiresAt,
+      created_at: at,
+    }).onConflict((conflict) => conflict.column("entry_id").doNothing())
+      .returning("entry_id").executeTakeFirst();
+    const stored = await transaction.executor.selectFrom("ai_funded_credit_ledger")
+      .selectAll().where("entry_id", "=", grant.entryId).executeTakeFirstOrThrow();
+    if (stored.owner_id !== grant.identity.ownerId || stored.machine_id !== grant.identity.machineId
+      || stored.runtime_slot !== grant.identity.runtimeSlot || stored.kind !== grant.kind
+      || exactInteger(stored.amount_microusd) !== grant.amountMicrousd
+      || stored.source_reference !== grant.sourceReference || stored.reservation_id !== null
+      || stored.expires_at !== grant.expiresAt) {
+      throw new AiFundedPolicyError("idempotency_conflict");
+    }
+    if (inserted) {
+      if (grant.kind === "promotional_grant") {
+        await reconcileExpiredPromotionalCredit(transaction.executor, grant.identity, at);
+        const activeGrantCount = await transaction.executor.selectFrom("ai_funded_promotional_grant_balances")
+          .select(({ fn }) => fn.countAll<number>().as("count"))
           .where("owner_id", "=", grant.identity.ownerId)
+          .where("machine_id", "=", grant.identity.machineId)
           .where("runtime_slot", "=", grant.identity.runtimeSlot)
-          .where(sql<boolean>`credit_balance_microusd <= ${Number.MAX_SAFE_INTEGER - grant.amountMicrousd}`)
-          .returning("machine_id").executeTakeFirst();
-        if (!balance) throw new Error("Funded AI credit balance exceeds supported bounds");
+          .where("remaining_microusd", ">", 0).executeTakeFirstOrThrow();
+        if (exactInteger(activeGrantCount.count) >= MAX_PROMOTIONAL_GRANTS_PER_RUNTIME) {
+          throw new AiFundedPolicyError("rate_limited");
+        }
+        await transaction.executor.insertInto("ai_funded_promotional_grant_balances").values({
+          grant_entry_id: grant.entryId,
+          owner_id: grant.identity.ownerId,
+          machine_id: grant.identity.machineId,
+          runtime_slot: grant.identity.runtimeSlot,
+          remaining_microusd: grant.amountMicrousd,
+          expires_at: grant.expiresAt,
+          created_at: at,
+          updated_at: at,
+          revision: 0,
+        }).execute();
       }
-      return { ...grant, createdAt: stored.created_at };
-    });
+      const bucketUpdate = grant.kind === "promotional_grant"
+        ? { promotional_balance_microusd: sql<number>`promotional_balance_microusd + ${grant.amountMicrousd}` }
+        : { addon_balance_microusd: sql<number>`addon_balance_microusd + ${grant.amountMicrousd}` };
+      const balance = await transaction.executor.updateTable("ai_funded_runtime_balances").set({
+        credit_balance_microusd: sql<number>`credit_balance_microusd + ${grant.amountMicrousd}`,
+        ...bucketUpdate,
+        updated_at: at,
+      }).where("machine_id", "=", grant.identity.machineId)
+        .where("owner_id", "=", grant.identity.ownerId)
+        .where("runtime_slot", "=", grant.identity.runtimeSlot)
+        .where(sql<boolean>`credit_balance_microusd <= ${Number.MAX_SAFE_INTEGER - grant.amountMicrousd}`)
+        .returning("machine_id").executeTakeFirst();
+      if (!balance) throw new Error("Funded AI credit balance exceeds supported bounds");
+    }
+    return { ...grant, createdAt: stored.created_at };
+  }
+
+  async function grantCredit(input: z.input<typeof GrantSchema>) {
+    await options.db.ready;
+    const createdAt = options.now().toISOString();
+    return options.db.transaction((trx) => grantCreditInTransaction(trx, input, createdAt));
   }
 
   async function checkPolicy(
@@ -1088,5 +1096,6 @@ export function createAiFundedMeteringRepository(options: AiFundedMeteringReposi
     releaseReservation,
     cleanupExpiredReservations,
     grantCredit,
+    grantCreditInTransaction,
   };
 }

--- a/packages/platform/src/ai-funded-policy-routes.ts
+++ b/packages/platform/src/ai-funded-policy-routes.ts
@@ -180,6 +180,7 @@ export function createAiFundedRuntimeRoutes(options: {
   db: PlatformDB;
   platformSecret: string;
   repository: AiFundedPolicyRepository;
+  topUpEnabled?: boolean;
 }) {
   if (!options.repository || !options.db) throw new Error("Funded AI runtime dependencies are missing");
   if (options.platformSecret.length < 32) throw new Error("Funded AI runtime authentication is misconfigured");
@@ -231,7 +232,11 @@ export function createAiFundedRuntimeRoutes(options: {
         machineId: machine.machineId,
         runtimeSlot: machine.runtimeSlot,
       });
-      return c.json(FundedAiRuntimeFundingSummaryResponseSchema.parse({ contractVersion: 1, ...summary }), 200);
+      return c.json(FundedAiRuntimeFundingSummaryResponseSchema.parse({
+        contractVersion: 1,
+        funding: { ...summary.funding, topUpEnabled: options.topUpEnabled === true },
+        policy: summary.policy,
+      }), 200);
     } catch (error) {
       return policyErrorResponse(c, error);
     }

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -54,10 +54,15 @@ import { HetznerServerTypeSchema, RuntimeSlotSchema } from './customer-vps-schem
 import {
   AiCreditCheckoutRequestSchema,
   findAiCreditPackage,
-  isAiCreditCheckoutObject,
   loadAiCreditCheckoutConfig,
-  parseAiCreditCheckoutCompletion,
 } from './ai-credit-checkout.js';
+import {
+  AiCreditCheckoutStoreError,
+  finalizeAiCreditCheckoutClaim,
+  getClaimByRequestId,
+  prepareAiCreditCheckoutClaim,
+} from './ai-credit-checkout-store.js';
+import { processAiCreditWebhookEvent } from './ai-credit-checkout-webhook.js';
 
 const BILLING_BODY_LIMIT = 16 * 1024;
 const STRIPE_WEBHOOK_BODY_LIMIT = 1024 * 1024;
@@ -72,6 +77,7 @@ const BILLING_UNAVAILABLE_RESPONSE = {
   error: 'Billing unavailable',
   code: 'billing_unavailable',
 } as const;
+
 const BILLING_CHECKOUT_STARTED_EVENT =
   MATRIX_TELEMETRY_EVENTS.BILLING_CHECKOUT_STARTED ?? 'matrix_billing_checkout_started';
 const BILLING_CHECKOUT_CREATED_EVENT =
@@ -616,7 +622,7 @@ export function createBillingRoutes(options: {
   app.post('/ai-credit/checkout', bodyLimit({ maxSize: BILLING_BODY_LIMIT }), async (c) => {
     const clerkUserId = await resolveRouteClerkUserId(c, 'ai-credit checkout');
     if (!clerkUserId) return c.json({ error: 'Unauthorized' }, 401);
-    if (!aiCreditCheckout.enabled || !options.fundedAiRepository) {
+    if (!options.fundedAiRepository) {
       return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
     }
     let body: unknown;
@@ -628,8 +634,6 @@ export function createBillingRoutes(options: {
     }
     const parsed = AiCreditCheckoutRequestSchema.safeParse(body);
     if (!parsed.success) return c.json({ error: 'Invalid request' }, 400);
-    const selectedPackage = findAiCreditPackage(aiCreditCheckout, parsed.data.packageId);
-    if (!selectedPackage) return c.json({ error: 'Invalid request' }, 400);
     try {
       if (options.stripe.apiTimeoutMs > MAX_STRIPE_API_TIMEOUT_MS) {
         throw new Error('stripe_timeout_exceeds_budget');
@@ -641,21 +645,44 @@ export function createBillingRoutes(options: {
       const idempotencyKey = `matrix-ai-credit:${createHash('sha256')
         .update(`${clerkUserId}\0${machine.machineId}\0${parsed.data.requestId}`)
         .digest('hex')}`;
+      const persisted = await getClaimByRequestId(options.db, parsed.data.requestId);
+      if (persisted && (persisted.owner_id !== clerkUserId || persisted.machine_id !== machine.machineId
+        || persisted.runtime_slot !== machine.runtimeSlot || persisted.package_id !== parsed.data.packageId
+        || persisted.idempotency_key !== idempotencyKey)) {
+        throw new AiCreditCheckoutStoreError('conflict');
+      }
+      const selectedPackage = findAiCreditPackage(aiCreditCheckout, parsed.data.packageId);
+      if (!persisted && !selectedPackage) return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
+      const claim = persisted ?? await prepareAiCreditCheckoutClaim(options.db, {
+        idempotencyKey, requestId: parsed.data.requestId, ownerId: clerkUserId,
+        machineId: machine.machineId, runtimeSlot: machine.runtimeSlot,
+        packageId: selectedPackage!.id, priceId: selectedPackage!.priceId,
+        amountMicrousd: selectedPackage!.amountMicrousd, amountCents: selectedPackage!.amountCents,
+        currency: selectedPackage!.currency, automaticTax: aiCreditCheckout.enabled && aiCreditCheckout.automaticTax,
+      }, now());
+      if (claim.checkout_url) return c.json({ url: claim.checkout_url }, 200);
       const session = await options.stripe.createAiCreditCheckoutSession({
-        idempotencyKey,
-        requestId: parsed.data.requestId,
-        clerkUserId,
-        machineId: machine.machineId,
-        runtimeSlot: machine.runtimeSlot,
-        packageId: selectedPackage.id,
-        priceId: selectedPackage.priceId,
-        amountMicrousd: selectedPackage.amountMicrousd,
-        automaticTax: aiCreditCheckout.automaticTax,
+        idempotencyKey: claim.idempotency_key,
+        requestId: claim.request_id,
+        clerkUserId: claim.owner_id,
+        machineId: claim.machine_id,
+        runtimeSlot: claim.runtime_slot,
+        packageId: claim.package_id,
+        priceId: claim.stripe_price_id,
+        amountMicrousd: Number(claim.amount_microusd),
+        automaticTax: claim.automatic_tax,
         successUrl: resolveBillingReturnUrl(env, 'success'),
         cancelUrl: resolveBillingReturnUrl(env, 'canceled'),
       });
-      return c.json({ url: session.url }, 200);
+      const finalized = await finalizeAiCreditCheckoutClaim(
+        options.db, claim.request_id, session, now().toISOString(),
+      );
+      return c.json({ url: finalized.checkout_url }, 200);
     } catch (err: unknown) {
+      if (err instanceof AiCreditCheckoutStoreError) {
+        if (err.code === 'rate_limited') return c.json({ error: 'Too many requests' }, 429);
+        if (err.code === 'conflict') return c.json({ error: 'Checkout already active' }, 409);
+      }
       console.error('[billing] AI credit checkout failed:', err instanceof Error ? err.name : typeof err);
       return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
     }
@@ -807,19 +834,10 @@ export function createBillingRoutes(options: {
           return { received: true, duplicate: true };
         }
 
-        if (event.type === 'checkout.session.completed' && isAiCreditCheckoutObject(event.data.object)) {
-          if (!options.fundedAiRepository) throw new Error('Funded AI credit ledger is unavailable');
-          const completion = parseAiCreditCheckoutCompletion(event.data.object, aiCreditCheckout);
-          await options.fundedAiRepository.grantCreditInTransaction(trx, {
-            entryId: `addon:${completion.sessionId}`,
-            identity: completion.identity,
-            kind: 'addon_grant',
-            amountMicrousd: completion.amountMicrousd,
-            sourceReference: completion.sessionId,
-            expiresAt: null,
-          }, webhookProcessedAt.toISOString());
-          return { received: true, processed: true };
-        }
+        const aiCreditResult = await processAiCreditWebhookEvent({
+          event, trx, repository: options.fundedAiRepository, at: webhookProcessedAt.toISOString(),
+        });
+        if (aiCreditResult) return aiCreditResult;
 
         // Checkout session lifecycle drives the settling-attempt status: a
         // confirmed payment marks the attempt `paid` (sticky), an expiry marks

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -1,6 +1,6 @@
 import { Hono, type Context } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { MATRIX_TELEMETRY_EVENTS } from '@matrix-os/observability';
 import { z } from 'zod/v4';
 import { appOrigin, resolveReturnPath } from './origins.js';
@@ -51,6 +51,13 @@ import {
 } from './billing.js';
 import { DeveloperToolsWithDefaultSchema, type DeveloperToolId } from './developer-tools.js';
 import { HetznerServerTypeSchema, RuntimeSlotSchema } from './customer-vps-schema.js';
+import {
+  AiCreditCheckoutRequestSchema,
+  findAiCreditPackage,
+  isAiCreditCheckoutObject,
+  loadAiCreditCheckoutConfig,
+  parseAiCreditCheckoutCompletion,
+} from './ai-credit-checkout.js';
 
 const BILLING_BODY_LIMIT = 16 * 1024;
 const STRIPE_WEBHOOK_BODY_LIMIT = 1024 * 1024;
@@ -153,6 +160,20 @@ export interface StripeCheckoutSessionProjection {
   regionSlug: string | null;
 }
 
+export interface StripeAiCreditCheckoutSessionInput {
+  idempotencyKey: string;
+  requestId: string;
+  clerkUserId: string;
+  machineId: string;
+  runtimeSlot: string;
+  packageId: string;
+  priceId: string;
+  amountMicrousd: number;
+  automaticTax: boolean;
+  successUrl: string;
+  cancelUrl: string;
+}
+
 export interface StripeBillingClient {
   apiTimeoutMs: number;
   /**
@@ -164,6 +185,10 @@ export interface StripeBillingClient {
     url: string;
     id: string;
     expiresAt?: string;
+  }>;
+  createAiCreditCheckoutSession(input: StripeAiCreditCheckoutSessionInput): Promise<{
+    url: string;
+    id: string;
   }>;
   retrieveCheckoutSession(id: string): Promise<StripeCheckoutSessionProjection>;
   createPortalSession(input: {
@@ -228,6 +253,7 @@ export function createBillingRoutes(options: {
   now?: () => Date;
   upsertEntitlement?: typeof upsertBillingEntitlement;
   prebilling?: PrebillingCheckoutCoordinator;
+  fundedAiRepository?: Pick<import('./ai-funded-policy-repository.js').AiFundedPolicyRepository, 'grantCreditInTransaction'>;
   /**
    * Optional product telemetry sink. Fire-and-forget: implementations must
    * never throw into the request path, and callers only pass low-cardinality,
@@ -245,6 +271,7 @@ export function createBillingRoutes(options: {
     && env.MATRIX_BILLING_PROVIDER === 'stripe';
   const now = options.now ?? (() => new Date());
   const persistEntitlement = options.upsertEntitlement ?? upsertBillingEntitlement;
+  const aiCreditCheckout = loadAiCreditCheckoutConfig(env);
 
   function emitTelemetry(
     event: string,
@@ -586,6 +613,54 @@ export function createBillingRoutes(options: {
     }
   });
 
+  app.post('/ai-credit/checkout', bodyLimit({ maxSize: BILLING_BODY_LIMIT }), async (c) => {
+    const clerkUserId = await resolveRouteClerkUserId(c, 'ai-credit checkout');
+    if (!clerkUserId) return c.json({ error: 'Unauthorized' }, 401);
+    if (!aiCreditCheckout.enabled || !options.fundedAiRepository) {
+      return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
+    }
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch (err: unknown) {
+      if (err instanceof SyntaxError) return c.json({ error: 'Invalid request' }, 400);
+      throw err;
+    }
+    const parsed = AiCreditCheckoutRequestSchema.safeParse(body);
+    if (!parsed.success) return c.json({ error: 'Invalid request' }, 400);
+    const selectedPackage = findAiCreditPackage(aiCreditCheckout, parsed.data.packageId);
+    if (!selectedPackage) return c.json({ error: 'Invalid request' }, 400);
+    try {
+      if (options.stripe.apiTimeoutMs > MAX_STRIPE_API_TIMEOUT_MS) {
+        throw new Error('stripe_timeout_exceeds_budget');
+      }
+      const machine = await getActiveUserMachineByClerkId(options.db, clerkUserId, parsed.data.runtimeSlot);
+      if (!machine || machine.status !== 'running' || machine.activationState !== 'authorized') {
+        return c.json({ error: 'Computer is unavailable', code: 'runtime_unavailable' }, 409);
+      }
+      const idempotencyKey = `matrix-ai-credit:${createHash('sha256')
+        .update(`${clerkUserId}\0${machine.machineId}\0${parsed.data.requestId}`)
+        .digest('hex')}`;
+      const session = await options.stripe.createAiCreditCheckoutSession({
+        idempotencyKey,
+        requestId: parsed.data.requestId,
+        clerkUserId,
+        machineId: machine.machineId,
+        runtimeSlot: machine.runtimeSlot,
+        packageId: selectedPackage.id,
+        priceId: selectedPackage.priceId,
+        amountMicrousd: selectedPackage.amountMicrousd,
+        automaticTax: aiCreditCheckout.automaticTax,
+        successUrl: resolveBillingReturnUrl(env, 'success'),
+        cancelUrl: resolveBillingReturnUrl(env, 'canceled'),
+      });
+      return c.json({ url: session.url }, 200);
+    } catch (err: unknown) {
+      console.error('[billing] AI credit checkout failed:', err instanceof Error ? err.name : typeof err);
+      return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
+    }
+  });
+
   app.get('/checkout/status', async (c) => {
     const clerkUserId = await resolveRouteClerkUserId(c, 'checkout status');
     if (!clerkUserId) return c.json({ error: 'Unauthorized' }, 401);
@@ -730,6 +805,20 @@ export function createBillingRoutes(options: {
         });
         if (!inserted.inserted) {
           return { received: true, duplicate: true };
+        }
+
+        if (event.type === 'checkout.session.completed' && isAiCreditCheckoutObject(event.data.object)) {
+          if (!options.fundedAiRepository) throw new Error('Funded AI credit ledger is unavailable');
+          const completion = parseAiCreditCheckoutCompletion(event.data.object, aiCreditCheckout);
+          await options.fundedAiRepository.grantCreditInTransaction(trx, {
+            entryId: `addon:${completion.sessionId}`,
+            identity: completion.identity,
+            kind: 'addon_grant',
+            amountMicrousd: completion.amountMicrousd,
+            sourceReference: completion.sessionId,
+            expiresAt: null,
+          }, webhookProcessedAt.toISOString());
+          return { received: true, processed: true };
         }
 
         // Checkout session lifecycle drives the settling-attempt status: a

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -208,6 +208,42 @@ export interface AiFundedPromotionalGrantBalancesTable {
   revision: number;
 }
 
+export interface AiCreditCheckoutClaimsTable {
+  request_id: string;
+  owner_id: string;
+  machine_id: string;
+  runtime_slot: string;
+  package_id: string;
+  stripe_price_id: string;
+  amount_microusd: number;
+  amount_cents: number;
+  currency: string;
+  automatic_tax: boolean;
+  idempotency_key: string;
+  stripe_session_id: string | null;
+  checkout_url: string | null;
+  payment_intent_id: string | null;
+  charge_id: string | null;
+  status: string;
+  granted_microusd: number;
+  reversed_microusd: number;
+  reversal_debt_microusd: number;
+  refunded_at: string | null;
+  dispute_status: string;
+  created_at: string;
+  updated_at: string;
+  expires_at: string;
+}
+
+export interface AiFundedCreditRestrictionsTable {
+  machine_id: string;
+  owner_id: string;
+  runtime_slot: string;
+  debt_microusd: number;
+  frozen: boolean;
+  updated_at: string;
+}
+
 export interface ProvisioningJobsTable {
   job_id: string;
   machine_id: string;
@@ -695,6 +731,8 @@ export interface PlatformDatabase {
   ai_funded_credit_ledger: AiFundedCreditLedgerTable;
   ai_funded_promotional_grant_balances: AiFundedPromotionalGrantBalancesTable;
   ai_funded_runtime_balances: AiFundedRuntimeBalancesTable;
+  ai_credit_checkout_claims: AiCreditCheckoutClaimsTable;
+  ai_funded_credit_restrictions: AiFundedCreditRestrictionsTable;
   provisioning_jobs: ProvisioningJobsTable;
   billing_checkout_attempts: BillingCheckoutAttemptsTable;
   prebilling_provisioning_intents: PrebillingProvisioningIntentsTable;
@@ -1446,7 +1484,7 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
       machine_id TEXT NOT NULL REFERENCES user_machines(machine_id) ON UPDATE CASCADE ON DELETE CASCADE,
       runtime_slot TEXT NOT NULL,
       kind TEXT NOT NULL CONSTRAINT ai_funded_credit_ledger_kind_v3_check
-        CHECK (kind IN ('promotional_grant', 'addon_grant', 'promotional_debit', 'addon_debit', 'promotional_expiry', 'usage_shortfall')),
+        CHECK (kind IN ('promotional_grant', 'addon_grant', 'promotional_debit', 'addon_debit', 'promotional_expiry', 'addon_reversal', 'usage_shortfall')),
       amount_microusd BIGINT NOT NULL,
       source_reference TEXT NOT NULL,
       reservation_id TEXT REFERENCES ai_funded_usage_reservations(reservation_id) ON UPDATE CASCADE ON DELETE CASCADE,
@@ -1457,7 +1495,7 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
         (kind IN ('promotional_grant', 'addon_grant') AND amount_microusd > 0 AND reservation_id IS NULL AND period_start IS NULL)
         OR (kind IN ('promotional_debit', 'addon_debit') AND amount_microusd < 0 AND reservation_id IS NOT NULL AND period_start IS NOT NULL)
         OR (kind = 'usage_shortfall' AND amount_microusd < 0 AND reservation_id IS NOT NULL AND period_start IS NOT NULL AND expires_at IS NULL)
-        OR (kind = 'promotional_expiry' AND amount_microusd < 0 AND reservation_id IS NULL AND period_start IS NULL AND expires_at IS NULL)
+        OR (kind IN ('promotional_expiry', 'addon_reversal') AND amount_microusd < 0 AND reservation_id IS NULL AND period_start IS NULL AND expires_at IS NULL)
       )
     )
   `.execute(db);
@@ -1472,7 +1510,7 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
       BEGIN
         ALTER TABLE ai_funded_credit_ledger
           ADD CONSTRAINT ai_funded_credit_ledger_kind_v3_check
-          CHECK (kind IN ('promotional_grant', 'addon_grant', 'promotional_debit', 'addon_debit', 'promotional_expiry', 'usage_shortfall'));
+          CHECK (kind IN ('promotional_grant', 'addon_grant', 'promotional_debit', 'addon_debit', 'promotional_expiry', 'addon_reversal', 'usage_shortfall'));
       EXCEPTION WHEN duplicate_object THEN NULL;
       END;
       BEGIN
@@ -1481,7 +1519,7 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
             (kind IN ('promotional_grant', 'addon_grant') AND amount_microusd > 0 AND reservation_id IS NULL AND period_start IS NULL)
             OR (kind IN ('promotional_debit', 'addon_debit') AND amount_microusd < 0 AND reservation_id IS NOT NULL AND period_start IS NOT NULL)
             OR (kind = 'usage_shortfall' AND amount_microusd < 0 AND reservation_id IS NOT NULL AND period_start IS NOT NULL AND expires_at IS NULL)
-            OR (kind = 'promotional_expiry' AND amount_microusd < 0 AND reservation_id IS NULL AND period_start IS NULL AND expires_at IS NULL)
+            OR (kind IN ('promotional_expiry', 'addon_reversal') AND amount_microusd < 0 AND reservation_id IS NULL AND period_start IS NULL AND expires_at IS NULL)
           );
       EXCEPTION WHEN duplicate_object THEN NULL;
       END;
@@ -1493,6 +1531,53 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
     CREATE INDEX IF NOT EXISTS idx_ai_funded_ledger_promotional_expiry
     ON ai_funded_credit_ledger(machine_id, runtime_slot, expires_at)
     WHERE kind = 'promotional_grant' AND expires_at IS NOT NULL
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS ai_credit_checkout_claims (
+      request_id TEXT PRIMARY KEY CHECK (length(request_id) <= 64),
+      owner_id TEXT NOT NULL CHECK (length(owner_id) <= 160),
+      machine_id TEXT NOT NULL REFERENCES user_machines(machine_id) ON UPDATE CASCADE,
+      runtime_slot TEXT NOT NULL CHECK (length(runtime_slot) <= 80),
+      package_id TEXT NOT NULL CHECK (package_id IN ('usd_5', 'usd_10', 'usd_25')),
+      stripe_price_id TEXT NOT NULL CHECK (length(stripe_price_id) <= 255),
+      amount_microusd BIGINT NOT NULL CHECK (amount_microusd > 0),
+      amount_cents INTEGER NOT NULL CHECK (amount_cents > 0),
+      currency TEXT NOT NULL CHECK (currency = 'usd'),
+      automatic_tax BOOLEAN NOT NULL,
+      idempotency_key TEXT NOT NULL UNIQUE CHECK (length(idempotency_key) <= 160),
+      stripe_session_id TEXT UNIQUE,
+      checkout_url TEXT CHECK (checkout_url IS NULL OR length(checkout_url) <= 2048),
+      payment_intent_id TEXT UNIQUE,
+      charge_id TEXT UNIQUE,
+      status TEXT NOT NULL CHECK (status IN ('creating', 'open', 'awaiting_payment', 'paid', 'payment_failed', 'expired')),
+      granted_microusd BIGINT NOT NULL DEFAULT 0 CHECK (granted_microusd >= 0),
+      reversed_microusd BIGINT NOT NULL DEFAULT 0 CHECK (reversed_microusd >= 0),
+      reversal_debt_microusd BIGINT NOT NULL DEFAULT 0 CHECK (reversal_debt_microusd >= 0),
+      refunded_at TEXT,
+      dispute_status TEXT NOT NULL DEFAULT 'none' CHECK (dispute_status IN ('none', 'open', 'won', 'lost')),
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL
+    )
+  `.execute(db);
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_ai_credit_checkout_claims_runtime_created
+    ON ai_credit_checkout_claims(owner_id, runtime_slot, created_at DESC)
+  `.execute(db);
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_credit_checkout_claims_active_runtime
+    ON ai_credit_checkout_claims(owner_id, runtime_slot)
+    WHERE status IN ('creating', 'open', 'awaiting_payment')
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS ai_funded_credit_restrictions (
+      machine_id TEXT PRIMARY KEY REFERENCES user_machines(machine_id) ON UPDATE CASCADE ON DELETE CASCADE,
+      owner_id TEXT NOT NULL,
+      runtime_slot TEXT NOT NULL,
+      debt_microusd BIGINT NOT NULL DEFAULT 0 CHECK (debt_microusd >= 0),
+      frozen BOOLEAN NOT NULL DEFAULT FALSE,
+      updated_at TEXT NOT NULL
+    )
   `.execute(db);
   await sql`
     CREATE TABLE IF NOT EXISTS ai_funded_promotional_grant_balances (

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -325,6 +325,7 @@ export function createApp(deps: {
   internalFundedAiRuntimeRoutes?: Hono<any>;
   internalFundedAiRelayRoutes?: Hono<any>;
   internalFundedAiOperatorRoutes?: Hono<any>;
+  fundedAiRepository?: import('./ai-funded-policy-repository.js').AiFundedPolicyRepository;
   customerVpsService?: CustomerVpsService;
   goldenSnapshotService?: GoldenSnapshotService;
   goldenSnapshotConfig?: GoldenSnapshotRuntimeConfig;
@@ -574,6 +575,7 @@ export function createApp(deps: {
     resolveClerkUserId: resolveBillingClerkUserId,
     captureEvent: captureFunnelEvent,
     prebilling,
+    fundedAiRepository: deps.fundedAiRepository,
   }));
 
   // Onboarding journey (spec 092): one server-owned signup-to-ready state every

--- a/packages/platform/src/platform-startup.ts
+++ b/packages/platform/src/platform-startup.ts
@@ -42,13 +42,14 @@ import { logPlatformRouteError } from './platform-route-utils.js';
 import { CustomerVpsError } from './customer-vps-errors.js';
 import { dispatchBillingRuntimeActions } from './billing-runtime-actions.js';
 import { registerPlatformWebSocketUpgradeHandler } from './platform-websocket-upgrade.js';
-import { createAiFundedPolicyRepository } from './ai-funded-policy-repository.js';
+import { createAiFundedPolicyRepository, type AiFundedPolicyRepository } from './ai-funded-policy-repository.js';
 import {
   createAiFundedOperatorRoutes,
   createAiFundedRelayRoutes,
   createAiFundedRuntimeRoutes,
   loadAiFundedControlPlaneConfig,
 } from './ai-funded-policy-routes.js';
+import { loadAiCreditCheckoutConfig } from './ai-credit-checkout.js';
 import {
   createR2CapabilityGate,
   createStorageGatedHetznerClient,
@@ -166,6 +167,7 @@ type CreatePlatformApp = (deps: {
   internalFundedAiRuntimeRoutes?: Hono<any>;
   internalFundedAiRelayRoutes?: Hono<any>;
   internalFundedAiOperatorRoutes?: Hono<any>;
+  fundedAiRepository?: AiFundedPolicyRepository;
   customerVpsService?: CustomerVpsService;
   goldenSnapshotService?: GoldenSnapshotService;
   goldenSnapshotConfig?: GoldenSnapshotRuntimeConfig;
@@ -263,8 +265,9 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
   let internalFundedAiRuntimeRoutes: Hono | undefined;
   let internalFundedAiRelayRoutes: Hono | undefined;
   let internalFundedAiOperatorRoutes: Hono | undefined;
+  let fundedAiRepository: AiFundedPolicyRepository | undefined;
   if (fundedAiConfig.enabled) {
-    const fundedAiRepository = createAiFundedPolicyRepository({
+    fundedAiRepository = createAiFundedPolicyRepository({
       db,
       credentialHashSecret: fundedAiConfig.credentialHashSecret,
       credentialTtlMs: fundedAiConfig.credentialTtlMs,
@@ -275,6 +278,7 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
       db,
       platformSecret: fundedAiConfig.platformSecret,
       repository: fundedAiRepository,
+      topUpEnabled: loadAiCreditCheckoutConfig(process.env).enabled,
     });
     internalFundedAiRelayRoutes = createAiFundedRelayRoutes({
       relayControlToken: fundedAiConfig.relayControlToken,
@@ -780,6 +784,7 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
     internalFundedAiRuntimeRoutes,
     internalFundedAiRelayRoutes,
     internalFundedAiOperatorRoutes,
+    fundedAiRepository,
     customerVpsService,
     goldenSnapshotService,
     goldenSnapshotConfig,

--- a/packages/platform/src/stripe-billing.ts
+++ b/packages/platform/src/stripe-billing.ts
@@ -1,13 +1,21 @@
 import Stripe from 'stripe';
-import { createHash } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import type {
   StripeBillingClient,
+  StripeAiCreditCheckoutSessionInput,
   StripeCheckoutSessionInput,
   StripeWebhookEvent,
 } from './billing-routes.js';
 
 export const MATRIX_STRIPE_API_VERSION = '2026-07-29.dahlia';
 export const MATRIX_STRIPE_API_TIMEOUT_MS = 10_000;
+
+function checkoutIntegrationIdentifier(prefix: 'matrix-subscription' | 'matrix-ai-credit'): string {
+  const suffix = [...randomBytes(8)]
+    .map((value) => String.fromCharCode(97 + (value % 26)))
+    .join('');
+  return `${prefix}-${suffix}`;
+}
 
 export function createStripeBillingClient(options: {
   secretKey: string;
@@ -35,10 +43,7 @@ export function createStripeBillingClient(options: {
         automatic_tax: { enabled: input.automaticTax },
         ...(input.expiresAt ? { expires_at: Math.floor(Date.parse(input.expiresAt) / 1_000) } : {}),
         ...(input.paymentMethodMode === 'card_required'
-          ? {
-            payment_method_types: ['card'] as const,
-            payment_method_collection: 'always' as const,
-          }
+          ? { payment_method_collection: 'always' as const }
           : {}),
         metadata: {
           clerk_user_id: input.clerkUserId,
@@ -88,6 +93,30 @@ export function createStripeBillingClient(options: {
       };
     },
 
+    async createAiCreditCheckoutSession(input: StripeAiCreditCheckoutSessionInput) {
+      const session = await stripe.checkout.sessions.create({
+        mode: 'payment',
+        integration_identifier: checkoutIntegrationIdentifier('matrix-ai-credit'),
+        client_reference_id: input.clerkUserId,
+        line_items: [{ price: input.priceId, quantity: 1 }],
+        success_url: input.successUrl,
+        cancel_url: input.cancelUrl,
+        automatic_tax: { enabled: input.automaticTax },
+        metadata: {
+          matrix_checkout_kind: 'ai_credit_addon',
+          matrix_owner_id: input.clerkUserId,
+          matrix_machine_id: input.machineId,
+          matrix_runtime_slot: input.runtimeSlot,
+          matrix_ai_credit_package_id: input.packageId,
+          matrix_ai_credit_request_id: input.requestId,
+          matrix_ai_credit_price_id: input.priceId,
+          matrix_ai_credit_microusd: String(input.amountMicrousd),
+        },
+      }, { idempotencyKey: input.idempotencyKey });
+      if (!session.url) throw new Error('Stripe checkout session missing redirect URL');
+      return { url: session.url, id: session.id };
+    },
+
     async retrieveCheckoutSession(id) {
       const session = await stripe.checkout.sessions.retrieve(id, {
         expand: ['line_items.data.price'],
@@ -131,6 +160,7 @@ export function createUnavailableStripeBillingClient(): StripeBillingClient {
   return {
     apiTimeoutMs: MATRIX_STRIPE_API_TIMEOUT_MS,
     createCheckoutSession: unavailable,
+    createAiCreditCheckoutSession: unavailable,
     retrieveCheckoutSession: unavailable,
     createPortalSession: unavailable,
     constructWebhookEvent() {

--- a/packages/platform/src/stripe-billing.ts
+++ b/packages/platform/src/stripe-billing.ts
@@ -1,5 +1,5 @@
 import Stripe from 'stripe';
-import { createHash, randomBytes } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import type {
   StripeBillingClient,
   StripeAiCreditCheckoutSessionInput,
@@ -10,8 +10,14 @@ import type {
 export const MATRIX_STRIPE_API_VERSION = '2026-07-29.dahlia';
 export const MATRIX_STRIPE_API_TIMEOUT_MS = 10_000;
 
-function checkoutIntegrationIdentifier(prefix: 'matrix-subscription' | 'matrix-ai-credit'): string {
-  const suffix = [...randomBytes(8)]
+function checkoutIntegrationIdentifier(
+  prefix: 'matrix-subscription' | 'matrix-ai-credit',
+  idempotencyKey: string,
+): string {
+  // Stripe requires retries with an idempotency key to send byte-for-byte
+  // equivalent parameters. Derive the opaque suffix from that server-owned
+  // key so a process retry does not mutate the Checkout request.
+  const suffix = [...createHash('sha256').update(`${prefix}\0${idempotencyKey}`).digest().subarray(0, 8)]
     .map((value) => String.fromCharCode(97 + (value % 26)))
     .join('');
   return `${prefix}-${suffix}`;
@@ -94,24 +100,26 @@ export function createStripeBillingClient(options: {
     },
 
     async createAiCreditCheckoutSession(input: StripeAiCreditCheckoutSessionInput) {
+      const metadata = {
+        matrix_checkout_kind: 'ai_credit_addon',
+        matrix_owner_id: input.clerkUserId,
+        matrix_machine_id: input.machineId,
+        matrix_runtime_slot: input.runtimeSlot,
+        matrix_ai_credit_package_id: input.packageId,
+        matrix_ai_credit_request_id: input.requestId,
+        matrix_ai_credit_price_id: input.priceId,
+        matrix_ai_credit_microusd: String(input.amountMicrousd),
+      };
       const session = await stripe.checkout.sessions.create({
         mode: 'payment',
-        integration_identifier: checkoutIntegrationIdentifier('matrix-ai-credit'),
+        integration_identifier: checkoutIntegrationIdentifier('matrix-ai-credit', input.idempotencyKey),
         client_reference_id: input.clerkUserId,
         line_items: [{ price: input.priceId, quantity: 1 }],
         success_url: input.successUrl,
         cancel_url: input.cancelUrl,
         automatic_tax: { enabled: input.automaticTax },
-        metadata: {
-          matrix_checkout_kind: 'ai_credit_addon',
-          matrix_owner_id: input.clerkUserId,
-          matrix_machine_id: input.machineId,
-          matrix_runtime_slot: input.runtimeSlot,
-          matrix_ai_credit_package_id: input.packageId,
-          matrix_ai_credit_request_id: input.requestId,
-          matrix_ai_credit_price_id: input.priceId,
-          matrix_ai_credit_microusd: String(input.amountMicrousd),
-        },
+        metadata,
+        payment_intent_data: { metadata },
       }, { idempotencyKey: input.idempotencyKey });
       if (!session.url) throw new Error('Stripe checkout session missing redirect URL');
       return { url: session.url, id: session.id };

--- a/packages/ui/src/agents-providers/GatewayPanel.tsx
+++ b/packages/ui/src/agents-providers/GatewayPanel.tsx
@@ -23,11 +23,20 @@ export function GatewayPanel({
   canSetAllowlist: boolean;
   canAddCredit: boolean;
   onMutate: (intent: ProviderSettingsMutationIntent) => void;
-  onAddCredit: (sourceId: string) => void;
+  onAddCredit: (
+    sourceId: string,
+    packageId: "usd_5" | "usd_10" | "usd_25",
+    requestId: string,
+  ) => Promise<void> | void;
   onRefresh: () => void;
 }) {
   const budget = policy?.monthlyBudgetMicrousd ?? null;
   const [budgetUsd, setBudgetUsd] = useState(budget === null ? "" : String(budget / 1_000_000));
+  const [creditDialogOpen, setCreditDialogOpen] = useState(false);
+  const [creditPackage, setCreditPackage] = useState<"usd_5" | "usd_10" | "usd_25">("usd_5");
+  const [creditBusy, setCreditBusy] = useState(false);
+  const [creditError, setCreditError] = useState(false);
+  const [creditRequestId, setCreditRequestId] = useState("");
   useEffect(() => {
     setBudgetUsd(budget === null ? "" : String(budget / 1_000_000));
   }, [budget]);
@@ -44,6 +53,20 @@ export function GatewayPanel({
     const parsed = Number(trimmed);
     if (!Number.isFinite(parsed) || parsed < 0) return;
     onMutate({ type: "set_gateway_budget", monthlyBudgetMicrousd: Math.round(parsed * 1_000_000) });
+  };
+
+  const submitCredit = async () => {
+    if (creditBusy) return;
+    setCreditBusy(true);
+    setCreditError(false);
+    try {
+      await onAddCredit(source.id, creditPackage, creditRequestId);
+      setCreditDialogOpen(false);
+    } catch {
+      setCreditError(true);
+    } finally {
+      setCreditBusy(false);
+    }
   };
 
   return (
@@ -72,7 +95,11 @@ export function GatewayPanel({
             <button
               type="button"
               className="matrix-ap-button matrix-ap-button-primary"
-              onClick={() => onAddCredit(source.id)}
+              onClick={() => {
+                setCreditError(false);
+                setCreditRequestId(crypto.randomUUID());
+                setCreditDialogOpen(true);
+              }}
               disabled={disabled || !canAddCredit}
               title={canAddCredit ? undefined : "Adding credit is not available yet"}
             >
@@ -143,6 +170,63 @@ export function GatewayPanel({
       ) : (
         <p className="matrix-ap-help">Budget and model controls will appear when Matrix gateway policy is available.</p>
       )}
+
+      {creditDialogOpen ? (
+        <div className="matrix-ap-dialog-backdrop" role="presentation">
+          <section className="matrix-ap-dialog" role="dialog" aria-modal="true" aria-labelledby="matrix-ap-credit-title">
+            <div className="matrix-ap-dialog-head">
+              <div>
+                <span className="matrix-ap-eyebrow">Matrix gateway</span>
+                <h3 id="matrix-ap-credit-title">Add Matrix AI credit</h3>
+                <p className="matrix-ap-dialog-copy">
+                  Credit is added to this computer after Stripe confirms payment. It does not expire.
+                </p>
+              </div>
+            </div>
+            <fieldset className="matrix-ap-credit-packages" disabled={creditBusy}>
+              <legend>Choose an amount</legend>
+              {([5, 10, 25] as const).map((amount) => {
+                const id = `usd_${amount}` as const;
+                return (
+                  <label key={id} data-selected={creditPackage === id ? "true" : undefined}>
+                    <input
+                      type="radio"
+                      name="matrix-ai-credit-package"
+                      value={id}
+                      checked={creditPackage === id}
+                      onChange={() => setCreditPackage(id)}
+                      aria-label={`$${amount} credit`}
+                    />
+                    <strong>${amount}</strong>
+                    <span>AI credit</span>
+                  </label>
+                );
+              })}
+            </fieldset>
+            {creditError ? (
+              <p className="matrix-ap-credit-error" role="alert">Checkout could not be opened. Try again.</p>
+            ) : null}
+            <div className="matrix-ap-dialog-actions">
+              <button
+                type="button"
+                className="matrix-ap-button"
+                disabled={creditBusy}
+                onClick={() => setCreditDialogOpen(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="matrix-ap-button matrix-ap-button-primary"
+                disabled={creditBusy}
+                onClick={() => { void submitCredit(); }}
+              >
+                {creditBusy ? "Opening checkout…" : "Continue to checkout"}
+              </button>
+            </div>
+          </section>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/packages/ui/src/agents-providers/GatewayPanel.tsx
+++ b/packages/ui/src/agents-providers/GatewayPanel.tsx
@@ -62,7 +62,11 @@ export function GatewayPanel({
     try {
       await onAddCredit(source.id, creditPackage, creditRequestId);
       setCreditDialogOpen(false);
-    } catch {
+    } catch (error) {
+      console.warn(
+        "[provider-settings] Credit checkout failed:",
+        error instanceof Error ? error.name : typeof error,
+      );
       setCreditError(true);
     } finally {
       setCreditBusy(false);

--- a/packages/ui/src/agents-providers/agents-providers.css
+++ b/packages/ui/src/agents-providers/agents-providers.css
@@ -263,6 +263,14 @@
 .matrix-ap-dialog-head { margin-bottom: 16px; }
 .matrix-ap-dialog-head h3 { font-size: 19px; letter-spacing: -0.025em; margin: 0; }
 .matrix-ap-dialog-actions { gap: 8px; justify-content: flex-end; margin-top: 18px; }
+.matrix-ap-credit-packages { border: 0; display: grid; gap: 9px; grid-template-columns: repeat(3, minmax(0, 1fr)); margin: 0; padding: 0; }
+.matrix-ap-credit-packages legend { color: var(--matrix-ap-muted); font-size: 11px; font-weight: 620; margin-bottom: 8px; }
+.matrix-ap-credit-packages label { align-items: center; background: var(--matrix-ap-surface); border: 1px solid var(--matrix-ap-border); border-radius: 10px; cursor: pointer; display: grid; gap: 2px; min-height: 72px; padding: 12px; position: relative; }
+.matrix-ap-credit-packages label[data-selected="true"] { border-color: var(--matrix-ap-accent); box-shadow: inset 0 0 0 1px var(--matrix-ap-accent); }
+.matrix-ap-credit-packages input { inset: 9px 9px auto auto; margin: 0; position: absolute; }
+.matrix-ap-credit-packages strong { color: var(--matrix-ap-text); font-size: 18px; }
+.matrix-ap-credit-packages span { color: var(--matrix-ap-muted); font-size: 10px; }
+.matrix-ap-credit-error { color: var(--matrix-ap-danger); font-size: 11px; margin: 12px 0 0; }
 .matrix-ap-driver-grid { display: grid; gap: 7px; grid-template-columns: repeat(2, minmax(0, 1fr)); margin-bottom: 15px; }
 .matrix-ap-driver-grid label { align-items: center; background: var(--matrix-ap-surface); border: 1px solid var(--matrix-ap-border); border-radius: 9px; cursor: pointer; display: flex; gap: 8px; min-height: 46px; padding: 10px; }
 .matrix-ap-driver-grid label[data-selected="true"] { border-color: var(--matrix-ap-accent); box-shadow: inset 0 0 0 1px var(--matrix-ap-accent); }
@@ -293,6 +301,7 @@
   .matrix-ap-account { grid-template-columns: 1fr; }
   .matrix-ap-account-actions,
   .matrix-ap-account-usage { grid-column: 1; grid-row: auto; }
+  .matrix-ap-credit-packages { grid-template-columns: 1fr; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/packages/ui/src/agents-providers/types.ts
+++ b/packages/ui/src/agents-providers/types.ts
@@ -58,5 +58,9 @@ export interface AgentsProvidersViewProps {
   onMutate: (intent: ProviderSettingsMutationIntent) => void;
   onOpenTerminal: (terminalSessionId: string) => void;
   onOpenBrowser: (authorizationPath: string) => void;
-  onAddCredit: (accessSourceId: string) => void;
+  onAddCredit: (
+    accessSourceId: string,
+    packageId: "usd_5" | "usd_10" | "usd_25",
+    requestId: string,
+  ) => Promise<void> | void;
 }

--- a/shell/src/components/settings/sections/AgentSection.tsx
+++ b/shell/src/components/settings/sections/AgentSection.tsx
@@ -5,6 +5,7 @@ import { AgentsProvidersView, useProviderSettingsController } from "@matrix-os/u
 import { getGatewayUrl } from "@/lib/gateway";
 import { openProviderAuthorizationPath } from "@/lib/provider-browser-action";
 import { createProviderSettingsTransport } from "@/lib/provider-settings-transport";
+import { currentAiCreditRuntimeSlot, openWebAiCreditCheckout } from "@/lib/ai-credit-checkout";
 
 export function AgentSection({
   onOpenTerminal,
@@ -42,7 +43,9 @@ export function AgentSection({
         onMutate={(intent) => { void controller.mutate(intent); }}
         onOpenTerminal={(sessionId) => { onOpenTerminal?.(sessionId); }}
         onOpenBrowser={openProviderAuthorizationPath}
-        onAddCredit={() => undefined}
+        onAddCredit={async (_sourceId, packageId, requestId) => {
+          await openWebAiCreditCheckout({ packageId, requestId, runtimeSlot: currentAiCreditRuntimeSlot() });
+        }}
       />
     </div>
   );

--- a/shell/src/lib/ai-credit-checkout.ts
+++ b/shell/src/lib/ai-credit-checkout.ts
@@ -14,7 +14,13 @@ function isStripeCheckoutUrl(value: unknown): value is string {
   try {
     const url = new URL(value);
     return url.protocol === "https:" && url.hostname === "checkout.stripe.com";
-  } catch {
+  } catch (error) {
+    if (!(error instanceof TypeError)) {
+      console.warn(
+        "[ai-credit] Checkout URL validation failed:",
+        error instanceof Error ? error.name : typeof error,
+      );
+    }
     return false;
   }
 }
@@ -51,7 +57,13 @@ async function readBoundedCheckoutResponse(response: Response): Promise<unknown>
   }
   try {
     return JSON.parse(new TextDecoder().decode(bytes)) as unknown;
-  } catch {
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) {
+      console.warn(
+        "[ai-credit] Checkout response decoding failed:",
+        error instanceof Error ? error.name : typeof error,
+      );
+    }
     throw new AiCreditCheckoutError();
   }
 }

--- a/shell/src/lib/ai-credit-checkout.ts
+++ b/shell/src/lib/ai-credit-checkout.ts
@@ -1,0 +1,101 @@
+const MAX_CHECKOUT_RESPONSE_BYTES = 8 * 1024;
+const CHECKOUT_TIMEOUT_MS = 10_000;
+type PackageId = "usd_5" | "usd_10" | "usd_25";
+
+class AiCreditCheckoutError extends Error {
+  constructor() {
+    super("Checkout is unavailable.");
+    this.name = "AiCreditCheckoutError";
+  }
+}
+
+function isStripeCheckoutUrl(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" && url.hostname === "checkout.stripe.com";
+  } catch {
+    return false;
+  }
+}
+
+async function readBoundedCheckoutResponse(response: Response): Promise<unknown> {
+  const declared = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > MAX_CHECKOUT_RESPONSE_BYTES) {
+    await response.body?.cancel();
+    throw new AiCreditCheckoutError();
+  }
+  const reader = response.body?.getReader();
+  if (!reader) throw new AiCreditCheckoutError();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      size += next.value.byteLength;
+      if (size > MAX_CHECKOUT_RESPONSE_BYTES) {
+        await reader.cancel();
+        throw new AiCreditCheckoutError();
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+  } catch {
+    throw new AiCreditCheckoutError();
+  }
+}
+
+export function currentAiCreditRuntimeSlot(): string {
+  if (typeof window === "undefined") return "primary";
+  const runtimeSlot = new URLSearchParams(window.location.search).get("runtime");
+  return runtimeSlot && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(runtimeSlot) && runtimeSlot.length <= 32
+    ? runtimeSlot
+    : "primary";
+}
+
+export async function openWebAiCreditCheckout(input: {
+  packageId: PackageId;
+  runtimeSlot?: string;
+  requestId: string;
+  fetcher?: typeof fetch;
+  navigate?: (url: string) => void;
+}): Promise<void> {
+  const fetcher = input.fetcher ?? fetch;
+  const navigate = input.navigate ?? ((url: string) => window.location.assign(url));
+  try {
+    const response = await fetcher("/billing/ai-credit/checkout", {
+      method: "POST",
+      credentials: "include",
+      signal: AbortSignal.timeout(CHECKOUT_TIMEOUT_MS),
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify({
+        packageId: input.packageId,
+        runtimeSlot: input.runtimeSlot ?? currentAiCreditRuntimeSlot(),
+        requestId: input.requestId,
+      }),
+    });
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new AiCreditCheckoutError();
+    }
+    const value = await readBoundedCheckoutResponse(response);
+    const url = value && typeof value === "object" ? (value as { url?: unknown }).url : undefined;
+    if (!isStripeCheckoutUrl(url)) throw new AiCreditCheckoutError();
+    navigate(url);
+  } catch (error) {
+    if (error instanceof AiCreditCheckoutError) throw error;
+    console.warn("[ai-credit] Checkout request failed:", error instanceof Error ? error.name : typeof error);
+    throw new AiCreditCheckoutError();
+  }
+}

--- a/specs/118-ai-gateway-provider-auth/contracts/http.md
+++ b/specs/118-ai-gateway-provider-auth/contracts/http.md
@@ -41,13 +41,27 @@ machine, Price, currency, or amount makes the request invalid. The Checkout
 create uses a fixed-length idempotency key derived from owner, machine, and
 request UUID. Browser retries reuse the same UUID.
 
-Only a signed `checkout.session.completed` event can grant credit. Validation
-requires `mode=payment`, `status=complete`, `payment_status=paid`, `currency=usd`,
-the exact configured `amount_total`, and exact server-written kind, owner,
-machine, runtime, package, Price, request, and microusd metadata. The platform
-inserts the Stripe event receipt and `addon:<checkout-session-id>` ledger entry
-in one Kysely transaction. Mismatch, expiry, or unpaid state rolls back and
-returns non-2xx so Stripe can retry; duplicate valid delivery is a 2xx no-op.
+Before Stripe is called, the platform inserts an immutable Checkout claim. It
+reuses an active same-package claim and permits at most five new claims per
+owner/runtime in a rolling hour. The claim, not mutable environment state, is
+the fulfillment authority after Price rotation or feature disable.
+
+Signed `checkout.session.completed` and
+`checkout.session.async_payment_succeeded` events can grant credit only with
+`mode=payment`, `status=complete`, `payment_status=paid`, `currency=usd`, exact
+pre-tax `amount_subtotal`, `amount_total >= amount_subtotal`, and exact
+server-written kind, owner, machine, runtime, package, Price, request, and
+microusd metadata. Unpaid completion waits; async failure and expiry close the
+attempt without credit. The platform inserts the event receipt and
+`addon:<checkout-session-id>` ledger entry in one Kysely transaction. Mismatch
+rolls back and returns non-2xx; duplicate valid delivery is a 2xx no-op.
+
+Signed `charge.refunded` and dispute lifecycle events resolve through the
+persisted payment-intent/charge association. Any positive refund or open/lost
+dispute reverses the full grant exactly once. Unused balance is removed;
+already consumed/reserved credit becomes durable debt and freezes further
+authorization. A won dispute restores only the removed portion and clears its
+debt atomically.
 
 ## `GET /api/ai/providers`
 

--- a/specs/118-ai-gateway-provider-auth/contracts/http.md
+++ b/specs/118-ai-gateway-provider-auth/contracts/http.md
@@ -18,6 +18,8 @@ All route schemas use `zod/v4`. Every mutating route uses Hono `bodyLimit` befor
 | `POST` | `/v1/messages/count_tokens` | central relay | Same relay service credential | 256 KiB | Optional funded token-count endpoint |
 | `GET` | `/health/ready` | central relay | Platform/internal health auth; never public detail | n/a | Coarse readiness |
 | `POST` | `/internal/containers/:handle/ai/funding-summary` | platform internal | Exact per-handle platform HMAC; owner/machine/runtime derived from the running machine record | 1 KiB | Identity-free authoritative Matrix credit and monthly-budget summary |
+| `POST` | `/billing/ai-credit/checkout` | platform | Authenticated Clerk owner; active machine/runtime derived server-side | 16 KiB | Create hosted Stripe Checkout for one server-owned add-on package |
+| `POST` | `/billing/webhooks/stripe` | platform | Stripe signature over the exact raw body | 1 MiB | Verify paid add-on completion and atomically record receipt + ledger grant |
 
 The exact prefix can be adapted to existing `/api/settings` compatibility routes. Compatibility routes must call the same service and return the canonical state; they cannot maintain a second provider truth.
 
@@ -28,6 +30,24 @@ entries, source references, or database/provider errors. The owner gateway uses
 the provisioned per-handle platform HMAC, a bounded response reader, an explicit
 timeout, and `redirect: "error"`; failure projects usage as unavailable instead
 of falling back to local estimates.
+
+## Funded AI add-on Checkout
+
+The checkout request is a strict object containing only `packageId`
+(`usd_5`, `usd_10`, or `usd_25`), a bounded runtime slot, and a UUID
+`requestId`. The platform maps the package to configured Stripe Price and exact
+USD/microusd amounts. The strict schema rejects extra fields: any client-supplied owner,
+machine, Price, currency, or amount makes the request invalid. The Checkout
+create uses a fixed-length idempotency key derived from owner, machine, and
+request UUID. Browser retries reuse the same UUID.
+
+Only a signed `checkout.session.completed` event can grant credit. Validation
+requires `mode=payment`, `status=complete`, `payment_status=paid`, `currency=usd`,
+the exact configured `amount_total`, and exact server-written kind, owner,
+machine, runtime, package, Price, request, and microusd metadata. The platform
+inserts the Stripe event receipt and `addon:<checkout-session-id>` ledger entry
+in one Kysely transaction. Mismatch, expiry, or unpaid state rolls back and
+returns non-2xx so Stripe can retry; duplicate valid delivery is a 2xx no-op.
 
 ## `GET /api/ai/providers`
 

--- a/specs/118-ai-gateway-provider-auth/data-model.md
+++ b/specs/118-ai-gateway-provider-auth/data-model.md
@@ -236,6 +236,26 @@ No Chat content is persisted at the relay in the first release.
 
 These tables are intentionally deferred until per-user allowance/add-on work. They use platform Postgres and Kysely migrations.
 
+### `ai_credit_checkout_claims`
+
+- immutable fulfillment identity: request, owner, machine, runtime, package,
+  Stripe Price, USD subtotal, microusd grant, tax mode, and idempotency key;
+- mutable bounded lifecycle: Checkout Session URL/ID, payment intent, charge,
+  status, grant/reversal/debt totals, refund timestamp, dispute state, and
+  expiry timestamps;
+- request/idempotency/session/payment-intent/charge references are unique;
+- one partial unique active claim exists per owner/machine/runtime;
+- the claim is inserted before Stripe and remains authoritative after catalog
+  rotation or feature disable.
+
+### `ai_funded_credit_restrictions`
+
+- one row per machine/runtime with non-negative reversal debt and a freeze bit;
+- refund/dispute reversal, balance mutation, debt mutation, ledger entry, claim
+  transition, and webhook receipt share one transaction;
+- authorization rejects while debt or freeze remains, including when the
+  original credit was already consumed.
+
 ### `ai_entitlements`
 
 - unique logical key: `(owner_id, entitlement_kind, status)` with an active-scope constraint;

--- a/specs/118-ai-gateway-provider-auth/plan.md
+++ b/specs/118-ai-gateway-provider-auth/plan.md
@@ -356,7 +356,7 @@ before those authorities exist.
 2. Add Kysely migrations for entitlements, atomic reservations, content-free usage, and reconciliation.
 3. Reserve before dispatch in one transaction with budget predicate in the write and unique request ID.
 4. Reconcile canonical model/tokens/cost; bounded job releases/reconciles abandoned holds.
-5. Add allowance/add-on UI, warnings, stops, exports, deletion/retention, and support tools. Exact remaining credit comes only from the authoritative Matrix ledger; provider subscription allowance and provider API balance remain separately labeled sources. Add-on Checkout accepts only a bounded server-owned package ID and request UUID; Clerk auth plus the active machine row derive owner/machine/runtime, and a signed webhook verifies exact paid USD totals before atomically recording its receipt and idempotent ledger grant.
+5. Add allowance/add-on UI, warnings, stops, exports, deletion/retention, and support tools. Exact remaining credit comes only from the authoritative Matrix ledger; provider subscription allowance and provider API balance remain separately labeled sources. Add-on Checkout accepts only a bounded server-owned package ID and request UUID; Clerk auth plus the active machine row derive owner/machine/runtime. Persist an immutable claim before calling Stripe, reuse one active attempt, and durably rate-limit creation. Signed synchronous or asynchronous payment lifecycle events verify the claim and exact USD subtotal before atomically recording the receipt and idempotent ledger grant.
 6. Retain Cloudflare limits as a second, eventually consistent fuse.
 7. Do not model variable user add-ons as Cloudflare rules: a split-by-user rule gives each value the same budget, Cloudflare caps gateways at 20 spend rules, and concurrent requests can briefly overshoot.
 
@@ -434,10 +434,15 @@ grant workflow is authoritatively configured. `topUpEnabled` comes from the
 platform funding summary (never owner-local JSON), and `add_credit` appears only
 with it. The shared Canvas/Web Desktop/Electron package picker sends
 `$5/$10/$25` package IDs to one Clerk-authenticated platform route. Hosted
-Stripe Checkout owns card collection; the signed completion webhook verifies
-kind, mode, status, payment status, currency, exact amount, Price, request,
-owner, machine, and runtime. Webhook receipt and non-expiring add-on grant
-commit in one transaction and use `ON CONFLICT` idempotency. Cloudflare remains
+Stripe Checkout owns card collection; its integration identifier is derived
+deterministically from the server idempotency key. A pre-call immutable claim
+survives feature disable or Price rotation. Signed completion/async lifecycle
+events verify kind, mode, status, payment status, currency, exact pre-tax
+subtotal, non-decreasing tax-inclusive total, Price, request, owner, machine,
+and runtime. Webhook receipt and non-expiring add-on grant commit in one
+transaction and use `ON CONFLICT` idempotency. Refunds and disputes reverse the
+grant; consumed/reserved remainder becomes frozen debt, and a won dispute
+restores only the previously removed portion. Cloudflare remains
 upstream; Matrix's ledger owns the credit. Add-on Stripe Tax remains disabled
 until operators explicitly attest that required registrations are active.
 

--- a/specs/118-ai-gateway-provider-auth/plan.md
+++ b/specs/118-ai-gateway-provider-auth/plan.md
@@ -356,7 +356,7 @@ before those authorities exist.
 2. Add Kysely migrations for entitlements, atomic reservations, content-free usage, and reconciliation.
 3. Reserve before dispatch in one transaction with budget predicate in the write and unique request ID.
 4. Reconcile canonical model/tokens/cost; bounded job releases/reconciles abandoned holds.
-5. Add allowance/add-on UI, warnings, stops, exports, deletion/retention, and support tools. Exact remaining credit comes only from the authoritative Matrix ledger; provider subscription allowance and provider API balance remain separately labeled sources.
+5. Add allowance/add-on UI, warnings, stops, exports, deletion/retention, and support tools. Exact remaining credit comes only from the authoritative Matrix ledger; provider subscription allowance and provider API balance remain separately labeled sources. Add-on Checkout accepts only a bounded server-owned package ID and request UUID; Clerk auth plus the active machine row derive owner/machine/runtime, and a signed webhook verifies exact paid USD totals before atomically recording its receipt and idempotent ledger grant.
 6. Retain Cloudflare limits as a second, eventually consistent fuse.
 7. Do not model variable user add-ons as Cloudflare rules: a split-by-user rule gives each value the same budget, Cloudflare caps gateways at 20 spend rules, and concurrent requests can briefly overshoot.
 
@@ -429,9 +429,17 @@ The first layer-6 increment exposes the platform Postgres metering summary to
 the exact authenticated runtime and projects it into provider settings. The
 Matrix card distinguishes promotional and add-on balances, held reservations,
 settled monthly use, remaining monthly budget, and the smaller amount currently
-spendable. Stripe purchase is deliberately not advertised: `topUpEnabled`
-remains false and `add_credit` remains absent until a real checkout and ledger
-grant workflow exists.
+spendable. Stripe purchase is advertised only when the real checkout and ledger
+grant workflow is authoritatively configured. `topUpEnabled` comes from the
+platform funding summary (never owner-local JSON), and `add_credit` appears only
+with it. The shared Canvas/Web Desktop/Electron package picker sends
+`$5/$10/$25` package IDs to one Clerk-authenticated platform route. Hosted
+Stripe Checkout owns card collection; the signed completion webhook verifies
+kind, mode, status, payment status, currency, exact amount, Price, request,
+owner, machine, and runtime. Webhook receipt and non-expiring add-on grant
+commit in one transaction and use `ON CONFLICT` idempotency. Cloudflare remains
+upstream; Matrix's ledger owns the credit. Add-on Stripe Tax remains disabled
+until operators explicitly attest that required registrations are active.
 
 ## Documentation and Review Deliverables
 

--- a/specs/118-ai-gateway-provider-auth/tasks.md
+++ b/specs/118-ai-gateway-provider-auth/tasks.md
@@ -128,6 +128,14 @@ mutation or funded balances.
 - [ ] T046 Add Matrix Postgres/Kysely entitlements, atomic spend reservations, reconciliation, add-ons, and truthful credit UI; retain Cloudflare limits as a coarse fuse
 - [ ] T047 Add generic/model-specific harness routing and additional model providers through V3 conformance tests, one adapter PR at a time
 
+### T046 add-on checkout increment
+
+- [X] T046A Add server-owned `$5/$10/$25` Stripe Price configuration and a strict Clerk-authenticated Checkout route that derives the active owner machine/runtime
+- [X] T046B Add signed completion validation plus one-transaction, `ON CONFLICT`-idempotent webhook receipt and Matrix add-on ledger grant
+- [X] T046C Gate `topUpEnabled` and `add_credit` only from authoritative platform checkout configuration, failing closed when absent
+- [X] T046D Add one shared package/busy/safe-error UI with same-origin web navigation and authenticated Electron external-browser handoff
+- [X] T046E Cover package spoofing, unpaid/expired/mismatched events, duplicate delivery, transaction rollback, shell parity, redirect validation, and Stripe integration metadata
+
 ---
 
 ## Dependencies and Execution Order

--- a/specs/118-ai-gateway-provider-auth/tasks.md
+++ b/specs/118-ai-gateway-provider-auth/tasks.md
@@ -135,6 +135,8 @@ mutation or funded balances.
 - [X] T046C Gate `topUpEnabled` and `add_credit` only from authoritative platform checkout configuration, failing closed when absent
 - [X] T046D Add one shared package/busy/safe-error UI with same-origin web navigation and authenticated Electron external-browser handoff
 - [X] T046E Cover package spoofing, unpaid/expired/mismatched events, duplicate delivery, transaction rollback, shell parity, redirect validation, and Stripe integration metadata
+- [X] T046F Persist immutable Checkout claims, reuse active attempts, enforce a durable five-per-hour owner/runtime creation limit, and fulfill paid asynchronous methods against the claim after configuration rotation
+- [X] T046G Reverse refunded/disputed grants idempotently, convert consumed credit to frozen debt, restore won disputes, and cover tax-on-top subtotal validation
 
 ---
 

--- a/tests/desktop/provider-settings-adapter.test.ts
+++ b/tests/desktop/provider-settings-adapter.test.ts
@@ -5,6 +5,7 @@ import {
   createDesktopProviderSettingsTransport,
   desktopProviderIdentityKey,
   openExistingProviderTerminalSession,
+  openAiCreditCheckout,
   openProviderAuthorizationPath,
 } from "../../desktop/src/renderer/src/features/settings/provider-settings-desktop-adapter";
 import type { ApiClient } from "../../desktop/src/renderer/src/lib/api";
@@ -148,6 +149,36 @@ describe("desktop provider settings transport", () => {
 });
 
 describe("desktop provider connection actions", () => {
+  it("opens server-created AI credit checkout externally for the selected runtime", async () => {
+    const post = vi.fn().mockResolvedValue({ url: "https://checkout.stripe.com/c/pay/cs_ai_25" });
+    const openExternal = vi.fn().mockResolvedValue(undefined);
+    await expect(openAiCreditCheckout({
+      api: api({ post }),
+      runtimeSlot: "studio",
+      packageId: "usd_25",
+      requestId: "77f105df-6e24-4e13-a881-af9ce20d6a63",
+      openExternal,
+    })).resolves.toBe(true);
+    expect(post).toHaveBeenCalledWith("/billing/ai-credit/checkout", {
+      packageId: "usd_25",
+      runtimeSlot: "studio",
+      requestId: "77f105df-6e24-4e13-a881-af9ce20d6a63",
+    }, { maxBytes: 8 * 1024 });
+    expect(openExternal).toHaveBeenCalledWith("https://checkout.stripe.com/c/pay/cs_ai_25");
+  });
+
+  it("rejects invalid AI checkout redirects without opening the browser", async () => {
+    const openExternal = vi.fn();
+    await expect(openAiCreditCheckout({
+      api: api({ post: vi.fn().mockResolvedValue({ url: "https://evil.example/steal" }) }),
+      runtimeSlot: "primary",
+      packageId: "usd_5",
+      requestId: crypto.randomUUID(),
+      openExternal,
+    })).resolves.toBe(false);
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
   it("scopes provider state to owner, runtime slot, host, and credential generation", () => {
     expect(desktopProviderIdentityKey({
       status: "signed-in",

--- a/tests/gateway/provider-settings-store.test.ts
+++ b/tests/gateway/provider-settings-store.test.ts
@@ -347,7 +347,10 @@ describe("ProviderSettingsStore", () => {
     expect(snapshot.supportedActions).not.toContain("set_gateway_allowlist");
 
     const purchasable = await createStore({
-      fundingSummary: { ...fundingSummary, topUpEnabled: true },
+      fundingSummary: {
+        funding: { ...fundingSummary, topUpEnabled: true },
+        policy,
+      },
     }).getSnapshot();
     expect(purchasable.gatewayPolicy?.topUpEnabled).toBe(true);
     expect(purchasable.supportedActions).toContain("add_credit");

--- a/tests/gateway/provider-settings-store.test.ts
+++ b/tests/gateway/provider-settings-store.test.ts
@@ -345,6 +345,12 @@ describe("ProviderSettingsStore", () => {
     expect(snapshot.supportedActions).not.toContain("add_credit");
     expect(snapshot.supportedActions).not.toContain("set_gateway_budget");
     expect(snapshot.supportedActions).not.toContain("set_gateway_allowlist");
+
+    const purchasable = await createStore({
+      fundingSummary: { ...fundingSummary, topUpEnabled: true },
+    }).getSnapshot();
+    expect(purchasable.gatewayPolicy?.topUpEnabled).toBe(true);
+    expect(purchasable.supportedActions).toContain("add_credit");
     await expect(store.mutate({
       type: "set_gateway_budget",
       expectedRevision: snapshot.revision,

--- a/tests/platform/ai-funded-policy-routes.test.ts
+++ b/tests/platform/ai-funded-policy-routes.test.ts
@@ -63,7 +63,7 @@ describe("funded AI policy routes", () => {
     vi.restoreAllMocks();
   });
 
-  async function createTestApp(options: { promotionalGrantEnabled?: boolean } = {}) {
+  async function createTestApp(options: { promotionalGrantEnabled?: boolean; topUpEnabled?: boolean } = {}) {
     const repository = createAiFundedPolicyRepository({
       db, credentialHashSecret: hashSecret, now: () => new Date(now),
       tokenIdFactory: () => "credential_123", tokenSecretFactory: () => "s".repeat(43),
@@ -89,7 +89,12 @@ describe("funded AI policy routes", () => {
         db,
         orchestrator: stubOrchestrator(),
         platformSecret,
-        internalFundedAiRuntimeRoutes: createAiFundedRuntimeRoutes({ db, platformSecret, repository }),
+        internalFundedAiRuntimeRoutes: createAiFundedRuntimeRoutes({
+          db,
+          platformSecret,
+          repository,
+          topUpEnabled: options.topUpEnabled,
+        }),
         internalFundedAiRelayRoutes: createAiFundedRelayRoutes({ relayControlToken, repository }),
         internalFundedAiOperatorRoutes: createAiFundedOperatorRoutes({
           db,
@@ -381,7 +386,7 @@ describe("funded AI policy routes", () => {
   });
 
   it("returns the exact identity-free Postgres funding summary for the authenticated runtime", async () => {
-    const { app } = await createTestApp();
+    const { app, repository } = await createTestApp();
     for (const authorization of [
       undefined,
       "Bearer wrong-runtime-token",
@@ -426,6 +431,22 @@ describe("funded AI policy routes", () => {
       method: "POST",
       headers: { authorization: `Bearer ${bearerFor("alice")}` },
     })).status).toBe(400);
+
+    const enabledApp = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      platformSecret,
+      internalFundedAiRuntimeRoutes: createAiFundedRuntimeRoutes({
+        db, platformSecret, repository, topUpEnabled: true,
+      }),
+    });
+    const enabledResponse = await enabledApp.request("/internal/containers/alice/ai/funding-summary?runtimeSlot=primary", {
+      method: "POST",
+      headers: { authorization: `Bearer ${bearerFor("alice")}`, "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(FundedAiRuntimeFundingSummaryResponseSchema.parse(await enabledResponse.json()).funding.topUpEnabled)
+      .toBe(true);
   });
 
   it("rejects missing auth, malformed or oversized bodies, caller identity fields, and legacy-only handles", async () => {

--- a/tests/platform/funded-ai-addon-checkout.test.ts
+++ b/tests/platform/funded-ai-addon-checkout.test.ts
@@ -57,6 +57,11 @@ describe("funded AI add-on checkout", () => {
       monthlyBudgetMicrousd: 50_000_000,
       expiresAt: null,
     });
+    await repository.updateGlobalPolicy({
+      expectedRevision: 0,
+      enabled: true,
+      allowedModelIds: ["anthropic/claude-sonnet-5"],
+    });
     stripe = {
       apiTimeoutMs: 10_000,
       createCheckoutSession: vi.fn(),
@@ -86,6 +91,14 @@ describe("funded AI add-on checkout", () => {
       fundedAiRepository: repository,
     }));
     return hono;
+  }
+
+  async function createCheckout(env: NodeJS.ProcessEnv = checkoutEnv, requestId = completedMetadata().matrix_ai_credit_request_id) {
+    return app(identity.ownerId, env).request("/billing/ai-credit/checkout", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ packageId: "usd_5", runtimeSlot: "primary", requestId }),
+    });
   }
 
   it("loads a complete, bounded, server-owned package catalog or disables checkout", () => {
@@ -169,6 +182,7 @@ describe("funded AI add-on checkout", () => {
   });
 
   it("atomically records one signed receipt and grants exact non-expiring add-on credit once", async () => {
+    expect((await createCheckout()).status).toBe(200);
     const first = await app().request("/billing/webhooks/stripe", {
       method: "POST",
       headers: { "stripe-signature": "signed" },
@@ -203,14 +217,14 @@ describe("funded AI add-on checkout", () => {
   });
 
   it.each([
-    ["unpaid", { payment_status: "unpaid" }],
-    ["expired", { status: "expired" }],
     ["wrong amount", { amount_total: 499 }],
+    ["wrong subtotal", { amount_subtotal: 499 }],
     ["wrong currency", { currency: "eur" }],
     ["wrong owner", { client_reference_id: "user_other" }],
     ["wrong machine", { metadata: { ...completedMetadata(), matrix_machine_id: "machine_other" } }],
     ["wrong mode", { mode: "subscription" }],
   ])("rejects %s completion without persisting a receipt or credit", async (_label, patch) => {
+    expect((await createCheckout()).status).toBe(200);
     webhookEvent = completedEvent(patch);
     const response = await app().request("/billing/webhooks/stripe", {
       method: "POST",
@@ -220,6 +234,130 @@ describe("funded AI add-on checkout", () => {
 
     expect(response.status).toBe(500);
     expect(await getBillingWebhookEvent(db, webhookEvent.id)).toBeUndefined();
+    expect(await db.executor.selectFrom("ai_funded_credit_ledger").selectAll().execute()).toEqual([]);
+  });
+
+  it("uses the immutable checkout claim after feature disable or price rotation and treats tax as additional", async () => {
+    const taxEnv = { ...checkoutEnv, MATRIX_AI_CREDIT_STRIPE_TAX_REGISTRATIONS_VERIFIED: "true" };
+    expect((await createCheckout(taxEnv)).status).toBe(200);
+    webhookEvent = completedEvent({ amount_subtotal: 500, amount_total: 550 });
+    const disabledEnv = { ...checkoutEnv, MATRIX_FUNDED_AI_ADDON_CHECKOUT_ENABLED: "false", STRIPE_PRICE_AI_CREDIT_USD_5: "price_rotated" };
+    const retry = await createCheckout(disabledEnv);
+    expect(retry.status).toBe(200);
+    expect(stripe.createAiCreditCheckoutSession).toHaveBeenCalledTimes(1);
+    const response = await app(identity.ownerId, disabledEnv).request("/billing/webhooks/stripe", {
+      method: "POST", headers: { "stripe-signature": "signed" }, body: "{}",
+    });
+    expect(response.status).toBe(200);
+    await expect(repository.getFundingSummary(identity)).resolves.toMatchObject({ creditBalanceMicrousd: 5_000_000 });
+  });
+
+  it("waits for asynchronous payment success and never grants failed or unpaid Checkout", async () => {
+    expect((await createCheckout()).status).toBe(200);
+    webhookEvent = completedEvent({ payment_status: "unpaid" });
+    expect((await app().request("/billing/webhooks/stripe", {
+      method: "POST", headers: { "stripe-signature": "signed" }, body: "{}",
+    })).status).toBe(200);
+    expect(await db.executor.selectFrom("ai_funded_credit_ledger").selectAll().execute()).toEqual([]);
+
+    webhookEvent = completedEvent({ payment_status: "paid" });
+    webhookEvent.id = "evt_ai_async_success";
+    webhookEvent.type = "checkout.session.async_payment_succeeded";
+    expect((await app().request("/billing/webhooks/stripe", {
+      method: "POST", headers: { "stripe-signature": "signed" }, body: "{}",
+    })).status).toBe(200);
+    expect(await db.executor.selectFrom("ai_funded_credit_ledger").selectAll().execute()).toHaveLength(1);
+  });
+
+  it("records asynchronous failure and expiry without ever granting credit", async () => {
+    expect((await createCheckout()).status).toBe(200);
+    webhookEvent = completedEvent({ payment_status: "unpaid" });
+    webhookEvent.id = "evt_ai_async_failed";
+    webhookEvent.type = "checkout.session.async_payment_failed";
+    expect((await app().request("/billing/webhooks/stripe", {
+      method: "POST", headers: { "stripe-signature": "signed" }, body: "{}",
+    })).status).toBe(200);
+    webhookEvent = completedEvent({ status: "expired", payment_status: "unpaid" });
+    webhookEvent.id = "evt_ai_expired";
+    webhookEvent.type = "checkout.session.expired";
+    expect((await app().request("/billing/webhooks/stripe", {
+      method: "POST", headers: { "stripe-signature": "signed" }, body: "{}",
+    })).status).toBe(200);
+    expect(await db.executor.selectFrom("ai_funded_credit_ledger").selectAll().execute()).toEqual([]);
+    expect(await db.executor.selectFrom("ai_credit_checkout_claims").select("status").executeTakeFirst())
+      .toEqual({ status: "expired" });
+  });
+
+  it("reuses an active attempt and durably rate limits repeated Checkout creation", async () => {
+    expect((await createCheckout()).status).toBe(200);
+    const second = await createCheckout(checkoutEnv, "2cdca480-3baa-42ae-a77b-e1a0cb51f1ea");
+    expect(second.status).toBe(200);
+    expect(stripe.createAiCreditCheckoutSession).toHaveBeenCalledTimes(1);
+
+    await db.executor.updateTable("ai_credit_checkout_claims").set({ status: "expired" }).execute();
+    vi.mocked(stripe.createAiCreditCheckoutSession).mockImplementation(async (input) => ({
+      id: `cs_${input.requestId.replaceAll("-", "")}`,
+      url: `https://checkout.stripe.test/${input.requestId}`,
+    }));
+    for (let index = 1; index < 5; index += 1) {
+      const response = await createCheckout(checkoutEnv, `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`);
+      expect(response.status).toBe(200);
+      await db.executor.updateTable("ai_credit_checkout_claims").set({ status: "expired" })
+        .where("request_id", "=", `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`).execute();
+    }
+    const limited = await createCheckout(checkoutEnv, "00000000-0000-4000-8000-000000000099");
+    expect(limited.status).toBe(429);
+  });
+
+  it("atomically reverses refunded credit, records consumed-credit debt, and restores a won dispute", async () => {
+    const credential = await repository.issueRuntimeCredential(identity);
+    expect((await createCheckout()).status).toBe(200);
+    expect((await app().request("/billing/webhooks/stripe", {
+      method: "POST", headers: { "stripe-signature": "signed" }, body: "{}",
+    })).status).toBe(200);
+
+    webhookEvent = disputeEvent("charge.dispute.created", "under_review", "evt_dispute_created");
+    expect((await app().request("/billing/webhooks/stripe", {
+      method: "POST", headers: { "stripe-signature": "signed" }, body: "{}",
+    })).status).toBe(200);
+    expect(await db.executor.selectFrom("ai_funded_credit_restrictions").selectAll().executeTakeFirst()).toMatchObject({ frozen: true });
+    await expect(repository.getFundingSummary(identity)).resolves.toMatchObject({ creditBalanceMicrousd: 0 });
+
+    webhookEvent = disputeEvent("charge.dispute.closed", "won", "evt_dispute_won");
+    expect((await app().request("/billing/webhooks/stripe", {
+      method: "POST", headers: { "stripe-signature": "signed" }, body: "{}",
+    })).status).toBe(200);
+    await expect(repository.getFundingSummary(identity)).resolves.toMatchObject({ creditBalanceMicrousd: 5_000_000 });
+    expect(await db.executor.selectFrom("ai_funded_credit_restrictions").selectAll().executeTakeFirst()).toMatchObject({ frozen: false, debt_microusd: 0 });
+
+    await db.executor.updateTable("ai_funded_runtime_balances").set({
+      credit_balance_microusd: 0, addon_balance_microusd: 0,
+    }).where("machine_id", "=", identity.machineId).execute();
+    webhookEvent = refundedEvent();
+    expect((await app().request("/billing/webhooks/stripe", {
+      method: "POST", headers: { "stripe-signature": "signed" }, body: "{}",
+    })).status).toBe(200);
+    expect(await db.executor.selectFrom("ai_funded_credit_restrictions").selectAll().executeTakeFirst()).toMatchObject({
+      frozen: true, debt_microusd: 5_000_000,
+    });
+    await expect(repository.authorize({
+      credential: credential.credential.token,
+      requestId: "refund_blocked_spend",
+      modelId: "anthropic/claude-sonnet-5",
+      maxCostMicrousd: 1,
+    })).rejects.toMatchObject({ code: "access_disabled" });
+  });
+
+  it("ignores unrelated Stripe refunds without trapping subscription webhook delivery", async () => {
+    webhookEvent = {
+      id: "evt_unrelated_refund", type: "charge.refunded", created: 1_788_172_700,
+      data: { object: { id: "ch_subscription", payment_intent: "pi_subscription", amount_refunded: 1_000, currency: "eur" } },
+    };
+    const response = await app().request("/billing/webhooks/stripe", {
+      method: "POST", headers: { "stripe-signature": "signed" }, body: "{}",
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ received: true, ignored: true });
     expect(await db.executor.selectFrom("ai_funded_credit_ledger").selectAll().execute()).toEqual([]);
   });
 });
@@ -248,6 +386,8 @@ function completedEvent(patch: Record<string, unknown> = {}): StripeWebhookEvent
         mode: "payment",
         status: "complete",
         payment_status: "paid",
+        payment_intent: "pi_ai_5",
+        amount_subtotal: 500,
         amount_total: 500,
         currency: "usd",
         client_reference_id: identity.ownerId,
@@ -255,5 +395,19 @@ function completedEvent(patch: Record<string, unknown> = {}): StripeWebhookEvent
         ...patch,
       },
     },
+  };
+}
+
+function disputeEvent(type: string, status: string, id: string): StripeWebhookEvent {
+  return {
+    id, type, created: 1_788_172_500,
+    data: { object: { id: `dp_${id}`, charge: "ch_ai_5", payment_intent: "pi_ai_5", status } },
+  };
+}
+
+function refundedEvent(): StripeWebhookEvent {
+  return {
+    id: "evt_refund", type: "charge.refunded", created: 1_788_172_600,
+    data: { object: { id: "ch_ai_5", payment_intent: "pi_ai_5", amount_refunded: 500, currency: "usd" } },
   };
 }

--- a/tests/platform/funded-ai-addon-checkout.test.ts
+++ b/tests/platform/funded-ai-addon-checkout.test.ts
@@ -101,6 +101,18 @@ describe("funded AI add-on checkout", () => {
     });
   }
 
+  async function deliver(event: StripeWebhookEvent) {
+    webhookEvent = event;
+    return app().request("/billing/webhooks/stripe", {
+      method: "POST", headers: { "stripe-signature": "signed" }, body: "{}",
+    });
+  }
+
+  async function purchaseCredit() {
+    expect((await createCheckout()).status).toBe(200);
+    expect((await deliver(completedEvent())).status).toBe(200);
+  }
+
   it("loads a complete, bounded, server-owned package catalog or disables checkout", () => {
     expect(loadAiCreditCheckoutConfig(checkoutEnv)).toEqual({
       enabled: true,
@@ -359,6 +371,57 @@ describe("funded AI add-on checkout", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ received: true, ignored: true });
     expect(await db.executor.selectFrom("ai_funded_credit_ledger").selectAll().execute()).toEqual([]);
+  });
+
+  it("does not regress a won dispute when created or opposite terminal events arrive late", async () => {
+    await purchaseCredit();
+    expect((await deliver(disputeEvent("charge.dispute.created", "under_review", "evt_won_created"))).status).toBe(200);
+    expect((await deliver(disputeEvent("charge.dispute.closed", "won", "evt_won_closed"))).status).toBe(200);
+    expect((await deliver(disputeEvent("charge.dispute.created", "needs_response", "evt_won_late_created"))).status).toBe(200);
+    expect((await deliver(disputeEvent("charge.dispute.closed", "lost", "evt_won_late_lost"))).status).toBe(200);
+
+    expect(await db.executor.selectFrom("ai_credit_checkout_claims")
+      .select(["dispute_status", "reversed_microusd"]).executeTakeFirst()).toEqual({
+      dispute_status: "won", reversed_microusd: 0,
+    });
+    await expect(repository.getFundingSummary(identity)).resolves.toMatchObject({ creditBalanceMicrousd: 5_000_000 });
+    expect(await db.executor.selectFrom("ai_funded_credit_restrictions").selectAll().executeTakeFirst())
+      .toMatchObject({ frozen: false, debt_microusd: 0 });
+  });
+
+  it("does not regress a lost dispute when created or opposite terminal events arrive late", async () => {
+    await purchaseCredit();
+    expect((await deliver(disputeEvent("charge.dispute.created", "under_review", "evt_lost_created"))).status).toBe(200);
+    expect((await deliver(disputeEvent("charge.dispute.closed", "lost", "evt_lost_closed"))).status).toBe(200);
+    expect((await deliver(disputeEvent("charge.dispute.created", "needs_response", "evt_lost_late_created"))).status).toBe(200);
+    expect((await deliver(disputeEvent("charge.dispute.closed", "won", "evt_lost_late_won"))).status).toBe(200);
+
+    expect(await db.executor.selectFrom("ai_credit_checkout_claims")
+      .select(["dispute_status", "reversed_microusd"]).executeTakeFirst()).toEqual({
+      dispute_status: "lost", reversed_microusd: 5_000_000,
+    });
+    await expect(repository.getFundingSummary(identity)).resolves.toMatchObject({ creditBalanceMicrousd: 0 });
+    expect(await db.executor.selectFrom("ai_funded_credit_restrictions").selectAll().executeTakeFirst())
+      .toMatchObject({ frozen: true });
+  });
+
+  it("keeps refund reversal but clears zero-debt dispute freeze when a refunded dispute is won", async () => {
+    await purchaseCredit();
+    expect((await deliver(disputeEvent("charge.dispute.created", "under_review", "evt_refunded_created"))).status).toBe(200);
+    expect((await deliver(refundedEvent())).status).toBe(200);
+    expect((await deliver(disputeEvent("charge.dispute.closed", "won", "evt_refunded_won"))).status).toBe(200);
+
+    expect(await db.executor.selectFrom("ai_credit_checkout_claims")
+      .select(["dispute_status", "refunded_at", "reversed_microusd", "reversal_debt_microusd"])
+      .executeTakeFirst()).toEqual({
+      dispute_status: "won",
+      refunded_at: "2026-08-31T10:00:00.000Z",
+      reversed_microusd: 5_000_000,
+      reversal_debt_microusd: 0,
+    });
+    await expect(repository.getFundingSummary(identity)).resolves.toMatchObject({ creditBalanceMicrousd: 0 });
+    expect(await db.executor.selectFrom("ai_funded_credit_restrictions").selectAll().executeTakeFirst())
+      .toMatchObject({ frozen: false, debt_microusd: 0 });
   });
 });
 

--- a/tests/platform/funded-ai-addon-checkout.test.ts
+++ b/tests/platform/funded-ai-addon-checkout.test.ts
@@ -1,0 +1,259 @@
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createHash } from "node:crypto";
+import { createAiFundedPolicyRepository } from "../../packages/platform/src/ai-funded-policy-repository.js";
+import {
+  createBillingRoutes,
+  type StripeBillingClient,
+  type StripeWebhookEvent,
+} from "../../packages/platform/src/billing-routes.js";
+import { loadAiCreditCheckoutConfig } from "../../packages/platform/src/ai-credit-checkout.js";
+import { getBillingWebhookEvent, insertUserMachine, type PlatformDB } from "../../packages/platform/src/db.js";
+import { createTestPlatformDb, destroyTestPlatformDb } from "./platform-db-test-helper.js";
+
+const checkoutEnv = {
+  MATRIX_FUNDED_AI_ADDON_CHECKOUT_ENABLED: "true",
+  STRIPE_SECRET_KEY: "configured",
+  STRIPE_WEBHOOK_SECRET: "whsec_test",
+  STRIPE_PRICE_AI_CREDIT_USD_5: "price_ai_5",
+  STRIPE_PRICE_AI_CREDIT_USD_10: "price_ai_10",
+  STRIPE_PRICE_AI_CREDIT_USD_25: "price_ai_25",
+};
+
+const identity = {
+  ownerId: "user_alice",
+  machineId: "machine_alice",
+  runtimeSlot: "primary",
+} as const;
+
+describe("funded AI add-on checkout", () => {
+  let db: PlatformDB;
+  let stripe: StripeBillingClient;
+  let repository: ReturnType<typeof createAiFundedPolicyRepository>;
+  let webhookEvent: StripeWebhookEvent;
+
+  beforeEach(async () => {
+    ({ db } = await createTestPlatformDb());
+    await insertUserMachine(db, {
+      machineId: identity.machineId,
+      clerkUserId: identity.ownerId,
+      handle: "alice",
+      runtimeSlot: identity.runtimeSlot,
+      status: "running",
+      imageVersion: "v1",
+      provisionedAt: "2026-08-31T09:00:00.000Z",
+      activationState: "authorized",
+    });
+    repository = createAiFundedPolicyRepository({
+      db,
+      credentialHashSecret: "h".repeat(32),
+      now: () => new Date("2026-08-31T10:00:00.000Z"),
+    });
+    await repository.setRuntimePolicy({
+      identity,
+      expectedRevision: 0,
+      enabled: true,
+      allowedModelIds: ["anthropic/claude-sonnet-5"],
+      monthlyBudgetMicrousd: 50_000_000,
+      expiresAt: null,
+    });
+    stripe = {
+      apiTimeoutMs: 10_000,
+      createCheckoutSession: vi.fn(),
+      createAiCreditCheckoutSession: vi.fn().mockResolvedValue({
+        url: "https://checkout.stripe.com/c/pay/cs_test",
+        id: "cs_ai_5",
+      }),
+      retrieveCheckoutSession: vi.fn(),
+      createPortalSession: vi.fn(),
+      constructWebhookEvent: vi.fn(() => webhookEvent),
+    };
+    webhookEvent = completedEvent();
+  });
+
+  afterEach(async () => {
+    await destroyTestPlatformDb(db);
+  });
+
+  function app(userId: string | null = identity.ownerId, env: NodeJS.ProcessEnv = checkoutEnv) {
+    const hono = new Hono();
+    hono.route("/billing", createBillingRoutes({
+      db,
+      stripe,
+      env,
+      resolveClerkUserId: () => Promise.resolve(userId),
+      now: () => new Date("2026-08-31T10:00:00.000Z"),
+      fundedAiRepository: repository,
+    }));
+    return hono;
+  }
+
+  it("loads a complete, bounded, server-owned package catalog or disables checkout", () => {
+    expect(loadAiCreditCheckoutConfig(checkoutEnv)).toEqual({
+      enabled: true,
+      automaticTax: false,
+      packages: [
+        { id: "usd_5", amountUsd: 5, amountMicrousd: 5_000_000, amountCents: 500, currency: "usd", priceId: "price_ai_5" },
+        { id: "usd_10", amountUsd: 10, amountMicrousd: 10_000_000, amountCents: 1_000, currency: "usd", priceId: "price_ai_10" },
+        { id: "usd_25", amountUsd: 25, amountMicrousd: 25_000_000, amountCents: 2_500, currency: "usd", priceId: "price_ai_25" },
+      ],
+    });
+    expect(loadAiCreditCheckoutConfig({ ...checkoutEnv, STRIPE_PRICE_AI_CREDIT_USD_10: undefined }))
+      .toEqual({ enabled: false });
+    expect(loadAiCreditCheckoutConfig({
+      ...checkoutEnv,
+      MATRIX_AI_CREDIT_STRIPE_TAX_REGISTRATIONS_VERIFIED: "true",
+    })).toMatchObject({ enabled: true, automaticTax: true });
+    expect(() => loadAiCreditCheckoutConfig({ ...checkoutEnv, STRIPE_PRICE_AI_CREDIT_USD_10: "price_ai_5" }))
+      .toThrow(/misconfigured/i);
+  });
+
+  it("derives the exact owner runtime and creates payment Checkout from a package id only", async () => {
+    const response = await app().request("/billing/ai-credit/checkout", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        packageId: "usd_5",
+        runtimeSlot: "primary",
+        requestId: "77f105df-6e24-4e13-a881-af9ce20d6a63",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ url: "https://checkout.stripe.com/c/pay/cs_test" });
+    expect(stripe.createAiCreditCheckoutSession).toHaveBeenCalledWith({
+      idempotencyKey: `matrix-ai-credit:${createHash("sha256")
+        .update(["user_alice", "machine_alice", "77f105df-6e24-4e13-a881-af9ce20d6a63"].join("\0"))
+        .digest("hex")}`,
+      requestId: "77f105df-6e24-4e13-a881-af9ce20d6a63",
+      clerkUserId: identity.ownerId,
+      machineId: identity.machineId,
+      runtimeSlot: identity.runtimeSlot,
+      packageId: "usd_5",
+      priceId: "price_ai_5",
+      amountMicrousd: 5_000_000,
+      automaticTax: false,
+      successUrl: "https://app.matrix-os.com/?billing=success&checkout=success",
+      cancelUrl: "https://app.matrix-os.com/?billing=canceled",
+    });
+  });
+
+  it("rejects client-supplied money, unknown packages, missing auth, and non-running runtimes", async () => {
+    const clientMoney = await app().request("/billing/ai-credit/checkout", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ packageId: "usd_5", requestId: crypto.randomUUID(), amount: 1, priceId: "price_attacker" }),
+    });
+    expect(clientMoney.status).toBe(400);
+    expect(stripe.createAiCreditCheckoutSession).not.toHaveBeenCalled();
+
+    const unknown = await app().request("/billing/ai-credit/checkout", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ packageId: "usd_500", requestId: crypto.randomUUID() }),
+    });
+    expect(unknown.status).toBe(400);
+    expect((await app(null).request("/billing/ai-credit/checkout", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ packageId: "usd_5", requestId: crypto.randomUUID() }),
+    })).status).toBe(401);
+
+    await db.executor.updateTable("user_machines").set({ status: "suspended" })
+      .where("machine_id", "=", identity.machineId).execute();
+    expect((await app().request("/billing/ai-credit/checkout", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ packageId: "usd_5", requestId: crypto.randomUUID() }),
+    })).status).toBe(409);
+  });
+
+  it("atomically records one signed receipt and grants exact non-expiring add-on credit once", async () => {
+    const first = await app().request("/billing/webhooks/stripe", {
+      method: "POST",
+      headers: { "stripe-signature": "signed" },
+      body: "{}",
+    });
+    const duplicate = await app().request("/billing/webhooks/stripe", {
+      method: "POST",
+      headers: { "stripe-signature": "signed" },
+      body: "{}",
+    });
+
+    expect(first.status).toBe(200);
+    expect(duplicate.status).toBe(200);
+    expect(await duplicate.json()).toEqual({ received: true, duplicate: true });
+    expect(await getBillingWebhookEvent(db, webhookEvent.id)).toMatchObject({ status: "processed" });
+    expect(await db.executor.selectFrom("ai_funded_credit_ledger").selectAll().execute()).toEqual([
+      expect.objectContaining({
+        entry_id: "addon:cs_ai_5",
+        owner_id: identity.ownerId,
+        machine_id: identity.machineId,
+        runtime_slot: identity.runtimeSlot,
+        kind: "addon_grant",
+        amount_microusd: 5_000_000,
+        source_reference: "cs_ai_5",
+        expires_at: null,
+      }),
+    ]);
+    await expect(repository.getFundingSummary(identity)).resolves.toMatchObject({
+      addonBalanceMicrousd: 5_000_000,
+      creditBalanceMicrousd: 5_000_000,
+    });
+  });
+
+  it.each([
+    ["unpaid", { payment_status: "unpaid" }],
+    ["expired", { status: "expired" }],
+    ["wrong amount", { amount_total: 499 }],
+    ["wrong currency", { currency: "eur" }],
+    ["wrong owner", { client_reference_id: "user_other" }],
+    ["wrong machine", { metadata: { ...completedMetadata(), matrix_machine_id: "machine_other" } }],
+    ["wrong mode", { mode: "subscription" }],
+  ])("rejects %s completion without persisting a receipt or credit", async (_label, patch) => {
+    webhookEvent = completedEvent(patch);
+    const response = await app().request("/billing/webhooks/stripe", {
+      method: "POST",
+      headers: { "stripe-signature": "signed" },
+      body: "{}",
+    });
+
+    expect(response.status).toBe(500);
+    expect(await getBillingWebhookEvent(db, webhookEvent.id)).toBeUndefined();
+    expect(await db.executor.selectFrom("ai_funded_credit_ledger").selectAll().execute()).toEqual([]);
+  });
+});
+
+function completedMetadata() {
+  return {
+    matrix_checkout_kind: "ai_credit_addon",
+    matrix_owner_id: identity.ownerId,
+    matrix_machine_id: identity.machineId,
+    matrix_runtime_slot: identity.runtimeSlot,
+    matrix_ai_credit_package_id: "usd_5",
+    matrix_ai_credit_request_id: "77f105df-6e24-4e13-a881-af9ce20d6a63",
+    matrix_ai_credit_price_id: "price_ai_5",
+    matrix_ai_credit_microusd: "5000000",
+  };
+}
+
+function completedEvent(patch: Record<string, unknown> = {}): StripeWebhookEvent {
+  return {
+    id: "evt_ai_5",
+    type: "checkout.session.completed",
+    created: 1_788_172_400,
+    data: {
+      object: {
+        id: "cs_ai_5",
+        mode: "payment",
+        status: "complete",
+        payment_status: "paid",
+        amount_total: 500,
+        currency: "usd",
+        client_reference_id: identity.ownerId,
+        metadata: completedMetadata(),
+        ...patch,
+      },
+    },
+  };
+}

--- a/tests/platform/funded-ai-addon-checkout.test.ts
+++ b/tests/platform/funded-ai-addon-checkout.test.ts
@@ -423,6 +423,55 @@ describe("funded AI add-on checkout", () => {
     expect(await db.executor.selectFrom("ai_funded_credit_restrictions").selectAll().executeTakeFirst())
       .toMatchObject({ frozen: false, debt_microusd: 0 });
   });
+
+  it.each(["won", "lost"] as const)(
+    "freezes an already-refunded runtime for a later dispute, then settles %s monotonically and idempotently",
+    async (resolution) => {
+      await purchaseCredit();
+      expect((await deliver(refundedEvent())).status).toBe(200);
+      expect(await db.executor.selectFrom("ai_funded_credit_restrictions").selectAll().executeTakeFirst())
+        .toMatchObject({ frozen: false, debt_microusd: 0 });
+
+      const created = disputeEvent(
+        "charge.dispute.created",
+        "under_review",
+        `evt_refund_first_${resolution}_created`,
+      );
+      expect((await deliver(created)).status).toBe(200);
+      expect(await db.executor.selectFrom("ai_funded_credit_restrictions").selectAll().executeTakeFirst())
+        .toMatchObject({ frozen: true, debt_microusd: 0 });
+      await expect((await deliver(created)).json()).resolves.toEqual({ received: true, duplicate: true });
+      expect((await deliver(disputeEvent(
+        "charge.dispute.created",
+        "needs_response",
+        `evt_refund_first_${resolution}_created_retry`,
+      ))).status).toBe(200);
+
+      expect((await deliver(disputeEvent(
+        "charge.dispute.closed",
+        resolution,
+        `evt_refund_first_${resolution}_closed`,
+      ))).status).toBe(200);
+      expect((await deliver(disputeEvent(
+        "charge.dispute.created",
+        "needs_response",
+        `evt_refund_first_${resolution}_late_created`,
+      ))).status).toBe(200);
+
+      expect(await db.executor.selectFrom("ai_credit_checkout_claims")
+        .select(["dispute_status", "refunded_at", "reversed_microusd", "reversal_debt_microusd"])
+        .executeTakeFirst()).toEqual({
+        dispute_status: resolution,
+        refunded_at: "2026-08-31T10:00:00.000Z",
+        reversed_microusd: 5_000_000,
+        reversal_debt_microusd: 0,
+      });
+      await expect(repository.getFundingSummary(identity)).resolves.toMatchObject({ creditBalanceMicrousd: 0 });
+      expect(await db.executor.selectFrom("ai_funded_credit_restrictions").selectAll().executeTakeFirst())
+        .toMatchObject({ frozen: resolution === "lost", debt_microusd: 0 });
+      expect(await db.executor.selectFrom("ai_funded_credit_ledger").selectAll().execute()).toHaveLength(2);
+    },
+  );
 });
 
 function completedMetadata() {

--- a/tests/platform/stripe-billing.test.ts
+++ b/tests/platform/stripe-billing.test.ts
@@ -104,7 +104,7 @@ describe('platform/stripe-billing', () => {
     });
   });
 
-  it('creates a card-required native Stripe trial when trial days are present', async () => {
+  it('collects a trial payment method without restricting Stripe dynamic payment methods', async () => {
     const sessionsCreate = vi.fn().mockResolvedValue({ url: 'https://checkout.stripe.test/trial', id: 'cs_trial' });
     const client = createStripeBillingClient({
       secretKey: 'sk_test_123',
@@ -127,7 +127,6 @@ describe('platform/stripe-billing', () => {
     });
 
     expect(sessionsCreate).toHaveBeenCalledWith(expect.objectContaining({
-      payment_method_types: ['card'],
       payment_method_collection: 'always',
       subscription_data: expect.objectContaining({
         trial_period_days: 7,
@@ -136,6 +135,7 @@ describe('platform/stripe-billing', () => {
         },
       }),
     }), { idempotencyKey: 'attempt_trial' });
+    expect(sessionsCreate.mock.calls[0]?.[0]).not.toHaveProperty('payment_method_types');
   });
 
   it('binds an eligible preparation intent to an explicitly expiring checkout and subscription', async () => {
@@ -221,6 +221,51 @@ describe('platform/stripe-billing', () => {
       customer: 'cus_123',
       return_url: 'https://app.matrix-os.com/?billing=portal',
     });
+  });
+
+  it('creates one-time AI credit checkout with only server-written identity and package metadata', async () => {
+    const sessionsCreate = vi.fn().mockResolvedValue({
+      url: 'https://checkout.stripe.com/c/pay/cs_ai_5',
+      id: 'cs_ai_5',
+    });
+    const client = createStripeBillingClient({
+      secretKey: 'sk_test_123',
+      stripe: fakeStripe({ checkout: { sessions: { create: sessionsCreate } } }),
+    });
+
+    await expect(client.createAiCreditCheckoutSession({
+      clerkUserId: 'user_123',
+      requestId: '77f105df-6e24-4e13-a881-af9ce20d6a63',
+      machineId: 'machine_123',
+      runtimeSlot: 'primary',
+      packageId: 'usd_5',
+      priceId: 'price_ai_5',
+      amountMicrousd: 5_000_000,
+      automaticTax: false,
+      idempotencyKey: '77f105df-6e24-4e13-a881-af9ce20d6a63',
+      successUrl: 'https://app.matrix-os.com/?billing=success',
+      cancelUrl: 'https://app.matrix-os.com/?billing=canceled',
+    })).resolves.toEqual({ url: 'https://checkout.stripe.com/c/pay/cs_ai_5', id: 'cs_ai_5' });
+    expect(sessionsCreate).toHaveBeenCalledWith({
+      mode: 'payment',
+      integration_identifier: expect.stringMatching(/^matrix-ai-credit-[a-z]{8}$/),
+      client_reference_id: 'user_123',
+      line_items: [{ price: 'price_ai_5', quantity: 1 }],
+      success_url: 'https://app.matrix-os.com/?billing=success',
+      cancel_url: 'https://app.matrix-os.com/?billing=canceled',
+      automatic_tax: { enabled: false },
+      metadata: {
+        matrix_checkout_kind: 'ai_credit_addon',
+        matrix_owner_id: 'user_123',
+        matrix_machine_id: 'machine_123',
+        matrix_runtime_slot: 'primary',
+        matrix_ai_credit_package_id: 'usd_5',
+        matrix_ai_credit_request_id: '77f105df-6e24-4e13-a881-af9ce20d6a63',
+        matrix_ai_credit_price_id: 'price_ai_5',
+        matrix_ai_credit_microusd: '5000000',
+      },
+    }, { idempotencyKey: '77f105df-6e24-4e13-a881-af9ce20d6a63' });
+    expect(sessionsCreate.mock.calls[0]?.[0]).not.toHaveProperty('payment_method_types');
   });
 
   it('uses the newest mature Stripe API version allowed by package policy', () => {

--- a/tests/platform/stripe-billing.test.ts
+++ b/tests/platform/stripe-billing.test.ts
@@ -14,7 +14,7 @@ describe('platform/stripe-billing', () => {
     const client = createStripeBillingClient({ secretKey: 'sk_test_123', stripe });
 
     expect(client.apiTimeoutMs).toBe(MATRIX_STRIPE_API_TIMEOUT_MS);
-    await expect(client.createCheckoutSession({
+    const subscriptionInput = {
       clerkUserId: 'user_123',
       idempotencyKey: 'attempt_123',
       customerId: 'cus_123',
@@ -26,7 +26,10 @@ describe('platform/stripe-billing', () => {
       runtimeSlot: 'studio',
       successUrl: 'https://app.matrix-os.com/?checkout=success',
       cancelUrl: 'https://app.matrix-os.com/?billing=canceled',
-    })).resolves.toEqual({ url: 'https://checkout.stripe.test/session', id: 'cs_123' });
+    } as const;
+    await expect(client.createCheckoutSession(subscriptionInput))
+      .resolves.toEqual({ url: 'https://checkout.stripe.test/session', id: 'cs_123' });
+    await client.createCheckoutSession(subscriptionInput);
 
     expect(sessionsCreate).toHaveBeenCalledWith({
       mode: 'subscription',
@@ -57,23 +60,7 @@ describe('platform/stripe-billing', () => {
       },
     }, { idempotencyKey: 'attempt_123' });
     expect(sessionsCreate.mock.calls[0]?.[0]).not.toHaveProperty('payment_method_types');
-
-    await client.createCheckoutSession({
-      clerkUserId: 'user_123',
-      idempotencyKey: 'attempt_123',
-      customerId: 'cus_123',
-      priceId: 'price_builder_monthly',
-      mode: 'subscription',
-      automaticTax: true,
-      allowPromotionCodes: true,
-      regionSlug: 'region_nbg1',
-      runtimeSlot: 'studio',
-      successUrl: 'https://app.matrix-os.com/?checkout=success',
-      cancelUrl: 'https://app.matrix-os.com/?billing=canceled',
-    });
-    expect(sessionsCreate.mock.calls[1]?.[0].integration_identifier).toBe(
-      sessionsCreate.mock.calls[0]?.[0].integration_identifier,
-    );
+    expect(sessionsCreate.mock.calls[1]).toEqual(sessionsCreate.mock.calls[0]);
   });
 
   it('creates checkout sessions without customer-write permission when no customer exists yet', async () => {
@@ -233,7 +220,7 @@ describe('platform/stripe-billing', () => {
       stripe: fakeStripe({ checkout: { sessions: { create: sessionsCreate } } }),
     });
 
-    await expect(client.createAiCreditCheckoutSession({
+    const checkoutInput = {
       clerkUserId: 'user_123',
       requestId: '77f105df-6e24-4e13-a881-af9ce20d6a63',
       machineId: 'machine_123',
@@ -245,7 +232,10 @@ describe('platform/stripe-billing', () => {
       idempotencyKey: '77f105df-6e24-4e13-a881-af9ce20d6a63',
       successUrl: 'https://app.matrix-os.com/?billing=success',
       cancelUrl: 'https://app.matrix-os.com/?billing=canceled',
-    })).resolves.toEqual({ url: 'https://checkout.stripe.com/c/pay/cs_ai_5', id: 'cs_ai_5' });
+    } as const;
+    await expect(client.createAiCreditCheckoutSession(checkoutInput))
+      .resolves.toEqual({ url: 'https://checkout.stripe.com/c/pay/cs_ai_5', id: 'cs_ai_5' });
+    await client.createAiCreditCheckoutSession(checkoutInput);
     expect(sessionsCreate).toHaveBeenCalledWith({
       mode: 'payment',
       integration_identifier: expect.stringMatching(/^matrix-ai-credit-[a-z]{8}$/),
@@ -264,8 +254,21 @@ describe('platform/stripe-billing', () => {
         matrix_ai_credit_price_id: 'price_ai_5',
         matrix_ai_credit_microusd: '5000000',
       },
+      payment_intent_data: {
+        metadata: {
+          matrix_checkout_kind: 'ai_credit_addon',
+          matrix_owner_id: 'user_123',
+          matrix_machine_id: 'machine_123',
+          matrix_runtime_slot: 'primary',
+          matrix_ai_credit_package_id: 'usd_5',
+          matrix_ai_credit_request_id: '77f105df-6e24-4e13-a881-af9ce20d6a63',
+          matrix_ai_credit_price_id: 'price_ai_5',
+          matrix_ai_credit_microusd: '5000000',
+        },
+      },
     }, { idempotencyKey: '77f105df-6e24-4e13-a881-af9ce20d6a63' });
     expect(sessionsCreate.mock.calls[0]?.[0]).not.toHaveProperty('payment_method_types');
+    expect(sessionsCreate.mock.calls[1]).toEqual(sessionsCreate.mock.calls[0]);
   });
 
   it('uses the newest mature Stripe API version allowed by package policy', () => {

--- a/tests/shell/ai-credit-checkout.test.ts
+++ b/tests/shell/ai-credit-checkout.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  currentAiCreditRuntimeSlot,
+  openWebAiCreditCheckout,
+} from "../../shell/src/lib/ai-credit-checkout.js";
+
+afterEach(() => {
+  window.history.replaceState({}, "", "/");
+  vi.restoreAllMocks();
+});
+
+describe("web AI credit checkout", () => {
+  it("posts one package and request UUID for the active runtime, then navigates to HTTPS Stripe Checkout", async () => {
+    window.history.replaceState({}, "", "/vm/alice?runtime=studio");
+    const fetcher = vi.fn(async () => Response.json({
+      url: "https://checkout.stripe.com/c/pay/cs_ai_10",
+    }));
+    const navigate = vi.fn();
+
+    await openWebAiCreditCheckout({
+      packageId: "usd_10",
+      runtimeSlot: currentAiCreditRuntimeSlot(),
+      requestId: "77f105df-6e24-4e13-a881-af9ce20d6a63",
+      fetcher,
+      navigate,
+    });
+
+    expect(fetcher).toHaveBeenCalledWith("/billing/ai-credit/checkout", expect.objectContaining({
+      method: "POST",
+      credentials: "include",
+      signal: expect.any(AbortSignal),
+      body: JSON.stringify({
+        packageId: "usd_10",
+        runtimeSlot: "studio",
+        requestId: "77f105df-6e24-4e13-a881-af9ce20d6a63",
+      }),
+    }));
+    expect(navigate).toHaveBeenCalledWith("https://checkout.stripe.com/c/pay/cs_ai_10");
+  });
+
+  it("fails safely on oversized, malformed, non-HTTPS, and non-Stripe responses", async () => {
+    const cases = [
+      new Response("x".repeat(9_000), { headers: { "content-length": "9000" } }),
+      Response.json({ url: "not a url" }),
+      Response.json({ url: "http://checkout.stripe.com/c/pay/cs_bad" }),
+      Response.json({ url: "https://evil.example/steal" }),
+    ];
+    for (const response of cases) {
+      await expect(openWebAiCreditCheckout({
+        packageId: "usd_5",
+        requestId: crypto.randomUUID(),
+        fetcher: vi.fn(async () => response),
+        navigate: vi.fn(),
+      })).rejects.toMatchObject({ message: "Checkout is unavailable." });
+    }
+  });
+});

--- a/tests/ui/agents-providers-view.test.tsx
+++ b/tests/ui/agents-providers-view.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from "react";
 import "@testing-library/jest-dom/vitest";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   ProviderConnectionAttempt,
@@ -441,24 +441,51 @@ describe("AgentsProvidersView", () => {
     expect(onOpenBrowser).toHaveBeenCalledWith("/api/ai/providers/login-attempts/attempt_browser/authorize");
   });
 
-  it("controls gateway budget, model allowlist, refresh, and add-on credit", () => {
+  it("controls gateway budget and offers one shared, server-backed add-on package flow", async () => {
     const onRefresh = vi.fn();
-    const onAddCredit = vi.fn();
+    let finishCheckout!: () => void;
+    const onAddCredit = vi.fn(() => new Promise<void>((resolve) => { finishCheckout = resolve; }));
     const { onMutate } = setup({ onRefresh, onAddCredit });
 
     fireEvent.click(screen.getByRole("button", { name: "Refresh provider status" }));
     fireEvent.click(screen.getByRole("button", { name: "Add credit" }));
+    expect(screen.getByRole("dialog", { name: "Add Matrix AI credit" })).toBeVisible();
+    expect(screen.getByRole("radio", { name: "$5 credit" })).toBeChecked();
+    fireEvent.click(screen.getByRole("radio", { name: "$10 credit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue to checkout" }));
+    expect(screen.getByRole("button", { name: "Opening checkout…" })).toBeDisabled();
     fireEvent.change(screen.getByLabelText("Monthly budget in USD"), { target: { value: "2.5" } });
     fireEvent.click(screen.getByRole("button", { name: "Save budget" }));
     fireEvent.click(screen.getByRole("checkbox", { name: "Allow Claude Sonnet 5" }));
 
     expect(onRefresh).toHaveBeenCalledOnce();
-    expect(onAddCredit).toHaveBeenCalledWith("source_matrix");
+    expect(onAddCredit).toHaveBeenCalledWith(
+      "source_matrix",
+      "usd_10",
+      expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i),
+    );
     expect(onMutate).toHaveBeenCalledWith({ type: "set_gateway_budget", monthlyBudgetMicrousd: 2_500_000 });
     expect(onMutate).toHaveBeenCalledWith({
       type: "set_gateway_allowlist",
       allowedModelIds: ["anthropic/claude-opus-5", "anthropic/claude-sonnet-5"],
     });
+    finishCheckout();
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Add Matrix AI credit" })).toBeNull());
+  });
+
+  it("keeps checkout failures safe and retryable inside the shared dialog", async () => {
+    const onAddCredit = vi.fn().mockRejectedValue(new Error("postgresql://secret@db.internal"));
+    setup({ onAddCredit });
+    fireEvent.click(screen.getByRole("button", { name: "Add credit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue to checkout" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Checkout could not be opened. Try again.");
+    expect(screen.queryByText(/postgresql|secret|internal/i)).toBeNull();
+    expect(screen.getByRole("button", { name: "Continue to checkout" })).toBeEnabled();
+    const firstRequestId = onAddCredit.mock.calls[0]?.[2];
+    fireEvent.click(screen.getByRole("button", { name: "Continue to checkout" }));
+    await waitFor(() => expect(onAddCredit).toHaveBeenCalledTimes(2));
+    expect(onAddCredit.mock.calls[1]?.[2]).toBe(firstRequestId);
   });
 
   it("shows install, offline, busy, and read-only states without inventing an install capability", () => {


### PR DESCRIPTION
## Summary

- add server-owned $5/$10/$25 Stripe Checkout packages for Matrix AI credit
- derive owner, active machine, and runtime from Clerk/platform state; persist immutable, rate-limited checkout claims and retry-stable Stripe parameters
- grant paid credit exactly once in the signed webhook transaction, including async methods and tax-on-top totals
- reverse refunds/disputes atomically; consumed or reserved remainder becomes durable debt that freezes funded authorization until safely resolved
- expose one shared add-credit flow in Canvas, Web Desktop, and Electron

## Safety and invariants

- **Source of truth:** immutable Postgres checkout claims plus funded ledger/balance rows; the browser sends only package ID, runtime slot, and request UUID.
- **Atomicity:** webhook receipt, claim transition, grant/reversal, balance, debt, and restriction writes share one transaction.
- **Idempotency:** deterministic Stripe keys/identifiers, `ON CONFLICT` ledger writes, active-attempt reuse, and monotonic terminal dispute states.
- **Failure mode:** unpaid/expired/mismatched events never grant; refunds remove unspent credit and freeze any unrecoverable remainder.
- **Operations:** checkout stays disabled until all Prices, restricted key, webhook secret, and enable flag are configured; automatic tax additionally requires an explicit verified-registration flag.

## Validation

- 170 tests across nine affected platform/billing suites
- contracts, platform, gateway, UI, shell, and Electron TypeScript checks
- independent security/idempotency review with all findings closed
- included in the restacked top validation: 817 changed-surface tests; Electron production build passed
- `git diff --check`

Stack parent: #1460
