### PR TITLE
fix(desktop): restore secure chat submissions

### DIFF
--- a/desktop/src/main/renderer-url.ts
+++ b/desktop/src/main/renderer-url.ts
@@ -1,4 +1,4 @@
-export const DESKTOP_DEV_RENDERER_HOST = "desktop.local.matrix-os.com";
+export const DESKTOP_DEV_RENDERER_HOST = "desktop.localhost";
 
 const LOCAL_RENDERER_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]"]);
 
@@ -19,4 +19,3 @@ export function resolveDesktopRendererUrl(rendererUrl: string | undefined): stri
 export function desktopDevHostResolverRules(): string {
   return `MAP ${DESKTOP_DEV_RENDERER_HOST} 127.0.0.1`;
 }
-

--- a/tests/desktop/desktop-renderer-url.test.ts
+++ b/tests/desktop/desktop-renderer-url.test.ts
@@ -6,6 +6,10 @@ import {
 } from "@desktop/main/renderer-url";
 
 describe("Desktop renderer URL", () => {
+  it("keeps the local renderer in a potentially trustworthy localhost origin", () => {
+    expect(DESKTOP_DEV_RENDERER_HOST).toMatch(/(?:^|\.)localhost$/);
+  });
+
   it("maps the local Vite renderer onto an allowed Matrix development hostname", () => {
     expect(resolveDesktopRendererUrl("http://127.0.0.1:5173/")).toBe(
       `http://${DESKTOP_DEV_RENDERER_HOST}:5173/`,


### PR DESCRIPTION
## Summary

- serve the Electron development renderer from `desktop.localhost`
- restore a potentially trustworthy origin so Web Crypto APIs such as `crypto.randomUUID()` are available to Chat submissions
- add regression coverage requiring the development hostname to remain localhost-trusted

## Tests

- `pnpm --filter desktop typecheck`
- `pnpm exec vitest run tests/desktop/desktop-renderer-url.test.ts tests/desktop/header-injection.test.ts tests/desktop/renderer-csp.test.ts` (27 passed)
- `pnpm run check:patterns` (0 violations; existing warnings only)
- Electron runtime probe: `isSecureContext === true`, `crypto.randomUUID` available

## Validation notes

- The root `typecheck` command could not start because `bun` is unavailable in the current shell; the affected desktop package typecheck passed.
- The full test suite was stopped after unrelated `tests/kernel/heartbeat.test.ts` and `tests/gateway/app-runtime/build-orchestrator.test.ts` cases repeatedly timed out. The affected desktop test set passes.
