### PR TITLE
fix(chat): project approval requests into renderable messages and fix seq collision

### DIFF
--- a/packages/gateway/src/chat/run-lifecycle-repository.ts
+++ b/packages/gateway/src/chat/run-lifecycle-repository.ts
@@ -8,6 +8,7 @@ import {
   type CanonicalChatRun,
   type CanonicalChatRunActivity,
 } from "@matrix-os/contracts";
+import { createHash } from "node:crypto";
 import { sql, type Kysely, type Selectable, type Transaction } from "kysely";
 import { z } from "zod/v4";
 import type { ChatDatabase, ChatsTable } from "./database.js";
@@ -76,6 +77,68 @@ function railTransitionForActivity(activity: CanonicalChatRunActivity): {
     default:
       return undefined;
   }
+}
+
+// Run activities (CanonicalChatRunActivity, dot-namespaced: "approval.requested")
+// are an internal, ephemeral event stream — the run's status/attention fields
+// already react to them via railTransitionForActivity above. But the chat UI
+// (specifically CanonicalApprovalMessage) only ever renders approval controls
+// from CanonicalChatMessage.parts entries typed "approval_request" /
+// "approval_result" (snake_case, the persisted message schema — see
+// packages/contracts/src/canonical-chat.ts). Nothing previously projected one
+// stream into the other, so an agent's approval request was tracked correctly
+// server-side but never became a message the browser could act on.
+// approvalMessageId/approvalRequestDescription/approvalMessageParts below
+// produce that projection; see their single call site in appendRunActivities,
+// which mirrors the existing terminal.bound side effect in the same function.
+function approvalMessageId(kind: "request" | "result", approvalId: string): string {
+  const digest = createHash("sha256").update(approvalId).digest("hex").slice(0, 32);
+  return `msg_approval_${kind}_${digest}`;
+}
+
+// CanonicalChatRunActivity's "approval.requested" variant intentionally carries
+// only { approvalId, title, risk, allowedDecisions } — no free-text description
+// (see canonical-chat.ts). The approval_request message part requires one, so
+// this synthesizes a generic, provider-neutral sentence from risk alone rather
+// than widening the canonical contract.
+function approvalRequestDescription(risk: "low" | "medium" | "high"): string {
+  if (risk === "high") {
+    return "This action needs your approval before the agent can continue — it may have a significant or hard-to-reverse effect.";
+  }
+  if (risk === "medium") {
+    return "This action needs your approval before the agent can continue.";
+  }
+  return "This action needs your approval before the agent can continue. It's expected to be low-risk.";
+}
+
+function approvalMessageParts(activity: CanonicalChatRunActivity): {
+  id: string;
+  parts: CanonicalChatMessage["parts"];
+} | undefined {
+  if (activity.type === "approval.requested") {
+    return {
+      id: approvalMessageId("request", activity.approvalId),
+      parts: [CanonicalChatMessagePartSchema.parse({
+        type: "approval_request",
+        approvalId: activity.approvalId,
+        title: activity.title,
+        description: approvalRequestDescription(activity.risk),
+        risk: activity.risk,
+        allowedDecisions: activity.allowedDecisions,
+      })],
+    };
+  }
+  if (activity.type === "approval.resolved") {
+    return {
+      id: approvalMessageId("result", activity.approvalId),
+      parts: [CanonicalChatMessagePartSchema.parse({
+        type: "approval_result",
+        approvalId: activity.approvalId,
+        decision: activity.decision,
+      })],
+    };
+  }
+  return undefined;
 }
 
 function canTransitionAgentActivity(
@@ -298,7 +361,7 @@ export class ChatRunLifecycleRepository {
     return this.transact(async (trx) => {
       const current = await selectOwnedChat(trx, owner, CanonicalChatIdSchema.parse(chatId), true);
       if (!current) throw new ChatNotFoundError(chatId);
-      const run = await trx.selectFrom("chat_runs").select("id")
+      const run = await trx.selectFrom("chat_runs").select(["id", "turn_id"])
         .where("id", "=", runId).where("chat_id", "=", chatId)
         .where("status", "in", [...ACTIVE_RUNS]).executeTakeFirst();
       const existingRun = run ?? await trx.selectFrom("chat_runs").select("id")
@@ -344,6 +407,21 @@ export class ChatRunLifecycleRepository {
       let nextSequence = Number(latestSequence?.sequence ?? 0);
       let changed = 0;
       let railTransition: ReturnType<typeof railTransitionForActivity>;
+      // Lazily fetched: most batches contain no approval activity, so avoid
+      // the extra chat_messages seq lookup unless we actually need one.
+      let nextMessageSeq: number | undefined;
+      const allocateMessageSeq = async (): Promise<number> => {
+        if (nextMessageSeq === undefined) {
+          const latestMessage = await trx.selectFrom("chat_messages")
+            .select(({ fn }) => fn.max("seq").as("seq"))
+            .where("chat_id", "=", chatId)
+            .executeTakeFirst();
+          nextMessageSeq = Number(latestMessage?.seq ?? 0);
+        }
+        nextMessageSeq += 1;
+        return nextMessageSeq;
+      };
+      const insertedApprovalMessageIds: string[] = [];
       for (const activity of activities) {
         if (existingIds.has(activity.id)) {
           const row = existingById.get(activity.id);
@@ -395,6 +473,41 @@ export class ChatRunLifecycleRepository {
               session_created_at: sequenced.terminalSessionCreatedAt,
             })).execute();
           }
+          // Project approval.requested / approval.resolved into a chat message
+          // the browser can actually render (see approvalMessageParts above).
+          // Only fires for a genuinely new chat_run_events row (we're inside
+          // `if (row)`), and the chat_messages insert below is itself
+          // deduplicated on a deterministic id, so replaying or retrying the
+          // same activity can never produce a duplicate approval card.
+          const approvalMessage = approvalMessageParts(sequenced);
+          if (approvalMessage) {
+            const messageSeq = await allocateMessageSeq();
+            const message = CanonicalChatMessageSchema.parse({
+              id: approvalMessage.id,
+              chatId,
+              seq: messageSeq,
+              role: "system",
+              state: "committed",
+              turnId: run.turn_id,
+              runId,
+              parts: approvalMessage.parts,
+              createdAt: sequenced.occurredAt,
+            });
+            const messageRow = await trx.insertInto("chat_messages").values({
+              id: message.id,
+              chat_id: message.chatId,
+              seq: message.seq,
+              role: message.role,
+              state: message.state,
+              turn_id: message.turnId ?? null,
+              run_id: message.runId ?? null,
+              parts: jsonb(message.parts),
+              byte_count: encoded.encode(JSON.stringify(message)).byteLength,
+              search_text: messageSearchText(message),
+              created_at: message.createdAt,
+            }).onConflict((oc) => oc.column("id").doNothing()).returning("id").executeTakeFirst();
+            if (messageRow) insertedApprovalMessageIds.push(message.id);
+          }
         }
       }
       if (changed > 0) {
@@ -408,9 +521,15 @@ export class ChatRunLifecycleRepository {
         await trx.updateTable("chats").set({
           revision,
           ...(railTransition ? { attention: railTransition.attention } : {}),
+          ...(insertedApprovalMessageIds.length > 0
+            ? { message_count: sql<number>`message_count + ${insertedApprovalMessageIds.length}` }
+            : {}),
           updated_at: sql`now()`,
         }).where("id", "=", chatId).execute();
         await this.appendOutbox(trx, owner, chatId, revision, "run.activity", { runId });
+        for (const messageId of insertedApprovalMessageIds) {
+          await this.appendOutbox(trx, owner, chatId, revision, "run.message", { runId, messageId });
+        }
       }
       return changed;
     });
@@ -539,6 +658,16 @@ export class ChatRunLifecycleRepository {
         return { run: toRun(current), transitioned: false };
       }
       const expectedState = input.outcome === "completed" ? "committed" : "failed";
+      // Finalizes whatever assistant message(s) appendAssistantDelta already
+      // streamed for this run (state "pending" -> committed/failed). A
+      // non-streaming adapter that never called appendAssistantDelta can
+      // instead pass its complete output here via `output` -- that's the
+      // `else` branch below. Neither branch trusts a caller-supplied seq:
+      // the streaming branch keeps the pending row's existing seq (already
+      // allocated when appendAssistantDelta first inserted it), and the
+      // `output` branch allocates its own seq from MAX(seq)+1 itself, same
+      // as appendAssistantDelta and the approval projection -- so this
+      // remains the single, repository-owned seq allocator for the chat.
       const pendingRows = await trx.selectFrom("chat_messages").selectAll()
         .where("chat_id", "=", input.chatId)
         .where("run_id", "=", input.runId)
@@ -553,14 +682,12 @@ export class ChatRunLifecycleRepository {
         if (pendingMessages.some((pending) => pending.state !== "pending")) {
           throw new ChatConflictError(input.chatId, Number(chat.revision));
         }
-        if (output !== undefined && !pendingMessages.some((pending) => (
-          output.id === pending.id && output.seq === pending.seq
-        ))) {
+        if (output !== undefined && !pendingMessages.some((pending) => output.id === pending.id)) {
           throw new ChatConflictError(input.chatId, Number(chat.revision));
         }
         for (const pending of pendingMessages) {
           const finalized = CanonicalChatMessageSchema.parse({
-            ...(output?.id === pending.id ? output : pending),
+            ...(output?.id === pending.id ? { ...output, seq: pending.seq } : pending),
             state: expectedState,
           });
           await trx.updateTable("chat_messages").set({
@@ -581,23 +708,21 @@ export class ChatRunLifecycleRepository {
           .select(({ fn }) => fn.max("seq").as("seq"))
           .where("chat_id", "=", input.chatId)
           .executeTakeFirst();
-        if (output.seq !== Number(latest?.seq ?? 0) + 1) {
-          throw new ChatConflictError(input.chatId, Number(chat.revision));
-        }
+        const finalized = CanonicalChatMessageSchema.parse({ ...output, seq: Number(latest?.seq ?? 0) + 1 });
         await trx.insertInto("chat_messages").values({
-          id: output.id,
-          chat_id: output.chatId,
-          seq: output.seq,
-          role: output.role,
-          state: output.state,
-          turn_id: output.turnId ?? null,
-          run_id: output.runId ?? null,
-          parts: jsonb(output.parts),
-          byte_count: encoded.encode(JSON.stringify(output)).byteLength,
-          search_text: messageSearchText(output),
-          created_at: output.createdAt,
+          id: finalized.id,
+          chat_id: finalized.chatId,
+          seq: finalized.seq,
+          role: finalized.role,
+          state: finalized.state,
+          turn_id: finalized.turnId ?? null,
+          run_id: finalized.runId ?? null,
+          parts: jsonb(finalized.parts),
+          byte_count: encoded.encode(JSON.stringify(finalized)).byteLength,
+          search_text: messageSearchText(finalized),
+          created_at: finalized.createdAt,
         }).execute();
-        finalizedOutput = output;
+        finalizedOutput = finalized;
         insertedOutput = true;
       }
       const updated = await trx.updateTable("chat_runs").set({

--- a/packages/gateway/src/chat/run-lifecycle-repository.ts
+++ b/packages/gateway/src/chat/run-lifecycle-repository.ts
@@ -91,8 +91,15 @@ function railTransitionForActivity(activity: CanonicalChatRunActivity): {
 // approvalMessageId/approvalRequestDescription/approvalMessageParts below
 // produce that projection; see their single call site in appendRunActivities,
 // which mirrors the existing terminal.bound side effect in the same function.
-function approvalMessageId(kind: "request" | "result", approvalId: string): string {
-  const digest = createHash("sha256").update(approvalId).digest("hex").slice(0, 32);
+// Scoped by runId, not just approvalId: chat_messages.id is a global primary
+// key (not chat- or run-scoped — see database.ts), so a bare hash of
+// approvalId alone would let two different runs that happen to reuse the
+// same provider-supplied approvalId collide onto the same row, silently
+// dropping the second projection via the onConflict do-nothing below.
+// Matches the same scoping activityPersistenceId (orchestrator.ts) already
+// uses for run activities.
+function approvalMessageId(kind: "request" | "result", runId: string, approvalId: string): string {
+  const digest = createHash("sha256").update(`${runId}\0${approvalId}`).digest("hex").slice(0, 32);
   return `msg_approval_${kind}_${digest}`;
 }
 
@@ -117,7 +124,7 @@ function approvalMessageParts(activity: CanonicalChatRunActivity): {
 } | undefined {
   if (activity.type === "approval.requested") {
     return {
-      id: approvalMessageId("request", activity.approvalId),
+      id: approvalMessageId("request", activity.runId, activity.approvalId),
       parts: [CanonicalChatMessagePartSchema.parse({
         type: "approval_request",
         approvalId: activity.approvalId,
@@ -130,7 +137,7 @@ function approvalMessageParts(activity: CanonicalChatRunActivity): {
   }
   if (activity.type === "approval.resolved") {
     return {
-      id: approvalMessageId("result", activity.approvalId),
+      id: approvalMessageId("result", activity.runId, activity.approvalId),
       parts: [CanonicalChatMessagePartSchema.parse({
         type: "approval_result",
         approvalId: activity.approvalId,

--- a/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
+++ b/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
@@ -927,6 +927,19 @@ async function applyControl(control) {
       sessionApprovalGrants.grant(pending.method);
     }
     pendingApprovals.delete(control.approvalId);
+    // Mirrors the matrix.codex.approval.requested persist() above: without a
+    // resolved record, the gateway (and the approval_request card it renders)
+    // has no way to learn a decision was actually made here. The decision
+    // has already been sent to the provider at this point, so a transcript
+    // write failure here must not turn into an { ok: false } control
+    // response — that would misreport an approval that did go through.
+    try {
+      await persist({
+        type: "matrix.codex.approval.resolved",
+        approvalId: control.approvalId,
+        decision: control.decision,
+      });
+    } catch (_error) { stopping = true; }
   } else {
     const pending = pendingInputs.get(control.requestId);
     if (!pending) return { ok: false };
@@ -996,7 +1009,14 @@ const cleanupTimer = setInterval(() => {
   for (const [approvalId, pending] of pendingApprovals) {
     if (pending.expiresAt > now) continue;
     pendingApprovals.delete(approvalId);
-    try { sendProvider({ id: pending.nativeRequestId, result: { decision: "cancel" } }); } catch (_error) { stopping = true; }
+    try {
+      sendProvider({ id: pending.nativeRequestId, result: { decision: "cancel" } });
+      // Same resolved-record gap as applyControl's approval branch: a
+      // timed-out request needs this too, or its card stays "pending" in the
+      // UI forever even though the agent has already moved on.
+      void persist({ type: "matrix.codex.approval.resolved", approvalId, decision: "cancel" })
+        .catch(() => { stopping = true; });
+    } catch (_error) { stopping = true; }
   }
   for (const [requestId, pending] of pendingInputs) {
     if (pending.expiresAt > now) continue;

--- a/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
+++ b/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
@@ -939,7 +939,10 @@ async function applyControl(control) {
         approvalId: control.approvalId,
         decision: control.decision,
       });
-    } catch (_error) { stopping = true; }
+    } catch (error) {
+      process.stderr.write(`Failed to persist approval resolution for ${control.approvalId}: ${error?.message ?? error}\n`);
+      stopping = true;
+    }
   } else {
     const pending = pendingInputs.get(control.requestId);
     if (!pending) return { ok: false };
@@ -1015,7 +1018,10 @@ const cleanupTimer = setInterval(() => {
       // timed-out request needs this too, or its card stays "pending" in the
       // UI forever even though the agent has already moved on.
       void persist({ type: "matrix.codex.approval.resolved", approvalId, decision: "cancel" })
-        .catch(() => { stopping = true; });
+        .catch((error) => {
+          process.stderr.write(`Failed to persist timeout resolution for ${approvalId}: ${error?.message ?? error}\n`);
+          stopping = true;
+        });
     } catch (_error) { stopping = true; }
   }
   for (const [requestId, pending] of pendingInputs) {

--- a/packages/gateway/src/coding-agents/codex-events.ts
+++ b/packages/gateway/src/coding-agents/codex-events.ts
@@ -110,6 +110,11 @@ const MatrixCodexRecordSchema = z.discriminatedUnion("type", [
       .min(1).max(4),
   }).strict(),
   z.object({
+    type: z.literal("matrix.codex.approval.resolved"),
+    approvalId: ApprovalIdSchema,
+    decision: z.enum(["approve", "approve_for_session", "decline", "cancel"]),
+  }).strict(),
+  z.object({
     type: z.literal("matrix.codex.user_input.requested"),
     requestId: RequestIdSchema,
     correlationId: CorrelationIdSchema,
@@ -205,6 +210,13 @@ function appServerRecordEvents(
         allowedDecisions: record.allowedDecisions,
         correlationId: record.correlationId,
       },
+    })];
+  }
+  if (record.type === "matrix.codex.approval.resolved") {
+    return [event(context, {
+      type: "approval.resolved",
+      approvalId: record.approvalId,
+      decision: record.decision,
     })];
   }
   if (record.type === "matrix.codex.user_input.requested") {

--- a/shell/src/components/VocalPanel.tsx
+++ b/shell/src/components/VocalPanel.tsx
@@ -8,6 +8,7 @@ import type { ChatState } from "@/hooks/useChatState";
 import { AgentStatusCard } from "./AgentStatusCard";
 import { ShellNotificationCard } from "./ShellNotificationCard";
 import { ShellNotificationPortal } from "./ShellNotificationPortal";
+import { findRecentSystemErrorMessage } from "./vocal-panel-approval-guard.js";
 
 const GLOW_OPACITY: Record<string, number> = {
   idle: 0.68,
@@ -244,16 +245,9 @@ export function VocalPanel({ active, chat, onOpenApp }: VocalPanelProps) {
         reported = true;
         // Extract the last error from chat messages so Aoede can explain
         // what went wrong when the build fails.
-        let errorMessage: string | undefined;
-        if (newAppName === undefined) {
-          const msgs = chatMessagesRef.current;
-          for (let i = msgs.length - 1; i >= current.messageStartIdx; i--) {
-            if (msgs[i].role === "system") {
-              errorMessage = msgs[i].content.slice(0, 500);
-              break;
-            }
-          }
-        }
+        const errorMessage = newAppName === undefined
+          ? findRecentSystemErrorMessage(chatMessagesRef.current, current.messageStartIdx)
+          : undefined;
         notifyDelegationComplete({
           kind: "create_app",
           description: current.description,

--- a/shell/src/components/vocal-panel-approval-guard.ts
+++ b/shell/src/components/vocal-panel-approval-guard.ts
@@ -1,0 +1,23 @@
+// Pulled out of VocalPanel.tsx as a dependency-free module so it's testable
+// without VocalPanel's WS/mic session, react-query, and hook dependencies.
+
+// Finds the most recent role:"system" message in a delegation window to
+// narrate as a create_app build's error. Canonical approval cards are also
+// role "system" (canonical-chat-client.ts's projectCanonicalMessages), so an
+// unrelated pending/resolved approval in the window must be skipped rather
+// than narrated as the build's error. metadata.canonicalApproval is the same
+// marker CanonicalApprovalMessage keys off to render controls vs. a plain
+// notice.
+export function findRecentSystemErrorMessage(
+  messages: readonly { role: string; content: string; metadata?: Record<string, unknown> }[],
+  startIdx: number,
+): string | undefined {
+  const start = Math.max(0, startIdx);
+  for (let i = messages.length - 1; i >= start; i--) {
+    const m = messages[i];
+    if (m.role === "system" && m.metadata?.canonicalApproval === undefined) {
+      return m.content.slice(0, 500);
+    }
+  }
+  return undefined;
+}

--- a/tests/gateway/chat-orchestrator.test.ts
+++ b/tests/gateway/chat-orchestrator.test.ts
@@ -1313,6 +1313,86 @@ describe("CanonicalChatOrchestrator", () => {
     await orchestrator.drain();
   });
 
+  // Regression test: appendAssistantDelta and the approval-projection insert
+  // in appendRunActivities both write chat_messages rows and both used to
+  // compute their own target seq independently. In production the resolved
+  // record is persisted by the coding-agent runner process over its own
+  // control-socket connection -- genuinely out of band, concurrent with the
+  // dispatch loop below still streaming assistant output for the same run,
+  // not sequenced through the adapter's own event stream the way the test
+  // above resolves it. This drives that out-of-band write directly through
+  // repository.appendRunActivities while the dispatch loop is parked on the
+  // approval pause, then lets the loop resume to a second assistant message
+  // and completion, and asserts no seq collision.
+  it("assigns a collision-free seq to assistant output resumed after an out-of-band approval resolution", async () => {
+    await repository.create(owner, {
+      id: "chat_approval_seq",
+      clientRequestId: "req_create_approval_seq",
+      title: "Approval seq",
+    });
+    let release!: () => void;
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const provider = adapter(async function* () {
+      yield { type: "assistant.delta", messageId: "seq_before_approval", delta: "I need to change a file outside the workspace." };
+      yield {
+        type: "approval.requested" as const,
+        approvalId: "appr_seq",
+        title: "Run command",
+        risk: "medium" as const,
+        allowedDecisions: ["approve" as const, "decline" as const],
+      };
+      await released;
+      yield { type: "assistant.delta", messageId: "seq_after_approval", delta: "Resuming the change now that it's approved." };
+      yield { type: "run.completed" as const, outcome: "completed" as const };
+    });
+    const orchestrator = new CanonicalChatOrchestrator({
+      repository,
+      catalog: { getCatalog: async () => catalog() },
+      adapters: new CanonicalChatProviderRegistry([provider]),
+    });
+    const admitted = await orchestrator.admitTurn(principal, owner, "chat_approval_seq", {
+      clientRequestId: "req_approval_seq_turn",
+      baseRevision: 0,
+      parts: [{ type: "text", text: "run it" }],
+      selection: { instanceId: "codex_default", model: "gpt-5.6-sol" },
+      interactionMode: "default",
+      permissionMode: "supervised",
+    });
+    await vi.waitFor(async () => {
+      expect((await repository.get(owner, "chat_approval_seq"))?.activeRun?.status)
+        .toBe("waiting_for_approval");
+    });
+
+    await repository.appendRunActivities(owner, "chat_approval_seq", admitted.run.id, [{
+      id: "activity_approval_seq_resolved",
+      chatId: "chat_approval_seq",
+      runId: admitted.run.id,
+      occurredAt: "2026-08-26T00:00:00.000Z",
+      type: "approval.resolved",
+      approvalId: "appr_seq",
+      decision: "approve",
+    }]);
+    release();
+    await orchestrator.drain();
+
+    const messages = await repository.getMessages(owner, "chat_approval_seq", { afterSeq: 0, limit: 50 });
+    // user turn, assistant text, approval_request, approval_result, assistant text
+    expect(messages).toHaveLength(5);
+    const seqs = messages.map((m) => m.seq);
+    expect(new Set(seqs).size).toBe(seqs.length);
+    expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
+
+    const finalMessage = messages.at(-1)!;
+    expect(finalMessage.role).toBe("assistant");
+    expect(finalMessage.state).toBe("committed");
+    expect(finalMessage.parts.some((p) => p.type === "text" && p.text.includes("Resuming"))).toBe(true);
+
+    const record = await repository.get(owner, "chat_approval_seq");
+    expect(record?.activeRun).toBeUndefined(); // terminal: run completed, no longer active
+  });
+
   it("resumes later Turns only through the same adapter state schema and Instance", async () => {
     await repository.create(owner, {
       id: "chat_resumed",

--- a/tests/gateway/chat-repository.test.ts
+++ b/tests/gateway/chat-repository.test.ts
@@ -525,6 +525,132 @@ describe("ChatRepository", () => {
     expect(transitionEvents.map((event) => event.revision)).toEqual([2, 3, 4, 5]);
   });
 
+  // The rail (chat.attention / run.status) reacting to approval.requested /
+  // approval.resolved is covered above. It is not the only thing the browser
+  // needs: CanonicalApprovalMessage only ever renders approve/decline
+  // controls from a CanonicalChatMessage.parts entry typed "approval_request"
+  // / "approval_result" (role "system" -- see projectCanonicalMessages in
+  // shell/src/lib/canonical-chat-client.ts). Nothing previously projected the
+  // activity stream into that message stream, so an approval was tracked
+  // correctly server-side but never became something the browser could act
+  // on. These tests cover that projection.
+  it("projects approval.requested into a browser-renderable approval_request message", async () => {
+    const admitted = await admitChat(repository, "approval_projection_request");
+    await appendActivity(repository, admitted, {
+      id: "activity_approval_projection_request",
+      occurredAt: "2026-08-25T00:00:40.000Z",
+      type: "approval.requested",
+      approvalId: "approval_projection_1",
+      title: "Allow the command",
+      risk: "high",
+      allowedDecisions: ["approve", "decline"],
+    });
+
+    const messages = await repository.getMessages(owner, admitted.chatId, { afterSeq: 0, limit: 50 });
+    expect(messages).toHaveLength(2); // admitChat's user turn message, then the projected card
+    const message = messages[1];
+    expect(message.role).toBe("system");
+    expect(message.state).toBe("committed");
+    expect(message.runId).toBe(admitted.runId);
+    const part = message.parts.find((p) => p.type === "approval_request");
+    expect(part).toMatchObject({
+      approvalId: "approval_projection_1",
+      title: "Allow the command",
+      risk: "high",
+      allowedDecisions: ["approve", "decline"],
+    });
+
+    const record = await repository.get(owner, admitted.chatId);
+    expect(record?.chat.messageCount).toBe(2);
+  });
+
+  it("projects approval.resolved into an approval_result message and does not duplicate cards on replay", async () => {
+    const admitted = await admitChat(repository, "approval_projection_resolved");
+    const requested: ActivityInput = {
+      id: "activity_approval_projection_resolved_req",
+      occurredAt: "2026-08-25T00:00:40.000Z",
+      type: "approval.requested",
+      approvalId: "approval_projection_2",
+      title: "Allow the command",
+      risk: "medium",
+      allowedDecisions: ["approve", "decline"],
+    };
+    await appendActivity(repository, admitted, requested);
+    // Exact replay of the same requested activity must not add a second card.
+    await appendActivity(repository, admitted, requested);
+    await appendActivity(repository, admitted, {
+      id: "activity_approval_projection_resolved_res",
+      occurredAt: "2026-08-25T00:00:50.000Z",
+      type: "approval.resolved",
+      approvalId: "approval_projection_2",
+      decision: "approve",
+    });
+
+    const messages = await repository.getMessages(owner, admitted.chatId, { afterSeq: 0, limit: 50 });
+    expect(messages).toHaveLength(3); // admitChat's user turn message, then request, then result
+    expect(messages[1].seq).toBeLessThan(messages[2].seq);
+    expect(messages[2].role).toBe("system");
+    expect(messages[2].parts.find((p) => p.type === "approval_result")).toMatchObject({
+      approvalId: "approval_projection_2",
+      decision: "approve",
+    });
+
+    const record = await repository.get(owner, admitted.chatId);
+    expect(record?.chat.messageCount).toBe(3);
+  });
+
+  // Regression test: appendAssistantDelta and the approval projection above
+  // both insert into chat_messages and both used to compute their own target
+  // seq independently. A card projected mid-run could allocate a seq the
+  // caller of appendAssistantDelta didn't know about, so the next assistant
+  // message's caller-predicted seq would collide with it. Both call sites now
+  // allocate from MAX(seq)+1 themselves, inside the same chats-row FOR UPDATE
+  // transaction, making the repository the single seq allocator for a chat.
+  it("allocates a collision-free seq for a new assistant message after an approval resolves mid-run", async () => {
+    const admitted = await admitChat(repository, "approval_projection_seq");
+    const first = await repository.appendAssistantDelta(owner, {
+      chatId: admitted.chatId,
+      runId: admitted.runId,
+      messageId: `msg_${admitted.chatId}_assistant_1`,
+      delta: "I need to change a file outside the workspace.",
+      createdAt: "2026-08-25T00:00:35.000Z",
+    });
+    await appendActivity(repository, admitted, {
+      id: "activity_approval_projection_seq_req",
+      occurredAt: "2026-08-25T00:00:40.000Z",
+      type: "approval.requested",
+      approvalId: "approval_projection_3",
+      title: "Allow the command",
+      risk: "medium",
+      allowedDecisions: ["approve", "decline"],
+    });
+    await appendActivity(repository, admitted, {
+      id: "activity_approval_projection_seq_res",
+      occurredAt: "2026-08-25T00:00:50.000Z",
+      type: "approval.resolved",
+      approvalId: "approval_projection_3",
+      decision: "approve",
+    });
+    const resumed = await repository.appendAssistantDelta(owner, {
+      chatId: admitted.chatId,
+      runId: admitted.runId,
+      messageId: `msg_${admitted.chatId}_assistant_2`,
+      delta: "Resuming the change now that it's approved.",
+      createdAt: "2026-08-25T00:00:55.000Z",
+    });
+
+    const messages = await repository.getMessages(owner, admitted.chatId, { afterSeq: 0, limit: 50 });
+    expect(messages).toHaveLength(5); // user turn, text, approval_request, approval_result, text
+    const seqs = messages.map((m) => m.seq);
+    expect(new Set(seqs).size).toBe(seqs.length);
+    expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
+    expect(resumed.seq).toBeGreaterThan(first.seq);
+    expect(resumed.seq).toBe(Math.max(...seqs));
+
+    const record = await repository.get(owner, admitted.chatId);
+    expect(record?.activeRun?.status).toBe("running");
+  });
+
   it("projects failed and exact successful completion state without treating aborted or idle as complete", async () => {
     const failed = await admitChat(repository, "rail_terminal_failed");
     const unseen = await admitChat(repository, "rail_terminal_unseen");

--- a/tests/gateway/coding-agents-codex-events.test.ts
+++ b/tests/gateway/coding-agents-codex-events.test.ts
@@ -393,4 +393,23 @@ describe("Codex structured event normalization", () => {
       delta: "Working on it.",
     });
   });
+
+  it("normalizes matrix.codex.approval.resolved and rejects a malformed decision", () => {
+    const resolved = parseCodexExecJsonLine(JSON.stringify({
+      type: "matrix.codex.approval.resolved",
+      approvalId: "appr_codex_11111111111111111111111111111111",
+      decision: "approve",
+    }), context);
+    expect(resolved.events[0]).toMatchObject({
+      type: "approval.resolved",
+      approvalId: "appr_codex_11111111111111111111111111111111",
+      decision: "approve",
+    });
+
+    expect(parseCodexExecJsonLine(JSON.stringify({
+      type: "matrix.codex.approval.resolved",
+      approvalId: "appr_codex_11111111111111111111111111111111",
+      decision: "not_a_real_decision",
+    }), context)).toEqual({ events: [] });
+  });
 });

--- a/tests/shell/vocal-panel-approval-guard.test.ts
+++ b/tests/shell/vocal-panel-approval-guard.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { findRecentSystemErrorMessage } from "../../shell/src/components/vocal-panel-approval-guard.js";
+
+describe("findRecentSystemErrorMessage", () => {
+  it("returns the most recent plain system message as the error", () => {
+    const messages = [
+      { role: "user", content: "build me a todo app" },
+      { role: "assistant", content: "on it" },
+      { role: "system", content: "kernel: sandbox write denied" },
+    ];
+
+    expect(findRecentSystemErrorMessage(messages, 0)).toBe("kernel: sandbox write denied");
+  });
+
+  it("skips a system message carrying approval metadata and keeps looking", () => {
+    const messages = [
+      { role: "user", content: "build me a todo app" },
+      { role: "system", content: "kernel: sandbox write denied" },
+      {
+        role: "system",
+        content: "Allow the command: write outside the sandboxed workspace root.",
+        metadata: { canonicalApproval: { approvalId: "appr_1", pending: true } },
+      },
+    ];
+
+    expect(findRecentSystemErrorMessage(messages, 0)).toBe("kernel: sandbox write denied");
+  });
+
+  it("returns undefined when the only system message in range is an approval card", () => {
+    const messages = [
+      { role: "user", content: "build me a todo app" },
+      {
+        role: "system",
+        content: "Allow the command: write outside the sandboxed workspace root.",
+        metadata: { canonicalApproval: { approvalId: "appr_1", pending: false } },
+      },
+    ];
+
+    expect(findRecentSystemErrorMessage(messages, 0)).toBeUndefined();
+  });
+
+  it("respects startIdx and ignores messages before the delegation window", () => {
+    const messages = [
+      { role: "system", content: "stale error from a previous delegation" },
+      { role: "user", content: "build me a todo app" },
+      { role: "assistant", content: "on it" },
+    ];
+
+    expect(findRecentSystemErrorMessage(messages, 1)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #1531

## Root cause

1. Approval projection was missing entirely: `appendRunActivities` reacted to `approval.requested`/`approval.resolved` by updating run status/attention, but never turned the activity into a `CanonicalChatMessage` part — the only shape the chat UI's approval-controls component (`CanonicalApprovalMessage`) knows how to render. So an approval was tracked correctly server-side but the user never saw a control to grant or deny it.
2. Assistant output and the (now-added) approval projection did not share one serialized sequence-allocation path. Both write into `chat_messages`; if each computes its own target `seq` independently, a card projected mid-run can take a `seq` a concurrently-streaming assistant message doesn't know about, producing a sequence conflict on the next assistant message and failing the run — on exactly the turn approval was supposed to unblock.

## Fix

- Approval messages now use canonical role `"system"` — the role `projectCanonicalMessages` (shell) already collapses every non-user/non-assistant canonical role into, and the only role `ChatApp` routes to the approval-controls component for.
- Assistant output (`appendAssistantDelta`) and the approval projection (in `appendRunActivities`) now allocate a new message's `seq` through one repository-owned, serialized path: both compute `MAX(seq)+1` themselves, inside the same `chats`-row `FOR UPDATE` transaction that `selectOwnedChat` already takes for both call sites — no caller supplies or predicts a `seq` for a new message. `finishRun`'s existing (previously untested, still-used) `output` path for a non-streaming adapter's atomic final message is hardened the same way.
- `codex-app-server-runner.mjs` now persists a `matrix.codex.approval.resolved` record on both the control-socket decision path and the timeout-cleanup path, mirroring the existing `matrix.codex.approval.requested` persist() call. `codex-events.ts`'s parser gains the matching record type.
- Approval metadata is excluded from `VocalPanel`'s create_app build-failure narration, which previously scanned for the most recent `role:"system"` message without knowing an approval card is also `role:"system"` — an unrelated pending/resolved approval sitting in the narration window could get read out as the build's error message.

**Not touched**: sandbox policy, the approval decision logic, the control-socket protocol, and the canonical contract (`packages/contracts/src/canonical-chat.ts`) — role `"system"` and the message-part shapes used here were already part of the schema.

To be precise about scope: this does **not** move every sequence number in the system behind one exclusively-repository-generated path. `admitTurn`'s user-turn message still uses a separate, pre-existing, independently-guarded mechanism (a client-predicted `seq` validated under the same row lock, rejected with a conflict if stale) — unrelated to and unchanged by this fix. It cannot collide a row into the table; a stale prediction there only rejects the turn admission.

## Tests

New coverage added to the existing suites (no new test files except one for the narration-fix module):
- `tests/gateway/chat-repository.test.ts`: projection of `approval.requested`/`approval.resolved` into `approval_request`/`approval_result` messages, no duplicate cards on activity replay, and an end-to-end regression test driving assistant text → approval request → resolution → resumed assistant text and asserting no sequence collision.
- `tests/gateway/chat-orchestrator.test.ts`: the same scenario driven through the actual dispatch loop (not just the repository), with the resolution written out-of-band via a direct `appendRunActivities` call while the loop is parked on the approval pause — this is the real concurrency the fix closes, since in production the resolution is persisted by the coding-agent runner process over its own control-socket connection, genuinely concurrent with the dispatch loop still streaming output for the same run.
- `tests/gateway/coding-agents-codex-events.test.ts`: `matrix.codex.approval.resolved` event parsing, including malformed-decision rejection.
- `tests/shell/vocal-panel-approval-guard.test.ts` (new file): the extracted narration-guard function, including the "only an approval card is present" case.

**Result**: full `pnpm test` run against this branch (13,195 tests): 1,120 test files / 13,164 tests passed, 21 skipped, 10 failed across 5 files. All 10 failures were triaged: 4 were bugs in my own new test assertions (off-by-one message counts, and two assistant-delta events in the orchestrator test colliding onto one message because they omitted `messageId` — both fixed, not implementation bugs), and 2 more were catching a real gap in this PR itself (`finishRun`'s existing, still-used `output` path for a non-streaming adapter's atomic final message — I'd incorrectly assumed it was dead code and removed it in an earlier iteration; restored and hardened to allocate its `seq` the same repository-owned way). The remaining 3 failed tests, across `coding-agents-codex-app-server-runtime.test.ts` and `terminal-agent-options.test.ts`, are pre-existing and environment-specific (both spawn real child processes and time out) — confirmed by reverting the relevant source file and re-running, which reproduces the identical failure with this PR's changes absent.

After fixes, the 7 test files this PR touches or calls into (`chat-repository`, `chat-orchestrator`, `coding-agents-codex-events`, `coding-agents-threads`, `coding-agents-turn-dispatch`, `canonical-chat-client`, `vocal-panel-approval-guard`) pass 155/155. `bun run typecheck`, `bun run check:patterns` (0 violations), and `react-doctor` (0 new findings in the changed files) all pass clean.

Not merging this myself — opening for review.
