### PR TITLE
fix(chat): isolate invalid skill catalog metadata

### DIFF
--- a/packages/contracts/src/canonical-chat-provider.ts
+++ b/packages/contracts/src/canonical-chat-provider.ts
@@ -95,7 +95,7 @@ export const CanonicalProviderOptionDescriptorSchema = z.object({
 const CanonicalSlashDescriptorSchema = z.object({
   id: canonicalReferenceId(80),
   displayName: canonicalSafeLabel(120, 480),
-  description: canonicalSafeLabel(400, 1_600),
+  description: canonicalSafeLabel(1_600, 1_600),
   invocation: z.string().min(2).max(81).regex(/^\/[a-z][a-z0-9_-]{0,79}$/),
 }).strict();
 

--- a/packages/gateway/src/chat/provider-catalog.ts
+++ b/packages/gateway/src/chat/provider-catalog.ts
@@ -1,6 +1,7 @@
 import {
   CanonicalChatModelSelectionSchema,
   CanonicalChatSafeErrorSchema,
+  CanonicalChatSkillDescriptorSchema,
   CanonicalProviderCatalogSchema,
   CODEX_VERIFIED_NPM_PACKAGE,
   type AgentProviderDescriptor,
@@ -425,6 +426,40 @@ function catalogRevision(drivers: unknown, instances: unknown): string {
   return `catalog_${digest}`;
 }
 
+function projectSkills(
+  source: Array<{ name: string; description: string }>,
+): CanonicalChatSkillDescriptor[] {
+  const projected: CanonicalChatSkillDescriptor[] = [];
+  const seenIds = new Set<string>();
+  let omitted = 0;
+
+  for (const skill of source) {
+    if (projected.length >= MAX_SKILLS) break;
+    const id = skill.name.trim().toLocaleLowerCase();
+    if (!/^[a-z][a-z0-9_-]{0,79}$/.test(id) || seenIds.has(id)) {
+      omitted += 1;
+      continue;
+    }
+    const parsed = CanonicalChatSkillDescriptorSchema.safeParse({
+      id,
+      displayName: skill.name,
+      description: skill.description,
+      invocation: `/${id}`,
+    });
+    if (!parsed.success) {
+      omitted += 1;
+      continue;
+    }
+    seenIds.add(id);
+    projected.push(parsed.data);
+  }
+
+  if (omitted > 0) {
+    console.warn(`[chat-providers] Omitted ${omitted} invalid or duplicate Skill catalog entries`);
+  }
+  return projected;
+}
+
 export function createChatProviderCatalogService(options: {
   codingProviders: Pick<CodingAgentProviderRegistry, "listProviders" | "invalidate">;
   agentRuntimeSource: AgentRuntimeSource;
@@ -455,16 +490,7 @@ export function createChatProviderCatalogService(options: {
       }
 
       const coding = codingResult.status === "fulfilled" ? codingResult.value : [];
-      const skills = (options.skillsSource?.() ?? []).flatMap((skill) => {
-        const id = skill.name.trim().toLocaleLowerCase();
-        if (!/^[a-z][a-z0-9_-]{0,79}$/.test(id)) return [];
-        return [{
-          id,
-          displayName: skill.name,
-          description: skill.description,
-          invocation: `/${id}`,
-        } satisfies CanonicalChatSkillDescriptor];
-      }).slice(0, MAX_SKILLS);
+      const skills = projectSkills(options.skillsSource?.() ?? []);
       const seenCodingDrivers: CanonicalProviderDriverKind[] = [];
       const codingInstances: InstanceDraft[] = [];
       for (const provider of coding) {

--- a/tests/gateway/chat-provider-catalog.test.ts
+++ b/tests/gateway/chat-provider-catalog.test.ts
@@ -230,6 +230,62 @@ describe("canonical Chat Provider catalog", () => {
       .toEqual(new Set([catalog.revision]));
   });
 
+  it("preserves long Skill descriptions within the canonical byte bound", async () => {
+    const description = "A".repeat(941);
+    const service = createChatProviderCatalogService({
+      codingProviders: codingRegistry(),
+      agentRuntimeSource: runtimeSource(),
+      skillsSource: () => [{ name: "animate", description }],
+    });
+
+    const catalog = await service.getCatalog(principal);
+    const codex = catalog.instances.find((instance) => instance.id === "codex_default")!;
+
+    expect(codex.skills).toEqual([{
+      id: "animate",
+      displayName: "animate",
+      description,
+      invocation: "/animate",
+    }]);
+    expect(CanonicalProviderCatalogSchema.parse(catalog)).toEqual(catalog);
+  });
+
+  it("omits invalid Skill metadata without failing the Provider catalog", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const service = createChatProviderCatalogService({
+      codingProviders: codingRegistry(),
+      agentRuntimeSource: runtimeSource(),
+      skillsSource: () => [{
+        name: "valid-skill",
+        description: "A safe Skill description",
+      }, {
+        name: "too-large",
+        description: "A".repeat(1_601),
+      }, {
+        name: "unsafe-skill",
+        description: "Read /home/owner/.ssh/id_rsa",
+      }, {
+        name: "VALID-SKILL",
+        description: "Duplicate normalized identifier",
+      }],
+    });
+
+    const catalog = await service.getCatalog(principal);
+    const codex = catalog.instances.find((instance) => instance.id === "codex_default")!;
+
+    expect(codex.skills).toEqual([{
+      id: "valid-skill",
+      displayName: "valid-skill",
+      description: "A safe Skill description",
+      invocation: "/valid-skill",
+    }]);
+    expect(CanonicalProviderCatalogSchema.parse(catalog)).toEqual(catalog);
+    expect(warning).toHaveBeenCalledWith(
+      "[chat-providers] Omitted 3 invalid or duplicate Skill catalog entries",
+    );
+    warning.mockRestore();
+  });
+
   it("fails a system harness closed until its own provider authentication is configured", async () => {
     const source: AgentRuntimeSource = async () => {
       const snapshot = await runtimeSource()();


### PR DESCRIPTION
## Summary

- remove the arbitrary 400-character ceiling from canonical Skill and command descriptions while retaining the existing 1,600-byte display-safety bound
- validate and deduplicate each Skill projection independently so one malformed installed Skill cannot take down the Provider catalog
- cover the live 941-character description regression plus unsafe, oversized, and duplicate metadata

## Root cause

`GET /api/chat-providers` projected raw installed Skill descriptions into the canonical catalog and validated only after assembling the whole response. Several shipped Skill descriptions exceed 400 characters, so the final schema rejected the entire catalog and the Gateway returned `503 service_unavailable`.

## Tests

- `bun run test tests/contracts/canonical-chat.test.ts tests/contracts/canonical-chat-fixtures.test.ts tests/contracts/canonical-chat-compatibility.test.ts tests/contracts/canonical-chat-api.test.ts tests/gateway/chat-provider-catalog.test.ts tests/desktop/chat-provider-catalog-client.test.tsx` — 57 passed
- `bun run typecheck` — passed
- `bun run check:patterns` — passed with 0 violations and 5 pre-existing warnings
- `git diff --check` — passed
- `bun run test` — 12,437 passed; 11 unrelated baseline/environment failures across 3 files:
  - `golden-snapshot-host-scripts.test.ts`: Linux `stat -c` and Ubuntu prerequisite assumptions on macOS
  - `packaging.test.ts`: committed DMG PNG byte snapshot differs from locally rendered artwork
  - `terminal-agent-options.test.ts`: three generated interactive Bash handoff cases timed out

## Review/Monitoring

- Latest reviewed commit: `b10a7b314890507fba90a3304576acb1d8c1b2f8`
- Greptile: 5/5, approved with no actionable findings
- Claude Code Review: passed
- PR title check: passed
- Unresolved review threads: none
- Label-gated CI: pending `ready-for-ci`

## Invariants

### Source of truth

- Installed Skill metadata remains sourced from the owner-controlled Skill files loaded by the existing `skillsSource`.
- The canonical Provider catalog remains the sole safe projection consumed by Chat clients.

### Lock/transaction scope

- No persistence, lock, transaction, or external network call is added or changed.
- Projection remains an in-memory, request-scoped operation capped by the existing 64-Skill catalog limit.

### Acceptable orphan states

- There are no writes or orphan states.
- Invalid, unsafe, oversized, or duplicate Skill entries are omitted individually and logged only as a coarse count; valid Providers and Skills remain available.

### Auth source of truth

- Existing verified request-principal auth on `GET /api/chat-providers` is unchanged.
- Auth or catalog dependency failures continue to fail closed through the existing generic error mapping.

### Deferred scope

- This PR does not change Provider discovery, readiness, model selection, client retry behavior, or release/deployment mechanics.
- The 1,600-byte safe-display boundary remains intentional defense in depth; only the redundant 400-character ceiling is removed.
