### PR TITLE
feat(cli): add remote computer MCP

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/118-fix-terminal-clipboard"
+  "feature_directory": "specs/120-remote-computer-mcp"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,6 +477,8 @@ Read these on demand, not every session:
 - N/A; selection, context-menu snapshots, and clipboard operation state are transient and must not be persisted (118-fix-terminal-clipboard)
 - Node.js 24+, TypeScript 5.5+ strict, ES modules + Claude Agent SDK V1 `query()`/`resume`, Hono, Zod 4 (`zod/v4`), Kysely, PostgreSQL, Next.js 16, React 19, Cloudflare AI Gateway, OpenRouter OAuth/API (118-ai-gateway-provider-auth)
 - owner configuration/secret files for provider credentials; owner Postgres only if provider account orchestration needs durable multi-instance state; platform PostgreSQL/Kysely for later entitlements, reservations, and content-free usage records (118-ai-gateway-provider-auth)
+- TypeScript 5.9 strict, ES modules; Node.js 24 production target (published CLI remains compatible with Node.js 20+) + `@modelcontextprotocol/sdk` 1.29, Zod 4, citty, native Fetch/AbortSignal, existing Matrix CLI shell/file/profile clients (120-remote-computer-mcp)
+- No new storage; reads existing owner-scoped Matrix CLI profile/auth files and Matrix computer data (120-remote-computer-mcp)
 
 - TypeScript 5.5+ strict, ES modules + node-pty (backend), @xterm/xterm + addon-webgl + addon-search + addon-serialize + addon-fit (frontend), Hono WebSocket (gateway), Zod 4 (validation) (056-terminal-upgrade)
 - Files — `~/system/terminal-sessions.json` (session metadata), `~/system/terminal-layout.json` (layout with sessionId) (056-terminal-upgrade)
@@ -533,5 +535,5 @@ Five canonical roles using default label names. See `docs/agents/triage-labels.m
 Single-context: `CONTEXT.md` + `docs/adr/` at repo root. See `docs/agents/domain.md`.
 
 <!-- SPECKIT START -->
-Current Spec Kit plan: `specs/118-fix-terminal-clipboard/plan.md`.
+Current Spec Kit plan: `specs/120-remote-computer-mcp/plan.md`.
 <!-- SPECKIT END -->

--- a/packages/gateway/src/shell/routes.ts
+++ b/packages/gateway/src/shell/routes.ts
@@ -53,6 +53,7 @@ interface ShellWorkspaceRoutes {
   listTabs(name: string): Promise<unknown[]>;
   createTab(name: string, input: { name?: string; cwd?: string; cmd?: string }): Promise<unknown>;
   switchTab(name: string, tab: number): Promise<unknown>;
+  switchTabById?(name: string, tabId: number): Promise<unknown>;
   closeTab(name: string, tab: number): Promise<unknown>;
   splitPane(name: string, input: { direction: "right" | "down"; cwd?: string; cmd?: string }): Promise<unknown>;
   closePane(name: string, pane: string): Promise<unknown>;
@@ -453,6 +454,17 @@ export function createShellRoutes(deps: ShellRouteDeps): Hono {
       if (!deps.workspace) return unavailable(c, "workspace_unavailable");
       const tab = z.coerce.number().int().nonnegative().parse(c.req.param("tab"));
       await deps.workspace.switchTab(SafeSessionNameSchema.parse(c.req.param("name")), tab);
+      return c.json({ ok: true });
+    } catch (err) {
+      return safeError(c, err);
+    }
+  });
+
+  app.post("/sessions/:name/tabs/by-id/:tabId/go", workspaceBodyLimit, async (c) => {
+    try {
+      if (!deps.workspace?.switchTabById) return unavailable(c, "workspace_unavailable");
+      const tabId = z.coerce.number().int().nonnegative().parse(c.req.param("tabId"));
+      await deps.workspace.switchTabById(SafeSessionNameSchema.parse(c.req.param("name")), tabId);
       return c.json({ ok: true });
     } catch (err) {
       return safeError(c, err);

--- a/packages/gateway/src/shell/user-systemd-zellij-adapter.ts
+++ b/packages/gateway/src/shell/user-systemd-zellij-adapter.ts
@@ -260,6 +260,7 @@ export function createUserSystemdZellijAdapter(options: {
     listTabs: (name) => delegate(name, (adapter, sessionName) => adapter.listTabs(sessionName)),
     createTab: (name, input) => delegate(name, (adapter, sessionName) => adapter.createTab(sessionName, input)),
     switchTab: (name, tab) => delegate(name, (adapter, sessionName) => adapter.switchTab(sessionName, tab)),
+    switchTabById: (name, tabId) => delegate(name, (adapter, sessionName) => adapter.switchTabById(sessionName, tabId)),
     closeTab: (name, tab) => delegate(name, (adapter, sessionName) => adapter.closeTab(sessionName, tab)),
     splitPane: (name, input) => delegate(name, (adapter, sessionName) => adapter.splitPane(sessionName, input)),
     closePane: (name, pane) => delegate(name, (adapter, sessionName) => adapter.closePane(sessionName, pane)),

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -108,6 +108,7 @@ export interface ZellijAdapter {
   listTabs(name: string): Promise<unknown[]>;
   createTab(name: string, input: { name?: string; cwd?: string; cmd?: string }): Promise<unknown>;
   switchTab(name: string, tab: number): Promise<unknown>;
+  switchTabById(name: string, tabId: number): Promise<unknown>;
   closeTab(name: string, tab: number): Promise<unknown>;
   splitPane(name: string, input: { direction: "right" | "down"; cwd?: string; cmd?: string }): Promise<unknown>;
   closePane(name: string, pane: string): Promise<unknown>;
@@ -119,6 +120,12 @@ export interface ZellijAdapter {
 const ZellijTabInfoSchema = z.object({
   tab_id: z.number().int().nonnegative(),
 }).passthrough();
+const ZellijTabListSchema = z.array(z.object({
+  tab_id: z.number().int().nonnegative(),
+  position: z.number().int().nonnegative(),
+  name: z.string().min(1).max(64),
+  active: z.boolean(),
+}).passthrough()).max(1024);
 const ZellijPaneListSchema = z.array(z.object({
   is_plugin: z.boolean(),
   is_focused: z.boolean(),
@@ -593,23 +600,41 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
       await run(["--session", name, "action", "write-chars", "--", data]);
     },
     async listTabs(name) {
-      const stdout = await run(["--session", name, "action", "query-tab-names"]);
-      return stdout
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .filter(Boolean)
-        .map((tab, idx) => ({ idx, name: tab }));
+      const stdout = await run(["--session", name, "action", "list-tabs", "--json"]);
+      let raw: unknown;
+      try {
+        raw = JSON.parse(stdout);
+      } catch (err: unknown) {
+        if (!(err instanceof SyntaxError)) throw err;
+        throw shellError("zellij_failed", "Shell operation failed", 500);
+      }
+      const parsed = ZellijTabListSchema.safeParse(raw);
+      if (!parsed.success) throw shellError("zellij_failed", "Shell operation failed", 500);
+      return parsed.data.map((tab) => ({
+        id: tab.tab_id,
+        idx: tab.position,
+        name: tab.name,
+        focused: tab.active,
+      }));
     },
     async createTab(name, input) {
       const args = ["--session", name, "action", "new-tab"];
       if (input.name) args.push("--name", input.name);
       if (input.cwd) args.push("--cwd", input.cwd);
       if (input.cmd) args.push("--", ...splitCommand(input.cmd));
-      await run(args);
-      return { ok: true };
+      const stdout = await run(args);
+      const rawId = stdout.trim();
+      if (!/^\d+$/.test(rawId)) throw shellError("zellij_failed", "Shell operation failed", 500);
+      const id = Number(rawId);
+      if (!Number.isSafeInteger(id)) throw shellError("zellij_failed", "Shell operation failed", 500);
+      return { id, ...(input.name ? { name: input.name } : {}) };
     },
     async switchTab(name, tab) {
       await run(["--session", name, "action", "go-to-tab", String(tab)]);
+      return { ok: true };
+    },
+    async switchTabById(name, tabId) {
+      await run(["--session", name, "action", "go-to-tab-by-id", String(tabId)]);
       return { ok: true };
     },
     async closeTab(name, tab) {

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -8,6 +8,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { z } from "zod/v4";
 import { shellError, type ShellSafeError } from "./errors.js";
+import { resolveShellCwd } from "./names.js";
 import {
   MATRIX_TERMINAL_BASHRC,
   MATRIX_TERMINAL_PROMPT_LABEL_SCRIPT,
@@ -618,9 +619,10 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
       }));
     },
     async createTab(name, input) {
+      const tabCwd = deps.homePath ? await resolveShellCwd(input.cwd, deps.homePath) : input.cwd;
       const args = ["--session", name, "action", "new-tab"];
       if (input.name) args.push("--name", input.name);
-      if (input.cwd) args.push("--cwd", input.cwd);
+      if (tabCwd) args.push("--cwd", tabCwd);
       if (input.cmd) args.push("--", ...splitCommand(input.cmd));
       const stdout = await run(args);
       const rawId = stdout.trim();

--- a/packages/sync-client/README.md
+++ b/packages/sync-client/README.md
@@ -41,6 +41,7 @@ matrix run -it -- codex   # same shared zellij session primitive for Codex
 matrix run -it --session setup -- gh auth login
 matrix forward 5173       # forward a Matrix computer dev server to local loopback
 mos shell attach setup    # reattach the same session from local CLI or web terminal
+matrix mcp serve          # expose Matrix computers to a coding agent over stdio
 matrix peers              # list connected peers
 matrix logout             # clear local credentials
 ```
@@ -53,11 +54,36 @@ participates in gateway ownership, size coordination, and renderer revocation.
 See [Terminal session ownership](../../docs/dev/terminal-session-ownership.md)
 for supported clients and the single-gateway deployment constraint.
 
+## Coding-agent MCP
+
+The Matrix OS plugin starts `matrix mcp serve --profile cloud` automatically.
+For a manual MCP client configuration, run the same command as a local stdio
+server after `matrix login`. Credentials stay in the Matrix CLI profile and are
+never placed in MCP configuration or tool arguments.
+
+The server exposes tools to:
+
+- list owner-authorized computers and explicitly target a `runtimeSlot`;
+- run captured argv commands or work through persistent zellij terminals/tabs;
+- list, read, download, and upload bounded Matrix-home file content; and
+- list, search, and inspect Matrix chats without mutating them.
+
+`run_command` is best for short commands that need stdout, stderr, and exit
+status. Persistent terminal tools are best for long-running work the user wants
+to observe or reattach. MCP file download returns at most 1 MiB as base64 and
+does not write a local path; use `matrix download` for larger files.
+
+Every computer-scoped call requires the `runtimeSlot` returned by
+`list_computers`. The server never silently chooses a different computer. MCP
+also cannot disable a coding agent's built-in local shell; disable that host
+tool separately when enforcing a remote-only workflow.
+
 ## Requirements
 
 - Node.js 20 or newer for npm package runners and global npm installs
 - No Node.js install is required when using the standalone binary from `get.matrix-os.com`
 - A Matrix OS account — sign up at [app.matrix-os.com](https://app.matrix-os.com)
+- A coding-agent host with local stdio MCP support for `matrix mcp serve`
 
 ## License
 

--- a/packages/sync-client/README.md
+++ b/packages/sync-client/README.md
@@ -70,7 +70,8 @@ The server exposes tools to:
 
 `run_command` is best for short commands that need stdout, stderr, and exit
 status. Persistent terminal tools are best for long-running work the user wants
-to observe or reattach. MCP file download returns at most 1 MiB as base64 and
+to observe or reattach. Tab creation returns a stable tab ID, and tab selection
+uses that ID rather than the mutable display position. MCP file download returns at most 1 MiB as base64 and
 does not write a local path; use `matrix download` for larger files.
 
 Every computer-scoped call requires the `runtimeSlot` returned by

--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finnaai/matrix",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Matrix OS command-line client — login, sync, and peer management for matrix-os.com",
   "type": "module",
   "license": "AGPL-3.0-or-later",
@@ -57,6 +57,7 @@
     "build:binaries": "node ./scripts/build-binaries.mjs"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "chokidar": "^4.0.0",
     "citty": "^0.2.2",
     "node-diff3": "^3.2.0",

--- a/packages/sync-client/scripts/check-publish.mjs
+++ b/packages/sync-client/scripts/check-publish.mjs
@@ -11,6 +11,9 @@ const pkgRoot = resolve(here, '..');
 const mustExist = [
   'bin/matrix.mjs',
   'src/cli/index.ts',
+  'src/cli/commands/mcp.ts',
+  'src/mcp/server.ts',
+  'src/mcp/clients.ts',
   'src/daemon/index.ts',
   'src/index.ts',
   'src/lib/find-tsx-loader.mjs',

--- a/packages/sync-client/src/cli/commands/mcp.ts
+++ b/packages/sync-client/src/cli/commands/mcp.ts
@@ -1,0 +1,41 @@
+import { defineCommand } from "citty";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createMatrixMcpServer } from "../../mcp/server.js";
+
+const serveCommand = defineCommand({
+  meta: {
+    name: "serve",
+    description: "Start the Matrix remote-computer MCP server over stdio",
+  },
+  args: {
+    profile: {
+      type: "string",
+      required: false,
+      description: "Matrix CLI profile to use (default: active profile)",
+    },
+  },
+  run: async ({ args }) => {
+    const server = createMatrixMcpServer({
+      profileName: typeof args.profile === "string" ? args.profile : undefined,
+      apiOrigin: process.env.MATRIXOS_API_URL,
+    });
+    try {
+      await server.connect(new StdioServerTransport());
+    } catch (error: unknown) {
+      console.error("Matrix MCP server failed to start.", error instanceof Error ? error.name : "UnknownError");
+      process.exitCode = 1;
+    }
+  },
+});
+
+export const mcpCommand = defineCommand({
+  meta: {
+    name: "mcp",
+    description: "Expose Matrix computers to coding agents over MCP",
+  },
+  subCommands: { serve: serveCommand },
+  run: () => {
+    console.error("Usage: matrix mcp serve [--profile <name>]");
+    process.exitCode = 1;
+  },
+});

--- a/packages/sync-client/src/cli/commands/mcp.ts
+++ b/packages/sync-client/src/cli/commands/mcp.ts
@@ -34,8 +34,4 @@ export const mcpCommand = defineCommand({
     description: "Expose Matrix computers to coding agents over MCP",
   },
   subCommands: { serve: serveCommand },
-  run: () => {
-    console.error("Usage: matrix mcp serve [--profile <name>]");
-    process.exitCode = 1;
-  },
 });

--- a/packages/sync-client/src/cli/index.ts
+++ b/packages/sync-client/src/cli/index.ts
@@ -11,6 +11,7 @@ import { instanceCommand } from "./commands/instance.js";
 import { whoamiCommand } from "./commands/whoami.js";
 import { statusCommand } from "./commands/status.js";
 import { completionCommand } from "./commands/completion.js";
+import { mcpCommand } from "./commands/mcp.js";
 import { runCommand } from "./commands/run.js";
 import { uploadCommand } from "./commands/upload.js";
 import { downloadCommand } from "./commands/download.js";
@@ -41,6 +42,7 @@ const subCommands = {
   doctor: doctorCommand,
   instance: instanceCommand,
   completion: completionCommand,
+  mcp: mcpCommand,
 };
 
 const main = defineCommand({

--- a/packages/sync-client/src/mcp/clients.ts
+++ b/packages/sync-client/src/mcp/clients.ts
@@ -1,0 +1,386 @@
+import { basename } from "node:path";
+import { z } from "zod/v4";
+import { createMcpError, type SafeMcpErrorCode } from "./errors.js";
+import { runtimeApiUrl, type MatrixMcpRuntime } from "./profile-context.js";
+import {
+  MCP_CHAT_MAX_ITEMS,
+  MCP_DIRECTORY_MAX_ENTRIES,
+  MCP_FILE_MAX_BYTES,
+  MCP_TEXT_FILE_MAX_BYTES,
+} from "./schemas.js";
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const COMMAND_RESPONSE_GRACE_MS = 30_000;
+const JSON_RESPONSE_MAX_BYTES = 4 * 1024 * 1024;
+const SAFE_JSON_MAX_DEPTH = 12;
+const SENSITIVE_KEY = /(?:authorization|cookie|password|secret|token)/i;
+
+const TerminalSchema = z.object({
+  name: z.string().min(1).max(64),
+  canonicalName: z.string().min(1).max(64).optional(),
+  status: z.enum(["active", "exited"]).optional(),
+  createdAt: z.string().max(64).optional(),
+  updatedAt: z.string().max(64).optional(),
+  attachedClients: z.number().int().nonnegative().max(10_000).optional(),
+  placement: z.enum(["active", "background"]).optional(),
+  visualStatus: z.enum(["running", "finished", "idle", "waiting"]).optional(),
+  agent: z.enum(["claude", "codex", "opencode", "pi"]).optional(),
+  cwd: z.string().max(4096).optional(),
+  pinned: z.boolean().optional(),
+  recoverable: z.boolean().optional(),
+}).strip();
+
+const TabSchema = z.object({
+  idx: z.number().int().nonnegative().max(1024),
+  name: z.string().min(1).max(64).optional(),
+  focused: z.boolean().optional(),
+  createdAt: z.string().max(64).optional(),
+}).strip();
+
+const FileEntrySchema = z.object({
+  name: z.string().min(1).max(255).refine((value) => !/[\0\r\n/\\]/.test(value)),
+  type: z.enum(["file", "directory"]),
+  size: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER).optional(),
+  gitStatus: z.string().max(32).nullable().optional(),
+  changedCount: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER).optional(),
+  modified: z.string().max(64).optional(),
+  created: z.string().max(64).optional(),
+  mime: z.string().max(160).optional(),
+  children: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER).optional(),
+}).strip();
+
+const RunResultSchema = z.object({
+  stdout: z.string().max(1024 * 1024),
+  stderr: z.string().max(1024 * 1024),
+  exitCode: z.number().int().nullable(),
+  signal: z.string().max(32).nullable(),
+  timedOut: z.boolean(),
+  truncated: z.boolean(),
+  durationMs: z.number().nonnegative().max(31 * 60 * 1000),
+}).strict().superRefine((result, ctx) => {
+  if (Buffer.byteLength(result.stdout, "utf8") + Buffer.byteLength(result.stderr, "utf8") > MCP_FILE_MAX_BYTES) {
+    ctx.addIssue({ code: "custom", message: "Command output exceeds byte limit" });
+  }
+});
+
+const CreateTerminalResultSchema = z.object({
+  name: z.string().min(1).max(64),
+  created: z.literal(true),
+}).strict();
+
+const CreateTabResultSchema = z.object({
+  tab: z.object({ ok: z.literal(true) }).strict(),
+}).strict();
+
+const UploadResultSchema = z.object({
+  ok: z.literal(true),
+  path: z.string().min(1).max(4096),
+  size: z.number().int().nonnegative().max(MCP_FILE_MAX_BYTES),
+}).strict();
+
+export interface McpGatewayClientOptions {
+  fetch?: typeof fetch;
+}
+
+export interface MatrixMcpGatewayClient {
+  listTerminals(): Promise<unknown[]>;
+  createTerminal(input: { name: string; cwd?: string }): Promise<unknown>;
+  listTabs(terminal: string): Promise<unknown[]>;
+  createTab(terminal: string, input: { name?: string; cwd?: string }): Promise<unknown>;
+  selectTab(terminal: string, tab: number): Promise<void>;
+  sendTerminalInput(terminal: string, data: string): Promise<void>;
+  runCommand(input: { command: string[]; cwd?: string; timeoutMs?: number }): Promise<z.infer<typeof RunResultSchema>>;
+  listFiles(path: string): Promise<unknown[]>;
+  readFile(path: string): Promise<{ content: string; size: number; mediaType: string }>;
+  downloadFile(path: string): Promise<{ bytes: Buffer; size: number; mediaType: string; filename: string }>;
+  uploadFile(path: string, bytes: Buffer, options: { overwrite: boolean; secret: boolean }): Promise<z.infer<typeof UploadResultSchema>>;
+  listChats(input: { limit: number; lifecycle?: "active" | "archived"; projectId?: string; cursor?: string }): Promise<unknown>;
+  searchChats(input: { query: string; limit: number; projectId?: string }): Promise<unknown>;
+  getChat(input: { chatId: string; limit: number; cursor?: string }): Promise<unknown>;
+}
+
+function errorCodeForStatus(status: number): SafeMcpErrorCode {
+  if (status === 400 || status === 422) return "invalid_input";
+  if (status === 401 || status === 403) return "auth_required";
+  if (status === 404) return "not_found";
+  if (status === 409) return "conflict";
+  if (status === 413) return "payload_too_large";
+  return "request_failed";
+}
+
+function requestError(error: unknown) {
+  return error instanceof DOMException && (error.name === "AbortError" || error.name === "TimeoutError")
+    ? createMcpError("request_timeout")
+    : createMcpError("request_failed");
+}
+
+function contentLength(response: Response): number | null {
+  const raw = response.headers.get("content-length");
+  if (raw === null) return null;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+async function boundedBytes(response: Response, maxBytes: number): Promise<Buffer> {
+  const declared = contentLength(response);
+  if (declared !== null && declared > maxBytes) throw createMcpError("payload_too_large");
+  const reader = response.body?.getReader();
+  if (!reader) return Buffer.alloc(0);
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      throw createMcpError("payload_too_large");
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)), total);
+}
+
+async function boundedJson(response: Response): Promise<unknown> {
+  const bytes = await boundedBytes(response, JSON_RESPONSE_MAX_BYTES);
+  try {
+    return JSON.parse(bytes.toString("utf8")) as unknown;
+  } catch (err: unknown) {
+    if (!(err instanceof SyntaxError)) throw err;
+    throw createMcpError("request_failed");
+  }
+}
+
+function sanitizeJson(value: unknown, depth = 0): unknown {
+  if (depth > SAFE_JSON_MAX_DEPTH) return "[depth limit]";
+  if (value === null || typeof value === "boolean" || typeof value === "number") return value;
+  if (typeof value === "string") return value.slice(0, 128 * 1024);
+  if (Array.isArray(value)) return value.slice(0, 500).map((item) => sanitizeJson(item, depth + 1));
+  if (typeof value !== "object") return null;
+  const safe: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value).slice(0, 500)) {
+    if (key.length > 160 || SENSITIVE_KEY.test(key)) continue;
+    safe[key] = sanitizeJson(item, depth + 1);
+  }
+  return safe;
+}
+
+function safeChatList(payload: unknown): Record<string, unknown> {
+  if (!payload || typeof payload !== "object") {
+    throw createMcpError("request_failed");
+  }
+  const source = payload as Record<string, unknown>;
+  const items = source.items;
+  if (!Array.isArray(items)) throw createMcpError("request_failed");
+  const nextCursor = typeof source.nextCursor === "string" && /^chatcur_[A-Za-z0-9_-]+$/.test(source.nextCursor)
+    ? source.nextCursor.slice(0, 512)
+    : undefined;
+  return {
+    items: items.slice(0, MCP_CHAT_MAX_ITEMS).map((item) => sanitizeJson(item)),
+    ...(nextCursor ? { nextCursor } : {}),
+  };
+}
+
+function safeChatDetail(payload: unknown): Record<string, unknown> {
+  if (!payload || typeof payload !== "object") throw createMcpError("request_failed");
+  const source = payload as Record<string, unknown>;
+  if (!source.record || typeof source.record !== "object" || !Array.isArray(source.messages)) {
+    throw createMcpError("request_failed");
+  }
+  const nextCursor = typeof source.nextCursor === "string" && /^chatcur_[A-Za-z0-9_-]+$/.test(source.nextCursor)
+    ? source.nextCursor.slice(0, 512)
+    : undefined;
+  return {
+    record: sanitizeJson(source.record),
+    messages: source.messages.slice(0, MCP_CHAT_MAX_ITEMS).map((message) => sanitizeJson(message)),
+    ...(nextCursor ? { nextCursor } : {}),
+  };
+}
+
+function parseEnvelopeArray(payload: unknown, key: string, schema: z.ZodType): unknown[] {
+  if (!payload || typeof payload !== "object" || !(key in payload)) throw createMcpError("request_failed");
+  const value = (payload as Record<string, unknown>)[key];
+  if (!Array.isArray(value)) throw createMcpError("request_failed");
+  const parsed = value.slice(0, MCP_DIRECTORY_MAX_ENTRIES).map((item) => schema.safeParse(item));
+  if (parsed.some((item) => !item.success)) throw createMcpError("request_failed");
+  return parsed.map((item) => item.data);
+}
+
+export function createMcpGatewayClient(
+  runtime: MatrixMcpRuntime,
+  options: McpGatewayClientOptions = {},
+): MatrixMcpGatewayClient {
+  const fetchImpl = options.fetch ?? fetch;
+
+  function urlFor(apiPath: string, query?: Record<string, string | undefined>): string {
+    const url = new URL(runtimeApiUrl(runtime.gatewayUrl, apiPath));
+    for (const [key, value] of Object.entries(query ?? {})) {
+      if (value !== undefined) url.searchParams.set(key, value);
+    }
+    return url.toString();
+  }
+
+  async function request(
+    apiPath: string,
+    init: RequestInit = {},
+    options: { timeoutMs?: number; query?: Record<string, string | undefined> } = {},
+  ): Promise<unknown> {
+    const headers = new Headers(init.headers);
+    headers.set("Authorization", `Bearer ${runtime.token}`);
+    if (init.body !== undefined && !headers.has("Content-Type")) headers.set("Content-Type", "application/json");
+    let response: Response;
+    try {
+      response = await fetchImpl(urlFor(apiPath, options.query), {
+        ...init,
+        headers: Object.fromEntries(headers.entries()),
+        signal: AbortSignal.timeout(options.timeoutMs ?? REQUEST_TIMEOUT_MS),
+      });
+    } catch (err: unknown) {
+      throw requestError(err);
+    }
+    if (!response.ok) throw createMcpError(errorCodeForStatus(response.status));
+    return boundedJson(response);
+  }
+
+  async function requestBytes(
+    apiPath: string,
+    options: { timeoutMs: number; query?: Record<string, string | undefined>; maxBytes: number },
+  ): Promise<{ bytes: Buffer; mediaType: string }> {
+    let response: Response;
+    try {
+      response = await fetchImpl(urlFor(apiPath, options.query), {
+        headers: { Authorization: `Bearer ${runtime.token}` },
+        signal: AbortSignal.timeout(options.timeoutMs),
+      });
+    } catch (err: unknown) {
+      throw requestError(err);
+    }
+    if (!response.ok) throw createMcpError(errorCodeForStatus(response.status));
+    return {
+      bytes: await boundedBytes(response, options.maxBytes),
+      mediaType: response.headers.get("content-type")?.slice(0, 160) || "application/octet-stream",
+    };
+  }
+
+  return {
+    async listTerminals() {
+      return parseEnvelopeArray(await request("/api/terminal/sessions"), "sessions", TerminalSchema);
+    },
+    async createTerminal(input) {
+      const payload = await request("/api/terminal/sessions", { method: "POST", body: JSON.stringify(input) });
+      const parsed = CreateTerminalResultSchema.safeParse(payload);
+      if (!parsed.success) throw createMcpError("request_failed");
+      return parsed.data;
+    },
+    async listTabs(terminal) {
+      return parseEnvelopeArray(
+        await request(`/api/terminal/sessions/${encodeURIComponent(terminal)}/tabs`),
+        "tabs",
+        TabSchema,
+      );
+    },
+    async createTab(terminal, input) {
+      const payload = await request(`/api/terminal/sessions/${encodeURIComponent(terminal)}/tabs`, {
+        method: "POST",
+        body: JSON.stringify(input),
+      });
+      const parsed = CreateTabResultSchema.safeParse(payload);
+      if (!parsed.success) throw createMcpError("request_failed");
+      return { created: true };
+    },
+    async selectTab(terminal, tab) {
+      await request(`/api/terminal/sessions/${encodeURIComponent(terminal)}/tabs/${tab}/go`, { method: "POST" });
+    },
+    async sendTerminalInput(terminal, data) {
+      await request(`/api/terminal/sessions/${encodeURIComponent(terminal)}/input`, {
+        method: "POST",
+        body: JSON.stringify({ data }),
+      });
+    },
+    async runCommand(input) {
+      const payload = await request("/api/terminal/run", {
+        method: "POST",
+        body: JSON.stringify(input),
+      }, { timeoutMs: (input.timeoutMs ?? 10 * 60 * 1000) + COMMAND_RESPONSE_GRACE_MS });
+      const parsed = RunResultSchema.safeParse(payload);
+      if (!parsed.success) throw createMcpError("request_failed");
+      return parsed.data;
+    },
+    async listFiles(path) {
+      return parseEnvelopeArray(
+        await request("/api/files/list", {}, { query: { path } }),
+        "entries",
+        FileEntrySchema,
+      ).slice(0, MCP_DIRECTORY_MAX_ENTRIES);
+    },
+    async readFile(path) {
+      const result = await requestBytes("/api/files/blob", {
+        query: { path },
+        maxBytes: MCP_TEXT_FILE_MAX_BYTES,
+        timeoutMs: REQUEST_TIMEOUT_MS,
+      });
+      let content: string;
+      try {
+        content = new TextDecoder("utf-8", { fatal: true }).decode(result.bytes);
+      } catch (err: unknown) {
+        if (!(err instanceof TypeError)) throw err;
+        throw createMcpError("invalid_input");
+      }
+      return { content, size: result.bytes.byteLength, mediaType: result.mediaType };
+    },
+    async downloadFile(path) {
+      const downloaded = await requestBytes("/api/files/blob", {
+        query: { path },
+        maxBytes: MCP_FILE_MAX_BYTES,
+        timeoutMs: 30_000,
+      });
+      return {
+        bytes: downloaded.bytes,
+        size: downloaded.bytes.byteLength,
+        mediaType: downloaded.mediaType,
+        filename: basename(path),
+      };
+    },
+    async uploadFile(path, bytes, uploadOptions) {
+      const payload = await request("/api/files/blob", {
+        method: "PUT",
+        headers: { "Content-Type": "application/octet-stream" },
+        body: new Uint8Array(bytes),
+      }, {
+        timeoutMs: 30_000,
+        query: {
+          path,
+          force: uploadOptions.overwrite ? "true" : undefined,
+          secret: uploadOptions.secret ? "true" : undefined,
+        },
+      });
+      const parsed = UploadResultSchema.safeParse(payload);
+      if (!parsed.success) throw createMcpError("request_failed");
+      return parsed.data;
+    },
+    async listChats(input) {
+      const payload = await request("/api/chats", {}, { query: {
+        limit: String(input.limit),
+        lifecycle: input.lifecycle,
+        projectId: input.projectId,
+        cursor: input.cursor,
+      } });
+      return safeChatList(payload);
+    },
+    async searchChats(input) {
+      const payload = await request("/api/chats/search", {}, { query: {
+        query: input.query,
+        limit: String(input.limit),
+        projectId: input.projectId,
+      } });
+      return safeChatList(payload);
+    },
+    async getChat(input) {
+      const payload = await request(`/api/chats/${encodeURIComponent(input.chatId)}`, {}, { query: {
+        limit: String(Math.min(input.limit, MCP_CHAT_MAX_ITEMS)),
+        cursor: input.cursor,
+      } });
+      return safeChatDetail(payload);
+    },
+  };
+}

--- a/packages/sync-client/src/mcp/clients.ts
+++ b/packages/sync-client/src/mcp/clients.ts
@@ -31,6 +31,7 @@ const TerminalSchema = z.object({
 }).strip();
 
 const TabSchema = z.object({
+  id: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
   idx: z.number().int().nonnegative().max(1024),
   name: z.string().min(1).max(64).optional(),
   focused: z.boolean().optional(),
@@ -69,7 +70,10 @@ const CreateTerminalResultSchema = z.object({
 }).strict();
 
 const CreateTabResultSchema = z.object({
-  tab: z.object({ ok: z.literal(true) }).strict(),
+  tab: z.object({
+    id: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+    name: z.string().min(1).max(64).optional(),
+  }).strict(),
 }).strict();
 
 const UploadResultSchema = z.object({
@@ -87,7 +91,7 @@ export interface MatrixMcpGatewayClient {
   createTerminal(input: { name: string; cwd?: string }): Promise<unknown>;
   listTabs(terminal: string): Promise<unknown[]>;
   createTab(terminal: string, input: { name?: string; cwd?: string }): Promise<unknown>;
-  selectTab(terminal: string, tab: number): Promise<void>;
+  selectTab(terminal: string, tabId: number): Promise<void>;
   sendTerminalInput(terminal: string, data: string): Promise<void>;
   runCommand(input: { command: string[]; cwd?: string; timeoutMs?: number }): Promise<z.infer<typeof RunResultSchema>>;
   listFiles(path: string): Promise<unknown[]>;
@@ -286,10 +290,10 @@ export function createMcpGatewayClient(
       });
       const parsed = CreateTabResultSchema.safeParse(payload);
       if (!parsed.success) throw createMcpError("request_failed");
-      return { created: true };
+      return parsed.data.tab;
     },
-    async selectTab(terminal, tab) {
-      await request(`/api/terminal/sessions/${encodeURIComponent(terminal)}/tabs/${tab}/go`, { method: "POST" });
+    async selectTab(terminal, tabId) {
+      await request(`/api/terminal/sessions/${encodeURIComponent(terminal)}/tabs/by-id/${tabId}/go`, { method: "POST" });
     },
     async sendTerminalInput(terminal, data) {
       await request(`/api/terminal/sessions/${encodeURIComponent(terminal)}/input`, {

--- a/packages/sync-client/src/mcp/clients.ts
+++ b/packages/sync-client/src/mcp/clients.ts
@@ -237,6 +237,7 @@ export function createMcpGatewayClient(
       response = await fetchImpl(urlFor(apiPath, options.query), {
         ...init,
         headers: Object.fromEntries(headers.entries()),
+        redirect: "error",
         signal: AbortSignal.timeout(options.timeoutMs ?? REQUEST_TIMEOUT_MS),
       });
     } catch (err: unknown) {
@@ -254,6 +255,7 @@ export function createMcpGatewayClient(
     try {
       response = await fetchImpl(urlFor(apiPath, options.query), {
         headers: { Authorization: `Bearer ${runtime.token}` },
+        redirect: "error",
         signal: AbortSignal.timeout(options.timeoutMs),
       });
     } catch (err: unknown) {

--- a/packages/sync-client/src/mcp/errors.ts
+++ b/packages/sync-client/src/mcp/errors.ts
@@ -1,0 +1,73 @@
+export type SafeMcpErrorCode =
+  | "invalid_input"
+  | "auth_required"
+  | "computer_not_found"
+  | "computer_unavailable"
+  | "not_found"
+  | "conflict"
+  | "payload_too_large"
+  | "request_timeout"
+  | "request_failed";
+
+export interface SafeMcpError {
+  code: SafeMcpErrorCode;
+  message: string;
+  retryable: boolean;
+}
+
+const ERRORS: Record<SafeMcpErrorCode, Omit<SafeMcpError, "code">> = {
+  invalid_input: { message: "The Matrix tool input is invalid.", retryable: false },
+  auth_required: { message: "Authenticate with the Matrix CLI and try again.", retryable: false },
+  computer_not_found: { message: "That Matrix computer is not available to this account.", retryable: false },
+  computer_unavailable: { message: "That Matrix computer is not currently available.", retryable: true },
+  not_found: { message: "The requested Matrix resource was not found.", retryable: false },
+  conflict: { message: "The Matrix resource already exists or changed.", retryable: false },
+  payload_too_large: { message: "The Matrix tool payload exceeds its size limit.", retryable: false },
+  request_timeout: { message: "The Matrix request timed out.", retryable: true },
+  request_failed: { message: "Matrix could not complete the request.", retryable: true },
+};
+
+const CODE_MAP: Record<string, SafeMcpErrorCode> = {
+  auth_expired: "auth_required",
+  auth_rejected: "auth_required",
+  not_authenticated: "auth_required",
+  computer_not_found: "computer_not_found",
+  computer_unavailable: "computer_unavailable",
+  invalid_input: "invalid_input",
+  invalid_remote_path: "invalid_input",
+  remote_file_not_found: "not_found",
+  not_found: "not_found",
+  remote_file_exists: "conflict",
+  conflict: "conflict",
+  payload_too_large: "payload_too_large",
+  request_timeout: "request_timeout",
+};
+
+export function createMcpError(code: SafeMcpErrorCode): Error & { code: SafeMcpErrorCode } {
+  return Object.assign(new Error(code), { code });
+}
+
+export function toSafeMcpError(error: unknown): SafeMcpError {
+  if (error instanceof ZodError) {
+    return { code: "invalid_input", ...ERRORS.invalid_input };
+  }
+  const rawCode = error instanceof Error && "code" in error
+    ? String((error as Error & { code?: unknown }).code)
+    : "";
+  const code = CODE_MAP[rawCode] ?? "request_failed";
+  return { code, ...ERRORS[code] };
+}
+
+export function safeErrorResult(error: unknown) {
+  return {
+    isError: true,
+    content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: toSafeMcpError(error) }) }],
+  };
+}
+
+export function jsonResult(value: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(value) }],
+  };
+}
+import { ZodError } from "zod/v4";

--- a/packages/sync-client/src/mcp/errors.ts
+++ b/packages/sync-client/src/mcp/errors.ts
@@ -28,6 +28,7 @@ const ERRORS: Record<SafeMcpErrorCode, Omit<SafeMcpError, "code">> = {
 };
 
 const CODE_MAP: Record<string, SafeMcpErrorCode> = {
+  auth_required: "auth_required",
   auth_expired: "auth_required",
   auth_rejected: "auth_required",
   not_authenticated: "auth_required",

--- a/packages/sync-client/src/mcp/profile-context.ts
+++ b/packages/sync-client/src/mcp/profile-context.ts
@@ -173,6 +173,7 @@ export function createMcpProfileContext(options: McpProfileContextOptions = {}):
     try {
       response = await fetchImpl(url, {
         headers: { Authorization: `Bearer ${context.auth.accessToken}` },
+        redirect: "error",
         signal: AbortSignal.timeout(PROFILE_REQUEST_TIMEOUT_MS),
       });
     } catch (err: unknown) {
@@ -214,6 +215,7 @@ export function createMcpProfileContext(options: McpProfileContextOptions = {}):
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ slot }),
+        redirect: "error",
         signal: AbortSignal.timeout(PROFILE_REQUEST_TIMEOUT_MS),
       });
     } catch (err: unknown) {

--- a/packages/sync-client/src/mcp/profile-context.ts
+++ b/packages/sync-client/src/mcp/profile-context.ts
@@ -1,0 +1,240 @@
+import { z } from "zod/v4";
+import { isExpired, loadProfileAuth, type AuthData } from "../auth/token-store.js";
+import { resolveCliProfile, type ResolvedCliProfile } from "../cli/profiles.js";
+import { createMcpError } from "./errors.js";
+import { RuntimeSlotSchema } from "./schemas.js";
+
+const PROFILE_REQUEST_TIMEOUT_MS = 10_000;
+const PROFILE_RESPONSE_MAX_BYTES = 128 * 1024;
+
+const ComputerSchema = z.object({
+  handle: z.string().min(2).max(63).regex(/^[a-z0-9][a-z0-9-]{1,62}$/),
+  runtimeSlot: RuntimeSlotSchema,
+  label: z.enum(["Main Computer", "Preview Computer", "Additional Computer"]),
+  availability: z.enum(["available", "starting", "unavailable"]),
+  kind: z.enum(["customer", "preview"]),
+  versionLabel: z.string().min(1).max(64).optional(),
+  gatewayPath: z.string().min(6).max(108),
+  capabilities: z.array(z.string().min(1).max(80).regex(/^[a-z][A-Za-z0-9]{0,79}$/)).max(64),
+}).strict().superRefine((computer, ctx) => {
+  const expected = computer.runtimeSlot === "primary"
+    ? `/vm/${computer.handle}`
+    : `/vm/${computer.handle}?runtime=${computer.runtimeSlot}`;
+  if (computer.gatewayPath !== expected) {
+    ctx.addIssue({ code: "custom", path: ["gatewayPath"], message: "Invalid gateway path" });
+  }
+});
+
+const ComputerListSchema = z.object({
+  items: z.array(ComputerSchema).max(20),
+  hasMore: z.boolean(),
+  limit: z.number().int().min(1).max(20),
+  selectedSlot: RuntimeSlotSchema.nullable(),
+}).strict().superRefine((inventory, ctx) => {
+  if (inventory.items.length > inventory.limit) {
+    ctx.addIssue({ code: "custom", path: ["items"], message: "Inventory limit exceeded" });
+  }
+  if (new Set(inventory.items.map((item) => item.runtimeSlot)).size !== inventory.items.length) {
+    ctx.addIssue({ code: "custom", path: ["items"], message: "Duplicate runtime slot" });
+  }
+  if (inventory.selectedSlot !== null
+    && !inventory.items.some((item) => item.runtimeSlot === inventory.selectedSlot)) {
+    ctx.addIssue({ code: "custom", path: ["selectedSlot"], message: "Selected runtime is not present" });
+  }
+});
+
+const RuntimeSelectionSchema = z.object({
+  accessToken: z.string().min(32).max(8192),
+  expiresAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+  handle: ComputerSchema.shape.handle,
+  slot: RuntimeSlotSchema,
+}).strict();
+
+export type MatrixMcpComputer = z.infer<typeof ComputerSchema>;
+export type MatrixMcpComputerList = z.infer<typeof ComputerListSchema>;
+
+export interface MatrixMcpRuntime {
+  computer: MatrixMcpComputer;
+  gatewayUrl: string;
+  token: string;
+}
+
+export interface McpProfileContext {
+  listComputers(): Promise<MatrixMcpComputerList>;
+  resolveRuntime(runtimeSlot: string): Promise<MatrixMcpRuntime>;
+}
+
+export interface McpProfileContextOptions {
+  profileName?: string;
+  configDir?: string;
+  apiOrigin?: string;
+  fetch?: typeof fetch;
+}
+
+interface PrincipalContext {
+  profile: ResolvedCliProfile;
+  auth: AuthData;
+}
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function assertCredentialOrigin(url: URL): void {
+  const loopback = url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]";
+  if ((url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) || url.username || url.password) {
+    throw createMcpError("invalid_input");
+  }
+}
+
+export function resolveRuntimeSelectionOrigin(platformUrl: string, override?: string): string {
+  const base = new URL(override ?? platformUrl);
+  assertCredentialOrigin(base);
+  if (!override && base.hostname === "app.matrix-os.com") {
+    base.hostname = "api.matrix-os.com";
+  }
+  base.pathname = "/";
+  base.search = "";
+  base.hash = "";
+  return stripTrailingSlash(base.toString());
+}
+
+export function runtimeApiUrl(gatewayUrl: string, apiPath: string): string {
+  if (!apiPath.startsWith("/api/") || apiPath.includes("?") || apiPath.includes("#")) {
+    throw createMcpError("invalid_input");
+  }
+  const url = new URL(gatewayUrl);
+  assertCredentialOrigin(url);
+  const runtimePath = url.pathname.replace(/\/+$/, "");
+  url.pathname = `${runtimePath}${apiPath}`;
+  return url.toString();
+}
+
+function gatewayForComputer(profile: ResolvedCliProfile, computer: MatrixMcpComputer): string {
+  const origin = new URL(profile.gatewayUrl);
+  origin.pathname = "/";
+  origin.search = "";
+  origin.hash = "";
+  return new URL(computer.gatewayPath, origin).toString();
+}
+
+async function boundedJson(response: Response): Promise<unknown> {
+  const declared = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > PROFILE_RESPONSE_MAX_BYTES) {
+    throw createMcpError("request_failed");
+  }
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const reader = response.body?.getReader();
+  if (reader) {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > PROFILE_RESPONSE_MAX_BYTES) {
+        await reader.cancel();
+        throw createMcpError("request_failed");
+      }
+      chunks.push(value);
+    }
+  }
+  const text = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)), total).toString("utf8");
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (err: unknown) {
+    if (!(err instanceof SyntaxError)) throw err;
+    throw createMcpError("request_failed");
+  }
+}
+
+function requestCode(error: unknown) {
+  return error instanceof DOMException && (error.name === "AbortError" || error.name === "TimeoutError")
+    ? "request_timeout" as const
+    : "request_failed" as const;
+}
+
+export function createMcpProfileContext(options: McpProfileContextOptions = {}): McpProfileContext {
+  const fetchImpl = options.fetch ?? fetch;
+
+  async function principal(): Promise<PrincipalContext> {
+    const profile = await resolveCliProfile({ profile: options.profileName }, options.configDir);
+    assertCredentialOrigin(new URL(profile.platformUrl));
+    assertCredentialOrigin(new URL(profile.gatewayUrl));
+    const auth = await loadProfileAuth(profile.name, options.configDir);
+    if (!auth || isExpired(auth)) {
+      throw createMcpError("auth_required");
+    }
+    return { profile, auth };
+  }
+
+  async function inventory(context: PrincipalContext): Promise<MatrixMcpComputerList> {
+    const url = new URL("/api/auth/computers", context.profile.platformUrl).toString();
+    let response: Response;
+    try {
+      response = await fetchImpl(url, {
+        headers: { Authorization: `Bearer ${context.auth.accessToken}` },
+        signal: AbortSignal.timeout(PROFILE_REQUEST_TIMEOUT_MS),
+      });
+    } catch (err: unknown) {
+      throw createMcpError(requestCode(err));
+    }
+    if (response.status === 401 || response.status === 403) throw createMcpError("auth_required");
+    if (!response.ok) throw createMcpError("request_failed");
+    const parsed = ComputerListSchema.safeParse(await boundedJson(response));
+    if (!parsed.success) throw createMcpError("request_failed");
+    return parsed.data;
+  }
+
+  async function listComputers(): Promise<MatrixMcpComputerList> {
+    return inventory(await principal());
+  }
+
+  async function resolveRuntime(runtimeSlot: string): Promise<MatrixMcpRuntime> {
+    const slot = RuntimeSlotSchema.parse(runtimeSlot);
+    const context = await principal();
+    const listed = await inventory(context);
+    const computer = listed.items.find((item) => item.runtimeSlot === slot);
+    if (!computer) throw createMcpError("computer_not_found");
+    if (computer.availability !== "available") throw createMcpError("computer_unavailable");
+
+    if (context.auth.runtimeSlot === slot) {
+      return { computer, gatewayUrl: stripTrailingSlash(context.profile.gatewayUrl), token: context.auth.accessToken };
+    }
+
+    const selectionUrl = new URL(
+      "/api/auth/runtime-selection",
+      resolveRuntimeSelectionOrigin(context.profile.platformUrl, options.apiOrigin),
+    ).toString();
+    let response: Response;
+    try {
+      response = await fetchImpl(selectionUrl, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${context.auth.accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ slot }),
+        signal: AbortSignal.timeout(PROFILE_REQUEST_TIMEOUT_MS),
+      });
+    } catch (err: unknown) {
+      throw createMcpError(requestCode(err));
+    }
+    if (response.status === 401 || response.status === 403) throw createMcpError("auth_required");
+    if (response.status === 404) throw createMcpError("computer_not_found");
+    if (!response.ok) throw createMcpError("request_failed");
+    const selected = RuntimeSelectionSchema.safeParse(await boundedJson(response));
+    if (!selected.success
+      || selected.data.slot !== slot
+      || selected.data.handle !== computer.handle
+      || selected.data.expiresAt <= Date.now()) {
+      throw createMcpError("request_failed");
+    }
+    return {
+      computer,
+      gatewayUrl: gatewayForComputer(context.profile, computer),
+      token: selected.data.accessToken,
+    };
+  }
+
+  return { listComputers, resolveRuntime };
+}

--- a/packages/sync-client/src/mcp/schemas.ts
+++ b/packages/sync-client/src/mcp/schemas.ts
@@ -1,0 +1,159 @@
+import { posix } from "node:path";
+import { z } from "zod/v4";
+
+export const MCP_TEXT_FILE_MAX_BYTES = 256 * 1024;
+export const MCP_FILE_MAX_BYTES = 1024 * 1024;
+export const MCP_TERMINAL_INPUT_MAX_BYTES = 60_000;
+export const MCP_DIRECTORY_MAX_ENTRIES = 500;
+export const MCP_CHAT_MAX_ITEMS = 100;
+
+const utf8Bytes = (value: string) => Buffer.byteLength(value, "utf8");
+const SAFE_BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+export const RuntimeSlotSchema = z.string()
+  .min(1)
+  .max(32)
+  .regex(/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/);
+
+function normalizeMatrixPath(value: string): string {
+  if (value.includes("\\") || /[\0\r\n]/.test(value)) {
+    throw new Error("invalid_path");
+  }
+  const homeRelative = value === "~"
+    ? "."
+    : value.startsWith("~/")
+      ? value.slice(2) || "."
+      : value;
+  if (!homeRelative || homeRelative.startsWith("/")) {
+    throw new Error("invalid_path");
+  }
+  const normalized = posix.normalize(homeRelative);
+  if (normalized === ".." || normalized.startsWith("../")) {
+    throw new Error("invalid_path");
+  }
+  return normalized;
+}
+
+export const MatrixPathSchema = z.string()
+  .trim()
+  .min(1)
+  .max(4096)
+  .transform((value, ctx) => {
+    try {
+      return normalizeMatrixPath(value);
+    } catch (err: unknown) {
+      if (!(err instanceof Error)) throw err;
+      ctx.addIssue({ code: "custom", message: "Invalid Matrix home path" });
+      return z.NEVER;
+    }
+  });
+
+export const MatrixFilePathSchema = MatrixPathSchema.refine((path) => path !== ".", {
+  message: "A file path is required",
+});
+
+export const TerminalNameSchema = z.string().min(1).max(64).regex(/^[a-z0-9][a-z0-9_-]{0,63}$/);
+export const NewTerminalNameSchema = z.string().min(1).max(31).regex(/^[a-z0-9][a-z0-9-]{0,30}$/);
+export const TabNameSchema = z.string().min(1).max(64).regex(/^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$/);
+export const ChatIdSchema = z.string().min(6).max(133).regex(/^chat_[A-Za-z0-9_-]+$/);
+export const ChatCursorSchema = z.string().min(9).max(512).regex(/^chatcur_[A-Za-z0-9_-]+$/);
+
+export const ComputerInputSchema = z.object({ computer: RuntimeSlotSchema }).strict();
+
+export const RunCommandInputSchema = z.object({
+  computer: RuntimeSlotSchema,
+  command: z.array(z.string().min(1).max(4096)).min(1).max(64),
+  cwd: MatrixPathSchema.optional(),
+  timeoutMs: z.number().int().min(1_000).max(30 * 60 * 1000).optional(),
+}).strict();
+
+export const CreateTerminalInputSchema = z.object({
+  computer: RuntimeSlotSchema,
+  name: NewTerminalNameSchema,
+  cwd: MatrixPathSchema.optional(),
+}).strict();
+
+export const TerminalInputSchema = z.object({
+  computer: RuntimeSlotSchema,
+  terminal: TerminalNameSchema,
+}).strict();
+
+export const CreateTerminalTabInputSchema = TerminalInputSchema.extend({
+  name: TabNameSchema.optional(),
+  cwd: MatrixPathSchema.optional(),
+}).strict();
+
+export const SelectTerminalTabInputSchema = TerminalInputSchema.extend({
+  tab: z.number().int().min(0).max(1024),
+}).strict();
+
+export const SendTerminalInputSchema = TerminalInputSchema.extend({
+  data: z.string().min(1).refine((value) => utf8Bytes(value) <= MCP_TERMINAL_INPUT_MAX_BYTES, {
+    message: "Terminal input exceeds byte limit",
+  }),
+}).strict();
+
+export const ListFilesInputSchema = z.object({
+  computer: RuntimeSlotSchema,
+  path: MatrixPathSchema.default("."),
+}).strict();
+
+export const ReadFileInputSchema = z.object({
+  computer: RuntimeSlotSchema,
+  path: MatrixFilePathSchema,
+}).strict();
+
+export const DownloadFileInputSchema = ReadFileInputSchema;
+
+const UploadBaseSchema = z.object({
+  computer: RuntimeSlotSchema,
+  path: MatrixFilePathSchema,
+  overwrite: z.boolean().default(false),
+  secret: z.boolean().default(false),
+});
+
+export const UploadFileInputSchema = UploadBaseSchema.extend({
+  encoding: z.enum(["utf8", "base64"]),
+  content: z.string().max(Math.ceil(MCP_FILE_MAX_BYTES / 3) * 4),
+}).strict().superRefine((input, ctx) => {
+  if (input.encoding === "base64" && !SAFE_BASE64.test(input.content)) {
+    ctx.addIssue({ code: "custom", path: ["content"], message: "Invalid base64 content" });
+    return;
+  }
+  const size = input.encoding === "utf8"
+    ? utf8Bytes(input.content)
+    : Buffer.from(input.content, "base64").byteLength;
+  if (size > MCP_FILE_MAX_BYTES) {
+    ctx.addIssue({ code: "custom", path: ["content"], message: "Upload exceeds byte limit" });
+  }
+});
+
+export type UploadFileInput = z.infer<typeof UploadFileInputSchema>;
+
+export function decodeUploadContent(input: UploadFileInput): Buffer {
+  return Buffer.from(input.content, input.encoding === "utf8" ? "utf8" : "base64");
+}
+
+const ChatPageFields = {
+  computer: RuntimeSlotSchema,
+  limit: z.number().int().min(1).max(MCP_CHAT_MAX_ITEMS).default(20),
+  projectId: z.string().min(1).max(160).regex(/^[A-Za-z0-9_.-]+$/).optional(),
+};
+
+export const ListChatsInputSchema = z.object({
+  ...ChatPageFields,
+  lifecycle: z.enum(["active", "archived"]).optional(),
+  cursor: ChatCursorSchema.optional(),
+}).strict();
+
+export const SearchChatsInputSchema = z.object({
+  ...ChatPageFields,
+  query: z.string().trim().min(1).max(200),
+}).strict();
+
+export const GetChatInputSchema = z.object({
+  computer: RuntimeSlotSchema,
+  chatId: ChatIdSchema,
+  limit: z.number().int().min(1).max(MCP_CHAT_MAX_ITEMS).default(MCP_CHAT_MAX_ITEMS),
+  cursor: ChatCursorSchema.optional(),
+}).strict();

--- a/packages/sync-client/src/mcp/schemas.ts
+++ b/packages/sync-client/src/mcp/schemas.ts
@@ -84,7 +84,7 @@ export const CreateTerminalTabInputSchema = TerminalInputSchema.extend({
 }).strict();
 
 export const SelectTerminalTabInputSchema = TerminalInputSchema.extend({
-  tab: z.number().int().min(0).max(1024),
+  tabId: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
 }).strict();
 
 export const SendTerminalInputSchema = TerminalInputSchema.extend({

--- a/packages/sync-client/src/mcp/server.ts
+++ b/packages/sync-client/src/mcp/server.ts
@@ -167,12 +167,12 @@ export function createMatrixMcpServer(options: MatrixMcpServerOptions = {}): Mcp
   }))));
 
   server.registerTool("select_terminal_tab", {
-    description: "Select the active tab in a named persistent Matrix terminal before sending input.",
+    description: "Select the active tab by its stable Matrix tab ID before sending input.",
     inputSchema: SelectTerminalTabInputSchema.shape,
     annotations: changeAnnotations,
   }, async (input) => safely(() => withClient(input.computer, async (client, computer) => {
-    await client.selectTab(input.terminal, input.tab);
-    return { ok: true, computer, terminal: input.terminal, tab: input.tab };
+    await client.selectTab(input.terminal, input.tabId);
+    return { ok: true, computer, terminal: input.terminal, tabId: input.tabId };
   })));
 
   server.registerTool("send_terminal_input", {

--- a/packages/sync-client/src/mcp/server.ts
+++ b/packages/sync-client/src/mcp/server.ts
@@ -1,0 +1,285 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createMcpGatewayClient } from "./clients.js";
+import { jsonResult, safeErrorResult } from "./errors.js";
+import { createMcpProfileContext, type McpProfileContext } from "./profile-context.js";
+import {
+  ComputerInputSchema,
+  CreateTerminalInputSchema,
+  CreateTerminalTabInputSchema,
+  DownloadFileInputSchema,
+  GetChatInputSchema,
+  ListChatsInputSchema,
+  ListFilesInputSchema,
+  ReadFileInputSchema,
+  RunCommandInputSchema,
+  SearchChatsInputSchema,
+  SelectTerminalTabInputSchema,
+  SendTerminalInputSchema,
+  TerminalInputSchema,
+  UploadFileInputSchema,
+  decodeUploadContent,
+} from "./schemas.js";
+
+export interface MatrixMcpServerOptions {
+  context?: McpProfileContext;
+  profileName?: string;
+  configDir?: string;
+  apiOrigin?: string;
+  fetch?: typeof fetch;
+}
+
+const readOnlyAnnotations = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: true,
+};
+
+const changeAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: false,
+  openWorldHint: true,
+};
+
+const executionAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: false,
+  openWorldHint: true,
+};
+
+async function safely<T>(operation: () => Promise<T>) {
+  try {
+    return jsonResult(await operation());
+  } catch (error: unknown) {
+    return safeErrorResult(error);
+  }
+}
+
+function publicComputer(computer: Awaited<ReturnType<McpProfileContext["listComputers"]>>["items"][number]) {
+  return {
+    runtimeSlot: computer.runtimeSlot,
+    handle: computer.handle,
+    label: computer.label,
+    availability: computer.availability,
+    kind: computer.kind,
+    ...(computer.versionLabel ? { versionLabel: computer.versionLabel } : {}),
+    capabilities: computer.capabilities,
+  };
+}
+
+function computerResult(computer: { runtimeSlot: string; handle: string }) {
+  return { runtimeSlot: computer.runtimeSlot, handle: computer.handle };
+}
+
+export function createMatrixMcpServer(options: MatrixMcpServerOptions = {}): McpServer {
+  const profileContext = options.context ?? createMcpProfileContext({
+    profileName: options.profileName,
+    configDir: options.configDir,
+    apiOrigin: options.apiOrigin,
+    fetch: options.fetch,
+  });
+  const server = new McpServer(
+    { name: "matrix-remote-computer", version: "1.0.0" },
+    {
+      instructions:
+        "Use these tools to work on an explicitly selected Matrix computer. Call list_computers first. Use run_command for captured one-shot output and persistent terminal tools for visible long-running work. Never imply these tools disable the host's local shell.",
+    },
+  );
+
+  async function withClient<T>(computer: string, operation: (
+    client: ReturnType<typeof createMcpGatewayClient>,
+    selected: { runtimeSlot: string; handle: string },
+  ) => Promise<T>): Promise<T> {
+    const runtime = await profileContext.resolveRuntime(computer);
+    return operation(
+      createMcpGatewayClient(runtime, { fetch: options.fetch }),
+      computerResult(runtime.computer),
+    );
+  }
+
+  server.registerTool("list_computers", {
+    description: "List Matrix computers available to the signed-in owner. Call this before any computer-scoped tool.",
+    annotations: readOnlyAnnotations,
+  }, async () => safely(async () => {
+    const inventory = await profileContext.listComputers();
+    return {
+      ok: true,
+      computers: inventory.items.map(publicComputer),
+      selectedSlot: inventory.selectedSlot,
+      hasMore: inventory.hasMore,
+    };
+  }));
+
+  server.registerTool("run_command", {
+    description: "Run a captured argv command on one explicit Matrix computer and return bounded output and exit metadata.",
+    inputSchema: RunCommandInputSchema.shape,
+    annotations: executionAnnotations,
+  }, async (input) => safely(() => withClient(input.computer, async (client, computer) => ({
+    ok: true,
+    computer,
+    ...await client.runCommand({
+      command: input.command,
+      ...(input.cwd ? { cwd: input.cwd } : {}),
+      ...(input.timeoutMs ? { timeoutMs: input.timeoutMs } : {}),
+    }),
+  }))));
+
+  server.registerTool("list_terminals", {
+    description: "List persistent zellij terminal sessions on one explicit Matrix computer.",
+    inputSchema: ComputerInputSchema.shape,
+    annotations: readOnlyAnnotations,
+  }, async (input) => safely(() => withClient(input.computer, async (client, computer) => ({
+    ok: true, computer, terminals: await client.listTerminals(),
+  }))));
+
+  server.registerTool("create_terminal", {
+    description: "Create a named persistent zellij terminal on one explicit Matrix computer.",
+    inputSchema: CreateTerminalInputSchema.shape,
+    annotations: changeAnnotations,
+  }, async (input) => safely(() => withClient(input.computer, async (client, computer) => ({
+    ok: true,
+    computer,
+    terminal: await client.createTerminal({ name: input.name, ...(input.cwd ? { cwd: input.cwd } : {}) }),
+  }))));
+
+  server.registerTool("list_terminal_tabs", {
+    description: "List tabs in a named persistent Matrix terminal.",
+    inputSchema: TerminalInputSchema.shape,
+    annotations: readOnlyAnnotations,
+  }, async (input) => safely(() => withClient(input.computer, async (client, computer) => ({
+    ok: true, computer, terminal: input.terminal, tabs: await client.listTabs(input.terminal),
+  }))));
+
+  server.registerTool("create_terminal_tab", {
+    description: "Create a tab in a named persistent Matrix terminal.",
+    inputSchema: CreateTerminalTabInputSchema.shape,
+    annotations: changeAnnotations,
+  }, async (input) => safely(() => withClient(input.computer, async (client, computer) => ({
+    ok: true,
+    computer,
+    terminal: input.terminal,
+    tab: await client.createTab(input.terminal, {
+      ...(input.name ? { name: input.name } : {}),
+      ...(input.cwd ? { cwd: input.cwd } : {}),
+    }),
+  }))));
+
+  server.registerTool("select_terminal_tab", {
+    description: "Select the active tab in a named persistent Matrix terminal before sending input.",
+    inputSchema: SelectTerminalTabInputSchema.shape,
+    annotations: changeAnnotations,
+  }, async (input) => safely(() => withClient(input.computer, async (client, computer) => {
+    await client.selectTab(input.terminal, input.tab);
+    return { ok: true, computer, terminal: input.terminal, tab: input.tab };
+  })));
+
+  server.registerTool("send_terminal_input", {
+    description: "Send bounded input to the active tab of a persistent Matrix terminal. Include a newline to submit a shell command.",
+    inputSchema: SendTerminalInputSchema.shape,
+    annotations: executionAnnotations,
+  }, async (input) => safely(() => withClient(input.computer, async (client, computer) => {
+    await client.sendTerminalInput(input.terminal, input.data);
+    return {
+      ok: true,
+      computer,
+      terminal: input.terminal,
+      bytes: Buffer.byteLength(input.data, "utf8"),
+    };
+  })));
+
+  server.registerTool("list_files", {
+    description: "List a bounded Matrix-home directory on one explicit Matrix computer.",
+    inputSchema: ListFilesInputSchema.shape,
+    annotations: readOnlyAnnotations,
+  }, async (input) => safely(() => withClient(input.computer, async (client, computer) => ({
+    ok: true, computer, path: input.path, entries: await client.listFiles(input.path),
+  }))));
+
+  server.registerTool("read_file", {
+    description: "Read a UTF-8 Matrix-home file up to 256 KiB without writing to the local computer.",
+    inputSchema: ReadFileInputSchema.shape,
+    annotations: readOnlyAnnotations,
+  }, async (input) => safely(() => withClient(input.computer, async (client, computer) => ({
+    ok: true, computer, path: input.path, encoding: "utf8", ...await client.readFile(input.path),
+  }))));
+
+  server.registerTool("download_file", {
+    description: "Return a Matrix-home file up to 1 MiB as base64 content; never writes a local path.",
+    inputSchema: DownloadFileInputSchema.shape,
+    annotations: readOnlyAnnotations,
+  }, async (input) => safely(() => withClient(input.computer, async (client, computer) => {
+    const downloaded = await client.downloadFile(input.path);
+    return {
+      ok: true,
+      computer,
+      path: input.path,
+      filename: downloaded.filename,
+      mediaType: downloaded.mediaType,
+      size: downloaded.size,
+      encoding: "base64",
+      content: downloaded.bytes.toString("base64"),
+    };
+  })));
+
+  server.registerTool("upload_file", {
+    description: "Upload bounded UTF-8 or base64 content to Matrix home. Existing files require overwrite=true.",
+    inputSchema: UploadFileInputSchema.shape,
+    annotations: executionAnnotations,
+  }, async (input) => safely(async () => {
+    const validated = UploadFileInputSchema.parse(input);
+    return withClient(validated.computer, async (client, computer) => {
+      const uploaded = await client.uploadFile(validated.path, decodeUploadContent(validated), {
+        overwrite: validated.overwrite,
+        secret: validated.secret,
+      });
+      return { computer, ...uploaded };
+    });
+  }));
+
+  server.registerTool("list_chats", {
+    description: "List a bounded page of read-only Matrix chat summaries on one explicit computer.",
+    inputSchema: ListChatsInputSchema.shape,
+    annotations: readOnlyAnnotations,
+  }, async (input) => safely(() => withClient(input.computer, async (client, computer) => ({
+    ok: true,
+    computer,
+    ...await client.listChats({
+      limit: input.limit,
+      ...(input.lifecycle ? { lifecycle: input.lifecycle } : {}),
+      ...(input.projectId ? { projectId: input.projectId } : {}),
+      ...(input.cursor ? { cursor: input.cursor } : {}),
+    }) as Record<string, unknown>,
+  }))));
+
+  server.registerTool("search_chats", {
+    description: "Search read-only Matrix chat summaries on one explicit computer.",
+    inputSchema: SearchChatsInputSchema.shape,
+    annotations: readOnlyAnnotations,
+  }, async (input) => safely(() => withClient(input.computer, async (client, computer) => ({
+    ok: true,
+    computer,
+    ...await client.searchChats({
+      query: input.query,
+      limit: input.limit,
+      ...(input.projectId ? { projectId: input.projectId } : {}),
+    }) as Record<string, unknown>,
+  }))));
+
+  server.registerTool("get_chat", {
+    description: "Read bounded metadata and messages for one Matrix chat without changing chat state.",
+    inputSchema: GetChatInputSchema.shape,
+    annotations: readOnlyAnnotations,
+  }, async (input) => safely(() => withClient(input.computer, async (client, computer) => ({
+    ok: true,
+    computer,
+    ...await client.getChat({
+      chatId: input.chatId,
+      limit: input.limit,
+      ...(input.cursor ? { cursor: input.cursor } : {}),
+    }) as Record<string, unknown>,
+  }))));
+
+  return server;
+}

--- a/packages/sync-client/tests/integration/mcp-cli.test.ts
+++ b/packages/sync-client/tests/integration/mcp-cli.test.ts
@@ -1,0 +1,33 @@
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+
+it("serves MCP through the published entry and exits cleanly after stdin closes", async () => {
+  const child = spawn(process.execPath, [
+    fileURLToPath(new URL("../../bin/matrix.mjs", import.meta.url)), "mcp", "serve",
+  ], { env: { ...process.env, MATRIX_NO_TELEMETRY: "1" }, stdio: ["pipe", "pipe", "pipe"] });
+  let stdout = "";
+  let stderr = "";
+  const timer = setTimeout(() => child.kill("SIGTERM"), 8_000);
+  try {
+    const exited = new Promise((resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", (code, signal) => resolve({ code, signal }));
+    });
+    child.stdout.on("data", (data) => {
+      stdout += data;
+      if (stdout.includes("\"id\":1")) child.stdin.end();
+    });
+    child.stderr.on("data", (data) => { stderr += data; });
+    child.stdin.write(JSON.stringify({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "test", version: "1" } },
+    }) + "\n");
+    expect(await exited).toEqual({ code: 0, signal: null });
+    expect(JSON.parse(stdout).result.serverInfo.name).toBe("matrix-remote-computer");
+    expect(stderr).toBe("");
+  } finally {
+    clearTimeout(timer);
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+  }
+}, 10_000);

--- a/packages/sync-client/tests/integration/mcp-server.test.ts
+++ b/packages/sync-client/tests/integration/mcp-server.test.ts
@@ -1,0 +1,284 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { McpProfileContext, MatrixMcpRuntime } from "../../src/mcp/profile-context.js";
+import { createMatrixMcpServer } from "../../src/mcp/server.js";
+
+const computer = {
+  handle: "neo-review",
+  runtimeSlot: "review",
+  label: "Additional Computer" as const,
+  availability: "available" as const,
+  kind: "customer" as const,
+  versionLabel: "stable",
+  gatewayPath: "/vm/neo-review?runtime=review",
+  capabilities: ["terminal"],
+};
+
+const runtime: MatrixMcpRuntime = {
+  computer,
+  gatewayUrl: "https://app.matrix-os.com/vm/neo-review?runtime=review",
+  token: "scoped-secret-token",
+};
+
+function context(): McpProfileContext {
+  return {
+    listComputers: vi.fn(async () => ({
+      items: [computer],
+      selectedSlot: null,
+      hasMore: false,
+      limit: 20,
+    })),
+    resolveRuntime: vi.fn(async (slot) => {
+      if (slot !== "review") throw Object.assign(new Error("wrong computer private detail"), { code: "computer_not_found" });
+      return runtime;
+    }),
+  };
+}
+
+function json(status: number, body: unknown, headers: Record<string, string> = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+async function connect(options: { context?: McpProfileContext; fetch?: typeof fetch } = {}) {
+  const server = createMatrixMcpServer({
+    context: options.context ?? context(),
+    fetch: options.fetch ?? vi.fn<typeof fetch>(),
+  });
+  const client = new Client({ name: "matrix-remote-test", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { client, server };
+}
+
+function textResult(result: Awaited<ReturnType<Client["callTool"]>>) {
+  const content = result.content[0];
+  if (!content || content.type !== "text") throw new Error("Expected text result");
+  return JSON.parse(content.text) as Record<string, unknown>;
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("Matrix remote computer MCP server", () => {
+  it("advertises the stable remote computer tool contract", async () => {
+    const { client, server } = await connect();
+    const listed = await client.listTools();
+
+    expect(listed.tools.map((tool) => tool.name)).toEqual([
+      "list_computers",
+      "run_command",
+      "list_terminals",
+      "create_terminal",
+      "list_terminal_tabs",
+      "create_terminal_tab",
+      "select_terminal_tab",
+      "send_terminal_input",
+      "list_files",
+      "read_file",
+      "download_file",
+      "upload_file",
+      "list_chats",
+      "search_chats",
+      "get_chat",
+    ]);
+    expect(listed.tools.find((tool) => tool.name === "list_computers")?.annotations?.readOnlyHint).toBe(true);
+    expect(listed.tools.find((tool) => tool.name === "run_command")?.annotations?.readOnlyHint).toBe(false);
+    expect(listed.tools.find((tool) => tool.name === "send_terminal_input")?.annotations?.destructiveHint).toBe(true);
+
+    await client.close();
+    await server.close();
+  });
+
+  it("lists computers without exposing gateway routing or tokens", async () => {
+    const { client, server } = await connect();
+    const result = textResult(await client.callTool({ name: "list_computers", arguments: {} }));
+    const serialized = JSON.stringify(result);
+
+    expect(result).toMatchObject({
+      ok: true,
+      computers: [{ runtimeSlot: "review", handle: "neo-review", availability: "available" }],
+    });
+    expect(serialized).not.toContain("gatewayPath");
+    expect(serialized).not.toContain("token");
+
+    await client.close();
+    await server.close();
+  });
+
+  it("runs captured argv only on the explicitly resolved computer", async () => {
+    const profileContext = context();
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(json(200, {
+      stdout: "repo\n",
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      truncated: false,
+      durationMs: 12,
+    }));
+    const { client, server } = await connect({ context: profileContext, fetch: fetcher });
+    const result = textResult(await client.callTool({
+      name: "run_command",
+      arguments: { computer: "review", command: ["basename", "/work/repo"], cwd: "projects/repo" },
+    }));
+
+    expect(profileContext.resolveRuntime).toHaveBeenCalledWith("review");
+    expect(result).toMatchObject({
+      ok: true,
+      computer: { runtimeSlot: "review", handle: "neo-review" },
+      stdout: "repo\n",
+      exitCode: 0,
+    });
+    expect(fetcher.mock.calls[0]?.[1]).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({ command: ["basename", "/work/repo"], cwd: "projects/repo" }),
+    });
+
+    await client.close();
+    await server.close();
+  });
+
+  it("creates and controls persistent terminals and tabs", async () => {
+    const requests: Array<{ url: string; method: string; body?: string }> = [];
+    const fetcher = vi.fn<typeof fetch>(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      requests.push({ url, method, ...(typeof init?.body === "string" ? { body: init.body } : {}) });
+      if (method === "GET" && url.includes("/sessions?")) return json(200, { sessions: [{ name: "work", status: "active" }] });
+      if (method === "POST" && url.includes("/sessions?") && !url.includes("/tabs")) return json(201, { name: "work", created: true });
+      if (method === "GET" && url.includes("/tabs?")) return json(200, { tabs: [{ idx: 0, name: "shell", focused: true }] });
+      if (method === "POST" && url.includes("/tabs?") && !url.includes("/go")) return json(200, { tab: { ok: true } });
+      return json(200, { ok: true });
+    });
+    const { client, server } = await connect({ fetch: fetcher });
+
+    expect(textResult(await client.callTool({ name: "list_terminals", arguments: { computer: "review" } })))
+      .toMatchObject({ ok: true, terminals: [{ name: "work" }] });
+    expect(textResult(await client.callTool({ name: "create_terminal", arguments: {
+      computer: "review", name: "work", cwd: "projects/repo",
+    } }))).toMatchObject({ ok: true, terminal: { name: "work" } });
+    expect(textResult(await client.callTool({ name: "list_terminal_tabs", arguments: {
+      computer: "review", terminal: "work",
+    } }))).toMatchObject({ ok: true, tabs: [{ idx: 0, name: "shell" }] });
+    expect(textResult(await client.callTool({ name: "create_terminal_tab", arguments: {
+      computer: "review", terminal: "work", name: "tests", cwd: "projects/repo",
+    } }))).toMatchObject({ ok: true, tab: { created: true } });
+    await client.callTool({ name: "select_terminal_tab", arguments: { computer: "review", terminal: "work", tab: 1 } });
+    await client.callTool({ name: "send_terminal_input", arguments: {
+      computer: "review", terminal: "work", data: "bun test\n",
+    } });
+
+    expect(requests.some((request) => request.url.includes("/tabs/1/go?") && request.method === "POST")).toBe(true);
+    expect(requests.some((request) => request.url.includes("/input?") && request.body === JSON.stringify({ data: "bun test\n" }))).toBe(true);
+
+    await client.close();
+    await server.close();
+  });
+
+  it("lists, reads, downloads, and uploads bounded remote file content", async () => {
+    const binary = Buffer.from([0, 1, 2, 255]);
+    const fetcher = vi.fn<typeof fetch>(async (input, init) => {
+      const url = String(input);
+      if (url.includes("/api/files/list")) return json(200, { entries: [{ name: "note.txt", type: "file", size: 5 }] });
+      if (init?.method === "PUT") return json(200, { ok: true, path: "artifacts/copy.bin", size: 4 });
+      if (url.includes("note.txt")) return new Response("hello", { status: 200, headers: { "content-type": "text/plain" } });
+      return new Response(binary, { status: 200, headers: { "content-type": "application/octet-stream" } });
+    });
+    const { client, server } = await connect({ fetch: fetcher });
+
+    expect(textResult(await client.callTool({ name: "list_files", arguments: {
+      computer: "review", path: "artifacts",
+    } }))).toMatchObject({ ok: true, entries: [{ name: "note.txt" }] });
+    expect(textResult(await client.callTool({ name: "read_file", arguments: {
+      computer: "review", path: "artifacts/note.txt",
+    } }))).toMatchObject({ ok: true, encoding: "utf8", content: "hello", size: 5 });
+    expect(textResult(await client.callTool({ name: "download_file", arguments: {
+      computer: "review", path: "artifacts/pixel.bin",
+    } }))).toMatchObject({ ok: true, encoding: "base64", content: binary.toString("base64"), size: 4 });
+    expect(textResult(await client.callTool({ name: "upload_file", arguments: {
+      computer: "review",
+      path: "artifacts/copy.bin",
+      encoding: "base64",
+      content: binary.toString("base64"),
+      overwrite: true,
+    } }))).toMatchObject({ ok: true, path: "artifacts/copy.bin", size: 4 });
+
+    const upload = fetcher.mock.calls.find(([, init]) => init?.method === "PUT");
+    expect(Buffer.from(upload?.[1]?.body as Uint8Array)).toEqual(binary);
+
+    await client.close();
+    await server.close();
+  });
+
+  it("inspects chats through GET-only bounded requests and removes sensitive keys", async () => {
+    const fetcher = vi.fn<typeof fetch>(async (input, init) => {
+      expect(init?.method ?? "GET").toBe("GET");
+      const url = String(input);
+      if (url.includes("/search")) return json(200, { items: [{ chat: { id: "chat_one", title: "Search" } }] });
+      if (url.includes("/api/chats/chat_one")) return json(200, {
+        record: { chat: { id: "chat_one", title: "One" }, accessToken: "never-return" },
+        messages: [{ id: "msg_one", role: "user", parts: [{ type: "text", text: "hello" }] }],
+      });
+      return json(200, { items: [{ chat: { id: "chat_one", title: "One" } }], nextCursor: "chatcur_next" });
+    });
+    const { client, server } = await connect({ fetch: fetcher });
+
+    expect(textResult(await client.callTool({ name: "list_chats", arguments: { computer: "review", limit: 20 } })))
+      .toMatchObject({ ok: true, items: [{ chat: { id: "chat_one" } }] });
+    expect(textResult(await client.callTool({ name: "search_chats", arguments: {
+      computer: "review", query: "Search", limit: 20,
+    } }))).toMatchObject({ ok: true, items: [{ chat: { title: "Search" } }] });
+    const detail = textResult(await client.callTool({ name: "get_chat", arguments: {
+      computer: "review", chatId: "chat_one", limit: 100,
+    } }));
+    expect(detail).toMatchObject({ ok: true, messages: [{ id: "msg_one" }] });
+    expect(JSON.stringify(detail)).not.toContain("never-return");
+
+    await client.close();
+    await server.close();
+  });
+
+  it("returns allowlisted errors and rejects invalid input before network activity", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+    const { client, server } = await connect({ fetch: fetcher });
+
+    const wrongComputer = await client.callTool({
+      name: "list_files",
+      arguments: { computer: "missing", path: "." },
+    });
+    expect(wrongComputer.isError).toBe(true);
+    expect(textResult(wrongComputer)).toEqual({
+      ok: false,
+      error: {
+        code: "computer_not_found",
+        message: "That Matrix computer is not available to this account.",
+        retryable: false,
+      },
+    });
+
+    const invalid = await client.callTool({
+      name: "run_command",
+      arguments: { computer: "review", command: [], cwd: "../../etc" },
+    });
+    expect(invalid.isError).toBe(true);
+
+    const invalidBase64 = await client.callTool({
+      name: "upload_file",
+      arguments: {
+        computer: "review",
+        path: "artifacts/bad.bin",
+        encoding: "base64",
+        content: "not-base64!",
+      },
+    });
+    expect(invalidBase64.isError).toBe(true);
+    expect(textResult(invalidBase64)).toMatchObject({ error: { code: "invalid_input" } });
+    expect(fetcher).not.toHaveBeenCalled();
+
+    await client.close();
+    await server.close();
+  });
+});

--- a/packages/sync-client/tests/integration/mcp-server.test.ts
+++ b/packages/sync-client/tests/integration/mcp-server.test.ts
@@ -149,8 +149,8 @@ describe("Matrix remote computer MCP server", () => {
       requests.push({ url, method, ...(typeof init?.body === "string" ? { body: init.body } : {}) });
       if (method === "GET" && url.includes("/sessions?")) return json(200, { sessions: [{ name: "work", status: "active" }] });
       if (method === "POST" && url.includes("/sessions?") && !url.includes("/tabs")) return json(201, { name: "work", created: true });
-      if (method === "GET" && url.includes("/tabs?")) return json(200, { tabs: [{ idx: 0, name: "shell", focused: true }] });
-      if (method === "POST" && url.includes("/tabs?") && !url.includes("/go")) return json(200, { tab: { ok: true } });
+      if (method === "GET" && url.includes("/tabs?")) return json(200, { tabs: [{ id: 11, idx: 0, name: "shell", focused: true }] });
+      if (method === "POST" && url.includes("/tabs?") && !url.includes("/go")) return json(200, { tab: { id: 41, name: "tests" } });
       return json(200, { ok: true });
     });
     const { client, server } = await connect({ fetch: fetcher });
@@ -162,16 +162,16 @@ describe("Matrix remote computer MCP server", () => {
     } }))).toMatchObject({ ok: true, terminal: { name: "work" } });
     expect(textResult(await client.callTool({ name: "list_terminal_tabs", arguments: {
       computer: "review", terminal: "work",
-    } }))).toMatchObject({ ok: true, tabs: [{ idx: 0, name: "shell" }] });
+    } }))).toMatchObject({ ok: true, tabs: [{ id: 11, idx: 0, name: "shell" }] });
     expect(textResult(await client.callTool({ name: "create_terminal_tab", arguments: {
       computer: "review", terminal: "work", name: "tests", cwd: "projects/repo",
-    } }))).toMatchObject({ ok: true, tab: { created: true } });
-    await client.callTool({ name: "select_terminal_tab", arguments: { computer: "review", terminal: "work", tab: 1 } });
+    } }))).toMatchObject({ ok: true, tab: { id: 41, name: "tests" } });
+    await client.callTool({ name: "select_terminal_tab", arguments: { computer: "review", terminal: "work", tabId: 41 } });
     await client.callTool({ name: "send_terminal_input", arguments: {
       computer: "review", terminal: "work", data: "bun test\n",
     } });
 
-    expect(requests.some((request) => request.url.includes("/tabs/1/go?") && request.method === "POST")).toBe(true);
+    expect(requests.some((request) => request.url.includes("/tabs/by-id/41/go?") && request.method === "POST")).toBe(true);
     expect(requests.some((request) => request.url.includes("/input?") && request.body === JSON.stringify({ data: "bun test\n" }))).toBe(true);
 
     await client.close();

--- a/packages/sync-client/tests/unit/mcp-clients.test.ts
+++ b/packages/sync-client/tests/unit/mcp-clients.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMcpGatewayClient } from "../../src/mcp/clients.js";
+import type { MatrixMcpRuntime } from "../../src/mcp/profile-context.js";
+
+const runtime: MatrixMcpRuntime = {
+  computer: {
+    handle: "neo-review",
+    runtimeSlot: "review",
+    label: "Additional Computer",
+    availability: "available",
+    kind: "customer",
+    versionLabel: "stable",
+    gatewayPath: "/vm/neo-review?runtime=review",
+    capabilities: ["terminal"],
+  },
+  gatewayUrl: "https://app.matrix-os.com/vm/neo-review?runtime=review",
+  token: "scoped-token",
+};
+
+describe("Matrix MCP gateway client", () => {
+  it("preserves runtime routing and sends bearer auth with a timeout", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({
+      sessions: [{ name: "main", status: "active", createdAt: "2026-09-04T00:00:00.000Z" }],
+    }), { status: 200 }));
+    const client = createMcpGatewayClient(runtime, { fetch: fetcher });
+
+    await expect(client.listTerminals()).resolves.toEqual([
+      { name: "main", status: "active", createdAt: "2026-09-04T00:00:00.000Z" },
+    ]);
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://app.matrix-os.com/vm/neo-review/api/terminal/sessions?runtime=review",
+      expect.objectContaining({
+        headers: { authorization: "Bearer scoped-token" },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("maps raw upstream failures to safe status codes", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response(
+      JSON.stringify({ error: "postgres://secret@private-host/db" }),
+      { status: 500 },
+    ));
+    const client = createMcpGatewayClient(runtime, { fetch: fetcher });
+
+    await expect(client.listTerminals()).rejects.toEqual(expect.objectContaining({
+      code: "request_failed",
+      message: "request_failed",
+    }));
+  });
+
+  it("maps aborts without exposing the thrown network message", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockRejectedValue(new DOMException("private host", "TimeoutError"));
+    const client = createMcpGatewayClient(runtime, { fetch: fetcher });
+
+    await expect(client.listTerminals()).rejects.toEqual(expect.objectContaining({
+      code: "request_timeout",
+      message: "request_timeout",
+    }));
+  });
+
+  it("rejects downloads by declared and actual size before returning bytes", async () => {
+    const declaredFetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response("small", {
+      status: 200,
+      headers: { "content-length": String(1024 * 1024 + 1) },
+    }));
+    await expect(createMcpGatewayClient(runtime, { fetch: declaredFetcher }).downloadFile("large.bin"))
+      .rejects.toMatchObject({ code: "payload_too_large" });
+
+    const actualFetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response(new Uint8Array(1024 * 1024 + 1), {
+      status: 200,
+    }));
+    await expect(createMcpGatewayClient(runtime, { fetch: actualFetcher }).downloadFile("large.bin"))
+      .rejects.toMatchObject({ code: "payload_too_large" });
+  });
+
+  it("uploads bytes with explicit overwrite and secret flags", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({
+      ok: true,
+      path: "secrets/note.txt",
+      size: 5,
+    }), { status: 200 }));
+    const client = createMcpGatewayClient(runtime, { fetch: fetcher });
+
+    await expect(client.uploadFile("secrets/note.txt", Buffer.from("hello"), {
+      overwrite: true,
+      secret: true,
+    })).resolves.toEqual({ ok: true, path: "secrets/note.txt", size: 5 });
+    const [url, init] = fetcher.mock.calls[0]!;
+    expect(String(url)).toBe(
+      "https://app.matrix-os.com/vm/neo-review/api/files/blob?runtime=review&path=secrets%2Fnote.txt&force=true&secret=true",
+    );
+    expect(init).toMatchObject({
+      method: "PUT",
+      headers: {
+        authorization: "Bearer scoped-token",
+        "content-type": "application/octet-stream",
+      },
+    });
+    expect(Buffer.from(init?.body as Uint8Array).toString()).toBe("hello");
+  });
+
+  it("uses an extended bounded timeout only for captured commands", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({
+      stdout: "ok\n",
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      truncated: false,
+      durationMs: 20,
+    }), { status: 200 }));
+    const client = createMcpGatewayClient(runtime, { fetch: fetcher });
+
+    await expect(client.runCommand({ command: ["printf", "ok\\n"], timeoutMs: 60_000 }))
+      .resolves.toMatchObject({ stdout: "ok\n", exitCode: 0 });
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://app.matrix-os.com/vm/neo-review/api/terminal/run?runtime=review",
+      expect.objectContaining({ method: "POST", signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("parses the gateway's terminal creation acknowledgements", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ name: "agent-task", created: true }), { status: 201 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ tab: { ok: true } }), { status: 200 }));
+    const client = createMcpGatewayClient(runtime, { fetch: fetcher });
+
+    await expect(client.createTerminal({ name: "agent-task" })).resolves.toEqual({
+      name: "agent-task",
+      created: true,
+    });
+    await expect(client.createTab("agent-task", { name: "tests" })).resolves.toEqual({ created: true });
+  });
+
+  it("preserves the bounded file response media type for UTF-8 reads", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response("# Notes\n", {
+      status: 200,
+      headers: { "content-type": "text/markdown; charset=utf-8" },
+    }));
+    const client = createMcpGatewayClient(runtime, { fetch: fetcher });
+
+    await expect(client.readFile("notes.md")).resolves.toEqual({
+      content: "# Notes\n",
+      size: 8,
+      mediaType: "text/markdown; charset=utf-8",
+    });
+  });
+
+  it("rejects command responses whose combined output exceeds the MCP limit", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({
+      stdout: "a".repeat(600_000),
+      stderr: "b".repeat(600_000),
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      truncated: false,
+      durationMs: 20,
+    }), { status: 200 }));
+    const client = createMcpGatewayClient(runtime, { fetch: fetcher });
+
+    await expect(client.runCommand({ command: ["large-output"] }))
+      .rejects.toMatchObject({ code: "request_failed" });
+  });
+});

--- a/packages/sync-client/tests/unit/mcp-clients.test.ts
+++ b/packages/sync-client/tests/unit/mcp-clients.test.ts
@@ -31,6 +31,7 @@ describe("Matrix MCP gateway client", () => {
       "https://app.matrix-os.com/vm/neo-review/api/terminal/sessions?runtime=review",
       expect.objectContaining({
         headers: { authorization: "Bearer scoped-token" },
+        redirect: "error",
         signal: expect.any(AbortSignal),
       }),
     );
@@ -72,6 +73,10 @@ describe("Matrix MCP gateway client", () => {
     }));
     await expect(createMcpGatewayClient(runtime, { fetch: actualFetcher }).downloadFile("large.bin"))
       .rejects.toMatchObject({ code: "payload_too_large" });
+    expect(actualFetcher).toHaveBeenCalledWith(
+      "https://app.matrix-os.com/vm/neo-review/api/files/blob?runtime=review&path=large.bin",
+      expect.objectContaining({ redirect: "error", signal: expect.any(AbortSignal) }),
+    );
   });
 
   it("uploads bytes with explicit overwrite and secret flags", async () => {

--- a/packages/sync-client/tests/unit/mcp-clients.test.ts
+++ b/packages/sync-client/tests/unit/mcp-clients.test.ts
@@ -123,14 +123,14 @@ describe("Matrix MCP gateway client", () => {
   it("parses the gateway's terminal creation acknowledgements", async () => {
     const fetcher = vi.fn<typeof fetch>()
       .mockResolvedValueOnce(new Response(JSON.stringify({ name: "agent-task", created: true }), { status: 201 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ tab: { ok: true } }), { status: 200 }));
+      .mockResolvedValueOnce(new Response(JSON.stringify({ tab: { id: 41, name: "tests" } }), { status: 200 }));
     const client = createMcpGatewayClient(runtime, { fetch: fetcher });
 
     await expect(client.createTerminal({ name: "agent-task" })).resolves.toEqual({
       name: "agent-task",
       created: true,
     });
-    await expect(client.createTab("agent-task", { name: "tests" })).resolves.toEqual({ created: true });
+    await expect(client.createTab("agent-task", { name: "tests" })).resolves.toEqual({ id: 41, name: "tests" });
   });
 
   it("preserves the bounded file response media type for UTF-8 reads", async () => {

--- a/packages/sync-client/tests/unit/mcp-profile-context.test.ts
+++ b/packages/sync-client/tests/unit/mcp-profile-context.test.ts
@@ -1,0 +1,190 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createMcpProfileContext,
+  resolveRuntimeSelectionOrigin,
+  runtimeApiUrl,
+} from "../../src/mcp/profile-context.js";
+
+const tempDirs: string[] = [];
+
+async function profileFixture(input: { expiresAt?: number; runtimeSlot?: string } = {}) {
+  const configDir = await mkdtemp(join(tmpdir(), "matrix-mcp-profile-"));
+  tempDirs.push(configDir);
+  await mkdir(join(configDir, "profiles", "cloud"), { recursive: true });
+  await writeFile(join(configDir, "profiles.json"), JSON.stringify({
+    active: "cloud",
+    profiles: {
+      cloud: {
+        platformUrl: "https://app.matrix-os.com",
+        gatewayUrl: "https://app.matrix-os.com",
+      },
+    },
+  }));
+  await writeFile(join(configDir, "profiles", "cloud", "auth.json"), JSON.stringify({
+    accessToken: "owner-token",
+    expiresAt: input.expiresAt ?? Date.now() + 60_000,
+    userId: "user_123",
+    handle: "neo",
+    runtimeSlot: input.runtimeSlot ?? "primary",
+  }));
+  return configDir;
+}
+
+function computer(runtimeSlot = "primary", availability = "available") {
+  const handle = runtimeSlot === "primary" ? "neo" : `neo-${runtimeSlot}`;
+  return {
+    handle,
+    runtimeSlot,
+    label: runtimeSlot === "primary" ? "Main Computer" : "Additional Computer",
+    availability,
+    kind: "customer",
+    versionLabel: "stable",
+    gatewayPath: runtimeSlot === "primary" ? `/vm/${handle}` : `/vm/${handle}?runtime=${runtimeSlot}`,
+    capabilities: ["terminal"],
+  };
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(tempDirs.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe("Matrix MCP profile context", () => {
+  it("maps the production app origin to the control-plane origin", () => {
+    expect(resolveRuntimeSelectionOrigin("https://app.matrix-os.com")).toBe("https://api.matrix-os.com");
+    expect(resolveRuntimeSelectionOrigin("http://localhost:9000/")).toBe("http://localhost:9000");
+    expect(resolveRuntimeSelectionOrigin("https://app.matrix-os.com", "https://control.example/")).toBe("https://control.example");
+    expect(() => resolveRuntimeSelectionOrigin("http://matrix.example"))
+      .toThrow(expect.objectContaining({ code: "invalid_input" }));
+  });
+
+  it("preserves the selected runtime query while appending a fixed API path", () => {
+    expect(runtimeApiUrl(
+      "https://app.matrix-os.com/vm/neo-review?runtime=review",
+      "/api/terminal/sessions/main/tabs",
+    )).toBe("https://app.matrix-os.com/vm/neo-review/api/terminal/sessions/main/tabs?runtime=review");
+    expect(() => runtimeApiUrl("http://matrix.example", "/api/terminal/sessions"))
+      .toThrow(expect.objectContaining({ code: "invalid_input" }));
+  });
+
+  it("lists only a validated owner inventory using the stored profile token", async () => {
+    const configDir = await profileFixture();
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({
+      items: [computer()],
+      selectedSlot: "primary",
+      hasMore: false,
+      limit: 20,
+    }), { status: 200, headers: { "content-type": "application/json" } }));
+
+    const context = createMcpProfileContext({ configDir, fetch: fetcher });
+    await expect(context.listComputers()).resolves.toMatchObject({ selectedSlot: "primary" });
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://app.matrix-os.com/api/auth/computers",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer owner-token" },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("fails closed before a request when profile auth is expired", async () => {
+    const configDir = await profileFixture({ expiresAt: Date.now() - 1 });
+    const fetcher = vi.fn<typeof fetch>();
+    const context = createMcpProfileContext({ configDir, fetch: fetcher });
+
+    await expect(context.listComputers()).rejects.toMatchObject({ code: "auth_required" });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("rejects unavailable and unknown computers without selecting them", async () => {
+    const configDir = await profileFixture();
+    const fetcher = vi.fn<typeof fetch>().mockImplementation(async () => new Response(JSON.stringify({
+      items: [computer("primary", "unavailable")],
+      selectedSlot: "primary",
+      hasMore: false,
+      limit: 20,
+    }), { status: 200 }));
+    const context = createMcpProfileContext({ configDir, fetch: fetcher });
+
+    await expect(context.resolveRuntime("primary")).rejects.toMatchObject({ code: "computer_unavailable" });
+    await expect(context.resolveRuntime("review")).rejects.toMatchObject({ code: "computer_not_found" });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("mints an in-memory token for a non-default computer without changing profile auth", async () => {
+    const configDir = await profileFixture();
+    const fetcher = vi.fn<typeof fetch>(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/api/auth/computers")) {
+        return new Response(JSON.stringify({
+          items: [computer(), computer("review")],
+          selectedSlot: "primary",
+          hasMore: false,
+          limit: 20,
+        }), { status: 200 });
+      }
+      expect(url).toBe("https://api.matrix-os.com/api/auth/runtime-selection");
+      expect(init).toMatchObject({
+        method: "POST",
+        headers: {
+          Authorization: "Bearer owner-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ slot: "review" }),
+      });
+      return new Response(JSON.stringify({
+        accessToken: "r".repeat(32),
+        expiresAt: Date.now() + 60_000,
+        handle: "neo-review",
+        slot: "review",
+      }), { status: 200 });
+    });
+    const context = createMcpProfileContext({ configDir, fetch: fetcher });
+
+    await expect(context.resolveRuntime("review")).resolves.toMatchObject({
+      token: "r".repeat(32),
+      gatewayUrl: "https://app.matrix-os.com/vm/neo-review?runtime=review",
+      computer: { runtimeSlot: "review", handle: "neo-review" },
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects an inventory whose selected slot is not present", async () => {
+    const configDir = await profileFixture();
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({
+      items: [computer("review")],
+      selectedSlot: "primary",
+      hasMore: false,
+      limit: 20,
+    }), { status: 200 }));
+    const context = createMcpProfileContext({ configDir, fetch: fetcher });
+
+    await expect(context.listComputers()).rejects.toMatchObject({ code: "request_failed" });
+  });
+
+  it("rejects an expired token minted for another computer", async () => {
+    const configDir = await profileFixture();
+    const fetcher = vi.fn<typeof fetch>(async (input) => {
+      if (String(input).endsWith("/api/auth/computers")) {
+        return new Response(JSON.stringify({
+          items: [computer(), computer("review")],
+          selectedSlot: "primary",
+          hasMore: false,
+          limit: 20,
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({
+        accessToken: "r".repeat(32),
+        expiresAt: Date.now() - 1,
+        handle: "neo-review",
+        slot: "review",
+      }), { status: 200 });
+    });
+    const context = createMcpProfileContext({ configDir, fetch: fetcher });
+
+    await expect(context.resolveRuntime("review")).rejects.toMatchObject({ code: "request_failed" });
+  });
+});

--- a/packages/sync-client/tests/unit/mcp-profile-context.test.ts
+++ b/packages/sync-client/tests/unit/mcp-profile-context.test.ts
@@ -85,6 +85,7 @@ describe("Matrix MCP profile context", () => {
       "https://app.matrix-os.com/api/auth/computers",
       expect.objectContaining({
         headers: { Authorization: "Bearer owner-token" },
+        redirect: "error",
         signal: expect.any(AbortSignal),
       }),
     );
@@ -129,6 +130,7 @@ describe("Matrix MCP profile context", () => {
       expect(url).toBe("https://api.matrix-os.com/api/auth/runtime-selection");
       expect(init).toMatchObject({
         method: "POST",
+        redirect: "error",
         headers: {
           Authorization: "Bearer owner-token",
           "Content-Type": "application/json",

--- a/packages/sync-client/tests/unit/mcp-schemas.test.ts
+++ b/packages/sync-client/tests/unit/mcp-schemas.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  DownloadFileInputSchema,
+  MatrixPathSchema,
+  RunCommandInputSchema,
+  SendTerminalInputSchema,
+  UploadFileInputSchema,
+  decodeUploadContent,
+} from "../../src/mcp/schemas.js";
+import { toSafeMcpError } from "../../src/mcp/errors.js";
+
+describe("Matrix MCP boundary schemas", () => {
+  it("normalizes owner-relative Matrix paths and rejects escape syntax", () => {
+    expect(MatrixPathSchema.parse("~/projects/./matrix/README.md")).toBe("projects/matrix/README.md");
+    expect(MatrixPathSchema.parse(".")).toBe(".");
+    for (const path of ["/etc/passwd", "../secret", "projects/../../secret", "projects\\secret", "bad\0path", "bad\npath"]) {
+      expect(MatrixPathSchema.safeParse(path).success, path).toBe(false);
+    }
+  });
+
+  it("caps command argv, command items, cwd, and timeout", () => {
+    expect(RunCommandInputSchema.parse({
+      computer: "review-1",
+      command: ["git", "status", "--short"],
+      cwd: "~/projects/repo",
+      timeoutMs: 1_800_000,
+    })).toEqual({
+      computer: "review-1",
+      command: ["git", "status", "--short"],
+      cwd: "projects/repo",
+      timeoutMs: 1_800_000,
+    });
+    expect(RunCommandInputSchema.safeParse({ computer: "review-1", command: [] }).success).toBe(false);
+    expect(RunCommandInputSchema.safeParse({ computer: "review_1", command: ["pwd"] }).success).toBe(false);
+    expect(RunCommandInputSchema.safeParse({ computer: "review-1", command: ["x".repeat(4097)] }).success).toBe(false);
+    expect(RunCommandInputSchema.safeParse({ computer: "review-1", command: ["pwd"], timeoutMs: 1_800_001 }).success).toBe(false);
+  });
+
+  it("uses a stricter byte cap for terminal input", () => {
+    expect(SendTerminalInputSchema.parse({
+      computer: "primary",
+      terminal: "agent-task",
+      data: "bun test\n",
+    }).data).toBe("bun test\n");
+    expect(SendTerminalInputSchema.safeParse({
+      computer: "primary",
+      terminal: "agent-task",
+      data: "😀".repeat(15_001),
+    }).success).toBe(false);
+  });
+
+  it("accepts exact base64 uploads and rejects malformed or oversized content", () => {
+    const input = UploadFileInputSchema.parse({
+      computer: "primary",
+      path: "artifacts/pixel.bin",
+      encoding: "base64",
+      content: Buffer.from([0, 1, 2, 255]).toString("base64"),
+    });
+    expect(decodeUploadContent(input)).toEqual(Buffer.from([0, 1, 2, 255]));
+
+    expect(UploadFileInputSchema.safeParse({
+      computer: "primary",
+      path: "artifacts/pixel.bin",
+      encoding: "base64",
+      content: "not-base64!",
+    }).success).toBe(false);
+    expect(UploadFileInputSchema.safeParse({
+      computer: "primary",
+      path: "artifacts/large.bin",
+      encoding: "utf8",
+      content: "x".repeat(1024 * 1024 + 1),
+    }).success).toBe(false);
+  });
+
+  it("does not accept a local destination for downloads", () => {
+    expect(DownloadFileInputSchema.safeParse({
+      computer: "primary",
+      path: "artifacts/report.pdf",
+      localPath: "/tmp/report.pdf",
+    }).success).toBe(false);
+  });
+});
+
+describe("safe MCP errors", () => {
+  it("maps known errors and hides unknown messages", () => {
+    expect(toSafeMcpError(Object.assign(new Error("token expired at secret path"), { code: "auth_expired" }))).toEqual({
+      code: "auth_required",
+      message: "Authenticate with the Matrix CLI and try again.",
+      retryable: false,
+    });
+    expect(toSafeMcpError(new Error("postgres://secret@private-host/db"))).toEqual({
+      code: "request_failed",
+      message: "Matrix could not complete the request.",
+      retryable: true,
+    });
+  });
+});

--- a/packages/sync-client/tests/unit/mcp-schemas.test.ts
+++ b/packages/sync-client/tests/unit/mcp-schemas.test.ts
@@ -3,6 +3,7 @@ import {
   DownloadFileInputSchema,
   MatrixPathSchema,
   RunCommandInputSchema,
+  SelectTerminalTabInputSchema,
   SendTerminalInputSchema,
   UploadFileInputSchema,
   decodeUploadContent,
@@ -46,6 +47,19 @@ describe("Matrix MCP boundary schemas", () => {
       computer: "primary",
       terminal: "agent-task",
       data: "😀".repeat(15_001),
+    }).success).toBe(false);
+  });
+
+  it("selects tabs only by a stable non-negative tab ID", () => {
+    expect(SelectTerminalTabInputSchema.parse({
+      computer: "primary",
+      terminal: "agent-task",
+      tabId: 41,
+    }).tabId).toBe(41);
+    expect(SelectTerminalTabInputSchema.safeParse({
+      computer: "primary",
+      terminal: "agent-task",
+      tab: 1,
     }).success).toBe(false);
   });
 

--- a/packages/sync-client/tests/unit/mcp-schemas.test.ts
+++ b/packages/sync-client/tests/unit/mcp-schemas.test.ts
@@ -8,7 +8,7 @@ import {
   UploadFileInputSchema,
   decodeUploadContent,
 } from "../../src/mcp/schemas.js";
-import { toSafeMcpError } from "../../src/mcp/errors.js";
+import { createMcpError, toSafeMcpError } from "../../src/mcp/errors.js";
 
 describe("Matrix MCP boundary schemas", () => {
   it("normalizes owner-relative Matrix paths and rejects escape syntax", () => {
@@ -96,6 +96,14 @@ describe("Matrix MCP boundary schemas", () => {
 });
 
 describe("safe MCP errors", () => {
+  it("preserves authentication errors produced by the MCP clients", () => {
+    expect(toSafeMcpError(createMcpError("auth_required"))).toEqual({
+      code: "auth_required",
+      message: "Authenticate with the Matrix CLI and try again.",
+      retryable: false,
+    });
+  });
+
   it("maps known errors and hides unknown messages", () => {
     expect(toSafeMcpError(Object.assign(new Error("token expired at secret path"), { code: "auth_expired" }))).toEqual({
       code: "auth_required",

--- a/plugins/matrix-os/.codex-plugin/plugin.json
+++ b/plugins/matrix-os/.codex-plugin/plugin.json
@@ -1,20 +1,21 @@
 {
   "name": "matrix-os",
-  "version": "0.2.0",
-  "description": "Run development work on your Matrix cloud computer",
+  "version": "0.3.0",
+  "description": "Run development work on your Matrix computer through skills and remote MCP tools",
   "author": {
     "name": "Matrix OS"
   },
   "homepage": "https://matrix-os.com",
   "repository": "https://github.com/HamedMP/matrix-os",
   "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "Matrix OS",
-    "shortDescription": "Run development work on your Matrix cloud computer",
-    "longDescription": "Set up and recover your Matrix cloud computer, run commands and coding-agent tasks, and safely clone or update GitHub projects without moving local credentials.",
+    "shortDescription": "Run development work on your Matrix computer",
+    "longDescription": "List Matrix computers, run captured commands, manage persistent terminals and tabs, transfer bounded files, inspect chats, and safely clone or update GitHub projects without moving local credentials.",
     "developerName": "Matrix OS",
     "category": "Productivity",
-    "capabilities": ["Read", "Write"],
+    "capabilities": ["Interactive", "Read", "Write"],
     "websiteURL": "https://matrix-os.com",
     "brandColor": "#434E3F",
     "composerIcon": "./assets/matrix-icon.png",

--- a/plugins/matrix-os/.mcp.json
+++ b/plugins/matrix-os/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "matrix-remote-computer": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@finnaai/matrix@0.3.16",
+        "mcp",
+        "serve",
+        "--profile",
+        "cloud"
+      ]
+    }
+  }
+}

--- a/plugins/matrix-os/skills/matrix-cloud-run/SKILL.md
+++ b/plugins/matrix-os/skills/matrix-cloud-run/SKILL.md
@@ -5,12 +5,22 @@ description: Run commands and coding-agent tasks in observable Matrix OS session
 
 # Run Work on Matrix OS
 
-Execute every remote workflow in a uniquely named Matrix CLI session so the user can observe and reattach it.
+Use Matrix MCP tools for remote work when they are available. Use the Matrix CLI fallback only for authentication, MCP recovery, or clients that do not expose the remote tools.
 
-## Session policy
+## MCP-first execution
+
+1. Call `list_computers` and choose the explicit `runtimeSlot`; never guess or silently fall back to another computer.
+2. Use `run_command` with an argv array for short probes that need captured output.
+3. For observable or long-running work, use `create_terminal`, `create_terminal_tab` when useful, `select_terminal_tab`, and `send_terminal_input`. Report the terminal and tab names so the user can reconnect in Matrix.
+4. Use `list_files`, `read_file`, `download_file`, and `upload_file` for bounded Matrix-home files. These tools never read or write arbitrary local paths.
+5. Use `list_chats`, `search_chats`, and `get_chat` only when prior Matrix chat context is relevant; these tools are read-only.
+
+If a tool returns `auth_required`, use the CLI fallback below to authenticate. If MCP tools are not present, continue with the CLI fallback rather than claiming remote execution is unavailable.
+
+## CLI fallback session policy
 
 - Always use `matrix run -it --session <session-name> ... -- <argv...>` for remote commands.
-- Never create or use shell tabs. When another terminal or concurrent task is needed, create a separate uniquely named session.
+- When using the CLI fallback, create a separate uniquely named session for every additional terminal or concurrent task because the current CLI workflow does not address tabs directly.
 - Use a short collision-resistant suffix in names such as `readiness-<suffix>`, `inspect-<slug>-<suffix>`, or `task-<slug>-<suffix>`.
 - Report every session name and `matrix shell connect <session-name>` command immediately.
 - Pass prompts as command arguments after `--`; never interpolate user input into `sh -c`, `bash -lc`, substitutions, or a single shell string.

--- a/plugins/matrix-os/skills/matrix-github-project/SKILL.md
+++ b/plugins/matrix-os/skills/matrix-github-project/SKILL.md
@@ -5,12 +5,22 @@ description: Clone, verify, reuse, and change GitHub repositories in observable 
 
 # Work on GitHub Projects in Matrix OS
 
-Authenticate and inspect everything on the Matrix VPS, preserve existing work, and push or open a PR only when explicitly requested.
+Authenticate and inspect everything on the Matrix VPS, preserve existing work, and push or open a PR only when explicitly requested. Prefer Matrix MCP tools and retain the CLI fallback for authentication and recovery.
 
-## Session policy
+## MCP-first execution
+
+1. Call `list_computers` and target one explicit `runtimeSlot` for every operation.
+2. Use `run_command` argv arrays for repository probes, Git operations, tests, and other work that needs captured output.
+3. Use `create_terminal`, `create_terminal_tab`, `select_terminal_tab`, and `send_terminal_input` for long-running or user-observable work. Report the terminal/tab identity.
+4. Use bounded file tools only for Matrix-home content; never move local credentials or accept arbitrary local paths.
+5. Use read-only chat tools when a prior Matrix chat is necessary to recover project context.
+
+If MCP reports `auth_required` or the tools are absent, authenticate or continue through the CLI fallback below.
+
+## CLI fallback session policy
 
 - Always run remote work with `matrix run -it --session <session-name> ... -- <argv...>`.
-- Never create or use shell tabs. Create a separate uniquely named session for every additional command, terminal, or concurrent task.
+- When using the CLI fallback, create a separate uniquely named session for every additional command, terminal, or concurrent task because the current CLI workflow does not address tabs directly.
 - Use collision-resistant names such as `readiness-github-<suffix>`, `inspect-<repo>-<suffix>`, `clone-<repo>-<suffix>`, and `task-<slug>-<suffix>`.
 - Report every session name and its `matrix shell connect <session-name>` command.
 - Pass arguments after `--`; never interpolate user input into a shell string.

--- a/plugins/matrix-os/skills/matrix-onboarding/SKILL.md
+++ b/plugins/matrix-os/skills/matrix-onboarding/SKILL.md
@@ -5,7 +5,13 @@ description: Set up, authenticate, diagnose, and recover a Matrix OS cloud compu
 
 # Matrix OS Setup and Recovery
 
-Prepare the user's Matrix cloud computer without collecting or transferring local secrets.
+Prepare the user's Matrix cloud computer without collecting or transferring local secrets. Prefer the bundled Matrix MCP tools after authentication and use the CLI fallback for login, diagnosis, and recovery.
+
+## MCP readiness
+
+When remote tools are available, call `list_computers` first. After selecting an explicit `runtimeSlot`, use `run_command` for captured readiness checks and the terminal tools (`create_terminal`, `create_terminal_tab`, `select_terminal_tab`, and `send_terminal_input`) for observable authentication or recovery work. Never pass credentials as tool arguments.
+
+If `list_computers` returns `auth_required`, complete the CLI fallback readiness gate below. If the tools are absent, continue with the CLI fallback and re-open the coding-agent conversation after installing or updating the plugin.
 
 ## Safety and session rules
 
@@ -14,8 +20,8 @@ Prepare the user's Matrix cloud computer without collecting or transferring loca
 - Never ask for tokens, OAuth codes, API keys, or credential contents in chat.
 - Ask before deleting files, resetting authentication or sessions, or installing global tools.
 - Prefer Matrix's visible developer-tool installation path for missing agents or GitHub CLI.
-- Always run remote work in a uniquely named session created with `matrix run -it --session`.
-- Never create or use shell tabs. Open a separate uniquely named session whenever another terminal or concurrent task is needed.
+- With MCP, use explicit named terminals and tabs and report their identities.
+- With the CLI fallback, run remote work in a uniquely named session created with `matrix run -it --session`; create another session for concurrent work because the current CLI workflow does not address tabs directly.
 - Report every session name and its `matrix shell connect <session-name>` command.
 - Use the existing Matrix CLI. Do not invent endpoints, SSH access, persistence, or detached-job APIs.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -917,6 +917,9 @@ importers:
 
   packages/sync-client:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.30.0(zod@4.4.3)
       chokidar:
         specifier: ^4.0.0
         version: 4.0.3

--- a/specs/120-remote-computer-mcp/checklists/requirements.md
+++ b/specs/120-remote-computer-mcp/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Remote Computer MCP
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-09-04
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed in one review iteration. Security-specific limits and the authorization matrix are included because they define observable product guarantees rather than an implementation choice.

--- a/specs/120-remote-computer-mcp/contracts/tools.md
+++ b/specs/120-remote-computer-mcp/contracts/tools.md
@@ -1,0 +1,143 @@
+# MCP Tool Contract: Matrix Remote Computer
+
+All tool names are exposed under the MCP server namespace chosen by the coding-agent host. JSON examples omit the outer MCP protocol envelope.
+
+Every computer-scoped input requires `computer`, the `runtimeSlot` returned by `list_computers`. Every result includes a machine-readable `ok` boolean. Failures use a safe code and message; credentials and raw upstream bodies are never returned.
+
+## Discovery
+
+### `list_computers`
+
+Input: `{}`
+
+Output:
+
+```json
+{"ok":true,"computers":[{"runtimeSlot":"primary","handle":"neo","label":"Main Computer","availability":"available","kind":"customer","versionLabel":"stable","capabilities":[]}],"selectedSlot":"primary","hasMore":false}
+```
+
+Annotation: read-only, open-world.
+
+## Commands
+
+### `run_command`
+
+Input:
+
+```json
+{"computer":"primary","command":["git","status","--short"],"cwd":"projects/repo","timeoutMs":60000}
+```
+
+Output:
+
+```json
+{"ok":true,"computer":{"runtimeSlot":"primary","handle":"neo"},"stdout":"","stderr":"","exitCode":0,"signal":null,"timedOut":false,"truncated":false,"durationMs":18}
+```
+
+Annotation: state-changing, open-world. Although commands may be read-only, their effect is determined by argv, so this tool is never marked read-only.
+
+## Persistent terminals
+
+### `list_terminals`
+
+Input: `{"computer":"primary"}`
+
+Output: `{"ok":true,"terminals":[...bounded safe terminal metadata...]}`
+
+### `create_terminal`
+
+Input: `{"computer":"primary","name":"agent-task-4f2a","cwd":"projects/repo"}`
+
+Output: `{"ok":true,"terminal":{"name":"agent-task-4f2a","created":true}}`
+
+### `list_terminal_tabs`
+
+Input: `{"computer":"primary","terminal":"agent-task-4f2a"}`
+
+Output: `{"ok":true,"tabs":[{"idx":0,"name":"shell"}]}`
+
+### `create_terminal_tab`
+
+Input: `{"computer":"primary","terminal":"agent-task-4f2a","name":"tests","cwd":"projects/repo"}`
+
+Output: `{"ok":true,"tab":{"created":true}}`
+
+### `select_terminal_tab`
+
+Input: `{"computer":"primary","terminal":"agent-task-4f2a","tab":1}`
+
+Output: `{"ok":true,"terminal":"agent-task-4f2a","tab":1}`
+
+### `send_terminal_input`
+
+Input: `{"computer":"primary","terminal":"agent-task-4f2a","data":"bun run test\n"}`
+
+Output: `{"ok":true,"terminal":"agent-task-4f2a","bytes":13}`
+
+Terminal listing is read-only. Create/select/input operations are state-changing and open-world. Input is sent to the currently active tab; callers use `select_terminal_tab` first when tab identity matters.
+
+## Files
+
+### `list_files`
+
+Input: `{"computer":"primary","path":"projects/repo"}`
+
+Output: `{"ok":true,"path":"projects/repo","entries":[...up to 500...]}`
+
+### `read_file`
+
+Input: `{"computer":"primary","path":"projects/repo/README.md"}`
+
+Output: `{"ok":true,"path":"projects/repo/README.md","encoding":"utf8","content":"...","size":1234,"mediaType":"text/markdown"}`
+
+### `download_file`
+
+Input: `{"computer":"primary","path":"artifacts/report.pdf"}`
+
+Output: `{"ok":true,"path":"artifacts/report.pdf","filename":"report.pdf","encoding":"base64","content":"JVBERi0...","size":8192,"mediaType":"application/pdf"}`
+
+### `upload_file`
+
+UTF-8 input:
+
+```json
+{"computer":"primary","path":"projects/repo/notes.txt","encoding":"utf8","content":"hello\n","overwrite":false,"secret":false}
+```
+
+Binary input uses `"encoding":"base64"`. Output is `{"ok":true,"path":"...","size":6}`.
+
+List/read/download are read-only and open-world. Upload is state-changing and open-world; overwrite defaults to false.
+
+## Chats
+
+### `list_chats`
+
+Input: `{"computer":"primary","limit":20,"lifecycle":"active","cursor":"optional-cursor"}`
+
+Output: `{"ok":true,"items":[...],"nextCursor":"optional-cursor"}`
+
+### `search_chats`
+
+Input: `{"computer":"primary","query":"terminal bug","limit":20}`
+
+Output follows `list_chats`.
+
+### `get_chat`
+
+Input: `{"computer":"primary","chatId":"chat_...","limit":100,"cursor":"optional-cursor"}`
+
+Output: `{"ok":true,"record":{...},"messages":[...up to 100...],"nextCursor":"optional-cursor"}`
+
+All chat tools are read-only and open-world.
+
+## Safe error shape
+
+```json
+{"ok":false,"error":{"code":"auth_required","message":"Authenticate with the Matrix CLI and try again.","retryable":false}}
+```
+
+Allowed public codes: `invalid_input`, `auth_required`, `computer_not_found`, `computer_unavailable`, `not_found`, `conflict`, `payload_too_large`, `request_timeout`, and `request_failed`.
+
+## Transport lifecycle
+
+The command `matrix mcp serve [--profile <name>]` starts one stdio server, loads no owner data merely for protocol initialization, and exits when stdin closes or the transport disconnects. It never emits human-readable text on stdout.

--- a/specs/120-remote-computer-mcp/contracts/tools.md
+++ b/specs/120-remote-computer-mcp/contracts/tools.md
@@ -54,19 +54,19 @@ Output: `{"ok":true,"terminal":{"name":"agent-task-4f2a","created":true}}`
 
 Input: `{"computer":"primary","terminal":"agent-task-4f2a"}`
 
-Output: `{"ok":true,"tabs":[{"idx":0,"name":"shell"}]}`
+Output: `{"ok":true,"tabs":[{"id":17,"idx":0,"name":"shell"}]}`
 
 ### `create_terminal_tab`
 
 Input: `{"computer":"primary","terminal":"agent-task-4f2a","name":"tests","cwd":"projects/repo"}`
 
-Output: `{"ok":true,"tab":{"created":true}}`
+Output: `{"ok":true,"tab":{"id":41,"name":"tests"}}`
 
 ### `select_terminal_tab`
 
-Input: `{"computer":"primary","terminal":"agent-task-4f2a","tab":1}`
+Input: `{"computer":"primary","terminal":"agent-task-4f2a","tabId":41}`
 
-Output: `{"ok":true,"terminal":"agent-task-4f2a","tab":1}`
+Output: `{"ok":true,"terminal":"agent-task-4f2a","tabId":41}`
 
 ### `send_terminal_input`
 
@@ -74,7 +74,9 @@ Input: `{"computer":"primary","terminal":"agent-task-4f2a","data":"bun run test\
 
 Output: `{"ok":true,"terminal":"agent-task-4f2a","bytes":13}`
 
-Terminal listing is read-only. Create/select/input operations are state-changing and open-world. Input is sent to the currently active tab; callers use `select_terminal_tab` first when tab identity matters.
+Terminal listing is read-only. Create/select/input operations are state-changing and open-world. `id` is the stable Zellij tab ID; `idx` is the current display position. Input is sent to the currently active tab, so callers pass the stable `id` to `select_terminal_tab` first when tab identity matters.
+
+The gateway returns the ID emitted by `zellij action new-tab` and accepts it at `POST /api/terminal/sessions/:name/tabs/by-id/:tabId/go`. The existing position-based tab route remains unchanged for current shell clients. Both routes use the same computer-scoped gateway authentication boundary; the stable-ID route has bounded-body middleware and validates both path parameters.
 
 ## Files
 

--- a/specs/120-remote-computer-mcp/contracts/tools.md
+++ b/specs/120-remote-computer-mcp/contracts/tools.md
@@ -1,145 +1,61 @@
 # MCP Tool Contract: Matrix Remote Computer
 
-All tool names are exposed under the MCP server namespace chosen by the coding-agent host. JSON examples omit the outer MCP protocol envelope.
+All scoped inputs require `computer`, the `runtimeSlot` returned by `list_computers`. Results include `ok`; failures expose only allowlisted codes/messages, never credentials or upstream bodies.
 
-Every computer-scoped input requires `computer`, the `runtimeSlot` returned by `list_computers`. Every result includes a machine-readable `ok` boolean. Failures use a safe code and message; credentials and raw upstream bodies are never returned.
+| Tool | Required input | Result | Semantics |
+|---|---|---|---|
+| `list_computers` | none | computers, selected slot, pagination flag | read-only |
+| `run_command` | computer, argv | bounded output/exit metadata | state-changing |
+| `list_terminals` | computer | bounded session metadata | read-only |
+| `create_terminal` | computer, name | created session | state-changing |
+| `list_terminal_tabs` | computer, terminal | stable IDs, positions, names/focus | read-only |
+| `create_terminal_tab` | computer, terminal | stable tab ID/name | state-changing |
+| `select_terminal_tab` | computer, terminal, stable tab ID | selection acknowledgement | state-changing |
+| `send_terminal_input` | computer, terminal, data | accepted byte count | state-changing |
+| `list_files` | computer, path | at most 500 entries | read-only |
+| `read_file` | computer, path | UTF-8 content, metadata | read-only |
+| `download_file` | computer, path | base64 content, metadata | read-only |
+| `upload_file` | computer, path, encoding/content | path and size | state-changing |
+| `list_chats` | computer | bounded summaries/cursor | read-only |
+| `search_chats` | computer, query | bounded summaries/cursor | read-only |
+| `get_chat` | computer, chat ID | record, up to 100 messages/cursor | read-only |
 
-## Discovery
+Every tool is open-world because it contacts Matrix. `run_command` is state-changing regardless of argv. Upload overwrite defaults false; all chat tools are read-only.
 
-### `list_computers`
-
-Input: `{}`
-
-Output:
-
-```json
-{"ok":true,"computers":[{"runtimeSlot":"primary","handle":"neo","label":"Main Computer","availability":"available","kind":"customer","versionLabel":"stable","capabilities":[]}],"selectedSlot":"primary","hasMore":false}
-```
-
-Annotation: read-only, open-world.
-
-## Commands
-
-### `run_command`
-
-Input:
+## Representative messages
 
 ```json
 {"computer":"primary","command":["git","status","--short"],"cwd":"projects/repo","timeoutMs":60000}
 ```
 
-Output:
-
 ```json
 {"ok":true,"computer":{"runtimeSlot":"primary","handle":"neo"},"stdout":"","stderr":"","exitCode":0,"signal":null,"timedOut":false,"truncated":false,"durationMs":18}
 ```
 
-Annotation: state-changing, open-world. Although commands may be read-only, their effect is determined by argv, so this tool is never marked read-only.
+```json
+{"computer":"primary","terminal":"agent-task-4f2a","name":"tests","cwd":"projects/repo"}
+```
 
-## Persistent terminals
+```json
+{"ok":true,"tab":{"id":41,"name":"tests"}}
+```
 
-### `list_terminals`
+`id` is the stable Zellij tab ID; `idx` from listing is only its current display position. Callers select by `id` before sending input when identity matters. The gateway returns the ID emitted by `zellij action new-tab` and accepts it at `POST /api/terminal/sessions/:name/tabs/by-id/:tabId/go`; the position route stays compatible. The stable-ID route uses existing computer-scoped auth, bounded-body middleware, and validated path parameters.
 
-Input: `{"computer":"primary"}`
-
-Output: `{"ok":true,"terminals":[...bounded safe terminal metadata...]}`
-
-### `create_terminal`
-
-Input: `{"computer":"primary","name":"agent-task-4f2a","cwd":"projects/repo"}`
-
-Output: `{"ok":true,"terminal":{"name":"agent-task-4f2a","created":true}}`
-
-### `list_terminal_tabs`
-
-Input: `{"computer":"primary","terminal":"agent-task-4f2a"}`
-
-Output: `{"ok":true,"tabs":[{"id":17,"idx":0,"name":"shell"}]}`
-
-### `create_terminal_tab`
-
-Input: `{"computer":"primary","terminal":"agent-task-4f2a","name":"tests","cwd":"projects/repo"}`
-
-Output: `{"ok":true,"tab":{"id":41,"name":"tests"}}`
-
-### `select_terminal_tab`
-
-Input: `{"computer":"primary","terminal":"agent-task-4f2a","tabId":41}`
-
-Output: `{"ok":true,"terminal":"agent-task-4f2a","tabId":41}`
-
-### `send_terminal_input`
-
-Input: `{"computer":"primary","terminal":"agent-task-4f2a","data":"bun run test\n"}`
-
-Output: `{"ok":true,"terminal":"agent-task-4f2a","bytes":13}`
-
-Terminal listing is read-only. Create/select/input operations are state-changing and open-world. `id` is the stable Zellij tab ID; `idx` is the current display position. Input is sent to the currently active tab, so callers pass the stable `id` to `select_terminal_tab` first when tab identity matters.
-
-The gateway returns the ID emitted by `zellij action new-tab` and accepts it at `POST /api/terminal/sessions/:name/tabs/by-id/:tabId/go`. The existing position-based tab route remains unchanged for current shell clients. Both routes use the same computer-scoped gateway authentication boundary; the stable-ID route has bounded-body middleware and validates both path parameters.
-
-## Files
-
-### `list_files`
-
-Input: `{"computer":"primary","path":"projects/repo"}`
-
-Output: `{"ok":true,"path":"projects/repo","entries":[...up to 500...]}`
-
-### `read_file`
-
-Input: `{"computer":"primary","path":"projects/repo/README.md"}`
-
-Output: `{"ok":true,"path":"projects/repo/README.md","encoding":"utf8","content":"...","size":1234,"mediaType":"text/markdown"}`
-
-### `download_file`
-
-Input: `{"computer":"primary","path":"artifacts/report.pdf"}`
-
-Output: `{"ok":true,"path":"artifacts/report.pdf","filename":"report.pdf","encoding":"base64","content":"JVBERi0...","size":8192,"mediaType":"application/pdf"}`
-
-### `upload_file`
-
-UTF-8 input:
+File transfer is content-only:
 
 ```json
 {"computer":"primary","path":"projects/repo/notes.txt","encoding":"utf8","content":"hello\n","overwrite":false,"secret":false}
 ```
 
-Binary input uses `"encoding":"base64"`. Output is `{"ok":true,"path":"...","size":6}`.
+Binary upload/download uses base64. Text reads cap at 256 KiB, binary at 1 MiB, terminal input at 60,000 characters, command output at 1 MiB combined, directories at 500 entries, and chat pages at 100.
 
-List/read/download are read-only and open-world. Upload is state-changing and open-world; overwrite defaults to false.
-
-## Chats
-
-### `list_chats`
-
-Input: `{"computer":"primary","limit":20,"lifecycle":"active","cursor":"optional-cursor"}`
-
-Output: `{"ok":true,"items":[...],"nextCursor":"optional-cursor"}`
-
-### `search_chats`
-
-Input: `{"computer":"primary","query":"terminal bug","limit":20}`
-
-Output follows `list_chats`.
-
-### `get_chat`
-
-Input: `{"computer":"primary","chatId":"chat_...","limit":100,"cursor":"optional-cursor"}`
-
-Output: `{"ok":true,"record":{...},"messages":[...up to 100...],"nextCursor":"optional-cursor"}`
-
-All chat tools are read-only and open-world.
-
-## Safe error shape
+## Safe errors and transport
 
 ```json
 {"ok":false,"error":{"code":"auth_required","message":"Authenticate with the Matrix CLI and try again.","retryable":false}}
 ```
 
-Allowed public codes: `invalid_input`, `auth_required`, `computer_not_found`, `computer_unavailable`, `not_found`, `conflict`, `payload_too_large`, `request_timeout`, and `request_failed`.
+Allowed codes: `invalid_input`, `auth_required`, `computer_not_found`, `computer_unavailable`, `not_found`, `conflict`, `payload_too_large`, `request_timeout`, `request_failed`.
 
-## Transport lifecycle
-
-The command `matrix mcp serve [--profile <name>]` starts one stdio server, loads no owner data merely for protocol initialization, and exits when stdin closes or the transport disconnects. It never emits human-readable text on stdout.
+`matrix mcp serve [--profile <name>]` starts one stdio server, performs no owner-data read during protocol initialization, emits protocol data only on stdout, and exits when stdin or transport disconnects.

--- a/specs/120-remote-computer-mcp/data-model.md
+++ b/specs/120-remote-computer-mcp/data-model.md
@@ -1,0 +1,139 @@
+# Data Model: Remote Computer MCP
+
+This feature adds no persisted entities. The model below defines validated request/response projections held only for one MCP tool call.
+
+## CLI Principal
+
+Fields:
+
+- `profileName`: active or explicitly configured CLI profile name.
+- `platformUrl`: trusted platform origin from the profile.
+- `gatewayUrl`: current gateway origin from the profile.
+- `accessToken`: existing owner bearer, held process-private.
+- `expiresAt`: absolute expiry used before network access.
+- `userId`, `handle`, `runtimeSlot`: authenticated identity metadata; never returned wholesale.
+
+Rules:
+
+- Missing or expired auth transitions directly to `auth_required`.
+- Tokens never appear in tool input, tool output, logs, or persisted MCP state.
+
+## Computer Reference
+
+Fields:
+
+- `handle`: safe display/routing handle.
+- `runtimeSlot`: stable tool-facing identifier, 1-32 safe characters.
+- `label`, `availability`, `kind`, `versionLabel`, `capabilities`.
+- `gatewayPath`: inventory-derived relative path that must exactly match handle and slot.
+
+Relationships:
+
+- Many computer references belong to one CLI principal.
+- One scoped tool call targets exactly one computer reference.
+
+State transitions:
+
+```text
+unknown -> inventory member -> available -> scoped runtime access
+                         \-> unavailable -> safe rejection
+```
+
+## Scoped Runtime Access
+
+Fields:
+
+- `computer`: resolved computer reference.
+- `gatewayBase`: trusted origin plus validated inventory path.
+- `accessToken`: current token if already scoped, otherwise a non-persisted replacement.
+- `expiresAt`: replacement expiry when minted.
+
+Rules:
+
+- Created for one operation; no token cache is introduced, avoiding a new in-memory collection and eviction lifecycle.
+
+## Terminal Session
+
+Fields are projected from the gateway response and include a validated name plus safe status/metadata fields. Unknown server fields are discarded.
+
+Relationships:
+
+- Belongs to one computer.
+- Owns zero or more terminal tabs.
+
+State transitions:
+
+```text
+absent --create--> active
+active --list/read/input--> active
+```
+
+Deletion is outside scope.
+
+## Terminal Tab
+
+Fields:
+
+- `index`: non-negative safe integer supplied by zellij/Matrix.
+- `name`: bounded display name when available.
+- `active`: boolean when available.
+
+State transitions:
+
+```text
+absent --create--> present
+present --select--> active
+active --send input--> active
+```
+
+## Captured Command
+
+Input:
+
+- `computer`: runtime slot.
+- `command`: 1-64 argv items, each 1-4096 characters.
+- `cwd`: optional normalized Matrix-home-relative path.
+- `timeoutMs`: optional, 1 second through 30 minutes.
+
+Result:
+
+- `computer`: selected runtime slot/handle.
+- `stdout`, `stderr`: bounded strings.
+- `exitCode`, `signal`, `timedOut`, `truncated`, `durationMs`.
+
+Lifecycle is one request; no record is persisted.
+
+## Remote File Payload
+
+Fields:
+
+- `computer`, `path`, `filename`, `mediaType`, `size`.
+- `encoding`: `utf8` or `base64`.
+- `content`: bounded data matching encoding.
+- `overwrite`, `secret`: explicit upload flags.
+
+Rules:
+
+- Paths normalize within Matrix home; absolute and traversal paths are invalid.
+- Text read is at most 256 KiB; binary transfer is at most 1 MiB.
+- Existing files remain unchanged unless `overwrite=true`.
+- Download never gains a local destination field.
+
+## Chat Page
+
+Inputs:
+
+- `computer`.
+- `limit`: 1-100.
+- optional safe `cursor`, `lifecycle`, `projectId`, `query`.
+- detail additionally requires canonical `chatId`.
+
+Result:
+
+- projected canonical chat records and, for detail, at most 100 messages.
+- `nextCursor` when another page exists.
+
+Rules:
+
+- Data is read-only.
+- Unknown/cross-owner ids are indistinguishable as `not_found`.

--- a/specs/120-remote-computer-mcp/data-model.md
+++ b/specs/120-remote-computer-mcp/data-model.md
@@ -1,139 +1,39 @@
 # Data Model: Remote Computer MCP
 
-This feature adds no persisted entities. The model below defines validated request/response projections held only for one MCP tool call.
+No entity is persisted. These are validated, per-call projections.
 
-## CLI Principal
+## CLI principal and runtime
 
-Fields:
+- **CLI principal**: profile name; trusted platform/gateway origins; process-private owner token and expiry; authenticated user, handle, and runtime slot.
+- **Computer reference**: safe handle; stable `runtimeSlot`; label, availability, kind, version, capabilities; inventory-derived `gatewayPath` that must match handle and slot.
+- **Scoped runtime**: one computer, validated gateway base, and current or freshly minted non-persisted token.
 
-- `profileName`: active or explicitly configured CLI profile name.
-- `platformUrl`: trusted platform origin from the profile.
-- `gatewayUrl`: current gateway origin from the profile.
-- `accessToken`: existing owner bearer, held process-private.
-- `expiresAt`: absolute expiry used before network access.
-- `userId`, `handle`, `runtimeSlot`: authenticated identity metadata; never returned wholesale.
-
-Rules:
-
-- Missing or expired auth transitions directly to `auth_required`.
-- Tokens never appear in tool input, tool output, logs, or persisted MCP state.
-
-## Computer Reference
-
-Fields:
-
-- `handle`: safe display/routing handle.
-- `runtimeSlot`: stable tool-facing identifier, 1-32 safe characters.
-- `label`, `availability`, `kind`, `versionLabel`, `capabilities`.
-- `gatewayPath`: inventory-derived relative path that must exactly match handle and slot.
-
-Relationships:
-
-- Many computer references belong to one CLI principal.
-- One scoped tool call targets exactly one computer reference.
-
-State transitions:
+Missing/expired auth becomes `auth_required`. Tokens never enter tool inputs, outputs, logs, or MCP persistence. Every scoped call targets exactly one inventory member; unknown/unavailable targets fail safely. No token cache or unbounded in-memory collection is added.
 
 ```text
-unknown -> inventory member -> available -> scoped runtime access
+unknown -> inventory member -> available -> scoped call
                          \-> unavailable -> safe rejection
 ```
 
-## Scoped Runtime Access
+## Terminal session and tab
 
-Fields:
-
-- `computer`: resolved computer reference.
-- `gatewayBase`: trusted origin plus validated inventory path.
-- `accessToken`: current token if already scoped, otherwise a non-persisted replacement.
-- `expiresAt`: replacement expiry when minted.
-
-Rules:
-
-- Created for one operation; no token cache is introduced, avoiding a new in-memory collection and eviction lifecycle.
-
-## Terminal Session
-
-Fields are projected from the gateway response and include a validated name plus safe status/metadata fields. Unknown server fields are discarded.
-
-Relationships:
-
-- Belongs to one computer.
-- Owns zero or more terminal tabs.
-
-State transitions:
+A terminal belongs to one computer and owns zero or more tabs. Session responses keep bounded names and known status/metadata while discarding unknown fields. A tab exposes stable numeric `id`, current display position `idx`, optional name, and focus state.
 
 ```text
-absent --create--> active
-active --list/read/input--> active
+session: absent --create--> active --list/input--> active
+tab:     absent --create--> present --select by id--> focused
 ```
 
-Deletion is outside scope.
+Deletion is outside scope. Input targets the selected tab.
 
-## Terminal Tab
+## Captured command
 
-Fields:
+Input: computer slot, 1-64 argv items (1-4096 characters each), optional Matrix-home-relative `cwd`, and 1 second-to-30 minute timeout. Result: selected computer, bounded stdout/stderr, exit code, signal, timeout/truncation flags, and duration. Its lifetime is one request.
 
-- `index`: non-negative safe integer supplied by zellij/Matrix.
-- `name`: bounded display name when available.
-- `active`: boolean when available.
+## Remote file payload
 
-State transitions:
+Fields: computer, normalized Matrix-home-relative path, filename, media type, size, `utf8|base64` encoding/content, and explicit overwrite/secret flags. Absolute/traversal paths are invalid; text is capped at 256 KiB and binary transfer at 1 MiB. Existing files require `overwrite=true`. Downloads never accept a local destination.
 
-```text
-absent --create--> present
-present --select--> active
-active --send input--> active
-```
+## Chat page
 
-## Captured Command
-
-Input:
-
-- `computer`: runtime slot.
-- `command`: 1-64 argv items, each 1-4096 characters.
-- `cwd`: optional normalized Matrix-home-relative path.
-- `timeoutMs`: optional, 1 second through 30 minutes.
-
-Result:
-
-- `computer`: selected runtime slot/handle.
-- `stdout`, `stderr`: bounded strings.
-- `exitCode`, `signal`, `timedOut`, `truncated`, `durationMs`.
-
-Lifecycle is one request; no record is persisted.
-
-## Remote File Payload
-
-Fields:
-
-- `computer`, `path`, `filename`, `mediaType`, `size`.
-- `encoding`: `utf8` or `base64`.
-- `content`: bounded data matching encoding.
-- `overwrite`, `secret`: explicit upload flags.
-
-Rules:
-
-- Paths normalize within Matrix home; absolute and traversal paths are invalid.
-- Text read is at most 256 KiB; binary transfer is at most 1 MiB.
-- Existing files remain unchanged unless `overwrite=true`.
-- Download never gains a local destination field.
-
-## Chat Page
-
-Inputs:
-
-- `computer`.
-- `limit`: 1-100.
-- optional safe `cursor`, `lifecycle`, `projectId`, `query`.
-- detail additionally requires canonical `chatId`.
-
-Result:
-
-- projected canonical chat records and, for detail, at most 100 messages.
-- `nextCursor` when another page exists.
-
-Rules:
-
-- Data is read-only.
-- Unknown/cross-owner ids are indistinguishable as `not_found`.
+Inputs: computer, limit 1-100, optional bounded cursor/lifecycle/project/query, and canonical chat ID for detail. Results contain projected canonical records, at most 100 messages, and an optional cursor. Chats are read-only; unknown and cross-owner IDs both map to `not_found`.

--- a/specs/120-remote-computer-mcp/plan.md
+++ b/specs/120-remote-computer-mcp/plan.md
@@ -1,0 +1,139 @@
+# Implementation Plan: Remote Computer MCP
+
+**Branch**: `codex/remote-computer-mcp` | **Date**: 2026-09-04 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/120-remote-computer-mcp/spec.md`
+
+## Summary
+
+Extend the published Matrix CLI with a local stdio MCP server and attach it to the existing Matrix OS coding-agent plugin. Each tool validates input locally, resolves the requested owner-authorized computer without changing the active CLI profile, then delegates to the existing authenticated platform/gateway interfaces for terminals, commands, files, and chats. No new persistence or remote HTTP MCP endpoint is introduced.
+
+The implementation deliberately distinguishes two execution modes:
+
+- `run_command` is a bounded, captured, one-shot remote process using an argv array.
+- persistent observable work uses a named zellij terminal and tabs through create/list/select/input tools.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9 strict, ES modules; Node.js 24 production target (published CLI remains compatible with Node.js 20+)
+**Primary Dependencies**: `@modelcontextprotocol/sdk` 1.29, Zod 4, citty, native Fetch/AbortSignal, existing Matrix CLI shell/file/profile clients
+**Storage**: No new storage; reads existing owner-scoped Matrix CLI profile/auth files and Matrix computer data
+**Testing**: Vitest unit, contract, and mocked full-path integration tests; plugin validator; repository type/pattern/full test gates
+**Target Platform**: Local coding-agent host starting a stdio child process; remote Matrix customer VPS data plane
+**Project Type**: Monorepo package extension plus existing repository-local Codex plugin
+**Performance Goals**: tool discovery under 2 seconds after process start; non-command API calls complete within 10 seconds under normal conditions; bounded command/file calls use documented longer timeouts
+**Constraints**: explicit computer on every scoped call; no local arbitrary file reads/writes; 20 computers; 500 directory entries; 256 KiB text; 1 MiB MCP binary transfer; 1 MiB command output; 30-minute maximum command timeout; 60,000-byte terminal input
+**Scale/Scope**: 15 MCP tools across five domains; one active CLI profile per MCP process; at most 20 owner-authorized computers per inventory
+
+## Constitution Check
+
+*GATE: Passed before research and re-checked after design.*
+
+| Principle | Design evidence | Status |
+|---|---|---|
+| Data belongs to its owner | Computer inventory and runtime access derive from the signed-in owner; files stay in the selected Matrix home; chats use canonical owner checks; no data is copied into new storage. | Pass |
+| AI is the kernel | The feature exposes Matrix's existing headless capabilities to coding agents without adding a parallel orchestration store or provider-specific kernel. | Pass |
+| Headless core, multi-shell | MCP is another programmatic shell over the same gateway contracts used by CLI and visual clients. | Pass |
+| Defense in depth | Every tool has strict boundary schemas, explicit computer targeting, bounded responses, request timeouts, allowlisted errors, and no credential/result leakage. The auth matrix is in the specification. | Pass |
+| TDD | Tests for schemas, routing, safe errors, each domain client, tool registration, and full-path calls are written failing before implementation. | Pass |
+| Worktree and PR | Work occurs in a manual worktree on `codex/remote-computer-mcp`; changes ship through a Conventional Commit PR with required invariants and Greptile gate. | Pass |
+| Documentation-driven development | This repository includes operator/developer quickstart updates; a separate `FinnaAI/matrix-os-site` documentation PR is an explicit release deliverable. | Pass, release deliverable |
+| No unjustified persistence/dependencies | No database or alternate persistence is added. MCP SDK is required for the protocol boundary; native Fetch handles network calls. | Pass |
+
+### Post-design re-check
+
+The contracts retain explicit runtime identity, preserve the gateway as the authorization source of truth, and add no server endpoints. State-changing tools reuse existing endpoint validation and atomicity. No constitution exception is required.
+
+## Architecture
+
+```text
+Coding agent
+  -> Matrix OS plugin (.mcp.json)
+    -> matrix mcp serve (local stdio; active CLI profile)
+      -> computer inventory / scoped-token resolver (platform)
+        -> selected Matrix gateway
+          -> terminal + command + file + canonical chat interfaces
+```
+
+### Runtime wiring
+
+1. The plugin starts `matrix mcp serve`; the server writes protocol messages only to stdout and diagnostics only to stderr.
+2. The first tool call loads the selected CLI profile and validates its unexpired auth record.
+3. `list_computers` calls the platform inventory with the profile token.
+4. Every scoped tool resolves its required `computer` runtime slot from a fresh bounded inventory.
+5. If the slot differs from the token's current slot, the resolver requests a short-lived replacement token from the platform control-plane origin. The token remains process-private and is not persisted.
+6. The resolver combines the trusted profile origin and inventory-provided gateway path, then the domain client appends only fixed API paths while preserving the runtime query.
+7. Domain responses are parsed, projected into bounded MCP-safe results, and returned as text JSON or binary-safe base64 metadata.
+
+### Error and retry policy
+
+- Validation fails before network activity.
+- Fetch failures map to `auth_required`, `computer_not_found`, `computer_unavailable`, `not_found`, `conflict`, `payload_too_large`, `request_timeout`, or `request_failed`.
+- No tool retries a mutating call. Inventory may be refreshed once before a scoped call, but a failed domain request is never invisibly replayed.
+- Raw response bodies, URLs, paths outside Matrix home, and internal exception messages never reach tool output.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/120-remote-computer-mcp/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── tools.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+packages/sync-client/
+├── package.json
+├── src/
+│   ├── cli/
+│   │   ├── commands/mcp.ts
+│   │   └── index.ts
+│   └── mcp/
+│       ├── clients.ts
+│       ├── errors.ts
+│       ├── profile-context.ts
+│       ├── schemas.ts
+│       └── server.ts
+└── tests/
+    ├── integration/mcp-server.test.ts
+    └── unit/
+        ├── mcp-clients.test.ts
+        ├── mcp-profile-context.test.ts
+        └── mcp-schemas.test.ts
+
+plugins/matrix-os/
+├── .codex-plugin/plugin.json
+├── .mcp.json
+└── skills/
+    ├── matrix-cloud-run/SKILL.md
+    └── matrix-github-project/SKILL.md
+
+tests/plugins/
+└── matrix-os-plugin.test.ts
+```
+
+**Structure Decision**: Keep the protocol adapter in the already published and authenticated `@finnaai/matrix` CLI, organized by responsibility to keep files below the project's large-file threshold. Extend the existing `matrix-os` plugin rather than creating a second marketplace item. Reuse gateway routes unchanged.
+
+## Delivery Strategy
+
+One implementation PR is appropriate because the source change is isolated to the CLI package and existing plugin, adds no gateway endpoints or migrations, and can remain below 20 production/test files. The PR is independently releasable after publishing the next CLI patch version. A separate public documentation PR in `FinnaAI/matrix-os-site` is required before release.
+
+### Required PR invariants
+
+- **Source of truth**: active CLI profile/auth for principal identity; platform computer inventory for available runtimes; selected gateway for terminals/files/chats.
+- **Lock/transaction scope**: none added; one-shot operations delegate to existing atomic gateway behavior.
+- **Acceptable orphan states**: a newly created terminal or tab may remain if the MCP client disconnects after the gateway commits; this is visible owner data and can be managed through Matrix.
+- **Auth source of truth**: platform-issued sync bearer plus selected computer-scoped replacement token.
+- **Deferred scope**: hosted Streamable HTTP/OAuth MCP, chat mutations, delete tools, pane tools, live terminal streaming, large-file MCP streaming, disabling host local-shell tools, and public marketplace publication.
+
+## Complexity Tracking
+
+No constitution violations require justification.

--- a/specs/120-remote-computer-mcp/plan.md
+++ b/specs/120-remote-computer-mcp/plan.md
@@ -41,7 +41,7 @@ The implementation deliberately distinguishes two execution modes:
 
 ### Post-design re-check
 
-The contracts retain explicit runtime identity, preserve the gateway as the authorization source of truth, and add no server endpoints. State-changing tools reuse existing endpoint validation and atomicity. No constitution exception is required.
+The contracts retain explicit runtime identity and preserve the gateway as the authorization source of truth. One authenticated terminal subroute adds stable-ID tab selection while leaving existing position-based clients compatible; other state-changing tools reuse existing endpoint validation and atomicity. No constitution exception is required.
 
 ## Architecture
 
@@ -120,16 +120,16 @@ tests/plugins/
 └── matrix-os-plugin.test.ts
 ```
 
-**Structure Decision**: Keep the protocol adapter in the already published and authenticated `@finnaai/matrix` CLI, organized by responsibility to keep files below the project's large-file threshold. Extend the existing `matrix-os` plugin rather than creating a second marketplace item. Reuse gateway routes unchanged.
+**Structure Decision**: Keep the protocol adapter in the already published and authenticated `@finnaai/matrix` CLI, organized by responsibility to keep files below the project's large-file threshold. Extend the existing `matrix-os` plugin rather than creating a second marketplace item. Reuse existing gateway routes except for one backward-compatible stable-ID tab-selection subroute.
 
 ## Delivery Strategy
 
-One implementation PR is appropriate because the source change is isolated to the CLI package and existing plugin, adds no gateway endpoints or migrations, and can remain below 20 production/test files. The PR is independently releasable after publishing the next CLI patch version. A separate public documentation PR in `FinnaAI/matrix-os-site` is required before release.
+One implementation PR is appropriate because the source change is one cohesive remote-computer boundary spanning the CLI, existing terminal adapter, and existing plugin; it adds one backward-compatible terminal subroute and no migration. The PR is independently releasable after publishing the next CLI patch version and host bundle together. A separate public documentation PR in `FinnaAI/matrix-os-site` is required before release.
 
 ### Required PR invariants
 
 - **Source of truth**: active CLI profile/auth for principal identity; platform computer inventory for available runtimes; selected gateway for terminals/files/chats.
-- **Lock/transaction scope**: none added; one-shot operations delegate to existing atomic gateway behavior.
+- **Lock/transaction scope**: no database scope is added; Zellij returns the created tab ID in the same process invocation, avoiding list/create inference or a new lock.
 - **Acceptable orphan states**: a newly created terminal or tab may remain if the MCP client disconnects after the gateway commits; this is visible owner data and can be managed through Matrix.
 - **Auth source of truth**: platform-issued sync bearer plus selected computer-scoped replacement token.
 - **Deferred scope**: hosted Streamable HTTP/OAuth MCP, chat mutations, delete tools, pane tools, live terminal streaming, large-file MCP streaming, disabling host local-shell tools, and public marketplace publication.

--- a/specs/120-remote-computer-mcp/quickstart.md
+++ b/specs/120-remote-computer-mcp/quickstart.md
@@ -1,0 +1,70 @@
+# Quickstart: Matrix Remote Computer MCP
+
+## User setup
+
+1. Install the Matrix CLI and sign in:
+
+   ```bash
+   matrix login --profile cloud
+   matrix doctor --profile cloud
+   ```
+
+2. Install or update the Matrix OS coding-agent plugin. The plugin starts the MCP server with the CLI; no token belongs in plugin configuration.
+
+3. Start a new coding-agent conversation and ask:
+
+   > List my Matrix computers, then run `pwd` on my primary computer.
+
+4. For observable long-running work, ask the agent to create a named terminal and tab. Use `run_command` for short probes that need captured output.
+
+5. If strict remote-only execution is required, disable the coding agent's built-in local shell separately. MCP cannot override tools supplied by the host.
+
+## Manual protocol smoke test
+
+Run the server directly only for MCP inspector/development use:
+
+```bash
+matrix mcp serve --profile cloud
+```
+
+The process speaks MCP on standard input/output. Do not type shell commands into it.
+
+## Developer validation
+
+From the repository root:
+
+```bash
+pnpm install
+pnpm --filter @finnaai/matrix test
+pnpm --filter @finnaai/matrix build
+python3 /Users/hamed/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/matrix-os
+bun run typecheck
+bun run check:patterns
+bun run test
+```
+
+The full-path integration test uses a bounded fake platform/gateway server and verifies the MCP handler-to-HTTP wiring without real credentials.
+
+### Validation evidence (2026-09-04)
+
+- Remote MCP unit/integration suites: 30 tests passed across four files.
+- Sync client: TypeScript build and publish-content check passed.
+- Matrix OS plugin: two contract tests passed and the plugin validator reported a valid bundle.
+- Repository typecheck: every underlying workspace compiler/build invoked by the root typecheck passed when run directly.
+- Pattern scan: no violations in the changed files; only pre-existing repository warnings remained.
+- Public docs: 50 tests passed in the companion site repository.
+- The repository-wide test command was exercised but cannot complete cleanly in this checkout's Node 22 shell: Matrix OS requires Node 24 and the installed QMD `better-sqlite3` binary targets Node 24 ABI 137 rather than Node 22 ABI 127. All feature-focused tests pass. The sync-client suite's one credential-discovery failure is environment-sensitive and reproduces unchanged on `main` because this machine has a Claude Code Keychain credential.
+
+### Deliberate first-release boundaries
+
+- This release exposes captured argv execution and persistent zellij session/tab control, not a generic operating-system process registry.
+- File transfer is content-based and capped at 256 KiB for text and 1 MiB for binary; large-file streaming is deferred.
+- Chat tools are read-only.
+- Terminal input is fire-and-observe through Matrix surfaces; captured output belongs to `run_command`.
+
+## Release checklist
+
+- Publish the new `@finnaai/matrix` patch before enabling the pinned plugin MCP command.
+- Validate the repo marketplace entry and plugin archive.
+- Open and land the companion `FinnaAI/matrix-os-site` docs PR covering installation, auth, limits, computer selection, terminal versus captured-command semantics, file transfer, and read-only chats.
+- Verify Greptile 5/5 and all required CI checks before merge.

--- a/specs/120-remote-computer-mcp/quickstart.md
+++ b/specs/120-remote-computer-mcp/quickstart.md
@@ -47,7 +47,7 @@ The full-path integration test uses a bounded fake platform/gateway server and v
 
 ### Validation evidence (2026-09-04)
 
-- Remote MCP unit/integration suites: 30 tests passed across four files.
+- Remote MCP unit/integration suites: 31 tests passed across four files.
 - Sync client: TypeScript build and publish-content check passed.
 - Matrix OS plugin: two contract tests passed and the plugin validator reported a valid bundle.
 - Repository typecheck: every underlying workspace compiler/build invoked by the root typecheck passed when run directly.

--- a/specs/120-remote-computer-mcp/quickstart.md
+++ b/specs/120-remote-computer-mcp/quickstart.md
@@ -43,16 +43,18 @@ bun run check:patterns
 bun run test
 ```
 
-The full-path integration test uses a bounded fake platform/gateway server and verifies the MCP handler-to-HTTP wiring without real credentials.
+MCP tests verify handler-to-HTTP wiring with mocked responses; additional integration tests exercise the published CLI's stdio lifecycle and the real gateway route-to-adapter path without real credentials.
 
-### Validation evidence (2026-09-04)
+### Validation evidence (2026-09-05)
 
-- Remote MCP unit/integration suites: 31 tests passed across four files.
+- Remote MCP unit/integration suites: 33 tests passed across five files, including authentication error projection and a real CLI handshake/clean shutdown.
+- Gateway tab regression: home-relative/default cwd resolution and rejection of missing, traversal, and out-of-home symlink paths passed through the real route and adapter.
 - Sync client: TypeScript build and publish-content check passed.
 - Matrix OS plugin: two contract tests passed and the plugin validator reported a valid bundle.
 - Repository typecheck: every underlying workspace compiler/build invoked by the root typecheck passed when run directly.
 - Pattern scan: no violations in the changed files; only pre-existing repository warnings remained.
 - Public docs: 50 tests passed in the companion site repository.
+- Broader terminal verification: 56/57 tests passed; the existing shell-wrapper 1-second timeout reproduced with expected stdout, including in isolation (unrelated to tab creation).
 - The repository-wide test command was exercised but cannot complete cleanly in this checkout's Node 22 shell: Matrix OS requires Node 24 and the installed QMD `better-sqlite3` binary targets Node 24 ABI 137 rather than Node 22 ABI 127. All feature-focused tests pass. The sync-client suite's one credential-discovery failure is environment-sensitive and reproduces unchanged on `main` because this machine has a Claude Code Keychain credential.
 
 ### Deliberate first-release boundaries

--- a/specs/120-remote-computer-mcp/research.md
+++ b/specs/120-remote-computer-mcp/research.md
@@ -40,11 +40,11 @@
 - Persist every tool-selected computer to the CLI profile: rejected because an agent call should not alter the user's global CLI state.
 - Accept raw gateway URLs: rejected because it would bypass inventory ownership and create an SSRF boundary.
 
-## Decision 4: Use existing interfaces without adding gateway endpoints
+## Decision 4: Reuse existing interfaces with one stable-tab extension
 
-**Decision**: Delegate to existing computer inventory/runtime selection, terminal, captured command, file list/blob, and canonical chat routes.
+**Decision**: Delegate to existing computer inventory/runtime selection, terminal, captured command, file list/blob, and canonical chat routes. Add one authenticated terminal subroute that selects a tab by the stable ID returned atomically by Zellij.
 
-**Rationale**: These routes already implement owner auth, home-path security, zellij lifecycle, output caps, atomic upload, and canonical chat ownership. The MCP boundary adds stricter limits where protocol responses need to stay smaller.
+**Rationale**: These routes already implement owner auth, home-path security, zellij lifecycle, output caps, atomic upload, and canonical chat ownership. Existing position-based tab selection is not safe after concurrent tab creation, while Zellij 0.44.3 emits a stable tab ID from `new-tab` and supports `go-to-tab-by-id`. The narrow subroute preserves existing position-based clients and the MCP boundary adds stricter limits where protocol responses need to stay smaller.
 
 **Alternatives considered**:
 

--- a/specs/120-remote-computer-mcp/research.md
+++ b/specs/120-remote-computer-mcp/research.md
@@ -1,97 +1,31 @@
 # Research: Remote Computer MCP
 
-## Decision 1: Treat terminals, not processes, as the persistent object
+## Decisions
 
-**Decision**: Model persistent observable work as Matrix zellij terminal sessions and tabs. Keep `run_command` as a one-shot captured operating-system process without a new process registry.
+### Persistent work is a terminal, not a process registry
 
-**Rationale**: Matrix already persists and renders sessions/tabs across its clients. A second process abstraction would duplicate lifecycle state while still needing a terminal for observation.
+Matrix zellij sessions and tabs are the persistent, observable objects. `run_command` remains a one-shot OS process with captured output and exit metadata. A detached-job registry would duplicate terminal lifecycle, cleanup, and UI state.
 
-**Alternatives considered**:
+### Ship a local stdio bridge
 
-- Add detached process/job records: rejected because it adds persistence, cleanup, and UI parity work before a user need exists.
-- Treat every command as a terminal: rejected because agents need structured output and exit status for small probes.
+The published CLI exposes `matrix mcp serve`; the Matrix plugin starts it over stdio. The CLI already owns portable profile auth, and stdio keeps credentials local. Hosted HTTP MCP is deferred until its OAuth 2.1, protected-resource metadata, audience, deployment, and abuse-control design exists. References: [MCP authorization](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) and [stateless transport update](https://blog.modelcontextprotocol.io/posts/2026-07-28/).
 
-## Decision 2: Ship a local stdio bridge first
+### Every operation names a computer
 
-**Decision**: Add `matrix mcp serve` to the published CLI and start it from the existing plugin using stdio.
+Computer-scoped tools require the inventory `runtimeSlot`. Inventory is refreshed and a non-persisted scoped token is minted when the slot differs from the profile token. This prevents accidental execution elsewhere without mutating the user's global CLI selection. Raw gateway URLs are never accepted.
 
-**Rationale**: The CLI already owns device login, profile selection, and a portable runtime. Stdio keeps credentials local, requires no new public endpoint, and works with coding agents that support local MCP subprocesses.
+### Reuse Matrix interfaces; extend stable tab selection only
 
-**Alternatives considered**:
+The bridge delegates to existing inventory/runtime selection, terminal, command, file, and canonical chat routes. Zellij 0.44.3 emits a stable ID from `new-tab` and supports `go-to-tab-by-id`, so one authenticated, bounded route selects by ID while existing position-based clients remain compatible. A generic MCP proxy or direct SSH would duplicate or bypass Matrix authorization.
 
-- Hosted Streamable HTTP MCP: deferred because it requires a protected-resource metadata and OAuth 2.1 lifecycle, audience validation, and additional deployment/abuse controls.
-- A new private workspace package: rejected because a coding agent outside the Matrix monorepo could not install it.
-- Embed a JavaScript server inside the plugin: rejected because it would duplicate the authenticated CLI client and release channel.
+### Transfer bounded content, never local paths
 
-**Primary references**:
+Downloads return metadata plus at most 1 MiB of base64; uploads accept bounded UTF-8 or validated base64. Text reads are capped at 256 KiB. Local source/destination paths are forbidden because they would expose the coding-agent host. Large streaming and resumable transfer remain deferred.
 
-- MCP authorization requirements: https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
-- MCP 2026-07-28 stateless transport update: https://blog.modelcontextprotocol.io/posts/2026-07-28/
+### Chats are read-only
 
-## Decision 3: Require explicit computer targeting
+List, search, and detail use canonical owner-scoped chat routes with pages of at most 100 items/messages. Mutations need separate approval, idempotency, delivery, and notification semantics.
 
-**Decision**: Require the runtime slot on every computer-scoped tool. Refresh inventory for resolution and mint a non-persisted scoped token when the requested slot differs from the profile token.
+### Extend the existing plugin and verified SDK path
 
-**Rationale**: Agents must never silently run on another machine. Runtime slots are validated, owner-scoped, stable identifiers; labels and handles are display metadata.
-
-**Alternatives considered**:
-
-- Implicit current computer: rejected because multi-computer workflows become ambiguous.
-- Persist every tool-selected computer to the CLI profile: rejected because an agent call should not alter the user's global CLI state.
-- Accept raw gateway URLs: rejected because it would bypass inventory ownership and create an SSRF boundary.
-
-## Decision 4: Reuse existing interfaces with one stable-tab extension
-
-**Decision**: Delegate to existing computer inventory/runtime selection, terminal, captured command, file list/blob, and canonical chat routes. Add one authenticated terminal subroute that selects a tab by the stable ID returned atomically by Zellij.
-
-**Rationale**: These routes already implement owner auth, home-path security, zellij lifecycle, output caps, atomic upload, and canonical chat ownership. Existing position-based tab selection is not safe after concurrent tab creation, while Zellij 0.44.3 emits a stable tab ID from `new-tab` and supports `go-to-tab-by-id`. The narrow subroute preserves existing position-based clients and the MCP boundary adds stricter limits where protocol responses need to stay smaller.
-
-**Alternatives considered**:
-
-- A broad `/api/mcp/*` proxy: rejected because it would duplicate authorization and parsing.
-- Direct SSH: rejected because it bypasses Matrix identity, routing, auditability, and customer topology.
-
-## Decision 5: Keep MCP file transfer content-based and small
-
-**Decision**: Return downloads as bounded base64 with metadata and accept uploads as either bounded UTF-8 text or validated base64. Never accept a local source/destination path.
-
-**Rationale**: A local-path file bridge lets prompt-injected content read or overwrite the coding-agent host. Content-based transfer preserves the remote-computer boundary and remains portable across MCP clients.
-
-**Alternatives considered**:
-
-- Arbitrary local path arguments: rejected as an unnecessary local filesystem capability.
-- Large binary streaming: deferred until MCP client support and resumable semantics are designed.
-- Signed download URLs: rejected because current file routes require bearer auth and tokens must not appear in URLs.
-
-## Decision 6: Keep chats read-only
-
-**Decision**: Expose list, search, and detail only, with at most 100 list items/messages per request.
-
-**Rationale**: The stated need is to check chat sessions. Mutations need separate approval semantics, idempotency, queue state, and notification expectations.
-
-**Alternatives considered**:
-
-- Expose the whole canonical chat API: rejected as oversized and riskier than the request.
-- Read raw conversation files: rejected because canonical chats live in owner-controlled Postgres and gateway contracts are the source of truth.
-
-## Decision 7: Extend the existing Matrix OS plugin
-
-**Decision**: Add `.mcp.json` and `mcpServers` to `plugins/matrix-os`, bump its version, and update its skills to prefer MCP while retaining CLI fallback instructions.
-
-**Rationale**: Users should install one Matrix OS bundle, not choose between a skills plugin and a remote-tools plugin. The repo-local marketplace already contains the plugin and its policy metadata.
-
-**Alternatives considered**:
-
-- Create a second `matrix-remote` plugin: rejected because it splits discovery and duplicates onboarding.
-- Replace the skills with MCP only: rejected because safe workflow guidance remains valuable and supports clients where the MCP server is unavailable.
-
-## Decision 8: Use the stable MCP SDK server API already verified in the repository
-
-**Decision**: Use `McpServer.registerTool` and `StdioServerTransport`, already exercised by `packages/integrations-mcp` with SDK 1.29.
-
-**Rationale**: This is not an undocumented SDK assumption; the repository already builds and tests the same boundary. Tool annotations describe read-only, destructive, and open-world characteristics.
-
-**Alternatives considered**:
-
-- Implement JSON-RPC manually: rejected because protocol framing and schema interoperability are existing SDK responsibilities.
-- Use the Agent SDK's in-process MCP helper: rejected because the server must work across coding-agent hosts, not only Matrix's current kernel.
+`plugins/matrix-os` gains `.mcp.json` and retains workflow skills as guidance/fallback. The CLI uses the repository-verified MCP SDK `McpServer.registerTool` plus `StdioServerTransport`; handwritten JSON-RPC and an Agent-SDK-only server would reduce portability.

--- a/specs/120-remote-computer-mcp/research.md
+++ b/specs/120-remote-computer-mcp/research.md
@@ -1,0 +1,97 @@
+# Research: Remote Computer MCP
+
+## Decision 1: Treat terminals, not processes, as the persistent object
+
+**Decision**: Model persistent observable work as Matrix zellij terminal sessions and tabs. Keep `run_command` as a one-shot captured operating-system process without a new process registry.
+
+**Rationale**: Matrix already persists and renders sessions/tabs across its clients. A second process abstraction would duplicate lifecycle state while still needing a terminal for observation.
+
+**Alternatives considered**:
+
+- Add detached process/job records: rejected because it adds persistence, cleanup, and UI parity work before a user need exists.
+- Treat every command as a terminal: rejected because agents need structured output and exit status for small probes.
+
+## Decision 2: Ship a local stdio bridge first
+
+**Decision**: Add `matrix mcp serve` to the published CLI and start it from the existing plugin using stdio.
+
+**Rationale**: The CLI already owns device login, profile selection, and a portable runtime. Stdio keeps credentials local, requires no new public endpoint, and works with coding agents that support local MCP subprocesses.
+
+**Alternatives considered**:
+
+- Hosted Streamable HTTP MCP: deferred because it requires a protected-resource metadata and OAuth 2.1 lifecycle, audience validation, and additional deployment/abuse controls.
+- A new private workspace package: rejected because a coding agent outside the Matrix monorepo could not install it.
+- Embed a JavaScript server inside the plugin: rejected because it would duplicate the authenticated CLI client and release channel.
+
+**Primary references**:
+
+- MCP authorization requirements: https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
+- MCP 2026-07-28 stateless transport update: https://blog.modelcontextprotocol.io/posts/2026-07-28/
+
+## Decision 3: Require explicit computer targeting
+
+**Decision**: Require the runtime slot on every computer-scoped tool. Refresh inventory for resolution and mint a non-persisted scoped token when the requested slot differs from the profile token.
+
+**Rationale**: Agents must never silently run on another machine. Runtime slots are validated, owner-scoped, stable identifiers; labels and handles are display metadata.
+
+**Alternatives considered**:
+
+- Implicit current computer: rejected because multi-computer workflows become ambiguous.
+- Persist every tool-selected computer to the CLI profile: rejected because an agent call should not alter the user's global CLI state.
+- Accept raw gateway URLs: rejected because it would bypass inventory ownership and create an SSRF boundary.
+
+## Decision 4: Use existing interfaces without adding gateway endpoints
+
+**Decision**: Delegate to existing computer inventory/runtime selection, terminal, captured command, file list/blob, and canonical chat routes.
+
+**Rationale**: These routes already implement owner auth, home-path security, zellij lifecycle, output caps, atomic upload, and canonical chat ownership. The MCP boundary adds stricter limits where protocol responses need to stay smaller.
+
+**Alternatives considered**:
+
+- A broad `/api/mcp/*` proxy: rejected because it would duplicate authorization and parsing.
+- Direct SSH: rejected because it bypasses Matrix identity, routing, auditability, and customer topology.
+
+## Decision 5: Keep MCP file transfer content-based and small
+
+**Decision**: Return downloads as bounded base64 with metadata and accept uploads as either bounded UTF-8 text or validated base64. Never accept a local source/destination path.
+
+**Rationale**: A local-path file bridge lets prompt-injected content read or overwrite the coding-agent host. Content-based transfer preserves the remote-computer boundary and remains portable across MCP clients.
+
+**Alternatives considered**:
+
+- Arbitrary local path arguments: rejected as an unnecessary local filesystem capability.
+- Large binary streaming: deferred until MCP client support and resumable semantics are designed.
+- Signed download URLs: rejected because current file routes require bearer auth and tokens must not appear in URLs.
+
+## Decision 6: Keep chats read-only
+
+**Decision**: Expose list, search, and detail only, with at most 100 list items/messages per request.
+
+**Rationale**: The stated need is to check chat sessions. Mutations need separate approval semantics, idempotency, queue state, and notification expectations.
+
+**Alternatives considered**:
+
+- Expose the whole canonical chat API: rejected as oversized and riskier than the request.
+- Read raw conversation files: rejected because canonical chats live in owner-controlled Postgres and gateway contracts are the source of truth.
+
+## Decision 7: Extend the existing Matrix OS plugin
+
+**Decision**: Add `.mcp.json` and `mcpServers` to `plugins/matrix-os`, bump its version, and update its skills to prefer MCP while retaining CLI fallback instructions.
+
+**Rationale**: Users should install one Matrix OS bundle, not choose between a skills plugin and a remote-tools plugin. The repo-local marketplace already contains the plugin and its policy metadata.
+
+**Alternatives considered**:
+
+- Create a second `matrix-remote` plugin: rejected because it splits discovery and duplicates onboarding.
+- Replace the skills with MCP only: rejected because safe workflow guidance remains valuable and supports clients where the MCP server is unavailable.
+
+## Decision 8: Use the stable MCP SDK server API already verified in the repository
+
+**Decision**: Use `McpServer.registerTool` and `StdioServerTransport`, already exercised by `packages/integrations-mcp` with SDK 1.29.
+
+**Rationale**: This is not an undocumented SDK assumption; the repository already builds and tests the same boundary. Tool annotations describe read-only, destructive, and open-world characteristics.
+
+**Alternatives considered**:
+
+- Implement JSON-RPC manually: rejected because protocol framing and schema interoperability are existing SDK responsibilities.
+- Use the Agent SDK's in-process MCP helper: rejected because the server must work across coding-agent hosts, not only Matrix's current kernel.

--- a/specs/120-remote-computer-mcp/spec.md
+++ b/specs/120-remote-computer-mcp/spec.md
@@ -116,7 +116,7 @@ A coding-agent user installs or updates the existing Matrix OS plugin and receiv
 - **FR-007**: Captured commands MUST be provided as an argument vector rather than an interpolated shell string, MUST support a validated Matrix-home-relative working directory, and MUST return structured completion metadata.
 - **FR-008**: Captured command execution MUST default to a 10-minute timeout, MUST reject timeouts longer than 30 minutes, and MUST cap combined returned output at 1 MiB while reporting truncation.
 - **FR-009**: Persistent terminal creation MUST accept a validated unique name and optional Matrix-home-relative working directory; a duplicate create MUST fail without altering the existing terminal.
-- **FR-010**: Tab creation MUST target one named terminal, accept a bounded optional name and working directory, and return a stable tab index or identifier supplied by Matrix.
+- **FR-010**: Tab creation MUST target one named terminal, accept a bounded optional name and working directory, and return the stable Zellij tab ID emitted atomically by the create operation.
 - **FR-011**: Terminal input MUST target one named terminal after explicit tab selection, MUST be capped at 60,000 bytes per request, and MUST be annotated as a state-changing operation.
 - **FR-012**: The initial MCP release MUST NOT expose terminal/session/tab deletion, arbitrary pane manipulation, or an unbounded terminal-output stream.
 - **FR-013**: All file paths MUST be normalized beneath the selected computer owner's Matrix home and MUST preserve existing protected-path, symlink, regular-file, and secret-file rules.
@@ -139,7 +139,7 @@ A coding-agent user installs or updates the existing Matrix OS plugin and receiv
 | Start local MCP server / discover tool schemas | Local plugin process | No owner data is read until a tool is called | Yes, locally |
 | List computers | Active Matrix CLI sign-in | Signed-in user's runtime inventory only | No |
 | Select computer / obtain scoped access | Active Matrix CLI sign-in | Requested computer must belong to the signed-in user | No |
-| Commands and persistent terminals | Computer-scoped Matrix access | Selected computer and its owner only | No |
+| Commands and persistent terminals, including stable-ID tab selection | Computer-scoped Matrix access enforced by the existing gateway auth boundary | Selected computer and its owner only | No |
 | Files | Computer-scoped Matrix access plus Matrix-home path policy | Selected owner's Matrix home only | No |
 | Chats | Computer-scoped Matrix access plus chat ownership checks | Selected owner's chats only | No |
 
@@ -148,7 +148,7 @@ A coding-agent user installs or updates the existing Matrix OS plugin and receiv
 - **Computer Reference**: A stable runtime identifier plus user-facing label, handle, availability, type, version, gateway location, and declared capabilities. It belongs to exactly one signed-in owner.
 - **Runtime Access**: A short-lived, computer-scoped authorization resolved from the active Matrix sign-in. It is never returned to the MCP client.
 - **Terminal Session**: A persistent, user-visible terminal identified by a validated name on one computer. It owns an ordered collection of tabs.
-- **Terminal Tab**: A user-visible execution surface within one terminal session, addressable by the index or identifier supplied by Matrix.
+- **Terminal Tab**: A user-visible execution surface within one terminal session, addressable by a stable Zellij ID supplied atomically at creation; its display position may change independently.
 - **Captured Command Result**: A bounded, non-persistent execution result containing output, exit, signal, timeout, truncation, duration, and selected-computer metadata.
 - **Remote File Payload**: Bounded text or binary content associated with a normalized Matrix-home-relative path, size, filename, and media type.
 - **Chat Summary and Detail**: Read-only, owner-authorized chat metadata and paginated messages with stable cursors.

--- a/specs/120-remote-computer-mcp/spec.md
+++ b/specs/120-remote-computer-mcp/spec.md
@@ -1,0 +1,175 @@
+# Feature Specification: Remote Computer MCP
+
+**Feature Branch**: `codex/remote-computer-mcp`
+**Created**: 2026-09-04
+**Status**: Draft
+**Input**: User description: "Ship an MCP and coding-agent plugin that can operate Matrix computers instead of the local computer: create and inspect persistent terminals and tabs, run commands, list computers, transfer files, and inspect chat sessions."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Run work on a chosen Matrix computer (Priority: P1)
+
+A signed-in Matrix user enables the Matrix OS plugin in a coding agent, lists their available computers, chooses one explicitly, and runs a command there. The command returns bounded output and status to the agent so the agent can continue without using its local shell.
+
+**Why this priority**: Remote execution is the central value of the feature. Computer discovery and explicit targeting prevent work from silently running on the wrong machine.
+
+**Independent Test**: Connect the plugin to an account with two computers, list them, run a harmless command on the non-default computer, and verify the result identifies the selected computer and contains the remote command result.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is signed in and owns at least one available Matrix computer, **When** the agent lists computers, **Then** it receives only computers accessible to that user with stable identifiers, labels, availability, type, version, and capabilities.
+2. **Given** two available computers, **When** the agent runs an argument-vector command against one stable identifier, **Then** the command executes only on that computer and returns exit status, standard output, standard error, duration, timeout status, and truncation status.
+3. **Given** an unavailable, inaccessible, or unknown computer, **When** the agent targets it, **Then** no command runs and the agent receives a safe actionable error.
+4. **Given** no valid Matrix sign-in, **When** any remote operation is attempted, **Then** it fails without exposing stored credentials and directs the user to authenticate with the Matrix CLI.
+
+---
+
+### User Story 2 - Work in persistent terminals and tabs (Priority: P1)
+
+A coding agent can inspect persistent Matrix terminals, create a named terminal, inspect and create its tabs, select a tab, and send bounded input to the active terminal. These terminals remain visible and reconnectable in Matrix interfaces.
+
+**Why this priority**: Persistent terminals make remote work observable to the user and let the user or another agent continue it later.
+
+**Independent Test**: Create a new terminal on a selected computer, create a named tab, list both, select the tab, send a harmless command followed by Enter, and verify the terminal remains available through the existing Matrix terminal interface.
+
+**Acceptance Scenarios**:
+
+1. **Given** an available computer, **When** the agent lists terminals, **Then** it receives the user's current persistent terminal sessions without creating or changing any session.
+2. **Given** an unused valid name, **When** the agent creates a terminal, **Then** exactly one persistent terminal is created and its normalized metadata is returned.
+3. **Given** an existing terminal, **When** the agent lists or creates a tab, **Then** the operation applies only to that terminal and returns enough metadata to address the tab later.
+4. **Given** an existing terminal and tab, **When** the agent selects the tab and sends bounded input, **Then** the input reaches that terminal and no local terminal is used.
+5. **Given** a duplicate name, invalid name, oversized input, or stale terminal/tab reference, **When** the operation is attempted, **Then** the request is rejected without partial creation or disclosure of internal details.
+
+---
+
+### User Story 3 - Inspect and transfer Matrix files (Priority: P2)
+
+A coding agent can list a directory, read bounded text, download bounded binary content through the tool result, and upload bounded content into the selected Matrix computer's home directory.
+
+**Why this priority**: Agents need project context and artifact transfer, but file access must remain constrained to the owner's Matrix home and must not turn the MCP subprocess into a general local-filesystem bridge.
+
+**Independent Test**: Upload a small text and binary fixture to a temporary Matrix-home path, list and read the text fixture, download both fixtures, verify byte equality, and verify that traversal, protected paths, oversize payloads, and accidental overwrites are rejected.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid Matrix-home directory, **When** the agent lists it, **Then** it receives a bounded set of file and directory metadata.
+2. **Given** a regular UTF-8 file within the read limit, **When** the agent reads it, **Then** it receives the content and byte metadata without writing anything locally.
+3. **Given** a regular file within the transfer limit, **When** the agent downloads it, **Then** its bytes are returned in a transport-safe representation with filename, media type, size, and truncation metadata.
+4. **Given** bounded text or binary content and a valid Matrix-home destination, **When** the agent uploads it, **Then** the file is written atomically on the selected computer.
+5. **Given** an existing destination, **When** upload is requested without explicit overwrite authorization, **Then** the existing file is unchanged.
+6. **Given** an absolute path, traversal path, protected path, symlink escape, directory in place of a file, or oversized request, **When** a file operation is attempted, **Then** it is rejected safely.
+
+---
+
+### User Story 4 - Check Matrix chat sessions (Priority: P2)
+
+A coding agent can list, search, and inspect the user's Matrix chat sessions on a selected computer without sending messages or changing chat state.
+
+**Why this priority**: Existing chats contain task context that can help a coding agent continue work, while read-only access keeps the initial release narrow and predictable.
+
+**Independent Test**: Seed multiple chats with messages, list and search them with pagination, inspect one chat, and verify no messages, lifecycle state, or unread state are modified.
+
+**Acceptance Scenarios**:
+
+1. **Given** a selected computer with chats, **When** the agent lists chats, **Then** it receives a bounded page of owner-authorized summaries and a continuation cursor when needed.
+2. **Given** a bounded search query, **When** the agent searches chats, **Then** it receives only matching owner-authorized summaries.
+3. **Given** an accessible chat identifier, **When** the agent inspects it, **Then** it receives bounded chat metadata and a paginated message page.
+4. **Given** an inaccessible or unknown chat, **When** the agent inspects it, **Then** the operation returns a generic not-found response and leaks no cross-owner data.
+5. **Given** any chat inspection operation, **When** it completes, **Then** no message is sent and no chat state is mutated.
+
+---
+
+### User Story 5 - Install one portable Matrix OS plugin (Priority: P3)
+
+A coding-agent user installs or updates the existing Matrix OS plugin and receives both its guidance skills and its remote-computer MCP server. The MCP server uses the user's existing Matrix CLI profile and sign-in.
+
+**Why this priority**: A single installable bundle makes the capability discoverable and avoids separate manual MCP configuration.
+
+**Independent Test**: Validate the plugin bundle, install it in a clean coding-agent profile with an authenticated Matrix CLI, start a new conversation, and verify the Matrix tools are discoverable without placing credentials in plugin files.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Matrix CLI is installed and authenticated, **When** the plugin is enabled, **Then** its MCP server starts through standard input/output and exposes the documented tools.
+2. **Given** the plugin is installed but the CLI is unauthenticated, **When** a tool is invoked, **Then** the server returns safe setup guidance rather than prompting for or printing credentials.
+3. **Given** the plugin is validated, **When** it is packaged, **Then** all referenced skills, assets, and MCP configuration are present and no secret or machine-specific path is embedded.
+
+### Edge Cases
+
+- The account has zero computers, more computers than one response can include, or a computer changes availability between discovery and execution.
+- The selected computer changes, is reprovisioned, or its short-lived access token expires during a request.
+- A terminal is created by another client between list and create, or a tab disappears before selection/input.
+- Command output contains non-UTF-8 bytes, exceeds the response cap, times out, or the command exits due to a signal.
+- A file is empty, binary, changes during download, has an unknown media type, or has a filename containing control characters.
+- A chat has no messages, contains very large messages, is archived, or changes while pages are being read.
+- The MCP client disconnects while an operation is in flight; the remote operation must retain the semantics of its underlying Matrix request and must not be retried invisibly.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST expose a local coding-agent MCP server through the existing Matrix OS plugin and Matrix CLI distribution.
+- **FR-002**: The MCP server MUST authenticate from an explicitly selected or active Matrix CLI profile and MUST NOT accept, return, log, or persist credentials as tool arguments or results.
+- **FR-003**: The system MUST list only computers authorized for the signed-in owner and MUST cap one response at 20 computers.
+- **FR-004**: Every computer-scoped tool MUST require an explicit stable computer identifier; the server MUST NOT silently fall back to a different computer.
+- **FR-005**: The system MUST resolve a fresh computer-scoped access token when the selected computer differs from the profile's current computer, without mutating the user's active profile.
+- **FR-006**: The system MUST expose computer discovery, terminal listing/creation, tab listing/creation/selection, terminal input, captured command execution, directory listing, text-file reading, binary-safe download, binary-safe upload, chat listing/search, and chat detail tools.
+- **FR-007**: Captured commands MUST be provided as an argument vector rather than an interpolated shell string, MUST support a validated Matrix-home-relative working directory, and MUST return structured completion metadata.
+- **FR-008**: Captured command execution MUST default to a 10-minute timeout, MUST reject timeouts longer than 30 minutes, and MUST cap combined returned output at 1 MiB while reporting truncation.
+- **FR-009**: Persistent terminal creation MUST accept a validated unique name and optional Matrix-home-relative working directory; a duplicate create MUST fail without altering the existing terminal.
+- **FR-010**: Tab creation MUST target one named terminal, accept a bounded optional name and working directory, and return a stable tab index or identifier supplied by Matrix.
+- **FR-011**: Terminal input MUST target one named terminal after explicit tab selection, MUST be capped at 60,000 bytes per request, and MUST be annotated as a state-changing operation.
+- **FR-012**: The initial MCP release MUST NOT expose terminal/session/tab deletion, arbitrary pane manipulation, or an unbounded terminal-output stream.
+- **FR-013**: All file paths MUST be normalized beneath the selected computer owner's Matrix home and MUST preserve existing protected-path, symlink, regular-file, and secret-file rules.
+- **FR-014**: Directory listings MUST be capped at 500 entries, text reads MUST be capped at 256 KiB, and upload/download payloads MUST be capped at 1 MiB for MCP responses even if the underlying Matrix interface supports larger files.
+- **FR-015**: File download MUST return bytes through the MCP result and MUST NOT write an arbitrary path on the coding agent's local computer.
+- **FR-016**: File upload MUST accept either UTF-8 text or base64-encoded bytes, validate the claimed encoding, write atomically, and require an explicit overwrite flag before replacing an existing file.
+- **FR-017**: Chat operations MUST be read-only, paginated, and bounded to at most 100 chats or messages per request.
+- **FR-018**: All inputs MUST be validated at the MCP boundary before any network call, including identifiers, names, paths, limits, cursors, queries, command arguments, and encoded content.
+- **FR-019**: Every remote network request MUST have an explicit timeout; the system MUST map auth, validation, not-found, conflict, size, timeout, and availability failures to a small allowlisted set of safe errors.
+- **FR-020**: MCP responses MUST NOT reveal access tokens, cookies, provider errors, database errors, filesystem root paths, private hostnames, or raw internal error messages.
+- **FR-021**: The plugin bundle MUST reference its MCP configuration in its manifest, use portable package-runner commands, and contain no environment-specific absolute paths.
+- **FR-022**: The plugin's remote-work skills MUST prefer the MCP tools when available and MUST continue to document the CLI as a compatible fallback.
+- **FR-023**: Integration tests MUST exercise the full MCP-tool-to-authenticated-Matrix-interface path for at least computer discovery, command execution, file transfer, terminal creation, and chat inspection.
+- **FR-024**: The feature MUST document installation, authentication, computer targeting, tool behavior, limits, and the distinction between captured commands and persistent terminals.
+
+### Authorization Matrix
+
+| Operation group | Authentication source | Owner boundary | Public |
+|---|---|---|---|
+| Start local MCP server / discover tool schemas | Local plugin process | No owner data is read until a tool is called | Yes, locally |
+| List computers | Active Matrix CLI sign-in | Signed-in user's runtime inventory only | No |
+| Select computer / obtain scoped access | Active Matrix CLI sign-in | Requested computer must belong to the signed-in user | No |
+| Commands and persistent terminals | Computer-scoped Matrix access | Selected computer and its owner only | No |
+| Files | Computer-scoped Matrix access plus Matrix-home path policy | Selected owner's Matrix home only | No |
+| Chats | Computer-scoped Matrix access plus chat ownership checks | Selected owner's chats only | No |
+
+### Key Entities
+
+- **Computer Reference**: A stable runtime identifier plus user-facing label, handle, availability, type, version, gateway location, and declared capabilities. It belongs to exactly one signed-in owner.
+- **Runtime Access**: A short-lived, computer-scoped authorization resolved from the active Matrix sign-in. It is never returned to the MCP client.
+- **Terminal Session**: A persistent, user-visible terminal identified by a validated name on one computer. It owns an ordered collection of tabs.
+- **Terminal Tab**: A user-visible execution surface within one terminal session, addressable by the index or identifier supplied by Matrix.
+- **Captured Command Result**: A bounded, non-persistent execution result containing output, exit, signal, timeout, truncation, duration, and selected-computer metadata.
+- **Remote File Payload**: Bounded text or binary content associated with a normalized Matrix-home-relative path, size, filename, and media type.
+- **Chat Summary and Detail**: Read-only, owner-authorized chat metadata and paginated messages with stable cursors.
+
+### Assumptions
+
+- A "process" in this feature means an operating-system program that is currently running. Matrix does not introduce a second persistent process registry: long-lived observable work is represented by terminal sessions and tabs, while one-shot work is represented by captured command results.
+- The MCP transport is local standard input/output for the first release. A hosted HTTP MCP endpoint and its OAuth lifecycle are deferred.
+- The existing Matrix CLI device login, computer inventory, terminal, file, and chat interfaces remain the source of truth; this feature adds a bounded adapter rather than duplicating those domains.
+- File transfer through MCP is intentionally smaller than interactive CLI transfer. Larger files continue to use the existing `matrix upload` and `matrix download` commands.
+- Chat mutation, terminal deletion, live terminal streaming, background job scheduling, plugin marketplace publication, and automatic disabling of a coding agent's built-in local shell are outside this release.
+- To enforce a fully remote workflow, users or agent hosts must separately disable local shell tools and enable the Matrix MCP tools.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A signed-in user can discover a computer and complete a captured remote command through an MCP client in under 30 seconds, excluding the command's own runtime.
+- **SC-002**: In automated tests with two user-owned computers, 100% of tool calls execute against the explicitly named computer and 0% silently fall back to another runtime.
+- **SC-003**: Terminal, file, and chat tool responses stay within their documented caps for boundary-size and oversize test cases, with truncation or rejection reported explicitly.
+- **SC-004**: Traversal, protected-path, cross-owner computer, cross-owner chat, expired-auth, invalid-base64, oversized-input, and accidental-overwrite tests all fail without remote mutation or sensitive-data disclosure.
+- **SC-005**: A clean plugin validation run reports no manifest, referenced-file, placeholder, or portability errors.
+- **SC-006**: The full feature test suite, type check, repository pattern check, and existing regression suite pass before the pull request is opened.
+- **SC-007**: A new coding-agent conversation can discover all documented Matrix tools after one plugin installation and an existing Matrix CLI sign-in, without manual credential configuration.

--- a/specs/120-remote-computer-mcp/tasks.md
+++ b/specs/120-remote-computer-mcp/tasks.md
@@ -146,7 +146,7 @@
 
 ## Graphite Stack Plan
 
-This feature is planned as one structured-review PR, not a stack: it changes one published CLI boundary plus its existing plugin, introduces no endpoint or migration, and is expected to remain in the repository's 1,000-3,000-addition / 20-50-file single-PR band. If implementation exceeds 3,000 additions or 50 files, stop before commit and split with Graphite into:
+This feature is planned as one structured-review PR, not a stack: it changes one published CLI boundary, its existing plugin, and one narrow terminal tab-selection route; it adds no persistence and remains in the repository's 1,000-3,000-addition / 20-50-file single-PR band. If implementation exceeds 3,000 additions or 50 files, split with Graphite into:
 
 1. CLI MCP foundation + computers/commands/terminals.
 2. Files/chats + plugin packaging/documentation.

--- a/specs/120-remote-computer-mcp/tasks.md
+++ b/specs/120-remote-computer-mcp/tasks.md
@@ -1,0 +1,169 @@
+# Tasks: Remote Computer MCP
+
+**Input**: Design documents from `specs/120-remote-computer-mcp/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/tools.md
+
+**Tests**: TDD is mandatory. Each test task must be run and observed failing before its paired implementation task begins.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can be worked independently in a different file after its prerequisites
+- **[Story]**: User story from the specification
+
+## Phase 1: Setup
+
+**Purpose**: Establish the distributable protocol dependency and CLI entry point.
+
+- [x] T001 Update the published CLI patch version and add `@modelcontextprotocol/sdk` in `packages/sync-client/package.json`, then refresh `pnpm-lock.yaml` from the repository root
+- [x] T002 Add the `mcp` command registration shell without tool implementation in `packages/sync-client/src/cli/commands/mcp.ts` and `packages/sync-client/src/cli/index.ts`
+
+---
+
+## Phase 2: Foundational boundary
+
+**Purpose**: Shared validation, safe errors, profile auth, computer resolution, and gateway URL construction.
+
+**Critical**: All user stories depend on this phase.
+
+- [x] T003 Write failing boundary/adversarial tests for runtime slots, paths, command argv, base64, byte limits, and safe error projection in `packages/sync-client/tests/unit/mcp-schemas.test.ts`
+- [x] T004 Implement strict tool schemas and safe MCP result/error helpers in `packages/sync-client/src/mcp/schemas.ts` and `packages/sync-client/src/mcp/errors.ts`
+- [x] T005 Write failing tests for active/explicit profile resolution, expired auth, production control-plane origin, inventory validation, unavailable computers, and query-preserving gateway URLs in `packages/sync-client/tests/unit/mcp-profile-context.test.ts`
+- [x] T006 Implement profile/auth loading plus explicit owner-authorized computer resolution in `packages/sync-client/src/mcp/profile-context.ts`
+- [x] T007 Write failing HTTP-client tests for authorization headers, request timeouts, response size caps, safe status mapping, and no raw error leakage in `packages/sync-client/tests/unit/mcp-clients.test.ts`
+- [x] T008 Implement the shared bounded authenticated request layer in `packages/sync-client/src/mcp/clients.ts`
+
+**Checkpoint**: A scoped runtime can be resolved safely, but no MCP domain tool is registered yet.
+
+---
+
+## Phase 3: User Story 1 - Run work on a chosen Matrix computer (Priority: P1) MVP
+
+**Goal**: Discover authorized computers and run captured argv commands on an explicit computer.
+
+**Independent Test**: With a fake account containing two computers, list both and run `pwd` on the non-default slot; verify only that gateway receives the request and structured completion metadata is returned.
+
+- [x] T009 [US1] Write failing MCP handler tests for `list_computers` and `run_command`, including explicit target, timeout, output truncation metadata, unavailable target, and second-computer token selection in `packages/sync-client/tests/integration/mcp-server.test.ts`
+- [x] T010 [US1] Add computer inventory and captured-command methods to `packages/sync-client/src/mcp/clients.ts`
+- [x] T011 [US1] Register `list_computers` and `run_command` with correct annotations and safe results in `packages/sync-client/src/mcp/server.ts`
+- [x] T012 [US1] Wire stdio transport and profile selection into `packages/sync-client/src/cli/commands/mcp.ts`
+
+**Checkpoint**: The MVP can execute captured work remotely through a real MCP client without using a local shell.
+
+---
+
+## Phase 4: User Story 2 - Work in persistent terminals and tabs (Priority: P1)
+
+**Goal**: Create/list persistent zellij terminals and tabs, select a tab, and send bounded input.
+
+**Independent Test**: Create a terminal and tab through MCP, list them, select the new tab, send `printf ok\n`, and verify the fake gateway receives each request in order.
+
+- [x] T013 [US2] Add failing terminal tool tests for list/create session, list/create/select tab, input size, stale references, and duplicate names in `packages/sync-client/tests/integration/mcp-server.test.ts`
+- [x] T014 [US2] Add bounded terminal session/tab/input methods and safe projections in `packages/sync-client/src/mcp/clients.ts`
+- [x] T015 [US2] Register six persistent terminal tools with read-only/state-changing annotations in `packages/sync-client/src/mcp/server.ts`
+
+**Checkpoint**: Persistent work is visible and reconnectable through Matrix terminal surfaces.
+
+---
+
+## Phase 5: User Story 3 - Inspect and transfer Matrix files (Priority: P2)
+
+**Goal**: List/read/download/upload bounded content without local filesystem path access.
+
+**Independent Test**: Transfer text and binary fixtures through MCP and reject traversal, protected/invalid paths, invalid base64, oversize content, symlink/not-file responses, and overwrite without consent.
+
+- [x] T016 [US3] Add failing file tool tests for list, UTF-8 read, base64 download/upload, 256 KiB/1 MiB caps, traversal, invalid base64, timeout, and overwrite conflict in `packages/sync-client/tests/integration/mcp-server.test.ts`
+- [x] T017 [US3] Add bounded list/blob client methods with content-length and post-read caps in `packages/sync-client/src/mcp/clients.ts`
+- [x] T018 [US3] Register `list_files`, `read_file`, `download_file`, and `upload_file` with content-only transfer contracts in `packages/sync-client/src/mcp/server.ts`
+
+**Checkpoint**: Small remote artifacts can move through MCP without granting local path access.
+
+---
+
+## Phase 6: User Story 4 - Check Matrix chat sessions (Priority: P2)
+
+**Goal**: List, search, and inspect canonical chats without mutation.
+
+**Independent Test**: List/search seeded chat summaries and inspect a paginated chat detail; verify every request is GET, limits are capped at 100, and cross-owner/not-found responses are generic.
+
+- [x] T019 [US4] Add failing read-only chat tests for list/search/detail pagination, query encoding, item/message caps, empty chats, and generic not-found in `packages/sync-client/tests/integration/mcp-server.test.ts`
+- [x] T020 [US4] Add read-only canonical chat methods and bounded response projection in `packages/sync-client/src/mcp/clients.ts`
+- [x] T021 [US4] Register `list_chats`, `search_chats`, and `get_chat` as read-only tools in `packages/sync-client/src/mcp/server.ts`
+
+**Checkpoint**: Agents can recover bounded task context without altering chat state.
+
+---
+
+## Phase 7: User Story 5 - Install one portable Matrix OS plugin (Priority: P3)
+
+**Goal**: Ship the MCP alongside existing Matrix skills through the current plugin.
+
+**Independent Test**: Validate the plugin and assert its MCP config is portable, referenced by the manifest, contains no credentials/absolute paths, and starts the pinned Matrix CLI MCP command.
+
+- [x] T022 [US5] Write failing plugin contract tests for manifest/MCP linkage, command portability, version pinning, and secret/absolute-path rejection in `tests/plugins/matrix-os-plugin.test.ts`
+- [x] T023 [US5] Add `plugins/matrix-os/.mcp.json`, bump and update `plugins/matrix-os/.codex-plugin/plugin.json`, and preserve the existing marketplace entry in `.agents/plugins/marketplace.json`
+- [x] T024 [US5] Update remote-first MCP guidance with CLI fallback in `plugins/matrix-os/skills/matrix-cloud-run/SKILL.md` and `plugins/matrix-os/skills/matrix-github-project/SKILL.md`
+- [x] T025 [US5] Run the plugin creator validator against `plugins/matrix-os` and fix every reported issue in the plugin bundle
+
+---
+
+## Phase 8: Polish and release gates
+
+**Purpose**: Documentation, packaging, security review, and PR delivery.
+
+- [x] T026 Update CLI usage/tool/limit documentation and packaging checks in `packages/sync-client/README.md` and `packages/sync-client/scripts/check-publish.mjs`
+- [x] T027 Mark completed work and record exact validation evidence in `specs/120-remote-computer-mcp/tasks.md` and `specs/120-remote-computer-mcp/quickstart.md`
+- [x] T028 Run focused CLI tests/build plus `bun run typecheck`, `bun run check:patterns`, and `bun run test`; fix only failures caused by this branch
+- [x] T029 Perform the review pipeline mechanical, trust-boundary, and failure-mode sweeps over changed production files and document any intentional deferral in the PR body
+- [x] T030 Create the companion public documentation change in `FinnaAI/matrix-os-site/content/docs/` and link its PR from the implementation PR
+- [ ] T031 Commit with a Conventional Commit message, push `codex/remote-computer-mcp`, open the implementation PR with the mandatory Invariants section, and run `prcheck` until required checks and Greptile reach the merge gate
+
+---
+
+## Dependencies and Execution Order
+
+### Phase dependencies
+
+- Setup (Phase 1) starts immediately.
+- Foundational (Phase 2) depends on Setup and blocks all stories.
+- US1 establishes server/transport registration used by later stories.
+- US2, US3, and US4 depend on the foundation and server registration; their domain client/test work is otherwise independent.
+- US5 depends on the final CLI command/tool names.
+- Polish depends on all selected stories.
+
+### User story dependencies
+
+- **US1**: Foundation only; MVP.
+- **US2**: Foundation plus MCP server scaffold from US1.
+- **US3**: Foundation plus MCP server scaffold from US1.
+- **US4**: Foundation plus MCP server scaffold from US1.
+- **US5**: Completed public CLI contract from US1-US4.
+
+### Parallel opportunities
+
+- After T008, test design for terminal, file, and chat domains can proceed independently in separate files if later split from the integration suite.
+- Plugin contract tests can begin after the final command/tool contract is frozen.
+- Public docs can be drafted while the full repository test suite runs, but cannot claim release readiness until validation passes.
+
+## Graphite Stack Plan
+
+This feature is planned as one structured-review PR, not a stack: it changes one published CLI boundary plus its existing plugin, introduces no endpoint or migration, and is expected to remain in the repository's 1,000-3,000-addition / 20-50-file single-PR band. If implementation exceeds 3,000 additions or 50 files, stop before commit and split with Graphite into:
+
+1. CLI MCP foundation + computers/commands/terminals.
+2. Files/chats + plugin packaging/documentation.
+
+Do not flatten those branches if the split threshold is crossed.
+
+## Implementation Strategy
+
+1. Complete T001-T008 with observed red/green tests.
+2. Complete US1 and validate the MVP independently.
+3. Add persistent terminals, then files, then read-only chats with a red/green cycle per story.
+4. Freeze the tool contract, wire the plugin, and validate the bundle.
+5. Run full gates, structured review, companion docs, and PR workflow.
+
+## Format Validation
+
+- Every executable line uses `- [ ] TNNN`.
+- Story tasks include `[USN]`; setup/foundation/polish tasks do not.
+- Every task names concrete file paths.
+- Test tasks precede implementation tasks for each boundary/story.

--- a/tests/gateway/shell-tab-cwd.test.ts
+++ b/tests/gateway/shell-tab-cwd.test.ts
@@ -1,0 +1,45 @@
+import { EventEmitter } from "node:events";
+import { mkdir, mkdtemp, realpath, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { it, expect, vi } from "vitest";
+import { createZellijAdapter } from "../../packages/gateway/src/shell/zellij.js";
+import { createShellRoutes } from "../../packages/gateway/src/shell/routes.js";
+
+it("resolves tab cwd within Matrix home through the real route and adapter", async () => {
+  const root = await mkdtemp(join(tmpdir(), "matrix-tab-cwd-"));
+  try {
+    const homePath = join(root, "home");
+    await mkdir(join(homePath, "projects/repo"), { recursive: true });
+    await mkdir(join(root, "outside"));
+    await symlink(join(root, "outside"), join(homePath, "escape"));
+    const execFile = vi.fn((_file, _args, _opts, cb) => {
+      cb(null, "41\n", "");
+      return new EventEmitter();
+    });
+    const app = createShellRoutes({
+      homePath,
+      registry: { list: vi.fn(), create: vi.fn(), delete: vi.fn() },
+      workspace: createZellijAdapter({ homePath, manageConfig: false, execFile, spawn: vi.fn() }),
+    });
+    const createTab = (cwd?: string) => app.request("/sessions/main/tabs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "tests", ...(cwd === undefined ? {} : { cwd }) }),
+    });
+    for (const cwd of ["projects/repo", "~/projects/repo", undefined]) {
+      expect((await createTab(cwd)).status).toBe(200);
+      expect(execFile.mock.lastCall?.[1]).toEqual([
+        "--session", "main", "action", "new-tab", "--name", "tests", "--cwd",
+        await realpath(cwd === undefined ? homePath : join(homePath, "projects/repo")),
+      ]);
+    }
+    execFile.mockClear();
+    for (const cwd of ["escape", "missing", "../outside"]) {
+      expect((await createTab(cwd)).status).toBe(400);
+    }
+    expect(execFile).not.toHaveBeenCalled();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/tests/gateway/shell-tabs.test.ts
+++ b/tests/gateway/shell-tabs.test.ts
@@ -15,8 +15,9 @@ describe("gateway shell tab routes", () => {
   it("lists, creates, switches, and closes tabs with validated inputs", async () => {
     const workspace = {
       listTabs: vi.fn(async () => [{ idx: 0, name: "main", focused: true }]),
-      createTab: vi.fn(async () => ({ idx: 1, name: "api" })),
+      createTab: vi.fn(async () => ({ id: 41, idx: 1, name: "api" })),
       switchTab: vi.fn(async () => ({ ok: true })),
+      switchTabById: vi.fn(async () => ({ ok: true })),
       closeTab: vi.fn(async () => ({ ok: true })),
     };
     const app = appWithWorkspace(workspace);
@@ -28,8 +29,11 @@ describe("gateway shell tab routes", () => {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "api", cwd: "~/repo", cmd: "pnpm dev" }),
-    })).json()).resolves.toEqual({ tab: { idx: 1, name: "api" } });
+    })).json()).resolves.toEqual({ tab: { id: 41, idx: 1, name: "api" } });
     await expect((await app.request("/api/sessions/main/tabs/1/go", {
+      method: "POST",
+    })).json()).resolves.toEqual({ ok: true });
+    await expect((await app.request("/api/sessions/main/tabs/by-id/41/go", {
       method: "POST",
     })).json()).resolves.toEqual({ ok: true });
     await expect((await app.request("/api/sessions/main/tabs/1", {
@@ -42,6 +46,7 @@ describe("gateway shell tab routes", () => {
       cmd: "pnpm dev",
     });
     expect(workspace.switchTab).toHaveBeenCalledWith("main", 1);
+    expect(workspace.switchTabById).toHaveBeenCalledWith("main", 41);
     expect(workspace.closeTab).toHaveBeenCalledWith("main", 1);
   });
 
@@ -50,6 +55,7 @@ describe("gateway shell tab routes", () => {
       listTabs: vi.fn(),
       createTab: vi.fn(),
       switchTab: vi.fn(),
+      switchTabById: vi.fn(),
       closeTab: vi.fn(),
     });
 

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -887,8 +887,8 @@ describe("zellij adapter", () => {
 
   it("creates tabs and panes with terminal-capable environment at process launch", async () => {
     const child = childProcess();
-    const execFile = vi.fn((_file, _args, _opts, cb) => {
-      cb(null, "", "");
+    const execFile = vi.fn((_file, args: string[], _opts, cb) => {
+      cb(null, args.includes("new-tab") ? "1\n" : "", "");
       return child;
     });
     const adapter = createZellijAdapter({
@@ -914,10 +914,40 @@ describe("zellij adapter", () => {
     }
   });
 
+  it("returns the stable tab ID emitted atomically by Zellij and selects by ID", async () => {
+    const child = childProcess();
+    const execFile = vi.fn((_file, args: string[], _opts, cb) => {
+      const stdout = args.includes("list-tabs")
+        ? JSON.stringify([{ tab_id: 41, position: 1, name: "tests", active: true }])
+        : args.includes("new-tab") ? "41\n" : "";
+      cb(null, stdout, "");
+      return child;
+    });
+    const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
+
+    await expect(adapter.listTabs("main")).resolves.toEqual([{
+      id: 41,
+      idx: 1,
+      name: "tests",
+      focused: true,
+    }]);
+    await expect(adapter.createTab("main", { name: "tests" })).resolves.toEqual({
+      id: 41,
+      name: "tests",
+    });
+    await expect(adapter.switchTabById("main", 41)).resolves.toEqual({ ok: true });
+    expect(execFile).toHaveBeenCalledWith(
+      "zellij",
+      ["--session", "main", "action", "go-to-tab-by-id", "41"],
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
   it("splits multi-word commands into argv tokens for zellij actions", async () => {
     const child = childProcess();
-    const execFile = vi.fn((_file, _args, _opts, cb) => {
-      cb(null, "", "");
+    const execFile = vi.fn((_file, args: string[], _opts, cb) => {
+      cb(null, args.includes("new-tab") ? "1\n" : "", "");
       return child;
     });
     const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });

--- a/tests/gateway/user-systemd-zellij-adapter.test.ts
+++ b/tests/gateway/user-systemd-zellij-adapter.test.ts
@@ -43,6 +43,7 @@ function fakeAdapter(): ZellijAdapter {
     listTabs: vi.fn(async () => []),
     createTab: vi.fn(async () => ({ ok: true })),
     switchTab: vi.fn(async () => ({ ok: true })),
+    switchTabById: vi.fn(async () => ({ ok: true })),
     closeTab: vi.fn(async () => ({ ok: true })),
     splitPane: vi.fn(async () => ({ ok: true })),
     closePane: vi.fn(async () => ({ ok: true })),
@@ -130,6 +131,7 @@ describe("user-systemd zellij adapter", () => {
     await expect(adapter.listSessions()).resolves.toEqual(["Main"]);
     await expect(adapter.getSessionCreatedAt?.("Main")).resolves.toBe(live.createdAt);
     await adapter.sendInput("Main", "echo safe");
+    await adapter.switchTabById("Main", 41);
     adapter.attachSession("Main");
 
     expect(controller.list).toHaveBeenCalledWith({ scope: "terminal", runningOnly: true });
@@ -137,6 +139,7 @@ describe("user-systemd zellij adapter", () => {
       `/opt/matrix/terminal-runtime/generations/${GENERATION}/zellij`,
     );
     expect(pinned.sendInput).toHaveBeenCalledWith(live.sessionName, "echo safe");
+    expect(pinned.switchTabById).toHaveBeenCalledWith(live.sessionName, 41);
     expect(pinned.attachSession).toHaveBeenCalledWith(live.sessionName, {});
   });
 

--- a/tests/gateway/user-systemd-zellij-runtime.test.ts
+++ b/tests/gateway/user-systemd-zellij-runtime.test.ts
@@ -15,7 +15,8 @@ function fakeAdapter(): ZellijAdapter {
     deleteSession: vi.fn(async () => undefined), renameSession: vi.fn(async () => undefined),
     validateLayout: vi.fn(async () => undefined), attachSession: vi.fn() as never,
     sendInput: vi.fn(async () => undefined), listTabs: vi.fn(async () => []),
-    createTab: vi.fn(async () => ({})), switchTab: vi.fn(async () => ({})), closeTab: vi.fn(async () => ({})),
+    createTab: vi.fn(async () => ({})), switchTab: vi.fn(async () => ({})), switchTabById: vi.fn(async () => ({})),
+    closeTab: vi.fn(async () => ({})),
     splitPane: vi.fn(async () => ({})), closePane: vi.fn(async () => ({})), applyLayout: vi.fn(async () => ({})),
     dumpLayout: vi.fn(async () => ({})), setShellTheme: vi.fn(async () => undefined),
   };

--- a/tests/plugins/matrix-os-plugin.test.ts
+++ b/tests/plugins/matrix-os-plugin.test.ts
@@ -1,0 +1,46 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(import.meta.dirname, "../..");
+const pluginRoot = resolve(root, "plugins/matrix-os");
+
+async function jsonFile(path: string) {
+  return JSON.parse(await readFile(resolve(pluginRoot, path), "utf8")) as Record<string, unknown>;
+}
+
+describe("Matrix OS coding-agent plugin", () => {
+  it("ships a manifest-linked portable and version-pinned MCP server", async () => {
+    const manifest = await jsonFile(".codex-plugin/plugin.json");
+    const mcp = await jsonFile(".mcp.json");
+
+    expect(manifest).toMatchObject({
+      name: "matrix-os",
+      version: "0.3.0",
+      mcpServers: "./.mcp.json",
+    });
+    expect(mcp).toEqual({
+      mcpServers: {
+        "matrix-remote-computer": {
+          command: "npx",
+          args: ["-y", "@finnaai/matrix@0.3.16", "mcp", "serve", "--profile", "cloud"],
+        },
+      },
+    });
+    const serialized = JSON.stringify(mcp);
+    expect(serialized).not.toMatch(/Bearer |access[_-]?token|refresh[_-]?token|\/Users\/|\/home\//i);
+  });
+
+  it("teaches MCP-first remote execution while retaining a CLI fallback", async () => {
+    const cloudRun = await readFile(resolve(pluginRoot, "skills/matrix-cloud-run/SKILL.md"), "utf8");
+    const githubProject = await readFile(resolve(pluginRoot, "skills/matrix-github-project/SKILL.md"), "utf8");
+    const onboarding = await readFile(resolve(pluginRoot, "skills/matrix-onboarding/SKILL.md"), "utf8");
+
+    for (const skill of [cloudRun, githubProject, onboarding]) {
+      expect(skill).toContain("list_computers");
+      expect(skill).toContain("run_command");
+      expect(skill).toContain("CLI fallback");
+      expect(skill).not.toContain("Never create or use shell tabs");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add a stdio Matrix MCP server to the published CLI with 15 tools for computer discovery, captured command execution, persistent zellij sessions and tabs, bounded file transfer, and read-only chat inspection
- return stable Zellij tab IDs atomically and add backward-compatible stable-ID selection while preserving position-based shell clients
- resolve tab working directories within Matrix home, preserve actionable authentication errors, and exit cleanly after MCP stdio disconnects
- ship the MCP alongside the existing Matrix OS plugin and update its skills to prefer remote MCP tools with CLI fallback
- add the complete Spec Kit plan and companion public documentation

Companion docs: https://github.com/FinnaAI/matrix-os-site/pull/73

## Invariants

- source of truth: the existing platform computer inventory and per-computer gateway remain authoritative; the MCP process does not replicate remote state
- auth source of truth: the selected Matrix CLI profile supplies the owner principal, and non-active computers receive only a bounded in-memory runtime-selection token
- lock and transaction scope: no database write, lock, or transaction is added; Zellij emits the created tab ID from the same process invocation, avoiding list/create inference or a new lock
- acceptable orphan states: a created zellij session or tab, or an already-started captured command, may survive an MCP client disconnect and remains discoverable through Matrix; no MCP-local durable state is orphaned
- every scoped tool requires an explicit owner-authorized Matrix computer
- credentials stay in the Matrix CLI profile store and are never embedded in plugin configuration or tool output
- authenticated remote requests reject redirects, use explicit timeouts, and bound responses; client-visible failures use a fixed safe error allowlist
- file tools accept only normalized Matrix-home-relative paths and never read or write coding-agent-local paths
- chat tools are GET-only; no new persistence layer or database migration is introduced
- the one new terminal subroute uses the existing computer-scoped gateway auth boundary, bounded-body middleware, and validated session/tab IDs
- MCP cannot disable host-provided local tools; strict remote-only operation remains a coding-agent host policy
- the final diff is 2,991 additions across 40 files, within the repository's single-PR review band

## Validation

- 33 focused MCP unit and integration tests pass, including a real subprocess handshake and clean shutdown
- the real terminal route-to-adapter test passes for relative/default cwd and rejects missing, traversal, and out-of-home symlink paths
- the broader terminal/plugin suite passes 56/57 tests; its existing shell-wrapper test hits its 1-second timeout after producing the expected stdout, including in isolation, unrelated to tab creation
- both plugin contract tests pass
- sync-client and gateway TypeScript builds pass
- sync-client pre-publish check and plugin validator pass
- all underlying repository typecheck workspace compilers/builds pass when run directly
- changed-file pattern scan reports zero violations
- companion docs suite passes 50 tests

The repository-wide test command was exercised but cannot complete cleanly in this checkout Node 22 shell: Matrix OS requires Node 24, while the installed QMD better-sqlite3 binary targets Node 24 ABI 137. All feature-focused tests pass. The one sync-client credential-discovery failure is environment-sensitive and reproduces on main because this machine has a Claude Code Keychain credential.

## Deferred scope

- no generic operating-system process registry; use captured `run_command` or persistent zellij controls
- no large-file streaming beyond the documented 256 KiB text and 1 MiB binary caps
- no chat mutation
- persistent terminal output is observed through Matrix terminal surfaces; captured output uses `run_command`
