### PR TITLE
fix(provisioning): bind production VPS bundles to stable

### DIFF
--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -53,7 +53,7 @@ jobs:
       MATRIX_APP_URL: ${{ vars.MATRIX_APP_URL }}
       MATRIX_APP_DOMAIN_HOSTS: ${{ vars.MATRIX_APP_DOMAIN_HOSTS }}
       MATRIX_CODE_DOMAIN_HOSTS: ${{ vars.MATRIX_CODE_DOMAIN_HOSTS }}
-      CUSTOMER_VPS_IMAGE_VERSION: ${{ vars.CUSTOMER_VPS_IMAGE_VERSION }}
+      CUSTOMER_VPS_IMAGE_VERSION: 'stable'
       ATS_BOOKING_BASE_URL: ${{ vars.ATS_BOOKING_BASE_URL }}
       GOLDEN_SNAPSHOT_BUILDS_ENABLED: ${{ vars.GOLDEN_SNAPSHOT_BUILDS_ENABLED || 'false' }}
       GOLDEN_SNAPSHOTS_ENABLED: 'true'
@@ -84,8 +84,7 @@ jobs:
             MATRIX_API_ORIGIN \
             MATRIX_APP_URL \
             MATRIX_APP_DOMAIN_HOSTS \
-            MATRIX_CODE_DOMAIN_HOSTS \
-            CUSTOMER_VPS_IMAGE_VERSION; do
+            MATRIX_CODE_DOMAIN_HOSTS; do
             if [ -z "${!name:-}" ]; then
               missing+=("$name")
             fi
@@ -566,6 +565,7 @@ jobs:
             --region "$GCP_REGION" \
             --format=json)"
           required_provisioning_env=(
+            CUSTOMER_VPS_IMAGE_VERSION
             MATRIX_PREBILLING_PROVISIONING_ENABLED
             MATRIX_PREBILLING_PROVISIONING_ROLLOUT_PERCENT
             MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE
@@ -705,7 +705,7 @@ jobs:
             echo "Candidate pre-VPS billing shell served the platform fallback auth page." >&2
             exit 1
           fi
-          manifest="$(curl --fail --silent --show-error --max-time 10 "$CANDIDATE_URL/system-bundles/channels/dev.json")"
+          manifest="$(curl --fail --silent --show-error --max-time 10 "$CANDIDATE_URL/system-bundles/channels/${CUSTOMER_VPS_IMAGE_VERSION}.json")"
           bundle_url="$(printf '%s\n' "$manifest" | jq -r '.url // empty')"
           if [ -z "$bundle_url" ]; then
             echo "Candidate host bundle channel smoke did not return a signed bundle URL." >&2
@@ -759,7 +759,7 @@ jobs:
             --no-traffic \
             --min-instances "$min_instances" \
             --no-cpu-throttling \
-            --update-env-vars "PLATFORM_BACKGROUND_WORKERS_ENABLED=true,MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED},MATRIX_CARD_TRIAL_DAYS=${MATRIX_CARD_TRIAL_DAYS},MATRIX_PREBILLING_PROVISIONING_ENABLED=${MATRIX_PREBILLING_PROVISIONING_ENABLED},MATRIX_PREBILLING_PROVISIONING_ROLLOUT_PERCENT=${MATRIX_PREBILLING_PROVISIONING_ROLLOUT_PERCENT},MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE=${MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE},GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED},GOLDEN_SNAPSHOTS_ENABLED=${GOLDEN_SNAPSHOTS_ENABLED},GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=${GOLDEN_SNAPSHOT_ROLLOUT_PERCENT}" \
+            --update-env-vars "PLATFORM_BACKGROUND_WORKERS_ENABLED=true,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED},MATRIX_CARD_TRIAL_DAYS=${MATRIX_CARD_TRIAL_DAYS},MATRIX_PREBILLING_PROVISIONING_ENABLED=${MATRIX_PREBILLING_PROVISIONING_ENABLED},MATRIX_PREBILLING_PROVISIONING_ROLLOUT_PERCENT=${MATRIX_PREBILLING_PROVISIONING_ROLLOUT_PERCENT},MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE=${MATRIX_PREBILLING_PROVISIONING_MAX_ACTIVE},GOLDEN_SNAPSHOT_BUILDS_ENABLED=${GOLDEN_SNAPSHOT_BUILDS_ENABLED},GOLDEN_SNAPSHOTS_ENABLED=${GOLDEN_SNAPSHOTS_ENABLED},GOLDEN_SNAPSHOT_ROLLOUT_PERCENT=${GOLDEN_SNAPSHOT_ROLLOUT_PERCENT}" \
             --remove-env-vars "MATRIX_PREBILLING_PROVISIONING_MAX_HOURLY_COST_MICROS,MATRIX_PREBILLING_PROVISIONING_COSTS" \
             --format=json)"
           production_revision="$(printf '%s\n' "$deploy_json" | jq -r '.status.traffic[]? | select(.tag == "production-candidate") | .revisionName // empty' | head -1)"
@@ -779,6 +779,7 @@ jobs:
             --format=json)"
           required_production_env=(
             "PLATFORM_BACKGROUND_WORKERS_ENABLED=true"
+            "CUSTOMER_VPS_IMAGE_VERSION=stable"
             "MATRIX_CARD_TRIALS_ENABLED=${MATRIX_CARD_TRIALS_ENABLED}"
             "MATRIX_CARD_TRIAL_DAYS=${MATRIX_CARD_TRIAL_DAYS}"
             "MATRIX_PREBILLING_PROVISIONING_ENABLED=true"

--- a/docs/dev/vps-deployment.md
+++ b/docs/dev/vps-deployment.md
@@ -49,9 +49,12 @@ Internet
 New VPS provisions download the host bundle from R2:
 
 ```text
-system-bundles/<CUSTOMER_VPS_IMAGE_VERSION>/matrix-host-bundle.tar.gz
-system-bundles/<CUSTOMER_VPS_IMAGE_VERSION>/matrix-host-bundle.tar.gz.sha256
+system-bundles/<version>/matrix-host-bundle.tar.gz
+system-bundles/<version>/matrix-host-bundle.tar.gz.sha256
 ```
+
+Production resolves the `stable` channel to that immutable version when each
+provisioning job starts.
 
 The per-user Docker image path is legacy/local-development only. It is not used for production customer VPSes.
 
@@ -599,12 +602,18 @@ Customer VPS host services are not affected by a platform control-plane restart.
 
 ### Update Customer VPS Host Bundle
 
-Customer VPSes boot from a host bundle downloaded from R2 at:
+Customer VPSes boot from an immutable host bundle downloaded from R2 at:
 
 ```text
-system-bundles/<CUSTOMER_VPS_IMAGE_VERSION>/matrix-host-bundle.tar.gz
-system-bundles/<CUSTOMER_VPS_IMAGE_VERSION>/matrix-host-bundle.tar.gz.sha256
+system-bundles/<version>/matrix-host-bundle.tar.gz
+system-bundles/<version>/matrix-host-bundle.tar.gz.sha256
 ```
+
+Production provisioning is bound to the `stable` channel. Each create or
+recovery resolves `stable` once, persists the exact version and SHA, and uses
+that same immutable target for either a golden snapshot or clean-image
+fallback. Promote a reviewed prior release back to `stable` for rollback;
+never repoint production through a separate image-version environment value.
 
 Use this path whenever shell, gateway, bundled apps, host scripts, Postgres env wiring, or agent CLI versions change for VPS-hosted users. The normal path is the GitHub Actions release workflow on `main`; local builds are for break-glass verification or emergency release preparation.
 

--- a/docs/platform/dev/architecture.md
+++ b/docs/platform/dev/architecture.md
@@ -75,9 +75,13 @@ The current bootstrap starts Postgres as a single machine-local `postgres:16` se
 Customer VPSes download and extract:
 
 ```text
-system-bundles/<CUSTOMER_VPS_IMAGE_VERSION>/matrix-host-bundle.tar.gz
-system-bundles/<CUSTOMER_VPS_IMAGE_VERSION>/matrix-host-bundle.tar.gz.sha256
+system-bundles/<version>/matrix-host-bundle.tar.gz
+system-bundles/<version>/matrix-host-bundle.tar.gz.sha256
 ```
+
+Production resolves the `stable` channel to an immutable version and SHA when
+the provisioning job is created. Snapshot and clean-image paths share that
+pinned target.
 
 The bundle includes:
 
@@ -157,7 +161,7 @@ Legacy `/containers/*` routes remain for local development and old fallback path
 
 ```
 1. Platform publishes matrix-host-bundle.tar.gz and .sha256 under system-bundles/<version>/
-2. New VPSes download the selected CUSTOMER_VPS_IMAGE_VERSION during cloud-init
+2. New VPS jobs resolve `stable` once and download that pinned version during cloud-init
 3. Existing VPSes refresh in place with matrix-update or recovery/reprovision
 4. matrix-db-backup.timer uploads hourly custom-format pg_dump snapshots to the user's R2 prefix
 ```

--- a/docs/platform/dev/deployment.md
+++ b/docs/platform/dev/deployment.md
@@ -10,7 +10,7 @@ Production Matrix OS is VPS-native:
 - one customer VPS per active user;
 - Matrix gateway, shell, code-server, sync, and app assets run on the customer VPS through host services;
 - each customer VPS has its own local Postgres endpoint at `127.0.0.1:5432`;
-- customer VPSes download the published host bundle from `system-bundles/<CUSTOMER_VPS_IMAGE_VERSION>/`;
+- production provisioning resolves the `stable` host-bundle channel once and pins that immutable version and SHA for the customer VPS;
 - Pipedream, Clerk server-side auth, provisioning, routing, and host-bundle publication stay on the platform.
 
 Legacy Docker Compose and `/containers/*` instructions are not the production customer runtime. They are only for archived shared-container deployments or local development.
@@ -55,7 +55,7 @@ ATS_ADMIN_SECRET=...
 ATS_BOOKING_BASE_URL=https://booking-provider.example/...
 
 CUSTOMER_VPS_ENABLED=true
-CUSTOMER_VPS_IMAGE_VERSION=matrix-os-host-dev
+CUSTOMER_VPS_IMAGE_VERSION=stable
 HETZNER_API_TOKEN=...
 HETZNER_CUSTOMER_PROJECT=matrix-os-customers
 HETZNER_LOCATION=nbg1
@@ -216,12 +216,20 @@ set +a
 sha256sum dist/host-bundle/matrix-host-bundle.tar.gz
 ```
 
-Publish:
+Publish an immutable version, then promote the reviewed release through the
+`stable` channel:
 
 ```text
-system-bundles/$CUSTOMER_VPS_IMAGE_VERSION/matrix-host-bundle.tar.gz
-system-bundles/$CUSTOMER_VPS_IMAGE_VERSION/matrix-host-bundle.tar.gz.sha256
+system-bundles/<version>/matrix-host-bundle.tar.gz
+system-bundles/<version>/matrix-host-bundle.tar.gz.sha256
 ```
+
+Production Cloud Run binds `CUSTOMER_VPS_IMAGE_VERSION=stable` directly. At
+provision time the platform resolves that channel to an immutable release and
+stores its exact version and SHA on the machine/job. Golden-snapshot selection
+and clean-image fallback therefore use identical bundle bytes. Roll back new
+provisions by promoting the reviewed prior release to `stable`; do not maintain
+a separate mutable production image-version variable.
 
 The bundle contains `/opt/matrix/app`, `/opt/matrix/runtime`, and `/opt/matrix/bin`. It includes bundled Vite/React default apps and the launchers for `matrix-gateway.service`, `matrix-shell.service`, `matrix-code.service`, `matrix-sync-agent.service`, and `matrix-update`.
 

--- a/specs/070-vps-per-user/quickstart.md
+++ b/specs/070-vps-per-user/quickstart.md
@@ -22,7 +22,7 @@ HETZNER_SERVER_TYPE=cpx22
 HETZNER_SSH_KEY_NAME=matrix-ops
 PLATFORM_SECRET=...
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_or_pk_test_...
-CUSTOMER_VPS_IMAGE_VERSION=matrix-os-host-dev
+CUSTOMER_VPS_IMAGE_VERSION=stable
 R2_ACCOUNT_ID=...
 R2_ACCESS_KEY_ID=...
 R2_SECRET_ACCESS_KEY=...
@@ -45,14 +45,18 @@ sha256sum dist/host-bundle/matrix-host-bundle.tar.gz
 
 The build must fail if `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is missing. A bundle that serves `clerk.example.com` is invalid and must not be published.
 
-Publish:
+Publish an immutable version:
 
 ```text
-system-bundles/$CUSTOMER_VPS_IMAGE_VERSION/matrix-host-bundle.tar.gz
-system-bundles/$CUSTOMER_VPS_IMAGE_VERSION/matrix-host-bundle.tar.gz.sha256
+system-bundles/<version>/matrix-host-bundle.tar.gz
+system-bundles/<version>/matrix-host-bundle.tar.gz.sha256
 ```
 
-For new provisions, bump `CUSTOMER_VPS_IMAGE_VERSION` when the bundle is meant to become the default. For already-running VPSes, refresh the bundle in place or run recovery/reprovisioning until automated bundle upgrades exist.
+Production keeps `CUSTOMER_VPS_IMAGE_VERSION=stable`. Promote the reviewed
+immutable release to the `stable` channel when it should become the default for
+new provisions. The platform resolves and pins the exact version and SHA at
+provision time, so a later channel promotion cannot change an in-flight job and
+clean-image fallback cannot drift from the selected snapshot target.
 
 ## 2. Test-First Checklist
 

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -600,6 +600,27 @@ describe('CI workflows', () => {
     expect(production).toContain('--to-revisions "$PRODUCTION_REVISION=100"');
   });
 
+  it('binds production customer provisioning to the stable host-bundle channel', () => {
+    const root = process.cwd();
+    const production = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
+    const candidateContract = production.slice(
+      production.indexOf('      - name: Verify deployed provisioning contract'),
+      production.indexOf('      - name: Smoke candidate revision'),
+    );
+    const productionContract = production.slice(
+      production.indexOf('      - name: Verify production provisioning contract'),
+      production.indexOf('      - name: Promote revision'),
+    );
+
+    expect(production).toContain("CUSTOMER_VPS_IMAGE_VERSION: 'stable'");
+    expect(production).not.toContain('CUSTOMER_VPS_IMAGE_VERSION: ${{ vars.CUSTOMER_VPS_IMAGE_VERSION }}');
+    expect(production).toContain('CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION}');
+    expect(candidateContract).toContain('CUSTOMER_VPS_IMAGE_VERSION');
+    expect(productionContract).toContain('"CUSTOMER_VPS_IMAGE_VERSION=stable"');
+    expect(production).toContain('channels/${CUSTOMER_VPS_IMAGE_VERSION}.json');
+    expect(production).not.toContain('channels/dev.json');
+  });
+
   it('preflights and binds distinct golden snapshot operator secrets for platform revisions', () => {
     const root = process.cwd();
     const production = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -1780,7 +1780,10 @@ json_field() { python3 -c "import json,sys; print(json.load(sys.stdin).get(sys.a
     const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
 
     expect(workflow).toContain('curl --fail --silent --show-error --max-time 10 "$CANDIDATE_URL/health"');
-    expect(workflow).toContain('$CANDIDATE_URL/system-bundles/channels/dev.json');
+    expect(workflow).toContain(
+      '$CANDIDATE_URL/system-bundles/channels/${CUSTOMER_VPS_IMAGE_VERSION}.json',
+    );
+    expect(workflow).not.toContain('$CANDIDATE_URL/system-bundles/channels/dev.json');
     expect(workflow).toContain("jq -r '.url // empty'");
     expect(workflow).toContain('sync_bucket="$(gcloud secrets versions access latest --secret=r2-bucket)"');
     expect(workflow).toContain('bundle_bucket="$(gcloud secrets versions access latest --secret=r2-bundles-bucket)"');


### PR DESCRIPTION
## Summary

- bind production customer VPS provisioning directly to the `stable` host-bundle channel instead of a mutable GitHub environment variable
- verify the stable binding on both candidate and production Cloud Run revisions, and smoke the configured channel before promotion
- document that each provisioning job resolves `stable` once, persists the immutable release version/SHA, and uses that same target for snapshot and clean-image paths

## Tests

- `pnpm exec vitest run tests/platform/ci-workflows.test.ts tests/platform/host-bundle-snapshot-workflow.test.ts` (66 passed)
- `pnpm exec vitest run tests/platform/customer-vps.test.ts --testNamePattern "pins channel image versions to the current immutable host bundle release at provision time|defaults new customer VPS provisioning to the stable host bundle channel"` (2 passed)
- affected host-bundle workflow contract (1 passed)
- platform/repository TypeScript checks through the underlying pnpm commands (passed; the aggregate local wrapper requires unavailable `bun`)
- `pnpm run check:patterns` (0 violations)
- workflow YAML parse and `git diff --check` (passed)

The broad local test run encountered unrelated environment-sensitive failures in existing CLI/Codex/Zellij and bundled-home log tests. The exact-head GitHub unit shards and E2E suite passed.

## Review/Monitoring

- exact head: `1cf5aafb975a801f8b027a835a38a44e393ec330`
- required GitHub `CI Results`: passed, including type check, production shell build, four unit-test shards, and E2E
- Claude review: passed
- Greptile: 5/5 on the exact head with no findings
- unresolved review threads: none

## Invariants

- **Source of truth:** `host_bundle_channels.stable` in platform Postgres remains canonical. The workflow chooses the channel; existing provisioning code resolves its current immutable release and persists the exact version and SHA on the machine/job.
- **Lock/transaction scope:** unchanged. Bundle resolution remains outside the owner provisioning transaction; machine/job persistence and existing fencing remain inside their current transaction/lock boundaries. No network call was moved into a transaction.
- **Acceptable orphan states:** unchanged. An in-flight job keeps its persisted immutable bundle target even if `stable` is promoted later; existing provider cleanup and job recovery behavior remains authoritative.
- **Auth source of truth:** unchanged. Cloud Run/IAM, platform registration tokens, Clerk identity, and operator/release credentials retain their current responsibilities.
- **Rollback:** promote a reviewed previous immutable release back to `stable`; no production image-version variable can silently diverge from that channel.
- **Deferred scope:** golden-snapshot machine-profile coverage and provisioning performance are not changed here. This PR only removes production channel drift; snapshot selection, clean-image fallback, recovery, updates, and public HTTP behavior are otherwise unchanged.
