### PR TITLE
fix(shell): restore PostHog and quiet console noise

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,13 +31,20 @@ NEXT_PUBLIC_GATEWAY_WS=ws://localhost:4000/ws
 NEXT_PUBLIC_GATEWAY_URL=http://localhost:4000
 GATEWAY_URL=http://localhost:4000
 
-# PostHog error tracking (optional)
-# Server/Hono captures use POSTHOG_TOKEN; browser captures use NEXT_PUBLIC_*.
+# PostHog telemetry and support chat (optional)
+# Server/Hono captures use POSTHOG_TOKEN. Web Desktop uses NEXT_PUBLIC_*;
+# Electron Desktop uses VITE_*. The project token is public by design.
+# For local Conversations testing, allow localhost and desktop.localhost in
+# the PostHog project's permitted domains.
 POSTHOG_TOKEN=
 POSTHOG_HOST=https://eu.i.posthog.com
+NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=
+# Legacy web token alias; prefer NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN.
 NEXT_PUBLIC_POSTHOG_KEY=
-NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
-NEXT_PUBLIC_POSTHOG_API_HOST=
+NEXT_PUBLIC_POSTHOG_HOST=https://eu.posthog.com
+NEXT_PUBLIC_POSTHOG_API_HOST=/relay
+VITE_POSTHOG_PROJECT_TOKEN=
+VITE_POSTHOG_HOST=https://eu.posthog.com
 
 # Clerk Authentication (shared with the dedicated matrix-os-site deployment)
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_xxx

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopBackground.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopBackground.tsx
@@ -3,12 +3,6 @@ import { DESKTOP_Z_INDEX } from "../../design/layering";
 import type { ApiClient } from "../../lib/api";
 import { useConnection } from "../../stores/connection";
 import { useUi } from "../../stores/ui";
-import {
-  captureDesktopIconsHydrationRevision,
-  defaultDesktopIcons,
-  useDesktopIcons,
-} from "../../stores/desktop-icons";
-import { FIXED_DESKTOP_APPS } from "./desktop-apps";
 
 type DesktopBackgroundConfig =
   | { type: "pattern" }
@@ -19,7 +13,6 @@ type DesktopBackgroundConfig =
 
 const FALLBACK_STYLE: CSSProperties = { background: "var(--bg-app)" };
 const WALLPAPER_MAX_BYTES = 10 * 1024 * 1024;
-const DEFAULT_DESKTOP_ICONS = defaultDesktopIcons(FIXED_DESKTOP_APPS.map((app) => app.path));
 
 function meshGradient(): string {
   return [
@@ -148,11 +141,7 @@ export default function DesktopBackground() {
 
     if (api) {
       void (async () => {
-        const iconHydrationRevision = captureDesktopIconsHydrationRevision();
-        const config = await api.get<{ background?: unknown; desktopIcons?: unknown }>("/api/settings/desktop");
-        if (!cancelled) {
-          useDesktopIcons.getState().hydrate(config.desktopIcons, DEFAULT_DESKTOP_ICONS, iconHydrationRevision);
-        }
+        const config = await api.get<{ background?: unknown }>("/api/settings/desktop");
         const background = backgroundConfig(config?.background);
         if (!background) return;
         if (background.type !== "wallpaper") {

--- a/docs/dev/releases.md
+++ b/docs/dev/releases.md
@@ -84,8 +84,8 @@ Release metadata also records:
    |------|------|---------|
    | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | secret | shell build |
    | `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` or `NEXT_PUBLIC_POSTHOG_KEY` | secret/var | shell build |
-   | `NEXT_PUBLIC_POSTHOG_HOST` | var | shell build; EU uses `https://eu.i.posthog.com` |
-   | `NEXT_PUBLIC_POSTHOG_API_HOST` | var | shell build; EU uses `https://eu.i.posthog.com` |
+   | `NEXT_PUBLIC_POSTHOG_HOST` | var | shell build; PostHog UI host, EU uses `https://eu.posthog.com` |
+   | `NEXT_PUBLIC_POSTHOG_API_HOST` | var | shell build; same-origin client relay uses `/relay` |
    | `R2_ACCOUNT_ID` | secret | publish |
    | `R2_ACCESS_KEY_ID` | secret | publish |
    | `R2_SECRET_ACCESS_KEY` | secret | publish |

--- a/shell/instrumentation-client.ts
+++ b/shell/instrumentation-client.ts
@@ -1,3 +1,3 @@
 import { initializeShellPostHog } from "./src/lib/posthog-client";
 
-initializeShellPostHog(document.documentElement.dataset.posthogVisitorCountry);
+initializeShellPostHog();

--- a/shell/src/app/layout.tsx
+++ b/shell/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata, Viewport } from "next";
-import { headers } from "next/headers";
 import {
   Bricolage_Grotesque,
   Cormorant_Garamond,
@@ -12,7 +11,6 @@ import {
   Orbitron,
 } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
-import { getPostHogVisitorCountry } from "@matrix-os/observability/client";
 import { platformShellAssetPath } from "@/lib/platform-shell-assets";
 import { buildShellMetadata } from "@/lib/shell-metadata";
 import "@xterm/xterm/css/xterm.css";
@@ -30,12 +28,14 @@ import { AppProviders } from "./providers";
 const inter = Inter({
   variable: "--font-inter",
   subsets: ["latin"],
+  preload: false,
 });
 
 // Default shell sans — matches the landing site's --font-sans (Instrument Sans).
 const instrumentSans = Instrument_Sans({
   variable: "--font-instrument",
   subsets: ["latin"],
+  preload: false,
 });
 
 const instrumentSerif = Instrument_Serif({
@@ -43,33 +43,39 @@ const instrumentSerif = Instrument_Serif({
   subsets: ["latin"],
   weight: "400",
   style: ["normal", "italic"],
+  preload: false,
 });
 
 const jetbrainsMono = JetBrains_Mono({
   variable: "--font-jetbrains",
   subsets: ["latin"],
+  preload: false,
 });
 
 const cormorant = Cormorant_Garamond({
   variable: "--font-serif",
   subsets: ["latin"],
   weight: ["300", "400", "500"],
+  preload: false,
 });
 
 const orbitron = Orbitron({
   variable: "--font-orbitron",
   subsets: ["latin"],
   weight: ["400", "500", "600", "700"],
+  preload: false,
 });
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
+  preload: false,
 });
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+  preload: false,
 });
 
 // Landing/brand display face. `block` prevents the Matrix loading wordmark from
@@ -78,6 +84,7 @@ const bricolage = Bricolage_Grotesque({
   variable: "--font-bricolage",
   subsets: ["latin"],
   display: "block",
+  preload: false,
 });
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -118,17 +125,15 @@ export const viewport: Viewport = {
   ],
 };
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const visitorCountry = getPostHogVisitorCountry(await headers());
   const selfHostedMode = process.env.MATRIX_SELF_HOSTED === "1";
   const renderDocument = (includePostHogIdentify: boolean) => (
     <html
       lang="en"
-      data-posthog-visitor-country={visitorCountry ?? undefined}
       data-matrix-self-hosted={selfHostedMode ? "1" : undefined}
       // Runtime replay kill switch: read on the server per request, so
       // setting POSTHOG_DISABLE_REPLAY and restarting matrix-shell stops

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -114,22 +114,25 @@ function listShellSessions(): Promise<ShellSessionSummary[] | null> {
   });
 }
 
-async function savedShellSessionsAreActive(sessionNames: string[]): Promise<boolean> {
+type SavedShellSessionsStatus = "active" | "stale" | "unavailable";
+
+async function getSavedShellSessionsStatus(sessionNames: string[]): Promise<SavedShellSessionsStatus> {
   const requestedNames = Array.from(new Set(
     sessionNames.filter((name) => isCanonicalShellSessionId(name)),
   ));
   if (requestedNames.length === 0) {
-    return true;
+    return "active";
   }
 
   try {
     const sessions = await listShellSessions();
+    if (sessions === null) {
+      return "unavailable";
+    }
     const existingNames = new Set<string>();
-    if (sessions) {
-      for (const session of sessions) {
-        if (typeof session.name === "string") {
-          existingNames.add(session.name);
-        }
+    for (const session of sessions) {
+      if (typeof session.name === "string") {
+        existingNames.add(session.name);
       }
     }
 
@@ -137,10 +140,10 @@ async function savedShellSessionsAreActive(sessionNames: string[]): Promise<bool
     // intentionally interrupted, so mounting Terminal must never relaunch them.
     // Falling back to the first active session also prevents a stale layout from
     // producing one expected 409 response per missing pane on every app mount.
-    return requestedNames.every((name) => existingNames.has(name));
+    return requestedNames.every((name) => existingNames.has(name)) ? "active" : "stale";
   } catch (err: unknown) {
     console.warn("Failed to validate saved terminal sessions:", err instanceof Error ? err.message : err);
-    return false;
+    return "unavailable";
   }
 }
 
@@ -565,8 +568,11 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
           const data = await res.json() as TerminalLayout;
           if (!cancelled && Array.isArray(data.tabs) && data.tabs.length > 0) {
             if (layoutUsesOnlyCanonicalShellSessions(data)) {
-              const sessionReady = await savedShellSessionsAreActive(getCanonicalShellSessionIds(data));
-              if (!cancelled && sessionReady) {
+              const sessionStatus = await getSavedShellSessionsStatus(getCanonicalShellSessionIds(data));
+              // A failed catalog request does not prove that a runtime stopped.
+              // Preserve the saved layout so a transient outage cannot overwrite
+              // the user's tabs and panes; only an authoritative stale result falls back.
+              if (!cancelled && sessionStatus !== "stale") {
                 const nextActiveTabId = data.activeTabId ?? data.tabs[0].id;
                 const nextActiveTab = data.tabs.find((tab) => tab.id === nextActiveTabId) ?? data.tabs[0];
                 setTabs(applyCompatModeToTabs(data.tabs));

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -114,7 +114,7 @@ function listShellSessions(): Promise<ShellSessionSummary[] | null> {
   });
 }
 
-async function ensureShellSessions(sessionNames: string[]): Promise<boolean> {
+async function savedShellSessionsAreActive(sessionNames: string[]): Promise<boolean> {
   const requestedNames = Array.from(new Set(
     sessionNames.filter((name) => isCanonicalShellSessionId(name)),
   ));
@@ -133,25 +133,13 @@ async function ensureShellSessions(sessionNames: string[]): Promise<boolean> {
       }
     }
 
-    for (const name of requestedNames) {
-      if (existingNames.has(name)) {
-        continue;
-      }
-      // react-doctor-disable-next-line react-doctor/async-await-in-loop -- ordered repair: each missing saved zellij session is recreated once before layout restore; these are user-visible session names, not a fan-out workload.
-      const createRes = await fetch(`${getGatewayUrl()}/api/terminal/sessions`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, cwd: DEFAULT_CWD }),
-        signal: AbortSignal.timeout(10_000),
-      });
-      if (!createRes.ok && createRes.status !== 409) {
-        return false;
-      }
-    }
-
-    return true;
+    // A saved layout is only a UI reference. Missing runtimes can be stopped or
+    // intentionally interrupted, so mounting Terminal must never relaunch them.
+    // Falling back to the first active session also prevents a stale layout from
+    // producing one expected 409 response per missing pane on every app mount.
+    return requestedNames.every((name) => existingNames.has(name));
   } catch (err: unknown) {
-    console.warn("Failed to ensure terminal sessions:", err instanceof Error ? err.message : err);
+    console.warn("Failed to validate saved terminal sessions:", err instanceof Error ? err.message : err);
     return false;
   }
 }
@@ -577,7 +565,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
           const data = await res.json() as TerminalLayout;
           if (!cancelled && Array.isArray(data.tabs) && data.tabs.length > 0) {
             if (layoutUsesOnlyCanonicalShellSessions(data)) {
-              const sessionReady = await ensureShellSessions(getCanonicalShellSessionIds(data));
+              const sessionReady = await savedShellSessionsAreActive(getCanonicalShellSessionIds(data));
               if (!cancelled && sessionReady) {
                 const nextActiveTabId = data.activeTabId ?? data.tabs[0].id;
                 const nextActiveTab = data.tabs.find((tab) => tab.id === nextActiveTabId) ?? data.tabs[0];

--- a/shell/src/lib/posthog-client.ts
+++ b/shell/src/lib/posthog-client.ts
@@ -3,7 +3,6 @@
 import "posthog-js/dist/conversations";
 import posthog from "posthog-js";
 import {
-  buildPostHogCookieConsentInitOptions,
   getPostHogClientConfig,
   resolvePostHogClientApiHost,
 } from "@matrix-os/observability/client";
@@ -203,11 +202,10 @@ export function resetPostHogIdentity(currentConfig: typeof config = config) {
 }
 
 function ensurePostHogInitialized(currentConfig: NonNullable<typeof config>) {
-  initializeShellPostHog(getPostHogVisitorCountry(), currentConfig);
+  initializeShellPostHog(currentConfig);
 }
 
 export function initializeShellPostHog(
-  visitorCountry?: string | null,
   currentConfig: typeof config = config,
 ) {
   if (!currentConfig || initialized) return;
@@ -244,14 +242,8 @@ export function initializeShellPostHog(
       environment: process.env.NODE_ENV,
       serviceVersion: process.env.NEXT_PUBLIC_MATRIX_BUILD_SHA,
     },
-    ...buildPostHogCookieConsentInitOptions(visitorCountry),
   } as PostHogInitOptions);
   initialized = true;
-}
-
-function getPostHogVisitorCountry(): string | null {
-  if (typeof document === "undefined") return null;
-  return document.documentElement.dataset.posthogVisitorCountry ?? null;
 }
 
 function sanitizeProperties(properties: ClientProperties): Record<string, string | number | boolean> {

--- a/shell/src/lib/posthog-client.ts
+++ b/shell/src/lib/posthog-client.ts
@@ -26,6 +26,7 @@ const SUPPORT_AVAILABILITY_TIMEOUT_MS = 10_000;
 const POSTHOG_WIDGET_ID = "ph-conversations-widget-container";
 const POSTHOG_LAUNCHER_SELECTOR = 'button[aria-label^="Open chat"]';
 const POSTHOG_CLOSE_SELECTOR = 'button[aria-label="Close"]';
+const LEGACY_POSTHOG_CONSENT_STORAGE_KEY = "matrix_posthog_cookie_consent";
 // Replay kill switch. NEXT_PUBLIC_* is inlined at build time, so the build
 // flag alone cannot stop replay during an incident. The layout additionally
 // exposes the server's runtime POSTHOG_DISABLE_REPLAY env as a data
@@ -243,7 +244,30 @@ export function initializeShellPostHog(
       serviceVersion: process.env.NEXT_PUBLIC_MATRIX_BUILD_SHA,
     },
   } as PostHogInitOptions);
+  migrateLegacyPostHogConsent();
   initialized = true;
+}
+
+function migrateLegacyPostHogConsent(): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    const legacyConsent = window.localStorage.getItem(LEGACY_POSTHOG_CONSENT_STORAGE_KEY);
+    if (legacyConsent !== "accepted" && legacyConsent !== "declined") return;
+
+    // The shell no longer uses the Matrix consent banner. Restore capture only
+    // when that removed banner was the source of the opt-out; an opt-out with
+    // no legacy marker may belong to a different privacy control.
+    if (legacyConsent === "declined" && posthog.has_opted_out_capturing()) {
+      posthog.opt_in_capturing({ captureEventName: false });
+    }
+    window.localStorage.removeItem(LEGACY_POSTHOG_CONSENT_STORAGE_KEY);
+  } catch (err: unknown) {
+    console.warn(
+      "[posthog] Failed to migrate legacy consent:",
+      err instanceof Error ? err.name : typeof err,
+    );
+  }
 }
 
 function sanitizeProperties(properties: ClientProperties): Record<string, string | number | boolean> {

--- a/tests/desktop/desktop-background.test.tsx
+++ b/tests/desktop/desktop-background.test.tsx
@@ -21,14 +21,43 @@ vi.mock("../../desktop/src/renderer/src/stores/ui", () => ({
 }));
 
 import DesktopBackground from "../../desktop/src/renderer/src/features/desktop-shell/DesktopBackground";
+import {
+  captureDesktopIconsHydrationRevision,
+  resetDesktopIconsRuntime,
+  useDesktopIcons,
+} from "../../desktop/src/renderer/src/stores/desktop-icons";
 
 afterEach(() => {
   cleanup();
+  resetDesktopIconsRuntime();
   vi.unstubAllGlobals();
   mocks.api = null;
 });
 
 describe("DesktopBackground", () => {
+  it("does not replace canonical icon positions with legacy desktop settings", async () => {
+    const movedSettingsIcon = { path: "__settings__", x: 640, y: 320 };
+    useDesktopIcons.getState().hydrate(
+      [movedSettingsIcon],
+      [],
+      captureDesktopIconsHydrationRevision(),
+    );
+    mocks.api = {
+      get: vi.fn().mockResolvedValue({
+        background: { type: "solid", color: "#123456" },
+        desktopIcons: [{ path: "__settings__", x: 20, y: 204 }],
+      }),
+      getBlob: vi.fn(),
+    };
+
+    const { getByTestId } = render(<DesktopBackground />);
+
+    await waitFor(() => {
+      expect(getByTestId("desktop-background").style.backgroundColor).toBe("rgb(18, 52, 86)");
+    });
+    expect(useDesktopIcons.getState().icons).toEqual([movedSettingsIcon]);
+  });
+
   it("keeps the current wallpaper visible until a focus refresh downloads its replacement", async () => {
     class LoadedImage {
       onload: (() => void) | null = null;

--- a/tests/observability/posthog-error-tracking.test.ts
+++ b/tests/observability/posthog-error-tracking.test.ts
@@ -67,7 +67,7 @@ describe("PostHog error tracking", () => {
     // The shell ships a same-origin /relay rewrite, so it opts into relative
     // API hosts to keep capture calls first-party on user subdomains.
     expect(shellClient).toContain("allowRelativeApiHost: true");
-    expect(shellClient).toContain("buildPostHogCookieConsentInitOptions");
+    expect(shellClient).not.toContain("buildPostHogCookieConsentInitOptions");
     expect(shellLayout).not.toContain("PostHogCookieBanner");
   });
 
@@ -596,7 +596,7 @@ describe("PostHog error tracking", () => {
     const shellPostHogClient = await readFile("shell/src/lib/posthog-client.ts", "utf8");
     expect(shellPostHogClient).toContain("same-origin PostHog proxy at /relay");
     expect(shellPostHogClient).toContain('NEXT_PUBLIC_POSTHOG_API_HOST ?? "/relay"');
-    expect(shellPostHogClient).toContain("buildPostHogCookieConsentInitOptions");
+    expect(shellPostHogClient).not.toContain("buildPostHogCookieConsentInitOptions");
     expect(shellPostHogClient).not.toContain("__loaded");
 
   });

--- a/tests/shell/font-preload-policy.test.ts
+++ b/tests/shell/font-preload-policy.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const layoutSource = readFileSync(join(process.cwd(), "shell/src/app/layout.tsx"), "utf8");
+
+function fontOptions(fontName: string): string {
+  const match = layoutSource.match(new RegExp(`const ${fontName} = [A-Za-z_]+\\(\\{([\\s\\S]*?)\\n\\}\\);`));
+  expect(match, `${fontName} declaration`).not.toBeNull();
+  return match?.[1] ?? "";
+}
+
+describe("shell font preload policy", () => {
+  it.each([
+    "inter",
+    "instrumentSans",
+    "instrumentSerif",
+    "jetbrainsMono",
+    "cormorant",
+    "orbitron",
+    "geistSans",
+    "geistMono",
+    "bricolage",
+  ])("does not preload the %s family on every route", (fontName) => {
+    expect(fontOptions(fontName)).toContain("preload: false");
+  });
+});

--- a/tests/shell/posthog-local-config.test.ts
+++ b/tests/shell/posthog-local-config.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("local PostHog configuration", () => {
+  it("documents the canonical web and Electron variables", () => {
+    const example = readFileSync(join(process.cwd(), ".env.example"), "utf8");
+
+    expect(example).toContain("NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=");
+    expect(example).toContain("NEXT_PUBLIC_POSTHOG_HOST=https://eu.posthog.com");
+    expect(example).toContain("NEXT_PUBLIC_POSTHOG_API_HOST=/relay");
+    expect(example).toContain("VITE_POSTHOG_PROJECT_TOKEN=");
+    expect(example).toContain("VITE_POSTHOG_HOST=https://eu.posthog.com");
+    expect(example).toContain("desktop.localhost");
+  });
+});

--- a/tests/shell/posthog-proxy.test.ts
+++ b/tests/shell/posthog-proxy.test.ts
@@ -79,13 +79,14 @@ describe("shell PostHog same-origin proxy", () => {
   it("initializes posthog-js with a relative api_host", async () => {
     const { initializeShellPostHog } = await import("../../shell/src/lib/posthog-client");
 
-    initializeShellPostHog("US", { token: "phc_test", apiHost: "/relay", uiHost: "https://eu.posthog.com" });
+    initializeShellPostHog({ token: "phc_test", apiHost: "/relay", uiHost: "https://eu.posthog.com" });
 
     expect(posthogMock.init).toHaveBeenCalledTimes(1);
     const [token, options] = posthogMock.init.mock.calls[0] as [string, Record<string, unknown>];
     expect(token).toBe("phc_test");
     expect(options.api_host).toBe("/relay");
     expect(options.ui_host).toBe("https://eu.posthog.com");
+    expect(options).not.toHaveProperty("cookieless_mode");
   });
 
   it("only resets identity for provably identified sessions", async () => {
@@ -93,7 +94,7 @@ describe("shell PostHog same-origin proxy", () => {
       "../../shell/src/lib/posthog-client"
     );
     const config = { token: "phc_test", apiHost: "/relay", uiHost: "https://eu.posthog.com" };
-    initializeShellPostHog("US", config);
+    initializeShellPostHog(config);
     const mock = posthogMock as typeof posthogMock & { _isIdentified?: () => boolean };
 
     // Identity check unavailable: never reset (would rotate anonymous ids).

--- a/tests/shell/posthog-session-replay.test.tsx
+++ b/tests/shell/posthog-session-replay.test.tsx
@@ -12,6 +12,8 @@ const posthogMock = vi.hoisted(() => ({
   reset: vi.fn(),
   captureException: vi.fn(),
   setPersonProperties: vi.fn(),
+  has_opted_out_capturing: vi.fn(() => false),
+  opt_in_capturing: vi.fn(),
 }));
 
 vi.mock("posthog-js", () => ({
@@ -33,6 +35,10 @@ describe("shell session replay init", () => {
   beforeEach(() => {
     posthogMock.init.mockClear();
     posthogMock.setPersonProperties.mockClear();
+    posthogMock.has_opted_out_capturing.mockReset();
+    posthogMock.has_opted_out_capturing.mockReturnValue(false);
+    posthogMock.opt_in_capturing.mockReset();
+    window.localStorage.removeItem("matrix_posthog_cookie_consent");
     vi.unstubAllEnvs();
   });
 
@@ -56,6 +62,36 @@ describe("shell session replay init", () => {
       maskTextSelector: "[data-ph-mask]",
       blockSelector: ".ph-no-capture",
     });
+  });
+
+  it("migrates profiles that declined the removed Matrix consent banner", async () => {
+    window.localStorage.setItem("matrix_posthog_cookie_consent", "declined");
+    posthogMock.has_opted_out_capturing.mockReturnValue(true);
+    const { initializeShellPostHog } = await importShellPostHog();
+
+    initializeShellPostHog(TEST_CONFIG);
+
+    expect(posthogMock.opt_in_capturing).toHaveBeenCalledWith({ captureEventName: false });
+    expect(window.localStorage.getItem("matrix_posthog_cookie_consent")).toBeNull();
+  });
+
+  it("removes an accepted legacy consent marker without changing capture state", async () => {
+    window.localStorage.setItem("matrix_posthog_cookie_consent", "accepted");
+    const { initializeShellPostHog } = await importShellPostHog();
+
+    initializeShellPostHog(TEST_CONFIG);
+
+    expect(posthogMock.opt_in_capturing).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem("matrix_posthog_cookie_consent")).toBeNull();
+  });
+
+  it("preserves PostHog opt-outs that did not come from the removed Matrix banner", async () => {
+    posthogMock.has_opted_out_capturing.mockReturnValue(true);
+    const { initializeShellPostHog } = await importShellPostHog();
+
+    initializeShellPostHog(TEST_CONFIG);
+
+    expect(posthogMock.opt_in_capturing).not.toHaveBeenCalled();
   });
 
   it("sets onboarding attribution as a first-touch person property", async () => {

--- a/tests/shell/posthog-session-replay.test.tsx
+++ b/tests/shell/posthog-session-replay.test.tsx
@@ -43,7 +43,7 @@ describe("shell session replay init", () => {
   it("enables masked session recording without console log capture", async () => {
     const { initializeShellPostHog } = await importShellPostHog();
 
-    initializeShellPostHog("US", TEST_CONFIG);
+    initializeShellPostHog(TEST_CONFIG);
 
     expect(posthogMock.init).toHaveBeenCalledTimes(1);
     const [, options] = posthogMock.init.mock.calls[0] as [string, Record<string, unknown>];
@@ -82,7 +82,7 @@ describe("shell session replay init", () => {
     vi.stubEnv("NEXT_PUBLIC_POSTHOG_DISABLE_REPLAY", "1");
     const { initializeShellPostHog } = await importShellPostHog();
 
-    initializeShellPostHog("US", TEST_CONFIG);
+    initializeShellPostHog(TEST_CONFIG);
 
     expect(posthogMock.init).toHaveBeenCalledTimes(1);
     const [, options] = posthogMock.init.mock.calls[0] as [string, Record<string, unknown>];
@@ -94,7 +94,7 @@ describe("shell session replay init", () => {
     try {
       const { initializeShellPostHog } = await importShellPostHog();
 
-      initializeShellPostHog("US", TEST_CONFIG);
+      initializeShellPostHog(TEST_CONFIG);
 
       expect(posthogMock.init).toHaveBeenCalledTimes(1);
       const [, options] = posthogMock.init.mock.calls[0] as [string, Record<string, unknown>];

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -3515,6 +3515,54 @@ describe("TerminalApp", () => {
     expect(props.paneTree.sessionId).toBe("main");
   });
 
+  it("preserves a saved shell layout when the session catalog is unavailable", async () => {
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/terminal/layout") && init?.method !== "PUT") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            tabs: [{
+              id: "bench-tab",
+              label: "bench",
+              paneTree: {
+                type: "pane",
+                id: "bench-pane",
+                cwd: "projects",
+                sessionId: "bench",
+              },
+            }],
+            activeTabId: "bench-tab",
+          }),
+        });
+      }
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve({ ok: false });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+    }));
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(terminalSessionPostBodies()).toHaveLength(0);
+    const props = paneGridSpy.mock.lastCall?.[0] as {
+      paneTree: { type: "pane"; sessionId?: string };
+    };
+    expect(props.paneTree.sessionId).toBe("bench");
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(vi.mocked(fetch).mock.calls.filter(([input, init]) => (
+      String(input).includes("/api/terminal/layout") && init?.method === "PUT"
+    ))).toHaveLength(0);
+  });
+
   it("does not replace a legacy layout after unmount while validating the canonical session", async () => {
     let resolveSessions: ((value: { ok: boolean; json: () => Promise<{ sessions: Array<{ name: string }> }> }) => void) | null = null;
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -3473,7 +3473,7 @@ describe("TerminalApp", () => {
     expect(props.paneTree.sessionId).toBe("main");
   });
 
-  it("recreates saved canonical shell sessions before restoring a layout", async () => {
+  it("does not relaunch a stale saved shell session while restoring a layout", async () => {
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/api/terminal/layout") && init?.method !== "PUT") {
@@ -3508,20 +3508,14 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
-    expect(global.fetch).toHaveBeenCalledWith(
-      expect.stringContaining("/api/terminal/sessions"),
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({ name: "bench", cwd: "projects" }),
-      }),
-    );
+    expect(terminalSessionPostBodies()).toHaveLength(0);
     const props = paneGridSpy.mock.lastCall?.[0] as {
       paneTree: { type: "pane"; sessionId?: string };
     };
-    expect(props.paneTree.sessionId).toBe("bench");
+    expect(props.paneTree.sessionId).toBe("main");
   });
 
-  it("does not replace a legacy layout after unmount while ensuring the canonical session", async () => {
+  it("does not replace a legacy layout after unmount while validating the canonical session", async () => {
     let resolveSessions: ((value: { ok: boolean; json: () => Promise<{ sessions: Array<{ name: string }> }> }) => void) | null = null;
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);


### PR DESCRIPTION
## Summary

- initialize Web Desktop PostHog normally, without the consent/cookieless gate that prevented Conversations from loading
- document canonical Web Desktop and Electron Desktop PostHog variables plus local Conversations domain requirements
- disable global Next font preloads so route-specific fonts load on demand without unused-preload warnings
- validate saved terminal layout sessions instead of relaunching interrupted sessions and generating repeated 409 responses
- preserve saved terminal tabs and panes when the session catalog is temporarily unavailable
- preserve moved Electron Desktop icons by keeping legacy background settings from overwriting canonical OS-view positions

## Testing

- `vitest run tests/desktop/desktop-background.test.tsx tests/desktop/desktop-icons-store.test.ts tests/desktop/os-view-state-client.test.ts tests/desktop/use-native-os-view-persistence.test.tsx tests/desktop/native-desktop-shell.test.tsx tests/shell/font-preload-policy.test.ts tests/shell/posthog-local-config.test.ts tests/shell/posthog-proxy.test.ts tests/shell/posthog-session-replay.test.tsx tests/observability/posthog-error-tracking.test.ts tests/shell/terminal-app-component.test.tsx` (228 passed)
- `tsc --noEmit -p desktop/tsconfig.json`
- `tsc --noEmit -p shell/tsconfig.json`
- changed-file ESLint (0 errors; 2 pre-existing hook warnings in TerminalApp)
- `next build --webpack` with release-parity shell environment
- verified the production output contains no font preload links

The repository-wide shell lint still reports its existing unrelated baseline (51 errors / 80 warnings); none are in the files changed by this PR.

## Invariants

- **Source of truth:** PostHog build-time variables remain the source of truth for client initialization; a successful active terminal session catalog remains the source of truth for determining stale runtime references; canonical OS-view state remains the source of truth for Electron Desktop icon positions.
- **Lock/transaction scope:** No database writes, locks, or transactions are introduced.
- **Acceptable orphan states:** Stale terminal layout references may remain persisted, but confirmed stale references are ignored at restore time and never relaunch a stopped process. A transient catalog failure preserves the saved layout rather than overwriting it.
- **Auth source of truth:** Clerk and existing gateway authentication remain unchanged; PostHog project tokens are public client configuration and no private token is exposed.
- **Deferred scope:** The reusable observability consent helpers remain available to other consumers, but Web Desktop no longer opts into them. Project-side PostHog domain configuration for `localhost` and `desktop.localhost` remains an operator setting.
