### PR TITLE
fix(self-host): keep ShellHome off Clerk in standalone mode

### DIFF
--- a/shell/src/components/ShellHome.tsx
+++ b/shell/src/components/ShellHome.tsx
@@ -17,6 +17,7 @@ import { CommandPalette } from "@/components/CommandPalette";
 import { ApprovalDialog } from "@/components/ApprovalDialog";
 import { useMobileViewport } from "@/hooks/useMobileViewport";
 import { createShellSnapshotScope } from "@/lib/shell-snapshot-cache";
+import { isSelfHostedRuntime, SELF_HOSTED_SHELL_USER_ID } from "@/lib/self-host-mode";
 
 const LAUNCHABLE_BUILT_IN_PATHS = new Set([
   "__terminal__",
@@ -40,8 +41,19 @@ const subscribeLaunchPathNoop = () => () => {};
 const getLaunchPathServerSnapshot = (): string | null => null;
 
 export function ShellHome() {
-  const isMobile = useMobileViewport();
+  if (isSelfHostedRuntime()) {
+    return <ShellHomeBody userId={SELF_HOSTED_SHELL_USER_ID} />;
+  }
+  return <ClerkShellHome />;
+}
+
+function ClerkShellHome() {
   const { userId } = useAuth();
+  return <ShellHomeBody userId={userId} />;
+}
+
+function ShellHomeBody({ userId }: { userId: string | null | undefined }) {
+  const isMobile = useMobileViewport();
   const cachePathname = typeof window === "undefined" ? "/" : window.location.pathname;
   const cacheScope = createShellSnapshotScope({ userId, pathname: cachePathname });
   useTheme({ cacheScope });

--- a/shell/src/lib/self-host-mode.ts
+++ b/shell/src/lib/self-host-mode.ts
@@ -11,3 +11,5 @@ export function isSelfHostedRuntime(): boolean {
   }
   return typeof process !== "undefined" && process.env.MATRIX_SELF_HOSTED === "1";
 }
+
+export const SELF_HOSTED_SHELL_USER_ID = "self-hosted-owner";

--- a/tests/shell/self-host-shell-mode.test.ts
+++ b/tests/shell/self-host-shell-mode.test.ts
@@ -8,6 +8,7 @@ describe("self-host shell mode", () => {
   it("bypasses managed-cloud onboarding without loading Clerk on bare IP installs", () => {
     const page = readFileSync(join(root, "shell/src/app/page.tsx"), "utf8");
     const layout = readFileSync(join(root, "shell/src/app/layout.tsx"), "utf8");
+    const shellHome = readFileSync(join(root, "shell/src/components/ShellHome.tsx"), "utf8");
     const userButton = readFileSync(join(root, "shell/src/components/UserButton.tsx"), "utf8");
     const billingAccess = readFileSync(join(root, "shell/src/hooks/useMatrixBillingAccess.ts"), "utf8");
     const settings = readFileSync(join(root, "shell/src/components/Settings.tsx"), "utf8");
@@ -22,6 +23,10 @@ describe("self-host shell mode", () => {
     expect(layout).toContain("return renderDocument(false);");
     expect(layout).toContain("<ClerkProvider>");
     expect(layout).toContain("{renderDocument(true)}");
+    expect(shellHome).toContain("if (isSelfHostedRuntime()) {");
+    expect(shellHome).toContain("return <ShellHomeBody userId={SELF_HOSTED_SHELL_USER_ID} />;");
+    expect(shellHome).toContain("function ClerkShellHome()");
+    expect(shellHome).toContain("const { userId } = useAuth();");
     expect(userButton).toContain("SelfHostedUserButton");
     expect(billingAccess).toContain("useManagedMatrixBillingAccess");
     expect(billingAccess).not.toContain("isSelfHostedDocument");
@@ -29,6 +34,7 @@ describe("self-host shell mode", () => {
     expect(settings).toContain("showBillingSection={false}");
     expect(settings).toContain("function ManagedSettings");
     expect(selfHostMode).toContain('process.env.MATRIX_SELF_HOSTED === "1"');
+    expect(selfHostMode).toContain('SELF_HOSTED_SHELL_USER_ID = "self-hosted-owner"');
     expect(win11StartMenu).not.toContain("@clerk/nextjs");
     expect(win11StartMenu).toContain("isSelfHostedDocument() ? null : <Win11ManagedAccountActions");
   });

--- a/tests/shell/shell-home-self-host.test.tsx
+++ b/tests/shell/shell-home-self-host.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const clerk = vi.hoisted(() => ({
+  useAuth: vi.fn(() => {
+    throw new Error("Clerk useAuth should not run in self-host mode");
+  }),
+}));
+
+const commands = vi.hoisted(() => ({
+  register: vi.fn(),
+  unregister: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs", () => ({ useAuth: clerk.useAuth }));
+vi.mock("@/hooks/useMobileViewport", () => ({ useMobileViewport: () => false }));
+vi.mock("@/hooks/useTheme", () => ({ useTheme: vi.fn() }));
+vi.mock("@/hooks/useDesktopConfig", () => ({ useDesktopConfig: vi.fn() }));
+vi.mock("@/hooks/useCanonicalChatState", () => ({
+  useCanonicalChatState: () => ({ newChat: vi.fn() }),
+}));
+vi.mock("@/hooks/useGlobalShortcuts", () => ({ useGlobalShortcuts: vi.fn() }));
+vi.mock("@/stores/commands", () => ({
+  useCommandStore: (selector: (state: typeof commands) => unknown) => selector(commands),
+}));
+vi.mock("@/lib/posthog-client", () => ({ capturePostHogEvent: vi.fn() }));
+vi.mock("@matrix-os/observability/events", () => ({
+  MATRIX_TELEMETRY_EVENTS: { SHELL_LOADED: "shell_loaded" },
+}));
+vi.mock("@/components/Desktop", () => ({
+  Desktop: () => <div data-testid="desktop">desktop</div>,
+}));
+vi.mock("@/components/mobile/MobileShell", () => ({ MobileShell: () => null }));
+vi.mock("@/components/CommandPalette", () => ({ CommandPalette: () => null }));
+vi.mock("@/components/ApprovalDialog", () => ({ ApprovalDialog: () => null }));
+
+import { ShellHome } from "@/components/ShellHome";
+
+describe("ShellHome self-host mode", () => {
+  beforeEach(() => {
+    process.env.MATRIX_SELF_HOSTED = "1";
+    clerk.useAuth.mockClear();
+    commands.register.mockClear();
+    commands.unregister.mockClear();
+  });
+
+  afterEach(() => {
+    delete process.env.MATRIX_SELF_HOSTED;
+  });
+
+  it("renders the standalone shell without invoking Clerk", () => {
+    expect(() => render(<ShellHome />)).not.toThrow();
+    expect(screen.getByTestId("desktop")).toBeTruthy();
+    expect(clerk.useAuth).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1522.

Standalone self-host mode intentionally renders the shell without `<ClerkProvider>`, but `ShellHome` still called Clerk's `useAuth()` unconditionally. That makes the default self-host shell crash during hydration even though the server-rendered page is healthy.

This change follows the self-host/managed split already used elsewhere in the shell:

- the outer `ShellHome` checks `isSelfHostedRuntime()` before any Clerk hook can run
- self-hosted mode renders the shared shell body with a stable local cache identity
- managed/cloud mode keeps the existing Clerk-backed `useAuth()` path unchanged
- a behavioral jsdom regression test renders the standalone `ShellHome` with Clerk's `useAuth()` mocked to throw, and verifies the shell renders without invoking Clerk

## Why this shape

PR #680 established the invariant that self-host mode does not mount Clerk and instead routes Clerk-dependent UI through managed-only components. `ShellHome`'s `useAuth()` call predates that retrofit and was left outside that boundary. This restores the established pattern rather than adding a fake/unconfigured Clerk provider or conditionally calling hooks.

## Validation

The `ShellHome` fix was rebuilt with `MATRIX_SELF_HOSTED=1` and validated on a real standalone VPS installation. After the change:

- the Matrix desktop shell loads successfully through hydration
- no new Clerk-provider client exception is recorded
- terminal/WebSocket functionality works
- Settings/basic navigation works
- managed/cloud Clerk behavior is left in its own component path

The PR also includes a provider-free behavioral render test in addition to the existing source-architecture assertions.