### PR TITLE
feat(observability): monitor MCP tool usage

### DIFF
--- a/docs/dev/posthog-mcp-analytics.md
+++ b/docs/dev/posthog-mcp-analytics.md
@@ -1,0 +1,58 @@
+# PostHog MCP Analytics
+
+Matrix instruments its in-process IPC and browser MCP servers with PostHog's official MCP analytics package. The gateway owns the existing PostHog client and lifecycle; each kernel-created MCP server is wrapped with that shared client, so there is no second telemetry queue or shutdown path.
+
+Upstream references:
+
+- [MCP analytics overview](https://posthog.com/docs/mcp-analytics)
+- [Installation and instrumentation](https://posthog.com/docs/mcp-analytics/installation)
+- [Privacy controls](https://posthog.com/docs/mcp-analytics/privacy)
+
+## Package policy
+
+`@posthog/mcp` is pre-1.0 and the PostHog documentation labels the feature beta. Matrix pins an exact version rather than taking a range. The current pin is `0.11.7`, the newest release that satisfied the workspace's seven-day `minimumReleaseAge` policy when this integration was added. Do not add a maturity-policy exception merely to take a newer MCP analytics release.
+
+## What Matrix captures
+
+PostHog receives the MCP event name plus a small allowlist of operational metadata:
+
+- server, client, and protocol versions;
+- tool name and optional low-cardinality category;
+- duration;
+- error boolean and low-cardinality error type;
+- generated MCP session ID;
+- Matrix service name.
+
+This supports tool volume, error rate, and latency monitoring without tool content.
+
+## What Matrix removes
+
+The `beforeSend` hook is allowlist-based. It removes tool parameters, responses, resource names, tool descriptions, inferred or supplied intent, raw error messages, exception stacks, raw user-agent/vendor headers, conversation IDs, and any future property that has not been explicitly reviewed.
+
+Matrix also configures the SDK with:
+
+- `context: false` so no required analytics argument is injected into tools;
+- `enableConversationId: false` so the agent is not asked to carry analytics state;
+- `reportMissing: false` so no virtual tool is added;
+- `enableExceptionAutocapture: false` so raw exception payloads do not fan out from failed calls.
+
+The owner ID may be used as PostHog's distinct ID, but no person properties are attached by this MCP integration.
+
+## Suggested PostHog views
+
+Create three insights on `$mcp_tool_call`:
+
+1. Calls over time, broken down by `$mcp_tool_name` and filtered by `service`.
+2. Error rate using `$mcp_is_error = true`, broken down by `$mcp_error_type`.
+3. p50/p95 `$mcp_duration_ms`, broken down by `$mcp_server_name` or tool.
+
+Add these to the existing Matrix OS Errors dashboard. Configure spike or issue alerts in the PostHog UI; the repository alert bootstrap intentionally does not use an unstable public alerts API.
+
+## Verification
+
+With a PostHog project token configured, invoke one successful and one deliberately validation-failing MCP tool, then confirm:
+
+- both calls appear as `$mcp_tool_call`;
+- the failure has `$mcp_is_error = true` and a coarse error type;
+- parameters, response content, intent, raw error messages, and `$exception_list` are absent;
+- gateway shutdown flushes the shared PostHog client.

--- a/packages/gateway/src/dispatcher.ts
+++ b/packages/gateway/src/dispatcher.ts
@@ -39,6 +39,8 @@ export interface DispatchOptions {
       (trace/session id, model, latency, token counts, error category input).
       Never receives message content. Failures are swallowed. */
   onAiGeneration?: (input: AiGenerationInput) => void;
+  /** Shared PostHog wrapper for in-process MCP servers. */
+  instrumentMcpServer?: (server: unknown) => void;
 }
 
 export interface DispatchContext {
@@ -192,6 +194,7 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
         workingDirectory: entry.kernelOverrides?.workingDirectory,
         maxTurns: opts.maxTurns,
         env: await buildKernelEnv(homePath),
+        instrumentMcpServer: opts.instrumentMcpServer,
       };
 
       for await (const event of spawnFn(message, config, entry.abortController)) {
@@ -326,6 +329,7 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
             model: opts.model,
             maxTurns: opts.maxTurns,
             env: await buildKernelEnv(homePath),
+            instrumentMcpServer: opts.instrumentMcpServer,
           };
 
           try {

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -548,6 +548,9 @@ export async function createGateway(config: GatewayConfig) {
     homePath,
     model: config.model,
     maxTurns: config.maxTurns,
+    instrumentMcpServer: (server) => {
+      posthogErrorTracker.instrumentMcpServer(server);
+    },
     spawnFn: config.spawnFn,
     onAiGeneration: recordAiGeneration,
   });

--- a/packages/kernel/src/options.ts
+++ b/packages/kernel/src/options.ts
@@ -228,6 +228,25 @@ export interface KernelConfig {
   effort?: string;
   maxTurns?: number;
   env?: Record<string, string | undefined>;
+  /** Gateway-owned telemetry hook. Receives MCP server instances, never tool payloads. */
+  instrumentMcpServer?: (server: unknown) => void;
+}
+
+function instrumentConfiguredMcpServer(
+  instrumentMcpServer: KernelConfig["instrumentMcpServer"],
+  configuredServer: unknown,
+): void {
+  if (!instrumentMcpServer || !configuredServer || typeof configuredServer !== "object") return;
+  const instance = (configuredServer as { instance?: unknown }).instance;
+  if (!instance) return;
+  try {
+    instrumentMcpServer(instance);
+  } catch (err: unknown) {
+    console.warn(
+      "[kernel-options] MCP instrumentation failed:",
+      err instanceof Error ? err.name : typeof err,
+    );
+  }
 }
 
 export async function kernelOptions(config: KernelConfig) {
@@ -245,6 +264,7 @@ export async function kernelOptions(config: KernelConfig) {
   const controls = resolveKernelSdkControls(model, config.effort ?? fileKernel.effort);
 
   const ipcServer = await createIpcServer(db, homePath);
+  instrumentConfiguredMcpServer(config.instrumentMcpServer, ipcServer);
   const coreAgents = getCoreAgents(homePath);
   const customAgents = loadCustomAgents(`${homePath}/agents/custom`, homePath);
   const agents = { ...coreAgents, ...customAgents };
@@ -261,6 +281,7 @@ export async function kernelOptions(config: KernelConfig) {
   if (browserConfig) {
     const browserServer = await tryCreateBrowserServer(homePath, browserConfig);
     if (browserServer) {
+      instrumentConfiguredMcpServer(config.instrumentMcpServer, browserServer);
       mcpServers["matrix-os-browser"] = browserServer;
       browserToolNames.push(...BROWSER_TOOL_NAMES);
     }

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -29,6 +29,7 @@
     "build": "tsc"
   },
   "dependencies": {
+    "@posthog/mcp": "0.11.7",
     "hono": "^4.11.9",
     "posthog-node": "^5.24.15"
   },

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -1,4 +1,5 @@
 import { PostHog } from "posthog-node";
+import { instrument, type MCPAnalyticsOptions } from "@posthog/mcp";
 import type { Context, Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 export { MATRIX_TELEMETRY_EVENTS, isMatrixTelemetryEvent, type MatrixTelemetryEvent } from "./events.js";
@@ -29,6 +30,11 @@ export interface CreatePostHogErrorTrackerOptions {
   flushTimeoutMs?: number;
   clientFactory?: (config: PostHogConfig) => PostHogCaptureClient;
   logger?: PostHogLogger;
+  mcpInstrumenter?: (
+    server: unknown,
+    posthog: PostHog,
+    options?: MCPAnalyticsOptions,
+  ) => unknown;
 }
 
 export interface CaptureExceptionOptions {
@@ -38,6 +44,7 @@ export interface CaptureExceptionOptions {
 
 export interface PostHogErrorTracker {
   enabled: boolean;
+  instrumentMcpServer(server: unknown): boolean;
   captureEvent(event: string, options?: CaptureExceptionOptions): Promise<boolean>;
   captureException(error: unknown, options?: CaptureExceptionOptions): Promise<boolean>;
   captureHonoException(error: unknown, c: Context, properties?: PostHogProperties): Promise<boolean>;
@@ -118,6 +125,33 @@ const HOST_ENV_KEYS = ["POSTHOG_HOST", "NEXT_PUBLIC_POSTHOG_HOST"];
 const DEFAULT_CLIENT_ERROR_MESSAGE = "Internal Server Error";
 const MAX_PROPERTY_LENGTH = 512;
 const DEFAULT_POSTHOG_FLUSH_TIMEOUT_MS = 5_000;
+const SAFE_MCP_PROPERTY_KEYS = new Set([
+  "$mcp_client_name",
+  "$mcp_client_version",
+  "$mcp_duration_ms",
+  "$mcp_error_type",
+  "$mcp_is_error",
+  "$mcp_protocol_version",
+  "$mcp_server_name",
+  "$mcp_server_version",
+  "$mcp_source",
+  "$mcp_tool_category",
+  "$mcp_tool_name",
+  "$session_id",
+  "service",
+]);
+
+export function sanitizePostHogMcpEvent<T extends {
+  properties?: Record<string, unknown>;
+}>(event: T): T {
+  const properties = event.properties ?? {};
+  return {
+    ...event,
+    properties: Object.fromEntries(
+      Object.entries(properties).filter(([key]) => SAFE_MCP_PROPERTY_KEYS.has(key)),
+    ),
+  };
+}
 
 export function getPostHogConfig(env: EnvSource = process.env): PostHogConfig | null {
   const token = firstEnv(env, TOKEN_ENV_KEYS);
@@ -181,6 +215,27 @@ export function createPostHogErrorTracker(
 
   return {
     enabled: Boolean(config),
+    instrumentMcpServer(server) {
+      const posthog = getClient();
+      if (!posthog) return false;
+      try {
+        const distinctId = resolveOwnerTelemetryDistinctId(options.env);
+        (options.mcpInstrumenter ?? instrument)(server, posthog as PostHog, {
+          context: false,
+          enableConversationId: false,
+          enableExceptionAutocapture: false,
+          reportMissing: false,
+          ...(distinctId ? { identify: { distinctId } } : {}),
+          eventProperties: () => ({ service: options.service }),
+          beforeSend: sanitizePostHogMcpEvent,
+          logger: () => undefined,
+        });
+        return true;
+      } catch (err: unknown) {
+        logger.warn(`[posthog] Failed to instrument MCP server for ${options.service}: ${errorKind(err)}`);
+        return false;
+      }
+    },
     async captureEvent(event, captureOptions = {}) {
       const posthog = getClient();
       if (!posthog?.capture) return false;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -752,6 +752,9 @@ importers:
 
   packages/observability:
     dependencies:
+      '@posthog/mcp':
+        specifier: 0.11.7
+        version: 0.11.7(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(posthog-node@5.28.4)
       hono:
         specifier: ^4.11.9
         version: 4.12.8
@@ -4095,6 +4098,22 @@ packages:
   '@posthog/core@1.39.6':
     resolution: {integrity: sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw==}
 
+  '@posthog/core@1.48.9':
+    resolution: {integrity: sha512-jKJyG12L0TcLaa0av6lmSl8pLANUmvp2RVebM0/FYa/gID47BAVzuj3fT6QPJ7RZe0U4QZGQIrkB1amVYfBcig==}
+
+  '@posthog/mcp@0.11.7':
+    resolution: {integrity: sha512-hDokMScYN1LAYbQdO4vBSF7/hpnC0WvEz0xpC/m1zru7jaNXFIy8AMm4F6K40J3BX0EE9LzNdAPPA1bp5ntxsQ==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.26.0'
+      '@modelcontextprotocol/server': '>=2.0.0'
+      posthog-node: ^5.0.0
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+      '@modelcontextprotocol/server':
+        optional: true
+
   '@posthog/nextjs-config@1.9.47':
     resolution: {integrity: sha512-Aiumj1u43iNkpmuNnOH+p2tcUgZhFBqMCp2P72P/ayMFmxK6DV2rv0lhWOE5kic5oanHHu+z6vxMYlbRiWjCqQ==}
     engines: {node: ^20.20.0 || >=22.22.0}
@@ -4118,6 +4137,9 @@ packages:
 
   '@posthog/types@1.392.1':
     resolution: {integrity: sha512-Qg6Gl7/1vlr8+gPtBi5gwnLgAgiyFoKOVmTvTtDcvya9cpTwZfna7rQmkGQ4B63CunUYNNbOlqcwiUwUDyTK6w==}
+
+  '@posthog/types@1.405.2':
+    resolution: {integrity: sha512-NVsw5pER9YEDFOfvmbpyRtIgv+0411QXHg1IjCFh+EcxtmLUP2FdJyiWYVpNM6WhTTlrPEW+fPZpGz1OBXijvQ==}
 
   '@posthog/webpack-plugin@1.5.3':
     resolution: {integrity: sha512-vh1GSMpxfHI8Rg6lDptwFlAA26dV95joI/O014pF1faRnbxCyvUnLF8yEYz8ZYdWP8hxHHqiwpAylTRBmn1OLg==}
@@ -18732,6 +18754,17 @@ snapshots:
     dependencies:
       '@posthog/types': 1.392.1
 
+  '@posthog/core@1.48.9':
+    dependencies:
+      '@posthog/types': 1.405.2
+
+  '@posthog/mcp@0.11.7(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(posthog-node@5.28.4)':
+    dependencies:
+      '@posthog/core': 1.48.9
+      posthog-node: 5.28.4
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
+
   '@posthog/nextjs-config@1.9.47(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.51.0))(webpack@5.107.2(lightningcss@1.32.0))':
     dependencies:
       '@posthog/cli': 0.7.18
@@ -18756,6 +18789,8 @@ snapshots:
   '@posthog/types@1.379.2': {}
 
   '@posthog/types@1.392.1': {}
+
+  '@posthog/types@1.405.2': {}
 
   '@posthog/webpack-plugin@1.5.3(webpack@5.107.2(lightningcss@1.32.0))':
     dependencies:

--- a/tests/gateway/dispatcher-observability.test.ts
+++ b/tests/gateway/dispatcher-observability.test.ts
@@ -146,6 +146,30 @@ describe("T1204: Interaction logger wiring in dispatcher", () => {
     expect(events.length).toBeGreaterThan(0);
     expect(events.some((e) => e.type === "result")).toBe(true);
   });
+
+  it("forwards the shared MCP instrumentation hook to serial and batch kernel runs", async () => {
+    const instrumentMcpServer = vi.fn();
+    const receivedHooks: unknown[] = [];
+    const spawnFn: SpawnFn = async function* (_message, config) {
+      receivedHooks.push(config.instrumentMcpServer);
+      yield { type: "init", sessionId: "instrumented-session" } as KernelEvent;
+      yield {
+        type: "result",
+        data: { sessionId: "instrumented-session", cost: 0, turns: 1 },
+      } as KernelEvent;
+    };
+    const dispatcher = createDispatcher({
+      homePath,
+      spawnFn,
+      maxConcurrency: 1,
+      instrumentMcpServer,
+    });
+
+    await dispatcher.dispatch("hello", undefined, () => {});
+    await dispatcher.dispatchBatch([{ taskId: "batch-1", message: "hi", onEvent: () => {} }]);
+
+    expect(receivedHooks).toEqual([instrumentMcpServer, instrumentMcpServer]);
+  });
 });
 
 describe("T1206: Dispatch metrics instrumentation", () => {

--- a/tests/kernel/options-working-directory.test.ts
+++ b/tests/kernel/options-working-directory.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { MatrixDB } from "../../packages/kernel/src/db.js";
+import { createIpcServer } from "../../packages/kernel/src/ipc-server.js";
 
 vi.mock("../../packages/kernel/src/ipc-server.js", () => ({
   createIpcServer: vi.fn(async () => ({ name: "matrix-os-ipc" })),
@@ -62,5 +63,22 @@ describe("kernel working directory", () => {
     const options = await kernelOptions(config);
 
     expect(options.cwd).toBe(config.homePath);
+  });
+
+  it("offers each in-process MCP server to the gateway instrumentation hook", async () => {
+    const instance = { server: "matrix-os-ipc" };
+    vi.mocked(createIpcServer).mockResolvedValueOnce({
+      name: "matrix-os-ipc",
+      instance,
+    } as never);
+    const instrumentMcpServer = vi.fn();
+
+    await kernelOptions({
+      db,
+      homePath: "/home/matrix/home",
+      instrumentMcpServer,
+    });
+
+    expect(instrumentMcpServer).toHaveBeenCalledWith(instance);
   });
 });

--- a/tests/observability/posthog-error-tracking.test.ts
+++ b/tests/observability/posthog-error-tracking.test.ts
@@ -16,6 +16,7 @@ import {
   extractPostHogDistinctId,
   installPostHogProcessErrorTracking,
   installPostHogHonoErrorTracking,
+  sanitizePostHogMcpEvent,
 } from "../../packages/observability/src/index.ts";
 
 describe("PostHog error tracking", () => {
@@ -115,6 +116,65 @@ describe("PostHog error tracking", () => {
     expect(tracker.enabled).toBe(false);
     await expect(tracker.captureException(new Error("boom"))).resolves.toBe(false);
     await expect(tracker.captureEvent("host_bundle_release_registered")).resolves.toBe(false);
+    expect(tracker.instrumentMcpServer({})).toBe(false);
+  });
+
+  it("instruments MCP servers without conversation context or exception payloads", () => {
+    const client = {
+      capture: vi.fn(),
+      captureException: vi.fn(),
+      flush: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    };
+    const mcpInstrumenter = vi.fn();
+    const tracker = createPostHogErrorTracker({
+      env: { POSTHOG_TOKEN: "phc_test", MATRIX_USER_ID: "user_123" },
+      service: "matrix-gateway",
+      clientFactory: () => client,
+      mcpInstrumenter,
+    });
+    const server = { name: "matrix-os-ipc" };
+
+    expect(tracker.instrumentMcpServer(server)).toBe(true);
+    expect(mcpInstrumenter).toHaveBeenCalledWith(
+      server,
+      client,
+      expect.objectContaining({
+        context: false,
+        enableConversationId: false,
+        enableExceptionAutocapture: false,
+        reportMissing: false,
+        identify: { distinctId: "user_123" },
+        beforeSend: sanitizePostHogMcpEvent,
+      }),
+    );
+  });
+
+  it("strips MCP parameters, responses, intent, and raw errors before capture", () => {
+    const event = sanitizePostHogMcpEvent({
+      event: "$mcp_tool_call",
+      properties: {
+        $mcp_server_name: "matrix-os-ipc",
+        $mcp_tool_name: "app_data",
+        $mcp_duration_ms: 42,
+        $mcp_is_error: true,
+        $mcp_parameters: { query: "private prompt" },
+        $mcp_response: { content: "owner data" },
+        $mcp_intent: "inspect secret project",
+        $mcp_error_message: "/home/matrix/private/file was not found",
+        $exception_list: [{ value: "private stack" }],
+      },
+    });
+
+    expect(event).toEqual({
+      event: "$mcp_tool_call",
+      properties: {
+        $mcp_server_name: "matrix-os-ipc",
+        $mcp_tool_name: "app_data",
+        $mcp_duration_ms: 42,
+        $mcp_is_error: true,
+      },
+    });
   });
 
   it("captures non-error PostHog events with sanitized properties", async () => {


### PR DESCRIPTION
## Summary

- instrument Matrix IPC and browser MCP servers with PostHog's official MCP analytics package
- reuse the gateway-owned PostHog client and lifecycle for serial and batch kernel runs
- retain only an explicit operational allowlist for server/tool identity, duration, error classification, protocol, session, and service
- disable context arguments, conversation IDs, missing-tool reporting, and exception autocapture to prevent tool content from reaching analytics

## Verification

- observability, kernel, and gateway builds pass under Node 24
- focused MCP observability tests pass as part of the 252-test stack suite
- frozen lockfile validation passes offline with pnpm 10.33.4
- pattern scan reports 0 violations
- layer size: 10 files, 279 additions

## Invariants

- **Source of truth:** the gateway's existing PostHog client/configuration is the single telemetry owner; MCP instrumentation adds no second client or queue.
- **Lock/transaction scope:** no database transaction or shared mutable lock is introduced; events use the existing PostHog flush/shutdown lifecycle.
- **Acceptable orphan states:** analytics are best-effort and may be dropped when PostHog is absent or unavailable; MCP execution must continue unaffected.
- **Auth source of truth:** existing PostHog project token and Matrix owner identity environment variables remain canonical; no credentials are exposed to MCP tools.
- **Deferred scope:** dashboard spike/issue alerts remain manual because PostHog does not expose a stable public alerts API.
