### PR TITLE
fix(kernel): recover corrupt template manifests

### DIFF
--- a/packages/kernel/src/boot.ts
+++ b/packages/kernel/src/boot.ts
@@ -5,7 +5,7 @@ import {
 import * as fs from "node:fs";
 import { join, resolve, relative, dirname } from "node:path";
 import { execFileSync } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 const DEFAULT_HOME = join(
   process.env.HOME ?? process.env.USERPROFILE ?? ".",
@@ -121,6 +121,61 @@ function hashFile(filePath: string): string {
   return createHash("sha256").update(content).digest("hex");
 }
 
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return typeof value === "object"
+    && value !== null
+    && !Array.isArray(value)
+    && Object.values(value).every((entry) => typeof entry === "string");
+}
+
+function readInstalledManifest(
+  manifestPath: string,
+  logLines: string[],
+  now: string,
+): Record<string, string> {
+  if (!existsSync(manifestPath)) return {};
+
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    if (!isStringRecord(parsed)) {
+      throw new SyntaxError("Installed template manifest must be a string record");
+    }
+    return parsed;
+  } catch (err: unknown) {
+    if (!(err instanceof SyntaxError)) throw err;
+    logLines.push(`[${now}] Ignoring invalid installed manifest`);
+    return {};
+  }
+}
+
+function writeFileAtomic(filePath: string, contents: string): void {
+  const tempPath = `${filePath}.matrixos-${randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(tempPath, contents, {
+      encoding: "utf-8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    fs.renameSync(tempPath, filePath);
+  } catch (err: unknown) {
+    try {
+      fs.unlinkSync(tempPath);
+    } catch (cleanupErr: unknown) {
+      if (
+        !(cleanupErr instanceof Error)
+        || !("code" in cleanupErr)
+        || (cleanupErr as NodeJS.ErrnoException).code !== "ENOENT"
+      ) {
+        console.warn(
+          "[boot] Failed to clean template manifest temp file:",
+          cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+        );
+      }
+    }
+    throw err;
+  }
+}
+
 export function smartSyncTemplate(
   homePath: string,
   templateDir: string,
@@ -146,10 +201,7 @@ export function smartSyncTemplate(
 
   // Load installed manifest (what was last synced to user's home)
   const installedManifestPath = join(homePath, ".template-manifest.json");
-  let installedManifest: Record<string, string> = {};
-  if (existsSync(installedManifestPath)) {
-    installedManifest = JSON.parse(readFileSync(installedManifestPath, "utf-8"));
-  }
+  const installedManifest = readInstalledManifest(installedManifestPath, logLines, now);
 
   for (const [relPath, templateHash] of Object.entries(templateManifest)) {
     const homeFilePath = join(homePath, relPath);
@@ -211,7 +263,7 @@ export function smartSyncTemplate(
   }
 
   // Write updated installed manifest
-  writeFileNow(installedManifestPath, JSON.stringify(installedManifest, null, 2));
+  writeFileAtomic(installedManifestPath, JSON.stringify(installedManifest, null, 2));
 
   const summary = `${report.updated.length} updated, ${report.added.length} added, ${report.skipped.length} skipped`;
   logLines.push(`[${now}] Template sync completed: ${summary}`);

--- a/tests/kernel/smart-sync.test.ts
+++ b/tests/kernel/smart-sync.test.ts
@@ -205,6 +205,41 @@ describe("smart syncTemplate", () => {
     expect(installed["agents/builder.md"]).toBe(sha256("builder"));
   });
 
+  it("recovers from a corrupt installed manifest without overwriting customized files", async () => {
+    const smartSync = await importSync();
+
+    mkdirSync(join(templateDir, "apps", "notes"), { recursive: true });
+    mkdirSync(join(homeDir, "apps", "notes"), { recursive: true });
+    writeFileSync(join(templateDir, "apps", "notes", "matching.ts"), "bundled matching");
+    writeFileSync(join(templateDir, "apps", "notes", "customized.ts"), "bundled customized");
+    writeFileSync(join(homeDir, "apps", "notes", "matching.ts"), "bundled matching");
+    writeFileSync(join(homeDir, "apps", "notes", "customized.ts"), "owner customization");
+
+    writeManifest(templateDir, {
+      "apps/notes/matching.ts": sha256("bundled matching"),
+      "apps/notes/customized.ts": sha256("bundled customized"),
+    });
+    writeFileSync(
+      join(homeDir, ".template-manifest.json"),
+      '{"apps/notes/matching.ts":"stale"}trailing-corruption',
+    );
+
+    const report = smartSync(homeDir, templateDir);
+
+    expect(report.updated).toEqual([]);
+    expect(report.added).toEqual([]);
+    expect(report.skipped).toEqual(["apps/notes/customized.ts"]);
+    expect(readFileSync(join(homeDir, "apps", "notes", "customized.ts"), "utf-8")).toBe(
+      "owner customization",
+    );
+    expect(JSON.parse(readFileSync(join(homeDir, ".template-manifest.json"), "utf-8"))).toEqual({
+      "apps/notes/matching.ts": sha256("bundled matching"),
+    });
+    expect(readFileSync(join(homeDir, "system", "logs", "template-sync.log"), "utf-8")).toContain(
+      "Ignoring invalid installed manifest",
+    );
+  });
+
   it("is idempotent - running twice produces same result", async () => {
     const smartSync = await importSync();
 


### PR DESCRIPTION
## Summary

- recover kernel boot when the installed `.template-manifest.json` is syntactically or structurally invalid
- rebuild tracking conservatively so matching bundled files are re-tracked while owner-customized files remain untouched
- replace the installed manifest through an exclusive same-directory temporary file and atomic rename to prevent partial JSON writes

## Tests

- `flox activate -- bun run test tests/kernel/smart-sync.test.ts tests/kernel/boot.test.ts` — 22 passed
- `bun run typecheck` — passed
- `bun run check:patterns` — 0 violations
- `bun run check:patterns:diff` — 0 violations
- `git diff --check origin/main...HEAD` — passed
- `bun run test` on the host Node 26.3.1 runtime — 12,132 passed / 289 failed; failures are distributed across unrelated CLI/UI suites and include missing experimental `localStorage`, Node deprecation output, and terminal timing behavior. The affected kernel suites pass under the repository's Flox Node 24.14 runtime above; required CI remains the release gate.

## Review / Monitoring

- keep this PR open for Greptile review and required CI
- add `ready-for-ci` only after the latest Greptile review reaches 5/5 with no unresolved findings

## Invariants

- **Source of truth:** owner files remain authoritative. When installed tracking metadata is unreadable, sync treats files as untracked and only re-tracks exact template matches; mismatches are preserved as owner customizations.
- **Atomicity boundary:** the complete manifest is serialized to a unique same-directory file created with `wx`, then atomically renamed over the installed manifest.
- **Acceptable orphan state:** normal write or rename failures clean the temporary file. A forced process termination may leave a uniquely named temporary file, which is ignored by boot and never replaces owner data.
- **Auth / tenancy:** unchanged; this operates only inside the already-resolved Matrix home and bundled template directories.
- **Deferred scope:** no out-of-band mutation of an owner's existing manifest is needed; the next boot repairs tracking metadata in place.
