### PR TITLE
feat(desktop-chat): add chat title renaming

### DIFF
--- a/desktop/src/renderer/src/features/chat/ChatTitleEditor.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatTitleEditor.tsx
@@ -51,9 +51,11 @@ export function ChatTitleEditor({
       onKeyDown={(event) => {
         if (event.key === "Enter") {
           event.preventDefault();
+          event.stopPropagation();
           commit();
         } else if (event.key === "Escape") {
           event.preventDefault();
+          event.stopPropagation();
           settledRef.current = true;
           onCancel();
         }

--- a/desktop/src/renderer/src/features/chat/ChatTitleEditor.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatTitleEditor.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from "react";
+
+export function ChatTitleEditor({
+  title,
+  disabled = false,
+  className = "",
+  onCommit,
+  onCancel,
+}: {
+  title: string;
+  disabled?: boolean;
+  className?: string;
+  onCommit: (title: string) => void;
+  onCancel: () => void;
+}) {
+  const [value, setValue] = useState(title);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const settledRef = useRef(false);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const commit = () => {
+    if (settledRef.current || disabled) return;
+    const nextTitle = value.trim();
+    if (!nextTitle || nextTitle === title) {
+      settledRef.current = true;
+      onCancel();
+      return;
+    }
+    settledRef.current = true;
+    onCommit(nextTitle);
+  };
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      aria-label={`Rename ${title}`}
+      value={value}
+      maxLength={160}
+      disabled={disabled}
+      className={`no-drag min-w-0 rounded border bg-[var(--bg-surface)] px-1.5 py-0.5 text-inherit font-inherit outline-none focus:border-[var(--accent)] ${className}`}
+      style={{ color: "var(--text-primary)", borderColor: "var(--border-default)" }}
+      onClick={(event) => event.stopPropagation()}
+      onDoubleClick={(event) => event.stopPropagation()}
+      onChange={(event) => setValue(event.currentTarget.value)}
+      onBlur={commit}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          commit();
+        } else if (event.key === "Escape") {
+          event.preventDefault();
+          settledRef.current = true;
+          onCancel();
+        }
+      }}
+    />
+  );
+}

--- a/desktop/src/renderer/src/features/chat/ChatTitleEditor.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatTitleEditor.tsx
@@ -42,7 +42,7 @@ export function ChatTitleEditor({
       value={value}
       maxLength={160}
       disabled={disabled}
-      className={`no-drag min-w-0 rounded border bg-[var(--bg-surface)] px-1.5 py-0.5 text-inherit font-inherit outline-none focus:border-[var(--accent)] ${className}`}
+      className={`no-drag pointer-events-auto min-w-0 rounded border bg-[var(--bg-surface)] px-1.5 py-0.5 text-inherit font-inherit outline-none focus:border-[var(--accent)] ${className}`}
       style={{ color: "var(--text-primary)", borderColor: "var(--border-default)" }}
       onClick={(event) => event.stopPropagation()}
       onDoubleClick={(event) => event.stopPropagation()}

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
@@ -235,7 +235,7 @@ export default function DesktopSurfaceFrame({
     boxShadow: "none",
   };
   const workChatTitle = isWorkSurface && tab.chatId
-    ? tab.chatTitle ?? surfaceChrome?.title ?? "Chat"
+    ? surfaceChrome?.title ?? tab.chatTitle ?? "Chat"
     : undefined;
   const showsSurfaceTopBar = isWindow
     || Boolean(workChatTitle)

--- a/desktop/src/renderer/src/features/desktop-shell/OSWindow.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/OSWindow.tsx
@@ -155,7 +155,7 @@ export function TopBar({
   onMaximize,
   onDragStart,
 }: {
-  title?: string;
+  title?: ReactNode;
   icon?: ReactNode;
   leftActions?: ReactNode;
   rightActions?: ReactNode;
@@ -233,7 +233,7 @@ export function TopBar({
                 <div className={`flex min-w-0 items-center justify-start text-[15px] font-medium ${showSidebarTrigger ? "gap-1" : "gap-1.5"}`}>
                   {showSidebarTrigger ? <OSWindowSidebarTrigger label={sidebarTriggerLabel} /> : null}
                   {icon}
-                  <span className="truncate">{title}</span>
+                  <span className="min-w-0 truncate">{title}</span>
                 </div>
               ) : null}
             </div>
@@ -256,7 +256,7 @@ export function TopBar({
                 <div className="flex min-w-0 flex-1 items-center justify-center gap-1.5 text-xs font-medium" style={{ color: "var(--text-primary)" }}>
                   {showSidebarTrigger ? <OSWindowSidebarTrigger label={sidebarTriggerLabel} /> : null}
                   {icon}
-                  <span className="truncate">{title}</span>
+                  <span className="min-w-0 truncate">{title}</span>
                 </div>
                 <div className="w-28" aria-hidden="true" />
               </>

--- a/desktop/src/renderer/src/features/desktop-shell/SurfaceChrome.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/SurfaceChrome.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, type ReactNode } from "react";
 
 export interface SurfaceChromeSpec {
-  title?: string;
+  title?: ReactNode;
   leftActions?: ReactNode;
   rightActions?: ReactNode;
   leftPaneWidth?: number;

--- a/desktop/src/renderer/src/features/work/HostedWorkSidebar.tsx
+++ b/desktop/src/renderer/src/features/work/HostedWorkSidebar.tsx
@@ -50,6 +50,9 @@ export function HostedWorkSidebar({ tab, active }: { tab: Tab; active: boolean }
       onCreateProject={() => useUi.getState().openCreateProject()}
       onNewProjectChat={openWorkProject}
       onSelectChat={selectChat}
+      onChatRenamed={(record) => {
+        useTabs.getState().updateChatTitle(record.chat.id, record.chat.title);
+      }}
       onChatDeleted={(record, project) => {
         if (record.chat.id !== tab.chatId) return;
         if (project) openWorkProject(project);

--- a/desktop/src/renderer/src/features/work/HostedWorkSidebar.tsx
+++ b/desktop/src/renderer/src/features/work/HostedWorkSidebar.tsx
@@ -39,6 +39,7 @@ export function HostedWorkSidebar({ tab, active }: { tab: Tab; active: boolean }
     <WorkRail
       client={runtime?.client ?? null}
       eventSource={runtime?.eventSource ?? undefined}
+      projectedChatTitle={runtime?.projectedChatTitle ?? undefined}
       projects={projects}
       active={active}
       activeChatId={tab.chatId}

--- a/desktop/src/renderer/src/features/work/HostedWorkSidebar.tsx
+++ b/desktop/src/renderer/src/features/work/HostedWorkSidebar.tsx
@@ -39,7 +39,7 @@ export function HostedWorkSidebar({ tab, active }: { tab: Tab; active: boolean }
     <WorkRail
       client={runtime?.client ?? null}
       eventSource={runtime?.eventSource ?? undefined}
-      projectedChatTitle={runtime?.projectedChatTitle ?? undefined}
+      projectedChatTitles={runtime?.projectedChatTitles}
       projects={projects}
       active={active}
       activeChatId={tab.chatId}

--- a/desktop/src/renderer/src/features/work/WorkRail.tsx
+++ b/desktop/src/renderer/src/features/work/WorkRail.tsx
@@ -45,6 +45,7 @@ export function WorkRail({
   onNewProjectChat,
   onSelectChat,
   onChatDeleted,
+  onChatRenamed,
   onCollapse,
   showCollapseControl = true,
   className = "w-[240px]",
@@ -60,6 +61,7 @@ export function WorkRail({
   onNewProjectChat: (project: Project) => void;
   onSelectChat: (record: CanonicalChatRecord, project?: Project) => void;
   onChatDeleted?: (record: CanonicalChatRecord, project?: Project) => void;
+  onChatRenamed?: (record: CanonicalChatRecord, project?: Project) => void;
   onCollapse: () => void;
   showCollapseControl?: boolean;
   className?: string;
@@ -77,6 +79,9 @@ export function WorkRail({
   const [deleteChatTarget, setDeleteChatTarget] = useState<CanonicalChatRecord | null>(null);
   const [deletingChat, setDeletingChat] = useState(false);
   const [deleteChatError, setDeleteChatError] = useState<string | null>(null);
+  const [renamingChatId, setRenamingChatId] = useState<string | null>(null);
+  const [renamePending, setRenamePending] = useState(false);
+  const [renameError, setRenameError] = useState<string | null>(null);
   const [deleteProjectTarget, setDeleteProjectTarget] = useState<Project | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
   const routeScope = `${active ? "active" : "inactive"}\0${activeChatId ?? ""}\0${activeProjectSlug ?? ""}`;
@@ -104,6 +109,9 @@ export function WorkRail({
     setDeleteChatTarget(null);
     setDeletingChat(false);
     setDeleteChatError(null);
+    setRenamingChatId(null);
+    setRenamePending(false);
+    setRenameError(null);
     setStatus("loading");
     const refresh = async () => {
       if (refreshInFlight) {
@@ -201,6 +209,36 @@ export function WorkRail({
     }
   };
 
+  const renameChat = async (record: CanonicalChatRecord, title: string) => {
+    if (!client || renamePending) return;
+    const requestRouteGeneration = routeScopeRef.current.generation;
+    const targetProject = model.projects.find((group) => (
+      group.id === record.projectId || group.slug === record.projectId
+    ))?.project;
+    setRenamePending(true);
+    setRenameError(null);
+    try {
+      const updated = await client.updateTitle(record.chat.id, {
+        baseRevision: record.chat.revision,
+        title,
+      });
+      if (routeScopeRef.current.generation !== requestRouteGeneration) return;
+      setRecords((current) => current.map((candidate) => (
+        candidate.chat.id === updated.chat.id ? updated : candidate
+      )));
+      setRenamingChatId(null);
+      onChatRenamed?.(updated, targetProject);
+    } catch (error: unknown) {
+      console.warn("[work] Chat rename failed:", error instanceof Error ? error.name : "UnknownError");
+      if (routeScopeRef.current.generation === requestRouteGeneration) {
+        setRenameError("The Chat could not be renamed. Try again.");
+        setRenamingChatId(null);
+      }
+    } finally {
+      if (routeScopeRef.current.generation === requestRouteGeneration) setRenamePending(false);
+    }
+  };
+
   return (
     <nav
       aria-label="Chat navigation"
@@ -226,6 +264,11 @@ export function WorkRail({
               placement="pinned"
               active={record.chat.id === activeChatId}
               pinning={Boolean(pinning[record.chat.id])}
+              renaming={renamingChatId === record.chat.id}
+              renamePending={renamePending && renamingChatId === record.chat.id}
+              onRenameStart={() => { setRenameError(null); setRenamingChatId(record.chat.id); }}
+              onRenameCommit={(title) => { void renameChat(record, title); }}
+              onRenameCancel={() => setRenamingChatId(null)}
               onSelect={() => onSelectChat(
                 record,
                 model.projects.find((group) => (
@@ -268,6 +311,11 @@ export function WorkRail({
                 activeProjectSlug={activeProjectSlug}
                 activeChatId={activeChatId}
                 pinning={pinning}
+                renamingChatId={renamingChatId}
+                renamePending={renamePending}
+                onRenameChat={(record) => { setRenameError(null); setRenamingChatId(record.chat.id); }}
+                onRenameCommit={(record, title) => { void renameChat(record, title); }}
+                onRenameCancel={() => setRenamingChatId(null)}
                 onToggle={() => setExpandedProjects((current) => ({
                   ...current,
                   [group.id]: !current[group.id],
@@ -299,6 +347,11 @@ export function WorkRail({
               placement="recent"
               active={record.chat.id === activeChatId}
               pinning={Boolean(pinning[record.chat.id])}
+              renaming={renamingChatId === record.chat.id}
+              renamePending={renamePending && renamingChatId === record.chat.id}
+              onRenameStart={() => { setRenameError(null); setRenamingChatId(record.chat.id); }}
+              onRenameCommit={(title) => { void renameChat(record, title); }}
+              onRenameCancel={() => setRenamingChatId(null)}
               onSelect={() => onSelectChat(record)}
               onPin={() => updatePinned(record)}
               onDelete={() => {
@@ -316,6 +369,9 @@ export function WorkRail({
         ) : null}
         {pinError ? (
           <p role="alert" className="px-2 py-3 text-xs" style={{ color: "var(--text-tertiary)" }}>{pinError}</p>
+        ) : null}
+        {renameError ? (
+          <p role="alert" className="px-2 py-3 text-xs" style={{ color: "var(--danger)" }}>{renameError}</p>
         ) : null}
       </div>
       <DeleteConversationDialog

--- a/desktop/src/renderer/src/features/work/WorkRail.tsx
+++ b/desktop/src/renderer/src/features/work/WorkRail.tsx
@@ -17,9 +17,23 @@ import { WorkRailHeader } from "./work-rail/WorkRailHeader";
 import { WorkRailProjectGroup } from "./work-rail/WorkRailProjectGroup";
 import { WorkRailSection } from "./work-rail/WorkRailSection";
 import { WorkRailSearchDialog } from "./WorkRailSearchDialog";
+import type { CanonicalChatTitleProjection } from "./WorkSurfaceRuntime";
 
 type SectionKey = "pinned" | "projects" | "recents";
 const MAX_CHAT_PAGES = 10;
+
+function applyProjectedChat(
+  records: CanonicalChatRecord[],
+  projection: CanonicalChatTitleProjection | undefined,
+): CanonicalChatRecord[] {
+  if (!projection) return records;
+  const index = records.findIndex((record) => record.chat.id === projection.chatId);
+  if (index < 0 || records[index]!.chat.revision >= projection.revision) return records;
+  return records.map((record, candidateIndex) => candidateIndex === index ? {
+    ...record,
+    chat: { ...record.chat, title: projection.title, revision: projection.revision },
+  } : record);
+}
 
 async function loadWorkRailChats(client: CanonicalChatClient): Promise<CanonicalChatRecord[]> {
   const records: CanonicalChatRecord[] = [];
@@ -36,6 +50,7 @@ async function loadWorkRailChats(client: CanonicalChatClient): Promise<Canonical
 export function WorkRail({
   client,
   eventSource,
+  projectedChatTitle,
   projects,
   active,
   activeChatId,
@@ -52,6 +67,7 @@ export function WorkRail({
 }: {
   client: CanonicalChatClient | null;
   eventSource?: Pick<CanonicalChatEventSource, "subscribe">;
+  projectedChatTitle?: CanonicalChatTitleProjection;
   projects: Project[];
   active: boolean;
   activeChatId?: string;
@@ -86,6 +102,8 @@ export function WorkRail({
   const [searchOpen, setSearchOpen] = useState(false);
   const routeScope = `${active ? "active" : "inactive"}\0${activeChatId ?? ""}\0${activeProjectSlug ?? ""}`;
   const routeScopeRef = useRef({ client, key: routeScope, generation: 0 });
+  const projectedChatTitleRef = useRef(projectedChatTitle);
+  projectedChatTitleRef.current = projectedChatTitle;
   if (routeScopeRef.current.key !== routeScope || routeScopeRef.current.client !== client) {
     routeScopeRef.current = {
       client,
@@ -124,7 +142,7 @@ export function WorkRail({
         try {
           const loaded = await loadWorkRailChats(client);
           if (!current) return;
-          setRecords(loaded);
+          setRecords(applyProjectedChat(loaded, projectedChatTitleRef.current));
           setStatus("ready");
         } catch (error: unknown) {
           if (!current) return;
@@ -145,6 +163,11 @@ export function WorkRail({
       subscription?.dispose();
     };
   }, [active, activeChatId, activeProjectSlug, client, eventSource]);
+
+  useEffect(() => {
+    if (!projectedChatTitle) return;
+    setRecords((current) => applyProjectedChat(current, projectedChatTitle));
+  }, [projectedChatTitle]);
 
   const toggleSection = (key: SectionKey) => {
     setSections((current) => ({ ...current, [key]: !current[key] }));

--- a/desktop/src/renderer/src/features/work/WorkRail.tsx
+++ b/desktop/src/renderer/src/features/work/WorkRail.tsx
@@ -22,17 +22,19 @@ import type { CanonicalChatTitleProjection } from "./WorkSurfaceRuntime";
 type SectionKey = "pinned" | "projects" | "recents";
 const MAX_CHAT_PAGES = 10;
 
-function applyProjectedChat(
+function applyProjectedChats(
   records: CanonicalChatRecord[],
-  projection: CanonicalChatTitleProjection | undefined,
+  projections: CanonicalChatTitleProjection[] | undefined,
 ): CanonicalChatRecord[] {
-  if (!projection) return records;
-  const index = records.findIndex((record) => record.chat.id === projection.chatId);
-  if (index < 0 || records[index]!.chat.revision >= projection.revision) return records;
-  return records.map((record, candidateIndex) => candidateIndex === index ? {
-    ...record,
-    chat: { ...record.chat, title: projection.title, revision: projection.revision },
-  } : record);
+  if (!projections?.length) return records;
+  return records.map((record) => {
+    const projection = projections.find((candidate) => candidate.chatId === record.chat.id);
+    if (!projection || record.chat.revision >= projection.revision) return record;
+    return {
+      ...record,
+      chat: { ...record.chat, title: projection.title, revision: projection.revision },
+    };
+  });
 }
 
 async function loadWorkRailChats(client: CanonicalChatClient): Promise<CanonicalChatRecord[]> {
@@ -50,7 +52,7 @@ async function loadWorkRailChats(client: CanonicalChatClient): Promise<Canonical
 export function WorkRail({
   client,
   eventSource,
-  projectedChatTitle,
+  projectedChatTitles,
   projects,
   active,
   activeChatId,
@@ -67,7 +69,7 @@ export function WorkRail({
 }: {
   client: CanonicalChatClient | null;
   eventSource?: Pick<CanonicalChatEventSource, "subscribe">;
-  projectedChatTitle?: CanonicalChatTitleProjection;
+  projectedChatTitles?: CanonicalChatTitleProjection[];
   projects: Project[];
   active: boolean;
   activeChatId?: string;
@@ -102,8 +104,8 @@ export function WorkRail({
   const [searchOpen, setSearchOpen] = useState(false);
   const routeScope = `${active ? "active" : "inactive"}\0${activeChatId ?? ""}\0${activeProjectSlug ?? ""}`;
   const routeScopeRef = useRef({ client, key: routeScope, generation: 0 });
-  const projectedChatTitleRef = useRef(projectedChatTitle);
-  projectedChatTitleRef.current = projectedChatTitle;
+  const projectedChatTitlesRef = useRef(projectedChatTitles);
+  projectedChatTitlesRef.current = projectedChatTitles;
   if (routeScopeRef.current.key !== routeScope || routeScopeRef.current.client !== client) {
     routeScopeRef.current = {
       client,
@@ -142,7 +144,7 @@ export function WorkRail({
         try {
           const loaded = await loadWorkRailChats(client);
           if (!current) return;
-          setRecords(applyProjectedChat(loaded, projectedChatTitleRef.current));
+          setRecords(applyProjectedChats(loaded, projectedChatTitlesRef.current));
           setStatus("ready");
         } catch (error: unknown) {
           if (!current) return;
@@ -165,9 +167,9 @@ export function WorkRail({
   }, [active, activeChatId, activeProjectSlug, client, eventSource]);
 
   useEffect(() => {
-    if (!projectedChatTitle) return;
-    setRecords((current) => applyProjectedChat(current, projectedChatTitle));
-  }, [projectedChatTitle]);
+    if (!projectedChatTitles?.length) return;
+    setRecords((current) => applyProjectedChats(current, projectedChatTitles));
+  }, [projectedChatTitles]);
 
   const toggleSection = (key: SectionKey) => {
     setSections((current) => ({ ...current, [key]: !current[key] }));

--- a/desktop/src/renderer/src/features/work/WorkRail.tsx
+++ b/desktop/src/renderer/src/features/work/WorkRail.tsx
@@ -266,7 +266,12 @@ export function WorkRail({
               pinning={Boolean(pinning[record.chat.id])}
               renaming={renamingChatId === record.chat.id}
               renamePending={renamePending && renamingChatId === record.chat.id}
-              onRenameStart={() => { setRenameError(null); setRenamingChatId(record.chat.id); }}
+              renameDisabled={renamePending}
+              onRenameStart={() => {
+                if (renamePending) return;
+                setRenameError(null);
+                setRenamingChatId(record.chat.id);
+              }}
               onRenameCommit={(title) => { void renameChat(record, title); }}
               onRenameCancel={() => setRenamingChatId(null)}
               onSelect={() => onSelectChat(
@@ -313,7 +318,11 @@ export function WorkRail({
                 pinning={pinning}
                 renamingChatId={renamingChatId}
                 renamePending={renamePending}
-                onRenameChat={(record) => { setRenameError(null); setRenamingChatId(record.chat.id); }}
+                onRenameChat={(record) => {
+                  if (renamePending) return;
+                  setRenameError(null);
+                  setRenamingChatId(record.chat.id);
+                }}
                 onRenameCommit={(record, title) => { void renameChat(record, title); }}
                 onRenameCancel={() => setRenamingChatId(null)}
                 onToggle={() => setExpandedProjects((current) => ({
@@ -349,7 +358,12 @@ export function WorkRail({
               pinning={Boolean(pinning[record.chat.id])}
               renaming={renamingChatId === record.chat.id}
               renamePending={renamePending && renamingChatId === record.chat.id}
-              onRenameStart={() => { setRenameError(null); setRenamingChatId(record.chat.id); }}
+              renameDisabled={renamePending}
+              onRenameStart={() => {
+                if (renamePending) return;
+                setRenameError(null);
+                setRenamingChatId(record.chat.id);
+              }}
               onRenameCommit={(title) => { void renameChat(record, title); }}
               onRenameCancel={() => setRenamingChatId(null)}
               onSelect={() => onSelectChat(record)}

--- a/desktop/src/renderer/src/features/work/WorkSurfaceRuntime.tsx
+++ b/desktop/src/renderer/src/features/work/WorkSurfaceRuntime.tsx
@@ -6,11 +6,20 @@ import {
   type DesktopCanonicalChatWebSocket,
 } from "../../lib/canonical-chat-client";
 import { useConnection } from "../../stores/connection";
-import { createContext, useContext, useEffect, useMemo, useRef, type ReactNode } from "react";
+import type { CanonicalChatRecord } from "@matrix-os/contracts";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 interface WorkSurfaceRuntime {
   client: CanonicalChatClient | null;
   eventSource: CanonicalChatEventSource | null;
+  projectedChatTitle: CanonicalChatTitleProjection | null;
+  projectChat: (record: CanonicalChatRecord) => void;
+}
+
+export interface CanonicalChatTitleProjection {
+  chatId: string;
+  title: string;
+  revision: number;
 }
 
 const WorkSurfaceRuntimeContext = createContext<WorkSurfaceRuntime | null>(null);
@@ -19,6 +28,10 @@ export function WorkSurfaceRuntimeProvider({ active, children }: { active: boole
   const api = useConnection((state) => state.api);
   const runtimeSlot = useConnection((state) => state.runtimeSlot);
   const authGeneration = useConnection((state) => state.authGeneration);
+  const [projection, setProjection] = useState<{
+    client: CanonicalChatClient | null;
+    title: CanonicalChatTitleProjection;
+  } | null>(null);
   const pendingDisposalRef = useRef<{ source: CanonicalChatEventSource; cancelled: boolean } | null>(null);
   const client = useMemo(() => api ? createCanonicalChatClient(api) : null, [api, authGeneration, runtimeSlot]);
   const eventSource = useMemo<CanonicalChatEventSource | null>(() => {
@@ -53,7 +66,21 @@ export function WorkSurfaceRuntimeProvider({ active, children }: { active: boole
     };
   }, [eventSource]);
 
-  const value = useMemo(() => ({ client, eventSource }), [client, eventSource]);
+  const projectChat = useCallback((record: CanonicalChatRecord) => {
+    setProjection({
+      client,
+      title: {
+        chatId: record.chat.id,
+        title: record.chat.title,
+        revision: record.chat.revision,
+      },
+    });
+  }, [client]);
+  const projectedChatTitle = projection?.client === client ? projection.title : null;
+  const value = useMemo(
+    () => ({ client, eventSource, projectedChatTitle, projectChat }),
+    [client, eventSource, projectChat, projectedChatTitle],
+  );
   return <WorkSurfaceRuntimeContext.Provider value={value}>{children}</WorkSurfaceRuntimeContext.Provider>;
 }
 

--- a/desktop/src/renderer/src/features/work/WorkSurfaceRuntime.tsx
+++ b/desktop/src/renderer/src/features/work/WorkSurfaceRuntime.tsx
@@ -12,7 +12,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 interface WorkSurfaceRuntime {
   client: CanonicalChatClient | null;
   eventSource: CanonicalChatEventSource | null;
-  projectedChatTitle: CanonicalChatTitleProjection | null;
+  projectedChatTitles: CanonicalChatTitleProjection[];
   projectChat: (record: CanonicalChatRecord) => void;
 }
 
@@ -22,6 +22,9 @@ export interface CanonicalChatTitleProjection {
   revision: number;
 }
 
+const MAX_CHAT_TITLE_PROJECTIONS = 100;
+const EMPTY_CHAT_TITLE_PROJECTIONS: CanonicalChatTitleProjection[] = [];
+
 const WorkSurfaceRuntimeContext = createContext<WorkSurfaceRuntime | null>(null);
 
 export function WorkSurfaceRuntimeProvider({ active, children }: { active: boolean; children: ReactNode }) {
@@ -30,7 +33,7 @@ export function WorkSurfaceRuntimeProvider({ active, children }: { active: boole
   const authGeneration = useConnection((state) => state.authGeneration);
   const [projection, setProjection] = useState<{
     client: CanonicalChatClient | null;
-    title: CanonicalChatTitleProjection;
+    titles: CanonicalChatTitleProjection[];
   } | null>(null);
   const pendingDisposalRef = useRef<{ source: CanonicalChatEventSource; cancelled: boolean } | null>(null);
   const client = useMemo(() => api ? createCanonicalChatClient(api) : null, [api, authGeneration, runtimeSlot]);
@@ -67,19 +70,23 @@ export function WorkSurfaceRuntimeProvider({ active, children }: { active: boole
   }, [eventSource]);
 
   const projectChat = useCallback((record: CanonicalChatRecord) => {
-    setProjection({
-      client,
-      title: {
-        chatId: record.chat.id,
-        title: record.chat.title,
-        revision: record.chat.revision,
-      },
+    setProjection((current) => {
+      const titles = current?.client === client ? current.titles : [];
+      const existing = titles.find((candidate) => candidate.chatId === record.chat.id);
+      if (existing && existing.revision > record.chat.revision) return current;
+      return {
+        client,
+        titles: [
+          ...titles.filter((candidate) => candidate.chatId !== record.chat.id),
+          { chatId: record.chat.id, title: record.chat.title, revision: record.chat.revision },
+        ].slice(-MAX_CHAT_TITLE_PROJECTIONS),
+      };
     });
   }, [client]);
-  const projectedChatTitle = projection?.client === client ? projection.title : null;
+  const projectedChatTitles = projection?.client === client ? projection.titles : EMPTY_CHAT_TITLE_PROJECTIONS;
   const value = useMemo(
-    () => ({ client, eventSource, projectedChatTitle, projectChat }),
-    [client, eventSource, projectChat, projectedChatTitle],
+    () => ({ client, eventSource, projectedChatTitles, projectChat }),
+    [client, eventSource, projectChat, projectedChatTitles],
   );
   return <WorkSurfaceRuntimeContext.Provider value={value}>{children}</WorkSurfaceRuntimeContext.Provider>;
 }

--- a/desktop/src/renderer/src/features/work/WorkTab.tsx
+++ b/desktop/src/renderer/src/features/work/WorkTab.tsx
@@ -490,10 +490,11 @@ export default function WorkTab({
   }, [initialChatId, layout, openGlobalDraft, showChat]);
   const applyRenamedChat = useCallback((record: CanonicalChatRecord) => {
     useTabs.getState().updateChatTitle(record.chat.id, record.chat.title);
+    hostedRuntime?.projectChat(record);
     if (record.chat.id === activeChatScopeRef.current.chatId) {
       setActiveChatTitle(record.chat.title);
     }
-  }, []);
+  }, [hostedRuntime]);
   const renameActiveChat = useCallback(async (title: string) => {
     const scope = activeChatScopeRef.current;
     if (!scope.client || !scope.chatId || renamingChatTitle) return;

--- a/desktop/src/renderer/src/features/work/WorkTab.tsx
+++ b/desktop/src/renderer/src/features/work/WorkTab.tsx
@@ -25,6 +25,7 @@ import type { WorkRoute } from "../../stores/tabs";
 import { useTabs } from "../../stores/tabs";
 import { useUi } from "../../stores/ui";
 import ChatTab from "../chat/ChatTab";
+import { ChatTitleEditor } from "../chat/ChatTitleEditor";
 import ProjectChatsView from "../project/ProjectChatsView";
 import ProjectsIndex from "../project/ProjectsIndex";
 import { WorkRail } from "./WorkRail";
@@ -237,6 +238,10 @@ export default function WorkTab({
     chatId: string;
     session: TerminalSessionSummary;
   } | null>(null);
+  const [activeChatTitle, setActiveChatTitle] = useState(initialChatTitle ?? "Chat");
+  const [editingChatTitle, setEditingChatTitle] = useState(false);
+  const [renamingChatTitle, setRenamingChatTitle] = useState(false);
+  const [renameChatError, setRenameChatError] = useState<string | null>(null);
   const { layout, navigationOpen, inspectorOpen } = responsive;
   const localClient = useMemo(() => api ? createCanonicalChatClient(api) : null, [api, authGeneration, runtimeSlot]);
   const localEventSource = useMemo<CanonicalChatEventSource | null>(() => {
@@ -254,6 +259,8 @@ export default function WorkTab({
   }, [active, api, authGeneration, hostedRuntime, runtimeSlot]);
   const client = hostedRuntime?.client ?? localClient;
   const eventSource = hostedRuntime?.eventSource ?? localEventSource;
+  const activeChatScopeRef = useRef({ client, chatId: initialChatId });
+  activeChatScopeRef.current = { client, chatId: initialChatId };
   const routeKey = `${active}:${route}:${projectSlug ?? ""}:${initialChatView ?? ""}:${initialChatId ?? ""}`;
   const hasInspector = Boolean(active && (route === "chat" || route === "project"));
   const narrowPane = effectiveNarrowPane(responsive, routeKey, hasInspector);
@@ -291,6 +298,13 @@ export default function WorkTab({
       && initialChatTitle !== "New chat"
     ) setDraftTerminalLaunch(null);
   }, [draftTerminalLaunch, initialChatId, initialChatTitle]);
+
+  useEffect(() => {
+    setActiveChatTitle(initialChatTitle ?? "Chat");
+    setEditingChatTitle(false);
+    setRenamingChatTitle(false);
+    setRenameChatError(null);
+  }, [initialChatId, initialChatTitle]);
 
   useLayoutEffect(() => {
     if (!active || route !== "project" || !projectSlug) return;
@@ -474,6 +488,41 @@ export default function WorkTab({
     }
     openGlobalDraft();
   }, [initialChatId, layout, openGlobalDraft, showChat]);
+  const applyRenamedChat = useCallback((record: CanonicalChatRecord) => {
+    useTabs.getState().updateChatTitle(record.chat.id, record.chat.title);
+    if (record.chat.id === activeChatScopeRef.current.chatId) {
+      setActiveChatTitle(record.chat.title);
+    }
+  }, []);
+  const renameActiveChat = useCallback(async (title: string) => {
+    const scope = activeChatScopeRef.current;
+    if (!scope.client || !scope.chatId || renamingChatTitle) return;
+    setRenamingChatTitle(true);
+    setRenameChatError(null);
+    try {
+      const detail = await scope.client.getDetail(scope.chatId, { limit: 200 });
+      const updated = await scope.client.updateTitle(scope.chatId, {
+        baseRevision: detail.record.chat.revision,
+        title,
+      });
+      if (activeChatScopeRef.current.client !== scope.client
+        || activeChatScopeRef.current.chatId !== scope.chatId) return;
+      applyRenamedChat(updated);
+      setEditingChatTitle(false);
+    } catch (error: unknown) {
+      console.warn("[work] active Chat rename failed:", error instanceof Error ? error.name : "UnknownError");
+      if (activeChatScopeRef.current.client === scope.client
+        && activeChatScopeRef.current.chatId === scope.chatId) {
+        setRenameChatError("The Chat could not be renamed. Try again.");
+        setEditingChatTitle(false);
+      }
+    } finally {
+      if (activeChatScopeRef.current.client === scope.client
+        && activeChatScopeRef.current.chatId === scope.chatId) {
+        setRenamingChatTitle(false);
+      }
+    }
+  }, [applyRenamedChat, renamingChatTitle]);
   const collapseRail = useCallback(() => {
     if (layout === "narrow") showChat(true);
     else hideRail();
@@ -602,11 +651,38 @@ export default function WorkTab({
       onNewProjectChat={openProjectDraft}
       onSelectChat={selectRailChat}
       onChatDeleted={handleRailChatDeleted}
+      onChatRenamed={applyRenamedChat}
     />
-  ), [active, client, collapseRail, eventSource, handleRailChatDeleted, initialChatId, openCreateProject, openGlobalDraft, openProjectDraft, projectSlug, projects, route, selectRailChat]);
-  const chromeTitle = initialChatId && initialChatId !== draftTerminalLaunch?.chatId
-    ? initialChatTitle ?? "Chat"
-    : route === "projects" ? "Chat" : undefined;
+  ), [active, applyRenamedChat, client, collapseRail, eventSource, handleRailChatDeleted, initialChatId, openCreateProject, openGlobalDraft, openProjectDraft, projectSlug, projects, route, selectRailChat]);
+  const chromeTitle = useMemo(() => initialChatId && initialChatId !== draftTerminalLaunch?.chatId
+    ? editingChatTitle ? (
+        <ChatTitleEditor
+          title={activeChatTitle}
+          disabled={renamingChatTitle}
+          className="w-[min(360px,40vw)]"
+          onCommit={(title) => { void renameActiveChat(title); }}
+          onCancel={() => setEditingChatTitle(false)}
+        />
+      ) : (
+        <button
+          type="button"
+          aria-label={`Rename ${activeChatTitle}`}
+          title="Rename chat"
+          className="no-drag pointer-events-auto min-w-0 truncate rounded px-1.5 py-0.5 text-left outline-none hover:bg-[var(--bg-hover)] focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          onClick={() => { setRenameChatError(null); setEditingChatTitle(true); }}
+        >
+          {activeChatTitle}
+        </button>
+      )
+    : route === "projects" ? "Chat" : undefined, [
+      activeChatTitle,
+      draftTerminalLaunch?.chatId,
+      editingChatTitle,
+      initialChatId,
+      renameActiveChat,
+      renamingChatTitle,
+      route,
+    ]);
   const chromeSpec = useMemo(() => ({
     title: chromeTitle,
     leftPaneWidth: hostedChrome || (layout !== "narrow" && navigationVisible) ? NAVIGATION_WIDTH : 0,
@@ -646,6 +722,11 @@ export default function WorkTab({
           aria-hidden="true"
           className="h-12 shrink-0"
         />
+      ) : null}
+      {renameChatError ? (
+        <div role="alert" className="shrink-0 border-b px-3 py-2 text-xs" style={{ borderColor: "var(--border-subtle)", color: "var(--danger)" }}>
+          {renameChatError}
+        </div>
       ) : null}
       {!hostedChrome && layout === "narrow" && narrowPane === "chat" ? (
         <header

--- a/desktop/src/renderer/src/features/work/work-rail/WorkRailChatRow.tsx
+++ b/desktop/src/renderer/src/features/work/work-rail/WorkRailChatRow.tsx
@@ -9,6 +9,7 @@ import {
 } from "@renderer/lib/hugeicons";
 import { ContextMenu } from "../../../design/primitives";
 import { OverflowingChatTitle } from "../OverflowingChatTitle";
+import { ChatTitleEditor } from "../../chat/ChatTitleEditor";
 import {
   resolveWorkRailAgentState,
   type WorkRailAgentState,
@@ -20,6 +21,11 @@ export function WorkRailChatRow({
   pinning,
   placement,
   onSelect,
+  renaming,
+  renamePending,
+  onRenameStart,
+  onRenameCommit,
+  onRenameCancel,
   onPin,
   onDelete,
 }: {
@@ -28,6 +34,11 @@ export function WorkRailChatRow({
   pinning: boolean;
   placement: "pinned" | "project" | "recent";
   onSelect: () => void;
+  renaming: boolean;
+  renamePending: boolean;
+  onRenameStart: () => void;
+  onRenameCommit: (title: string) => void;
+  onRenameCancel: () => void;
   onPin: () => void;
   onDelete: () => void;
 }) {
@@ -35,6 +46,11 @@ export function WorkRailChatRow({
   const agentState = resolveWorkRailAgentState(record);
   return (
     <ContextMenu items={[
+      {
+        label: "Rename",
+        disabled: renamePending,
+        onSelect: () => window.setTimeout(onRenameStart, 20),
+      },
       {
         label: pinned ? "Unpin" : "Pin",
         disabled: pinning,
@@ -51,19 +67,35 @@ export function WorkRailChatRow({
         className="group/chat relative flex min-w-0 items-center rounded-md transition-colors duration-100 hover:bg-[var(--bg-hover)] focus-within:bg-[var(--bg-hover)]"
         style={{ background: active ? "var(--bg-selected)" : undefined }}
       >
-        <button
+        {renaming ? (
+          <div className="flex w-full min-w-0 items-center gap-2.5 px-2.5 py-1.5 text-sm font-medium">
+            <MessageSquare size={15} aria-hidden className="shrink-0" style={{ color: active ? "var(--accent)" : "var(--text-tertiary)" }} />
+            <ChatTitleEditor
+              title={record.chat.title}
+              disabled={renamePending}
+              className="w-full"
+              onCommit={onRenameCommit}
+              onCancel={onRenameCancel}
+            />
+          </div>
+        ) : <button
           type="button"
           aria-label={record.chat.title}
           aria-current={active ? "page" : undefined}
           className="flex w-full min-w-0 items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-sm font-medium outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--accent)]"
           style={{ color: active ? "var(--text-primary)" : "var(--text-secondary)" }}
           onClick={onSelect}
+          onDoubleClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            window.setTimeout(onRenameStart, 0);
+          }}
         >
           <MessageSquare size={15} aria-hidden className="shrink-0" style={{ color: active ? "var(--accent)" : "var(--text-tertiary)" }} />
           <OverflowingChatTitle title={record.chat.title} />
           <ChatAgentStateIndicator state={agentState} title={record.chat.title} />
-        </button>
-        <div
+        </button>}
+        {!renaming ? <div
           className="pointer-events-none absolute right-1 top-1/2 z-10 flex -translate-y-1/2 items-center gap-0.5 rounded-md opacity-0 transition-opacity group-hover/chat:pointer-events-auto group-hover/chat:opacity-100 group-focus-within/chat:pointer-events-auto group-focus-within/chat:opacity-100"
           style={{
             background: active
@@ -92,7 +124,7 @@ export function WorkRailChatRow({
           >
             <Trash2 size={13} aria-hidden />
           </button>
-        </div>
+        </div> : null}
       </div>
     </ContextMenu>
   );

--- a/desktop/src/renderer/src/features/work/work-rail/WorkRailChatRow.tsx
+++ b/desktop/src/renderer/src/features/work/work-rail/WorkRailChatRow.tsx
@@ -23,6 +23,7 @@ export function WorkRailChatRow({
   onSelect,
   renaming,
   renamePending,
+  renameDisabled,
   onRenameStart,
   onRenameCommit,
   onRenameCancel,
@@ -36,6 +37,7 @@ export function WorkRailChatRow({
   onSelect: () => void;
   renaming: boolean;
   renamePending: boolean;
+  renameDisabled: boolean;
   onRenameStart: () => void;
   onRenameCommit: (title: string) => void;
   onRenameCancel: () => void;
@@ -48,7 +50,7 @@ export function WorkRailChatRow({
     <ContextMenu items={[
       {
         label: "Rename",
-        disabled: renamePending,
+        disabled: renameDisabled,
         onSelect: () => window.setTimeout(onRenameStart, 20),
       },
       {
@@ -88,7 +90,7 @@ export function WorkRailChatRow({
           onDoubleClick={(event) => {
             event.preventDefault();
             event.stopPropagation();
-            window.setTimeout(onRenameStart, 0);
+            if (!renameDisabled) window.setTimeout(onRenameStart, 0);
           }}
         >
           <MessageSquare size={15} aria-hidden className="shrink-0" style={{ color: active ? "var(--accent)" : "var(--text-tertiary)" }} />

--- a/desktop/src/renderer/src/features/work/work-rail/WorkRailChatRow.tsx
+++ b/desktop/src/renderer/src/features/work/work-rail/WorkRailChatRow.tsx
@@ -14,6 +14,7 @@ import {
   resolveWorkRailAgentState,
   type WorkRailAgentState,
 } from "../work-rail-model";
+import { useEffect, useRef } from "react";
 
 export function WorkRailChatRow({
   record,
@@ -44,6 +45,19 @@ export function WorkRailChatRow({
   onPin: () => void;
   onDelete: () => void;
 }) {
+  const selectTimerRef = useRef<number | null>(null);
+  const renameTimerRef = useRef<number | null>(null);
+  useEffect(() => () => {
+    if (selectTimerRef.current !== null) window.clearTimeout(selectTimerRef.current);
+    if (renameTimerRef.current !== null) window.clearTimeout(renameTimerRef.current);
+  }, []);
+  const scheduleRename = (delay: number) => {
+    if (renameTimerRef.current !== null) window.clearTimeout(renameTimerRef.current);
+    renameTimerRef.current = window.setTimeout(() => {
+      renameTimerRef.current = null;
+      onRenameStart();
+    }, delay);
+  };
   const pinned = Boolean(record.chat.userState?.pinned);
   const agentState = resolveWorkRailAgentState(record);
   return (
@@ -51,7 +65,7 @@ export function WorkRailChatRow({
       {
         label: "Rename",
         disabled: renameDisabled,
-        onSelect: () => window.setTimeout(onRenameStart, 20),
+        onSelect: () => scheduleRename(20),
       },
       {
         label: pinned ? "Unpin" : "Pin",
@@ -86,11 +100,25 @@ export function WorkRailChatRow({
           aria-current={active ? "page" : undefined}
           className="flex w-full min-w-0 items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-sm font-medium outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--accent)]"
           style={{ color: active ? "var(--text-primary)" : "var(--text-secondary)" }}
-          onClick={onSelect}
+          onClick={(event) => {
+            if (event.detail === 0) {
+              onSelect();
+              return;
+            }
+            if (selectTimerRef.current !== null) window.clearTimeout(selectTimerRef.current);
+            selectTimerRef.current = window.setTimeout(() => {
+              selectTimerRef.current = null;
+              onSelect();
+            }, 250);
+          }}
           onDoubleClick={(event) => {
             event.preventDefault();
             event.stopPropagation();
-            if (!renameDisabled) window.setTimeout(onRenameStart, 0);
+            if (selectTimerRef.current !== null) {
+              window.clearTimeout(selectTimerRef.current);
+              selectTimerRef.current = null;
+            }
+            if (!renameDisabled) scheduleRename(0);
           }}
         >
           <MessageSquare size={15} aria-hidden className="shrink-0" style={{ color: active ? "var(--accent)" : "var(--text-tertiary)" }} />

--- a/desktop/src/renderer/src/features/work/work-rail/WorkRailProjectGroup.tsx
+++ b/desktop/src/renderer/src/features/work/work-rail/WorkRailProjectGroup.tsx
@@ -15,6 +15,11 @@ export function WorkRailProjectGroup({
   onNewChat,
   onDeleteProject,
   onSelectChat,
+  renamingChatId,
+  renamePending,
+  onRenameChat,
+  onRenameCommit,
+  onRenameCancel,
   onPinChat,
   onDeleteChat,
 }: {
@@ -27,6 +32,11 @@ export function WorkRailProjectGroup({
   onNewChat: (project: Project) => void;
   onDeleteProject: (project: Project) => void;
   onSelectChat: (record: CanonicalChatRecord, project: Project) => void;
+  renamingChatId: string | null;
+  renamePending: boolean;
+  onRenameChat: (record: CanonicalChatRecord) => void;
+  onRenameCommit: (record: CanonicalChatRecord, title: string) => void;
+  onRenameCancel: () => void;
   onPinChat: (record: CanonicalChatRecord) => void;
   onDeleteChat: (record: CanonicalChatRecord) => void;
 }) {
@@ -82,6 +92,11 @@ export function WorkRailProjectGroup({
               placement="project"
               active={record.chat.id === activeChatId}
               pinning={Boolean(pinning[record.chat.id])}
+              renaming={renamingChatId === record.chat.id}
+              renamePending={renamePending && renamingChatId === record.chat.id}
+              onRenameStart={() => onRenameChat(record)}
+              onRenameCommit={(title) => onRenameCommit(record, title)}
+              onRenameCancel={onRenameCancel}
               onSelect={() => onSelectChat(record, group.project)}
               onPin={() => onPinChat(record)}
               onDelete={() => onDeleteChat(record)}

--- a/desktop/src/renderer/src/features/work/work-rail/WorkRailProjectGroup.tsx
+++ b/desktop/src/renderer/src/features/work/work-rail/WorkRailProjectGroup.tsx
@@ -94,6 +94,7 @@ export function WorkRailProjectGroup({
               pinning={Boolean(pinning[record.chat.id])}
               renaming={renamingChatId === record.chat.id}
               renamePending={renamePending && renamingChatId === record.chat.id}
+              renameDisabled={renamePending}
               onRenameStart={() => onRenameChat(record)}
               onRenameCommit={(title) => onRenameCommit(record, title)}
               onRenameCancel={onRenameCancel}

--- a/desktop/src/renderer/src/lib/canonical-chat-client.ts
+++ b/desktop/src/renderer/src/lib/canonical-chat-client.ts
@@ -30,6 +30,7 @@ import {
   CanonicalSubmitChatApprovalRequestSchema,
   CanonicalRetryChatTurnRequestSchema,
   CanonicalUpdateChatProjectRequestSchema,
+  CanonicalUpdateChatTitleRequestSchema,
   CanonicalUpdateChatUserStateRequestSchema,
   type CanonicalChatDetailResponse,
   type CanonicalChatListResponse,
@@ -55,6 +56,7 @@ import {
   type CanonicalSubmitChatApprovalRequest,
   type CanonicalRetryChatTurnRequest,
   type CanonicalUpdateChatProjectRequest,
+  type CanonicalUpdateChatTitleRequest,
   type CanonicalUpdateChatUserStateRequest,
 } from "@matrix-os/contracts";
 import { z } from "zod/v4";
@@ -430,6 +432,7 @@ export interface CanonicalChatClient {
   ): Promise<CanonicalChatListResponse>;
   create(input: CanonicalCreateChatRequest): Promise<CanonicalChatRecord>;
   updateProject(chatId: string, input: CanonicalUpdateChatProjectRequest): Promise<CanonicalChatRecord>;
+  updateTitle(chatId: string, input: CanonicalUpdateChatTitleRequest): Promise<CanonicalChatRecord>;
   updateUserState(chatId: string, input: CanonicalUpdateChatUserStateRequest): Promise<CanonicalChatRecord>;
   acknowledgeCompletion(
     chatId: string,
@@ -541,6 +544,15 @@ export function createCanonicalChatClient(
       const request = CanonicalUpdateChatProjectRequestSchema.parse(input);
       return CanonicalChatRecordSchema.parse(await api.patch(
         `/api/chats/${encodeURIComponent(parsedChatId)}/project`,
+        request,
+      ));
+    },
+
+    async updateTitle(chatId, input) {
+      const parsedChatId = CanonicalChatIdSchema.parse(chatId);
+      const request = CanonicalUpdateChatTitleRequestSchema.parse(input);
+      return CanonicalChatRecordSchema.parse(await api.patch(
+        `/api/chats/${encodeURIComponent(parsedChatId)}/title`,
         request,
       ));
     },

--- a/desktop/src/renderer/src/stores/tabs.ts
+++ b/desktop/src/renderer/src/stores/tabs.ts
@@ -139,6 +139,7 @@ interface TabsState {
     id: string,
     route: { chatId?: string; chatView: "index" | "draft" | "conversation"; title: string },
   ): void;
+  updateChatTitle(chatId: string, title: string): void;
   clearActiveTab(id: string): void;
   closeTab(id: string): void;
   closeProjectTabs(projectSlug: string): void;
@@ -252,6 +253,16 @@ export const useTabs = create<TabsState>()((set, get) => ({
           title: route.title,
           chatId: route.chatId,
           chatView: route.chatView,
+        }
+      : tab),
+  })),
+
+  updateChatTitle: (chatId, title) => set((state) => ({
+    tabs: state.tabs.map((tab) => tab.chatId === chatId
+      ? {
+          ...tab,
+          chatTitle: title,
+          ...(tab.kind === "chat" ? { title } : {}),
         }
       : tab),
   })),

--- a/packages/contracts/src/canonical-chat-api.ts
+++ b/packages/contracts/src/canonical-chat-api.ts
@@ -102,6 +102,11 @@ export const CanonicalUpdateChatProjectRequestSchema = z.object({
   projectId: canonicalReferenceId(160).nullable(),
 }).strict();
 
+export const CanonicalUpdateChatTitleRequestSchema = z.object({
+  baseRevision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  title: z.string().trim().min(1).max(160),
+}).strict();
+
 export const CanonicalUpdateChatUserStateRequestSchema = z.object({
   pinned: z.boolean(),
 }).strict();
@@ -333,6 +338,7 @@ export type CanonicalChatStreamEvent = z.infer<typeof CanonicalChatStreamEventSc
 export type CanonicalChatStreamClientFrame = z.infer<typeof CanonicalChatStreamClientFrameSchema>;
 export type CanonicalChatStreamServerFrame = z.infer<typeof CanonicalChatStreamServerFrameSchema>;
 export type CanonicalUpdateChatProjectRequest = z.infer<typeof CanonicalUpdateChatProjectRequestSchema>;
+export type CanonicalUpdateChatTitleRequest = z.infer<typeof CanonicalUpdateChatTitleRequestSchema>;
 export type CanonicalUpdateChatUserStateRequest = z.infer<typeof CanonicalUpdateChatUserStateRequestSchema>;
 export type CanonicalCreateChatTurnRequest = z.infer<typeof CanonicalCreateChatTurnRequestSchema>;
 export type CanonicalQueueChatTurnRequest = z.infer<typeof CanonicalQueueChatTurnRequestSchema>;

--- a/packages/gateway/src/chat/routes.ts
+++ b/packages/gateway/src/chat/routes.ts
@@ -31,6 +31,7 @@ import {
   CanonicalRetryChatTurnRequestSchema,
   CanonicalSteerChatRunRequestSchema,
   CanonicalUpdateChatProjectRequestSchema,
+  CanonicalUpdateChatTitleRequestSchema,
   CanonicalUpdateChatUserStateRequestSchema,
   type CanonicalChatDetailResponse,
   type CanonicalChatListResponse,
@@ -56,6 +57,7 @@ import {
   type CanonicalRetryChatTurnRequest,
   type CanonicalSteerChatRunRequest,
   type CanonicalUpdateChatProjectRequest,
+  type CanonicalUpdateChatTitleRequest,
   type CanonicalUpdateChatUserStateRequest,
 } from "@matrix-os/contracts";
 import { Hono, type Context } from "hono";
@@ -112,6 +114,11 @@ export interface CanonicalChatRouteService {
     owner: ChatOwner,
     chatId: string,
     input: CanonicalUpdateChatProjectRequest,
+  ): Promise<CanonicalChatRecord>;
+  updateTitle(
+    owner: ChatOwner,
+    chatId: string,
+    input: CanonicalUpdateChatTitleRequest,
   ): Promise<CanonicalChatRecord>;
   updateUserState(
     owner: ChatOwner,
@@ -394,6 +401,22 @@ export function createCanonicalChatRoutes(options: {
       const parsed = CanonicalUpdateChatProjectRequestSchema.safeParse(await context.req.json());
       if (!parsed.success) return validationError(context);
       const result = await options.service.updateProject(
+        ownerFromPrincipal(options.getPrincipal(context)),
+        chatId,
+        parsed.data,
+      );
+      return context.json(CanonicalChatRecordSchema.parse(result));
+    } catch (error: unknown) {
+      return handleError(context, error);
+    }
+  });
+
+  routes.patch("/api/chats/:chatId/title", updateBodyLimit, async (context) => {
+    try {
+      const chatId = CanonicalChatIdSchema.parse(context.req.param("chatId"));
+      const parsed = CanonicalUpdateChatTitleRequestSchema.safeParse(await context.req.json());
+      if (!parsed.success) return validationError(context);
+      const result = await options.service.updateTitle(
         ownerFromPrincipal(options.getPrincipal(context)),
         chatId,
         parsed.data,

--- a/packages/gateway/src/chat/service.ts
+++ b/packages/gateway/src/chat/service.ts
@@ -25,6 +25,7 @@ import {
   CanonicalSubmitChatApprovalRequestSchema,
   CanonicalSteerChatRunRequestSchema,
   CanonicalUpdateChatProjectRequestSchema,
+  CanonicalUpdateChatTitleRequestSchema,
   CanonicalUpdateChatUserStateRequestSchema,
   CanonicalCreateChatRequestSchema,
   type CanonicalChatDetailResponse,
@@ -51,6 +52,7 @@ import {
   type CanonicalSteerChatRunRequest,
   type CanonicalChatApprovalSubmissionResponse,
   type CanonicalUpdateChatProjectRequest,
+  type CanonicalUpdateChatTitleRequest,
   type CanonicalUpdateChatUserStateRequest,
 } from "@matrix-os/contracts";
 import { z } from "zod/v4";
@@ -183,6 +185,18 @@ export function createCanonicalChatService(
         owner,
         CanonicalChatIdSchema.parse(chatId),
         request,
+      ));
+    },
+
+    async updateTitle(
+      owner: ChatOwner,
+      chatId: string,
+      input: CanonicalUpdateChatTitleRequest,
+    ): Promise<CanonicalChatRecord> {
+      return CanonicalChatRecordSchema.parse(await repository.update(
+        owner,
+        CanonicalChatIdSchema.parse(chatId),
+        CanonicalUpdateChatTitleRequestSchema.parse(input),
       ));
     },
 
@@ -445,6 +459,7 @@ export function createUnavailableCanonicalChatService(): CanonicalChatRouteServi
   return {
     create: unavailable,
     updateProject: unavailable,
+    updateTitle: unavailable,
     updateUserState: unavailable,
     acknowledgeCompletion: unavailable,
     delete: unavailable,

--- a/shell/src/components/ChatApp.tsx
+++ b/shell/src/components/ChatApp.tsx
@@ -51,6 +51,11 @@ import {
   canonicalApproval,
 } from "./chat/CanonicalApprovalMessage";
 import {
+  ChatTitleEditor,
+  RenameableConversationRow,
+  type RenameableConversation,
+} from "./chat/ChatTitleRename";
+import {
   PlusIcon,
   SendIcon,
   MicIcon,
@@ -63,12 +68,7 @@ import {
   Settings2Icon,
 } from "@/lib/hugeicons";
 
-interface ConversationMeta {
-  id: string;
-  preview: string;
-  messageCount: number;
-  updatedAt: number;
-}
+type ConversationMeta = RenameableConversation;
 
 const HERMES_SETUP_STORAGE_KEY = "matrix:hermes-setup";
 
@@ -107,6 +107,8 @@ interface ChatAppProps {
   conversations: ConversationMeta[];
   onNewChat: () => void;
   onSwitchConversation: (id: string) => void;
+  activeConversationTitle?: string;
+  onRenameConversation?: (id: string, title: string) => Promise<boolean>;
   onSubmit: (
     text: string,
     files?: Array<{ name: string; type: string; data: string }>,
@@ -170,6 +172,8 @@ export function ChatApp({
   conversations,
   onNewChat,
   onSwitchConversation,
+  activeConversationTitle,
+  onRenameConversation,
   onSubmit,
   providerSelection,
   onSubmitApproval,
@@ -184,6 +188,8 @@ export function ChatApp({
   const [setupOpen, setSetupOpen] = useState(false);
   const [submittingApprovalId, setSubmittingApprovalId] = useState<string | null>(null);
   const [providerSetupError, setProviderSetupError] = useState<string | null>(null);
+  const [editingChat, setEditingChat] = useState<{ id: string; source: "header" | "rail" } | null>(null);
+  const [renamePending, setRenamePending] = useState(false);
   const initialHermesSetupRef = useRef<ReturnType<typeof readHermesSetup> | null>(null);
   const getInitialHermesSetup = () => {
     // react-doctor-disable-next-line react-hooks-js/todo -- React Compiler cannot yet lower the `??=` logical-assignment operator (BuildHIR Todo); this lazy one-time ref cache is a deliberate first-render localStorage read and rewriting it would not change behavior.
@@ -223,7 +229,7 @@ export function ChatApp({
   const filteredConversations = !trimmedSearch
     ? conversations
     : conversations.filter((c) =>
-        c.preview?.toLowerCase().includes(searchQuery.toLowerCase()),
+        `${c.title ?? ""}\n${c.preview ?? ""}`.toLowerCase().includes(searchQuery.toLowerCase()),
       );
 
   const timeGroups = groupConversationsByTime(filteredConversations);
@@ -314,22 +320,25 @@ export function ChatApp({
                   {group.label}
                 </div>
                 {group.items.map((conv) => (
-                  <button
+                  <RenameableConversationRow
                     key={conv.id}
-                    type="button"
-                    onClick={() => onSwitchConversation(conv.id)}
-                    className={`group flex w-full items-center gap-2 rounded-lg px-2.5 text-left text-[13px] transition-colors ${mobile ? "py-3" : "py-2"} ${
-                      conv.id === sessionId
-                        ? "bg-accent/50 text-foreground"
-                        : "text-foreground/70 hover:bg-accent/30 hover:text-foreground"
-                    }`}
-                  >
-                    <span className="flex-1 truncate">
-                      {conv.preview
-                        ? conv.preview.slice(0, 40) + (conv.preview.length > 40 ? "..." : "")
-                        : "New chat"}
-                    </span>
-                  </button>
+                    conversation={conv}
+                    active={conv.id === sessionId}
+                    mobile={mobile}
+                    editing={editingChat?.source === "rail" && editingChat.id === conv.id}
+                    renamePending={renamePending && editingChat?.id === conv.id}
+                    onSelect={() => onSwitchConversation(conv.id)}
+                    onRenameStart={!mobile && onRenameConversation && !renamePending ? () => setEditingChat({ id: conv.id, source: "rail" }) : undefined}
+                    onRenameCancel={() => setEditingChat(null)}
+                    onRenameCommit={(title) => {
+                      if (!onRenameConversation || renamePending) return;
+                      setRenamePending(true);
+                      void onRenameConversation(conv.id, title).finally(() => {
+                        setRenamePending(false);
+                        setEditingChat(null);
+                      });
+                    }}
+                  />
                 ))}
               </div>
             ))}
@@ -375,10 +384,32 @@ export function ChatApp({
               <span className="inline-flex size-6 items-center justify-center rounded-full bg-primary/10 text-primary">
                 <BotIcon className="size-3.5" aria-hidden="true" />
               </span>
-              <div className="min-w-0 text-center">
-                <p className="truncate text-sm font-semibold leading-4 text-foreground">
-                  {providerState.activeInstance?.displayName ?? "Matrix Agent"}
-                </p>
+              <div className="min-w-0 flex-1 text-center">
+                {editingChat?.source === "header" && editingChat.id === sessionId && activeConversationTitle ? (
+                  <ChatTitleEditor
+                    title={activeConversationTitle}
+                    pending={renamePending}
+                    onCancel={() => setEditingChat(null)}
+                    onCommit={(title) => {
+                      if (!sessionId || !onRenameConversation || renamePending) return;
+                      setRenamePending(true);
+                      void onRenameConversation(sessionId, title).finally(() => {
+                        setRenamePending(false);
+                        setEditingChat(null);
+                      });
+                    }}
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    aria-label={activeConversationTitle ? `Rename ${activeConversationTitle}` : undefined}
+                    disabled={!sessionId || !activeConversationTitle || !onRenameConversation || renamePending}
+                    className={`max-w-full truncate rounded px-1 text-sm font-semibold leading-4 text-foreground outline-none enabled:hover:bg-accent/40 enabled:focus-visible:ring-2 enabled:focus-visible:ring-primary/40 ${mobile ? "min-h-11 py-2" : ""}`}
+                    onClick={() => sessionId && activeConversationTitle && setEditingChat({ id: sessionId, source: "header" })}
+                  >
+                    {activeConversationTitle ?? providerState.activeInstance?.displayName ?? "Matrix Agent"}
+                  </button>
+                )}
                 <p className="truncate text-[10px] leading-3 text-muted-foreground">
                   {providerState.selected?.modelLabel ?? (providerState.loading ? "Loading AI access" : "AI access unavailable")}
                 </p>

--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -526,6 +526,8 @@ export function CanvasWindow({ win, iconUrl, hidden = false, deferAppContent = f
               conversations={chatState.conversations}
               onNewChat={chatState.newChat}
               onSwitchConversation={chatState.switchConversation}
+              activeConversationTitle={chatState.activeConversationTitle}
+              onRenameConversation={chatState.renameConversation}
               onSubmit={chatState.submitMessage}
               onSubmitApproval={chatState.submitApproval}
               providerSelection={chatState.providerSelection}

--- a/shell/src/components/chat/ChatTitleRename.tsx
+++ b/shell/src/components/chat/ChatTitleRename.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+
+export interface RenameableConversation {
+  id: string;
+  title?: string;
+  preview: string;
+  messageCount: number;
+  updatedAt: number;
+}
+
+export function ChatTitleEditor({ title, pending, onCommit, onCancel }: {
+  title: string;
+  pending: boolean;
+  onCommit: (title: string) => void;
+  onCancel: () => void;
+}) {
+  const [value, setValue] = useState(title);
+  const committedRef = useRef(false);
+  const commit = () => {
+    if (committedRef.current || pending) return;
+    const next = value.trim();
+    if (!next || next === title) {
+      onCancel();
+      return;
+    }
+    committedRef.current = true;
+    onCommit(next);
+  };
+  return (
+    <input
+      autoFocus
+      aria-label={`Rename ${title}`}
+      className="min-w-0 w-full rounded border border-primary/45 bg-background px-1.5 py-0.5 text-sm font-semibold text-foreground outline-none focus:ring-2 focus:ring-primary/30"
+      disabled={pending}
+      maxLength={160}
+      value={value}
+      onChange={(event) => setValue(event.target.value)}
+      onFocus={(event) => event.currentTarget.select()}
+      onBlur={commit}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          commit();
+        } else if (event.key === "Escape") {
+          event.preventDefault();
+          committedRef.current = true;
+          onCancel();
+        }
+      }}
+    />
+  );
+}
+
+export function RenameableConversationRow({
+  conversation,
+  active,
+  mobile,
+  editing,
+  renamePending,
+  onSelect,
+  onRenameStart,
+  onRenameCommit,
+  onRenameCancel,
+}: {
+  conversation: RenameableConversation;
+  active: boolean;
+  mobile: boolean;
+  editing: boolean;
+  renamePending: boolean;
+  onSelect: () => void;
+  onRenameStart?: () => void;
+  onRenameCommit: (title: string) => void;
+  onRenameCancel: () => void;
+}) {
+  const selectTimerRef = useRef<number | null>(null);
+  const renameTimerRef = useRef<number | null>(null);
+  useEffect(() => () => {
+    if (selectTimerRef.current !== null) window.clearTimeout(selectTimerRef.current);
+    if (renameTimerRef.current !== null) window.clearTimeout(renameTimerRef.current);
+  }, []);
+  const title = conversation.title || conversation.preview || "New chat";
+  const row = editing ? (
+    <div className={`flex w-full items-center px-2.5 ${mobile ? "py-3" : "py-1.5"}`}>
+      <ChatTitleEditor title={title} pending={renamePending} onCommit={onRenameCommit} onCancel={onRenameCancel} />
+    </div>
+  ) : (
+    <button
+      type="button"
+      aria-label={title}
+      aria-current={active ? "page" : undefined}
+      onClick={(event) => {
+        if (!onRenameStart || event.detail === 0) {
+          onSelect();
+          return;
+        }
+        if (selectTimerRef.current !== null) window.clearTimeout(selectTimerRef.current);
+        selectTimerRef.current = window.setTimeout(() => {
+          selectTimerRef.current = null;
+          onSelect();
+        }, 250);
+      }}
+      onDoubleClick={onRenameStart ? (event) => {
+        event.preventDefault();
+        if (selectTimerRef.current !== null) window.clearTimeout(selectTimerRef.current);
+        selectTimerRef.current = null;
+        onRenameStart();
+      } : undefined}
+      className={`group flex w-full items-center gap-2 rounded-lg px-2.5 text-left text-[13px] transition-colors ${mobile ? "py-3" : "py-2"} ${
+        active ? "bg-accent/50 text-foreground" : "text-foreground/70 hover:bg-accent/30 hover:text-foreground"
+      }`}
+    >
+      <span className="flex-1 truncate">{title.slice(0, 40) + (title.length > 40 ? "..." : "")}</span>
+    </button>
+  );
+  if (!onRenameStart || editing) return row;
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onSelect={() => {
+          if (renameTimerRef.current !== null) window.clearTimeout(renameTimerRef.current);
+          renameTimerRef.current = window.setTimeout(() => {
+            renameTimerRef.current = null;
+            onRenameStart();
+          }, 0);
+        }}>
+          Rename
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/shell/src/components/desktop/DesktopWindow.tsx
+++ b/shell/src/components/desktop/DesktopWindow.tsx
@@ -214,6 +214,8 @@ export function DesktopWindow({
                 conversations={chat.conversations}
                 onNewChat={chat.newChat}
                 onSwitchConversation={chat.switchConversation}
+                activeConversationTitle={chat.activeConversationTitle}
+                onRenameConversation={chat.renameConversation}
                 onSubmit={chat.submitMessage}
                 onSubmitApproval={chat.submitApproval}
                 providerSelection={chat.providerSelection}

--- a/shell/src/components/mobile/MobileShell.tsx
+++ b/shell/src/components/mobile/MobileShell.tsx
@@ -613,6 +613,8 @@ function MobileAppFrame({
         conversations={chat.conversations}
         onNewChat={() => void chat.newChat()}
         onSwitchConversation={chat.switchConversation}
+        activeConversationTitle={chat.activeConversationTitle}
+        onRenameConversation={chat.renameConversation}
         onSubmit={chat.submitMessage}
         onSubmitApproval={chat.submitApproval}
         providerSelection={chat.providerSelection}

--- a/shell/src/hooks/useCanonicalChatState.ts
+++ b/shell/src/hooks/useCanonicalChatState.ts
@@ -292,9 +292,22 @@ export function useCanonicalChatState(): ChatState {
         baseRevision: current.chat.revision,
         title,
       });
-      setRecords((existing) => existing.map((record) => record.chat.id === chatId ? updated : record));
+      const projectTitle = (record: CanonicalChatRecord) => (
+        record.chat.revision > updated.chat.revision
+          ? record
+          : {
+            ...record,
+            chat: {
+              ...record.chat,
+              title: updated.chat.title,
+              revision: updated.chat.revision,
+              updatedAt: updated.chat.updatedAt,
+            },
+          }
+      );
+      setRecords((existing) => existing.map((record) => record.chat.id === chatId ? projectTitle(record) : record));
       setDetail((existing) => existing?.record.chat.id === chatId
-        ? { ...existing, record: updated }
+        ? { ...existing, record: projectTitle(existing.record) }
         : existing);
       setSafeError(null);
       return true;

--- a/shell/src/hooks/useCanonicalChatState.ts
+++ b/shell/src/hooks/useCanonicalChatState.ts
@@ -24,6 +24,7 @@ function requestId(): string {
 function conversationMeta(record: CanonicalChatRecord) {
   return {
     id: record.chat.id,
+    title: record.chat.title,
     preview: record.chat.lastMessagePreview ?? record.chat.title,
     messageCount: record.chat.messageCount,
     createdAt: Date.parse(record.chat.createdAt),
@@ -278,6 +279,32 @@ export function useCanonicalChatState(): ChatState {
     }
   }, [client, loadDetail]);
 
+  const renameConversation = useCallback(async (chatId: string, title: string) => {
+    const current = detailRef.current?.record.chat.id === chatId
+      ? detailRef.current.record
+      : records.find((record) => record.chat.id === chatId);
+    if (!current) {
+      setSafeError("The Chat could not be renamed. Refresh and try again.");
+      return false;
+    }
+    try {
+      const updated = await client.updateTitle(chatId, {
+        baseRevision: current.chat.revision,
+        title,
+      });
+      setRecords((existing) => existing.map((record) => record.chat.id === chatId ? updated : record));
+      setDetail((existing) => existing?.record.chat.id === chatId
+        ? { ...existing, record: updated }
+        : existing);
+      setSafeError(null);
+      return true;
+    } catch (error: unknown) {
+      console.warn("[canonical-chat] Shell rename failed:", error instanceof Error ? error.name : "UnknownError");
+      setSafeError("The Chat could not be renamed. Try again.");
+      return false;
+    }
+  }, [client, records]);
+
   const messages = detail ? projectCanonicalMessages(detail.messages) : [];
   if (safeError) {
     messages.push({ id: "canonical-safe-error", role: "system", content: safeError, timestamp: Date.now() });
@@ -295,6 +322,8 @@ export function useCanonicalChatState(): ChatState {
     queue: [],
     providerSelection: activeRecord?.chat.currentSelection,
     conversations: records.map(conversationMeta),
+    activeConversationTitle: activeRecord?.chat.title,
+    renameConversation,
     composerDraftRequest,
     requestComposerDraft: (text) => setComposerDraftRequest({ id: ++composerDraftSequence.current, text }),
     consumeComposerDraft: (id) => setComposerDraftRequest((current) => current?.id === id ? null : current),

--- a/shell/src/hooks/useChatState.ts
+++ b/shell/src/hooks/useChatState.ts
@@ -32,6 +32,8 @@ export interface ChatState {
   queue: QueuedMessage[];
   providerSelection?: CanonicalChatModelSelection;
   conversations: ReturnType<typeof useConversation>["conversations"];
+  activeConversationTitle?: string;
+  renameConversation?: (id: string, title: string) => Promise<boolean>;
   composerDraftRequest: { id: number; text: string } | null;
   requestComposerDraft: (text: string) => void;
   consumeComposerDraft: (id: number) => void;

--- a/shell/src/lib/canonical-chat-client.ts
+++ b/shell/src/lib/canonical-chat-client.ts
@@ -9,6 +9,7 @@ import {
   CanonicalChatRunIdSchema,
   CanonicalChatRunCancellationResponseSchema,
   CanonicalChatTurnAdmissionResponseSchema,
+  CanonicalUpdateChatTitleRequestSchema,
   CanonicalSubmitChatApprovalRequestSchema,
   CanonicalCreateChatRequestSchema,
   CanonicalCreateChatTurnRequestSchema,
@@ -23,6 +24,7 @@ import {
   type CanonicalChatTurnAdmissionResponse,
   type CanonicalCreateChatRequest,
   type CanonicalCreateChatTurnRequest,
+  type CanonicalUpdateChatTitleRequest,
 } from "@matrix-os/contracts";
 import type { ChatMessage } from "@/lib/chat";
 
@@ -32,6 +34,7 @@ export interface CanonicalShellChatClient {
   list(): Promise<CanonicalChatListResponse>;
   create(input: CanonicalCreateChatRequest): Promise<CanonicalChatRecord>;
   detail(chatId: string): Promise<CanonicalChatDetailResponse>;
+  updateTitle(chatId: string, input: CanonicalUpdateChatTitleRequest): Promise<CanonicalChatRecord>;
   admitTurn(chatId: string, input: CanonicalCreateChatTurnRequest): Promise<CanonicalChatTurnAdmissionResponse>;
   cancelRun(chatId: string, runId: string, clientRequestId: string): Promise<CanonicalChatRunCancellationResponse>;
   uploadAttachment(file: ShellAttachmentInput): Promise<CanonicalAttachmentReference>;
@@ -133,6 +136,15 @@ export function createCanonicalShellChatClient(options: {
     async detail(chatId) {
       const id = CanonicalChatIdSchema.parse(chatId);
       return CanonicalChatDetailResponseSchema.parse(await request(`/api/chats/${encodeURIComponent(id)}?limit=200`));
+    },
+    async updateTitle(chatId, input) {
+      const id = CanonicalChatIdSchema.parse(chatId);
+      const body = CanonicalUpdateChatTitleRequestSchema.parse(input);
+      return CanonicalChatRecordSchema.parse(await request(`/api/chats/${encodeURIComponent(id)}/title`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }));
     },
     async admitTurn(chatId, input) {
       const id = CanonicalChatIdSchema.parse(chatId);

--- a/tests/contracts/canonical-chat-api.test.ts
+++ b/tests/contracts/canonical-chat-api.test.ts
@@ -4,6 +4,7 @@ import {
   CanonicalChatRunAdmissionResponseSchema,
   CanonicalCreateChatTurnRequestSchema,
   CanonicalRetryChatTurnRequestSchema,
+  CanonicalUpdateChatTitleRequestSchema,
   CanonicalUpdateChatUserStateRequestSchema,
   CanonicalChatDetailResponseSchema,
   CanonicalChatListResponseSchema,
@@ -104,6 +105,26 @@ describe("canonical Chat API contracts", () => {
       .toEqual({ pinned: true });
     expect(CanonicalUpdateChatUserStateRequestSchema.safeParse({
       pinned: true,
+      ownerId: "other_owner",
+    }).success).toBe(false);
+  });
+
+  it("accepts only bounded, non-empty revision-guarded Chat titles", () => {
+    expect(CanonicalUpdateChatTitleRequestSchema.parse({
+      baseRevision: 4,
+      title: "  Release plan  ",
+    })).toEqual({ baseRevision: 4, title: "Release plan" });
+    expect(CanonicalUpdateChatTitleRequestSchema.safeParse({
+      baseRevision: 4,
+      title: "   ",
+    }).success).toBe(false);
+    expect(CanonicalUpdateChatTitleRequestSchema.safeParse({
+      baseRevision: 4,
+      title: "x".repeat(161),
+    }).success).toBe(false);
+    expect(CanonicalUpdateChatTitleRequestSchema.safeParse({
+      baseRevision: 4,
+      title: "Release plan",
       ownerId: "other_owner",
     }).success).toBe(false);
   });

--- a/tests/desktop/canonical-chat-client.test.ts
+++ b/tests/desktop/canonical-chat-client.test.ts
@@ -217,6 +217,21 @@ describe("canonical Chat client", () => {
     })).resolves.toEqual(movedRecord);
   });
 
+  it("renames a Chat through the canonical revision-guarded endpoint", async () => {
+    const renamed = { ...record, chat: { ...record.chat, title: "Release plan", revision: 1 } };
+    const patch = vi.fn(async () => renamed);
+    const client = createCanonicalChatClient(api({ patch }));
+
+    await expect(client.updateTitle(record.chat.id, {
+      baseRevision: 0,
+      title: "  Release plan  ",
+    })).resolves.toEqual(renamed);
+    expect(patch).toHaveBeenCalledWith("/api/chats/chat_client_test/title", {
+      baseRevision: 0,
+      title: "Release plan",
+    });
+  });
+
   it("updates durable Chat pin state through the owner-scoped endpoint", async () => {
     const pinned = {
       ...record,

--- a/tests/desktop/hosted-work-sidebar.test.tsx
+++ b/tests/desktop/hosted-work-sidebar.test.tsx
@@ -23,22 +23,31 @@ const renamedRecord: CanonicalChatRecord = {
     updatedAt: "2026-09-04T01:00:00.000Z",
   },
 };
+const secondRenamedRecord: CanonicalChatRecord = {
+  ...renamedRecord,
+  chat: { ...renamedRecord.chat, id: "chat_second", title: "Second synced title" },
+};
 
 vi.mock("@desktop/renderer/src/features/work/WorkRail", () => ({
   WorkRail: (props: {
     onChatRenamed?: (record: CanonicalChatRecord) => void;
-    projectedChatTitle?: CanonicalChatTitleProjection;
+    projectedChatTitles?: CanonicalChatTitleProjection[];
   }) => (<>
     <button type="button" onClick={() => props.onChatRenamed?.(renamedRecord)}>
       Complete hosted rail rename
     </button>
-    <span data-testid="hosted-rail-projected-title">{props.projectedChatTitle?.title ?? "No projection"}</span>
+    <span data-testid="hosted-rail-projected-title">
+      {props.projectedChatTitles?.map((projection) => projection.title).join("|") || "No projection"}
+    </span>
   </>),
 }));
 
 function ProjectHeaderRename() {
   const runtime = useWorkSurfaceRuntime();
-  return <button type="button" onClick={() => runtime?.projectChat(renamedRecord)}>Complete header rename</button>;
+  return <>
+    <button type="button" onClick={() => runtime?.projectChat(renamedRecord)}>Complete header rename</button>
+    <button type="button" onClick={() => runtime?.projectChat(secondRenamedRecord)}>Complete second header rename</button>
+  </>;
 }
 
 beforeEach(() => {
@@ -85,5 +94,25 @@ describe("HostedWorkSidebar", () => {
     expect(screen.getByTestId("hosted-rail-projected-title").textContent).toBe("No projection");
     fireEvent.click(screen.getByRole("button", { name: "Complete header rename" }));
     expect(screen.getByTestId("hosted-rail-projected-title").textContent).toBe("Synced title");
+  });
+
+  it("retains bounded projections for multiple header renames", () => {
+    useTabs.getState().openTab({
+      kind: "work", title: "Chat", workRoute: "chat", chatId: "chat_global",
+      chatTitle: "Old title", chatView: "conversation", closable: false,
+    });
+    const tab = useTabs.getState().tabs[0]!;
+
+    render(
+      <WorkSurfaceRuntimeProvider active={false}>
+        <ProjectHeaderRename />
+        <HostedWorkSidebar tab={tab} active={false} />
+      </WorkSurfaceRuntimeProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Complete header rename" }));
+    fireEvent.click(screen.getByRole("button", { name: "Complete second header rename" }));
+
+    expect(screen.getByTestId("hosted-rail-projected-title").textContent)
+      .toBe("Synced title|Second synced title");
   });
 });

--- a/tests/desktop/hosted-work-sidebar.test.tsx
+++ b/tests/desktop/hosted-work-sidebar.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { CanonicalChatRecord } from "@matrix-os/contracts";
+import { HostedWorkSidebar } from "@desktop/renderer/src/features/work/HostedWorkSidebar";
+import { useTabs } from "@desktop/renderer/src/stores/tabs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const renamedRecord: CanonicalChatRecord = {
+  chat: {
+    id: "chat_global",
+    ownerScope: { type: "personal", ownerId: "owner_test" },
+    title: "Synced title",
+    lifecycle: "active",
+    attention: "none",
+    revision: 2,
+    messageCount: 1,
+    userState: { readThroughSeq: 0, pinned: false, muted: false },
+    createdAt: "2026-09-04T00:00:00.000Z",
+    updatedAt: "2026-09-04T01:00:00.000Z",
+  },
+};
+
+vi.mock("@desktop/renderer/src/features/work/WorkRail", () => ({
+  WorkRail: (props: { onChatRenamed?: (record: CanonicalChatRecord) => void }) => (
+    <button type="button" onClick={() => props.onChatRenamed?.(renamedRecord)}>
+      Complete hosted rail rename
+    </button>
+  ),
+}));
+
+beforeEach(() => {
+  useTabs.setState(useTabs.getInitialState(), true);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("HostedWorkSidebar", () => {
+  it("synchronizes a rail rename into the active center-title projection", () => {
+    useTabs.getState().openTab({
+      kind: "work",
+      title: "Chat",
+      workRoute: "chat",
+      chatId: "chat_global",
+      chatTitle: "Old title",
+      chatView: "conversation",
+      closable: false,
+    });
+    const tab = useTabs.getState().tabs[0]!;
+
+    render(<HostedWorkSidebar tab={tab} active />);
+    fireEvent.click(screen.getByRole("button", { name: "Complete hosted rail rename" }));
+
+    expect(useTabs.getState().tabs[0]?.chatTitle).toBe("Synced title");
+  });
+});

--- a/tests/desktop/hosted-work-sidebar.test.tsx
+++ b/tests/desktop/hosted-work-sidebar.test.tsx
@@ -4,6 +4,8 @@ import React from "react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { CanonicalChatRecord } from "@matrix-os/contracts";
 import { HostedWorkSidebar } from "@desktop/renderer/src/features/work/HostedWorkSidebar";
+import { WorkSurfaceRuntimeProvider, useWorkSurfaceRuntime } from "@desktop/renderer/src/features/work/WorkSurfaceRuntime";
+import type { CanonicalChatTitleProjection } from "@desktop/renderer/src/features/work/WorkSurfaceRuntime";
 import { useTabs } from "@desktop/renderer/src/stores/tabs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -23,12 +25,21 @@ const renamedRecord: CanonicalChatRecord = {
 };
 
 vi.mock("@desktop/renderer/src/features/work/WorkRail", () => ({
-  WorkRail: (props: { onChatRenamed?: (record: CanonicalChatRecord) => void }) => (
+  WorkRail: (props: {
+    onChatRenamed?: (record: CanonicalChatRecord) => void;
+    projectedChatTitle?: CanonicalChatTitleProjection;
+  }) => (<>
     <button type="button" onClick={() => props.onChatRenamed?.(renamedRecord)}>
       Complete hosted rail rename
     </button>
-  ),
+    <span data-testid="hosted-rail-projected-title">{props.projectedChatTitle?.title ?? "No projection"}</span>
+  </>),
 }));
+
+function ProjectHeaderRename() {
+  const runtime = useWorkSurfaceRuntime();
+  return <button type="button" onClick={() => runtime?.projectChat(renamedRecord)}>Complete header rename</button>;
+}
 
 beforeEach(() => {
   useTabs.setState(useTabs.getInitialState(), true);
@@ -56,5 +67,23 @@ describe("HostedWorkSidebar", () => {
     fireEvent.click(screen.getByRole("button", { name: "Complete hosted rail rename" }));
 
     expect(useTabs.getState().tabs[0]?.chatTitle).toBe("Synced title");
+  });
+
+  it("synchronizes a header rename directly into the mounted hosted rail without a stream event", () => {
+    useTabs.getState().openTab({
+      kind: "work", title: "Chat", workRoute: "chat", chatId: "chat_global",
+      chatTitle: "Old title", chatView: "conversation", closable: false,
+    });
+    const tab = useTabs.getState().tabs[0]!;
+
+    render(
+      <WorkSurfaceRuntimeProvider active={false}>
+        <ProjectHeaderRename />
+        <HostedWorkSidebar tab={tab} active={false} />
+      </WorkSurfaceRuntimeProvider>,
+    );
+    expect(screen.getByTestId("hosted-rail-projected-title").textContent).toBe("No projection");
+    fireEvent.click(screen.getByRole("button", { name: "Complete header rename" }));
+    expect(screen.getByTestId("hosted-rail-projected-title").textContent).toBe("Synced title");
   });
 });

--- a/tests/desktop/work-rail.test.tsx
+++ b/tests/desktop/work-rail.test.tsx
@@ -142,9 +142,9 @@ describe("WorkRail", () => {
       chat: { ...recent.chat, title: "Projected title", revision: recent.chat.revision + 1 },
     };
 
-    rerender(<WorkRail client={client} projectedChatTitle={{
+    rerender(<WorkRail client={client} projectedChatTitles={[{
       chatId: projected.chat.id, title: projected.chat.title, revision: projected.chat.revision,
-    }} projects={[]} active {...actions} />);
+    }]} projects={[]} active {...actions} />);
 
     expect(await screen.findByRole("button", { name: "Projected title" })).toBeTruthy();
     expect(client.list).toHaveBeenCalledOnce();
@@ -171,14 +171,45 @@ describe("WorkRail", () => {
     act(() => events.emit({ type: "chat.changed", chatId: recent.chat.id, cursor: 2 }));
     await waitFor(() => expect(client.list).toHaveBeenCalledTimes(2));
 
-    rerender(<WorkRail client={client} eventSource={events.eventSource} projectedChatTitle={{
+    rerender(<WorkRail client={client} eventSource={events.eventSource} projectedChatTitles={[{
       chatId: projected.chat.id, title: projected.chat.title, revision: projected.chat.revision,
-    }} projects={[]} active {...actions} />);
+    }]} projects={[]} active {...actions} />);
     expect(await screen.findByRole("button", { name: "Newest projected title" })).toBeTruthy();
     await act(async () => resolveRefresh({ items: [recent] }));
 
     expect(screen.getByRole("button", { name: "Newest projected title" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Recent global" })).toBeNull();
+  });
+
+  it("preserves every newer title projection across one delayed stale list response", async () => {
+    const second = {
+      ...recent,
+      chat: { ...recent.chat, id: "chat_second", title: "Second old title" },
+    };
+    let resolveRefresh!: (value: { items: CanonicalChatRecord[] }) => void;
+    const client = {
+      list: vi.fn()
+        .mockResolvedValueOnce({ items: [recent, second] })
+        .mockImplementationOnce(() => new Promise<{ items: CanonicalChatRecord[] }>((resolve) => { resolveRefresh = resolve; })),
+    } as unknown as CanonicalChatClient;
+    const events = eventHarness();
+    const actions = {
+      onNewGlobalChat: vi.fn(), onCreateProject: vi.fn(), onNewProjectChat: vi.fn(),
+      onSelectChat: vi.fn(), onCollapse: vi.fn(),
+    };
+    const { rerender } = render(<WorkRail client={client} eventSource={events.eventSource} projects={[]} active {...actions} />);
+    expect(await screen.findByRole("button", { name: "Recent global" })).toBeTruthy();
+    act(() => events.emit({ type: "chat.changed", chatId: recent.chat.id, cursor: 2 }));
+    await waitFor(() => expect(client.list).toHaveBeenCalledTimes(2));
+
+    rerender(<WorkRail client={client} eventSource={events.eventSource} projectedChatTitles={[
+      { chatId: recent.chat.id, title: "First new title", revision: recent.chat.revision + 1 },
+      { chatId: second.chat.id, title: "Second new title", revision: second.chat.revision + 1 },
+    ]} projects={[]} active {...actions} />);
+    await act(async () => resolveRefresh({ items: [recent, second] }));
+
+    expect(screen.getByRole("button", { name: "First new title" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Second new title" })).toBeTruthy();
   });
 
   it("lets an authoritative equal-revision list or omission retire a title projection", async () => {
@@ -190,14 +221,14 @@ describe("WorkRail", () => {
     const { rerender } = render(<WorkRail client={client} projects={[]} active {...actions} />);
     expect(await screen.findByRole("button", { name: "Recent global" })).toBeTruthy();
 
-    rerender(<WorkRail client={client} projectedChatTitle={{
+    rerender(<WorkRail client={client} projectedChatTitles={[{
       chatId: recent.chat.id, title: "Stale projection", revision: recent.chat.revision,
-    }} projects={[]} active {...actions} />);
+    }]} projects={[]} active {...actions} />);
     expect(screen.getByRole("button", { name: "Recent global" })).toBeTruthy();
 
-    rerender(<WorkRail client={client} projectedChatTitle={{
+    rerender(<WorkRail client={client} projectedChatTitles={[{
       chatId: "chat_deleted", title: "Deleted elsewhere", revision: 99,
-    }} projects={[]} active {...actions} />);
+    }]} projects={[]} active {...actions} />);
     expect(screen.queryByRole("button", { name: "Deleted elsewhere" })).toBeNull();
   });
 

--- a/tests/desktop/work-rail.test.tsx
+++ b/tests/desktop/work-rail.test.tsx
@@ -129,6 +129,78 @@ afterEach(() => {
 });
 
 describe("WorkRail", () => {
+  it("applies a direct canonical projection without waiting for a stream refresh", async () => {
+    const client = { list: vi.fn(async () => ({ items: [recent] })) } as unknown as CanonicalChatClient;
+    const actions = {
+      onNewGlobalChat: vi.fn(), onCreateProject: vi.fn(), onNewProjectChat: vi.fn(),
+      onSelectChat: vi.fn(), onCollapse: vi.fn(),
+    };
+    const { rerender } = render(<WorkRail client={client} projects={[]} active {...actions} />);
+    expect(await screen.findByRole("button", { name: "Recent global" })).toBeTruthy();
+    const projected = {
+      ...recent,
+      chat: { ...recent.chat, title: "Projected title", revision: recent.chat.revision + 1 },
+    };
+
+    rerender(<WorkRail client={client} projectedChatTitle={{
+      chatId: projected.chat.id, title: projected.chat.title, revision: projected.chat.revision,
+    }} projects={[]} active {...actions} />);
+
+    expect(await screen.findByRole("button", { name: "Projected title" })).toBeTruthy();
+    expect(client.list).toHaveBeenCalledOnce();
+  });
+
+  it("does not let a delayed stale list response overwrite a newer direct projection", async () => {
+    let resolveRefresh!: (value: { items: CanonicalChatRecord[] }) => void;
+    const client = {
+      list: vi.fn()
+        .mockResolvedValueOnce({ items: [recent] })
+        .mockImplementationOnce(() => new Promise<{ items: CanonicalChatRecord[] }>((resolve) => { resolveRefresh = resolve; })),
+    } as unknown as CanonicalChatClient;
+    const events = eventHarness();
+    const actions = {
+      onNewGlobalChat: vi.fn(), onCreateProject: vi.fn(), onNewProjectChat: vi.fn(),
+      onSelectChat: vi.fn(), onCollapse: vi.fn(),
+    };
+    const projected = {
+      ...recent,
+      chat: { ...recent.chat, title: "Newest projected title", revision: recent.chat.revision + 1 },
+    };
+    const { rerender } = render(<WorkRail client={client} eventSource={events.eventSource} projects={[]} active {...actions} />);
+    expect(await screen.findByRole("button", { name: "Recent global" })).toBeTruthy();
+    act(() => events.emit({ type: "chat.changed", chatId: recent.chat.id, cursor: 2 }));
+    await waitFor(() => expect(client.list).toHaveBeenCalledTimes(2));
+
+    rerender(<WorkRail client={client} eventSource={events.eventSource} projectedChatTitle={{
+      chatId: projected.chat.id, title: projected.chat.title, revision: projected.chat.revision,
+    }} projects={[]} active {...actions} />);
+    expect(await screen.findByRole("button", { name: "Newest projected title" })).toBeTruthy();
+    await act(async () => resolveRefresh({ items: [recent] }));
+
+    expect(screen.getByRole("button", { name: "Newest projected title" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Recent global" })).toBeNull();
+  });
+
+  it("lets an authoritative equal-revision list or omission retire a title projection", async () => {
+    const client = { list: vi.fn(async () => ({ items: [recent] })) } as unknown as CanonicalChatClient;
+    const actions = {
+      onNewGlobalChat: vi.fn(), onCreateProject: vi.fn(), onNewProjectChat: vi.fn(),
+      onSelectChat: vi.fn(), onCollapse: vi.fn(),
+    };
+    const { rerender } = render(<WorkRail client={client} projects={[]} active {...actions} />);
+    expect(await screen.findByRole("button", { name: "Recent global" })).toBeTruthy();
+
+    rerender(<WorkRail client={client} projectedChatTitle={{
+      chatId: recent.chat.id, title: "Stale projection", revision: recent.chat.revision,
+    }} projects={[]} active {...actions} />);
+    expect(screen.getByRole("button", { name: "Recent global" })).toBeTruthy();
+
+    rerender(<WorkRail client={client} projectedChatTitle={{
+      chatId: "chat_deleted", title: "Deleted elsewhere", revision: 99,
+    }} projects={[]} active {...actions} />);
+    expect(screen.queryByRole("button", { name: "Deleted elsewhere" })).toBeNull();
+  });
+
   it("matches the Settings sidebar title, groups, and item styling", async () => {
     setup();
     const rail = screen.getByRole("navigation", { name: "Chat navigation" });
@@ -1029,7 +1101,9 @@ describe("WorkRail", () => {
     const { client, actions } = setup();
     const recentChat = await screen.findByRole("button", { name: "Recent global" });
 
-    fireEvent.doubleClick(recentChat);
+    fireEvent.click(recentChat, { detail: 1 });
+    fireEvent.click(recentChat, { detail: 2 });
+    fireEvent.doubleClick(recentChat, { detail: 2 });
     const input = await screen.findByRole("textbox", { name: "Rename Recent global" });
     expect((input as HTMLInputElement).selectionStart).toBe(0);
     expect((input as HTMLInputElement).selectionEnd).toBe("Recent global".length);

--- a/tests/desktop/work-rail.test.tsx
+++ b/tests/desktop/work-rail.test.tsx
@@ -1079,6 +1079,37 @@ describe("WorkRail", () => {
     expect(screen.getByRole("button", { name: "Blurred title" })).toBeTruthy();
   });
 
+  it("blocks a second row from entering rename while the first rename is pending", async () => {
+    let resolveRename!: (value: CanonicalChatRecord) => void;
+    const pendingRename = new Promise<CanonicalChatRecord>((resolve) => {
+      resolveRename = resolve;
+    });
+    const { client } = setup();
+    const updateTitle = client.updateTitle as ReturnType<typeof vi.fn>;
+    updateTitle.mockImplementationOnce(() => pendingRename);
+
+    fireEvent.doubleClick(await screen.findByRole("button", { name: "Recent global" }));
+    const input = await screen.findByRole("textbox", { name: "Rename Recent global" });
+    fireEvent.change(input, { target: { value: "Pending title" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(updateTitle).toHaveBeenCalledTimes(1));
+
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Pinned global" }));
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 20));
+    });
+    expect(screen.queryByRole("textbox", { name: "Rename Pinned global" })).toBeNull();
+
+    await act(async () => {
+      resolveRename({
+        ...recent,
+        chat: { ...recent.chat, title: "Pending title", revision: 2 },
+      });
+      await pendingRename;
+    });
+    expect(await screen.findByRole("button", { name: "Pending title" })).toBeTruthy();
+  });
+
   it("deletes a Chat from its hover action after confirmation", async () => {
     const { client } = setup();
     await screen.findByRole("button", { name: "Recent global" });

--- a/tests/desktop/work-rail.test.tsx
+++ b/tests/desktop/work-rail.test.tsx
@@ -80,6 +80,13 @@ function setup() {
         },
       };
     }),
+    updateTitle: vi.fn(async (chatId: string, input: { title: string }) => {
+      const current = records.find((candidate) => candidate.chat.id === chatId)!;
+      return {
+        ...current,
+        chat: { ...current.chat, title: input.title, revision: current.chat.revision + 1 },
+      };
+    }),
   } as unknown as CanonicalChatClient;
   const actions = {
     onNewGlobalChat: vi.fn(),
@@ -1007,14 +1014,69 @@ describe("WorkRail", () => {
     expect((screen.getByRole("button", { name: "Pin Recent global" }) as HTMLButtonElement).disabled).toBe(true);
   });
 
-  it("shows Pin and Delete in the Chat context menu", async () => {
+  it("shows Rename, Pin, and Delete in the Chat context menu", async () => {
     setup();
     const recentChat = await screen.findByRole("button", { name: "Recent global" });
 
     fireEvent.contextMenu(recentChat, { clientX: 120, clientY: 160 });
 
-    expect(await screen.findByRole("menuitem", { name: "Pin" })).toBeTruthy();
+    expect(await screen.findByRole("menuitem", { name: "Rename" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Pin" })).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: "Delete" })).toBeTruthy();
+  });
+
+  it("renames a Chat from a rail double-click and updates the visible projection", async () => {
+    const { client, actions } = setup();
+    const recentChat = await screen.findByRole("button", { name: "Recent global" });
+
+    fireEvent.doubleClick(recentChat);
+    const input = await screen.findByRole("textbox", { name: "Rename Recent global" });
+    expect((input as HTMLInputElement).selectionStart).toBe(0);
+    expect((input as HTMLInputElement).selectionEnd).toBe("Recent global".length);
+    fireEvent.change(input, { target: { value: "  Release plan  " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => expect(client.updateTitle).toHaveBeenCalledWith("chat_recent", {
+      baseRevision: 1,
+      title: "Release plan",
+    }));
+    expect(await screen.findByRole("button", { name: "Release plan" })).toBeTruthy();
+    expect(actions.onSelectChat).not.toHaveBeenCalled();
+  });
+
+  it("opens the same rename editor from the context menu and Escape restores the title", async () => {
+    const { client } = setup();
+    const recentChat = await screen.findByRole("button", { name: "Recent global" });
+    fireEvent.contextMenu(recentChat);
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Rename" }));
+
+    const input = await screen.findByRole("textbox", { name: "Rename Recent global" });
+    fireEvent.change(input, { target: { value: "Discard me" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(screen.getByRole("button", { name: "Recent global" })).toBeTruthy();
+    expect(client.updateTitle).not.toHaveBeenCalled();
+  });
+
+  it("commits a changed title on blur and restores the old title after a safe failure", async () => {
+    const { client } = setup();
+    const updateTitle = client.updateTitle as ReturnType<typeof vi.fn>;
+    const recentChat = await screen.findByRole("button", { name: "Recent global" });
+
+    fireEvent.doubleClick(recentChat);
+    const input = await screen.findByRole("textbox", { name: "Rename Recent global" });
+    fireEvent.change(input, { target: { value: "Blurred title" } });
+    fireEvent.blur(input);
+    expect(await screen.findByRole("button", { name: "Blurred title" })).toBeTruthy();
+
+    updateTitle.mockRejectedValueOnce(new Error("private gateway detail"));
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Blurred title" }));
+    const retryInput = await screen.findByRole("textbox", { name: "Rename Blurred title" });
+    fireEvent.change(retryInput, { target: { value: "Will fail" } });
+    fireEvent.keyDown(retryInput, { key: "Enter" });
+
+    expect((await screen.findByRole("alert")).textContent).toBe("The Chat could not be renamed. Try again.");
+    expect(screen.getByRole("button", { name: "Blurred title" })).toBeTruthy();
   });
 
   it("deletes a Chat from its hover action after confirmation", async () => {

--- a/tests/desktop/work-tab.test.tsx
+++ b/tests/desktop/work-tab.test.tsx
@@ -236,6 +236,13 @@ describe("WorkTab rail integration", () => {
     });
     globalThis.ResizeObserver = WorkResizeObserver;
     const get = vi.fn(async (path: string) => {
+      if (path === "/api/chats/chat_global?limit=200") return {
+        record: globalChat,
+        messages: [],
+        turns: [],
+        runs: [],
+        activities: [],
+      };
       if (path.startsWith("/api/chats")) return { items: [projectChat, globalChat] };
       throw new Error("Unexpected WorkTab test request");
     });
@@ -251,7 +258,17 @@ describe("WorkTab rail integration", () => {
           if (path === "/api/chats") return chat("chat_draft_terminal", "New chat");
           throw new Error("Unexpected WorkTab test request");
         }),
-        patch: vi.fn(),
+        patch: vi.fn(async (path: string, body: unknown) => {
+          if (path === "/api/chats/chat_global/title") return {
+            ...globalChat,
+            chat: {
+              ...globalChat.chat,
+              title: (body as { title: string }).title,
+              revision: globalChat.chat.revision + 1,
+            },
+          };
+          throw new Error("Unexpected WorkTab test request");
+        }),
         delete: vi.fn(),
       } as never,
     }, true);
@@ -670,7 +687,7 @@ describe("WorkTab rail integration", () => {
     render(<HostedWork />);
     await screen.findByText("Chat center");
 
-    const chromeTitle = screen.getByText("Global chat", { selector: "header span" });
+    const chromeTitle = screen.getByRole("button", { name: "Rename Global chat" });
     expect(chromeTitle).toBeTruthy();
     const hostedMainElement = screen.getByTestId("hosted-chat-main");
     const hostedMain = within(hostedMainElement);
@@ -694,6 +711,39 @@ describe("WorkTab rail integration", () => {
 
     fireEvent.click(hideInspector);
     expect(screen.getByRole("button", { name: "Show inspector" })).toBeTruthy();
+  });
+
+  it("renames the active Chat from a single click on the center header", async () => {
+    function HostedWork() {
+      const [chrome, setChrome] = React.useState<SurfaceChromeSpec | null>(null);
+      const host = React.useMemo(() => ({ setChrome }), []);
+      return (
+        <SurfaceChromeContext.Provider value={host}>
+          <header>{chrome?.title}</header>
+          <WorkTab
+            tabId="work-chat"
+            route="chat"
+            active
+            initialChatId="chat_global"
+            initialChatTitle="Global chat"
+            initialChatView="conversation"
+          />
+        </SurfaceChromeContext.Provider>
+      );
+    }
+
+    render(<HostedWork />);
+    const trigger = await screen.findByRole("button", { name: "Rename Global chat" });
+    fireEvent.click(trigger);
+    const input = screen.getByRole("textbox", { name: "Rename Global chat" });
+    fireEvent.change(input, { target: { value: "Release plan" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => expect(useConnection.getState().api?.patch).toHaveBeenCalledWith(
+      "/api/chats/chat_global/title",
+      { baseRevision: 1, title: "Release plan" },
+    ));
+    expect(await screen.findByRole("button", { name: "Rename Release plan" })).toBeTruthy();
   });
 
   it("uses the hosted main-pane width without adding the window sidebar", async () => {

--- a/tests/desktop/work-tab.test.tsx
+++ b/tests/desktop/work-tab.test.tsx
@@ -746,6 +746,36 @@ describe("WorkTab rail integration", () => {
     expect(await screen.findByRole("button", { name: "Rename Release plan" })).toBeTruthy();
   });
 
+  it("cancels a header rename with Escape without dismissing the medium inspector", async () => {
+    initialWorkWidth = 900;
+    function HostedWork() {
+      const [chrome, setChrome] = React.useState<SurfaceChromeSpec | null>(null);
+      const host = React.useMemo(() => ({ setChrome }), []);
+      return (
+        <SurfaceChromeContext.Provider value={host}>
+          <header>{chrome?.title}{chrome?.rightActions}</header>
+          <WorkTab
+            tabId="work-chat"
+            route="chat"
+            active
+            initialChatId="chat_global"
+            initialChatTitle="Global chat"
+            initialChatView="conversation"
+          />
+        </SurfaceChromeContext.Provider>
+      );
+    }
+
+    render(<HostedWork />);
+    fireEvent.click(await screen.findByRole("button", { name: "Show inspector" }));
+    expect(screen.getByRole("complementary", { name: "Chat inspector" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Rename Global chat" }));
+    fireEvent.keyDown(screen.getByRole("textbox", { name: "Rename Global chat" }), { key: "Escape" });
+
+    expect(screen.getByRole("button", { name: "Rename Global chat" })).toBeTruthy();
+    expect(screen.getByRole("complementary", { name: "Chat inspector" })).toBeTruthy();
+  });
+
   it("uses the hosted main-pane width without adding the window sidebar", async () => {
     initialWorkWidth = 900;
     function HostedWork() {

--- a/tests/desktop/work-tab.test.tsx
+++ b/tests/desktop/work-tab.test.tsx
@@ -736,6 +736,11 @@ describe("WorkTab rail integration", () => {
     const trigger = await screen.findByRole("button", { name: "Rename Global chat" });
     fireEvent.click(trigger);
     const input = screen.getByRole("textbox", { name: "Rename Global chat" });
+    expect(input.className).toContain("pointer-events-auto");
+    (input as HTMLInputElement).setSelectionRange(4, 4);
+    fireEvent.click(input);
+    expect((input as HTMLInputElement).selectionStart).toBe(4);
+    expect(screen.getByRole("textbox", { name: "Rename Global chat" })).toBe(input);
     fireEvent.change(input, { target: { value: "Release plan" } });
     fireEvent.keyDown(input, { key: "Enter" });
 

--- a/tests/gateway/chat-routes.test.ts
+++ b/tests/gateway/chat-routes.test.ts
@@ -10,6 +10,7 @@ import {
   type CanonicalChatRecord,
   type CanonicalCreateChatRequest,
   type CanonicalUpdateChatUserStateRequest,
+  type CanonicalUpdateChatTitleRequest,
 } from "@matrix-os/contracts";
 import { Hono } from "hono";
 import { KyselyPGlite } from "kysely-pglite";
@@ -45,6 +46,7 @@ function routeService(overrides: Partial<CanonicalChatRouteService> = {}): Canon
   return {
     create: vi.fn(async () => record),
     updateProject: vi.fn(async () => record),
+    updateTitle: vi.fn(async () => record),
     updateUserState: vi.fn(async () => record),
     acknowledgeCompletion: vi.fn(async () => record),
     delete: vi.fn(async () => ({ chatId: record.chat.id, deletedAt: record.chat.updatedAt })),
@@ -181,6 +183,44 @@ describe("canonical Chat routes", () => {
       body: JSON.stringify({ baseRevision: 0, projectId: null, ownerId: "other" }),
     });
     expect(invalid.status).toBe(400);
+  });
+
+  it("renames a Chat with owner-derived identity, validation, and a body limit", async () => {
+    const renamed = { ...record, chat: { ...record.chat, title: "Release plan", revision: 1 } };
+    const updateTitle = vi.fn(async (
+      _owner: ChatOwner,
+      _chatId: string,
+      _input: CanonicalUpdateChatTitleRequest,
+    ) => renamed);
+    const app = appFor(routeService({ updateTitle }));
+
+    const response = await app.request("/api/chats/chat_route_test/title", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ baseRevision: 0, title: "  Release plan  " }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(renamed);
+    expect(updateTitle).toHaveBeenCalledWith(
+      { type: "personal", ownerId: "owner_1" },
+      "chat_route_test",
+      { baseRevision: 0, title: "Release plan" },
+    );
+
+    const invalid = await app.request("/api/chats/chat_route_test/title", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ baseRevision: 0, title: "   " }),
+    });
+    expect(invalid.status).toBe(400);
+
+    const oversized = await app.request("/api/chats/chat_route_test/title", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ baseRevision: 0, title: "x".repeat(5 * 1024) }),
+    });
+    expect(oversized.status).toBe(413);
   });
 
   it("updates only the authenticated principal's bounded Chat user state", async () => {

--- a/tests/gateway/chat-service.test.ts
+++ b/tests/gateway/chat-service.test.ts
@@ -90,6 +90,24 @@ describe("canonical Chat service", () => {
     expect(moved.projectId).toBe("project_1");
   });
 
+  it("renames a Chat through the revision-guarded repository update", async () => {
+    const renamed = {
+      ...record(),
+      chat: { ...record().chat, title: "Release plan", revision: 1 },
+    };
+    const update = vi.fn(async () => renamed);
+    const service = createCanonicalChatService(repository({ update }));
+
+    await expect(service.updateTitle(owner, "chat_service_test", {
+      baseRevision: 0,
+      title: "  Release plan  ",
+    })).resolves.toEqual(renamed);
+    expect(update).toHaveBeenCalledWith(owner, "chat_service_test", {
+      baseRevision: 0,
+      title: "Release plan",
+    });
+  });
+
   it("delegates canonical deletion to the existing atomic repository tombstone flow", async () => {
     const hardDelete = vi.fn(async () => ({
       chatId: "chat_service_test",

--- a/tests/shell/canonical-chat-client.test.ts
+++ b/tests/shell/canonical-chat-client.test.ts
@@ -49,6 +49,26 @@ describe("canonical shell Chat client", () => {
     );
   });
 
+  it("renames a Chat through the canonical revision-guarded endpoint", async () => {
+    const renamed = { ...record, chat: { ...record.chat, title: "Release plan", revision: 1 } };
+    const fetchFn = vi.fn(async () => Response.json(renamed));
+    const client = createCanonicalShellChatClient({ gatewayUrl: "https://matrix.test", fetchFn });
+
+    await expect(client.updateTitle("chat_shell_test", {
+      baseRevision: 0,
+      title: "Release plan",
+    })).resolves.toEqual(renamed);
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://matrix.test/api/chats/chat_shell_test/title",
+      expect.objectContaining({
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ baseRevision: 0, title: "Release plan" }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
   it("projects canonical parts without exposing raw structured payloads", () => {
     expect(projectCanonicalMessages([{
       id: "msg_shell_user", chatId: "chat_shell_test", seq: 1, role: "user", state: "committed",

--- a/tests/shell/canonical-chat-state.test.tsx
+++ b/tests/shell/canonical-chat-state.test.tsx
@@ -34,6 +34,32 @@ beforeEach(() => {
 });
 
 describe("canonical shell Chat state", () => {
+  it("renames through canonical persistence and synchronizes list and active title projections", async () => {
+    const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.includes("/api/chats?") && init?.method === undefined) {
+        return Response.json({ items: [record("chat_a", "Old title", 3)] });
+      }
+      if (url.includes("/api/chats/chat_a?") && init?.method === undefined) {
+        return Response.json(detail("chat_a", "Old title", 3));
+      }
+      if (url.endsWith("/api/chats/chat_a/title") && init?.method === "PATCH") {
+        expect(JSON.parse(String(init.body))).toEqual({ baseRevision: 3, title: "New title" });
+        return Response.json(record("chat_a", "New title", 4));
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchFn);
+
+    const { result } = renderHook(() => useCanonicalChatState());
+    await waitFor(() => expect(result.current.conversations[0]?.title).toBe("Old title"));
+    await act(async () => {
+      await expect(result.current.renameConversation?.("chat_a", "New title")).resolves.toBe(true);
+    });
+
+    expect(result.current.conversations[0]?.title).toBe("New title");
+    expect(result.current.activeConversationTitle).toBe("New title");
+  });
+
   it("ignores an out-of-order detail response after switching chats", async () => {
     let resolveA: ((response: Response) => void) | undefined;
     const detailA = new Promise<Response>((resolve) => { resolveA = resolve; });

--- a/tests/shell/canonical-chat-state.test.tsx
+++ b/tests/shell/canonical-chat-state.test.tsx
@@ -60,6 +60,37 @@ describe("canonical shell Chat state", () => {
     expect(result.current.activeConversationTitle).toBe("New title");
   });
 
+  it("does not let an older rename response regress a newer canonical refresh", async () => {
+    let resolveRename!: (response: Response) => void;
+    const renameResponse = new Promise<Response>((resolve) => { resolveRename = resolve; });
+    let detailCalls = 0;
+    let listCalls = 0;
+    vi.stubGlobal("fetch", vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.includes("/api/chats?") && init?.method === undefined) {
+        listCalls += 1;
+        return Response.json({ items: [record("chat_a", listCalls === 1 ? "Initial" : "Newest refresh", listCalls === 1 ? 3 : 5)] });
+      }
+      if (url.includes("/api/chats/chat_a?") && init?.method === undefined) {
+        detailCalls += 1;
+        return Response.json(detail("chat_a", detailCalls === 1 ? "Initial" : "Newest refresh", detailCalls === 1 ? 3 : 5));
+      }
+      if (url.endsWith("/api/chats/chat_a/title") && init?.method === "PATCH") return renameResponse;
+      throw new Error(`Unexpected request: ${url}`);
+    }));
+
+    const { result } = renderHook(() => useCanonicalChatState());
+    await waitFor(() => expect(result.current.activeConversationTitle).toBe("Initial"));
+    let rename!: Promise<boolean>;
+    act(() => { rename = result.current.renameConversation!("chat_a", "Renamed"); });
+    act(() => window.dispatchEvent(new Event("focus")));
+    await waitFor(() => expect(result.current.activeConversationTitle).toBe("Newest refresh"));
+    resolveRename(Response.json(record("chat_a", "Renamed", 4)));
+    await act(async () => { await rename; });
+
+    expect(result.current.conversations[0]?.title).toBe("Newest refresh");
+    expect(result.current.activeConversationTitle).toBe("Newest refresh");
+  });
+
   it("ignores an out-of-order detail response after switching chats", async () => {
     let resolveA: ((response: Response) => void) | undefined;
     const detailA = new Promise<Response>((resolve) => { resolveA = resolve; });

--- a/tests/shell/chat-app-provider-state.test.tsx
+++ b/tests/shell/chat-app-provider-state.test.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import "@testing-library/jest-dom/vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CanonicalProviderCatalogSchema } from "@matrix-os/contracts";
 import { ChatApp } from "../../shell/src/components/ChatApp.js";
@@ -83,6 +83,92 @@ beforeEach(() => {
 });
 
 describe("Chat canonical provider state", () => {
+  it("renames the shared Web Desktop and Web Canvas Chat from the header, rail double-click, and context menu", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json(providerCatalog())));
+    const onSwitchConversation = vi.fn();
+    const renameConversation = vi.fn(async () => true);
+    const conversation = {
+      id: "chat_shared", title: "Old title", preview: "Last message", messageCount: 1, updatedAt: Date.now(),
+    };
+
+    const { rerender } = render(<ChatApp
+      messages={[]} sessionId="chat_shared" busy={false} connected conversations={[conversation]}
+      activeConversationTitle="Old title" onRenameConversation={renameConversation}
+      onNewChat={vi.fn()} onSwitchConversation={onSwitchConversation} onSubmit={vi.fn()}
+    />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Rename Old title" }));
+    const headerEditor = await screen.findByRole("textbox", { name: "Rename Old title" });
+    fireEvent.click(headerEditor);
+    expect(screen.getByRole("textbox", { name: "Rename Old title" })).toBeVisible();
+    fireEvent.change(headerEditor, { target: { value: "Header title" } });
+    fireEvent.keyDown(headerEditor, { key: "Enter" });
+    await waitFor(() => expect(renameConversation).toHaveBeenCalledWith("chat_shared", "Header title"));
+
+    renameConversation.mockClear();
+    rerender(<ChatApp
+      messages={[]} sessionId="chat_shared" busy={false} connected
+      conversations={[{ ...conversation, title: "Header title" }]}
+      activeConversationTitle="Header title" onRenameConversation={renameConversation}
+      onNewChat={vi.fn()} onSwitchConversation={onSwitchConversation} onSubmit={vi.fn()}
+    />);
+    const row = screen.getByRole("button", { name: "Header title" });
+    fireEvent.click(row, { detail: 1 });
+    fireEvent.click(row, { detail: 2 });
+    fireEvent.doubleClick(row, { detail: 2 });
+    expect(await screen.findByRole("textbox", { name: "Rename Header title" })).toBeVisible();
+    expect(onSwitchConversation).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(screen.getByRole("textbox", { name: "Rename Header title" }), { key: "Escape" });
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Header title" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Rename" }));
+    expect(await screen.findByRole("textbox", { name: "Rename Header title" })).toBeVisible();
+  });
+
+  it("keeps the shared Web Mobile Chat header rename touch-accessible", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json(providerCatalog())));
+    const renameConversation = vi.fn(async () => true);
+    render(<ChatApp
+      mobile messages={[]} sessionId="chat_mobile" busy={false} connected
+      conversations={[{ id: "chat_mobile", title: "Mobile title", preview: "", messageCount: 0, updatedAt: Date.now() }]}
+      activeConversationTitle="Mobile title" onRenameConversation={renameConversation}
+      onNewChat={vi.fn()} onSwitchConversation={vi.fn()} onSubmit={vi.fn()}
+    />);
+
+    const titleButton = await screen.findByRole("button", { name: "Rename Mobile title" });
+    expect(titleButton.className).toContain("min-h-11");
+    fireEvent.click(titleButton);
+    const editor = await screen.findByRole("textbox", { name: "Rename Mobile title" });
+    fireEvent.change(editor, { target: { value: "Renamed on mobile" } });
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    await waitFor(() => expect(renameConversation).toHaveBeenCalledWith("chat_mobile", "Renamed on mobile"));
+  });
+
+  it("does not let an earlier pending rename close a later editor", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json(providerCatalog())));
+    let resolveRename!: (value: boolean) => void;
+    const renameConversation = vi.fn(() => new Promise<boolean>((resolve) => { resolveRename = resolve; }));
+    render(<ChatApp
+      messages={[]} sessionId="chat_a" busy={false} connected
+      conversations={[
+        { id: "chat_a", title: "Alpha", preview: "", messageCount: 0, updatedAt: Date.now() },
+        { id: "chat_b", title: "Beta", preview: "", messageCount: 0, updatedAt: Date.now() - 1 },
+      ]}
+      activeConversationTitle="Alpha" onRenameConversation={renameConversation}
+      onNewChat={vi.fn()} onSwitchConversation={vi.fn()} onSubmit={vi.fn()}
+    />);
+    fireEvent.click(await screen.findByRole("button", { name: "Rename Alpha" }));
+    const editor = await screen.findByRole("textbox", { name: "Rename Alpha" });
+    fireEvent.change(editor, { target: { value: "Alpha pending" } });
+    fireEvent.keyDown(editor, { key: "Enter" });
+    await waitFor(() => expect(renameConversation).toHaveBeenCalledOnce());
+
+    expect(screen.getByRole("button", { name: "Beta" })).toHaveProperty("ondblclick", null);
+    expect(screen.getByRole("textbox", { name: "Rename Alpha" })).toBeDisabled();
+    await act(async () => resolveRename(true));
+  });
+
   it("coalesces a focus refresh that arrives while the provider catalog is in flight", async () => {
     let resolveFirst: ((response: Response) => void) | undefined;
     const first = new Promise<Response>((resolve) => { resolveFirst = resolve; });


### PR DESCRIPTION
## Summary

- add an owner-scoped, revision-guarded canonical Chat title update endpoint
- support rename from Electron Desktop rail double-click, rail context-menu Rename, and center-header click
- add the same canonical rename behavior to Web Desktop and Web Canvas, plus a touch-accessible header editor on Web Mobile
- keep rail, active header, and canonical projections synchronized without letting delayed stale list responses overwrite newer titles or unrelated record fields
- disambiguate single-click navigation from double-click rename and isolate concurrent rename requests

## Test plan

- `flox activate -- bun run test -- tests/desktop/work-rail.test.tsx tests/desktop/hosted-work-sidebar.test.tsx tests/desktop/work-tab.test.tsx tests/shell/chat-app-provider-state.test.tsx tests/shell/canonical-chat-state.test.tsx tests/shell/canonical-chat-client.test.ts` — 108/108 passed
- OS View parity CI suite — 107/107 passed
- `flox activate -- bun run typecheck` — passed
- `pnpm exec tsc --noEmit -p shell/tsconfig.json` — passed
- `flox activate -- bun run check:patterns` — 0 violations (5 existing broad warnings)
- production shell build — compilation and TypeScript passed; local prerender then stopped because `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is not present in the isolated worktree environment
- independent standards and spec reviews — no remaining actionable findings

## Human Review

- [x] Double-click a Chat row, edit the title, and press Enter
- [x] Right-click a Chat row, choose Rename, and click away to save
- [x] Click the active Chat title at the top of the center pane and rename it
- [x] Press Escape from each editor and confirm the old title remains
- [x] Reload and confirm the saved title persists

Human Review passed. Merge is gated on exact-head Greptile 5/5, required CI/Docker green, and zero unresolved review threads.

## Platform scope

- Web Desktop and Web Canvas share the canonical rail and header rename behavior.
- Web Mobile exposes the same canonical title mutation through a 44px touch-accessible header editor; desktop-only double-click and context-menu gestures are intentionally omitted.
- Native Mobile is outside MAT-516 because it still uses the legacy `/api/conversations` metadata and transport without canonical title revisions. Its canonical Chat transport migration is separate parity work.

## Mandatory invariants

- **Source of truth:** `chats.title` in owner-controlled Postgres; canonical Chat records and `chat.updated` outbox events project the committed title.
- **Lock/transaction scope:** the existing repository update transaction enforces `WHERE revision = baseRevision`; conflicts return the typed canonical conflict path.
- **Acceptable orphan states:** none. A failed mutation leaves the persisted and visible prior title intact.
- **Auth source of truth:** the authenticated `RequestPrincipal` is mapped to `ChatOwner`; clients cannot supply or override ownership.

Linear: https://linear.app/matrix-os/issue/MAT-516/featdesktop-chat-rename-chats-from-the-rail-and-header
