### PR TITLE
fix(terminal): add durable session lifecycle UI

### DIFF
--- a/packages/contracts/src/os-view.ts
+++ b/packages/contracts/src/os-view.ts
@@ -150,6 +150,7 @@ export function isOsViewDestinationPath(path: string): boolean {
 const OsViewPathSchema = z.string().min(1).max(2048);
 const OsViewCoordinateSchema = z.number().finite().min(-16_384).max(16_384);
 const OsViewDimensionSchema = z.number().finite().min(1).max(16_384);
+const OsViewTerminalLayoutIdSchema = z.string().regex(/^term-layout_[0-9a-f]{32}$/);
 
 export const OsViewAppStateSchema = z.object({
   path: OsViewPathSchema,
@@ -164,6 +165,7 @@ export const OsViewWindowGeometrySchema = z.object({
   y: OsViewCoordinateSchema,
   width: OsViewDimensionSchema,
   height: OsViewDimensionSchema,
+  terminalLayoutId: OsViewTerminalLayoutIdSchema.optional(),
 }).strict();
 
 export const OsViewDesktopIconSchema = z.object({

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -56,7 +56,6 @@ import { isMainSectionApp, applyOrder } from "@/lib/dock-sections";
 import { MatrixLoadingScreen } from "./MatrixLoadingScreen";
 import {
   enqueueTerminalLaunch,
-  TERMINAL_SETUP_WINDOW_PATH,
   type TerminalLaunchAction,
 } from "@/lib/terminal-launch";
 import { enqueueExistingTerminalSession } from "@/lib/provider-terminal-session";
@@ -355,7 +354,9 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
     // In canvas mode, pan to center on the window after it opens/focuses
     if (useDesktopMode.getState().mode === "canvas") {
       requestAnimationFrame(() => {
-        const win = useWindowManager.getState().windows.find((w) => w.path === path);
+        const win = useWindowManager.getState().windows.find((w) => (
+          w.path === path && (path !== "__terminal__" || w.terminalPersistence !== "ephemeral")
+        ));
         if (win) {
           const cRect = useCanvasTransform.getState().containerRect;
           useCanvasTransform.getState().focusOnWindow(
@@ -386,7 +387,9 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- identity consumed by the launch-path useEffect dependency array (L~930); a fresh function each render would re-fire that effect every render
   const focusOrOpen = useCallback((name: string, path: string) => {
     const existing = useWindowManager.getState().windows.find(
-      (w) => w.path === path || w.path.startsWith(path + ":"),
+      (w) => path === "__terminal__"
+        ? w.path === path && w.terminalPersistence !== "ephemeral"
+        : w.path === path || w.path.startsWith(path + ":"),
     );
 
     if (existing) {
@@ -424,23 +427,20 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
 
   const focusTerminalForHandoff = useCallback((handoff: (targetId?: string) => void) => {
     const windows = useWindowManager.getState().windows;
-    const focusedId = useWindowManager.getState().focusedWindowId;
-    const focusedTerminal = windows.find((w) => w.id === focusedId && w.path.startsWith("__terminal__"));
-    const setupTerminal = windows.find((w) => w.path === TERMINAL_SETUP_WINDOW_PATH);
-    const existingTerminal = focusedTerminal ?? setupTerminal ?? windows.reduce<typeof windows[number] | undefined>(
-      (best, w) =>
-        w.path.startsWith("__terminal__") && (best === undefined || w.zIndex > best.zIndex) ? w : best,
-      undefined,
-    );
-    if (existingTerminal) {
-      wmRestoreAndFocusWindow(existingTerminal.id);
+    const setupTerminal = windows.find((w) => (
+      w.path === "__terminal__" && w.terminalPersistence === "ephemeral"
+    ));
+    if (setupTerminal) {
+      wmRestoreAndFocusWindow(setupTerminal.id);
     } else {
-      wmOpenWindow("Terminal", TERMINAL_SETUP_WINDOW_PATH, dockXOffset);
+      wmOpenWindow("Terminal", "__terminal__", dockXOffset, { terminalPersistence: "ephemeral" });
     }
     const resolveTargetTerminal = () => (
-      existingTerminal
-        ? useWindowManager.getState().getWindow(existingTerminal.id)
-        : useWindowManager.getState().windows.find((w) => w.path === TERMINAL_SETUP_WINDOW_PATH)
+      setupTerminal
+        ? useWindowManager.getState().getWindow(setupTerminal.id)
+        : useWindowManager.getState().windows.find((w) => (
+            w.path === "__terminal__" && w.terminalPersistence === "ephemeral"
+          ))
     );
 
     requestAnimationFrame(() => {
@@ -1344,7 +1344,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
                     and isn't duplicated in the apps row below. */}
                 {(() => {
                   const terminalApp = apps.find((a) => a.path === "__terminal__");
-                  const terminalActive = windows.some((w) => !w.minimized && (w.path === "__terminal__" || w.path.startsWith("__terminal__:")));
+                  const terminalActive = windows.some((w) => !w.minimized && w.path === "__terminal__");
                   return (
                     <DockIcon
                       name="Terminal"

--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -494,6 +494,8 @@ export function CanvasWindow({ win, iconUrl, hidden = false, deferAppContent = f
         <TerminalApp
           mobile={isMobile}
           launchTargetId={win.id}
+          layoutId={win.terminalLayoutId}
+          persistence={win.terminalPersistence ?? "durable"}
           embeddedChrome
           canvasZoom={isFullscreen ? 1 : zoom}
           suspended={hidden || isPreview}

--- a/shell/src/components/desktop/DesktopWindow.tsx
+++ b/shell/src/components/desktop/DesktopWindow.tsx
@@ -184,6 +184,8 @@ export function DesktopWindow({
         {win.path.startsWith("__terminal__") ? (
           <TerminalApp
             launchTargetId={win.id}
+            layoutId={win.terminalLayoutId}
+            persistence={win.terminalPersistence ?? "durable"}
             embeddedChrome
             desktopParity={desktopParity}
             windowControls={{

--- a/shell/src/components/mobile/MobileShell.tsx
+++ b/shell/src/components/mobile/MobileShell.tsx
@@ -53,11 +53,17 @@ import { Settings } from "@/components/Settings";
 import { PreviewWindow } from "@/components/preview-window/PreviewWindow";
 import { enqueueTerminalLaunch, type TerminalLaunchAction } from "@/lib/terminal-launch";
 import { enqueueExistingTerminalSession } from "@/lib/provider-terminal-session";
+import {
+  createTerminalLayoutId,
+  type TerminalPersistence,
+} from "@/lib/terminal-window-metadata";
 
 interface OpenApp {
   id: string;
   app: MobileApp;
   openedAt: number;
+  terminalLayoutId?: string;
+  terminalPersistence?: TerminalPersistence;
 }
 
 const FETCH_TIMEOUT_MS = 10_000;
@@ -235,7 +241,13 @@ export function MobileShell({ launchAppPath, onOpenCommandPalette, cacheScope }:
           return [...prev.filter((entry) => entry.id !== latestTerminal.id), latestTerminal];
         }
         const id = `term:${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
-        return [...prev, { id, app, openedAt: Date.now() }];
+        return [...prev, {
+          id,
+          app,
+          openedAt: Date.now(),
+          terminalLayoutId: createTerminalLayoutId(),
+          terminalPersistence: "durable",
+        }];
       }
       const existing = prev.findIndex((o) => o.app.path === app.path);
       if (existing >= 0) {
@@ -254,13 +266,23 @@ export function MobileShell({ launchAppPath, onOpenCommandPalette, cacheScope }:
     const terminal = BUILT_IN_APPS.find((app) => app.path === "__terminal__");
     if (!terminal) return;
     const terminals = stackRef.current.filter((entry) => entry.app.path === "__terminal__");
-    const reusable = terminals.length >= MAX_TERMINAL_INSTANCES
-      ? terminals[terminals.length - 1]
-      : undefined;
+    const reusable = terminals.find((entry) => entry.terminalPersistence === "ephemeral");
     const id = reusable?.id ?? `term:${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
-    setOpenStack((previous) => reusable
-      ? [...previous.filter((entry) => entry.id !== reusable.id), reusable]
-      : [...previous, { id, app: terminal, openedAt: Date.now() }]);
+    setOpenStack((previous) => {
+      if (reusable) {
+        return [...previous.filter((entry) => entry.id !== reusable.id), reusable];
+      }
+      const atCapacity = terminals.length >= MAX_TERMINAL_INSTANCES;
+      const withoutOldestTerminal = atCapacity
+        ? previous.filter((entry) => entry.id !== terminals[0]?.id)
+        : previous;
+      return [...withoutOldestTerminal, {
+        id,
+        app: terminal,
+        openedAt: Date.now(),
+        terminalPersistence: "ephemeral",
+      }];
+    });
     setSettingsOpen(false);
     setView("app");
     enqueueTerminalLaunch(action, id);
@@ -408,7 +430,7 @@ export function MobileShell({ launchAppPath, onOpenCommandPalette, cacheScope }:
                 background: "var(--background)",
               }}
             >
-              <MobileAppFrame app={o.app} openId={o.id} chat={chat} />
+              <MobileAppFrame openApp={o} chat={chat} />
             </motion.div>
           );
         })}
@@ -502,16 +524,23 @@ export function MobileShell({ launchAppPath, onOpenCommandPalette, cacheScope }:
 }
 
 function MobileAppFrame({
-  app,
-  openId,
+  openApp,
   chat,
 }: {
-  app: MobileApp;
-  openId: string;
+  openApp: OpenApp;
   chat: ReturnType<typeof useChatContext>;
 }) {
+  const { app, id: openId } = openApp;
   if (app.path.startsWith("__terminal__")) {
-    return <TerminalApp key={openId} mobile launchTargetId={openId} />;
+    return (
+      <TerminalApp
+        key={openId}
+        mobile
+        launchTargetId={openId}
+        layoutId={openApp.terminalLayoutId}
+        persistence={openApp.terminalPersistence ?? "durable"}
+      />
+    );
   }
   if (app.path === "__file-browser__") {
     return <FileBrowser windowId={openId} mobile />;

--- a/shell/src/components/mobile/MobileShell.tsx
+++ b/shell/src/components/mobile/MobileShell.tsx
@@ -267,16 +267,16 @@ export function MobileShell({ launchAppPath, onOpenCommandPalette, cacheScope }:
     if (!terminal) return;
     const terminals = stackRef.current.filter((entry) => entry.app.path === "__terminal__");
     const reusable = terminals.find((entry) => entry.terminalPersistence === "ephemeral");
+    if (!reusable && terminals.length >= MAX_TERMINAL_INSTANCES) {
+      toast("Close a Terminal before starting setup");
+      return;
+    }
     const id = reusable?.id ?? `term:${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
     setOpenStack((previous) => {
       if (reusable) {
         return [...previous.filter((entry) => entry.id !== reusable.id), reusable];
       }
-      const atCapacity = terminals.length >= MAX_TERMINAL_INSTANCES;
-      const withoutOldestTerminal = atCapacity
-        ? previous.filter((entry) => entry.id !== terminals[0]?.id)
-        : previous;
-      return [...withoutOldestTerminal, {
+      return [...previous, {
         id,
         app: terminal,
         openedAt: Date.now(),

--- a/shell/src/components/terminal/PaneGrid.tsx
+++ b/shell/src/components/terminal/PaneGrid.tsx
@@ -17,9 +17,11 @@ interface PaneGridProps {
   allowRemoteResize?: boolean;
   suppressNativeKeyboard?: boolean;
   canvasZoom?: number;
+  unavailableSessionIds?: string[];
+  onRecoverSession?: (sessionId: string, cwd: string) => Promise<boolean>;
 }
 
-export function PaneGrid({ paneTree, theme, focusedPaneId, focusRequestId = 0, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane, allowRemoteResize = true, suppressNativeKeyboard = false, canvasZoom = 1 }: PaneGridProps) {
+export function PaneGrid({ paneTree, theme, focusedPaneId, focusRequestId = 0, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane, allowRemoteResize = true, suppressNativeKeyboard = false, canvasZoom = 1, unavailableSessionIds = [], onRecoverSession }: PaneGridProps) {
   return (
     <div className="flex-1 min-h-0 min-w-0 overflow-hidden">
       <PaneNodeRenderer
@@ -34,6 +36,8 @@ export function PaneGrid({ paneTree, theme, focusedPaneId, focusRequestId = 0, o
         allowRemoteResize={allowRemoteResize}
         suppressNativeKeyboard={suppressNativeKeyboard}
         canvasZoom={canvasZoom}
+        unavailableSessionIds={unavailableSessionIds}
+        onRecoverSession={onRecoverSession}
       />
     </div>
   );
@@ -51,9 +55,11 @@ interface PaneNodeRendererProps {
   allowRemoteResize?: boolean;
   suppressNativeKeyboard?: boolean;
   canvasZoom?: number;
+  unavailableSessionIds: string[];
+  onRecoverSession?: (sessionId: string, cwd: string) => Promise<boolean>;
 }
 
-function PaneNodeRenderer({ node, theme, focusedPaneId, focusRequestId = 0, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane, allowRemoteResize = true, suppressNativeKeyboard = false, canvasZoom = 1 }: PaneNodeRendererProps) {
+function PaneNodeRenderer({ node, theme, focusedPaneId, focusRequestId = 0, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane, allowRemoteResize = true, suppressNativeKeyboard = false, canvasZoom = 1, unavailableSessionIds, onRecoverSession }: PaneNodeRendererProps) {
   if (node.type === "pane") {
     const focused = focusedPaneId === node.id;
     return (
@@ -67,25 +73,33 @@ function PaneNodeRenderer({ node, theme, focusedPaneId, focusRequestId = 0, onFo
           position: "relative",
         }}
       >
-        <TerminalPane
-          key={node.id}
-          paneId={node.id}
-          cwd={node.cwd}
-          theme={theme}
-          isFocused={focused}
-          focusRequestId={focusRequestId}
-          sessionId={node.sessionId}
-          claudeMode={node.claudeMode === true}
-          startupCommand={node.startupCommand}
-          compatMode={node.compatMode}
-          onFocus={onFocusPane}
-          onSessionAttached={onSessionAttached}
-          shouldCacheOnUnmount={shouldCachePane}
-          shouldDestroyOnUnmount={shouldDestroyPane}
-          allowRemoteResize={allowRemoteResize}
-          suppressNativeKeyboard={suppressNativeKeyboard}
-          canvasZoom={canvasZoom}
-        />
+        {node.sessionId && unavailableSessionIds.includes(node.sessionId) ? (
+          <RecoverableSessionPane
+            sessionId={node.sessionId}
+            cwd={node.cwd}
+            onRecoverSession={onRecoverSession}
+          />
+        ) : (
+          <TerminalPane
+            key={node.id}
+            paneId={node.id}
+            cwd={node.cwd}
+            theme={theme}
+            isFocused={focused}
+            focusRequestId={focusRequestId}
+            sessionId={node.sessionId}
+            claudeMode={node.claudeMode === true}
+            startupCommand={node.startupCommand}
+            compatMode={node.compatMode}
+            onFocus={onFocusPane}
+            onSessionAttached={onSessionAttached}
+            shouldCacheOnUnmount={shouldCachePane}
+            shouldDestroyOnUnmount={shouldDestroyPane}
+            allowRemoteResize={allowRemoteResize}
+            suppressNativeKeyboard={suppressNativeKeyboard}
+            canvasZoom={canvasZoom}
+          />
+        )}
       </div>
     );
   }
@@ -106,6 +120,8 @@ function PaneNodeRenderer({ node, theme, focusedPaneId, focusRequestId = 0, onFo
       allowRemoteResize={allowRemoteResize}
       suppressNativeKeyboard={suppressNativeKeyboard}
       canvasZoom={canvasZoom}
+      unavailableSessionIds={unavailableSessionIds}
+      onRecoverSession={onRecoverSession}
     />
   );
 }
@@ -125,9 +141,11 @@ interface SplitContainerProps {
   allowRemoteResize?: boolean;
   suppressNativeKeyboard?: boolean;
   canvasZoom?: number;
+  unavailableSessionIds: string[];
+  onRecoverSession?: (sessionId: string, cwd: string) => Promise<boolean>;
 }
 
-function SplitContainer({ direction, ratio, left, right, theme, focusedPaneId, focusRequestId = 0, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane, allowRemoteResize = true, suppressNativeKeyboard = false, canvasZoom = 1 }: SplitContainerProps) {
+function SplitContainer({ direction, ratio, left, right, theme, focusedPaneId, focusRequestId = 0, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane, allowRemoteResize = true, suppressNativeKeyboard = false, canvasZoom = 1, unavailableSessionIds, onRecoverSession }: SplitContainerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   // react-doctor-disable-next-line react-doctor/no-derived-useState -- local drag buffer, not a mirror of `ratio`: it is seeded from the prop, then diverges live as the user drags the split divider (setCurrentRatio in onMouseMove). It must NOT stay in sync with `ratio` or the divider would snap back mid-drag; it holds uncommitted pointer-driven layout state.
   const [currentRatio, setCurrentRatio] = useState(ratio);
@@ -183,6 +201,8 @@ function SplitContainer({ direction, ratio, left, right, theme, focusedPaneId, f
           allowRemoteResize={allowRemoteResize}
           suppressNativeKeyboard={suppressNativeKeyboard}
           canvasZoom={canvasZoom}
+          unavailableSessionIds={unavailableSessionIds}
+          onRecoverSession={onRecoverSession}
         />
       </div>
       {/* react-doctor-disable-next-line react-doctor/no-static-element-interactions -- presentational pointer-only resize affordance: the 4px gutter starts a mouse/pointer drag to repan the split. It carries no control semantics, has no keyboard equivalent (panes auto-fit on resize), and adding an interactive role would require a non-trivial keyboard-resize behavior change out of scope for this pass. */}
@@ -204,7 +224,54 @@ function SplitContainer({ direction, ratio, left, right, theme, focusedPaneId, f
           allowRemoteResize={allowRemoteResize}
           suppressNativeKeyboard={suppressNativeKeyboard}
           canvasZoom={canvasZoom}
+          unavailableSessionIds={unavailableSessionIds}
+          onRecoverSession={onRecoverSession}
         />
+      </div>
+    </div>
+  );
+}
+
+function RecoverableSessionPane({
+  sessionId,
+  cwd,
+  onRecoverSession,
+}: {
+  sessionId: string;
+  cwd: string;
+  onRecoverSession?: (sessionId: string, cwd: string) => Promise<boolean>;
+}) {
+  const [recovering, setRecovering] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const recover = async () => {
+    if (recovering || !onRecoverSession) return;
+    setRecovering(true);
+    setFailed(false);
+    const recovered = await onRecoverSession(sessionId, cwd);
+    if (!recovered) {
+      setFailed(true);
+      setRecovering(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full w-full items-center justify-center bg-background p-6 text-foreground">
+      <div className="flex max-w-sm flex-col items-center gap-3 text-center">
+        <div className="text-sm font-semibold">Session is unavailable</div>
+        <p className="m-0 text-xs text-muted-foreground">
+          {sessionId} stopped unexpectedly. Matrix will not recreate it without your permission.
+        </p>
+        <button
+          type="button"
+          className="rounded-md bg-primary px-3 py-2 text-xs font-medium text-primary-foreground disabled:opacity-60"
+          disabled={recovering || !onRecoverSession}
+          onClick={() => void recover()}
+          aria-label={`Recover ${sessionId}`}
+        >
+          {recovering ? "Recovering..." : "Recover session"}
+        </button>
+        {failed ? <div role="alert" className="text-xs text-destructive">Recovery failed. Try again.</div> : null}
       </div>
     </div>
   );

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -40,6 +40,7 @@ import {
   genId,
   hasPaneId,
   layoutUsesOnlyCanonicalShellSessions,
+  mergeTerminalLayouts,
   removeSessionFromPaneTree,
   renameSessionInTree,
   setPaneSessionId,
@@ -115,39 +116,6 @@ function listShellSessions(): Promise<ShellSessionSummary[] | null> {
       shellSessionsListInflight = null;
     }
   });
-}
-
-type SavedShellSessionsStatus = "active" | "stale" | "unavailable";
-
-async function getSavedShellSessionsStatus(sessionNames: string[]): Promise<SavedShellSessionsStatus> {
-  const requestedNames = Array.from(new Set(
-    sessionNames.filter((name) => isCanonicalShellSessionId(name)),
-  ));
-  if (requestedNames.length === 0) {
-    return "active";
-  }
-
-  try {
-    const sessions = await listShellSessions();
-    if (sessions === null) {
-      return "unavailable";
-    }
-    const existingNames = new Set<string>();
-    for (const session of sessions) {
-      if (typeof session.name === "string") {
-        existingNames.add(session.name);
-      }
-    }
-
-    // A saved layout is only a UI reference. Missing runtimes can be stopped or
-    // intentionally interrupted, so mounting Terminal must never relaunch them.
-    // Falling back to the first active session also prevents a stale layout from
-    // producing one expected 409 response per missing pane on every app mount.
-    return requestedNames.every((name) => existingNames.has(name)) ? "active" : "stale";
-  } catch (err: unknown) {
-    console.warn("Failed to validate saved terminal sessions:", err instanceof Error ? err.message : err);
-    return "unavailable";
-  }
 }
 
 async function getFirstOrderedShellSessionName(): Promise<string | null> {
@@ -227,10 +195,14 @@ interface TerminalAppProps {
   suspended?: boolean;
   /** Use the native Desktop session workspace inside a web OS window. */
   desktopParity?: boolean;
+  /** Stable owner ID for this ordinary Terminal window's independent layout. */
+  layoutId?: string;
+  /** Setup/login terminals never read or write durable window layouts. */
+  persistence?: "durable" | "ephemeral";
 }
 
 // react-doctor-disable-next-line react-doctor/no-giant-component, react-doctor/prefer-useReducer -- no-giant-component: cohesive core terminal shell component; extraction tracked separately. prefer-useReducer: the 6 useState fields are independent, not one related cluster: tabs/activeTabId/focusedPaneId are mutated through many distinct code paths (split, close, rename, reorder, session-attach) using nested functional updaters that read prev and call sibling setters, while sidebarOpen/sidebarSelectedPath are sidebar UI and initialized is a one-time bootstrap gate; a single reducer would not be a mechanical, behavior-identical change.
-export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = false, initialSessionId, launchTargetId, mobile = false, windowControls, embeddedChrome = false, canvasZoom = 1, suspended = false, desktopParity = false }: TerminalAppProps = {}) {
+export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = false, initialSessionId, launchTargetId, mobile = false, windowControls, embeddedChrome = false, canvasZoom = 1, suspended = false, desktopParity = false, layoutId, persistence = "durable" }: TerminalAppProps = {}) {
   const theme = useTheme();
   const themeId = useTerminalSettings((s) => s.themeId);
   const setThemeId = useTerminalSettings((s) => s.setThemeId);
@@ -269,6 +241,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
   const [initialized, setInitialized] = useState(false);
   const [mobileInputActive, setMobileInputActive] = useState(false);
   const [desktopSessionState, setDesktopSessionState] = useState<{ count: number; ready: boolean }>({ count: 0, ready: false });
+  const [unavailableSessionIds, setUnavailableSessionIds] = useState<string[]>([]);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const tabsRef = useRef<Tab[]>(tabs);
@@ -291,8 +264,14 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
   const layoutSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const terminalLayoutHydratedRef = useRef(false);
   const terminalLayoutDirtyRef = useRef(false);
+  const terminalLayoutChangeVersionRef = useRef(0);
+  const terminalLayoutRevisionRef = useRef(0);
+  const terminalLayoutBaseRef = useRef<TerminalLayout | null>(null);
+  const terminalLayoutSkipNextDirtyRef = useRef(false);
+  const terminalLayoutRetryAttemptRef = useRef(0);
   const markTerminalLayoutDirty = () => {
     terminalLayoutDirtyRef.current = true;
+    terminalLayoutChangeVersionRef.current += 1;
   };
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- stable identity for effect dep: `log` is consumed in the dependency array of the tabs-changed useEffect below; removing the memo would re-create it every render and re-run that effect.
   const log = useCallback((event: string, details: Record<string, unknown> = {}) => {
@@ -324,22 +303,105 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     };
   }, [mobile, mobileTerminalInputId]);
 
-  const persistLayoutNow = () => {
+  const persistLayoutNow = async (): Promise<boolean> => {
+    if (persistence === "ephemeral") return true;
+    const changeVersion = terminalLayoutChangeVersionRef.current;
     const layout: TerminalLayout = {
       tabs: tabsRef.current,
       activeTabId: activeTabIdRef.current,
       ...(initialMobileRef.current ? {} : { sidebarOpen: sidebarOpenRef.current }),
     };
 
-    return fetch(`${getGatewayUrl()}/api/terminal/layout`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(layout),
-      keepalive: true,
-      signal: AbortSignal.timeout(10_000),
-    }).catch((err: unknown) => {
+    const endpoint = layoutId
+      ? `${getGatewayUrl()}/api/terminal/window-layouts/${encodeURIComponent(layoutId)}`
+      : `${getGatewayUrl()}/api/terminal/layout`;
+    try {
+      const res = await fetch(endpoint, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(layoutId
+          ? { baseRevision: terminalLayoutRevisionRef.current, layout }
+          : layout),
+        keepalive: true,
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (layoutId && res.status === 409) {
+        const currentRes = await fetch(endpoint, {
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!currentRes.ok) {
+          console.warn("Failed to reload terminal layout after conflict:", currentRes.status);
+          return false;
+        }
+        const current = await currentRes.json() as {
+          revision?: unknown;
+          layout?: TerminalLayout;
+        };
+        if (typeof current.revision !== "number" || !current.layout) {
+          console.warn("Failed to reload terminal layout after conflict: invalid response");
+          return false;
+        }
+        const merged = mergeTerminalLayouts(
+          terminalLayoutBaseRef.current ?? current.layout,
+          layout,
+          current.layout,
+        );
+        const retryRes = await fetch(endpoint, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ baseRevision: current.revision, layout: merged }),
+          keepalive: true,
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!retryRes.ok) {
+          console.warn("Failed to save rebased terminal layout:", retryRes.status);
+          return false;
+        }
+        const saved = await retryRes.json() as { revision?: unknown; layout?: TerminalLayout };
+        if (typeof saved.revision !== "number") {
+          console.warn("Failed to save rebased terminal layout: invalid response");
+          return false;
+        }
+        terminalLayoutRevisionRef.current = saved.revision;
+        const persistedLayout = saved.layout ?? merged;
+        terminalLayoutBaseRef.current = persistedLayout;
+        const changedDuringSave = terminalLayoutChangeVersionRef.current !== changeVersion;
+        const latestLayout: TerminalLayout = {
+          tabs: tabsRef.current,
+          activeTabId: activeTabIdRef.current,
+          ...(initialMobileRef.current ? {} : { sidebarOpen: sidebarOpenRef.current }),
+        };
+        const layoutToAdopt = changedDuringSave
+          ? mergeTerminalLayouts(layout, latestLayout, persistedLayout)
+          : persistedLayout;
+        if (mountedRef.current && JSON.stringify(layoutToAdopt) !== JSON.stringify(latestLayout)) {
+          const nextTabs = layoutToAdopt.tabs ?? [];
+          const nextActiveTabId = nextTabs.some((tab) => tab.id === layoutToAdopt.activeTabId)
+            ? layoutToAdopt.activeTabId ?? ""
+            : nextTabs[0]?.id ?? "";
+          terminalLayoutSkipNextDirtyRef.current = !changedDuringSave;
+          setTabs(applyCompatModeToTabs(nextTabs));
+          setActiveTabId(nextActiveTabId);
+          if (!initialMobileRef.current) setSidebarOpen(layoutToAdopt.sidebarOpen ?? true);
+        }
+        return true;
+      }
+      if (!res.ok) {
+        console.warn("Failed to save terminal layout:", res.status);
+        return false;
+      }
+      if (layoutId) {
+        const saved = await res.json() as { revision?: unknown; layout?: TerminalLayout };
+        if (typeof saved.revision === "number") {
+          terminalLayoutRevisionRef.current = saved.revision;
+          terminalLayoutBaseRef.current = saved.layout ?? layout;
+        }
+      }
+      return true;
+    } catch (err: unknown) {
       console.warn("Failed to save terminal layout:", err instanceof Error ? err.message : err);
-    });
+      return false;
+    }
   };
 
   const getPendingSessionIds = (paneIds: string[]) => {
@@ -368,8 +430,20 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
+      if (persistence === "ephemeral") {
+        destroyTerminalSessions(tabsRef.current.flatMap((tab) => getSessionIds(tab.paneTree)));
+        return;
+      }
+      if (!terminalLayoutDirtyRef.current) return;
+      if (layoutSaveTimerRef.current) {
+        clearTimeout(layoutSaveTimerRef.current);
+        layoutSaveTimerRef.current = null;
+      }
+      const changeVersion = terminalLayoutChangeVersionRef.current;
+      void persistLayoutNow().then((saved) => settleLayoutSave(saved, changeVersion));
     };
-  }, []);
+    // react-doctor-disable-next-line react-doctor/exhaustive-deps -- persistence is a mount-time window policy; persistLayoutNow and settleLayoutSave read the latest layout exclusively through refs, and re-subscribing this cleanup would flush during ordinary renders. The retry continuation intentionally survives this component's unmount so a transient final-save failure cannot discard the window layout.
+  }, [persistence]);
 
   useEffect(() => {
     loadGlobalShellThemePreference(setThemeId);
@@ -559,32 +633,56 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
         return;
       }
 
+      if (persistence === "ephemeral") {
+        if (!cancelled) setInitialized(true);
+        return;
+      }
+
       try {
         // Warm the sessions list in parallel with the layout fetch — the
         // ensure step below joins the same in-flight request instead of
         // paying a second serial roundtrip before the terminal can open.
-        void listShellSessions();
-        const res = await fetch(`${getGatewayUrl()}/api/terminal/layout`, {
+        const sessionsPromise = listShellSessions();
+        const endpoint = layoutId
+          ? `${getGatewayUrl()}/api/terminal/window-layouts/${encodeURIComponent(layoutId)}`
+          : `${getGatewayUrl()}/api/terminal/layout`;
+        const res = await fetch(endpoint, {
           signal: AbortSignal.timeout(10_000),
         });
         if (res.ok) {
-          const data = await res.json() as TerminalLayout;
+          const response = await res.json() as TerminalLayout | {
+            revision?: unknown;
+            layout?: TerminalLayout;
+          };
+          const data = layoutId && "layout" in response && response.layout
+            ? response.layout
+            : response as TerminalLayout;
+          if (layoutId && "revision" in response && typeof response.revision === "number") {
+            terminalLayoutRevisionRef.current = response.revision;
+            terminalLayoutBaseRef.current = data;
+          }
           if (!cancelled && Array.isArray(data.tabs) && data.tabs.length > 0) {
             if (layoutUsesOnlyCanonicalShellSessions(data)) {
-              const sessionStatus = await getSavedShellSessionsStatus(getCanonicalShellSessionIds(data));
-              // A failed catalog request does not prove that a runtime stopped.
-              // Preserve the saved layout so a transient outage cannot overwrite
-              // the user's tabs and panes; only an authoritative stale result falls back.
-              if (!cancelled && sessionStatus !== "stale") {
-                const nextActiveTabId = data.activeTabId ?? data.tabs[0].id;
-                const nextActiveTab = data.tabs.find((tab) => tab.id === nextActiveTabId) ?? data.tabs[0];
-                setTabs(applyCompatModeToTabs(data.tabs));
-                setActiveTabId(nextActiveTabId);
-                setSidebarOpen(initialMobileRef.current ? false : data.sidebarOpen ?? true);
-                requestPaneFocus(nextActiveTab ? getFirstPaneId(nextActiveTab.paneTree) : null);
-                setInitialized(true);
-                return;
+              const sessions = await sessionsPromise;
+              if (cancelled) return;
+              if (sessions) {
+                const activeNames = new Set(sessions.flatMap((session) => (
+                  typeof session.name === "string" && session.status !== "exited"
+                    ? [session.name]
+                    : []
+                )));
+                setUnavailableSessionIds(
+                  getCanonicalShellSessionIds(data).filter((name) => !activeNames.has(name)),
+                );
               }
+              const nextActiveTabId = data.activeTabId ?? data.tabs[0].id;
+              const nextActiveTab = data.tabs.find((tab) => tab.id === nextActiveTabId) ?? data.tabs[0];
+              setTabs(applyCompatModeToTabs(data.tabs));
+              setActiveTabId(nextActiveTabId);
+              setSidebarOpen(initialMobileRef.current ? false : data.sidebarOpen ?? true);
+              requestPaneFocus(nextActiveTab ? getFirstPaneId(nextActiveTab.paneTree) : null);
+              setInitialized(true);
+              return;
             }
 
             const sessionName = await getFirstOrderedShellSessionName();
@@ -693,8 +791,25 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     };
   }, [initialized, launchTargetId]);
 
-  const flushLayout = useEffectEvent(() => {
-    void persistLayoutNow();
+  const flushLayout = useEffectEvent(() => persistLayoutNow());
+
+  const settleLayoutSave = useEffectEvent(function settle(saved: boolean, changeVersion: number) {
+    if (saved) {
+      terminalLayoutRetryAttemptRef.current = 0;
+      if (terminalLayoutChangeVersionRef.current === changeVersion) {
+        terminalLayoutDirtyRef.current = false;
+        return;
+      }
+    }
+    if (!terminalLayoutDirtyRef.current || layoutSaveTimerRef.current) return;
+    const retryAttempt = Math.min(terminalLayoutRetryAttemptRef.current, 4);
+    terminalLayoutRetryAttemptRef.current = retryAttempt + 1;
+    const retryDelayMs = Math.min(500 * (2 ** retryAttempt), 5_000);
+    layoutSaveTimerRef.current = setTimeout(() => {
+      layoutSaveTimerRef.current = null;
+      const retryVersion = terminalLayoutChangeVersionRef.current;
+      void flushLayout().then((retrySaved) => settle(retrySaved, retryVersion));
+     }, retryDelayMs);
   });
 
   useEffect(() => {
@@ -706,16 +821,21 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
       terminalLayoutHydratedRef.current = true;
       if (!terminalLayoutDirtyRef.current) return;
     }
+    if (terminalLayoutSkipNextDirtyRef.current) {
+      terminalLayoutSkipNextDirtyRef.current = false;
+      return;
+    }
     terminalLayoutDirtyRef.current = true;
+    terminalLayoutChangeVersionRef.current += 1;
 
     if (layoutSaveTimerRef.current) {
       clearTimeout(layoutSaveTimerRef.current);
     }
 
+    const changeVersion = terminalLayoutChangeVersionRef.current;
     layoutSaveTimerRef.current = setTimeout(() => {
       layoutSaveTimerRef.current = null;
-      flushLayout();
-      terminalLayoutDirtyRef.current = false;
+      void flushLayout().then((saved) => settleLayoutSave(saved, changeVersion));
     }, 500);
 
     return () => {
@@ -740,8 +860,8 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
         layoutSaveTimerRef.current = null;
       }
 
-      flushLayout();
-      terminalLayoutDirtyRef.current = false;
+      const changeVersion = terminalLayoutChangeVersionRef.current;
+      void flushLayout().then((saved) => settleLayoutSave(saved, changeVersion));
     };
 
     window.addEventListener("pagehide", flushOnPageHide);
@@ -859,6 +979,27 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
 
   const shouldDestroyPane = (paneId: string) => {
     return closingPaneIdsRef.current!.has(paneId);
+  };
+
+  const recoverShellSession = async (sessionId: string, cwd: string): Promise<boolean> => {
+    if (!isCanonicalShellSessionId(sessionId)) return false;
+    try {
+      const res = await fetch(
+        `${getGatewayUrl()}/api/terminal/sessions/${encodeURIComponent(sessionId)}/recover`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ cwd }),
+          signal: AbortSignal.timeout(10_000),
+        },
+      );
+      if (!res.ok) return false;
+      setUnavailableSessionIds((current) => current.filter((name) => name !== sessionId));
+      return true;
+    } catch (err: unknown) {
+      console.warn("Failed to recover terminal session:", err instanceof Error ? err.message : String(err));
+      return false;
+    }
   };
 
   useEffect(() => {
@@ -1040,6 +1181,8 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
                     focusRequestId={focusRequestId}
                     onFocusPane={setFocusedPaneId}
                     onSessionAttached={handleSessionAttached}
+                    unavailableSessionIds={unavailableSessionIds}
+                    onRecoverSession={recoverShellSession}
                     shouldCachePane={shouldCachePane}
                     shouldDestroyPane={shouldDestroyPane}
                     allowRemoteResize={!mobile}

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -56,6 +56,8 @@ import { DesktopTerminalEmptyState, DesktopTerminalSessionHeader } from "./Deskt
 export { TERMINAL_INPUT_EVENT };
 export type { TerminalInputEventDetail };
 
+const MAX_UNMOUNTED_LAYOUT_SAVE_RETRIES = 3;
+
 function dispatchPaneInput(paneId: string | null, data: string): void {
   if (!paneId) return;
   if (typeof window === "undefined") return;
@@ -269,6 +271,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
   const terminalLayoutBaseRef = useRef<TerminalLayout | null>(null);
   const terminalLayoutSkipNextDirtyRef = useRef(false);
   const terminalLayoutRetryAttemptRef = useRef(0);
+  const terminalLayoutUnmountedRetryCountRef = useRef(0);
   const markTerminalLayoutDirty = () => {
     terminalLayoutDirtyRef.current = true;
     terminalLayoutChangeVersionRef.current += 1;
@@ -428,6 +431,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
 
   useEffect(() => {
     mountedRef.current = true;
+    terminalLayoutUnmountedRetryCountRef.current = 0;
     return () => {
       mountedRef.current = false;
       if (persistence === "ephemeral") {
@@ -440,9 +444,10 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
         layoutSaveTimerRef.current = null;
       }
       const changeVersion = terminalLayoutChangeVersionRef.current;
+      terminalLayoutUnmountedRetryCountRef.current = 0;
       void persistLayoutNow().then((saved) => settleLayoutSave(saved, changeVersion));
     };
-    // react-doctor-disable-next-line react-doctor/exhaustive-deps -- persistence is a mount-time window policy; persistLayoutNow and settleLayoutSave read the latest layout exclusively through refs, and re-subscribing this cleanup would flush during ordinary renders. The retry continuation intentionally survives this component's unmount so a transient final-save failure cannot discard the window layout.
+    // react-doctor-disable-next-line react-doctor/exhaustive-deps -- persistence is a mount-time window policy; persistLayoutNow and settleLayoutSave read the latest layout exclusively through refs, and re-subscribing this cleanup would flush during ordinary renders. A bounded retry continuation survives unmount so transient final-save failures get a limited recovery window.
   }, [persistence]);
 
   useEffect(() => {
@@ -796,12 +801,19 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
   const settleLayoutSave = useEffectEvent(function settle(saved: boolean, changeVersion: number) {
     if (saved) {
       terminalLayoutRetryAttemptRef.current = 0;
+      terminalLayoutUnmountedRetryCountRef.current = 0;
       if (terminalLayoutChangeVersionRef.current === changeVersion) {
         terminalLayoutDirtyRef.current = false;
         return;
       }
     }
     if (!terminalLayoutDirtyRef.current || layoutSaveTimerRef.current) return;
+    if (!mountedRef.current) {
+      if (terminalLayoutUnmountedRetryCountRef.current >= MAX_UNMOUNTED_LAYOUT_SAVE_RETRIES) {
+        return;
+      }
+      terminalLayoutUnmountedRetryCountRef.current += 1;
+    }
     const retryAttempt = Math.min(terminalLayoutRetryAttemptRef.current, 4);
     terminalLayoutRetryAttemptRef.current = retryAttempt + 1;
     const retryDelayMs = Math.min(500 * (2 ** retryAttempt), 5_000);

--- a/shell/src/components/terminal/terminal-layout.ts
+++ b/shell/src/components/terminal/terminal-layout.ts
@@ -18,6 +18,130 @@ export interface TerminalLayout {
   sidebarOpen?: boolean;
 }
 
+function layoutValueEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function mergeLayoutValue<T>(base: T, local: T, remote: T): T {
+  if (layoutValueEqual(local, remote)) return local;
+  if (layoutValueEqual(local, base)) return remote;
+  if (layoutValueEqual(remote, base)) return local;
+  return remote;
+}
+
+function mergeOptionalPaneValue<T>(
+  base: T | undefined,
+  local: T | undefined,
+  remote: T | undefined,
+): T | undefined {
+  if (base !== undefined && (local === undefined || remote === undefined)) return undefined;
+  return mergeLayoutValue(base, local, remote);
+}
+
+function findPaneById(node: PaneNode, paneId: string): Extract<PaneNode, { type: "pane" }> | null {
+  if (node.type === "pane") return node.id === paneId ? node : null;
+  return findPaneById(node.children[0], paneId) ?? findPaneById(node.children[1], paneId);
+}
+
+function mergePaneTrees(base: PaneNode, local: PaneNode, remote: PaneNode): PaneNode {
+  if (layoutValueEqual(local, remote)) return local;
+  if (layoutValueEqual(local, base)) return remote;
+  if (layoutValueEqual(remote, base)) return local;
+  if (base.type !== local.type || base.type !== remote.type) {
+    if (remote.type === "pane") {
+      const basePane = findPaneById(base, remote.id);
+      const localPane = findPaneById(local, remote.id);
+      if (basePane && localPane) return mergePaneTrees(basePane, localPane, remote);
+    }
+    if (local.type === "pane") {
+      const basePane = findPaneById(base, local.id);
+      const remotePane = findPaneById(remote, local.id);
+      if (basePane && remotePane) return mergePaneTrees(basePane, local, remotePane);
+    }
+    return remote;
+  }
+
+  if (base.type === "pane" && local.type === "pane" && remote.type === "pane") {
+    if (base.id !== local.id || base.id !== remote.id) return remote;
+    const sessionId = mergeOptionalPaneValue(base.sessionId, local.sessionId, remote.sessionId);
+    const claudeMode = mergeOptionalPaneValue(base.claudeMode, local.claudeMode, remote.claudeMode);
+    const startupCommand = mergeOptionalPaneValue(base.startupCommand, local.startupCommand, remote.startupCommand);
+    const compatMode = mergeOptionalPaneValue(base.compatMode, local.compatMode, remote.compatMode);
+    return {
+      type: "pane",
+      id: base.id,
+      cwd: mergeLayoutValue(base.cwd, local.cwd, remote.cwd),
+      ...(sessionId === undefined ? {} : { sessionId }),
+      ...(claudeMode === undefined ? {} : { claudeMode }),
+      ...(startupCommand === undefined ? {} : { startupCommand }),
+      ...(compatMode === undefined ? {} : { compatMode }),
+    };
+  }
+
+  if (base.type === "split" && local.type === "split" && remote.type === "split") {
+    return {
+      type: "split",
+      direction: mergeLayoutValue(base.direction, local.direction, remote.direction),
+      ratio: mergeLayoutValue(base.ratio, local.ratio, remote.ratio),
+      children: [
+        mergePaneTrees(base.children[0], local.children[0], remote.children[0]),
+        mergePaneTrees(base.children[1], local.children[1], remote.children[1]),
+      ],
+    };
+  }
+
+  return remote;
+}
+
+/** Three-way merge for concurrent Terminal windows. Tab/pane deletion wins over stale references. */
+export function mergeTerminalLayouts(
+  base: TerminalLayout,
+  local: TerminalLayout,
+  remote: TerminalLayout,
+): TerminalLayout {
+  const baseTabs = base.tabs ?? [];
+  const localTabs = local.tabs ?? [];
+  const remoteTabs = remote.tabs ?? [];
+  const localOrderUnchanged = layoutValueEqual(
+    localTabs.map((tab) => tab.id),
+    baseTabs.map((tab) => tab.id),
+  );
+  const candidateIds = [
+    ...(localOrderUnchanged ? remoteTabs : localTabs).map((tab) => tab.id),
+    ...localTabs.map((tab) => tab.id),
+    ...remoteTabs.map((tab) => tab.id),
+  ];
+  const orderedIds = candidateIds.filter((id, index) => candidateIds.indexOf(id) === index);
+  const tabs = orderedIds.flatMap((id) => {
+    const baseTab = baseTabs.find((tab) => tab.id === id);
+    const localTab = localTabs.find((tab) => tab.id === id);
+    const remoteTab = remoteTabs.find((tab) => tab.id === id);
+    if (!baseTab) return localTab ? [localTab] : remoteTab ? [remoteTab] : [];
+    if (!localTab || !remoteTab) return [];
+    return [{
+      id,
+      label: mergeLayoutValue(baseTab.label, localTab.label, remoteTab.label),
+      paneTree: mergePaneTrees(baseTab.paneTree, localTab.paneTree, remoteTab.paneTree),
+    }];
+  });
+  const requestedActiveTabId = mergeLayoutValue(
+    base.activeTabId,
+    local.activeTabId,
+    remote.activeTabId,
+  );
+  const activeTabId = tabs.some((tab) => tab.id === requestedActiveTabId)
+    ? requestedActiveTabId
+    : tabs.find((tab) => tab.id === local.activeTabId)?.id
+      ?? tabs.find((tab) => tab.id === remote.activeTabId)?.id
+      ?? tabs[0]?.id
+      ?? "";
+  return {
+    tabs,
+    activeTabId,
+    sidebarOpen: mergeLayoutValue(base.sidebarOpen, local.sidebarOpen, remote.sidebarOpen),
+  };
+}
+
 export function genId() {
   return Math.random().toString(36).slice(2, 9);
 }

--- a/shell/src/components/terminal/terminal-session-state.ts
+++ b/shell/src/components/terminal/terminal-session-state.ts
@@ -21,6 +21,8 @@ export interface ShellSessionSummary {
   branch?: string;
   pullRequest?: { number: number; url?: string };
   attachCommand?: string;
+  recoverable?: boolean;
+  recoveryReason?: "missing_runtime_session";
   tabs?: Array<{ idx: number; name?: string; focused?: boolean }>;
 }
 
@@ -80,7 +82,9 @@ export function shellSessionsEqual(left: ShellSessionSummary[], right: ShellSess
       session.branch !== next.branch ||
       session.pullRequest?.number !== next.pullRequest?.number ||
       session.pullRequest?.url !== next.pullRequest?.url ||
-      session.attachCommand !== next.attachCommand
+      session.attachCommand !== next.attachCommand ||
+      session.recoverable !== next.recoverable ||
+      session.recoveryReason !== next.recoveryReason
     ) {
       return false;
     }

--- a/shell/src/hooks/useWindowManager.ts
+++ b/shell/src/hooks/useWindowManager.ts
@@ -226,7 +226,14 @@ function debouncedSave(
       }
     }
 
-    const geometry = layoutWindows.map(({ path, x, y, width, height }) => ({ path, x, y, width, height }));
+    const geometry = layoutWindows.map(({ path, x, y, width, height, terminalLayoutId }) => ({
+      path,
+      x,
+      y,
+      width,
+      height,
+      ...(terminalLayoutId ? { terminalLayoutId } : {}),
+    }));
     const mode = useDesktopMode.getState().mode;
     patchWebOsViewState(gatewayUrl, {
       apps: layoutWindows.map(({ path, title, state }) => ({ path, title, state })),

--- a/shell/src/hooks/useWindowManager.ts
+++ b/shell/src/hooks/useWindowManager.ts
@@ -4,6 +4,10 @@ import { TERMINAL_MIN_WINDOW_HEIGHT, TERMINAL_MIN_WINDOW_WIDTH } from "@/lib/bui
 import { getGatewayUrl } from "@/lib/gateway";
 import { isPreVpsBillingSetupRoute } from "@/lib/pre-vps-shell";
 import { SHELL_WINDOW_Z_INDEX_MAX, SHELL_WINDOW_Z_INDEX_START } from "@/lib/shell-layering";
+import {
+  createTerminalLayoutId,
+  type TerminalPersistence,
+} from "@/lib/terminal-window-metadata";
 import { useDesktopMode } from "@/stores/desktop-mode";
 import { patchWebOsViewState, resetWebOsViewStateClientForTests } from "@/lib/os-view-state-client";
 
@@ -17,6 +21,8 @@ export interface AppWindow {
   height: number;
   minimized: boolean;
   zIndex: number;
+  terminalLayoutId?: string;
+  terminalPersistence?: TerminalPersistence;
 }
 
 export interface LayoutWindow {
@@ -27,6 +33,7 @@ export interface LayoutWindow {
   width: number;
   height: number;
   state: "open" | "minimized" | "closed";
+  terminalLayoutId?: string;
 }
 
 export interface AppEntry {
@@ -78,6 +85,18 @@ interface ClosedLayout {
   y: number;
   width: number;
   height: number;
+  terminalLayoutId?: string;
+}
+
+const TERMINAL_LAYOUT_ID_PATTERN = /^term-layout_[0-9a-f]{32}$/;
+
+function terminalLayoutIdForPath(
+  path: string,
+  persistence: TerminalPersistence | undefined,
+  existing?: string,
+): string | undefined {
+  if (!isTerminalWindowPath(path) || persistence === "ephemeral") return undefined;
+  return existing && TERMINAL_LAYOUT_ID_PATTERN.test(existing) ? existing : createTerminalLayoutId();
 }
 
 function normalizeRestoredLayout(path: string, layout: ClosedLayout): ClosedLayout {
@@ -127,7 +146,12 @@ interface WindowManagerState {
 }
 
 interface WindowManagerActions {
-  openWindow: (name: string, path: string, dockXOffset: number) => void;
+  openWindow: (
+    name: string,
+    path: string,
+    dockXOffset: number,
+    options?: { terminalPersistence?: TerminalPersistence },
+  ) => void;
   openWindowExclusive: (name: string, path: string, dockXOffset: number, basePath?: string) => void;
   closeWindow: (id: string) => void;
   minimizeWindow: (id: string) => void;
@@ -170,15 +194,20 @@ function debouncedSave(
   saveTimer = setTimeout(() => {
     if (isPreVpsBillingSetupRoute()) return;
     const gatewayUrl = getGatewayUrl();
-    const layoutWindows: LayoutWindow[] = state.windows.map((w) => ({
-      path: w.path,
-      title: w.title,
-      x: w.x,
-      y: w.y,
-      width: w.width,
-      height: w.height,
-      state: w.minimized ? ("minimized" as const) : ("open" as const),
-    }));
+    const layoutWindows: LayoutWindow[] = state.windows.flatMap((w) => (
+      w.terminalPersistence === "ephemeral"
+        ? []
+        : [{
+            path: w.path,
+            title: w.title,
+            x: w.x,
+            y: w.y,
+            width: w.width,
+            height: w.height,
+            state: w.minimized ? ("minimized" as const) : ("open" as const),
+            ...(w.terminalLayoutId ? { terminalLayoutId: w.terminalLayoutId } : {}),
+          }]
+    ));
 
     const layoutPaths = new Set(layoutWindows.map((lw) => lw.path));
     for (const path of state.closedPaths) {
@@ -192,6 +221,7 @@ function debouncedSave(
           width: closedLayout?.width ?? 640,
           height: closedLayout?.height ?? 480,
           state: "closed",
+          ...(closedLayout?.terminalLayoutId ? { terminalLayoutId: closedLayout.terminalLayoutId } : {}),
         });
       }
     }
@@ -245,12 +275,16 @@ function createWindowRecord(
   path: string,
   fallbackX: number,
   fallbackY: number,
+  options: { terminalPersistence?: TerminalPersistence } = {},
 ): AppWindow {
   const storedLayout = state.closedLayouts.get(path);
   const saved = storedLayout ? normalizeRestoredLayout(path, storedLayout) : undefined;
   const minSize = getEffectiveMinimumWindowSize(path);
   const { width: defaultWidth, height: defaultHeight } = computeDefaultWindowSize(path);
 
+  const terminalPersistence = isTerminalWindowPath(path)
+    ? options.terminalPersistence ?? "durable"
+    : undefined;
   return {
     id: `win-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
     title: name,
@@ -261,6 +295,8 @@ function createWindowRecord(
     height: Math.max(saved?.height ?? defaultHeight, minSize.height),
     minimized: false,
     zIndex: state.nextZ,
+    terminalLayoutId: terminalLayoutIdForPath(path, terminalPersistence, saved?.terminalLayoutId),
+    ...(terminalPersistence ? { terminalPersistence } : {}),
   };
 }
 
@@ -300,16 +336,22 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     appLaunchTimes: {},
     fullscreenWindowId: null,
 
-    openWindow: (name, path, dockXOffset) => {
+    openWindow: (name, path, dockXOffset, options = {}) => {
       markUserLayoutMutation();
       set((state) => {
         const zState = normalizeWindowZOrder(state.windows, state.nextZ);
         const launchTimes = { ...state.appLaunchTimes, [path]: Date.now() };
-        const existing = zState.windows.find((w) => w.path === path);
+        const desiredPersistence = isTerminalWindowPath(path)
+          ? options.terminalPersistence ?? "durable"
+          : undefined;
+        const existing = zState.windows.find((w) => (
+          w.path === path
+          && (!desiredPersistence || (w.terminalPersistence ?? "durable") === desiredPersistence)
+        ));
         if (existing) {
           return {
             windows: zState.windows.map((w) =>
-              w.path === path
+              w.id === existing.id
                 ? { ...w, minimized: false, zIndex: zState.nextZ }
                 : w,
             ),
@@ -348,6 +390,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
           path,
           fallbackX,
           fallbackY,
+          options,
         );
         return {
           windows: [...zState.windows, nextWindow],
@@ -406,7 +449,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
         const win = state.windows.find((w) => w.id === id);
         const newClosed = new Set(state.closedPaths);
         const newLayouts = new Map(state.closedLayouts);
-        if (win) {
+        if (win && win.terminalPersistence !== "ephemeral") {
           newClosed.add(win.path);
           newLayouts.set(win.path, {
             title: win.title,
@@ -414,6 +457,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
             y: win.y,
             width: win.width,
             height: win.height,
+            ...(win.terminalLayoutId ? { terminalLayoutId: win.terminalLayoutId } : {}),
           });
         }
         // Evict oldest entries if over cap
@@ -557,6 +601,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
               y: restored.y,
               width: restored.width,
               height: restored.height,
+              ...(s.terminalLayoutId ? { terminalLayoutId: s.terminalLayoutId } : {}),
             });
             continue;
           }
@@ -570,6 +615,8 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
             height: restored.height,
             minimized: s.state === "minimized",
             zIndex: z++,
+            terminalLayoutId: terminalLayoutIdForPath(s.path, "durable", s.terminalLayoutId),
+            ...(isTerminalWindowPath(s.path) ? { terminalPersistence: "durable" as const } : {}),
           });
         }
 

--- a/shell/src/lib/terminal-launch.ts
+++ b/shell/src/lib/terminal-launch.ts
@@ -60,7 +60,6 @@ const TERMINAL_ACTIONS: Record<TerminalLaunchAction, TerminalLaunchConfig> = {
 };
 
 const TERMINAL_LAUNCH_QUEUE_KEY = "matrix:terminal-launch-queue";
-export const TERMINAL_SETUP_WINDOW_PATH = "__terminal__";
 export const TERMINAL_LAUNCH_EVENT = "matrix:terminal-launch";
 
 interface QueuedTerminalLaunch {

--- a/shell/src/lib/terminal-window-metadata.ts
+++ b/shell/src/lib/terminal-window-metadata.ts
@@ -1,0 +1,7 @@
+export type TerminalPersistence = "durable" | "ephemeral";
+
+export function createTerminalLayoutId(): string {
+  const bytes = new Uint8Array(16);
+  globalThis.crypto.getRandomValues(bytes);
+  return `term-layout_${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+}

--- a/tests/contracts/os-view.test.ts
+++ b/tests/contracts/os-view.test.ts
@@ -134,6 +134,44 @@ describe("shared OS-view contract", () => {
     }).success).toBe(false);
   });
 
+  it("preserves validated terminal layout identity in window geometry", () => {
+    const request = PatchOsViewStateRequestSchema.parse({
+      baseRevision: 1,
+      mutationId: `osvm_${"a".repeat(32)}`,
+      patch: {
+        desktop: {
+          windows: [{
+            path: "__terminal__",
+            x: 20,
+            y: 30,
+            width: 900,
+            height: 640,
+            terminalLayoutId: "term-layout_0123456789abcdef0123456789abcdef",
+          }],
+        },
+      },
+    });
+
+    expect(request.patch.desktop?.windows?.[0]?.terminalLayoutId)
+      .toBe("term-layout_0123456789abcdef0123456789abcdef");
+    expect(PatchOsViewStateRequestSchema.safeParse({
+      baseRevision: 1,
+      mutationId: `osvm_${"b".repeat(32)}`,
+      patch: {
+        desktop: {
+          windows: [{
+            path: "__terminal__",
+            x: 20,
+            y: 30,
+            width: 900,
+            height: 640,
+            terminalLayoutId: "unsafe-layout-id",
+          }],
+        },
+      },
+    }).success).toBe(false);
+  });
+
   it("rebases stale collection snapshots without losing concurrent entity or field edits", () => {
     const base = mergeOsViewStatePatch(createDefaultOsViewDocument(), {
       apps: [{ path: "__chat__", title: "Chat", state: "open" }],

--- a/tests/shell/canvas-window-terminal-overlay.test.tsx
+++ b/tests/shell/canvas-window-terminal-overlay.test.tsx
@@ -69,6 +69,7 @@ const terminalWindow: AppWindow = {
   height: 420,
   minimized: false,
   zIndex: 1,
+  terminalLayoutId: "term-layout_0123456789abcdef0123456789abcdef",
 };
 
 const iframeWindow: AppWindow = {
@@ -203,6 +204,8 @@ describe("CanvasWindow terminal interactivity", () => {
     expect(container.textContent).toContain("Terminal tab one");
     expect(terminalRender).toHaveBeenCalledWith(expect.objectContaining({
       launchTargetId: "win-terminal",
+      layoutId: terminalWindow.terminalLayoutId,
+      persistence: "durable",
       windowControls: expect.objectContaining({
         close: expect.any(Function),
         minimize: expect.any(Function),

--- a/tests/shell/desktop-terminal-fullscreen-pill.test.tsx
+++ b/tests/shell/desktop-terminal-fullscreen-pill.test.tsx
@@ -86,6 +86,7 @@ const terminalWindow: AppWindow = {
   height: 620,
   minimized: false,
   zIndex: 10,
+  terminalLayoutId: "term-layout_fedcba9876543210fedcba9876543210",
 };
 
 const appWindow: AppWindow = {
@@ -217,6 +218,8 @@ describe("Desktop terminal fullscreen chrome", () => {
 
     await screen.findByText("Terminal content");
     const props = terminalRender.mock.lastCall?.[0] as {
+      layoutId?: string;
+      persistence?: string;
       windowControls?: {
         dragHandleProps?: {
           onDoubleClick?: () => void;
@@ -224,6 +227,8 @@ describe("Desktop terminal fullscreen chrome", () => {
       };
     };
 
+    expect(props.layoutId).toBe(terminalWindow.terminalLayoutId);
+    expect(props.persistence).toBe("durable");
     expect(props.windowControls?.dragHandleProps?.onDoubleClick).toEqual(expect.any(Function));
 
     act(() => {

--- a/tests/shell/mobile-shell.test.tsx
+++ b/tests/shell/mobile-shell.test.tsx
@@ -21,8 +21,16 @@ vi.mock("../../shell/src/hooks/useFileWatcher.js", () => ({
 }));
 
 vi.mock("../../shell/src/components/terminal/TerminalApp.js", () => ({
-  TerminalApp: ({ launchTargetId }: { launchTargetId?: string }) => (
-    <div data-testid="terminal-app">
+  TerminalApp: ({ launchTargetId, layoutId, persistence }: {
+    launchTargetId?: string;
+    layoutId?: string;
+    persistence?: "durable" | "ephemeral";
+  }) => (
+    <div
+      data-testid="terminal-app"
+      data-layout-id={layoutId}
+      data-persistence={persistence}
+    >
       <input
         aria-label="Command composer"
         onFocus={() => window.dispatchEvent(new CustomEvent("matrixos:terminal-input-active", {
@@ -212,7 +220,9 @@ describe("mobile shell", () => {
     render(<MobileShell />);
     fireEvent.click(screen.getByRole("button", { name: "Install OpenClaw from Settings" }));
 
-    expect(await screen.findByTestId("terminal-app")).toBeTruthy();
+    const terminal = await screen.findByTestId("terminal-app");
+    expect(terminal.dataset.persistence).toBe("ephemeral");
+    expect(terminal.dataset.layoutId).toBeUndefined();
     expect(window.sessionStorage.getItem("matrix:terminal-launch-queue")).toContain("openclaw-install");
   });
 
@@ -229,6 +239,29 @@ describe("mobile shell", () => {
     expect(await screen.findByTestId("terminal-app")).toBeTruthy();
     expect(window.sessionStorage.getItem("matrix:provider-terminal-session-queue")).toContain("provider-login");
     expect(window.sessionStorage.getItem("matrix:terminal-launch-queue")).toBeNull();
+  });
+
+  it("gives normal mobile terminals independent durable layouts", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve({
+      ok: true,
+      json: async () => [],
+    })));
+    const MobileShell = await loadMobileShell();
+
+    render(<MobileShell />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    act(() => {
+      fireEvent.click(screen.getByLabelText("Terminal"));
+      fireEvent.click(screen.getByLabelText("Terminal"));
+    });
+
+    const terminals = screen.getAllByTestId("terminal-app");
+    const layoutIds = terminals.map((terminal) => terminal.dataset.layoutId);
+    expect(terminals.every((terminal) => terminal.dataset.persistence === "durable")).toBe(true);
+    expect(layoutIds.every((layoutId) => /^term-layout_[0-9a-f]{32}$/.test(layoutId ?? ""))).toBe(true);
+    expect(new Set(layoutIds).size).toBe(2);
   });
 
   it("hides the bottom dock while the terminal command composer is focused", async () => {

--- a/tests/shell/mobile-shell.test.tsx
+++ b/tests/shell/mobile-shell.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { renderToString } from "react-dom/server";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
 import { useMobileViewport } from "../../shell/src/hooks/useMobileViewport.js";
 import { createShellSnapshotScope, saveShellSnapshot } from "../../shell/src/lib/shell-snapshot-cache.js";
 import { setDesktopViewport, setPhoneViewport } from "./mobile-shell-test-utils.js";
@@ -196,6 +197,32 @@ describe("mobile shell", () => {
     });
 
     expect(screen.getAllByLabelText("Close Terminal")).toHaveLength(5);
+  });
+
+  it("does not evict a durable terminal when setup is launched at capacity", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve({
+      ok: true,
+      json: async () => [],
+    })));
+    const MobileShell = await loadMobileShell();
+
+    render(<MobileShell />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    act(() => {
+      for (let i = 0; i < 5; i += 1) {
+        fireEvent.click(screen.getByLabelText("Terminal"));
+      }
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Install OpenClaw from Settings" }));
+
+    const terminals = screen.getAllByTestId("terminal-app");
+    expect(terminals).toHaveLength(5);
+    expect(terminals.every((terminal) => terminal.dataset.persistence === "durable")).toBe(true);
+    expect(window.sessionStorage.getItem("matrix:terminal-launch-queue") ?? "").not.toContain("openclaw-install");
+    expect(toast).toHaveBeenCalledWith("Close a Terminal before starting setup");
   });
 
   it("opens a launch shortcut target inside the mobile shell", async () => {

--- a/tests/shell/os-view-state-client.test.ts
+++ b/tests/shell/os-view-state-client.test.ts
@@ -42,12 +42,28 @@ describe("Web OS-view state client", () => {
     ];
     document.desktop.windows = [
       { path: "__chat__", x: 40, y: 60, width: 900, height: 640 },
-      { path: "__terminal__", x: 80, y: 100, width: 840, height: 560 },
+      {
+        path: "__terminal__",
+        x: 80,
+        y: 100,
+        width: 840,
+        height: 560,
+        terminalLayoutId: "term-layout_0123456789abcdef0123456789abcdef",
+      },
     ];
 
     expect(layoutWindowsFromOsViewState({ ...latest, document }, "canvas")).toEqual([
       { path: "__chat__", title: "Chat", state: "open", x: 40, y: 60, width: 900, height: 640 },
-      { path: "__terminal__", title: "Terminal", state: "minimized", x: 80, y: 100, width: 840, height: 560 },
+      {
+        path: "__terminal__",
+        title: "Terminal",
+        state: "minimized",
+        x: 80,
+        y: 100,
+        width: 840,
+        height: 560,
+        terminalLayoutId: "term-layout_0123456789abcdef0123456789abcdef",
+      },
     ]);
   });
 

--- a/tests/shell/pane-grid-recovery.test.tsx
+++ b/tests/shell/pane-grid-recovery.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PaneGrid } from "../../shell/src/components/terminal/PaneGrid.js";
+
+vi.mock("../../shell/src/components/terminal/TerminalPane.js", () => ({
+  TerminalPane: () => <div>Live terminal</div>,
+}));
+
+const theme = {
+  name: "matrix-dark",
+  mode: "dark" as const,
+  colors: { background: "#000", foreground: "#fff", primary: "#39ff6a" },
+  fonts: { mono: "monospace", sans: "sans-serif" },
+  radius: "0.75rem",
+};
+
+describe("PaneGrid missing session recovery", () => {
+  it("renders a recoverable placeholder instead of attaching a missing runtime", async () => {
+    const onRecoverSession = vi.fn(async () => true);
+    render(<PaneGrid
+      paneTree={{ type: "pane", id: "pane-one", cwd: "projects/demo", sessionId: "bench" }}
+      theme={theme}
+      unavailableSessionIds={["bench"]}
+      onRecoverSession={onRecoverSession}
+    />);
+
+    expect(screen.queryByText("Live terminal")).toBeNull();
+    expect(screen.getByText("Session is unavailable")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Recover bench" }));
+
+    await vi.waitFor(() => {
+      expect(onRecoverSession).toHaveBeenCalledWith("bench", "projects/demo");
+    });
+  });
+
+  it("shows a bounded retry message when explicit recovery fails", async () => {
+    render(<PaneGrid
+      paneTree={{ type: "pane", id: "pane-one", cwd: "projects", sessionId: "bench" }}
+      theme={theme}
+      unavailableSessionIds={["bench"]}
+      onRecoverSession={vi.fn(async () => false)}
+    />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Recover bench" }));
+
+    expect(await screen.findByText("Recovery failed. Try again.")).toBeTruthy();
+  });
+});

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -795,6 +795,509 @@ describe("TerminalApp", () => {
     expect(layoutPutCalls).toHaveLength(0);
   });
 
+  it("loads and revision-saves only its ID-scoped Terminal window layout", async () => {
+    const layoutId = "term-layout_0123456789abcdef0123456789abcdef";
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes(`/api/terminal/window-layouts/${layoutId}`) && init?.method === "PUT") {
+        return Promise.resolve(mockJsonResponse({ layoutId, revision: 5, layout: JSON.parse(String(init.body)).layout }));
+      }
+      if (url.includes(`/api/terminal/window-layouts/${layoutId}`)) {
+        return Promise.resolve(mockJsonResponse({
+          layoutId,
+          revision: 4,
+          layout: {
+            activeTabId: "bench-tab",
+            sidebarOpen: true,
+            tabs: [{
+              id: "bench-tab",
+              label: "bench",
+              paneTree: { type: "pane", id: "bench-pane", cwd: "projects", sessionId: "bench" },
+            }],
+          },
+        }));
+      }
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve(mockJsonResponse({ sessions: [{ name: "bench", status: "active" }] }));
+      }
+      return Promise.resolve(mockJsonResponse({}));
+    }));
+
+    render(<TerminalApp layoutId={layoutId} />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const paneProps = paneGridSpy.mock.lastCall?.[0] as {
+      paneTree: { id: string };
+      onSessionAttached: (paneId: string, sessionId: string) => void;
+    };
+    act(() => paneProps.onSessionAttached(paneProps.paneTree.id, "bench-next"));
+    act(() => window.dispatchEvent(new Event("pagehide")));
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/api/terminal/window-layouts/${layoutId}`),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    const putCall = vi.mocked(global.fetch).mock.calls.find(([input, init]) => (
+      String(input).includes(`/api/terminal/window-layouts/${layoutId}`) && init?.method === "PUT"
+    ));
+    expect(JSON.parse(String(putCall?.[1]?.body))).toMatchObject({
+      baseRevision: 4,
+      layout: { activeTabId: "bench-tab" },
+    });
+  });
+
+  it("rebases local layout edits onto newer state after a revision conflict", async () => {
+    const layoutId = "term-layout_0123456789abcdef0123456789abcdef";
+    let layoutReads = 0;
+    let layoutWrites = 0;
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes(`/api/terminal/window-layouts/${layoutId}`) && init?.method === "PUT") {
+        layoutWrites += 1;
+        if (layoutWrites === 1) {
+          return Promise.resolve(mockJsonResponse({
+            error: { code: "layout_revision_conflict", message: "Layout changed elsewhere" },
+          }, 409));
+        }
+        const body = JSON.parse(String(init.body));
+        return Promise.resolve(mockJsonResponse({ layoutId, revision: 6, layout: body.layout }));
+      }
+      if (url.includes(`/api/terminal/window-layouts/${layoutId}`)) {
+        layoutReads += 1;
+        return Promise.resolve(mockJsonResponse({
+          layoutId,
+          revision: layoutReads === 1 ? 4 : 5,
+          layout: layoutReads === 1 ? {
+              activeTabId: "bench-tab",
+              sidebarOpen: true,
+              tabs: [{
+                id: "bench-tab",
+                label: "bench",
+                paneTree: { type: "pane", id: "bench-pane", cwd: "projects", sessionId: "bench" },
+              }],
+            } : {
+              activeTabId: "bench-tab",
+              sidebarOpen: false,
+              tabs: [{
+                id: "bench-tab",
+                label: "bench",
+                paneTree: { type: "pane", id: "bench-pane", cwd: "projects", sessionId: "bench" },
+              }, {
+                id: "remote-tab",
+                label: "remote",
+                paneTree: { type: "pane", id: "remote-pane", cwd: "projects", sessionId: "remote" },
+              }],
+            },
+        }));
+      }
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve(mockJsonResponse({ sessions: [{ name: "bench", status: "active" }] }));
+      }
+      return Promise.resolve(mockJsonResponse({}));
+    }));
+
+    render(<TerminalApp layoutId={layoutId} />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const paneProps = paneGridSpy.mock.lastCall?.[0] as {
+      paneTree: { id: string };
+      onSessionAttached: (paneId: string, sessionId: string) => void;
+    };
+    act(() => paneProps.onSessionAttached(paneProps.paneTree.id, "bench-local"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    const putsAfterConflict = vi.mocked(global.fetch).mock.calls.filter(([input, init]) => (
+      String(input).includes(`/api/terminal/window-layouts/${layoutId}`) && init?.method === "PUT"
+    ));
+    expect(putsAfterConflict).toHaveLength(2);
+    expect(JSON.parse(String(putsAfterConflict[1]?.[1]?.body))).toMatchObject({
+      baseRevision: 5,
+      layout: {
+        sidebarOpen: false,
+        tabs: [
+          { id: "bench-tab", paneTree: { sessionId: "bench-local" } },
+          { id: "remote-tab", paneTree: { sessionId: "remote" } },
+        ],
+      },
+    });
+
+    act(() => window.dispatchEvent(new Event("pagehide")));
+    const putsAfterPageHide = vi.mocked(global.fetch).mock.calls.filter(([input, init]) => (
+      String(input).includes(`/api/terminal/window-layouts/${layoutId}`) && init?.method === "PUT"
+    ));
+    expect(putsAfterPageHide).toHaveLength(2);
+  });
+
+  it("rebases edits made during conflict resolution without restoring remotely deleted tabs", async () => {
+    const layoutId = "term-layout_0123456789abcdef0123456789abcdef";
+    let layoutReads = 0;
+    let layoutWrites = 0;
+    let resolveConflictReload!: (response: Response) => void;
+    const conflictReload = new Promise<Response>((resolve) => {
+      resolveConflictReload = resolve;
+    });
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes(`/api/terminal/window-layouts/${layoutId}`) && init?.method === "PUT") {
+        layoutWrites += 1;
+        if (layoutWrites === 1) {
+          return Promise.resolve(mockJsonResponse({
+            error: { code: "layout_revision_conflict", message: "Layout changed elsewhere" },
+          }, 409));
+        }
+        const body = JSON.parse(String(init.body));
+        return Promise.resolve(mockJsonResponse({
+          layoutId,
+          revision: layoutWrites === 2 ? 6 : 7,
+          layout: body.layout,
+        }));
+      }
+      if (url.includes(`/api/terminal/window-layouts/${layoutId}`)) {
+        layoutReads += 1;
+        if (layoutReads > 1) return conflictReload;
+        return Promise.resolve(mockJsonResponse({
+          layoutId,
+          revision: 4,
+          layout: {
+            activeTabId: "bench-tab",
+            sidebarOpen: true,
+            tabs: [{
+              id: "bench-tab",
+              label: "bench",
+              paneTree: { type: "pane", id: "bench-pane", cwd: "projects", sessionId: "bench" },
+            }, {
+              id: "obsolete-tab",
+              label: "obsolete",
+              paneTree: { type: "pane", id: "obsolete-pane", cwd: "projects", sessionId: "obsolete" },
+            }],
+          },
+        }));
+      }
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve(mockJsonResponse({
+          sessions: [
+            { name: "bench", status: "active" },
+            { name: "obsolete", status: "active" },
+          ],
+        }));
+      }
+      return Promise.resolve(mockJsonResponse({}));
+    }));
+
+    render(<TerminalApp layoutId={layoutId} />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const firstPaneProps = paneGridSpy.mock.lastCall?.[0] as {
+      paneTree: { id: string };
+      onSessionAttached: (paneId: string, sessionId: string) => void;
+    };
+    act(() => firstPaneProps.onSessionAttached(firstPaneProps.paneTree.id, "bench-local"));
+    act(() => vi.advanceTimersByTime(500));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const inFlightPaneProps = paneGridSpy.mock.lastCall?.[0] as typeof firstPaneProps;
+    act(() => inFlightPaneProps.onSessionAttached(inFlightPaneProps.paneTree.id, "bench-newer"));
+    await act(async () => {
+      resolveConflictReload(mockJsonResponse({
+        layoutId,
+        revision: 5,
+        layout: {
+          activeTabId: "bench-tab",
+          sidebarOpen: false,
+          tabs: [{
+            id: "bench-tab",
+            label: "bench",
+            paneTree: { type: "pane", id: "bench-pane", cwd: "projects", sessionId: "bench" },
+          }],
+        },
+      }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    const putCalls = vi.mocked(global.fetch).mock.calls.filter(([input, init]) => (
+      String(input).includes(`/api/terminal/window-layouts/${layoutId}`) && init?.method === "PUT"
+    ));
+    expect(putCalls).toHaveLength(3);
+    expect(JSON.parse(String(putCalls[2]?.[1]?.body))).toMatchObject({
+      baseRevision: 6,
+      layout: {
+        tabs: [{ id: "bench-tab", paneTree: { sessionId: "bench-newer" } }],
+      },
+    });
+    expect(JSON.parse(String(putCalls[2]?.[1]?.body)).layout.tabs).toHaveLength(1);
+  });
+
+  it("schedules another durable save when the conflict retry also conflicts", async () => {
+    const layoutId = "term-layout_0123456789abcdef0123456789abcdef";
+    let layoutReads = 0;
+    let layoutWrites = 0;
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes(`/api/terminal/window-layouts/${layoutId}`) && init?.method === "PUT") {
+        layoutWrites += 1;
+        if (layoutWrites <= 3) {
+          return Promise.resolve(mockJsonResponse({
+            error: { code: "layout_revision_conflict", message: "Layout changed elsewhere" },
+          }, 409));
+        }
+        const body = JSON.parse(String(init.body));
+        return Promise.resolve(mockJsonResponse({ layoutId, revision: 7, layout: body.layout }));
+      }
+      if (url.includes(`/api/terminal/window-layouts/${layoutId}`)) {
+        layoutReads += 1;
+        const revision = layoutReads === 1 ? 4 : layoutReads === 2 ? 5 : 6;
+        return Promise.resolve(mockJsonResponse({
+          layoutId,
+          revision,
+          layout: {
+            activeTabId: "bench-tab",
+            sidebarOpen: true,
+            tabs: [{
+              id: "bench-tab",
+              label: "bench",
+              paneTree: { type: "pane", id: "bench-pane", cwd: "projects", sessionId: "bench" },
+            }],
+          },
+        }));
+      }
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve(mockJsonResponse({ sessions: [{ name: "bench", status: "active" }] }));
+      }
+      return Promise.resolve(mockJsonResponse({}));
+    }));
+
+    render(<TerminalApp layoutId={layoutId} />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const paneProps = paneGridSpy.mock.lastCall?.[0] as {
+      paneTree: { id: string };
+      onSessionAttached: (paneId: string, sessionId: string) => void;
+    };
+    act(() => paneProps.onSessionAttached(paneProps.paneTree.id, "bench-local"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(layoutWrites).toBe(2);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(layoutWrites).toBe(4);
+    const finalPut = vi.mocked(global.fetch).mock.calls.filter(([input, init]) => (
+      String(input).includes(`/api/terminal/window-layouts/${layoutId}`) && init?.method === "PUT"
+    )).at(-1);
+    expect(JSON.parse(String(finalPut?.[1]?.body))).toMatchObject({
+      baseRevision: 6,
+      layout: { tabs: [{ paneTree: { sessionId: "bench-local" } }] },
+    });
+  });
+
+  it("flushes a dirty durable layout when the Terminal unmounts after a conflict", async () => {
+    const layoutId = "term-layout_0123456789abcdef0123456789abcdef";
+    let layoutReads = 0;
+    let layoutWrites = 0;
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes(`/api/terminal/window-layouts/${layoutId}`) && init?.method === "PUT") {
+        layoutWrites += 1;
+        if (layoutWrites <= 2) {
+          return Promise.resolve(mockJsonResponse({
+            error: { code: "layout_revision_conflict", message: "Layout changed elsewhere" },
+          }, 409));
+        }
+        const body = JSON.parse(String(init.body));
+        return Promise.resolve(mockJsonResponse({ layoutId, revision: 7, layout: body.layout }));
+      }
+      if (url.includes(`/api/terminal/window-layouts/${layoutId}`)) {
+        layoutReads += 1;
+        return Promise.resolve(mockJsonResponse({
+          layoutId,
+          revision: layoutReads === 1 ? 4 : 5,
+          layout: {
+            activeTabId: "bench-tab",
+            sidebarOpen: true,
+            tabs: [{
+              id: "bench-tab",
+              label: "bench",
+              paneTree: { type: "pane", id: "bench-pane", cwd: "projects", sessionId: "bench" },
+            }],
+          },
+        }));
+      }
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve(mockJsonResponse({ sessions: [{ name: "bench", status: "active" }] }));
+      }
+      return Promise.resolve(mockJsonResponse({}));
+    }));
+
+    const mounted = render(<TerminalApp layoutId={layoutId} />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const paneProps = paneGridSpy.mock.lastCall?.[0] as {
+      paneTree: { id: string };
+      onSessionAttached: (paneId: string, sessionId: string) => void;
+    };
+    act(() => paneProps.onSessionAttached(paneProps.paneTree.id, "bench-local"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(layoutWrites).toBe(2);
+
+    mounted.unmount();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(layoutWrites).toBe(3);
+    const finalPut = vi.mocked(global.fetch).mock.calls.filter(([input, init]) => (
+      String(input).includes(`/api/terminal/window-layouts/${layoutId}`) && init?.method === "PUT"
+    )).at(-1);
+    expect(JSON.parse(String(finalPut?.[1]?.body))).toMatchObject({
+      layout: { tabs: [{ paneTree: { sessionId: "bench-local" } }] },
+    });
+  });
+
+  it("keeps retrying a failed durable layout flush after the Terminal unmounts", async () => {
+    const layoutId = "term-layout_0123456789abcdef0123456789abcdef";
+    let layoutWrites = 0;
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes(`/api/terminal/window-layouts/${layoutId}`) && init?.method === "PUT") {
+        layoutWrites += 1;
+        if (layoutWrites <= 3) {
+          return Promise.resolve(mockJsonResponse({
+            error: { code: "layout_save_failed", message: "Layout save failed" },
+          }, 503));
+        }
+        const body = JSON.parse(String(init.body));
+        return Promise.resolve(mockJsonResponse({ layoutId, revision: 5, layout: body.layout }));
+      }
+      if (url.includes(`/api/terminal/window-layouts/${layoutId}`)) {
+        return Promise.resolve(mockJsonResponse({
+          layoutId,
+          revision: 4,
+          layout: {
+            activeTabId: "bench-tab",
+            sidebarOpen: true,
+            tabs: [{
+              id: "bench-tab",
+              label: "bench",
+              paneTree: { type: "pane", id: "bench-pane", cwd: "projects", sessionId: "bench" },
+            }],
+          },
+        }));
+      }
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve(mockJsonResponse({ sessions: [{ name: "bench", status: "active" }] }));
+      }
+      return Promise.resolve(mockJsonResponse({}));
+    }));
+
+    const mounted = render(<TerminalApp layoutId={layoutId} />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const paneProps = paneGridSpy.mock.lastCall?.[0] as {
+      paneTree: { id: string };
+      onSessionAttached: (paneId: string, sessionId: string) => void;
+    };
+    act(() => paneProps.onSessionAttached(paneProps.paneTree.id, "bench-local"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(layoutWrites).toBe(1);
+
+    mounted.unmount();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(layoutWrites).toBe(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(layoutWrites).toBe(3);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    expect(layoutWrites).toBe(4);
+    const finalPut = vi.mocked(global.fetch).mock.calls.filter(([input, init]) => (
+      String(input).includes(`/api/terminal/window-layouts/${layoutId}`) && init?.method === "PUT"
+    )).at(-1);
+    expect(JSON.parse(String(finalPut?.[1]?.body))).toMatchObject({
+      baseRevision: 4,
+      layout: { tabs: [{ paneTree: { sessionId: "bench-local" } }] },
+    });
+  });
+
+  it("does not read or save durable layouts for an ephemeral setup terminal", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(mockJsonResponse({ sessions: [] }))));
+
+    render(<TerminalApp persistence="ephemeral" />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    act(() => window.dispatchEvent(new Event("pagehide")));
+
+    expect(vi.mocked(global.fetch).mock.calls.some(([input]) => (
+      String(input).includes("/api/terminal/layout")
+      || String(input).includes("/api/terminal/window-layouts")
+    ))).toBe(false);
+  });
+
+  it("deletes the temporary shell when an ephemeral setup terminal closes", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(mockJsonResponse({ ok: true }))));
+    const mounted = render(<TerminalApp persistence="ephemeral" initialCommand="codex" />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const props = paneGridSpy.mock.lastCall?.[0] as {
+      paneTree: { id: string };
+      onSessionAttached: (paneId: string, sessionId: string) => void;
+    };
+    act(() => props.onSessionAttached(props.paneTree.id, "setup-shell"));
+
+    mounted.unmount();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/terminal/sessions/setup-shell?force=1"),
+      expect.objectContaining({ method: "DELETE", keepalive: true }),
+    );
+  });
+
   it("does not render workspace transport ids as managed shell sessions", async () => {
     render(<TerminalApp initialSessionId="matrix-sess_run_db0dded67faaca6b" />);
 
@@ -3501,7 +4004,7 @@ describe("TerminalApp", () => {
     expect(props.paneTree.sessionId).toBe("main");
   });
 
-  it("does not relaunch a stale saved shell session while restoring a layout", async () => {
+  it("restores a stale saved shell session as unavailable without relaunching it", async () => {
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/api/terminal/layout") && init?.method !== "PUT") {
@@ -3525,6 +4028,9 @@ describe("TerminalApp", () => {
       if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
         return Promise.resolve({ ok: true, json: async () => ({ sessions: [{ name: "main" }] }) });
       }
+      if (url.includes("/api/terminal/sessions/bench/recover") && init?.method === "POST") {
+        return Promise.resolve(mockJsonResponse({ session: { name: "bench", status: "active" } }, 201));
+      }
       return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
     }));
 
@@ -3539,8 +4045,24 @@ describe("TerminalApp", () => {
     expect(terminalSessionPostBodies()).toHaveLength(0);
     const props = paneGridSpy.mock.lastCall?.[0] as {
       paneTree: { type: "pane"; sessionId?: string };
+      unavailableSessionIds?: string[];
+      onRecoverSession?: (sessionId: string, cwd: string) => Promise<boolean>;
     };
-    expect(props.paneTree.sessionId).toBe("main");
+    expect(props.paneTree.sessionId).toBe("bench");
+    expect(props.unavailableSessionIds).toEqual(["bench"]);
+
+    await act(async () => {
+      await expect(props.onRecoverSession?.("bench", "projects")).resolves.toBe(true);
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/terminal/sessions/bench/recover"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ cwd: "projects" }),
+      }),
+    );
+    const recoveredProps = paneGridSpy.mock.lastCall?.[0] as { unavailableSessionIds?: string[] };
+    expect(recoveredProps.unavailableSessionIds).toEqual([]);
   });
 
   it("preserves a saved shell layout when the session catalog is unavailable", async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -1261,6 +1261,68 @@ describe("TerminalApp", () => {
     });
   });
 
+  it("stops retrying a failed durable layout flush after a bounded unmount window", async () => {
+    const layoutId = "term-layout_0123456789abcdef0123456789abcdef";
+    let layoutWrites = 0;
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes(`/api/terminal/window-layouts/${layoutId}`) && init?.method === "PUT") {
+        layoutWrites += 1;
+        return Promise.resolve(mockJsonResponse({
+          error: { code: "layout_save_failed", message: "Layout save failed" },
+        }, 503));
+      }
+      if (url.includes(`/api/terminal/window-layouts/${layoutId}`)) {
+        return Promise.resolve(mockJsonResponse({
+          layoutId,
+          revision: 4,
+          layout: {
+            activeTabId: "bench-tab",
+            sidebarOpen: true,
+            tabs: [{
+              id: "bench-tab",
+              label: "bench",
+              paneTree: { type: "pane", id: "bench-pane", cwd: "projects", sessionId: "bench" },
+            }],
+          },
+        }));
+      }
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve(mockJsonResponse({ sessions: [{ name: "bench", status: "active" }] }));
+      }
+      return Promise.resolve(mockJsonResponse({}));
+    }));
+
+    const mounted = render(<TerminalApp layoutId={layoutId} />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const paneProps = paneGridSpy.mock.lastCall?.[0] as {
+      paneTree: { id: string };
+      onSessionAttached: (paneId: string, sessionId: string) => void;
+    };
+    act(() => paneProps.onSessionAttached(paneProps.paneTree.id, "bench-local"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(layoutWrites).toBe(1);
+
+    mounted.unmount();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(layoutWrites).toBe(5);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(layoutWrites).toBe(5);
+  });
+
   it("does not read or save durable layouts for an ephemeral setup terminal", async () => {
     vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(mockJsonResponse({ sessions: [] }))));
 

--- a/tests/shell/terminal-launch.test.ts
+++ b/tests/shell/terminal-launch.test.ts
@@ -5,7 +5,6 @@ import {
   drainTerminalLaunchQueue,
   enqueueTerminalLaunch,
   terminalLaunchConfig,
-  TERMINAL_SETUP_WINDOW_PATH,
 } from "../../shell/src/lib/terminal-launch.js";
 
 describe("terminal launch paths", () => {
@@ -55,10 +54,6 @@ describe("terminal launch paths", () => {
       label: "Restart OpenClaw",
       command: "/opt/matrix/bin/matrix-agent-runtime-control switch openclaw",
     });
-  });
-
-  it("targets setup actions at the canonical terminal surface", () => {
-    expect(TERMINAL_SETUP_WINDOW_PATH).toBe("__terminal__");
   });
 
   it("queues setup actions so an existing terminal can open them as tabs", () => {

--- a/tests/shell/terminal-layout.test.ts
+++ b/tests/shell/terminal-layout.test.ts
@@ -11,6 +11,7 @@ import {
   getPaneSessionId,
   getSessionIds,
   layoutUsesOnlyCanonicalShellSessions,
+  mergeTerminalLayouts,
   removeSessionFromPaneTree,
   renameSessionInTree,
   setPaneSessionId,
@@ -112,6 +113,86 @@ describe("terminal layout helpers", () => {
         { type: "pane", id: "left", cwd: "projects/app", sessionId: "shell-main", compatMode: undefined },
         { type: "pane", id: "right", cwd: DEFAULT_CWD, sessionId: "codex-build", compatMode: "codex-tui" },
       ],
+    });
+  });
+
+  it("rebases independent local and remote layout edits without resurrecting deletions", () => {
+    const base: TerminalLayout = {
+      activeTabId: "main-tab",
+      sidebarOpen: true,
+      tabs: [{
+        id: "main-tab",
+        label: "Main",
+        paneTree: { type: "pane", id: "main-pane", cwd: "projects", sessionId: "main" },
+      }, {
+        id: "deleted-tab",
+        label: "Deleted",
+        paneTree: { type: "pane", id: "deleted-pane", cwd: "projects", sessionId: "deleted" },
+      }],
+    };
+    const local: TerminalLayout = {
+      ...base,
+      tabs: [{
+        id: "main-tab",
+        label: "Main",
+        paneTree: { type: "pane", id: "main-pane", cwd: "projects", sessionId: "main-local" },
+      }, base.tabs![1]!],
+    };
+    const remote: TerminalLayout = {
+      activeTabId: "main-tab",
+      sidebarOpen: false,
+      tabs: [{
+        id: "main-tab",
+        label: "Main",
+        paneTree: { type: "pane", id: "main-pane", cwd: "projects", sessionId: "main" },
+      }, {
+        id: "remote-tab",
+        label: "Remote",
+        paneTree: { type: "pane", id: "remote-pane", cwd: "projects", sessionId: "remote" },
+      }],
+    };
+
+    expect(mergeTerminalLayouts(base, local, remote)).toEqual({
+      activeTabId: "main-tab",
+      sidebarOpen: false,
+      tabs: [{
+        id: "main-tab",
+        label: "Main",
+        paneTree: { type: "pane", id: "main-pane", cwd: "projects", sessionId: "main-local" },
+      }, {
+        id: "remote-tab",
+        label: "Remote",
+        paneTree: { type: "pane", id: "remote-pane", cwd: "projects", sessionId: "remote" },
+      }],
+    });
+  });
+
+  it("preserves an edit to a surviving pane when another window closes its sibling", () => {
+    const base: TerminalLayout = {
+      activeTabId: "main-tab",
+      tabs: [{ id: "main-tab", label: "Main", paneTree: splitTree }],
+    };
+    const local: TerminalLayout = {
+      ...base,
+      tabs: [{
+        id: "main-tab",
+        label: "Main",
+        paneTree: setPaneSessionId(splitTree, "left", "shell-local"),
+      }],
+    };
+    const remote: TerminalLayout = {
+      ...base,
+      tabs: [{
+        id: "main-tab",
+        label: "Main",
+        paneTree: splitTree.children[0],
+      }],
+    };
+
+    expect(mergeTerminalLayouts(base, local, remote).tabs?.[0]?.paneTree).toMatchObject({
+      type: "pane",
+      id: "left",
+      sessionId: "shell-local",
     });
   });
 });

--- a/tests/shell/window-manager.test.ts
+++ b/tests/shell/window-manager.test.ts
@@ -338,17 +338,20 @@ describe("Window Manager Store", () => {
       );
     });
 
-    it("persists a stable layout id for an ordinary Terminal window", () => {
+    it("persists a stable layout id for an ordinary Terminal window", async () => {
       useWindowManager.getState().openWindow("Terminal", "__terminal__", 80);
       const opened = useWindowManager.getState().windows[0];
       expect(opened.terminalLayoutId).toMatch(/^term-layout_[0-9a-f]{32}$/);
 
       vi.advanceTimersByTime(500);
-      const body = JSON.parse(fetchSpy.mock.calls[0][1].body) as { windows: LayoutWindow[] };
-      expect(body.windows[0]?.terminalLayoutId).toBe(opened.terminalLayoutId);
+      await Promise.resolve();
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body) as {
+        patch: { desktop: { windows: LayoutWindow[] } };
+      };
+      expect(body.patch.desktop.windows[0]?.terminalLayoutId).toBe(opened.terminalLayoutId);
     });
 
-    it("keeps setup terminals separate, ephemeral, and out of desktop persistence", () => {
+    it("keeps setup terminals separate, ephemeral, and out of desktop persistence", async () => {
       useWindowManager.getState().openWindow("Terminal", "__terminal__", 80);
       useWindowManager.getState().openWindow("Terminal", "__terminal__", 80, {
         terminalPersistence: "ephemeral",
@@ -362,8 +365,11 @@ describe("Window Manager Store", () => {
       expect(setup?.terminalLayoutId).toBeUndefined();
 
       vi.advanceTimersByTime(500);
-      const body = JSON.parse(fetchSpy.mock.calls[0][1].body) as { windows: LayoutWindow[] };
-      expect(body.windows.map((win) => win.path)).toEqual(["__terminal__"]);
+      await Promise.resolve();
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body) as {
+        patch: { desktop: { windows: LayoutWindow[] } };
+      };
+      expect(body.patch.desktop.windows.map((win) => win.path)).toEqual(["__terminal__"]);
     });
 
     it("does not save layout on the pre-VPS billing setup route", () => {

--- a/tests/shell/window-manager.test.ts
+++ b/tests/shell/window-manager.test.ts
@@ -338,6 +338,34 @@ describe("Window Manager Store", () => {
       );
     });
 
+    it("persists a stable layout id for an ordinary Terminal window", () => {
+      useWindowManager.getState().openWindow("Terminal", "__terminal__", 80);
+      const opened = useWindowManager.getState().windows[0];
+      expect(opened.terminalLayoutId).toMatch(/^term-layout_[0-9a-f]{32}$/);
+
+      vi.advanceTimersByTime(500);
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body) as { windows: LayoutWindow[] };
+      expect(body.windows[0]?.terminalLayoutId).toBe(opened.terminalLayoutId);
+    });
+
+    it("keeps setup terminals separate, ephemeral, and out of desktop persistence", () => {
+      useWindowManager.getState().openWindow("Terminal", "__terminal__", 80);
+      useWindowManager.getState().openWindow("Terminal", "__terminal__", 80, {
+        terminalPersistence: "ephemeral",
+      });
+
+      const ordinary = useWindowManager.getState().windows.find((win) => win.terminalPersistence !== "ephemeral");
+      const setup = useWindowManager.getState().windows.find((win) => win.terminalPersistence === "ephemeral");
+      expect(ordinary?.path).toBe("__terminal__");
+      expect(setup?.path).toBe("__terminal__");
+      expect(ordinary?.terminalLayoutId).toMatch(/^term-layout_[0-9a-f]{32}$/);
+      expect(setup?.terminalLayoutId).toBeUndefined();
+
+      vi.advanceTimersByTime(500);
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body) as { windows: LayoutWindow[] };
+      expect(body.windows.map((win) => win.path)).toEqual(["__terminal__"]);
+    });
+
     it("does not save layout on the pre-VPS billing setup route", () => {
       window.history.pushState(null, "", "/?billing=setup");
       useWindowManager.getState().openWindow("Settings", "__settings__", 80);
@@ -394,6 +422,22 @@ describe("Window Manager Store", () => {
   });
 
   describe("loadLayout", () => {
+    it("restores the same Terminal layout id across shell reloads", () => {
+      const terminalLayoutId = "term-layout_0123456789abcdef0123456789abcdef";
+      useWindowManager.getState().loadLayout([{
+        path: "__terminal__",
+        title: "Terminal",
+        x: 100,
+        y: 100,
+        width: 1040,
+        height: 680,
+        state: "open",
+        terminalLayoutId,
+      }]);
+
+      expect(useWindowManager.getState().windows[0]?.terminalLayoutId).toBe(terminalLayoutId);
+    });
+
     it("restores windows from saved layout", () => {
       const saved: LayoutWindow[] = [
         {


### PR DESCRIPTION
## Relationship

Final shell/UI layer for the terminal-session lifecycle fix. The gateway foundation in #1426 is merged into `main` at `3c4e92c89ddb94100286ec01bf1306b5dd8e0004`; this PR is rebased directly on that commit.

## Summary

- stop passive terminal-layout restore from recreating missing or deliberately deleted shell sessions
- render missing runtime references as explicit recoverable placeholders
- persist independent, conflict-aware layouts for each Terminal window instead of one shared global layout
- preserve each Terminal window's durable layout identity through OS-view persistence and reload
- preserve deletion-winning reconciliation during concurrent saves and bounded unmount retries
- keep setup/sign-in terminals ephemeral on the canonical `__terminal__` path across Canvas, Desktop, and Mobile
- give ordinary Mobile Terminal instances independent durable layout IDs
- refuse agent setup at Mobile Terminal capacity instead of silently evicting a live durable terminal

## Invariants

- **Source of truth:** gateway tombstones and revisioned per-layout records remain authoritative; OS-view state persists only each Terminal window's validated layout identity.
- **Concurrency:** layout saves use revision-aware conflict handling, deletion wins reconciliation, and unmount persistence is bounded.
- **Missing runtimes:** passive restore never creates them. The UI renders an unavailable placeholder and recovery requires an explicit user action.
- **Setup isolation:** setup/sign-in Terminal windows remain ephemeral while using the canonical `__terminal__` path in Canvas, Desktop, and Mobile.
- **Auth:** this PR adds no new route or authentication mechanism; it consumes the authenticated lifecycle APIs merged in #1426.
- **Deferred scope:** pruning historical raw Zellij `EXITED` entries is intentionally separate from preventing deleted sessions from reappearing in the shell.

## Validation

- 206/206 focused contract, Desktop, Canvas, Mobile, TerminalApp, recovery, layout, and window-manager tests passed after rebasing onto current `main`.
- shell and contracts strict TypeScript checks passed.
- CI-equivalent production shell build passed.
- pattern scanner reported 0 violations; `git diff --check` passed.
- React Doctor completed successfully for `shell` (only the repository's deprecated config warning was emitted).
- The branch differs from `main` in 22 intended UI/contract/test files; the gateway implementation from #1426 is not duplicated.

## CI / review

- Current exact head: `52ece6dd26388633e309f6a3607f7ab7c263d424`.
- `ready-for-ci`, `preview-vps`, and `user-systemd-production-acceptance` are enabled.
- Exact-head CI passed: [run 34113725003](https://github.com/HamedMP/matrix-os/actions/runs/34113725003), including React Doctor, OS-view parity, all four unit shards, shell production build, and E2E.
- Exact-head Claude review passed: [run 34113725078](https://github.com/HamedMP/matrix-os/actions/runs/34113725078).
- Greptile reviewed the exact head at 5/5 with no blocking findings or unresolved threads.
- Disposable preview [run 34113558774](https://github.com/HamedMP/matrix-os/actions/runs/34113558774) built the exact-head bundle successfully but is again waiting on the existing `pr-1476` machine to finish provisioning. Production acceptance will be triggered after a healthy exact-head preview exists.

## Visual evidence

### Canvas — missing runtime is recoverable, not recreated

![Canvas recoverable terminal session](https://github.com/HamedMP/matrix-os/blob/3c4e92c89ddb94100286ec01bf1306b5dd8e0004/specs/119-terminal-session-lifecycle/evidence/canvas-recoverable-session.png?raw=true)

### Desktop — a fresh Terminal stays empty until explicit creation

![Desktop empty terminal](https://github.com/HamedMP/matrix-os/blob/3c4e92c89ddb94100286ec01bf1306b5dd8e0004/specs/119-terminal-session-lifecycle/evidence/desktop-empty-terminal.png?raw=true)

## Documentation

Public documentation is published on branch `FinnaAI/matrix-os-site:codex/terminal-session-lifecycle-docs` for a separate docs PR.
