### PR TITLE
fix(chat): unify responsive inspector layout

### DIFF
--- a/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
@@ -566,10 +566,13 @@ export function CanonicalChatWorkspace({
           >
             <div
               data-slot="chat-starter-scroll"
-              className={`flex min-h-0 flex-1 items-center justify-center ${workspaceLayout === "narrow" ? "overflow-y-auto px-3 py-3" : "px-5 py-8"}`}
+              className={`flex min-h-0 flex-1 justify-center ${workspaceLayout === "narrow" ? "items-start overflow-y-auto px-3 py-3" : "items-center px-5 py-8"}`}
               style={workspaceLayout === "narrow" ? { scrollbarGutter: "stable" } : undefined}
             >
-              <div className="w-full max-w-[480px]">
+              <div
+                data-slot="chat-starter-stack"
+                className={`w-full max-w-[480px] ${workspaceLayout === "narrow" ? "my-auto" : ""}`}
+              >
                 <ChatStarterCards
                   layout="two-by-two"
                   density={workspaceLayout === "narrow" ? "compact" : "regular"}

--- a/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
@@ -566,7 +566,7 @@ export function CanonicalChatWorkspace({
           >
             <div
               data-slot="chat-starter-scroll"
-              className={`flex min-h-0 flex-1 justify-center ${workspaceLayout === "narrow" ? "items-start overflow-y-auto px-3 py-3" : "items-center px-5 py-8"}`}
+              className={`flex min-h-0 flex-1 items-center justify-center ${workspaceLayout === "narrow" ? "overflow-y-auto px-3 py-3" : "px-5 py-8"}`}
               style={workspaceLayout === "narrow" ? { scrollbarGutter: "stable" } : undefined}
             >
               <div className="w-full max-w-[480px]">

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
@@ -237,6 +237,9 @@ export default function DesktopSurfaceFrame({
   const workChatTitle = isWorkSurface && tab.chatId
     ? tab.chatTitle ?? surfaceChrome?.title ?? "Chat"
     : undefined;
+  const showsSurfaceTopBar = isWindow
+    || Boolean(workChatTitle)
+    || Boolean(surfaceChrome && (!isWorkSurface || surfaceChrome.rightActions));
 
   const frame = (
     <SurfaceChromeContext.Provider value={surfaceChromeHost}>
@@ -250,7 +253,7 @@ export default function DesktopSurfaceFrame({
       ) : undefined}
       safeAreaLayout={sidebarOwnsChrome ? "sidebar" : "pane"}
       topBarReservesSafeArea={isWindow || !isWorkSurface}
-      topBar={isWindow || workChatTitle || (surfaceChrome && !isWorkSurface) ? (
+      topBar={showsSurfaceTopBar ? (
         <TopBar
           title={workChatTitle ?? (sidebarHidesTitle ? undefined : surfaceChrome ? surfaceChrome.title : tab.title)}
           leftActions={surfaceChrome?.leftActions}

--- a/desktop/src/renderer/src/features/work/WorkTab.tsx
+++ b/desktop/src/renderer/src/features/work/WorkTab.tsx
@@ -48,13 +48,11 @@ interface WorkResponsiveState {
 }
 
 const WIDE_WORK_MIN_WIDTH = 1_280;
-const MEDIUM_WORK_MIN_WIDTH = 840;
+const MEDIUM_WORK_MIN_WIDTH = 740;
 const NAVIGATION_WIDTH = 240;
-const MIN_INSPECTOR_WIDTH = 360;
-const MAX_INSPECTOR_WIDTH = 820;
-const MIN_CHAT_WIDTH = 360;
+const MIN_INSPECTOR_WIDTH = 240;
+const MAX_INSPECTOR_WIDTH = 380;
 const COLLAPSE_RESIZE_THRESHOLD = 48;
-const INSPECTOR_SIDE_BY_SIDE_MIN_WIDTH = 1_000;
 
 function workLayoutForWidth(width: number): WorkLayout {
   if (width >= WIDE_WORK_MIN_WIDTH) return "wide";
@@ -111,7 +109,6 @@ function ResponsiveWorkInspector({
   scope,
   projects,
   active,
-  exclusive,
   layout,
   onClose,
   onOpen,
@@ -130,7 +127,6 @@ function ResponsiveWorkInspector({
   scope?: WorkFilesScope;
   projects: Project[];
   active: boolean;
-  exclusive: boolean;
   layout: WorkLayout;
   onClose: () => void;
   onOpen: () => void;
@@ -171,12 +167,10 @@ function ResponsiveWorkInspector({
       hidden={!active}
       className={layout === "narrow"
         ? "absolute inset-0 z-20 flex w-full"
-        : exclusive
-          ? "relative flex min-h-0 min-w-0 flex-1"
-          : "relative flex min-h-0 shrink-0"}
-      style={layout === "narrow" || exclusive ? undefined : { width }}
+        : "relative flex min-h-0 shrink-0"}
+      style={layout === "narrow" ? undefined : { width }}
     >
-      {layout !== "narrow" && !exclusive ? <ResizeHandle side="left" label="Resize Chat inspector" value={width} min={MIN_INSPECTOR_WIDTH} max={MAX_INSPECTOR_WIDTH} onPointerDown={onResizeStart} onKeyboardResize={onResizeKeyboard} /> : null}
+      {layout !== "narrow" ? <ResizeHandle side="left" label="Resize Chat inspector" value={width} min={MIN_INSPECTOR_WIDTH} max={MAX_INSPECTOR_WIDTH} onPointerDown={onResizeStart} onKeyboardResize={onResizeKeyboard} /> : null}
       <WorkFilesInspector
         detail={detail}
         scope={scope}
@@ -238,8 +232,7 @@ export default function WorkTab({
     narrowPane: "chat",
     narrowPaneRouteKey: null,
   });
-  const [inspectorWidth, setInspectorWidth] = useState(640);
-  const [surfaceWidth, setSurfaceWidth] = useState(0);
+  const [inspectorWidth, setInspectorWidth] = useState(MAX_INSPECTOR_WIDTH);
   const [draftTerminalLaunch, setDraftTerminalLaunch] = useState<{
     chatId: string;
     session: TerminalSessionSummary;
@@ -268,11 +261,7 @@ export default function WorkTab({
     ((layout === "wide" || layout === "medium") && inspectorOpen)
     || (layout === "narrow" && narrowPane === "inspector")
   );
-  const inspectorExclusive = inspectorVisible && (
-    layout === "narrow"
-      ? narrowPane === "inspector"
-      : surfaceWidth > 0 && surfaceWidth < INSPECTOR_SIDE_BY_SIDE_MIN_WIDTH
-  );
+  const inspectorExclusive = inspectorVisible && layout === "narrow";
 
   useEffect(() => {
     const pendingDisposal = pendingEventSourceDisposalRef.current;
@@ -326,14 +315,7 @@ export default function WorkTab({
     const applyWidth = (width: number) => {
       const firstMeasurement = !measuredWidthRef.current;
       measuredWidthRef.current = true;
-      const osWindowWidth = node.closest<HTMLElement>("[data-os-window]")?.clientWidth ?? 0;
-      const measuredSurfaceWidth = osWindowWidth > 0
-        ? osWindowWidth
-        : width > 0
-          ? width + (hostedChrome ? NAVIGATION_WIDTH : 0)
-          : 0;
-      setSurfaceWidth(measuredSurfaceWidth);
-      const nextLayout = measuredSurfaceWidth > 0 ? workLayoutForWidth(measuredSurfaceWidth) : "narrow";
+      const nextLayout = width > 0 ? workLayoutForWidth(width) : "narrow";
       const inspectorFocused = Boolean(
         inspectorRegionRef.current?.contains(document.activeElement),
       );
@@ -409,9 +391,7 @@ export default function WorkTab({
         closeInspector();
         return;
       }
-      const navigationSpace = hostedChrome ? NAVIGATION_WIDTH : navigationOpen ? NAVIGATION_WIDTH : 36;
-      const maxInspector = Math.max(MIN_INSPECTOR_WIDTH, Math.min(MAX_INSPECTOR_WIDTH, bounds.width - navigationSpace - MIN_CHAT_WIDTH));
-      setInspectorWidth(Math.max(MIN_INSPECTOR_WIDTH, Math.min(maxInspector, requested)));
+      setInspectorWidth(Math.max(MIN_INSPECTOR_WIDTH, Math.min(MAX_INSPECTOR_WIDTH, requested)));
     };
     const captureTarget = event.currentTarget;
     const pointerId = event.pointerId;
@@ -439,14 +419,11 @@ export default function WorkTab({
     captureTarget.addEventListener("lostpointercapture", stop);
   };
   const resizeInspectorWithKeyboard = (delta: number) => {
-    const width = workRef.current?.getBoundingClientRect().width ?? 0;
     if (inspectorWidth + delta < MIN_INSPECTOR_WIDTH) {
       closeInspector();
       return;
     }
-    const navigationSpace = hostedChrome ? NAVIGATION_WIDTH : navigationOpen ? NAVIGATION_WIDTH : 36;
-    const maxInspector = Math.max(MIN_INSPECTOR_WIDTH, Math.min(MAX_INSPECTOR_WIDTH, width - navigationSpace - MIN_CHAT_WIDTH));
-    setInspectorWidth((current) => Math.max(MIN_INSPECTOR_WIDTH, Math.min(maxInspector, current + delta)));
+    setInspectorWidth((current) => Math.max(MIN_INSPECTOR_WIDTH, Math.min(MAX_INSPECTOR_WIDTH, current + delta)));
   };
   const showChat = useCallback((focusNavigation = false) => {
     if (focusNavigation) pendingFocusRef.current = showNavigationRef;
@@ -560,7 +537,6 @@ export default function WorkTab({
       detail={detail}
       projects={projects}
       active={inspectorVisible}
-      exclusive={inspectorExclusive}
       layout={layout}
       onClose={closeInspector}
       onOpen={openInspector}
@@ -586,7 +562,6 @@ export default function WorkTab({
       scope={draftScope}
       projects={projects}
       active={inspectorVisible}
-      exclusive={inspectorExclusive}
       layout={layout}
       onClose={closeInspector}
       onOpen={openInspector}
@@ -635,7 +610,7 @@ export default function WorkTab({
   const chromeSpec = useMemo(() => ({
     title: chromeTitle,
     leftPaneWidth: hostedChrome || (layout !== "narrow" && navigationVisible) ? NAVIGATION_WIDTH : 0,
-    rightPaneWidth: layout !== "narrow" && inspectorVisible && !inspectorExclusive ? inspectorWidth : 0,
+    rightPaneWidth: layout !== "narrow" && inspectorVisible ? inspectorWidth : 0,
     rightActions: hasInspector ? (
       <PaneButton
         buttonRef={showToolsRef}
@@ -650,7 +625,7 @@ export default function WorkTab({
           : <PanelRightOpen size={15} aria-hidden />}
       </PaneButton>
     ) : undefined,
-  }), [chromeTitle, closeInspector, hasInspector, hostedChrome, inspectorExclusive, inspectorVisible, inspectorWidth, layout, navigationVisible, openInspector]);
+  }), [chromeTitle, closeInspector, hasInspector, hostedChrome, inspectorVisible, inspectorWidth, layout, navigationVisible, openInspector]);
 
   useLayoutEffect(() => {
     if (!active || !surfaceChromeHost) return;
@@ -663,9 +638,9 @@ export default function WorkTab({
       ref={workRef}
       className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
       data-layout={layout}
-      data-pane={layout === "narrow" ? narrowPane : inspectorExclusive ? "inspector" : undefined}
+      data-pane={layout === "narrow" ? narrowPane : undefined}
     >
-      {hostedChrome && initialChatId && initialChatTitle ? (
+      {hostedChrome && hasInspector ? (
         <div
           data-work-main-header
           aria-hidden="true"

--- a/tests/desktop/canonical-chat-workspace.test.tsx
+++ b/tests/desktop/canonical-chat-workspace.test.tsx
@@ -331,6 +331,7 @@ describe("CanonicalChatWorkspace", () => {
     const index = screen.getByRole("complementary", { name: "Global chats" }).parentElement;
     const starters = document.querySelector<HTMLElement>('[data-slot="chat-starter-cards"]');
     const starterScroll = document.querySelector<HTMLElement>('[data-slot="chat-starter-scroll"]');
+    const starterStack = document.querySelector<HTMLElement>('[data-slot="chat-starter-stack"]');
     const composer = document.querySelector<HTMLElement>('[data-slot="shared-chat-composer"] .prompt-card');
     const newChatContent = document.querySelector<HTMLElement>('[data-slot="chat-new-chat-content"]');
     expect(workspace?.getAttribute("data-layout")).toBe("narrow");
@@ -339,8 +340,8 @@ describe("CanonicalChatWorkspace", () => {
     expect(starters?.className).toContain("grid-cols-1");
     expect(screen.getByRole("button", { name: "Explore and understand code" }).className).toContain("min-h-20");
     expect(starterScroll?.className).toContain("overflow-y-auto");
-    expect(starterScroll?.className).toContain("items-center");
-    expect(starterScroll?.className).not.toContain("items-start");
+    expect(starterScroll?.className).toContain("items-start");
+    expect(starterStack?.className).toContain("my-auto");
     expect(starterScroll?.style.scrollbarGutter).toBe("stable");
     expect(newChatContent?.className).toContain("overflow-hidden");
     expect(composer?.getAttribute("data-layout")).toBe("narrow");

--- a/tests/desktop/canonical-chat-workspace.test.tsx
+++ b/tests/desktop/canonical-chat-workspace.test.tsx
@@ -339,7 +339,8 @@ describe("CanonicalChatWorkspace", () => {
     expect(starters?.className).toContain("grid-cols-1");
     expect(screen.getByRole("button", { name: "Explore and understand code" }).className).toContain("min-h-20");
     expect(starterScroll?.className).toContain("overflow-y-auto");
-    expect(starterScroll?.className).toContain("items-start");
+    expect(starterScroll?.className).toContain("items-center");
+    expect(starterScroll?.className).not.toContain("items-start");
     expect(starterScroll?.style.scrollbarGutter).toBe("stable");
     expect(newChatContent?.className).toContain("overflow-hidden");
     expect(composer?.getAttribute("data-layout")).toBe("narrow");

--- a/tests/desktop/tab-content.test.tsx
+++ b/tests/desktop/tab-content.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TabPane, TabErrorBoundary } from "@desktop/renderer/src/features/mission-control/TabContent";
 import DesktopSurfaceFrame from "@desktop/renderer/src/features/desktop-shell/DesktopSurfaceFrame";
+import { useSurfaceChromeHost } from "@desktop/renderer/src/features/desktop-shell/SurfaceChrome";
 import type { Tab } from "@desktop/renderer/src/stores/tabs";
 
 const workTabMock = vi.hoisted(() => vi.fn(() => <div>Work</div>));
@@ -116,6 +117,46 @@ describe("current desktop tab panes", () => {
     const tabSidebar = view.container.querySelector("[data-os-window-sidebar]") as HTMLElement;
     expect(tabSidebar.querySelector<HTMLElement>('[data-os-window-safe-view="sidebar"]')?.style.paddingTop).toBe("");
     expect(view.container.querySelector("[data-os-window-top-bar-overlay]")).toBeNull();
+  });
+
+  it("shows the inspector toggle for a New Chat in full-tab mode", () => {
+    workTabMock.mockImplementation(function DraftWorkWithInspectorChrome() {
+      const chromeHost = useSurfaceChromeHost();
+      React.useLayoutEffect(() => {
+        chromeHost?.setChrome({
+          leftPaneWidth: 240,
+          rightPaneWidth: 0,
+          rightActions: <button type="button" aria-label="Show inspector">Inspector</button>,
+        });
+        return () => chromeHost?.setChrome(null);
+      }, [chromeHost]);
+      return <div>Work</div>;
+    });
+    const tab: Tab = {
+      id: "chat-draft",
+      kind: "work",
+      title: "Chat",
+      closable: false,
+      workRoute: "chat",
+      chatView: "draft",
+    };
+
+    const view = render(<DesktopSurfaceFrame
+      tab={tab}
+      surface={{ tabId: tab.id, mode: "tab", bounds: { x: 0, y: 0, width: 1_200, height: 800 }, zIndex: 1 }}
+      active
+      tabWorkspaceActive
+      overlayOpen={false}
+      presentation="desktop"
+      onFocus={vi.fn()}
+      onClose={vi.fn()}
+      onMinimize={vi.fn()}
+      onMaximize={vi.fn()}
+      onBoundsChange={vi.fn()}
+    />);
+
+    expect(screen.getByRole("button", { name: "Show inspector" })).toBeTruthy();
+    expect(view.container.querySelector("[data-os-window-top-bar-overlay]")).toBeTruthy();
   });
 
   it("collapses and restores an active Chat sidebar through OSWindow", () => {

--- a/tests/desktop/work-tab.test.tsx
+++ b/tests/desktop/work-tab.test.tsx
@@ -496,6 +496,7 @@ describe("WorkTab rail integration", () => {
 
     const sideBySideInspector = screen.getByRole("complementary", { name: "Chat inspector" }).parentElement as HTMLElement;
     expect(screen.getByRole("main").getAttribute("aria-hidden")).toBeNull();
+    expect(screen.queryByRole("navigation", { name: "Chat navigation" })).toBeNull();
     expect(sideBySideInspector.className).toContain("shrink-0");
     expect(sideBySideInspector.style.width).toBe("380px");
   });

--- a/tests/desktop/work-tab.test.tsx
+++ b/tests/desktop/work-tab.test.tsx
@@ -478,26 +478,26 @@ describe("WorkTab rail integration", () => {
     expect(inspectorProps.active.at(-1)).toBe(false);
   });
 
-  it("shows only the inspector below 1000px and uses side-by-side panes at 1000px", async () => {
+  it("shows only the inspector below a 740px main pane and docks it at 740px", async () => {
     render(<WorkTab route="chat" active initialChatId="chat_global" initialChatView="conversation" />);
     await screen.findByRole("button", { name: "Global chat" });
 
-    resizeWork(999);
+    resizeWork(739);
     fireEvent.click(screen.getByRole("button", { name: "Show inspector" }));
 
     const exclusiveInspector = screen.getByRole("complementary", { name: "Chat inspector" }).parentElement as HTMLElement;
     expect(screen.getByRole("main", { hidden: true }).getAttribute("aria-hidden")).toBe("true");
-    expect(exclusiveInspector.className).toContain("flex-1");
+    expect(exclusiveInspector.className).toContain("w-full");
     expect(exclusiveInspector.style.width).toBe("");
 
-    fireEvent.click(screen.getByRole("button", { name: "Hide inspector" }));
-    resizeWork(1_000);
+    fireEvent.click(screen.getByRole("button", { name: "Back to chat" }));
+    resizeWork(740);
     fireEvent.click(screen.getByRole("button", { name: "Show inspector" }));
 
     const sideBySideInspector = screen.getByRole("complementary", { name: "Chat inspector" }).parentElement as HTMLElement;
     expect(screen.getByRole("main").getAttribute("aria-hidden")).toBeNull();
     expect(sideBySideInspector.className).toContain("shrink-0");
-    expect(sideBySideInspector.style.width).toBe("640px");
+    expect(sideBySideInspector.style.width).toBe("380px");
   });
 
   it.each([
@@ -539,13 +539,14 @@ describe("WorkTab rail integration", () => {
     const inspectorSeparator = screen.getByRole("separator", { name: "Resize Chat inspector" });
     expect(screen.queryByRole("separator", { name: "Resize Chat navigation" })).toBeNull();
     expect(screen.getByRole("navigation", { name: "Chat navigation" }).className).not.toContain("border-r-0");
-    expect(inspectorSeparator.getAttribute("aria-valuemin")).toBe("360");
-    expect(inspectorSeparator.getAttribute("aria-valuenow")).toBe("640");
+    expect(inspectorSeparator.getAttribute("aria-valuemin")).toBe("240");
+    expect(inspectorSeparator.getAttribute("aria-valuemax")).toBe("380");
+    expect(inspectorSeparator.getAttribute("aria-valuenow")).toBe("380");
     expect(inspectorSeparator.querySelector("span")?.style.background).toBe("transparent");
 
-    fireEvent.keyDown(inspectorSeparator, { key: "ArrowLeft" });
+    fireEvent.keyDown(inspectorSeparator, { key: "ArrowRight" });
 
-    expect(screen.getByRole("separator", { name: "Resize Chat inspector" }).getAttribute("aria-valuenow")).toBe("656");
+    expect(screen.getByRole("separator", { name: "Resize Chat inspector" }).getAttribute("aria-valuenow")).toBe("364");
   });
 
   it("stops resizing the Chat inspector when an extreme pointer drag is cancelled", async () => {
@@ -555,12 +556,12 @@ describe("WorkTab rail integration", () => {
     const inspectorSeparator = screen.getByRole("separator", { name: "Resize Chat inspector" });
     fireEvent.pointerDown(inspectorSeparator, { button: 0, clientX: 760, pointerId: 17 });
     fireEvent.pointerMove(window, { clientX: 700, pointerId: 17 });
-    expect(screen.getByRole("separator", { name: "Resize Chat inspector" }).getAttribute("aria-valuenow")).toBe("700");
+    expect(screen.getByRole("separator", { name: "Resize Chat inspector" }).getAttribute("aria-valuenow")).toBe("380");
 
     fireEvent.pointerCancel(window, { pointerId: 17 });
     fireEvent.pointerMove(window, { clientX: -1_000, pointerId: 17 });
 
-    expect(screen.getByRole("separator", { name: "Resize Chat inspector" }).getAttribute("aria-valuenow")).toBe("700");
+    expect(screen.getByRole("separator", { name: "Resize Chat inspector" }).getAttribute("aria-valuenow")).toBe("380");
   });
 
   it("keeps navigation visible while the inspector divider collapses past its minimum", async () => {
@@ -676,7 +677,7 @@ describe("WorkTab rail integration", () => {
     expect(hostedMain.queryByRole("button", { name: "Toggle Chat sidebar" })).toBeNull();
     expect(hostedMainElement.querySelector("[data-work-main-header]")?.className).toContain("h-12");
     expect(screen.getByTestId("left-pane-width").textContent).toBe("240");
-    expect(screen.getByTestId("right-pane-width").textContent).toBe("640");
+    expect(screen.getByTestId("right-pane-width").textContent).toBe("380");
     expect(within(screen.getByTestId("hosted-chat-main")).queryByRole("navigation", { name: "Chat navigation" })).toBeNull();
     const hideInspector = screen.getByRole("button", { name: "Hide inspector" });
     expect(within(chromeTitle.closest("header")!).queryByRole("button", { name: /Chat navigation/ })).toBeNull();
@@ -694,7 +695,7 @@ describe("WorkTab rail integration", () => {
     expect(screen.getByRole("button", { name: "Show inspector" })).toBeTruthy();
   });
 
-  it("keeps the hosted layout stable after the sidebar slot reduces the measured main-pane width", async () => {
+  it("uses the hosted main-pane width without adding the window sidebar", async () => {
     initialWorkWidth = 900;
     function HostedWork() {
       const [chrome, setChrome] = React.useState<SurfaceChromeSpec | null>(null);
@@ -711,12 +712,16 @@ describe("WorkTab rail integration", () => {
     await screen.findByText("Projects center");
     expect(screen.getByTestId("stable-hosted-width").textContent).toBe("240");
 
-    resizeWork(660);
+    resizeWork(739);
+
+    await waitFor(() => expect(document.querySelector('[data-layout="narrow"]')).toBeTruthy());
+
+    resizeWork(740);
 
     await waitFor(() => expect(document.querySelector('[data-layout="medium"]')).toBeTruthy());
   });
 
-  it("omits a top-bar title for a new Chat draft", async () => {
+  it("keeps a new Chat title empty while reserving the shared inspector header row", async () => {
     function HostedDraft() {
       const [chrome, setChrome] = React.useState<SurfaceChromeSpec | null>(null);
       const host = React.useMemo(() => ({ setChrome }), []);
@@ -732,7 +737,7 @@ describe("WorkTab rail integration", () => {
     await screen.findByText("Chat center");
 
     expect(screen.getByTestId("draft-chrome").textContent).toBe("");
-    expect(document.querySelector("[data-work-main-header]")).toBeNull();
+    expect(document.querySelector("[data-work-main-header]")?.className).toContain("h-12");
   });
 
   it("returns a stale narrow inspector to Chat when Work becomes inactive", async () => {


### PR DESCRIPTION
## Summary
- vertically center compact single-column Chat starter cards while keeping an overflowing stack reachable from its top
- switch the inspector at the exact measured 740px Work pane breakpoint: full-pane below it and docked at or above it
- constrain the docked inspector to the requested 240–380px range
- align New Chat inspector chrome with existing chats and expose its toggle in full-tab mode

## Tests
- `pnpm exec vitest run tests/desktop/canonical-chat-workspace.test.tsx tests/desktop/work-tab.test.tsx tests/desktop/tab-content.test.tsx tests/desktop/os-window.test.tsx tests/desktop/work-inspector-terminal.test.tsx` — 101 passed
- `pnpm --dir desktop typecheck` — passed
- `pnpm run check:patterns` — 0 violations; 5 repository-wide warnings outside this UI diff
- manual responsive-layout validation by the requester — passed
- root `bun run typecheck` — unavailable because `bun` is not installed on this shell; the equivalent desktop TypeScript check passed via pnpm
- full `pnpm run test` — previously attempted; unrelated gateway app-runtime builder suites remained long-running and emitted temporary `.build.log` ENOENT warnings, so focused UI coverage and CI remain authoritative

## Review/Monitoring
- Greptile's centered-overflow finding is addressed with start-aligned scrolling plus auto margins on the starter stack, which centers fitting content without placing overflow above the scroll origin
- the 740px docking breakpoint is an intentional product requirement based on the measured Work pane
- in medium layout, opening the inspector closes the 240px navigation pane; a regression assertion verifies the navigation and inspector cannot produce the reported 120px Chat region
- require the latest trusted Greptile result to reach 5/5 before adding `ready-for-ci`
- add `ready-for-ci` only after review is clean, then wait for triggered CI

## Invariants
- Source of truth: existing React responsive state and shared SurfaceChrome registration remain authoritative
- Lock/transaction scope: not applicable; UI-only change with no persistence or database writes
- Acceptable orphan states: none introduced
- Auth source of truth: unchanged
- Deferred scope: unrelated gateway app-runtime builder timeout behavior remains outside this PR
