### PR TITLE
feat(provider-settings): expose generic harness setup truth

### DIFF
--- a/docs/dev/provider-settings-parity.md
+++ b/docs/dev/provider-settings-parity.md
@@ -168,6 +168,12 @@ child processes with cancellation, timeout, output, event, and active-process
 limits. A request for workspace-write or full access is rejected rather than
 run without confinement.
 
+Long Pi and OpenCode first turns are dispatched only after the queued Chat is
+durably visible. They never hold the global thread-state mutation queue while a
+CLI runs; inspect, abort, another Chat, and shutdown retain bounded independent
+progress. Provider output is finalized in a short race-safe mutation and late
+output cannot resurrect an aborted or otherwise terminal Chat.
+
 Each Pi or OpenCode turn resolves the one enabled owner harness instance and its
 selected access source immediately before spawn. Only portable credentials for
 that exact source are copied into the child environment. Matrix-included access
@@ -176,6 +182,12 @@ not reused by another CLI. Missing binaries, duplicate enabled instances,
 unavailable credentials, offline routes, unsupported model vendors, and stale
 models all remain non-runnable. Resume state retains only the provider session ID
 and the validated working directory; it never persists a credential.
+
+The portable-credential predicate is one shared contract. The add-harness UI
+filters provider, model, and source choices with it, configuration mutations
+revalidate it at the gateway boundary, and the Chat catalog plus child-process
+credential resolver enforce it again. Renderer state can therefore never make
+an otherwise unsupported owner subscription or model vendor executable.
 
 Multiple accounts are first-class. Account IDs are stable and owner-scoped;
 labels are safe display metadata, not secret suffixes. Adding an account must

--- a/packages/contracts/src/provider-settings.ts
+++ b/packages/contracts/src/provider-settings.ts
@@ -19,6 +19,9 @@ const UsageScopeSchema = z.enum(["account", "access_source", "owner_entitlement"
 export const ProviderHarnessKindSchema = z.enum([
   "hermes", "openclaw", "pi", "opencode", "codex", "claude",
 ]);
+export const ProviderGenericHarnessKindSchema = z.enum([
+  "hermes", "openclaw", "pi", "opencode",
+]);
 export const ProviderHarnessInstallStateSchema = z.enum([
   "installed", "missing", "installing", "failed", "unknown",
 ]);
@@ -269,6 +272,48 @@ export const ProviderHarnessInstanceSchema = z.object({
   }
 });
 
+export const ProviderHarnessSetupActionSchema = z.enum([
+  "none", "install", "connect_account", "enter_api_key", "open_terminal", "retry",
+]);
+export const ProviderHarnessCatalogSafeReasonSchema = z.enum([
+  "not_installed",
+  "installing",
+  "install_failed",
+  "install_state_unknown",
+  "runtime_not_supported",
+  "runtime_unavailable",
+  "setup_required",
+]);
+export const ProviderHarnessCatalogEntrySchema = z.object({
+  harness: ProviderGenericHarnessKindSchema,
+  displayName: DisplayNameSchema,
+  installState: ProviderHarnessInstallStateSchema,
+  /** The current runtime coordinator supports configuration for this kind. */
+  available: z.boolean(),
+  /** Canonical inventory says an add/enable operation can run now. */
+  runnable: z.boolean(),
+  setupAction: ProviderHarnessSetupActionSchema,
+  safeReason: ProviderHarnessCatalogSafeReasonSchema.nullable(),
+}).strict().superRefine((entry, ctx) => {
+  if (entry.runnable && (!entry.available || entry.installState !== "installed"
+    || entry.setupAction !== "none" || entry.safeReason !== null)) {
+    ctx.addIssue({ code: "custom", message: "Runnable harnesses must be installed, available, and setup-free" });
+  }
+  if (!entry.runnable && entry.safeReason === null) {
+    ctx.addIssue({ code: "custom", path: ["safeReason"], message: "Unavailable harnesses require a safe reason" });
+  }
+  if (!entry.available && (entry.runnable || entry.setupAction !== "none"
+    || entry.safeReason !== "runtime_not_supported")) {
+    ctx.addIssue({ code: "custom", message: "Unsupported harnesses cannot advertise setup or execution" });
+  }
+  if (entry.available && !entry.runnable && entry.setupAction === "none") {
+    ctx.addIssue({ code: "custom", path: ["setupAction"], message: "Supported unavailable harnesses require a setup action" });
+  }
+  if (entry.setupAction === "install" && entry.installState === "installed") {
+    ctx.addIssue({ code: "custom", path: ["setupAction"], message: "Installed harnesses cannot require installation" });
+  }
+});
+
 export const ProviderGatewayPolicySchema = z.object({
   accessSourceId: ReferenceIdSchema,
   monthlyBudgetMicrousd: MicrousdSchema.nullable(),
@@ -316,6 +361,7 @@ export const ProviderSettingsSnapshotSchema = z.object({
   access: ProviderSettingsAccessSchema,
   supportedActions: z.array(ProviderSettingsSupportedActionSchema).max(15),
   configurationHarnessKinds: z.array(ProviderHarnessKindSchema).max(6).optional(),
+  harnessCatalog: z.array(ProviderHarnessCatalogEntrySchema).length(4),
   modelProviders: z.array(ProviderModelProviderSchema).max(32),
   accessSources: z.array(ProviderAccessSourceSchema).max(64),
   accounts: z.array(ProviderAccountSchema).max(128),
@@ -333,6 +379,19 @@ export const ProviderSettingsSnapshotSchema = z.object({
   }
   if (snapshot.configurationHarnessKinds && !unique(snapshot.configurationHarnessKinds)) {
     ctx.addIssue({ code: "custom", path: ["configurationHarnessKinds"], message: "Duplicate configurable harness kind" });
+  }
+  const genericHarnessKinds = ProviderGenericHarnessKindSchema.options;
+  if (!unique(snapshot.harnessCatalog.map((entry) => entry.harness))
+    || genericHarnessKinds.some((kind) => !snapshot.harnessCatalog.some((entry) => entry.harness === kind))) {
+    ctx.addIssue({ code: "custom", path: ["harnessCatalog"], message: "Generic harness catalog must contain each supported kind exactly once" });
+  }
+  if (snapshot.configurationHarnessKinds) {
+    const configurable = new Set(snapshot.configurationHarnessKinds);
+    snapshot.harnessCatalog.forEach((entry, index) => {
+      if (entry.available !== configurable.has(entry.harness)) {
+        ctx.addIssue({ code: "custom", path: ["harnessCatalog", index, "available"], message: "Harness availability must match runtime configuration support" });
+      }
+    });
   }
   if (snapshot.access.mode === "read_only" && snapshot.supportedActions.length > 0) {
     ctx.addIssue({ code: "custom", path: ["supportedActions"], message: "Read-only settings cannot advertise mutations" });
@@ -492,6 +551,7 @@ export const ProviderSettingsMutationResponseSchema = z.discriminatedUnion("kind
 ]);
 
 export type ProviderHarnessKind = z.infer<typeof ProviderHarnessKindSchema>;
+export type ProviderGenericHarnessKind = z.infer<typeof ProviderGenericHarnessKindSchema>;
 export type ProviderHarnessInstallState = z.infer<typeof ProviderHarnessInstallStateSchema>;
 export type ProviderAuthenticationState = z.infer<typeof ProviderAuthenticationStateSchema>;
 export type ProviderLoginMethod = z.infer<typeof ProviderLoginMethodSchema>;
@@ -512,6 +572,9 @@ export type ProviderAccessSource = z.infer<typeof ProviderAccessSourceSchema>;
 export type ProviderDependencyCounts = z.infer<typeof ProviderDependencyCountsSchema>;
 export type ProviderAccount = z.infer<typeof ProviderAccountSchema>;
 export type ProviderHarnessInstance = z.infer<typeof ProviderHarnessInstanceSchema>;
+export type ProviderHarnessSetupAction = z.infer<typeof ProviderHarnessSetupActionSchema>;
+export type ProviderHarnessCatalogSafeReason = z.infer<typeof ProviderHarnessCatalogSafeReasonSchema>;
+export type ProviderHarnessCatalogEntry = z.infer<typeof ProviderHarnessCatalogEntrySchema>;
 export type ProviderGatewayPolicy = z.infer<typeof ProviderGatewayPolicySchema>;
 export type ProviderSettingsSupportedAction = z.infer<typeof ProviderSettingsSupportedActionSchema>;
 /** Mutable Settings projection with explicit lineage to its canonical V3 input. */

--- a/packages/gateway/src/ai-providers/provider-settings-projector.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-projector.ts
@@ -8,6 +8,7 @@ import {
   type ProviderDependencyCounts,
   type ProviderHarnessInstance,
   type ProviderHarnessKind,
+  type ProviderHarnessCatalogEntry,
   type ProviderLoginMethod,
   type ProviderSettingsSupportedAction,
   type ProviderSettingsSnapshot,
@@ -329,6 +330,10 @@ export async function projectProviderSettings(input: {
         topUpEnabled: input.fundingSummary?.topUpEnabled === true,
       } : null;
   const allowedGatewayModels = new Set(gatewayPolicy?.allowedModelIds ?? []);
+  const harnessCatalog = projectHarnessCatalog(
+    input.canonical,
+    input.configurationHarnessKinds ?? [],
+  );
   const harnesses = input.config.harnesses.flatMap((stored) => {
     const harness = projectHarness({
       stored,
@@ -354,10 +359,88 @@ export async function projectProviderSettings(input: {
       : { mode: "read_only", reason: "runtime_unavailable" },
     supportedActions,
     configurationHarnessKinds: input.configurationHarnessKinds ?? [],
+    harnessCatalog,
     modelProviders,
     accessSources: sources,
     accounts,
     harnesses,
     gatewayPolicy,
+  });
+}
+
+const GENERIC_HARNESS_CATALOG = [
+  { harness: "hermes", displayName: "Hermes", system: true },
+  { harness: "openclaw", displayName: "OpenClaw", system: true },
+  { harness: "pi", displayName: "Pi", system: false },
+  { harness: "opencode", displayName: "OpenCode", system: false },
+] as const;
+
+type GenericHarnessCatalogDefinition = (typeof GENERIC_HARNESS_CATALOG)[number];
+type CanonicalDriver = AiProviderSnapshotV3["drivers"][number];
+
+function catalogDriverRunnable(
+  catalog: GenericHarnessCatalogDefinition,
+  driver: CanonicalDriver | undefined,
+): boolean {
+  if (!driver || driver.installState !== "installed") return false;
+  if (!catalog.system) return driver.health === "ready" || driver.health === "degraded";
+  return driver.health === "ready" || driver.health === "degraded"
+    || (driver.health === "stopped" && driver.setupActions.length === 0);
+}
+
+function catalogSafeReason(
+  driver: CanonicalDriver | undefined,
+): Exclude<ProviderHarnessCatalogEntry["safeReason"], null> {
+  if (!driver || driver.installState === "missing") return "not_installed";
+  if (driver.installState === "installing") return "installing";
+  if (driver.installState === "failed") return "install_failed";
+  if (driver.installState === "unknown") return "install_state_unknown";
+  if (driver.health === "unavailable" || driver.health === "unknown") return "runtime_unavailable";
+  return "setup_required";
+}
+
+function projectHarnessCatalog(
+  canonical: AiProviderSnapshotV3,
+  supportedKinds: readonly ProviderHarnessKind[],
+): ProviderHarnessCatalogEntry[] {
+  const supported = new Set(supportedKinds);
+  return GENERIC_HARNESS_CATALOG.map((catalog): ProviderHarnessCatalogEntry => {
+    const driver = canonical.drivers.find((candidate) => candidate.id === catalog.harness);
+    const installState = driver?.installState ?? "missing";
+    if (!supported.has(catalog.harness)) {
+      return {
+        harness: catalog.harness,
+        displayName: driver?.displayName ?? catalog.displayName,
+        installState,
+        available: false,
+        runnable: false,
+        setupAction: "none",
+        safeReason: "runtime_not_supported",
+      };
+    }
+
+    if (catalogDriverRunnable(catalog, driver)) {
+      return {
+        harness: catalog.harness,
+        displayName: driver!.displayName,
+        installState,
+        available: true,
+        runnable: true,
+        setupAction: "none",
+        safeReason: null,
+      };
+    }
+
+    const setupAction = driver?.setupActions[0]
+      ?? (installState === "missing" ? "install" : "retry");
+    return {
+      harness: catalog.harness,
+      displayName: driver?.displayName ?? catalog.displayName,
+      installState,
+      available: true,
+      runnable: false,
+      setupAction,
+      safeReason: catalogSafeReason(driver),
+    };
   });
 }

--- a/packages/gateway/src/ai-providers/provider-settings-projector.ts
+++ b/packages/gateway/src/ai-providers/provider-settings-projector.ts
@@ -383,7 +383,12 @@ function catalogDriverRunnable(
   driver: CanonicalDriver | undefined,
 ): boolean {
   if (!driver || driver.installState !== "installed") return false;
-  if (!catalog.system) return driver.health === "ready" || driver.health === "degraded";
+  // Pi and OpenCode receive credentials from the access source selected while
+  // adding the harness. Their installation probe intentionally cannot prove
+  // that future route credential, so a registered direct adapter reports
+  // unknown health until the first configured run. Match the runtime
+  // coordinator's admission rule here instead of creating a setup deadlock.
+  if (!catalog.system) return driver.health !== "unavailable" && driver.health !== "stopped";
   return driver.health === "ready" || driver.health === "degraded"
     || (driver.health === "stopped" && driver.setupActions.length === 0);
 }

--- a/packages/ui/src/agents-providers/AddHarnessDialog.tsx
+++ b/packages/ui/src/agents-providers/AddHarnessDialog.tsx
@@ -1,8 +1,10 @@
 import { useMemo, useState } from "react";
-import type {
-  ProviderGenericHarnessKind,
-  ProviderHarnessCatalogEntry,
-  ProviderSettingsSnapshot,
+import {
+  isPortableGenericHarnessCredentialRoute,
+  type ProviderAccessSource,
+  type ProviderGenericHarnessKind,
+  type ProviderHarnessCatalogEntry,
+  type ProviderSettingsSnapshot,
 } from "@matrix-os/contracts";
 import { FeatureDialog } from "./FeatureDialog.js";
 import type { ProviderSettingsMutationIntent } from "./types.js";
@@ -50,14 +52,39 @@ function setupCopy(entry: ProviderHarnessCatalogEntry): { title: string; body: s
 
 function sourceSupportsRoute(
   snapshot: ProviderSettingsSnapshot,
+  harness: ProviderGenericHarnessKind,
   source: ProviderSettingsSnapshot["accessSources"][number],
   providerId: string,
   modelId: string,
 ): boolean {
   if (source.providerId !== providerId || !source.eligibleModelIds.includes(modelId)) return false;
-  if (source.kind !== "matrix_gateway") return true;
-  return snapshot.gatewayPolicy?.accessSourceId === source.id
-    && snapshot.gatewayPolicy.allowedModelIds.includes(modelId);
+  const gatewayAllowed = source.kind !== "matrix_gateway"
+    || (snapshot.gatewayPolicy?.accessSourceId === source.id
+      && snapshot.gatewayPolicy.allowedModelIds.includes(modelId));
+  if (!gatewayAllowed) return false;
+  if (harness !== "pi" && harness !== "opencode") return true;
+  return isPortableGenericHarnessCredentialRoute({
+    harness,
+    accessSourceId: source.id,
+    route: { kind: "configurable", providerId, modelId },
+  }, source as ProviderAccessSource);
+}
+
+function modelsForProvider(
+  snapshot: ProviderSettingsSnapshot,
+  harness: ProviderGenericHarnessKind,
+  provider: ProviderSettingsSnapshot["modelProviders"][number],
+) {
+  return provider.models.filter((model) => model.enabled && snapshot.accessSources.some((source) =>
+    sourceSupportsRoute(snapshot, harness, source, provider.id, model.id)));
+}
+
+function providersForHarness(
+  snapshot: ProviderSettingsSnapshot,
+  harness: ProviderGenericHarnessKind,
+) {
+  return snapshot.modelProviders.filter((provider) =>
+    modelsForProvider(snapshot, harness, provider).length > 0);
 }
 
 export function AddHarnessDialog({
@@ -73,14 +100,18 @@ export function AddHarnessDialog({
     ?? snapshot.harnessCatalog[0]!;
   const [kind, setKind] = useState<ProviderGenericHarnessKind>(firstCatalog.harness);
   const selectedCatalog = snapshot.harnessCatalog.find((entry) => entry.harness === kind) ?? firstCatalog;
-  const defaultProvider = snapshot.modelProviders[0] ?? null;
+  const eligibleProviders = useMemo(() => providersForHarness(snapshot, kind), [kind, snapshot]);
+  const defaultProvider = eligibleProviders[0] ?? null;
   const [displayName, setDisplayName] = useState(selectedCatalog.displayName);
   const [providerId, setProviderId] = useState(defaultProvider?.id ?? "");
-  const provider = snapshot.modelProviders.find((candidate) => candidate.id === providerId) ?? defaultProvider;
-  const firstModel = provider?.models.find((model) => model.enabled) ?? null;
+  const provider = eligibleProviders.find((candidate) => candidate.id === providerId) ?? defaultProvider;
+  const eligibleModels = useMemo(() => provider === null ? [] : modelsForProvider(snapshot, kind, provider),
+    [kind, provider, snapshot]);
+  const firstModel = eligibleModels[0] ?? null;
   const [modelId, setModelId] = useState(firstModel?.id ?? "");
   const eligibleSources = useMemo(() => snapshot.accessSources.filter((source) =>
-    sourceSupportsRoute(snapshot, source, providerId, modelId)), [modelId, providerId, snapshot]);
+    sourceSupportsRoute(snapshot, kind, source, provider?.id ?? "", modelId)),
+    [kind, modelId, provider, snapshot]);
   const [sourceId, setSourceId] = useState(eligibleSources[0]?.id ?? "");
   const selectedSource = eligibleSources.find((source) => source.id === sourceId) ?? eligibleSources[0] ?? null;
   const canAdd = selectedCatalog.available && selectedCatalog.runnable
@@ -89,10 +120,10 @@ export function AddHarnessDialog({
 
   const selectKind = (nextKind: ProviderGenericHarnessKind) => {
     const catalog = snapshot.harnessCatalog.find((entry) => entry.harness === nextKind) ?? snapshot.harnessCatalog[0]!;
-    const nextProvider = snapshot.modelProviders[0] ?? null;
-    const nextModel = nextProvider?.models.find((model) => model.enabled) ?? null;
+    const nextProvider = providersForHarness(snapshot, nextKind)[0] ?? null;
+    const nextModel = nextProvider ? modelsForProvider(snapshot, nextKind, nextProvider)[0] ?? null : null;
     const nextSource = nextModel === null ? undefined : snapshot.accessSources.find((source) =>
-      sourceSupportsRoute(snapshot, source, nextProvider?.id ?? "", nextModel.id));
+      sourceSupportsRoute(snapshot, nextKind, source, nextProvider?.id ?? "", nextModel.id));
     setKind(nextKind);
     setDisplayName(catalog.displayName);
     setProviderId(nextProvider?.id ?? "");
@@ -101,10 +132,10 @@ export function AddHarnessDialog({
   };
 
   const selectProvider = (nextProviderId: string) => {
-    const nextProvider = snapshot.modelProviders.find((candidate) => candidate.id === nextProviderId) ?? null;
-    const nextModel = nextProvider?.models.find((model) => model.enabled) ?? null;
+    const nextProvider = eligibleProviders.find((candidate) => candidate.id === nextProviderId) ?? null;
+    const nextModel = nextProvider ? modelsForProvider(snapshot, kind, nextProvider)[0] ?? null : null;
     const nextSource = nextModel === null ? undefined : snapshot.accessSources.find((source) =>
-      sourceSupportsRoute(snapshot, source, nextProviderId, nextModel.id));
+      sourceSupportsRoute(snapshot, kind, source, nextProviderId, nextModel.id));
     setProviderId(nextProviderId);
     setModelId(nextModel?.id ?? "");
     setSourceId(nextSource?.id ?? "");
@@ -112,7 +143,7 @@ export function AddHarnessDialog({
 
   const selectModel = (nextModelId: string) => {
     const nextSource = snapshot.accessSources.find((source) =>
-      sourceSupportsRoute(snapshot, source, providerId, nextModelId));
+      sourceSupportsRoute(snapshot, kind, source, provider?.id ?? "", nextModelId));
     setModelId(nextModelId);
     setSourceId(nextSource?.id ?? "");
   };
@@ -125,7 +156,7 @@ export function AddHarnessDialog({
       displayName: displayName.trim(),
       route: {
         kind: "configurable",
-        providerId,
+        providerId: provider!.id,
         modelId,
       },
       accessSourceId: selectedSource.id,
@@ -175,14 +206,14 @@ export function AddHarnessDialog({
       <div className="matrix-ap-form-grid">
         <label className="matrix-ap-field">
           <span>Model provider</span>
-          <select value={providerId} onChange={(event) => selectProvider(event.target.value)} disabled={!selectedCatalog.runnable}>
-            {snapshot.modelProviders.map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.displayName}</option>)}
+          <select value={provider?.id ?? ""} onChange={(event) => selectProvider(event.target.value)} disabled={!selectedCatalog.runnable}>
+            {eligibleProviders.map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.displayName}</option>)}
           </select>
         </label>
         <label className="matrix-ap-field">
           <span>Model</span>
           <select value={modelId} onChange={(event) => selectModel(event.target.value)} disabled={!selectedCatalog.runnable}>
-            {provider?.models.filter((model) => model.enabled).map((model) => <option key={model.id} value={model.id}>{model.displayName}</option>)}
+            {eligibleModels.map((model) => <option key={model.id} value={model.id}>{model.displayName}</option>)}
           </select>
         </label>
       </div>

--- a/packages/ui/src/agents-providers/AddHarnessDialog.tsx
+++ b/packages/ui/src/agents-providers/AddHarnessDialog.tsx
@@ -1,19 +1,52 @@
 import { useMemo, useState } from "react";
-import type { ProviderHarnessKind, ProviderSettingsSnapshot } from "@matrix-os/contracts";
+import type {
+  ProviderGenericHarnessKind,
+  ProviderHarnessCatalogEntry,
+  ProviderSettingsSnapshot,
+} from "@matrix-os/contracts";
 import { FeatureDialog } from "./FeatureDialog.js";
 import type { ProviderSettingsMutationIntent } from "./types.js";
 
-const HARNESS_CATALOG: ReadonlyArray<{
-  id: ProviderHarnessKind;
-  label: string;
-  routeKind: "configurable" | "fixed";
-  preferredProvider: string | null;
-}> = [
-  { id: "hermes", label: "Hermes", routeKind: "configurable", preferredProvider: null },
-  { id: "openclaw", label: "OpenClaw", routeKind: "configurable", preferredProvider: null },
-  { id: "pi", label: "Pi", routeKind: "configurable", preferredProvider: null },
-  { id: "opencode", label: "OpenCode", routeKind: "configurable", preferredProvider: null },
-];
+function catalogStatus(entry: ProviderHarnessCatalogEntry): string {
+  const installed = {
+    installed: "Installed",
+    missing: "Not installed",
+    installing: "Installing",
+    failed: "Install failed",
+    unknown: "Install status unknown",
+  }[entry.installState];
+  const state = entry.runnable ? "Ready" : {
+    runtime_not_supported: "Unavailable in this runtime",
+    not_installed: "Install required",
+    installing: "Setup in progress",
+    install_failed: "Retry required",
+    install_state_unknown: "Status unavailable",
+    setup_required: "Setup required",
+    runtime_unavailable: "Unavailable",
+  }[entry.safeReason!];
+  return `${installed} · ${state}`;
+}
+
+function setupCopy(entry: ProviderHarnessCatalogEntry): { title: string; body: string } | null {
+  if (entry.runnable || !entry.available) return null;
+  if (entry.setupAction === "install") {
+    return {
+      title: `Install ${entry.displayName} before adding it`,
+      body: `Open Terminal and use the + menu to install ${entry.displayName}. Refresh this page when the install finishes.`,
+    };
+  }
+  if (entry.setupAction === "open_terminal" || entry.setupAction === "connect_account"
+    || entry.setupAction === "enter_api_key") {
+    return {
+      title: `Finish ${entry.displayName} setup before adding it`,
+      body: `Open Terminal and run ${entry.displayName} once to finish setup or authentication. Then refresh this page.`,
+    };
+  }
+  return {
+    title: `${entry.displayName} isn't ready yet`,
+    body: "Refresh provider status after the current setup finishes. If the status does not recover, open Terminal to inspect the harness.",
+  };
+}
 
 function sourceSupportsRoute(
   snapshot: ProviderSettingsSnapshot,
@@ -36,15 +69,12 @@ export function AddHarnessDialog({
   onMutate: (intent: ProviderSettingsMutationIntent) => void;
   onClose: () => void;
 }) {
-  const availableCatalog = HARNESS_CATALOG.filter((entry) =>
-    snapshot.configurationHarnessKinds?.includes(entry.id));
-  const firstCatalog = availableCatalog[0] ?? HARNESS_CATALOG[0]!;
-  const [kind, setKind] = useState<ProviderHarnessKind>(firstCatalog.id);
-  const selectedCatalog = HARNESS_CATALOG.find((entry) => entry.id === kind) ?? firstCatalog;
-  const defaultProvider = snapshot.modelProviders.find((provider) => provider.id === selectedCatalog.preferredProvider)
-    ?? snapshot.modelProviders[0]
-    ?? null;
-  const [displayName, setDisplayName] = useState(selectedCatalog.label);
+  const firstCatalog = snapshot.harnessCatalog.find((entry) => entry.available)
+    ?? snapshot.harnessCatalog[0]!;
+  const [kind, setKind] = useState<ProviderGenericHarnessKind>(firstCatalog.harness);
+  const selectedCatalog = snapshot.harnessCatalog.find((entry) => entry.harness === kind) ?? firstCatalog;
+  const defaultProvider = snapshot.modelProviders[0] ?? null;
+  const [displayName, setDisplayName] = useState(selectedCatalog.displayName);
   const [providerId, setProviderId] = useState(defaultProvider?.id ?? "");
   const provider = snapshot.modelProviders.find((candidate) => candidate.id === providerId) ?? defaultProvider;
   const firstModel = provider?.models.find((model) => model.enabled) ?? null;
@@ -53,19 +83,18 @@ export function AddHarnessDialog({
     sourceSupportsRoute(snapshot, source, providerId, modelId)), [modelId, providerId, snapshot]);
   const [sourceId, setSourceId] = useState(eligibleSources[0]?.id ?? "");
   const selectedSource = eligibleSources.find((source) => source.id === sourceId) ?? eligibleSources[0] ?? null;
-  const canAdd = availableCatalog.some((entry) => entry.id === kind)
+  const canAdd = selectedCatalog.available && selectedCatalog.runnable
     && displayName.trim() !== "" && provider !== null && modelId !== "" && selectedSource !== null;
+  const setup = setupCopy(selectedCatalog);
 
-  const selectKind = (nextKind: ProviderHarnessKind) => {
-    const catalog = HARNESS_CATALOG.find((entry) => entry.id === nextKind) ?? HARNESS_CATALOG[0]!;
-    const nextProvider = snapshot.modelProviders.find((candidate) => candidate.id === catalog.preferredProvider)
-      ?? snapshot.modelProviders[0]
-      ?? null;
+  const selectKind = (nextKind: ProviderGenericHarnessKind) => {
+    const catalog = snapshot.harnessCatalog.find((entry) => entry.harness === nextKind) ?? snapshot.harnessCatalog[0]!;
+    const nextProvider = snapshot.modelProviders[0] ?? null;
     const nextModel = nextProvider?.models.find((model) => model.enabled) ?? null;
     const nextSource = nextModel === null ? undefined : snapshot.accessSources.find((source) =>
       sourceSupportsRoute(snapshot, source, nextProvider?.id ?? "", nextModel.id));
     setKind(nextKind);
-    setDisplayName(catalog.label);
+    setDisplayName(catalog.displayName);
     setProviderId(nextProvider?.id ?? "");
     setModelId(nextModel?.id ?? "");
     setSourceId(nextSource?.id ?? "");
@@ -95,7 +124,7 @@ export function AddHarnessDialog({
       harness: kind,
       displayName: displayName.trim(),
       route: {
-        kind: selectedCatalog.routeKind,
+        kind: "configurable",
         providerId,
         modelId,
       },
@@ -108,19 +137,37 @@ export function AddHarnessDialog({
   return (
     <FeatureDialog title="Add harness" onClose={onClose}>
       <div className="matrix-ap-driver-grid">
-        {availableCatalog.map((entry) => (
-          <label key={entry.id} data-selected={entry.id === kind ? "true" : undefined}>
-            <input
-              type="radio"
-              name="harness-kind"
-              value={entry.id}
-              checked={entry.id === kind}
-              onChange={() => selectKind(entry.id)}
-            />
-            <span>{entry.label}</span>
-          </label>
-        ))}
+        {snapshot.harnessCatalog.map((entry) => {
+          const statusId = `matrix-ap-harness-status-${entry.harness}`;
+          return (
+            <label
+              key={entry.harness}
+              data-selected={entry.harness === kind ? "true" : undefined}
+              data-available={entry.available ? "true" : "false"}
+              data-runnable={entry.runnable ? "true" : "false"}
+            >
+              <input
+                type="radio"
+                name="harness-kind"
+                value={entry.harness}
+                checked={entry.harness === kind}
+                disabled={!entry.available}
+                aria-label={entry.displayName}
+                aria-describedby={statusId}
+                onChange={() => selectKind(entry.harness)}
+              />
+              <span>{entry.displayName}</span>
+              <small id={statusId}>{catalogStatus(entry)}</small>
+            </label>
+          );
+        })}
       </div>
+      {setup ? (
+        <div className="matrix-ap-setup-notice" role="status">
+          <strong>{setup.title}</strong>
+          <span>{setup.body}</span>
+        </div>
+      ) : null}
       <label className="matrix-ap-field">
         <span>Display name</span>
         <input value={displayName} onChange={(event) => setDisplayName(event.target.value)} maxLength={120} />
@@ -128,24 +175,32 @@ export function AddHarnessDialog({
       <div className="matrix-ap-form-grid">
         <label className="matrix-ap-field">
           <span>Model provider</span>
-          <select value={providerId} onChange={(event) => selectProvider(event.target.value)} disabled={selectedCatalog.routeKind === "fixed"}>
+          <select value={providerId} onChange={(event) => selectProvider(event.target.value)} disabled={!selectedCatalog.runnable}>
             {snapshot.modelProviders.map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.displayName}</option>)}
           </select>
         </label>
         <label className="matrix-ap-field">
           <span>Model</span>
-          <select value={modelId} onChange={(event) => selectModel(event.target.value)} disabled={selectedCatalog.routeKind === "fixed"}>
+          <select value={modelId} onChange={(event) => selectModel(event.target.value)} disabled={!selectedCatalog.runnable}>
             {provider?.models.filter((model) => model.enabled).map((model) => <option key={model.id} value={model.id}>{model.displayName}</option>)}
           </select>
         </label>
       </div>
       <label className="matrix-ap-field">
         <span>Access source</span>
-        <select value={selectedSource?.id ?? ""} onChange={(event) => setSourceId(event.target.value)}>
-          {eligibleSources.map((source) => <option key={source.id} value={source.id}>{source.displayName}</option>)}
+        <select value={selectedSource?.id ?? ""} onChange={(event) => setSourceId(event.target.value)} disabled={!selectedCatalog.runnable}>
+          {eligibleSources.map((source) => (
+            <option key={source.id} value={source.id}>
+              {source.displayName}{source.readiness.state === "ready" ? "" : " · authentication required"}
+            </option>
+          ))}
         </select>
       </label>
-      <p className="matrix-ap-help">Authentication opens in a visible Terminal, browser, or secure credential prompt after the harness is added.</p>
+      <p className="matrix-ap-help">
+        {selectedSource && selectedSource.readiness.state !== "ready"
+          ? "After adding the harness, continue authentication from Accounts in a visible Terminal, browser, or secure credential prompt."
+          : "Authentication always continues in a visible Terminal, browser, or secure credential prompt."}
+      </p>
       <div className="matrix-ap-dialog-actions">
         <button type="button" className="matrix-ap-button" onClick={onClose}>Cancel</button>
         <button type="button" className="matrix-ap-button matrix-ap-button-primary" disabled={!canAdd} onClick={add}>Add harness</button>

--- a/packages/ui/src/agents-providers/agents-providers.css
+++ b/packages/ui/src/agents-providers/agents-providers.css
@@ -274,10 +274,14 @@
 .matrix-ap-driver-grid { display: grid; gap: 7px; grid-template-columns: repeat(2, minmax(0, 1fr)); margin-bottom: 15px; }
 .matrix-ap-driver-grid label { align-items: center; background: var(--matrix-ap-surface); border: 1px solid var(--matrix-ap-border); border-radius: 9px; cursor: pointer; display: flex; gap: 8px; min-height: 46px; padding: 10px; }
 .matrix-ap-driver-grid label[data-selected="true"] { border-color: var(--matrix-ap-accent); box-shadow: inset 0 0 0 1px var(--matrix-ap-accent); }
-.matrix-ap-driver-grid label[data-installed="true"] { cursor: not-allowed; opacity: 0.5; }
+.matrix-ap-driver-grid label[data-available="false"] { cursor: not-allowed; opacity: 0.62; }
+.matrix-ap-driver-grid label[data-runnable="false"][data-available="true"] small { color: var(--matrix-ap-warning); }
 .matrix-ap-driver-grid input { accent-color: var(--matrix-ap-accent); }
 .matrix-ap-driver-grid span { font-size: 13px; font-weight: 620; }
 .matrix-ap-driver-grid small { color: var(--matrix-ap-faint); font-size: 10px; margin-left: auto; }
+.matrix-ap-setup-notice { background: color-mix(in srgb, var(--matrix-ap-warning) 9%, var(--matrix-ap-surface)); border: 1px solid color-mix(in srgb, var(--matrix-ap-warning) 28%, var(--matrix-ap-border)); border-radius: 9px; display: flex; flex-direction: column; gap: 3px; margin: 0 0 15px; padding: 10px 11px; }
+.matrix-ap-setup-notice strong { font-size: 11px; }
+.matrix-ap-setup-notice span { color: var(--matrix-ap-muted); font-size: 10px; line-height: 1.5; }
 
 @media (max-width: 760px) {
   .matrix-ap-page-head { align-items: flex-start; flex-direction: column; }

--- a/tests/contracts/provider-settings.test.ts
+++ b/tests/contracts/provider-settings.test.ts
@@ -44,6 +44,44 @@ function makeSnapshot(): ProviderSettingsSnapshot {
       "set_gateway_budget",
       "set_gateway_allowlist",
     ],
+    harnessCatalog: [
+      {
+        harness: "hermes",
+        displayName: "Hermes",
+        installState: "installed",
+        available: true,
+        runnable: true,
+        setupAction: "none",
+        safeReason: null,
+      },
+      {
+        harness: "openclaw",
+        displayName: "OpenClaw",
+        installState: "missing",
+        available: true,
+        runnable: false,
+        setupAction: "install",
+        safeReason: "not_installed",
+      },
+      {
+        harness: "pi",
+        displayName: "Pi",
+        installState: "missing",
+        available: false,
+        runnable: false,
+        setupAction: "none",
+        safeReason: "runtime_not_supported",
+      },
+      {
+        harness: "opencode",
+        displayName: "OpenCode",
+        installState: "unknown",
+        available: false,
+        runnable: false,
+        setupAction: "none",
+        safeReason: "runtime_not_supported",
+      },
+    ],
     modelProviders: [{
       id: "anthropic",
       displayName: "Anthropic",
@@ -208,6 +246,34 @@ describe("provider settings contracts", () => {
     expect(ProviderSettingsSnapshotSchema.safeParse(unavailableLogin).success).toBe(true);
     unavailableLogin.harnesses[0]!.recommendedLoginMethod = "terminal";
     expect(ProviderSettingsSnapshotSchema.safeParse(unavailableLogin).success).toBe(false);
+  });
+
+  it("requires a truthful, unique four-harness setup catalog", () => {
+    const snapshot = makeSnapshot();
+    expect(snapshot.harnessCatalog.map((entry) => entry.harness)).toEqual([
+      "hermes", "openclaw", "pi", "opencode",
+    ]);
+
+    expect(ProviderSettingsSnapshotSchema.safeParse({
+      ...snapshot,
+      harnessCatalog: snapshot.harnessCatalog.slice(0, 3),
+    }).success).toBe(false);
+    expect(ProviderSettingsSnapshotSchema.safeParse({
+      ...snapshot,
+      harnessCatalog: snapshot.harnessCatalog.map((entry) => entry.harness === "openclaw"
+        ? { ...entry, runnable: true }
+        : entry),
+    }).success).toBe(false);
+    expect(ProviderSettingsSnapshotSchema.safeParse({
+      ...snapshot,
+      harnessCatalog: snapshot.harnessCatalog.map((entry) => entry.harness === "pi"
+        ? { ...entry, setupAction: "install" }
+        : entry),
+    }).success).toBe(false);
+    expect(ProviderSettingsSnapshotSchema.safeParse({
+      ...snapshot,
+      configurationHarnessKinds: ["hermes"],
+    }).success).toBe(false);
   });
 
   it("keeps accounts owner-funded, opaque, reciprocal, and secret-free", () => {

--- a/tests/desktop/provider-settings-adapter.test.ts
+++ b/tests/desktop/provider-settings-adapter.test.ts
@@ -22,6 +22,12 @@ function snapshot(revision = 1): ProviderSettingsSnapshot {
     refreshedAt: checkedAt,
     access: { mode: "writable" },
     supportedActions: ["set_harness_enabled"],
+    harnessCatalog: [
+      { harness: "hermes", displayName: "Hermes", installState: "installed", available: true, runnable: true, setupAction: "none", safeReason: null },
+      { harness: "openclaw", displayName: "OpenClaw", installState: "missing", available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" },
+      { harness: "pi", displayName: "Pi", installState: "missing", available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" },
+      { harness: "opencode", displayName: "OpenCode", installState: "missing", available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" },
+    ],
     modelProviders: [{
       id: "anthropic",
       displayName: "Anthropic",

--- a/tests/gateway/chat-provider-catalog.test.ts
+++ b/tests/gateway/chat-provider-catalog.test.ts
@@ -160,6 +160,12 @@ function harnessSettings(
       refreshedAt: "2026-08-30T00:00:00.000Z",
       access: { mode: "writable" },
       supportedActions: [],
+      harnessCatalog: [
+        { harness: "hermes", displayName: "Hermes", installState: "missing", available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" },
+        { harness: "openclaw", displayName: "OpenClaw", installState: "missing", available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" },
+        { harness: "pi", displayName: "Pi", installState: "missing", available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" },
+        { harness: "opencode", displayName: "OpenCode", installState: "missing", available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" },
+      ],
       modelProviders: [],
       accessSources,
       accounts: [],

--- a/tests/gateway/provider-settings-routes.test.ts
+++ b/tests/gateway/provider-settings-routes.test.ts
@@ -25,6 +25,12 @@ const snapshot: ProviderSettingsSnapshot = {
     "set_gateway_budget",
     "set_gateway_allowlist",
   ],
+  harnessCatalog: [
+    { harness: "hermes", displayName: "Hermes", installState: "installed", available: true, runnable: true, setupAction: "none", safeReason: null },
+    { harness: "openclaw", displayName: "OpenClaw", installState: "missing", available: true, runnable: false, setupAction: "install", safeReason: "not_installed" },
+    { harness: "pi", displayName: "Pi", installState: "missing", available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" },
+    { harness: "opencode", displayName: "OpenCode", installState: "missing", available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" },
+  ],
   modelProviders: [{
     id: "anthropic",
     displayName: "Anthropic",

--- a/tests/gateway/provider-settings-store.test.ts
+++ b/tests/gateway/provider-settings-store.test.ts
@@ -159,6 +159,12 @@ describe("ProviderSettingsStore", () => {
       revision: 0,
       access: { mode: "writable" },
     });
+    expect(initial.harnessCatalog).toEqual([
+      expect.objectContaining({ harness: "hermes", available: false, runnable: false, safeReason: "runtime_not_supported" }),
+      expect.objectContaining({ harness: "openclaw", available: false, runnable: false, safeReason: "runtime_not_supported" }),
+      expect.objectContaining({ harness: "pi", available: false, runnable: false, safeReason: "runtime_not_supported" }),
+      expect.objectContaining({ harness: "opencode", available: false, runnable: false, safeReason: "runtime_not_supported" }),
+    ]);
     expect(initial.accessSources[0]!.usage).toMatchObject({
       kind: "unavailable",
       authority: "unavailable",
@@ -271,6 +277,44 @@ describe("ProviderSettingsStore", () => {
     })).resolves.toMatchObject({
       kind: "snapshot",
       snapshot: { harnesses: [expect.objectContaining({ enabled: true })] },
+    });
+  });
+
+  it("projects all four generic harness setup states from canonical inventory and runtime support", async () => {
+    canonical.drivers.push(
+      { id: "hermes", displayName: "Hermes", kind: "cli", installState: "installed", health: "ready", capabilities: ["tools"], setupActions: [] },
+      { id: "openclaw", displayName: "OpenClaw", kind: "cli", installState: "missing", health: "stopped", capabilities: ["tools"], setupActions: ["install"] },
+      { id: "pi", displayName: "Pi", kind: "cli", installState: "installed", health: "stopped", capabilities: ["tools"], setupActions: ["open_terminal"] },
+      { id: "opencode", displayName: "OpenCode", kind: "cli", installState: "installed", health: "ready", capabilities: ["tools"], setupActions: [] },
+    );
+    runtime = { ...runtime, supportedHarnessKinds: ["hermes", "openclaw", "pi"] };
+
+    const projected = await createStore().getSnapshot();
+
+    expect(projected.harnessCatalog).toEqual([
+      { harness: "hermes", displayName: "Hermes", installState: "installed", available: true, runnable: true, setupAction: "none", safeReason: null },
+      { harness: "openclaw", displayName: "OpenClaw", installState: "missing", available: true, runnable: false, setupAction: "install", safeReason: "not_installed" },
+      { harness: "pi", displayName: "Pi", installState: "installed", available: true, runnable: false, setupAction: "open_terminal", safeReason: "setup_required" },
+      { harness: "opencode", displayName: "OpenCode", installState: "installed", available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" },
+    ]);
+  });
+
+  it("fails closed when an installed coding harness has unknown health", async () => {
+    canonical.drivers.push(
+      { id: "opencode", displayName: "OpenCode", kind: "cli", installState: "installed", health: "unknown", capabilities: ["tools"], setupActions: [] },
+    );
+    runtime = { ...runtime, supportedHarnessKinds: ["opencode"] };
+
+    const projected = await createStore().getSnapshot();
+
+    expect(projected.harnessCatalog.find((entry) => entry.harness === "opencode")).toEqual({
+      harness: "opencode",
+      displayName: "OpenCode",
+      installState: "installed",
+      available: true,
+      runnable: false,
+      setupAction: "retry",
+      safeReason: "runtime_unavailable",
     });
   });
 

--- a/tests/gateway/provider-settings-store.test.ts
+++ b/tests/gateway/provider-settings-store.test.ts
@@ -18,6 +18,7 @@ import {
   type ProviderLoginCoordinator,
   type ProviderSettingsRuntimeCoordinator,
 } from "../../packages/gateway/src/ai-providers/provider-settings-store.js";
+import { createProviderDriverInventoryReader } from "../../packages/gateway/src/ai-providers/provider-driver-inventory.js";
 import {
   PROVIDER_SETTINGS_NOW as NOW,
   providerReady as ready,
@@ -299,10 +300,28 @@ describe("ProviderSettingsStore", () => {
     ]);
   });
 
-  it("fails closed when an installed coding harness has unknown health", async () => {
-    canonical.drivers.push(
-      { id: "opencode", displayName: "OpenCode", kind: "cli", installState: "installed", health: "unknown", capabilities: ["tools"], setupActions: [] },
-    );
+  it("lets a registered installed direct adapter receive credentials from its selected route", async () => {
+    const readDrivers = createProviderDriverInventoryReader({
+      detectAgentInstallations: vi.fn(async () => ({
+        agents: [{
+          id: "opencode" as const,
+          command: "opencode",
+          displayName: "OpenCode",
+          installState: "installed" as const,
+          installed: true,
+          authState: "unknown" as const,
+          workspaceCompatibility: "not_applicable" as const,
+          version: "1.16.0",
+          errorCode: null,
+        }],
+      })),
+      runtimeSource: vi.fn(async () => ({
+        runtime: { selected: null, transition: null, options: [] },
+        providers: [],
+        messaging: { runtime: "hermes" as const, provider: null, model: null, configured: false },
+      })),
+    });
+    canonical.drivers.push(...await readDrivers(AbortSignal.timeout(1_000)));
     runtime = { ...runtime, supportedHarnessKinds: ["opencode"] };
 
     const projected = await createStore().getSnapshot();
@@ -312,9 +331,9 @@ describe("ProviderSettingsStore", () => {
       displayName: "OpenCode",
       installState: "installed",
       available: true,
-      runnable: false,
-      setupAction: "retry",
-      safeReason: "runtime_unavailable",
+      runnable: true,
+      setupAction: "none",
+      safeReason: null,
     });
   });
 

--- a/tests/shell/provider-settings-transport.test.ts
+++ b/tests/shell/provider-settings-transport.test.ts
@@ -25,6 +25,12 @@ const snapshot = ProviderSettingsSnapshotSchema.parse({
   refreshedAt: "2026-08-30T10:00:00.000Z",
   access: { mode: "read_only", reason: "runtime_unavailable" },
   supportedActions: [],
+  harnessCatalog: [
+    { harness: "hermes", displayName: "Hermes", installState: "missing", available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" },
+    { harness: "openclaw", displayName: "OpenClaw", installState: "missing", available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" },
+    { harness: "pi", displayName: "Pi", installState: "missing", available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" },
+    { harness: "opencode", displayName: "OpenCode", installState: "missing", available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" },
+  ],
   modelProviders: [{
     id: "anthropic",
     displayName: "Anthropic",

--- a/tests/ui/agents-providers-view.test.tsx
+++ b/tests/ui/agents-providers-view.test.tsx
@@ -46,7 +46,7 @@ function snapshot(): ProviderSettingsSnapshot {
     ],
     accessSources: [
       {
-        id: "source_matrix",
+        id: "matrix_included",
         kind: "matrix_gateway",
         fundingKind: "matrix_included",
         providerId: "anthropic",
@@ -88,7 +88,7 @@ function snapshot(): ProviderSettingsSnapshot {
         },
       },
       {
-        id: "source_personal",
+        id: "owner_anthropic_profile",
         kind: "provider_account",
         fundingKind: "owner_subscription",
         providerId: "anthropic",
@@ -113,7 +113,7 @@ function snapshot(): ProviderSettingsSnapshot {
         },
       },
       {
-        id: "source_work",
+        id: "owner_anthropic_key",
         kind: "provider_account",
         fundingKind: "owner_api_key",
         providerId: "anthropic",
@@ -141,7 +141,7 @@ function snapshot(): ProviderSettingsSnapshot {
         },
       },
       {
-        id: "source_openai",
+        id: "owner_openai_profile",
         kind: "provider_account",
         fundingKind: "owner_subscription",
         providerId: "openai",
@@ -174,7 +174,7 @@ function snapshot(): ProviderSettingsSnapshot {
         authMethod: "terminal",
         authState: "authenticated",
         lastCheckedAt: now,
-        accessSourceId: "source_personal",
+        accessSourceId: "owner_anthropic_profile",
         dependencies: { activeChatCount: 2, resumableChatCount: 1, harnessInstanceCount: 1 },
       },
       {
@@ -184,7 +184,7 @@ function snapshot(): ProviderSettingsSnapshot {
         authMethod: "api_key",
         authState: "unauthenticated",
         lastCheckedAt: now,
-        accessSourceId: "source_work",
+        accessSourceId: "owner_anthropic_key",
         dependencies: { activeChatCount: 0, resumableChatCount: 0, harnessInstanceCount: 0 },
       },
       {
@@ -194,7 +194,7 @@ function snapshot(): ProviderSettingsSnapshot {
         authMethod: "oauth",
         authState: "authenticated",
         lastCheckedAt: now,
-        accessSourceId: "source_openai",
+        accessSourceId: "owner_openai_profile",
         dependencies: { activeChatCount: 0, resumableChatCount: 0, harnessInstanceCount: 0 },
       },
     ],
@@ -213,7 +213,7 @@ function snapshot(): ProviderSettingsSnapshot {
         connectivity: "online",
         accountIds: ["account_personal", "account_work"],
         selectedAccountId: "account_personal",
-        accessSourceId: "source_personal",
+        accessSourceId: "owner_anthropic_profile",
         route: { kind: "configurable", providerId: "anthropic", modelId: "anthropic/claude-opus-5" },
         activeChatCount: 2,
       },
@@ -231,13 +231,13 @@ function snapshot(): ProviderSettingsSnapshot {
         connectivity: "online",
         accountIds: ["account_personal"],
         selectedAccountId: null,
-        accessSourceId: "source_matrix",
+        accessSourceId: "matrix_included",
         route: { kind: "fixed", providerId: "anthropic", modelId: "anthropic/claude-opus-5" },
         activeChatCount: 0,
       },
     ],
     gatewayPolicy: {
-      accessSourceId: "source_matrix",
+      accessSourceId: "matrix_included",
       monthlyBudgetMicrousd: 1_000_000,
       allowedModelIds: ["anthropic/claude-opus-5"],
       topUpEnabled: true,
@@ -308,7 +308,7 @@ describe("AgentsProvidersView", () => {
       type: "set_route",
       harnessInstanceId: "harness_hermes",
       route: { kind: "configurable", providerId: "openai", modelId: "openai/gpt-5.6" },
-      accessSourceId: "source_openai",
+      accessSourceId: "owner_openai_profile",
       accountId: "account_openai",
     });
     expect(onMutate).toHaveBeenCalledWith({ type: "set_harness_enabled", harnessInstanceId: "harness_hermes", enabled: false });
@@ -318,18 +318,18 @@ describe("AgentsProvidersView", () => {
     const next = snapshot();
     const harness = next.harnesses[0]!;
     harness.route = { kind: "configurable", providerId: "anthropic", modelId: "anthropic/claude-sonnet-5" };
-    harness.accessSourceId = "source_matrix";
+    harness.accessSourceId = "matrix_included";
     harness.selectedAccountId = null;
     next.gatewayPolicy!.allowedModelIds = ["anthropic/claude-opus-5", "anthropic/claude-sonnet-5"];
     const { onMutate } = setup({ snapshot: next });
 
-    fireEvent.change(screen.getByLabelText("Access source"), { target: { value: "source_personal" } });
+    fireEvent.change(screen.getByLabelText("Access source"), { target: { value: "owner_anthropic_profile" } });
     fireEvent.change(screen.getByLabelText("Account"), { target: { value: "account_work" } });
     fireEvent.change(screen.getByLabelText("Account"), { target: { value: "" } });
 
-    expect(onMutate).toHaveBeenCalledWith({ type: "select_access_source", harnessInstanceId: "harness_hermes", accessSourceId: "source_personal" });
+    expect(onMutate).toHaveBeenCalledWith({ type: "select_access_source", harnessInstanceId: "harness_hermes", accessSourceId: "owner_anthropic_profile" });
     expect(onMutate).toHaveBeenCalledWith({ type: "select_account", harnessInstanceId: "harness_hermes", accountId: "account_work" });
-    expect(onMutate).toHaveBeenCalledWith({ type: "select_access_source", harnessInstanceId: "harness_hermes", accessSourceId: "source_matrix" });
+    expect(onMutate).toHaveBeenCalledWith({ type: "select_access_source", harnessInstanceId: "harness_hermes", accessSourceId: "matrix_included" });
     expect(onMutate).not.toHaveBeenCalledWith(expect.objectContaining({ type: "select_account", accountId: "" }));
   });
 
@@ -405,7 +405,7 @@ describe("AgentsProvidersView", () => {
     expect(within(sources).getByRole("option", {
       name: "Work Anthropic key · authentication required",
     })).toBeVisible();
-    fireEvent.change(sources, { target: { value: "source_work" } });
+    fireEvent.change(sources, { target: { value: "owner_anthropic_key" } });
     expect(within(dialog).getByText(/continue authentication from Accounts in a visible Terminal, browser, or secure credential prompt/)).toBeVisible();
   });
 
@@ -464,13 +464,13 @@ describe("AgentsProvidersView", () => {
     expect(dialog).toHaveTextContent("2 active chats");
     expect(dialog).toHaveTextContent("1 resumable chat");
     expect(within(dialog).queryByRole("button", { name: "Remove account" })).toBeNull();
-    fireEvent.change(within(dialog).getByLabelText("Reassign to"), { target: { value: "source:source_matrix" } });
+    fireEvent.change(within(dialog).getByLabelText("Reassign to"), { target: { value: "source:matrix_included" } });
     fireEvent.click(within(dialog).getByRole("button", { name: "Reassign dependencies" }));
 
     expect(onMutate).toHaveBeenCalledWith(expect.objectContaining({
       type: "reassign_account",
       fromAccountId: "account_personal",
-      target: { kind: "access_source", accessSourceId: "source_matrix" },
+      target: { kind: "access_source", accessSourceId: "matrix_included" },
       scope: "all_dependencies",
     }));
   });
@@ -535,7 +535,7 @@ describe("AgentsProvidersView", () => {
 
     expect(onRefresh).toHaveBeenCalledOnce();
     expect(onAddCredit).toHaveBeenCalledWith(
-      "source_matrix",
+      "matrix_included",
       "usd_10",
       expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i),
     );
@@ -576,7 +576,7 @@ describe("AgentsProvidersView", () => {
       connectivity: "offline",
       accountIds: [],
       selectedAccountId: null,
-      accessSourceId: "source_matrix",
+      accessSourceId: "matrix_included",
       activeChatCount: 0,
     });
     const { rerender } = setup({ snapshot: base, selectedHarnessId: "harness_pi" });
@@ -639,6 +639,28 @@ describe("AgentsProvidersView", () => {
     expect(within(dialog).queryByLabelText(/API key/i)).toBeNull();
   });
 
+  it("offers direct adapters only routes backed by portable credentials", () => {
+    setup();
+    fireEvent.click(screen.getByRole("button", { name: "Add harness" }));
+    const dialog = screen.getByRole("dialog", { name: "Add harness" });
+    fireEvent.click(within(dialog).getByRole("radio", { name: "OpenCode" }));
+
+    expect(within(within(dialog).getByLabelText("Model provider"))
+      .queryByRole("option", { name: "OpenAI" })).toBeNull();
+    expect(within(within(dialog).getByLabelText("Access source"))
+      .getByRole("option", { name: "Matrix AI included credit" })).toBeVisible();
+    expect(within(within(dialog).getByLabelText("Access source"))
+      .queryByRole("option", { name: "Personal Anthropic subscription" })).toBeNull();
+
+    fireEvent.change(within(dialog).getByLabelText("Model"), {
+      target: { value: "anthropic/claude-sonnet-5" },
+    });
+    expect(within(within(dialog).getByLabelText("Access source"))
+      .getByRole("option", { name: "Work Anthropic key · authentication required" })).toBeVisible();
+    expect(within(within(dialog).getByLabelText("Access source"))
+      .queryByRole("option", { name: "Personal Anthropic subscription" })).toBeNull();
+  });
+
   it("adds a second instance of an existing harness with its own route and account", () => {
     const { onMutate } = setup();
     fireEvent.click(screen.getByRole("button", { name: "Add harness" }));
@@ -657,7 +679,7 @@ describe("AgentsProvidersView", () => {
       harness: "hermes",
       displayName: "Hermes OpenAI",
       route: { kind: "configurable", providerId: "openai", modelId: "openai/gpt-5.6" },
-      accessSourceId: "source_openai",
+      accessSourceId: "owner_openai_profile",
       accountId: "account_openai",
     });
   });

--- a/tests/ui/agents-providers-view.test.tsx
+++ b/tests/ui/agents-providers-view.test.tsx
@@ -23,6 +23,12 @@ function snapshot(): ProviderSettingsSnapshot {
     refreshedAt: now,
     access: { mode: "writable" },
     configurationHarnessKinds: ["hermes", "openclaw", "pi", "opencode"],
+    harnessCatalog: [
+      { harness: "hermes", displayName: "Hermes", installState: "installed", available: true, runnable: true, setupAction: "none", safeReason: null },
+      { harness: "openclaw", displayName: "OpenClaw", installState: "missing", available: true, runnable: false, setupAction: "install", safeReason: "not_installed" },
+      { harness: "pi", displayName: "Pi", installState: "installed", available: true, runnable: true, setupAction: "none", safeReason: null },
+      { harness: "opencode", displayName: "OpenCode", installState: "installed", available: true, runnable: true, setupAction: "none", safeReason: null },
+    ],
     modelProviders: [
       {
         id: "anthropic",
@@ -350,17 +356,57 @@ describe("AgentsProvidersView", () => {
     expect(within(dialog).queryByRole("radio", { name: "Claude" })).toBeNull();
   });
 
-  it("offers only harness kinds enabled by the runtime workspace", () => {
+  it("always shows all generic harnesses and explains why unavailable kinds cannot be added", () => {
     const limited = snapshot();
     limited.configurationHarnessKinds = ["hermes", "openclaw"];
+    limited.harnessCatalog = limited.harnessCatalog.map((entry) => {
+      if (entry.harness === "pi" || entry.harness === "opencode") {
+        return { ...entry, available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" };
+      }
+      return entry;
+    });
     setup({ snapshot: limited });
 
     fireEvent.click(screen.getByRole("button", { name: "Add harness" }));
     const dialog = screen.getByRole("dialog", { name: "Add harness" });
     expect(within(dialog).getByRole("radio", { name: "Hermes" })).toBeVisible();
     expect(within(dialog).getByRole("radio", { name: "OpenClaw" })).toBeVisible();
-    expect(within(dialog).queryByRole("radio", { name: "Pi" })).toBeNull();
-    expect(within(dialog).queryByRole("radio", { name: "OpenCode" })).toBeNull();
+    expect(within(dialog).getByRole("radio", { name: "Pi" })).toBeDisabled();
+    expect(within(dialog).getByRole("radio", { name: "OpenCode" })).toBeDisabled();
+    expect(within(dialog).getAllByText(/Unavailable in this runtime/)).toHaveLength(2);
+    expect(within(dialog).getByRole("radio", { name: "Pi" }))
+      .toHaveAccessibleDescription(/Unavailable in this runtime/);
+    expect(within(dialog).getByRole("radio", { name: "OpenCode" }))
+      .toHaveAccessibleDescription(/Unavailable in this runtime/);
+  });
+
+  it("shows the truthful setup path for a supported harness that is not installed", () => {
+    setup();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add harness" }));
+    const dialog = screen.getByRole("dialog", { name: "Add harness" });
+    fireEvent.click(within(dialog).getByRole("radio", { name: "OpenClaw" }));
+
+    expect(within(dialog).getByText("Install OpenClaw before adding it")).toBeVisible();
+    expect(within(dialog).getByText(/Open Terminal and use the \+ menu to install OpenClaw/)).toBeVisible();
+    expect(within(dialog).getByRole("button", { name: "Add harness" })).toBeDisabled();
+  });
+
+  it("marks access sources that still need authentication and keeps the auth handoff visible", () => {
+    setup();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add harness" }));
+    const dialog = screen.getByRole("dialog", { name: "Add harness" });
+    fireEvent.change(within(dialog).getByLabelText("Model"), {
+      target: { value: "anthropic/claude-sonnet-5" },
+    });
+    const sources = within(dialog).getByLabelText("Access source");
+
+    expect(within(sources).getByRole("option", {
+      name: "Work Anthropic key · authentication required",
+    })).toBeVisible();
+    fireEvent.change(sources, { target: { value: "source_work" } });
+    expect(within(dialog).getByText(/continue authentication from Accounts in a visible Terminal, browser, or secure credential prompt/)).toBeVisible();
   });
 
   it("shows exact, stale, and unavailable gateway credit without inventing balances", () => {

--- a/tests/ui/provider-settings-controller.test.tsx
+++ b/tests/ui/provider-settings-controller.test.tsx
@@ -24,6 +24,12 @@ function snapshot(revision: number, harnessIds = ["harness_one"]): ProviderSetti
     refreshedAt: checkedAt,
     access: { mode: "writable" },
     supportedActions: ["update_harness", "set_harness_enabled", "start_login"],
+    harnessCatalog: [
+      { harness: "hermes", displayName: "Hermes", installState: "installed", available: true, runnable: true, setupAction: "none", safeReason: null },
+      { harness: "openclaw", displayName: "OpenClaw", installState: "missing", available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" },
+      { harness: "pi", displayName: "Pi", installState: "missing", available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" },
+      { harness: "opencode", displayName: "OpenCode", installState: "missing", available: false, runnable: false, setupAction: "none", safeReason: "runtime_not_supported" },
+    ],
     modelProviders: [{
       id: "anthropic",
       displayName: "Anthropic",


### PR DESCRIPTION
## Summary

- project a server-owned four-entry generic harness catalog for Hermes, OpenClaw, Pi, and OpenCode from canonical driver inventory plus runtime coordinator capabilities
- keep every harness visible with truthful installed, available, runnable, setup, and accessibility-readable status; block invalid adds when the runtime cannot execute the harness
- show the existing visible Terminal/browser/secure-prompt setup and authentication path without fabricating install sessions or credentials
- preserve the runtime coordinator as the fail-closed mutation authority; this PR does not add Pi or OpenCode execution support

## Tests

- 15 focused contract, gateway, UI, shell, and desktop adapter files: 192 passed
- TypeScript: contracts, gateway, UI, shell, Electron renderer, and Electron node configs
- `./scripts/review/check-patterns.sh --diff codex/generic-harness-lifecycle`: 0 violations; one reviewed warning for bounded ephemeral projection/schema Map/Set instances
- `git diff --check`

## Review / monitoring

- draft child of `codex/generic-harness-lifecycle`; exact Git parent is `a9b26971f3f3c88c2c5c164f102782545fccb3c5`
- Greptile review and CI are pending; do not merge independently of the parent stack
- Graphite tracking is configured locally. Direct submission was used because unrelated stale ancestors in the shared Graphite metadata block global `gt submit`; no unrelated branches were rewritten.

## Invariants

- **Source of truth:** canonical `AiProviderSnapshotV3.drivers` plus runtime coordinator `supportedHarnessKinds`, projected server-side into the settings snapshot
- **Fail closed:** only `ready` or `degraded` coding drivers are runnable; unknown/stopped/unavailable states remain non-runnable, and unsupported harnesses cannot submit mutations
- **Lock / transaction scope:** read-only projection only; mutations remain serialized by `ProviderSettingsStore` and the runtime coordinator
- **Acceptable orphan states:** no new persistence; unsupported or missing catalog rows are display-only and cannot mutate runtime state
- **Authentication:** provider access-source/account readiness stays canonical, and no credential or raw provider error is added to the snapshot
- **Deferred scope:** no Pi/OpenCode runtime adapters or binary installation are introduced; install/login execution continues through the existing Terminal and Accounts surfaces
