### PR TITLE
fix(desktop): retain obscured app content

### DIFF
--- a/desktop/src/main/embeds/embed-manager.ts
+++ b/desktop/src/main/embeds/embed-manager.ts
@@ -17,6 +17,7 @@ export interface EmbedViewLike {
   setBounds(bounds: Bounds): void;
   setScale(factor: number): void;
   loadUrl(url: string): Promise<void>;
+  captureSnapshot?(): Promise<string | null>;
   attach(): void;
   detach(): void;
   destroy(): void;
@@ -44,6 +45,7 @@ export type EmbedManagerOptions = {
 
 export const MAX_TOTAL_EMBEDS = 12;
 const DEFAULT_MAX_LIVE = 3;
+const EMBED_SNAPSHOT_TIMEOUT_MS = 400;
 const SAFE_SLUG = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/;
 const ERR_ABORTED = -3;
 
@@ -54,6 +56,8 @@ interface EmbedRecord {
   live: boolean;
   loadFailed: boolean;
   loadGeneration: number;
+  activationGeneration: number;
+  retainedSnapshotDataUrl: string | null;
   lastUsed: number;
   onState: (state: "loading" | "ready" | "failed") => void;
   onDispose?: () => void;
@@ -156,6 +160,8 @@ export class EmbedManager {
       live: active,
       loadFailed: false,
       loadGeneration: 0,
+      activationGeneration: 0,
+      retainedSnapshotDataUrl: null,
       lastUsed: ++this.tick,
       onState: emitState,
       onDispose: options?.onDispose,
@@ -190,6 +196,7 @@ export class EmbedManager {
   setActive(embedId: string, active: boolean): boolean {
     const record = this.records.get(embedId);
     if (!record) return false;
+    record.activationGeneration += 1;
     if (active) {
       if (!record.live) {
         record.view.attach();
@@ -206,6 +213,43 @@ export class EmbedManager {
       record.live = false;
     }
     return true;
+  }
+
+  async deactivate(embedId: string): Promise<{ ok: boolean; snapshotDataUrl: string | null }> {
+    const record = this.records.get(embedId);
+    if (!record) return { ok: false, snapshotDataUrl: null };
+    const generation = ++record.activationGeneration;
+    let snapshotDataUrl: string | null = null;
+    try {
+      if (record.view.captureSnapshot) {
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+        try {
+          const capturedSnapshotDataUrl = await Promise.race([
+            record.view.captureSnapshot(),
+            new Promise<null>((resolve) => {
+              timeout = setTimeout(() => resolve(null), EMBED_SNAPSHOT_TIMEOUT_MS);
+            }),
+          ]);
+          if (capturedSnapshotDataUrl) {
+            record.retainedSnapshotDataUrl = capturedSnapshotDataUrl;
+          }
+        } finally {
+          if (timeout) clearTimeout(timeout);
+        }
+      }
+    } catch (error: unknown) {
+      console.warn(
+        "[embeds] retained frame capture failed:",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+    }
+    const current = this.records.get(embedId);
+    if (current === record && record.activationGeneration === generation && record.live) {
+      record.view.detach();
+      record.live = false;
+    }
+    snapshotDataUrl ??= record.retainedSnapshotDataUrl;
+    return { ok: true, snapshotDataUrl };
   }
 
   suspendAll(): boolean {

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -164,9 +164,7 @@ export class EmbedService {
   }
 
   setActive(embedId: string, active: boolean): boolean {
-    const pending = this.pendingHostedShells.has(embedId)
-      || this.pendingCodeEditors.has(embedId)
-      || this.pendingApps.has(embedId);
+    const pending = this.isPending(embedId);
     if (pending) {
       this.pendingActive.set(embedId, active);
     }
@@ -174,6 +172,15 @@ export class EmbedService {
       this.scheduleHostedShellSessionRefresh(this.deps.getGatewayOrigin());
     }
     return this.manager.setActive(embedId, active) || pending;
+  }
+
+  async deactivate(embedId: string): Promise<{ ok: boolean; snapshotDataUrl: string | null }> {
+    const pending = this.isPending(embedId);
+    if (pending) {
+      this.pendingActive.set(embedId, false);
+      return { ok: true, snapshotDataUrl: null };
+    }
+    return this.manager.deactivate(embedId);
   }
 
   suspendAll(): boolean {
@@ -184,6 +191,9 @@ export class EmbedService {
       this.pendingActive.set(embedId, false);
     }
     for (const embedId of this.pendingCodeEditors.keys()) {
+      this.pendingActive.set(embedId, false);
+    }
+    for (const embedId of this.pendingBrowsers) {
       this.pendingActive.set(embedId, false);
     }
     return this.manager.suspendAll();
@@ -332,6 +342,7 @@ export class EmbedService {
 
     const generation = this.browserGeneration;
     this.pendingBrowsers.add(embedId);
+    this.pendingActive.set(embedId, active);
     const startPortForward = this.deps.startPortForward ?? startMatrixPortForward;
     let forward: PortForwardHandle;
     try {
@@ -345,6 +356,7 @@ export class EmbedService {
       });
     } catch (err: unknown) {
       this.pendingBrowsers.delete(embedId);
+      this.pendingActive.delete(embedId);
       console.warn(
         "[embed-service] runtime browser tunnel failed:",
         err instanceof Error ? err.message : String(err),
@@ -353,6 +365,8 @@ export class EmbedService {
     }
 
     const stillPending = this.pendingBrowsers.delete(embedId);
+    const resolvedActive = this.pendingActive.get(embedId) ?? active;
+    this.pendingActive.delete(embedId);
     if (generation !== this.browserGeneration || !stillPending) {
       void forward.close().catch((err: unknown) => {
         console.warn(
@@ -376,7 +390,7 @@ export class EmbedService {
     try {
       this.manager.open("browser", null, bounds, localUrl.toString(), {
         id: embedId,
-        active,
+        active: resolvedActive,
         allowedOrigins,
         resolveNavigation: (url) => resolveRuntimeBrowserNavigation(
           url,
@@ -395,6 +409,13 @@ export class EmbedService {
       return { embedId, state: "failed" };
     }
     return { embedId, state: "loading" };
+  }
+
+  private isPending(embedId: string): boolean {
+    return this.pendingHostedShells.has(embedId)
+      || this.pendingCodeEditors.has(embedId)
+      || this.pendingApps.has(embedId)
+      || this.pendingBrowsers.has(embedId);
   }
 
   private async openBrowser(

--- a/desktop/src/main/embeds/web-contents-view.ts
+++ b/desktop/src/main/embeds/web-contents-view.ts
@@ -11,6 +11,7 @@ import { resolveBrowserAddress } from "../../shared/runtime-browser-url";
 
 const MAX_PUBLIC_BROWSER_ORIGINS = 64;
 const MAX_EMBED_SNAPSHOT_BYTES = 3_000_000;
+const MAX_EMBED_SNAPSHOT_CAPTURE_EDGE = 2_048;
 const EMBED_SNAPSHOT_QUALITIES = [72, 54, 36, 24] as const;
 
 function encodeBoundedSnapshot(source: NativeImage): string | null {
@@ -63,12 +64,36 @@ export function createWebContentsView(options: {
 
   const contents = view.webContents;
   let retainedSnapshotDataUrl: string | null = null;
-  const captureSnapshot = async (): Promise<string | null> => {
-    if (contents.isDestroyed()) return retainedSnapshotDataUrl;
-    const image = await contents.capturePage();
-    if (image.isEmpty()) return retainedSnapshotDataUrl;
-    retainedSnapshotDataUrl = encodeBoundedSnapshot(image) ?? retainedSnapshotDataUrl;
-    return retainedSnapshotDataUrl;
+  let snapshotContentGeneration = 0;
+  let snapshotCaptureBounds: Bounds | undefined;
+  let snapshotCaptureInFlight: {
+    generation: number;
+    promise: Promise<string | null>;
+  } | null = null;
+  const captureSnapshot = (): Promise<string | null> => {
+    const generation = snapshotContentGeneration;
+    if (snapshotCaptureInFlight?.generation === generation) {
+      return snapshotCaptureInFlight.promise;
+    }
+    const capture = (async (): Promise<string | null> => {
+      if (contents.isDestroyed()) return retainedSnapshotDataUrl;
+      const image = await contents.capturePage(snapshotCaptureBounds);
+      if (generation !== snapshotContentGeneration) return retainedSnapshotDataUrl;
+      if (image.isEmpty()) return retainedSnapshotDataUrl;
+      retainedSnapshotDataUrl = encodeBoundedSnapshot(image) ?? retainedSnapshotDataUrl;
+      return retainedSnapshotDataUrl;
+    })();
+    const inFlight = { generation, promise: capture };
+    snapshotCaptureInFlight = inFlight;
+    void capture.then(
+      () => {
+        if (snapshotCaptureInFlight === inFlight) snapshotCaptureInFlight = null;
+      },
+      () => {
+        if (snapshotCaptureInFlight === inFlight) snapshotCaptureInFlight = null;
+      },
+    );
+    return capture;
   };
   const publicOrigins = new Map<string, true>();
   for (const origin of options.allowedOrigins) publicOrigins.set(origin, true);
@@ -165,7 +190,11 @@ export function createWebContentsView(options: {
     if (externalUrl) void shell.openExternal(externalUrl);
     return { action: "deny" };
   });
-  contents.on("did-start-loading", () => options.onState("loading"));
+  contents.on("did-start-loading", () => {
+    snapshotContentGeneration += 1;
+    retainedSnapshotDataUrl = null;
+    options.onState("loading");
+  });
   contents.on("did-finish-load", () => {
     options.onState("ready");
     // Warm the first retained frame while the view is definitely paintable so
@@ -198,6 +227,12 @@ export function createWebContentsView(options: {
   return {
     setBounds(bounds: Bounds) {
       view.setBounds(bounds);
+      snapshotCaptureBounds = {
+        x: 0,
+        y: 0,
+        width: Math.min(bounds.width, MAX_EMBED_SNAPSHOT_CAPTURE_EDGE),
+        height: Math.min(bounds.height, MAX_EMBED_SNAPSHOT_CAPTURE_EDGE),
+      };
     },
     setScale(factor: number) {
       contents.setZoomFactor(factor);
@@ -205,9 +240,7 @@ export function createWebContentsView(options: {
     async loadUrl(url: string) {
       await contents.loadURL(url);
     },
-    async captureSnapshot() {
-      return captureSnapshot();
-    },
+    captureSnapshot,
     attach() {
       if (attached) return;
       options.window.contentView.addChildView(view);

--- a/desktop/src/main/embeds/web-contents-view.ts
+++ b/desktop/src/main/embeds/web-contents-view.ts
@@ -11,11 +11,19 @@ import { resolveBrowserAddress } from "../../shared/runtime-browser-url";
 
 const MAX_PUBLIC_BROWSER_ORIGINS = 64;
 const MAX_EMBED_SNAPSHOT_BYTES = 3_000_000;
-const MAX_EMBED_SNAPSHOT_CAPTURE_EDGE = 2_048;
+const MAX_EMBED_SNAPSHOT_EDGE = 2_048;
 const EMBED_SNAPSHOT_QUALITIES = [72, 54, 36, 24] as const;
 
 function encodeBoundedSnapshot(source: NativeImage): string | null {
-  let image = source;
+  const sourceSize = source.getSize();
+  const longestEdge = Math.max(sourceSize.width, sourceSize.height);
+  const initialScale = Math.min(1, MAX_EMBED_SNAPSHOT_EDGE / longestEdge);
+  let image = initialScale < 1
+    ? source.resize({
+        width: Math.max(1, Math.round(sourceSize.width * initialScale)),
+        height: Math.max(1, Math.round(sourceSize.height * initialScale)),
+      })
+    : source;
   for (let resizeAttempt = 0; resizeAttempt < 4; resizeAttempt += 1) {
     for (const quality of EMBED_SNAPSHOT_QUALITIES) {
       const jpeg = image.toJPEG(quality);
@@ -65,7 +73,6 @@ export function createWebContentsView(options: {
   const contents = view.webContents;
   let retainedSnapshotDataUrl: string | null = null;
   let snapshotContentGeneration = 0;
-  let snapshotCaptureBounds: Bounds | undefined;
   let snapshotCaptureInFlight: {
     generation: number;
     promise: Promise<string | null>;
@@ -77,7 +84,7 @@ export function createWebContentsView(options: {
     }
     const capture = (async (): Promise<string | null> => {
       if (contents.isDestroyed()) return retainedSnapshotDataUrl;
-      const image = await contents.capturePage(snapshotCaptureBounds);
+      const image = await contents.capturePage();
       if (generation !== snapshotContentGeneration) return retainedSnapshotDataUrl;
       if (image.isEmpty()) return retainedSnapshotDataUrl;
       retainedSnapshotDataUrl = encodeBoundedSnapshot(image) ?? retainedSnapshotDataUrl;
@@ -227,12 +234,6 @@ export function createWebContentsView(options: {
   return {
     setBounds(bounds: Bounds) {
       view.setBounds(bounds);
-      snapshotCaptureBounds = {
-        x: 0,
-        y: 0,
-        width: Math.min(bounds.width, MAX_EMBED_SNAPSHOT_CAPTURE_EDGE),
-        height: Math.min(bounds.height, MAX_EMBED_SNAPSHOT_CAPTURE_EDGE),
-      };
     },
     setScale(factor: number) {
       contents.setZoomFactor(factor);

--- a/desktop/src/main/embeds/web-contents-view.ts
+++ b/desktop/src/main/embeds/web-contents-view.ts
@@ -2,7 +2,7 @@
 // in its own isolated partition. Hosted-shell views have no preload/IPC
 // exposure; app views may receive the narrow database-only preload. Navigation
 // is gated by an origin allowlist; external links open in the system browser.
-import { WebContentsView, shell, type BaseWindow } from "electron";
+import { WebContentsView, shell, type BaseWindow, type NativeImage } from "electron";
 import { isNavigationAllowed } from "./origin-policy";
 import type { Bounds, EmbedViewLike } from "./embed-manager";
 import { safeExternalHttpUrl } from "../external-url";
@@ -10,6 +10,27 @@ import type { RuntimeBrowserNavigationDecision } from "../../shared/runtime-brow
 import { resolveBrowserAddress } from "../../shared/runtime-browser-url";
 
 const MAX_PUBLIC_BROWSER_ORIGINS = 64;
+const MAX_EMBED_SNAPSHOT_BYTES = 3_000_000;
+const EMBED_SNAPSHOT_QUALITIES = [72, 54, 36, 24] as const;
+
+function encodeBoundedSnapshot(source: NativeImage): string | null {
+  let image = source;
+  for (let resizeAttempt = 0; resizeAttempt < 4; resizeAttempt += 1) {
+    for (const quality of EMBED_SNAPSHOT_QUALITIES) {
+      const jpeg = image.toJPEG(quality);
+      if (jpeg.byteLength <= MAX_EMBED_SNAPSHOT_BYTES) {
+        return `data:image/jpeg;base64,${jpeg.toString("base64")}`;
+      }
+    }
+    const { width, height } = image.getSize();
+    if (width <= 320 || height <= 200) break;
+    image = image.resize({
+      width: Math.max(320, Math.floor(width * 0.7)),
+      height: Math.max(200, Math.floor(height * 0.7)),
+    });
+  }
+  return null;
+}
 
 export function createWebContentsView(options: {
   window: BaseWindow;
@@ -41,6 +62,14 @@ export function createWebContentsView(options: {
   });
 
   const contents = view.webContents;
+  let retainedSnapshotDataUrl: string | null = null;
+  const captureSnapshot = async (): Promise<string | null> => {
+    if (contents.isDestroyed()) return retainedSnapshotDataUrl;
+    const image = await contents.capturePage();
+    if (image.isEmpty()) return retainedSnapshotDataUrl;
+    retainedSnapshotDataUrl = encodeBoundedSnapshot(image) ?? retainedSnapshotDataUrl;
+    return retainedSnapshotDataUrl;
+  };
   const publicOrigins = new Map<string, true>();
   for (const origin of options.allowedOrigins) publicOrigins.set(origin, true);
   const rememberPublicOrigin = (origin: string) => {
@@ -137,7 +166,17 @@ export function createWebContentsView(options: {
     return { action: "deny" };
   });
   contents.on("did-start-loading", () => options.onState("loading"));
-  contents.on("did-finish-load", () => options.onState("ready"));
+  contents.on("did-finish-load", () => {
+    options.onState("ready");
+    // Warm the first retained frame while the view is definitely paintable so
+    // an immediate z-order change can fall back if the next capture is late.
+    void captureSnapshot().catch((error: unknown) => {
+      console.warn(
+        "[embeds] retained frame warm-up failed:",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+    });
+  });
   contents.on("did-fail-load", (_e, errorCode, _description, _validatedUrl, isMainFrame) => {
     if (isMainFrame === false) return;
     // -3 is ERR_ABORTED (e.g. a redirect); not a real failure.
@@ -165,6 +204,9 @@ export function createWebContentsView(options: {
     },
     async loadUrl(url: string) {
       await contents.loadURL(url);
+    },
+    async captureSnapshot() {
+      return captureSnapshot();
     },
     attach() {
       if (attached) return;

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -359,6 +359,7 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
   handle("embed:set-active", ({ embedId, active }) => ({
     ok: ctx.embeds.setActive(embedId, active),
   }));
+  handle("embed:deactivate", ({ embedId }) => ctx.embeds.deactivate(embedId));
   handle("embed:suspend-all", () => ({ ok: ctx.embeds.suspendAll() }));
   handle("embed:reload", async ({ embedId }) => ({ ok: await ctx.embeds.reload(embedId) }));
   handle("embed:close", ({ embedId }) => ({ ok: ctx.embeds.close(embedId) }));

--- a/desktop/src/renderer/src/features/chat/CanonicalChatRoute.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatRoute.tsx
@@ -22,6 +22,7 @@ export function CanonicalChatRoute({
   initialView,
   projectLabel,
   active,
+  live = active,
   externalNavigation = false,
   fallback,
   inspector,
@@ -36,6 +37,7 @@ export function CanonicalChatRoute({
   initialView?: "index" | "draft" | "conversation";
   projectLabel?: string;
   active: boolean;
+  live?: boolean;
   externalNavigation?: boolean;
   fallback: ReactNode;
   inspector?: ReactNode;
@@ -101,7 +103,7 @@ export function CanonicalChatRoute({
       setAvailability({ routeKey: null, value: "unavailable" });
       return () => { current = false; };
     }
-    if (!active) return () => { current = false; };
+    if (!live) return () => { current = false; };
     if (
       provenRoute.current?.client === client
       && provenRoute.current.projectId === canonicalProjectId
@@ -121,7 +123,7 @@ export function CanonicalChatRoute({
       setAvailability({ routeKey, value: "unavailable" });
     });
     return () => { current = false; };
-  }, [active, canonicalProjectId, client, routeKey]);
+  }, [canonicalProjectId, client, live, routeKey]);
 
   if (!client || currentAvailability === "unavailable") return fallback;
   if (currentAvailability === "checking") {
@@ -145,6 +147,7 @@ export function CanonicalChatRoute({
       initialView={initialView}
       projectLabel={projectLabel}
       active={active}
+      live={live}
       eventSource={eventSource}
       externalNavigation={externalNavigation}
       inspector={inspector}

--- a/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
@@ -75,6 +75,7 @@ export function CanonicalChatWorkspace({
   initialView,
   projectLabel,
   active,
+  live = active,
   externalNavigation = false,
   catalog,
   inspector,
@@ -91,6 +92,7 @@ export function CanonicalChatWorkspace({
   initialView?: "index" | "draft" | "conversation";
   projectLabel?: string;
   active: boolean;
+  live?: boolean;
   externalNavigation?: boolean;
   catalog?: CanonicalProviderCatalog;
   inspector?: ReactNode;
@@ -105,7 +107,7 @@ export function CanonicalChatWorkspace({
     () => createLegacyGlobalProviderCatalog({ hasProject: projects.length > 0 }),
     [projects.length],
   );
-  const liveCatalog = useChatProviderCatalog(fallbackCatalog, { api: api ?? null, active });
+  const liveCatalog = useChatProviderCatalog(fallbackCatalog, { api: api ?? null, active: live });
   const unavailableCatalog = useMemo(() => failClosedProviderCatalog(fallbackCatalog), [fallbackCatalog]);
   const providerCatalog = catalog ?? (
     liveCatalog.status === "ready" ? liveCatalog.catalog : unavailableCatalog
@@ -113,7 +115,7 @@ export function CanonicalChatWorkspace({
   const controller = useCanonicalChatRouteController({
     client,
     projectId,
-    active,
+    active: live,
     initialChatId,
     autoSelectFirst: false,
     eventSource,

--- a/desktop/src/renderer/src/features/chat/ChatTab.tsx
+++ b/desktop/src/renderer/src/features/chat/ChatTab.tsx
@@ -387,6 +387,7 @@ export function ChatUnavailableState({ onRetry }: { onRetry: () => void }) {
 
 export default function ChatTab({
   active = true,
+  visible = active,
   tabId,
   initialChatId,
   initialView,
@@ -397,6 +398,7 @@ export default function ChatTab({
   eventSource,
 }: {
   active?: boolean;
+  visible?: boolean;
   tabId?: string;
   initialChatId?: string;
   initialView?: "index" | "draft" | "conversation";
@@ -417,6 +419,7 @@ export default function ChatTab({
       initialChatId={initialChatId}
       initialView={initialView}
       active={active}
+      live={visible}
       eventSource={eventSource}
       externalNavigation={externalNavigation}
       renderInspector={renderInspector}

--- a/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
+++ b/desktop/src/renderer/src/features/desktop-shell/DesktopSurfaceFrame.tsx
@@ -249,7 +249,7 @@ export default function DesktopSurfaceFrame({
       sidebar={tab.kind === "settings" ? (
         <SettingsSidebar section={settingsSection} onSectionChange={setSettingsSection} />
       ) : isWorkSurface ? (
-        <HostedWorkSidebar tab={tab} active={paneActive} />
+        <HostedWorkSidebar tab={tab} active={visible} />
       ) : undefined}
       safeAreaLayout={sidebarOwnsChrome ? "sidebar" : "pane"}
       topBarReservesSafeArea={isWindow || !isWorkSurface}
@@ -321,6 +321,6 @@ export default function DesktopSurfaceFrame({
     </SurfaceChromeContext.Provider>
   );
   return isWorkSurface ? (
-    <WorkSurfaceRuntimeProvider active={paneActive}>{frame}</WorkSurfaceRuntimeProvider>
+    <WorkSurfaceRuntimeProvider active={visible}>{frame}</WorkSurfaceRuntimeProvider>
   ) : frame;
 }

--- a/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
+++ b/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
@@ -44,6 +44,7 @@ export default function EmbedHost({
   const [openedEmbedRevision, setOpenedEmbedRevision] = useState(0);
   const [retryRevision, setRetryRevision] = useState(0);
   const [state, setState] = useState<"loading" | "ready" | "auth-required" | "failed">("loading");
+  const [snapshotDataUrl, setSnapshotDataUrl] = useState<string | null>(null);
 
   const reportBounds = useCallback((): void => {
     const id = embedIdRef.current;
@@ -136,14 +137,37 @@ export default function EmbedHost({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [appIdentity, kind, retryRevision, runtimeSlot, slug, url]);
 
-  // Attach/detach the native view as the hosting tab activates/deactivates.
+  // Native views always paint above renderer windows. Keep a bounded local
+  // frame under the detached view so obscured Matrix windows do not go blank.
   useEffect(() => {
     const id = embedIdRef.current;
     // While embed:open is pending there is no native view to attach yet. The
     // open resolution path applies activeRef.current before reporting bounds.
     if (!id) return;
-    void invoke("embed:set-active", { embedId: id, active });
-    if (active) reportBounds();
+    if (active) {
+      setSnapshotDataUrl(null);
+      void invoke("embed:set-active", { embedId: id, active: true });
+      reportBounds();
+      return;
+    }
+    void invoke("embed:deactivate", { embedId: id }).then((result) => {
+      if (embedIdRef.current !== id || activeRef.current) return;
+      if (result.snapshotDataUrl) setSnapshotDataUrl(result.snapshotDataUrl);
+    }).catch((error: unknown) => {
+      console.warn(
+        "[embeds] retained frame request failed:",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+      if (embedIdRef.current !== id || activeRef.current) return;
+      void invoke("embed:set-active", { embedId: id, active: false }).catch(
+        (fallbackError: unknown) => {
+          console.warn(
+            "[embeds] fallback detach failed:",
+            fallbackError instanceof Error ? fallbackError.name : "UnknownError",
+          );
+        },
+      );
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active]);
 
@@ -176,7 +200,17 @@ export default function EmbedHost({
   }, [active, openedEmbedRevision, refreshRequest]);
 
   return (
-    <div ref={hostRef} className="relative min-h-0 flex-1" style={{ background: "var(--bg-app)" }}>
+    <div ref={hostRef} className="ph-no-capture relative min-h-0 flex-1" style={{ background: "var(--bg-app)" }}>
+      {snapshotDataUrl ? (
+        <img
+          data-testid="embed-retained-frame"
+          src={snapshotDataUrl}
+          alt=""
+          aria-hidden="true"
+          draggable={false}
+          className="pointer-events-none absolute inset-0 size-full object-fill"
+        />
+      ) : null}
       {state === "loading" ? (
         <div className="absolute inset-0 flex items-center justify-center">
           <span className="status-pulse text-sm" style={{ color: "var(--text-tertiary)" }}>

--- a/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
+++ b/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
@@ -67,6 +67,7 @@ export default function EmbedHost({
     if (!host) return;
     embedIdRef.current = null;
     setState("loading");
+    setSnapshotDataUrl(null);
     let disposed = false;
     let offState: (() => void) | null = null;
     const pendingStates = new Map<string, typeof state>();

--- a/desktop/src/renderer/src/features/mission-control/TabContent.tsx
+++ b/desktop/src/renderer/src/features/mission-control/TabContent.tsx
@@ -72,12 +72,13 @@ export function TabPane({
         route={tab.workRoute ?? "chat"}
         projectSlug={tab.projectSlug}
         active={active}
+        visible={visible}
         initialChatId={tab.chatId}
         initialChatView={tab.chatView}
         initialChatTitle={tab.chatTitle}
       />;
     case "chat":
-      return <WorkTab tabId={tab.id} route="chat" active={active} initialChatId={tab.chatId} initialChatView={tab.chatView} initialChatTitle={tab.chatTitle} />;
+      return <WorkTab tabId={tab.id} route="chat" active={active} visible={visible} initialChatId={tab.chatId} initialChatView={tab.chatView} initialChatTitle={tab.chatTitle} />;
     case "terminals":
       return <TerminalsTab active={active} visible={visible} visualScale={visualScale} />;
     case "files":
@@ -91,13 +92,13 @@ export function TabPane({
     case "apps":
       return <AppLauncher />;
     case "projects":
-      return <WorkTab route="projects" active={active} />;
+      return <WorkTab route="projects" active={active} visible={visible} />;
     case "app":
       return tab.slug
         ? <EmbedHost kind="app" slug={tab.slug} appIdentity={tab.appIdentity} active={active} layoutRevision={layoutRevision} visualScale={visualScale} />
         : null;
     case "project":
-      return <WorkTab route="project" projectSlug={tab.projectSlug} active={active} initialChatId={tab.chatId} initialChatTitle={tab.chatTitle} />;
+      return <WorkTab route="project" projectSlug={tab.projectSlug} active={active} visible={visible} initialChatId={tab.chatId} initialChatTitle={tab.chatTitle} />;
     case "task":
       return tab.taskId ? <TaskWorkspace taskId={tab.taskId} projectSlug={tab.projectSlug} active={active} /> : null;
     case "terminal":

--- a/desktop/src/renderer/src/features/project/ProjectChatsView.tsx
+++ b/desktop/src/renderer/src/features/project/ProjectChatsView.tsx
@@ -714,6 +714,7 @@ function LegacyProjectChatsView({ projectId, active }: { projectId: string; acti
 export default function ProjectChatsView({
   projectId,
   active,
+  visible = active,
   initialChatId,
   initialView,
   externalNavigation = false,
@@ -724,6 +725,7 @@ export default function ProjectChatsView({
 }: {
   projectId: string;
   active: boolean;
+  visible?: boolean;
   initialChatId?: string;
   initialView?: "index" | "draft" | "conversation";
   externalNavigation?: boolean;
@@ -746,6 +748,7 @@ export default function ProjectChatsView({
       initialView={initialView}
       projectLabel={projectLabel}
       active={active}
+      live={visible}
       eventSource={eventSource}
       externalNavigation={externalNavigation}
       renderInspector={renderInspector}

--- a/desktop/src/renderer/src/features/work/WorkTab.tsx
+++ b/desktop/src/renderer/src/features/work/WorkTab.tsx
@@ -193,6 +193,7 @@ export default function WorkTab({
   route,
   projectSlug,
   active,
+  visible = active,
   initialChatId,
   initialChatView,
   initialChatTitle,
@@ -201,6 +202,7 @@ export default function WorkTab({
   route: WorkRoute;
   projectSlug?: string;
   active: boolean;
+  visible?: boolean;
   initialChatId?: string;
   initialChatView?: "index" | "draft" | "conversation";
   initialChatTitle?: string;
@@ -240,7 +242,7 @@ export default function WorkTab({
   const { layout, navigationOpen, inspectorOpen } = responsive;
   const localClient = useMemo(() => api ? createCanonicalChatClient(api) : null, [api, authGeneration, runtimeSlot]);
   const localEventSource = useMemo<CanonicalChatEventSource | null>(() => {
-    if (hostedRuntime || !api || !active) return null;
+    if (hostedRuntime || !api || !visible) return null;
     return createCanonicalChatEventSource({
       gatewayOrigin: api.baseUrl,
       runtimeSlot,
@@ -251,7 +253,7 @@ export default function WorkTab({
       },
       createWebSocket: (url) => new WebSocket(url) as unknown as DesktopCanonicalChatWebSocket,
     });
-  }, [active, api, authGeneration, hostedRuntime, runtimeSlot]);
+  }, [api, authGeneration, hostedRuntime, runtimeSlot, visible]);
   const client = hostedRuntime?.client ?? localClient;
   const eventSource = hostedRuntime?.eventSource ?? localEventSource;
   const routeKey = `${active}:${route}:${projectSlug ?? ""}:${initialChatView ?? ""}:${initialChatId ?? ""}`;
@@ -578,11 +580,11 @@ export default function WorkTab({
   ) : null;
   const canonicalInspector = initialChatId ? renderInspector : undefined;
   const content = route === "chat"
-    ? <ChatTab tabId={tabId} active={active} initialChatId={initialChatId} initialView={initialChatView} eventSource={eventSource ?? undefined} externalNavigation renderInspector={canonicalInspector} inspectorExclusive={inspectorExclusive} allowLegacyFallback={false} />
+    ? <ChatTab tabId={tabId} active={active} visible={visible} initialChatId={initialChatId} initialView={initialChatView} eventSource={eventSource ?? undefined} externalNavigation renderInspector={canonicalInspector} inspectorExclusive={inspectorExclusive} allowLegacyFallback={false} />
     : route === "projects"
       ? <ProjectsIndex />
       : projectSlug
-        ? <ProjectChatsView projectId={projectSlug} active={active} initialChatId={initialChatId} initialView={initialChatView} eventSource={eventSource ?? undefined} externalNavigation renderInspector={canonicalInspector} inspectorExclusive={inspectorExclusive} allowLegacyFallback={false} />
+        ? <ProjectChatsView projectId={projectSlug} active={active} visible={visible} initialChatId={initialChatId} initialView={initialChatView} eventSource={eventSource ?? undefined} externalNavigation renderInspector={canonicalInspector} inspectorExclusive={inspectorExclusive} allowLegacyFallback={false} />
         : null;
 
   const navigationVisible = layout === "narrow" ? narrowPane === "rail" : navigationOpen;

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -372,6 +372,16 @@ export const INVOKE_CHANNELS = {
     request: z.object({ embedId: z.string().min(1).max(64), active: z.boolean() }).strict(),
     response: Ok,
   },
+  "embed:deactivate": {
+    request: z.object({ embedId: z.string().min(1).max(64) }).strict(),
+    response: z.strictObject({
+      ok: z.boolean(),
+      snapshotDataUrl: z.string()
+        .max(4_000_023)
+        .regex(/^data:image\/jpeg;base64,[A-Za-z0-9+/]*={0,2}$/)
+        .nullable(),
+    }),
+  },
   "embed:suspend-all": {
     request: Empty,
     response: Ok,

--- a/tests/desktop/canonical-chat-route.test.tsx
+++ b/tests/desktop/canonical-chat-route.test.tsx
@@ -130,6 +130,47 @@ describe("CanonicalChatRoute", () => {
     expect(screen.getByRole("complementary", { name: "Global chats" })).toBeTruthy();
   });
 
+  it("keeps a loaded conversation rendered while its visible window is behind another window", async () => {
+    vi.stubGlobal("ResizeObserver", class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    });
+    const completed = createCanonicalChatFixture("running");
+    const { project, providerBinding, activeRun, ...chat } = completed.snapshot.chat;
+    const record = { chat, projectId: project?.projectId, providerBinding, activeRun };
+    const routeApi = api(vi.fn(async (path: string) => {
+      if (path.startsWith("/api/chat-providers")) return completed.providerCatalog;
+      if (path.startsWith(`/api/chats/${chat.id}`)) {
+        return {
+          record,
+          messages: completed.snapshot.messages,
+          turns: completed.snapshot.turns,
+          runs: completed.snapshot.runs,
+          activities: completed.snapshot.activities,
+          queuedTurns: [],
+        };
+      }
+      if (path.startsWith("/api/chats")) return { items: [record] };
+      throw new Error("route unavailable");
+    }));
+    const props = {
+      api: routeApi,
+      projectId: null,
+      initialChatId: chat.id,
+      initialView: "conversation" as const,
+      live: true,
+      fallback: <div>legacy chat</div>,
+    };
+    const view = render(<CanonicalChatRoute {...props} active />);
+
+    expect(await screen.findByText("Build the canonical Chat contract.")).toBeTruthy();
+    view.rerender(<CanonicalChatRoute {...props} active={false} />);
+
+    expect(screen.getByText("Build the canonical Chat contract.")).toBeTruthy();
+    expect(screen.queryByRole("status", { name: "Loading chat" })).toBeNull();
+  });
+
   it("keeps the legacy route on an older Gateway instead of showing a broken surface", async () => {
     render(
       <CanonicalChatRoute

--- a/tests/desktop/embed-host.test.tsx
+++ b/tests/desktop/embed-host.test.tsx
@@ -97,6 +97,64 @@ describe("EmbedHost", () => {
     });
   });
 
+  it("keeps a retained native frame visible after an embed moves behind another window", async () => {
+    vi.mocked(invoke).mockImplementation((channel: string) => {
+      if (channel === "embed:open") {
+        return Promise.resolve({ embedId: "browser-1", state: "ready" }) as ReturnType<typeof invoke>;
+      }
+      if (channel === "embed:deactivate") {
+        return Promise.resolve({
+          ok: true,
+          snapshotDataUrl: "data:image/jpeg;base64,cGVyc2lzdGVkLWJyb3dzZXI=",
+        }) as ReturnType<typeof invoke>;
+      }
+      return Promise.resolve({ ok: true }) as ReturnType<typeof invoke>;
+    });
+
+    const view = render(<EmbedHost kind="browser" url="https://example.com" active />);
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith(
+      "embed:set-active",
+      { embedId: "browser-1", active: true },
+    ));
+
+    view.rerender(<EmbedHost kind="browser" url="https://example.com" active={false} />);
+
+    const retainedFrame = await screen.findByTestId("embed-retained-frame");
+    expect(retainedFrame.getAttribute("src")).toBe("data:image/jpeg;base64,cGVyc2lzdGVkLWJyb3dzZXI=");
+    expect(invoke).toHaveBeenCalledWith("embed:deactivate", { embedId: "browser-1" });
+  });
+
+  it.each([
+    ["Home", (active: boolean) => <EmbedHost kind="hosted-shell" active={active} />],
+    ["VS Code", (active: boolean) => <EmbedHost kind="code-editor" active={active} />],
+    ["installed web apps", (active: boolean) => (
+      <EmbedHost kind="app" slug="whiteboard" active={active} />
+    )],
+  ])("uses the same retained-frame lifecycle for %s", async (_label, renderEmbed) => {
+    vi.mocked(invoke).mockImplementation((channel: string) => {
+      if (channel === "embed:open") {
+        return Promise.resolve({ embedId: "embed-1", state: "ready" }) as ReturnType<typeof invoke>;
+      }
+      if (channel === "embed:deactivate") {
+        return Promise.resolve({
+          ok: true,
+          snapshotDataUrl: "data:image/jpeg;base64,cmV0YWluZWQ=",
+        }) as ReturnType<typeof invoke>;
+      }
+      return Promise.resolve({ ok: true }) as ReturnType<typeof invoke>;
+    });
+    const view = render(renderEmbed(true));
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith(
+      "embed:set-active",
+      { embedId: "embed-1", active: true },
+    ));
+
+    view.rerender(renderEmbed(false));
+
+    expect(await screen.findByTestId("embed-retained-frame")).toBeTruthy();
+    expect(invoke).toHaveBeenCalledWith("embed:deactivate", { embedId: "embed-1" });
+  });
+
   it("resynchronizes native bounds and page scale when the Canvas transform changes", async () => {
     const view = render(<EmbedHost kind="app" slug="notes" layoutRevision="canvas:0:0:1" visualScale={1} />);
     await act(async () => {

--- a/tests/desktop/embed-host.test.tsx
+++ b/tests/desktop/embed-host.test.tsx
@@ -124,6 +124,39 @@ describe("EmbedHost", () => {
     expect(invoke).toHaveBeenCalledWith("embed:deactivate", { embedId: "browser-1" });
   });
 
+  it("clears a retained frame when an inactive embed is replaced", async () => {
+    let nextEmbedId = 0;
+    vi.mocked(invoke).mockImplementation((channel: string) => {
+      if (channel === "embed:open") {
+        nextEmbedId += 1;
+        return Promise.resolve({ embedId: `browser-${nextEmbedId}`, state: "ready" }) as ReturnType<typeof invoke>;
+      }
+      if (channel === "embed:deactivate") {
+        return Promise.resolve({
+          ok: true,
+          snapshotDataUrl: "data:image/jpeg;base64,b2xkLXBhZ2U=",
+        }) as ReturnType<typeof invoke>;
+      }
+      return Promise.resolve({ ok: true }) as ReturnType<typeof invoke>;
+    });
+
+    const view = render(<EmbedHost kind="browser" url="https://one.example" active />);
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith(
+      "embed:set-active",
+      { embedId: "browser-1", active: true },
+    ));
+    view.rerender(<EmbedHost kind="browser" url="https://one.example" active={false} />);
+    expect(await screen.findByTestId("embed-retained-frame")).toBeTruthy();
+
+    view.rerender(<EmbedHost kind="browser" url="https://two.example" active={false} />);
+
+    expect(screen.queryByTestId("embed-retained-frame")).toBeNull();
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith(
+      "embed:open",
+      expect.objectContaining({ kind: "browser", url: "https://two.example", active: false }),
+    ));
+  });
+
   it.each([
     ["Home", (active: boolean) => <EmbedHost kind="hosted-shell" active={active} />],
     ["VS Code", (active: boolean) => <EmbedHost kind="code-editor" active={active} />],

--- a/tests/desktop/embed-manager.test.ts
+++ b/tests/desktop/embed-manager.test.ts
@@ -43,6 +43,11 @@ class FakeView implements EmbedViewLike {
     }
   }
 
+  async captureSnapshot(): Promise<string> {
+    this.events.push("captureSnapshot");
+    return "data:image/jpeg;base64,c25hcHNob3Q=";
+  }
+
   attach(): void {
     this.events.push("attach");
   }
@@ -90,6 +95,7 @@ function flush(): Promise<void> {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -471,6 +477,81 @@ describe("EmbedManager", () => {
     expect(manager.setActive(id, false)).toBe(true);
     expect(views[0]?.view.events).toContain("detach");
     expect(manager.liveCount).toBe(0);
+  });
+
+  it("captures a retained frame before detaching an obscured embed", async () => {
+    const { manager, views } = makeManager();
+    const id = manager.open("hosted-shell", null, BOUNDS, "https://gw.test/canvas");
+
+    await expect(manager.deactivate(id)).resolves.toEqual({
+      ok: true,
+      snapshotDataUrl: "data:image/jpeg;base64,c25hcHNob3Q=",
+    });
+    expect(views[0]?.view.events.slice(-2)).toEqual(["captureSnapshot", "detach"]);
+    expect(manager.liveCount).toBe(0);
+  });
+
+  it("reuses the last retained frame when a later capture is unavailable", async () => {
+    const { manager, views } = makeManager();
+    const id = manager.open("browser", null, BOUNDS, "https://gw.test/page");
+    await manager.deactivate(id);
+    manager.setActive(id, true);
+    vi.spyOn(views[0]!.view, "captureSnapshot").mockResolvedValueOnce(null);
+
+    await expect(manager.deactivate(id)).resolves.toEqual({
+      ok: true,
+      snapshotDataUrl: "data:image/jpeg;base64,c25hcHNob3Q=",
+    });
+  });
+
+  it("does not detach after a pending capture is superseded by reactivation", async () => {
+    let resolveCapture!: (value: string) => void;
+    const events: string[] = [];
+    const manager = new EmbedManager({
+      allowedOrigins: ["https://gw.test"],
+      createView: () => ({
+        setBounds: () => undefined,
+        setScale: () => undefined,
+        loadUrl: async () => undefined,
+        captureSnapshot: () => new Promise((resolve) => { resolveCapture = resolve; }),
+        attach: () => events.push("attach"),
+        detach: () => events.push("detach"),
+        destroy: () => undefined,
+      }),
+    });
+    const id = manager.open("hosted-shell", null, BOUNDS, "https://gw.test/canvas");
+    const pending = manager.deactivate(id);
+
+    manager.setActive(id, true);
+    resolveCapture("data:image/jpeg;base64,c25hcHNob3Q=");
+    await pending;
+
+    expect(events).toEqual(["attach"]);
+    expect(manager.liveCount).toBe(1);
+  });
+
+  it("detaches within a bounded time when native frame capture stalls", async () => {
+    vi.useFakeTimers();
+    const events: string[] = [];
+    const manager = new EmbedManager({
+      allowedOrigins: ["https://gw.test"],
+      createView: () => ({
+        setBounds: () => undefined,
+        setScale: () => undefined,
+        loadUrl: async () => undefined,
+        captureSnapshot: () => new Promise(() => undefined),
+        attach: () => events.push("attach"),
+        detach: () => events.push("detach"),
+        destroy: () => undefined,
+      }),
+    });
+    const id = manager.open("hosted-shell", null, BOUNDS, "https://gw.test/canvas");
+    const pending = manager.deactivate(id);
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(pending).resolves.toEqual({ ok: true, snapshotDataUrl: null });
+    expect(events).toEqual(["attach", "detach"]);
   });
 
   it("setActive(true) re-attaches a detached embed without reloading", () => {

--- a/tests/desktop/embed-service.test.ts
+++ b/tests/desktop/embed-service.test.ts
@@ -266,6 +266,50 @@ describe("EmbedService", () => {
     await vi.waitFor(() => expect(closeForward).toHaveBeenCalledOnce());
   });
 
+  it("keeps a pending Browser tunnel inactive when it finishes opening in the background", async () => {
+    let resolveForward!: (value: PortForwardHandle) => void;
+    const startPortForward = vi.fn(() => new Promise<PortForwardHandle>((resolve) => {
+      resolveForward = resolve;
+    }));
+    const service = new EmbedService({
+      getWindow: () => null,
+      getGatewayOrigin: () => "https://gateway.test",
+      getToken: () => "token",
+      emitState: vi.fn(),
+      startPortForward,
+    });
+    const internals = service as unknown as {
+      pendingBrowsers: Set<string>;
+      manager: { open: (...args: unknown[]) => string };
+    };
+    const open = vi.spyOn(internals.manager, "open").mockImplementation((...args) => (
+      (args[4] as { id: string }).id
+    ));
+
+    const opening = service.open({ kind: "browser", url: "127.0.0.1:3000", bounds: BOUNDS });
+    await vi.waitFor(() => expect(startPortForward).toHaveBeenCalledOnce());
+    const pendingId = Array.from(internals.pendingBrowsers)[0]!;
+    expect(service.setActive(pendingId, false)).toBe(true);
+    resolveForward({
+      localHost: "127.0.0.1",
+      localPort: 49152,
+      remoteHost: "127.0.0.1",
+      remotePort: 3000,
+      ready: Promise.resolve(),
+      closed: new Promise<void>(() => {}),
+      close: vi.fn(async () => {}),
+    });
+
+    await expect(opening).resolves.toMatchObject({ embedId: pendingId, state: "loading" });
+    expect(open).toHaveBeenCalledWith(
+      "browser",
+      null,
+      BOUNDS,
+      "http://127.0.0.1:49152/",
+      expect.objectContaining({ id: pendingId, active: false }),
+    );
+  });
+
   it("caps pending Browser tunnels", async () => {
     const startPortForward = vi.fn(() => new Promise<PortForwardHandle>(() => {}));
     const service = new EmbedService({
@@ -608,19 +652,23 @@ describe("EmbedService", () => {
     const internals = service as unknown as {
       pendingHostedShells: Map<string, Bounds>;
       pendingApps: Map<string, { slug: string; appIdentity: string; bounds: Bounds }>;
+      pendingBrowsers: Set<string>;
       pendingActive: Map<string, boolean>;
       manager: { suspendAll: () => boolean };
     };
     const suspendAll = vi.spyOn(internals.manager, "suspendAll").mockReturnValue(true);
     internals.pendingHostedShells.set("embed-shell", BOUNDS);
     internals.pendingApps.set("embed-app", { slug: "notes", appIdentity: "notes", bounds: BOUNDS });
+    internals.pendingBrowsers.add("embed-browser");
     internals.pendingActive.set("embed-shell", true);
     internals.pendingActive.set("embed-app", true);
+    internals.pendingActive.set("embed-browser", true);
 
     expect(service.suspendAll()).toBe(true);
     expect(suspendAll).toHaveBeenCalledOnce();
     expect(internals.pendingActive.get("embed-shell")).toBe(false);
     expect(internals.pendingActive.get("embed-app")).toBe(false);
+    expect(internals.pendingActive.get("embed-browser")).toBe(false);
   });
 
   it("schedules hosted-shell session refresh from the app-session cookie expiry", async () => {

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -44,6 +44,7 @@ describe("IPC contract", () => {
       "state:set",
       "embed:open",
       "embed:set-bounds",
+      "embed:deactivate",
       "embed:suspend-all",
       "embed:reload",
       "embed:close",
@@ -990,6 +991,16 @@ describe("IPC contract", () => {
     expect(schema.safeParse({ embedId: "e1", state: "loading" }).success).toBe(true);
     expect(schema.safeParse({ embedId: "e1" }).success).toBe(false);
     expect(schema.safeParse({ embedId: "e1", state: "auth-required", token: "secret" }).success).toBe(false);
+  });
+
+  it("bounds retained embed frames to local JPEG data URLs", () => {
+    const schema = INVOKE_CHANNELS["embed:deactivate"].response;
+    expect(schema.safeParse({
+      ok: true,
+      snapshotDataUrl: "data:image/jpeg;base64,c25hcHNob3Q=",
+    }).success).toBe(true);
+    expect(schema.safeParse({ ok: true, snapshotDataUrl: "https://example.com/private.png" }).success).toBe(false);
+    expect(schema.safeParse({ ok: false, snapshotDataUrl: null }).success).toBe(true);
   });
 
   it("requires kind-specific embed:open payloads", () => {

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -29,6 +29,7 @@ function makeHarness(overrides: Partial<HandlerContext> = {}) {
       open: vi.fn(),
       setBounds: vi.fn(),
       setActive: vi.fn(),
+      deactivate: vi.fn(),
       suspendAll: vi.fn(),
       reload: vi.fn(),
       close: vi.fn(),
@@ -214,6 +215,20 @@ describe("registerIpcHandlers", () => {
       bounds: { x: 360, y: 57, width: 920, height: 764 },
       active: true,
     });
+  });
+
+  it("captures and detaches an embed through one validated IPC operation", async () => {
+    const harness = makeHarness();
+    vi.mocked(harness.ctx.embeds.deactivate).mockResolvedValue({
+      ok: true,
+      snapshotDataUrl: "data:image/jpeg;base64,c25hcHNob3Q=",
+    });
+
+    await expect(harness.invoke("embed:deactivate", { embedId: "embed-1" })).resolves.toEqual({
+      ok: true,
+      snapshotDataUrl: "data:image/jpeg;base64,c25hcHNob3Q=",
+    });
+    expect(harness.ctx.embeds.deactivate).toHaveBeenCalledWith("embed-1");
   });
 
   it("routes Browser embeds with only the validated tunnel URL fields", async () => {

--- a/tests/desktop/tab-content.test.tsx
+++ b/tests/desktop/tab-content.test.tsx
@@ -69,6 +69,16 @@ describe("current desktop tab panes", () => {
     expect(terminalsTabMock).toHaveBeenLastCalledWith({ active: false, visible: false, visualScale: 1 }, undefined);
   });
 
+  it("keeps a visible background Chat live without giving it keyboard ownership", () => {
+    const tab: Tab = { id: "chat", kind: "chat", title: "Chat", closable: false };
+    render(<TabPane tab={tab} active={false} visible />);
+
+    expect(workTabMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ active: false, visible: true }),
+      undefined,
+    );
+  });
+
   it.each(["desktop", "canvas"] as const)("detaches native embeds under overlays in %s", (presentation) => {
     const tab: Tab = { id: "browser", kind: "home", title: "Browser", closable: false };
     const props = {

--- a/tests/desktop/web-contents-view.test.ts
+++ b/tests/desktop/web-contents-view.test.ts
@@ -73,6 +73,88 @@ describe("createWebContentsView", () => {
     );
   });
 
+  it("deduplicates overlapping retained-frame captures", async () => {
+    let resolveCapture: ((image: {
+      isEmpty: () => boolean;
+      toJPEG: () => Buffer;
+    }) => void) | null = null;
+    electronMock.webContents.capturePage.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveCapture = resolve;
+    }));
+    const view = createWebContentsView({
+      window: {
+        isDestroyed: () => false,
+        contentView: { addChildView: vi.fn(), removeChildView: vi.fn() },
+      } as never,
+      partition: "persist:browser",
+      allowedOrigins: ["https://gateway.test"],
+      onState: vi.fn(),
+    });
+
+    const first = view.captureSnapshot?.();
+    const second = view.captureSnapshot?.();
+    expect(electronMock.webContents.capturePage).toHaveBeenCalledOnce();
+    resolveCapture?.({
+      isEmpty: () => false,
+      toJPEG: () => Buffer.from("shared-frame"),
+    });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      `data:image/jpeg;base64,${Buffer.from("shared-frame").toString("base64")}`,
+      `data:image/jpeg;base64,${Buffer.from("shared-frame").toString("base64")}`,
+    ]);
+  });
+
+  it("caps the native capture rectangle before allocating a retained frame", async () => {
+    const view = createWebContentsView({
+      window: {
+        isDestroyed: () => false,
+        contentView: { addChildView: vi.fn(), removeChildView: vi.fn() },
+      } as never,
+      partition: "persist:browser",
+      allowedOrigins: ["https://gateway.test"],
+      onState: vi.fn(),
+    });
+    view.setBounds({ x: 20, y: 30, width: 16_384, height: 8_192 });
+
+    await view.captureSnapshot?.();
+
+    expect(electronMock.webContents.capturePage).toHaveBeenCalledWith({
+      x: 0,
+      y: 0,
+      width: 2_048,
+      height: 2_048,
+    });
+  });
+
+  it("does not retain a capture that finishes after a new page starts loading", async () => {
+    let resolveCapture: ((image: {
+      isEmpty: () => boolean;
+      toJPEG: () => Buffer;
+    }) => void) | null = null;
+    electronMock.webContents.capturePage.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveCapture = resolve;
+    }));
+    const view = createWebContentsView({
+      window: {
+        isDestroyed: () => false,
+        contentView: { addChildView: vi.fn(), removeChildView: vi.fn() },
+      } as never,
+      partition: "persist:browser",
+      allowedOrigins: ["https://gateway.test"],
+      onState: vi.fn(),
+    });
+
+    const staleCapture = view.captureSnapshot?.();
+    electronMock.handlers.get("did-start-loading")?.();
+    resolveCapture?.({
+      isEmpty: () => false,
+      toJPEG: () => Buffer.from("stale-frame"),
+    });
+
+    await expect(staleCapture).resolves.toBeNull();
+  });
+
   it("downscales an oversized frame instead of dropping the retained content", async () => {
     const resized = {
       isEmpty: () => false,

--- a/tests/desktop/web-contents-view.test.ts
+++ b/tests/desktop/web-contents-view.test.ts
@@ -17,6 +17,10 @@ const electronMock = vi.hoisted(() => {
     }),
     setWindowOpenHandler: vi.fn(),
     loadURL: vi.fn(async () => {}),
+    capturePage: vi.fn(async () => ({
+      isEmpty: () => false,
+      toJPEG: () => Buffer.from("retained-frame"),
+    })),
     isDestroyed: vi.fn(() => false),
     close: vi.fn(),
   };
@@ -44,6 +48,7 @@ beforeEach(() => {
   electronMock.shell.openExternal.mockClear();
   electronMock.webContents.setWindowOpenHandler.mockClear();
   electronMock.webContents.loadURL.mockClear();
+  electronMock.webContents.capturePage.mockClear();
   electronMock.webContents.isDestroyed.mockReset();
   electronMock.webContents.isDestroyed.mockReturnValue(false);
   electronMock.webContents.close.mockClear();
@@ -52,6 +57,72 @@ beforeEach(() => {
 });
 
 describe("createWebContentsView", () => {
+  it("captures a bounded JPEG frame for the detached renderer fallback", async () => {
+    const view = createWebContentsView({
+      window: {
+        isDestroyed: () => false,
+        contentView: { addChildView: vi.fn(), removeChildView: vi.fn() },
+      } as never,
+      partition: "persist:browser",
+      allowedOrigins: ["https://gateway.test"],
+      onState: vi.fn(),
+    });
+
+    await expect(view.captureSnapshot?.()).resolves.toBe(
+      `data:image/jpeg;base64,${Buffer.from("retained-frame").toString("base64")}`,
+    );
+  });
+
+  it("downscales an oversized frame instead of dropping the retained content", async () => {
+    const resized = {
+      isEmpty: () => false,
+      toJPEG: () => Buffer.from("bounded-frame"),
+      getSize: () => ({ width: 1344, height: 840 }),
+      resize: vi.fn(),
+    };
+    electronMock.webContents.capturePage.mockResolvedValueOnce({
+      isEmpty: () => false,
+      toJPEG: () => Buffer.alloc(3_000_001),
+      getSize: () => ({ width: 1920, height: 1200 }),
+      resize: vi.fn(() => resized),
+    });
+    const view = createWebContentsView({
+      window: {
+        isDestroyed: () => false,
+        contentView: { addChildView: vi.fn(), removeChildView: vi.fn() },
+      } as never,
+      partition: "persist:browser",
+      allowedOrigins: ["https://gateway.test"],
+      onState: vi.fn(),
+    });
+
+    await expect(view.captureSnapshot?.()).resolves.toBe(
+      `data:image/jpeg;base64,${Buffer.from("bounded-frame").toString("base64")}`,
+    );
+  });
+
+  it("falls back to the warmed frame when a later native capture is empty", async () => {
+    const view = createWebContentsView({
+      window: {
+        isDestroyed: () => false,
+        contentView: { addChildView: vi.fn(), removeChildView: vi.fn() },
+      } as never,
+      partition: "persist:browser",
+      allowedOrigins: ["https://gateway.test"],
+      onState: vi.fn(),
+    });
+    electronMock.handlers.get("did-finish-load")?.();
+    await vi.waitFor(() => expect(electronMock.webContents.capturePage).toHaveBeenCalledOnce());
+    electronMock.webContents.capturePage.mockResolvedValueOnce({
+      isEmpty: () => true,
+      toJPEG: vi.fn(),
+    });
+
+    await expect(view.captureSnapshot?.()).resolves.toBe(
+      `data:image/jpeg;base64,${Buffer.from("retained-frame").toString("base64")}`,
+    );
+  });
+
   it("detaches safely after the parent window has already been destroyed", () => {
     let windowDestroyed = false;
     const removeChildView = vi.fn(() => {

--- a/tests/desktop/web-contents-view.test.ts
+++ b/tests/desktop/web-contents-view.test.ts
@@ -20,6 +20,8 @@ const electronMock = vi.hoisted(() => {
     capturePage: vi.fn(async () => ({
       isEmpty: () => false,
       toJPEG: () => Buffer.from("retained-frame"),
+      getSize: () => ({ width: 1_280, height: 720 }),
+      resize: vi.fn(),
     })),
     isDestroyed: vi.fn(() => false),
     close: vi.fn(),
@@ -97,6 +99,8 @@ describe("createWebContentsView", () => {
     resolveCapture?.({
       isEmpty: () => false,
       toJPEG: () => Buffer.from("shared-frame"),
+      getSize: () => ({ width: 1_280, height: 720 }),
+      resize: vi.fn(),
     });
 
     await expect(Promise.all([first, second])).resolves.toEqual([
@@ -105,7 +109,20 @@ describe("createWebContentsView", () => {
     ]);
   });
 
-  it("caps the native capture rectangle before allocating a retained frame", async () => {
+  it("captures the full viewport before proportionally bounding a retained frame", async () => {
+    const resized = {
+      isEmpty: () => false,
+      toJPEG: () => Buffer.from("bounded-full-frame"),
+      getSize: () => ({ width: 2_048, height: 1_024 }),
+      resize: vi.fn(),
+    };
+    const resize = vi.fn(() => resized);
+    electronMock.webContents.capturePage.mockResolvedValueOnce({
+      isEmpty: () => false,
+      toJPEG: () => Buffer.from("full-frame"),
+      getSize: () => ({ width: 16_384, height: 8_192 }),
+      resize,
+    });
     const view = createWebContentsView({
       window: {
         isDestroyed: () => false,
@@ -119,11 +136,10 @@ describe("createWebContentsView", () => {
 
     await view.captureSnapshot?.();
 
-    expect(electronMock.webContents.capturePage).toHaveBeenCalledWith({
-      x: 0,
-      y: 0,
+    expect(electronMock.webContents.capturePage).toHaveBeenCalledWith();
+    expect(resize).toHaveBeenCalledWith({
       width: 2_048,
-      height: 2_048,
+      height: 1_024,
     });
   });
 


### PR DESCRIPTION
## Summary

- keep visible background Chat and Project Chat surfaces live without granting them keyboard interaction ownership
- capture and render a bounded retained frame while native Electron embeds are detached below overlapping renderer windows
- apply the shared native lifecycle to Browser, hosted Home, VS Code, and installed web apps, including pending Browser tunnel and reactivation races
- clear stale frames across content changes, deduplicate concurrent captures, preserve the complete viewport with proportional downscaling, and discard captures completed after navigation starts

Fixes [OM-208](https://linear.app/matrix-os/issue/OM-208/keep-obscured-desktop-app-content-visible-behind-overlapping-windows).

## Tests

- `flox activate -- bun run typecheck`
- focused Desktop typecheck
- `flox activate -- bun run check:patterns` (0 violations; 5 pre-existing warnings)
- 205 focused OM-208 Desktop tests passed
- `flox activate -- bun run test`: 13,275 passed, 21 skipped, 22 failed across 10 untouched baseline test files. The unrelated failures cover platform script snapshots/defaults, billing/runtime expectations, Todo date boundaries, and Terminal install handoff timeouts.
- `git diff --check`

## Human Review

Approved on 2026-09-04 after validating the Electron Desktop overlap and foreground restoration flow.

## Invariants

### Source of truth
- Native embed web contents remain the live source of truth; the retained JPEG is a bounded, ephemeral renderer fallback only while the native view is detached.
- Canonical Chat state and event streams remain authoritative; `live` controls lifecycle while `active` controls interaction ownership.

### Lock/transaction scope
- No database writes or transactions are introduced.
- Snapshot capture is bounded to 400 ms and guarded by activation and content generations so late captures cannot detach a reactivated view or repopulate stale content.
- Concurrent capture requests for the same content generation share one in-flight native capture.
- Large full-viewport frames are proportionally reduced to a 2,048-pixel maximum edge before bounded JPEG encoding.

### Acceptable orphan states
- Failed or oversized captures fall back to the last valid retained frame from the current content generation when available; otherwise the existing loading surface remains visible.
- Retained frames live only in embed manager/renderer memory and are released with the embed lifecycle.

### Auth source of truth
- Existing Electron IPC validation, native embed navigation policy, and Gateway authentication remain unchanged.
- Snapshot IPC accepts only a bounded local JPEG data URL produced by the main process.

### Deferred scope
- This change does not alter Files, Editor, Terminal, Settings, or React Notes because their renderer content already persists when obscured.
