### PR TITLE
fix(desktop): guard embed cleanup after window destruction

### DIFF
--- a/desktop/src/main/embeds/web-contents-view.ts
+++ b/desktop/src/main/embeds/web-contents-view.ts
@@ -145,6 +145,16 @@ export function createWebContentsView(options: {
   });
 
   let attached = false;
+  const detachFromWindow = () => {
+    if (!attached) return;
+    attached = false;
+    // BrowserWindow emits "closed" after Electron has destroyed its native
+    // contentView. OTA quit-and-install can therefore reach embed cleanup
+    // after the parent is already gone; the child view is detached as part of
+    // that destruction, so there is nothing left to remove explicitly.
+    if (options.window.isDestroyed()) return;
+    options.window.contentView.removeChildView(view);
+  };
 
   return {
     setBounds(bounds: Bounds) {
@@ -162,16 +172,11 @@ export function createWebContentsView(options: {
       attached = true;
     },
     detach() {
-      if (!attached) return;
-      options.window.contentView.removeChildView(view);
-      attached = false;
+      detachFromWindow();
     },
     destroy() {
       options.appBridge?.unregister(contents.id);
-      if (attached) {
-        options.window.contentView.removeChildView(view);
-        attached = false;
-      }
+      detachFromWindow();
       // WebContentsView is GC'd once detached and dereferenced; closing the
       // contents releases the renderer process promptly.
       if (!contents.isDestroyed()) contents.close();

--- a/tests/desktop/web-contents-view.test.ts
+++ b/tests/desktop/web-contents-view.test.ts
@@ -44,11 +44,38 @@ beforeEach(() => {
   electronMock.shell.openExternal.mockClear();
   electronMock.webContents.setWindowOpenHandler.mockClear();
   electronMock.webContents.loadURL.mockClear();
+  electronMock.webContents.isDestroyed.mockReset();
+  electronMock.webContents.isDestroyed.mockReturnValue(false);
+  electronMock.webContents.close.mockClear();
   electronMock.webContents.session.setPermissionCheckHandler.mockClear();
   electronMock.webContents.session.setPermissionRequestHandler.mockClear();
 });
 
 describe("createWebContentsView", () => {
+  it("detaches safely after the parent window has already been destroyed", () => {
+    let windowDestroyed = false;
+    const removeChildView = vi.fn(() => {
+      if (windowDestroyed) throw new TypeError("Object has been destroyed");
+    });
+    const view = createWebContentsView({
+      window: {
+        isDestroyed: () => windowDestroyed,
+        contentView: { addChildView: vi.fn(), removeChildView },
+      } as never,
+      partition: "persist:hosted-shell",
+      allowedOrigins: ["https://gateway.test"],
+      onState: vi.fn(),
+    });
+
+    view.attach();
+    windowDestroyed = true;
+
+    expect(() => view.detach()).not.toThrow();
+    expect(() => view.destroy()).not.toThrow();
+    expect(removeChildView).not.toHaveBeenCalled();
+    expect(electronMock.webContents.close).toHaveBeenCalledOnce();
+  });
+
   it("denies browser permissions for the trusted code editor surface", () => {
     createWebContentsView({
       window: {


### PR DESCRIPTION
## Summary

- Avoid native child-view removal after the parent `BrowserWindow` has already been destroyed during OTA quit-and-install.
- Share the guarded detach path between explicit detach and embed destruction.
- Add regression coverage for the exact `TypeError: Object has been destroyed` shutdown sequence.

## Root cause

Electron emits the window `closed` event after its native `contentView` has been destroyed. The handler calls `embeds.closeAll()`, and the WebContentsView adapter previously attempted `removeChildView()` against that destroyed parent. During `quitAndInstall()`, the resulting uncaught exception interrupted the update flow.

## Validation

- `bun run test tests/desktop/web-contents-view.test.ts tests/desktop/embed-manager.test.ts tests/desktop/embed-service.test.ts tests/desktop/updater.test.ts` — 77/77 passed on `929cd247b`.
- `pnpm --filter desktop run typecheck` — passed on `929cd247b`.
- `bun run check:patterns` — 0 violations, 5 existing warnings on the then-current main base.
- `bun run build:desktop` — passed on `929cd247b`.
- `bun run test` — not green on the earlier exact-main base: 12,305 passed, 18 failed in 6 unrelated files (`todo-model`, onboarding tool packs, zellij, CI workflow checkout retry, Linux golden-snapshot scripts on macOS, and terminal-agent handoff timeouts). The four modified-path regression suites remained green. The full suite was not rerun after rebasing onto subsequent main commits; current-head focused/typecheck/build gates are listed above.

## Invariants

### Source of truth

- Electron's `BrowserWindow.isDestroyed()` is authoritative for whether its native `contentView` may still be accessed.

### Lock/transaction scope

- Not applicable; this changes no persistence, transactions, or shared locks.

### Acceptable orphan states

- When the parent window is already destroyed, Electron has already detached its native children. The adapter still unregisters the bridge and closes any live child `webContents`.

### Auth source of truth

- Unchanged; embed origin and permission policies remain authoritative.

### Deferred scope

- Packaged exact-head manual OTA acceptance and release publication/deployment are not part of this PR.
