### PR TITLE
fix(desktop): follow hosted chat navigation in e2e

### DIFF
--- a/tests/e2e/desktop/project-folder-picker-layout.e2e.test.ts
+++ b/tests/e2e/desktop/project-folder-picker-layout.e2e.test.ts
@@ -82,7 +82,6 @@ suite("Desktop Add Project compact folder picker", () => {
 
   it("keeps the sticky list header flush with the toolbar while rows scroll beneath it", async () => {
     await page.getByRole("button", { name: "Chat", exact: true }).dblclick();
-    await page.getByRole("button", { name: "Show Chat navigation" }).click();
     await page.getByRole("navigation", { name: "Chat navigation" }).waitFor();
     await page.getByRole("button", { name: "Create project" }).click();
     const dialog = page.getByRole("dialog", { name: "Create a project" });


### PR DESCRIPTION
## Summary

- update the required MAT-335 Electron regression to use Chat navigation from its hosted OS-window sidebar
- remove the stale click on the retired in-content `Show Chat navigation` control
- restore the latest `main` E2E gate and its downstream host-bundle same-SHA gate

## Tests

- `MATRIX_DESKTOP_E2E_REQUIRED=1 xvfb-run --auto-servernum pnpm exec vitest run --config vitest.e2e.config.ts tests/e2e/desktop/project-folder-picker-layout.e2e.test.ts` — passed (1/1)
- `pnpm exec vitest run tests/platform/ci-workflows.test.ts tests/desktop/tab-content.test.tsx tests/desktop/work-tab.test.tsx` — passed (87/87)
- full typecheck-equivalent pipeline — passed; run package-by-package because Bun is not installed in the local shell
- `pnpm run check:patterns` — passed with baseline warnings and zero violations
- `pnpm run test` — stopped after an unrelated environment-sensitive baseline failure in `bundled home sync treats log write failures as best effort`; the isolated failure expects an unwritable log path, but the local execution environment permits the write. GitHub's same-SHA unit shards are green.

## Review/Monitoring

- PR is monitored for required CI checks, unresolved review threads, Codex review comments, and the latest trusted Greptile score
- do not merge until Greptile reports 5/5

## Invariants

- **Source of truth:** the current Desktop hosted-sidebar accessibility contract is canonical; the E2E now follows the visible `Chat navigation` landmark directly
- **Lock/transaction scope:** none; test-only navigation change with no persistence or concurrency behavior
- **Acceptable orphan states:** none; no data or external resources are created by the committed change
- **Auth source of truth:** unchanged; the Electron E2E continues using the existing stub gateway device flow
- **Deferred scope:** the unrelated local host-bundle permission-sensitive test is not changed because the latest main unit shards already pass and this PR does not touch host-bundle code
