### PR TITLE
fix(gateway): await completed Codex turn in interrupt test

### DIFF
--- a/tests/gateway/coding-agents-codex-app-server-runtime.test.ts
+++ b/tests/gateway/coding-agents-codex-app-server-runtime.test.ts
@@ -765,7 +765,10 @@ describe("Codex app-server control runtime", () => {
         modelOptions: [],
         clientRequestId: "req_control_interrupt_2",
       })).resolves.toEqual({ ok: true });
-      const transcript = await waitForTranscript(eventPath, /after-interrupt/);
+      const transcript = await waitForTranscript(
+        eventPath,
+        /after-interrupt[\s\S]*"type":"turn\.completed"/,
+      );
       expect(transcript).toContain('"type":"turn.aborted"');
       expect(transcript).toContain('"type":"turn.completed"');
       expect(child.exitCode).toBeNull();


### PR DESCRIPTION
## Summary

- wait for the resumed native Codex turn to persist `turn.completed` before asserting the transcript
- remove the race where the test could observe `after-interrupt` before the completion event was appended
- leave runtime behavior unchanged

## Tests

- focused interrupt test repeated 25 consecutive times: passed
- `pnpm test -- --shard=1/4`: repaired test and 12,414 tests passed; 13 unrelated Linux-host-script/macOS-local failures remain
- repository TypeScript validation pipeline: passed
- `./scripts/review/check-patterns.sh`: passed with existing warnings and zero violations

## CI diagnosis

Latest `main` production build, typecheck, pattern scan, and all other CI jobs passed. Only Unit Tests shard 1 failed because the test began asserting after the assistant delta but before the asynchronous `turn.completed` append.
