### PR TITLE
feat(shell): add Discord community shortcut

### DIFF
--- a/desktop/src/renderer/src/features/desktop-shell/DesktopModeControls.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopModeControls.tsx
@@ -1,5 +1,6 @@
 import AccountMenu from "../mission-control/AccountMenu";
 import RuntimeComputerMenu from "../runtime/RuntimeComputerMenu";
+import DesktopDiscordButton from "../support/DesktopDiscordButton";
 import DesktopSupportButton from "../support/DesktopSupportButton";
 import DesktopUpdateButton from "../updates/DesktopUpdateButton";
 import { Search } from "../../lib/hugeicons";
@@ -20,6 +21,7 @@ export default function DesktopModeControls() {
         <Search aria-hidden="true" size={16} />
       </button>
       <DesktopSupportButton />
+      <DesktopDiscordButton />
       <div className="relative w-[156px]">
         <RuntimeComputerMenu collapsed={false} />
       </div>

--- a/desktop/src/renderer/src/features/support/DesktopDiscordButton.tsx
+++ b/desktop/src/renderer/src/features/support/DesktopDiscordButton.tsx
@@ -1,0 +1,26 @@
+import { DiscordIcon } from "../../lib/hugeicons";
+import { invoke } from "../../lib/operator";
+
+const DISCORD_INVITE_URL = "https://discord.gg/WHbvTG33w";
+
+export default function DesktopDiscordButton() {
+  return (
+    <button
+      type="button"
+      aria-label="Join Discord"
+      title="Join Discord"
+      className="flex size-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-[var(--bg-hover)] focus-visible:bg-[var(--bg-hover)]"
+      style={{ color: "var(--text-secondary)" }}
+      onClick={() => {
+        void invoke("shell:open-external", { url: DISCORD_INVITE_URL }).catch((error: unknown) => {
+          console.warn(
+            "[desktop-discord] Failed to open invite:",
+            error instanceof Error ? error.name : typeof error,
+          );
+        });
+      }}
+    >
+      <DiscordIcon aria-hidden="true" size={16} />
+    </button>
+  );
+}

--- a/desktop/src/renderer/src/lib/hugeicons.tsx
+++ b/desktop/src/renderer/src/lib/hugeicons.tsx
@@ -290,6 +290,16 @@ function createIcon(icon: IconSvgElement): LucideIcon {
   };
 }
 
+const DiscordIconData: IconSvgElement = [[
+  "path",
+  {
+    d: "M20.317 4.37a19.79 19.79 0 0 0-4.885-1.515 14.9 14.9 0 0 0-.626 1.284 18.27 18.27 0 0 0-5.61 0 12.64 12.64 0 0 0-.634-1.284A19.74 19.74 0 0 0 3.678 4.37C.59 8.965-.246 13.45.172 17.886a19.9 19.9 0 0 0 5.993 3.028 14.3 14.3 0 0 0 1.272-1.67 12.9 12.9 0 0 1-2.003-.957c.168-.122.33-.247.488-.373 3.862 1.787 8.05 1.787 11.866 0 .159.13.324.256.487.373-.635.375-1.305.695-2.002.957.372.464.785.987 1.271 1.67a19.85 19.85 0 0 0 6.002-3.028c.493-5.197-.844-9.708-3.549-13.697ZM8.02 15.331c-1.183 0-2.157-1.086-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.419 0 1.333-.955 2.419-2.157 2.419Zm7.975 0c-1.183 0-2.157-1.086-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.419 0 1.333-.946 2.419-2.157 2.419Z",
+    fill: "currentColor",
+    stroke: "none",
+    key: "discord",
+  },
+]];
+
 export const Activity: LucideIcon = createIcon(ActivityData);
 export const ActivityIcon: LucideIcon = createIcon(ActivityIconData);
 export const AlertCircle: LucideIcon = createIcon(AlertCircleData);
@@ -371,6 +381,7 @@ export const CpuIcon: LucideIcon = createIcon(CpuIconData);
 export const CreditCard: LucideIcon = createIcon(CreditCardData);
 export const CreditCardIcon: LucideIcon = createIcon(CreditCardIconData);
 export const DatabaseIcon: LucideIcon = createIcon(DatabaseIconData);
+export const DiscordIcon: LucideIcon = createIcon(DiscordIconData);
 export const Download: LucideIcon = createIcon(DownloadData);
 export const DownloadIcon: LucideIcon = createIcon(DownloadIconData);
 export const Edit3: LucideIcon = createIcon(Edit3Data);

--- a/shell/src/components/desktop/WebDesktopControls.tsx
+++ b/shell/src/components/desktop/WebDesktopControls.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { MessageCircleIcon, SearchIcon, ServerIcon } from "@/lib/hugeicons";
+import { DiscordIcon, MessageCircleIcon, SearchIcon, ServerIcon } from "@/lib/hugeicons";
 import { UserButton } from "../UserButton";
 
 export type WebDesktopSettingsSection = "appearance" | "billing" | "integrations";
@@ -37,6 +37,16 @@ export function WebDesktopControls({ onOpenSettings, onOpenCommandPalette, onOpe
       >
         <MessageCircleIcon className="size-3.5" aria-hidden="true" />
       </button>
+      <a
+        href="https://discord.gg/WHbvTG33w"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Join Discord"
+        title="Join Discord"
+        className={actionClass}
+      >
+        <DiscordIcon className="size-3.5" aria-hidden="true" />
+      </a>
       <Link
         href="/runtime"
         aria-label="Switch computer"

--- a/shell/src/lib/hugeicons.tsx
+++ b/shell/src/lib/hugeicons.tsx
@@ -288,6 +288,16 @@ function createIcon(icon: IconSvgElement): LucideIcon {
   };
 }
 
+const DiscordIconData: IconSvgElement = [[
+  "path",
+  {
+    d: "M20.317 4.37a19.79 19.79 0 0 0-4.885-1.515 14.9 14.9 0 0 0-.626 1.284 18.27 18.27 0 0 0-5.61 0 12.64 12.64 0 0 0-.634-1.284A19.74 19.74 0 0 0 3.678 4.37C.59 8.965-.246 13.45.172 17.886a19.9 19.9 0 0 0 5.993 3.028 14.3 14.3 0 0 0 1.272-1.67 12.9 12.9 0 0 1-2.003-.957c.168-.122.33-.247.488-.373 3.862 1.787 8.05 1.787 11.866 0 .159.13.324.256.487.373-.635.375-1.305.695-2.002.957.372.464.785.987 1.271 1.67a19.85 19.85 0 0 0 6.002-3.028c.493-5.197-.844-9.708-3.549-13.697ZM8.02 15.331c-1.183 0-2.157-1.086-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.419 0 1.333-.955 2.419-2.157 2.419Zm7.975 0c-1.183 0-2.157-1.086-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.419 0 1.333-.946 2.419-2.157 2.419Z",
+    fill: "currentColor",
+    stroke: "none",
+    key: "discord",
+  },
+]];
+
 export const Activity: LucideIcon = createIcon(ActivityData);
 export const ActivityIcon: LucideIcon = createIcon(ActivityIconData);
 export const AlertCircle: LucideIcon = createIcon(AlertCircleData);
@@ -369,6 +379,7 @@ export const CpuIcon: LucideIcon = createIcon(CpuIconData);
 export const CreditCard: LucideIcon = createIcon(CreditCardData);
 export const CreditCardIcon: LucideIcon = createIcon(CreditCardIconData);
 export const DatabaseIcon: LucideIcon = createIcon(DatabaseIconData);
+export const DiscordIcon: LucideIcon = createIcon(DiscordIconData);
 export const Download: LucideIcon = createIcon(DownloadData);
 export const DownloadIcon: LucideIcon = createIcon(DownloadIconData);
 export const Edit3: LucideIcon = createIcon(Edit3Data);

--- a/tests/desktop/desktop-mode-controls.test.tsx
+++ b/tests/desktop/desktop-mode-controls.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import DesktopModeControls from "@desktop/renderer/src/features/desktop-shell/DesktopModeControls";
 import { useConnection } from "@desktop/renderer/src/stores/connection";
@@ -46,10 +46,16 @@ describe("Desktop mode controls", () => {
     expect(labels).toEqual([
       "Search",
       "Support",
+      "Join Discord",
       "Main computer",
       "Update Matrix OS to 1.2.3",
       "Open account menu",
     ]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Join Discord" }));
+    expect(window.operator.invoke).toHaveBeenCalledWith("shell:open-external", {
+      url: "https://discord.gg/WHbvTG33w",
+    });
 
     const update = screen.getByRole("button", { name: "Update Matrix OS to 1.2.3" });
     const avatar = screen.getByRole("button", { name: "Open account menu" }).querySelector("span");

--- a/tests/desktop/desktop-support-widget.test.tsx
+++ b/tests/desktop/desktop-support-widget.test.tsx
@@ -190,7 +190,7 @@ describe("Desktop support widget", () => {
     await waitFor(() => expect(screen.queryByRole("button", { name: "Open chat" })).toBeNull());
 
     expect(screen.getAllByRole("button").map((button) => button.getAttribute("aria-label") ?? button.textContent))
-      .toEqual(["Search", "Support", "Main computer", "Open account menu"]);
+      .toEqual(["Search", "Support", "Join Discord", "Main computer", "Open account menu"]);
 
     const unrelatedClose = document.createElement("button");
     unrelatedClose.id = "unrelated-close";

--- a/tests/shell/web-desktop-controls.test.tsx
+++ b/tests/shell/web-desktop-controls.test.tsx
@@ -29,9 +29,13 @@ describe("WebDesktopControls", () => {
     expect(screen.getByRole("link", { name: "Switch computer" }).getAttribute("href")).toBe("/runtime");
     fireEvent.click(screen.getByRole("button", { name: "Support chat" }));
     expect(onOpenSupport).toHaveBeenCalledOnce();
+    const discord = screen.getByRole("link", { name: "Join Discord" });
+    expect(discord.getAttribute("href")).toBe("https://discord.gg/WHbvTG33w");
+    expect(discord.getAttribute("target")).toBe("_blank");
+    expect(discord.getAttribute("rel")).toBe("noopener noreferrer");
     expect(Array.from(screen.getByRole("navigation", { name: "Desktop controls" }).children)
       .map((control) => control.getAttribute("aria-label") ?? control.textContent))
-      .toEqual(["Search", "Support chat", "Switch computer", "Account"]);
+      .toEqual(["Search", "Support chat", "Join Discord", "Switch computer", "Account"]);
     fireEvent.click(screen.getByRole("button", { name: "Account" }));
     expect(onOpenSettings).toHaveBeenCalledWith("billing");
   });


### PR DESCRIPTION
## Summary

- add a Discord community shortcut immediately beside Support in the web OS controls
- add the same Discord shortcut to the native desktop controls through the HTTPS-only external-link IPC bridge
- add an accessible Discord brand icon and regression coverage for link safety, behavior, and ordering

## Tests

- `bun run test -- tests/shell/web-desktop-controls.test.tsx tests/desktop/desktop-mode-controls.test.tsx tests/desktop/desktop-support-widget.test.tsx` — 10 passed
- `bun run typecheck` — passed
- `bun run check:patterns` — passed with 0 violations and 5 existing repository audit warnings
- `bun run build:shell:production` — passed
- `pnpm --filter desktop build` — passed
- `bun run test` — not completed: the broad local run produced unrelated failures across existing default-app, golden-snapshot, coding-agent runtime, sync, and CLI suites; stopped after the unrelated failure set was established

## Review/Monitoring

- monitoring with the worktree PR workflow
- do not merge automatically
- add `ready-for-ci` only after the latest trusted Greptile result reaches 5/5

## Invariants

- **Source of truth:** the requested Discord invite is `https://discord.gg/WHbvTG33w`; renderer-specific tests pin the exact destination
- **Lock/transaction scope:** no database, file-state, lock, or transaction behavior changes
- **Acceptable orphan states:** none; this change creates no persistent or remote resources
- **Auth source of truth:** unchanged; the web link is a safe external anchor and desktop uses the existing validated HTTPS-only IPC boundary
- **Deferred scope:** no Discord account linking, channel configuration, analytics, or documentation changes