### PR TITLE
fix(chat): preserve provider and model defaults

### DIFF
--- a/desktop/src/main/persistence/local-store.ts
+++ b/desktop/src/main/persistence/local-store.ts
@@ -10,6 +10,7 @@ import {
   DesktopReleaseNotesSchema,
   DesktopUpdateVersionSchema,
 } from "../../shared/desktop-update";
+import { ProviderPreferencesSchema } from "../../shared/provider-preferences";
 
 export const PANEL_LAYOUT_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000;
 
@@ -53,35 +54,6 @@ const PanelLayoutSchema = z
 const PanelLayoutsSchema = z.record(z.string().max(256), PanelLayoutSchema);
 
 const RecentsSchema = z.array(z.string().max(512)).max(50);
-
-const ComposerOptionPreferenceSchema = z.strictObject({
-  id: z.string().regex(/^[a-z0-9][a-z0-9_-]{0,79}$/),
-  value: z.union([z.string().max(128), z.boolean()]),
-});
-
-const ComposerSelectionPreferenceSchema = z.strictObject({
-  options: z.array(ComposerOptionPreferenceSchema).max(16),
-  permissionMode: z.string().regex(/^[a-z0-9][a-z0-9_-]{0,79}$/),
-});
-
-const ComposerSelectionsSchema = z
-  .record(
-    z.string().regex(/^[a-z0-9][a-z0-9_-]{0,79}$/),
-    ComposerSelectionPreferenceSchema,
-  )
-  .refine((selections) => Object.keys(selections).length <= 20, {
-    message: "too many composer selection preferences",
-  });
-
-const ProviderPreferencesSchema = z
-  .object({
-    defaultProviderId: z
-      .string()
-      .regex(/^[a-z0-9][a-z0-9_-]{0,79}$/)
-      .nullable(),
-    composerSelections: ComposerSelectionsSchema.optional(),
-  })
-  .strict();
 
 const ProfileSchema = z
   .object({

--- a/desktop/src/renderer/src/features/chat/canonical-composer-state.ts
+++ b/desktop/src/renderer/src/features/chat/canonical-composer-state.ts
@@ -22,6 +22,7 @@ export interface CanonicalSlashEntry {
 }
 
 export interface CanonicalComposerPreference {
+  model?: string;
   options: Array<{ id: string; value: string | boolean }>;
   permissionMode: string;
 }
@@ -118,7 +119,12 @@ export function applyCanonicalComposerPreference(
   if (!preference) return current;
   const instance = catalog.instances.find((candidate) => candidate.id === current.instanceId);
   if (!instance) return current;
-  let next = current;
+  const preferredModel = preference.model
+    ? instance.models.find((model) => (
+        model.id === preference.model && model.availability === "available"
+      ))
+    : undefined;
+  let next = preferredModel ? { ...current, model: preferredModel.id } : current;
   for (const option of preference.options) {
     next = updateCanonicalComposerOption(catalog, next, option.id, option.value);
   }

--- a/desktop/src/renderer/src/features/chat/use-canonical-composer-selection.ts
+++ b/desktop/src/renderer/src/features/chat/use-canonical-composer-selection.ts
@@ -41,6 +41,7 @@ export function useCanonicalComposerSelection({
     initializeImmediately ? createCanonicalComposerSelection(catalog) : null
   ));
   const providerPreferencesHydrated = useProviderPreferences((state) => state.hydrated);
+  const lastComposerInstanceId = useProviderPreferences((state) => state.lastComposerInstanceId);
   const setComposerSelection = useProviderPreferences((state) => state.setComposerSelection);
   const composerSelectionTouched = useRef(false);
   const selectionChatId = useRef<string | null>(null);
@@ -58,9 +59,17 @@ export function useCanonicalComposerSelection({
     setSelection((current) => {
       if (!catalogReady) return null;
       const currentInstance = catalog.instances.find((instance) => instance.id === current?.instanceId);
+      const selectedChatInstance = currentSelection
+        ? catalog.instances.find((instance) => instance.id === currentSelection.instanceId)
+        : undefined;
+      const rememberedInstance = lastComposerInstanceId
+        ? catalog.instances.find((instance) => instance.id === lastComposerInstanceId)
+        : undefined;
       const requiredInstance = boundInstanceId
         ? catalog.instances.find((instance) => instance.id === boundInstanceId)
-        : currentInstance;
+        : chatId
+          ? selectedChatInstance ?? currentInstance
+          : rememberedInstance ?? currentInstance;
       const next = requiredInstance
         ? createCanonicalComposerSelection(catalog, requiredInstance.id)
         : createCanonicalComposerSelection(catalog);
@@ -93,7 +102,15 @@ export function useCanonicalComposerSelection({
           }
         : preferred;
     });
-  }, [boundInstanceId, catalog, catalogReady, chatId, currentSelection, providerPreferencesHydrated]);
+  }, [
+    boundInstanceId,
+    catalog,
+    catalogReady,
+    chatId,
+    currentSelection,
+    lastComposerInstanceId,
+    providerPreferencesHydrated,
+  ]);
 
   const onSelectionChange = useCallback((nextSelection: CanonicalComposerSelection) => {
     composerSelectionTouched.current = true;

--- a/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
@@ -54,6 +54,15 @@ import {
 import { ProjectChatHero } from "./ProjectChatHero";
 import { startCanonicalProjectChat } from "./start-canonical-project-chat";
 
+function composerOptionsEqual(
+  left: CanonicalComposerSelection["options"],
+  right: CanonicalComposerSelection["options"],
+): boolean {
+  return left.length === right.length && left.every((option) => (
+    right.some((candidate) => candidate.id === option.id && candidate.value === option.value)
+  ));
+}
+
 /**
  * The draft-chat pane: shown in the conversation column while no chat is
  * selected. It reuses the exact floating composer bar threads use (PromptInput
@@ -92,6 +101,7 @@ export function ProjectChatDraft({
   heroHeadline?: string;
 }) {
   const preferredProviderId = useProviderPreferences((s) => s.defaultProviderId);
+  const lastComposerInstanceId = useProviderPreferences((s) => s.lastComposerInstanceId);
   const composerSelections = useProviderPreferences((s) => s.composerSelections);
   const setComposerSelectionPreference = useProviderPreferences((s) => s.setComposerSelection);
   const api = useConnection((state) => state.api);
@@ -186,7 +196,7 @@ export function ProjectChatDraft({
     [canonicalClient, liveCatalog.catalog, liveCatalog.status, summary, unavailableCatalog],
   );
   const preferredInstanceId = canonicalClient
-    ? undefined
+    ? lastComposerInstanceId ?? undefined
     : instanceIdForLegacyProvider(projectCatalog, summary, effectiveDraft.providerId);
   const [canonicalSelection, setCanonicalSelection] = useState<CanonicalComposerSelection | null>(
     () => {
@@ -195,6 +205,9 @@ export function ProjectChatDraft({
         summary,
         restoredDraft?.providerId ?? initialDraft.providerId,
       ));
+      if (canonicalClient && lastComposerInstanceId) {
+        selection = createCanonicalComposerSelection(fallbackCatalog, lastComposerInstanceId);
+      }
       if (selection) {
         selection = applyCanonicalComposerPreference(
           fallbackCatalog,
@@ -249,6 +262,7 @@ export function ProjectChatDraft({
         && current.model === next.model
         && current.interactionMode === next.interactionMode
         && current.permissionMode === next.permissionMode
+        && composerOptionsEqual(current.options, next.options)
         ? current
         : next;
     });

--- a/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatDraft.tsx
@@ -205,7 +205,7 @@ export function ProjectChatDraft({
         summary,
         restoredDraft?.providerId ?? initialDraft.providerId,
       ));
-      if (canonicalClient && lastComposerInstanceId) {
+      if (canonicalClient && lastComposerInstanceId && !restoredEntry?.pickerTouched) {
         selection = createCanonicalComposerSelection(fallbackCatalog, lastComposerInstanceId);
       }
       if (selection) {

--- a/desktop/src/renderer/src/features/settings/provider-preferences.ts
+++ b/desktop/src/renderer/src/features/settings/provider-preferences.ts
@@ -7,6 +7,12 @@
 import "../../lib/operator";
 import { create } from "zustand";
 import { diagnosticErrorKind } from "../../lib/errors";
+import {
+  ComposerSelectionPreferenceSchema,
+  type ComposerSelectionPreference,
+  type ComposerSelectionPreferences,
+} from "../../../../shared/provider-preferences";
+import { CanonicalProviderInstanceIdSchema } from "@matrix-os/contracts";
 import type { CanonicalComposerSelection } from "../chat/canonical-composer-state";
 
 export const PROVIDER_PREFERENCES_STATE_KEY = "providerPreferences";
@@ -15,19 +21,11 @@ export const PROVIDER_PREFERENCES_STATE_KEY = "providerPreferences";
 // never trusts persisted or caller-supplied values).
 const PROVIDER_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,79}$/;
 const MAX_COMPOSER_SELECTIONS = 20;
-const MAX_COMPOSER_OPTIONS = 16;
-const MAX_OPTION_VALUE_LENGTH = 128;
-
-export interface ComposerSelectionPreference {
-  options: Array<{ id: string; value: string | boolean }>;
-  permissionMode: string;
-}
-
-type ComposerSelectionPreferences = Record<string, ComposerSelectionPreference>;
 
 interface ProviderPreferencesState {
   // null = automatic (composer picks the first ready provider).
   defaultProviderId: string | null;
+  lastComposerInstanceId: string | null;
   composerSelections: ComposerSelectionPreferences;
   hydrated: boolean;
   hydrate: () => Promise<void>;
@@ -39,6 +37,10 @@ function isValidProviderId(value: unknown): value is string {
   return typeof value === "string" && PROVIDER_ID_PATTERN.test(value);
 }
 
+function isValidInstanceId(value: unknown): value is string {
+  return CanonicalProviderInstanceIdSchema.safeParse(value).success;
+}
+
 function logPersistence(context: string, err: unknown): void {
   console.warn(
     `[provider-preferences] ${context}:`,
@@ -47,28 +49,17 @@ function logPersistence(context: string, err: unknown): void {
 }
 
 function parseComposerPreference(value: unknown): ComposerSelectionPreference | null {
-  if (!value || typeof value !== "object") return null;
-  const candidate = value as { options?: unknown; permissionMode?: unknown };
-  if (!isValidProviderId(candidate.permissionMode) || !Array.isArray(candidate.options)
-    || candidate.options.length > MAX_COMPOSER_OPTIONS) return null;
-  const options: ComposerSelectionPreference["options"] = [];
-  for (const option of candidate.options) {
-    if (!option || typeof option !== "object") return null;
-    const parsed = option as { id?: unknown; value?: unknown };
-    if (!isValidProviderId(parsed.id)) return null;
-    if (typeof parsed.value !== "boolean"
-      && (typeof parsed.value !== "string" || parsed.value.length > MAX_OPTION_VALUE_LENGTH)) return null;
-    if (options.some((existing) => existing.id === parsed.id)) return null;
-    options.push({ id: parsed.id, value: parsed.value });
-  }
-  return { options, permissionMode: candidate.permissionMode };
+  const parsed = ComposerSelectionPreferenceSchema.safeParse(value);
+  if (!parsed.success) return null;
+  const optionIds = parsed.data.options.map((option) => option.id);
+  return new Set(optionIds).size === optionIds.length ? parsed.data : null;
 }
 
 function parseComposerSelections(value: unknown): ComposerSelectionPreferences {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
   const parsed: ComposerSelectionPreferences = {};
   for (const [instanceId, preference] of Object.entries(value).slice(0, MAX_COMPOSER_SELECTIONS)) {
-    if (!isValidProviderId(instanceId)) continue;
+    if (!isValidInstanceId(instanceId)) continue;
     const valid = parseComposerPreference(preference);
     if (valid) parsed[instanceId] = valid;
   }
@@ -77,16 +68,24 @@ function parseComposerSelections(value: unknown): ComposerSelectionPreferences {
 
 function persistedPreferences(state: Pick<
   ProviderPreferencesState,
-  "defaultProviderId" | "composerSelections"
->): { defaultProviderId: string | null; composerSelections?: ComposerSelectionPreferences } {
-  return Object.keys(state.composerSelections).length > 0
-    ? { defaultProviderId: state.defaultProviderId, composerSelections: state.composerSelections }
-    : { defaultProviderId: state.defaultProviderId };
+  "defaultProviderId" | "lastComposerInstanceId" | "composerSelections"
+>): {
+  defaultProviderId: string | null;
+  lastComposerInstanceId?: string;
+  composerSelections?: ComposerSelectionPreferences;
+} {
+  return {
+    defaultProviderId: state.defaultProviderId,
+    ...(state.lastComposerInstanceId ? { lastComposerInstanceId: state.lastComposerInstanceId } : {}),
+    ...(Object.keys(state.composerSelections).length > 0
+      ? { composerSelections: state.composerSelections }
+      : {}),
+  };
 }
 
 function persistCurrentPreferences(state: Pick<
   ProviderPreferencesState,
-  "defaultProviderId" | "composerSelections"
+  "defaultProviderId" | "lastComposerInstanceId" | "composerSelections"
 >): void {
   void window.operator
     .invoke("state:set", {
@@ -100,6 +99,7 @@ function persistCurrentPreferences(state: Pick<
 
 export const useProviderPreferences = create<ProviderPreferencesState>()((set, get) => ({
   defaultProviderId: null,
+  lastComposerInstanceId: null,
   composerSelections: {},
   hydrated: false,
 
@@ -122,6 +122,10 @@ export const useProviderPreferences = create<ProviderPreferencesState>()((set, g
     const composerSelections = stored && typeof stored === "object"
       ? parseComposerSelections((stored as { composerSelections?: unknown }).composerSelections)
       : {};
+    const lastComposerInstanceId = stored && typeof stored === "object"
+      && isValidInstanceId((stored as { lastComposerInstanceId?: unknown }).lastComposerInstanceId)
+      ? (stored as { lastComposerInstanceId: string }).lastComposerInstanceId
+      : null;
     const current = get();
     set({
       defaultProviderId: current.defaultProviderId !== beforeHydration.defaultProviderId
@@ -130,6 +134,9 @@ export const useProviderPreferences = create<ProviderPreferencesState>()((set, g
       composerSelections: current.composerSelections !== beforeHydration.composerSelections
         ? current.composerSelections
         : composerSelections,
+      lastComposerInstanceId: current.lastComposerInstanceId !== beforeHydration.lastComposerInstanceId
+        ? current.lastComposerInstanceId
+        : lastComposerInstanceId,
       hydrated: true,
     });
   },
@@ -144,8 +151,9 @@ export const useProviderPreferences = create<ProviderPreferencesState>()((set, g
   },
 
   setComposerSelection: (selection) => {
-    if (!isValidProviderId(selection.instanceId)) return;
+    if (!isValidInstanceId(selection.instanceId)) return;
     const preference = parseComposerPreference({
+      model: selection.model,
       options: selection.options,
       permissionMode: selection.permissionMode,
     });
@@ -156,7 +164,11 @@ export const useProviderPreferences = create<ProviderPreferencesState>()((set, g
     if (keys.length > MAX_COMPOSER_SELECTIONS) {
       for (const key of keys.slice(0, keys.length - MAX_COMPOSER_SELECTIONS)) delete next[key];
     }
-    set({ composerSelections: next });
-    persistCurrentPreferences({ ...get(), composerSelections: next });
+    set({ composerSelections: next, lastComposerInstanceId: selection.instanceId });
+    persistCurrentPreferences({
+      ...get(),
+      composerSelections: next,
+      lastComposerInstanceId: selection.instanceId,
+    });
   },
 }));

--- a/desktop/src/shared/provider-preferences.ts
+++ b/desktop/src/shared/provider-preferences.ts
@@ -1,0 +1,34 @@
+import {
+  CanonicalChatModelReferenceSchema,
+  CanonicalProviderInstanceIdSchema,
+} from "@matrix-os/contracts";
+import { z } from "zod/v4";
+
+const PreferenceIdSchema = z.string().regex(/^[a-z0-9][a-z0-9_-]{0,79}$/);
+
+export const ComposerOptionPreferenceSchema = z.strictObject({
+  id: PreferenceIdSchema,
+  value: z.union([z.string().max(128), z.boolean()]),
+});
+
+export const ComposerSelectionPreferenceSchema = z.strictObject({
+  model: CanonicalChatModelReferenceSchema.optional(),
+  options: z.array(ComposerOptionPreferenceSchema).max(16),
+  permissionMode: PreferenceIdSchema,
+});
+
+export const ComposerSelectionsSchema = z
+  .record(CanonicalProviderInstanceIdSchema, ComposerSelectionPreferenceSchema)
+  .refine((selections) => Object.keys(selections).length <= 20, {
+    message: "too many composer selection preferences",
+  });
+
+export const ProviderPreferencesSchema = z.strictObject({
+  defaultProviderId: PreferenceIdSchema.nullable(),
+  lastComposerInstanceId: CanonicalProviderInstanceIdSchema.optional(),
+  composerSelections: ComposerSelectionsSchema.optional(),
+});
+
+export type ComposerSelectionPreference = z.infer<typeof ComposerSelectionPreferenceSchema>;
+export type ComposerSelectionPreferences = z.infer<typeof ComposerSelectionsSchema>;
+export type ProviderPreferences = z.infer<typeof ProviderPreferencesSchema>;

--- a/tests/desktop/canonical-chat-composer-preferences.test.tsx
+++ b/tests/desktop/canonical-chat-composer-preferences.test.tsx
@@ -12,6 +12,7 @@ import {
   snapshot,
 } from "./canonical-chat-workspace-test-utils";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetProviderPreferences } from "./provider-preferences-test-utils";
 
 describe("Canonical Chat composer preferences", () => {
   beforeAll(() => {
@@ -26,11 +27,7 @@ describe("Canonical Chat composer preferences", () => {
   beforeEach(() => {
     useBoard.setState(useBoard.getInitialState(), true);
     useConnection.setState(useConnection.getInitialState(), true);
-    useProviderPreferences.setState({
-      defaultProviderId: null,
-      composerSelections: {},
-      hydrated: true,
-    });
+    resetProviderPreferences({ hydrated: true });
     window.operator = {
       invoke: vi.fn(async () => ({ ok: true })),
       on: vi.fn(() => () => undefined),
@@ -81,6 +78,7 @@ describe("Canonical Chat composer preferences", () => {
     fireEvent.click(screen.getByRole("menuitemradio", { name: "full access" }));
 
     expect(useProviderPreferences.getState().composerSelections.codex_fixture).toEqual({
+      model: "gpt-5.6-sol",
       options: [{ id: "effort", value: "high" }],
       permissionMode: "full_access",
     });
@@ -91,5 +89,83 @@ describe("Canonical Chat composer preferences", () => {
     await screen.findByRole("textbox", { name: "Start a chat" });
     expect(screen.getByRole("button", { name: "Reasoning" }).textContent).toContain("High");
     expect(screen.getByRole("button", { name: "Permission mode" }).textContent).toContain("full access");
+  });
+
+  it("uses the last provider and model choice as the default for a new Chat", async () => {
+    const codexInstance = providerCatalog.instances[0]!;
+    const preferenceCatalog = {
+      ...providerCatalog,
+      drivers: [
+        ...providerCatalog.drivers,
+        {
+          kind: "claude_code" as const,
+          displayName: "Claude Code",
+          adapterVersion: "1.0.0",
+          capabilityClass: "coding_agent" as const,
+        },
+      ],
+      instances: [
+        codexInstance,
+        {
+          ...codexInstance,
+          id: "claude_fixture",
+          driverKind: "claude_code" as const,
+          displayName: "Claude fixture",
+          models: [
+            {
+              ...codexInstance.models[0]!,
+              id: "anthropic:claude-opus-4.6",
+              displayName: "Claude Opus 4.6",
+            },
+            {
+              ...codexInstance.models[0]!,
+              id: "anthropic:claude-sonnet-4.6",
+              displayName: "Claude Sonnet 4.6",
+            },
+          ],
+          defaultSelection: {
+            instanceId: "claude_fixture",
+            model: "anthropic:claude-opus-4.6",
+          },
+        },
+      ],
+    };
+    const first = render(
+      <CanonicalChatWorkspace
+        client={client()}
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        initialView="draft"
+        active
+        catalog={preferenceCatalog}
+      />,
+    );
+
+    await screen.findByRole("textbox", { name: "Start a chat" });
+    fireEvent.click(screen.getByRole("button", { name: "Choose model and provider" }));
+    fireEvent.click(screen.getByRole("button", { name: "Claude Code harness, Available" }));
+    fireEvent.click(screen.getByRole("option", { name: /Claude Sonnet 4\.6/ }));
+    expect(screen.getByRole("button", { name: "Choose model and provider" })
+      .getAttribute("data-provider-instance")).toBe("claude_fixture");
+    expect(screen.getByRole("button", { name: "Choose model and provider" })
+      .getAttribute("data-model")).toBe("anthropic:claude-sonnet-4.6");
+
+    first.unmount();
+    render(
+      <CanonicalChatWorkspace
+        client={client()}
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        initialView="draft"
+        active
+        catalog={preferenceCatalog}
+      />,
+    );
+
+    await screen.findByRole("textbox", { name: "Start a chat" });
+    expect(screen.getByRole("button", { name: "Choose model and provider" })
+      .getAttribute("data-provider-instance")).toBe("claude_fixture");
+    expect(screen.getByRole("button", { name: "Choose model and provider" })
+      .getAttribute("data-model")).toBe("anthropic:claude-sonnet-4.6");
   });
 });

--- a/tests/desktop/canonical-chat-composer-state.test.ts
+++ b/tests/desktop/canonical-chat-composer-state.test.ts
@@ -4,6 +4,7 @@ import type {
   CanonicalProviderCatalog,
 } from "@matrix-os/contracts";
 import {
+  applyCanonicalComposerPreference,
   changeCanonicalComposerInstance,
   createCanonicalComposerSelection,
   listCanonicalSlashEntries,
@@ -155,6 +156,22 @@ describe("canonical Chat composer state", () => {
         { id: "effort", value: "low" },
         { id: "fast", value: false },
       ]);
+  });
+
+  it("applies a remembered model only while it remains available", () => {
+    const catalog = catalogFixture();
+    const current = createCanonicalComposerSelection(catalog)!;
+
+    expect(applyCanonicalComposerPreference(catalog, current, {
+      model: "gpt-5.6-terra",
+      options: [],
+      permissionMode: "supervised",
+    }).model).toBe("gpt-5.6-terra");
+    expect(applyCanonicalComposerPreference(catalog, current, {
+      model: "gpt-5.6-missing",
+      options: [],
+      permissionMode: "supervised",
+    }).model).toBe("gpt-5.6-sol");
   });
 
   it("combines skills and commands into one slash menu", () => {

--- a/tests/desktop/chat-tab-render.test.tsx
+++ b/tests/desktop/chat-tab-render.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ChatTab from "../../desktop/src/renderer/src/features/chat/ChatTab";
 import { createLegacyGlobalProviderCatalog } from "../../desktop/src/renderer/src/features/chat/canonical-composer-adapter";
 import { useProviderPreferences } from "../../desktop/src/renderer/src/features/settings/provider-preferences";
+import { resetProviderPreferences } from "./provider-preferences-test-utils";
 import { useDesktopEditor } from "../../desktop/src/renderer/src/features/editor/desktop-editor-store";
 import {
   conversationMessageDisplay,
@@ -70,11 +71,7 @@ describe("ChatTab", () => {
     });
     useTabs.setState(useTabs.getInitialState(), true);
     useDesktopEditor.setState(useDesktopEditor.getInitialState(), true);
-    useProviderPreferences.setState({
-      defaultProviderId: null,
-      composerSelections: {},
-      hydrated: true,
-    });
+    resetProviderPreferences({ hydrated: true });
     useConnection.setState({
       status: "signed-in",
       handle: "operator",
@@ -749,6 +746,7 @@ describe("ChatTab", () => {
     fireEvent.click(screen.getByRole("menuitemradio", { name: "full access" }));
 
     expect(useProviderPreferences.getState().composerSelections.hermes_default).toEqual({
+      model: "provider-default",
       options: [{ id: "effort", value: "high" }],
       permissionMode: "full_access",
     });

--- a/tests/desktop/chat-tab-send-errors.test.tsx
+++ b/tests/desktop/chat-tab-send-errors.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ChatTab from "@desktop/renderer/src/features/chat/ChatTab";
 import { useProviderPreferences } from "@desktop/renderer/src/features/settings/provider-preferences";
+import { resetProviderPreferences } from "./provider-preferences-test-utils";
 import { useBoard } from "@desktop/renderer/src/stores/board";
 import { useCodingAgentWorkspace } from "@desktop/renderer/src/stores/coding-agent-workspace";
 import { useConnection } from "@desktop/renderer/src/stores/connection";
@@ -24,7 +25,7 @@ describe("ChatTab send failures", () => {
     useHermesChat.setState({ messages: [], status: "idle", view: "conversation" });
     useCodingAgentWorkspace.setState(useCodingAgentWorkspace.getInitialState(), true);
     useCodingAgentWorkspace.setState({ summary: { providers: [] } as never, status: "ready" });
-    useProviderPreferences.setState({ defaultProviderId: null, composerSelections: {}, hydrated: true });
+    resetProviderPreferences({ hydrated: true });
     useConnection.setState({
       status: "signed-in",
       handle: "operator",

--- a/tests/desktop/composer-provider-preference.test.tsx
+++ b/tests/desktop/composer-provider-preference.test.tsx
@@ -12,6 +12,7 @@ import { defaultAgentThreadComposerDraft, type RuntimeSummary } from "@matrix-os
 import { AgentComposer } from "../../desktop/src/renderer/src/features/coding-agents/AgentComposer";
 import { useProviderPreferences } from "../../desktop/src/renderer/src/features/settings/provider-preferences";
 import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
+import { resetProviderPreferences } from "./provider-preferences-test-utils";
 
 const NOW = "2026-07-27T12:00:00.000Z";
 
@@ -56,7 +57,7 @@ describe("AgentComposer default provider preference", () => {
         on: vi.fn(() => () => undefined),
       },
     });
-    useProviderPreferences.setState({ defaultProviderId: null, composerSelections: {}, hydrated: false });
+    resetProviderPreferences();
     useCodingAgentWorkspace.setState({ createStatus: "idle", createError: null });
   });
 
@@ -66,7 +67,7 @@ describe("AgentComposer default provider preference", () => {
   });
 
   it("keeps the ready provider when the saved preference is not runnable", () => {
-    useProviderPreferences.setState({ defaultProviderId: "claude", composerSelections: {}, hydrated: true });
+    resetProviderPreferences({ defaultProviderId: "claude", hydrated: true });
     render(
       <AgentComposer
         summary={summaryWith([provider("codex", true), provider("claude", false)])}
@@ -81,7 +82,7 @@ describe("AgentComposer default provider preference", () => {
   });
 
   it("uses the saved preference when that provider is runnable", () => {
-    useProviderPreferences.setState({ defaultProviderId: "claude", composerSelections: {}, hydrated: true });
+    resetProviderPreferences({ defaultProviderId: "claude", hydrated: true });
     render(
       <AgentComposer
         summary={summaryWith([provider("codex", true), provider("claude", true)])}

--- a/tests/desktop/draft-chat-replaces-selection.test.tsx
+++ b/tests/desktop/draft-chat-replaces-selection.test.tsx
@@ -15,6 +15,7 @@ import { useProjectChatLauncher } from "../../desktop/src/renderer/src/lib/proje
 import { clearDraftChats, useDraftChat } from "../../desktop/src/renderer/src/stores/draft-chat";
 import { codingAgentRuntimeScope } from "../../desktop/src/shared/coding-agent-project-workspace";
 import { setSharedComposerText } from "./shared-chat-composer-test-utils";
+import { resetProviderPreferences } from "./provider-preferences-test-utils";
 
 const NOW = "2026-07-12T12:00:00.000Z";
 const RUNTIME_SCOPE = codingAgentRuntimeScope({
@@ -222,7 +223,7 @@ function resetStores() {
     runtimeScope: RUNTIME_SCOPE,
     hydratedScope: RUNTIME_SCOPE,
   });
-  useProviderPreferences.setState({ defaultProviderId: null, composerSelections: {}, hydrated: false });
+  resetProviderPreferences();
   useCodingAgentWorkspace.setState({
     status: "idle",
     summary: null,

--- a/tests/desktop/draft-chat-send.test.tsx
+++ b/tests/desktop/draft-chat-send.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "@matrix-os/contracts";
 import ProjectChatsView from "../../desktop/src/renderer/src/features/project/ProjectChatsView";
 import { useProviderPreferences } from "../../desktop/src/renderer/src/features/settings/provider-preferences";
+import { resetProviderPreferences } from "./provider-preferences-test-utils";
 import { useCodingAgentWorkspace } from "../../desktop/src/renderer/src/stores/coding-agent-workspace";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 import { useInspectorLayout } from "../../desktop/src/renderer/src/features/panels/inspector-layout-store";
@@ -156,7 +157,7 @@ function resetStores() {
   useProjectChatLauncher.setState({ composerRequest: null });
   useTabs.setState(useTabs.getInitialState(), true);
   useInspectorLayout.setState({ entries: {}, runtimeScope: null });
-  useProviderPreferences.setState({ defaultProviderId: null, composerSelections: {}, hydrated: false });
+  resetProviderPreferences();
   useCodingAgentWorkspace.setState({
     status: "idle",
     summary: null,

--- a/tests/desktop/local-store.test.ts
+++ b/tests/desktop/local-store.test.ts
@@ -22,8 +22,10 @@ describe("local store", () => {
     const store = createLocalStore({ dir: await makeDir() });
     const preferences = {
       defaultProviderId: "codex",
+      lastComposerInstanceId: "codex_default",
       composerSelections: {
         codex_default: {
+          model: "openai-codex/gpt-5.6-sol",
           options: [{ id: "effort", value: "high" }],
           permissionMode: "full_access",
         },
@@ -42,6 +44,43 @@ describe("local store", () => {
         },
       },
     })).rejects.toThrow();
+    await expect(store.setUnknown("providerPreferences", {
+      ...preferences,
+      composerSelections: {
+        codex_default: {
+          model: "../../private-model",
+          options: [],
+          permissionMode: "supervised",
+        },
+      },
+    })).rejects.toThrow();
+    await expect(store.setUnknown("providerPreferences", {
+      ...preferences,
+      composerSelections: {
+        codex_default: {
+          model: "C:/private-model",
+          options: [],
+          permissionMode: "supervised",
+        },
+      },
+    })).rejects.toThrow();
+  });
+
+  it("keeps older composer preferences readable before a model is chosen", async () => {
+    const store = createLocalStore({ dir: await makeDir() });
+    const legacyPreferences = {
+      defaultProviderId: "codex",
+      composerSelections: {
+        codex_default: {
+          options: [{ id: "effort", value: "high" }],
+          permissionMode: "full_access",
+        },
+      },
+    };
+
+    await store.set("providerPreferences", legacyPreferences);
+
+    expect(await store.get("providerPreferences")).toEqual(legacyPreferences);
   });
 
   it("persists bounded desktop release notes for the post-update What's New dialog", async () => {

--- a/tests/desktop/project-chat-draft-send-errors.test.tsx
+++ b/tests/desktop/project-chat-draft-send-errors.test.tsx
@@ -178,6 +178,50 @@ describe("ProjectChatDraft send failures", () => {
     expect(picker.getAttribute("data-model")).toBe("claude-sonnet-4.6");
   });
 
+  it("applies the global default to a restored draft without explicit picker intent", async () => {
+    const summaryWithModels: RuntimeSummary = {
+      ...summary,
+      providers: summary.providers.map((provider) => ({
+        ...provider,
+        defaultModel: provider.id === "claude" ? "claude-sonnet-4.6" : "gpt-5.6",
+      })),
+    };
+    useDraftChat.getState().setDraft("matrix-os", {
+      ...defaultAgentThreadComposerDraft(summaryWithModels),
+      providerId: "claude",
+      prompt: "Continue the untouched restored draft",
+    });
+    resetProviderPreferences({
+      hydrated: true,
+      lastComposerInstanceId: "codex_default",
+      composerSelections: {
+        codex_default: {
+          model: "gpt-5.6",
+          options: [{ id: "effort", value: "high" }],
+          permissionMode: "supervised",
+        },
+      },
+    });
+
+    render(
+      <ProjectChatDraft
+        summary={summaryWithModels}
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        active={false}
+        seed={null}
+        focusRequestId={0}
+        typeToStartEnabled={false}
+        onCreated={vi.fn()}
+        canonicalClient={{} as never}
+      />,
+    );
+
+    const picker = await screen.findByRole("button", { name: "Choose model and provider" });
+    expect(picker.getAttribute("data-provider-instance")).toBe("codex_default");
+    expect(picker.getAttribute("data-model")).toBe("gpt-5.6");
+  });
+
   it("applies a remembered effort after preferences hydrate on a cold mount", async () => {
     resetProviderPreferences();
     let resolveStateGet!: (result: { value: unknown }) => void;

--- a/tests/desktop/project-chat-draft-send-errors.test.tsx
+++ b/tests/desktop/project-chat-draft-send-errors.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeSummary } from "@matrix-os/contracts";
 import { ProjectChatDraft } from "@desktop/renderer/src/features/project/ProjectChatDraft";
@@ -11,6 +11,7 @@ import { useProjectWorkspaces } from "@desktop/renderer/src/stores/project-works
 import { useProviderPreferences } from "@desktop/renderer/src/features/settings/provider-preferences";
 import { AppError } from "@desktop/shared/app-error";
 import { setSharedComposerText } from "./shared-chat-composer-test-utils";
+import { resetProviderPreferences } from "./provider-preferences-test-utils";
 
 const catalogMock = vi.hoisted(() => ({ attachments: true }));
 vi.mock("@desktop/renderer/src/features/chat/chat-provider-catalog", async (importOriginal) => {
@@ -45,6 +46,16 @@ const summary: RuntimeSummary = {
     supportedModes: ["default"],
     defaultMode: "default",
     setupActions: [],
+  }, {
+    id: "claude",
+    kind: "claude",
+    displayName: "Claude Code",
+    availability: "available",
+    installStatus: "installed",
+    authStatus: "authenticated",
+    supportedModes: ["default"],
+    defaultMode: "default",
+    setupActions: [],
   }],
   projects: { items: [], hasMore: false, limit: 20 },
   activeThreads: { items: [], hasMore: false, limit: 20 },
@@ -69,7 +80,7 @@ describe("ProjectChatDraft send failures", () => {
     useProjectWorkspaces.setState({
       resolveNewChatTarget: vi.fn(async () => ({ projectId: "matrix-os" })),
     });
-    useProviderPreferences.setState({ composerSelections: {}, hydrated: true });
+    resetProviderPreferences({ hydrated: true });
     Object.defineProperty(window, "operator", {
       configurable: true,
       value: {
@@ -86,6 +97,85 @@ describe("ProjectChatDraft send failures", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+  });
+
+  it("restores the last Provider Instance and model in a canonical Project Chat draft", async () => {
+    resetProviderPreferences({
+      hydrated: true,
+      lastComposerInstanceId: "claude_code_default",
+      composerSelections: {
+        claude_code_default: {
+          model: "provider-default",
+          options: [],
+          permissionMode: "supervised",
+        },
+      },
+    });
+
+    render(
+      <ProjectChatDraft
+        summary={summary}
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        active={false}
+        seed={null}
+        focusRequestId={0}
+        typeToStartEnabled={false}
+        onCreated={vi.fn()}
+        canonicalClient={{} as never}
+      />,
+    );
+
+    await screen.findByRole("textbox", { name: "Message new chat" });
+    const picker = screen.getByRole("button", { name: "Choose model and provider" });
+    expect(picker.getAttribute("data-provider-instance")).toBe("claude_code_default");
+    expect(picker.getAttribute("data-model")).toBe("provider-default");
+  });
+
+  it("applies a remembered effort after preferences hydrate on a cold mount", async () => {
+    resetProviderPreferences();
+    let resolveStateGet!: (result: { value: unknown }) => void;
+    const stateGet = new Promise<{ value: unknown }>((resolve) => {
+      resolveStateGet = resolve;
+    });
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "state:get") return stateGet;
+      if (channel === "state:set") return Promise.resolve({ ok: true });
+      return Promise.reject(new Error(`unexpected channel ${channel}`));
+    });
+
+    render(
+      <ProjectChatDraft
+        summary={summary}
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        active={false}
+        seed={null}
+        focusRequestId={0}
+        typeToStartEnabled={false}
+        onCreated={vi.fn()}
+        canonicalClient={{} as never}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Reasoning" }).textContent).toContain("Low");
+    resolveStateGet({
+      value: {
+        defaultProviderId: null,
+        lastComposerInstanceId: "codex_default",
+        composerSelections: {
+          codex_default: {
+            model: "provider-default",
+            options: [{ id: "effort", value: "high" }],
+            permissionMode: "supervised",
+          },
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Reasoning" }).textContent).toContain("High");
+    });
   });
 
   it("shows the upload reason and keeps the draft for retry", async () => {

--- a/tests/desktop/project-chat-draft-send-errors.test.tsx
+++ b/tests/desktop/project-chat-draft-send-errors.test.tsx
@@ -3,10 +3,11 @@
 import React from "react";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { RuntimeSummary } from "@matrix-os/contracts";
+import { defaultAgentThreadComposerDraft, type RuntimeSummary } from "@matrix-os/contracts";
 import { ProjectChatDraft } from "@desktop/renderer/src/features/project/ProjectChatDraft";
 import { useCodingAgentWorkspace } from "@desktop/renderer/src/stores/coding-agent-workspace";
 import { useConnection } from "@desktop/renderer/src/stores/connection";
+import { useDraftChat } from "@desktop/renderer/src/stores/draft-chat";
 import { useProjectWorkspaces } from "@desktop/renderer/src/stores/project-workspaces";
 import { useProviderPreferences } from "@desktop/renderer/src/features/settings/provider-preferences";
 import { AppError } from "@desktop/shared/app-error";
@@ -77,6 +78,7 @@ describe("ProjectChatDraft send failures", () => {
     } as typeof ResizeObserver;
     useConnection.setState({ api: null });
     useCodingAgentWorkspace.setState(useCodingAgentWorkspace.getInitialState(), true);
+    useDraftChat.setState({ entries: {} });
     useProjectWorkspaces.setState({
       resolveNewChatTarget: vi.fn(async () => ({ projectId: "matrix-os" })),
     });
@@ -130,6 +132,50 @@ describe("ProjectChatDraft send failures", () => {
     const picker = screen.getByRole("button", { name: "Choose model and provider" });
     expect(picker.getAttribute("data-provider-instance")).toBe("claude_code_default");
     expect(picker.getAttribute("data-model")).toBe("provider-default");
+  });
+
+  it("keeps an explicitly selected restored draft provider ahead of the global default", async () => {
+    const summaryWithModels: RuntimeSummary = {
+      ...summary,
+      providers: summary.providers.map((provider) => ({
+        ...provider,
+        defaultModel: provider.id === "claude" ? "claude-sonnet-4.6" : "gpt-5.6",
+      })),
+    };
+    useDraftChat.getState().setDraft("matrix-os", {
+      ...defaultAgentThreadComposerDraft(summaryWithModels),
+      providerId: "claude",
+      prompt: "Continue the restored draft",
+    }, true);
+    resetProviderPreferences({
+      hydrated: true,
+      lastComposerInstanceId: "codex_default",
+      composerSelections: {
+        codex_default: {
+          model: "gpt-5.6",
+          options: [{ id: "effort", value: "high" }],
+          permissionMode: "supervised",
+        },
+      },
+    });
+
+    render(
+      <ProjectChatDraft
+        summary={summaryWithModels}
+        projectId="matrix-os"
+        projectLabel="Matrix OS"
+        active={false}
+        seed={null}
+        focusRequestId={0}
+        typeToStartEnabled={false}
+        onCreated={vi.fn()}
+        canonicalClient={{} as never}
+      />,
+    );
+
+    const picker = await screen.findByRole("button", { name: "Choose model and provider" });
+    expect(picker.getAttribute("data-provider-instance")).toBe("claude_code_default");
+    expect(picker.getAttribute("data-model")).toBe("claude-sonnet-4.6");
   });
 
   it("applies a remembered effort after preferences hydrate on a cold mount", async () => {

--- a/tests/desktop/provider-preferences-test-utils.ts
+++ b/tests/desktop/provider-preferences-test-utils.ts
@@ -1,0 +1,14 @@
+import type { ProviderPreferences } from "@desktop/shared/provider-preferences";
+import { useProviderPreferences } from "@desktop/renderer/src/features/settings/provider-preferences";
+
+export function resetProviderPreferences(
+  overrides: Partial<ProviderPreferences> & { hydrated?: boolean } = {},
+): void {
+  useProviderPreferences.setState({
+    defaultProviderId: null,
+    lastComposerInstanceId: null,
+    composerSelections: {},
+    hydrated: false,
+    ...overrides,
+  });
+}

--- a/tests/desktop/providers-section.test.tsx
+++ b/tests/desktop/providers-section.test.tsx
@@ -5,6 +5,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-libra
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ProvidersSection from "../../desktop/src/renderer/src/features/settings/sections/ProvidersSection";
 import { useProviderPreferences } from "../../desktop/src/renderer/src/features/settings/provider-preferences";
+import { resetProviderPreferences } from "./provider-preferences-test-utils";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 import { useTabs } from "../../desktop/src/renderer/src/stores/tabs";
 
@@ -90,7 +91,7 @@ describe("ProvidersSection", () => {
       activeTabId: "home",
       tabs: [{ id: "home", kind: "home", title: "Home", closable: false }],
     });
-    useProviderPreferences.setState({ defaultProviderId: null, composerSelections: {}, hydrated: false });
+    resetProviderPreferences();
     window.operator = {
       invoke: vi.fn((channel: string) => {
         if (channel === "runtime:get-summary") return summaryResult();
@@ -238,7 +239,7 @@ describe("ProvidersSection", () => {
   });
 
   it("resets the default provider back to automatic", async () => {
-    useProviderPreferences.setState({ defaultProviderId: "codex", composerSelections: {}, hydrated: true });
+    resetProviderPreferences({ defaultProviderId: "codex", hydrated: true });
     render(<ProvidersSection />);
     expect((await screen.findAllByText("Codex")).length).toBeGreaterThan(0);
 

--- a/tests/desktop/settings-provider-preferences.test.tsx
+++ b/tests/desktop/settings-provider-preferences.test.tsx
@@ -5,10 +5,11 @@ import {
   PROVIDER_PREFERENCES_STATE_KEY,
   useProviderPreferences,
 } from "../../desktop/src/renderer/src/features/settings/provider-preferences";
+import { resetProviderPreferences } from "./provider-preferences-test-utils";
 
 describe("provider preferences store", () => {
   beforeEach(() => {
-    useProviderPreferences.setState({ defaultProviderId: null, composerSelections: {}, hydrated: false });
+    resetProviderPreferences();
     window.operator = {
       invoke: vi.fn((channel: string) => {
         if (channel === "state:get") return Promise.resolve({ value: null });
@@ -72,7 +73,7 @@ describe("provider preferences store", () => {
     expect(useProviderPreferences.getState().hydrated).toBe(true);
   });
 
-  it("persists bounded effort and permission preferences per Provider Instance", () => {
+  it("persists the bounded model, effort, and permission preference per Provider Instance", () => {
     useProviderPreferences.getState().setComposerSelection({
       instanceId: "codex_default",
       model: "gpt-5.6-sol",
@@ -82,15 +83,19 @@ describe("provider preferences store", () => {
     });
 
     expect(useProviderPreferences.getState().composerSelections.codex_default).toEqual({
+      model: "gpt-5.6-sol",
       options: [{ id: "effort", value: "high" }],
       permissionMode: "full_access",
     });
+    expect(useProviderPreferences.getState().lastComposerInstanceId).toBe("codex_default");
     expect(window.operator.invoke).toHaveBeenCalledWith("state:set", {
       key: PROVIDER_PREFERENCES_STATE_KEY,
       value: {
         defaultProviderId: null,
+        lastComposerInstanceId: "codex_default",
         composerSelections: {
           codex_default: {
+            model: "gpt-5.6-sol",
             options: [{ id: "effort", value: "high" }],
             permissionMode: "full_access",
           },
@@ -131,6 +136,48 @@ describe("provider preferences store", () => {
     });
   });
 
+  it("hydrates the last Provider Instance and model while rejecting unsafe model references", async () => {
+    window.operator.invoke = vi.fn((channel: string) => {
+      if (channel === "state:get") {
+        return Promise.resolve({
+          value: {
+            defaultProviderId: "codex",
+            lastComposerInstanceId: "codex:work",
+            composerSelections: {
+              "codex:work": {
+                model: "openai-codex/gpt-5.6-terra",
+                options: [],
+                permissionMode: "supervised",
+              },
+              codex_unsafe: {
+                model: "../../private-model",
+                options: [],
+                permissionMode: "supervised",
+              },
+              codex_windows: {
+                model: "C:/private-model",
+                options: [],
+                permissionMode: "supervised",
+              },
+            },
+          },
+        });
+      }
+      return Promise.resolve({ ok: true });
+    });
+
+    await useProviderPreferences.getState().hydrate();
+
+    expect(useProviderPreferences.getState().lastComposerInstanceId).toBe("codex:work");
+    expect(useProviderPreferences.getState().composerSelections).toEqual({
+      "codex:work": {
+        model: "openai-codex/gpt-5.6-terra",
+        options: [],
+        permissionMode: "supervised",
+      },
+    });
+  });
+
   it("does not overwrite a picker change made while hydration is in flight", async () => {
     let resolveHydration!: (value: { value: null }) => void;
     window.operator.invoke = vi.fn((channel: string) => {
@@ -152,9 +199,11 @@ describe("provider preferences store", () => {
     await hydration;
 
     expect(useProviderPreferences.getState().composerSelections.codex_default).toEqual({
+      model: "gpt-5.6-sol",
       options: [{ id: "effort", value: "high" }],
       permissionMode: "full_access",
     });
+    expect(useProviderPreferences.getState().lastComposerInstanceId).toBe("codex_default");
   });
 
   it("hydrate falls back to automatic when the persisted value is malformed", async () => {


### PR DESCRIPTION
## Summary

- Persist the last canonical Chat Provider Instance and model alongside effort and permission preferences.
- Restore supported provider/model defaults in new Global and Project Chats while keeping an existing Chat binding authoritative.
- Keep an explicitly selected restored Project Chat draft ahead of the global provider/model default, while untouched drafts adopt the latest global default.
- Reapply remembered Project Chat options after asynchronous cold-start hydration.
- Validate persisted preference data with shared canonical schemas and fall back safely when a remembered instance or model is unavailable.

## Tests

- `flox activate -- bun run test tests/desktop/canonical-chat-composer-preferences.test.tsx tests/desktop/canonical-chat-composer-state.test.ts tests/desktop/settings-provider-preferences.test.tsx tests/desktop/local-store.test.ts tests/desktop/draft-chat-replaces-selection.test.tsx tests/desktop/project-chat-draft-send-errors.test.tsx tests/desktop/chat-tab-send-errors.test.tsx tests/desktop/draft-chat-send.test.tsx tests/desktop/chat-tab-render.test.tsx tests/desktop/providers-section.test.tsx tests/desktop/composer-provider-preference.test.tsx` (129 passed)
- `flox activate -- bun run typecheck`
- `flox activate -- bun run check:patterns` (0 violations; 5 existing warnings)
- `flox activate -- bun run build:desktop`
- `flox activate -- bun run test` completed with 1,050 test files and 12,310 tests passing. Eighteen tests failed in six unrelated platform, gateway, and terminal baseline files; none of those files or their implementations are changed by this PR.

## Invariants

- **Source of truth:** Desktop `providerPreferences` stores user defaults for a new composer. The canonical Provider catalog remains authoritative for availability, and an existing Chat binding or explicitly touched restored draft remains authoritative for that Chat. An untouched restored draft retains prompt/context but adopts the latest global provider/model default.
- **Lock/transaction scope:** None. This is bounded, recreatable local Desktop preference state.
- **Acceptable orphan states:** Stale provider/model preferences may remain on disk; they are ignored and replaced with an available catalog default.
- **Auth source of truth:** Unchanged. Provider availability and authentication continue to come from the canonical catalog/runtime.
- **Deferred scope:** Switching the Provider Instance of an already bound Chat remains intentionally locked.
