### PR TITLE
fix(installer): install terminal runtime user units

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -536,6 +536,10 @@ install_terminal_runtime_user_units() {
       || fail "bundled terminal runtime unit is missing or unsafe: $unit"
     install -o root -g root -m 0644 "/opt/matrix/user-systemd/$unit" "/etc/systemd/user/$unit"
   done
+  [ -x /opt/matrix/terminal-runtime/current/matrix-terminal-attach.mjs ] \
+    || fail "bundled terminal runtime attach helper is missing or not executable"
+  install -d -o root -g root -m 0755 /usr/local/bin
+  install -o root -g root -m 0755 /opt/matrix/terminal-runtime/current/matrix-terminal-attach.mjs /usr/local/bin/matrix-terminal-attach
 
   matrix_uid="$(id -u matrix)"
   run_required "enabling Matrix user linger" loginctl enable-linger matrix

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -526,6 +526,27 @@ WantedBy=multi-user.target
 EOF
 }
 
+install_terminal_runtime_user_units() {
+  local matrix_uid unit
+
+  [ -d /opt/matrix/user-systemd ] || fail "bundled terminal runtime user units are missing"
+  install -d -o root -g root -m 0755 /etc/systemd/user
+  for unit in matrix-zellij@.service matrix-terminal.slice; do
+    [ -f "/opt/matrix/user-systemd/$unit" ] && [ ! -L "/opt/matrix/user-systemd/$unit" ] \
+      || fail "bundled terminal runtime unit is missing or unsafe: $unit"
+    install -o root -g root -m 0644 "/opt/matrix/user-systemd/$unit" "/etc/systemd/user/$unit"
+  done
+
+  matrix_uid="$(id -u matrix)"
+  run_required "enabling Matrix user linger" loginctl enable-linger matrix
+  run_required "starting Matrix user manager" systemctl start "user@${matrix_uid}.service"
+  run_required "reloading Matrix user systemd units" runuser -u matrix -- env \
+    HOME="$MATRIX_HOME_DIR" \
+    XDG_RUNTIME_DIR="/run/user/${matrix_uid}" \
+    DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/${matrix_uid}/bus" \
+    systemctl --user daemon-reload
+}
+
 install_systemd_units() {
   section "Installing systemd units"
   install -m 0644 /opt/matrix/systemd/matrix-gateway.service /etc/systemd/system/matrix-gateway.service
@@ -536,6 +557,7 @@ install_systemd_units() {
     install -m 0644 /opt/matrix/systemd/matrix-developer-tools.service /etc/systemd/system/matrix-developer-tools.service
   fi
   write_self_host_restore_service
+  install_terminal_runtime_user_units
   run_required "reloading systemd" systemctl daemon-reload
   run_required "enabling Matrix OS services" systemctl enable docker matrix-restore matrix-gateway matrix-shell matrix-code matrix-code-server
   if [ -f /etc/systemd/system/matrix-developer-tools.service ] && [ -n "$MATRIX_DEVELOPER_TOOLS" ]; then

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -134,6 +134,10 @@ describe("self-host server installer", () => {
     expect(script).toContain("loginctl enable-linger matrix");
     expect(script).toContain('systemctl start "user@${matrix_uid}.service"');
     expect(script).toContain('systemctl --user daemon-reload');
+    expect(script).toContain("install -o root -g root -m 0755 /opt/matrix/terminal-runtime/current/matrix-terminal-attach.mjs /usr/local/bin/matrix-terminal-attach");
+    expect(script.indexOf("install_terminal_runtime_user_units")).toBeLessThan(
+      script.indexOf("start_services"),
+    );
   });
 
   it("installs the core Matrix services without enabling managed-cloud backup requirements", () => {

--- a/tests/scripts/self-host-installer.test.ts
+++ b/tests/scripts/self-host-installer.test.ts
@@ -125,6 +125,17 @@ describe("self-host server installer", () => {
     expect(script).not.toContain("grep '^MATRIX_CODE_PROXY_TOKEN='");
   });
 
+  it("installs the terminal-runtime user units and reloads the matrix user manager", () => {
+    const script = readFileSync(join(root, "scripts/install-server.sh"), "utf8");
+
+    expect(script).toContain("install -d -o root -g root -m 0755 /etc/systemd/user");
+    expect(script).toContain('install -o root -g root -m 0644 "/opt/matrix/user-systemd/$unit" "/etc/systemd/user/$unit"');
+    expect(script).toContain("matrix-zellij@.service matrix-terminal.slice");
+    expect(script).toContain("loginctl enable-linger matrix");
+    expect(script).toContain('systemctl start "user@${matrix_uid}.service"');
+    expect(script).toContain('systemctl --user daemon-reload');
+  });
+
   it("installs the core Matrix services without enabling managed-cloud backup requirements", () => {
     const script = readFileSync(join(root, "scripts/install-server.sh"), "utf8");
 


### PR DESCRIPTION
## Summary
- install the bundled `matrix-zellij@.service` and `matrix-terminal.slice` files into `/etc/systemd/user` during standalone self-host installation
- enable lingering, start the `matrix` user manager, and reload its unit cache before the gateway starts
- fail the installation if either bundled unit is absent or a symlink

## Verification
- `bash -n scripts/install-server.sh`
- `pnpm exec vitest run tests/scripts/self-host-installer.test.ts tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts`

## Invariants
- **Source of truth:** The signed Matrix host bundle supplies the two user units from `/opt/matrix/user-systemd`; the installer copies them as root-owned regular files into the gateway's required `/etc/systemd/user` location.
- **Lock/transaction scope:** No shared data or database mutation. Unit installation and systemd manager setup run synchronously before the installer starts `matrix-gateway.service`.
- **Acceptable orphan states:** If installation stops after copying the files but before service startup, the root-owned unit files and enabled linger state are safe, idempotent prerequisites for a later installer retry.
- **Auth source of truth:** Unchanged. This operates only as root within the existing server installer and does not add an endpoint, credential, or authentication path.
- **Deferred scope:** Existing hosts that already ran a defective installer require the documented one-time repair or a future update/reconciliation path; this PR fixes clean and repeat standalone installs.
