### PR TITLE
fix(chat): tolerate bounded Hermes vision frames

### DIFF
--- a/desktop/src/renderer/src/features/chat/canonical-chat-presentation.ts
+++ b/desktop/src/renderer/src/features/chat/canonical-chat-presentation.ts
@@ -237,6 +237,43 @@ function isActiveRun(run: CanonicalChatRun | undefined): boolean {
   ].includes(run.status);
 }
 
+function selectedModelDisplayName(run: CanonicalChatRun): string {
+  const namespaceSeparator = run.selection.model.indexOf(":");
+  return namespaceSeparator >= 0
+    ? run.selection.model.slice(namespaceSeparator + 1)
+    : run.selection.model;
+}
+
+function activeModelStatus(run: CanonicalChatRun | undefined): ConversationWorkPresentation | undefined {
+  if (!run || !isActiveRun(run)) return undefined;
+  const model = selectedModelDisplayName(run);
+  const id = `${run.id}:selected-model`;
+  return {
+    kind: "activity-group",
+    id,
+    timestamp: Date.parse(run.startedAt ?? run.createdAt),
+    sequence: 0,
+    activities: [{
+      id,
+      kind: "phase",
+      state: "running",
+      label: "Working",
+      preview: `Current model: ${model}`,
+      previewKind: "text",
+    }],
+  };
+}
+
+function isDuplicateProviderModelStatus(
+  run: CanonicalChatRun,
+  activity: Extract<CanonicalChatRunActivity, { type: "agent.activity" }>,
+): boolean {
+  const expected = `Current model: ${selectedModelDisplayName(run)}`.toLowerCase();
+  return activity.kind === "phase"
+    && activity.label === "Working"
+    && [activity.summary, activity.preview].some((value) => value?.trim().toLowerCase() === expected);
+}
+
 function activityState(
   status:
     | Extract<CanonicalChatRunActivity, { type: "tool.progress" }>["status"]
@@ -336,6 +373,7 @@ function runPresentation(
       }
       setBounded(toolProgress, activity.toolCallId, activity, MAX_RUN_ACTIVITY_PROJECTIONS);
     } else if (activity.type === "agent.activity") {
+      if (isDuplicateProviderModelStatus(run, activity)) continue;
       if (!agentActivities.has(activity.activityId)) {
         activityOrder.push({
           type: "agent",
@@ -447,8 +485,12 @@ function runPresentation(
       }],
     });
   }
+  const active = isActiveRun(run);
+  const projectedActivityGroups = active
+    ? activityGroups.slice(0, MAX_RUN_ACTIVITY_PROJECTIONS - 1)
+    : activityGroups;
   const work: ConversationWorkPresentation[] = [
-    ...activityGroups,
+    ...projectedActivityGroups,
     ...requestOrder.flatMap((key) => {
       const request = requests.get(key);
       return request ? [request] : [];
@@ -456,7 +498,6 @@ function runPresentation(
   ];
   const failed = run.status === "failed" || run.outcome === "failed";
   const stopped = run.status === "aborted" || run.outcome === "aborted";
-  const active = isActiveRun(run);
   const streamedMessages = [...streamed.entries()].map(([messageId, value]) => ({
     kind: "message" as const,
     id: messageId,
@@ -517,7 +558,9 @@ export function canonicalChatPresentation(input: {
       || run?.outcome === "failed" || run?.outcome === "aborted";
     const finalMessage = terminalFailure || isActiveRun(run) ? undefined : assistantMessages.at(-1);
     const live = runPresentation(run, input.activities, Boolean(finalMessage), turn.id);
+    const modelStatus = activeModelStatus(run);
     const unsortedWork = [
+      ...(modelStatus ? [modelStatus] : []),
       ...assistantMessages.filter((message) => message.id !== finalMessage?.id).flatMap((message) => [
         ...messageWork(message),
         ...(messageText(message) ? [messagePresentation(message, "commentary")] : []),

--- a/desktop/src/renderer/src/features/chat/canonical-chat-presentation.ts
+++ b/desktop/src/renderer/src/features/chat/canonical-chat-presentation.ts
@@ -344,7 +344,11 @@ function runPresentation(
     });
   const uniqueRunActivities = new Map<string, CanonicalChatRunActivity>();
   for (const { activity } of ordered) {
-    setBounded(uniqueRunActivities, activity.id, activity, MAX_RUN_ACTIVITY_PROJECTIONS);
+    if (!uniqueRunActivities.has(activity.id) && uniqueRunActivities.size >= MAX_RUN_ACTIVITY_PROJECTIONS) {
+      const oldest = uniqueRunActivities.keys().next();
+      if (!oldest.done) uniqueRunActivities.delete(oldest.value);
+    }
+    uniqueRunActivities.set(activity.id, activity);
   }
   const runActivities = [...uniqueRunActivities.values()];
   const toolProgress = new Map<string, Extract<CanonicalChatRunActivity, { type: "tool.progress" }>>();
@@ -487,7 +491,7 @@ function runPresentation(
   }
   const active = isActiveRun(run);
   const projectedActivityGroups = active
-    ? activityGroups.slice(0, MAX_RUN_ACTIVITY_PROJECTIONS - 1)
+    ? activityGroups.slice(-(MAX_RUN_ACTIVITY_PROJECTIONS - 1))
     : activityGroups;
   const work: ConversationWorkPresentation[] = [
     ...projectedActivityGroups,

--- a/desktop/src/renderer/src/features/chat/canonical-chat-presentation.ts
+++ b/desktop/src/renderer/src/features/chat/canonical-chat-presentation.ts
@@ -6,6 +6,7 @@ import type {
 } from "@matrix-os/contracts";
 import type {
   ConversationAttachmentPresentation,
+  ConversationActivityGroupPresentation,
   ConversationActivityPresentation,
   ConversationMessagePresentation,
   ConversationMessageContentPresentation,
@@ -446,7 +447,7 @@ function runPresentation(
     }
   }
 
-  const activityGroups: ConversationWorkPresentation[] = [];
+  const activityGroups: ConversationActivityGroupPresentation[] = [];
   for (const entry of activityOrder) {
     if (entry.type === "agent") {
       const activity = agentActivities.get(entry.id);
@@ -491,7 +492,15 @@ function runPresentation(
   }
   const active = isActiveRun(run);
   const projectedActivityGroups = active
-    ? activityGroups.slice(-(MAX_RUN_ACTIVITY_PROJECTIONS - 1))
+    ? activityGroups
+      .map((item, index) => ({ item, index }))
+      .sort((left, right) => (
+        (left.item.sequence ?? Number.MAX_SAFE_INTEGER) - (right.item.sequence ?? Number.MAX_SAFE_INTEGER)
+        || (left.item.timestamp ?? Number.MAX_SAFE_INTEGER) - (right.item.timestamp ?? Number.MAX_SAFE_INTEGER)
+        || left.index - right.index
+      ))
+      .slice(-(MAX_RUN_ACTIVITY_PROJECTIONS - 1))
+      .map(({ item }) => item)
     : activityGroups;
   const work: ConversationWorkPresentation[] = [
     ...projectedActivityGroups,

--- a/packages/gateway/src/chat/hermes-provider-adapter.ts
+++ b/packages/gateway/src/chat/hermes-provider-adapter.ts
@@ -737,7 +737,12 @@ export function createHermesChatProviderAdapter(options: {
             ? `${error.name}:${error.reason}${error.eventType ? `:${error.eventType}` : ""}`
             : error instanceof Error ? error.name : "UnknownError",
         );
-        const safeFailure = error instanceof HermesRunFailure
+        const safeFailure = error instanceof HermesGatewayProtocolError && error.reason === "frame_too_large"
+          ? {
+              code: "run_failed" as const,
+              safeMessage: "The agent returned a response that was too large to process.",
+            }
+          : error instanceof HermesRunFailure
           ? {
               code: "run_failed" as const,
               safeMessage: error.reason === "interrupted"

--- a/packages/gateway/src/chat/hermes-stdio-client.ts
+++ b/packages/gateway/src/chat/hermes-stdio-client.ts
@@ -62,7 +62,8 @@ export interface HermesStdioClient {
 }
 
 const defaultSpawn: HermesGatewaySpawn = (command, args, options) => spawn(command, args, options);
-const MAX_FRAME_BYTES = 256 * 1024;
+const MAX_INBOUND_FRAME_BYTES = 512 * 1024;
+const MAX_OUTBOUND_FRAME_BYTES = 256 * 1024;
 const MAX_PENDING_REQUESTS = 16;
 const DEFAULT_READY_TIMEOUT_MS = 15_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
@@ -165,7 +166,7 @@ export function createHermesStdioClient(options: {
   }
 
   function handleFrame(line: string): void {
-    if (Buffer.byteLength(line, "utf8") > MAX_FRAME_BYTES) {
+    if (Buffer.byteLength(line, "utf8") > MAX_INBOUND_FRAME_BYTES) {
       fail(protocolError("frame_too_large", "Hermes gateway frame exceeded limit"));
       return;
     }
@@ -207,7 +208,7 @@ export function createHermesStdioClient(options: {
   child.stdout.on("data", (chunk) => {
     if (failed || closing) return;
     inputBuffer += decoder.write(chunk);
-    if (Buffer.byteLength(inputBuffer, "utf8") > MAX_FRAME_BYTES && !inputBuffer.includes("\n")) {
+    if (Buffer.byteLength(inputBuffer, "utf8") > MAX_INBOUND_FRAME_BYTES && !inputBuffer.includes("\n")) {
       fail(protocolError("frame_too_large", "Hermes gateway frame exceeded limit"));
       return;
     }
@@ -218,7 +219,7 @@ export function createHermesStdioClient(options: {
       inputBuffer = inputBuffer.slice(newline + 1);
       if (line) handleFrame(line);
     }
-    if (!failed && Buffer.byteLength(inputBuffer, "utf8") > MAX_FRAME_BYTES) {
+    if (!failed && Buffer.byteLength(inputBuffer, "utf8") > MAX_INBOUND_FRAME_BYTES) {
       fail(protocolError("frame_too_large", "Hermes gateway frame exceeded limit"));
     }
   });
@@ -246,7 +247,7 @@ export function createHermesStdioClient(options: {
       }
       const id = ++requestId;
       const frame = `${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`;
-      if (Buffer.byteLength(frame, "utf8") > MAX_FRAME_BYTES) {
+      if (Buffer.byteLength(frame, "utf8") > MAX_OUTBOUND_FRAME_BYTES) {
         return Promise.reject(safeError("Hermes gateway request exceeded limit"));
       }
       return new Promise<unknown>((resolve, reject) => {

--- a/tests/desktop/canonical-chat-presentation.test.ts
+++ b/tests/desktop/canonical-chat-presentation.test.ts
@@ -3,6 +3,66 @@ import { createCanonicalChatFixture } from "../contracts/fixtures/canonical-chat
 import { canonicalChatPresentation } from "@desktop/renderer/src/features/chat/canonical-chat-presentation";
 
 describe("canonical Chat presentation adapter", () => {
+  it("shows the canonical selected model first while a Run is active", () => {
+    const { snapshot } = createCanonicalChatFixture("accepted");
+    const run = snapshot.runs[0]!;
+
+    const [presented] = canonicalChatPresentation({
+      messages: snapshot.messages,
+      turns: snapshot.turns,
+      runs: snapshot.runs,
+      activities: snapshot.activities,
+    });
+
+    expect(presented?.work).toEqual([
+      {
+        kind: "activity-group",
+        id: `${run.id}:selected-model`,
+        timestamp: Date.parse(run.createdAt),
+        sequence: 0,
+        activities: [{
+          id: `${run.id}:selected-model`,
+          kind: "phase",
+          state: "running",
+          label: "Working",
+          preview: "Current model: gpt-5.6-sol",
+          previewKind: "text",
+        }],
+      },
+    ]);
+  });
+
+  it("deduplicates a provider model status against the canonical selected model", () => {
+    const { snapshot } = createCanonicalChatFixture("accepted");
+    const run = snapshot.runs[0]!;
+
+    const [presented] = canonicalChatPresentation({
+      messages: snapshot.messages,
+      turns: snapshot.turns,
+      runs: snapshot.runs,
+      activities: [{
+        id: "activity_provider_model_status",
+        chatId: snapshot.chat.id,
+        runId: run.id,
+        sequence: 1,
+        type: "agent.activity",
+        activityId: "provider_model_status",
+        kind: "phase",
+        label: "Working",
+        summary: "Current model: gpt-5.6-sol",
+        status: "running",
+        occurredAt: run.createdAt,
+      }],
+    });
+
+    expect(presented?.work).toEqual([
+      expect.objectContaining({
+        kind: "activity-group",
+        id: `${run.id}:selected-model`,
+      }),
+    ]);
+  });
+
   it("caps transcript projection collections at the public activity-page boundary", () => {
     const { snapshot } = createCanonicalChatFixture("accepted");
     const run = snapshot.runs[0]!;
@@ -29,7 +89,8 @@ describe("canonical Chat presentation adapter", () => {
     const projectedActivities = presented?.work.filter((item) => item.kind === "activity-group") ?? [];
 
     expect(projectedActivities).toHaveLength(500);
-    expect(projectedActivities.at(-1)?.id).toContain("activity_bounded_499");
+    expect(projectedActivities[0]?.id).toBe(`${run.id}:selected-model`);
+    expect(projectedActivities.at(-1)?.id).toContain("activity_bounded_498");
   });
 
   it("projects canonical messages into the shared provider-neutral transcript", () => {
@@ -310,7 +371,7 @@ describe("canonical Chat presentation adapter", () => {
     expect(presented?.final).toBeUndefined();
   });
 
-  it("uses generic Thinking only as a live placeholder until visible process text arrives", () => {
+  it("shows the model first and removes generic Thinking when visible work arrives", () => {
     const { snapshot } = createCanonicalChatFixture("accepted");
     const run = snapshot.runs[0]!;
     const reasoning = {
@@ -335,7 +396,8 @@ describe("canonical Chat presentation adapter", () => {
     expect(placeholderOnly?.work).toEqual([
       expect.objectContaining({
         kind: "activity-group",
-        activities: [expect.objectContaining({ kind: "reasoning", label: "Thinking" })],
+        id: `${run.id}:selected-model`,
+        activities: [expect.objectContaining({ preview: "Current model: gpt-5.6-sol" })],
       }),
     ]);
 
@@ -355,6 +417,10 @@ describe("canonical Chat presentation adapter", () => {
       }],
     });
     expect(withVisibleProcessText?.work).toEqual([
+      expect.objectContaining({
+        kind: "activity-group",
+        id: `${run.id}:selected-model`,
+      }),
       expect.objectContaining({
         kind: "message",
         id: "msg_visible_process",
@@ -388,6 +454,10 @@ describe("canonical Chat presentation adapter", () => {
       }],
     });
     expect(withRealActivity?.work).toEqual([
+      expect.objectContaining({
+        kind: "activity-group",
+        id: `${run.id}:selected-model`,
+      }),
       expect.objectContaining({
         kind: "activity-group",
         activities: [expect.objectContaining({ kind: "command", label: "Run command" })],
@@ -479,6 +549,11 @@ describe("canonical Chat presentation adapter", () => {
     expect(presented?.work).toEqual([
       expect.objectContaining({
         kind: "activity-group",
+        id: `${run.id}:selected-model`,
+        activities: [expect.objectContaining({ preview: "Current model: gpt-5.6-sol" })],
+      }),
+      expect.objectContaining({
+        kind: "activity-group",
         id: `${run.id}:activities:activity_reasoning`,
         activities: [expect.objectContaining({ id: "activity_reasoning", kind: "reasoning", state: "partial" })],
       }),
@@ -537,6 +612,11 @@ describe("canonical Chat presentation adapter", () => {
       id: turn.id,
       active: true,
       work: [
+        expect.objectContaining({
+          kind: "activity-group",
+          id: `${run.id}:selected-model`,
+          activities: [expect.objectContaining({ preview: "Current model: gpt-5.6-sol" })],
+        }),
         expect.objectContaining({
           kind: "activity-group",
           activities: [expect.objectContaining({ label: "Reading project files", state: "running" })],

--- a/tests/desktop/canonical-chat-presentation.test.ts
+++ b/tests/desktop/canonical-chat-presentation.test.ts
@@ -94,6 +94,42 @@ describe("canonical Chat presentation adapter", () => {
     expect(projectedActivities.at(-1)?.id).toContain("activity_bounded_500");
   });
 
+  it("retains a newest server update when it reuses the oldest activity id", () => {
+    const { snapshot } = createCanonicalChatFixture("accepted");
+    const run = snapshot.runs[0]!;
+    const occurredAt = run.startedAt ?? run.createdAt;
+    const activities = Array.from({ length: 500 }, (_, index) => ({
+      id: `activity_reused_${index}`,
+      chatId: snapshot.chat.id,
+      runId: run.id,
+      sequence: index + 1,
+      type: "agent.activity" as const,
+      activityId: `reused_${index}`,
+      kind: "phase" as const,
+      label: `Phase ${index}`,
+      status: "running" as const,
+      occurredAt,
+    }));
+
+    const [presented] = canonicalChatPresentation({
+      messages: snapshot.messages,
+      turns: snapshot.turns,
+      runs: snapshot.runs,
+      activities: [
+        ...activities,
+        { ...activities[0]!, sequence: 501, label: "Phase 0 updated" },
+      ],
+    });
+    const projectedActivities = presented?.work.filter((item) => item.kind === "activity-group") ?? [];
+
+    expect(projectedActivities).toHaveLength(500);
+    expect(projectedActivities.some((item) => item.id.endsWith("activity_reused_1"))).toBe(false);
+    expect(projectedActivities.at(-1)).toMatchObject({
+      id: expect.stringContaining("activity_reused_0"),
+      activities: [expect.objectContaining({ label: "Phase 0 updated" })],
+    });
+  });
+
   it("projects canonical messages into the shared provider-neutral transcript", () => {
     const { snapshot } = createCanonicalChatFixture("completed");
 

--- a/tests/desktop/canonical-chat-presentation.test.ts
+++ b/tests/desktop/canonical-chat-presentation.test.ts
@@ -63,7 +63,7 @@ describe("canonical Chat presentation adapter", () => {
     ]);
   });
 
-  it("caps transcript projection collections at the public activity-page boundary", () => {
+  it("caps active transcript projection while preserving the newest server-ordered activity", () => {
     const { snapshot } = createCanonicalChatFixture("accepted");
     const run = snapshot.runs[0]!;
     const occurredAt = run.startedAt ?? run.createdAt;
@@ -90,7 +90,8 @@ describe("canonical Chat presentation adapter", () => {
 
     expect(projectedActivities).toHaveLength(500);
     expect(projectedActivities[0]?.id).toBe(`${run.id}:selected-model`);
-    expect(projectedActivities.at(-1)?.id).toContain("activity_bounded_498");
+    expect(projectedActivities.some((item) => item.id.endsWith("activity_bounded_1"))).toBe(false);
+    expect(projectedActivities.at(-1)?.id).toContain("activity_bounded_500");
   });
 
   it("projects canonical messages into the shared provider-neutral transcript", () => {

--- a/tests/gateway/chat-hermes-provider.test.ts
+++ b/tests/gateway/chat-hermes-provider.test.ts
@@ -105,6 +105,45 @@ async function collect(iterable: AsyncIterable<unknown>): Promise<unknown[]> {
 }
 
 describe("Hermes canonical Chat Provider adapter", () => {
+  it("projects a large official Hermes vision result before the final assistant message", async () => {
+    const gateway = fakeGateway();
+    const adapter = createHermesChatProviderAdapter({ homePath: "/home/matrix/home", spawnFn: gateway.spawnFn });
+    const eventsPromise = collect(adapter.start(baseInput));
+    await vi.waitFor(() => expect(gateway.requests.some(({ method }) => method === "prompt.submit")).toBe(true));
+
+    const privateVisionPayload = "vision-private-sentinel".repeat(19_000);
+    gateway.event("tool.start", {
+      tool_id: "tool_browser_vision",
+      name: "browser_vision",
+      args: { path: "/home/matrix/home/private/screenshot.png" },
+    });
+    gateway.event("tool.complete", {
+      tool_id: "tool_browser_vision",
+      name: "browser_vision",
+      result: { success: true, output: privateVisionPayload },
+    });
+    gateway.event("message.complete", { text: "The game is ready.", status: "complete" });
+
+    const events = await eventsPromise;
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: "agent.activity",
+        activityId: "tool_browser_vision",
+        status: "running",
+      }),
+      expect.objectContaining({
+        type: "agent.activity",
+        activityId: "tool_browser_vision",
+        status: "completed",
+      }),
+      { type: "assistant.delta", delta: "The game is ready." },
+      { type: "run.completed", outcome: "completed" },
+    ]));
+    expect(gateway.process.kill).not.toHaveBeenCalled();
+    expect(JSON.stringify(events)).not.toContain("vision-private-sentinel");
+    expect(JSON.stringify(events)).not.toContain("/home/matrix/home/private/screenshot.png");
+  });
+
   it("projects official Hermes tool frames without leaking provider payloads", async () => {
     const gateway = fakeGateway();
     const adapter = createHermesChatProviderAdapter({ homePath: "/home/matrix/home", spawnFn: gateway.spawnFn });

--- a/tests/gateway/chat-hermes-provider.test.ts
+++ b/tests/gateway/chat-hermes-provider.test.ts
@@ -144,6 +144,31 @@ describe("Hermes canonical Chat Provider adapter", () => {
     expect(JSON.stringify(events)).not.toContain("/home/matrix/home/private/screenshot.png");
   });
 
+  it("reports an oversized Hermes response as a Run failure instead of a connection failure", async () => {
+    const gateway = fakeGateway();
+    const adapter = createHermesChatProviderAdapter({ homePath: "/home/matrix/home", spawnFn: gateway.spawnFn });
+    const eventsPromise = collect(adapter.start(baseInput));
+    await vi.waitFor(() => expect(gateway.requests.some(({ method }) => method === "prompt.submit")).toBe(true));
+
+    gateway.event("tool.complete", {
+      tool_id: "tool_browser_vision",
+      name: "browser_vision",
+      result: { success: true, output: "oversized-private-sentinel".repeat(25_000) },
+    });
+
+    expect(await eventsPromise).toEqual([{
+      type: "run.completed",
+      outcome: "failed",
+      error: {
+        code: "run_failed",
+        safeMessage: "The agent returned a response that was too large to process.",
+        retryable: true,
+        recoveryActions: ["retry"],
+      },
+    }]);
+    expect(gateway.process.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
   it("projects official Hermes tool frames without leaking provider payloads", async () => {
     const gateway = fakeGateway();
     const adapter = createHermesChatProviderAdapter({ homePath: "/home/matrix/home", spawnFn: gateway.spawnFn });


### PR DESCRIPTION
## Summary

- accept bounded official Hermes response frames large enough for browser vision results before provider-neutral projection
- keep raw vision payloads, absolute paths, and provider-owned results out of canonical Chat activity
- classify responses beyond the inbound hard cap as a truthful Run failure instead of a provider connection failure
- show the canonical Run's selected model at the start of active Working presentation for Hermes, Codex, and Claude without depending on optional provider status frames
- remove the derived model row after completion and preserve server-ordered process/tool activity underneath it

Follow-up for [OM-186](https://linear.app/matrix-os/issue/OM-186).

## Root cause

Hermes successfully emitted an official `tool.complete` frame for `browser_vision`, but its approximately 438 KiB payload exceeded the shared 256 KiB stdio frame limit. The client killed the provider before canonical projection, and the protocol error was then collapsed into `provider_unavailable`, producing the misleading "Hermes connection failed" UI. The observed six-minute duration was incidental: a retry reproduced the same boundary at about 110 seconds.

The missing model line was independent. Presentation only retained an optional Hermes-owned `status.update` matching `Current model: ...`; real runtime traces did not emit that frame even though the durable canonical Run already recorded `selection.model`.

## Tests

- `flox activate -- pnpm exec vitest run tests/gateway/chat-hermes-provider.test.ts tests/desktop/canonical-chat-presentation.test.ts tests/desktop/conversation-worked-row.test.tsx tests/desktop/conversation-transcript-neutral.test.tsx tests/desktop/canonical-chat-workspace.test.tsx` — 128 passed
- `flox activate -- bun run typecheck` — passed
- contracts, Gateway, and Desktop package typechecks — passed
- `flox activate -- ./scripts/review/check-patterns.sh --diff origin/main` — 0 violations; one reviewed lexical path warning in existing Gateway code, no new user-controlled path operation
- React Doctor — skipped by the same CI routing because this PR changes no `.tsx` or `.jsx` files
- `flox activate -- bun run build:desktop` — passed
- `flox activate -- bun run test` — 12,284 passed, 18 failed across 6 unrelated files
- exact `origin/main@a607e4695e8b4c5c42c63f5d6dc8a8a77a964c23` baseline rerun of those 6 files — identical 18 failures (130 passed), confirming no new full-suite failures

## Invariants

### Source of truth
- The canonical Run and durable Run activity log remain the source of truth for selected model, ordering, outcome, and reload/reconnect projection.
- Hermes stdout is provider input only; raw provider payloads are never a renderer source of truth.

### Lock/transaction scope
- No database writes, locks, or transactions are added.
- Provider frame parsing remains inside the bounded stdio client before canonical event validation.

### Acceptable orphan states
- An inbound frame beyond the 512 KiB hard cap fails the Run safely and terminates the provider process.
- Frames inside the cap are projected to bounded canonical activity; provider results remain discarded after status classification.

### Auth source of truth
- Existing canonical Chat owner authorization and provider runtime credentials remain unchanged.
- No credentials, environment values, headers, raw arguments, file content, diffs, or absolute paths are projected.

### Deferred scope
- No provider-owned renderer state, file preview/diff UI, Work rail behavior, or streaming persistence refactor.
- No changes to provider selection or provider catalog behavior.
