### PR TITLE
fix(chat): preserve Pi final assistant output

### DIFF
--- a/packages/gateway/src/coding-agents/pi-provider.ts
+++ b/packages/gateway/src/coding-agents/pi-provider.ts
@@ -269,6 +269,7 @@ interface PiRunCollectorOptions {
 interface PiCollectedRun {
   events: AgentThreadEvent[];
   sessionId: string | null;
+  hasMeaningfulOutput: boolean;
 }
 
 // Aggregating reducer: pi streams fine-grained deltas, but the provider
@@ -283,6 +284,7 @@ function createPiRunCollector(options: PiRunCollectorOptions) {
   let assistantText = "";
   let assistantMessageId: string | null = null;
   let assistantEmittedChars = 0;
+  let hasMeaningfulOutput = false;
   let fallbackToolCounter = 0;
   // Each tracked tool needs at least a started + completed event. Reserving
   // half the run budget keeps both the event stream and the in-memory tool
@@ -296,7 +298,16 @@ function createPiRunCollector(options: PiRunCollectorOptions) {
       dropped += 1;
       return;
     }
-    events.push(AgentThreadEventSchema.parse(event));
+    const parsed = AgentThreadEventSchema.parse(event);
+    events.push(parsed);
+    if (
+      parsed.type === "assistant.text.delta"
+      || parsed.type === "tool.started"
+      || parsed.type === "tool.output"
+      || parsed.type === "tool.completed"
+    ) {
+      hasMeaningfulOutput = true;
+    }
   }
 
   function baseEvent() {
@@ -314,6 +325,35 @@ function createPiRunCollector(options: PiRunCollectorOptions) {
       emit({ ...baseEvent(), type: "assistant.text.delta", messageId: assistantMessageId, delta: chunk });
     }
     assistantEmittedChars = assistantText.length;
+  }
+
+  function ensureAssistantMessage(): void {
+    if (assistantMessageId) return;
+    assistantMessageCounter += 1;
+    assistantMessageId = `msg_${options.scope}_${assistantMessageCounter}`;
+  }
+
+  function reconcileAssistantText(authoritativeText: string): void {
+    if (authoritativeText.length === 0) return;
+    ensureAssistantMessage();
+    // Keep one character beyond the output cap so flushAssistantText can
+    // preserve the existing explicit truncation marker without retaining an
+    // arbitrarily large final payload.
+    const bounded = authoritativeText.slice(0, MAX_TEXT_CHARS + 1);
+    if (!options.streaming || assistantEmittedChars === 0) {
+      assistantText = bounded;
+      return;
+    }
+    if (bounded.startsWith(assistantText)) {
+      assistantText = bounded;
+      return;
+    }
+    // Already-published streaming text cannot be retracted safely. Keep it
+    // visible and record only bounded lengths when Pi's final snapshot differs.
+    logCodingAgentWarning(
+      "pi provider final assistant text diverged from streamed output",
+      new Error(`streamedChars=${assistantText.length} finalChars=${bounded.length}`),
+    );
   }
 
   function flushAssistantText(): void {
@@ -404,10 +444,7 @@ function createPiRunCollector(options: PiRunCollectorOptions) {
           return;
         }
         if (kind === "text_delta") {
-          if (!assistantMessageId) {
-            assistantMessageCounter += 1;
-            assistantMessageId = `msg_${options.scope}_${assistantMessageCounter}`;
-          }
+          ensureAssistantMessage();
           const delta = (update as Record<string, unknown>).delta;
           if (typeof delta === "string" && assistantText.length < MAX_TEXT_CHARS) {
             assistantText += delta.slice(0, MAX_TEXT_CHARS - assistantText.length);
@@ -418,9 +455,8 @@ function createPiRunCollector(options: PiRunCollectorOptions) {
         if (kind === "text_end") {
           const content = (update as Record<string, unknown>).content;
           if (typeof content === "string" && content.length > 0) {
-            assistantText = content;
+            reconcileAssistantText(content);
           }
-          flushAssistantText();
           return;
         }
         // toolcall_start/delta/end and thinking_* carry no execution signal
@@ -433,11 +469,9 @@ function createPiRunCollector(options: PiRunCollectorOptions) {
           ? (message as Record<string, unknown>).role
           : undefined;
         if (role === "assistant") {
-          if (assistantText.trim().length === 0 && message && typeof message === "object") {
+          if (message && typeof message === "object") {
             const text = contentText((message as Record<string, unknown>).content);
-            if (text.length > 0 && assistantMessageId) {
-              assistantText = text;
-            }
+            reconcileAssistantText(text);
           }
           flushAssistantText();
         }
@@ -535,7 +569,7 @@ function createPiRunCollector(options: PiRunCollectorOptions) {
       if (dropped > 0) {
         logCodingAgentWarning("pi provider dropped events beyond the run cap", new Error(`dropped=${dropped}`));
       }
-      return { events, sessionId };
+      return { events, sessionId, hasMeaningfulOutput };
     },
   };
 }
@@ -889,6 +923,14 @@ export function createPiCodingAgentProvider(options: PiCodingAgentProviderOption
         }
         if (code !== 0) {
           logCodingAgentWarning("pi provider run failed", new Error(`exit=${code} stderr=${stderrText.slice(0, 512)}`));
+          settle({ events: collected.events, outcome: "failed", sessionId });
+          return;
+        }
+        if (!collected.hasMeaningfulOutput) {
+          logCodingAgentWarning(
+            "pi provider completed without meaningful output",
+            new Error("exit=0 assistantEvents=0 toolEvents=0"),
+          );
           settle({ events: collected.events, outcome: "failed", sessionId });
           return;
         }

--- a/tests/gateway/pi-provider.test.ts
+++ b/tests/gateway/pi-provider.test.ts
@@ -656,6 +656,81 @@ describe("pi provider adapter — spawn contract", () => {
 });
 
 describe("pi provider adapter — event normalization", () => {
+  it("emits final assistant text delivered only by message_end exactly once", async () => {
+    const finalText = "Final answer from Pi.";
+    const fake = fakeSpawn({
+      lines: [
+        sessionLine(SESSION_ID),
+        JSON.stringify({ type: "message_start", message: { role: "assistant", content: [] } }),
+        JSON.stringify({
+          type: "message_end",
+          message: { role: "assistant", content: [{ type: "text", text: finalText }] },
+        }),
+      ],
+    });
+    const provider = providerFor(fake.spawnFn);
+    const published: AgentThreadEvent[] = [];
+
+    const result = await provider.startThread({
+      principal: ownerPrincipal,
+      thread: threadSummary(),
+      request: createRequest("Say hi"),
+      publishEvents: async (batch) => published.push(...batch.events),
+      now: () => baseNow,
+      nextEventId: nextEventIdFactory(),
+    });
+
+    const deltas = published.filter((event) => event.type === "assistant.text.delta");
+    const completed = published.filter((event) => event.type === "assistant.text.completed");
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]).toMatchObject({ type: "assistant.text.delta", delta: finalText });
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({
+      type: "assistant.text.completed",
+      messageId: deltas[0]?.type === "assistant.text.delta" ? deltas[0].messageId : undefined,
+    });
+    expect(result.events.at(-1)).toMatchObject({ type: "thread.completed", outcome: "completed" });
+  });
+
+  it("reconciles message_end by emitting only the missing streamed suffix", async () => {
+    const fake = fakeSpawn({
+      lines: [
+        sessionLine(SESSION_ID),
+        JSON.stringify({ type: "message_start", message: { role: "assistant", content: [] } }),
+        JSON.stringify({
+          type: "message_update",
+          assistantMessageEvent: { type: "text_start", contentIndex: 0 },
+        }),
+        JSON.stringify({
+          type: "message_update",
+          assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "Final ans" },
+        }),
+        JSON.stringify({
+          type: "message_end",
+          message: { role: "assistant", content: [{ type: "text", text: "Final answer." }] },
+        }),
+      ],
+    });
+    const provider = providerFor(fake.spawnFn);
+    const published: AgentThreadEvent[] = [];
+
+    const result = await provider.startThread({
+      principal: ownerPrincipal,
+      thread: threadSummary(),
+      request: createRequest("Say hi"),
+      publishEvents: async (batch) => published.push(...batch.events),
+      now: () => baseNow,
+      nextEventId: nextEventIdFactory(),
+    });
+
+    const deltas = published.filter((event) => event.type === "assistant.text.delta");
+    expect(deltas.map((event) => event.type === "assistant.text.delta" ? event.delta : ""))
+      .toEqual(["Final ans", "wer."]);
+    expect(new Set(deltas.map((event) => event.type === "assistant.text.delta" ? event.messageId : "")).size).toBe(1);
+    expect(published.filter((event) => event.type === "assistant.text.completed")).toHaveLength(1);
+    expect(result.events.at(-1)).toMatchObject({ type: "thread.completed", outcome: "completed" });
+  });
+
   it("maps a text-only run into the normalized lifecycle", async () => {
     const fake = fakeSpawn({ lines: textRunLines(SESSION_ID, "Say hi", "hello") });
     const provider = providerFor(fake.spawnFn);
@@ -1076,6 +1151,33 @@ describe("pi provider adapter — resume", () => {
 });
 
 describe("pi provider adapter — failures", () => {
+  it("fails safely when Pi exits successfully without meaningful output", async () => {
+    const fake = fakeSpawn({
+      lines: [
+        sessionLine(SESSION_ID),
+        JSON.stringify({ type: "agent_start" }),
+        JSON.stringify({ type: "turn_start" }),
+        JSON.stringify({ type: "turn_end", message: { role: "assistant", content: [] }, toolResults: [] }),
+        JSON.stringify({ type: "agent_end", messages: [], willRetry: false }),
+        JSON.stringify({ type: "agent_settled" }),
+      ],
+      exitCode: 0,
+    });
+    const provider = providerFor(fake.spawnFn);
+
+    const result = await provider.startThread({
+      principal: ownerPrincipal,
+      thread: threadSummary(),
+      request: createRequest("Say hi"),
+      now: () => baseNow,
+      nextEventId: nextEventIdFactory(),
+    });
+    const parsed = parseCodingAgentProviderRunResult(result, threadSummary().id);
+
+    expect(parsed.events.some((event) => event.type === "thread.error")).toBe(true);
+    expect(parsed.events.at(-1)).toMatchObject({ type: "thread.completed", outcome: "failed" });
+  });
+
   it("does not reject a completed run when Pi returns an invalid session id", async () => {
     const fake = fakeSpawn({ lines: textRunLines("not-a-valid-session", "Say hi", "hello") });
     const provider = providerFor(fake.spawnFn);


### PR DESCRIPTION
## Summary

- Recover Pi assistant text when the authoritative response arrives only in `message_end`.
- Reconcile streamed prefixes by emitting only the missing final suffix, then complete each assistant message exactly once.
- Treat an exit-code-zero Pi run with no assistant or tool output as a safe retryable provider failure, with bounded content-free diagnostics.

## Root cause

The Pi adapter only accepted `message_end` text when a streamed assistant message ID already existed and its buffer was blank. Pi can return a successful run whose complete answer is present only in the final `message_end`, so the adapter could terminalize the run as completed without persisting any assistant content.

## Tests

- `flox activate -- bun run test tests/gateway/pi-provider.test.ts tests/gateway/chat-coding-provider.test.ts tests/gateway/chat-orchestrator.test.ts` — 90 passed
- `flox activate -- bun run typecheck` — passed
- `flox activate -- bun run check:patterns` — 0 violations
- `flox activate -- bun run lint` — blocked by the workspace dependency error `Cannot find module 'next/dist/compiled/babel/eslint-parser'`; this lint target covers `shell`, while this PR changes only gateway code and its tests
- `flox activate -- bun run test` — 13,065 passed, 22 failed across 10 files outside this diff. A focused rerun reproduced 21 failures in nine unrelated files (macOS/GNU host-script assumptions, checkout fixtures, billing/runtime defaults, Todo date boundaries, and terminal wrapper timeouts).

## Invariants

### Source of truth

- Pi's final assistant `message_end` content is the authoritative provider snapshot. Direct final-only text allocates a canonical message ID; when the live stream is a prefix, only the missing suffix is emitted.
- Canonical Chat remains the durable source of truth after normalized events leave the provider adapter.

### Lock/transaction scope

- Reconciliation is isolated to one in-memory Pi run collector. No database transaction, shared lock, or external call is added.

### Acceptable orphan states

- A clean Pi process exit without user-visible assistant or tool output is no longer accepted as a completed blank run; it terminalizes as a generic retryable provider failure.
- Open tool executions retain the existing bounded cancellation drain at stream end.

### Auth source of truth

- Unchanged. Pi authentication and credential launch environment remain owner-scoped through the existing native harness credential resolver.

### Deferred scope

- This PR does not rewrite historical blank conversations or introduce a cross-provider zero-output policy.
- Already-published streamed text cannot be retracted by the current event contract. A divergent final Pi snapshot keeps the visible stream and records only bounded character counts; no assistant content is logged.
