### PR TITLE
fix(self-host): preserve code-server WebSocket host headers

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -635,6 +635,9 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade";
+    proxy_set_header Host \$host;
+    proxy_set_header X-Forwarded-Host \$host;
+    proxy_set_header X-Forwarded-Proto \$scheme;
     proxy_read_timeout 3600s;
     proxy_set_header Authorization "";
     proxy_set_header X-Forwarded-Prefix /code;
@@ -646,6 +649,9 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade";
+    proxy_set_header Host \$host;
+    proxy_set_header X-Forwarded-Host \$host;
+    proxy_set_header X-Forwarded-Proto \$scheme;
     proxy_read_timeout 3600s;
     proxy_set_header Authorization "";
     proxy_pass http://127.0.0.1:8788;

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -107,6 +107,9 @@ describe("self-host server installer", () => {
     expect(script).toContain('if (\\$arg_reconnectionToken != "")');
     expect(script).toContain("error_page 418 = @matrix_code_root_ws");
     expect(script).toContain("proxy_set_header X-Forwarded-Prefix /code");
+    expect(script.match(/proxy_set_header Host \\$host;/g)).toHaveLength(3);
+    expect(script.match(/proxy_set_header X-Forwarded-Host \\$host;/g)).toHaveLength(3);
+    expect(script.match(/proxy_set_header X-Forwarded-Proto \\$scheme;/g)).toHaveLength(3);
     expect(script).toContain("proxy_read_timeout 3600s");
     expect(script).toContain("proxy_pass http://127.0.0.1:8788");
     expect(script).toContain("proxy_pass http://127.0.0.1:3000");

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -4,6 +4,14 @@ import { describe, expect, it } from "vitest";
 
 const root = process.cwd();
 
+function nginxLocation(script: string, location: string): string {
+  const start = script.indexOf(`  location ${location} {`);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = script.indexOf("\n  }\n", start);
+  expect(end).toBeGreaterThan(start);
+  return script.slice(start, end);
+}
+
 describe("self-host server installer", () => {
   it("keeps the source installer executable", () => {
     expect(statSync(join(root, "scripts/install-server.sh")).mode & 0o111).not.toBe(0);
@@ -107,9 +115,12 @@ describe("self-host server installer", () => {
     expect(script).toContain('if (\\$arg_reconnectionToken != "")');
     expect(script).toContain("error_page 418 = @matrix_code_root_ws");
     expect(script).toContain("proxy_set_header X-Forwarded-Prefix /code");
-    expect(script.match(/proxy_set_header Host \\$host;/g)).toHaveLength(3);
-    expect(script.match(/proxy_set_header X-Forwarded-Host \\$host;/g)).toHaveLength(3);
-    expect(script.match(/proxy_set_header X-Forwarded-Proto \\$scheme;/g)).toHaveLength(3);
+    for (const location of ["/code/", "@matrix_code_root_ws"]) {
+      const block = nginxLocation(script, location);
+      expect(block).toContain("proxy_set_header Host \\$host;");
+      expect(block).toContain("proxy_set_header X-Forwarded-Host \\$host;");
+      expect(block).toContain("proxy_set_header X-Forwarded-Proto \\$scheme;");
+    }
     expect(script).toContain("proxy_read_timeout 3600s");
     expect(script).toContain("proxy_pass http://127.0.0.1:8788");
     expect(script).toContain("proxy_pass http://127.0.0.1:3000");


### PR DESCRIPTION
## Summary

Fixes #1524.

The standalone nginx config sets `proxy_set_header` inside both `/code/` and `@matrix_code_root_ws`. Because nginx header inheritance is all-or-nothing at the location level, those local directives drop the server-level `Host`, `X-Forwarded-Host`, and `X-Forwarded-Proto` headers.

That leaves code-server seeing `Host: 127.0.0.1:8788` while the browser sends the public Matrix origin. code-server rejects the WebSocket upgrade with HTTP 403, which VS Code surfaces as WebSocket close code 1006.

## Change

Explicitly preserve these headers in both code-server proxy locations:

```nginx
proxy_set_header Host $host;
proxy_set_header X-Forwarded-Host $host;
proxy_set_header X-Forwarded-Proto $scheme;
```

The installer regression test extracts `/code/` and `@matrix_code_root_ws` independently and verifies that each location contains all three forwarding headers.

## Validation

This exact nginx change was validated on a standalone Matrix OS VPS installation:

- normal `/code/` assets continued to return 200
- the previously failing `?reconnectionToken=...` WebSocket handshake changed from 403 to `101 Switching Protocols`
- VS Code/code-server loaded successfully through the full browser path
- integrated terminal and file operations worked
- Matrix Basic Auth remained enforced
- `nginx -t` passed and nginx reloaded cleanly
- Cloudflare Tunnel was ruled out as the cause; direct and proxied handshake tests isolated the failure to the generated nginx header set

No code-server, gateway, Cloudflare, or auth behavior is otherwise changed.