### PR TITLE
fix(gateway): never fall back to a fake Codex model id

### DIFF
--- a/packages/gateway/src/chat/codex-model-catalog.ts
+++ b/packages/gateway/src/chat/codex-model-catalog.ts
@@ -8,6 +8,20 @@ const MAX_MODELS = 64;
 const MAX_OPTIONS = 32;
 const DEFAULT_TIMEOUT_MS = 5_000;
 const DEFAULT_CACHE_TTL_MS = 60_000;
+// A cold app-server start, one dropped handshake, or a momentary scheduling
+// hiccup are all ordinary and should not immediately degrade Codex to
+// "unavailable" for a full cache window. One bounded retry after a short
+// delay absorbs those without materially slowing a healthy request or
+// risking an unbounded/tight retry loop against a genuinely broken CLI.
+const DEFAULT_MAX_ATTEMPTS = 2;
+const DEFAULT_RETRY_DELAY_MS = 300;
+const DEFAULT_TERMINATE_GRACE_MS = 1_000;
+// A failed lookup is cached only briefly. Long enough that repeated polling
+// (e.g. an open Chat tab) cannot retry-storm a down or mid-install Codex
+// with a fresh spawn+retry sequence on every request; short enough that a
+// login or install finishing mid-outage is reflected on the next request
+// shortly after, without needing a dedicated invalidation signal.
+const DEFAULT_FAILURE_CACHE_TTL_MS = 10_000;
 
 const ReferenceIdSchema = z.string().trim().min(1).max(160)
   .regex(/^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,159}$/);
@@ -120,26 +134,46 @@ async function readCodexModels(input: {
     let buffer = "";
     let totalBytes = 0;
     let settled = false;
-    const timeout = setTimeout(() => finish(new Error("Codex model catalog timed out")), input.timeoutMs);
+    let requestedOutcome: { error?: Error; value?: unknown } | null = null;
+    let terminateTimer: NodeJS.Timeout | null = null;
+    const timeout = setTimeout(() => requestFinish(new Error("Codex model catalog timed out")), input.timeoutMs);
     timeout.unref();
 
-    const finish = (error?: Error, value?: unknown) => {
+    const settleAfterExit = () => {
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
+      if (terminateTimer) clearTimeout(terminateTimer);
+      const outcome = requestedOutcome ?? { error: new Error("Codex model catalog stopped") };
+      if (outcome.error) reject(outcome.error);
+      else resolve(outcome.value);
+    };
+
+    const requestFinish = (error?: Error, value?: unknown) => {
+      if (settled || requestedOutcome) return;
+      requestedOutcome = { ...(error ? { error } : {}), ...(error ? {} : { value }) };
+      clearTimeout(timeout);
+
+      // A retry must never overlap the child from the previous attempt. Ask
+      // the app-server to terminate, escalate if it ignores SIGTERM, and only
+      // settle this attempt after the OS reports the child has actually
+      // closed. fetchCodexModelsWithRetry cannot start its next attempt until
+      // this promise settles.
       child.kill("SIGTERM");
-      if (error) reject(error);
-      else resolve(value);
+      terminateTimer = setTimeout(() => {
+        child.kill("SIGKILL");
+      }, DEFAULT_TERMINATE_GRACE_MS);
+      terminateTimer.unref();
     };
     const send = (message: unknown) => child.stdin.write(`${JSON.stringify(message)}\n`);
 
-    child.once("error", () => finish(new Error("Codex model catalog unavailable")));
-    child.once("close", () => finish(new Error("Codex model catalog stopped")));
+    child.once("error", () => requestFinish(new Error("Codex model catalog unavailable")));
+    child.once("close", settleAfterExit);
     child.stdout.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => {
       totalBytes += Buffer.byteLength(chunk, "utf8");
       if (totalBytes > MAX_RESPONSE_BYTES) {
-        finish(new Error("Codex model catalog exceeded its response limit"));
+        requestFinish(new Error("Codex model catalog exceeded its response limit"));
         return;
       }
       buffer += chunk;
@@ -159,7 +193,7 @@ async function readCodexModels(input: {
           send({ method: "initialized", params: {} });
           send({ id: 2, method: "model/list", params: { limit: MAX_MODELS, includeHidden: false } });
         } else if (message.id === 2) {
-          finish(undefined, message.result);
+          requestFinish(undefined, message.result);
         }
       }
     });
@@ -174,32 +208,91 @@ async function readCodexModels(input: {
   });
 }
 
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref();
+  });
+}
+
+async function fetchCodexModelsWithRetry(input: {
+  executable: string;
+  cwd: string;
+  timeoutMs: number;
+  maxAttempts: number;
+  retryDelayMs: number;
+  spawnProcess: SpawnProcess;
+}): Promise<CodingModelCatalogProjection> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= input.maxAttempts; attempt += 1) {
+    try {
+      const raw = await readCodexModels({
+        executable: input.executable,
+        cwd: input.cwd,
+        timeoutMs: input.timeoutMs,
+        spawnProcess: input.spawnProcess,
+      });
+      return normalizeCodexModelCatalog(raw);
+    } catch (error) {
+      lastError = error;
+      // Sequential and bounded: the next attempt only starts once the
+      // previous attempt's process has already been terminated inside
+      // readCodexModels, so at most one app-server child is ever alive at a
+      // time and the total added delay is capped by maxAttempts.
+      if (attempt < input.maxAttempts) await wait(input.retryDelayMs);
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error("Codex model catalog unavailable");
+}
+
 export function createCodexModelCatalogSource(options: {
   executable: string;
   cwd: string;
   timeoutMs?: number;
   cacheTtlMs?: number;
+  failureCacheTtlMs?: number;
+  maxAttempts?: number;
+  retryDelayMs?: number;
   spawnProcess?: SpawnProcess;
 }) {
   const timeoutMs = Math.max(1, Math.min(options.timeoutMs ?? DEFAULT_TIMEOUT_MS, 30_000));
   const cacheTtlMs = Math.max(1, Math.min(options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS, 5 * 60_000));
+  const failureCacheTtlMs = Math.max(
+    1,
+    Math.min(options.failureCacheTtlMs ?? DEFAULT_FAILURE_CACHE_TTL_MS, cacheTtlMs),
+  );
+  const maxAttempts = Math.max(1, Math.min(options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS, 3));
+  const retryDelayMs = Math.max(0, Math.min(options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS, 2_000));
   const spawnProcess = options.spawnProcess ?? (nodeSpawn as SpawnProcess);
   let cached: { expiresAt: number; value: CodingModelCatalogProjection } | null = null;
+  let failedUntil = 0;
   let pending: Promise<CodingModelCatalogProjection> | null = null;
 
   return async (provider: AgentProviderSummary): Promise<CodingModelCatalogProjection | null> => {
     if (provider.kind !== "codex" && provider.id !== "codex") return null;
     const now = Date.now();
     if (cached && cached.expiresAt > now) return cached.value;
+    if (!pending && failedUntil > now) {
+      throw new Error("Codex model catalog unavailable");
+    }
     if (!pending) {
-      pending = readCodexModels({
+      pending = fetchCodexModelsWithRetry({
         executable: options.executable,
         cwd: options.cwd,
         timeoutMs,
+        maxAttempts,
+        retryDelayMs,
         spawnProcess,
-      }).then(normalizeCodexModelCatalog).then((value) => {
+      }).then((value) => {
         cached = { expiresAt: Date.now() + cacheTtlMs, value };
+        failedUntil = 0;
         return value;
+      }).catch((error: unknown) => {
+        // Cache the failure only briefly (see DEFAULT_FAILURE_CACHE_TTL_MS)
+        // so repeated polling while Codex is down or mid-install cannot
+        // retry-storm it with a fresh spawn+retry sequence on every request.
+        failedUntil = Date.now() + failureCacheTtlMs;
+        throw error;
       }).finally(() => {
         pending = null;
       });

--- a/packages/gateway/src/chat/provider-catalog.ts
+++ b/packages/gateway/src/chat/provider-catalog.ts
@@ -171,11 +171,14 @@ function codingModels(provider: AgentProviderSummary): CanonicalModelDescriptor[
   const parsedModel = provider.defaultModel === undefined
     ? null
     : CanonicalChatModelSelectionSchema.shape.model.safeParse(provider.defaultModel);
-  if (parsedModel?.success !== true
-    && (codingDriverKind(provider) === "pi" || codingDriverKind(provider) === "opencode")) {
-    return [];
-  }
-  const id = parsedModel?.success === true ? parsedModel.data : "provider-default";
+  // Without a real, parseable model id there is nothing safe to offer: a
+  // synthetic placeholder id (e.g. "provider-default") is not a model this
+  // driver's CLI actually recognizes, and sending it would fail the turn
+  // silently. Report no models instead, exactly like Pi and OpenCode already
+  // do -- this only affects Codex, since Claude Code returns its own fixed
+  // model list above and never reaches this branch.
+  if (parsedModel?.success !== true) return [];
+  const id = parsedModel.data;
   const availability = provider.availability === "available"
     ? "available" as const
     : provider.availability === "auth_required"
@@ -183,7 +186,7 @@ function codingModels(provider: AgentProviderSummary): CanonicalModelDescriptor[
       : "unavailable" as const;
   return [{
     id,
-    displayName: parsedModel?.success === true ? parsedModel.data : `${provider.displayName} default`,
+    displayName: id,
     availability,
     capabilities: ["reasoning", "tools"],
     supportsVision: false,

--- a/tests/gateway/chat-provider-catalog.test.ts
+++ b/tests/gateway/chat-provider-catalog.test.ts
@@ -1420,16 +1420,44 @@ describe("canonical Chat Provider catalog", () => {
     expect(JSON.stringify(catalog)).not.toContain("secret coding inventory failure");
   });
 
-  it("names an unenumerated legacy model after its harness", async () => {
+  it("never fabricates a sendable model for an unenumerated legacy Codex default", async () => {
     const service = createChatProviderCatalogService({
       codingProviders: codingRegistry([codingProvider({ defaultModel: "GPT 5 default" })]),
       agentRuntimeSource: runtimeSource(),
     });
 
-    const catalog = await service.getCatalog(principal);
+    const codex = (await service.getCatalog(principal)).instances
+      .find((instance) => instance.id === "codex_default")!;
 
-    expect(catalog.instances.find((instance) => instance.id === "codex_default")?.models)
-      .toMatchObject([{ id: "provider-default", displayName: "Codex default" }]);
+    // An unparseable legacy default is exactly as unusable as no default at
+    // all: Matrix cannot resolve it to a real model id, so it must never be
+    // turned into a synthetic "provider-default" id that Codex itself would
+    // reject at send time. See "never exposes a fake sendable Codex model
+    // when catalog discovery fails" below for the failed-fetch counterpart.
+    expect(codex.models).toEqual([]);
+    expect(codex.defaultSelection).toBeUndefined();
+    expect(codex.models.some((model) => model.id === "provider-default")).toBe(false);
+  });
+
+  it("never exposes a fake sendable Codex model when catalog discovery fails", async () => {
+    const service = createChatProviderCatalogService({
+      codingProviders: codingRegistry([codingProvider({ defaultModel: undefined })]),
+      agentRuntimeSource: runtimeSource(),
+      codingModelCatalogSource: vi.fn(async (provider) => {
+        if (provider.id !== "codex") return null;
+        throw new Error("Codex model catalog unavailable");
+      }),
+    });
+
+    const codex = (await service.getCatalog(principal)).instances
+      .find((instance) => instance.id === "codex_default")!;
+
+    // This is the exact shape of the confirmed bug: catalog discovery fails,
+    // Matrix must not fall back to a synthetic model id that gets threaded
+    // through to the real Codex app-server and rejected at send time.
+    expect(codex.models).toEqual([]);
+    expect(codex.models.some((model) => model.id === "provider-default")).toBe(false);
+    expect(codex.defaultSelection).toBeUndefined();
   });
 
   it("advertises file attachments forwarded by native Pi and OpenCode adapters", async () => {

--- a/tests/gateway/codex-model-catalog.test.ts
+++ b/tests/gateway/codex-model-catalog.test.ts
@@ -1,5 +1,62 @@
-import { describe, expect, it } from "vitest";
-import { normalizeCodexModelCatalog } from "../../packages/gateway/src/chat/codex-model-catalog.js";
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createCodexModelCatalogSource,
+  normalizeCodexModelCatalog,
+} from "../../packages/gateway/src/chat/codex-model-catalog.js";
+
+const SAMPLE_MODEL = {
+  id: "gpt-5.6-sol",
+  model: "gpt-5.6-sol",
+  displayName: "GPT-5.6-Sol",
+  description: "Frontier coding model",
+  hidden: false,
+  isDefault: true,
+  defaultReasoningEffort: "low",
+  supportedReasoningEfforts: [{ reasoningEffort: "low", description: "Fast" }],
+  inputModalities: ["text"],
+  serviceTiers: [],
+  defaultServiceTier: null,
+};
+
+/**
+ * A fake `codex app-server --stdio` child: a stdin that captures writes, a
+ * stdout that the test drives line-by-line, and a `kill` spy so tests can
+ * assert every spawned attempt is actually terminated (never leaked).
+ */
+function fakeCodexChild(options: { autoCloseOnKill?: boolean } = {}) {
+  const stdout = new EventEmitter() as EventEmitter & { setEncoding: (enc: string) => void };
+  stdout.setEncoding = () => {};
+  const stderr = new EventEmitter() as EventEmitter & { resume: () => void };
+  stderr.resume = () => {};
+  const writes: string[] = [];
+  const child = Object.assign(new EventEmitter(), {
+    stdout,
+    stderr,
+    stdin: { write: (chunk: string) => { writes.push(chunk); return true; } },
+  });
+  const kill = vi.fn(() => {
+    if (options.autoCloseOnKill !== false) queueMicrotask(() => child.emit("close", 0, null));
+    return true;
+  });
+  Object.assign(child, {
+    kill,
+  });
+  return { child, stdout, writes, kill };
+}
+
+/** Emits the real model/list handshake so the caller resolves with SAMPLE_MODEL. */
+function respondWithRealCatalog(stdout: EventEmitter, writes: string[]) {
+  stdout.emit("data", `${JSON.stringify({ id: 1, result: {} })}\n`);
+  queueMicrotask(() => {
+    const request = JSON.parse(writes[writes.length - 1]!) as { id?: number };
+    if (request.id !== 2) return;
+    stdout.emit(
+      "data",
+      `${JSON.stringify({ id: 2, result: { data: [SAMPLE_MODEL], nextCursor: null } })}\n`,
+    );
+  });
+}
 
 describe("Codex model catalog projection", () => {
   it("projects live app-server models and their effort/service-tier options", () => {
@@ -50,5 +107,158 @@ describe("Codex model catalog projection", () => {
         values: [{ value: "priority", label: "Fast" }],
       }],
     });
+  });
+});
+
+const codexProvider = { id: "codex", kind: "codex" } as Parameters<
+  ReturnType<typeof createCodexModelCatalogSource>
+>[0];
+
+describe("Codex model catalog source retry and cache behavior", () => {
+  it("retries once after a transient app-server failure and returns real models", async () => {
+    const attempts: ReturnType<typeof fakeCodexChild>[] = [];
+    const spawnProcess = vi.fn(() => {
+      const attempt = fakeCodexChild();
+      attempts.push(attempt);
+      return attempt.child as never;
+    });
+    const source = createCodexModelCatalogSource({
+      executable: "/opt/matrix/runtime/node/bin/codex",
+      cwd: "/home/matrix/home",
+      maxAttempts: 2,
+      retryDelayMs: 1,
+      spawnProcess,
+    });
+
+    const resultPromise = source(codexProvider);
+    // First attempt fails immediately (e.g. a transient spawn/handshake error).
+    await vi.waitFor(() => expect(attempts.length).toBeGreaterThanOrEqual(1));
+    attempts[0]!.child.emit("error", new Error("transient failure"));
+    // Second attempt succeeds with a real catalog.
+    await vi.waitFor(() => expect(attempts.length).toBe(2));
+    respondWithRealCatalog(attempts[1]!.stdout, attempts[1]!.writes);
+
+    const result = await resultPromise;
+
+    expect(result?.models.map((model) => model.id)).toEqual(["gpt-5.6-sol"]);
+    expect(spawnProcess).toHaveBeenCalledTimes(2);
+    // The failed first attempt's process must be terminated, not leaked.
+    expect(attempts[0]!.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("does not start a retry until the previous app-server child has actually exited", async () => {
+    const attempts: ReturnType<typeof fakeCodexChild>[] = [];
+    const spawnProcess = vi.fn(() => {
+      const attempt = fakeCodexChild({ autoCloseOnKill: false });
+      attempts.push(attempt);
+      return attempt.child as never;
+    });
+    const source = createCodexModelCatalogSource({
+      executable: "/opt/matrix/runtime/node/bin/codex",
+      cwd: "/home/matrix/home",
+      maxAttempts: 2,
+      retryDelayMs: 1,
+      spawnProcess,
+    });
+
+    const resultPromise = source(codexProvider);
+    await vi.waitFor(() => expect(attempts.length).toBe(1));
+    attempts[0]!.child.emit("error", new Error("transient failure"));
+
+    expect(attempts[0]!.kill).toHaveBeenCalledWith("SIGTERM");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(spawnProcess).toHaveBeenCalledTimes(1);
+
+    attempts[0]!.child.emit("close", 0, null);
+    await vi.waitFor(() => expect(attempts.length).toBe(2));
+    respondWithRealCatalog(attempts[1]!.stdout, attempts[1]!.writes);
+
+    await expect(resultPromise).resolves.toMatchObject({ models: [{ id: "gpt-5.6-sol" }] });
+  });
+
+  it("gives up after exhausting bounded retries without leaking any app-server child", async () => {
+    const attempts: ReturnType<typeof fakeCodexChild>[] = [];
+    const spawnProcess = vi.fn(() => {
+      const attempt = fakeCodexChild();
+      attempts.push(attempt);
+      return attempt.child as never;
+    });
+    const source = createCodexModelCatalogSource({
+      executable: "/opt/matrix/runtime/node/bin/codex",
+      cwd: "/home/matrix/home",
+      maxAttempts: 2,
+      retryDelayMs: 1,
+      spawnProcess,
+    });
+
+    const resultPromise = source(codexProvider);
+    await vi.waitFor(() => expect(attempts.length).toBeGreaterThanOrEqual(1));
+    attempts[0]!.child.emit("error", new Error("still failing"));
+    await vi.waitFor(() => expect(attempts.length).toBe(2));
+    attempts[1]!.child.emit("error", new Error("still failing"));
+
+    await expect(resultPromise).rejects.toThrow();
+    // Bounded: never more than the configured number of attempts.
+    expect(spawnProcess).toHaveBeenCalledTimes(2);
+    // Every spawned attempt was terminated -- none left running.
+    for (const attempt of attempts) {
+      expect(attempt.kill).toHaveBeenCalledWith("SIGTERM");
+    }
+  });
+
+  it("does not re-spawn app-server for a request served from the success cache", async () => {
+    const attempts: ReturnType<typeof fakeCodexChild>[] = [];
+    const spawnProcess = vi.fn(() => {
+      const attempt = fakeCodexChild();
+      attempts.push(attempt);
+      return attempt.child as never;
+    });
+    const source = createCodexModelCatalogSource({
+      executable: "/opt/matrix/runtime/node/bin/codex",
+      cwd: "/home/matrix/home",
+      cacheTtlMs: 60_000,
+      spawnProcess,
+    });
+
+    const first = source(codexProvider);
+    await vi.waitFor(() => expect(attempts.length).toBe(1));
+    respondWithRealCatalog(attempts[0]!.stdout, attempts[0]!.writes);
+    await first;
+
+    await source(codexProvider);
+
+    expect(spawnProcess).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches an exhausted failure briefly so repeated polling cannot retry-storm a down Codex", async () => {
+    const attempts: ReturnType<typeof fakeCodexChild>[] = [];
+    const spawnProcess = vi.fn(() => {
+      const attempt = fakeCodexChild();
+      attempts.push(attempt);
+      return attempt.child as never;
+    });
+    const source = createCodexModelCatalogSource({
+      executable: "/opt/matrix/runtime/node/bin/codex",
+      cwd: "/home/matrix/home",
+      maxAttempts: 1,
+      failureCacheTtlMs: 50,
+      spawnProcess,
+    });
+
+    const first = source(codexProvider);
+    await vi.waitFor(() => expect(attempts.length).toBe(1));
+    attempts[0]!.child.emit("error", new Error("down"));
+    await expect(first).rejects.toThrow();
+
+    // Polled again immediately: must not spawn a second app-server process.
+    await expect(source(codexProvider)).rejects.toThrow();
+    expect(spawnProcess).toHaveBeenCalledTimes(1);
+
+    // Once the short failure cache expires, the next request retries.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    const retried = source(codexProvider);
+    await vi.waitFor(() => expect(attempts.length).toBe(2));
+    respondWithRealCatalog(attempts[1]!.stdout, attempts[1]!.writes);
+    await expect(retried).resolves.toMatchObject({ models: [{ id: "gpt-5.6-sol" }] });
   });
 });


### PR DESCRIPTION
## Summary

Fix Codex Chat failures caused by Matrix synthesizing the placeholder model id `provider-default` when live Codex model discovery fails or no real model can be resolved.

The patch:

- never exposes a fake Codex model id; Codex reports no models and falls back to the existing unavailable/setup state instead;
- adds one bounded sequential retry to Codex model discovery (2 attempts by default, 300 ms delay);
- preserves the existing 60-second success cache and adds a short 10-second failure cache to prevent repeated app-server spawn/retry storms during a genuine outage while still recovering quickly;
- waits for the failed Codex app-server child to actually exit before a retry can start, escalating from `SIGTERM` to `SIGKILL` after a bounded grace period if necessary;
- leaves Claude Code, Pi, and OpenCode behavior unchanged.

Failed catalog lookups were not cached before this patch. Each request was single-shot, and a later request could retry; the new short failure cache is specifically to bound repeated polling during an outage.

## Regression coverage

Focused tests cover:

- no `provider-default` / fake default selection after Codex catalog failure;
- the legacy invalid/default-model trigger path;
- retry-then-success;
- bounded exhausted retries with child cleanup;
- success-cache behavior;
- short failure-cache behavior and recovery after expiry;
- no retry process starts until the previous Codex child has actually exited.

The original focused patch passed 58 targeted tests and gateway TypeScript typecheck completed cleanly. The child-exit hardening was added in response to Greptile review feedback, with an explicit regression test; the review thread is now resolved. Fork-triggered GitHub Actions for the current squashed commit are still `action_required`, so they have not independently run yet.

The exact historical cause of the transient catalog failures remains undetermined; this PR fixes the unsafe fallback and makes transient failures more resilient without claiming a specific root cause.

Fixes #1527