### PR TITLE
fix(desktop): reveal pinned Chat actions on hover

### DIFF
--- a/desktop/src/renderer/src/features/work/work-rail/WorkRailChatRow.tsx
+++ b/desktop/src/renderer/src/features/work/work-rail/WorkRailChatRow.tsx
@@ -64,7 +64,7 @@ export function WorkRailChatRow({
           <ChatAgentStateIndicator state={agentState} title={record.chat.title} />
         </button>
         <div
-          className="absolute right-1 top-1/2 z-10 flex -translate-y-1/2 items-center gap-0.5 rounded-md opacity-0 transition-opacity group-hover/chat:opacity-100 group-focus-within/chat:opacity-100"
+          className="pointer-events-none absolute right-1 top-1/2 z-10 flex -translate-y-1/2 items-center gap-0.5 rounded-md opacity-0 transition-opacity group-hover/chat:pointer-events-auto group-hover/chat:opacity-100 group-focus-within/chat:pointer-events-auto group-focus-within/chat:opacity-100"
           style={{
             background: active
               ? "linear-gradient(var(--bg-selected), var(--bg-selected)), var(--bg-surface)"

--- a/desktop/src/renderer/src/features/work/work-rail/WorkRailChatRow.tsx
+++ b/desktop/src/renderer/src/features/work/work-rail/WorkRailChatRow.tsx
@@ -64,7 +64,7 @@ export function WorkRailChatRow({
           <ChatAgentStateIndicator state={agentState} title={record.chat.title} />
         </button>
         <div
-          className={`absolute right-1 top-1/2 z-10 flex -translate-y-1/2 items-center rounded-md transition-[gap,opacity] group-hover/chat:opacity-100 group-focus-within/chat:opacity-100 ${placement === "pinned" ? "gap-0 opacity-100 group-hover/chat:gap-0.5 group-focus-within/chat:gap-0.5" : "gap-0.5 opacity-0"}`}
+          className="absolute right-1 top-1/2 z-10 flex -translate-y-1/2 items-center gap-0.5 rounded-md opacity-0 transition-opacity group-hover/chat:opacity-100 group-focus-within/chat:opacity-100"
           style={{
             background: active
               ? "linear-gradient(var(--bg-selected), var(--bg-selected)), var(--bg-surface)"
@@ -79,17 +79,15 @@ export function WorkRailChatRow({
             className="flex size-6 shrink-0 items-center justify-center rounded-md outline-none hover:bg-[var(--bg-selected)] focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
             onClick={onPin}
           >
-            {placement === "pinned"
-              ? <PinIcon size={14} strokeWidth={1.5} aria-hidden />
-              : pinned
-                ? <PinOffIcon size={13} aria-hidden />
-                : <PinIcon size={13} aria-hidden />}
+            {pinned
+              ? <PinOffIcon size={13} aria-hidden />
+              : <PinIcon size={13} aria-hidden />}
           </button>
           <button
             type="button"
             aria-label={`Delete ${record.chat.title}`}
             title={`Delete ${record.chat.title}`}
-            className={`${placement === "pinned" ? "w-0 overflow-hidden opacity-0 group-hover/chat:w-6 group-hover/chat:opacity-100 group-focus-within/chat:w-6 group-focus-within/chat:opacity-100" : "w-6"} flex h-6 shrink-0 items-center justify-center rounded-md outline-none transition-[width,opacity] hover:bg-[var(--danger-muted)] hover:text-[var(--danger)] focus-visible:w-6 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-[var(--accent)]`}
+            className="flex size-6 shrink-0 items-center justify-center rounded-md outline-none hover:bg-[var(--danger-muted)] hover:text-[var(--danger)] focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
             onClick={onDelete}
           >
             <Trash2 size={13} aria-hidden />

--- a/tests/desktop/work-rail.test.tsx
+++ b/tests/desktop/work-rail.test.tsx
@@ -9,6 +9,7 @@ import type {
   CanonicalChatInvalidation,
 } from "@desktop/renderer/src/lib/canonical-chat-client";
 import { WorkRail } from "@desktop/renderer/src/features/work/WorkRail";
+import { PinOffIcon } from "@desktop/renderer/src/lib/hugeicons";
 import type { Project } from "@desktop/renderer/src/stores/board";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -296,26 +297,33 @@ describe("WorkRail", () => {
     );
   });
 
-  it("keeps a pinned Chat action compact until hover or keyboard focus reveals Delete", async () => {
-    setup();
-    await screen.findByRole("button", { name: "Pinned global" });
-    const pin = screen.getByRole("button", { name: "Unpin Pinned global" });
-    const remove = screen.getByRole("button", { name: "Delete Pinned global" });
+  it("hides pinned Chat actions until hover or focus while preserving run status and an Unpin icon", async () => {
+    const runningPinned = record("chat_running_pinned", "Running pinned", {
+      pinned: true,
+      updatedAt: "2026-08-28T12:00:00.000Z",
+      activeRunStatus: "running",
+    });
+    const client = {
+      list: vi.fn(async () => ({ items: [runningPinned] })),
+    } as unknown as CanonicalChatClient;
+    renderRail(client);
+
+    const chat = await screen.findByRole("button", { name: "Running pinned" });
+    const pin = screen.getByRole("button", { name: "Unpin Running pinned" });
+    const remove = screen.getByRole("button", { name: "Delete Running pinned" });
     const actions = pin.parentElement as HTMLElement;
+    const expectedIcon = render(<PinOffIcon size={13} aria-hidden />).container.querySelector("svg");
 
-    expect(actions.className).toContain("gap-0");
-    expect(actions.className).toContain("group-hover/chat:gap-0.5");
-    expect(actions.className).toContain("group-focus-within/chat:gap-0.5");
-    expect(remove.className).toContain("w-0");
-    expect(remove.className).toContain("group-hover/chat:w-6");
-    expect(remove.className).toContain("group-focus-within/chat:w-6");
-    expect(remove.className).toContain("opacity-0");
-    expect(remove.className).toContain("group-hover/chat:opacity-100");
-    expect(remove.className).toContain("group-focus-within/chat:opacity-100");
-    expect(remove.getAttribute("tabindex")).toBeNull();
+    expect(within(chat).getByLabelText("Agent running for Running pinned")).toBeTruthy();
+    expect(actions.className).toContain("gap-0.5");
+    expect(actions.className).toContain("opacity-0");
+    expect(actions.className).toContain("group-hover/chat:opacity-100");
+    expect(actions.className).toContain("group-focus-within/chat:opacity-100");
+    expect(remove.className).toContain("size-6");
+    expect(pin.querySelector("svg")?.isEqualNode(expectedIcon ?? null)).toBe(true);
 
-    remove.focus();
-    expect(document.activeElement).toBe(remove);
+    pin.focus();
+    expect(document.activeElement).toBe(pin);
   });
 
   it("scrolls only an overflowing Chat title while hover actions are visible", async () => {

--- a/tests/desktop/work-rail.test.tsx
+++ b/tests/desktop/work-rail.test.tsx
@@ -317,6 +317,9 @@ describe("WorkRail", () => {
     expect(within(chat).getByLabelText("Agent running for Running pinned")).toBeTruthy();
     expect(actions.className).toContain("gap-0.5");
     expect(actions.className).toContain("opacity-0");
+    expect(actions.className).toContain("pointer-events-none");
+    expect(actions.className).toContain("group-hover/chat:pointer-events-auto");
+    expect(actions.className).toContain("group-focus-within/chat:pointer-events-auto");
     expect(actions.className).toContain("group-hover/chat:opacity-100");
     expect(actions.className).toContain("group-focus-within/chat:opacity-100");
     expect(remove.className).toContain("size-6");


### PR DESCRIPTION
## Summary

- hide pinned Chat row actions until hover or keyboard focus
- show the Unpin glyph for pinned rows instead of the Pin glyph
- preserve the trailing agent run-state indicator while the row is at rest
- prevent visually hidden actions from intercepting pointer input
- cover the pinned-running row and pointer-event behavior in the WorkRail test

Closes OM-196.

## Invariants

- **Source of truth:** unchanged; pinned state continues to come from canonical Chat `record.chat.userState.pinned`, and run state continues to come from `resolveWorkRailAgentState(record)`.
- **Lock / transaction scope:** none; this is a renderer-only presentation change with no persistence or mutation-path changes.
- **Acceptable orphan states:** none introduced.
- **Auth source of truth:** unchanged; no auth or gateway behavior changed.
- **Deferred scope:** none. Public docs are unaffected.

## Tests

- `flox activate -- pnpm exec vitest run tests/desktop/work-rail.test.tsx` — 33/33 passed after both TDD cycles
- `flox activate -- bun run typecheck` — passed on final head
- `flox activate -- bun run check:patterns` — passed on final head (0 violations; 5 pre-existing scanner warnings)
- `flox activate -- bun run build:desktop` — passed on final head
- Local full `bun run test` is not clean on this macOS host: the unrelated Linux host-script suite fails 8/34 tests because GNU `stat -c` and `add-apt-repository` are unavailable. The suite reproduced alone as the same 8 failures with 26/34 passing. Exact-head Linux CI is required before merge.

## Review / monitoring

- Human Review passed on the original UI behavior.
- Greptile's pointer-input finding was fixed in `1b80dc808`; its thread is answered and resolved.
- `ready-for-ci` will provide the required exact-head Linux validation before merge.
