### PR TITLE
fix(platform): derive golden snapshot capacity from billing catalog

### DIFF
--- a/packages/contracts/src/billing-catalog.ts
+++ b/packages/contracts/src/billing-catalog.ts
@@ -36,6 +36,7 @@ export interface MatrixMachineProfile {
   planSlug: MatrixHostedBillingPlanSlug;
   regionSlug: MatrixHostedBillingRegionSlug;
   serverType: "cpx21" | "cpx22" | "cpx31" | "cpx41" | "cpx42" | "cpx52";
+  architecture: "x86" | "arm";
   vcpus: number;
   memoryGb: number;
   diskGb: number;
@@ -83,15 +84,15 @@ export const MATRIX_HOSTED_BILLING_REGIONS: readonly MatrixHostedBillingRegion[]
 ];
 
 const EU_MACHINE_SHAPES = {
-  matrix_starter: { serverType: "cpx22", vcpus: 2, memoryGb: 4, diskGb: 80 },
-  matrix_builder: { serverType: "cpx42", vcpus: 8, memoryGb: 16, diskGb: 320 },
-  matrix_max: { serverType: "cpx52", vcpus: 12, memoryGb: 24, diskGb: 480 },
+  matrix_starter: { serverType: "cpx22", architecture: "x86", vcpus: 2, memoryGb: 4, diskGb: 80 },
+  matrix_builder: { serverType: "cpx42", architecture: "x86", vcpus: 8, memoryGb: 16, diskGb: 320 },
+  matrix_max: { serverType: "cpx52", architecture: "x86", vcpus: 12, memoryGb: 24, diskGb: 480 },
 } as const;
 
 const US_MACHINE_SHAPES = {
-  matrix_starter: { serverType: "cpx21", vcpus: 3, memoryGb: 4, diskGb: 80 },
-  matrix_builder: { serverType: "cpx31", vcpus: 4, memoryGb: 8, diskGb: 160 },
-  matrix_max: { serverType: "cpx41", vcpus: 8, memoryGb: 16, diskGb: 240 },
+  matrix_starter: { serverType: "cpx21", architecture: "x86", vcpus: 3, memoryGb: 4, diskGb: 80 },
+  matrix_builder: { serverType: "cpx31", architecture: "x86", vcpus: 4, memoryGb: 8, diskGb: 160 },
+  matrix_max: { serverType: "cpx41", architecture: "x86", vcpus: 8, memoryGb: 16, diskGb: 240 },
 } as const;
 
 export const MATRIX_HOSTED_MACHINE_PROFILES: readonly MatrixMachineProfile[] =

--- a/packages/platform/src/golden-snapshot-activation.ts
+++ b/packages/platform/src/golden-snapshot-activation.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { MATRIX_HOSTED_MACHINE_PROFILES } from '@matrix-os/contracts';
 import { z } from 'zod/v4';
 import type { PlatformDB } from './db.js';
 import {
@@ -8,19 +9,36 @@ import {
 } from './golden-snapshot-repository.js';
 import { GoldenSnapshotRuntimeConfigSchema, type GoldenSnapshotRuntimeConfig } from './golden-snapshot-schema.js';
 
-const ServerProfiles: Record<string, { architecture: 'x86' | 'arm'; diskGb: number }> = {
-  cpx22: { architecture: 'x86', diskGb: 80 },
+type GoldenSnapshotServerProfile = { architecture: 'x86' | 'arm'; diskGb: number };
+
+// Existing machines may still recover onto a server type that predates the
+// current hosted billing catalog. New purchasable types come only from the
+// shared catalog below; this bounded compatibility set preserves recovery.
+const LegacyServerProfiles = {
   cpx32: { architecture: 'x86', diskGb: 160 },
-  cpx52: { architecture: 'x86', diskGb: 320 },
   cax21: { architecture: 'arm', diskGb: 80 },
   cax31: { architecture: 'arm', diskGb: 160 },
   cax41: { architecture: 'arm', diskGb: 320 },
-};
+} satisfies Record<string, GoldenSnapshotServerProfile>;
+
+const ServerProfiles = MATRIX_HOSTED_MACHINE_PROFILES.reduce<Record<string, GoldenSnapshotServerProfile>>(
+  (profiles, profile) => {
+    const candidate = { architecture: profile.architecture, diskGb: profile.diskGb };
+    const existing = profiles[profile.serverType];
+    if (existing
+      && (existing.architecture !== candidate.architecture || existing.diskGb !== candidate.diskGb)) {
+      throw new Error(`Conflicting hosted machine profile for ${profile.serverType}`);
+    }
+    profiles[profile.serverType] = candidate;
+    return profiles;
+  },
+  { ...LegacyServerProfiles },
+);
 
 export function getGoldenSnapshotServerProfile(
   serverType: string,
-): { architecture: 'x86' | 'arm'; diskGb: number } | undefined {
-  return ServerProfiles[serverType];
+): GoldenSnapshotServerProfile | undefined {
+  return Object.hasOwn(ServerProfiles, serverType) ? ServerProfiles[serverType] : undefined;
 }
 
 const SelectionInputSchema = z.object({
@@ -124,7 +142,7 @@ export async function chooseProvisioningImage(
   const target = await db.executor.selectFrom('host_bundle_releases').select(['sha256'])
     .where('version', '=', input.targetBundleVersion).executeTakeFirst();
   const rollout = await resolveGoldenSnapshotRollout(db, config, input.machineId, input.now);
-  const profile = ServerProfiles[input.serverType];
+  const profile = getGoldenSnapshotServerProfile(input.serverType);
   if (!rollout.included
     || !profile || profile.architecture !== config.compatibility.architecture || !target) {
     return persistCleanDecision(db, input, target?.sha256 ?? '0'.repeat(64));
@@ -193,7 +211,7 @@ export async function chooseRecoveryImage(
   const target = await db.executor.selectFrom('host_bundle_releases').select('sha256')
     .where('version', '=', input.targetBundleVersion).executeTakeFirst();
   const rollout = await resolveGoldenSnapshotRollout(db, config, input.machineId, input.now);
-  const profile = ServerProfiles[input.serverType];
+  const profile = getGoldenSnapshotServerProfile(input.serverType);
   if (!rollout.included
     || !profile || profile.architecture !== config.compatibility.architecture || !target) {
     return {

--- a/specs/109-golden-vps-snapshots/spec.md
+++ b/specs/109-golden-vps-snapshots/spec.md
@@ -441,7 +441,11 @@ straightforward billing, and one-owner-per-VPS isolation.
   When no exact image exists, the system MUST use the clean Ubuntu path.
 - **FR-022**: Snapshot compatibility MUST account for architecture, base-system and boot
   compatibility, minimum disk requirement, and any release-declared activation
-  constraint.
+  constraint. Every purchasable hosted server type MUST derive its architecture and
+  disk capacity from the shared hosted-machine catalog; an independent snapshot
+  allowlist MUST NOT silently send a supported paid configuration to clean-image
+  provisioning. Bounded legacy capability entries MAY remain for recovery of existing
+  machines that are no longer offered for purchase.
 - **FR-023**: The platform MUST NOT select an older or merely compatible snapshot for a
   different target bundle.
 - **FR-024**: A new VPS MUST receive customer identity and secrets only during its own

--- a/tests/platform/golden-snapshot-provisioning.test.ts
+++ b/tests/platform/golden-snapshot-provisioning.test.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { MATRIX_HOSTED_MACHINE_PROFILES } from '@matrix-os/contracts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getActiveUserMachineByClerkId,
@@ -15,6 +16,7 @@ import {
   chooseProvisioningImage,
   chooseRecoveryImage,
   fallbackProvisioningImage,
+  getGoldenSnapshotServerProfile,
 } from '../../packages/platform/src/golden-snapshot-activation.js';
 import {
   advanceGoldenSnapshot,
@@ -76,6 +78,21 @@ describe('golden snapshot provisioning activation', () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     await destroyTestPlatformDb(db);
+  });
+
+  it('derives snapshot capacity for every offered hosted machine type', () => {
+    for (const profile of MATRIX_HOSTED_MACHINE_PROFILES) {
+      expect(getGoldenSnapshotServerProfile(profile.serverType)).toEqual({
+        architecture: profile.architecture,
+        diskGb: profile.diskGb,
+      });
+    }
+    expect(getGoldenSnapshotServerProfile('constructor')).toBeUndefined();
+  });
+
+  it('preserves snapshot compatibility for legacy recovery server types', () => {
+    expect(getGoldenSnapshotServerProfile('cpx32')).toEqual({ architecture: 'x86', diskGb: 160 });
+    expect(getGoldenSnapshotServerProfile('cax31')).toEqual({ architecture: 'arm', diskGb: 160 });
   });
 
   it('normalizes Postgres BIGINT provider image ids before exact preview comparison', () => {
@@ -453,6 +470,24 @@ describe('golden snapshot provisioning activation', () => {
       targetBundleVersion: 'v2', targetBundleSha256: '2'.repeat(64), activationStep: 'creating',
     });
   });
+
+  it.each([...new Set(MATRIX_HOSTED_MACHINE_PROFILES.map((profile) => profile.serverType))])(
+    'selects an exact snapshot for offered server type %s',
+    async (serverType) => {
+      const snapshotId = await readySnapshot('v2', 302);
+      const selected = await chooseProvisioningImage(db, config, {
+        jobId: '50000000-0000-4000-8000-000000000001',
+        machineId: '30000000-0000-4000-8000-000000000001',
+        targetBundleVersion: 'v2',
+        serverType,
+        purpose: 'provision',
+        leaseId: '40000000-0000-4000-8000-000000000001',
+        now: '2026-07-03T00:01:00.000Z',
+      });
+
+      expect(selected).toMatchObject({ imageSource: 'snapshot', providerImageId: 302, snapshotId });
+    },
+  );
 
   it('links the provisioning job to its singleton create intent', async () => {
     const snapshotId = await readySnapshot('v2', 302);


### PR DESCRIPTION
## Summary

- derive golden-snapshot architecture and disk compatibility for every purchasable server type from the shared hosted-machine catalog
- retain a bounded legacy compatibility set only for recovery of machines on retired server types
- prevent supported Builder/US configurations from silently falling back to slow clean-image provisioning
- document the shared catalog as the source of truth for purchasable snapshot compatibility

## Tests

- focused golden snapshot provisioning/recovery and billing catalog suites: 65 passed
- all golden snapshot suites exercised during validation: 279 passed
- contracts and platform TypeScript checks passed
- changed-diff pattern scan: 0 violations; one pre-existing fixed-size timezone Set warning
- exact-head GitHub CI passed: four unit shards, E2E, type-check, contracts, SDK compatibility, OS parity, sync package, production shell build, Docker build/smoke, patterns, and audits

## Invariants

- **Source of truth:** MATRIX_HOSTED_MACHINE_PROFILES is canonical for every currently purchasable server type, architecture, and disk capacity. The local bounded legacy map is recovery-only.
- **Lock/transaction scope:** unchanged. Snapshot selection, lease fencing, and persisted provisioning decisions remain in their existing PostgreSQL transaction/lock boundaries; no provider calls were moved into a transaction.
- **Acceptable orphan states:** unchanged. Existing create-intent reconciliation, lease expiry, clean-image fallback, cleanup, and recovery behavior remain authoritative.
- **Auth source of truth:** unchanged. Existing internal provisioning and provider registration authentication remains in force; no public endpoint or response contract changes.
- **Rollback:** reverting this commit restores the prior selector; there is no schema migration or database state transition change.
- **Deferred scope:** checkout admission, prebilling leases, cleanup, paid continuation, machine reuse, provider APIs, public HTTP behavior, and production rollout are not changed. Unknown custom server types continue to fail safely to clean-image provisioning until reviewed and cataloged.

## Review status

Branch is frozen at 10a723906267b9518acd7fa57c4b0a46b24fd202. Exact-head CI passed, Greptile is 5/5, and no review threads are unresolved. The PR is intentionally unmerged for review.