### PR TITLE
docs(chat): design agents, templates, and task workflows

### DIFF
--- a/specs/121-chat-agent-templates/contract.md
+++ b/specs/121-chat-agent-templates/contract.md
@@ -1,0 +1,126 @@
+# Template and execution data contract
+
+Proposed schema version 1. This is a normative specification, not executable product code. [Behavior and security](spec.md).
+
+## Definition
+
+Markdown body contains original method instructions. Frontmatter is parsed as data by a strict Zod 4 schema; reject unknown executable fields, duplicate keys, invalid IDs and unknown versions. Never evaluate template expressions or load dependencies from URLs.
+
+| Field | Type / bound | Meaning |
+| --- | --- | --- |
+| `schemaVersion` | literal `1` | Parser contract |
+| `id`, `version` | safe slug ≤80; semver ≤32 | Stable template identity and immutable revision |
+| `name`, `summary` | text ≤80 / ≤280 chars | Original user-facing text |
+| `provenance` | `{kind: matrix_original, license: AGPL-3.0-or-later, inspirationUrls: string[]}`; ≤5 HTTPS references | Attribution references only; not executable URLs or a claim of upstream endorsement |
+| `job` | text ≤500 chars | One concrete user outcome |
+| `trigger` | literal `manual` | No schedule/recurrence activation |
+| `inputs` | discriminated input schema ID plus ≤4 connection slots | Typed required/optional context; arbitrary JSON Schema execution is excluded |
+| `authority` | `{mode: draft_only, harnessTools: none, externalWrites: denied}` | Enforced execution profile, not a user-editable promise |
+| `cap` | bounded numeric fields below | Work, source and output ceilings |
+| `proof` | known result schema ID | Output sections and evidence requirements |
+| `readback` | known verifier ID | Server validator selecting a fixed implementation, never template-supplied code |
+| `escalation` | array of known reason codes, ≤12 | Stop conditions and what the user can repair |
+| `owner` | literal `chat_owner` | Resolve authenticated personal owner at launch; never ship a creator account ID |
+| `executionProfile` | literal `context_snapshot_draft_v1` | Requires adapter attestation; no implicit full-access fallback |
+
+Method body ≤8 KiB. Prompt assembly keeps existing kernel system-prompt budget below 7K tokens; put bounded source material in explicit untrusted input blocks, not the global kernel prompt. Template instruction order cannot override OS security or authenticated owner policy.
+
+Input schema IDs are `meeting_brief_v1` and `sponsorship_reply_v1`. Both accept up to 10 pasted sources, each `{label, text}` with label ≤120 chars and text ≤8 KiB. Total pasted plus connected text ≤48 KiB. Required core text fields are non-empty, ≤4 KiB each. Titles, labels and other display strings reject control characters and HTML execution. Source selection is a strict union, not a generic action payload:
+
+- `pasted_text`: bounded content already supplied by the user; optional declared date, labeled user-provided rather than externally verified.
+- `gmail_messages`: own immutable `connectionId`, explicit list of message IDs (≤10), using only `get_message`. Optional discovery uses bounded `list_messages` with user-entered query ≤200 characters, ≤20 returned IDs; the user selects messages before preparing body content.
+- `calendar_events`: own immutable `connectionId`, selected event IDs (≤10), UTC start/end ≤7 days apart and timezone. Execute `list_events` in that interval, project only selected IDs and fail if they are absent. Do not treat undisclosed additional events as approved prompt context.
+
+The gateway maps these variants to compile-time registered read actions. It validates source ownership and response type/size. It does not allow a client to name an arbitrary action, service URL, MCP server, shell command or credential. Calendar and mail API responses may carry more data than the selected fields; normalize/minimize before preview storage and model transmission, discarding unused response data. Source discovery is visibly a real account read.
+
+## Original seed definitions
+
+These are Matrix-authored examples. Public Grok jobs informed the choice of use cases; no Grok profile prompt, standing commercial term or skill bundle is copied.
+
+| Dimension | Meeting Brief | Sponsorship Reply Draft |
+| --- | --- | --- |
+| Job | Prepare one meeting's decision brief and questions | Draft one response to one sponsor inquiry using owner-provided terms |
+| Trigger | User starts or continues Chat | User starts or continues Chat |
+| Inputs | Required meeting objective and supplied meeting context; optional selected Calendar event and Gmail messages | Required inquiry and owner's rate/constraints text; optional selected Gmail message |
+| Authority | Read chosen snapshot; draft only; no tools | Read chosen snapshot; draft only; no email draft creation in Gmail and no sending |
+| Cap | One brief, ≤5 questions, ≤20 sources, ≤10 preparation calls, 120-second run, 16 KiB output | One reply, ≤5 clarification questions, same source/call/time/output caps |
+| Proof | Objective, facts with source IDs, open questions, risks, missing context and prepared-at time | Proposed reply, supporting terms with source IDs, unresolved exceptions and missing context |
+| Readback | All referenced sources exist; required sections present; no claim a follow-up was sent | All referenced terms come from supplied context; sections present; no claim a reply was sent |
+| Escalation | Missing meeting context, conflicting dates/identities, source failure, cap reached, expanded authority | Missing rates, contradictory obligations, source failure, cap reached, request to commit/send |
+| Owner | Authenticated Chat owner reviews and acts outside this template | Authenticated Chat owner reviews and acts outside this template |
+
+Proposed original method for Meeting Brief: identify the decision the meeting should support; distinguish source facts from questions; group facts by topic; cite source IDs beside factual claims; expose contradictions and missing information; return the brief and five or fewer questions. Do not browse, contact attendees, schedule anything or claim live verification beyond the snapshot.
+
+Proposed original method for Sponsorship Reply Draft: extract the ask from the selected inquiry; compare it against the owner's supplied terms; identify exceptions without inventing prices; draft one reply and mark unresolved points. Do not accept a deal, create an external draft, send a message or infer approval from the inquiry.
+
+## Binding, preview and per-turn snapshot
+
+Use separate definition/configuration and execution objects; do not store runtime state in the distributed Markdown.
+
+```ts
+// Illustrative shape; implementation must use strict bounded Zod schemas.
+type TemplateBinding = {
+  chatId: string;
+  ownerId: string; // server-derived, never trusted from input
+  template: { id: string; version: string; sha256: string };
+  definitionSnapshot: string;
+  inputSchemaId: 'meeting_brief_v1' | 'sponsorship_reply_v1';
+  authority: 'draft_only';
+  executionProfile: 'context_snapshot_draft_v1';
+  createdAt: string;
+};
+type PreparedContext = {
+  id: string;
+  ownerId: string;
+  templateHash: string;
+  projectId: string | null;
+  selectionHash: string; // exact V3 harness/account/access source/model choice
+  sourceSelectionHash: string;
+  contextHash: string;
+  sources: SourceSnapshot[];
+  proposedFirstMessage: string;
+  preparedAt: string;
+  expiresAt: string;
+};
+type SourceSnapshot = {
+  id: string; // opaque source reference in the prompt/result
+  kind: 'pasted_text' | 'gmail_message' | 'calendar_event';
+  connectionId: string | null; // private binding, not in model-facing projection
+  resourceId: string | null;
+  label: string;
+  normalizedText: string;
+  sourceTimestamp: string | null;
+  retrievedAt: string;
+  sha256: string;
+};
+```
+
+All identifiers follow existing canonical reference constraints where applicable; use UUID/opaque IDs for new preview/source records. Persist per-turn linkage `{chatId, turnId, snapshotId, snapshotHash, definitionHash, executionProfile, selection}` and a versioned verification receipt. Owner ID is part of all queries and unique scopes; foreign keys cover binding/Chat/turn/snapshot relationships. Two related inserts or updates must share a transaction. Retain exact selection in the canonical run record; a hash is not a second selection store.
+
+Preview storage has TTL and quota; accepted snapshots move to Chat retention. No sensitive data is written to repository files, analytics or general logs. An owner Chat export includes definition, bounded inputs/snapshots and receipts but excludes credential values and opaque provider auth state. On deletion remove previews linked to that Chat and use the canonical deletion policy for child records; soft-deleted material stays out of normal/export reads. Preview IDs must not become reusable cross-owner bearer grants.
+
+Template catalog absence on another release does not erase the pinned definition. Reads must distinguish a valid old snapshot from a disabled unsafe template. Local tampering with shipped definitions must not silently replace trusted hashes or admit an unknown execution profile.
+
+## Result and completion readback
+
+Each template requests a structured object bounded to 16 KiB: `schemaVersion`, `templateId`, `status` (`draft_ready`, `needs_context`, `partial`), template-specific sections, `sourcesUsed` (≤20 opaque source IDs), `missingContext` (≤10 bounded strings), `limitations` (≤10) and `readback`.
+
+The gateway validates this object and generates its own receipt, rather than trusting the model's claim of completion. The receipt records run ID, template/snapshot hashes, required-section check, source-reference check, output-limit check and execution-profile enforcement status. Never infer enforcement from model prose. Unknown source IDs or malformed structure mean **verification incomplete** with the readable draft preserved; offer correction via another user-requested canonical turn, not an automatic unbounded repair loop.
+
+Deterministic validation cannot prove that every sentence follows from its citation. UI wording is **Draft ready — structure and source references checked**, not “facts verified.” Unsupported claims and contradictory inputs are reviewer concerns and must be exposed. Proof does not mean a provider exit code of zero. No assistant content is an ordinary canonical failure, not an empty successful template artifact.
+
+Readback includes what was produced, which sources were used, snapshot age, missing context, whether limits interrupted work, and the enforced absence of external actions. Verification status is metadata on the canonical run result, not a competing run status machine. Streamed text is provisional until validation; unsupported structured output does not silently earn a success badge.
+
+## Explicit recovery decisions
+
+| Condition | Behavior |
+| --- | --- |
+| Connection renamed | Resolve stable ID; display current label; do not alter account selection |
+| Connection removed/replaced | Block refresh/launch involving that ID; require explicit new selection |
+| Preview expired | Preserve setup, request a new preparation; do not launch with stale authority |
+| Catalog/selection changed since preview | Return conflict and show new preview; do not auto-accept |
+| Provider is unavailable | Keep draft/setup and show V3 recovery action |
+| Cross-harness continuation | New compatible execution state from canonical transcript, never foreign resume blob |
+| External text asks to send or reveal secrets | Treat as untrusted input; no tools exist to perform the instruction |
+| User requests broader authority | Explain scope; no escalation into full-access execution inside this binding |
+| Review or navigation failure after admission | Recover by request ID/canonical Chat ID; do not create another Chat |

--- a/specs/121-chat-agent-templates/research.md
+++ b/specs/121-chat-agent-templates/research.md
@@ -1,0 +1,73 @@
+# Grok Bot research and Matrix product decision
+
+Checked: 2026-09-06. Research/specification only; no Bot installed, third-party code executed, or product capability validated live.
+
+## Recommendation
+
+Build a Templates view inside Chat. A template supplies a bounded job and reviewed context to a canonical Chat; it does not create another conversation system. Start with original **Meeting Brief** and **Sponsorship Reply Draft** templates. Keep live tool execution, recurring workflows, persistent agent management and distribution outside this MVP. See [spec](spec.md), [contract](contract.md), and [implementation tasks](tasks.md).
+
+## Source verification
+
+| Primary source | Current observation | What it establishes / does not establish |
+| --- | --- | --- |
+| [Eric's announcement](https://x.com/ericosiu/status/2095272180854489337) | Browser read succeeded; generic web fetch returned 403. The post advertises public templates and a choose/context/run flow, linking the article. | Marketing claim, not a software license or measured success rate. |
+| [Business article](https://x.com/ericosiu/article/2095207617610256720) | Browser article text and its embedded contract were read; generic web fetch returned 403. Dated September 2. | Author describes nine specialist loops plus a coordinator, seven public examples, narrow authority, caps and proof. No runtime test or source export was performed. |
+| [Skills Dojo templates](https://skillsdojo.com/templates) | Nine cards: seven by Eric Siu, two by Shubham Rasal; each links to an x.ai Bot page. | Public workflow descriptions and destinations, not a repository containing seven portable definitions. |
+| [Pre-Call share page](https://x.ai/bot/yQRbVJ7aZL2DyPAWulXn7) | Browser read succeeded. Visible name, author, description, terms and `grokbot://app/v1/bot-template?id=...` app link. | Representative web preview; no downloadable manifest exposed in this inspection. Other six configurations were not installed or inspected. |
+| [Create and manage Bots](https://docs.x.ai/grok-bot/bots) | Official docs describe account copies containing shared configuration and a desktop-app add flow. | Recipients use their own account; creator computer/logins/history are not transferred. Docs explicitly say shared configuration can be viewed. |
+| [Skills and routines](https://docs.x.ai/grok-bot/skills-routines-and-automations) | Official docs separate reusable instructions from schedule/event triggers and recommend testing a one-time workflow first. | Routines are a separate lifecycle; an MVP template need not implement them. |
+| [Third-party Bot terms](https://x.ai/legal/bot-sharing-terms) | Effective August 22; personal-use license and creator-permission requirement for redistribution/re-export remain present. | Public addability is insufficient authorization to redistribute configuration in Matrix. |
+| [Skills Dojo terms](https://skillsdojo.com/terms) | July 14 terms retain content ownership and limits on copying/scraping. | Do not mirror the catalog or reuse branding/descriptions as product assets. |
+| [MIT skills repository](https://github.com/ericosiu/ai-marketing-skills/tree/502336b416004765b4d37af65a1a00d759be689d) | GitHub API resolved current main to `502336b416004765b4d37af65a1a00d759be689d`; recursive tree has 29 `SKILL.md` files. [License](https://github.com/ericosiu/ai-marketing-skills/blob/502336b416004765b4d37af65a1a00d759be689d/LICENSE) remains MIT. | A separately licensed source artifact. No verified one-to-one mapping to the seven shared Bots. |
+
+The prior September 3 research was useful for locating sources, but its blanket implication that shared configurations cannot be viewed is too strong. The observed web preview is limited; the official product permits viewing/installing shared configuration. Availability inside Grok and redistribution rights are separate questions. Exact reuse needs a portable source artifact plus explicit rights covering that artifact. This spec copies neither hidden configuration nor upstream skill files.
+
+## Workflow inventory and MVP fit
+
+The first two columns summarize the [public catalog](https://skillsdojo.com/templates) and [article](https://x.com/ericosiu/article/2095207617610256720); the final column is Matrix design judgment, not recovered Bot configuration.
+
+| Public example | Job and boundary | Matrix treatment |
+| --- | --- | --- |
+| [Pre-Call Intelligence](https://x.ai/bot/yQRbVJ7aZL2DyPAWulXn7) | Brief from account/meeting context; follow-up remains a draft. | Best first slice: one meeting, explicit sources, missing-data disclosure. |
+| [Sponsorship Deal Desk](https://x.ai/bot/bFrGNsUsXpsIfnCIUEvKy) | Qualify inbound; a narrow standing reply is an exception to human review. | Second original template; omit standing sends entirely. |
+| [Outreach Agent](https://x.ai/bot/wexM_NUvEByvLwrnTR_F3) | Capped, evidence-backed outreach queue; hold sending. | Later: lead sourcing, deduplication and contact policies expand scope. |
+| [Shortform Scaler](https://x.ai/bot/NA1zDLMoKJZVcjl3mZ2tT) | Candidate clips, human selection, then scheduling. | Later: media ingestion/rendering and destination integrations. |
+| [Trial Reels](https://x.ai/bot/HktaB2ID5y5djGCrRAxvf) | Video experiments and performance comparison. | Later: publication and measurement loop. |
+| [AEO/SEO Bot](https://x.ai/bot/Jyx1Lg-VzYgyjDc-y-GQi) | Research candidates, select drafts, hold publishing. | Later: search data, CMS and outcome measurement. |
+| [Talent Bot](https://x.ai/bot/P2cMMcajyHuHZ4OsZOWfe) | Evidence against a role pack; restrict ATS writes/outreach. | Later: separate recruiting requirements and review. |
+
+The other catalog entries are Mixey and Motion God, by Shubham Rasal; neither is part of Eric's seven. Public examples demonstrate a product pattern, not independently verified business outcomes.
+
+The [MIT repository README](https://github.com/ericosiu/ai-marketing-skills/blob/502336b416004765b4d37af65a1a00d759be689d/README.md) describes workflows with scripts, dependencies, references and optional harness metadata. It requires complete directories for bundled skills and describes local telemetry plus optional remote reporting. Future reuse must pin a commit, retain the copyright/license notice, audit dependencies and outbound calls, replace credential handling with scoped Matrix access, and disable unrequested telemetry. MIT availability alone does not prove runtime compatibility or safe execution. No dependency installation is needed for the two original text-oriented templates proposed here.
+
+## Product discussion recovered
+
+The referenced local task **阅读Discord页面并总结观点** was read through all three pages of turns, including the original Discord request, additional linked examples, the integration-versus-replication discussion, the broader recipe proposal, the later Chat-view clarification, and the licensing correction. It was treated as contextual evidence; old assistant plans and screenshot descriptions were not treated as new instructions or independently verified Discord transcripts.
+
+The sequence matters: initial discussion explored recipes, persistent apps, agent builders and external Grok integration. The user questioned adding a competing Bot object. The later clarification placed agents/templates inside Chat and decoupled them from harness choice. OM-214 explicitly adopts that narrower flow. Therefore this proposal retains canonical Chat identity and does not make a recipe installer, marketing cockpit, shared family app, new store or automation ledger a prerequisite. The family daily brief remains a possible later template; it brings broader source selection and household scope than one meeting.
+
+External Grok integration remains a separate option, not an MVP dependency. The reviewed Bot docs did not establish a supported external start/cancel/event-stream API for controlling these shared Bots. This is an evidence gap, not a claim that no API exists. A future adapter needs documented lifecycle/authorization semantics or an explicitly reviewed spike; do not emulate the Grok UI to run Matrix Chats.
+
+## Current code baseline
+
+Inspected main commit: `802690a28ec5e2134ac1c32c20ae141a12e137d6` (September 6). Paths below are repository-relative.
+
+| Area | Existing implementation evidence | Required change |
+| --- | --- | --- |
+| Chat identity and admission | `packages/contracts/src/canonical-chat-api.ts`; `packages/gateway/src/chat/{service,orchestrator,repository}.ts` | Strict create/turn schemas have no template binding. Add typed launch metadata and preserve canonical idempotency, revision, run and outbox ownership. |
+| Harness abstraction | `packages/gateway/src/chat/provider-adapter.ts`, `provider-catalog.ts` | Shared start/resume/cancel and normalized events exist. No template-specific restricted-execution attestation exists. |
+| Provider readiness | `packages/contracts/src/ai-provider.ts`; `packages/gateway/src/ai-providers/service.ts` | V3 remains harness/account/access-source/model truth. Add capability evidence there first, project to Chat; never infer readiness from a template. |
+| Connections | `packages/gateway/src/integrations/{registry,registry-expansion,routes,types}.ts` | Catalog includes read/write risk metadata and expanded services. Existing calls use service/action/label; template reads need exact connection-ID binding and per-source constraints. |
+| Existing integration access | `packages/kernel/src/tools/integrations.ts`; `packages/integrations-mcp/src/server.ts`; `packages/gateway/src/onboarding/integration-capabilities.ts` | Generic tools and onboarding approvals are useful primitives, not proof of per-template isolation. Do not pass broad integration credentials to a template harness. |
+| Custom agents | `packages/kernel/src/agents.ts` | Markdown discovery projects kernel subagent definitions. It is not a harness-neutral managed template API; leave it unchanged. |
+| Presentation | `shell/src/components/ChatApp.tsx`; `desktop/src/renderer/src/features/chat/SharedChatSurface.tsx`; `apps/mobile/app/(tabs)/chat.tsx` | Multiple Chat compositions exist. Shared template controller/contracts and shared web/Electron feature components are required. |
+
+Do not repeat the old “only seven integrations” conclusion: the current tree contains `registry-expansion.ts` and spec 118. Catalog presence is still not a live credential/action success test. The proposed MVP intentionally uses only narrowly selected Gmail/Calendar reads and pasted text, regardless of the larger installed catalog.
+
+## Decisions and remaining evidence gates
+
+- Original native templates, not imported Grok configurations or an audited-skills project hidden inside a UI change.
+- One-time source snapshot and text drafting first; active harness tool access is deferred.
+- Harness-neutral definition does not imply every adapter currently enforces the necessary restrictions. The compatibility gate in the spec must precede product delivery.
+- No undocumented SDK behavior is assumed as working. This research did not need an execution spike because it records the restriction as a mandatory implementation gate, with unsupported adapters blocked.
+- Yuhan reviews the bounded product scope and restrictions before implementation. This docs/spec PR does not approve product launch.

--- a/specs/121-chat-agent-templates/spec.md
+++ b/specs/121-chat-agent-templates/spec.md
@@ -4,6 +4,8 @@ Status: Proposed for Yuhan review. Research/spec only. Tracking: [OM-214](https:
 
 For the complete proposed Agent creation/use, workspace and Task experience, see [ux-design.md](ux-design.md). That target includes later phases; this document remains the restricted Phase A implementation boundary.
 
+The reusable-Agent phase requires `@Bot` invocation from any new or existing Chat. The Phase A restriction below on switching templates does not prohibit that later, explicitly attributed invocation flow; it requires its own versioned admission/context contract.
+
 ## Outcome and scope
 
 Inside Chat, a user opens **Templates**, chooses a job, supplies context and explicitly selected existing connections, chooses a compatible harness/account/model, reviews the scope, and starts a canonical Chat. Follow-ups continue that Chat and its pinned template contract. “Agents/Templates” is the discovery concept; MVP navigation uses **Templates** to avoid confusion with Settings → Agents & providers or the future Custom agents editor.

--- a/specs/121-chat-agent-templates/spec.md
+++ b/specs/121-chat-agent-templates/spec.md
@@ -1,0 +1,143 @@
+# Chat agent templates
+
+Status: Proposed for Yuhan review. Research/spec only. Tracking: [OM-214](https://linear.app/matrix-os/issue/OM-214/research-grok-bot-workflows-and-specify-matrix-native-agent-templates).
+
+## Outcome and scope
+
+Inside Chat, a user opens **Templates**, chooses a job, supplies context and explicitly selected existing connections, chooses a compatible harness/account/model, reviews the scope, and starts a canonical Chat. Follow-ups continue that Chat and its pinned template contract. “Agents/Templates” is the discovery concept; MVP navigation uses **Templates** to avoid confusion with Settings → Agents & providers or the future Custom agents editor.
+
+Ship two original templates: **Meeting Brief** and **Sponsorship Reply Draft**. Both accept pasted text and optionally read selected Gmail/Calendar context through the gateway. Both return drafts in Chat. No external write tools are granted. This is a concrete scope reduction from the Grok operational loops, not a claim of feature equivalence. [Research rationale](research.md).
+
+MVP includes discovery, setup, preview, start, continue, explicit source refresh, provenance, reconnect guidance and recoverable errors. There is no separately installed agent instance: the canonical Chat is the user's configured instance. Recent template Chats are a filtered projection of existing Chat records, not a second roster or lifecycle store.
+
+Non-goals: template authoring/builder; editing `~/agents/custom/`; automatic learned memory; autonomous tool use; sends/publishing/payments; scheduled/event/webhook triggers; multi-agent orchestration; a new approvals center; importing remote manifests or MIT skill scripts; Grok execution adapter; sharing/store/RBAC; generated persistent apps; video processing; full CRM/SEO/ATS integrations. OM-209–OM-213, Zellij-from-Chat and Pi output repairs are separate work and must not be folded into this implementation.
+
+## User flow
+
+1. **Browse:** Templates is available from Chat's new-conversation area and navigation. Cards show original name, job, draft-only behavior, needed inputs, optional connections and compatibility. Empty/search-empty/loading/error states have distinct copy and retry behavior.
+2. **Choose and configure:** Selecting a card opens an inline setup view. Enter the meeting objective or sponsor inquiry and commercial constraints; optionally pick an existing Project for organization. Add pasted source text. No automatic access to every file in that Project.
+3. **Bind sources:** Select an exact connection account and bounded source selection. Multiple accounts never silently fall back to the first account. An optional missing connection can be skipped explicitly; a selected required source that fails blocks Start until repaired or deliberately removed. “Manage connections” opens existing settings and returns to the preserved draft; setup does not launch OAuth itself.
+4. **Choose execution:** Existing Provider V3 selection supplies harness, account, access source and model. Keep the user's current choice if compatible; otherwise show why it cannot run this template and let the user select. Never silently substitute a paid source, model or harness. Show that selected source content will be sent to that inference route.
+5. **Preview:** “Prepare context” reads only the selected sources, displays source identities, freshness, exclusions, missing data, contract limits and a proposed first message. Preparing context is a real read, clearly labeled. “Start Chat” uses that exact snapshot; an expired/changed preview requires preparing again. Editing setup never sends a Chat turn.
+6. **Start:** One Start creates one Chat, a pinned binding and one canonical turn/run admission. Disable duplicate clicks, but server idempotency is authoritative. If navigation/reload fails after admission, recover the existing Chat with the same request ID.
+7. **Continue:** Template badge opens a read-only contract/source summary. Normal follow-ups retain the contract. “Refresh sources” is a deliberate new bounded read and preview for the next turn. “Use template again” opens a fresh setup with blank private context and unbound accounts. Switching templates creates a new Chat. No insertion into an unrelated existing Chat in MVP.
+8. **Review result:** Render the draft plus sources, missing/contradictory evidence and completion readback. A stopped or failed run remains distinguishable from a verified result. Requests to send or expand authority explain the draft-only boundary; they do not launch a new privileged run.
+
+Changing harness in an idle template Chat triggers the same compatibility/data-disclosure check. Do not reuse provider-specific resume state with another harness. Continue using canonical transcript projection; if safe cross-harness continuation cannot be supported, explain the limitation and offer a new Chat with a reviewed context preview. An active run cannot change its binding or selection.
+
+## Contract and storage
+
+[contract.md](contract.md) defines the versioned data objects and original examples. The nine contract dimensions are job → trigger → inputs → authority → cap → proof → readback → escalation → owner.
+
+- **Definition:** release-bundled Markdown with validated frontmatter under proposed `home/agents/templates/<id>/<version>.md`; no scripts, secret values or account IDs. This separate namespace does not create executable custom subagents. Server loads a bounded immutable catalog and fingerprints normalized definition bytes. Catalog content is owned by the repository and distributed under its license.
+- **Binding:** owner-controlled Postgres/Kysely operational state keyed to canonical `chatId`, containing immutable definition snapshot/hash, selected inputs, exact connection references and source snapshot versions. It is not a second authoring source. Export with Chat; include source data in owner data deletion. No shared/org bindings in MVP.
+- **Sources and proof:** bounded source snapshots and verification receipts live with the Chat's operational records. User-entered inputs and external content are data, not system authority. Credential material never enters these records, prompts or analytics.
+- **Updates:** newly started Chats use a selected catalog version; existing Chats retain their snapshot. No silent upgrades or changed permissions. If a version is administratively disabled for safety, keep history readable and block further starts/continuations under it with a safe explanation.
+
+## Architecture and runtime wiring
+
+Add shared Zod 4 contracts to `packages/contracts/src/`, focused template catalog/context/binding modules under `packages/gateway/src/chat/templates/`, a shared controller and feature UI under `packages/ui/src/chat-templates/`, and thin shell/native adapters. Names are proposed module locations, not existing APIs.
+
+```mermaid
+sequenceDiagram
+  actor User
+  participant UI as Shared Templates controller
+  participant GW as Gateway template service
+  participant DB as Owner Postgres / canonical Chat
+  participant C as Existing connection service
+  participant H as Compatible harness adapter
+  User->>UI: Select template, context, account and harness
+  UI->>GW: Prepare bounded source snapshot
+  GW->>C: Owner-checked exact-account read
+  C-->>GW: Source data, timestamp and origin
+  GW-->>UI: Preview with hash and expiry
+  User->>UI: Start Chat
+  UI->>GW: Launch with preview and request ID
+  GW->>DB: Transaction: Chat + binding + turn/outbox
+  DB-->>GW: Canonical IDs
+  GW->>H: Restricted prompt + reviewed source snapshot
+  H-->>DB: Through canonical orchestration/events
+  DB-->>UI: Stream, result and verification receipt
+```
+
+Gateway owns admission and source access; kernel/harness retains execution responsibility. The template service calls the existing integration service through injected dependencies, never self-fetches with a privileged token or executes an upstream URL from the manifest. Extract exact-account read operations from the existing route into a focused service; do not duplicate connector routing or OAuth logic. Template reads enforce the intersection of owner access, current connection status, catalog read risk, template allowlist and user-selected source constraints. A label is display metadata, never account identity.
+
+The main execution change is a proposed **restricted template execution profile**: no shell, browser, file mutation, network tool, general MCP, subagent delegation or inherited project/user plugins. Only reviewed text context and inference credentials needed by the chosen harness are available. Remove broad Matrix gateway tokens and unrelated credentials from the execution environment. A prompt saying “do not send” is not enforcement. A generic supervised mode is not proof that tools cannot execute. A candidate adapter must demonstrate these restrictions before being offered as compatible.
+
+No general capability broker or per-run tool proxy is required for this snapshot-only MVP. If live tools are added later, a separate design must bind authority to owner/chat/run/account/action/resource, support revocation and prevent bypass through broad MCP or terminal access. Do not reuse this MVP's draft label for a full-access run.
+
+### Canonical lifecycle and atomicity
+
+Launch extends existing canonical admission through a shared transaction-aware service. Commit Chat, template binding, initial turn/run admission and outbox together; refactor existing admission primitives if necessary. Never call independent create and turn endpoints and present that as atomic. Unique `(owner, clientRequestId)` plus stored payload hash returns the same IDs on exact retry and rejects reuse with different input. Existing base-revision checks and single-active-run rules remain authoritative.
+
+Source reads happen before the transaction; no external I/O inside DB locks. Preview records are owner-bound, content-addressed, capped and expiring. At admission recheck catalog version, preview expiry/hash, connection ownership/status and provider readiness. Persist the accepted snapshot inside the transaction, then dispatch via the existing outbox. A disconnect after dispatch blocks future refreshes; already transmitted content cannot be recalled. Removing a connection never silently binds a replacement.
+
+Acceptable intermediate state: an unconsumed preview that expires, or a committed pending canonical outbox item reconciled after restart. Unacceptable: running orphan with no Chat, duplicate first turn, binding without its Chat, or a failed source read represented as empty success. Source refresh inserts a new snapshot and attaches it to the next admitted turn with revision protection; do not mutate snapshots used by active or completed runs.
+
+## Endpoint authentication and limits
+
+All routes below are proposed unless marked existing. Production uses the same gateway auth middleware and `RequestPrincipal` resolution as canonical Chat: verified JWT/platform identity or authenticated single-user host identity. Never accept owner IDs or unverified identity headers from payloads. Missing auth is 401, inaccessible owner resources use safe 404, malformed input 400, stale revision/payload conflict 409, unavailable dependencies 503. No public template API in MVP.
+
+| Route | Caller/auth and authorization | Validation / bounds |
+| --- | --- | --- |
+| `GET /api/chat-templates` | Authenticated owner; catalog metadata only | Search ≤200 chars; cursor/limit Zod validated, page ≤50 |
+| `GET /api/chat-templates/:templateId` | Same; selected published version only | Safe slug ≤80, version ≤32; response ≤64 KiB |
+| `POST /api/chat-templates/sources` | Same; own exact connection; explicit discovery request | `bodyLimit` 8 KiB; Gmail query or Calendar interval union; ≤20 metadata rows, no pagination loop; same preparation quota/time/response bounds |
+| `POST /api/chat-templates/preview` | Same; own exact connections and Project | `bodyLimit` 64 KiB; typed per-template input and source union; 10 previews/owner/hour, ≤10 live previews |
+| `POST /api/chat-templates/launch` | Same; own preview, current V3 readiness | `bodyLimit` 8 KiB; request ID, preview ID/hash and selection; idempotent |
+| `POST /api/chats/:chatId/template-context` | Same plus own existing idle template Chat | `bodyLimit` 64 KiB; revision + typed refresh intent; creates preview only |
+| `POST /api/chats/:chatId/turns` (existing, extended) | Canonical principal/owner rules plus pinned binding policy | Existing 128 KiB bound; optional fresh preview reference; revalidate restrictions every turn |
+| Chat detail/events/cancel/delete (existing) | Existing owner/auth checks; no public reads | Include bounded binding/readback projection; deletion includes new child rows; keep DELETE body limits |
+| `GET /api/integrations` and `/available` (existing) | Existing authenticated owner | Setup metadata only; do not expose tokens |
+
+The source endpoint returns minimal selectable metadata, not a body-content preview or a permission grant. Only explicitly selected records can enter the subsequent prepared snapshot. Reuse an existing source picker if it satisfies these same bounds. No browser WebSocket route is added; use the existing authenticated canonical event stream, including its query-token registration and replay behavior. Use same-origin requests and existing explicit CORS policy, never wildcard origins.
+
+Each upstream read: 10-second timeout, ≤1 MiB decoded response, at most 10 calls total per preview, no automatic retries in MVP. Overall preparation ≤30 seconds; cancel pending reads on request cancellation. Maximum 20 selected source items, 8 KiB normalized text each, 48 KiB total context including pasted text; reject excess or let the user explicitly deselect sources, never silently drop relevant evidence. Calendar range ≤7 days; email discovery page ≤20 IDs, followed only by user-selected message IDs. Preview expires after 15 minutes; hourly recurring DB cleanup removes expired previews and clears timer on shutdown. Stop per-run execution after 120 seconds or 16 KiB assistant output; report partial results honestly. No claimed dollar budget when an access source cannot enforce one.
+
+Bound catalog to 100 definitions, 64 KiB each; startup validation fails closed on duplicate IDs/versions or malformed definitions. Use a fixed catalog map; no unbounded caches. Shared owner DB pool lifecycle remains with its existing owner. In-flight source requests and timers drain during gateway shutdown.
+
+No user-URL fetch occurs in this MVP. Source links are generated from validated connector records; pasted URLs are text references, not fetch instructions. If arbitrary fetching is later introduced it requires SSRF validation, DNS pinning or documented residual risk, redirect revalidation and independent tests.
+
+## Harness compatibility
+
+The definition is portable; current adapters are not certified for the restricted profile. V3 must publish explicit, versioned restriction support and fail closed on unknown/stale evidence. Existing rootChat/resume/cancellation/model flags remain necessary but insufficient.
+
+| Harness | Evidence in current tree | MVP gate |
+| --- | --- | --- |
+| Claude Code | `claude-provider-adapter.ts` maps supervised/auto/full-access permissions and start/resume | Verify explicit tool exclusion and isolated config/environment on both start and resume; supervised alone is insufficient. |
+| Codex | `coding-provider-adapter.ts` maps approval/sandbox settings | Verify no inherited MCP, tools, workspace reads or execution escape; approval policy alone is insufficient. |
+| OpenCode | Shared coding adapter, provider registry/catalog | Verify restricted invocation and canonical continuation for its exact version. |
+| Hermes | `hermes-provider-adapter.ts` currently requires `full_access` | Block until an isolated restricted profile is implemented and tested. |
+| OpenClaw | Dedicated provider adapter and catalog | Verify gateway/session configuration cannot inherit broad tools; otherwise block. |
+| Pi | Coding provider/catalog path | Same restriction gate. Do not couple this task to paused Pi output work. |
+| Matrix kernel | `kernel-provider-adapter.ts` currently requires `full_access` | Do not use it as a hidden privileged fallback. |
+
+The first implementation task is a disposable restriction spike, not building the UI around assumed support. Target Claude Code and Codex first; certify at least two harnesses for MVP release. Each remaining harness must be visibly unsupported with an actionable reason until certified. If no two adapters can enforce the profile, return a scope decision to Yuhan rather than silently relaxing it. No Grok Bot adapter is promised.
+
+## Surface parity
+
+Web Canvas, Web Desktop and Electron Desktop share template schema, client/controller, cards, setup, capability filtering, draft/readback and recovery derivations. Entry stays inside canonical `__chat__`; do not add an Agents app/window built-in. Electron Desktop is the shared visual/interaction reference; use brand tokens/primitives. Validate Web Canvas first, then Web Desktop, then Electron Desktop.
+
+Web Mobile and Native Mobile both have Chat and are in scope: same templates, source/account selection, review/start/continue/refresh/error semantics. Native layouts may use native controls and an equivalent presentation adapter, but must consume shared contracts and derivation. Stack panels on narrow screens; preserve Back navigation and drafts. No hover-only action, no icon-only authority disclosure. Keyboard focus enters setup on selection and returns to the chosen card on cancel. Pending errors announce through accessible live regions.
+
+No surface may ship “coming soon” while the same capability is enabled on another without a separately approved spec limitation. Disabled feature flag keeps existing template Chats readable and disables new starts/refreshes; it never deletes data.
+
+## Acceptance criteria
+
+| ID | Observable condition |
+| --- | --- |
+| AC1 | Both original definitions validate; catalog/version/hash and all nine dimensions are inspectable. No upstream prompts, credentials or private discussion text ship. |
+| AC2 | Full browse → context → exact account → compatible harness → preview → Start → follow-up works on all five surfaces; ordinary Chat is unchanged. |
+| AC3 | Two simultaneous identical launches, lost response retry and process restart produce one Chat/first turn/run; altered payload with same key conflicts. |
+| AC4 | Wrong owner, disconnected account, renamed account, stale preview, missing required source and changed catalog fail safely; no fallback account or partial silent context. |
+| AC5 | Every certified harness denies tools/inherited configuration on initial and resumed turns, including malicious instructions in source text; at least two harnesses pass real-adapter tests. Others are visibly blocked. |
+| AC6 | Provider V3 unavailable/auth/funding/policy states disable Start; model selection is never replaced silently. Unknown restriction evidence fails closed. |
+| AC7 | Result includes source IDs/freshness, missing data and readback. Invented source IDs, missing required sections, empty output or timeout never receive a verified-complete receipt. |
+| AC8 | Cancel/retry/reload/delete/export retain canonical lifecycle and owner boundaries; refresh is explicit and old snapshots remain immutable. |
+| AC9 | A send/publish request remains a blocked scope expansion, including in follow-up; no approval click can widen this template's authority. |
+| AC10 | Limits, shutdown cleanup, DB transaction rollback and event replay are tested; UI keeps draft input on preparation, admission or navigation failures. |
+| AC11 | Separate public documentation PR in `FinnaAI/matrix-os-site` explains the actual shipped flow and limitations and is reviewed alongside implementation. |
+
+## Review and documentation
+
+Yuhan's decisions: accept the snapshot/draft-only MVP, two initial templates, restriction-based harness availability and five-surface scope. These are recommendations awaiting product review, not permission to implement now. Implementation and a separate public-docs PR follow [tasks.md](tasks.md). This task ends with research/spec PR and Linear deliverables; no deploy or merge.

--- a/specs/121-chat-agent-templates/spec.md
+++ b/specs/121-chat-agent-templates/spec.md
@@ -2,6 +2,8 @@
 
 Status: Proposed for Yuhan review. Research/spec only. Tracking: [OM-214](https://linear.app/matrix-os/issue/OM-214/research-grok-bot-workflows-and-specify-matrix-native-agent-templates).
 
+For the complete proposed Agent creation/use, workspace and Task experience, see [ux-design.md](ux-design.md). That target includes later phases; this document remains the restricted Phase A implementation boundary.
+
 ## Outcome and scope
 
 Inside Chat, a user opens **Templates**, chooses a job, supplies context and explicitly selected existing connections, chooses a compatible harness/account/model, reviews the scope, and starts a canonical Chat. Follow-ups continue that Chat and its pinned template contract. “Agents/Templates” is the discovery concept; MVP navigation uses **Templates** to avoid confusion with Settings → Agents & providers or the future Custom agents editor.

--- a/specs/121-chat-agent-templates/tasks.md
+++ b/specs/121-chat-agent-templates/tasks.md
@@ -2,6 +2,8 @@
 
 All items below are future product work, not completed by the OM-214 research/spec PR. Yuhan reviews the [spec](spec.md) before implementation. No date or one-day delivery claim is implied.
 
+The broader [interaction design](ux-design.md) proposes Phases B/C for reusable Agents, Tasks and routines. Their contracts and implementation plans require separate scope review; they are not implicitly added to the sequence below.
+
 ## Delivery sequence
 
 | Step | Scope and dependencies | Required evidence |

--- a/specs/121-chat-agent-templates/tasks.md
+++ b/specs/121-chat-agent-templates/tasks.md
@@ -4,6 +4,8 @@ All items below are future product work, not completed by the OM-214 research/sp
 
 The broader [interaction design](ux-design.md) proposes Phases B/C for reusable Agents, Tasks and routines. Their contracts and implementation plans require separate scope review; they are not implicitly added to the sequence below.
 
+Required in the reusable-Agent phase: create a Bot and invoke it with `@` from any Chat, without requiring a Task. Plan shared typed mention contracts, owner/readiness checks, immutable invocation version/context, idempotent canonical admission and attributed results. Write failing integration tests for same-Chat routing, non-sticky invocation, draft preservation, active-run queueing and access revocation before implementation. A future `@Chat` context reference is a different object kind and does not invoke another Agent.
+
 ## Delivery sequence
 
 | Step | Scope and dependencies | Required evidence |

--- a/specs/121-chat-agent-templates/tasks.md
+++ b/specs/121-chat-agent-templates/tasks.md
@@ -1,0 +1,60 @@
+# Implementation and validation plan
+
+All items below are future product work, not completed by the OM-214 research/spec PR. Yuhan reviews the [spec](spec.md) before implementation. No date or one-day delivery claim is implied.
+
+## Delivery sequence
+
+| Step | Scope and dependencies | Required evidence |
+| --- | --- | --- |
+| 0. Restricted execution spike | Test Claude Code and Codex first, then record Hermes/OpenClaw/OpenCode/Pi status. Use disposable credentials/data and temp config with explicit cleanup. No product UI yet. | Real start/resume attempts prove no tools, inherited MCP/plugins, arbitrary workspace access or broad gateway credentials. Cancellation and 120-second limit hold. Pin harness versions and record exact failures in a future `SDK-VERIFICATION.md`. At least two pass or return scope to Yuhan. |
+| 1. Shared contracts and catalog | Depends on accepted scope and restriction feasibility. Add bounded Zod schemas, parser, hash/version rules and the two original definitions. | Failing tests first for malformed/unknown fields, duplicate versions, oversized content, schema discriminants, hashes and disabled versions. |
+| 2. Exact-account source service | Reuse integration registry/risk metadata and credential store; extract focused read service from route composition. No new connector installation. | Tests first for owner isolation, ID vs label, scoped selections, disconnect/race, response type/size, timeouts, cancellation and malicious source instructions. One staging account read for each supported connection action. |
+| 3. Canonical persistence/admission | Add owner-scoped binding/snapshot/receipt migrations and preview TTL cleanup. Refactor transaction-aware Chat admission, preserving existing outbox. | Real Postgres tests for exact retry, different payload conflict, concurrent starts, rollback, dispatch-after-commit, restart reconciliation, deletion/export and immutable snapshots. |
+| 4. Provider V3 and adapter projection | Expose versioned restricted-profile capability in V3 first; project to canonical catalog and enforce at every turn. | Contract tests for unknown/stale evidence, catalog outage, disabled account, unfunded source and unsupported model. Exercise each certified real adapter; mark the rest unsupported. |
+| 5. Shared feature and all surface adapters | Browse/setup/source selection/preview/start/continue/refresh/readback. Build shared web/Electron components and native adaptation using shared derivation. | Interaction tests for draft preservation, idempotency recovery, navigation/back, accessibility and every error state. No tests that merely duplicate internal implementation. |
+| 6. End-to-end and documentation | Depends on complete runtime wiring. Validate five surfaces; prepare public-docs PR and exact-head review environment. | Full-path trace below; authenticated manual review with Yuhan; public-docs PR reviewed alongside implementation. |
+
+Suggested reviewable implementation PR boundaries: contracts + source/admission core; certified adapters + V3 capability; parity UI + end-to-end evidence; separate site docs PR. Keep each boundary deploy-safe behind the disabled template flag until the full flow is ready. Do not split into independently enabled partial features.
+
+Large-file constraint: the inspected `chat/orchestrator.ts` and `chat/repository.ts` exceed 1,000 lines. Before adding behavior, extract focused transaction/admission and template persistence modules with characterization tests. `chat/routes.ts` and `shell/.../ChatApp.tsx` are over 500 lines; use thin registrations/composition and dedicated modules. Do not add a second giant template service or duplicate canonical lifecycle logic.
+
+## End-to-end proof required before product review
+
+Use synthetic meeting and sponsorship examples, a disposable test account/runtime, and exact implementation commit. For each certified harness:
+
+1. In Web Canvas open Chat → Templates, select Meeting Brief, choose synthetic pasted context and an explicitly selected Calendar/Gmail source from the test account. Confirm that unrelated account records never enter the snapshot.
+2. Prepare and inspect the data and inference destination; start twice concurrently with the same idempotency key. Observe one Chat, one first turn and one run, via normal canonical events and database assertions.
+3. Receive a source-linked draft and gateway verification receipt. Continue the same Chat without re-reading accounts. Refresh sources explicitly and observe a new immutable snapshot only on the next accepted turn.
+4. Repeat with Sponsorship Reply Draft and request sending the reply. Confirm that no email draft/send or external mutation is possible, including malicious content in the inquiry and an attempted full-access follow-up.
+5. Exercise cancel, provider outage, revoked connection, oversized response, changed preview, reload during admission and gateway restart before outbox delivery. Confirm safe errors and recovery without duplicated work.
+6. Repeat product flow in Web Desktop, Electron Desktop, Web Mobile and Native Mobile. Validate keyboard/screen-reader access, narrow-screen Back behavior and the same compatibility/recovery derivations.
+7. Export/delete the Chat; verify template data follows owner retention and is absent from normal/export reads after deletion. Verify pending previews expire and shutdown drains reads/timers.
+
+A signed-out onboarding screen, successful build, mocked harness or fabricated connector result does not satisfy authenticated product QA. Do not open external authentication automatically during agent-driven Electron Desktop review. Prepare the exact-head runnable environment and a concise manual flow, then wait for Yuhan's product feedback.
+
+## Acceptance traceability
+
+| Spec criteria | Planned tests |
+| --- | --- |
+| AC1 | Parser/schema/fixture/provenance tests |
+| AC2, AC10 | Shared controller integration plus five-surface interaction and accessibility checks |
+| AC3, AC8 | Postgres concurrent admission, outbox crash recovery, export/delete tests |
+| AC4 | Exact-account source service tests with cross-owner and disconnect races |
+| AC5, AC9 | Real restricted-adapter adversarial start/resume suite and denied authority expansion |
+| AC6 | V3-to-catalog-to-admission contract tests with stale/unavailable states |
+| AC7 | Result parser/verifier with fabricated IDs, absent fields, zero output and timeouts |
+| AC11 | Separate public-docs PR and site build/link validation |
+
+Use Vitest for contract/gateway tests and existing surface test frameworks. Target the constitution's 99–100% kernel/gateway coverage for new modules and measure it. Run focused tests, then required repo typecheck/pattern/unit checks. Real SDK probes use the least-cost compatible model and a documented spend cap; do not claim a spend cap is enforced where the harness cannot report/control it.
+
+## Public documentation deliverable
+
+Create a **separate PR in private `FinnaAI/matrix-os-site`, under `content/docs/`**, as part of product implementation. Locate the current navigation/content structure before selecting exact filenames; do not recreate a `www/` tree in this repository.
+
+Cover: Templates versus harness/accounts/custom agents; both starter jobs; pasted context and exact-account selection; data sent to selected inference route; draft-only authority; preparation freshness and explicit refresh; supported/unsupported harness behavior; continue/retry/cancel; source-reference checks versus factual accuracy; export/delete; troubleshooting missing connections and provider readiness. State schedules, live actions, sharing and imported Grok Bots are not supported by this MVP. Use original screenshots from a synthetic account on the final implementation commit. Never publish account IDs, private discussion transcripts, credentials or incident-specific commands.
+
+The OM-214 docs/spec PR only plans this site deliverable; publishing product documentation now would describe an unimplemented feature. At product delivery, validate the site's own build and links, link both PRs, and keep launch flag disabled until review is complete.
+
+## Research/spec completion boundary
+
+This task delivers research, a concrete proposed contract/spec, implementation breakdown, and a docs/spec PR linked from OM-214. It does not execute the product tasks above, install upstream Bots/skills, run paid harness probes, deploy or merge. Automated PR checks are review evidence; they are not Yuhan's product approval.

--- a/specs/121-chat-agent-templates/ux-design.md
+++ b/specs/121-chat-agent-templates/ux-design.md
@@ -1,0 +1,215 @@
+# Agents, Chat and Tasks: interaction design
+
+Status: Proposed for Yuhan review, 2026-09-09. Research/design only. [OM-214](https://linear.app/matrix-os/issue/OM-214/research-grok-bot-workflows-and-specify-matrix-native-agent-templates).
+
+## Recommendation
+
+Make **Agents a reusable way to work inside Chat**. Keep everyday conversation lightweight. When work needs an outcome, owner or follow-up, track it as a **Task**. Give Projects a **Tasks** view with List as the default and Board as an alternative. Open every task into its working Chat and inspectable results.
+
+A Bot homepage full of Kanban columns would make the user organize work before getting value. A single endless Chat per Bot would make separate deliverables hard to find and review. The proposed design offers a quick conversation entry and a durable work entry that share the same Chat runtime.
+
+Use **Agent** in product copy and **Agents** for the library; “Bot” describes the researched category. Settings → **Agents & providers** continues to mean runtime/account setup. Inside Chat, **Agents** means reusable roles such as Meeting Brief or Sponsorship Assistant. If user testing confuses these destinations, rename the library **Your agents**, not the underlying harnesses. Do not introduce another top-level OS application.
+
+## Relationship to the initial proposal
+
+The September 6 [MVP spec](spec.md) proposes bundled templates and immutable Chat bindings, with no persistent custom Agent. This document answers the broader request for a complete creation/use/workspace/task design. It proposes the target experience; it does not silently expand that MVP's execution authority.
+
+| Topic | Initial MVP | Full experience proposed here |
+| --- | --- | --- |
+| Discovery | Templates | Agents: My agents and Templates |
+| Creation | Configure a template for one Chat | Save a reusable Agent; start separate work from it |
+| Persistence | Definition snapshot bound to Chat | Versioned Agent definition plus per-work snapshots |
+| Work tracking | Existing Chat/project organization | Canonical Task, multiple linked Chats, primary working Chat |
+| Planning | No new task flow | Project Tasks: List and optional Board |
+| Repetition | Use template again | Reuse manually; reviewed routines in a later phase |
+| Authority | Proven restricted draft execution | Same default; explicit capabilities only when enforced |
+
+The existing MVP spec/contract remains the executable Phase A boundary. Product implementation of Phases B/C requires revised contracts, migrations and Human Review. No reusable-Agent, Task or routine API is approved merely by this design.
+
+## Evidence and adaptation
+
+Research checked on September 9, 2026. These products inform the proposal; they do not prove Matrix supports the same capabilities.
+
+| Primary source | Observation | Design inference for Matrix |
+| --- | --- | --- |
+| [xAI: Bots](https://docs.x.ai/grok-bot/bots) | Bots have durable roles and conversations; multiple Bots can share a computer. | Separate reusable role from work history. Make the selected Project/computer visible rather than implying one machine per Agent. |
+| [Notion: Build your first Custom Agent](https://www.notion.com/help/guides/build-your-first-custom-agent) | Setup combines instructions, access, triggers and testing. | Start with job/output/context; reveal advanced execution and recurrence later. Include a test before unattended work. |
+| [Linear: Agents in Linear](https://linear.app/docs/agents-in-linear) | Human accountability and delegated Agent work coexist on an issue. | Retain a human owner; show Agent separately. Do not replace ownership with an avatar of an AI. |
+| [Linear: Agent interaction](https://linear.app/developers/agent-interaction) | Agent sessions have execution/attention states and link to their work context. | Task workflow, run status and attention are separate axes; navigation can expose them without creating another task store. |
+
+Current-code review uses main `7551bfbf79fade6982a6fe6e6171af71d58c63a7`. WorkRail already organizes canonical Chats by project/pins/recency and derives attention from Chat state. Existing board cards have workflow statuses and a single `linkedSessionId`; that is not proof of canonical many-Chat-per-Task support. The task/thread distinction in `specs/105-coding-agent-shells/ARCHITECTURE.md` supports independent state. Provider V3 remains the source of harness/account/access-source/model readiness. Implementation must verify those seams on its own base.
+
+## Object model users can understand
+
+| Object | User question | Relationship and boundary |
+| --- | --- | --- |
+| Owner space | Whose work and data is this? | Personal or org ownership boundary; never implicitly mix data. |
+| Workspace context | Where am I working? | Current owner, Project and computer context. Not a new entity or retired `__workspace__` route. |
+| Project | What larger effort is this for? | Groups Chats, Tasks and explicitly selected context. Can be absent for personal work. |
+| Agent | Who/what method should help? | Reusable job, instructions, output format and declared capabilities. Many independent Tasks/Chats. |
+| Template | Where can I start? | Reusable starting definition; installing creates an owned copy without credentials or private history. |
+| Task | What needs to be delivered? | Outcome, human owner, workflow, results, primary Chat and additional linked Chats. Agent is optional. |
+| Chat | Where do we work through it? | Canonical transcript and execution surface. One Project and at most one primary Task association in the first Task release. |
+| Run | What is happening now? | One execution attempt in a Chat. A retry is another attempt in the same Task, not another card. |
+| Routine | When should this recur? | Later-phase trigger targeting an Agent version and scope; each occurrence has distinct work identity. |
+
+An Agent is not a harness, model, provider account, background process, computer or task assignee replacing a human. Changing an Agent's display name does not rename past Tasks. Every Task keeps its execution snapshots and history when its Agent is archived.
+
+## Information architecture and navigation
+
+Keep the current WorkRail hierarchy and add only two utility destinations above Projects:
+
+```text
+Chat
+  New chat
+  Needs attention                 derived items, actionable count only
+  Agents                          My agents | Templates
+  Pinned                          existing Chats/Tasks by canonical identity
+  Projects
+    Launch campaign               project landing: Chats | Tasks | Context
+  Recent                          canonical Chats, including Agent work
+```
+
+“New chat” is always immediately available. The composer has optional **Agent**, **Project/context**, and existing execution selection. Selecting an Agent does not create a Task or start a run. **Track as task** appears as an explicit choice during Agent launch and in an existing Chat's menu. For long deliverable-oriented templates it may be preselected with a visible Task title; ordinary chat defaults to untracked.
+
+Project landing uses **Chats / Tasks / Context**, with the last subview remembered per Project. Tasks offers **List / Board** in the content toolbar. Agent profile uses **Overview / Work / Instructions**; later **Routines** appears only when supported. Work is a filtered projection of the same Tasks and Chats, not a separate “Bot workspace.”
+
+Do not render a second nested global sidebar inside Chat. Web Canvas opens the same feature in a Canvas window; Web Desktop and Electron Desktop use shared content. All links route to the same canonical Chat/Task IDs.
+
+## Screen inventory and layout
+
+| Screen | Primary content and action | Secondary content |
+| --- | --- | --- |
+| New Chat | Composer, selected Agent/job, Start | Optional Project/context and Track as task |
+| Agents library | Search, My agents/Templates, Create agent | Job, output and readiness on each card; no fake productivity score |
+| Agent setup | Name, responsibility, expected output, context; Continue | Starting template and preserved unsaved state |
+| Review setup | Effective access, selected account/sources, execution readiness; Create agent | Create and start test as an explicit alternative |
+| Agent profile | Job, current version, Start work | Recent work, default context, Edit, Duplicate, Archive |
+| Task work | Task title/status/owner above Chat; next relevant action | Result/context inspector, Agent/version, linked Chats |
+| Project Tasks | Shared tasks in List or Board; New task | Agent/owner/status filters and empty state |
+| Needs attention | Needs your input, Approval requested, Ready to review | Task/Chat link and precise pending action |
+| Routine setup, later | Trigger/timezone, scope, limits, approval policy; Enable | Test result, next occurrence, pause and run history |
+
+Desktop: preserve the approximately 240px WorkRail. Main content flexes; show a result inspector around 320–380px only when the remaining Chat stays usable. Under approximately 1100px total available application width, open results in a full content view instead of squeezing three panes. Below 640px, use stacked navigation and one content pane. Breakpoints follow container width in Canvas, not just browser width.
+
+Use shared brand forest/paper surfaces, restrained coral/gold attention accents, existing typography and 8–12px control radii. One primary action per current decision. Status always has a text label. Agent initials/icon support recognition but do not create a separate visual identity for every card. Long task names wrap; timestamps and IDs remain secondary.
+
+## Creation: three entrances, one builder
+
+1. **From a template:** Open Templates → choose Sponsorship Reply Draft → inspect job/output/access → Use template. Prefill editable instructions; require selection of the user's own context and account.
+2. **Describe a role:** Create agent → “What should it help with?” → generate a proposed name, instructions, input questions and output. The user reviews the proposal before saving. Generating configuration does not grant tools or schedule work.
+3. **Save successful work:** Chat menu → Save as agent → extract reusable instructions and output shape. Preview exact retained material. Exclude transcript, people, addresses, files, secrets, approvals and connection IDs unless explicitly selected as owned context.
+
+All three enter the same builder. First step contains name, responsibility, expected output and input requirements. Second step selects Project default and bounded context: pasted text/files/exact connected-account resources. Context chips disclose source and scope; Project selection alone grants no blanket file access. Third step reviews effective capabilities, source disclosure to inference, execution choice and limits.
+
+Advanced disclosure contains harness/account/access-source/model, run budget/time limit and notification preferences. Keep a valid current execution choice. Explain incompatible or unavailable configurations and route to existing setup without losing the draft; no silent paid fallback. A “read only” promise appears only with proven restriction support from the backend.
+
+**Create agent** saves without execution. **Create and test** saves then starts a clearly labeled test Chat using reviewed sample data; tests may incur inference usage and perform the selected reads, which the button area states. Test output can be inspected, refined and rerun. Failed execution preserves the saved Agent and setup; Create must not report failure if only the later test failed.
+
+Back navigation preserves the draft. Closing with edits offers Keep draft or Discard. Reload restoration is owner-scoped. Validation appears inline and identifies a fix, including missing inputs, unavailable sources and unsupported execution modes.
+
+## Use inside Chat
+
+**Start new work.** Agent → Start work opens New Chat with the Agent chip selected. Ask for the inputs the job requires, not all configuration fields again. Show the selected Project and Task tracking choice. Review sources when needed, then Start creates one canonical Chat/run and optional Task atomically and idempotently. Recover the same objects after timeout/reload.
+
+**Continue work.** Opening a Task resumes its primary Chat. The header shows human owner, Agent/version, workflow and run status separately. Follow-ups, Stop and Retry retain the Task ID. A source refresh previews the changed context; history is not silently rewritten.
+
+**Track an existing Chat.** Track as task proposes a title and outcome, human owner and optional Project. Confirm links the existing Chat and creates a Task; it neither repeats the prompt nor copies history. Choosing an existing Task checks ownership/Project compatibility. When a Chat already belongs to another Task, offer an explicit reassociation or a new Chat with reviewed context; do not silently show one conversation as two independently editable workstreams.
+
+**Change Agent.** For a new Chat, replace the selection freely. For existing work, default to New Chat for this task with the new Agent and a reviewed handoff summary. Keep earlier Chat/version readable and let the user choose the primary Chat. Do not retroactively change an active run's instructions or reuse incompatible harness resume state.
+
+**Inspect outputs.** Result panel has Summary, Deliverable, Evidence and unresolved Questions. Each result links to the producing Chat/run and source freshness. Multiple attempts expose a version selector. Incomplete generation is labeled Partial. Chat text alone is not a verified result or proof of an external action.
+
+**Finish work.** Request changes sends feedback in the same Task and starts work only through explicit canonical admission. Accept result records acceptance for the selected result version. Mark done is a separate workflow mutation. A draft accepted by its owner is still a draft; sending/publishing is a distinct scoped action.
+
+## Task workflow, execution and attention
+
+Target workflow: **To do → In progress → Review → Done**, plus Archive outside the active board. Blocked is a reason/attention marker that preserves the workflow stage. The human owner can move work backward. Review means an outcome is awaiting human evaluation, not that a tool is awaiting permission.
+
+| Event | Task workflow | Run state | User-facing action |
+| --- | --- | --- | --- |
+| Save planned task | To do | No run | Start work |
+| Explicit Start work | In progress | Queued/running | Open Chat; Stop when running |
+| Agent asks a question | Unchanged | Awaiting input | Answer in Task Chat |
+| External action requested, later | Unchanged | Awaiting approval | Review exact action scope |
+| Run finishes with usable output | Unchanged until a workflow event | Completed | Review result; Submit for review |
+| Submit for review | Review | Unchanged | Accept result or Request changes |
+| Accept result | Review; acceptance recorded | Unchanged | Mark done |
+| Mark done | Done | No running attempt allowed without resolving it | Reopen |
+| Error or user Stop | Unchanged | Failed/canceled | Retry or revise instructions |
+| Move board card | Explicit selected stage only | Unchanged | No implicit execution or approval |
+
+A run-completion event must not automatically move a card to Done. A later explicit project policy may submit verified outputs for review, but the rule must be visible and auditable. If someone tries to mark a running Task Done, offer Cancel run and mark done as a combined confirmed operation or keep it active; do not hide a live process behind Done.
+
+Current board statuses are `todo/running/waiting/blocked/complete/archived`. For the first Task integration, preserve those existing meanings or ship an explicit versioned migration. In particular, `waiting` cannot be relabeled Review and `blocked` cannot be discarded automatically. Migration must preserve legacy state, blocked reason and audit history; classify ambiguous records with a visible legacy marker and an explicit user action. The target mockup illustrates the new workflow, not a claim that the old schema already supports it.
+
+## Why List first, when Board helps
+
+List gives titles, next action and results more space and scales to personal work or a narrow window. Board helps compare concurrent deliverables across a Project and spot review bottlenecks. It becomes useful when the user actively manages work across stages; it is not necessary to create/use an Agent.
+
+Both views use identical Task IDs, filters, counts and ordering rules. Remember the selected view per Project. A card shows title, Agent, human owner, workflow, run/attention label and latest result indicator. Click opens Task work. Status menu provides the keyboard/touch equivalent to drag. Dragging is optional, never the only way to move work.
+
+Empty Project: “Track work you want to come back to” with Create task and Start with agent. Empty column: simple label, not another setup prompt. Empty filter: Clear filters. Done is collapsed or filtered by default once history grows; Archive remains recoverable. Do not duplicate cards per run, subagent, Chat message or routine retry.
+
+## Attention, permissions and trust
+
+Needs attention is a projection of canonical pending input, action approvals and review-ready results. The same pending action opened from Chat, a Task, WorkRail or a notification has one ID and resolution. Separate Approval requested from Ready to review: approving a tool action is not accepting a deliverable. Do not invent another approvals ledger.
+
+An action review shows what will happen, affected resources, destination/account, exact payload preview, scope/expiry and Allow once / Deny. Changed payloads invalidate prior approval; resumed runs recheck authorization. Bulk approval and approval via board drag are excluded. External writes and live tools stay unavailable until capability enforcement is demonstrated across the complete harness path.
+
+Owner defaults to the initiating human; Agent is shown as Doing the work. Later org roles must authorize both the Task and its linked resources. A shared Agent definition grants no data access. Changing owner space resets selected accounts and context before another run. If a user loses permission, preserve only the history they remain entitled to view and remove actionable controls with safe copy.
+
+## Agent lifecycle and recurring work
+
+Edits create a new Agent definition version. Existing work keeps its pinned instructions/sources. New work uses the latest eligible version; adopting changes in existing work requires a diff and a new reviewed run boundary. Archive stops new starts and asks how to handle active runs and routines. It does not delete historical results. Permanent deletion is separate and follows owner export/deletion policy.
+
+Duplicate copies reusable configuration, not credentials, grants, history or private samples. Agent instructions remain inspectable/exportable files in the future Custom agents namespace; operational links/results/triggers live in owner Postgres. Reconcile file changes and DB metadata explicitly in the later technical design; do not create two editable instruction stores.
+
+Routines are a later phase inside Agent profile, not a prerequisite to first use. Setup requires trigger/timezone, selected Project/context, output destination, limits and policy; show next occurrence and test result before Enable. Pause blocks future occurrences without pretending an active run stopped. An occurrence key deduplicates retries and creates one Task/work instance; distinct scheduled deliverables create distinct Tasks. If a source is missing or policy changed, pause and request repair instead of repeatedly creating failing cards. Avoid catch-up floods after downtime; require a documented skip/coalesce policy.
+
+Notifications default to meaningful input/approval/review/failure events, deep-link to the canonical work, and deduplicate across surfaces. Routine success can be a digest or quiet mode; do not notify for every token or every unchanged poll.
+
+Delegation remains inside the owning Task unless a human explicitly promotes a sub-result to a child Task. Show delegated activity in Chat when helpful. Do not populate the board with internal agent processes. Scheduling, delegated execution and shared-agent publishing require separate capability/RBAC designs before shipping.
+
+## Responsive behavior, accessibility and recovery
+
+| Situation | Required experience |
+| --- | --- |
+| Web Canvas | Same library/builder/task/result actions in a resizable Canvas window; container-responsive layout |
+| Web Desktop | Shared desktop feature; persisted local view preferences |
+| Electron Desktop | Ongoing visual/interaction reference; same business state and capabilities |
+| Web Mobile / Native Mobile, when exposed | Same creation/use/status/approval semantics; list default, result screen with Back to chat, status menu instead of required drag |
+| Loading | Bounded skeletons; preserve last known content during refresh; never flash an empty library |
+| Offline / disconnect | Show stale state and reconnect; preserve draft; do not fabricate a running start or optimistic approval |
+| Start timeout | Recover by request ID; offer Open existing work, not a blind second start |
+| No compatible harness | Explain unavailable mode and open existing setup, returning to draft |
+| Source disconnected | Identify selected source safely; Reconnect or Remove source and review again |
+| Save conflict | Preserve local edits, show changed version and explicit comparison/retry |
+| Permission denied | Safe message, no leaked resource/account/provider internals |
+| No result / partial / failed | Distinct labels, retained work history and relevant next action |
+
+Keyboard users can reach navigation, Agent choices, forms, task status and results with visible focus. Dialogs restore focus to their trigger; route changes focus the new heading. Screen readers receive concise admission/attention changes, not streamed-token announcements. Touch targets are at least approximately 44px. Color is never the sole status signal; reduced-motion users get no unnecessary transitions. Long names and translated labels must fit at 320px without horizontal page overflow.
+
+## Delivery phases and review criteria
+
+**A — Template work in Chat.** Deliver the existing restricted MVP first if accepted: two templates, setup/source preview, canonical Chat, correct execution/source disclosure and result readback. Use Templates navigation until saved Agents exist. No placeholder Create agent button.
+
+**B — Reusable Agents and durable Tasks.** Add owned Agent creation/versioning, Track as task, canonical Task/Chat associations, primary Chat, result acceptance, Project List/Board and derived attention. Requires migration of legacy board links/statuses and shared capability/state contracts. This is the complete manual-work loop illustrated by the design, with no implicit external writes.
+
+**C — Routines and controlled actions.** Add reviewed triggers, occurrence deduplication, enforced scoped tool capabilities, real action approval, budget/limits and reliable recovery. Do not market Phase A as this phase. Shared Agent distribution/org policy can follow separate authorization work.
+
+Each implementation phase follows TDD, updates the contract/auth matrix before new endpoints, proves runtime wiring and owner isolation, and prepares exact-head Human Review. Product delivery includes a separate public-documentation PR in `FinnaAI/matrix-os-site`; this research change does not modify that repository.
+
+Usability validation proposal: test with five representative users, observe rather than explain the model, and treat the following as acceptance targets rather than measured outcomes:
+
+1. Start a Meeting Brief from a template, selecting only intended sources; at least four of five can explain what data it accesses and whether it can send anything.
+2. Create a reusable Agent and start two independent jobs; users can find both outputs without treating one Chat as a global memory bucket.
+3. Track existing work as a Task without losing messages or producing a duplicate run.
+4. Switch List/Board, move a Task and explain that this did not run an Agent or approve an action.
+5. Respond to missing input, inspect a result, request changes, accept the new version and mark Done; all entry points agree.
+6. Retry an interrupted start and reconnect a missing source without creating duplicate Tasks or losing setup.
+7. Complete core flows using only keyboard and at 390px width; confirm 320px fit and readable dark appearance.
+
+Observe time to first useful result, setup abandonment, task reopen/rework, duplicate-start rate and successful attention resolution. Define analytics using IDs/stages only; do not collect prompts, files, source bodies or credentials. Establish baselines before setting numeric production targets.
+
+Design decisions proposed for review: Agents inside Chat; optional Task creation; human owner plus Agent; Project List default with optional Board; explicit result acceptance separate from external-action approval; advanced routines after the manual loop. The immediate design review should exercise creation → work → result → Task views before approving implementation scope.

--- a/specs/121-chat-agent-templates/ux-design.md
+++ b/specs/121-chat-agent-templates/ux-design.md
@@ -6,6 +6,8 @@ Status: Proposed for Yuhan review, 2026-09-09. Research/design only. [OM-214](ht
 
 Make **Agents a reusable way to work inside Chat**. Keep everyday conversation lightweight. When work needs an outcome, owner or follow-up, track it as a **Task**. Give Projects a **Tasks** view with List as the default and Board as an alternative. Open every task into its working Chat and inspectable results.
 
+Updated direction, September 9: introduce a simple Agents section alongside ordinary Chats, lead onboarding with connecting selected tools and discovering useful work, and reveal reusable configuration progressively. **Once created, a Bot must be callable with `@` from a new or existing Chat.** This mention entry is a required part of the reusable-Agent experience. Task organization and Board remain optional secondary capabilities.
+
 A Bot homepage full of Kanban columns would make the user organize work before getting value. A single endless Chat per Bot would make separate deliverables hard to find and review. The proposed design offers a quick conversation entry and a durable work entry that share the same Chat runtime.
 
 Use **Agent** in product copy and **Agents** for the library; “Bot” describes the researched category. Settings → **Agents & providers** continues to mean runtime/account setup. Inside Chat, **Agents** means reusable roles such as Meeting Brief or Sponsorship Assistant. If user testing confuses these destinations, rename the library **Your agents**, not the underlying harnesses. Do not introduce another top-level OS application.
@@ -116,7 +118,38 @@ Back navigation preserves the draft. Closing with edits offers Keep draft or Dis
 
 **Track an existing Chat.** Track as task proposes a title and outcome, human owner and optional Project. Confirm links the existing Chat and creates a Task; it neither repeats the prompt nor copies history. Choosing an existing Task checks ownership/Project compatibility. When a Chat already belongs to another Task, offer an explicit reassociation or a new Chat with reviewed context; do not silently show one conversation as two independently editable workstreams.
 
-**Change Agent.** For a new Chat, replace the selection freely. For existing work, default to New Chat for this task with the new Agent and a reviewed handoff summary. Keep earlier Chat/version readable and let the user choose the primary Chat. Do not retroactively change an active run's instructions or reuse incompatible harness resume state.
+**Call another Bot.** Type `@` in the current Chat, select an available Bot, add a request and send. Its contribution appears in this Chat with explicit Bot attribution. This is a scoped invocation, not a permanent change to the Chat's default Agent or the Task's owner. The user can still start separate work from an Agent profile when they want an independent conversation.
+
+**Change the default Agent.** Keep this separate from a mention. A deliberate default change may require a new execution context and reviewed handoff. Do not retroactively change an active run's instructions or reuse incompatible harness resume state. A new visible Chat is not required merely because a user mentions another Bot.
+
+### Mention a Bot from any Chat
+
+The core flow is **Create Bot → return to any Chat → type `@` → select Bot → write a request → Send → see that Bot's contribution in the same Chat**. No Project, Task, template editor or Board setup is a prerequisite.
+
+| Interaction | Required behavior |
+| --- | --- |
+| Type `@` or choose the composer mention button | Show a searchable picker of Bots the current user can invoke; typing a query narrows results. Open from a new Chat or an existing Chat. |
+| Choose a Bot | Insert a removable typed mention chip with stable Bot ID and display name. Show its job and availability in the picker. Selection alone does not run it or grant access. |
+| Enter the request | Keep the selected Bot visible above/in the composer. Show the context boundary before sending: this request and relevant context from the current Chat; extra files or other Chats require explicit references. |
+| Send | Admit one canonical invocation against the selected Bot version and current Chat. Pin the identity/version to this turn. Recheck access/readiness and deduplicate retries using the submission ID. |
+| Receive a contribution | Attribute progress, questions, tool requests and output to the invoked Bot. Keep Chat ID, Task association, human owner and default Agent unchanged. |
+| Continue without a mention | Use the Chat's existing default Agent. Mentions do not silently become a sticky routing switch. The contributing Bot remains named in the transcript. |
+| Create a Bot and return | The newly saved Bot is discoverable in the picker without reloading; preserve any pre-existing composer draft. |
+| Remove/change the chip before Send | Only update the pending recipient; no execution, cancellation or permission mutation. |
+
+The first mention release supports **one invoked Bot per message**. Additional Bot selections require replacing the recipient or sending a separate message; never silently fan out work. Team/group orchestration can extend the contract later. When a run is already active, use the canonical queued-next-turn flow with visible recipient attribution, or explain that the chosen harness cannot queue it. Do not interrupt or steer the active Agent merely because another Bot was mentioned.
+
+Keep Bot identity, standing instructions and approved reusable preferences distinct from transcript access. Mentioning a Bot does not automatically import its private historical Chats, credentials, computer session or all project files into the current conversation. Effective access is the intersection of the current principal, destination Chat, Bot capability policy and explicitly granted resource scope. An external action still requires its normal authorization; `@` is not a grant.
+
+Renamed Bots resolve by stable ID. Archived, deleted, unauthorized or unavailable Bots cannot be invoked; preserve the request and offer removal/replacement, never silently substitute the default Agent. Invalid raw text such as an email address, pasted transcript, code block or an unresolved `@name` is not an executable mention. Distinguish completed, failed, stopped and awaiting-input invocations without moving Task workflow implicitly.
+
+### Other Chat references use a separate mention type
+
+The same picker may later offer grouped **Bots** and **Chats** results. **A Bot mention invokes a participant; a Chat reference supplies context.** Chat results show title and Project, and selecting one previews the source and bounded excerpt/summary that will be included. It does not start the referenced Chat's Agent or expose its whole history automatically. Revalidate source access at Send and preserve provenance in the result. The reference contract must distinguish object kinds by stable ID, not infer kind from a label.
+
+Cross-Chat references are a proposed extension, not an already approved implementation requirement. Ship the Bot group first without a nonfunctional Chats placeholder. A user can always navigate to an existing Chat normally. User mentions, channel notifications and automatic messages to other people are outside this feature.
+
+Keyboard behavior: arrow keys move through suggestions, Enter selects a highlighted result rather than submitting the message, Escape dismisses, and a visible remove control clears the chip. After selection, focus returns to the composer. Announce the selected recipient and unavailable state. Use the same typed mention semantics on Web Canvas, Web Desktop, Electron Desktop, and applicable mobile surfaces; touch uses a compact sheet/picker.
 
 **Inspect outputs.** Result panel has Summary, Deliverable, Evidence and unresolved Questions. Each result links to the producing Chat/run and source freshness. Multiple attempts expose a version selector. Incomplete generation is labeled Partial. Chat text alone is not a verified result or proof of an external action.
 
@@ -194,7 +227,7 @@ Keyboard users can reach navigation, Agent choices, forms, task status and resul
 
 **A — Template work in Chat.** Deliver the existing restricted MVP first if accepted: two templates, setup/source preview, canonical Chat, correct execution/source disclosure and result readback. Use Templates navigation until saved Agents exist. No placeholder Create agent button.
 
-**B — Reusable Agents and durable Tasks.** Add owned Agent creation/versioning, Track as task, canonical Task/Chat associations, primary Chat, result acceptance, Project List/Board and derived attention. Requires migration of legacy board links/statuses and shared capability/state contracts. This is the complete manual-work loop illustrated by the design, with no implicit external writes.
+**B — Reusable Agents and optional durable Tasks.** Prioritize owned Agent creation/versioning and `@Bot` invocation in any Chat, with attributed canonical turns and scoped context. Neither requires Task setup. Then add Track as task, canonical Task/Chat associations, primary Chat, result acceptance, Project List/Board and derived attention. Task integration requires migration of legacy board links/statuses and shared capability/state contracts. Cross-Chat references need a separate typed context contract. No mention implicitly authorizes external writes.
 
 **C — Routines and controlled actions.** Add reviewed triggers, occurrence deduplication, enforced scoped tool capabilities, real action approval, budget/limits and reliable recovery. Do not market Phase A as this phase. Shared Agent distribution/org policy can follow separate authorization work.
 
@@ -209,6 +242,8 @@ Usability validation proposal: test with five representative users, observe rath
 5. Respond to missing input, inspect a result, request changes, accept the new version and mark Done; all entry points agree.
 6. Retry an interrupted start and reconnect a missing source without creating duplicate Tasks or losing setup.
 7. Complete core flows using only keyboard and at 390px width; confirm 320px fit and readable dark appearance.
+8. Create a Bot, return to an existing Chat, invoke it with `@`, and identify its response. Verify unchanged Chat/Task/default-Agent identity, no execution on selection, no Task required, and ordinary routing on the next unmentioned message.
+9. Test mention search, keyboard selection/removal, renamed/archived/unavailable Bots, access revocation at Send, duplicate submission and active-run queueing. Prove that raw text mentions and referenced source content cannot trigger another invocation or broaden access.
 
 Observe time to first useful result, setup abandonment, task reopen/rework, duplicate-start rate and successful attention resolution. Define analytics using IDs/stages only; do not collect prompts, files, source bodies or credentials. Establish baselines before setting numeric production targets.
 


### PR DESCRIPTION
## Summary

Design how reusable Agents are created and used inside Chat, with optional durable Tasks and a Project Tasks view. The proposal keeps a human owner, separates task workflow from execution, and uses List by default with an optional Board. Creation, source selection, task association, result review, versioning, attention, responsive behavior and recovery are specified together. Saved Bots must also be callable with `@` from any new or existing Chat: one attributed invocation per message, unchanged Chat/Task/default Agent, and no Task prerequisite. A future Chat reference is a separate context object, not an invocation.

The restricted first release remains two original templates: Meeting Brief and Sponsorship Reply Draft. The full UX target adds reusable Agents and canonical Task/Chat relationships in a later phase; routines and external actions require separate enforcement and contract work. No product behavior changes in this PR.

Deliverables in `specs/121-chat-agent-templates/`:

- `research.md`: Grok Bot primary-source evidence, reuse boundary and original code-gap analysis.
- `ux-design.md`: complete proposed Agent/Chat/Project/Task interaction design, optional Kanban, migration constraints, phases and usability review scenarios. Current-code review uses main `7551bfbf79fade6982a6fe6e6171af71d58c63a7`; competitor sources include xAI, Notion and Linear.
- `spec.md`: restricted Phase A UI, runtime wiring, auth matrix and acceptance criteria.
- `contract.md`: Phase A template, source snapshot, binding, proof and readback contracts.
- `tasks.md`: restriction feasibility gate, TDD sequence and documentation plan; later UX phases are explicitly separate.

Research/design for [OM-214](https://linear.app/matrix-os/issue/OM-214/research-grok-bot-workflows-and-specify-matrix-native-agent-templates), awaiting Yuhan's design review. The conversation also contains a local interactive preview using sample data; it is not a product implementation or a committed runtime dependency.

## Validation

- All five Markdown files: local links and fenced blocks checked.
- `git diff --check`: passed.
- Direct pattern scanner: exit 0, 0 violations, 5 warning categories in unchanged product code.
- Interactive design preview: creation → work → review → acceptance → Done → same Task in Board exercised; desktop dark and narrow light appearances inspected, 320px and 736px fit checked. Simulation only; no live harness, connector, persistence or product parity validation claimed.
- Bot mention preview: keyboard search/selection, same-Chat attributed response, return to default Agent on the next unmentioned message, newly created Bot discovery without reload, retained draft/recipient across navigation, removal and 390px layout checked. Backend authorization, queueing and persistence remain future implementation acceptance tests.
- Runtime typecheck/tests remain unavailable in this docs checkout (`bun` not on PATH; no installed dependencies). No product or dependency files changed.

## Invariants

- **Source of truth:** versioned file definitions and owner Postgres operational state; existing canonical Chat/run/outbox and Provider V3. Later reusable Agents/Task associations require revised contracts. List, Board and Agent Work are projections of the same Tasks.
- **Lock/transaction scope:** future launch atomically persists Chat, binding, optional Task association and canonical admission/outbox. External reads stay outside DB locks. This PR changes no runtime writes.
- **Acceptable orphan states:** expiring unconsumed preview or recoverable pending outbox only; no running orphan or duplicate first turn. Agent save and later test failure are separately reported.
- **Auth source of truth:** gateway principal and exact owner/resource/account checks. Project selection is not an access grant. Prompt wording is not capability enforcement. Existing work pins its reviewed version and context.
- **Deferred scope:** implementation, new Task migrations/APIs, live tools, external writes, routines, sharing/store, Grok adapter and MIT imports. Related OM-209–OM-213, Zellij and Pi work remain separate. Product delivery includes a separate `FinnaAI/matrix-os-site` docs PR.
