### PR TITLE
fix(chat): expose uploaded file paths to providers

### DIFF
--- a/packages/gateway/src/chat/orchestrator.ts
+++ b/packages/gateway/src/chat/orchestrator.ts
@@ -108,15 +108,31 @@ function promptFor(parts: CanonicalCreateChatTurnRequest["parts"]): string {
       return [`${part.invocation.invocation}${part.invocation.arguments ? ` ${part.invocation.arguments}` : ""}`];
     }
     if (part.type === "resource_reference") return [`@${part.resource.label}`];
-    if (part.type === "attachment_reference") return [`@${part.label}`];
+    if (part.type === "attachment_reference" && !part.ownerReference) return [`@${part.label}`];
     return [];
   });
+  const attachmentReferences = parts.flatMap((part) => (
+    part.type === "attachment_reference" && part.ownerReference
+      ? [`- ${JSON.stringify(part.label)}: ${shellQuotedOwnerReference(part.ownerReference)}`]
+      : []
+  ));
+  if (attachmentReferences.length > 0) {
+    lines.push(
+      "",
+      "Attached files (available on this Matrix computer):",
+      ...attachmentReferences,
+    );
+  }
   const prompt = lines.join("\n").trim();
   if (!prompt) throw new CanonicalChatOrchestrationError(
     safeError("capability_mismatch", "The message does not contain supported input."),
     400,
   );
   return prompt;
+}
+
+function shellQuotedOwnerReference(ownerReference: string): string {
+  return `"$MATRIX_HOME"/'${ownerReference.replaceAll("'", "'\\''")}'`;
 }
 
 function requirementsFor(input: CanonicalCreateChatTurnRequest) {

--- a/tests/gateway/chat-orchestrator.test.ts
+++ b/tests/gateway/chat-orchestrator.test.ts
@@ -169,6 +169,63 @@ describe("CanonicalChatOrchestrator", () => {
     ]);
   });
 
+  it("projects uploaded attachment paths through the Provider-neutral prompt", async () => {
+    await repository.create(owner, {
+      id: "chat_attachment_prompt",
+      clientRequestId: "req_create_attachment_prompt",
+      title: "Attachment prompt",
+    });
+    let providerPrompt: string | undefined;
+    const provider = adapter(async function* (input) {
+      providerPrompt = input.prompt;
+      yield { type: "run.completed", outcome: "completed" };
+    });
+    const orchestrator = new CanonicalChatOrchestrator({
+      repository,
+      catalog: { getCatalog: async () => catalog() },
+      adapters: new CanonicalChatProviderRegistry([provider]),
+      now: () => new Date("2026-08-31T01:34:00.000Z"),
+    });
+
+    await orchestrator.admitTurn(principal, owner, "chat_attachment_prompt", {
+      clientRequestId: "req_attachment_prompt_turn",
+      baseRevision: 0,
+      parts: [
+        { type: "text", text: "Do a summary" },
+        {
+          type: "attachment_reference",
+          attachmentId: "desktop_upload_attachment_prompt",
+          kind: "file",
+          label: "message (1).txt",
+          mimeType: "text/plain",
+          sizeBytes: 19_505,
+          ownerReference: "temporary/desktop-chat/upload_123-message (1).txt",
+        },
+        {
+          type: "attachment_reference",
+          attachmentId: "desktop_upload_shell_chars",
+          kind: "file",
+          label: "notes'$(touch ignored).txt",
+          mimeType: "text/plain",
+          sizeBytes: 32,
+          ownerReference: "temporary/desktop-chat/upload_456-notes'$(touch ignored).txt",
+        },
+      ],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+    });
+    await orchestrator.drain();
+
+    expect(providerPrompt).toBe([
+      "Do a summary",
+      "",
+      "Attached files (available on this Matrix computer):",
+      '- "message (1).txt": "$MATRIX_HOME"/\'temporary/desktop-chat/upload_123-message (1).txt\'',
+      '- "notes\'$(touch ignored).txt": "$MATRIX_HOME"/\'temporary/desktop-chat/upload_456-notes\'\\\'\'$(touch ignored).txt\'',
+    ].join("\n"));
+  });
+
   it("persists one stable typed activity row across live lifecycle updates", async () => {
     await repository.create(owner, {
       id: "chat_activity_projection",


### PR DESCRIPTION
## Summary

- project canonical Chat attachment `ownerReference` values into provider prompts
- expose files through a shell-safe `$MATRIX_HOME` path for Claude, Codex, and Hermes
- preserve the existing label-only fallback for attachments without an owner reference

## Root cause

Desktop uploads were persisted under the owner's Matrix home and the canonical attachment retained the owner-relative path, but the provider-neutral prompt projection discarded that path and emitted only `@filename`. Providers therefore received a filename without a readable workspace location.

## Tests

- `flox activate -- bun run test -- tests/gateway/chat-orchestrator.test.ts tests/gateway/chat-claude-provider.test.ts tests/gateway/chat-coding-provider.test.ts tests/gateway/chat-hermes-provider.test.ts tests/gateway/coding-agents-workspace-provider.test.ts tests/gateway/agent-session-manager.test.ts tests/gateway/agent-launcher.test.ts tests/contracts/canonical-chat.test.ts tests/desktop/local-attachment-controller.test.ts` (156 passed)
- `flox activate -- bun run typecheck`
- `flox activate -- bun run check:patterns` (0 violations; 5 existing repository-wide heuristic warnings)
- `flox activate -- bun run test` (12,281 passed; 18 unrelated failures across 6 existing test files: Todo date assumptions, macOS/Linux host-script differences, CI checkout fixture behavior, and terminal/tool-pack timeouts)

## Invariants

### Source of truth

- The canonical Chat attachment part remains the source of truth. Its API-boundary-validated `ownerReference` is projected into the provider prompt; no second attachment store is introduced.

### Lock/transaction scope

- No lock or transaction scope changes. Turn admission and canonical message persistence keep their existing ownership boundaries; prompt projection is read-only and performs no network calls.

### Acceptable orphan states

- No new persisted objects or orphan states are introduced. Existing temporary upload retention and cleanup behavior is unchanged.

### Auth source of truth

- Existing canonical Chat principal and owner authorization remain authoritative. The prompt exposes only the already-authorized owner-relative reference under that runtime's `$MATRIX_HOME`.

### Deferred scope

- Binary attachment embedding, provider-specific attachment APIs, upload size limits, and temporary-file retention changes are explicitly out of scope.
