### PR TITLE
fix(ci): repair desktop settings regressions

### DIFF
--- a/desktop/src/renderer/src/features/settings/sections/CronSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/CronSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useConnection } from "../../../stores/connection";
 import { Card, Empty, SettingsSectionHeader } from "./section-kit";
@@ -10,10 +10,19 @@ export default function CronSection() {
   const authGeneration = useConnection((s) => s.authGeneration);
   const runtimeSlot = useConnection((s) => s.runtimeSlot);
   const scope = useMemo(() => ({ platformHost, authGeneration, runtimeSlot }), [platformHost, authGeneration, runtimeSlot]);
-  const { data: jobs = [], isError, isPending } = useQuery({
+  const previousApiRef = useRef(api);
+  const { data: jobs = [], isError, isPending, refetch } = useQuery({
     ...cronQueryOptions(api ?? { get: async () => [] } as never, scope),
     enabled: api !== null,
   });
+
+  useEffect(() => {
+    const previousApi = previousApiRef.current;
+    previousApiRef.current = api;
+    if (previousApi !== null && api !== null && previousApi !== api) {
+      void refetch();
+    }
+  }, [api, refetch]);
 
   return (
     <>

--- a/tests/desktop/settings-sections-error.test.tsx
+++ b/tests/desktop/settings-sections-error.test.tsx
@@ -2,9 +2,11 @@
 
 import React from "react";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import CronSection from "../../desktop/src/renderer/src/features/settings/sections/CronSection";
 import SystemSection from "../../desktop/src/renderer/src/features/settings/sections/SystemSection";
+import { createDesktopQueryClient } from "../../desktop/src/renderer/src/lib/query-client";
 import { useConnection } from "../../desktop/src/renderer/src/stores/connection";
 
 function makeApi(response: unknown, reject = false) {
@@ -27,6 +29,15 @@ function makePendingApi() {
     delete: vi.fn(),
     putText: vi.fn(),
   } as never;
+}
+
+function renderSettingsSection(Component: React.ComponentType) {
+  const queryClient = createDesktopQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Component />
+    </QueryClientProvider>,
+  );
 }
 
 describe("settings data sections", () => {
@@ -62,11 +73,11 @@ describe("settings data sections", () => {
       visible: "1.0.0",
     },
   ])("clears stale $name errors after a successful retry", async ({ Component, unavailable, response, visible }) => {
-    render(<Component />);
+    renderSettingsSection(Component);
 
     await waitFor(() => {
       expect(screen.queryByText(unavailable)).not.toBeNull();
-    });
+    }, { timeout: 2_500 });
 
     await act(async () => {
       useConnection.setState({ api: makeApi(response) });
@@ -88,7 +99,7 @@ describe("settings data sections", () => {
   ])("shows loading instead of empty state while $name load is pending", ({ Component, loading, empty }) => {
     useConnection.setState({ api: makePendingApi() });
 
-    render(<Component />);
+    renderSettingsSection(Component);
 
     expect(screen.queryByText(loading)).not.toBeNull();
     expect(screen.queryByText(empty)).toBeNull();
@@ -102,7 +113,7 @@ describe("settings data sections", () => {
       }),
     });
 
-    render(<SystemSection />);
+    renderSettingsSection(SystemSection);
 
     expect(await screen.findByText("Installed version")).not.toBeNull();
     expect(screen.getByText("Running version")).not.toBeNull();

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -5211,7 +5211,8 @@ describe("platform proxy routing", () => {
       expect(body).not.toContain("registration.unregister()");
       expect(body).toContain('p.startsWith("/api/")');
       expect(body).toContain('p.startsWith("/files/apps/")');
-      expect(body).toContain('p.startsWith("/_next/static/")');
+      expect(body).not.toContain('p.startsWith("/_next/static/")');
+      expect(body).not.toMatch(/woff2\?\|ttf\|css\|js/);
       expect(verifyToken).not.toHaveBeenCalled();
       expect(fetchMock).not.toHaveBeenCalled();
     } finally {


### PR DESCRIPTION
## Summary

- wrap desktop settings error regressions in the production-equivalent React Query provider
- refetch cron settings when the connected API client instance changes without an auth-generation change
- align the service-worker regression with the current no-cache behavior for Next.js JavaScript and CSS assets

## Tests

- `bun run test tests/desktop/settings-sections-error.test.tsx tests/platform/proxy-routing.test.ts --reporter=dot` (135/135)
- `pnpm --filter desktop run typecheck`
- `pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json`
- `bun run check:patterns` (0 violations)
- `git diff --check`

## Review/Monitoring

- This PR repairs the two failing unit-test shards on the current exact `main` head.
- Keep the provider/gateway feature stack unlabelled and unmerged until this PR reaches exact-head Greptile 5/5 and label-gated CI passes.
- Do not merge automatically.

## Invariants

- **Source of truth:** React Query remains the settings server-state cache; the connection store remains the source of the active API client.
- **Lock/transaction scope:** none; this change does not add persistence or database writes.
- **Acceptable orphan states:** none introduced. A replaced API client may briefly display the previous query result until the bounded refetch settles.
- **Auth source of truth:** unchanged; connection identity and `authGeneration` still control query scoping and cache separation.
- **Deferred scope:** provider/gateway stack restacking, preview funded-AI credentials, and feature-stack CI remain deferred until `main` is green.