### PR TITLE
fix(desktop): preserve durable icon layouts

### DIFF
--- a/desktop/src/renderer/src/features/desktop-shell/DesktopBackground.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopBackground.tsx
@@ -1,14 +1,9 @@
 import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { DESKTOP_Z_INDEX } from "../../design/layering";
 import type { ApiClient } from "../../lib/api";
+import { loadNativeDesktopConfig } from "../../lib/desktop-config-client";
 import { useConnection } from "../../stores/connection";
 import { useUi } from "../../stores/ui";
-import {
-  captureDesktopIconsHydrationRevision,
-  defaultDesktopIcons,
-  useDesktopIcons,
-} from "../../stores/desktop-icons";
-import { FIXED_DESKTOP_APPS } from "./desktop-apps";
 
 type DesktopBackgroundConfig =
   | { type: "pattern" }
@@ -19,7 +14,6 @@ type DesktopBackgroundConfig =
 
 const FALLBACK_STYLE: CSSProperties = { background: "var(--bg-app)" };
 const WALLPAPER_MAX_BYTES = 10 * 1024 * 1024;
-const DEFAULT_DESKTOP_ICONS = defaultDesktopIcons(FIXED_DESKTOP_APPS.map((app) => app.path));
 
 function meshGradient(): string {
   return [
@@ -114,6 +108,7 @@ export default function DesktopBackground() {
   const [loaded, setLoaded] = useState<{ api: ApiClient; style: CSSProperties } | null>(null);
   const [refreshRevision, setRefreshRevision] = useState(0);
   const activeObjectUrl = useRef<{ api: ApiClient; url: string } | null>(null);
+  const loadedConfigApi = useRef<ApiClient | null>(null);
   const style = api && loaded?.api === api ? loaded.style : FALLBACK_STYLE;
 
   useEffect(() => {
@@ -148,12 +143,14 @@ export default function DesktopBackground() {
 
     if (api) {
       void (async () => {
-        const iconHydrationRevision = captureDesktopIconsHydrationRevision();
-        const config = await api.get<{ background?: unknown; desktopIcons?: unknown }>("/api/settings/desktop");
-        if (!cancelled) {
-          useDesktopIcons.getState().hydrate(config.desktopIcons, DEFAULT_DESKTOP_ICONS, iconHydrationRevision);
-        }
-        const background = backgroundConfig(config?.background);
+        const refresh = loadedConfigApi.current === api;
+        loadedConfigApi.current = api;
+        const config = await loadNativeDesktopConfig(api, { refresh });
+        const background = backgroundConfig(
+          typeof config === "object" && config !== null && !Array.isArray(config)
+            ? (config as { background?: unknown }).background
+            : undefined,
+        );
         if (!background) return;
         if (background.type !== "wallpaper") {
           if (!cancelled) {

--- a/desktop/src/renderer/src/features/desktop-shell/NativeDesktopShell.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/NativeDesktopShell.tsx
@@ -21,7 +21,8 @@ import DesktopBackgroundMenu from "./DesktopBackgroundMenu";
 import DesktopAppDrawer from "./DesktopAppDrawer";
 import { useDesktopAppDrawer } from "../../stores/desktop-app-drawer";
 import { useConnection } from "../../stores/connection";
-import { defaultDesktopIcons, useDesktopIcons } from "../../stores/desktop-icons";
+import { useDesktopIcons } from "../../stores/desktop-icons";
+import { createDefaultOsViewDesktopIcons } from "@matrix-os/contracts";
 import { trackDesktopEvent } from "../../lib/desktop-analytics";
 import { appIconUrl, useAppsQuery } from "../apps/apps.api";
 import { LayoutGrid } from "@renderer/lib/hugeicons";
@@ -94,7 +95,7 @@ export default function NativeDesktopShell({ overlayOpen }: { overlayOpen: boole
   const durableOpenedPathsRef = useRef<Record<string, true>>({});
   const tabIds = useMemo(() => tabs.map((tab) => tab.id), [tabs]);
   const defaultIconLayout = useMemo(
-    () => defaultDesktopIcons(FIXED_DESKTOP_APPS.map((app) => app.path)),
+    createDefaultOsViewDesktopIcons,
     [],
   );
 

--- a/desktop/src/renderer/src/features/desktop-shell/desktop-apps.ts
+++ b/desktop/src/renderer/src/features/desktop-shell/desktop-apps.ts
@@ -116,7 +116,7 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
   },
   {
     id: "notes",
-    path: "__notes__",
+    path: "apps/notes/index.html",
     kind: "notes",
     icon: Notebook,
     name: "Notes",

--- a/desktop/src/renderer/src/features/desktop-shell/use-native-os-view-persistence.ts
+++ b/desktop/src/renderer/src/features/desktop-shell/use-native-os-view-persistence.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { OsViewMode, OsViewStateResponse } from "@matrix-os/contracts";
 import type { ApiClient } from "../../lib/api";
-import { loadNativeOsViewState, patchNativeOsViewState } from "../../lib/os-view-state-client";
+import { loadNativeOsViewStateWithLegacyImport, patchNativeOsViewState } from "../../lib/os-view-state-client";
 import type { MatrixApp } from "../apps/apps.api";
 import {
   desktopSurfaceBounds,
@@ -104,7 +104,7 @@ export function useNativeOsViewPersistence(input: {
     if (!input.api) return;
     let cancelled = false;
     const iconHydrationRevision = captureDesktopIconsHydrationRevision();
-    void loadNativeOsViewState(input.api).then((state) => {
+    void loadNativeOsViewStateWithLegacyImport(input.api).then((state) => {
       if (cancelled) return;
       loadedRef.current = true;
       canonicalGeometryRef.current = {
@@ -112,9 +112,7 @@ export function useNativeOsViewPersistence(input: {
         canvas: Object.fromEntries(state.document.canvas.windows.map(({ path, ...bounds }) => [path, bounds])),
       };
       useNativeDesktopMode.getState().setCanvasTransform(state.document.canvas.transform);
-      if (state.revision > 1) {
-        useDesktopIcons.getState().hydrate(state.document.desktop.icons, input.defaultIconLayout, iconHydrationRevision);
-      }
+      useDesktopIcons.getState().hydrate(state.document.desktop.icons, input.defaultIconLayout, iconHydrationRevision);
       setDurableState(state);
     }).catch((error: unknown) => {
       if (!cancelled) {

--- a/desktop/src/renderer/src/lib/desktop-config-client.ts
+++ b/desktop/src/renderer/src/lib/desktop-config-client.ts
@@ -1,0 +1,21 @@
+import type { ApiClient } from "./api";
+
+// Weak keys make the cache runtime-scoped without retaining disconnected API
+// clients. The first Desktop consumers share one read; explicit refreshes
+// replace it after focus or a background settings change.
+const desktopConfigRequests = new WeakMap<ApiClient, Promise<unknown>>();
+
+export function loadNativeDesktopConfig(
+  api: ApiClient,
+  options: { refresh?: boolean } = {},
+): Promise<unknown> {
+  const existing = desktopConfigRequests.get(api);
+  if (existing && !options.refresh) return existing;
+
+  const pending = api.get<unknown>("/api/settings/desktop");
+  desktopConfigRequests.set(api, pending);
+  void pending.catch(() => {
+    if (desktopConfigRequests.get(api) === pending) desktopConfigRequests.delete(api);
+  });
+  return pending;
+}

--- a/desktop/src/renderer/src/lib/os-view-state-client.ts
+++ b/desktop/src/renderer/src/lib/os-view-state-client.ts
@@ -1,13 +1,17 @@
 import {
+  LegacyDesktopImportSchema,
   OsViewStateResponseSchema,
   createDefaultOsViewDocument,
   mergeOsViewStatePatch,
+  legacyDesktopImportFromConfig,
   rebaseOsViewStatePatch,
   type OsViewStatePatch,
   type OsViewStateResponse,
+  type LegacyDesktopImport,
 } from "@matrix-os/contracts";
 import { AppError } from "../../../shared/app-error";
 import type { ApiClient } from "./api";
+import { loadNativeDesktopConfig } from "./desktop-config-client";
 
 let cached: { api: ApiClient; state: OsViewStateResponse } | null = null;
 let mutationQueue: Promise<void> = Promise.resolve();
@@ -28,6 +32,31 @@ export async function loadNativeOsViewState(api: ApiClient): Promise<OsViewState
   const state = OsViewStateResponseSchema.parse(await api.get("/api/os-view-state"));
   cached = { api, state };
   return state;
+}
+
+export async function importNativeLegacyDesktopConfig(
+  api: ApiClient,
+  input: LegacyDesktopImport,
+): Promise<OsViewStateResponse> {
+  const legacy = LegacyDesktopImportSchema.parse(input);
+  const state = OsViewStateResponseSchema.parse(
+    await api.post("/api/os-view-state/import-legacy-desktop", legacy),
+  );
+  cached = { api, state };
+  return state;
+}
+
+export async function loadNativeOsViewStateWithLegacyImport(
+  api: ApiClient,
+): Promise<OsViewStateResponse> {
+  if (typeof api.post !== "function") return loadNativeOsViewState(api);
+  try {
+    const legacy = legacyDesktopImportFromConfig(await loadNativeDesktopConfig(api));
+    if (legacy !== null) return await importNativeLegacyDesktopConfig(api, legacy);
+  } catch (error: unknown) {
+    console.warn("[os-view-state] Electron Desktop legacy import failed:", error instanceof Error ? error.name : "UnknownError");
+  }
+  return loadNativeOsViewState(api);
 }
 
 export function primeNativeOsViewState(api: ApiClient, state: OsViewStateResponse): void {

--- a/desktop/src/renderer/src/stores/desktop-icons.ts
+++ b/desktop/src/renderer/src/stores/desktop-icons.ts
@@ -7,7 +7,11 @@ import {
   primeNativeOsViewState,
   resetNativeOsViewStateClientForTests,
 } from "../lib/os-view-state-client";
-import { createDefaultOsViewDocument, OsViewStateResponseSchema } from "@matrix-os/contracts";
+import {
+  createDefaultOsViewDocument,
+  normalizeOsViewDesktopAppPath,
+  OsViewStateResponseSchema,
+} from "@matrix-os/contracts";
 
 export interface DesktopIconPlacement {
   path: string;
@@ -43,9 +47,11 @@ export function parseDesktopIcons(value: unknown): DesktopIconPlacement[] | null
   const icons: DesktopIconPlacement[] = [];
   const seen = new Set<string>();
   for (const raw of value.slice(0, MAX_DESKTOP_ICONS)) {
-    if (!validPlacement(raw) || seen.has(raw.path)) continue;
-    seen.add(raw.path);
-    icons.push({ path: raw.path, x: raw.x, y: raw.y });
+    if (!validPlacement(raw)) continue;
+    const path = normalizeOsViewDesktopAppPath(raw.path);
+    if (seen.has(path)) continue;
+    seen.add(path);
+    icons.push({ path, x: raw.x, y: raw.y });
   }
   return icons;
 }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1137,13 +1137,19 @@ export const ReviewSnapshotSchema = z.object({
 export type ReviewSnapshot = z.infer<typeof ReviewSnapshotSchema>;
 
 export {
+  DEFAULT_OS_VIEW_DESKTOP_APP_PATHS,
+  LegacyDesktopImportSchema,
   OS_VIEW_DESTINATION_PATHS,
   OS_VIEW_LABELS,
   OS_VIEW_MODES,
   isOsViewDestinationPath,
+  legacyDesktopImportFromConfig,
   normalizeOsViewMode,
+  normalizeOsViewDesktopAppPath,
+  normalizeOsViewDesktopIcons,
   otherOsViewMode,
   createDefaultOsViewDocument,
+  createDefaultOsViewDesktopIcons,
   mergeOsViewStatePatch,
   rebaseOsViewStatePatch,
   OsViewAppStateSchema,
@@ -1157,6 +1163,7 @@ export {
   PatchOsViewStateRequestSchema,
 } from "#os-view";
 export type {
+  LegacyDesktopImport,
   OsViewAppState,
   OsViewCanvasTransform,
   OsViewDesktopIcon,

--- a/packages/contracts/src/os-view.ts
+++ b/packages/contracts/src/os-view.ts
@@ -13,6 +13,39 @@ export const OS_VIEW_DESTINATION_PATHS: Readonly<Record<OsViewMode, string>> = {
   canvas: "__os-view-canvas__",
 };
 
+export const DEFAULT_OS_VIEW_DESKTOP_APP_PATHS = Object.freeze([
+  "__chat__",
+  "__terminal__",
+  "__file-browser__",
+  "__editor__",
+  "__vscode__",
+  "__settings__",
+  "__plugins__",
+  "__browser__",
+  "apps/notes/index.html",
+  "apps/whiteboard/index.html",
+] as const);
+
+const DEFAULT_DESKTOP_GRID = Object.freeze({
+  startX: 20,
+  startY: 20,
+  columnWidth: 88,
+  rowHeight: 92,
+  columns: 2,
+});
+
+const OS_VIEW_DESKTOP_APP_PATH_ALIASES: Readonly<Record<string, string>> = Object.freeze({
+  "apps/browser/index.html": "__browser__",
+  "apps/browser/dist/index.html": "__browser__",
+  "__notes__": "apps/notes/index.html",
+  "apps/notes/dist/index.html": "apps/notes/index.html",
+  "apps/whiteboard/dist/index.html": "apps/whiteboard/index.html",
+});
+
+export function normalizeOsViewDesktopAppPath(path: string): string {
+  return OS_VIEW_DESKTOP_APP_PATH_ALIASES[path] ?? path;
+}
+
 export function normalizeOsViewMode(value: unknown): OsViewMode {
   return value === "canvas" ? "canvas" : "desktop";
 }
@@ -50,6 +83,11 @@ export const OsViewDesktopIconSchema = z.object({
   iconKey: z.string().min(1).max(256).optional(),
   x: OsViewCoordinateSchema,
   y: OsViewCoordinateSchema,
+}).strict();
+
+export const LegacyDesktopImportSchema = z.object({
+  pinnedApps: z.array(OsViewPathSchema).max(512).optional(),
+  desktopIcons: z.array(OsViewDesktopIconSchema).max(512).optional(),
 }).strict();
 
 export const OsViewCanvasTransformSchema = z.object({
@@ -102,18 +140,58 @@ export const OsViewStateResponseSchema = z.object({
 export type OsViewAppState = z.infer<typeof OsViewAppStateSchema>;
 export type OsViewWindowGeometry = z.infer<typeof OsViewWindowGeometrySchema>;
 export type OsViewDesktopIcon = z.infer<typeof OsViewDesktopIconSchema>;
+export type LegacyDesktopImport = z.infer<typeof LegacyDesktopImportSchema>;
 export type OsViewCanvasTransform = z.infer<typeof OsViewCanvasTransformSchema>;
 export type OsViewDocument = z.infer<typeof OsViewDocumentSchema>;
 export type OsViewStatePatch = z.infer<typeof OsViewStatePatchSchema>;
 export type PatchOsViewStateRequest = z.infer<typeof PatchOsViewStateRequestSchema>;
 export type OsViewStateResponse = z.infer<typeof OsViewStateResponseSchema>;
 
+export function legacyDesktopImportFromConfig(value: unknown): LegacyDesktopImport | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  const config = value as Record<string, unknown>;
+  const candidate = Object.prototype.hasOwnProperty.call(config, "legacyDesktopImport")
+    ? config.legacyDesktopImport
+    : {
+        ...(Object.prototype.hasOwnProperty.call(config, "pinnedApps")
+          ? { pinnedApps: config.pinnedApps }
+          : {}),
+        ...(Object.prototype.hasOwnProperty.call(config, "desktopIcons")
+          ? { desktopIcons: config.desktopIcons }
+          : {}),
+      };
+  const parsed = LegacyDesktopImportSchema.safeParse(candidate);
+  return parsed.success ? parsed.data : null;
+}
+
+export function normalizeOsViewDesktopIcons(
+  icons: readonly OsViewDesktopIcon[],
+): OsViewDesktopIcon[] {
+  const normalized: OsViewDesktopIcon[] = [];
+  const seen = new Set<string>();
+  for (const icon of icons) {
+    const path = normalizeOsViewDesktopAppPath(icon.path);
+    if (seen.has(path)) continue;
+    seen.add(path);
+    normalized.push({ ...icon, path });
+  }
+  return normalized;
+}
+
+export function createDefaultOsViewDesktopIcons(): OsViewDesktopIcon[] {
+  return DEFAULT_OS_VIEW_DESKTOP_APP_PATHS.map((path, index) => ({
+    path,
+    x: DEFAULT_DESKTOP_GRID.startX + (index % DEFAULT_DESKTOP_GRID.columns) * DEFAULT_DESKTOP_GRID.columnWidth,
+    y: DEFAULT_DESKTOP_GRID.startY + Math.floor(index / DEFAULT_DESKTOP_GRID.columns) * DEFAULT_DESKTOP_GRID.rowHeight,
+  }));
+}
+
 export function createDefaultOsViewDocument(): OsViewDocument {
   return {
     schemaVersion: 1,
     apps: [],
     pinnedApps: [],
-    desktop: { windows: [], icons: [] },
+    desktop: { windows: [], icons: createDefaultOsViewDesktopIcons() },
     canvas: {
       windows: [],
       transform: { panX: 0, panY: 0, zoom: 1 },

--- a/packages/gateway/src/os-view-state/repository.ts
+++ b/packages/gateway/src/os-view-state/repository.ts
@@ -9,11 +9,16 @@ import {
 } from "kysely";
 import pg from "pg";
 import {
+  LegacyDesktopImportSchema,
   OsViewDocumentSchema,
   PatchOsViewStateRequestSchema,
+  createDefaultOsViewDesktopIcons,
   createDefaultOsViewDocument,
   mergeOsViewStatePatch,
+  normalizeOsViewDesktopIcons,
+  type LegacyDesktopImport,
   type OsViewDocument,
+  type OsViewStatePatch,
   type OsViewStateResponse,
   type PatchOsViewStateRequest,
 } from "@matrix-os/contracts";
@@ -27,6 +32,8 @@ interface OsViewStatesTable {
   schema_version: number;
   document: ColumnType<unknown, unknown, unknown>;
   recent_mutation_ids: ColumnType<unknown, unknown | undefined, unknown>;
+  desktop_icons_initialized_at: ColumnType<Date | string, Date | string | undefined, Date | string>;
+  legacy_desktop_imported_at: ColumnType<Date | string | null, Date | string | null | undefined, Date | string | null>;
   created_at: ColumnType<Date | string, Date | string | undefined, Date | string>;
   updated_at: ColumnType<Date | string, Date | string | undefined, Date | string>;
 }
@@ -61,6 +68,51 @@ function mutationIds(row: Selectable<OsViewStatesTable>): string[] {
   return Array.isArray(parsed)
     ? parsed.filter((value): value is string => typeof value === "string").slice(-RECENT_MUTATION_LIMIT)
     : [];
+}
+
+function sameDocumentValue(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function normalizeCachedLegacyMigration(
+  row: Selectable<OsViewStatesTable>,
+  request: PatchOsViewStateRequest,
+): { patch: OsViewStatePatch; markImported: boolean } {
+  const patch: OsViewStatePatch = request.patch.desktop?.icons !== undefined
+    ? {
+        ...request.patch,
+        desktop: {
+          ...request.patch.desktop,
+          icons: normalizeOsViewDesktopIcons(request.patch.desktop.icons),
+        },
+      }
+    : request.patch;
+  if (row.legacy_desktop_imported_at !== null) {
+    return { patch, markImported: false };
+  }
+  const patchKeys = Object.keys(patch);
+  const desktopKeys = Object.keys(patch.desktop ?? {});
+  const matchesLegacyClient = patch.pinnedApps !== undefined
+    && patch.desktop?.icons !== undefined
+    && patchKeys.every((key) => key === "pinnedApps" || key === "desktop")
+    && desktopKeys.every((key) => key === "icons");
+  if (!matchesLegacyClient || request.baseRevision !== 1) {
+    return {
+      patch,
+      markImported: patch.pinnedApps !== undefined || patch.desktop?.icons !== undefined,
+    };
+  }
+
+  const currentDocument = OsViewDocumentSchema.parse(parseJson(row.document, createDefaultOsViewDocument()));
+  const sentIcons = patch.desktop?.icons ?? [];
+  const shouldDiscardPoisonedEmptyIcons = sentIcons.length === 0
+    && sameDocumentValue(currentDocument.desktop.icons, createDefaultOsViewDesktopIcons());
+  return {
+    patch: shouldDiscardPoisonedEmptyIcons
+      ? { pinnedApps: patch.pinnedApps }
+      : patch,
+    markImported: true,
+  };
 }
 
 function toResponse(row: Selectable<OsViewStatesTable>): OsViewStateResponse {
@@ -102,12 +154,40 @@ export class OsViewStateRepository {
         schema_version INTEGER NOT NULL DEFAULT 1,
         document JSONB NOT NULL,
         recent_mutation_ids JSONB NOT NULL DEFAULT '[]',
+        desktop_icons_initialized_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        legacy_desktop_imported_at TIMESTAMPTZ,
         created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
         updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
         PRIMARY KEY (owner_type, owner_id)
       )
     `.execute(this.kysely);
+    await sql`ALTER TABLE os_view_states ADD COLUMN IF NOT EXISTS desktop_icons_initialized_at TIMESTAMPTZ`.execute(this.kysely);
+    await sql`ALTER TABLE os_view_states ADD COLUMN IF NOT EXISTS legacy_desktop_imported_at TIMESTAMPTZ`.execute(this.kysely);
+    const defaultIcons = JSON.stringify(createDefaultOsViewDesktopIcons());
+    const repaired = await sql`
+      UPDATE os_view_states
+      SET document = jsonb_set(document, '{desktop,icons}', ${defaultIcons}::jsonb, false),
+          revision = revision + 1,
+          updated_at = now(),
+          desktop_icons_initialized_at = now(),
+          legacy_desktop_imported_at = now()
+      WHERE desktop_icons_initialized_at IS NULL
+        AND jsonb_typeof(document #> '{desktop,icons}') = 'array'
+        AND jsonb_array_length(document #> '{desktop,icons}') = 0
+    `.execute(this.kysely);
+    await sql`
+      UPDATE os_view_states
+      SET desktop_icons_initialized_at = now(),
+          legacy_desktop_imported_at = now()
+      WHERE desktop_icons_initialized_at IS NULL
+    `.execute(this.kysely);
+    await sql`ALTER TABLE os_view_states ALTER COLUMN desktop_icons_initialized_at SET DEFAULT now()`.execute(this.kysely);
+    await sql`ALTER TABLE os_view_states ALTER COLUMN desktop_icons_initialized_at SET NOT NULL`.execute(this.kysely);
     await sql`CREATE INDEX IF NOT EXISTS idx_os_view_states_updated ON os_view_states(updated_at DESC)`.execute(this.kysely);
+    const repairedCount = Number(repaired.numAffectedRows ?? 0n);
+    if (repairedCount > 0) {
+      console.info(`[os-view-state] Restored default Desktop icons for ${repairedCount} layout${repairedCount === 1 ? "" : "s"}`);
+    }
   }
 
   async destroy(): Promise<void> {
@@ -136,6 +216,48 @@ export class OsViewStateRepository {
       .where("owner_id", "=", ownerId)
       .executeTakeFirstOrThrow();
     return toResponse(existing);
+  }
+
+  async importLegacyDesktop(ownerId: string, input: LegacyDesktopImport): Promise<OsViewStateResponse> {
+    const legacy = LegacyDesktopImportSchema.parse(input);
+    return this.kysely.transaction().execute(async (transaction: Transaction<OsViewStateDatabase>) => {
+      const repository = new OsViewStateRepository(transaction);
+      let current = await repository.getRowForUpdate(ownerId);
+      if (!current) {
+        await repository.getOrCreate(ownerId);
+        current = await repository.getRowForUpdate(ownerId);
+      }
+      if (!current) throw new Error("OS-view state initialization failed");
+      if (current.legacy_desktop_imported_at !== null) return toResponse(current);
+
+      const currentDocument = OsViewDocumentSchema.parse(parseJson(current.document, createDefaultOsViewDocument()));
+      const document = mergeOsViewStatePatch(currentDocument, {
+        ...(legacy.pinnedApps !== undefined ? { pinnedApps: legacy.pinnedApps } : {}),
+        ...(legacy.desktopIcons !== undefined ? {
+          desktop: {
+            icons: normalizeOsViewDesktopIcons(legacy.desktopIcons),
+          },
+        } : {}),
+      });
+      const updated = await repository.kysely
+        .updateTable("os_view_states")
+        .set({
+          document: jsonb(document),
+          revision: sql`revision + 1`,
+          updated_at: sql`now()`,
+          desktop_icons_initialized_at: sql`now()`,
+          legacy_desktop_imported_at: sql`now()`,
+        })
+        .where("owner_type", "=", "user")
+        .where("owner_id", "=", ownerId)
+        .where("legacy_desktop_imported_at", "is", null)
+        .returningAll()
+        .executeTakeFirst();
+      if (updated) return toResponse(updated);
+      const latest = await repository.getRow(ownerId);
+      if (!latest) throw new Error("OS-view state initialization failed");
+      return toResponse(latest);
+    });
   }
 
   async patch(ownerId: string, input: PatchOsViewStateRequest): Promise<OsViewStateResponse> {
@@ -171,8 +293,9 @@ export class OsViewStateRepository {
       throw new OsViewStateConflictError(Number(current.revision));
     }
 
+    const normalized = normalizeCachedLegacyMigration(current, request);
     const currentDocument = OsViewDocumentSchema.parse(parseJson(current.document, createDefaultOsViewDocument()));
-    const document: OsViewDocument = mergeOsViewStatePatch(currentDocument, request.patch);
+    const document: OsViewDocument = mergeOsViewStatePatch(currentDocument, normalized.patch);
     const nextMutationIds = [...recentIds, request.mutationId].slice(-RECENT_MUTATION_LIMIT);
     // The owner document is deliberately one aggregate with one revision:
     // apps and presentation geometry have cross-field invariants and must be
@@ -187,6 +310,7 @@ export class OsViewStateRepository {
         recent_mutation_ids: jsonb(nextMutationIds),
         revision: sql`revision + 1`,
         updated_at: sql`now()`,
+        ...(normalized.markImported ? { legacy_desktop_imported_at: sql`now()` } : {}),
       })
       .where("owner_type", "=", "user")
       .where("owner_id", "=", ownerId)
@@ -206,6 +330,16 @@ export class OsViewStateRepository {
       .selectAll()
       .where("owner_type", "=", "user")
       .where("owner_id", "=", ownerId)
+      .executeTakeFirst();
+  }
+
+  private getRowForUpdate(ownerId: string): Promise<Selectable<OsViewStatesTable> | undefined> {
+    return this.kysely
+      .selectFrom("os_view_states")
+      .selectAll()
+      .where("owner_type", "=", "user")
+      .where("owner_id", "=", ownerId)
+      .forUpdate()
       .executeTakeFirst();
   }
 }

--- a/packages/gateway/src/os-view-state/routes.ts
+++ b/packages/gateway/src/os-view-state/routes.ts
@@ -1,6 +1,12 @@
 import { Hono, type Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
-import { PatchOsViewStateRequestSchema, type OsViewStateResponse, type PatchOsViewStateRequest } from "@matrix-os/contracts";
+import {
+  LegacyDesktopImportSchema,
+  PatchOsViewStateRequestSchema,
+  type LegacyDesktopImport,
+  type OsViewStateResponse,
+  type PatchOsViewStateRequest,
+} from "@matrix-os/contracts";
 import { isRequestPrincipalError, mapRequestPrincipalError } from "../request-principal.js";
 import { OsViewStateConflictError } from "./repository.js";
 
@@ -8,6 +14,7 @@ const OS_VIEW_STATE_BODY_LIMIT = 256 * 1024;
 
 export interface OsViewStateRouteRepository {
   getOrCreate(ownerId: string): Promise<OsViewStateResponse>;
+  importLegacyDesktop(ownerId: string, input: LegacyDesktopImport): Promise<OsViewStateResponse>;
   patch(ownerId: string, request: PatchOsViewStateRequest): Promise<OsViewStateResponse>;
 }
 
@@ -39,6 +46,9 @@ export function createOsViewStateRoutes(deps: {
     if (error instanceof Error && error.message === "missing owner") {
       return context.json({ error: "Unauthorized" }, 401);
     }
+    if (error instanceof Error && error.name === "BodyLimitError") {
+      return context.json({ error: "Request body too large" }, 413);
+    }
     console.error("[os-view-state] Request failed:", error instanceof Error ? error.name : "UnknownError");
     return context.json({ error: "OS-view state request failed" }, 500);
   }
@@ -47,6 +57,19 @@ export function createOsViewStateRoutes(deps: {
     try {
       return context.json(await deps.repository.getOrCreate(ownerId(context)));
     } catch (error: unknown) {
+      return handleError(context, error);
+    }
+  });
+
+  app.post("/import-legacy-desktop", writeBodyLimit, async (context) => {
+    try {
+      const parsed = LegacyDesktopImportSchema.safeParse(await context.req.json());
+      if (!parsed.success) return context.json({ error: "Invalid legacy Desktop import" }, 400);
+      return context.json(await deps.repository.importLegacyDesktop(ownerId(context), parsed.data));
+    } catch (error: unknown) {
+      if (error instanceof SyntaxError) {
+        return context.json({ error: "Invalid legacy Desktop import" }, 400);
+      }
       return handleError(context, error);
     }
   });

--- a/packages/gateway/src/routes/settings.ts
+++ b/packages/gateway/src/routes/settings.ts
@@ -215,11 +215,20 @@ function mergeDesktopDefaults(config: Record<string, unknown>): Record<string, u
   const pinnedApps = Array.isArray(config.pinnedApps)
     ? config.pinnedApps.filter((path): path is string => typeof path === "string" && !RETIRED_DESKTOP_APP_PATHS.has(path))
     : DESKTOP_DEFAULTS.pinnedApps;
+  const legacyDesktopImport = {
+    ...(Object.prototype.hasOwnProperty.call(config, "pinnedApps")
+      ? { pinnedApps: Array.isArray(config.pinnedApps) ? pinnedApps : config.pinnedApps }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(config, "desktopIcons")
+      ? { desktopIcons: config.desktopIcons }
+      : {}),
+  };
   return {
     ...DESKTOP_DEFAULTS,
     ...config,
     dock: { ...DESKTOP_DEFAULTS.dock, ...dock },
     pinnedApps,
+    legacyDesktopImport,
   };
 }
 
@@ -484,11 +493,13 @@ export function createSettingsRoutes(opts: {
     }
     await enqueueDesktopWrite(async () => {
       const current = await readJson<Record<string, unknown>>(desktopPath, {}, "desktop config");
+      const desktopBody = { ...body };
+      delete desktopBody.legacyDesktopImport;
       await writeJsonAtomic(desktopPath, {
-        ...body,
-        pinnedApps: body.pinnedApps === undefined
+        ...desktopBody,
+        pinnedApps: desktopBody.pinnedApps === undefined
           ? current.pinnedApps
-          : preserveRetiredPinnedApps(current.pinnedApps, body.pinnedApps),
+          : preserveRetiredPinnedApps(current.pinnedApps, desktopBody.pinnedApps),
       });
     });
     return c.json({ ok: true });

--- a/shell/src/components/desktop/WebDesktopSurface.tsx
+++ b/shell/src/components/desktop/WebDesktopSurface.tsx
@@ -6,6 +6,10 @@ import { useDesktopConfigStore, type DesktopIconPlacement } from "@/stores/deskt
 import { SHELL_Z_INDEX } from "@/lib/shell-layering";
 import { buildWebDesktopIconApps } from "@/lib/web-desktop-app-launch";
 import {
+  createDefaultOsViewDesktopIcons,
+  normalizeOsViewDesktopAppPath,
+} from "@matrix-os/contracts";
+import {
   Blocks,
   BrushIcon,
   Code2,
@@ -257,19 +261,16 @@ export function WebDesktopSurface({
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const primeDesktopIcons = useDesktopConfigStore((state) => state.primeDesktopIcons);
   const desktopApps = useMemo(() => buildWebDesktopIconApps(apps).slice(0, 10), [apps]);
-  const defaultPlacements = useMemo<DesktopIconPlacement[]>(() => desktopApps.map((app, index) => ({
-    path: app.path,
-    x: 20 + (index % 2) * 88,
-    y: 20 + Math.floor(index / 2) * 92,
-  })), [desktopApps]);
+  const defaultPlacements = useMemo<DesktopIconPlacement[]>(createDefaultOsViewDesktopIcons, []);
   useLayoutEffect(() => {
     if (desktopIcons === undefined) primeDesktopIcons(defaultPlacements);
   }, [defaultPlacements, desktopIcons, primeDesktopIcons]);
   const placements = desktopIcons ?? defaultPlacements;
   const placedApps = useMemo(() => placements.flatMap((placement) => {
-    const app = desktopApps.find((candidate) => candidate.path === placement.path)
-      ?? apps.find((candidate) => candidate.path === placement.path);
-    return app ? [{ app, placement }] : [];
+    const app = desktopApps.find((candidate) => (
+      normalizeOsViewDesktopAppPath(candidate.path) === placement.path
+    )) ?? apps.find((candidate) => normalizeOsViewDesktopAppPath(candidate.path) === placement.path);
+    return app ? [{ app: { ...app, path: placement.path }, placement }] : [];
   }), [apps, desktopApps, placements]);
   const filesApp = apps.find((app) => app.path === "__file-browser__");
   const filesWindow = windows.find((windowRecord) => windowRecord.path === "__file-browser__");

--- a/shell/src/hooks/useDesktopConfig.ts
+++ b/shell/src/hooks/useDesktopConfig.ts
@@ -5,7 +5,6 @@ import { useFileWatcher } from "./useFileWatcher";
 import { getGatewayUrl } from "@/lib/gateway";
 import {
   captureWebDesktopIconsHydrationRevision,
-  scheduleWebDesktopConfigConflictRetry,
   useDesktopConfigStore,
   type DesktopIconPlacement,
   type DockConfig,
@@ -17,10 +16,14 @@ import {
   type ShellSnapshotScope,
 } from "@/lib/shell-snapshot-cache";
 import {
+  importWebLegacyDesktopConfig,
   loadWebOsViewState,
-  OsViewStateConflictExhaustedError,
   patchWebOsViewState,
 } from "@/lib/os-view-state-client";
+import {
+  legacyDesktopImportFromConfig,
+  type LegacyDesktopImport,
+} from "@matrix-os/contracts";
 export type { DockConfig };
 
 export interface DesktopConfig {
@@ -169,7 +172,9 @@ function applyDesktopConfigSnapshot(
   setters.setDock(cfg.dock);
   setters.setPinnedApps(cfg.pinnedApps);
   setters.setDockOrder(cfg.dockOrder);
-  setters.setDesktopIcons(cfg.desktopIcons, desktopIconsHydrationRevision);
+  if (cfg.desktopIcons !== undefined) {
+    setters.setDesktopIcons(cfg.desktopIcons, desktopIconsHydrationRevision);
+  }
   applyBackground(cfg.background, gatewayUrl);
 }
 
@@ -193,7 +198,7 @@ export function useDesktopConfig(options: DesktopConfigHookOptions = {}) {
   useEffect(() => {
     const controller = new AbortController();
     const desktopIconsHydrationRevision = captureWebDesktopIconsHydrationRevision();
-    fetchDesktopConfig(gatewayUrl, controller.signal).then((cfg) => {
+    fetchDesktopConfig(gatewayUrl, controller.signal).then(({ config: cfg, legacyImport }) => {
       if (controller.signal.aborted) return;
       setConfig(cfg);
       applyDesktopConfigSnapshot(
@@ -202,24 +207,18 @@ export function useDesktopConfig(options: DesktopConfigHookOptions = {}) {
         { setDock, setPinnedApps, setDockOrder, setDesktopIcons },
         desktopIconsHydrationRevision,
       );
-      saveShellSnapshot(cacheScope, { desktopConfig: cfg });
+      const currentIcons = useDesktopConfigStore.getState().desktopIcons;
+      saveShellSnapshot(cacheScope, {
+        desktopConfig: cfg.desktopIcons !== undefined || currentIcons === undefined
+          ? cfg
+          : { ...cfg, desktopIcons: currentIcons },
+      });
       const durableHydrationRevision = captureWebDesktopIconsHydrationRevision();
-      void loadWebOsViewState(gatewayUrl, controller.signal).then((osViewState) => {
+      const durableState = legacyImport === null
+        ? loadWebOsViewState(gatewayUrl, controller.signal)
+        : importWebLegacyDesktopConfig(gatewayUrl, legacyImport, controller.signal);
+      void durableState.then((osViewState) => {
         if (controller.signal.aborted) return;
-        if (osViewState.revision === 1) {
-          void patchWebOsViewState(gatewayUrl, {
-            pinnedApps: cfg.pinnedApps,
-            desktop: { icons: cfg.desktopIcons ?? [] },
-          }).catch((error: unknown) => {
-            if (!controller.signal.aborted) {
-              console.warn("[desktop-config] Initial durable migration failed:", error instanceof Error ? error.name : "UnknownError");
-              if (error instanceof OsViewStateConflictExhaustedError) {
-                scheduleWebDesktopConfigConflictRetry(gatewayUrl);
-              }
-            }
-          });
-          return;
-        }
         const durableConfig: DesktopConfig = {
           ...cfg,
           pinnedApps: osViewState.document.pinnedApps,
@@ -231,7 +230,7 @@ export function useDesktopConfig(options: DesktopConfigHookOptions = {}) {
         saveShellSnapshot(cacheScope, { desktopConfig: durableConfig });
       }).catch((error: unknown) => {
         if (!controller.signal.aborted) {
-          console.warn("[desktop-config] Durable hydration failed:", error instanceof Error ? error.name : "UnknownError");
+          console.warn("[desktop-config] Durable import/hydration failed:", error instanceof Error ? error.name : "UnknownError");
         }
       });
     });
@@ -247,13 +246,20 @@ export function useDesktopConfig(options: DesktopConfigHookOptions = {}) {
   useFileWatcher((path, event) => {
     if (path === "system/desktop.json" && event !== "unlink") {
       const desktopIconsHydrationRevision = captureWebDesktopIconsHydrationRevision();
-      fetchDesktopConfig(gatewayUrl).then((cfg) => {
+      fetchDesktopConfig(gatewayUrl).then(({ config: cfg }) => {
         setConfig(cfg);
         setDock(cfg.dock);
         setPinnedApps(cfg.pinnedApps);
         setDockOrder(cfg.dockOrder);
-        setDesktopIcons(cfg.desktopIcons, desktopIconsHydrationRevision);
-        saveShellSnapshot(cacheScope, { desktopConfig: cfg });
+        if (cfg.desktopIcons !== undefined) {
+          setDesktopIcons(cfg.desktopIcons, desktopIconsHydrationRevision);
+        }
+        const currentIcons = useDesktopConfigStore.getState().desktopIcons;
+        saveShellSnapshot(cacheScope, {
+          desktopConfig: cfg.desktopIcons !== undefined || currentIcons === undefined
+            ? cfg
+            : { ...cfg, desktopIcons: currentIcons },
+        });
       });
     }
   });
@@ -266,25 +272,34 @@ function settingsFetchSignal(signal?: AbortSignal): AbortSignal {
   return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 }
 
-async function fetchDesktopConfig(gatewayUrl: string, signal?: AbortSignal): Promise<DesktopConfig> {
+interface DesktopConfigFetchResult {
+  config: DesktopConfig;
+  legacyImport: LegacyDesktopImport | null;
+}
+
+async function fetchDesktopConfig(gatewayUrl: string, signal?: AbortSignal): Promise<DesktopConfigFetchResult> {
   try {
     const res = await fetch(`${gatewayUrl}/api/settings/desktop`, {
       signal: settingsFetchSignal(signal),
     });
     if (res.ok) {
       const data = await res.json();
+      const configData = typeof data === "object" && data !== null && !Array.isArray(data)
+        ? { ...data } as Record<string, unknown>
+        : {};
+      delete configData.legacyDesktopImport;
       const merged = {
         ...DEFAULT_DESKTOP_CONFIG,
-        ...data,
-      };
+        ...configData,
+      } as DesktopConfig;
       merged.dock = { ...merged.dock, autoHide: false };
-      return merged;
+      return { config: merged, legacyImport: legacyDesktopImportFromConfig(data) };
     }
   } catch (err) {
-    if (signal?.aborted) return DEFAULT_DESKTOP_CONFIG;
+    if (signal?.aborted) return { config: DEFAULT_DESKTOP_CONFIG, legacyImport: null };
     console.warn("[desktop-config] failed to load desktop config:", err instanceof Error ? err.message : String(err));
   }
-  return DEFAULT_DESKTOP_CONFIG;
+  return { config: DEFAULT_DESKTOP_CONFIG, legacyImport: null };
 }
 
 export function saveDesktopConfig(config: DesktopConfig): Promise<void>;
@@ -307,7 +322,9 @@ export async function saveDesktopConfig(
     };
     await patchWebOsViewState(gatewayUrl, {
       pinnedApps: normalizedConfig.pinnedApps,
-      desktop: { icons: normalizedConfig.desktopIcons ?? [] },
+      ...(normalizedConfig.desktopIcons !== undefined
+        ? { desktop: { icons: normalizedConfig.desktopIcons } }
+        : {}),
     });
     saveShellSnapshot(options.cacheScope, { desktopConfig: normalizedConfig });
     const store = useDesktopConfigStore.getState();

--- a/shell/src/lib/os-view-state-client.ts
+++ b/shell/src/lib/os-view-state-client.ts
@@ -1,4 +1,5 @@
 import {
+  LegacyDesktopImportSchema,
   OsViewStateResponseSchema,
   createDefaultOsViewDocument,
   mergeOsViewStatePatch,
@@ -6,6 +7,7 @@ import {
   type OsViewStatePatch,
   type OsViewStateResponse,
   type OsViewMode,
+  type LegacyDesktopImport,
 } from "@matrix-os/contracts";
 import type { LayoutWindow } from "@/hooks/useWindowManager";
 
@@ -42,6 +44,45 @@ export async function loadWebOsViewState(
 ): Promise<OsViewStateResponse> {
   const state = await requestState(gatewayUrl, signal);
   cached = { gatewayUrl, state };
+  return state;
+}
+
+export async function importWebLegacyDesktopConfig(
+  gatewayUrl: string,
+  input: LegacyDesktopImport,
+  signal?: AbortSignal,
+): Promise<OsViewStateResponse> {
+  const legacy = LegacyDesktopImportSchema.parse(input);
+  const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  const response = await fetch(`${gatewayUrl}/api/os-view-state/import-legacy-desktop`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    cache: "no-store",
+    signal: signal ? AbortSignal.any([signal, timeout]) : timeout,
+    body: JSON.stringify(legacy),
+  });
+  if (response.ok) {
+    const state = OsViewStateResponseSchema.parse(await response.json());
+    cached = { gatewayUrl, state };
+    return state;
+  }
+  if (response.status !== 404 && response.status !== 405) {
+    throw new Error(`POST /api/os-view-state/import-legacy-desktop ${response.status}`);
+  }
+
+  // Rolling compatibility for a new shell briefly connected to an older
+  // gateway. Preserve absent legacy icons rather than reproducing the old
+  // undefined -> [] migration bug.
+  let state = await requestState(gatewayUrl, signal);
+  cached = { gatewayUrl, state };
+  if (state.revision === 1 && Object.keys(legacy).length > 0) {
+    await patchWebOsViewState(gatewayUrl, {
+      ...(legacy.pinnedApps !== undefined ? { pinnedApps: legacy.pinnedApps } : {}),
+      ...(legacy.desktopIcons !== undefined ? { desktop: { icons: legacy.desktopIcons } } : {}),
+    });
+    state = await requestState(gatewayUrl, signal);
+    cached = { gatewayUrl, state };
+  }
   return state;
 }
 

--- a/shell/src/lib/shell-snapshot-cache.ts
+++ b/shell/src/lib/shell-snapshot-cache.ts
@@ -3,6 +3,7 @@
 import { DEFAULT_PINNED_APPS } from "@/lib/builtin-apps";
 import type { Theme } from "@/hooks/useTheme";
 import type { DesktopConfig } from "@/hooks/useDesktopConfig";
+import { normalizeOsViewDesktopAppPath } from "@matrix-os/contracts";
 
 export const SHELL_SNAPSHOT_STORAGE_PREFIX = "matrix:shell-snapshot:v1";
 const SHELL_SNAPSHOT_VERSION = 1;
@@ -154,10 +155,12 @@ function normalizeThemeSnapshot(value: unknown): Theme | undefined {
 function normalizeDesktopConfigSnapshot(value: unknown): DesktopConfig | undefined {
   if (!isRecord(value)) return undefined;
   const dock = normalizeDock(value.dock);
+  const desktopIcons = normalizeDesktopIconsSnapshot(value.desktopIcons);
   return {
     background: normalizeBackground(value.background),
     dock,
     pinnedApps: normalizeAppPaths(value.pinnedApps, DEFAULT_PINNED_APPS),
+    ...(desktopIcons !== undefined ? { desktopIcons } : {}),
     ...(typeof value.iconStyle === "string" && value.iconStyle.length <= 240 ? { iconStyle: value.iconStyle } : {}),
     ...(isRecord(value.dockOrder)
       ? {
@@ -168,6 +171,25 @@ function normalizeDesktopConfigSnapshot(value: unknown): DesktopConfig | undefin
         }
       : {}),
   };
+}
+
+function normalizeDesktopIconsSnapshot(value: unknown): DesktopConfig["desktopIcons"] {
+  if (!Array.isArray(value)) return undefined;
+  if (value.length === 0) return [];
+  const icons: NonNullable<DesktopConfig["desktopIcons"]> = [];
+  const seen = new Set<string>();
+  for (const entry of value.slice(0, 512)) {
+    if (!isRecord(entry) || typeof entry.path !== "string") continue;
+    const path = normalizeOsViewDesktopAppPath(entry.path.trim());
+    if (!SAFE_APP_PATH.test(path) || path.includes("..") || seen.has(path)) continue;
+    if (!Number.isInteger(entry.x) || !Number.isInteger(entry.y)) continue;
+    const x = entry.x as number;
+    const y = entry.y as number;
+    if (x < 0 || x > 16_384 || y < 0 || y > 16_384) continue;
+    seen.add(path);
+    icons.push({ path, x, y });
+  }
+  return icons.length > 0 ? icons : undefined;
 }
 
 function normalizeBootstrapSnapshot(value: unknown): ShellBootstrapSnapshot | undefined {

--- a/shell/src/lib/web-desktop-app-launch.ts
+++ b/shell/src/lib/web-desktop-app-launch.ts
@@ -2,6 +2,7 @@ import type { AppEntry } from "@/hooks/useWindowManager";
 import type { DesktopMode } from "@/stores/desktop-mode";
 import { iconUrlForSlug } from "@/lib/app-launch";
 import {
+  DEFAULT_OS_VIEW_DESKTOP_APP_PATHS,
   OS_VIEW_DESTINATION_PATHS,
   OS_VIEW_LABELS,
   isOsViewDestinationPath,
@@ -43,8 +44,15 @@ function findCanonicalApp(apps: readonly AppEntry[], paths: readonly string[]): 
   return apps.find((app) => paths.includes(app.path));
 }
 
+function namedDesktopApp(app: AppEntry | undefined, fallback: AppEntry): AppEntry {
+  return app ? { ...app, name: fallback.name } : fallback;
+}
+
 export function buildWebDesktopIconApps(apps: readonly AppEntry[]): AppEntry[] {
   const chat = findCanonicalApp(apps, ["__chat__"]);
+  const browserPaths = ["__browser__", "apps/browser/index.html", "apps/browser/dist/index.html"];
+  const notesPaths = ["apps/notes/index.html", "apps/notes/dist/index.html"];
+  const whiteboardPaths = ["apps/whiteboard/index.html", "apps/whiteboard/dist/index.html"];
   const firstClass: AppEntry[] = [
     chat ? { ...chat, name: "Chat" } : { name: "Chat", path: "__chat__" },
     findCanonicalApp(apps, ["__terminal__"]) ?? { name: "Terminal", path: "__terminal__" },
@@ -53,14 +61,16 @@ export function buildWebDesktopIconApps(apps: readonly AppEntry[]): AppEntry[] {
     { name: "VS Code", path: "__vscode__", iconUrl: "/vscode.png" },
     { name: "Settings", path: "__settings__" },
     { name: "Plugins", path: "__plugins__" },
-    findCanonicalApp(apps, ["apps/browser/index.html", "apps/browser/dist/index.html"])
-      ?? { name: "Browser", path: "__browser__" },
-    findCanonicalApp(apps, ["apps/notes/index.html", "apps/notes/dist/index.html"])
-      ?? { name: "Notes", path: "apps/notes/index.html" },
-    findCanonicalApp(apps, ["apps/whiteboard/index.html", "apps/whiteboard/dist/index.html"])
-      ?? { name: "Whiteboard", path: "apps/whiteboard/index.html" },
+    namedDesktopApp(findCanonicalApp(apps, browserPaths), { name: "Browser", path: "__browser__" }),
+    namedDesktopApp(findCanonicalApp(apps, notesPaths), { name: "Notes", path: "apps/notes/index.html" }),
+    namedDesktopApp(findCanonicalApp(apps, whiteboardPaths), { name: "Whiteboard", path: "apps/whiteboard/index.html" }),
   ];
-  const firstClassPaths = new Set(firstClass.map((app) => app.path));
+  const firstClassPaths = new Set([
+    ...DEFAULT_OS_VIEW_DESKTOP_APP_PATHS,
+    ...browserPaths,
+    ...notesPaths,
+    ...whiteboardPaths,
+  ]);
   return [...firstClass, ...apps.filter((app) => !firstClassPaths.has(app.path))];
 }
 

--- a/shell/src/stores/desktop-config.ts
+++ b/shell/src/stores/desktop-config.ts
@@ -6,6 +6,7 @@ import {
   resetWebOsViewStateClientForTests,
 } from "@/lib/os-view-state-client";
 import { DEFAULT_PINNED_APPS } from "@/lib/builtin-apps";
+import { normalizeOsViewDesktopIcons } from "@matrix-os/contracts";
 
 export interface DockConfig {
   position: "left" | "right" | "bottom";
@@ -84,7 +85,7 @@ export function resetWebDesktopIconsRuntime(): void {
 }
 
 function copyDesktopIcons(icons: readonly DesktopIconPlacement[] | undefined): DesktopIconPlacement[] | undefined {
-  return icons?.map((icon) => ({ ...icon }));
+  return icons ? normalizeOsViewDesktopIcons(icons) : undefined;
 }
 
 function persistDesktopPatch(patch: Record<string, unknown>): Promise<void> {

--- a/specs/119-os-view-parity/spec.md
+++ b/specs/119-os-view-parity/spec.md
@@ -62,6 +62,8 @@ Durable writes that update multiple related records use one transaction. Revisio
 
 The OS-view document is intentionally a coarse owner aggregate with one revision. App state and presentation geometry have cross-field invariants and are read atomically, so a validated partial PATCH is merged into the latest complete document and committed as one JSONB value. Concurrent writers that started from the same revision serialize: the loser receives a conflict, reloads the latest aggregate, three-way rebases path-keyed collection and field changes over that document, and retries with the same mutation ID. This preserves independent same-collection edits as well as separate Desktop and Canvas changes without lost updates. Targeting individual JSONB paths while retaining one aggregate revision would not reduce contention; moving to path-level writes requires a separately reviewed per-entity or per-namespace revision model.
 
+Desktop icon initialization is explicit and distinct from an intentionally empty layout. New owner documents begin with the shared ten-icon canonical layout. A one-time, owner-scoped legacy import copies only fields actually present in `system/desktop.json`; absence never becomes an empty icon array. Internal initialization markers make the import and the recovery of legacy empty rows idempotent, while later user-authored empty layouts remain durable. Web and Electron use the same canonical icon paths and coordinates, and client snapshots may accelerate first paint but never outrank the PostgreSQL document.
+
 ## Workspace Canvas retirement
 
 Workspace Canvas is retired from navigation, built-in registration, product copy, and new creation flows. The retirement must not delete existing owner data. Existing records remain exportable and recoverable until a separately reviewed data-lifecycle migration defines user-visible export, deletion, and cleanup behavior.
@@ -88,6 +90,12 @@ The retirement sequence is:
 ## Security and integration wiring
 
 This contract introduces no unauthenticated route. New persistence endpoints must use the authenticated owner principal, `bodyLimit`, bounded Zod schemas, generic client errors, and owner-scoped Kysely queries. Browser WebSocket routes must use the registered query-token path because browsers cannot attach authorization headers to upgrades.
+
+| Route | Method | Authentication | Validation and limits |
+| --- | --- | --- | --- |
+| `/api/os-view-state` | GET | Authenticated owner principal | Owner-scoped read; schema-v1 response |
+| `/api/os-view-state` | PATCH | Authenticated owner principal | 256 KiB `bodyLimit`; bounded revisioned patch schema |
+| `/api/os-view-state/import-legacy-desktop` | POST | Authenticated owner principal | 256 KiB `bodyLimit`; strict bounded legacy Desktop schema; one-time marker predicate |
 
 At runtime:
 

--- a/tests/contracts/os-view.test.ts
+++ b/tests/contracts/os-view.test.ts
@@ -1,17 +1,65 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_OS_VIEW_DESKTOP_APP_PATHS,
+  LegacyDesktopImportSchema,
   PatchOsViewStateRequestSchema,
+  createDefaultOsViewDesktopIcons,
   createDefaultOsViewDocument,
   OS_VIEW_DESTINATION_PATHS,
   OS_VIEW_LABELS,
   isOsViewDestinationPath,
+  legacyDesktopImportFromConfig,
   mergeOsViewStatePatch,
   normalizeOsViewMode,
+  normalizeOsViewDesktopAppPath,
+  normalizeOsViewDesktopIcons,
   otherOsViewMode,
   rebaseOsViewStatePatch,
 } from "@matrix-os/contracts";
 
 describe("shared OS-view contract", () => {
+  it("defines one canonical ten-icon Desktop layout for every renderer", () => {
+    expect(DEFAULT_OS_VIEW_DESKTOP_APP_PATHS).toEqual([
+      "__chat__",
+      "__terminal__",
+      "__file-browser__",
+      "__editor__",
+      "__vscode__",
+      "__settings__",
+      "__plugins__",
+      "__browser__",
+      "apps/notes/index.html",
+      "apps/whiteboard/index.html",
+    ]);
+    expect(createDefaultOsViewDesktopIcons()).toEqual(
+      DEFAULT_OS_VIEW_DESKTOP_APP_PATHS.map((path, index) => ({
+        path,
+        x: 20 + (index % 2) * 88,
+        y: 20 + Math.floor(index / 2) * 92,
+      })),
+    );
+    expect(createDefaultOsViewDocument().desktop.icons).toEqual(createDefaultOsViewDesktopIcons());
+    expect(normalizeOsViewDesktopAppPath("__notes__")).toBe("apps/notes/index.html");
+    expect(normalizeOsViewDesktopAppPath("apps/whiteboard/dist/index.html")).toBe("apps/whiteboard/index.html");
+    expect(normalizeOsViewDesktopIcons([
+      { path: "__notes__", x: 20, y: 20 },
+      { path: "apps/notes/index.html", x: 108, y: 20 },
+    ])).toEqual([{ path: "apps/notes/index.html", x: 20, y: 20 }]);
+    expect(LegacyDesktopImportSchema.parse({})).toEqual({});
+    expect(legacyDesktopImportFromConfig({ background: { type: "solid" } })).toEqual({});
+    expect(legacyDesktopImportFromConfig({ pinnedApps: ["__chat__"] })).toEqual({ pinnedApps: ["__chat__"] });
+    expect(legacyDesktopImportFromConfig({ desktopIcons: [] })).toEqual({ desktopIcons: [] });
+    expect(legacyDesktopImportFromConfig({ desktopIcons: "invalid" })).toBeNull();
+    expect(legacyDesktopImportFromConfig({
+      pinnedApps: ["__terminal__", "__file-browser__", "__chat__"],
+      legacyDesktopImport: {},
+    })).toEqual({});
+    expect(legacyDesktopImportFromConfig({
+      pinnedApps: ["__terminal__", "__file-browser__", "__chat__"],
+      legacyDesktopImport: { pinnedApps: ["__chat__"], desktopIcons: [] },
+    })).toEqual({ pinnedApps: ["__chat__"], desktopIcons: [] });
+  });
+
   it("defines the same launcher destinations for Web and Electron clients", () => {
     expect(OS_VIEW_LABELS).toEqual({ desktop: "Desktop", canvas: "Canvas" });
     expect(OS_VIEW_DESTINATION_PATHS).toEqual({

--- a/tests/desktop/app-launcher.test.tsx
+++ b/tests/desktop/app-launcher.test.tsx
@@ -139,7 +139,7 @@ describe("AppLauncher", () => {
     fireEvent.contextMenu(screen.getByRole("button", { name: "Notes" }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Add Notes to Desktop" }));
 
-    expect(onAddToDesktop).toHaveBeenCalledWith("__notes__");
+    expect(onAddToDesktop).toHaveBeenCalledWith("apps/notes/index.html");
   });
 
   it("keeps the focused launcher search field free of a nested focus ring", () => {

--- a/tests/desktop/desktop-default-apps.test.ts
+++ b/tests/desktop/desktop-default-apps.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { DEFAULT_OS_VIEW_DESKTOP_APP_PATHS } from "@matrix-os/contracts";
 import { FIXED_DESKTOP_APPS } from "@desktop/renderer/src/features/desktop-shell/desktop-apps";
 
 describe("native desktop default apps", () => {
@@ -15,6 +16,7 @@ describe("native desktop default apps", () => {
       "notes",
       "whiteboard",
     ]);
+    expect(FIXED_DESKTOP_APPS.map((app) => app.path)).toEqual(DEFAULT_OS_VIEW_DESKTOP_APP_PATHS);
   });
 
   it("keeps every desktop destination identity unique even when surfaces are shared", () => {

--- a/tests/desktop/os-view-state-client.test.ts
+++ b/tests/desktop/os-view-state-client.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDefaultOsViewDocument } from "@matrix-os/contracts";
 import { AppError } from "../../desktop/src/shared/app-error";
 import {
+  importNativeLegacyDesktopConfig,
   patchNativeOsViewState,
   resetNativeOsViewStateClientForTests,
 } from "@desktop/renderer/src/lib/os-view-state-client";
@@ -14,6 +15,22 @@ const latest = {
 
 describe("Electron Desktop OS-view state client", () => {
   beforeEach(() => resetNativeOsViewStateClientForTests());
+
+  it("imports only present legacy Desktop fields and primes the durable cache", async () => {
+    const imported = { ...latest, revision: 2 };
+    const api = {
+      post: vi.fn(async () => imported),
+    };
+
+    await expect(importNativeLegacyDesktopConfig(api as never, {
+      pinnedApps: ["__chat__"],
+    })).resolves.toEqual(imported);
+
+    expect(api.post).toHaveBeenCalledWith(
+      "/api/os-view-state/import-legacy-desktop",
+      { pinnedApps: ["__chat__"] },
+    );
+  });
 
   it("reloads and retries the same mutation after a revision conflict", async () => {
     const latestAfterConflict = {
@@ -46,12 +63,7 @@ describe("Electron Desktop OS-view state client", () => {
     expect(retried.baseRevision).toBe(6);
     expect(retried.mutationId).toBe(first.mutationId);
     expect(retried.patch).toEqual({
-      desktop: {
-        icons: [
-          { path: "__terminal__", x: 40, y: 50 },
-          { path: "__chat__", x: 20, y: 30 },
-        ],
-      },
+      desktop: { icons: [{ path: "__chat__", x: 20, y: 30 }] },
     });
     expect(api.patch.mock.calls[2][1].baseRevision).toBe(9);
   });

--- a/tests/desktop/use-native-os-view-persistence.test.tsx
+++ b/tests/desktop/use-native-os-view-persistence.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useNativeOsViewPersistence } from "@desktop/renderer/src/features/desktop-shell/use-native-os-view-persistence";
 import { resetNativeOsViewStateClientForTests } from "@desktop/renderer/src/lib/os-view-state-client";
 import { useDesktopSurfaces } from "@desktop/renderer/src/stores/desktop-surfaces";
+import { resetDesktopIconsRuntime, useDesktopIcons } from "@desktop/renderer/src/stores/desktop-icons";
 import { useTabs } from "@desktop/renderer/src/stores/tabs";
 
 const loadedState = {
@@ -17,6 +18,8 @@ const loadedState = {
 describe("Electron OS-view persistence hook", () => {
   beforeEach(() => {
     resetNativeOsViewStateClientForTests();
+    resetDesktopIconsRuntime();
+    useDesktopIcons.setState(useDesktopIcons.getInitialState(), true);
     useTabs.setState(useTabs.getInitialState(), true);
     useDesktopSurfaces.setState(useDesktopSurfaces.getInitialState(), true);
   });
@@ -25,7 +28,8 @@ describe("Electron OS-view persistence hook", () => {
 
   it("retries a fresh native snapshot after a persistence failure", async () => {
     const api = {
-      get: vi.fn(async () => loadedState),
+      get: vi.fn(async (path: string) => path === "/api/settings/desktop" ? {} : loadedState),
+      post: vi.fn(async () => loadedState),
       patch: vi.fn()
         .mockRejectedValueOnce(new Error("offline"))
         .mockResolvedValueOnce({ ...loadedState, revision: 2 }),
@@ -64,5 +68,39 @@ describe("Electron OS-view persistence hook", () => {
     expect(api.patch.mock.calls[1][1].patch.desktop.windows).toEqual([
       { path: "__chat__", x: 40, y: 60, width: 900, height: 640 },
     ]);
+  });
+
+  it("imports exact legacy fields once and hydrates icons from PostgreSQL", async () => {
+    const document = createDefaultOsViewDocument();
+    document.desktop.icons = [{ path: "__terminal__", x: 44, y: 55 }];
+    const importedState = { ...loadedState, document };
+    const api = {
+      get: vi.fn(async (path: string) => path === "/api/settings/desktop"
+        ? {
+            background: { type: "solid", color: "#123456" },
+            pinnedApps: ["__terminal__", "__file-browser__", "__chat__"],
+            legacyDesktopImport: { pinnedApps: ["__chat__"] },
+          }
+        : importedState),
+      post: vi.fn(async () => importedState),
+    };
+    const defaultIconLayout = createDefaultOsViewDocument().desktop.icons;
+
+    const { result } = renderHook(() => useNativeOsViewPersistence({
+      api: api as never,
+      tabs: [],
+      surfaces: {},
+      installedApps: [],
+      mode: "desktop",
+      viewport: { width: 1200, height: 800 },
+      defaultIconLayout,
+    }));
+
+    await waitFor(() => expect(result.current.durableState).toEqual(importedState));
+    expect(useDesktopIcons.getState().icons).toEqual([{ path: "__terminal__", x: 44, y: 55 }]);
+    expect(api.post).toHaveBeenCalledWith(
+      "/api/os-view-state/import-legacy-desktop",
+      { pinnedApps: ["__chat__"] },
+    );
   });
 });

--- a/tests/gateway/os-view-state-repository.test.ts
+++ b/tests/gateway/os-view-state-repository.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { KyselyPGlite } from "kysely-pglite";
+import { sql } from "kysely";
+import { createDefaultOsViewDesktopIcons } from "@matrix-os/contracts";
 import {
   OsViewStateConflictError,
   OsViewStateRepository,
@@ -33,6 +35,127 @@ describe("OS-view state repository", () => {
     });
     expect(updated.document.pinnedApps).toEqual(["__chat__"]);
     expect((await repository.getOrCreate("bob")).document.pinnedApps).toEqual([]);
+  });
+
+  it("repairs a pre-marker empty icon layout exactly once", async () => {
+    const initial = await repository.getOrCreate("alice");
+    const emptied = await repository.patch("alice", {
+      baseRevision: initial.revision,
+      mutationId: `osvm_${"0".repeat(32)}`,
+      patch: { desktop: { icons: [] } },
+    });
+    await sql`ALTER TABLE os_view_states ALTER COLUMN desktop_icons_initialized_at DROP NOT NULL`.execute(repository.kysely);
+    await sql`UPDATE os_view_states
+      SET desktop_icons_initialized_at = NULL, legacy_desktop_imported_at = NULL
+      WHERE owner_id = 'alice'`.execute(repository.kysely);
+
+    await repository.bootstrap();
+
+    const repaired = await repository.getOrCreate("alice");
+    expect(repaired.revision).toBe(emptied.revision + 1);
+    expect(repaired.document.desktop.icons).toEqual(createDefaultOsViewDesktopIcons());
+
+    const intentionallyEmpty = await repository.patch("alice", {
+      baseRevision: repaired.revision,
+      mutationId: `osvm_${"9".repeat(32)}`,
+      patch: { desktop: { icons: [] } },
+    });
+    await repository.bootstrap();
+    expect((await repository.getOrCreate("alice"))).toMatchObject({
+      revision: intentionallyEmpty.revision,
+      document: { desktop: { icons: [] } },
+    });
+  });
+
+  it("marks customized pre-marker layouts without changing their order or revision", async () => {
+    const initial = await repository.getOrCreate("alice");
+    const custom = [{ path: "__terminal__", x: 333, y: 444 }];
+    const customized = await repository.patch("alice", {
+      baseRevision: initial.revision,
+      mutationId: `osvm_${"8".repeat(32)}`,
+      patch: { desktop: { icons: custom } },
+    });
+    await sql`ALTER TABLE os_view_states ALTER COLUMN desktop_icons_initialized_at DROP NOT NULL`.execute(repository.kysely);
+    await sql`UPDATE os_view_states
+      SET desktop_icons_initialized_at = NULL, legacy_desktop_imported_at = NULL
+      WHERE owner_id = 'alice'`.execute(repository.kysely);
+
+    await repository.bootstrap();
+
+    expect(await repository.getOrCreate("alice")).toMatchObject({
+      revision: customized.revision,
+      document: { desktop: { icons: custom } },
+    });
+  });
+
+  it("imports only present legacy fields once and preserves defaults when icons are absent", async () => {
+    const defaults = createDefaultOsViewDesktopIcons();
+    const imported = await repository.importLegacyDesktop("alice", {
+      pinnedApps: ["__chat__"],
+    });
+    const repeated = await repository.importLegacyDesktop("alice", {
+      pinnedApps: ["__terminal__"],
+      desktopIcons: [],
+    });
+
+    expect(imported.document.pinnedApps).toEqual(["__chat__"]);
+    expect(imported.document.desktop.icons).toEqual(defaults);
+    expect(repeated).toEqual(imported);
+  });
+
+  it("serializes concurrent legacy imports and applies exactly one payload", async () => {
+    await repository.getOrCreate("alice");
+
+    const [first, second] = await Promise.all([
+      repository.importLegacyDesktop("alice", { pinnedApps: ["__chat__"] }),
+      repository.importLegacyDesktop("alice", { pinnedApps: ["__terminal__"] }),
+    ]);
+
+    expect(second).toEqual(first);
+    expect([["__chat__"], ["__terminal__"]]).toContainEqual(first.document.pinnedApps);
+    expect((await repository.getOrCreate("alice")).revision).toBe(2);
+  });
+
+  it("preserves an explicit empty legacy icon layout", async () => {
+    const imported = await repository.importLegacyDesktop("alice", {
+      pinnedApps: [],
+      desktopIcons: [],
+    });
+
+    expect(imported.document.desktop.icons).toEqual([]);
+    expect((await repository.getOrCreate("alice")).document.desktop.icons).toEqual([]);
+  });
+
+  it("lets a current icon write preempt a later legacy import", async () => {
+    const initial = await repository.getOrCreate("alice");
+    const emptied = await repository.patch("alice", {
+      baseRevision: initial.revision,
+      mutationId: `osvm_${"6".repeat(32)}`,
+      patch: { desktop: { icons: [] } },
+    });
+
+    const afterImport = await repository.importLegacyDesktop("alice", {
+      desktopIcons: createDefaultOsViewDesktopIcons(),
+    });
+
+    expect(afterImport).toEqual(emptied);
+    expect(afterImport.document.desktop.icons).toEqual([]);
+  });
+
+  it("discards the poisoned empty migration signature from a cached old client", async () => {
+    const initial = await repository.getOrCreate("alice");
+    const migrated = await repository.patch("alice", {
+      baseRevision: initial.revision,
+      mutationId: `osvm_${"7".repeat(32)}`,
+      patch: { pinnedApps: ["__chat__"], desktop: { icons: [] } },
+    });
+
+    expect(migrated.document.pinnedApps).toEqual(["__chat__"]);
+    expect(migrated.document.desktop.icons).toEqual(createDefaultOsViewDesktopIcons());
+    await expect(repository.importLegacyDesktop("alice", {
+      pinnedApps: [],
+      desktopIcons: [],
+    })).resolves.toEqual(migrated);
   });
 
   it("enforces the revision in the update and reports the latest revision", async () => {

--- a/tests/gateway/os-view-state-routes.test.ts
+++ b/tests/gateway/os-view-state-routes.test.ts
@@ -7,6 +7,7 @@ import { OsViewStateConflictError } from "../../packages/gateway/src/os-view-sta
 function appFor(repository: {
   getOrCreate: ReturnType<typeof vi.fn>;
   patch: ReturnType<typeof vi.fn>;
+  importLegacyDesktop: ReturnType<typeof vi.fn>;
 }, ownerId = "owner-1") {
   const app = new Hono();
   app.route("/api/os-view-state", createOsViewStateRoutes({ repository, getOwnerId: () => ownerId }));
@@ -21,7 +22,7 @@ const record = {
 
 describe("OS-view state routes", () => {
   it("loads the authenticated owner's document", async () => {
-    const repository = { getOrCreate: vi.fn(async () => record), patch: vi.fn() };
+    const repository = { getOrCreate: vi.fn(async () => record), patch: vi.fn(), importLegacyDesktop: vi.fn() };
     const response = await appFor(repository).request("/api/os-view-state");
 
     expect(response.status).toBe(200);
@@ -30,7 +31,7 @@ describe("OS-view state routes", () => {
   });
 
   it("validates a bounded mutation before writing", async () => {
-    const repository = { getOrCreate: vi.fn(), patch: vi.fn() };
+    const repository = { getOrCreate: vi.fn(), patch: vi.fn(), importLegacyDesktop: vi.fn() };
     const response = await appFor(repository).request("/api/os-view-state", {
       method: "PATCH",
       headers: { "content-type": "application/json" },
@@ -46,6 +47,7 @@ describe("OS-view state routes", () => {
     const repository = {
       getOrCreate: vi.fn(),
       patch: vi.fn(async () => { throw new OsViewStateConflictError(7); }),
+      importLegacyDesktop: vi.fn(),
     };
     const response = await appFor(repository).request("/api/os-view-state", {
       method: "PATCH",
@@ -62,8 +64,71 @@ describe("OS-view state routes", () => {
   });
 
   it("requires a resolved owner", async () => {
-    const repository = { getOrCreate: vi.fn(), patch: vi.fn() };
+    const repository = { getOrCreate: vi.fn(), patch: vi.fn(), importLegacyDesktop: vi.fn() };
     const response = await appFor(repository, "").request("/api/os-view-state");
     expect(response.status).toBe(401);
+  });
+
+  it("imports bounded legacy Desktop fields for the authenticated owner", async () => {
+    const repository = {
+      getOrCreate: vi.fn(),
+      patch: vi.fn(),
+      importLegacyDesktop: vi.fn(async () => record),
+    };
+    const response = await appFor(repository).request("/api/os-view-state/import-legacy-desktop", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ pinnedApps: ["__chat__"] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(repository.importLegacyDesktop).toHaveBeenCalledWith("owner-1", { pinnedApps: ["__chat__"] });
+    await expect(response.json()).resolves.toEqual(record);
+  });
+
+  it("marks a legacy Desktop source with no layout fields as imported", async () => {
+    const repository = {
+      getOrCreate: vi.fn(),
+      patch: vi.fn(),
+      importLegacyDesktop: vi.fn(async () => record),
+    };
+    const response = await appFor(repository).request("/api/os-view-state/import-legacy-desktop", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+
+    expect(response.status).toBe(200);
+    expect(repository.importLegacyDesktop).toHaveBeenCalledWith("owner-1", {});
+  });
+
+  it("rejects invalid legacy imports before writing", async () => {
+    const repository = { getOrCreate: vi.fn(), patch: vi.fn(), importLegacyDesktop: vi.fn() };
+    const response = await appFor(repository).request("/api/os-view-state/import-legacy-desktop", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ desktopIcons: [{ path: "", x: -1, y: 0 }] }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(repository.importLegacyDesktop).not.toHaveBeenCalled();
+  });
+
+  it("requires an owner and applies the import body limit", async () => {
+    const repository = { getOrCreate: vi.fn(), patch: vi.fn(), importLegacyDesktop: vi.fn() };
+    const unauthorized = await appFor(repository, "").request("/api/os-view-state/import-legacy-desktop", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    const oversized = await appFor(repository).request("/api/os-view-state/import-legacy-desktop", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ pinnedApps: ["a".repeat(256 * 1024)] }),
+    });
+
+    expect(unauthorized.status).toBe(401);
+    expect(oversized.status).toBe(413);
+    expect(repository.importLegacyDesktop).not.toHaveBeenCalled();
   });
 });

--- a/tests/gateway/settings-desktop.test.ts
+++ b/tests/gateway/settings-desktop.test.ts
@@ -63,6 +63,7 @@ describe("Settings: desktop + theme + wallpapers", () => {
         autoHide: false,
       });
       expect(data.pinnedApps).toEqual(["__terminal__", "__file-browser__", "__chat__"]);
+      expect(data.legacyDesktopImport).toEqual({});
     });
 
     it("returns saved config merged with defaults when desktop.json exists", async () => {
@@ -81,6 +82,22 @@ describe("Settings: desktop + theme + wallpapers", () => {
       expect(data.background.type).toBe("solid");
       expect(data.dock.position).toBe("bottom");
       expect(data.pinnedApps).toEqual(["__terminal__", "apps/notes/index.html"]);
+      expect(data.legacyDesktopImport).toEqual({
+        pinnedApps: ["__terminal__", "apps/notes/index.html"],
+      });
+    });
+
+    it("reports an explicitly empty legacy icon layout without inventing absent pins", async () => {
+      writeFileSync(
+        join(homePath, "system/desktop.json"),
+        JSON.stringify({ desktopIcons: [] }),
+      );
+
+      const res = await app.request("/api/settings/desktop");
+      const data = await res.json();
+
+      expect(data.pinnedApps).toEqual(["__terminal__", "__file-browser__", "__chat__"]);
+      expect(data.legacyDesktopImport).toEqual({ desktopIcons: [] });
     });
   });
 
@@ -112,6 +129,7 @@ describe("Settings: desktop + theme + wallpapers", () => {
       const config = {
         background: { type: "gradient", from: "#000", to: "#fff" },
         dock: { position: "left", size: 56, iconSize: 40, autoHide: false },
+        legacyDesktopImport: { pinnedApps: ["__chat__"] },
       };
       const res = await app.request("/api/settings/desktop", {
         method: "PUT",
@@ -126,6 +144,7 @@ describe("Settings: desktop + theme + wallpapers", () => {
         readFileSync(join(homePath, "system/desktop.json"), "utf-8"),
       );
       expect(saved.background.type).toBe("gradient");
+      expect(saved.legacyDesktopImport).toBeUndefined();
     });
 
     it("rejects invalid JSON body", async () => {

--- a/tests/shell/desktop-config.test.ts
+++ b/tests/shell/desktop-config.test.ts
@@ -20,7 +20,7 @@ import {
   type DesktopConfig,
 } from "../../shell/src/hooks/useDesktopConfig";
 import { createShellSnapshotScope, loadShellSnapshot, saveShellSnapshot } from "../../shell/src/lib/shell-snapshot-cache";
-import { createDefaultOsViewDocument } from "@matrix-os/contracts";
+import { createDefaultOsViewDesktopIcons, createDefaultOsViewDocument } from "@matrix-os/contracts";
 
 function createMemoryStorage(): Storage {
   const values = new Map<string, string>();
@@ -473,6 +473,58 @@ describe("Desktop config", () => {
     expect(useDesktopConfigStore.getState().dock.position).toBe("bottom");
     await waitFor(() => expect(result.current.background).toEqual({ type: "wallpaper", name: "fresh-wallpaper.jpg" }));
     expect(loadShellSnapshot(scope)?.desktopConfig?.pinnedApps).toEqual(["apps/fresh/index.html"]);
+  });
+
+  it("keeps cached Desktop icons visible while legacy settings without icons hydrate", async () => {
+    const scope = createShellSnapshotScope({ userId: "user_123", pathname: "/" });
+    expect(scope).not.toBeNull();
+    const icons = createDefaultOsViewDesktopIcons();
+    saveShellSnapshot(scope, {
+      desktopConfig: {
+        background: { type: "wallpaper", name: "cached-wallpaper.jpg" },
+        dock: { position: "left", size: 56, iconSize: 40, autoHide: false },
+        pinnedApps: [],
+        desktopIcons: icons,
+      },
+    });
+    let resolveImport: ((value: unknown) => void) | undefined;
+    const importResponse = new Promise((resolve) => { resolveImport = resolve; });
+    const fetchMock = vi.fn((url: string) => {
+      if (url.includes("/api/settings/desktop")) return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          background: { type: "wallpaper", name: "fresh-wallpaper.jpg" },
+          dock: { position: "left", size: 56, iconSize: 40, autoHide: false },
+          pinnedApps: ["__terminal__", "__file-browser__", "__chat__"],
+          legacyDesktopImport: {},
+        }),
+      });
+      if (url.includes("/api/os-view-state/import-legacy-desktop")) return importResponse;
+      return Promise.resolve({ ok: false, status: 503 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useDesktopConfig({ cacheScope: scope }));
+
+    expect(useDesktopConfigStore.getState().desktopIcons).toEqual(icons);
+    await waitFor(() => expect(fetchMock.mock.calls.some(([url]) => (
+      String(url).includes("/api/os-view-state/import-legacy-desktop")
+    ))).toBe(true));
+    expect(useDesktopConfigStore.getState().desktopIcons).toEqual(icons);
+    const importCall = fetchMock.mock.calls.find(([url]) => String(url).includes("/api/os-view-state/import-legacy-desktop"));
+    expect(JSON.parse(importCall?.[1]?.body)).toEqual({});
+
+    resolveImport?.({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        revision: 2,
+        document: createDefaultOsViewDocument(),
+        updatedAt: "2026-08-30T12:00:00.000Z",
+      }),
+    });
+    await waitFor(() => expect(loadShellSnapshot(scope)?.desktopConfig?.desktopIcons).toEqual(icons));
   });
 
   it("keeps the active OS wallpaper when a second desktop-config consumer mounts", async () => {

--- a/tests/shell/os-view-state-client.test.ts
+++ b/tests/shell/os-view-state-client.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDefaultOsViewDocument } from "@matrix-os/contracts";
 import {
+  importWebLegacyDesktopConfig,
   layoutWindowsFromOsViewState,
   patchWebOsViewState,
   resetWebOsViewStateClientForTests,
@@ -14,6 +15,24 @@ const latest = {
 
 describe("Web OS-view state client", () => {
   beforeEach(() => resetWebOsViewStateClientForTests());
+
+  it("imports only present legacy Desktop fields and caches the returned state", async () => {
+    const imported = { ...latest, revision: 2 };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => imported,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(importWebLegacyDesktopConfig("http://gateway.test", {
+      pinnedApps: ["__chat__"],
+    })).resolves.toEqual(imported);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe("http://gateway.test/api/os-view-state/import-legacy-desktop");
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ pinnedApps: ["__chat__"] });
+  });
 
   it("restores shared open apps from the other presentation when selected geometry is empty", () => {
     const document = createDefaultOsViewDocument();

--- a/tests/shell/shell-snapshot-cache.test.ts
+++ b/tests/shell/shell-snapshot-cache.test.ts
@@ -20,6 +20,10 @@ const freshSnapshot = {
     background: { type: "wallpaper", name: "cached-wallpaper.jpg" },
     dock: { position: "bottom", size: 64, iconSize: 44, autoHide: false },
     pinnedApps: ["apps/notes/index.html"],
+    desktopIcons: [
+      { path: "__chat__", x: 20, y: 20 },
+      { path: "apps/notes/index.html", x: 108, y: 20 },
+    ],
   },
   bootstrap: {
     layout: { windows: [{ id: "w1", path: "__terminal__", title: "Terminal" }] },
@@ -61,6 +65,10 @@ describe("shell snapshot cache", () => {
     expect(primary?.storageKey).toContain(SHELL_SNAPSHOT_STORAGE_PREFIX);
     expect(primary?.storageKey).not.toBe(vm?.storageKey);
     expect(primary?.storageKey).not.toBe(otherUser?.storageKey);
+
+    saveShellSnapshot(primary, freshSnapshot, storage);
+    expect(loadShellSnapshot(vm, storage)).toBeNull();
+    expect(loadShellSnapshot(otherUser, storage)).toBeNull();
   });
 
   it("does not create a readable cache scope without a loaded user id", () => {
@@ -79,6 +87,20 @@ describe("shell snapshot cache", () => {
       desktopConfig: expect.objectContaining({ background: { type: "wallpaper", name: "cached-wallpaper.jpg" } }),
       bootstrap: expect.objectContaining({ apps: freshSnapshot.bootstrap.apps }),
     }));
+    expect(loadShellSnapshot(scope, storage)?.desktopConfig?.desktopIcons).toEqual(
+      freshSnapshot.desktopConfig.desktopIcons,
+    );
+  });
+
+  it("preserves an explicitly empty Desktop icon layout", () => {
+    const scope = createShellSnapshotScope({ userId: "user_123", pathname: "/" });
+    expect(scope).not.toBeNull();
+
+    saveShellSnapshot(scope, {
+      desktopConfig: { ...freshSnapshot.desktopConfig, desktopIcons: [] },
+    }, storage);
+
+    expect(loadShellSnapshot(scope, storage)?.desktopConfig?.desktopIcons).toEqual([]);
   });
 
   it("ignores corrupt, stale, and oversized entries", () => {
@@ -108,6 +130,12 @@ describe("shell snapshot cache", () => {
         background: { type: "image", url: "javascript:alert(1)" },
         dock: { position: "sideways", size: 10000, iconSize: -1, autoHide: true },
         pinnedApps: ["apps/safe/index.html", "../escape"],
+        desktopIcons: [
+          { path: "__chat__", x: 20, y: 20 },
+          { path: "../escape", x: 20, y: 20 },
+          { path: "__terminal__", x: -1, y: 0 },
+          { path: "__chat__", x: 40, y: 40 },
+        ],
       },
       bootstrap: {
         layout: { windows: "bad" },
@@ -122,6 +150,7 @@ describe("shell snapshot cache", () => {
     expect(loaded?.desktopConfig?.background).toEqual({ type: "wallpaper", name: "matrix-dusk.webp" });
     expect(loaded?.desktopConfig?.dock).toEqual({ position: "left", size: 56, iconSize: 40, autoHide: false });
     expect(loaded?.desktopConfig?.pinnedApps).toEqual(["apps/safe/index.html"]);
+    expect(loaded?.desktopConfig?.desktopIcons).toEqual([{ path: "__chat__", x: 20, y: 20 }]);
     expect(loaded?.bootstrap?.layout).toEqual({});
     expect(loaded?.bootstrap?.modules).toEqual([]);
     expect(loaded?.bootstrap?.apps).toEqual([{ name: "Safe", path: "/files/apps/safe/index.html", icon: undefined, slug: "safe" }]);

--- a/tests/shell/web-desktop-app-launch.test.ts
+++ b/tests/shell/web-desktop-app-launch.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_OS_VIEW_DESKTOP_APP_PATHS,
+  normalizeOsViewDesktopAppPath,
+} from "@matrix-os/contracts";
+import {
   buildWebDesktopIconApps,
   buildWebDesktopLauncherApps,
   resolveWebDesktopBuiltInLaunch,
@@ -64,6 +68,18 @@ describe("web Desktop built-in app launch routing", () => {
       iconUrl: "/icons/desktop.svg",
     });
     expect(buildWebDesktopIconApps([]).some((app) => app.path.startsWith("__os-view-"))).toBe(false);
+  });
+
+  it("uses canonical durable paths for all ten default Desktop icons", () => {
+    expect(buildWebDesktopIconApps([]).slice(0, 10).map((app) => app.path)).toEqual(
+      DEFAULT_OS_VIEW_DESKTOP_APP_PATHS,
+    );
+    expect(buildWebDesktopIconApps([
+      { name: "Notes", path: "apps/notes/dist/index.html" },
+      { name: "Whiteboard", path: "apps/whiteboard/dist/index.html" },
+    ]).slice(0, 10).map((app) => normalizeOsViewDesktopAppPath(app.path))).toEqual(
+      DEFAULT_OS_VIEW_DESKTOP_APP_PATHS,
+    );
   });
 
   it("routes launcher OS-view destinations as presentation switches", () => {


### PR DESCRIPTION
## Summary

- make PostgreSQL the authoritative Desktop icon-layout source with explicit initialization and one-time legacy-import markers
- seed and repair the shared canonical ten-icon layout without confusing missing legacy data with an intentional empty array
- add an authenticated, bounded, idempotent legacy Desktop import route with row-lock serialization and cached old-client protection
- hydrate validated, user/runtime-scoped shell snapshots before paint and reconcile Web and Electron through the same durable layout paths
- normalize Browser, Notes, and Whiteboard aliases while retaining existing installed Browser command and dock compatibility

## Tests

- `231` focused contract, gateway, Web, Electron, cache, persistence, and parity tests passed
- exact OS View Parity CI command: `101/101` passed
- `bun run typecheck`
- `pnpm --filter './shell' exec tsc --noEmit`
- `bun run check:patterns` and `bun run check:patterns:diff` (`0` violations; baseline warnings only)
- `bun run build:shell:production`
- `bun run build:desktop`
- `bun run test` was attempted from the clean worktree; it was stopped after unrelated baseline/environment failures were established in source-control diff fixtures, host-script prerequisites, sync timers, Codex app-server sockets, CLI PTY sessions, runtime manager, and app process-manager suites. All changed and OS-view parity suites remained green.

## Review / Monitoring

- review range: `84cc4a95a..d243ca36e`
- Greptile score: `5/5`; `ready-for-ci` applied afterward
- required GitHub CI passed, including four unit shards, E2E, production shell build, OS-view parity, typecheck, React audit, and pattern scan
- the separate always-on Codex provider-contract check is red because upstream Codex `0.152.0` has not yet been added to the repository compatibility allowlist; it is unrelated to this diff
- public-safe companion documentation: FinnaAI/matrix-os-site#66
- exact-head preview bundle `v2026.09.01-pr1508-33469148483-1-d243ca3` published successfully, but disposable VPS provisioning returned HTTP `429` twice while fleet status stayed `absent`; the preview trigger was removed so a later push cannot create an unexpected paid VM

## Invariants

### Source of truth

- PostgreSQL `os_view_states.document.desktop.icons` is authoritative for Desktop icon layout.
- `system/desktop.json` is only a one-time legacy import source. The settings response carries an internal exact-field envelope so merged defaults cannot invent legacy fields.
- Scoped shell snapshots accelerate first paint only; the PostgreSQL response reconciles and replaces them.

### Lock/transaction scope

- Legacy import creates/locks the owner row, checks the import marker, merges only present fields, increments the revision, and writes the marker in one Kysely transaction.
- Startup repair is one conditional SQL update for pre-marker empty rows; customized rows are only marked and never reordered.
- No network or filesystem calls occur while the PostgreSQL row lock is held.

### Acceptable orphan states

- Failed imports leave the marker unset and the PostgreSQL document unchanged, so a later request can retry.
- A failed client write keeps or restores the last confirmed icon layout through the existing optimistic rollback/retry path.
- There are no created external objects and therefore no cleanup or garbage-collection orphan state.

### Auth source of truth

- The existing authenticated owner principal is authoritative for GET, PATCH, and legacy import.
- Missing or invalid ownership fails closed; validation and internal failures return generic bounded responses.

### Deferred scope

- No Desktop reset UI is added.
- Individual move, add, and remove UX remains unchanged.
- Public documentation ships as a separate `FinnaAI/matrix-os-site` PR.
- Live poisoned-row validation remains blocked until disposable preview capacity is available; no customer or primary runtime was touched.
