### PR TITLE
fix(handoff): preserve Matrix project names safely

### DIFF
--- a/.agents/skills/matrix-handoff/SKILL.md
+++ b/.agents/skills/matrix-handoff/SKILL.md
@@ -39,7 +39,7 @@ Package the current working tree and a continuation brief, upload them through t
 - `--brief PATH`: agent-written continuation summary.
 - `--history-file PATH`: explicit raw JSONL transcript. Use only when the preview names it and the user approves it.
 - `--no-history`: summary-only handoff. Recommend this when transcript discovery is ambiguous or the conversation contains sensitive content.
-- `--project-name NAME`: base for the new, unique `~/projects/...-handoff-...` directory.
+- `--project-name NAME`: exact slug basis for `~/projects/<name>`. By default, reuse the source repository name.
 - `--profile NAME`: target a non-default Matrix CLI profile.
 - `--attach`: attach the local terminal after the remote session is created.
 - `--approve TOKEN`: upload only when the newly staged scope exactly matches the preview token.
@@ -50,6 +50,6 @@ Package the current working tree and a continuation brief, upload them through t
 - Never upload a transcript discovered only by modification time when its metadata does not match the repository.
 - Never add secret files to bypass the built-in exclusion list. Authentication must happen again inside Matrix.
 - Never bypass the approval token. If repository files, the continuation brief, transcript content, agent, profile, or destination basis changes, run a new preview and ask for approval again.
-- The destination is always a new unique directory. Do not overwrite an existing Matrix project.
+- Use the same project name by default; never append `-handoff`. If that destination already exists, do not overwrite it. Ask the user for a different project name and rerun the preview with `--project-name`.
 - If automatic transcript discovery finds nothing, continue with the brief only unless the user explicitly supplies a transcript path.
 - Do not claim that Matrix resumes the original provider session ID. This is a context handoff into a new remote agent session.

--- a/.agents/skills/matrix-handoff/scripts/matrix-handoff.mjs
+++ b/.agents/skills/matrix-handoff/scripts/matrix-handoff.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFile } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import {
   copyFile,
   lstat,
@@ -162,6 +162,15 @@ function assertSafeGeneratedPath(value) {
   }
 }
 
+export function createHandoffUploadId({ stamp, scopeDigest }) {
+  if (!/^\d{12}$/.test(stamp) || !/^[a-f0-9]{64}$/.test(scopeDigest)) {
+    throw new Error("Expected a valid approved handoff scope");
+  }
+  const uploadId = `handoff-${stamp}-${scopeDigest.slice(0, 12)}-${randomBytes(16).toString("hex")}`;
+  assertSafeGeneratedPath(uploadId);
+  return uploadId;
+}
+
 export function buildRemoteExtractScript({ uploadId, projectDir }) {
   assertSafeGeneratedPath(uploadId);
   assertSafeGeneratedPath(projectDir);
@@ -169,12 +178,28 @@ export function buildRemoteExtractScript({ uploadId, projectDir }) {
     "set -eu",
     `upload_dir="$HOME/.matrix-handoff/${uploadId}"`,
     `destination="$HOME/${projectDir}"`,
-    'test ! -e "$destination"',
-    'mkdir -p "$destination"',
-    'cat "$upload_dir"/bundle.part-* | tar -xzf - -C "$destination"',
-    'rm -f "$upload_dir"/bundle.part-*',
-    'rmdir "$upload_dir"',
+    'staging="$upload_dir/staging"',
+    'cleanup_upload() { rm -rf "$staging"; rm -f "$upload_dir"/bundle.part-*; rmdir "$upload_dir" 2>/dev/null || true; }',
+    'abort_handoff() { cleanup_upload; trap - EXIT HUP INT TERM; exit 74; }',
+    'trap cleanup_upload EXIT',
+    'trap abort_handoff HUP INT TERM',
+    'mkdir "$staging"',
+    'if ! cat "$upload_dir"/bundle.part-* | tar -xzf - -C "$staging"; then printf "%s\\n" "Matrix handoff extraction failed. Retry the same project name." >&2; exit 74; fi',
+    'mkdir -p "$(dirname "$destination")"',
+    'if ! mv -T -n "$staging" "$destination"; then printf "%s\\n" "Matrix handoff publish failed. Retry the same project name." >&2; exit 74; fi',
+    'if [ -e "$staging" ]; then printf "%s\\n" "Matrix project already exists: $destination. Choose another --project-name." >&2; exit 73; fi',
+    'trap - EXIT HUP INT TERM',
+    'cleanup_upload',
     'printf "%s\\n" "$destination"',
+  ].join("; ");
+}
+
+export function buildRemoteDestinationCheckScript({ projectDir }) {
+  assertSafeGeneratedPath(projectDir);
+  return [
+    "set -eu",
+    `destination="$HOME/${projectDir}"`,
+    'if [ -e "$destination" ]; then printf "%s\\n" "Matrix project already exists: $destination. Choose another --project-name." >&2; exit 73; fi',
   ].join("; ");
 }
 
@@ -551,8 +576,8 @@ async function main() {
       throw new Error("Scope changed after preview. Run a new preview and approve its new token.");
     }
     const suffix = scopeDigest.slice(0, 12);
-    const uploadId = `handoff-${stamp}-${suffix}`;
-    const projectDir = `projects/${base}-handoff-${stamp}-${suffix}`;
+    const uploadId = createHandoffUploadId({ stamp, scopeDigest });
+    const projectDir = `projects/${base}`;
 
     console.log("Matrix handoff preview");
     console.log(`  Repository: ${root}`);
@@ -567,6 +592,11 @@ async function main() {
       console.log(`\nPreview only. Review the scope, then re-run with --approve ${approvalToken} to upload and continue.`);
       return;
     }
+
+    const matrix = process.env.MATRIX_CLI || "matrix";
+    const profileArgs = options.profile ? ["--profile", options.profile] : [];
+    const destinationCheckScript = buildRemoteDestinationCheckScript({ projectDir });
+    await run(matrix, ["run", ...profileArgs, "--", "sh", "-lc", destinationCheckScript]);
 
     await writeHandoffMetadata({
       root,
@@ -583,8 +613,6 @@ async function main() {
     const archive = join(temp, "handoff.tar.gz");
     await run("tar", ["-czf", archive, "-C", stage, "."], { timeout: 300_000 });
     const parts = await splitFile(archive, temp);
-    const matrix = process.env.MATRIX_CLI || "matrix";
-    const profileArgs = options.profile ? ["--profile", options.profile] : [];
     for (const [index, part] of parts.entries()) {
       console.log(`Uploading part ${index + 1}/${parts.length}...`);
       await run(matrix, ["upload", part, `~/.matrix-handoff/${uploadId}/`, "--force", ...profileArgs], { timeout: 180_000 });

--- a/tests/scripts/matrix-handoff.test.ts
+++ b/tests/scripts/matrix-handoff.test.ts
@@ -1,12 +1,14 @@
 import { execFile } from "node:child_process";
-import { chmod, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  buildRemoteDestinationCheckScript,
   buildRemoteExtractScript,
+  createHandoffUploadId,
   encodeClaudeProjectPath,
   isSafeHandoffPath,
   parseHandoffArgs,
@@ -133,16 +135,105 @@ describe("matrix handoff", () => {
   });
 
   it("builds an extraction script from validated generated identifiers only", () => {
+    const destinationCheck = buildRemoteDestinationCheckScript({
+      projectDir: "projects/matrix-os",
+    });
+    expect(destinationCheck).toContain('destination="$HOME/projects/matrix-os"');
+    expect(destinationCheck).toContain("Choose another --project-name");
+
     const script = buildRemoteExtractScript({
       uploadId: "handoff-20260731-abc123",
-      projectDir: "projects/matrix-os-handoff-20260731-abc123",
+      projectDir: "projects/matrix-os",
     });
-    expect(script).toContain('test ! -e "$destination"');
+    expect(script).toContain("Matrix project already exists");
+    expect(script).toContain("Choose another --project-name");
     expect(script).toContain('cat "$upload_dir"/bundle.part-*');
-    expect(script).toContain('tar -xzf - -C "$destination"');
+    expect(script).toContain('tar -xzf - -C "$staging"');
+    expect(script).toContain('mv -T -n "$staging" "$destination"');
+    expect(script).toContain("trap cleanup_upload EXIT");
+    expect(script).toContain("trap abort_handoff HUP INT TERM");
+    expect(script).not.toContain('mkdir -p "$destination"');
+    expect(script).not.toContain('rm -rf "$destination"');
+    expect(() =>
+      buildRemoteDestinationCheckScript({ projectDir: "../../bad" }),
+    ).toThrow(/safe handoff identifier/);
     expect(() =>
       buildRemoteExtractScript({ uploadId: "../../bad", projectDir: "projects/good" }),
     ).toThrow(/safe handoff identifier/);
+  });
+
+  it.skipIf(process.platform !== "linux")("atomically reserves a same-name destination during concurrent extraction", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "matrix-handoff-race-test-"));
+    tempDirectories.push(fixture);
+    const sourceA = join(fixture, "source-a");
+    const sourceB = join(fixture, "source-b");
+    const approval = {
+      stamp: "202608311945",
+      scopeDigest: "a".repeat(64),
+    };
+    const uploadIdA = createHandoffUploadId(approval);
+    const uploadIdB = createHandoffUploadId(approval);
+    const uploadA = join(fixture, ".matrix-handoff", uploadIdA);
+    const uploadB = join(fixture, ".matrix-handoff", uploadIdB);
+    expect(uploadIdA).not.toBe(uploadIdB);
+    await Promise.all([mkdir(sourceA), mkdir(sourceB), mkdir(uploadA, { recursive: true }), mkdir(uploadB, { recursive: true })]);
+    await Promise.all([
+      writeFile(join(sourceA, "winner-a.txt"), "a\n"),
+      writeFile(join(sourceB, "winner-b.txt"), "b\n"),
+    ]);
+    await Promise.all([
+      execFileAsync("tar", ["-czf", join(uploadA, "bundle.part-000000"), "-C", sourceA, "."]),
+      execFileAsync("tar", ["-czf", join(uploadB, "bundle.part-000000"), "-C", sourceB, "."]),
+    ]);
+
+    const projectDir = "projects/shared-name";
+    const results = await Promise.allSettled([
+      execFileAsync("sh", ["-c", buildRemoteExtractScript({ uploadId: uploadIdA, projectDir })], {
+        env: { ...process.env, HOME: fixture },
+      }),
+      execFileAsync("sh", ["-c", buildRemoteExtractScript({ uploadId: uploadIdB, projectDir })], {
+        env: { ...process.env, HOME: fixture },
+      }),
+    ]);
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const destination = join(fixture, projectDir);
+    const markers = await Promise.all([
+      readFile(join(destination, "winner-a.txt"), "utf8").then(() => "a", () => null),
+      readFile(join(destination, "winner-b.txt"), "utf8").then(() => "b", () => null),
+    ]);
+    expect(markers.filter(Boolean)).toHaveLength(1);
+  });
+
+  it("uses a unique upload namespace for identical approved scopes", () => {
+    const approval = {
+      stamp: "202608311945",
+      scopeDigest: "b".repeat(64),
+    };
+
+    const first = createHandoffUploadId(approval);
+    const second = createHandoffUploadId(approval);
+
+    expect(first).toMatch(/^handoff-202608311945-b{12}-[a-f0-9]{32}$/);
+    expect(second).not.toBe(first);
+  });
+
+  it("removes its reserved destination when archive extraction fails", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "matrix-handoff-extract-failure-test-"));
+    tempDirectories.push(fixture);
+    const uploadDir = join(fixture, ".matrix-handoff", "broken-upload");
+    await mkdir(uploadDir, { recursive: true });
+    await writeFile(join(uploadDir, "bundle.part-000000"), "not a gzip archive\n");
+    const projectDir = "projects/retryable-name";
+
+    await expect(execFileAsync(
+      "sh",
+      ["-c", buildRemoteExtractScript({ uploadId: "broken-upload", projectDir })],
+      { env: { ...process.env, HOME: fixture } },
+    )).rejects.toBeTruthy();
+
+    await expect(stat(join(fixture, projectDir))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(uploadDir)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("packages, uploads, extracts, and starts a detached remote agent session", async () => {
@@ -185,12 +276,67 @@ appendFileSync(process.env.MATRIX_CALL_LOG, JSON.stringify(process.argv.slice(2)
     );
 
     const calls = (await readFile(logPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
-    expect(calls.some((args) => args[0] === "upload")).toBe(true);
+    const destinationCheckIndex = calls.findIndex((args) =>
+      args[0] === "run" && args.some((arg: unknown) => typeof arg === "string" && arg.includes("Matrix project already exists")),
+    );
+    const uploadIndex = calls.findIndex((args) => args[0] === "upload");
+    expect(destinationCheckIndex).toBeGreaterThanOrEqual(0);
+    expect(uploadIndex).toBeGreaterThan(destinationCheckIndex);
     expect(calls.some((args) =>
       args[0] === "run" && args.some((arg: unknown) => typeof arg === "string" && arg.includes("tar -xzf - -C")),
     )).toBe(true);
     expect(calls.some((args) => args[0] === "shell" && args[1] === "new")).toBe(true);
     expect(stdout).toContain("Handoff ready.");
-    expect(stdout).toContain("~/projects/demo-project-handoff-");
+    expect(stdout).toContain("~/projects/demo-project");
+    expect(stdout).not.toContain("demo-project-handoff-");
+  });
+
+  it("stops before upload when the Matrix project destination already exists", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "matrix-handoff-collision-test-"));
+    tempDirectories.push(fixture);
+    await execFileAsync("git", ["init", "-q"], { cwd: fixture });
+    await writeFile(join(fixture, "safe.ts"), "export const safe = true;\n");
+    await execFileAsync("git", ["add", "safe.ts"], { cwd: fixture });
+
+    const logPath = join(fixture, "matrix-calls.jsonl");
+    const fakeMatrix = join(fixture, "fake-matrix.mjs");
+    await writeFile(
+      fakeMatrix,
+      `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+const args = process.argv.slice(2);
+appendFileSync(process.env.MATRIX_CALL_LOG, JSON.stringify(args) + "\\n");
+if (args[0] === "run" && args.some((arg) => arg.includes("Matrix project already exists"))) {
+  console.error("Matrix project already exists");
+  process.exit(73);
+}
+`,
+    );
+    await chmod(fakeMatrix, 0o700);
+
+    const script = resolve(".agents/skills/matrix-handoff/scripts/matrix-handoff.mjs");
+    const commonArgs = ["--no-history", "--project-name", "Demo Project"];
+    const preview = await execFileAsync(process.execPath, [script, ...commonArgs], {
+      cwd: fixture,
+      timeout: 30_000,
+    });
+    const approvalToken = preview.stdout.match(/Approval token: (\d{12}\.[a-f0-9]{64})/)?.[1];
+    expect(approvalToken).toBeTruthy();
+
+    await expect(execFileAsync(
+      process.execPath,
+      [script, ...commonArgs, "--approve", approvalToken!],
+      {
+        cwd: fixture,
+        env: { ...process.env, MATRIX_CLI: fakeMatrix, MATRIX_CALL_LOG: logPath },
+        timeout: 30_000,
+      },
+    )).rejects.toMatchObject({
+      stderr: expect.stringContaining("Matrix project already exists"),
+    });
+
+    const calls = (await readFile(logPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+    expect(calls.some((args) => args[0] === "run")).toBe(true);
+    expect(calls.some((args) => args[0] === "upload")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- default handoffs to `~/projects/<project-name>` without adding a `-handoff` suffix
- fail clearly on an existing destination so the user can choose another name
- preflight the destination before uploading and clean uploaded parts if a race creates the destination before extraction

## Verification

- 10/10 focused handoff tests pass
- collision simulation proves no upload call occurs when the destination exists
- script passes `node --check`
- layer size: 3 files, 89 additions, 10 deletions

## Invariants

- **Source of truth:** the source repository remains authoritative until extraction succeeds; the Matrix project directory becomes the continuation checkout afterward.
- **Lock/transaction scope:** there is no cross-host lock; a preflight check avoids normal collisions and extraction rechecks immediately before creating the destination.
- **Acceptable orphan states:** failed uploads may leave remote parts under the unique upload ID as before; destination-collision failures now leave no uploaded parts. Local temporary archives are always removed in `finally`.
- **Auth source of truth:** Matrix CLI profile/session authentication is unchanged.
- **Deferred scope:** interactive name selection remains agent/user policy; the CLI returns a clear alternate-name instruction rather than inventing a name.
