### PR TITLE
fix(os-view): restore canvas and launcher parity

### DIFF
--- a/desktop/src/renderer/src/features/desktop-shell/desktop-apps.ts
+++ b/desktop/src/renderer/src/features/desktop-shell/desktop-apps.ts
@@ -12,7 +12,10 @@ import {
   type LucideIcon,
 } from "@renderer/lib/hugeicons";
 import type { TabKind } from "../../stores/tabs";
+import { OS_VIEW_FIXED_APP_APPEARANCES } from "@matrix-os/contracts";
 import vscodeIconUrl from "../../../../../../shell/public/vscode.png";
+
+const APPEARANCE = OS_VIEW_FIXED_APP_APPEARANCES;
 
 export type DesktopAppId =
   | "work"
@@ -46,8 +49,8 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
     kind: "work",
     icon: MessageSquare,
     name: "Chat",
-    color: "var(--surface-error-emphasis, #BA5236)",
-    iconColor: "white",
+    color: APPEARANCE.chat.background,
+    iconColor: APPEARANCE.chat.foreground,
   },
   {
     id: "terminal",
@@ -55,8 +58,8 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
     kind: "terminals",
     icon: SquareTerminal,
     name: "Terminal",
-    color: "var(--surface-warning-emphasis, #E0AA52)",
-    iconColor: "white",
+    color: APPEARANCE.terminal.background,
+    iconColor: APPEARANCE.terminal.foreground,
   },
   {
     id: "files",
@@ -64,8 +67,8 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
     kind: "files",
     icon: FolderTree,
     name: "Files",
-    color: "var(--surface-brand-emphasis, #748E59)",
-    iconColor: "white",
+    color: APPEARANCE.files.background,
+    iconColor: APPEARANCE.files.foreground,
   },
   {
     id: "editor",
@@ -73,8 +76,8 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
     kind: "editor",
     icon: FilePenLine,
     name: "Editor",
-    color: "#4D7FA8",
-    iconColor: "white",
+    color: APPEARANCE.editor.background,
+    iconColor: APPEARANCE.editor.foreground,
   },
   {
     id: "vscode",
@@ -83,8 +86,8 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
     icon: Code2,
     iconUrl: vscodeIconUrl,
     name: "VS Code",
-    color: "#FFFEFC",
-    iconColor: "#007ACC",
+    color: APPEARANCE.vscode.background,
+    iconColor: APPEARANCE.vscode.foreground,
   },
   {
     id: "settings",
@@ -92,8 +95,8 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
     kind: "settings",
     icon: Settings,
     name: "Settings",
-    color: "var(--surface-neutral-emphasis, #6B7280)",
-    iconColor: "white",
+    color: APPEARANCE.settings.background,
+    iconColor: APPEARANCE.settings.foreground,
   },
   {
     id: "plugins",
@@ -101,8 +104,8 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
     kind: "settings",
     icon: Blocks,
     name: "Plugins",
-    color: "#7C6DB4",
-    iconColor: "white",
+    color: APPEARANCE.plugins.background,
+    iconColor: APPEARANCE.plugins.foreground,
     settingsSection: "services",
   },
   {
@@ -111,8 +114,8 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
     kind: "browser",
     icon: Globe2,
     name: "Browser",
-    color: "var(--surface-info-emphasis, #3B85BA)",
-    iconColor: "white",
+    color: APPEARANCE.browser.background,
+    iconColor: APPEARANCE.browser.foreground,
   },
   {
     id: "notes",
@@ -120,8 +123,8 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
     kind: "notes",
     icon: Notebook,
     name: "Notes",
-    color: "var(--surface-purple-emphasis)",
-    iconColor: "white",
+    color: APPEARANCE.notes.background,
+    iconColor: APPEARANCE.notes.foreground,
   },
   {
     id: "whiteboard",
@@ -129,8 +132,8 @@ export const FIXED_DESKTOP_APPS: readonly DesktopAppConfig[] = [
     kind: "app",
     icon: BrushIcon,
     name: "Whiteboard",
-    color: "#D46A92",
-    iconColor: "white",
+    color: APPEARANCE.whiteboard.background,
+    iconColor: APPEARANCE.whiteboard.foreground,
     slug: "whiteboard",
   },
 ];

--- a/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
+++ b/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
@@ -9,6 +9,7 @@ import {
   OS_VIEW_DESTINATION_PATHS,
   OS_VIEW_CREATE_APP_APPEARANCE,
   OS_VIEW_LABELS,
+  osViewFixedAppAppearanceForPath,
   otherOsViewMode,
   type OsViewMode,
 } from "@matrix-os/contracts";
@@ -106,11 +107,12 @@ export default function AppLauncher({
       }] : []),
       ...FIXED_DESKTOP_APPS.map((app) => {
         const installed = apps.find((candidate) => candidate.name.toLowerCase() === app.name.toLowerCase());
+        const appearance = osViewFixedAppAppearanceForPath(app.path);
         return {
           type: "fixed" as const,
           key: app.path,
           name: app.name,
-          app: installed
+          app: installed && appearance?.iconSource === "app"
             ? { ...app, iconUrl: appIconUrl(platformHost, installed.slug, runtimeSlot) ?? app.iconUrl }
             : app,
         };

--- a/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
+++ b/desktop/src/renderer/src/features/embeds/AppLauncher.tsx
@@ -7,6 +7,7 @@ import { useTabs } from "../../stores/tabs";
 import { FIXED_DESKTOP_APPS, type DesktopAppConfig } from "../desktop-shell/desktop-apps";
 import {
   OS_VIEW_DESTINATION_PATHS,
+  OS_VIEW_CREATE_APP_APPEARANCE,
   OS_VIEW_LABELS,
   otherOsViewMode,
   type OsViewMode,
@@ -268,7 +269,13 @@ export default function AppLauncher({
                   onClick={() => open(entry)}
                 >
                   {entry.type === "create" ? (
-                    <span className="flex size-16 items-center justify-center rounded-[18px] bg-[var(--accent)] text-white shadow-[var(--shadow-1)]">
+                    <span
+                      className="flex size-16 items-center justify-center rounded-[18px] shadow-[var(--shadow-1)]"
+                      style={{
+                        background: OS_VIEW_CREATE_APP_APPEARANCE.background,
+                        color: OS_VIEW_CREATE_APP_APPEARANCE.foreground,
+                      }}
+                    >
                       <Plus size={40} aria-hidden="true" />
                     </span>
                   ) : entry.type === "os-view" ? (

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1138,10 +1138,13 @@ export type ReviewSnapshot = z.infer<typeof ReviewSnapshotSchema>;
 
 export {
   OS_VIEW_DESTINATION_PATHS,
+  OS_VIEW_CREATE_APP_APPEARANCE,
+  OS_VIEW_FIXED_APP_APPEARANCES,
   OS_VIEW_LABELS,
   OS_VIEW_MODES,
   isOsViewDestinationPath,
   normalizeOsViewMode,
+  osViewFixedAppAppearanceForPath,
   otherOsViewMode,
   createDefaultOsViewDocument,
   mergeOsViewStatePatch,
@@ -1161,6 +1164,8 @@ export type {
   OsViewCanvasTransform,
   OsViewDesktopIcon,
   OsViewDocument,
+  OsViewFixedAppIcon,
+  OsViewFixedAppId,
   OsViewMode,
   OsViewStatePatch,
   OsViewStateResponse,

--- a/packages/contracts/src/os-view.ts
+++ b/packages/contracts/src/os-view.ts
@@ -16,38 +16,44 @@ export const OS_VIEW_DESTINATION_PATHS: Readonly<Record<OsViewMode, string>> = {
 export const OS_VIEW_FIXED_APP_APPEARANCES = {
   chat: {
     icon: "message-square",
+    iconSource: "fixed",
     background: "var(--surface-error-emphasis, #BA5236)",
     foreground: "white",
   },
   terminal: {
     icon: "square-terminal",
+    iconSource: "fixed",
     background: "var(--surface-warning-emphasis, #E0AA52)",
     foreground: "white",
   },
   files: {
     icon: "folder-tree",
+    iconSource: "fixed",
     background: "var(--surface-brand-emphasis, #748E59)",
     foreground: "white",
   },
-  editor: { icon: "file-pen", background: "#4D7FA8", foreground: "white" },
-  vscode: { icon: "code", background: "#FFFEFC", foreground: "#007ACC" },
+  editor: { icon: "file-pen", iconSource: "fixed", background: "#4D7FA8", foreground: "white" },
+  vscode: { icon: "code", iconSource: "app", background: "#FFFEFC", foreground: "#007ACC" },
   settings: {
     icon: "settings",
+    iconSource: "fixed",
     background: "var(--surface-neutral-emphasis, #6B7280)",
     foreground: "white",
   },
-  plugins: { icon: "blocks", background: "#7C6DB4", foreground: "white" },
+  plugins: { icon: "blocks", iconSource: "fixed", background: "#7C6DB4", foreground: "white" },
   browser: {
     icon: "globe",
+    iconSource: "fixed",
     background: "var(--surface-info-emphasis, #3B85BA)",
     foreground: "white",
   },
   notes: {
     icon: "notebook",
-    background: "var(--surface-purple-emphasis)",
+    iconSource: "app",
+    background: "var(--surface-purple-emphasis, #8B6BB1)",
     foreground: "white",
   },
-  whiteboard: { icon: "brush", background: "#D46A92", foreground: "white" },
+  whiteboard: { icon: "brush", iconSource: "app", background: "#D46A92", foreground: "white" },
 } as const;
 
 export const OS_VIEW_CREATE_APP_APPEARANCE = {
@@ -67,6 +73,7 @@ const OS_VIEW_FIXED_APP_ID_BY_PATH: Readonly<Record<string, OsViewFixedAppId>> =
   __settings__: "settings",
   __plugins__: "plugins",
   __browser__: "browser",
+  __notes__: "notes",
   "apps/browser/index.html": "browser",
   "apps/browser/dist/index.html": "browser",
   "apps/notes/index.html": "notes",

--- a/packages/contracts/src/os-view.ts
+++ b/packages/contracts/src/os-view.ts
@@ -13,6 +13,73 @@ export const OS_VIEW_DESTINATION_PATHS: Readonly<Record<OsViewMode, string>> = {
   canvas: "__os-view-canvas__",
 };
 
+export const OS_VIEW_FIXED_APP_APPEARANCES = {
+  chat: {
+    icon: "message-square",
+    background: "var(--surface-error-emphasis, #BA5236)",
+    foreground: "white",
+  },
+  terminal: {
+    icon: "square-terminal",
+    background: "var(--surface-warning-emphasis, #E0AA52)",
+    foreground: "white",
+  },
+  files: {
+    icon: "folder-tree",
+    background: "var(--surface-brand-emphasis, #748E59)",
+    foreground: "white",
+  },
+  editor: { icon: "file-pen", background: "#4D7FA8", foreground: "white" },
+  vscode: { icon: "code", background: "#FFFEFC", foreground: "#007ACC" },
+  settings: {
+    icon: "settings",
+    background: "var(--surface-neutral-emphasis, #6B7280)",
+    foreground: "white",
+  },
+  plugins: { icon: "blocks", background: "#7C6DB4", foreground: "white" },
+  browser: {
+    icon: "globe",
+    background: "var(--surface-info-emphasis, #3B85BA)",
+    foreground: "white",
+  },
+  notes: {
+    icon: "notebook",
+    background: "var(--surface-purple-emphasis)",
+    foreground: "white",
+  },
+  whiteboard: { icon: "brush", background: "#D46A92", foreground: "white" },
+} as const;
+
+export const OS_VIEW_CREATE_APP_APPEARANCE = {
+  background: "var(--accent)",
+  foreground: "white",
+} as const;
+
+export type OsViewFixedAppId = keyof typeof OS_VIEW_FIXED_APP_APPEARANCES;
+export type OsViewFixedAppIcon = (typeof OS_VIEW_FIXED_APP_APPEARANCES)[OsViewFixedAppId]["icon"];
+
+const OS_VIEW_FIXED_APP_ID_BY_PATH: Readonly<Record<string, OsViewFixedAppId>> = {
+  __chat__: "chat",
+  __terminal__: "terminal",
+  "__file-browser__": "files",
+  __editor__: "editor",
+  __vscode__: "vscode",
+  __settings__: "settings",
+  __plugins__: "plugins",
+  __browser__: "browser",
+  "apps/browser/index.html": "browser",
+  "apps/browser/dist/index.html": "browser",
+  "apps/notes/index.html": "notes",
+  "apps/notes/dist/index.html": "notes",
+  "apps/whiteboard/index.html": "whiteboard",
+  "apps/whiteboard/dist/index.html": "whiteboard",
+};
+
+export function osViewFixedAppAppearanceForPath(path: string) {
+  const id = OS_VIEW_FIXED_APP_ID_BY_PATH[path];
+  return id ? OS_VIEW_FIXED_APP_APPEARANCES[id] : undefined;
+}
+
 export function normalizeOsViewMode(value: unknown): OsViewMode {
   return value === "canvas" ? "canvas" : "desktop";
 }

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -1059,7 +1059,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
       ) : canvasToolbarChild ? (
         <header
           data-testid="canvas-toolbar"
-          className="relative hidden h-[38px] shrink-0 items-center justify-center gap-0.5 border-b border-white/30 bg-card/70 px-3 text-xs leading-none text-foreground/70 shadow-[0_1px_2px_rgba(0,0,0,0.04)] backdrop-blur-xl md:flex"
+          className="relative flex h-[38px] shrink-0 items-center justify-center gap-0.5 border-b border-white/30 bg-card/70 px-3 text-xs leading-none text-foreground/70 shadow-[0_1px_2px_rgba(0,0,0,0.04)] backdrop-blur-xl"
           style={{ zIndex: SHELL_Z_INDEX.menuBar }}
         >
           {canvasToolbarChild}

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -39,6 +39,7 @@ import { nameToSlug } from "@/lib/utils";
 import { iconUrlForSlug } from "@/lib/app-launch";
 import { versionedIconUrl } from "@/lib/icon-url";
 import { VOICE_HIDDEN, getCodeEditorUrl } from "@/lib/feature-flags";
+import { SHELL_Z_INDEX } from "@/lib/shell-layering";
 import {
   buildWebDesktopLauncherApps,
   buildWebDesktopIconApps,
@@ -1055,9 +1056,17 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat, cacheScope 
         >
           {canvasToolbarChild}
         </WindowsTaskbar>
-      ) : canvasToolbarChild)}
+      ) : canvasToolbarChild ? (
+        <header
+          data-testid="canvas-toolbar"
+          className="relative hidden h-[38px] shrink-0 items-center justify-center gap-0.5 border-b border-white/30 bg-card/70 px-3 text-xs leading-none text-foreground/70 shadow-[0_1px_2px_rgba(0,0,0,0.04)] backdrop-blur-xl md:flex"
+          style={{ zIndex: SHELL_Z_INDEX.menuBar }}
+        >
+          {canvasToolbarChild}
+        </header>
+      ) : null)}
       <OsSessionHost />
-      <div className="relative flex-1 flex flex-col md:flex-row">
+      <div className="relative min-h-0 flex-1 flex flex-col md:flex-row">
         {/* Desktop dock -- hidden in ambient/conversational modes. */}
         {desktopMode !== "desktop" && !isWindowsDesign && <div
           className={[

--- a/shell/src/components/launchpad/Launchpad.tsx
+++ b/shell/src/components/launchpad/Launchpad.tsx
@@ -230,6 +230,7 @@ function LaunchpadTile({ app, onLaunch, onContextMenu }: { app: AppEntry; onLaun
   const BuiltInIcon = builtInAppearance
     ? BUILT_IN_ICON_COMPONENTS[builtInAppearance.icon]
     : undefined;
+  const useFixedIcon = BuiltInIcon && builtInAppearance?.iconSource === "fixed";
   return (
     <button type="button" aria-label={app.name} data-launchpad-tile className="launchpad-tile" onClick={onLaunch} onContextMenu={onContextMenu ? (event) => { event.preventDefault(); onContextMenu(); } : undefined}>
       <span className="launchpad-icon">
@@ -243,6 +244,18 @@ function LaunchpadTile({ app, onLaunch, onContextMenu }: { app: AppEntry; onLaun
             }}
           >
             <PlusIcon className="size-12" aria-hidden="true" />
+          </span>
+        ) : useFixedIcon && builtInAppearance ? (
+          <span
+            data-launchpad-built-in-icon
+            className="flex size-full items-center justify-center"
+            style={{
+              background: builtInAppearance.background,
+              color: builtInAppearance.foreground,
+            }}
+            aria-hidden="true"
+          >
+            <BuiltInIcon className="size-8" />
           </span>
         ) : showImage && app.iconUrl ? (
           // react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- app icon served from a runtime gateway host (/icons/{slug}.png) that cannot be statically configured for next/image

--- a/shell/src/components/launchpad/Launchpad.tsx
+++ b/shell/src/components/launchpad/Launchpad.tsx
@@ -1,7 +1,26 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { PlusIcon, SearchIcon } from "@/lib/hugeicons";
+import {
+  Blocks,
+  BrushIcon,
+  Code2,
+  FilePenLine,
+  FolderTree,
+  Globe2,
+  MessageSquare,
+  Notebook,
+  PlusIcon,
+  SearchIcon,
+  Settings,
+  SquareTerminal,
+  type LucideIcon,
+} from "@/lib/hugeicons";
+import {
+  OS_VIEW_CREATE_APP_APPEARANCE,
+  osViewFixedAppAppearanceForPath,
+  type OsViewFixedAppIcon,
+} from "@matrix-os/contracts";
 import { useIconWithFallback } from "@/hooks/useIconWithFallback";
 import type { AppEntry } from "@/hooks/useWindowManager";
 import { groupLauncherApps } from "@/lib/dock-sections";
@@ -14,6 +33,19 @@ import {
   paginateLaunchpadApps,
 } from "./launchpad-utils";
 import "./launchpad.css";
+
+const BUILT_IN_ICON_COMPONENTS: Readonly<Record<OsViewFixedAppIcon, LucideIcon>> = {
+  "message-square": MessageSquare,
+  "square-terminal": SquareTerminal,
+  "folder-tree": FolderTree,
+  "file-pen": FilePenLine,
+  code: Code2,
+  settings: Settings,
+  blocks: Blocks,
+  globe: Globe2,
+  notebook: Notebook,
+  brush: BrushIcon,
+};
 
 /**
  * macOS Launchpad: full-screen frosted-glass app launcher used in place of
@@ -194,14 +226,39 @@ export function Launchpad({
 
 function LaunchpadTile({ app, onLaunch, onContextMenu }: { app: AppEntry; onLaunch: () => void; onContextMenu?: () => void }) {
   const { showImage, onError } = useIconWithFallback(app.iconUrl);
+  const builtInAppearance = osViewFixedAppAppearanceForPath(app.path);
+  const BuiltInIcon = builtInAppearance
+    ? BUILT_IN_ICON_COMPONENTS[builtInAppearance.icon]
+    : undefined;
   return (
     <button type="button" aria-label={app.name} data-launchpad-tile className="launchpad-tile" onClick={onLaunch} onContextMenu={onContextMenu ? (event) => { event.preventDefault(); onContextMenu(); } : undefined}>
       <span className="launchpad-icon">
         {app.path === "__create-app__" ? (
-          <PlusIcon className="size-12" aria-hidden="true" />
+          <span
+            data-launchpad-create-icon
+            className="flex size-full items-center justify-center"
+            style={{
+              background: OS_VIEW_CREATE_APP_APPEARANCE.background,
+              color: OS_VIEW_CREATE_APP_APPEARANCE.foreground,
+            }}
+          >
+            <PlusIcon className="size-12" aria-hidden="true" />
+          </span>
         ) : showImage && app.iconUrl ? (
           // react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- app icon served from a runtime gateway host (/icons/{slug}.png) that cannot be statically configured for next/image
           <img src={app.iconUrl} alt="" draggable={false} onError={onError} />
+        ) : BuiltInIcon && builtInAppearance ? (
+          <span
+            data-launchpad-built-in-icon
+            className="flex size-full items-center justify-center"
+            style={{
+              background: builtInAppearance.background,
+              color: builtInAppearance.foreground,
+            }}
+            aria-hidden="true"
+          >
+            <BuiltInIcon className="size-8" />
+          </span>
         ) : (
           <span className="launchpad-icon-fallback" aria-hidden>
             {app.name.charAt(0).toUpperCase()}

--- a/shell/src/lib/hugeicons.tsx
+++ b/shell/src/lib/hugeicons.tsx
@@ -194,6 +194,7 @@ import { MoreHorizontalIcon as MoreHorizontalIconData } from "@hugeicons/core-fr
 import { MousePointer as MousePointerData } from "@hugeicons/core-free-icons";
 import { MousePointer2 as MousePointer2Data } from "@hugeicons/core-free-icons";
 import { MusicIcon as MusicIconData } from "@hugeicons/core-free-icons";
+import { Note01Icon as Note01Data } from "@hugeicons/core-free-icons";
 import { OctagonXIcon as OctagonXIconData } from "@hugeicons/core-free-icons";
 import { Palette as PaletteData } from "@hugeicons/core-free-icons";
 import { PaletteIcon as PaletteIconData } from "@hugeicons/core-free-icons";
@@ -481,6 +482,7 @@ export const MoreHorizontalIcon: LucideIcon = createIcon(MoreHorizontalIconData)
 export const MousePointer: LucideIcon = createIcon(MousePointerData);
 export const MousePointer2: LucideIcon = createIcon(MousePointer2Data);
 export const MusicIcon: LucideIcon = createIcon(MusicIconData);
+export const Notebook: LucideIcon = createIcon(Note01Data);
 export const OctagonXIcon: LucideIcon = createIcon(OctagonXIconData);
 export const Palette: LucideIcon = createIcon(PaletteData);
 export const PaletteIcon: LucideIcon = createIcon(PaletteIconData);

--- a/tests/contracts/os-view.test.ts
+++ b/tests/contracts/os-view.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from "vitest";
 import {
   PatchOsViewStateRequestSchema,
   createDefaultOsViewDocument,
+  OS_VIEW_CREATE_APP_APPEARANCE,
   OS_VIEW_DESTINATION_PATHS,
+  OS_VIEW_FIXED_APP_APPEARANCES,
   OS_VIEW_LABELS,
   isOsViewDestinationPath,
   mergeOsViewStatePatch,
   normalizeOsViewMode,
+  osViewFixedAppAppearanceForPath,
   otherOsViewMode,
   rebaseOsViewStatePatch,
 } from "@matrix-os/contracts";
@@ -28,6 +31,19 @@ describe("shared OS-view contract", () => {
     expect(normalizeOsViewMode("removed-mode")).toBe("desktop");
     expect(otherOsViewMode("desktop")).toBe("canvas");
     expect(otherOsViewMode("canvas")).toBe("desktop");
+  });
+
+  it("shares fixed launcher appearance across Web and Electron paths", () => {
+    expect(OS_VIEW_CREATE_APP_APPEARANCE).toEqual({
+      background: "var(--accent)",
+      foreground: "white",
+    });
+    expect(osViewFixedAppAppearanceForPath("__chat__")).toBe(OS_VIEW_FIXED_APP_APPEARANCES.chat);
+    expect(osViewFixedAppAppearanceForPath("apps/browser/dist/index.html"))
+      .toBe(OS_VIEW_FIXED_APP_APPEARANCES.browser);
+    expect(osViewFixedAppAppearanceForPath("apps/notes/index.html"))
+      .toBe(OS_VIEW_FIXED_APP_APPEARANCES.notes);
+    expect(osViewFixedAppAppearanceForPath("apps/custom/index.html")).toBeUndefined();
   });
 
   it("keeps Desktop and Canvas presentation geometry in separate namespaces", () => {

--- a/tests/contracts/os-view.test.ts
+++ b/tests/contracts/os-view.test.ts
@@ -41,8 +41,15 @@ describe("shared OS-view contract", () => {
     expect(osViewFixedAppAppearanceForPath("__chat__")).toBe(OS_VIEW_FIXED_APP_APPEARANCES.chat);
     expect(osViewFixedAppAppearanceForPath("apps/browser/dist/index.html"))
       .toBe(OS_VIEW_FIXED_APP_APPEARANCES.browser);
+    expect(OS_VIEW_FIXED_APP_APPEARANCES.browser.iconSource).toBe("fixed");
     expect(osViewFixedAppAppearanceForPath("apps/notes/index.html"))
       .toBe(OS_VIEW_FIXED_APP_APPEARANCES.notes);
+    expect(osViewFixedAppAppearanceForPath("__notes__"))
+      .toBe(OS_VIEW_FIXED_APP_APPEARANCES.notes);
+    expect(OS_VIEW_FIXED_APP_APPEARANCES.notes).toMatchObject({
+      iconSource: "app",
+      background: "var(--surface-purple-emphasis, #8B6BB1)",
+    });
     expect(osViewFixedAppAppearanceForPath("apps/custom/index.html")).toBeUndefined();
   });
 

--- a/tests/desktop/app-launcher.test.tsx
+++ b/tests/desktop/app-launcher.test.tsx
@@ -113,6 +113,23 @@ describe("AppLauncher", () => {
     expect(onSwitchOsView).toHaveBeenCalledWith("canvas");
   });
 
+  it("keeps core system vectors while allowing app artwork for Notes", () => {
+    clearDesktopApps();
+    seedDesktopApps([
+      { slug: "chat", name: "Chat" },
+      { slug: "notes", name: "Notes" },
+    ]);
+
+    render(<AppLauncher presentation="launchpad" />);
+
+    const chat = screen.getByRole("button", { name: "Chat" });
+    expect(chat.querySelector("svg")).toBeTruthy();
+    expect(chat.querySelector("img")).toBeNull();
+
+    const notes = screen.getByRole("button", { name: "Notes" });
+    expect(notes.querySelector("img")?.getAttribute("src")).toContain("/icons/notes.png");
+  });
+
   it("offers Desktop from Canvas and keeps the OS-view destination launcher-only", () => {
     const onSwitchOsView = vi.fn();
     const onAddToDesktop = vi.fn();

--- a/tests/shell/desktop-launcher-mode.test.tsx
+++ b/tests/shell/desktop-launcher-mode.test.tsx
@@ -73,7 +73,12 @@ vi.mock("../../shell/src/components/canvas/CanvasRenderer.js", () => ({
 }));
 
 vi.mock("../../shell/src/components/canvas/CanvasToolbar.js", () => ({
-  CanvasToolbar: () => null,
+  CanvasToolbar: () => (
+    <>
+      <button type="button" data-testid="canvas-zoom-control">Zoom</button>
+      <input data-testid="canvas-zoom-slider" aria-label="Canvas zoom" type="range" />
+    </>
+  ),
 }));
 
 vi.mock("../../shell/src/components/VocalPanel.js", () => ({
@@ -213,6 +218,18 @@ describe("Desktop launcher dock button by mode", () => {
     renderDesktop();
 
     expect(await screen.findByTestId("dock-tasks")).toBeTruthy();
+  });
+
+  it("contains Canvas controls in one non-shrinking toolbar row", async () => {
+    resetShellMode("canvas", true);
+
+    renderDesktop();
+
+    const toolbar = await screen.findByTestId("canvas-toolbar");
+    expect(toolbar.className).toContain("shrink-0");
+    expect(toolbar.className).toContain("items-center");
+    expect(screen.getByTestId("canvas-zoom-control").parentElement).toBe(toolbar);
+    expect(screen.getByTestId("canvas-zoom-slider").parentElement).toBe(toolbar);
   });
 
   it("keeps the launcher visible in developer mode", async () => {

--- a/tests/shell/launchpad.test.tsx
+++ b/tests/shell/launchpad.test.tsx
@@ -201,6 +201,45 @@ describe("Launchpad (macos-glass launcher)", () => {
     expect(screen.queryByRole("button", { name: /go to page/i })).toBeNull();
   });
 
+  it("matches Electron Desktop's fixed launcher icon treatment", async () => {
+    setDesign("macos-glass");
+    const apps: TestApp[] = [
+      { name: "Chat", path: "__chat__" },
+      { name: "Terminal", path: "__terminal__" },
+      { name: "Files", path: "__file-browser__" },
+      { name: "Editor", path: "__editor__" },
+      { name: "Settings", path: "__settings__" },
+      { name: "Plugins", path: "__plugins__" },
+      { name: "Browser", path: "apps/browser/dist/index.html" },
+    ];
+
+    await renderLauncher({ apps });
+
+    const expectedBackgrounds = new Map([
+      ["Chat", "var(--surface-error-emphasis, #BA5236)"],
+      ["Terminal", "var(--surface-warning-emphasis, #E0AA52)"],
+      ["Files", "var(--surface-brand-emphasis, #748E59)"],
+      ["Editor", "rgb(77, 127, 168)"],
+      ["Settings", "var(--surface-neutral-emphasis, #6B7280)"],
+      ["Plugins", "rgb(124, 109, 180)"],
+      ["Browser", "var(--surface-info-emphasis, #3B85BA)"],
+    ]);
+
+    for (const [name, background] of expectedBackgrounds) {
+      const tile = screen.getByRole("button", { name });
+      const icon = tile.querySelector<HTMLElement>("[data-launchpad-built-in-icon]");
+      expect(icon).toBeTruthy();
+      expect(icon?.style.background).toBe(background);
+      expect(icon?.querySelector("svg")).toBeTruthy();
+      expect(icon?.textContent).toBe("");
+    }
+
+    const createIcon = screen.getByRole("button", { name: "Create app" })
+      .querySelector<HTMLElement>("[data-launchpad-create-icon]");
+    expect(createIcon?.style.background).toBe("var(--accent)");
+    expect(createIcon?.style.color).toBe("white");
+  });
+
   it("launches Create app through the dedicated first tile", async () => {
     setDesign("macos-glass");
     const { handlers, container } = await renderLauncher();

--- a/tests/shell/launchpad.test.tsx
+++ b/tests/shell/launchpad.test.tsx
@@ -210,7 +210,8 @@ describe("Launchpad (macos-glass launcher)", () => {
       { name: "Editor", path: "__editor__" },
       { name: "Settings", path: "__settings__" },
       { name: "Plugins", path: "__plugins__" },
-      { name: "Browser", path: "apps/browser/dist/index.html" },
+      { name: "Browser", path: "apps/browser/dist/index.html", iconUrl: "/icons/browser.png" },
+      { name: "Notes", path: "apps/notes/index.html", iconUrl: "/icons/notes.png" },
     ];
 
     await renderLauncher({ apps });
@@ -238,6 +239,9 @@ describe("Launchpad (macos-glass launcher)", () => {
       .querySelector<HTMLElement>("[data-launchpad-create-icon]");
     expect(createIcon?.style.background).toBe("var(--accent)");
     expect(createIcon?.style.color).toBe("white");
+    expect(screen.getByRole("button", { name: "Browser" }).querySelector("img")).toBeNull();
+    expect(screen.getByRole("button", { name: "Notes" }).querySelector("img")?.getAttribute("src"))
+      .toBe("/icons/notes.png");
   });
 
   it("launches Create app through the dedicated first tile", async () => {


### PR DESCRIPTION
## Summary

- contain Web Canvas controls in one non-shrinking toolbar row so short viewports no longer collapse the canvas
- render Web launcher built-ins with the same colored vector treatment as Electron Desktop, including installed Browser aliases and Create app
- centralize fixed OS-view launcher appearance in the shared contract so Web and Electron cannot drift independently

## Tests

- 42 focused contract, Web shell, and Electron launcher tests passed
- contracts TypeScript check passed
- Web shell TypeScript check passed
- pattern scanner: 0 violations
- git diff --check passed
- full monorepo typecheck was attempted but pnpm could not fetch its pinned package-manager artifact in the restricted environment; the directly affected typechecks passed

## Invariants

- **Source of truth:** `OS_VIEW_FIXED_APP_APPEARANCES` and `OS_VIEW_CREATE_APP_APPEARANCE` in `@matrix-os/contracts` own cross-renderer launcher appearance.
- **Lock / transaction scope:** No persistence or database writes are changed; no lock or transaction is required.
- **Acceptable orphan states:** None. The toolbar wrapper and launcher fallback are render-only and do not create durable state.
- **Auth source of truth:** Unchanged. No authentication or authorization path is touched.
- **Deferred scope:** Live visual verification against an authenticated production-style runtime remains a CI/reviewer step; no data or routing migration is required.