### PR TITLE
fix(shell): refresh stale clients and open support chat

### DIFF
--- a/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
+++ b/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
@@ -107,6 +107,10 @@ function supportOpenIsCurrent(generation: number): boolean {
   return generation === supportLifecycleGeneration && initialized && activeIdentity !== null;
 }
 
+function findPostHogButton(selector: string): HTMLButtonElement | null {
+  return document.getElementById(POSTHOG_WIDGET_ID)?.querySelector<HTMLButtonElement>(selector) ?? null;
+}
+
 async function waitForSupportReady(generation: number): Promise<boolean> {
   const deadline = Date.now() + SUPPORT_OPEN_TIMEOUT_MS;
   while (Date.now() < deadline && generation === supportLifecycleGeneration) {
@@ -118,7 +122,7 @@ async function waitForSupportReady(generation: number): Promise<boolean> {
 
 function waitForElement(selector: string, generation: number): Promise<HTMLButtonElement | null> {
   if (!supportOpenIsCurrent(generation)) return Promise.resolve(null);
-  const existing = document.querySelector<HTMLButtonElement>(selector);
+  const existing = findPostHogButton(selector);
   if (existing) return Promise.resolve(existing);
 
   return new Promise((resolve) => {
@@ -137,7 +141,7 @@ function waitForElement(selector: string, generation: number): Promise<HTMLButto
         finish(null);
         return;
       }
-      const element = document.querySelector<HTMLButtonElement>(selector);
+      const element = findPostHogButton(selector);
       if (element) finish(element);
     });
     const timeoutId = window.setTimeout(() => finish(null), SUPPORT_OPEN_TIMEOUT_MS);
@@ -163,7 +167,7 @@ async function openSupportPanel(generation: number): Promise<boolean> {
     if (!supportOpenIsCurrent(generation)) return false;
     posthog.conversations.show();
 
-    let closeButton = document.querySelector<HTMLButtonElement>(POSTHOG_CLOSE_SELECTOR);
+    let closeButton = findPostHogButton(POSTHOG_CLOSE_SELECTOR);
     if (!closeButton) {
       const launcher = await waitForElement(POSTHOG_LAUNCHER_SELECTOR, generation);
       if (!launcher || !supportOpenIsCurrent(generation)) return false;
@@ -174,7 +178,7 @@ async function openSupportPanel(generation: number): Promise<boolean> {
 
     return true;
   } finally {
-    if (generation === supportLifecycleGeneration && !document.querySelector(POSTHOG_CLOSE_SELECTOR)) {
+    if (generation === supportLifecycleGeneration && !findPostHogButton(POSTHOG_CLOSE_SELECTOR)) {
       allowPostHogWidget = false;
       suppressDefaultLauncher();
     }

--- a/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
+++ b/desktop/src/renderer/src/features/support/DesktopSupportWidget.tsx
@@ -107,6 +107,15 @@ function supportOpenIsCurrent(generation: number): boolean {
   return generation === supportLifecycleGeneration && initialized && activeIdentity !== null;
 }
 
+async function waitForSupportReady(generation: number): Promise<boolean> {
+  const deadline = Date.now() + SUPPORT_OPEN_TIMEOUT_MS;
+  while (Date.now() < deadline && generation === supportLifecycleGeneration) {
+    if (supportOpenIsCurrent(generation)) return true;
+    await new Promise((resolve) => window.setTimeout(resolve, 50));
+  }
+  return false;
+}
+
 function waitForElement(selector: string, generation: number): Promise<HTMLButtonElement | null> {
   if (!supportOpenIsCurrent(generation)) return Promise.resolve(null);
   const existing = document.querySelector<HTMLButtonElement>(selector);
@@ -147,7 +156,7 @@ async function waitForConversations(generation: number): Promise<boolean> {
 }
 
 async function openSupportPanel(generation: number): Promise<boolean> {
-  if (!supportOpenIsCurrent(generation) || !await waitForConversations(generation)) return false;
+  if (!await waitForSupportReady(generation) || !await waitForConversations(generation)) return false;
 
   allowPostHogWidget = true;
   try {

--- a/packages/platform/src/app-domain-service-worker.ts
+++ b/packages/platform/src/app-domain-service-worker.ts
@@ -1,5 +1,5 @@
 const APP_DOMAIN_SAFE_SERVICE_WORKER = `
-const VERSION = "app-v2";
+const VERSION = "app-v3";
 const CACHE_STATIC = "matrix-os-static-" + VERSION;
 
 self.addEventListener("install", () => {
@@ -38,13 +38,12 @@ function isBypassed(url) {
 function isStaticAsset(url) {
   const p = url.pathname;
   return (
-    p.startsWith("/_next/static/") ||
     p.startsWith("/icons/") ||
     p.startsWith("/wallpapers/") ||
     p.startsWith("/files/system/wallpapers/") ||
     p.startsWith("/textures/") ||
     p.startsWith("/fonts/") ||
-    /\\.(?:png|jpg|jpeg|svg|webp|woff2?|ttf|css|js|wav|mp3)$/.test(p)
+    /\\.(?:png|jpg|jpeg|svg|webp|woff2?|ttf|wav|mp3)$/.test(p)
   );
 }
 

--- a/shell/public/service-worker.js
+++ b/shell/public/service-worker.js
@@ -1,13 +1,13 @@
 // Matrix OS PWA service worker.
 // Strategy:
 //   - HTML navigation: network-first with 3s timeout, falls back to cache.
-//   - Static shell assets (/_next/static/*, /icons/*, manifest, app icons,
-//     wallpapers, textures, fonts): cache-first.
+//   - Safe media and font assets: cache-first. Executable JS/CSS stays on the
+//     browser/CDN HTTP cache so releases cannot mix application generations.
 //   - Skip everything authenticated/dynamic: /api/*, /v1/*, Clerk, gateway
 //     WebSocket upgrades, anything cross-origin we don't serve.
 // On version bump, old caches are pruned during activate.
 
-const VERSION = "v2";
+const VERSION = "v3";
 const CACHE_STATIC = `matrix-os-static-${VERSION}`;
 const CACHE_HTML = `matrix-os-html-${VERSION}`;
 const PRECACHE = [
@@ -69,13 +69,12 @@ function isBypassed(url) {
 function isStaticAsset(url) {
   const p = url.pathname;
   return (
-    p.startsWith("/_next/static/") ||
     p.startsWith("/icons/") ||
     p.startsWith("/wallpapers/") ||
     p.startsWith("/files/system/wallpapers/") ||
     p.startsWith("/textures/") ||
     p.startsWith("/fonts/") ||
-    /\.(?:png|jpg|jpeg|svg|webp|woff2?|ttf|css|js|wav|mp3)$/.test(p)
+    /\.(?:png|jpg|jpeg|svg|webp|woff2?|ttf|wav|mp3)$/.test(p)
   );
 }
 

--- a/shell/src/api/http.ts
+++ b/shell/src/api/http.ts
@@ -36,7 +36,10 @@ export interface ShellApiClient {
 
 export function createShellApiClient(options: ShellApiClientOptions = {}): ShellApiClient {
   const resolveGatewayUrl = options.getGatewayUrl ?? getGatewayUrl;
-  const fetchFn = options.fetchFn ?? ((input: string, init?: RequestInit) => fetch(input, init));
+  const fetchFn = options.fetchFn ?? ((input: string, init: RequestInit = {}) => fetch(input, {
+    ...init,
+    signal: init.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+  }));
 
   async function request<T>(path: string, init: RequestInit, requestOptions?: RequestOptions): Promise<T> {
     const timeout = AbortSignal.timeout(requestOptions?.timeoutMs ?? DEFAULT_TIMEOUT_MS);

--- a/shell/src/components/pwa/PwaRegister.tsx
+++ b/shell/src/components/pwa/PwaRegister.tsx
@@ -3,13 +3,25 @@
 import { useEffect } from "react";
 
 /**
- * Registers the PWA service worker. New SW versions are *not* activated
- * mid-session: forcing `skipWaiting` while the page is open lets the new SW
- * `clients.claim()` and prune old caches, breaking static chunk lookups for
- * code the running page still needs. Instead, an installed-and-waiting SW
- * stays in `waiting` state and activates on the next full page load, which
- * is the standard safe pattern.
+ * Activates an already-installed update and reloads once the new worker owns
+ * the page. The immediate reload prevents the running document from mixing
+ * application generations after the worker prunes its predecessor's caches.
  */
+export function activateWaitingServiceWorker(
+  registration: ServiceWorkerRegistration,
+  serviceWorkers: ServiceWorkerContainer,
+  reload: () => void,
+): void {
+  if (!registration.waiting) return;
+  let reloading = false;
+  serviceWorkers.addEventListener("controllerchange", () => {
+    if (reloading) return;
+    reloading = true;
+    reload();
+  }, { once: true });
+  registration.waiting.postMessage("skipWaiting");
+}
+
 export function PwaRegister() {
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -18,9 +30,24 @@ export function PwaRegister() {
 
     const register = async () => {
       try {
-        await navigator.serviceWorker.register("/service-worker.js", {
+        const registration = await navigator.serviceWorker.register("/service-worker.js", {
           scope: "/",
           updateViaCache: "none",
+        });
+        let activationRequested = false;
+        const activateUpdate = () => {
+          if (activationRequested || !navigator.serviceWorker.controller || !registration.waiting) return;
+          activationRequested = true;
+          activateWaitingServiceWorker(registration, navigator.serviceWorker, () => window.location.reload());
+        };
+
+        activateUpdate();
+        registration.addEventListener("updatefound", () => {
+          const installing = registration.installing;
+          if (!installing) return;
+          installing.addEventListener("statechange", () => {
+            if (installing.state === "installed") activateUpdate();
+          });
         });
       } catch (err) {
         console.warn("[pwa] service worker registration failed:", err instanceof Error ? err.message : err);

--- a/shell/src/components/pwa/PwaRegister.tsx
+++ b/shell/src/components/pwa/PwaRegister.tsx
@@ -22,6 +22,32 @@ export function activateWaitingServiceWorker(
   registration.waiting.postMessage("skipWaiting");
 }
 
+export function monitorServiceWorkerUpdate(
+  registration: ServiceWorkerRegistration,
+  serviceWorkers: ServiceWorkerContainer,
+  reload: () => void,
+): void {
+  let activationRequested = false;
+  let observedInstalling: ServiceWorker | null = null;
+  const activateUpdate = () => {
+    if (activationRequested || !serviceWorkers.controller || !registration.waiting) return;
+    activationRequested = true;
+    activateWaitingServiceWorker(registration, serviceWorkers, reload);
+  };
+  const observeInstalling = () => {
+    const installing = registration.installing;
+    if (!installing || installing === observedInstalling) return;
+    observedInstalling = installing;
+    installing.addEventListener("statechange", () => {
+      if (installing.state === "installed") activateUpdate();
+    });
+  };
+
+  activateUpdate();
+  observeInstalling();
+  registration.addEventListener("updatefound", observeInstalling);
+}
+
 export function PwaRegister() {
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -34,21 +60,7 @@ export function PwaRegister() {
           scope: "/",
           updateViaCache: "none",
         });
-        let activationRequested = false;
-        const activateUpdate = () => {
-          if (activationRequested || !navigator.serviceWorker.controller || !registration.waiting) return;
-          activationRequested = true;
-          activateWaitingServiceWorker(registration, navigator.serviceWorker, () => window.location.reload());
-        };
-
-        activateUpdate();
-        registration.addEventListener("updatefound", () => {
-          const installing = registration.installing;
-          if (!installing) return;
-          installing.addEventListener("statechange", () => {
-            if (installing.state === "installed") activateUpdate();
-          });
-        });
+        monitorServiceWorkerUpdate(registration, navigator.serviceWorker, () => window.location.reload());
       } catch (err) {
         console.warn("[pwa] service worker registration failed:", err instanceof Error ? err.message : err);
       }

--- a/shell/src/lib/posthog-client.ts
+++ b/shell/src/lib/posthog-client.ts
@@ -24,6 +24,8 @@ const config = getPostHogClientConfig({
 });
 const CLIENT_ERROR_REPORT_TIMEOUT_MS = 10_000;
 const SUPPORT_AVAILABILITY_TIMEOUT_MS = 10_000;
+const POSTHOG_LAUNCHER_SELECTOR = 'button[aria-label^="Open chat"]';
+const POSTHOG_CLOSE_SELECTOR = 'button[aria-label="Close"]';
 // Replay kill switch. NEXT_PUBLIC_* is inlined at build time, so the build
 // flag alone cannot stop replay during an incident. The layout additionally
 // exposes the server's runtime POSTHOG_DISABLE_REPLAY env as a data
@@ -97,8 +99,16 @@ export async function openShellSupport(currentConfig: typeof config = config): P
     const deadline = Date.now() + SUPPORT_AVAILABILITY_TIMEOUT_MS;
     while (Date.now() < deadline) {
       if (posthog.conversations.isAvailable()) {
-        posthog.capture("shell_support_chat_opened", { matrix_client: "web" });
         posthog.conversations.show();
+        let closeButton = document.querySelector<HTMLButtonElement>(POSTHOG_CLOSE_SELECTOR);
+        if (!closeButton) {
+          const launcher = await waitForPostHogButton(POSTHOG_LAUNCHER_SELECTOR, deadline);
+          if (!launcher) return false;
+          launcher.click();
+          closeButton = await waitForPostHogButton(POSTHOG_CLOSE_SELECTOR, deadline);
+        }
+        if (!closeButton) return false;
+        posthog.capture("shell_support_chat_opened", { matrix_client: "web" });
         return true;
       }
       await new Promise((resolve) => globalThis.setTimeout(resolve, 100));
@@ -108,6 +118,15 @@ export async function openShellSupport(currentConfig: typeof config = config): P
     console.warn("[posthog] Failed to open support chat:", err instanceof Error ? err.name : typeof err);
     return false;
   }
+}
+
+async function waitForPostHogButton(selector: string, deadline: number): Promise<HTMLButtonElement | null> {
+  while (Date.now() < deadline) {
+    const button = document.querySelector<HTMLButtonElement>(selector);
+    if (button) return button;
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 50));
+  }
+  return null;
 }
 
 export function setPostHogPersonPropertiesOnce(

--- a/shell/src/lib/posthog-client.ts
+++ b/shell/src/lib/posthog-client.ts
@@ -24,6 +24,7 @@ const config = getPostHogClientConfig({
 });
 const CLIENT_ERROR_REPORT_TIMEOUT_MS = 10_000;
 const SUPPORT_AVAILABILITY_TIMEOUT_MS = 10_000;
+const POSTHOG_WIDGET_ID = "ph-conversations-widget-container";
 const POSTHOG_LAUNCHER_SELECTOR = 'button[aria-label^="Open chat"]';
 const POSTHOG_CLOSE_SELECTOR = 'button[aria-label="Close"]';
 // Replay kill switch. NEXT_PUBLIC_* is inlined at build time, so the build
@@ -100,7 +101,7 @@ export async function openShellSupport(currentConfig: typeof config = config): P
     while (Date.now() < deadline) {
       if (posthog.conversations.isAvailable()) {
         posthog.conversations.show();
-        let closeButton = document.querySelector<HTMLButtonElement>(POSTHOG_CLOSE_SELECTOR);
+        let closeButton = findPostHogButton(POSTHOG_CLOSE_SELECTOR);
         if (!closeButton) {
           const launcher = await waitForPostHogButton(POSTHOG_LAUNCHER_SELECTOR, deadline);
           if (!launcher) return false;
@@ -122,11 +123,15 @@ export async function openShellSupport(currentConfig: typeof config = config): P
 
 async function waitForPostHogButton(selector: string, deadline: number): Promise<HTMLButtonElement | null> {
   while (Date.now() < deadline) {
-    const button = document.querySelector<HTMLButtonElement>(selector);
+    const button = findPostHogButton(selector);
     if (button) return button;
     await new Promise((resolve) => globalThis.setTimeout(resolve, 50));
   }
   return null;
+}
+
+function findPostHogButton(selector: string): HTMLButtonElement | null {
+  return document.getElementById(POSTHOG_WIDGET_ID)?.querySelector<HTMLButtonElement>(selector) ?? null;
 }
 
 export function setPostHogPersonPropertiesOnce(

--- a/tests/desktop/desktop-support-widget.test.tsx
+++ b/tests/desktop/desktop-support-widget.test.tsx
@@ -92,6 +92,7 @@ describe("Desktop support widget", () => {
     vi.clearAllMocks();
     vi.restoreAllMocks();
     document.getElementById("ph-conversations-widget-container")?.remove();
+    document.getElementById("unrelated-close")?.remove();
   });
 
   it("fails closed when PostHog cannot initialize", async () => {
@@ -191,6 +192,11 @@ describe("Desktop support widget", () => {
     expect(screen.getAllByRole("button").map((button) => button.getAttribute("aria-label") ?? button.textContent))
       .toEqual(["Search", "Support", "Main computer", "Open account menu"]);
 
+    const unrelatedClose = document.createElement("button");
+    unrelatedClose.id = "unrelated-close";
+    unrelatedClose.setAttribute("aria-label", "Close");
+    document.body.appendChild(unrelatedClose);
+
     fireEvent.click(screen.getByRole("button", { name: "Search" }));
     expect(useUi.getState().paletteOpen).toBe(true);
 
@@ -198,13 +204,19 @@ describe("Desktop support widget", () => {
 
     await waitFor(() => expect(posthogClient.conversations.show).toHaveBeenCalledTimes(1));
     expect(useUi.getState().rendererOverlayCount).toBe(1);
-    expect(await screen.findByRole("button", { name: "Close" })).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        document.querySelector('#ph-conversations-widget-container button[aria-label="Close"]'),
+      ).not.toBeNull();
+    });
     expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull();
 
     // PostHog can re-render its panel while it is open. Replacing the close
     // control exercises the user-visible contract without relying on a
     // listener remaining attached to one provider-owned DOM node.
-    const close = screen.getByRole("button", { name: "Close" });
+    const close = document.querySelector<HTMLButtonElement>(
+      '#ph-conversations-widget-container button[aria-label="Close"]',
+    )!;
     const replacementClose = close.cloneNode(true) as HTMLButtonElement;
     replacementClose.addEventListener("click", renderPostHogLauncher);
     close.replaceWith(replacementClose);
@@ -218,7 +230,11 @@ describe("Desktop support widget", () => {
 
     await waitFor(() => expect(posthogClient.conversations.show).toHaveBeenCalledTimes(2));
     expect(useUi.getState().rendererOverlayCount).toBe(1);
-    expect(await screen.findByRole("button", { name: "Close" })).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        document.querySelector('#ph-conversations-widget-container button[aria-label="Close"]'),
+      ).not.toBeNull();
+    });
     expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull();
   });
 

--- a/tests/desktop/desktop-support-widget.test.tsx
+++ b/tests/desktop/desktop-support-widget.test.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import DesktopModeControls from "@desktop/renderer/src/features/desktop-shell/DesktopModeControls";
-import DesktopSupportWidget from "@desktop/renderer/src/features/support/DesktopSupportWidget";
+import DesktopSupportWidget, { openDesktopSupport } from "@desktop/renderer/src/features/support/DesktopSupportWidget";
 import { useConnection } from "@desktop/renderer/src/stores/connection";
 import { useBrowserNavigation } from "@desktop/renderer/src/stores/browser-navigation";
 import { useTabs } from "@desktop/renderer/src/stores/tabs";
@@ -292,5 +292,18 @@ describe("Desktop support widget", () => {
 
     await waitFor(() => expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull());
     expect(screen.queryByRole("button", { name: "Close" })).toBeNull();
+  });
+
+  it("honors a support click while the widget is still initializing", async () => {
+    posthogClient.conversations.hide.mockImplementation(() => {
+      document.getElementById("ph-conversations-widget-container")?.remove();
+    });
+    posthogClient.conversations.show.mockImplementation(renderPostHogLauncher);
+
+    const opening = openDesktopSupport();
+    render(<DesktopSupportWidget />);
+
+    await expect(opening).resolves.toBe(true);
+    expect(await screen.findByRole("button", { name: "Close" })).toBeTruthy();
   });
 });

--- a/tests/shell/client-http.test.ts
+++ b/tests/shell/client-http.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import { ClientApiError, createShellApiClient } from "@/api/http";
 
@@ -9,6 +10,13 @@ function jsonResponse(status: number, body: unknown): Response {
 }
 
 describe("createShellApiClient", () => {
+  it("keeps the default fetch fallback visibly timeout-bound for the release scanner", () => {
+    const source = readFileSync("shell/src/api/http.ts", "utf8");
+    const fallback = source.slice(source.indexOf("const fetchFn"), source.indexOf("async function request"));
+
+    expect(fallback).toContain("signal: init.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS)");
+  });
+
   it("resolves the gateway URL at request time and composes caller cancellation with its timeout", async () => {
     const fetchFn = vi.fn().mockResolvedValue(jsonResponse(200, { apps: [] }));
     const controller = new AbortController();

--- a/tests/shell/platform-shell-assets.test.ts
+++ b/tests/shell/platform-shell-assets.test.ts
@@ -114,9 +114,11 @@ describe("platform-owned shell assets", () => {
       join(process.cwd(), "packages/platform/src/app-domain-service-worker.ts"),
       "utf8",
     );
-    expect(platformWorker).toContain('const VERSION = "app-v2"');
+    expect(platformWorker).toContain('const VERSION = "app-v3"');
     expect(platformWorker).toContain(
       'p === "/__platform-shell" || p.startsWith("/__platform-shell/")',
     );
+    expect(platformWorker).not.toContain('p.startsWith("/_next/static/")');
+    expect(platformWorker).not.toMatch(/woff2\?\|ttf\|css\|js/);
   });
 });

--- a/tests/shell/posthog-proxy.test.ts
+++ b/tests/shell/posthog-proxy.test.ts
@@ -33,6 +33,7 @@ async function getRewrites(): Promise<RewriteRule[]> {
 describe("shell PostHog same-origin proxy", () => {
   afterEach(() => {
     document.getElementById("ph-conversations-widget-container")?.remove();
+    document.getElementById("unrelated-close")?.remove();
     posthogMock.conversations.show.mockReset();
   });
 
@@ -112,6 +113,10 @@ describe("shell PostHog same-origin proxy", () => {
   });
 
   it("opens PostHog Conversations from the shell navbar", async () => {
+    const unrelatedClose = document.createElement("button");
+    unrelatedClose.id = "unrelated-close";
+    unrelatedClose.setAttribute("aria-label", "Close");
+    document.body.appendChild(unrelatedClose);
     const launcherClick = vi.fn(() => {
       const close = document.createElement("button");
       close.setAttribute("aria-label", "Close");
@@ -136,7 +141,9 @@ describe("shell PostHog same-origin proxy", () => {
     expect(opened).toBe(true);
     expect(posthogMock.conversations.show).toHaveBeenCalledOnce();
     expect(launcherClick).toHaveBeenCalledOnce();
-    expect(document.querySelector('button[aria-label="Close"]')).not.toBeNull();
+    expect(
+      document.querySelector('#ph-conversations-widget-container button[aria-label="Close"]'),
+    ).not.toBeNull();
     expect(posthogMock.capture).toHaveBeenCalledWith("shell_support_chat_opened", {
       matrix_client: "web",
     });

--- a/tests/shell/posthog-proxy.test.ts
+++ b/tests/shell/posthog-proxy.test.ts
@@ -1,6 +1,8 @@
+// @vitest-environment jsdom
+
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import nextConfig from "../../shell/next.config";
 
 const posthogMock = vi.hoisted(() => ({
@@ -29,6 +31,11 @@ async function getRewrites(): Promise<RewriteRule[]> {
 }
 
 describe("shell PostHog same-origin proxy", () => {
+  afterEach(() => {
+    document.getElementById("ph-conversations-widget-container")?.remove();
+    posthogMock.conversations.show.mockReset();
+  });
+
   it("rewrites the same-origin health probe to the gateway", async () => {
     const rewrites = await getRewrites();
     const healthRule = rewrites.find((rule) => rule.source === "/health");
@@ -105,6 +112,20 @@ describe("shell PostHog same-origin proxy", () => {
   });
 
   it("opens PostHog Conversations from the shell navbar", async () => {
+    const launcherClick = vi.fn(() => {
+      const close = document.createElement("button");
+      close.setAttribute("aria-label", "Close");
+      document.getElementById("ph-conversations-widget-container")?.replaceChildren(close);
+    });
+    posthogMock.conversations.show.mockImplementation(() => {
+      const container = document.createElement("div");
+      container.id = "ph-conversations-widget-container";
+      const launcher = document.createElement("button");
+      launcher.setAttribute("aria-label", "Open chat");
+      launcher.addEventListener("click", launcherClick);
+      container.appendChild(launcher);
+      document.body.appendChild(container);
+    });
     const { openShellSupport } = await import("../../shell/src/lib/posthog-client");
     const opened = await openShellSupport({
       token: "phc_test",
@@ -114,6 +135,8 @@ describe("shell PostHog same-origin proxy", () => {
 
     expect(opened).toBe(true);
     expect(posthogMock.conversations.show).toHaveBeenCalledOnce();
+    expect(launcherClick).toHaveBeenCalledOnce();
+    expect(document.querySelector('button[aria-label="Close"]')).not.toBeNull();
     expect(posthogMock.capture).toHaveBeenCalledWith("shell_support_chat_opened", {
       matrix_client: "web",
     });

--- a/tests/shell/pwa-register.test.ts
+++ b/tests/shell/pwa-register.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { activateWaitingServiceWorker } from "@/components/pwa/PwaRegister";
+import {
+  activateWaitingServiceWorker,
+  monitorServiceWorkerUpdate,
+} from "@/components/pwa/PwaRegister";
 
 describe("PWA service-worker updates", () => {
   it("activates a waiting worker and reloads once after it takes control", () => {
@@ -21,5 +24,36 @@ describe("PWA service-worker updates", () => {
     controllerChange?.();
     controllerChange?.();
     expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("observes a worker that was already installing when registration resolved", () => {
+    const postMessage = vi.fn();
+    let stateChange: (() => void) | undefined;
+    const installing = {
+      state: "installing",
+      addEventListener: vi.fn((event: string, listener: () => void) => {
+        if (event === "statechange") stateChange = listener;
+      }),
+    } as unknown as ServiceWorker;
+    const registrationState = {
+      installing,
+      waiting: null as ServiceWorker | null,
+      addEventListener: vi.fn(),
+    };
+    const serviceWorkers = {
+      controller: {} as ServiceWorker,
+      addEventListener: vi.fn(),
+    } as unknown as ServiceWorkerContainer;
+
+    monitorServiceWorkerUpdate(
+      registrationState as unknown as ServiceWorkerRegistration,
+      serviceWorkers,
+      vi.fn(),
+    );
+    registrationState.waiting = { postMessage } as unknown as ServiceWorker;
+    Object.assign(installing, { state: "installed" });
+    stateChange?.();
+
+    expect(postMessage).toHaveBeenCalledWith("skipWaiting");
   });
 });

--- a/tests/shell/pwa-register.test.ts
+++ b/tests/shell/pwa-register.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { activateWaitingServiceWorker } from "@/components/pwa/PwaRegister";
+
+describe("PWA service-worker updates", () => {
+  it("activates a waiting worker and reloads once after it takes control", () => {
+    const postMessage = vi.fn();
+    const reload = vi.fn();
+    let controllerChange: (() => void) | undefined;
+    const serviceWorkers = {
+      addEventListener: vi.fn((event: string, listener: () => void) => {
+        if (event === "controllerchange") controllerChange = listener;
+      }),
+    } as unknown as ServiceWorkerContainer;
+    const registration = {
+      waiting: { postMessage },
+    } as unknown as ServiceWorkerRegistration;
+
+    activateWaitingServiceWorker(registration, serviceWorkers, reload);
+    expect(postMessage).toHaveBeenCalledWith("skipWaiting");
+
+    controllerChange?.();
+    controllerChange?.();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/shell/service-worker.test.ts
+++ b/tests/shell/service-worker.test.ts
@@ -2,6 +2,12 @@ import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 
 describe("shell service worker", () => {
+  it("moves clients off the executable-asset cache generation that could strand stale bundles", async () => {
+    const source = await readFile("shell/public/service-worker.js", "utf8");
+
+    expect(source).toContain('const VERSION = "v3"');
+  });
+
   it("turns uncached static fetch failures into a response instead of rejecting the FetchEvent", async () => {
     const source = await readFile("shell/public/service-worker.js", "utf8");
 
@@ -21,10 +27,11 @@ describe("shell service worker", () => {
     expect(source).toContain('p.startsWith("/sign-up")');
   });
 
-  it("limits app-domain static caching to shell assets and safe image/font files", async () => {
+  it("limits static caching to safe image, audio, and font files", async () => {
     const source = await readFile("shell/public/service-worker.js", "utf8");
 
-    expect(source).toContain('p.startsWith("/_next/static/")');
+    expect(source).not.toContain('p.startsWith("/_next/static/")');
+    expect(source).not.toMatch(/woff2\?\|ttf\|css\|js/);
     expect(source).toContain('p.startsWith("/icons/")');
     expect(source).toContain('p.startsWith("/wallpapers/")');
     expect(source).toContain('p.startsWith("/files/system/wallpapers/")');


### PR DESCRIPTION
## Summary
- retire the stale executable-asset service-worker caches and coordinate one safe reload when an updated worker takes control
- open the actual PostHog Conversations panel from the web navbar and preserve early Electron support clicks while the widget initializes
- make the default shell HTTP fetch fallback visibly timeout-bound so the same-SHA Pattern Scan no longer blocks Host Bundle Release

## Root cause
- the v2 workers cached JavaScript/CSS cache-first and the web registration left updated workers waiting, allowing mixed release generations until users cleared Cache Storage
- PostHog Conversations `show()` restores/displays the widget but does not guarantee the panel is open; web never clicked the provider launcher
- Electron rejected support opens before PostHog identity initialization completed
- the HTTP wrapper passed a timeout signal at request time, but the fallback `fetch()` itself did not expose one within the release scanner window

## Verification
- 30 focused Vitest tests
- shell, Desktop renderer/main, and platform TypeScript checks
- Electron production build
- Next.js production shell build
- `./scripts/review/check-patterns.sh` (0 violations)
- `git diff --check`

## Invariants
- **Source of truth:** browser/CDN HTTP caching owns executable Next.js assets; the service worker owns only versioned shell HTML fallback plus safe media/font assets. PostHog Conversations remains the support UI provider.
- **Lock/transaction scope:** none; this change has no database writes or shared persistence mutation.
- **Acceptable orphan states:** if service-worker activation fails, the current controller remains and registration retries on a later load. If support cannot initialize/open within its bounded timeout, it returns false and Electron releases its renderer overlay.
- **Auth source of truth:** unchanged; Clerk/runtime connection identity and the existing build-time PostHog project token remain authoritative.
- **Deferred scope:** no production bundle publish, VPS rollout, analytics-dashboard changes, or unrelated service-worker redesign is included.