### PR TITLE
fix(chat): preserve composer defaults and explain send failures

### DIFF
--- a/desktop/src/main/coding-agents/runtime-summary-client.ts
+++ b/desktop/src/main/coding-agents/runtime-summary-client.ts
@@ -51,6 +51,11 @@ import {
 import { z } from "zod/v4";
 import type { AuthService } from "../auth/auth-service";
 import {
+  AppError,
+  classifyHttpStatus,
+  classifyTransportError,
+} from "../../shared/app-error";
+import {
   CodingAgentProjectWorkspaceRequestSchema,
   type CodingAgentProjectWorkspaceRequest,
 } from "../../shared/coding-agent-project-workspace";
@@ -273,28 +278,33 @@ export async function createCodingAgentThread(
 ): Promise<AgentThreadSnapshot> {
   const token = auth.getToken();
   if (!token) {
-    throw new Error("agent thread unavailable");
+    throw new AppError("unauthorized");
   }
 
   const url = buildRuntimeUrl(auth, "/api/coding-agents/threads");
-  const res = await fetchFn(url.toString(), {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(request),
-    signal: AbortSignal.timeout(THREAD_CREATE_TIMEOUT_MS),
-  });
+  let res: Response;
+  try {
+    res = await fetchFn(url.toString(), {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(request),
+      signal: AbortSignal.timeout(THREAD_CREATE_TIMEOUT_MS),
+    });
+  } catch (error: unknown) {
+    throw new AppError(classifyTransportError(error), { cause: error });
+  }
   if (!res.ok) {
-    throw new Error("agent thread unavailable");
+    throw new AppError(classifyHttpStatus(res.status));
   }
 
   const body = await res.json();
   const parsed = AgentThreadSnapshotSchema.safeParse(body);
   if (!parsed.success) {
-    throw new Error("agent thread unavailable");
+    throw new AppError("server");
   }
   return parsed.data;
 }

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -11,6 +11,7 @@ import type { CodingAgentProjectWorkspaceRequest } from "../../shared/coding-age
 import type { z } from "zod/v4";
 import { AgentThreadSnapshotSchema } from "@matrix-os/contracts";
 import { clampZoomFactor, DEFAULT_ZOOM_FACTOR } from "../platform/zoom";
+import { AppError, categoryMessage, type AppErrorCategory } from "../../shared/app-error";
 
 interface IpcMainLike {
   handle(
@@ -101,6 +102,33 @@ type Handler<C extends InvokeChannel> = (
 ) => Promise<InvokeResponse<C>> | InvokeResponse<C>;
 
 const PUBLIC_IPC_ERRORS = new Set(["invalid request", "internal error", "embed unavailable"]);
+
+const THREAD_CREATE_ERROR_CODES: Record<AppErrorCategory, string> = {
+  unauthorized: "thread_create_unauthorized",
+  offline: "thread_create_offline",
+  timeout: "thread_create_timeout",
+  notFound: "thread_create_not_found",
+  server: "thread_create_server",
+  misconfigured: "thread_create_misconfigured",
+  fatalSession: "thread_create_fatal_session",
+};
+
+function threadCreateFailure(error: unknown): InvokeResponse<"runtime:create-thread"> {
+  const category: AppErrorCategory = error instanceof AppError ? error.category : "server";
+  return {
+    ok: false,
+    error: {
+      code: THREAD_CREATE_ERROR_CODES[category],
+      safeMessage: categoryMessage(category),
+      retryable: category !== "unauthorized" && category !== "fatalSession",
+      recoveryActions: category === "unauthorized" || category === "fatalSession"
+        ? ["sign_in"]
+        : category === "misconfigured"
+          ? ["select_runtime"]
+          : ["retry"],
+    },
+  };
+}
 
 // The sender's webContents is the only zoom target; anything else (tests,
 // malformed events) degrades to a no-op instead of throwing.
@@ -212,7 +240,17 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
   });
   handle("runtime:submit-approval-decision", (request) => ctx.submitApprovalDecision(request));
   handle("runtime:submit-input-answer", (request) => ctx.submitInputAnswer(request));
-  handle("runtime:create-thread", (request) => ctx.createAgentThread(request));
+  handle("runtime:create-thread", async (request) => {
+    try {
+      return { ok: true, snapshot: await ctx.createAgentThread(request) };
+    } catch (error: unknown) {
+      console.warn(
+        "[ipc] runtime:create-thread failed:",
+        error instanceof AppError ? error.category : error instanceof Error ? error.name : "UnknownError",
+      );
+      return threadCreateFailure(error);
+    }
+  });
   handle("runtime:create-turn", (request) => ctx.createAgentTurn(request));
   handle("runtime:abort-thread", (request) => ctx.abortAgentThread(request));
 

--- a/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
@@ -28,6 +28,7 @@ import { DeleteConversationDialog } from "./DeleteConversationDialog";
 import { canonicalChatPresentation } from "./canonical-chat-presentation";
 import { canonicalChatInputParts, canonicalChatTitle } from "./canonical-chat-submission";
 import { createLegacyGlobalProviderCatalog } from "./canonical-composer-adapter";
+import { chatSendFailureMessage } from "./chat-send-error";
 import { failClosedProviderCatalog, useChatProviderCatalog } from "./chat-provider-catalog";
 import { searchGlobalChatResources } from "./chat-resource-search";
 import ConversationContextPicker from "./ConversationContextPicker";
@@ -119,6 +120,7 @@ export function CanonicalChatWorkspace({
   const [referenceTokens, setReferenceTokens] = useState<ComposerReferenceToken[]>([]);
   const [draftProjectId, setDraftProjectId] = useState<string | null>(projectId);
   const [uploadingAttachments, setUploadingAttachments] = useState(false);
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
   const [globalView, setGlobalView] = useState<"index" | "draft" | "conversation">(
     initialView ?? (initialChatId ? "conversation" : "index"),
   );
@@ -192,6 +194,7 @@ export function CanonicalChatWorkspace({
   useLayoutEffect(() => {
     submissionSequence.current += 1;
     setUploadingAttachments(false);
+    setSubmissionError(null);
   }, [client]);
 
   useEffect(() => {
@@ -268,8 +271,14 @@ export function CanonicalChatWorkspace({
       !selection
       || activeRun
       || uploadingAttachments
-      || (attachments.items.length > 0 && !supportsNativeFileAttachments(selectedInstance))
     ) return;
+    if (attachments.items.length > 0 && !supportsNativeFileAttachments(selectedInstance)) {
+      setSubmissionError(chatSendFailureMessage(
+        "The selected provider does not support file attachments.",
+      ));
+      return;
+    }
+    setSubmissionError(null);
     const runtimeGeneration = captureRuntimeGeneration();
     const sequence = ++submissionSequence.current;
     const isCurrentSubmission = () => (
@@ -279,7 +288,11 @@ export function CanonicalChatWorkspace({
     setUploadingAttachments(true);
     try {
       const uploaded = await attachments.uploadAll();
-      if (!uploaded.ok || !isCurrentSubmission()) return;
+      if (!isCurrentSubmission()) return;
+      if (!uploaded.ok) {
+        setSubmissionError(chatSendFailureMessage(uploaded.error));
+        return;
+      }
       const uploadedParts: CanonicalChatMessagePart[] = uploaded.attachments.flatMap((attachment) => (
         attachment.path
           ? [{
@@ -324,6 +337,7 @@ export function CanonicalChatWorkspace({
   };
 
   const startNewChat = () => {
+    setSubmissionError(null);
     controller.startNewChat();
     reportedChatId.current = null;
     onActiveChatChanged?.(null);
@@ -332,6 +346,7 @@ export function CanonicalChatWorkspace({
   };
 
   const selectChat = (chatId: string) => {
+    setSubmissionError(null);
     controller.selectChat(chatId);
     const selected = controller.items.find((item) => item.chat.id === chatId);
     reportedChatId.current = chatId;
@@ -511,9 +526,9 @@ export function CanonicalChatWorkspace({
         className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
         {...attachments.paneProps}
       >
-        {controller.error ? (
+        {submissionError || controller.error ? (
           <div role="alert" className={cn("mx-auto mt-3 w-[calc(100%-2.5rem)] rounded-lg border px-3 py-2 text-sm", CHAT_CONTENT_WIDTH_CLASS)} style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
-            {controller.error}
+            {submissionError ?? controller.error}
           </div>
         ) : null}
         {controller.detail && globalView === "conversation" ? (

--- a/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
@@ -28,10 +28,6 @@ import { DeleteConversationDialog } from "./DeleteConversationDialog";
 import { canonicalChatPresentation } from "./canonical-chat-presentation";
 import { canonicalChatInputParts, canonicalChatTitle } from "./canonical-chat-submission";
 import { createLegacyGlobalProviderCatalog } from "./canonical-composer-adapter";
-import {
-  createCanonicalComposerSelection,
-  type CanonicalComposerSelection,
-} from "./canonical-composer-state";
 import { failClosedProviderCatalog, useChatProviderCatalog } from "./chat-provider-catalog";
 import { searchGlobalChatResources } from "./chat-resource-search";
 import ConversationContextPicker from "./ConversationContextPicker";
@@ -43,25 +39,11 @@ import {
 } from "./SharedChatComposer";
 import { SharedChatSurface } from "./SharedChatSurface";
 import { useCanonicalChatRouteController } from "./use-canonical-chat-route-controller";
+import { useCanonicalComposerSelection } from "./use-canonical-composer-selection";
 import { useProviderSetup } from "./use-provider-setup";
 import { useCreateAppRequest } from "../../stores/create-app-request";
 
 const EMPTY_PROVIDER_SUMMARIES: AgentProviderSummary[] = [];
-
-function rememberedOptions(
-  catalog: CanonicalProviderCatalog,
-  selection: CanonicalComposerSelection,
-) {
-  const instance = catalog.instances.find((candidate) => candidate.id === selection.instanceId);
-  if (!instance) return [];
-  return selection.options.filter((selected) => {
-    const descriptor = instance.options.find((candidate) => candidate.id === selected.id);
-    if (!descriptor) return false;
-    if (descriptor.kind === "boolean") return typeof selected.value === "boolean";
-    return typeof selected.value === "string"
-      && descriptor.values?.some((candidate) => candidate.value === selected.value) === true;
-  });
-}
 
 function projectContext(
   projectId: string | undefined,
@@ -153,9 +135,14 @@ export function CanonicalChatWorkspace({
     refreshRuntimeSummary,
     api ?? null,
   );
-  const [selection, setSelection] = useState<CanonicalComposerSelection | null>(() => (
-    catalog ? createCanonicalComposerSelection(providerCatalog) : null
-  ));
+  const { selection, onSelectionChange } = useCanonicalComposerSelection({
+    catalog: providerCatalog,
+    catalogReady: Boolean(catalog || liveCatalog.status === "ready"),
+    initializeImmediately: Boolean(catalog),
+    chatId: controller.detail?.record.chat.id ?? null,
+    currentSelection: controller.detail?.record.chat.currentSelection,
+    boundInstanceId: controller.detail?.record.providerBinding?.instanceId,
+  });
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; title: string } | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -206,37 +193,6 @@ export function CanonicalChatWorkspace({
     submissionSequence.current += 1;
     setUploadingAttachments(false);
   }, [client]);
-
-  useEffect(() => {
-    setSelection((current) => {
-      if (!catalog && liveCatalog.status !== "ready") return null;
-      const boundInstance = controller.detail?.record.providerBinding?.instanceId;
-      const currentInstance = providerCatalog.instances.find((instance) => instance.id === current?.instanceId);
-      const requiredInstance = boundInstance
-        ? providerCatalog.instances.find((instance) => instance.id === boundInstance)
-        : currentInstance;
-      const next = requiredInstance
-        ? createCanonicalComposerSelection(providerCatalog, requiredInstance.id)
-        : createCanonicalComposerSelection(providerCatalog);
-      if (!next) return null;
-      const currentSelection = controller.detail?.record.chat.currentSelection;
-      const rememberedModel = currentSelection && currentSelection.instanceId === next.instanceId
-        ? requiredInstance?.models.find((model) => (
-            model.id === currentSelection.model && model.availability === "available"
-          ))
-        : undefined;
-      return currentSelection && rememberedModel
-        ? {
-            ...next,
-            model: currentSelection.model,
-            options: rememberedOptions(providerCatalog, {
-              ...next,
-              options: currentSelection.options ?? next.options,
-            }),
-          }
-        : next;
-    });
-  }, [catalog, controller.detail?.record.chat.currentSelection, controller.detail?.record.providerBinding, liveCatalog.status, providerCatalog]);
 
   useEffect(() => {
     const record = controller.detail?.record;
@@ -410,7 +366,7 @@ export function CanonicalChatWorkspace({
         ))}
         catalog={providerCatalog}
         selection={selection}
-        onSelectionChange={setSelection}
+        onSelectionChange={onSelectionChange}
         onProviderSetup={(instance, action) => void handleProviderSetup(instance, action)}
         instanceLocked={controller.detail?.record.providerBinding !== undefined}
         resources={resources}

--- a/desktop/src/renderer/src/features/chat/ChatTab.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatTab.tsx
@@ -15,6 +15,7 @@ import { AttachmentPreviewRow } from "./attachments/AttachmentPreviewRow";
 import { appendHermesAttachmentPaths } from "./attachments/local-attachment-controller";
 import { useConversationAttachments } from "./attachments/use-conversation-attachments";
 import { ChatStarterCards } from "./ChatStarterCards";
+import { chatSendFailureMessage } from "./chat-send-error";
 import {
   SharedChatComposer,
   type ComposerReferenceToken,
@@ -75,6 +76,7 @@ export function HermesPane({ active = true }: { active?: boolean } = {}) {
   const [draft, setDraft] = useState("");
   const [referenceTokens, setReferenceTokens] = useState<ComposerReferenceToken[]>([]);
   const [uploadingAttachments, setUploadingAttachments] = useState(false);
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const attachments = useConversationAttachments(sessionId);
   const projects = useBoard((state) => state.projects);
@@ -124,6 +126,10 @@ export function HermesPane({ active = true }: { active?: boolean } = {}) {
     void useProviderPreferences.getState().hydrate();
   }, []);
 
+  useEffect(() => {
+    setSubmissionError(null);
+  }, [sessionId]);
+
   const turns = hermesConversationPresentation(messages, status, activeRequestId);
   const copyText = useCallback(async (text: string) => {
     if (!navigator.clipboard?.writeText) throw new Error("ClipboardUnavailable");
@@ -149,7 +155,6 @@ export function HermesPane({ active = true }: { active?: boolean } = {}) {
     if (
       uploadingAttachments
       || !legacyGlobalSelectionExecutable(providerCatalog, canonicalSelection)
-      || (attachments.items.length > 0 && !supportsNativeAttachments)
       || !canSubmitChatDraft(
         draft,
         status,
@@ -158,11 +163,27 @@ export function HermesPane({ active = true }: { active?: boolean } = {}) {
         referenceTokens.length,
       )
     ) return;
+    if (attachments.items.length > 0 && !supportsNativeAttachments) {
+      setSubmissionError(chatSendFailureMessage(
+        "The selected provider does not support file attachments.",
+      ));
+      return;
+    }
+    setSubmissionError(null);
     setUploadingAttachments(true);
     try {
       const uploaded = await attachments.uploadAll();
-      if (!uploaded.ok) return;
-      send(appendHermesAttachmentPaths(submission.agentPrompt, uploaded.paths));
+      if (!uploaded.ok) {
+        setSubmissionError(chatSendFailureMessage(uploaded.error));
+        return;
+      }
+      const sent = send(appendHermesAttachmentPaths(submission.agentPrompt, uploaded.paths));
+      if (!sent) {
+        setSubmissionError(chatSendFailureMessage(
+          "Can't reach Matrix OS. Check your connection.",
+        ));
+        return;
+      }
       setDraft("");
       setReferenceTokens([]);
       attachments.clear();
@@ -240,7 +261,10 @@ export function HermesPane({ active = true }: { active?: boolean } = {}) {
             setCanonicalSelection(selection);
           }}
           onProviderSetup={(instance, action) => void handleProviderSetup(instance, action)}
-          onNewChat={newChat}
+          onNewChat={() => {
+            setSubmissionError(null);
+            newChat();
+          }}
           instanceLocked={providerInstanceLocked}
           resources={projects.map((project) => ({
             kind: "project" as const,
@@ -265,9 +289,10 @@ export function HermesPane({ active = true }: { active?: boolean } = {}) {
     </>
   );
 
-  const loadErrorBanner = loadError ? (
+  const visibleError = submissionError ?? loadError;
+  const errorBanner = visibleError ? (
     <div role="alert" className={cn("mx-auto mt-3 w-[calc(100%-2.5rem)] rounded-lg border px-3 py-2 text-sm", CHAT_CONTENT_WIDTH_CLASS)} style={{ borderColor: "var(--border-subtle)", color: "var(--text-secondary)" }}>
-      {loadError}
+      {visibleError}
     </div>
   ) : null;
 
@@ -277,7 +302,7 @@ export function HermesPane({ active = true }: { active?: boolean } = {}) {
       className="relative flex min-h-0 flex-1 flex-col overflow-hidden"
       {...attachments.paneProps}
     >
-      {loadErrorBanner}
+      {errorBanner}
       {empty ? (
         <div data-testid="chat-empty-content" className={cn("mx-auto flex min-h-0 w-full flex-1 flex-col justify-center gap-[26px] px-5 py-8", CHAT_CONTENT_WIDTH_CLASS)}>
           <div className="flex shrink-0 flex-col items-center gap-[26px] text-center">

--- a/desktop/src/renderer/src/features/chat/attachments/local-attachment-controller.ts
+++ b/desktop/src/renderer/src/features/chat/attachments/local-attachment-controller.ts
@@ -1,7 +1,7 @@
-import type { AgentAttachment } from "@matrix-os/contracts";
+import { MAX_AGENT_ATTACHMENT_BYTES, type AgentAttachment } from "@matrix-os/contracts";
 import type { ApiClient } from "../../../lib/api";
 
-export const MAX_ATTACHMENT_FILE_BYTES = 10 * 1024 * 1024;
+export const MAX_ATTACHMENT_FILE_BYTES = MAX_AGENT_ATTACHMENT_BYTES;
 const MAX_ATTACHMENTS = 8;
 const MAX_SUBSCRIBERS = 16;
 const MAX_CONCURRENT_UPLOADS = 3;

--- a/desktop/src/renderer/src/features/chat/attachments/local-attachment-controller.ts
+++ b/desktop/src/renderer/src/features/chat/attachments/local-attachment-controller.ts
@@ -1,5 +1,6 @@
 import { MAX_AGENT_ATTACHMENT_BYTES, type AgentAttachment } from "@matrix-os/contracts";
 import type { ApiClient } from "../../../lib/api";
+import { diagnosticErrorKind, toUserMessage } from "../../../lib/errors";
 
 export const MAX_ATTACHMENT_FILE_BYTES = MAX_AGENT_ATTACHMENT_BYTES;
 const MAX_ATTACHMENTS = 8;
@@ -32,7 +33,7 @@ export interface LocalAttachmentController {
   add(files: readonly File[]): void;
   remove(localId: string): void;
   retry(localId: string): Promise<void>;
-  uploadAll(): Promise<UploadedConversationAttachments | { ok: false }>;
+  uploadAll(): Promise<UploadedConversationAttachments | { ok: false; error: string }>;
   clear(): void;
   dispose(): void;
 }
@@ -96,7 +97,13 @@ export function createLocalAttachmentController(options: {
   };
 
   const uploadOne = async (item: InternalAttachment): Promise<boolean> => {
-    if (disposed || !options.api || item.file.size > MAX_ATTACHMENT_FILE_BYTES) return false;
+    if (disposed || item.file.size > MAX_ATTACHMENT_FILE_BYTES) return false;
+    if (!options.api) {
+      item.status = "failed";
+      item.error = "Attachment upload is unavailable because no Matrix computer is connected.";
+      emit();
+      return false;
+    }
     if (item.uploadedPath) return true;
     item.status = "uploading";
     item.error = undefined;
@@ -117,10 +124,10 @@ export function createLocalAttachmentController(options: {
       emit();
       return true;
     } catch (err: unknown) {
-      console.warn("[desktop attachments] upload failed:", err instanceof Error ? err.message : String(err));
+      console.warn("[desktop attachments] upload failed:", diagnosticErrorKind(err));
       if (!disposed && items.includes(item)) {
         item.status = "failed";
-        item.error = "Upload failed. Try again.";
+        item.error = `Attachment upload failed. ${toUserMessage(err)}`;
         emit();
       }
       return false;
@@ -168,7 +175,7 @@ export function createLocalAttachmentController(options: {
       await uploadOne(item);
     },
     async uploadAll() {
-      if (uploadInFlight) return { ok: false };
+      if (uploadInFlight) return { ok: false, error: "Attachment upload is already in progress." };
       uploadInFlight = true;
       const batch = [...items];
       try {
@@ -186,9 +193,18 @@ export function createLocalAttachmentController(options: {
         ));
         const batchStillCurrent = items.length === batch.length
           && batch.every((item, index) => items[index] === item);
-        if (disposed || !batchStillCurrent || batch.some((item) => !item.uploadedPath)) return { ok: false };
+        if (disposed) return { ok: false, error: "Attachment upload was interrupted. Try again." };
+        if (!batchStillCurrent) {
+          return { ok: false, error: "The attachment selection changed before upload completed. Try again." };
+        }
+        const failed = batch.find((item) => !item.uploadedPath);
+        if (failed) {
+          return { ok: false, error: failed.error ?? "Attachment upload failed. Try again." };
+        }
         const attachments = batch.map(attachmentReference);
-        if (attachments.some((attachment) => !attachment)) return { ok: false };
+        if (attachments.some((attachment) => !attachment)) {
+          return { ok: false, error: "An attachment could not be prepared for Chat. Remove it and try again." };
+        }
         return {
           ok: true,
           paths: batch.map((item) => item.uploadedPath!),

--- a/desktop/src/renderer/src/features/chat/canonical-chat-submit-error.ts
+++ b/desktop/src/renderer/src/features/chat/canonical-chat-submit-error.ts
@@ -1,0 +1,43 @@
+import type { CanonicalChatSafeError } from "@matrix-os/contracts";
+import { ZodError } from "zod/v4";
+import { AppError, categoryMessage } from "../../../../shared/app-error";
+import { chatSendFailureMessage } from "./chat-send-error";
+
+const CANONICAL_CHAT_SUBMIT_REASONS: Record<CanonicalChatSafeError["code"], string> = {
+  chat_not_found: "This Chat no longer exists. Start a new Chat.",
+  chat_busy: "This Chat already has an active response. Wait for it to finish or stop it.",
+  chat_conflict: "This Chat changed before the message was sent. Refresh and try again.",
+  chat_unavailable: "This Chat is temporarily unavailable. Try again.",
+  project_required: "Choose a Project before sending this message.",
+  project_unavailable: "The selected Project is unavailable. Choose another Project.",
+  provider_unavailable: "The selected provider is unavailable. Choose another provider or finish setup.",
+  provider_instance_locked: "This Chat is locked to another provider. Use that provider or start a new Chat.",
+  model_unavailable: "The selected model is unavailable. Choose another model.",
+  capability_mismatch: "The selected provider does not support one of the requested options or attachments.",
+  run_not_found: "The previous Run no longer exists. Refresh and try again.",
+  run_not_resumable: "The previous Run cannot be resumed. Start a new message.",
+  run_unavailable: "The agent Run is temporarily unavailable. Try again.",
+  history_window_required: "This Chat needs more recent history before it can continue. Refresh and try again.",
+  migration_in_progress: "This Chat is being upgraded. Wait a moment and try again.",
+  run_failed: "The agent Run failed before it could start. Try again.",
+  resource_unavailable: "One of the referenced files or resources is unavailable.",
+  authorization_failed: "You do not have permission to send this message.",
+  service_unavailable: "Chat service is temporarily unavailable. Try again.",
+};
+
+export function canonicalChatSubmitFailureReason(error: unknown): string {
+  if (error instanceof AppError) {
+    const reason = error.detail
+      ? CANONICAL_CHAT_SUBMIT_REASONS[error.detail as CanonicalChatSafeError["code"]]
+      : undefined;
+    return reason ?? categoryMessage(error.category);
+  }
+  if (error instanceof ZodError) {
+    return "The message or its attachments do not match the supported format.";
+  }
+  return categoryMessage("server");
+}
+
+export function canonicalChatSubmitFailureMessage(error: unknown): string {
+  return chatSendFailureMessage(canonicalChatSubmitFailureReason(error));
+}

--- a/desktop/src/renderer/src/features/chat/chat-send-error.ts
+++ b/desktop/src/renderer/src/features/chat/chat-send-error.ts
@@ -1,0 +1,3 @@
+export function chatSendFailureMessage(reason: string): string {
+  return `The message could not be sent. Reason: ${reason}`;
+}

--- a/desktop/src/renderer/src/features/chat/use-canonical-chat-route-controller.ts
+++ b/desktop/src/renderer/src/features/chat/use-canonical-chat-route-controller.ts
@@ -10,6 +10,7 @@ import type {
   CanonicalChatEventSource,
 } from "../../lib/canonical-chat-client";
 import { diagnosticErrorKind } from "../../lib/errors";
+import { canonicalChatSubmitFailureMessage } from "./canonical-chat-submit-error";
 import { canonicalChatRequestId } from "./canonical-chat-submission";
 
 export type CanonicalChatRouteStatus = "idle" | "loading" | "ready" | "error";
@@ -390,7 +391,7 @@ export function useCanonicalChatRouteController({
     } catch (error: unknown) {
       console.warn("[canonical-chat] submit failed:", diagnosticErrorKind(error));
       if (!isCurrentScope()) return null;
-      setError("The message could not be sent. Try again.");
+      setError(canonicalChatSubmitFailureMessage(error));
       return null;
     }
   }, [client, detail, projectId]);

--- a/desktop/src/renderer/src/features/chat/use-canonical-composer-selection.ts
+++ b/desktop/src/renderer/src/features/chat/use-canonical-composer-selection.ts
@@ -1,0 +1,105 @@
+import type { CanonicalChatSummary, CanonicalProviderCatalog } from "@matrix-os/contracts";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  applyCanonicalComposerPreference,
+  createCanonicalComposerSelection,
+  type CanonicalComposerSelection,
+} from "./canonical-composer-state";
+import { useProviderPreferences } from "../settings/provider-preferences";
+
+function rememberedOptions(
+  catalog: CanonicalProviderCatalog,
+  selection: CanonicalComposerSelection,
+) {
+  const instance = catalog.instances.find((candidate) => candidate.id === selection.instanceId);
+  if (!instance) return [];
+  return selection.options.filter((selected) => {
+    const descriptor = instance.options.find((candidate) => candidate.id === selected.id);
+    if (!descriptor) return false;
+    if (descriptor.kind === "boolean") return typeof selected.value === "boolean";
+    return typeof selected.value === "string"
+      && descriptor.values?.some((candidate) => candidate.value === selected.value) === true;
+  });
+}
+
+export function useCanonicalComposerSelection({
+  catalog,
+  catalogReady,
+  initializeImmediately,
+  chatId,
+  currentSelection,
+  boundInstanceId,
+}: {
+  catalog: CanonicalProviderCatalog;
+  catalogReady: boolean;
+  initializeImmediately: boolean;
+  chatId: string | null;
+  currentSelection?: CanonicalChatSummary["currentSelection"];
+  boundInstanceId?: string;
+}) {
+  const [selection, setSelection] = useState<CanonicalComposerSelection | null>(() => (
+    initializeImmediately ? createCanonicalComposerSelection(catalog) : null
+  ));
+  const providerPreferencesHydrated = useProviderPreferences((state) => state.hydrated);
+  const setComposerSelection = useProviderPreferences((state) => state.setComposerSelection);
+  const composerSelectionTouched = useRef(false);
+  const selectionChatId = useRef<string | null>(null);
+
+  useEffect(() => {
+    void useProviderPreferences.getState().hydrate();
+  }, []);
+
+  useEffect(() => {
+    const chatChanged = selectionChatId.current !== chatId;
+    if (chatChanged) {
+      selectionChatId.current = chatId;
+      composerSelectionTouched.current = false;
+    }
+    setSelection((current) => {
+      if (!catalogReady) return null;
+      const currentInstance = catalog.instances.find((instance) => instance.id === current?.instanceId);
+      const requiredInstance = boundInstanceId
+        ? catalog.instances.find((instance) => instance.id === boundInstanceId)
+        : currentInstance;
+      const next = requiredInstance
+        ? createCanonicalComposerSelection(catalog, requiredInstance.id)
+        : createCanonicalComposerSelection(catalog);
+      if (!next) return null;
+      const currentIsSupported = current && currentInstance
+        && currentInstance.models.some((model) => (
+          model.id === current.model && model.availability === "available"
+        ))
+        && currentInstance.supports.permissionModes.includes(current.permissionMode)
+        && rememberedOptions(catalog, current).length === current.options.length;
+      if (!chatChanged && composerSelectionTouched.current && currentIsSupported) return current;
+      const preferred = applyCanonicalComposerPreference(
+        catalog,
+        next,
+        useProviderPreferences.getState().composerSelections[next.instanceId],
+      );
+      const rememberedModel = currentSelection && currentSelection.instanceId === preferred.instanceId
+        ? requiredInstance?.models.find((model) => (
+            model.id === currentSelection.model && model.availability === "available"
+          ))
+        : undefined;
+      return currentSelection && rememberedModel
+        ? {
+            ...preferred,
+            model: currentSelection.model,
+            options: rememberedOptions(catalog, {
+              ...preferred,
+              options: currentSelection.options ?? preferred.options,
+            }),
+          }
+        : preferred;
+    });
+  }, [boundInstanceId, catalog, catalogReady, chatId, currentSelection, providerPreferencesHydrated]);
+
+  const onSelectionChange = useCallback((nextSelection: CanonicalComposerSelection) => {
+    composerSelectionTouched.current = true;
+    setComposerSelection(nextSelection);
+    setSelection(nextSelection);
+  }, [setComposerSelection]);
+
+  return { selection, onSelectionChange };
+}

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopModeControls.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopModeControls.tsx
@@ -1,6 +1,7 @@
 import AccountMenu from "../mission-control/AccountMenu";
 import RuntimeComputerMenu from "../runtime/RuntimeComputerMenu";
 import DesktopSupportButton from "../support/DesktopSupportButton";
+import DesktopUpdateButton from "../updates/DesktopUpdateButton";
 import { Search } from "../../lib/hugeicons";
 import { useUi } from "../../stores/ui";
 
@@ -22,6 +23,7 @@ export default function DesktopModeControls() {
       <div className="relative w-[156px]">
         <RuntimeComputerMenu collapsed={false} />
       </div>
+      <DesktopUpdateButton />
       <AccountMenu collapsed compact />
     </div>
   );

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopTaskbar.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopTaskbar.tsx
@@ -1,6 +1,5 @@
 import { LayoutGrid } from "@renderer/lib/hugeicons";
 import type { ReactNode } from "react";
-import DesktopUpdateButton from "../updates/DesktopUpdateButton";
 import type { DesktopSurface } from "../../stores/desktop-surfaces";
 import type { Tab } from "../../stores/tabs";
 import DesktopAppIcon from "./DesktopAppIcon";
@@ -161,7 +160,6 @@ export default function DesktopTaskbar({
           })}
         </div>
       </> : null}
-      <DesktopUpdateButton collapsed />
     </nav>
   );
 }

--- a/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
@@ -40,6 +40,8 @@ import {
   type CanonicalComposerSelection,
 } from "../chat/canonical-composer-state";
 import { failClosedProviderCatalog, useChatProviderCatalog } from "../chat/chat-provider-catalog";
+import { canonicalChatSubmitFailureMessage } from "../chat/canonical-chat-submit-error";
+import { chatSendFailureMessage } from "../chat/chat-send-error";
 import { useProviderSetup } from "../chat/use-provider-setup";
 import { capabilityEnabled } from "../coding-agents/capabilities";
 import { isTypeToStartInteractiveTarget } from "../coding-agents/type-to-start";
@@ -148,7 +150,7 @@ export function ProjectChatDraft({
   const [referenceTokens, setReferenceTokens] = useState<ComposerReferenceToken[]>([]);
   const [resolvingTarget, setResolvingTarget] = useState(false);
   const [canonicalSubmitting, setCanonicalSubmitting] = useState(false);
-  const [canonicalError, setCanonicalError] = useState<string | null>(null);
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
   const submitInFlightRef = useRef(false);
   const busy = submitting || resolvingTarget || canonicalSubmitting;
   // Local focus bumps (type-to-start, chip seeds) combine with the shared
@@ -292,14 +294,22 @@ export function ProjectChatDraft({
     const selectedInstance = projectCatalog.instances.find((instance) => (
       instance.id === canonicalSelection?.instanceId
     ));
-    if (attachments.items.length > 0 && !supportsNativeFileAttachments(selectedInstance)) return;
+    if (attachments.items.length > 0 && !supportsNativeFileAttachments(selectedInstance)) {
+      setSubmissionError(chatSendFailureMessage(
+        "The selected provider does not support file attachments.",
+      ));
+      return;
+    }
+    setSubmissionError(null);
     if (canonicalClient && canonicalSelection) {
       submitInFlightRef.current = true;
       setCanonicalSubmitting(true);
-      setCanonicalError(null);
       try {
         const uploaded = await attachments.uploadAll();
-        if (!uploaded.ok) return;
+        if (!uploaded.ok) {
+          setSubmissionError(chatSendFailureMessage(uploaded.error));
+          return;
+        }
         const started = await startCanonicalProjectChat({
           client: canonicalClient,
           projectId: canonicalProjectId,
@@ -321,7 +331,7 @@ export function ProjectChatDraft({
           "[project-chat] canonical first turn failed:",
           error instanceof Error ? error.name : "UnknownError",
         );
-        setCanonicalError("The message could not be sent. Try again.");
+        setSubmissionError(canonicalChatSubmitFailureMessage(error));
       } finally {
         submitInFlightRef.current = false;
         setCanonicalSubmitting(false);
@@ -354,7 +364,10 @@ export function ProjectChatDraft({
         setDraft({ ...effective, prompt: effectiveDraft.prompt });
       }
       const uploaded = await attachments.uploadAll();
-      if (!uploaded.ok) return;
+      if (!uploaded.ok) {
+        setSubmissionError(chatSendFailureMessage(uploaded.error));
+        return;
+      }
       const prompt = effective.prompt.trim() || "Please inspect the attached files.";
       const threadId = await createThread({
         ...effective,
@@ -362,6 +375,9 @@ export function ProjectChatDraft({
         ...(uploaded.attachments.length > 0 ? { attachments: uploaded.attachments } : {}),
       });
       if (!threadId) {
+        const reason = useCodingAgentWorkspace.getState().createError
+          ?? "Agent run could not be started. Try again.";
+        setSubmissionError(chatSendFailureMessage(reason));
         // Keep the prompt for retry; drop one-shot launch context (review
         // references, task targeting) exactly like the legacy form did.
         setDraft((current) => clearComposerLaunchContext(current));
@@ -406,8 +422,8 @@ export function ProjectChatDraft({
       ) : null}
       <div className={`shrink-0 ${presentation === "landing" ? "" : "px-6 pb-5"}`}>
         <div className={cn("@container/project-composer mx-auto w-full", presentation === "landing" ? "max-w-none" : CHAT_CONTENT_WIDTH_CLASS)} data-slot="draft-composer">
-          {canonicalError || createError ? (
-            <p className="mb-1 px-1 text-xs" style={{ color: "var(--danger)" }}>{canonicalError ?? createError}</p>
+          {submissionError || createError ? (
+            <p className="mb-1 px-1 text-xs" role="alert" style={{ color: "var(--danger)" }}>{submissionError ?? createError}</p>
           ) : null}
           {canCreate ? (
             <>

--- a/desktop/src/renderer/src/features/updates/DesktopUpdateButton.tsx
+++ b/desktop/src/renderer/src/features/updates/DesktopUpdateButton.tsx
@@ -1,11 +1,7 @@
 import { Download, LoaderCircle } from "@renderer/lib/hugeicons";
 import { useDesktopUpdate } from "../../stores/desktop-update";
 
-interface DesktopUpdateButtonProps {
-  collapsed: boolean;
-}
-
-export default function DesktopUpdateButton({ collapsed }: DesktopUpdateButtonProps) {
+export default function DesktopUpdateButton() {
   const snapshot = useDesktopUpdate((state) => state.snapshot);
   const installing = useDesktopUpdate((state) => state.installing);
   const install = useDesktopUpdate((state) => state.install);
@@ -13,19 +9,17 @@ export default function DesktopUpdateButton({ collapsed }: DesktopUpdateButtonPr
   if (snapshot.status !== "ready" || !snapshot.version) return null;
 
   const label = `Update Matrix OS to ${snapshot.version}`;
-  const button = (
+  return (
     <button
       type="button"
       aria-label={label}
       title={label}
       disabled={installing}
-      className="no-drag flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-white shadow-sm transition-[transform,filter] duration-150 hover:brightness-110 active:scale-[0.97] disabled:cursor-wait disabled:opacity-80"
+      className="no-drag flex size-6 shrink-0 items-center justify-center rounded-full text-white shadow-sm transition-[transform,filter] duration-150 hover:brightness-110 active:scale-[0.97] disabled:cursor-wait disabled:opacity-80"
       style={{ background: "var(--update-action)" }}
       onClick={() => void install()}
     >
-      {installing ? <LoaderCircle size={13} className="animate-spin" /> : <Download size={13} />}
+      {installing ? <LoaderCircle size={12} className="animate-spin" /> : <Download size={12} />}
     </button>
   );
-
-  return collapsed ? <div className="flex justify-center px-2 pt-1">{button}</div> : button;
 }

--- a/desktop/src/renderer/src/stores/coding-agent-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-workspace.ts
@@ -33,6 +33,7 @@ import {
 } from "./coding-agent/thread-model";
 import { createThreadSnapshotPoller } from "./coding-agent/thread-snapshot-poller";
 import { captureRuntimeGeneration, isCurrentRuntimeGeneration } from "./runtime-generation";
+import { diagnosticErrorKind } from "../lib/errors";
 
 type WorkspaceStatus = "idle" | "loading" | "ready" | "error";
 type ReviewStatus = "idle" | "loading" | "ready" | "error";
@@ -1004,8 +1005,13 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
     const runtimeGeneration = captureRuntimeGeneration();
     set({ createStatus: "submitting", createError: null });
     try {
-      const snapshot = await invoke("runtime:create-thread", built.request);
+      const result = await invoke("runtime:create-thread", built.request);
       if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
+      if (!result.ok) {
+        set({ createStatus: "idle", createError: result.error.safeMessage });
+        return null;
+      }
+      const snapshot = result.snapshot;
       const thread = snapshot.thread;
       set((state) => {
         const createdThreadHandles = [
@@ -1049,9 +1055,9 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
       });
       attachActiveThreadEventStream(snapshot);
       return thread.id;
-    } catch {
+    } catch (error: unknown) {
       if (!isCurrentRuntimeGeneration(runtimeGeneration)) return null;
-      console.warn("[coding-agents] thread create failed");
+      console.warn("[coding-agents] thread create failed:", diagnosticErrorKind(error));
       set({ createStatus: "idle", createError: "Agent run could not be started. Try again." });
       return null;
     }

--- a/desktop/src/renderer/src/stores/hermes-chat.ts
+++ b/desktop/src/renderer/src/stores/hermes-chat.ts
@@ -33,7 +33,6 @@ const CONVERSATION_INDEX_CAP = 100;
 const CONVERSATION_PREVIEW_CAP = 240;
 const CONVERSATION_TITLE_CAP = 80;
 const REPLAY_EVENT_CAP = 2_000;
-const DISCONNECTED_MESSAGE = "Can't reach Matrix OS. Check your connection.";
 const INDEX_ERROR_MESSAGE = "Conversations could not be loaded. Try again.";
 const LOAD_ERROR_MESSAGE = "Conversation could not be opened. Try again.";
 const DELETE_ERROR_MESSAGE = "Chat could not be deleted. Try again.";
@@ -182,7 +181,7 @@ interface HermesChatState {
   transcriptRevision: number;
   seenReplayEventIds: string[];
   providerInstanceLocked: boolean;
-  send: (text: string) => void;
+  send: (text: string) => boolean;
   abort: () => void;
   newChat: () => void;
   showIndex: () => void;
@@ -253,7 +252,7 @@ export const useHermesChat = create<HermesChatState>()((set, get) => ({
 
   send: (text) => {
     const trimmed = text.trim();
-    if (trimmed.length === 0 || get().status !== "idle") return;
+    if (trimmed.length === 0 || get().status !== "idle") return false;
     const requestId = nextId();
     const userMessage: ChatMessage = {
       id: nextId(),
@@ -262,28 +261,21 @@ export const useHermesChat = create<HermesChatState>()((set, get) => ({
       requestId,
       timestamp: Date.now(),
     };
-    set((state) => ({
-      messages: [...state.messages, userMessage].slice(-TRANSCRIPT_CAP),
-      status: "thinking",
-      activeRequestId: requestId,
-      transcriptRevision: state.transcriptRevision + 1,
-    }));
     const sent = sendKernelMessage({
       text: trimmed,
       requestId,
       ...(get().sessionId ? { sessionId: get().sessionId! } : {}),
     });
     if (!sent) {
-      set((state) => ({
-        messages: reduceChat(state.messages, {
-          type: "kernel:error",
-          message: DISCONNECTED_MESSAGE,
-          requestId,
-        }).slice(-TRANSCRIPT_CAP),
-        status: "idle",
-        activeRequestId: null,
-      }));
+      return false;
     }
+    set((state) => ({
+      messages: [...state.messages, userMessage].slice(-TRANSCRIPT_CAP),
+      status: "thinking",
+      activeRequestId: requestId,
+      transcriptRevision: state.transcriptRevision + 1,
+    }));
+    return true;
   },
 
   abort: () => {

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -63,6 +63,10 @@ const CodingAgentCreateTurnResultSchema = z.discriminatedUnion("ok", [
   z.object({ ok: z.literal(true), response: CreateAgentTurnResponseSchema }).strict(),
   z.object({ ok: z.literal(false), error: CreateAgentTurnErrorSchema }).strict(),
 ]);
+const CodingAgentCreateThreadResultSchema = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true), snapshot: AgentThreadSnapshotSchema }).strict(),
+  z.object({ ok: z.literal(false), error: SafeClientErrorSchema }).strict(),
+]);
 const EmbedStateSchema = z.enum(["loading", "ready", "auth-required", "failed"]);
 const ReviewIdSchema = z.string().regex(/^rev_[A-Za-z0-9_-]{1,128}$/);
 
@@ -264,7 +268,7 @@ export const INVOKE_CHANNELS = {
   },
   "runtime:create-thread": {
     request: CreateAgentThreadRequestSchema,
-    response: AgentThreadSnapshotSchema,
+    response: CodingAgentCreateThreadResultSchema,
   },
   "runtime:create-turn": {
     request: CodingAgentCreateTurnRequestSchema,

--- a/packages/contracts/src/agent-thread-contracts.ts
+++ b/packages/contracts/src/agent-thread-contracts.ts
@@ -28,6 +28,8 @@ const AssistantTextDeltaSchema = z.string()
   .max(4_000)
   .refine((value) => byteLength(value) <= 16 * 1024, { message: "Text exceeds byte limit" });
 
+export const MAX_AGENT_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+
 export const AgentThreadStatusSchema = z.enum([
   "queued", "starting", "running", "waiting_for_approval", "waiting_for_input",
   "completed", "failed", "aborted", "stale", "archived",
@@ -43,7 +45,7 @@ export const AgentAttachmentSchema = z.object({
   label: SafeDisplayStringSchema,
   path: safeRelativePath().optional(),
   mimeType: z.string().min(1).max(120).regex(/^[A-Za-z0-9][A-Za-z0-9.+/-]+$/).optional(),
-  sizeBytes: z.number().int().min(0).max(5 * 1024 * 1024).optional(),
+  sizeBytes: z.number().int().min(0).max(MAX_AGENT_ATTACHMENT_BYTES).optional(),
 }).strict();
 
 export const AgentThreadSummarySchema = z.object({

--- a/packages/contracts/src/canonical-chat.ts
+++ b/packages/contracts/src/canonical-chat.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import { IsoTimestampSchema, ProviderModelReferenceSchema } from "#contract-primitives";
+import { MAX_AGENT_ATTACHMENT_BYTES } from "#agent-thread-contracts";
 import {
   CanonicalChatExecutionRootRefSchema,
   CanonicalProviderDriverKindSchema,
@@ -278,7 +279,7 @@ export const CanonicalChatMessagePartSchema = z.discriminatedUnion("type", [
     kind: CanonicalChatAttachmentKindSchema,
     label: canonicalSafeLabel(240, 960),
     mimeType: z.string().min(1).max(120).regex(/^[A-Za-z0-9][A-Za-z0-9.+/-]+$/).optional(),
-    sizeBytes: z.number().int().min(0).max(5 * 1024 * 1024).optional(),
+    sizeBytes: z.number().int().min(0).max(MAX_AGENT_ATTACHMENT_BYTES).optional(),
     ownerReference: canonicalOwnerRelativePath().optional(),
   }).strict(),
   z.object({

--- a/tests/contracts/canonical-chat.test.ts
+++ b/tests/contracts/canonical-chat.test.ts
@@ -596,7 +596,7 @@ describe("canonical Chat contracts", () => {
         attachmentId: "attachment_too_large",
         kind: "file",
         label: "large.bin",
-        sizeBytes: 5 * 1024 * 1024 + 1,
+        sizeBytes: 10 * 1024 * 1024 + 1,
       }],
     }).success).toBe(false);
 

--- a/tests/contracts/coding-agents.test.ts
+++ b/tests/contracts/coding-agents.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  AgentAttachmentSchema,
   AgentProviderSummarySchema,
   AgentThreadEventSchema,
   AgentThreadSnapshotSchema,
@@ -43,6 +44,25 @@ import {
 const now = "2026-07-06T12:00:00.000Z";
 
 describe("coding agent contracts", () => {
+  it("matches the Desktop 10 MiB attachment boundary", () => {
+    const attachment = {
+      id: "desktop_upload_contract",
+      kind: "file" as const,
+      label: "research.pdf",
+      path: "temporary/desktop-chat/research.pdf",
+      mimeType: "application/pdf",
+    };
+
+    expect(AgentAttachmentSchema.safeParse({
+      ...attachment,
+      sizeBytes: 10 * 1024 * 1024,
+    }).success).toBe(true);
+    expect(AgentAttachmentSchema.safeParse({
+      ...attachment,
+      sizeBytes: 10 * 1024 * 1024 + 1,
+    }).success).toBe(false);
+  });
+
   it("rejects unsafe identifiers and unsafe client error text", () => {
     expect(ThreadIdSchema.parse("thread_abc-123")).toBe("thread_abc-123");
     expect(() => ThreadIdSchema.parse("../thread_abc")).toThrow();

--- a/tests/desktop/canonical-chat-client.test.ts
+++ b/tests/desktop/canonical-chat-client.test.ts
@@ -278,6 +278,31 @@ describe("canonical Chat client", () => {
       { clientRequestId: "req_client_approval", decision: "approve_for_session" },
     );
   });
+
+  it("admits files accepted by the Desktop 10 MiB attachment picker", async () => {
+    const turnInput = {
+      clientRequestId: "req_client_attachment",
+      baseRevision: 0,
+      parts: [{
+        type: "attachment_reference" as const,
+        attachmentId: "desktop_upload_large_file",
+        kind: "file" as const,
+        label: "research.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 6 * 1024 * 1024,
+        ownerReference: "temporary/desktop-chat/large-research.pdf",
+      }],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+    };
+    const post = vi.fn(async () => admissionResponse(turnInput));
+    const client = createCanonicalChatClient(api({ post }));
+
+    await client.admitTurn(record.chat.id, turnInput);
+
+    expect(post).toHaveBeenCalledWith("/api/chats/chat_client_test/turns", turnInput);
+  });
 });
 
 const capabilitySnapshot = {

--- a/tests/desktop/canonical-chat-composer-preferences.test.tsx
+++ b/tests/desktop/canonical-chat-composer-preferences.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { CanonicalChatWorkspace } from "@desktop/renderer/src/features/chat/CanonicalChatWorkspace";
+import { useProviderPreferences } from "@desktop/renderer/src/features/settings/provider-preferences";
+import { useBoard } from "@desktop/renderer/src/stores/board";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+import {
+  createCanonicalChatWorkspaceClient as client,
+  providerCatalog,
+  snapshot,
+} from "./canonical-chat-workspace-test-utils";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Canonical Chat composer preferences", () => {
+  beforeAll(() => {
+    globalThis.ResizeObserver = class implements ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      takeRecords() { return []; }
+    };
+  });
+
+  beforeEach(() => {
+    useBoard.setState(useBoard.getInitialState(), true);
+    useConnection.setState(useConnection.getInitialState(), true);
+    useProviderPreferences.setState({
+      defaultProviderId: null,
+      composerSelections: {},
+      hydrated: true,
+    });
+    window.operator = {
+      invoke: vi.fn(async () => ({ ok: true })),
+      on: vi.fn(() => () => undefined),
+    };
+  });
+
+  afterEach(cleanup);
+
+  it("uses the last effort and permission choice as the default for a new Chat", async () => {
+    const preferenceCatalog = {
+      ...providerCatalog,
+      instances: providerCatalog.instances.map((instance) => ({
+        ...instance,
+        options: [{
+          id: "effort",
+          label: "Reasoning",
+          kind: "enum" as const,
+          values: [
+            { value: "low", label: "Low" },
+            { value: "high", label: "High" },
+          ],
+          defaultValue: "low",
+          placement: "composer" as const,
+        }],
+        defaultSelection: {
+          instanceId: instance.id,
+          model: instance.models[0]!.id,
+          options: [{ id: "effort", value: "low" }],
+        },
+      })),
+    };
+    render(
+      <CanonicalChatWorkspace
+        client={client()}
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        initialChatId={snapshot.chat.id}
+        initialView="conversation"
+        active
+        catalog={preferenceCatalog}
+      />,
+    );
+
+    await screen.findByRole("textbox", { name: "Reply to chat" });
+    fireEvent.click(screen.getByRole("button", { name: "Reasoning" }));
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "High" }));
+    fireEvent.click(screen.getByRole("button", { name: "Permission mode" }));
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "full access" }));
+
+    expect(useProviderPreferences.getState().composerSelections.codex_fixture).toEqual({
+      options: [{ id: "effort", value: "high" }],
+      permissionMode: "full_access",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose model and provider" }));
+    fireEvent.click(screen.getByRole("button", { name: "Start a new chat" }));
+
+    await screen.findByRole("textbox", { name: "Start a chat" });
+    expect(screen.getByRole("button", { name: "Reasoning" }).textContent).toContain("High");
+    expect(screen.getByRole("button", { name: "Permission mode" }).textContent).toContain("full access");
+  });
+});

--- a/tests/desktop/canonical-chat-route-controller.test.tsx
+++ b/tests/desktop/canonical-chat-route-controller.test.tsx
@@ -7,6 +7,7 @@ import type {
   CanonicalChatInvalidation,
 } from "@desktop/renderer/src/lib/canonical-chat-client";
 import { useCanonicalChatRouteController } from "@desktop/renderer/src/features/chat/use-canonical-chat-route-controller";
+import { AppError } from "@desktop/shared/app-error";
 import { describe, expect, it, vi } from "vitest";
 
 const globalRecord = {
@@ -1048,12 +1049,12 @@ describe("canonical Chat route controller", () => {
     expect(result.current.error).toBeNull();
   });
 
-  it("keeps the user error generic while recording a diagnostic category", async () => {
+  it("includes a safe failure reason while recording only the diagnostic category", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const failedClient = client({
       list: vi.fn(async () => ({ items: [] })),
       create: vi.fn(async () => globalRecord),
-      admitTurn: vi.fn(async () => { throw new TypeError("provider secret detail"); }),
+      admitTurn: vi.fn(async () => { throw new AppError("offline", { cause: new TypeError("provider secret detail") }); }),
     });
     const { result } = renderHook(() => useCanonicalChatRouteController({
       client: failedClient,
@@ -1072,9 +1073,12 @@ describe("canonical Chat route controller", () => {
       }, "Fail safely");
     });
 
-    expect(result.current.error).toBe("The message could not be sent. Try again.");
-    expect(warn).toHaveBeenCalledWith("[canonical-chat] submit failed:", "TypeError");
+    expect(result.current.error).toBe(
+      "The message could not be sent. Reason: Can't reach Matrix OS. Check your connection.",
+    );
+    expect(warn).toHaveBeenCalledWith("[canonical-chat] submit failed:", "offline");
     expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("provider secret detail"));
     warn.mockRestore();
   });
+
 });

--- a/tests/desktop/canonical-chat-submit-error.test.ts
+++ b/tests/desktop/canonical-chat-submit-error.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { AppError } from "@desktop/shared/app-error";
+import {
+  canonicalChatSubmitFailureMessage,
+  canonicalChatSubmitFailureReason,
+} from "@desktop/renderer/src/features/chat/canonical-chat-submit-error";
+
+describe("canonical Chat submit failures", () => {
+  it("translates allowlisted canonical error codes", () => {
+    expect(canonicalChatSubmitFailureMessage(
+      new AppError("server", { detail: "model_unavailable" }),
+    )).toBe(
+      "The message could not be sent. Reason: The selected model is unavailable. Choose another model.",
+    );
+  });
+
+  it("does not expose unknown server details", () => {
+    expect(canonicalChatSubmitFailureReason(
+      new AppError("server", { detail: "provider secret detail" }),
+    )).toBe("Something went wrong. Please try again.");
+  });
+});

--- a/tests/desktop/canonical-chat-workspace-send-errors.test.tsx
+++ b/tests/desktop/canonical-chat-workspace-send-errors.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CanonicalChatWorkspace } from "@desktop/renderer/src/features/chat/CanonicalChatWorkspace";
+import { useBoard } from "@desktop/renderer/src/stores/board";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+import { AppError } from "@desktop/shared/app-error";
+import {
+  createCanonicalChatWorkspaceClient as client,
+  providerCatalog,
+} from "./canonical-chat-workspace-test-utils";
+import { setSharedComposerText } from "./shared-chat-composer-test-utils";
+
+class WorkspaceResizeObserver implements ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() { return []; }
+}
+
+describe("CanonicalChatWorkspace send failures", () => {
+  beforeEach(() => {
+    globalThis.ResizeObserver = WorkspaceResizeObserver;
+    useBoard.setState(useBoard.getInitialState(), true);
+    useConnection.setState(useConnection.getInitialState(), true);
+    window.operator = {
+      invoke: vi.fn(async () => ({ ok: true })),
+      on: vi.fn(() => () => undefined),
+    };
+  });
+
+  afterEach(cleanup);
+
+  it("shows the safe attachment upload reason", async () => {
+    const api = {
+      putBytes: vi.fn(async () => { throw new AppError("offline"); }),
+    } as never;
+    const routeClient = client();
+    vi.mocked(routeClient.list).mockResolvedValue({ items: [] });
+    render(
+      <CanonicalChatWorkspace
+        api={api}
+        client={routeClient}
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        active
+        catalog={providerCatalog}
+      />,
+    );
+    await setSharedComposerText(
+      await screen.findByRole("textbox", { name: "Start a chat" }),
+      "Inspect this file",
+    );
+    fireEvent.change(screen.getByLabelText("Choose files"), {
+      target: { files: [new File(["notes"], "notes.txt", { type: "text/plain" })] },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect((await screen.findByRole("alert")).textContent).toBe(
+      "The message could not be sent. Reason: Attachment upload failed. Can't reach Matrix OS. Check your connection.",
+    );
+    expect(routeClient.create).not.toHaveBeenCalled();
+  });
+
+  it("explains when the selected provider cannot send files", async () => {
+    const routeClient = client();
+    vi.mocked(routeClient.list).mockResolvedValue({ items: [] });
+    const catalogWithoutAttachments = {
+      ...providerCatalog,
+      instances: providerCatalog.instances.map((instance) => ({
+        ...instance,
+        supports: { ...instance.supports, attachments: [] },
+      })),
+    };
+    render(
+      <CanonicalChatWorkspace
+        client={routeClient}
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        active
+        catalog={catalogWithoutAttachments}
+      />,
+    );
+    await setSharedComposerText(
+      await screen.findByRole("textbox", { name: "Start a chat" }),
+      "Inspect this file",
+    );
+    fireEvent.change(screen.getByLabelText("Choose files"), {
+      target: { files: [new File(["notes"], "notes.txt", { type: "text/plain" })] },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect((await screen.findByRole("alert")).textContent).toBe(
+      "The message could not be sent. Reason: The selected provider does not support file attachments.",
+    );
+    expect(routeClient.create).not.toHaveBeenCalled();
+  });
+});

--- a/tests/desktop/canonical-chat-workspace-test-utils.ts
+++ b/tests/desktop/canonical-chat-workspace-test-utils.ts
@@ -1,0 +1,44 @@
+import type { CanonicalChatClient } from "@desktop/renderer/src/lib/canonical-chat-client";
+import { createCanonicalChatFixture } from "../contracts/fixtures/canonical-chat";
+import { vi } from "vitest";
+
+export const { snapshot, providerCatalog } = createCanonicalChatFixture("completed");
+
+export const canonicalChatRecord = {
+  chat: {
+    id: snapshot.chat.id,
+    ownerScope: snapshot.chat.ownerScope,
+    title: snapshot.chat.title,
+    lifecycle: snapshot.chat.lifecycle,
+    attention: snapshot.chat.attention,
+    revision: snapshot.chat.revision,
+    messageCount: snapshot.chat.messageCount,
+    lastMessagePreview: snapshot.chat.lastMessagePreview,
+    currentSelection: snapshot.chat.currentSelection,
+    createdAt: snapshot.chat.createdAt,
+    updatedAt: snapshot.chat.updatedAt,
+  },
+  projectId: "matrix-os",
+  providerBinding: snapshot.chat.providerBinding,
+};
+
+export function createCanonicalChatWorkspaceClient(): CanonicalChatClient {
+  return {
+    list: vi.fn(async () => ({ items: [canonicalChatRecord] })),
+    search: vi.fn(async () => ({ items: [canonicalChatRecord] })),
+    getDetail: vi.fn(async () => ({
+      record: canonicalChatRecord,
+      messages: snapshot.messages,
+      turns: snapshot.turns,
+      runs: snapshot.runs,
+      activities: snapshot.activities,
+    })),
+    create: vi.fn(),
+    updateProject: vi.fn(),
+    delete: vi.fn(),
+    admitTurn: vi.fn(),
+    cancelRun: vi.fn(),
+    submitApproval: vi.fn(),
+    retryTurn: vi.fn(),
+  } as CanonicalChatClient;
+}

--- a/tests/desktop/canonical-chat-workspace.test.tsx
+++ b/tests/desktop/canonical-chat-workspace.test.tsx
@@ -2,16 +2,20 @@
 
 import React, { useState } from "react";
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import type { CanonicalChatClient } from "@desktop/renderer/src/lib/canonical-chat-client";
 import { CanonicalChatWorkspace } from "@desktop/renderer/src/features/chat/CanonicalChatWorkspace";
 import { useBoard } from "@desktop/renderer/src/stores/board";
 import { useConnection } from "@desktop/renderer/src/stores/connection";
 import { advanceRuntimeGeneration } from "@desktop/renderer/src/stores/runtime-generation";
 import { createCanonicalChatFixture } from "../contracts/fixtures/canonical-chat";
+import {
+  canonicalChatRecord as record,
+  createCanonicalChatWorkspaceClient as client,
+  providerCatalog,
+  snapshot,
+} from "./canonical-chat-workspace-test-utils";
 import { setSharedComposerText } from "./shared-chat-composer-test-utils";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { snapshot, providerCatalog } = createCanonicalChatFixture("completed");
 const resizeObserverCallbacks: ResizeObserverCallback[] = [];
 
 class WorkspaceResizeObserver implements ResizeObserver {
@@ -37,45 +41,6 @@ function resizeChatWorkspace(width: number) {
   }
 }
 
-const record = {
-  chat: {
-    id: snapshot.chat.id,
-    ownerScope: snapshot.chat.ownerScope,
-    title: snapshot.chat.title,
-    lifecycle: snapshot.chat.lifecycle,
-    attention: snapshot.chat.attention,
-    revision: snapshot.chat.revision,
-    messageCount: snapshot.chat.messageCount,
-    lastMessagePreview: snapshot.chat.lastMessagePreview,
-    currentSelection: snapshot.chat.currentSelection,
-    createdAt: snapshot.chat.createdAt,
-    updatedAt: snapshot.chat.updatedAt,
-  },
-  projectId: "matrix-os",
-  providerBinding: snapshot.chat.providerBinding,
-};
-
-function client(): CanonicalChatClient {
-  return {
-    list: vi.fn(async () => ({ items: [record] })),
-    search: vi.fn(async () => ({ items: [record] })),
-    getDetail: vi.fn(async () => ({
-      record,
-      messages: snapshot.messages,
-      turns: snapshot.turns,
-      runs: snapshot.runs,
-      activities: snapshot.activities,
-    })),
-    create: vi.fn(),
-    updateProject: vi.fn(),
-    delete: vi.fn(),
-    admitTurn: vi.fn(),
-    cancelRun: vi.fn(),
-    submitApproval: vi.fn(),
-    retryTurn: vi.fn(),
-  } as CanonicalChatClient;
-}
-
 describe("CanonicalChatWorkspace", () => {
   beforeAll(() => {
     globalThis.ResizeObserver = WorkspaceResizeObserver;
@@ -85,6 +50,10 @@ describe("CanonicalChatWorkspace", () => {
     resizeObserverCallbacks.length = 0;
     useBoard.setState(useBoard.getInitialState(), true);
     useConnection.setState(useConnection.getInitialState(), true);
+    window.operator = {
+      invoke: vi.fn(async () => ({ ok: true })),
+      on: vi.fn(() => () => undefined),
+    };
   });
 
   afterEach(cleanup);
@@ -1038,4 +1007,5 @@ describe("CanonicalChatWorkspace", () => {
       expect.objectContaining({ type: "resource_reference" }),
     ]));
   });
+
 });

--- a/tests/desktop/chat-tab-render.test.tsx
+++ b/tests/desktop/chat-tab-render.test.tsx
@@ -59,7 +59,7 @@ describe("ChatTab", () => {
       loadStatus: "idle",
       loadError: null,
       loadingConversationId: null,
-      send: vi.fn(),
+      send: vi.fn(() => true),
       abort: vi.fn(),
     });
     useThreads.setState({ threads: [], activeThreadId: null });
@@ -419,7 +419,7 @@ describe("ChatTab", () => {
   });
 
   it("renders the approved centered empty state and only working composer controls", () => {
-    useHermesChat.setState({ messages: [], status: "idle", send: vi.fn(), abort: vi.fn() });
+    useHermesChat.setState({ messages: [], status: "idle", send: vi.fn(() => true), abort: vi.fn() });
     render(<ChatTab />);
 
     expect(screen.getByRole("heading", { name: "What should we build today?" })).toBeTruthy();
@@ -444,7 +444,7 @@ describe("ChatTab", () => {
   });
 
   it("seeds the shared composer from a Figma starter card", async () => {
-    useHermesChat.setState({ messages: [], status: "idle", send: vi.fn(), abort: vi.fn() });
+    useHermesChat.setState({ messages: [], status: "idle", send: vi.fn(() => true), abort: vi.fn() });
     render(<ChatTab />);
 
     fireEvent.click(screen.getByRole("button", { name: "Review code and suggest changes" }));
@@ -469,7 +469,7 @@ describe("ChatTab", () => {
   });
 
   it("adds files from the visible attachment control", async () => {
-    useHermesChat.setState({ messages: [], status: "idle", send: vi.fn(), abort: vi.fn() });
+    useHermesChat.setState({ messages: [], status: "idle", send: vi.fn(() => true), abort: vi.fn() });
     render(<ChatTab />);
 
     const picker = screen.getByLabelText("Choose files") as HTMLInputElement;
@@ -522,7 +522,7 @@ describe("ChatTab", () => {
   });
 
   it("previews pasted files horizontally, uploads on Send, and sends Hermes readable paths", async () => {
-    const send = vi.fn();
+    const send = vi.fn(() => true);
     const putBytes = vi.fn(async (path: string, file: File) => ({
       ok: true,
       path: decodeURIComponent(path.split("path=")[1] ?? ""),
@@ -551,7 +551,7 @@ describe("ChatTab", () => {
   });
 
   it("promotes a Hermes conversation only after the user sends a message", async () => {
-    const send = vi.fn();
+    const send = vi.fn(() => true);
     useHermesChat.setState({
       messages: [],
       sessionId: "conversation-active",
@@ -571,7 +571,7 @@ describe("ChatTab", () => {
   });
 
   it("sends Global Chat skill and project tokens as agent-readable prompt context", async () => {
-    const send = vi.fn();
+    const send = vi.fn(() => true);
     const catalog = createLegacyGlobalProviderCatalog({ hasProject: true });
     const availableCatalog = {
       ...catalog,
@@ -766,7 +766,7 @@ describe("ChatTab", () => {
   });
 
   it("does not intercept a text-only drop in Chat", () => {
-    useHermesChat.setState({ messages: [], status: "idle", send: vi.fn(), abort: vi.fn() });
+    useHermesChat.setState({ messages: [], status: "idle", send: vi.fn(() => true), abort: vi.fn() });
     render(<ChatTab />);
 
     const pane = screen.getByRole("region", { name: "Hermes conversation" });
@@ -778,20 +778,6 @@ describe("ChatTab", () => {
 
     expect(drop.defaultPrevented).toBe(false);
     expect(screen.queryByRole("group", { name: "Attachments" })).toBeNull();
-  });
-
-  it("retains a failed Chat preview instead of sending", async () => {
-    const send = vi.fn();
-    useHermesChat.setState({ messages: [], status: "idle", send, abort: vi.fn() });
-    useConnection.setState({ api: { putBytes: vi.fn().mockRejectedValue(new Error("offline")) } as never });
-    render(<ChatTab />);
-    const pane = screen.getByRole("region", { name: "Hermes conversation" });
-    fireEvent.drop(pane, { dataTransfer: { files: [new File(["x"], "notes.txt", { type: "text/plain" })] } });
-    fireEvent.click(await screen.findByRole("button", { name: "Send" }));
-
-    expect(await screen.findByText("Upload failed. Try again.")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Retry notes.txt" })).toBeTruthy();
-    expect(send).not.toHaveBeenCalled();
   });
 
   it("renders the persistent Hermes index newest-first with bounded metadata", () => {

--- a/tests/desktop/chat-tab-send-errors.test.tsx
+++ b/tests/desktop/chat-tab-send-errors.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ChatTab from "@desktop/renderer/src/features/chat/ChatTab";
+import { useProviderPreferences } from "@desktop/renderer/src/features/settings/provider-preferences";
+import { useBoard } from "@desktop/renderer/src/stores/board";
+import { useCodingAgentWorkspace } from "@desktop/renderer/src/stores/coding-agent-workspace";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+import { useHermesChat } from "@desktop/renderer/src/stores/hermes-chat";
+import { AppError } from "@desktop/shared/app-error";
+import { setSharedComposerText } from "./shared-chat-composer-test-utils";
+
+describe("ChatTab send failures", () => {
+  beforeEach(() => {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as typeof ResizeObserver;
+    useBoard.setState({ projects: [{ slug: "matrix-os", name: "Matrix OS" }] });
+    useHermesChat.setState(useHermesChat.getInitialState(), true);
+    useHermesChat.setState({ messages: [], status: "idle", view: "conversation" });
+    useCodingAgentWorkspace.setState(useCodingAgentWorkspace.getInitialState(), true);
+    useCodingAgentWorkspace.setState({ summary: { providers: [] } as never, status: "ready" });
+    useProviderPreferences.setState({ defaultProviderId: null, composerSelections: {}, hydrated: true });
+    useConnection.setState({
+      status: "signed-in",
+      handle: "operator",
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+      authGeneration: 1,
+      api: null,
+    });
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: {
+        invoke: vi.fn(async (channel: string) => {
+          if (channel === "state:get") return { value: null };
+          if (channel === "state:set") return { ok: true };
+          throw new Error(`unexpected channel ${channel}`);
+        }),
+        on: vi.fn(() => () => undefined),
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("retains a failed attachment preview and shows the upload reason", async () => {
+    const send = vi.fn(() => true);
+    useHermesChat.setState({ send });
+    useConnection.setState({ api: { putBytes: vi.fn().mockRejectedValue(new AppError("offline")) } as never });
+    render(<ChatTab />);
+    const pane = screen.getByRole("region", { name: "Hermes conversation" });
+    fireEvent.drop(pane, {
+      dataTransfer: { files: [new File(["x"], "notes.txt", { type: "text/plain" })] },
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Send" }));
+
+    expect((await screen.findByRole("alert")).textContent).toBe(
+      "The message could not be sent. Reason: Attachment upload failed. Can't reach Matrix OS. Check your connection.",
+    );
+    expect(screen.getByRole("button", { name: "Retry notes.txt" })).toBeTruthy();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("keeps the draft and explains when Hermes rejects the send", async () => {
+    const send = vi.fn(() => false);
+    useHermesChat.setState({ send });
+    render(<ChatTab />);
+    const input = screen.getByRole("textbox", { name: "How can I help you today?" });
+    await setSharedComposerText(input, "Keep this draft");
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect((await screen.findByRole("alert")).textContent).toBe(
+      "The message could not be sent. Reason: Can't reach Matrix OS. Check your connection.",
+    );
+    expect(input.textContent).toBe("Keep this draft");
+  });
+});

--- a/tests/desktop/coding-agent-runtime-client.test.ts
+++ b/tests/desktop/coding-agent-runtime-client.test.ts
@@ -18,6 +18,7 @@ import {
   updateCodingAgentNotificationPreferences,
 } from "../../desktop/src/main/coding-agents/runtime-summary-client";
 import type { AuthService } from "../../desktop/src/main/auth/auth-service";
+import { AppError } from "../../desktop/src/shared/app-error";
 
 function auth(runtimeSlot = "primary"): AuthService {
   return {
@@ -281,6 +282,44 @@ describe("coding agent desktop runtime client", () => {
       "https://runtime.test/api/coding-agents/threads?runtime=secondary",
       expect.objectContaining({ method: "POST" }),
     );
+  });
+
+  it("classifies thread creation transport failures without exposing raw details", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(
+      new TypeError("fetch failed for https://private-runtime.test with token secret"),
+    );
+
+    const rejection = createCodingAgentThread(auth(), {
+      providerId: "codex",
+      prompt: "Run the focused tests.",
+      clientRequestId: "req_desktop_thread_create",
+    }, fetchFn);
+
+    await expect(rejection).rejects.toMatchObject({
+      name: "AppError",
+      category: "offline",
+      message: "Can't reach Matrix OS. Check your connection.",
+    });
+    await expect(rejection).rejects.not.toThrow(/private-runtime|token secret/i);
+  });
+
+  it("classifies unauthorized thread creation responses for the IPC boundary", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(null, { status: 401 }));
+
+    try {
+      await createCodingAgentThread(auth(), {
+        providerId: "codex",
+        prompt: "Run the focused tests.",
+        clientRequestId: "req_desktop_thread_create",
+      }, fetchFn);
+      throw new Error("expected createCodingAgentThread to reject");
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(AppError);
+      expect(error).toMatchObject({
+        category: "unauthorized",
+        message: "Your session has expired. Please sign in again.",
+      });
+    }
   });
 
   it("creates same-thread turns against the selected runtime without exposing credentials", async () => {

--- a/tests/desktop/coding-agent-workspace.test.tsx
+++ b/tests/desktop/coding-agent-workspace.test.tsx
@@ -394,6 +394,10 @@ function threadSnapshotFixture() {
   };
 }
 
+function threadCreateSuccess<T>(snapshot: T) {
+  return { ok: true as const, snapshot };
+}
+
 function reviewReadyThreadSnapshotFixture() {
   const base = threadSnapshotFixture();
   return {
@@ -3152,7 +3156,7 @@ describe("ProjectChatsView", () => {
       if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
       if (channel === "runtime:get-review-snapshot") return Promise.resolve(reviewSnapshotFixture());
       if (channel === "runtime:create-thread") {
-        return Promise.resolve({
+        return Promise.resolve(threadCreateSuccess({
           thread: {
             id: "thread_review_followup",
             providerId: "codex",
@@ -3167,7 +3171,7 @@ describe("ProjectChatsView", () => {
             hasMore: false,
             limit: 200,
           },
-        });
+        }));
       }
       return Promise.reject(new Error("unexpected channel"));
     });
@@ -3340,7 +3344,7 @@ describe("ProjectChatsView", () => {
       if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
       if (channel === "runtime:get-review-snapshot") return Promise.resolve(reviewSnapshotFixture());
       if (channel === "runtime:create-thread") {
-        return Promise.resolve({
+        return Promise.resolve(threadCreateSuccess({
           thread: {
             id: "thread_review_followup",
             providerId: "codex",
@@ -3355,7 +3359,7 @@ describe("ProjectChatsView", () => {
             hasMore: false,
             limit: 200,
           },
-        });
+        }));
       }
       return Promise.reject(new Error("unexpected channel"));
     });
@@ -3405,7 +3409,7 @@ describe("ProjectChatsView", () => {
             rejectFirstCreate = reject;
           });
         }
-        return Promise.resolve({
+        return Promise.resolve(threadCreateSuccess({
           thread: {
             id: "thread_unrelated_after_failure",
             providerId: "codex",
@@ -3420,7 +3424,7 @@ describe("ProjectChatsView", () => {
             hasMore: false,
             limit: 200,
           },
-        });
+        }));
       }
       return Promise.reject(new Error("unexpected channel"));
     });
@@ -3744,7 +3748,7 @@ describe("ProjectChatsView", () => {
       if (channel === "runtime:get-summary") return Promise.resolve(summaryFixture({ threadCreate: true }));
       if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
       if (channel === "runtime:create-thread") {
-        return Promise.resolve({
+        return Promise.resolve(threadCreateSuccess({
           thread: {
             id: "thread_desktop_1",
             providerId: "codex",
@@ -3759,7 +3763,7 @@ describe("ProjectChatsView", () => {
             hasMore: false,
             limit: 200,
           },
-        });
+        }));
       }
       return Promise.reject(new Error("unexpected channel"));
     });
@@ -3815,7 +3819,7 @@ describe("ProjectChatsView", () => {
       },
     };
     window.operator.invoke = vi.fn((channel: string) => {
-      if (channel === "runtime:create-thread") return Promise.resolve(runningSnapshot);
+      if (channel === "runtime:create-thread") return Promise.resolve(threadCreateSuccess(runningSnapshot));
       if (channel === "runtime:subscribe-thread-events") return Promise.resolve({ ok: true });
       if (channel === "runtime:get-thread-snapshot") return Promise.resolve(completedSnapshot);
       if (channel === "runtime:unsubscribe-thread-events") return Promise.resolve({ ok: true });
@@ -3844,7 +3848,7 @@ describe("ProjectChatsView", () => {
       if (channel === "runtime:get-summary") return Promise.resolve(summary);
       if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
       if (channel === "runtime:create-thread") {
-        return Promise.resolve({
+        return Promise.resolve(threadCreateSuccess({
           thread: {
             id: "thread_created_handle",
             providerId: "codex",
@@ -3860,7 +3864,7 @@ describe("ProjectChatsView", () => {
             hasMore: false,
             limit: 200,
           },
-        });
+        }));
       }
       return Promise.reject(new Error("unexpected channel"));
     });
@@ -3919,7 +3923,7 @@ describe("ProjectChatsView", () => {
     window.operator.invoke = vi.fn((channel: string, payload?: unknown) => {
       if (channel === "runtime:get-summary") return Promise.resolve(summary);
       if (channel === "runtime:get-reviews") return Promise.resolve(reviewsFixture());
-      if (channel === "runtime:create-thread") return Promise.resolve(createdSnapshot);
+      if (channel === "runtime:create-thread") return Promise.resolve(threadCreateSuccess(createdSnapshot));
       if (channel === "runtime:get-thread-snapshot") {
         const threadId = (payload as { threadId?: string } | undefined)?.threadId;
         return Promise.resolve(threadId === "thread_created_handle" ? createdSnapshot : threadSnapshotFixture());
@@ -4041,7 +4045,7 @@ describe("ProjectChatsView", () => {
 
     await expect(second).resolves.toBeNull();
     expect(window.operator.invoke).toHaveBeenCalledTimes(1);
-    resolveCreate({
+    resolveCreate(threadCreateSuccess({
       thread: {
         id: "thread_duplicate_1",
         providerId: "codex",
@@ -4056,7 +4060,7 @@ describe("ProjectChatsView", () => {
         hasMore: false,
         limit: 200,
       },
-    });
+    }));
     await expect(first).resolves.toBe("thread_duplicate_1");
   });
 
@@ -4081,7 +4085,7 @@ describe("ProjectChatsView", () => {
 
     const pending = useCodingAgentWorkspace.getState().createThread(draft);
     reconcileDesktopRuntimeChange({ disposeRuntimeAttachments: vi.fn() });
-    resolveCreate({
+    resolveCreate(threadCreateSuccess({
       thread: {
         id: "thread_stale_1",
         providerId: "codex",
@@ -4096,7 +4100,7 @@ describe("ProjectChatsView", () => {
         hasMore: false,
         limit: 200,
       },
-    });
+    }));
 
     await expect(pending).resolves.toBeNull();
     expect(useCodingAgentWorkspace.getState().activeThreadId).toBeNull();

--- a/tests/desktop/conversation-hero.test.tsx
+++ b/tests/desktop/conversation-hero.test.tsx
@@ -94,17 +94,20 @@ function mockOperator({ withThreads = true, failFirstCreate = false }: {
       if (failFirstCreate && createCount === 1) throw new Error("provider failed");
       const draft = payload as { projectId?: string; prompt?: string };
       return {
-        thread: {
-          id: `thread_created_${createCount}`,
-          providerId: "codex",
-          title: draft.prompt ?? "Created chat",
-          status: "queued",
-          attention: "none",
-          projectId: draft.projectId,
-          createdAt: NOW,
-          updatedAt: NOW,
+        ok: true,
+        snapshot: {
+          thread: {
+            id: `thread_created_${createCount}`,
+            providerId: "codex",
+            title: draft.prompt ?? "Created chat",
+            status: "queued",
+            attention: "none",
+            projectId: draft.projectId,
+            createdAt: NOW,
+            updatedAt: NOW,
+          },
+          events: { items: [], hasMore: false, limit: 200 },
         },
-        events: { items: [], hasMore: false, limit: 200 },
       };
     }
     if (channel === "runtime:get-thread-snapshot") {

--- a/tests/desktop/desktop-mode-controls.test.tsx
+++ b/tests/desktop/desktop-mode-controls.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import DesktopModeControls from "@desktop/renderer/src/features/desktop-shell/DesktopModeControls";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+import { useDesktopUpdate } from "@desktop/renderer/src/stores/desktop-update";
+import { useTabs } from "@desktop/renderer/src/stores/tabs";
+import { useUi } from "@desktop/renderer/src/stores/ui";
+
+vi.mock("@desktop/renderer/src/features/runtime/RuntimeComputerMenu", () => ({
+  default: () => <button type="button">Main computer</button>,
+}));
+vi.mock("@desktop/renderer/src/features/support/DesktopSupportButton", () => ({
+  default: () => <button type="button">Support</button>,
+}));
+
+describe("Desktop mode controls", () => {
+  beforeEach(() => {
+    useConnection.setState(useConnection.getInitialState(), true);
+    useConnection.setState({ handle: "neo", displayName: "Neo", imageUrl: null });
+    useDesktopUpdate.setState({
+      snapshot: { status: "ready", version: "1.2.3", progress: 100 },
+      installing: false,
+    });
+    useTabs.setState(useTabs.getInitialState(), true);
+    useUi.setState(useUi.getInitialState(), true);
+    window.operator = {
+      invoke: vi.fn(async () => ({ ok: true })),
+      on: vi.fn(() => () => undefined),
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("places the ready Update control immediately left of the same-size account avatar", () => {
+    render(<DesktopModeControls />);
+
+    const labels = screen.getAllByRole("button").map((button) => (
+      button.getAttribute("aria-label") ?? button.textContent
+    ));
+    expect(labels).toEqual([
+      "Search",
+      "Support",
+      "Main computer",
+      "Update Matrix OS to 1.2.3",
+      "Open account menu",
+    ]);
+
+    const update = screen.getByRole("button", { name: "Update Matrix OS to 1.2.3" });
+    const avatar = screen.getByRole("button", { name: "Open account menu" }).querySelector("span");
+    expect(update.className).toContain("size-6");
+    expect(avatar?.className).toContain("size-6");
+  });
+});

--- a/tests/desktop/desktop-update-ui.test.tsx
+++ b/tests/desktop/desktop-update-ui.test.tsx
@@ -364,7 +364,7 @@ describe("desktop update experience", () => {
 
     const view = render(
       <Tooltip.Provider>
-        <DesktopUpdateButton collapsed={false} />
+        <DesktopUpdateButton />
       </Tooltip.Provider>,
     );
 
@@ -380,13 +380,13 @@ describe("desktop update experience", () => {
     useDesktopUpdate.setState({ snapshot: { status: "downloading", version: "1.2.4", progress: 99 } });
     render(
       <Tooltip.Provider>
-        <DesktopUpdateButton collapsed={false} />
+        <DesktopUpdateButton />
       </Tooltip.Provider>,
     );
     expect(screen.queryByRole("button", { name: /Update Matrix OS/ })).toBeNull();
   });
 
-  it("renders a compact icon-only update control in expanded and collapsed sidebars", () => {
+  it("renders a compact icon-only update control", () => {
     vi.stubGlobal("operator", { invoke: vi.fn(), on: vi.fn() });
     useDesktopUpdate.setState({
       snapshot: {
@@ -397,29 +397,16 @@ describe("desktop update experience", () => {
       },
     });
 
-    const view = render(
+    render(
       <Tooltip.Provider>
-        <DesktopUpdateButton collapsed={false} />
+        <DesktopUpdateButton />
       </Tooltip.Provider>,
     );
 
-    const expandedButton = screen.getByRole("button", {
+    const button = screen.getByRole("button", {
       name: "Update Matrix OS to 1.2.3",
     });
-    expect(expandedButton.getAttribute("title")).toBe("Update Matrix OS to 1.2.3");
-    expect(screen.queryByText("Update")).toBeNull();
-    expect(screen.queryByText("v1.2.3")).toBeNull();
-
-    view.rerender(
-      <Tooltip.Provider>
-        <DesktopUpdateButton collapsed />
-      </Tooltip.Provider>,
-    );
-
-    const collapsedButton = screen.getByRole("button", {
-      name: "Update Matrix OS to 1.2.3",
-    });
-    expect(collapsedButton.getAttribute("title")).toBe("Update Matrix OS to 1.2.3");
+    expect(button.getAttribute("title")).toBe("Update Matrix OS to 1.2.3");
     expect(screen.queryByText("Update")).toBeNull();
     expect(screen.queryByText("v1.2.3")).toBeNull();
   });

--- a/tests/desktop/draft-chat-send.test.tsx
+++ b/tests/desktop/draft-chat-send.test.tsx
@@ -108,8 +108,10 @@ function mockOperator({ createImpl, summary = summaryFixture() }: {
     }
     if (channel === "runtime:get-project-workspace") return workspaceFixture();
     if (channel === "runtime:create-thread") {
-      if (createImpl) return createImpl(payload);
-      return createdThreadSnapshot((payload as { prompt?: string }).prompt ?? "New chat");
+      const snapshot = createImpl
+        ? await createImpl(payload)
+        : createdThreadSnapshot((payload as { prompt?: string }).prompt ?? "New chat");
+      return { ok: true, snapshot };
     }
     if (channel === "runtime:get-thread-snapshot") {
       const { threadId } = payload as { threadId: string };

--- a/tests/desktop/hermes-chat.test.ts
+++ b/tests/desktop/hermes-chat.test.ts
@@ -68,18 +68,19 @@ describe("useHermesChat", () => {
   it("returns to idle and shows an error when the kernel socket is unavailable", () => {
     kernel.sendKernelMessage.mockReturnValue(false);
 
-    useHermesChat.getState().send("hello");
+    expect(useHermesChat.getState().send("hello")).toBe(false);
 
     expect(useHermesChat.getState().status).toBe("idle");
     expect(useHermesChat.getState().activeRequestId).toBeNull();
+    expect(useHermesChat.getState().messages).toEqual([]);
+    expect(useHermesChat.getState().providerInstanceLocked).toBe(false);
+  });
+
+  it("reports when the kernel accepted a message", () => {
+    expect(useHermesChat.getState().send("hello")).toBe(true);
     expect(useHermesChat.getState().messages).toEqual([
       expect.objectContaining({ role: "user", content: "hello" }),
-      expect.objectContaining({
-        role: "system",
-        content: "Can't reach Matrix OS. Check your connection.",
-      }),
     ]);
-    expect(useHermesChat.getState().providerInstanceLocked).toBe(false);
   });
 
   it("locks the provider only after the Gateway accepts the first Turn", () => {

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -177,19 +177,33 @@ describe("IPC contract", () => {
     ).toBe(false);
     expect(
       INVOKE_CHANNELS["runtime:create-thread"].response.safeParse({
-        thread: {
-          id: "thread_desktop_1",
-          providerId: "codex",
-          title: "Summarize the failing checks",
-          status: "queued",
-          attention: "none",
-          createdAt: "2026-07-06T00:00:00.000Z",
-          updatedAt: "2026-07-06T00:00:00.000Z",
+        ok: true,
+        snapshot: {
+          thread: {
+            id: "thread_desktop_1",
+            providerId: "codex",
+            title: "Summarize the failing checks",
+            status: "queued",
+            attention: "none",
+            createdAt: "2026-07-06T00:00:00.000Z",
+            updatedAt: "2026-07-06T00:00:00.000Z",
+          },
+          events: {
+            items: [],
+            hasMore: false,
+            limit: 200,
+          },
         },
-        events: {
-          items: [],
-          hasMore: false,
-          limit: 200,
+      }).success,
+    ).toBe(true);
+    expect(
+      INVOKE_CHANNELS["runtime:create-thread"].response.safeParse({
+        ok: false,
+        error: {
+          code: "thread_create_offline",
+          safeMessage: "Can't reach Matrix OS. Check your connection.",
+          retryable: true,
+          recoveryActions: ["retry"],
         },
       }).success,
     ).toBe(true);

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerIpcHandlers, type HandlerContext } from "../../desktop/src/main/ipc/handlers";
+import { AppError } from "../../desktop/src/shared/app-error";
 
 type IpcListener = (event: unknown, payload: unknown) => Promise<unknown> | unknown;
 
@@ -1081,30 +1082,56 @@ describe("registerIpcHandlers", () => {
       clientRequestId: "req_desktop_1",
     };
 
-    await expect(harness.invoke("runtime:create-thread", request)).resolves.toEqual(snapshot);
+    await expect(harness.invoke("runtime:create-thread", request)).resolves.toEqual({
+      ok: true,
+      snapshot,
+    });
     expect(createAgentThread).toHaveBeenCalledWith(request);
   });
 
-  it("maps agent thread create failures to a generic IPC error", async () => {
+  it("maps agent thread create failures to a safe typed IPC result", async () => {
     const createAgentThread = vi
       .fn()
       .mockRejectedValue(new Error("provider failed on /home/matrix/workspace with token secret"));
     const harness = makeHarness({ createAgentThread } as Partial<HandlerContext>);
 
-    await expect(
-      harness.invoke("runtime:create-thread", {
-        providerId: "codex",
-        prompt: "Summarize the failing checks",
-        clientRequestId: "req_desktop_1",
-      }),
-    ).rejects.toThrow("internal error");
-    await expect(
-      harness.invoke("runtime:create-thread", {
-        providerId: "codex",
-        prompt: "Summarize the failing checks",
-        clientRequestId: "req_desktop_1",
-      }),
-    ).rejects.not.toThrow("/home/matrix");
+    await expect(harness.invoke("runtime:create-thread", {
+      providerId: "codex",
+      prompt: "Summarize the failing checks",
+      clientRequestId: "req_desktop_1",
+    })).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "thread_create_server",
+        safeMessage: "Something went wrong. Please try again.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      },
+    });
+  });
+
+  it("preserves a safe offline reason across the agent thread IPC boundary", async () => {
+    const createAgentThread = vi.fn().mockRejectedValue(new AppError("offline", {
+      cause: new TypeError("fetch failed for https://private-runtime.test"),
+    }));
+    const harness = makeHarness({ createAgentThread } as Partial<HandlerContext>);
+
+    const result = await harness.invoke("runtime:create-thread", {
+      providerId: "codex",
+      prompt: "Summarize the failing checks",
+      clientRequestId: "req_desktop_1",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "thread_create_offline",
+        safeMessage: "Can't reach Matrix OS. Check your connection.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      },
+    });
+    expect(JSON.stringify(result)).not.toMatch(/private-runtime|provider/i);
   });
 
   it("creates same-thread turns through trusted-core IPC without exposing credentials", async () => {

--- a/tests/desktop/local-attachment-controller.test.ts
+++ b/tests/desktop/local-attachment-controller.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppError } from "@desktop/shared/app-error";
 import {
   appendHermesAttachmentPaths,
   createLocalAttachmentController,
@@ -165,7 +166,7 @@ describe("local Desktop attachment controller", () => {
   it("retains failed previews for Retry and reuses the stable destination", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const putBytes = vi.fn()
-      .mockRejectedValueOnce(new Error("offline"))
+      .mockRejectedValueOnce(new AppError("offline"))
       .mockResolvedValueOnce({ ok: true, path: "temporary/desktop-chat/stable_retry-retry.txt", size: 1 });
     const controller = createLocalAttachmentController({
       api: { putBytes } as never,
@@ -174,8 +175,14 @@ describe("local Desktop attachment controller", () => {
     controller.add([file("retry.txt", 1, "text/plain")]);
     const id = controller.getSnapshot()[0]!.localId;
 
-    await expect(controller.uploadAll()).resolves.toEqual({ ok: false });
-    expect(controller.getSnapshot()[0]).toMatchObject({ status: "failed", error: "Upload failed. Try again." });
+    await expect(controller.uploadAll()).resolves.toEqual({
+      ok: false,
+      error: "Attachment upload failed. Can't reach Matrix OS. Check your connection.",
+    });
+    expect(controller.getSnapshot()[0]).toMatchObject({
+      status: "failed",
+      error: "Attachment upload failed. Can't reach Matrix OS. Check your connection.",
+    });
     await controller.retry(id);
 
     expect(putBytes).toHaveBeenCalledTimes(2);

--- a/tests/desktop/project-chat-draft-send-errors.test.tsx
+++ b/tests/desktop/project-chat-draft-send-errors.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeSummary } from "@matrix-os/contracts";
+import { ProjectChatDraft } from "@desktop/renderer/src/features/project/ProjectChatDraft";
+import { useCodingAgentWorkspace } from "@desktop/renderer/src/stores/coding-agent-workspace";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+import { useProjectWorkspaces } from "@desktop/renderer/src/stores/project-workspaces";
+import { useProviderPreferences } from "@desktop/renderer/src/features/settings/provider-preferences";
+import { AppError } from "@desktop/shared/app-error";
+import { setSharedComposerText } from "./shared-chat-composer-test-utils";
+
+const catalogMock = vi.hoisted(() => ({ attachments: true }));
+vi.mock("@desktop/renderer/src/features/chat/chat-provider-catalog", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@desktop/renderer/src/features/chat/chat-provider-catalog")>();
+  return {
+    ...actual,
+    useChatProviderCatalog: (fallback: { instances: Array<{ supports: { attachments: string[] } }> }) => ({
+      catalog: catalogMock.attachments
+        ? fallback
+        : {
+            ...fallback,
+            instances: fallback.instances.map((instance) => ({
+              ...instance,
+              supports: { ...instance.supports, attachments: [] },
+            })),
+          },
+      status: "ready",
+    }),
+  };
+});
+
+const summary: RuntimeSummary = {
+  runtime: { id: "rt_primary", label: "Matrix", status: "available" },
+  capabilities: [{ id: "codingAgentsThreadCreate", enabled: true }],
+  providers: [{
+    id: "codex",
+    kind: "codex",
+    displayName: "Codex",
+    availability: "available",
+    installStatus: "installed",
+    authStatus: "authenticated",
+    supportedModes: ["default"],
+    defaultMode: "default",
+    setupActions: [],
+  }],
+  projects: { items: [], hasMore: false, limit: 20 },
+  activeThreads: { items: [], hasMore: false, limit: 20 },
+  attentionThreads: { items: [], hasMore: false, limit: 20 },
+  terminalSessions: { items: [], hasMore: false, limit: 20 },
+  previewSessions: { items: [], hasMore: false, limit: 20 },
+  recentActivity: { items: [], hasMore: false, limit: 20 },
+  limits: { maxPromptBytes: 16_384, maxAttachmentCount: 8, maxTerminalInputBytes: 8_192, maxListItems: 20 },
+  serverTime: "2026-08-31T00:00:00.000Z",
+};
+
+describe("ProjectChatDraft send failures", () => {
+  beforeEach(() => {
+    catalogMock.attachments = true;
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as typeof ResizeObserver;
+    useConnection.setState({ api: null });
+    useCodingAgentWorkspace.setState(useCodingAgentWorkspace.getInitialState(), true);
+    useProjectWorkspaces.setState({
+      resolveNewChatTarget: vi.fn(async () => ({ projectId: "matrix-os" })),
+    });
+    useProviderPreferences.setState({ composerSelections: {}, hydrated: true });
+    Object.defineProperty(window, "operator", {
+      configurable: true,
+      value: {
+        invoke: vi.fn(async (channel: string) => {
+          if (channel === "state:get") return { value: null };
+          if (channel === "state:set") return { ok: true };
+          throw new Error(`unexpected channel ${channel}`);
+        }),
+        on: vi.fn(() => () => undefined),
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shows the upload reason and keeps the draft for retry", async () => {
+    render(
+      <ProjectChatDraft
+        summary={summary}
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        active={false}
+        seed={null}
+        focusRequestId={0}
+        typeToStartEnabled={false}
+        onCreated={vi.fn()}
+        canonicalClient={{} as never}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Message new chat" });
+    await setSharedComposerText(input, "Inspect this file");
+    fireEvent.change(screen.getByLabelText("Choose files"), {
+      target: { files: [new File(["notes"], "notes.txt", { type: "text/plain" })] },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect((await screen.findByRole("alert")).textContent).toBe(
+      "The message could not be sent. Reason: Attachment upload is unavailable because no Matrix computer is connected.",
+    );
+    expect(input.textContent).toBe("Inspect this file");
+  });
+
+  it("explains when the selected provider cannot send files", async () => {
+    catalogMock.attachments = false;
+    render(
+      <ProjectChatDraft
+        summary={summary}
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        active={false}
+        seed={null}
+        focusRequestId={0}
+        typeToStartEnabled={false}
+        onCreated={vi.fn()}
+        canonicalClient={{} as never}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Message new chat" });
+    await setSharedComposerText(input, "Inspect this file");
+    fireEvent.change(screen.getByLabelText("Choose files"), {
+      target: { files: [new File(["notes"], "notes.txt", { type: "text/plain" })] },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect((await screen.findByRole("alert")).textContent).toBe(
+      "The message could not be sent. Reason: The selected provider does not support file attachments.",
+    );
+  });
+
+  it("translates a canonical admission failure into a safe reason", async () => {
+    const create = vi.fn(async () => { throw new AppError("server", { detail: "model_unavailable" }); });
+    render(
+      <ProjectChatDraft
+        summary={summary}
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        active={false}
+        seed={null}
+        focusRequestId={0}
+        typeToStartEnabled={false}
+        onCreated={vi.fn()}
+        canonicalClient={{ create } as never}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Message new chat" });
+    await setSharedComposerText(input, "Use this model");
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect((await screen.findByRole("alert")).textContent).toBe(
+      "The message could not be sent. Reason: The selected model is unavailable. Choose another model.",
+    );
+  });
+
+  it("shows the safe reason from the wired legacy thread creation path", async () => {
+    useCodingAgentWorkspace.setState({ summary });
+    window.operator.invoke = vi.fn(async (channel: string) => {
+      if (channel === "runtime:create-thread") return {
+        ok: false,
+        error: {
+          code: "thread_create_offline",
+          safeMessage: "Can't reach Matrix OS. Check your connection.",
+          retryable: true,
+          recoveryActions: ["retry"],
+        },
+      };
+      if (channel === "state:get") return { value: null };
+      if (channel === "state:set") return { ok: true };
+      throw new Error(`unexpected channel ${channel}`);
+    });
+    render(
+      <ProjectChatDraft
+        summary={summary}
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        active={false}
+        seed={null}
+        focusRequestId={0}
+        typeToStartEnabled={false}
+        onCreated={vi.fn()}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Message new chat" });
+    await setSharedComposerText(input, "Keep this draft");
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect((await screen.findByRole("alert")).textContent).toBe(
+      "The message could not be sent. Reason: Can't reach Matrix OS. Check your connection.",
+    );
+    expect(input.textContent).toBe("Keep this draft");
+  });
+});

--- a/tests/desktop/project-task-chat-flow.test.ts
+++ b/tests/desktop/project-task-chat-flow.test.ts
@@ -106,7 +106,7 @@ describe("project to task to chat flow", () => {
     const created = [snapshot("thread_one", "First chat"), snapshot("thread_two", "Second chat")];
     window.operator = {
       invoke: vi.fn(async (channel: string, request: unknown) => {
-        if (channel === "runtime:create-thread") return created.shift()!;
+        if (channel === "runtime:create-thread") return { ok: true, snapshot: created.shift()! };
         if (channel === "runtime:get-thread-snapshot") {
           return snapshot((request as { threadId: string }).threadId, "Reopened chat");
         }


### PR DESCRIPTION
## Summary
- move the ready Desktop Update action immediately left of the account avatar and match the 24 px avatar size
- persist each provider instance latest effort/options and permission mode, then use them as the default for a new canonical Chat
- keep one shared 10 MiB attachment boundary across Desktop admission and canonical request contracts; PR #1467 separately fixed exposing uploaded paths to providers and explicitly left size limits out of scope
- show a bounded safe failure reason in canonical Chat, Project Chat draft, and Hermes Chat while preserving failed drafts and attachment previews
- carry thread-create failures through a schema-validated discriminated Electron IPC result so transport/session categories survive the real main-to-renderer boundary without raw provider, path, token, or database detail

## Root cause
- canonical Chat recreated composer state from catalog defaults and did not consume the existing persisted provider preference store
- Desktop accepted files up to 10 MiB, while canonical and agent attachment schemas rejected files above 5 MiB
- the Update action lived in the taskbar and used a separate compact presentation
- send failures collapsed to generic copy, and thrown custom errors could not retain their type across Electron IPC

## Tests
- `flox activate -- bun run typecheck` — passed
- `flox activate -- bun run check:patterns` — 0 violations; 5 existing full-scan warning classes
- focused exact-head regression set — 411 passed across 22 files
- `flox activate -- bun run build:desktop` — passed
- Playwright exact-head renderer check — Update precedes Account and both measured 24 x 24 px
- `flox activate -- bun run test -- --reporter=dot` — 12,298 passed, 21 skipped, 18 failed in 6 untouched suites. The failures match the existing baseline and cover local-date behavior, CI workflow fixtures, macOS/Linux host-script portability, onboarding/tool-pack fixtures, and terminal install timeouts.

## Review
- exact review head: `66109bfd9`
- scope/spec review: no findings
- structured standards review: the prior real-IPC P1 is fixed; safe categories cross runtime -> main IPC -> validated contract -> renderer without raw details
- Greptile/CI will be rerun on this exact head before `ready-for-ci` is restored

## Large-file extraction plan
The touched 1000-2000 LOC test roots remain single-responsibility suites, but this bug-fix PR does not mix in a mechanical split. Follow-up extraction will keep assertion text unchanged and split by behavior:
- `tests/contracts/coding-agents.test.ts`: attachment and request-boundary contracts
- `tests/desktop/coding-agent-runtime-client.test.ts`: thread-create transport and HTTP classification
- `tests/desktop/ipc-contract.test.ts`: coding-agent IPC schemas
- `tests/desktop/ipc-handlers.test.ts`: coding-agent IPC handlers with a shared focused harness
- `tests/desktop/canonical-chat-route-controller.test.tsx`: submit/admission failure behavior

## Invariants

### Source of truth
- Desktop local state under `providerPreferences` remains the source of truth for the last per-provider composer options and permission mode.
- `MAX_AGENT_ATTACHMENT_BYTES` is the single source of truth for the 10 MiB attachment boundary shared by Desktop admission and request schemas.
- main-process `AppError` categories are mapped to fixed safe IPC codes/messages before crossing into the renderer.

### Lock/transaction scope
- No database writes, locks, transactions, or new external network calls are introduced.
- Preference updates are bounded local-state writes through the existing validated Desktop IPC bridge.

### Acceptable orphan states
- A failed preference persistence write leaves the current in-memory selection active for the session and logs a safe diagnostic.
- Failed sends retain the draft and attachment previews for retry; no additional remote or filesystem attachment object is created by this change.

### Auth source of truth
- Existing Desktop trusted-core auth and canonical Chat authorization remain unchanged; this PR does not add an auth fallback.
- Unauthorized thread creation maps only to the fixed sign-in recovery result.

### Deferred scope
- PR #1467 owns uploaded-path exposure to providers; this PR owns the shared 10 MiB admission contract.
- Provider/model selection persistence beyond existing per-provider effort/options and permission choices is unchanged.
- The six unrelated full-suite baseline failures are not addressed in this PR.
- Public documentation is unchanged because this is a UI/runtime bug fix with no new public API.