### PR TITLE
fix(platform): load TypeScript MCP runtime in Cloud Run

### DIFF
--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -91,6 +91,8 @@ COPY --from=builder --chown=matrix-platform:matrix-platform /app/shell ./shell
 COPY --chown=matrix-platform:matrix-platform distro/customer-vps ./distro/customer-vps
 COPY --chown=matrix-platform:matrix-platform scripts/start-platform-cloud-run.sh ./scripts/start-platform-cloud-run.sh
 
+RUN node --import=tsx --input-type=module --eval "await import('@finnaai/matrix/mcp')"
+
 RUN chmod 0755 ./scripts/start-platform-cloud-run.sh && \
     mkdir -p ./shell/.next/cache ./shell/.next/server && \
     chown -R matrix-platform:matrix-platform ./shell/.next/cache ./shell/.next/server

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -15,7 +15,6 @@
     "@types/pg": "^8.18.0",
     "@types/ws": "^8.18.1",
     "kysely-pglite": "^0.6.1",
-    "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },
   "dependencies": {
@@ -36,6 +35,7 @@
     "pg": "^8.21.0",
     "prom-client": "^15.1.3",
     "stripe": "22.5.0",
+    "tsx": "^4.21.0",
     "undici": "7.24.8",
     "ws": "^8.19.0",
     "zod": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -849,6 +849,9 @@ importers:
       stripe:
         specifier: 22.5.0
         version: 22.5.0(@types/node@25.5.0)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       undici:
         specifier: 7.24.8
         version: 7.24.8
@@ -877,9 +880,6 @@ importers:
       kysely-pglite:
         specifier: ^0.6.1
         version: 0.6.1(@electric-sql/pglite@0.4.1)(better-sqlite3@12.10.0)(kysely@0.28.14)(pg@8.21.0)
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3

--- a/scripts/start-platform-cloud-run.sh
+++ b/scripts/start-platform-cloud-run.sh
@@ -56,7 +56,7 @@ if [ "${AUTH_SHELL_ENABLED:-true}" = "true" ]; then
   fi
 fi
 
-node packages/platform/dist/main.js &
+node --import=tsx packages/platform/dist/main.js &
 platform_pid="$!"
 
 while :; do

--- a/tests/scripts/start-platform-cloud-run.test.ts
+++ b/tests/scripts/start-platform-cloud-run.test.ts
@@ -16,10 +16,22 @@ describe('start-platform-cloud-run.sh', () => {
 
     const authStartIndex = script.indexOf('node node_modules/next/dist/bin/next start shell');
     const readinessIndex = script.indexOf('if ! wait_for_auth_shell; then');
-    const platformStartIndex = script.indexOf('node packages/platform/dist/main.js');
+    const platformStartIndex = script.indexOf('node --import=tsx packages/platform/dist/main.js');
     expect(authStartIndex).toBeGreaterThanOrEqual(0);
     expect(readinessIndex).toBeGreaterThan(authStartIndex);
     expect(platformStartIndex).toBeGreaterThan(readinessIndex);
+  });
+
+  it('loads TypeScript workspace exports in the production platform process', () => {
+    const root = process.cwd();
+    const script = readFileSync(join(root, 'scripts/start-platform-cloud-run.sh'), 'utf8');
+    const platformPackage = JSON.parse(
+      readFileSync(join(root, 'packages/platform/package.json'), 'utf8'),
+    ) as { dependencies?: Record<string, string>; devDependencies?: Record<string, string> };
+
+    expect(script).toContain('node --import=tsx packages/platform/dist/main.js');
+    expect(platformPackage.dependencies?.tsx).toBe('^4.21.0');
+    expect(platformPackage.devDependencies?.tsx).toBeUndefined();
   });
 
   it('installs the readiness probe client in the platform runtime image', () => {

--- a/tests/scripts/start-platform-cloud-run.test.ts
+++ b/tests/scripts/start-platform-cloud-run.test.ts
@@ -25,11 +25,15 @@ describe('start-platform-cloud-run.sh', () => {
   it('loads TypeScript workspace exports in the production platform process', () => {
     const root = process.cwd();
     const script = readFileSync(join(root, 'scripts/start-platform-cloud-run.sh'), 'utf8');
+    const dockerfile = readFileSync(join(root, 'Dockerfile.platform'), 'utf8');
     const platformPackage = JSON.parse(
       readFileSync(join(root, 'packages/platform/package.json'), 'utf8'),
     ) as { dependencies?: Record<string, string>; devDependencies?: Record<string, string> };
 
     expect(script).toContain('node --import=tsx packages/platform/dist/main.js');
+    expect(dockerfile).toContain(
+      'RUN node --import=tsx --input-type=module --eval "await import(\'@finnaai/matrix/mcp\')"',
+    );
     expect(platformPackage.dependencies?.tsx).toBe('^4.21.0');
     expect(platformPackage.devDependencies?.tsx).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

- start the compiled platform server with Node's `tsx` import hook so the `@finnaai/matrix/mcp` TypeScript export resolves in the Cloud Run runtime
- move `tsx` into the platform's production dependencies so the launcher does not rely on a development-only install
- execute the MCP import during the production image build and cover the launcher, image, and dependency contracts with a regression test

This fixes the `ERR_MODULE_NOT_FOUND` startup crash introduced when platform startup began statically importing the MCP workspace export. The previous serving revision remains unaffected until this candidate passes readiness.

## Tests

- `pnpm exec vitest run tests/scripts/start-platform-cloud-run.test.ts`
- `pnpm --filter @matrix-os/platform build`
- `pnpm install --frozen-lockfile --lockfile-only`
- `pnpm run check:patterns` (0 violations; existing repository warnings only)
- all package TypeScript checks from the root typecheck script, invoked with pnpm because `bun` is unavailable in this environment
- `node --import=tsx --input-type=module --eval "await import('@finnaai/matrix/mcp')"`
- production-image MCP import runs as part of `Dockerfile.platform`
- full `pnpm run test` started locally; GitHub CI remains the authoritative full-suite gate

## Invariants

- **Source of truth:** `scripts/start-platform-cloud-run.sh` defines the production process invocation; `packages/platform/package.json` and `pnpm-lock.yaml` define the runtime dependency closure.
- **Lock/transaction scope:** no database or filesystem transaction behavior changes. Startup remains ordered after auth-shell readiness exactly as before.
- **Acceptable orphan states:** a candidate revision that cannot start fails Cloud Run readiness and receives no traffic; the prior healthy revision continues serving.
- **Auth source of truth:** unchanged. Clerk/platform authentication and MCP credential handling are unaffected; this only changes TypeScript module loading.
- **Deferred scope:** compiling the sync-client's TypeScript package exports to JavaScript is intentionally not part of this focused recovery PR.
